### PR TITLE
Revert "[dynamo] Simplify creation of VariableTrackers (#135714)"

### DIFF
--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -601,20 +601,6 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
         compl_fn = torch.compile(fn, dynamic=True, backend="eager")
         self.assertEqual(compl_fn(inputs), fn(inputs))
 
-    @torch._dynamo.config.patch(specialize_float=False)
-    def test_unspec_roundtrip_float_input(self):
-        def f(x, y):
-            if y == 5.0:
-                return x + 2
-            else:
-                return x + y
-            return (x, y)
-
-        cf = torch.compile(backend="eager", fullgraph=True)(f)
-        x = 1.1234567891234568
-        y = 1.1234567891234569
-        self.assertAlmostEqual(f(x, y), cf(x, y))
-
     @torch._dynamo.config.patch(specialize_float=False, assume_static_by_default=True)
     def test_unspec_float_input(self):
         cnts = torch._dynamo.testing.CompileCounter()

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -185,9 +185,7 @@ class PyCodegen:
             # NB: It works to add_graph_output on a computed expression
             # as_tensor here, because we memoize as_tensor calls on
             # SymNodeVariable!
-            graph_outputs_key = self.add_graph_output(
-                value.as_tensor(self.tx, torch.float64)
-            )
+            graph_outputs_key = self.add_graph_output(value.as_tensor(self.tx))
 
             def gen_fn():
                 self.load_graph_output(graph_outputs[graph_outputs_key].index)

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -91,6 +91,7 @@ from .variables.builder import (
     BackwardStateGraphArg,
     GraphArg,
     TrackedFake,
+    VariableBuilder,
     wrap_fx_proxy,
 )
 from .variables.lists import BaseListVariable
@@ -497,7 +498,7 @@ class OutputGraph:
         cg.store(varname)
         self.pregraph_bytecode.extend(cg.get_instructions())
         source = SyntheticLocalSource(varname)
-        result = VariableTracker.build(self.root_tx, example_value, source)
+        result = VariableBuilder(self.root_tx, source)(example_value)
         TracingContext.get().guards_context.dynamo_guards.remove_guards_with_source(
             source
         )
@@ -766,8 +767,8 @@ class OutputGraph:
     ):
         if is_dynamic_nn_module(target, self.root_tx.export):
             # Instead of returning UnspecializedNNModuleVariable, call
-            # VariableTracker.build so that it is tracked for mutation.
-            return VariableTracker.build(self.current_tx, target, **options)
+            # VariableBuilder so that it is tracked for mutation.
+            return VariableBuilder(self.current_tx, **options)(target)
 
         options = dict(options)
         assert "source" in options
@@ -859,8 +860,8 @@ class OutputGraph:
             def wrap_name(module_key):
                 self.output.update_co_names(module_key)
                 self.global_scope[module_key] = target
-                return VariableTracker.build(
-                    self, target, ConstantSource(source_name=module_key)
+                return VariableBuilder(self, ConstantSource(source_name=module_key))(
+                    target
                 )
 
         for k, v in self.nn_modules.items():

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -809,7 +809,7 @@ class InstructionTranslatorBase(
 
         cur_offset = self.current_instruction.offset
         assert self.instruction_pointer is not None
-        for inst in self.instructions[self.instruction_pointer:]:
+        for inst in self.instructions[self.instruction_pointer :]:
             if inst.opname in ("RETURN_VALUE", "RETURN_CONST"):
                 return False
             if inst.opname in JUMP_OPNAMES:
@@ -1818,7 +1818,7 @@ class InstructionTranslatorBase(
         fn = self.pop()
         assert isinstance(argnames, TupleVariable) and argnames.is_python_constant()
         argnames = argnames.as_python_constant()
-        args, kwargs_list = args[: -len(argnames)], args[-len(argnames):]
+        args, kwargs_list = args[: -len(argnames)], args[-len(argnames) :]
         kwargs = dict(zip(argnames, kwargs_list))
         assert len(kwargs) == len(argnames)
         self.call_function(fn, args, kwargs)
@@ -1942,7 +1942,7 @@ class InstructionTranslatorBase(
     def BUILD_TUPLE(self, inst):
         name_tuple = None
         if sys.version_info >= (3, 13):
-            name_tuple = tuple(self.name_stack[-inst.argval:])
+            name_tuple = tuple(self.name_stack[-inst.argval :])
         items = self.popn(inst.argval)
         self.push(TupleVariable(items), name=name_tuple)
 
@@ -2112,8 +2112,8 @@ class InstructionTranslatorBase(
             vals = list(seq.force_unpack_var_sequence(self))
             assert len(vals) >= prefix + suffix
             vals_prefix = vals[:prefix]
-            vals_list = vals[prefix: len(vals) - suffix]
-            vals_suffix = vals[len(vals) - suffix:]
+            vals_list = vals[prefix : len(vals) - suffix]
+            vals_suffix = vals[len(vals) - suffix :]
             for item in reversed(vals_suffix):
                 self.push(item)
             self.push(TupleVariable(vals_list))
@@ -2395,8 +2395,8 @@ class InstructionTranslatorBase(
                 args = [contents[1]]
 
         if kw_names:
-            args = args + contents[2: -len(kw_names)]
-            kwargs_list = contents[-len(kw_names):]
+            args = args + contents[2 : -len(kw_names)]
+            kwargs_list = contents[-len(kw_names) :]
             kwargs = dict(zip(kw_names, kwargs_list))
             assert len(kwargs) == len(kw_names)
         else:
@@ -3413,7 +3413,11 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             module_source = self.import_source(module_name)
             if "torch_package" in module_name:
                 # type: ignore[assignment]
-                fglobals_value = torch.package.package_importer._package_imported_modules[module_name]
+                fglobals_value = (
+                    torch.package.package_importer._package_imported_modules[
+                        module_name
+                    ]
+                )
             else:
                 fglobals_value = importlib.import_module(module_name)  # type: ignore[assignment]
             fglobals_vt = VariableBuilder(self, module_source)(fglobals_value)

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -12,7 +12,7 @@ from ..utils import istype
 
 
 if TYPE_CHECKING:
-    from .symbolic_convert import InstructionTranslator, InstructionTranslatorBase
+    from torch._dynamo.symbolic_convert import InstructionTranslator
 
 
 class MutableLocalSource(Enum):
@@ -121,8 +121,6 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     VariableTracker instances are immutable and should be copied in
     order to change them.
-
-    Prefer the factory function VariableTracker.build() over VariableTracker.__init__().
     """
 
     # fields to leave unmodified in apply()
@@ -246,7 +244,9 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         value = self.const_getattr(tx, name)
         if not variables.ConstantVariable.is_literal(value):
             raise NotImplementedError
-        source = self.source and AttrSource(self.source, name)
+        source = None
+        if self.source:
+            source = AttrSource(self.source, name)
         return variables.ConstantVariable.create(value, source=source)
 
     def is_proxy(self):
@@ -362,20 +362,6 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def is_strict_mode(self, tx):
         return tx.strict_checks_fn and tx.strict_checks_fn(self)
-
-    @staticmethod
-    def build(
-        tx: "InstructionTranslatorBase",
-        value: Any,
-        source: Optional[Source] = None,
-    ) -> Any:
-        """Create a new VariableTracker from a value and optional Source"""
-        from . import builder
-
-        if source is None:
-            return builder.SourcelessBuilder.create(tx, value)
-        else:
-            return builder.VariableBuilder(tx, source)(value)
 
     def __init__(
         self,

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -984,10 +984,12 @@ class HFPretrainedConfigVariable(VariableTracker):
         assert self.is_matching_cls(type(obj))
 
     def var_getattr(self, tx: "InstructionTranslator", name: str) -> "VariableTracker":
+        from .builder import VariableBuilder
+
         try:
             attr_value = getattr(self.obj, name)
-            source = self.source and AttrSource(self.source, name)
-            return VariableTracker.build(tx, attr_value, source)
+            attr_source = AttrSource(self.source, name)
+            return VariableBuilder(tx, attr_source)(attr_value)
 
         except AttributeError:
             unimplemented(f"getattr({self.value}, {name})")
@@ -1051,11 +1053,15 @@ class PythonSysModulesVariable(VariableTracker):
         key: VariableTracker,
         default: Optional[VariableTracker] = None,
     ):
+        from .builder import VariableBuilder
+
         k, has_key = self._contains_helper(tx, key)
 
         if has_key:
-            source = self.source and GetItemSource(self.source, k)
-            return VariableTracker.build(tx, sys.modules[k], source)
+            return VariableBuilder(
+                tx,
+                GetItemSource(self.source, k),
+            )(sys.modules[k])
 
         if default is not None:
             return default
@@ -1063,6 +1069,10 @@ class PythonSysModulesVariable(VariableTracker):
         return ConstantVariable.create(value=None)
 
     def call_getitem(self, tx: "InstructionTranslator", key: VariableTracker):
+        from .builder import VariableBuilder
+
         k, has_key = self._contains_helper(tx, key)
-        source = self.source and GetItemSource(self.source, k)
-        return VariableTracker.build(tx, sys.modules[k], source)
+        return VariableBuilder(
+            tx,
+            GetItemSource(self.source, k),
+        )(sys.modules[k])

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -1,9 +1,5 @@
 # mypy: ignore-errors
 
-from torch._higher_order_ops.triton_kernel_wrap import (
-    TMADescriptorMetadata,
-    TritonHOPifier,
-)
 import builtins
 import collections
 import functools
@@ -24,6 +20,10 @@ from typing import (
 from typing_extensions import Never
 
 import torch
+from torch._higher_order_ops.triton_kernel_wrap import (
+    TMADescriptorMetadata,
+    TritonHOPifier,
+)
 
 from .. import polyfills, variables
 from ..bytecode_transformation import create_call_function, create_rot_n
@@ -1068,6 +1068,7 @@ class PolyfilledFunctionVariable(VariableTracker):
             )
 
         from torch._dynamo.variables.builder import SourcelessBuilder
+
         traceable_function_variable = SourcelessBuilder.create(tx, self.traceable_fn)
 
         return traceable_function_variable.call_function(tx, args, kwargs)

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -172,8 +172,10 @@ class ItertoolsVariable(VariableTracker):
                     *args, mutable_local=MutableLocal()
                 )
 
+            from .builder import SourcelessBuilder
+
             return tx.inline_user_function_return(
-                VariableTracker.build(tx, polyfills.repeat), args, kwargs
+                SourcelessBuilder.create(tx, polyfills.repeat), args, kwargs
             )
         elif self.value is itertools.count:
             return variables.CountIteratorVariable(*args, mutable_local=MutableLocal())

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -20,15 +20,14 @@ class LazyCache:
     def realize(self) -> None:
         assert self.vt is None
         from ..symbolic_convert import InstructionTranslator
+        from .builder import SourcelessBuilder, VariableBuilder
 
         tx = InstructionTranslator.current_tx()
-
         if isinstance(self.value, LazySymNodeFormatString):
-            source = None
+            self.vt = SourcelessBuilder.create(tx, self.value)
         else:
-            source = self.source
+            self.vt = VariableBuilder(tx, self.source)(self.value)
 
-        self.vt = VariableTracker.build(tx, self.value, source)
         del self.value
         del self.source
 
@@ -38,7 +37,7 @@ class LazyVariableTracker(VariableTracker):
     A structure that defers the creation of the actual VariableTracker
     for a given underlying value until it is accessed.
 
-    The `realize` function invokes VariableTracker.build() to produce the real object.
+    The `realize` function invokes VariableBuilder to produce the real object.
     Once a LazyVariableTracker has been realized, internal bookkeeping will
     prevent double realization.
 

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -135,8 +135,10 @@ class BaseListVariable(VariableTracker):
             assert not kwargs
             return iter_contains(self.unpack_var_sequence(tx), args[0], tx)
         elif name == "index":
+            from .builder import SourcelessBuilder
+
             return tx.inline_user_function_return(
-                VariableTracker.build(tx, polyfills.index),
+                SourcelessBuilder.create(tx, polyfills.index),
                 [self] + list(args),
                 kwargs,
             )

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -207,10 +207,12 @@ class SuperVariable(VariableTracker):
             and len(kwargs) == 0
             and args[0].is_python_constant()
         ):
+            from .builder import VariableBuilder
+
             key = args[0].as_python_constant()
-            value = collections.OrderedDict.__getitem__(self.objvar.value, key)
-            source = ODictGetItemSource(self.objvar.source, key)
-            return VariableTracker.build(tx, value, source)
+            return VariableBuilder(tx, ODictGetItemSource(self.objvar.source, key))(
+                collections.OrderedDict.__getitem__(self.objvar.value, key)
+            )
         elif inner_fn in (
             collections.OrderedDict.__setitem__,
             object.__setattr__,
@@ -465,10 +467,15 @@ class InspectParameterVariable(VariableTracker):
         self.value = value
 
     def var_getattr(self, tx: "InstructionTranslator", name: str) -> "VariableTracker":
+        from .builder import SourcelessBuilder, VariableBuilder
+
         try:
             attr_value = getattr(self.value, name)
-            source = self.source and AttrSource(self.source, name)
-            return VariableTracker.build(tx, attr_value, source)
+            if self.source:
+                attr_source = AttrSource(self.source, name)
+                return VariableBuilder(tx, attr_source)(attr_value)
+            else:
+                return SourcelessBuilder.create(tx, attr_value)
         except AttributeError:
             unimplemented(f"getattr({self.value}, {name})")
 
@@ -902,9 +909,11 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
             if self.needs_input_grad is not None:
                 return variables.ConstantVariable.create(self.needs_input_grad)
             if self.source:
-                source = AttrSource(self.source, "needs_input_grad")
-                return VariableTracker.build(tx, self.value.needs_input_grad, source)
+                from .builder import VariableBuilder
 
+                return VariableBuilder(tx, AttrSource(self.source, "needs_input_grad"))(
+                    self.value.needs_input_grad
+                )
         return super().var_getattr(tx, name)
 
 
@@ -1109,8 +1118,11 @@ class GetSetDescriptorVariable(VariableTracker):
 
     def var_getattr(self, tx: "InstructionTranslator", name):
         if name == "__get__" and self.source:
-            source = AttrSource(self.source, "__get__")
-            return VariableTracker.build(tx, self.desc.__get__, source)
+            from .builder import VariableBuilder
+
+            return VariableBuilder(tx, AttrSource(self.source, "__get__"))(
+                self.desc.__get__
+            )
         else:
             return super().var_getattr(tx, name)
 
@@ -1150,13 +1162,18 @@ class PythonModuleVariable(VariableTracker):
         if tx.output.side_effects.has_pending_mutation_of_attr(self, name):
             return tx.output.side_effects.load_attr(self, name)
 
+        from .builder import SourcelessBuilder, VariableBuilder
+
         if self.is_torch or name not in self.value.__dict__:
             attr_value = getattr(self.value, name)
         else:
             attr_value = self.value.__dict__[name]
 
-        source = self.source and AttrSource(self.source, name)
-        return VariableTracker.build(tx, attr_value, source)
+        if self.source:
+            new_source = AttrSource(self.source, name)
+            return VariableBuilder(tx, new_source)(attr_value)
+        else:
+            return SourcelessBuilder.create(tx, attr_value)
 
 
 class TypingVariable(VariableTracker):

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -246,7 +246,12 @@ class NNModuleVariable(VariableTracker):
         )
 
     def var_getattr(self, tx: "InstructionTranslator", name):
-        source = self.source and AttrSource(self.source, name)
+        from .builder import VariableBuilder
+
+        if self.source:
+            source = AttrSource(self.source, name)
+        else:
+            source = None
 
         base = tx.output.get_submodule(self.module_key)
         base_dict = object.__getattribute__(base, "__dict__")
@@ -294,7 +299,7 @@ class NNModuleVariable(VariableTracker):
             return variables.UserDefinedClassVariable(base.__class__, source=source)
 
         if object_member:
-            out = VariableTracker.build(tx, subobj, NNModuleSource(source))
+            out = VariableBuilder(tx, NNModuleSource(source))(subobj)
 
             if isinstance(out, (NNModuleVariable, UnspecializedNNModuleVariable)):
                 # nn_module_stack source is BC surface area. Ensure that
@@ -330,7 +335,7 @@ class NNModuleVariable(VariableTracker):
                 return variables.UserMethodVariable(subobj, self, source=source)
             elif is_safe_constant(subobj) or istensor(subobj):
                 # Support possibly common cases of class members
-                return VariableTracker.build(tx, subobj, NNModuleSource(source))
+                return VariableBuilder(tx, NNModuleSource(source))(subobj)
             else:
                 unimplemented(
                     f"class property {name} - {typestr(base)} {typestr(subobj)}"
@@ -1094,7 +1099,7 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
                         )
                     return variables.ConstDictVariable({})
 
-        # For non-empty hook dicts, one way is to just fallback to VariableTracker.build() and create a ConstDictVariable.
+        # For non-empty hook dicts, one way is to just fallback to VariableBuilder and create a ConstDictVariable.
         # However, ConstDictVariable guards on keys. This can cause recompiles when the same hook is installed for
         # differnt nn module instances, because the key keeps changing (look more into RemovableHandle to understand why
         # key changes - also related https://github.com/pytorch/pytorch/issues/125836). Here, we carefully craft a

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -17,7 +17,6 @@ from ..source import (
     GradSource,
 )
 from ..utils import GLOBAL_KEY_PREFIX
-from .base import VariableTracker
 from .constant import ConstantVariable
 from .dicts import ConstDictVariable
 from .lists import ListVariable
@@ -27,6 +26,8 @@ from .user_defined import UserDefinedObjectVariable
 
 if TYPE_CHECKING:
     from torch._dynamo.symbolic_convert import InstructionTranslator
+
+    from .base import VariableTracker
 
 
 class ArgMappingException(Exception):
@@ -146,6 +147,7 @@ class OptimizerVariable(UserDefinedObjectVariable):
 
     def _set_capturable(self, tx):
         from . import LazyVariableTracker
+        from .builder import VariableBuilder
 
         # We only set capturable if params are on cuda
         # and the state is not initialized
@@ -166,9 +168,10 @@ class OptimizerVariable(UserDefinedObjectVariable):
             if safe_to_set_capturable(group):
                 group["capturable"] = True
 
-        source = self.source and AttrSource(self.source, "param_groups")
         param_groups_vt = LazyVariableTracker.realize_all(
-            VariableTracker.build(tx, self.value.param_groups, source)
+            VariableBuilder(tx, AttrSource(self.source, "param_groups"))(
+                self.value.param_groups
+            )
         )
         for ind, param_group_vt in enumerate(param_groups_vt.items):
             key = ConstDictVariable._HashableTracker(
@@ -211,6 +214,7 @@ class OptimizerVariable(UserDefinedObjectVariable):
 
     def map_sources_and_install_guards(self, tx):
         from ..decorators import mark_static_address
+        from .builder import VariableBuilder
         from .lazy import LazyVariableTracker
 
         self.grad_to_source = {}
@@ -231,13 +235,15 @@ class OptimizerVariable(UserDefinedObjectVariable):
 
         # Recursively realize the variable trackers for optim.state and
         # optim.param_groups, which recursively install the necessary guards.
-        params_groups_source = self.source and AttrSource(self.source, "param_groups")
         param_groups_vt = LazyVariableTracker.realize_all(
-            VariableTracker.build(tx, self.value.param_groups, params_groups_source)
+            VariableBuilder(tx, AttrSource(self.source, "param_groups"))(
+                self.value.param_groups
+            )
         )
 
-        state_source = self.source and AttrSource(self.source, "state")
-        state_vt = VariableTracker.build(tx, self.value.state, state_source)
+        state_vt = VariableBuilder(tx, AttrSource(self.source, "state"))(
+            self.value.state
+        )
 
         # We need to realize the top level state dict to populate
         # the guard locals
@@ -259,15 +265,15 @@ class OptimizerVariable(UserDefinedObjectVariable):
                                 key_index = i
                                 break
                         if key_index:
+                            state_source = AttrSource(self.source, "state")
                             LazyVariableTracker.realize_all(
-                                VariableTracker.build(
+                                VariableBuilder(
                                     tx,
-                                    self.value.state[param],
                                     GetItemSource(
                                         state_source,
                                         ConstDictKeySource(state_source, key_index),
                                     ),
-                                )
+                                )(self.value.state[param])
                             )
                             break
 
@@ -306,6 +312,7 @@ class OptimizerVariable(UserDefinedObjectVariable):
 
         # We have to again iterate over the state dict to collect the
         # tensor_to_source dict. This is used for the finalizer.
+        state_source = AttrSource(self.source, "state")
         for idx, (p, value) in enumerate(self.value.state.items()):
             p_state_source = GetItemSource(
                 state_source, ConstDictKeySource(state_source, idx)
@@ -321,6 +328,7 @@ class OptimizerVariable(UserDefinedObjectVariable):
     def wrap_tensor(self, tx: "InstructionTranslator", tensor_value):
         """Wrap state tensor in a TensorVariable"""
         from ..decorators import mark_static_address
+        from .builder import VariableBuilder
 
         # If we have a source for a tensor already use it,
         # if we have not seen a tensor before, stash and use a
@@ -330,19 +338,20 @@ class OptimizerVariable(UserDefinedObjectVariable):
         if tensor_value in self.tensor_to_source:
             # mark these tensors as static for cudagraphs
             mark_static_address(tensor_value)
-            source = self.tensor_to_source[tensor_value]
-            self.static_tensor_names.add(tx.output.module_key_name(source.name))
+            builder = VariableBuilder(tx, self.tensor_to_source[tensor_value])
+            self.static_tensor_names.add(tx.output.module_key_name(builder.name))
         elif tensor_value in self.grad_to_source:
-            source = self.grad_to_source[tensor_value]
+            builder = VariableBuilder(tx, self.grad_to_source[tensor_value])
         else:
             # mark these tensors as static for cudagraphs
             mark_static_address(tensor_value)
 
             global_name = tx.store_global_weakref_by_id(GLOBAL_KEY_PREFIX, tensor_value)
-            source = GlobalWeakRefSource(global_name)
-            self.static_tensor_names.add(tx.output.module_key_name(source.name))
+            builder = VariableBuilder(tx, GlobalWeakRefSource(global_name))
+            self.static_tensor_names.add(tx.output.module_key_name(builder.name))
 
-        return VariableTracker.build(tx, tensor_value, source)
+        result = builder(tensor_value)
+        return result
 
     def update_list_args(
         self, tx: "InstructionTranslator", args, kwargs, py_args, py_kwargs
@@ -358,8 +367,14 @@ class OptimizerVariable(UserDefinedObjectVariable):
                     if isinstance(val, torch.Tensor):
                         arg.items.append(self.wrap_tensor(tx, val))
                     else:
-                        source = arg.source and GetItemSource(arg.source, i)
-                        arg.items.append(VariableTracker.build(tx, val, source))
+                        from .builder import SourcelessBuilder, VariableBuilder
+
+                        if arg.source:
+                            arg.items.append(
+                                VariableBuilder(tx, GetItemSource(arg.source, i))(val)
+                            )
+                        else:
+                            arg.items.append(SourcelessBuilder.create(tx, val))
 
     def create_finalizer(self, tx):
         names_to_delete = self.static_tensor_names

--- a/torch/_dynamo/variables/sdpa.py
+++ b/torch/_dynamo/variables/sdpa.py
@@ -5,14 +5,11 @@ from typing import TYPE_CHECKING
 
 from ..bytecode_transformation import create_call_function
 from ..exc import Unsupported
-from ..source import AttrSource
 from .base import VariableTracker
 
 
 if TYPE_CHECKING:
     from torch._dynamo.symbolic_convert import InstructionTranslator
-
-PARAM_NAMES = "query key value attn_mask dropout is_causal enable_gqa".split()
 
 
 class SDPAParamsVariable(VariableTracker):
@@ -23,13 +20,35 @@ class SDPAParamsVariable(VariableTracker):
     def create(tx: "InstructionTranslator", value, source):
         from torch.backends.cuda import SDPAParams
 
+        from ..source import AttrSource
+        from .builder import VariableBuilder
         from .torch import TorchInGraphFunctionVariable
 
-        params = [
-            VariableTracker.build(tx, getattr(value, p), AttrSource(source, p))
-            for p in PARAM_NAMES
+        query_var = VariableBuilder(tx, AttrSource(source, "query"))(value.query)
+        key_var = VariableBuilder(tx, AttrSource(source, "key"))(value.key)
+        value_var = VariableBuilder(tx, AttrSource(source, "value"))(value.value)
+        attn_mask_var = VariableBuilder(tx, AttrSource(source, "attn_mask"))(
+            value.attn_mask
+        )
+        dropout_var = VariableBuilder(tx, AttrSource(source, "dropout"))(value.dropout)
+        is_causal_var = VariableBuilder(tx, AttrSource(source, "is_causal"))(
+            value.is_causal
+        )
+        enable_gqa_var = VariableBuilder(tx, AttrSource(source, "enable_gqa"))(
+            value.enable_gqa
+        )
+        param_vars = [
+            query_var,
+            key_var,
+            value_var,
+            attn_mask_var,
+            dropout_var,
+            is_causal_var,
+            enable_gqa_var,
         ]
-        return TorchInGraphFunctionVariable(SDPAParams).call_function(tx, params, {})
+        return TorchInGraphFunctionVariable(SDPAParams).call_function(
+            tx, param_vars, {}
+        )
 
     def __init__(self, proxy, param_vars, **kwargs) -> None:
         self.proxy = proxy
@@ -51,6 +70,7 @@ class SDPAParamsVariable(VariableTracker):
     def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
         import torch._C
 
+        from ..source import AttrSource
         from .builder import wrap_fx_proxy
         from .misc import GetAttrVariable
 

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -242,7 +242,9 @@ class TensorVariable(VariableTracker):
             # any other attributes on the subclass (that are not methods)
             # are assumed to be constant metadata.
             elif not callable(example_value):
-                return VariableTracker.build(tx, example_value)
+                from .builder import SourcelessBuilder
+
+                return SourcelessBuilder.create(tx, example_value)
 
         if not (self.source and self.source.subguards_allowed()):
             raise NotImplementedError
@@ -279,9 +281,12 @@ class TensorVariable(VariableTracker):
             # Note - at a certain point we may want to handle
             raise NotImplementedError
 
+        from ..guards import GuardBuilder
+        from .builder import VariableBuilder
+
         attr_source = AttrSource(self.source, name)
         install_guard(attr_source.make_guard(GuardBuilder.HASATTR))
-        return VariableTracker.build(tx, real_value, attr_source)
+        return VariableBuilder(tx, attr_source)(real_value)
 
     def method_attr_ndim(self, tx):
         if self.ndim is not None:
@@ -698,6 +703,7 @@ class TensorVariable(VariableTracker):
     def method_as_subclass(self, cls):
         if isinstance(cls, TensorSubclassVariable) and cls.source:
             from ..symbolic_convert import InstructionTranslator
+            from .builder import VariableBuilder
             from .torch_function import TensorWithTFOverrideVariable
 
             tx = InstructionTranslator.current_tx()
@@ -707,11 +713,10 @@ class TensorVariable(VariableTracker):
             # defines a constructor, but if only a __torch_function__ impl is defined, this is okay to call.
             # It is up to the user whether this is correct behavior or not.
             py_cls = cls.as_python_constant()
-            torch_fn = VariableTracker.build(
+            torch_fn = VariableBuilder(
                 tx,
-                py_cls.__torch_function__.__func__,
                 AttrSource(AttrSource(cls.source, "__torch_function__"), "__func__"),
-            )
+            )(py_cls.__torch_function__.__func__)
 
             return TensorWithTFOverrideVariable.from_tensor_var(
                 tx, self, py_cls, torch_fn
@@ -753,6 +758,7 @@ class TensorVariable(VariableTracker):
 
     def method_tolist(self):
         from ..symbolic_convert import InstructionTranslator
+        from .builder import SourcelessBuilder
 
         tx = InstructionTranslator.current_tx()
 
@@ -789,7 +795,7 @@ class TensorVariable(VariableTracker):
 
         tensor = self.as_proxy().node.meta["example_value"]
         out = tolist(tensor, self.as_proxy())
-        return VariableTracker.build(tx, out)
+        return SourcelessBuilder.create(tx, out)
 
     def method_backward(self, *args, **kwargs):
         unimplemented("Tensor.backward")
@@ -859,9 +865,10 @@ class TensorVariable(VariableTracker):
         tx = InstructionTranslator.current_tx()
         if value is not None:
             from .. import polyfills
+            from .builder import SourcelessBuilder
 
             return tx.inline_user_function_return(
-                VariableTracker.build(tx, polyfills.addcmul_inplace),
+                SourcelessBuilder.create(tx, polyfills.addcmul_inplace),
                 [self, tensor1, tensor2, value],
                 {},
             )
@@ -1156,7 +1163,9 @@ class SymNodeVariable(VariableTracker):
 
     def as_tensor(self, tx, dtype):
         if self._tensor_var is None:
-            self._tensor_var = VariableTracker.build(
+            from .builder import SourcelessBuilder
+
+            self._tensor_var = SourcelessBuilder.create(
                 tx, torch.scalar_tensor
             ).call_function(tx, [self], {"dtype": VariableTracker.build(tx, dtype)})
         return self._tensor_var
@@ -1361,10 +1370,12 @@ class TensorSubclassVariable(VariableTracker):
         kwargs: Dict[str, VariableTracker],
     ) -> VariableTracker:
         if len(args) == 1 and isinstance(args[0], TensorVariable):
+            from .builder import VariableBuilder
             from .torch_function import TensorWithTFOverrideVariable
 
-            source = AttrSource(self.source, "__torch_function__")
-            torch_fn = VariableTracker.build(tx, self.value.__torch_function__, source)
+            torch_fn = VariableBuilder(
+                tx, AttrSource(self.source, "__torch_function__")
+            )(self.value.__torch_function__)
 
             return TensorWithTFOverrideVariable.from_tensor_var(
                 tx, args[0], self.value, torch_fn

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1161,13 +1161,13 @@ class SymNodeVariable(VariableTracker):
     def as_proxy(self):
         return self.proxy
 
-    def as_tensor(self, tx, dtype):
+    def as_tensor(self, tx):
         if self._tensor_var is None:
             from .builder import SourcelessBuilder
 
             self._tensor_var = SourcelessBuilder.create(
                 tx, torch.scalar_tensor
-            ).call_function(tx, [self], {"dtype": VariableTracker.build(tx, dtype)})
+            ).call_function(tx, [self], {})
         return self._tensor_var
 
     def evaluate_expr(self, output_graph=None):

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -397,7 +397,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             TensorVariable,
             UserDefinedObjectVariable,
         )
-        from .builder import wrap_fx_proxy, wrap_fx_proxy_cls
+        from .builder import SourcelessBuilder, wrap_fx_proxy, wrap_fx_proxy_cls
 
         @register(*tracing_state_functions)
         def handle_tracing_state_functions(
@@ -422,14 +422,14 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             # the set of functions that we trace __torch_function__ on to
             # functions outside of the actual set. Implementing this properly will require implementing
             # some variable types to track and compare tensor getset descriptors
-            return VariableTracker.build(
+            return SourcelessBuilder.create(
                 tx, torch.overrides.get_default_nowrap_functions()
             )
 
         @register(torch.ops.inductor.accumulate_grad_.default)
         def handle_accumulate_grad_(self, tx: "InstructionTranslator", *args, **kwargs):
             return tx.inline_user_function_return(
-                VariableTracker.build(tx, polyfills.accumulate_grad), args, kwargs
+                SourcelessBuilder.create(tx, polyfills.accumulate_grad), args, kwargs
             )
 
         @register(math.radians)
@@ -437,7 +437,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             if not check_unspec_or_constant_args(args, kwargs):
                 # Use polyfill to convert math.radians(x) into math.pi * x / 180.0
                 return tx.inline_user_function_return(
-                    VariableTracker.build(tx, polyfills.radians), args, kwargs
+                    SourcelessBuilder.create(tx, polyfills.radians), args, kwargs
                 )
 
         @register(torch.is_tensor, torch.overrides.is_tensor_like)
@@ -622,7 +622,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
         ):
             if len(args) == 3 and not isinstance(args[2], ListVariable) and not kwargs:
                 return tx.inline_user_function_return(
-                    VariableTracker.build(tx, polyfills.foreach_lerp_inplace),
+                    SourcelessBuilder.create(tx, polyfills.foreach_lerp_inplace),
                     args,
                     kwargs,
                 )
@@ -635,7 +635,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             # in compile, it's more performant to not graph break.
             if len(args) == 2 and isinstance(args[0], TensorVariable) and not kwargs:
                 return tx.inline_user_function_return(
-                    VariableTracker.build(tx, polyfills.foreach_pow_scalar),
+                    SourcelessBuilder.create(tx, polyfills.foreach_pow_scalar),
                     args,
                     kwargs,
                 )
@@ -704,7 +704,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 # Note - while we *could* cook up sources around invocations, like a FunctionSource
                 # the space of invoking functions in the middle of the guard chain is very iffy. As such,
                 # guard propagation via options is the best we can do.
-                return VariableTracker.build(tx, invocation_result)
+                return SourcelessBuilder.create(tx, invocation_result)
 
             @register(DTensor.from_local)
             def handle_from_local(self, tx: "InstructionTranslator", *args, **kwargs):
@@ -1143,6 +1143,8 @@ Either create the tensor outside the compiled region, or do not set the tensor t
     @staticmethod
     def _nn_param_via_prefix_insert(tx: "InstructionTranslator", data, requires_grad):
         # Alternate version if we have a .source
+        from .builder import VariableBuilder
+
         varname = tx.output.new_var()
 
         # construct the nn.Parmeter before the graph save it to varname
@@ -1165,7 +1167,7 @@ Either create the tensor outside the compiled region, or do not set the tensor t
         example_value = torch.nn.Parameter(
             tx.output.example_value_from_input_node(data.as_proxy().node)
         )
-        result = VariableTracker.build(tx, example_value, source)
+        result = VariableBuilder(tx, source)(example_value)
         # No need to guard on this since we already guarded on `data`.
         # These guards would fail since varname doesn't exist until after the function starts
         TracingContext.get().guards_context.dynamo_guards.remove_guards_with_source(


### PR DESCRIPTION
TESTING:

This PR might hae been the cause of some OOMs seen in recent tests. Preparing a revert PR just in case, to see some signal already.

This reverts commit e1c45484410c27cf18adf045aa0cb6158dacbd13.

Additionally, revert "Have as_tensor always return a float64 tensor in dynamo (#138598)" that uses VariableTracker.build


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec