### PR TITLE
Simplify all the axioms

### DIFF
--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5400,12 +5400,12 @@ class ShapeEnv:
 
         # Pattern matching
         if axioms is None:
-            subst = self.axioms
-        else:
-            subst = {}
-            for e in axioms:
-                if e.free_symbols.issubset(expr.free_symbols):
-                    subst.update(dict(self.get_implications(self.simplify(e))))
+            axioms = self.axioms
+
+        subst = {}
+        for e in axioms:
+            if e.free_symbols.issubset(expr.free_symbols):
+                subst.update(dict(self.get_implications(self.simplify(e))))
 
         expr = expr.xreplace(subst)
         # TODO: compute hint might have gotten broken here


### PR DESCRIPTION
Summary: https://github.com/pytorch/pytorch/pull/135499 addressed the case when axioms was passed in, but we need to do the same simplification on self.axioms if there are no axioms explicitly passed in.

Test Plan:
```
TORCH_LOGS="+dynamo" TORCHDYNAMO_VERBOSE=1 buck2 run mode/opt //minim
al_viable_ai/fire:light -- -d ~/fbsource/fbcode/hpc/ -d ~/fbsource/fbcode/hammer -d ~/fbsource/fbcode/minimal_viable_ai/ minimal_viable_ai/new_format/preproc_
ta/experimental/pt2_export_train_preproc_roo_for_umia.py --start-ts 2024-11-10+10:00:00 --end-ts 2024-11-10+11:00:00 --steps 1 --preproc-type TA_accel_cpu_eag
er --export-archive-path /home/bobren/umia_train_preproc

Reviewed By: ezyang

Differential Revision: D66145304




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv