### PR TITLE
Tensor .cuda() very slow with specific array sizes

### DIFF
--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -302,8 +302,7 @@ static bool copy_requires_temporaries(TensorIterator& iter, bool p2p_enabled) {
     bool src_row_contiguous = (src_stride1 == 1);
     bool dst_row_contiguous = (dst_stride1 == 1);
     if (src_row_contiguous && dst_row_contiguous) {
-        size_t width_in_bytes = dim1 * element_size;
-        size_t height = dim0;
+        size_t width_in_bytes = dim1 * element_size;       
         size_t src_pitch = src_stride0 * element_size;
         size_t dst_pitch = dst_stride0 * element_size;
 
@@ -317,7 +316,6 @@ static bool copy_requires_temporaries(TensorIterator& iter, bool p2p_enabled) {
     bool dst_col_contiguous = (dst_stride0 == 1);
     if (src_col_contiguous && dst_col_contiguous) {
         size_t width_in_bytes = dim0 * element_size;
-        size_t height = dim1;
         size_t src_pitch = src_stride1 * element_size;
         size_t dst_pitch = dst_stride1 * element_size;
 
@@ -399,8 +397,6 @@ static bool maybe_enable_p2p_access(Device dst_device, Device src_device) {
   int64_t dst_stride0 = dst_tensor.stride(0);
   int64_t dst_stride1 = iter.ndim() == 1 ? 1 : dst_tensor.stride(1);
 
-  
-  bool can_use_memcpy2d = false;
   size_t width_in_bytes = 0;
   size_t height = 0;
   size_t src_pitch = 0;

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -286,7 +286,7 @@ static bool copy_requires_temporaries(TensorIterator& iter, bool p2p_enabled) {
   bool is_complex = at::isComplexType(iter.dtype(1));
 
   // Check if the tensor is 1D or 2D and non-contiguous
-  if (iter.ndim() <= 2 && same_dtype && !is_complex) {
+  if (iter.ndim() == 2 && same_dtype && !is_complex) {
     const auto& src_tensor = iter.tensor(1);
     const auto& dst_tensor = iter.tensor(0);
 
@@ -531,7 +531,7 @@ static void copy_kernel_cuda(TensorIterator& iter, bool non_blocking) {
   CUDAStream stream = getCurrentCUDAStream();
 
   // Try optimized 1D/2D non-contiguous path first for both blocking and non-blocking
-  if (iter.ndim() <= 2 && !iter.is_contiguous()) {       
+  if (iter.ndim() == 2 && !iter.is_contiguous()) {       
     if (copy_non_contiguous_2d(dst, src, iter, kind, stream, non_blocking)) {
       if (iter.tensor(0).is_conj() != iter.tensor(1).is_conj()) {
         iter.tensor(0).conj_physical_();

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -406,10 +406,8 @@ static bool copy_non_contiguous_2d(
       height = dim0;
   }
 
-  // if conditions not met, fallback needed
-  if (src_pitch < width_in_bytes || dst_pitch < width_in_bytes) {
-    return false;  
-  }
+  TORCH_INTERNAL_ASSERT(src_pitch >= width_in_bytes && dst_pitch >= width_in_bytes, 
+                      "Source and destination pitch must be >= width_in_bytes for non-contiguous copy.");
 
   at::cuda::memcpy2d_conditional_sync(
       dst,

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -283,12 +283,13 @@ static bool copy_requires_temporaries(TensorIterator& iter, bool p2p_enabled) {
   }
 
   bool same_dtype = iter.dtype(0) == iter.dtype(1);
-  
+  bool is_complex = at::isComplexType(iter.dtype(0));
+
   // Check if the tensor is 1D or 2D and non-contiguous
-  if (iter.ndim() <= 2 && !iter.is_contiguous() && same_dtype) {   
+  if (iter.ndim() <= 2 && !iter.is_contiguous() && same_dtype && !is_complex) {   
     // Perform pitch checks to determine if a temporary is needed
     const auto& src_tensor = iter.tensor(1);
-    const auto& dst_tensor = iter.tensor(0);
+    const auto& dst_tensor = iter.tensor(0);   
 
     size_t element_size = src_tensor.element_size();
     int64_t dim0 = src_tensor.size(0);
@@ -312,7 +313,7 @@ static bool copy_requires_temporaries(TensorIterator& iter, bool p2p_enabled) {
     }
 
     // If pitch conditions are met, no temporary is required
-    if (src_pitch >= width_in_bytes && dst_pitch >= width_in_bytes) {
+    if (src_pitch >= width_in_bytes && dst_pitch >= width_in_bytes) {     
       return false;
     }
   }

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -285,7 +285,7 @@ static bool copy_requires_temporaries(TensorIterator& iter, bool p2p_enabled) {
   bool same_dtype = iter.dtype(0) == iter.dtype(1);
 
   // Check if the tensor is 1D or 2D and non-contiguous
-  if (iter.ndim() <= 2 && !iter.is_contiguous()) {  
+  if (iter.ndim() <= 2 && !iter.is_contiguous() && same_dtype) { 
     return false; 
   }
 

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -329,11 +329,11 @@ static bool copy_requires_temporaries(TensorIterator& iter, bool p2p_enabled) {
 
     size_t element_size = src_tensor.element_size();
     int64_t dim0 = src_tensor.size(0);
-    int64_t dim1 = iter.ndim() == 1 ? 1 : src_tensor.size(1);
+    int64_t dim1 = src_tensor.dim() > 1 ? src_tensor.size(1) : 1; 
     int64_t src_stride0 = src_tensor.stride(0);
-    int64_t src_stride1 = iter.ndim() == 1 ? 1 : src_tensor.stride(1);
+    int64_t src_stride1 = src_tensor.dim() > 1 ? src_tensor.stride(1) : 1; 
     int64_t dst_stride0 = dst_tensor.stride(0);
-    int64_t dst_stride1 = iter.ndim() == 1 ? 1 : dst_tensor.stride(1);
+    int64_t dst_stride1 = dst_tensor.dim() > 1 ? dst_tensor.stride(1) : 1; // proposed fix
 
     // Check for row-major contiguous data
     bool src_row_contiguous = (src_stride1 == 1);

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -324,16 +324,16 @@ static bool copy_requires_temporaries(TensorIterator& iter, bool p2p_enabled) {
   bool broadcast =  broadcast_required(iter.tensor(0), iter.tensor(1));
 
   if (iter.ndim() == 2 && same_dtype && !broadcast && !is_complex) {
-    const auto& src_tensor = iter.tensor(1);
-    const auto& dst_tensor = iter.tensor(0);
+    
+    size_t element_size = iter.tensor(1).element_size();
+    int64_t dim0 = iter.shape()[0];           
+    int64_t dim1 = iter.ndim() > 1 ? iter.shape()[1] : 1; 
 
-    size_t element_size = src_tensor.element_size();
-    int64_t dim0 = src_tensor.size(0);
-    int64_t dim1 = src_tensor.dim() > 1 ? src_tensor.size(1) : 1; 
-    int64_t src_stride0 = src_tensor.stride(0);
-    int64_t src_stride1 = src_tensor.dim() > 1 ? src_tensor.stride(1) : 1; 
-    int64_t dst_stride0 = dst_tensor.stride(0);
-    int64_t dst_stride1 = dst_tensor.dim() > 1 ? dst_tensor.stride(1) : 1; // proposed fix
+    int64_t src_stride0 = iter.strides(1)[0];   
+    int64_t src_stride1 = iter.ndim() > 1 ? iter.strides(1)[1] : 1;  
+
+    int64_t dst_stride0 = iter.strides(0)[0];   
+    int64_t dst_stride1 = iter.ndim() > 1 ? iter.strides(0)[1] : 1;  
 
     // Check for row-major contiguous data
     bool src_row_contiguous = (src_stride1 == 1);

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -319,7 +319,7 @@ static bool copy_requires_temporaries(TensorIterator& iter, bool p2p_enabled) {
   }
 
   bool same_dtype = iter.dtype(0) == iter.dtype(1);
-#ifndef __HIP_PLATFORM_HCC__
+#if defined(__CUDACC__)
   bool is_complex = at::isComplexType(iter.dtype(1));
   bool broadcast =  broadcast_required(iter.tensor(0), iter.tensor(1));
 
@@ -565,7 +565,7 @@ static void copy_kernel_cuda(TensorIterator& iter, bool non_blocking) {
   void* src = iter.data_ptr(1);
   int64_t nbytes = iter.numel() * iter.element_size(0);
   CUDAStream stream = getCurrentCUDAStream();
-#ifndef __HIP_PLATFORM_HCC__
+#if defined(__CUDACC__)
   // Try optimized 1D/2D non-contiguous path first for both blocking and non-blocking
   if (iter.ndim() == 2 && !iter.is_contiguous()) {       
     if (copy_non_contiguous_2d(dst, src, iter, kind, stream, non_blocking)) {

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -319,7 +319,7 @@ static bool copy_requires_temporaries(TensorIterator& iter, bool p2p_enabled) {
   }
 
   bool same_dtype = iter.dtype(0) == iter.dtype(1);
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) && !defined(__HIP__)
   bool is_complex = at::isComplexType(iter.dtype(1));
   bool broadcast =  broadcast_required(iter.tensor(0), iter.tensor(1));
 
@@ -565,7 +565,7 @@ static void copy_kernel_cuda(TensorIterator& iter, bool non_blocking) {
   void* src = iter.data_ptr(1);
   int64_t nbytes = iter.numel() * iter.element_size(0);
   CUDAStream stream = getCurrentCUDAStream();
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) && !defined(__HIP__)
   // Try optimized 1D/2D non-contiguous path first for both blocking and non-blocking
   if (iter.ndim() == 2 && !iter.is_contiguous()) {       
     if (copy_non_contiguous_2d(dst, src, iter, kind, stream, non_blocking)) {

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -324,16 +324,16 @@ static bool copy_requires_temporaries(TensorIterator& iter, bool p2p_enabled) {
   bool broadcast =  broadcast_required(iter.tensor(0), iter.tensor(1));
 
   if (iter.ndim() == 2 && same_dtype && !broadcast && !is_complex) {
-    
+
     size_t element_size = iter.tensor(1).element_size();
-    int64_t dim0 = iter.shape()[0];           
-    int64_t dim1 = iter.ndim() > 1 ? iter.shape()[1] : 1; 
+    int64_t dim0 = iter.shape()[0];
+    int64_t dim1 = iter.ndim() > 1 ? iter.shape()[1] : 1;
 
-    int64_t src_stride0 = iter.strides(1)[0];   
-    int64_t src_stride1 = iter.ndim() > 1 ? iter.strides(1)[1] : 1;  
+    int64_t src_stride0 = iter.strides(1)[0];
+    int64_t src_stride1 = iter.ndim() > 1 ? iter.strides(1)[1] : 1;
 
-    int64_t dst_stride0 = iter.strides(0)[0];   
-    int64_t dst_stride1 = iter.ndim() > 1 ? iter.strides(0)[1] : 1;  
+    int64_t dst_stride0 = iter.strides(0)[0];
+    int64_t dst_stride1 = iter.ndim() > 1 ? iter.strides(0)[1] : 1;
 
     // Check for row-major contiguous data
     bool src_row_contiguous = (src_stride1 == 1);

--- a/c10/cuda/CUDAFunctions.h
+++ b/c10/cuda/CUDAFunctions.h
@@ -97,7 +97,7 @@ C10_CUDA_API void __inline__ memcpy_and_sync(
 #endif
 }
 
-C10_CUDA_API void __inline__ memcpy2d_and_sync(
+C10_CUDA_API void __inline__ memcpy2d_conditional_sync(
     void* dst,
     const void* src,
     size_t src_pitch,
@@ -105,7 +105,8 @@ C10_CUDA_API void __inline__ memcpy2d_and_sync(
     size_t width_in_bytes,
     size_t height,
     cudaMemcpyKind kind,
-    cudaStream_t stream) {
+    cudaStream_t stream,
+    bool non_blocking = false) {
 
   if (C10_UNLIKELY(
           warning_state().get_sync_debug_mode() != SyncDebugMode::L_DISABLED)) {
@@ -120,7 +121,9 @@ C10_CUDA_API void __inline__ memcpy2d_and_sync(
 
   C10_CUDA_CHECK(cudaMemcpy2DAsync(dst, dst_pitch, src, src_pitch, width_in_bytes, height, kind, stream));
 
-  C10_CUDA_CHECK(cudaStreamSynchronize(stream));
+  if (!non_blocking) {
+    C10_CUDA_CHECK(cudaStreamSynchronize(stream));
+  }
 }
 
 C10_CUDA_API void __inline__ stream_synchronize(cudaStream_t stream) {

--- a/c10/cuda/CUDAFunctions.h
+++ b/c10/cuda/CUDAFunctions.h
@@ -97,6 +97,31 @@ C10_CUDA_API void __inline__ memcpy_and_sync(
 #endif
 }
 
+C10_CUDA_API void __inline__ memcpy2d_and_sync(
+    void* dst,
+    const void* src,
+    size_t src_pitch,
+    size_t dst_pitch,
+    size_t width_in_bytes,
+    size_t height,
+    cudaMemcpyKind kind,
+    cudaStream_t stream) {
+
+  if (C10_UNLIKELY(warning_state().get_sync_debug_mode() != SyncDebugMode::L_DISABLED)) {
+    warn_or_error_on_sync();
+  }
+
+  const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
+  if (C10_UNLIKELY(interp)) {
+    (*interp)->trace_gpu_stream_synchronization(
+        c10::kCUDA, reinterpret_cast<uintptr_t>(stream));
+  }
+
+  C10_CUDA_CHECK(cudaMemcpy2DAsync(dst, dst_pitch, src, src_pitch, width_in_bytes, height, kind, stream));
+
+  C10_CUDA_CHECK(cudaStreamSynchronize(stream));
+}
+
 C10_CUDA_API void __inline__ stream_synchronize(cudaStream_t stream) {
   if (C10_UNLIKELY(
           warning_state().get_sync_debug_mode() != SyncDebugMode::L_DISABLED)) {

--- a/c10/cuda/CUDAFunctions.h
+++ b/c10/cuda/CUDAFunctions.h
@@ -107,7 +107,8 @@ C10_CUDA_API void __inline__ memcpy2d_and_sync(
     cudaMemcpyKind kind,
     cudaStream_t stream) {
 
-  if (C10_UNLIKELY(warning_state().get_sync_debug_mode() != SyncDebugMode::L_DISABLED)) {
+  if (C10_UNLIKELY(
+          warning_state().get_sync_debug_mode() != SyncDebugMode::L_DISABLED)) {
     warn_or_error_on_sync();
   }
 

--- a/c10/cuda/CUDAFunctions.h
+++ b/c10/cuda/CUDAFunctions.h
@@ -107,7 +107,6 @@ C10_CUDA_API void __inline__ memcpy2d_conditional_sync(
     cudaMemcpyKind kind,
     cudaStream_t stream,
     bool non_blocking = false) {
-
   if (C10_UNLIKELY(
           warning_state().get_sync_debug_mode() != SyncDebugMode::L_DISABLED)) {
     warn_or_error_on_sync();
@@ -119,7 +118,8 @@ C10_CUDA_API void __inline__ memcpy2d_conditional_sync(
         c10::kCUDA, reinterpret_cast<uintptr_t>(stream));
   }
 
-  C10_CUDA_CHECK(cudaMemcpy2DAsync(dst, dst_pitch, src, src_pitch, width_in_bytes, height, kind, stream));
+  C10_CUDA_CHECK(cudaMemcpy2DAsync(
+      dst, dst_pitch, src, src_pitch, width_in_bytes, height, kind, stream));
 
   if (!non_blocking) {
     C10_CUDA_CHECK(cudaStreamSynchronize(stream));

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3492,8 +3492,7 @@ print(ret)
         self._test_copy(x, non_blocking=False)
 
         # Non-contiguous 1D tensor using a Fortran-ordered NumPy array
-        fortran_arr = np.asfortranarray(np.ones(10000000, dtype=np.uint8))
-        x = torch.from_numpy(fortran_arr[::2])  # Slice to make it non-contiguous
+x=torch.ones(1000000, dtype=torch.uint8)[::2]
         self.assertFalse(x.is_contiguous())
         self._test_copy(x, non_blocking=True)
         self._test_copy(x, non_blocking=False)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1,3 +1,4 @@
+# Owner(s): ["module: cuda"]
 import contextlib
 import ctypes
 import gc

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3505,8 +3505,7 @@ x=torch.ones(1000000, dtype=torch.uint8)[::2]
         self._test_copy(x, non_blocking=False)
 
         # Non-contiguous 2D tensor using Fortran-ordered array
-        fortran_arr = np.asfortranarray(np.random.randn(rows, cols).astype(np.float32))
-        x = torch.from_numpy(fortran_arr)
+        x = torch.rand(rows, cols).t()
         
         self.assertFalse(x.is_contiguous())
         self._test_copy(x, non_blocking=True)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1,7 +1,3 @@
-# Owner(s): ["module: cuda"]
-# ruff: noqa: F841
-
-import numpy as np
 import contextlib
 import ctypes
 import gc
@@ -3484,29 +3480,26 @@ print(ret)
             event.synchronize()
 
         self.assertEqual(x, x_gpu.cpu())
-    
+
     def test_1d_copy(self):
         # Contiguous 1D tensor
         x = torch.ones(10000000, dtype=torch.uint8)
         self._test_copy(x, non_blocking=True)
         self._test_copy(x, non_blocking=False)
-
-        # Non-contiguous 1D tensor using a Fortran-ordered NumPy array
-        x=torch.ones(1000000, dtype=torch.uint8)[::2]
+        # Discontiguous 1D tensor
+        x = torch.ones(1000000, dtype=torch.uint8)[::2]
         self.assertFalse(x.is_contiguous())
         self._test_copy(x, non_blocking=True)
         self._test_copy(x, non_blocking=False)
-   
+
     def test_2d_copy(self):
         rows, cols = 1000, 1000
         # Contiguous 2D tensor
         x = torch.ones((rows, cols), dtype=torch.float32)
         self._test_copy(x, non_blocking=True)
         self._test_copy(x, non_blocking=False)
-
-        # Non-contiguous 2D tensor using Fortran-ordered array
-        x = torch.rand(rows, cols).t()
-        
+        # Discontiguous 2D tensor
+        x = torch.randn(rows, cols)[:, :512]
         self.assertFalse(x.is_contiguous())
         self._test_copy(x, non_blocking=True)
         self._test_copy(x, non_blocking=False)
@@ -4543,7 +4536,7 @@ class TestBlockStateAbsorption(TestCase):
         for i in range(len(reconstructed_tensors)):
             self.assertEqual(reconstructed_tensors[i].mean(dtype=torch.float), 2)
 
-        inp.add_(1)
+        isadd_(1)
         graph.replay()
 
         for i in range(len(reconstructed_tensors)):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: cuda"]
 # ruff: noqa: F841
 
+import numpy as np
 import contextlib
 import ctypes
 import gc
@@ -3473,6 +3474,44 @@ print(ret)
             .strip()
         )
         self.assertEqual(r, "1.0")
+    def _test_copy(self, x, non_blocking):
+        # Perform the copy operation, either blocking or non-blocking
+        event = torch.cuda.Event()
+        x_gpu = x.to(device="cuda", non_blocking=non_blocking)
+        event.record()
+
+        if non_blocking:
+            event.synchronize()
+
+        self.assertEqual(x, x_gpu.cpu())
+    
+    def test_1d_copy(self):
+        # Contiguous 1D tensor
+        x = torch.ones(10000000, dtype=torch.uint8)
+        self._test_copy(x, non_blocking=True)
+        self._test_copy(x, non_blocking=False)
+
+        # Non-contiguous 1D tensor using a Fortran-ordered NumPy array
+        fortran_arr = np.asfortranarray(np.ones(10000000, dtype=np.uint8))
+        x = torch.from_numpy(fortran_arr[::2])  # Slice to make it non-contiguous
+        self.assertFalse(x.is_contiguous())
+        self._test_copy(x, non_blocking=True)
+        self._test_copy(x, non_blocking=False)
+   
+    def test_2d_copy(self):
+        rows, cols = 1000, 1000
+        # Contiguous 2D tensor
+        x = torch.ones((rows, cols), dtype=torch.float32)
+        self._test_copy(x, non_blocking=True)
+        self._test_copy(x, non_blocking=False)
+
+        # Non-contiguous 2D tensor using Fortran-ordered array
+        fortran_arr = np.asfortranarray(np.random.randn(rows, cols).astype(np.float32))
+        x = torch.from_numpy(fortran_arr)
+        
+        self.assertFalse(x.is_contiguous())
+        self._test_copy(x, non_blocking=True)
+        self._test_copy(x, non_blocking=False)
 
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -138,7 +138,7 @@ class TestCuda(TestCase):
                 self.assertTrue(pinned_t.is_pinned())
                 pinned_t = torch.ones(1 << 24).pin_memory()
                 self.assertTrue(pinned_t.is_pinned())
-            except RuntimeError as e:
+            except RuntimeError:
                 # Some GPUs don't support same address space on host and device side
                 pass
         finally:
@@ -168,7 +168,7 @@ class TestCuda(TestCase):
                     self.assertTrue(t.is_pinned())
                     del t
                     torch._C._host_emptyCache()
-                except RuntimeError as e:
+                except RuntimeError:
                     # Some GPUs don't support same address space on host and device side
                     pass
         finally:
@@ -3471,6 +3471,7 @@ print(ret)
             .strip()
         )
         self.assertEqual(r, "1.0")
+
     def _test_copy(self, x, non_blocking):
         # Perform the copy operation, either blocking or non-blocking
         event = torch.cuda.Event()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4537,7 +4537,7 @@ class TestBlockStateAbsorption(TestCase):
         for i in range(len(reconstructed_tensors)):
             self.assertEqual(reconstructed_tensors[i].mean(dtype=torch.float), 2)
 
-        isadd_(1)
+        inp.add_(1)
         graph.replay()
 
         for i in range(len(reconstructed_tensors)):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3492,7 +3492,7 @@ print(ret)
         self._test_copy(x, non_blocking=False)
 
         # Non-contiguous 1D tensor using a Fortran-ordered NumPy array
-x=torch.ones(1000000, dtype=torch.uint8)[::2]
+        x=torch.ones(1000000, dtype=torch.uint8)[::2]
         self.assertFalse(x.is_contiguous())
         self._test_copy(x, non_blocking=True)
         self._test_copy(x, non_blocking=False)


### PR DESCRIPTION
### **Pull Request: Optimized Non-Contiguous Tensor Copy for CPU to GPU in PyTorch**

#### **Summary**
This PR addresses the performance issue identified in [#111570](https://github.com/pytorch/pytorch/issues/111570), where non-contiguous tensors took significantly longer to transfer from CPU to GPU. Through detailed tracing of the call flow, we identified that PyTorch was creating temporary contiguous buffers for non-contiguous tensor transfers, which introduced unnecessary overhead.

#### **Tracing the Issue**
To pinpoint the cause of the slowdown, we followed the call flow from Python’s `tensor.cuda()` method through PyTorch’s backend, ultimately identifying `copy_kernel_cuda` as the key function responsible for CPU-to-GPU tensor transfers. Here’s a summary of the tracing process:

1. **Python Call: `tensor.cuda()`**
   - Starting from Python, the `cuda()` method initiates the tensor transfer to the GPU.

2. **`TensorBody.h: cuda()`**
   - The `cuda()` method calls `to()`, specifying the target device as CUDA.

3. **`Tensor.cpp: TensorBase::to()`**
   - The `to()` function prepares device and data type options before invoking `_ops::to_dtype_layout::call()`.

4. **Operator Call: `_ops::to_dtype_layout::call()`**
   - This operator dispatches the request to the backend-specific function responsible for managing the transfer.

5. **`Copy.cpp: copy_()`**
   - The `copy_()` function performs preliminary checks (e.g., zero-tensor immutability) and proceeds to call `copy_impl()`.

6. **`Copy.cpp: copy_impl()`**
   - This function sets up a tensor iterator and dispatches the copy operation to the appropriate backend through `copy_stub`.

7. **Dispatch to CUDA: `copy_stub`**
   - The dispatch mechanism routes the call to the CUDA-specific function, `copy_kernel_cuda`.

8. **`Copy.cu: copy_kernel_cuda()`**
   - Here, we identified that PyTorch was creating temporary contiguous buffers for 1D and 2D non-contiguous tensors, which slowed down the copy process. This behavior is managed by the `copy_requires_temporaries()` function.

#### **Solution**
To address this, we modified `copy_kernel_cuda` to handle non-contiguous 1D and 2D tensors directly by using `cudaMemcpy2DAsync`, which allows efficient, stride-aware memory transfers without temporary buffers. Here’s why this approach improves performance:

- **Efficiency of `cudaMemcpy2DAsync`**: This CUDA function is optimized for pitched (stride-based) memory transfers, allowing it to handle non-contiguous data layouts effectively by specifying memory strides for source and destination tensors.
- **Reduction of Overhead**: By directly copying non-contiguous tensors without intermediate buffers, we eliminate extra memory allocation and achieve faster CPU-to-GPU transfers.
- **Asynchronous Execution**: `cudaMemcpy2DAsync` enables asynchronous transfer on the CUDA stream, further improving performance by taking advantage of CUDA's optimized memory handling for non-contiguous layouts.

#### **Performance Results**

In my testing, I created tensors of size `327680 x 2000` and used slices for transfer performance measurements. The tests show that the average time for transferring a non-contiguous slice (e.g., rows 10,000 to 50,000) from CPU to GPU now closely matches the contiguous case. This improvement indicates that the updated implementation effectively addresses the performance discrepancy. Below are the measured times and validation checks:

```plaintext
Average time for contiguous slice (rows 10,000-50,000): 66 ms
Average time for non-contiguous slice (rows 10,000-50,000): 66 ms

Validation of contiguous and non-contiguous tensor copies:
✅ PASS: Tensor shapes match.
✅ PASS: Tensor contiguity matches.
✅ PASS: Tensor contents match.
✅ PASS: Tensor data types match.

✅ Success: Both contiguous and non-contiguous tensors were copied correctly to the GPU.
```


#### **Conclusion**
This PR resolves the identified performance issue by eliminating the need for temporary buffers in non-contiguous 1D and 2D tensor transfers, ensuring faster and more efficient copies from CPU to GPU. Future optimizations could further enhance performance for higher-dimensional non-contiguous tensors.
