### PR TITLE
Add a config `hash_in_kernel_names` 

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3157,6 +3157,8 @@ class TritonScheduling(SIMDScheduling):
             kernel_name = "_".join(
                 ["triton", kernel_category, fused_name, wrapper.next_kernel_suffix()]
             )
+            if config.triton.hash_in_kernel_names:
+                kernel_name = f"{kernel_name}_{code_hash(src_code.strip())}"
             # use the original src_code as the key
             wrapper.src_to_kernel[src_code] = kernel_name
             subs_name = kernel_name if config.triton.unique_kernel_names else "triton_"

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -934,6 +934,12 @@ class triton:
         os.environ.get("TORCHINDUCTOR_UNIQUE_KERNEL_NAMES", "1") == "1"
     )
 
+    # this option adds a hash suffix to the kernel names. it helps profiler to map kernels
+    # back to its source code
+    hash_in_kernel_names = (
+        os.environ.get("TORCHINDUCTOR_HASH_IN_KERNEL_NAMES", "0") == "1"
+    )
+
     # should we put op names in kernel names
     # False: No special names (just triton__1, triton__2, etc.)
     # "torch": Maps to the fx op in the Dynamo graph (module name, method name, etc.)


### PR DESCRIPTION
This option helps correlating triton kernel in profiling traces with its source code. It is disabled by default and should be for profiling purpose only.

After run with `TORCHINDUCTOR_HASH_IN_KERNEL_NAMES=1`, an exampled code snippet in output_code.py:
```
# kernel path: /tmp/torchinductor_yhao/tmp7mf5xcsz/lo/clobi4dt6e3xuk6pckv5l7uqxsf2ianp6d3g6lgh6wrm5f64vxaz.py
# Topologically Sorted Source Nodes: [embedding], Original ATen: [aten.embedding]
# Source node to ATen node mapping:
#   embedding => embedding
# Graph fragment:
#   %embedding : [num_users=1] = call_function[target=torch.ops.aten.embedding.default](args = (%arg2_1, %view), kwargs = {})
triton_poi_fused_embedding_1_cemi5yor3uh3muxgzlaoqs5wrpjk7q6xod6dgmymw2y5xd6wk3sk = async_compile.triton('triton_poi_fused_embedding_1_cemi5yor3uh3muxgzlaoqs5wrpjk7q6xod6dgmymw2y5xd6wk3sk', 
```
The hash is per-kernel and different from the hashed file names in `/tmp/`.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov