### PR TITLE
[Traceable FSDP2] Run any unexecuted post_backward at beginning of pre_backward hook

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -171,6 +171,13 @@ class TestFullyShardCompile(FSDPTest):
         torch.compile(f, backend="aot_eager")(x)
         self.assertEqual(x, ref_x)
 
+    def _get_resize_count_in_fx_graph(self, graph: torch.fx.Graph):
+        resize_count = 0
+        for node in graph.nodes:
+            if node.op == "call_function" and node.target == torch.ops.inductor.resize_storage_bytes_.default:
+                resize_count += 1
+        return resize_count
+
     def _assert_no_aliased_unsharded_params_in_graph_inputs(
         self, model, graph: torch.fx.Graph
     ) -> None:
@@ -212,9 +219,11 @@ val.shape: {[node.meta['val'].shape for node in aliased_graph_inputs]},
         self.assertTrue(no_aliased_unsharded_params_in_graph_inputs, err_msg)
 
     def _remove_fsdp2_unsharded_param_graph_input_usage_with_optional_checks(
-        self, model, fwd_fullgraph
+        self, model, *, bwd_resize_count_before_pass=None, fwd_fullgraph=False
     ):
         def _run_with_checks(graph, orig_fn):
+            if self._is_bwd_fx_graph(graph) and bwd_resize_count_before_pass is not None:
+                self.assertEqual(bwd_resize_count_before_pass, self._get_resize_count_in_fx_graph(graph))
             self._assert_no_aliased_unsharded_params_in_graph_inputs(model, graph)
             orig_fn(graph)
 
@@ -312,6 +321,12 @@ val.shape: {[node.meta['val'].shape for node in aliased_graph_inputs]},
             return True
         else:
             return False
+
+    def _is_bwd_fx_graph(self, graph):
+        for node in graph.nodes:
+            if node.op == "call_function" and node.target == torch.ops._c10d_functional.reduce_scatter_tensor.default:
+                return True
+        return False
 
     def _maybe_run_decide_global_ordering_of_comms_with_checks(self, fwd_fullgraph):
         def _check_fsdp_ops_in_snodes(snodes, is_fwd_graph, expect=True):
@@ -443,6 +458,8 @@ val.shape: {[node.meta['val'].shape for node in aliased_graph_inputs]},
         input_creation_fn,
         backend,
         fwd_fullgraph,
+        *,
+        bwd_resize_count_before_inductor=None,
     ):
         def fwd_bwd(model, inp):
             out = model(inp)
@@ -474,7 +491,7 @@ val.shape: {[node.meta['val'].shape for node in aliased_graph_inputs]},
 
             counters.clear()
             with self._remove_fsdp2_unsharded_param_graph_input_usage_with_optional_checks(
-                model, fwd_fullgraph
+                model, bwd_resize_count_before_pass=bwd_resize_count_before_inductor, fwd_fullgraph=fwd_fullgraph,
             ):
                 fwd_bwd_fn_compiled = torch.compile(
                     fwd_bwd_fn,
@@ -619,8 +636,9 @@ val.shape: {[node.meta['val'].shape for node in aliased_graph_inputs]},
             def forward(self, x):
                 # Intentionally reusing all layers a few times,
                 # to test "multiple all-gathers for the same parameter" case.
-                for layer in self.layers:
-                    x = layer(x)
+                for layer_id in range(len(self.layers)):
+                    for _ in range(2):
+                        x = self.layers[layer_id](x)
                 for layer in self.layers:
                     x = layer(x)
                 for layer in self.layers:
@@ -700,6 +718,7 @@ val.shape: {[node.meta['val'].shape for node in aliased_graph_inputs]},
                         ),
                         "inductor",
                         fwd_fullgraph=fwd_fullgraph,
+                        bwd_resize_count_before_inductor=48 if fwd_fullgraph else None,
                     )
                 )
             if fwd_fullgraph:
@@ -925,6 +944,7 @@ val.shape: {[node.meta['val'].shape for node in aliased_graph_inputs]},
                         ),
                         "inductor",
                         fwd_fullgraph=fwd_fullgraph,
+                        bwd_resize_count_before_inductor=76 if fwd_fullgraph else None,
                     )
                 )
             if fwd_fullgraph:

--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -174,7 +174,10 @@ class TestFullyShardCompile(FSDPTest):
     def _get_resize_count_in_fx_graph(self, graph: torch.fx.Graph):
         resize_count = 0
         for node in graph.nodes:
-            if node.op == "call_function" and node.target == torch.ops.inductor.resize_storage_bytes_.default:
+            if (
+                node.op == "call_function"
+                and node.target == torch.ops.inductor.resize_storage_bytes_.default
+            ):
                 resize_count += 1
         return resize_count
 
@@ -222,8 +225,14 @@ val.shape: {[node.meta['val'].shape for node in aliased_graph_inputs]},
         self, model, *, bwd_resize_count_before_pass=None, fwd_fullgraph=False
     ):
         def _run_with_checks(graph, orig_fn):
-            if self._is_bwd_fx_graph(graph) and bwd_resize_count_before_pass is not None:
-                self.assertEqual(bwd_resize_count_before_pass, self._get_resize_count_in_fx_graph(graph))
+            if (
+                self._is_bwd_fx_graph(graph)
+                and bwd_resize_count_before_pass is not None
+            ):
+                self.assertEqual(
+                    bwd_resize_count_before_pass,
+                    self._get_resize_count_in_fx_graph(graph),
+                )
             self._assert_no_aliased_unsharded_params_in_graph_inputs(model, graph)
             orig_fn(graph)
 
@@ -324,7 +333,11 @@ val.shape: {[node.meta['val'].shape for node in aliased_graph_inputs]},
 
     def _is_bwd_fx_graph(self, graph):
         for node in graph.nodes:
-            if node.op == "call_function" and node.target == torch.ops._c10d_functional.reduce_scatter_tensor.default:
+            if (
+                node.op == "call_function"
+                and node.target
+                == torch.ops._c10d_functional.reduce_scatter_tensor.default
+            ):
                 return True
         return False
 
@@ -491,7 +504,9 @@ val.shape: {[node.meta['val'].shape for node in aliased_graph_inputs]},
 
             counters.clear()
             with self._remove_fsdp2_unsharded_param_graph_input_usage_with_optional_checks(
-                model, bwd_resize_count_before_pass=bwd_resize_count_before_inductor, fwd_fullgraph=fwd_fullgraph,
+                model,
+                bwd_resize_count_before_pass=bwd_resize_count_before_inductor,
+                fwd_fullgraph=fwd_fullgraph,
             ):
                 fwd_bwd_fn_compiled = torch.compile(
                     fwd_bwd_fn,

--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -651,9 +651,11 @@ val.shape: {[node.meta['val'].shape for node in aliased_graph_inputs]},
             def forward(self, x):
                 # Intentionally reusing all layers a few times,
                 # to test "multiple all-gathers for the same parameter" case.
+                # Case 1: rerun the same layer twice
                 for layer_id in range(len(self.layers)):
                     for _ in range(2):
                         x = self.layers[layer_id](x)
+                # Case 2: iterate through all layers twice
                 for layer in self.layers:
                     x = layer(x)
                 for layer in self.layers:

--- a/torch/distributed/_composable/fsdp/_fsdp_param.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param.py
@@ -518,7 +518,9 @@ class FSDPParam:
                 # resize_(full) -> copy_ -> resize_(0) pattern, we will remove those
                 # resize_ and copy_ ops in a compiler graph pass
                 # `remove_fsdp2_unsharded_param_graph_input_usage` to recover performance.
-                self._unsharded_param.untyped_storage().resize_(self._unsharded_param.numel() * self._unsharded_param.itemsize)
+                self._unsharded_param.untyped_storage().resize_(
+                    self._unsharded_param.numel() * self._unsharded_param.itemsize
+                )
                 torch.ops.fsdp.copy_(self._unsharded_param, unsharded_param)
         else:
             self._unsharded_param = nn.Parameter(

--- a/torch/distributed/_composable/fsdp/_fsdp_param.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param.py
@@ -518,7 +518,7 @@ class FSDPParam:
                 # resize_(full) -> copy_ -> resize_(0) pattern, we will remove those
                 # resize_ and copy_ ops in a compiler graph pass
                 # `remove_fsdp2_unsharded_param_graph_input_usage` to recover performance.
-                alloc_storage(self._unsharded_param)
+                self._unsharded_param.untyped_storage().resize_(self._unsharded_param.numel() * self._unsharded_param.itemsize)
                 torch.ops.fsdp.copy_(self._unsharded_param, unsharded_param)
         else:
             self._unsharded_param = nn.Parameter(

--- a/torch/distributed/_composable/fsdp/_fsdp_param_group.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param_group.py
@@ -2,6 +2,7 @@
 import contextlib
 import logging
 from typing import Any, Callable, cast, Dict, List, NamedTuple, Optional, Set, Tuple
+import functools
 
 import torch
 import torch.distributed as dist
@@ -345,6 +346,10 @@ class FSDPParamGroup:
         self._post_forward_indices.append(post_forward_index)
 
     def pre_backward(self, default_prefetch: bool, *unused: Any):
+        if compiled_autograd_enabled() and self._training_state == TrainingState.PRE_BACKWARD:
+            # Traceable FSDP2 cannot trigger the param group's post-backward immediately after param usage;
+            # instead it relies on this to trigger the previously pending post-backward.
+            self.post_backward()
         if self._training_state == TrainingState.PRE_BACKWARD:
             return
         if not compiled_autograd_enabled():
@@ -677,8 +682,10 @@ class RegisterPostBackwardFunction(torch.autograd.Function):
         if compiled_autograd_enabled():
             # TODO: Find a way to print the offending FSDP2 module.
             msg = """\
-When Traceable FSDP2 is enabled, we rely on `root_post_backward_callback` to call
-each `FSDPParamGroup.post_backward`, and we should not be calling into `RegisterPostBackwardFunction`.
+When Traceable FSDP2 is enabled, we should not be calling into `RegisterPostBackwardFunction`.
+Instead, we rely on the param group's next `pre_backward` hook to trigger its previously unexecuted
+`post_backward` hook, and we rely on FSDPState's `root_post_backward_callback` to trigger the resharding
+of any leftover unsharded param groups. 
 If you are here, it means the forward part of this FSDP2 instance is not compiled, and you must also
 compile the forward part if you want to use Traceable FSDP2."""
             torch._dynamo.comptime.comptime.print(msg)

--- a/torch/distributed/_composable/fsdp/_fsdp_param_group.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param_group.py
@@ -2,7 +2,6 @@
 import contextlib
 import logging
 from typing import Any, Callable, cast, Dict, List, NamedTuple, Optional, Set, Tuple
-import functools
 
 import torch
 import torch.distributed as dist
@@ -346,7 +345,10 @@ class FSDPParamGroup:
         self._post_forward_indices.append(post_forward_index)
 
     def pre_backward(self, default_prefetch: bool, *unused: Any):
-        if compiled_autograd_enabled() and self._training_state == TrainingState.PRE_BACKWARD:
+        if (
+            compiled_autograd_enabled()
+            and self._training_state == TrainingState.PRE_BACKWARD
+        ):
             # Traceable FSDP2 cannot trigger the param group's post-backward immediately after param usage;
             # instead it relies on this to trigger the previously pending post-backward.
             self.post_backward()
@@ -685,7 +687,7 @@ class RegisterPostBackwardFunction(torch.autograd.Function):
 When Traceable FSDP2 is enabled, we should not be calling into `RegisterPostBackwardFunction`.
 Instead, we rely on the param group's next `pre_backward` hook to trigger its previously unexecuted
 `post_backward` hook, and we rely on FSDPState's `root_post_backward_callback` to trigger the resharding
-of any leftover unsharded param groups. 
+of any leftover unsharded param groups.
 If you are here, it means the forward part of this FSDP2 instance is not compiled, and you must also
 compile the forward part if you want to use Traceable FSDP2."""
             torch._dynamo.comptime.comptime.print(msg)

--- a/torch/distributed/_composable/fsdp/_fsdp_param_group.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param_group.py
@@ -349,8 +349,8 @@ class FSDPParamGroup:
             compiled_autograd_enabled()
             and self._training_state == TrainingState.PRE_BACKWARD
         ):
-            # Traceable FSDP2 cannot trigger the param group's post-backward immediately after param usage;
-            # instead it relies on this to trigger the previously pending post-backward.
+            # Traceable FSDP2 cannot trigger the param group's `post_backward` immediately after param usage;
+            # instead it relies on this to trigger the previously unexecuted `post_backward`.
             self.post_backward()
         if self._training_state == TrainingState.PRE_BACKWARD:
             return
@@ -686,7 +686,7 @@ class RegisterPostBackwardFunction(torch.autograd.Function):
             msg = """\
 When Traceable FSDP2 is enabled, we should not be calling into `RegisterPostBackwardFunction`.
 Instead, we rely on the param group's next `pre_backward` hook to trigger its previously unexecuted
-`post_backward` hook, and we rely on FSDPState's `root_post_backward_callback` to trigger the resharding
+`post_backward`, and we rely on FSDPState's `root_post_backward_callback` to trigger the resharding
 of any leftover unsharded param groups.
 If you are here, it means the forward part of this FSDP2 instance is not compiled, and you must also
 compile the forward part if you want to use Traceable FSDP2."""


### PR DESCRIPTION
Assuming the forward pass user code looks like:
```
for _ in range(2):
    x = layer(x)
```
and we have `fully_shard(layer)`, then:
- the forward pass will be like: "unshard layer -> call layer 1st time -> reshard layer -> unshard layer -> call layer 2nd time-> reshard layer" (currently same for both eager and compile)
- the backward pass will be like: "unshard layer -> call layer 1st time -> reshard layer -> unshard layer -> call layer 2nd time-> reshard layer" in eager, but currently it's "unshard layer -> call layer 1st time -> call layer 2nd time -> reshard layer" in compile

The behavior in the backward pass is different between eager and compile, which is not ideal.

 I am currently trying to look for a way to fix this non-ideal behavior of compile - tried a few things:
1. Tracing the RegisterPostBackwardFunction custom autograd function - this stills seems to be a no-go, due to HOP not supporting side-effects.
2. Instead of custom autograd function, do a "multi-grad hook" to wait for all gradients to be ready before triggering post_backward. However, this approach seems to have bad interaction with register_hook of pre_backward, in the sense that it's unclear which of them will be triggered first in practice.
3. Force execute any pending post_backward before unshard in pre_backward hook, and rely on compiler to move the reshard to the right place to optimize peak memory. -> This PR

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #139672
* __->__ #139671



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o