### PR TITLE
Don't use deprecated type properties in UpsampleKernel

### DIFF
--- a/aten/src/ATen/native/cpu/UpSampleKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleKernel.cpp
@@ -735,8 +735,8 @@ struct HelperInterpBase {
 
     for ([[maybe_unused]] const auto j : c10::irange(interp_size)) {
       output.emplace_back(
-          empty(new_shape, CPU(c10::CppTypeToScalarType<int64_t>())));
-      output.emplace_back(empty(new_shape, CPU(output_type)));
+          empty(new_shape, at::device(kCPU).dtype(c10::CppTypeToScalarType<int64_t>())));
+      output.emplace_back(empty(new_shape, at::device(kCPU).dtype(output_type)));
     }
   }
 
@@ -878,16 +878,16 @@ struct HelperInterpBase {
 
     // Bounds approach as in PIL: xmin/xmax
     output.emplace_back(
-        empty(new_shape, CPU(c10::CppTypeToScalarType<int64_t>())));
+        empty(new_shape, at::device(kCPU).dtype(c10::CppTypeToScalarType<int64_t>())));
     output.emplace_back(
-        empty(new_shape, CPU(c10::CppTypeToScalarType<int64_t>())));
+        empty(new_shape, at::device(kCPU).dtype(c10::CppTypeToScalarType<int64_t>())));
     output.emplace_back(
-        empty(new_shape, CPU(c10::CppTypeToScalarType<int64_t>())));
+        empty(new_shape, at::device(kCPU).dtype(c10::CppTypeToScalarType<int64_t>())));
 
     {
       // Weights
       new_shape[reshape_dim] = output_size * max_interp_size;
-      auto wts = empty(new_shape, CPU(c10::CppTypeToScalarType<scalar_t>()));
+      auto wts = empty(new_shape, at::device(kCPU).dtype(c10::CppTypeToScalarType<scalar_t>()));
       auto strides = wts.strides().vec();
       strides[reshape_dim] = 0;
       new_shape[reshape_dim] = output_size;
@@ -895,7 +895,7 @@ struct HelperInterpBase {
       output.emplace_back(wts);
       // Weights indices
       output.emplace_back(
-          empty(new_shape, CPU(c10::CppTypeToScalarType<int64_t>())));
+          empty(new_shape, at::device(kCPU).dtype(c10::CppTypeToScalarType<int64_t>())));
     }
 
     int64_t* idx_ptr_xmin = output[0].data_ptr<int64_t>();
@@ -1050,9 +1050,9 @@ struct HelperInterpNearest : public HelperInterpBase {
 
     for ([[maybe_unused]] const auto j : c10::irange(interp_size)) {
       output.emplace_back(
-          empty(new_shape, CPU(c10::CppTypeToScalarType<int64_t>())));
+          empty(new_shape, at::device(kCPU).dtype(c10::CppTypeToScalarType<int64_t>())));
       // Defines weights for consistency, but not used
-      output.emplace_back(at::ones(new_shape, CPU(output_type)));
+      output.emplace_back(at::ones(new_shape, at::device(kCPU).dtype(output_type)));
     }
   }
 

--- a/torch/csrc/jit/mobile/flatbuffer_loader.cpp
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.cpp
@@ -469,8 +469,8 @@ IValue parseBasic(
 at::Tensor parseTensorFromMetadata(
     FlatbufferLoader* loader,
     const mobile::serialization::TensorMetadata* tensor_md) {
-  at::ScalarType type = static_cast<at::ScalarType>(tensor_md->scalar_type());
-  auto options = at::CPU(type).options();
+  auto type = static_cast<at::ScalarType>(tensor_md->scalar_type());
+  auto options = at::device(at::kCPU).dtype(type);
   at::Tensor tensor;
   if (tensor_md->quantized_schema() != nullptr) {
     // is quantized

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -293,7 +293,7 @@ RegisterOperators reg({
     DEFINE_TORCH_TENSOR_OP(
         bool,
         bool,
-        at::empty({}, at::CPU(at::kBool).options()).fill_(scalar_val))
+        at::empty({}, at::device(at::kCPU).dtype(at::kBool)).fill_(scalar_val))
         DEFINE_TORCH_TENSOR_OP(
             float,
             double,

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -586,7 +586,7 @@ PickleOpCode Unpickler::readInstruction() {
         storage = storage_context_->getStorage(key);
       } else {
         int64_t numel = args.at(4).toInt();
-        caffe2::TypeMeta dtype = at::CPU(type).typeMeta();
+        auto dtype = scalarTypeToTypeMeta(type);
 
         at::DataPtr storage_ptr;
         if (numel > 0) {
@@ -608,7 +608,7 @@ PickleOpCode Unpickler::readInstruction() {
         }
       }
 
-      auto options = at::CPU(type).options();
+      auto options = at::device(at::kCPU).dtype(type);
       if (use_storage_device_) {
         options = options.device(storage.device());
         device = storage.device();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #139358
* __->__ #139399


By replacing `at::CPU(dtype)` pattern with `at::device(kCPU).dtype(dtype)` pattern


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10