### PR TITLE
Fix TypeError in Conv2d by ensuring dilation is always a tuple

### DIFF
--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -517,14 +517,14 @@ class Conv2d(_ConvNd):
         kernel_size_ = _pair(kernel_size)
         stride_ = _pair(stride)
         padding_ = padding if isinstance(padding, str) else _pair(padding)
-        dilation_ = _pair(dilation)
+        self._dilation = _pair(dilation)
         super().__init__(
             in_channels,
             out_channels,
             kernel_size_,
             stride_,
             padding_,
-            dilation_,
+            self._dilation,
             False,
             _pair(0),
             groups,
@@ -533,6 +533,16 @@ class Conv2d(_ConvNd):
             **factory_kwargs,
         )
 
+    @property
+    def dilation(self):
+        # fallback for older serialised models
+        return getattr(self, "_dilation", self.__dict__.get("dilation", (1, 1)))
+
+    @dilation.setter
+    def dilation(self, value):
+        # ensures dilation is always a tuple
+        self._dilation = _pair(value)
+    
     def _conv_forward(self, input: Tensor, weight: Tensor, bias: Optional[Tensor]):
         if self.padding_mode != "zeros":
             return F.conv2d(


### PR DESCRIPTION
**Description**:
This PR addresses an issue in the `Conv2d `class where dilation set as an integer (rather than a tuple) can lead to a `TypeError` when calling methods like `extra_repr` that expect dilation to be a tuple.

**Problem**
In certain cases, if dilation is set to an integer, calling methods that access `len(self.dilation)` will raise the following error:
```
TypeError: object of type 'int' has no len()`
```
This is because dilation can sometimes be stored as an integer, while some internal methods assume it's always a tuple. The [PyTorch Conv2d documentation](https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html) specifies that dilation can be set as either an integer or a tuple.

**Changes made**
- Added `@property` and `@dilation.setter` in `Conv2d` to convert integer inputs to tuples using `_pair`.
- Updated the internal `dilation_` usage in the constructor to use `self._dilation`, enforcing the correct format.
- Applied `getattr` fallback logic for loading legacy models, setting dilation as `(1, 1)` if absent.

**Tests**
The following code demonstrates the fix. Previously, setting `self.conv.dilation = 1` could raise a `TypeError` when calling `extra_repr`, but this fix resolves that issue:
```
import torch
import torch.nn as nn

class SimpleModel(nn.Module):
    def __init__(self):
        super(SimpleModel, self).__init__()
        self.conv = nn.Conv2d(1, 1, kernel_size=3)
        self.conv.dilation = 1  # setting dilation as an integer should now be handled

    def forward(self, x):
        return self.conv(x)

model = SimpleModel()
input_tensor = torch.randn(1, 1, 5, 5)
output = model(input_tensor)
print(model)

```


cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki