### PR TITLE
Remove compile event logging for automatic dynamic

### DIFF
--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -308,7 +308,6 @@ def update_automatic_dynamic(
                 "cached": str(old_entry.scalar),
                 "new": str(entry.scalar),
             },
-            log_pt2_compile_event=True,
         )
         if is_unspecialized_nn_module:
             log.info(
@@ -348,7 +347,6 @@ def update_automatic_dynamic(
                 "cached": str(old_entry_tup),
                 "new": str(entry_tup),
             },
-            log_pt2_compile_event=True,
         )
 
     if is_update and old_entry.size != mut_entry.size:


### PR DESCRIPTION
Summary: These events are a pretty large portion of the table, but not really currently used. Only log to tlparse for now.

Test Plan: Unit tests

Differential Revision: D65539986




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames