### PR TITLE
[export] compile cache

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -5740,6 +5740,17 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, c_
         )
         self.assertTrue(torch.allclose(core_aten_ep.module()(*inp), m(*inp)))
 
+    def test_compile_cache(self):
+        import os
+        os.environ["TORCH_COMPILE_STICKY_CACHE"] = "compile"
+
+        @torch.export._compile_cache("add")
+        def add(x, y):
+            return x + y
+
+        a, b = (torch.randn(3, 2), torch.randn(3, 2))
+        self.assertEqual(add(a, b), a + b)
+
     def test_nonzero_2(self):
         class Module(torch.nn.Module):
             def forward(self, x):

--- a/torch/_export/wrappers.py
+++ b/torch/_export/wrappers.py
@@ -12,6 +12,15 @@ from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode, track_ten
 from torch.utils import _pytree as pytree
 
 
+class ExportWrapper(torch.nn.Module):
+    def __init__(self, fn):
+        super().__init__()
+        self.fn = fn
+    
+    def forward(self, *args, **kwargs):
+        return self.fn(*args, **kwargs)
+
+        
 class ExportTracepoint(HigherOrderOperator):
     def __init__(self):
         super().__init__("_export_tracepoint")


### PR DESCRIPTION
Summary: Not ready for landing or reviewing, used for PyTorch Compiler User Empathy Day.

Differential Revision: D65667885


