### PR TITLE
Removing warning for Windows Arm64

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -228,7 +228,7 @@ if sys.platform == "win32":
         try:
             ctypes.CDLL("vcruntime140.dll")
             ctypes.CDLL("msvcp140.dll")
-            if(platform.machine() != "ARM64"):
+            if platform.machine() != "ARM64":
                 ctypes.CDLL("vcruntime140_1.dll")
         except OSError:
             print(

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -228,7 +228,8 @@ if sys.platform == "win32":
         try:
             ctypes.CDLL("vcruntime140.dll")
             ctypes.CDLL("msvcp140.dll")
-            ctypes.CDLL("vcruntime140_1.dll")
+            if(platform.machine() != "ARM64"):
+                ctypes.CDLL("vcruntime140_1.dll")
         except OSError:
             print(
                 textwrap.dedent(


### PR DESCRIPTION
This PR removes the warning message on Windows on Arm64, which was triggered by an issue in one of the DLLs, to improve the user experience.

`Microsoft Visual C++ Redistributable is not installed, this may lead to the DLL load failure.
                 It can be downloaded at https://aka.ms/vs/16/release/vc_redist.x64.exe`

The issue is being tracked here: https://developercommunity.visualstudio.com/t/VCRUNTIME140_1DLL-Miscompiled-for-Arm64/10781635?

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @Blackhex