### PR TITLE
Add `cmake` to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ lintrunner ; platform_system != "Windows"
 ninja
 packaging
 optree>=0.13.0
+cmake


### PR DESCRIPTION
As one can not build PyTorch in clean venv if cmake is not installed
