### PR TITLE
OpenReg: Fix releasing tensor issue when exiting process

### DIFF
--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/csrc/OpenRegMem.cpp
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/csrc/OpenRegMem.cpp
@@ -32,7 +32,7 @@ struct OpenRegAllocator final : at::Allocator {
   }
 
   static void ReportAndDelete(void* ptr) {
-    if (!ptr) {
+    if (!ptr || !Py_IsInitialized()) {
       return;
     }
     py::gil_scoped_acquire acquire;


### PR DESCRIPTION
When executing the following code:

```
import pytorch_openreg

import torch

if __name__ == "__main__":
    a = torch.tensor(1, device="openreg")

```
Sometimes releases tensor a failed after the process finishes executing `main` function. The trace of releasing `a` is `~Tensor()` -> ... -> `OpenRegMem.cpp` -> `OpenRegHooks.cpp` -> `_aten_impl.py`. 

There are two failed scenarios I've found:

1. Segmentation fault: Before executing `~Tensor()`, the process has released global variables in `_aten_impl.py`, which causes the issue.
2. Waiting indefinitely: The main process passes the `free ptr` command  to deamon process, however daemon processes have shutdown.

The way to fix this issue is when the process is shutting down, we ignore the del ptr operation.

cc @ezyang @albanD