### PR TITLE
Add logging for num_triton_bundles

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -144,6 +144,8 @@ frame_phase_timing: Dict[str, Dict[str, float]] = collections.defaultdict(
     lambda: collections.defaultdict(float)
 )
 
+codecache_metrics: Counter[str] = collections.Counter()
+
 timer_counter = itertools.count()
 
 
@@ -419,6 +421,9 @@ def dynamo_timed(
                                 remote_cache_time_saved_s=remote_cache_time_saved,
                                 structured_logging_overhead_s=structured_logging_overhead_s,
                                 is_forward=False,  # is_forward
+                                num_triton_bundles=codecache_metrics.get(
+                                    "num_triton_bundles", None
+                                ),
                                 remote_fx_graph_cache_get_time_ms=to_int_ms(
                                     remote_fx_graph_cache_get_time
                                 ),
@@ -899,6 +904,7 @@ class CompilationMetrics:
     specialize_float: Optional[bool] = None
     dynamo_config: Optional[str] = None
     is_forward: Optional[bool] = None
+    num_triton_bundles: Optional[int] = None
     remote_fx_graph_cache_get_time_ms: Optional[int] = None
     remote_fx_graph_cache_put_time_ms: Optional[int] = None
     start_time_us: Optional[int] = None

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -55,6 +55,7 @@ import torch.distributed as dist
 from torch import SymInt, Tensor
 from torch._dynamo.utils import (
     add_remote_cache_time_saved,
+    codecache_metrics,
     counters,
     dynamo_timed,
     get_chromium_event_logger,
@@ -1151,6 +1152,8 @@ class FxGraphCache:
                     logger.add_event_data(
                         "inductor_compile", cached_kernel_names=meta.cached_kernel_names
                     )
+                if len(meta.cached_kernel_names) > 0:
+                    codecache_metrics["num_triton_bundles"] += 1
 
         inductor_meta = autotune_cache.inductor_meta_from_config()
         AutotuneCacheBundler.begin_compile(inductor_meta, code=code)


### PR DESCRIPTION
Summary: Adding logs for number of inductor cache triton bundles

Test Plan:
Ran adhoc code and looked at dynamo_compile/sandbox

https://fburl.com/scuba/dynamo_compile/sandbox/nhktfy19

Differential Revision: D65490826




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov