### PR TITLE
Also check for attention mask shape for _sfdp_params_check

### DIFF
--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -577,6 +577,7 @@ def _sfdp_params_check(match):
                 or attn_mask.dtype == torch.float
             )
             or query.device != attn_mask.device
+            or query.shape != attn_mask.shape
         ):
             return False
     return True

--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -579,7 +579,7 @@ def _sfdp_params_check(match):
             or query.device != attn_mask.device
             # When we tensorify floats we end up turning floats
             # into 0d scalar tensors. It doesn't make any sense
-            # to ahve a 0d scalar tensor attention mask so
+            # to have a 0d scalar tensor attention mask so
             # coveniently we can insert this check to get
             # tests that erroneously passing in a float
             # attention mask to fail as expected.

--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -577,7 +577,13 @@ def _sfdp_params_check(match):
                 or attn_mask.dtype == torch.float
             )
             or query.device != attn_mask.device
-            or query.shape != attn_mask.shape
+            # When we tensorify floats we end up turning floats
+            # into 0d scalar tensors. It doesn't make any sense
+            # to ahve a 0d scalar tensor attention mask so
+            # coveniently we can insert this check to get
+            # tests that erroneously passing in a float
+            # attention mask to fail as expected.
+            or attn_mask.dim() == 0
         ):
             return False
     return True

--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -580,7 +580,7 @@ def _sfdp_params_check(match):
             # When we tensorify floats we end up turning floats
             # into 0d scalar tensors. It doesn't make any sense
             # to have a 0d scalar tensor attention mask so
-            # coveniently we can insert this check to get
+            # conveniently we can insert this check to get
             # tests that erroneously passing in a float
             # attention mask to fail as expected.
             or attn_mask.dim() == 0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141003
* #140983

Fixes `python test/inductor/test_fused_attention.py SDPAPatternRewriterCpuTests.test_pattern_fails_with_unsupported_mask_cpu` when `specialize_float=False`. You might wonder how it's related, it's because there is a "negative" test that expects us not to match. Previously it would fail on isinstance(param, Tensor), but now that we tensorify the float, it did match and caused a failure. This check ensures the mask has the same shape to ensure this negative test case actually fails.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov