### PR TITLE
[AOTI] Fix a cubin file path issue

### DIFF
--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -54,6 +54,13 @@ std::string create_temp_dir() {
   return temp_dir;
 #endif
 }
+
+#ifdef _WIN32
+const std::string k_separator = "\\";
+#else
+const std::string k_separator = "/";
+#endif
+
 } // namespace
 
 namespace torch::inductor {
@@ -286,6 +293,8 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
   std::string cpp_filename = "";
   std::string consts_filename = "";
   std::string found_filenames = ""; // Saving for bookkeeping
+  std::string model_directory =
+      "data" + k_separator + "aotinductor" + k_separator + model_name;
 
   for (uint32_t i = 0; i < zip_archive.m_total_files; i++) {
     uint32_t filename_len =
@@ -303,11 +312,10 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
     found_filenames += " ";
 
     // Only compile files in the specified model directory
-    std::string model_directory = "data/aotinductor/" + model_name;
     if (filename_str.length() >= model_directory.length() &&
         filename_str.substr(0, model_directory.length()) == model_directory) {
       std::string output_path_str = temp_dir;
-      output_path_str += "/";
+      output_path_str += k_separator;
       output_path_str += filename_str;
 
       // Create the parent directory if it doesn't exist
@@ -378,7 +386,8 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
     throw std::runtime_error("Unsupported device found: " + device);
   }
 
-  runner_ = registered_aoti_runner[device](so_path, 1, device, "");
+  std::string cubin_dir = temp_dir + k_separator + model_directory;
+  runner_ = registered_aoti_runner[device](so_path, 1, device, cubin_dir);
 
   std::remove(temp_dir.c_str());
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139848

Summary: When we use aoti_compile_and_package to package the AOTI compiled artifacts, cubin files will be included, and at the deploy time, we should setup the cubin file directory to the right path that contains unziped cubin files.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang @aakhundov