### PR TITLE
Fix _out_spec for _LazyGraphModule

### DIFF
--- a/test/fx/test_lazy_graph_module.py
+++ b/test/fx/test_lazy_graph_module.py
@@ -274,6 +274,32 @@ class TestLazyGraphModule(TestCase):
         )
         assert hasattr(got_lazy_inner_forward, "__self__")
 
+    def test_get_spec_attribute(self):
+        """
+        _in_spec and _out_spec should be populated.
+        """
+        from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
+        from torch.utils import _pytree as pytree
+
+        def f(x):
+            return x * 2
+
+        _, spec = pytree.tree_flatten(torch.randn(1))
+        gm = torch.fx.symbolic_trace(f)
+        lazy_gm = torch.fx._lazy_graph_module._LazyGraphModule.from_graphmodule(gm)
+
+        lazy_gm.graph._codegen = _PyTreeCodeGen(
+            _PyTreeInfo(
+                ["x"],
+                spec,
+                spec,
+            )
+        )
+        out_spec = lazy_gm._out_spec
+        in_spec = lazy_gm._in_spec
+        self.assertEqual(out_spec, spec)
+        self.assertEqual(in_spec, spec)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/fx/_lazy_graph_module.py
+++ b/torch/fx/_lazy_graph_module.py
@@ -176,6 +176,16 @@ class _LazyGraphModule(GraphModule):
         self.real_recompile()
         return super().code
 
+    @property
+    def _out_spec(self):
+        self.real_recompile()
+        return super()._out_spec
+
+    @property
+    def _in_spec(self):
+        self.real_recompile()
+        return super()._in_spec
+
     def __str__(self) -> str:
         """
         str(GraphModule) will access the _code attribute. Make sure recompile


### PR DESCRIPTION
Summary:
When we call .recompile(), GraphModule populates the self._out_spec, but _LazyGraphModule(GraphModule).recompile() doesn't populate it.

This Diff fixes it by adding a forced recomopile before calling ._out_spec and _in_spec.

Also add the tests for _LazyGraphModule to FX tests TARGETS file.

Test Plan:
```
buck run 'fbcode//mode/dev-nosan'  fbcode//caffe2/test:fx -- -r test_autowrap_functions

buck run 'fbcode//mode/dev-nosan'  fbcode//caffe2/test:fx -- -r get_spec_attribute
```

Differential Revision: D65928949




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv