### PR TITLE
Raise error for int64 and bool dtypes in nanmean, even for empty tensors

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1434,10 +1434,10 @@ Tensor& nanmean_out(
     bool keepdim,
     std::optional<ScalarType> opt_dtype,
     Tensor& result) {
-  // Check if dtype is int64 or bool and raise an error
+  // Check if dtype is an integral type or Bool and raise an error
   TORCH_CHECK(
-      self.scalar_type() != ScalarType::Bool && self.scalar_type() != ScalarType::Long,
-      "nanmean(): dtype 'Bool' and 'Long' are not supported for nanmean, even for empty tensors.");
+    !at::isIntegralType(self.scalar_type(), /*includeBool=*/true),
+    "nanmean(): integral types and 'Bool' are not supported for nanmean, even for empty tensors.");
   TORCH_CHECK(
       self.is_floating_point() || self.is_complex(),
       "nanmean(): expected input to have floating point or complex dtype but got ",

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1434,6 +1434,10 @@ Tensor& nanmean_out(
     bool keepdim,
     std::optional<ScalarType> opt_dtype,
     Tensor& result) {
+  // Check if dtype is int64 or bool and raise an error
+  TORCH_CHECK(
+      self.scalar_type() != ScalarType::Bool && self.scalar_type() != ScalarType::Long,
+      "nanmean(): dtype 'Bool' and 'Long' are not supported for nanmean, even for empty tensors.");
   TORCH_CHECK(
       self.is_floating_point() || self.is_complex(),
       "nanmean(): expected input to have floating point or complex dtype but got ",

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2251,7 +2251,35 @@ class TestReductions(TestCase):
         self.assertEqual(x[:, :2].max().item(), 5)
         self.assertEqual(x[:, :2].amax().item(), 5)
         self.assertEqual(x[:, :2].argmax().item(), 2)
+    
+    @onlyCPU
+    @dtypes(*integral_types_and(torch.bool))
+    def test_nanmean_integral_types(self, device, dtype):
 
+        # List of tensor shapes to test
+        shapes = [
+            (),           # Scalar tensor
+            (0,),         # Empty tensor
+            (1,),         # Single-element tensor
+            (3, 4, 5),     # Standard multi-dimensional tensor
+            (2, 0, 3),     # Tensor with an empty dimension
+            (10, 10, 10),  # Larger tensor
+            (2, 3, 0, 4),   # Tensor with multiple empty dimensions
+            (100,),         # High-dimensional tensor with 1D shape
+            (1, 1, 1),      # Tensor with singleton dimensions
+            (5, 5, 5, 5, 5), # High-dimensional tensor
+        ]
+        
+        for shape in shapes:
+            # Tensor of the specified shape and dtype
+            t = make_tensor(shape, dtype=dtype, device=device)
+            
+            # Attempt to call torch.nanmean and expect a RuntimeError
+            with self.assertRaisesRegex(
+                RuntimeError, 
+                r"nanmean\(\): expected input to have floating point or complex dtype but got \w+"
+            ):
+                torch.nanmean(t)
 
     @precisionOverride({torch.float16: 1e-2, torch.bfloat16: 1e-2})
     @dtypes(*set(all_types_and(torch.half, torch.bfloat16)) - {torch.uint8})

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2251,23 +2251,25 @@ class TestReductions(TestCase):
         self.assertEqual(x[:, :2].max().item(), 5)
         self.assertEqual(x[:, :2].amax().item(), 5)
         self.assertEqual(x[:, :2].argmax().item(), 2)
+
     @onlyCPU
     @dtypes(*integral_types_and(torch.bool))
     def test_nanmean_integral_types(self, device, dtype):
 
         # List of tensor shapes to test
         shapes = [
-            (),           # Scalar tensor
-            (0,),         # Empty tensor
-            (1,),         # Single-element tensor
-            (3, 4, 5),     # Standard multi-dimensional tensor
-            (2, 0, 3),     # Tensor with an empty dimension
-            (10, 10, 10),  # Larger tensor
-            (2, 3, 0, 4),   # Tensor with multiple empty dimensions
-            (100,),         # High-dimensional tensor with 1D shape
-            (1, 1, 1),      # Tensor with singleton dimensions
-            (5, 5, 5, 5, 5), # High-dimensional tensor
+            (),
+            (0,),
+            (1,),
+            (3, 4, 5),
+            (2, 0, 3),
+            (10, 10, 10),
+            (2, 3, 0, 4),
+            (100,),
+            (1, 1, 1),
+            (5, 5, 5, 5, 5),
         ]
+
         for shape in shapes:
             # Tensor of the specified shape and dtype
             t = make_tensor(shape, dtype=dtype, device=device)

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2251,7 +2251,6 @@ class TestReductions(TestCase):
         self.assertEqual(x[:, :2].max().item(), 5)
         self.assertEqual(x[:, :2].amax().item(), 5)
         self.assertEqual(x[:, :2].argmax().item(), 2)
-    
     @onlyCPU
     @dtypes(*integral_types_and(torch.bool))
     def test_nanmean_integral_types(self, device, dtype):
@@ -2269,14 +2268,12 @@ class TestReductions(TestCase):
             (1, 1, 1),      # Tensor with singleton dimensions
             (5, 5, 5, 5, 5), # High-dimensional tensor
         ]
-        
         for shape in shapes:
             # Tensor of the specified shape and dtype
             t = make_tensor(shape, dtype=dtype, device=device)
-            
             # Attempt to call torch.nanmean and expect a RuntimeError
             with self.assertRaisesRegex(
-                RuntimeError, 
+                RuntimeError,
                 r"nanmean\(\): expected input to have floating point or complex dtype but got \w+"
             ):
                 torch.nanmean(t)


### PR DESCRIPTION
This PR ensures that the `nanmean()` function raises a `RuntimeError` when using `int64` or `bool` dtypes, even for empty tensors. Previously, non-empty tensors correctly raised errors for unsupported dtypes, while empty tensors did not. This change brings consistent error handling for both cases.

addressing the need raised in an issue by @hyperkai  (Issue [#131043](https://github.com/pytorch/pytorch/issues/131043)).

### Changes

- Added checks in `nanmean_out()` to raise errors for `int64` and `bool` dtypes regardless of tensor size.

