### PR TITLE
[PyTorch] Unbreak C10_ALWAYS_INLINE_ATTRIBUTE on MSVC

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -217,7 +217,9 @@ using namespace c10::xpu;
 // Unlike C10_ALWAYS_INLINE, C10_ALWAYS_INLINE_ATTRIBUTE can be used
 // on a lambda.
 #if defined(_MSC_VER)
-#define C10_ALWAYS_INLINE_ATTRIBUTE [[msvc::forceinline]]
+// MSVC 14.39 is reasonably recent and doesn't like
+// [[msvc::forceinline]] on a lambda, so don't try to use it.
+#define C10_ALWAYS_INLINE_ATTRIBUTE
 #elif __has_attribute(always_inline) || defined(__GNUC__)
 #define C10_ALWAYS_INLINE_ATTRIBUTE __attribute__((__always_inline__))
 #else


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #139369
* __->__ #139363

At least one recent version refuses to accept it on a lambda, so disable.

Differential Revision: [D65250256](https://our.internmc.facebook.com/intern/diff/D65250256/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D65250256/)!