### PR TITLE
Add missing boundary checks to cunn_SoftMaxForward

### DIFF
--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -465,7 +465,7 @@ ilpReduce(index_t shift,
   if(shift > 0){
     data -= shift;
     size += shift;
-    if(threadIdx.x >= shift){
+    if (offset >= shift && offset < size) {
       threadVal = r(threadVal, data[offset]);
     }
     size -= blockDim.x;
@@ -515,7 +515,7 @@ WriteFpropResultsVectorized(
     output -= shift;
     size += shift;
 
-    if (threadIdx.x >= shift) {
+    if (offset >= shift && offset < size) {
       output[offset] = epilogue(input[offset]);
     }
     size -= blockDim.x;


### PR DESCRIPTION
This fixes OOB memory access for following code
```python
import torch
qk = torch.randn((1024,587), dtype=torch.float64, device='cuda')
smqk = torch.softmax(qk, dim=-1)
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd