### PR TITLE
[AOTI][refactor] Move stack allocation related configs

### DIFF
--- a/test/inductor/test_aot_inductor_utils.py
+++ b/test/inductor/test_aot_inductor_utils.py
@@ -169,8 +169,8 @@ def check_model(
 ):
     with torch.no_grad(), config.patch(
         {
-            "allow_stack_allocation": self.allow_stack_allocation,
-            "use_minimal_arrayref_interface": self.use_minimal_arrayref_interface,
+            "aot_inductor.allow_stack_allocation": self.allow_stack_allocation,
+            "aot_inductor.use_minimal_arrayref_interface": self.use_minimal_arrayref_interface,
         }
     ):
         torch.manual_seed(0)
@@ -202,8 +202,8 @@ def check_model_with_multiple_inputs(
 ):
     with torch.no_grad(), config.patch(
         {
-            "allow_stack_allocation": self.allow_stack_allocation,
-            "use_minimal_arrayref_interface": self.use_minimal_arrayref_interface,
+            "aot_inductor.allow_stack_allocation": self.allow_stack_allocation,
+            "aot_inductor.use_minimal_arrayref_interface": self.use_minimal_arrayref_interface,
         }
     ):
         torch.manual_seed(0)
@@ -229,8 +229,8 @@ def code_check_count(
 ):
     with torch.no_grad(), config.patch(
         {
-            "allow_stack_allocation": self.allow_stack_allocation,
-            "use_minimal_arrayref_interface": self.use_minimal_arrayref_interface,
+            "aot_inductor.allow_stack_allocation": self.allow_stack_allocation,
+            "aot_inductor.use_minimal_arrayref_interface": self.use_minimal_arrayref_interface,
         }
     ):
         so_path = torch._export.aot_compile(model, example_inputs)

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -366,7 +366,9 @@ def init_backend_registration():
             "cpu",
             lambda *args, **kwargs: cpu_backends[config.cpu_backend](*args, **kwargs),
             PythonWrapperCodegen,
-            CppWrapperCpuArrayRef if config.allow_stack_allocation else CppWrapperCpu,
+            CppWrapperCpuArrayRef
+            if config.aot_inductor.allow_stack_allocation
+            else CppWrapperCpu,
         )
 
     if get_scheduling_for_device("cuda") is None:

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -74,7 +74,9 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
         self.scalar_to_tensor_id = count()
         self.custom_op_wrapper_loaded = False
         self.expr_printer = cexpr
-        self.allow_stack_allocation: Optional[bool] = config.allow_stack_allocation
+        self.allow_stack_allocation: Optional[
+            bool
+        ] = config.aot_inductor.allow_stack_allocation
         self.stack_allocated_buffers: Dict[BufferName, BufferLike] = {}
 
     @staticmethod
@@ -87,7 +89,7 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
 
     @staticmethod
     def get_input_cpp_type(input):
-        assert config.use_minimal_arrayref_interface
+        assert config.aot_inductor.use_minimal_arrayref_interface
 
         if isinstance(input, sympy.Expr):
             from ..graph import may_get_constant_buffer_dtype
@@ -175,7 +177,10 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
     def write_wrapper_decl(self):
         inputs_len = len(V.graph.graph_inputs.keys())
         if V.graph.aot_mode:
-            if config.use_minimal_arrayref_interface and not V.graph.is_const_graph:
+            if (
+                config.aot_inductor.use_minimal_arrayref_interface
+                and not V.graph.is_const_graph
+            ):
                 input_cpp_types = ", ".join(
                     f"{CppWrapperCpuArrayRef.get_input_cpp_type(x)}"
                     for x in V.graph.graph_inputs.values()
@@ -239,7 +244,7 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
                     run_impl_proto += """
                         __check_inputs_outputs(input_handles, output_handles);
                     """
-                if config.use_minimal_arrayref_interface:
+                if config.aot_inductor.use_minimal_arrayref_interface:
                     self.prefix.splice(
                         """
                         template <>
@@ -301,7 +306,7 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
             )
         with self.prefix.indent():
             # assign inputs and outputs in both cases so the later codegen can be simplified
-            if not config.use_minimal_arrayref_interface:
+            if not config.aot_inductor.use_minimal_arrayref_interface:
                 if not V.graph.is_const_graph:
                     if V.graph.aot_mode:
                         num_args = len(V.graph.graph_inputs)
@@ -319,7 +324,7 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
 
             if inputs_len != 0:
                 for idx, input_key in enumerate(V.graph.graph_inputs.keys()):
-                    if config.use_minimal_arrayref_interface:
+                    if config.aot_inductor.use_minimal_arrayref_interface:
                         self.prefix.writeline(
                             f"auto {input_key} = std::get<{idx}>(inputs);"
                         )
@@ -363,7 +368,7 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
 
             if V.graph.aot_mode:
                 if not V.graph.is_const_graph:
-                    if config.use_minimal_arrayref_interface:
+                    if config.aot_inductor.use_minimal_arrayref_interface:
                         # TODO: input shape checking for regular tensor interface as well?
                         self.codegen_input_numel_asserts()
                     else:
@@ -375,7 +380,8 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
     def generate_return(self, output_refs: List[str]):
         cst_names = V.graph.constants.keys()
         arr_iface = (
-            not V.graph.is_const_graph and config.use_minimal_arrayref_interface
+            not V.graph.is_const_graph
+            and config.aot_inductor.use_minimal_arrayref_interface
         )  # For brevity.
 
         def use_thread_local_cached_output_tensor(idx, output):
@@ -541,7 +547,7 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
 
         self.allow_stack_allocation = (
             self.allow_stack_allocation is not False
-            and config.allow_stack_allocation
+            and config.aot_inductor.allow_stack_allocation
             and total_allocated_buffer_size <= MAX_STACK_ALLOCATION_SIZE
         )
 
@@ -561,7 +567,7 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
             if isinstance(buffer.get_output_spec(), ir.MultiOutputLayout)
             or (V.graph.aot_mode and buffer.get_name() in self.stack_allocated_buffers)
             or (
-                config.use_minimal_arrayref_interface
+                config.aot_inductor.use_minimal_arrayref_interface
                 and V.graph.aot_mode
                 and buffer.get_name() in V.graph.graph_inputs
             )
@@ -992,7 +998,7 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
                 # type_ is Optional[Tensor]
                 # Similar to other data type, use pointer to denote optional tensor arg in v2 C shim
                 base_handle = self.val_to_arg_str(val, element_type)
-                if config.use_minimal_arrayref_interface:
+                if config.aot_inductor.use_minimal_arrayref_interface:
                     base_handle = f"convert_arrayref_tensor_to_tensor({base_handle})"
                 (
                     tmp_raii_handle_var,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -766,21 +766,6 @@ freezing: bool = os.environ.get("TORCHINDUCTOR_FREEZING", "0") == "1"
 # of potentially keeping multiple copies of weights.
 freezing_discard_parameters: bool = False
 
-# Kill switch for allowing temporary tensors to be allocated as stack arrays. Tests
-# should be run with this flag both on and off to make sure we have coverage.
-allow_stack_allocation: bool = False
-
-# Enables an alternate DSO interface (the "minimal ArrayRef interface") intended
-# to maximize performance for use cases that it can accommodate at the expense of
-# generality. In brief:
-# - inputs and outputs are ArrayRefTensor<T> (note that strides are required, but the
-#   tensor must be contiguous)
-# - constant handling is unchanged because it is not a per-inference-iteration bottleneck
-#
-# When the DSO is generated in this mode, the usual interface will also be supported,
-# but performance for that interface may be degraded.
-use_minimal_arrayref_interface: bool = False
-
 # decompose some memory bound matmul/bmm to mul
 decompose_mem_bound_mm: bool = False
 
@@ -1117,6 +1102,21 @@ class aot_inductor:
 
     # Dictionary of presets that can be passed in
     presets: Dict[str, Any] = {}
+
+    # Kill switch for allowing temporary tensors to be allocated as stack arrays. Tests
+    # should be run with this flag both on and off to make sure we have coverage.
+    allow_stack_allocation: bool = False
+
+    # Enables an alternate DSO interface (the "minimal ArrayRef interface") intended
+    # to maximize performance for use cases that it can accommodate at the expense of
+    # generality. In brief:
+    # - inputs and outputs are ArrayRefTensor<T> (note that strides are required, but the
+    #   tensor must be contiguous)
+    # - constant handling is unchanged because it is not a per-inference-iteration bottleneck
+    #
+    # When the DSO is generated in this mode, the usual interface will also be supported,
+    # but performance for that interface may be degraded.
+    use_minimal_arrayref_interface: bool = False
 
 
 class cuda:


### PR DESCRIPTION
Summary: Move allow_stack_allocation and use_minimal_arrayref_interface configs into the aot_inductor subclass.

Test Plan: CI

Differential Revision: D65064301




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang @aakhundov