### PR TITLE
fix: Add type annotation to _record_memory_history

### DIFF
--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -8,7 +8,7 @@ import pickle
 import sys
 import warnings
 from inspect import signature
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Literal, Optional, Tuple, Union
 from typing_extensions import deprecated
 
 import torch
@@ -738,7 +738,7 @@ def _record_memory_history_legacy(
     )
 
 
-def _record_memory_history(enabled="all", *args, **kwargs):
+def _record_memory_history(enabled: Literal[None, "state", "all"] = "all", *args, **kwargs):
     """Enable recording of stack traces associated with memory
     allocations, so you can tell what allocated any piece of memory in
     :func:`torch.cuda.memory._snapshot()`.

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -738,7 +738,9 @@ def _record_memory_history_legacy(
     )
 
 
-def _record_memory_history(enabled: Literal[None, "state", "all"] = "all", *args, **kwargs) -> None:
+def _record_memory_history(
+    enabled: Literal[None, "state", "all"] = "all", *args, **kwargs
+) -> None:
     """Enable recording of stack traces associated with memory
     allocations, so you can tell what allocated any piece of memory in
     :func:`torch.cuda.memory._snapshot()`.

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -738,7 +738,7 @@ def _record_memory_history_legacy(
     )
 
 
-def _record_memory_history(enabled: Literal[None, "state", "all"] = "all", *args, **kwargs):
+def _record_memory_history(enabled: Literal[None, "state", "all"] = "all", *args, **kwargs) -> None:
     """Enable recording of stack traces associated with memory
     allocations, so you can tell what allocated any piece of memory in
     :func:`torch.cuda.memory._snapshot()`.


### PR DESCRIPTION
Pylance infers the type of the first argument (`enabled`) to `_record_memory_history` as `str` even though the function accepts `Literal[None, "state", "all"]`.

This raises an issue when passing `None`, even though it is a legitimate argument.

This PR addresses the issue by adding the type annotation in the doc string.

cc @ezyang @malfet @xuzhao9 @gramster