### PR TITLE
[Testing][Invesitation]

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -9,6 +9,9 @@ set -ex
 # Suppress ANSI color escape sequences
 export TERM=vt100
 
+TEST_REPORTS_CHECK=$(pwd)/test/test-reports/check
+LOG_FILE="gpu_utilization.log"
+
 # shellcheck source=./common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
@@ -557,6 +560,25 @@ test_perf_for_dashboard() {
       fi
     done
   done
+}
+
+record_timing_and_pid() {
+  mkdir -p "$TEST_REPORTS_DIR"
+  local start_time end_time
+  local command="$*"
+
+  # Get start time
+  start_time=$(date +%s)
+
+  # Execute the command passed as arguments
+  "$@"
+
+  # Get end time
+  end_time=$(date +%s)
+
+  # Print the details
+  echo "TestName: $command, Start Time: $(date -d @$start_time +'%Y-%m-%d %H:%M:%S'), End Time: $(date -d @$end_time +'%Y-%m-%d %H:%M:%S')"
+  echo "{\"test-name\": \"$command\", \"start_time\": \"$(date -d @$start_time +'%Y-%m-%d %H:%M:%S')\", \"end_time\": \"$(date -d @$end_time +'%Y-%m-%d %H:%M:%S')\"}" > "$TEST_REPORTS_CHECK/$LOG_FILE"
 }
 
 test_single_dynamo_benchmark() {

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -578,10 +578,10 @@ record_time() {
 
   if [ $status -ne 0 ]; then
     echo "TestName: $command, Start Time: $start_time, End Time: $end_time, Status: Failed"
-    echo "{\"test-name\": \"$command\", \"start_time\": \"$start_time\", \"end_time\": \"$end_time\", \"status\": \"failed\"}" >> "$TEST_REPORTS_DIR/$LOG_FILE"
+    echo "{\"test-name\": \"$command\", \"start_time\": \"$start_time\", \"end_time\": \"$end_time\", \"status\": \"failed\"}" > "$TEST_REPORTS_DIR/$LOG_FILE"
   else
     echo "TestName: $command, Start Time: $start_time, End Time: $end_time, Status: Success"
-    echo "{\"test-name\": \"$command\", \"start_time\": \"$start_time\", \"end_time\": \"$end_time\", \"status\": \"success\"}" >> "$TEST_REPORTS_DIR/$LOG_FILE"
+    echo "{\"test-name\": \"$command\", \"start_time\": \"$start_time\", \"end_time\": \"$end_time\", \"status\": \"success\"}" > "$TEST_REPORTS_DIR/$LOG_FILE"
   fi
 
   return $status

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -146,7 +146,7 @@ jobs:
         shell: bash
         continue-on-error: true
         run: |
-          python3 -m pip install psutil==5.9.1 nvidia-ml-py==11.525.84
+          python3 -m pip install psutil==5.9.1 nvidia-ml-py==11.525.84 gputil
           python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -4,6 +4,7 @@
 name: inductor-unittest
 
 on:
+  pull_request:
   workflow_call:
   schedule:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests.

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -10,6 +10,7 @@
 name: inductor
 
 on:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -10,7 +10,6 @@
 name: inductor
 
 on:
-  pull_request:
   push:
     branches:
       - main

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -126,8 +126,17 @@ if __name__ == "__main__":
                 stats["per_process_gpu_info"] = get_per_process_gpu_info(nvml_handle)
                 # https://docs.nvidia.com/deploy/nvml-api/structnvmlUtilization__t.html
                 gpu_utilization = pynvml.nvmlDeviceGetUtilizationRates(nvml_handle)
-                stats["total_gpu_utilization"] = gpu_utilization.gpu
-                stats["total_gpu_mem_utilization"] = gpu_utilization.memory
+                gpu_count = pynvml.nvmlDeviceGetCount()
+                # Iterate over the available GPUs
+                for i in range(gpu_count):
+                    # Get the handle to the current GPU
+                    gpu_handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+                    # Get the message for the current GPU
+                    message = pynvml.nvmlDeviceGetErrorMessage(gpu_handle)
+                    # Print the message
+                    print(f"GPU {i}: {message}")
+                    stats["total_gpu_utilization-{i}"] = gpu_utilization.gpu
+                    stats["total_gpu_mem_utilization-{i}"] = gpu_utilization.memory
             if amdsmi_handle is not None:
                 stats["per_process_gpu_info"] = rocm_get_per_process_gpu_info(
                     amdsmi_handle

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -30,7 +30,7 @@ def get_per_process_cpu_info() -> list[dict[str, Any]]:
     for p in processes:
         info = {
             "pid": p.pid,
-            "cmd": p.cmdline(),
+            "cmd":  " ".join(p.cmdline()),
             "cpu_percent": p.cpu_percent(),
             "rss_memory": p.memory_info().rss,
             "ppid":p.ppid,

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -33,9 +33,8 @@ def get_per_process_cpu_info() -> list[dict[str, Any]]:
             "cmd": " ".join(p.cmdline()),
             "cpu_percent": p.cpu_percent(),
             "rss_memory": p.memory_info().rss,
-            "ppid":p.ppid.pid,
+            "ppid":p.ppid(),
         }
-
         # https://psutil.readthedocs.io/en/latest/index.html?highlight=memory_full_info
         # requires higher user privileges and could throw AccessDenied error, i.e. mac
         try:
@@ -45,7 +44,6 @@ def get_per_process_cpu_info() -> list[dict[str, Any]]:
             if "pss" in memory_full_info:
                 # only availiable in linux
                 info["pss_memory"] = memory_full_info.pss
-
         except psutil.AccessDenied as e:
             # It's ok to skip this
             pass

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -85,11 +85,13 @@ def get_nvml_handle():
         import pynvml # type: ignore[import]
         try:
             pynvml.nvmlInit()
+
             handle = pynvml.nvmlDeviceGetHandleByIndex(0)
             return handle
         except pynvml.NVMLError:
             pass
     except ModuleNotFoundError:
+        # no pynvml avaliable, probably because not cuda
         pass
 
 def get_amdsmi_handle():
@@ -104,7 +106,7 @@ def get_amdsmi_handle():
     except ModuleNotFoundError:
         # no amdsmi is available
         pass
-    
+
 if __name__ == "__main__":
     nvml_handle = get_nvml_handle()
     amdsmi_handle = get_amdsmi_handle()

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -119,7 +119,6 @@ if __name__ == "__main__":
                 "total_cpu_percent": psutil.cpu_percent(),
                 "per_process_cpu_info": get_per_process_cpu_info(),
             }
-
             if nvml_handle is not None:
                 stats["per_process_gpu_info"] = get_per_process_gpu_info(nvml_handle)
                 # https://docs.nvidia.com/deploy/nvml-api/structnvmlUtilization__t.html

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -79,33 +79,35 @@ def rocm_get_per_process_gpu_info(handle: Any) -> list[dict[str, Any]]:
         per_process_info.append(info)
     return per_process_info
 
-
-if __name__ == "__main__":
-    nvml_handle = None
-    amdsmi_handle = None
-
+def get_nvml_handle():
     try:
-        import pynvml  # type: ignore[import]
-
+        # Import pynvml inside the try block
+        import pynvml # type: ignore[import]
         try:
             pynvml.nvmlInit()
             handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            return handle
         except pynvml.NVMLError:
             pass
     except ModuleNotFoundError:
-        # no pynvml avaliable, probably because not cuda
         pass
+
+def get_amdsmi_handle():
     try:
         import amdsmi  # type: ignore[import]
-
         try:
             amdsmi.amdsmi_init()
-            amdsmi_handle = amdsmi.amdsmi_get_processor_handles()[0]
+            handle = amdsmi.amdsmi_get_processor_handles()[0]
+            return handle
         except amdsmi.AmdSmiException:
             pass
     except ModuleNotFoundError:
         # no amdsmi is available
         pass
+    
+if __name__ == "__main__":
+    nvml_handle = get_nvml_handle()
+    amdsmi_handle = get_amdsmi_handle()
 
     kill_now = False
 

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -143,9 +143,7 @@ if __name__ == "__main__":
                     # Get the handle to the current GPU
                     gpu_handle = pynvml.nvmlDeviceGetHandleByIndex(i)
                     # Get the message for the current GPU
-                    message = pynvml.nvmlDeviceGetErrorMessage(gpu_handle)
                     # Print the message
-                    print(f"GPU {i}: {message}")
                     stats["total_gpu_utilization-{i}"] = gpu_utilization.gpu
                     stats["total_gpu_mem_utilization-{i}"] = gpu_utilization.memory
                 # Run the nvidia-smi command and capture its output

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -79,36 +79,33 @@ def rocm_get_per_process_gpu_info(handle: Any) -> list[dict[str, Any]]:
         per_process_info.append(info)
     return per_process_info
 
-def get_nvml_handle():
+
+if __name__ == "__main__":
+    nvml_handle = None
+    amdsmi_handle = None
+
     try:
-        # Import pynvml inside the try block
-        import pynvml # type: ignore[import]
+        import pynvml  # type: ignore[import]
+
         try:
             pynvml.nvmlInit()
             handle = pynvml.nvmlDeviceGetHandleByIndex(0)
-            return handle
         except pynvml.NVMLError:
             pass
     except ModuleNotFoundError:
         # no pynvml avaliable, probably because not cuda
         pass
-
-def get_amdsmi_handle():
     try:
         import amdsmi  # type: ignore[import]
+
         try:
             amdsmi.amdsmi_init()
-            handle = amdsmi.amdsmi_get_processor_handles()[0]
-            return handle
+            amdsmi_handle = amdsmi.amdsmi_get_processor_handles()[0]
         except amdsmi.AmdSmiException:
             pass
     except ModuleNotFoundError:
         # no amdsmi is available
         pass
-
-if __name__ == "__main__":
-    nvml_handle = get_nvml_handle()
-    amdsmi_handle = get_amdsmi_handle()
 
     kill_now = False
 

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -83,7 +83,7 @@ def rocm_get_per_process_gpu_info(handle: Any) -> list[dict[str, Any]]:
 if __name__ == "__main__":
     nvml_handle = None
     amdsmi_handle = None
-    
+
     try:
         import pynvml  # type: ignore[import]
 

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -81,7 +81,9 @@ def rocm_get_per_process_gpu_info(handle: Any) -> list[dict[str, Any]]:
 
 
 if __name__ == "__main__":
-    handle = None
+    nvml_handle = None
+    amdsmi_handle = None
+    
     try:
         import pynvml  # type: ignore[import]
 
@@ -120,10 +122,10 @@ if __name__ == "__main__":
                 "total_cpu_percent": psutil.cpu_percent(),
                 "per_process_cpu_info": get_per_process_cpu_info(),
             }
-            if handle is not None:
-                stats["per_process_gpu_info"] = get_per_process_gpu_info(handle)
+            if nvml_handle is not None:
+                stats["per_process_gpu_info"] = get_per_process_gpu_info(nvml_handle)
                 # https://docs.nvidia.com/deploy/nvml-api/structnvmlUtilization__t.html
-                gpu_utilization = pynvml.nvmlDeviceGetUtilizationRates(handle)
+                gpu_utilization = pynvml.nvmlDeviceGetUtilizationRates(nvml_handle)
                 stats["total_gpu_utilization"] = gpu_utilization.gpu
                 stats["total_gpu_mem_utilization"] = gpu_utilization.memory
             if amdsmi_handle is not None:

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
 
         try:
             pynvml.nvmlInit()
-            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            nvml_handle = pynvml.nvmlDeviceGetHandleByIndex(0)
         except pynvml.NVMLError:
             pass
     except ModuleNotFoundError:

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -6,6 +6,7 @@ import datetime
 import json
 import signal
 import time
+import subprocess
 from datetime import timezone
 from typing import Any
 
@@ -137,6 +138,12 @@ if __name__ == "__main__":
                     print(f"GPU {i}: {message}")
                     stats["total_gpu_utilization-{i}"] = gpu_utilization.gpu
                     stats["total_gpu_mem_utilization-{i}"] = gpu_utilization.memory
+                # Run the nvidia-smi command and capture its output
+                output = subprocess.check_output(['nvidia-smi', '--query-gpu=utilization.gpu', '--format=csv,noheader,nounits'])# Decode the output from bytes to string
+                output_str = output.decode('utf-8')
+                # Print the output
+                stats["nvidia-smi-test"] = output_str
+                stats["total_gpu_mem_utilization-{i}"] = gpu_utilization.memory
             if amdsmi_handle is not None:
                 stats["per_process_gpu_info"] = rocm_get_per_process_gpu_info(
                     amdsmi_handle

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -143,7 +143,6 @@ if __name__ == "__main__":
                 output_str = output.decode('utf-8')
                 # Print the output
                 stats["nvidia-smi-test"] = output_str
-                stats["total_gpu_mem_utilization-{i}"] = gpu_utilization.memory
             if amdsmi_handle is not None:
                 stats["per_process_gpu_info"] = rocm_get_per_process_gpu_info(
                     amdsmi_handle

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -84,6 +84,15 @@ def rocm_get_per_process_gpu_info(handle: Any) -> list[dict[str, Any]]:
 if __name__ == "__main__":
     nvml_handle = None
     amdsmi_handle = None
+    isValid = True
+    try:
+        import gputil
+
+    except ModuleNotFoundError:
+        print("gputil not found, skipping gputil stats")
+        # no pynvml avaliable, probably because not cuda
+        isValid = False
+        pass
 
     try:
         import pynvml  # type: ignore[import]
@@ -123,6 +132,7 @@ if __name__ == "__main__":
                 "total_cpu_percent": psutil.cpu_percent(),
                 "per_process_cpu_info": get_per_process_cpu_info(),
             }
+
             if nvml_handle is not None:
                 stats["per_process_gpu_info"] = get_per_process_gpu_info(nvml_handle)
                 # https://docs.nvidia.com/deploy/nvml-api/structnvmlUtilization__t.html
@@ -153,6 +163,11 @@ if __name__ == "__main__":
                 stats["total_gpu_mem_utilization"] = amdsmi.amdsmi_get_gpu_activity(
                     amdsmi_handle
                 )["umc_activity"]
+            if isValid:
+                gpus = gputil.getGPUs()
+                # Print the GPU names and indices
+                for i, gpu in enumerate(gpus):
+                    stats["gputil-{i}"]= gpu.load*100
         except Exception as e:
             stats = {
                 "time": datetime.datetime.now(timezone.utc).isoformat("T") + "Z",

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -33,7 +33,7 @@ def get_per_process_cpu_info() -> list[dict[str, Any]]:
             "cmd": " ".join(p.cmdline()),
             "cpu_percent": p.cpu_percent(),
             "rss_memory": p.memory_info().rss,
-            "ppid":p.ppid,
+            "ppid":p.ppid.pid,
         }
 
         # https://psutil.readthedocs.io/en/latest/index.html?highlight=memory_full_info

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -85,7 +85,6 @@ def get_nvml_handle():
         import pynvml # type: ignore[import]
         try:
             pynvml.nvmlInit()
-
             handle = pynvml.nvmlDeviceGetHandleByIndex(0)
             return handle
         except pynvml.NVMLError:

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -30,7 +30,7 @@ def get_per_process_cpu_info() -> list[dict[str, Any]]:
     for p in processes:
         info = {
             "pid": p.pid,
-            "cmd":  " ".join(p.cmdline()),
+            "cmd": " ".join(p.cmdline()),
             "cpu_percent": p.cpu_percent(),
             "rss_memory": p.memory_info().rss,
             "ppid":p.ppid,

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -144,8 +144,8 @@ if __name__ == "__main__":
                     gpu_handle = pynvml.nvmlDeviceGetHandleByIndex(i)
                     # Get the message for the current GPU
                     # Print the message
-                    stats["total_gpu_utilization-{i}"] = gpu_utilization.gpu
-                    stats["total_gpu_mem_utilization-{i}"] = gpu_utilization.memory
+                    stats[f"total_gpu_utilization-{i}"] = gpu_utilization.gpu
+                    stats[f"total_gpu_mem_utilization-{i}"] = gpu_utilization.memory
                 # Run the nvidia-smi command and capture its output
                 output = subprocess.check_output(['nvidia-smi', '--query-gpu=utilization.gpu', '--format=csv,noheader,nounits'])# Decode the output from bytes to string
                 output_str = output.decode('utf-8')
@@ -165,7 +165,7 @@ if __name__ == "__main__":
                 gpus = gputil.getGPUs()
                 # Print the GPU names and indices
                 for i, gpu in enumerate(gpus):
-                    stats["gputil-{i}"]= gpu.load*100
+                    stats[f"gputil-{i}"]= gpu.load*100
         except Exception as e:
             stats = {
                 "time": datetime.datetime.now(timezone.utc).isoformat("T") + "Z",


### PR DESCRIPTION
# Overview
- Initialize the amdsmi_handle variable to avoid the error "amdsmi_handle" is not defined.
- change handle to nvml_handle to indicate it's nvidia gpu handle

# Reason
Currently I'm investigating the utilization tracking tool, but unable to investigate what current log output are from monitor.py except list of errors.

# Example:
Link: https://hud.pytorch.org/pytorch/pytorch/commit/d2d1258b1b9ef49809025db5da69c0d881ac07da
- Test: cuda12.1-py3.10-gcc9-sm86 / test (aot_inductor_huggingface, 1, 1, linux.g5.4xlarge.nvidia.gpu)
- Artifact: [s3] logs-test-aot_inductor_huggingface-1-1-linux.g5.4xlarge.nvidia.gpu_32746677274.zip (15 KB)

user_log.txt snapshot:

```
{"time": "2024-11-09T05:27:10.534593+00:00Z", "error": "name 'amdsmi_handle' is not defined"}
{"time": "2024-11-09T05:27:11.552874+00:00Z", "error": "name 'amdsmi_handle' is not defined"}
{"time": "2024-11-09T05:27:12.570648+00:00Z", "error": "name 'amdsmi_handle' is not defined"}
{"time": "2024-11-09T05:27:13.588328+00:00Z", "error": "name 'amdsmi_handle' is not defined"}
{"time": "2024-11-09T05:27:14.605899+00:00Z", "error": "name 'amdsmi_handle' is not defined"}
{"time": "2024-11-09T05:27:15.623844+00:00Z", "error": "name 'amdsmi_handle' is not defined"}
{"time": "2024-11-09T05:27:16.641490+00:00Z", "error": "name 'amdsmi_handle' is not defined"}
{"time": "2024-11-09T05:27:17.659226+00:00Z", "error": "name 'amdsmi_handle' is not defined"}
```