### PR TITLE
[Windows XPU] SYCL version compatibility

### DIFF
--- a/cmake/Modules/FindSYCLToolkit.cmake
+++ b/cmake/Modules/FindSYCLToolkit.cmake
@@ -66,10 +66,9 @@ endif()
 # sycl_runtime_version needs to be hardcoded and uplifted when SYCL runtime version uplifts.
 # TODO: remove this when sycl.lib is supported on Windows
 if(WIN32)
-  set(sycl_runtime_version 7)
   find_library(
     SYCL_LIBRARY
-    NAMES "sycl${sycl_runtime_version}"
+    NAMES "sycl7" "sycl8"
     HINTS ${SYCL_LIBRARY_DIR}
     NO_DEFAULT_PATH
   )


### PR DESCRIPTION
From oneAPI 2025.0, the sycl lib naming is changed to sycl8.dll, which can result in failure with current implementation of finding sycl lib as sycl7.dll. Hence, adding sycl7 and sycl8 both as library search options.
