### PR TITLE
[Inductor] Defer reduction split after fusion

### DIFF
--- a/test/inductor/test_defer_reduction_split.py
+++ b/test/inductor/test_defer_reduction_split.py
@@ -1,0 +1,159 @@
+# Owner(s): ["module: inductor"]
+
+import os
+import unittest
+
+import torch
+from torch._dynamo.utils import same
+from torch._inductor import config as inductor_config, metrics
+from torch._inductor.codegen.triton import TritonScheduling
+from torch._inductor.test_case import run_tests, TestCase
+from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.utils._pytree import tree_map
+
+
+DO_PERF_TEST = os.environ.get("DO_PERF_TEST") == "1"
+
+
+if HAS_GPU:
+    torch.set_default_device(GPU_TYPE)
+
+
+class MockScheduler:
+    available_buffer_names = ()
+
+    @staticmethod
+    def get_backend(cls, *args):
+        return TritonScheduling(cls)
+
+
+@inductor_config.patch(
+    {
+        "benchmark_kernel": True,
+        "loop_ordering_after_fusion": True,
+        "triton.unique_kernel_names": True,
+        "defer_reduction_split": True,
+    }
+)
+class DeferReductionSplitTest(TestCase):
+    device = GPU_TYPE
+
+    def do_acc_test(self, f, *args, cast_fp8=True):
+        expect = f(*args)
+        actual = torch.compile(f)(*args)
+
+        if cast_fp8:
+
+            def _cast(x):
+                if isinstance(x, torch.Tensor) and x.dtype in (
+                    torch.float8_e5m2,
+                    torch.float8_e4m3fn,
+                ):
+                    return x.to(torch.float32)
+                return x
+
+            # Wordaround the issue that call allclose on fp8 tensor triggers error
+            #   RuntimeError: "mul_cuda" not implemented for 'Float8_e4m3fn'
+            expect = tree_map(_cast, expect)
+            actual = tree_map(_cast, actual)
+        self.assertTrue(same(expect, actual, tol=1e-3))
+
+    def setUp(self):
+        super().setUp()
+        metrics.reset()
+
+    def test_patter_1(self):
+        def f(x):
+            y = x.abs().max(dim=-1)
+            z = x.abs().max()
+            return y[0], z
+
+        A, B = 1024, 1536
+        x = torch.randn(A, B, device=GPU_TYPE)
+
+        self.do_acc_test(f, x)
+        self.assertEqual(2, metrics.generated_kernel_count)
+        expected_num_bytes = A * B + 3 * A + 1
+        expected_num_bytes *= x.itemsize
+        self.assertEqual(expected_num_bytes, metrics.num_bytes_accessed)
+
+    def test_patter_2(self):
+        def f(x):
+            y = x.abs().max()
+            z = x / 10.0
+            z_t = z.t().contiguous().t()
+            return y, z, z_t
+
+        A, B = 1024, 1536
+        x = torch.randn(A, B, device=GPU_TYPE)
+
+        self.do_acc_test(f, x)
+
+        self.assertEqual(2, metrics.generated_kernel_count)
+
+        expected_num_bytes = A * B * 3 + A * 2 + 1
+        expected_num_bytes *= x.itemsize
+        self.assertEqual(expected_num_bytes, metrics.num_bytes_accessed)
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, "FP8 requires H100+ and MI300+")
+    def test_patter_fp8(self):
+        ref_dtype = torch.bfloat16
+        M, K = 4096, 2048
+
+        input_tensor = torch.randn(
+            M, K, device="cuda", dtype=ref_dtype, requires_grad=False
+        )
+        scale = torch.Tensor([10.0]).to("cuda")
+
+        E4M3_MAX_POS = torch.finfo(torch.float8_e4m3fn).max
+
+        def f(tensor_x_inp, scale_x):
+            tensor_x = tensor_x_inp * scale_x
+            tensor_x = tensor_x.clamp(min=-1 * E4M3_MAX_POS, max=E4M3_MAX_POS)
+            tensor_fp8 = tensor_x.to(torch.float8_e4m3fn)
+
+            tensor_x_t = (tensor_x_inp * scale_x).t()
+            tensor_x_t = tensor_x_t.clamp(min=-1 * E4M3_MAX_POS, max=E4M3_MAX_POS)
+            tensor_fp8_t = tensor_x_t.to(torch.float8_e4m3fn)
+
+            tensor_fp8_t = tensor_fp8_t.contiguous().t()
+
+            new_scale = tensor_x_inp.abs().max()
+
+            return (tensor_fp8, tensor_fp8_t, new_scale)
+
+        test_pattern = torch.compile(f)
+        tensor_fp8, tensor_fp8_t, new_scale = test_pattern(input_tensor, scale)
+
+        # fused_cast_transpose_amax, second_level_amax_reduction
+        self.assertEqual(2, metrics.generated_kernel_count)
+
+        expected_numbytes = scale.nbytes  # scalar
+        expected_numbytes += input_tensor.nbytes  # input
+        expected_numbytes += tensor_fp8.nbytes + tensor_fp8_t.nbytes  # output
+        expected_numbytes += new_scale.nbytes  # new scaler output
+        expected_numbytes += 2 * M * scale.itemsize  # second-level reduction in/output
+        self.assertEqual(expected_numbytes, metrics.num_bytes_accessed)
+
+        self.do_acc_test(f, input_tensor, scale)
+
+    def test_patter_cannot_fuse(self):
+        def f(x):
+            y = x.abs().max()
+            z = x / 10.0
+            z_t = z.t().contiguous().t()
+            return y, z, z_t
+
+        A, B = 8192, 128
+        x = torch.randn(A, B, device=GPU_TYPE)
+
+        self.do_acc_test(f, x)
+
+        # The reduction tiling should not be modified. 128 is too small compared with the original split_size
+        self.assertEqual(3, metrics.generated_kernel_count)
+
+
+if __name__ == "__main__":
+    if HAS_GPU:
+        run_tests()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -441,6 +441,9 @@ enabled_metric_tables = os.environ.get("TORCHINDUCTOR_ENABLED_METRIC_TABLES", ""
 loop_ordering_after_fusion = (
     os.environ.get("TORCHINDUCTOR_LOOP_ORDERING_AFTER_FUSION", "0") == "1"
 )
+defer_reduction_split = (
+    os.environ.get("TORCHINDUCTOR_DEFER_REDUCTION_SPLIT", "0") == "1"
+)
 
 # If fusing two nodes only save less then score_fusion_memory_threshold memory,
 # we should not bother fusing the nodes.

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -20,7 +20,8 @@ class ReductionHint(Enum):
     INNER = 0
     OUTER = 1
     OUTER_TINY = 2
-    DEFAULT = 3
+    DEFERRED_SPLIT = 3
+    DEFAULT = 4
 
 
 class TileHint(Enum):


### PR DESCRIPTION
**Context**
We mainly want to address the two cases that are commonly used in float8 training:
1. reduction with a tiled pointwise, for example:
```
def test_1(input_x):
    y = input_x.abs().max()

    z = input_x / 10.0
    z_t = z.t().contiguous().t()  # `z` and `z_t` will be fused into a tiled pointwise

    return y, z, z_t
```
This fusion of `y` and `z_z_t` failed due to "invalid tiling" (https://github.com/pytorch/pytorch/issues/128063)

2. reduction with a "partial reduction", for example:
```
def test_2(x):
    y = x.abs().max(dim=-1)
    z = x.abs().max()   # we want the first-level reduction of `z` can be fused with `y`.
    return y[0], z
```
This fusion doesn't happen also because `y` and first-level reduction of `z` has a different tiling (https://github.com/pytorch/pytorch/issues/136267)

To fix the two cases, we attempted to defer the split of reduction after fusion, so that the reductio split can take its neighbor op into consideration to allow the fusions to happen.

**Summary of the changes**:
* Added a config option `defer_reduction_split`. When it's enabled, if `num_splits` gets a `>1` result, return `ReductionHint.DEFERRED_SPLIT, 1` instead.
* In scheduler, when fusing nodes, if a node is a `ReductionHint.DEFERRED_SPLIT`, ignore it for now. After all non-DEFERRED_SPLIT nodes are fused, split DEFERRED_SPLIT Reduction nodes.
  * I thought about a better place to put `split_reduction_nodes`. However, there are cases that the tiled operations will only occur after fusion. So I chose to run `fuse_nodes` first, and then used the fused nodes to split the reduction nodes.
For example,
```
# op0. the reduction, read: arg0_1
y = x.abs().max()
# op1. read: arg0_1; write: buf0; no tiling
> z = x / 10.0   
# op2. read: transposed buf0              
z_t = z.t().contiguous().t()  

# Before fusion of op1 and op2:
Only op1 has shared data with op0, however op1 has no tiling
# After fusion of op1 and op2:
fused op0_1: read arg0_1, and has a tiling that the reduction (op0) can try to match
```
* For a  DEFERRED_SPLIT Reduction node, find all nodes that has shared data with it. (if `loop_reordering_after_fusion` is enabled, `loop_reordering` will also be considered.) 
Use the other nodes' tiling as the hints to split the reduction. If "hints" are too different from the original num_split, they'll be ignored.
*  Create new Scheduler nodes from the split reduction nodes. Remove the DEFERRED_SPLIT Reduction node and add the new Reduction nodes in Scheduler, and updating all related scheduler fields. (Hope I didn't miss any necessary fields in the scheduler...)
*  If there are new nodes added, re-run `fuse_nodes`. The second `fuse_nodes` should finish quickly as only the newly added reduction nodes may be fused into other nodes.

**Test Plan**:
Some test cases in my testing scripts in fbcode (in the diff)
```
TORCHINDUCTOR_PROFILE_OUTPUT=/tmp/profile.txt TORCHINDUCTOR_PROFILE=1 TORCHINDUCTOR_PROFILE_WITH_DO_BENCH_USING_PROFILING=1  TORCHINDUCTOR_DEFER_REDUCTION_SPLIT=1 TORCHINDUCTOR_LOOP_ORDERING_AFTER_FUSION=1 TORCH_LOGS="fusion" buck run mode/opt scripts/shuqiyang/test_inductor:test_reduction 2>&1 | tee ~/test_reduction_log_4.txt
```
* Includes both the delayed scaling and luca's rowwise scaling. Next step is to test it in actual float8 training use case.
------
Unit test:
Defer_reduction_split test:
```
buck2 test 'fbcode//mode/opt' caffe2/test/inductor:defer_reduction_split
```

Differential Revision: D66157846




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov