### PR TITLE
Gaussian nll loss scalar variance support

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2688,6 +2688,17 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             var = -1 * torch.ones(3, 5)
             torch.nn.functional.gaussian_nll_loss(input, target, var)
 
+    def test_gaussian_nll_loss_scalar_var(self):
+        input = torch.tensor([[0.5, 1.5, 2.5], [2., 4., 6.]])
+        target = torch.tensor([[1., 2., 3.], [1., 2., 3.]])
+        var = 0.5
+        var_tensor = var*torch.ones_like(input)
+        component_wise_loss = 0.5 * (torch.log(var_full) + (input - target_full)**2 / var_full)
+        self.assertEqual(component_wise_loss,
+                         F.gaussian_nll_loss(input, target, var, reduction='none'))
+        self.assertEqual(F.gaussian_nll_loss(input, target, var_tensor, reduction='none'),
+                         F.gaussian_nll_loss(input, target, var, reduction='none'))
+
     def test_KLDivLoss_batch_mean(self):
         input_shape = (2, 5)
         log_prob1 = F.log_softmax(torch.randn(input_shape), 1)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2687,13 +2687,16 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaisesRegex(ValueError, 'var has negative entry/entries'):
             var = -1 * torch.ones(3, 5)
             torch.nn.functional.gaussian_nll_loss(input, target, var)
+        with self.assertRaisesRegex(ValueError, 'var has negative entry/entries'):
+            var = -1.0
+            torch.nn.functional.gaussian_nll_loss(input, target, var)
 
     def test_gaussian_nll_loss_scalar_var(self):
         input = torch.tensor([[0.5, 1.5, 2.5], [2., 4., 6.]])
         target = torch.tensor([[1., 2., 3.], [1., 2., 3.]])
         var = 0.5
         var_tensor = var*torch.ones_like(input)
-        component_wise_loss = 0.5 * (torch.log(var_full) + (input - target_full)**2 / var_full)
+        component_wise_loss = 0.5 * (torch.log(var_tensor) + (input - target)**2 / var_tensor)
         self.assertEqual(component_wise_loss,
                          F.gaussian_nll_loss(input, target, var, reduction='none'))
         self.assertEqual(F.gaussian_nll_loss(input, target, var_tensor, reduction='none'),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2695,7 +2695,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         input = torch.tensor([[0.5, 1.5, 2.5], [2., 4., 6.]])
         target = torch.tensor([[1., 2., 3.], [1., 2., 3.]])
         var = 0.5
-        var_tensor = var*torch.ones_like(input)
+        var_tensor = var * torch.ones_like(input)
         component_wise_loss = 0.5 * (torch.log(var_tensor) + (input - target)**2 / var_tensor)
         self.assertEqual(component_wise_loss,
                          F.gaussian_nll_loss(input, target, var, reduction='none'))

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3269,7 +3269,7 @@ def gaussian_nll_loss(
     if isinstance(var, float):
         if var < 0:
             raise ValueError("var has negative entry/entries")
-        var = var*torch.ones_like(input)
+        var = var * torch.ones_like(input)
     elif torch.any(var < 0):
         raise ValueError("var has negative entry/entries")
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3230,7 +3230,7 @@ def poisson_nll_loss(
 def gaussian_nll_loss(
     input: Tensor,
     target: Tensor,
-    var: Tensor,
+    var: Tensor | float,
     full: bool = False,
     eps: float = 1e-6,
     reduction: str = "mean",
@@ -3243,7 +3243,8 @@ def gaussian_nll_loss(
         input: expectation of the Gaussian distribution.
         target: sample from the Gaussian distribution.
         var: tensor of positive variance(s), one for each of the expectations
-            in the input (heteroscedastic), or a single one (homoscedastic).
+            in the input (heteroscedastic), or a single one (homoscedastic),
+            or a positive scalar value to be used for all expectations.
         full (bool, optional): include the constant term in the loss calculation. Default: ``False``.
         eps (float, optional): value added to var, for stability. Default: 1e-6.
         reduction (str, optional): specifies the reduction to apply to the output:
@@ -3263,6 +3264,14 @@ def gaussian_nll_loss(
             eps=eps,
             reduction=reduction,
         )
+
+    # Entries of var must be non-negative
+    if isinstance(var, float):
+        if var < 0:
+            raise ValueError("var has negative entry/entries")
+        var = var*torch.ones_like(inputs)
+    elif torch.any(var < 0):
+        raise ValueError("var has negative entry/entries")
 
     # Check var size
     # If var.size == input.size, the case is heteroscedastic and no further checks are needed.
@@ -3290,10 +3299,6 @@ def gaussian_nll_loss(
     # Check validity of reduction mode
     if reduction != "none" and reduction != "mean" and reduction != "sum":
         raise ValueError(reduction + " is not valid")
-
-    # Entries of var must be non-negative
-    if torch.any(var < 0):
-        raise ValueError("var has negative entry/entries")
 
     # Clamp for stability
     var = var.clone()

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3269,7 +3269,7 @@ def gaussian_nll_loss(
     if isinstance(var, float):
         if var < 0:
             raise ValueError("var has negative entry/entries")
-        var = var*torch.ones_like(inputs)
+        var = var*torch.ones_like(input)
     elif torch.any(var < 0):
         raise ValueError("var has negative entry/entries")
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3230,7 +3230,7 @@ def poisson_nll_loss(
 def gaussian_nll_loss(
     input: Tensor,
     target: Tensor,
-    var: Tensor | float,
+    var: Union[Tensor, float],
     full: bool = False,
     eps: float = 1e-6,
     reduction: str = "mean",

--- a/torch/nn/functional.pyi.in
+++ b/torch/nn/functional.pyi.in
@@ -353,7 +353,7 @@ def poisson_nll_loss(
 def gaussian_nll_loss(
     input: Tensor,
     target: Tensor,
-    var: Tensor,
+    var: Tensor | float,
     full: Optional[bool] = ...,
     eps: Optional[float] = ...,
     reduction: Optional[str] = ...,

--- a/torch/nn/functional.pyi.in
+++ b/torch/nn/functional.pyi.in
@@ -353,7 +353,7 @@ def poisson_nll_loss(
 def gaussian_nll_loss(
     input: Tensor,
     target: Tensor,
-    var: Tensor | float,
+    var: Union[Tensor, float],
     full: Optional[bool] = ...,
     eps: Optional[float] = ...,
     reduction: Optional[str] = ...,

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -397,7 +397,7 @@ class GaussianNLLLoss(_Loss):
           but with one dimension equal to 1 (to allow for broadcasting)
         - Var: :math:`(N, *)` or :math:`(*)`, same shape as the input, or same shape as the input but
           with one dimension equal to 1, or same shape as the input but with one fewer
-          dimension (to allow for broadcasting)
+          dimension (to allow for broadcasting), or a scalar value
         - Output: scalar if :attr:`reduction` is ``'mean'`` (default) or
           ``'sum'``. If :attr:`reduction` is ``'none'``, then :math:`(N, *)`, same
           shape as the input
@@ -438,7 +438,7 @@ class GaussianNLLLoss(_Loss):
         self.full = full
         self.eps = eps
 
-    def forward(self, input: Tensor, target: Tensor, var: Tensor) -> Tensor:
+    def forward(self, input: Tensor, target: Tensor, var: Tensor | float) -> Tensor:
         return F.gaussian_nll_loss(
             input, target, var, full=self.full, eps=self.eps, reduction=self.reduction
         )

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1,5 +1,5 @@
 # mypy: allow-untyped-defs
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 from typing_extensions import deprecated
 
 from torch import Tensor
@@ -438,7 +438,9 @@ class GaussianNLLLoss(_Loss):
         self.full = full
         self.eps = eps
 
-    def forward(self, input: Tensor, target: Tensor, var: Tensor | float) -> Tensor:
+    def forward(
+        self, input: Tensor, target: Tensor, var: Union[Tensor, float]
+    ) -> Tensor:
         return F.gaussian_nll_loss(
             input, target, var, full=self.full, eps=self.eps, reduction=self.reduction
         )


### PR DESCRIPTION
Fixes #138747

Adds support for `variance` being a Tensor or a float in `gaussian_nll_loss` to avoid a cpu-gpu sync point in the loss function, when the variance is a static tensor like `<scalar>*torch.ones_like(input)`
