### PR TITLE
Fix CPP FP16 GEMM Template

### DIFF
--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -819,7 +819,7 @@ class CppMicroBrgemm(CppMicroGemm):
     at::native::cpublas::brgemm(
       M, N, K,
       lda, ldb, ldc,
-      1.f, accum ? 1.f : 0.f,
+      accum,
       A,
       B,
       C);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #140207

**Summary**
Fix https://github.com/pytorch/pytorch/issues/140206, the parameters mis-used in FP16 GEMM Template.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov