### PR TITLE
[Windows XPU] Fix MSVC ambiguous symbol error

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1035,6 +1035,10 @@ if(USE_XPU)
   add_library(torch_xpu ${Caffe2_XPU_SRCS})
   torch_compile_options(torch_xpu)  # see cmake/public/utils.cmake
   target_compile_definitions(torch_xpu PRIVATE USE_XPU)
+  
+  if(WIN32)
+    target_compile_options(torch_xpu PRIVATE /permissive-)
+  endif()
 
   # ATen XPU implementation
   set(TORCH_XPU_OPS_DIR ${TORCH_ROOT}/third_party/torch-xpu-ops)

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1035,7 +1035,6 @@ if(USE_XPU)
   add_library(torch_xpu ${Caffe2_XPU_SRCS})
   torch_compile_options(torch_xpu)  # see cmake/public/utils.cmake
   target_compile_definitions(torch_xpu PRIVATE USE_XPU)
-  
   if(WIN32)
     target_compile_options(torch_xpu PRIVATE /permissive-)
   endif()


### PR DESCRIPTION
PT master build with XPU will fail due to MSVC issue of ambiguous symbol error 'std', previously fixed it with MSVC flag in torch-xpu-ops https://github.com/intel/torch-xpu-ops/pull/946/files, but the error is observed in PT master too after 2.5 and oneAPI update.
