### PR TITLE
Add overflow check for negtive integer div_floor and div_trunc on CPU

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -209,6 +209,11 @@ void div_trunc_kernel(TensorIteratorBase& iter) {
     // constant.
     AT_DISPATCH_INTEGRAL_TYPES(dtype, "div_trunc_cpu", [&]() {
       cpu_kernel(iter, [](scalar_t a, scalar_t b) -> scalar_t {
+        // int64 and int division may cause floating point exception
+        if constexpr (std::is_same_v<scalar_t, int64_t> || std::is_same_v<scalar_t, int>) {
+          constexpr scalar_t min = std::numeric_limits<scalar_t>::min();
+          TORCH_CHECK(b != -1 || a != min, "OverflowDivisionError");
+        }
         TORCH_CHECK(b != 0, "ZeroDivisionError");
         return a / b;
       });
@@ -285,6 +290,11 @@ void div_floor_kernel(TensorIteratorBase& iter) {
     // There's no SIMD integer division, so don't try to vectorize it.
     AT_DISPATCH_INTEGRAL_TYPES(dtype, "div_floor_cpu", [&]() {
       cpu_kernel(iter, [](scalar_t a, scalar_t b) -> scalar_t {
+        // int64 and int division may cause floating point exception
+        if constexpr (std::is_same_v<scalar_t, int64_t> || std::is_same_v<scalar_t, int>) {
+          constexpr scalar_t min = std::numeric_limits<scalar_t>::min();
+          TORCH_CHECK(b != -1 || a != min, "OverflowDivisionError");
+        }
         TORCH_CHECK(b != 0, "ZeroDivisionError");
         return c10::div_floor_integer(a, b);
       });

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3208,6 +3208,17 @@ else:
         self.assertEqual(src.abs().bfloat16(), src_bf16.abs())
 
     @onlyCPU
+    @dtypes(torch.int32, torch.int64)
+    def test_neg_integer_div_overflow(self, device, dtype):
+        x = torch.tensor([torch.iinfo(dtype).min], dtype=dtype, device=device)
+        y = torch.tensor([-1], dtype=dtype, device=device)
+        torch.div(x, y)
+        with self.assertRaisesRegex(RuntimeError, r'OverflowDivisionError'):
+            torch.div(x, y, rounding_mode='trunc')
+        with self.assertRaisesRegex(RuntimeError, r'OverflowDivisionError'):
+            torch.div(x, y, rounding_mode='floor')
+
+    @onlyCPU
     @dtypes(torch.bfloat16, torch.half)
     def test_reduced_type_float_copy(self, device, dtype):
         for shape in [(20, 7), (249, 137), (1029, 917), (1, 7, 19, 17), (3, 77, 1091)]:


### PR DESCRIPTION
Fixes #138425.
Add overflow check of negative integer division for div_floor and div_trunc on CPU. This check affects performance by less than 1%.
cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168