### PR TITLE
[ROCm] AMDSMI memory usage unification

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3956,24 +3956,6 @@ class TestCudaMallocAsync(TestCase):
         self.assertTrue(torch.cuda.clock_rate() >= 0)
 
     @unittest.skipIf(TEST_PYNVML, "pynvml/amdsmi is not available")
-    def test_memory_usage(self):
-        """
-        Verify memory activity reports a percentage output on memory utilization
-        """
-        memory_usage = []
-        tensor = torch.randn(16384, 16384).cuda()
-
-        for i in range(300):
-            t = tensor.t()
-            sliced_t = tensor[:8192, :8192].clone()
-            tensor[:8192, :8192] = sliced_t
-            torch.cuda.synchronize()
-            memory_usage.append(torch.cuda.memory_usage())
-
-        peak_memory_utilization = max(memory_usage)
-        self.assertTrue(peak_memory_utilization > 0, peak_memory_utilization <= 100)
-
-    @unittest.skipIf(TEST_PYNVML, "pynvml/amdsmi is not available")
     @unittest.skipIf(not TEST_WITH_ROCM, "amdsmi specific test")
     def test_raw_amdsmi_device_count(self):
         """

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3963,7 +3963,7 @@ class TestCudaMallocAsync(TestCase):
         memory_usage = []
         tensor = torch.randn(16384, 16384).cuda()
 
-        for i in range(100):
+        for i in range(300):
             t = tensor.t()
             sliced_t = tensor[:8192, :8192].clone()
             tensor[:8192, :8192] = sliced_t

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3960,13 +3960,18 @@ class TestCudaMallocAsync(TestCase):
         """
         Verify memory activity reports a percentage output on memory utilization
         """
-        a = torch.randn(16384, 16384).cuda()
-        b = torch.randn(16384, 16384).cuda()
-        res = a + b
-        torch.cuda.synchronize()
-        mem_utilization = torch.cuda.memory_usage()
-        print(mem_utilization)
-        self.assertTrue(mem_utilization > 0, mem_utilization <= 100)
+        memory_usage = []
+        tensor = torch.randn(8192, 8192).cuda()
+        
+        for i in range(100)
+            t = tensor.t()
+            sliced_t = tensor[:4096, :4096].clone()
+            tensor[:4096, :4096] = sliced_t
+            torch.cuda.synchronize()
+            memory_usage.append(torch.cuda.memory_usage())
+
+        peak_memory_utilization = max(memory_usage)
+        self.assertTrue(peak_memory_utilization > 0, peak_memory_utilization <= 100)
 
     @unittest.skipIf(TEST_PYNVML, "pynvml/amdsmi is not available")
     @unittest.skipIf(not TEST_WITH_ROCM, "amdsmi specific test")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3963,7 +3963,7 @@ class TestCudaMallocAsync(TestCase):
         memory_usage = []
         tensor = torch.randn(8192, 8192).cuda()
         
-        for i in range(100)
+        for i in range(100):
             t = tensor.t()
             sliced_t = tensor[:4096, :4096].clone()
             tensor[:4096, :4096] = sliced_t

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3961,12 +3961,12 @@ class TestCudaMallocAsync(TestCase):
         Verify memory activity reports a percentage output on memory utilization
         """
         memory_usage = []
-        tensor = torch.randn(8192, 8192).cuda()
+        tensor = torch.randn(16384, 16384).cuda()
 
         for i in range(100):
             t = tensor.t()
-            sliced_t = tensor[:4096, :4096].clone()
-            tensor[:4096, :4096] = sliced_t
+            sliced_t = tensor[:8192, :8192].clone()
+            tensor[:8192, :8192] = sliced_t
             torch.cuda.synchronize()
             memory_usage.append(torch.cuda.memory_usage())
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3956,6 +3956,19 @@ class TestCudaMallocAsync(TestCase):
         self.assertTrue(torch.cuda.clock_rate() >= 0)
 
     @unittest.skipIf(TEST_PYNVML, "pynvml/amdsmi is not available")
+    def test_memory_usage(self):
+        """
+        Verify memory activity reports a percentage output on memory utilization
+        """
+        a = torch.randn(16384, 16384).cuda()
+        b = torch.randn(16384, 16384).cuda()
+        res = a + b
+        torch.cuda.synchronize()
+        mem_utilization = torch.cuda.memory_usage()
+        print(mem_utilization)
+        self.assertTrue(mem_utilization > 0, mem_utilization <= 100)
+
+    @unittest.skipIf(TEST_PYNVML, "pynvml/amdsmi is not available")
     @unittest.skipIf(not TEST_WITH_ROCM, "amdsmi specific test")
     def test_raw_amdsmi_device_count(self):
         """

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3962,7 +3962,7 @@ class TestCudaMallocAsync(TestCase):
         """
         memory_usage = []
         tensor = torch.randn(8192, 8192).cuda()
-        
+
         for i in range(100):
             t = tensor.t()
             sliced_t = tensor[:4096, :4096].clone()

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1113,7 +1113,8 @@ def _get_amdsmi_device_index(device: Optional[Union[int, Device]]) -> int:
 def _get_amdsmi_memory_usage(device: Optional[Union[Device, int]] = None) -> int:
     handle = _get_amdsmi_handler()
     device = _get_amdsmi_device_index(device)
-    return amdsmi.amdsmi_get_gpu_vram_usage(handle)["vram_used"]
+    handle = amdsmi.amdsmi_get_processor_handles()[device]
+    return amdsmi.amdsmi_get_gpu_activity(handle)["umc_activity"]
 
 
 def _get_amdsmi_utilization(device: Optional[Union[Device, int]] = None) -> int:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/140638

Old implementation used vram_used, which is not the correct equivalent API for pynvml memory utilization.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang @naromero77amd