### PR TITLE
Add missing 'raise' in exception handling of metrics in the backwards

### DIFF
--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -2029,6 +2029,7 @@ To fix this, your tensor subclass must implement the dunder method __force_to_sa
                             # TODO(masnesral): Populating the exception info should be automatic.
                             fail_type = type(e).__qualname__
                             fail_reason = str(e)
+                            raise
                         finally:
                             # TODO(masnesral): Populating time fields should be automatic.
                             end_ns = time.time_ns()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #140490

Summary: https://github.com/pytorch/pytorch/pull/139849 moved the CompilationMetrics logging from dyanmo_timed to the backwards, but I missed a critical 'raise'