### PR TITLE
[Profiler] Fix ASAN Overflow Issues

### DIFF
--- a/c10/util/ApproximateClock.cpp
+++ b/c10/util/ApproximateClock.cpp
@@ -72,7 +72,9 @@ std::function<time_t(approx_time_t)> ApproximateClockToUnixTimeConverter::
 
   return [=](approx_time_t t_approx) {
     // See above for why this is more stable than `A * t_approx + B`.
-    return (time_t)((double)(t_approx - t0_approx) * scale_factor) + t0;
+    return t_approx > t0_approx
+        ? (time_t)((double)(t_approx - t0_approx) * scale_factor) + t0
+        : 0;
   };
 }
 


### PR DESCRIPTION
Summary:
It seems like this issues is due to leftover cupti events during warmup staying persistent in the queue during profiling. These events start before our actual time window and therefore have a timestamp lower than our basetime. This makes the delta become negative which results in unsigned overflow. This then creates a large number which later gets sign added which creates the signed overflow.

Solution: If a raw timestamp is less than the base timestamp, just mark the process timestamp as -1 so we can mark these events as "to ignore". In Kineto, add a special case to ignore timestamps that are negative.

Test Plan: Test with ASAN

Differential Revision: D65835650




cc @robieta @chaekit @guotuofeng @guyang3532 @dzhulgakov @davidberard98 @briancoutinho @sanrise