### PR TITLE
[PyTorch] Fix lack of alias annotations for dropout variants

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -308,25 +308,25 @@
 
 - func: _shape_as_tensor(Tensor self) -> Tensor
 
-- func: dropout(Tensor input, float p, bool train) -> Tensor
+- func: dropout(Tensor(a) input, float p, bool train) -> Tensor(a)
   tags: nondeterministic_seeded
 
 - func: dropout_(Tensor(a!) self, float p, bool train) -> Tensor(a!)
   tags: nondeterministic_seeded
 
-- func: feature_dropout(Tensor input, float p, bool train) -> Tensor
+- func: feature_dropout(Tensor(a) input, float p, bool train) -> Tensor(a)
   tags: nondeterministic_seeded
 
 - func: feature_dropout_(Tensor(a!) self, float p, bool train) -> Tensor(a!)
   tags: nondeterministic_seeded
 
-- func: alpha_dropout(Tensor input, float p, bool train) -> Tensor
+- func: alpha_dropout(Tensor(a) input, float p, bool train) -> Tensor(a)
   tags: nondeterministic_seeded
 
 - func: alpha_dropout_(Tensor(a!) self, float p, bool train) -> Tensor(a!)
   tags: nondeterministic_seeded
 
-- func: feature_alpha_dropout(Tensor input, float p, bool train) -> Tensor
+- func: feature_alpha_dropout(Tensor(a) input, float p, bool train) -> Tensor(a)
   tags: nondeterministic_seeded
 
 - func: feature_alpha_dropout_(Tensor(a!) self, float p, bool train) -> Tensor(a!)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139231

IIUC, these dropout variants can all return their input: https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/Dropout.cpp#L65
Therefore their schemata should reflect that.

Differential Revision: [D65177851](https://our.internmc.facebook.com/intern/diff/D65177851/)