### PR TITLE
Prevent tensorify sledgehammer from eliminating inputs used by non item calls

### DIFF
--- a/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
+++ b/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
@@ -167,6 +167,7 @@ class CheckpointWrapper(ActivationWrapper):
                 *flat_args,
             )
         else:
+            # python test/distributed/_composable/fsdp/test_fully_shard_training.py TestFullyShard1DTrainingCompose.test_train_parity_with_activation_checkpointing
             return self.checkpoint_fn(  # type: ignore[misc]
                 self._checkpoint_wrapped_module, *args, **kwargs
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #140830
* #138922
* #138666
* #138915
* __->__ #140831
* #140832
* #140829
* #140828
* #140346

Fixes `python test/distributed/_composable/fsdp/test_fully_shard_training.py TestFullyShard1DTrainingCompose.test_train_parity_with_activation_checkpointing` when `specialize_float=False`

Reviewers, I'm less familiar with distributed and activation checkpointing so I'm open to other approaches. The reason we need this check is because activation checkpointing creates a dependency on the f64[] tensor input, so simply eliminating it causes a getitem(float, int) call which fails (getitem expects (tensor, int)).


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames