### PR TITLE
Give the magma build job id-token write permissions

### DIFF
--- a/.github/workflows/build-magma-linux.yml
+++ b/.github/workflows/build-magma-linux.yml
@@ -30,6 +30,8 @@ jobs:
   build-linux-magma:
     if: github.repository_owner == 'pytorch'
     runs-on: linux.2xlarge
+    permissions:
+      id-token: write
     strategy:
       matrix:
         cuda_version: ["124", "121", "118"]  # There is no pytorch/manylinux-cuda126 yet


### PR DESCRIPTION
The configure-aws-credentials action requires special permissions: https://github.com/aws-actions/configure-aws-credentials?tab=readme-ov-file#oidc

Give "id-token: write" permssion to the job that sets the AWS credentials to upload to the S3 bucket.

Fixes #139397
