### PR TITLE
Migrate inductor-perf-test-nightly.yml to use linux.aws.a100

### DIFF
--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -87,18 +87,18 @@ jobs:
       cuda-arch-list: '8.0'
       test-matrix: |
         { include: [
-          { config: "inductor_huggingface_perf", shard: 1, num_shards: 3, runner: "linux.gcp.a100.large" },
-          { config: "inductor_huggingface_perf", shard: 2, num_shards: 3, runner: "linux.gcp.a100.large" },
-          { config: "inductor_huggingface_perf", shard: 3, num_shards: 3, runner: "linux.gcp.a100.large" },
-          { config: "inductor_timm_perf", shard: 1, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "inductor_timm_perf", shard: 2, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "inductor_timm_perf", shard: 3, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "inductor_timm_perf", shard: 4, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "inductor_timm_perf", shard: 5, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "inductor_torchbench_perf", shard: 1, num_shards: 4, runner: "linux.gcp.a100.large" },
-          { config: "inductor_torchbench_perf", shard: 2, num_shards: 4, runner: "linux.gcp.a100.large" },
-          { config: "inductor_torchbench_perf", shard: 3, num_shards: 4, runner: "linux.gcp.a100.large" },
-          { config: "inductor_torchbench_perf", shard: 4, num_shards: 4, runner: "linux.gcp.a100.large" },
+          { config: "inductor_huggingface_perf", shard: 1, num_shards: 3, runner: "linux.aws.a100" },
+          { config: "inductor_huggingface_perf", shard: 2, num_shards: 3, runner: "linux.aws.a100" },
+          { config: "inductor_huggingface_perf", shard: 3, num_shards: 3, runner: "linux.aws.a100" },
+          { config: "inductor_timm_perf", shard: 1, num_shards: 5, runner: "linux.aws.a100" },
+          { config: "inductor_timm_perf", shard: 2, num_shards: 5, runner: "linux.aws.a100" },
+          { config: "inductor_timm_perf", shard: 3, num_shards: 5, runner: "linux.aws.a100" },
+          { config: "inductor_timm_perf", shard: 4, num_shards: 5, runner: "linux.aws.a100" },
+          { config: "inductor_timm_perf", shard: 5, num_shards: 5, runner: "linux.aws.a100" },
+          { config: "inductor_torchbench_perf", shard: 1, num_shards: 4, runner: "linux.aws.a100" },
+          { config: "inductor_torchbench_perf", shard: 2, num_shards: 4, runner: "linux.aws.a100" },
+          { config: "inductor_torchbench_perf", shard: 3, num_shards: 4, runner: "linux.aws.a100" },
+          { config: "inductor_torchbench_perf", shard: 4, num_shards: 4, runner: "linux.aws.a100" },
         ]}
       selected-test-configs: ${{ inputs.benchmark_configs }}
     secrets:

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -1,6 +1,9 @@
 name: inductor-A100-perf-nightly
 
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/inductor-perf-test-nightly.yml'
   schedule:
     - cron: 0 7 * * 1-6
     - cron: 0 7 * * 0

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -1,9 +1,6 @@
 name: inductor-A100-perf-nightly
 
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/inductor-perf-test-nightly.yml'
   schedule:
     - cron: 0 7 * * 1-6
     - cron: 0 7 * * 0


### PR DESCRIPTION
We are deprecating the `linux.gcp.a100` runners, in favor of its AWS counterpart labeled `linux.aws.a100` given the fact it is cheaper and should perform just as well.