### PR TITLE
Add bfloat16 support for per tensor/channel cpu/cuda fake quantize ops

### DIFF
--- a/aten/src/ATen/native/quantized/cuda/FakeQuantizeCore.cu
+++ b/aten/src/ATen/native/quantized/cuda/FakeQuantizeCore.cu
@@ -34,20 +34,38 @@ void fake_quantize_tensor_cachemask_kernel_cuda(
     .add_output(mask)
     .add_input(input)
     .build();
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
-    gpu_kernel_multiple_outputs(
-      iter,
-      [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
-        const auto qval = static_cast<int64_t>(std::nearbyint(input_val * inv_scale) + zero_point);
-        return {
-          // fake_quantized value
-          (fminf(quant_max, fmaxf(quant_min, qval)) - zero_point) * scale,
-          // mask for grad
-          ((quant_min <= qval) && (qval <= quant_max))
-        };
-      }
-    );
-  });
+
+  if (at::isReducedFloatingType(input.scalar_type())) {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
+      gpu_kernel_multiple_outputs(
+        iter,
+        [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
+          const auto qval = static_cast<int64_t>(std::nearbyint(input_val * inv_scale) + zero_point);
+          return {
+            // fake_quantized value
+            (fminf(quant_max, fmaxf(quant_min, qval)) - zero_point) * scale,
+            // mask for grad
+            ((quant_min <= qval) && (qval <= quant_max))
+          };
+        }
+      );
+    });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
+      gpu_kernel_multiple_outputs(
+        iter,
+        [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
+          const auto qval = static_cast<int64_t>(std::nearbyint(input_val * inv_scale) + zero_point);
+          return {
+            // fake_quantized value
+            (fminf(quant_max, fmaxf(quant_min, qval)) - zero_point) * scale,
+            // mask for grad
+            ((quant_min <= qval) && (qval <= quant_max))
+          };
+        }
+      );
+    });
+  }
 }
 
 void fake_quantize_tensor_cachemask_tensor_qparams_kernel_cuda(
@@ -68,24 +86,46 @@ void fake_quantize_tensor_cachemask_tensor_qparams_kernel_cuda(
     .add_output(mask)
     .add_input(input)
     .build();
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
-    gpu_kernel_multiple_outputs(
-      iter,
-      [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
-        if (*fake_quant_on == 0) {
-          return {input_val, 1};
+
+  if (at::isReducedFloatingType(input.scalar_type())) {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
+      gpu_kernel_multiple_outputs(
+        iter,
+        [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
+          if (*fake_quant_on == 0) {
+            return {input_val, 1};
+          }
+          float inv_scale = 1.0f / (*scale_ptr);
+          const auto qval = static_cast<int64_t>(std::nearbyint(input_val * inv_scale) + (*zp_ptr));
+          return {
+            // fake_quantized value
+            (fminf(quant_max, fmaxf(quant_min, qval)) - (*zp_ptr)) * (*scale_ptr),
+            // mask for grad
+            ((quant_min <= qval) && (qval <= quant_max))
+          };
         }
-        float inv_scale = 1.0f / (*scale_ptr);
-        const auto qval = static_cast<int64_t>(std::nearbyint(input_val * inv_scale) + (*zp_ptr));
-        return {
-          // fake_quantized value
-          (fminf(quant_max, fmaxf(quant_min, qval)) - (*zp_ptr)) * (*scale_ptr),
-          // mask for grad
-          ((quant_min <= qval) && (qval <= quant_max))
-        };
-      }
-    );
-  });
+      );
+    });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
+      gpu_kernel_multiple_outputs(
+        iter,
+        [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
+          if (*fake_quant_on == 0) {
+            return {input_val, 1};
+          }
+          float inv_scale = 1.0f / (*scale_ptr);
+          const auto qval = static_cast<int64_t>(std::nearbyint(input_val * inv_scale) + (*zp_ptr));
+          return {
+            // fake_quantized value
+            (fminf(quant_max, fmaxf(quant_min, qval)) - (*zp_ptr)) * (*scale_ptr),
+            // mask for grad
+            ((quant_min <= qval) && (qval <= quant_max))
+          };
+        }
+      );
+    });
+  }
 }
 
 void _fake_quantize_grad_learnable_tensor_kernel_cuda(
@@ -181,9 +221,15 @@ void _fake_quant_per_channel_cachemask_cuda_helper(
 
 void fake_quant_per_channel_cachemask_cuda(
     TensorIterator &iter, TensorIterator &iter_mask, int64_t quant_min, int64_t quant_max) {
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "fake_quantize_channel_cachemask_cpu_type_handling", [&] {
-    _fake_quant_per_channel_cachemask_cuda_helper<scalar_t>(iter, iter_mask, quant_min, quant_max);
-  });
+  if (at::isReducedFloatingType(iter.dtype())) {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(iter.dtype(), "fake_quantize_channel_cachemask_cuda_type_handling", [&] {
+      _fake_quant_per_channel_cachemask_cuda_helper<scalar_t>(iter, iter_mask, quant_min, quant_max);
+    });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "fake_quantize_channel_cachemask_cuda_type_handling", [&] {
+      _fake_quant_per_channel_cachemask_cuda_helper<scalar_t>(iter, iter_mask, quant_min, quant_max);
+    });
+  }
 }
 
 void _fake_quantize_grad_learnable_channel_kernel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max, float grad_factor) {

--- a/test/quantization/core/test_workflow_ops.py
+++ b/test/quantization/core/test_workflow_ops.py
@@ -331,7 +331,7 @@ class TestFakeQuantizeOps(TestCase):
         self.assertEqual(Y3, Y3r, rtol=tolerance, atol=tolerance)
 
     def _test_forward_per_tensor_cachemask_impl(self, device):
-        float_types = (torch.float32, torch.float16, torch.float64)
+        float_types = (torch.float32, torch.float16, torch.float64, torch.bfloat16)
         torch_types = (torch.qint8, torch.quint8)
         Xs = (torch.randn(4, 8, device=device), torch.randn(4, 16, device=device)[:, ::2])
         tensor_qparam = (True, False)
@@ -698,7 +698,7 @@ class TestFakeQuantizeOps(TestCase):
 
     def _test_forward_per_channel_cachemask_impl(self, device):
         torch_types = (torch.qint8, torch.quint8)
-        float_types = (torch.float32, torch.float16, torch.float64)
+        float_types = (torch.float32, torch.float16, torch.float64, torch.bfloat16)
         zero_point_types = (torch.int, torch.float32, torch.float16)
 
         for torch_type, float_type, zero_point_type in itertools.product(torch_types, float_types, zero_point_types):
@@ -716,7 +716,7 @@ class TestFakeQuantizeOps(TestCase):
                 X.cpu(), scale.cpu(), zero_point.cpu(), axis, quant_min, quant_max)
             Y_prime = torch.fake_quantize_per_channel_affine(
                 X, scale, zero_point, axis, quant_min, quant_max)
-            np.testing.assert_allclose(Y, Y_prime.cpu(), rtol=tolerance, atol=tolerance)
+            torch.testing.assert_allclose(Y, Y_prime.cpu(), rtol=tolerance, atol=tolerance)
             self.assertTrue(Y.dtype == float_type)
 
     def test_forward_per_channel_cachemask_cpu(self):


### PR DESCRIPTION
Summary: Fixes https://fb.workplace.com/groups/2240361332735959/permalink/8190736677698365

Test Plan:
buck2 test 'fbcode//mode/dev' fbcode//caffe2/test/quantization:test_quantization -- --exact 'caffe2/test/quantization:test_quantization - test_forward_per_channel_cachemask_cpu (caffe2.test.quantization.core.test_workflow_ops.TestFakeQuantizeOps)'


buck2 test 'fbcode//mode/dev-nosan' fbcode//caffe2/test/quantization:test_quantization -- --exact 'caffe2/test/quantization:test_quantization - test_forward_per_tensor_cachemask_cpu (caffe2.test.quantization.core.test_workflow_ops.TestFakeQuantizeOps)'


buck2 test 'fbcode//mode/dev-nosan' fbcode//caffe2/test/quantization:test_quantization -- --exact 'caffe2/test/quantization:test_quantization - test_forward_per_channel_cachemask_cuda (caffe2.test.quantization.core.test_workflow_ops.TestFakeQuantizeOps)'


buck2 test 'fbcode//mode/dev-nosan' fbcode//caffe2/test/quantization:test_quantization -- --exact 'caffe2/test/quantization:test_quantization - test_forward_per_channel_cachemask_cpu (caffe2.test.quantization.core.test_workflow_ops.TestFakeQuantizeOps)'

Differential Revision: D65221710




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10