### PR TITLE
create a new torch.cuda.memory_usage_in_bytes api

### DIFF
--- a/docs/source/cuda.rst
+++ b/docs/source/cuda.rst
@@ -28,6 +28,7 @@ torch.cuda
     is_available
     is_initialized
     memory_usage
+    memory_usage_in_bytes
     set_device
     set_stream
     set_sync_debug_mode

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3948,6 +3948,20 @@ class TestCudaMallocAsync(TestCase):
         self.assertTrue(0 <= torch.cuda.temperature() <= 150)
 
     @unittest.skipIf(TEST_PYNVML, "pynvml/amdsmi is not available")
+    def test_memory_usage_in_bytes(self):
+        """
+        Verify memory usage in bytes
+        """
+        torch.cuda.empty_cache()
+        a = torch.cuda.memory_usage_in_bytes()
+        num_bytes = 256 * 1024**2
+        _ = torch.empty(num_bytes, dtype=torch.int8, device="cuda")
+        torch.cuda.synchronize()
+        b = torch.cuda.memory_usage_in_bytes()
+        mem_bytes = b - a
+        self.assertTrue(mem_bytes > num_bytes // 2, mem_bytes < num_bytes * 8)
+
+    @unittest.skipIf(TEST_PYNVML, "pynvml/amdsmi is not available")
     def test_power_draw(self):
         self.assertTrue(torch.cuda.power_draw() >= 0)
 

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -2540,6 +2540,7 @@ torch_non_c_binding_in_graph_functions = dict.fromkeys(
         "torch.cuda.jiterator._create_jit_fn",
         "torch.cuda.jiterator._create_multi_output_jit_fn",
         "torch.cuda.memory_usage",
+        "torch.cuda.memory_usage_in_bytes",
         "torch.cuda.memory._dump_snapshot",
         "torch.cuda.memory._free_mutex",
         "torch.cuda.memory._get_current_allocator",


### PR DESCRIPTION
Summary:
the current torch.cuda.memory_usage returns the memory utilization, more specifically, percent of time over the past sample period global memory being read/written for Nvidia. 

see more details in https://github.com/pytorch/pytorch/issues/140638

Test Plan: added a new unittest

Differential Revision: D65928031




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames