### PR TITLE
Don't use sudo to checkout sources

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
         with:
-          no-sudo: ${{ inputs.build-environment == 'linux-s390x-binary-manywheel' }}
+          no-sudo: true
 
       - name: Setup Linux
         uses: ./.github/actions/setup-linux

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -82,6 +82,8 @@ jobs:
 
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+        with:
+          no-sudo: true
 
       - name: Setup Linux
         uses: ./.github/actions/setup-linux


### PR DESCRIPTION
Move this part out of https://github.com/pytorch/pytorch/pull/125401 and try using it for all architectures.