### PR TITLE
[BE]: Add NT missing fp classification functions

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3179,6 +3179,7 @@
   device_guard: False
   dispatch:
     CPU, CUDA, MPS: isnan
+    NestedTensorCPU, NestedTensorCUDA: NestedTensor_isnan
     SparseCPU, SparseCUDA: isnan_sparse
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta: isnan_sparse_csr
   autogen: isnan.out
@@ -13070,6 +13071,7 @@
   device_guard: False
   dispatch:
     CompositeExplicitAutograd: isinf
+    NestedTensorCPU, NestedTensorCUDA: NestedTensor_isinf
     SparseCPU, SparseCUDA: isinf_sparse
     SparseMeta: isinf_sparse_meta
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta: isinf_sparse_csr
@@ -13085,6 +13087,7 @@
   variants: function, method
   structured_delegate: isposinf.out
   dispatch:
+    NestedTensorCPU, NestedTensorCUDA: NestedTensor_isposinf
     SparseCPU, SparseCUDA: isposinf_sparse
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta: isposinf_sparse_csr
   tags: pointwise

--- a/aten/src/ATen/native/nested/NestedTensorUnaryOps.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUnaryOps.cpp
@@ -89,8 +89,20 @@ Tensor NestedTensor_logical_not(const Tensor& self) {
   return map_nt(self, at::logical_not);
 }
 
+Tensor NestedTensor_isinf(const Tensor& self) {
+  return map_nt(self, at::isinf);
+}
+
+Tensor NestedTensor_isposinf(const Tensor& self) {
+  return map_nt(self, at::isposinf);
+}
+
 Tensor NestedTensor_isneginf(const Tensor& self) {
   return map_nt(self, at::isneginf);
+}
+
+Tensor NestedTensor_isnan(const Tensor& self) {
+  return map_nt(self, at::isnan);
 }
 
 Tensor& NestedTensor_relu_(Tensor& self) {

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -1274,9 +1274,13 @@ class TestNestedTensorDeviceType(NestedTensorTestCase):
             subtest(torch.logical_not, name="logical_not"),
             subtest(torch.sin, name="sin"),
             subtest(torch.cos, name="cos"),
+            subtest(torch.isinf, name="isinf"),
+            subtest(torch.isposinf, name="isposinf"),
+            subtest(torch.isneginf, name="isneginf"),
+            subtest(torch.isnan, name="isnan"),
         ],
     )
-    def test_activations(self, device, func):
+    def test_unary_funcs(self, device, func):
         nt, nt_noncontiguous = random_nt_noncontiguous_pair(
             (2, 3, 6, 7), device=device, dtype=torch.float32
         )


### PR DESCRIPTION
Follow up to some issues @malfet's recent PR pointed out about missing ops #139763. Tried to mirror it to other important nearby ops. Seems like we could automate / autogen this more for generic pointwise ops like this.

cc @cpuhrsch @jbschlosser @bhosmer @drisspg @soulitzer @davidberard98 @YuqingJ