### PR TITLE
[ez] Make merge blocking sevs be based on label instead of string

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci-sev.md
+++ b/.github/ISSUE_TEMPLATE/ci-sev.md
@@ -1,8 +1,9 @@
 ---
 name: "⚠️ CI SEV"
 about: Tracking incidents for PyTorch's CI infra.
-label: ["ci: sev"]
 ---
+
+> NOTE: Remember to label this issue with "`ci: sev`"
 
  <!-- Add the `merge blocking` label to this PR to prevent PRs from being merged while this issue is open -->
 

--- a/.github/ISSUE_TEMPLATE/ci-sev.md
+++ b/.github/ISSUE_TEMPLATE/ci-sev.md
@@ -1,12 +1,10 @@
 ---
 name: "⚠️ CI SEV"
 about: Tracking incidents for PyTorch's CI infra.
+label: ["ci: sev"]
 ---
 
-> NOTE: Remember to label this issue with "`ci: sev`"
-
- <!-- uncomment the below line if you don't want this SEV to block merges -->
- <!--  **MERGE BLOCKING** -->
+ <!-- Add the `merge blocking` label to this PR to prevent PRs from being merged while this issue is open -->
 
 ## Current Status
 *Status could be: preemptive, ongoing, mitigated, closed. Also tell people if they need to take action to fix it (i.e. rebase)*.

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -2005,17 +2005,16 @@ def check_for_sev(org: str, project: str, skip_mandatory_checks: bool) -> None:
         Dict[str, Any],
         gh_fetch_json_list(
             "https://api.github.com/search/issues",
-            params={"q": f'repo:{org}/{project} is:open is:issue label:"ci: sev"'},
+            # Having two label: queries is an AND operation
+            params={"q": f'repo:{org}/{project} is:open is:issue label:"ci: sev" label:"merge blocking"'},
         ),
     )
     if response["total_count"] != 0:
-        for item in response["items"]:
-            if "MERGE BLOCKING" in item["body"]:
-                raise RuntimeError(
-                    "Not merging any PRs at the moment because there is a "
-                    + "merge blocking https://github.com/pytorch/pytorch/labels/ci:%20sev issue open at: \n"
-                    + f"{item['html_url']}"
-                )
+        raise RuntimeError(
+            "Not merging any PRs at the moment because there is a "
+            + "merge blocking https://github.com/pytorch/pytorch/labels/ci:%20sev issue open at: \n"
+            + f"{response['items'][0]['html_url']}"
+        )
     return
 
 

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -2006,7 +2006,9 @@ def check_for_sev(org: str, project: str, skip_mandatory_checks: bool) -> None:
         gh_fetch_json_list(
             "https://api.github.com/search/issues",
             # Having two label: queries is an AND operation
-            params={"q": f'repo:{org}/{project} is:open is:issue label:"ci: sev" label:"merge blocking"'},
+            params={
+                "q": f'repo:{org}/{project} is:open is:issue label:"ci: sev" label:"merge blocking"'
+            },
         ),
     )
     if response["total_count"] != 0:


### PR DESCRIPTION
sev issues are now merge blocking if they are labeled merge blocking, instead of simply having the merge blocking string in the body.  This makes it easier to default to non merge blocking when creating a sev
