### PR TITLE
[AOTAutograd] Handle edge cases for donated buffer & enable in oss

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -959,6 +959,8 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
         out_test = m_compiled(*sample_inputs)
         self.assertEqual(out_ref, out_test)
 
+    # set donated_buffer=False due to create_graph=True
+    @torch._functorch.config.patch("donated_buffer", False)
     def test_eager_sequence_nr(self):
         class Model(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
@@ -23,6 +23,7 @@ from torch._dynamo.utils import detect_fake_mode, lazy_format_graph_code
 from torch._guards import CompileContext, TracingContext
 from torch._logging import getArtifactLogger, trace_structured
 from torch._subclasses import FakeTensor
+from torch._subclasses.meta_utils import is_sparse_any
 from torch.fx.experimental._backward_state import BackwardState
 from torch.fx.experimental.proxy_tensor import is_sym_node
 from torch.fx.experimental.symbolic_shapes import fx_placeholder_vals
@@ -290,14 +291,19 @@ def collect_fw_donated_buffer_idxs(
 
     storage_refs = set()
     for t in itertools.chain(fw_ins, user_fw_outs, bw_outs):
-        if isinstance(t, FakeTensor):
+        # Only access storage if a tensor has storage (not sparse)
+        if t is not None and isinstance(t, FakeTensor) and not is_sparse_any(t):
             storage_refs.add(StorageWeakRef(t.untyped_storage()))
 
     num_saved_tensor = len(saved_tensors)
     donated_buffer_idxs = []
     for i in range(num_saved_tensor):
         t = saved_tensors[i]
-        if StorageWeakRef(t.untyped_storage()) not in storage_refs:
+        if (
+            t is not None
+            and not is_sparse_any(t)
+            and StorageWeakRef(t.untyped_storage()) not in storage_refs
+        ):
             donated_buffer_idxs.append(i)
 
     return donated_buffer_idxs
@@ -316,9 +322,18 @@ def collect_bw_donated_buffer_idxs(
     bw_outs = next(reversed(bw_module.graph.find_nodes(op="output"))).args[0]
     fw_outs = next(reversed(fw_module.graph.find_nodes(op="output"))).args[0]
 
-    fw_ins = [n.meta["val"] if hasattr(n, "meta") else None for n in fw_ins]
-    fw_outs = [n.meta["val"] if hasattr(n, "meta") else None for n in fw_outs]
-    bw_outs = [n.meta["val"] if hasattr(n, "meta") else None for n in bw_outs]
+    fw_ins = [
+        n.meta["val"] if (hasattr(n, "meta") and "val" in n.meta) else None
+        for n in fw_ins
+    ]
+    fw_outs = [
+        n.meta["val"] if (hasattr(n, "meta") and "val" in n.meta) else None
+        for n in fw_outs
+    ]
+    bw_outs = [
+        n.meta["val"] if (hasattr(n, "meta") and "val" in n.meta) else None
+        for n in bw_outs
+    ]
 
     user_fw_outs = fw_outs[: fw_metadata.num_forward]
     saved_tensors = fw_outs[fw_metadata.tensors_saved_for_backwards_slice]

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -199,7 +199,7 @@ fake_tensor_propagate_real_tensors = False
 
 # This controls whether we collect donated buffer. This flag must be set
 # False if a user wants to retain_graph=True for backward.
-donated_buffer = False
+donated_buffer = False if is_fbcode() else True
 
 # Controls the default graph output format used by draw_graph
 # Supported formats are defined here https://graphviz.org/docs/outputs/


### PR DESCRIPTION
This PR enables donated buffer in OSS and handles two edge cases:

1. While donated buffer relies on storage to check alias, sparse tensor subclasses does not provide access to storage. So we skip sparse tensor subclasses for donated buffer.
2. Handles missing "val" from n.meta. This is observed from `inductor/test_fused_attention.py::SDPAPatternRewriterCpuTests::test_sdpa_rewriter_11_cpu`, 
`functorch/test_aotdispatch.py::TestAOTAutograd::test_input_mutation_simple_with_none_and_nontensor`, and 
`inductor/test_compiled_autograd.py::TestCompiledAutograd::test_trace_run_with_rng_state`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames