### PR TITLE
Update grad_scaler.py（Just for this bug)

### DIFF
--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -3,13 +3,13 @@ from typing_extensions import deprecated
 import torch
 
 # We need to keep this unused import for BC reasons
-from torch.amp.grad_scaler import OptState  # noqa: F401
+from gradscaler1 import OptState  # noqa: F401
 
 
 __all__ = ["GradScaler"]
 
 
-class GradScaler(torch.amp.GradScaler):
+class GradScaler(torch.cuda.amp.GradScaler):
     r"""
     See :class:`torch.amp.GradScaler`.
     ``torch.cuda.amp.GradScaler(args...)`` is deprecated. Please use ``torch.amp.GradScaler("cuda", args...)`` instead.
@@ -29,7 +29,6 @@ class GradScaler(torch.amp.GradScaler):
         enabled: bool = True,
     ) -> None:
         super().__init__(
-            "cuda",
             init_scale=init_scale,
             growth_factor=growth_factor,
             backoff_factor=backoff_factor,


### PR DESCRIPTION
Fixes #138412 

The following code only provides a possible solution to this problem by saving the torch.amp.GradScaler code locally and calling it.
First, modify the original code that calls torch.amp.GradScaler as follows.

```
import torch
N, D_in, D_out = 64, 1024, 16
x = torch.randn(N, D_in, device='cuda')
y = torch.randn(N, D_out, device='cuda')

model = torch.nn.Linear(D_in, D_out).cuda()
optimizer = torch.optim.SGD(model.parameters(), lr=1e-2)
loss_fn = torch.nn.MSELoss()

# from torch.cuda.amp import GradScaler, autocast

from gradscaler2 import GradScaler
scaler = GradScaler()

def run_fwd_bwd():
    with torch.cuda.amp.autocast():
        y_pred = model(x)
        loss = loss_fn(y_pred, y)
    scaler.scale(loss).backward()
    scaler.step(optimizer)
    optimizer.zero_grad(set_to_none=True)
    scaler.update()

for t in range(20):
    run_fwd_bwd()
```

Then copy the torch/cuda/amp/grad_scaler.py file to your gradscaler2.py and modify it as follows commit.
Finally create a new gradscaler1.py file and copy the contents of torch/amp/grad_scaler into it correctly.

After doing this, you should be able to download the original torch.amp.GradScaler code locally and call it correctly. However, I have an older version of pytorch, 1.9.0+cu111, and there is a hint in the code snippet that this method is now outdated, so I'm not sure if it applies to your version.

Lastly, this PR is just a fix for this issue, I don't want to cause any changes to the original code repository, I just chose to use the PR to make my description a bit clearer than replying directly in the comment section, I apologize if it caused any problems for the project maintainers! Any comments or suggestions on what I did are welcome.

