### PR TITLE
[Dynamo] Replace `torch._dynamo.optimize()` with `torch.compile()` [1/N]

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -55,7 +55,7 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
 
         mod = Repro()
 
-        aot_mod = torch._dynamo.optimize("aot_eager")(mod)
+        aot_mod = torch.compile(mod, backend="aot_eager")
 
         args = [((92, 4, 64), (1, 5888, 92), torch.float32, "cpu", False)]
         args = [
@@ -80,7 +80,7 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
 
         y = torch.randn(4)
         x = torch.nn.Parameter(torch.randn(4))
-        aot_fn = torch._dynamo.optimize("aot_eager")(fn)
+        aot_fn = torch.compile(fn, backend="aot_eager")
         # This should not error: we mutated an autograd leaf under no_grad mode.
         aot_fn(x, y)
 
@@ -107,7 +107,7 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
 
         x = torch.randn(torch.Size([12, 4, 256, 513]))
         y = torch.randn(torch.Size([12, 3, 512, 513]))
-        aot_fn = torch._dynamo.optimize("aot_eager")(fn)
+        aot_fn = torch.compile(fn, backend="aot_eager")
         aot_fn(x, y)
 
     def test_negative_testing_mutation(self):
@@ -134,7 +134,7 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
 
         x = torch.randn(torch.Size([12, 4, 256, 513]))
         y = torch.randn(torch.Size([12, 3, 512, 513]))
-        aot_fn = torch._dynamo.optimize("aot_eager")(fn)
+        aot_fn = torch.compile(fn, backend="aot_eager")
         aot_fn(x, y)
 
     def test_negative_testing(self):
@@ -143,7 +143,7 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
 
         y = torch.randn(4)
         x = torch.randn(4)
-        aot_fn = torch._dynamo.optimize("aot_eager")(fn)
+        aot_fn = torch.compile(fn, backend="aot_eager")
         aot_fn(x, y)
 
     def test_call_fn_with_non_const_inputs_aot_safe(self):
@@ -173,7 +173,7 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
         # Run exported graph with AOT
         self.assertTrue(torch._dynamo.testing.same(real, graph(rx)))
 
-        aot_fn = torch._dynamo.optimize("aot_eager")(graph)
+        aot_fn = torch.compile(graph, backend="aot_eager")
         aot_fn(rx)
 
     def test_call_fn_with_non_const_inputs_aot_unsafe(self):
@@ -205,7 +205,7 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(torch._dynamo.testing.same(real, graph(x, y)))
 
         # Run exported graph with AOT
-        aot_fn = torch._dynamo.optimize("aot_eager")(graph)
+        aot_fn = torch.compile(graph, backend="aot_eager")
         # This should not error: we mutated an autograd leaf under no_grad mode.
         aot_fn(x, y)
 
@@ -240,7 +240,7 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
             gms.append(gm)
             return counter(gm, inputs)
 
-        optimized_mod = torch._dynamo.optimize(capturing_fn)(mod)
+        optimized_mod = torch.compile(mod, backend=capturing_fn)
 
         # Assert equal
         self.assertTrue(torch._dynamo.testing.same(real, optimized_mod(x, y)))
@@ -277,7 +277,7 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
         # Run fn with AOT
         torch._dynamo.reset()
 
-        aot_fn = torch._dynamo.optimize("aot_eager")(optimized_mod)
+        aot_fn = torch.compile(optimized_mod, backend="aot_eager")
         aot_fn(x, y)
 
     # Note: Dynamo recompilation guarding invalid grad
@@ -683,7 +683,7 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
             return b
 
         ref_output = fn()
-        aot_fn = torch._dynamo.optimize("aot_eager")(fn)
+        aot_fn = torch.compile(fn, backend="aot_eager")
         actual_output = aot_fn()
         self.assertEqual(ref_output, actual_output)
 
@@ -753,7 +753,7 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
             )
             return split_gm
 
-        @torch._dynamo.optimize(test_compile)
+        @torch.compile(backend=test_compile)
         def f(a):
             b, c = torch.ops.custom.maybe_dupe_op(a)
             return (b.mul_(c),)
@@ -770,7 +770,7 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
 
         x = torch.rand((4, 4))
 
-        opt_fn = torch._dynamo.optimize("aot_eager")(fn)
+        opt_fn = torch.compile(fn, backend="aot_eager")
         self.assertTrue(torch._dynamo.testing.same(fn(x), opt_fn(x)))
 
     def test_aot_sequence_nr(self):


### PR DESCRIPTION
``torch._dynamo.optimize()`` is wrapped for convenience by ``torch.compile()``.

related commits:

- #139706
- #140238
- #140247
- #140253

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames