### PR TITLE
Add an opt-out label to runner determinator on PR

### DIFF
--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -53,12 +53,16 @@ Example config:
     @User3,split_build
 """
 
+import json
 import logging
 import os
 import random
+import sys
 from argparse import ArgumentParser
+from functools import lru_cache
 from logging import LogRecord
-from typing import Any, Dict, FrozenSet, Iterable, List, NamedTuple, Tuple
+from typing import Any, Dict, FrozenSet, Iterable, List, NamedTuple, Set, Tuple
+from urllib.request import Request, urlopen
 
 import yaml
 from github import Auth, Github
@@ -72,7 +76,7 @@ WORKFLOW_LABEL_LF_CANARY = "lf.c."  # use canary runners from the linux foundati
 GITHUB_OUTPUT = os.getenv("GITHUB_OUTPUT", "")
 GH_OUTPUT_KEY_AMI = "runner-ami"
 GH_OUTPUT_KEY_LABEL_TYPE = "label-type"
-
+OPT_OUT_LABEL = "no-runner-determinator"
 
 SETTING_EXPERIMENTS = "experiments"
 
@@ -190,6 +194,13 @@ def parse_args() -> Any:
         required=False,
         default="",
         help="comma separated list of experiments to check, if omitted all experiments marked with default=True are checked",
+    )
+    parser.add_argument(
+        "--pr-number",
+        type=str,
+        required=False,
+        default="",
+        help="the optional PR number where this is run",
     )
 
     return parser.parse_args()
@@ -451,10 +462,65 @@ def get_rollout_state_from_issue(github_token: str, repo: str, issue_num: int) -
     return str(issue.get_comments()[0].body.strip("\n\t "))
 
 
+def download_json(url: str, headers: Dict[str, str], num_retries: int = 3) -> Any:
+    for _ in range(num_retries):
+        try:
+            req = Request(url=url, headers=headers)
+            content = urlopen(req, timeout=5).read().decode("utf-8")
+            return json.loads(content)
+        except Exception as e:
+            log.warning(f"Could not download {url}: {e}")
+
+    log.warning(f"All {num_retries} retries exhausted, downloading {url} failed")
+    return {}
+
+
+@lru_cache(maxsize=None)
+def get_pr_info(github_repo: str, github_token: str, pr_number: int) -> Dict[str, Any]:
+    """
+    Dynamically get PR information
+    """
+    github_api = f"https://api.github.com/repos/{github_repo}"
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "Authorization": f"token {github_token}",
+    }
+    json_response: Dict[str, Any] = download_json(
+        url=f"{github_api}/issues/{pr_number}",
+        headers=headers,
+    )
+
+    if not json_response:
+        log.warning(f"Failed to get the labels for #{pr_number}")
+        return {}
+
+    return json_response
+
+
+def get_labels(github_repo: str, github_token: str, pr_number: int) -> Set[str]:
+    """
+    Dynamically get the latest list of labels from the pull request
+    """
+    pr_info = get_pr_info(github_repo, github_token, pr_number)
+    return {
+        label.get("name") for label in pr_info.get("labels", []) if label.get("name")
+    }
+
+
 def main() -> None:
     args = parse_args()
 
     runner_label_prefix = DEFAULT_LABEL_PREFIX
+
+    # Check if the PR is opt-out
+    if args.pr_number:
+        labels = get_labels(args.github_repo, args.github_token, int(args.pr_number))
+        if OPT_OUT_LABEL in labels:
+            log.info(
+                f"Opt-out runner determinator because #{args.pr_number} has {OPT_OUT_LABEL} label"
+            )
+            set_github_output(GH_OUTPUT_KEY_LABEL_TYPE, runner_label_prefix)
+            sys.exit()
 
     try:
         rollout_state = get_rollout_state_from_issue(

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -76,7 +76,7 @@ WORKFLOW_LABEL_LF_CANARY = "lf.c."  # use canary runners from the linux foundati
 GITHUB_OUTPUT = os.getenv("GITHUB_OUTPUT", "")
 GH_OUTPUT_KEY_AMI = "runner-ami"
 GH_OUTPUT_KEY_LABEL_TYPE = "label-type"
-OPT_OUT_LABEL = "no-runner-determinator"
+OPT_OUT_LABEL = "no-runner-experiments"
 
 SETTING_EXPERIMENTS = "experiments"
 

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -144,7 +144,7 @@ jobs:
           GITHUB_OUTPUT = os.getenv("GITHUB_OUTPUT", "")
           GH_OUTPUT_KEY_AMI = "runner-ami"
           GH_OUTPUT_KEY_LABEL_TYPE = "label-type"
-          OPT_OUT_LABEL = "no-runner-determinator"
+          OPT_OUT_LABEL = "no-runner-experiments"
 
           SETTING_EXPERIMENTS = "experiments"
 

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -51,6 +51,7 @@ jobs:
       TRIGGERING_ACTOR: ${{ inputs.triggering_actor }}
       ISSUE_OWNER: ${{ inputs.issue_owner }}
       CHECK_EXPERIMENTS: ${{ inputs.check_experiments }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       # - name: Checkout PyTorch
       #   uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
@@ -580,3 +581,4 @@ jobs:
             --github-ref-type "$curr_ref_type" \
             --github-repo "$GITHUB_REPOSITORY" \
             --eligible-experiments "$CHECK_EXPERIMENTS" \
+            --pr-number "${PR_NUMBER}"

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -121,12 +121,16 @@ jobs:
               @User3,split_build
           """
 
+          import json
           import logging
           import os
           import random
+          import sys
           from argparse import ArgumentParser
+          from functools import lru_cache
           from logging import LogRecord
-          from typing import Any, Dict, FrozenSet, Iterable, List, NamedTuple, Tuple
+          from typing import Any, Dict, FrozenSet, Iterable, List, NamedTuple, Set, Tuple
+          from urllib.request import Request, urlopen
 
           import yaml
           from github import Auth, Github
@@ -140,7 +144,7 @@ jobs:
           GITHUB_OUTPUT = os.getenv("GITHUB_OUTPUT", "")
           GH_OUTPUT_KEY_AMI = "runner-ami"
           GH_OUTPUT_KEY_LABEL_TYPE = "label-type"
-
+          OPT_OUT_LABEL = "no-runner-determinator"
 
           SETTING_EXPERIMENTS = "experiments"
 
@@ -258,6 +262,13 @@ jobs:
                   required=False,
                   default="",
                   help="comma separated list of experiments to check, if omitted all experiments marked with default=True are checked",
+              )
+              parser.add_argument(
+                  "--pr-number",
+                  type=str,
+                  required=False,
+                  default="",
+                  help="the optional PR number where this is run",
               )
 
               return parser.parse_args()
@@ -519,10 +530,65 @@ jobs:
               return str(issue.get_comments()[0].body.strip("\n\t "))
 
 
+          def download_json(url: str, headers: Dict[str, str], num_retries: int = 3) -> Any:
+              for _ in range(num_retries):
+                  try:
+                      req = Request(url=url, headers=headers)
+                      content = urlopen(req, timeout=5).read().decode("utf-8")
+                      return json.loads(content)
+                  except Exception as e:
+                      log.warning(f"Could not download {url}: {e}")
+
+              log.warning(f"All {num_retries} retries exhausted, downloading {url} failed")
+              return {}
+
+
+          @lru_cache(maxsize=None)
+          def get_pr_info(github_repo: str, github_token: str, pr_number: int) -> Dict[str, Any]:
+              """
+              Dynamically get PR information
+              """
+              github_api = f"https://api.github.com/repos/{github_repo}"
+              headers = {
+                  "Accept": "application/vnd.github.v3+json",
+                  "Authorization": f"token {github_token}",
+              }
+              json_response: Dict[str, Any] = download_json(
+                  url=f"{github_api}/issues/{pr_number}",
+                  headers=headers,
+              )
+
+              if not json_response:
+                  log.warning(f"Failed to get the labels for #{pr_number}")
+                  return {}
+
+              return json_response
+
+
+          def get_labels(github_repo: str, github_token: str, pr_number: int) -> Set[str]:
+              """
+              Dynamically get the latest list of labels from the pull request
+              """
+              pr_info = get_pr_info(github_repo, github_token, pr_number)
+              return {
+                  label.get("name") for label in pr_info.get("labels", []) if label.get("name")
+              }
+
+
           def main() -> None:
               args = parse_args()
 
               runner_label_prefix = DEFAULT_LABEL_PREFIX
+
+              # Check if the PR is opt-out
+              if args.pr_number:
+                  labels = get_labels(args.github_repo, args.github_token, int(args.pr_number))
+                  if OPT_OUT_LABEL in labels:
+                      log.info(
+                          f"Opt-out runner determinator because #{args.pr_number} has {OPT_OUT_LABEL} label"
+                      )
+                      set_github_output(GH_OUTPUT_KEY_LABEL_TYPE, runner_label_prefix)
+                      sys.exit()
 
               try:
                   rollout_state = get_rollout_state_from_issue(

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -38,9 +38,7 @@ jobs:
 
   get-label-type:
     name: get-label-type
-    # FOR TESTING ON PR, WILL REVERT THIS BACK BEFORE COMMIT
-    # uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    uses: ./.github/workflows/_runner-determinator.yml
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -38,7 +38,9 @@ jobs:
 
   get-label-type:
     name: get-label-type
-    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    # FOR TESTING ON PR, WILL REVERT THIS BACK BEFORE COMMIT
+    # uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    uses: ./.github/workflows/_runner-determinator.yml
     if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:
       triggering_actor: ${{ github.triggering_actor }}


### PR DESCRIPTION
My sales pitch:  I need to ssh into the runner from time to time on my PR to debug issues, but it's well-known that LF runners don't support SSH login anymore.  So, the propose fix here is to introduce a new label called ~no-runner-determinator~ `no-runner-experiments` that can be attached to the PR.  Whenever `.github/scripts/runner_determinator.py` runs on a PR and sees this label, it will not apply any logic and just straight up use an empty prefix.

### Testing

With the label:

```
python3 runner_determinator.py \
    --github-token "MY_TOKEN" \
    --github-issue "5132" \
    --github-branch "install-torchao-torchtune-et" \
    --github-actor "huydhn" \
    --github-issue-owner "huydhn" \
    --github-ref-type "branch" \
    --github-repo "pytorch/pytorch" \
    --eligible-experiments "" \
    --pr-number "139947"

INFO    : Opt-out runner determinator because #139947 has no-runner-determinator label
WARNING : No env var found for GITHUB_OUTPUT, you must be running this code locally. Falling back to the deprecated print method.
::set-output name=label-type::
```

Without the label:

```
python3 runner_determinator.py \
    --github-token "MY_TOKEN" \
    --github-issue "5132" \
    --github-branch "install-torchao-torchtune-et" \
    --github-actor "huydhn" \
    --github-issue-owner "huydhn" \
    --github-ref-type "branch" \
    --github-repo "pytorch/pytorch" \
    --eligible-experiments "" \
    --pr-number "139947"

INFO    : Based on rollout percentage of 95%, enabling experiment lf.
INFO    : Skipping experiment 'awsa100', as it is not a default experiment
WARNING : No env var found for GITHUB_OUTPUT, you must be running this code locally. Falling back to the deprecated print method.
::set-output name=label-type::lf.
```

Running in trunk commit without a PR number will use the regular logic:

```
python3 runner_determinator.py \
    --github-token "MY_TOKEN" \
    --github-issue "5132" \
    --github-branch "install-torchao-torchtune-et" \
    --github-actor "huydhn" \
    --github-issue-owner "huydhn" \
    --github-ref-type "branch" \
    --github-repo "pytorch/pytorch" \
    --eligible-experiments "" \
    --pr-number ""

INFO    : Based on rollout percentage of 95%, enabling experiment lf.
INFO    : Skipping experiment 'awsa100', as it is not a default experiment
WARNING : No env var found for GITHUB_OUTPUT, you must be running this code locally. Falling back to the deprecated print method.
::set-output name=label-type::lf.
```