### PR TITLE
[Docs] Remove duplicate declaration of `double_tensor`

### DIFF
--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -75,7 +75,6 @@ Promotion Examples::
     >>> int_tensor = torch.ones(1, dtype=torch.int)
     >>> long_tensor = torch.ones(1, dtype=torch.long)
     >>> uint_tensor = torch.ones(1, dtype=torch.uint8)
-    >>> double_tensor = torch.ones(1, dtype=torch.double)
     >>> bool_tensor = torch.ones(1, dtype=torch.bool)
     # zero-dim tensors
     >>> long_zerodim = torch.tensor(1, dtype=torch.long)


### PR DESCRIPTION
Fixes #140920
