### PR TITLE
[TorchScript] bindings for torch._C.ClassType.method_names()

### DIFF
--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -1071,8 +1071,15 @@ void initPythonIRBindings(PyObject* module_) {
         return get_python_cu()->get_class(c10::QualifiedName(qualified_name));
       }))
       .def("name", [](ClassType& self) { return self.name()->name(); })
-      .def("qualified_name", [](ClassType& self) {
-        return self.name()->qualifiedName();
+      .def(
+          "qualified_name",
+          [](ClassType& self) { return self.name()->qualifiedName(); })
+      .def("method_names", [](ClassType& self) {
+        std::vector<std::string> method_names;
+        for (const auto* method : self.methods()) {
+          method_names.push_back(method->name());
+        }
+        return method_names;
       });
   py::class_<EnumType, Type, EnumTypePtr>(m, "EnumType")
       .def(py::init([](const std::string& qualified_name,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #140444

I used this for debugging, figured I'd upstream it.

This gives you a list of the method names provided by the given ClassType.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel