### PR TITLE
[ROCm] re-enable flex attention UTs

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -43,8 +43,8 @@ from torch.testing._internal.common_device_type import (
     skipCPUIf,
     skipCUDAIf,
     skipCUDAIfRocm,
+    skipIfRocm,
     skipMeta,
-    skipIfRocm
 )
 from torch.testing._internal.common_dtype import floating_types_and_half
 from torch.testing._internal.common_utils import (

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -43,7 +43,6 @@ from torch.testing._internal.common_device_type import (
     skipCPUIf,
     skipCUDAIf,
     skipCUDAIfRocm,
-    skipIfRocm,
     skipMeta,
 )
 from torch.testing._internal.common_dtype import floating_types_and_half
@@ -58,6 +57,7 @@ from torch.testing._internal.common_utils import (
     NestedTensorTestCase,
     parametrize,
     run_tests,
+    skipIfRocm,
     skipIfSlowGradcheckEnv,
     skipIfTorchDynamo,
     subtest,

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -44,6 +44,7 @@ from torch.testing._internal.common_device_type import (
     skipCUDAIf,
     skipCUDAIfRocm,
     skipMeta,
+    skipIfRocm
 )
 from torch.testing._internal.common_dtype import floating_types_and_half
 from torch.testing._internal.common_utils import (
@@ -7025,6 +7026,7 @@ torch.cuda.synchronize()
     # non-contiguous with holes not supported yet
     @decorateIf(unittest.skip, lambda params: params["noncontig_with_holes"])
     @parametrize("noncontig_with_holes", [False, True])
+    @skipIfRocm
     def test_flex_attention(self, device, dtype, noncontig_with_holes):
         query, key, value = self._rand_qkv(device, dtype, noncontig_with_holes)
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1954,7 +1954,6 @@ def get_all_device_types() -> List[str]:
 
 flex_attention_supported_platform = unittest.skipUnless(
     torch.cuda.is_available()
-    and torch.version.hip is None
     and torch.utils._triton.has_triton()
     and torch.cuda.get_device_capability() >= (8, 0),
     "Requires CUDA and Triton",


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/136792 accidentally disabled flex attention UTs on ROCm. Re-enabling.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang @naromero77amd