### PR TITLE
Save indexing for getitem nodes when do custom replacements

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -3,6 +3,7 @@ import copy
 import itertools
 import os
 import unittest
+from typing import Callable, List, Optional
 
 import torch
 import torch._dynamo.config as dynamo_config
@@ -10,11 +11,13 @@ import torch._inductor.config as inductor_config
 import torch._inductor.fx_passes.post_grad
 import torch.nn.functional as F
 from torch._dynamo.utils import count_calls, counters
+from torch._higher_order_ops.auto_functionalize import auto_functionalized
 from torch._higher_order_ops.out_dtype import out_dtype
 from torch._inductor.fx_passes import joint_graph
 from torch._inductor.pattern_matcher import (
     Arg,
     CallFunction,
+    fwd_only,
     gen_pattern,
     is_mutation_op,
     KeywordArg,
@@ -22,6 +25,7 @@ from torch._inductor.pattern_matcher import (
     PatternMatcherPass,
     PatternPrettyPrinter,
     register_graph_pattern,
+    register_replacement,
     stable_topological_sort,
 )
 from torch._inductor.test_case import run_tests, TestCase
@@ -1618,6 +1622,148 @@ class TestPatternMatcher(TestCase):
             {},
             expect=False,
         )
+
+    def test_multioutput_register_replacement(self):
+        @torch.library.custom_op(
+            "vllm::fused_rms_norm_quant_static", mutates_args=["result", "scale"]
+        )
+        def fused_rms_norm_quant_static(
+            result: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            scale: torch.Tensor,
+            azp: torch.Tensor,
+            epsilon: float,
+        ) -> None:
+            print("vllm::fused_rms_norm_quant_static")
+            result_rms = torch.mul(input, weight) + epsilon
+            result = torch.mul(result_rms, scale).to(torch.int8)
+            scale.fill_(0.5)
+
+        @torch.library.custom_op("vllm::rms_norm", mutates_args=["result"])
+        def rms_norm(
+            result: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            epsilon: float,
+        ) -> None:
+            # bogus implementation doesn't matter
+            result = torch.mul(input, weight) + epsilon
+
+        @torch.library.custom_op(
+            "vllm::static_scaled_int8_quant", mutates_args=["result", "scale"]
+        )
+        def static_scaled_int8_quant(
+            result: torch.Tensor,
+            input: torch.Tensor,
+            scale: torch.Tensor,
+            azp: Optional[torch.Tensor] = None,
+        ) -> None:
+            # bogus implementation doesn't matter
+            result = torch.mul(input, scale).to(torch.int8)
+            scale.fill_(0.5)
+
+        def rms_pattern_static(
+            result: torch.Tensor,
+            result_rms: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            scale: torch.Tensor,
+        ):
+            at1 = auto_functionalized(
+                torch.ops.vllm.rms_norm.default,
+                result=result_rms,
+                input=input,
+                weight=weight,
+                epsilon=1e-6,
+            )
+            at2 = auto_functionalized(
+                torch.ops.vllm.static_scaled_int8_quant.default,
+                result=result,
+                input=at1[1],
+                scale=scale,
+                azp=None,
+            )
+
+            return at2[1], at2[2]
+
+        def rms_replacement_static(
+            result: torch.Tensor,
+            result_rms: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            scale: torch.Tensor,
+        ):
+            at = auto_functionalized(
+                torch.ops.vllm.fused_rms_norm_quant_static.default,
+                result=result,
+                input=input,
+                weight=weight,
+                epsilon=1e-6,
+                scale=scale,
+                azp=None,
+            )
+            return at[1], at[2]
+
+        def empty_bf16(*args, **kwargs):
+            return torch.empty(*args, **kwargs, dtype=torch.bfloat16)
+
+        def empty_int8(*args, **kwargs):
+            return torch.empty(*args, **kwargs, dtype=torch.int8)
+
+        my_patterns = PatternMatcherPass()
+        inputs = [
+            empty_int8(5, 4),
+            empty_bf16(5, 4),
+            empty_bf16(5, 4),
+            empty_bf16(5, 1),
+            torch.empty(1, 1),
+        ]
+        register_replacement(
+            rms_pattern_static, rms_replacement_static, inputs, fwd_only, my_patterns
+        )
+
+        def custom_pass(graph: torch.fx.Graph) -> torch.fx.Graph:
+            count = my_patterns.apply(graph)
+            # print(f"Count: {count}")
+            graph.eliminate_dead_code()
+            # graph.print_tabular()
+            return graph
+
+        def custom_backend(
+            graph: torch.fx.GraphModule, example_inputs: List[torch.Tensor]
+        ) -> Callable:
+            from torch._inductor import config
+
+            current_config = config.shallow_copy_dict()
+            from torch._inductor.compile_fx import compile_fx
+
+            current_config["post_grad_custom_post_pass"] = custom_pass
+            return compile_fx(graph, example_inputs, config_patches=current_config)
+
+        @torch.compile(backend=custom_backend)
+        def my_func_static(x, w, epsilon):
+            quant_result = torch.empty_like(x, dtype=torch.int8)
+            result_rms = torch.empty_like(x, dtype=torch.bfloat16)
+            scale = torch.ones((1, 1))
+
+            x = x.to(torch.bfloat16)
+            w = w.to(torch.bfloat16)
+
+            quant_result, scale = rms_pattern_static(
+                result=quant_result,
+                result_rms=result_rms,
+                input=x,
+                weight=w,
+                scale=scale,
+            )
+
+            return quant_result, scale
+
+        inputs = [torch.empty((5, 4)), torch.empty((5, 1)), 1e-6]
+        # print(my_func_static(*inputs))
+        test, (code,) = run_and_get_code(my_func_static, *inputs)
+        self.assertTrue("static_scaled_int8_quant" not in code)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1802,8 +1802,12 @@ def fx_to_pattern(
     inv_scalar_workaround = {v: k for k, v in scalar_workaround.items()}
     assert len(inv_scalar_workaround) == len(scalar_workaround)
 
-    def process_arg(x: T, ignore_types_override: Optional[Sequence[Type[Any]]] = None) -> Union[T, KeywordArg, Ignored]:
-        current_ignore_types = ignore_types_override if ignore_types_override is not None else ignore_types
+    def process_arg(
+        x: T, ignore_types_override: Optional[Sequence[Type[Any]]] = None
+    ) -> Union[T, KeywordArg, Ignored]:
+        current_ignore_types = (
+            ignore_types_override if ignore_types_override is not None else ignore_types
+        )
         if isinstance(x, (float, int)) and x in inv_scalar_workaround:
             return KeywordArg(inv_scalar_workaround[x])
         if type(x) in current_ignore_types:
@@ -1842,7 +1846,12 @@ def fx_to_pattern(
             # Indexing is critical for matching getitem nodes, so we can't ignore int args here
             if target == operator.getitem and int in ignore_types:
                 temp_ignore_types = tuple(t for t in ignore_types if t is not int)
-                process_arg_fun = functools.partial(process_arg, ignore_types_override=temp_ignore_types)
+
+                def process_arg_fun(
+                    x: T, ignore_types_override: Optional[Sequence[Type[Any]]] = None
+                ) -> Union[T, KeywordArg, Ignored]:
+                    return process_arg(x, ignore_types_override=temp_ignore_types)
+
             else:
                 process_arg_fun = process_arg
             args, kwargs = pytree.tree_map(process_arg_fun, (args, kwargs))

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1802,10 +1802,11 @@ def fx_to_pattern(
     inv_scalar_workaround = {v: k for k, v in scalar_workaround.items()}
     assert len(inv_scalar_workaround) == len(scalar_workaround)
 
-    def process_arg(x: T) -> Union[T, KeywordArg, Ignored]:
+    def process_arg(x: T, ignore_types_override: Optional[Sequence[Type[Any]]] = None) -> Union[T, KeywordArg, Ignored]:
+        current_ignore_types = ignore_types_override if ignore_types_override is not None else ignore_types
         if isinstance(x, (float, int)) and x in inv_scalar_workaround:
             return KeywordArg(inv_scalar_workaround[x])
-        if type(x) in ignore_types:
+        if type(x) in current_ignore_types:
             return Ignored()
         if isinstance(x, list) and all(isinstance(y, Ignored) for y in x) and x:
             return Ignored()
@@ -1838,11 +1839,17 @@ def fx_to_pattern(
         def call_function(
             self, target: str, args: Sequence[Any], kwargs: Mapping[str, Any]  # type: ignore[override]
         ) -> PatternExpr:
-            args, kwargs = pytree.tree_map(process_arg, (args, kwargs))
+            # Indexing is critical for matching getitem nodes, so we can't ignore int args here
+            if target == operator.getitem and int in ignore_types:
+                temp_ignore_types = tuple(t for t in ignore_types if t is not int)
+                process_arg_fun = functools.partial(process_arg, ignore_types_override=temp_ignore_types)
+            else:
+                process_arg_fun = process_arg
+            args, kwargs = pytree.tree_map(process_arg_fun, (args, kwargs))
             if list in ignore_types:
                 # Handle a burned in tensor size which are now [Ignored(), Ignored(), ...]
-                args = [process_arg(a) for a in args]
-                kwargs = {k: process_arg(a) for k, a in kwargs.items()}
+                args = [process_arg_fun(a) for a in args]
+                kwargs = {k: process_arg_fun(a) for k, a in kwargs.items()}
             return CallFunction(target, *args, **kwargs)
 
         def run_node(self, n: torch.fx.Node) -> Any:

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1843,10 +1843,11 @@ def fx_to_pattern(
         def call_function(
             self, target: str, args: Sequence[Any], kwargs: Mapping[str, Any]  # type: ignore[override]
         ) -> PatternExpr:
+            process_arg_fn = process_arg
             # Indexing is critical for matching getitem nodes, so we can't ignore int args here
             if target == operator.getitem:
 
-                def process_arg_fn(
+                def process_arg_fn_impl(
                     x: T,
                     ignore_types_override: Optional[Sequence[Type[Any]]] = tuple(
                         t for t in ignore_types if t is not int
@@ -1854,8 +1855,8 @@ def fx_to_pattern(
                 ) -> Union[T, KeywordArg, Ignored]:
                     return process_arg(x, ignore_types_override)
 
-            else:
-                process_arg_fn = process_arg
+                process_arg_fn = process_arg_fn_impl
+
             args, kwargs = pytree.tree_map(process_arg_fn, (args, kwargs))
             if list in ignore_types:
                 # Handle a burned in tensor size which are now [Ignored(), Ignored(), ...]


### PR DESCRIPTION
Fixes #137280

When we have multiple indexings for the same array as returned items in pattern replacement, we shouldn't ignore its indexing numbers. otherwise, we may create a wrong pattern_to_node mapping. 

A unit test is added in this PR. In this unit test, the function `rms_pattern_static` is replaced with `rms_replacement_static` when called. The function `rms_pattern_static` calls two functionalized custom operators, `torch.ops.vllm.rms_norm.default` and `torch.ops.vllm.static_scaled_int8_quant.default`, and it returns at2[1] and at2[2] as outputs. The function `rms_replacement_static` calls one functionalized custom operator `torch.ops.vllm.fused_rms_norm_quant_static.default`, which returns two corresponding items.

Run `python test/inductor/test_pattern_matcher.py -k test_multioutput_register_replacement` to test. After set `TORCH_COMPILE_DEBUG` to 1, the final part of the `fx_graph_readable.py` is like the following.
```python
# File: /home/yhao/p9/pytorch/test/inductor/test_pattern_matcher.py:1673 in rms_pattern_static, code: at1 = auto_functionalized(
auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.vllm.rms_norm.default, result = permute_1, input = convert_element_type, weight = convert_element_type_1, epsilon = 1e-06);  permute_1 = convert_element_type = convert_element_type_1 = None
getitem_1: "bf16[5, 4]" = auto_functionalized[1];  auto_functionalized = None

# File: /home/yhao/p9/pytorch/test/inductor/test_pattern_matcher.py:1680 in rms_pattern_static, code: at2 = auto_functionalized(
auto_functionalized_1 = torch.ops.higher_order.auto_functionalized(torch.ops.vllm.static_scaled_int8_quant.default, result = permute, input = getitem_1, scale = full_default, azp = None);  permute = getitem_1 = full_default = None
getitem_3: "i8[5, 4]" = auto_functionalized_1[1]
getitem_4: "f32[1, 1]" = auto_functionalized_1[2];  auto_functionalized_1 = None
return (getitem_3, getitem_4)
```
This happens before pattern matching, so is it expected to call `static_scaled_int8_quant` and `rms_norm` and return auto_functionalized_1 as outputs.

However, for pytorch before this PR, the `fx_graph_transformed.py`, which is after pattern matching, has the following code.
```python
 # File: /home/yhao/p9/pytorch/test/inductor/test_pattern_matcher.py:1748 in my_func_static, code: scale = torch.ones((1, 1))
full_default: "f32[1, 1]" = torch.ops.aten.full.default([1, 1], 1, dtype = torch.float32, layout = torch.strided, device = device(type='cpu'), pin_memory = False)

# No stacktrace found for following nodes
as_strided_default: "i8[20]" = torch.ops.aten.as_strided.default(permute, [20], [1], 0)
clone_default: "i8[20]" = torch.ops.aten.clone.default(as_strided_default);  as_strided_default = None
as_strided_default_1: "i8[5, 4]" = torch.ops.aten.as_strided.default(clone_default, [5, 4], [4, 1], 0);  clone_default = None
as_strided_default_2: "f32[1]" = torch.ops.aten.as_strided.default(full_default, [1], [1], 0)
clone_default_1: "f32[1]" = torch.ops.aten.clone.default(as_strided_default_2);  as_strided_default_2 = None
as_strided_default_3: "f32[1, 1]" = torch.ops.aten.as_strided.default(clone_default_1, [1, 1], [1, 1], 0);  clone_default_1 = None
static_scaled_int8_quant_default = torch.ops.vllm.static_scaled_int8_quant.default(as_strided_default_1, permute_1, as_strided_default_3);  as_strided_default_1 = permute_1 = static_scaled_int8_quant_default = None
fused_rms_norm_quant_static_default = torch.ops.vllm.fused_rms_norm_quant_static.default(permute, convert_element_type, convert_element_type_1, full_default, None, 1e-06);  convert_element_type = convert_element_type_1 = full_default = fused_rms_norm_quant_static_default = None
return (permute, as_strided_default_3)
``` 
Here, it returns `(permute, as_strided_default_3)` while `permute` is written by fused_rms_norm_quant_static and `as_strided_default_3` is written by `static_scaled_int8_quant`. This is wrong because in our expectation, the `static_scaled_int8_quant` should be removed since it is replaced with `fused_rms_norm_quant_static`. It is supposed to return `(permute, full_default)`. 

The root cause is the following part. When we [generate patterns](https://github.com/pytorch/pytorch/blob/5f4a21dc58c7b0a732ae0dec8fdbf2dfbda4e7d5/torch/_inductor/pattern_matcher.py#L1580) with traced fx graph and call the following function, the indexing numbers' type int in traced graph are ignored in `ignore_types`. So, the final arguments of patterns for those two output items are like `(CallFunction(auto_functionalized,XXX)), *)`. 
 
https://github.com/pytorch/pytorch/blob/5f4a21dc58c7b0a732ae0dec8fdbf2dfbda4e7d5/torch/_inductor/pattern_matcher.py#L1839-L1847


When we do pattern matching after we generated patterns in the following part, the `sorted(itertools.chain.from_iterable(nodes), reverse=True)` is `[getitem_4, getitem_3, getitem_1]`. The getitem_4's iteration is always FailedMatch because we always use the first element to do the pattern match here (it fails on different match functions before and after this PR, but the reason is always the indexing numbers issue)https://github.com/pytorch/pytorch/blob/d4cdc098817a0af10b478256b524533ed67285a9/torch/_inductor/pattern_matcher.py#L848. However, when we do pattern matching for getitem_3, the child_match returns a match for getitem_3 again which is because the `*` pattern can match anything. Then the getitem_3's pattern matching returns a `[getitem_3, getitem_3]` as outputs which are wrong.  
https://github.com/pytorch/pytorch/blob/d4cdc098817a0af10b478256b524533ed67285a9/torch/_inductor/pattern_matcher.py#L856

https://github.com/pytorch/pytorch/blob/d4cdc098817a0af10b478256b524533ed67285a9/torch/_inductor/pattern_matcher.py#L1750-L1774


This PR doesn't ignore `int` type when we generate patterns for getitem functions because integer indexing numbers are important to them. Thus, the indexing information is kept in patterns, ensuring correct matchings. With this PR, the above `child_match` returns a match for getitem_4, and the final getitem_3's pattern matching returns the correct `[getitem_3, getitem_4]`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov