### PR TITLE
[Test][FSDP1] Skip test_dtensor_sharded_model_load_state_dict if Rocm

### DIFF
--- a/test/distributed/fsdp/test_fsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_dtensor_state_dict.py
@@ -18,6 +18,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    skipIfRocm,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
@@ -248,6 +249,7 @@ class TestFSDPWithDeviceMeshAndDTensor(DTensorTestBase):
                     self.assertEqual(type(v2), DTensor)
 
     @with_comms
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @parametrize("offload_to_cpu", [True, False])
     @parametrize("is_even_sharded_model", [True, False])


### PR DESCRIPTION
Test is failing on ROCm. 

```
PYTORCH_TEST_WITH_ROCM=1 python test/distributed/fsdp/test_fsdp_dtensor_state_dict.py TestFSDPWithDeviceMeshAndDTensor.test_dtensor_sharded_model_load_state_dict_offload_to_cpu_False_is_even_sharded_model_False
```

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd