### PR TITLE
[IG] Update merge_devices in fake_tensor to allow meta & cpu device mismatch

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2209,6 +2209,15 @@ class MiniOpTest(CustomOpTestCaseBase):
             result = torch.ops.aten.mm.default(x, y)
             self.assertEqual(result.shape, (x @ y).shape)
 
+    def test_mm_cpu_meta_device_mismatch(self):
+        with torch._subclasses.fake_tensor.FakeTensorMode():
+            x = torch.randn(3, 3, requires_grad=True, device="cpu")
+            y = torch.randn(3, 3, device="meta")
+            result = torch.ops.aten.mm.default(x, y)
+            self.assertEqual(result.shape, (x & y).shape)
+            result_flip = torch.ops.aten.mm.default(y, x)
+            self.assertEqual(result_flip.shape, (y @ x).shape)
+
     def test_mm_errors(self):
         x = torch.randn(2, 3, requires_grad=True)
         y = torch.randn(4, 5)

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -870,6 +870,11 @@ class FakeTensor(Tensor):
                 is_cpu_zero_dim = t_is_cpu_zero_dim
                 return
 
+            # if mismatched device are cpu & meta, set common_device to meta
+            if {str(common_device), str(t.device)} == {"cpu", "meta"}:
+                common_device = torch.device("meta")
+                return
+
             # mismatching devices of non-zero dim tensors, throw
             # This might be valid behavior and need to be explicitly modeled, e.g. reshape_as
             raise RuntimeError(


### PR DESCRIPTION
Summary:
Set device to meta if the mismatch is between meta & cpu to address error:
```
RuntimeError: Unhandled FakeTensor Device Propagation for aten.mm.default, found two different devices meta, cpu
```

Test Plan: CI

Differential Revision: D65295204


