### PR TITLE
enable test_x86inductor_quantizer.py UTs on Windows.

### DIFF
--- a/test/quantization/pt2e/test_x86inductor_quantizer.py
+++ b/test/quantization/pt2e/test_x86inductor_quantizer.py
@@ -1,7 +1,6 @@
 # Owner(s): ["oncall: quantization"]
 import copy
 import itertools
-import sys
 from enum import Enum
 
 import torch
@@ -25,12 +24,7 @@ from torch.testing._internal.common_quantization import (
     skipIfNoX86,
 )
 from torch.testing._internal.common_quantized import override_quantized_engine
-from torch.testing._internal.common_utils import IS_CI, IS_WINDOWS, skipIfTorchDynamo
-
-
-if IS_WINDOWS and IS_CI:
-    sys.stderr.write("Windows CI still has some issue to be fixed.\n")
-    sys.exit(0)
+from torch.testing._internal.common_utils import skipIfTorchDynamo
 
 
 class NodePosType(Enum):


### PR DESCRIPTION
This UTs are failed months ago, but due to the main branch move forward, some PRs fixed it. Let's turn on them.

Local test passed:
<img width="863" alt="image" src="https://github.com/user-attachments/assets/a2ec160c-cdf1-404d-bc24-2f60faa8d791">


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10