### PR TITLE
Reraise worker errors as runtime errors in more cases when the original exception can't be constructed

### DIFF
--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -726,9 +726,9 @@ class ExceptionWrapper:
             raise self.exc_type(message=msg)
         try:
             exception = self.exc_type(msg)
-        except TypeError:
-            # If the exception takes multiple arguments, don't try to
-            # instantiate since we don't know how to
+        except Exception:
+            # If the exception takes multiple arguments or otherwise can't
+            # be constructed, don't try to instantiate since we don't know how to
             raise RuntimeError(msg) from None
         raise exception
 


### PR DESCRIPTION
related to https://github.com/pytorch/pytorch/issues/34130

when pytorch attempts to re-raise an exception from a worker process (e.g. multiprocessing dataloader), if it can't reconstruct the original exception message due to a type error, it instead raises it as a runtime error. However, if it can't reconstruct the exception for some other reason, it throws an error with a stacktrace pointing to the `ExceptionWrapper` code rather than the original underlying issue. 

One case in which I run into this is with boto3's [HTTPClientError](https://github.com/boto/botocore/blob/66dc1f8d52aab1da8c2e03c722d15567b682a874/botocore/exceptions.py#L94)s. They must be constructed with a keyword argument `error`, but if `error` isn't passed, a `KeyError` is thrown instead of a `TypeError`, due to the particular way it is implemented:

* [HTTPClientError](https://github.com/boto/botocore/blob/66dc1f8d52aab1da8c2e03c722d15567b682a874/botocore/exceptions.py#L94)'s constructor excepts variable keyword arguments it passes to `super` (BotoCoreError)
* [it also defines a field `fmt` with `error`](https://github.com/boto/botocore/blob/66dc1f8d52aab1da8c2e03c722d15567b682a874/botocore/exceptions.py#L95)
* BotoCoreError [expects to be able to format that string with the kwargs](https://github.com/boto/botocore/blob/66dc1f8d52aab1da8c2e03c722d15567b682a874/botocore/exceptions.py#L41) 

So in this case, if a HTTPClientError occurs on a worker process, you simply get a `KeyError: error` with a stacktrace pointing to [this line](https://github.com/pytorch/pytorch/blob/3e2f276a1445c6e27ebeb1fa5d60bce2200af315/torch/_utils.py#L710) which is unhelpful.

Instead, I propose to reraise the error as a `RuntimeError` unconditionally.