### PR TITLE
Add option to split Linear gates for Quantizable LSTM into separate ops

### DIFF
--- a/torch/ao/nn/quantized/modules/rnn.py
+++ b/torch/ao/nn/quantized/modules/rnn.py
@@ -49,7 +49,7 @@ class LSTM(torch.ao.nn.quantizable.LSTM):
 
     @classmethod
     def from_observed(cls, other):
-        assert type(other) == cls._FLOAT_MODULE  # type: ignore[has-type]
+        assert isinstance(other, cls._FLOAT_MODULE)
         converted = torch.ao.quantization.convert(
             other, inplace=False, remove_qconfig=True
         )

--- a/torch/ao/quantization/fx/lstm_utils.py
+++ b/torch/ao/quantization/fx/lstm_utils.py
@@ -25,6 +25,7 @@ def _get_lstm_with_individually_observed_parts(
     tanh_obs_ctr: Optional[_PartialWrapper] = None,
     cell_state_obs_ctr: Optional[_PartialWrapper] = None,
     hidden_state_obs_ctr: Optional[_PartialWrapper] = None,
+    split_gates: bool = False,
 ) -> torch.ao.nn.quantizable.LSTM:
     """
     Return an observed `torch.ao.nn.quantizable.LSTM` created from a `torch.nn.LSTM`
@@ -75,6 +76,7 @@ def _get_lstm_with_individually_observed_parts(
         float_lstm.batch_first,
         float_lstm.dropout,
         float_lstm.bidirectional,
+        split_gates=split_gates,
     )
     quantizable_lstm.qconfig = float_lstm.qconfig
 
@@ -82,7 +84,11 @@ def _get_lstm_with_individually_observed_parts(
         quantizable_lstm.layers[
             idx
         ] = torch.ao.nn.quantizable.modules.rnn._LSTMLayer.from_float(
-            float_lstm, idx, float_lstm.qconfig, batch_first=False
+            float_lstm,
+            idx,
+            float_lstm.qconfig,
+            batch_first=False,
+            split_gates=split_gates,
         )
 
     # Build QConfigMapping for the LSTM cell
@@ -105,13 +111,25 @@ def _get_lstm_with_individually_observed_parts(
         # to configure these ops in FX graph mode quantization today. This is because
         # the FloatFunctional modules simply disappear from the graph after tracing.
         # In the future, we should rewrite quantizable LSTM without FloatFunctionals.
-        op_index_to_activation_post_process_ctr = {
-            (torch.add, 0): linear_output_obs_ctr,  # gates.add
-            (torch.mul, 0): cell_state_obs_ctr,  # fgate_cx.mul
-            (torch.mul, 1): cell_state_obs_ctr,  # igate_cgate.mul
-            (torch.add, 1): cell_state_obs_ctr,  # fgate_cx_igate_cgate.add
-            (torch.mul, 2): hidden_state_obs_ctr,  # ogate_cy.mul
-        }
+        if not split_gates:
+            op_index_to_activation_post_process_ctr = {
+                (torch.add, 0): linear_output_obs_ctr,  # gates.add
+                (torch.mul, 0): cell_state_obs_ctr,  # fgate_cx.mul
+                (torch.mul, 1): cell_state_obs_ctr,  # igate_cgate.mul
+                (torch.add, 1): cell_state_obs_ctr,  # fgate_cx_igate_cgate.add
+                (torch.mul, 2): hidden_state_obs_ctr,  # ogate_cy.mul
+            }
+        else:
+            op_index_to_activation_post_process_ctr = {
+                (torch.add, 0): linear_output_obs_ctr,  # gates.add (input)
+                (torch.add, 1): linear_output_obs_ctr,  # gates.add (forget)
+                (torch.add, 2): linear_output_obs_ctr,  # gates.add (cell)
+                (torch.add, 3): linear_output_obs_ctr,  # gates.add (output)
+                (torch.mul, 0): cell_state_obs_ctr,  # fgate_cx.mul
+                (torch.mul, 1): cell_state_obs_ctr,  # igate_cgate.mul
+                (torch.add, 4): cell_state_obs_ctr,  # fgate_cx_igate_cgate.add
+                (torch.mul, 2): hidden_state_obs_ctr,  # ogate_cy.mul
+            }
         add_count = 0
         mul_count = 0
         for node in cell.graph.nodes:


### PR DESCRIPTION
Summary:
For LSTM, the input and hidden state are projected with Linear layers to construct the 4 gates. This is typically performed together as a single Linear (for each state) with output channel count `4 * hidden_dim` for efficiency. 
https://www.internalfb.com/code/fbsource/[ebef7c4238aa55948b2b444044f2c8ed2040de55]/fbcode/caffe2/torch/ao/nn/quantizable/modules/rnn.py?lines=52-58
The output is then ultimately split into 4:
https://www.internalfb.com/code/fbsource/[ebef7c4238aa55948b2b444044f2c8ed2040de55]/fbcode/caffe2/torch/ao/nn/quantizable/modules/rnn.py?lines=83-87

For on-device latency (and possibly memory) considerations, we want to avoid constructing the intermediate `gates` tensor (which can be relatively large), by splitting `igates` and `hgates` first (as 4x `Linear(hidden_dim, hidden_dim)` each), applying add separately, then proceeding as usual.

This functionality can be enabled by specifying `split_gates=True` (default False is original behavior) at any entry point (directly with `torch.ao.nn.quantizable.LSTM`  or via `_get_lstm_with_individually_observed_parts`).

Test Plan:
piggy back on existing test to check for correct swap handling, numerics, and jit.script during prepare/convert
```
buck2 test 'fbcode//mode/opt' fbcode//caffe2/test/quantization:test_quantization -- --exact 'caffe2/test/quantization:test_quantization - test_custom_module_lstm (caffe2.test.quantization.core.test_quantized_op.TestQuantizedOps)'
```
https://www.internalfb.com/intern/testinfra/testrun/11540474102848372

This test is quite long running now (more than double original).

Reviewed By: Ninja91

Differential Revision: D65283170




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv