### PR TITLE
[Functorch] Fix devices Parameter Type in benchmark_utilization Function

### DIFF
--- a/torch/_functorch/benchmark_utils.py
+++ b/torch/_functorch/benchmark_utils.py
@@ -222,7 +222,7 @@ def benchmark_utilization(
         optimize_ctx,
         [ProfilerActivity.CUDA],
         num_runs=num_runs,
-        devices="cuda",
+        devices=["cuda"],
     )
     utilization, mm_conv_utilization = compute_utilization(
         chrome_trace_file_name, total_length

--- a/torch/_prims_common/wrappers.py
+++ b/torch/_prims_common/wrappers.py
@@ -68,7 +68,9 @@ def _maybe_convert_to_dtype(a, dtype):
     if a is None:
         return None
 
-    raise ValueError(f"Received type {type(a)} that is neither a tensor or a number!")
+    raise ValueError(
+        f"Received unsupported type {type(a)}. Expected TensorLike, Number, or Sequence."
+    )
 
 
 def _maybe_convert_to_type(a: NumberType, typ: type) -> NumberType:


### PR DESCRIPTION
Summary:
Issue described in https://github.com/pytorch/pytorch/issues/136697

Original user does not have CLA privileges so this is my commandeer

Test Plan: OSS CI

Differential Revision: D64872833


