### PR TITLE
Remove thunkify call in nested tensor torch function

### DIFF
--- a/torch/nested/_internal/nested_tensor.py
+++ b/torch/nested/_internal/nested_tensor.py
@@ -337,19 +337,14 @@ class NestedTensor(torch.Tensor):
         if kwargs is None:
             kwargs = {}
 
-        from torch.fx.experimental.proxy_tensor import maybe_enable_thunkify
-
         from .ops import jagged_torch_function
 
-        # This should be removed after
-        # https://github.com/pytorch/pytorch/pull/125941/ lands
-        with maybe_enable_thunkify():
-            try:
-                return jagged_torch_function(func, *args, **kwargs)
-            except NotImplementedError:
-                pass
-            with torch._C.DisableTorchFunctionSubclass():
-                return func(*args, **kwargs)
+        try:
+            return jagged_torch_function(func, *args, **kwargs)
+        except NotImplementedError:
+            pass
+        with torch._C.DisableTorchFunctionSubclass():
+            return func(*args, **kwargs)
 
 
 # NB: These fake view autograd.Functions are superseded by real view ops. Don't use them!


### PR DESCRIPTION
Context: https://github.com/pytorch/pytorch/pull/125941#issuecomment-2458403848

Basically the conditions under which this were needed have since been banned. This is needed to enable full tracing of the nested tensor torch function which will unblock https://github.com/pytorch/pytorch/pull/137822