### PR TITLE
Remove most rockset references

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -281,11 +281,6 @@ redis>=4.0.0
 #Description: redis database
 #test that import: anything that tests OSS caching/mocking (inductor/test_codecache.py, inductor/test_max_autotune.py)
 
-rockset==1.0.3
-#Description: queries Rockset
-#Pinned versions: 1.0.3
-#test that import:
-
 ghstack==0.8.0
 #Description: ghstack tool
 #Pinned versions: 0.8.0

--- a/.github/requirements-gha-cache.txt
+++ b/.github/requirements-gha-cache.txt
@@ -12,4 +12,3 @@ nvidia-ml-py==11.525.84
 pyyaml==6.0
 requests==2.32.2
 rich==10.9.0
-rockset==1.0.3

--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -24,7 +24,6 @@ unittest-xml-reporting<=3.2.0,>=2.0.0
 xdoctest==1.1.0
 filelock==3.6.0
 pytest-cpp==2.3.0
-rockset==1.0.3
 z3-solver==4.12.2.0
 tensorboard==2.13.0
 optree==0.13.0

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -559,8 +559,8 @@ class TestTryMerge(TestCase):
                 "expected": "lintrunner / linux-job",
             },
             {
-                "name": "Test `run_test.py` is usable without boto3/rockset",
-                "expected": "Test `run_test.py` is usable without boto3/rockset",
+                "name": "Test `run_test.py` is usable without boto3",
+                "expected": "Test `run_test.py` is usable without boto3",
             },
         ]
 

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -96,7 +96,7 @@ jobs:
           retry_wait_seconds: 30
           command: |
             set -eu
-            python3 -m pip install rockset==1.0.3 'xdoctest>=1.1.0'
+            python3 -m pip install 'xdoctest>=1.1.0'
 
       - name: Start monitoring script
         id: monitor-script

--- a/.github/workflows/check_mergeability_ghstack.yml
+++ b/.github/workflows/check_mergeability_ghstack.yml
@@ -56,7 +56,7 @@ jobs:
           cache: pip
           architecture: x64
 
-      - run: pip install pyyaml==6.0 rockset==1.0.3
+      - run: pip install pyyaml==6.0
         shell: bash
 
       - name: Verify mergeability

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -26,7 +26,7 @@ jobs:
           cache: pip
 
       # Not the direct dependencies but the script uses trymerge
-      - run: pip install pyyaml==6.0 rockset==1.0.3
+      - run: pip install pyyaml==6.0
 
       - name: Setup committer id
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -207,7 +207,7 @@ jobs:
         python3 -m unittest discover -vs .github/scripts -p 'test_*.py'
 
   test_run_test:
-    name: Test `run_test.py` is usable without boto3/rockset
+    name: Test `run_test.py` is usable without boto3
     if: ${{ github.repository == 'pytorch/pytorch' }}
     runs-on: linux.20_04.4x
     steps:

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -53,7 +53,7 @@ jobs:
           cache: pip
 
       - run: |
-          pip3 install requests==2.32.2 rockset==1.0.3 boto3==1.35.42
+          pip3 install requests==2.32.2 boto3==1.35.42
 
       - name: Upload test artifacts
         id: upload-s3
@@ -72,7 +72,6 @@ jobs:
 
       - name: Upload test stats
         env:
-          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
           WORKFLOW_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
@@ -95,16 +94,15 @@ jobs:
           # Analyze the results from disable tests rerun and upload them to S3
           python3 -m tools.stats.check_disabled_tests --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" --repo "${REPO_FULLNAME}"
 
-      - name: Upload gpt-fast benchmark results to Rockset
+      - name: Upload gpt-fast benchmark results to s3
         if: steps.upload-s3.outcome && steps.upload-s3.outcome == 'success' && contains(github.event.workflow_run.name, 'inductor-micro-benchmark')
         env:
-          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
           WORKFLOW_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           REPO_FULLNAME: ${{ github.event.workflow_run.repository.full_name }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          python3 -m tools.stats.upload_dynamo_perf_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" --repo "${REPO_FULLNAME}" --head-branch "${HEAD_BRANCH}" --rockset-collection oss_ci_benchmark --rockset-workspace benchmarks --dynamodb-table torchci-oss-ci-benchmark --match-filename "^gpt_fast_benchmark"
+          python3 -m tools.stats.upload_dynamo_perf_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" --repo "${REPO_FULLNAME}" --head-branch "${HEAD_BRANCH}" --dynamodb-table torchci-oss-ci-benchmark --match-filename "^gpt_fast_benchmark"
 
   check-api-rate:
     if: ${{ always() && github.repository_owner == 'pytorch' }}

--- a/.github/workflows/upload-torch-dynamo-perf-stats.yml
+++ b/.github/workflows/upload-torch-dynamo-perf-stats.yml
@@ -49,7 +49,7 @@ jobs:
           cache: pip
 
       - run: |
-          pip3 install requests==2.32.2 rockset==1.0.3 boto3==1.35.42
+          pip3 install requests==2.32.2 boto3==1.35.42
 
       - name: Upload torch dynamo performance stats to S3
         id: upload-s3
@@ -64,13 +64,12 @@ jobs:
           # on HUD
           python3 -m tools.stats.upload_artifacts --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" --repo "${REPO_FULLNAME}"
 
-      - name: Upload torch dynamo performance stats to Rockset
+      - name: Upload torch dynamo performance stats to s3
         if: steps.upload-s3.outcome && steps.upload-s3.outcome == 'success'
         env:
-          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
           WORKFLOW_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           REPO_FULLNAME: ${{ github.event.workflow_run.repository.full_name }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          python3 -m tools.stats.upload_dynamo_perf_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" --repo "${REPO_FULLNAME}" --head-branch "${HEAD_BRANCH}" --rockset-collection torch_dynamo_perf_stats --rockset-workspace inductor --dynamodb-table torchci-dynamo-perf-stats --match-filename "^inductor_"
+          python3 -m tools.stats.upload_dynamo_perf_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" --repo "${REPO_FULLNAME}" --head-branch "${HEAD_BRANCH}" --dynamodb-table torchci-dynamo-perf-stats --match-filename "^inductor_"

--- a/.github/workflows/upload_test_stats_intermediate.yml
+++ b/.github/workflows/upload_test_stats_intermediate.yml
@@ -28,7 +28,7 @@ jobs:
           cache: pip
 
       - run: |
-          pip3 install requests==2.32.2 rockset==1.0.3 boto3==1.35.42
+          pip3 install requests==2.32.2 boto3==1.35.42
 
       - name: Upload test stats
         env:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1037,7 +1037,7 @@ def get_pytest_args(options, is_cpp_test=False, is_distributed_test=False):
     if RERUN_DISABLED_TESTS:
         # Distributed tests are too slow, so running them x50 will cause the jobs to timeout after
         # 3+ hours. So, let's opt for less number of reruns. We need at least 150 instances of the
-        # test every 2 weeks to satisfy the Rockset query (15 x 14 = 210). The same logic applies
+        # test every 2 weeks to satisfy the SQL query (15 x 14 = 210). The same logic applies
         # to ASAN, which is also slow
         count = 15 if is_distributed_test or TEST_WITH_ASAN else 50
         # When under rerun-disabled-tests mode, run the same tests multiple times to determine their

--- a/tools/stats/README.md
+++ b/tools/stats/README.md
@@ -18,8 +18,8 @@ graph LR
     S3 --> uts[upload-test-stats.yml]
     GHA --> uts
 
-    uts --json--> R[(s3)]
-    s3 --> R[(database)]
+    uts --json--> s3[(s3)]
+    s3 --> DB[(database)]
 ```
 
 Why this weird indirection? Because writing to the database requires special

--- a/tools/stats/README.md
+++ b/tools/stats/README.md
@@ -18,7 +18,8 @@ graph LR
     S3 --> uts[upload-test-stats.yml]
     GHA --> uts
 
-    uts --json--> R[(s3)] --> R[(database)]
+    uts --json--> R[(s3)]
+    s3 --> R[(database)]
 ```
 
 Why this weird indirection? Because writing to the database requires special

--- a/tools/stats/README.md
+++ b/tools/stats/README.md
@@ -8,7 +8,7 @@ We track various stats about each CI job.
 2. When a workflow completes, a `workflow_run` event [triggers
    `upload-test-stats.yml`](https://github.com/pytorch/pytorch/blob/d9fca126fca7d7780ae44170d30bda901f4fe35e/.github/workflows/upload-test-stats.yml#L4).
 3. `upload-test-stats` downloads the raw stats from the intermediate data store
-   and uploads them as JSON to Rockset, our metrics backend.
+   and uploads them as JSON to s3, which then uploads to our database backend
 
 ```mermaid
 graph LR
@@ -18,10 +18,10 @@ graph LR
     S3 --> uts[upload-test-stats.yml]
     GHA --> uts
 
-    uts --json--> R[(Rockset)]
+    uts --json--> R[(s3)] --> R[(database)]
 ```
 
-Why this weird indirection? Because writing to Rockset requires special
+Why this weird indirection? Because writing to the database requires special
 permissions which, for security reasons, we do not want to give to pull request
 CI. Instead, we implemented GitHub's [recommended
 pattern](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

--- a/tools/stats/check_disabled_tests.py
+++ b/tools/stats/check_disabled_tests.py
@@ -168,7 +168,7 @@ def save_results(
     all_tests: dict[str, dict[str, int]],
 ) -> None:
     """
-    Save the result to S3, so it can go to Rockset
+    Save the result to S3, which then gets put into the HUD backened database
     """
     should_be_enabled_tests = {
         name: stats

--- a/tools/stats/upload_metrics.py
+++ b/tools/stats/upload_metrics.py
@@ -78,7 +78,7 @@ def emit_metric(
     metrics: dict[str, Any],
 ) -> None:
     """
-    Upload a metric to DynamoDB (and from there, Rockset).
+    Upload a metric to DynamoDB (and from there, the HUD backend database).
 
     Even if EMIT_METRICS is set to False, this function will still run the code to
     validate and shape the metrics, skipping just the upload.

--- a/tools/stats/upload_sccache_stats.py
+++ b/tools/stats/upload_sccache_stats.py
@@ -31,7 +31,7 @@ def get_sccache_stats(
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Upload test stats to Rockset")
+    parser = argparse.ArgumentParser(description="Upload test stats to s3")
     parser.add_argument(
         "--workflow-run-id",
         type=int,

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -68,7 +68,7 @@ def process_xml_element(element: ET.Element) -> dict[str, Any]:
     ret.update(element.attrib)
 
     # The XML format encodes all values as strings. Convert to ints/floats if
-    # possible to make aggregation possible in Rockset.
+    # possible to make aggregation possible in SQL.
     for k, v in ret.items():
         try:
             ret[k] = int(v)
@@ -218,7 +218,7 @@ def summarize_test_cases(test_cases: list[dict[str, Any]]) -> list[dict[str, Any
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Upload test stats to Rockset")
+    parser = argparse.ArgumentParser(description="Upload test stats to s3")
     parser.add_argument(
         "--workflow-run-id",
         required=True,
@@ -256,11 +256,11 @@ if __name__ == "__main__":
     else:
         test_cases = get_tests(args.workflow_run_id, args.workflow_run_attempt)
 
-    # Flush stdout so that any errors in Rockset upload show up last in the logs.
+    # Flush stdout so that any errors in the upload show up last in the logs.
     sys.stdout.flush()
 
     # For PRs, only upload a summary of test_runs. This helps lower the
-    # volume of writes we do to Rockset.
+    # volume of writes we do to the HUD backend database.
     test_case_summary = summarize_test_cases(test_cases)
 
     upload_workflow_stats_to_s3(

--- a/tools/stats/upload_test_stats_intermediate.py
+++ b/tools/stats/upload_test_stats_intermediate.py
@@ -6,7 +6,7 @@ from tools.stats.upload_test_stats import get_tests
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Upload test stats to Rockset")
+    parser = argparse.ArgumentParser(description="Upload test stats to s3")
     parser.add_argument(
         "--workflow-run-id",
         required=True,
@@ -24,7 +24,7 @@ if __name__ == "__main__":
 
     test_cases = get_tests(args.workflow_run_id, args.workflow_run_attempt)
 
-    # Flush stdout so that any errors in Rockset upload show up last in the logs.
+    # Flush stdout so that any errors in the upload show up last in the logs.
     sys.stdout.flush()
 
     upload_additional_info(args.workflow_run_id, args.workflow_run_attempt, test_cases)

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -14,10 +14,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from tools.stats.upload_metrics import add_global_metric, emit_metric, global_metrics
-from tools.stats.upload_stats_lib import (
-    get_s3_resource,
-    remove_nan_inf,
-)
+from tools.stats.upload_stats_lib import get_s3_resource, remove_nan_inf
 
 
 sys.path.remove(str(REPO_ROOT))

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -15,10 +15,8 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from tools.stats.upload_metrics import add_global_metric, emit_metric, global_metrics
 from tools.stats.upload_stats_lib import (
-    BATCH_SIZE,
     get_s3_resource,
     remove_nan_inf,
-    upload_to_rockset,
 )
 
 
@@ -259,38 +257,6 @@ class TestUploadStats(unittest.TestCase):
         emit_metric("metric_name", metric)
 
         self.assertTrue(self.emitted_metric["did_not_emit"])
-
-    def test_upload_to_rockset_batch_size(self, _mocked_resource: Any) -> None:
-        cases = [
-            {
-                "batch_size": BATCH_SIZE - 1,
-                "expected_number_of_requests": 1,
-            },
-            {
-                "batch_size": BATCH_SIZE,
-                "expected_number_of_requests": 1,
-            },
-            {
-                "batch_size": BATCH_SIZE + 1,
-                "expected_number_of_requests": 2,
-            },
-        ]
-
-        for case in cases:
-            mock_client = mock.Mock()
-            mock_client.Documents.add_documents.return_value = "OK"
-
-            batch_size = case["batch_size"]
-            expected_number_of_requests = case["expected_number_of_requests"]
-
-            docs = list(range(batch_size))
-            upload_to_rockset(
-                collection="test", docs=docs, workspace="commons", client=mock_client
-            )
-            self.assertEqual(
-                mock_client.Documents.add_documents.call_count,
-                expected_number_of_requests,
-            )
 
     def test_remove_nan_inf(self, _mocked_resource: Any) -> None:
         checks = [


### PR DESCRIPTION
Remove most references to rockset:
* replace comments and docs with a generic "backend database"
* Delete `upload_to_rockset`, so we no longer need to install the package.
* Do not upload perf stats to rockset as well (we should be completely on DynamoDB now right @huydhn?)

According to VSCode, it went from 41 -> 7 instances of "rockset" in the repo