### PR TITLE
[fr][c10d] move logger out from utils.py

### DIFF
--- a/tools/flight_recorder/components/builder.py
+++ b/tools/flight_recorder/components/builder.py
@@ -9,6 +9,7 @@ import ast
 import sys
 from typing import Any, Dict, List, Set, Tuple  # type: ignore[attr-defined]
 
+from tools.flight_recorder.components.fr_logger import FlightRecorderLogger
 from tools.flight_recorder.components.types import (
     Collective,
     Database,
@@ -25,7 +26,6 @@ from tools.flight_recorder.components.utils import (
     check_size_alltoall,
     check_version,
     find_coalesced_group,
-    FlightRecorderLogger,
     format_frames,
     get_version_detail,
     just_print_entries,

--- a/tools/flight_recorder/components/config_manager.py
+++ b/tools/flight_recorder/components/config_manager.py
@@ -8,10 +8,10 @@ import argparse
 import logging
 from typing import Optional, Sequence
 
-from tools.flight_recorder.components.utils import FlightRecorderLogger
+from tools.flight_recorder.components.fr_logger import FlightRecorderLogger
 
 
-logger = FlightRecorderLogger()
+logger: FlightRecorderLogger = FlightRecorderLogger()
 
 
 class JobConfig:

--- a/tools/flight_recorder/components/fr_logger.py
+++ b/tools/flight_recorder/components/fr_logger.py
@@ -1,0 +1,50 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+from typing import Any, Callable, Optional
+
+
+class FlightRecorderLogger:
+    _instance: Optional[Any] = None
+    logger: logging.Logger
+
+    def __init__(self) -> None:
+        self.logger: logging.Logger = logging.getLogger("Flight Recorder")
+
+    def __new__(cls) -> Any:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance.logger = logging.getLogger("Flight Recorder")
+            cls._instance.logger.setLevel(logging.INFO)
+            formatter = logging.Formatter("%(message)s")
+            ch = logging.StreamHandler()
+            ch.setFormatter(formatter)
+            cls._instance.logger.addHandler(ch)
+        return cls._instance
+
+    def set_log_level(self, level: int) -> None:
+        self.logger.setLevel(level)
+
+    @property
+    def debug(self) -> Callable[..., None]:
+        return self.logger.debug
+
+    @property
+    def info(self) -> Callable[..., None]:
+        return self.logger.info
+
+    @property
+    def warning(self) -> Callable[..., None]:
+        return self.logger.warning
+
+    @property
+    def error(self) -> Callable[..., None]:
+        return self.logger.error
+
+    @property
+    def critical(self) -> Callable[..., None]:
+        return self.logger.critical

--- a/tools/flight_recorder/components/loader.py
+++ b/tools/flight_recorder/components/loader.py
@@ -13,7 +13,7 @@ import typing
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
-from tools.flight_recorder.components.utils import FlightRecorderLogger
+from tools.flight_recorder.components.fr_logger import FlightRecorderLogger
 
 
 logger: FlightRecorderLogger = FlightRecorderLogger()

--- a/tools/flight_recorder/components/utils.py
+++ b/tools/flight_recorder/components/utils.py
@@ -5,56 +5,20 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
-import logging
 import math
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
-from .types import Group, MatchState, Membership, Op, P2P
-
-
-class FlightRecorderLogger:
-    _instance: Optional[Any] = None
-    logger: logging.Logger
-
-    def __init__(self) -> None:
-        self.logger: logging.Logger = logging.getLogger("Flight Recorder")
-
-    def __new__(cls) -> Any:
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-            cls._instance.logger = logging.getLogger("Flight Recorder")
-            cls._instance.logger.setLevel(logging.INFO)
-            formatter = logging.Formatter("%(message)s")
-            ch = logging.StreamHandler()
-            ch.setFormatter(formatter)
-            cls._instance.logger.addHandler(ch)
-        return cls._instance
-
-    def set_log_level(self, level: int) -> None:
-        self.logger.setLevel(level)
-
-    @property
-    def debug(self) -> Callable[..., None]:
-        return self.logger.debug
-
-    @property
-    def info(self) -> Callable[..., None]:
-        return self.logger.info
-
-    @property
-    def warning(self) -> Callable[..., None]:
-        return self.logger.warning
-
-    @property
-    def error(self) -> Callable[..., None]:
-        return self.logger.error
-
-    @property
-    def critical(self) -> Callable[..., None]:
-        return self.logger.critical
+from tools.flight_recorder.components.fr_logger import FlightRecorderLogger
+from tools.flight_recorder.components.types import (
+    Group,
+    MatchState,
+    Membership,
+    Op,
+    P2P,
+)
 
 
-logger = FlightRecorderLogger()
+logger: FlightRecorderLogger = FlightRecorderLogger()
 
 
 try:


### PR DESCRIPTION
Summary:
Move flight recorder logger class out from utils.py into its own file.
This makes the program more modular.
This is mostly a refactoring/non-functional change.

Test Plan:
Build fr_trace locally and ran it.
```
buck build //caffe2/fb/flight_recorder:fr_trace
Buck UI: https://www.internalfb.com/buck2/875ca6a3-e86e-4263-95a0-579502494c5c
Network: Up: 0B  Down: 0B
Jobs completed: 6818. Time elapsed: 0.2s.
BUILD SUCCEEDED
```
Ran it as follows:
```
cd buck-out/v2/gen/fbcode/caffe2/fb/flight_recorder

./fr_trace.par  -p trace_ /tmp
Not all ranks joining collective 3 at entry 2
group info: 0:default_pg
collective: nccl:all_reduce
missing ranks: {1}
input sizes: [[4, 5]]
output sizes: [[4, 5]]
expected ranks: 2
collective state: scheduled
collective stack trace:
 <module> at /home/cpio/test/c.py:66
```

Differential Revision: D65503768


