### PR TITLE
OpenReg: Fix issue when casting tensor on the executor size

### DIFF
--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/_device_daemon.py
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/_device_daemon.py
@@ -64,10 +64,8 @@ class Allocator:
 
         # Raw 1d uint8 data
         raw = found_base
-        # Slice the right storage part
-        raw_slice = raw.narrow(0, 0, meta.nelem_in_bytes)
         # Reinterpret cast in the right dtype
-        as_dtype = raw_slice.view(dtype=meta.dtype)
+        as_dtype = raw.view(dtype=meta.dtype)
         # View to the right shape/stride/offset
         view = as_dtype.as_strided(meta.size, meta.stride, meta.storage_offset)
         return view

--- a/test/cpp_extensions/open_registration_extension/test/test_openreg.py
+++ b/test/cpp_extensions/open_registration_extension/test/test_openreg.py
@@ -119,6 +119,12 @@ class TestOpenReg(TestCase):
         e1 = s1.record_event()
         e1.wait(s2)
 
+    def test_expand(self):
+        x = torch.tensor([[1], [2], [3]], device="openreg")
+        y = x.expand(3, 2)
+        self.assertEqual(y.to(device="cpu"), torch.tensor([[1, 1], [2, 2], [3, 3]]))
+        self.assertEqual(x.data_ptr(), y.data_ptr())
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Previously we assumed that the number of tensor elements multiplied by the type size is not greater than the allocated memory size. However in some scenarios such as `tensor.expand`, the stride can be zero, which makes the assumption not true.

cc @ezyang @albanD