### PR TITLE
[BE]: FURB189: Use collections subclass builtins

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3180,7 +3180,7 @@ def maybe_enable_compiled_autograd(should_enable, fullgraph=True, dynamic=True):
 
 def invalid_removeable_handle():
     # need a subclass so weakref works
-    class Invalid(dict):  # type: ignore[type-arg]
+    class Invalid(collections.UserDict):  # type: ignore[type-arg]
         pass
 
     return RemovableHandle(Invalid())

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -4,6 +4,7 @@ import logging
 import operator
 import typing
 import warnings
+from collections import UserDict
 from contextlib import contextmanager
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 
@@ -1315,7 +1316,7 @@ class ExplainTS2FXGraphConverter(TS2FXGraphConverter):
     also mocks some internal attributes (e.g., name_to_node).
     """
 
-    class _DictMock(dict):
+    class _DictMock(UserDict):
         def __init__(self, dict_data, mock_value):
             super().__init__(dict_data)
             self.mock_value = mock_value

--- a/torch/_export/serde/union.py
+++ b/torch/_export/serde/union.py
@@ -1,10 +1,11 @@
 # mypy: allow-untyped-defs
 import functools
+from collections import UserString
 from dataclasses import fields
 from typing import Hashable, Set
 
 
-class _UnionTag(str):
+class _UnionTag(UserString):
     _cls: Hashable
 
     @staticmethod

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -2,7 +2,7 @@
 import bisect
 import itertools
 import math
-from collections import defaultdict, namedtuple
+from collections import defaultdict, namedtuple, UserList
 from operator import attrgetter
 from typing import Any, Dict, List, Optional, Tuple
 from typing_extensions import deprecated
@@ -23,7 +23,7 @@ __all__ = [
 ]
 
 
-class EventList(list):
+class EventList(UserList):
     """A list of Events (for pretty printing)."""
 
     def __init__(self, *args, **kwargs):

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -220,7 +220,7 @@ def supports_complex(reduceOp: ReduceOp) -> bool:
     return reduceOp not in denyList
 
 
-class Backend(str):
+class Backend(collections.UserString):
     """
     An enum-like class for backends.
 

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -2,6 +2,7 @@
 import multiprocessing
 import os
 import threading
+from collections import UserDict
 from multiprocessing import reduction
 from multiprocessing.util import register_after_fork
 from typing import Union
@@ -58,7 +59,7 @@ class StorageWeakRef:
         return self.cdata == other.cdata
 
 
-class SharedCache(dict):
+class SharedCache(UserDict):
     """Dictionary from multiprocessing handles to StorageWeakRef."""
 
     def __init__(self) -> None:

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -27,7 +27,7 @@ from torch.testing._internal.common_utils import enable_profiling_mode  # noqa: 
 from contextlib import contextmanager
 from functools import reduce
 from io import StringIO
-from collections import defaultdict
+from collections import defaultdict, UserList
 
 import importlib.util
 import inspect
@@ -102,7 +102,7 @@ class JitTestCase(JitCommonTestCase):
     _do_cuda_memory_leak_check = True
     _restored_warnings = False
 
-    class capture_stdout(list):
+    class capture_stdout(UserList):
         """
         Replace sys.stdout with a temporary StringIO
         """
@@ -117,7 +117,7 @@ class JitTestCase(JitCommonTestCase):
             del self.stringio
             sys.stdout = self.sys_stdout
 
-    class capture_stderr(list):
+    class capture_stderr(UserList):
         """
         Replace sys.stderr with a temporary StringIO
         """

--- a/torch/torch_version.py
+++ b/torch/torch_version.py
@@ -1,3 +1,4 @@
+from collections import UserString
 from typing import Any, Iterable
 
 from torch._vendor.packaging.version import InvalidVersion, Version
@@ -7,7 +8,7 @@ from torch.version import __version__ as internal_version
 __all__ = ["TorchVersion"]
 
 
-class TorchVersion(str):
+class TorchVersion(UserString):
     """A string with magic powers to compare to both Version and iterables!
     Prior to 1.10.0 torch.__version__ was stored as a str and so many did
     comparisons against torch.__version__ as if it were a str. In order to not


### PR DESCRIPTION
Subclassing builtin collections is bad. Luckily, python has user classes that are safe to subclass from.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames