### PR TITLE
[export] Add support for symbool to make it usable for torch.cond

### DIFF
--- a/docs/source/export.rst
+++ b/docs/source/export.rst
@@ -888,6 +888,8 @@ API Reference
 .. autoclass:: InputSpec
 .. autoclass:: OutputKind
 .. autoclass:: OutputSpec
+.. autoclass:: SymIntArgument
+.. autoclass:: SymBoolArgument
 .. autoclass:: ExportGraphSignature
 
     .. automethod:: replace_all_uses

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -843,6 +843,28 @@ graph():
                 foo, bad_example_inp, dynamic_shapes=dynamic_shapes, strict=False
             )
 
+    def test_symint_item(self):
+        class M(torch.nn.Module):
+            def forward(self, tensor):
+                return tensor.item()
+
+        input = (torch.tensor([1], dtype=torch.int),)
+
+        orig_res = M()(*input)
+        ep_res = torch.export.export(M(), input).module()(*input)
+        self.assertEqual(orig_res, ep_res)
+
+    def test_symbool_item(self):
+        class M(torch.nn.Module):
+            def forward(self, tensor):
+                return tensor.item()
+
+        input = (torch.tensor([1], dtype=torch.bool),)
+
+        orig_res = M()(*input)
+        ep_res = torch.export.export(M(), input).module()(*input)
+        self.assertEqual(orig_res, ep_res)
+
     def test_unbacked_to_cond(self):
         class M(torch.nn.Module):
             def forward(self, a):
@@ -5319,6 +5341,28 @@ def forward(self, b_a_buffer, x):
 
         inp = (torch.tensor(5),)
         self.assertTrue(torch.allclose(ep.module()(*inp), Foo()(*inp)))
+
+        transform = ep.run_decompositions()
+        self.assertEqual(len(ep.graph_signature.input_specs), 4)
+        self.assertTrue(torch.allclose(ep.module()(*inp), transform.module()(*inp)))
+
+        class Boo(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.a = torch.tensor(True)
+
+            def forward(self, x):
+                list_tensor = [torch.tensor(False), torch.tensor(True)]
+                return x + self.a + list_tensor[0] + list_tensor[1]
+
+        ep = export(Boo(), (torch.tensor(False),))
+
+        self.assertEqual(len(ep.graph_signature.input_specs), 4)
+        self.assertEqual(len(ep.state_dict), 0)
+        self.assertEqual(len(ep.constants), 3)
+
+        inp = (torch.tensor(True),)
+        self.assertTrue(torch.allclose(ep.module()(*inp), Boo()(*inp)))
 
         transform = ep.run_decompositions()
         self.assertEqual(len(ep.graph_signature.input_specs), 4)

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -2763,6 +2763,22 @@ class AOTInductorTestsTemplate:
         )
         self.check_model(Model(), inputs)
 
+    def test_symint_item(self):
+        class Model(torch.nn.Module):
+            def forward(self, tensor):
+                return tensor.item()
+
+        inputs = (torch.tensor([1], dtype=torch.int, device=self.device),)
+        self.check_model(Model(), inputs)
+
+    def test_symbool_item(self):
+        class Model(torch.nn.Module):
+            def forward(self, tensor):
+                return tensor.item()
+
+        inputs = (torch.tensor([0], dtype=torch.bool, device=self.device),)
+        self.check_model(Model(), inputs)
+
     def test_constant_original_fqn_and_dtype(self):
         class FooBarModule(torch.nn.Module):
             def __init__(self) -> None:

--- a/test/inductor/test_aot_inductor_arrayref.py
+++ b/test/inductor/test_aot_inductor_arrayref.py
@@ -175,6 +175,10 @@ CPU_TEST_FAILURES = {
     "test_size_from_multi_output": fail_stack_allocation(is_skip=True),
     "test_masked_select_dynamic": fail_stack_allocation(is_skip=True),
     "test_torchvision_transforms_functional_tensor_resize": fail_minimal_arrayref_interface(),
+    # TODO: AttributeError: 'ShapeAsConstantBuffer' object has no attribute 'dtype'
+    "test_symint_item": fail_minimal_arrayref_interface(is_skip=True),
+    # TODO: AttributeError: 'ShapeAsConstantBuffer' object has no attribute 'dtype'
+    "test_symbool_item": fail_minimal_arrayref_interface(is_skip=True),
 }
 
 

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -36,6 +36,7 @@ from torch.export.graph_signature import (
     OutputKind,
     OutputSpec,
     SymIntArgument,
+    SymBoolArgument,
     TensorArgument,
 )
 from torch.fx import traceback as fx_traceback

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -12,6 +12,7 @@ from torch.export.graph_signature import (
     CustomObjArgument,
     InputKind,
     SymIntArgument,
+    SymBoolArgument,
     TensorArgument,
     TokenArgument,
 )
@@ -308,7 +309,7 @@ def _verify_exported_program_signature(exported_program) -> None:
         )
 
     for input_spec, node in zip(gs.input_specs, input_node_names):
-        if isinstance(input_spec.arg, (TensorArgument, SymIntArgument)):
+        if isinstance(input_spec.arg, (TensorArgument, SymIntArgument, SymBoolArgument)):
             if input_spec.arg.name != node:
                 raise SpecViolationError(
                     f"Input spec name {input_spec.arg.name} does not match node name {node}"

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -74,6 +74,7 @@ from .graph_signature import (  # noqa: F401
     InputSpec,
     OutputKind,
     OutputSpec,
+    SymBoolArgument,
     SymIntArgument,
     TensorArgument,
     TokenArgument,
@@ -466,6 +467,8 @@ def _decompose_and_get_gm_with_new_signature_constants(
             return TensorArgument(name=new_ph.name)
         elif isinstance(old_arg, SymIntArgument):
             return SymIntArgument(name=new_ph.name)
+        elif isinstance(old_arg, SymBoolArgument):
+            return SymBoolArgument(name=new_ph.name)
         raise RuntimeError(f"Type of old_arg not supported: {type(old_arg)}")
 
     new_placeholders = [node for node in gm.graph.nodes if node.op == "placeholder"]

--- a/torch/export/graph_signature.py
+++ b/torch/export/graph_signature.py
@@ -20,6 +20,7 @@ __all__ = [
     "OutputKind",
     "OutputSpec",
     "SymIntArgument",
+    "SymBoolArgument",
     "TensorArgument",
 ]
 
@@ -40,6 +41,11 @@ class SymIntArgument:
 
 
 @dataclasses.dataclass
+class SymBoolArgument:
+    name: str
+
+
+@dataclasses.dataclass
 class CustomObjArgument:
     name: str
     class_fqn: str
@@ -55,6 +61,7 @@ class ConstantArgument:
 ArgumentSpec = Union[
     TensorArgument,
     SymIntArgument,
+    SymBoolArgument,
     ConstantArgument,
     CustomObjArgument,
     TokenArgument,
@@ -87,6 +94,7 @@ class InputSpec:
             (
                 TensorArgument,
                 SymIntArgument,
+                SymBoolArgument,
                 ConstantArgument,
                 CustomObjArgument,
                 TokenArgument,
@@ -116,6 +124,7 @@ class OutputSpec:
             (
                 TensorArgument,
                 SymIntArgument,
+                SymBoolArgument,
                 ConstantArgument,
                 TokenArgument,
                 CustomObjArgument,
@@ -262,7 +271,10 @@ class ExportGraphSignature:
             if s.kind != InputKind.USER_INPUT:
                 continue
 
-            if isinstance(s.arg, (TensorArgument, SymIntArgument, CustomObjArgument)):
+            if isinstance(
+                s.arg,
+                (TensorArgument, SymIntArgument, SymBoolArgument, CustomObjArgument),
+            ):
                 user_inputs.append(s.arg.name)
             elif isinstance(s.arg, ConstantArgument):
                 user_inputs.append(s.arg.value)
@@ -278,7 +290,7 @@ class ExportGraphSignature:
             if s.kind != OutputKind.USER_OUTPUT:
                 continue
 
-            if isinstance(s.arg, (TensorArgument, SymIntArgument)):
+            if isinstance(s.arg, (TensorArgument, SymIntArgument, SymBoolArgument)):
                 user_outputs.append(s.arg.name)
             elif isinstance(s.arg, ConstantArgument):
                 user_outputs.append(s.arg.value)
@@ -425,7 +437,13 @@ class ExportGraphSignature:
         """
         assert isinstance(old, str)
         assert isinstance(new, str)
-        arg_types = (TensorArgument, SymIntArgument, CustomObjArgument, TokenArgument)
+        arg_types = (
+            TensorArgument,
+            SymIntArgument,
+            SymBoolArgument,
+            CustomObjArgument,
+            TokenArgument,
+        )
         for o in self.output_specs:
             if isinstance(o.arg, arg_types):
                 if o.arg.name == old:
@@ -454,7 +472,7 @@ def _immutable_dict(items):
 
 
 def _make_argument_spec(node, token_names) -> ArgumentSpec:
-    from torch import ScriptObject, SymInt
+    from torch import ScriptObject, SymBool, SymInt
     from torch._library.fake_class_registry import FakeScriptObject
     from torch._subclasses.fake_tensor import FakeTensor
 
@@ -472,6 +490,8 @@ def _make_argument_spec(node, token_names) -> ArgumentSpec:
         return TensorArgument(name=node.name)
     elif isinstance(val, SymInt):
         return SymIntArgument(name=node.name)
+    elif isinstance(val, SymBool):
+        return SymBoolArgument(name=node.name)
     elif isinstance(val, ScriptObject):
         return CustomObjArgument(name=node.name, class_fqn=val._type().qualified_name())  # type: ignore[attr-defined]
     elif isinstance(val, FakeScriptObject):

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -22,6 +22,7 @@ from torch.export.exported_program import (
     ExportGraphSignature,
     InputKind,
     ModuleCallSignature,
+    SymBoolArgument,
     SymIntArgument,
     TensorArgument,
 )
@@ -869,7 +870,9 @@ class _ModuleFrame:
                     elif input.name not in self.seen_nodes:
                         input_nodes.append(None)
                     else:
-                        assert isinstance(input, (TensorArgument, SymIntArgument))
+                        assert isinstance(
+                            input, (TensorArgument, SymIntArgument, SymBoolArgument)
+                        )
                         input_nodes.append(
                             self.parent.remap_input(self.seen_nodes[input.name])
                         )
@@ -975,7 +978,9 @@ class _ModuleFrame:
         signature = self.module_call_graph.get(self.child_fqn)
         if signature is not None and self.parent is not None:
             for output in signature.outputs:
-                if isinstance(output, (TensorArgument, SymIntArgument)):
+                if isinstance(
+                    output, (TensorArgument, SymIntArgument, SymBoolArgument)
+                ):
                     if output.name in self.seen_nodes:
                         orig_outputs.append(self.seen_nodes[output.name])
                     else:


### PR DESCRIPTION
# Why?

I want the following code to work.

minimal repro:
```
class M(torch.nn.Module):
    def forward(self, dilate_flag):
        return dilate_flag.item()

input1 = (torch.tensor([1], dtype=torch.bool, device="cuda"),)
model = M().cuda()

ep = torch.export.export(model, input1, strict=True)
path = torch._inductor.aot_compile(ep.module(), input1)
aot_model = torch._export.aot_load(path, device="cuda")
actual_output = aot_model(*input1)
```

error: AssertionError: Encountered an unsupported object of type <class 'torch.SymBool'> while writing the metadata for exported program

second error will be handled by https://github.com/pytorch/pytorch/pull/138760

# Motivation

I could technically bypass it with a torch.int tensor. However, it doesn't work with torch.cond. I want the following to work. It would also require https://github.com/pytorch/pytorch/pull/138760 for aot compile to work.

```
class M(torch.nn.Module):
    def __init__(self) -> None:
        super().__init__()
        self.dilate_flag = 0

    def forward(self, dilate_flag):
        self.dilate_flag = dilate_flag.item()

        def true_fn(dilate_flag):
            return dilate_flag.clone()

        def false_fn(dilate_flag):
            return dilate_flag.clone()

        torch.cond(
            self.dilate_flag,
            true_fn,
            false_fn,
            (dilate_flag,),
        )
        return self.dilate_flag

input1 = (torch.tensor([1], dtype=torch.bool, device="cuda"),)
input2 = (torch.tensor([0], dtype=torch.bool, device="cuda"),)
inputs = (input1, input2)
model = M().cuda()

for input in inputs:
    expected_output = model(*input)

    ep = torch.export.export(model, input, strict=False)
    path = torch._inductor.aot_compile(ep.module(), input)
    aot_model = torch._export.aot_load(path, device="cuda")
    actual_output = aot_model(*input)

    assert (
        expected_output == actual_output
    ), f"henry they are not equal {expected_output} != {actual_output}"
```

Differential Revision: D64867504




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov