### PR TITLE
[PT2] native_layer_norm make [out, mean, rstd] match input dtype regardless of device

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -3269,7 +3269,7 @@ def native_layer_norm(
         out = out * weight + bias
 
     out = _maybe_convert_to_dtype(out, input.dtype)  # type: ignore[assignment]
-    if input.device.type == "cpu":
+    if input.device.type in ["cpu", "meta"]:
         mean = _maybe_convert_to_dtype(mean, input.dtype)  # type: ignore[assignment]
         rstd = _maybe_convert_to_dtype(rstd, input.dtype)  # type: ignore[assignment]
     return (out, mean, rstd)


### PR DESCRIPTION
Summary:
**Problem:**

We have run into an issue when we feed a BF16 input tensor to `aten.native_layer_norm.default` with BF16 weights and bias (dispatched by dynamo), it returns 3 outputs [out, mean, rstd] in dtypes [BF16, FP32, FP32].

The expected dtypes should be [BF16, BF16, BF16], which is what `torch.native_layer_norm` returns on CPU.

**Solution:**

I found out the root cause is that mean and rstd dtype casts are guarded by device type. This issue can be mitigated by removing the if condition based on device type.

Test Plan: CI

Differential Revision: D65558497


