### PR TITLE
[EZ] Delete unused `xfailIfMacOS14_4Plus`

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -69,9 +69,6 @@ def xfailIf(condition):
             return func
     return wrapper
 
-def xfailIfMacOS14_4Plus(func):
-    return unittest.expectedFailure(func) if product_version > 14.3 else func  # noqa: F821
-
 def mps_ops_grad_modifier(ops):
     XFAILLIST_GRAD = {
 


### PR DESCRIPTION
Issue was fixed by https://github.com/pytorch/pytorch/pull/130038 but decorator remained in place
