### PR TITLE
[pytorch/profiler] Profiler NCCL metadata can now contain collective Input and Ouput Tensor addrs

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -502,6 +502,15 @@ void onFunctionExit(
   }
   kineto_ctx_ptr->event_->basic_fields_.end_tid_ =
       at::RecordFunction::currentThreadId();
+  if (fn.isNcclMeta()) {
+    auto& extra_meta = *(kineto_ctx_ptr->event_->extra_nccl_meta_);
+    // Record only the outputs in this exit callback of the record function
+    torch::profiler::impl::SaveNcclMetaConfig ncclMetaConfig{
+        false, false, false, true};
+    auto additonal_nccl_meta =
+        torch::profiler::impl::saveNcclMeta(fn, ncclMetaConfig);
+    extra_meta.insert(additonal_nccl_meta.begin(), additonal_nccl_meta.end());
+  }
   if (config.state == ProfilerState::KINETO_GPU_FALLBACK) {
     try {
       auto fallback = kineto_ctx_ptr->fallback_;

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -449,6 +449,7 @@ struct KinetoObserverContext : public at::ObserverContext {
 
     bool allow_tf32_cublas_;
     std::unique_ptr<perf_counters_t> counters_;
+    extra_meta_t* extra_nccl_meta_{};
   };
 
   explicit KinetoObserverContext(Event* event) : event_{event} {}
@@ -675,5 +676,11 @@ TORCH_API void set_fwd_bwd_enabled_val(bool);
 TORCH_API bool get_cuda_sync_enabled();
 TORCH_API void set_cuda_sync_enabled_fn(std::function<bool()>);
 TORCH_API void set_cuda_sync_enabled_val(bool);
+
+// Comms related RecordFunctions will record information about tensor storage
+// locations.
+TORCH_API bool get_record_tensor_addrs_enabled();
+TORCH_API void set_record_tensor_addrs_enabled_fn(std::function<bool()>);
+TORCH_API void set_record_tensor_addrs_enabled_val(bool);
 
 } // namespace torch::profiler::impl

--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -529,7 +529,10 @@ inline std::string getCommsNodeAttrs(const RecordFunction& fn) { // NOLINT
   }
 
   // get NcclMeta from record function, this used ParamCommsDebugInfo above
-  auto meta = saveNcclMeta(fn, false /*truncate*/);
+  // since we currently have this read called in onFunctionExit flow, we should
+  // only introspect output tensors to prevent an INTERNAL ASSERT FAILED in
+  // RecordFunction when we try to read input in RecordFunction exit methods.
+  auto meta = saveNcclMeta(fn, SaveNcclMetaConfig(false, true, false, true));
 
   auto addAttr =
       [&](const char* commsMetaName, const char* etMetaName, const char* type) {
@@ -595,20 +598,11 @@ static void recordOperatorStart(
     }
 
     fc.name = fn.name();
-    auto num_inputs = fn.num_inputs();
-    const auto inputs = fn.inputs();
-
-    VLOG(2) << "inputs: " << num_inputs << " " << inputs.size() << '\n';
-    // We have two cases: for unboxed kernel, we have num_inputs ==
-    // inputs.size() for boxed kernel using stack, there could be more elements
-    // on the stack from previous ops.
-    // TORCH_INTERNAL_ASSERT(num_inputs <= inputs.size());
-    if (num_inputs > inputs.size()) {
-      LOG(WARNING) << "RecordFunction " << fc.name
-                   << " expected num_inputs=" << num_inputs
-                   << " > inputs.size()=" << inputs.size();
+    if (!checkFunctionInputsForLogging(fn)) {
       return;
     }
+    auto num_inputs = fn.num_inputs();
+    const auto inputs = fn.inputs();
     // need to account for Stack mode where the inputs are at the end.
     size_t input_start = inputs.size() - num_inputs;
 
@@ -699,20 +693,11 @@ static void onFunctionExit(const RecordFunction& fn, ObserverContext* ctx_ptr) {
       return;
     }
     auto& fc = *fc_ptr;
-
-    auto const& outputs = fn.outputs();
-    auto num_outputs = fn.num_outputs();
-    // We have two cases: for unboxed kernel, we have num_outputs ==
-    // outputs.size() for boxed kernel using stack, there could be more elements
-    // on the stack from previous ops.
-    VLOG(2) << "outputs: " << num_outputs << " " << outputs.size() << '\n';
-    // TORCH_INTERNAL_ASSERT(num_outputs <= outputs.size());
-    if (num_outputs > outputs.size()) {
-      LOG(WARNING) << "RecordFunction " << fc.name
-                   << " num_outputs=" << num_outputs
-                   << " > outputs.size()=" << outputs.size();
+    if (!checkFunctionOutputsForLogging(fn)) {
       return;
     }
+    auto outputs = fn.outputs();
+    auto num_outputs = fn.num_outputs();
     // need to account for Stack mode where the outputs are at the end.
     size_t output_start = outputs.size() - num_outputs;
 
@@ -724,7 +709,7 @@ static void onFunctionExit(const RecordFunction& fn, ObserverContext* ctx_ptr) {
       for (const auto i : c10::irange(output_start, outputs.size())) {
         appendValueInfo(
             *ob,
-            outputs[i],
+            outputs.at(i),
             output_shapes,
             output_strides,
             output_types,

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/autograd/function.h>
+#include <torch/csrc/profiler/collection.h>
 #include <torch/csrc/profiler/kineto_shim.h>
 #include <torch/csrc/profiler/util.h>
 
@@ -29,10 +30,15 @@ bool softAssertRaises() {
 }
 
 void logSoftAssert(
+    // @lint-ignore CLANGTIDY
     const char* func,
+    // @lint-ignore CLANGTIDY
     const char* file,
+    // @lint-ignore CLANGTIDY
     uint32_t line,
+    // @lint-ignore CLANGTIDY
     const char* cond,
+    // @lint-ignore CLANGTIDY
     const char* args) {
 #ifdef USE_KINETO
   std::string error;
@@ -49,10 +55,15 @@ void logSoftAssert(
 }
 
 void logSoftAssert(
+    // @lint-ignore CLANGTIDY
     const char* func,
+    // @lint-ignore CLANGTIDY
     const char* file,
+    // @lint-ignore CLANGTIDY
     uint32_t line,
+    // @lint-ignore CLANGTIDY
     const char* cond,
+    // @lint-ignore CLANGTIDY
     const std::string& args) {
 #ifdef USE_KINETO
   std::string error;
@@ -366,71 +377,182 @@ std::vector<std::string> inputTypes(const at::RecordFunction& fn) {
 static constexpr int32_t kTruncatLength = 30;
 
 template <typename ListLikeType>
-inline std::string format_list(ListLikeType list, bool truncate) {
+inline std::string format_list(
+    ListLikeType list,
+    bool truncate,
+    bool with_escaped_quotes = true) {
   if (truncate && list.size() > kTruncatLength) {
     return fmt::format(
         "\"[{}, ...]\"",
         fmt::join(list.begin(), list.begin() + kTruncatLength, ", "));
   }
-  return fmt::format("\"[{}]\"", fmt::join(list.begin(), list.end(), ", "));
+  if (with_escaped_quotes == true) {
+    auto x = fmt::format("\"[{}]\"", fmt::join(list.begin(), list.end(), ", "));
+    return x;
+  } else {
+    auto x = fmt::format("[{}]", fmt::join(list.begin(), list.end(), ", "));
+    return x;
+  }
+}
+
+std::pair<bool, std::variant<int, std::vector<int>>> findStartAddrForTensors(
+    const c10::IValue& val) {
+  if (val.isTensor()) {
+    // Store hints about where the input starts in memory.
+    // Useful for debugging memory access patterns.
+    const auto& tensor = val.toTensor();
+    const int result = getTensorStartHint(tensor);
+    return {false, result};
+  } else if (val.isTuple()) {
+    const auto& val_tuple = val.toTupleRef().elements();
+    size_t tuple_size = val_tuple.size();
+    std::vector<int> responses;
+    responses.reserve(tuple_size);
+    for (const auto j : c10::irange(tuple_size)) {
+      auto [is_list, res] = findStartAddrForTensors(val_tuple[j]);
+      if (is_list) {
+        auto vec_res = std::get<std::vector<int>>(res);
+        responses.insert(responses.end(), vec_res.begin(), vec_res.end());
+      } else {
+        responses.push_back(std::get<int>(res));
+      }
+    }
+    return {true, responses};
+  } else if (val.isList()) {
+    const auto& val_list = val.toList();
+    size_t list_size = val_list.size();
+    std::vector<int> responses;
+    responses.reserve(list_size);
+    for (const auto j : c10::irange(list_size)) {
+      auto [is_list, res] = findStartAddrForTensors(val_list[j]);
+      if (is_list) {
+        auto vec_res = std::get<std::vector<int>>(res);
+        responses.insert(responses.end(), vec_res.begin(), vec_res.end());
+      } else {
+        responses.push_back(std::get<int>(res));
+      }
+    }
+    return {true, responses};
+  } else {
+    // push back an invalid value for indices representing non-tensor inputs
+    return {false, -1};
+  }
 }
 
 std::unordered_map<std::string, std::string> saveNcclMeta(
+    // @lint-ignore CLANGTIDY
     const at::RecordFunction& fn,
-    bool truncate) {
+    // @lint-ignore CLANGTIDY
+    const SaveNcclMetaConfig& config) {
   std::unordered_map<std::string, std::string> map;
 #ifdef USE_DISTRIBUTED
   auto debugInfo = dynamic_cast<ParamCommsDebugInfo*>(
       c10::ThreadLocalDebugInfo::get(c10::DebugInfoKind::PARAM_COMMS_INFO));
-  if (debugInfo == nullptr) {
-    LOG(WARNING) << "ParamCommsDebugInfo not available for function: "
-                 << fn.name();
-    return map;
-  }
 
-  auto& collective_name = debugInfo->getCollectiveName();
-  map.emplace(kCommsName, fmt::format("\"{}\"", collective_name));
-  map.emplace(
-      kDtype, fmt::format("\"{}\"", c10::toString(debugInfo->getDType())));
-  map.emplace(kInMsgNelems, std::to_string(debugInfo->getInMessageNelems()));
-  map.emplace(kOutMsgNelems, std::to_string(debugInfo->getOutMessageNelems()));
-
-  auto& inSplitSizes = debugInfo->getInputSplitSizes();
-  map.emplace(kInSplit, format_list(inSplitSizes, truncate));
-
-  auto& outSplitSizes = debugInfo->getOutputSplitSizes();
-  map.emplace(kOutSplit, format_list(outSplitSizes, truncate));
-
-  auto globalRankStart = debugInfo->getGlobalRankStart();
-  if (globalRankStart >= 0) {
-    map.emplace(kGlobalRankStart, std::to_string(globalRankStart));
-  }
-  auto globalRankStride = debugInfo->getGlobalRankStride();
-  if (globalRankStride > 0) {
-    map.emplace(kGlobalRankStride, std::to_string(globalRankStride));
-  }
-  map.emplace(kGroupSize, std::to_string(debugInfo->getWorldSize()));
-  auto& group_name = debugInfo->getProcessGroupName();
-  if (!group_name.empty()) {
-    map.emplace(kProcessGroupName, fmt::format("\"{}\"", group_name));
-  }
-  auto& group_desc = debugInfo->getProcessGroupDesc();
-  if (!group_desc.empty()) {
-    map.emplace(kProcessGroupDesc, fmt::format("\"{}\"", group_desc));
-  }
-  auto& groupRanks = debugInfo->getGroupRanks();
-  map.emplace(kGroupRanks, format_list(groupRanks, truncate));
-
-  auto rank = debugInfo->getRank();
-  map.emplace(kRank, std::to_string(rank));
-  int nRanks = static_cast<int>(groupRanks.size());
-  if (collective_name == "send") {
-    if (rank >= 0 && rank < nRanks) {
-      map.emplace(kP2pDst, std::to_string(groupRanks[rank]));
+  if (config.introspectMetadata) {
+    if (debugInfo == nullptr) {
+      LOG(WARNING) << "ParamCommsDebugInfo not available for function: "
+                   << fn.name();
+      return map;
     }
-  } else if (collective_name == "recv") {
-    if (rank >= 0 && rank < nRanks) {
-      map.emplace(kP2pSrc, std::to_string(groupRanks[rank]));
+    auto& collective_name = debugInfo->getCollectiveName();
+    map.emplace(kCommsName, fmt::format("\"{}\"", collective_name));
+    map.emplace(
+        kDtype, fmt::format("\"{}\"", c10::toString(debugInfo->getDType())));
+    map.emplace(kInMsgNelems, std::to_string(debugInfo->getInMessageNelems()));
+    map.emplace(
+        kOutMsgNelems, std::to_string(debugInfo->getOutMessageNelems()));
+
+    auto& inSplitSizes = debugInfo->getInputSplitSizes();
+    map.emplace(kInSplit, format_list(inSplitSizes, config.truncate));
+
+    auto& outSplitSizes = debugInfo->getOutputSplitSizes();
+    map.emplace(kOutSplit, format_list(outSplitSizes, config.truncate));
+
+    auto globalRankStart = debugInfo->getGlobalRankStart();
+    if (globalRankStart >= 0) {
+      map.emplace(kGlobalRankStart, std::to_string(globalRankStart));
+    }
+    auto globalRankStride = debugInfo->getGlobalRankStride();
+    if (globalRankStride > 0) {
+      map.emplace(kGlobalRankStride, std::to_string(globalRankStride));
+    }
+    map.emplace(kGroupSize, std::to_string(debugInfo->getWorldSize()));
+    auto& group_name = debugInfo->getProcessGroupName();
+    if (!group_name.empty()) {
+      map.emplace(kProcessGroupName, fmt::format("\"{}\"", group_name));
+    }
+    auto& group_desc = debugInfo->getProcessGroupDesc();
+    if (!group_desc.empty()) {
+      map.emplace(kProcessGroupDesc, fmt::format("\"{}\"", group_desc));
+    }
+    auto& groupRanks = debugInfo->getGroupRanks();
+    map.emplace(kGroupRanks, format_list(groupRanks, config.truncate));
+
+    auto rank = debugInfo->getRank();
+    map.emplace(kRank, std::to_string(rank));
+    int nRanks = static_cast<int>(groupRanks.size());
+    if (collective_name == "send") {
+      if (rank >= 0 && rank < nRanks) {
+        map.emplace(kP2pDst, std::to_string(groupRanks[rank]));
+      }
+    } else if (collective_name == "recv") {
+      if (rank >= 0 && rank < nRanks) {
+        map.emplace(kP2pSrc, std::to_string(groupRanks[rank]));
+      }
+    }
+  }
+
+  if (get_record_tensor_addrs_enabled()) {
+    std::vector<std::string> addressList;
+    if (config.introspectInputs) {
+      auto num_inputs = fn.num_inputs();
+      const auto inputs = fn.inputs();
+      if (checkFunctionInputsForLogging(fn)) {
+        // need to account for Stack mode where the inputs are at the end.
+        size_t input_start = inputs.size() - num_inputs;
+        for (const auto i : c10::irange(input_start, inputs.size())) {
+          const c10::IValue& val = inputs[i];
+          auto [is_list, result] = findStartAddrForTensors(val);
+          if (is_list) {
+            auto list_result = std::get<std::vector<int>>(result);
+            addressList.push_back(
+                format_list(list_result, config.truncate, false));
+          } else {
+            auto scalar_result = std::get<int>(result);
+            addressList.push_back(std::to_string(scalar_result));
+          }
+          // today we record a lot of metadata in record_param_comms that shows
+          // up as inputs. here we only need the addresses of the first inputs,
+          // which are the real tensor inputs to the collective call. So let's
+          // break out of the loop here.
+          break;
+        }
+        map.emplace(kInTensorsStart, format_list(addressList, false));
+        addressList.clear();
+      }
+    }
+    if (config.introspectOutputs) {
+      const auto outputs = fn.outputs();
+      auto num_outputs = fn.num_outputs();
+      if (checkFunctionOutputsForLogging(fn)) {
+        // need to account for Stack mode where the outputs are at the end.
+        size_t output_start = outputs.size() - num_outputs;
+        for (const auto i : c10::irange(output_start, outputs.size())) {
+          const c10::IValue& val = outputs[i];
+          auto [is_list, result] = findStartAddrForTensors(val);
+          if (is_list) {
+            auto list_result = std::get<std::vector<int>>(result);
+            addressList.push_back(
+                format_list(list_result, config.truncate, false));
+          } else {
+            auto scalar_result = std::get<int>(result);
+            addressList.push_back(std::to_string(scalar_result));
+          }
+        }
+        map.emplace(kOutTensorsStart, format_list(addressList, false));
+        addressList.clear();
+      }
     }
   }
 #endif // USE_DISTRIBUTED
@@ -786,6 +908,46 @@ uint64_t computeFlops(
     return flops;
   }
   return 0;
+}
+
+// A function that takes an IValue
+// and returns a conventional string representation of the IValue
+// Currently it returns int representation of the last 20 bits of the address
+// value
+int getTensorStartHint(const at::Tensor& t) {
+  const auto tensor_impl = t.unsafeGetTensorImpl();
+  uintptr_t storage_addr = 0;
+  storage_addr = reinterpret_cast<uintptr_t>(tensor_impl->storage().data());
+  int last_bits = static_cast<int>(storage_addr & 0xFFFFF);
+  return last_bits;
+}
+
+bool checkFunctionOutputsForLogging(const at::RecordFunction& fn) {
+  const auto& outputs = fn.outputs();
+  auto num_outputs = fn.num_outputs();
+  VLOG(2) << "outputs: " << num_outputs << " " << outputs.size() << '\n';
+  // We have two cases: for unboxed kernel, we have num_outputs ==
+  // outputs.size() for boxed kernel using stack, there could be more elements
+  // on the stack from previous ops.
+  // TORCH_INTERNAL_ASSERT(num_outputs <= outputs.size());
+  if (num_outputs > outputs.size()) {
+    return false;
+  }
+  return true;
+}
+
+bool checkFunctionInputsForLogging(const at::RecordFunction& fn) {
+  auto num_inputs = fn.num_inputs();
+  const auto inputs = fn.inputs();
+  VLOG(2) << "inputs: " << num_inputs << " " << inputs.size() << '\n';
+  // We have two cases: for unboxed kernel, we have num_inputs ==
+  // inputs.size() for boxed kernel using stack, there could be more elements
+  // on the stack from previous ops.
+  // TORCH_INTERNAL_ASSERT(num_inputs <= inputs.size());
+  if (num_inputs > inputs.size()) {
+    return false;
+  }
+  return true;
 }
 
 } // namespace torch::profiler::impl


### PR DESCRIPTION
Summary: Studying memory access patterns is the primary use cases.

Differential Revision: D65918359


