### PR TITLE
[export] fix loss_output in joint graph signature

### DIFF
--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -263,6 +263,33 @@ def forward(self, p_linear_weight, p_linear_bias, c_lifted_tensor_0, x):
         ep = export_for_training(net, inputs)
         ep = _export_forward_backward(ep)
 
+    def test_joint_loss_index(self):
+        from torch.export.graph_signature import OutputKind
+
+        class Foo(torch.nn.Module):
+            def __init__(self, index):
+                super().__init__()
+                self.l = torch.nn.Linear(4, 4)
+                self.index = index
+
+            def forward(self, x):
+                x = self.l(x)
+                x = x.sum()
+                if self.index == 0:
+                    return x, -x.detach()
+                else:
+                    return x.detach(), x
+
+        inputs = (torch.randn(4, 4),)
+        for i in [0, 1]:
+            ep = export_for_training(Foo(i), inputs)
+            ep_joint = _export_forward_backward(ep, joint_loss_index=i)
+            for j, spec in enumerate(ep_joint.graph_signature.output_specs):
+                if i == j:
+                    self.assertTrue(spec.kind == OutputKind.LOSS_OUTPUT)
+                else:
+                    self.assertTrue(spec.kind != OutputKind.LOSS_OUTPUT)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -594,7 +594,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
 
     output_specs = [
         OutputSpec(
-            OutputKind.LOSS_OUTPUT if joint_loss_index is not None else spec.kind,
+            OutputKind.LOSS_OUTPUT if i == joint_loss_index else spec.kind,
             update_arg(spec.arg, new_outputs[i]),
             old_new_placeholder_map.get(spec.target, spec.target),
         )

--- a/torch/export/graph_signature.py
+++ b/torch/export/graph_signature.py
@@ -283,11 +283,15 @@ class ExportGraphSignature:
         return tuple(user_inputs)
 
     # Graph node names of pytree-flattened outputs of original program
+    # For joint-graph purposes, will include the loss output.
     @property
     def user_outputs(self) -> Collection[Union[int, float, bool, None, str]]:
         user_outputs: List[Union[int, float, bool, None, str]] = []
         for s in self.output_specs:
-            if s.kind != OutputKind.USER_OUTPUT:
+            if s.kind not in [
+                OutputKind.USER_OUTPUT,
+                OutputKind.LOSS_OUTPUT,
+            ]:
                 continue
 
             if isinstance(s.arg, (TensorArgument, SymIntArgument, SymBoolArgument)):


### PR DESCRIPTION
Summary: joint-graph export is marking all outputs as LOSS_OUTPUT, fix so it marks only the correct one

Test Plan: test_experimental

Differential Revision: D66117412


