### PR TITLE
Migrate invoke_subgraph to subclass PrimHOPBase

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -1,7 +1,6 @@
 # Owner(s): ["module: higher order operators"]
 # flake8: noqa: B950
 
-import unittest
 
 import torch
 import torch._dynamo
@@ -96,7 +95,6 @@ class TestInvokeSubgraph(TestCase):
 
         self.assertEqual(ref, res)
 
-    @unittest.skip("TODO: need to find a better test case")
     def test_differing_strides_for_grad_outs(self):
         class CustomOp(torch.autograd.Function):
             @staticmethod
@@ -105,12 +103,8 @@ class TestInvokeSubgraph(TestCase):
 
             @staticmethod
             def backward(ctx, grad_out):
-                if grad_out.is_contiguous():
-                    return grad_out.sin()
-                else:
-                    return grad_out.cos()
-                # a = grad_out.reshape(12, 5)
-                # return torch.cos(torch.reshape(a, (3, 4, 5)))
+                a = grad_out.view(12, 5)
+                return torch.cos(torch.reshape(a, (3, 4, 5)))
 
         def gn(x):
             return (CustomOp.apply(x),)
@@ -130,8 +124,8 @@ class TestInvokeSubgraph(TestCase):
         res = aot_fn(x_clone)
 
         # Run backward
-        ref.clone().sum().backward()
-        res.clone().sum().backward()
+        ref.sum().backward()
+        res.sum().backward()
 
         self.assertEqual(ref, res)
         self.assertEqual(x.grad, x_clone.grad)

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -1,6 +1,8 @@
 # Owner(s): ["module: higher order operators"]
 # flake8: noqa: B950
 
+import unittest
+
 import torch
 import torch._dynamo
 import torch._functorch
@@ -9,6 +11,7 @@ import torch._inductor.decomposition
 from functorch.compile import aot_function, nop
 from torch._dynamo.testing import AotEagerAndRecordGraphs, normalize_gm
 from torch._higher_order_ops import invoke_subgraph
+from torch._higher_order_ops.prim_hop_base import FunctionWithNoFreeVars
 from torch.testing._internal.common_utils import (
     run_tests,
     skipIfTorchDynamo,
@@ -24,7 +27,9 @@ class TestInvokeSubgraph(TestCase):
             return (torch.mul(x, y),)
 
         def fn(x, y):
-            return invoke_subgraph(gn, None, (x, y))[0]
+            return invoke_subgraph(FunctionWithNoFreeVars(gn), (x, y), identifier=None)[
+                0
+            ]
 
         x = torch.randn(8, requires_grad=True)
         y = torch.randn(8, requires_grad=True)
@@ -47,7 +52,9 @@ class TestInvokeSubgraph(TestCase):
             return (torch.mul(x, y),)
 
         def fn(x, y):
-            return invoke_subgraph(gn, None, (x, y))[0]
+            return invoke_subgraph(FunctionWithNoFreeVars(gn), (x, y), identifier=None)[
+                0
+            ]
 
         x = torch.randn(8, requires_grad=True)
         y = torch.randn(8, requires_grad=True)
@@ -76,9 +83,11 @@ class TestInvokeSubgraph(TestCase):
             return (torch.sin(x),)
 
         def fn(x):
-            a = invoke_subgraph(cos, None, (x,))[0]
-            b = invoke_subgraph(sin, None, (a,))[0]
-            return invoke_subgraph(cos, None, (b,))[0]
+            a = invoke_subgraph(FunctionWithNoFreeVars(cos), (x,), identifier=None)[0]
+            b = invoke_subgraph(FunctionWithNoFreeVars(sin), (a,), identifier=None)[0]
+            return invoke_subgraph(FunctionWithNoFreeVars(cos), (b,), identifier=None)[
+                0
+            ]
 
         x = torch.randn(8, requires_grad=True)
         ref = fn(x)
@@ -87,6 +96,7 @@ class TestInvokeSubgraph(TestCase):
 
         self.assertEqual(ref, res)
 
+    @unittest.skip("TODO: need to find a better test case")
     def test_differing_strides_for_grad_outs(self):
         class CustomOp(torch.autograd.Function):
             @staticmethod
@@ -95,14 +105,18 @@ class TestInvokeSubgraph(TestCase):
 
             @staticmethod
             def backward(ctx, grad_out):
-                a = grad_out.view(12, 5)
-                return torch.cos(torch.reshape(a, (3, 4, 5)))
+                if grad_out.is_contiguous():
+                    return grad_out.sin()
+                else:
+                    return grad_out.cos()
+                # a = grad_out.reshape(12, 5)
+                # return torch.cos(torch.reshape(a, (3, 4, 5)))
 
         def gn(x):
             return (CustomOp.apply(x),)
 
         def fn(x):
-            a = invoke_subgraph(gn, None, (x,))[0]
+            a = invoke_subgraph(FunctionWithNoFreeVars(gn), (x,), identifier=None)[0]
             # Force stride changes so that backward view causes a failure if
             # contiguous not called.
             b = torch.permute(a, (0, 2, 1))
@@ -116,8 +130,8 @@ class TestInvokeSubgraph(TestCase):
         res = aot_fn(x_clone)
 
         # Run backward
-        ref.sum().backward()
-        res.sum().backward()
+        ref.clone().sum().backward()
+        res.clone().sum().backward()
 
         self.assertEqual(ref, res)
         self.assertEqual(x.grad, x_clone.grad)
@@ -137,7 +151,7 @@ class TestInvokeSubgraphCompile(TestCase):
             return (torch.mul(x, y),)
 
         def fn(x, y):
-            return invoke_subgraph(gn, None, (x, y))[0]
+            return invoke_subgraph(gn, (x, y), identifier=None)[0]
 
         x = torch.randn(8, requires_grad=True)
         y = torch.randn(8, requires_grad=True)
@@ -160,16 +174,19 @@ class TestInvokeSubgraphCompile(TestCase):
             return (torch.mul(x, y),)
 
         def fn(x, y):
-            a = invoke_subgraph(gn, None, (x, y))[0]
-            return invoke_subgraph(gn, None, (a, y))[0]
+            a = invoke_subgraph(gn, (x, y), identifier=None)[0]
+            return invoke_subgraph(gn, (a, y), identifier=None)[0]
 
         x = torch.randn(8, requires_grad=True)
         y = torch.randn(8, requires_grad=True)
+        old_gn = gn
+        gn = FunctionWithNoFreeVars(gn)
         ref = fn(x, y)
 
         x_clone = x.clone().detach().requires_grad_(True)
         y_clone = y.clone().detach().requires_grad_(True)
         backend = AotEagerAndRecordGraphs()
+        gn = old_gn
         res = torch.compile(fn, backend=backend, fullgraph=True)(x_clone, y_clone)
 
         # Run backward
@@ -198,11 +215,11 @@ class GraphModule(torch.nn.Module):
         l_y_ = L_y_
 
         invoke_subgraph_0 = self.invoke_subgraph_0
-        invoke_subgraph = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_0, 'invoke_subgraph_0', (l_x_, l_y_));  invoke_subgraph_0 = l_x_ = None
+        invoke_subgraph = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_0, (l_x_, l_y_), identifier = 'invoke_subgraph_0');  invoke_subgraph_0 = l_x_ = None
         a: "f32[8]" = invoke_subgraph[0];  invoke_subgraph = None
 
         invoke_subgraph_1 = self.invoke_subgraph_0
-        invoke_subgraph_2 = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_1, 'invoke_subgraph_0', (a, l_y_));  invoke_subgraph_1 = a = l_y_ = None
+        invoke_subgraph_2 = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_1, (a, l_y_), identifier = 'invoke_subgraph_0');  invoke_subgraph_1 = a = l_y_ = None
         getitem_1: "f32[8]" = invoke_subgraph_2[0];  invoke_subgraph_2 = None
         return (getitem_1,)
 
@@ -218,16 +235,16 @@ class GraphModule(torch.nn.Module):
             """\
 class GraphModule(torch.nn.Module):
     def forward(self, primals_1: "f32[8]", primals_2: "f32[8]"):
-        repeated_subgraph0 = self.repeated_subgraph0
-        invoke_subgraph = torch.ops.higher_order.invoke_subgraph(repeated_subgraph0, '___forward_invoke_subgraph_0', (primals_1, primals_2));  repeated_subgraph0 = None
+        subgraph0 = self.subgraph0
+        invoke_subgraph = torch.ops.higher_order.invoke_subgraph(subgraph0, (primals_1, primals_2), identifier = '___forward_invoke_subgraph_0');  subgraph0 = None
         getitem: "f32[8]" = invoke_subgraph[0];  invoke_subgraph = None
 
-        repeated_subgraph0_1 = self.repeated_subgraph0
-        invoke_subgraph_1 = torch.ops.higher_order.invoke_subgraph(repeated_subgraph0_1, '___forward_invoke_subgraph_0', (getitem, primals_2));  repeated_subgraph0_1 = None
+        subgraph0_1 = self.subgraph0
+        invoke_subgraph_1 = torch.ops.higher_order.invoke_subgraph(subgraph0_1, (getitem, primals_2), identifier = '___forward_invoke_subgraph_0');  subgraph0_1 = None
         getitem_1: "f32[8]" = invoke_subgraph_1[0];  invoke_subgraph_1 = None
         return (getitem_1, primals_1, primals_2, getitem)
 
-    class repeated_subgraph0(torch.nn.Module):
+    class subgraph0(torch.nn.Module):
         def forward(self, arg0_1: "f32[8]", arg1_1: "f32[8]"):
             mul: "f32[8]" = torch.ops.aten.mul.Tensor(arg0_1, arg1_1);  arg0_1 = arg1_1 = None
             return (mul,)
@@ -244,19 +261,25 @@ class GraphModule(torch.nn.Module):
         def fn(x, y):
             nonlocal counter
             counter = 2
-            a = invoke_subgraph(gn, None, (x, y))[0]
+            a = invoke_subgraph(gn, (x, y), identifier=None)[0]
             counter = 3
-            return invoke_subgraph(gn, None, (a, y))[0]
+            return invoke_subgraph(gn, (a, y), identifier=None)[0]
 
-        x = torch.randn(8, requires_grad=True)
-        y = torch.randn(8, requires_grad=True)
-        ref = fn(x, y)
+        def fn2(x, y):
+            nonlocal counter
+            counter = 2
+            a = gn(x, y)[0]
+            counter = 3
+            return gn(a, y)[0]
+
+        x = torch.ones(8, requires_grad=True)
+        y = torch.ones(8, requires_grad=True)
+        ref = fn2(x, y)
 
         x_clone = x.clone().detach().requires_grad_(True)
         y_clone = y.clone().detach().requires_grad_(True)
         res = torch.compile(fn, backend="inductor", fullgraph=True)(x_clone, y_clone)
 
-        # Run backward
         ref.sum().backward()
         res.sum().backward()
 
@@ -278,11 +301,11 @@ class GraphModule(torch.nn.Module):
         l_y_ = L_y_
 
         invoke_subgraph_0 = self.invoke_subgraph_0
-        invoke_subgraph = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_0, 'invoke_subgraph_0', (l_x_, l_y_));  invoke_subgraph_0 = l_x_ = None
+        invoke_subgraph = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_0, (l_x_, l_y_), identifier = 'invoke_subgraph_0');  invoke_subgraph_0 = l_x_ = None
         a: "f32[8]" = invoke_subgraph[0];  invoke_subgraph = None
 
         invoke_subgraph_1 = self.invoke_subgraph_1
-        invoke_subgraph_2 = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_1, 'invoke_subgraph_1', (a, l_y_));  invoke_subgraph_1 = a = l_y_ = None
+        invoke_subgraph_2 = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_1, (a, l_y_), identifier = 'invoke_subgraph_1');  invoke_subgraph_1 = a = l_y_ = None
         getitem_1: "f32[8]" = invoke_subgraph_2[0];  invoke_subgraph_2 = None
         return (getitem_1,)
 
@@ -309,7 +332,7 @@ class GraphModule(torch.nn.Module):
 
         def fn(x, y):
             for _ in range(5):
-                x = invoke_subgraph(gn, None, (x, y))
+                x = invoke_subgraph(gn, (x, y), identifier=None)
             return x
 
         backend = AotEagerAndRecordGraphs()
@@ -330,19 +353,19 @@ class GraphModule(torch.nn.Module):
         l_y_ = L_y_
 
         invoke_subgraph_0 = self.invoke_subgraph_0
-        invoke_subgraph = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_0, 'invoke_subgraph_0', (l_x_, l_y_));  invoke_subgraph_0 = l_x_ = None
+        invoke_subgraph = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_0, (l_x_, l_y_), identifier = 'invoke_subgraph_0');  invoke_subgraph_0 = l_x_ = None
         x: "f32[8]" = invoke_subgraph[0];  invoke_subgraph = None
         invoke_subgraph_1 = self.invoke_subgraph_0
-        invoke_subgraph_2 = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_1, 'invoke_subgraph_0', (x, l_y_));  invoke_subgraph_1 = x = None
+        invoke_subgraph_2 = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_1, (x, l_y_), identifier = 'invoke_subgraph_0');  invoke_subgraph_1 = x = None
         x_1: "f32[8]" = invoke_subgraph_2[0];  invoke_subgraph_2 = None
         invoke_subgraph_3 = self.invoke_subgraph_0
-        invoke_subgraph_4 = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_3, 'invoke_subgraph_0', (x_1, l_y_));  invoke_subgraph_3 = x_1 = None
+        invoke_subgraph_4 = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_3, (x_1, l_y_), identifier = 'invoke_subgraph_0');  invoke_subgraph_3 = x_1 = None
         x_2: "f32[8]" = invoke_subgraph_4[0];  invoke_subgraph_4 = None
         invoke_subgraph_5 = self.invoke_subgraph_0
-        invoke_subgraph_6 = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_5, 'invoke_subgraph_0', (x_2, l_y_));  invoke_subgraph_5 = x_2 = None
+        invoke_subgraph_6 = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_5, (x_2, l_y_), identifier = 'invoke_subgraph_0');  invoke_subgraph_5 = x_2 = None
         x_3: "f32[8]" = invoke_subgraph_6[0];  invoke_subgraph_6 = None
         invoke_subgraph_7 = self.invoke_subgraph_0
-        invoke_subgraph_8 = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_7, 'invoke_subgraph_0', (x_3, l_y_));  invoke_subgraph_7 = x_3 = l_y_ = None
+        invoke_subgraph_8 = torch.ops.higher_order.invoke_subgraph(invoke_subgraph_7, (x_3, l_y_), identifier = 'invoke_subgraph_0');  invoke_subgraph_7 = x_3 = l_y_ = None
         x_4: "f32[8]" = invoke_subgraph_8[0];  invoke_subgraph_8 = None
         return (x_4,)
 
@@ -363,15 +386,13 @@ class GraphModule(torch.nn.Module):
             return (torch.mul(x, y),)
 
         def fn(x, y):
-            return invoke_subgraph(gn, None, (x, y))[0]
+            return invoke_subgraph(gn, (x, y), identifier=None)[0]
 
         x = torch.randn(8, requires_grad=False)
         y = torch.randn(8, requires_grad=False)
 
         opt_fn = torch.compile(fn, backend="inductor", fullgraph=True)
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported, "NYI: invoke_subgraph with aliasing"
-        ):
+        with self.assertRaisesRegex(RuntimeError, "mutated"):
             opt_fn(x, y)
 
     def test_simple_module(self):
@@ -381,7 +402,7 @@ class GraphModule(torch.nn.Module):
             return mod(x)
 
         def fn(x):
-            return invoke_subgraph(gn, mod, (x,))
+            return invoke_subgraph(gn, (x,), identifier=None)
 
         opt_fn = torch.compile(fn, backend="inductor", fullgraph=True)
         x = torch.randn(8, 8, requires_grad=True)
@@ -395,16 +416,14 @@ class GraphModule(torch.nn.Module):
             return (x, torch.mul(x, y))
 
         def fn(x, y):
-            outs = invoke_subgraph(gn, None, (x, y))
+            outs = invoke_subgraph(gn, (x, y), identifier=None)
             return outs[0] * outs[1]
 
         x = torch.randn(8, requires_grad=False)
         y = torch.randn(8, requires_grad=False)
 
         opt_fn = torch.compile(fn, backend="inductor", fullgraph=True)
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported, "NYI: invoke_subgraph with aliasing"
-        ):
+        with self.assertRaisesRegex(RuntimeError, "aliases"):
             opt_fn(x, y)
 
 

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3214,6 +3214,7 @@ LEGACY_MOD_INLINELIST = {
     "torch._functorch.deprecated",
     "torch._higher_order_ops.cond",
     "torch._higher_order_ops.while_loop",
+    "torch._higher_order_ops.prim_hop_base",
     "torch._higher_order_ops.associative_scan",
     "torch._higher_order_ops.scan",
     "torch._higher_order_ops.utils",

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -53,16 +53,43 @@ class InvokeSubgraphHOP(PrimHOPBase):
 
         return super().__call__(subgraph, operands, identifier=identifier)
 
-    def _forward_kwargs(self, *_, **kwargs):
-        return {"identifier": f"___forward_{kwargs['identifier']}"}
+    def _call_Autograd(self, subgraph, operands, *, identifier):
+        if not torch.is_grad_enabled():
+            with torch._C._AutoDispatchBelowAutograd():
+                return invoke_subgraph(subgraph, operands, identifier=identifier)
 
-    def _backward_kwargs(self, *_, **kwargs):
-        # TODO: I've wiped out the Autograd cache. We should
-        # figure out what we want to do with it...
-        # BTW the following is probably wrong. Each backward might actually
-        # be different depending on the grad_output, so they probably need a unique
-        # identifier?
-        return {"identifier": f"___backward_{kwargs['identifier']}"}
+        # A shortcut for the case where all inputs don't require gradient,
+        # we skip tracing the forward and backward graph.
+        if pytree.tree_all_only(
+            torch.Tensor,
+            lambda t: not t.requires_grad,  # type: ignore[union-attr]
+            operands,
+        ):
+            with torch._C._AutoDispatchBelowAutograd():
+                return invoke_subgraph(subgraph, operands, identifier=identifier)
+
+        # Check if we have already traced the subgraph.
+        invoke_subgraph_cache = get_invoke_subgraph_cache()
+        if invoke_subgraph_cache:
+            if saved_autograd_fn := invoke_subgraph_cache.get_autograd_key_entry(
+                identifier
+            ):
+                return saved_autograd_fn(*operands)
+
+        fw_graph, bw_graph, num_fw_outs = create_fw_bw_graph(subgraph, operands)
+
+        def autograd_fn_callable(*args):
+            return InvokeSubgraphAutogradOp.apply(
+                fw_graph, bw_graph, identifier, num_fw_outs, *args
+            )
+
+        # Save the autograd_fn_callable in the dispatch set cache.
+        if invoke_subgraph_cache:
+            invoke_subgraph_cache.add_autograd_key_entry(
+                identifier, autograd_fn_callable
+            )
+
+        return autograd_fn_callable(*operands)
 
     def _trace_subgraph(self, proxy_mode, subgraph, operands, *, identifier):
         # Check if we have already traced the subgraph.
@@ -115,3 +142,118 @@ def get_invoke_subgraph_cache():
     if tracing_ctx := torch._guards.TracingContext.try_get():
         cache = tracing_ctx.hop_dispatch_set_cache.get_cache(invoke_subgraph)
     return cache
+
+
+def trace_joint_graph(fn, fw_inputs, fw_outputs):
+    """
+    Naively trace out a joint graph. This simplifies the reconstruction of joint
+    graph in the min-cut partitioner later on.
+    """
+    from torch._functorch.aot_autograd import create_joint
+
+    dummy_aot_config = get_dummy_aot_autograd_config()
+
+    # This joint_fn is inserted as the backward graph as is. This simplifies the
+    # min-cut partitioner work later on.
+    #   Input signature - (*primals, *tangents)
+    #   Output signature - (*grads, *fw_outs)
+    # The output signature is deliberately kept grads first and fw_outs second.
+    # Having grads first makes the min-cut partitioner HOP graph stitching
+    # easier.
+    def joint_fn(*primals_and_tangents):
+        primals = primals_and_tangents[: len(fw_inputs)]
+        tangents = primals_and_tangents[len(fw_inputs) :]
+
+        fw_outs, grads = create_joint(
+            prepare_fw_with_masks(fn), aot_config=dummy_aot_config
+        )(primals, tangents)
+
+        maybe_clone = clone_outputs_aliasing_inputs(primals_and_tangents)
+
+        # return signature is deliberately kept (*grads, *fw_outs). This
+        # simplifies partitioning work later on.
+        return pytree.tree_map(maybe_clone, grads + list(fw_outs))
+
+    primals = list(fw_inputs)
+    # This assumes that the tangent strides match fw_outputs strides. Check the
+    # InvokeSubgraphAutogradOp backward op for the contiguous call.
+    tangents = [_from_fun(out) for out in fw_outputs]
+
+    joint_operands = primals + tangents
+
+    return _maybe_reenter_make_fx(joint_fn)(*joint_operands)
+
+
+def create_fw_bw_graph(subgraph, operands):
+    with suspend_functionalization(), disable_functional_mode():
+        with disable_proxy_modes_tracing():
+            # args are functional tensors, generate some example tensors
+            fw_inputs = pytree.tree_map(_from_fun, operands)
+
+            fw_outputs = pytree.tree_map(_from_fun, subgraph(*fw_inputs))
+            if any(
+                not isinstance(out, torch.Tensor)
+                for out in fw_outputs
+                if out is not None
+            ):
+                raise RuntimeError(
+                    "Expect outputs of invoke_subgraph to only contains tensors or None. "
+                    f"Got types {[type(out) for out in fw_outputs]}."
+                )
+
+            # Trace the forward subgraph
+            fw_graph = _maybe_reenter_make_fx(subgraph)(*fw_inputs)
+
+            # Trace the joint graph and assign it to the bwd graph
+            bw_graph = trace_joint_graph(
+                subgraph,
+                fw_inputs,
+                fw_outputs,
+            )
+            return fw_graph, bw_graph, len(fw_outputs)
+
+
+class InvokeSubgraphAutogradOp(torch.autograd.Function):
+    """
+    This autograd function op is to stash the backward graph in the ctx while
+    running forward.
+    """
+
+    @staticmethod
+    def forward(ctx, fw_graph, bw_graph, identifier, num_fw_outs, *operands):
+        ctx._fw_graph = fw_graph
+        ctx._bw_graph = bw_graph
+        ctx._identifier = identifier
+        ctx._num_fw_outs = num_fw_outs
+
+        with torch._C._AutoDispatchBelowAutograd():
+            out = invoke_subgraph(
+                fw_graph,
+                operands,
+                identifier=f"___forward_{identifier}",
+            )
+
+        ctx.save_for_backward(*operands)
+        return out
+
+    @staticmethod
+    def backward(ctx, *grad_outs):
+        bw_graph = ctx._bw_graph
+        identifier = ctx._identifier
+        primals = ctx.saved_tensors
+        num_fw_outs = ctx._num_fw_outs
+
+        # While tracing we made the assumption that tangents are contiguous. So,
+        # force the grad_outs to be contiguous.
+        contiguous_grad_outs = tuple([o.contiguous() for o in grad_outs])
+
+        # bw_graph is a joint graph with signature (*primals_and_tangents) and
+        # returns (*grads_and_fw_outs). To get the grads, we use the num_fw_outs
+        # to extract the grads.
+        primals_and_tangents = primals + contiguous_grad_outs
+        grads = invoke_subgraph(
+            bw_graph,
+            primals_and_tangents,
+            identifier=f"___backward_{identifier}",
+        )[:-num_fw_outs]
+        return None, None, None, None, *grads

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -53,12 +53,15 @@ class InvokeSubgraphHOP(PrimHOPBase):
 
         return super().__call__(subgraph, operands, identifier=identifier)
 
-    # TODO: I've wiped out the Autograd cache. We should
-    # figure out what we want to do with it...
     def _forward_kwargs(self, *_, **kwargs):
         return {"identifier": f"___forward_{kwargs['identifier']}"}
 
     def _backward_kwargs(self, *_, **kwargs):
+        # TODO: I've wiped out the Autograd cache. We should
+        # figure out what we want to do with it...
+        # BTW the following is probably wrong. Each backward might actually
+        # be different depending on the grad_output, so they probably need a unique
+        # identifier?
         return {"identifier": f"___backward_{kwargs['identifier']}"}
 
     def _trace_subgraph(self, proxy_mode, subgraph, operands, *, identifier):
@@ -112,118 +115,3 @@ def get_invoke_subgraph_cache():
     if tracing_ctx := torch._guards.TracingContext.try_get():
         cache = tracing_ctx.hop_dispatch_set_cache.get_cache(invoke_subgraph)
     return cache
-
-
-def trace_joint_graph(fn, fw_inputs, fw_outputs):
-    """
-    Naively trace out a joint graph. This simplifies the reconstruction of joint
-    graph in the min-cut partitioner later on.
-    """
-    from torch._functorch.aot_autograd import create_joint
-
-    dummy_aot_config = get_dummy_aot_autograd_config()
-
-    # This joint_fn is inserted as the backward graph as is. This simplifies the
-    # min-cut partitioner work later on.
-    #   Input signature - (*primals, *tangents)
-    #   Output signature - (*grads, *fw_outs)
-    # The output signature is deliberately kept grads first and fw_outs second.
-    # Having grads first makes the min-cut partitioner HOP graph stitching
-    # easier.
-    def joint_fn(*primals_and_tangents):
-        primals = primals_and_tangents[: len(fw_inputs)]
-        tangents = primals_and_tangents[len(fw_inputs) :]
-
-        fw_outs, grads = create_joint(
-            prepare_fw_with_masks(fn), aot_config=dummy_aot_config
-        )(primals, tangents)
-
-        maybe_clone = clone_outputs_aliasing_inputs(primals_and_tangents)
-
-        # return signature is deliberately kept (*grads, *fw_outs). This
-        # simplifies partitioning work later on.
-        return pytree.tree_map(maybe_clone, grads + list(fw_outs))
-
-    primals = list(fw_inputs)
-    # This assumes that the tangent strides match fw_outputs strides. Check the
-    # InvokeSubgraphAutogradOp backward op for the contiguous call.
-    tangents = [_from_fun(out) for out in fw_outputs]
-
-    joint_operands = primals + tangents
-
-    return _maybe_reenter_make_fx(joint_fn)(*joint_operands)
-
-
-def create_fw_bw_graph(subgraph, operands):
-    with suspend_functionalization(), disable_functional_mode():
-        with disable_proxy_modes_tracing():
-            # args are functional tensors, generate some example tensors
-            fw_inputs = pytree.tree_map(_from_fun, operands)
-
-            fw_outputs = pytree.tree_map(_from_fun, subgraph(*fw_inputs))
-            if any(
-                not isinstance(out, torch.Tensor)
-                for out in fw_outputs
-                if out is not None
-            ):
-                raise RuntimeError(
-                    "Expect outputs of invoke_subgraph to only contains tensors or None. "
-                    f"Got types {[type(out) for out in fw_outputs]}."
-                )
-
-            # Trace the forward subgraph
-            fw_graph = _maybe_reenter_make_fx(subgraph)(*fw_inputs)
-
-            # Trace the joint graph and assign it to the bwd graph
-            bw_graph = trace_joint_graph(
-                subgraph,
-                fw_inputs,
-                fw_outputs,
-            )
-            return fw_graph, bw_graph, len(fw_outputs)
-
-
-class InvokeSubgraphAutogradOp(torch.autograd.Function):
-    """
-    This autograd function op is to stash the backward graph in the ctx while
-    running forward.
-    """
-
-    @staticmethod
-    def forward(ctx, fw_graph, bw_graph, identifier, num_fw_outs, *operands):
-        ctx._fw_graph = fw_graph
-        ctx._bw_graph = bw_graph
-        ctx._identifier = identifier
-        ctx._num_fw_outs = num_fw_outs
-
-        with torch._C._AutoDispatchBelowAutograd():
-            out = invoke_subgraph(
-                fw_graph,
-                operands,
-                identifier=f"___forward_{identifier}",
-            )
-
-        ctx.save_for_backward(*operands)
-        return out
-
-    @staticmethod
-    def backward(ctx, *grad_outs):
-        bw_graph = ctx._bw_graph
-        identifier = ctx._identifier
-        primals = ctx.saved_tensors
-        num_fw_outs = ctx._num_fw_outs
-
-        # While tracing we made the assumption that tangents are contiguous. So,
-        # force the grad_outs to be contiguous.
-        contiguous_grad_outs = tuple([o.contiguous() for o in grad_outs])
-
-        # bw_graph is a joint graph with signature (*primals_and_tangents) and
-        # returns (*grads_and_fw_outs). To get the grads, we use the num_fw_outs
-        # to extract the grads.
-        primals_and_tangents = primals + contiguous_grad_outs
-        grads = invoke_subgraph(
-            bw_graph,
-            primals_and_tangents,
-            identifier=f"___backward_{identifier}",
-        )[:-num_fw_outs]
-        return None, None, None, None, *grads

--- a/torch/_higher_order_ops/prim_hop_base.py
+++ b/torch/_higher_order_ops/prim_hop_base.py
@@ -90,12 +90,6 @@ class PrimHOPBase(HigherOrderOperator, abc.ABC):
         # In the PT2 stack, this is Dynamo's responsibility to figure out.
         return PrimHOPBaseFunction.apply(self, subgraph, kwargs, *operands)
 
-    def _forward_kwargs(self, *_, **kwargs):
-        return kwargs
-
-    def _backward_kwargs(self, *_, **kwargs):
-        return kwargs
-
     def _call_CompositeExplicitAutograd(self, subgraph, operands, *_, **kwargs):
         from torch.utils._python_dispatch import _get_current_dispatch_mode
 
@@ -158,7 +152,7 @@ class PrimHOPBaseFunction(torch.autograd.Function):
         ctx.kwargs = kwargs
 
         with torch._C._AutoDispatchBelowAutograd():
-            return hop(subgraph, operands, **hop._forward_kwargs(**kwargs))
+            return hop(subgraph, operands, **kwargs)
 
     @staticmethod
     def backward(ctx, *grad_outputs):
@@ -184,7 +178,7 @@ class PrimHOPBaseFunction(torch.autograd.Function):
             *ctx.hop(
                 joint_graph,
                 (*grad_outputs, *operands),
-                **ctx.hop._backward_kwargs(**ctx.kwargs),
+                **kwargs,
             ),
         )
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6417,7 +6417,7 @@ def while_loop(cond_fn, body_fn, carried_inputs, additional_inputs):
 
 
 @register_lowering(torch.ops.higher_order.invoke_subgraph, type_promotion_kind=None)
-def invoke_subgraph(subgraph_fn: ir.Subgraph, identifier: str, operands):
+def invoke_subgraph(subgraph_fn: ir.Subgraph, operands, *, identifier: str):
     result = ir.InvokeSubgraph.create(subgraph_fn, operands)
     return list(map(TensorBox.create, result))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139928
* #139898

This involved:
- adding some new extension points so that invoke_subgraph can do
  caching.
- I preserved the original invoke_subgraph Autograd caching behavior.
  It was too difficult to get it to do deferred backward.

Test Plan:
- new tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov