### PR TITLE
Ignore logger methods to avoid graph breaks

### DIFF
--- a/test/dynamo/test_reorder_logs.py
+++ b/test/dynamo/test_reorder_logs.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 import io
+import logging
 import warnings
 from unittest.mock import patch
 
@@ -9,13 +10,15 @@ import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.testing import same
 from torch._dynamo.utils import counters
-import logging
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
 )
+
+
 logger = logging.getLogger(__name__)
 logger_test = logging.getLogger("test")
+
 
 def f_info(x):
     x = x + x
@@ -23,25 +26,30 @@ def f_info(x):
     x = x * x
     return x
 
+
 def f_isEnabledFor(x):
     x = x + x
     if logger.isEnabledFor(logging.INFO):
         logger.info("moo")
     x = x * x
     return x
+
+
 @instantiate_parametrized_tests
 class IgnoreLogsTests(torch._dynamo.test_case.TestCase):
-
-    @parametrize("ignore_method, fn, should_ignore_logger",[
-        (None, f_info, False),
-        (logger_test.info, f_info, False),
-        (None, f_isEnabledFor, False),
-        (logger_test.isEnabledFor, f_isEnabledFor, False),
-        (logger.info, f_info, True),
-        (logging.Logger.info, f_info, True),
-        (logger.isEnabledFor, f_isEnabledFor, True),
-        (logging.Logger.isEnabledFor, f_isEnabledFor, True),
-    ])
+    @parametrize(
+        "ignore_method, fn, should_ignore_logger",
+        [
+            (None, f_info, False),
+            (logger_test.info, f_info, False),
+            (None, f_isEnabledFor, False),
+            (logger_test.isEnabledFor, f_isEnabledFor, False),
+            (logger.info, f_info, True),
+            (logging.Logger.info, f_info, True),
+            (logger.isEnabledFor, f_isEnabledFor, True),
+            (logging.Logger.isEnabledFor, f_isEnabledFor, True),
+        ],
+    )
     def test_ignore_logger(self, ignore_method, fn, should_ignore_logger):
         counters.clear()
         x = torch.randn(3, 3)

--- a/test/dynamo/test_reorder_logs.py
+++ b/test/dynamo/test_reorder_logs.py
@@ -42,7 +42,7 @@ class IgnoreLogsTests(torch._dynamo.test_case.TestCase):
         (logger.isEnabledFor, f_isEnabledFor, True),
         (logging.Logger.isEnabledFor, f_isEnabledFor, True),
     ])
-    def test_dont_ignore_logger(self, ignore_method, fn, should_ignore_logger):
+    def test_ignore_logger(self, ignore_method, fn, should_ignore_logger):
         counters.clear()
         x = torch.randn(3, 3)
         orig_out = fn(x)

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -446,7 +446,7 @@ reorderable_logging_functions: Set[Callable[[Any], None]] = set()
 # to prevent graph breaks.
 # Add logging.Logger.<method> to ignore all calls for method,
 # or logger.<method> to ignore calls for method from this logger instance only.
-ignore_logger_methods: Set[Callable] = set()
+ignore_logger_methods: Set[Callable[..., Any]] = set()
 
 # simulates what would happen if we didn't have support for BUILD_SET opcode,
 # used for testing

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -442,6 +442,10 @@ log_compilation_metrics = True
 # mutated after the print statement.
 reorderable_logging_functions: Set[Callable[[Any], None]] = set()
 
+# A set of methods that will be ignored while tracing,
+# to prevent graph breaks.
+ignore_logger_methods = set()
+
 # simulates what would happen if we didn't have support for BUILD_SET opcode,
 # used for testing
 inject_BUILD_SET_unimplemented_TESTING_ONLY = False
@@ -518,9 +522,6 @@ automatic_dynamic_remote_pgo: Optional[bool] = get_tristate_env(
 
 # HACK: this is for testing custom ops profiling only
 _custom_ops_profile: Optional[Any] = None
-
-# Disable logger calls to avoid graph breaks
-disable_logs = os.environ.get("DISABLE_LOGS_WHILE_COMPILING", "0") == "1"
 
 if TYPE_CHECKING:
     from torch.utils._config_typing import *  # noqa: F401, F403

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -444,7 +444,7 @@ reorderable_logging_functions: Set[Callable[[Any], None]] = set()
 
 # A set of methods that will be ignored while tracing,
 # to prevent graph breaks.
-ignore_logger_methods = set()
+ignore_logger_methods: Set[Callable] = set()
 
 # simulates what would happen if we didn't have support for BUILD_SET opcode,
 # used for testing

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -444,6 +444,8 @@ reorderable_logging_functions: Set[Callable[[Any], None]] = set()
 
 # A set of methods that will be ignored while tracing,
 # to prevent graph breaks.
+# Add logging.Logger.<method> to ignore all calls for method,
+# or logger.<method> to ignore calls for method from this logger instance only.
 ignore_logger_methods: Set[Callable] = set()
 
 # simulates what would happen if we didn't have support for BUILD_SET opcode,

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -519,6 +519,9 @@ automatic_dynamic_remote_pgo: Optional[bool] = get_tristate_env(
 # HACK: this is for testing custom ops profiling only
 _custom_ops_profile: Optional[Any] = None
 
+# Disable logger calls to avoid graph breaks
+disable_logs = os.environ.get("DISABLE_LOGS_WHILE_COMPILING", "0") == "1"
+
 if TYPE_CHECKING:
     from torch.utils._config_typing import *  # noqa: F401, F403
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1089,6 +1089,7 @@ def _compile(
                     "inject_BUILD_SET_unimplemented_TESTING_ONLY",
                     "_autograd_backward_strict_mode_banned_ops",
                     "reorderable_logging_functions",
+                    "ignore_logger_methods",
                     "traceable_tensor_subclasses",
                     "_custom_ops_profile",
                 }

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1465,7 +1465,14 @@ class LoggingLoggerVariable(VariableTracker):
         if tx.export:
             # For export cases, we can just make debugging functions no-ops
             return
-        unimplemented("Logger not supported for non-export cases")
+        if config.disable_logs:
+            if name == "isEnabledFor":
+                return variables.ConstantVariable.create(False)
+            if name in ['info', 'debug', 'error', 'warning', 'critical', 'exception']:
+                return
+        unimplemented("Logger not supported for non-export cases. "
+                      "To avoid graph breaks caused by logger in compile-mode, it is recommended to"
+                               " disable logging by setting env var DISABLE_LOGS_WHILE_COMPILING=1")
 
 
 class ConstantLikeVariable(VariableTracker):

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1469,10 +1469,12 @@ class LoggingLoggerVariable(VariableTracker):
         method = getattr(self.value, name, None)
         function = getattr(method, "__func__", None)
         if {method, function}.intersection(torch._dynamo.config.ignore_logger_methods):
-                return variables.ConstantVariable.create(None)
-        unimplemented("Logger not supported for non-export cases. "
-                      "To avoid graph breaks caused by logger in compile-mode, it is recommended to"
-                               " disable logging by adding logging methods to config.ignore_logger_methods")
+            return variables.ConstantVariable.create(None)
+        unimplemented(
+            "Logger not supported for non-export cases. "
+            "To avoid graph breaks caused by logger in compile-mode, it is recommended to"
+            " disable logging by adding logging methods to config.ignore_logger_methods"
+        )
 
 
 class ConstantLikeVariable(VariableTracker):

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1466,12 +1466,13 @@ class LoggingLoggerVariable(VariableTracker):
         if tx.export:
             # For export cases, we can just make debugging functions no-ops
             return
-        method = getattr(self.value, name, None).__func__
-        if method in torch._dynamo.config.ignore_logger_methods:
+        method = getattr(self.value, name, None)
+        function = method.__func__
+        if {method, function}.intersection(torch._dynamo.config.ignore_logger_methods):
                 return variables.ConstantVariable.create(None)
         unimplemented("Logger not supported for non-export cases. "
                       "To avoid graph breaks caused by logger in compile-mode, it is recommended to"
-                               " disable logging by setting env var DISABLE_LOGS_WHILE_COMPILING=1")
+                               " disable logging by adding logging methods to config.ignore_logger_methods")
 
 
 class ConstantLikeVariable(VariableTracker):

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1467,7 +1467,7 @@ class LoggingLoggerVariable(VariableTracker):
             return
         if config.disable_logs:
             if name == "isEnabledFor":
-                return variables.ConstantVariable.create(False)
+                return variables.ConstantVariable.create(None)
             if name in ['info', 'debug', 'error', 'warning', 'critical', 'exception']:
                 return
         unimplemented("Logger not supported for non-export cases. "

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1454,6 +1454,7 @@ class LoggingLoggerVariable(VariableTracker):
 
     def __init__(self, value, **kwargs) -> None:
         super().__init__(**kwargs)
+        self.value = value
 
     def call_method(
         self,
@@ -1465,11 +1466,9 @@ class LoggingLoggerVariable(VariableTracker):
         if tx.export:
             # For export cases, we can just make debugging functions no-ops
             return
-        if config.disable_logs:
-            if name == "isEnabledFor":
+        method = getattr(self.value, name, None).__func__
+        if method in torch._dynamo.config.ignore_logger_methods:
                 return variables.ConstantVariable.create(None)
-            if name in ['info', 'debug', 'error', 'warning', 'critical', 'exception']:
-                return
         unimplemented("Logger not supported for non-export cases. "
                       "To avoid graph breaks caused by logger in compile-mode, it is recommended to"
                                " disable logging by setting env var DISABLE_LOGS_WHILE_COMPILING=1")

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1467,7 +1467,7 @@ class LoggingLoggerVariable(VariableTracker):
             # For export cases, we can just make debugging functions no-ops
             return
         method = getattr(self.value, name, None)
-        function = method.__func__
+        function = getattr(method, "__func__", None)
         if {method, function}.intersection(torch._dynamo.config.ignore_logger_methods):
                 return variables.ConstantVariable.create(None)
         unimplemented("Logger not supported for non-export cases. "


### PR DESCRIPTION
Fixes #132635

Calls to logging.logger cause a graph break, this PR allows the user to avoid these graph breaks (for specific methods) by setting DISABLE_LOGS_WHILE_COMPILING to 1.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames