### PR TITLE
[PyTorch] Correct comment on #310353

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -217,8 +217,7 @@ using namespace c10::xpu;
 // Unlike C10_ALWAYS_INLINE, C10_ALWAYS_INLINE_ATTRIBUTE can be used
 // on a lambda.
 #if defined(_MSC_VER)
-// MSVC 14.39 is reasonably recent and doesn't like
-// [[msvc::forceinline]] on a lambda, so don't try to use it.
+// VS2022 doesn't accept [[msvc::forceinline]] on a lambda..
 #define C10_ALWAYS_INLINE_ATTRIBUTE
 #elif __has_attribute(always_inline) || defined(__GNUC__)
 #define C10_ALWAYS_INLINE_ATTRIBUTE __attribute__((__always_inline__))

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -217,7 +217,8 @@ using namespace c10::xpu;
 // Unlike C10_ALWAYS_INLINE, C10_ALWAYS_INLINE_ATTRIBUTE can be used
 // on a lambda.
 #if defined(_MSC_VER)
-// VS2022 doesn't accept [[msvc::forceinline]] on a lambda..
+// Several recent versions of VS2022 (at least VS17.7 through VS17.10)
+// don't accept [[msvc::forceinline]] on a lambda.
 #define C10_ALWAYS_INLINE_ATTRIBUTE
 #elif __has_attribute(always_inline) || defined(__GNUC__)
 #define C10_ALWAYS_INLINE_ATTRIBUTE __attribute__((__always_inline__))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139369
* #139363

@malfet pointed out that the version I listed was a C++ runtime version.

Differential Revision: [D65253971](https://our.internmc.facebook.com/intern/diff/D65253971/)