### PR TITLE
[fr][ez] better log messages + minor fixups

### DIFF
--- a/tools/flight_recorder/components/builder.py
+++ b/tools/flight_recorder/components/builder.py
@@ -295,9 +295,9 @@ def build_collectives(
                 candidate_ranks | found_ranks
             ) <= dumps_ranks:
                 mismatch[pg_name] += 1
-                logger_msg = "Not all ranks joining collective %s at entry %s"
+                logger_msg = "Not all ranks joining collective, sequence number: %s"
                 missing_ranks = expected_ranks - (candidate_ranks | found_ranks)
-                entry_state.logging_info(
+                entry_state.log(
                     logger, logger_msg, format_frames, missing_ranks=missing_ranks
                 )
                 candidate_ranks.update(found_ranks)
@@ -320,10 +320,8 @@ def build_collectives(
                     if fail_check:
                         # When we see errors in all_to_all, it's hard to tell which rank is the source of the error.
                         mismatch[pg_name] += 1
-                        logger_msg = (
-                            "Input/output mismatch in the collective %s at entry %s"
-                        )
-                        entry_state.logging_info(
+                        logger_msg = "Input/output mismatch in the collective sequence number: %s"
+                        entry_state.log(
                             logger,
                             logger_msg,
                             format_frames,
@@ -348,10 +346,8 @@ def build_collectives(
             # case four: mismatch cases due to not same type, size mismatch or state mismatch.
             elif len(errors) > 0:
                 mismatch[pg_name] += 1
-                logger_msg = "Collective %s at entry %s errors"
-                entry_state.logging_info(
-                    logger, logger_msg, format_frames, errors=errors
-                )
+                logger_msg = "Collective sequence number: %s has errors"
+                entry_state.log(logger, logger_msg, format_frames, errors=errors)
                 candidate_ranks.update(found_ranks)
                 candidate_idx.update(found_idx)
                 found_idx.clear()

--- a/tools/flight_recorder/components/types.py
+++ b/tools/flight_recorder/components/types.py
@@ -220,8 +220,12 @@ class EntryState:
         self.collective_state = entry["state"]
         self.collective_frames = entry["frames"]
         self.expected_ranks = expected_ranks
+        self.missing_ranks: Set[int]
+        self.input_numel: int
+        self.output_numel: int
+        self.errors: Set[Tuple[int, MatchState]]
 
-    def logging_info(
+    def log(
         self,
         logger: FlightRecorderLogger,
         logger_msg: str,
@@ -233,8 +237,8 @@ class EntryState:
         logger.info(
             logger_msg,
             self.collective_seq_id,
-            self.record_id,
         )
+        logger.info("internal record id: %s", self.record_id)
         logger.info("group info: %s", self.pg_desc)
         logger.info("collective: %s", self.profiling_name)
         if missing_ranks:


### PR DESCRIPTION
Summary:
1. Clearly specify error messages that we are refering to a collective_sequence_id and an internal_record id for entry.
The entry id is semi-useless for the end consumer so at least let them know that this is an internal record id.
2. Add some missing fields in types.py. 
  self.missing_ranks = set()
  self.input_numel = tuple()
  self.output_numel = tuple()
  self.errors = set()

These were showing up as linter errors when I opened the file in vs-code

Test Plan:
```
buck2 run //caffe2/fb/flight_recorder:fr_trace -- -m f665492593-nerf_training-96ab95e0 -w 8 --mast_job_version 0 -a 0
Buck UI: https://www.internalfb.com/buck2/2cac9273-1b7b-47bf-867f-82f9a4c1d581
Network: Up: 0B  Down: 0B
Not all ranks joining collective: sequence number: 31117
internal record id: 31116
group info: 0:default_pg
collective: nccl:all_reduce
missing ranks: {3, 4, 5, 6, 7}
input sizes: [[1571911]]
output sizes: [[1571911]]
world size: 8
expected ranks: {0, 1, 2, 3, 4, 5, 6, 7}
collective state: scheduled
collective stack trace:
 all_reduce at /packages/fblearner.flow.canary/workflow#link-tree/torch/distributed/distributed_c10d.py:2707
wrapper at /packages/fblearner.flow.canary/workflow#link-tree/torch/distributed/c10d_logger.py:81
sync_buffers at /packages/fblearner.flow.canary/workflow#link-tree/xri_mapsr/neural_fields/models/gaussian_splatting.py:650
decorate_context at /packages/fblearner.flow.canary/workflow#link-tree/torch/utils/_contextlib.py:116
step at /packages/fblearner.flow.canary/workflow#link-tree/xri_mapsr/neural_fields/training/training_manager/splatting.py:356
main at /packages/fblearner.flow.canary/workflow#link-tree/xri_mapsr/neural_fields/nerf_training.py:260
main_impl at /packages/fblearner.flow.canary/workflow#link-tree/rl_aiep/mast/endpoint.py:57
main at /packages/fblearner.flow.canary/workflow#link-tree/rl_aiep/mast/endpoint.py:34
wrapper at /packages/fblearner.flow.canary/workflow#link-tree/torch/distributed/elastic/multiprocessing/errors/__init__.py:355
<module> at /packages/fblearner.flow.canary/workflow#link-tree/rl_aiep/mast/endpoint.py:118
_run_code at /packages/fblearner.flow.canary/workflow#link-tree/runtime/lib/python3.10/runpy.py:86
_run_module_as_main at /packages/fblearner.flow.canary/workflow#link-tree/runtime/lib/python3.10/runpy.py:196
run_as_main at /packages/fblearner.flow.canary/workflow#link-tree/__par__/bootstrap.py:69
run_as_main at /packages/fblearner.flow.canary/workflow#link-tree/__par__/meta_only/bootstrap.py:98
__invoke_main at /packages/fblearner.flow.canary/workflow#link-tree/__run_lpar_main__.py:28
<module> at /packages/fblearner.flow.canary/workflow#link-tree/__run_lpar_main__.py:31


...

Differential Revision: D66018461


