### PR TITLE
Broadcast constants on vectorised stores in `CppTile2DKernel`

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -58,7 +58,6 @@ _lowp_fp_dtypes = (
     torch.float16,
 )
 run_and_get_cpp_code = test_torchinductor.run_and_get_cpp_code
-run_and_get_code = test_torchinductor.run_and_get_code
 TestCase = test_torchinductor.TestCase
 aten = torch.ops.aten
 check_model = test_torchinductor.check_model

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1032,11 +1032,11 @@ class CPUReproTests(TestCase):
                     window_overlap * 2 + 1,
                 )
             )
-            diagonal_attention_scores[:, :3, :, window_overlap:] = (
-                diagonal_chunked_attention_scores[
-                    :, :, :window_overlap, : window_overlap + 1
-                ]
-            )
+            diagonal_attention_scores[
+                :, :3, :, window_overlap:
+            ] = diagonal_chunked_attention_scores[
+                :, :, :window_overlap, : window_overlap + 1
+            ]
             return diagonal_attention_scores
 
         self.common(
@@ -3449,8 +3449,14 @@ class CPUReproTests(TestCase):
             fn, data, weight_one, weight_two, bias_one, bias_two
         )
 
-        self.assertTrue("auto tmp1 = static_cast<int8_t>(0);" in fw_code)
-        self.assertTrue("auto tmp2 = at::vec::Vectorized<int8_t>(tmp1);" in fw_code)
+        kernel_name = "cpp_fused_convolution_max_pool2d_with_indices"
+        self.assertTrue(kernel_name in fw_code)
+
+        conv_maxpool2d_code = fw_code[fw_code.find(kernel_name) :]
+        self.assertTrue("auto tmp1 = static_cast<int8_t>(0);" in conv_maxpool2d_code)
+        self.assertTrue(
+            "auto tmp2 = at::vec::Vectorized<int8_t>(tmp1);" in conv_maxpool2d_code
+        )
 
     def test_to_channels_last_lowp_fp(self):
         def f(a):

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3445,9 +3445,7 @@ class CPUReproTests(TestCase):
 
         torch._dynamo.mark_dynamic(data, 2)
         torch._dynamo.mark_dynamic(data, 3)
-        self.common(
-            fn, (data, weight_one, weight_two, bias_one, bias_two)
-        )
+        self.common(fn, (data, weight_one, weight_two, bias_one, bias_two))
 
     def test_to_channels_last_lowp_fp(self):
         def f(a):

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3445,17 +3445,8 @@ class CPUReproTests(TestCase):
 
         torch._dynamo.mark_dynamic(data, 2)
         torch._dynamo.mark_dynamic(data, 3)
-        _, (fw_code, _bw_code) = run_and_get_code(
-            fn, data, weight_one, weight_two, bias_one, bias_two
-        )
-
-        kernel_name = "cpp_fused_convolution_max_pool2d_with_indices"
-        self.assertTrue(kernel_name in fw_code)
-
-        conv_maxpool2d_code = fw_code[fw_code.find(kernel_name) :]
-        self.assertTrue("auto tmp1 = static_cast<int8_t>(0);" in conv_maxpool2d_code)
-        self.assertTrue(
-            "auto tmp2 = at::vec::Vectorized<int8_t>(tmp1);" in conv_maxpool2d_code
+        self.common(
+            fn, (data, weight_one, weight_two, bias_one, bias_two)
         )
 
     def test_to_channels_last_lowp_fp(self):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -3284,6 +3284,11 @@ class CppTile2DKernel(CppVecKernel):
 
     def store(self, name, index, value, mode=None):
         assert "buf" in name
+        assert isinstance(value, CppCSEVariable), value
+        if not value.is_vec:
+            # this happens when we store a scalar into a vectorized buffer like "fill"
+            value = self.broadcast(value)
+
         var = self.args.output(name)
 
         inner = self.inner_itervar()


### PR DESCRIPTION
Currently constants are not broadcasted on vectorised stores in `CppTile2DKernel`. This leads to errors like the following:
```shell
error:: request for member 'store' in 'tmp1', which is of non-class type 'signed char'
   61 |                                 tmp1.store(tmp2 + static_cast<int64_t>(8L*x0_inner), static_cast<int64_t>(8));
      |                                           ^~~~~
```
This PR adds the required broadcasting.

Fixes #ISSUE_NUMBER


cc @ezyang @chauhang @penguinwu @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @aakhundov