### PR TITLE
[fx graph cache] Refactor FxGraphCachePickler

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -12,6 +12,7 @@ from torch._dynamo.utils import counters
 from torch._inductor import config, metrics
 from torch._inductor.async_compile import AsyncCompile
 from torch._inductor.codecache import (
+    BypassFxGraphCache,
     cuda_compile_command,
     CUDACodeCache,
     FxGraphCachePickler,
@@ -633,113 +634,112 @@ class TestFxGraphCacheHashing(TestCase):
         """
         Test the hashing of tensor constants.
         """
-        data = FxGraphCachePickler.dumps(torch.tensor(list(range(9))))
+        data = FxGraphCachePickler().dumps(torch.tensor(list(range(9))))
         self.assertIsInstance(pickle.loads(data), TensorMetadataAndValues)
 
     def test_hash_fake_tensors(self):
         """
         Test hashing (pickling) FakeTensors with various characteristics.
         """
+        pickler = FxGraphCachePickler()
         with torch._subclasses.FakeTensorMode():
             # Verify that FakeTensors get pickled into a TensorMetadata:
-            data = FxGraphCachePickler.dumps(torch.randn(1))
+            data = pickler.dumps(torch.randn(1))
             self.assertIsInstance(pickle.loads(data), TensorMetadata)
 
             # Different shapes:
             self.assertEqual(
-                FxGraphCachePickler.dumps(torch.randn(3)),
-                FxGraphCachePickler.dumps(torch.randn(3)),
+                pickler.dumps(torch.randn(3)),
+                pickler.dumps(torch.randn(3)),
             )
             self.assertNotEqual(
-                FxGraphCachePickler.dumps(torch.randn(3)),
-                FxGraphCachePickler.dumps(torch.randn(4)),
+                pickler.dumps(torch.randn(3)),
+                pickler.dumps(torch.randn(4)),
             )
             self.assertNotEqual(
-                FxGraphCachePickler.dumps(torch.randn(3)),
-                FxGraphCachePickler.dumps(torch.randn(3, 3)),
+                pickler.dumps(torch.randn(3)),
+                pickler.dumps(torch.randn(3, 3)),
             )
 
             self.assertEqual(
-                FxGraphCachePickler.dumps(torch.randn(3, 3)),
-                FxGraphCachePickler.dumps(torch.randn(3, 3)),
+                pickler.dumps(torch.randn(3, 3)),
+                pickler.dumps(torch.randn(3, 3)),
             )
             self.assertNotEqual(
-                FxGraphCachePickler.dumps(torch.randn(3, 3)),
-                FxGraphCachePickler.dumps(torch.randn(3, 4)),
+                pickler.dumps(torch.randn(3, 3)),
+                pickler.dumps(torch.randn(3, 4)),
             )
             self.assertNotEqual(
-                FxGraphCachePickler.dumps(torch.randn(3, 3)),
-                FxGraphCachePickler.dumps(torch.randn(4, 3)),
+                pickler.dumps(torch.randn(3, 3)),
+                pickler.dumps(torch.randn(4, 3)),
             )
 
             # Different strides:
             self.assertEqual(
-                FxGraphCachePickler.dumps(torch.randn(3, 3)),
-                FxGraphCachePickler.dumps(
-                    torch.randn(3, 3).transpose(0, 1).transpose(0, 1)
-                ),
+                pickler.dumps(torch.randn(3, 3)),
+                pickler.dumps(torch.randn(3, 3).transpose(0, 1).transpose(0, 1)),
             )
             self.assertNotEqual(
-                FxGraphCachePickler.dumps(torch.randn(3, 3)),
-                FxGraphCachePickler.dumps(torch.randn(3, 3).transpose(0, 1)),
+                pickler.dumps(torch.randn(3, 3)),
+                pickler.dumps(torch.randn(3, 3).transpose(0, 1)),
             )
 
             # Different storage offsets:
             self.assertEqual(
-                FxGraphCachePickler.dumps(torch.randn(3)[1:]),
-                FxGraphCachePickler.dumps(torch.randn(3)[1:]),
+                pickler.dumps(torch.randn(3)[1:]),
+                pickler.dumps(torch.randn(3)[1:]),
             )
             self.assertEqual(
-                FxGraphCachePickler.dumps(torch.randn(3)[1:]),
-                FxGraphCachePickler.dumps(torch.randn(2)),
+                pickler.dumps(torch.randn(3)[1:]),
+                pickler.dumps(torch.randn(2)),
             )
 
             # Different dtypes:
             self.assertEqual(
-                FxGraphCachePickler.dumps(torch.randn(3, dtype=torch.float32)),
-                FxGraphCachePickler.dumps(torch.randn(3, dtype=torch.float32)),
+                pickler.dumps(torch.randn(3, dtype=torch.float32)),
+                pickler.dumps(torch.randn(3, dtype=torch.float32)),
             )
             self.assertNotEqual(
-                FxGraphCachePickler.dumps(torch.randn(3, dtype=torch.float32)),
-                FxGraphCachePickler.dumps(torch.randn(3, dtype=torch.float64)),
+                pickler.dumps(torch.randn(3, dtype=torch.float32)),
+                pickler.dumps(torch.randn(3, dtype=torch.float64)),
             )
 
             # Different 'requires_grad':
             self.assertEqual(
-                FxGraphCachePickler.dumps(torch.randn(3, requires_grad=True)),
-                FxGraphCachePickler.dumps(torch.randn(3, requires_grad=True)),
+                pickler.dumps(torch.randn(3, requires_grad=True)),
+                pickler.dumps(torch.randn(3, requires_grad=True)),
             )
             self.assertNotEqual(
-                FxGraphCachePickler.dumps(torch.randn(3, requires_grad=True)),
-                FxGraphCachePickler.dumps(torch.randn(3, requires_grad=False)),
+                pickler.dumps(torch.randn(3, requires_grad=True)),
+                pickler.dumps(torch.randn(3, requires_grad=False)),
             )
 
             # Different memory formats:
             self.assertNotEqual(
-                FxGraphCachePickler.dumps(torch.randn(1, 2, 3, 4)),
-                FxGraphCachePickler.dumps(
+                pickler.dumps(torch.randn(1, 2, 3, 4)),
+                pickler.dumps(
                     torch.randn(1, 2, 3, 4).to(memory_format=torch.channels_last)
                 ),
             )
 
             # Different devices:
             self.assertEqual(
-                FxGraphCachePickler.dumps(torch.randn(3, device="meta")),
-                FxGraphCachePickler.dumps(torch.randn(3, device="meta")),
+                pickler.dumps(torch.randn(3, device="meta")),
+                pickler.dumps(torch.randn(3, device="meta")),
             )
             self.assertNotEqual(
-                FxGraphCachePickler.dumps(torch.randn(3, device="meta")),
-                FxGraphCachePickler.dumps(torch.randn(3, device="cpu")),
+                pickler.dumps(torch.randn(3, device="meta")),
+                pickler.dumps(torch.randn(3, device="cpu")),
             )
 
             if HAS_MULTIGPU:
                 self.assertEqual(
-                    FxGraphCachePickler.dumps(torch.randn(3, device=f"{GPU_TYPE}:1")),
-                    FxGraphCachePickler.dumps(torch.randn(3, device=f"{GPU_TYPE}:1")),
+                    pickler.dumps(torch.randn(3, device=f"{GPU_TYPE}:1")),
+                    pickler.dumps(torch.randn(3, device=f"{GPU_TYPE}:1")),
                 )
                 self.assertNotEqual(
-                    FxGraphCachePickler.dumps(torch.randn(3, device=f"{GPU_TYPE}:0")),
-                    FxGraphCachePickler.dumps(torch.randn(3, device=f"{GPU_TYPE}:1")),
+                    pickler.dumps(torch.randn(3, device=f"{GPU_TYPE}:0")),
+                    pickler.dumps(torch.randn(3, device=f"{GPU_TYPE}:1")),
                 )
 
     def test_hash_kwargs(self):
@@ -747,20 +747,22 @@ class TestFxGraphCacheHashing(TestCase):
         Test the special handling of the kwargs when hashing, i.e.,
         ordering of the kwargs dict and any set arguments.
         """
+        pickler = FxGraphCachePickler()
+
         # Dict order of the kwargs should not affect hashes.
         details1 = FxGraphHashDetails(None, [], {"a": 0, "z": 1}, [])
         details2 = FxGraphHashDetails(None, [], {"z": 1, "a": 0}, [])
         self.assertEqual(
-            FxGraphCachePickler.dumps(details1),
-            FxGraphCachePickler.dumps(details2),
+            pickler.dumps(details1),
+            pickler.dumps(details2),
         )
 
         # Different kwarg values should affect hashes.
         details1 = FxGraphHashDetails(None, [], {"a": 0}, [])
         details2 = FxGraphHashDetails(None, [], {"a": 1}, [])
         self.assertNotEqual(
-            FxGraphCachePickler.dumps(details1),
-            FxGraphCachePickler.dumps(details2),
+            pickler.dumps(details1),
+            pickler.dumps(details2),
         )
 
         # Set order should not affect hashes. Sets are unordered, but
@@ -770,16 +772,16 @@ class TestFxGraphCacheHashing(TestCase):
         details1 = FxGraphHashDetails(None, [], {"a": set1}, [])
         details2 = FxGraphHashDetails(None, [], {"a": set2}, [])
         self.assertEqual(
-            FxGraphCachePickler.dumps(details1),
-            FxGraphCachePickler.dumps(details2),
+            pickler.dumps(details1),
+            pickler.dumps(details2),
         )
 
         # But different set contents should affect hashes.
         details1 = FxGraphHashDetails(None, [], {"a": {1, 2, 3}}, [])
         details2 = FxGraphHashDetails(None, [], {"a": {1, 2}}, [])
         self.assertNotEqual(
-            FxGraphCachePickler.dumps(details1),
-            FxGraphCachePickler.dumps(details2),
+            pickler.dumps(details1),
+            pickler.dumps(details2),
         )
 
     def test_hash_config_changes(self):
@@ -793,13 +795,15 @@ class TestFxGraphCacheHashing(TestCase):
         with config.patch({"max_autotune": True}):
             details3 = FxGraphHashDetails(None, [], {}, [])
 
+        pickler = FxGraphCachePickler()
+
         self.assertEqual(
-            FxGraphCachePickler.dumps(details1),
-            FxGraphCachePickler.dumps(details2),
+            pickler.dumps(details1),
+            pickler.dumps(details2),
         )
         self.assertNotEqual(
-            FxGraphCachePickler.dumps(details1),
-            FxGraphCachePickler.dumps(details3),
+            pickler.dumps(details1),
+            pickler.dumps(details3),
         )
 
     def test_hash_custom_passes(self):
@@ -826,13 +830,24 @@ class TestFxGraphCacheHashing(TestCase):
             custom_pass._uuid = "2"
             details3 = FxGraphHashDetails(None, [], {}, [])
 
+            pickler = FxGraphCachePickler()
+
             self.assertEqual(
-                FxGraphCachePickler.dumps(details1),
-                FxGraphCachePickler.dumps(details2),
+                pickler.dumps(details1),
+                pickler.dumps(details2),
             )
             self.assertNotEqual(
-                FxGraphCachePickler.dumps(details1),
-                FxGraphCachePickler.dumps(details3),
+                pickler.dumps(details1),
+                pickler.dumps(details3),
+            )
+
+    def test_bypass_unsupported(self):
+        """
+        Test _reduce_unsupported
+        """
+        with self.assertRaises(BypassFxGraphCache):
+            FxGraphCachePickler().dumps(
+                torch.fx.experimental._backward_state.BackwardState()
             )
 
     def test_stable_strings(self):
@@ -846,9 +861,10 @@ class TestFxGraphCacheHashing(TestCase):
 
         self.assertNotEqual(id(s1), id(s2))
 
+        pickler = FxGraphCachePickler()
         self.assertEqual(
-            FxGraphCachePickler.dumps([s1, s1]),
-            FxGraphCachePickler.dumps([s1, s2]),
+            pickler.dumps([s1, s1]),
+            pickler.dumps([s1, s2]),
         )
 
     def test_get_hash_for_files(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #138679
* #138648

Summary: In an upcoming change, we need to modify how FxGraphCachePickler pickles tensor constants. Specifically, we'll pickle differently depending on whether parameters have been frozen. To do that, it will be convenient to change FxGraphCachePickler into a regular object instead of a collection of classmethods.

Test Plan: unit tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov