### PR TITLE
cpu: enable gemm-bf16f32 for SDPA BF16 

### DIFF
--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -435,6 +435,14 @@ void gemm(
       return;
    }
 #endif
+#if defined(__aarch64__) && AT_MKLDNN_ENABLED()
+// add support for non-aarch64 CPU's
+// add heuristic based on shape to dispatch to sbgemm_ vs MKLDNN
+   if (mkldnn_bf16f32_gemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)) {
+     return;
+   }
+#endif
+
 #ifdef MKL_HAS_SBGEMM
   if (use_blas_gemm(transa, transb, m, n, k, lda, ldb, ldc)) {
     int m_ = m, n_ = n, k_ = k, lda_ = lda, ldb_ = ldb, ldc_ = ldc;

--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -435,13 +435,12 @@ void gemm(
       return;
    }
 #endif
-#if defined(__aarch64__) && AT_MKLDNN_ENABLED()
-// add support for non-aarch64 CPU's
+#if AT_MKLDNN_ACL_ENABLED()
 // add heuristic based on shape to dispatch to sbgemm_ vs MKLDNN
    if (mkldnn_bf16f32_gemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)) {
      return;
    }
-#endif
+#endif //AT_MKLDNN_ACL_ENABLED
 
 #ifdef MKL_HAS_SBGEMM
   if (use_blas_gemm(transa, transb, m, n, k, lda, ldb, ldc)) {

--- a/aten/src/ATen/native/mkldnn/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/Matmul.cpp
@@ -206,7 +206,7 @@ mkldnn_gemm(
     float* c_data, int64_t ldc) {
 // introduce heuristic to validate dispatch to MKLDNN
 // (m * n * k <= 16 * 16 * 16)
-  bool bf16_usable = std::is_same_v<scalar_t, c10::BFloat16> && use_mkldnn_bf16_matmul();
+  bool bf16_usable = use_mkldnn_bf16_matmul();
   if (!bf16_usable) {
     return false;
   }
@@ -228,9 +228,6 @@ mkldnn_gemm(
   }
 
   auto idtype = ideep::tensor::data_type::bf16;
-  if constexpr (std::is_same_v<scalar_t, float>) {
-    idtype = ideep::tensor::data_type::f32;
-  }
 
   ideep::tensor a = make_ideep_tensor<scalar_t>({k, m}, idtype, a_strides, const_cast<scalar_t*>(a_data));
   ideep::tensor b = make_ideep_tensor<scalar_t>({n, k}, idtype, b_strides, const_cast<scalar_t*>(b_data));

--- a/aten/src/ATen/native/mkldnn/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/Matmul.cpp
@@ -107,6 +107,25 @@ static bool use_mkldnn_bf32_matmul() {
   return use_mkldnn_bf16_matmul() && at::globalContext().float32MatmulPrecision() == at::Float32MatmulPrecision::MEDIUM;
 }
 
+// returns an ideep::tensor
+// - dims: shape e.g: {M,N}
+// - idtype: ideep data type e.g: (f32, bf16, f16)
+// - strides: Memory layout
+// - data: data pointer
+template <typename scalar_t>
+inline ideep::tensor make_ideep_tensor(
+    std::vector<int64_t> dims,
+    ideep::tensor::data_type idtype,
+    ideep::tensor::dims& strides,
+    scalar_t *data){
+    ideep::tensor res({
+      dims,
+      idtype,
+      strides
+      },
+    data);
+    return res;
+  }
 
 template<typename scalar_t>
 static inline typename std::enable_if_t<
@@ -155,35 +174,77 @@ mkldnn_gemm(
     idtype = ideep::tensor::data_type::f32;
   }
 
-  ideep::tensor a({
-      /*sizes=*/{k, m},
-      idtype,
-      /*strides=*/a_strides},
-    const_cast<scalar_t*>(a_data));
-  ideep::tensor b({
-      /*sizes=*/{n, k},
-      idtype,
-      /*strides=*/b_strides},
-    const_cast<scalar_t*>(b_data));
-  ideep::tensor c({
-      /*sizes=*/{n, m},
-      idtype,
-      /*strides=*/c_strides},
-    c_data);
+  ideep::tensor a = make_ideep_tensor<scalar_t>({k, m}, idtype, a_strides, const_cast<scalar_t*>(a_data));
+  ideep::tensor b = make_ideep_tensor<scalar_t>({n, k}, idtype, b_strides, const_cast<scalar_t*>(b_data));
+  ideep::tensor c = make_ideep_tensor<scalar_t>({n, m}, idtype, c_strides, c_data);
 
   ideep::matmul_forward::compute(
       b, a, c, alpha, beta,
       ideep::scale_t(), ideep::scale_t(), ideep::scale_t(), op_attr);
 
   if (c.get_data_handle() != c_data){
+    // ideep will query oneDNN expect format of output
+    // if given output format is not expected, ideep will re-init an output buffer
+    // under this case, we need copy the re-inited buffer back to given buffer
+    ideep::tensor real_output = make_ideep_tensor<scalar_t>({n,m}, idtype, c_strides, c_data);
+    c.reorder_to(real_output);
+  }
+  return true;
+}
+
+template<typename scalar_t>
+inline typename std::enable_if_t<
+    std::is_same_v<scalar_t, c10::BFloat16>,
+    bool>
+mkldnn_gemm(
+    TransposeType transa, TransposeType transb,
+    int64_t m, int64_t n, int64_t k,
+    float alpha,
+    const scalar_t *a_data, int64_t lda,
+    const scalar_t *b_data, int64_t ldb,
+    float beta,
+    float* c_data, int64_t ldc) {
+// introduce heuristic to validate dispatch to MKLDNN
+// (m * n * k <= 16 * 16 * 16)
+  bool bf16_usable = std::is_same_v<scalar_t, c10::BFloat16> && use_mkldnn_bf16_matmul();
+  if (!bf16_usable) {
+    return false;
+  }
+
+  ideep::attr_t op_attr;
+  // Use mkldnn post ops to perform the add.
+  if (beta != 0.0f) {
+    op_attr = ideep::attr_t::fuse_sum();
+  }
+
+  // NOTE: View as c-contiguous to avoid extra reordering in mkldnn
+  // Use identity: C = AB <=> C^T = B^T A^T
+  ideep::tensor::dims a_strides{{lda, 1}}, b_strides{{ldb, 1}}, c_strides{{ldc, 1}};
+  if (transa != TransposeType::NoTranspose) {
+    std::swap(a_strides[0], a_strides[1]);
+  }
+  if (transb != TransposeType::NoTranspose) {
+    std::swap(b_strides[0], b_strides[1]);
+  }
+
+  auto idtype = ideep::tensor::data_type::bf16;
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    idtype = ideep::tensor::data_type::f32;
+  }
+
+  ideep::tensor a = make_ideep_tensor<scalar_t>({k, m}, idtype, a_strides, const_cast<scalar_t*>(a_data));
+  ideep::tensor b = make_ideep_tensor<scalar_t>({n, k}, idtype, b_strides, const_cast<scalar_t*>(b_data));
+  ideep::tensor c = make_ideep_tensor<float>({n, m}, ideep::tensor::data_type::f32, c_strides, c_data);
+
+  ideep::matmul_forward::compute(
+      b, a, c, alpha, beta,
+      ideep::scale_t(), ideep::scale_t(), ideep::scale_t(), op_attr);
+
+  if(c.get_data_handle() != c_data){
     // ideep will query onednn expect format of output
     // if given output format is not expected, ideep will re-init an output buffer
     // under this case, we need copy the re-inited buffer back to given buffer
-    ideep::tensor real_output({
-        /*sizes=*/{n, m},
-        idtype,
-        /*strides=*/c_strides},
-      c_data);
+    ideep::tensor real_output = make_ideep_tensor<float>({n,m}, idtype, c_strides, c_data);
     c.reorder_to(real_output);
   }
 
@@ -198,6 +259,17 @@ bool mkldnn_bf16_gemm(
     const c10::BFloat16 *b, int64_t ldb,
     float beta,
     c10::BFloat16 *c, int64_t ldc) {
+  return mkldnn_gemm<c10::BFloat16>(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+}
+
+bool mkldnn_bf16f32_gemm(
+    TransposeType transa, TransposeType transb,
+    int64_t m, int64_t n, int64_t k,
+    float alpha,
+    const c10::BFloat16 *a, int64_t lda,
+    const c10::BFloat16 *b, int64_t ldb,
+    float beta,
+    float *c, int64_t ldc) {
   return mkldnn_gemm<c10::BFloat16>(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
 }
 

--- a/aten/src/ATen/native/mkldnn/Matmul.h
+++ b/aten/src/ATen/native/mkldnn/Matmul.h
@@ -39,6 +39,15 @@ bool mkldnn_bf16_gemm(
     float beta,
     c10::BFloat16 *c, int64_t ldc);
 
+bool mkldnn_bf16f32_gemm(
+    TransposeType transa, TransposeType transb,
+    int64_t m, int64_t n, int64_t k,
+    float alpha,
+    const c10::BFloat16 *a, int64_t lda,
+    const c10::BFloat16 *b, int64_t ldb,
+    float beta,
+    float *c, int64_t ldc);
+
 bool mkldnn_fp16_gemm(
     TransposeType transa, TransposeType transb,
     int64_t m, int64_t n, int64_t k,


### PR DESCRIPTION
This PR enables SDPA BF16:  gemm:bf16f32 for aarch64.  This will enable faster inference for models with attention layers  for autocast mode (bf16).

Benchmark results from  [PyTorch CI HUD - branch](https://hud.pytorch.org/benchmark/huggingface/inductor_no_cudagraphs?dashboard=torchinductor&startTime=Fri%2C%2028%20Mar%202025%2021%3A26%3A20%20GMT&stopTime=Fri%2C%2004%20Apr%202025%2020%3A26%3A20%20GMT&granularity=hour&mode=inference&dtype=bfloat16&deviceName=cpu%20(aarch64)&lBranch=adi/gemm_bf16f32&lCommit=d5aeab452e4b1f0580a4636b15a604c77a02c57b&rBranch=main&rCommit=bc72420bcb37390af3fced885e019903e6e425bd)
Overall Geometric mean speedup in HUD dashboard  : for Huggingface: `[0.48x → 0.58x]` and for Blueberries: `[0.88x → 1.13x]`  

Benchmark numbers for `torch.nn.functional.scaled_dot_product_attention`on Neoverse™ V1. 

`batch_size = 1, num_attention_heads = 64, sequence_length = 512, attention_head_size = 128`
 `threads=16` 
<img width="319" alt="Screenshot 2024-12-20 at 16 23 22" src="https://github.com/user-attachments/assets/c863f97d-0761-4fb8-aa6c-fc67b22ac3f9" />

Script to benchmark & profile SDPA: 

    import torch
    import torch.nn as nn
    import time
    import numpy as np
    from torch.profiler import profile, record_function, ProfilerActivity
    class SimpleAttentionModel(nn.Module):
        def __init__(self, query, key, value):
            super(SimpleAttentionModel, self).__init__()
            self.query = query
            self.key = key
            self.value = value

        def forward(self, attn_mask=None):
            torch.nn.functional.scaled_dot_product_attention(
                        self.query,
                        self.key,
                        self.value,
                        attn_mask=attn_mask)

    #batch_size = 1, num_attention_heads = 64, sequence_length = 512, hidden_size = 128
    def bench_sdpa(batch_size = 1, num_attention_heads = 64, sequence_length = 512, query_sequence_length = 128 , hidden_size=128, precision=torch.float32):
        with torch.no_grad():
            attention_head_size = int(hidden_size / num_attention_heads)
            query = torch.rand(size=(batch_size, num_attention_heads, query_sequence_length, attention_head_size), dtype=precision)
            key = torch.rand(size=(batch_size, num_attention_heads, sequence_length, attention_head_size), dtype=precision)
            value = torch.rand(size=(batch_size, num_attention_heads, sequence_length, attention_head_size), dtype=precision)
            
            model = SimpleAttentionModel(query, key, value)
            model.eval()        
            for _ in range(10):
                model()
            times = []
            n_iters = 100
            for _ in range(n_iters):
                s = time.time_ns()
                model()
                times.append((time.time_ns() - s) / 1e3)
            min_times = np.min(times)
            mean_times = np.mean(times)
            print(f"Min Times = {min_times} us")
            print(f"Mean Times = {mean_times} us")
            print("Times = ", times)

    print("BF16 mode:")
    with profile(activities=[ProfilerActivity.CPU], record_shapes=True) as prof:
        with record_function("model_inference"):
            bench_sdpa(precision=torch.bfloat16)
    profile_data = prof.key_averages(group_by_input_shape=True).table(sort_by="cpu_time_total")
    print(profile_data)



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @malfet @milpuz01 @nikhil-arm @fadara01 @voznesenskym @penguinwu @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @xmfan