### PR TITLE
Update torch-xpu-ops commit pin

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -349,8 +349,6 @@ inductor_expected_failures_single_sample["xpu"] = {
     # a deconvolution forward propagation primitive
     "nn.functional.conv_transpose2d": {f32, f64},
     "nn.functional.conv_transpose3d": {f32, f64},
-    # frexp not supported on XPU now
-    "frexp": {f16, f32, f64},
     # not implemented for 'Half'
     "sort": {b8},
     "argsort": {b8},

--- a/third_party/xpu.txt
+++ b/third_party/xpu.txt
@@ -1,1 +1,1 @@
-01f4e293fa39818bd0d018e9bb82d4e2cf54be48
+b75da0cba01fadafca9df95b1df88f0ed24ed312


### PR DESCRIPTION
Update the torch-xpu-ops commit to [b75da0c](https://github.com/intel/torch-xpu-ops/commit/b75da0cba01fadafca9df95b1df88f0ed24ed312), includes:

- Support `SparseXPU` operators
- Improve XPU operator coverage
- Fix `Werror=terminate` relevant building issues


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov