### PR TITLE
[ONNX] Set flags correctly in tests

### DIFF
--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 
 import torch
+import torch.onnx._flags
 from torch.onnx._internal.exporter import _testing as onnx_testing
 from torch.testing._internal import common_utils
 
@@ -149,8 +150,7 @@ class TestExportAPIDynamo(common_utils.TestCase):
         )
 
     def test_auto_convert_all_axes_to_dynamic_shapes_with_dynamo_export(self):
-        os.environ["TORCH_ONNX_USE_EXPERIMENTAL_LOGIC"] = "1"
-        assert os.environ.get("TORCH_ONNX_USE_EXPERIMENTAL_LOGIC") == "1"
+        torch.onnx._flags.USE_EXPERIMENTAL_LOGIC = True
 
         class Nested(torch.nn.Module):
             def forward(self, x):


### PR DESCRIPTION
Previously the flag was set via envvar, since the envvar was read at initialization, it may not have been correctly set.