### PR TITLE
[FSDP] Add support for `FSDPCommContext` on PrivateUse1 backend

### DIFF
--- a/torch/distributed/_composable/fsdp/_fsdp_param_group.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param_group.py
@@ -51,7 +51,7 @@ class FSDPCommContext:
 
     def lazy_init(self, device: torch.device):
         self.device_handle = _get_device_handle(device.type)
-        if device.type not in ["cuda", "hpu"]:
+        if device.type not in ["cuda", "hpu", torch._C._get_privateuse1_backend_name()]:
             raise RuntimeError("FSDP requires streams support")
         # Setting the all-gather/reduce-scatter streams to be higher priority
         # can help avoid some issues where their copies in/out are delayed and


### PR DESCRIPTION
I believe NPU supports streams, but what about other privateuse1 backends?

cc: @FFFrog @noemotiovon

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o