### PR TITLE
Add C10_EMBEDDED to gate ostream usage in Half/BFloat16

### DIFF
--- a/c10/util/BFloat16.h
+++ b/c10/util/BFloat16.h
@@ -8,7 +8,9 @@
 #include <cstdint>
 #include <cstring>
 #include <iosfwd>
+#ifndef C10_EMBEDDED
 #include <ostream>
+#endif // C10_EMBEDDED
 
 #if defined(__CUDACC__) && !defined(USE_ROCM)
 #include <cuda_bf16.h>
@@ -114,12 +116,14 @@ struct alignas(2) BFloat16 {
 #endif
 };
 
+#ifndef C10_EMBEDDED
 C10_API inline std::ostream& operator<<(
     std::ostream& out,
     const BFloat16& value) {
   out << (float)value;
   return out;
 }
+#endif // C10_EMBEDDED
 
 } // namespace c10
 

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -30,7 +30,9 @@
 #include <cstring>
 #include <iosfwd>
 #include <limits>
+#ifndef C10_EMBEDDED
 #include <ostream>
+#endif // C10_EMBEDDED
 
 #ifdef __CUDACC__
 #include <cuda_fp16.h>
@@ -385,10 +387,12 @@ struct alignas(2) Half {
 #endif
 };
 
+#ifndef C10_EMBEDDED
 C10_API inline std::ostream& operator<<(std::ostream& out, const Half& value) {
   out << (float)value;
   return out;
 }
+#endif // C10_EMBEDDED
 
 } // namespace c10
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #140720
* #140567
* __->__ #140566
* #140565
* #140564

We want to use Half/BFloat16 in ExecuTorch to support shared kernel code. They will need to be used in ExecuTorch core, so they can't have streams. This diff introduces a macro to gate the stream code off.

Differential Revision: [D65888035](https://our.internmc.facebook.com/intern/diff/D65888035/)