### PR TITLE
Turn off PRINT_AUTOTUNE by default

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -64,7 +64,7 @@ log = logging.getLogger(__name__)
 
 # correctness checks struggle with fp16/tf32
 VERIFY: Dict[str, Any] = {}
-PRINT_AUTOTUNE = True
+PRINT_AUTOTUNE = False
 DEBUG = False
 
 


### PR DESCRIPTION
Currently max-autotune prints out all the autotuning logs, which can be overwhelming, we should turn off this logging be default or gate it somehow cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov  @HDCharles 