### PR TITLE
Fix bug in selecting addr for TCPStore

### DIFF
--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -1198,11 +1198,7 @@ class DynamicRendezvousHandler(RendezvousHandler):
             # To avoid race in get_free_port because we release the port after the call,
             # we want to create a TCPStore server soon afterwards.
             server_port = 0
-            addr = (
-                self._store.host
-                if isinstance(self._store, dist.TCPStore)
-                else self._this_node.addr
-            )
+            addr = self._this_node.addr
             if rank == 0:
                 self._shared_tcp_store_server = self._create_tcp_store_server(
                     addr, server_port


### PR DESCRIPTION
Fixes S463164

When using torchrun to run a multinode job, we observe that TCPStore is not being hosted on the correct addr after this change: https://github.com/pytorch/pytorch/commit/40c825d773d04e64484e125521b1fb4138b3fe20#diff-26da16e9cd5270c60dd229d66e4cee0a5eff45f5799ad5baf2e3046725c5d596R1202


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o