### PR TITLE
Use 'val' metadata to print output dtype/shape info for EXIR Graphs.

### DIFF
--- a/torch/fx/passes/graph_drawer.py
+++ b/torch/fx/passes/graph_drawer.py
@@ -279,6 +279,14 @@ if HAS_PYDOT:
             tensor_meta = node.meta.get("tensor_meta")
             label += self._tensor_meta_to_label(tensor_meta)
 
+            node_val = node.meta.get("val", None)
+            if tensor_meta is None and node_val is not None:
+                if isinstance(node_val, torch.Tensor):
+                    label += f"|output={self._get_tensor_label(node_val)}" + r"\n"
+                if isinstance(node_val, (list, tuple)):
+                    for i, v in enumerate(node_val):
+                        label += f"|output[{i}]={self._get_tensor_label(v)}" + r"\n"
+
             # for original fx graph
             # print buf=buf0, n_origin=6
             buf_meta = node.meta.get("buf_meta", None)


### PR DESCRIPTION
Summary: FXGraphDrawer on EXIR graphs does no display output dtype/shape information. This diff adds dtype/shape info.

Test Plan:
After this diff, we see shape for EXIR graphs.
 {F1951517134}

Differential Revision: D65350860




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv