### PR TITLE
[easy] Log subproc pool creation

### DIFF
--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -167,7 +167,9 @@ class AsyncCompile:
         else:
             pre_fork_setup()
             ctx = multiprocessing.get_context(get_worker_start_method())
-            log.info("Creating forked subprocess pool with %d workers", get_compile_threads())
+            log.info(
+                "Creating forked subprocess pool with %d workers", get_compile_threads()
+            )
             pool = ProcessPoolExecutor(
                 get_compile_threads(),
                 mp_context=ctx,

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -49,6 +49,8 @@ _t0: Optional[float] = None
 
 kernel_code_log = torch._logging.getArtifactLogger(__name__, "kernel_code")
 
+log = logging.getLogger(__name__)
+
 
 def pre_fork_setup():
     """
@@ -160,10 +162,12 @@ class AsyncCompile:
         pool: AnyPool
         if get_worker_start_method() == "subprocess":
             # Wrapper around ProcessPoolExecutor forks in a new process we control
+            log.info("Creating subprocess pool with %d workers", get_compile_threads())
             pool = SubprocPool(get_compile_threads())
         else:
             pre_fork_setup()
             ctx = multiprocessing.get_context(get_worker_start_method())
+            log.info("Creating forked subprocess pool with %d workers", get_compile_threads())
             pool = ProcessPoolExecutor(
                 get_compile_threads(),
                 mp_context=ctx,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #138642

Summary: Request from internal to log subproc pool creation

Test Plan:
```
$ TORCH_LOGS=+torch._inductor.async_compile python ~/add.py
I1022 14:12:41.915000 444394 torch/_inductor/async_compile.py:165] Creating subprocess pool with 32 workers
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov