### PR TITLE
Integrate compute sanitizer API in to cuda caching allocator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,10 +205,7 @@ endif()
 # ---[ Options. Note to developers: if you add an option below, make sure you
 # also add it to cmake/Summary.cmake so that the summary prints out the option
 # values.
-# Add this line to include the NVTX library
-add_subdirectory(third_party/NVTX/c/)
-get_property(targets DIRECTORY "${CMAKE_SOURCE_DIR}/third_party/NVTX/c" PROPERTY BUILDSYSTEM_TARGETS)
-message("Available targets after NVTX: ${targets}")
+
 include(CMakeDependentOption)
 option(ATEN_NO_TEST "Do not build ATen test binaries" OFF)
 option(BUILD_BINARY "Build C++ binaries" OFF)
@@ -441,11 +438,6 @@ if(USE_GLOO_WITH_OPENSSL)
   set(USE_TCP_OPENSSL_LOAD
       ON
       CACHE STRING "")
-endif()
-if(USE_SYSTEM_NVTX)
-message("=== SENTINEL USE_SYSTEM_NVTX is ON ===")
-else()
-message("=== SENTINEL USE_SYSTEM_NVTX is OFF ===")
 endif()
 
 # Linux distributions do not want too many embedded sources, in that sense we
@@ -1247,9 +1239,6 @@ if(USE_MIMALLOC)
 endif()
 
 # ---[ Main build
-foreach(target IN LISTS targets)
-  message("Available target: ${target}")
-endforeach()
 add_subdirectory(c10)
 add_subdirectory(caffe2)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,10 @@ endif()
 # ---[ Options. Note to developers: if you add an option below, make sure you
 # also add it to cmake/Summary.cmake so that the summary prints out the option
 # values.
+# Add this line to include the NVTX library
+add_subdirectory(third_party/NVTX/c/)
+get_property(targets DIRECTORY "${CMAKE_SOURCE_DIR}/third_party/NVTX/c" PROPERTY BUILDSYSTEM_TARGETS)
+message("Available targets after NVTX: ${targets}")
 include(CMakeDependentOption)
 option(ATEN_NO_TEST "Do not build ATen test binaries" OFF)
 option(BUILD_BINARY "Build C++ binaries" OFF)
@@ -437,6 +441,11 @@ if(USE_GLOO_WITH_OPENSSL)
   set(USE_TCP_OPENSSL_LOAD
       ON
       CACHE STRING "")
+endif()
+if(USE_SYSTEM_NVTX)
+message("=== SENTINEL USE_SYSTEM_NVTX is ON ===")
+else()
+message("=== SENTINEL USE_SYSTEM_NVTX is OFF ===")
 endif()
 
 # Linux distributions do not want too many embedded sources, in that sense we
@@ -1238,6 +1247,9 @@ if(USE_MIMALLOC)
 endif()
 
 # ---[ Main build
+foreach(target IN LISTS targets)
+  message("Available target: ${target}")
+endforeach()
 add_subdirectory(c10)
 add_subdirectory(caffe2)
 

--- a/c10/cuda/CMakeLists.txt
+++ b/c10/cuda/CMakeLists.txt
@@ -65,25 +65,6 @@ if(NOT BUILD_LIBTORCHLESS)
   endif()
 
   # ---[ Dependency of c10_cuda
-  if(TRUE)
-    message("This will never be printed.")
-    message("This will never be printed.")
-    message("This will never be printed.")
-    message("This will never be printed.")
-  endif()
-  message("CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
-
-  # Try getting the target properties to see what include directories it knows about
-  get_target_property(NVTX_INCLUDES nvtx3-cpp INTERFACE_INCLUDE_DIRECTORIES)
-  message("NVTX include directories: ${NVTX_INCLUDES}")
-  target_include_directories(c10_cuda PRIVATE ${CMAKE_SOURCE_DIR}/third_party/NVTX/c/include)
-
-
-  if(USE_SYSTEM_NVTX)
-    message("=== USE_SYSTEM_NVTX is ON ===")
-  else()
-    message("=== USE_SYSTEM_NVTX is OFF ===")
-  endif()
 
   target_link_libraries(c10_cuda PUBLIC ${C10_LIB} torch::cudart torch::nvtx3)
 

--- a/c10/cuda/CMakeLists.txt
+++ b/c10/cuda/CMakeLists.txt
@@ -65,7 +65,6 @@ if(NOT BUILD_LIBTORCHLESS)
   endif()
 
   # ---[ Dependency of c10_cuda
-
   target_link_libraries(c10_cuda PUBLIC ${C10_LIB} torch::cudart torch::nvtx3)
 
   if(NOT WIN32)

--- a/c10/cuda/CMakeLists.txt
+++ b/c10/cuda/CMakeLists.txt
@@ -65,7 +65,27 @@ if(NOT BUILD_LIBTORCHLESS)
   endif()
 
   # ---[ Dependency of c10_cuda
-  target_link_libraries(c10_cuda PUBLIC ${C10_LIB} torch::cudart)
+  if(TRUE)
+    message("This will never be printed.")
+    message("This will never be printed.")
+    message("This will never be printed.")
+    message("This will never be printed.")
+  endif()
+  message("CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
+
+  # Try getting the target properties to see what include directories it knows about
+  get_target_property(NVTX_INCLUDES nvtx3-cpp INTERFACE_INCLUDE_DIRECTORIES)
+  message("NVTX include directories: ${NVTX_INCLUDES}")
+  target_include_directories(c10_cuda PRIVATE ${CMAKE_SOURCE_DIR}/third_party/NVTX/c/include)
+
+
+  if(USE_SYSTEM_NVTX)
+    message("=== USE_SYSTEM_NVTX is ON ===")
+  else()
+    message("=== USE_SYSTEM_NVTX is OFF ===")
+  endif()
+
+  target_link_libraries(c10_cuda PUBLIC ${C10_LIB} torch::cudart torch::nvtx3)
 
   if(NOT WIN32)
   target_link_libraries(c10_cuda PRIVATE dl)

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -7,7 +7,7 @@
 #include <c10/util/ApproximateClock.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Registry.h>
-
+#include <nvtx3/nvToolsExtMem.h>
 #include <array>
 #include <atomic>
 #include <cstddef>


### PR DESCRIPTION
Currently there exists a branch on NVTX named `dev-mem-api` that offers some cool utility that could be helpful with debugging. The motivating use case of this requires a lot of context and nuances so for now I'll omit it. Please keep in mind this is my first time interacting with the allocator internals so if I have any misunderstandings please LMK.


Summary:
1) Marks blocks as a pool of memory
2) Marks tensors as suballocations that can be tracked by the API now
3) The compute-sanitizer API is now able to be used for memcheck, race checks, initialization checks, etc.  

So you now get access to errors like so(and their stack trace):

```
========= Invalid __global__ write of size 4 bytes
=========     at void at::native::<unnamed>::distribution_elementwise_grid_stride_kernel<float, (int)4, void at::native::templates::cuda::normal_and_transform<float, float, at::CUDAGeneratorImpl *, void at::native::templates::cuda::normal_kernel<at::CUDAGeneratorImpl *>(const at::TensorBase &, double, double, T1)::[lambda() (instance 1)]::operator ()() const::[lambda() (instance 2)]::operator ()() const::[lambda(float) (instance 1)]>(at::TensorIteratorBase &, T3, T4)::[lambda(curandStatePhilox4_32_10 *) (instance 2)], void at::native::<unnamed>::distribution_nullary_kernel<float, float, float4, at::CUDAGeneratorImpl *, void at::native::templates::cuda::normal_and_transform<float, float, at::CUDAGeneratorImpl *, void at::native::templates::cuda::normal_kernel<at::CUDAGeneratorImpl *>(const at::TensorBase &, double, double, T1)::[lambda() (instance 1)]::operator ()() const::[lambda() (instance 2)]::operator ()() const::[lambda(float) (instance 1)]>(at::TensorIteratorBase &, T3, T4)::[lambda(curandStatePhilox4_32_10 *) (instance 2)], void at::native::templates::cuda::normal_kernel<at::CUDAGeneratorImpl *>(const at::TensorBase &, double, double, T1)::[lambda() (instance 1)]::operator ()() const::[lambda() (instance 2)]::operator ()() const::[lambda(float) (instance 1)]>(at::TensorIteratorBase &, T4, const T5 &, T6)::[lambda(int, float) (instance 1)]>(int, at::PhiloxCudaState, T3, T4)+0x1270
=========     by thread (163,0,0) in block (2,0,0)
=========     Address 0xf10220a8c is out of bounds
=========     and is 4522125 bytes after the nearest allocation at 0xf0fa00000 of size 4000256 bytes
=========     Saved host backtrace up to driver entry point at kernel launch time
=========     Host Frame: [0x23b3b7]
=========                in /usr/lib/wsl/drivers/nv_dispui.inf_amd64_79a078bc9eefa4a6/libcuda.so.1.1
=========     Host Frame: [0x15803]
=========                in /usr/local/cuda-12.4/lib64/libcudart.so.12
=========     Host Frame:cudaLaunchKernel [0x75230]
=========                in /usr/local/cuda-12.4/lib64/libcudart.so.12
=========     Host Frame:void at::native::(anonymous namespace)::distribution_nullary_kernel<float, float, float4, at::CUDAGeneratorImpl*..........................) [clone .isra.0] [0x1aa065d]
```

Important to consider that expandable segments is likely to complicate things.