### PR TITLE
Ensure scalar tensor device matches attn_mask for convert_boolean_attn_mask_cudnn.

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -549,7 +549,7 @@ std::optional<Tensor> convert_boolean_attn_mask_cudnn(const std::optional<Tensor
   // to mask *out*.
   if (attn_mask->dtype() == at::kBool) {
     // TODO Use the max type of the input and output
-    return at::where(attn_mask->logical_not(), -65504.0, at::scalar_tensor(0.0, at::TensorOptions().dtype(dtype)));
+    return at::where(attn_mask->logical_not(), -65504.0, at::scalar_tensor(0.0, at::TensorOptions().dtype(dtype).device(attn_mask->device())));
   }
   // Otherwise, attn_mask represents an additive attention tensor
   return attn_mask;


### PR DESCRIPTION
This is causing a small performance hit when using SDPA with the cuDNN backend due to unnecessary host-to-device memcpy.