### PR TITLE
Use base32 triton cache function if base64 is not found

### DIFF
--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -146,14 +146,22 @@ except AttributeError:  # Compile workers only have a mock version of torch
 
 
 def triton_hash_to_path_key(key):
-    # In early versions of triton, the hash is directly used in the path name.
+    # In early versions of Triton, the hash is directly used in the path name.
     # Later, the hash is converted to base64 before being used in the path name.
+    # Later, the base64 convertion was replaced to the base32
     #
-    # To handle this: try to import the to-base64-conversion function.
-    # If it exists, use it; otherwise fall back to using the hash directly.
+    # This code tries to import _base64 and falls back to _base32 if _base64 is unavailable.
+    #
+    # To handle this, try to import the to-base64-conversion function.
+    # If it exists, use it; otherwise, try using _base32; if both are unavailable, use the hash directly.
     try:
         from triton.runtime.cache import _base64
 
         return _base64(key)
     except Exception as e:
-        return key
+        try:
+            from triton.runtime.cache import _base32
+
+            return _base32(key)
+        except Exception as e:
+            return key


### PR DESCRIPTION
In #140190 the base64 function is imported from triton

But, since triton-lang/triton#5088 ,
the base64 function was replaced to base32


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @davidberard98 