### PR TITLE
Fix to modules.rst: indent line with activation functions

### DIFF
--- a/docs/source/notes/modules.rst
+++ b/docs/source/notes/modules.rst
@@ -202,7 +202,7 @@ register submodules from a list or dict:
      def forward(self, x, act):
        for linear in self.linears:
          x = linear(x)
-       x = self.activations[act](x)
+         x = self.activations[act](x)
        x = self.final(x)
        return x
 


### PR DESCRIPTION
At line 205, I believe the code `x = self.activations[act](x)` should be indented so that it is in the body of the for loop. Otherwise, applying the four linear modules has the same effect as applying a single linear module, in the sense that it is still just a linear map so there is no point in having four of them.  In other words, each layer of this network should have a nonlinearity.


cc @svekars @brycebortree @sekyondaMeta