### PR TITLE
Fixes #140986, improves wording and grammar of nn/module.py

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -405,7 +405,7 @@ class Module:
 
     Your models should also subclass this class.
 
-    Modules can also contain other Modules, allowing to nest them in
+    Modules can also contain other Modules, allowing them to be nested in
     a tree structure. You can assign the submodules as regular attributes::
 
         import torch.nn as nn
@@ -421,8 +421,8 @@ class Module:
                 x = F.relu(self.conv1(x))
                 return F.relu(self.conv2(x))
 
-    Submodules assigned in this way will be registered, and will have their
-    parameters converted too when you call :meth:`to`, etc.
+    Submodules assigned in this way will be registered, and will also have their
+    parameters converted when you call :meth:`to`, etc.
 
     .. note::
         As per the example above, an ``__init__()`` call to the parent class
@@ -681,7 +681,7 @@ class Module:
                 )
             )
 
-        (The diagram shows an ``nn.Module`` ``A``. ``A`` has a nested
+        (The diagram shows an ``nn.Module`` ``A``. ``A`` which has a nested
         submodule ``net_b``, which itself has two submodules ``net_c``
         and ``linear``. ``net_c`` then has a submodule ``conv``.)
 
@@ -868,7 +868,7 @@ class Module:
         module's `state_dict()`.
 
         Note that extra state should be picklable to ensure working serialization
-        of the state_dict. We only provide provide backwards compatibility guarantees
+        of the state_dict. We only provide backwards compatibility guarantees
         for serializing Tensors; other objects may break backwards compatibility if
         their serialized pickled form changes.
 
@@ -2497,9 +2497,9 @@ class Module:
             strict (bool, optional): whether to strictly enforce that the keys
                 in :attr:`state_dict` match the keys returned by this module's
                 :meth:`~torch.nn.Module.state_dict` function. Default: ``True``
-            assign (bool, optional): When ``False``, the properties of the tensors
-                in the current module are preserved while when ``True``, the
-                properties of the Tensors in the state dict are preserved. The only
+            assign (bool, optional): When set to ``False``, the properties of the tensors
+                in the current module are preserved whereas setting it to ``True`` preserves
+                properties of the Tensors in the state dict. The only
                 exception is the ``requires_grad`` field of :class:`~torch.nn.Parameter`s
                 for which the value from the module is preserved.
                 Default: ``False``
@@ -2831,9 +2831,9 @@ class Module:
     def train(self: T, mode: bool = True) -> T:
         r"""Set the module in training mode.
 
-        This has any effect only on certain modules. See documentations of
+        This has an effect only on certain modules. See the documentation of
         particular modules for details of their behaviors in training/evaluation
-        mode, if they are affected, e.g. :class:`Dropout`, :class:`BatchNorm`,
+        mode, i.e., whether they are affected, e.g. :class:`Dropout`, :class:`BatchNorm`,
         etc.
 
         Args:
@@ -2853,9 +2853,9 @@ class Module:
     def eval(self: T) -> T:
         r"""Set the module in evaluation mode.
 
-        This has any effect only on certain modules. See documentations of
+        This has an effect only on certain modules. See the documentation of
         particular modules for details of their behaviors in training/evaluation
-        mode, if they are affected, e.g. :class:`Dropout`, :class:`BatchNorm`,
+        mode, i.e. whether they are affected, e.g. :class:`Dropout`, :class:`BatchNorm`,
         etc.
 
         This is equivalent with :meth:`self.train(False) <torch.nn.Module.train>`.
@@ -2927,7 +2927,7 @@ class Module:
         return self.__class__.__name__
 
     def extra_repr(self) -> str:
-        r"""Set the extra representation of the module.
+        r"""Return the extra representation of the module.
 
         To print customized extra information, you should re-implement
         this method in your own modules. Both single-line and multi-line

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1038,7 +1038,7 @@ class Module:
         r"""Move all model parameters and buffers to the GPU.
 
         This also makes associated parameters and buffers different objects. So
-        it should be called before constructing optimizer if the module will
+        it should be called before constructing the optimizer if the module will
         live on GPU while being optimized.
 
         .. note::
@@ -1057,7 +1057,7 @@ class Module:
         r"""Move all model parameters and buffers to the IPU.
 
         This also makes associated parameters and buffers different objects. So
-        it should be called before constructing optimizer if the module will
+        it should be called before constructing the optimizer if the module will
         live on IPU while being optimized.
 
         .. note::
@@ -1095,7 +1095,7 @@ class Module:
         r"""Move all model parameters and buffers to the MTIA.
 
         This also makes associated parameters and buffers different objects. So
-        it should be called before constructing optimizer if the module will
+        it should be called before constructing the optimizer if the module will
         live on MTIA while being optimized.
 
         .. note::


### PR DESCRIPTION
Fixes #140986 

This includes several improvements on the grammar and wording of nn/module.py, mostly simple one word fixes, but also other slightly more elaborate ones.  

It addresses about half of the docs for module.py but I would be glad to cover the rest of it if required to do so.