### PR TITLE
Improvements for associative_scan - slicing of xs

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -3228,9 +3228,10 @@ class AssociativeScanTests(TestCase):
 
     @unittest.skipIf(not SM70OrLater, "triton")
     @requires_cuda
-    def test_associative_scan_combine_fn_wrong_meta_in_combine_fn(self, device):
+    def test_associative_scan_combine_fn_wrong_meta_in_combine_fn(self):
+        device = torch.device("cuda")
         B, N, C, H, W = 3, 3, 2, 3, 3
-        x = torch.randn(B, N, C, H, W, device=torch.device("cuda"))
+        x = torch.randn(B, N, C, H, W, device=device)
 
         def fct_wrong_dtype(x, y):
             return (x + y).to(torch.int64)

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -1665,7 +1665,7 @@ def forward(self, pred_1, x_1):
                 reverse=reverse_associative_scan,
                 combine_mode=combine_mode,
             )
-            return x + vyal, x + val
+            return x + y, x + val
 
         result = scan_fct(body, init, inp, dim=0, reverse=reverse)
         expected_result = _fake_scan(

--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -829,7 +829,8 @@ class AssociativeScanTests(TestCase):
         def fct(x: torch.Tensor, y: torch.Tensor):
             return x + y
 
-        for n in range(10):
+        # for n in range(10):
+        for n in [9]:
             x = torch.arange(n, device=device)
             torch.compiler.reset()
             associative_scan1 = torch.compile(

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3210,6 +3210,7 @@ LEGACY_MOD_INLINELIST = {
     "torch._higher_order_ops.while_loop",
     "torch._higher_order_ops.associative_scan",
     "torch._higher_order_ops.scan",
+    "torch._higher_order_ops.utils",
     "torch.nn.attention.flex_attention",
     "torch.ao.quantization.pt2e.export_utils",
     "torch.ao.quantization.pt2e.qat_utils",

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1051,6 +1051,8 @@ class AssociativeScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
         args: List[VariableTracker],
         kwargs: Dict[str, VariableTracker],
     ) -> VariableTracker:
+        from torch._higher_order_ops.associative_scan import first_slice_copy
+
         from .builder import wrap_fx_proxy
 
         args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
@@ -1068,29 +1070,10 @@ class AssociativeScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
 
         # Trace the subgraph
         # TODO: Fix these pointless new_empty calls appearing in the dynamo output graph.
+        # The sub_args is a slice of original input, e.g. if input.size is (3, 4), and scan dim=0
+        # the sub_args shape will be (4, ).
         sub_args = [
-            leaf.call_method(
-                tx,
-                "new_empty",
-                args=(
-                    VariableTracker.build(
-                        tx,
-                        (
-                            leaf.size
-                            if leaf.size is not None
-                            else BuiltinVariable(getattr)
-                            .call_function(
-                                tx, [leaf, ConstantVariable.create("shape")], {}
-                            )
-                            .items
-                        ),
-                    ),
-                ),
-                kwargs={
-                    "dtype": VariableTracker.build(tx, leaf.dtype),
-                    "requires_grad": VariableTracker.build(tx, leaf.requires_grad),
-                },
-            )
+            _make_inlined(tx, first_slice_copy)(leaf)
             for leaf in itertools.chain(xs.items, xs.items)
         ]
         (

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1052,6 +1052,7 @@ class AssociativeScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
         kwargs: Dict[str, VariableTracker],
     ) -> VariableTracker:
         from torch._higher_order_ops.utils import first_slice_copy
+
         from .builder import wrap_fx_proxy
 
         args, kwargs = LazyVariableTracker.realize_all((args, kwargs))

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1073,7 +1073,7 @@ class AssociativeScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
         # The sub_args is a slice of original input, e.g. if input.size is (3, 4), and scan dim=0
         # the sub_args shape will be (4, ).
         sub_args = [
-            _make_inlined(tx, first_slice_copy)(leaf)
+            _make_inlined(tx, first_slice_copy)(leaf, dim)
             for leaf in itertools.chain(xs.items, xs.items)
         ]
         (

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1051,8 +1051,7 @@ class AssociativeScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
         args: List[VariableTracker],
         kwargs: Dict[str, VariableTracker],
     ) -> VariableTracker:
-        from torch._higher_order_ops.associative_scan import first_slice_copy
-
+        from torch._higher_order_ops.utils import first_slice_copy
         from .builder import wrap_fx_proxy
 
         args, kwargs = LazyVariableTracker.realize_all((args, kwargs))

--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -213,9 +213,17 @@ def associative_scan(
         #            [torch.tensor([[1.0, 3.0],
         #                           [1.0, 3.0]])])
         # The arguments are of shape 2 x 2, but can be evaluated in parallel along the scan dimension.
+        # TODO: In case of the additional inputs, we the in_dims should be set to None
         combine_fn = functools.partial(
             wrap_combine_fn_flat,
-            combine_fn=torch.vmap(combine_fn, dim, dim),
+            combine_fn=torch.vmap(
+                combine_fn,
+                in_dims=(
+                    pytree.tree_unflatten([dim] * len(leaves), spec),
+                    pytree.tree_unflatten([dim] * len(leaves), spec),
+                ),
+                out_dims=dim,
+            ),
             spec=spec,
             num_leaves=len(leaves),
         )

--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -176,8 +176,8 @@ def associative_scan(
 
     # Call the combine_fn with only a slice along the scan dim
     # and check whether the output leaves have the same slice dimensions
-    sliced_leaves = [first_slice_copy(leaf) for leaf in leaves]
-    sliced_shape = shape[1:]
+    sliced_leaves = [first_slice_copy(leaf, dim) for leaf in leaves]
+    sliced_shape = sliced_leaves[0].shape
 
     out = combine_fn(
         pytree.tree_unflatten(sliced_leaves, spec),
@@ -308,7 +308,7 @@ def trace_associative_scan(
     proxy_mode, func_overload, combine_fn: Callable, xs: List[torch.Tensor], dim: int
 ):
     with disable_proxy_modes_tracing():
-        sample_xs = [first_slice_copy(x) for x in itertools.chain(xs, xs)]
+        sample_xs = [first_slice_copy(x, dim) for x in itertools.chain(xs, xs)]
         combine_graph = reenter_make_fx(combine_fn)(*sample_xs)
 
     outputs = None

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -475,6 +475,7 @@ def get_dummy_aot_autograd_config():
         keep_inference_input_mutations=False,
     )
 
+
 # Slices off the first element of a given dimension
 def first_slice_copy(t: torch.Tensor, dim: int = 0) -> torch.Tensor:
     return torch.select_copy(t, dim, 0)

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -474,3 +474,7 @@ def get_dummy_aot_autograd_config():
         aot_id=0,
         keep_inference_input_mutations=False,
     )
+
+# Slices off the first element of a given dimension
+def first_slice_copy(t: torch.Tensor, dim: int = 0) -> torch.Tensor:
+    return torch.select_copy(t, dim, 0)


### PR DESCRIPTION
In this PR, the combine_fn is consistently called with a slice along the scan dim. It implements part of https://github.com/pytorch/pytorch/pull/136966

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @rec @ydwu4