### PR TITLE
Fix index_reduce mean error when dtype is bfloat16 (#139242)

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -1140,8 +1140,8 @@ static void index_reduce_func_impl(
     });
 
     if (op == ReductionType::MEAN) {
-      auto counts = include_self ? at::ones_like(result, ScalarType::Long) : at::zeros_like(result, ScalarType::Long);
-      counts.index_add_(dim, index, at::ones_like(source, ScalarType::Long));
+      auto counts = include_self ? at::ones_like(result, index.dtype()) : at::zeros_like(result, index.dtype());
+      counts.index_add_(dim, index, at::ones_like(source, index.dtype()));
       counts.masked_fill_(counts == 0, 1);
       if (result.is_floating_point() || result.is_complex()) {
         result.div_(counts);

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1313,8 +1313,8 @@ TORCH_IMPL_FUNC(index_reduce_cuda_out)
     index_reduce_func_cuda_impl(self, dim, index, source, include_self, ReductionType::PROD, reduce_multiply, result);
   } else if (reduce == "mean") {
     index_reduce_func_cuda_impl(self, dim, index, source, include_self, ReductionType::MEAN, reduce_add, result);
-    auto counts = include_self ? at::ones_like(result, ScalarType::Long) : at::zeros_like(result, ScalarType::Long);
-    counts.index_add_(dim, index, at::ones_like(source, ScalarType::Long));
+    auto counts = include_self ? at::ones_like(result, index.dtype()) : at::zeros_like(result, index.dtype());
+    counts.index_add_(dim, index, at::ones_like(source, index.dtype()));
     counts.masked_fill_(counts == 0, 1);
     if (result.is_floating_point() || result.is_complex()) {
       result.div_(counts);

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1313,8 +1313,8 @@ TORCH_IMPL_FUNC(index_reduce_cuda_out)
     index_reduce_func_cuda_impl(self, dim, index, source, include_self, ReductionType::PROD, reduce_multiply, result);
   } else if (reduce == "mean") {
     index_reduce_func_cuda_impl(self, dim, index, source, include_self, ReductionType::MEAN, reduce_add, result);
-    auto counts = include_self ? at::ones_like(result) : at::zeros_like(result);
-    counts.index_add_(dim, index, at::ones_like(source));
+    auto counts = include_self ? at::ones_like(result, ScalarType::Long) : at::zeros_like(result, ScalarType::Long);
+    counts.index_add_(dim, index, at::ones_like(source, ScalarType::Long));
     counts.masked_fill_(counts == 0, 1);
     if (result.is_floating_point() || result.is_complex()) {
       result.div_(counts);

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -5,6 +5,7 @@ import random
 import unittest
 import warnings
 from functools import reduce
+from itertools import product
 
 import numpy as np
 
@@ -20,8 +21,10 @@ from torch.testing._internal.common_device_type import (
     onlyNativeDeviceTypes,
     skipXLA,
 )
+from torch.testing._internal.common_dtype import all_types_and
 from torch.testing._internal.common_utils import (
     DeterministicGuard,
+    parametrize,
     run_tests,
     serialTest,
     skipIfTorchDynamo,
@@ -1647,6 +1650,87 @@ class TestIndexing(TestCase):
         idx_max = torch.iinfo(torch.int64).max
         self.assertRaises(IndexError, lambda: t[idx_min])
         self.assertRaises(IndexError, lambda: t[idx_max])
+
+    @parametrize("reduce", ["prod", "amin", "amax", "mean"])
+    @dtypes(*all_types_and(torch.half, torch.bfloat16))
+    def test_index_reduce(self, device, dtype, reduce):
+        sizes = [(3, 4, 5), (512,)]
+        index_dtypes = [torch.int, torch.long]
+        include_selfs = [True, False]
+        amin_init = float("inf") if dtype.is_floating_point else torch.iinfo(dtype).max
+        amax_init = -float("inf") if dtype.is_floating_point else torch.iinfo(dtype).min
+        reduction_init = {"prod": 1, "mean": 0, "amin": amin_init, "amax": amax_init}
+
+        for dest_noncontig, src_noncontig, index_noncontig in product(
+            [True, False], repeat=3
+        ):
+            for idx_dtype, include_self in product(index_dtypes, include_selfs):
+                for size in sizes:
+                    for dim in range(len(size)):
+                        num_src = np.random.randint(10)
+                        num_dest = size[dim]
+                        dest = make_tensor(
+                            size,
+                            device=device,
+                            dtype=dtype,
+                            noncontiguous=dest_noncontig,
+                        )
+                        src_size = size[:dim] + (num_src,) + size[dim + 1 :]
+                        src = make_tensor(
+                            src_size,
+                            device=device,
+                            dtype=dtype,
+                            noncontiguous=src_noncontig,
+                        )
+                        idx = torch.testing.make_tensor(
+                            num_src,
+                            low=0,
+                            high=num_dest,
+                            dtype=idx_dtype,
+                            device=device,
+                            noncontiguous=index_noncontig,
+                        )
+                        expected = dest.clone()
+                        dest.index_reduce_(
+                            dim, idx, src, reduce, include_self=include_self
+                        )
+                        # fill rows in idx with reduction inits if include_self=False
+                        if not include_self:
+                            expected.index_fill_(
+                                dim, idx.long(), reduction_init[reduce]
+                            )
+                        expected = expected.transpose(0, dim)
+                        src = src.transpose(0, dim)
+                        for i in range(num_src):
+                            if reduce == "prod":
+                                expected[idx[i]] *= src[i]
+                            elif reduce == "amin":
+                                torch.minimum(
+                                    expected[idx[i]], src[i], out=expected[idx[i]]
+                                )
+                            elif reduce == "amax":
+                                torch.maximum(
+                                    expected[idx[i]], src[i], out=expected[idx[i]]
+                                )
+                            else:
+                                expected[idx[i]] += src[i]
+                        if reduce == "mean":
+                            counts = (
+                                torch.ones_like(expected, dtype=idx_dtype)
+                                if include_self
+                                else torch.zeros_like(expected, dtype=idx_dtype)
+                            )
+                            counts.index_add_(
+                                0, idx, torch.ones_like(src, dtype=idx_dtype)
+                            )
+                            counts.masked_fill_(counts == 0, 1)
+                            if dtype.is_floating_point:
+                                expected.div_(counts)
+                            else:
+                                expected.div_(counts, rounding_mode="floor")
+                        expected = expected.transpose(0, dim)
+
+                        self.assertEqual(dest, expected)
 
 
 # The tests below are from NumPy test_indexing.py with some modifications to

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3362,57 +3362,6 @@ else:
         actual = torch.narrow_copy(inp, 1, 0, 10)
         self.assertEqual(expected, actual)
 
-    # FIXME: move to indexing test suite
-    @parametrize("reduce", ['prod', 'amin', 'amax', 'mean'])
-    @dtypes(*all_types_and(torch.half, torch.bfloat16))
-    def test_index_reduce(self, device, dtype, reduce):
-        sizes = [(3, 4, 5), (512,)]
-        index_dtypes = [torch.int, torch.long]
-        include_selfs = [True, False]
-        amin_init = float('inf') if dtype.is_floating_point else torch.iinfo(dtype).max
-        amax_init = -float('inf') if dtype.is_floating_point else torch.iinfo(dtype).min
-        reduction_init = {'prod': 1, 'mean': 0, 'amin': amin_init, 'amax': amax_init}
-
-        for dest_noncontig, src_noncontig, index_noncontig in product([True, False], repeat=3):
-            for idx_dtype, include_self in product(index_dtypes, include_selfs):
-                for size in sizes:
-                    for dim in range(len(size)):
-                        num_src = np.random.randint(10)
-                        num_dest = size[dim]
-                        dest = make_tensor(size, device=device, dtype=dtype, noncontiguous=dest_noncontig)
-                        src_size = size[:dim] + (num_src,) + size[dim + 1:]
-                        src = make_tensor(src_size, device=device, dtype=dtype, noncontiguous=src_noncontig)
-                        idx = torch.testing.make_tensor(
-                            num_src, low=0, high=num_dest, dtype=idx_dtype, device=device, noncontiguous=index_noncontig
-                        )
-                        expected = dest.clone()
-                        dest.index_reduce_(dim, idx, src, reduce, include_self=include_self)
-                        # fill rows in idx with reduction inits if include_self=False
-                        if (not include_self):
-                            expected.index_fill_(dim, idx.long(), reduction_init[reduce])
-                        expected = expected.transpose(0, dim)
-                        src = src.transpose(0, dim)
-                        for i in range(num_src):
-                            if reduce == 'prod':
-                                expected[idx[i]] *= src[i]
-                            elif reduce == 'amin':
-                                torch.minimum(expected[idx[i]], src[i], out=expected[idx[i]])
-                            elif reduce == 'amax':
-                                torch.maximum(expected[idx[i]], src[i], out=expected[idx[i]])
-                            else:
-                                expected[idx[i]] += src[i]
-                        if reduce == 'mean':
-                            counts = torch.ones_like(expected, dtype=idx_dtype) if include_self else torch.zeros_like(expected, dtype=idx_dtype)
-                            counts.index_add_(0, idx, torch.ones_like(src, dtype=idx_dtype))
-                            counts.masked_fill_(counts == 0, 1)
-                            if (dtype.is_floating_point):
-                                expected.div_(counts)
-                            else:
-                                expected.div_(counts, rounding_mode="floor")
-                        expected = expected.transpose(0, dim)
-
-                        self.assertEqual(dest, expected)
-
     # FIXME: move to test indexing
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
     def test_index_copy(self, device, dtype):


### PR DESCRIPTION
Change the variable `count` from scalar_t to int64_t in case of accumulation error

Fixes #139242
