### PR TITLE
Updated docstrings referring to `torch.expand` to point to `torch.Tensor.expand`

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13829,7 +13829,7 @@ are freshly created instead of aliasing the input.
 add_docstr(
     torch.expand_copy,
     r"""
-Performs the same operation as :func:`torch.expand`, but all output tensors
+Performs the same operation as :func:`torch.Tensor.expand`, but all output tensors
 are freshly created instead of aliasing the input.
 """,
 )

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1996,7 +1996,7 @@ def gradcheck(
     .. warning::
        If any checked tensor in :attr:`input` has overlapping memory, i.e.,
        different indices pointing to the same memory address (e.g., from
-       :func:`torch.expand`), this check will likely fail because the numerical
+       :func:`torch.Tensor.expand`), this check will likely fail because the numerical
        gradients computed by point perturbation at such indices will change
        values at all other indices that share the same memory address.
 
@@ -2150,7 +2150,7 @@ def gradgradcheck(
     .. warning::
        If any checked tensor in :attr:`input` and :attr:`grad_outputs` has
        overlapping memory, i.e., different indices pointing to the same memory
-       address (e.g., from :func:`torch.expand`), this check will likely fail
+       address (e.g., from :func:`torch.Tensor.expand`), this check will likely fail
        because the numerical gradients computed by point perturbation at such
        indices will change values at all other indices that share the same
        memory address.


### PR DESCRIPTION
`torch.expand` was moved to `torch.Tensor.expand` but some docstrings still refer to `torch.expand`
