### PR TITLE
Make automatic_dynamic state live per CodeId, rather than on code object

### DIFF
--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -33,6 +33,7 @@ from .eval_frame import (
 )
 from .external_utils import is_compiling
 from .mutation_guard import GenerationTracker
+from .pgo import CODE_STATE
 from .utils import graph_break_reasons, guard_failures, orig_code_map, reset_frame_count
 
 
@@ -82,6 +83,7 @@ def reset() -> None:
     with convert_frame.compile_lock:
         reset_code_caches()
         convert_frame.input_codes.clear()
+        CODE_STATE.clear()
         convert_frame.output_codes.clear()
         orig_code_map.clear()
         guard_failures.clear()

--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -5,17 +5,49 @@ import dataclasses
 import enum
 import logging
 import time
-from typing import Optional, Tuple, TYPE_CHECKING, TypeVar, Union
+from collections import defaultdict
+from typing import DefaultDict, Optional, Tuple, TYPE_CHECKING, TypeVar, Union
 from typing_extensions import Self
 
 from torch._dynamo.utils import get_chromium_event_logger
 
 
 if TYPE_CHECKING:
+    import types
+
     from torch._dynamo.symbolic_convert import InstructionTranslator
 
 
 log = logging.getLogger(__name__)
+
+# How does in memory representation work?  Concretely, this module is
+# responsible for holding GLOBAL state representing the state it holds, no
+# other copies permitted.  So we retire frame_state entirely and store it
+# here.  This should be reset when Dynamo is reset.  We never GC information
+# (similar to how the filesystem doesn't get cleaned up except by tmp
+# cleaner), so the expectation is the information is relatively cheap and we
+# don't mind leaking it.
+
+
+@dataclasses.dataclass(frozen=True)
+class CodeId:
+    filename: str
+    firstlineno: int
+    name: str
+
+    @staticmethod
+    def make(code: types.CodeType) -> CodeId:
+        return CodeId(code.co_filename, code.co_firstlineno, code.co_name)
+
+
+@dataclasses.dataclass
+class CodeState:
+    automatic_dynamic: DefaultDict[str, FrameStateSizeEntry] = dataclasses.field(
+        default_factory=lambda: defaultdict(FrameStateSizeEntry)
+    )
+
+
+CODE_STATE: DefaultDict[CodeId, CodeState] = defaultdict(CodeState)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -160,8 +192,10 @@ def update_automatic_dynamic(
     *,
     is_unspecialized_nn_module: bool = False,
 ) -> FrameStateSizeEntry:
-    is_update = name in tx.output.frame_state
-    mut_entry = tx.output.frame_state.setdefault(name, FrameStateSizeEntry())
+    code_id = CodeId.make(tx.f_code)
+    frame_state = CODE_STATE[code_id]
+    is_update = name in frame_state.automatic_dynamic
+    mut_entry = frame_state.automatic_dynamic[name]
     old_entry = copy.copy(mut_entry)
     mut_entry |= entry
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #139001
* __->__ #138740
* #138717

This is semantics changing as if you are dealing with multiple code objects which have exactly the same filename/firstlineno/name, but are distinct objects, and need non-aliasing automatic dynamic state. Otherwise, this should be equivalent (modulo lifetime). I want to do this because when I do PGO I can't index on code object identity, need a stable identifier.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec