### PR TITLE
clarifies the wording in the main README to make it clearer that visu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ They require JetPack 4.2 and above, and [@dusty-nv](https://github.com/dusty-nv)
 If you are installing from source, you will need:
 - Python 3.9 or later
 - A compiler that fully supports C++17, such as clang or gcc (gcc 9.4.0 or newer is required, on Linux)
-- Visual Studio or Visual Studio Build Tool on Windows
+- Visual Studio or Visual Studio Build Tool (Windows only)
 
 \* PyTorch CI uses Visual C++ BuildTools, which come with Visual Studio Enterprise,
 Professional, or Community Editions. You can also install the build tools from


### PR DESCRIPTION
…al studio build tool is only needed for Windows

I created no issue since the suggested change is actually very small.  This is my very first PR so partly I am creating it just to dip my toes in the water.  In fact I would understand if the change does not get accepted since it's a simple modification to part of the wording in the README.  The wording as it currently stands is probably clear enough for most people, but I still missed the fact that visual studio build tool must only be installed for Windows (even though that is stated there), and I thought by adding some parentheses this might become even more clear, specially since elsewhere in the README the formatting makes it more explicit that some steps must only be run for Windows/Linux/MacOS

As I said, it's a trivial change so I'd understand if it's not accepted, and I am looking forward to making more meaningful contributions as time goes on.

Fixes #ISSUE_NUMBER
