### PR TITLE
[DCP] Fix process_group logging for DCP methods

### DIFF
--- a/torch/distributed/checkpoint/logger.py
+++ b/torch/distributed/checkpoint/logger.py
@@ -54,7 +54,7 @@ def _msg_dict_from_dcp_method_args(*args, **kwargs) -> Dict[str, Any]:
 
 def _get_msg_dict(func_name, *args, **kwargs) -> Dict[str, Any]:
     msg_dict = _msg_dict_from_dcp_method_args(*args, **kwargs)
-    msg_dict.update(c10d_logger._get_msg_dict(func_name, **msg_dict))
+    msg_dict.update(c10d_logger._get_msg_dict(func_name, *args, **kwargs))
 
     return msg_dict
 

--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -206,6 +206,7 @@ def _load_state_dict(
     ckpt_kwargs = {}
     if (ckpt_id := getattr(storage_reader, "checkpoint_id", None)) is not None:
         ckpt_kwargs["checkpoint_id"] = ckpt_id
+        ckpt_kwargs["process_group"] = distW.group
 
     @_dcp_method_logger(**ckpt_kwargs)
     def local_step():

--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -280,6 +280,7 @@ def _save_state_dict(
     ckpt_kwargs = {}
     if (ckpt_id := getattr(storage_writer, "checkpoint_id", None)) is not None:
         ckpt_kwargs["checkpoint_id"] = ckpt_id
+        ckpt_kwargs["process_group"] = distW.group
 
     @_dcp_method_logger(**ckpt_kwargs)
     def local_step():


### PR DESCRIPTION
Summary:
Currently, we incorrectly log process_group for DCP based events. 

We rely on [c10d_logger.py](https://fburl.com/v4mdme9z) to fill in information about process_group (e.g. backend, nccl_version if available). 

In [checkpoint/logger.py](https://fburl.com/yho9nqbu) we pass the `msg_dict` to c10d_logger which never contains the `process_group` param, so [c10d_logger](https://fburl.com/zlw2ukxp) logs information about the default process_group which is always `NCCL`.

Test Plan:
Before: 

Always defaults to NCCL even though GLOO is passed by caller. 

{F1950847585} 

After:

GLOO backend shows up. 

{F1950848375}

Differential Revision: D65255871




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @mhorowitz @pradeepfn