### PR TITLE
[DTensor][unpickler] Add DTensor related classes to allowed globals so we can still torch.load(DTensor) with weights_only=True

### DIFF
--- a/test/distributed/fsdp/test_fsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_dtensor_state_dict.py
@@ -247,7 +247,7 @@ class TestFSDPWithDeviceMeshAndDTensor(DTensorTestBase):
                     self.assertEqual(type(v1), DTensor)
                     self.assertEqual(type(v2), DTensor)
 
-    @with_comms
+    @with_comms()
     @skip_if_lt_x_gpu(2)
     @parametrize("offload_to_cpu", [True, False])
     @parametrize("is_even_sharded_model", [True, False])

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -159,6 +159,11 @@ def _tensor_rebuild_functions():
 # Unpickling machinery
 @_functools.lru_cache(maxsize=1)
 def _get_allowed_globals():
+    dtensor_module = (
+        torch.distributed.tensor
+        if hasattr(torch.distributed, "tensor")
+        else torch.distributed._tensor
+    )
     rc: Dict[str, Any] = {
         "collections.OrderedDict": OrderedDict,
         "collections.Counter": Counter,
@@ -171,13 +176,13 @@ def _get_allowed_globals():
         "builtins.bytearray": bytearray,  # for bytearray
         "builtins.set": set,  # for set
         # DTensor related
-        "torch.distributed.tensor.DTensor": torch.distributed.tensor.DTensor,
-        "torch.distributed.tensor._dtensor_spec.DTensorSpec": torch.distributed.tensor._dtensor_spec.DTensorSpec,
         "torch.distributed.device_mesh.DeviceMesh": torch.distributed.device_mesh.DeviceMesh,
-        "torch.distributed.tensor.placement_types.Shard": torch.distributed.tensor.placement_types.Shard,
-        "torch.distributed.tensor.placement_types.Replicate": torch.distributed.tensor.placement_types.Replicate,
-        "torch.distributed.tensor.placement_types.Partial": torch.distributed.tensor.placement_types.Partial,
-        "torch.distributed.tensor._dtensor_spec.TensorMeta": torch.distributed.tensor._dtensor_spec.TensorMeta,
+        "torch.distributed.tensor._dtensor_spec.DTensorSpec": dtensor_module._dtensor_spec.DTensorSpec,
+        "torch.distributed.tensor._dtensor_spec.TensorMeta": dtensor_module._dtensor_spec.TensorMeta,
+        "torch.distributed.tensor.DTensor": dtensor_module.DTensor,
+        "torch.distributed.tensor.placement_types.Shard": dtensor_module.placement_types.Shard,
+        "torch.distributed.tensor.placement_types.Replicate": dtensor_module.placement_types.Replicate,
+        "torch.distributed.tensor.placement_types.Partial": dtensor_module.placement_types.Partial,
     }
     # dtype
     for t in torch.storage._dtype_to_storage_type_map().keys():

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -171,18 +171,18 @@ def _get_allowed_globals():
         "builtins.bytearray": bytearray,  # for bytearray
         "builtins.set": set,  # for set
     }
-    dtensor_rc: Dict[str, Any] = {
-        # DTensor related
-        "torch.distributed.device_mesh.DeviceMesh": torch.distributed.device_mesh.DeviceMesh,
-        "torch.distributed.tensor._dtensor_spec.DTensorSpec": torch.distributed.tensor._dtensor_spec.DTensorSpec,
-        "torch.distributed.tensor._dtensor_spec.TensorMeta": torch.distributed.tensor._dtensor_spec.TensorMeta,
-        "torch.distributed.tensor.DTensor": torch.distributed.tensor.DTensor,
-        "torch.distributed.tensor.placement_types.Partial": torch.distributed.tensor.placement_types.Partial,
-        "torch.distributed.tensor.placement_types.Replicate": torch.distributed.tensor.placement_types.Replicate,
-        "torch.distributed.tensor.placement_types.Shard": torch.distributed.tensor.placement_types.Shard,
-    }
     # Only add the dtensor related classes if the dtensor module is available
     if hasattr(torch.distributed, "tensor"):
+        dtensor_rc: Dict[str, Any] = {
+            # DTensor related
+            "torch.distributed.device_mesh.DeviceMesh": torch.distributed.device_mesh.DeviceMesh,
+            "torch.distributed.tensor._dtensor_spec.DTensorSpec": torch.distributed.tensor._dtensor_spec.DTensorSpec,
+            "torch.distributed.tensor._dtensor_spec.TensorMeta": torch.distributed.tensor._dtensor_spec.TensorMeta,
+            "torch.distributed.tensor.DTensor": torch.distributed.tensor.DTensor,
+            "torch.distributed.tensor.placement_types.Partial": torch.distributed.tensor.placement_types.Partial,
+            "torch.distributed.tensor.placement_types.Replicate": torch.distributed.tensor.placement_types.Replicate,
+            "torch.distributed.tensor.placement_types.Shard": torch.distributed.tensor.placement_types.Shard,
+        }
         rc.update(dtensor_rc)
     # dtype
     for t in torch.storage._dtype_to_storage_type_map().keys():

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -159,11 +159,6 @@ def _tensor_rebuild_functions():
 # Unpickling machinery
 @_functools.lru_cache(maxsize=1)
 def _get_allowed_globals():
-    dtensor_module = (
-        torch.distributed.tensor
-        if hasattr(torch.distributed, "tensor")
-        else torch.distributed._tensor
-    )
     rc: Dict[str, Any] = {
         "collections.OrderedDict": OrderedDict,
         "collections.Counter": Counter,
@@ -175,15 +170,20 @@ def _get_allowed_globals():
         "_codecs.encode": encode,  # for bytes
         "builtins.bytearray": bytearray,  # for bytearray
         "builtins.set": set,  # for set
+    }
+    dtensor_rc: Dict[str, Any] = {
         # DTensor related
         "torch.distributed.device_mesh.DeviceMesh": torch.distributed.device_mesh.DeviceMesh,
-        "torch.distributed.tensor._dtensor_spec.DTensorSpec": dtensor_module._dtensor_spec.DTensorSpec,
-        "torch.distributed.tensor._dtensor_spec.TensorMeta": dtensor_module._dtensor_spec.TensorMeta,
-        "torch.distributed.tensor.DTensor": dtensor_module.DTensor,
-        "torch.distributed.tensor.placement_types.Shard": dtensor_module.placement_types.Shard,
-        "torch.distributed.tensor.placement_types.Replicate": dtensor_module.placement_types.Replicate,
-        "torch.distributed.tensor.placement_types.Partial": dtensor_module.placement_types.Partial,
+        "torch.distributed.tensor._dtensor_spec.DTensorSpec": torch.distributed.tensor._dtensor_spec.DTensorSpec,
+        "torch.distributed.tensor._dtensor_spec.TensorMeta": torch.distributed.tensor._dtensor_spec.TensorMeta,
+        "torch.distributed.tensor.DTensor": torch.distributed.tensor.DTensor,
+        "torch.distributed.tensor.placement_types.Partial": torch.distributed.tensor.placement_types.Partial,
+        "torch.distributed.tensor.placement_types.Replicate": torch.distributed.tensor.placement_types.Replicate,
+        "torch.distributed.tensor.placement_types.Shard": torch.distributed.tensor.placement_types.Shard,
     }
+    # Only add the dtensor related classes if the dtensor module is available
+    if hasattr(torch.distributed, "tensor"):
+        rc.update(dtensor_rc)
     # dtype
     for t in torch.storage._dtype_to_storage_type_map().keys():
         rc[str(t)] = t


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #139949

Test uses `torch.load()` for DTensor state_dict:
```
python3 test/distributed/fsdp/test_fsdp_dtensor_state_dict.py -k TestFSDPWithDeviceMeshAndDTensor
```

In this PR, we add `DTensor` related class to allowed safe globals so we can still `torch.load()` a `DTensor` with `weights_only=True`. We also need this for backward compatibility, since `DTensor` can be `torch.load()` before `weights_only` defaults to True. Without the change, `torch.load()` a `DTensor` would run into the following error: 
```
_pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
        (1) Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
        (2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
        WeightsUnpickler error: Unsupported global: GLOBAL torch.distributed.tensor.DTensor was not an allowed global by default. Please use `torch.serialization.add_safe_globals([DTensor])` or the `torch.serialization.safe_globals([DTensor])` context manager to allowlist this global if you trust this class/function.
```

The unit test failure is not being captured by CI when `weights_only` being rolled out for `torch.load()` by default. This is due to another issue that the test communication wrapper `with_comms` let unit tests silently pass without capturing failure due to a recent change (https://github.com/pytorch/pytorch/pull/138108). This wrapper issue is going to be fixed 
by a separate PR https://github.com/pytorch/pytorch/pull/139637. 

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @tianyu-l @XilunWu