### PR TITLE
Enables static quantization for aarch64

### DIFF
--- a/torch/ao/nn/quantized/reference/modules/conv.py
+++ b/torch/ao/nn/quantized/reference/modules/conv.py
@@ -30,7 +30,7 @@ class _ConvNd(torch.nn.modules.conv._ConvNd, ReferenceQuantizedModule):
     _IS_REFERENCE = True
 
     @staticmethod
-    def from_float(cls, float_conv, weight_qparams):
+    def from_float(cls, float_conv, weight_qparams, bias_qparams = None):
         qref_conv = cls(
             float_conv.in_channels,
             float_conv.out_channels,
@@ -110,8 +110,8 @@ class Conv1d(_ConvNd, nn.Conv1d):
         return "QuantizedConv1d(Reference)"
 
     @classmethod
-    def from_float(cls, float_conv, weight_qparams):
-        return _ConvNd.from_float(cls, float_conv, weight_qparams)
+    def from_float(cls, float_conv, weight_qparams, bias_qparams = None):
+        return _ConvNd.from_float(cls, float_conv, weight_qparams, bias_qparams)
 
 
 class Conv2d(_ConvNd, nn.Conv2d):
@@ -129,6 +129,7 @@ class Conv2d(_ConvNd, nn.Conv2d):
         device=None,
         dtype=None,
         weight_qparams: Optional[Dict[str, Any]] = None,
+        bias_qparams: Optional[Dict[str, Any]] = None
     ):
         nn.Conv2d.__init__(
             self,
@@ -145,6 +146,7 @@ class Conv2d(_ConvNd, nn.Conv2d):
             dtype,
         )
         self._init_weight_qparams(weight_qparams, device)
+        self._init_bias_qparams(bias_qparams, device)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
@@ -173,8 +175,8 @@ class Conv2d(_ConvNd, nn.Conv2d):
         return "QuantizedConv2d(Reference)"
 
     @classmethod
-    def from_float(cls, float_conv, weight_qparams):
-        return _ConvNd.from_float(cls, float_conv, weight_qparams)
+    def from_float(cls, float_conv, weight_qparams, bias_qparams = None):
+        return _ConvNd.from_float(cls, float_conv, weight_qparams, bias_qparams)
 
 
 class Conv3d(_ConvNd, nn.Conv3d):
@@ -248,7 +250,7 @@ class _ConvTransposeNd(_ConvNd, torch.nn.modules.conv._ConvTransposeNd):
     """
 
     @staticmethod
-    def from_float(cls, float_conv, weight_qparams):
+    def from_float(cls, float_conv, weight_qparams, bias_qparams = None):
         qref_conv = cls(
             float_conv.in_channels,
             float_conv.out_channels,
@@ -263,7 +265,7 @@ class _ConvTransposeNd(_ConvNd, torch.nn.modules.conv._ConvTransposeNd):
             device=float_conv.weight.device,
             dtype=float_conv.weight.dtype,
             weight_qparams=weight_qparams,
-        )
+            bias_qparams=bias_qparams)
         qref_conv.weight = torch.nn.Parameter(float_conv.weight.detach())
         if float_conv.bias is not None:
             qref_conv.bias = torch.nn.Parameter(float_conv.bias.detach())

--- a/torch/ao/nn/quantized/reference/modules/linear.py
+++ b/torch/ao/nn/quantized/reference/modules/linear.py
@@ -30,9 +30,10 @@ class Linear(nn.Linear, ReferenceQuantizedModule):
         device: Optional[torch.device] = None,
         dtype: Optional[torch.dtype] = None,
         weight_qparams: Optional[Dict[str, Any]] = None,
-    ):
+        bias_qparams: Optional[Dict[str, Any]] = None):
         super().__init__(in_features, out_features, bias_, device, dtype)
         self._init_weight_qparams(weight_qparams, device)
+        self._init_bias_qparams(bias_qparams, device)
 
     def _get_name(self):
         return "QuantizedLinear(Reference)"
@@ -53,7 +54,7 @@ class Linear(nn.Linear, ReferenceQuantizedModule):
         return result
 
     @classmethod
-    def from_float(cls, float_linear, weight_qparams):
+    def from_float(cls, float_linear, weight_qparams, bias_qparams = None):
         qref_linear = Linear(
             float_linear.in_features,
             float_linear.out_features,
@@ -61,6 +62,7 @@ class Linear(nn.Linear, ReferenceQuantizedModule):
             device=float_linear.weight.device,
             dtype=float_linear.weight.dtype,
             weight_qparams=weight_qparams,
+            bias_qparams=bias_qparams
         )
         qref_linear.weight = torch.nn.Parameter(float_linear.weight.detach())
         if float_linear.bias is not None:

--- a/torch/ao/quantization/fx/qconfig_mapping_utils.py
+++ b/torch/ao/quantization/fx/qconfig_mapping_utils.py
@@ -266,7 +266,6 @@ def _is_qconfig_supported_by_dtype_configs(
             is_dynamic = False
         input_dtype = dtype_config.input_dtype or torch.float
         weight_dtype = dtype_config.weight_dtype or torch.float
-        bias_dtype = dtype_config.bias_dtype or torch.float
         output_dtype = dtype_config.output_dtype or torch.float
         (
             qconfig_activation_dtype,
@@ -295,7 +294,7 @@ def _is_qconfig_supported_by_dtype_configs(
                 input_dtype == qconfig_activation_dtype
                 and output_dtype == qconfig_activation_dtype
                 and weight_dtype == qconfig_weight_dtype
-                and bias_dtype == qconfig_bias_dtype
+                # FIXME: should we check for bias data type too
             )
         if is_match:
             return True


### PR DESCRIPTION
This pull request enables static quantization for aarch64, supporting both convolution and matmul in signed 8-bit (`s8s8s8`) and unsigned 8-bit (`u8s8u8`) formats.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @ezyang @SherlockNoMad @EikanWang @wenzhe-nrv