### PR TITLE
Workaround torch.deploy failures

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -34,7 +34,7 @@ from typing import (
     TypeVar as _TypeVar,
     Union as _Union,
 )
-from typing_extensions import ParamSpec as _ParamSpec, TypeIs as _TypeIs
+from typing_extensions import ParamSpec as _ParamSpec
 
 
 if TYPE_CHECKING:
@@ -64,7 +64,15 @@ from torch._utils_internal import (
 # TODO(torch_deploy) figure out how to freeze version.py in fbcode build
 if _running_with_deploy():
     __version__ = "torch-deploy-1.8"
+    # TODO: Remove this ugly hack when deploy typing extensions are updated to 4.10+
+    if not TYPE_CHECKING:
+        import typing_extensions
+
+        _TypeIs = typing_extensions.TypeGuard
+        typing_extensions.TypeIs = _TypeIs
 else:
+    from typing_extensions import TypeIs as _TypeIs
+
     from torch.torch_version import __version__ as __version__
 
 __all__ = [


### PR DESCRIPTION
Summary:
Which are backed with an older version of `typing_extensoins` but this runtime could not care less about type-checking.
So pretend that is has `TypeIs` by replacing it with `TypeGuard`

Fixes test failures introduced by https://github.com/pytorch/pytorch/pull/133814 / D65030974

Test Plan: `buck2 test 'fbcode//mode/opt' fbcode//multipy/runtime:test_deploy -- --exact 'multipy/runtime:test_deploy - TorchpyTest.TestNumpy'`

Differential Revision: D65145409


