### PR TITLE
[AOTI] Update C++ runner API to take a const vector

### DIFF
--- a/test/cpp/aoti_inference/test.cpp
+++ b/test/cpp/aoti_inference/test.cpp
@@ -29,8 +29,6 @@ void test_aoti(const std::string& device, bool use_runtime_constant_folding) {
   std::string inputs_attr = "inputs_" + suffix;
   std::string outputs_attr = "outputs_" + suffix;
   const auto& model_so_path = data_loader.attr(path_attr.c_str()).toStringRef();
-  auto input_tensors =
-      data_loader.attr(inputs_attr.c_str()).toTensorList().vec();
   const auto& ref_output_tensors =
       data_loader.attr(outputs_attr.c_str()).toTensorList().vec();
 
@@ -46,7 +44,8 @@ void test_aoti(const std::string& device, bool use_runtime_constant_folding) {
   } else {
     testing::AssertionFailure() << "unsupported device: " << device;
   }
-  auto actual_output_tensors = runner->run(input_tensors);
+  auto actual_output_tensors =
+      runner->run(data_loader.attr(inputs_attr.c_str()).toTensorList().vec());
   ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
 }
 

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -397,7 +397,7 @@ AOTIModelContainerRunner* AOTIModelPackageLoader::get_runner() {
 }
 
 std::vector<at::Tensor> AOTIModelPackageLoader::run(
-    std::vector<at::Tensor>& inputs) {
+    const std::vector<at::Tensor>& inputs) {
   return runner_->run(inputs);
 }
 

--- a/torch/csrc/inductor/aoti_package/model_package_loader.h
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.h
@@ -14,7 +14,7 @@ class TORCH_API AOTIModelPackageLoader {
 
   AOTIModelContainerRunner* get_runner();
   std::unordered_map<std::string, std::string> get_metadata();
-  std::vector<at::Tensor> run(std::vector<at::Tensor>& inputs);
+  std::vector<at::Tensor> run(const std::vector<at::Tensor>& inputs);
   std::vector<std::string> get_call_spec();
 
  private:

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
@@ -90,7 +90,7 @@ AOTIModelContainerRunner::~AOTIModelContainerRunner() {
 }
 
 std::vector<at::Tensor> AOTIModelContainerRunner::run(
-    std::vector<at::Tensor>& inputs,
+    const std::vector<at::Tensor>& inputs,
     AOTInductorStreamHandle cuda_stream_handle) {
   auto input_handles =
       torch::aot_inductor::unsafe_alloc_new_handles_from_tensors(inputs);

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.h
@@ -25,7 +25,7 @@ class TORCH_API AOTIModelContainerRunner {
   ~AOTIModelContainerRunner();
 
   std::vector<at::Tensor> run(
-      std::vector<at::Tensor>& inputs,
+      const std::vector<at::Tensor>& inputs,
       AOTInductorStreamHandle cuda_stream_handle = nullptr);
 
   std::unordered_map<std::string, std::string> getConstantNamesToOriginalFQNs()

--- a/torch/csrc/inductor/aoti_runner/model_container_runner_cpu.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner_cpu.cpp
@@ -13,7 +13,7 @@ AOTIModelContainerRunnerCpu::AOTIModelContainerRunnerCpu(
 AOTIModelContainerRunnerCpu::~AOTIModelContainerRunnerCpu() = default;
 
 std::vector<at::Tensor> AOTIModelContainerRunnerCpu::run(
-    std::vector<at::Tensor>& inputs) {
+    const std::vector<at::Tensor>& inputs) {
   return AOTIModelContainerRunner::run(inputs);
 }
 

--- a/torch/csrc/inductor/aoti_runner/model_container_runner_cpu.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner_cpu.h
@@ -12,7 +12,7 @@ class TORCH_API AOTIModelContainerRunnerCpu : public AOTIModelContainerRunner {
 
   ~AOTIModelContainerRunnerCpu();
 
-  std::vector<at::Tensor> run(std::vector<at::Tensor>& inputs);
+  std::vector<at::Tensor> run(const std::vector<at::Tensor>& inputs);
 };
 
 } // namespace torch::inductor

--- a/torch/csrc/inductor/aoti_runner/model_container_runner_cuda.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner_cuda.cpp
@@ -17,14 +17,14 @@ AOTIModelContainerRunnerCuda::AOTIModelContainerRunnerCuda(
 AOTIModelContainerRunnerCuda::~AOTIModelContainerRunnerCuda() = default;
 
 std::vector<at::Tensor> AOTIModelContainerRunnerCuda::run(
-    std::vector<at::Tensor>& inputs) {
+    const std::vector<at::Tensor>& inputs) {
   at::cuda::CUDAStream cuda_stream = c10::cuda::getCurrentCUDAStream();
   return AOTIModelContainerRunner::run(
       inputs, reinterpret_cast<AOTInductorStreamHandle>(cuda_stream.stream()));
 }
 
 std::vector<at::Tensor> AOTIModelContainerRunnerCuda::run_with_cuda_stream(
-    std::vector<at::Tensor>& inputs,
+    const std::vector<at::Tensor>& inputs,
     at::cuda::CUDAStream cuda_stream) {
   return AOTIModelContainerRunner::run(
       inputs, reinterpret_cast<AOTInductorStreamHandle>(cuda_stream.stream()));

--- a/torch/csrc/inductor/aoti_runner/model_container_runner_cuda.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner_cuda.h
@@ -20,10 +20,10 @@ class TORCH_API AOTIModelContainerRunnerCuda : public AOTIModelContainerRunner {
 
   ~AOTIModelContainerRunnerCuda();
 
-  std::vector<at::Tensor> run(std::vector<at::Tensor>& inputs);
+  std::vector<at::Tensor> run(const std::vector<at::Tensor>& inputs);
 
   std::vector<at::Tensor> run_with_cuda_stream(
-      std::vector<at::Tensor>& inputs,
+      const std::vector<at::Tensor>& inputs,
       at::cuda::CUDAStream cuda_stream);
 };
 

--- a/torch/csrc/inductor/aoti_runner/pybind.cpp
+++ b/torch/csrc/inductor/aoti_runner/pybind.cpp
@@ -45,7 +45,7 @@ void initAOTIRunnerBindings(PyObject* module) {
 
   m.def(
       "unsafe_alloc_void_ptrs_from_tensors",
-      [](std::vector<at::Tensor>& tensors) {
+      [](const std::vector<at::Tensor>& tensors) {
         std::vector<AtenTensorHandle> handles =
             torch::aot_inductor::unsafe_alloc_new_handles_from_tensors(tensors);
         std::vector<void*> result(

--- a/torch/csrc/inductor/aoti_torch/tensor_converter.cpp
+++ b/torch/csrc/inductor/aoti_torch/tensor_converter.cpp
@@ -4,7 +4,7 @@
 namespace torch::aot_inductor {
 
 std::vector<AtenTensorHandle> unsafe_alloc_new_handles_from_tensors(
-    std::vector<at::Tensor>& tensors) {
+    const std::vector<at::Tensor>& tensors) {
   std::vector<AtenTensorHandle> result;
   result.reserve(tensors.size());
   for (auto tensor : tensors) {

--- a/torch/csrc/inductor/aoti_torch/tensor_converter.h
+++ b/torch/csrc/inductor/aoti_torch/tensor_converter.h
@@ -12,13 +12,13 @@ namespace torch::aot_inductor {
 // tensor objects and return them as a vector of AtenTensorHandle (raw
 // pointers), and those pointers will be stolen by model.so.
 TORCH_API std::vector<AtenTensorHandle> unsafe_alloc_new_handles_from_tensors(
-    std::vector<at::Tensor>& tensors);
+    const std::vector<at::Tensor>& tensors);
 
 // alloc_tensors_by_stealing_from_handles is used for creating a vector of aten
 // tensors by stealing from an array of handles. Only the handles are stolen,
 // and the array itself is borrowed.
 //
-// WARNING: Can NOT be called in model.so unless in the non-ABI-compatible mode
+// WARNING: Can NOT be called in model.so
 TORCH_API std::vector<at::Tensor> alloc_tensors_by_stealing_from_handles(
     AtenTensorHandle* handles,
     size_t length);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #139956
* __->__ #139955

Summary: Tighten the AOTIModelContainerRunner::run interface to take a const vector of at::Tensor, which 1) makes it clear that the runner will not modify the input tensor vector; 2) runner will be able to take a temp vector of tensors as the input.