### PR TITLE
OpenReg: Fix issue when creating empty tensor

### DIFF
--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/_device_daemon.py
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/_device_daemon.py
@@ -59,6 +59,10 @@ class Allocator:
                         storage_offset=0,
                     )
 
+        # Might be an empty tensor
+        if found_base is None and meta.nelem_in_bytes == 0:
+            found_base = torch.tensor((), dtype=torch.uint8)
+
         # This pointer is not allocated here, segfault !
         if found_base is None:
             log.info("Currently allocated blocks:\n %s", safe_str(self.allocated))

--- a/test/cpp_extensions/open_registration_extension/test/test_openreg.py
+++ b/test/cpp_extensions/open_registration_extension/test/test_openreg.py
@@ -125,6 +125,10 @@ class TestOpenReg(TestCase):
         self.assertEqual(y.to(device="cpu"), torch.tensor([[1, 1], [2, 2], [3, 3]]))
         self.assertEqual(x.data_ptr(), y.data_ptr())
 
+    def test_empty_tensor(self):
+        empty_tensor = torch.tensor((), device="openreg")
+        self.assertEqual(empty_tensor.to(device="cpu"), torch.tensor(()))
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
On the exeuctor side, when it is found that meta.data_ptr is not in the allocated memory, tensor creation will fail, but there is no need to allocate memory when creating an empty tensor.

cc @ezyang @albanD