### PR TITLE
Move pippy to training IR

### DIFF
--- a/test/distributed/pipelining/test_unflatten.py
+++ b/test/distributed/pipelining/test_unflatten.py
@@ -20,7 +20,7 @@ class Block(torch.nn.Module):
         x = self.conv(x)
         x = self.lin0(x)
         pipe_split()
-        x.add_(constant)
+        x.add(constant)
         x = self.lin1(x)
         return self.relu(x)
 

--- a/torch/distributed/pipelining/_IR.py
+++ b/torch/distributed/pipelining/_IR.py
@@ -1003,7 +1003,7 @@ class Pipe(torch.nn.Module):
     ) -> ExportedProgram:
         logger.info("Tracing model ...")
         try:
-            ep = torch.export.export(
+            ep = torch.export.export_for_training(
                 mod,
                 example_args,
                 example_kwargs,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #138923
* #138749
* #138658

Export IR is changing to non-functional training IR as a result, in the near future, export_for_trainining will be an alias to export. To make the migration easier, this PR makes pippy to use export_for_training. I encountered one bug where pippy test case has a mutating op which is not supported when you are passing in an input that requires grad. The fix is to just make the test use functional operator. 

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o

Differential Revision: [D64977030](https://our.internmc.facebook.com/intern/diff/D64977030)