### PR TITLE
[Reland] Use static_assert to detect get_type_index used in device code

### DIFF
--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -93,11 +93,7 @@ inline constexpr uint64_t type_index_impl() {
 
 template <typename T>
 inline constexpr type_index get_type_index() {
-#if defined(__CUDA_ARCH__)
-  // Don't run this on device code
-  static_assert(false && sizeof(T));
-  return type_index(0);
-#endif
+  static_assert(!defined(__CUDA_ARCH__) && sizeof(T), " Don't call me from device code");
   // To enforce that this is really computed at compile time, we pass the
   // type index through std::integral_constant.
   return type_index{std::integral_constant<

--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -93,17 +93,16 @@ inline constexpr uint64_t type_index_impl() {
 
 template <typename T>
 inline constexpr type_index get_type_index() {
-#if !defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__)
+  // Don't run this on device code
+  static_assert(false && sizeof(T));
+  return type_index(0);
+#endif
   // To enforce that this is really computed at compile time, we pass the
   // type index through std::integral_constant.
   return type_index{std::integral_constant<
       uint64_t,
       detail::type_index_impl<std::decay_t<T>>()>::value};
-#else
-  // There's nothing in theory preventing us from running this on device code
-  // except for nvcc throwing a compiler error if we enable it.
-  return (abort(), type_index(0));
-#endif
 }
 
 #if !defined(TORCH_PEDANTIC)

--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -93,7 +93,9 @@ inline constexpr uint64_t type_index_impl() {
 
 template <typename T>
 inline constexpr type_index get_type_index() {
-  static_assert(!defined(__CUDA_ARCH__) && sizeof(T), " Don't call me from device code");
+#if defined(__CUDA_ARCH__)
+  static_assert(false && sizeof(T), " Don't call me from device code");
+#endif
   // To enforce that this is really computed at compile time, we pass the
   // type index through std::integral_constant.
   return type_index{std::integral_constant<

--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/macros/Macros.h>
 #include <c10/util/ConstexprCrc.h>
 #include <c10/util/IdWrapper.h>
 #include <c10/util/string_view.h>
@@ -92,7 +93,7 @@ inline constexpr uint64_t type_index_impl() {
 } // namespace detail
 
 template <typename T>
-inline constexpr type_index get_type_index() {
+C10_HOST inline constexpr type_index get_type_index() {
 #if defined(__CUDA_ARCH__)
   static_assert(false && sizeof(T), " Don't call me from device code");
 #endif


### PR DESCRIPTION
#139173 was reverted due to an internal build break of using get_type_index in device code. This PR is created for ease of importing into META to further investigation.