### PR TITLE
Fix chromium logger missing dynamo end event

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1150,11 +1150,10 @@ def _compile(
             }
             metrics_context.update_outer(metrics)
             torch._dynamo.callback_handler.run_end_callbacks()
+            chromium_event_log.log_event_end(
+                "dynamo", time.time_ns(), {}, chromium_start_time, True
+            )
             # === END WARNING WARNING WARNING ===
-
-    chromium_event_log.log_event_end(
-        "dynamo", time.time_ns(), {}, chromium_start_time, True
-    )
 
 
 class ConvertFrame:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #140966
* #140964

This never ran lol because the try block would return results on success. We probably wanted this in the finally block.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames