### PR TITLE
[dynamo] Improve codegen for `DataPtrVariable` and fix tensor reference issue

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1739,6 +1739,13 @@ class OutputGraph:
         self.register_finalizer_fns.clear()
         self.dynamo_flat_name_to_original_fqn.clear()
         self.tracing_context.clear()
+        self.input_source_to_var.clear()
+        self.cleanup_hooks.clear()
+        self.cleanups.clear()
+        self.unspec_variable_map.clear()
+        self.random_calls.clear()
+        self.random_values_var = None
+        self.backward_state.clear()
 
     def set_torch_function_state(self, enabled: bool) -> None:
         self.torch_function_enabled = enabled

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1741,7 +1741,6 @@ class OutputGraph:
         self.tracing_context.clear()
         self.input_source_to_var.clear()
         self.unspec_variable_map.clear()
-        self.random_calls.clear()
         self.backward_state.clear()
 
     def set_torch_function_state(self, enabled: bool) -> None:

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1740,11 +1740,8 @@ class OutputGraph:
         self.dynamo_flat_name_to_original_fqn.clear()
         self.tracing_context.clear()
         self.input_source_to_var.clear()
-        self.cleanup_hooks.clear()
-        self.cleanups.clear()
         self.unspec_variable_map.clear()
         self.random_calls.clear()
-        self.random_values_var = None
         self.backward_state.clear()
 
     def set_torch_function_state(self, enabled: bool) -> None:

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1448,6 +1448,6 @@ class DataPtrVariable(VariableTracker):
         self.from_tensor = from_tensor
 
     def reconstruct(self, codegen):
-        codegen(self.from_tensor, allow_cache=False)
+        codegen(self.from_tensor)
         codegen.load_method("data_ptr")
         codegen.call_method(0)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #139538
* __->__ #139487

This addresses
https://github.com/pytorch/pytorch/pull/137677/files#r1799836499, which
had to set `allow_cache=False` for codegen on `DataPtrVariable.base`,
which is a `TensorVariable`, otherwise we observe failure of
`test_no_grad_copy` when testing with Dynamo.

I've seen `test_no_grad_copy` failing a few times, and every single time
it's related to cyclic reference, my best guess is the cyclic reference
holds some tensor object longer in memory than necessary, preventing the
optimization introduced in #11165.

This patch makes `OutputGraph.cleanup()` more aggressive by clearing out
all fields that might reference a `VariableTracker`. As a result, we can
remove the aforementioned `allow_cache=False`, which helps generate
better code (e.g., in the case of `test_no_grad_copy`, it skipped generating
a redundant graph whose only op is returning the input tensor; instead we just
generate a single `LOAD_FAST`).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames