### PR TITLE
Switch c10::string_view to std::string_view

### DIFF
--- a/aten/src/ATen/core/dynamic_type.cpp
+++ b/aten/src/ATen/core/dynamic_type.cpp
@@ -69,16 +69,6 @@ DynamicType::Arguments::Arguments(
   }
 }
 
-DynamicType::Arguments::Arguments(
-    const std::vector<c10::string_view>& names,
-    c10::ArrayRef<TypePtr> args)
-    : Arguments(args) {
-  TORCH_INTERNAL_ASSERT(names.size() == args.size());
-  for (size_t i = 0; i < args.size(); i++) {
-    elems[i].label = std::string{names[i]};
-  }
-}
-
 DynamicType::~DynamicType() {
   if (tag_ == Tag::Class) {
     class_.~ClassTypePtr();

--- a/aten/src/ATen/core/dynamic_type.h
+++ b/aten/src/ATen/core/dynamic_type.h
@@ -138,7 +138,6 @@ class DynamicType : public SharedType {
   struct Arguments {
     Arguments() = default;
     Arguments(c10::ArrayRef<TypePtr>);
-    Arguments(const std::vector<c10::string_view>&, c10::ArrayRef<TypePtr>);
     Arguments(const std::vector<std::string_view>&, c10::ArrayRef<TypePtr>);
     std::vector<LabeledDynamicType> elems;
   };

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -45,11 +45,6 @@ TORCH_API c10::intrusive_ptr<ConstantString> ConstantString::create(
 }
 
 TORCH_API c10::intrusive_ptr<ConstantString> ConstantString::create(
-    c10::string_view str_) {
-  return c10::make_intrusive<ConstantString>(std::string(str_));
-}
-
-TORCH_API c10::intrusive_ptr<ConstantString> ConstantString::create(
     std::string_view str_) {
   return c10::make_intrusive<ConstantString>(std::string(str_));
 }

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -690,7 +690,6 @@ struct TORCH_API IValue final {
   IValue(c10::intrusive_ptr<ivalue::ConstantString> v);
   IValue(std::string v);
   IValue(const char* v) : IValue(std::string(v)) {}
-  IValue(c10::string_view v) : IValue(std::string(v)){}
   IValue(std::string_view v) : IValue(std::string(v)){}
   bool isString() const {
     return Tag::String == tag;

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -301,10 +301,8 @@ struct TORCH_API ConstantString final : c10::intrusive_ptr_target {
 
  public:
   ConstantString(std::string str) : str_(std::move(str)) {}
-  ConstantString(c10::string_view str) : str_(std::string(str)) {}
   ConstantString(std::string_view str) : str_(std::string(str)) {}
   static c10::intrusive_ptr<ConstantString> create(std::string str_);
-  static c10::intrusive_ptr<ConstantString> create(c10::string_view str_);
   static c10::intrusive_ptr<ConstantString> create(std::string_view str_);
   static c10::intrusive_ptr<ConstantString> create(const char* str_);
 

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1955,12 +1955,6 @@ struct getTypePtr_<std::string> final {
   }
 };
 template <>
-struct getTypePtr_<c10::string_view> final {
-  static decltype(auto) call() {
-    return StringType::get();
-  }
-};
-template <>
 struct getTypePtr_<std::string_view> final {
   static decltype(auto) call() {
     return StringType::get();

--- a/aten/src/ATen/core/operator_name.h
+++ b/aten/src/ATen/core/operator_name.h
@@ -3,6 +3,8 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 #include <c10/util/string_view.h>
+
+#include <cstring>
 #include <optional>
 #include <ostream>
 #include <string>

--- a/aten/src/ATen/core/register_symbols.cpp
+++ b/aten/src/ATen/core/register_symbols.cpp
@@ -4,6 +4,8 @@
 #include <ATen/core/interned_strings.h>
 #include <ATen/core/interned_strings_class.h>
 
+#include <cstring>
+
 namespace c10 {
 
 namespace {

--- a/c10/core/Allocator.cpp
+++ b/c10/core/Allocator.cpp
@@ -3,6 +3,8 @@
 
 #include <c10/util/ThreadLocalDebugInfo.h>
 
+#include <cstring>
+
 namespace c10 {
 
 DataPtr Allocator::clone(const void* data, std::size_t n) {

--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -1,5 +1,7 @@
 #include <c10/core/DeviceType.h>
 #include <c10/util/Exception.h>
+
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <mutex>

--- a/c10/test/util/string_view_test.cpp
+++ b/c10/test/util/string_view_test.cpp
@@ -3,7 +3,7 @@
 #include <gmock/gmock.h>
 
 // NOLINTBEGIN(modernize*, readability*, bugprone-string-constructor)
-using c10::string_view;
+using string_view = c10::c10_string_view;
 
 namespace {
 namespace testutils {

--- a/c10/util/ConstexprCrc.h
+++ b/c10/util/ConstexprCrc.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/macros/Macros.h>
 #include <c10/util/IdWrapper.h>
 #include <c10/util/string_view.h>
 #include <cstddef>

--- a/c10/util/NetworkFlow.cpp
+++ b/c10/util/NetworkFlow.cpp
@@ -2,8 +2,7 @@
 
 #include <c10/util/Exception.h>
 
-#include <iostream>
-#include <optional>
+#include <functional>
 #include <queue>
 #include <unordered_map>
 #include <vector>

--- a/c10/util/StringUtil.cpp
+++ b/c10/util/StringUtil.cpp
@@ -83,7 +83,7 @@ std::ostream& operator<<(std::ostream& out, const SourceLocation& loc) {
   return out;
 }
 
-size_t ReplaceAll(std::string& s, c10::string_view from, c10::string_view to) {
+size_t ReplaceAll(std::string& s, std::string_view from, std::string_view to) {
   if (from.empty()) {
     return 0;
   }

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -139,7 +139,7 @@ inline std::string Join(const std::string& delimiter, const Container& v) {
 // Replace all occurrences of "from" substring to "to" string.
 // Returns number of replacements
 size_t C10_API
-ReplaceAll(std::string& s, c10::string_view from, c10::string_view to);
+ReplaceAll(std::string& s, std::string_view from, std::string_view to);
 
 /// Represents a location in source code (for debugging).
 struct C10_API SourceLocation {
@@ -155,7 +155,7 @@ inline bool isPrint(char s) {
   return s > 0x1f && s < 0x7f;
 }
 
-inline void printQuotedString(std::ostream& stmt, const string_view str) {
+inline void printQuotedString(std::ostream& stmt, const std::string_view str) {
   stmt << "\"";
   for (auto s : str) {
     switch (s) {

--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -32,13 +32,13 @@ struct type_index final : IdWrapper<type_index, uint64_t> {
 
 namespace detail {
 
-inline constexpr string_view extract(
-    string_view prefix,
-    string_view suffix,
-    string_view str) {
+inline constexpr c10::c10_string_view extract(
+    c10::c10_string_view prefix,
+    c10::c10_string_view suffix,
+    c10::c10_string_view str) {
 #if !defined(__CUDA_ARCH__) // CUDA doesn't like std::logic_error in device code
   return (!str.starts_with(prefix) || !str.ends_with(suffix))
-      ? (throw std::logic_error("Invalid pattern"), string_view())
+      ? (throw std::logic_error("Invalid pattern"), c10::c10_string_view())
       : str.substr(prefix.size(), str.size() - prefix.size() - suffix.size());
 #else
   return str.substr(prefix.size(), str.size() - prefix.size() - suffix.size());
@@ -46,7 +46,7 @@ inline constexpr string_view extract(
 }
 
 template <typename T>
-inline constexpr c10::string_view fully_qualified_type_name_impl() {
+inline constexpr c10::c10_string_view fully_qualified_type_name_impl() {
 #if defined(_MSC_VER) && !defined(__clang__)
 #if defined(__NVCC__)
   return extract(
@@ -61,13 +61,13 @@ inline constexpr c10::string_view fully_qualified_type_name_impl() {
 #endif
 #elif defined(__clang__)
   return extract(
-      "c10::string_view c10::util::detail::fully_qualified_type_name_impl() [T = ",
+      "c10::c10_string_view c10::util::detail::fully_qualified_type_name_impl() [T = ",
       "]",
       __PRETTY_FUNCTION__);
 #elif defined(__GNUC__)
   return extract(
-      "constexpr c10::string_view c10::util::detail::fully_qualified_type_name_impl() [with T = ",
-      "; c10::string_view = c10::basic_string_view<char>]",
+      "constexpr c10::c10_string_view c10::util::detail::fully_qualified_type_name_impl() [with T = ",
+      "; c10::c10_string_view = c10::basic_string_view<char>]",
       __PRETTY_FUNCTION__);
 #endif
 }
@@ -122,8 +122,9 @@ inline constexpr type_index get_type_index<std::string>() {
 #endif
 
 template <typename T>
-inline constexpr string_view get_fully_qualified_type_name() noexcept {
-  constexpr string_view name = detail::fully_qualified_type_name_impl<T>();
+inline constexpr c10::c10_string_view get_fully_qualified_type_name() noexcept {
+  constexpr c10::c10_string_view name =
+      detail::fully_qualified_type_name_impl<T>();
   return name;
 }
 } // namespace c10::util

--- a/c10/util/string_view.h
+++ b/c10/util/string_view.h
@@ -596,22 +596,38 @@ constexpr inline void swap(
     basic_string_view<CharT>& rhs) noexcept {
   lhs.swap(rhs);
 }
-using string_view = basic_string_view<char>;
+using string_view = std::string_view;
+using c10_string_view = basic_string_view<char>;
 
-// NOTE: In C++20, this function should be replaced by str.starts_with
-constexpr bool string_view_starts_with(
-    std::string_view str,
-    std::string_view prefix) noexcept {
-  return str.size() >= prefix.size() && str.substr(0, prefix.size()) == prefix;
+// NOTE: In C++20, this function should be replaced by string_view.starts_with
+constexpr bool starts_with(
+    const std::string_view s,
+    const std::string_view prefix) noexcept {
+  return (prefix.size() > s.size()) ? false
+                                    : prefix == s.substr(0, prefix.size());
 }
 
-// NOTE: In C++20, this function should be replaced by str.ends_with
-constexpr bool string_view_ends_with(
-    std::string_view str,
-    std::string_view suffix) noexcept {
-  return str.size() >= suffix.size() &&
-      str.substr(str.size() - suffix.size()) == suffix;
+// NOTE: In C++20, this function should be replaced by string_view.starts_with
+constexpr bool starts_with(
+    const std::string_view s,
+    const char prefix) noexcept {
+  return !s.empty() && prefix == s.front();
 }
+
+// NOTE: In C++20, this function should be replaced by string_view.ends_with
+constexpr bool ends_with(
+    const std::string_view s,
+    const std::string_view suffix) noexcept {
+  return (suffix.size() > s.size())
+      ? false
+      : suffix == s.substr(s.size() - suffix.size(), suffix.size());
+}
+
+// NOTE: In C++20, this function should be replaced by string_view.ends_with
+constexpr bool ends_with(const std::string_view s, const char prefix) noexcept {
+  return !s.empty() && prefix == s.back();
+}
+
 } // namespace c10
 
 namespace std {

--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -13,7 +13,6 @@
 #include <c10/core/Allocator.h>
 #include <c10/core/Backend.h>
 #include <c10/core/CPUAllocator.h>
-#include <c10/core/Backend.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Logging.h>
 #include <c10/util/hash.h>
@@ -283,7 +282,7 @@ size_t getPadding(
 bool PyTorchStreamReader::hasRecord(const std::string& name) {
   std::lock_guard<std::mutex> guard(reader_lock_);
 
-  if ((!load_debug_symbol_) && c10::string_view_ends_with(std::string_view(name), kDebugPklSuffix)) {
+  if ((!load_debug_symbol_) && c10::ends_with(std::string_view(name), kDebugPklSuffix)) {
     return false;
   }
   std::string ss = archive_name_plus_slash_ + name;
@@ -320,7 +319,7 @@ std::vector<std::string> PyTorchStreamReader::getAllRecords() {
           buf);
     }
     if ((load_debug_symbol_) ||
-        (!c10::string_view_ends_with(std::string_view(buf + archive_name_plus_slash_.size()),kDebugPklSuffix))) {
+        (!c10::ends_with(std::string_view(buf + archive_name_plus_slash_.size()),kDebugPklSuffix))) {
       // NOLINTNEXTLINE(modernize-use-emplace)
       out.push_back(buf + archive_name_plus_slash_.size());
     }
@@ -343,7 +342,7 @@ size_t PyTorchStreamReader::getRecordID(const std::string& name) {
 // return dataptr, size
 std::tuple<at::DataPtr, size_t> PyTorchStreamReader::getRecord(const std::string& name) {
   std::lock_guard<std::mutex> guard(reader_lock_);
-  if ((!load_debug_symbol_) && c10::string_view_ends_with(name, kDebugPklSuffix)) {
+  if ((!load_debug_symbol_) && c10::ends_with(name, kDebugPklSuffix)) {
     at::DataPtr retval;
     return std::make_tuple(std::move(retval), 0);
   }
@@ -424,7 +423,7 @@ PyTorchStreamReader::getRecord(const std::string& name,
     return getRecord(name);
   }
 
-  if ((!load_debug_symbol_) && c10::string_view_ends_with(name, kDebugPklSuffix)) {
+  if ((!load_debug_symbol_) && c10::ends_with(name, kDebugPklSuffix)) {
     at::DataPtr retval;
     return std::make_tuple(std::move(retval), 0);
   }
@@ -448,7 +447,7 @@ PyTorchStreamReader::getRecord(const std::string& name,
 size_t
 PyTorchStreamReader::getRecord(const std::string& name, void* dst, size_t n) {
   std::lock_guard<std::mutex> guard(reader_lock_);
-  if ((!load_debug_symbol_) && c10::string_view_ends_with(name, kDebugPklSuffix)) {
+  if ((!load_debug_symbol_) && c10::ends_with(name, kDebugPklSuffix)) {
     return 0;
   }
   size_t key = getRecordID(name);
@@ -477,7 +476,7 @@ PyTorchStreamReader::getRecord(const std::string& name, void* dst, size_t n,
     return getRecord(name, dst, n);
   }
 
-  if ((!load_debug_symbol_) && c10::string_view(name).ends_with(kDebugPklSuffix)) {
+  if ((!load_debug_symbol_) && c10::ends_with(std::string_view(name), kDebugPklSuffix)) {
     return 0;
   }
   size_t key = getRecordID(name);
@@ -508,7 +507,7 @@ size_t PyTorchStreamReader::getRecord(
     void* buf,
     const std::function<void(void*, const void*, size_t)>& memcpy_func) {
   std::lock_guard<std::mutex> guard(reader_lock_);
-  if ((!load_debug_symbol_) && c10::string_view_ends_with(name, kDebugPklSuffix)) {
+  if ((!load_debug_symbol_) && c10::ends_with(name, kDebugPklSuffix)) {
     return 0;
   }
   if (chunk_size <= 0) {

--- a/torch/csrc/jit/mobile/debug_info.cpp
+++ b/torch/csrc/jit/mobile/debug_info.cpp
@@ -117,7 +117,7 @@ MobileDebugTable::MobileDebugTable(
   const std::vector<std::string>& record_names = reader->getAllRecords();
   constexpr std::string_view suffix(".debug_pkl");
   for (const auto& record_name : record_names) {
-    if (c10::string_view_ends_with(std::string_view(record_name), suffix)) {
+    if (c10::ends_with(std::string_view(record_name), suffix)) {
       auto [debug_data, debug_size] = reader->getRecord(record_name);
       auto ivalueTuple = jit::unpickle(
           reinterpret_cast<const char*>(debug_data.get()),

--- a/torch/csrc/jit/mobile/flatbuffer_loader.cpp
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.cpp
@@ -70,9 +70,10 @@ static_assert(
 
 namespace {
 
-static constexpr auto kCustomClassPrefix = "__torch__.torch.classes";
-static constexpr auto kTorchPrefix = "__torch__";
-static constexpr auto kJitPrefix = "torch.jit";
+static constexpr std::string_view kCustomClassPrefix =
+    "__torch__.torch.classes";
+static constexpr std::string_view kTorchPrefix = "__torch__";
+static constexpr std::string_view kJitPrefix = "torch.jit";
 
 class FlatbufferLoader final {
  public:
@@ -188,13 +189,13 @@ TypePtr resolveType(
     const std::shared_ptr<CompilationUnit>& cu) {
   TypePtr type;
   std::string_view type_str(type_string);
-  if (c10::string_view_starts_with(type_str, kCustomClassPrefix)) {
+  if (c10::starts_with(type_str, kCustomClassPrefix)) {
     type = getCustomClass(type_string);
     TORCH_CHECK(
         type, "The implementation of class ", type_string, " cannot be found.");
   } else if (
-      c10::string_view_starts_with(type_str, kTorchPrefix) ||
-      c10::string_view_starts_with(type_str, kJitPrefix)) {
+      c10::starts_with(type_str, kTorchPrefix) ||
+      c10::starts_with(type_str, kJitPrefix)) {
     c10::QualifiedName qn(type_string);
     if (cu->get_class(qn) == nullptr) {
       auto classtype = ClassType::create(qn, cu, true);
@@ -609,8 +610,8 @@ ClassTypePtr FlatbufferLoader::getOrCreateClassTypeForObject(
   if (cls == nullptr) {
     std::string_view qn_str(
         obj_type->type_name()->c_str(), obj_type->type_name()->size());
-    if (c10::string_view_starts_with(qn_str, kTorchPrefix) ||
-        c10::string_view_starts_with(qn_str, kJitPrefix)) {
+    if (c10::starts_with(qn_str, kTorchPrefix) ||
+        c10::starts_with(qn_str, kJitPrefix)) {
       c10::QualifiedName qn(obj_type->type_name()->str());
       cls = cu_->get_class(qn);
       if (cls == nullptr) {

--- a/torch/csrc/lazy/core/hash.h
+++ b/torch/csrc/lazy/core/hash.h
@@ -149,10 +149,6 @@ static inline hash_t Hash(const std::string& value) {
   return DataHash(value.data(), value.size());
 }
 
-static inline hash_t Hash(const c10::string_view& value) {
-  return DataHash(value.data(), value.size());
-}
-
 static inline hash_t Hash(const std::string_view& value) {
   return DataHash(value.data(), value.size());
 }

--- a/torch/csrc/profiler/perf-inl.h
+++ b/torch/csrc/profiler/perf-inl.h
@@ -13,6 +13,8 @@
 
 #include <torch/csrc/profiler/perf.h>
 
+#include <limits>
+
 namespace torch::profiler::impl::linux_perf {
 
 /*


### PR DESCRIPTION
Shortens `string_view_starts_with` to `starts_with`. Adds some missing headers. Isolates `c10_string_view` to use with `get_fully_qualified_name`.

Test Plan: Sandcastle

Reviewed By: ezyang

Differential Revision: D64833558




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel