### PR TITLE
[c10d][fr][easy] Move check_no_missing_dump_files

### DIFF
--- a/tools/flight_recorder/components/builder.py
+++ b/tools/flight_recorder/components/builder.py
@@ -112,8 +112,8 @@ def build_groups_memberships(
                 assert (
                     _groups[pg_guid].desc == desc
                 ), f"mismatch in desc {_groups[pg_guid].desc} vs {desc} for group {pg_guid}"
-                assert _memberships[pg_guid] == set(
-                    ranks
+                assert (
+                    _memberships[pg_guid] == set(ranks)
                 ), f"mismatch in membership for group {pg_guid} {_memberships[pg_guid]} vs {set(ranks)}"
     return groups, _groups, memberships, _memberships, _pg_guids
 

--- a/tools/flight_recorder/components/builder.py
+++ b/tools/flight_recorder/components/builder.py
@@ -112,8 +112,8 @@ def build_groups_memberships(
                 assert (
                     _groups[pg_guid].desc == desc
                 ), f"mismatch in desc {_groups[pg_guid].desc} vs {desc} for group {pg_guid}"
-                assert (
-                    _memberships[pg_guid] == set(ranks)
+                assert _memberships[pg_guid] == set(
+                    ranks
                 ), f"mismatch in membership for group {pg_guid} {_memberships[pg_guid]} vs {set(ranks)}"
     return groups, _groups, memberships, _memberships, _pg_guids
 
@@ -447,11 +447,11 @@ def build_db(
     )
     print("built groups, memberships")
 
-    check_no_missing_dump_files(entries, memberships)
-
     if args.just_print_entries:
         just_print_entries(entries, _groups, _memberships, _pg_guids, args)
         sys.exit(0)
+
+    check_no_missing_dump_files(entries, memberships)
 
     tracebacks, collectives, nccl_calls = build_collectives(
         entries, _groups, _memberships, _pg_guids, version


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139417

Summary:
Move check_no_missing_dump_files to after the "just print" location.
This allows us to print dump_files when there are actual missing files.

Test Plan:
```
torchfrtrace -j ~/pyper-training-online-924394600  --selected-ranks 1 2

Inferred common prefix nccl_trace_rank_
loaded 95 files in 0.040270328521728516s
built groups, memberships
Rank 1                                                              Rank 2
------------------------------------------------------------------  ------------------------------------------------------------------
broadcast(input_sizes=[[2]], state=completed)                       broadcast(input_sizes=[[2]], state=completed)
```
Without this change, the command was erroring out.