### PR TITLE
Enable c10::sv and std::sv constexpr conversions

### DIFF
--- a/c10/test/util/string_view_test.cpp
+++ b/c10/test/util/string_view_test.cpp
@@ -80,6 +80,20 @@ TEST(StringViewTest, testStringConstructor) {
 }
 } // namespace test_string_constructor
 
+namespace test_std_string_view_constructor {
+void test_std_string_view_conversion_is_implicit(c10::string_view a) {}
+TEST(StringViewTest, testStringViewConstructor) {
+  std::string_view empty;
+  EXPECT_EQ(0, c10::string_view(empty).size());
+  std::string_view hello_std_sv = "hello";
+  c10::string_view hello_sv = hello_std_sv;
+  EXPECT_EQ(5, hello_sv.size());
+  EXPECT_TRUE(string_equal("hello", hello_sv.data(), hello_sv.size()));
+
+  test_std_string_view_conversion_is_implicit(hello_std_sv);
+}
+} // namespace test_std_string_view_constructor
+
 namespace test_conversion_to_string {
 TEST(StringViewTest, testConversionToString) {
   string_view empty;
@@ -90,6 +104,17 @@ TEST(StringViewTest, testConversionToString) {
   EXPECT_EQ(std::string("hello"), hello_str);
 }
 } // namespace test_conversion_to_string
+
+namespace test_conversion_to_std_string_view {
+TEST(StringViewTest, testConversionToString) {
+  c10::string_view empty;
+  EXPECT_EQ(0, std::string_view(empty).size());
+  c10::string_view hello_sv = "hello";
+  std::string_view hello_str(hello_sv);
+  EXPECT_EQ(5, hello_str.size());
+  EXPECT_EQ(std::string_view("hello"), hello_str);
+}
+} // namespace test_conversion_to_std_string_view
 
 namespace test_copy_constructor {
 constexpr string_view hello = "hello";

--- a/c10/util/string_view.h
+++ b/c10/util/string_view.h
@@ -54,6 +54,10 @@ class basic_string_view final {
   /* implicit */ basic_string_view(const ::std::basic_string<CharT>& str)
       : basic_string_view(str.data(), str.size()) {}
 
+  /* implicit */ constexpr basic_string_view(
+      const ::std::basic_string_view<CharT>& str)
+      : basic_string_view(str.data(), str.size()) {}
+
   constexpr basic_string_view(const basic_string_view&) noexcept = default;
 
   constexpr basic_string_view& operator=(
@@ -61,6 +65,10 @@ class basic_string_view final {
     begin_ = rhs.begin_;
     size_ = rhs.size_;
     return *this;
+  }
+
+  constexpr operator ::std::basic_string_view<CharT>() const {
+    return ::std::basic_string_view<CharT>(data(), size());
   }
 
   explicit operator ::std::basic_string<CharT>() const {
@@ -588,7 +596,6 @@ constexpr inline void swap(
     basic_string_view<CharT>& rhs) noexcept {
   lhs.swap(rhs);
 }
-
 using string_view = basic_string_view<char>;
 
 } // namespace c10


### PR DESCRIPTION
As a small step towards moving c10::sv to std::sv and this tiny change shouldn't break META builds.
