### PR TITLE
Add missing cast to int type for `aten::pow.int_to_int(int a, int b) -> int` primitive.

### DIFF
--- a/test/jit/test_aten_pow.py
+++ b/test/jit/test_aten_pow.py
@@ -27,6 +27,9 @@ class TestAtenPow(TestCase):
         # zero base and negative exponent case that should trigger RunTimeError
         self.assertRaises(RuntimeError, fn_int_int, 0, -2)
 
+        # the result type is expected to be int
+        self.assertEqual(type(fn_int_int(2, 2)), int)
+
         """
         2. Testing a = int, b = float
         """

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -1020,7 +1020,7 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs{
         [](Stack& stack) {
           int64_t a = 0, b = 0;
           pop(stack, a, b);
-          push(stack, powWrapper(a, b));
+          push(stack, static_cast<int64_t>(powWrapper(a, b)));
         },
         aliasAnalysisFromSchema()),
     // min and max are in prim:: because there is a difference between


### PR DESCRIPTION
`pow(a, b)` will return a double even if `a` and `b` are `int64_t`.


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel