### PR TITLE
Fix for T206766523 ("Your diff, D65462767, broke some tests")

### DIFF
--- a/torch/distributed/c10d_logger.py
+++ b/torch/distributed/c10d_logger.py
@@ -53,7 +53,6 @@ def _get_msg_dict(func_name, *args, **kwargs) -> Dict[str, Any]:
         group = kwargs.get("group") or kwargs.get("process_group")
         msg_dict = {
             "func_name": f"{func_name}",
-            "args": f"{args}, {kwargs}",
             "pg_name": f"{dist._get_process_group_name(kwargs.get('pg'))}",  # type: ignore[arg-type]
             "backend": f"{dist.get_backend(group)}",
             "world_size": f"{dist.get_world_size()}",
@@ -67,7 +66,6 @@ def _get_msg_dict(func_name, *args, **kwargs) -> Dict[str, Any]:
     else:
         msg_dict = {
             "func_name": f"{func_name}",
-            "args": f"{args}, {kwargs}",
         }
     return msg_dict
 


### PR DESCRIPTION
Summary:
This is trying to fix a regression caused by https://github.com/pytorch/pytorch/pull/139757. We now don't want to log args and kwargs directly because if they contain tensor or tensor subclass it would take lots of time in conversion to string or even not supported. 

Reviewed By: fduwjj

Differential Revision: D65490202




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @wz337 @wconstab @d4l3k @c-p-i-o