### PR TITLE
removed dead code for dynamo flag dead_code_elimination

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -19,7 +19,6 @@ import threading
 import time
 import traceback
 import typing
-import warnings
 import weakref
 from pathlib import Path
 from types import CellType, CodeType, FunctionType, ModuleType
@@ -700,14 +699,6 @@ def _compile(
         assert output.output_instructions
         instructions[:] = output.output_instructions
         code_options.update(output.code_options)
-
-        # The config.dead_code_elimination flag is deprecated
-        # See https://github.com/pytorch/pytorch/issues/136862 for more information
-        if not config.dead_code_elimination:
-            warnings.warn(
-                "The config.dead_code_elimination flag is deprecated, it's now always true."
-            )
-
         propagate_inst_exn_table_entries(instructions)
         check_inst_exn_tab_entries_valid(instructions)
         instructions[:] = remove_pointless_jumps(remove_dead_code(instructions))


### PR DESCRIPTION
Fixes #136862

1.  removed dead code from torch/_dynamo/convert_frame.py
2.  ran `lintrunner -a` and all the tests passed.
3. ran the unit tests and everything seems to be in order. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames