### PR TITLE
[Workflow][1/3] Remove benchmack tests from rerun disbled tests

### DIFF
--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -1,11 +1,12 @@
 
-# This workflow is designed to run unit tests for inductor tests.
-
+# Workflow: Inductor Unit Test
+# This workflow runs both unit tests for inductor.
+# It also runs for rerun-disabled-tests work nightly.
 name: inductor-unittest
 on:
   workflow_call:
   schedule:
-    - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests, `schedule 29 8 * * *` is reserved for rerun disabled tests.
+    - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests. `schedule 29 8 * * *` is reserved for rerun disabled tests.
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -1,0 +1,152 @@
+
+# This workflow is designed to run unit tests for inductor tests.
+
+name: inductor-unittest
+on:
+  schedule:
+    - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests, `schedule 29 8 * * *` is reserved for rerun disabled tests.
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  get-label-type:
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+
+  linux-focal-cuda12_1-py3_10-gcc9-inductor-build:
+    name: cuda12.1-py3.10-gcc9-sm86
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm86
+      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn9-py3-gcc9-inductor-benchmarks
+      cuda-arch-list: '8.6'
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      test-matrix: |
+        { include: [
+          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
+          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
+          { config: "inductor_distributed", shard: 1, num_shards: 1, runner: "linux.g5.12xlarge.nvidia.gpu" },
+          { config: "inductor_cpp_wrapper", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
+        ]}
+    secrets: inherit
+
+  linux-focal-cuda12_1-py3_10-gcc9-inductor-test:
+    name: cuda12.1-py3.10-gcc9-sm86
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-focal-cuda12_1-py3_10-gcc9-inductor-build
+    with:
+      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm86
+      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+    secrets: inherit
+
+  linux-focal-cuda12_1-py3_12-gcc9-inductor-build:
+    name: cuda12.1-py3.12-gcc9-sm86
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      build-environment: linux-focal-cuda12.1-py3.12-gcc9-sm86
+      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn9-py3.12-gcc9-inductor-benchmarks
+      cuda-arch-list: '8.6'
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      test-matrix: |
+        { include: [
+          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
+          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
+        ]}
+    secrets: inherit
+
+  linux-focal-cuda12_1-py3_12-gcc9-inductor-test:
+    name: cuda12.1-py3.12-gcc9-sm86
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-focal-cuda12_1-py3_12-gcc9-inductor-build
+    with:
+      build-environment: linux-focal-cuda12.1-py3.12-gcc9-sm86
+      docker-image: ${{ needs.linux-focal-cuda12_1-py3_12-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_12-gcc9-inductor-build.outputs.test-matrix }}
+    secrets: inherit
+
+  linux-jammy-cpu-py3_12-inductor-halide-build:
+    name: linux-jammy-cpu-py3.12-gcc11-inductor-halide
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      build-environment: linux-jammy-py3.12-gcc11
+      docker-image-name: pytorch-linux-jammy-py3.12-halide
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      test-matrix: |
+        { include: [
+          { config: "inductor-halide", shard: 1, num_shards: 1, runner: "linux.12xlarge" },
+        ]}
+    secrets: inherit
+
+  linux-jammy-cpu-py3_12-inductor-halide-test:
+    name: linux-jammy-cpu-py3.12-gcc11-inductor-halide
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-jammy-cpu-py3_12-inductor-halide-build
+    with:
+      build-environment: linux-jammy-py3.12-gcc11
+      docker-image: ${{ needs.linux-jammy-cpu-py3_12-inductor-halide-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cpu-py3_12-inductor-halide-build.outputs.test-matrix }}
+    secrets: inherit
+
+  linux-jammy-cpu-py3_12-inductor-triton-cpu-build:
+    name: linux-jammy-cpu-py3.12-gcc11-inductor-triton-cpu
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      build-environment: linux-jammy-py3.12-gcc11
+      docker-image-name: pytorch-linux-jammy-py3.12-triton-cpu
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      test-matrix: |
+        { include: [
+          { config: "inductor-triton-cpu", shard: 1, num_shards: 1, runner: "linux.12xlarge" },
+        ]}
+
+  linux-jammy-cpu-py3_12-inductor-triton-cpu-test:
+    name: linux-jammy-cpu-py3.12-gcc11-inductor-triton-cpu
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-jammy-cpu-py3_12-inductor-triton-cpu-build
+    with:
+      build-environment: linux-jammy-py3.12-gcc11
+      docker-image: ${{ needs.linux-jammy-cpu-py3_12-inductor-triton-cpu-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cpu-py3_12-inductor-triton-cpu-build.outputs.test-matrix }}
+
+  linux-jammy-cpu-py3_9-gcc11-inductor-build:
+    name: linux-jammy-cpu-py3.9-gcc11-inductor
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      build-environment: linux-jammy-py3.9-gcc11-build
+      docker-image-name: pytorch-linux-jammy-py3.9-gcc11-inductor-benchmarks
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      test-matrix: |
+        { include: [
+          { config: "inductor_avx512", shard: 1, num_shards: 2, runner: "linux.12xlarge" },
+          { config: "inductor_avx512", shard: 2, num_shards: 2, runner: "linux.12xlarge" },
+          { config: "inductor_avx2", shard: 1, num_shards: 2, runner: "linux.10xlarge.avx2" },
+          { config: "inductor_avx2", shard: 2, num_shards: 2, runner: "linux.10xlarge.avx2" },
+        ]}
+    secrets: inherit
+
+  linux-jammy-cpu-py3_9-gcc11-inductor-test:
+    name: linux-jammy-cpu-py3.9-gcc11-inductor
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-jammy-cpu-py3_9-gcc11-inductor-build
+    with:
+      build-environment: linux-jammy-py3.9-gcc11-build
+      docker-image: ${{ needs.linux-jammy-cpu-py3_9-gcc11-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cpu-py3_9-gcc11-inductor-build.outputs.test-matrix }}
+    secrets: inherit

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -4,6 +4,10 @@
 # It also runs for rerun-disabled-tests work nightly.
 name: inductor-unittest
 on:
+  # for testing
+  pull_request:
+    branches:
+      - main
   workflow_call:
   schedule:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests. `schedule 29 8 * * *` is reserved for rerun disabled tests.

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -3,6 +3,7 @@
 
 name: inductor-unittest
 on:
+  workflow_call:
   schedule:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests, `schedule 29 8 * * *` is reserved for rerun disabled tests.
   workflow_dispatch:

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -21,13 +21,6 @@ concurrency:
 permissions: read-all
 
 jobs:
-  echo-event:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Echo GitHub Event
-        env:
-          GITHUB_EVENT: ${{ toJson(github.event) }}
-        run: echo "$GITHUB_EVENT"
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -6,7 +6,7 @@ name: inductor-unittest
 on:
   workflow_call:
     inputs:
-      additional_name:
+      job_name:
         required: false
         default: "inductor-unittest"
         type: string
@@ -15,7 +15,7 @@ on:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ inputs.additional_name || 'default' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ inputs.job_name || 'default' }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       job_name:
         required: false
-        default: "default"
+        default: "inductor-unittest"
         type: string
         description: 'A job name passed for concurrency group'
   schedule:

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -9,7 +9,7 @@ on:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-unit-test
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-unit-test
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -1,13 +1,8 @@
 
 # Workflow: Inductor Unit Test
-# This workflow runs both unit tests for inductor.
-# It also runs for rerun-disabled-tests work nightly.
+# This workflow runs both unit tests for inductor. It also runs for rerun-disabled-tests work nightly.
 name: inductor-unittest
 on:
-  # for testing
-  pull_request:
-    branches:
-      - main
   workflow_call:
   schedule:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests. `schedule 29 8 * * *` is reserved for rerun disabled tests.

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -9,7 +9,7 @@ on:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-inductor-unittest
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -1,13 +1,12 @@
-
 # Workflow: Inductor Unit Test
-# This workflow runs both unit tests for inductor. It also runs for rerun-disabled-tests work nightly.
+# runs unit tests for inductor.
+# Perfoms daily memory leak checks and reruns of disabled tests, scheduled at `29 8 * * *`.
+
 name: inductor-unittest
 on:
   workflow_call:
   schedule:
-    - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests. `schedule 29 8 * * *` is reserved for rerun disabled tests.
-  workflow_dispatch:
-
+    - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -5,11 +5,17 @@
 name: inductor-unittest
 on:
   workflow_call:
+    inputs:
+      job_name:
+        required: false
+        default: "inductor-unittest"
+        type: string
+        description: 'A name passed for concurrency group'
   schedule:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-unittest
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event.inputs.job_name || 'default' }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -15,12 +15,19 @@ on:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event.inputs.job_name || 'default' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-unittest
   cancel-in-progress: true
 
 permissions: read-all
 
 jobs:
+  echo-event:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo GitHub Event
+        env:
+          GITHUB_EVENT: ${{ toJson(github.event) }}
+        run: echo "$GITHUB_EVENT"
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -5,17 +5,11 @@
 name: inductor-unittest
 on:
   workflow_call:
-    inputs:
-      job_name:
-        required: false
-        default: "inductor-unittest"
-        type: string
-        description: 'A name passed for concurrency group'
   schedule:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ inputs.job_name || 'default' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-unit-test
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -1,12 +1,13 @@
 # Workflow: Inductor Unit Test
-# runs unit tests for inductor.
-# Perfoms daily memory leak checks and reruns of disabled tests, scheduled at `29 8 * * *`.
+# 1. runs unit tests for inductor.
+# 2. Perfoms daily memory leak checks and reruns of disabled tests, scheduled at `29 8 * * *`.
 
 name: inductor-unittest
 on:
   workflow_call:
   schedule:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests.
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -1,16 +1,10 @@
 # Workflow: Inductor Unit Test
 # 1. runs unit tests for inductor.
 # 2. perfoms daily memory leak checks and reruns of disabled tests, scheduled at `29 8 * * *`.
-
 name: inductor-unittest
+
 on:
   workflow_call:
-    inputs:
-      job_name:
-        required: false
-        default: "inductor-unittest"
-        type: string
-        description: 'A name passed for concurrency group'
   schedule:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests.
 

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -5,11 +5,16 @@
 name: inductor-unittest
 on:
   workflow_call:
+    inputs:
+      job_name:
+        description: 'A job name passed for concurrency group'
+        required: false
+        type: string
   schedule:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-inductor-unittest
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}${{ inputs.job_name && '-' + inputs.job_name || '' }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -9,7 +9,7 @@ on:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-unit-test
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-unittest
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -1,6 +1,6 @@
 # Workflow: Inductor Unit Test
-# 1. Runs unit tests for inductor.
-# 2. Perfoms daily memory leak checks and reruns of disabled tests, scheduled at `29 8 * * *`.
+# 1. runs unit tests for inductor.
+# 2. perfoms daily memory leak checks and reruns of disabled tests, scheduled at `29 8 * * *`.
 
 name: inductor-unittest
 on:

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -1,5 +1,5 @@
 # Workflow: Inductor Unit Test
-# 1. runs unit tests for inductor.
+# 1. Runs unit tests for inductor.
 # 2. Perfoms daily memory leak checks and reruns of disabled tests, scheduled at `29 8 * * *`.
 
 name: inductor-unittest

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -14,7 +14,7 @@ on:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}${{ inputs.job_name && '-' + inputs.job_name || '' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ inputs.job_name || 'default' }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -7,9 +7,10 @@ on:
   workflow_call:
     inputs:
       job_name:
-        description: 'A job name passed for concurrency group'
         required: false
+        default: "default"
         type: string
+        description: 'A job name passed for concurrency group'
   schedule:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests.
 

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -6,16 +6,16 @@ name: inductor-unittest
 on:
   workflow_call:
     inputs:
-      job_name:
+      additional_name:
         required: false
         default: "inductor-unittest"
         type: string
-        description: 'A job name passed for concurrency group'
+        description: 'A name passed for concurrency group'
   schedule:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ inputs.job_name || 'default' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ inputs.additional_name || 'default' }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -29,6 +29,8 @@ jobs:
     if: github.repository_owner == 'pytorch'
     name: unit-test
     uses: ./.github/workflows/inductor-unittest.yml
+    with:
+      job_name: unit-test
 
   get-label-type:
     name: get-label-type

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -1,9 +1,9 @@
 # Workflow: Inductor
 # runs all inductor tests, including both benchmark tests and unit tests.
-# To add new test:
-#  1. Unit Tests: inductor-unittest.yml
-#  2. Benchmark Tests: this workflow
-#  3. Mixed: inductor-unittest.yml, and skip benchmark tests in test script.
+# Adding New Tests:
+#  1. Unit Tests: add to inductor-unittest.yml
+#  2. Benchmark Tests: add in this workflow
+#  3. Mixed: add to inductor-unittest.yml, and skip benchmark tests using rerun-disabled-test flag in script.
 name: inductor
 on:
   push:

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -27,7 +27,7 @@ permissions: read-all
 jobs:
   unit-test:
     if: github.repository_owner == 'pytorch'
-    name: inductor-unittest
+    name: unittest
     uses: ./.github/workflows/inductor-unittest.yml
     with:
       additional_name: unit-test

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -27,7 +27,7 @@ permissions: read-all
 jobs:
   unit-test:
     if: github.repository_owner == 'pytorch'
-    name: unittest
+    name: unit-test
     uses: ./.github/workflows/inductor-unittest.yml
     with:
       additional_name: unit-test

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -29,8 +29,6 @@ jobs:
     if: github.repository_owner == 'pytorch'
     name: unit-test
     uses: ./.github/workflows/inductor-unittest.yml
-    with:
-      job_name: unit-test
 
   get-label-type:
     name: get-label-type

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -1,6 +1,6 @@
 # Workflow: Inductor
 # runs all inductor tests, including both benchmark tests and unit tests.
-# Adding New Tests:
+# adding New Tests:
 #  1. inductor-unittest.yml:
 #      - Unit Tests
 #      - Mixed Tests

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -26,6 +26,7 @@ permissions: read-all
 
 jobs:
   inductor-unittest:
+    if: github.repository_owner == 'pytorch'
     name: inductor-unittest
     uses: ./.github/workflows/inductor-unittest.yml
 

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -14,13 +14,14 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}-${{ github.event.schedule }}
   cancel-in-progress: true
 
 permissions: read-all
 
 jobs:
   inductor-unittest:
+    if: github.repository_owner == 'pytorch'
     name: inductor-unittest
     uses: ./.github/workflows/inductor-unittest.yml
 

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -30,7 +30,7 @@ jobs:
     name: unit-test
     uses: ./.github/workflows/inductor-unittest.yml
     with:
-      additional_name: unit-test
+      job_name: unit-test
 
   get-label-type:
     name: get-label-type

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -6,7 +6,7 @@
 #      - Mixed Tests
 #      - Flaky Benchmark tests
 #  2. inductor.yml(this workflow):
-#      - non-flaky benchmakr tests
+#      - non-flaky benchmark tests
 name: inductor
 
 on:

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -29,6 +29,8 @@ jobs:
     if: github.repository_owner == 'pytorch'
     name: inductor-unittest
     uses: ./.github/workflows/inductor-unittest.yml
+    with:
+      job_name: inductor-unittest
 
   get-label-type:
     name: get-label-type

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -25,12 +25,12 @@ concurrency:
 permissions: read-all
 
 jobs:
-  inductor-unittest:
+  unit-test:
     if: github.repository_owner == 'pytorch'
     name: inductor-unittest
     uses: ./.github/workflows/inductor-unittest.yml
     with:
-      job_name: inductor-unittest
+      job_name: unit-test
 
   get-label-type:
     name: get-label-type

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -8,6 +8,7 @@
 #  2. inductor.yml(this workflow):
 #      - non-flaky benchmakr tests
 name: inductor
+
 on:
   push:
     branches:

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -30,7 +30,7 @@ jobs:
     name: inductor-unittest
     uses: ./.github/workflows/inductor-unittest.yml
     with:
-      job_name: unit-test
+      additional_name: unit-test
 
   get-label-type:
     name: get-label-type

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -1,3 +1,9 @@
+# Workflow: Inductor
+# This workflow runs both benchmark tests and unit tests for inductor.
+# To include new test:
+#  1. Unit Tests: add to workflow inductor-unittest.yml
+#  2. Benchmark Tests: this workflow
+#  3. Mixed: add to workflow inductor-unittest.yml, and skip benchmark tests using rerun-disabled-tests in bash script.
 name: inductor
 
 on:
@@ -7,8 +13,6 @@ on:
       - release/*
     tags:
       - ciflow/inductor/*
-  schedule:
-    - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests
   workflow_dispatch:
 
 concurrency:
@@ -18,6 +22,10 @@ concurrency:
 permissions: read-all
 
 jobs:
+  inductor-unittest:
+    name: inductor-unittest
+    uses: ./.github/workflows/inductor-unittest.yml
+
   get-label-type:
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
@@ -39,9 +47,6 @@ jobs:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       test-matrix: |
         { include: [
-          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor_distributed", shard: 1, num_shards: 1, runner: "linux.g5.12xlarge.nvidia.gpu" },
           { config: "inductor_huggingface", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
           { config: "inductor_timm", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
           { config: "inductor_timm", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
@@ -57,7 +62,6 @@ jobs:
           { config: "aot_inductor_timm", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
           { config: "aot_inductor_torchbench", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
           { config: "aot_inductor_torchbench", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor_cpp_wrapper", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
         ]}
     secrets: inherit
 
@@ -70,78 +74,6 @@ jobs:
       docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
     secrets: inherit
-
-  linux-focal-cuda12_1-py3_12-gcc9-inductor-build:
-    name: cuda12.1-py3.12-gcc9-sm86
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      build-environment: linux-focal-cuda12.1-py3.12-gcc9-sm86
-      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn9-py3.12-gcc9-inductor-benchmarks
-      cuda-arch-list: '8.6'
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      test-matrix: |
-        { include: [
-          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-        ]}
-    secrets: inherit
-
-  linux-focal-cuda12_1-py3_12-gcc9-inductor-test:
-    name: cuda12.1-py3.12-gcc9-sm86
-    uses: ./.github/workflows/_linux-test.yml
-    needs: linux-focal-cuda12_1-py3_12-gcc9-inductor-build
-    with:
-      build-environment: linux-focal-cuda12.1-py3.12-gcc9-sm86
-      docker-image: ${{ needs.linux-focal-cuda12_1-py3_12-gcc9-inductor-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_12-gcc9-inductor-build.outputs.test-matrix }}
-    secrets: inherit
-
-  linux-jammy-cpu-py3_12-inductor-halide-build:
-    name: linux-jammy-cpu-py3.12-gcc11-inductor-halide
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      build-environment: linux-jammy-py3.12-gcc11
-      docker-image-name: pytorch-linux-jammy-py3.12-halide
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      test-matrix: |
-        { include: [
-          { config: "inductor-halide", shard: 1, num_shards: 1, runner: "linux.12xlarge" },
-        ]}
-    secrets: inherit
-
-  linux-jammy-cpu-py3_12-inductor-halide-test:
-    name: linux-jammy-cpu-py3.12-gcc11-inductor-halide
-    uses: ./.github/workflows/_linux-test.yml
-    needs: linux-jammy-cpu-py3_12-inductor-halide-build
-    with:
-      build-environment: linux-jammy-py3.12-gcc11
-      docker-image: ${{ needs.linux-jammy-cpu-py3_12-inductor-halide-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cpu-py3_12-inductor-halide-build.outputs.test-matrix }}
-    secrets: inherit
-
-  linux-jammy-cpu-py3_12-inductor-triton-cpu-build:
-    name: linux-jammy-cpu-py3.12-gcc11-inductor-triton-cpu
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      build-environment: linux-jammy-py3.12-gcc11
-      docker-image-name: pytorch-linux-jammy-py3.12-triton-cpu
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      test-matrix: |
-        { include: [
-          { config: "inductor-triton-cpu", shard: 1, num_shards: 1, runner: "linux.12xlarge" },
-        ]}
-
-  linux-jammy-cpu-py3_12-inductor-triton-cpu-test:
-    name: linux-jammy-cpu-py3.12-gcc11-inductor-triton-cpu
-    uses: ./.github/workflows/_linux-test.yml
-    needs: linux-jammy-cpu-py3_12-inductor-triton-cpu-build
-    with:
-      build-environment: linux-jammy-py3.12-gcc11
-      docker-image: ${{ needs.linux-jammy-cpu-py3_12-inductor-triton-cpu-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cpu-py3_12-inductor-triton-cpu-build.outputs.test-matrix }}
 
   linux-focal-cuda12_4-py3_10-gcc9-inductor-build:
     # Should be synced with the one in inductor-periodic.yml but this only runs inductor_timm
@@ -182,8 +114,6 @@ jobs:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       test-matrix: |
         { include: [
-          { config: "inductor_avx512", shard: 1, num_shards: 2, runner: "linux.12xlarge" },
-          { config: "inductor_avx512", shard: 2, num_shards: 2, runner: "linux.12xlarge" },
           { config: "cpu_inductor_huggingface", shard: 1, num_shards: 1, runner: "linux.12xlarge" },
           { config: "cpu_inductor_timm", shard: 1, num_shards: 2, runner: "linux.12xlarge" },
           { config: "cpu_inductor_timm", shard: 2, num_shards: 2, runner: "linux.12xlarge" },
@@ -216,8 +146,6 @@ jobs:
           { config: "dynamic_cpu_aot_inductor_amp_freezing_torchbench", shard: 1, num_shards: 2, runner: "linux.12xlarge" },
           { config: "dynamic_cpu_aot_inductor_amp_freezing_torchbench", shard: 2, num_shards: 2, runner: "linux.12xlarge" },
           { config: "inductor_torchbench_cpu_smoketest_perf", shard: 1, num_shards: 1, runner: "linux.24xl.spr-metal" },
-          { config: "inductor_avx2", shard: 1, num_shards: 2, runner: "linux.10xlarge.avx2" },
-          { config: "inductor_avx2", shard: 2, num_shards: 2, runner: "linux.10xlarge.avx2" },
           { config: "cpu_inductor_freezing_avx2_huggingface", shard: 1, num_shards: 1, runner: "linux.10xlarge.avx2" },
           { config: "cpu_inductor_freezing_avx2_torchbench", shard: 1, num_shards: 2, runner: "linux.10xlarge.avx2" },
           { config: "cpu_inductor_freezing_avx2_torchbench", shard: 2, num_shards: 2, runner: "linux.10xlarge.avx2" },

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -1,10 +1,6 @@
 name: inductor
 
 on:
-  # for testing
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -7,6 +7,10 @@
 name: inductor
 
 on:
+  # for testing
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -1,5 +1,10 @@
+# Workflow: Inductor
+# runs all inductor tests, including both benchmark tests and unit tests.
+# To add new test:
+#  1. Unit Tests: inductor-unittest.yml
+#  2. Benchmark Tests: this workflow
+#  3. Mixed: inductor-unittest.yml, and skip benchmark tests in test script.
 name: inductor
-
 on:
   push:
     branches:
@@ -10,14 +15,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}-${{ github.event.schedule }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
 permissions: read-all
 
 jobs:
   inductor-unittest:
-    if: github.repository_owner == 'pytorch'
     name: inductor-unittest
     uses: ./.github/workflows/inductor-unittest.yml
 

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -1,9 +1,12 @@
 # Workflow: Inductor
 # runs all inductor tests, including both benchmark tests and unit tests.
 # Adding New Tests:
-#  1. Unit Tests: add to inductor-unittest.yml
-#  2. Benchmark Tests: add in this workflow
-#  3. Mixed: add to inductor-unittest.yml, and skip benchmark tests using rerun-disabled-test flag in script.
+#  1. inductor-unittest.yml:
+#      - Unit Tests
+#      - Mixed Tests
+#      - Flaky Benchmark tests
+#  2. inductor.yml(this workflow):
+#      - non-flaky benchmakr tests
 name: inductor
 on:
   push:

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -1,9 +1,3 @@
-# Workflow: Inductor
-# This workflow runs both benchmark tests and unit tests for inductor.
-# To include new test:
-#  1. Unit Tests: add to workflow inductor-unittest.yml
-#  2. Benchmark Tests: this workflow
-#  3. Mixed: add to workflow inductor-unittest.yml, and skip benchmark tests using rerun-disabled-tests in bash script.
 name: inductor
 
 on:


### PR DESCRIPTION
Fixes [#5774](https://github.com/pytorch/test-infra/issues/5774)
# Overview 
Remove benchmark tests from rerun-disabled-tests, this is considered non-unittest.
See one page doc: [[Bootcamp Task] Remove non-unittest test during rerun-disabled-tests](https://docs.google.com/document/d/1xffkt_LNC5ZLsoVQDmuKbNqYnMUW_xYYStv66Pr-qac/edit?tab=t.0)

# Manual Test
- Test run Inductor.yml:
https://github.com/pytorch/pytorch/actions/runs/11603287758/job/32309968542?pr=139337
- Test run inductor-unittest.yml ([3cbd83d](https://github.com/pytorch/pytorch/pull/139337/commits/3cbd83d3d5760be979b5b9d70f5b5fd61c7c05de))
https://github.com/pytorch/pytorch/actions/runs/11605399925/job/32315737205?pr=139337

# Steps to fix the issue

- [x]  [**THIS PR**] Create inductor-unittest.yml to handle unit test and daily rerun for inductor 
- [ ] Create Inductor-cu124-unittest.yml to handle unit tests and daily rerun for inductor-cu124
- [ ] Disable benchmark test in mixed test such as CPP_Wrapper which includes both unittest and benchmark test

