### PR TITLE
[Bugfix] UnicodeDecodeError: 'utf-8' codec can't decode byte

### DIFF
--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -245,7 +245,7 @@ class _KinetoProfile:
             fp = tempfile.NamedTemporaryFile("w+b", suffix=".json", delete=False)
             fp.close()
             retvalue = self.profiler.export_chrome_trace(fp.name)
-            with open(fp.name, 'rb') as fin:
+            with open(fp.name, "rb") as fin:
                 with gzip.open(path, "wb") as fout:
                     fout.writelines(fin)
             os.remove(fp.name)

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -242,11 +242,11 @@ class _KinetoProfile:
         """
         assert self.profiler
         if path.endswith(".gz"):
-            fp = tempfile.NamedTemporaryFile("w+t", suffix=".json", delete=False)
+            fp = tempfile.NamedTemporaryFile("w+b", suffix=".json", delete=False)
             fp.close()
             retvalue = self.profiler.export_chrome_trace(fp.name)
-            with open(fp.name) as fin:
-                with gzip.open(path, "wt") as fout:
+            with open(fp.name, 'rb') as fin:
+                with gzip.open(path, "wb") as fout:
                     fout.writelines(fin)
             os.remove(fp.name)
             return retvalue


### PR DESCRIPTION
Fixes #113564

When I used PyTorch's profiler to analyze the performance of vLLM, I encountered the following error. This error is similar to #113564. After analysis and troubleshooting, I changed the temporary file from text mode to binary mode, and it no longer reported an error and ran normally.

```bash
ERROR 10-28 10:25:50 engine.py:160]   File "/usr/local/lib/python3.12/dist-packages/torch/profiler/profiler.py", line 722, in stop 
ERROR 10-28 10:25:50 engine.py:160]     self._transit_action(self.current_action, None) 
ERROR 10-28 10:25:50 engine.py:160]   File "/usr/local/lib/python3.12/dist-packages/torch/profiler/profiler.py", line 751, in _transit_action 
ERROR 10-28 10:25:50 engine.py:160]     action() 
ERROR 10-28 10:25:50 engine.py:160]   File "/usr/local/lib/python3.12/dist-packages/torch/profiler/profiler.py", line 745, in _trace_ready 
ERROR 10-28 10:25:50 engine.py:160]     self.on_trace_ready(self) 
ERROR 10-28 10:25:50 engine.py:160]   File "/usr/local/lib/python3.12/dist-packages/torch/profiler/profiler.py", line 444, in handler_fn 
ERROR 10-28 10:25:50 engine.py:160]     prof.export_chrome_trace(os.path.join(dir_name, file_name)) 
ERROR 10-28 10:25:50 engine.py:160]   File "/usr/local/lib/python3.12/dist-packages/torch/profiler/profiler.py", line 220, in export_chrome_trace 
ERROR 10-28 10:25:50 engine.py:160]     fout.writelines(fin) 
ERROR 10-28 10:25:50 engine.py:160]   File "<frozen codecs>", line 322, in decode 
ERROR 10-28 10:25:50 engine.py:160] UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8e in position 5896: invalid start byte
```