### PR TITLE
[SDPA] Allow user-specified priority order with context manager

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -122,6 +122,20 @@ void Context::setAllowTF32CuDNN(bool b) {
   allow_tf32_cudnn = b;
 }
 
+void Context::setSDPPriorityOrder(const std::vector<int64_t>& order) {
+  // TODO*eqy): should it always be the number of backends - 1 (override backend excluded?)
+  TORCH_CHECK(at::num_sdp_backends == sdp_priority_order.size(),
+    "setSDPPriority order expected ", sdp_priority_order.size() - 1, " but got ",
+    at::num_sdp_backends, " unique backends specified in priority order.");
+  for (uint32_t i = 0; i < order.size(); i++) {
+    sdp_priority_order[i] = (at::SDPBackend) order[i];
+  }
+}
+
+std::array<at::SDPBackend, at::num_sdp_backends> Context::sDPPriorityOrder() {
+  return sdp_priority_order;
+}
+
 bool Context::userEnabledFlashSDP() const {
   return enabled_flashSDP;
 }

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -388,10 +388,11 @@ class TORCH_API Context {
   bool _deterministic_algorithms = false;
   bool _deterministic_algorithms_warn_only = false;
   bool _deterministic_fill_uninitialized_memory = true;
-  std::array<at::SDPBackend, at::num_sdp_backends> sdp_priority_order = {at::SDPBackend::flash_attention,
-                                                                         at::SDPBackend::efficient_attention,
-                                                                         at::SDPBackend::math,
-                                                                         at::SDPBackend::cudnn_attention};
+  std::array<at::SDPBackend, at::num_sdp_backends> sdp_priority_order = {
+      at::SDPBackend::flash_attention,
+      at::SDPBackend::efficient_attention,
+      at::SDPBackend::math,
+      at::SDPBackend::cudnn_attention};
   bool enabled_flashSDP = true;
   bool enabled_mem_efficientSDP = true;
   bool enabled_mathSDP = true;

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -4,6 +4,7 @@
 #include <ATen/CPUGeneratorImpl.h>
 #include <ATen/DeviceAccelerator.h>
 #include <ATen/LinalgBackend.h>
+#include <ATen/SDPBackend.h>
 #include <ATen/core/ATenGeneral.h>
 #include <ATen/core/DeprecatedTypeProperties.h>
 #include <ATen/core/Generator.h>
@@ -210,6 +211,9 @@ class TORCH_API Context {
   // the math SDP kernel, you can force your code to use flash kernels.
   // The math SDP kernel can be disabled by setting
   // at::globalContext().setUserEnabledMathSDP(false) flag.
+  void setSDPPriorityOrder(const std::vector<int64_t>& order);
+  std::array<at::SDPBackend, at::num_sdp_backends> sDPPriorityOrder();
+
   void setSDPUseFlash(bool);
   bool userEnabledFlashSDP() const;
 
@@ -384,6 +388,10 @@ class TORCH_API Context {
   bool _deterministic_algorithms = false;
   bool _deterministic_algorithms_warn_only = false;
   bool _deterministic_fill_uninitialized_memory = true;
+  std::array<at::SDPBackend, at::num_sdp_backends> sdp_priority_order = {at::SDPBackend::flash_attention,
+                                                                         at::SDPBackend::efficient_attention,
+                                                                         at::SDPBackend::math,
+                                                                         at::SDPBackend::cudnn_attention};
   bool enabled_flashSDP = true;
   bool enabled_mem_efficientSDP = true;
   bool enabled_mathSDP = true;

--- a/aten/src/ATen/SDPBackend.h
+++ b/aten/src/ATen/SDPBackend.h
@@ -12,4 +12,4 @@ enum class SDPBackend {
   overrideable = 4
 };
 
-}
+} // namespace at

--- a/aten/src/ATen/SDPBackend.h
+++ b/aten/src/ATen/SDPBackend.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace at {
+
+constexpr int32_t num_sdp_backends = 5;
+enum class SDPBackend {
+  error = -1,
+  math = 0,
+  flash_attention = 1,
+  efficient_attention = 2,
+  cudnn_attention = 3,
+  overrideable = 4
+};
+
+}

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -75,13 +75,7 @@ bool check_prefer_cudnn_attention() {
 
 // flash_attention V2 is universally faster than efficient_attention and Math
 std::array<SDPBackend, num_backends> priority_order(sdp_params const& params) {
-  constexpr std::array<SDPBackend, num_backends> default_order{
-      SDPBackend::flash_attention,
-      SDPBackend::efficient_attention,
-      SDPBackend::math,
-      SDPBackend::cudnn_attention,
-      };
-  return default_order;
+  return at::globalContext().sDPPriorityOrder();
 }
 
 bool use_tensor_cores(sdp_params const& params, cudaDeviceProp* dprops, bool is_half) {

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -22,15 +22,8 @@
 
 namespace sdp {
 
-constexpr int32_t num_backends = 5;
-enum class SDPBackend {
-  error = -1,
-  math = 0,
-  flash_attention = 1,
-  efficient_attention = 2,
-  cudnn_attention = 3,
-  overrideable = 4
-};
+constexpr int32_t num_backends = at::num_sdp_backends;
+using SDPBackend = at::SDPBackend;
 
 // Note that if this changed make sure to update
 // the templated enum in mem_eff/kernel_forward.h and mem_eff/kernel_backward.h

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2947,6 +2947,35 @@ class TestSDPACudaOnly(NNTestCase):
             with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION, SDPBackend.MATH]):
                 assert torch._fused_sdp_choice(query, key, value) == SDPBackend.EFFICIENT_ATTENTION.value
 
+    @skipIfRocm
+    @onlyCUDA
+    @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cuDNN Attention is not supported on this system")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Platform does not support fused SDPA")
+    def test_fused_sdp_priority_order(self, device):
+        q = torch.randn(64, 8, 1024, 64, dtype=torch.half, device='cuda')
+        default_order = torch._C._get_sdp_priority_order()
+        orders = [[SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH, SDPBackend.EFFICIENT_ATTENTION],
+                  [SDPBackend.MATH, SDPBackend.CUDNN_ATTENTION, SDPBackend.EFFICIENT_ATTENTION],
+                  [SDPBackend.EFFICIENT_ATTENTION, SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH],
+                  [SDPBackend.FLASH_ATTENTION, SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH]]
+        import time
+        times = list()
+        for order in orders:
+            with sdpa_kernel(order, set_priority=True):
+                scaled_dot_product_attention(q, q, q)
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            with sdpa_kernel(order, set_priority=True):
+                scaled_dot_product_attention(q, q, q)
+            torch.cuda.synchronize()
+            t1 = time.perf_counter()
+            times.append(t1 - t0)
+        self.assertTrue(times[0] < times[1], "expected cuDNN SDPA to be faster than Math backend.")
+        self.assertTrue(times[1] > times[2], "expected Eff Attn backend to faster than Math backend.")
+        self.assertTrue(times[3] < times[2], "expected Flash Attn backend to faster than Math backend.")
+        reset_order = torch._C._get_sdp_priority_order()
+        self.assertEqual(default_order, reset_order, "expected SDPA context manager to reset priority order.")
+
     @skipIfRocm  # Missing deterministic algo
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Fused SDPA was not built for this system")
     @parametrize("fused_kernel", PLATFORM_SPECIFIC_SDPA)

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1163,7 +1163,7 @@ def _set_math_sdp_allow_fp16_bf16_reduction(arg: _bool) -> None: ...  # THPModul
 def _get_overrideable_sdp_enabled() -> _bool: ...  # THPModule_userEnabledOverrideableSDP
 def _set_sdp_use_overrideable(arg: _bool) -> None: ...  # THPModule_setSDPUseOverrideable
 def _get_sdp_priority_order() -> List[_int]: ... #THPModule_getSDPPriorityOrder
-def _set_sdp_priority_order(arg: List[_int]) -> None: #THPModule_setSDPPriorityOrder
+def _set_sdp_priority_order(arg: List[_int]) -> None: ... #THPModule_setSDPPriorityOrder
 def _get_cudnn_sdp_enabled() -> _bool: ...  # THPModule_userEnabledMathSDP
 def _set_sdp_use_cudnn(arg: _bool) -> None: ...  # THPModule_setSDPUseMath
 def _get_mkldnn_enabled() -> _bool: ...  # THPModule_userEnabledMkldnn

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1163,7 +1163,7 @@ def _set_math_sdp_allow_fp16_bf16_reduction(arg: _bool) -> None: ...  # THPModul
 def _get_overrideable_sdp_enabled() -> _bool: ...  # THPModule_userEnabledOverrideableSDP
 def _set_sdp_use_overrideable(arg: _bool) -> None: ...  # THPModule_setSDPUseOverrideable
 def _get_sdp_priority_order() -> List[_int]: ... #THPModule_getSDPPriorityOrder
-def _set_sdp_priority_order(List[_int]) -> None: #THPModule_setSDPPriorityOrder
+def _set_sdp_priority_order(arg: List[_int]) -> None: #THPModule_setSDPPriorityOrder
 def _get_cudnn_sdp_enabled() -> _bool: ...  # THPModule_userEnabledMathSDP
 def _set_sdp_use_cudnn(arg: _bool) -> None: ...  # THPModule_setSDPUseMath
 def _get_mkldnn_enabled() -> _bool: ...  # THPModule_userEnabledMkldnn

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1162,6 +1162,8 @@ def _get_math_sdp_allow_fp16_bf16_reduction() -> _bool: ...  # THPModule_allowFP
 def _set_math_sdp_allow_fp16_bf16_reduction(arg: _bool) -> None: ...  # THPModule_setAllowFP16BF16ReductionMathSDP
 def _get_overrideable_sdp_enabled() -> _bool: ...  # THPModule_userEnabledOverrideableSDP
 def _set_sdp_use_overrideable(arg: _bool) -> None: ...  # THPModule_setSDPUseOverrideable
+def _get_sdp_priority_order() -> List[_int]: ... #THPModule_getSDPPriorityOrder
+def _set_sdp_priority_order(List[_int]) -> None: #THPModule_setSDPPriorityOrder
 def _get_cudnn_sdp_enabled() -> _bool: ...  # THPModule_userEnabledMathSDP
 def _set_sdp_use_cudnn(arg: _bool) -> None: ...  # THPModule_setSDPUseMath
 def _get_mkldnn_enabled() -> _bool: ...  # THPModule_userEnabledMkldnn

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -704,7 +704,6 @@ static PyObject* THPModule_setSDPPriorityOrder(
 static PyObject* THPModule_sDPPriorityOrder(
     PyObject* _unused,
     PyObject* noargs) {
-
   auto ordervec = at::globalContext().sDPPriorityOrder();
   auto order =
       THPObjectPtr(PyList_New(static_cast<Py_ssize_t>(ordervec.size())));
@@ -715,7 +714,6 @@ static PyObject* THPModule_sDPPriorityOrder(
     PyList_SET_ITEM(order.get(), i, i64);
   }
   return order.release();
-
 }
 static PyObject* THPModule_setSDPUseFlash(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
@@ -1450,7 +1448,10 @@ static std::initializer_list<PyMethodDef> TorchMethods = {
      METH_NOARGS,
      nullptr},
     {"_set_sdp_priority_order", THPModule_setSDPPriorityOrder, METH_O, nullptr},
-    {"_get_sdp_priority_order", THPModule_sDPPriorityOrder, METH_NOARGS, nullptr},
+    {"_get_sdp_priority_order",
+     THPModule_sDPPriorityOrder,
+     METH_NOARGS,
+     nullptr},
     {"_set_sdp_use_flash", THPModule_setSDPUseFlash, METH_O, nullptr},
     {"_get_mem_efficient_sdp_enabled",
      userEnabledMemEfficientSDP,

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -692,14 +692,18 @@ static PyObject* THPModule_float32MatmulPrecision(
   }
   return THPUtils_packString(s);
 }
-static PyObject* THPModule_setSDPPriorityOrder(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setSDPPriorityOrder(
+    PyObject* _unused,
+    PyObject* arg) {
   HANDLE_TH_ERRORS
   auto priority_order = THPUtils_unpackLongs(arg);
   at::globalContext().setSDPPriorityOrder(priority_order);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
-static PyObject* THPModule_sDPPriorityOrder(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_sDPPriorityOrder(
+    PyObject* _unused,
+    PyObject* noargs) {
 
   auto ordervec = at::globalContext().sDPPriorityOrder();
   auto order =

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -692,6 +692,27 @@ static PyObject* THPModule_float32MatmulPrecision(
   }
   return THPUtils_packString(s);
 }
+static PyObject* THPModule_setSDPPriorityOrder(PyObject* _unused, PyObject* arg) {
+  HANDLE_TH_ERRORS
+  auto priority_order = THPUtils_unpackLongs(arg);
+  at::globalContext().setSDPPriorityOrder(priority_order);
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+static PyObject* THPModule_sDPPriorityOrder(PyObject* _unused, PyObject* noargs) {
+
+  auto ordervec = at::globalContext().sDPPriorityOrder();
+  auto order =
+      THPObjectPtr(PyList_New(static_cast<Py_ssize_t>(ordervec.size())));
+  for (const auto i : c10::irange(ordervec.size())) {
+    PyObject* i64 = THPUtils_packInt64(static_cast<int64_t>(ordervec[i]));
+    if (!i64)
+      return nullptr;
+    PyList_SET_ITEM(order.get(), i, i64);
+  }
+  return order.release();
+
+}
 static PyObject* THPModule_setSDPUseFlash(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
@@ -1424,6 +1445,8 @@ static std::initializer_list<PyMethodDef> TorchMethods = {
      THPModule_userEnabledFlashSDP,
      METH_NOARGS,
      nullptr},
+    {"_set_sdp_priority_order", THPModule_setSDPPriorityOrder, METH_O, nullptr},
+    {"_get_sdp_priority_order", THPModule_sDPPriorityOrder, METH_NOARGS, nullptr},
     {"_set_sdp_use_flash", THPModule_setSDPUseFlash, METH_O, nullptr},
     {"_get_mem_efficient_sdp_enabled",
      userEnabledMemEfficientSDP,

--- a/torch/nn/attention/__init__.py
+++ b/torch/nn/attention/__init__.py
@@ -129,7 +129,7 @@ def sdpa_kernel(
 
     if set_priority:
         user_priority = [
-            int(x) for idx, x in enumerate(backends) if backends.index(x) == idx # type: ignore[call-overload]
+            int(x) for idx, x in enumerate(backends) if backends.index(x) == idx  # type: ignore[call-overload]
         ]
         previous_priority = torch._C._get_sdp_priority_order()
         for backend in previous_priority:

--- a/torch/nn/attention/__init__.py
+++ b/torch/nn/attention/__init__.py
@@ -138,13 +138,13 @@ def sdpa_kernel(
     previous_backends = _cur_sdpa_kernel_backends()
     try:
         if set_priority:
-            torch._C._set_sdp_priority_order(user_priority)
+            torch._C._set_sdp_priority_order(user_priority) # type: ignore[arg-type]
         _sdpa_kernel(backends_set)
         yield {}
     finally:
         _sdpa_kernel(previous_backends)
         if set_priority:
-            torch._C._set_sdp_priority_order(previous_priority)
+            torch._C._set_sdp_priority_order(previous_priority) # type: ignore[arg-type]
 
 
 # variadic version of sdpa_kernel for dynamo to use while reconstructing

--- a/torch/nn/attention/__init__.py
+++ b/torch/nn/attention/__init__.py
@@ -124,10 +124,12 @@ def sdpa_kernel(
         backends = [backends]
 
     backends_set = set(backends)
+    user_priority = None
+    previous_priority = None
 
     if set_priority:
         user_priority = [
-            int(x) for idx, x in enumerate(backends) if backends.index(x) == idx
+            int(x) for idx, x in enumerate(backends) if backends.index(x) == idx # type: ignore[call-overload]
         ]
         previous_priority = torch._C._get_sdp_priority_order()
         for backend in previous_priority:

--- a/torch/nn/attention/__init__.py
+++ b/torch/nn/attention/__init__.py
@@ -138,13 +138,13 @@ def sdpa_kernel(
     previous_backends = _cur_sdpa_kernel_backends()
     try:
         if set_priority:
-            torch._C._set_sdp_priority_order(user_priority) # type: ignore[arg-type]
+            torch._C._set_sdp_priority_order(user_priority)  # type: ignore[arg-type]
         _sdpa_kernel(backends_set)
         yield {}
     finally:
         _sdpa_kernel(previous_backends)
         if set_priority:
-            torch._C._set_sdp_priority_order(previous_priority) # type: ignore[arg-type]
+            torch._C._set_sdp_priority_order(previous_priority)  # type: ignore[arg-type]
 
 
 # variadic version of sdpa_kernel for dynamo to use while reconstructing

--- a/torch/nn/attention/__init__.py
+++ b/torch/nn/attention/__init__.py
@@ -95,6 +95,7 @@ def sdpa_kernel(backends: Union[List[SDPBackend], SDPBackend], set_priority : bo
 
     Args:
         backends (Union[List[SDPBackend], SDPBackend]): A backend or list of backends for scaled dot product attention.
+        set_priority_order (bool=False): Whether the ordering of the backends is interpreted as their priority order.
 
     Example:
 

--- a/torch/nn/attention/__init__.py
+++ b/torch/nn/attention/__init__.py
@@ -87,7 +87,9 @@ def _sdpa_kernel(backends: Iterable[SDPBackend]):
 
 
 @contextlib.contextmanager
-def sdpa_kernel(backends: Union[List[SDPBackend], SDPBackend], set_priority : bool=False):
+def sdpa_kernel(
+    backends: Union[List[SDPBackend], SDPBackend], set_priority: bool = False
+):
     r"""
     Context manager to select which backend to use for scaled dot product attention.
 
@@ -124,7 +126,9 @@ def sdpa_kernel(backends: Union[List[SDPBackend], SDPBackend], set_priority : bo
     backends_set = set(backends)
 
     if set_priority:
-        user_priority = [int(x) for idx, x in enumerate(backends) if backends.index(x) == idx]
+        user_priority = [
+            int(x) for idx, x in enumerate(backends) if backends.index(x) == idx
+        ]
         previous_priority = torch._C._get_sdp_priority_order()
         for backend in previous_priority:
             if backend not in user_priority:


### PR DESCRIPTION
TODO: docs changes? 
For better debuggability of issues like https://github.com/pytorch/pytorch/issues/139298

Better testing, current sketch:

``` Python
import torch
from torch.nn.functional import scaled_dot_product_attention
from torch.nn.attention import SDPBackend, sdpa_kernel

q = torch.randn(64, 1024, 8, 64, dtype=torch.half, device='cuda')
print(torch._C._get_sdp_priority_order())

orders = [[SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH, SDPBackend.EFFICIENT_ATTENTION],
          [SDPBackend.MATH, SDPBackend.CUDNN_ATTENTION, SDPBackend.EFFICIENT_ATTENTION],
          [SDPBackend.EFFICIENT_ATTENTION, SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH]]
import time
times = list()
for order in orders:
    print(order)
    with sdpa_kernel(order, set_priority=True):
        scaled_dot_product_attention(q, q, q)
    torch.cuda.synchronize()
    t0 = time.perf_counter()
    with sdpa_kernel(order, set_priority=True):
        scaled_dot_product_attention(q, q, q)
    torch.cuda.synchronize()
    t1 = time.perf_counter()
    times.append(t1 - t0)
print(times)
assert times[0] < times[1]
assert times[0] > times[2]
assert times[1] > times[2]
print(torch._C._get_sdp_priority_order())
```

cc @csarofeen @ptrblck @xwang233 @drisspg @mikaylagawarecki