### PR TITLE
Add masked_select.default to fallback

### DIFF
--- a/torchgen/aoti/fallback_ops.py
+++ b/torchgen/aoti/fallback_ops.py
@@ -75,6 +75,7 @@ inductor_fallback_ops = {
     "aten.lu_unpack.default",
     "aten.masked_scatter.default",
     "aten.masked_scatter_backward.default",
+    "aten.masked_select.default",
     "aten.max_pool2d_with_indices_backward.default",
     "aten.max_pool2d_with_indices.default",
     "aten.max_pool3d_with_indices.default",


### PR DESCRIPTION
Seeing this warning:

```
W1025 17:01:40.089000 2771567 site-packages/torch/_inductor/ir.py:6220] aten.masked_select.default is missing a c-shim implementation, using proxy executor as fallback
```

Patching the fallback ops to get rid of it

Fixes #ISSUE_NUMBER
