### PR TITLE
Add current FSDP2 path to old composable FSDP1 warning

### DIFF
--- a/torch/distributed/_composable/fully_shard.py
+++ b/torch/distributed/_composable/fully_shard.py
@@ -42,7 +42,8 @@ from torch.distributed.fsdp.wrap import _Policy
     "`torch.distributed._composable.fully_shard` is being deprecated. "
     "You can continue to use the wrapper based FSDP. "
     "See usage in: https://github.com/pytorch/pytorch/blob/main/torch/distributed/fsdp/fully_sharded_data_parallel.py. "
-    "`torch.distributed._composable.fully_shard` will be removed after PyTorch 2.5.",
+    "`torch.distributed._composable.fully_shard` will be removed after PyTorch 2.5. "
+    "If you are looking for FSDP2, please see `torch.distributed._composable.fsdp.fully_shard.`",
     category=FutureWarning,
 )
 def fully_shard(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139759
* #139650



cc @H-Huang @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o