### PR TITLE
Fix TORCH_CUDA_ARCH_LIST for SBSA+CUDA build

### DIFF
--- a/.ci/aarch64_linux/aarch64_wheel_ci_build.py
+++ b/.ci/aarch64_linux/aarch64_wheel_ci_build.py
@@ -177,7 +177,7 @@ if __name__ == "__main__":
         branch = "master"
 
     print("Building PyTorch wheel")
-    build_vars = "MAX_JOBS=5 CMAKE_SHARED_LINKER_FLAGS=-Wl,-z,max-page-size=0x10000 "
+    build_vars = "MAX_JOBS=5 CMAKE_SHARED_LINKER_FLAGS=-Wl,-z,max-page-size=0x10000 TORCH_CUDA_ARCH_LIST='9.0'"
     os.system("cd /pytorch; python setup.py clean")
 
     override_package_version = os.getenv("OVERRIDE_PACKAGE_VERSION")


### PR DESCRIPTION
SBSA+CUDA is building beyond sm90 specified in https://github.com/pytorch/pytorch/blob/22dfb5b6cf9a9a92ff1f6c411a285dc1b2dd9f75/.ci/manywheel/build_cuda.sh#L64 

```
python -c "import torch; print(torch.cuda.get_arch_list())"
['sm_50', 'sm_80', 'sm_86', 'sm_89', 'sm_90', 'sm_90a']

```

Root cause seems to be ARM build missing TORCH_CUDA_ARCH_LIST
```
-- Building version 2.6.0.dev20241113+cu124
2024-11-13T07:51:21.6301398Z cmake -GNinja -DBLAS=NVPL -DBUILD_ENVIRONMENT=linux-aarch64-binary-manywheel -DBUILD_PYTHON=True -DBUILD_PYTHONLESS= -DBUILD_TEST=False -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/pytorch/torch -DCMAKE_PREFIX_PATH=/opt/python/cp312-cp312/lib/python3.12/site-packages -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-z,max-page-size=0x10000 -DPython_EXECUTABLE=/opt/python/cp312-cp312/bin/python3 -DTORCH_BUILD_VERSION=2.6.0.dev20241113+cu124 -DUSE_FBGEMM=1 -DUSE_GLOO_WITH_OPENSSL=OFF -DUSE_GOLD_LINKER=OFF -DUSE_MKLDNN=ON -DUSE_MKLDNN_ACL=ON -DUSE_NUMPY=True -DUSE_PRIORITIZED_TEXT_FOR_LD=1 -DUSE_SPLIT_BUILD=false /pytorch
```

Test PR to try fix
