### PR TITLE
Remove multinomial from cudagraph skip list'

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -1051,6 +1051,34 @@ if HAS_CUDA and not TEST_WITH_ASAN:
             self.assertFalse(first_node.unaliased_in_all_paths[0])
             self.assertTrue(first_node.cached_tensor_outputs[0] is None)
 
+        @torch._inductor.config.patch("implicit_fallbacks", True)
+        def test_multinomial(self):
+            def sample_multinomial(probs, num_samples, replacement=True):
+                return torch.multinomial(probs, num_samples, replacement=replacement)
+
+            # Create and prepare probability tensor on GPU
+            probs = torch.tensor([0.1, 0.2, 0.3, 0.4]).cuda()
+            probs = probs / probs.sum()
+
+            # Sample using the function
+            num_skipped = counters["inductor"]["cudagraph_skips"]
+
+            with torch._dynamo.utils.preserve_rng_state():
+                samples = self.run_twc(
+                    sample_multinomial, probs, num_samples=5, replacement=True
+                )
+
+            with torch._dynamo.utils.preserve_rng_state():
+                samples_compiled = self.run_twc(
+                    torch.compile(sample_multinomial),
+                    probs,
+                    num_samples=5,
+                    replacement=True,
+                )
+
+            self.assertEqual(samples, samples_compiled)
+            self.assertEqual(num_skipped, counters["inductor"]["cudagraph_skips"])
+
         @skipIfRocm
         def test_checkpointing_resets_persistent_refs(self):
             @torch.compile(mode="reduce-overhead")

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -739,7 +739,6 @@ def get_first_incompatible_cudagraph_node(
     forbidden_set = {
         "aten._fused_moving_avg_obs_fq_helper.default",
         "aten._fused_moving_avg_obs_fq_helper_functional.default",
-        "aten.multinomial.default",
         "fbgemm.dense_to_jagged.default",
         "fbgemm.jagged_to_padded_dense.default",
         "run_and_save_rng_state",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139897

Since https://github.com/pytorch/pytorch/pull/134818/files we can run multinomial in cudagraph without error.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @vmoens 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov