### PR TITLE
[ROCm] Add ROCR_VISIBLE_DEVICE parsing logic to initialisation

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -665,7 +665,6 @@ def _parse_visible_devices() -> Union[List[int], List[str]]:
             if rocr_devices is not None:
                 var = ",".join(str(i) for i in range(max_length))
 
-
     if var is None:
         return list(range(64))
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/140318

Currently ROCR_VISIBLE_DEVICES is not respected in the _parse_visible_devices logic, updating this code to ensure visible devices count returned does not exceed the number of devices specified in ROCR_VISIBLE_DEVICES, which restricts the number of GPUs available at runtime.

PyTorch 2.5
```
ROCR_VISIBLE_DEVICES="0" HIP_VISIBLE_DEVICES="0,1" 
print(torch.cuda.device_count())
>>> 2
```
 
 
PyTorch 2.0
```
ROCR_VISIBLE_DEVICES="0" HIP_VISIBLE_DEVICES="0,1" 
print(torch.cuda.device_count())
>>> 1
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang @naromero77amd