### PR TITLE
Add support for loading model `state_dict()`in C++ which are OrderedDicts

### DIFF
--- a/test/cpp/jit/tests_setup.py
+++ b/test/cpp/jit/tests_setup.py
@@ -51,6 +51,17 @@ class SerializationInterop(FileSetup):
         torch.save(value, self.path, _use_new_zipfile_serialization=True)
 
 
+class StateDictSerializationInterop(FileSetup):
+    path = "state_dict.pt"
+
+    def setup(self):
+        model = torch.nn.Linear(10, 10)
+        torch.nn.init.constant_(model.weight, 2.0)
+        torch.nn.init.constant_(model.bias, 3.0)
+
+        torch.save(model.state_dict(), self.path, _use_new_zipfile_serialization=True)
+
+
 # See testTorchSaveError in test/cpp/jit/tests.h for usage
 class TorchSaveError(FileSetup):
     path = "eager_value.pt"
@@ -95,6 +106,7 @@ class TorchSaveJitStream_CUDA(FileSetup):
 tests = [
     EvalModeForLoadedModule(),
     SerializationInterop(),
+    StateDictSerializationInterop(),
     TorchSaveError(),
     TorchSaveJitStream_CUDA(),
 ]

--- a/test/cpp/jit/torch_python_test.cpp
+++ b/test/cpp/jit/torch_python_test.cpp
@@ -2,6 +2,7 @@
 #include <c10/util/Exception.h>
 #include <torch/csrc/Export.h>
 #include <torch/csrc/jit/api/module.h>
+#include <torch/csrc/jit/serialization/import_read.h>
 #include <torch/script.h>
 
 namespace torch {
@@ -33,6 +34,36 @@ void testEvalModeForLoadedModule() {
   module.train();
   AT_ASSERT(module.attr("dropout").toModule().is_training());
 }
+
+void testLoadStateDict() {
+  if (isSandcastle())
+    return; // The module file to load is not generated in Sandcastle
+  
+   // Requires the state_dict that should have been written in tests_setup.py
+   // Refer: StateDictSerializationInterop in test/cpp/jit/tests_setup.py
+   caffe2::serialize::PyTorchStreamReader reader("state_dict.pt");
+   auto dict = torch::jit::readArchiveAndTensors(
+      "data",
+      /*pickle_prefix=*/"",
+      /*tensor_prefix=*/"",
+      /*type_resolver=*/c10::nullopt,
+      /*obj_loader=*/c10::nullopt,
+      /*device=*/c10::nullopt,
+      reader
+    );
+
+   for (auto& el : dict.toGenericDict()) {
+     auto key = el.key().toStringRef();
+     auto ten = el.value().toTensor();
+     if (key == "weight") {
+       AT_ASSERT(ten.eq(2.0).all().item().toBool());
+     } else if (key == "bias") {
+       AT_ASSERT(ten.eq(3.0).all().item().toBool());
+     } else {
+       AT_ASSERT(false);
+     }
+   }
+ }
 
 // TODO: this test never ran before and is broken.
 // void testSerializationInterop() {
@@ -82,6 +113,7 @@ JIT_TEST_API void runJITCPPTests() {
   // testSerializationInterop();
   testEvalModeForLoadedModule();
   testTorchSaveError();
+  testLoadStateDict();
 }
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/torch_python_test.cpp
+++ b/test/cpp/jit/torch_python_test.cpp
@@ -38,32 +38,31 @@ void testEvalModeForLoadedModule() {
 void testLoadStateDict() {
   if (isSandcastle())
     return; // The module file to load is not generated in Sandcastle
-  
-   // Requires the state_dict that should have been written in tests_setup.py
-   // Refer: StateDictSerializationInterop in test/cpp/jit/tests_setup.py
-   caffe2::serialize::PyTorchStreamReader reader("state_dict.pt");
-   auto dict = torch::jit::readArchiveAndTensors(
+
+  // Requires the state_dict that should have been written in tests_setup.py
+  // Refer: StateDictSerializationInterop in test/cpp/jit/tests_setup.py
+  caffe2::serialize::PyTorchStreamReader reader("state_dict.pt");
+  auto dict = torch::jit::readArchiveAndTensors(
       "data",
       /*pickle_prefix=*/"",
       /*tensor_prefix=*/"",
       /*type_resolver=*/c10::nullopt,
       /*obj_loader=*/c10::nullopt,
       /*device=*/c10::nullopt,
-      reader
-    );
+      reader);
 
-   for (auto& el : dict.toGenericDict()) {
-     auto key = el.key().toStringRef();
-     auto ten = el.value().toTensor();
-     if (key == "weight") {
-       AT_ASSERT(ten.eq(2.0).all().item().toBool());
-     } else if (key == "bias") {
-       AT_ASSERT(ten.eq(3.0).all().item().toBool());
-     } else {
-       AT_ASSERT(false);
-     }
-   }
- }
+  for (auto& el : dict.toGenericDict()) {
+    auto key = el.key().toStringRef();
+    auto ten = el.value().toTensor();
+    if (key == "weight") {
+      AT_ASSERT(ten.eq(2.0).all().item().toBool());
+    } else if (key == "bias") {
+      AT_ASSERT(ten.eq(3.0).all().item().toBool());
+    } else {
+      AT_ASSERT(false);
+    }
+  }
+}
 
 // TODO: this test never ran before and is broken.
 // void testSerializationInterop() {

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -555,7 +555,6 @@ PickleOpCode Unpickler::readInstruction() {
           stack_.size(),
           " elements, at least 2 expected");
 
-
       // In the OrderedDict case, the id has already been materialized
       // and added to the stack, thus there's no <functor_idx> but a Dict
       // there, in this case we can just pop the functor args and break.
@@ -565,7 +564,7 @@ PickleOpCode Unpickler::readInstruction() {
         stack_.pop_back();
         break;
       }
-      
+
       std::swap(*(stack_.end() - 2), *(stack_.end() - 1));
       size_t idx = stack_.back().toInt();
       stack_.pop_back();

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -554,6 +554,18 @@ PickleOpCode Unpickler::readInstruction() {
           "Parsing error: stack_ contains ",
           stack_.size(),
           " elements, at least 2 expected");
+
+
+      // In the OrderedDict case, the id has already been materialized
+      // and added to the stack, thus there's no <functor_idx> but a Dict
+      // there, in this case we can just pop the functor args and break.
+      // The functor args in this case contain some other metadata like
+      // '{_metadata: {: {version: 1}}}' which seem to be safe to ignore.
+      if (stack_.at(stack_.size() - 2).isGenericDict()) {
+        stack_.pop_back();
+        break;
+      }
+      
       std::swap(*(stack_.end() - 2), *(stack_.end() - 1));
       size_t idx = stack_.back().toInt();
       stack_.pop_back();
@@ -801,11 +813,12 @@ void Unpickler::readGlobal(
   } else if (module_name == "collections" && class_name == "OrderedDict") {
     // collections.OrderedDict is used in tensor serialization for a tensor's
     // backward hooks (but they are not actually saved with this Pickler)
+    // Python's model.state_dict() is an OrderedDict, but this is not used
+    // for model loading.
     globals_.emplace_back([this] {
-      // drop the Tuple that was argument to OrderedDict, and replace it
-      // with None OrderedDicts only appear in tensor deserialization and
-      // their value is never used
-      stack_.back() = IValue();
+      // The OrderedDict becomes a GenericDict. The inputs which are in
+      // stack.back() are fully ignored, but they are empty anyways.
+      stack_.back() = c10::impl::GenericDict(AnyType::get(), AnyType::get());
     });
   } else if (module_name == "torch" && class_name == "device") {
     globals_.emplace_back([this] {


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/100741 and some others similar problems:
https://github.com/pytorch/pytorch/issues/67902, https://github.com/pytorch/pytorch/issues/37213, https://github.com/pytorch/pytorch/issues/36577 and https://github.com/pytorch/pytorch/issues/95362

This is a very common problem for bindings to libtorch that use `pickle_load` to read model state dicts. See also:
https://github.com/ankane/torch.rb/issues/21 and https://github.com/LaurentMazare/tch-rs/issues/595

This PR is retrying to merge: https://github.com/pytorch/pytorch/pull/101118
Which was eventually merged but got reverted due to errors in the internal builds. I fixed the issue by moving the test case to the correct place.









cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel