### PR TITLE
[pipelining] allow multiple backward grads

### DIFF
--- a/test/distributed/pipelining/schedule_registry.py
+++ b/test/distributed/pipelining/schedule_registry.py
@@ -172,3 +172,50 @@ class ScheduleWithW(PipelineScheduleMulti):
                 _Action(1, W, 1),
             ],
         }
+
+
+class ScheduleWithReorderedB(PipelineScheduleMulti):
+    n_stages = 4
+    num_microbatches = 2
+    rank_stages = {
+        0: [0, 2],
+        1: [1, 3],
+    }
+
+    def __init__(
+        self,
+        stages: List[_PipelineStageBase],
+        n_microbatches: int,
+        loss_fn: Optional[Callable] = None,
+    ):
+        super().__init__(
+            stages=stages,
+            n_microbatches=n_microbatches,
+            loss_fn=loss_fn,
+        )
+        # Go through two microbatches
+        self.pipeline_order = {
+            0: [
+                _Action(0, F, 0),
+                _Action(0, F, 1),
+                _Action(2, F, 0),
+                _Action(2, F, 1),
+                None,
+                None,
+                _Action(2, B, 0),
+                _Action(2, B, 1),
+                _Action(0, B, 0),
+                _Action(0, B, 1),
+            ],
+            1: [
+                None,
+                _Action(1, F, 0),
+                _Action(1, F, 1),
+                _Action(3, F, 0),
+                _Action(3, F, 1),
+                _Action(3, B, 0),
+                _Action(3, B, 1),
+                _Action(1, B, 0),
+                _Action(1, B, 1),
+            ],
+        }

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -7,7 +7,12 @@ import sys
 import tempfile
 
 from model_registry import ModelWithKwargs, MultiMLP, MultiMLPWithDw
-from schedule_registry import ScheduleUnbalanced, ScheduleVShaped, ScheduleWithW
+from schedule_registry import (
+    ScheduleUnbalanced,
+    ScheduleVShaped,
+    ScheduleWithReorderedB,
+    ScheduleWithW,
+)
 
 import torch
 import torch.distributed as dist
@@ -362,7 +367,12 @@ class ScheduleTest(MultiProcContinousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     @parametrize(
         "ScheduleClass",
-        [ScheduleInterleaved1F1B, ScheduleLoopedBFS, ScheduleInterleavedZeroBubble],
+        [
+            ScheduleInterleaved1F1B,
+            ScheduleLoopedBFS,
+            ScheduleInterleavedZeroBubble,
+            ScheduleWithReorderedB,
+        ],
     )
     @parametrize("use_new_runtime", [False, True])
     def test_grad_with_manual_interleaved(self, ScheduleClass, use_new_runtime):

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -608,6 +608,109 @@ class ScheduleTest(MultiProcContinousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    @parametrize(
+        "ScheduleClass",
+        [
+            ScheduleWithReorderedB,
+        ],
+    )
+    def test_pipeline_schedule_runtime_custom_sched(self, ScheduleClass):
+        n_stages = 2
+        num_microbatches = 2
+        stages_per_rank = 1
+        full_mod = MultiMLP(d_hid, n_layers=n_stages)
+        full_mod.to(self.device)
+
+        ref_mod = copy.deepcopy(full_mod)
+        x = torch.randn(batch_size, d_hid, device=self.device)
+        with torch.no_grad():
+            y = ref_mod(x)
+            # Add a small perturbation
+            target = y + torch.randn(batch_size, d_hid, device=self.device)
+
+        loss_fn = torch.nn.MSELoss(reduction="sum")
+
+        # Run reference
+        for _ in range(2):
+            ref_mod.zero_grad()
+            ref_out = ref_mod(x)
+            ref_loss = loss_fn(ref_out, target)
+            ref_loss.backward()
+
+        # Get a submodule, e.g. `layers.0` or `layers.1`
+        stage_indices = [
+            self.rank + i * self.world_size for i in range(stages_per_rank)
+        ]
+        print(f"Rank {self.rank} stages: {stage_indices}")
+        submod_names = [f"layers.{i}" for i in stage_indices]
+        stage_modules = [
+            full_mod.get_submodule(submod_name) for submod_name in submod_names
+        ]
+        # Create a pipeline stage to wrap that submodule
+        num_microbatches = (
+            ScheduleClass.num_microbatches
+            if hasattr(ScheduleClass, "num_microbatches")
+            else 8
+        )
+        stages = [
+            PipelineStage(
+                stage_module,
+                stage_idx,
+                n_stages,
+                self.device,
+            )
+            for stage_module, stage_idx in zip(stage_modules, stage_indices)
+        ]
+
+        # Attach to a schedule
+        schedule = ScheduleClass(stages, num_microbatches, loss_fn=loss_fn)
+        assert isinstance(schedule, _PipelineScheduleRuntime)
+
+        # Run
+        with check_leaked_tensors() as garbage_tensors:
+            for _ in range(2):
+                # Zero gradients
+                for stage_module in stage_modules:
+                    stage_module.zero_grad()
+                if self.rank == 0:
+                    schedule.step(x)
+                elif self.rank == self.world_size - 1:
+                    losses = []
+                    out = schedule.step(target=target, losses=losses)
+                else:
+                    schedule.step()
+        self.assertEqual(
+            len(garbage_tensors),
+            0,
+            "Found leaked tensors, check logs above for debug info",
+        )
+        dist.barrier()
+
+        # Last rank checks result
+        if self.rank == self.world_size - 1:
+            # Check output
+            torch.testing.assert_close(out, ref_out)
+            # Check loss
+            # Since the reduction used in the loss function above is "sum", we use
+            # "sum" here to reduce microbatch losses into a single value too.
+            pipe_loss = sum(losses)
+            torch.testing.assert_close(pipe_loss, ref_loss)
+
+        # Every rank checks gradients
+        for stage_module, submod_name in zip(stage_modules, submod_names):
+            # Get corresponding submodule from reference model
+            ref_submod = ref_mod.get_submodule(submod_name)
+            # Check gradients per parameter
+            for name, p in stage_module.named_parameters():
+                ref_p = ref_submod.get_parameter(name)
+                try:
+                    torch.testing.assert_close(p.grad, ref_p.grad, rtol=1e-5, atol=4e-5)
+                except AssertionError:
+                    print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
+                    raise
+
+    @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     @parametrize("ScheduleClass", [ScheduleVShaped, ScheduleUnbalanced])
     def test_non_symmetric_stage_ids(self, ScheduleClass):
         n_stages = ScheduleClass.n_stages

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -371,7 +371,6 @@ class ScheduleTest(MultiProcContinousTest):
             ScheduleInterleaved1F1B,
             ScheduleLoopedBFS,
             ScheduleInterleavedZeroBubble,
-            ScheduleWithReorderedB,
         ],
     )
     @parametrize("use_new_runtime", [False, True])

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -177,6 +177,8 @@ class _PipelineStageBase(ABC):
         self._outputs_meta: Optional[Tuple[torch.Tensor, ...]] = None
         # map microbatch ID to list of forward tensor args
         self.fwd_cache: Dict[int, Tuple[Any, List[torch.Tensor]]] = {}
+        # map microbatch ID to list of backward grad tensor args
+        self.bwd_cache: Dict[int, Tuple[Optional[torch.Tensor], ...]] = {}
         # Caching chunk outputs for final output merge or reduction
         self.output_chunks: List[Any] = []
 
@@ -381,10 +383,7 @@ class _PipelineStageBase(ABC):
         assert not self.is_first, "can't get bwd output if this stage is first"
 
         self._check_chunk_id(mb_index)
-        # TODO(whc) we should be indexing mb_index into self.grads_input, but it appears we are only storing
-        # the most recently created grads which needs to be fixed not only here but also for get_bwd_send_ops.
-
-        return self.grads_input
+        return self.bwd_cache.pop(mb_index)
 
     def set_local_bwd_input(
         self, next_stage_bwd_outputs: Tuple[Optional[torch.Tensor], ...], mb_index: int
@@ -481,7 +480,8 @@ class _PipelineStageBase(ABC):
             self.grad_send_info = self._create_grad_send_info(self.args_recv_info[0])
 
         ops: List[dist.P2POp] = []
-        for grad, grad_recv_stage in zip(self.grads_input, self.grad_send_info):
+        grads_input = self.bwd_cache.pop(bwd_chunk_id)
+        for grad, grad_recv_stage in zip(grads_input, self.grad_send_info):
             if isinstance(grad, torch.Tensor) and grad_recv_stage is not None:
                 logger.debug(
                     "%s Sending gradient to Stage %s: %s",
@@ -771,11 +771,13 @@ class _PipelineStageBase(ABC):
                 "input_values": input_values,
             }
 
+        grads_input: Tuple[Optional[torch.Tensor], ...] = ()
+
         # Custom backward function
         if self.dw_builder:
             # TODO: We may want to change our semantics so we are allowed to ignore
             # the 'dw_builder' and call full_backward directly when it is a full_backward op.
-            self.grads_input, _ = self.backward_maybe_with_nosync(
+            grads_input, _ = self.backward_maybe_with_nosync(
                 "full", bwd_kwargs, last_backward=last_backward
             )
             if full_backward:
@@ -784,11 +786,10 @@ class _PipelineStageBase(ABC):
                 self.dw_runner[bwd_chunk_id] = self.dw_builder()
         else:
             if full_backward:
-                self.grads_input, _ = self.backward_maybe_with_nosync(
+                grads_input, _ = self.backward_maybe_with_nosync(
                     "full", bwd_kwargs, last_backward=last_backward
                 )
             else:
-                grads_input: Tuple[torch.Tensor | None, ...] = ()
                 param_groups: List[Dict[str, Any]] | None = None
                 # Skip the backward for the first stage since we will perform the weight update with
                 # autograd.backward in backward_weight_one_chunk
@@ -809,9 +810,10 @@ class _PipelineStageBase(ABC):
                     bwd_kwargs["stage_output"],
                     bwd_kwargs["output_grads"],
                 )
-                self.grads_input = grads_input
                 # Save a placeholder for the dw_runner
                 self.dw_runner[bwd_chunk_id] = lambda: None
+
+        self.bwd_cache[bwd_chunk_id] = grads_input
 
         if self.is_last and not self.is_first:
             # Autograd dependencies:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #140981

fixes https://github.com/pytorch/pytorch/issues/139404. The input grads get saved in a new `self.bwd_cache` container and get popped off after they are used in `backward_one_chunk`

`python test/distributed/pipelining/test_schedule_multiproc.py -k test_pipeline_schedule_runtime_custom_sched`

cc @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o