### PR TITLE
[AOTI][refactor] Separate header codegen

### DIFF
--- a/torch/_inductor/codegen/aoti_runtime/implementation.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/implementation.cpp
@@ -1,8 +1,11 @@
 // NOTE: Like interface.cpp, this file will be copied into AOTInductor
 // generated output. This file is intended to keep implementation
 // details separate from the implementation of the AOTI public
-// interface. Note also that #includes should go into interface.cpp
-// for simplicity of maintenance.
+// interface.
+#include <torch/csrc/inductor/aoti_runtime/arrayref_tensor.h>
+#include <torch/csrc/inductor/aoti_runtime/scalar_to_tensor.h>
+#include <torch/csrc/inductor/aoti_runtime/thread_local.h>
+#include <torch/csrc/inductor/aoti_torch/utils.h>
 
 namespace torch {
 namespace aot_inductor {

--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -1,8 +1,7 @@
-#include <torch/csrc/inductor/aoti_runtime/arrayref_tensor.h>
+// Definition of AOTI runtime interface functions
+
 #include <torch/csrc/inductor/aoti_runtime/interface.h>
 #include <torch/csrc/inductor/aoti_runtime/model_container.h>
-#include <torch/csrc/inductor/aoti_runtime/scalar_to_tensor.h>
-#include <torch/csrc/inductor/aoti_runtime/thread_local.h>
 
 #include <iostream>
 #include <sstream>

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -146,13 +146,16 @@ class CppWrapperCpu(PythonWrapperCodegen):
             return
 
         if V.graph.aot_mode:
-            for header_cpp_file in ("interface.cpp", "implementation.cpp"):
-                with open(
-                    os.path.join(
-                        os.path.dirname(__file__), "aoti_runtime", header_cpp_file
-                    )
-                ) as f:
-                    self.header.splice(f.read())
+            self.header.splice(
+                """
+                #include <torch/csrc/inductor/aoti_runtime/interface.h>
+                #include <torch/csrc/inductor/aoti_runtime/model.h>
+                """
+            )
+            with open(
+                os.path.join(os.path.dirname(__file__), "aoti_runtime", "interface.cpp")
+            ) as f:
+                self.header.splice(f.read())
         else:
             self.header.splice(
                 """
@@ -161,44 +164,8 @@ class CppWrapperCpu(PythonWrapperCodegen):
 
                 cpp_wrapper_src = (
                 '''
-                """
-            )
-
-        self.header.splice(
-            f"#include <torch/csrc/inductor/aoti_torch/generated/c_shim_{self.device}.h>"
-        )
-        self.header.splice(
-            """
-            #include <torch/csrc/inductor/aoti_runtime/arrayref_tensor.h>
-            #include <torch/csrc/inductor/aoti_runtime/thread_local.h>
-            #include <torch/csrc/inductor/aoti_runtime/scalar_to_tensor.h>
-            """
-        )
-        if V.graph.aot_mode:
-            self.header.splice(
-                """
-                #include <torch/csrc/inductor/aoti_runtime/model.h>
-                """
-            )
-
-        enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
-            "linux",
-            "win32",
-        ]
-        if config.profiler_mark_wrapper_call or enable_kernel_profile:
-            self.header.splice("#include <ATen/record_function.h>")
-
-        self.header.splice("typedef at::Half half;")
-        self.header.splice("typedef at::BFloat16 bfloat16;")
-        self.header.splice("#include <c10/util/generic_math.h>")
-
-        if not V.graph.aot_mode:
-            self.header.splice(
-                """
                 #include <pybind11/pybind11.h>
-
                 namespace py = pybind11;
-                using namespace torch::aot_inductor;
 
                 class RAIIPyObject {
                 public:
@@ -224,18 +191,39 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 private:
                     PyObject* obj_;
                 };
+
+                #include <torch/csrc/inductor/aoti_runtime/device_utils.h>
+                #include <torch/csrc/inductor/aoti_runtime/utils.h>
+                using namespace torch::aot_inductor;
                 """
             )
 
-        # Round up to the nearest multiple of ALIGN_BYTES
-        # ALIGN_BYTES must be a power of 2
         self.header.splice(
             f"""
+            #include <torch/csrc/inductor/aoti_runtime/arrayref_tensor.h>
+            #include <torch/csrc/inductor/aoti_runtime/thread_local.h>
+            #include <torch/csrc/inductor/aoti_runtime/scalar_to_tensor.h>
+            #include <torch/csrc/inductor/aoti_torch/generated/c_shim_{self.device}.h>
+
+            #include <c10/util/generic_math.h>
+            typedef at::Half half;
+            typedef at::BFloat16 bfloat16;
+
+            // Round up to the nearest multiple of {ALIGN_BYTES}
             [[maybe_unused]] static int64_t align(int64_t nbytes) {{
               return (nbytes + {ALIGN_BYTES} - 1) & -{ALIGN_BYTES};
             }}
             """
         )
+
+        enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
+            "linux",
+            "win32",
+        ]
+        if config.profiler_mark_wrapper_call or enable_kernel_profile:
+            # No C shim for profiling APIs, assuming profiling is a debugging feature which
+            # does not provide any ABI compatibility promise.
+            self.header.splice("#include <ATen/record_function.h>")
 
     @functools.lru_cache(None)  # noqa: B019
     def include_extra_header(self, header: str):
@@ -259,10 +247,8 @@ class CppWrapperCpu(PythonWrapperCodegen):
         if V.graph.is_const_graph:
             # We do not write prefix for constant graph, it will be written by main module.
             return
-
         if V.graph.aot_mode:
-            self.prefix.writeline("namespace torch {")
-            self.prefix.writeline("namespace aot_inductor {")
+            self.prefix.writeline("namespace torch::aot_inductor {")
 
     def write_input_output_info(
         self,
@@ -945,14 +931,14 @@ class CppWrapperCpu(PythonWrapperCodegen):
             if V.graph.is_const_graph:
                 result.writeline("} // AOTInductorModel::_const_run_impl")
             else:
-                result.writeline("} // namespace aot_inductor")
-                result.writeline("} // namespace torch")
+                result.writeline("} // namespace torch::aot_inductor\n\n\n")
             return
 
         # cpp entry function for JIT with cpp wrapper
-        result.writeline("'''\n)")
         result.splice(
             f"""
+            '''
+            )
             inductor_entry = CppWrapperCodeCache.load_pybinding(
                 ["std::vector<AtenTensorHandle>"], cpp_wrapper_src, "{self.device}", {len(V.graph.graph_outputs)})
             """

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import os
 from itertools import count
 from typing import Dict, List, Optional, Tuple
 
@@ -96,6 +97,19 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
             assert dtype is not None, f"Failed to get the dtype of sympy.Expr: {input}"
             return DTYPE_TO_CPP[dtype]
         return f"ArrayRefTensor<{DTYPE_TO_CPP[input.get_dtype()]}>"
+
+    def write_header(self):
+        if V.graph.is_const_graph:
+            # We do not write header for constant graph, it will be written by main module.
+            return
+
+        super().write_header()
+        with open(
+            os.path.join(
+                os.path.dirname(__file__), "aoti_runtime", "implementation.cpp"
+            )
+        ) as f:
+            self.header.splice(f.read())
 
     def codegen_input_numel_asserts(self):
         for name, buf in V.graph.graph_inputs.items():


### PR DESCRIPTION
Summary: Move arrayref specific header codegen logic to cpp_wrapper_cpu_array_ref.py, and consolidate some header files codegen logic

Test Plan: CI

Differential Revision: D64899248




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang @aakhundov