### PR TITLE
[AOTI][reland] Switch OSS dashboard to use aoti_compile_and_package

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2051,8 +2051,12 @@ class AotCodeCompiler:
                 else:
                     run_command_and_check(link_cmd)
 
-                for o_file in [output_o, consts_o]:
-                    # remove .o files to save disk space since we already have the .so file
+                for o_file in [
+                    output_o,
+                    consts_o,
+                    os.path.splitext(consts_o)[0] + ".S",
+                ]:
+                    # No need to package .o or .S into the output artifact
                     os.remove(o_file)
 
                 if use_mmap_weights:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139597

Summary: Reland https://github.com/pytorch/pytorch/pull/139154

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang @aakhundov