### PR TITLE
General per-SampleInput xfail / skip system

### DIFF
--- a/test/functorch/common_utils.py
+++ b/test/functorch/common_utils.py
@@ -19,6 +19,7 @@ from torch.testing._internal.common_device_type import toleranceOverride
 from torch.testing._internal.common_methods_invocations import DecorateInfo, op_db
 from torch.testing._internal.common_modules import module_db
 from torch.testing._internal.custom_op_db import custom_op_db
+from torch.testing._internal.opinfo.core import sample_skips_and_xfails, XFailRule
 
 
 IS_FBCODE = os.getenv("FUNCTORCH_TEST_FBCODE") == "1"
@@ -443,6 +444,25 @@ def xfail(op_name, variant_name="", *, device_type=None, dtypes=None):
         op_name=op_name,
         variant_name=variant_name,
         decorator=unittest.expectedFailure,
+        device_type=device_type,
+        dtypes=dtypes,
+    )
+
+
+# fail_fn should be a callable that accepts a single SampleInput and returns True if failure
+# is expected
+def xfailIf(op_name, fail_fn, variant_name="", *, device_type=None, dtypes=None):
+    return decorate(
+        op_name=op_name,
+        variant_name=variant_name,
+        decorator=sample_skips_and_xfails(
+            [
+                XFailRule(
+                    op_match_fn=lambda device, op: op.full_name == op_name,
+                    sample_match_fn=lambda device, sample: fail_fn(sample),
+                )
+            ]
+        ),
         device_type=device_type,
         dtypes=dtypes,
     )

--- a/test/functorch/common_utils.py
+++ b/test/functorch/common_utils.py
@@ -458,7 +458,9 @@ def xfailIf(op_name, fail_fn, variant_name="", *, device_type=None, dtypes=None)
         decorator=sample_skips_and_xfails(
             [
                 XFailRule(
-                    op_match_fn=lambda device, op: op.full_name == op_name,
+                    # op matching is already handled by DecorateMeta
+                    op_match_fn=lambda device, op: True,
+                    # device matching is already handled by DecorateMeta
                     sample_match_fn=lambda device, sample: fail_fn(sample),
                 )
             ]

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4380,6 +4380,7 @@ class TestVmapOperatorsOpInfo(TestCase):
                 xfail("torch.ops.aten._efficient_attention_forward"),  # outputs ints
                 # TypeError: expected Tensor as element 0 in argument 0, but got float
                 xfail("item"),
+                # RuntimeError: required rank 4 tensor to use channels_last format
                 xfailIf(
                     "to",
                     lambda sample: (

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -32,6 +32,7 @@ from common_utils import (
     skipOps,
     tol1,
     xfail,
+    xfailIf,
 )
 from functorch_additional_op_db import additional_op_db
 
@@ -4141,50 +4142,55 @@ class TestVmapOperatorsOpInfo(TestCase):
                 "special.shifted_chebyshev_polynomial_w",
             }
             if op.name in sample_inputs_op:
-                sample_inputs_itr = op.sample_inputs(device, dtype, requires_grad=False)
+                sample_inputs_itr = op.sample_inputs(
+                    device, dtype, requires_grad=False, use_subtests=True
+                )
             else:
                 sample_inputs_itr = op.reference_inputs(
-                    device, dtype, requires_grad=False
+                    device, dtype, requires_grad=False, use_subtests=True
                 )
             aliases, inplace_aliases = discover_variants(op)
             check_shape_only = op.name in ("empty_like", "new_empty")
-            for sample_input in sample_inputs_itr:
-                args = (sample_input.input,) + sample_input.args
-                if not any(isinstance(arg, torch.Tensor) for arg in args):
-                    # Atleast one tensor required for vmap.
-                    continue
-                kwargs = sample_input.kwargs
-                is_batch_norm_and_training = is_batch_norm_training(op.name, kwargs)
-                out_dim = 0
-                if op.name == "NumpySplitCopyWithIntCustomOp":
-                    # special case for this custom op
-                    def sample_vmap_out_dim_numpy_split_copy_with_int(x, splits, dim):
-                        return [0 for _ in range(len(splits) + 1)], None
+            for sample_input, subtest_ctx in sample_inputs_itr:
+                with subtest_ctx(self):
+                    args = (sample_input.input,) + sample_input.args
+                    if not any(isinstance(arg, torch.Tensor) for arg in args):
+                        # Atleast one tensor required for vmap.
+                        continue
+                    kwargs = sample_input.kwargs
+                    is_batch_norm_and_training = is_batch_norm_training(op.name, kwargs)
+                    out_dim = 0
+                    if op.name == "NumpySplitCopyWithIntCustomOp":
+                        # special case for this custom op
+                        def sample_vmap_out_dim_numpy_split_copy_with_int(
+                            x, splits, dim
+                        ):
+                            return [0 for _ in range(len(splits) + 1)], None
 
-                    out_dim = sample_vmap_out_dim_numpy_split_copy_with_int(*args)
-                for batched_args, in_dims, _ in generate_vmap_inputs(
-                    args, {}, is_batch_norm_and_training=is_batch_norm_and_training
-                ):
-                    for func in aliases:
-                        self.vmap_outplace_test(
-                            func,
-                            batched_args,
-                            kwargs,
-                            in_dims,
-                            check_shape_only,
-                            postprocess_fn,
-                            out_dim=out_dim,
-                        )
-                    if op.name in skip_inplace:
-                        continue
-                    if not is_valid_inplace_sample_input(
-                        sample_input, op, op.inplace_variant
+                        out_dim = sample_vmap_out_dim_numpy_split_copy_with_int(*args)
+                    for batched_args, in_dims, _ in generate_vmap_inputs(
+                        args, {}, is_batch_norm_and_training=is_batch_norm_and_training
                     ):
-                        continue
-                    for func in inplace_aliases:
-                        self.vmap_inplace_test(
-                            func, batched_args, kwargs, in_dims, postprocess_fn
-                        )
+                        for func in aliases:
+                            self.vmap_outplace_test(
+                                func,
+                                batched_args,
+                                kwargs,
+                                in_dims,
+                                check_shape_only,
+                                postprocess_fn,
+                                out_dim=out_dim,
+                            )
+                        if op.name in skip_inplace:
+                            continue
+                        if not is_valid_inplace_sample_input(
+                            sample_input, op, op.inplace_variant
+                        ):
+                            continue
+                        for func in inplace_aliases:
+                            self.vmap_inplace_test(
+                                func, batched_args, kwargs, in_dims, postprocess_fn
+                            )
 
         if check_has_batch_rule:
             check_vmap_fallback(self, test, op)
@@ -4244,7 +4250,6 @@ class TestVmapOperatorsOpInfo(TestCase):
         skip(
             "linalg.eigh", ""
         ),  # not always return the same result for the same input, see test_linalg_eigh for manual test
-        skip("to"),  # RuntimeError: required rank 4 tensor to use channels_last format
         # UnimplementedError: data-dependent operators cannot be vmapped
         xfail("NumpyNonzeroCustomOp"),
         xfail("NumpyNMSCustomOp"),
@@ -4375,6 +4380,12 @@ class TestVmapOperatorsOpInfo(TestCase):
                 xfail("torch.ops.aten._efficient_attention_forward"),  # outputs ints
                 # TypeError: expected Tensor as element 0 in argument 0, but got float
                 xfail("item"),
+                xfailIf(
+                    "to",
+                    lambda sample: (
+                        sample.kwargs["memory_format"] == torch.channels_last
+                    ),
+                ),
             }
         ),
     )

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -8137,7 +8137,7 @@ BACKWARD_SAMPLE_RULES = [
     XFailRule(
         error_type=NotImplementedError,
         op_match_fn=lambda device, op: (op.full_name == "atanh"),
-        sample_match_fn=lambda device, sample: ("with_seqlen_cache" in sample.name,),
+        sample_match_fn=lambda device, sample: ("with_seqlen_cache" in sample.name),
         name="atanh_unimplemented_fill",
     ),
     # expected: autodiff on complex dtype is not supported

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -68,6 +68,7 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.opinfo.core import (
     BinaryUfuncInfo,
     ReductionOpInfo,
+    sample_skips_and_xfails,
     SkipRule,
     XFailRule,
 )
@@ -8377,14 +8378,14 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
     @ops(
         [op for op in njt_op_db if op.supports_njt],
         allowed_dtypes=(torch.float32,),
-        sample_skips_and_xfails=FORWARD_SKIPS_AND_XFAILS,
     )
-    def test_forward(self, device, dtype, op, sample_skips_and_xfails):
+    @sample_skips_and_xfails(FORWARD_SKIPS_AND_XFAILS)
+    def test_forward(self, device, dtype, op):
         for sample, subtest_ctx in op.sample_inputs(
             device=device,
             dtype=dtype,
             requires_grad=False,
-            sample_skips_and_xfails=sample_skips_and_xfails,
+            use_subtests=True,
         ):
             with subtest_ctx(self):
                 # compare to reference, but expect different nested int
@@ -8401,14 +8402,11 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
     @ops(
         [op for op in njt_op_db if op.supports_njt and op.supports_autograd],
         allowed_dtypes=(torch.float32,),
-        sample_skips_and_xfails=BACKWARD_SKIPS_AND_XFAILS,
     )
-    def test_backward(self, device, dtype, op, sample_skips_and_xfails):
+    @sample_skips_and_xfails(BACKWARD_SKIPS_AND_XFAILS)
+    def test_backward(self, device, dtype, op):
         for sample, subtest_ctx in op.sample_inputs(
-            device=device,
-            dtype=dtype,
-            requires_grad=True,
-            sample_skips_and_xfails=sample_skips_and_xfails,
+            device=device, dtype=dtype, requires_grad=True, use_subtests=True
         ):
             with subtest_ctx(self):
                 # compare to reference, but expect different nested int
@@ -8439,14 +8437,11 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
     @ops(
         [op for op in njt_op_db if op.supports_njt],
         allowed_dtypes=(torch.float32,),
-        sample_skips_and_xfails=COMPILE_FORWARD_SKIPS_AND_XFAILS,
     )
-    def test_compile_forward(self, device, dtype, op, sample_skips_and_xfails):
+    @sample_skips_and_xfails(COMPILE_FORWARD_SKIPS_AND_XFAILS)
+    def test_compile_forward(self, device, dtype, op):
         for sample, subtest_ctx in op.sample_inputs(
-            device=device,
-            dtype=dtype,
-            requires_grad=False,
-            sample_skips_and_xfails=sample_skips_and_xfails,
+            device=device, dtype=dtype, requires_grad=False, use_subtests=True
         ):
             with subtest_ctx(self):
                 torch.compiler.reset()
@@ -8498,15 +8493,12 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
     @ops(
         [op for op in njt_op_db if op.supports_njt and op.supports_autograd],
         allowed_dtypes=(torch.float32,),
-        sample_skips_and_xfails=COMPILE_BACKWARD_SKIPS_AND_XFAILS,
     )
     @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
-    def test_compile_backward(self, device, dtype, op, sample_skips_and_xfails):
+    @sample_skips_and_xfails(COMPILE_BACKWARD_SKIPS_AND_XFAILS)
+    def test_compile_backward(self, device, dtype, op):
         for sample, subtest_ctx in op.sample_inputs(
-            device=device,
-            dtype=dtype,
-            requires_grad=True,
-            sample_skips_and_xfails=sample_skips_and_xfails,
+            device=device, dtype=dtype, requires_grad=True, use_subtests=True
         ):
             with subtest_ctx(self):
                 torch.compiler.reset()

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1141,7 +1141,7 @@ class ops(_TestParametrizer):
                 # Construct parameter kwargs to pass to the test.
                 param_kwargs = {"op": op}
                 _update_param_kwargs(param_kwargs, "dtype", dtype)
-                # Filter sample rules to only apply those that match the op.
+                # Filter sample rules to only those that apply to the OpInfo.
                 sample_rules = (
                     None
                     if self.sample_rules is None

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1064,7 +1064,7 @@ class ops(_TestParametrizer):
         dtypes: Union[OpDTypes, Sequence[torch.dtype]] = OpDTypes.supported,
         allowed_dtypes: Optional[Sequence[torch.dtype]] = None,
         skip_if_dynamo=True,
-        sample_rules=None,
+        sample_skips_and_xfails=None,
     ):
         self.op_list = list(op_list)
         self.opinfo_dtypes = dtypes
@@ -1072,7 +1072,7 @@ class ops(_TestParametrizer):
             set(allowed_dtypes) if allowed_dtypes is not None else None
         )
         self.skip_if_dynamo = skip_if_dynamo
-        self.sample_rules = sample_rules
+        self.sample_skips_and_xfails = sample_skips_and_xfails
 
     def _parametrize_test(self, test, generic_cls, device_cls):
         """Parameterizes the given test function across each op and its associated dtypes."""
@@ -1141,18 +1141,18 @@ class ops(_TestParametrizer):
                 # Construct parameter kwargs to pass to the test.
                 param_kwargs = {"op": op}
                 _update_param_kwargs(param_kwargs, "dtype", dtype)
-                # Filter sample rules to only those that apply to the OpInfo.
-                sample_rules = (
+                # Filter sample skips / xfails to only those that apply to the OpInfo.
+                sample_skips_and_xfails = (
                     None
-                    if self.sample_rules is None
+                    if self.sample_skips_and_xfails is None
                     else [
                         rule
-                        for rule in self.sample_rules
+                        for rule in self.sample_skips_and_xfails
                         if rule.op_match_fn(device_cls.device_type, op)
                     ]
                 )
-                if sample_rules is not None:
-                    param_kwargs["sample_rules"] = sample_rules
+                if sample_skips_and_xfails is not None:
+                    param_kwargs["sample_skips_and_xfails"] = sample_skips_and_xfails
 
                 # NOTE: test_wrapper exists because we don't want to apply
                 #   op-specific decorators to the original test.

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -378,6 +378,10 @@ class TrackedInputIter:
         self.child_iter = enumerate(child_iter)
         # Input type describes the things we're tracking (e.g. "sample input", "error input").
         self.input_type_desc = input_type_desc
+        # NB: The two types of callbacks below exist because the thing we want to track isn't
+        # always the same as the thing we want returned from the iterator. An example of this
+        # is ErrorInput, which we want returned from the iterator, but which contains a
+        # SampleInput that we want to track.
         # Item callback is run on each (iterated thing, index) to get the thing to return.
         self.item_callback = item_callback
         if self.item_callback is None:

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -54,13 +54,6 @@ XS = 3
 _NOTHING = object()
 
 
-# Helper to combine multiple context managers into one
-@contextlib.contextmanager
-def _multi_context(*context_managers):
-    with contextlib.ExitStack() as stack:
-        yield (stack.enter_context(cm) for cm in context_managers)
-
-
 # Extension of getattr to support qualified names
 # e.g. _getattr_qual(torch, 'linalg.norm') -> torch.linalg.norm
 def _getattr_qual(obj, name, default=_NOTHING):

--- a/torch/testing/_internal/opinfo/definitions/nested.py
+++ b/torch/testing/_internal/opinfo/definitions/nested.py
@@ -1,89 +1,18 @@
 # mypy: ignore-errors
 
-import contextlib
-from abc import ABC, abstractmethod
 from copy import copy
-from dataclasses import dataclass
 from functools import partial
-from typing import Callable, TypeVar
 
 import torch
 from torch.fx.experimental.symbolic_shapes import is_nested_int
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.opinfo.core import (
     BinaryUfuncInfo,
-    OpInfo,
     ReductionOpInfo,
     SampleInput,
     UnaryUfuncInfo,
 )
 from torch.utils._pytree import tree_map
-
-
-# Represents a rule matching a particular set of tests. It allows granularity
-# at the device, dtype, op, and individual sample levels. This flexibility allows entire
-# bugs to be represented by a single rule, even if this corresponds with multiple conceptual
-# test cases across multiple ops.
-@dataclass
-class SampleRule(ABC):
-    # function to indicate whether the rule applies; return True if so
-    match_fn: Callable[[torch.device, torch.dtype, OpInfo, SampleInput], bool] = None
-    # optional name for identifying the rule
-    name: str = ""
-
-    def __post_init__(self):
-        if self.match_fn is None:
-            raise ValueError("rule must have match_fn set to be useful")
-
-    # returns True if the rule applies or False otherwise
-    def match(self, device, dtype, op, sample) -> bool:
-        return self.match_fn(device, dtype, op, sample)
-
-    # returns a string identifier of the rule type
-    @abstractmethod
-    def type(self) -> str:
-        ...
-
-    # returns an appropriate context that e.g. handles the xfail, skips, etc.
-    @abstractmethod
-    def get_context(self, test_case):
-        ...
-
-
-# useful for specifying xfails
-@dataclass
-class XFailRule(SampleRule):
-    # expected error type
-    error_type: TypeVar = Exception
-    # expected error message
-    error_msg: str = ".*"
-
-    @property
-    def type(self) -> str:
-        return "xfail"
-
-    def get_context(self, test_case):
-        return test_case.assertRaisesRegex(
-            # failing within torch.compile wraps within a BackendCompilerFailed
-            (self.error_type, torch._dynamo.exc.BackendCompilerFailed),
-            self.error_msg,
-        )
-
-
-# useful for specifying skips
-@dataclass
-class SkipRule(SampleRule):
-    @property
-    def type(self):
-        return "skip"
-
-    def get_context(self, test_case):
-        @contextlib.contextmanager
-        def skipcontext(test_case=test_case):
-            test_case.skipTest("Skipped!")
-            yield
-
-        return skipcontext()
 
 
 # random integer used for sizes


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #140161
* #140736
* __->__ #140443
* #138370
* #140160

### Background
This PR adds the functionality to xfail / skip on a per-`SampleInput` basis for `OpInfo` tests. See #89354 and #82669 for some requests asking for this type of functionality.

This was originally landed for NJT in #138370 and is generalized and slightly tweaked here.

### Design
#### Principles
* Clean separation among `SampleInput` generation logic, test logic that uses the `SampleInput`s, and xfail / skip logic (which will change as bugs are addressed).
* Flexibility in xfail / skip predicate specification - ideally each bug can be handled by a single skip / xfail, even if it surfaces across a specific class of ops.
    * This is important in practice for NJT, where it's common to have a bug that affects all binary ops, for example.
* Opt-in with minimal test logic changes + no substantial impact on other tests.

#### Details
The core new concept is a `SampleRule`, which can be either an `XFailRule` or `SkipRule`.

```python
@dataclass
class SampleRule(ABC):
    # function to indicate whether the rule applies to this op; return True if so
    # NB: str arg of callable is device_type
    op_match_fn: Callable[[str, OpInfo], bool] = None
    # function to indicate whether the rule applies to this sample; return True if so
    sample_match_fn: Callable[[torch.device, SampleInput], bool] = None
    # optional name for identifying the rule
    name: str = ""

@dataclass
class XFailRule(SampleRule):
    # expected error type
    error_type: TypeVar = Exception
    # expected error message
    error_msg: str = ".*"

@dataclass
class SkipRule(SampleRule):
    ...
```

* See below for example usage details, but at a high level: each test should have a corresponding list of `sample_skips_and_xfails`.
    * The list of `sample_skips_and_xfails` is traversed in order, and the first rule that matches (if any) is applied, so order can matter.
    * The PR includes a logging mechanism for matched rules accessible by setting the loglevel to `DEBUG`.
* The split between `op_match_fn` and `sample_match_fn` is made to allow pre-filtering of the list of rules to get only those that apply to the op under test.
* Each `SampleInput` is run within a subtest context so they can be individually skipped / xfailed as needed. This also means that a test will no longer stop after the first erroring `SampleInput`; all samples will be run through test logic.

### Example Usage
Consider the following OpInfo test:
```python
class MyTestCase(TestCase):
    @ops(op_db)
    def test_foo(self, device, dtype, op):
        for sample in op.sample_inputs(device, dtype, requires_grad=False):
            # do some SampleInput-based test logic
            output = op.op(sample.input, *sample.args, **sample.kwargs)
            ...
```

This is a common pattern for such tests; simply generate a list of `SampleInputs` and run them through the op. Now say you want to xfail one of these `SampleInput`s for a given op. Today, you have to xfail the entire test or hack around this in the test logic.

This PR lets you do this to get very flexible xfail / skips based on op / sample input properties:
```python
# NB: Define rules for per-SampleInput xfails / skips. These can also be defined in-line in the @ops decorator, but
# it can be more readable to maintain these somewhere else. These are attempted to be matched in order and 
# the first one that matches applies, so order can matter.
FOO_SKIPS_AND_XFAILS = [
    XFailRule(
        error_type=ValueError,
        error_mg="2D inputs not supported",
        op_match_fn=lambda device, op: (
            # NB: logic for which ops this rule applies to goes here
            op.full_name == "add"
        ),
        sample_match_fn=lambda device, sample: (
            # NB: logic which samples this rule applies to goes here
            sample.input.dim() == 2
        ),
        # NB: optional rule identifier can help with debugging matched rules
        name="add_with_2D_inputs_not_supported",
    ),
    # NB: This follows a similar structure as XFailRule but without error_type / error_msg. Obviously
    # this skips a particular SampleInput instead of xfailing :)
    SkipRule(...),
    ...
]

class MyTestCase(TestCase):
    @ops(op_db)
    @sample_skips_and_xfails(FOO_SKIPS_AND_XFAILS)
    # NB: the @ops decorator automatically filters out any rules that don't apply to this op
    def test_foo(self, device, dtype, op):
        for sample, subtest_ctx in op.sample_inputs(
            # NB: use_subtests=True is required for skips / xfails to work. If skips / xfails are defined and use_subtests != True,
            # an informative error will be thrown.
            device, dtype, requires_grad=False, use_subtests=True
        ):
            # NB: this subtest context manager runs each sample input as a "subtest" and handles skips / xfails appropriately
            with subtest_ctx(self):
                # do some SampleInput-based test logic
                output = op.op(sample.input, *sample.args, **sample.kwargs)
                ...
```

More examples can be seen in `test/test_nestedtensor.py`, where this system is used in practice.

I also demonstrate usage of syntactic sugar over this system in `test/functorch/test_vmap.py`. Here, a skip for the `to()` operator is replaced with a granular xfail for `test_vmap_exhaustive()`:
```python
...
# pre-existing xfail
xfail("item"),
# new granular xfail using syntactic sugar over the general system
xfailIf(
    "to",
    lambda sample: (
        sample.kwargs["memory_format"] == torch.channels_last
    ),
),
...
```