### PR TITLE
handle AttrProxy._modules when module is overwritten as None

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -7243,6 +7243,25 @@ def forward(self, p_bar_linear_weight, p_bar_linear_bias, x):
         # this doesn't work today
         gm_unflat_strict = unflatten(ep)
 
+    def test_modules_access_for_deleted_submodule(self):
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(10, 10)
+                self.foo = torch.nn.Linear(10, 10)
+
+            def forward(self, x):
+                for name, mod in self._modules.items():
+                    if mod is None:
+                        continue
+                    pass
+                return self.linear(x)
+
+        mod = Foo()
+        mod.foo = None
+        mod(torch.randn(10, 10))
+        export(mod, (torch.randn(10, 10),), strict=False)
+
     def test_predispatch_cond(self):
         class Model(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1634,7 +1634,11 @@ class _ModuleStackTracer(PythonKeyTracer):
                 submodules = self.__dict__["_modules"]
                 assert isinstance(submodules, dict)
                 return {
-                    key: AttrProxy(value, tracer.proxy_paths[self] + "." + str(key))
+                    key: (
+                        AttrProxy(value, tracer.proxy_paths[self] + "." + str(key))  # type: ignore[misc]
+                        if value is not None
+                        else value
+                    )
                     for key, value in submodules.items()
                 }
 


### PR DESCRIPTION
Fixes tracing through `mod._modules` access, when one of the submodules has been reset to None

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv