### PR TITLE
[PT2][Optimus] Normalize Clamp to use kwargs

### DIFF
--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -469,6 +469,10 @@ def normalize_reshape_default(match: Match, *args, **kwargs):
     CallMethodVarArgs("clamp", users=MULTIPLE),
     pass_dict=construct_pattern_matcher_pass("normalization_pass"),
 )
+@register_graph_pattern(
+    CallFunctionVarArgs(torch.clamp, users=MULTIPLE),
+    pass_dict=construct_pattern_matcher_pass("normalization_pass"),
+)
 def normalize_clamp_default(match: Match, *args, **kwargs):
     clamp_node = match.nodes[0]
     if not is_node_meta_valid(clamp_node):
@@ -478,12 +482,20 @@ def normalize_clamp_default(match: Match, *args, **kwargs):
     if free_symbols(clamp_node.meta["example_value"].shape):
         log.debug("dynamic shape not supported: %s", clamp_node)
         return
-
+    if len(clamp_node.args) > 1:
+        args = (get_arg_value(clamp_node, 0),)
+        kwargs = {
+            "min": get_arg_value(clamp_node, 1, kwarg_name="min"),
+            "max": get_arg_value(clamp_node, 2, kwarg_name="max"),
+        }
+    else:
+        args = clamp_node.args
+        kwargs = clamp_node.kwargs
     with match.graph.inserting_after(clamp_node):
         new_clamp_node = match.graph.call_function(
             torch.clamp,
-            args=clamp_node.args,
-            kwargs=clamp_node.kwargs,
+            args=args,
+            kwargs=kwargs,
         )
     clamp_node.replace_all_uses_with(new_clamp_node)
     new_clamp_node.meta.update(clamp_node.meta)


### PR DESCRIPTION
Summary: The current clamp normalization does not include torch.clamp where its min and max are not normalized to kwargs, thus the batch fusion of clamp can hit min and max are both empty problem.

Test Plan:
```
buck2 run mode/opt servicelab/ai_ml/auto_tune:local_model_pt2 -- --flow_id 654509735 --test_mode split
```

GPU type: NVIDIA PG509-210
=============Print full analysis for offsite_cvr_oba_optout_dedicated_model================
| Metric             | Value            |
|:-------------------|:-----------------|
| GPU type           | A100             |
| Batch size         | 10               |
| Latency            | 227.13 ms        |
| Model size         | 2322763344 bytes |
| Flops/example      | 1136.52 G        |
| TFLOPS             | 50.04            |
| MFU                | 16.04%           |
| Activation/example | 2722.49 MB       |
I1023 112249.043 local_model_with_pt2.py:25] benchmark results [('batch_size', 10), ('latency_ms', 22712), ('model_size_bytes', 2322763344), ('flops_per_example', 113652), ('tflops_g', 5003), ('mfu', 1603), ('activation_per_example_mb', 272249)

Differential Revision: D64848369




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov