### PR TITLE
[BE][MPS] Use templates in Repeat shader

### DIFF
--- a/aten/src/ATen/native/mps/operations/Repeat.mm
+++ b/aten/src/ATen/native/mps/operations/Repeat.mm
@@ -131,8 +131,8 @@ void computeRepeatIndices(const index_t* repeat_ptr,
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {
-      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      id<MTLComputePipelineState> pipelineState = lib.getPipelineStateForFunc(fmt::format("repeat_interleave_{}", scalar_type));
+      auto computeEncoder = mpsStream->commandEncoder();
+      auto pipelineState = lib.getPipelineStateForFunc(fmt::format("repeat_interleave_{}", scalar_type));
 
       // this function call is a no-op if MPS Profiler is not enabled
       getMPSProfiler().beginProfileKernel(pipelineState, "repeat_interleave:" + scalar_type, false);

--- a/aten/src/ATen/native/mps/operations/Repeat.mm
+++ b/aten/src/ATen/native/mps/operations/Repeat.mm
@@ -86,20 +86,27 @@ Tensor repeat_mps(const Tensor& self, IntArrayRef repeats) {
 }
 
 static mps::MetalShaderLibrary lib(R"METAL_REPEAT(
-kernel void repeat_interleave(constant {0}     * repeat_ptr                [[buffer(0)]],
-                              constant int64_t * cumsum_ptr                [[buffer(1)]],
-                              device {0}       * result_ptr                [[buffer(2)]],
-                              uint               threads_per_threadgroup   [[threads_per_threadgroup]],
-                              uint               tid                       [[thread_position_in_grid]]) {{
+template<typename T>
+kernel void repeat_interleave(
+    constant T     * repeat_ptr    [[buffer(0)]],
+    constant int64_t * cumsum_ptr  [[buffer(1)]],
+    device T       * result_ptr    [[buffer(2)]],
+    uint               tid         [[thread_position_in_grid]]) {
   int64_t end = cumsum_ptr[tid];
-  {0} repeat = repeat_ptr[tid];
+  T repeat = repeat_ptr[tid];
   int64_t start = end - repeat;
-  for (uint j = start; j < end; j++) {{
+  for (uint j = start; j < end; j++) {
     result_ptr[j] = tid;
-  }}
-}}
-)METAL_REPEAT",
-                                   1);
+  }
+}
+
+template [[host_name("repeat_interleave_int32_t")]]
+kernel void repeat_interleave<int32_t>(constant int32_t*, constant int64_t*, device int32_t*, uint);
+
+template [[host_name("repeat_interleave_int64_t")]]
+kernel void repeat_interleave<int64_t>(constant int64_t*, constant int64_t*, device int64_t*, uint);
+
+)METAL_REPEAT");
 
 template <typename index_t>
 void computeRepeatIndices(const index_t* repeat_ptr,
@@ -113,9 +120,9 @@ void computeRepeatIndices(const index_t* repeat_ptr,
   TORCH_CHECK(repeatBuffer && cumsumBuffer && resultBuffer);
 
   std::string scalar_type;
-  if (typeid(index_t) == typeid(int32_t)) {
+  if constexpr (std::is_same_v<index_t, int32_t>) {
     scalar_type = "int32_t";
-  } else if (typeid(index_t) == typeid(int64_t)) {
+  } else if constexpr (std::is_same_v<index_t, int64_t>) {
     scalar_type = "int64_t";
   } else {
     TORCH_CHECK(false, "repeat_interleave: unsupported indexing data type");
@@ -125,7 +132,7 @@ void computeRepeatIndices(const index_t* repeat_ptr,
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      id<MTLComputePipelineState> pipelineState = lib.getPipelineStateForFunc("repeat_interleave", {scalar_type});
+      id<MTLComputePipelineState> pipelineState = lib.getPipelineStateForFunc(fmt::format("repeat_interleave_{}", scalar_type));
 
       // this function call is a no-op if MPS Profiler is not enabled
       getMPSProfiler().beginProfileKernel(pipelineState, "repeat_interleave:" + scalar_type, false);


### PR DESCRIPTION
- Instead of generating shader from templated code on host, just define two specializations of one kernel template
- Get rid of unused `threads_per_threadgroup` argument
- Replace `if (typeid(scalar_t) == typeid(int32_t))` with `if constexpr (std::is_same_v<scalar_t, int32_t>)` in the host code
