### PR TITLE
Revert D65857711: Multisect successfully blamed "D65857711: Allow NJT by default for weights_only torch.load (#140304)" for one test failure

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -3712,8 +3712,21 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
 
         with tempfile.TemporaryFile() as f:
             torch.save(nt, f)
+            safe_globals = [
+                torch.nested._internal.nested_tensor.NestedTensor,
+                torch.nested._internal.nested_tensor._rebuild_njt,
+                set,
+                torch._dynamo.decorators._DimRange,
+            ]
             f.seek(0)
-            nt_loaded = torch.load(f, weights_only=weights_only)
+            ctx = (
+                torch.serialization.safe_globals(safe_globals)
+                if weights_only
+                else contextlib.nullcontext()
+            )
+
+            with ctx:
+                nt_loaded = torch.load(f, weights_only=weights_only)
 
             self.assertIsNot(nt, nt_loaded)
             # we expect a new offsets tensor -> different nested int upon load

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -182,16 +182,6 @@ def _get_allowed_globals():
             "torch.distributed.tensor.placement_types.Shard": torch.distributed.tensor.placement_types.Shard,
         }
         rc.update(dtensor_rc)
-
-    # nested tensor related
-    rc["torch.nested._internal.nested_tensor.NestedTensor"] = (
-        torch.nested._internal.nested_tensor.NestedTensor
-    )
-    rc["torch.nested._internal.nested_tensor._rebuild_njt"] = (
-        torch.nested._internal.nested_tensor._rebuild_njt
-    )
-    rc["torch._dynamo.decorators._DimRange"] = torch._dynamo.decorators._DimRange
-
     # dtype
     for t in torch.storage._dtype_to_storage_type_map().keys():
         rc[str(t)] = t


### PR DESCRIPTION
Summary:
This diff reverts D65857711
D65857711: Allow NJT by default for weights_only torch.load (#140304) by mikaylagawarecki causes the following test failure:

Tests affected:
- [cogwheel:cogwheel_conductor#main](https://www.internalfb.com/intern/test/844425041013411/)

Here's the Multisect link:
https://www.internalfb.com/multisect/13930544
Here are the tasks that are relevant to this breakage:
T191385495: 10+ CI signals unhealthy for frl_conductor

The backout may land if someone accepts it.

If this diff has been generated in error, you can Commandeer and Abandon it.

Test Plan: NA

Differential Revision: D65876086


