### PR TITLE
[aoti] Avoid DCE unbacked symint node

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1356,6 +1356,30 @@ class AOTInductorTestsTemplate:
             dynamic_shapes=dynamic_shapes,
         )
 
+    def test_cond_unbacked_symint_input(self):
+        class M(torch.nn.Module):
+            def forward(self, x, y, z):
+                a = y.shape[0]
+                b = z.item()
+
+                def true_fn(x):
+                    return x + a
+
+                def false_fn(x):
+                    return x + b * z
+
+                return torch.cond(x.shape[0] > 5, true_fn, false_fn, (x,))
+
+        input1 = (torch.ones(3, 3), torch.ones(5), torch.ones(3, 3))
+        input2 = (torch.ones(10, 3), torch.ones(6), torch.ones(10, 3))
+        inputs = (input1, input2)
+        dynamic_shapes = {"x": {0: Dim("d")}, "y": {0: Dim("d1")}, "z": {0: Dim("d")}}
+        self.check_model_with_multiple_inputs(
+            M(),
+            inputs,
+            dynamic_shapes=dynamic_shapes,
+        )
+
     def test_while_loop_simple(self):
         inputs = (
             torch.randn((10, 20), device=self.device),

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1370,10 +1370,10 @@ class AOTInductorTestsTemplate:
 
                 return torch.cond(x.shape[0] > 5, true_fn, false_fn, (x,))
 
-        input1 = (torch.ones(3, 3), torch.ones(5), torch.ones(3, 3))
-        input2 = (torch.ones(10, 3), torch.ones(6), torch.ones(10, 3))
+        input1 = (torch.ones(3, 3), torch.ones(5), torch.ones(1))
+        input2 = (torch.ones(10, 3), torch.ones(6), torch.ones(1))
         inputs = (input1, input2)
-        dynamic_shapes = {"x": {0: Dim("d")}, "y": {0: Dim("d1")}, "z": {0: Dim("d")}}
+        dynamic_shapes = {"x": {0: Dim("d")}, "y": {0: Dim("d1")}, "z": {}}
         self.check_model_with_multiple_inputs(
             M(),
             inputs,

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2166,7 +2166,16 @@ class Scheduler:
                 else:
                     active_buffers = True
 
-            can_eliminate = not node.has_side_effects() and not active_buffers
+            # Node's read_writes doesn't contain unbacked symbols, so if the output buffer defines an unbacked symint,
+            # don't clean this node.
+            defines_unbacked_symbol = (
+                node.node is not None and len(node.node.get_unbacked_symbol_defs()) > 0
+            )
+            can_eliminate = (
+                not node.has_side_effects()
+                and not active_buffers
+                and not defines_unbacked_symbol
+            )
 
             if not can_eliminate:
                 updated_nodes.append(node)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #140858

Summary: In the case where torch.cond takes symint:

```
_local_scalar_dense: "Sym(Eq(u0, 1))" = torch.ops.aten._local_scalar_dense.default(logical_not_1);  logical_not_1 = None
cond = torch.ops.higher_order.cond(_local_scalar_dense_1, true_graph_0, false_graph_0, [arg0_1, sym_size_int_1, _local_scalar_dense, arg2_1])
```

The `_local_scalar_dense` node will be DCE'd because currently we don't
put any symint into a node's `read_writes.read`: see logic in https://github.com/pytorch/pytorch/blob/main/torch/_inductor/ir.py#L4312

Without deeper knowledge on whether this is intentional, here I'm
patching the DCE logic to not prune the node where it is defining an
unbacked symbol.

Test Plan: See new unit test

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov