### PR TITLE
[ROCM][CUDA][NCCL] Disable `test_lowering_one_shot_all_reduce` on ROCM

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -17,7 +17,6 @@ from torch.distributed._symmetric_memory import (
     restride_A_for_fused_matmul_reduce_scatter,
     restride_A_shard_for_fused_all_gather_matmul,
 )
-from torch.testing._internal.common_device_type import skipCUDAIfRocm
 from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     skip_if_lt_x_gpu,
@@ -767,7 +766,7 @@ class LoweringTest(MultiProcessTestCase):
 
         torch._inductor.config._collective.auto_select = True
 
-    @skipCUDAIfRocm # requires registered-buffer support
+    @skipIfRocm  # requires registered-buffer support
     @skip_if_lt_x_gpu(2)
     @fresh_inductor_cache()
     def test_lowering_one_shot_all_reduce(self):

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -17,6 +17,7 @@ from torch.distributed._symmetric_memory import (
     restride_A_for_fused_matmul_reduce_scatter,
     restride_A_shard_for_fused_all_gather_matmul,
 )
+from torch.testing._internal.common_device_type import skipCUDAIfRocm
 from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     skip_if_lt_x_gpu,
@@ -766,6 +767,7 @@ class LoweringTest(MultiProcessTestCase):
 
         torch._inductor.config._collective.auto_select = True
 
+    @skipCUDAIfRocm # requires registered-buffer support
     @skip_if_lt_x_gpu(2)
     @fresh_inductor_cache()
     def test_lowering_one_shot_all_reduce(self):


### PR DESCRIPTION
I'm not sure this is expected to run if it requires buffer-registration support CC @yifuwang @huydhn @syed-ahmed #138029

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @ptrblck @msaroufim @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov