### PR TITLE
refuse to generate a symbolic variable if a float input is inf

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -430,7 +430,7 @@ class FakeTensorConverter:
 
             with no_dispatch():
                 value = t.item()
-            if not math.isnan(value):
+            if not math.isnan(value) and not math.isinf(value):
                 # Peephole strip out unnecessary torch.as_tensor(x).item()
                 if isinstance(source, FloatTensorSource):
                     item_source = source.base


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #139933
* #139583
* #138922
* #138918
* #138666
* #138915
* #139587
* #139935
* #139896
* #139454
* __->__ #139846
* #139572
* #139568
* #139457
* #139569

Fixes `PYTORCH_TEST_WITH_INDUCTOR=1 tlp python test/test_torch.py TestTorchDeviceTypeCPU.test_cauchy_cpu_float64` when `specialize_float=False`

