### PR TITLE
Mark full_like as core ATen

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2821,6 +2821,7 @@
     # non-differentiable so NonFunctional doesn't apply
     CompositeExplicitAutograd: full_like
   autogen: full_like.out
+  tags: core
 
 - func: from_file(str filename, bool? shared=None, int? size=0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:


### PR DESCRIPTION
Fixes #139617

As titled. For ExecuTorch `full_like` is implemented so this should be fine: https://github.com/pytorch/executorch/blob/main/kernels/portable/cpu/op_full.cpp

Also there are decompositions for ops such as `fill.Scalar` that gives `full_like`: https://github.com/pytorch/pytorch/blob/main/torch/_decomp/decompositions.py#L164

Fixes #ISSUE_NUMBER
