### PR TITLE
optimize unnecessary view replay nodes during functionalization

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -150,6 +150,9 @@ FunctionalTensorWrapper::FunctionalTensorWrapper(const Tensor& view_value, const
   view_metas_.push_back(meta);
   maybe_mark_symbolic(meta);
   storage_ = base->storage_; // alias this tensor's storage with the base tensor's
+  // Optimization: if the base already had a mutation on it,
+  // we can treat this view as already having the mutation too.
+  generation_ = base->generation_;
 }
 
 
@@ -167,7 +170,7 @@ void FunctionalTensorWrapper::commit_update() {
   // doesn't result in an unnecessary materialization of the base.
   // This optimization results in the slice temporarily haven't incorrect
   // stride/storage_offset though, and DCE should handle that optimization anyway.
-  // generation_ = storage_impl->generation();
+  generation_ = storage_impl->generation();
 }
 
 bool FunctionalTensorWrapper::is_up_to_date() const {


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/140835

This adds back an old optimization that we had for XLA: basically, if we perform a mutation on a tensor, we can immediately treat that tensor as "up to date", so any views generated off of it later don't need to be treated as "stale / needs updating"

This PR isn't landable yet though: as per the comment in the code that I uncommented, it has some problems with `view_scatter` operator size/stride assertions that need looking into.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #140882

