### PR TITLE
[MPS] Update error message for supported autocast type

### DIFF
--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -350,7 +350,7 @@ class TestAutocastMPS(TestCase):
 
     def test_mps_autocast_error_message(self):
         with self.assertWarnsRegex(
-                UserWarning, "MPS Autocast only supports dtype of torch.float16 currently."
+            UserWarning, "MPS Autocast only supports dtype of torch.float16 currently."
         ):
             with torch.autocast(device_type="mps", dtype=torch.bfloat16):
                 _ = torch.ones(10)

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -350,6 +350,9 @@ class TestAutocastMPS(TestCase):
 
     def test_mps_autocast_error_message(self):
         with self.assertWarnsRegex(UserWarning, "MPS Autocast only supports dtype of torch.float16 currently."):
+        with self.assertWarnsRegex(
+                UserWarning, "MPS Autocast only supports dtype of torch.float16 currently."
+        ):
             with torch.autocast(device_type="mps", dtype=torch.bfloat16):
                 _ = torch.ones(10)
 

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -348,6 +348,11 @@ class TestAutocastMPS(TestCase):
             s.backward()
         self.assertEqual(weight_dtype_cast_counter, 2)
 
+    def test_mps_autocast_error_message(self):
+        with self.assertWarnsRegex(UserWarning, "MPS Autocast only supports dtype of torch.float16 currently."):
+            with torch.autocast(device_type="mps", dtype=torch.bfloat16):
+                _ = torch.ones(10)
+
 
 class TestTorchAutocast(TestCase):
     def test_autocast_fast_dtype(self):

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -349,7 +349,6 @@ class TestAutocastMPS(TestCase):
         self.assertEqual(weight_dtype_cast_counter, 2)
 
     def test_mps_autocast_error_message(self):
-        with self.assertWarnsRegex(UserWarning, "MPS Autocast only supports dtype of torch.float16 currently."):
         with self.assertWarnsRegex(
                 UserWarning, "MPS Autocast only supports dtype of torch.float16 currently."
         ):

--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -327,7 +327,7 @@ class autocast:
             if self.fast_dtype not in supported_dtype:
                 error_message = "In MPS autocast, but the target dtype is not supported. Disabling autocast.\n"
                 error_message += (
-                    "MPS Autocast only supports dtype of torch.bfloat16 currently."
+                    "MPS Autocast only supports dtype of torch.float16 currently."
                 )
                 warnings.warn(error_message)
                 enabled = False


### PR DESCRIPTION
Autocast in MPS currently only supports dtype of `torch.float16`. This PR updates the error message to reflect this.

This PR was created using [Copilot Workspace](https://copilot-workspace.githubnext.com/pytorch/pytorch/issues/139190?shareId=5b510fda-380c-4e86-8e91-6b67a078f180) with no human input other than clicking buttons.

Fixes #139190


cc @mcarilli @ptrblck @leslie-fang-intel @jgong5