### PR TITLE
add serialized_type_name to torch.size register_pytree_node

### DIFF
--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -131,6 +131,7 @@ pytree.register_pytree_node(
         [(pytree.SequenceKey(i), x) for i, x in enumerate(xs)],
         None,
     ),
+    serialized_type_name="torch.Size",
 )
 
 


### PR DESCRIPTION
Summary: We are working on onboarding legokit modules to ModuleStability and this is needed to fix the serialization issue found in P1680200613

Test Plan:
`buck2 test //torchrec/fb/legokit/module_stability_tests/layer_norm_stability_test:layer_norm_stability_test -- --env ADD_NEW_STABILITY_CONFIGS=True`

serialization succeeds when the above command is run on top of this diff.

Differential Revision: D66034492




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv