### PR TITLE
Run buck build job on main commit

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -255,16 +255,6 @@ jobs:
           }
         ]}
 
-  buck-build-test:
-    if: github.repository_owner == 'pytorch'
-    name: buck-build-test
-    uses: ./.github/workflows/_buck-build-test.yml
-    with:
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 1, runner: "ubuntu-latest" },
-        ]}
-
   android-emulator-build-test:
     if: github.repository_owner == 'pytorch'
     name: android-emulator-build-test

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -293,3 +293,14 @@ jobs:
       build-environment: linux-focal-cuda12.4-py3.10-gcc9-experimental-split-build
       docker-image: ${{ needs.linux-focal-cuda12_4-py3_10-gcc9-experimental-split-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-cuda12_4-py3_10-gcc9-experimental-split-build.outputs.test-matrix }}
+
+  # No need to run following jobs on PR, just need to gather their signals on main
+  buck-build-test:
+    if: github.repository_owner == 'pytorch' && github.ref == 'refs/heads/main'
+    name: buck-build-test
+    uses: ./.github/workflows/_buck-build-test.yml
+    with:
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 1, runner: "ubuntu-latest" },
+        ]}


### PR DESCRIPTION
As an outcome of https://fburl.com/gdoc/voce5o06, I'm moving buck build job to run on main commit.  It takes around 45 minutes and it could sometimes catch caffe2-related changes like https://github.com/pytorch/pytorch/pull/139217.  Maybe in the near future where caffe2 is cleaned up, we can remove the job.