### PR TITLE
Skipped some test_torchinductor tests for no hipcc rocm environments

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -87,6 +87,7 @@ from torch.testing._internal.common_utils import (
     subtest,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
+    HAS_HIPCC,
 )
 from torch.utils import _pytree as pytree
 from torch.utils._python_dispatch import TorchDispatchMode
@@ -119,6 +120,8 @@ from torch.testing._internal.inductor_utils import (
 
 
 HAS_AVX2 = "fbgemm" in torch.backends.quantized.supported_engines
+
+ROCM_WHEELS_ENV = TEST_WITH_ROCM and not HAS_HIPCC
 
 aten = torch.ops.aten
 
@@ -973,6 +976,7 @@ class CommonTemplate:
                 self.assertEqual(ref_value, res_value)
 
     @skipCUDAIf(not SM80OrLater, "Requires sm80")
+    @skipCUDAIf(ROCM_WHEELS_ENV, "ROCm requires hipcc compiler")
     @skip_if_halide  # aoti
     @skip_if_triton_cpu  # aoti
     @skipIfWindows(msg="aoti not support on Windows")
@@ -1017,6 +1021,7 @@ class CommonTemplate:
                 self.assertEqual(ref_value, res_value)
 
     @skipCUDAIf(not SM80OrLater, "Requires sm80")
+    @skipCUDAIf(ROCM_WHEELS_ENV, "ROCm requires hipcc compiler")
     @skip_if_halide  # aoti
     @skip_if_triton_cpu  # aoti
     @skipIfWindows(msg="aoti not support on Windows")

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -121,8 +121,6 @@ from torch.testing._internal.inductor_utils import (
 
 HAS_AVX2 = "fbgemm" in torch.backends.quantized.supported_engines
 
-ROCM_WHEELS_ENV = TEST_WITH_ROCM and not HAS_HIPCC
-
 aten = torch.ops.aten
 
 requires_multigpu = functools.partial(
@@ -976,7 +974,7 @@ class CommonTemplate:
                 self.assertEqual(ref_value, res_value)
 
     @skipCUDAIf(not SM80OrLater, "Requires sm80")
-    @skipCUDAIf(ROCM_WHEELS_ENV, "ROCm requires hipcc compiler")
+    @skipCUDAIf(TEST_WITH_ROCM and not HAS_HIPCC, "ROCm requires hipcc compiler")
     @skip_if_halide  # aoti
     @skip_if_triton_cpu  # aoti
     @skipIfWindows(msg="aoti not support on Windows")
@@ -1021,7 +1019,7 @@ class CommonTemplate:
                 self.assertEqual(ref_value, res_value)
 
     @skipCUDAIf(not SM80OrLater, "Requires sm80")
-    @skipCUDAIf(ROCM_WHEELS_ENV, "ROCm requires hipcc compiler")
+    @skipCUDAIf(TEST_WITH_ROCM and not HAS_HIPCC, "ROCm requires hipcc compiler")
     @skip_if_halide  # aoti
     @skip_if_triton_cpu  # aoti
     @skipIfWindows(msg="aoti not support on Windows")

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -96,6 +96,7 @@ from torch.testing._comparison import (
 from torch.testing._comparison import not_close_error_metas
 from torch.testing._internal.common_dtype import get_all_dtypes
 from torch.utils._import_utils import _check_module_exists
+from torch.utils.cpp_extension import ROCM_HOME
 import torch.utils._pytree as pytree
 try:
     import pytest
@@ -105,6 +106,8 @@ except ImportError:
 
 
 MI300_ARCH = ("gfx940", "gfx941", "gfx942")
+
+HAS_HIPCC = torch.version.hip is not None and ROCM_HOME is not None
 
 
 def freeze_rng_state(*args, **kwargs):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -107,7 +107,7 @@ except ImportError:
 
 MI300_ARCH = ("gfx940", "gfx941", "gfx942")
 
-HAS_HIPCC = torch.version.hip is not None and ROCM_HOME is not None
+HAS_HIPCC = torch.version.hip is not None and ROCM_HOME is not None and shutil.which('hipcc') is not None
 
 
 def freeze_rng_state(*args, **kwargs):


### PR DESCRIPTION
Since there can be no hipcc compiler in some ROCm environments we need to skip some tests from test_torchinductor.py


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov