### PR TITLE
Type check delta value in HuberLoss

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1095,6 +1095,8 @@ class HuberLoss(_Loss):
     __constants__ = ["reduction", "delta"]
 
     def __init__(self, reduction: str = "mean", delta: float = 1.0) -> None:
+        if not isinstance(delta, float):
+            raise TypeError( f"delta should be of type float, got: {type(delta).__name__}" )
         super().__init__(reduction=reduction)
         self.delta = delta
 

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1096,7 +1096,7 @@ class HuberLoss(_Loss):
 
     def __init__(self, reduction: str = "mean", delta: float = 1.0) -> None:
         if not isinstance(delta, float):
-            raise TypeError( f"delta should be of type float, got: {type(delta).__name__}" )
+            raise TypeError( f"delta should be of type float, got: {type(delta)}" )
         super().__init__(reduction=reduction)
         self.delta = delta
 

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1095,7 +1095,7 @@ class HuberLoss(_Loss):
     __constants__ = ["reduction", "delta"]
 
     def __init__(self, reduction: str = "mean", delta: float = 1.0) -> None:
-        if not isinstance(delta, float):
+        if not isinstance(delta, float) and not isinstance(delta, int):
             raise TypeError( f"delta should be of type float, got: {type(delta)}" )
         super().__init__(reduction=reduction)
         self.delta = delta

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3359,6 +3359,18 @@ def module_error_inputs_torch_nn_Pad3d(module_info, device, dtype, requires_grad
         ),
     ]
 
+def module_error_inputs_torch_nn_HuberLoss(module_info, device, dtype, requires_grad, training, **kwargs):
+
+    return [
+        ErrorModuleInput(
+            ModuleInput(constructor_input=FunctionInput(delta=1.+0.j),
+            ),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=TypeError,
+            error_regex=r"delta should be of type float, got: complex",
+
+            ),
+    ]
 
 _macos15_or_newer = torch.backends.mps.is_available() and torch.backends.mps.is_macos_or_newer(15, 0)
 
@@ -3967,6 +3979,7 @@ module_db: list[ModuleInfo] = [
                ),
     ModuleInfo(torch.nn.HuberLoss,
                module_inputs_func=module_inputs_torch_nn_HuberLoss,
+               module_error_inputs_func=module_error_inputs_torch_nn_HuberLoss,
                skips=(
                    # No channels_last support for loss functions.
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format'),

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3367,7 +3367,7 @@ def module_error_inputs_torch_nn_HuberLoss(module_info, device, dtype, requires_
             ),
             error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
             error_type=TypeError,
-            error_regex=r"delta should be of type float, got: complex",
+            error_regex=r"delta should be of type float, got: <class 'complex'>",
 
             ),
     ]


### PR DESCRIPTION
Fixes #133796. Added a type check when initializing HuberLoss so that only a float can be passed in as specified in the docs: `delta (float, optional)`. Ints were also allowed to pass the type check as ints could be passed in successfully before this change and can reasonably be expected to work where floats are used.