### PR TITLE
[logging] Add new utilities to record and log compilation metrics

### DIFF
--- a/test/dynamo/test_metrics_context.py
+++ b/test/dynamo/test_metrics_context.py
@@ -1,0 +1,108 @@
+# Owner(s): ["module: dynamo"]
+
+import time
+
+from torch._dynamo.metrics_context import MetricsContext
+from torch._dynamo.test_case import run_tests, TestCase
+
+
+class TestMetricsContext(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.metrics = {}
+
+    def _on_exit(self, metrics, exc_type, exc_value):
+        # Save away the metrics to be validated in the test.
+        self.metrics = metrics.copy()
+
+    def test_context_exists(self):
+        """
+        Setting a value with entering the context should raise.
+        """
+        context = MetricsContext(self._on_exit)
+        with self.assertRaisesRegex(RuntimeError, "outside of a MetricsContext"):
+            context.increment("metric", 1)
+
+        with self.assertRaisesRegex(RuntimeError, "outside of a MetricsContext"):
+            context.set("metric", 1)
+
+        with self.assertRaisesRegex(RuntimeError, "outside of a MetricsContext"):
+            context.set_once("metric", 1)
+
+        with self.assertRaisesRegex(RuntimeError, "outside of a MetricsContext"):
+            context.update({"metric", 1})
+
+    def test_nested_context(self):
+        """
+        Entering the context twice should raise.
+        """
+        with self.assertRaisesRegex(RuntimeError, "Cannot re-enter"):
+            context = MetricsContext(self._on_exit)
+            with context:
+                with context:
+                    pass
+
+    def test_set(self):
+        """
+        Validate various ways to set metrics.
+        """
+        with MetricsContext(self._on_exit) as context:
+            context.set("m1", 1)
+            context.set_once("m2", 2)
+            context.update({"m3": 3, "m4": 4})
+
+        self.assertEqual(self.metrics, {"m1": 1, "m2": 2, "m3": 3, "m4": 4})
+
+    def test_timed(self):
+        """
+        Validate the timed contextmanager.
+        """
+        context = MetricsContext(self._on_exit)
+
+        # Make sure we count recursive calls correctly. We should account
+        # for the full time of execution, but not double count.
+        def fn(n=10):
+            with context.timed("runtime_ms"):
+                if n == 3:
+                    time.sleep(0.7)
+                elif n == 2:
+                    time.sleep(0.3)
+                if n > 0:
+                    fn(n - 1)
+
+        with context:
+            fn()
+
+        runtime_ms = self.metrics.get("runtime_ms", None)
+        self.assertTrue(runtime_ms is not None)
+        self.assertTrue(runtime_ms > 900)
+        self.assertTrue(runtime_ms < 1100)
+
+    def test_timed_decorator(self):
+        """
+        Validate the timed contextmanager as a decorator.
+        """
+        context = MetricsContext(self._on_exit)
+
+        # Make sure we count recursive calls correctly. We should account
+        # for the full time of execution, but not double count.
+        @context.timed("runtime_us")
+        def fn(n=10):
+            if n > 0:
+                fn(n - 1)
+            if n == 3:
+                time.sleep(0.7)
+            elif n == 2:
+                time.sleep(0.3)
+
+        with context:
+            fn()
+
+        runtime_us = self.metrics.get("runtime_us", None)
+        self.assertTrue(runtime_us is not None)
+        self.assertTrue(runtime_us > 900000)
+        self.assertTrue(runtime_us < 1100000)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_dynamo/metrics_context.py
+++ b/torch/_dynamo/metrics_context.py
@@ -1,0 +1,123 @@
+import time
+from contextlib import contextmanager
+from typing import Any, Callable, Dict, Generator, Optional, Type, Union
+from typing_extensions import TypeAlias
+
+
+OnExitType: TypeAlias = Callable[
+    [Dict[str, Any], Optional[Type[BaseException]], Optional[BaseException]], None
+]
+
+
+class MetricsContext:
+    def __init__(self, on_exit: OnExitType):
+        """
+        Use this class as a contextmanager to create a context under which to accumulate
+        a set of metrics, e.g., metrics gathered during a compilation. On exit of the
+        contextmanager, we call the provided 'on_exit' function and pass a dictionary of
+        all metrics set during the lifetime of the contextmanager. Automatically adjusts
+        timing for any timed fields, i.e., those with a suffix of '_us', '_ms', or '_s'.
+        """
+        self._on_exit = on_exit
+        self._metrics: Dict[str, Any] = {}
+        self._start_time: Dict[str, int] = {}
+        self._recording = False
+
+    def __enter__(self) -> "MetricsContext":
+        """
+        Initialize metrics recording.
+        """
+        if self._recording:
+            raise RuntimeError("Cannot re-enter a MetricsContext")
+        self._metrics = {}
+        self._start_time = {}
+        self._recording = True
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        _traceback: Any,
+    ) -> None:
+        """
+        Post-process metrics where appropriate and call the provided on_exit function.
+        """
+        for name, value in self._metrics.items():
+            if not isinstance(value, (float, int)):
+                continue
+
+            if name.endswith("_us"):
+                self._metrics[name] = self._metrics[name] // 1000
+            elif name.endswith("_ms"):
+                self._metrics[name] = self._metrics[name] // 1000**2
+            elif name.endswith("_s"):
+                self._metrics[name] = float(self._metrics[name]) / 1000**3
+
+        self._on_exit(self._metrics, exc_type, exc_value)
+        self._recording = False
+
+    def _check(self) -> None:
+        """
+        Raise if we haven't entered the contextmanager.
+        """
+        if not self._recording:
+            raise RuntimeError("Cannot set metrics outside of a MetricsContext")
+
+    def increment(self, metric: str, value: Union[str, float]) -> None:
+        """
+        Increment a metric by a given amount.
+        """
+        self._check()
+        if metric not in self._metrics:
+            self._metrics[metric] = 0
+        self._metrics[metric] += value
+
+    def set(self, metric: str, value: Any) -> None:
+        """
+        Set a metric to a given value. Use set_once to raise if the metric is set
+        more than once.
+        """
+        self._check()
+        self._metrics[metric] = value
+
+    def set_once(self, metric: str, value: Any) -> None:
+        """
+        Set a metric to a given value. Raise if the metrics has been set previously
+        in the current context.
+        """
+        self._check()
+        if metric in self._metrics:
+            raise RuntimeError(
+                f"Metric '{metric}' has already been set in the current context"
+            )
+        self._metrics[metric] = value
+
+    def update(self, values: Dict[str, Any]) -> None:
+        """
+        Set multiple metrics.
+        """
+        self._check()
+        self._metrics.update(values)
+
+    @contextmanager
+    def timed(self, metric: str) -> Generator[Any, None, None]:
+        """
+        Use this context manager to record execution time. Note that at exit, any
+        timing fields are updated automatically to represent us, ms, or s depending
+        on the suffix: "_us", "_ms", or "_s", respectively.
+        """
+
+        # To properly record timing when there's recursion, start and stop the timer
+        # only for the outermost instance of any metric.
+        outermost = False
+        if metric not in self._start_time:
+            self._start_time[metric] = time.time_ns()
+            outermost = True
+        try:
+            yield
+        finally:
+            if outermost:
+                elapsed = time.time_ns() - self._start_time[metric]
+                self.increment(metric, elapsed)
+                del self._start_time[metric]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #139263
* #139260
* __->__ #139259

Summary: Add a new class we'll use to capture various metrics during compile that we'll use to log CompilationMetrics.

Test Plan: New unit tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames