### PR TITLE
[WIP] functional autograd + compiled autograd

### DIFF
--- a/aten/src/ATen/TensorGeometry.h
+++ b/aten/src/ATen/TensorGeometry.h
@@ -37,6 +37,16 @@ struct TORCH_API TensorGeometry {
         has_symbolic_sizes_strides_(
             t.unsafeGetTensorImpl()->has_symbolic_sizes_strides()) {}
 
+  explicit TensorGeometry(
+      std::vector<at::SymInt> sizes,
+      std::vector<at::SymInt> strides,
+      at::SymInt storage_offset)
+      : sizes_(std::move(sizes)),
+        strides_(std::move(strides)),
+        storage_offset_(std::move(storage_offset)) {
+    recompute();
+  }
+
   // true if the tensor is contiguous
   bool is_contiguous() const;
 

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -88,7 +88,9 @@ c10::TypePtr IValue::TagType<c10::Type>::get(const IValue& v) {
       case Tag::None:
         return NoneType::get();
       case Tag::Tensor:
-        return TensorType::create(v.toTensor());
+        return TensorType::get();
+        // TODO(rzou): following errors
+        // return TensorType::create(v.toTensor());
       case Tag::Storage:
         return StorageType::get();
       case Tag::Double:

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -1735,6 +1735,7 @@ TORCH_LIBRARY(test_autograd_cpp_node_id, m) {
             cpp_sources=cpp_source,
             functions="custom_op_backed_by_autograd_fn",
             verbose=True,
+            extra_cflags=["-g", "-O0"],
         )
 
         def same_autograd_fn():
@@ -1773,6 +1774,7 @@ TORCH_LIBRARY(test_autograd_cpp_node_id, m) {
 
         self.check_output_and_recompiles(different_autograd_fn, 2)
 
+    @unittest.skip("Flaky, cache from test ordering affects test. #135369")
     def test_autograd_cpp_node_saved(self):
         cpp_source = """
 struct CustomOpAutogradFunction : public torch::autograd::Function<CustomOpAutogradFunction> {
@@ -1848,6 +1850,7 @@ TORCH_LIBRARY(test_autograd_cpp_node_saved, m) {
 
         self.check_output_and_recompiles(fn, 2)
 
+    @unittest.skip("Flaky, cache from test ordering affects test. #135369")
     def test_autograd_cpp_node_saved_dynamic(self):
         cpp_source = """
 struct CustomOpAutogradFunction : public torch::autograd::Function<CustomOpAutogradFunction> {
@@ -1904,6 +1907,7 @@ TORCH_LIBRARY(test_autograd_cpp_node_saved_dynamic, m) {
         # compiles for 10 (static) and 100 (dynamic)
         self.check_output_and_recompiles(fn, 2)
 
+    @unittest.skip("Flaky, cache from test ordering affects test. #135369")
     def test_autograd_cpp_node_saved_int(self):
         cpp_source = """
 struct CustomOpAutogradFunction : public torch::autograd::Function<CustomOpAutogradFunction> {
@@ -1962,6 +1966,7 @@ TORCH_LIBRARY(test_autograd_cpp_node_saved_int, m) {
 
         self.check_output_and_recompiles(fn, 1)
 
+    @unittest.skip("Flaky, cache from test ordering affects test. #135369")
     def test_autograd_cpp_node_saved_float(self):
         cpp_source = """
 struct CustomOpAutogradFunction : public torch::autograd::Function<CustomOpAutogradFunction> {
@@ -2021,6 +2026,7 @@ TORCH_LIBRARY(test_autograd_cpp_node_saved_float, m) {
         # compiled autograd and dynamo both support symfloat, but not backend
         self.check_output_and_recompiles(fn, [1, 3])
 
+    @unittest.skip("Flaky, cache from test ordering affects test. #135369")
     def test_autograd_cpp_node_data_dependent(self):
         cpp_source = """
 struct CustomOpAutogradFunction : public torch::autograd::Function<CustomOpAutogradFunction> {

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -28,6 +28,7 @@ from torch.fx.experimental.proxy_tensor import (
     PythonKeyTracer,
     track_tensor_tree,
 )
+import torch.utils._pytree as pytree
 from torch.fx.experimental.symbolic_shapes import DimDynamic, ShapeEnv
 from torch.fx.traceback import preserve_node_meta, set_stack_trace
 from torch.utils._traceback import CapturedTraceback
@@ -137,6 +138,35 @@ def maybe_clone(x):
         return clone_preserve_strides(x)
     return x
 
+counter = 0
+
+class OpNamespace:
+    def __init__(self):
+        self.next_id = {}
+
+    def add(self, base_name, fn):
+        if base_name not in self.next_id:
+            self.next_id[base_name] = 0
+        nid = self.next_id[base_name]
+        name = f"{base_name}_{nid}"
+        self.next_id[base_name] += 1
+        result = Op(name, fn)
+        torch._dynamo.allow_in_graph(result)
+        setattr(self, name, result)
+        return result
+
+class Op:
+    def __init__(self, name, fn):
+        self.fn = fn
+        self.__name__ = name
+        self.__module__ = "torch._dynamo.compiled_autograd.ops"
+
+    def __call__(self, *args, **kwargs):
+        return self.fn(*args, **kwargs)
+
+
+ops = OpNamespace()
+
 
 class AutogradCompilerInstance:
     def __init__(self, compiler_fn) -> None:
@@ -153,6 +183,7 @@ class AutogradCompilerInstance:
         self.proxy_mode = ProxyTorchDispatchMode(self.fx_tracer, "symbolic")
         self.hooks_proxy: Optional[Proxy] = None
         self.graph_placeholders = ["inputs", "sizes", "scalars", "hooks"]
+        self.old_inline_behavior = True
 
     def wrap_fake(self, x, source):
         assert isinstance(x, torch.Tensor)
@@ -263,6 +294,55 @@ class AutogradCompilerInstance:
                 )
             self.bind_tensors_to_proxies(grad_ins, proxies)
         return tuple(grad_ins)
+
+    def allocate_dummy(self, *examples):
+        with disable_proxy_modes_tracing():
+            return torch.zeros(0)
+
+    def apply_functional(self, fn, inputs, stack, num_outputs, debug_name):
+        if self.old_inline_behavior:
+            result = fn(inputs, *stack)
+            return result
+        # TODO: if the node is a python autograd.Function or a CompiledFunctionBackward,
+        # we should probably "plop" the subgraph into the graph instead
+        # of allow_in_graph the node through Dynamo.
+        proxy_inputs, proxy_stack = pytree.tree_map(lambda t: self.to_proxy(t) if isinstance(t, torch.Tensor) else t,  (inputs, stack))
+        op = ops.add(debug_name, fn)
+        proxy_out = self.fx_tracer.create_proxy(
+            "call_function",
+            op,
+            args=(proxy_inputs, *proxy_stack),
+            kwargs={})
+        result = [self.allocate_dummy(*inputs, *stack) for _ in range(num_outputs)]
+        self.bind_tensors_to_proxies(result, [proxy_out[i] for i in range(num_outputs)])
+        return result
+
+    def validate_outputs(self, fn, outputs, stack, _0, _1):
+        if self.old_inline_behavior:
+            return fn(outputs, *stack)
+        proxy_outputs, proxy_stack = pytree.tree_map(lambda t: self.to_proxy(t) if isinstance(t, torch.Tensor) else t, (outputs, stack))
+        op = ops.add("validate_outputs", fn)
+        new_proxy_outputs = self.fx_tracer.create_proxy(
+            "call_function",
+            op,
+            args=(proxy_outputs, *proxy_stack),
+            kwargs={})
+        self.bind_tensors_to_proxies(outputs, new_proxy_outputs)
+        return outputs
+
+    def accumulate(self, old_var, new_var):
+        if self.old_inline_behavior:
+            return torch.add(old_var, new_var)
+        old_var_proxy = self.to_proxy(old_var)
+        new_var_proxy = self.to_proxy(new_var)
+        proxy_out = self.fx_tracer.create_proxy(
+            "call_function",
+            torch.add,
+            args=(old_var_proxy, new_var_proxy),
+            kwargs={})
+        result = self.allocate_dummy(old_var)
+        self.bind_tensors_to_proxies([result], [proxy_out])
+        return result
 
     def proxy_call_hook(self, hook, *args, **kwargs):
         return self.fx_tracer.create_proxy(
@@ -535,8 +615,6 @@ class AutogradCompilerInstance:
             return [self.to_proxy(x) for x in t]
         if isinstance(t, tuple):
             return tuple(self.to_proxy(x) for x in t)
-        # can it be torch.SymInt as the code used to imply?
-        assert isinstance(t, torch.Tensor)
         proxy_tensor = fetch_object_proxy(self.fx_tracer, t)
         assert isinstance(proxy_tensor, torch.fx.experimental.proxy_tensor._ProxyTensor)
         return proxy_tensor.proxy

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3243,6 +3243,7 @@ if torch.distributed.is_available():
 MOD_INLINELIST = [
     "torch._decomp",
     "torch._dynamo._trace_wrapped_higher_order_op",
+    "torch._dynamo.compiled_autograd.ops",
     "torch._dynamo.comptime",
     "torch._dynamo.polyfills",
     "torch._functorch.autograd_function",

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -530,9 +530,16 @@ variable_list AutogradContext::get_saved_variables() const {
   variable_list saved;
   saved.reserve(saved_variables_.size());
   auto ptr = grad_fn_.lock();
-  TORCH_INTERNAL_ASSERT(ptr);
-  for (auto& var : saved_variables_) {
-    saved.push_back(var.unpack(ptr));
+  // TORCH_INTERNAL_ASSERT(ptr);
+  // TODO(rzou): hacky, can do this in a more legit way
+  if (ptr) {
+    for (auto& var : saved_variables_) {
+      saved.push_back(var.unpack(ptr));
+    }
+  } else {
+    for (auto& var : saved_variables_) {
+      saved.push_back(var.unpack());
+    }
   }
   return saved;
 }
@@ -543,6 +550,7 @@ bool AutogradContext::needs_input_grad(size_t output_edge_index) const {
   return ptr->task_should_compute_output(output_edge_index);
 }
 
+// TODO(rzou): might segfault, need to make this functional
 bool AutogradContext::needs_input_grad(
     std::initializer_list<IndexRange> idxs) const {
   auto ptr = grad_fn_.lock();

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -241,6 +241,111 @@ struct CppNode : public Node {
     saved.after(output_info_);
     return results;
   }
+
+  functional_apply_t get_functional() override {
+    auto name = this->name();
+
+    // TODO(rzou): probably need to pre compute needs_input_grad
+    return [name](const variable_list& inputs, const std::vector<c10::IValue>& saved) {
+      SavedState state;
+      state.stack = saved;
+      auto ctx = AutogradContext();
+      std::vector<VariableInfo> output_info;
+      std::vector<bool> is_variable_input;
+      state.dequeue(ctx.saved_data);
+      state.dequeue(ctx.saved_variables_);
+      state.dequeue(ctx.materialize_grads_);
+      state.dequeue(output_info);
+      state.dequeue(is_variable_input);
+
+      // TODO(rzou): refactor to share code with CppNode<T>::apply
+      at::OptionalDeviceGuard _device_guard;
+      auto num_inputs = inputs.size();
+      variable_list backward_inputs;
+      backward_inputs.reserve(num_inputs);
+      for (const auto i : c10::irange(num_inputs)) {
+        if (inputs[i].defined() || !ctx.materialize_grads_) {
+          backward_inputs.emplace_back(inputs[i]);
+        } else {
+          backward_inputs.emplace_back(output_info[i].zeros(_device_guard));
+        }
+      }
+
+      auto outputs = T::backward(&ctx, inputs);
+
+      const auto num_forward_inputs =
+          static_cast<int64_t>(is_variable_input.size());
+      auto num_outputs = static_cast<int64_t>(outputs.size());
+      // Returning too many results is ok, but only as long as they're all
+      // undefined. Truncate the result vector in that case.
+      if (num_outputs > num_forward_inputs) {
+        bool all_undef = true;
+        for (const auto i : c10::irange(num_forward_inputs, num_outputs)) {
+          all_undef &= (!outputs[i].defined());
+        }
+        if (all_undef) {
+          outputs.resize(num_forward_inputs);
+          num_outputs = num_forward_inputs;
+        }
+      }
+
+      if (num_outputs != num_forward_inputs) {
+        std::string msg("function ");
+        msg += name + " returned an incorrect number of gradients (expected ";
+        msg += std::to_string(num_forward_inputs) + ", got ";
+        msg += std::to_string(num_outputs) + ")";
+        throw std::runtime_error(msg);
+      }
+
+      variable_list results;
+      results.reserve(num_outputs);
+      for (const auto i : c10::irange(num_outputs)) {
+        if (!is_variable_input[i]) {
+          if (outputs[i].defined()) {
+            std::string msg("function ");
+            msg += name +
+                " returned a gradient different that is defined at position ";
+            msg += std::to_string(i + 1) +
+                ", std the corresponding forward input was not a Variable";
+            throw std::runtime_error(msg);
+          }
+          continue;
+        }
+        results.emplace_back(outputs[i]);
+      }
+      return results;
+    };
+  }
+  ivalue_list retrieve_saved(SwapSavedVariables& saved) override {
+    saved.before(ctx_.saved_data);
+    TORCH_INTERNAL_ASSERT(ctx_.non_differentiable_.empty());
+    TORCH_INTERNAL_ASSERT(ctx_.dirty_inputs_.empty());
+    saved.before(ctx_.saved_variables_);
+    TORCH_INTERNAL_ASSERT(ctx_.to_save_.empty());
+    saved.before(ctx_.materialize_grads_);
+    saved.before(ctx_.has_freed_buffers_);
+    saved.before(input_info_);
+    saved.before(output_info_);
+
+    SavedState state;
+    state.enqueue(ctx_.saved_data);
+    state.enqueue(ctx_.saved_variables_, shared_from_this());
+    state.enqueue(ctx_.materialize_grads_);
+    state.enqueue(output_info_);
+    state.enqueue(is_variable_input_);
+
+    saved.after(ctx_.saved_data);
+    TORCH_INTERNAL_ASSERT(ctx_.non_differentiable_.empty());
+    TORCH_INTERNAL_ASSERT(ctx_.dirty_inputs_.empty());
+    saved.after(ctx_.saved_variables_);
+    TORCH_INTERNAL_ASSERT(ctx_.to_save_.empty());
+    saved.after(ctx_.materialize_grads_);
+    saved.after(ctx_.has_freed_buffers_);
+    saved.after(input_info_);
+    saved.after(output_info_);
+
+    return state.stack;
+  }
 };
 
 struct ExtractVariables : IterArgs<ExtractVariables> {

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -43,6 +43,11 @@ TORCH_API void validate_outputs(
     const edge_list& edges,
     variable_list& grads,
     const std::function<std::string(const std::string&)>& format_error);
+TORCH_API void validate_outputs(
+    const std::vector<c10::optional<InputMetadata>>& input_metadata,
+    variable_list& grads,
+    const std::function<std::string(const std::string&)>& format_error);
+TORCH_API std::vector<c10::optional<InputMetadata>> collect_input_metadata(const edge_list& edges);
 
 struct NodeTask {
   std::weak_ptr<GraphTask> base_;

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -34,8 +34,12 @@ using tensor_list = std::vector<at::Tensor>;
 using variable_list = std::vector<Variable>;
 using edge_list = std::vector<Edge>;
 using saved_variable_list = std::vector<SavedVariable>;
+using ivalue_list = std::vector<c10::IValue>;
+using functional_apply_t = std::function<
+    variable_list(const variable_list&, const std::vector<c10::IValue>&)>;
 using IndexRange = std::pair<size_t, size_t>;
 using torch::dynamo::autograd::CompiledNodeArgs;
+using torch::dynamo::autograd::SavedState;
 using torch::dynamo::autograd::SwapSavedVariables;
 
 // Custom deleter to prevent stack overflows.
@@ -602,6 +606,17 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
       SwapSavedVariables& saved) {
     throw std::runtime_error(
         std::string("apply_with_saved not implemented: ") + name());
+  }
+
+  virtual ivalue_list retrieve_saved(SwapSavedVariables& saved) {
+    throw std::runtime_error(
+        std::string("retrieve_saved not implemented: ") + name());
+  }
+  virtual std::function<
+      variable_list(const variable_list&, const std::vector<c10::IValue>&)>
+  get_functional() {
+    throw std::runtime_error(
+        std::string("get_functional not implemented: ") + name());
   }
 
  protected:

--- a/torch/csrc/autograd/function_hook.h
+++ b/torch/csrc/autograd/function_hook.h
@@ -8,6 +8,7 @@
 namespace torch::dynamo::autograd {
 class CompiledNodeArgs;
 class SwapSavedVariables;
+struct SavedState;
 } // namespace torch::dynamo::autograd
 
 // A hook that's called on gradients

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -103,4 +103,40 @@ variable_list AccumulateGrad::apply_with_saved(
   return variable_list();
 }
 
+ivalue_list AccumulateGrad::retrieve_saved(SwapSavedVariables& saved) {
+  auto should_visit = variable.defined() && variable.requires_grad();
+  if (should_visit) {
+    saved.before(variable);
+  }
+
+  SavedState state;
+  state.enqueue(variable);
+
+  if (should_visit) {
+    saved.after(variable);
+  }
+
+  return state.stack;
+}
+
+functional_apply_t AccumulateGrad::get_functional() {
+  return [](const variable_list& inputs,
+            const std::vector<c10::IValue>& saved) -> variable_list {
+    SavedState state;
+    state.stack = saved;
+    Variable foo;
+    state.dequeue(foo);
+    if (!(foo.defined() && foo.requires_grad()) || !inputs[0].defined()) {
+      return variable_list();
+    }
+    // op is intentionally static
+    static auto op = c10::Dispatcher::singleton()
+                         .findSchemaOrThrow("inductor::accumulate_grad_", "")
+                         .typed<void(const at::Tensor&, const at::Tensor&)>();
+    op.call(foo, inputs[0]);
+    // TODO(rzou): tensor_post_acc_grad_hooks
+    return variable_list();
+  };
+}
+
 } // namespace torch::autograd

--- a/torch/csrc/autograd/functions/accumulate_grad.h
+++ b/torch/csrc/autograd/functions/accumulate_grad.h
@@ -267,6 +267,9 @@ struct TORCH_API AccumulateGrad : public Node {
       const variable_list& inputs,
       SwapSavedVariables& saved) override;
 
+  ivalue_list retrieve_saved(SwapSavedVariables& saved) override;
+  functional_apply_t get_functional() override;
+
   Variable variable;
 };
 

--- a/torch/csrc/autograd/functions/basic_ops.cpp
+++ b/torch/csrc/autograd/functions/basic_ops.cpp
@@ -77,5 +77,22 @@ variable_list GraphRoot::apply_with_saved(
   saved.after(outputs);
   return result;
 }
+ivalue_list GraphRoot::retrieve_saved(SwapSavedVariables& saved) {
+  saved.before(outputs);
+  SavedState state;
+  state.enqueue(outputs);
+  saved.after(outputs);
+  return state.stack;
+}
+functional_apply_t GraphRoot::get_functional() {
+  return [](const variable_list& inputs,
+            const std::vector<c10::IValue>& saved) -> variable_list {
+    SavedState state;
+    state.stack = saved;
+    variable_list outputs;
+    state.dequeue(outputs);
+    return outputs;
+  };
+}
 
 } // namespace torch::autograd

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -97,6 +97,8 @@ struct TORCH_API GraphRoot : public Node {
   variable_list apply_with_saved(
       const variable_list& inputs,
       SwapSavedVariables& saved) override;
+  ivalue_list retrieve_saved(SwapSavedVariables& saved) override;
+  functional_apply_t get_functional() override;
 
   variable_list outputs;
 };

--- a/torch/csrc/autograd/input_metadata.h
+++ b/torch/csrc/autograd/input_metadata.h
@@ -103,7 +103,7 @@ struct TORCH_API InputMetadata {
   bool maybe_expandable_to(const at::Tensor& grad) const;
 
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
-  const at::TensorOptions options_;
+  at::TensorOptions options_;
   MetadataShape shape_;
   c10::Stream stream_ = c10::Stream(c10::Stream::Default::DEFAULT, device());
   bool is_tensor_subclass_ = false;

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -25,6 +25,7 @@
 #include <torch/csrc/autograd/saved_variable.h>
 #include <torch/csrc/autograd/utils/wrap_outputs.h>
 #include <torch/csrc/dynamo/compiled_autograd.h>
+#include <torch/csrc/dynamo/python_compiled_autograd.h>
 #include <torch/csrc/jit/frontend/tracer.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
@@ -394,6 +395,99 @@ variable_list PyNode::apply_with_saved(
   saved.after(f->output_info);
   saved.after(f->input_info);
   return result;
+}
+
+ivalue_list PyNode::retrieve_saved(SwapSavedVariables& saved) {
+  auto f = (THPFunction*)obj;
+  saved.before(f->compiled_autograd_symints);
+  saved.before(f->saved_variables);
+  saved.before(f->needs_input_grad);
+  saved.before(f->materialize_non_diff_grads);
+  saved.before(f->output_info);
+  saved.before(f->input_info);
+
+  SavedState state;
+  state.enqueue(f->compiled_autograd_symints);
+  state.enqueue(f->saved_variables, shared_from_this());
+  // state.enqueue(f->needs_input_grad);
+  // state.enqueue(f->materialize_non_diff_grads);
+  // state.enqueue(f->output_info);
+  // state.enqueue(f->input_info);
+
+  saved.after(f->compiled_autograd_symints);
+  saved.after(f->saved_variables);
+  saved.after(f->needs_input_grad);
+  saved.after(f->materialize_non_diff_grads);
+  saved.after(f->output_info);
+  saved.after(f->input_info);
+
+  state.enqueue(f->compiled_autograd_symints);
+  state.enqueue(f->saved_variables, shared_from_this());
+  // state.enqueue(f->needs_input_grad);
+  // state.enqueue(f->materialize_non_diff_grads);
+  // state.enqueue(f->output_info);
+  // state.enqueue(f->input_info);
+
+  return state.stack;
+}
+
+// TODO(rzou): compiled autograd needs special handling of the following.
+std::function<
+    variable_list(const variable_list&, const std::vector<c10::IValue>&)>
+PyNode::get_functional() {
+  auto node = std::static_pointer_cast<PyNode>(shared_from_this());
+  // TODO(rzou): probably need to pre compute needs_input_grad
+  return
+      [node](
+          const variable_list& inputs, const std::vector<c10::IValue>& saved) {
+        SavedState state;
+        state.stack = saved;
+
+        auto f = (THPFunction*)node->obj;
+
+        state.dequeue(f->compiled_autograd_symints);
+        state.dequeue(f->saved_variables);
+        // state.dequeue(f->needs_input_grad);
+        // state.dequeue(f->materialize_non_diff_grads);
+        // state.dequeue(f->output_info);
+        // state.dequeue(f->input_info);
+
+        f->compiled_autograd_tracing = true;
+        variable_list result;
+        if (!node->compiled_autograd_should_lift()) {
+          if (node->_backward_state_idx.has_value()) {
+            PyObject* r = PyObject_CallMethod(
+                torch::dynamo::autograd::current_py_compiler(),
+                "bind_backward_state",
+                "i",
+                *node->_backward_state_idx);
+            if (r == nullptr) {
+              throw python_error();
+            }
+            THPObjectPtr prior(f->compiled_autograd_backward_state);
+            f->compiled_autograd_backward_state = r;
+            result = node->apply(variable_list(inputs));
+            Py_CLEAR(f->compiled_autograd_backward_state);
+            f->compiled_autograd_backward_state = prior.release();
+          } else {
+            result = node->apply(variable_list(inputs));
+          }
+        } else {
+          result = node->defer_to_dynamo(
+              variable_list(inputs),
+              torch::dynamo::autograd::current_py_compiler());
+        }
+        f->compiled_autograd_tracing = false;
+
+        state.dequeue(f->compiled_autograd_symints);
+        state.dequeue(f->saved_variables);
+        // state.dequeue(f->needs_input_grad);
+        // state.dequeue(f->materialize_non_diff_grads);
+        // state.dequeue(f->output_info);
+        // state.dequeue(f->input_info);
+
+        return result;
+      };
 }
 
 PyObject* PyNode::to_py_args(

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -70,6 +70,11 @@ struct PyNode : public Node {
       Py_DECREF(obj);
     }
   }
+
+  std::function<
+      variable_list(const variable_list&, const std::vector<c10::IValue>&)>
+  get_functional() override;
+  ivalue_list retrieve_saved(SwapSavedVariables& saved) override; 
 };
 
 /**

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -914,6 +914,321 @@ class SwapSavedVariables {
   StashedVars<at::IValue> stashed_ivalues;
 };
 
+struct SavedState {
+  std::vector<at::IValue> stack;
+  int64_t idx = 0;
+
+  void enqueue(
+      const SavedVariable& sv,
+      const std::shared_ptr<Node>& saved_for) {
+    stack.emplace_back(sv.unpack(saved_for));
+  }
+  void dequeue(SavedVariable& sv) {
+    sv = SavedVariable(stack[idx++].toTensor(), /*is_output*/ true);
+  }
+
+  void enqueue(
+      const std::vector<SavedVariable>& sv,
+      const std::shared_ptr<Node>& saved_for) {
+    enqueue(static_cast<int64_t>(sv.size()));
+    for (const auto& v : sv) {
+      enqueue(v, saved_for);
+    }
+  }
+  void dequeue(std::vector<SavedVariable>& sv) {
+    int64_t size = 0;
+    dequeue(size);
+    sv.clear();
+    for (int64_t idx = 0; idx < size; idx++) {
+      sv.emplace_back();
+      dequeue(sv.back());
+    }
+  }
+
+  /*
+  void enqueue(const PyObject*& t) {
+    enqueue_ivalue(t);
+  }
+  void dequeue(PyObject*& t) {
+    dequeue_ivalue(t);
+  }
+  */
+
+  void enqueue(const VariableInfo& t) {
+    enqueue(t.layout);
+    enqueue(t.device);
+    enqueue(t.scalar_type);
+    enqueue(t.size);
+    enqueue(t.requires_grad);
+    enqueue(t.is_empty);
+  }
+  void dequeue(VariableInfo& t) {
+    dequeue(t.layout);
+    dequeue(t.device);
+    dequeue(t.scalar_type);
+    dequeue(t.size);
+    dequeue(t.requires_grad);
+    dequeue(t.is_empty);
+  }
+
+  void enqueue(size_t t) {
+    enqueue(static_cast<int64_t>(t));
+  }
+  void dequeue(size_t& t) {
+    int64_t tmp = 0;
+    dequeue(tmp);
+    t = static_cast<size_t>(tmp);
+  }
+
+  // TODO: probably wildly inefficient
+  template <class T>
+  void enqueue(const c10::List<T> t) {
+    enqueue(t.vec());
+  }
+  template <class T>
+  void dequeue(c10::List<T>& t) {
+    std::vector<T> tmp;
+    dequeue(tmp);
+    t = c10::List<T>(tmp);
+  }
+
+  void enqueue(const TypeAndSize& value) {
+    enqueue(value.sym_sizes);
+    enqueue(value.options);
+  }
+  void dequeue(TypeAndSize& value) {
+    dequeue(value.sym_sizes);
+    dequeue(value.options);
+  }
+
+  void enqueue(const InputMetadata& value) {
+    enqueue(value.options());
+    enqueue(value.shape_as_dim_vector().vec());
+    enqueue(value.is_tensor_subclass());
+    TORCH_INTERNAL_ASSERT(!value.is_nested_tensor());
+  }
+  // Special case: InputMetadata has no copy ctor
+  // TODO(rzou): ??
+  void dequeue(InputMetadata& value) {
+    at::TensorOptions options;
+    dequeue(options);
+    std::vector<at::SymInt> shape;
+    dequeue(shape);
+    bool is_tensor_subclass = false;
+    dequeue(is_tensor_subclass);
+    SymIntSmallVec sym_shape;
+    for (const auto& s : shape) {
+      sym_shape.emplace_back(s);
+    }
+    value = InputMetadata(options, sym_shape, is_tensor_subclass, false);
+  }
+
+  void enqueue(const ska::flat_hash_map<std::string, at::IValue>& dct) {
+    std::vector<std::string> keys;
+    std::vector<at::IValue> values;
+    for (const auto& [key, value] : dct) {
+      keys.emplace_back(key);
+      values.emplace_back(value);
+    }
+    enqueue(keys);
+    enqueue(values);
+  }
+  void enqueue(const at::IValue& iv) {
+    stack.emplace_back(iv);
+  }
+  void dequeue(at::IValue& iv) {
+    iv = stack[idx++];
+  }
+  void dequeue(ska::flat_hash_map<std::string, at::IValue>& dct) {
+    std::vector<std::string> keys;
+    std::vector<at::IValue> values;
+    dequeue(keys);
+    dequeue(values);
+    dct.clear();
+    for (const auto i : c10::irange(keys.size())) {
+      dct.insert({keys[i], values[i]});
+    }
+  }
+
+  void enqueue(const at::TensorOptions& value) {
+    enqueue(value.requires_grad_opt());
+    enqueue(value.memory_format_opt());
+    enqueue(value.device_opt());
+    enqueue(value.dtype_opt());
+    enqueue(value.layout_opt());
+    enqueue(value.pinned_memory_opt());
+  }
+  void dequeue(at::TensorOptions& value) {
+    auto result = at::TensorOptions();
+    c10::optional<bool> requires_grad_opt;
+    dequeue(requires_grad_opt);
+    if (requires_grad_opt) {
+      result = result.requires_grad(*requires_grad_opt);
+    }
+    c10::optional<c10::MemoryFormat> memory_format_opt;
+    dequeue(memory_format_opt);
+    if (memory_format_opt) {
+      result = result.memory_format(*memory_format_opt);
+    }
+    c10::optional<c10::Device> device_opt;
+    dequeue(device_opt);
+    if (device_opt) {
+      result = result.device(*device_opt);
+    }
+    c10::optional<caffe2::TypeMeta> dtype_opt;
+    dequeue(dtype_opt);
+    if (dtype_opt) {
+      result = result.dtype(*dtype_opt);
+    }
+    c10::optional<c10::Layout> layout_opt;
+    dequeue(layout_opt);
+    if (layout_opt) {
+      result = result.layout(*layout_opt);
+    }
+    c10::optional<bool> pinned_memory_opt;
+    dequeue(pinned_memory_opt);
+    if (pinned_memory_opt) {
+      result = result.pinned_memory(*pinned_memory_opt);
+    }
+    value = result;
+  }
+
+  void enqueue(const caffe2::TypeMeta& value) {
+    enqueue(at::typeMetaToScalarType(value));
+  }
+  void dequeue(caffe2::TypeMeta& value) {
+    at::ScalarType result = at::kFloat;
+    dequeue(result);
+    value = caffe2::TypeMeta::fromScalarType(result);
+  }
+
+  template <typename T>
+  void enqueue(const c10::OptionalArray<T>& t) {
+    enqueue(t.list);
+  }
+  template <typename T>
+  void dequeue(c10::OptionalArray<T>& t) {
+    dequeue(t.list);
+  }
+
+  template <typename T>
+  void enqueue(const std::optional<T>& t) {
+    enqueue(t.has_value());
+    if (t.has_value()) {
+      enqueue(*t);
+    }
+  }
+  template <typename T>
+  void dequeue(c10::optional<T>& value) {
+    bool has_value = false;
+    dequeue(has_value);
+    T tmp;
+    if (has_value) {
+      dequeue(tmp);
+    }
+    value = tmp;
+  }
+
+  void enqueue(const at::TensorGeometry& t) {
+    enqueue(t.sym_sizes().vec());
+    enqueue(t.sym_strides().vec());
+    enqueue(t.sym_storage_offset());
+  }
+  void dequeue(at::TensorGeometry& t) {
+    std::vector<at::SymInt> sym_sizes;
+    std::vector<at::SymInt> sym_strides;
+    at::SymInt sym_storage_offset;
+    dequeue(sym_sizes);
+    dequeue(sym_strides);
+    dequeue(sym_storage_offset);
+    t = at::TensorGeometry(sym_sizes, sym_strides, sym_storage_offset);
+  }
+
+  template <typename T>
+  void enqueue(const std::vector<T>& t) {
+    enqueue(static_cast<int64_t>(t.size()));
+    for (const T& i : t) {
+      enqueue(i);
+    }
+  }
+  template <typename T>
+  void dequeue(std::vector<T>& t) {
+    int64_t size = 0;
+    dequeue(size);
+    t.clear();
+    for (int64_t idx = 0; idx < size; idx++) {
+      t.emplace_back();
+      dequeue(t.back());
+    }
+  }
+
+  void enqueue(const c10::SymInt& t) {
+    stack.emplace_back(t);
+  }
+  void dequeue(c10::SymInt& t) {
+    t = stack[idx++].toSymInt();
+  }
+
+  void enqueue(int64_t t) {
+    stack.emplace_back(t);
+  }
+  void dequeue(int64_t& t) {
+    t = stack[idx++].toInt();
+  }
+
+  void enqueue(const std::vector<c10::SymInt>& t) {
+    enqueue_ivalue(t);
+  }
+  void dequeue(std::vector<c10::SymInt>& t) {
+    t = stack[idx++].toSymIntVector();
+  }
+
+  void enqueue(const std::vector<int64_t>& t) {
+    enqueue_ivalue(t);
+  }
+  void dequeue(std::vector<int64_t>& t) {
+    t = stack[idx++].toIntVector();
+  }
+
+  template <class ivalue_t>
+  void enqueue_ivalue(const ivalue_t& t) {
+    stack.emplace_back(t);
+  }
+  template <class ivalue_t>
+  void dequeue_ivalue(ivalue_t& value) {
+    value = stack[idx++].to<ivalue_t>();
+  }
+#define HANDLE_IVALUE(ivalue_t)                            \
+  void enqueue(const ivalue_t& value) {                    \
+    return enqueue_ivalue<ivalue_t>(value);                \
+  }                                                        \
+  void enqueue(const std::vector<ivalue_t>& value) {       \
+    return enqueue_ivalue<std::vector<ivalue_t>>(value);   \
+  }                                                        \
+  void enqueue(const c10::optional<ivalue_t>& value) {     \
+    return enqueue_ivalue<c10::optional<ivalue_t>>(value); \
+  }                                                        \
+  void dequeue(ivalue_t& value) {                          \
+    return dequeue_ivalue<ivalue_t>(value);                \
+  }                                                        \
+  void dequeue(std::vector<ivalue_t>& value) {             \
+    return dequeue_ivalue<std::vector<ivalue_t>>(value);   \
+  }                                                        \
+  void dequeue(c10::optional<ivalue_t>& value) {           \
+    return dequeue_ivalue<c10::optional<ivalue_t>>(value); \
+  }
+  HANDLE_IVALUE(at::Tensor)
+  HANDLE_IVALUE(c10::ScalarType)
+  HANDLE_IVALUE(c10::Scalar)
+  HANDLE_IVALUE(c10::Layout)
+  HANDLE_IVALUE(c10::Device)
+  HANDLE_IVALUE(c10::MemoryFormat)
+  HANDLE_IVALUE(bool)
+  HANDLE_IVALUE(double)
+  HANDLE_IVALUE(std::string)
+#undef HANDLE_IVALUE
+};
+
 } // namespace torch::dynamo::autograd
 
 template <>

--- a/torch/csrc/dynamo/python_compiled_autograd.h
+++ b/torch/csrc/dynamo/python_compiled_autograd.h
@@ -4,4 +4,5 @@
 // see [Note: Compiled Autograd]
 namespace torch::dynamo::autograd {
 PyObject* torch_c_dynamo_compiled_autograd_init();
+PyObject* current_py_compiler();
 } // namespace torch::dynamo::autograd

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -369,8 +369,18 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
           }
         case TypeKind::BoolType:
           return IValue(py::cast<std::vector<bool>>(obj));
-        case TypeKind::TensorType:
-          return IValue(py::cast<std::vector<at::Tensor>>(obj));
+        case TypeKind::TensorType: {
+          auto thing = py::cast<std::vector<std::optional<at::Tensor>>>(obj);
+          auto thing2 = std::vector<at::Tensor>();
+          for (const auto& inp : thing) {
+            if (inp.has_value()) {
+              thing2.emplace_back(*inp);
+            } else {
+              thing2.emplace_back();
+            }
+          }
+          return IValue(thing2);
+        }
         default:
           return createGenericList(obj, elem_type);
       }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #140115
* #140104
* #139855
* #139930
* #139121
* #140114
* __->__ #139098

This commit refactors autograd so that nodes can be called in a
functional way. Furthermore, it refactors compiled autograd to use
the new functional autograd, without any behavior changes.

This is on the way to getting compiled autograd to stop tracing into
autograd nodes when it constructs an FX graph out of the autograd graph.
We also implement some very basic support for that, which can be toggled
via `old_inline_behavior=False` in compiled_autograd.py.

Functional autograd works like the following:
- All torch::autograd::Node must define a
  `retrieve_saved(SwapSavedVariables) -> ivalue_list` API. This function
  takes compiled autograd's SwapSavedVariables and packs the state that
  is relevant to the current Node into an ivalue_list.
- All torch::autograd::Node must define a
  `get_functional() -> std::function`.
  This returns a new stateless function that accepts the
  gradients and saved values as an ivalue_list and returns new
  gradients.
- We developed a mechanism to bind arbitrary C++ functions that take
  ivalue_list to Python.
  This is really similar to how we bind custom ops to Python and was
  done in consideration of the Windows symbol limit (otherwise, we'd be
  binding one symbol per Node into Python).

Here's an example of the new autograd generated code
- https://gist.github.com/zou3519/09bb98bb0f11445bc3da063201adb818

Here's an example of the FX graph compiled autograd produces (with
old_inline_behavior=False):
- https://gist.github.com/zou3519/43e8106176d15d623e1377850f585c97

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @rec @xmfan