### PR TITLE
Update ir_printer.cpp

### DIFF
--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -191,25 +191,26 @@ void IRPrinter::visit(const CompareSelectPtr& v) {
   withParens(v->ret_val2());
 }
 
-static void formatFPSuffix(std::ostream& os, double v) {
-  os << (v == std::ceil(v) ? ".0" : "");
+static void formatFPSuffix(std::ostream& os, double v, bool flag) {
+  os << (flag && v == std::ceil(v) ? ".0" : "");
 }
 
 template <typename T>
-static void formatFPSuffix(std::ostream& os, T v) {
-  os << (v == std::ceil(v) ? ".f" : "f");
+static void formatFPSuffix(std::ostream& os, T v, bool flag) {
+  os << (flag && v == std::ceil(v) ? ".f" : "f");
 }
 
 template <typename T, std::enable_if_t<std::is_floating_point_v<T>>* = nullptr>
 static void formatImm(std::ostream& os, T v) {
   const int precision = 16;
+  const T const_range[] = {std::static_cast<T>(-1e16), std::static_cast<T>(1e16)}
   if (std::isnan(v)) {
     os << "NAN";
   } else if (std::isinf(v)) {
     os << (v > 0 ? "POS_INFINITY" : "NEG_INFINITY");
   } else {
     os << std::setprecision(precision) << v;
-    formatFPSuffix(os, v);
+    formatFPSuffix(os, v, v > const_range[0] && v < const_range[1]);
   }
 }
 


### PR DESCRIPTION
when v larger than 1e16, the format will be error. example: v is 1.2e17, the output is 1.2e17.f, it have two '.'

Fixes #114035


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel