### PR TITLE
fix specialization logic in Scalar.h

### DIFF
--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -122,9 +122,9 @@ class C10_API Scalar {
     } else if (Tag::HAS_z == tag) {                                   \
       return checked_convert<type, c10::complex<double>>(v.z, #type); \
     } else if (Tag::HAS_sd == tag) {                                  \
-      return checked_convert<type, double>(                          \
+      return checked_convert<type, double>(                           \
           toSymFloat().guard_float(__FILE__, __LINE__), #type);       \
-    }                                                            \
+    }                                                                 \
     if (Tag::HAS_b == tag) {                                          \
       return checked_convert<type, bool>(v.i, #type);                 \
     } else if (Tag::HAS_i == tag) {                                   \

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -121,7 +121,10 @@ class C10_API Scalar {
       return checked_convert<type, double>(v.d, #type);               \
     } else if (Tag::HAS_z == tag) {                                   \
       return checked_convert<type, c10::complex<double>>(v.z, #type); \
-    }                                                                 \
+    } else if (Tag::HAS_sd == tag) {                                  \
+      return checked_convert<type, double>(                          \
+          toSymFloat().guard_float(__FILE__, __LINE__), #type);       \
+    }                                                            \
     if (Tag::HAS_b == tag) {                                          \
       return checked_convert<type, bool>(v.i, #type);                 \
     } else if (Tag::HAS_i == tag) {                                   \
@@ -131,9 +134,6 @@ class C10_API Scalar {
     } else if (Tag::HAS_si == tag) {                                  \
       return checked_convert<type, int64_t>(                          \
           toSymInt().guard_int(__FILE__, __LINE__), #type);           \
-    } else if (Tag::HAS_sd == tag) {                                  \
-      return checked_convert<type, int64_t>(                          \
-          toSymFloat().guard_float(__FILE__, __LINE__), #type);       \
     } else if (Tag::HAS_sb == tag) {                                  \
       return checked_convert<type, int64_t>(                          \
           toSymBool().guard_bool(__FILE__, __LINE__), #type);         \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #138922
* #138666
* #138915
* __->__ #140280

Fixes `test/inductor/test_torchinductor_opinfo.py TestInductorOpInfoCUDA.test_comprehensive_linalg_norm_subgradients_at_zero_cuda_float64` when `specialize_float=False`