### PR TITLE
[PT2][Optimus] Fix a corner case in merge splits

### DIFF
--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -629,6 +629,10 @@ def merge_splits(
                 next_split_num_to_user = {
                     user.args[1]: user for user in node.users.keys()
                 }
+                split_getitem_indices = list(next_split_num_to_user.keys())
+                # check if it is consecutive and starts from index 0
+                if split_getitem_indices[0] != 0 or not is_sorted_and_consecutive(split_getitem_indices):  # type: ignore[arg-type]
+                    return
                 # It is not necessary all getitems from the split node are used.
                 # We use the num of users to check the getitems to be merged.
                 for next_split_num in range(len(node.users.keys())):


### PR DESCRIPTION
Summary:
We observed another corner case where not all split items are used, see the screenshot

{F1960315622}

We thus skip such cases by checking the getitem indices.

Test Plan:
# local reproduce
```
buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode batch-split  --flow_id 663157369 2>&1 | tee ~/cmf.txt
```
P1679677122

# E2E

before fix
f663157369

after fix

Differential Revision: D65990213




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov