### PR TITLE
only use hint_size in _smart_symbol_sort for size type symbols

### DIFF
--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5836,9 +5836,11 @@ class ShapeEnv:
             hint_size = self.size_hint(x, allow_none=True)
             if hint_size is None:
                 size = sys.maxsize
-            else:
+            elif symbol_is_type(x, SymT.SIZE):
                 assert isinstance(hint_size, sympy.Expr)
                 size = int(hint_size)
+            else:
+                size = sys.maxsize
             name = x.name
             # 1 puts ephemeral sourced symbols first when sorting in reverse
             return (1 if has_only_ephemeral_sources else 0, size, name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #138922
* #138918
* #138666
* #138915
* #139583
* #139572
* #139569
* #139568
* #139454
* #139457
* __->__ #139571
* #139486
* #139484
* #139482
* #139451

Fixes `PYTORCH_TEST_WITH_DYNAMO=1 python test/test_torch.py TestTorchDeviceTypeCPU.test_exponential_kstest_cpu_bfloat16` when specialize_float = False

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv