### PR TITLE
[BE]: Apply PERF401 autofixes from ruff

### DIFF
--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -64,8 +64,7 @@ def _add_op_to_registry(registry, op, fn):
         overloads.append(op)
     else:
         assert isinstance(op, OpOverloadPacket)
-        for ol in op.overloads():
-            overloads.append(getattr(op, ol))
+        overloads.extend(getattr(op, ol) for ol in op.overloads())
 
     for op_overload in overloads:
         if op_overload in registry:

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -64,7 +64,8 @@ def _add_op_to_registry(registry, op, fn):
         overloads.append(op)
     else:
         assert isinstance(op, OpOverloadPacket)
-        overloads.extend(getattr(op, ol) for ol in op.overloads())
+        for ol in op.overloads():
+            overloads.append(getattr(op, ol))
 
     for op_overload in overloads:
         if op_overload in registry:

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2301,7 +2301,10 @@ def native_batch_norm_backward(
     broadcast_mask: List[int] = [1] * input_rank
     broadcast_mask[axis] = input_shape[axis]
 
-    reduction_axes: List[int] = [i for i in range(input_rank) if i != axis]
+    reduction_axes: List[int] = []
+    for i in range(input_rank):
+        if i != axis:
+            reduction_axes.append(i)
 
     mean = _broadcast_batch_norm_backward(mean, broadcast_mask)  # type: ignore[arg-type]
     norm = 1.0 / num_features
@@ -4487,8 +4490,10 @@ def matmul(tensor1, tensor2, *, is_out=False):
         m2 = tensor2.size(-2) if dim_tensor2 > 1 else tensor2.size(-1)
         p = tensor2.size(-1) if dim_tensor2 > 1 else 1
 
+        batch_tensor2: List[int] = []
         # TODO: handling of slice
-        batch_tensor2: List[int] = [tensor2.size(i) for i in range(dim_tensor2 - 2)]
+        for i in range(dim_tensor2 - 2):
+            batch_tensor2.append(tensor2.size(i))
 
         # Same optimization for the gradients as that in should_fold
         # If we're going to broadcast, we force it to go through the should_fold branch

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2301,10 +2301,7 @@ def native_batch_norm_backward(
     broadcast_mask: List[int] = [1] * input_rank
     broadcast_mask[axis] = input_shape[axis]
 
-    reduction_axes: List[int] = []
-    for i in range(input_rank):
-        if i != axis:
-            reduction_axes.append(i)
+    reduction_axes: List[int] = [i for i in range(input_rank) if i != axis]
 
     mean = _broadcast_batch_norm_backward(mean, broadcast_mask)  # type: ignore[arg-type]
     norm = 1.0 / num_features
@@ -4490,10 +4487,8 @@ def matmul(tensor1, tensor2, *, is_out=False):
         m2 = tensor2.size(-2) if dim_tensor2 > 1 else tensor2.size(-1)
         p = tensor2.size(-1) if dim_tensor2 > 1 else 1
 
-        batch_tensor2: List[int] = []
         # TODO: handling of slice
-        for i in range(dim_tensor2 - 2):
-            batch_tensor2.append(tensor2.size(i))
+        batch_tensor2: List[int] = [tensor2.size(i) for i in range(dim_tensor2 - 2)]
 
         # Same optimization for the gradients as that in should_fold
         # If we're going to broadcast, we force it to go through the should_fold branch

--- a/torch/_decomp/decompositions_for_jvp.py
+++ b/torch/_decomp/decompositions_for_jvp.py
@@ -251,7 +251,10 @@ def native_batch_norm_backward(
     broadcast_mask = [1] * input_rank
     broadcast_mask[axis] = input_shape[axis]
 
-    reduction_axes: List[int] = [i for i in range(input_rank) if i != axis]
+    reduction_axes: List[int] = []
+    for i in range(input_rank):
+        if i != axis:
+            reduction_axes.append(i)
 
     mean = torch.reshape(mean, broadcast_mask)
     norm = 1.0 / num_features

--- a/torch/_decomp/decompositions_for_jvp.py
+++ b/torch/_decomp/decompositions_for_jvp.py
@@ -251,10 +251,7 @@ def native_batch_norm_backward(
     broadcast_mask = [1] * input_rank
     broadcast_mask[axis] = input_shape[axis]
 
-    reduction_axes: List[int] = []
-    for i in range(input_rank):
-        if i != axis:
-            reduction_axes.append(i)
+    reduction_axes: List[int] = [i for i in range(input_rank) if i != axis]
 
     mean = torch.reshape(mean, broadcast_mask)
     norm = 1.0 / num_features

--- a/torch/_dynamo/backends/distributed.py
+++ b/torch/_dynamo/backends/distributed.py
@@ -67,8 +67,7 @@ def pretty_print_buckets(buckets: List[Bucket], bucket_bytes_cap: int):
     for idx, bucket in enumerate(reversed(buckets)):
         if len(bucket.params) > 0:
             rows.append((idx, bucket.size, bucket.params[0]))
-            for param in bucket.params[1:]:
-                rows.append((None, None, param))
+            rows.extend((None, None, param) for param in bucket.params[1:])
         if bucket.opcount_increased_to_capture_external_output > 0:
             extended_buckets.append(
                 (

--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -1140,7 +1140,12 @@ def update_offsets(instructions) -> None:
 
 def debug_bytes(*args) -> str:
     index = range(max(map(len, args)))
-    result = [" ".join(f"{x:03}" for x in arg) for arg in [index] + list(args) + [[int(a != b) for a, b in zip(args[-1], args[-2])]]]
+    result = [
+        " ".join(f"{x:03}" for x in arg)
+        for arg in [index]
+        + list(args)
+        + [[int(a != b) for a, b in zip(args[-1], args[-2])]]
+    ]
 
     return "bytes mismatch\n" + "\n".join(result)
 

--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -1140,11 +1140,7 @@ def update_offsets(instructions) -> None:
 
 def debug_bytes(*args) -> str:
     index = range(max(map(len, args)))
-    result = []
-    for arg in (
-        [index] + list(args) + [[int(a != b) for a, b in zip(args[-1], args[-2])]]
-    ):
-        result.append(" ".join(f"{x:03}" for x in arg))
+    result = [" ".join(f"{x:03}" for x in arg) for arg in [index] + list(args) + [[int(a != b) for a, b in zip(args[-1], args[-2])]]]
 
     return "bytes mismatch\n" + "\n".join(result)
 

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -669,11 +669,15 @@ class AutogradCompilerInstance:
             input_nodes_and_users = []
             input_nodes_and_users.extend(list(input_nodes))
             for input_node in input_nodes:
-                input_nodes_and_users.extend(user for user in list(input_node.users.keys()) if not (
+                input_nodes_and_users.extend(
+                    user
+                    for user in list(input_node.users.keys())
+                    if not (
                         user.op == "call_function"
                         and user.target == call_hook
                         and node.kwargs.get("hook_type", None) == "post_hook"
-                    ))
+                    )
+                )
 
             arg = max(input_nodes_and_users)  # last input users
             if (

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -478,10 +478,8 @@ class AutogradCompilerInstance:
 
     @staticmethod
     def get_all_nodes(args):
-        nodes = []
-        for n in args:
-            if type(n) is torch.fx.Node:  # filter out non-Node args, like None
-                nodes.append(n)
+        # filter out non-Node args, like None
+        nodes = [n for n in args if type(n) is torch.fx.Node]
         return nodes
 
     @staticmethod
@@ -671,13 +669,11 @@ class AutogradCompilerInstance:
             input_nodes_and_users = []
             input_nodes_and_users.extend(list(input_nodes))
             for input_node in input_nodes:
-                for user in list(input_node.users.keys()):
-                    if not (
+                input_nodes_and_users.extend(user for user in list(input_node.users.keys()) if not (
                         user.op == "call_function"
                         and user.target == call_hook
                         and node.kwargs.get("hook_type", None) == "post_hook"
-                    ):
-                        input_nodes_and_users.append(user)
+                    ))
 
             arg = max(input_nodes_and_users)  # last input users
             if (

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -2518,7 +2518,9 @@ def recompilation_reason_for_no_tensor_aliasing_guard(guard_manager, scope):
         tensor_id = id(eval(tensor_source, global_scope, scope))
         ids_to_source[tensor_id].append(tensor_source)
 
-    duplicate_tensors = [f"{ids_to_source[key]}" for key in ids_to_source if len(ids_to_source[key]) > 1]
+    duplicate_tensors = [
+        f"{ids_to_source[key]}" for key in ids_to_source if len(ids_to_source[key]) > 1
+    ]
 
     reason = ", ".join(duplicate_tensors)
     return [f"Duplicate tensors found: {reason}"]

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -2511,7 +2511,6 @@ def make_torch_function_mode_stack_guard(intial_stack):
 
 
 def recompilation_reason_for_no_tensor_aliasing_guard(guard_manager, scope):
-    duplicate_tensors = []
     global_scope = dict(guard_manager.global_scope)
     ids_to_source = collections.defaultdict(list)
     for tensor_source in guard_manager.no_tensor_aliasing_sources:  # type: ignore[attr-defined]
@@ -2519,9 +2518,7 @@ def recompilation_reason_for_no_tensor_aliasing_guard(guard_manager, scope):
         tensor_id = id(eval(tensor_source, global_scope, scope))
         ids_to_source[tensor_id].append(tensor_source)
 
-    for key in ids_to_source:
-        if len(ids_to_source[key]) > 1:
-            duplicate_tensors.append(f"{ids_to_source[key]}")
+    duplicate_tensors = [f"{ids_to_source[key]}" for key in ids_to_source if len(ids_to_source[key]) > 1]
 
     reason = ", ".join(duplicate_tensors)
     return [f"Duplicate tensors found: {reason}"]

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1463,9 +1463,7 @@ class OutputGraph:
         return compiled_fn
 
     def example_inputs(self) -> List[torch.Tensor]:
-        result = []
-        for arg in self.graphargs:
-            result.append(arg.example)
+        result = [arg.example for arg in self.graphargs]
         return result
 
     def remove_unused_graphargs(self) -> None:

--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -252,8 +252,7 @@ def _filter_iter(l1, l2, cond):
 def _load_tuple_and_call(tup):
     insts: List[Instruction] = []
     _initial_push_null(insts)
-    for val in tup:
-        insts.append(create_instruction("LOAD_CONST", argval=val))
+    insts.extend(create_instruction("LOAD_CONST", argval=val) for val in tup)
     insts.extend(create_call_function(len(tup), False))
     return insts
 

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -95,9 +95,7 @@ def collect_results(
     results.append(buffers)
     for example in example_inputs:
         if isinstance(example, (tuple, list)):
-            for inp in example:
-                if isinstance(inp, torch.Tensor):
-                    results.append(inp.grad)
+            results.extend(inp.grad for inp in example if isinstance(inp, torch.Tensor))
         else:
             if isinstance(example, torch.Tensor):
                 results.append(example.grad)

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1458,9 +1458,7 @@ def checkpoint_params(gm):
         rng_state = torch.clone(torch.random.get_rng_state())
         if torch.cuda.is_available():
             cuda_rng_state = torch.clone(torch.cuda.get_rng_state())
-        saved_state = []
-        for param in itertools.chain(gm.parameters(), gm.buffers()):
-            saved_state.append((param, param._version, torch.clone(param)))
+        saved_state = [(param, param._version, torch.clone(param)) for param in itertools.chain(gm.parameters(), gm.buffers())]
 
     def restore():
         with torch.no_grad():

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1458,7 +1458,10 @@ def checkpoint_params(gm):
         rng_state = torch.clone(torch.random.get_rng_state())
         if torch.cuda.is_available():
             cuda_rng_state = torch.clone(torch.cuda.get_rng_state())
-        saved_state = [(param, param._version, torch.clone(param)) for param in itertools.chain(gm.parameters(), gm.buffers())]
+        saved_state = [
+            (param, param._version, torch.clone(param))
+            for param in itertools.chain(gm.parameters(), gm.buffers())
+        ]
 
     def restore():
         with torch.no_grad():

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1765,10 +1765,7 @@ class BuiltinVariable(VariableTracker):
                     # tracked fakes to produce incorrect guards. This is sound because the TensorVariable
                     # coming out of set_() below will be a new one, and get
                     # installed in tracked fakes.
-                    to_remove = []
-                    for tf in tx.output.tracked_fakes:
-                        if tf.source == obj.source:
-                            to_remove.append(tf)
+                    to_remove = [tf for tf in tx.output.tracked_fakes if tf.source == obj.source]
                     for tf in to_remove:
                         tx.output.tracked_fakes.remove(tf)
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1765,7 +1765,9 @@ class BuiltinVariable(VariableTracker):
                     # tracked fakes to produce incorrect guards. This is sound because the TensorVariable
                     # coming out of set_() below will be a new one, and get
                     # installed in tracked fakes.
-                    to_remove = [tf for tf in tx.output.tracked_fakes if tf.source == obj.source]
+                    to_remove = [
+                        tf for tf in tx.output.tracked_fakes if tf.source == obj.source
+                    ]
                     for tf in to_remove:
                         tx.output.tracked_fakes.remove(tf)
 

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1027,12 +1027,15 @@ class SDPAKernelVariable(ContextWrappingVariable):
     @staticmethod
     def _backends_to_nodes(tx, backends):
         # convert to/from string in order to bake the backend into FX graph
-        nodes = [tx.output.create_node(
-                    "call_function",
-                    torch.nn.attention._backend_from_string,
-                    (backend.name,),
-                    {},
-                ) for backend in backends]
+        nodes = [
+            tx.output.create_node(
+                "call_function",
+                torch.nn.attention._backend_from_string,
+                (backend.name,),
+                {},
+            )
+            for backend in backends
+        ]
         return nodes
 
     def enter(self, tx):

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1026,17 +1026,13 @@ class SDPAKernelVariable(ContextWrappingVariable):
 
     @staticmethod
     def _backends_to_nodes(tx, backends):
-        nodes = []
-        for backend in backends:
-            # convert to/from string in order to bake the backend into FX graph
-            nodes.append(
-                tx.output.create_node(
+        # convert to/from string in order to bake the backend into FX graph
+        nodes = [tx.output.create_node(
                     "call_function",
                     torch.nn.attention._backend_from_string,
                     (backend.name,),
                     {},
-                )
-            )
+                ) for backend in backends]
         return nodes
 
     def enter(self, tx):

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -48,7 +48,9 @@ class ItertoolsVariable(VariableTracker):
             and all(arg.has_unpack_var_sequence(tx) for arg in args)
         ):
             seqs = [arg.unpack_var_sequence(tx) for arg in args]
-            items = [variables.TupleVariable(list(item)) for item in itertools.product(*seqs)]
+            items = [
+                variables.TupleVariable(list(item)) for item in itertools.product(*seqs)
+            ]
             return variables.ListIteratorVariable(
                 items, mutation_type=ValueMutationNew()
             )

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -48,9 +48,7 @@ class ItertoolsVariable(VariableTracker):
             and all(arg.has_unpack_var_sequence(tx) for arg in args)
         ):
             seqs = [arg.unpack_var_sequence(tx) for arg in args]
-            items = []
-            for item in itertools.product(*seqs):
-                items.append(variables.TupleVariable(list(item)))
+            items = [variables.TupleVariable(list(item)) for item in itertools.product(*seqs)]
             return variables.ListIteratorVariable(
                 items, mutation_type=ValueMutationNew()
             )

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -776,14 +776,10 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             ):
                 assert self.source  # OrderedDict, dict subtypes must always have source
                 assert not (args or kwargs)
-                items = []
                 keys = self.call_method(tx, "keys", [], {})
-                for key in keys.force_unpack_var_sequence(tx):
-                    items.append(
-                        TupleVariable(
+                items = [TupleVariable(
                             [key, self.odict_getitem(tx, key)],
-                        )
-                    )
+                        ) for key in keys.force_unpack_var_sequence(tx)]
                 tx.output.guard_on_key_order.add(self.source.name())
                 return TupleVariable(items)
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -777,9 +777,12 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 assert self.source  # OrderedDict, dict subtypes must always have source
                 assert not (args or kwargs)
                 keys = self.call_method(tx, "keys", [], {})
-                items = [TupleVariable(
-                            [key, self.odict_getitem(tx, key)],
-                        ) for key in keys.force_unpack_var_sequence(tx)]
+                items = [
+                    TupleVariable(
+                        [key, self.odict_getitem(tx, key)],
+                    )
+                    for key in keys.force_unpack_var_sequence(tx)
+                ]
                 tx.output.guard_on_key_order.add(self.source.name())
                 return TupleVariable(items)
 

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -833,9 +833,7 @@ class TS2FXGraphConverter:
         self._convert_prim_iterator(node)
 
     def _convert_prim_iterator(self, node: torch._C.Node):
-        output_list = []
-        for inp in node.inputs():
-            output_list.append(self.get_fx_value_by_ir_value(inp))
+        output_list = [self.get_fx_value_by_ir_value(inp) for inp in node.inputs()]
 
         output_name = node.output().debugName()
         self.name_to_node[output_name] = output_list

--- a/torch/_export/db/examples/static_for_loop.py
+++ b/torch/_export/db/examples/static_for_loop.py
@@ -7,9 +7,8 @@ class StaticForLoop(torch.nn.Module):
     """
 
     def forward(self, x):
-        ret = []
-        for i in range(10):  # constant
-            ret.append(i + x)
+        # constant
+        ret = [i + x for i in range(10)]
         return ret
 
 example_args = (torch.randn(3, 2),)

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -1666,9 +1666,7 @@ class GraphModuleDeserializer(metaclass=Final):
                 ) from e
 
         # Outputs: convert to a single `output` node.
-        outputs = []
-        for output in serialized_graph.outputs:
-            outputs.append(self.deserialize_graph_output(output))
+        outputs = [self.deserialize_graph_output(output) for output in serialized_graph.outputs]
 
         if serialized_graph.is_single_tensor_return:
             assert len(outputs) == 1
@@ -2035,9 +2033,7 @@ class GraphModuleDeserializer(metaclass=Final):
             if len(value) == 0:
                 return []
             elif typ_ == "as_tensors":
-                result = []
-                for arg in value:
-                    result.append(self.serialized_name_to_node[arg.name])
+                result = [self.serialized_name_to_node[arg.name] for arg in value]
                 return result
             elif typ_ in ("as_ints", "as_floats", "as_bools", "as_strings"):
                 # convert from serialized.python.types.List to python list

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -1306,7 +1306,9 @@ def merge_view_inputs(
             mutated_input_info[inpt_idx].mutates_data
             for inpt_idx in aliased_input_indices
         ):
-            other_args.extend(fwd_inputs[curr_idx] for curr_idx in aliased_input_indices)
+            other_args.extend(
+                fwd_inputs[curr_idx] for curr_idx in aliased_input_indices
+            )
             continue
 
         # Here, we attempt to do a more complicated check to detect false aliasing
@@ -1319,7 +1321,9 @@ def merge_view_inputs(
             fwd_inputs, aliased_input_indices
         )
         if len(aliased_input_indices_no_false_sharing) <= 1:
-            other_args.extend(fwd_inputs[curr_idx] for curr_idx in aliased_input_indices)
+            other_args.extend(
+                fwd_inputs[curr_idx] for curr_idx in aliased_input_indices
+            )
             continue
 
         # We detected an input that was mutated, AND aliases with another input.

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -1306,8 +1306,7 @@ def merge_view_inputs(
             mutated_input_info[inpt_idx].mutates_data
             for inpt_idx in aliased_input_indices
         ):
-            for curr_idx in aliased_input_indices:
-                other_args.append(fwd_inputs[curr_idx])
+            other_args.extend(fwd_inputs[curr_idx] for curr_idx in aliased_input_indices)
             continue
 
         # Here, we attempt to do a more complicated check to detect false aliasing
@@ -1320,8 +1319,7 @@ def merge_view_inputs(
             fwd_inputs, aliased_input_indices
         )
         if len(aliased_input_indices_no_false_sharing) <= 1:
-            for curr_idx in aliased_input_indices:
-                other_args.append(fwd_inputs[curr_idx])
+            other_args.extend(fwd_inputs[curr_idx] for curr_idx in aliased_input_indices)
             continue
 
         # We detected an input that was mutated, AND aliases with another input.

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -217,9 +217,7 @@ def trace_map(proxy_mode, func_overload, f, xs, pos_args):
 
 @map_impl.py_impl(DispatchKey.CompositeExplicitAutograd)
 def map_dense(f, xs, pos_args):
-    pytrees = []
-    for inp in _unstack_pytree(xs):
-        pytrees.append(f(*inp, *pos_args))
+    pytrees = [f(*inp, *pos_args) for inp in _unstack_pytree(xs)]
     return _stack_pytree(pytrees)
 
 

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -532,8 +532,7 @@ def analyze_kernel_mutations(
                 )
                 stack.extend(arg for arg, mutated in zip(op.args, mutations) if mutated)
             else:
-                for idx in MUTATION_OPS.get(op.name, []):
-                    stack.append(op.args[idx])
+                stack.extend(op.args[idx] for idx in MUTATION_OPS.get(op.name, []))
 
     # The following is an iterative DFS algorithm
     mutated = [False] * num_args

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -388,9 +388,7 @@ def _unstack_pytree(xs):
 
     a = zip(*flat_xs)
 
-    pytrees = []
-    for tuple in a:
-        pytrees.append(pytree.tree_unflatten(tuple, inspec))
+    pytrees = [pytree.tree_unflatten(tuple, inspec) for tuple in a]
     return pytrees
 
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2103,13 +2103,10 @@ class AotCodeCompiler:
                 aot_constants = struct.pack("qq", consts_size + 8, magic_number)
 
             consts_o = _compile_consts(aot_constants, sys.platform)
-            kernels_o = []
             gpu_codecache: Union[ROCmCodeCache, CUDACodeCache] = (
                 ROCmCodeCache() if torch.version.hip else CUDACodeCache()
             )
-            for entry in gpu_codecache.cache.values():
-                if entry.output_path.endswith(".o"):
-                    kernels_o.append(entry.output_path)
+            kernels_o = [entry.output_path for entry in gpu_codecache.cache.values() if entry.output_path.endswith(".o")]
             kernels_o = " ".join(kernels_o)
 
             output_name, output_dir = get_name_and_dir_from_output_file_path(output_so)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2106,7 +2106,11 @@ class AotCodeCompiler:
             gpu_codecache: Union[ROCmCodeCache, CUDACodeCache] = (
                 ROCmCodeCache() if torch.version.hip else CUDACodeCache()
             )
-            kernels_o = [entry.output_path for entry in gpu_codecache.cache.values() if entry.output_path.endswith(".o")]
+            kernels_o = [
+                entry.output_path
+                for entry in gpu_codecache.cache.values()
+                if entry.output_path.endswith(".o")
+            ]
             kernels_o = " ".join(kernels_o)
 
             output_name, output_dir = get_name_and_dir_from_output_file_path(output_so)

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -4800,7 +4800,7 @@ class LoopLevel:
 
     def split_with_tiling(self, depth, factor):
         def clone_inner():
-            inner = []
+            inner: List[LoopLevel] = []
             if self.inner:
                 inner.extend(loop.clone() for loop in self.inner)
             return inner

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -4802,8 +4802,7 @@ class LoopLevel:
         def clone_inner():
             inner = []
             if self.inner:
-                for loop in self.inner:
-                    inner.append(loop.clone())
+                inner.extend(loop.clone() for loop in self.inner)
             return inner
 
         def do_split_with_tiling():

--- a/torch/_inductor/codegen/debug_utils.py
+++ b/torch/_inductor/codegen/debug_utils.py
@@ -150,18 +150,10 @@ class DebugPrinterManager:
         # get the list of args_to_print_or_save
         # TODO: Find a more reliable way to detect kernel args types to print for extern kernel calls
         if kernel_type == "extern":
-            args_to_print_or_save_extern = []
-            for arg in args_to_print_or_save:
-                if arg.startswith(("buf", "arg")):
-                    args_to_print_or_save_extern.append(arg)
+            args_to_print_or_save_extern = [arg for arg in args_to_print_or_save if arg.startswith(("buf", "arg"))]
             self.args_to_print_or_save = args_to_print_or_save_extern
         elif kernel_type == "cpp":
-            args_to_print_or_save_cpp = []
-            for arg in args_to_print_or_save:
-                if arg.startswith(("buf", "arg")):
-                    args_to_print_or_save_cpp.append(
-                        f"convert_arrayref_tensor_to_tensor({arg})"
-                    )
+            args_to_print_or_save_cpp = [f"convert_arrayref_tensor_to_tensor({arg})" for arg in args_to_print_or_save if arg.startswith(("buf", "arg"))]
             self.args_to_print_or_save = args_to_print_or_save_cpp
         else:
             self.args_to_print_or_save = args_to_print_or_save

--- a/torch/_inductor/codegen/debug_utils.py
+++ b/torch/_inductor/codegen/debug_utils.py
@@ -150,10 +150,16 @@ class DebugPrinterManager:
         # get the list of args_to_print_or_save
         # TODO: Find a more reliable way to detect kernel args types to print for extern kernel calls
         if kernel_type == "extern":
-            args_to_print_or_save_extern = [arg for arg in args_to_print_or_save if arg.startswith(("buf", "arg"))]
+            args_to_print_or_save_extern = [
+                arg for arg in args_to_print_or_save if arg.startswith(("buf", "arg"))
+            ]
             self.args_to_print_or_save = args_to_print_or_save_extern
         elif kernel_type == "cpp":
-            args_to_print_or_save_cpp = [f"convert_arrayref_tensor_to_tensor({arg})" for arg in args_to_print_or_save if arg.startswith(("buf", "arg"))]
+            args_to_print_or_save_cpp = [
+                f"convert_arrayref_tensor_to_tensor({arg})"
+                for arg in args_to_print_or_save
+                if arg.startswith(("buf", "arg"))
+            ]
             self.args_to_print_or_save = args_to_print_or_save_cpp
         else:
             self.args_to_print_or_save = args_to_print_or_save

--- a/torch/_inductor/codegen/halide.py
+++ b/torch/_inductor/codegen/halide.py
@@ -1392,9 +1392,7 @@ class HalideKernel(SIMDKernel):
             result.append((call_str, arg))
             if isinstance(arg, TensorArg):
                 assert arg.offset == 0 and arg.alias_of is None
-                for alias in self.buffer_aliases.get(arg.name, ()):
-                    result.append(
-                        (
+                result.extend((
                             None,
                             TensorArg(
                                 alias,
@@ -1403,8 +1401,7 @@ class HalideKernel(SIMDKernel):
                                 arg.offset,
                                 alias_of=arg.name,
                             ),
-                        )
-                    )
+                        ) for alias in self.buffer_aliases.get(arg.name, ()))
         return result
 
     def halide_kernel_meta(self) -> HalideMeta:

--- a/torch/_inductor/codegen/halide.py
+++ b/torch/_inductor/codegen/halide.py
@@ -1392,16 +1392,19 @@ class HalideKernel(SIMDKernel):
             result.append((call_str, arg))
             if isinstance(arg, TensorArg):
                 assert arg.offset == 0 and arg.alias_of is None
-                result.extend((
-                            None,
-                            TensorArg(
-                                alias,
-                                arg.buffer,
-                                arg.dtype,
-                                arg.offset,
-                                alias_of=arg.name,
-                            ),
-                        ) for alias in self.buffer_aliases.get(arg.name, ()))
+                result.extend(
+                    (
+                        None,
+                        TensorArg(
+                            alias,
+                            arg.buffer,
+                            arg.dtype,
+                            arg.offset,
+                            alias_of=arg.name,
+                        ),
+                    )
+                    for alias in self.buffer_aliases.get(arg.name, ())
+                )
         return result
 
     def halide_kernel_meta(self) -> HalideMeta:

--- a/torch/_inductor/codegen/multi_kernel.py
+++ b/torch/_inductor/codegen/multi_kernel.py
@@ -72,7 +72,11 @@ def get_all_call_args(call_args_list, arg_types_list):
 
 
 def get_numel_argdefs(kernel):
-    numel_argdefs = [f"{tree.prefix}numel" for tree in kernel.range_trees if tree.prefix != "r" or kernel.inside_reduction]
+    numel_argdefs = [
+        f"{tree.prefix}numel"
+        for tree in kernel.range_trees
+        if tree.prefix != "r" or kernel.inside_reduction
+    ]
 
     return numel_argdefs
 

--- a/torch/_inductor/codegen/multi_kernel.py
+++ b/torch/_inductor/codegen/multi_kernel.py
@@ -72,10 +72,7 @@ def get_all_call_args(call_args_list, arg_types_list):
 
 
 def get_numel_argdefs(kernel):
-    numel_argdefs = []
-    for tree in kernel.range_trees:
-        if tree.prefix != "r" or kernel.inside_reduction:
-            numel_argdefs.append(f"{tree.prefix}numel")
+    numel_argdefs = [f"{tree.prefix}numel" for tree in kernel.range_trees if tree.prefix != "r" or kernel.inside_reduction]
 
     return numel_argdefs
 

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -111,12 +111,9 @@ def _default_custom_combo_kernel_horizontal_partition(
                 len(large_pointwise),
             )
             not_reduction = [n for n in not_reduction if n not in large_pointwise]
-            for node in large_pointwise:
-                nodes_per_ndim.append([node])
+            nodes_per_ndim.extend([node] for node in large_pointwise)
 
-        for g in (not_reduction, short_reduction, long_reduction):
-            if g:
-                nodes_per_ndim.append(g)
+        nodes_per_ndim.extend(g for g in (not_reduction, short_reduction, long_reduction) if g)
 
     assert sum(len(p) for p in nodes_per_ndim) == len(nodes)
     return nodes_per_ndim

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -76,7 +76,7 @@ def _default_custom_combo_kernel_horizontal_partition(
     tilings = [node_info_map[n][1] for n in nodes]
 
     max_dims = max(len(t) for t in tilings)
-    nodes_per_ndim = []
+    nodes_per_ndim: List[List[BaseSchedulerNode]] = []
     for i in range(2, max_dims + 1):
         group_per_dim = [n for n, t in zip(nodes, tilings) if len(t) == i]
         reduction = [

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -113,7 +113,9 @@ def _default_custom_combo_kernel_horizontal_partition(
             not_reduction = [n for n in not_reduction if n not in large_pointwise]
             nodes_per_ndim.extend([node] for node in large_pointwise)
 
-        nodes_per_ndim.extend(g for g in (not_reduction, short_reduction, long_reduction) if g)
+        nodes_per_ndim.extend(
+            g for g in (not_reduction, short_reduction, long_reduction) if g
+        )
 
     assert sum(len(p) for p in nodes_per_ndim) == len(nodes)
     return nodes_per_ndim

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -741,8 +741,8 @@ def _setup_standard_sys_libs(
 
 
 def _get_build_args_of_chosen_isa(vec_isa: VecISA) -> Tuple[List[str], List[str]]:
-    macros = []
-    build_flags = []
+    macros: List[str] = []
+    build_flags: List[str] = []
     if vec_isa != invalid_vec_isa:
         # Add Windows support later.
         macros.extend(copy.deepcopy(x) for x in vec_isa.build_macro())

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -288,8 +288,7 @@ def get_compiler_version_info(compiler: str) -> str:
 
 # =============================== cpp builder ===============================
 def _append_list(dest_list: List[str], src_list: List[str]) -> None:
-    for item in src_list:
-        dest_list.append(copy.deepcopy(item))
+    dest_list.extend(copy.deepcopy(item) for item in src_list)
 
 
 def _remove_duplication_in_list(orig_list: List[str]) -> List[str]:
@@ -746,8 +745,7 @@ def _get_build_args_of_chosen_isa(vec_isa: VecISA) -> Tuple[List[str], List[str]
     build_flags = []
     if vec_isa != invalid_vec_isa:
         # Add Windows support later.
-        for x in vec_isa.build_macro():
-            macros.append(copy.deepcopy(x))
+        macros.extend(copy.deepcopy(x) for x in vec_isa.build_macro())
 
         build_flags = [vec_isa.build_arch_flags()]
 

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -398,7 +398,11 @@ def valid_vec_isa_list() -> List[VecISA]:
         arch value is x86_64 on Linux, and the value is AMD64 on Windows.
         """
         _cpu_supported_x86_isa = x86_isa_checker()
-        isa_list.extend(isa for isa in supported_vec_isa_list if all(flag in _cpu_supported_x86_isa for flag in str(isa).split()) and isa)
+        isa_list.extend(
+            isa
+            for isa in supported_vec_isa_list
+            if all(flag in _cpu_supported_x86_isa for flag in str(isa).split()) and isa
+        )
 
     return isa_list
 

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -398,9 +398,7 @@ def valid_vec_isa_list() -> List[VecISA]:
         arch value is x86_64 on Linux, and the value is AMD64 on Windows.
         """
         _cpu_supported_x86_isa = x86_isa_checker()
-        for isa in supported_vec_isa_list:
-            if all(flag in _cpu_supported_x86_isa for flag in str(isa).split()) and isa:
-                isa_list.append(isa)
+        isa_list.extend(isa for isa in supported_vec_isa_list if all(flag in _cpu_supported_x86_isa for flag in str(isa).split()) and isa)
 
     return isa_list
 

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -621,13 +621,8 @@ class CUDAWarmupNode:
         }
 
         def get_non_cudagraph_inps() -> List[weakref.ReferenceType[UntypedStorage]]:
-            non_cudagraph_inps = []
-            for t in itertools.chain(new_inputs, self.wrapped_function.constants):
-                if (
-                    isinstance(t, torch.Tensor)
-                    and t.untyped_storage().data_ptr() not in existing_path_data_ptrs
-                ):
-                    non_cudagraph_inps.append(weakref.ref(t.untyped_storage()))
+            non_cudagraph_inps = [weakref.ref(t.untyped_storage()) for t in itertools.chain(new_inputs, self.wrapped_function.constants) if isinstance(t, torch.Tensor)
+                    and t.untyped_storage().data_ptr() not in existing_path_data_ptrs]
             return non_cudagraph_inps
 
         non_cudagraph_inps_storages = get_non_cudagraph_inps()
@@ -1709,12 +1704,8 @@ def get_block_addrs(pool_id: Tuple[int, int], live_only: bool = True) -> List[in
 
 
 def format_tb(frames: List[Any]) -> str:
-    formatted_traceback = []
 
-    for entry in frames:
-        formatted_traceback.append(
-            traceback.FrameSummary(entry["filename"], entry["line"], entry["name"])
-        )
+    formatted_traceback = [traceback.FrameSummary(entry["filename"], entry["line"], entry["name"]) for entry in frames]
 
     return "".join(traceback.format_list(formatted_traceback))
 

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -621,8 +621,12 @@ class CUDAWarmupNode:
         }
 
         def get_non_cudagraph_inps() -> List[weakref.ReferenceType[UntypedStorage]]:
-            non_cudagraph_inps = [weakref.ref(t.untyped_storage()) for t in itertools.chain(new_inputs, self.wrapped_function.constants) if isinstance(t, torch.Tensor)
-                    and t.untyped_storage().data_ptr() not in existing_path_data_ptrs]
+            non_cudagraph_inps = [
+                weakref.ref(t.untyped_storage())
+                for t in itertools.chain(new_inputs, self.wrapped_function.constants)
+                if isinstance(t, torch.Tensor)
+                and t.untyped_storage().data_ptr() not in existing_path_data_ptrs
+            ]
             return non_cudagraph_inps
 
         non_cudagraph_inps_storages = get_non_cudagraph_inps()
@@ -1704,8 +1708,10 @@ def get_block_addrs(pool_id: Tuple[int, int], live_only: bool = True) -> List[in
 
 
 def format_tb(frames: List[Any]) -> str:
-
-    formatted_traceback = [traceback.FrameSummary(entry["filename"], entry["line"], entry["name"]) for entry in frames]
+    formatted_traceback = [
+        traceback.FrameSummary(entry["filename"], entry["line"], entry["name"])
+        for entry in frames
+    ]
 
     return "".join(traceback.format_list(formatted_traceback))
 

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -127,9 +127,7 @@ class MemoryDep(Dep):
             return None
 
         stride_to_index = {s: i for i, s in enumerate(self_strides)}
-        order = []
-        for s in other_strides:
-            order.append(stride_to_index[s])
+        order = [stride_to_index[s] for s in other_strides]
 
         assert set(order) == set(range(0, self.num_vars))
         return order
@@ -547,9 +545,7 @@ def var_builder(prefix: str) -> Tuple[VarRanges, Callable[[sympy.Expr], sympy.Sy
 
 def index_vars_no_squeeze(*argsizes: Tuple[sympy.Expr, ...], prefix: str):
     var_ranges, add_var = var_builder(prefix)
-    args: List[List[sympy.Symbol]] = []
-    for size in argsizes:
-        args.append(list(map(add_var, size)))
+    args: List[List[sympy.Symbol]] = [list(map(add_var, size)) for size in argsizes]
     return args, var_ranges
 
 

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -1120,9 +1120,7 @@ class UnbindCatRemover(SplitCatSimplifier):
             return
         # we need to check if the getitem indices from unbind are consecutive and all go to the same cat node
         # before we do the unbind remove, otherwise it will hit the error when we unbind part of them
-        getitem_indices = []
-        for getitem_node in unbind_node.users.keys():
-            getitem_indices.append(getitem_node.args[1])
+        getitem_indices = [getitem_node.args[1] for getitem_node in unbind_node.users.keys()]
         if not is_sorted_and_consecutive(getitem_indices) or len(  # type: ignore[arg-type]
             getitem_indices
         ) != len(
@@ -1497,9 +1495,8 @@ def merge_getitem_cat(match: Match, split_sections: List[int], dim: int):
             ):
                 continue
             # find the index of getitems to be cated/stacked
-            indices = []
-            for arg in cat_user.args[0]:  # type: ignore[union-attr]
-                indices.append(arg.args[1])  # type: ignore[union-attr]
+            # type: ignore[union-attr]
+            indices = [arg.args[1] for arg in cat_user.args[0]]  # type: ignore[union-attr]
             # the gettitems to be merged must be consecutive, otherwise
             # returned sliced tensor could be wrong
             if not is_sorted_and_consecutive(indices):

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -1120,7 +1120,9 @@ class UnbindCatRemover(SplitCatSimplifier):
             return
         # we need to check if the getitem indices from unbind are consecutive and all go to the same cat node
         # before we do the unbind remove, otherwise it will hit the error when we unbind part of them
-        getitem_indices = [getitem_node.args[1] for getitem_node in unbind_node.users.keys()]
+        getitem_indices = [
+            getitem_node.args[1] for getitem_node in unbind_node.users.keys()
+        ]
         if not is_sorted_and_consecutive(getitem_indices) or len(  # type: ignore[arg-type]
             getitem_indices
         ) != len(

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1629,8 +1629,14 @@ class GraphLowering(torch.fx.Interpreter):
             new_unbacked_defs |= op.get_unbacked_symbol_defs()
 
         def format_new_defs() -> str:
-            r = [f"unbacked_symbol_defs={buf.get_unbacked_symbol_defs()} in:\n{buf}\n" for buf in self.buffers[buffer_watermark:]]
-            r.extend(f"unbacked_symbol_defs={op.get_unbacked_symbol_defs()} in:\n{op}\n" for op in self.operations[operation_watermark:])
+            r = [
+                f"unbacked_symbol_defs={buf.get_unbacked_symbol_defs()} in:\n{buf}\n"
+                for buf in self.buffers[buffer_watermark:]
+            ]
+            r.extend(
+                f"unbacked_symbol_defs={op.get_unbacked_symbol_defs()} in:\n{op}\n"
+                for op in self.operations[operation_watermark:]
+            )
             return "***\n".join(r)
 
         if n.op != "placeholder":

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1629,15 +1629,8 @@ class GraphLowering(torch.fx.Interpreter):
             new_unbacked_defs |= op.get_unbacked_symbol_defs()
 
         def format_new_defs() -> str:
-            r = []
-            for buf in self.buffers[buffer_watermark:]:
-                r.append(
-                    f"unbacked_symbol_defs={buf.get_unbacked_symbol_defs()} in:\n{buf}\n"
-                )
-            for op in self.operations[operation_watermark:]:
-                r.append(
-                    f"unbacked_symbol_defs={op.get_unbacked_symbol_defs()} in:\n{op}\n"
-                )
+            r = [f"unbacked_symbol_defs={buf.get_unbacked_symbol_defs()} in:\n{buf}\n" for buf in self.buffers[buffer_watermark:]]
+            r.extend(f"unbacked_symbol_defs={op.get_unbacked_symbol_defs()} in:\n{op}\n" for op in self.operations[operation_watermark:])
             return "***\n".join(r)
 
         if n.op != "placeholder":

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5489,7 +5489,9 @@ class UserDefinedTritonKernel(ExternKernel):
             # https://github.com/triton-lang/triton/pull/5083
             # changes kernel.restore_idx to kernel.restore_value
             if hasattr(kernel, "restore_idx"):
-                restore_value_args.extend(kernel.fn.arg_names[i] for i in kernel.restore_idx)
+                restore_value_args.extend(
+                    kernel.fn.arg_names[i] for i in kernel.restore_idx
+                )
             else:
                 assert hasattr(kernel, "restore_value")
                 restore_value_args.extend(kernel.restore_value)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5489,8 +5489,7 @@ class UserDefinedTritonKernel(ExternKernel):
             # https://github.com/triton-lang/triton/pull/5083
             # changes kernel.restore_idx to kernel.restore_value
             if hasattr(kernel, "restore_idx"):
-                for i in kernel.restore_idx:
-                    restore_value_args.append(kernel.fn.arg_names[i])
+                restore_value_args.extend(kernel.fn.arg_names[i] for i in kernel.restore_idx)
             else:
                 assert hasattr(kernel, "restore_value")
                 restore_value_args.extend(kernel.restore_value)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5484,7 +5484,7 @@ class UserDefinedTritonKernel(ExternKernel):
 
         kernel = kernel_side_table.get_kernel(self.kernel_idx)
         configs = []
-        restore_value_args = []
+        restore_value_args: List[str] = []
         if isinstance(kernel, Autotuner):
             # https://github.com/triton-lang/triton/pull/5083
             # changes kernel.restore_idx to kernel.restore_value

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1691,9 +1691,7 @@ def split_with_sizes(x, sizes, dim=0):
 def unbind(x, dim=0):
     dim = _validate_dim(x, dim, 0)
     x_size = V.graph.sizevars.evaluate_static_shape(x.get_size()[dim])
-    result = []
-    for i in range(x_size):
-        result.append(select(x, dim, i))
+    result = [select(x, dim, i) for i in range(x_size)]
     return result
 
 

--- a/torch/_inductor/mkldnn_ir.py
+++ b/torch/_inductor/mkldnn_ir.py
@@ -87,8 +87,7 @@ def _prepare_convolution_fusion_create(
             weight_size = []
             weight_size.append(prepacked_weight_size[1] * groups)
             weight_size.append(prepacked_weight_size[0] / groups)
-            for d in range(2, dim):
-                weight_size.append(prepacked_weight_size[d])
+            weight_size.extend(prepacked_weight_size[d] for d in range(2, dim))
         else:
             weight_size = prepacked_weight.transpose(0, 1).size()
         return weight_size

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -952,7 +952,10 @@ class PatternPrettyPrinter:
         assert hasattr(obj, "pretty_print")
         out_str = obj.pretty_print(pp=pp)
 
-        output = [f"{pp.memoized_objs_names[key]} = {pp.memoized_objs_pp[key]}" for key in pp.memoized_objs_names]
+        output = [
+            f"{pp.memoized_objs_names[key]} = {pp.memoized_objs_pp[key]}"
+            for key in pp.memoized_objs_names
+        ]
 
         output.append(f"{output_name} = {out_str}")
 

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -952,9 +952,7 @@ class PatternPrettyPrinter:
         assert hasattr(obj, "pretty_print")
         out_str = obj.pretty_print(pp=pp)
 
-        output = []
-        for key in pp.memoized_objs_names:
-            output.append(f"{pp.memoized_objs_names[key]} = {pp.memoized_objs_pp[key]}")
+        output = [f"{pp.memoized_objs_names[key]} = {pp.memoized_objs_pp[key]}" for key in pp.memoized_objs_names]
 
         output.append(f"{output_name} = {out_str}")
 
@@ -1361,9 +1359,7 @@ def register_replacement(
             return False
 
     def normalize_args(**kwargs: Any) -> List[Any]:
-        args = []
-        for name in argnames_static:
-            args.append(kwargs.pop(name))
+        args = [kwargs.pop(name) for name in argnames_static]
         for i in range(1, len(kwargs) + 1):
             if f"tangents_{i}" not in kwargs:
                 break

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -138,13 +138,16 @@ def autotune_hints_to_configs(
                     (1, block_size // 4, 1),
                     (1, 1, block_size // 4),
                 )
-            configs.extend(triton_config(
-                        size_hints,
-                        *xyz,
-                        num_elements_per_warp=(
-                            device_props.warp_size if device_props.warp_size else 32
-                        ),
-                    ) for xyz in xyz_options)
+            configs.extend(
+                triton_config(
+                    size_hints,
+                    *xyz,
+                    num_elements_per_warp=(
+                        device_props.warp_size if device_props.warp_size else 32
+                    ),
+                )
+                for xyz in xyz_options
+            )
 
     return configs
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -120,7 +120,7 @@ def autotune_hints_to_configs(
     configs to try.
     """
     xyz_options: Tuple[Tuple[int, Optional[int], Optional[int]], ...]
-    configs = []
+    configs: List[Config] = []
     warp_size = device_props.warp_size
     # CPU target has no concept of "warp"
     if warp_size is None:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -138,16 +138,13 @@ def autotune_hints_to_configs(
                     (1, block_size // 4, 1),
                     (1, 1, block_size // 4),
                 )
-            for xyz in xyz_options:
-                configs.append(
-                    triton_config(
+            configs.extend(triton_config(
                         size_hints,
                         *xyz,
                         num_elements_per_warp=(
                             device_props.warp_size if device_props.warp_size else 32
                         ),
-                    )
-                )
+                    ) for xyz in xyz_options)
 
     return configs
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -308,7 +308,13 @@ class BaseSchedulerNode:
             dep = deps.pop()
             used_names.add(dep)
             if V.graph.name_to_buffer.get(dep):
-                deps.extend(alias for alias in V.graph.name_to_buffer[dep].get_inputs_that_alias_output() if alias not in used_names)
+                deps.extend(
+                    alias
+                    for alias in V.graph.name_to_buffer[
+                        dep
+                    ].get_inputs_that_alias_output()
+                    if alias not in used_names
+                )
         return used_names
 
     def prune_deps(self) -> None:
@@ -3319,7 +3325,11 @@ class Scheduler:
                 node1 = node2
                 node2 = tmp
 
-            deps = [dep for dep in node1.read_writes.reads | node1.read_writes.writes if dep in node2.read_writes.reads or dep in node2.read_writes.writes]
+            deps = [
+                dep
+                for dep in node1.read_writes.reads | node1.read_writes.writes
+                if dep in node2.read_writes.reads or dep in node2.read_writes.writes
+            ]
 
             return sum(self.dep_size_hint(dep) for dep in deps)
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -308,9 +308,7 @@ class BaseSchedulerNode:
             dep = deps.pop()
             used_names.add(dep)
             if V.graph.name_to_buffer.get(dep):
-                for alias in V.graph.name_to_buffer[dep].get_inputs_that_alias_output():
-                    if alias not in used_names:
-                        deps.append(alias)
+                deps.extend(alias for alias in V.graph.name_to_buffer[dep].get_inputs_that_alias_output() if alias not in used_names)
         return used_names
 
     def prune_deps(self) -> None:
@@ -3321,10 +3319,7 @@ class Scheduler:
                 node1 = node2
                 node2 = tmp
 
-            deps = []
-            for dep in node1.read_writes.reads | node1.read_writes.writes:
-                if dep in node2.read_writes.reads or dep in node2.read_writes.writes:
-                    deps.append(dep)
+            deps = [dep for dep in node1.read_writes.reads | node1.read_writes.writes if dep in node2.read_writes.reads or dep in node2.read_writes.writes]
 
             return sum(self.dep_size_hint(dep) for dep in deps)
 

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -176,14 +176,12 @@ def derived_types(
         ]
 
     if list_base:
-        for seq_typ in derived_seq_types(base_type):
-            result.append((seq_typ, f"{cpp_type}[]"))  # type: ignore[valid-type]
+        result.extend((seq_typ, f"{cpp_type}[]") for seq_typ in derived_seq_types(base_type))  # type: ignore[valid-type]
     if optional_base_list:
-        for seq_typ in derived_seq_types(typing.Optional[base_type]):
-            result.append((seq_typ, f"{cpp_type}?[]"))  # type: ignore[valid-type]
+        result.extend((seq_typ, f"{cpp_type}?[]") for seq_typ in derived_seq_types(typing.Optional[base_type]))  # type: ignore[valid-type]
     if optional_list_base:
-        for seq_typ in derived_seq_types(base_type):  # type: ignore[valid-type]
-            result.append((typing.Optional[seq_typ], f"{cpp_type}[]?"))  # type: ignore[valid-type]
+        # type: ignore[valid-type]
+        result.extend((typing.Optional[seq_typ], f"{cpp_type}[]?") for seq_typ in derived_seq_types(base_type))  # type: ignore[valid-type]
     return result
 
 

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -284,9 +284,12 @@ def handle_dispatch_mode(curr_mode, op_overload, *args, **kwargs):
     # It's generated in PyInterpreter.cpp, but seems to be generated in two places,
     # where in one case we only include tensors with the python key, and in another
     # we include **all** tensors.
-    overload_types = [type(a) for a in args_flattened if isinstance(a, torch.Tensor) and torch._C._dispatch_keys(a).has(
-            torch._C.DispatchKey.Python
-        )]
+    overload_types = [
+        type(a)
+        for a in args_flattened
+        if isinstance(a, torch.Tensor)
+        and torch._C._dispatch_keys(a).has(torch._C.DispatchKey.Python)
+    ]
     # TODO: check that I got these args correct (in C++, we pass in "0000"??)
 
     return curr_mode.__torch_dispatch__(op_overload, overload_types, args, kwargs)

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -279,17 +279,14 @@ def requires_set_python_module() -> bool:
 
 def handle_dispatch_mode(curr_mode, op_overload, *args, **kwargs):
     assert isinstance(curr_mode, torch.utils._python_dispatch.TorchDispatchMode)
-    overload_types = []
     args_flattened, _ = torch.utils._pytree.tree_flatten((args, kwargs.values()))
-    for a in args_flattened:
-        # TODO: need to double check the semantics of the "types" argument to torch_dispatch.
-        # It's generated in PyInterpreter.cpp, but seems to be generated in two places,
-        # where in one case we only include tensors with the python key, and in another
-        # we include **all** tensors.
-        if isinstance(a, torch.Tensor) and torch._C._dispatch_keys(a).has(
+    # TODO: need to double check the semantics of the "types" argument to torch_dispatch.
+    # It's generated in PyInterpreter.cpp, but seems to be generated in two places,
+    # where in one case we only include tensors with the python key, and in another
+    # we include **all** tensors.
+    overload_types = [type(a) for a in args_flattened if isinstance(a, torch.Tensor) and torch._C._dispatch_keys(a).has(
             torch._C.DispatchKey.Python
-        ):
-            overload_types.append(type(a))
+        )]
     # TODO: check that I got these args correct (in C++, we pass in "0000"??)
 
     return curr_mode.__torch_dispatch__(op_overload, overload_types, args, kwargs)

--- a/torch/_logging/structured.py
+++ b/torch/_logging/structured.py
@@ -43,15 +43,11 @@ def dump_file(filename: str) -> None:
 
 
 def from_traceback(tb: Sequence[traceback.FrameSummary]) -> List[Dict[str, Any]]:
-    r = []
-    for frame in tb:
-        # dict naming convention here coincides with
-        # python/combined_traceback.cpp
-        r.append(
-            {
+    # dict naming convention here coincides with
+    # python/combined_traceback.cpp
+    r = [{
                 "line": frame.lineno,
                 "name": frame.name,
                 "filename": intern_string(frame.filename),
-            }
-        )
+            } for frame in tb]
     return r

--- a/torch/_logging/structured.py
+++ b/torch/_logging/structured.py
@@ -45,9 +45,12 @@ def dump_file(filename: str) -> None:
 def from_traceback(tb: Sequence[traceback.FrameSummary]) -> List[Dict[str, Any]]:
     # dict naming convention here coincides with
     # python/combined_traceback.cpp
-    r = [{
-                "line": frame.lineno,
-                "name": frame.name,
-                "filename": intern_string(frame.filename),
-            } for frame in tb]
+    r = [
+        {
+            "line": frame.lineno,
+            "name": frame.name,
+            "filename": intern_string(frame.filename),
+        }
+        for frame in tb
+    ]
     return r

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -312,10 +312,7 @@ def _make_prim(
         prim_autograd_impl.impl(name, _autograd_impl)
         prim_meta_impl.impl(name, meta)
     else:
-        mutates_args = []
-        for arg in cpp_schema.arguments:
-            if arg.alias_info is not None and arg.alias_info.is_write:
-                mutates_args.append(arg.name)
+        mutates_args = [arg.name for arg in cpp_schema.arguments if arg.alias_info is not None and arg.alias_info.is_write]
         prim_def = torch.library.custom_op(
             "prims::" + name,
             _prim_impl,

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -312,7 +312,11 @@ def _make_prim(
         prim_autograd_impl.impl(name, _autograd_impl)
         prim_meta_impl.impl(name, meta)
     else:
-        mutates_args = [arg.name for arg in cpp_schema.arguments if arg.alias_info is not None and arg.alias_info.is_write]
+        mutates_args = [
+            arg.name
+            for arg in cpp_schema.arguments
+            if arg.alias_info is not None and arg.alias_info.is_write
+        ]
         prim_def = torch.library.custom_op(
             "prims::" + name,
             _prim_impl,

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -3024,9 +3024,7 @@ def chunk(a: TensorLikeType, chunks: int, dim: int = 0) -> Tuple[TensorLikeType,
     full_chunks = math.floor(length / chunk_size)
     tail_chunk_size = length % chunk_size
 
-    result = []
-    for i in range(full_chunks):
-        result.append(narrow(a, dim, i * chunk_size, chunk_size))
+    result = [narrow(a, dim, i * chunk_size, chunk_size) for i in range(full_chunks)]
 
     if tail_chunk_size != 0:
         result.append(narrow(a, dim, full_chunks * chunk_size, tail_chunk_size))

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -572,9 +572,13 @@ def has_meta(func):
     lambda func: is_builtin(func) and "foreach" in func.name() and has_meta(func)
 )
 def foreach_run_and_map_input_device(fake_mode, func, *args, **kwargs):
-    tensor_lists = [arg for arg in itertools.chain(args, kwargs.values()) if isinstance(arg, (list, tuple))
-            and len(arg)
-            and isinstance(arg[0], torch.Tensor)]
+    tensor_lists = [
+        arg
+        for arg in itertools.chain(args, kwargs.values())
+        if isinstance(arg, (list, tuple))
+        and len(arg)
+        and isinstance(arg[0], torch.Tensor)
+    ]
 
     try:
         with in_kernel_invocation_manager(fake_mode):

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -572,14 +572,9 @@ def has_meta(func):
     lambda func: is_builtin(func) and "foreach" in func.name() and has_meta(func)
 )
 def foreach_run_and_map_input_device(fake_mode, func, *args, **kwargs):
-    tensor_lists = []
-    for arg in itertools.chain(args, kwargs.values()):
-        if (
-            isinstance(arg, (list, tuple))
+    tensor_lists = [arg for arg in itertools.chain(args, kwargs.values()) if isinstance(arg, (list, tuple))
             and len(arg)
-            and isinstance(arg[0], torch.Tensor)
-        ):
-            tensor_lists.append(arg)
+            and isinstance(arg[0], torch.Tensor)]
 
     try:
         with in_kernel_invocation_manager(fake_mode):

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -171,8 +171,7 @@ def get_plain_tensors(
             continue
 
         inner_keys, _ = curr.__tensor_flatten__()
-        for key in reversed(inner_keys):
-            todo.append(getattr(curr, key))
+        todo.extend(getattr(curr, key) for key in reversed(inner_keys))
 
     return out
 
@@ -1629,13 +1628,9 @@ class FakeTensorMode(TorchDispatchMode):
             )
 
         if isinstance(output, tuple):
-            output_infos = []
-            for out_elem in output:
-                output_infos.append(
-                    self._get_output_info_for_cache_entry(
+            output_infos = [self._get_output_info_for_cache_entry(
                         state, key, func, args, kwargs, out_elem
-                    )
-                )
+                    ) for out_elem in output]
             return _DispatchCacheEntry(
                 output_infos=tuple(output_infos), is_output_tuple=True
             )
@@ -1727,17 +1722,13 @@ class FakeTensorMode(TorchDispatchMode):
         """
 
         if entry.is_output_tuple:
-            outputs = []
-            for output_info in entry.output_infos:
-                outputs.append(
-                    self._get_output_tensor_from_cache_entry(
+            outputs = [self._get_output_tensor_from_cache_entry(
                         state,
                         output_info,
                         key,
                         func,
                         args,
-                    )
-                )
+                    ) for output_info in entry.output_infos]
             return tuple(outputs)
         else:
             return self._get_output_tensor_from_cache_entry(

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1628,9 +1628,12 @@ class FakeTensorMode(TorchDispatchMode):
             )
 
         if isinstance(output, tuple):
-            output_infos = [self._get_output_info_for_cache_entry(
-                        state, key, func, args, kwargs, out_elem
-                    ) for out_elem in output]
+            output_infos = [
+                self._get_output_info_for_cache_entry(
+                    state, key, func, args, kwargs, out_elem
+                )
+                for out_elem in output
+            ]
             return _DispatchCacheEntry(
                 output_infos=tuple(output_infos), is_output_tuple=True
             )
@@ -1722,13 +1725,16 @@ class FakeTensorMode(TorchDispatchMode):
         """
 
         if entry.is_output_tuple:
-            outputs = [self._get_output_tensor_from_cache_entry(
-                        state,
-                        output_info,
-                        key,
-                        func,
-                        args,
-                    ) for output_info in entry.output_infos]
+            outputs = [
+                self._get_output_tensor_from_cache_entry(
+                    state,
+                    output_info,
+                    key,
+                    func,
+                    args,
+                )
+                for output_info in entry.output_infos
+            ]
             return tuple(outputs)
         else:
             return self._get_output_tensor_from_cache_entry(

--- a/torch/ao/nn/quantizable/modules/rnn.py
+++ b/torch/ao/nn/quantizable/modules/rnn.py
@@ -389,14 +389,17 @@ class LSTM(torch.nn.Module):
                 **factory_kwargs,
             )
         ]
-        layers.extend(_LSTMLayer(
-                    self.hidden_size,
-                    self.hidden_size,
-                    self.bias,
-                    batch_first=False,
-                    bidirectional=self.bidirectional,
-                    **factory_kwargs,
-                ) for layer in range(1, num_layers))
+        layers.extend(
+            _LSTMLayer(
+                self.hidden_size,
+                self.hidden_size,
+                self.bias,
+                batch_first=False,
+                bidirectional=self.bidirectional,
+                **factory_kwargs,
+            )
+            for layer in range(1, num_layers)
+        )
         self.layers = torch.nn.ModuleList(layers)
 
     def forward(self, x: Tensor, hidden: Optional[Tuple[Tensor, Tensor]] = None):

--- a/torch/ao/nn/quantizable/modules/rnn.py
+++ b/torch/ao/nn/quantizable/modules/rnn.py
@@ -389,17 +389,14 @@ class LSTM(torch.nn.Module):
                 **factory_kwargs,
             )
         ]
-        for layer in range(1, num_layers):
-            layers.append(
-                _LSTMLayer(
+        layers.extend(_LSTMLayer(
                     self.hidden_size,
                     self.hidden_size,
                     self.bias,
                     batch_first=False,
                     bidirectional=self.bidirectional,
                     **factory_kwargs,
-                )
-            )
+                ) for layer in range(1, num_layers))
         self.layers = torch.nn.ModuleList(layers)
 
     def forward(self, x: Tensor, hidden: Optional[Tuple[Tensor, Tensor]] = None):

--- a/torch/ao/nn/quantized/modules/conv.py
+++ b/torch/ao/nn/quantized/modules/conv.py
@@ -32,8 +32,7 @@ def _reverse_repeat_padding(padding: List[int]) -> List[int]:
     _reversed_padding_repeated_twice: List[int] = []
     N = len(padding)
     for idx in range(N):
-        for _ in range(2):
-            _reversed_padding_repeated_twice.append(padding[N - idx - 1])
+        _reversed_padding_repeated_twice.extend(padding[N - idx - 1] for _ in range(2))
     return _reversed_padding_repeated_twice
 
 

--- a/torch/ao/ns/fx/n_shadows_utils.py
+++ b/torch/ao/ns/fx/n_shadows_utils.py
@@ -568,7 +568,9 @@ def create_one_transformed_and_logged_copy_of_subgraph(
                     and len(arg)
                     and isinstance(arg[0], Node)
                 ):
-                    new_args.extend(inner_arg for inner_arg in arg if isinstance(inner_arg, Node))
+                    new_args.extend(
+                        inner_arg for inner_arg in arg if isinstance(inner_arg, Node)
+                    )
 
             new_kwargs = {}
             for name, old_kwarg in first_node.kwargs.items():

--- a/torch/ao/ns/fx/n_shadows_utils.py
+++ b/torch/ao/ns/fx/n_shadows_utils.py
@@ -568,9 +568,7 @@ def create_one_transformed_and_logged_copy_of_subgraph(
                     and len(arg)
                     and isinstance(arg[0], Node)
                 ):
-                    for inner_arg in arg:
-                        if isinstance(inner_arg, Node):
-                            new_args.append(inner_arg)
+                    new_args.extend(inner_arg for inner_arg in arg if isinstance(inner_arg, Node))
 
             new_kwargs = {}
             for name, old_kwarg in first_node.kwargs.items():

--- a/torch/ao/ns/fx/utils.py
+++ b/torch/ao/ns/fx/utils.py
@@ -312,10 +312,7 @@ def get_arg_indices_of_inputs_to_log(node: Node) -> List[int]:
         node.target in (torch.add, torch.ops.quantized.add, operator.add)
         or node.target in (torch.mul, torch.ops.quantized.mul, operator.mul)
     ):
-        result = []
-        for i in range(2):
-            if type(node.args[i]) == Node:
-                result.append(i)
+        result = [i for i in range(2) if type(node.args[i]) == Node]
         return result
     return [0]
 

--- a/torch/ao/quantization/_equalize.py
+++ b/torch/ao/quantization/_equalize.py
@@ -191,8 +191,7 @@ def expand_groups_in_paired_modules_list(paired_modules_list):
         elif len(group) == 2:
             new_list.append(group)
         elif len(group) > 2:
-            for i in range(len(group) - 1):
-                new_list.append([group[i], group[i + 1]])
+            new_list.extend([group[i], group[i + 1]] for i in range(len(group) - 1))
 
     return new_list
 

--- a/torch/ao/quantization/backend_config/_common_operator_config_utils.py
+++ b/torch/ao/quantization/backend_config/_common_operator_config_utils.py
@@ -155,14 +155,11 @@ def _get_binary_op_configs(
             (op_with_quantized_bop_scalar_variant, torch.relu),
             op_with_quantized_bop_scalar_variant,
         ]
-        for bop_pattern in bop_patterns:
-            binary_op_configs.append(
-                BackendPatternConfig(bop_pattern)
+        binary_op_configs.extend(BackendPatternConfig(bop_pattern)
                 .set_dtype_configs(dtype_configs)  # noqa: E131
                 ._set_num_tensor_args_to_observation_type(
                     num_tensor_args_to_observation_type_mapping
-                )
-            )
+                ) for bop_pattern in bop_patterns)
     # matmul
     binary_op_configs.append(
         BackendPatternConfig(torch.matmul).set_dtype_configs(
@@ -502,7 +499,6 @@ def _get_ln_configs(dtype_configs: List[DTypeConfig]) -> List[BackendPatternConf
 def _get_default_op_configs(
     dtype_configs: List[DTypeConfig],
 ) -> List[BackendPatternConfig]:
-    configs = []
     default_ops = [
         torch.nn.ELU,
         torch.nn.LeakyReLU,
@@ -517,14 +513,11 @@ def _get_default_op_configs(
         torch.nn.functional.leaky_relu,
         torch.nn.functional.dropout,
     ]
-    for op in default_ops:
-        configs.append(
-            BackendPatternConfig(op)
+    configs = [BackendPatternConfig(op)
             .set_observation_type(
                 ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
             )  # noqa: E131
-            .set_dtype_configs(dtype_configs)
-        )
+            .set_dtype_configs(dtype_configs) for op in default_ops]
 
     configs.append(
         BackendPatternConfig(torch.nn.functional.group_norm)

--- a/torch/ao/quantization/backend_config/_common_operator_config_utils.py
+++ b/torch/ao/quantization/backend_config/_common_operator_config_utils.py
@@ -155,11 +155,14 @@ def _get_binary_op_configs(
             (op_with_quantized_bop_scalar_variant, torch.relu),
             op_with_quantized_bop_scalar_variant,
         ]
-        binary_op_configs.extend(BackendPatternConfig(bop_pattern)
-                .set_dtype_configs(dtype_configs)  # noqa: E131
-                ._set_num_tensor_args_to_observation_type(
-                    num_tensor_args_to_observation_type_mapping
-                ) for bop_pattern in bop_patterns)
+        binary_op_configs.extend(
+            BackendPatternConfig(bop_pattern)
+            .set_dtype_configs(dtype_configs)  # noqa: E131
+            ._set_num_tensor_args_to_observation_type(
+                num_tensor_args_to_observation_type_mapping
+            )
+            for bop_pattern in bop_patterns
+        )
     # matmul
     binary_op_configs.append(
         BackendPatternConfig(torch.matmul).set_dtype_configs(
@@ -513,11 +516,14 @@ def _get_default_op_configs(
         torch.nn.functional.leaky_relu,
         torch.nn.functional.dropout,
     ]
-    configs = [BackendPatternConfig(op)
-            .set_observation_type(
-                ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
-            )  # noqa: E131
-            .set_dtype_configs(dtype_configs) for op in default_ops]
+    configs = [
+        BackendPatternConfig(op)
+        .set_observation_type(
+            ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
+        )  # noqa: E131
+        .set_dtype_configs(dtype_configs)
+        for op in default_ops
+    ]
 
     configs.append(
         BackendPatternConfig(torch.nn.functional.group_norm)

--- a/torch/ao/quantization/backend_config/_qnnpack_pt2e.py
+++ b/torch/ao/quantization/backend_config/_qnnpack_pt2e.py
@@ -159,11 +159,14 @@ def get_binary_op_configs():
             # TODO: remove when functionalization is supported in pt2_mode
             (op_with_quantized_bop_scalar_variant, torch.ops.aten.relu_.default),
         ]
-        binary_op_configs.extend(BackendPatternConfig(bop_pattern)
-                .set_dtype_configs(dtype_configs)  # noqa: E131
-                ._set_num_tensor_args_to_observation_type(
-                    num_tensor_args_to_observation_type_mapping
-                ) for bop_pattern in bop_patterns)
+        binary_op_configs.extend(
+            BackendPatternConfig(bop_pattern)
+            .set_dtype_configs(dtype_configs)  # noqa: E131
+            ._set_num_tensor_args_to_observation_type(
+                num_tensor_args_to_observation_type_mapping
+            )
+            for bop_pattern in bop_patterns
+        )
 
     return binary_op_configs
 

--- a/torch/ao/quantization/backend_config/_qnnpack_pt2e.py
+++ b/torch/ao/quantization/backend_config/_qnnpack_pt2e.py
@@ -159,14 +159,11 @@ def get_binary_op_configs():
             # TODO: remove when functionalization is supported in pt2_mode
             (op_with_quantized_bop_scalar_variant, torch.ops.aten.relu_.default),
         ]
-        for bop_pattern in bop_patterns:
-            binary_op_configs.append(
-                BackendPatternConfig(bop_pattern)
+        binary_op_configs.extend(BackendPatternConfig(bop_pattern)
                 .set_dtype_configs(dtype_configs)  # noqa: E131
                 ._set_num_tensor_args_to_observation_type(
                     num_tensor_args_to_observation_type_mapping
-                )
-            )
+                ) for bop_pattern in bop_patterns)
 
     return binary_op_configs
 

--- a/torch/ao/quantization/backend_config/executorch.py
+++ b/torch/ao/quantization/backend_config/executorch.py
@@ -325,11 +325,14 @@ def _get_binary_ops_configs() -> List[BackendPatternConfig]:
             (op, torch.relu),
             op,
         ]
-        binary_op_configs.extend(BackendPatternConfig(bop_pattern)
-                .set_dtype_configs(dtype_configs)  # noqa: E131
-                ._set_num_tensor_args_to_observation_type(
-                    num_tensor_args_to_observation_type_mapping
-                ) for bop_pattern in bop_patterns)
+        binary_op_configs.extend(
+            BackendPatternConfig(bop_pattern)
+            .set_dtype_configs(dtype_configs)  # noqa: E131
+            ._set_num_tensor_args_to_observation_type(
+                num_tensor_args_to_observation_type_mapping
+            )
+            for bop_pattern in bop_patterns
+        )
     return binary_op_configs
 
 
@@ -382,9 +385,12 @@ def _get_share_qparams_ops_configs() -> List[BackendPatternConfig]:
         "squeeze_",
         "leaky_relu",
     ]
-    share_qparams_op_configs: List[BackendPatternConfig] = [BackendPatternConfig(op)
-            .set_observation_type(observation_type)  # noqa: E131
-            .set_dtype_configs(dtype_configs) for op in share_qparams_ops]
+    share_qparams_op_configs: List[BackendPatternConfig] = [
+        BackendPatternConfig(op)
+        .set_observation_type(observation_type)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
+        for op in share_qparams_ops
+    ]
     return share_qparams_op_configs
 
 

--- a/torch/ao/quantization/backend_config/executorch.py
+++ b/torch/ao/quantization/backend_config/executorch.py
@@ -325,14 +325,11 @@ def _get_binary_ops_configs() -> List[BackendPatternConfig]:
             (op, torch.relu),
             op,
         ]
-        for bop_pattern in bop_patterns:
-            binary_op_configs.append(
-                BackendPatternConfig(bop_pattern)
+        binary_op_configs.extend(BackendPatternConfig(bop_pattern)
                 .set_dtype_configs(dtype_configs)  # noqa: E131
                 ._set_num_tensor_args_to_observation_type(
                     num_tensor_args_to_observation_type_mapping
-                )
-            )
+                ) for bop_pattern in bop_patterns)
     return binary_op_configs
 
 
@@ -385,13 +382,9 @@ def _get_share_qparams_ops_configs() -> List[BackendPatternConfig]:
         "squeeze_",
         "leaky_relu",
     ]
-    share_qparams_op_configs: List[BackendPatternConfig] = []
-    for op in share_qparams_ops:
-        share_qparams_op_configs.append(
-            BackendPatternConfig(op)
+    share_qparams_op_configs: List[BackendPatternConfig] = [BackendPatternConfig(op)
             .set_observation_type(observation_type)  # noqa: E131
-            .set_dtype_configs(dtype_configs)
-        )
+            .set_dtype_configs(dtype_configs) for op in share_qparams_ops]
     return share_qparams_op_configs
 
 

--- a/torch/ao/quantization/backend_config/utils.py
+++ b/torch/ao/quantization/backend_config/utils.py
@@ -36,12 +36,20 @@ def get_pattern_to_dtype_configs(
 
 
 def get_qat_module_classes(backend_config: BackendConfig) -> Tuple[type, ...]:
-    qat_module_classes = [config.qat_module for config in backend_config.configs if config.qat_module is not None]
+    qat_module_classes = [
+        config.qat_module
+        for config in backend_config.configs
+        if config.qat_module is not None
+    ]
     return tuple(set(qat_module_classes))
 
 
 def get_fused_module_classes(backend_config: BackendConfig) -> Tuple[type, ...]:
-    fused_module_classes = [config.fused_module for config in backend_config.configs if config.fused_module is not None]
+    fused_module_classes = [
+        config.fused_module
+        for config in backend_config.configs
+        if config.fused_module is not None
+    ]
     return tuple(set(fused_module_classes))
 
 

--- a/torch/ao/quantization/backend_config/utils.py
+++ b/torch/ao/quantization/backend_config/utils.py
@@ -36,18 +36,12 @@ def get_pattern_to_dtype_configs(
 
 
 def get_qat_module_classes(backend_config: BackendConfig) -> Tuple[type, ...]:
-    qat_module_classes = []
-    for config in backend_config.configs:
-        if config.qat_module is not None:
-            qat_module_classes.append(config.qat_module)
+    qat_module_classes = [config.qat_module for config in backend_config.configs if config.qat_module is not None]
     return tuple(set(qat_module_classes))
 
 
 def get_fused_module_classes(backend_config: BackendConfig) -> Tuple[type, ...]:
-    fused_module_classes = []
-    for config in backend_config.configs:
-        if config.fused_module is not None:
-            fused_module_classes.append(config.fused_module)
+    fused_module_classes = [config.fused_module for config in backend_config.configs if config.fused_module is not None]
     return tuple(set(fused_module_classes))
 
 

--- a/torch/ao/quantization/fuse_modules.py
+++ b/torch/ao/quantization/fuse_modules.py
@@ -92,9 +92,7 @@ def _fuse_modules_helper(
     additional_fuser_method_mapping = fuse_custom_config_dict.get(
         "additional_fuser_method_mapping", {}
     )
-    mod_list = []
-    for item in modules_to_fuse:
-        mod_list.append(_get_module(model, item))
+    mod_list = [_get_module(model, item) for item in modules_to_fuse]
 
     # Fuse list of modules
     new_mod_list = fuser_func(mod_list, is_qat, additional_fuser_method_mapping)

--- a/torch/ao/quantization/fuser_method_mappings.py
+++ b/torch/ao/quantization/fuser_method_mappings.py
@@ -266,9 +266,7 @@ def _get_valid_patterns(op_pattern):
     """
     result: List[Any]
     if isinstance(op_pattern, (tuple, list)):
-        sub_combs = []
-        for sub_pattern in op_pattern:
-            sub_combs.append(_get_valid_patterns(sub_pattern))
+        sub_combs = [_get_valid_patterns(sub_pattern) for sub_pattern in op_pattern]
         result = list(itertools.product(*sub_combs))
     else:
         result = [op_pattern, MatchAllNode]

--- a/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
+++ b/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
@@ -527,7 +527,9 @@ class ModelReportVisualizer:
             # gather the x_data and multiple y_data
             # calculate the number of channels
             num_channels: int = max(row[self.CHANNEL_NUM_INDEX] for row in table) + 1
-            y_data.extend([] for channel in range(num_channels))  # separate data list per channel
+            y_data.extend(
+                [] for channel in range(num_channels)
+            )  # separate data list per channel
 
             for table_row_num, row in enumerate(table):
                 # get x_value to append

--- a/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
+++ b/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
@@ -527,8 +527,7 @@ class ModelReportVisualizer:
             # gather the x_data and multiple y_data
             # calculate the number of channels
             num_channels: int = max(row[self.CHANNEL_NUM_INDEX] for row in table) + 1
-            for channel in range(num_channels):
-                y_data.append([])  # separate data list per channel
+            y_data.extend([] for channel in range(num_channels))  # separate data list per channel
 
             for table_row_num, row in enumerate(table):
                 # get x_value to append

--- a/torch/ao/quantization/fx/convert.py
+++ b/torch/ao/quantization/fx/convert.py
@@ -1116,10 +1116,7 @@ def convert(
     # for dynamic quant ops or weight only quant ops
     _run_weight_observers(model, backend_config)
 
-    graph_inputs: List[str] = []
-    for node in model.graph.nodes:
-        if node.op == "placeholder":
-            graph_inputs.append(node.name)
+    graph_inputs: List[str] = [node.name for node in model.graph.nodes if node.op == "placeholder"]
 
     # additional state to override inputs to be quantized, if specified
     # by the user

--- a/torch/ao/quantization/fx/convert.py
+++ b/torch/ao/quantization/fx/convert.py
@@ -1116,7 +1116,9 @@ def convert(
     # for dynamic quant ops or weight only quant ops
     _run_weight_observers(model, backend_config)
 
-    graph_inputs: List[str] = [node.name for node in model.graph.nodes if node.op == "placeholder"]
+    graph_inputs: List[str] = [
+        node.name for node in model.graph.nodes if node.op == "placeholder"
+    ]
 
     # additional state to override inputs to be quantized, if specified
     # by the user

--- a/torch/ao/quantization/fx/fuse_handler.py
+++ b/torch/ao/quantization/fx/fuse_handler.py
@@ -78,8 +78,7 @@ class DefaultFuseHandler(FuseHandler):
                 n, *args = pattern
                 modules: List[torch.nn.Module] = []
                 modules.append(get_modules(n))
-                for a in args:
-                    modules.append(get_modules(a))
+                modules.extend(get_modules(a) for a in args)
                 return tuple(modules)
             else:
                 n = pattern
@@ -111,9 +110,7 @@ class DefaultFuseHandler(FuseHandler):
         # as input
         fused_module = fuser_method(is_qat, *matched_modules)
         setattr(named_modules[module_parent_name], module_name, fused_module)
-        extra_args = []
-        for input in extra_inputs:
-            extra_args.append(load_arg(input))
+        extra_args = [load_arg(input) for input in extra_inputs]
         node = fused_graph.node_copy(root_node, load_arg)
         args = list(node.args)
         args.extend(extra_args)

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -1219,13 +1219,9 @@ def _maybe_insert_observers_before_graph_output(
             else:
                 return maybe_node
         elif isinstance(maybe_node, (list, tuple)):
-            results = []
-            for inner_node in maybe_node:
-                results.append(
-                    _recursive_maybe_replace_node_with_obs(
+            results = [_recursive_maybe_replace_node_with_obs(
                         inner_node, model, named_modules, graph
-                    )
-                )
+                    ) for inner_node in maybe_node]
             if isinstance(maybe_node, list):
                 return results
             else:
@@ -1244,11 +1240,7 @@ def _maybe_insert_observers_before_graph_output(
                 "Unhandled type for returned node:", maybe_node
             )
 
-    new_args = []
-    for old_arg in graph_output_node.args:
-        new_args.append(
-            _recursive_maybe_replace_node_with_obs(old_arg, model, named_modules, graph)
-        )
+    new_args = [_recursive_maybe_replace_node_with_obs(old_arg, model, named_modules, graph) for old_arg in graph_output_node.args]
 
     graph_output_node.args = tuple(new_args)  # type: ignore[assignment]
 

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -1219,9 +1219,12 @@ def _maybe_insert_observers_before_graph_output(
             else:
                 return maybe_node
         elif isinstance(maybe_node, (list, tuple)):
-            results = [_recursive_maybe_replace_node_with_obs(
-                        inner_node, model, named_modules, graph
-                    ) for inner_node in maybe_node]
+            results = [
+                _recursive_maybe_replace_node_with_obs(
+                    inner_node, model, named_modules, graph
+                )
+                for inner_node in maybe_node
+            ]
             if isinstance(maybe_node, list):
                 return results
             else:
@@ -1240,7 +1243,10 @@ def _maybe_insert_observers_before_graph_output(
                 "Unhandled type for returned node:", maybe_node
             )
 
-    new_args = [_recursive_maybe_replace_node_with_obs(old_arg, model, named_modules, graph) for old_arg in graph_output_node.args]
+    new_args = [
+        _recursive_maybe_replace_node_with_obs(old_arg, model, named_modules, graph)
+        for old_arg in graph_output_node.args
+    ]
 
     graph_output_node.args = tuple(new_args)  # type: ignore[assignment]
 

--- a/torch/ao/quantization/pt2e/graph_utils.py
+++ b/torch/ao/quantization/pt2e/graph_utils.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import itertools
 import operator
-from typing import Any, Callable, List, Optional, OrderedDict, Set
+from typing import Any, Callable, List, Optional, OrderedDict, Sequence, Set
 
 import torch
 from torch.fx import Node
@@ -58,7 +58,7 @@ def update_equivalent_types_dict(customized_equivalent_types=None):
     _EQUIVALENT_TYPES_DICT = _create_equivalent_types_dict()
 
 
-def _partitions_sequential(partitions: List[SourcePartition]):
+def _partitions_sequential(partitions: Sequence[SourcePartition]):
     prev_partition = None
     for partition in partitions:
         if prev_partition is not None and not check_subgraphs_connected(
@@ -108,7 +108,6 @@ def find_sequential_partitions(
 
     typed_partitions_list = list(typed_partitions.values())
     fusion_candidates = itertools.product(*typed_partitions_list)
-    # type: ignore[arg-type]
     fused_partitions = [
         candidate
         for candidate in fusion_candidates

--- a/torch/ao/quantization/pt2e/graph_utils.py
+++ b/torch/ao/quantization/pt2e/graph_utils.py
@@ -108,8 +108,6 @@ def find_sequential_partitions(
 
     typed_partitions_list = list(typed_partitions.values())
     fusion_candidates = itertools.product(*typed_partitions_list)
-    fused_partitions = []
-    for candidate in fusion_candidates:
-        if _partitions_sequential(candidate):  # type: ignore[arg-type]
-            fused_partitions.append(candidate)
+    # type: ignore[arg-type]
+    fused_partitions = [candidate for candidate in fusion_candidates if _partitions_sequential(candidate)]
     return fused_partitions

--- a/torch/ao/quantization/pt2e/graph_utils.py
+++ b/torch/ao/quantization/pt2e/graph_utils.py
@@ -109,5 +109,9 @@ def find_sequential_partitions(
     typed_partitions_list = list(typed_partitions.values())
     fusion_candidates = itertools.product(*typed_partitions_list)
     # type: ignore[arg-type]
-    fused_partitions = [candidate for candidate in fusion_candidates if _partitions_sequential(candidate)]
+    fused_partitions = [
+        candidate
+        for candidate in fusion_candidates
+        if _partitions_sequential(candidate)
+    ]
     return fused_partitions

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer.py
@@ -93,7 +93,10 @@ def _get_supported_symmetric_config_and_operators() -> List[OperatorConfig]:
         get_symmetric_quantization_config(is_per_channel=True, is_qat=True),
     ]:
         ops = _supported_symmetric_quantized_operators()
-        supported_config_and_operators.extend(OperatorConfig(quantization_config, pattern_list) for pattern_list in ops.values())
+        supported_config_and_operators.extend(
+            OperatorConfig(quantization_config, pattern_list)
+            for pattern_list in ops.values()
+        )
     return copy.deepcopy(supported_config_and_operators)
 
 

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer.py
@@ -93,10 +93,7 @@ def _get_supported_symmetric_config_and_operators() -> List[OperatorConfig]:
         get_symmetric_quantization_config(is_per_channel=True, is_qat=True),
     ]:
         ops = _supported_symmetric_quantized_operators()
-        for pattern_list in ops.values():
-            supported_config_and_operators.append(
-                OperatorConfig(quantization_config, pattern_list)
-            )
+        supported_config_and_operators.extend(OperatorConfig(quantization_config, pattern_list) for pattern_list in ops.values())
     return copy.deepcopy(supported_config_and_operators)
 
 

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -55,10 +55,7 @@ def _allocate_jacobians_with_inputs(
     # of `t.numel` and width of `numel_output`. Otherwise, for each tensor, returns
     # a 1-d tensor with size `(t.numel,)`. Each new tensor will be strided and have
     # the same dtype and device as those of the corresponding input.
-    out: List[torch.Tensor] = []
-    for t in input_tensors:
-        if _is_float_or_complex_tensor(t) and t.requires_grad:
-            out.append(t.new_zeros((t.numel(), numel_output), layout=torch.strided))
+    out: List[torch.Tensor] = [t.new_zeros((t.numel(), numel_output), layout=torch.strided) for t in input_tensors if _is_float_or_complex_tensor(t) and t.requires_grad]
     return tuple(out)
 
 
@@ -69,11 +66,8 @@ def _allocate_jacobians_with_outputs(
     # in `output_tensors`, returns a new zero-filled tensor with height of `dim` and
     # width of `t.numel`. Otherwise, for each tensor, returns a 1-d tensor with size
     # (t.numel,).
-    out: List[torch.Tensor] = []
     options = {"dtype": dtype, "device": device, "layout": torch.strided}
-    for t in output_tensors:
-        if _is_float_or_complex_tensor(t):
-            out.append(t.new_zeros((numel_input, t.numel()), **options))
+    out: List[torch.Tensor] = [t.new_zeros((numel_input, t.numel()), **options) for t in output_tensors if _is_float_or_complex_tensor(t)]
     return tuple(out)
 
 
@@ -904,10 +898,8 @@ def _compute_analytical_jacobian_rows(
 def _get_analytical_vjps_wrt_specific_output(
     vjp_fn, sample_output, v
 ) -> List[List[Optional[torch.Tensor]]]:
-    vjps: List[List[Optional[torch.Tensor]]] = []
     grad_inputs = vjp_fn(v.reshape(sample_output.shape))
-    for vjp in grad_inputs:
-        vjps.append([vjp.clone() if isinstance(vjp, torch.Tensor) else None])
+    vjps: List[List[Optional[torch.Tensor]]] = [[vjp.clone() if isinstance(vjp, torch.Tensor) else None] for vjp in grad_inputs]
     return vjps
 
 

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -55,7 +55,11 @@ def _allocate_jacobians_with_inputs(
     # of `t.numel` and width of `numel_output`. Otherwise, for each tensor, returns
     # a 1-d tensor with size `(t.numel,)`. Each new tensor will be strided and have
     # the same dtype and device as those of the corresponding input.
-    out: List[torch.Tensor] = [t.new_zeros((t.numel(), numel_output), layout=torch.strided) for t in input_tensors if _is_float_or_complex_tensor(t) and t.requires_grad]
+    out: List[torch.Tensor] = [
+        t.new_zeros((t.numel(), numel_output), layout=torch.strided)
+        for t in input_tensors
+        if _is_float_or_complex_tensor(t) and t.requires_grad
+    ]
     return tuple(out)
 
 
@@ -67,7 +71,11 @@ def _allocate_jacobians_with_outputs(
     # width of `t.numel`. Otherwise, for each tensor, returns a 1-d tensor with size
     # (t.numel,).
     options = {"dtype": dtype, "device": device, "layout": torch.strided}
-    out: List[torch.Tensor] = [t.new_zeros((numel_input, t.numel()), **options) for t in output_tensors if _is_float_or_complex_tensor(t)]
+    out: List[torch.Tensor] = [
+        t.new_zeros((numel_input, t.numel()), **options)
+        for t in output_tensors
+        if _is_float_or_complex_tensor(t)
+    ]
     return tuple(out)
 
 
@@ -899,7 +907,9 @@ def _get_analytical_vjps_wrt_specific_output(
     vjp_fn, sample_output, v
 ) -> List[List[Optional[torch.Tensor]]]:
     grad_inputs = vjp_fn(v.reshape(sample_output.shape))
-    vjps: List[List[Optional[torch.Tensor]]] = [[vjp.clone() if isinstance(vjp, torch.Tensor) else None] for vjp in grad_inputs]
+    vjps: List[List[Optional[torch.Tensor]]] = [
+        [vjp.clone() if isinstance(vjp, torch.Tensor) else None] for vjp in grad_inputs
+    ]
     return vjps
 
 

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -802,9 +802,7 @@ def _register_logging_hooks_on_whole_graph(
         log_str = f"Executing: {node} with grad_outputs: {grad_outputs_str}"
         log.debug(log_str)
 
-    handles = []
-    for node in iter_graph(grad_fns):
-        handles.append(node.register_prehook(prehook))
+    handles = [node.register_prehook(prehook) for node in iter_graph(grad_fns)]
 
     def unregister_hooks() -> None:
         for handle in handles:

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -856,10 +856,7 @@ def _build_table(
     flops_column_width = DEFAULT_COLUMN_WIDTH
 
     src_column_width = None
-    stacks = []
-    for evt in events:
-        if evt.stack is not None and len(evt.stack) > 0:
-            stacks.append(evt.stack)
+    stacks = [evt.stack for evt in events if evt.stack is not None and len(evt.stack) > 0]
     has_stack = len(stacks) > 0
     if has_stack:
         src_column_width = (
@@ -947,10 +944,7 @@ def _build_table(
 
     if with_flops:
         # Auto-scaling of flops header
-        raw_flops = []
-        for evt in events:
-            if evt.flops > 0:
-                raw_flops.append(evt.flops)
+        raw_flops = [evt.flops for evt in events if evt.flops > 0]
         if len(raw_flops) != 0:
             (flops_scale, flops_header) = auto_scale_flops(min(raw_flops))
             headers.append(f"Total {flops_header}")

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -856,7 +856,9 @@ def _build_table(
     flops_column_width = DEFAULT_COLUMN_WIDTH
 
     src_column_width = None
-    stacks = [evt.stack for evt in events if evt.stack is not None and len(evt.stack) > 0]
+    stacks = [
+        evt.stack for evt in events if evt.stack is not None and len(evt.stack) > 0
+    ]
     has_stack = len(stacks) > 0
     if has_stack:
         src_column_width = (

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -322,9 +322,7 @@ def _lazy_init():
         # However, we must not let any *other* threads in!
         _tls.is_initializing = True
 
-        for calls in _lazy_seed_tracker.get_calls():
-            if calls:
-                _queued_calls.append(calls)
+        _queued_calls.extend(calls for calls in _lazy_seed_tracker.get_calls() if calls)
 
         try:
             for queued_call, orig_traceback in _queued_calls:

--- a/torch/cuda/random.py
+++ b/torch/cuda/random.py
@@ -44,9 +44,7 @@ def get_rng_state(device: Union[int, str, torch.device] = "cuda") -> Tensor:
 
 def get_rng_state_all() -> List[Tensor]:
     r"""Return a list of ByteTensor representing the random number states of all devices."""
-    results = []
-    for i in range(device_count()):
-        results.append(get_rng_state(i))
+    results = [get_rng_state(i) for i in range(device_count())]
     return results
 
 

--- a/torch/distributed/_shard/sharded_optim/api.py
+++ b/torch/distributed/_shard/sharded_optim/api.py
@@ -31,8 +31,7 @@ class ShardedOptimizer(optim.Optimizer):
         tensors: List[Tensor] = []
         for value in named_params.values():
             if isinstance(value, ShardedTensor):
-                for local_shard in value.local_shards():
-                    tensors.append(local_shard.tensor)
+                tensors.extend(local_shard.tensor for local_shard in value.local_shards())
             else:
                 tensors.append(value)
 

--- a/torch/distributed/_shard/sharded_optim/api.py
+++ b/torch/distributed/_shard/sharded_optim/api.py
@@ -31,7 +31,9 @@ class ShardedOptimizer(optim.Optimizer):
         tensors: List[Tensor] = []
         for value in named_params.values():
             if isinstance(value, ShardedTensor):
-                tensors.extend(local_shard.tensor for local_shard in value.local_shards())
+                tensors.extend(
+                    local_shard.tensor for local_shard in value.local_shards()
+                )
             else:
                 tensors.append(value)
 

--- a/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
@@ -99,9 +99,7 @@ def sharded_type_as(args, kwargs, pg):
     tensor = args[1]
     if isinstance(tensor, ShardedTensor):
         tensor = tensor.local_tensor()
-    new_local_shards = []
-    for shard in st.local_shards():
-        new_local_shards.append(Shard(shard.tensor.type_as(tensor), shard.metadata))
+    new_local_shards = [Shard(shard.tensor.type_as(tensor), shard.metadata) for shard in st.local_shards()]
     st_meta = copy.deepcopy(st._metadata)
     st_meta.tensor_properties.dtype = tensor.dtype
     return new_local_shards, st_meta

--- a/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
@@ -99,7 +99,10 @@ def sharded_type_as(args, kwargs, pg):
     tensor = args[1]
     if isinstance(tensor, ShardedTensor):
         tensor = tensor.local_tensor()
-    new_local_shards = [Shard(shard.tensor.type_as(tensor), shard.metadata) for shard in st.local_shards()]
+    new_local_shards = [
+        Shard(shard.tensor.type_as(tensor), shard.metadata)
+        for shard in st.local_shards()
+    ]
     st_meta = copy.deepcopy(st._metadata)
     st_meta.tensor_properties.dtype = tensor.dtype
     return new_local_shards, st_meta

--- a/torch/distributed/_shard/sharded_tensor/reshard.py
+++ b/torch/distributed/_shard/sharded_tensor/reshard.py
@@ -191,7 +191,9 @@ def reshard_local_shard(
     )
 
     # Compute expected size
-    input_split_sizes = [metadata.shard_sizes[reshard_dim] for metadata in shards_metadata]
+    input_split_sizes = [
+        metadata.shard_sizes[reshard_dim] for metadata in shards_metadata
+    ]
     rearrange_input = any(ranks[i] > ranks[i + 1] for i in range(len(ranks) - 1))
 
     if rearrange_input:

--- a/torch/distributed/_shard/sharded_tensor/reshard.py
+++ b/torch/distributed/_shard/sharded_tensor/reshard.py
@@ -191,9 +191,7 @@ def reshard_local_shard(
     )
 
     # Compute expected size
-    input_split_sizes = []
-    for metadata in shards_metadata:
-        input_split_sizes.append(metadata.shard_sizes[reshard_dim])
+    input_split_sizes = [metadata.shard_sizes[reshard_dim] for metadata in shards_metadata]
     rearrange_input = any(ranks[i] > ranks[i + 1] for i in range(len(ranks) - 1))
 
     if rearrange_input:

--- a/torch/distributed/benchmarks/benchmark_ddp_rpc.py
+++ b/torch/distributed/benchmarks/benchmark_ddp_rpc.py
@@ -142,8 +142,7 @@ def _run_trainer(emb_rref_list, rank):
         )
 
     # model.parameters() only includes local parameters.
-    for param in model.parameters():
-        model_parameter_rrefs.append(RRef(param))
+    model_parameter_rrefs.extend(RRef(param) for param in model.parameters())
 
     # Setup distributed optimizer
     opt = DistributedOptimizer(optim.SGD, model_parameter_rrefs, lr=0.05)

--- a/torch/distributed/checkpoint/planner_helpers.py
+++ b/torch/distributed/checkpoint/planner_helpers.py
@@ -207,7 +207,10 @@ def _create_default_metadata_only_plan(state_dict: STATE_DICT_TYPE) -> SavePlan:
         if isinstance(obj, DTensor):
             requests.append(_create_write_items_for_dtensor(fqn, obj))
         elif isinstance(obj, ShardedTensor):
-            requests.extend(_create_write_item_for_shard(fqn, obj, shard_md) for shard_md in obj.metadata().shards_metadata)
+            requests.extend(
+                _create_write_item_for_shard(fqn, obj, shard_md)
+                for shard_md in obj.metadata().shards_metadata
+            )
         elif isinstance(obj, torch.Tensor):
             requests.append(_create_write_item_for_tensor(fqn, obj))
         else:

--- a/torch/distributed/checkpoint/planner_helpers.py
+++ b/torch/distributed/checkpoint/planner_helpers.py
@@ -207,8 +207,7 @@ def _create_default_metadata_only_plan(state_dict: STATE_DICT_TYPE) -> SavePlan:
         if isinstance(obj, DTensor):
             requests.append(_create_write_items_for_dtensor(fqn, obj))
         elif isinstance(obj, ShardedTensor):
-            for shard_md in obj.metadata().shards_metadata:
-                requests.append(_create_write_item_for_shard(fqn, obj, shard_md))
+            requests.extend(_create_write_item_for_shard(fqn, obj, shard_md) for shard_md in obj.metadata().shards_metadata)
         elif isinstance(obj, torch.Tensor):
             requests.append(_create_write_item_for_tensor(fqn, obj))
         else:

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1370,7 +1370,9 @@ def _get_all_pg_configs() -> List[Dict[str, Any]]:
     Return the pg configuration of all the process groups.
 
     """
-    config_info: List[Dict[str, Any]] = [_get_pg_config(pg) for pg in _world.pg_map.keys()]
+    config_info: List[Dict[str, Any]] = [
+        _get_pg_config(pg) for pg in _world.pg_map.keys()
+    ]
     return config_info
 
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1370,9 +1370,7 @@ def _get_all_pg_configs() -> List[Dict[str, Any]]:
     Return the pg configuration of all the process groups.
 
     """
-    config_info: List[Dict[str, Any]] = []
-    for pg in _world.pg_map.keys():
-        config_info.append(_get_pg_config(pg))
+    config_info: List[Dict[str, Any]] = [_get_pg_config(pg) for pg in _world.pg_map.keys()]
     return config_info
 
 
@@ -2495,9 +2493,7 @@ def _coalescing_manager(
         # - coalesced `reduce_scatter_tensor`
         op0 = op_list[0].op
         if op0 == all_reduce:
-            tensors = []
-            for op in op_list:
-                tensors.append(op.tensor)
+            tensors = [op.tensor for op in op_list]
             all_reduce_opts = AllreduceCoalescedOptions()
             all_reduce_opts.reduceOp = not_none(op_list[0].redop)
             work = group.allreduce_coalesced(tensors, all_reduce_opts)

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -568,7 +568,11 @@ def _root_pre_forward(
             state._needs_buffer_dtype_restore_check = False
 
         if state.forward_prefetch:
-            handles = [fsdp_state._handle for fsdp_state in state._all_fsdp_states if fsdp_state._handle]
+            handles = [
+                fsdp_state._handle
+                for fsdp_state in state._all_fsdp_states
+                if fsdp_state._handle
+            ]
             for handle in handles:
                 handle._needs_pre_forward_unshard = True
                 handle._prefetched = False

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -568,10 +568,7 @@ def _root_pre_forward(
             state._needs_buffer_dtype_restore_check = False
 
         if state.forward_prefetch:
-            handles = []
-            for fsdp_state in state._all_fsdp_states:
-                if fsdp_state._handle:
-                    handles.append(fsdp_state._handle)
+            handles = [fsdp_state._handle for fsdp_state in state._all_fsdp_states if fsdp_state._handle]
             for handle in handles:
                 handle._needs_pre_forward_unshard = True
                 handle._prefetched = False

--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -110,9 +110,7 @@ def _create_module_with_interface(
 
 
 def _param_rrefs(module_rref, recurse) -> List[rpc.RRef[Parameter]]:
-    ret: List[rpc.RRef[Parameter]] = []
-    for param in module_rref.local_value().parameters(recurse):
-        ret.append(rpc.RRef(param))
+    ret: List[rpc.RRef[Parameter]] = [rpc.RRef(param) for param in module_rref.local_value().parameters(recurse)]
     return ret
 
 

--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -110,7 +110,9 @@ def _create_module_with_interface(
 
 
 def _param_rrefs(module_rref, recurse) -> List[rpc.RRef[Parameter]]:
-    ret: List[rpc.RRef[Parameter]] = [rpc.RRef(param) for param in module_rref.local_value().parameters(recurse)]
+    ret: List[rpc.RRef[Parameter]] = [
+        rpc.RRef(param) for param in module_rref.local_value().parameters(recurse)
+    ]
     return ret
 
 

--- a/torch/distributed/optim/named_optimizer.py
+++ b/torch/distributed/optim/named_optimizer.py
@@ -146,9 +146,7 @@ class _NamedOptimizer(optim.Optimizer):
 
         ret_groups = []
         for group in param_groups:
-            param_keys = []
-            for param in group["params"]:
-                param_keys.append(self.ordered_param_keys[param])
+            param_keys = [self.ordered_param_keys[param] for param in group["params"]]
             ret_group = {"params": sorted(param_keys)}
             for k, v in group.items():
                 if k != "params":

--- a/torch/distributed/optim/optimizer.py
+++ b/torch/distributed/optim/optimizer.py
@@ -245,13 +245,9 @@ class DistributedOptimizer:
             else _local_optimizer_step
         )
 
-        rpc_futs = []
-        for optimizer in self.remote_optimizers:
-            rpc_futs.append(
-                rpc.rpc_async(
+        rpc_futs = [rpc.rpc_async(
                     optimizer.owner(),
                     optimizer_step_func,
                     args=(optimizer, context_id),
-                )
-            )
+                ) for optimizer in self.remote_optimizers]
         _wait_for_all(rpc_futs)

--- a/torch/distributed/optim/optimizer.py
+++ b/torch/distributed/optim/optimizer.py
@@ -245,9 +245,12 @@ class DistributedOptimizer:
             else _local_optimizer_step
         )
 
-        rpc_futs = [rpc.rpc_async(
-                    optimizer.owner(),
-                    optimizer_step_func,
-                    args=(optimizer, context_id),
-                ) for optimizer in self.remote_optimizers]
+        rpc_futs = [
+            rpc.rpc_async(
+                optimizer.owner(),
+                optimizer_step_func,
+                args=(optimizer, context_id),
+            )
+            for optimizer in self.remote_optimizers
+        ]
         _wait_for_all(rpc_futs)

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -781,12 +781,15 @@ class ZeroRedundancyOptimizer(Optimizer, Joinable):
                 self.process_group, rank
             )
             for param_group in param_groups:
-                handles.extend(dist.broadcast(
-                            tensor=param.data,
-                            src=global_rank,
-                            group=self.process_group,
-                            async_op=True,
-                        ) for param in param_group["params"])
+                handles.extend(
+                    dist.broadcast(
+                        tensor=param.data,
+                        src=global_rank,
+                        group=self.process_group,
+                        async_op=True,
+                    )
+                    for param in param_group["params"]
+                )
         return handles
 
     def _sync_params(self):

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -781,15 +781,12 @@ class ZeroRedundancyOptimizer(Optimizer, Joinable):
                 self.process_group, rank
             )
             for param_group in param_groups:
-                for param in param_group["params"]:
-                    handles.append(
-                        dist.broadcast(
+                handles.extend(dist.broadcast(
                             tensor=param.data,
                             src=global_rank,
                             group=self.process_group,
                             async_op=True,
-                        )
-                    )
+                        ) for param in param_group["params"])
         return handles
 
     def _sync_params(self):

--- a/torch/distributed/pipelining/microbatch.py
+++ b/torch/distributed/pipelining/microbatch.py
@@ -224,9 +224,7 @@ def _shard_dict_of_args(
     for chunk_idx in range(real_num_chunks):
         chunk_args = {}
         for key, arg in args_sharded_replicated.items():
-            arg_single_chunk = []
-            for v_flat in arg:
-                arg_single_chunk.append(v_flat[chunk_idx])
+            arg_single_chunk = [v_flat[chunk_idx] for v_flat in arg]
             chunk_args[key] = arg_single_chunk
         chunks_flat.append(chunk_args)
 
@@ -340,9 +338,7 @@ def split_args_kwargs_into_chunks(
             f"{len(args_split_dict)}, {len(kwargs_split)}"
         )
 
-    args_split = []
-    for chunk_args in args_split_dict:
-        args_split.append(tuple(chunk_args[i] for i in range(len(chunk_args))))
+    args_split = [tuple(chunk_args[i] for i in range(len(chunk_args))) for chunk_args in args_split_dict]
 
     return args_split, kwargs_split
 

--- a/torch/distributed/pipelining/microbatch.py
+++ b/torch/distributed/pipelining/microbatch.py
@@ -338,7 +338,10 @@ def split_args_kwargs_into_chunks(
             f"{len(args_split_dict)}, {len(kwargs_split)}"
         )
 
-    args_split = [tuple(chunk_args[i] for i in range(len(chunk_args))) for chunk_args in args_split_dict]
+    args_split = [
+        tuple(chunk_args[i] for i in range(len(chunk_args)))
+        for chunk_args in args_split_dict
+    ]
 
     return args_split, kwargs_split
 

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -1706,7 +1706,10 @@ class ScheduleLoopedBFS(PipelineScheduleMulti):
         rank_ops: List[Optional[_Action]] = [None for _ in range(rank)]
 
         for stage_index in stage_indices:
-            rank_ops.extend(_Action(stage_index, _ComputationType.FORWARD, mb_index) for mb_index in range(self._n_microbatches))
+            rank_ops.extend(
+                _Action(stage_index, _ComputationType.FORWARD, mb_index)
+                for mb_index in range(self._n_microbatches)
+            )
 
         # wait for the first backward to trickle up
         # which is 2 for every hop away
@@ -1714,7 +1717,10 @@ class ScheduleLoopedBFS(PipelineScheduleMulti):
         rank_ops.extend([None] * post_warmup_ops)
 
         for stage_index in reversed(stage_indices):
-            rank_ops.extend(_Action(stage_index, _ComputationType.FULL_BACKWARD, mb_index) for mb_index in reversed(range(self._n_microbatches)))
+            rank_ops.extend(
+                _Action(stage_index, _ComputationType.FULL_BACKWARD, mb_index)
+                for mb_index in reversed(range(self._n_microbatches))
+            )
         return rank_ops
 
 

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -1702,16 +1702,11 @@ class ScheduleLoopedBFS(PipelineScheduleMulti):
         )
 
         # Store the list of operations used for that rank
-        rank_ops: List[Optional[_Action]] = []
         # Pre-padding, rank starts with no-ops based on the warmup.
-        for _ in range(rank):
-            rank_ops.append(None)
+        rank_ops: List[Optional[_Action]] = [None for _ in range(rank)]
 
         for stage_index in stage_indices:
-            for mb_index in range(self._n_microbatches):
-                rank_ops.append(
-                    _Action(stage_index, _ComputationType.FORWARD, mb_index)
-                )
+            rank_ops.extend(_Action(stage_index, _ComputationType.FORWARD, mb_index) for mb_index in range(self._n_microbatches))
 
         # wait for the first backward to trickle up
         # which is 2 for every hop away
@@ -1719,10 +1714,7 @@ class ScheduleLoopedBFS(PipelineScheduleMulti):
         rank_ops.extend([None] * post_warmup_ops)
 
         for stage_index in reversed(stage_indices):
-            for mb_index in reversed(range(self._n_microbatches)):
-                rank_ops.append(
-                    _Action(stage_index, _ComputationType.FULL_BACKWARD, mb_index)
-                )
+            rank_ops.extend(_Action(stage_index, _ComputationType.FULL_BACKWARD, mb_index) for mb_index in reversed(range(self._n_microbatches)))
         return rank_ops
 
 
@@ -1744,10 +1736,8 @@ def _get_1f1b_rank_ops(
     weight_stage_mb_index: Dict[int, int] = defaultdict(int)
 
     # Store the list of operations used for that rank
-    rank_ops: List[Optional[_Action]] = []
     # Pre-padding, rank starts with no-ops based on the warmup.
-    for _ in range(rank):
-        rank_ops.append(None)
+    rank_ops: List[Optional[_Action]] = [None for _ in range(rank)]
     # These are used to calculate the number of slots to fill with no-ops, to account for the delay in warmup
     # when we want to wait for the backward to trickle back up and start 1f1b to align all ranks.
     # Formula:

--- a/torch/distributed/tensor/_collective_utils.py
+++ b/torch/distributed/tensor/_collective_utils.py
@@ -195,8 +195,7 @@ def fill_empty_tensor_to_shards(
         size if idx != shard_dim else 0 for idx, size in enumerate(tensor_size)
     ]
     tensor = shards[0].new_zeros(tensor_size)
-    for _ in range(num_empty_tensors):
-        shards.append(tensor)
+    shards.extend(tensor for _ in range(num_empty_tensors))
     return shards
 
 

--- a/torch/distributed/tensor/_ops/_einsum_strategy.py
+++ b/torch/distributed/tensor/_ops/_einsum_strategy.py
@@ -167,9 +167,7 @@ def gen_einsum_strategies(
     # (i.e. for Shard, tensor dim size must > mesh size)
     all_strategies = []
     for strategy_comb in strategy_combs:
-        spec_list = []
-        for specs in zip(*strategy_comb):
-            spec_list.append(DTensorSpec(mesh, tuple(specs)))
+        spec_list = [DTensorSpec(mesh, tuple(specs)) for specs in zip(*strategy_comb)]
         strat = PlacementStrategy(output_specs=spec_list[0], input_specs=spec_list[1:])
         all_strategies.append(strat)
 

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -43,18 +43,14 @@ def default_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> StrategyType:
     # Default strategy by default just propagate the first input strategy
     select_strategy = op_schema.args_schema[0]
     assert isinstance(select_strategy, OpStrategy)
-    default_strategy = []
-    for strategy in select_strategy.strategies:
-        # we create new DTensorSpecs even for default strategy to assure that
-        # the tensor metas are distinct between the arguments and outputs
-        default_strategy.append(
-            PlacementStrategy(
+    # we create new DTensorSpecs even for default strategy to assure that
+    # the tensor metas are distinct between the arguments and outputs
+    default_strategy = [PlacementStrategy(
                 output_specs=DTensorSpec(
                     mesh=strategy.output_spec.mesh,
                     placements=strategy.output_spec.placements,
                 )
-            )
-        )
+            ) for strategy in select_strategy.strategies]
     return OpStrategy(default_strategy)
 
 

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -45,12 +45,15 @@ def default_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> StrategyType:
     assert isinstance(select_strategy, OpStrategy)
     # we create new DTensorSpecs even for default strategy to assure that
     # the tensor metas are distinct between the arguments and outputs
-    default_strategy = [PlacementStrategy(
-                output_specs=DTensorSpec(
-                    mesh=strategy.output_spec.mesh,
-                    placements=strategy.output_spec.placements,
-                )
-            ) for strategy in select_strategy.strategies]
+    default_strategy = [
+        PlacementStrategy(
+            output_specs=DTensorSpec(
+                mesh=strategy.output_spec.mesh,
+                placements=strategy.output_spec.placements,
+            )
+        )
+        for strategy in select_strategy.strategies
+    ]
     return OpStrategy(default_strategy)
 
 

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -209,9 +209,7 @@ def map_placements_after_broadcast(
 def generate_redistribute_costs(
     src_strategy: OpStrategy, dst_spec: DTensorSpec
 ) -> List[float]:
-    redistribute_costs: List[float] = []
-    for strat in src_strategy.strategies:
-        redistribute_costs.append(redistribute_cost(strat.output_spec, dst_spec))
+    redistribute_costs: List[float] = [redistribute_cost(strat.output_spec, dst_spec) for strat in src_strategy.strategies]
 
     return redistribute_costs
 

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -209,7 +209,10 @@ def map_placements_after_broadcast(
 def generate_redistribute_costs(
     src_strategy: OpStrategy, dst_spec: DTensorSpec
 ) -> List[float]:
-    redistribute_costs: List[float] = [redistribute_cost(strat.output_spec, dst_spec) for strat in src_strategy.strategies]
+    redistribute_costs: List[float] = [
+        redistribute_cost(strat.output_spec, dst_spec)
+        for strat in src_strategy.strategies
+    ]
 
     return redistribute_costs
 

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -152,7 +152,11 @@ class InterpreterModule(torch.nn.Module):
                 # the keys in the kwarg dict.
                 arg_list = list(args)
                 kwarg_names = self.arg_names[len(arg_list) :]
-                arg_list.extend(kwargs[kwarg_name] for kwarg_name in kwarg_names if kwarg_name in kwargs)
+                arg_list.extend(
+                    kwargs[kwarg_name]
+                    for kwarg_name in kwarg_names
+                    if kwarg_name in kwargs
+                )
 
                 # Assert that the kwargs passed in exactly match the positional
                 # arguments specified by the GraphModule. This should be
@@ -931,7 +935,10 @@ class _ModuleFrame:
             assert kwargs_spec.context is not None
 
             with self.graph.inserting_after(None):
-                arg_nodes = [self.graph.placeholder(f"_positional_arg_{idx}") for idx in range(args_spec.num_children)]
+                arg_nodes = [
+                    self.graph.placeholder(f"_positional_arg_{idx}")
+                    for idx in range(args_spec.num_children)
+                ]
                 kwarg_nodes = {}
                 for name in kwargs_spec.context:
                     kwarg_nodes[name] = self.graph.placeholder(name)

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -152,9 +152,7 @@ class InterpreterModule(torch.nn.Module):
                 # the keys in the kwarg dict.
                 arg_list = list(args)
                 kwarg_names = self.arg_names[len(arg_list) :]
-                for kwarg_name in kwarg_names:
-                    if kwarg_name in kwargs:
-                        arg_list.append(kwargs[kwarg_name])
+                arg_list.extend(kwargs[kwarg_name] for kwarg_name in kwarg_names if kwarg_name in kwargs)
 
                 # Assert that the kwargs passed in exactly match the positional
                 # arguments specified by the GraphModule. This should be
@@ -933,9 +931,7 @@ class _ModuleFrame:
             assert kwargs_spec.context is not None
 
             with self.graph.inserting_after(None):
-                arg_nodes = []
-                for idx in range(args_spec.num_children):
-                    arg_nodes.append(self.graph.placeholder(f"_positional_arg_{idx}"))
+                arg_nodes = [self.graph.placeholder(f"_positional_arg_{idx}") for idx in range(args_spec.num_children)]
                 kwarg_nodes = {}
                 for name in kwargs_spec.context:
                     kwarg_nodes[name] = self.graph.placeholder(name)

--- a/torch/fx/experimental/accelerator_partitioner.py
+++ b/torch/fx/experimental/accelerator_partitioner.py
@@ -1015,10 +1015,7 @@ class Partitioner:
         # Keep tracking the partition pair of node pair
         partition_pair: List[Partition] = []
         # Collect all the op nodes from the graph
-        op_nodes = []
-        for n in self.graph_module.graph.nodes:
-            if n.op not in {"placeholder", "get_attr", "output"}:
-                op_nodes.append(n)
+        op_nodes = [n for n in self.graph_module.graph.nodes if n.op not in {"placeholder", "get_attr", "output"}]
         for node in op_nodes:
             # Find which partition the current node belongs
             p0_index = self.node_to_partition[node]

--- a/torch/fx/experimental/accelerator_partitioner.py
+++ b/torch/fx/experimental/accelerator_partitioner.py
@@ -1015,7 +1015,11 @@ class Partitioner:
         # Keep tracking the partition pair of node pair
         partition_pair: List[Partition] = []
         # Collect all the op nodes from the graph
-        op_nodes = [n for n in self.graph_module.graph.nodes if n.op not in {"placeholder", "get_attr", "output"}]
+        op_nodes = [
+            n
+            for n in self.graph_module.graph.nodes
+            if n.op not in {"placeholder", "get_attr", "output"}
+        ]
         for node in op_nodes:
             # Find which partition the current node belongs
             p0_index = self.node_to_partition[node]

--- a/torch/fx/experimental/migrate_gradual_types/constraint_transformation.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_transformation.py
@@ -648,11 +648,8 @@ def generate_reshape(constraint, counter):
 
     # then there must be exactly one occurrence of dyn
     else:
-        new_target = []
 
-        for n in target:
-            if n != Dyn:
-                new_target.append(n)
+        new_target = [n for n in target if n != Dyn]
 
         # tensor 1
         c3_tensor1 = Disj(
@@ -886,10 +883,8 @@ def generate_all_int_dyn_dim_possibilities(my_list: List[DVar]):
     neq_possibilities = [
         BinConstraintD(my_list[i], Dyn, op_neq) for i in range(len(my_list))
     ]
-    d_possibilities = []
 
-    for i in zip(eq_possibilities, neq_possibilities):
-        d_possibilities.append(list(i))
+    d_possibilities = [list(i) for i in zip(eq_possibilities, neq_possibilities)]
     all_possibilities = list(itertools.product(*d_possibilities))
     return all_possibilities
 
@@ -1043,13 +1038,9 @@ def apply_padding(
 
         assert len(simulate_padding + d1) == len(d2)
 
-        broadcast_padding = []
 
         # for every padding size, we also consider broadcasting
-        for j in range(len(d2) - i):
-            broadcast_padding.append(
-                broadcast_dim(simulate_padding, d2, d11, d12, j, True)
-            )
+        broadcast_padding = [broadcast_dim(simulate_padding, d2, d11, d12, j, True) for j in range(len(d2) - i)]
 
         # we consider the possibilities for broadcasting for every dimension. Since we already
         # padded d1, we do not consider it while broadcasting

--- a/torch/fx/experimental/migrate_gradual_types/constraint_transformation.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_transformation.py
@@ -648,7 +648,6 @@ def generate_reshape(constraint, counter):
 
     # then there must be exactly one occurrence of dyn
     else:
-
         new_target = [n for n in target if n != Dyn]
 
         # tensor 1
@@ -1038,9 +1037,11 @@ def apply_padding(
 
         assert len(simulate_padding + d1) == len(d2)
 
-
         # for every padding size, we also consider broadcasting
-        broadcast_padding = [broadcast_dim(simulate_padding, d2, d11, d12, j, True) for j in range(len(d2) - i)]
+        broadcast_padding = [
+            broadcast_dim(simulate_padding, d2, d11, d12, j, True)
+            for j in range(len(d2) - i)
+        ]
 
         # we consider the possibilities for broadcasting for every dimension. Since we already
         # padded d1, we do not consider it while broadcasting

--- a/torch/fx/experimental/partitioner_utils.py
+++ b/torch/fx/experimental/partitioner_utils.py
@@ -302,11 +302,8 @@ def get_latency_of_partitioned_graph(
         """This function is to return all the partitions without parents
         as the starting points of all the paths
         """
-        top_partitions = []
-        for partition in partitions:
-            # If a partition has no parents, then it is a top partition
-            if len(partition.parents) == 0:
-                top_partitions.append(partition)
+        # If a partition has no parents, then it is a top partition
+        top_partitions = [partition for partition in partitions if len(partition.parents) == 0]
         return top_partitions
 
     top_partitions = get_top_partitions(partitions)

--- a/torch/fx/experimental/partitioner_utils.py
+++ b/torch/fx/experimental/partitioner_utils.py
@@ -303,7 +303,9 @@ def get_latency_of_partitioned_graph(
         as the starting points of all the paths
         """
         # If a partition has no parents, then it is a top partition
-        top_partitions = [partition for partition in partitions if len(partition.parents) == 0]
+        top_partitions = [
+            partition for partition in partitions if len(partition.parents) == 0
+        ]
         return top_partitions
 
     top_partitions = get_top_partitions(partitions)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5201,7 +5201,9 @@ class ShapeEnv:
         symints = {
             s.node.expr for s in symints if isinstance(s.node.expr, sympy.Symbol)
         }
-        guards = [g for g in self.guards if all(s in symints for s in g.expr.free_symbols)]
+        guards = [
+            g for g in self.guards if all(s in symints for s in g.expr.free_symbols)
+        ]
         return guards
 
     def bind_symbols(

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5201,10 +5201,7 @@ class ShapeEnv:
         symints = {
             s.node.expr for s in symints if isinstance(s.node.expr, sympy.Symbol)
         }
-        guards = []
-        for g in self.guards:
-            if all(s in symints for s in g.expr.free_symbols):
-                guards.append(g)
+        guards = [g for g in self.guards if all(s in symints for s in g.expr.free_symbols)]
         return guards
 
     def bind_symbols(

--- a/torch/fx/passes/pass_manager.py
+++ b/torch/fx/passes/pass_manager.py
@@ -220,10 +220,7 @@ class PassManager:
     def remove_pass(self, _passes: List[str]):
         if _passes is None:
             return
-        passes_left = []
-        for ps in self.passes:
-            if ps.__name__ not in _passes:
-                passes_left.append(ps)
+        passes_left = [ps for ps in self.passes if ps.__name__ not in _passes]
         self.passes = passes_left
         self._validated = False
 

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -957,7 +957,10 @@ def interface_script(mod_interface, nn_module):
 
         It is used to know which methods need to act as starting points for compilation.
         """
-        stubs = [make_stub_from_method(nn_module, method) for method in mod_interface.getMethodNames()]
+        stubs = [
+            make_stub_from_method(nn_module, method)
+            for method in mod_interface.getMethodNames()
+        ]
         return stubs
 
     return create_script_module(nn_module, infer_interface_methods_to_compile)

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -881,9 +881,7 @@ def infer_methods_to_compile(nn_module):
         uniqued_methods.append(name)
         uniquer.add(name)
 
-    stubs = []
-    for method in uniqued_methods:
-        stubs.append(make_stub_from_method(nn_module, method))
+    stubs = [make_stub_from_method(nn_module, method) for method in uniqued_methods]
     return overload_stubs + stubs
 
 
@@ -959,9 +957,7 @@ def interface_script(mod_interface, nn_module):
 
         It is used to know which methods need to act as starting points for compilation.
         """
-        stubs = []
-        for method in mod_interface.getMethodNames():
-            stubs.append(make_stub_from_method(nn_module, method))
+        stubs = [make_stub_from_method(nn_module, method) for method in mod_interface.getMethodNames()]
         return stubs
 
     return create_script_module(nn_module, infer_interface_methods_to_compile)

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -1493,7 +1493,10 @@ def _get_overloads(obj):
             _jit_internal.get_overload_no_implementation_error_message("function", obj)
         )
 
-    compiled_fns = [_compile_function_with_overload(overload_fn, qual_name, obj) for overload_fn in uncompiled_overloads]
+    compiled_fns = [
+        _compile_function_with_overload(overload_fn, qual_name, obj)
+        for overload_fn in uncompiled_overloads
+    ]
 
     if existing_compiled_fns:
         compiled_fns = existing_compiled_fns + compiled_fns

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -1493,11 +1493,7 @@ def _get_overloads(obj):
             _jit_internal.get_overload_no_implementation_error_message("function", obj)
         )
 
-    compiled_fns = []
-    for overload_fn in uncompiled_overloads:
-        compiled_fns.append(
-            _compile_function_with_overload(overload_fn, qual_name, obj)
-        )
+    compiled_fns = [_compile_function_with_overload(overload_fn, qual_name, obj) for overload_fn in uncompiled_overloads]
 
     if existing_compiled_fns:
         compiled_fns = existing_compiled_fns + compiled_fns

--- a/torch/jit/supported_ops.py
+++ b/torch/jit/supported_ops.py
@@ -72,9 +72,7 @@ def _get_tensor_ops():
     for elem in dir(torch.Tensor):
         if not _hidden(elem):
             schemas = torch._C._jit_get_schemas_for_operator("aten::" + elem)
-            for schema in schemas:
-                if is_tensor_method(schema):
-                    methods.append(_emit_schema("Tensor", elem, schema, arg_start=1))
+            methods.extend(_emit_schema("Tensor", elem, schema, arg_start=1) for schema in schemas if is_tensor_method(schema))
 
     return "Supported Tensor Methods", methods
 
@@ -115,10 +113,8 @@ def _get_nn_functional_ops():
             builtin = _find_builtin(getattr(mod, elem))
             if builtin is not None:
                 schemas = torch._C._jit_get_schemas_for_operator(builtin)
-                for schema in schemas:
-                    # remove _tan but not __and__
-                    if not _hidden(elem):
-                        functions.append(_emit_schema(name, elem, schema))
+                # remove _tan but not __and__
+                functions.extend(_emit_schema(name, elem, schema) for schema in schemas if not _hidden(elem))
     return "Supported PyTorch Functions", functions
 
 
@@ -164,8 +160,7 @@ def _get_torchscript_builtins():
         builtin = _find_builtin(fn)
         if builtin is not None:
             schemas = torch._C._jit_get_schemas_for_operator(builtin)
-            for schema in schemas:
-                functions.append(_emit_schema(mod.__name__, fn.__name__, schema))
+            functions.extend(_emit_schema(mod.__name__, fn.__name__, schema) for schema in schemas)
 
     return "TorchScript Builtin Functions", functions
 
@@ -271,8 +266,7 @@ def _get_global_builtins():
         if fn in op_renames:
             op_name = op_renames[fn]
         schemas = torch._C._jit_get_schemas_for_operator(op_name)
-        for s in schemas:
-            schematized_ops.append(_emit_schema(None, fn, s, padding=0))
+        schematized_ops.extend(_emit_schema(None, fn, s, padding=0) for s in schemas)
         if len(schemas) > 0:
             schematized_ops.append("")
         else:

--- a/torch/jit/supported_ops.py
+++ b/torch/jit/supported_ops.py
@@ -72,7 +72,11 @@ def _get_tensor_ops():
     for elem in dir(torch.Tensor):
         if not _hidden(elem):
             schemas = torch._C._jit_get_schemas_for_operator("aten::" + elem)
-            methods.extend(_emit_schema("Tensor", elem, schema, arg_start=1) for schema in schemas if is_tensor_method(schema))
+            methods.extend(
+                _emit_schema("Tensor", elem, schema, arg_start=1)
+                for schema in schemas
+                if is_tensor_method(schema)
+            )
 
     return "Supported Tensor Methods", methods
 
@@ -114,7 +118,11 @@ def _get_nn_functional_ops():
             if builtin is not None:
                 schemas = torch._C._jit_get_schemas_for_operator(builtin)
                 # remove _tan but not __and__
-                functions.extend(_emit_schema(name, elem, schema) for schema in schemas if not _hidden(elem))
+                functions.extend(
+                    _emit_schema(name, elem, schema)
+                    for schema in schemas
+                    if not _hidden(elem)
+                )
     return "Supported PyTorch Functions", functions
 
 
@@ -160,7 +168,9 @@ def _get_torchscript_builtins():
         builtin = _find_builtin(fn)
         if builtin is not None:
             schemas = torch._C._jit_get_schemas_for_operator(builtin)
-            functions.extend(_emit_schema(mod.__name__, fn.__name__, schema) for schema in schemas)
+            functions.extend(
+                _emit_schema(mod.__name__, fn.__name__, schema) for schema in schemas
+            )
 
     return "TorchScript Builtin Functions", functions
 

--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -77,9 +77,7 @@ def _lazy_init() -> None:
         # However, we must not let any *other* threads in!
         _tls.is_initializing = True
 
-        for calls in _lazy_seed_tracker.get_calls():
-            if calls:
-                _queued_calls.append(calls)
+        _queued_calls.extend(calls for calls in _lazy_seed_tracker.get_calls() if calls)
 
         try:
             for queued_call, orig_traceback in _queued_calls:

--- a/torch/nn/parallel/_functions.py
+++ b/torch/nn/parallel/_functions.py
@@ -23,8 +23,7 @@ class Broadcast(Function):
         non_differentiables = []
         for idx, input_requires_grad in enumerate(ctx.needs_input_grad[1:]):
             if not input_requires_grad:
-                for output in outputs:
-                    non_differentiables.append(output[idx])
+                non_differentiables.extend(output[idx] for output in outputs)
         ctx.mark_non_differentiable(*non_differentiables)
         return tuple([t for tensors in outputs for t in tensors])
 

--- a/torch/nn/utils/_expanded_weights/conv_utils.py
+++ b/torch/nn/utils/_expanded_weights/conv_utils.py
@@ -142,9 +142,7 @@ def conv_backward(func, ctx, grad_output):
         ctx.groups,
     )
 
-    kernel_size = []
-    for i in range(2, conv_picker(func, 3, 4, 5)):
-        kernel_size.append(weight_shape[i])
+    kernel_size = [weight_shape[i] for i in range(2, conv_picker(func, 3, 4, 5))]
 
     batch_size = ctx.batch_size
     results: List[Optional[torch.Tensor]] = []

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -360,7 +360,10 @@ def quantized_args(
             for descriptor, arg in descriptor_args:
                 # ListConstruct
                 if _is_packed_list(arg):
-                    is_quantized.extend(_is_arg_quantized(descriptor, arg_input) for arg_input in arg.node().inputs())
+                    is_quantized.extend(
+                        _is_arg_quantized(descriptor, arg_input)
+                        for arg_input in arg.node().inputs()
+                    )
                 else:
                     is_quantized.append(_is_arg_quantized(descriptor, arg))
 

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -356,7 +356,7 @@ def quantized_args(
                 return descriptor and _is_value(arg) and _is_tuple_construct(arg)
 
             # Run regular symbolic function if none of the argument is QTensor.
-            is_quantized = []
+            is_quantized: typing.List[bool] = []
             for descriptor, arg in descriptor_args:
                 # ListConstruct
                 if _is_packed_list(arg):

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -360,8 +360,7 @@ def quantized_args(
             for descriptor, arg in descriptor_args:
                 # ListConstruct
                 if _is_packed_list(arg):
-                    for arg_input in arg.node().inputs():
-                        is_quantized.append(_is_arg_quantized(descriptor, arg_input))
+                    is_quantized.extend(_is_arg_quantized(descriptor, arg_input) for arg_input in arg.node().inputs())
                 else:
                     is_quantized.append(_is_arg_quantized(descriptor, arg))
 

--- a/torch/onnx/symbolic_opset18.py
+++ b/torch/onnx/symbolic_opset18.py
@@ -69,8 +69,7 @@ def col2im(
     # convert [i0, i1, ..., in] into [i0, i0, i1, i1, ..., in, in]
     adjusted_padding = []
     for pad in padding:
-        for _ in range(2):
-            adjusted_padding.append(pad)
+        adjusted_padding.extend(pad for _ in range(2))
 
     num_dimensional_axis = symbolic_helper._get_tensor_sizes(output_size)[0]
     if not adjusted_padding:

--- a/torch/onnx/symbolic_opset18.py
+++ b/torch/onnx/symbolic_opset18.py
@@ -67,7 +67,7 @@ def col2im(
     stride: Sequence[int],
 ):
     # convert [i0, i1, ..., in] into [i0, i0, i1, i1, ..., in, in]
-    adjusted_padding = []
+    adjusted_padding: List[int] = []
     for pad in padding:
         adjusted_padding.extend(pad for _ in range(2))
 

--- a/torch/onnx/verification.py
+++ b/torch/onnx/verification.py
@@ -1397,7 +1397,6 @@ class GraphInfo:
         original_outputs = list(graph.outputs())
         original_inputs = list(graph.inputs())
 
-        new_outputs = []
 
         def _process_bridge_value_for_lower(
             graph: torch.Graph, bridge_value: torch.Value
@@ -1416,9 +1415,7 @@ class GraphInfo:
             graph, pivot, process_bridge_value_for_lower
         )
 
-        for output in original_outputs:
-            if _produced_by(output, lower_nodes):
-                new_outputs.append(output)
+        new_outputs = [output for output in original_outputs if _produced_by(output, lower_nodes)]
         for _ in enumerate(original_outputs):
             graph.eraseOutput(0)
         for output in new_outputs:

--- a/torch/onnx/verification.py
+++ b/torch/onnx/verification.py
@@ -1397,7 +1397,6 @@ class GraphInfo:
         original_outputs = list(graph.outputs())
         original_inputs = list(graph.inputs())
 
-
         def _process_bridge_value_for_lower(
             graph: torch.Graph, bridge_value: torch.Value
         ) -> torch.Value:
@@ -1415,7 +1414,9 @@ class GraphInfo:
             graph, pivot, process_bridge_value_for_lower
         )
 
-        new_outputs = [output for output in original_outputs if _produced_by(output, lower_nodes)]
+        new_outputs = [
+            output for output in original_outputs if _produced_by(output, lower_nodes)
+        ]
         for _ in enumerate(original_outputs):
             graph.eraseOutput(0)
         for output in new_outputs:

--- a/torch/package/_directory_reader.py
+++ b/torch/package/_directory_reader.py
@@ -50,7 +50,11 @@ class DirectoryReader:
     def get_all_records(
         self,
     ):
-        files = [filename[len(self.directory) + 1 :] for filename in glob(f"{self.directory}/**", recursive=True) if not os.path.isdir(filename)]
+        files = [
+            filename[len(self.directory) + 1 :]
+            for filename in glob(f"{self.directory}/**", recursive=True)
+            if not os.path.isdir(filename)
+        ]
         return files
 
     def serialization_id(

--- a/torch/package/_directory_reader.py
+++ b/torch/package/_directory_reader.py
@@ -50,10 +50,7 @@ class DirectoryReader:
     def get_all_records(
         self,
     ):
-        files = []
-        for filename in glob(f"{self.directory}/**", recursive=True):
-            if not os.path.isdir(filename):
-                files.append(filename[len(self.directory) + 1 :])
+        files = [filename[len(self.directory) + 1 :] for filename in glob(f"{self.directory}/**", recursive=True) if not os.path.isdir(filename)]
         return files
 
     def serialization_id(

--- a/torch/package/find_file_dependencies.py
+++ b/torch/package/find_file_dependencies.py
@@ -56,13 +56,11 @@ class _ExtractModuleReferences(ast.NodeVisitor):
                 fromlist = []
                 level = 0
                 if len(node.args) > 3:
-                    for v in node.args[3].elts:
-                        fromlist.append(self._grab_node_str(v))
+                    fromlist.extend(self._grab_node_str(v) for v in node.args[3].elts)
                 elif hasattr(node, "keywords"):
                     for keyword in node.keywords:
                         if keyword.arg == "fromlist":
-                            for v in keyword.value.elts:
-                                fromlist.append(self._grab_node_str(v))
+                            fromlist.extend(self._grab_node_str(v) for v in keyword.value.elts)
                 if len(node.args) > 4:
                     level = self._grab_node_int(node.args[4])
                 elif hasattr(node, "keywords"):

--- a/torch/package/find_file_dependencies.py
+++ b/torch/package/find_file_dependencies.py
@@ -60,7 +60,9 @@ class _ExtractModuleReferences(ast.NodeVisitor):
                 elif hasattr(node, "keywords"):
                     for keyword in node.keywords:
                         if keyword.arg == "fromlist":
-                            fromlist.extend(self._grab_node_str(v) for v in keyword.value.elts)
+                            fromlist.extend(
+                                self._grab_node_str(v) for v in keyword.value.elts
+                            )
                 if len(node.args) > 4:
                     level = self._grab_node_int(node.args[4])
                 elif hasattr(node, "keywords"):

--- a/torch/package/find_file_dependencies.py
+++ b/torch/package/find_file_dependencies.py
@@ -53,7 +53,7 @@ class _ExtractModuleReferences(ast.NodeVisitor):
         if hasattr(node.func, "id") and node.func.id == "__import__":
             try:
                 name = self._grab_node_str(node.args[0])
-                fromlist = []
+                fromlist: List[str] = []
                 level = 0
                 if len(node.args) > 3:
                     fromlist.extend(self._grab_node_str(v) for v in node.args[3].elts)

--- a/torch/profiler/_pattern_matcher.py
+++ b/torch/profiler/_pattern_matcher.py
@@ -97,7 +97,9 @@ class Pattern:
     def matched_events(self):
         if self.skip:
             return []
-        matched_events = [event for event in self.eventTreeTraversal() if self.match(event)]
+        matched_events = [
+            event for event in self.eventTreeTraversal() if self.match(event)
+        ]
         return matched_events
 
     def root_of(self, event: _ProfilerEvent):

--- a/torch/profiler/_pattern_matcher.py
+++ b/torch/profiler/_pattern_matcher.py
@@ -97,10 +97,7 @@ class Pattern:
     def matched_events(self):
         if self.skip:
             return []
-        matched_events = []
-        for event in self.eventTreeTraversal():
-            if self.match(event):
-                matched_events.append(event)
+        matched_events = [event for event in self.eventTreeTraversal() if self.match(event)]
         return matched_events
 
     def root_of(self, event: _ProfilerEvent):

--- a/torch/sparse/_triton_ops_meta.py
+++ b/torch/sparse/_triton_ops_meta.py
@@ -233,8 +233,7 @@ def dump():
     for op_key in sorted(_operation_device_version_data, key=sort_key):
         data_part.append("    " + repr(op_key).replace("'", '"') + ": {")
         op_data = _operation_device_version_data[op_key]
-        for key in sorted(op_data):
-            data_part.append(f"        {key}: {op_data[key]},")
+        data_part.extend(f"        {key}: {op_data[key]}," for key in sorted(op_data))
         data_part.append("    },")
     new_content = part1 + "\n".join(data_part) + "\n" + part2
     if current_content != new_content:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2285,9 +2285,7 @@ def sample_inputs_stack(op_info, device, dtype, requires_grad, **kwargs):
         ((0, 1, 0), 2),)
 
     for shape, num_tensors in cases:
-        tensors = []
-        for _ in range(num_tensors):
-            tensors.append(make_arg(shape))
+        tensors = [make_arg(shape) for _ in range(num_tensors)]
         for dim in range(-1, len(shape) - 1):
             yield SampleInput(tensors, args=(dim,))
 
@@ -2328,9 +2326,7 @@ def sample_inputs_chunk_cat(op_info, device, dtype, requires_grad, **kwargs):
         ),
     )
     for sizes, dim, num_chunks in same_ndim_cases:
-        tensors = []
-        for size in sizes:
-            tensors.append(make_arg(size))
+        tensors = [make_arg(size) for size in sizes]
         yield SampleInput(tensors, args=(dim, num_chunks))
 
     different_ndim_case = [

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -2373,9 +2373,7 @@ class ModelWithSequentialFusion(nn.Module):
         super().__init__()
         self.conv1 = nn.Conv2d(3, 3, 1)
         self.relu1 = nn.ReLU(inplace=False)
-        layers = []
-        for _ in range(3):
-            layers.append(ConvBNReLU())
+        layers = [ConvBNReLU() for _ in range(3)]
         self.features = nn.Sequential(*layers)
         head = [nn.Linear(300, 10), nn.ReLU(inplace=False)]
         self.classifier = nn.Sequential(*head)

--- a/torch/testing/_internal/common_quantized.py
+++ b/torch/testing/_internal/common_quantized.py
@@ -127,9 +127,7 @@ def _snr(x, x_hat):
     """
     if isinstance(x, (list, tuple)):
         assert len(x) == len(x_hat)
-        res = []
-        for idx in range(len(x)):
-            res.append(_snr(x[idx], x_hat[idx]))
+        res = [_snr(x[idx], x_hat[idx]) for idx in range(len(x))]
         return res
     if x_hat.is_quantized:
         x_hat = x_hat.dequantize()

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -4618,8 +4618,7 @@ def _generate_indices_prefer_all_rows(rows: int, cols: int, num_indices: int) ->
 
     for r in range(rows):
         # Note that this can yield overlapping indices
-        for c in random.choices(col_indices, k=n_per_row):
-            indices.append((r, c))
+        indices.extend((r, c) for c in random.choices(col_indices, k=n_per_row))
 
     return torch.tensor(indices[:num_indices])
 
@@ -5114,9 +5113,7 @@ def get_cycles_per_ms() -> float:
     # and seems to return stable values. Therefore, we enable caching
     # using lru_cache decorator above.
     num = 10
-    vals = []
-    for _ in range(num):
-        vals.append(measure())
+    vals = [measure() for _ in range(num)]
     vals = sorted(vals)
     return mean(vals[2 : num - 2])
 

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -444,7 +444,9 @@ class DTensorConverter:
 
         choices_for_args = [self.gen_sharding_choices_for_arg(arg) for arg in self.flatten_args if isinstance(arg, torch.Tensor)]
 
-        choices_for_args.extend(self.gen_sharding_choices_for_arg(arg) for arg in self.flatten_kwargs if isinstance(arg, torch.Tensor))
+        choices_for_args.extend(
+            self.gen_sharding_choices_for_arg(arg) for arg in self.flatten_kwargs if isinstance(arg, torch.Tensor)
+        )
 
         self.sharding_combs: Iterator[Sequence[Placement]] = iter(
             itertools.product(*choices_for_args)

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -442,14 +442,9 @@ class DTensorConverter:
         self.flatten_kwargs: List[object] = flatten_kwargs
         self.flatten_kwargs_spec: TreeSpec = flatten_kwargs_spec
 
-        choices_for_args = []
-        for arg in self.flatten_args:
-            if isinstance(arg, torch.Tensor):
-                choices_for_args.append(self.gen_sharding_choices_for_arg(arg))
+        choices_for_args = [self.gen_sharding_choices_for_arg(arg) for arg in self.flatten_args if isinstance(arg, torch.Tensor)]
 
-        for arg in self.flatten_kwargs:
-            if isinstance(arg, torch.Tensor):
-                choices_for_args.append(self.gen_sharding_choices_for_arg(arg))
+        choices_for_args.extend(self.gen_sharding_choices_for_arg(arg) for arg in self.flatten_kwargs if isinstance(arg, torch.Tensor))
 
         self.sharding_combs: Iterator[Sequence[Placement]] = iter(
             itertools.product(*choices_for_args)

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -2437,9 +2437,7 @@ class DistributedTest:
             rank_to_GPU = init_multigpu_helper(dist.get_world_size(), BACKEND)
             device_id = rank_to_GPU[rank][0]
 
-            input_split_sizes = []
-            for src in group:
-                input_split_sizes.append(src + 1)
+            input_split_sizes = [src + 1 for src in group]
             start_len = sum(input_split_sizes[:rank])
             end_len = start_len + input_split_sizes[rank]
             sum_len = sum(input_split_sizes)
@@ -3464,9 +3462,7 @@ class DistributedTest:
             rank_to_GPU = init_multigpu_helper(dist.get_world_size(), BACKEND)
             device_id = rank_to_GPU[rank][0]
 
-            output_split_sizes = []
-            for dst in group:
-                output_split_sizes.append(dst + 1)
+            output_split_sizes = [dst + 1 for dst in group]
             sum_len = sum(output_split_sizes)
             value = 2
 

--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -123,13 +123,11 @@ class AllReduce:
     @torch.no_grad()
     def work(self, data):
         for i in range(len(data[0])):
-            tensors = []
             # use rank0 as the device for sum
             rank_0_device = data[0][i].device
             # collect all data to the list and make them
             # all on rank 0 device
-            for src_rank in range(0, len(data)):
-                tensors.append(data[src_rank][i].to(rank_0_device))
+            tensors = [data[src_rank][i].to(rank_0_device) for src_rank in range(0, len(data))]
 
             # now mimic reduce across all ranks
             res = _reduce_ops[self.op](tensors)

--- a/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
@@ -714,15 +714,11 @@ class CommonDistAutogradTest(RpcAgentTestFixture):
 
         # kick off forward and backward pass on three other workers (trainers)
         rank_diffs = [1, 2, 3]
-        futures = []
-        for rank_diff in rank_diffs:
-            futures.append(
-                rpc.rpc_async(
+        futures = [rpc.rpc_async(
                     worker_name((self.rank + rank_diff) % self.world_size),
                     trainer_fn,
                     args=(rref_t1, t2, worker_name(self.rank), rank_diff, sparse),
-                )
-            )
+                ) for rank_diff in rank_diffs]
 
         # check if the trainers have done with their backward pass
         for rank_diff in rank_diffs:
@@ -2747,13 +2743,11 @@ class TensorPipeCudaDistAutogradTest(RpcAgentTestFixture):
             # this is master
             layers = [nn.Linear(2000, 2000) for _ in range(self.world_size - 1)]
             local_layers = [l.to(0) for l in layers]
-            remote_layers = []
-            for rank in range(1, self.world_size):
-                remote_layers.append(rpc.remote(
+            remote_layers = [rpc.remote(
                     worker_name(rank),
                     WrapperModule,
                     args=(layers[rank - 1], rank)
-                ))
+                ) for rank in range(1, self.world_size)]
 
             x = torch.randn(5000, 2000).to(0)
             # local iteration

--- a/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
@@ -714,11 +714,13 @@ class CommonDistAutogradTest(RpcAgentTestFixture):
 
         # kick off forward and backward pass on three other workers (trainers)
         rank_diffs = [1, 2, 3]
-        futures = [rpc.rpc_async(
-                    worker_name((self.rank + rank_diff) % self.world_size),
-                    trainer_fn,
-                    args=(rref_t1, t2, worker_name(self.rank), rank_diff, sparse),
-                ) for rank_diff in rank_diffs]
+        futures = [
+            rpc.rpc_async(
+                worker_name((self.rank + rank_diff) % self.world_size),
+                trainer_fn,
+                args=(rref_t1, t2, worker_name(self.rank), rank_diff, sparse),
+            ) for rank_diff in rank_diffs
+        ]
 
         # check if the trainers have done with their backward pass
         for rank_diff in rank_diffs:
@@ -2743,11 +2745,13 @@ class TensorPipeCudaDistAutogradTest(RpcAgentTestFixture):
             # this is master
             layers = [nn.Linear(2000, 2000) for _ in range(self.world_size - 1)]
             local_layers = [l.to(0) for l in layers]
-            remote_layers = [rpc.remote(
+            remote_layers = [
+                rpc.remote(
                     worker_name(rank),
                     WrapperModule,
                     args=(layers[rank - 1], rank)
-                ) for rank in range(1, self.world_size)]
+                ) for rank in range(1, self.world_size)
+            ]
 
             x = torch.randn(5000, 2000).to(0)
             # local iteration

--- a/torch/testing/_internal/distributed/rpc/examples/parameter_server_test.py
+++ b/torch/testing/_internal/distributed/rpc/examples/parameter_server_test.py
@@ -107,11 +107,7 @@ def run_ps(trainers):
     timed_log("Start training")
     start = perf_counter()
     ps_rref = rpc.RRef(BatchUpdateParameterServer(len(trainers)))
-    futs = []
-    for trainer in trainers:
-        futs.append(
-            rpc.rpc_async(trainer, run_trainer, args=(ps_rref,))
-        )
+    futs = [rpc.rpc_async(trainer, run_trainer, args=(ps_rref,)) for trainer in trainers]
 
     torch.futures.wait_all(futs)
     stop = perf_counter()

--- a/torch/testing/_internal/distributed/rpc/examples/reinforcement_learning_rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/examples/reinforcement_learning_rpc_test.py
@@ -166,16 +166,12 @@ class Agent:
         r"""
         Run one episode. The agent will tell each observer to run n_steps.
         """
-        futs = []
-        for ob_rref in self.ob_rrefs:
-            # make async RPC to kick off an episode on all observers
-            futs.append(
-                rpc_async(
+        # make async RPC to kick off an episode on all observers
+        futs = [rpc_async(
                     ob_rref.owner(),
                     _call_method,
                     args=(Observer.run_episode, ob_rref, self.agent_rref, n_steps)
-                )
-            )
+                ) for ob_rref in self.ob_rrefs]
 
         # wait until all observers have finished this episode
         for fut in futs:

--- a/torch/testing/_internal/distributed/rpc/examples/reinforcement_learning_rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/examples/reinforcement_learning_rpc_test.py
@@ -167,11 +167,13 @@ class Agent:
         Run one episode. The agent will tell each observer to run n_steps.
         """
         # make async RPC to kick off an episode on all observers
-        futs = [rpc_async(
-                    ob_rref.owner(),
-                    _call_method,
-                    args=(Observer.run_episode, ob_rref, self.agent_rref, n_steps)
-                ) for ob_rref in self.ob_rrefs]
+        futs = [
+            rpc_async(
+                ob_rref.owner(),
+                _call_method,
+                args=(Observer.run_episode, ob_rref, self.agent_rref, n_steps)
+            ) for ob_rref in self.ob_rrefs
+        ]
 
         # wait until all observers have finished this episode
         for fut in futs:

--- a/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
@@ -1356,9 +1356,13 @@ class JitRpcTest(
         dst2 = worker_name((self.rank + 2) % self.world_size)
 
         num = 20
-        rrefs = [rpc.remote(
-                    dst1, async_add, args=(dst2, torch.ones(2, 2), torch.ones(2, 2) * i)
-                ) for i in range(num)]
+        rrefs = [
+            rpc.remote(
+                dst1,
+                async_add,
+                args=(dst2, torch.ones(2, 2), torch.ones(2, 2) * i)
+            ) for i in range(num)
+        ]
 
         for i in range(num):
             self.assertEqual(rrefs[i].to_here(), torch.ones(2, 2) + i)

--- a/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
@@ -1356,13 +1356,9 @@ class JitRpcTest(
         dst2 = worker_name((self.rank + 2) % self.world_size)
 
         num = 20
-        rrefs = []
-        for i in range(num):
-            rrefs.append(
-                rpc.remote(
+        rrefs = [rpc.remote(
                     dst1, async_add, args=(dst2, torch.ones(2, 2), torch.ones(2, 2) * i)
-                )
-            )
+                ) for i in range(num)]
 
         for i in range(num):
             self.assertEqual(rrefs[i].to_here(), torch.ones(2, 2) + i)

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -1038,11 +1038,13 @@ class RpcTestCommon:
         n = self.rank + 1
         dst_rank1 = n % self.world_size
         dst_rank2 = (n + 1) % self.world_size
-        all_rrefs = [rpc.remote(
-                    worker_name(dst_rank1),
-                    f,
-                    args=(worker_name(dst_rank2),),
-                ) for _ in range(20)]
+        all_rrefs = [
+            rpc.remote(
+                worker_name(dst_rank1),
+                f,
+                args=(worker_name(dst_rank2),),
+            ) for _ in range(20)
+        ]
 
         for i in range(20):
             rref_of_rrefs = all_rrefs[i]
@@ -1069,14 +1071,15 @@ class RpcTestCommon:
 
     def _my_parameter_server(self, sparse):
         ps_rref = RRef(MyParameterServer(self.world_size - 1))
-        futures = [rpc.rpc_async(
-                    worker_name((self.rank + index) % self.world_size),
-                    self._trainer_func,
-                    args=(
-                        ps_rref,
-                        sparse
-                    ),
-                ) for index in range(1, self.world_size)]
+        futures = [
+            rpc.rpc_async(
+                worker_name((self.rank + index) % self.world_size),
+                self._trainer_func,
+                args=(
+                    ps_rref,
+                    sparse
+                ),
+            ) for index in range(1, self.world_size)]
         torch.futures.wait_all(futures)
 
     def _test_cuda_future_extraction(self, wrapper, unwrapper, sparse_tensor):
@@ -6198,11 +6201,13 @@ class TensorPipeAgentCudaRpcTest(RpcAgentTestFixture, RpcTestCommon):
             rpc_backend_options=options,
         )
 
-        futs = [rpc.rpc_async(
+        futs = [
+            rpc.rpc_async(
                 dst,
                 TensorPipeAgentCudaRpcTest._return_tensor_view,
                 args=(i,)
-            ) for i in range(5)]
+            ) for i in range(5)
+        ]
 
         for i in range(5):
             self.assertEqual(torch.ones(100, 200) * i, futs[i].wait())

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -1038,15 +1038,11 @@ class RpcTestCommon:
         n = self.rank + 1
         dst_rank1 = n % self.world_size
         dst_rank2 = (n + 1) % self.world_size
-        all_rrefs = []
-        for _ in range(20):
-            all_rrefs.append(
-                rpc.remote(
+        all_rrefs = [rpc.remote(
                     worker_name(dst_rank1),
                     f,
                     args=(worker_name(dst_rank2),),
-                )
-            )
+                ) for _ in range(20)]
 
         for i in range(20):
             rref_of_rrefs = all_rrefs[i]
@@ -1073,18 +1069,14 @@ class RpcTestCommon:
 
     def _my_parameter_server(self, sparse):
         ps_rref = RRef(MyParameterServer(self.world_size - 1))
-        futures = []
-        for index in range(1, self.world_size):
-            futures.append(
-                rpc.rpc_async(
+        futures = [rpc.rpc_async(
                     worker_name((self.rank + index) % self.world_size),
                     self._trainer_func,
                     args=(
                         ps_rref,
                         sparse
                     ),
-                )
-            )
+                ) for index in range(1, self.world_size)]
         torch.futures.wait_all(futures)
 
     def _test_cuda_future_extraction(self, wrapper, unwrapper, sparse_tensor):
@@ -1457,9 +1449,7 @@ class RpcTest(RpcAgentTestFixture, RpcTestCommon):
         model = torch.nn.parallel.DistributedDataParallel(model)
 
         with self.assertRaisesRegex(RuntimeError, 'Current RPC agent is not set! Did you initialize the RPC framework'):
-            params = []
-            for param in model.parameters():
-                params.append(RRef(param))
+            params = [RRef(param) for param in model.parameters()]
 
     def test_world_size_one(self):
         self._world_size_one(
@@ -3889,9 +3879,7 @@ class RpcTest(RpcAgentTestFixture, RpcTestCommon):
             args=(torch.ones(n, n), torch.ones(n, n))
         )
 
-        cb_futs = []
-        for idx in range(num_cbs):
-            cb_futs.append(fut.then(partial(callback, idx)))
+        cb_futs = [fut.then(partial(callback, idx)) for idx in range(num_cbs)]
 
         self.assertEqual(fut.wait(), torch.ones(n, n) * 2)
 
@@ -4368,20 +4356,16 @@ class RpcTest(RpcAgentTestFixture, RpcTestCommon):
 
     @dist_init
     def test_wait_all_with_exception(self):
-        futs = []
         dst = worker_name((self.rank + 1) % self.world_size)
-        for _ in range(10):
-            futs.append(rpc.rpc_async(dst, raise_func))
+        futs = [rpc.rpc_async(dst, raise_func) for _ in range(10)]
 
         with self.assertRaisesRegex(ValueError, "Expected error"):
             torch.futures.wait_all(futs)
 
     @dist_init
     def test_wait_all_with_partial_exception(self):
-        futs = []
         dst = worker_name((self.rank + 1) % self.world_size)
-        for _ in range(10):
-            futs.append(rpc.rpc_async(dst, torch.add, args=(torch.ones(2), 1)))
+        futs = [rpc.rpc_async(dst, torch.add, args=(torch.ones(2), 1)) for _ in range(10)]
 
         futs.append(rpc.rpc_async(dst, raise_func))
 
@@ -6214,13 +6198,11 @@ class TensorPipeAgentCudaRpcTest(RpcAgentTestFixture, RpcTestCommon):
             rpc_backend_options=options,
         )
 
-        futs = []
-        for i in range(5):
-            futs.append(rpc.rpc_async(
+        futs = [rpc.rpc_async(
                 dst,
                 TensorPipeAgentCudaRpcTest._return_tensor_view,
                 args=(i,)
-            ))
+            ) for i in range(5)]
 
         for i in range(5):
             self.assertEqual(torch.ones(100, 200) * i, futs[i].wait())

--- a/torch/testing/_internal/hypothesis_utils.py
+++ b/torch/testing/_internal/hypothesis_utils.py
@@ -316,13 +316,9 @@ def tensor_conv(
     if isinstance(spatial_dim, Iterable):
         spatial_dim = draw(st.sampled_from(spatial_dim))
 
-    feature_map_shape = []
-    for _ in range(spatial_dim):
-        feature_map_shape.append(draw(st.integers(*feature_map_range)))
+    feature_map_shape = [draw(st.integers(*feature_map_range)) for _ in range(spatial_dim)]
 
-    kernels = []
-    for _ in range(spatial_dim):
-        kernels.append(draw(st.integers(*kernel_range)))
+    kernels = [draw(st.integers(*kernel_range)) for _ in range(spatial_dim)]
 
     tr = False
     weight_shape = (output_channels, input_channels_per_group) + tuple(kernels)

--- a/torch/testing/_internal/opinfo/definitions/nested.py
+++ b/torch/testing/_internal/opinfo/definitions/nested.py
@@ -252,13 +252,9 @@ def unbind_reference(op, sample, wrap_output_as_njt=True):
             # ensure we get the same number of returns for each invocation
             assert all(len(o) == num_returns for o in out_ref_components)
             # construct NJTs from same index returns from each invocation
-            njt_returns = []
-            for r in range(num_returns):
-                njt_returns.append(
-                    torch.nested.as_nested_tensor(
+            njt_returns = [torch.nested.as_nested_tensor(
                         [o[r] for o in out_ref_components], layout=torch.jagged
-                    )
-                )
+                    ) for r in range(num_returns)]
             return type(out_ref_components[0])(njt_returns)
         return torch.nested.as_nested_tensor(out_ref_components, layout=torch.jagged)
 
@@ -312,11 +308,7 @@ def reduction_reference(op, sample):
             # ensure we get the same number of returns for each invocation
             assert all(len(o) == num_returns for o in out_ref_components)
             # stack same index returns from each invocation
-            stacked_returns = []
-            for r in range(num_returns):
-                stacked_returns.append(
-                    torch.stack([o[r] for o in out_ref_components], dim=0)
-                )
+            stacked_returns = [torch.stack([o[r] for o in out_ref_components], dim=0) for r in range(num_returns)]
             return type(out_ref_components[0])(stacked_returns)
         return torch.stack(out_ref_components, dim=0)
 

--- a/torch/testing/_internal/opinfo/definitions/nested.py
+++ b/torch/testing/_internal/opinfo/definitions/nested.py
@@ -252,9 +252,12 @@ def unbind_reference(op, sample, wrap_output_as_njt=True):
             # ensure we get the same number of returns for each invocation
             assert all(len(o) == num_returns for o in out_ref_components)
             # construct NJTs from same index returns from each invocation
-            njt_returns = [torch.nested.as_nested_tensor(
-                        [o[r] for o in out_ref_components], layout=torch.jagged
-                    ) for r in range(num_returns)]
+            njt_returns = [
+                torch.nested.as_nested_tensor(
+                    [o[r] for o in out_ref_components], layout=torch.jagged
+                )
+                for r in range(num_returns)
+            ]
             return type(out_ref_components[0])(njt_returns)
         return torch.nested.as_nested_tensor(out_ref_components, layout=torch.jagged)
 
@@ -308,7 +311,10 @@ def reduction_reference(op, sample):
             # ensure we get the same number of returns for each invocation
             assert all(len(o) == num_returns for o in out_ref_components)
             # stack same index returns from each invocation
-            stacked_returns = [torch.stack([o[r] for o in out_ref_components], dim=0) for r in range(num_returns)]
+            stacked_returns = [
+                torch.stack([o[r] for o in out_ref_components], dim=0)
+                for r in range(num_returns)
+            ]
             return type(out_ref_components[0])(stacked_returns)
         return torch.stack(out_ref_components, dim=0)
 

--- a/torch/utils/_device.py
+++ b/torch/utils/_device.py
@@ -70,9 +70,7 @@ class DeviceContext(TorchFunctionMode):
         # If we set default device within a function mode context
         # exiting that context mode will pop the device function mode off
         # of the stack incorrectly
-        cur_stack = []
-        for _ in range(_len_torch_function_stack()):
-            cur_stack.append(_pop_mode())
+        cur_stack = [_pop_mode() for _ in range(_len_torch_function_stack())]
 
         _push_mode(self)
 

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -1412,7 +1412,9 @@ def _json_to_treespec(json_schema: DumpableContext) -> TreeSpec:
     else:
         context = serialize_node_def.from_dumpable_context(json_schema["context"])
 
-    children_specs = [_json_to_treespec(child_string) for child_string in json_schema["children_spec"]]
+    children_specs = [
+        _json_to_treespec(child_string) for child_string in json_schema["children_spec"]
+    ]
 
     return TreeSpec(typ, context, children_specs)
 

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -1412,9 +1412,7 @@ def _json_to_treespec(json_schema: DumpableContext) -> TreeSpec:
     else:
         context = serialize_node_def.from_dumpable_context(json_schema["context"])
 
-    children_specs = []
-    for child_string in json_schema["children_spec"]:
-        children_specs.append(_json_to_treespec(child_string))
+    children_specs = [_json_to_treespec(child_string) for child_string in json_schema["children_spec"]]
 
     return TreeSpec(typ, context, children_specs)
 

--- a/torch/utils/benchmark/utils/compare.py
+++ b/torch/utils/benchmark/utils/compare.py
@@ -244,8 +244,7 @@ class Table:
 
     def render(self) -> str:
         string_rows = [[""] + self.column_keys]
-        for r in self.rows:
-            string_rows.append(r.as_column_strings())
+        string_rows.extend(r.as_column_strings() for r in self.rows)
         num_cols = max(len(i) for i in string_rows)
         for sr in string_rows:
             sr.extend(["" for _ in range(num_cols - len(sr))])
@@ -327,9 +326,7 @@ class Compare:
     def _render(self):
         results = common.Measurement.merge(self._results)
         grouped_results = self._group_by_label(results)
-        output = []
-        for group in grouped_results.values():
-            output.append(self._layout(group))
+        output = [self._layout(group) for group in grouped_results.values()]
         return output
 
     def _group_by_label(self, results: List[common.Measurement]):

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -94,9 +94,7 @@ class WorkerInfo:
         return super().__setattr__(key, val)
 
     def __repr__(self):
-        items = []
-        for k in self.__keys:
-            items.append(f"{k}={getattr(self, k)}")
+        items = [f"{k}={getattr(self, k)}" for k in self.__keys]
         return f"{self.__class__.__name__}({', '.join(items)})"
 
 

--- a/torch/utils/data/datapipes/dataframe/datapipes.py
+++ b/torch/utils/data/datapipes/dataframe/datapipes.py
@@ -67,8 +67,7 @@ class ShuffleDataFramesPipe(DFIterDataPipe):
         for df in self.source_datapipe:
             if size is None:
                 size = df_wrapper.get_len(df)
-            for i in range(df_wrapper.get_len(df)):
-                all_buffer.append(df_wrapper.get_item(df, i))
+            all_buffer.extend(df_wrapper.get_item(df, i) for i in range(df_wrapper.get_len(df)))
         random.shuffle(all_buffer)
         buffer = []
         for df in all_buffer:

--- a/torch/utils/data/datapipes/dataframe/datapipes.py
+++ b/torch/utils/data/datapipes/dataframe/datapipes.py
@@ -67,7 +67,9 @@ class ShuffleDataFramesPipe(DFIterDataPipe):
         for df in self.source_datapipe:
             if size is None:
                 size = df_wrapper.get_len(df)
-            all_buffer.extend(df_wrapper.get_item(df, i) for i in range(df_wrapper.get_len(df)))
+            all_buffer.extend(
+                df_wrapper.get_item(df, i) for i in range(df_wrapper.get_len(df))
+            )
         random.shuffle(all_buffer)
         buffer = []
         for df in all_buffer:

--- a/torch/utils/data/datapipes/dataframe/datapipes.py
+++ b/torch/utils/data/datapipes/dataframe/datapipes.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import random
+from typing import Any, List
 
 from torch.utils.data.datapipes._decorator import functional_datapipe
 from torch.utils.data.datapipes.dataframe import dataframe_wrapper as df_wrapper
@@ -63,7 +64,7 @@ class ShuffleDataFramesPipe(DFIterDataPipe):
 
     def __iter__(self):
         size = None
-        all_buffer = []
+        all_buffer: List[Any] = []
         for df in self.source_datapipe:
             if size is None:
                 size = df_wrapper.get_len(df)

--- a/torch/utils/data/datapipes/iter/sharding.py
+++ b/torch/utils/data/datapipes/iter/sharding.py
@@ -69,10 +69,7 @@ class ShardingFilterIterDataPipe(_ShardingIterDataPipe):
         self._update_num_of_instances()
 
     def _update_num_of_instances(self):
-        sorted_sharding_groups = []
-        for key in sorted(self.groups.keys()):
-            if self.sharding_group_filter is None or key == self.sharding_group_filter:
-                sorted_sharding_groups.append(self.groups[key])
+        sorted_sharding_groups = [self.groups[key] for key in sorted(self.groups.keys()) if self.sharding_group_filter is None or key == self.sharding_group_filter]
 
         sorted_sharding_groups.reverse()
 

--- a/torch/utils/data/datapipes/iter/sharding.py
+++ b/torch/utils/data/datapipes/iter/sharding.py
@@ -69,7 +69,11 @@ class ShardingFilterIterDataPipe(_ShardingIterDataPipe):
         self._update_num_of_instances()
 
     def _update_num_of_instances(self):
-        sorted_sharding_groups = [self.groups[key] for key in sorted(self.groups.keys()) if self.sharding_group_filter is None or key == self.sharding_group_filter]
+        sorted_sharding_groups = [
+            self.groups[key]
+            for key in sorted(self.groups.keys())
+            if self.sharding_group_filter is None or key == self.sharding_group_filter
+        ]
 
         sorted_sharding_groups.reverse()
 

--- a/torch/utils/data/datapipes/map/grouping.py
+++ b/torch/utils/data/datapipes/map/grouping.py
@@ -55,8 +55,7 @@ class BatcherMapDataPipe(MapDataPipe[DataChunk]):
         batch: List = []
         indices = range(index * self.batch_size, (index + 1) * self.batch_size)
         try:
-            for i in indices:
-                batch.append(self.datapipe[i])
+            batch.extend(self.datapipe[i] for i in indices)
             return self.wrapper_class(batch)
         except IndexError as e:
             if not self.drop_last and len(batch) > 0:

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -1149,14 +1149,10 @@ def hipify(
             header_include_dir_path = Path(header_include_dir)
         else:
             header_include_dir_path = Path(os.path.join(output_directory, header_include_dir))
-        for path in header_include_dir_path.rglob('*'):
-            if (
-                path.is_file()
+        all_files.extend(str(path) for path in header_include_dir_path.rglob('*') if path.is_file()
                 and _fnmatch(str(path), includes)
                 and (not _fnmatch(str(path), ignores))
-                and match_extensions(path.name, header_extensions)
-            ):
-                all_files.append(str(path))
+                and match_extensions(path.name, header_extensions))
 
     if clean_ctx is None:
         clean_ctx = GeneratedFileCleaner(keep_intermediates=True)

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -1149,10 +1149,12 @@ def hipify(
             header_include_dir_path = Path(header_include_dir)
         else:
             header_include_dir_path = Path(os.path.join(output_directory, header_include_dir))
-        all_files.extend(str(path) for path in header_include_dir_path.rglob('*') if path.is_file()
-                and _fnmatch(str(path), includes)
-                and (not _fnmatch(str(path), ignores))
-                and match_extensions(path.name, header_extensions))
+        all_files.extend(
+            str(path) for path in header_include_dir_path.rglob('*') if path.is_file()
+            and _fnmatch(str(path), includes)
+            and (not _fnmatch(str(path), ignores))
+            and match_extensions(path.name, header_extensions)
+        )
 
     if clean_ctx is None:
         clean_ctx = GeneratedFileCleaner(keep_intermediates=True)

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -120,9 +120,7 @@ class BackwardHook:
         return tuple(res)
 
     def _unpack_none(self, indices, values):
-        res = []
-        for idx in indices:
-            res.append(values[idx])
+        res = [values[idx] for idx in indices]
 
         return tuple(res)
 

--- a/torch/utils/mobile_optimizer.py
+++ b/torch/utils/mobile_optimizer.py
@@ -49,10 +49,7 @@ def optimize_for_mobile(
     if all(hasattr(script_module, method) for method in bundled_inputs_attributes):
         preserved_methods_str = list(set(preserved_methods_str + bundled_inputs_attributes))
 
-    non_exist_methods = []
-    for method in preserved_methods_str:
-        if not hasattr(script_module, method):
-            non_exist_methods.append(method)
+    non_exist_methods = [method for method in preserved_methods_str if not hasattr(script_module, method)]
     if non_exist_methods:
         raise AttributeError(
             f"The following methods to preserve do not exist in script_module: {', '.join(non_exist_methods)}")

--- a/torch/utils/tensorboard/_onnx_graph.py
+++ b/torch/utils/tensorboard/_onnx_graph.py
@@ -41,9 +41,7 @@ def parse(graph):
         )
 
     for node in graph.node:
-        _attr = []
-        for s in node.attribute:
-            _attr.append(" = ".join([str(f[1]) for f in s.ListFields()]))
+        _attr = [" = ".join([str(f[1]) for f in s.ListFields()]) for s in node.attribute]
         attr = ", ".join(_attr).encode(encoding="utf_8")
         print(node.output[0])
         nodes.append(

--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -55,11 +55,7 @@ class NodeBase:
     def __repr__(self):
         repr = []
         repr.append(str(type(self)))
-        for m in dir(self):
-            if "__" not in m:
-                repr.append(
-                    m + ": " + str(getattr(self, m)) + str(type(getattr(self, m)))
-                )
+        repr.extend(m + ": " + str(getattr(self, m)) + str(type(getattr(self, m))) for m in dir(self) if "__" not in m)
         return "\n".join(repr) + "\n\n"
 
 
@@ -216,17 +212,13 @@ class GraphPy:
         """Convert graph representation of GraphPy object to TensorBoard required format."""
         # TODO: compute correct memory usage and CPU time once
         # PyTorch supports it
-        nodes = []
-        for v in self.nodes_io.values():
-            nodes.append(
-                node_proto(
+        nodes = [node_proto(
                     v.debugName,
                     input=v.inputs,
                     outputsize=v.tensor_size,
                     op=v.kind,
                     attributes=v.attributes,
-                )
-            )
+                ) for v in self.nodes_io.values()]
         return nodes
 
 

--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -55,7 +55,11 @@ class NodeBase:
     def __repr__(self):
         repr = []
         repr.append(str(type(self)))
-        repr.extend(m + ": " + str(getattr(self, m)) + str(type(getattr(self, m))) for m in dir(self) if "__" not in m)
+        repr.extend(
+            m + ": " + str(getattr(self, m)) + str(type(getattr(self, m)))
+            for m in dir(self)
+            if "__" not in m
+        )
         return "\n".join(repr) + "\n\n"
 
 
@@ -212,13 +216,16 @@ class GraphPy:
         """Convert graph representation of GraphPy object to TensorBoard required format."""
         # TODO: compute correct memory usage and CPU time once
         # PyTorch supports it
-        nodes = [node_proto(
-                    v.debugName,
-                    input=v.inputs,
-                    outputsize=v.tensor_size,
-                    op=v.kind,
-                    attributes=v.attributes,
-                ) for v in self.nodes_io.values()]
+        nodes = [
+            node_proto(
+                v.debugName,
+                input=v.inputs,
+                outputsize=v.tensor_size,
+                op=v.kind,
+                attributes=v.attributes,
+            )
+            for v in self.nodes_io.values()
+        ]
         return nodes
 
 

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -122,9 +122,7 @@ def _lazy_init():
         # just return without initializing in that case.
         _tls.is_initializing = True
 
-        for calls in _lazy_seed_tracker.get_calls():
-            if calls:
-                _queued_calls.append(calls)
+        _queued_calls.extend(calls for calls in _lazy_seed_tracker.get_calls() if calls)
 
         try:
             for queued_call, orig_traceback in _queued_calls:

--- a/torch/xpu/random.py
+++ b/torch/xpu/random.py
@@ -31,9 +31,7 @@ def get_rng_state(device: Union[int, str, torch.device] = "xpu") -> Tensor:
 
 def get_rng_state_all() -> List[Tensor]:
     r"""Return a list of ByteTensor representing the random number states of all devices."""
-    results = []
-    for i in range(device_count()):
-        results.append(get_rng_state(i))
+    results = [get_rng_state(i) for i in range(device_count())]
     return results
 
 

--- a/torchgen/dest/register_dispatch_key.py
+++ b/torchgen/dest/register_dispatch_key.py
@@ -879,13 +879,10 @@ return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), si
                     self.g.out.precomputed.add,
                 ]
                 for precomputed_elems in precomputed_values:
-                    for arg in precomputed_elems:
-                        context.append(
-                            Expr(
+                    context.extend(Expr(
                                 expr=f"precompute.{arg.name}",
                                 type=structured.argument_type(arg, binds=arg.name),
-                            )
-                        )
+                            ) for arg in precomputed_elems)
 
                 # Add a use of the precompute struct so FB internal compilers don't
                 # complain that there is an unused variable.

--- a/torchgen/dest/register_dispatch_key.py
+++ b/torchgen/dest/register_dispatch_key.py
@@ -879,10 +879,13 @@ return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), si
                     self.g.out.precomputed.add,
                 ]
                 for precomputed_elems in precomputed_values:
-                    context.extend(Expr(
-                                expr=f"precompute.{arg.name}",
-                                type=structured.argument_type(arg, binds=arg.name),
-                            ) for arg in precomputed_elems)
+                    context.extend(
+                        Expr(
+                            expr=f"precompute.{arg.name}",
+                            type=structured.argument_type(arg, binds=arg.name),
+                        )
+                        for arg in precomputed_elems
+                    )
 
                 # Add a use of the precompute struct so FB internal compilers don't
                 # complain that there is an unused variable.

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -2615,7 +2615,11 @@ codegen to generate the correct cpp call for this op. Contact AOTInductor team f
     view_map: dict[OperatorName, NativeFunction] = {
         f.func.name: f for f in concatMap(lambda g: list(g.functions()), view_groups)
     }
-    all_groups.extend(f for f in native_functions if f.func.name not in structured_map and f.func.name not in view_map)
+    all_groups.extend(
+        f
+        for f in native_functions
+        if f.func.name not in structured_map and f.func.name not in view_map
+    )
 
     cpu_fm.write_sharded(
         "RegisterFunctionalization.cpp",

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -2615,9 +2615,7 @@ codegen to generate the correct cpp call for this op. Contact AOTInductor team f
     view_map: dict[OperatorName, NativeFunction] = {
         f.func.name: f for f in concatMap(lambda g: list(g.functions()), view_groups)
     }
-    for f in native_functions:
-        if f.func.name not in structured_map and f.func.name not in view_map:
-            all_groups.append(f)
+    all_groups.extend(f for f in native_functions if f.func.name not in structured_map and f.func.name not in view_map)
 
     cpu_fm.write_sharded(
         "RegisterFunctionalization.cpp",

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -5,7 +5,7 @@ import itertools
 import re
 from dataclasses import dataclass
 from enum import auto, Enum
-from typing import Callable, Iterator, Sequence
+from typing import Callable, Iterator, List, Sequence
 
 from torchgen.utils import assert_never, NamespaceHelper, OrderedSet
 
@@ -245,7 +245,7 @@ class _TorchDispatchModeKey(Enum):
 
 
 def codegen_per_backend_entries() -> str:
-    r = []
+    r: List[str] = []
     for fk in FUNCTIONALITY_KEYS:
         r.extend(f"    {fk}{bc} = auto()" for bc in BACKEND_COMPONENTS)
     return "\n".join(r)

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -247,8 +247,7 @@ class _TorchDispatchModeKey(Enum):
 def codegen_per_backend_entries() -> str:
     r = []
     for fk in FUNCTIONALITY_KEYS:
-        for bc in BACKEND_COMPONENTS:
-            r.append(f"    {fk}{bc} = auto()")
+        r.extend(f"    {fk}{bc} = auto()" for bc in BACKEND_COMPONENTS)
     return "\n".join(r)
 
 

--- a/torchgen/operator_versions/gen_mobile_upgraders.py
+++ b/torchgen/operator_versions/gen_mobile_upgraders.py
@@ -189,15 +189,14 @@ PER_OPERATOR_UPGRADER_LIST = CodeTemplate(
 
 
 def construct_instruction(instruction_list_from_yaml: list[Any]) -> str:
-    instruction_list_part = []
-    for instruction in instruction_list_from_yaml:
-        instruction_list_part.append(
-            ONE_INSTRUCTION.substitute(
-                operator_name=instruction[0],
-                X=instruction[1],
-                N=instruction[2],
-            )
+    instruction_list_part = [
+        ONE_INSTRUCTION.substitute(
+            operator_name=instruction[0],
+            X=instruction[1],
+            N=instruction[2],
         )
+        for instruction in instruction_list_from_yaml
+    ]
     return INSTRUCTION_LIST.substitute(
         instruction_list="".join(instruction_list_part).lstrip("\n")
     )
@@ -230,24 +229,23 @@ def construct_constants(constants_list_from_yaml: list[Any]) -> str:
 
 
 def construct_operators(operator_list_from_yaml: list[Any]) -> str:
-    operator_list_part = []
-    for operator in operator_list_from_yaml:
-        operator_list_part.append(
-            ONE_OPERATOTR_STRING.substitute(
-                operator_name=operator[0],
-                overload_name=operator[1],
-                num_of_args=operator[2],
-            )
+    operator_list_part = [
+        ONE_OPERATOTR_STRING.substitute(
+            operator_name=operator[0],
+            overload_name=operator[1],
+            num_of_args=operator[2],
         )
+        for operator in operator_list_from_yaml
+    ]
     return OPERATOR_STRING_LIST.substitute(
         operator_string_list="".join(operator_list_part).lstrip("\n")
     )
 
 
 def construct_types(types_tr_list_from_yaml: list[Any]) -> str:
-    types_tr_list_part = []
-    for types_tr in types_tr_list_from_yaml:
-        types_tr_list_part.append(ONE_TYPE.substitute(type_str=types_tr))
+    types_tr_list_part = [
+        ONE_TYPE.substitute(type_str=types_tr) for types_tr in types_tr_list_from_yaml
+    ]
     if len(types_tr_list_part) == 0:
         return TYPE_LIST_EMPTY
     return TYPE_LIST.substitute(type_list="".join(types_tr_list_part).lstrip("\n"))


### PR DESCRIPTION
* Automatically applies ruff rule 401. Turns loops into equivalent list comprehensions which are faster and do not leak the scope of the loop variables.
* list comprehensions not only often have better typing, but are 50+% faster than for loops on overhead. They also preserve length information etc and are better for the interpreter to optimize.
* Manually went back and made mypy happy after the change. 
* Also fixed style lints in files covered by flake8 but not by pyfmt

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @ezyang @SherlockNoMad @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn @xmfan