### PR TITLE
Remove UB type punning from c10/util/floating_point_utils.h

### DIFF
--- a/c10/util/floating_point_utils.h
+++ b/c10/util/floating_point_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/macros/Macros.h>
+#include <c10/util/bit_cast.h>
 #include <cstdint>
 
 namespace c10::detail {
@@ -13,11 +14,7 @@ C10_HOST_DEVICE inline float fp32_from_bits(uint32_t w) {
 #elif defined(__INTEL_COMPILER)
   return _castu32_f32(w);
 #else
-  union {
-    uint32_t as_bits;
-    float as_value;
-  } fp32 = {w};
-  return fp32.as_value;
+  return c10::bit_cast<float>(w);
 #endif
 }
 
@@ -29,11 +26,7 @@ C10_HOST_DEVICE inline uint32_t fp32_to_bits(float f) {
 #elif defined(__INTEL_COMPILER)
   return _castf32_u32(f);
 #else
-  union {
-    float as_value;
-    uint32_t as_bits;
-  } fp32 = {f};
-  return fp32.as_bits;
+  return c10::bit_cast<uint32_t>(f);
 #endif
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #140720
* __->__ #140567
* #140566
* #140565
* #140564

Accessing the inactive member of a union is undefined behavior. Fortunately, we have c10::bit_cast.

Differential Revision: [D65888680](https://our.internmc.facebook.com/intern/diff/D65888680/)