### PR TITLE
[export] add mark_unbacked to export dynamic_shapes API

### DIFF
--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -106,6 +106,8 @@ def fakify(
             # are raised when specializing.
             dynamic_sizes.append(DimDynamic.DYNAMIC)
             constraint_sizes[i] = RelaxedUnspecConstraint(warn_only=False)  # type: ignore[call-overload]
+        elif i in getattr(t, "_dynamo_unbacked_indices", {}):
+            dynamic_sizes.append(DimDynamic.SIZE_LIKE_UNBACKED)
         else:
             dynamic_sizes.append(DimDynamic.STATIC)
     symbolic_context = StatelessSymbolicContext(

--- a/torch/export/dynamic_shapes.py
+++ b/torch/export/dynamic_shapes.py
@@ -46,11 +46,13 @@ class _DimHint(Enum):
     - AUTO means automatic inference of shape (static or dynamic).
     - STATIC means static shape (always specialized).
     - DYNAMIC means dynamic, will error out if specialized.
+    - UNBACKED means allocating an unbacked symbol for the shape.
     """
 
     AUTO = auto()
     STATIC = auto()
     DYNAMIC = auto()
+    UNBACKED = auto()
 
 
 class _Dim(type):
@@ -238,6 +240,7 @@ def Dim(name: str, *, min: Optional[int] = None, max: Optional[int] = None):
 Dim.AUTO = _DimHint.AUTO  # type: ignore[attr-defined]
 Dim.STATIC = _DimHint.STATIC  # type: ignore[attr-defined]
 Dim.DYNAMIC = _DimHint.DYNAMIC  # type: ignore[attr-defined]
+Dim.UNBACKED = _DimHint.UNBACKED  # type: ignore[attr-defined]
 
 
 def dims(*names: str, min: Optional[int] = None, max: Optional[int] = None):
@@ -920,6 +923,8 @@ def _process_dynamic_shapes(
                         torch._dynamo.mark_static(tensor, i)
                     elif dim == _DimHint.DYNAMIC:
                         torch._dynamo.mark_dynamic(tensor, i)
+                    elif dim == _DimHint.UNBACKED:
+                        torch._dynamo.decorators.mark_unbacked(tensor, i)
                     constraints.append(_RelaxedConstraint(id(tensor), i))
                 elif dim is None:
                     torch._dynamo.mark_static(tensor, i)
@@ -937,6 +942,8 @@ def _process_dynamic_shapes(
                         torch._dynamo.mark_static(tensor, i)
                     elif dim == _DimHint.DYNAMIC:
                         torch._dynamo.mark_dynamic(tensor, i)
+                    elif dim == _DimHint.UNBACKED:
+                        torch._dynamo.decorators.mark_unbacked(tensor, i)
                     constraints.append(_RelaxedConstraint(id(tensor), i))
                 elif dim is None:
                     torch._dynamo.mark_static(tensor, i)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -4127,6 +4127,7 @@ class ShapeEnv:
         if dynamic_dim is DimDynamic.SIZE_LIKE_UNBACKED:
             out = self.create_unbacked_symint().node.expr
             self._constrain_range_for_size(out)
+            self.set_unbacked_var_to_val(out, val)
             # TODO: maybe put the hint somewhere
             if isinstance(symbolic_context, StatefulSymbolicContext) and source_name:
                 symbolic_context.shape_env_to_source_to_symbol_cache[id(self)][


### PR DESCRIPTION
Adding `Dim.UNBACKED` to represent unbacked dims, basically calls `torch._dynamo.decorators.mark_unbacked()` under the hood. Does some plumbing for unbacked bindings & unbacked hints.




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv