### PR TITLE
[MPS] Fix conv backward pass for channels last

### DIFF
--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -537,9 +537,10 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
   TORCH_CHECK(isFloatingType(grad_output_t.scalar_type()), "Convolution is supported only for Floating types");
   CheckedFrom c = "mps_convolution_backward_weights";
   auto memory_format = grad_output_t.suggest_memory_format();
-  bool is_channels_last = (memory_format == at::MemoryFormat::ChannelsLast) && !is3DConv;
+  const bool supports_strided_api = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
+  const bool is_channels_last = (memory_format == MemoryFormat::ChannelsLast) && !is3DConv && !supports_strided_api;
 
-  MPSShape* gradOutputShape = mps::getMPSShape(grad_output_t, memory_format);
+  auto gradOutputShape = getMPSShape(grad_output_t, supports_strided_api ? MemoryFormat::Contiguous : memory_format);
 
   // For uniformity with everything else, although it seems grad_weight
   // would be unambiguous too.

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -536,11 +536,7 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
   bool is3DConv = input_t.dim() == 5;
   TORCH_CHECK(isFloatingType(grad_output_t.scalar_type()), "Convolution is supported only for Floating types");
   CheckedFrom c = "mps_convolution_backward_weights";
-  auto memory_format = grad_output_t.suggest_memory_format();
   const bool supports_strided_api = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
-  const bool is_channels_last = (memory_format == MemoryFormat::ChannelsLast) && !is3DConv && !supports_strided_api;
-
-  auto gradOutputShape = getMPSShape(grad_output_t, supports_strided_api ? MemoryFormat::Contiguous : memory_format);
 
   // For uniformity with everything else, although it seems grad_weight
   // would be unambiguous too.
@@ -567,45 +563,28 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
   @autoreleasepool {
     MPSStream* stream = getCurrentMPSStream();
 
-    string mem_format_key;
-    switch (memory_format) {
-      case at::MemoryFormat::Contiguous:
-        mem_format_key = "Contiguous";
-        break;
-      case at::MemoryFormat::ChannelsLast:
-        mem_format_key = "ChannelsLast";
-        break;
-      default:
-        assert(0 && "Check should have been done earlier\n");
-    }
     MPSShape* mps_weight_shape = getMPSShape(weight_size);
-    NSString* ns_shape_key = [[gradOutputShape valueForKey:@"description"] componentsJoinedByString:@","];
     string key;
     if (is3DConv) {
       key = "mps_3d_convolution_backward_weights:" + std::to_string(stride[0]) + ":" + std::to_string(stride[1]) + ":" +
           std::to_string(stride[2]) + ":" + std::to_string(dilation[0]) + ":" + std::to_string(dilation[1]) + ":" +
           std::to_string(dilation[2]) + ":" + std::to_string(padding[0]) + ":" + std::to_string(padding[1]) + ":" +
-          std::to_string(padding[2]) + ":" + std::to_string(groups) + ":" + mem_format_key +
-          getTensorsStringKey({grad_output_t, input_t, grad_weight_t}) + ":" + string([ns_shape_key UTF8String]);
+          std::to_string(padding[2]) + ":" + std::to_string(groups) + ":" +
+          getTensorsStringKey({grad_output_t, input_t, grad_weight_t});
     } else {
       key = "mps_convolution_backward_weights:" + std::to_string(stride[0]) + ":" + std::to_string(stride[1]) + ":" +
           std::to_string(dilation[0]) + ":" + std::to_string(dilation[1]) + ":" + std::to_string(padding[0]) + ":" +
-          std::to_string(padding[1]) + ":" + std::to_string(groups) + ":" + mem_format_key +
-          getTensorsStringKey({grad_output_t, input_t, grad_weight_t}) + ":" + string([ns_shape_key UTF8String]);
+          std::to_string(padding[1]) + ":" + std::to_string(groups) + ":" +
+          getTensorsStringKey({grad_output_t, input_t, grad_weight_t});
     }
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSShape* inputShape = mps::getMPSShape(input_t);
+      MPSShape* inputShape = getMPSShape(input_t);
       bool isDepthwiseConv = ((groups > 1 && (mps_weight_shape[1].intValue == 1)) && inputShape.count >= 4 &&
-                              mps_weight_shape.count >= 4 && !is_channels_last);
+                              mps_weight_shape.count >= 4);
 
-      MPSGraphTensor* gradOutputTensor =
-          mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(grad_output_t), gradOutputShape);
+      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output_t);
       MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
 
-      MPSGraphTensor* gradOutputTensorTranspose = gradOutputTensor;
-      if (is_channels_last) {
-        gradOutputTensorTranspose = mps::convertNHWCtoNCHW(mpsGraph, gradOutputTensorTranspose);
-      }
 
       MPSGraphTensor* gradWeightTensor;
       if (is3DConv) {
@@ -621,7 +600,7 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
                          padding[1],
                          padding[0],
                          groups);
-        gradWeightTensor = [mpsGraph convolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+        gradWeightTensor = [mpsGraph convolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensor
                                                                                sourceTensor:inputTensor
                                                                                 outputShape:mps_weight_shape
                                                                forwardConvolutionDescriptor:conv3dDescriptor_
@@ -641,7 +620,7 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
         NSNumber* outputFeatChannelDim = mps_weight_shape[0];
         MPSShape* weightShapeTranspose = @[ @1, outputFeatChannelDim, mps_weight_shape[2], mps_weight_shape[3] ];
         MPSGraphTensor* gradWeightTensorTranspose =
-            [mpsGraph depthwiseConvolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+            [mpsGraph depthwiseConvolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensor
                                                                          sourceTensor:inputTensor
                                                                           outputShape:weightShapeTranspose
                                                                            descriptor:depthWiseConv3dDescriptor_
@@ -659,7 +638,7 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
                        at::MemoryFormat::Contiguous,
                        groups);
 
-        gradWeightTensor = [mpsGraph convolution2DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+        gradWeightTensor = [mpsGraph convolution2DWeightsGradientWithIncomingGradientTensor:gradOutputTensor
                                                                                sourceTensor:inputTensor
                                                                                 outputShape:mps_weight_shape
                                                                forwardConvolutionDescriptor:conv2dDescriptor_
@@ -671,7 +650,7 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
       newCachedGraph->gradWeightTensor_ = gradWeightTensor;
     });
 
-    auto gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output_t, gradOutputShape);
+    auto gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output_t);
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
     auto outputPlaceholder = Placeholder(cachedGraph->gradWeightTensor_, grad_weight_t);
 

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -579,12 +579,11 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
     }
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       MPSShape* inputShape = getMPSShape(input_t);
-      bool isDepthwiseConv = ((groups > 1 && (mps_weight_shape[1].intValue == 1)) && inputShape.count >= 4 &&
-                              mps_weight_shape.count >= 4);
+      bool isDepthwiseConv =
+          ((groups > 1 && (mps_weight_shape[1].intValue == 1)) && inputShape.count >= 4 && mps_weight_shape.count >= 4);
 
       MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output_t);
       MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
-
 
       MPSGraphTensor* gradWeightTensor;
       if (is3DConv) {

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -536,7 +536,6 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
   bool is3DConv = input_t.dim() == 5;
   TORCH_CHECK(isFloatingType(grad_output_t.scalar_type()), "Convolution is supported only for Floating types");
   CheckedFrom c = "mps_convolution_backward_weights";
-  const bool supports_strided_api = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
 
   // For uniformity with everything else, although it seems grad_weight
   // would be unambiguous too.

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10556,6 +10556,22 @@ class TestConvolutionMPS(TestCaseMPS):
         helper(shape=(1024, 376, 9), in_channels=9, out_channels=1, groups=1)
         helper(shape=(1024, 376, 9), in_channels=9, out_channels=9, groups=3)
 
+        # Regression test for https://github.com/pytorch/pytorch/issues/140902
+        ic, oc, ks, f = 2, 5, 3, 7
+        conv = torch.nn.Conv1d(ic, oc, kernel_size=ks, padding=1).to("mps")
+        inp = torch.rand(1, ic, f, device="mps")
+        out = conv(inp)
+        grad_in = torch.rand(1, oc, f, device="mps")
+        grad_in_cl = torch.empty(1, f, oc, device="mps").transpose(1, 2)
+        grad_in_cl[:] = grad_in
+
+        # It does not matter whether grad_in contigous, or channels last, results should equal to each other
+        grad_rc = torch.autograd.grad((out,), (conv.weight, conv.bias), (grad_in,), retain_graph=True)
+        grad_rc_cl = torch.autograd.grad((out,), (conv.weight, conv.bias), (grad_in_cl,), retain_graph=True)
+
+        self.assertEqual(grad_rc[0], grad_rc_cl[0])
+        self.assertEqual(grad_rc[1], grad_rc_cl[1])
+
     def test_conv1d_contiguous(self):
         model_cpu = torch.nn.Conv1d(1, 128, 3)
         a_cpu = torch.ones(128, 1, 176)


### PR DESCRIPTION
Looks like a regression caused by use of strided API, but adding the test revealed (at least in CI), that on Ventura it worked but returned garbage results, so fixed by removing all the logic about channels last (as it's irrelevant for strided API case and placeholder already turns tensor into a correct one)

This also allows one to remove `mem_format_key` and `ns_shape_key` (it was redundant even back then, as `mem_format_key` + `getTensorsStringKey(grad_output_t)` already uniquely identified the operation)

Fixes https://github.com/pytorch/pytorch/issues/140902
