### PR TITLE
[SymmetricMemory] resolve a modernize-use-transparent-functors linter warning

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -135,6 +135,17 @@ class SymmetricMemoryTest(MultiProcessTestCase):
             self.assertEqual(len(row), torch.cuda.device_count())
 
     @skipIfRocm
+    def test_large_alloc(self) -> None:
+        t = _SymmetricMemory.empty_strided_p2p(
+            (2 * 1024**3,),
+            (1,),
+            dtype=torch.uint8,
+            device=self.device,
+            group_name="0",
+        )
+        self.assertEqual(t.numel() * t.element_size(), 2 * 1024**3)
+
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     def test_empty_strided_p2p(self) -> None:
         self._init_process()

--- a/torch/csrc/distributed/c10d/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/SymmetricMemory.cpp
@@ -71,12 +71,8 @@ static at::Tensor empty_strided_p2p_persistent(
         "is still active.");
   }
 
-  const size_t numel = std::accumulate(
-      size.begin(),
-      size.end(),
-      size_t(1),
-      // NOLINTNEXTLINE(modernize-use-transparent-functors)
-      std::multiplies<size_t>());
+  const size_t numel =
+      std::accumulate(size.begin(), size.end(), size_t(1), std::multiplies<>());
   const size_t element_size = c10::elementSize(dtype);
   const size_t alloc_size = numel * element_size;
 
@@ -159,12 +155,8 @@ at::Tensor empty_strided_p2p(
     return empty_strided_p2p_persistent(
         size, stride, dtype, device, group_name, *alloc_id);
   }
-  const size_t numel = std::accumulate(
-      size.begin(),
-      size.end(),
-      size_t(1),
-      // NOLINTNEXTLINE(modernize-use-transparent-functors)
-      std::multiplies<size_t>());
+  const size_t numel =
+      std::accumulate(size.begin(), size.end(), size_t(1), std::multiplies<>());
   const size_t element_size = c10::elementSize(dtype);
   const size_t alloc_size = numel * element_size;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #139677
* #139529
* __->__ #139528



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o