### PR TITLE
Remove shebang line from easy_install generated python scripts on Windows only (#108602)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -257,7 +257,7 @@ import time
 from collections import defaultdict
 
 import setuptools.command.build_ext
-import setuptools.command.install
+from setuptools.command.install import install
 import setuptools.command.sdist
 from setuptools import Extension, find_packages, setup
 from setuptools.dist import Distribution
@@ -267,6 +267,20 @@ from tools.setup_helpers.cmake import CMake
 from tools.setup_helpers.env import build_type, IS_DARWIN, IS_LINUX, IS_WINDOWS
 from tools.setup_helpers.generate_linker_script import gen_linker_script
 
+class SetupToolsInstallOverride(install):
+    def run(self):
+        super().run()
+        if sys.platform == "win32":
+            self.remove_shebang_from_easy_install_generated_scripts()
+
+    def remove_shebang_from_easy_install_generated_scripts(self):
+        for script in self.get_outputs():
+            if script.endswith('-script.py'):
+                with open(script, 'rb') as f:
+                    lines = f.readlines()
+                if len(lines) > 0 and lines[0].startswith(b'#!'):
+                    with open(script, 'wb') as f:
+                        f.writelines(lines[1:])
 
 def _get_package_path(package_name):
     spec = importlib.util.find_spec(package_name)
@@ -1069,8 +1083,8 @@ def configure_extension_build():
         "bdist_wheel": wheel_concatenate,
         "build_ext": build_ext,
         "clean": clean,
-        "install": install,
-        "sdist": sdist,
+        "install": SetupToolsInstallOverride,
+        "sdist": sdist
     }
 
     entry_points = {


### PR DESCRIPTION
Fixes 
- #108602

On windows only, for install step: remove shebang line from python scripts generated by `easy_install`.

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex