### PR TITLE
[PyTorch] Fix out-of-bounds array access in atomic_add_vec

### DIFF
--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -637,8 +637,8 @@ void atomic_add_vec(T *addr, at::vec::VectorizedN<int64_t, NI> index, at::vec::V
   static_assert(len <= at::vec::VectorizedN<T, NV>::size());
   __at_align__ std::array<T, len> tmpbuf;
   __at_align__ std::array<int64_t, len> tmpidx;
-  offset.store(tmpbuf.data());
-  index.store(tmpidx.data());
+  offset.store(tmpbuf.data(), len);
+  index.store(tmpidx.data(), len);
   for (int i = 0; i < len; i++){
     atomic_add(addr + tmpidx[i], tmpbuf[i]);
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #138275
* #138005
* #137918
* #137917
* #137916
* #137915
* #137914
* #137913
* #137912
* #137911
* #137661
* #137426
* __->__ #138744
* #138716
* #138655
* #138542
* #138486

There is no guarantee that `len` here is enough for a full vector. This was causing at least one test failure on https://github.com/pytorch/pytorch/pull/137426.

Differential Revision: [D64857786](https://our.internmc.facebook.com/intern/diff/D64857786/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov