### PR TITLE
[Dynamo] Add explaination for not support usecase to fix todo in dynamo

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -3086,7 +3086,7 @@ def forward(self, x):
             torch._dynamo.exc.UserError,
             "Dynamic control flow is not supported at the moment",
         ):
-            gm, _ = torch._dynamo.export(f, aten_graph=True)(torch.randn(5, 6))
+            torch._dynamo.export(f, aten_graph=True)(torch.randn(5, 6))
 
     @config.patch(assume_static_by_default=False)
     def test_export_persist_assert(self):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -611,7 +611,6 @@ def generic_jump(truth_fn: typing.Callable[[object], bool], push: bool):
                         self.push(value)
                     self.jump(inst)
             else:
-                # TODO link the torch.cond doc later
                 raise exc.UserError(
                     exc.UserErrorType.DYNAMIC_CONTROL_FLOW,
                     "Dynamic control flow is not supported at the moment. Please use "

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2427,7 +2427,7 @@ def tensor_always_has_static_shape(
 def lazy_format_graph_tabular(fn_name, gm):
     def inner():
         try:
-            from tabulate import tabulate  # TODO: Check that this is installed
+            from tabulate import tabulate
         except ImportError:
             return (
                 "Tabulate module missing, please install tabulate to log the graph in tabular format, logging code instead:\n"

--- a/torch/_export/db/examples/cond_operands.py
+++ b/torch/_export/db/examples/cond_operands.py
@@ -15,6 +15,9 @@ class CondOperands(torch.nn.Module):
     - match arguments of `true_fn` and `false_fn`
 
     NOTE: If the `pred` is test on a dim with batch size < 2, it will be specialized.
+
+    NOTE: Currently `torch._dynamo.export` not suport dynamic flow control, like `if-else` statement.
+    You will get `UserError` if you try to export, replace them with `cond` operator like below.
     """
 
     def forward(self, x, y):


### PR DESCRIPTION
Fixes TODOs:

- **TODO link the torch.cond doc later**: there's an error message with link of docs will display when failed, add an explanation in the page of `cond-operands`
![image](https://github.com/user-attachments/assets/4525af60-3104-49ca-bd7c-65c48cf55712)


Run test like:
```python
    @config.patch(capture_dynamic_output_shape_ops=True)
    def test_export_dynamic_control_flow_error(self):
        def f(x):
            if x.nonzero() > 3:
                return x.cos()
            return x.sin()

        torch._dynamo.export(f, aten_graph=True)(torch.randn(5, 6))
```

Get error result with doc link:
```

----------------------------------------------------------------------- Captured stdout call ------------------------------------------------------------------------
inductor []
unimplemented [('Dynamic control flow is not supported at the moment. Please use functorch.experimental.control_flow.cond to explicitly capture the control flow. For more information about this error, see: https://pytorch.org/docs/main/generated/exportdb/index.html#cond-operands', 1)]
====================================================================== short test summary info ======================================================================
FAILED [0.2091s] test/dynamo/test_export.py::ExportTests::test_export_dynamic_control_flow_error - torch._dynamo.exc.UserError: Dynamic control flow is not supported at the moment. Please use functorch.experimental.control_flow.cond to explicitly capture the ...

```

- **TODO: Check that this is installed**: `try-catch`  with `import tabulate` works as checker of installation, so this todo already achieved, I think might be safe to remove.
- Remove unused variable in `test_export_dynamic_control_flow_error`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec