### PR TITLE
[Bash][3/3] Remove benchmack tests from rerun disbled test 

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -384,22 +384,28 @@ test_inductor_cpp_wrapper() {
   # unit tests with cpp wrapper.
   python test/run_test.py --include inductor/test_torchinductor.py --verbose
 
-  python benchmarks/dynamo/timm_models.py --device cuda --accuracy --amp \
+  # Skip inductor bench mark tests for rerun-disabled-mode.
+  if [[ "${PYTORCH_TEST_RERUN_DISABLED_TESTS}" == "1" ]]; then
+    echo "skip dynamo benchmark tests for rerun-disabled-test"
+  else
+    echo "run dynamo benchmark tests for rerun-disabled-test"
+    python benchmarks/dynamo/timm_models.py --device cuda --accuracy --amp \
     --training --inductor --disable-cudagraphs --only vit_base_patch16_224 \
     --output "$TEST_REPORTS_DIR/inductor_cpp_wrapper_training.csv"
-  python benchmarks/dynamo/check_accuracy.py \
-    --actual "$TEST_REPORTS_DIR/inductor_cpp_wrapper_training.csv" \
-    --expected "benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv"
+    python benchmarks/dynamo/check_accuracy.py \
+      --actual "$TEST_REPORTS_DIR/inductor_cpp_wrapper_training.csv" \
+      --expected "benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv"
 
-  python benchmarks/dynamo/torchbench.py --device cuda --accuracy \
-    --bfloat16 --inference --inductor --only hf_T5 --output "$TEST_REPORTS_DIR/inductor_cpp_wrapper_inference.csv"
-  python benchmarks/dynamo/torchbench.py --device cuda --accuracy \
-    --bfloat16 --inference --inductor --only llama --output "$TEST_REPORTS_DIR/inductor_cpp_wrapper_inference.csv"
-  python benchmarks/dynamo/torchbench.py --device cuda --accuracy \
-    --bfloat16 --inference --inductor --only moco --output "$TEST_REPORTS_DIR/inductor_cpp_wrapper_inference.csv"
-  python benchmarks/dynamo/check_accuracy.py \
-    --actual "$TEST_REPORTS_DIR/inductor_cpp_wrapper_inference.csv" \
-    --expected "benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv"
+    python benchmarks/dynamo/torchbench.py --device cuda --accuracy \
+      --bfloat16 --inference --inductor --only hf_T5 --output "$TEST_REPORTS_DIR/inductor_cpp_wrapper_inference.csv"
+    python benchmarks/dynamo/torchbench.py --device cuda --accuracy \
+      --bfloat16 --inference --inductor --only llama --output "$TEST_REPORTS_DIR/inductor_cpp_wrapper_inference.csv"
+    python benchmarks/dynamo/torchbench.py --device cuda --accuracy \
+      --bfloat16 --inference --inductor --only moco --output "$TEST_REPORTS_DIR/inductor_cpp_wrapper_inference.csv"
+    python benchmarks/dynamo/check_accuracy.py \
+      --actual "$TEST_REPORTS_DIR/inductor_cpp_wrapper_inference.csv" \
+      --expected "benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv"
+  fi
 }
 
 # "Global" flags for inductor benchmarking controlled by TEST_CONFIG

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -384,7 +384,9 @@ test_inductor_cpp_wrapper() {
   # unit tests with cpp wrapper.
   python test/run_test.py --include inductor/test_torchinductor.py --verbose
 
-  # Skip inductor bench mark tests for rerun-disabled-mode.
+
+  # Run inductor benchmark tests with cpp wrapper.
+  # Skip benchmark tests if it's in rerun-disabled-mode.
   if [[ "${PYTORCH_TEST_RERUN_DISABLED_TESTS}" == "1" ]]; then
     echo "skip dynamo benchmark tests for rerun-disabled-test"
   else

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -390,7 +390,7 @@ test_inductor_cpp_wrapper() {
   if [[ "${PYTORCH_TEST_RERUN_DISABLED_TESTS}" == "1" ]]; then
     echo "skip dynamo benchmark tests for rerun-disabled-test"
   else
-    echo "run dynamo benchmark tests for rerun-disabled-test"
+    echo "run dynamo benchmark tests with cpp wrapper"
     python benchmarks/dynamo/timm_models.py --device cuda --accuracy --amp \
     --training --inductor --disable-cudagraphs --only vit_base_patch16_224 \
     --output "$TEST_REPORTS_DIR/inductor_cpp_wrapper_training.csv"


### PR DESCRIPTION
Fixes [#5774](https://github.com/pytorch/test-infra/issues/5774)
# Overview 
Remove benchmark tests from rerun-disabled-tests, this is considered non-unittest.
See one page doc: [[Bootcamp Task] Remove non-unittest test during rerun-disabled-tests](https://docs.google.com/document/d/1xffkt_LNC5ZLsoVQDmuKbNqYnMUW_xYYStv66Pr-qac/edit?tab=t.0)

# Steps to fix the issue
- [ ] Create inductor-unittest.yml to handle unit test and daily rerun for inductor 
- [ ] Create Inductor-cu124-unittest.yml to handle unit tests and daily rerun for inductor-cu124
- [x] Disable benchmark test in mixed test such as CPP_Wrapper which includes both unittest and benchmark test
