### PR TITLE
[ONNX] Fix 2GB exporting crash during onnx shape type inference

### DIFF
--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -657,7 +657,7 @@ def _optimize_graph(
             _C._jit_pass_onnx_graph_shape_type_inference(
                 graph, params_dict, GLOBALS.export_onnx_opset_version
             )
-        except RuntimeError as e:
+        except RuntimeError:
             # NOTE: shape type inference error should not stop the export process
             # https://github.com/pytorch/pytorch/issues/132205
             pass
@@ -1123,9 +1123,14 @@ def _model_to_graph(
         _C._jit_pass_dce_allow_deleting_nodes_with_side_effects(graph)
 
     if GLOBALS.onnx_shape_inference:
-        _C._jit_pass_onnx_graph_shape_type_inference(
-            graph, params_dict, GLOBALS.export_onnx_opset_version
-        )
+        try:
+            _C._jit_pass_onnx_graph_shape_type_inference(
+                graph, params_dict, GLOBALS.export_onnx_opset_version
+            )
+        except RuntimeError:
+            # NOTE: shape type inference error should not stop the export process
+            # https://github.com/pytorch/pytorch/issues/132205
+            pass
 
     params_dict = _C._jit_pass_onnx_eliminate_unused_items(graph, params_dict)
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -658,6 +658,8 @@ def _optimize_graph(
                 graph, params_dict, GLOBALS.export_onnx_opset_version
             )
         except RuntimeError as e:
+            # NOTE: shape type inference error should not stop the export process
+            # https://github.com/pytorch/pytorch/issues/132205
             pass
 
     return graph

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -653,9 +653,12 @@ def _optimize_graph(
     graph = _C._jit_pass_canonicalize(graph)
     _C._jit_pass_lint(graph)
     if GLOBALS.onnx_shape_inference:
-        _C._jit_pass_onnx_graph_shape_type_inference(
-            graph, params_dict, GLOBALS.export_onnx_opset_version
-        )
+        try:
+            _C._jit_pass_onnx_graph_shape_type_inference(
+                graph, params_dict, GLOBALS.export_onnx_opset_version
+            )
+        except RuntimeError as e:
+            pass
 
     return graph
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/132205

Regression happened after https://github.com/pytorch/pytorch/pull/128675 that ONNX shape type inference error stops the exporting process during shape type inference. ONNX shape type inference during the export only does it's best to fulfill the information, and should not crash the export.