### PR TITLE
[Dynamo] Support tensor mro without source

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1188,6 +1188,19 @@ utils_device.CURRENT_DEVICE == None""".split(
         inp.test = None
         self.assertEqual(torch.ones(2, 2) + 2, fn(inp))
 
+    def test_mro_type_tensor_no_source(self):
+        @torch.compile(fullgraph=True)
+        def fn(x):
+            z = []
+            input_type = type(torch.ones(2, 2))
+            for cls in input_type.__mro__:
+                z.append(cls.__name__)
+
+            return x, input_type, z
+
+        inp = torch.ones(2, 2)
+        fn(inp)
+
     def test_shape_unpack(self):
         def fn(x):
             a, b = x.size()

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -26,7 +26,13 @@ from ..exc import (
 )
 from ..guards import GuardBuilder, install_guard
 from ..replay_record import DummyModule
-from ..source import AttrSource, GetItemSource, is_constant_source, TypeSource
+from ..source import (
+    AttrSource,
+    GetItemSource,
+    GlobalSource,
+    is_constant_source,
+    TypeSource,
+)
 from ..utils import (
     check_constant_args,
     check_numpy_ndarray_args,
@@ -1879,6 +1885,9 @@ class BuiltinVariable(VariableTracker):
             ) from None
 
         source = obj.source and TypeSource(obj.source)
+        if py_type is torch.Tensor:
+            source = AttrSource(GlobalSource("torch"), "Tensor")
+
         return VariableTracker.build(tx, py_type, source)
 
     def call_reversed(self, tx: "InstructionTranslator", obj: VariableTracker):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1886,7 +1886,9 @@ class BuiltinVariable(VariableTracker):
 
         source = obj.source and TypeSource(obj.source)
         if py_type is torch.Tensor:
-            source = AttrSource(GlobalSource("torch"), "Tensor")
+            # In some cases torch isn't available in globals
+            name = tx.output.install_global_by_id("", torch)
+            source = AttrSource(GlobalSource(name), "Tensor")
 
         return VariableTracker.build(tx, py_type, source)
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -107,7 +107,6 @@ class UserDefinedVariable(VariableTracker):
 
 class UserDefinedClassVariable(UserDefinedVariable):
     def __init__(self, value, **kwargs) -> None:
-        breakpoint()
         super().__init__(**kwargs)
         self.value = value
 
@@ -159,9 +158,6 @@ class UserDefinedClassVariable(UserDefinedVariable):
         return key in self.value.__dict__
 
     def var_getattr(self, tx: "InstructionTranslator", name: str) -> "VariableTracker":
-        if name == "__mro__":
-            breakpoint()
-
         from . import ConstantVariable, EnumVariable
 
         source = AttrSource(self.source, name) if self.source is not None else None

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -107,6 +107,7 @@ class UserDefinedVariable(VariableTracker):
 
 class UserDefinedClassVariable(UserDefinedVariable):
     def __init__(self, value, **kwargs) -> None:
+        breakpoint()
         super().__init__(**kwargs)
         self.value = value
 
@@ -158,6 +159,9 @@ class UserDefinedClassVariable(UserDefinedVariable):
         return key in self.value.__dict__
 
     def var_getattr(self, tx: "InstructionTranslator", name: str) -> "VariableTracker":
+        if name == "__mro__":
+            breakpoint()
+
         from . import ConstantVariable, EnumVariable
 
         source = AttrSource(self.source, name) if self.source is not None else None


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/137743

The issue here is that if `type` was called on a tensor without a source, we wouldn't have a source even for `torch.Tensor`, and the `__mro__` retrieval would fail. Since `torch.Tensor` is an internal torch type, I add handling for it in `call_type` in builtins. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames