### PR TITLE
[pt2e][quant] Add simple cond support for annotate, prepare and convert

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -54,6 +54,7 @@ from torch.testing._internal.common_utils import (
     TemporaryFileName,
     TEST_CUDA,
     TEST_HPU,
+    run_tests,
 )
 
 
@@ -2339,10 +2340,62 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         m = convert_pt2e(m)
         m(*example_inputs)
 
+    def test_cond_op(self):
+        m = TestHelperModules.Cond()
+        example_inputs = m.example_inputs()
+        m = export_for_training(m, example_inputs).module()
+        quantizer = XNNPACKQuantizer().set_global(
+            get_symmetric_quantization_config(),
+        )
+        gm = prepare_pt2e(m, quantizer)
+
+        from torch.ao.quantization.observer import ObserverBase
+
+        for node in gm.graph.nodes:
+            if node.target == torch.ops.higher_order.cond:
+                true_gm = getattr(gm, node.args[1].target)
+                for n in true_gm.graph.nodes:
+                    if n.target == torch.ops.aten.conv2d.default:
+                        assert n.meta.get("quantization_annotation", None) is not None
+                        input_act = n.args[0]
+                        weight = n.args[1]
+                        output = list(n.users)[0]
+                        for obs_node in [input_act, weight, output]:
+                            obs_ins = getattr(true_gm, obs_node.target)
+                            assert isinstance(obs_ins, ObserverBase)
+                false_gm = getattr(gm, node.args[2].target)
+                for n in false_gm.graph.nodes:
+                    if n.target == torch.ops.aten.conv2d.default:
+                        assert n.meta.get("quantization_annotation", None) is not None
+                        input_act = n.args[0]
+                        weight = n.args[1]
+                        output = list(n.users)[0]
+                        for obs_node in [input_act, weight, output]:
+                            obs_ins = getattr(false_gm, obs_node.target)
+                            assert isinstance(obs_ins, ObserverBase)
+
+        # gm(*example_inputs)
+        gm = convert_pt2e(gm)
+
+        node_occurrences = {
+            ns.call_function(
+                torch.ops.quantized_decomposed.quantize_per_tensor.default
+            ): 3,
+            ns.call_function(
+                torch.ops.quantized_decomposed.dequantize_per_tensor.default
+            ): 3,
+        }
+        for node in gm.graph.nodes:
+            if node.target == torch.ops.higher_order.cond:
+                true_gm = getattr(gm, node.args[1].target)
+                self.checkGraphModuleNodes(true_gm, expected_node_occurrence=node_occurrences)
+                false_gm = getattr(gm, node.args[2].target)
+                self.checkGraphModuleNodes(false_gm, expected_node_occurrence=node_occurrences)
+
 
 instantiate_parametrized_tests(TestQuantizePT2E)
 
 devices = ["cpu", "cuda"]
 if TEST_HPU:
     devices.append("hpu")
-instantiate_device_type_tests(TestQuantizePT2E, globals(), only_for=devices)
+# instantiate_device_type_tests(TestQuantizePT2E, globals(), only_for=devices)

--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -50,11 +50,11 @@ from torch.testing._internal.common_quantization import (
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
+    run_tests,
     skipIfHpu,
     TemporaryFileName,
     TEST_CUDA,
     TEST_HPU,
-    run_tests,
 )
 
 
@@ -2388,9 +2388,13 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         for node in gm.graph.nodes:
             if node.target == torch.ops.higher_order.cond:
                 true_gm = getattr(gm, node.args[1].target)
-                self.checkGraphModuleNodes(true_gm, expected_node_occurrence=node_occurrences)
+                self.checkGraphModuleNodes(
+                    true_gm, expected_node_occurrence=node_occurrences
+                )
                 false_gm = getattr(gm, node.args[2].target)
-                self.checkGraphModuleNodes(false_gm, expected_node_occurrence=node_occurrences)
+                self.checkGraphModuleNodes(
+                    false_gm, expected_node_occurrence=node_occurrences
+                )
 
 
 instantiate_parametrized_tests(TestQuantizePT2E)

--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -40,7 +40,6 @@ from torch.ao.quantization.quantizer.xnnpack_quantizer_utils import (
 )
 from torch.export import export_for_training
 from torch.fx import Node
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_quantization import (
     NodeSpec as ns,
     PT2EQuantizationTestCase,
@@ -1864,6 +1863,7 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
             torch.ops.aten.batch_norm.default,
         )
 
+    @parametrize("device", ["cpu"] + (["cuda"] if TEST_CUDA else []) + (["hpu"] if TEST_HPU else []))
     def test_move_exported_model_bn(self, device):
         """
         Test switching batch_norm behavior between train and eval modes using
@@ -2374,7 +2374,7 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
                             obs_ins = getattr(false_gm, obs_node.target)
                             assert isinstance(obs_ins, ObserverBase)
 
-        # gm(*example_inputs)
+        gm(*example_inputs)
         gm = convert_pt2e(gm)
 
         node_occurrences = {
@@ -2398,8 +2398,3 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
 
 
 instantiate_parametrized_tests(TestQuantizePT2E)
-
-devices = ["cpu", "cuda"]
-if TEST_HPU:
-    devices.append("hpu")
-# instantiate_device_type_tests(TestQuantizePT2E, globals(), only_for=devices)

--- a/torch/ao/quantization/quantize_pt2e.py
+++ b/torch/ao/quantization/quantize_pt2e.py
@@ -41,6 +41,7 @@ def _annotate_cond_ops(model: torch.fx.GraphModule, quantizer: Quantizer) -> Non
                 quantizer.annotate(true_gm)
                 quantizer.annotate(false_gm)
 
+
 def _prepare_cond_ops(model: torch.fx.GraphModule, is_qat: bool) -> None:
     gm_maybe_with_cond = [model]
     while gm_maybe_with_cond:
@@ -61,6 +62,7 @@ def _prepare_cond_ops(model: torch.fx.GraphModule, is_qat: bool) -> None:
                 false_gm = prepare(false_gm, node_name_to_scope, is_qat=is_qat)
                 false_gm.recompile()
                 setattr(gm, n.args[2].target, false_gm)
+
 
 def prepare_pt2e(
     model: GraphModule,
@@ -235,6 +237,7 @@ def _quant_node_constraint(n: Node) -> bool:
     """
     return n.op == "call_function" and n.target in _QUANT_OPS
 
+
 def _convert_pt2e_impl(
     model: GraphModule,
     use_reference_representation: bool = False,
@@ -278,12 +281,16 @@ def _convert_cond_ops(
                 gm_maybe_with_cond.append(false_gm)
 
                 node_name_to_scope = _get_node_name_to_scope(true_gm)
-                true_gm = _convert_pt2e_impl(true_gm, use_reference_representation, fold_quantize)
+                true_gm = _convert_pt2e_impl(
+                    true_gm, use_reference_representation, fold_quantize
+                )
                 true_gm.recompile()
                 setattr(gm, n.args[1].target, true_gm)
 
                 node_name_to_scope = _get_node_name_to_scope(false_gm)
-                false_gm = _convert_pt2e_impl(false_gm, use_reference_representation, fold_quantize)
+                false_gm = _convert_pt2e_impl(
+                    false_gm, use_reference_representation, fold_quantize
+                )
                 false_gm.recompile()
                 setattr(gm, n.args[2].target, false_gm)
 

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -48,7 +48,6 @@ from torch.testing._internal.common_quantized import (
     override_quantized_engine,
 )
 from torch.jit.mobile import _load_for_lite_interpreter
-from functorch.experimental import control_flow
 
 try:
     # graph mode quantization based on fx


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #140323

Summary:
This is requested by some internal teams, we added support for higher order cond op in pt2e quant flow,
where we call quantizer on the true/false graph modules recursively, and also prepare/convert functions as well

Test Plan:
python test/test_quantization.py -k test_cond_op

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D65899386](https://our.internmc.facebook.com/intern/diff/D65899386)