### PR TITLE
[BE][MPS] Remove extra semicolons

### DIFF
--- a/aten/src/ATen/mps/MPSGeneratorImpl.h
+++ b/aten/src/ATen/mps/MPSGeneratorImpl.h
@@ -37,10 +37,10 @@ struct TORCH_API MPSGeneratorImpl : public c10::GeneratorImpl {
   c10::intrusive_ptr<c10::TensorImpl> get_state() const override;
   void update_philox_counters();
 
-  void set_engine(at::Philox4_32 engine) { engine_ = engine; };
-  at::Philox4_32 engine() { return engine_; };
+  void set_engine(at::Philox4_32 engine) { engine_ = engine; }
+  at::Philox4_32 engine() { return engine_; }
   uint32_t* state_data() { return data_.state.data(); }
-  static DeviceType device_type() { return DeviceType::MPS; };
+  static DeviceType device_type() { return DeviceType::MPS; }
 
 private:
   mps::detail::rng_data_pod data_;


### PR DESCRIPTION
Fixes following warnings:
```
In file included from /Users/malfet/git/pytorch/pytorch/torch/csrc/Generator.cpp:25:
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/mps/MPSGeneratorImpl.h:40:63: warning: extra ';' after member function definition [-Wextra-semi]
   40 |   void set_engine(at::Philox4_32 engine) { engine_ = engine; };
      |                                                               ^
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/mps/MPSGeneratorImpl.h:41:46: warning: extra ';' after member function definition [-Wextra-semi]
   41 |   at::Philox4_32 engine() { return engine_; };
      |                                              ^
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/mps/MPSGeneratorImpl.h:43:62: warning: extra ';' after member function definition [-Wextra-semi]
   43 |   static DeviceType device_type() { return DeviceType::MPS; };
      |                                                              ^
3 warnings generated.
```
