### PR TITLE
ILP for auto FSDP wrapping

### DIFF
--- a/test/distributed/_tools/test_fsdp_ilp.py
+++ b/test/distributed/_tools/test_fsdp_ilp.py
@@ -1,0 +1,423 @@
+# Owner(s): ["module: unknown"]
+from typing import Dict
+
+from torch.distributed._tools.fsdp_ilp import CommParams, CommType, fsdp_milp
+from torch.distributed._tools.ilp_utils import ModuleInfo, parse_module_info
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestFSDPILP(TestCase):
+    """
+    Test the fsdp ilp formulation on a LLM model with transformation blocks.
+    ``mod_info`` and ``comm_params`` are hard coded instead of traced to avoid machine dependency.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.comm_params = self._get_test_comm_params()
+        self.comm_params_low_bw = self._get_test_comm_params(True)
+        self.mod_info = self._get_mod_info()
+        self.g = parse_module_info(self.mod_info)
+
+    def _get_test_comm_params(
+        self, comm_bound: bool = False
+    ) -> Dict[CommType, CommParams]:
+        if comm_bound:
+            return {
+                CommType.ALL_GATHER: CommParams(latency=0.01, bandwidth=1e7),
+                CommType.REDUCE_SCATTER: CommParams(latency=0.01, bandwidth=1e7),
+            }
+        else:
+            return {
+                CommType.ALL_GATHER: CommParams(latency=0.01, bandwidth=1e8),
+                CommType.REDUCE_SCATTER: CommParams(latency=0.01, bandwidth=1e8),
+            }
+
+    def _get_mod_info(self) -> ModuleInfo:
+        mod_info = {
+            "mod_order": {
+                "fw_pre_order": [
+                    "Transformer",
+                    "Transformer.layers.0",
+                    "Transformer.layers.0.attention",
+                    "Transformer.layers.0.feed_forward",
+                    "Transformer.layers.1",
+                    "Transformer.layers.1.attention",
+                    "Transformer.layers.1.feed_forward",
+                    "Transformer.layers.2",
+                    "Transformer.layers.2.attention",
+                    "Transformer.layers.2.feed_forward",
+                    "Transformer.layers.3",
+                    "Transformer.layers.3.attention",
+                    "Transformer.layers.3.feed_forward",
+                    "Transformer.output",
+                ],
+                "bw_pre_order": [
+                    "Transformer",
+                    "Transformer.output",
+                    "Transformer.layers.3",
+                    "Transformer.layers.3.feed_forward",
+                    "Transformer.layers.3.attention",
+                    "Transformer.layers.2",
+                    "Transformer.layers.2.feed_forward",
+                    "Transformer.layers.2.attention",
+                    "Transformer.layers.1",
+                    "Transformer.layers.1.feed_forward",
+                    "Transformer.layers.1.attention",
+                    "Transformer.layers.0",
+                    "Transformer.layers.0.feed_forward",
+                    "Transformer.layers.0.attention",
+                ],
+                "fw_post_order": [
+                    "Transformer.layers.0.attention",
+                    "Transformer.layers.0.feed_forward",
+                    "Transformer.layers.0",
+                    "Transformer.layers.1.attention",
+                    "Transformer.layers.1.feed_forward",
+                    "Transformer.layers.1",
+                    "Transformer.layers.2.attention",
+                    "Transformer.layers.2.feed_forward",
+                    "Transformer.layers.2",
+                    "Transformer.layers.3.attention",
+                    "Transformer.layers.3.feed_forward",
+                    "Transformer.layers.3",
+                    "Transformer.output",
+                    "Transformer",
+                ],
+                "bw_post_order": [
+                    "Transformer.output",
+                    "Transformer.layers.3.feed_forward",
+                    "Transformer.layers.3.attention",
+                    "Transformer.layers.3",
+                    "Transformer.layers.2.feed_forward",
+                    "Transformer.layers.2.attention",
+                    "Transformer.layers.2",
+                    "Transformer.layers.1.feed_forward",
+                    "Transformer.layers.1.attention",
+                    "Transformer.layers.1",
+                    "Transformer.layers.0.feed_forward",
+                    "Transformer.layers.0.attention",
+                    "Transformer.layers.0",
+                    "Transformer",
+                ],
+            },
+            "mod_stats": [
+                {
+                    "fqn": "Transformer",
+                    "param_per_module": 1960000000,
+                    "grad_per_module": 1960000000,
+                    "grad_total": 0,
+                    "act_fw_per_module": 2548856832,
+                    "act_bw_per_module": 482486272,
+                    "act_grad_per_module": 402665472,
+                    "act_total": 2683074560,
+                    "input_per_module": 0,
+                    "output_per_module": 67108864,
+                    "fw_runtime_per_module": 115.51510375623819,
+                    "bw_runtime_per_module": 262.8396350763604,
+                },
+                {
+                    "fqn": "Transformer.layers.0",
+                    "param_per_module": 453095424,
+                    "grad_per_module": 453095424,
+                    "grad_total": 2265501696,
+                    "act_fw_per_module": 390202368,
+                    "act_bw_per_module": 482486272,
+                    "act_grad_per_module": 276836352,
+                    "act_total": 526525440,
+                    "input_per_module": 25165824,
+                    "output_per_module": 25165824,
+                    "fw_runtime_per_module": 18.586358962812866,
+                    "bw_runtime_per_module": 42.31444884235838,
+                },
+                {
+                    "fqn": "Transformer.layers.0.attention",
+                    "param_per_module": 150994944,
+                    "grad_per_module": 150994944,
+                    "grad_total": 2567577600,
+                    "act_fw_per_module": 107054080,
+                    "act_bw_per_module": 224520192,
+                    "act_grad_per_module": 100663296,
+                    "act_total": 268559360,
+                    "input_per_module": 25165824,
+                    "output_per_module": 25165824,
+                    "fw_runtime_per_module": 6.914146061765929,
+                    "bw_runtime_per_module": 16.190205050846142,
+                },
+                {
+                    "fqn": "Transformer.layers.0.feed_forward",
+                    "param_per_module": 302051328,
+                    "grad_per_module": 302051328,
+                    "grad_total": 2265501696,
+                    "act_fw_per_module": 207618048,
+                    "act_bw_per_module": 482486272,
+                    "act_grad_per_module": 276836352,
+                    "act_total": 526525440,
+                    "input_per_module": 25165824,
+                    "output_per_module": 25165824,
+                    "fw_runtime_per_module": 11.49012612856017,
+                    "bw_runtime_per_module": 25.499871304739376,
+                },
+                {
+                    "fqn": "Transformer.layers.1",
+                    "param_per_module": 453095424,
+                    "grad_per_module": 453095424,
+                    "grad_total": 1812406272,
+                    "act_fw_per_module": 390202368,
+                    "act_bw_per_module": 482486272,
+                    "act_grad_per_module": 276836352,
+                    "act_total": 941893632,
+                    "input_per_module": 25165824,
+                    "output_per_module": 25165824,
+                    "fw_runtime_per_module": 18.586358962812866,
+                    "bw_runtime_per_module": 42.31444884235838,
+                },
+                {
+                    "fqn": "Transformer.layers.1.attention",
+                    "param_per_module": 150994944,
+                    "grad_per_module": 150994944,
+                    "grad_total": 2114482176,
+                    "act_fw_per_module": 107054080,
+                    "act_bw_per_module": 224520192,
+                    "act_grad_per_module": 100663296,
+                    "act_total": 683927552,
+                    "input_per_module": 25165824,
+                    "output_per_module": 25165824,
+                    "fw_runtime_per_module": 6.914146061765929,
+                    "bw_runtime_per_module": 16.190205050846142,
+                },
+                {
+                    "fqn": "Transformer.layers.1.feed_forward",
+                    "param_per_module": 302051328,
+                    "grad_per_module": 302051328,
+                    "grad_total": 1812406272,
+                    "act_fw_per_module": 207618048,
+                    "act_bw_per_module": 482486272,
+                    "act_grad_per_module": 276836352,
+                    "act_total": 526525440,
+                    "input_per_module": 25165824,
+                    "output_per_module": 25165824,
+                    "fw_runtime_per_module": 11.49012612856017,
+                    "bw_runtime_per_module": 25.499871304739376,
+                },
+                {
+                    "fqn": "Transformer.layers.2",
+                    "param_per_module": 453095424,
+                    "grad_per_module": 453095424,
+                    "grad_total": 1359310848,
+                    "act_fw_per_module": 390202368,
+                    "act_bw_per_module": 482486272,
+                    "act_grad_per_module": 276836352,
+                    "act_total": 1357261824,
+                    "input_per_module": 25165824,
+                    "output_per_module": 25165824,
+                    "fw_runtime_per_module": 18.586358962812866,
+                    "bw_runtime_per_module": 42.31444884235838,
+                },
+                {
+                    "fqn": "Transformer.layers.2.attention",
+                    "param_per_module": 150994944,
+                    "grad_per_module": 150994944,
+                    "grad_total": 1661386752,
+                    "act_fw_per_module": 107054080,
+                    "act_bw_per_module": 224520192,
+                    "act_grad_per_module": 100663296,
+                    "act_total": 1099295744,
+                    "input_per_module": 25165824,
+                    "output_per_module": 25165824,
+                    "fw_runtime_per_module": 6.914146061765929,
+                    "bw_runtime_per_module": 16.190205050846142,
+                },
+                {
+                    "fqn": "Transformer.layers.2.feed_forward",
+                    "param_per_module": 302051328,
+                    "grad_per_module": 302051328,
+                    "grad_total": 1359310848,
+                    "act_fw_per_module": 207618048,
+                    "act_bw_per_module": 482486272,
+                    "act_grad_per_module": 276836352,
+                    "act_total": 1357261824,
+                    "input_per_module": 25165824,
+                    "output_per_module": 25165824,
+                    "fw_runtime_per_module": 11.49012612856017,
+                    "bw_runtime_per_module": 25.499871304739376,
+                },
+                {
+                    "fqn": "Transformer.layers.3",
+                    "param_per_module": 453095424,
+                    "grad_per_module": 453095424,
+                    "grad_total": 906215424,
+                    "act_fw_per_module": 390202368,
+                    "act_bw_per_module": 482486272,
+                    "act_grad_per_module": 276836352,
+                    "act_total": 1772630016,
+                    "input_per_module": 25165824,
+                    "output_per_module": 25165824,
+                    "fw_runtime_per_module": 18.586358962812866,
+                    "bw_runtime_per_module": 42.31444884235838,
+                },
+                {
+                    "fqn": "Transformer.layers.3.attention",
+                    "param_per_module": 150994944,
+                    "grad_per_module": 150994944,
+                    "grad_total": 1208291328,
+                    "act_fw_per_module": 107054080,
+                    "act_bw_per_module": 224520192,
+                    "act_grad_per_module": 100663296,
+                    "act_total": 1514663936,
+                    "input_per_module": 25165824,
+                    "output_per_module": 25165824,
+                    "fw_runtime_per_module": 6.914146061765929,
+                    "bw_runtime_per_module": 16.190205050846142,
+                },
+                {
+                    "fqn": "Transformer.layers.3.feed_forward",
+                    "param_per_module": 302051328,
+                    "grad_per_module": 302051328,
+                    "grad_total": 906215424,
+                    "act_fw_per_module": 207618048,
+                    "act_bw_per_module": 482486272,
+                    "act_grad_per_module": 276836352,
+                    "act_total": 1772630016,
+                    "input_per_module": 25165824,
+                    "output_per_module": 25165824,
+                    "fw_runtime_per_module": 11.49012612856017,
+                    "bw_runtime_per_module": 25.499871304739376,
+                },
+                {
+                    "fqn": "Transformer.output",
+                    "param_per_module": 100663296,
+                    "grad_per_module": 100663296,
+                    "grad_total": 0,
+                    "act_fw_per_module": 0,
+                    "act_bw_per_module": 2615966720,
+                    "act_grad_per_module": 125829120,
+                    "act_total": 2695657472,
+                    "input_per_module": 25165824,
+                    "output_per_module": 67108864,
+                    "fw_runtime_per_module": 3.7249330481443956,
+                    "bw_runtime_per_module": 8.000336731209435,
+                },
+            ],
+        }
+
+        return mod_info
+
+    def test_fsdp_ilp_case1(self):
+        """a standard case with memory budget that is not too tight"""
+
+        fsdp_decisions, exposed_comm_time, peak_mem = fsdp_milp(
+            self.g,
+            world_size=4,
+            comm_params=self.comm_params,
+            memory_budget=4.75,
+        )
+        self.assertEqual(
+            fsdp_decisions,
+            {
+                "Transformer",
+                "Transformer.layers.0.attention",
+                "Transformer.layers.0.feed_forward",
+                "Transformer.layers.1",
+                "Transformer.layers.2",
+                "Transformer.layers.3",
+                "Transformer.output",
+            },
+        )
+        self.assertAlmostEqual(exposed_comm_time / 4.0, 1, delta=0.05)
+        self.assertAlmostEqual(peak_mem / 4672410203, 1, delta=0.05)
+
+    def test_fsdp_ilp_case2(self):
+        """with user specified fsdp units"""
+
+        fsdp_decisions, exposed_comm_time, peak_mem = fsdp_milp(
+            self.g,
+            world_size=4,
+            comm_params=self.comm_params,
+            memory_budget=4.75,
+            fsdp_units=[
+                "Transformer.layers.0",
+                "Transformer.layers.1",
+                "Transformer.layers.2",
+                "Transformer.layers.3",
+                "Transformer.output",
+            ],
+        )
+        self.assertEqual(
+            fsdp_decisions,
+            {
+                "Transformer",
+                "Transformer.layers.0",
+                "Transformer.layers.1",
+                "Transformer.layers.2",
+                "Transformer.layers.3",
+                "Transformer.output",
+            },
+        )
+        self.assertAlmostEqual(exposed_comm_time / 10.041, 1, delta=0.05)
+        self.assertAlmostEqual(peak_mem / 4672311956, 1, delta=0.05)
+
+    def test_fsdp_ilp_case3(self):
+        """a case with tight memory budget"""
+
+        fsdp_decisions, exposed_comm_time, peak_mem = fsdp_milp(
+            self.g,
+            world_size=4,
+            comm_params=self.comm_params,
+            memory_budget=4,
+        )
+        self.assertEqual(
+            fsdp_decisions,
+            {
+                "Transformer",
+                "Transformer.layers.0.attention",
+                "Transformer.layers.0.feed_forward",
+                "Transformer.layers.1.attention",
+                "Transformer.layers.1.feed_forward",
+                "Transformer.layers.2.attention",
+                "Transformer.layers.2.feed_forward",
+                "Transformer.layers.3.attention",
+                "Transformer.layers.3.feed_forward",
+                "Transformer.output",
+            },
+        )
+        self.assertAlmostEqual(exposed_comm_time / 4.0029, 1, delta=0.05)
+        self.assertAlmostEqual(peak_mem / 4274145874, 1, delta=0.05)
+
+    def test_fsdp_ilp_case4(self):
+        """a case with extremely tight memory budget but no feasible solution is possible"""
+
+        fsdp_decisions, exposed_comm_time, peak_mem = fsdp_milp(
+            self.g,
+            world_size=4,
+            comm_params=self.comm_params,
+            memory_budget=3.5,
+        )
+        self.assertEqual(fsdp_decisions, set())
+        self.assertEqual(peak_mem, -1)
+
+    def test_fsdp_ilp_case5(self):
+        """a case similar to case 1 but with low communication bandwidth"""
+
+        fsdp_decisions, exposed_comm_time, peak_mem = fsdp_milp(
+            self.g,
+            world_size=4,
+            comm_params=self.comm_params_low_bw,
+            memory_budget=4.75,
+        )
+        self.assertEqual(
+            fsdp_decisions,
+            {
+                "Transformer",
+                "Transformer.layers.0",
+                "Transformer.layers.1",
+                "Transformer.layers.2",
+                "Transformer.layers.3",
+            },
+        )
+        self.assertAlmostEqual(exposed_comm_time / 303.0618, 1, delta=0.05)
+        self.assertAlmostEqual(peak_mem / 4873638548, 1, delta=0.05)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/_tools/fsdp_ilp.py
+++ b/torch/distributed/_tools/fsdp_ilp.py
@@ -1,0 +1,348 @@
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Optional, Set, Tuple
+
+from torch.distributed._tools.ilp_utils import display_bytes, Graph
+
+
+try:
+    from pulp import (  # type: ignore[import-untyped,import-not-found]
+        lpDot,
+        LpInteger,
+        LpMinimize,
+        LpProblem,
+        LpStatus,
+        lpSum,
+        LpVariable,
+        PULP_CBC_CMD,
+        value,
+    )
+except ImportError as err:
+    raise ImportError(
+        "Please install pulp package. See: https://github.com/coin-or/pulp."
+    ) from err
+
+# Create a logger object
+logger = logging.getLogger(__name__)
+
+# Set the logging level to INFO
+logger.setLevel(logging.INFO)
+
+
+class CommType(Enum):
+    ALL_GATHER = "all_gather"
+    REDUCE_SCATTER = "reduce_scatter"
+
+
+@dataclass
+class CommParams:
+    latency: float  # in ms
+    bandwidth: float  # in bytes / ms
+
+
+def fsdp_milp(
+    graph: Graph,
+    world_size: int,
+    comm_params: Dict[CommType, CommParams],
+    memory_budget: float,
+    fsdp_units: Optional[List[str]] = None,
+) -> Tuple[Set[str], float, int]:
+    """
+    MILP to decide FSDP units.
+    The objective is to minimize exposed computation time.
+    The constraint is to ensure peak memory is under budget.
+
+    Args:
+        graph: graph representation of the model as a module submodule tree
+            where each node is a submodule with memory & runtime stats
+        world_size: number of GPUs parameters and gradients are sharded across for FSDP.
+        comm_params: a dictionary of communication parameters, including latency and bandwidth.
+        memory_budget: memory budget in GiB
+        fsdp_units: a list of user-specified FSDP units.
+        selective_ac: whether to use selective AC jointly with FSDP.
+
+    Returns:
+        Set[str]: the set of FSDP units
+        float: the per-iteration exposed communication time of the returned FSDP solution.
+        int: upper bound on the peak memory of the returned FSDP solution
+            note that value of -1 means that the ILP solver failed to find a solution.
+    """
+
+    num_nodes = len(graph.nodes)
+    BIG_M = 1000
+    MEM_MULTIPLIER = 2**30
+
+    # Create a MILP problem
+    prob = LpProblem("FSDP", LpMinimize)
+
+    # Create decision variables
+    # x_i: indicator if module i is an fsdp unit
+    x = LpVariable.matrix("x", list(range(num_nodes)), 0, 1, LpInteger)
+    # p_i: parameter memory during module i
+    p = LpVariable.matrix("p", list(range(num_nodes)), 0)
+    # g_i: gradient memory during module i
+    g = LpVariable.matrix("g", list(range(num_nodes)), 0)
+    # a_i: activation(-related) memory during module i
+    a = LpVariable.matrix("a", list(range(num_nodes)), 0)
+    # m_i: total memory during module i (including params, grads, and activations)
+    m = LpVariable.matrix("m", list(range(num_nodes)), 0)
+    # max_m: peak memory
+    max_m = LpVariable("max_m", 0)
+    # max_p: maximum fsdp shard
+    max_p = LpVariable("max_p", 0)
+    # ag_i: all gather communication time of parameters for module i
+    ag = LpVariable.matrix("ag", list(range(num_nodes)), 0)
+    # t0_i: helper variable for the forward prefetch all gather communication time
+    t0 = LpVariable.matrix("t0", list(range(num_nodes)), 0)
+    # fw_ag_i: all gather communication time at module i during forward
+    # this is the prefetch for the next fsdp unit
+    fw_ag = LpVariable.matrix("fw_ag", list(range(num_nodes)), 0)
+    # t1_i: helper variable for the backward prefetch all gather communication time
+    t1 = LpVariable.matrix("t1", list(range(num_nodes)), 0)
+    # bw_ag_i: all gather communication time at module i during backward
+    # this is the prefetch for the next fsdp unit
+    bw_ag = LpVariable.matrix("bw_ag", list(range(num_nodes)), 0)
+    # rs_i: reduce scatter communication time of parameters for module i
+    rs = LpVariable.matrix("rs", list(range(num_nodes)), 0)
+    # t2_i: helper variable for the backward prefetch reduce scatter communication time
+    t2 = LpVariable.matrix("t2", list(range(num_nodes)), 0)
+    # bw_rs_i: reduce scatter communication time at module i during backward
+    # this is the prefetch for the next fsdp unit
+    bw_rs = LpVariable.matrix("bw_rs", list(range(num_nodes)), 0)
+    # t3_i: helpr variable for the exposed communication time in the forward pass
+    t3 = LpVariable.matrix("t3", list(range(num_nodes)), 0)
+    # fw_e_i: exposed communication time in the forward pass for module i if fsdp unit
+    fw_e = LpVariable.matrix("fw_e", list(range(num_nodes)), 0)
+    # t4_i: helper variable for the exposed communication time in the backward pass
+    t4 = LpVariable.matrix("t4", list(range(num_nodes)), 0)
+    # bw_e_i: exposed communication time in the backward pass for module i if fsdp unit
+    bw_e = LpVariable.matrix("bw_e", list(range(num_nodes)), 0)
+
+    # Add constraints
+    # [Constraint] Root module is always an FSDP unit
+    prob += x[0] == 1
+
+    # [Constraint] Use user specified FSDP units if provided
+    if fsdp_units:
+        fsdp_units_set = set(fsdp_units)
+        for i in range(1, num_nodes):
+            if graph.nodes[i]["fqn"] in fsdp_units_set:
+                prob += x[i] == 1
+            else:
+                prob += x[i] == 0
+
+    # [Constraint] No nested FSDP unit
+    # This is not a necessary constraint for the application of FSDP. But having it does not
+    # significantly affect the solution qulity and improves the speed of the solver.
+    for i in range(1, num_nodes):
+        for j in range(i + 1, num_nodes):
+            if graph.ad_matrix[i][j] == 1:
+                prob += x[i] + x[j] <= 1
+
+    # [Constraint] Express param size of each module if it is an FSDP unit, zero otherwise
+    for i in range(1, num_nodes):
+        P_i = graph.nodes[i]["param_per_module"] / MEM_MULTIPLIER
+        prob += p[i] == P_i * x[i]
+    P_1 = graph.nodes[0]["param_per_module"] / MEM_MULTIPLIER  # total parameter size
+    prob += p[0] == P_1 - lpSum(p[1:])
+
+    # [Constraint] Express grad size of each module if it is an FSDP unit, zero otherwise
+    for i in range(1, num_nodes):
+        G_i = graph.nodes[i]["grad_per_module"] / MEM_MULTIPLIER
+        prob += g[i] == G_i * x[i]
+    G_1 = graph.nodes[0]["grad_per_module"] / MEM_MULTIPLIER  # total gradient size
+    prob += g[0] == G_1 - lpSum(g[1:])
+
+    # [Constraint] Express total activation memory of each module in the bwd pass
+    for i in range(num_nodes):
+        AG_i = graph.nodes[i]["act_grad_per_module"] / MEM_MULTIPLIER
+        TA_i = graph.nodes[i]["act_total"] / MEM_MULTIPLIER
+        prob += a[i] == TA_i + AG_i
+
+    # [Constraint] Express the total amount memory at each module
+    # It includes: sharded parameters and gradients; unsharded parameters and gradients, activations
+    for i in range(num_nodes):
+        TG_i = graph.nodes[i]["grad_total"] / MEM_MULTIPLIER
+        coeff = [0] * num_nodes
+        for j in range(num_nodes):
+            if graph.ad_matrix[j][i] == 1:
+                coeff[j] = 1
+        prob += (
+            m[i] == (P_1 + TG_i) / world_size + lpDot(p, coeff) + lpDot(g, coeff) + a[i]
+        )
+
+    # [Constraint] Express peak memory
+    for i in range(num_nodes):
+        prob += max_m >= m[i]
+
+    # [Constraint] Express the maximum size of an FSDP shard
+    for i in range(num_nodes):
+        prob += max_p >= p[i]
+
+    # [Constraint] Respect memory budget
+    # `2 * max_p` is the hacky way to deal with prefetched all-gathered parameter memory
+    prob += max_m + 2 * max_p <= memory_budget
+
+    # [Constraint] Express the all gather communication time of each FSDP unit
+    comm_model = comm_params[CommType.ALL_GATHER]
+    for i in range(num_nodes):
+        prob += ag[i] == comm_model.latency + p[i] * (
+            MEM_MULTIPLIER / comm_model.bandwidth  # convert from bytes/ms to GiB/ms
+        )
+
+    # [Constraint] Express the reduce scatter communication time of each FSDP unit
+    comm_model = comm_params[CommType.REDUCE_SCATTER]
+    for i in range(num_nodes):
+        prob += rs[i] == comm_model.latency + g[i] * (
+            MEM_MULTIPLIER / comm_model.bandwidth  # convert from bytes/ms to GiB/ms
+        )
+
+    # [Constraint] Express the forward prefetch all gather communication time
+    # E.g., each FSDP unit will prefetch the parameters for the next FSDP unit
+    # The constraints below are to linearize the following non-linear constraints:
+    #    t0_i = ag_i * x_i + t0_{i+1} * (1 - x_i)
+    #    fw-ag_i = t0_{i+1} * x_i
+    # Note that t0 is a helper decision variable, expressing the all-gather communication
+    # time of the next fsdp unit (self included).
+    prob += t0[num_nodes - 1] == ag[num_nodes - 1]
+    for i in range(1, num_nodes - 1):
+        prob += t0[i] <= t0[i + 1] + BIG_M * x[i]
+        prob += t0[i] >= t0[i + 1] - BIG_M * x[i]
+        prob += t0[i] <= ag[i] + BIG_M * (1 - x[i])
+        prob += t0[i] >= ag[i] - BIG_M * (1 - x[i])
+    prob += fw_ag[num_nodes - 1] == 0
+    for i in range(num_nodes - 1):
+        prob += fw_ag[i] <= BIG_M * x[i]
+        prob += fw_ag[i] <= t0[i + 1]
+        prob += fw_ag[i] >= t0[i + 1] - BIG_M * (1 - x[i])
+
+    # [Constraint] Express the backward prefetch all gather communication time
+    # E.g., each FSDP unit will prefetch the parameters for the next FSDP unit
+    # The constraints below are to linearize the following non-linear constraints:
+    #    t1_{o1(k)} = ag_{o1(k)} * x_{o1(k)} + t1_{o1(k+1)} * (1 - x_{o1(k)})
+    #    bw-ag_i = t1_{o1(k+1)} * x_{o1(k)}
+    # Note that t1 is a helper decision variable, expressing the all-gather communication
+    # time of the next fsdp unit (self included).
+    # Note the order of module traversal is different in the backward pass. Thus, needing
+    # ``o1`` which is the index of modules in the backward pre order.
+    o1 = [graph.name2node[fqn]["index"] for fqn in reversed(graph.fw_post_order)]
+    prob += t1[o1[num_nodes - 1]] == ag[o1[num_nodes - 1]]
+    for k in range(1, num_nodes - 1):
+        i = o1[k]
+        i_next = o1[k + 1]
+        prob += t1[i] <= t1[i_next] + BIG_M * x[i]
+        prob += t1[i] >= t1[i_next] - BIG_M * x[i]
+        prob += t1[i] <= ag[i] + BIG_M * (1 - x[i])
+        prob += t1[i] >= ag[i] - BIG_M * (1 - x[i])
+    prob += bw_ag[o1[num_nodes - 1]] == 0
+    for k in range(1, num_nodes - 1):
+        i = o1[k]
+        i_next = o1[k + 1]
+        prob += bw_ag[i] <= BIG_M * x[i]
+        prob += bw_ag[i] <= t1[i_next]
+        prob += bw_ag[i] >= t1[i_next] - BIG_M * (1 - x[i])
+
+    # [Constraint] Express the previous module's reduce scatter communication time
+    # E.g., each FSDP unit's all-gather call follows the reduce-scatter call of the previous FSDP unit
+    # The constraints below are to linearize the following non-linear constraints:
+    #    t2_i = rs_i * x_i + t2_{i+1} * (1 - x_i)
+    #    bw-rs_i = t2_{i+1} * x_i
+    # Note that t2 is a helper decision variable, expressing the reduce communication
+    # time of the next fsdp unit (self included).
+    prob += t2[num_nodes - 1] == rs[num_nodes - 1]
+    for i in range(1, num_nodes - 1):
+        prob += t2[i] <= t2[i + 1] + BIG_M * x[i]
+        prob += t2[i] >= t2[i + 1] - BIG_M * x[i]
+        prob += t2[i] <= rs[i] + BIG_M * (1 - x[i])
+        prob += t2[i] >= rs[i] - BIG_M * (1 - x[i])
+    prob += bw_rs[num_nodes - 1] == 0
+    for i in range(num_nodes - 1):
+        prob += bw_rs[i] <= BIG_M * x[i]
+        prob += bw_rs[i] <= t2[i + 1]
+        prob += bw_rs[i] >= t2[i + 1] - BIG_M * (1 - x[i])
+
+    # [Constraint] Express the exposed communication time in the forward pass for
+    # The constraints below are to linearize the following non-linear constraints:
+    #    t3_i = max(0, fw-ag_i - FCP_i)
+    #    fw_e_i = t3_i * x_i
+    for i in range(1, num_nodes):
+        FCP_i = graph.nodes[i]["fw_runtime_per_module"]
+        prob += t3[i] >= fw_ag[i] - FCP_i
+        prob += fw_e[i] <= BIG_M * x[i]
+        prob += fw_e[i] <= t3[i]
+        prob += fw_e[i] >= t3[i] - BIG_M * (1 - x[i])
+    prob += fw_e[0] == 0
+
+    # [Constraint] Express the exposed communication time in the backward pass
+    # The constraints below are to linearize the following non-linear constraints:
+    #    t4_i = max(0, bw-ag_i + bw-rs_i - FCP_i)
+    #    bw_e_i = t4_i * x_i
+    for i in range(1, num_nodes):
+        BCP_i = graph.nodes[i]["bw_runtime_per_module"]
+        prob += t4[i] >= bw_ag[i] + bw_rs[i] - BCP_i
+        prob += bw_e[i] <= BIG_M * x[i]
+        prob += bw_e[i] <= t4[i]
+        prob += bw_e[i] >= t4[i] - BIG_M * (1 - x[i])
+    prob += bw_e[0] == 0
+
+    # Set objeictive -- minimize total exposed communication time
+    prob += lpSum(fw_e[1:]) + lpSum(bw_e[1:]) + ag[0] + rs[0] + fw_ag[0] + bw_rs[0]
+
+    # Solve
+    solver = PULP_CBC_CMD(gapRel=0.05, timeLimit=180, msg=0)
+    status = prob.solve(solver)
+
+    # If solver fails, print status and return empty solution
+    if status != 1:
+        logger.error("Solver failed to find a solution: %s", LpStatus[status])
+        return set(), 0, -1
+
+    # Gather and return solution if optimal solution is found
+    fsdp_decisions = set()
+    for i in range(num_nodes):
+        if round(value(x[i]) if x[i] else 0) == 1:
+            fsdp_decisions.add(graph.nodes[i]["fqn"])
+    peak_mem = round((max_m.varValue + 2 * max_p.varValue) * MEM_MULTIPLIER)
+    exposed_comm_time = round(value(prob.objective), 4)
+
+    # debugging info
+    fqn_len = min(30, max(len(graph.nodes[i]["fqn"]) for i in range(num_nodes)))
+    for i in range(num_nodes):
+        fqn = graph.nodes[i]["fqn"][-fqn_len:].ljust(fqn_len)
+        x_i = value(x[i]) if x[i] else 0
+        p_i = p[i].varValue * MEM_MULTIPLIER
+        g_i = g[i].varValue * MEM_MULTIPLIER
+        TG_i = graph.nodes[i]["grad_total"]
+        a_i = a[i].varValue * MEM_MULTIPLIER
+        m_i = m[i].varValue * MEM_MULTIPLIER
+        ag_i = ag[i].varValue if ag[i] else 0
+        fw_ag_i = fw_ag[i].varValue if fw_ag[i] else 0
+        bw_ag_i = bw_ag[i].varValue if bw_ag[i] else 0
+        rs_i = rs[i].varValue if rs[i] else 0
+        bw_rs_i = bw_rs[i].varValue if bw_rs[i] else 0
+        FCP_i = graph.nodes[i]["fw_runtime_per_module"]
+        BCP_i = graph.nodes[i]["bw_runtime_per_module"]
+        fw_e_i = fw_e[i].varValue if fw_e[i] else 0
+        bw_e_i = bw_e[i].varValue if bw_e[i] else 0
+        debug_str = (
+            ("FSDP" if round(x_i) == 1 else "    ")
+            + f" {fqn} : "
+            + f"p_i = {display_bytes(p_i, 'GiB'):<10} "
+            + f"g_i = {display_bytes(g_i, 'GiB'):<10} "
+            + f"TG_i = {display_bytes(TG_i, 'GiB'):<10} "
+            + f"a_i = {display_bytes(a_i, 'GiB'):<10} "
+            + f"m_i = {display_bytes(m_i, 'GiB'):<10} "
+            + f"ag_i = {round(ag_i, 2):5.2f} ms "
+            + f"fw_ag_i = {round(fw_ag_i, 2):5.2f} ms "
+            + f"bw_ag_i = {round(bw_ag_i, 2):5.2f} ms "
+            + f"rs_i = {round(rs_i, 2):5.2f} ms "
+            + f"bw_rs_i = {round(bw_rs_i, 2):5.2f} ms "
+            + f"FCP_i = {FCP_i:8.2f} ms "
+            + f"BCP_i = {BCP_i:8.2f} ms "
+            + f"fw_e_i = {round(fw_e_i, 2):5.2f} ms "
+            + f"bw_e_i = {round(bw_e_i, 2):5.2f} ms "
+        )
+        logger.debug(debug_str)
+
+    return fsdp_decisions, exposed_comm_time, peak_mem


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #140298

This PR presents a mixed integer linear programming (MILP) formulation that can be utilized to determine, under a memory budget, which modules to wrap as FSDP units. Similar to the auto SAC MILP introduced in https://github.com/pytorch/pytorch/pull/137908, the MILP uses information collected from MemTracker, Runtime Estimator, and SAC Estimator, introduced in these PRs:
* https://github.com/pytorch/pytorch/pull/124688
* https://github.com/pytorch/pytorch/pull/134243
* https://github.com/pytorch/pytorch/pull/135208

End-to-end example and its sample output:

```
import copy
from typing import Tuple

import torch
from torch._subclasses.fake_tensor import FakeTensorMode

from torch.distributed._tools.ilp_utils import (
    aggregate_stats,
    get_peak_memory_runtime_baseline,
    parse_module_info,
)
from torch.distributed._tools.mem_tracker import _ModState, MemTracker
from torch.distributed._tools.runtime_estimator import RuntimeEstimator
from torch.distributed._tools.sac_estimator import SACEstimator
from torch.distributed._tools.fsdp_ilp import fsdp_milp, CommType, CommParams
from torch.testing._internal.distributed._tensor.common_dtensor import (
    ModelArgs,
    Transformer,
)


def _init_model_input_optimizer() -> (
    Tuple[torch.nn.Module, torch.optim.Optimizer, torch.Tensor]
):
    bsz = 2
    model_args = ModelArgs(
        n_layers=6,
        n_heads=12,
        vocab_size=8192,
        max_seq_len=1024,
        dim=6144,
        dropout_p=0.1,
    )
    with torch.device(torch.cuda.current_device()):
        model = Transformer(model_args)
    optimizer = torch.optim.Adam(model.parameters(), lr=1e-2, foreach=True)
    inp = torch.randint(
        0,
        model_args.vocab_size,
        (bsz, model_args.max_seq_len),
        device=torch.cuda.current_device(),
    )
    return (model, optimizer, inp)


def _run_and_get_mem_tracker(
    model: torch.nn.Module,
    optimizer: torch.optim.Optimizer,
    inp: torch.Tensor,
) -> MemTracker:
    mem_tracker = MemTracker()
    mem_tracker.track_external(model, optimizer)
    with mem_tracker as mt:
        for iter_idx in range(2):  # running twice to initialize optimizer
            output = model(inp)
            output.sum().backward()
            if iter_idx == 1:
                last_snapshot = mt.get_tracker_snapshot("current")
            optimizer.step()
            optimizer.zero_grad()
            if iter_idx == 0:
                mt.reset_mod_stats()
    assert last_snapshot is not None
    for mod_stats in mem_tracker.memory_tracking.values():
        if _ModState.POST_BW not in mod_stats.snapshots.keys():
            mod_stats.snapshots.setdefault(_ModState.POST_BW, []).append(
                copy.deepcopy(last_snapshot)
            )
    return mem_tracker


def _run_and_get_runtime_estimator(
    model: torch.nn.Module,
    optimizer: torch.optim.Optimizer,
    inp: torch.Tensor,
) -> RuntimeEstimator:
    def _run_one_step() -> None:
        output = model(inp)
        output.sum().backward()
        optimizer.step()
        optimizer.zero_grad()

    # Initializing optimizer states and warm-up
    _run_one_step()

    runtime_estimator = RuntimeEstimator()
    with runtime_estimator(estimate_mode_type="operator-level-cost-model"):
        _run_one_step()  # We use only one iteration for estimation
    return runtime_estimator


def _run_and_get_sac_estimator(
    model: torch.nn.Module,
    inp: torch.Tensor,
) -> SACEstimator:
    sac_estimator = SACEstimator()
    with sac_estimator(estimate_mode_type="operator-level-cost-model"):
        loss = model(inp).sum()
    loss.backward()
    return sac_estimator


def main():
    with FakeTensorMode():
        model, optimizer, inp = _init_model_input_optimizer()
        mem_tracker = _run_and_get_mem_tracker(model, optimizer, inp)
        runtime_estimator = _run_and_get_runtime_estimator(model, optimizer, inp)
        sac_estimator = _run_and_get_sac_estimator(model, inp)
        mod_info = aggregate_stats(
            model,
            mem_tracker,
            runtime_estimator,
            sac_estimator,
            torch.device(torch.cuda.current_device()),
        )
        g = parse_module_info(mod_info)

        peak_mem, compute_time = get_peak_memory_runtime_baseline(g)
        print("=== WITHOUT FSDP ===")
        print(f"peak_mem: {round(peak_mem / 2**30, 2)} GiB")
        print(f"compute_time: {round(compute_time, 2)} ms")

        fsdp_decisions, exposed_comm_time, peak_mem = fsdp_milp(
            g,
            world_size=8,
            memory_budget=15,
            comm_params={
                CommType.ALL_GATHER: CommParams(latency=0.01, bandwidth=2 * 1e8),
                CommType.REDUCE_SCATTER: CommParams(latency=0.01, bandwidth=2 * 1e8),
            },
        )
        print("=== WITH FSDP on 8 ranks ===")
        print(f"fsdp units: {sorted(fsdp_decisions)}")
        print(f"peak_mem: {round(peak_mem / 2**30, 2)} GiB")
        print(f"exposed communication time: {round(exposed_comm_time, 2)} ms")


if __name__ == "__main__":
    main()
```

```
=== WITHOUT FSDP ===
peak_mem: 20.92 GiB
compute_time: 1375.49 ms
=== WITH FSDP on 8 ranks ===
fsdp units: [
    'Transformer', 
    'Transformer.layers.0.attention.wk', 
    'Transformer.layers.0.attention.wo', 
    'Transformer.layers.0.attention.wq', 
    'Transformer.layers.0.attention.wv', 
    'Transformer.layers.0.feed_forward.w1', 
    'Transformer.layers.0.feed_forward.w2', 
    'Transformer.layers.1', 
    'Transformer.layers.2', 
    'Transformer.layers.3', 
    'Transformer.layers.4', 
    'Transformer.layers.5', 
    'Transformer.output', 
    'Transformer.pos_embeddings'
]
peak_mem: 13.63 GiB
exposed communication time: 1.02 ms
```


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o