### PR TITLE
Noop m.set_python_module on C10_MOBILE builds

### DIFF
--- a/aten/src/ATen/core/library.cpp
+++ b/aten/src/ATen/core/library.cpp
@@ -135,6 +135,9 @@ Library& Library::_def(c10::FunctionSchema&& schema, c10::OperatorName* out_name
   }
   switch (rv) {
     case _RegisterOrVerify::REGISTER:
+// Workaround for https://github.com/pytorch/pytorch/issues/140272 on mobile.
+// Since Python isn't available at all we can noop registerPythonModule
+#ifndef C10_MOBILE
       if (python_module_.has_value()) {
         registrars_.emplace_back(
           c10::Dispatcher::singleton().registerPythonModule(
@@ -143,6 +146,7 @@ Library& Library::_def(c10::FunctionSchema&& schema, c10::OperatorName* out_name
             python_module_->second)
         );
       }
+#endif
       registrars_.emplace_back(
         c10::Dispatcher::singleton().registerDef(
           std::move(schema),


### PR DESCRIPTION
Summary:
This was causing issues. Since Python isn't available on C10_MOBILE anyways,
it's OK to noop the call to m.set_python_module. We no-op it by just never
calling registerPythonModule.

This is a fix only for C10_MOBILE, there's likely a corresponding issue for
regular PyTorch that we need to work through
(https://github.com/pytorch/pytorch/issues/140272)

Test Plan: - tests

Differential Revision: D65758016


