### PR TITLE
Use a different test name for testConversionToStringView

### DIFF
--- a/c10/test/util/string_view_test.cpp
+++ b/c10/test/util/string_view_test.cpp
@@ -106,7 +106,7 @@ TEST(StringViewTest, testConversionToString) {
 } // namespace test_conversion_to_string
 
 namespace test_conversion_to_std_string_view {
-TEST(StringViewTest, testConversionToString) {
+TEST(StringViewTest, testConversionToStringView) {
   c10::string_view empty;
   EXPECT_EQ(0, std::string_view(empty).size());
   c10::string_view hello_sv = "hello";


### PR DESCRIPTION
Summary:
The change comes from D65214804 (https://github.com/pytorch/pytorch/pull/139239)

`buck2 test @//fbobjc/mode/buck2/ios-tests fbsource//xplat/caffe2/c10:c10_testApple` doesn't like having 2 `testConversionToString` in the same suite `StringViewTest`, so just need to use a different name there.

Test Plan: `buck2 test @//fbobjc/mode/buck2/ios-tests fbsource//xplat/caffe2/c10:c10_testApple` passes

Differential Revision: D65314266


