### PR TITLE
[CI] Run aarch64 build/tests on every trunk commit

### DIFF
--- a/.github/workflows/linux-aarch64.yml
+++ b/.github/workflows/linux-aarch64.yml
@@ -2,8 +2,12 @@ name: linux-aarch64
 
 on:
   push:
+    branches:
+      - main
+      - release/*
     tags:
       - ciflow/linux-aarch64/*
+      - ciflow/trunk/*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
As we have sccache now, should be reasonably fast
