### PR TITLE
[MPS] torch.nn.functional.pad may cause broken tensor if elements >= 2^16

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -99,6 +99,11 @@ static Tensor& pad_out_template(Tensor& output,
 
   Tensor grad_output, input = input_;
 
+  // `-[MPSGraph padTensor:withPaddingMode:leftPadding:rightPadding:constantValue:name:]`
+  // seems not support elements >= 2^16 and returns broken tensor.
+  TORCH_CHECK_NOT_IMPLEMENTED(input_w * input_h < 1 << 16,
+                              "Input elements >= 65536 causes broken tensor at the MPS device.")
+
   if (!is_backward_pass) {
     TORCH_CHECK(output_w >= 1 || output_h >= padding_dim - 1,
                 "input (H: ",

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9462,6 +9462,35 @@ class TestPad(TestCaseMPS):
         nhwc_padded = torch.constant_pad_nd(nhwc_tensor, [1, 2], 0.5)
         self.assertTrue(nhwc_padded.is_contiguous(memory_format=torch.channels_last))
 
+    def test_pad_limit(self):
+        def helper(elements):
+            inputCPU = torch.rand(
+                (1, 1, 1, 1, elements), device="cpu", dtype=torch.float
+            )
+            inputMPS = inputCPU.detach().clone().to("mps")
+            paddedCPU = F.pad(
+                inputCPU, pad=(0, 0, 0, 0, 1, 0), mode="constant", value=0.5
+            )
+            paddedMPS = F.pad(
+                inputMPS, pad=(0, 0, 0, 0, 1, 0), mode="constant", value=0.5
+            )
+            self.assertEqual(paddedCPU, paddedMPS)
+
+        mps_pad_size_limit = 1 << 16
+
+        # Under the limit
+        helper(mps_pad_size_limit - 1)
+
+        # On the limit
+        try:
+            helper(mps_pad_size_limit)
+        except NotImplementedError as e:
+            with self.assertRaisesRegex(
+                NotImplementedError,
+                "Input elements >= 65536 causes broken tensor at the MPS device.",
+            ):
+                raise e
+
 
 class TestLinalgMPS(TestCaseMPS):
     def _test_addmm_addmv(self, f, t, m, v, *, alpha=None, beta=None, transpose_out=False):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9482,14 +9482,11 @@ class TestPad(TestCaseMPS):
         helper(mps_pad_size_limit - 1)
 
         # On the limit
-        try:
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "Input elements >= 65536 causes broken tensor at the MPS device.",
+        ):
             helper(mps_pad_size_limit)
-        except NotImplementedError as e:
-            with self.assertRaisesRegex(
-                NotImplementedError,
-                "Input elements >= 65536 causes broken tensor at the MPS device.",
-            ):
-                raise e
 
 
 class TestLinalgMPS(TestCaseMPS):


### PR DESCRIPTION
**Problem**

It's undocumented limitation, or probably a bug though, based on the test on actual device,
`-[MPSGraph padTensor:withPaddingMode:leftPadding:rightPadding:constantValue:name:]` API doesn't work properly if number of elements >= 2^16 (65536) and returns a broken tensor, which elements are sometimes 0.0, sometimes completely random value.

It is tested with this Swift code on the following environments: https://gist.github.com/niw/456d83732bd2c720359abfab1e6eae0f
- MacBook Pro, M1, macOS 15.1
- MacBook Pro, M3, macOS 14.6.1, macOS 15.0.1

Originally this problem is found at kijai/ComfyUI-MochiWrapper#66.

**Solution**

Check the number of elements in `pad_out_template` and throw not implemented error if it's >= 2^16.

Add a unit test that should success but not on actual device, catch not implemented error and assert it for now.

cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen