### PR TITLE
[dynamo] switch to get_framelocals_mapping for 3.10 and below

### DIFF
--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -583,18 +583,7 @@ static PyObject* dynamo__custom_eval_frame(
   }
 
 
-  #if IS_PYTHON_3_11_PLUS
   PyObject *locals = get_framelocals_mapping(frame);
-  #else
-  if (PyFrame_FastToLocalsWithError(frame) < 0) {
-    DEBUG_TRACE("error %s", get_frame_name(frame));
-    *should_clear_frame = 1;
-    return NULL;
-  }
-  PyObject *locals = frame->f_locals;
-  Py_INCREF(locals);
-  #endif
-
   PyObject* backend = get_backend(callback);
 
 

--- a/torch/csrc/dynamo/framelocals_mapping.cpp
+++ b/torch/csrc/dynamo/framelocals_mapping.cpp
@@ -1,12 +1,13 @@
 #include <torch/csrc/dynamo/framelocals_mapping.h>
 
-#if IS_PYTHON_3_11_PLUS
 #include <torch/csrc/dynamo/cpython_defs.h>
 #include <torch/csrc/dynamo/cpython_includes.h>
 #include <torch/csrc/dynamo/debug_macros.h>
 #include <torch/csrc/utils/pybind.h>
 
 #include <internal/pycore_code.h>
+
+#if IS_PYTHON_3_11_PLUS
 
 // Our own version of PyFrame_GetLocals.
 // Also combines functionality from frame_init_get_vars and frame_get_var.
@@ -67,6 +68,59 @@ PyObject* get_framelocals_mapping(_PyInterpreterFrame* frame) {
   // NOTE no need to move the instruction pointer to after COPY_FREE_VARS
   // since we don't actually copy free vars from the closure to the frame
   // localsplus.
+
+  return mapping.release().ptr();
+}
+
+#else
+
+// Based on
+// https://github.com/python/cpython/blob/5f24da9d75bb0150781b17ee4706e93e6bb364ea/Objects/frameobject.c#L1016
+PyObject* get_framelocals_mapping(PyFrameObject* frame) {
+  PyCodeObject* co = F_CODE(frame);
+  py::dict mapping;
+
+  auto update_mapping =
+      [&](PyObject* names, int i, PyObject* value, bool deref) {
+        py::str name = py::cast<py::str>(PyTuple_GET_ITEM(names, i));
+        if (deref) {
+          CHECK(value != nullptr && PyCell_Check(value));
+          value = PyCell_GET(value);
+        }
+        if (value == nullptr) {
+          mapping.attr("pop")(name, py::none());
+        } else {
+          mapping[name] = py::cast<py::object>(value);
+        }
+      };
+
+  // locals
+  int nlocals = PyTuple_GET_SIZE(co->co_varnames);
+  if (nlocals > co->co_nlocals) {
+    nlocals = co->co_nlocals;
+  }
+  for (int i = 0; i < nlocals; i++) {
+    update_mapping(co->co_varnames, i, frame->f_localsplus[i], false);
+  }
+
+  // cellvars
+  int ncells = PyTuple_GET_SIZE(co->co_cellvars);
+  for (int i = 0; i < ncells; i++) {
+    update_mapping(
+        co->co_cellvars, i, frame->f_localsplus[co->co_nlocals + i], true);
+  }
+
+  // freevars
+  if (co->co_flags & CO_OPTIMIZED) {
+    int nfree = PyTuple_GET_SIZE(co->co_freevars);
+    for (int i = 0; i < nfree; i++) {
+      update_mapping(
+          co->co_freevars,
+          i,
+          frame->f_localsplus[co->co_nlocals + ncells + i],
+          true);
+    }
+  }
 
   return mapping.release().ptr();
 }

--- a/torch/csrc/dynamo/framelocals_mapping.h
+++ b/torch/csrc/dynamo/framelocals_mapping.h
@@ -9,6 +9,8 @@ extern "C" {
 #if IS_PYTHON_3_11_PLUS
 typedef struct _PyInterpreterFrame _PyInterpreterFrame;
 PyObject* get_framelocals_mapping(_PyInterpreterFrame* frame);
+#else
+PyObject* get_framelocals_mapping(PyFrameObject* frame);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #140063
* __->__ #140037
* #139950
* #139921

Part of implementing https://github.com/pytorch/pytorch/issues/93753. Next step will be to use a lower overhead data structure over `py::dict`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames