### PR TITLE
[dyanmo] support subclasses of namedtuple type

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1892,6 +1892,9 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         def class_method(cls) -> str:
             return cls.__name__
 
+    class MyNamedTupleSubclass(MyNamedTuple):
+        pass
+
     @make_test
     def test_namedtuple_user_methods(a, b):
         mytuple = FunctionTests.MyNamedTuple(a, b)
@@ -1912,6 +1915,15 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
             return a + b
         else:
             return a - b
+
+    @make_test
+    def test_namedtuple_subclass(a, b):
+        mytuple = FunctionTests.MyNamedTupleSubclass(a, b)
+        mytuple.x = a
+        mytuple.y = b
+        mytuple.z = b
+        mytuple.z = a
+        return hasattr(mytuple, "x"), mytuple.x + mytuple.y, mytuple.z
 
     @make_test
     def test_torch_size_hasattr(x):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1410,9 +1410,8 @@ def is_namedtuple_cls(cls):
                     # This is a namedtuple type directly created by `collections.namedtuple(...)`
                     return True
                 if (
-                    len(cls.__bases__) >= 2
-                    and cls.__bases__[-1] is tuple
-                    and is_namedtuple_cls(cls.__bases__[0])
+                    # Subclass of namedtuple
+                    is_namedtuple_cls(cls.__bases__[0])
                     # For subclasses of namedtuple, the __new__ method should not be customized
                     and cls.__new__ is cls.__bases__[0].__new__
                 ):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1740,6 +1740,7 @@ class BuiltinVariable(VariableTracker):
             (
                 variables.CustomizedDictVariable,
                 variables.PlacementVariable,
+                variables.NamedTupleVariable,
                 variables.UserDefinedObjectVariable,
             ),
         ):

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -748,20 +748,25 @@ class SizeVariable(TupleVariable):
 class NamedTupleVariable(TupleVariable):
     _nonvar_fields = {
         "tuple_cls",
+        "dynamic_attributes",
         *TupleVariable._nonvar_fields,
     }
 
     def __init__(self, items, tuple_cls, **kwargs) -> None:
         super().__init__(items, **kwargs)
         self.tuple_cls = tuple_cls
+        self.dynamic_attributes = {}
 
     def is_namedtuple(self):
-        return hasattr(self.tuple_cls, "_fields") and callable(
+        return isinstance(getattr(self.tuple_cls, "_fields", None), tuple) and callable(
             getattr(self.tuple_cls, "_make", None)
         )
 
     def is_structseq(self):
         return not self.is_namedtuple()
+
+    def fields(self):
+        return namedtuple_fields(self.tuple_cls)
 
     def debug_repr(self):
         if self.is_structseq():
@@ -805,6 +810,33 @@ class NamedTupleVariable(TupleVariable):
             + create_call_function(1, False)
         )
 
+    def call_method(
+        self,
+        tx,
+        name,
+        args: List[VariableTracker],
+        kwargs: Dict[str, VariableTracker],
+    ) -> VariableTracker:
+        if name == "__setattr__":
+            assert len(args) == 2
+            assert len(kwargs) == 0
+            attr, value = args
+            attr = attr.as_python_constant()
+            if (
+                # structseq is immutable
+                self.is_structseq()
+                # namedtuple directly created by `collections.namedtuple` is immutable
+                or self.tuple_cls.__bases__ == (tuple,)
+                # fields are immutable
+                or attr in self.fields()
+            ):
+                raise_observed_exception(AttributeError, tx)
+            # Subclass of namedtuple type can have dynamic attributes
+            tx.output.side_effects.mutation(self)
+            self.dynamic_attributes[attr] = value
+            return ConstantVariable.create(None)
+        return super().call_method(tx, name, args, kwargs)
+
     def var_getattr(self, tx: "InstructionTranslator", name):
         def check_and_create_method():
             method = inspect.getattr_static(self.tuple_cls, name, None)
@@ -821,7 +853,10 @@ class NamedTupleVariable(TupleVariable):
             else:
                 return None
 
-        fields = namedtuple_fields(self.tuple_cls)
+        if name in self.dynamic_attributes:
+            return self.dynamic_attributes[name]
+
+        fields = self.fields()
         if name not in fields:
             method = check_and_create_method()
             if not method:
@@ -830,7 +865,9 @@ class NamedTupleVariable(TupleVariable):
         return self.items[fields.index(name)]
 
     def call_hasattr(self, tx: "InstructionTranslator", name: str) -> "VariableTracker":
-        return variables.ConstantVariable.create(hasattr(self.tuple_cls, name))
+        return variables.ConstantVariable.create(
+            name in self.dynamic_attributes or hasattr(self.tuple_cls, name)
+        )
 
 
 class SliceVariable(BaseListVariable):


### PR DESCRIPTION
Allow subclassing namedtuple type. Allow assign attributes to instances of these subtypes.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #140534



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames