### PR TITLE
[AOTI][refactor] Add sizes and strides util functions

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -274,10 +274,10 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 if isinstance(d, (int, sympy.Integer)):
                     self.prefix.splice(
                         f"""
-                            if ({d} != {name}_sizes[{dim_idx}]) {{
+                            if ({d} != {name}_size[{dim_idx}]) {{
                                 std::stringstream ss;
                                 ss << "{handle_kind}[{idx}]: unmatched dim value at {dim_idx}, "
-                                   << "expected: {d}, " << "but got: " << {name}_sizes[{dim_idx}]
+                                   << "expected: {d}, " << "but got: " << {name}_size[{dim_idx}]
                                    << "\\n";
                                 throw std::runtime_error(ss.str());
                             }}
@@ -290,11 +290,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
                     if not math.isinf(sym_range.lower):
                         self.prefix.splice(
                             f"""
-                                if ({name}_sizes[{dim_idx}] < {sym_range.lower}) {{
+                                if ({name}_size[{dim_idx}] < {sym_range.lower}) {{
                                     std::stringstream ss;
                                     ss << "{handle_kind}[{idx}]: dim value is too small at {dim_idx}, "
                                        << "expected it to be >= {sym_range.lower}, " << "but got: "
-                                       << {name}_sizes[{dim_idx}] << "\\n";
+                                       << {name}_size[{dim_idx}] << "\\n";
                                     throw std::runtime_error(ss.str());
                                 }}
                             """
@@ -302,11 +302,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
                     if not math.isinf(sym_range.upper):
                         self.prefix.splice(
                             f"""
-                                if ({name}_sizes[{dim_idx}] > {sym_range.upper}) {{
+                                if ({name}_size[{dim_idx}] > {sym_range.upper}) {{
                                     std::stringstream ss;
                                     ss << "{handle_kind}[{idx}]: dim value is too large at {dim_idx}, "
                                        << "expected to be <= {sym_range.upper}, " << "but got: "
-                                       << {name}_sizes[{dim_idx}] << "\\n";
+                                       << {name}_size[{dim_idx}] << "\\n";
                                     throw std::runtime_error(ss.str());
                                 }}
                             """
@@ -318,10 +318,10 @@ class CppWrapperCpu(PythonWrapperCodegen):
                     continue
                 self.prefix.splice(
                     f"""
-                        if ({s} != {name}_strides[{stride_idx}]) {{
+                        if ({s} != {name}_stride[{stride_idx}]) {{
                             std::stringstream ss;
                             ss << "{handle_kind}[{idx}]: unmatched stride value at {stride_idx}, "
-                               << "expected: {s}, " << "but got: " << {name}_strides[{stride_idx}]
+                               << "expected: {s}, " << "but got: " << {name}_stride[{stride_idx}]
                                << "\\n";
                             throw std::runtime_error(ss.str());
                         }}
@@ -489,10 +489,10 @@ class CppWrapperCpu(PythonWrapperCodegen):
         )
 
     def codegen_input_size_var_decl(self, code: IndentedBuffer, name):
-        code.writeline(f"int64_t* {name}_sizes = {name}.sizes();")
+        code.writeline(f"int64_t* {name}_size = {name}.sizes();")
 
     def codegen_input_stride_var_decl(self, code: IndentedBuffer, name):
-        code.writeline(f"int64_t* {name}_strides = {name}.strides();")
+        code.writeline(f"int64_t* {name}_stride = {name}.strides();")
 
     def codegen_model_kernels(self):
         self.prefix.writeline("namespace {")

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1160,12 +1160,12 @@ class PythonWrapperCodegen(CodeGen):
         @functools.lru_cache(None)
         def sizeof(name):
             self.codegen_input_size_var_decl(code, name)
-            return f"{name}_sizes"
+            return f"{name}_size"
 
         @functools.lru_cache(None)
         def strideof(name):
             self.codegen_input_stride_var_decl(code, name)
-            return f"{name}_strides"
+            return f"{name}_stride"
 
         # Assign all symbolic shapes needed to local variables
         bound_vars: Set[sympy.Symbol] = set()

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1160,12 +1160,12 @@ class PythonWrapperCodegen(CodeGen):
         @functools.lru_cache(None)
         def sizeof(name):
             self.codegen_input_size_var_decl(code, name)
-            return f"{name}_size"
+            return f"{name}_sizes"
 
         @functools.lru_cache(None)
         def strideof(name):
             self.codegen_input_stride_var_decl(code, name)
-            return f"{name}_stride"
+            return f"{name}_strides"
 
         # Assign all symbolic shapes needed to local variables
         bound_vars: Set[sympy.Symbol] = set()

--- a/torch/csrc/inductor/aoti_runtime/utils.h
+++ b/torch/csrc/inductor/aoti_runtime/utils.h
@@ -119,6 +119,18 @@ class RAIIAtenTensorHandle {
     return result;
   }
 
+  int64_t* sizes() const {
+    int64_t* result = nullptr;
+    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_sizes(handle_.get(), &result));
+    return result;
+  }
+
+  int64_t* strides() const {
+    int64_t* result = nullptr;
+    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_strides(handle_.get(), &result));
+    return result;
+  }
+
  private:
   std::unique_ptr<AtenTensorOpaque, DeleterFnPtr> handle_;
 };
@@ -186,6 +198,18 @@ class ConstantHandle {
 
   void* data_ptr() const {
     return data_;
+  }
+
+  int64_t* sizes() const {
+    int64_t* result = nullptr;
+    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_sizes(handle_, &result));
+    return result;
+  }
+
+  int64_t* strides() const {
+    int64_t* result = nullptr;
+    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_strides(handle_, &result));
+    return result;
   }
 
  private:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #140449
* #140448
* #140447

Summary: Similar to https://github.com/pytorch/pytorch/pull/139895, add sizes and strides methods to RAIIAtenTensorHandle and ConstantHandle, to increase the code readability.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang @aakhundov