### PR TITLE
Update torch.masked.mean to upcast dtype for bool tensors

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -4871,7 +4871,6 @@ class CPUReproTests(TestCase):
     @requires_vectorization
     def test_bool_reduction_vec(self):
         for op in (
-            torch.masked.mean,
             torch.any,
             torch.min,
             torch.max,

--- a/torch/masked/_ops.py
+++ b/torch/masked/_ops.py
@@ -1386,6 +1386,10 @@ elements, have ``nan`` values.
 {reduction_example}"""
     if dtype is None:
         dtype = input.dtype
+    if dtype is torch.bool:
+        # upcast dtype when computing mean of boolean tensors otherwise
+        # sum(..., dtype=torch.bool) is clamped to 1
+        dtype = torch.int32
     if input.layout == torch.strided:
         if mask is None:
             # TODO: compute count analytically

--- a/torch/masked/_ops.py
+++ b/torch/masked/_ops.py
@@ -1389,7 +1389,7 @@ elements, have ``nan`` values.
         dtype = input.dtype
         dtype_source = "Input"
 
-    if not (dtype.is_floating_point() or dtype.is_complex()):
+    if not (dtype.is_floating_point or dtype.is_complex):
         raise ValueError(
             f"mean(): Could not infer output dtype. {dtype_source} dtype must be either "
             f"a floating point or complex dtype. Got: {dtype}"

--- a/torch/masked/_ops.py
+++ b/torch/masked/_ops.py
@@ -1384,12 +1384,16 @@ elements, have ``nan`` values.
 {reduction_args}
 
 {reduction_example}"""
+    dtype_source = "Optional"
     if dtype is None:
         dtype = input.dtype
-    if dtype is torch.bool:
-        # upcast dtype when computing mean of boolean tensors otherwise
-        # sum(..., dtype=torch.bool) is clamped to 1
-        dtype = torch.int32
+        dtype_source = "Input"
+
+    if not (dtype.is_floating_point() or dtype.is_complex()):
+        raise ValueError(
+            f"mean(): Could not infer output dtype. {dtype_source} dtype must be either "
+            f"a floating point or complex dtype. Got: {dtype}"
+        )
     if input.layout == torch.strided:
         if mask is None:
             # TODO: compute count analytically

--- a/torch/testing/_internal/opinfo/definitions/_masked.py
+++ b/torch/testing/_internal/opinfo/definitions/_masked.py
@@ -773,20 +773,6 @@ op_db: List[OpInfo] = [
         skips=(
             DecorateInfo(
                 unittest.expectedFailure,
-                "TestReductions",
-                "test_ref_duplicate_values",
-                dtypes=(torch.bool,),
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestReductions",
-                "test_reference_masked",
-                dtypes=(torch.bool,),
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestReductions",
-                "test_ref_small_input",
                 dtypes=(torch.bool,),
             ),
             DecorateInfo(

--- a/torch/testing/_internal/opinfo/definitions/_masked.py
+++ b/torch/testing/_internal/opinfo/definitions/_masked.py
@@ -769,7 +769,7 @@ op_db: List[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         promotes_int_to_float=True,
-        dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
+        dtypes=all_types_and_complex_and(torch.float16, torch.bfloat16, torch.bool),
         skips=(
             DecorateInfo(
                 unittest.expectedFailure,

--- a/torch/testing/_internal/opinfo/definitions/_masked.py
+++ b/torch/testing/_internal/opinfo/definitions/_masked.py
@@ -769,13 +769,8 @@ op_db: List[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         promotes_int_to_float=True,
-        dtypes=all_types_and_complex_and(torch.float16, torch.bfloat16, torch.bool),
+        dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
         skips=(
-            # For any non-floating point or complex dtypes we expect a failure
-            DecorateInfo(
-                unittest.expectedFailure,
-                dtypes=(torch.bool, *integral_types()),
-            ),
             DecorateInfo(
                 unittest.expectedFailure,
                 "TestNormalizeOperators",

--- a/torch/testing/_internal/opinfo/definitions/_masked.py
+++ b/torch/testing/_internal/opinfo/definitions/_masked.py
@@ -769,7 +769,7 @@ op_db: List[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         promotes_int_to_float=True,
-        dtypes=all_types_and_complex_and(torch.float16, torch.bfloat16, torch.bool),
+        dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
         skips=(
             DecorateInfo(
                 unittest.expectedFailure,

--- a/torch/testing/_internal/opinfo/definitions/_masked.py
+++ b/torch/testing/_internal/opinfo/definitions/_masked.py
@@ -771,9 +771,10 @@ op_db: List[OpInfo] = [
         promotes_int_to_float=True,
         dtypes=all_types_and_complex_and(torch.float16, torch.bfloat16, torch.bool),
         skips=(
+            # For any non-floating point or complex dtypes we expect a failure
             DecorateInfo(
                 unittest.expectedFailure,
-                dtypes=(torch.bool,),
+                dtypes=(torch.bool, *integral_types()),
             ),
             DecorateInfo(
                 unittest.expectedFailure,


### PR DESCRIPTION
When calling `torch.masked.mean(...)` with a boolean tensor, the dtype is inferred to be bool. When the mean is being computed, the sum operator is used. When the sum operator is used with dtype=torch.bool, the result is clamped to True (1) leading to an incorrect mean being calculated.

The below example shows how the incorrect result occurs:
```
a = torch.tensor([True, True])
count = torch.sum(torch.ones(a.shape, dtype=torch.int64)) # 2
total = torch.sum(a, dtype=torch.bool) # True (1)
mean = total / count # 0.5
```

This PR upcasts the dtype used for the sumation to int32 in the case of bool tensors allowing for the correct result to be computed.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov