### PR TITLE
Revert D65490202

### DIFF
--- a/torch/distributed/c10d_logger.py
+++ b/torch/distributed/c10d_logger.py
@@ -53,6 +53,7 @@ def _get_msg_dict(func_name, *args, **kwargs) -> Dict[str, Any]:
         group = kwargs.get("group") or kwargs.get("process_group")
         msg_dict = {
             "func_name": f"{func_name}",
+            "args": f"{args}, {kwargs}",
             "pg_name": f"{dist._get_process_group_name(kwargs.get('pg'))}",  # type: ignore[arg-type]
             "backend": f"{dist.get_backend(group)}",
             "world_size": f"{dist.get_world_size()}",
@@ -66,6 +67,7 @@ def _get_msg_dict(func_name, *args, **kwargs) -> Dict[str, Any]:
     else:
         msg_dict = {
             "func_name": f"{func_name}",
+            "args": f"{args}, {kwargs}",
         }
     return msg_dict
 


### PR DESCRIPTION
Summary:
This diff reverts D65490202
This is causing tests to fail on open source. See distributed/test_c10d_logger.py::C10dErrorLoggerTest::test_exception_logger [GH job link](https://github.com/pytorch/pytorch/actions/runs/11736922614/job/32697709457) [HUD commit link](https://hud.pytorch.org/pytorch/pytorch/commit/ba9645f6e51bb98b39ca8b351dd7fee786083372)

Test Plan: NA

Differential Revision: D65663063




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o