### PR TITLE
[logging] Superficial use of new metrics_context in CompilationMetrics logging

### DIFF
--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -17,6 +17,7 @@ from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Union
 import torch
 import torch.utils.dlpack
 from torch import Tensor
+from torch._dynamo.utils import metrics_context
 from torch._guards import (
     compile_context,
     CompileContext,
@@ -1986,7 +1987,9 @@ To fix this, your tensor subclass must implement the dunder method __force_to_sa
                         )
                         with tracing(saved_context), compile_context(
                             saved_compile_context
-                        ), context(), track_graph_compiling(aot_config, "backward"):
+                        ), context(), track_graph_compiling(
+                            aot_config, "backward"
+                        ), metrics_context:
                             CompiledFunction.compiled_bw = aot_config.bw_compiler(
                                 bw_module, placeholder_list
                             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #139263
* __->__ #139260
* #139259

Summary: This change makes use of the new metrics accounting utility to record CompilationMetrics. This is a first step and not a deep integration: wherever we were previously creating a CompilationMetrics object to log, we instead update the current metrics_context and rely on that contextmanager to call record_compilation_metrics when it exits. In a subsequent change, we'll add usage of the 'timed' contextmanager to collect various compile times.

Test Plan: unit test

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames