### PR TITLE
[BE] Remove warn about using Half on CPUs

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -959,12 +959,6 @@ void tanh_backward_kernel(TensorIteratorBase& iter) {
 }
 
 void mse_kernel(TensorIteratorBase& iter) {
-  if (iter.dtype() == ScalarType::Half) {
-    TORCH_WARN_ONCE(
-        "Applying the CPU mse kernel on half-type tensors. "
-        "This may be slower than using float or double-type tensors.");
-  }
-
   AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, iter.dtype(), "mse_cpu", [&]() {
     cpu_kernel_vec(
         iter,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #139960
* #139959
* __->__ #139961

Was added by https://github.com/pytorch/pytorch/pull/33021, but modern CPUs right now are quite capable of handling half precision types. 
Alternatively one can guard the warning with `#ifdef x86_64`

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10