### PR TITLE
[ROCM] Support Multi-GPU offline tuning in TunableOp

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -952,6 +952,9 @@ test_distributed() {
     python test/run_test.py --cpp --verbose -i cpp/HashStoreTest
     python test/run_test.py --cpp --verbose -i cpp/TCPStoreTest
 
+    echo "Testing multi-GPU linalg tests"
+    python test/run_test.py -i test_linalg.py -k test_matmul_offline_mgpu_tunable --verbose
+
     if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
       MPIEXEC=$(command -v mpiexec)
       if [[ -n "$MPIEXEC" ]]; then

--- a/aten/src/ATen/cuda/tunable/README.md
+++ b/aten/src/ATen/cuda/tunable/README.md
@@ -174,6 +174,7 @@ All python APIs exist in the `torch.cuda.tunable` module.
 | write_file(filename: Optional[str] = None) -> None | If filename not given, it will call get_filename(). |
 | read_file(filename: Optional[str] = None) -> None | If filename not given, it will call get_filename(). |
 | tune_gemm_in_file(filename: str) -> None | read an untuned file and tune GEMMs in it. |
+| mgpu_tune_gemm_in_file(filename_pattern: str, num_gpus: int) -> None: -> None | read one or more untuned files and tune all unique GEMMs on one or more GPUs. |
 
 ### C++ Interface
 Example:

--- a/aten/src/ATen/cuda/tunable/README.md
+++ b/aten/src/ATen/cuda/tunable/README.md
@@ -107,21 +107,25 @@ os.putenv('PYTORCH_TUNABLEOP_RECORD_UNTUNED', '0')
 tunable.tune_gemm_in_file("tunableop_untuned0.csv")
 ```
 
-It is also possible to take multiple untuned files and distribute the GEMMs for tuning to multiple-GPUs.
-In the first step, the GEMMs are first gathered and duplicate GEMMs are eliminated. Next, the GEMMs are
-distributed to different GPUs for tuning. After all GEMMs are tuned, the results from all the GPUs are then
-gathered into a single file whose base filename has `_full0` appended to it (e.g. `tunableop_results_full0.csv`).
-Finally, this new file, containing the gathered results, will be duplicated N times, once for each GPU as
-convenience to the user will run the workload with the tuned configuration on N GPUs.
+It is also possible to take multiple untuned files and distribute the GEMMs for tuning to multiple GPUs
+within a single node. In the first step, the GEMMs are first gathered and duplicate GEMMs are eliminated.
+Next, the GEMMs are distributed to different GPUs for tuning. After all GEMMs are tuned, the results from
+all the GPUs are then gathered into a single file whose base filename has `_full0` appended to it
+(e.g. `tunableop_results_full0.csv`). Finally, this new file, containing the gathered results, will be
+duplicated N times, once for each GPU as convenience to the user will run the workload with the tuned
+configuration on N GPUs.
 
 ```
-num_gpus = 8 # number of GPUs that will be used during the tuning process
-tunable.mgpu_tune_gemm_in_file("tunableop_untuned?.csv", num_gpus)
+if __name__ == "__main__":
+    num_gpus = 8 # number of GPUs that will be used during the tuning process
+    tunable.mgpu_tune_gemm_in_file("tunableop_untuned?.csv", num_gpus)
 ```
 
-The argument to `mgpu_tune_gemm_in_file` must contain a wild card expression (? or *) to generate the list of
-untuned files containing the GEMMs to be processed. The `num_gpus` must between 1 and the total number of GPUs
-available.
+Note that the usage of the `mgpu_tune_gemm_in_file` API is different from its single GPU counterpart
+(`tune_gemm_in_file`). The body of the Python script that calls the API must be wrapped in `main()` as shown
+due to the use of concurrent futures module. The argument to `mgpu_tune_gemm_in_file` must contain a wild card
+expression (? or *) to generate the list of untuned files containing the GEMMs to be processed. The `num_gpus`
+must between 1 and the total number of GPUs available.
 
 ## Tuning Context
 The behavior of TunableOp is currently manipulated through environment variables, the C++ interface of

--- a/aten/src/ATen/cuda/tunable/README.md
+++ b/aten/src/ATen/cuda/tunable/README.md
@@ -84,14 +84,14 @@ Basically it is used for workload with high-memory utilization where one might r
 
 ### Workflow
 There are basically two steps:
-1) Set the environment variables to collect the untuned GEMM and this will generate `tunableop_untuned?.csv` ("?" is placeholder for the GPU ID), like:
+1) Set the environment variables to collect the untuned GEMM and this will generate `tunableop_untuned0.csv`
 ```
 PYTORCH_TUNABLEOP_ENABLED=1
 PYTORCH_TUNABLEOP_TUNING=0
 PYTORCH_TUNABLEOP_RECORD_UNTUNED=1
 ...
 ```
-2) Run a Python script that reads the `tunableop_untuned?.csv` and generates the `tunableop_results?.csv`, like:
+2) Run a Python script that reads the `tunableop_untuned0.csv` and generates the `tunableop_results0.csv`, like:
 ```
 import torch.cuda.tunable as tunable
 import os
@@ -99,7 +99,7 @@ import os
 os.putenv('PYTORCH_TUNABLEOP_ENABLED', '1')
 os.putenv('PYTORCH_TUNABLEOP_TUNING', '1')
 os.putenv('PYTORCH_TUNABLEOP_RECORD_UNTUNED', '0')
-tunable.tune_gemm_in_file("tunableop_results?.csv")
+tunable.tune_gemm_in_file("tunableop_untuned0.csv")
 ```
 
 ## Tuning Context

--- a/docs/source/cuda.tunable.rst
+++ b/docs/source/cuda.tunable.rst
@@ -33,3 +33,4 @@ API Reference
 .. autofunction:: write_file
 .. autofunction:: read_file
 .. autofunction:: tune_gemm_in_file
+.. autofunction:: mgpu_tune_gemm_in_file

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4673,6 +4673,7 @@ class TestLinalg(TestCase):
 
     @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
     @onlyCUDA
+    @skipCUDAIfNotRocm
     @dtypes(torch.float)
     def test_matmul_offline_mgpu_tunableop(self, device, dtype):
         # Offline tuning with multiple GPUs.

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -61,11 +61,8 @@ def set_tunableop_defaults():
         return
 
     # disable TunableOp and restore to default values
-    ordinal = torch.cuda.current_device()
-    filename = f"tunableop_results{ordinal}.csv"
     torch.cuda.tunable.enable(False)
     torch.cuda.tunable.tuning_enable(True)
-    torch.cuda.tunable.set_filename(filename)  # reset back to default filename for next unit test
     torch.cuda.tunable.set_max_tuning_duration(30)
     torch.cuda.tunable.set_max_tuning_iterations(100)
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -62,6 +62,7 @@ def set_tunableop_defaults():
 
     # disable TunableOp and restore to default values
     torch.cuda.tunable.enable(False)
+    torch.cuda.tunable.record_untuned_enable(False)
     torch.cuda.tunable.tuning_enable(True)
     torch.cuda.tunable.set_max_tuning_duration(30)
     torch.cuda.tunable.set_max_tuning_iterations(100)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -32,7 +32,7 @@ from torch.testing._internal.common_dtype import (
     floating_and_complex_types_and, floating_types_and, complex_types,
 )
 from torch.testing._internal.common_cuda import SM53OrLater, SM80OrLater, SM90OrLater, tf32_on_and_off, _get_magma_version, \
-    _get_torch_cuda_version, CDNA2OrLater
+    _get_torch_cuda_version, CDNA2OrLater, TEST_MULTIGPU
 from torch.testing._internal.common_quantization import _group_quantize_tensor, _dynamically_quantize_per_channel
 from torch.testing._internal.common_mkldnn import bf32_on_and_off
 from torch.distributions.binomial import Binomial
@@ -4670,6 +4670,102 @@ class TestLinalg(TestCase):
         torch.cuda.tunable.set_max_tuning_iterations(100)
         assert torch.cuda.tunable.is_enabled() is False, "TunableOp should be off after resetting"
         assert torch.cuda.tunable.get_max_tuning_iterations() == 100
+
+    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @onlyCUDA
+    @dtypes(torch.float)
+    def test_matmul_offline_mgpu_tunableop(self, device, dtype):
+        # Offline tuning with multiple GPUs.
+        # Case where you record GEMMs on one GPU, but then tune
+        # on multiple GPUs
+        import tempfile
+        import os
+
+        tmp_dir = tempfile.mkdtemp()
+
+        # Use all available GPUs for this test
+        total_gpus = torch.cuda.device_count()
+
+        # Test in try-finally block to avoid leaking state
+        # if test is interrupted.
+        try:
+            set_tunableop_defaults()
+            os.environ["PYTORCH_TUNABLEOP_ROTATING_BUFFER_SIZE"] = "0"
+
+            # Pointing to temp files. The test cannot remove them on Windows because
+            # they are in use and locked
+            os.putenv("PYTORCH_TUNABLEOP_UNTUNED_FILENAME", os.path.join(tmp_dir, "tunableop_untuned.csv"))
+            os.putenv("PYTORCH_TUNABLEOP_FILENAME", os.path.join(tmp_dir, "tunableop_results.csv"))
+
+            #  turn on untuned GEMM recording and turn off tuning
+            torch.cuda.tunable.enable(True)
+            torch.cuda.tunable.tuning_enable(False)
+            torch.cuda.tunable.record_untuned_enable(True)
+
+            # Choose matrix sizes that have not been used before
+            m = n = k = 23
+
+            # Create at least one GEMM per GPU, so when the GEMMs
+            # are distributed to the GPUs there is at least one
+            # GEMM per GPU.
+            for g in range(1, total_gpus + 1):
+                A = torch.rand(m * g, k * g, device=device, dtype=dtype)
+                B = torch.rand(k * g, n * g, device=device, dtype=dtype)
+                C = torch.matmul(A, B)
+
+            # check the untuned file was written
+            ordinal = torch.cuda.current_device()
+            untuned_filename = os.path.join(tmp_dir, f"tunableop_untuned{ordinal}.csv")
+            self.assertTrue(os.path.exists(untuned_filename))
+
+            # turn off untuned GEMM recording and turn on tuning
+            # We need to set the environment variables here instead of using
+            # the Python API, so that the child processes created will inherit
+            # these operations
+            os.environ["PYTORCH_TUNABLEOP_ENABLED"] = "1"
+            os.environ["PYTORCH_TUNABLEOP_TUNING"] = "1"
+            os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_ITERATIONS"] = "1"
+
+            torch.cuda.tunable.mgpu_tune_gemm_in_file(untuned_filename, total_gpus)
+            assert torch.cuda.tunable.write_file()
+
+            # check the results files where written, one per gpu
+            for i in range(total_gpus):
+                result_filename = os.path.join(tmp_dir, f"tunableop_results{i}.csv")
+                self.assertTrue(os.path.exists(result_filename))
+
+            # Check the full results files was written, one per gpu
+            # for i in range(total_gpus):
+            #     result_full_filename = os.path.join(tmp_dir, f"tunableop_results_full{i}.csv")
+            #     self.assertTrue(os.path.exists(result_full_filename))
+
+        finally:
+            # disables TunableOp
+            torch.cuda.tunable.enable(False)
+
+            # undo all the environment variables set
+            try:
+                del os.environ["PYTORCH_TUNABLEOP_ROTATING_BUFFER_SIZE"]
+                del os.environ["PYTORCH_TUNABLEOP_UNTUNED_FILENAME"]
+                del os.environ["PYTORCH_TUNABLEOP_FILENAME"]
+                del os.environ["PYTORCH_TUNABLEOP_ENABLED"]
+                del os.environ["PYTORCH_TUNABLEOP_TUNING"]
+                del os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_ITERATIONS"]
+            except KeyError:
+                pass
+
+            # # clean up, remove any files that were generated
+            try:
+                untuned_filename = os.path.join(tmp_dir, "tunableop_untuned0.csv")
+                os.remove(untuned_filename)
+                for i in range(total_gpus):
+                    result_filename = os.path.join(tmp_dir, f"tunableop_results{i}.csv")
+                    result_full_filename = os.path.join(tmp_dir, f"tunableop_results_full{i}.csv")
+                    os.remove(result_filename)
+                    os.remove(result_full_filename)
+            except FileNotFoundError:
+                pass
+
 
     @onlyCUDA
     @skipCUDAIfNotRocm

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -49,7 +49,7 @@ like so::
   GemmTunableOp_float_NT,nt_25088_4096_64,1219,1.262
   GemmTunableOp_float_NT,nt_4096_4096_64,1216,0.033
 
-Note the "Validator" lines. If you change a library verison, or ROCm version, or
+Note the "Validator" lines. If you change a library version, or ROCm version, or
 PyTorch version, TunableOp will detect this and reject the tunings file because
 the prior tunings are likely affected by other software changes.
 

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -141,7 +141,7 @@ __all__ = [
     "write_file",
     "read_file",
     "tune_gemm_in_file",
-    "mgpu_tune_in_file",
+    "mgpu_tune_gemm_in_file",
 ]
 
 

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -385,8 +385,8 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
 
     if underscore_count == 2:
         [op_sig, data_type, layout] = untuned_gemm[0].split("_")
-        transA = True if layout[0] == "T" else False
-        transB = True if layout[1] == "T" else False
+        transA = layout[0] == "T"
+        transB = layout[1] == "T"
         dtype = dtype_dict.get(data_type)
     else:  # ScaledGEMM
         untuned_gemm_temp = untuned_gemm[0].split("_")
@@ -394,8 +394,8 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
         data_typeA = untuned_gemm_temp[1] + "_" + untuned_gemm_temp[2]
         data_typeB = untuned_gemm_temp[3] + "_" + untuned_gemm_temp[4]
         data_typeC = untuned_gemm_temp[5] + "_" + untuned_gemm_temp[6]
-        transA = True if untuned_gemm_temp[7][0] == "T" else False
-        transB = True if untuned_gemm_temp[7][1] == "T" else False
+        transA = untuned_gemm_temp[7][0] == "T"
+        transB = untuned_gemm_temp[7][1] == "T"
         dtypeA = dtype_dict.get(data_typeA)
         dtypeB = dtype_dict.get(data_typeB)
         dtypeC = dtype_dict.get(data_typeC)

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -120,6 +120,7 @@ import concurrent.futures
 import multiprocessing as mp
 import glob
 import os
+import shutil
 
 __all__ = [
     "enable",

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -140,6 +140,7 @@ __all__ = [
     "write_file",
     "read_file",
     "tune_gemm_in_file",
+    "mgpu_tune_in_file",
 ]
 
 

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -412,7 +412,6 @@ def mgpu_tune_gemm_in_file(filename_pattern: str, num_gpus:int) -> None:
     with concurrent.futures.ProcessPoolExecutor(max_workers=num_gpus,
             mp_context=mp_context) as executor:
             for line in unique_gemm_entries:
-                print(h)
                 future = executor.submit(process_single_offline_gemm, line, h)
                 futures.append(future)
                 h = (h + 1) % num_gpus

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -116,7 +116,10 @@ import warnings
 from typing import Optional, Tuple
 
 import torch
-
+import concurrent.futures
+import multiprocessing as mp
+import glob
+import os
 
 __all__ = [
     "enable",

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -276,7 +276,7 @@ def tune_gemm_in_file(filename: str) -> None:
     with open(filename) as file:
         for line in file:
             if line.startswith("Gemm"):
-                process_single_offline_gemm(line, deviceid)
+                _process_single_offline_gemm(line, deviceid)
 
 
 def _gather_unique_untuned_gemm_from_files(filename_pattern: str) -> set[str]:

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -393,7 +393,7 @@ def process_single_offline_gemm(untuned_gemm_line:str, gpu_id:int) -> None:
         warnings.warn(f"error: unknown op {op_sig}")
 
 def mgpu_tune_gemm_in_file(filename_pattern: str, num_gpus:int) -> None:
-    r"""Process one or more files and distribute work over multiple GPUs."""
+    r"""Process one or more files and distribute work over one or more GPUs."""
     unique_gemm_entries = gather_unique_untuned_gemm_from_files(filename_pattern)
 
     assert is_enabled()
@@ -401,7 +401,7 @@ def mgpu_tune_gemm_in_file(filename_pattern: str, num_gpus:int) -> None:
 
     total_gpus = torch.cuda.device_count()
 
-    assert(num_gpus <= total_gpus)
+    assert(1 <= num_gpus <= total_gpus)
 
     mp_context = mp.get_context("spawn")
 

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -284,7 +284,7 @@ def gather_unique_untuned_gemm_from_files(filename_pattern: str) -> set[str]:
     unique_gemm_entries = set()  # set will avoid duplicates
 
     for file_path in glob.glob(filename_pattern):
-        with open(file_path, "r") as file:
+        with open(file_path) as file:
             for line in file:
                 if line.startswith("Gemm"):
                     unique_gemm_entries.add(line)
@@ -315,7 +315,7 @@ def gather_tunableop_results() -> None:
     matching_files = glob.glob(filename_pattern)
     num_matching_files = len(matching_files)
     for file_path in matching_files:
-        with open(file_path, "r") as file:
+        with open(file_path) as file:
             for line in file:
                 if line.startswith("Validator"):
                     if not (FirstFile):


### PR DESCRIPTION
This PR enhances offline tuning to support multi-GPUs. 

High-level description of algorithm:
- Duplicate GEMMs are first eliminated
- GEMMs are distributed to multi-GPUs for tuning
- Results are gathered into a file with `_full` in the filename

Also adding support for GemmAndBias and ScaledGemm

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang