### PR TITLE
Upload MPS benchmark results

### DIFF
--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -223,6 +223,14 @@ jobs:
           use-gha: true
           file-suffix: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.get-job-id.outputs.job-id }}
 
+      - name: Upload the benchmark results
+        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@main
+        with:
+          benchmark-results-dir: test/test-reports
+          dry-run: false
+          schema-version: v3
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Clean up disk space
         if: always()
         continue-on-error: true

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -224,8 +224,7 @@ jobs:
           file-suffix: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.get-job-id.outputs.job-id }}
 
       - name: Upload the benchmark results
-        # TODO: TESTING https://github.com/pytorch/test-infra/pull/5947, TO BE REVERTED BEFORE LANDING
-        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@handle-benchmark-results-jsoneachrow
+        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@main
         with:
           benchmark-results-dir: test/test-reports
           dry-run: false

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -224,7 +224,8 @@ jobs:
           file-suffix: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.get-job-id.outputs.job-id }}
 
       - name: Upload the benchmark results
-        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@main
+        # TODO: TESTING https://github.com/pytorch/test-infra/pull/5947, TO BE REVERTED BEFORE LANDING
+        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@handle-benchmark-results-jsoneachrow
         with:
           benchmark-results-dir: test/test-reports
           dry-run: false

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -412,7 +412,7 @@ def output_json(filename, headers, row):
         extra_info.update(current_settings)
 
     mapping_headers = {headers[i]: v for i, v in enumerate(row)}
-    with open(f"{os.path.splitext(filename)}.json", "a") as f:
+    with open(f"{os.path.splitext(filename)[0]}.json", "a") as f:
         for header, value in mapping_headers.items():
             # These headers are not metric names
             if header in ("dev", "name", "batch_size"):

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -365,14 +365,15 @@ def write_outputs(filename, headers, row):
     """
     Write both CSV and JSON outputs using the original CSV output interface
     """
+    global disable_output
+    if disable_output:
+        return
+
     output_csv(filename, headers, row)
     output_json(filename, headers, row)
 
 
 def output_csv(filename, headers, row):
-    global disable_output
-    if disable_output:
-        return
     if os.path.exists(filename):
         with open(filename) as fd:
             lines = list(csv.reader(fd)) or [[]]
@@ -424,7 +425,7 @@ def output_json(filename, headers, row):
                     "name": "TorchInductor",
                     "mode": current_mode,
                     "dtype": current_dtype,
-                    "extra_info": current_settings,
+                    "extra_info": extra_info,
                 },
                 "model": {
                     "name": current_name,
@@ -4531,6 +4532,11 @@ def run(runner, args, original_dir=None):
         current_name, \
         current_device, \
         current_batch_size, \
+        current_backend, \
+        current_mode, \
+        current_dtype, \
+        current_quantization, \
+        current_settings, \
         output_filename, \
         disable_output, \
         optimize_ctx, \

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -368,6 +368,7 @@ def write_outputs(filename, headers, row):
     output_csv(filename, headers, row)
     output_json(filename, headers, row)
 
+
 def output_csv(filename, headers, row):
     global disable_output
     if disable_output:


### PR DESCRIPTION
This uploads the MPS benchmark results to benchmark database.  The data can then be queried, for example:

```
select benchmark, model, metric from oss_ci_benchmark_v3 where head_sha = '99a133116fee15aa1467165f2b209b37da53f189' and metric.name in ['eager_peak_mem', 'dynamo_peak_mem', 'speedup'] and model.name = 'BERT_pytorch'
```

I'm documenting the JSON format at https://github.com/pytorch/pytorch/wiki/How-to-integrate-with-PyTorch-OSS-benchmark-database

### Testing

Locally,

```
PYTHONPATH=/Users/huydo/Storage/mine/benchmark python benchmarks/dynamo/torchbench.py --performance --only resnet152 --backend eager --training --devices mps --output test/test-reports/torchbench_training.csv
```

Workflow dispatch https://github.com/pytorch/pytorch/actions/runs/11927990520

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames