### PR TITLE
Create manylinux 2.28 cuda 12.6 image

### DIFF
--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.9xlarge.ephemeral"
     strategy:
       matrix:
-        cuda_version: ["12.4", "12.1", "11.8"]
+        cuda_version: ["12.6", "12.4", "12.1", "11.8"]
     env:
       GPU_ARCH_TYPE: cuda-manylinux_2_28
       GPU_ARCH_VERSION: ${{ matrix.cuda_version }}


### PR DESCRIPTION
Add a version of the manylinux 2.28 image with cuda 12.6.

Once this is done, cuda 12.6 can be enable for the new magma non-conda distribution provided by https://github.com/pytorch/pytorch/pull/139888

Partially-fixes #139397
