### PR TITLE
[ROCm] Support new AMD triton stream pipeliner

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -7,6 +7,8 @@ import torch._inductor.custom_graph_pass
 from torch._environment import is_fbcode
 from torch.utils._config_module import get_tristate_env, install_config_module
 
+from .runtime.triton_helpers import get_backend_options
+
 
 def fx_graph_remote_cache_default() -> Optional[bool]:
     return get_tristate_env("TORCHINDUCTOR_FX_GRAPH_REMOTE_CACHE")
@@ -1199,6 +1201,13 @@ class rocm:
     # Flag to use a short list of CK instances which perform well across a variety of shapes.
     # Currently RCR and F16 only
     use_preselected_instances: bool = False
+
+    # Default num_stages for gemm triton kernels on ROCm
+    try:
+        options = get_backend_options()
+        default_num_stages = options.get("num_stages", 2)
+    except Exception as e:
+        default_num_stages = 2
 
 
 # Backend to use for CPU codegen either "cpp" or "triton" (experimental) or "halide" (experimental)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1203,10 +1203,12 @@ class rocm:
     # Default num_stages for gemm triton kernels on ROCm
     try:
         from .runtime.triton_helpers import get_backend_options
-        options = get_backend_options()
-        default_num_stages = options.get("num_stages", 2)
-    except Exception as e:
-        default_num_stages = 2
+    except ImportError:
+        get_backend_options = None  # Fallback if needed
+
+    options = get_backend_options() if get_backend_options else {}
+    default_num_stages = options.get("num_stages", 2)
+
 
 
 # Backend to use for CPU codegen either "cpp" or "triton" (experimental) or "halide" (experimental)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -7,8 +7,6 @@ import torch._inductor.custom_graph_pass
 from torch._environment import is_fbcode
 from torch.utils._config_module import get_tristate_env, install_config_module
 
-from .runtime.triton_helpers import get_backend_options
-
 
 def fx_graph_remote_cache_default() -> Optional[bool]:
     return get_tristate_env("TORCHINDUCTOR_FX_GRAPH_REMOTE_CACHE")
@@ -1204,6 +1202,7 @@ class rocm:
 
     # Default num_stages for gemm triton kernels on ROCm
     try:
+        from .runtime.triton_helpers import get_backend_options
         options = get_backend_options()
         default_num_stages = options.get("num_stages", 2)
     except Exception as e:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1200,16 +1200,6 @@ class rocm:
     # Currently RCR and F16 only
     use_preselected_instances: bool = False
 
-    # Default num_stages for gemm triton kernels on ROCm
-    try:
-        from .runtime.triton_helpers import get_backend_options
-    except ImportError:
-        get_backend_options = None  # Fallback if needed
-
-    options = get_backend_options() if get_backend_options else {}
-    default_num_stages = options.get("num_stages", 2)
-
-
 
 # Backend to use for CPU codegen either "cpp" or "triton" (experimental) or "halide" (experimental)
 cpu_backend = "cpp"

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from sys import platform
 from typing import cast, List, Optional, Sequence, Tuple, TYPE_CHECKING, TypedDict
 
 import torch
@@ -28,7 +29,7 @@ from ..utils import (
     use_triton_template,
 )
 from ..virtualized import V
-from .mm_common import filtered_configs
+from .mm_common import build_rocm_gemm_configs, filtered_configs
 
 
 if TYPE_CHECKING:
@@ -78,9 +79,7 @@ platform_configs = tuple(
 
 # On ROCm convert num_stages to 1 as pipelining provides no benefit
 if torch.version.hip:
-    platform_configs = tuple(
-        (config[0], config[1], config[2], 1, config[4]) for config in platform_configs
-    )
+    platform_configs = build_rocm_gemm_configs(platform_configs)
 
 
 def _is_large_block_for_cpu(m, n, k):

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from sys import platform
 from typing import cast, List, Optional, Sequence, Tuple, TYPE_CHECKING, TypedDict
 
 import torch

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -346,7 +346,7 @@ scaled_mm_platform_configs = tuple(
 
 # On ROCm convert num_stages to improve performance
 if torch.version.hip:
-    mm_platform_configs = (build_rocm_gemm_configs(mm_platform_configs),)
+    mm_platform_configs = build_rocm_gemm_configs(mm_platform_configs)
     extra_mm_platform_configs = build_rocm_gemm_configs(extra_mm_platform_configs)
     int8_platform_configs = build_rocm_gemm_configs(int8_platform_configs)
     mixed_mm_platform_configs = build_rocm_gemm_configs(mixed_mm_platform_configs)

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -14,7 +14,7 @@ from .. import config as inductor_config
 from ..codegen.wrapper import PythonWrapperCodegen
 from ..ir import Layout
 from ..runtime.runtime_utils import next_power_of_2
-from ..utils import ceildiv as cdivh
+from ..utils import ceildiv as cdiv
 
 
 log = logging.getLogger(__name__)

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -14,7 +14,7 @@ from .. import config as inductor_config
 from ..codegen.wrapper import PythonWrapperCodegen
 from ..ir import Layout
 from ..runtime.runtime_utils import next_power_of_2
-from ..utils import ceildiv as cdiv
+from ..utils import ceildiv as cdiv, get_backend_num_stages
 
 
 log = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ def triton_config(num_stages, num_warps, **kwargs):
 
 
 def build_rocm_gemm_configs(configs):
-    rocm_num_stages = inductor_config.rocm.default_num_stages
+    rocm_num_stages = get_backend_num_stages()
     return tuple((c[0], c[1], c[2], rocm_num_stages, c[4]) for c in configs)
 
 

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -14,7 +14,7 @@ from .. import config as inductor_config
 from ..codegen.wrapper import PythonWrapperCodegen
 from ..ir import Layout
 from ..runtime.runtime_utils import next_power_of_2
-from ..utils import ceildiv as cdiv
+from ..utils import ceildiv as cdivh
 
 
 log = logging.getLogger(__name__)
@@ -24,6 +24,11 @@ def triton_config(num_stages, num_warps, **kwargs):
     from triton import Config
 
     return Config(kwargs, num_stages=num_stages, num_warps=num_warps)
+
+
+def build_rocm_gemm_configs(configs):
+    rocm_num_stages = inductor_config.rocm.default_num_stages
+    return tuple((c[0], c[1], c[2], rocm_num_stages, c[4]) for c in configs)
 
 
 def filtered_configs(
@@ -134,7 +139,7 @@ def filtered_configs(
 mm_kernel_configs = (
     [
         {"config": (32, 32, 16, 1, 2), "cond": True},
-        {"config": (32, 32, 128, 2, 4), "cond": torch.version.hip is None},
+        {"config": (32, 32, 128, 2, 4), "cond": True},
         {"config": (32, 64, 32, 5, 8), "cond": True},
         {"config": (64, 32, 32, 5, 8), "cond": True},
         {"config": (64, 32, 128, 5, 4), "cond": True},
@@ -195,8 +200,8 @@ int8_mm_kernel_configs = [
     # {"config": (32, 32, 128, 2, 4), "cond": True},
     # {"config": (64, 64, 16, 2, 4), "cond": True},
     # {"config": (32, 32, 16, 1, 2), "cond": True},
-    {"config": (128, 256, 128, 3, 8), "cond": torch.version.hip is None},
-    {"config": (256, 128, 128, 3, 8), "cond": torch.version.hip is None},
+    {"config": (128, 256, 128, 3, 8), "cond": True},
+    {"config": (256, 128, 128, 3, 8), "cond": True},
 ]
 
 # Mixed precision kernel configs for small sizes of m for mm's like (16, 8192) x (8192, 8192).
@@ -339,28 +344,13 @@ scaled_mm_platform_configs = tuple(
     if config["cond"]
 )
 
-# On ROCm convert num_stages to 0 to enable software pipelining
+# On ROCm convert num_stages to improve performance
 if torch.version.hip:
-    mm_platform_configs = tuple(
-        (config[0], config[1], config[2], 0, config[4])
-        for config in mm_platform_configs
-    )
-    extra_mm_platform_configs = tuple(
-        (config[0], config[1], config[2], 0, config[4])
-        for config in extra_mm_platform_configs
-    )
-    int8_platform_configs = tuple(
-        (config[0], config[1], config[2], 0, config[4])
-        for config in mm_platform_configs
-    )
-    mixed_mm_platform_configs = tuple(
-        (config[0], config[1], config[2], 0, config[4])
-        for config in mixed_mm_platform_configs
-    )
-    scaled_mm_platform_configs = tuple(
-        (config[0], config[1], config[2], 0, config[4])
-        for config in scaled_mm_platform_configs
-    )
+    mm_platform_configs = (build_rocm_gemm_configs(mm_platform_configs),)
+    extra_mm_platform_configs = build_rocm_gemm_configs(extra_mm_platform_configs)
+    int8_platform_configs = build_rocm_gemm_configs(int8_platform_configs)
+    mixed_mm_platform_configs = build_rocm_gemm_configs(mixed_mm_platform_configs)
+    scaled_mm_platform_configs = build_rocm_gemm_configs(scaled_mm_platform_configs)
 
 mm_configs = functools.partial(
     filtered_configs,

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -59,6 +59,14 @@ def set_driver_to_gpu():
     raise RuntimeError("Could not find an active GPU backend")
 
 
+def get_backend_options():
+    driver = triton.runtime.driver
+    target = driver.active.get_current_target()
+    backend = triton.compiler.compiler.make_backend(target)
+    options = backend.parse_options(dict())
+    return options.__dict__
+
+
 @triton.jit
 def promote_to_tensor(x):
     # Addition promotes to tensor for us

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1581,12 +1581,12 @@ def parallel_num_threads():
         threads = torch.get_num_threads()
     return threads
 
-
+@functools.lru_cache(None)
 def get_backend_num_stages():
     from .runtime.triton_helpers import get_backend_options
 
     options = get_backend_options()
-    return options.get("num_stages", 2 if torch.version.hip else None)
+    return options.get("num_stages", 2 if torch.version.hip else 3)
 
 
 @functools.lru_cache(None)

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1581,6 +1581,7 @@ def parallel_num_threads():
         threads = torch.get_num_threads()
     return threads
 
+
 @functools.lru_cache(None)
 def get_backend_num_stages():
     from .runtime.triton_helpers import get_backend_options

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1582,6 +1582,13 @@ def parallel_num_threads():
     return threads
 
 
+def get_backend_num_stages():
+    from .runtime.triton_helpers import get_backend_options
+
+    options = get_backend_options()
+    return options.get("num_stages", 2 if torch.version.hip else None)
+
+
 @functools.lru_cache(None)
 def get_device_tflops(dtype):
     from triton.testing import get_max_simd_tflops, get_max_tensorcore_tflops


### PR DESCRIPTION
Fixes #139182 

In Triton 3.2 num_stages=0 will be deprecated with Triton's AMD backend. Let's query default num_stages from the relevant triton backend


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov