### PR TITLE
Expliclty avoid recording when should_record_events is false in record_shapeenv_event

### DIFF
--- a/torch/fx/experimental/recording.py
+++ b/torch/fx/experimental/recording.py
@@ -253,7 +253,8 @@ def record_shapeenv_event(*, save_tracked_fakes: bool = False) -> Callable:
                 return r
 
             try:
-                if args[0].is_recording:  # type: ignore[has-type]
+                shape_env = args[0]
+                if not shape_env.should_record_events or shape_env.is_recording:  # type: ignore[has-type]
                     # If ShapeEnv is already recording an event, call the wrapped
                     # function directly.
                     #

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2910,7 +2910,7 @@ class ShapeEnv:
         )
 
         # This will make sure we only record the top-level function call.
-        self.is_recording = not self.should_record_events
+        self.is_recording = False
         # Keep track of the list of tracked fakes.
         self.tracked_fakes = tracked_fakes
         # List of events for reconstructing ShapeEnv at arbitrary points in time.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #138965
* #138804

Looking at the function record_shapeenv_event its hard to tell that it does not always run
but we do disable it by setting top level is_recording to True self.should_record_events is false
this makes it more explicit to avoid confusion and overloading is_recording.

alternativley we can rename is_recording to do_no_record.
cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv