### PR TITLE
[Intel GPU][Windows] Remove hardcoded SYCL runtime version

### DIFF
--- a/cmake/Modules/FindSYCLToolkit.cmake
+++ b/cmake/Modules/FindSYCLToolkit.cmake
@@ -60,16 +60,10 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     NO_DEFAULT_PATH
   )
 endif()
-# On Windows, currently there's no sycl.lib. Only sycl7.lib with version suffix,
-# where the current version of the SYCL runtime is 7.
-# Until oneAPI adds support to sycl.lib without the version suffix,
-# sycl_runtime_version needs to be hardcoded and uplifted when SYCL runtime version uplifts.
-# TODO: remove this when sycl.lib is supported on Windows
 if(WIN32)
-  set(sycl_runtime_version 7)
   find_library(
     SYCL_LIBRARY
-    NAMES "sycl${sycl_runtime_version}"
+    NAMES sycl
     HINTS ${SYCL_LIBRARY_DIR}
     NO_DEFAULT_PATH
   )

--- a/cmake/Modules/FindSYCLToolkit.cmake
+++ b/cmake/Modules/FindSYCLToolkit.cmake
@@ -60,13 +60,18 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     NO_DEFAULT_PATH
   )
 endif()
+# Windows now supports sycl.lib without a version suffix. However, we still include hardcoded
+# versions (8, 7, 6) to ensure backward compatibility with older compiler versions.
+# TODO: Remove hardcoded versions when compatibility with older SYCL runtime versions is no longer required.
 if(WIN32)
-  find_library(
-    SYCL_LIBRARY
-    NAMES sycl
-    HINTS ${SYCL_LIBRARY_DIR}
-    NO_DEFAULT_PATH
-  )
+  foreach(sycl_runtime_version "" 8 7 6)
+    find_library(
+      SYCL_LIBRARY
+      NAMES "sycl${sycl_runtime_version}"
+      HINTS ${SYCL_LIBRARY_DIR}
+      NO_DEFAULT_PATH
+    )
+  endforeach()
   if(SYCL_LIBRARY STREQUAL "SYCL_LIBRARY-NOTFOUND")
     message(FATAL_ERROR "Cannot find a SYCL library on Windows")
   endif()

--- a/cmake/Modules/FindSYCLToolkit.cmake
+++ b/cmake/Modules/FindSYCLToolkit.cmake
@@ -64,6 +64,7 @@ endif()
 # versions (8, 7, 6) to ensure backward compatibility with older compiler versions.
 # TODO: Remove hardcoded versions when compatibility with older SYCL runtime versions is no longer required.
 if(WIN32)
+  set(SYCL_LIBRARY_FOUND FALSE)
   foreach(sycl_runtime_version "" 8 7 6)
     find_library(
       SYCL_LIBRARY
@@ -71,8 +72,12 @@ if(WIN32)
       HINTS ${SYCL_LIBRARY_DIR}
       NO_DEFAULT_PATH
     )
+    if(EXISTS "${SYCL_LIBRARY}")
+      set(SYCL_LIBRARY_FOUND TRUE)
+      break()
+    endif()
   endforeach()
-  if(SYCL_LIBRARY STREQUAL "SYCL_LIBRARY-NOTFOUND")
+  if(NOT SYCL_LIBRARY_FOUND)
     message(FATAL_ERROR "Cannot find a SYCL library on Windows")
   endif()
 endif()

--- a/cmake/Modules/FindSYCLToolkit.cmake
+++ b/cmake/Modules/FindSYCLToolkit.cmake
@@ -61,11 +61,11 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   )
 endif()
 # Windows now supports sycl.lib without a version suffix. However, we still include hardcoded
-# versions (8, 7, 6) to ensure backward compatibility with older compiler versions.
+# versions (8, 7) to ensure backward compatibility with older compiler versions.
 # TODO: Remove hardcoded versions when compatibility with older SYCL runtime versions is no longer required.
 if(WIN32)
   set(SYCL_LIBRARY_FOUND FALSE)
-  foreach(sycl_runtime_version "" 8 7 6)
+  foreach(sycl_runtime_version "" 8 7)
     find_library(
       SYCL_LIBRARY
       NAMES "sycl${sycl_runtime_version}"


### PR DESCRIPTION
oneAPI 2025, targeted for PT 2.6, supports `sycl.lib` on Windows.