### PR TITLE
Fix `vec128_half_neon.h` compilation with GCC

### DIFF
--- a/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h
@@ -224,7 +224,7 @@ class Vectorized<c10::Half> {
     Vectorized<c10::Half> vec(
         vreinterpretq_f16_u16(
             vbslq_u16(
-                vreinterpretq_u16_f16(mask),
+                mask,
                 vreinterpretq_u16_f16(b.values),
                 vreinterpretq_u16_f16(a.values))));
 

--- a/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp
@@ -73,7 +73,7 @@ float reduce(vec::VectorizedN<Half, kF16RegistersPerIteration>& x) {
     }
   });
   const auto [t0, t1] = vec::convert_half_float(x[0]);
-#if defined(__aarch64__)
+#if defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE256)
   return vaddvq_f32(t0 + t1);
 #else
   return vec::vec_reduce_all<float>(
@@ -115,7 +115,7 @@ static void fp16_gemv_trans_fp16_arith_by_dot_products(const int m, const int n,
 #endif // !defined(__aarch64__) || defined( __ARM_FEATURE_FP16_SCALAR_ARITHMETIC)
 
 float reduce(vec::Vectorized<float> x) {
-#if defined(__aarch64__)
+#if defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE256)
   return vaddvq_f32(x);
 #else
   return vec::vec_reduce_all<float>(
@@ -146,7 +146,7 @@ std::pair<vec::Vectorized<float>, vec::Vectorized<float>> fmadd(
     const vec::Vectorized<c10::Half>& b,
     const vec::Vectorized<float>& acc_low,
     const vec::Vectorized<float>& acc_high) {
-#ifdef __ARM_FEATURE_FP16_FML
+#if defined(__ARM_FEATURE_FP16_FML) && !defined(CPU_CAPABILITY_SVE256)
   return std::make_pair(vfmlalq_low_f16(acc_low, a, b), vfmlalq_high_f16(acc_high, a, b));
 #else
   const auto [a_float_low, a_float_high] = convert_half_float(a);

--- a/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp
@@ -73,7 +73,7 @@ float reduce(vec::VectorizedN<Half, kF16RegistersPerIteration>& x) {
     }
   });
   const auto [t0, t1] = vec::convert_half_float(x[0]);
-#if defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE256)
+#if defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE)
   return vaddvq_f32(t0 + t1);
 #else
   return vec::vec_reduce_all<float>(
@@ -115,7 +115,7 @@ static void fp16_gemv_trans_fp16_arith_by_dot_products(const int m, const int n,
 #endif // !defined(__aarch64__) || defined( __ARM_FEATURE_FP16_SCALAR_ARITHMETIC)
 
 float reduce(vec::Vectorized<float> x) {
-#if defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE256)
+#if defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE)
   return vaddvq_f32(x);
 #else
   return vec::vec_reduce_all<float>(
@@ -146,7 +146,7 @@ std::pair<vec::Vectorized<float>, vec::Vectorized<float>> fmadd(
     const vec::Vectorized<c10::Half>& b,
     const vec::Vectorized<float>& acc_low,
     const vec::Vectorized<float>& acc_high) {
-#if defined(__ARM_FEATURE_FP16_FML) && !defined(CPU_CAPABILITY_SVE256)
+#if defined(__ARM_FEATURE_FP16_FML) && !defined(CPU_CAPABILITY_SVE)
   return std::make_pair(vfmlalq_low_f16(acc_low, a, b), vfmlalq_high_f16(acc_high, a, b));
 #else
   const auto [a_float_low, a_float_high] = convert_half_float(a);


### PR DESCRIPTION
`mask` is already defined as `uint16x8_t` no need to reinterpret it
https://github.com/pytorch/pytorch/blob/bd369bb18258fc3be5ee91f8fcaf06a4b6fc41a7/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h#L220

Fixes
```
var/lib/jenkins/workspace/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h: In static member function 'static at::vec::DEFAULT::Vectorized<c10::Half> at::vec::DEFAULT::Vectorized<c10::Half>::set(const at::vec::DEFAULT::Vectorized<c10::Half>&, const at::vec::DEFAULT::Vectorized<c10::Half>&, int64_t)':
/var/lib/jenkins/workspace/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h:227:39: error: cannot convert 'uint16x8_t' to 'float16x8_t'
  227 |                 vreinterpretq_u16_f16(mask),
      |                                       ^~~~
      |                                       |
      |                                       uint16x8_t
In file included from /var/lib/jenkins/workspace/aten/src/ATen/cpu/vec/intrinsics.h:23,
                 from /var/lib/jenkins/workspace/aten/src/ATen/cpu/vec/vec128/vec128.h:4,
                 from /var/lib/jenkins/workspace/aten/src/ATen/cpu/vec/vec.h:6,
                 from /var/lib/jenkins/workspace/aten/src/ATen/test/vec_test_all_types.h:2,
                 from /var/lib/jenkins/workspace/aten/src/ATen/test/vec_test_all_types.cpp:1:
/usr/lib/gcc/aarch64-linux-gnu/11/include/arm_neon.h:5841:36: note:   initializing argument 1 of 'uint16x8_t vreinterpretq_u16_f16(float16x8_t)'
 5841 | vreinterpretq_u16_f16 (float16x8_t __a)
      |                        ~~~~~~~~~~~~^~~
```

introduced by https://github.com/pytorch/pytorch/pull/137911

Also, guard any use of NEON intrinsics in `ReducedPrecisionFloatGemvFastPathKernel.cpp` with `!defined(CPU_CAPABILITY_SVE)` otherwise compilation fails with
```
/var/lib/jenkins/workspace/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp: In function 'float at::native::SVE256::reduce(at::vec::SVE256::VectorizedN<c10::Half, 16>&)':
/var/lib/jenkins/workspace/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp:77:24: error: cannot convert 'at::vec::SVE256::Vectorized<float>' to 'float32x4_t'
   77 |   return vaddvq_f32(t0 + t1);
      |                     ~~~^~~~
      |                        |
      |                        at::vec::SVE256::Vectorized<float>
In file included from /var/lib/jenkins/workspace/c10/util/Half.h:51,
                 from /var/lib/jenkins/workspace/c10/util/Float8_e5m2.h:17,
                 from /var/lib/jenkins/workspace/c10/core/ScalarType.h:8,
                 from /var/lib/jenkins/workspace/c10/core/TensorImpl.h:11,
                 from /var/lib/jenkins/workspace/c10/core/GeneratorImpl.h:8,
                 from /var/lib/jenkins/workspace/aten/src/ATen/core/Generator.h:18,
                 from /var/lib/jenkins/workspace/aten/src/ATen/CPUGeneratorImpl.h:3,
                 from /var/lib/jenkins/workspace/aten/src/ATen/Context.h:4,
                 from /var/lib/jenkins/workspace/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp:2,
                 from /var/lib/jenkins/workspace/build/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp.SVE256.cpp:1:
/usr/lib/gcc/aarch64-linux-gnu/11/include/arm_neon.h:10423:25: note:   initializing argument 1 of 'float32_t vaddvq_f32(float32x4_t)'
10423 | vaddvq_f32 (float32x4_t __a)
      |             ~~~~~~~~~~~~^~~
In file included from /var/lib/jenkins/workspace/build/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp.SVE256.cpp:1:
/var/lib/jenkins/workspace/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp: In function 'float at::native::SVE256::reduce(at::vec::SVE256::Vectorized<float>)':
/var/lib/jenkins/workspace/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp:119:21: error: cannot convert 'at::vec::SVE256::Vectorized<float>' to 'float32x4_t'
  119 |   return vaddvq_f32(x);
      |                     ^
      |                     |
      |                     at::vec::SVE256::Vectorized<float>
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10