### PR TITLE
[Fix] the monitor script keep posting error-only data

### DIFF
--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -79,33 +79,34 @@ def rocm_get_per_process_gpu_info(handle: Any) -> list[dict[str, Any]]:
         per_process_info.append(info)
     return per_process_info
 
-
-if __name__ == "__main__":
-    nvml_handle = None
-    amdsmi_handle = None
-
+def get_nvml_handle():
     try:
-        import pynvml  # type: ignore[import]
-
+        import pynvml # type: ignore[import]
         try:
             pynvml.nvmlInit()
-            nvml_handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            return handle
         except pynvml.NVMLError:
             pass
     except ModuleNotFoundError:
-        # no pynvml avaliable, probably because not cuda
         pass
+
+def get_amdsmi_handle():
     try:
         import amdsmi  # type: ignore[import]
-
         try:
             amdsmi.amdsmi_init()
-            amdsmi_handle = amdsmi.amdsmi_get_processor_handles()[0]
+            handle = amdsmi.amdsmi_get_processor_handles()[0]
+            return handle
         except amdsmi.AmdSmiException:
             pass
     except ModuleNotFoundError:
         # no amdsmi is available
         pass
+
+if __name__ == "__main__":
+    nvml_handle = get_nvml_handle()
+    amdsmi_handle = get_amdsmi_handle()
 
     kill_now = False
 

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -7,7 +7,7 @@ import json
 import signal
 import time
 from datetime import timezone
-from typing import Any, Optional
+from typing import Any
 
 import psutil  # type: ignore[import]
 

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -7,7 +7,7 @@ import json
 import signal
 import time
 from datetime import timezone
-from typing import Any
+from typing import Any, Optional
 
 import psutil  # type: ignore[import]
 
@@ -83,13 +83,13 @@ def rocm_get_per_process_gpu_info(handle: Any) -> list[dict[str, Any]]:
 if __name__ == "__main__":
     nvml_handle = None
     amdsmi_handle = None
-    
+
     try:
         import pynvml  # type: ignore[import]
 
         try:
             pynvml.nvmlInit()
-            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            nvml_handle = pynvml.nvmlDeviceGetHandleByIndex(0)
         except pynvml.NVMLError:
             pass
     except ModuleNotFoundError:

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -81,7 +81,9 @@ def rocm_get_per_process_gpu_info(handle: Any) -> list[dict[str, Any]]:
 
 
 if __name__ == "__main__":
-    handle = None
+    nvml_handle = None
+    amdsmi_handle = None
+    
     try:
         import pynvml  # type: ignore[import]
 
@@ -120,10 +122,10 @@ if __name__ == "__main__":
                 "total_cpu_percent": psutil.cpu_percent(),
                 "per_process_cpu_info": get_per_process_cpu_info(),
             }
-            if handle is not None:
-                stats["per_process_gpu_info"] = get_per_process_gpu_info(handle)
+            if nvml_handle is not None:
+                stats["per_process_gpu_info"] = get_per_process_gpu_info(nvml_handle)
                 # https://docs.nvidia.com/deploy/nvml-api/structnvmlUtilization__t.html
-                gpu_utilization = pynvml.nvmlDeviceGetUtilizationRates(handle)
+                gpu_utilization = pynvml.nvmlDeviceGetUtilizationRates(nvml_handle)
                 stats["total_gpu_utilization"] = gpu_utilization.gpu
                 stats["total_gpu_mem_utilization"] = gpu_utilization.memory
             if amdsmi_handle is not None:


### PR DESCRIPTION
# Overview
- Initialize the amdsmi_handle variable to avoid the error "amdsmi_handle" is not defined.
- change handle to nvml_handle to indicate it's nvidia gpu handle

# Reason
Currently I'm investigating the utilization tracking tool, but unable to investigate what current log output are from monitor.py except list of errors.

# Example:
Link: https://hud.pytorch.org/pytorch/pytorch/commit/d2d1258b1b9ef49809025db5da69c0d881ac07da
- Test: cuda12.1-py3.10-gcc9-sm86 / test (aot_inductor_huggingface, 1, 1, linux.g5.4xlarge.nvidia.gpu)
- Artifact: [s3] logs-test-aot_inductor_huggingface-1-1-linux.g5.4xlarge.nvidia.gpu_32746677274.zip (15 KB)

user_log.txt snapshot:

```
{"time": "2024-11-09T05:27:10.534593+00:00Z", "error": "name 'amdsmi_handle' is not defined"}
{"time": "2024-11-09T05:27:11.552874+00:00Z", "error": "name 'amdsmi_handle' is not defined"}
{"time": "2024-11-09T05:27:12.570648+00:00Z", "error": "name 'amdsmi_handle' is not defined"}
{"time": "2024-11-09T05:27:13.588328+00:00Z", "error": "name 'amdsmi_handle' is not defined"}
{"time": "2024-11-09T05:27:14.605899+00:00Z", "error": "name 'amdsmi_handle' is not defined"}
{"time": "2024-11-09T05:27:15.623844+00:00Z", "error": "name 'amdsmi_handle' is not defined"}
{"time": "2024-11-09T05:27:16.641490+00:00Z", "error": "name 'amdsmi_handle' is not defined"}
{"time": "2024-11-09T05:27:17.659226+00:00Z", "error": "name 'amdsmi_handle' is not defined"}
```