### PR TITLE
Fix RMSNorm Notation: Parentheses, Indices, Comma

### DIFF
--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -325,7 +325,7 @@ class RMSNorm(Module):
     the paper `Root Mean Square Layer Normalization <https://arxiv.org/pdf/1910.07467.pdf>`__
 
     .. math::
-        y = \frac{x}{\mathrm{RMS}[x]} * \gamma \quad
+        y_i = \frac{x_i}{\mathrm{RMS}(x)} * \gamma_i, \quad
         \text{where} \quad \text{RMS}(x) = \sqrt{\epsilon + \frac{1}{n} \sum_{i=1}^{n} x_i^2}
 
     The RMS is taken over the last ``D`` dimensions, where ``D``


### PR DESCRIPTION
Fixes #140165 

* fixed mathematical notation for RMSNorm:
  * changed RMS function from brackets `[x]` to parenthesis `(x)` for consistency and align with mathematical notation standards for functions
  * added indices (e.g. `y_i`)  for element-wise operations for the correctness in the context of tensor operations
  * added comma `,` before $$\text{where}$$

![grafik](https://github.com/user-attachments/assets/47368625-d97a-43de-8b90-17b2c01cbe2f)

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki