### PR TITLE
[c10/util] Add explicit include of <mutex> to c10/util/env.cpp

### DIFF
--- a/c10/util/env.cpp
+++ b/c10/util/env.cpp
@@ -2,6 +2,7 @@
 #include <c10/util/env.h>
 #include <fmt/format.h>
 #include <cstdlib>
+#include <mutex>
 #include <shared_mutex>
 
 namespace c10::utils {


### PR DESCRIPTION
Add explicit include of `<mutex>` to `c10/util/env.cpp` since it has usages of `std::lock_guard` which is defined in the header `<mutex>`.