### PR TITLE
[ROCm][CI] upgrade CI and manywheel docker images to ROCm 6.2.4

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -292,7 +292,7 @@ case "$image" in
     PROTOBUF=yes
     DB=yes
     VISION=yes
-    ROCM_VERSION=6.2
+    ROCM_VERSION=6.2.4
     NINJA_VERSION=1.9.0
     CONDA_CMAKE=yes
     TRITON=yes

--- a/.ci/docker/common/install_miopen.sh
+++ b/.ci/docker/common/install_miopen.sh
@@ -75,7 +75,10 @@ MIOPEN_CMAKE_COMMON_FLAGS="
 if [[ $ROCM_INT -ge 60300 ]]; then
     echo "ROCm 6.3+ MIOpen does not need any patches, do not build from source"
     exit 0
-elif [[ $ROCM_INT -ge 60200 ]] && [[ $ROCM_INT -lt 60300 ]]; then
+elif [[ $ROCM_INT -ge 60204 ]] && [[ $ROCM_INT -lt 60300 ]]; then
+    echo "ROCm 6.2.4+ MIOpen does not need any patches, do not build from source"
+    exit 0
+elif [[ $ROCM_INT -ge 60200 ]] && [[ $ROCM_INT -lt 60204 ]]; then
     MIOPEN_BRANCH="release/rocm-rel-6.2-staging"
 elif [[ $ROCM_INT -ge 60100 ]] && [[ $ROCM_INT -lt 60200 ]]; then
     echo "ROCm 6.1 MIOpen does not need any patches, do not build from source"

--- a/.github/workflows/build-libtorch-images.yml
+++ b/.github/workflows/build-libtorch-images.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.9xlarge.ephemeral"
     strategy:
       matrix:
-        rocm_version: ["6.1", "6.2"]
+        rocm_version: ["6.1", "6.2.4"]
     env:
       GPU_ARCH_TYPE: rocm
       GPU_ARCH_VERSION: ${{ matrix.rocm_version }}

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -178,7 +178,7 @@ jobs:
     runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.9xlarge.ephemeral"
     strategy:
       matrix:
-        rocm_version: ["6.1", "6.2"]
+        rocm_version: ["6.1", "6.2.4"]
     env:
       GPU_ARCH_TYPE: rocm
       GPU_ARCH_VERSION: ${{ matrix.rocm_version }}


### PR DESCRIPTION
Fixes issue of long docker build times in PRs which trigger the docker build in regular PyTorch build jobs eg. https://github.com/pytorch/pytorch/actions/runs/11751388838/job/32828886198. These docker builds take a long time for ROCm6.2 because:
1. They are run on less capable machines (`c5.2xlarge`) instead of the beefier ones on which [docker-build workflows](https://github.com/pytorch/pytorch/blob/924c1fe3f304aa599b823fb549c35b7809f61086/.github/workflows/docker-builds.yml#L50) run (`c5.12xlarge`)
2. ROCm6.2 docker builds enabled building of MIOpen from source, which runs into [timeout of 90mins](https://github.com/pytorch/test-infra/blob/9abd4d95bb0b86d78d1929abcd6046d07e8a5864/.github/actions/calculate-docker-image/action.yml#L171): https://github.com/pytorch/pytorch/actions/runs/11751388838/job/32828886198#step:7:160

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd