### PR TITLE
[DTensor][Test] Fix `with_comms` to allow it to work with/without parenthesis

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -290,7 +290,7 @@ class DeviceMeshTest(DTensorTestBase):
 
         mesh_tensor = torch.arange(4).reshape(2, 2)
         mesh = DeviceMesh(self.device_type, mesh_tensor)
-        # # Fake pg only have BackendType as BackendType::CUSTOM.
+        # Fake pg only have BackendType as BackendType::CUSTOM.
         self.assertEqual(mesh.get_group(1)._get_backend_name(), "custom")
 
 

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -124,8 +124,6 @@ class DeviceMeshTest(DTensorTestBase):
     # eager_init=True and eager_init=False scenarios.
     @with_comms(eager_init=True)
     def test_2d_mesh_eager_init_subgroup(self):
-        print("test")
-        # self.assertTrue(False)
         mesh_shape = (2, self.world_size // 2)
         mesh_2d = init_device_mesh(self.device_type, mesh_shape)
 
@@ -288,12 +286,11 @@ class DeviceMeshTest(DTensorTestBase):
 
     @with_comms
     def test_set_mesh_dim_group_options(self):
-        device_type = "cuda" if torch.cuda.is_available() else "cpu"
         _mesh_resources._set_mesh_dim_group_options(1, "fake", None)
 
         mesh_tensor = torch.arange(4).reshape(2, 2)
-        mesh = DeviceMesh(device_type, mesh_tensor)
-        # Fake pg only have BackendType as BackendType::CUSTOM.
+        mesh = DeviceMesh(self.device_type, mesh_tensor)
+        # # Fake pg only have BackendType as BackendType::CUSTOM.
         self.assertEqual(mesh.get_group(1)._get_backend_name(), "custom")
 
 

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -50,6 +50,30 @@ def _set_env_var(addr="localhost", port="25364", world_size=1, rank=0):
     os.environ["RANK"] = f"{rank}"
 
 
+class WithCommsTest(DTensorTestBase):
+    """
+    Test with_comms to make sure the decorator works as expected with or without parenthesis.
+
+    #TODO: this is probably not the best place to put this test, but just keeping it so we have
+    test coverage for the with_comms.
+    """
+
+    @with_comms
+    def test_with_comms(self):
+        with self.assertRaises(AssertionError):
+            self.assertTrue(False)
+
+    @with_comms(eager_init=True)
+    def test_with_comms_eager_init(self):
+        with self.assertRaises(AssertionError):
+            self.assertTrue(False)
+
+    @with_comms()
+    def test_with_comms_non_eager_init(self):
+        with self.assertRaises(AssertionError):
+            self.assertTrue(False)
+
+
 class DeviceMeshTestGlooBackend(DTensorTestBase):
     @property
     def backend(self):
@@ -100,6 +124,8 @@ class DeviceMeshTest(DTensorTestBase):
     # eager_init=True and eager_init=False scenarios.
     @with_comms(eager_init=True)
     def test_2d_mesh_eager_init_subgroup(self):
+        print("test")
+        # self.assertTrue(False)
         mesh_shape = (2, self.world_size // 2)
         mesh_2d = init_device_mesh(self.device_type, mesh_shape)
 
@@ -646,7 +672,7 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         cp_tp_mesh._flatten("dummy")
         self.assertEqual(mesh_3d["dummy"].mesh_dim_names[0], "dummy")
 
-    @with_comms(eager_init=True)
+    @with_comms
     def test_flatten_mesh_4d(self):
         mesh_shape = (2, 2, 2, 1)
         mesh_dim_names = ("dp_replicate", "dp_shard", "cp", "tp")

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -390,8 +390,7 @@ def with_comms(eager_init: bool = False) -> TestFunc:
 
         return wrapper
 
-    return decorator
-
+    return decorator(eager_init) if callable(eager_init) else decorator
 
 
 class DTensorOpTestBase(MultiThreadedTestCase):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139418

After the change (https://github.com/pytorch/pytorch/pull/138108) to add eager_init as an optional arg to `with_comms`, `with_comms` no longer works when using without parenthesis. This fixed the decorator to work for all following use cases:
- `with_comms`
- `with_comms()`
- `with_comms(eager_init=False)`
- `with_comms(eager_init=True)`


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o