### PR TITLE
fix REXML Improper restriction of recursive entity references in DTDs ('XML Entity Expansion')

### DIFF
--- a/ios/TestApp/Gemfile.lock
+++ b/ios/TestApp/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.3.3)
+    rexml (3.3.6)
       strscan
     rouge (2.0.7)
     ruby2_keywords (0.0.5)


### PR DESCRIPTION
The REXML gem before 3.3.6 has a DoS vulnerability when it parses an XML that has many deep elements that have same local name attributes. If you need to parse untrusted XMLs with tree parser API like `REXML::Document.new`, you may be impacted to this vulnerability. If you use other parser APIs such as stream parser API and SAX2 parser API, this vulnerability is not affected.

[CVE-2024-43398](https://nvd.nist.gov/vuln/detail/CVE-2024-43398)
[CWE-776](https://cwe.mitre.org/data/definitions/776.html)

