### PR TITLE
Prioritize building with libgomp over libomp

### DIFF
--- a/cmake/Modules/FindOpenMP.cmake
+++ b/cmake/Modules/FindOpenMP.cmake
@@ -291,7 +291,7 @@ function(_OPENMP_GET_FLAGS LANG FLAG_MODE OPENMP_FLAG_VAR OPENMP_LIB_NAMES_VAR)
 
     if (NOT OpenMP_libomp_LIBRARY)
       find_library(OpenMP_libomp_LIBRARY
-        NAMES omp gomp iomp5
+        NAMES gomp omp iomp5
         HINTS ${CMAKE_${LANG}_IMPLICIT_LINK_DIRECTORIES}
         DOC "libomp location for OpenMP"
       )
@@ -411,7 +411,7 @@ function(_OPENMP_GET_FLAGS LANG FLAG_MODE OPENMP_FLAG_VAR OPENMP_LIB_NAMES_VAR)
       #
       # Check for separate OpenMP library on AppleClang 7+
       find_library(OpenMP_libomp_LIBRARY
-        NAMES omp gomp iomp5
+        NAMES gomp omp iomp5
         HINTS ${CMAKE_${LANG}_IMPLICIT_LINK_DIRECTORIES}
         DOC "libomp location for OpenMP"
       )

--- a/cmake/Modules/FindOpenMP.cmake
+++ b/cmake/Modules/FindOpenMP.cmake
@@ -290,6 +290,9 @@ function(_OPENMP_GET_FLAGS LANG FLAG_MODE OPENMP_FLAG_VAR OPENMP_LIB_NAMES_VAR)
     endif()
 
     if (NOT OpenMP_libomp_LIBRARY)
+      # We prefer gomp over omp if possible, since we've configured MKL DNN
+      # to link in gomp. Linking in multiple OpenMP implementations can cause
+      # performance issues and sporadic runtime failures.
       find_library(OpenMP_libomp_LIBRARY
         NAMES gomp omp iomp5
         HINTS ${CMAKE_${LANG}_IMPLICIT_LINK_DIRECTORIES}
@@ -411,7 +414,7 @@ function(_OPENMP_GET_FLAGS LANG FLAG_MODE OPENMP_FLAG_VAR OPENMP_LIB_NAMES_VAR)
       #
       # Check for separate OpenMP library on AppleClang 7+
       find_library(OpenMP_libomp_LIBRARY
-        NAMES gomp omp iomp5
+        NAMES omp gomp iomp5
         HINTS ${CMAKE_${LANG}_IMPLICIT_LINK_DIRECTORIES}
         DOC "libomp location for OpenMP"
       )

--- a/cmake/Modules/FindOpenMP.cmake
+++ b/cmake/Modules/FindOpenMP.cmake
@@ -292,7 +292,14 @@ function(_OPENMP_GET_FLAGS LANG FLAG_MODE OPENMP_FLAG_VAR OPENMP_LIB_NAMES_VAR)
     if (NOT OpenMP_libomp_LIBRARY)
       # We prefer gomp over omp if possible, since we've configured MKL DNN
       # to link in gomp. Linking in multiple OpenMP implementations can cause
-      # performance issues and sporadic runtime failures.
+      # performance issues and sporadic runtime failures. This priority order
+      # is purely to avoid linking conflicting symbols. We have not considered
+      # any other reasons to prefer one OpenMP implementation over another.
+      #
+      # These implementations are
+      # * libgomp -> GNU OpenMP
+      # * libomp -> LLVM OpenMP
+      # * libiomp5 -> Intel OpenMP
       find_library(OpenMP_libomp_LIBRARY
         NAMES gomp omp iomp5
         HINTS ${CMAKE_${LANG}_IMPLICIT_LINK_DIRECTORIES}


### PR DESCRIPTION
Fixes #126211 

The approach I'm taking here is simply to prioritize gomp over omp, if it is available. Here's how this should affect possible build scenarios:

* host with gomp+omp, building without MKL DNN:
** old behavior: uses omp
** new behavior: uses gomp
* host with gomp+omp, building with MKL DNN:
** old behavior: unsafely links in both gomp+omp
** new behavior: uses only gomp

The pytorch distributions have always only linked to gomp, so I assume they're built on a machine without libomp. I've verified on my own machine that this build avoids linking to libomp.