### PR TITLE
[BE][MPS] Make metal shaders compile cleanly

### DIFF
--- a/cmake/Metal.cmake
+++ b/cmake/Metal.cmake
@@ -2,8 +2,13 @@ if(NOT APPLE)
     return()
 endif()
 
+set(METAL_CFLAGS -Wall -Wextra -fno-fast-math)
+if(WERROR)
+    string(APPEND METAL_CFLAGS -Werror)
+endif()
+
 function(metal_to_air SRC TARGET FLAGS)
-    add_custom_command(COMMAND xcrun metal -c ${SRC} -o ${TARGET} ${FLAGS} -Wall -Wextra -fno-fast-math
+    add_custom_command(COMMAND xcrun metal -c ${SRC} -o ${TARGET} ${FLAGS} ${METAL_CFLAGS}
                        DEPENDS ${SRC}
                        OUTPUT ${TARGET}
                        COMMENT "Compiling ${SRC} to ${TARGET}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #139530
* __->__ #139522

I.e. without warnings, by deleting dead code and fixing one
signed-unsigned comparison warning

Also, pass `-Werror` to metal compiler if WERROR options is set