### PR TITLE
[ONNX] Separate decomp into single step and add to the report

### DIFF
--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -72,7 +72,7 @@ _END = "\033[0m"
 
 _STEP_ONE_ERROR_MESSAGE = textwrap.dedent(
     f"""\
-    Failed to export the model with torch.export. {_BLUE}This is step 1/2{_END} of exporting the model to ONNX. Next steps:
+    Failed to export the model with torch.export. {_BLUE}This is step 1/3{_END} of exporting the model to ONNX. Next steps:
     - Modify the model code for `torch.export.export` to succeed. Refer to https://pytorch.org/docs/stable/generated/exportdb/index.html for more information.
     - Debug `torch.export.export` and summit a PR to PyTorch.
     - Create an issue in the PyTorch GitHub repository against the {_BLUE}*torch.export*{_END} component and attach the full error stack as well as reproduction scripts."""
@@ -80,10 +80,17 @@ _STEP_ONE_ERROR_MESSAGE = textwrap.dedent(
 
 _STEP_TWO_ERROR_MESSAGE = textwrap.dedent(
     f"""\
-    Failed to convert the exported program to an ONNX model. {_BLUE}This is step 2/2{_END} of exporting the model to ONNX. Next steps:
+    Failed to decompose the FX graph for ONNX compatibility. {_BLUE}This is step 2/3{_END} of exporting the model to ONNX. Next steps:
+    - Create an issue in the PyTorch GitHub repository against the {_BLUE}*torch.export*{_END} component and attach the full error stack as well as reproduction scripts.
+    - Create an error report with `torch.onnx.export(..., report=True)`, and save the ExportedProgram as a pt2 file. Create an issue in the PyTorch GitHub repository against the {_BLUE}*onnx*{_END} component. Attach the error report and the pt2 model."""
+)
+
+_STEP_THREE_ERROR_MESSAGE = textwrap.dedent(
+    f"""\
+    Failed to convert the exported program to an ONNX model. {_BLUE}This is step 3/3{_END} of exporting the model to ONNX. Next steps:
     - If there is a missing ONNX function, implement it and register it to the registry.
     - If there is an internal error during ONNX conversion, debug the error and summit a PR to PyTorch.
-    - Save the ExportedProgram as a pt2 file and create an error report with `export(..., report=True)`. Create an issue in the PyTorch GitHub repository against the {_BLUE}*onnx*{_END} component. Attach the pt2 model and the error report."""
+    - Create an error report with `torch.onnx.export(..., report=True)`, and save the ExportedProgram as a pt2 file. Create an issue in the PyTorch GitHub repository against the {_BLUE}*onnx*{_END} component. Attach the error report and the pt2 model."""
 )
 
 logger = logging.getLogger(__name__)
@@ -1015,10 +1022,10 @@ def export(
             result = strategy(model, args, kwargs, dynamic_shapes=dynamic_shapes)
 
             # Record the status
-            if strategy_class is _capture_strategies.TorchExportStrategy:
-                export_status.torch_export = result.success
-            elif strategy_class is _capture_strategies.TorchExportNonStrictStrategy:
+            if strategy_class is _capture_strategies.TorchExportNonStrictStrategy:
                 export_status.torch_export_non_strict = result.success
+            elif strategy_class is _capture_strategies.TorchExportStrategy:
+                export_status.torch_export = result.success
             elif strategy_class is _capture_strategies.JitTraceConvertStrategy:
                 export_status.torch_jit = result.success
 
@@ -1081,10 +1088,9 @@ def export(
         else:
             verbose_print(f"ExportedProgram has been saved to '{program_path}'.")
 
-    # Step 2: Convert the exported program to an ONNX model
-    verbose_print("Translate the graph into ONNX...")
+    # Step 2: Decompose the exported program and insert type promotion nodes
+    verbose_print("Run decomposition...")
 
-    # Step 2a: Decompose the exported program and insert type promotion nodes
     try:
         # Build the ONNX function registry
         if registry is None:
@@ -1095,8 +1101,8 @@ def export(
             program, registry=registry
         )
     except Exception as e:
-        export_status.onnx_translation = False
-        verbose_print("Translate the graph into ONNX... ❌")
+        export_status.decomposition = False
+        verbose_print("Run decomposition... ❌")
         profile_result = _maybe_stop_profiler_and_get_result(profiler)
 
         if report:
@@ -1124,8 +1130,12 @@ def export(
             + (f"\nError report has been saved to '{report_path}'." if report else "")
             + _summarize_exception_stack(e)
         ) from e
+    else:
+        export_status.decomposition = True
+        verbose_print("Run decomposition... ✅")
 
-    # Step 2b: Translate the decomposed program to ONNX and produce ONNXProgram
+    # Step 3: Translate the decomposed program to ONNX and produce ONNXProgram
+    verbose_print("Translate the graph into ONNX...")
     if report or profile:
         pre_decomp_unique_ops, post_decomp_unique_ops = _analysis.compare_ops(
             program, decomposed_program
@@ -1184,7 +1194,7 @@ def export(
             report_path = None
 
         raise _errors.ConversionError(
-            _STEP_TWO_ERROR_MESSAGE
+            _STEP_THREE_ERROR_MESSAGE
             + (f"\nError report has been saved to '{report_path}'." if report else "")
             + _summarize_exception_stack(e)
         ) from e
@@ -1224,7 +1234,7 @@ def export(
             verbose_print(profile_result)
         return onnx_program
 
-    # Step 3: (verify=True) Check the ONNX model with ONNX checker
+    # Step 4: (verify=True) Check the ONNX model with ONNX checker
     try:
         verbose_print("Check the ONNX model...")
         onnxscript_apis.check_model(onnx_program.model)
@@ -1264,7 +1274,7 @@ def export(
         )
         return onnx_program
 
-    # Step 4: (verify=True) Execute the model with ONNX Runtime
+    # Step 5: (verify=True) Execute the model with ONNX Runtime
     try:
         verbose_print("Execute the model with ONNX Runtime...")
         verification_results = _verification.verify_onnx_program(onnx_program)
@@ -1278,7 +1288,7 @@ def export(
         verification_message = None
 
     else:
-        # Step 5: (verify=True) Validate the output values
+        # Step 6: (verify=True) Validate the output values
         verbose_print("Verify output accuracy...")
         export_status.output_accuracy = True
         for verification_result in verification_results:

--- a/torch/onnx/_internal/exporter/_reporting.py
+++ b/torch/onnx/_internal/exporter/_reporting.py
@@ -24,6 +24,8 @@ class ExportStatus:
     torch_export_non_strict: bool | None = None
     # Whether torch.jit.trace succeeds
     torch_jit: bool | None = None
+    # Whether decomposition succeeds
+    decomposition: bool | None = None
     # Whether ONNX translation succeeds
     onnx_translation: bool | None = None
     # Whether ONNX model passes onnx.checker.check_model
@@ -43,9 +45,10 @@ def _status_emoji(status: bool | None) -> str:
 def _format_export_status(status: ExportStatus) -> str:
     return (
         f"```\n"
-        f"{_status_emoji(status.torch_export)} Obtain model graph with `torch.export.export`\n"
         f"{_status_emoji(status.torch_export_non_strict)} Obtain model graph with `torch.export.export(..., strict=False)`\n"
+        f"{_status_emoji(status.torch_export)} Obtain model graph with `torch.export.export(..., strict=True)`\n"
         f"{_status_emoji(status.torch_jit)} Obtain model graph with `torch.jit.trace`\n"
+        f"{_status_emoji(status.decomposition)} Decompose operators for ONNX compatibility\n"
         f"{_status_emoji(status.onnx_translation)} Translate the graph into ONNX\n"
         f"{_status_emoji(status.onnx_checker)} Run `onnx.checker` on the ONNX model\n"
         f"{_status_emoji(status.onnx_runtime)} Execute the model with ONNX Runtime\n"
@@ -77,6 +80,8 @@ def construct_report_file_name(timestamp: str, status: ExportStatus) -> str:
     if not (status.torch_export or status.torch_export_non_strict or status.torch_jit):
         # All strategies failed
         postfix = "pt_export"
+    elif status.decomposition is False:
+        postfix = "decomp"
     elif status.onnx_translation is False:
         postfix = "conversion"
     elif status.onnx_checker is False:


### PR DESCRIPTION
1. Fix the ordering of the error report entries so non-strict show on top
2. Isolate run_decomposition into a separate step because it sometimes fails. This makes it easier for users to understand what failed

Fix https://github.com/pytorch/pytorch/issues/140762 Fix https://github.com/pytorch/pytorch/issues/137638