### PR TITLE
Revert "[pt2 logging] move remote cache get/put logging up one level (#139423)"

### DIFF
--- a/torch/_inductor/remote_cache.py
+++ b/torch/_inductor/remote_cache.py
@@ -12,7 +12,6 @@ from abc import abstractmethod
 from typing import Any, Callable, Dict, Generic, List, Optional, Type, TypeVar, Union
 from typing_extensions import override, TypeAlias
 
-from torch._dynamo.utils import dynamo_timed
 from torch._inductor import config
 
 
@@ -145,39 +144,29 @@ class RemoteCache(Generic[_T]):
     # See if the cache contains `key`. Returns `None` if the value is not
     # present in the cache.
     def get(self, key: str) -> Optional[_T]:
-        with dynamo_timed(
-            "RemoteFxGraphCache.get",
-            phase_name="remote_fx_graph_cache_get",
-            fwd_only=False,
-        ):
-            sample = self._create_sample()
-            try:
-                result = self._get(key, sample)
-                cache_stats.get(type(self).__name__, result)
-            except Exception:
-                cache_stats.exception(type(self).__name__)
-                raise
-            self._log_sample(sample)
-            return result
+        sample = self._create_sample()
+        try:
+            result = self._get(key, sample)
+            cache_stats.get(type(self).__name__, result)
+        except Exception:
+            cache_stats.exception(type(self).__name__)
+            raise
+        self._log_sample(sample)
+        return result
 
     # Add `value` to the cache with the key `key`. Note that `None` is not a
     # valid value even if _T supports it (because you can't tell the difference
     # between `None` and a missing cache entry).
     def put(self, key: str, value: _T) -> None:
-        with dynamo_timed(
-            "RemoteFxGraphCache.put",
-            phase_name="remote_fx_graph_cache_put",
-            fwd_only=False,
-        ):
-            assert value is not None
-            sample = self._create_sample()
-            try:
-                self._put(key, value, sample)
-                cache_stats.put(type(self).__name__)
-            except Exception:
-                cache_stats.exception(type(self).__name__)
-                raise
-            self._log_sample(sample)
+        assert value is not None
+        sample = self._create_sample()
+        try:
+            self._put(key, value, sample)
+            cache_stats.put(type(self).__name__)
+        except Exception:
+            cache_stats.exception(type(self).__name__)
+            raise
+        self._log_sample(sample)
 
     # Used to convert data from the cache into structured data.
     def _decode(self, data: _U, sample: Optional[Sample]) -> _T:  # type: ignore[override]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This reverts commit c412a42ae2a978122d8a41b94c3861290bc689e0.

Reverted https://github.com/pytorch/pytorch/pull/139423 on behalf of https://github.com/ZainRizvi due to Reverted internally. See D65541060 for more details ([comment](https://github.com/pytorch/pytorch/pull/139423#issuecomment-2460765579))

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov