### PR TITLE
[AOTInductor] Add update_constant_buffer pybind support

### DIFF
--- a/test/inductor/test_aot_inductor_arrayref.py
+++ b/test/inductor/test_aot_inductor_arrayref.py
@@ -167,6 +167,7 @@ CPU_TEST_FAILURES = {
     # TODO: AttributeError: 'ShapeAsConstantBuffer' object has no attribute 'dtype'
     "test_symbool_item": fail_minimal_arrayref_interface(is_skip=True),
     "test_issue_140766": fail_minimal_arrayref_interface(),
+    "test_update_constant_buffer": fail_stack_allocation(is_skip=True),
 }
 
 

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
@@ -164,6 +164,21 @@ void AOTIModelContainerRunner::update_constant_buffer(
       check_full_update));
 }
 
+void AOTIModelContainerRunner::update_constant_buffer(
+    std::unordered_map<std::string, at::Tensor>& tensor_map,
+    bool use_inactive,
+    bool check_full_update) {
+  TensorConstantMap const_map;
+  for (auto& [k, v] : tensor_map) {
+    const_map.emplace(k, &v);
+  }
+  AOTI_RUNTIME_ERROR_CODE_CHECK(update_constant_buffer_func_(
+      container_handle_,
+      (AOTInductorConstantMapHandle)&const_map,
+      use_inactive,
+      check_full_update));
+}
+
 void AOTIModelContainerRunner::update_inactive_constant_buffer(
     const TensorConstantMap& const_map) {
   AOTI_RUNTIME_ERROR_CODE_CHECK(update_inactive_constant_buffer_func_(

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.h
@@ -33,6 +33,10 @@ class TORCH_API AOTIModelContainerRunner {
   std::unordered_map<std::string, int32_t> getConstantNamesToDtypes() const;
   void update_inactive_constant_buffer(const TensorConstantMap& const_map);
   void update_constant_buffer(
+      std::unordered_map<std::string, at::Tensor>& tensor_map,
+      bool use_inactive,
+      bool validate_full_updates);
+  void update_constant_buffer(
       const TensorConstantMap& const_map,
       bool use_inactive,
       bool validate_full_updates);

--- a/torch/csrc/inductor/aoti_runner/pybind.cpp
+++ b/torch/csrc/inductor/aoti_runner/pybind.cpp
@@ -22,7 +22,12 @@ void initAOTIRunnerBindings(PyObject* module) {
           &AOTIModelContainerRunnerCpu::getConstantNamesToOriginalFQNs)
       .def(
           "get_constant_names_to_dtypes",
-          &AOTIModelContainerRunnerCpu::getConstantNamesToDtypes);
+          &AOTIModelContainerRunnerCpu::getConstantNamesToDtypes)
+      .def(
+          "update_constant_buffer",
+          static_cast<void (AOTIModelContainerRunnerCpu::*)(
+              std::unordered_map<std::string, at::Tensor>&, bool, bool)>(
+              &AOTIModelContainerRunnerCpu::update_constant_buffer));
 
 #ifdef USE_CUDA
   py::class_<AOTIModelContainerRunnerCuda>(m, "AOTIModelContainerRunnerCuda")
@@ -40,7 +45,12 @@ void initAOTIRunnerBindings(PyObject* module) {
           &AOTIModelContainerRunnerCuda::getConstantNamesToOriginalFQNs)
       .def(
           "get_constant_names_to_dtypes",
-          &AOTIModelContainerRunnerCuda::getConstantNamesToDtypes);
+          &AOTIModelContainerRunnerCuda::getConstantNamesToDtypes)
+      .def(
+          "update_constant_buffer",
+          static_cast<void (AOTIModelContainerRunnerCuda::*)(
+              std::unordered_map<std::string, at::Tensor>&, bool, bool)>(
+              &AOTIModelContainerRunnerCuda::update_constant_buffer));
 #endif
 
   m.def(


### PR DESCRIPTION
Summary: We add update_constant_buffer python support for testing purpose.

Test Plan: Included in commit

Differential Revision: D65968613




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @ColinPeppler @amjames @desertfire @chauhang @aakhundov