### PR TITLE
[1/N] Replace c10::sv with std::sv

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -50,6 +50,11 @@ TORCH_API c10::intrusive_ptr<ConstantString> ConstantString::create(
 }
 
 TORCH_API c10::intrusive_ptr<ConstantString> ConstantString::create(
+    std::string_view str_) {
+  return c10::make_intrusive<ConstantString>(std::string(str_));
+}
+
+TORCH_API c10::intrusive_ptr<ConstantString> ConstantString::create(
     const char* str_) {
   return c10::make_intrusive<ConstantString>(std::string(str_));
 }

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -691,6 +691,7 @@ struct TORCH_API IValue final {
   IValue(std::string v);
   IValue(const char* v) : IValue(std::string(v)) {}
   IValue(c10::string_view v) : IValue(std::string(v)){}
+  IValue(std::string_view v) : IValue(std::string(v)){}
   bool isString() const {
     return Tag::String == tag;
   }

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -302,8 +302,10 @@ struct TORCH_API ConstantString final : c10::intrusive_ptr_target {
  public:
   ConstantString(std::string str) : str_(std::move(str)) {}
   ConstantString(c10::string_view str) : str_(std::string(str)) {}
+  ConstantString(std::string_view str) : str_(std::string(str)) {}
   static c10::intrusive_ptr<ConstantString> create(std::string str_);
   static c10::intrusive_ptr<ConstantString> create(c10::string_view str_);
+  static c10::intrusive_ptr<ConstantString> create(std::string_view str_);
   static c10::intrusive_ptr<ConstantString> create(const char* str_);
 
   const std::string& string() const {

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -184,7 +184,7 @@ void pushPyOutToStack(
 namespace {
 
 c10::TensorImpl::SizesStridesPolicy parseSizesStridesPolicyArgument(
-    c10::string_view arg) {
+    std::string_view arg) {
   if (arg == "strides") {
     return c10::TensorImpl::SizesStridesPolicy::CustomStrides;
   }

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -397,7 +397,7 @@ static PyObject* reduceopmeta___instancecheck__(
   if (Py_TYPE(self) == Py_TYPE(args)) {
     Py_RETURN_TRUE;
   }
-  if (c10::string_view(args->ob_type->tp_name).find("RedOpType") !=
+  if (std::string_view(args->ob_type->tp_name).find("RedOpType") !=
       c10::string_view::npos) {
     Py_RETURN_TRUE;
   }

--- a/torch/csrc/jit/frontend/function_schema_parser.cpp
+++ b/torch/csrc/jit/frontend/function_schema_parser.cpp
@@ -24,7 +24,7 @@ namespace {
 struct SchemaParser {
   explicit SchemaParser(const std::string& str, bool allow_typevars)
       : L(std::make_shared<Source>(
-            c10::string_view(str),
+            std::string_view(str),
             std::nullopt,
             0,
             nullptr,

--- a/torch/csrc/jit/frontend/lexer.h
+++ b/torch/csrc/jit/frontend/lexer.h
@@ -306,7 +306,7 @@ struct TORCH_API SharedParserData {
   // 1. skip whitespace
   // 2. handle comment or newline
   //
-  bool isNumber(c10::string_view str, size_t start, size_t* len) {
+  bool isNumber(std::string_view str, size_t start, size_t* len) {
     char first = str[start];
     // strtod allows numbers to start with + or - or nan or inf
     // http://en.cppreference.com/w/cpp/string/byte/strtof
@@ -326,7 +326,7 @@ struct TORCH_API SharedParserData {
     return *len > 0;
   }
 
-  bool isCharCount(char c, c10::string_view str, size_t start, int len) {
+  bool isCharCount(char c, std::string_view str, size_t start, int len) {
     // count checks from [start, start + len)
     return start + len <= str.size() &&
         std::count(str.begin() + start, str.begin() + start + len, c) == len;
@@ -336,7 +336,7 @@ struct TORCH_API SharedParserData {
   // strings can be enclosed with 1 or 3 single or double quotes
   // if enclosed with 3 quotes newlines are valid
   // as elsewhere, backslash and new line should be ignored
-  bool isString(c10::string_view str, size_t start, size_t* len) {
+  bool isString(std::string_view str, size_t start, size_t* len) {
     char quote = str[start];
     if (quote != '\"' && quote != '\'')
       return false;
@@ -369,7 +369,7 @@ struct TORCH_API SharedParserData {
   }
 
   bool isTypeComment(StringCordView::Iterator str_iter) {
-    c10::string_view rest_line = str_iter.rest_line();
+    std::string_view rest_line = str_iter.rest_line();
     const std::string type_string = "# type:";
     if (rest_line.size() < type_string.length()) {
       return false;

--- a/torch/csrc/jit/frontend/source_range.h
+++ b/torch/csrc/jit/frontend/source_range.h
@@ -55,7 +55,7 @@ struct TORCH_API StringCordView {
 
   bool operator==(const StringCordView& rhs) const;
 
-  c10::string_view piece(size_t index) const {
+  std::string_view piece(size_t index) const {
     return pieces_[index];
   }
 
@@ -138,12 +138,12 @@ struct TORCH_API StringCordView {
     }
 
     // returns rest of the line of the current iterator
-    c10::string_view rest_line() const {
+    std::string_view rest_line() const {
       if (line_ >= str_->pieces_.size()) {
         return "";
       }
 
-      c10::string_view cur_line = str_->pieces_[line_];
+      std::string_view cur_line = str_->pieces_[line_];
       return cur_line.substr(pos_, std::string::npos);
     }
 
@@ -187,7 +187,7 @@ struct TORCH_API Source {
   enum CopiesString { COPIES_STRING, DONT_COPY };
 
   explicit Source(
-      c10::string_view text_view,
+      std::string_view text_view,
       std::optional<std::string> filename = std::nullopt,
       size_t starting_line_no = 0,
       std::shared_ptr<SourceRangeUnpickler> gen_ranges = nullptr,
@@ -320,7 +320,7 @@ struct TORCH_API SourceRange {
         end_(end_),
         start_iter_(start_iter) {}
 
-  const c10::string_view token_text() const {
+  const std::string_view token_text() const {
     size_t size = end() - start();
     return start_iter_.rest_line().substr(0, size);
   }

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -660,7 +660,7 @@ void addInputs(
     const std::optional<at::Scalar>& value) {
   detail::genericAddOptionalInput(n, name, value);
 }
-void addInputs(Node* n, const char* name, const c10::string_view value) {
+void addInputs(Node* n, const char* name, const std::string_view value) {
   detail::genericAddInput(n, std::string(value));
 }
 void addInputs(

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -666,7 +666,7 @@ void addInputs(Node* n, const char* name, const std::string_view value) {
 void addInputs(
     Node* n,
     const char* name,
-    const std::optional<c10::string_view>& value) {
+    const std::optional<std::string_view>& value) {
   detail::genericAddOptionalInput(n, name, value);
 }
 void addInputs(Node* n, const char* name, const at::Tensor& value) {

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -660,13 +660,13 @@ void addInputs(
     const std::optional<at::Scalar>& value) {
   detail::genericAddOptionalInput(n, name, value);
 }
-void addInputs(Node* n, const char* name, const std::string_view value) {
+void addInputs(Node* n, const char* name, const c10::string_view value) {
   detail::genericAddInput(n, std::string(value));
 }
 void addInputs(
     Node* n,
     const char* name,
-    const std::optional<std::string_view>& value) {
+    const std::optional<c10::string_view>& value) {
   detail::genericAddOptionalInput(n, name, value);
 }
 void addInputs(Node* n, const char* name, const at::Tensor& value) {

--- a/torch/csrc/jit/frontend/tracer.h
+++ b/torch/csrc/jit/frontend/tracer.h
@@ -309,7 +309,7 @@ TORCH_API void addInputs(
 TORCH_API void addInputs(
     Node* n,
     const char* name,
-    const std::optional<c10::string_view>& value);
+    const std::optional<std::string_view>& value);
 TORCH_API void addInputs(Node* n, const char* name, at::Device value);
 TORCH_API void addInputs(Node* n, const char* name, c10::Stream stream);
 TORCH_API void addInputs(Node* n, const char* name, at::Layout value);

--- a/torch/csrc/jit/frontend/tracer.h
+++ b/torch/csrc/jit/frontend/tracer.h
@@ -305,11 +305,11 @@ TORCH_API void addInputs(
 TORCH_API void addInputs(
     Node* n,
     const char* name,
-    const std::string_view value);
+    const c10::string_view value);
 TORCH_API void addInputs(
     Node* n,
     const char* name,
-    const std::optional<std::string_view>& value);
+    const std::optional<c10::string_view>& value);
 TORCH_API void addInputs(Node* n, const char* name, at::Device value);
 TORCH_API void addInputs(Node* n, const char* name, c10::Stream stream);
 TORCH_API void addInputs(Node* n, const char* name, at::Layout value);

--- a/torch/csrc/jit/frontend/tracer.h
+++ b/torch/csrc/jit/frontend/tracer.h
@@ -305,7 +305,7 @@ TORCH_API void addInputs(
 TORCH_API void addInputs(
     Node* n,
     const char* name,
-    const c10::string_view value);
+    const std::string_view value);
 TORCH_API void addInputs(
     Node* n,
     const char* name,

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -67,11 +67,11 @@ void printValueRef(std::ostream& out, const Value* n) {
   out << "%" << n->debugName();
 }
 
-bool isNumber(c10::string_view str) {
+bool isNumber(std::string_view str) {
   return str.find_first_not_of("0123456789") == std::string::npos;
 }
 
-std::string normalizeAttrName(c10::string_view field) {
+std::string normalizeAttrName(std::string_view field) {
   if (isNumber(field)) {
     return "_" + std::string{field};
   }

--- a/torch/csrc/jit/mobile/type_parser.cpp
+++ b/torch/csrc/jit/mobile/type_parser.cpp
@@ -210,7 +210,7 @@ TypePtr TypeParser::parseNamedTuple(const std::string& qualified_name) {
 //   ]
 // ]"
 TypePtr TypeParser::parseCustomType() {
-  c10::string_view token = cur();
+  std::string_view token = cur();
   std::string qualified_name = "__torch__.";
   qualified_name.reserve(qualified_name.size() + token.size());
   qualified_name.append(token.begin(), token.end());
@@ -270,7 +270,7 @@ TypePtr TypeParser::parseTorchbindClassType() {
 }
 
 void TypeParser::expect(const char* s) {
-  c10::string_view token = cur();
+  std::string_view token = cur();
   TORCH_CHECK(
       token == s,
       "Error when parsing type ",
@@ -285,7 +285,7 @@ void TypeParser::expect(const char* s) {
 // c10::string_view::operator== calls memcmp to compare against the target
 // string; we can do better if we specialize for a single character.
 void TypeParser::expectChar(char c) {
-  c10::string_view token = cur();
+  std::string_view token = cur();
   TORCH_CHECK(
       token.size() == 1 && token[0] == c,
       "Error when parsing type ",
@@ -303,25 +303,25 @@ void TypeParser::lex() {
     ++start_;
   if (start_ < pythonStr_.size()) {
     if (isSpecialChar(pythonStr_[start_])) {
-      next_token_ = c10::string_view(pythonStr_.data() + start_++, 1);
+      next_token_ = std::string_view(pythonStr_.data() + start_++, 1);
     } else { // A word
       size_t end = start_;
       for (; end < pythonStr_.size() && !isSpecialChar(pythonStr_[end]) &&
            pythonStr_[end] != ' ';
            ++end)
         ;
-      next_token_ = c10::string_view(pythonStr_.data() + start_, end - start_);
+      next_token_ = std::string_view(pythonStr_.data() + start_, end - start_);
       start_ = end;
     }
   }
 }
 
-c10::string_view TypeParser::nextView() {
+std::string_view TypeParser::nextView() {
   TORCH_CHECK(
       !next_token_.empty(),
       "Empty token queue in mobile type parser.",
       "Check the format of the type string and make sure it's correct.");
-  c10::string_view token = cur();
+  std::string_view token = cur();
   advance();
   return token;
 }
@@ -336,7 +336,7 @@ void TypeParser::advance() {
   lex();
 }
 
-[[nodiscard]] c10::string_view TypeParser::cur() const {
+[[nodiscard]] std::string_view TypeParser::cur() const {
   return next_token_;
 }
 

--- a/torch/csrc/jit/mobile/type_parser.h
+++ b/torch/csrc/jit/mobile/type_parser.h
@@ -31,13 +31,13 @@ class TORCH_API TypeParser {
   void lex();
 
   std::string next();
-  c10::string_view nextView();
+  std::string_view nextView();
   void advance();
-  [[nodiscard]] c10::string_view cur() const;
+  [[nodiscard]] std::string_view cur() const;
 
   std::string pythonStr_;
   size_t start_;
-  c10::string_view next_token_;
+  std::string_view next_token_;
 
   // Used for parsing string list
   std::vector<std::string> pythonStrs_;

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -338,8 +338,8 @@ void Pickler::pushBytes(const std::string& string) {
 }
 
 void Pickler::pushGlobal(
-    c10::string_view module_name,
-    c10::string_view class_name) {
+    std::string_view module_name,
+    std::string_view class_name) {
   std::string key;
   key.reserve(module_name.size() + class_name.size() + 2);
   key.append(module_name.data(), module_name.size());

--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -190,7 +190,7 @@ class TORCH_API Pickler {
       const IValue& ivalue,
       const char* list_name,
       const std::function<void(const IValue&)>& item_pusher);
-  void pushGlobal(c10::string_view module_name, c10::string_view class_name);
+  void pushGlobal(std::string_view module_name, std::string_view class_name);
   // raw string data is appended directly to the byte stream
   void pushBytes(const std::string& string);
   void pushTensorData(const at::Tensor& tensor);

--- a/torch/csrc/jit/serialization/source_range_serialization.h
+++ b/torch/csrc/jit/serialization/source_range_serialization.h
@@ -19,7 +19,7 @@ class SourceRangeSerializer;
 static constexpr size_t kByteOffsetIndex = 0;
 static constexpr size_t kSourceRangeIndex = 1;
 static constexpr size_t kSourceRangeTagIndex = 2;
-constexpr c10::string_view kFormatWithStringTable = "FORMAT_WITH_STRING_TABLE";
+constexpr std::string_view kFormatWithStringTable = "FORMAT_WITH_STRING_TABLE";
 
 class SourceRangePickler {
  public:

--- a/torch/csrc/jit/testing/file_check.cpp
+++ b/torch/csrc/jit/testing/file_check.cpp
@@ -45,7 +45,7 @@ struct Check {
 
   Check(
       CheckType type,
-      c10::string_view str,
+      std::string_view str,
       std::optional<size_t> count = std::nullopt)
       : Check(type, std::string(str.begin(), str.end()), count) {}
 

--- a/torch/csrc/lazy/core/helpers.cpp
+++ b/torch/csrc/lazy/core/helpers.cpp
@@ -124,7 +124,7 @@ Shape GetPromotedBinaryOpShape(const Shape& shape1, const Shape& shape2) {
       GetPromotedShape(shape1.sizes(), shape2.sizes()));
 }
 
-std::vector<std::string> StrSplit(c10::string_view text, char delim) {
+std::vector<std::string> StrSplit(std::string_view text, char delim) {
   size_t start = 0;
   size_t end = 0;
 

--- a/torch/csrc/lazy/core/helpers.h
+++ b/torch/csrc/lazy/core/helpers.h
@@ -65,6 +65,6 @@ TORCH_API std::vector<int64_t> GetPromotedShape(
 TORCH_API Shape
 GetPromotedBinaryOpShape(const Shape& shape1, const Shape& shape2);
 
-TORCH_API std::vector<std::string> StrSplit(c10::string_view text, char delim);
+TORCH_API std::vector<std::string> StrSplit(std::string_view text, char delim);
 
 } // namespace torch::lazy

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -1127,7 +1127,7 @@ static inline std::vector<int64_t> parse_intlist_args(
 }
 
 // Parse a string literal to remove quotes and escape sequences
-static std::string parse_string_literal(c10::string_view str) {
+static std::string parse_string_literal(std::string_view str) {
   TORCH_CHECK(str.length() >= 2, "String defaults must be quoted");
 
   if (str.front() == '"') {

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -281,10 +281,10 @@ struct PythonArgs {
   inline std::string string(int i);
   inline std::string stringWithDefault(int i, const std::string& default_str);
   inline std::optional<std::string> stringOptional(int i);
-  inline c10::string_view stringView(int i);
-  inline c10::string_view stringViewWithDefault(
+  inline std::string_view stringView(int i);
+  inline std::string_view stringViewWithDefault(
       int i,
-      const c10::string_view default_str);
+      const std::string_view default_str);
   inline std::optional<c10::string_view> stringViewOptional(int i);
   inline PyObject* pyobject(int i);
   inline int64_t toInt64(int i);
@@ -930,13 +930,13 @@ inline std::optional<std::string> PythonArgs::stringOptional(int i) {
   return THPUtils_unpackString(args[i]);
 }
 
-inline c10::string_view PythonArgs::stringView(int i) {
+inline std::string_view PythonArgs::stringView(int i) {
   return stringViewWithDefault(i, signature.params[i].default_string);
 }
 
-inline c10::string_view PythonArgs::stringViewWithDefault(
+inline std::string_view PythonArgs::stringViewWithDefault(
     int i,
-    const c10::string_view default_str) {
+    const std::string_view default_str) {
   if (!args[i])
     return default_str;
   return THPUtils_unpackStringView(args[i]);

--- a/torch/csrc/utils/python_strings.h
+++ b/torch/csrc/utils/python_strings.h
@@ -36,16 +36,16 @@ inline std::string THPUtils_unpackString(PyObject* obj) {
 
 // Unpacks PyBytes (PyString) or PyUnicode as c10::string_view
 // PyBytes are unpacked as-is. PyUnicode is unpacked as UTF-8.
-// NOTE: If `obj` is destroyed, then the non-owning c10::string_view will
+// NOTE: If `obj` is destroyed, then the non-owning std::string_view will
 //   become invalid. If the string needs to be accessed at any point after
-//   `obj` is destroyed, then the c10::string_view should be copied into
+//   `obj` is destroyed, then the std::string_view should be copied into
 //   a std::string, or another owning object, and kept alive. For an example,
-//   look at how IValue and autograd nodes handle c10::string_view arguments.
+//   look at how IValue and autograd nodes handle std::string_view arguments.
 // NOTE: this method requires the GIL
-inline c10::string_view THPUtils_unpackStringView(PyObject* obj) {
+inline std::string_view THPUtils_unpackStringView(PyObject* obj) {
   if (PyBytes_Check(obj)) {
     size_t size = PyBytes_GET_SIZE(obj);
-    return c10::string_view(PyBytes_AS_STRING(obj), size);
+    return std::string_view(PyBytes_AS_STRING(obj), size);
   }
   if (PyUnicode_Check(obj)) {
     Py_ssize_t size = 0;
@@ -53,7 +53,7 @@ inline c10::string_view THPUtils_unpackStringView(PyObject* obj) {
     if (!data) {
       throw std::runtime_error("error unpacking string as utf-8");
     }
-    return c10::string_view(data, (size_t)size);
+    return std::string_view(data, (size_t)size);
   }
   throw std::runtime_error("unpackString: expected bytes or unicode object");
 }

--- a/torch/csrc/utils/schema_info.cpp
+++ b/torch/csrc/utils/schema_info.cpp
@@ -100,11 +100,11 @@ bool SchemaInfo::is_mutable(const c10::SchemaArgument& argument) {
       });
 }
 
-bool SchemaInfo::has_argument(c10::string_view name) {
+bool SchemaInfo::has_argument(std::string_view name) {
   return schema_.argumentIndexWithName(name) != std::nullopt;
 }
 
-bool SchemaInfo::is_mutable(c10::string_view name) {
+bool SchemaInfo::is_mutable(std::string_view name) {
   std::optional<int> index = schema_.argumentIndexWithName(name);
   TORCH_INTERNAL_ASSERT(
       index.has_value(), "Schema has no argument named ", name);

--- a/torch/csrc/utils/schema_info.h
+++ b/torch/csrc/utils/schema_info.h
@@ -29,9 +29,9 @@ struct TORCH_API SchemaInfo {
 
   bool is_mutable(const c10::SchemaArgument& argument);
 
-  bool is_mutable(c10::string_view name);
+  bool is_mutable(std::string_view name);
 
-  bool has_argument(c10::string_view name);
+  bool has_argument(std::string_view name);
 
   bool is_nondeterministic() const;
 


### PR DESCRIPTION
Picks some safe replacements.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @EikanWang @jgong5 @wenzhe-nrv @sanchitintel