### PR TITLE
Allow Lazy Module to be modelled as `UnspecializedNNModuleVariable`

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1613,6 +1613,35 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         exp_res = m(x, y)
         self.assertTrue(torch.allclose(exp_res, opt_m(x, y)))
 
+    def test_lazy_module_speculation_log_divergence(self):
+        class ModWithOneLazyLinear(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.layer = torch.nn.LazyLinear(8)
+
+            def forward(self, x):
+                return self.layer(x)
+
+        # This allows us to restart tracing without clearing speculation log
+        def id_and_graph_break(x):
+            torch._dynamo.graph_break()
+            return x
+
+        @torch.compile()
+        def test(mod, x):
+            res = mod(x)
+            # Speculation log must not diverge in the 2nd round of tracing,
+            # after we've initialized the `LazyLinear` into a `Linear` in the
+            # 1st round.
+            res2 = id_and_graph_break(res)
+            return res
+
+        x = torch.ones(10, 3)
+        mod = ModWithOneLazyLinear()
+        actual_res = test(mod, x)
+        expect_res = mod(x)
+        self.assertTrue(torch.allclose(expect_res, actual_res))
+
     def test_call_fn_with_non_const_inputs_safe(self):
         class ModuleSpecialFwd(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/_dynamo/mutation_guard.py
+++ b/torch/_dynamo/mutation_guard.py
@@ -6,7 +6,7 @@ import torch.nn
 from torch.nn import Module
 
 from . import config
-from .utils import ExactWeakKeyDictionary, is_lazy_module, nn_module_has_global_hooks
+from .utils import ExactWeakKeyDictionary, nn_module_has_global_hooks
 
 
 unpatched_nn_module_init = torch.nn.Module.__init__
@@ -99,8 +99,6 @@ def is_dynamic_nn_module(obj: Any, is_export: bool) -> bool:
         return True
     if hasattr(obj, "torchdynamo_force_dynamic"):
         return obj.torchdynamo_force_dynamic
-    if is_lazy_module(obj):
-        return False
     # For export, we will have to fix
     # 1) Input signature problem because params are lifted as inputs
     # 2) nn module stack info changes


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #138632
* __->__ #138631

This patch removes the `is_lazy_module` check from
`is_dynamic_nn_module`, and adds a regression test.

Fixes #138489. See more context in the issue.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec