### PR TITLE
[profiler] Annotate triton kernels with kernel hash

### DIFF
--- a/test/inductor/test_profiler.py
+++ b/test/inductor/test_profiler.py
@@ -1,11 +1,14 @@
 # Owner(s): ["module: inductor"]
 import json
+import os
+import tempfile
 import unittest
 from typing import Callable, Optional
 
 import torch
 import torch._inductor.test_case
 import torch._inductor.utils
+from torch import _dynamo as torchdynamo
 from torch._inductor import config
 from torch.profiler import ProfilerActivity
 from torch.testing._internal.common_utils import TemporaryFileName
@@ -197,6 +200,80 @@ class DynamoProfilerTests(torch._inductor.test_case.TestCase):
 
         self.assertTrue(hooks_called["enter"])
         self.assertTrue(hooks_called["exit"])
+
+    @unittest.skipIf(not HAS_TRITON, "requires cuda & triton")
+    def test_pt2_triton_attributes(self):
+        from torch._inductor.codecache import code_hash
+
+        device = "cuda"
+
+        @torchdynamo.optimize("inductor")
+        def fn(a, b, c):
+            x = torch.nn.functional.linear(a, b)
+            x = x + c
+            return x.cos()
+
+        a, b, c = (torch.randn(4, 4, requires_grad=True).to(device) for _ in range(3))
+
+        inputs = [a, b, c]
+        with config.patch(compile_threads=1):
+            fn(*inputs)
+
+        fp = tempfile.NamedTemporaryFile("w+t", suffix=".json", delete=False)
+        fp.close()
+
+        with torch.profiler.profile(
+            activities=torch.profiler.supported_activities(),
+            record_shapes=True,
+            schedule=torch.profiler.schedule(
+                skip_first=3, wait=1, warmup=1, active=2, repeat=1
+            ),
+        ) as prof:
+            for idx in range(10):
+                fn(*inputs)
+                prof.step()
+
+        prof.export_chrome_trace(fp.name)
+        print("Trace written to {fp.name}")
+
+        triton_events = []
+        with open(fp.name) as f:
+            trace_json = json.load(f)
+            triton_events = [
+                event
+                for event in trace_json["traceEvents"]
+                if "kernel_backend" in event.get("args", {}).keys()
+            ]
+
+        print(triton_events)
+        self.assertEqual(len(triton_events), 2)
+
+        def get_hash(kernel_file: str) -> str:
+            with open(kernel_file) as f:
+                kernel_src = f.read()
+            return code_hash(kernel_src.strip())
+
+        def check_triton_event(e) -> None:
+            args = e.get("args", {})
+            self.assertNotEqual(args, {}, msg=f"event = {e}")
+
+            self.assertEqual(args["kernel_backend"], "triton", msg=f"event = {e}")
+
+            self.assertTrue("stream" in args, msg=f"event = {e}")
+            self.assertTrue("grid" in args, msg=f"event = {e}")
+            self.assertTrue(args["grid"].startswith("grid"), msg=f"event = {e}")
+
+            self.assertTrue("kernel_file" in args, msg=f"event = {e}")
+            kernel_file = args["kernel_file"]
+            self.assertTrue(os.path.isfile(kernel_file), msg=f"event = {e}")
+
+            self.assertTrue("kernel_hash" in args, msg=f"event = {e}")
+            self.assertEqual(
+                args["kernel_hash"], get_hash(kernel_file), msg=f"event = {e}"
+            )
+
+        for e in triton_events:
+            check_triton_event(e)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_profiler.py
+++ b/test/inductor/test_profiler.py
@@ -206,6 +206,7 @@ class DynamoProfilerTests(torch._inductor.test_case.TestCase):
         from torch._inductor.codecache import code_hash
 
         device = "cuda"
+        debug = False  # set to True to get output file
 
         @torchdynamo.optimize("inductor")
         def fn(a, b, c):
@@ -219,7 +220,7 @@ class DynamoProfilerTests(torch._inductor.test_case.TestCase):
         with config.patch(compile_threads=1):
             fn(*inputs)
 
-        fp = tempfile.NamedTemporaryFile("w+t", suffix=".json", delete=False)
+        fp = tempfile.NamedTemporaryFile("w+t", suffix=".json", delete=not debug)
         fp.close()
 
         with torch.profiler.profile(
@@ -234,7 +235,7 @@ class DynamoProfilerTests(torch._inductor.test_case.TestCase):
                 prof.step()
 
         prof.export_chrome_trace(fp.name)
-        print("Trace written to {fp.name}")
+        print("Trace written to {fp.name}, set debug=True to retain file.")
 
         triton_events = []
         with open(fp.name) as f:

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -1687,7 +1687,7 @@ assert KinetoStepTracker.current_step() == initial_step + 2 * niters
                 ]
                 for e in op_events:
                     if e["name"] == "add_test_kwinputs":
-                        print(e["args"])
+                        # print(e["args"])
                         args = e["args"]
                         self.assertTrue("stream" in args)
                         self.assertTrue("grid" in args)
@@ -1715,7 +1715,7 @@ assert KinetoStepTracker.current_step() == initial_step + 2 * niters
                 ]
                 for e in op_events:
                     if e["name"] == "add_test_kwinputs":
-                        print(e["args"])
+                        # print(e["args"])
                         args = e["args"]
                         self.assertTrue("stream" not in args)
                         self.assertTrue("grid" not in args)

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -244,6 +244,16 @@ class CachingAutotuner(KernelInterface):
         )
         self.filename = filename
 
+        # used for profiling
+        self.kernel_hash: str = ""
+
+        # Kernels are stored in the codecache with the filename as a hash of the code.
+        # We rely on this to obtain the kernel hash
+        if self.filename is not None:
+            base_name = os.path.basename(self.filename)
+            if ".py" in base_name:
+                self.kernel_hash = os.path.splitext(base_name)[0]
+
         self.precompile_time_taken_ns = 0
         self.autotune_time_taken_ns = 0
         # Dumps the launch configs after autotuning.
@@ -991,11 +1001,13 @@ class CachingAutotuner(KernelInterface):
                 grid_info = str(grid)
             else:
                 grid_info = getattr(grid, "grid_fn_str", "")
+
             with torch._C._profiler._RecordFunctionFast(
                 self.inductor_meta.get("kernel_name", "triton kernel"),
                 args,
                 {
-                    "kernel_file": "" if self.filename is None else self.filename,
+                    "kernel_file": (self.filename or ""),
+                    "kernel_hash": self.kernel_hash,
                     "kernel_backend": "triton",
                     "grid": grid_info,
                     "stream": stream,


### PR DESCRIPTION
As above, annotates triton kernel hash in the profile attributes.

Added a new unit test in profiler to triton/dynamo events.

Testplan:

Running new unit test in CI

Internal:
  buck2 run @mode/dev-nosan caffe2/test:profiler -- -r test_pt2_triton_attributes

Running on an example, this is how the kernel hash file looks
```
  {
    "ph": "X", "cat": "cpu_op", "name": "triton_poi_fused_add_cos_sin_0", "pid": 1670242, "tid": 1670242,
    "ts": 2413669097354.058, "dur": 95.812,
    "args": {
      "External id": 3,"kernel_hash": "cqaokwf2bph4egogzevc22vluasiyuui4i54zpemp6knbsggfbuu", 
"grid": "grid(100,)", "Record function id": 0, "stream": 0, "Concrete Inputs": ["", "", "", "100"], "kernel_file": "/tmp/torchinductor_bcoutinho/qa/cqaokwf2bph4egogzevc22vluasiyuui4i54zpemp6knbsggfbuu.py", "kernel_backend": "triton", "Input type": ["float", "float", "float", "Scalar"], "Input Strides": [[10, 1], [10, 1], [10, 1], []], "Input Dims": [[10, 10], [10, 10], [10, 10], []], "Ev Idx": 2

```

cc @robieta @chaekit @guotuofeng @guyang3532 @dzhulgakov @davidberard98 @sraikund16 @sanrise @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov