### PR TITLE
[Pytorch][ATEN] Enable FP8 NCCL in Pytorch ATEN

### DIFF
--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -45,6 +45,13 @@ if (
 ) or TEST_WITH_ROCM:
     datatypes.append(torch.bfloat16)
 
+# Broadcast (and alltoall) support float8, while reduce and allreduce do not support float8 currently
+broadcast_dtypes = (
+    datatypes + [torch.float8_e4m3fnuz, torch.float8_e5m2fnuz]
+    if TEST_WITH_ROCM
+    else [torch.float8_e4m3fn, torch.float8_e5m2]
+)
+
 
 class TestNCCL(TestCase):
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
@@ -58,7 +65,7 @@ class TestNCCL(TestCase):
     )
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "only one GPU detected")
-    @dtypes(*datatypes)
+    @dtypes(*broadcast_dtypes)
     def test_broadcast(self, device, dtype):
         expected = torch.zeros(128).uniform_().to(dtype=dtype)
         tensors = [expected.cuda()]

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -113,6 +113,18 @@ ncclDataType_t to_nccl_data_type(c10::ScalarType type) {
       return ncclDataType_t::ncclUint8;
     case at::kBool:
       return ncclDataType_t::ncclUint8;
+#if defined(USE_ROCM)
+    case at::kFloat8_e4m3fnuz:
+      return ncclDataType_t::ncclUint8;
+    case at::kFloat8_e5m2fnuz:
+      return ncclDataType_t::ncclUint8;
+#else
+    case at::kFloat8_e4m3fn:
+      return ncclDataType_t::ncclUint8;
+    case at::kFloat8_e5m2:
+      return ncclDataType_t::ncclUint8;
+#endif
+
 #if HAS_NCCL_BF16_DATATYPE
     case at::kBFloat16:
       return ncclDataType_t::ncclBfloat16;


### PR DESCRIPTION
Summary: Enable FP8 NCCL in Pytorch ATEN to unblock FP8 collective communication such as FP8 all-to-all

Test Plan: CI & D64374424

Differential Revision: D64866426




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o