### PR TITLE
[MPS] Reintroduce support for convolutions with output_channels > 65536

### DIFF
--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -32,6 +32,7 @@ enum class MacOSVersion : uint32_t {
   MACOS_VER_14_0_PLUS,
   MACOS_VER_14_4_PLUS,
   MACOS_VER_15_0_PLUS,
+  MACOS_VER_15_1_PLUS,
 };
 
 //-----------------------------------------------------------------

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -72,6 +72,7 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
   static bool _macos_14_0_plus = is_os_version_at_least(14, 0);
   static bool _macos_14_4_plus = is_os_version_at_least(14, 4);
   static bool _macos_15_0_plus = is_os_version_at_least(15, 0);
+  static bool _macos_15_1_plus = is_os_version_at_least(15, 1);
 
   switch (version) {
     case MacOSVersion::MACOS_VER_13_1_PLUS:
@@ -86,6 +87,8 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
       return _macos_14_4_plus;
     case MacOSVersion::MACOS_VER_15_0_PLUS:
       return _macos_15_0_plus;
+    case MacOSVersion::MACOS_VER_15_1_PLUS:
+      return _macos_15_1_plus;
     default:
       return false;
   }

--- a/aten/src/ATen/mps/MPSHooks.mm
+++ b/aten/src/ATen/mps/MPSHooks.mm
@@ -22,9 +22,15 @@ bool MPSHooks::hasMPS() const {
 bool MPSHooks::isOnMacOSorNewer(unsigned major, unsigned minor) const {
   switch (major) {
     case 15:
-      if (minor > 0)
-        TORCH_WARN("Can't check whether running on 15.", minor, "+ returning one for 15.0+");
-      return is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
+      switch (minor) {
+        case 0:
+          return is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
+        case 1:
+          return is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_1_PLUS);
+        default:
+          TORCH_WARN("Can't check whether running on 15.", minor, "+ returning one for 15.1+");
+          return is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_1_PLUS);
+      }
     case 14:
       switch (minor) {
         case 0:

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -165,9 +165,11 @@ static Tensor _mps_convolution_impl(const Tensor& input_t_,
   }
   TensorArg output{output_t, "result", 0};
 
-  // TODO: MPS convolution kernel currently does not support output channels > 2^16
-  for (auto elem : output_t.sizes()) {
-    TORCH_CHECK_NOT_IMPLEMENTED(elem <= (1 << 16), "Output channels > 65536 not supported at the MPS device. ");
+  if (!detail::getMPSHooks().isOnMacOSorNewer(15, 1)) {
+    // On macOS < 15.1, MPS convolution kernel does not support output channels > 2^16
+    for (auto elem : output_t.sizes()) {
+      TORCH_CHECK_NOT_IMPLEMENTED(elem <= (1 << 16), "Output channels > 65536 not supported at the MPS device. ");
+    }
   }
 
   convolution_shape_check(c, input, weight, output, padding, stride, dilation, groups);
@@ -371,9 +373,11 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
   using namespace mps;
   bool is3DConv = grad_output_t.dim() == 5;
 
-  // TODO: MPS convolution kernel currently does not support output channels > 2^16
-  for (auto elem : grad_output_t.sizes()) {
-    TORCH_CHECK_NOT_IMPLEMENTED(elem <= (1 << 16), "Output channels > 65536 not supported at the MPS device. ");
+  if (!detail::getMPSHooks().isOnMacOSorNewer(15, 1)) {
+    // On macOS < 15.1, MPS convolution kernel does not support output channels > 2^16
+    for (auto elem : grad_output_t.sizes()) {
+      TORCH_CHECK_NOT_IMPLEMENTED(elem <= (1 << 16), "Output channels > 65536 not supported at the MPS device. ");
+    }
   }
 
   TORCH_CHECK(isFloatingType(grad_output_t.scalar_type()), "Convolution is supported only for Floating types");

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1619,12 +1619,22 @@ class TestMPS(TestCaseMPS):
             a = torch.tensor(v, dtype=dtype, device="mps") * b
             self.compare_with_numpy(torch.exp, np.exp, a)
 
+    @xfailIf(product_version > 15.0)
     def test_conv_raises_error(self, device='mps', dtype=torch.float):
         conv = nn.Conv1d(1, 65537, 3, padding=1).to('mps')
 
         x = torch.ones([1, 1, 3])
         with self.assertRaises(NotImplementedError):
             y = conv(x.to("mps"))
+
+    @xfailIf(product_version < 15.1)
+    def test_conv_high_channel_size(self):
+        out_channels = 65537
+        weight = torch.randn(out_channels, 1, 1)
+        x = torch.ones([1, 1, 1])
+        y_cpu = F.conv1d(x.to("cpu"), weight.to("cpu"))
+        y_mps = F.conv1d(x.to("mps"), weight.to("mps"))
+        self.assertEqual(y_cpu, y_mps)
 
     def test_triu_inf(self, device="mps", dtype=torch.float):
         for diag in [-1, 0, 1]:


### PR DESCRIPTION
This reintroduces support for high channel sizes for convs. The guard for macOS versions < 15.1 is still present to prevent reintroducing #129207.

I'm unsure about the specific macOS version support, but I'm assuming this was fixed in 15.1, and I'm relying on signals from ci for verification. I'm expecting the new test will fail for macOS versions < 15.1, and the old test will start failing for > 15.0. I've added xfails for this and extended the version helpers to support 15.1+.

Fixes #140722