### PR TITLE
[ONNX] Prioritize strict=False export strategy

### DIFF
--- a/torch/onnx/_internal/exporter/_capture_strategies.py
+++ b/torch/onnx/_internal/exporter/_capture_strategies.py
@@ -378,8 +378,8 @@ class LegacyDynamoStrategy(CaptureStrategy):
 
 
 CAPTURE_STRATEGIES = (
+    TorchExportNonStrictStrategy,  # strict=False is preferred over strict=True because it does not have dynamo issues
     TorchExportStrategy,
-    TorchExportNonStrictStrategy,
     JitTraceConvertStrategy,
     LegacyDynamoStrategy,
 )


### PR DESCRIPTION
Prioritize the `strict=False` export strategy in ONNX export because bypasses dynamo errors for full graph tracing and is preferred according to @SherlockNoMad 