### PR TITLE
Fix regex in `test_static_inputs_address_mutation_log` for Python 3.12

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -1967,8 +1967,8 @@ if HAS_CUDA and not TEST_WITH_ASAN:
 
             with self.assertRaisesRegex(
                 Exception,
-                r"static input data pointer changed.\n"
-                r"input name: primals_2. data pointer changed from .* to .*. input stack trace:(?s).*"
+                r"(?s)static input data pointer changed.\n"
+                r"input name: primals_2. data pointer changed from .* to .*. input stack trace:.*"
                 r"input name: primals_3. data pointer changed from .* to .*. input stack trace:.*,"
                 r" in forward\n.* self.static_tensor.add\_\(torch.ones\(\(2, 2\), device=\"cuda\"\)\).*\n",
             ):


### PR DESCRIPTION
Otherwise Python 3.12's `re` seems to be unhappy with `re.error: global flags not at the start of the expression at position 113`

cc @mcarilli @ezyang @eellison @penguinwu @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov