### PR TITLE
fix test_save_load_transform.

### DIFF
--- a/test/distributions/test_transforms.py
+++ b/test/distributions/test_transforms.py
@@ -552,7 +552,10 @@ def test_save_load_transform():
     stream = io.BytesIO()
     torch.save(dist, stream)
     stream.seek(0)
-    other = torch.load(stream)
+    with torch.serialization.safe_globals(
+        [TransformedDistribution, AffineTransform, Normal]
+    ):
+        other = torch.load(stream)
     assert torch.allclose(log_prob, other.log_prob(x))
 
 


### PR DESCRIPTION
test test_save_load_transform in [test_transforms.py](https://github.com/pytorch/pytorch/blob/main/test/distributions/test_transforms.py)

_pytest test_transforms.py -k test_save_load_transform_

error message:

```
.
.
.
  File "/workspace/pytorch/test/distributions/test_transforms.py", line 555, in test_save_load_transform
    other = torch.load(stream)
            ^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/serialization.py", line 1444, in load
    raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
_pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
	(1) Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
	(2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
	WeightsUnpickler error: Unsupported global: GLOBAL torch.distributions.transformed_distribution.TransformedDistribution was not an allowed global by default. Please use `torch.serialization.add_safe_globals([TransformedDistribution])` or the `torch.serialization.safe_globals([TransformedDistribution])` context manager to allowlist this global if you trust this class/function.

```