### PR TITLE
Add boolean conversion support for SymNodeVariable

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -6675,6 +6675,7 @@ class GraphModule(torch.nn.Module):
 
     def test_bool_conversion_symnode(self):
         import torch._dynamo.config
+
         torch._dynamo.config.capture_scalar_outputs = True
 
         class BoolConversionModule(torch.nn.Module):

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -6673,6 +6673,29 @@ class GraphModule(torch.nn.Module):
         actual = opt(x)
         self.assertEqual(expected, actual)
 
+    def test_bool_conversion_symnode(self):
+        import torch._dynamo.config
+        torch._dynamo.config.capture_scalar_outputs = True
+
+        class BoolConversionModule(torch.nn.Module):
+            def forward(self, x):
+                # Test both tensor ops and bool conversion
+                return bool(x.eq(0.1).any().item())
+
+        model = BoolConversionModule()
+        cnt = CompileCounter()
+        traced = torch.compile(model, backend=cnt)
+
+        # Test True case
+        x_true = torch.ones(64) * 0.1
+        result_true = traced(x_true)
+        self.assertTrue(result_true)
+
+        # Test False case
+        x_false = torch.zeros(64)
+        result_false = traced(x_false)
+        self.assertFalse(result_false)
+
 
 class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
     def _validate(self, fn, backend, *args, skip_check=False, fullgraph=True):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -2081,11 +2081,12 @@ def dynamo_disable_grad(tx):
     finally:
         gmv.exit(tx)
 
+
 def bool_handler(tx, args, kwargs):
     if not kwargs and len(args) == 1:
         arg = args[0]
         if isinstance(arg, SymNodeVariable):
-            # Use the __bool__ implementation added in tensor.py
-            return arg.__bool__()
+            # Handle tensor-to-bool conversion directly in the handler
+            return arg.call_method(tx, "item", [], {}) != 0
     # Fall back to default bool behavior
     return variables.base.BuiltinVariable(bool).call_function(tx, args, kwargs)

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -445,7 +445,7 @@ class BuiltinVariable(VariableTracker):
         # List-like expansion (e.g. [1, 2, 3] * 3)
         def expand_list_like(tx: "InstructionTranslator", lst, const):
             if isinstance(lst, ConstantVariable):
-                lst, const = const, lst
+                lst, const = const
             return lst.__class__(
                 items=lst.items * const.as_python_constant(),
                 mutation_type=ValueMutationNew(),
@@ -2080,3 +2080,12 @@ def dynamo_disable_grad(tx):
         yield
     finally:
         gmv.exit(tx)
+
+def bool_handler(tx, args, kwargs):
+    if not kwargs and len(args) == 1:
+        arg = args[0]
+        if isinstance(arg, SymNodeVariable):
+            # Use the __bool__ implementation added in tensor.py
+            return arg.__bool__()
+    # Fall back to default bool behavior
+    return variables.base.BuiltinVariable(bool).call_function(tx, args, kwargs)

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1171,6 +1171,9 @@ class SymNodeVariable(VariableTracker):
 
         return SymNodeVariable(proxy, sym_num, **options)
 
+    def __bool__(self):
+        return self.call_method(InstructionTranslator.current_tx(), 'item', [], {}) != 0
+
     def __init__(self, proxy, sym_num, **kwargs) -> None:
         super().__init__(**kwargs)
         self.proxy = proxy

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1171,9 +1171,6 @@ class SymNodeVariable(VariableTracker):
 
         return SymNodeVariable(proxy, sym_num, **options)
 
-    def __bool__(self):
-        return self.call_method(InstructionTranslator.current_tx(), 'item', [], {}) != 0
-
     def __init__(self, proxy, sym_num, **kwargs) -> None:
         super().__init__(**kwargs)
         self.proxy = proxy


### PR DESCRIPTION
Adds support for boolean conversion of tensor operations involving SymNodeVariable, fixing the "Unsupported: builtin: bool [SymNodeVariable]" error.

Changes:
- Implement bool_handler in builtin operations to handle SymNodeVariable
- Add test coverage for boolean conversion scenarios

## Testing
- Added test case in test_higher_order_ops.py verifying both tensor ops and explicit bool conversion
- Test covers both True and False cases with different tensor inputs

![Test result](https://cdn.discordapp.com/attachments/1160427026839257133/1307087729019846736/Screenshot_2024-11-15_at_12.59.26_PM.png?ex=673907cf&is=6737b64f&hm=518aa63de9afe19c6c2c7917dc04c9a4cacb924439e2e21c0c745cf797d1f733&)

Fixes [#136075](https://github.com/pytorch/pytorch/issues/136075)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames