### PR TITLE
Doc issue: Fix Inconsistent Notation for RMSNorm

### DIFF
--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -325,7 +325,7 @@ class RMSNorm(Module):
     the paper `Root Mean Square Layer Normalization <https://arxiv.org/pdf/1910.07467.pdf>`__
 
     .. math::
-        y = \frac{x}{\mathrm{RMS}(x)} * \gamma \quad
+        y_i = \frac{x_i}{\mathrm{RMS}(x)} * \gamma_i, \quad
         \text{where} \quad \text{RMS}(x) = \sqrt{\epsilon + \frac{1}{n} \sum_{i=1}^{n} x_i^2}
 
     The RMS is taken over the last ``D`` dimensions, where ``D``

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -325,7 +325,7 @@ class RMSNorm(Module):
     the paper `Root Mean Square Layer Normalization <https://arxiv.org/pdf/1910.07467.pdf>`__
 
     .. math::
-        y = \frac{x}{\mathrm{RMS}[x]} * \gamma \quad
+        y = \frac{x}{\mathrm{RMS}(x)} * \gamma \quad
         \text{where} \quad \text{RMS}(x) = \sqrt{\epsilon + \frac{1}{n} \sum_{i=1}^{n} x_i^2}
 
     The RMS is taken over the last ``D`` dimensions, where ``D``


### PR DESCRIPTION
Follow-up of #136597 

This pull request proposes a change to standardize the notation for the RMS function in the PyTorch documentation and formula expressions. The current documentation inconsistently uses both `\mathrm{RMS}[x]` and `\mathrm{RMS}(x)`, which can lead to confusion. Additionally, the formula should explicitly indicate indices for clarity.

#### **Why This Fix is Needed**

1. **Consistency in Notation**:
   - The current documentation uses both `\mathrm{RMS}[x]` and `\mathrm{RMS}(x)` interchangeably. To maintain consistency and align with standard mathematical notation, it is preferable to use `\mathrm{RMS}(x)`, which is more widely recognized in mathematical contexts as the correct functional form.
  
2. **Clarity with Indices**:
   - The formula for $$y$$ lacks explicit indexing, which can be confusing when dealing with element-wise operations on tensors or vectors. Adding indices (e.g., $$y_i$$, $$x_i$$, and $$\gamma_i$$) clarifies that the operation is applied element-wise, improving readability and correctness in the context of tensor operations.

3. **Alignment with Mathematical Standards**:
   - In mathematical conventions, functions are typically written using parentheses (e.g., $$f(x)$$), not brackets. Using `\mathrm{RMS}(x)` ensures that PyTorch's documentation adheres to these standards, making it easier for users to follow and reducing potential misunderstandings.

#### **Proposed Changes**

- Change all instances of `\mathrm{RMS}[x]` to `\mathrm{RMS}(x)` in the formula.
- Update the formula to include indices for element-wise operations as follows:

![grafik](https://github.com/user-attachments/assets/f250ee5a-167d-4e2f-9a25-55f51a465dea)

This will ensure that both the notation and indexing are clear and consistent throughout the documentation.