### PR TITLE
Add COW support for MPS backend.

### DIFF
--- a/aten/src/ATen/mps/MPSAllocatorInterface.h
+++ b/aten/src/ATen/mps/MPSAllocatorInterface.h
@@ -15,6 +15,7 @@ namespace at::mps {
 class IMPSAllocator : public c10::Allocator {
  public:
   // see the comments in MPSAllocator.h for the description of these methods.
+  virtual DataPtr registerCPUBackedPtr(void* cpu_ptr, const size_t nbytes) = 0;
   virtual void emptyCache() const = 0;
   virtual void freeInactiveBuffers() const = 0;
   virtual ssize_t getUnalignedBufferSize(const void* ptr) const = 0;
@@ -26,6 +27,7 @@ class IMPSAllocator : public c10::Allocator {
   virtual bool isSharedStorageSupported() const = 0;
   virtual c10::DataPtr allocScalarBufferWithValue(void* value, size_t size)
       const = 0;
+  virtual bool isSharedAllocatorUsage() const = 0;
   virtual std::string formatSize(size_t size) const = 0;
   virtual void setLowWatermarkRatio(double ratio) const = 0;
   virtual void setHighWatermarkRatio(double ratio) const = 0;
@@ -38,6 +40,7 @@ class IMPSAllocator : public c10::Allocator {
   virtual size_t getRecommendedMaxMemory() const = 0;
   virtual std::pair<const void*, uint32_t> getSharedBufferPtr(
       const void* ptr) const = 0;
+  virtual std::pair<void*, uint32_t> unsafeGetSharedBufferPtr(void* ptr) const = 0;
   virtual bool recordEvents(c10::ArrayRef<const void*> buffers) const = 0;
   virtual bool waitForEvents(c10::ArrayRef<const void*> buffers) const = 0;
 };
@@ -61,7 +64,7 @@ TORCH_DECLARE_REGISTRY(MPSAllocatorCallbacksRegistry, IMpsAllocatorCallback);
 #define REGISTER_MPS_ALLOCATOR_CALLBACK(name, ...) \
   C10_REGISTER_CLASS(MPSAllocatorCallbacksRegistry, name, __VA_ARGS__)
 
-IMPSAllocator* getIMPSAllocator(bool sharedAllocator = false);
+IMPSAllocator* getIMPSAllocator(bool sharedAllocator = true);
 
 bool isMPSPinnedPtr(const void* data);
 

--- a/aten/src/ATen/mps/MPSCOW.cpp
+++ b/aten/src/ATen/mps/MPSCOW.cpp
@@ -1,0 +1,241 @@
+//  Copyright © 2024 Apple Inc.
+
+#include <ATen/mps/MPSCOW.h>
+
+#include <ATen/detail/MPSHooksInterface.h>
+#include <ATen/mps/MPSAllocatorInterface.h>
+#include <ATen/mps/MPSCOWContext.h>
+#include <ATen/mps/MPSDevice.h>
+#include <c10/core/CPUAllocator.h>
+#include <c10/core/DispatchKeySet.h>
+#include <c10/core/StorageImpl.h>
+#include <c10/core/impl/COWDeleter.h>
+
+namespace at::mps::cow {
+namespace {
+DispatchKeySet ChangeDispatchKeySetBackend(
+    DispatchKeySet original,
+    BackendComponent new_backend) {
+  BackendComponent old_backend = original.highestBackendKey();
+
+  // following logic TensorImpl::TensorImpl, update the BackendComponent related
+  // keys to correspond to device
+
+  // TODO: Autocoast should be a per-backend functionality key, once that change
+  // is made this key swap will not be necessary.
+  auto new_key_set =
+      original - c10::getAutocastRelatedKeySetFromBackend(old_backend);
+  new_key_set =
+      new_key_set | c10::getAutocastRelatedKeySetFromBackend(new_backend);
+
+  // See note [Removing keys from DispatchKeySet Only Affects Functionality
+  // Keys]
+  new_key_set = new_key_set.remove_backend(old_backend);
+  return new_key_set | DispatchKeySet(new_backend);
+}
+
+template <typename T>
+static inline bool is_null_or_equal_to(
+    const std::optional<T>& test,
+    const T& value) {
+  if (!test.has_value()) {
+    return true;
+  }
+  return test.value() == value;
+}
+} // namespace
+
+c10::intrusive_ptr<c10::TensorImpl> lazy_cloned_tensor_for_unified_memory(
+    Tensor const& self,
+    std::optional<c10::Device> device,
+    c10::intrusive_ptr<c10::StorageImpl> lazy_cloned_storage) {
+  // For _lazy_clone with device, the tensor itself should be on either MPS or
+  // CPU.
+  TORCH_CHECK(self.device().is_mps() || self.device().is_cpu());
+  // The target device should be either MPS or CPU.
+  TORCH_CHECK(
+      device == std::nullopt ||
+      (device.value().is_mps() || device.value().is_cpu()));
+
+  c10::Device target_device =
+      device == std::nullopt ? self.device() : device.value();
+
+  auto device_key_set = self.key_set();
+
+  bool mps_to_cpu = self.device().is_mps() && target_device.is_cpu();
+  bool cpu_to_mps = self.device().is_cpu() && target_device.is_mps();
+
+  at::mps::IMPSAllocator* mps_alloc = at::mps::getIMPSAllocator();
+  bool is_shared_allocator_and_unified_memory =
+      mps_alloc->isSharedStorageSupported() &&
+      mps_alloc->isSharedAllocatorUsage();
+  // This will not work if our default is not MPS SharedAllocator and the
+  // hardware does not have unified memory architecture.
+  TORCH_CHECK(is_shared_allocator_and_unified_memory);
+
+  if (mps_to_cpu || cpu_to_mps) {
+    // Get the COW context.
+    at::DataPtr& data_ptr = lazy_cloned_storage->_mutable_data_ptr_no_checks();
+    TORCH_INTERNAL_ASSERT(data_ptr);
+
+    auto* ctx = data_ptr.cast_context<c10::impl::cow::COWDeleterContext>(
+        c10::impl::cow::cow_deleter);
+    TORCH_INTERNAL_ASSERT(ctx != nullptr);
+
+    at::Allocator* allocator = nullptr;
+    BackendComponent backend_component = BackendComponent::InvalidBit;
+    void* target_device_data_ptr = nullptr;
+
+    // If the underlying data context is not UnifiedMemoryDataPtrContext
+    if (ctx->GetDataDeleter() !=
+        c10::impl::cow::unified_memory_data_ptr_ctx_deleter) {
+      // Wrap the underlying data context as UnifiedMemoryDataPtrContext.
+      ctx->WrapDataPtr(
+          mps_to_cpu ? at::mps::cow::WrapMPSToCPU : at::mps::cow::WrapCPUToMPS,
+          lazy_cloned_storage->nbytes());
+    }
+    TORCH_INTERNAL_ASSERT(
+        ctx->GetDataDeleter() ==
+        c10::impl::cow::unified_memory_data_ptr_ctx_deleter);
+    auto* unified_data_ptr_ctx =
+        reinterpret_cast<const c10::impl::cow::UnifiedMemoryDataPtrContext*>(
+            ctx->GetConstDataPtr());
+
+    if (mps_to_cpu) {
+      backend_component = BackendComponent::CPUBit;
+      allocator = GetCPUAllocator();
+
+      // CPUTensor.to("mps").to("cpu")
+      if (unified_data_ptr_ctx->memory_backed_by_cpu()) {
+        target_device_data_ptr = unified_data_ptr_ctx->get_original_data_ctx();
+      } else { // MPSTensor.to("cpu")
+        target_device_data_ptr = unified_data_ptr_ctx->get_mapped_data_ctx();
+      }
+    } else {
+      TORCH_INTERNAL_ASSERT(cpu_to_mps);
+
+      backend_component = BackendComponent::MPSBit;
+      allocator = at::mps::GetMPSAllocator();
+
+      // MPSTensor.to("cpu").to("mps")
+      if (!unified_data_ptr_ctx->memory_backed_by_cpu()) {
+        target_device_data_ptr = unified_data_ptr_ctx->get_original_data_ctx();
+      } else { // CPUTensor.to("mps")
+        target_device_data_ptr = unified_data_ptr_ctx->get_mapped_data_ctx();
+      }
+    }
+
+    TORCH_INTERNAL_ASSERT(allocator != nullptr);
+    TORCH_INTERNAL_ASSERT(backend_component != BackendComponent::InvalidBit);
+    // target_device_data_ptr might be nullptr when encountering an empty tensor
+
+    // Convert the DispatchKeySet from the original backend to the desired
+    // backend
+    device_key_set =
+        ChangeDispatchKeySetBackend(device_key_set, backend_component);
+    if (mps_to_cpu) {
+      // TODO(Frank): This felt like an overkill for what's necessary. Maybe
+      // there is a way to synchronize only the Tensor event. However, we have
+      // to have a synchronization in order to have the MPS content reflects
+      // correctly on the CPU.
+      at::detail::getMPSHooks().deviceSynchronize();
+    }
+
+    // Increment the reference count. The old DataPtr will be deleted and thus
+    // the refcount is going to go down. We need to increment the refcount in
+    // order to maintain correctness.
+    ctx->increment_refcount();
+
+    // Create mapped data pointer with COW Context
+    DataPtr dp{
+        target_device_data_ptr,
+        ctx,
+        c10::impl::cow::cow_deleter,
+        device.value()};
+
+    lazy_cloned_storage->set_data_ptr_noswap(std::move(dp));
+    lazy_cloned_storage->set_allocator(
+        allocator); // allocator used for materialization
+  }
+
+  auto tensor = c10::make_intrusive<c10::TensorImpl>(
+      c10::Storage(std::move(lazy_cloned_storage)),
+      device_key_set,
+      self.dtype());
+
+  return tensor;
+}
+
+bool to_will_cow(
+    const Tensor& self,
+    std::optional<ScalarType> dtype,
+    std::optional<Layout> layout,
+    std::optional<Device> device,
+    bool copy,
+    std::optional<c10::MemoryFormat> optional_memory_format) {
+  auto memory_format = optional_memory_format.value_or(MemoryFormat::Preserve);
+  // Base case for dtype, layout, memory_format and whether copy or not.
+  if (!(is_null_or_equal_to(dtype, self.dtype().toScalarType()) &&
+        is_null_or_equal_to(layout, self.layout()) && !copy &&
+        (memory_format == MemoryFormat::Preserve ||
+         self.suggest_memory_format() == memory_format))) {
+    return false;
+  }
+
+  if (!(
+          // If tensor itself is not on CPU or MPS, and the target device is not
+          // CPU or MPS, we will not perform COW.
+          (self.device().is_cpu() || self.device().is_mps()) &&
+          // The target device has to be explicitly specified in order to
+          // perform COW.
+          (device != std::nullopt &&
+           (device.value().is_cpu() || device.value().is_mps())))) {
+    return false;
+  }
+
+  auto* mps_alloc =
+      reinterpret_cast<at::mps::IMPSAllocator*>(at::mps::GetMPSAllocator());
+  bool is_shared_allocator_and_unified_memory =
+      mps_alloc->isSharedStorageSupported() &&
+      mps_alloc->isSharedAllocatorUsage();
+  // SharedAllocator and unified memory is a must to enable COW for MPS.
+  if (!is_shared_allocator_and_unified_memory) {
+    return false;
+  }
+
+  const auto* storage = self.storage().unsafeGetStorageImpl();
+  // If we do not have a storage object, we can't perform COW.
+  if (!storage) {
+    return false;
+  }
+  // If the storage allocator is something we do not know how to handle.
+  // Eg. tensor created from torch.from_numpy, since we do not own the
+  // CPU storage of the numpy array.
+  const auto* storage_allocator = storage->allocator();
+  if (!(storage_allocator &&
+        (storage_allocator == mps_alloc ||
+         storage_allocator == GetCPUAllocator()))) {
+    return false;
+  }
+
+  const c10::DataPtr& data_ptr = storage->data_ptr();
+  // If we have an empty tensor, or the data pointer is complicated.
+  if (!(data_ptr.get() &&
+        (c10::impl::cow::has_simple_data_ptr(*storage) ||
+         c10::impl::cow::is_cow_data_ptr(data_ptr)))) {
+    return false;
+  }
+
+  // Case 1: MPSTensor.to("cpu")
+  if (self.device().is_mps() && (device != std::nullopt && device->is_cpu())) {
+    return true;
+    // Case 2: CPUTensor.to("mps")
+  } else if (
+      self.device().is_cpu() && (device != std::nullopt && device->is_mps())) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+} // namespace at::mps::cow

--- a/aten/src/ATen/mps/MPSCOW.h
+++ b/aten/src/ATen/mps/MPSCOW.h
@@ -1,0 +1,33 @@
+// Copyright © 2024 Apple Inc.
+// This file is to support the feature for MPS and CPU to share the same
+// underlying memory through Copy-on-write context.
+
+#pragma once
+
+#include <ATen/core/Tensor.h>
+#include <c10/core/Device.h>
+#include <c10/core/Layout.h>
+#include <c10/core/MemoryFormat.h>
+#include <c10/core/ScalarType.h>
+#include <c10/core/StorageImpl.h>
+#include <c10/core/TensorImpl.h>
+#include <c10/util/intrusive_ptr.h>
+
+#include <optional>
+
+namespace at::mps::cow {
+
+bool to_will_cow(
+    const Tensor& self,
+    std::optional<ScalarType> dtype,
+    std::optional<Layout> layout,
+    std::optional<Device> device,
+    bool copy,
+    std::optional<c10::MemoryFormat> optional_memory_format);
+
+c10::intrusive_ptr<c10::TensorImpl> lazy_cloned_tensor_for_unified_memory(
+    Tensor const& self,
+    std::optional<c10::Device> device,
+    c10::intrusive_ptr<c10::StorageImpl> lazy_cloned_storage);
+
+} // namespace at::mps::cow

--- a/aten/src/ATen/mps/MPSCOWContext.cpp
+++ b/aten/src/ATen/mps/MPSCOWContext.cpp
@@ -1,0 +1,131 @@
+//  Copyright © 2024 Apple Inc.
+
+#include <ATen/mps/MPSCOWContext.h>
+
+#include <ATen/mps/MPSAllocatorInterface.h>
+#include <c10/core/impl/COWDeleter.h>
+
+#include <memory>
+
+namespace at::mps::cow {
+namespace {
+void NoDeleter(void*){};
+} // namespace
+
+CPUToMPSDataPtrContext::CPUToMPSDataPtrContext(
+    std::unique_ptr<void, DeleterFnPtr> original_data,
+    size_t nbytes)
+    : original_data_(std::move(original_data)),
+      mapped_data_(nullptr, nullptr),
+      nbytes_(nbytes) {
+  InitializeMappedData();
+}
+
+CPUToMPSDataPtrContext::~CPUToMPSDataPtrContext() {
+  if (mapped_data_) {
+    mapped_data_.reset();
+  }
+  if (original_data_) {
+    original_data_.reset();
+  }
+}
+
+void CPUToMPSDataPtrContext::InitializeMappedData() {
+  at::mps::IMPSAllocator* mps_alloc = at::mps::getIMPSAllocator(true);
+  bool is_shared_allocator_and_unified_memory =
+      mps_alloc->isSharedStorageSupported() &&
+      mps_alloc->isSharedAllocatorUsage();
+  if (is_shared_allocator_and_unified_memory) {
+    mapped_data_ =
+        mps_alloc->registerCPUBackedPtr(original_data_.get(), nbytes_)
+            .move_context();
+  }
+}
+
+std::unique_ptr<void, DeleterFnPtr> CPUToMPSDataPtrContext::
+    move_original_data_ctx() {
+  return std::move(original_data_);
+}
+
+void* CPUToMPSDataPtrContext::get_original_data_ctx() const {
+  if (original_data_) {
+    return original_data_.get();
+  } else {
+    return nullptr;
+  }
+}
+void* CPUToMPSDataPtrContext::get_mapped_data_ctx() const {
+  if (mapped_data_) {
+    return mapped_data_.get();
+  } else {
+    return nullptr;
+  }
+}
+
+MPSToCPUDataPtrContext::MPSToCPUDataPtrContext(
+    std::unique_ptr<void, DeleterFnPtr> original_data)
+    : original_data_(std::move(original_data)), mapped_data_(nullptr, nullptr) {
+  InitializeMappedData();
+}
+
+MPSToCPUDataPtrContext::~MPSToCPUDataPtrContext() {
+  if (mapped_data_) {
+    mapped_data_.reset();
+  }
+  if (original_data_) {
+    original_data_.reset();
+  }
+}
+
+void MPSToCPUDataPtrContext::InitializeMappedData() {
+  at::mps::IMPSAllocator* mps_alloc = at::mps::getIMPSAllocator(true);
+  bool is_shared_allocator_and_unified_memory =
+      mps_alloc->isSharedStorageSupported() &&
+      mps_alloc->isSharedAllocatorUsage();
+  if (is_shared_allocator_and_unified_memory) {
+    mapped_data_ = std::unique_ptr<void, DeleterFnPtr>(
+        std::get<0>(
+            mps_alloc->unsafeGetSharedBufferPtr(get_original_data_ctx())),
+        NoDeleter);
+  }
+}
+
+std::unique_ptr<void, DeleterFnPtr> MPSToCPUDataPtrContext::
+    move_original_data_ctx() {
+  return std::move(original_data_);
+}
+
+void* MPSToCPUDataPtrContext::get_original_data_ctx() const {
+  if (original_data_) {
+    return original_data_.get();
+  } else {
+    return nullptr;
+  }
+}
+void* MPSToCPUDataPtrContext::get_mapped_data_ctx() const {
+  if (mapped_data_) {
+    return mapped_data_.get();
+  } else {
+    return nullptr;
+  }
+}
+
+std::unique_ptr<void, DeleterFnPtr> WrapCPUToMPS(
+    std::unique_ptr<void, DeleterFnPtr> data,
+    size_t nbytes) {
+  auto result = std::unique_ptr<void, DeleterFnPtr>(
+      new CPUToMPSDataPtrContext(std::move(data), nbytes),
+      c10::impl::cow::unified_memory_data_ptr_ctx_deleter);
+  return result;
+}
+
+std::unique_ptr<void, DeleterFnPtr> WrapMPSToCPU(
+    std::unique_ptr<void, DeleterFnPtr> data,
+    size_t nbytes) {
+  auto result = std::unique_ptr<void, DeleterFnPtr>(
+      new MPSToCPUDataPtrContext(std::move(data)),
+      c10::impl::cow::unified_memory_data_ptr_ctx_deleter);
+  return result;
+}
+
+} // namespace at::mps::cow

--- a/aten/src/ATen/mps/MPSCOWContext.h
+++ b/aten/src/ATen/mps/MPSCOWContext.h
@@ -1,0 +1,66 @@
+// Copyright © 2024 Apple Inc.
+// This file is to support the feature for MPS and CPU to share the same
+// underlying memory through Copy-on-write context. Please refer to
+// UnifiedMemoryDataPtrContext for comments.
+
+#pragma once
+
+#include <c10/core/impl/COWDeleter.h>
+#include <c10/util/UniqueVoidPtr.h>
+
+#include <memory>
+
+namespace at::mps::cow {
+
+class C10_API CPUToMPSDataPtrContext
+    : public c10::impl::cow::UnifiedMemoryDataPtrContext {
+ public:
+  explicit CPUToMPSDataPtrContext(
+      std::unique_ptr<void, DeleterFnPtr> original_data,
+      size_t nbytes);
+
+  ~CPUToMPSDataPtrContext() override;
+  void InitializeMappedData() override;
+
+  std::unique_ptr<void, DeleterFnPtr> move_original_data_ctx() override;
+  void* get_original_data_ctx() const override;
+  void* get_mapped_data_ctx() const override;
+  bool memory_backed_by_cpu() const override {
+    return true;
+  }
+
+ private:
+  std::unique_ptr<void, DeleterFnPtr> original_data_;
+  std::unique_ptr<void, DeleterFnPtr> mapped_data_;
+  size_t nbytes_;
+};
+
+class C10_API MPSToCPUDataPtrContext
+    : public c10::impl::cow::UnifiedMemoryDataPtrContext {
+ public:
+  explicit MPSToCPUDataPtrContext(
+      std::unique_ptr<void, DeleterFnPtr> original_data);
+
+  ~MPSToCPUDataPtrContext() override;
+  void InitializeMappedData() override;
+
+  std::unique_ptr<void, DeleterFnPtr> move_original_data_ctx() override;
+  void* get_original_data_ctx() const override;
+  void* get_mapped_data_ctx() const override;
+  bool memory_backed_by_cpu() const override {
+    return false;
+  }
+
+ private:
+  std::unique_ptr<void, DeleterFnPtr> original_data_;
+  std::unique_ptr<void, DeleterFnPtr> mapped_data_;
+};
+
+std::unique_ptr<void, DeleterFnPtr> WrapCPUToMPS(
+    std::unique_ptr<void, DeleterFnPtr> data,
+    size_t nbytes);
+std::unique_ptr<void, DeleterFnPtr> WrapMPSToCPU(
+    std::unique_ptr<void, DeleterFnPtr> data,
+    size_t nbytes);
+
+} // namespace at::mps::cow

--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -68,6 +68,6 @@ class TORCH_API MPSDevice {
 
 TORCH_API bool is_available();
 TORCH_API bool is_macos_13_or_newer(MacOSVersion version);
-TORCH_API at::Allocator* GetMPSAllocator(bool useSharedAllocator = false);
+TORCH_API at::Allocator* GetMPSAllocator(bool useSharedAllocator = true);
 
 } // namespace at::mps

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -62,6 +62,10 @@
 #include <algorithm>
 #include <numeric>
 
+#if USE_MPS
+#include <ATen/mps/MPSCOW.h>
+#endif  // USE_MPS
+
 namespace at::native {
 
 namespace {
@@ -435,6 +439,15 @@ static inline Tensor to_impl(
           self, dtype, layout, device, copy, optional_memory_format)) {
     return self;
   }
+
+#if USE_MPS
+  // MPS has a fast path with unified memory
+  if (at::mps::cow::to_will_cow(self, dtype, layout, device, copy, optional_memory_format)) {
+    // create a copy-on-write context
+    return at::_lazy_clone(self, device);
+  }
+#endif  // USE_MPS
+
   return at::_to_copy(
       self,
       dtype,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1250,7 +1250,7 @@
     CompositeExplicitAutograd: copysign_out
   tags: pointwise
 
-- func: _lazy_clone(Tensor self) -> Tensor
+- func: _lazy_clone(Tensor self, *, Device? device=None) -> Tensor
   # Like clone, but the copy takes place lazily, only if either the
   # input or the output are written.
   variants: function, method

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -111,7 +111,7 @@ list(APPEND ATen_VEC_TEST_SRCS
 list(APPEND ATen_MPS_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/mps_test_print.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mps_test_allocator.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/mps_test_metal_library.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/mps_test_metal_library.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mps_test_cow.cpp)
 if(APPLE AND USE_MPS)
   list(APPEND ATen_MPS_TEST_SRCS

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -112,6 +112,7 @@ list(APPEND ATen_MPS_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/mps_test_print.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mps_test_allocator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mps_test_metal_library.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/mps_test_cow.cpp)
 if(APPLE AND USE_MPS)
   list(APPEND ATen_MPS_TEST_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/mps_test_objc_interface.mm)

--- a/aten/src/ATen/test/mps_test_cow.cpp
+++ b/aten/src/ATen/test/mps_test_cow.cpp
@@ -1,0 +1,466 @@
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+#include <c10/core/impl/COWDeleter.h>
+#include <ATen/mps/MPSCOWContext.h>
+
+namespace at::mps {
+
+namespace {
+
+at::DataPtr& GetMutableDataPtr(torch::Tensor& t) {
+    auto* storage_impl = t.storage().unsafeGetStorageImpl();
+    return storage_impl->_mutable_data_ptr_no_checks();
+}
+
+}  // namespace
+
+TEST(MPSCOWContext, MPSToCPU) {
+    torch::Tensor mps_t = torch::randn({10000}, at::device(at::kMPS));
+    torch::Tensor cpu_t = at::_lazy_clone(mps_t, at::kCPU);
+
+    auto& mps_dp = GetMutableDataPtr(mps_t);
+    auto& cpu_dp = GetMutableDataPtr(cpu_t);
+
+    // They will share the same cow context.
+    ASSERT_EQ(mps_dp.get_context(), cpu_dp.get_context());
+    ASSERT_EQ(mps_dp.get_deleter(), c10::impl::cow::cow_deleter);
+    ASSERT_EQ(cpu_dp.get_deleter(), c10::impl::cow::cow_deleter);
+
+    auto* ctx = mps_dp.cast_context<c10::impl::cow::COWDeleterContext>(
+        c10::impl::cow::cow_deleter
+    );
+
+    ASSERT_EQ(ctx->GetDataDeleter(), c10::impl::cow::unified_memory_data_ptr_ctx_deleter);
+
+    const auto* unimem_ctx =
+        reinterpret_cast<const at::mps::cow::MPSToCPUDataPtrContext*>(ctx->GetConstDataPtr());
+    ASSERT_EQ(mps_dp.get(), unimem_ctx->get_original_data_ctx());
+    ASSERT_EQ(cpu_dp.get(), unimem_ctx->get_mapped_data_ctx());
+    ASSERT_FALSE(unimem_ctx->memory_backed_by_cpu());
+}
+
+TEST(MPSCOWContext, MPSToCPUMaterialization1) {
+    torch::Tensor mps_t = torch::randn({10000}, at::device(at::kMPS));
+    torch::Tensor cpu_t = at::_lazy_clone(mps_t, at::kCPU);
+    mps_t += 1;
+    cpu_t += 1;
+    // In this case both MPS and CPU will get its own dedicated memory.
+
+    auto& mps_dp = GetMutableDataPtr(mps_t);
+    auto& cpu_dp = GetMutableDataPtr(cpu_t);
+
+    ASSERT_NE(mps_dp.get_context(), cpu_dp.get_context());
+    ASSERT_NE(mps_dp.get_deleter(), cpu_dp.get_deleter());
+}
+
+TEST(MPSCOWContext, MPSToCPUMaterialization2) {
+    torch::Tensor mps_t = torch::randn({10000}, at::device(at::kMPS));
+    void* original_mps_pointer = GetMutableDataPtr(mps_t).get_context();
+    torch::Tensor cpu_t = at::_lazy_clone(mps_t, at::kCPU);
+    cpu_t += 1;
+    mps_t += 1;
+    // In this case MPS will own the original memory, CPU will get its
+    // own dedicated memory.
+
+    auto& mps_dp = GetMutableDataPtr(mps_t);
+    auto& cpu_dp = GetMutableDataPtr(cpu_t);
+
+    ASSERT_EQ(mps_dp.get(), original_mps_pointer);
+    ASSERT_EQ(mps_dp.get_context(), original_mps_pointer);
+
+    ASSERT_NE(mps_dp.get_context(), cpu_dp.get_context());
+    ASSERT_NE(mps_dp.get_deleter(), cpu_dp.get_deleter());
+}
+
+TEST(MPSCOWContext, CPUToMPS) {
+    torch::Tensor cpu_t = torch::randn({10000}, at::device(at::kCPU));
+    torch::Tensor mps_t = at::_lazy_clone(cpu_t, at::kMPS);
+
+    auto& mps_dp = GetMutableDataPtr(mps_t);
+    auto& cpu_dp = GetMutableDataPtr(cpu_t);
+
+    // They will share the same cow context.
+    ASSERT_EQ(mps_dp.get_context(), cpu_dp.get_context());
+    ASSERT_EQ(mps_dp.get_deleter(), c10::impl::cow::cow_deleter);
+    ASSERT_EQ(cpu_dp.get_deleter(), c10::impl::cow::cow_deleter);
+
+    auto* ctx = mps_dp.cast_context<c10::impl::cow::COWDeleterContext>(
+        c10::impl::cow::cow_deleter
+    );
+
+    ASSERT_EQ(ctx->GetDataDeleter(), c10::impl::cow::unified_memory_data_ptr_ctx_deleter);
+
+    const auto* unimem_ctx =
+        reinterpret_cast<const at::mps::cow::CPUToMPSDataPtrContext*>(ctx->GetConstDataPtr());
+    ASSERT_EQ(cpu_dp.get(), unimem_ctx->get_original_data_ctx());
+    ASSERT_EQ(mps_dp.get(), unimem_ctx->get_mapped_data_ctx());
+    ASSERT_TRUE(unimem_ctx->memory_backed_by_cpu());
+}
+
+TEST(MPSCOWContext, CPUToMPSMaterialization1) {
+    torch::Tensor cpu_t = torch::randn({10000}, at::device(at::kCPU));
+    torch::Tensor mps_t = at::_lazy_clone(cpu_t, at::kMPS);
+    cpu_t += 1;
+    mps_t += 1;
+    // In this case both MPS and CPU will get its own dedicated memory.
+
+    auto& mps_dp = GetMutableDataPtr(mps_t);
+    auto& cpu_dp = GetMutableDataPtr(cpu_t);
+
+    ASSERT_NE(mps_dp.get_context(), cpu_dp.get_context());
+    ASSERT_NE(mps_dp.get_deleter(), cpu_dp.get_deleter());
+}
+
+TEST(MPSCOWContext, CPUToMPSMaterialization2) {
+    torch::Tensor cpu_t = torch::randn({10000}, at::device(at::kCPU));
+    void* original_cpu_pointer = GetMutableDataPtr(cpu_t).get_context();
+    torch::Tensor mps_t = at::_lazy_clone(cpu_t, at::kMPS);
+    mps_t += 1;
+    cpu_t += 1;
+    // In this case CPU will own the original memory, MPS will get its
+    // own dedicated memory.
+
+    auto& mps_dp = GetMutableDataPtr(mps_t);
+    auto& cpu_dp = GetMutableDataPtr(cpu_t);
+
+    ASSERT_EQ(cpu_dp.get(), original_cpu_pointer);
+    ASSERT_EQ(cpu_dp.get_context(), original_cpu_pointer);
+
+    ASSERT_NE(mps_dp.get_context(), cpu_dp.get_context());
+    ASSERT_NE(mps_dp.get_deleter(), cpu_dp.get_deleter());
+}
+
+TEST(MPSCOWContext, MPSToCPUToMPS) {
+    torch::Tensor mps_t = torch::randn({10000}, at::device(at::kMPS));
+    torch::Tensor cpu_t = at::_lazy_clone(mps_t, at::kCPU);
+    torch::Tensor mps2_t = at::_lazy_clone(mps_t);
+    torch::Tensor mps3_t = at::_lazy_clone(cpu_t, at::kMPS);
+
+    auto& mps_dp = GetMutableDataPtr(mps_t);
+    auto& mps2_dp = GetMutableDataPtr(mps2_t);
+    auto& mps3_dp = GetMutableDataPtr(mps3_t);
+    auto& cpu_dp = GetMutableDataPtr(cpu_t);
+
+    auto* ctx = mps_dp.cast_context<c10::impl::cow::COWDeleterContext>(
+        c10::impl::cow::cow_deleter
+    );
+
+    ASSERT_EQ(ctx->GetDataDeleter(), c10::impl::cow::unified_memory_data_ptr_ctx_deleter);
+
+    const auto* unimem_ctx =
+        reinterpret_cast<const at::mps::cow::MPSToCPUDataPtrContext*>(ctx->GetConstDataPtr());
+    ASSERT_EQ(mps_dp.get(), unimem_ctx->get_original_data_ctx());
+    ASSERT_EQ(mps2_dp.get(), unimem_ctx->get_original_data_ctx());
+    ASSERT_EQ(mps3_dp.get(), unimem_ctx->get_original_data_ctx());
+    ASSERT_EQ(cpu_dp.get(), unimem_ctx->get_mapped_data_ctx());
+    ASSERT_FALSE(unimem_ctx->memory_backed_by_cpu());
+}
+
+TEST(MPSCOWContext, CPUToMPSToCPU) {
+    torch::Tensor cpu_t = torch::randn({10000}, at::device(at::kCPU));
+    torch::Tensor mps_t = at::_lazy_clone(cpu_t, at::kMPS);
+    torch::Tensor cpu2_t = at::_lazy_clone(cpu_t);
+    torch::Tensor cpu3_t = at::_lazy_clone(mps_t, at::kCPU);
+
+    auto& mps_dp = GetMutableDataPtr(mps_t);
+    auto& cpu2_dp = GetMutableDataPtr(cpu2_t);
+    auto& cpu3_dp = GetMutableDataPtr(cpu3_t);
+    auto& cpu_dp = GetMutableDataPtr(cpu_t);
+
+    auto* ctx = cpu_dp.cast_context<c10::impl::cow::COWDeleterContext>(
+        c10::impl::cow::cow_deleter
+    );
+
+    ASSERT_EQ(ctx->GetDataDeleter(), c10::impl::cow::unified_memory_data_ptr_ctx_deleter);
+
+    const auto* unimem_ctx =
+        reinterpret_cast<const at::mps::cow::CPUToMPSDataPtrContext*>(ctx->GetConstDataPtr());
+    ASSERT_EQ(cpu2_dp.get(), unimem_ctx->get_original_data_ctx());
+    ASSERT_EQ(cpu3_dp.get(), unimem_ctx->get_original_data_ctx());
+    ASSERT_EQ(cpu_dp.get(), unimem_ctx->get_original_data_ctx());
+    ASSERT_EQ(mps_dp.get(), unimem_ctx->get_mapped_data_ctx());
+    ASSERT_TRUE(unimem_ctx->memory_backed_by_cpu());
+}
+
+// Test the `to` interface.
+
+TEST(MPSCOWContextToImpl, MPSToCPU) {
+    torch::Tensor mps_t = torch::randn({10000}, at::device(at::kMPS));
+    torch::Tensor cpu_t = at::native::to(
+        mps_t,
+        /*dtype=*/std::nullopt,
+        /*layout=*/std::nullopt,
+        /*device=*/at::kCPU,
+        /*pin_memory=*/std::nullopt,
+        false,
+        false,
+        /*optional_memory_format=*/std::nullopt
+    );
+
+    auto& mps_dp = GetMutableDataPtr(mps_t);
+    auto& cpu_dp = GetMutableDataPtr(cpu_t);
+
+    // They will share the same cow context.
+    ASSERT_EQ(mps_dp.get_context(), cpu_dp.get_context());
+    ASSERT_EQ(mps_dp.get_deleter(), c10::impl::cow::cow_deleter);
+    ASSERT_EQ(cpu_dp.get_deleter(), c10::impl::cow::cow_deleter);
+
+    auto* ctx = mps_dp.cast_context<c10::impl::cow::COWDeleterContext>(
+        c10::impl::cow::cow_deleter
+    );
+
+    ASSERT_EQ(ctx->GetDataDeleter(), c10::impl::cow::unified_memory_data_ptr_ctx_deleter);
+
+    const auto* unimem_ctx =
+        reinterpret_cast<const at::mps::cow::MPSToCPUDataPtrContext*>(ctx->GetConstDataPtr());
+    ASSERT_EQ(mps_dp.get(), unimem_ctx->get_original_data_ctx());
+    ASSERT_EQ(cpu_dp.get(), unimem_ctx->get_mapped_data_ctx());
+    ASSERT_FALSE(unimem_ctx->memory_backed_by_cpu());
+}
+
+TEST(MPSCOWContextToImpl, MPSToCPUMaterialization1) {
+    torch::Tensor mps_t = torch::randn({10000}, at::device(at::kMPS));
+    torch::Tensor cpu_t = at::native::to(
+        mps_t,
+        /*dtype=*/std::nullopt,
+        /*layout=*/std::nullopt,
+        /*device=*/at::kCPU,
+        /*pin_memory=*/std::nullopt,
+        false,
+        false,
+        /*optional_memory_format=*/std::nullopt
+    );
+    mps_t += 1;
+    cpu_t += 1;
+    // In this case both MPS and CPU will get its own dedicated memory.
+
+    auto& mps_dp = GetMutableDataPtr(mps_t);
+    auto& cpu_dp = GetMutableDataPtr(cpu_t);
+
+    ASSERT_NE(mps_dp.get_context(), cpu_dp.get_context());
+    ASSERT_NE(mps_dp.get_deleter(), cpu_dp.get_deleter());
+}
+
+TEST(MPSCOWContextToImpl, MPSToCPUMaterialization2) {
+    torch::Tensor mps_t = torch::randn({10000}, at::device(at::kMPS));
+    void* original_mps_pointer = GetMutableDataPtr(mps_t).get_context();
+    torch::Tensor cpu_t = at::native::to(
+        mps_t,
+        /*dtype=*/std::nullopt,
+        /*layout=*/std::nullopt,
+        /*device=*/at::kCPU,
+        /*pin_memory=*/std::nullopt,
+        false,
+        false,
+        /*optional_memory_format=*/std::nullopt
+    );
+    cpu_t += 1;
+    mps_t += 1;
+    // In this case MPS will own the original memory, CPU will get its
+    // own dedicated memory.
+
+    auto& mps_dp = GetMutableDataPtr(mps_t);
+    auto& cpu_dp = GetMutableDataPtr(cpu_t);
+
+    ASSERT_EQ(mps_dp.get(), original_mps_pointer);
+    ASSERT_EQ(mps_dp.get_context(), original_mps_pointer);
+
+    ASSERT_NE(mps_dp.get_context(), cpu_dp.get_context());
+    ASSERT_NE(mps_dp.get_deleter(), cpu_dp.get_deleter());
+}
+
+TEST(MPSCOWContextToImpl, CPUToMPS) {
+    torch::Tensor cpu_t = torch::randn({10000}, at::device(at::kCPU));
+    torch::Tensor mps_t = at::native::to(
+        cpu_t,
+        /*dtype=*/std::nullopt,
+        /*layout=*/std::nullopt,
+        /*device=*/at::kMPS,
+        /*pin_memory=*/std::nullopt,
+        false,
+        false,
+        /*optional_memory_format=*/std::nullopt
+    );
+
+    auto& mps_dp = GetMutableDataPtr(mps_t);
+    auto& cpu_dp = GetMutableDataPtr(cpu_t);
+
+    // They will share the same cow context.
+    ASSERT_EQ(mps_dp.get_context(), cpu_dp.get_context());
+    ASSERT_EQ(mps_dp.get_deleter(), c10::impl::cow::cow_deleter);
+    ASSERT_EQ(cpu_dp.get_deleter(), c10::impl::cow::cow_deleter);
+
+    auto* ctx = mps_dp.cast_context<c10::impl::cow::COWDeleterContext>(
+        c10::impl::cow::cow_deleter
+    );
+
+    ASSERT_EQ(ctx->GetDataDeleter(), c10::impl::cow::unified_memory_data_ptr_ctx_deleter);
+
+    const auto* unimem_ctx =
+        reinterpret_cast<const at::mps::cow::CPUToMPSDataPtrContext*>(ctx->GetConstDataPtr());
+    ASSERT_EQ(cpu_dp.get(), unimem_ctx->get_original_data_ctx());
+    ASSERT_EQ(mps_dp.get(), unimem_ctx->get_mapped_data_ctx());
+    ASSERT_TRUE(unimem_ctx->memory_backed_by_cpu());
+}
+
+TEST(MPSCOWContextToImpl, CPUToMPSMaterialization1) {
+    torch::Tensor cpu_t = torch::randn({10000}, at::device(at::kCPU));
+    torch::Tensor mps_t = at::native::to(
+        cpu_t,
+        /*dtype=*/std::nullopt,
+        /*layout=*/std::nullopt,
+        /*device=*/at::kMPS,
+        /*pin_memory=*/std::nullopt,
+        false,
+        false,
+        /*optional_memory_format=*/std::nullopt
+    );
+    cpu_t += 1;
+    mps_t += 1;
+    // In this case both MPS and CPU will get its own dedicated memory.
+
+    auto& mps_dp = GetMutableDataPtr(mps_t);
+    auto& cpu_dp = GetMutableDataPtr(cpu_t);
+
+    ASSERT_NE(mps_dp.get_context(), cpu_dp.get_context());
+    ASSERT_NE(mps_dp.get_deleter(), cpu_dp.get_deleter());
+}
+
+TEST(MPSCOWContextToImpl, CPUToMPSMaterialization2) {
+    torch::Tensor cpu_t = torch::randn({10000}, at::device(at::kCPU));
+    void* original_cpu_pointer = GetMutableDataPtr(cpu_t).get_context();
+    torch::Tensor mps_t = at::native::to(
+        cpu_t,
+        /*dtype=*/std::nullopt,
+        /*layout=*/std::nullopt,
+        /*device=*/at::kMPS,
+        /*pin_memory=*/std::nullopt,
+        false,
+        false,
+        /*optional_memory_format=*/std::nullopt
+    );
+    mps_t += 1;
+    cpu_t += 1;
+    // In this case CPU will own the original memory, MPS will get its
+    // own dedicated memory.
+
+    auto& mps_dp = GetMutableDataPtr(mps_t);
+    auto& cpu_dp = GetMutableDataPtr(cpu_t);
+
+    ASSERT_EQ(cpu_dp.get(), original_cpu_pointer);
+    ASSERT_EQ(cpu_dp.get_context(), original_cpu_pointer);
+
+    ASSERT_NE(mps_dp.get_context(), cpu_dp.get_context());
+    ASSERT_NE(mps_dp.get_deleter(), cpu_dp.get_deleter());
+}
+
+TEST(MPSCOWContextToImpl, MPSToCPUToMPS) {
+    torch::Tensor mps_t = torch::randn({10000}, at::device(at::kMPS));
+    torch::Tensor cpu_t = at::native::to(
+        mps_t,
+        /*dtype=*/std::nullopt,
+        /*layout=*/std::nullopt,
+        /*device=*/at::kCPU,
+        /*pin_memory=*/std::nullopt,
+        false,
+        false,
+        /*optional_memory_format=*/std::nullopt
+    );
+    // This is an alias.
+    torch::Tensor mps2_t = at::native::to(
+        mps_t,
+        /*dtype=*/std::nullopt,
+        /*layout=*/std::nullopt,
+        /*device=*/std::nullopt,
+        /*pin_memory=*/std::nullopt,
+        false,
+        false,
+        /*optional_memory_format=*/std::nullopt
+    );
+    torch::Tensor mps3_t = at::native::to(
+        cpu_t,
+        /*dtype=*/std::nullopt,
+        /*layout=*/std::nullopt,
+        /*device=*/at::kMPS,
+        /*pin_memory=*/std::nullopt,
+        false,
+        false,
+        /*optional_memory_format=*/std::nullopt
+    );;
+
+    auto& mps_dp = GetMutableDataPtr(mps_t);
+    auto& mps2_dp = GetMutableDataPtr(mps2_t);
+    auto& mps3_dp = GetMutableDataPtr(mps3_t);
+    auto& cpu_dp = GetMutableDataPtr(cpu_t);
+
+    auto* ctx = mps_dp.cast_context<c10::impl::cow::COWDeleterContext>(
+        c10::impl::cow::cow_deleter
+    );
+
+    ASSERT_EQ(ctx->GetDataDeleter(), c10::impl::cow::unified_memory_data_ptr_ctx_deleter);
+
+    const auto* unimem_ctx =
+        reinterpret_cast<const at::mps::cow::MPSToCPUDataPtrContext*>(ctx->GetConstDataPtr());
+    ASSERT_EQ(mps_dp.get(), unimem_ctx->get_original_data_ctx());
+    ASSERT_EQ(mps2_dp.get(), unimem_ctx->get_original_data_ctx());
+    ASSERT_EQ(mps3_dp.get(), unimem_ctx->get_original_data_ctx());
+    ASSERT_EQ(cpu_dp.get(), unimem_ctx->get_mapped_data_ctx());
+    ASSERT_FALSE(unimem_ctx->memory_backed_by_cpu());
+}
+
+TEST(MPSCOWContextToImpl, CPUToMPSToCPU) {
+    torch::Tensor cpu_t = torch::randn({10000}, at::device(at::kCPU));
+    torch::Tensor mps_t = at::native::to(
+        cpu_t,
+        /*dtype=*/std::nullopt,
+        /*layout=*/std::nullopt,
+        /*device=*/at::kMPS,
+        /*pin_memory=*/std::nullopt,
+        false,
+        false,
+        /*optional_memory_format=*/std::nullopt
+    );
+    // This is an alias.
+    torch::Tensor cpu2_t = at::native::to(
+        cpu_t,
+        /*dtype=*/std::nullopt,
+        /*layout=*/std::nullopt,
+        /*device=*/std::nullopt,
+        /*pin_memory=*/std::nullopt,
+        false,
+        false,
+        /*optional_memory_format=*/std::nullopt
+    );
+    torch::Tensor cpu3_t = at::native::to(
+        mps_t,
+        /*dtype=*/std::nullopt,
+        /*layout=*/std::nullopt,
+        /*device=*/at::kCPU,
+        /*pin_memory=*/std::nullopt,
+        false,
+        false,
+        /*optional_memory_format=*/std::nullopt
+    );;
+
+    auto& mps_dp = GetMutableDataPtr(mps_t);
+    auto& cpu2_dp = GetMutableDataPtr(cpu2_t);
+    auto& cpu3_dp = GetMutableDataPtr(cpu3_t);
+    auto& cpu_dp = GetMutableDataPtr(cpu_t);
+
+    auto* ctx = cpu_dp.cast_context<c10::impl::cow::COWDeleterContext>(
+        c10::impl::cow::cow_deleter
+    );
+
+    ASSERT_EQ(ctx->GetDataDeleter(), c10::impl::cow::unified_memory_data_ptr_ctx_deleter);
+
+    const auto* unimem_ctx =
+        reinterpret_cast<const at::mps::cow::CPUToMPSDataPtrContext*>(ctx->GetConstDataPtr());
+    ASSERT_EQ(cpu2_dp.get(), unimem_ctx->get_original_data_ctx());
+    ASSERT_EQ(cpu3_dp.get(), unimem_ctx->get_original_data_ctx());
+    ASSERT_EQ(cpu_dp.get(), unimem_ctx->get_original_data_ctx());
+    ASSERT_EQ(mps_dp.get(), unimem_ctx->get_mapped_data_ctx());
+    ASSERT_TRUE(unimem_ctx->memory_backed_by_cpu());
+}
+
+}  // namespace at::mps

--- a/c10/core/impl/COWDeleter.cpp
+++ b/c10/core/impl/COWDeleter.cpp
@@ -39,4 +39,19 @@ cow::COWDeleterContext::~COWDeleterContext() {
   TORCH_INTERNAL_ASSERT(refcount_ == 0);
 }
 
+void cow::COWDeleterContext::WrapDataPtr(
+  std::function<
+    std::unique_ptr<void, DeleterFnPtr>(
+        std::unique_ptr<void, DeleterFnPtr>, size_t
+    )
+  > wrapper_func, size_t nbytes
+) {
+  data_ = wrapper_func(std::move(data_), nbytes);
+}
+
+void cow::unified_memory_data_ptr_ctx_deleter(void *ctx) {
+  delete reinterpret_cast<cow::UnifiedMemoryDataPtrContext*>(ctx);
+}
+
+
 } // namespace c10::impl

--- a/c10/core/impl/COWDeleter.h
+++ b/c10/core/impl/COWDeleter.h
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <shared_mutex>
 #include <variant>
@@ -45,6 +46,19 @@ class C10_API COWDeleterContext {
   // do with it.
   std::variant<NotLastReference, LastReference> decrement_refcount();
 
+  // Wrap the current underlying data a wrapper function. The wrapper
+  // function takes a unique void pointer and a size, and returns a
+  // unique void pointer.
+  void WrapDataPtr(
+    std::function<
+      std::unique_ptr<void, DeleterFnPtr>(
+        std::unique_ptr<void, DeleterFnPtr>, size_t
+      )
+    > wrapper_func, size_t nbytes
+  );
+
+  const void* GetConstDataPtr() const { return data_.get(); }
+  DeleterFnPtr GetDataDeleter() const { return data_.get_deleter(); }
  private:
   // The destructor is hidden, this should only ever be used within
   // UniqueVoidPtr using cow::delete_context as the deleter.
@@ -62,5 +76,27 @@ class C10_API COWDeleterContext {
 // was allocated on the heap with `new`, because when the refcount reaches 0,
 // the context is deleted with `delete`.
 C10_API void cow_deleter(void* ctx);
+
+
+class C10_API UnifiedMemoryDataPtrContext {
+ public:
+  // Provided the original_data context, initialize the mapped data pointer.
+  virtual void InitializeMappedData() = 0;
+  // Empty destructor
+  virtual ~UnifiedMemoryDataPtrContext() {};
+
+  // Transfer the ownership of the original data ctx
+  virtual std::unique_ptr<void, DeleterFnPtr> move_original_data_ctx() = 0;
+  // Get the original data ctx
+  virtual void* get_original_data_ctx() const = 0;
+  // Get the mapped data ctx
+  virtual void* get_mapped_data_ctx() const = 0;
+
+  // Whether the memory is allocated by the CPU
+  virtual bool memory_backed_by_cpu() const = 0;
+};
+
+// Deleter for UnifiedMemoryDataPtrContext
+C10_API void unified_memory_data_ptr_ctx_deleter(void *ctx);
 
 } // namespace c10::impl::cow

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -375,6 +375,7 @@ def mps_ops_modifier(ops):
         'addcmul',
         'addmmdecomposed',
         'addmv',
+        'as_stridedpartial_views',
         'asin',
         'atan',
         'atanh',
@@ -958,7 +959,6 @@ def mps_ops_modifier(ops):
         # CPU Errors:
         'addr': [torch.bool, torch.int16, torch.int32,
                  torch.int64, torch.uint8, torch.int8],  # "addmv_impl_cpu" not implemented for 'Half'
-        'as_stridedpartial_views': None,  # cpu result off, showing random values
 
         # random results
         # mps vs cpu:

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -451,9 +451,9 @@
   self: grad
   result: auto_linear
 
-- name: _lazy_clone(Tensor self) -> Tensor
-  self: grad
-  result: auto_linear
+- name: _lazy_clone(Tensor self, *, Device? device=None) -> Tensor
+  self: _lazy_clone_backward(grad, self.options())
+  result: _lazy_clone(self_t, device)
 
 - name: _to_copy(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool non_blocking=False, MemoryFormat? memory_format=None) -> Tensor
   self: _to_copy_backward(grad, self.options())

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -333,6 +333,7 @@ GRADIENT_IMPLEMENTED_FOR_COMPLEX = {
     "replication_pad3d",
     "put",
     "put_",
+    "_lazy_clone",
     "_to_copy",
     "replication_pad1d_backward",
     "replication_pad2d_backward",

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -6894,6 +6894,16 @@ Tensor _to_copy_backward(
   return grad->to(self_options, /*non_blocking=*/false, /*copy=*/false);
 }
 
+Tensor _lazy_clone_backward(
+    const Tensor& grad_,
+    const c10::TensorOptions& self_options) {
+  if (grad_.device() != self_options.device()) {
+    return grad_.to(self_options, /*non_blocking=*/false, /*copy=*/false);
+  } else {
+    return grad_;
+  }
+}
+
 std::tuple<Tensor, Tensor> index_reduce_backward(
     const Tensor& grad,
     const Tensor& self,

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -1055,6 +1055,10 @@ Tensor _to_copy_backward(
     const Tensor& grad,
     const c10::TensorOptions& self_options);
 
+Tensor _lazy_clone_backward(
+    const Tensor& grad,
+    const c10::TensorOptions& self_options);
+
 std::tuple<Tensor, Tensor> index_reduce_backward(
     const Tensor& grad,
     const Tensor& self,


### PR DESCRIPTION
Implemented COW logic w.r.t SharedMemoryStorage for MPSTensor.to(cpu), and CPUTensor.to(mps), so no explicit copy is needed unless a write occurred.

Removed the MANAGED UsageFlags and related logic. Removed PRIVATE_SMALL pool type and associated related logic to SHARED_SMALL.

