### PR TITLE
[invoke_subgraph] Generate fake_inputs correctly

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -374,6 +374,22 @@ class GraphModule(torch.nn.Module):
         ):
             opt_fn(x, y)
 
+    def test_simple_module(self):
+        mod = torch.nn.Linear(8, 8)
+
+        def gn(x):
+            return mod(x)
+
+        def fn(x):
+            return invoke_subgraph(gn, mod, (x,))
+
+        opt_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+        x = torch.randn(8, 8, requires_grad=True)
+
+        ref = mod(x)
+        res = opt_fn(x)
+        self.assertEqual(ref, res)
+
     def test_input_aliasing(self):
         def gn(x, y):
             return (x, torch.mul(x, y))

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2643,7 +2643,11 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
         # using the saved attr name.
         from torch._higher_order_ops.utils import has_potential_input_alias_or_mutation
 
-        fake_inputs = [arg.as_proxy().node.meta["example_value"] for arg in fn_args_vt]
+        fake_inputs = [
+            node.meta["example_value"]
+            for node in body_gmod.graph.nodes
+            if node.op == "placeholder"
+        ]
 
         # TODO(anijain2305) - This might be too big of a limitation. Consider
         # supporting mutation/aliasing in HOP itself to remove this restriction.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #139373
* #139325
* #139162
* #139094
* #139326
* __->__ #139130
* #139216



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec