### PR TITLE
[Device] Replace hardcoded devices with 'torch._C._get_accelerator()'

### DIFF
--- a/torch/distributed/_composable/fsdp/_fsdp_init.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_init.py
@@ -58,8 +58,8 @@ def _init_default_fully_shard_mesh() -> DeviceMesh:
     if not dist.distributed_c10d.is_initialized():
         dist.distributed_c10d.init_process_group()
     default_pg = dist.distributed_c10d._get_default_group()
-    device_type = "cuda" if torch.cuda.is_available() else "cpu"
-    mesh = init_device_mesh(device_type, mesh_shape=(default_pg.size(),))
+    device = torch._C._get_accelerator()
+    mesh = init_device_mesh(device.type, mesh_shape=(default_pg.size(),))
     return mesh
 
 


### PR DESCRIPTION
I noticed that some hard-code like `"cuda" if torch.cuda.is_available() else "cpu"` which can be replaced with `torch._C._get_accelerator()`

cc: @albanD @guangyey @FFFrog @zeshengzong @noemotiovon


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o