### PR TITLE
[logging] Use metrics_context.timed to log CompilationMetrics time fields

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -88,6 +88,7 @@ from .utils import (
     increment_op_count,
     lazy_format_graph_code,
     LazyString,
+    metrics_context,
     nn_module_proxy,
     same,
     set_example_value,
@@ -1454,7 +1455,7 @@ class OutputGraph:
     def call_user_compiler(self, gm: fx.GraphModule) -> CompiledFn:
         with dynamo_timed(
             "OutputGraph.call_user_compiler", phase_name="backend_compile"
-        ):
+        ), metrics_context.timed("aot_autograd_cumulative_compile_time_us"):
             return self._call_user_compiler(gm)
 
     def _call_user_compiler(self, gm: fx.GraphModule) -> CompiledFn:

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -336,12 +336,6 @@ def dynamo_timed(
                         # one record for one bwd graph.
                         if phase_name == "inductor_compile":
                             if fail_type is None:
-                                inductor_compile_time = frame_phase_timing[
-                                    compile_id
-                                ].get("inductor_compile", None)
-                                code_gen_time = frame_phase_timing[compile_id].get(
-                                    "code_gen", None
-                                )
                                 remote_cache_time_saved = frame_phase_timing[
                                     compile_id
                                 ].get("remote_cache_time_saved", None)
@@ -352,8 +346,6 @@ def dynamo_timed(
                                     compile_id
                                 ].get("remote_fx_graph_cache_put", None)
                             else:
-                                inductor_compile_time = None
-                                code_gen_time = None
                                 remote_cache_time_saved = None
                                 remote_fx_graph_cache_get_time = None
                                 remote_fx_graph_cache_put_time = None
@@ -362,8 +354,6 @@ def dynamo_timed(
                             )
                             metrics = {
                                 "compile_id": compile_id,
-                                "inductor_compile_time_s": inductor_compile_time,
-                                "code_gen_time_s": code_gen_time,
                                 "fail_type": fail_type,
                                 "fail_reason": fail_reason,
                                 "remote_cache_time_saved_s": remote_cache_time_saved,
@@ -377,12 +367,6 @@ def dynamo_timed(
                                 ),
                                 "start_time_us": start_ns // 1000,
                                 "duration_us": (end_ns - start_ns) // 1000,
-                                "inductor_cumulative_compile_time_us": to_int_us(
-                                    inductor_compile_time
-                                ),
-                                "inductor_code_gen_cumulative_compile_time_us": to_int_us(
-                                    code_gen_time
-                                ),
                                 "distributed_ephemeral_timeout_us": to_int_us(
                                     remote_cache_time_saved
                                 ),  # TODO: instrument more accurately
@@ -813,7 +797,7 @@ def to_int_us(v: Optional[float]) -> Optional[int]:
 
 # Version field added to every log. Increment to make it easier to distinguish new
 # vs. old entries when you make a substantive change to how the logs are populated.
-LOG_FORMAT_VERSION = 1
+LOG_FORMAT_VERSION = 2
 
 
 @dataclasses.dataclass
@@ -831,10 +815,6 @@ class CompilationMetrics:
     graph_node_count: Optional[int] = None
     graph_input_count: Optional[int] = None
     start_time: Optional[float] = None
-    entire_frame_compile_time_s: Optional[float] = None
-    backend_compile_time_s: Optional[float] = None
-    inductor_compile_time_s: Optional[float] = None
-    code_gen_time_s: Optional[float] = None
     fail_type: Optional[str] = None
     fail_reason: Optional[str] = None
     fail_user_frame_filename: Optional[str] = None

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -47,6 +47,7 @@ from torch._dynamo.utils import (
     dynamo_timed,
     flatten_graph_inputs,
     lazy_format_graph_code,
+    metrics_context,
 )
 from torch._functorch import config as functorch_config
 from torch._functorch.aot_autograd import aot_export_module, make_boxed_func
@@ -574,6 +575,7 @@ def compile_fx_inner(
         stack.enter_context(_WaitCounter("pytorch.wait_counter.dynamo_compile").guard())
         stack.enter_context(with_fresh_cache_if_config())
         stack.enter_context(DebugContext())
+        stack.enter_context(metrics_context.timed("inductor_cumulative_compile_time_us"))
 
         return wrap_compiler_debug(_compile_fx_inner, compiler_name="inductor")(
             gm,

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -34,7 +34,7 @@ import torch._logging
 import torch.fx
 from torch import device, Tensor
 from torch._decomp import get_decompositions
-from torch._dynamo.utils import defake, dynamo_timed
+from torch._dynamo.utils import defake, dynamo_timed, metrics_context
 from torch._logging import LazyString, trace_structured
 from torch._prims_common import make_channels_last_strides_for
 from torch._subclasses.fake_tensor import FakeTensor
@@ -1946,7 +1946,7 @@ class GraphLowering(torch.fx.Interpreter):
     def compile_to_module(self) -> ModuleType:
         with dynamo_timed(
             "GraphLowering.compile_to_module", phase_name="code_gen", fwd_only=False
-        ):
+        ), metrics_context.timed("inductor_code_gen_cumulative_compile_time_us"):
             return self._compile_to_module()
 
     def _compile_to_module(self) -> ModuleType:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139263
* #139260
* #139259

Summary: Next step in migrating to use metrics_context: update several fields to use metrics_context.timed rather than gathering them from frame_phase_timing. There are some fields that are updated only internally (remote cache get/put times), so those will be handled separately. Note that I'm removing obsolete columns in this PR. For example, I'm capturing `dynamo_cumulative_compile_time_us` directly using the new utility and removing `entire_frame_compile`. Same for the other metrics affected here.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov