### PR TITLE
Make anomaly mode asynchronous

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -22,6 +22,8 @@
 #include <ATen/ops/isnan.h>
 #endif
 
+#include <ATen/ops/_assert_async.h>
+
 #include <c10/core/DeviceGuard.h>
 #include <c10/core/Event.h>
 #include <c10/core/Stream.h>
@@ -1059,11 +1061,16 @@ void Engine::evaluate_function(
     for (const auto i : c10::irange(num_outputs)) {
       auto& output = outputs[i];
       at::OptionalDeviceGuard guard(device_of(output));
-      if (output.defined() && isnan(output)._is_any_true().item<bool>()) {
+      if (output.defined()) {
         std::stringstream ss;
         ss << "Function '" << fn.name() << "' returned nan values in its " << i
            << "th output.";
-        throw std::runtime_error(ss.str());
+        at::_assert_async(~(isnan(output).any()), ss.str());
+        // std::stringstream ss;
+        // ss << "Function '" << fn.name() << "' returned nan values in its " <<
+        // i
+        //    << "th output.";
+        // throw std::runtime_error(ss.str());
       }
     }
   }

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1066,11 +1066,6 @@ void Engine::evaluate_function(
         ss << "Function '" << fn.name() << "' returned nan values in its " << i
            << "th output.";
         at::_assert_async(~(isnan(output).any()), ss.str());
-        // std::stringstream ss;
-        // ss << "Function '" << fn.name() << "' returned nan values in its " <<
-        // i
-        //    << "th output.";
-        // throw std::runtime_error(ss.str());
       }
     }
   }


### PR DESCRIPTION
The original anomaly mode nan detection would sync at .item which made debugging streams not viable (anomaly mode couldn't detect nans as the additional syncs canceled the nastiness that was occurring). Opening this PR as this code helped me debug my streams issue, whereas the original anomaly mode did not.

We should either make anomaly mode async -- why make it synchronous at all? OR offer an API where it could be async. @soulitzer you had mentioned something about the CUDA context getting corrupted, but why is that an issue if people are normally using anomaly mode to debug when something bad occurs?

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139524

