### PR TITLE
[inductor] loaf-fix

### DIFF
--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 
 import contextlib
+import os
 import unittest
 
 import numpy as np
@@ -22,6 +23,9 @@ from torch.testing._internal.common_device_type import expectedFailureXPU
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 from torch.utils._pytree import tree_map
 from torch.utils._sympy.functions import ModularIndexing
+
+
+DO_PERF_TEST = os.environ.get("DO_PERF_TEST") == "1"
 
 
 if HAS_GPU:
@@ -451,6 +455,50 @@ class LoopOrderingTest(TestCase):
         expected_numbytes += input_tensor.nbytes  # input
         expected_numbytes += tensor_fp8.nbytes + tensor_fp8_t.nbytes  # output
         self.assertEqual(expected_numbytes, metrics.num_bytes_accessed)
+
+    # Disable split reduction to make it easier to calculate the expected
+    # number of bytes accessed. In this case, split reduction does not
+    # help perf much.
+    @inductor_config.patch(split_reductions=False)
+    def test_fuse_reduction_with_tiled_pw(self):
+        def f(x):
+            y = torch.sum(torch.sum(x, dim=-1))
+
+            z = x / 10.0
+            z_t = z.t().contiguous().t()
+            return y, z, z_t
+
+        # use this input sizes to test for perf
+        if DO_PERF_TEST:
+            M, N = 1024 * 32, 1024 * 8
+        else:
+            M, N = 200, 100
+        x = torch.randn(M, N, device="cuda")
+        actual = f(x)
+        opt_f = torch.compile(f)
+        expected = opt_f(x)
+        self.assertTrue(same(actual, expected, tol=1e-3))
+
+        # We should fuse the first sum with the two pointwise.
+        # Overall we read x once for all these three kernels and write
+        # out 2 buffers with the same size as x.
+        # This should be sort of 'optimal' for this workload.
+        expected_numbytes = x.nbytes * 3
+
+        # A small amount of extra memory access for:
+        # - store output for the first reduction
+        # - load input for the second redution
+        # - store output for the second reduction
+        expected_numbytes += (M * 2 + 1) * x.itemsize
+
+        print(expected_numbytes)
+        self.assertEqual(expected_numbytes, metrics.num_bytes_accessed)
+
+        if DO_PERF_TEST:
+            from triton.testing import do_bench
+
+            ms = do_bench(lambda: opt_f(x))
+            print(f"{ms=:.3f}")
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1630,7 +1630,7 @@ class SIMDScheduling(BaseScheduling):
             return ()
 
         rw = node.pointwise_read_writes()
-        assert len(rw.range_vars) == len(ranges)
+        assert len(rw.range_vars) == len(ranges), f"{rw.range_vars=} {ranges=}"
 
         # isinstance(dep, MemoryDep): this filters out StarDeps. StarDeps refer to reads
         # that need to access the entire tensor; they don't contribute read indexing

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -929,6 +929,7 @@ class SchedulerNode(BaseSchedulerNode):
         # entry by using a customized cache implemetation rather than
         # lru_cache.
         SIMDScheduling.candidate_tilings.cache_clear()
+        self.pointwise_read_writes.clear_cache(self)
 
     def reorder_loops_by_dep_pair(
         self, self_dep: MemoryDep, other_dep: MemoryDep

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -922,6 +922,14 @@ class SchedulerNode(BaseSchedulerNode):
 
         self.refresh_dependencies(normalize=False)
 
+        from .codegen.simd import SIMDScheduling
+
+        # TODO(shunting) if this cause compilation time increase when
+        # enabling LOAF by default, try just clearing the specific cache
+        # entry by using a customized cache implemetation rather than
+        # lru_cache.
+        SIMDScheduling.candidate_tilings.cache_clear()
+
     def reorder_loops_by_dep_pair(
         self, self_dep: MemoryDep, other_dep: MemoryDep
     ) -> None:
@@ -1125,7 +1133,7 @@ class FusedSchedulerNode(BaseSchedulerNode):
         self_sizes = None
         for snode in self.snodes:
             assert isinstance(snode, SchedulerNode)
-            if self_sizes is not None and self_sizes != snode._sizes[0]:
+            if self_sizes is not None and tuple(self_sizes) != tuple(snode._sizes[0]):
                 loop_ordering_log.debug(
                     "Can not reorder fused node due to different sizes"
                 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139376

Fix https://github.com/pytorch/pytorch/issues/128063 .

Now for this snippet
```
        def f(x):
            y = torch.sum(torch.sum(x, dim=-1))

            z = x / 10.0
            z_t = z.t().contiguous().t()
            return y, z, z_t
```
Inductor could generate a single kernel for the first reduction and the two ponitwise kernels (if loop-ordering after fusion is enabled). And the generated kernel read `x` only ONCE. (with no proper handling, the two pointwise's may each access x once even if they are fused).

The PR needs fix 2 subtile bugs regarding LOAF .
1. when we reorder loops for a FusedSchedulerNode, we check if each sub-node's sizes matches. But some node has sizes in `list` type (if its loop is not reordered) while others have its sizes in `tuple` type (if its loop is reordered). I could change the upstream code to uniformly use either `list` or `tuple`. But without strong enforcement, future code could break this. So I just convert sizes to uniform type before comparison.
2. We have a cache for tiling decisions of a BaseSchedulerNode. If we reorder loops for the node, we should invalidate the cache. Otherwise, a stale tiling decision can result in (very) bad kernel.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov