### PR TITLE
Bring back `io.BytesIO` type annotation for the output destination of `torch.onnx.export`

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -48,6 +48,7 @@ __all__ = [
     "is_onnxrt_backend_supported",
 ]
 
+import io
 from typing import Any, Callable, Collection, Mapping, Sequence, TYPE_CHECKING
 
 import torch
@@ -132,7 +133,7 @@ def export(
     | torch.jit.ScriptModule
     | torch.jit.ScriptFunction,
     args: tuple[Any, ...] = (),
-    f: str | os.PathLike | None = None,
+    f: str | os.PathLike | io.BytesIO | None = None,
     *,
     kwargs: dict[str, Any] | None = None,
     export_params: bool = True,

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import contextlib
 import copy
 import inspect
+import io
+import os
 import re
 import typing
 import warnings
@@ -168,7 +170,7 @@ def _get_torch_export_args(
 def export(
     model: torch.nn.Module | torch.jit.ScriptModule | torch.jit.ScriptFunction,
     args: tuple[Any, ...] | torch.Tensor,
-    f: str,
+    f: str | os.PathLike | io.BytesIO,
     *,
     kwargs: dict[str, Any] | None = None,
     export_params: bool = True,
@@ -249,7 +251,8 @@ def export(
 
                     torch.onnx.export(model, (x, {y: z}, {}), "test.onnx.pb")
 
-        f: Path to the output ONNX model file. E.g. "model.onnx".
+        f: A file-like object (such that ``f.fileno()`` returns a file descriptor)
+            or a path to the output ONNX model file. E.g. "model.onnx".
         kwargs: Named arguments to the model.
         export_params: If True, all parameters will
             be exported. Set this to False if you want to export an untrained model.


### PR DESCRIPTION
The support for `io.Bytes` was lost in [this refactoring](https://github.com/pytorch/pytorch/commit/e8fc1e0118da85c3529f71fa60823fdbbbebee56#diff-c3c8c09b65c1235ca4494633c6a0aab2761a11a7653ddaf9f874bbcd91e15553R148). The underlying implementation remains the same, only the type annotation was modified.
