### PR TITLE
Improve error message for grad-requiring tensor to numpy conversion

### DIFF
--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -145,7 +145,7 @@ PyObject* tensor_to_numpy(const at::Tensor& tensor, bool force /*=false*/) {
     TORCH_CHECK(
         !(at::GradMode::is_enabled() && tensor.requires_grad()),
         "Can't call numpy() on Tensor that requires grad. "
-        "Use tensor.detach().numpy() instead.");
+        "Use tensor.detach().cpu().numpy() instead.");
 
     TORCH_CHECK(
         !tensor.is_conj(),


### PR DESCRIPTION
The suggestion to use `tensor.detach().numpy()` may not be valid when the tensor is on a device other than CPU.

Moving the tensor to CPU will ensure that the suggestion will be always valid.
