### PR TITLE
Use std::bit_cast as c10::bit_cast if available

### DIFF
--- a/c10/util/bit_cast.h
+++ b/c10/util/bit_cast.h
@@ -3,8 +3,18 @@
 #include <cstring>
 #include <type_traits>
 
+#if __has_include(<bit>) && (__cplusplus >= 202002L || (defined(__cpp_lib_bit_cast) && __cpp_lib_bit_cast >= 201806L))
+#include <bit>
+#define C10_HAVE_STD_BIT_CAST 1
+#else
+#define C10_HAVE_STD_BIT_CAST 0
+#endif // __has_include(<bit>) && (__cplusplus >= 202002L || (defined(__cpp_lib_bit_cast) && __cpp_lib_bit_cast >= 201806L))
+
 namespace c10 {
 
+#if C10_HAVE_STD_BIT_CAST
+using std::bit_cast;
+#else
 // Implementations of std::bit_cast() from C++ 20.
 //
 // This is a less sketchy version of reinterpret_cast.
@@ -27,5 +37,6 @@ bit_cast(const From& src) noexcept {
   std::memcpy(&dst, &src, sizeof(To));
   return dst;
 }
+#endif // C10_HAVE_STD_BIT_CAST
 
 } // namespace c10


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141035
* #140994
* #140720
* #140567
* #140566
* #140565
* #140564

Make what we're doing as obvious as possible to the compiler.

Differential Revision: [D66108811](https://our.internmc.facebook.com/intern/diff/D66108811/)