### PR TITLE
[Profiler] Add More Logging for Dynamic Collection API

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -685,6 +685,11 @@ void toggleCollectionDynamic(
       activities.count(torch::autograd::profiler::ActivityType::CUDA) == 0) {
     LOG(WARNING)
         << "Toggling CPU activity with CUDA activity on may result in traces with CUDA events on artibrary tracks";
+  } else if (
+      activities.count(torch::autograd::profiler::ActivityType::CUDA) > 0 &&
+      activities.count(torch::autograd::profiler::ActivityType::CPU) == 0) {
+    LOG(WARNING)
+        << "Toggling CUDA activity with CPU activity on may result in traces with incorrect correlation between CPU and CUDA events";
   }
   for (auto act : activities) {
     if (act == torch::autograd::profiler::ActivityType::CUDA) {


### PR DESCRIPTION
Summary: Add a log warning users about how disabling only CUDA events can cause incorrect correlation IDs


Test Plan: Log was printed in the correct scenario

Differential Revision: D65762576




cc @robieta @chaekit @guotuofeng @guyang3532 @dzhulgakov @davidberard98 @briancoutinho @sanrise