### PR TITLE
Linter for no workflows on fork

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -53,6 +53,7 @@ env:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/templates/windows_binary_build_workflow.yml.j2
+++ b/.github/templates/windows_binary_build_workflow.yml.j2
@@ -54,6 +54,7 @@ env:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   auto-request-review:
     # Don't run on forked repos
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'pytorch' }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/build-android-binaries.yml
+++ b/.github/workflows/build-android-binaries.yml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   android-build-test:
+    if: github.repository_owner == 'pytorch'
     name: android-build-test
     uses: ./.github/workflows/_run_android_tests.yml
     with:

--- a/.github/workflows/build-conda-images.yml
+++ b/.github/workflows/build-conda-images.yml
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   build-docker:
+    if: github.repository_owner == 'pytorch'
     environment: ${{ (github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')) && 'docker-build' || '' }}
     runs-on: linux.9xlarge.ephemeral
     strategy:

--- a/.github/workflows/build-ios-binaries.yml
+++ b/.github/workflows/build-ios-binaries.yml
@@ -38,6 +38,7 @@ concurrency:
 jobs:
   # TODO: Figure out how to migrate this job to M1 runner
   ios-build-test:
+    if: github.repository_owner == 'pytorch'
     name: ios-build-test
     uses: ./.github/workflows/_ios-build-test.yml
     with:

--- a/.github/workflows/build-libtorch-images.yml
+++ b/.github/workflows/build-libtorch-images.yml
@@ -30,6 +30,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -34,6 +34,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -28,6 +28,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/check_mergeability_ghstack.yml
+++ b/.github/workflows/check_mergeability_ghstack.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   ghstack-mergeability-check:
+    if: github.repository_owner == 'pytorch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/docathon-sync-label.yml
+++ b/.github/workflows/docathon-sync-label.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-labels:
+    if: github.repository_owner == 'pytorch'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -31,6 +31,7 @@ permissions: read-all
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -35,6 +35,7 @@ permissions: read-all
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -38,6 +38,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/generated-linux-binary-conda-nightly.yml
+++ b/.github/workflows/generated-linux-binary-conda-nightly.yml
@@ -38,6 +38,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-main.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-main.yml
@@ -33,6 +33,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
@@ -38,6 +38,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-main.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-main.yml
@@ -33,6 +33,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
@@ -38,6 +38,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/generated-linux-binary-manywheel-main.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-main.yml
@@ -33,6 +33,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -38,6 +38,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
@@ -38,6 +38,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/generated-windows-binary-conda-nightly.yml
+++ b/.github/workflows/generated-windows-binary-conda-nightly.yml
@@ -33,6 +33,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/generated-windows-binary-libtorch-debug-main.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-main.yml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -33,6 +33,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/generated-windows-binary-libtorch-release-main.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-main.yml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
@@ -33,6 +33,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -33,6 +33,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/inductor-cu124.yml
+++ b/.github/workflows/inductor-cu124.yml
@@ -21,7 +21,7 @@ jobs:
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
@@ -75,6 +75,7 @@ jobs:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
 
   linux-focal-cuda12_4-py3_10-gcc9-inductor-build-gcp:
+    if: github.repository_owner == 'pytorch'
     name: cuda12.4-py3.10-gcc9-sm80
     uses: ./.github/workflows/_linux-build.yml
     with:
@@ -101,6 +102,7 @@ jobs:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
 
   linux-focal-cuda12_4-py3_12-gcc9-inductor-build:
+    if: github.repository_owner == 'pytorch'
     name: cuda12.4-py3.12-gcc9-sm86
     uses: ./.github/workflows/_linux-build.yml
     with:

--- a/.github/workflows/inductor-micro-benchmark-x86.yml
+++ b/.github/workflows/inductor-micro-benchmark-x86.yml
@@ -17,7 +17,7 @@ permissions: read-all
 
 jobs:
   linux-jammy-cpu-py3_9-gcc11-inductor-build:
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     name: linux-jammy-cpu-py3.9-gcc11-inductor
     uses: ./.github/workflows/_linux-build.yml
     with:

--- a/.github/workflows/inductor-micro-benchmark.yml
+++ b/.github/workflows/inductor-micro-benchmark.yml
@@ -19,7 +19,7 @@ jobs:
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}

--- a/.github/workflows/inductor-perf-compare.yml
+++ b/.github/workflows/inductor-perf-compare.yml
@@ -14,6 +14,7 @@ permissions: read-all
 
 jobs:
   get-default-label-prefix:
+    if: github.repository_owner == 'pytorch'
     name: get-default-label-prefix
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:
@@ -25,7 +26,7 @@ jobs:
   get-test-label-type:
     name: get-test-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}

--- a/.github/workflows/inductor-perf-test-nightly-a10g.yml
+++ b/.github/workflows/inductor-perf-test-nightly-a10g.yml
@@ -71,7 +71,7 @@ jobs:
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}

--- a/.github/workflows/inductor-perf-test-nightly-aarch64.yml
+++ b/.github/workflows/inductor-perf-test-nightly-aarch64.yml
@@ -51,7 +51,7 @@ jobs:
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}

--- a/.github/workflows/inductor-perf-test-nightly-x86.yml
+++ b/.github/workflows/inductor-perf-test-nightly-x86.yml
@@ -51,7 +51,7 @@ jobs:
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -69,7 +69,7 @@ jobs:
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}

--- a/.github/workflows/inductor-periodic.yml
+++ b/.github/workflows/inductor-periodic.yml
@@ -21,7 +21,7 @@ jobs:
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}

--- a/.github/workflows/inductor-rocm.yml
+++ b/.github/workflows/inductor-rocm.yml
@@ -25,7 +25,7 @@ jobs:
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -21,7 +21,7 @@ jobs:
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}

--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   bc_linter:
+    if: github.repository_owner == 'pytorch'
     runs-on: ubuntu-latest
     steps:
       - name: Run BC Lint Action

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,7 @@ permissions: read-all
 # When any other step fails, it's job will be retried once by retryBot.
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/linux-aarch64.yml
+++ b/.github/workflows/linux-aarch64.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
 
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -14,6 +14,7 @@ permissions: read-all
 
 jobs:
   macos-py3-arm64-build:
+    if: github.repository_owner == 'pytorch'
     name: macos-py3-arm64
     uses: ./.github/workflows/_mac-build.yml
     with:

--- a/.github/workflows/nightly-rockset-uploads.yml
+++ b/.github/workflows/nightly-rockset-uploads.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
 
   upload-stats-to-rockset:
+    if: github.repository_owner == 'pytorch'
     runs-on: ubuntu-22.04
     environment: upload-stats
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
@@ -54,7 +54,7 @@ jobs:
   update-vision-commit-hash:
     runs-on: ubuntu-latest
     environment: update-commit-hash
-    if: ${{ github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'schedule' && github.repository_owner == 'pytorch' }}
     steps:
       - name: update-vision-commit-hash
         uses: pytorch/test-infra/.github/actions/update-commit-hash@main
@@ -69,7 +69,7 @@ jobs:
   update-audio-commit-hash:
     runs-on: ubuntu-latest
     environment: update-commit-hash
-    if: ${{ github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'schedule' && github.repository_owner == 'pytorch' }}
     steps:
       - name: update-audio-commit-hash
         uses: pytorch/test-infra/.github/actions/update-commit-hash@main
@@ -84,7 +84,7 @@ jobs:
   update-executorch-commit-hash:
     runs-on: ubuntu-latest
     environment: update-commit-hash
-    if: ${{ github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'schedule' && github.repository_owner == 'pytorch' }}
     steps:
       - name: update-executorch-commit-hash
         uses: pytorch/test-infra/.github/actions/update-commit-hash@main

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -24,6 +24,7 @@ permissions: read-all
 
 jobs:
   llm-td:
+    if: github.repository_owner == 'pytorch'
     name: before-test
     uses: ./.github/workflows/llm_td_retrieval.yml
     permissions:
@@ -41,7 +42,7 @@ jobs:
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch'
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
@@ -255,6 +256,7 @@ jobs:
         ]}
 
   buck-build-test:
+    if: github.repository_owner == 'pytorch'
     name: buck-build-test
     uses: ./.github/workflows/_buck-build-test.yml
     with:
@@ -264,6 +266,7 @@ jobs:
         ]}
 
   android-emulator-build-test:
+    if: github.repository_owner == 'pytorch'
     name: android-emulator-build-test
     uses: ./.github/workflows/_run_android_tests.yml
     with:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -21,6 +21,7 @@ permissions: read-all
 
 jobs:
   llm-td:
+    if: github.repository_owner == 'pytorch'
     name: before-test
     uses: ./.github/workflows/llm_td_retrieval.yml
     permissions:
@@ -38,7 +39,7 @@ jobs:
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
@@ -467,6 +468,7 @@ jobs:
     secrets: inherit
 
   linux-focal-py3-clang9-android-ndk-r21e-gradle-custom-build-single:
+    if: github.repository_owner == 'pytorch'
     name: linux-focal-py3-clang9-android-ndk-r21e-gradle-custom-build-single
     uses: ./.github/workflows/_android-build-test.yml
     with:
@@ -479,6 +481,7 @@ jobs:
     secrets: inherit
 
   linux-focal-py3-clang9-android-ndk-r21e-gradle-custom-build-single-full-jit:
+    if: github.repository_owner == 'pytorch'
     name: linux-focal-py3-clang9-android-ndk-r21e-gradle-custom-build-single-full-jit
     uses: ./.github/workflows/_android-build-test.yml
     with:

--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -19,6 +19,7 @@ permissions: read-all
 
 jobs:
   target-determination:
+    if: github.repository_owner == 'pytorch'
     name: before-test
     uses: ./.github/workflows/target_determination.yml
     permissions:
@@ -26,7 +27,7 @@ jobs:
       contents: read
 
   linux-focal-rocm6_2-py3_10-build:
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     name: linux-focal-rocm6.2-py3.10
     uses: ./.github/workflows/_linux-build.yml
     with:

--- a/.github/workflows/runner-determinator-validator.yml
+++ b/.github/workflows/runner-determinator-validator.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   check-runner-determinator:
+    if: github.repository_owner == 'pytorch'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/runner_determinator_script_sync.yaml
+++ b/.github/workflows/runner_determinator_script_sync.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   python-script-sync-check:
+    if: github.repository_owner == 'pytorch'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/s390.yml
+++ b/.github/workflows/s390.yml
@@ -16,6 +16,7 @@ permissions: read-all
 
 jobs:
   linux-manylinux-2_28-py3-cpu-s390x-build:
+    if: github.repository_owner == 'pytorch'
     name: linux-manylinux-2_28-py3-cpu-s390x
     uses: ./.github/workflows/_linux-build.yml
     with:

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -22,6 +22,7 @@ permissions: read-all
 
 jobs:
   llm-td:
+    if: github.repository_owner == 'pytorch'
     name: before-test
     uses: ./.github/workflows/llm_td_retrieval.yml
     permissions:
@@ -39,7 +40,7 @@ jobs:
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}

--- a/.github/workflows/target-determination-indexer.yml
+++ b/.github/workflows/target-determination-indexer.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/torchbench.yml
+++ b/.github/workflows/torchbench.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -20,6 +20,7 @@ permissions: read-all
 
 jobs:
   llm-td:
+    if: github.repository_owner == 'pytorch'
     name: before-test
     uses: ./.github/workflows/llm_td_retrieval.yml
     permissions:
@@ -37,7 +38,7 @@ jobs:
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
@@ -132,6 +133,7 @@ jobs:
         ]}
 
   pytorch-linux-focal-py3-clang9-android-ndk-r21e-build:
+    if: github.repository_owner == 'pytorch'
     name: pytorch-linux-focal-py3-clang9-android-ndk-r21e-build
     uses: ./.github/workflows/_android-full-build-test.yml
     with:
@@ -143,6 +145,7 @@ jobs:
         ]}
 
   macos-py3-arm64-build:
+    if: github.repository_owner == 'pytorch'
     name: macos-py3-arm64
     uses: ./.github/workflows/_mac-build.yml
     with:

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -17,6 +17,7 @@ permissions: read-all
 jobs:
   # There must be at least one job here to satisfy GitHub action workflow syntax
   introduction:
+    if: github.repository_owner == 'pytorch'
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -12,6 +12,7 @@ permissions: read-all
 
 jobs:
   update-commit-hash:
+    if: github.repository_owner == 'pytorch'
     runs-on: ubuntu-latest
     environment: update-commit-hash
     steps:
@@ -41,6 +42,7 @@ jobs:
           pytorchbot-token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
 
   update-slow-tests:
+    if: github.repository_owner == 'pytorch'
     runs-on: ubuntu-latest
     environment: update-commit-hash
     steps:

--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
 
   get-label-type:
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:
@@ -51,6 +52,7 @@ jobs:
       test-matrix: ${{ needs.linux-jammy-xpu-py3_9-build.outputs.test-matrix }}
 
   windows-xpu-build:
+    if: github.repository_owner == 'pytorch'
     name: win-vs2022-xpu-py3
     uses: ./.github/workflows/_win-build.yml
     with:

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1007,6 +1007,28 @@ init_command = [
     'PyYAML==6.0.1',
 ]
 
+[[linter]]
+code = 'NO_WORKFLOWS_ON_FORK'
+include_patterns = [
+    '.github/**/*.yml',
+    '.github/**/*.yaml',
+]
+exclude_patterns = [
+    '**/fb/**',
+]
+command = [
+    'python3',
+    'tools/linter/adapters/no_workflows_on_fork.py',
+    '--',
+    '@{{PATHSFILE}}',
+]
+init_command = [
+    'python3',
+    'tools/linter/adapters/pip_init.py',
+    '--dry-run={{DRYRUN}}',
+    'PyYAML==6.0.1',
+]
+
 # usort + ruff-format
 [[linter]]
 code = 'PYFMT'

--- a/tools/linter/adapters/no_workflows_on_fork.py
+++ b/tools/linter/adapters/no_workflows_on_fork.py
@@ -1,0 +1,232 @@
+"""
+This a linter that ensures that jobs that can be triggered by push,
+pull_request, or schedule will check if the repository owner is 'pytorch'.  This
+ensures that forks will not run jobs.
+
+There are some edge cases that might be caught, and this prevents workflows from
+being reused in other organizations, but as of right now, there are no workflows
+with both push/pull_request/etc and workflow_call triggers simultaneously, so
+this is.
+
+There is also a setting in Github repos that can disable all workflows for that
+repo.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import logging
+import os
+import re
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, NamedTuple, Optional
+
+from yaml import load
+
+
+# Safely load fast C Yaml loader/dumper if they are available
+try:
+    from yaml import CSafeLoader as Loader
+except ImportError:
+    from yaml import SafeLoader as Loader  # type: ignore[assignment, misc]
+
+
+class LintSeverity(str, Enum):
+    ERROR = "error"
+    WARNING = "warning"
+    ADVICE = "advice"
+    DISABLED = "disabled"
+
+
+class LintMessage(NamedTuple):
+    path: str | None
+    line: int | None
+    char: int | None
+    code: str
+    severity: LintSeverity
+    name: str
+    original: str | None
+    replacement: str | None
+    description: str | None
+
+
+def load_yaml(path: Path) -> Any:
+    with open(path) as f:
+        return load(f, Loader)
+
+
+def gen_lint_message(
+    filename: Optional[str] = None,
+    original: Optional[str] = None,
+    replacement: Optional[str] = None,
+    description: Optional[str] = None,
+) -> LintMessage:
+    return LintMessage(
+        path=filename,
+        line=None,
+        char=None,
+        code="NO_WORKFLOWS_ON_FORK",
+        severity=LintSeverity.ERROR,
+        name="format",
+        original=original,
+        replacement=replacement,
+        description=description,
+    )
+
+
+def check_file(filename: str) -> List[LintMessage]:
+    logging.debug("Checking file %s", filename)
+
+    workflow = load_yaml(Path(filename))
+    bad_jobs: Dict[str, Optional[str]] = {}
+    if type(workflow) is not dict:
+        return []
+
+    # yaml parses "on" as True
+    triggers = workflow.get(True, {})
+    triggers_to_check = ["push", "schedule", "pull_request", "pull_request_target"]
+    if not any(trigger in triggers_to_check for trigger in triggers):
+        return []
+
+    jobs = workflow.get("jobs", {})
+    for job, definition in jobs.items():
+        if definition.get("needs"):
+            # The parent job will have the if statement
+            continue
+
+        if_statement = definition.get("if")
+
+        if if_statement is None:
+            bad_jobs[job] = None
+        elif type(if_statement) is bool and not if_statement:
+            # if: false
+            pass
+        else:
+            if_statement = str(if_statement)
+            valid_checks = [
+                "github.repository == 'pytorch/pytorch'",
+                "github.repository_owner == 'pytorch'",
+            ]
+            if not any(s in if_statement for s in valid_checks):
+                bad_jobs[job] = if_statement
+
+    with open(filename) as f:
+        lines = f.readlines()
+
+    smart_enough = True
+    original = "".join(lines)
+    iterator = iter(range(len(lines)))
+    replacement = ""
+    for i in iterator:
+        line = lines[i]
+        # Search for job name
+        re_match = re.match(r"( +)([-_\w]*):", line)
+        if not re_match or re_match.group(2) not in bad_jobs:
+            replacement += line
+            continue
+        job_name = re_match.group(2)
+
+        failure_type = bad_jobs[job_name]
+        if failure_type is None:
+            # Just need to add an if statement
+            replacement += (
+                f"{line}{re_match.group(1)}  if: github.repository_owner == 'pytorch'\n"
+            )
+            continue
+
+        # Search for if statement
+        while re.match(r"^ +if:", line) is None:
+            replacement += line
+            i = next(iterator)
+            line = lines[i]
+        if i + 1 < len(lines) and not re.match(r"^ +(.*):", lines[i + 1]):
+            # This is a multi line if statement
+            smart_enough = False
+            break
+
+        if_statement_match = re.match(r"^ +if: ([^#]*)(#.*)?$", line)
+        # Get ... in if: ... # comments
+        if not if_statement_match:
+            return [
+                gen_lint_message(
+                    description=f"Something went wrong when looking at {job_name}.",
+                )
+            ]
+
+        if_statement = if_statement_match.group(1).strip()
+
+        # Handle comment in if: ... # comments
+        comments = if_statement_match.group(2) or ""
+        if comments:
+            comments = " " + comments
+
+        # Too broad of a check, but should catch everything
+        needs_parens = "||" in if_statement
+
+        # Handle ${{ ... }}
+        has_brackets = re.match(r"\$\{\{(.*)\}\}", if_statement)
+        internal_statement = (
+            has_brackets.group(1).strip() if has_brackets else if_statement
+        )
+
+        if needs_parens:
+            internal_statement = f"({internal_statement})"
+        new_line = f"{internal_statement} && github.repository_owner == 'pytorch'"
+
+        # I don't actually know if we need the ${{ }} but do it just in case
+        new_line = "${{ " + new_line + " }}" + comments
+
+        replacement += f"{re_match.group(1)}  if: {new_line}\n"
+
+    description = (
+        "Please add checks for if: github.repository_owner == 'pytorch' in the following jobs in this file: "
+        + ", ".join(job for job in bad_jobs)
+    )
+
+    if not smart_enough:
+        return [
+            gen_lint_message(
+                filename=filename,
+                description=description,
+            )
+        ]
+
+    if replacement == original:
+        return []
+
+    return [
+        gen_lint_message(
+            filename=filename,
+            original=original,
+            replacement=replacement,
+            description=description,
+        )
+    ]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="workflow consistency linter.",
+        fromfile_prefix_chars="@",
+    )
+    parser.add_argument(
+        "filenames",
+        nargs="+",
+        help="paths to lint",
+    )
+    args = parser.parse_args()
+
+    with concurrent.futures.ProcessPoolExecutor(
+        max_workers=os.cpu_count(),
+    ) as executor:
+        futures = {executor.submit(check_file, x): x for x in args.filenames}
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                for lint_message in future.result():
+                    print(json.dumps(lint_message._asdict()), flush=True)
+            except Exception:
+                logging.critical('Failed at "%s".', futures[future])
+                raise

--- a/tools/linter/adapters/no_workflows_on_fork.py
+++ b/tools/linter/adapters/no_workflows_on_fork.py
@@ -22,7 +22,7 @@ import os
 import re
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, NamedTuple, Optional
+from typing import Any, Callable, Dict, List, NamedTuple, Optional
 
 from yaml import load
 
@@ -106,9 +106,11 @@ def check_file(filename: str) -> List[LintMessage]:
             pass
         else:
             if_statement = str(if_statement)
-            valid_checks = [
-                lambda x: "github.repository == 'pytorch/pytorch'" in x and not "github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'" in x,
-                lambda x: "github.repository_owner == 'pytorch'" in x
+            valid_checks: List[Callable[[str], bool]] = [
+                lambda x: "github.repository == 'pytorch/pytorch'" in x
+                and "github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'"
+                not in x,
+                lambda x: "github.repository_owner == 'pytorch'" in x,
             ]
             if not any(f(if_statement) for f in valid_checks):
                 bad_jobs[job] = if_statement

--- a/tools/linter/adapters/no_workflows_on_fork.py
+++ b/tools/linter/adapters/no_workflows_on_fork.py
@@ -107,10 +107,10 @@ def check_file(filename: str) -> List[LintMessage]:
         else:
             if_statement = str(if_statement)
             valid_checks = [
-                "github.repository == 'pytorch/pytorch'",
-                "github.repository_owner == 'pytorch'",
+                lambda x: "github.repository == 'pytorch/pytorch'" in x and not "github.event_name != 'schedule' || github.repository == 'pytorch/pytorch'" in x,
+                lambda x: "github.repository_owner == 'pytorch'" in x
             ]
-            if not any(s in if_statement for s in valid_checks):
+            if not any(f(if_statement) for f in valid_checks):
                 bad_jobs[job] = if_statement
 
     with open(filename) as f:


### PR DESCRIPTION
MInor, adds a linter that ensures that all jobs run on pull_request, schedule, push etc have a `if: github.repository_owner == 'pytorch'` or are dependent on a job that has that check

There is also a setting in Github repos that can disable all workflows for that repo

A lot of these are unnecessary because many jobs use reusable workflows that have that check.  However, this is a one time change so I'm not that bothered

Unfortunately I can't put this at the workflow level, which would make this better

Lots of weird string parsing


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd