### PR TITLE
[Workspace Inductor] Fix dynamic shapes

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -689,8 +689,8 @@ class TritonBenchmarkRequest(BenchmarkRequest):
                 run_method(
                     *input_tensors,
                     output_tensor,
-                    workspace_tensor,
                     *extra_args,
+                    workspace_tensor,
                     grid=self.grid,
                     **warmup_arg,
                     stream=stream,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #139542
* #138536
* __->__ #139777

# Summary
Arg ordering was wrong for when dynamic shapes is enabled and we pass in the additional size args


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov