### PR TITLE
Flex + NJT: cross attention support

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -7141,7 +7141,6 @@ torch.cuda.synchronize()
 
         query = _rand_nt()
         if q_and_kv_match:
-            # NB: randn_like() doesn't propagate lengths so this doesn't preserve non-contiguity
             key = torch.randn_like(query)
             value = torch.randn_like(query)
         else:

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -1228,7 +1228,13 @@ def flex_attention(
     if score_mod is None:
         score_mod = _identity
     elif query.is_nested:
-        score_mod = _nested_mod_func_adapter(score_mod, query, key, is_score_mod=True)  # type: ignore[assignment]
+        # use same NJT if the ragged structures for sequence lengths match between q and kv
+        kv = (
+            query
+            if query.size(query._ragged_idx) == key.size(query._ragged_idx)  # type: ignore[attr-defined]
+            else key
+        )
+        score_mod = _nested_mod_func_adapter(score_mod, query, kv, is_score_mod=True)  # type: ignore[assignment]
 
     if block_mask is None:
         block_mask = _create_empty_block_mask(query, key)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #140723

Fixes #140598

Allows ragged structures for query and key+value sequence lengths to differ (i.e. supports cross attention for Flex + NJT).

Technically, this is BC-breaking thanks to arg renaming and positional arg reordering in `create_nested_block_mask()`, but Flex + NJT support isn't in a major release yet so I'm hoping we can just do it.