### PR TITLE
Upload all run attempts when in upload_test_stats_intermediate

### DIFF
--- a/.github/workflows/upload_test_stats_intermediate.yml
+++ b/.github/workflows/upload_test_stats_intermediate.yml
@@ -6,9 +6,6 @@ on:
       workflow_id:
         description: workflow_id of the run
         required: true
-      workflow_run_attempt:
-        description: workflow_run_attempt of the run
-        required: true
 
 jobs:
   intermediate_upload_test_stats:
@@ -39,5 +36,4 @@ jobs:
           WORKFLOW_RUN_ATTEMPT: ${{ inputs.workflow_run_attempt }}
         run: |
           python3 -m tools.stats.upload_test_stats_intermediate \
-            --workflow-run-id "${WORKFLOW_RUN_ID}" \
-            --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" \
+            --workflow-run-id "${WORKFLOW_RUN_ID}"

--- a/.github/workflows/upload_test_stats_intermediate.yml
+++ b/.github/workflows/upload_test_stats_intermediate.yml
@@ -33,7 +33,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_RUN_ID: ${{ inputs.workflow_id }}
-          WORKFLOW_RUN_ATTEMPT: ${{ inputs.workflow_run_attempt }}
         run: |
           python3 -m tools.stats.upload_test_stats_intermediate \
             --workflow-run-id "${WORKFLOW_RUN_ID}"

--- a/tools/stats/test_dashboard.py
+++ b/tools/stats/test_dashboard.py
@@ -16,6 +16,7 @@ from tools.stats.upload_stats_lib import (
     _get_request_headers,
     download_s3_artifacts,
     get_job_id,
+    get_s3_resource,
     unzip,
     upload_workflow_stats_to_s3,
 )
@@ -157,6 +158,25 @@ def get_invoking_file_summary(grouped_tests: dict[str, Any]) -> dict[str, Any]:
                             ]["time"] += i["time"]
 
     return invoking_file_summary
+
+
+def get_all_run_attempts(workflow_run_id: int) -> list[int]:
+    # Returns all run attempts for a given workflow run id that have test
+    # artifacts
+    bucket = get_s3_resource().Bucket("gha-artifacts")
+    prefix = f"pytorch/pytorch/{workflow_run_id}/"
+    objs = bucket.objects.filter(
+        Prefix=prefix
+    )
+    run_attempts = set()
+    for obj in objs:
+        no_prefix = obj.key[len(prefix):]
+        try:
+            run_attempt = int(no_prefix.split("/")[0])
+            run_attempts.add(run_attempt)
+        except ValueError:
+            continue
+    return sorted(list(run_attempts))
 
 
 def upload_additional_info(

--- a/tools/stats/test_dashboard.py
+++ b/tools/stats/test_dashboard.py
@@ -165,18 +165,16 @@ def get_all_run_attempts(workflow_run_id: int) -> list[int]:
     # artifacts
     bucket = get_s3_resource().Bucket("gha-artifacts")
     prefix = f"pytorch/pytorch/{workflow_run_id}/"
-    objs = bucket.objects.filter(
-        Prefix=prefix
-    )
+    objs = bucket.objects.filter(Prefix=prefix)
     run_attempts = set()
     for obj in objs:
-        no_prefix = obj.key[len(prefix):]
+        no_prefix = obj.key[len(prefix) :]
         try:
             run_attempt = int(no_prefix.split("/")[0])
             run_attempts.add(run_attempt)
         except ValueError:
             continue
-    return sorted(list(run_attempts))
+    return sorted(run_attempts)
 
 
 def upload_additional_info(

--- a/tools/stats/upload_test_stats_intermediate.py
+++ b/tools/stats/upload_test_stats_intermediate.py
@@ -12,19 +12,16 @@ if __name__ == "__main__":
         required=True,
         help="id of the workflow to get artifacts from",
     )
-    parser.add_argument(
-        "--workflow-run-attempt",
-        type=int,
-        required=True,
-        help="which retry of the workflow this is",
-    )
     args = parser.parse_args()
 
     print(f"Workflow id is: {args.workflow_run_id}")
 
-    test_cases = get_tests(args.workflow_run_id, args.workflow_run_attempt)
+    run_attempts = get_all_run_attempts(args.workflow_run_id)
 
-    # Flush stdout so that any errors in the upload show up last in the logs.
-    sys.stdout.flush()
-
-    upload_additional_info(args.workflow_run_id, args.workflow_run_attempt, test_cases)
+    test_cases = []
+    for i in run_attempts:
+        test_cases = get_tests(args.workflow_run_id, i)
+        # Flush stdout so that any errors in the upload show up last in the
+        # logs.
+        sys.stdout.flush()
+        upload_additional_info(args.workflow_run_id, i, test_cases)

--- a/tools/stats/upload_test_stats_intermediate.py
+++ b/tools/stats/upload_test_stats_intermediate.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 
-from tools.stats.test_dashboard import upload_additional_info
+from tools.stats.test_dashboard import get_all_run_attempts, upload_additional_info
 from tools.stats.upload_test_stats import get_tests
 
 


### PR DESCRIPTION
Upload all run attempts since it can be hard to determine which run attempt to do from HUD, since HUD shows everything together