### PR TITLE
add hex method on SymFloat

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -681,6 +681,10 @@ class SymFloat:
         """Returns the complex conjugate of the float."""
         return self
 
+    def hex(self) -> "SymFloat":
+        """Returns the hexadecimal representation of the float."""
+        return self
+
 
 class SymBool:
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #138922
* #138918
* #138666
* #138915
* __->__ #139406

Fixes python test/dynamo/test_functions.py FunctionTests.test_number_method_method_hex_num_type5 when specialize_float is turned off

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames