### PR TITLE
Tests Generelization for multiple accelerator devices

### DIFF
--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -159,21 +159,20 @@ class DistConvolutionOpsTest(DTensorTestBase):
         bias_mse_abs = torch.mean(bias_diff_abs * bias_diff_abs).item()
         weight_mse_rel = torch.mean(weight_diff_rel * weight_diff_rel).item()
         bias_mse_rel = torch.mean(bias_diff_rel * bias_diff_rel).item()
-        abs_value = 1e-4 if TEST_HPU else 1e-6
         self.assertTrue(
-            weight_mse_abs <= (abs_value),
+            weight_mse_abs <= (1e-6),
             f"Too large absolute mse for weight tensor, expected less equal 1e-6, got {weight_mse_abs}",
         )
         self.assertTrue(
-            bias_mse_abs <= (abs_value),
+            bias_mse_abs <= (1e-6),
             f"Too large absolute mse for bias tensor, expected less equal 1e-6, got {bias_mse_abs}",
         )
         self.assertTrue(
-            weight_mse_rel <= (abs_value),
+            weight_mse_rel <= (1e-6),
             f"Too large relative mse for weight tensor, expected less equal 1e-6, got {weight_mse_rel}",
         )
         self.assertTrue(
-            bias_mse_rel <= (abs_value),
+            bias_mse_rel <= (1e-6),
             f"Too large relative mse for bias tensor, expected less equal 1e-6, got {bias_mse_rel}",
         )
 

--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -15,8 +15,10 @@ from torch.distributed._tensor import (
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
+    skip_if_lt_x_gpu,
     with_comms,
 )
+
 
 ITER_TIME = 10
 LR = 0.001
@@ -109,7 +111,10 @@ class DistConvolutionOpsTest(DTensorTestBase):
             f"Too large relative mse for bias tensor, expected less equal 1e-6, got {bias_mse_rel}",
         )
 
+    # TODO: test_depthwise_convolution is broken in CI with gloo backend.
+    # Temporarily disable it to unblock CI.
     @with_comms
+    @skip_if_lt_x_gpu(2)
     def test_depthwise_convolution(self):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         shard_spec = [Shard(3)]
@@ -160,23 +165,22 @@ class DistConvolutionOpsTest(DTensorTestBase):
         weight_mse_rel = torch.mean(weight_diff_rel * weight_diff_rel).item()
         bias_mse_rel = torch.mean(bias_diff_rel * bias_diff_rel).item()
         self.assertTrue(
-            weight_mse_abs <= (1e-6),
+            weight_mse_abs <= 1e-6,
             f"Too large absolute mse for weight tensor, expected less equal 1e-6, got {weight_mse_abs}",
         )
         self.assertTrue(
-            bias_mse_abs <= (1e-6),
+            bias_mse_abs <= 1e-6,
             f"Too large absolute mse for bias tensor, expected less equal 1e-6, got {bias_mse_abs}",
         )
         self.assertTrue(
-            weight_mse_rel <= (1e-6),
+            weight_mse_rel <= 1e-6,
             f"Too large relative mse for weight tensor, expected less equal 1e-6, got {weight_mse_rel}",
         )
         self.assertTrue(
-            bias_mse_rel <= (1e-6),
+            bias_mse_rel <= 1e-6,
             f"Too large relative mse for bias tensor, expected less equal 1e-6, got {bias_mse_rel}",
         )
 
 
 if __name__ == "__main__":
     run_tests()
-

--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -12,7 +12,7 @@ from torch.distributed._tensor import (
     Replicate,
     Shard,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_HPU
+from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,

--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -35,12 +35,14 @@ from torch.distributed.tensor.parallel import (
     RowwiseParallel,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import get_devtype
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
-    TEST_CUDA,
     skipIfTorchDynamo,
+    TEST_CUDA,
+    TEST_HPU,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
@@ -51,9 +53,10 @@ from torch.testing._internal.distributed.fake_pg import FakeStore
 from torch.testing._internal.inductor_utils import HAS_GPU
 from torch.testing._internal.two_tensor import TwoTensor
 from torch.utils.checkpoint import checkpoint
-from torch.testing._internal.common_fsdp import get_devtype
+
 
 dev_type = torch.device(get_devtype())
+
 
 class SimpleModel(nn.Module):
     def __init__(self, device):

--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -40,6 +40,8 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     skipIfTorchDynamo,
+    TEST_CUDA,
+    TEST_HPU,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
@@ -83,7 +85,8 @@ aot_eager_graph = aot_autograd(
     partition_fn=min_cut_rematerialization_partition,
 )
 
-
+device_type="hpu" if TEST_HPU else "cuda"
+@instantiate_parametrized_tests
 class TestDTensorCompile(torch._dynamo.test_case.TestCase):
     def setUp(self):
         super(
@@ -102,7 +105,7 @@ class TestDTensorCompile(torch._dynamo.test_case.TestCase):
 
     @property
     def device_type(self) -> str:
-        return "cuda" if torch.cuda.is_available() else "cpu"
+        return "cuda" if TEST_CUDA else "hpu" if TEST_HPU else "cpu"
 
     @property
     def world_size(self) -> int:
@@ -457,7 +460,8 @@ class TestDTensorCompile(torch._dynamo.test_case.TestCase):
         self.assertEqual(
             tmp_dt._local_tensor.stride(), tmp_dt_fake._local_tensor.stride()
         )
-
+    
+    @unittest.skipIf(TEST_HPU, "Inductor not supported on HPU")
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     def test_dtensor_contiguous_dtensor_noncontiguous_local_as_tangent(self):
         # Partial -> Shard on an unbalanced tensor results in:
@@ -534,6 +538,7 @@ class TestDTensorCompile(torch._dynamo.test_case.TestCase):
         out_test = opt_mod(dt)
         self.assertEqual(out_ref, out_test)
 
+    @unittest.skipIf(TEST_HPU, "Inductor not supported on HPU")
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     def test_dtensor_different_gradient_placement(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
@@ -892,7 +897,7 @@ class TestDTensorCompileE2E(DTensorTestBase):
 
         # 2-D mesh is [dp, tp]
         twod_mesh = init_device_mesh(
-            "cuda",
+            device_type,
             (data_parallel_size, self.world_size // data_parallel_size),
             mesh_dim_names=["dp", "tp"],
         )
@@ -905,9 +910,10 @@ class TestDTensorCompileE2E(DTensorTestBase):
             "mlp_1.net2": RowwiseParallel(),
         }
         tp_model = parallelize_module(model, twod_mesh["tp"], parallelize_plan)
+        device_id = "hpu:0" if TEST_HPU else self.rank
         eager_2d = FSDP(
             tp_model,
-            device_id=self.rank,
+            device_id=device_id,
             use_orig_params=True,
             device_mesh=twod_mesh["dp"],
         )
@@ -919,7 +925,7 @@ class TestDTensorCompileE2E(DTensorTestBase):
         )
         fsdp_2d = FSDP(
             tp_model2,
-            device_id=self.rank,
+            device_id=device_id,
             use_orig_params=True,
             device_mesh=twod_mesh["dp"],
         )
@@ -942,7 +948,7 @@ class TestDTensorCompileE2E(DTensorTestBase):
 
         # 2-D mesh is [dp, tp]
         mesh_2d = init_device_mesh(
-            "cuda", mesh_shape=(dp_degree, tp_degree), mesh_dim_names=("dp", "tp")
+            device_type, mesh_shape=(dp_degree, tp_degree), mesh_dim_names=("dp", "tp")
         )
 
         inp = torch.rand(20, 10, device=self.device_type)
@@ -986,7 +992,7 @@ class TestDTensorCompileE2E(DTensorTestBase):
     @with_comms
     @skip_if_lt_x_gpu(4)
     def test_compile_dtensor_redistribute_backward(self):
-        mesh = DeviceMesh(device_type="cuda", mesh=torch.arange(self.world_size))
+        mesh = DeviceMesh(device_type=device_type, mesh=torch.arange(self.world_size))
 
         def fn(x, y):
             dt = DTensor.from_local(x.reshape(2, 4), mesh, [Shard(0)], run_check=False)

--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -11,6 +11,7 @@ from torch.distributed._tensor._utils import compute_local_shape_and_global_offs
 from torch.distributed._tensor.api import distribute_tensor
 from torch.distributed._tensor.placement_types import Replicate, Shard
 from torch.distributed.distributed_c10d import broadcast_object_list
+<<<<<<< HEAD:test/distributed/tensor/test_random_ops.py
 from torch.distributed.fsdp import fully_shard
 from torch.distributed.tensor._random import (
     is_rng_supported_mesh,
@@ -19,7 +20,7 @@ from torch.distributed.tensor._random import (
 )
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.parallel import ColwiseParallel, parallelize_module
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import run_tests, TEST_HPU
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     skip_if_lt_x_gpu,
@@ -27,6 +28,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     with_comms,
 )
 
+TYPE_DEVICE = "hpu" if TEST_HPU else "cuda"
 
 class DistTensorRandomInitTest(DTensorTestBase):
     def _run_init_op(self, init_op, *args, **kwargs):
@@ -47,7 +49,7 @@ class DistTensorRandomInitTest(DTensorTestBase):
             self.assertEqual(local_tensor_clone, dtensor.to_local())
         else:
             # create DTensor from Tensor
-            _tensor = torch.empty(*input_size, device="cuda")
+            _tensor = torch.empty(*input_size, device=TYPE_DEVICE)
             dtensor = distribute_tensor(_tensor, device_mesh, [Shard(1)])
 
             # DTensor random init
@@ -242,15 +244,15 @@ class DistTensorRandomOpTest(DTensorTestBase):
     @with_comms
     @skip_unless_torch_gpu
     def test_rng_tracker_init(self):
-        torch.cuda.manual_seed(self.rank)
-        object_list = [torch.cuda.initial_seed()]
+        torch.manual_seed(self.rank)
+        object_list = [torch.initial_seed()]
         broadcast_object_list(object_list)
         seed_from_rank_0 = int(object_list[0])
 
         device_mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
         # seed synchronization happens after the first `distribute_tensor` call
         distribute_tensor(
-            torch.empty([self.world_size], device="cuda"), device_mesh, [Shard(0)]
+            torch.empty([self.world_size], device=TYPE_DEVICE), device_mesh, [Shard(0)]
         )
         self.assertEqual(seed_from_rank_0, random._rng_tracker.get_seed("parallel-rng"))
 
@@ -340,13 +342,13 @@ class DistTensorRandomOpTest(DTensorTestBase):
         # execution the default random seed will be different (a random value).
         # The DTensor random ops will use the same random seed even though the
         # torch random generator keeps different seeds on ranks.
-        torch.cuda.manual_seed(self.rank)
+        torch.manual_seed(self.rank)
         # TODO: add test before/after enabling distribute region
         device_mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
         size = [4, 4]
 
         dtensor = distribute_tensor(
-            torch.empty(*size, device="cuda"), device_mesh, [Shard(1)]
+            torch.empty(*size, device=TYPE_DEVICE), device_mesh, [Shard(1)]
         )
 
         # a random op call shifts the offset
@@ -400,7 +402,7 @@ class DistTensorRandomOpTest(DTensorTestBase):
                         local_tensor[other_slice, :],
                     )
 
-            torch.cuda.manual_seed(self.rank)
+            torch.manual_seed(self.rank)
             dtensor = fn(size, device_mesh=device_mesh, placements=[Replicate()])
             local_tensor = funcol.all_gather_tensor(
                 dtensor.to_local(), gather_dim=0, group=(device_mesh, 0)

--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -11,7 +11,6 @@ from torch.distributed._tensor._utils import compute_local_shape_and_global_offs
 from torch.distributed._tensor.api import distribute_tensor
 from torch.distributed._tensor.placement_types import Replicate, Shard
 from torch.distributed.distributed_c10d import broadcast_object_list
-<<<<<<< HEAD:test/distributed/tensor/test_random_ops.py
 from torch.distributed.fsdp import fully_shard
 from torch.distributed.tensor._random import (
     is_rng_supported_mesh,
@@ -28,7 +27,9 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     with_comms,
 )
 
+
 TYPE_DEVICE = "hpu" if TEST_HPU else "cuda"
+
 
 class DistTensorRandomInitTest(DTensorTestBase):
     def _run_init_op(self, init_op, *args, **kwargs):

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -9,7 +9,7 @@ from torch.distributed._tensor.placement_types import Partial, Replicate, Shard
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor._collective_utils import shard_dim_alltoall
 from torch.distributed.tensor.debug import CommDebugMode
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import run_tests, TEST_CUDA, TEST_HPU
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
@@ -366,7 +366,7 @@ class RedistributeTest(DTensorTestBase):
                 local_out_dt = out_dt.to_local()
                 local_expected_dt = expected_dt.to_local()
                 self.assertEqual(out_dt.to_local(), expected_dt.to_local())
-                if self.device_type == "cuda" or self.device_type == "hpu":
+                if TEST_HPU or TEST_CUDA:
                     self.assertEqual(
                         comm_mode.get_comm_counts()[
                             torch.ops._dtensor.shard_dim_alltoall

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -366,7 +366,7 @@ class RedistributeTest(DTensorTestBase):
                 local_out_dt = out_dt.to_local()
                 local_expected_dt = expected_dt.to_local()
                 self.assertEqual(out_dt.to_local(), expected_dt.to_local())
-                if self.device_type == "cuda":
+                if self.device_type == "cuda" or self.device_type == "hpu":
                     self.assertEqual(
                         comm_mode.get_comm_counts()[
                             torch.ops._dtensor.shard_dim_alltoall

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -348,9 +348,6 @@ class DTensorTestBase(MultiProcessTestCase):
         # For nccl backend, bind the device to the process if device_id is not None
         # so the nccl communicator is immediately formed and we can use `ncclCommSplit`
         # for form subgroup to avoid unnecesssary overhead.
-        if TEST_HPU:
-            import habana_frameworks.torch.distributed.hccl as hccl
-            hccl.initialize_distributed_hpu(self.world_size, self.rank, self.rank)
         dist.init_process_group(
             backend=self.backend,
             world_size=self.world_size,

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -325,7 +325,8 @@ class DTensorTestBase(MultiProcessTestCase):
 
     @property
     def backend(self) -> str:
-        return PG_BACKEND
+        backend = "nccl" if TEST_CUDA else "hccl" if TEST_HPU else "gloo"
+        return backend
 
     def build_device_mesh(self) -> DeviceMesh:
         return DeviceMesh(self.device_type, list(range(self.world_size)))

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -325,7 +325,7 @@ class DTensorTestBase(MultiProcessTestCase):
 
     @property
     def backend(self) -> str:
-        backend = "nccl" if TEST_CUDA else "gloo"
+        backend = "nccl" if TEST_CUDA else "hccl" if TEST_HPU else "gloo"
         return backend
 
     def build_device_mesh(self) -> DeviceMesh:

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -325,7 +325,7 @@ class DTensorTestBase(MultiProcessTestCase):
 
     @property
     def backend(self) -> str:
-        backend = "nccl" if TEST_CUDA else "hccl" if TEST_HPU else "gloo"
+        backend = "nccl" if TEST_CUDA else "gloo"
         return backend
 
     def build_device_mesh(self) -> DeviceMesh:

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -323,6 +323,10 @@ class DTensorTestBase(MultiProcessTestCase):
     def world_size(self) -> int:
         return NUM_DEVICES
 
+    @property
+    def backend(self) -> str:
+        return PG_BACKEND
+
     def build_device_mesh(self) -> DeviceMesh:
         return DeviceMesh(self.device_type, list(range(self.world_size)))
 

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -332,14 +332,14 @@ class DTensorTestBase(MultiProcessTestCase):
         return DeviceMesh(self.device_type, list(range(self.world_size)))
 
     def init_pg(self, eager_init) -> None:
-        if "nccl" in PG_BACKEND and DEVICE_COUNT < self.world_size:
+        if "nccl" in self.backend and DEVICE_COUNT < self.world_size:
             sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
 
-        if PG_BACKEND not in ["nccl", "gloo", "mpi", "cpu:gloo,cuda:nccl", "hccl"]:
-            raise RuntimeError(f"Backend {PG_BACKEND} not supported!")
+        if self.backend not in ["nccl", "gloo", "mpi", "cpu:gloo,cuda:nccl", "hccl"]:
+            raise RuntimeError(f"Backend {self.backend} not supported!")
 
         device_id = None
-        if "nccl" in PG_BACKEND:
+        if "nccl" in self.backend:
             # set device for nccl pg for collectives
             torch.cuda.set_device(self.rank)
             # we only need to set device_id for nccl backend with eager init
@@ -348,7 +348,7 @@ class DTensorTestBase(MultiProcessTestCase):
         # so the nccl communicator is immediately formed and we can use `ncclCommSplit`
         # for form subgroup to avoid unnecesssary overhead.
         dist.init_process_group(
-            backend=PG_BACKEND,
+            backend=self.backend,
             world_size=self.world_size,
             rank=self.rank,  # pyre-ignore[16]
             init_method=f"file://{self.file_name}",  # pyre-ignore[16]

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -332,11 +332,7 @@ class DTensorTestBase(MultiProcessTestCase):
         return DeviceMesh(self.device_type, list(range(self.world_size)))
 
     def init_pg(self, eager_init) -> None:
-        DEVICE_COUNT = _get_device_module(DEVICE_TYPE).device_count()
-        if "nccl" in self.backend and DEVICE_COUNT < self.world_size:
-            sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
-
-        if "hccl" in self.backend and DEVICE_COUNT < self.world_size:
+        if "nccl" in self.backend and torch.cuda.device_count() < self.world_size:
             sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
 
         if self.backend not in ["nccl", "gloo", "mpi", "cpu:gloo,cuda:nccl", "hccl"]:
@@ -398,9 +394,8 @@ def with_comms(eager_init: Union[TestFunc, bool] = False) -> TestFunc:
         def wrapper(
             self, *args: Tuple[object], **kwargs: Dict[str, Any]  # type: ignore[misc]
         ) -> None:
-            DEVICE_COUNT = _get_device_module(DEVICE_TYPE).device_count()
             # if enough GPU we can use GPU, otherwise we fallback to CPU
-            if not TEST_CUDA or not TEST_HPU or DEVICE_COUNT < self.world_size:
+            if not TEST_CUDA or torch.cuda.device_count() < self.world_size:
                 self.device_type = "cpu"
             else:
                 self.device_type = DEVICE_TYPE


### PR DESCRIPTION
Motivation: Generalize unit tests so that can be executed for cuda and non cuda devices.
Chnages: There are general changes in common_dtesnor module for device type generalization so that tests can be executed on non cuda devices too.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o