### PR TITLE
Optimize incremental summation of unique symbols using CustomAdd sympy expression. 

### DIFF
--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -1153,7 +1153,7 @@ def _make_node_magic(method, func):
                 else:
                     out = PythonMod(self.expr, other.expr)
             elif method == "add":
-                out = func(self.expr_allow_custom_add, other.expr_allow_custom_add, optimize_incremental_summations=True)
+                out = func(self.expr_allow_custom_add, other.expr_allow_custom_add)
             else:
                 # TODO: consider constant prop here
                 out = func(self.expr, other.expr)

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -1153,7 +1153,7 @@ def _make_node_magic(method, func):
                 else:
                     out = PythonMod(self.expr, other.expr)
             elif method == "add":
-                out = func(self.expr_allow_custom_add, other.expr_allow_custom_add)
+                out = func(self.expr_allow_custom_add, other.expr_allow_custom_add, optimize_incremental_summations=True)
             else:
                 # TODO: consider constant prop here
                 out = func(self.expr, other.expr)

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -1134,6 +1134,12 @@ def _make_node_magic(method, func):
                     out = Mod(self.expr, other.expr)
                 else:
                     out = PythonMod(self.expr, other.expr)
+            elif method == "add":
+                from torch.utils._sympy.functions import CustomAdd
+
+                out = CustomAdd(
+                    self.expr, other.expr, optimize_incremental_summations=True
+                )
             else:
                 # TODO: consider constant prop here
                 out = func(self.expr, other.expr)

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -170,13 +170,14 @@ class SymNode:
 
     @property
     def expr(self):
-        result =  self.expr_allow_custom_add
+        result = self.expr_allow_custom_add
         # We make sure that CustomAdd is not leaking outside the construction loop.
         # This is needed to allow Add(a, b) == CustomAdd(a, b) to be true.
         if isinstance(result, torch.utils._sympy.functions.CustomAdd):
             import sympy
+
             return sympy.Add(*result._args, evaluate=False)
-        
+
         return result
 
     @property
@@ -720,10 +721,12 @@ def _sympy_floordiv(a, b):
 
     return FloorDiv(a, b)
 
+
 def _sympy_add(a, b):
     from torch.utils._sympy.functions import CustomAdd
 
     return CustomAdd(a, b, optimize_incremental_summations=True)
+
 
 def _sympy_mod(a, b):
     from torch.utils._sympy.functions import Mod, PythonMod

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -868,7 +868,7 @@ class CustomAdd(sympy.core.add.Add):
 
         # This way we make sure the optimizations are only triggered when we pass optimize_incremental_summations.
         # sometimes sympy will call this function during its simplifications for example, in that case we bypass to add.
-        bypass_to_add = "optimize_incremental_summations" not in kwargs
+        bypass_to_add = not kwargs.get("optimize_incremental_summations", False) 
         if bypass_to_add:
             return sympy.Add(*args, **kwargs)
 
@@ -885,7 +885,7 @@ class CustomAdd(sympy.core.add.Add):
             assert isinstance(obj, CustomAdd)
             obj.ordered_summation_of_unique_symbols = True
 
-            if config.run_extra_validations:
+            if True : # config.run_extra_validations: # need to rebase on another PR to see this lol
                 ref = sympy.Add(lhs, rhs)
                 assert ref._args == obj._args
                 assert str(ref) == str(obj)

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -885,10 +885,10 @@ class CustomAdd(sympy.core.add.Add):
             assert isinstance(obj, CustomAdd)
             obj.ordered_summation_of_unique_symbols = True
 
-            if True : # config.run_extra_validations: # need to rebase on another PR to see this lol
-                ref = sympy.Add(lhs, rhs)
-                assert ref._args == obj._args
-                assert str(ref) == str(obj)
+            # if True : # config.run_extra_validations: # need to rebase on another PR to see this lol
+            #     ref = sympy.Add(lhs, rhs)
+            #     assert ref._args == obj._args
+            #     assert str(ref) == str(obj)
             return obj
 
         if isinstance(lhs, CustomAdd):

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -939,7 +939,7 @@ class CustomAdd(sympy.core.add.Add):
             if isinstance(obj, CustomAdd):
                 obj._ordered_summation_of_unique_symbols = True
             else:
-                # if the object is optimized post construction we will get Add and not CustomAdd.
+                # if the object is optimized post construction we might get Add and not CustomAdd.
                 obj = super().__new__(CustomAdd, *obj._args, evaluate=False)
                 obj._ordered_summation_of_unique_symbols = True
 

--- a/torch/utils/_sympy/interp.py
+++ b/torch/utils/_sympy/interp.py
@@ -20,6 +20,7 @@ import torch
 from .functions import (
     CeilToInt,
     CleanDiv,
+    CustomAdd,
     FloatPow,
     FloatTrueDiv,
     FloorDiv,
@@ -73,6 +74,7 @@ def handlers():
         TruncToFloat: "trunc",
         Where: "where",
         sympy.Add: "add",
+        CustomAdd: "add",
         sympy.Mul: "mul",
         FloatPow: "pow",
         PowByNatural: "pow_by_natural",

--- a/torch/utils/_sympy/interp.py
+++ b/torch/utils/_sympy/interp.py
@@ -20,7 +20,6 @@ import torch
 from .functions import (
     CeilToInt,
     CleanDiv,
-    CustomAdd,
     FloatPow,
     FloatTrueDiv,
     FloorDiv,
@@ -74,7 +73,6 @@ def handlers():
         TruncToFloat: "trunc",
         Where: "where",
         sympy.Add: "add",
-        CustomAdd: "add",
         sympy.Mul: "mul",
         FloatPow: "pow",
         PowByNatural: "pow_by_natural",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139867

**wins**
on torchrec benchmark, for 2K nodes we go from 333 to 295 (13% or so)
```
buck2 run @fbcode//mode/opt fbcode//torchrec/distributed/tests:pt2_compile_benchmark -- --num-features=200
```
This diff optimizes construction expressions of the form 
a+b+c...  (all unique symbols). 
which are very common in torchrec models. 

**How**
Expressions of the form a+b+c are not optimized by add, the only needed optimization is sorting them.
If we have  a+b+c and we are adding (d) to it, we can do a binary search to know 
the position of (d) and avoid optimizing the new expression by passing the new order. 

CustomAdd subclass sympy.Add and does some logic to assign attributes 
that store information about the expression and use it to build the next
expression when a symbol is added with out having to run all sympy.Add optimizations.


**Extensions**:
1. support constant terms.
2. support 10a+10b+.. (this will give even more wins will extend the support in second PR)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @ezyang @SherlockNoMad @EikanWang @wenzhe-nrv