### PR TITLE
[CI] Skip test_cuda_tracker_equivalence for ROCm

### DIFF
--- a/test/distributed/_tools/test_mem_tracker.py
+++ b/test/distributed/_tools/test_mem_tracker.py
@@ -7,7 +7,12 @@ import torch
 import torch.nn as nn
 from torch.distributed._tools.mem_tracker import MemTracker
 from torch.testing._internal.common_cuda import TEST_CUDA
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import (
+    run_tests,
+    skipIfRocm,
+    skipIfTorchDynamo,
+    TestCase,
+)
 from torch.utils.checkpoint import checkpoint
 
 
@@ -26,6 +31,7 @@ class TestMemTracker(TestCase):
 
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    @skipIfRocm()
     def test_cuda_tracker_equivalence(
         self,
     ):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139543

Test fails on ROCm, skipping it for this platform.
Resolves https://github.com/pytorch/pytorch/issues/139515

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd