### PR TITLE
Fix bug of torch.nn.functional.kl_div when broadcast happened

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3396,7 +3396,9 @@ def kl_div(
     reduced = torch.kl_div(input, target, reduction_enum, log_target=log_target)
 
     if reduction == "batchmean" and input.dim() != 0:
-        reduced = reduced / torch.broadcast_tensors(input, target)[0].size()[0]
+        # deal with potential broadcasting
+        batch_size = input.size(0) if input.dim() > 1 else target.size(0)
+        reduced = reduced / batch_size
 
     return reduced
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3396,7 +3396,7 @@ def kl_div(
     reduced = torch.kl_div(input, target, reduction_enum, log_target=log_target)
 
     if reduction == "batchmean" and input.dim() != 0:
-        reduced = reduced / torch.broadcast_shapes(input.size(), target.size())[0]
+        reduced = reduced / torch.broadcast_tensors(input, target)[0].size()[0]
 
     return reduced
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3396,7 +3396,7 @@ def kl_div(
     reduced = torch.kl_div(input, target, reduction_enum, log_target=log_target)
 
     if reduction == "batchmean" and input.dim() != 0:
-        reduced = reduced / input.size()[0]
+        reduced = reduced / torch.broadcast_shapes(input.size(), target.size())[0]
 
     return reduced
 


### PR DESCRIPTION
Currently, torch.nn.functional.kl_div calcalutes the KL divergence between `input` and `target` using torch.kl_div, which will automatically do broadcast if possible and needed. However, when `reduction = 'batchmean'`, it will average the result with `input.size()[0]`, as shown below:

```python
if reduction == "batchmean" and input.dim() != 0:
    reduced = reduced / input.size()[0]
```

which may not be true when broadcast happened.
