### PR TITLE
[pytorch/profielr] Profiler NCCL metadata can now contain start and end addr hints for Tensor values.

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -502,6 +502,10 @@ void onFunctionExit(
   }
   kineto_ctx_ptr->event_->basic_fields_.end_tid_ =
       at::RecordFunction::currentThreadId();
+  if (fn.isNcclMeta()) {
+      auto& extra_meta = *(kineto_ctx_ptr->event_->extra_meta_);
+      extra_meta = torch::profiler::impl::saveNcclMeta(fn);
+  }
   if (config.state == ProfilerState::KINETO_GPU_FALLBACK) {
     try {
       auto fallback = kineto_ctx_ptr->fallback_;

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -362,12 +362,9 @@ std::unique_ptr<KinetoObserverContext> ThreadLocalSubqueue::begin_op(
         torch::profiler::impl::saveExtraArgs(fn));
   }
 
-  // Record NCCL metadata for specific CPU ops
-  fn.isNcclMeta() ? torch_ops_.extra_meta_.emplace_back(
-                        torch::profiler::impl::saveNcclMeta(fn))
-                  : torch_ops_.extra_meta_.emplace_back();
-
   auto out = std::make_unique<KinetoObserverContext>(event);
+  // Record NCCL metadata for specific CPU ops
+  out->event_->extra_meta_ = torch_ops_.extra_meta_.emplace_back();
 
   if (config_.state == ProfilerState::KINETO_GPU_FALLBACK) {
     try {
@@ -1588,4 +1585,26 @@ void set_cuda_sync_enabled_val(bool val) {
   cuda_sync_enabled_fn() = [val]() { return val; };
 }
 
+namespace {
+std::function<bool()>& record_tensor_addrs_enabled() {
+  static std::function<bool()> fn = []() { return false; };
+  return fn;
+}
+} // namespace
+
+bool get_record_tensor_addrs_enabled() {
+  static std::optional<bool> cached_record_tensor_addrs_enabled;
+  if (!cached_record_tensor_addrs_enabled.has_value()) {
+    cached_record_tensor_addrs_enabled = record_tensor_addrs_enabled()();
+  }
+  return cached_record_tensor_addrs_enabled.value();
+}
+
+void set_record_tensor_addrs_enabled_fn(std::function<bool()> fn) {
+  record_tensor_addrs_enabled() = std::move(fn);
+}
+
+void set_record_tensor_addrs_enabled_val(bool val) {
+  record_tensor_addrs_enabled() = [val]() { return val; };
+}
 } // namespace torch::profiler::impl

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -449,6 +449,7 @@ struct KinetoObserverContext : public at::ObserverContext {
 
     bool allow_tf32_cublas_;
     std::unique_ptr<perf_counters_t> counters_;
+    extra_meta_t* extra_meta_{};
   };
 
   explicit KinetoObserverContext(Event* event) : event_{event} {}
@@ -675,5 +676,10 @@ TORCH_API void set_fwd_bwd_enabled_val(bool);
 TORCH_API bool get_cuda_sync_enabled();
 TORCH_API void set_cuda_sync_enabled_fn(std::function<bool()>);
 TORCH_API void set_cuda_sync_enabled_val(bool);
+
+// Comms related RecordFunctions will record information about tensor storage locations.
+TORCH_API bool get_record_tensor_addrs_enabled();
+TORCH_API void set_record_tensor_addrs_enabled_fn(std::function<bool()>);
+TORCH_API void set_record_tensor_addrs_enabled_val(bool);
 
 } // namespace torch::profiler::impl

--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -55,11 +55,6 @@ namespace torch::profiler::impl {
 //******************************************************************************
 // JSON output utility functions. To be merged with PyTorch profiler.
 //******************************************************************************
-template <typename T>
-inline std::string vectorToString(const std::vector<T>& v) {
-  return fmt::format("[{}]", fmt::join(v, ","));
-}
-
 std::string json_str_escape(const std::string& str);
 
 constexpr size_t kMaxNumElements = 4096;
@@ -595,20 +590,11 @@ static void recordOperatorStart(
     }
 
     fc.name = fn.name();
-    auto num_inputs = fn.num_inputs();
-    const auto inputs = fn.inputs();
-
-    VLOG(2) << "inputs: " << num_inputs << " " << inputs.size() << '\n';
-    // We have two cases: for unboxed kernel, we have num_inputs ==
-    // inputs.size() for boxed kernel using stack, there could be more elements
-    // on the stack from previous ops.
-    // TORCH_INTERNAL_ASSERT(num_inputs <= inputs.size());
-    if (num_inputs > inputs.size()) {
-      LOG(WARNING) << "RecordFunction " << fc.name
-                   << " expected num_inputs=" << num_inputs
-                   << " > inputs.size()=" << inputs.size();
+    if (!checkFunctionInputsForLogging(fn, fn.name())) {
       return;
     }
+    auto num_inputs = fn.num_inputs();
+    const auto inputs = fn.inputs();
     // need to account for Stack mode where the inputs are at the end.
     size_t input_start = inputs.size() - num_inputs;
 
@@ -699,20 +685,11 @@ static void onFunctionExit(const RecordFunction& fn, ObserverContext* ctx_ptr) {
       return;
     }
     auto& fc = *fc_ptr;
-
-    auto outputs = fn.outputs();
-    auto num_outputs = fn.num_outputs();
-    // We have two cases: for unboxed kernel, we have num_outputs ==
-    // outputs.size() for boxed kernel using stack, there could be more elements
-    // on the stack from previous ops.
-    VLOG(2) << "outputs: " << num_outputs << " " << outputs.size() << '\n';
-    // TORCH_INTERNAL_ASSERT(num_outputs <= outputs.size());
-    if (num_outputs > outputs.size()) {
-      LOG(WARNING) << "RecordFunction " << fc.name
-                   << " num_outputs=" << num_outputs
-                   << " > outputs.size()=" << outputs.size();
+    if (!checkFunctionOutputsForLogging(fn, fn.name())) {
       return;
     }
+    auto outputs = fn.outputs();
+    auto num_outputs = fn.num_outputs();
     // need to account for Stack mode where the outputs are at the end.
     size_t output_start = outputs.size() - num_outputs;
 
@@ -724,7 +701,7 @@ static void onFunctionExit(const RecordFunction& fn, ObserverContext* ctx_ptr) {
       for (const auto i : c10::irange(output_start, outputs.size())) {
         appendValueInfo(
             *ob,
-            outputs[i],
+            outputs.at(i),
             output_shapes,
             output_strides,
             output_types,

--- a/torch/csrc/profiler/util.h
+++ b/torch/csrc/profiler/util.h
@@ -13,6 +13,7 @@
 #include <torch/csrc/Export.h>
 #include <torch/csrc/jit/frontend/source_range.h>
 #include <optional>
+#include <fmt/format.h>
 
 // TODO: replace with pytorch/rfcs#43 when it is ready.
 #define SOFT_ASSERT(cond, ...)                         \
@@ -100,7 +101,12 @@ std::unordered_map<std::string, c10::IValue> TORCH_API
 saveExtraArgs(const at::RecordFunction& fn);
 std::unordered_map<std::string, std::string> TORCH_API
 saveNcclMeta(const at::RecordFunction& fn, bool truncate = true);
-
+int getTensorStartHint(const at::Tensor& t);
+bool checkFunctionOutputsForLogging(const at::RecordFunction& fn, const char* fn_name);
+bool checkFunctionInputsForLogging(const at::RecordFunction& fn, const char* fn_name);
+template <typename T>
+const std::string vectorToString(const std::vector<T>& v);
+std::pair<bool, std::variant<int, std::vector<int>>> findStartAddrForTensors(const c10::IValue& val);
 uint64_t TORCH_API computeFlops(
     const std::string& op_name,
     const std::unordered_map<std::string, c10::IValue>& extra_args);
@@ -156,6 +162,11 @@ struct HashCombine {
   }
 };
 
+template <typename T>
+const std::string vectorToString(const std::vector<T>& v) {
+  return fmt::format("[{}]", fmt::join(v, ","));
+}
+
 #ifdef USE_DISTRIBUTED
 constexpr auto kCommsName = "Collective name";
 constexpr auto kDtype = "dtype";
@@ -172,6 +183,8 @@ constexpr auto kGroupRanks = "Process Group Ranks";
 constexpr auto kRank = "Rank";
 constexpr auto kP2pSrc = "Src Rank";
 constexpr auto kP2pDst = "Dst Rank";
+constexpr auto kTensorsStartAt = "Input Tensors start";
+constexpr auto kTensorsEndAt = "Output Tensors start";
 #endif // USE_DISTRIBUTED
 
 } // namespace torch::profiler::impl


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139832

Studying memory access patterns is the primary use cases.

Internal:
The data may be used to find the % of operators that may cause alignment related overhead on custom silicon.

Differential Revision: [D64413699](https://our.internmc.facebook.com/intern/diff/D64413699/)

cc @robieta @chaekit @guotuofeng @guyang3532 @dzhulgakov @davidberard98 @briancoutinho @sraikund16