### PR TITLE
[POC] ROI instrumentation (eager vs compile speedup)

### DIFF
--- a/torch/csrc/dynamo/cpp_shim.cpp
+++ b/torch/csrc/dynamo/cpp_shim.cpp
@@ -1,12 +1,113 @@
+#include <cuda_runtime.h>
+#include <vector>
+#include <utility>
+
 #include <torch/csrc/dynamo/cpp_shim.h>
 
 #include <ATen/record_function.h>
+
+// TODO: thread safety
+class CUDATimingQueue {
+private:
+  struct EventPair {
+    cudaEvent_t start;
+    cudaEvent_t end;
+
+    EventPair() {
+      cudaEventCreate(&start);
+      cudaEventCreate(&end);
+    }
+
+    ~EventPair() {
+      cudaEventDestroy(start);
+      cudaEventDestroy(end);
+    }
+  };
+
+  // Remember: indices point between elements.
+  // https://blog.nelhage.com/2015/08/indices-point-between-elements/
+  //
+  //     -- len --
+  // O O X X X X X P O
+  //    ^- front  ^- back
+  //
+  // NB: we don't advance end pointer until recordEnd, so end is a valid
+  // pointer to the in progress cuda event pair
+
+  std::vector<EventPair> event_pool_;
+  // The queue is defined as the oldest events being in FRONT of the queue,
+  // and the new events we're adding in the BACK of the queue.
+  // Perhaps counter-intuitively, the back of the queue is a larger index if
+  // we haven't wrapped around.
+  // NB: do not test front_ == back_, you cannot distinguish full/empty.
+  size_t front_ = 0; // event_pool[front] is the next event to check for completion, UNLESS len == 0
+  size_t back_ = 0; // event_pool[back] is the next free element, UNLESS len == event_pool.size()
+  size_t len_ = 0;
+  size_t nesting_ = 0; // TODO: TLS
+
+public:
+  CUDATimingQueue(size_t pool_size = 10) {
+    event_pool_.resize(pool_size);
+  }
+
+  ~CUDATimingQueue() = default;
+
+  void recordStart() {
+    nesting_++;
+    if (nesting_ != 1) {
+      return;
+    }
+    // Put the new event in the back of the queue
+    TORCH_INTERNAL_ASSERT(len_ != event_pool_.size());
+    cudaEventRecord(event_pool_[back_].start);
+  }
+
+  void recordEnd() {
+    nesting_--;
+    if (nesting_ != 0) {
+      return;
+    }
+    cudaEventRecord(event_pool_[back_].end);
+    // NOW advance the pointer
+    back_ = (back_ + 1) % event_pool_.size();
+    len_++;
+
+    while (len_ > 0) {
+      // Try to complete events
+      cudaError_t status = cudaEventQuery(event_pool_[front_].end);
+      if (status != cudaSuccess) break;
+      float milliseconds;
+      cudaEventElapsedTime(&milliseconds,
+                 event_pool_[front_].start,
+                 event_pool_[front_].end);
+      std::cerr << "timing: " << milliseconds << "ms\n";
+      front_ = (front_ + 1) % event_pool_.size();
+      len_--;
+    }
+  }
+};
 
 struct _PytorchRecordFunctionState {
   at::RecordFunction guard;
 
   _PytorchRecordFunctionState() : guard(at::RecordScope::FUNCTION) {}
 };
+
+// Leak it!
+static CUDATimingQueue* queue = nullptr;
+
+void _compiled_region_enter() {
+  // TODO: thread safety
+  if (queue == nullptr) {
+    queue = new CUDATimingQueue();
+  }
+  queue->recordStart();
+}
+
+void _compiled_region_exit() {
+  TORCH_INTERNAL_ASSERT(queue);
+  queue->recordEnd();
+}
 
 _PytorchRecordFunctionState* _pytorch_record_function_enter(const char* name) {
   _PytorchRecordFunctionState* state = new _PytorchRecordFunctionState();

--- a/torch/csrc/dynamo/cpp_shim.h
+++ b/torch/csrc/dynamo/cpp_shim.h
@@ -10,6 +10,9 @@ typedef struct _PytorchRecordFunctionState _PytorchRecordFunctionState;
 _PytorchRecordFunctionState* _pytorch_record_function_enter(const char* name);
 void _pytorch_record_function_exit(_PytorchRecordFunctionState* state);
 
+void _compiled_region_enter();
+void _compiled_region_exit();
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -887,6 +887,16 @@ static PyObject* raise_sigtrap(PyObject* dummy, PyObject* obj) {
   Py_RETURN_NONE;
 }
 
+static PyObject* compiled_region_enter(PyObject* dummy, PyObject* obj) {
+  _compiled_region_enter();
+  Py_RETURN_NONE;
+}
+
+static PyObject* compiled_region_exit(PyObject* dummy, PyObject* obj) {
+  _compiled_region_exit();
+  Py_RETURN_NONE;
+}
+
 static PyMethodDef _methods[] = {
     {"set_eval_frame", set_eval_frame_py, METH_O, NULL},
     {"get_eval_frame_callback", get_eval_frame_callback_py, METH_NOARGS, NULL},
@@ -895,6 +905,8 @@ static PyMethodDef _methods[] = {
     {"skip_code", skip_code, METH_O, NULL},
     {"set_guard_error_hook", set_guard_error_hook, METH_O, NULL},
     {"raise_sigtrap", raise_sigtrap, METH_NOARGS, NULL},
+    {"compiled_region_enter", compiled_region_enter, METH_NOARGS, NULL},
+    {"compiled_region_exit", compiled_region_exit, METH_NOARGS, NULL},
     {NULL, NULL, 0, NULL}};
 
 static struct PyModuleDef _module = {

--- a/ts.py
+++ b/ts.py
@@ -1,0 +1,12 @@
+import torch
+
+@torch.compile()
+def f(x, y):
+    return x + y
+
+torch.compiler.set_stance('force_eager')
+for i in range(20):
+    print("iter", i)
+    if i == 5:
+        torch.compiler.set_stance('default')
+    f(torch.randn(3000, device='cuda'), torch.randn(3000, device='cuda'))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139765

The basic idea is we setup a CUDA event when we enter a torch.compile function, and a CUDA event when we exit, and then we can use to compute how long we spent running the function on CUDA. When combined with `set_stance`, you can easily compare the eager and compiled versions of code and see how much faster/slower they went.

Sample log: https://gist.github.com/ezyang/3659b9236d1232af827e7d2e3c020b75

What's missing:
* We need to actually log these timings to somewhere not stderr (this will also distort overhead measurement FYI)
* Need to record the active stance so I can distinguish eager from compile timings
* I need a unique identifier per torch.compile region so I can correlate related eager/compile runs. There may potentially be sample variation if the workloads to compile vary so you may also need to record extra information to distinguish these situations.
  * The begin/end of the cuda events doesn't have to be in torch.compile. It can potentially be hoisted all the way out to the top level trainer loop. This would eliminate the need for a unique identifier.
* I noticed that we are actually entering the compiled region "twice" for some reason. Some overhead here could be optimized
* The code is hella not thread safe, need to work on that
* Send this to Kineto team and have them evaluate whether or not this should be done in Kineto or not. If you do decide to do it in Kineto, you had better do a head-to-head overhead comparison
* Need to handle CPU case
* Need to handle what to do when CUDA not available (virtual call maybe?)
* Do more experiments sizing the cuda event queue; also handle what should happen when you run out of events
* Larger scale experiments on full models
* Measure overhead of the CUDA events
* This implementation loses events that happen at the very end of the program
* There's no way to turn off this instrumentation once you've collected enough samples
* Have a breaker to make sure we only run this every N seconds/milliseconds so that if a torch.compile region is really quick we don't bomb its performance
* Consider batching event processing more (don't process after every iteration); downside is you need more cuda events to do it this way. Hybrid strategy also ok: discharge cuda events at line speed, but upload/report more periodically.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames