### PR TITLE
[AOTI][refactor] Switch remaining aoti_torch_get_data_ptr

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -336,13 +336,11 @@ class CppWrapperGpu(CppWrapperCpu):
                         var_name,
                     )
                 else:
+                    device_ptr_type = self.device_codegen.cpp_device_ptr()
                     self.writeline(
                         maybe_hipify_code_wrapper(
-                            f"{self.device_codegen.cpp_device_ptr()} {var_name};"
+                            f"{device_ptr_type} {var_name} = reinterpret_cast<{device_ptr_type}>({arg}.data_ptr());"
                         )
-                    )
-                    self.writeline(
-                        f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_data_ptr({arg}, reinterpret_cast<void**>(&{var_name})));"
                     )
             elif arg_type in (sympy.Integer, int):
                 self.writeline(f"int {var_name} = {self.expr_printer(arg)};")

--- a/torch/csrc/inductor/aoti_runtime/arrayref_tensor.h
+++ b/torch/csrc/inductor/aoti_runtime/arrayref_tensor.h
@@ -145,6 +145,7 @@ class MiniArrayRef final {
   /// continues to select the move assignment operator.
   template <typename U>
   std::enable_if_t<std::is_same_v<U, T>, MiniArrayRef<T>>& operator=(
+      // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
       U&& Temporary) = delete;
 
   /// Disallow accidental assignment from a temporary.
@@ -275,18 +276,6 @@ static_assert(
             (alignof(ArrayRefTensor<int>) > 4 ? sizeof(int32_t) : 0),
     "changing the size of ArrayRefTensor breaks ABI compatibility!");
 
-inline AtenTensorHandle reinterpret_tensor_wrapper(
-    AtenTensorHandle self,
-    int64_t ndim,
-    const int64_t* sizes_ptr,
-    const int64_t* strides_ptr,
-    int64_t storage_offset) {
-  AtenTensorHandle result = nullptr;
-  AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch__reinterpret_tensor(
-      self, ndim, sizes_ptr, strides_ptr, storage_offset, &result));
-  return result;
-}
-
 template <typename T>
 inline ArrayRefTensor<T> reinterpret_tensor_wrapper(
     const ArrayRefTensor<T>& self,
@@ -306,12 +295,6 @@ inline ArrayRefTensor<T> reinterpret_tensor_wrapper(
       self.device_idx());
 }
 
-inline void* get_data_ptr_wrapper(AtenTensorHandle tensor) {
-  void* result = nullptr;
-  AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_data_ptr(tensor, &result));
-  return result;
-}
-
 template <typename T>
 inline T* get_data_ptr_wrapper(ArrayRefTensor<T>& tensor) {
   return tensor.data();
@@ -320,11 +303,6 @@ inline T* get_data_ptr_wrapper(ArrayRefTensor<T>& tensor) {
 template <typename T>
 inline T* get_data_ptr_wrapper(const MiniArrayRef<T>& arr) {
   return arr.data();
-}
-
-inline AtenTensorHandle unwrap_raii_handle_if_needed(
-    const RAIIAtenTensorHandle& handle) {
-  return handle.get();
 }
 
 template <typename T>
@@ -337,11 +315,6 @@ template <typename T>
 inline ArrayRefTensor<T>& unwrap_raii_handle_if_needed(
     ArrayRefTensor<T>& tensor) {
   return tensor;
-}
-
-inline RAIIAtenTensorHandle wrap_with_raii_handle_if_needed(
-    AtenTensorHandle handle) {
-  return RAIIAtenTensorHandle(handle);
 }
 
 template <typename T>

--- a/torch/csrc/inductor/aoti_runtime/utils.h
+++ b/torch/csrc/inductor/aoti_runtime/utils.h
@@ -136,6 +136,34 @@ inline std::vector<RAIIAtenTensorHandle> steal_from_raw_handles_to_raii_handles(
   return result;
 }
 
+inline AtenTensorHandle reinterpret_tensor_wrapper(
+    AtenTensorHandle self,
+    int64_t ndim,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr,
+    int64_t storage_offset) {
+  AtenTensorHandle result = nullptr;
+  AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch__reinterpret_tensor(
+      self, ndim, sizes_ptr, strides_ptr, storage_offset, &result));
+  return result;
+}
+
+inline void* get_data_ptr_wrapper(AtenTensorHandle tensor) {
+  void* result = nullptr;
+  AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_data_ptr(tensor, &result));
+  return result;
+}
+
+inline AtenTensorHandle unwrap_raii_handle_if_needed(
+    const RAIIAtenTensorHandle& handle) {
+  return handle.get();
+}
+
+inline RAIIAtenTensorHandle wrap_with_raii_handle_if_needed(
+    AtenTensorHandle handle) {
+  return RAIIAtenTensorHandle(handle);
+}
+
 class ConstantHandle {
  public:
   ConstantHandle() = default;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #140449
* __->__ #140448
* #140447

Summary: https://github.com/pytorch/pytorch/pull/139895 added data_ptr(), but there is a remaining place in cpp_wrapper_gpu.py didn't switch over. Also moved a few AtenTensorHandle related utility functions from arrayref_tensor.h to utils.h.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang @aakhundov