### PR TITLE
TunableOp use dense size calculations as minimum sizes

### DIFF
--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -75,6 +75,11 @@ static bool NumericalCheck(ScalarType dtype, void* c, void* other_c, int64_t siz
 
 }
 
+// Note on GetSizeA et al.
+// Tensors can be dense or arbitrarily strided. We only need our copies to be large enough.
+// Our copies must be at least as large as the m n k shapes dictate, but could be larger
+// depending on the lda ldb ldc values. Similarly for the batched case.
+
 template <typename T>
 struct GemmParams : OpParams {
   GemmParams() {
@@ -86,15 +91,21 @@ struct GemmParams : OpParams {
   }
 
   size_t GetSizeA() const {
-    return sizeof(T) * lda * ((transa == 'n' || transa == 'N') ? k : m);
+    size_t size_stride = lda * ((transa == 'n' || transa == 'N') ? k : m);
+    size_t size_dense = m * k;
+    return sizeof(T) * (size_stride > size_dense ? size_stride : size_dense);
   }
 
   size_t GetSizeB() const {
-    return sizeof(T) * ldb * ((transb == 'n' || transb == 'N') ? n : k);
+    size_t size_stride = ldb * ((transb == 'n' || transb == 'N') ? n : k);
+    size_t size_dense = k * n;
+    return sizeof(T) * (size_stride > size_dense ? size_stride : size_dense);
   }
 
   size_t GetSizeC() const {
-    return sizeof(T) * ldc * n;
+    size_t size_stride = ldc * n;
+    size_t size_dense = m * n;
+    return sizeof(T) * (size_stride > size_dense ? size_stride : size_dense);
   }
 
   size_t GetSize(bool duplicate_inputs) const {
@@ -136,7 +147,7 @@ struct GemmParams : OpParams {
 
   TuningStatus NumericalCheck(GemmParams<T> *other) {
     auto c_dtype = c10::CppTypeToScalarType<T>::value;
-    return detail::NumericalCheck(c_dtype, c, other->c, ldc*n) ? OK : FAIL;
+    return detail::NumericalCheck(c_dtype, c, other->c, GetSizeC()/sizeof(T)) ? OK : FAIL;
   }
 
   char transa;
@@ -162,11 +173,29 @@ struct GemmAndBiasParams : OpParams {
     return fmt::sprintf("%c%c_%ld_%ld_%ld", transa, transb, m, n, k);
   }
 
+  size_t GetSizeA() const {
+    size_t size_stride = lda * ((transa == 'n' || transa == 'N') ? k : m);
+    size_t size_dense = m * k;
+    return sizeof(T) * (size_stride > size_dense ? size_stride : size_dense);
+  }
+
+  size_t GetSizeB() const {
+    size_t size_stride = ldb * ((transb == 'n' || transb == 'N') ? n : k);
+    size_t size_dense = k * n;
+    return sizeof(T) * (size_stride > size_dense ? size_stride : size_dense);
+  }
+
+  size_t GetSizeC() const {
+    size_t size_stride = ldc * n;
+    size_t size_dense = m * n;
+    return sizeof(T) * (size_stride > size_dense ? size_stride : size_dense);
+  }
+
   size_t GetSize(bool duplicate_inputs) const {
-    size_t size = sizeof(T) * ldc * n;
+    size_t size = GetSizeC();
     if (duplicate_inputs) {
-      size += sizeof(T) * lda * ((transa == 'n' || transa == 'N') ? k : m);
-      size += sizeof(T) * ldb * ((transb == 'n' || transb == 'N') ? n : k);
+      size += GetSizeA();
+      size += GetSizeB();
     }
     return size;
   }
@@ -176,13 +205,13 @@ struct GemmAndBiasParams : OpParams {
     *copy = *this;
     c10::DeviceIndex device = 0;
     AT_CUDA_CHECK(c10::cuda::GetDevice(&device));
-    size_t c_size = ldc * n * sizeof(T);
+    size_t c_size = GetSizeC();
     copy->c = static_cast<T*>(c10::cuda::CUDACachingAllocator::raw_alloc(c_size));
     AT_CUDA_CHECK(c10::cuda::CUDACachingAllocator::memcpyAsync(
         copy->c, device, c, device, c_size, getCurrentCUDAStream(device), true));
     if (duplicate_inputs) {
-      size_t a_size = sizeof(T) * lda * ((transa == 'n' || transa == 'N') ? k : m);
-      size_t b_size = sizeof(T) * ldb * ((transb == 'n' || transb == 'N') ? n : k);
+      size_t a_size = GetSizeA();
+      size_t b_size = GetSizeB();
       copy->a = static_cast<const T*>(c10::cuda::CUDACachingAllocator::raw_alloc(a_size));
       copy->b = static_cast<const T*>(c10::cuda::CUDACachingAllocator::raw_alloc(b_size));
       copy->duplicate_inputs_ = true;
@@ -201,7 +230,7 @@ struct GemmAndBiasParams : OpParams {
 
   TuningStatus NumericalCheck(GemmAndBiasParams<T> *other) {
     auto c_dtype = c10::CppTypeToScalarType<T>::value;
-    return detail::NumericalCheck(c_dtype, c, other->c, ldc*n) ? OK : FAIL;
+    return detail::NumericalCheck(c_dtype, c, other->c, GetSizeC()/sizeof(T)) ? OK : FAIL;
   }
 
   char transa;
@@ -233,15 +262,21 @@ struct GemmStridedBatchedParams : OpParams {
   }
 
   size_t GetSizeA() const {
-    return sizeof(T) * std::min(lda, stride_a) * ((transa == 'n' || transa == 'N') ? k : m) * batch;
+    size_t size_stride = std::min(lda, stride_a) * ((transa == 'n' || transa == 'N') ? k : m) * batch;
+    size_t size_dense = m * k * batch;
+    return sizeof(T) * (size_stride > size_dense ? size_stride : size_dense);
   }
 
   size_t GetSizeB() const {
-    return sizeof(T) * std::min(ldb, stride_b) * ((transb == 'n' || transb == 'N') ? n : k) * batch;
+    size_t size_stride = std::min(ldb, stride_b) * ((transb == 'n' || transb == 'N') ? n : k) * batch;
+    size_t size_dense = k * n * batch;
+    return sizeof(T) * (size_stride > size_dense ? size_stride : size_dense);
   }
 
   size_t GetSizeC() const {
-    return sizeof(T) * std::min(ldc, stride_c) * n * batch;
+    size_t size_stride = std::min(ldc, stride_c) * n * batch;
+    size_t size_dense = m * n * batch;
+    return sizeof(T) * (size_stride > size_dense ? size_stride : size_dense);
   }
 
   size_t GetSize(bool duplicate_inputs) const {
@@ -283,7 +318,7 @@ struct GemmStridedBatchedParams : OpParams {
 
   TuningStatus NumericalCheck(GemmStridedBatchedParams<T> *other) {
     auto c_dtype = c10::CppTypeToScalarType<T>::value;
-    return detail::NumericalCheck(c_dtype, c, other->c, batch*stride_c) ? OK : FAIL;
+    return detail::NumericalCheck(c_dtype, c, other->c, GetSizeC()/sizeof(T)) ? OK : FAIL;
   }
 
   char transa;
@@ -318,15 +353,21 @@ struct ScaledGemmParams : OpParams {
   }
 
   size_t GetSizeA() const {
-    return sizeof(T) * lda * ((transa == 'n' || transa == 'N') ? k : m);
+    size_t size_stride = lda * ((transa == 'n' || transa == 'N') ? k : m);
+    size_t size_dense = m * k;
+    return sizeof(T) * (size_stride > size_dense ? size_stride : size_dense);
   }
 
   size_t GetSizeB() const {
-    return sizeof(T) * ldb * ((transb == 'n' || transb == 'N') ? n : k);
+    size_t size_stride = ldb * ((transb == 'n' || transb == 'N') ? n : k);
+    size_t size_dense = k * n;
+    return sizeof(T) * (size_stride > size_dense ? size_stride : size_dense);
   }
 
   size_t GetSizeC() const {
-    return sizeof(T) * ldc * n;
+    size_t size_stride = ldc * n;
+    size_t size_dense = m * n;
+    return sizeof(T) * (size_stride > size_dense ? size_stride : size_dense);
   }
 
   size_t GetSize(bool duplicate_inputs) const {
@@ -367,7 +408,7 @@ struct ScaledGemmParams : OpParams {
   }
 
   TuningStatus NumericalCheck(ScaledGemmParams<T> *other) {
-    return detail::NumericalCheck(c_dtype, c, other->c, ldc*n) ? OK : FAIL;
+    return detail::NumericalCheck(c_dtype, c, other->c, GetSizeC()/sizeof(T)) ? OK : FAIL;
   }
 
   char transa;

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -86,15 +86,15 @@ struct GemmParams : OpParams {
   }
 
   size_t GetSizeA() const {
-    return sizeof(T) * m * k;
+    return sizeof(T) * lda * ((transa == 'n' || transa == 'N') ? k : m);
   }
 
   size_t GetSizeB() const {
-    return sizeof(T) * k * n;
+    return sizeof(T) * ldb * ((transb == 'n' || transb == 'N') ? n : k);
   }
 
   size_t GetSizeC() const {
-    return sizeof(T) * m * n;
+    return sizeof(T) * ldc * n;
   }
 
   size_t GetSize(bool duplicate_inputs) const {
@@ -136,7 +136,7 @@ struct GemmParams : OpParams {
 
   TuningStatus NumericalCheck(GemmParams<T> *other) {
     auto c_dtype = c10::CppTypeToScalarType<T>::value;
-    return detail::NumericalCheck(c_dtype, c, other->c, m*n) ? OK : FAIL;
+    return detail::NumericalCheck(c_dtype, c, other->c, ldc*n) ? OK : FAIL;
   }
 
   char transa;
@@ -162,23 +162,11 @@ struct GemmAndBiasParams : OpParams {
     return fmt::sprintf("%c%c_%ld_%ld_%ld", transa, transb, m, n, k);
   }
 
-  size_t GetSizeA() const {
-    return sizeof(T) * m * k;
-  }
-
-  size_t GetSizeB() const {
-    return sizeof(T) * k * n;
-  }
-
-  size_t GetSizeC() const {
-    return sizeof(T) * m * n;
-  }
-
   size_t GetSize(bool duplicate_inputs) const {
-    size_t size = GetSizeC();
+    size_t size = sizeof(T) * ldc * n;
     if (duplicate_inputs) {
-      size += GetSizeA();
-      size += GetSizeB();
+      size += sizeof(T) * lda * ((transa == 'n' || transa == 'N') ? k : m);
+      size += sizeof(T) * ldb * ((transb == 'n' || transb == 'N') ? n : k);
     }
     return size;
   }
@@ -188,13 +176,13 @@ struct GemmAndBiasParams : OpParams {
     *copy = *this;
     c10::DeviceIndex device = 0;
     AT_CUDA_CHECK(c10::cuda::GetDevice(&device));
-    size_t c_size = GetSizeC();
+    size_t c_size = ldc * n * sizeof(T);
     copy->c = static_cast<T*>(c10::cuda::CUDACachingAllocator::raw_alloc(c_size));
     AT_CUDA_CHECK(c10::cuda::CUDACachingAllocator::memcpyAsync(
         copy->c, device, c, device, c_size, getCurrentCUDAStream(device), true));
     if (duplicate_inputs) {
-      size_t a_size = GetSizeA();
-      size_t b_size = GetSizeB();
+      size_t a_size = sizeof(T) * lda * ((transa == 'n' || transa == 'N') ? k : m);
+      size_t b_size = sizeof(T) * ldb * ((transb == 'n' || transb == 'N') ? n : k);
       copy->a = static_cast<const T*>(c10::cuda::CUDACachingAllocator::raw_alloc(a_size));
       copy->b = static_cast<const T*>(c10::cuda::CUDACachingAllocator::raw_alloc(b_size));
       copy->duplicate_inputs_ = true;
@@ -213,7 +201,7 @@ struct GemmAndBiasParams : OpParams {
 
   TuningStatus NumericalCheck(GemmAndBiasParams<T> *other) {
     auto c_dtype = c10::CppTypeToScalarType<T>::value;
-    return detail::NumericalCheck(c_dtype, c, other->c, m*n) ? OK : FAIL;
+    return detail::NumericalCheck(c_dtype, c, other->c, ldc*n) ? OK : FAIL;
   }
 
   char transa;
@@ -245,15 +233,15 @@ struct GemmStridedBatchedParams : OpParams {
   }
 
   size_t GetSizeA() const {
-    return sizeof(T) * m * k * batch;
+    return sizeof(T) * std::min(lda, stride_a) * ((transa == 'n' || transa == 'N') ? k : m) * batch;
   }
 
   size_t GetSizeB() const {
-    return sizeof(T) * k * n * batch;
+    return sizeof(T) * std::min(ldb, stride_b) * ((transb == 'n' || transb == 'N') ? n : k) * batch;
   }
 
   size_t GetSizeC() const {
-    return sizeof(T) * m * n * batch;
+    return sizeof(T) * std::min(ldc, stride_c) * n * batch;
   }
 
   size_t GetSize(bool duplicate_inputs) const {
@@ -330,15 +318,15 @@ struct ScaledGemmParams : OpParams {
   }
 
   size_t GetSizeA() const {
-    return sizeof(T) * m * k;
+    return sizeof(T) * lda * ((transa == 'n' || transa == 'N') ? k : m);
   }
 
   size_t GetSizeB() const {
-    return sizeof(T) * k * n;
+    return sizeof(T) * ldb * ((transb == 'n' || transb == 'N') ? n : k);
   }
 
   size_t GetSizeC() const {
-    return sizeof(T) * m * n;
+    return sizeof(T) * ldc * n;
   }
 
   size_t GetSize(bool duplicate_inputs) const {
@@ -379,7 +367,7 @@ struct ScaledGemmParams : OpParams {
   }
 
   TuningStatus NumericalCheck(ScaledGemmParams<T> *other) {
-    return detail::NumericalCheck(c_dtype, c, other->c, m*n) ? OK : FAIL;
+    return detail::NumericalCheck(c_dtype, c, other->c, ldc*n) ? OK : FAIL;
   }
 
   char transa;

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -86,15 +86,15 @@ struct GemmParams : OpParams {
   }
 
   size_t GetSizeA() const {
-    return sizeof(T) * lda * ((transa == 'n' || transa == 'N') ? k : m);
+    return sizeof(T) * m * k;
   }
 
   size_t GetSizeB() const {
-    return sizeof(T) * ldb * ((transb == 'n' || transb == 'N') ? n : k);
+    return sizeof(T) * k * n;
   }
 
   size_t GetSizeC() const {
-    return sizeof(T) * ldc * n;
+    return sizeof(T) * m * n;
   }
 
   size_t GetSize(bool duplicate_inputs) const {
@@ -136,7 +136,7 @@ struct GemmParams : OpParams {
 
   TuningStatus NumericalCheck(GemmParams<T> *other) {
     auto c_dtype = c10::CppTypeToScalarType<T>::value;
-    return detail::NumericalCheck(c_dtype, c, other->c, ldc*n) ? OK : FAIL;
+    return detail::NumericalCheck(c_dtype, c, other->c, m*n) ? OK : FAIL;
   }
 
   char transa;
@@ -162,11 +162,23 @@ struct GemmAndBiasParams : OpParams {
     return fmt::sprintf("%c%c_%ld_%ld_%ld", transa, transb, m, n, k);
   }
 
+  size_t GetSizeA() const {
+    return sizeof(T) * m * k;
+  }
+
+  size_t GetSizeB() const {
+    return sizeof(T) * k * n;
+  }
+
+  size_t GetSizeC() const {
+    return sizeof(T) * m * n;
+  }
+
   size_t GetSize(bool duplicate_inputs) const {
-    size_t size = sizeof(T) * ldc * n;
+    size_t size = GetSizeC();
     if (duplicate_inputs) {
-      size += sizeof(T) * lda * ((transa == 'n' || transa == 'N') ? k : m);
-      size += sizeof(T) * ldb * ((transb == 'n' || transb == 'N') ? n : k);
+      size += GetSizeA();
+      size += GetSizeB();
     }
     return size;
   }
@@ -176,13 +188,13 @@ struct GemmAndBiasParams : OpParams {
     *copy = *this;
     c10::DeviceIndex device = 0;
     AT_CUDA_CHECK(c10::cuda::GetDevice(&device));
-    size_t c_size = ldc * n * sizeof(T);
+    size_t c_size = GetSizeC();
     copy->c = static_cast<T*>(c10::cuda::CUDACachingAllocator::raw_alloc(c_size));
     AT_CUDA_CHECK(c10::cuda::CUDACachingAllocator::memcpyAsync(
         copy->c, device, c, device, c_size, getCurrentCUDAStream(device), true));
     if (duplicate_inputs) {
-      size_t a_size = sizeof(T) * lda * ((transa == 'n' || transa == 'N') ? k : m);
-      size_t b_size = sizeof(T) * ldb * ((transb == 'n' || transb == 'N') ? n : k);
+      size_t a_size = GetSizeA();
+      size_t b_size = GetSizeB();
       copy->a = static_cast<const T*>(c10::cuda::CUDACachingAllocator::raw_alloc(a_size));
       copy->b = static_cast<const T*>(c10::cuda::CUDACachingAllocator::raw_alloc(b_size));
       copy->duplicate_inputs_ = true;
@@ -201,7 +213,7 @@ struct GemmAndBiasParams : OpParams {
 
   TuningStatus NumericalCheck(GemmAndBiasParams<T> *other) {
     auto c_dtype = c10::CppTypeToScalarType<T>::value;
-    return detail::NumericalCheck(c_dtype, c, other->c, ldc*n) ? OK : FAIL;
+    return detail::NumericalCheck(c_dtype, c, other->c, m*n) ? OK : FAIL;
   }
 
   char transa;
@@ -233,15 +245,15 @@ struct GemmStridedBatchedParams : OpParams {
   }
 
   size_t GetSizeA() const {
-    return sizeof(T) * std::min(lda, stride_a) * ((transa == 'n' || transa == 'N') ? k : m) * batch;
+    return sizeof(T) * m * k * batch;
   }
 
   size_t GetSizeB() const {
-    return sizeof(T) * std::min(ldb, stride_b) * ((transb == 'n' || transb == 'N') ? n : k) * batch;
+    return sizeof(T) * k * n * batch;
   }
 
   size_t GetSizeC() const {
-    return sizeof(T) * std::min(ldc, stride_c) * n * batch;
+    return sizeof(T) * m * n * batch;
   }
 
   size_t GetSize(bool duplicate_inputs) const {
@@ -318,15 +330,15 @@ struct ScaledGemmParams : OpParams {
   }
 
   size_t GetSizeA() const {
-    return sizeof(T) * lda * ((transa == 'n' || transa == 'N') ? k : m);
+    return sizeof(T) * m * k;
   }
 
   size_t GetSizeB() const {
-    return sizeof(T) * ldb * ((transb == 'n' || transb == 'N') ? n : k);
+    return sizeof(T) * k * n;
   }
 
   size_t GetSizeC() const {
-    return sizeof(T) * ldc * n;
+    return sizeof(T) * m * n;
   }
 
   size_t GetSize(bool duplicate_inputs) const {
@@ -367,7 +379,7 @@ struct ScaledGemmParams : OpParams {
   }
 
   TuningStatus NumericalCheck(ScaledGemmParams<T> *other) {
-    return detail::NumericalCheck(c_dtype, c, other->c, ldc*n) ? OK : FAIL;
+    return detail::NumericalCheck(c_dtype, c, other->c, m*n) ? OK : FAIL;
   }
 
   char transa;


### PR DESCRIPTION
Fixes #139116.  Also fixes other unreported issues with torch.bmm due to incorrect size calculations.