### PR TITLE
[pipelining] RNG seed management for PP init

### DIFF
--- a/test/distributed/pipelining/model_registry.py
+++ b/test/distributed/pipelining/model_registry.py
@@ -87,6 +87,12 @@ class MLPModule(torch.nn.Module):
         x = self.net2(x)
         return x
 
+    def init_weights(self):
+        torch.nn.init.xavier_uniform_(self.net1.weight)
+        torch.nn.init.xavier_uniform_(self.net2.weight)
+        torch.nn.init.zeros_(self.net1.bias)
+        torch.nn.init.zeros_(self.net2.bias)
+
 
 # Multi-MLP model
 class MultiMLP(torch.nn.Module):
@@ -102,6 +108,10 @@ class MultiMLP(torch.nn.Module):
         for layer in self.layers:
             x = layer(x)
         return x
+
+    def init_weights(self):
+        for l in self.layers:
+            l.init_weights()
 
 
 class CustomLinearDx(Function):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #140026
* __->__ #139445

Add new 'seeded_module_init' API to PipelineScheduleMulti
- note: skipped for PipelineScheduleSingle for now. Could add it there
  too, but i want to delete that class and unify

Example:

```
schedule.seeded_module_init(
   # required arg, can be any fn that accepts 'module' as arg;
   # can be ModuleClass.init_weights
   my_initializer_fn,

   # optional args
   mode="serial",
   seed=1234
)
```

Implement both 'serial' and 'parallel' options described in #139304

'parallel' mode sets a unique seed per rank, but does not worry about
parity with non-PP initialization.  It is fastest becuase it
parallelizes initialization and uses no communication.

'serial' mode does initialization one stage at a time, communicating the
RNG states from rank to rank as needed so that the resulting
initialization is equivalent to non-PP initialization where the whole
model is initialized on one rank.

The overall initialization is delegated to the 'schedule' since it knows which
stages it owns, which ranks they are on, and what order they go in.
But the per-stage initialization is handled by a user-passed function
that can do anything it wants to the given module owned by that stage.