### PR TITLE
Switch to linux.8xlarge.amx

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -378,7 +378,7 @@ jobs:
       docker-image-name: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base:v1.3-lite
       test-matrix: |
         { include: [
-          { config: "xla", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.12xlarge" },
+          { config: "xla", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.8xlarge.amx" },
         ]}
     secrets: inherit
 


### PR DESCRIPTION
Utilizes the cheaper linux.8xlarge.amx instance type which is an AWS m7i-flex.8xlarge system.

Ref: pytorch/pytorch#138476
