### PR TITLE
[Utilization Monitor] input to disable utilization monitor

### DIFF
--- a/.github/actions/linux-test/action.yml
+++ b/.github/actions/linux-test/action.yml
@@ -115,7 +115,7 @@ runs:
 
     - name: Start monitoring script
       id: monitor-script
-      if: inputs.disable-monitor != 'true'
+      if: !inputs.disable-monitor
       shell: bash
       continue-on-error: true
       run: |
@@ -290,7 +290,7 @@ runs:
         cat test/**/*_toprint.log || true
 
     - name: Stop monitoring script
-      if: inputs.disable-monitor != 'true' && always() && steps.monitor-script.outputs.monitor-script-pid
+      if: !inputs.disable-monitor && always() && steps.monitor-script.outputs.monitor-script-pid
       shell: bash
       continue-on-error: true
       env:

--- a/.github/actions/linux-test/action.yml
+++ b/.github/actions/linux-test/action.yml
@@ -297,7 +297,7 @@ runs:
         cat test/**/*_toprint.log || true
 
     - name: Stop monitoring script
-      if: ${{ always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid }}
+      if: ${{ always() && steps.monitor-script.outputs.monitor-script-pid }}
       shell: bash
       continue-on-error: true
       env:

--- a/.github/actions/linux-test/action.yml
+++ b/.github/actions/linux-test/action.yml
@@ -115,7 +115,7 @@ runs:
 
     - name: Start monitoring script
       id: monitor-script
-      if: !inputs.disable-monitor
+      if: ${{ !inputs.disable-monitor }}
       shell: bash
       continue-on-error: true
       run: |
@@ -290,7 +290,7 @@ runs:
         cat test/**/*_toprint.log || true
 
     - name: Stop monitoring script
-      if: always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid
+      if: ${{ always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid }}
       shell: bash
       continue-on-error: true
       env:

--- a/.github/actions/linux-test/action.yml
+++ b/.github/actions/linux-test/action.yml
@@ -290,7 +290,7 @@ runs:
         cat test/**/*_toprint.log || true
 
     - name: Stop monitoring script
-      if: !inputs.disable-monitor && always() && steps.monitor-script.outputs.monitor-script-pid
+      if: always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid
       shell: bash
       continue-on-error: true
       env:

--- a/.github/actions/linux-test/action.yml
+++ b/.github/actions/linux-test/action.yml
@@ -47,7 +47,14 @@ inputs:
   GITHUB_TOKEN:
     description: GitHub token
     required: true
-
+  disable-monitor:
+    description: |
+      [Experimental] Disable utilization monitoring for tests.
+      Currently, by default we disable the monitor job and only look for specific tests,
+      since we are investigating the behaviour of the monitor script with different tests.
+    required: false
+    type: boolean
+    default: true
 #env:
 #  GIT_DEFAULT_BRANCH: ${{ inputs.default_branch }}
 

--- a/.github/actions/linux-test/action.yml
+++ b/.github/actions/linux-test/action.yml
@@ -115,6 +115,7 @@ runs:
 
     - name: Start monitoring script
       id: monitor-script
+      if: inputs.disable-monitor != 'true'
       shell: bash
       continue-on-error: true
       run: |
@@ -289,7 +290,7 @@ runs:
         cat test/**/*_toprint.log || true
 
     - name: Stop monitoring script
-      if: always() && steps.monitor-script.outputs.monitor-script-pid
+      if: inputs.disable-monitor != 'true' && always() && steps.monitor-script.outputs.monitor-script-pid
       shell: bash
       continue-on-error: true
       env:

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Start monitoring script
         id: monitor-script
-        if: inputs.disable-monitor != 'true'
+        if: !inputs.disable-monitor
         shell: bash
         continue-on-error: true
         run: |
@@ -337,7 +337,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: inputs.disable-monitor != 'true' && always() && steps.monitor-script.outputs.monitor-script-pid
+        if: !inputs.disable-monitor && always() && steps.monitor-script.outputs.monitor-script-pid
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -337,7 +337,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: ${{ always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid }}
+        if: ${{ always() && steps.monitor-script.outputs.monitor-script-pid }}
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Start monitoring script
         id: monitor-script
-        if: !inputs.disable-monitor
+        if: ${{ !inputs.disable-monitor }}
         shell: bash
         continue-on-error: true
         run: |
@@ -337,7 +337,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid
+        if: ${{ always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid }}
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -47,6 +47,14 @@ on:
         required: false
         type: string
         default: ""
+      disable-monitor:
+        description: |
+          [Experimental] Disable utilization monitoring for tests.
+          Currently, by default we disable the monitor job and only look for specific tests,
+          since we are investigating the behaviour of the monitor script with different tests.
+        required: false
+        type: boolean
+        default: true
     secrets:
       HUGGING_FACE_HUB_TOKEN:
         required: false
@@ -145,6 +153,7 @@ jobs:
 
       - name: Start monitoring script
         id: monitor-script
+        if: inputs.disable-monitor != 'true'
         shell: bash
         continue-on-error: true
         run: |
@@ -328,7 +337,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: always() && steps.monitor-script.outputs.monitor-script-pid
+        if: inputs.disable-monitor != 'true' && inputs.disable-monitor != 'true' && always() && steps.monitor-script.outputs.monitor-script-pid
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -337,7 +337,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: inputs.disable-monitor != 'true' && inputs.disable-monitor != 'true' && always() && steps.monitor-script.outputs.monitor-script-pid
+        if: inputs.disable-monitor != 'true' && always() && steps.monitor-script.outputs.monitor-script-pid
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -337,7 +337,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: !inputs.disable-monitor && always() && steps.monitor-script.outputs.monitor-script-pid
+        if: always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Start monitoring script
         id: monitor-script
-        if: !inputs.disable-monitor
+        if: ${{ !inputs.disable-monitor }}
         continue-on-error: true
         run: |
           ${CONDA_RUN} python3 -m tools.stats.monitor > usage_log.txt 2>&1 &

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -208,7 +208,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: always() && !inputs.disable-monitor && ${{ steps.monitor-script.outputs.monitor-script-pid }}
+        if: ${{ always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid }}
         continue-on-error: true
         env:
           MONITOR_SCRIPT_PID: ${{ steps.monitor-script.outputs.monitor-script-pid }}

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -208,7 +208,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: !inputs.disable-monitor && always() && ${{ steps.monitor-script.outputs.monitor-script-pid }}
+        if: always() && !inputs.disable-monitor && ${{ steps.monitor-script.outputs.monitor-script-pid }}
         continue-on-error: true
         env:
           MONITOR_SCRIPT_PID: ${{ steps.monitor-script.outputs.monitor-script-pid }}

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -30,7 +30,14 @@ on:
         default: 270
         description: |
           Set the maximum (in minutes) how long the workflow should take to finish
-
+      disable-monitor:
+        description: |
+          [Experimental] Disable utilization monitoring for tests.
+          Currently, by default we disable the monitor job and only look for specific tests,
+          since we are investigating the behaviour of the monitor script with different tests.
+        required: false
+        type: boolean
+        default: true
 jobs:
   test:
     # Don't run on forked repos or empty test matrix
@@ -101,6 +108,7 @@ jobs:
 
       - name: Start monitoring script
         id: monitor-script
+        if: inputs.disable-monitor != 'true'
         continue-on-error: true
         run: |
           ${CONDA_RUN} python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
@@ -200,7 +208,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: always() && ${{ steps.monitor-script.outputs.monitor-script-pid }}
+        if: inputs.disable-monitor != 'true' && always() && ${{ steps.monitor-script.outputs.monitor-script-pid }}
         continue-on-error: true
         env:
           MONITOR_SCRIPT_PID: ${{ steps.monitor-script.outputs.monitor-script-pid }}

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -38,6 +38,7 @@ on:
         required: false
         type: boolean
         default: true
+
 jobs:
   test:
     # Don't run on forked repos or empty test matrix

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Start monitoring script
         id: monitor-script
-        if: inputs.disable-monitor != 'true'
+        if: !inputs.disable-monitor
         continue-on-error: true
         run: |
           ${CONDA_RUN} python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
@@ -208,7 +208,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: inputs.disable-monitor != 'true' && always() && ${{ steps.monitor-script.outputs.monitor-script-pid }}
+        if: !inputs.disable-monitor && always() && ${{ steps.monitor-script.outputs.monitor-script-pid }}
         continue-on-error: true
         env:
           MONITOR_SCRIPT_PID: ${{ steps.monitor-script.outputs.monitor-script-pid }}

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -209,7 +209,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: ${{ always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid }}
+        if: ${{ always() && steps.monitor-script.outputs.monitor-script-pid }}
         continue-on-error: true
         env:
           MONITOR_SCRIPT_PID: ${{ steps.monitor-script.outputs.monitor-script-pid }}

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -38,6 +38,14 @@ on:
         default: ""
         description: |
           List of tests to include (empty string implies default list)
+      disable-monitor:
+        description: |
+          [Experimental] Disable utilization monitoring for tests.
+          Currently, by default we disable the monitor job and only look for specific tests,
+          since we are investigating the behaviour of the monitor script with different tests.
+        required: false
+        type: boolean
+        default: true
 
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -91,6 +99,7 @@ jobs:
 
       - name: Start monitoring script
         id: monitor-script
+        if: inputs.disable-monitor != 'true'
         shell: bash
         continue-on-error: true
         run: |
@@ -247,7 +256,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: always() && steps.monitor-script.outputs.monitor-script-pid
+        if: inputs.disable-monitor != 'true' && always() && steps.monitor-script.outputs.monitor-script-pid
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Start monitoring script
         id: monitor-script
-        if: !inputs.disable-monitor
+        if: ${{ !inputs.disable-monitor }}
         shell: bash
         continue-on-error: true
         run: |
@@ -256,7 +256,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid
+        if: ${{ always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid }}
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -256,7 +256,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: !inputs.disable-monitor && always() && steps.monitor-script.outputs.monitor-script-pid
+        if: always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -256,7 +256,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: ${{ always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid }}
+        if: ${{ always() && steps.monitor-script.outputs.monitor-script-pid }}
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Start monitoring script
         id: monitor-script
-        if: inputs.disable-monitor != 'true'
+        if: !inputs.disable-monitor
         shell: bash
         continue-on-error: true
         run: |
@@ -256,7 +256,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: inputs.disable-monitor != 'true' && always() && steps.monitor-script.outputs.monitor-script-pid
+        if: !inputs.disable-monitor && always() && steps.monitor-script.outputs.monitor-script-pid
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -222,7 +222,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: ${{ always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid }}
+        if: ${{ always() && steps.monitor-script.outputs.monitor-script-pid }}
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -222,7 +222,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: !inputs.disable-monitor && always() && steps.monitor-script.outputs.monitor-script-pid
+        if: always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -28,6 +28,14 @@ on:
         default: 240
         description: |
           Set the maximum (in minutes) how long the workflow should take to finish
+      disable-monitor:
+        description: |
+          [Experimental] Disable utilization monitoring for tests.
+          Currently, by default we disable the monitor job and only look for specific tests,
+          since we are investigating the behaviour of the monitor script with different tests.
+        required: false
+        type: boolean
+        default: true
 
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -101,6 +109,7 @@ jobs:
       - name: Start monitoring script
         id: monitor-script
         shell: bash
+        if: inputs.disable-monitor != 'true'
         continue-on-error: true
         run: |
           # Windows conda doesn't have python3 binary, only python, but it's python3
@@ -213,7 +222,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: always() && steps.monitor-script.outputs.monitor-script-pid
+        if: inputs.disable-monitor != 'true' && always() && steps.monitor-script.outputs.monitor-script-pid
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Start monitoring script
         id: monitor-script
         shell: bash
-        if: !inputs.disable-monitor
+        if: ${{ !inputs.disable-monitor }}
         continue-on-error: true
         run: |
           # Windows conda doesn't have python3 binary, only python, but it's python3
@@ -222,7 +222,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid
+        if: ${{ always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid }}
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Start monitoring script
         id: monitor-script
         shell: bash
-        if: inputs.disable-monitor != 'true'
+        if: !inputs.disable-monitor
         continue-on-error: true
         run: |
           # Windows conda doesn't have python3 binary, only python, but it's python3
@@ -222,7 +222,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: inputs.disable-monitor != 'true' && always() && steps.monitor-script.outputs.monitor-script-pid
+        if: !inputs.disable-monitor && always() && steps.monitor-script.outputs.monitor-script-pid
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_xpu-test.yml
+++ b/.github/workflows/_xpu-test.yml
@@ -251,7 +251,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: !inputs.disable-monitor && always() && steps.monitor-script.outputs.monitor-script-pid
+        if: always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_xpu-test.yml
+++ b/.github/workflows/_xpu-test.yml
@@ -251,7 +251,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: ${{ always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid }}
+        if: ${{ always() && steps.monitor-script.outputs.monitor-script-pid }}
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_xpu-test.yml
+++ b/.github/workflows/_xpu-test.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Start monitoring script
         id: monitor-script
-        if: !inputs.disable-monitor
+        if: ${{ !inputs.disable-monitor }}
         shell: bash
         continue-on-error: true
         run: |
@@ -251,7 +251,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid
+        if: ${{ always() && !inputs.disable-monitor && steps.monitor-script.outputs.monitor-script-pid }}
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_xpu-test.yml
+++ b/.github/workflows/_xpu-test.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Start monitoring script
         id: monitor-script
-        if: inputs.disable-monitor != 'true'
+        if: !inputs.disable-monitor
         shell: bash
         continue-on-error: true
         run: |
@@ -251,7 +251,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: inputs.disable-monitor != 'true' && always() && steps.monitor-script.outputs.monitor-script-pid
+        if: !inputs.disable-monitor && always() && steps.monitor-script.outputs.monitor-script-pid
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/_xpu-test.yml
+++ b/.github/workflows/_xpu-test.yml
@@ -38,6 +38,14 @@ on:
         default: ""
         description: |
           List of tests to include (empty string implies default list)
+      disable-monitor:
+        description: |
+          [Experimental] Disable utilization monitoring for tests.
+          Currently, by default we disable the monitor job and only look for specific tests,
+          since we are investigating the behaviour of the monitor script with different tests.
+        required: false
+        type: boolean
+        default: true
 
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -83,6 +91,7 @@ jobs:
 
       - name: Start monitoring script
         id: monitor-script
+        if: inputs.disable-monitor != 'true'
         shell: bash
         continue-on-error: true
         run: |
@@ -242,7 +251,7 @@ jobs:
           cat test/**/*_toprint.log || true
 
       - name: Stop monitoring script
-        if: always() && steps.monitor-script.outputs.monitor-script-pid
+        if: inputs.disable-monitor != 'true' && always() && steps.monitor-script.outputs.monitor-script-pid
         shell: bash
         continue-on-error: true
         env:

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -80,17 +80,17 @@ def parse_args() -> argparse.Namespace:
     args = parser.parse_args()
 
     parser.add_argument(
-        "--time-interval",
+        "--log-interval",
         type=int,
         default=10,
-        help="set time-interval for collecting log, default is 10 seconds",
+        help="set time interval for logging utilization data, default is 10 seconds",
     )
     args = parser.parse_args()
     return args
 
 if __name__ == "__main__":
     args = parse_args()
-    schedule_interval = args.time_interval
+    interval = args.log_interval
     # try import pynvml for Nvidia Gpu
     has_pynvml = False
     try:
@@ -115,7 +115,7 @@ if __name__ == "__main__":
         num_gpus = pynvml.nvmlDeviceGetCount()
     # log info
     info = {
-        "log_interval": f"{schedule_interval} seconds",
+        "log_interval": f"{interval} seconds",
         "gpu": "pynvml" if has_pynvml else "",
         "num_of_gpu":num_gpus,
         "num_of_cpu": num_cpus,
@@ -150,4 +150,4 @@ if __name__ == "__main__":
             }
         finally:
             print(json.dumps(stats))
-            time.sleep(schedule_interval)
+            time.sleep(interval)

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -90,9 +90,7 @@ def parse_args() -> argparse.Namespace:
 
 if __name__ == "__main__":
     args = parse_args()
-
     schedule_interval = args.time_interval
-
     # try import pynvml for Nvidia Gpu
     has_pynvml = False
     try:
@@ -109,8 +107,20 @@ if __name__ == "__main__":
     def exit_gracefully(*args: Any) -> None:
         global kill_now
         kill_now = True
-
     signal.signal(signal.SIGTERM, exit_gracefully)
+
+    num_cpus = psutil.cpu_count()
+    num_gpus = None
+    if has_pynvml:
+        num_gpus = pynvml.nvmlDeviceGetCount()
+    # log info
+    info = {
+        "log_interval": f"{schedule_interval} seconds",
+        "gpu": "pynvml" if has_pynvml else "",
+        "num_of_gpu":num_gpus,
+        "num_of_cpu": num_cpus,
+    }
+    print(json.dumps(info))
     while not kill_now:
         try:
             stats = {


### PR DESCRIPTION
# Overview
Currently monitor.py produces error only result, this pr introduct disable-monitor option to all *-test.yml. We also like to explore how the monitor code affect benchmark results.

# next steps
- fix the monitor.py
- enable non-benchmark tests with monitor
- investigate benchmark test behavior with monitor background job




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd