### PR TITLE
[Dynamo] Fix graph break when `tensor.split()` is called within a device context manager

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -6195,7 +6195,6 @@ def forward(self, s0 : torch.SymInt, s1 : torch.SymInt, L_x_ : torch.Tensor):
         # Ensure that the listcomp is fully compiled
         self.assertEqual(cnt.op_count, 8)
 
-    # https://github.com/pytorch/pytorch/issues/139183
     def test_tensor_split_within_device_cm(self):
         @torch.compile(fullgraph=True)
         def split(x):

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -6201,7 +6201,7 @@ def forward(self, s0 : torch.SymInt, s1 : torch.SymInt, L_x_ : torch.Tensor):
         def split(x):
             return x.split(4, 0)
 
-        x = torch.randn(12)
+        x = torch.zeros(12)
         res = split(x)
 
         with torch.device("cpu"):

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -6195,6 +6195,18 @@ def forward(self, s0 : torch.SymInt, s1 : torch.SymInt, L_x_ : torch.Tensor):
         # Ensure that the listcomp is fully compiled
         self.assertEqual(cnt.op_count, 8)
 
+    # https://github.com/pytorch/pytorch/issues/139183
+    def test_tensor_split_within_device_cm(self):
+        @torch.compile(fullgraph=True)
+        def split(x):
+            return x.split(4, 0)
+
+        x = torch.randn(12)
+        res = split(x)
+
+        with torch.device("cpu"):
+            self.assertEqual(res, split(x))
+
 
 instantiate_parametrized_tests(ReproTests)
 

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -192,6 +192,7 @@ manual_torch_name_rule_map = {
     "torch.sym_sum": TorchInGraphFunctionVariable,
     "torch.Tensor#_make_wrapper_subclass": SkipFunctionVariable,
     "torch.Tensor#__init__": SkipFunctionVariable,
+    "torch.Tensor#split": TorchInGraphFunctionVariable,
     "torch.cuda.set_device": SkipFunctionVariable,
     "torch.cuda.current_device": TorchInGraphFunctionVariable,
     "torch._C.autocast_decrement_nesting": SkipFunctionVariable,


### PR DESCRIPTION
Fixes: #139183

Note: this case can also be reproduced on cpu

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames