### PR TITLE
trace_rules

### DIFF
--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3282,6 +3282,7 @@ MOD_INLINELIST = [
     "torch._functorch.vmap",
     "torch._higher_order_ops.associative_scan",
     "torch._higher_order_ops.invoke_subgraph",
+    "torch._higher_order_ops.prim_hop_base",
     "torch._higher_order_ops.scan",
     "torch._higher_order_ops.strict_mode",
     "torch._higher_order_ops.while_loop",


### PR DESCRIPTION
Summary: D65791417 adds a class which breaks some tasks from gen_ai/evals

Test Plan:
Import error: 
  File "/data/users/ayaoibrahim1123/fbsource/buck-out/v2/gen/fbcode/3b3a98f731555671/gen_ai/evals/__thrift_main__/thrift_main#link-tree/gen_ai/evals/thrift_main.py", line 10, in <module>
    from gen_ai.evals.predictors.thrift import MultimodalThriftPredictor, ThriftPredictor
  File "/data/users/ayaoibrahim1123/fbsource/buck-out/v2/gen/fbcode/3b3a98f731555671/gen_ai/evals/__thrift_main__/thrift_main#link-tree/gen_ai/evals/predictors/thrift.py", line 27, in <module>
    from gen_ai.evals.utils import get_local_path, get_token_offsets, truncate
  File "/data/users/ayaoibrahim1123/fbsource/buck-out/v2/gen/fbcode/3b3a98f731555671/gen_ai/evals/__thrift_main__/thrift_main#link-tree/gen_ai/evals/utils/__init__.py", line 7, in <module>
    from gen_ai.evals.utils.common import (
  File "/data/users/ayaoibrahim1123/fbsource/buck-out/v2/gen/fbcode/3b3a98f731555671/gen_ai/evals/__thrift_main__/thrift_main#link-tree/gen_ai/evals/utils/common.py", line 42, in <module>
    import torch
  File "/data/users/ayaoibrahim1123/fbsource/buck-out/v2/gen/fbcode/3b3a98f731555671/gen_ai/evals/__thrift_main__/thrift_main#link-tree/torch/__init__.py", line 2548, in <module>
    from torch import (
  File "/data/users/ayaoibrahim1123/fbsource/buck-out/v2/gen/fbcode/3b3a98f731555671/gen_ai/evals/__thrift_main__/thrift_main#link-tree/torch/export/__init__.py", line 68, in <module>
    from .decomp_utils import CustomDecompTable
  File "/data/users/ayaoibrahim1123/fbsource/buck-out/v2/gen/fbcode/3b3a98f731555671/gen_ai/evals/__thrift_main__/thrift_main#link-tree/torch/export/decomp_utils.py", line 5, in <module>
    from torch._export.utils import (
  File "/data/users/ayaoibrahim1123/fbsource/buck-out/v2/gen/fbcode/3b3a98f731555671/gen_ai/evals/__thrift_main__/thrift_main#link-tree/torch/_export/__init__.py", line 47, in <module>
    from .wrappers import _wrap_submodules
  File "/data/users/ayaoibrahim1123/fbsource/buck-out/v2/gen/fbcode/3b3a98f731555671/gen_ai/evals/__thrift_main__/thrift_main#link-tree/torch/_export/wrappers.py", line 7, in <module>
    from torch._higher_order_ops.strict_mode import strict_mode
  File "/data/users/ayaoibrahim1123/fbsource/buck-out/v2/gen/fbcode/3b3a98f731555671/gen_ai/evals/__thrift_main__/thrift_main#link-tree/torch/_higher_order_ops/__init__.py", line 8, in <module>
    from torch._higher_order_ops.prim_hop_base import PrimHOPBase
  ModuleNotFoundError: No module named 'torch._higher_order_ops.prim_hop_base'

Reviewed By: jianyuh

Differential Revision: D66129750




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames