### PR TITLE
[EZ][BE] Update googletest submodule

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,6 +21,15 @@ http_archive(
     urls = ["https://github.com/tensorflow/runtime/archive/b1c7cce21ba4661c17ac72421c6a0e2015e7bef3.tar.gz"],
 )
 
+http_archive(
+    name = "platforms",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+    ],
+    sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
+)
+
 load("@rules_cuda//cuda:dependencies.bzl", "rules_cuda_dependencies")
 
 rules_cuda_dependencies(with_rules_cc = False)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,9 +25,10 @@ http_archive(
     name = "platforms",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
-        "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+        # TODO Fix bazel linter to support hashes for release tarballs.
+        # "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
     ],
-    sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
+    # sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
 )
 
 load("@rules_cuda//cuda:dependencies.bzl", "rules_cuda_dependencies")


### PR DESCRIPTION
From v1.11.0 (released in Jun 2021) to v1.15.2 (release in Jul 2024)
