### PR TITLE
Use manylinux-builder images with main tag

### DIFF
--- a/.ci/magma/Makefile
+++ b/.ci/magma/Makefile
@@ -12,7 +12,7 @@ DOCKER_RUN = set -eou pipefail; ${DOCKER_CMD} run --rm -i \
 	-e PACKAGE_NAME=${PACKAGE_NAME}${DESIRED_CUDA_SHORT} \
 	-e DESIRED_CUDA=${DESIRED_CUDA} \
 	-e CUDA_ARCH_LIST="${CUDA_ARCH_LIST}" \
-	"pytorch/manylinux-cuda${DESIRED_CUDA_SHORT}" \
+	"pytorch/manylinux-builder:cuda${DESIRED_CUDA}-main" \
 	magma/build_magma.sh
 
 .PHONY: all


### PR DESCRIPTION
The magma build uses deprecated manylinux-builder images. Update it to use the images with "main" in the tag:

  pytorch/manylinux-builder:cuda<version>-main

Fixes #ISSUE_NUMBER
