### PR TITLE
Simplify & rectify dequantized B buffer loading for AMX GEMM micro-kernel for WoQ int8 case

### DIFF
--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -543,12 +543,12 @@ class CppMicroGemmAMX(CppMicroGemm):
         {%- if (block_n % 32) != 0 %}
             auto b_int8_tail = at::vec::Vectorized<int8_t>::loadu(
                 base_addr + idx_q + {{block_n - (block_n % 32)}},
-                static_cast<int64_t>(block_n % 32)
+                static_cast<int64_t>({{block_n % 32}})
             );
             auto b_bf16_tail = at::vec::convert<{{input_t}}>(b_int8_tail);
             b_bf16_tail.store(
                 dequantized_B_buf + idx_dq + {{block_n - (block_n % 32)}},
-                static_cast<int64_t>(block_n % 32)
+                static_cast<int64_t>({{block_n % 32}})
             );
         {%- endif %}
         }

--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -535,8 +535,10 @@ class CppMicroGemmAMX(CppMicroGemm):
         // first element of a subsequent [K, block_n] block would be right after the last
         // element of the previous block sized [K x block_n] elements.
         // This is implicitly being ensured by the current weight-packing implementation.
-        // Since [K, block_n] blocks are to be cached, the details of the weight-packing
-        // implementation can't be made transparent to the dequantization & cahing logic.
+        // Since blocks sized [K, block_n] corresponding to each block_n sized segment of N
+        // are to be cached, the details of the weight-packing implementation can't be made
+        // transparent to the dequantization & caching logic here.
+        // It's worth noting that ldb doesn't matter in this context.
         const int base_idx = K * n;
         for (int idx = 0; idx < buf_size; idx += 32) {
             auto b_int8 = at::vec::Vectorized<int8_t>::loadu(

--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -546,7 +546,7 @@ class CppMicroGemmAMX(CppMicroGemm):
     for (int64_t n = 0; n < N; n += {{block_n}}) {
 {%- if use_cached_dequantized_B %}
         // Dequantize K * 32 int8 B elements into BF16
-        load_dequantized_B(n);
+        load_dequantized_B(n / {{block_n}});
 {%- endif %}
         for (int64_t m = 0; m < M; m += {{block_m}}) {
             int64_t block_m = std::min<int64_t>(M - m, {{block_m}});

--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -531,7 +531,7 @@ class CppMicroGemmAMX(CppMicroGemm):
     auto load_dequantized_B = [&](int n) {
         // Load a tile of B & cache it in L1D.
         // The assumption here is that if N would be a multiple of block_n,
-        // then B would be some consecutive tiles sized [k, block_n], so the
+        // then B would be some consecutive tiles sized [k, block_n] each, so the
         // first element of a subsequent [K, block_n] tile would be right after the last
         // element of the previous tile sized [K x block_n]
         auto base_idx = n * K * {{block_n}};

--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -514,11 +514,8 @@ class CppMicroGemmAMX(CppMicroGemm):
 {%- if use_cached_dequantized_B %}
     // Create a stack-allocated buffer for tiles of B.
     // Except maybe for the tail-case, an AMX tile of B has 16x32 BF16 elements.
-    const auto num_elements_per_b_tile = 512;
-    const auto last_k_offset = K / {{block_k}} * {{block_k}};
-    const auto tail_k_size = K - last_k_offset;
     // we cache K * {{block_n}} elements of dequantized B
-    const auto buf_size = K * {{block_n}} * sizeof({{input_t}});
+    const auto buf_size = K * {{block_n}};
     {%- if is_msvc_compiler %}
     // MSVC doesn't support stack-allocated dynamic-sized arrays, so using heap memory here.
     std::unique_ptr<{{input_t}}[]> heap_deq_b_buf_ptr(new {{input_t}}[buf_size]);
@@ -531,37 +528,17 @@ class CppMicroGemmAMX(CppMicroGemm):
     alignas(4096) {{input_t}} dequantized_B_buf[buf_size];
     {%- endif %}
 
-    const auto b_tile_ptr_stride = ldb * {{vnni_size}};
-
-    auto load_B_row = [&]({{input2_t}}* {{restrict_keyword}} src, {{input_t}}* {{restrict_keyword}} dst) {
-        auto b_int8 = at::vec::Vectorized<int8_t>::loadu(src, static_cast<int64_t>(32));
-        auto b_bf16 = at::vec::convert<{{input_t}}>(b_int8);
-        b_bf16.store(dst);
-    };
-
-    auto load_B_tile = [&]({{input2_t}}* B_ptr, int idx, int num_b_rows) {
-        {{input_t}}* base_addr = dequantized_B_buf + idx;
-        {{kernel.unroll_pragma(8)}}
-        for (int i = 0; i < num_b_rows; i++) {
-            load_B_row(
-                B_ptr + i * b_tile_ptr_stride,
-                base_addr + i * 32
-            );
-        }
-    };
     auto load_dequantized_B = [&](int n) {
         // Load a tile of B & cache it in L1D.
-        {{kernel.unroll_pragma(4)}}
-        for (int k = 0; k < K; k += {{block_k}}) {
-            int num_b_rows = (k < last_k_offset) ? 16 : tail_k_size;
-            {{kernel.unroll_pragma(2)}}
-            for (int tile_col = 0; tile_col <= 1; tile_col++) {
-                load_B_tile(
-                    const_cast<{{input2_t}}*>(B) + n + k * ldb + tile_col * {{16 * vnni_size}},
-                    (k / {{block_k // 2}} + tile_col) * num_elements_per_b_tile,
-                    num_b_rows
-                );
-            }
+        // The assumption here is that if N would be a multiple of block_n,
+        // then B would be some consecutive tiles sized [k, block_n], so the
+        // first element of a subsequent [K, block_n] tile would be right after the last
+        // element of the previous tile sized [K x block_n]
+        auto base_idx = n * K * {{block_n}};
+        for (int idx = 0; idx < buf_size; idx += {{block_k}}) {
+            auto b_int8 = at::vec::Vectorized<int8_t>::loadu(const_cast<{{input2_t}}*>(B) + base_idx + idx, static_cast<int64_t>({{block_k}}));
+            auto b_bf16 = at::vec::convert<{{input_t}}>(b_int8);
+            b_bf16.store(dequantized_B_buf + idx);
         }
     };
 {%- endif %}
@@ -626,11 +603,7 @@ template <bool accum>
 inline void {{kernel_name}}_amx_kernel_{{num_rows}}_{{num_columns}}(
     AMXState& amx_state,
     const {{input_t}}* {{restrict_keyword}} A,
-{%- if use_cached_dequantized_B %}
     const {{input_t}}* {{restrict_keyword}} B,
-{%- else %}
-    const {{input2_t}}* {{restrict_keyword}} B,
-{%- endif %}
     {{output_t}}* {{restrict_keyword}} C,
     int64_t K,
     int64_t lda,
@@ -673,11 +646,6 @@ inline void {{kernel_name}}_amx_kernel_{{num_rows}}_{{num_columns}}(
     }
 
     auto compute = [&](int k) {
-{%- if use_cached_dequantized_B %}
-    // base index for dequantized B
-    const auto num_elements_per_b_tile = 512;
-    const auto base_idx_of_deq_B = (k / {{block_k // 2}}) * num_elements_per_b_tile;
-{%- endif %}
 {%- set tile_offset_a = num_rows // 16 * num_columns %}
 {%- set tile_offset_b = tile_offset_a + num_rows // 16 %}
 {%- for tile_row in range(num_rows // 16) %}
@@ -689,11 +657,7 @@ inline void {{kernel_name}}_amx_kernel_{{num_rows}}_{{num_columns}}(
         _tile_stream_loadd({{tile_idx_a}}, A + {{tile_row * 16}} * lda + k, lda * sizeof({{input_t}}));
         {%- endif %}
         {%- if tile_row == 0 %}
-            {%- if use_cached_dequantized_B %}
-        _tile_loadd({{tile_idx_b}}, B + base_idx_of_deq_B + {{tile_col}} * num_elements_per_b_tile, 64);
-            {%- else %}
         _tile_loadd({{tile_idx_b}}, B + k * ldb + {{tile_col * 16 * vnni_size}}, ldb * {{vnni_size}} * sizeof({{input_t}}));
-            {%- endif %}
         {%- endif %}
         {%- if int8_gemm %}
         _tile_dpbusd({{tile_idx_c}}, {{tile_idx_a}}, {{tile_idx_b}});

--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -554,7 +554,7 @@ class CppMicroGemmAMX(CppMicroGemm):
         }
     };
 {%- endif %}
-// The ldb would not be block_n if N != block_n    
+// The ldb would not be block_n if N != block_n
 {%- if use_cached_dequantized_B %}
     const int64_t updated_ldb = {{block_n}};
 {%- else %}

--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -531,12 +531,15 @@ class CppMicroGemmAMX(CppMicroGemm):
     auto load_dequantized_B = [&](int tile_idx) {
         // Load a tile of B & cache it in L1D.
         // The assumption here is that if N would be a multiple of block_n,
-        // then B would be some consecutive tiles sized [k, block_n] each, so the
+        // then B would be some consecutive tiles sized [k, block_n] elements each, so the
         // first element of a subsequent [K, block_n] tile would be right after the last
-        // element of the previous tile sized [K x block_n]
-        int base_idx = tile_idx * K * {{block_n}};
+        // element of the previous tile sized [K x block_n] elements.
+        const int base_idx = tile_idx * K * {{block_n}};
         for (int idx = 0; idx < buf_size; idx += {{block_k}}) {
-            auto b_int8 = at::vec::Vectorized<int8_t>::loadu(const_cast<{{input2_t}}*>(B) + base_idx + idx, static_cast<int64_t>({{block_k}}));
+            auto b_int8 = at::vec::Vectorized<int8_t>::loadu(
+                const_cast<{{input2_t}}*>(B) + base_idx + idx,
+                static_cast<int64_t>({{block_k}})
+            );
             auto b_bf16 = at::vec::convert<{{input_t}}>(b_int8);
             b_bf16.store(dequantized_B_buf + idx);
         }


### PR DESCRIPTION
As suggested by @leslie-fang-intel in https://github.com/leslie-fang-intel/pytorch/commit/4c83e4e75138e8fa6e0d58438f75b7718dc8a0cc#diff-139642bd981df977f70f4c18c1c34bd1a85c1d6b9ffa06aaa98426ed83942a31R537 - all elements of `B` tiles (not referring to AMX tiles, but the tiles at the granularity of the micro-kernel) have contiguous elements since `B` matrix is pre-packed, so dequantized buffer loading logic can be simplified. While the previous approach kept elements to be loaded into a B AMX tile contiguous, the new approach doesn't entail any performance penalty either because that data is already in L1D, so loading AMX tiles from non-contiguous dequantized B elements doesn't adversely affect performance.

Also rectified the size of the dequantized B buffer.

Fixes #140208.

A subsequent PR will factor out caching of dequantized int8 weights into a separate codegen function


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov