### PR TITLE
Add torch.sum dtype promotion description

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -10592,7 +10592,7 @@ Args:
 Keyword args:
     {dtype}
 
-.. note:: Use the `dtype` argument if you need the result in a specific tensor type. 
+.. note:: Use the `dtype` argument if you need the result in a specific tensor type.
           Otherwise, the result type may be automatically promoted (e.g., from `torch.int32` to `torch.int64`).
 
 Example::

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -10592,6 +10592,9 @@ Args:
 Keyword args:
     {dtype}
 
+.. note:: Use the `dtype` argument if you need the result in a specific tensor type. 
+          Otherwise, the result type may be automatically promoted (e.g., from `torch.int32` to `torch.int64`).
+
 Example::
 
     >>> a = torch.randn(1, 3)


### PR DESCRIPTION
Fixes #82159

Add note description about type promotion of `torch.sum`.

**Test Result**

**Before**
![image](https://github.com/user-attachments/assets/fb952676-f190-4680-9e15-ea8c99d33c67)

**After**
![image](https://github.com/user-attachments/assets/ee0d46a6-5053-46d5-b412-5c919a40965a)

cc @mikaylagawarecki