### PR TITLE
[hop free symbols] refactor tensor.to_list implementation to call wrap_fx_proxy.

### DIFF
--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -758,6 +758,7 @@ class TensorVariable(VariableTracker):
 
     def method_tolist(self):
         from ..symbolic_convert import InstructionTranslator
+        from .builder import wrap_fx_proxy
 
         tx = InstructionTranslator.current_tx()
 
@@ -768,7 +769,7 @@ class TensorVariable(VariableTracker):
                 with unittest.mock.patch.object(
                     tx.fake_mode, "allow_scalar_outputs", True
                 ):
-                    return SymNodeVariable.create(
+                    return wrap_fx_proxy(
                         tx,
                         sub_proxy.item(),
                     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #138363
* __->__ #139663
* #138559
* #138737
* #138558
* #138428
* #138345

Refactoring only. Previously, we manually cal SymNodeVariable.create, now we handle it with wrap_fx_proxy. This unifies the handling of operations that produce symints in wrap_fx_proxy.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames