### PR TITLE
[profiler] fix a building warning by adding USE_KINETO namespace for setTraceID

### DIFF
--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -220,6 +220,7 @@ bool collectivesProfilerExists() {
 #endif
 }
 
+#ifdef USE_KINETO
 static const std::string setTraceID(const std::string& trace_id) {
   if (trace_id == "") {
     return "";
@@ -229,6 +230,7 @@ static const std::string setTraceID(const std::string& trace_id) {
   configss << "REQUEST_GROUP_TRACE_ID=" << trace_id << "\n";
   return configss.str();
 }
+#endif
 
 void prepareTrace(
     const bool cpuOnly,


### PR DESCRIPTION
Fix: https://github.com/pytorch/pytorch/issues/139460