### PR TITLE
Build magma tarball for cuda 126

### DIFF
--- a/.github/workflows/build-magma-linux.yml
+++ b/.github/workflows/build-magma-linux.yml
@@ -34,7 +34,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        cuda_version: ["124", "121", "118"]  # There is no pytorch/manylinux-cuda126 yet
+        cuda_version: ["126", "124", "121", "118"]  # There is no pytorch/manylinux-cuda126 yet
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v4


### PR DESCRIPTION
Now that manylinux 2.28 is available with cuda 1.26 https://github.com/pytorch/pytorch/pull/139909

we can build the magma tarball for cuda 1.26.

Fixes #139397
