### PR TITLE
[Workflow][2/3] Remove benchmack tests from rerun disbled test

### DIFF
--- a/.github/workflows/inductor-cu124-unittest.yml
+++ b/.github/workflows/inductor-cu124-unittest.yml
@@ -4,13 +4,18 @@
 name: inductor-cu124-unittest
 
 on:
-  call_workflow:
+  workflow_call:
+      inputs:
+        job_name:
+          description: 'A job name passed for concurrency group'
+          required: false
+          type: string
   workflow_dispatch:
   schedule:
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}${{ inputs.job_name && '-' + inputs.job_name || '' }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-cu124-unittest.yml
+++ b/.github/workflows/inductor-cu124-unittest.yml
@@ -10,7 +10,7 @@ on:
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-unit-test
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-unittest
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-cu124-unittest.yml
+++ b/.github/workflows/inductor-cu124-unittest.yml
@@ -1,8 +1,8 @@
 # Workflow: Inductor Cu124 Unit Test
 # 1. runs unit tests for inductor-cu124.
 # 2. perfoms daily memory leak checks and reruns of disabled tests, scheduled at `29 8 * * *`.
-name: inductor-cu124-unittest
 
+name: inductor-cu124-unittest
 on:
   workflow_call:
     inputs:
@@ -10,7 +10,7 @@ on:
         required: false
         type: string
         default: "inductor-cu124-unittest"
-        description: 'A job name passed for concurrency group'
+        description: 'A name passed for concurrency group'
   workflow_dispatch:
   schedule:
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests

--- a/.github/workflows/inductor-cu124-unittest.yml
+++ b/.github/workflows/inductor-cu124-unittest.yml
@@ -6,7 +6,7 @@ name: inductor-cu124-unittest
 on:
   workflow_call:
       inputs:
-        job_name:
+        additional_name:
           required: false
           type: string
           default: "inductor-cu124-unittest"
@@ -16,7 +16,7 @@ on:
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ inputs.job_name || 'default' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ inputs.additional_name || 'default' }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-cu124-unittest.yml
+++ b/.github/workflows/inductor-cu124-unittest.yml
@@ -7,10 +7,10 @@ on:
   workflow_call:
     inputs:
       job_name:
-      required: false
-      type: string
-      default: "inductor-cu124-unittest"
-      description: 'A job name passed for concurrency group'
+        required: false
+        type: string
+        default: "inductor-cu124-unittest"
+        description: 'A job name passed for concurrency group'
   workflow_dispatch:
   schedule:
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests

--- a/.github/workflows/inductor-cu124-unittest.yml
+++ b/.github/workflows/inductor-cu124-unittest.yml
@@ -5,18 +5,18 @@ name: inductor-cu124-unittest
 
 on:
   workflow_call:
-      inputs:
-        additional_name:
-          required: false
-          type: string
-          default: "inductor-cu124-unittest"
-          description: 'A job name passed for concurrency group'
+    inputs:
+      job_name:
+      required: false
+      type: string
+      default: "inductor-cu124-unittest"
+      description: 'A job name passed for concurrency group'
   workflow_dispatch:
   schedule:
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ inputs.additional_name || 'default' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ inputs.job_name || 'default' }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-cu124-unittest.yml
+++ b/.github/workflows/inductor-cu124-unittest.yml
@@ -1,8 +1,8 @@
 # Workflow: Inductor Cu124 Unit Test
 # 1. runs unit tests for inductor-cu124.
 # 2. perfoms daily memory leak checks and reruns of disabled tests, scheduled at `29 8 * * *`.
-
 name: inductor-cu124-unittest
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/inductor-cu124-unittest.yml
+++ b/.github/workflows/inductor-cu124-unittest.yml
@@ -1,6 +1,6 @@
 # Workflow: Inductor Cu124 Unit Test
-# 1. Runs unit tests for inductor-cu124.
-# 2. Perfoms daily memory leak checks and reruns of disabled tests, scheduled at `29 8 * * *`.
+# 1. runs unit tests for inductor-cu124.
+# 2. perfoms daily memory leak checks and reruns of disabled tests, scheduled at `29 8 * * *`.
 name: inductor-cu124-unittest
 
 on:

--- a/.github/workflows/inductor-cu124-unittest.yml
+++ b/.github/workflows/inductor-cu124-unittest.yml
@@ -16,7 +16,7 @@ on:
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ inputs.job_name || 'default' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event.inputs.job_name || 'default' }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-cu124-unittest.yml
+++ b/.github/workflows/inductor-cu124-unittest.yml
@@ -5,18 +5,12 @@ name: inductor-cu124-unittest
 
 on:
   workflow_call:
-    inputs:
-      job_name:
-        required: false
-        type: string
-        default: "inductor-cu124-unittest"
-        description: 'A job name passed for concurrency group'
   workflow_dispatch:
   schedule:
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event.inputs.job_name || 'default' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-unit-test
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-cu124-unittest.yml
+++ b/.github/workflows/inductor-cu124-unittest.yml
@@ -7,9 +7,10 @@ on:
   workflow_call:
       inputs:
         job_name:
-          description: 'A job name passed for concurrency group'
           required: false
           type: string
+          default: "inductor-cu124-unittest"
+          description: 'A job name passed for concurrency group'
   workflow_dispatch:
   schedule:
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests

--- a/.github/workflows/inductor-cu124-unittest.yml
+++ b/.github/workflows/inductor-cu124-unittest.yml
@@ -15,7 +15,7 @@ on:
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}${{ inputs.job_name && '-' + inputs.job_name || '' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ inputs.job_name || 'default' }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-cu124-unittest.yml
+++ b/.github/workflows/inductor-cu124-unittest.yml
@@ -1,23 +1,12 @@
-# Workflow: Inductor
-# runs all inductor tests, including both benchmark tests and unit tests.
-# Adding New Tests:
-#  1. inductor-cu124-unittest.yml:
-#      - Unit Tests
-#      - Mixed Tests
-#      - Flaky Benchmark tests
-#  2. inductor-cu124.yml(this workflow):
-#      - non-flaky benchmark tests
-name: inductor-cu124
+# Workflow: Inductor Cu124 Unit Test
+# 1. Runs unit tests for inductor-cu124.
+# 2. Perfoms daily memory leak checks and reruns of disabled tests, scheduled at `29 8 * * *`.
+name: inductor-cu124-unittest
 
 on:
-  push:
-    tags:
-      - ciflow/inductor-cu124/*
+  call_workflow:
   workflow_dispatch:
   schedule:
-    # Run every 4 hours during the week and every 12 hours on the weekend
-    - cron: 45 0,4,8,12,16,20 * * 1-5
-    - cron: 45 4,12 * * 0,6
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
 
 concurrency:
@@ -49,7 +38,6 @@ jobs:
       check_experiments: "awsa100"
 
   linux-focal-cuda12_4-py3_10-gcc9-inductor-build:
-    # Should be synced with the one in inductor.yml, but this doesn't run inductor_timm
     name: cuda12.4-py3.10-gcc9-sm86
     uses: ./.github/workflows/_linux-build.yml
     needs: get-default-label-prefix
@@ -64,19 +52,6 @@ jobs:
           { config: "inductor", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
           { config: "inductor", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
           { config: "inductor_distributed", shard: 1, num_shards: 1, runner: "linux.g5.12xlarge.nvidia.gpu" },
-          { config: "inductor_huggingface", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor_torchbench", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor_torchbench", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "dynamic_inductor_huggingface", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "dynamic_inductor_timm", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "dynamic_inductor_timm", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "dynamic_inductor_torchbench", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "dynamic_inductor_torchbench", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "aot_inductor_huggingface", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "aot_inductor_timm", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "aot_inductor_timm", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "aot_inductor_torchbench", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "aot_inductor_torchbench", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
           { config: "inductor_cpp_wrapper", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
         ]}
     secrets:
@@ -91,34 +66,6 @@ jobs:
       build-environment: linux-focal-cuda12.4-py3.10-gcc9-sm86
       docker-image: ${{ needs.linux-focal-cuda12_4-py3_10-gcc9-inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-cuda12_4-py3_10-gcc9-inductor-build.outputs.test-matrix }}
-    secrets:
-      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
-
-  linux-focal-cuda12_4-py3_10-gcc9-inductor-build-gcp:
-    if: github.repository_owner == 'pytorch'
-    name: cuda12.4-py3.10-gcc9-sm80
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-a100-test-label-type
-    with:
-      build-environment: linux-focal-cuda12.4-py3.10-gcc9-sm80
-      docker-image-name: pytorch-linux-focal-cuda12.4-cudnn9-py3-gcc9-inductor-benchmarks
-      cuda-arch-list: '8.0'
-      test-matrix: |
-        { include: [
-          { config: "inductor_torchbench_smoketest_perf", shard: 1, num_shards: 1, runner: "${{ needs.get-a100-test-label-type.outputs.label-type }}linux.gcp.a100" },
-        ]}
-    secrets:
-      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
-
-  linux-focal-cuda12_4-py3_10-gcc9-inductor-test-gcp:
-    name: cuda12.4-py3.10-gcc9-sm80
-    uses: ./.github/workflows/_linux-test.yml
-    needs: linux-focal-cuda12_4-py3_10-gcc9-inductor-build-gcp
-    with:
-      build-environment: linux-focal-cuda12.4-py3.10-gcc9-sm80
-      docker-image: ${{ needs.linux-focal-cuda12_4-py3_10-gcc9-inductor-build-gcp.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cuda12_4-py3_10-gcc9-inductor-build-gcp.outputs.test-matrix }}
-      use-gha: anything-non-empty-to-use-gha
     secrets:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
 

--- a/.github/workflows/inductor-cu124-unittest.yml
+++ b/.github/workflows/inductor-cu124-unittest.yml
@@ -10,7 +10,7 @@ on:
         required: false
         type: string
         default: "inductor-cu124-unittest"
-        description: 'A name passed for concurrency group'
+        description: 'A job name passed for concurrency group'
   workflow_dispatch:
   schedule:
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
@@ -31,17 +31,6 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
-
-  get-a100-test-label-type:
-    name: get-a100-test-label-type
-    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
-    with:
-      triggering_actor: ${{ github.triggering_actor }}
-      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
-      curr_branch: ${{ github.head_ref || github.ref_name }}
-      curr_ref_type: ${{ github.ref_type }}
-      check_experiments: "awsa100"
 
   linux-focal-cuda12_4-py3_10-gcc9-inductor-build:
     name: cuda12.4-py3.10-gcc9-sm86

--- a/.github/workflows/inductor-cu124.yml
+++ b/.github/workflows/inductor-cu124.yml
@@ -1,6 +1,6 @@
 # Workflow: Inductor
 # runs all inductor tests, including both benchmark tests and unit tests.
-# Adding New Tests:
+# adding New Tests:
 #  1. inductor-cu124-unittest.yml:
 #      - Unit Tests
 #      - Mixed Tests

--- a/.github/workflows/inductor-cu124.yml
+++ b/.github/workflows/inductor-cu124.yml
@@ -23,8 +23,6 @@ jobs:
     if: github.repository_owner == 'pytorch'
     name: inductor-unittest
     uses: ./.github/workflows/inductor-cu124-unittest.yml
-    with:
-      job_name: unit-test
 
   get-default-label-prefix:
     name: get-default-label-prefix

--- a/.github/workflows/inductor-cu124.yml
+++ b/.github/workflows/inductor-cu124.yml
@@ -1,12 +1,5 @@
 # Workflow: Inductor
-# runs all inductor tests, including both benchmark tests and unit tests.
-# adding New Tests:
-#  1. inductor-cu124-unittest.yml:
-#      - Unit Tests
-#      - Mixed Tests
-#      - Flaky Benchmark tests
-#  2. inductor-cu124.yml(this workflow):
-#      - non-flaky benchmark tests
+# runs all inductor cu124 tests, including both benchmark tests and unit tests.
 name: inductor-cu124
 
 on:
@@ -18,7 +11,6 @@ on:
     # Run every 4 hours during the week and every 12 hours on the weekend
     - cron: 45 0,4,8,12,16,20 * * 1-5
     - cron: 45 4,12 * * 0,6
-    - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
@@ -49,7 +41,7 @@ jobs:
       check_experiments: "awsa100"
 
   linux-focal-cuda12_4-py3_10-gcc9-inductor-build:
-    # Should be synced with the one in inductor.yml, but this doesn't run inductor_timm
+    # Should be synced with the benchmark tests in inductor.yml, but this doesn't run inductor_timm
     name: cuda12.4-py3.10-gcc9-sm86
     uses: ./.github/workflows/_linux-build.yml
     needs: get-default-label-prefix
@@ -61,9 +53,6 @@ jobs:
       cuda-arch-list: '8.6'
       test-matrix: |
         { include: [
-          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor_distributed", shard: 1, num_shards: 1, runner: "linux.g5.12xlarge.nvidia.gpu" },
           { config: "inductor_huggingface", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
           { config: "inductor_torchbench", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
           { config: "inductor_torchbench", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
@@ -77,7 +66,6 @@ jobs:
           { config: "aot_inductor_timm", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
           { config: "aot_inductor_torchbench", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
           { config: "aot_inductor_torchbench", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor_cpp_wrapper", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
         ]}
     secrets:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
@@ -121,26 +109,3 @@ jobs:
       use-gha: anything-non-empty-to-use-gha
     secrets:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
-
-  linux-focal-cuda12_4-py3_12-gcc9-inductor-build:
-    if: github.repository_owner == 'pytorch'
-    name: cuda12.4-py3.12-gcc9-sm86
-    uses: ./.github/workflows/_linux-build.yml
-    with:
-      build-environment: linux-focal-cuda12.4-py3.12-gcc9-sm86
-      docker-image-name: pytorch-linux-focal-cuda12.4-cudnn9-py3.12-gcc9-inductor-benchmarks
-      cuda-arch-list: '8.6'
-      test-matrix: |
-        { include: [
-          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-        ]}
-
-  linux-focal-cuda12_4-py3_12-gcc9-inductor-test:
-    name: cuda12.4-py3.12-gcc9-sm86
-    uses: ./.github/workflows/_linux-test.yml
-    needs: linux-focal-cuda12_4-py3_12-gcc9-inductor-build
-    with:
-      build-environment: linux-focal-cuda12.4-py3.12-gcc9-sm86
-      docker-image: ${{ needs.linux-focal-cuda12_4-py3_12-gcc9-inductor-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cuda12_4-py3_12-gcc9-inductor-build.outputs.test-matrix }}

--- a/.github/workflows/inductor-cu124.yml
+++ b/.github/workflows/inductor-cu124.yml
@@ -19,6 +19,13 @@ concurrency:
 permissions: read-all
 
 jobs:
+  unit-test:
+    if: github.repository_owner == 'pytorch'
+    name: inductor-unittest
+    uses: ./.github/workflows/inductor-cu124-unittest.yml
+    with:
+      job_name: unittest
+
   get-default-label-prefix:
     name: get-default-label-prefix
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main

--- a/.github/workflows/inductor-cu124.yml
+++ b/.github/workflows/inductor-cu124.yml
@@ -24,7 +24,7 @@ jobs:
     name: inductor-unittest
     uses: ./.github/workflows/inductor-cu124-unittest.yml
     with:
-      job_name: unittest
+      job_name: unit-test
 
   get-default-label-prefix:
     name: get-default-label-prefix

--- a/.github/workflows/inductor-cu124.yml
+++ b/.github/workflows/inductor-cu124.yml
@@ -24,7 +24,7 @@ jobs:
     name: inductor-unittest
     uses: ./.github/workflows/inductor-cu124-unittest.yml
     with:
-      job_name: unittest
+      additional_name: unittest
 
   get-default-label-prefix:
     name: get-default-label-prefix

--- a/.github/workflows/inductor-cu124.yml
+++ b/.github/workflows/inductor-cu124.yml
@@ -24,7 +24,7 @@ jobs:
     name: inductor-unittest
     uses: ./.github/workflows/inductor-cu124-unittest.yml
     with:
-      additional_name: unittest
+      job_name: unittest
 
   get-default-label-prefix:
     name: get-default-label-prefix


### PR DESCRIPTION
Fixes [#5774](https://github.com/pytorch/test-infra/issues/5774)
# Overview 
Remove benchmark tests from rerun-disabled-tests, this is considered non-unittest.
See one page doc: [[Bootcamp Task] Remove non-unittest test during rerun-disabled-tests](https://docs.google.com/document/d/1xffkt_LNC5ZLsoVQDmuKbNqYnMUW_xYYStv66Pr-qac/edit?tab=t.0)

# Steps to fix the issue
- [ ] Create inductor-unittest.yml to handle unit test and daily rerun for inductor 
- [x] [**THIS PR**] Create Inductor-cu124-unittest.yml to handle unit tests and daily rerun for inductor-cu124
- [ ] Disable benchmark test in mixed test such as CPP_Wrapper which includes both unittest and benchmark test

