### PR TITLE
[inductor] Allow unbacked symint fallback in stride reordering

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3011,7 +3011,9 @@ class Layout(IRNode):
         # reorder the stride given order
         stride_ordered = [-1] * len(order)
         for i in range(len(order)):
-            stride_ordered[order[i]] = V.graph.sizevars.size_hint(stride[i])
+            stride_ordered[order[i]] = V.graph.sizevars.size_hint(
+                stride[i], fallback=config.unbacked_symint_fallback
+            )
         # check if it is in ascending order
         for i in range(len(order) - 1):
             if stride_ordered[i] > stride_ordered[i + 1]:


### PR DESCRIPTION
Summary: Stride could contain unbacked symint. This change allows fallback rather than raising an exception.

Test Plan: CI

Differential Revision: D64855448




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov