### PR TITLE
Add base class for single-subgraph inductor HOPs

### DIFF
--- a/test/dynamo/test_prim_hop_base.py
+++ b/test/dynamo/test_prim_hop_base.py
@@ -1,0 +1,199 @@
+# Owner(s): ["module: dynamo"]
+import enum
+import functools
+import pprint
+import re
+import unittest
+import warnings
+
+import functorch.experimental.control_flow as control_flow
+import torch
+import torch._dynamo.config as config
+import torch._dynamo.test_case
+import torch._functorch.config
+import torch.nn as nn
+import torch.utils._pytree as pytree
+import torch.utils.checkpoint
+from torch._dynamo.backends.common import aot_autograd
+from torch._dynamo.testing import (
+    CompileCounter,
+    CompileCounterWithBackend,
+    EagerAndRecordGraphs,
+    AotEagerAndRecordGraphs,
+    empty_line_normalizer,
+    normalize_gm,
+)
+from torch._dynamo.utils import counters, ifdynstaticdefault
+from torch._higher_order_ops.hints_wrap import hints_wrapper
+from torch._higher_order_ops.wrap import wrap
+from torch.testing._internal.common_utils import (
+    munge_exc,
+    TEST_WITH_TORCHDYNAMO,
+    xfailIfTorchDynamo,
+)
+from torch.testing._internal.inductor_utils import HAS_CUDA
+from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
+
+
+requires_cuda = unittest.skipUnless(HAS_CUDA, "requires cuda")
+
+
+def normalize_graph(gm):
+    return normalize_gm(gm.print_readable(print_output=False))
+
+
+class InvokeQuantTest(torch._higher_order_ops.PrimHOPBase):
+    def __init__(self):
+        return super().__init__("invoke_quant_test")
+
+    def __call__(self, subgraph, operands, *, scheme):
+        return super().__call__(subgraph, operands, scheme=scheme)
+
+invoke_quant_test = InvokeQuantTest()
+
+
+class PrimHOPBaseTest(torch._dynamo.test_case.TestCase):
+    # TODO: flip to False later, we're landing a refactor PR and don't want to merge conflict
+    @torch._dynamo.config.patch(assume_static_by_default=True)
+    def test_dynamo(self):
+        def inner(x, y):
+            return (x @ y).sin().cos()
+
+        x = torch.randn(3, 3, requires_grad=True)
+        y = torch.randn(3, 3, requires_grad=True)
+
+        backend = EagerAndRecordGraphs()
+
+        @torch.compile(backend=backend)
+        def f(x, y):
+            return invoke_quant_test(inner, (x, y), scheme="nf4")
+
+        out = f(x, y)
+        self.assertEqual(out, inner(x, y))
+
+        assert len(backend.graphs) == 1
+        self.assertExpectedInline(normalize_graph(backend.graphs[0]), """\
+class GraphModule(torch.nn.Module):
+    def forward(self, L_x_: "f32[3, 3]", L_y_: "f32[3, 3]"):
+        l_x_ = L_x_
+        l_y_ = L_y_
+
+        subgraph_0 = self.subgraph_0
+        invoke_quant_test = torch.ops.higher_order.invoke_quant_test(subgraph_0, (l_x_, l_y_), scheme = 'nf4');  subgraph_0 = l_x_ = l_y_ = None
+        getitem: "f32[3, 3]" = invoke_quant_test[0];  invoke_quant_test = None
+        return (getitem,)
+
+    class subgraph_0(torch.nn.Module):
+        def forward(self, l_x_: "f32[3, 3]", l_y_: "f32[3, 3]"):
+            matmul: "f32[3, 3]" = l_x_ @ l_y_;  l_x_ = l_y_ = None
+            sin: "f32[3, 3]" = matmul.sin();  matmul = None
+            cos: "f32[3, 3]" = sin.cos();  sin = None
+            return (cos,)
+""")
+
+    @torch._dynamo.config.patch(assume_static_by_default=True)
+    def test_aot_eager(self):
+        def inner(x, y):
+            return (x @ y).sin_().cos()
+
+        x = torch.randn(3, 3, requires_grad=True)
+        y = torch.randn(3, 3, requires_grad=True)
+
+        backend = AotEagerAndRecordGraphs()
+
+        @torch.compile(backend=backend)
+        def f(x, y):
+            return invoke_quant_test(inner, (x, y), scheme="nf4")
+
+        out = f(x, y)
+        result = torch.autograd.grad(out, x, y)
+        out = inner(x, y)
+        expected = torch.autograd.grad(out, x, y)
+        self.assertEqual(result, expected)
+
+        assert len(backend.fw_graphs) == 1
+        self.assertExpectedInline(normalize_graph(backend.fw_graphs[0]), """\
+class GraphModule(torch.nn.Module):
+    def forward(self, primals_1: "f32[3, 3]", primals_2: "f32[3, 3]"):
+        subgraph0 = self.subgraph0
+        invoke_quant_test = torch.ops.higher_order.invoke_quant_test(subgraph0, (primals_1, primals_2), scheme = 'nf4');  subgraph0 = None
+        getitem: "f32[3, 3]" = invoke_quant_test[0];  invoke_quant_test = None
+        return (getitem, primals_1, primals_2)
+
+    class subgraph0(torch.nn.Module):
+        def forward(self, arg0_1: "f32[3, 3]", arg1_1: "f32[3, 3]"):
+            mm: "f32[3, 3]" = torch.ops.aten.mm.default(arg0_1, arg1_1);  arg0_1 = arg1_1 = None
+            sin: "f32[3, 3]" = torch.ops.aten.sin.default(mm);  mm = None
+            cos: "f32[3, 3]" = torch.ops.aten.cos.default(sin);  sin = None
+            return (cos,)
+""")
+
+        assert len(backend.bw_graphs) == 1
+        self.assertExpectedInline(normalize_graph(backend.bw_graphs[0]), """\
+class GraphModule(torch.nn.Module):
+    def forward(self, primals_1: "f32[3, 3]", primals_2: "f32[3, 3]", tangents_1: "f32[3, 3]"):
+        subgraph1 = self.subgraph1
+        invoke_quant_test_1 = torch.ops.higher_order.invoke_quant_test(subgraph1, (tangents_1, primals_1, primals_2), scheme = 'nf4');  subgraph1 = tangents_1 = primals_1 = primals_2 = None
+        getitem_1: "f32[3, 3]" = invoke_quant_test_1[0]
+        getitem_2: "f32[3, 3]" = invoke_quant_test_1[1];  invoke_quant_test_1 = None
+        return (getitem_1, getitem_2)
+
+    class subgraph1(torch.nn.Module):
+        def forward(self, arg0_1: "f32[3, 3]", arg1_1: "f32[3, 3]", arg2_1: "f32[3, 3]"):
+            mm: "f32[3, 3]" = torch.ops.aten.mm.default(arg1_1, arg2_1)
+            clone: "f32[3, 3]" = torch.ops.aten.clone.default(mm)
+            sin: "f32[3, 3]" = torch.ops.aten.sin.default(mm);  mm = None
+            cos: "f32[3, 3]" = torch.ops.aten.cos.default(sin);  cos = None
+            sin_1: "f32[3, 3]" = torch.ops.aten.sin.default(sin);  sin = None
+            neg: "f32[3, 3]" = torch.ops.aten.neg.default(sin_1);  sin_1 = None
+            mul: "f32[3, 3]" = torch.ops.aten.mul.Tensor(arg0_1, neg);  arg0_1 = neg = None
+            cos_1: "f32[3, 3]" = torch.ops.aten.cos.default(clone);  clone = None
+            mul_1: "f32[3, 3]" = torch.ops.aten.mul.Tensor(mul, cos_1);  mul = cos_1 = None
+            t: "f32[3, 3]" = torch.ops.aten.t.default(arg1_1);  arg1_1 = None
+            mm_1: "f32[3, 3]" = torch.ops.aten.mm.default(t, mul_1);  t = None
+            t_1: "f32[3, 3]" = torch.ops.aten.t.default(arg2_1);  arg2_1 = None
+            mm_2: "f32[3, 3]" = torch.ops.aten.mm.default(mul_1, t_1);  mul_1 = t_1 = None
+            return [mm_2, mm_1]
+""")
+
+    def test_aliasing_mutation_error(self):
+        def inner(x, y):
+            return x
+
+        x = torch.randn(3, 3)
+        y = torch.randn(3, 3)
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x, y):
+            return invoke_quant_test(inner, (x, y), scheme="nf4")
+
+        with self.assertRaisesRegex(RuntimeError, "aliases of the inputs"):
+            out = f(x, y)
+
+        def inner(x, y):
+            x.sin_()
+            return x + y
+
+        with self.assertRaisesRegex(RuntimeError, "inputs are mutated"):
+            out = f(x, y)
+
+    def test_eager_call(self):
+        def inner(x, y):
+            return x + y
+
+        x = torch.randn(3, 3)
+        y = torch.randn(3, 3)
+
+        with self.assertRaisesRegex(RuntimeError, "torch.fx.GraphModule"):
+            invoke_quant_test(inner, (x, y), scheme="nf4")
+
+        from functorch import make_fx
+        result = make_fx(inner)(x, y)
+        # smoke test
+        invoke_quant_test(result, (x, y), scheme="nf4")
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/test/dynamo/test_prim_hop_base.py
+++ b/test/dynamo/test_prim_hop_base.py
@@ -120,25 +120,25 @@ class GraphModule(torch.nn.Module):
 class GraphModule(torch.nn.Module):
     def forward(self, primals_1: "f32[3, 3]", primals_2: "f32[3, 3]", tangents_1: "f32[3, 3]"):
         subgraph1 = self.subgraph1
-        invoke_quant_test_1 = torch.ops.higher_order.invoke_quant_test(subgraph1, (tangents_1, primals_1, primals_2), scheme = 'nf4');  subgraph1 = tangents_1 = primals_1 = primals_2 = None
+        invoke_quant_test_1 = torch.ops.higher_order.invoke_quant_test(subgraph1, (primals_1, primals_2, tangents_1), scheme = 'nf4');  subgraph1 = primals_1 = primals_2 = tangents_1 = None
         getitem_1: "f32[3, 3]" = invoke_quant_test_1[0]
         getitem_2: "f32[3, 3]" = invoke_quant_test_1[1];  invoke_quant_test_1 = None
         return (getitem_1, getitem_2)
 
     class subgraph1(torch.nn.Module):
         def forward(self, arg0_1: "f32[3, 3]", arg1_1: "f32[3, 3]", arg2_1: "f32[3, 3]"):
-            mm: "f32[3, 3]" = torch.ops.aten.mm.default(arg1_1, arg2_1)
+            mm: "f32[3, 3]" = torch.ops.aten.mm.default(arg0_1, arg1_1)
             clone: "f32[3, 3]" = torch.ops.aten.clone.default(mm)
             sin: "f32[3, 3]" = torch.ops.aten.sin.default(mm);  mm = None
             cos: "f32[3, 3]" = torch.ops.aten.cos.default(sin);  cos = None
             sin_1: "f32[3, 3]" = torch.ops.aten.sin.default(sin);  sin = None
             neg: "f32[3, 3]" = torch.ops.aten.neg.default(sin_1);  sin_1 = None
-            mul: "f32[3, 3]" = torch.ops.aten.mul.Tensor(arg0_1, neg);  arg0_1 = neg = None
+            mul: "f32[3, 3]" = torch.ops.aten.mul.Tensor(arg2_1, neg);  arg2_1 = neg = None
             cos_1: "f32[3, 3]" = torch.ops.aten.cos.default(clone);  clone = None
             mul_1: "f32[3, 3]" = torch.ops.aten.mul.Tensor(mul, cos_1);  mul = cos_1 = None
-            t: "f32[3, 3]" = torch.ops.aten.t.default(arg1_1);  arg1_1 = None
+            t: "f32[3, 3]" = torch.ops.aten.t.default(arg0_1);  arg0_1 = None
             mm_1: "f32[3, 3]" = torch.ops.aten.mm.default(t, mul_1);  t = None
-            t_1: "f32[3, 3]" = torch.ops.aten.t.default(arg2_1);  arg2_1 = None
+            t_1: "f32[3, 3]" = torch.ops.aten.t.default(arg1_1);  arg1_1 = None
             mm_2: "f32[3, 3]" = torch.ops.aten.mm.default(mul_1, t_1);  mul_1 = t_1 = None
             return [mm_2, mm_1]
 """,  # NOQA: B950

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -598,6 +598,8 @@ class TorchHigherOrderOperatorVariable(VariableTracker):
 
     @staticmethod
     def make(value, source=None, **kwargs):
+        from torch._higher_order_ops import PrimHOPBase
+
         if value.__name__ == "cond":
             return CondHigherOrderVariable(value, source, **kwargs)
         elif value.__name__ == "while_loop":
@@ -644,6 +646,8 @@ class TorchHigherOrderOperatorVariable(VariableTracker):
             return AutoFunctionalizeHigherOrderVariable(value, source, **kwargs)
         elif value.__name__ == "invoke_subgraph":
             return InvokeSubgraphHigherOrderVariable(value, source, **kwargs)
+        elif isinstance(value, PrimHOPBase):
+            return PrimHOPBaseVariable(value, source, **kwargs)
         else:
             unimplemented(f"HigherOrderOperator {value.__name__}")
 
@@ -1504,6 +1508,8 @@ class WrapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         kwargs,
         description,
         under_activation_checkpoint=False,
+        *,
+        subgraph_name="wrap_body",
     ):
         # See NOTE [HigherOrderOperator tracing design] for more details
 
@@ -1524,7 +1530,12 @@ class WrapHigherOrderVariable(TorchHigherOrderOperatorVariable):
 
         body_gmod = torch.fx.GraphModule(tx.output.nn_modules, body_graph)
         body_name = self.install_subgraph_in_output_graph(
-            tx, fn_vt, fn_args_vt, kwargs, body_gmod
+            tx,
+            fn_vt,
+            fn_args_vt,
+            kwargs,
+            body_gmod,
+            attr_name=subgraph_name,
         )
         body_node = make_attr(tx, body_name)
 
@@ -2610,6 +2621,53 @@ def hash_graph_and_inputs(tx, gmod, fake_inputs):
 
     key, _ = autograd_cache_key(canonicalized_gmod, fake_inputs, config, {})
     return key
+
+
+class PrimHOPBaseVariable(WrapHigherOrderVariable):
+    def call_function(
+        self,
+        tx: "InstructionTranslator",
+        args: "List[VariableTracker]",
+        kwargs: "Dict[str, VariableTracker]",
+    ) -> "VariableTracker":
+        (
+            p_args,
+            p_kwargs,
+            example_value,
+            body_r,
+            treespec,
+            body_gmod,
+            body_name,
+        ) = self.create_wrapped_node(
+            tx, args[0], args[1].items, {}, self.value._name, subgraph_name="subgraph"
+        )
+        assert len(p_kwargs) == 0
+
+        from torch._higher_order_ops.utils import has_potential_input_alias_or_mutation
+
+        fake_inputs = [
+            node.meta["example_value"]
+            for node in body_gmod.graph.nodes
+            if node.op == "placeholder"
+        ]
+        if has_potential_input_alias_or_mutation(body_gmod, fake_inputs):
+            raise RuntimeError(
+                f"{self.value._name} where the inputs are mutated or the outputs are aliases of the inputs. Please ensure that this doesn't happen."
+            )
+
+        flat_example_value = pytree.tree_map_only(
+            torch.fx.Proxy,
+            lambda a: a.node.meta["example_value"],
+            body_r.as_proxy(),
+        )
+        p_args = (
+            p_args[0],
+            p_args[1:],
+        )
+        p_kwargs = {key: value.as_proxy() for key, value in kwargs.items()}
+        return _call_function_and_unflatten_output(
+            tx, self.value, p_args, p_kwargs, flat_example_value, treespec
+        )
 
 
 class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2673,7 +2673,7 @@ class PrimHOPBaseVariable(WrapHigherOrderVariable):
 
 class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
     def install_subgraph_in_output_graph(
-        self, tx, fn_vt, fn_args_vt, kwargs, body_gmod, attr_name="invoke_subgraph"
+        self, tx, fn_vt, fn_args_vt, kwargs, body_gmod, attr_name
     ):
         # Check if the subgraph from speculate_subgraph (body_gmod) and the fake
         # inputs have already been seen before. If yes, the subgraph is already
@@ -2705,7 +2705,7 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
                 return identifier
 
         body_name = super().install_subgraph_in_output_graph(
-            tx, fn_vt, fn_args_vt, kwargs, body_gmod, attr_name
+            tx, fn_vt, fn_args_vt, kwargs, body_gmod, "invoke_subgraph"
         )
         if invoke_subgraph_cache:
             invoke_subgraph_cache.add_dynamo_identifier(key, body_name)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2652,7 +2652,8 @@ class PrimHOPBaseVariable(WrapHigherOrderVariable):
         ]
         if has_potential_input_alias_or_mutation(body_gmod, fake_inputs):
             raise RuntimeError(
-                f"{self.value._name} where the inputs are mutated or the outputs are aliases of the inputs. Please ensure that this doesn't happen."
+                f"{self.value._name} where the inputs are mutated or the "
+                f"outputs are aliases of the inputs. Please ensure that this doesn't happen."
             )
 
         flat_example_value = pytree.tree_map_only(

--- a/torch/_higher_order_ops/__init__.py
+++ b/torch/_higher_order_ops/__init__.py
@@ -5,6 +5,7 @@ from torch._higher_order_ops.flex_attention import (
 )
 from torch._higher_order_ops.hints_wrap import hints_wrapper
 from torch._higher_order_ops.invoke_subgraph import invoke_subgraph
+from torch._higher_order_ops.prim_hop_base import PrimHOPBase
 from torch._higher_order_ops.scan import scan
 from torch._higher_order_ops.while_loop import while_loop
 
@@ -17,4 +18,5 @@ __all__ = [
     "flex_attention",
     "flex_attention_backward",
     "hints_wrapper",
+    "PrimHOPBase",
 ]

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -109,21 +109,24 @@ def trace_joint_graph(fn, fw_inputs, fw_outputs):
     return _maybe_reenter_make_fx(joint_fn)(*joint_operands)
 
 
-def create_fw_bw_graph(subgraph, operands):
+def create_fw_bw_graph(subgraph, operands, grad_outputs=None):
     with suspend_functionalization(), disable_functional_mode():
         with disable_proxy_modes_tracing():
             # args are functional tensors, generate some example tensors
             fw_inputs = pytree.tree_map(_from_fun, operands)
 
-            fw_outputs = pytree.tree_map(_from_fun, subgraph(*fw_inputs))
+            if grad_outputs is None:
+                # Infer grad_outputs to be the same properties as the fw_outputs
+                # if they're not passed in.
+                grad_outputs = pytree.tree_map(_from_fun, subgraph(*fw_inputs))
             if any(
                 not isinstance(out, torch.Tensor)
-                for out in fw_outputs
+                for out in grad_outputs
                 if out is not None
             ):
                 raise RuntimeError(
                     "Expect outputs of invoke_subgraph to only contains tensors or None. "
-                    f"Got types {[type(out) for out in fw_outputs]}."
+                    f"Got types {[type(out) for out in grad_outputs]}."
                 )
 
             # Trace the forward subgraph
@@ -133,9 +136,9 @@ def create_fw_bw_graph(subgraph, operands):
             bw_graph = trace_joint_graph(
                 subgraph,
                 fw_inputs,
-                fw_outputs,
+                grad_outputs,
             )
-            return fw_graph, bw_graph, len(fw_outputs)
+            return fw_graph, bw_graph, len(grad_outputs)
 
 
 class InvokeSubgraphAutogradOp(torch.autograd.Function):

--- a/torch/_higher_order_ops/prim_hop_base.py
+++ b/torch/_higher_order_ops/prim_hop_base.py
@@ -154,19 +154,31 @@ class PrimHOPBaseFunction(torch.autograd.Function):
         # TODO: Something special needs to happen with min cut partitioner
         with suspend_functionalization(), disable_functional_mode(), torch.enable_grad():
             with disable_proxy_modes_tracing():
-                from .utils import _from_fun, create_fw_bw_graph
+                from .invoke_subgraph import create_fw_bw_graph
+                from .utils import _from_fun
 
                 fw_inputs = pytree.tree_map(_from_fun, operands)
                 fw_outputs = subgraph(*fw_inputs)
-                _, joint_graph = create_fw_bw_graph(
-                    subgraph, False, fw_inputs, fw_outputs
+                _, joint_graph, _ = create_fw_bw_graph(
+                    subgraph, fw_inputs, grad_outputs
                 )
+
+        # The joint graph returns (*grad_inputs, *fwd_outputs).
+        # We only need the grad_inputs.
+        def bwd_fn(*args):
+            operands = args[: -len(grad_outputs)]
+            grad_outs = args[-len(grad_outputs) :]
+            result = joint_graph(*operands, *grad_outs)
+            grad_inputs = result[: -len(grad_outputs)]
+            return grad_inputs
 
         return (
             None,
             None,
             None,
-            *ctx.hop(joint_graph, (*grad_outputs, *operands), **ctx.kwargs),
+            *ctx.hop(
+                FunctionWithNoFreeVars(bwd_fn), (*operands, *grad_outputs), **kwargs
+            ),
         )
 
 

--- a/torch/_higher_order_ops/prim_hop_base.py
+++ b/torch/_higher_order_ops/prim_hop_base.py
@@ -1,0 +1,164 @@
+# mypy: allow-untyped-decorators
+# mypy: allow-untyped-defs
+from typing import List, Optional, Tuple, Union
+
+import torch
+import torch.utils._pytree as pytree
+from torch._C import DispatchKey
+from torch._dispatch.python import suspend_functionalization
+from torch._higher_order_ops.utils import (
+    _from_fun,
+    _maybe_reenter_make_fx,
+    clone_outputs_aliasing_inputs,
+    get_dummy_aot_autograd_config,
+    prepare_fw_with_masks,
+    reenter_make_fx,
+)
+from torch._ops import HigherOrderOperator
+from torch._subclasses import FakeTensorMode
+from torch._subclasses.functional_tensor import disable_functional_mode
+from torch.fx.experimental.proxy_tensor import (
+    disable_proxy_modes_tracing,
+    ProxyTorchDispatchMode,
+    track_tensor_tree,
+)
+from torch.fx.graph_module import GraphModule
+from .invoke_subgraph import create_fw_bw_graph
+import abc
+
+
+class PrimHOPBase(HigherOrderOperator, abc.ABC):
+    """
+    This is the "Base" HOP implementation for a HOP that looks like:
+
+        call_subgraph_hop(subgraph, operands, **kwargs)
+
+    That is:
+    1) the HOP is a "prim" (it stays alive until Inductor)
+    2) the HOP's semantics are subgraph(*operands)
+
+    To use this, please subclass this class and override methods as necessary:
+    ```
+    class InvokeQuant(PrimHOPBase):
+        def __init__(self):
+            return super().__init__("invoke_quant")
+
+    invoke_quant = InvokeQuant()
+
+    def g(x):
+        return x.sin().cos()
+
+    @torch.compile(backend="aot_eager")
+    def f(x):
+        return invoke_quant(g, (x,), scheme="nf4")
+    ```
+    """
+    def __init__(self, hop_name) -> None:
+        super().__init__(hop_name)
+
+        # Set up the registrations
+        # If you want to override any of these, override them in your subclass.
+        self.py_impl(DispatchKey.Autograd)(self.call_Autograd)
+        self.py_functionalize_impl(self.call_Functionalize)
+        self.py_impl(ProxyTorchDispatchMode)(self.call_ProxyTorchDispatchMode)
+        self.py_impl(FakeTensorMode)(self.call_FakeTensorMode)
+        self.py_impl(DispatchKey.CompositeExplicitAutograd)(self.call_CompositeExplicitAutograd)
+
+    def __call__(self, subgraph, operands, **kwargs):
+        if not isinstance(subgraph, (torch.fx.GraphModule, FunctionWithNoFreeVars)):
+            raise RuntimeError(f"{self._name}: when calling this API without torch.compile, we require that the subgraph be a torch.fx.GraphModule (or a function we know doesn't have free variables).")
+        return super().__call__(subgraph, operands, **kwargs)
+
+    def call_Autograd(self, subgraph, operands, **kwargs):
+        if isinstance(subgraph, torch.fx.GraphModule):
+            pass
+        if not torch.is_grad_enabled() or pytree.tree_all_only(
+            torch.Tensor,
+            lambda t: not t.requires_grad,  # type: ignore[union-attr]
+            operands,
+        ):
+            with torch._C._AutoDispatchBelowAutograd():
+                return self(subgraph, operands, **kwargs)
+
+        # We assume the subgraph doesn't mutate inputs and there is no aliasing.
+        # In the PT2 stack, this is Dynamo's responsibility to figure out.
+        return PrimHOPBaseFunction.apply(self, subgraph, kwargs, *operands)
+
+    def call_CompositeExplicitAutograd(self, subgraph, operands, **kwargs):
+        from torch.utils._python_dispatch import _get_current_dispatch_mode
+
+        mode = _get_current_dispatch_mode()
+        assert mode is None, "Mode should never be enabled for CPU/CUDA key"
+        return subgraph(*operands)
+
+    def call_ProxyTorchDispatchMode(self, proxy_mode, subgraph, operands, **kwargs):
+        traced_graph = reenter_make_fx(subgraph)(*operands)
+        assert isinstance(proxy_mode.tracer, torch.fx.Tracer)
+        qualname = proxy_mode.tracer.get_fresh_qualname("subgraph")
+        proxy_mode.tracer.root.register_module(qualname, traced_graph)
+
+        node_args = (traced_graph, operands)
+        proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, node_args)
+        proxy_kwargs = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, kwargs)
+        out_proxy = proxy_mode.tracer.create_proxy(
+            "call_function", self, proxy_args, proxy_kwargs
+        )
+
+        out = self(subgraph, operands, **kwargs)
+        return track_tensor_tree(out, out_proxy, constant=None, tracer=proxy_mode.tracer)
+
+    def call_FakeTensorMode(self, mode, subgraph, operands, **kwargs):
+        # TODO: this should probably route through FakeTensorMode to reuse caching
+        with mode:
+            return subgraph(*operands)
+
+    def call_Functionalize(self, ctx, subgraph, operands, **kwargs):
+        unwrapped_operands = ctx.unwrap_tensors(operands)
+        with ctx.redispatch_to_next() as m:
+            # We assume the subgraph doesn't mutate inputs and there is no aliasing.
+            # In the PT2 stack, this is Dynamo's responsibility to figure out.
+            functionalized_subgraph = FunctionWithNoFreeVars(ctx.functionalize(subgraph))
+            out = self(functionalized_subgraph, unwrapped_operands, **kwargs)
+        return ctx.wrap_tensors(out)
+
+
+class PrimHOPBaseFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, hop, subgraph, kwargs, *operands):
+        ctx.hop = hop
+        ctx.operands = operands
+        ctx.subgraph = subgraph
+        ctx.kwargs = kwargs
+
+        with torch._C._AutoDispatchBelowAutograd():
+            return hop(
+                subgraph,
+                operands,
+                **kwargs
+            )
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        subgraph = ctx.subgraph
+        operands = ctx.operands
+        kwargs = ctx.kwargs
+
+        # TODO: Something special needs to happen with min cut partitioner
+        with suspend_functionalization(), disable_functional_mode(), torch.enable_grad():
+            with disable_proxy_modes_tracing():
+                from .utils import _from_fun, create_fw_bw_graph
+                fw_inputs = pytree.tree_map(_from_fun, operands)
+                fw_outputs = subgraph(*fw_inputs)
+                _, joint_graph = create_fw_bw_graph(
+                    subgraph, False, fw_inputs, fw_outputs
+                )
+
+        return None, None, None, *ctx.hop(joint_graph, (*grad_outputs, *operands), **ctx.kwargs)
+
+
+class FunctionWithNoFreeVars:
+    def __init__(self, fn):
+        self.fn = fn
+
+    def __call__(self, *args, **kwargs):
+        return self.fn(*args, **kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #139928
* __->__ #139898

This PR adds "PrimHOPBase", which is intended to be a base class that
one can extend to create new HOPs that match some criteria:
- they take one subgraph as input, and their semantics are running the
  subgraph on some operands
- the HOP stays alive until Inductor

The motivation is that we are seeing a lot more HOPs (invoke_subgraph,
invoke_quant) that have this property and there can be a lot of shared
code between them.

Future:
- Migrate invoke_subgraph to use this
- There are some TODOs in the code

Test Plan:
- new tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames