### PR TITLE
Register AVX512 versions of fp16/bf16 gemv/dot kernels

### DIFF
--- a/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp
@@ -474,10 +474,10 @@ void bf16_gemv_trans(
 } // namespace CPU_CAPABILITY
 
 #if !defined(C10_MOBILE)
-REGISTER_DISPATCH(fp16_dot_with_fp32_arith_stub, &fp16_dot_with_fp32_arith)
-REGISTER_DISPATCH(fp16_gemv_trans_stub, &fp16_gemv_trans)
-REGISTER_DISPATCH(bf16_dot_with_fp32_arith_stub, &bf16_dot_with_fp32_arith);
-REGISTER_DISPATCH(bf16_gemv_trans_stub, &bf16_gemv_trans);
+ALSO_REGISTER_AVX512_DISPATCH(fp16_dot_with_fp32_arith_stub, &fp16_dot_with_fp32_arith)
+ALSO_REGISTER_AVX512_DISPATCH(fp16_gemv_trans_stub, &fp16_gemv_trans)
+ALSO_REGISTER_AVX512_DISPATCH(bf16_dot_with_fp32_arith_stub, &bf16_dot_with_fp32_arith);
+ALSO_REGISTER_AVX512_DISPATCH(bf16_gemv_trans_stub, &bf16_gemv_trans);
 #endif //!defined(C10_MOBILE)
 
 } // namespace at::native


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #140605

Longer vectors should be better. I forgot we have to opt into AVX512.

Differential Revision: [D65904404](https://our.internmc.facebook.com/intern/diff/D65904404/)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10