### PR TITLE
Extract reusable portions of GeluKernel into header

### DIFF
--- a/aten/src/ATen/native/Activation.h
+++ b/aten/src/ATen/native/Activation.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <ATen/native/DispatchStub.h>
+#include <ATen/native/Gelu.h>
 #include <c10/util/Exception.h>
-#include <c10/util/string_view.h>
 
 namespace c10 {
 class Scalar;
@@ -15,31 +15,6 @@ class TensorBase;
 }
 
 namespace at::native {
-
-// These constants control the approximation behavior of gelu function.
-enum class GeluType {
-  None,             // Baseline Gelu
-  Tanh,             // Tahn Gelu Approximation
-  END
-};
-
-inline GeluType get_gelutype_enum(const c10::string_view approximate) {
-  if (approximate == "none") {
-    return GeluType::None;
-  } else if (approximate == "tanh") {
-    return GeluType::Tanh;
-  } else {
-    TORCH_CHECK(false, "approximate argument must be either none or tanh.");
-  }
-}
-
-inline std::string gelutype_to_string(const GeluType type) {
-  switch(type) {
-    case GeluType::None: return "none";
-    case GeluType::Tanh: return "tanh";
-    default: TORCH_CHECK(false, "unknown GELU type: ", static_cast<int>(type));
-  }
-}
 
 using structured_activation_fn = void (*)(TensorIteratorBase&);
 using structured_activation_backward_fn = void (*)(TensorIteratorBase&);

--- a/aten/src/ATen/native/Gelu.h
+++ b/aten/src/ATen/native/Gelu.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <c10/util/Exception.h>
+#include <c10/util/string_view.h>
+
+namespace at::native {
+// These constants control the approximation behavior of gelu function.
+enum class GeluType {
+  None,             // Baseline Gelu
+  Tanh,             // Tanh Gelu Approximation
+  END
+};
+
+inline GeluType get_gelutype_enum(const c10::string_view approximate) {
+  if (approximate == "none") {
+    return GeluType::None;
+  } else if (approximate == "tanh") {
+    return GeluType::Tanh;
+  } else {
+    TORCH_CHECK(false, "approximate argument must be either none or tanh.");
+  }
+}
+
+inline std::string gelutype_to_string(const GeluType type) {
+  switch(type) {
+    case GeluType::None: return "none";
+    case GeluType::Tanh: return "tanh";
+    default: TORCH_CHECK(false, "unknown GELU type: ", static_cast<int>(type));
+  }
+}
+
+
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/Activation.cpp
+++ b/aten/src/ATen/native/cpu/Activation.cpp
@@ -15,6 +15,7 @@
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/TensorIterator.h>
+#include <ATen/native/cpu/Gelu.h>
 #include <ATen/native/cpu/Loops.h>
 #include <ATen/Parallel.h>
 
@@ -343,96 +344,35 @@ void GeluKernelImpl(TensorIteratorBase& it, GeluType approximate) {
   if (approximate == GeluType::Tanh) {
     if (at::isReducedFloatingType(it.common_dtype())) {
       AT_DISPATCH_REDUCED_FLOATING_TYPES(it.common_dtype(), "GeluKernelImpl", [&]() {
-        auto kBetaVec = Vectorized<float>((float)(M_SQRT2 * M_2_SQRTPI * 0.5));
-        auto kKappaVec = Vectorized<float>((float)(0.044715));
-        auto kOneVec = Vectorized<float>((float)(1));
-        auto kPointFiveVec = Vectorized<float>((float)(0.5));
         cpu_kernel_vec(
             it,
-            [](scalar_t x) -> scalar_t {
-              const float kBeta = float(M_SQRT2 * M_2_SQRTPI * 0.5);
-              const float kKappa = float(0.044715);
-              float x_cube = float(x) * float(x) * float(x);
-              float inner = kBeta * (float(x) + kKappa * x_cube);
-              return float(0.5) * float(x) * (float(1) + std::tanh(inner));
-            },
-            [&](Vectorized<scalar_t> x) -> Vectorized<scalar_t> {
-              auto [x0, x1] = convert_to_float<scalar_t>(x);
-              auto x0_cube = x0 * x0 * x0;
-              auto x1_cube = x1 * x1 * x1;
-              auto inner_vec0 = kBetaVec * (x0 + kKappaVec * x0_cube);
-              auto inner_vec1 = kBetaVec * (x1 + kKappaVec * x1_cube);
-              auto res0 = kPointFiveVec * x0 * (kOneVec + inner_vec0.tanh());
-              auto res1 = kPointFiveVec * x1 * (kOneVec + inner_vec1.tanh());
-              return convert_from_float<scalar_t>(res0, res1);
-            },
+            scalar_gelu_approximated_with_tanh<scalar_t>,
+            vectorized_gelu_approximated_with_tanh<scalar_t>,
             grain_size);
       });
     } else {
       AT_DISPATCH_FLOATING_TYPES(
           it.dtype(), "GeluKernelImpl", [&]() {
-        using Vec = vec::Vectorized<scalar_t>;
-        const Vec kBetaVec(scalar_t(M_SQRT2 * M_2_SQRTPI * 0.5));
-        const Vec kKappaVec(scalar_t(0.044715));
-        const Vec kOneVec(scalar_t(1));
-        const Vec kPointFiveVec(scalar_t(0.5));
         cpu_kernel_vec(
             it,
-            [](scalar_t x) {
-              const scalar_t kBeta = M_SQRT2 * M_2_SQRTPI * 0.5;
-              const scalar_t kKappa = 0.044715;
-              auto x_cube = x * x * x;
-              auto inner = kBeta * (x + kKappa * x_cube);
-              return scalar_t(0.5) * x * (scalar_t(1) + std::tanh(inner));
-            },
-            [&](Vec x_vec) {
-              auto x_cube = x_vec * x_vec * x_vec;
-              auto inner_vec = kBetaVec * (x_vec + kKappaVec * x_cube);
-              return kPointFiveVec * x_vec * (kOneVec + inner_vec.tanh());
-            },
+            scalar_gelu_approximated_with_tanh<scalar_t>,
+            vectorized_gelu_approximated_with_tanh<scalar_t>,
             grain_size);
       });
     }
   } else {
-    if (at::isReducedFloatingType(it.common_dtype())) {
-      AT_DISPATCH_REDUCED_FLOATING_TYPES(it.dtype(), "GeluKernelImpl", [&]() {
-        auto kAlphaVec = Vectorized<float>((float)(M_SQRT1_2));
-        auto kOneVec = Vectorized<float>((float)(1));
-        auto kPointFiveVec = Vectorized<float>((float)(0.5));
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        ScalarType::Half,
+        ScalarType::BFloat16,
+        it.dtype(),
+        "GeluKernelImpl",
+        [&]() {
         cpu_kernel_vec(
             it,
-            [](scalar_t x) -> scalar_t {
-              const float kAlpha = float(M_SQRT1_2);
-              return float(x) * float(0.5) * (float(1) + std::erf(float(x) * kAlpha));
-            },
-            [&](Vectorized<scalar_t> x) -> Vectorized<scalar_t> {
-              auto [x0, x1] = convert_to_float<scalar_t>(x);
-              auto res0 = x0 * kPointFiveVec * (kOneVec + (x0 * kAlphaVec).erf());
-              auto res1 = x1 * kPointFiveVec * (kOneVec + (x1 * kAlphaVec).erf());
-              return convert_from_float<scalar_t>(res0, res1);
-            },
+            scalar_gelu<scalar_t>,
+            vectorized_gelu<scalar_t>,
             grain_size);
       });
-    } else {
-      AT_DISPATCH_FLOATING_TYPES(
-          it.dtype(), "GeluKernelImpl", [&]() {
-        using Vec = vec::Vectorized<scalar_t>;
-        const Vec kAlphaVec(scalar_t(M_SQRT1_2));
-        const Vec kOneVec(scalar_t(1));
-        const Vec kPointFiveVec(scalar_t(0.5));
-        cpu_kernel_vec(
-            it,
-            [](scalar_t x) {
-              const scalar_t kAlpha = scalar_t(M_SQRT1_2);
-              return x * scalar_t(0.5) * (scalar_t(1) + std::erf(x * kAlpha));
-            },
-            [&](Vec x_vec) {
-              return x_vec * kPointFiveVec *
-                  (kOneVec + (x_vec * kAlphaVec).erf());
-            },
-            grain_size);
-      });
-    }
   }
 }
 

--- a/aten/src/ATen/native/cpu/Gelu.h
+++ b/aten/src/ATen/native/cpu/Gelu.h
@@ -42,8 +42,6 @@ vec::Vectorized<T> vectorized_gelu_approximated_with_tanh(vec::Vectorized<T> x) 
 
 template <typename T, std::enable_if_t<std::is_reduced_floating_point_v<T>, bool> = true>
 vec::Vectorized<T> vectorized_gelu_approximated_with_tanh(vec::Vectorized<T> x) {
-  const vec::Vectorized<float> kPointFiveVec(0.5f);
-  const vec::Vectorized<float> kOneVec(1);
   auto [x0, x1] = convert_to_float<T>(x);
   return convert_from_float<T>(
       vectorized_gelu_approximated_with_tanh(x0),
@@ -68,11 +66,8 @@ vec::Vectorized<T> vectorized_gelu(vec::Vectorized<T> x) {
 
 template<typename T, std::enable_if_t<std::is_reduced_floating_point_v<T>, bool> = true>
 vec::Vectorized<T> vectorized_gelu(vec::Vectorized<T> x) {
-  const vec::Vectorized<float> kAlphaVec(float(M_SQRT1_2));
-  const vec::Vectorized<float> kOneVec(float(1));
-  const vec::Vectorized<float> kPointFiveVec(float(0.5));
-  auto [x0, x1] = convert_to_float<T>(x);
-  return convert_from_float<T>(vectorized_gelu(x0), vectorized_gelu(x1));
+  auto [x0, x1] = at::vec::convert_to_float<T>(x);
+  return at::vec::convert_from_float<T>(vectorized_gelu(x0), vectorized_gelu(x1));
 }
 
 

--- a/aten/src/ATen/native/cpu/Gelu.h
+++ b/aten/src/ATen/native/cpu/Gelu.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <ATen/cpu/vec/vec.h>
+#include <c10/util/BFloat16.h> // For std::is_reduced_floating_point_v.
+
+namespace at::native {
+constexpr double kGeluBeta = M_SQRT2 * M_2_SQRTPI * 0.5;
+constexpr double kGeluKappa = 0.044715;
+
+template <typename T>
+using reduced_fp_to_float_t = std::conditional_t<std::is_reduced_floating_point_v<T>, float, T>;
+
+template <typename T, std::enable_if_t<std::is_reduced_floating_point_v<T>, bool> = true>
+float reduced_fp_to_float(T x) {
+  return float(x);
+}
+
+template <typename T, std::enable_if_t<!std::is_reduced_floating_point_v<T>, bool> = true>
+T reduced_fp_to_float(T x) {
+  return x;
+}
+
+template <typename T>
+T scalar_gelu_approximated_with_tanh(T x) {
+  using opmath_t = reduced_fp_to_float_t<T>;
+  auto x_float = reduced_fp_to_float(x);
+  auto x_cube = x_float * x_float * x_float;
+  auto inner = opmath_t(kGeluBeta) * (x_float + opmath_t(kGeluKappa) * x_cube);
+  return opmath_t(0.5) * x_float * (opmath_t(1) + std::tanh(inner));
+}
+
+template <typename T, std::enable_if_t<!std::is_reduced_floating_point_v<T>, bool> = true>
+vec::Vectorized<T> vectorized_gelu_approximated_with_tanh(vec::Vectorized<T> x) {
+  const vec::Vectorized<T> kPointFiveVec(T(0.5));
+  const vec::Vectorized<T> kOneVec(T(1));
+  const vec::Vectorized<T> kGeluBetaVec((T(kGeluBeta)));
+  const vec::Vectorized<T> kGeluKappaVec((T(kGeluKappa)));
+  auto x_cube = x * x * x;
+  vec::Vectorized<T> inner_vec = kGeluBetaVec * (x + kGeluKappaVec * x_cube);
+  return kPointFiveVec * x * (kOneVec + inner_vec.tanh());
+}
+
+template <typename T, std::enable_if_t<std::is_reduced_floating_point_v<T>, bool> = true>
+vec::Vectorized<T> vectorized_gelu_approximated_with_tanh(vec::Vectorized<T> x) {
+  const vec::Vectorized<float> kPointFiveVec(0.5f);
+  const vec::Vectorized<float> kOneVec(1);
+  auto [x0, x1] = convert_to_float<T>(x);
+  return convert_from_float<T>(
+      vectorized_gelu_approximated_with_tanh(x0),
+      vectorized_gelu_approximated_with_tanh(x1));
+}
+
+
+template <typename T>
+T scalar_gelu(T x) {
+  using opmath_t = reduced_fp_to_float_t<T>;
+  const auto kAlpha = opmath_t(M_SQRT1_2);
+  return reduced_fp_to_float(x) * opmath_t(0.5) * (opmath_t(1) + std::erf(reduced_fp_to_float(x) * kAlpha));
+}
+
+template<typename T, std::enable_if_t<!std::is_reduced_floating_point_v<T>, bool> = true>
+vec::Vectorized<T> vectorized_gelu(vec::Vectorized<T> x) {
+  const vec::Vectorized<T> kAlphaVec(T(M_SQRT1_2));
+  const vec::Vectorized<T> kOneVec(T(1));
+  const vec::Vectorized<T> kPointFiveVec(T(0.5));
+  return x * kPointFiveVec * (kOneVec + (x * kAlphaVec).erf());
+}
+
+template<typename T, std::enable_if_t<std::is_reduced_floating_point_v<T>, bool> = true>
+vec::Vectorized<T> vectorized_gelu(vec::Vectorized<T> x) {
+  const vec::Vectorized<float> kAlphaVec(float(M_SQRT1_2));
+  const vec::Vectorized<float> kOneVec(float(1));
+  const vec::Vectorized<float> kPointFiveVec(float(0.5));
+  auto [x0, x1] = convert_to_float<T>(x);
+  return convert_from_float<T>(vectorized_gelu(x0), vectorized_gelu(x1));
+}
+
+
+} // namespace

--- a/aten/src/ATen/native/cpu/Gelu.h
+++ b/aten/src/ATen/native/cpu/Gelu.h
@@ -42,8 +42,8 @@ vec::Vectorized<T> vectorized_gelu_approximated_with_tanh(vec::Vectorized<T> x) 
 
 template <typename T, std::enable_if_t<std::is_reduced_floating_point_v<T>, bool> = true>
 vec::Vectorized<T> vectorized_gelu_approximated_with_tanh(vec::Vectorized<T> x) {
-  auto [x0, x1] = convert_to_float<T>(x);
-  return convert_from_float<T>(
+  auto [x0, x1] = at::vec::convert_to_float<T>(x);
+  return at::vec::convert_from_float<T>(
       vectorized_gelu_approximated_with_tanh(x0),
       vectorized_gelu_approximated_with_tanh(x1));
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #140425

Makes the implementation reusable via header-only code sharing. (no diff for that yet, but we can commit the refactor regardless.)

Testing: existing correctness tests should cover.

Differential Revision: [D65608800](https://our.internmc.facebook.com/intern/diff/D65608800/)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10