### PR TITLE
[EZ] Make lintrunner usable with Python-3.12 and 3.13

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -47,7 +47,7 @@ init_command = [
     'mccabe==0.7.0',
     'pycodestyle==2.11.1',
     'pyflakes==3.1.0',
-    'torchfix==0.4.0 ; python_version >= "3.9"',
+    'torchfix==0.4.0 ; python_version >= "3.9" and python_version < "3.13"',
 ]
 
 
@@ -138,7 +138,8 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'numpy==1.26.0 ; python_version >= "3.9"',
+    'numpy==1.26.4 ; python_version >= "3.9" and python_version <= "3.11"',
+    'numpy==2.1.0 ; python_version >= "3.12"',
     'expecttest==0.2.1',
     'mypy==1.11.2',
     'sympy==1.13.0 ; python_version >= "3.9"',


### PR DESCRIPTION
By installing numpy-2.1 as 1.26 is available up to Python-3.11 And restricting torch fix to python older than 3.13, as TorchFix depends on libcstd-1.2 and therefore can not be installed to 3.13, see https://github.com/pytorch-labs/torchfix/issues/84
