### PR TITLE
[pt2 logging] move remote cache get/put logging up one level

### DIFF
--- a/torch/_inductor/remote_cache.py
+++ b/torch/_inductor/remote_cache.py
@@ -12,6 +12,7 @@ from abc import abstractmethod
 from typing import Any, Callable, Dict, Generic, List, Optional, Type, TypeVar, Union
 from typing_extensions import override, TypeAlias
 
+from torch._dynamo.utils import dynamo_timed
 from torch._inductor import config
 
 
@@ -144,29 +145,39 @@ class RemoteCache(Generic[_T]):
     # See if the cache contains `key`. Returns `None` if the value is not
     # present in the cache.
     def get(self, key: str) -> Optional[_T]:
-        sample = self._create_sample()
-        try:
-            result = self._get(key, sample)
-            cache_stats.get(type(self).__name__, result)
-        except Exception:
-            cache_stats.exception(type(self).__name__)
-            raise
-        self._log_sample(sample)
-        return result
+        with dynamo_timed(
+            "RemoteFxGraphCache.get",
+            phase_name="remote_fx_graph_cache_get",
+            fwd_only=False,
+        ):
+            sample = self._create_sample()
+            try:
+                result = self._get(key, sample)
+                cache_stats.get(type(self).__name__, result)
+            except Exception:
+                cache_stats.exception(type(self).__name__)
+                raise
+            self._log_sample(sample)
+            return result
 
     # Add `value` to the cache with the key `key`. Note that `None` is not a
     # valid value even if _T supports it (because you can't tell the difference
     # between `None` and a missing cache entry).
     def put(self, key: str, value: _T) -> None:
-        assert value is not None
-        sample = self._create_sample()
-        try:
-            self._put(key, value, sample)
-            cache_stats.put(type(self).__name__)
-        except Exception:
-            cache_stats.exception(type(self).__name__)
-            raise
-        self._log_sample(sample)
+        with dynamo_timed(
+            "RemoteFxGraphCache.put",
+            phase_name="remote_fx_graph_cache_put",
+            fwd_only=False,
+        ):
+            assert value is not None
+            sample = self._create_sample()
+            try:
+                self._put(key, value, sample)
+                cache_stats.put(type(self).__name__)
+            except Exception:
+                cache_stats.exception(type(self).__name__)
+                raise
+            self._log_sample(sample)
 
     # Used to convert data from the cache into structured data.
     def _decode(self, data: _U, sample: Optional[Sample]) -> _T:  # type: ignore[override]


### PR DESCRIPTION
Summary: I need to refactor the way we record CompilationMetrics. It will be much easier to do in OSS and having the relevant timing code in the OSS area of the codebase will make this much easier. I doubt this meaningfully changes the values we see.

Test Plan: Made sure samples show up: https://fburl.com/scuba/dynamo_compile/sandbox/c38zjq0x

Differential Revision: D65290089




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov