### PR TITLE
[ONNX] Update docstring typo in building

### DIFF
--- a/torch/onnx/_internal/exporter/_building.py
+++ b/torch/onnx/_internal/exporter/_building.py
@@ -496,7 +496,7 @@ def _construct_node(
 
 
 class OpRecorder(evaluator.Evaluator):
-    """An onnxscript Evaluator that captures the graph into torchscript."""
+    """An onnxscript Evaluator that captures the graph into ONNX IR."""
 
     def __init__(
         self, opset: onnxscript.values.Opset, constant_farm: dict[Any, ir.Value]


### PR DESCRIPTION
The oprecorder docstring mistakenly referred to torchscript when it should say ONNX IR.
