### PR TITLE
[ONNX] Update TorchTensor implementation to handle fake mode

### DIFF
--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -317,6 +317,13 @@ class TestFakeTensorExport(common_utils.TestCase):
             # The tensors need to be replaced with real tensors
             _ = onnx_program.model_proto
 
+        # If we replace with concrete tensors, the serialization will succeed
+        onnx_program.apply_weights({"weight": torch.tensor(42.0)})
+        onnx_model = ir.serde.deserialize_model(onnx_program.model_proto)
+        np.testing.assert_allclose(
+            onnx_model.graph.initializers["weight"].const_value.numpy(), 42.0
+        )
+
     def test_onnx_program_save_raises_when_model_initialized_in_fake_mode(self):
         class Model(torch.nn.Module):
             def __init__(self):
@@ -334,6 +341,13 @@ class TestFakeTensorExport(common_utils.TestCase):
         with self.assertRaises(Exception):
             # The tensors need to be replaced with real tensors
             _ = onnx_program.model_proto
+
+        # If we replace with concrete tensors, the serialization will succeed
+        onnx_program.apply_weights({"weight": torch.tensor(42.0)})
+        onnx_model = ir.serde.deserialize_model(onnx_program.model_proto)
+        np.testing.assert_allclose(
+            onnx_model.graph.initializers["weight"].const_value.numpy(), 42.0
+        )
 
     def test_onnx_program_save_succeeds_when_export_and_save_in_fake_mode(self):
         class Model(torch.nn.Module):

--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import os
 
-from onnxscript import BOOL, FLOAT, opset18 as op
+import numpy as np
+from onnxscript import BOOL, FLOAT, ir, opset18 as op
 
 import torch
 import torch.onnx._flags
@@ -292,6 +293,71 @@ class TestCustomTranslationTable(common_utils.TestCase):
         all_nodes = [n.op_type for n in onnx_program.model.graph]
         self.assertIn("Sub", all_nodes)
         self.assertNotIn("Add", all_nodes)
+
+
+class TestFakeTensorExport(common_utils.TestCase):
+    """Test exporting in fake mode."""
+
+    def test_onnx_program_fails_when_model_defined_in_fake_mode(self):
+        with torch.onnx.enable_fake_mode():
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.weight = torch.nn.Parameter(torch.tensor(42.0))
+
+                def forward(self, x):
+                    return self.weight + x
+
+            onnx_program = torch.onnx.export(Model(), (torch.tensor(1.0),), dynamo=True)
+
+        assert onnx_program is not None
+        # Convert to model proto and back to trigger to_bytes method which serializes the tensor
+        with self.assertRaises(Exception):
+            # The tensors need to be replaced with real tensors
+            _ = onnx_program.model_proto
+
+    def test_onnx_program_save_fails_when_model_initialized_in_fake_mode(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.tensor(42.0))
+
+            def forward(self, x):
+                return self.weight + x
+
+        with torch.onnx.enable_fake_mode():
+            onnx_program = torch.onnx.export(Model(), (torch.tensor(1.0),), dynamo=True)
+
+        assert onnx_program is not None
+        # Convert to model proto and back to trigger to_bytes method which serializes the tensor
+        with self.assertRaises(Exception):
+            # The tensors need to be replaced with real tensors
+            _ = onnx_program.model_proto
+
+    def test_onnx_program_save_succeeds_when_export_and_save_in_fake_mode(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.tensor(42.0))
+
+            def forward(self, x):
+                return self.weight + x
+
+        real_model = Model()
+
+        with torch.onnx.enable_fake_mode():
+            onnx_program = torch.onnx.export(
+                real_model, (torch.tensor(1.0),), dynamo=True
+            )
+
+            assert onnx_program is not None
+            # Convert to model proto and back to trigger to_bytes method which serializes the tensor
+            onnx_model = ir.serde.deserialize_model(onnx_program.model_proto)
+
+        np.testing.assert_allclose(
+            onnx_model.graph.initializers["weight"].const_value.numpy(), 42.0
+        )
 
 
 if __name__ == "__main__":

--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -354,7 +354,9 @@ class TestFakeTensorExport(common_utils.TestCase):
             assert onnx_program is not None
             # Convert to model proto and back to trigger to_bytes method which serializes the tensor
             # Note that even though we are calling .model_proto (equivalently .save()) in fake mode,
-            # the concrete tensors are maintained
+            # the concrete tensors are maintained.
+            # This is due to the usage of torch._subclasses.fake_tensor.unset_fake_temporarily() in
+            # TorchTensor.tobytes()
             onnx_model = ir.serde.deserialize_model(onnx_program.model_proto)
 
         np.testing.assert_allclose(

--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -353,6 +353,8 @@ class TestFakeTensorExport(common_utils.TestCase):
 
             assert onnx_program is not None
             # Convert to model proto and back to trigger to_bytes method which serializes the tensor
+            # Note that even though we are calling .model_proto (equivalently .save()) in fake mode,
+            # the concrete tensors are maintained
             onnx_model = ir.serde.deserialize_model(onnx_program.model_proto)
 
         np.testing.assert_allclose(

--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -298,7 +298,7 @@ class TestCustomTranslationTable(common_utils.TestCase):
 class TestFakeTensorExport(common_utils.TestCase):
     """Test exporting in fake mode."""
 
-    def test_onnx_program_fails_when_model_defined_in_fake_mode(self):
+    def test_onnx_program_raises_when_model_defined_in_fake_mode(self):
         with torch.onnx.enable_fake_mode():
 
             class Model(torch.nn.Module):
@@ -317,7 +317,7 @@ class TestFakeTensorExport(common_utils.TestCase):
             # The tensors need to be replaced with real tensors
             _ = onnx_program.model_proto
 
-    def test_onnx_program_save_fails_when_model_initialized_in_fake_mode(self):
+    def test_onnx_program_save_raises_when_model_initialized_in_fake_mode(self):
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()

--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -391,5 +391,6 @@ class TestFakeTensorExport(common_utils.TestCase):
             onnx_model.graph.initializers["weight"].const_value.numpy(), 42.0
         )
 
+
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/torch/onnx/_internal/_exporter_legacy.py
+++ b/torch/onnx/_internal/_exporter_legacy.py
@@ -381,13 +381,10 @@ def enable_fake_mode():
     is a :class:`torch.Tensor` with the ability to run PyTorch code without having to
     actually do computation through tensors allocated on a ``meta`` device. Because
     there is no actual data being allocated on the device, this API allows for
-    exporting large models without the actual memory footprint needed for executing it.
+    initializing and exporting large models without the actual memory footprint needed for executing it.
 
-    It is highly recommended to enable fake mode when exporting models that
+    It is highly recommended to initialize the model in fake mode when exporting models that
     are too large to fit into memory.
-
-    Returns:
-        A :class:`ONNXFakeContext` object.
 
     Example::
 

--- a/torch/onnx/_internal/_exporter_legacy.py
+++ b/torch/onnx/_internal/_exporter_legacy.py
@@ -393,8 +393,7 @@ def enable_fake_mode():
 
         # xdoctest: +REQUIRES(env:TORCH_DOCTEST_ONNX)
         >>> import torch
-        >>> import torch.onnx
-        >>> class MyModel(torch.nn.Module):  # Dummy model
+        >>> class MyModel(torch.nn.Module):  # Model with a parameter
         ...     def __init__(self) -> None:
         ...         super().__init__()
         ...         self.weight = torch.nn.Parameter(torch.tensor(42.0))

--- a/torch/onnx/_internal/_exporter_legacy.py
+++ b/torch/onnx/_internal/_exporter_legacy.py
@@ -400,10 +400,12 @@ def enable_fake_mode():
         ...     def forward(self, x):
         ...         return self.weight + x
         >>> with torch.onnx.enable_fake_mode():
+        ...     # When initialized in fake mode, the model's parameters are fake tensors
+        ...     # They do not take up memory so we can initialize large models
         ...     my_nn_module = MyModel()
         ...     arg1 = torch.randn(2, 2, 2)
         >>> onnx_program = torch.onnx.export(my_nn_module, (arg1,), dynamo=True)
-        >>> # Saving model WITHOUT initializers
+        >>> # Saving model WITHOUT initializers (only the architecture)
         >>> onnx_program.save(
         ...     "my_model_without_initializers.onnx",
         ...     include_initializers=False,

--- a/torch/onnx/_internal/_exporter_legacy.py
+++ b/torch/onnx/_internal/_exporter_legacy.py
@@ -397,13 +397,12 @@ def enable_fake_mode():
         >>> class MyModel(torch.nn.Module):  # Dummy model
         ...     def __init__(self) -> None:
         ...         super().__init__()
-        ...         self.linear = torch.nn.Linear(2, 2)
+        ...         self.weight = torch.nn.Parameter(torch.tensor(42.0))
         ...     def forward(self, x):
-        ...         out = self.linear(x)
-        ...         return out
+        ...         return self.weight + x
         >>> with torch.onnx.enable_fake_mode():
         ...     my_nn_module = MyModel()
-        ...     arg1 = torch.randn(2, 2, 2)  # positional input 1
+        ...     arg1 = torch.randn(2, 2, 2)
         >>> onnx_program = torch.onnx.export(my_nn_module, (arg1,), dynamo=True)
         >>> # Saving model WITHOUT initializers
         >>> onnx_program.save(
@@ -411,8 +410,8 @@ def enable_fake_mode():
         ...     include_initializers=False,
         ...     keep_initializers_as_inputs=True,
         ... )
-        >>> # Saving model WITH initializers
-        >>> onnx_program.apply_weights(MyModel().state_dict())
+        >>> # Saving model WITH initializers after applying concrete weights
+        >>> onnx_program.apply_weights({"weight": torch.tensor(42.0)})
         >>> onnx_program.save("my_model_with_initializers.onnx")
 
     .. warning::

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -126,13 +126,17 @@ class TorchTensor(ir.Tensor):
         # it avoids copying to a NumPy array
         import torch._subclasses.fake_tensor
 
-        if isinstance(self.raw, torch._subclasses.fake_tensor.FakeTensor):
+        with torch._subclasses.fake_tensor.unset_fake_temporarily():
+            # Disable any fake mode so calling detach() etc. will return a real tensor
+            tensor = self.raw.detach().cpu().contiguous()
+
+        if isinstance(tensor, torch._subclasses.fake_tensor.FakeTensor):
             raise TypeError(
                 f"Cannot take content out from the FakeTensor ('{self.name}'). Please replace the tensor "
                 "with a tensor backed by real data using ONNXProgram.apply_weights() "
                 "or save the model without initializers by setting include_initializers=False."
             )
-        tensor = self.raw.detach().cpu().contiguous()
+
         return bytes(
             (ctypes.c_ubyte * tensor.element_size() * tensor.numel()).from_address(
                 tensor.data_ptr()


### PR DESCRIPTION
Update TorchTensor implementation to handle fake mode better. Specifically, we disable fake mode before calling detach() etc. when getting the weights if it is already a real tensor so we do not lose it.
