### PR TITLE
Add --skip-internal-checks to allow manual force merge of already landed PRs

### DIFF
--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -470,6 +470,7 @@ class TestTryMerge(TestCase):
             skip_mandatory_checks=True,
             comment_id=mock.ANY,
             ignore_current=False,
+            skip_internal_checks=False,
         )
 
     @mock.patch("trymerge.gh_get_pr_info", return_value=mock_gh_get_info())
@@ -485,6 +486,7 @@ class TestTryMerge(TestCase):
             skip_mandatory_checks=False,
             comment_id=mock.ANY,
             ignore_current=False,
+            skip_internal_checks=False,
         )
 
     @mock.patch("trymerge.read_merge_rules", side_effect=mocked_read_merge_rules)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139570

Internal checks on https://github.com/pytorch/pytorch/pull/139001 are broken because I landed the internal diff before the PR, and for some reason the system didn't force merge the PR (bug, I guess?) I can't manually force merge because of the non-overrideable internal checks. Add an escape hatch to force merge in this case.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>