### PR TITLE
Fix S390 builds

### DIFF
--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -8,7 +8,9 @@
 #include <c10/util/irange.h>
 
 #include <climits>
+#if !defined(__s390x__ ) && !defined(__powerpc__)
 #include <cpuinfo.h>
+#endif
 
 #if AT_BUILD_WITH_BLAS()
 #if C10_IOS


### PR DESCRIPTION
Caused by https://github.com/pytorch/pytorch/pull/137918 By guarding all cpuinfo use with `!defined(__s390x__ ) && !defined(__powerpc__)`
