### PR TITLE
Fix type description of torch.chunk

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1900,7 +1900,7 @@ Example::
 add_docstr(
     torch.chunk,
     r"""
-chunk(input, chunks, dim=0) -> List of Tensors
+chunk(input: Tensor, chunks: int, dim: int = 0) -> Tuple[Tensor, ...]
 
 Attempts to split a tensor into the specified number of chunks. Each chunk is a view of
 the input tensor.


### PR DESCRIPTION
Fixes #126278

- Change return type description of `torch.chunk` to tuple
- Add type for input parameters

**Before**
![image](https://github.com/user-attachments/assets/087b6cfa-0815-443b-a69a-785ca4b421d7)

**After**
![image](https://github.com/user-attachments/assets/19532553-6004-4246-a6cf-f7f685f5775c)


cc @drisspg @janeyx99