### PR TITLE
[RFC] Add caching heuristic for skipping fast graphs

### DIFF
--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -33,7 +33,7 @@ from torch._inductor.codecache import (
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.utils import should_use_remote_fx_graph_cache
 from torch._logging import LazyString
-from torch._utils_internal import log_cache_bypass
+from torch._utils_internal import log_cache_operation
 
 from .runtime_wrappers import (
     AOTDispatchAutograd,
@@ -624,7 +624,7 @@ class AOTAutogradCache:
             cache_event_time = time.time_ns()
             cache_info["cache_bypass_reason"] = str(e)
             if remote:
-                log_cache_bypass("bypass_aot_autograd", str(e))
+                log_cache_operation("bypass_aot_autograd", bypass_reason=str(e))
             if config.strict_autograd_cache:
                 raise e
         if compiled_fn is None:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -53,6 +53,11 @@ fx_graph_cache = (
 # None: Not set -- Off for OSS, JustKnobs based for internal
 fx_graph_remote_cache: Optional[bool] = fx_graph_remote_cache_default()
 
+# If the graph takes longer to compile than this number, write to cache
+# If this number is set, then it takes priority. If not set, we use justknobs
+# to tell us what the value should be.
+fx_graph_cache_minimum_inductor_compile_time_for_caching_ms: Optional[int] = None
+
 # Enable autotune local cache.
 #
 # See bundled_autotune_remote_cache for the effect this flag has on the bundled

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -140,7 +140,7 @@ def log_trace_structured_event(*args, **kwargs) -> None:
     pass
 
 
-def log_cache_bypass(*args, **kwargs) -> None:
+def log_cache_operation(operation: str, bypass_reason: Optional[str] = None) -> None:
     pass
 
 


### PR DESCRIPTION
Summary:
Looking at scuba dataset, we can see that many graphs take less than 1s to compile. Caching is not worth it for those graphs. Lets add a heuristic.

https://fburl.com/scuba/dynamo_compile/hbf39dli

Test Plan: adhoc testing

Differential Revision: D64995390




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov