### PR TITLE
ModuleTracker: Add explicit garbage collection

### DIFF
--- a/torch/utils/module_tracker.py
+++ b/torch/utils/module_tracker.py
@@ -10,7 +10,7 @@ from torch.nn.modules.module import (
     register_module_forward_pre_hook,
 )
 from torch.utils._pytree import tree_flatten
-
+import gc
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +136,7 @@ class ModuleTracker:
         tensors = [a for a in args if isinstance(a, torch.Tensor) and a.requires_grad]
         if tensors:
             register_multi_grad_hook(tensors, self._get_append_fn(name, True))
+            gc.collect()
 
     def __enter__(self):
         self._fw_pre_handle = register_module_forward_pre_hook(self._fw_pre_hook)

--- a/torch/utils/module_tracker.py
+++ b/torch/utils/module_tracker.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import gc
 import logging
 import weakref
 from typing import Set
@@ -10,7 +11,7 @@ from torch.nn.modules.module import (
     register_module_forward_pre_hook,
 )
 from torch.utils._pytree import tree_flatten
-import gc
+
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
When running an FSDP model with FlopCounterMode, we are experiencing a memory leak. It is coming from ModuleTracker class. Even though ModuleTracker class is keeping weakrefrences of the operators, the tensors/operators are not being freed after the backward pass. To force free these tensors/operators after forward pass, I explicitly added garbage collection in the post forward hook.

Fixes #ISSUE_NUMBER


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o