### PR TITLE
[Break XPU][Inductor] Refine triton_bundler.py to support correctly on Intel GPU and fix CI failures.

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -146,9 +146,14 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
             self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 0)
-
+            # "cuda" has .ptx and .cubin file, but xpu only has .spv file
+            save_kernel_count = 6 if device == "xpu" else 7
+            read_and_emit_kernel_count = 6 if device == "xpu" else 7
             if bundle_triton and device != "cpu":
-                self.assertEqual(counters["inductor"]["triton_bundler_save_kernel"], 7)
+                self.assertEqual(
+                    counters["inductor"]["triton_bundler_save_kernel"],
+                    save_kernel_count,
+                )
                 self.assertEqual(
                     counters["inductor"]["triton_bundler_read_and_emit_kernel"], 0
                 )
@@ -167,9 +172,13 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
 
             if bundle_triton and device != "cpu":
-                self.assertEqual(counters["inductor"]["triton_bundler_save_kernel"], 7)
                 self.assertEqual(
-                    counters["inductor"]["triton_bundler_read_and_emit_kernel"], 7
+                    counters["inductor"]["triton_bundler_save_kernel"],
+                    save_kernel_count,
+                )
+                self.assertEqual(
+                    counters["inductor"]["triton_bundler_read_and_emit_kernel"],
+                    read_and_emit_kernel_count,
                 )
 
     @requires_triton()

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2159,6 +2159,7 @@ class CommonTemplate:
         self.common(fn, [packed])
 
     @skipCUDAIf(True, "No _weight_int8pack_mm implementation on CUDA")
+    @skipIfXpu(msg="No _weight_int8pack_mm implementation on XPU")
     def test_int8_weight_only_quant(self):
         def convert_weight_to_int8pack(b):
             b_int8pack, b_scales, _ = _dynamically_quantize_per_channel(

--- a/torch/_inductor/triton_bundler.py
+++ b/torch/_inductor/triton_bundler.py
@@ -9,6 +9,7 @@ from torch._dynamo.utils import counters, dynamo_timed
 from torch._utils_internal import justknobs_check
 
 from .runtime.runtime_utils import triton_cache_dir
+from .utils import GPU_KERNEL_BINS
 
 
 log = logging.getLogger(__name__)
@@ -157,8 +158,9 @@ class TritonBundler:
                             counters["inductor"]["triton_bundler_save_kernel"] += 1
                         except Exception:
                             log.debug("failed to collect triton kernel", exc_info=True)
-                        if filename.endswith(".cubin"):
-                            # Each kernel has bunch of files like .cubin, .json, .ttir
+                        file_extension = os.path.splitext(filename)
+                        if file_extension in GPU_KERNEL_BINS.values():
+                            # Each kernel has bunch of files like .cubin(for cuda), .spv(for xpu), .json, .ttir
                             # Just append one of them without the extension
                             kernel_names.append(Path(filename).stem)
                     if artifacts:
@@ -225,8 +227,9 @@ class TritonBundler:
                             )
                         file.write(payload)
                     counters["inductor"]["triton_bundler_read_and_emit_kernel"] += 1
-                    if artifact.filename.endswith(".cubin"):
-                        # Each kernel has bunch of files like .cubin, .json, .ttir
+                    file_extension = os.path.splitext(artifact.filename)
+                    if file_extension in GPU_KERNEL_BINS.values():
+                        # Each kernel has bunch of files like .cubin(for cuda), .spv(for xpu), .json, .ttir
                         # Just append one of them without the extension
                         kernel_names.append(Path(artifact.filename).stem)
                 # Atomic on POSIX systems

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -90,6 +90,7 @@ _T = TypeVar("_T")
 VarRanges = Dict[sympy.Expr, sympy.Expr]
 InputType = Optional[Union[torch.Tensor, int, torch.SymInt]]
 
+GPU_KERNEL_BINS = {"cuda": "cubin", "xpu": "spv"}
 
 GPU_ALIGN_BYTES = 16
 ALIGNMENT = 16


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov