### PR TITLE
support nesting of suppress_guards; suppress guards when generated compiled autograd graph

### DIFF
--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -227,6 +227,8 @@ class AutogradCompilerInstance:
         self.stack.enter_context(self.fake_tensor_mode)
         self.stack.enter_context(self.proxy_mode)
         self.stack.enter_context(disable_autocast_cache())
+        # Needed to make sure we don't accidentally specialize any symbols
+        self.fake_tensor_mode.shape_env._suppress_guards_enter()
         return inputs, sizes, scalars
 
     def proxy_call_backward(
@@ -382,6 +384,8 @@ class AutogradCompilerInstance:
             {},
         )
         self.stack.close()
+        # Needed to make sure we don't accidentally specialize any symbols
+        self.fake_tensor_mode.shape_env._suppress_guards_exit()
         self.fx_tracer.create_node(
             "output",
             "output",

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3538,11 +3538,16 @@ class ShapeEnv:
 
     @record_shapeenv_event()
     def _suppress_guards_enter(self) -> None:
+        if not hasattr(TLS, "suppress_guards_stack"):
+            setattr(TLS, "suppress_guards_stack", [])
+        old = self._suppress_guards_tls
+        TLS.suppress_guards_stack.append(old)
         TLS.suppress_guards = True
 
     @record_shapeenv_event()
     def _suppress_guards_exit(self) -> None:
-        TLS.suppress_guards = False
+        old = TLS.suppress_guards_stack.pop() if len(TLS.suppress_guards_stack) > 0 else False
+        TLS.suppress_guards = old
 
     @contextmanager
     def suppress_guards(self) -> Iterator[None]:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/138920. See comments there for details.

I still need to try to get a smaller repro to write an actual test. But suppressing the guards, I now no longer see the specilization in the CA graph in the linked example:
```
        aot1_view_3: ... = torch.ops.aten.view.default(aot1_tangents_1, [aot1_sym_size_int, 48, 1])
        aot1_view_4: ... = torch.ops.aten.view.default(aot1_view_3, [aot1_sym_size_int, 48])
```

Test Plan: fixes example in linked issue

Differential Revision: D64976468




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec @xmfan @yf225