### PR TITLE
[ez] Fix typo in the ci sev template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci-sev.md
+++ b/.github/ISSUE_TEMPLATE/ci-sev.md
@@ -5,7 +5,7 @@ about: Tracking incidents for PyTorch's CI infra.
 
 > NOTE: Remember to label this issue with "`ci: sev`"
 
- <!-- uncomment the below line if you don't want this SEV to block merges -->
+ <!-- uncomment the line below if you want this SEV to block merges -->
  <!--  **MERGE BLOCKING** -->
 
 ## Current Status


### PR DESCRIPTION
Complimentary change to go with https://github.com/pytorch/test-infra/pull/5914

Clarifies the intended usage of the `**MERGE BLOCKING**` tag.