### PR TITLE
[DTensor][Test] Fix gloo backend failure when eager_init is turned on

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -98,15 +98,17 @@ class DeviceMeshTest(DTensorTestBase):
 
     # TODO: need to refactor the other tests in this file to test both
     # eager_init=True and eager_init=False scenarios.
-    @skip_if_lt_x_gpu(4)
     @with_comms(eager_init=True)
     def test_2d_mesh_eager_init_subgroup(self):
         mesh_shape = (2, self.world_size // 2)
         mesh_2d = init_device_mesh(self.device_type, mesh_shape)
 
         curr_device = torch.cuda.current_device()
-        self.assertEqual(mesh_2d.get_group(0).bound_device_id.index, curr_device)
-        self.assertEqual(mesh_2d.get_group(1).bound_device_id.index, curr_device)
+        # when eager init is used, the subgroup is created from nccl comm split and
+        # there would be bound_device_id immediately assigned for the subgroup.
+        if self.backend == "nccl":
+            self.assertEqual(mesh_2d.get_group(0).bound_device_id.index, curr_device)
+            self.assertEqual(mesh_2d.get_group(1).bound_device_id.index, curr_device)
 
     @with_comms()
     def test_get_group_and_get_all_groups(self):

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -103,10 +103,10 @@ class DeviceMeshTest(DTensorTestBase):
         mesh_shape = (2, self.world_size // 2)
         mesh_2d = init_device_mesh(self.device_type, mesh_shape)
 
-        curr_device = torch.cuda.current_device()
         # when eager init is used, the subgroup is created from nccl comm split and
         # there would be bound_device_id immediately assigned for the subgroup.
         if self.backend == "nccl":
+            curr_device = torch.cuda.current_device()
             self.assertEqual(mesh_2d.get_group(0).bound_device_id.index, curr_device)
             self.assertEqual(mesh_2d.get_group(1).bound_device_id.index, curr_device)
 

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -314,9 +314,12 @@ class DTensorTestBase(MultiProcessTestCase):
         if self.backend not in ["nccl", "gloo", "mpi", "cpu:gloo,cuda:nccl"]:
             raise RuntimeError(f"Backend {self.backend} not supported!")
 
+        device_id = None
         if "nccl" in self.backend:
             # set device for nccl pg for collectives
             torch.cuda.set_device(self.rank)
+            # we only need to set device_id for nccl backend with eager init
+            device_id = torch.device(f"{self.device_type}:{self.rank}") if eager_init else None
 
         # For nccl backend, bind the device to the process if device_id is not None
         # so the nccl communicator is immediately formed and we can use `ncclCommSplit`
@@ -326,7 +329,7 @@ class DTensorTestBase(MultiProcessTestCase):
             world_size=self.world_size,
             rank=self.rank,  # pyre-ignore[16]
             init_method=f"file://{self.file_name}",  # pyre-ignore[16]
-            device_id=(torch.device(f"{self.device_type}:{self.rank}") if eager_init else None),
+            device_id=device_id,
         )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139097

We should only pass the `device_id` when the backend is `nccl`. Otherwise, we would run into the following error: 
```
RuntimeError: No backend for the parent process group or its backend does not support splitting
```



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @tianyu-l @XilunWu