### PR TITLE
[Torch Elastic] Fix the bug caused by wrong host address in creating TCPStore server inside dynamic rendezvous

### DIFF
--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -1198,20 +1198,15 @@ class DynamicRendezvousHandler(RendezvousHandler):
             # To avoid race in get_free_port because we release the port after the call,
             # we want to create a TCPStore server soon afterwards.
             server_port = 0
-            addr = (
-                self._store.host
-                if isinstance(self._store, dist.TCPStore)
-                else self._this_node.addr
-            )
             if rank == 0:
                 self._shared_tcp_store_server = self._create_tcp_store_server(
-                    addr, server_port
+                    self._this_node.addr, server_port
                 )
                 server_port = self._shared_tcp_store_server.port
             self._bootstrap_store_info = RendezvousStoreInfo.build(
                 rank,
                 store,
-                local_addr=addr,
+                local_addr=self._this_node.addr,
                 server_port=server_port,  # For non-0 rank, this is a no-op
             )
 


### PR DESCRIPTION
Summary: During dynamic rendezvous, we shouldn't use the address from the store but just use  `self._this_node.addr` directly because sometimes, the store host is not the host of rank0. Passing wrong host will cause timeout error. This is a follow up fix to S463164, for internal tests, we disable the TCPStore sharing for now.

Test Plan: CI.

Differential Revision: D65453312




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @wz337 @wconstab @d4l3k @c-p-i-o