### PR TITLE
Added Windows support for Inductor's has_dot debug function 

### DIFF
--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -44,7 +44,8 @@ GRAPHVIZ_COMMAND_SCALABLE = ["dot", "-Gnslimit=2", "-Gnslimit1=2", "-Gmaxiter=50
 @functools.lru_cache(None)
 def has_dot() -> bool:
     try:
-        subprocess.check_output(["which", "dot"], stderr=subprocess.PIPE)
+        which = "which" if os.name != 'nt' else "where"
+        subprocess.check_output([which, "dot"], stderr=subprocess.PIPE)
         return True
     except subprocess.SubprocessError:
         return False

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -44,7 +44,7 @@ GRAPHVIZ_COMMAND_SCALABLE = ["dot", "-Gnslimit=2", "-Gnslimit1=2", "-Gmaxiter=50
 @functools.lru_cache(None)
 def has_dot() -> bool:
     try:
-        which = "which" if os.name != 'nt' else "where"
+        which = "which" if os.name != "nt" else "where"
         subprocess.check_output([which, "dot"], stderr=subprocess.PIPE)
         return True
     except subprocess.SubprocessError:


### PR DESCRIPTION
The function has_dot cheks if the `dot` command is present assuming that the shell used has the `which` command. On Windows the equivalent is `where` which now is used if we are on that OS.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov