### PR TITLE
[export] Add serdes_non_strict to tests

### DIFF
--- a/test/export/test_serdes.py
+++ b/test/export/test_serdes.py
@@ -15,7 +15,7 @@ from torch.export import export, load, save
 test_classes = {}
 
 
-def mocked_serder_export(*args, **kwargs):
+def mocked_serder_export_strict(*args, **kwargs):
     ep = export(*args, **kwargs)
     buffer = io.BytesIO()
     save(ep, buffer)
@@ -24,16 +24,35 @@ def mocked_serder_export(*args, **kwargs):
     return loaded_ep
 
 
-def make_dynamic_cls(cls):
-    cls_prefix = "SerDesExport"
+def mocked_serder_export_non_strict(*args, **kwargs):
+    if "strict" in kwargs:
+        ep = export(*args, **kwargs)
+    else:
+        ep = export(*args, **kwargs, strict=False)
+    buffer = io.BytesIO()
+    save(ep, buffer)
+    buffer.seek(0)
+    loaded_ep = load(buffer)
+    return loaded_ep
 
-    test_class = testing.make_test_cls_with_mocked_export(
-        cls,
-        cls_prefix,
-        test_export.SERDES_SUFFIX,
-        mocked_serder_export,
-        xfail_prop="_expected_failure_serdes",
-    )
+
+def make_dynamic_cls(cls, strict):
+    if strict:
+        test_class = testing.make_test_cls_with_mocked_export(
+            cls,
+            "SerDesExport",
+            test_export.SERDES_SUFFIX,
+            mocked_serder_export_strict,
+            xfail_prop="_expected_failure_serdes",
+        )
+    else:
+        test_class = testing.make_test_cls_with_mocked_export(
+            cls,
+            "SerDesExportNonStrict",
+            test_export.SERDES_NON_STRICT_SUFFIX,
+            mocked_serder_export_non_strict,
+            xfail_prop="_expected_failure_serdes_non_strict",
+        )
 
     test_classes[test_class.__name__] = test_class
     # REMOVING THIS LINE WILL STOP TESTS FROM RUNNING
@@ -46,7 +65,8 @@ tests = [
     test_export.TestExport,
 ]
 for test in tests:
-    make_dynamic_cls(test)
+    make_dynamic_cls(test, True)
+    make_dynamic_cls(test, False)
 del test
 
 if __name__ == "__main__":

--- a/test/export/testing.py
+++ b/test/export/testing.py
@@ -270,6 +270,12 @@ def expectedFailureSerDer(fn):
     return fn
 
 
+# Controls tests generated in test/export/test_serdes.py
+def expectedFailureSerDerNonStrict(fn):
+    fn._expected_failure_serdes_non_strict = True
+    return fn
+
+
 def expectedFailureSerDerPreDispatch(fn):
     fn._expected_failure_serdes_pre_dispatch = True
     return fn


### PR DESCRIPTION
Summary: We expand the tests to cover serdes_non_strict. Currently failing tests are skipped.

Test Plan:
```
buck2 test @//mode/dev-nosan //caffe2/test:test_export -- -r _serdes_non_strict
```

Differential Revision: D64709285


