### PR TITLE
[ARM] Expand linux aarch64 unit test list

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1385,7 +1385,8 @@ test_executorch() {
 
 test_linux_aarch64() {
   python test/run_test.py --include test_modules test_mkldnn test_mkldnn_fusion test_openmp test_torch test_dynamic_shapes \
-        test_transformers test_multiprocessing test_numpy_interop \
+        test_transformers test_multiprocessing test_numpy_interop test_autograd test_binary_ufuncs test_complex test_spectral_ops \
+        test_foreach test_reductions test_unary_ufuncs \
         --shard "$SHARD_NUMBER" "$NUM_TEST_SHARDS" --verbose
 
   # Dynamo tests
@@ -1403,6 +1404,7 @@ test_linux_aarch64() {
        inductor/test_pattern_matcher inductor/test_perf inductor/test_profiler inductor/test_select_algorithm inductor/test_smoke \
        inductor/test_split_cat_fx_passes inductor/test_standalone_compile inductor/test_torchinductor \
        inductor/test_torchinductor_codegen_dynamic_shapes inductor/test_torchinductor_dynamic_shapes inductor/test_memory \
+       inductor/test_triton_cpu_backend inductor/test_triton_extension_backend \
        --shard "$SHARD_NUMBER" "$NUM_TEST_SHARDS" --verbose
 }
 


### PR DESCRIPTION
Expand the list of unit tests for test_linux_aarch64

These have been verified externally as passing on neoverse n1 and v1 based machines.

@malfet 

cc @malfet @snadampal @milpuz01