### PR TITLE
[MPS] Fix reduction ops outputs for empty tensors

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -208,9 +208,12 @@ static void reduction_out_mps(const Tensor& input_t,
       case MPSReductionType::COUNT_NONZERO:
         output_t.zero_();
         break;
+      case MPSReductionType::AMAX:
+      case MPSReductionType::AMIN:
       case MPSReductionType::MAX:
       case MPSReductionType::MIN:
         TORCH_CHECK(opt_dim.has_value(), "Expected reduction dim to be specified for input.numel() == 0");
+        break;
       default:
         TORCH_INTERNAL_ASSERT(false, "Unexpected reduction type ", reduction_type);
         break;

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -196,10 +196,24 @@ static void reduction_out_mps(const Tensor& input_t,
   NSArray<NSNumber*>* wrappedAxes = getTensorAxes(input_shape, opt_dim);
 
   if (output_t.numel() == 0 || input_t.numel() == 0) {
-    if (reduction_type == MPSReductionType::PROD) {
-      output_t.fill_(1);
-    } else if (reduction_type == MPSReductionType::SUM) {
-      output_t.zero_();
+    switch (reduction_type) {
+      case MPSReductionType::PROD:
+        output_t.fill_(1);
+        break;
+      case MPSReductionType::MEAN:
+        output_t.fill_(std::numeric_limits<float>::quiet_NaN());
+        break;
+      case MPSReductionType::SUM:
+      case MPSReductionType::NANSUM:
+      case MPSReductionType::COUNT_NONZERO:
+        output_t.zero_();
+        break;
+      case MPSReductionType::MAX:
+      case MPSReductionType::MIN:
+        TORCH_CHECK(opt_dim.has_value(), "Expected reduction dim to be specified for input.numel() == 0");
+      default:
+        TORCH_INTERNAL_ASSERT(false, "Unexpected reduction type ", reduction_type);
+        break;
     }
     return;
   }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11539,6 +11539,17 @@ class TestAdvancedIndexing(TestCaseMPS):
         self.assertEqual((60, 20, 5), z.stride())
         self.assertTrue(z.is_contiguous())
 
+    def test_empty_reduce(self, device="mps"):
+        x = torch.rand(0, 3, device=device)
+        self.assertTrue(x.mean().isnan())
+        self.assertEqual(x.count_nonzero(), 0)
+        self.assertEqual(x.sum(), 0)
+        self.assertEqual(x.nansum(), 0)
+        self.assertRaises(RuntimeError, lambda: x.amax())
+        self.assertRaises(IndexError, lambda: x.amax(dim=0))
+        self.assertRaises(RuntimeError, lambda: x.amin())
+        self.assertRaises(IndexError, lambda: x.amin(dim=0))
+
     def test_index_getitem_copy_bools_slices(self, device="mps"):
         true = torch.tensor(1, dtype=torch.uint8, device=device)
         false = torch.tensor(0, dtype=torch.uint8, device=device)


### PR DESCRIPTION
By adding a switch for all reduction types, that either sets it to given value or raises runtime error.
Before this change, reduction ops returned uninitialized values in many case

Fixes https://github.com/pytorch/pytorch/issues/139400
