### PR TITLE
[MPS][BE] Do not create 4 instances of `FUSED_ADAM_OPS`

### DIFF
--- a/aten/src/ATen/native/mps/operations/FusedAdamAmsgradKernelImpl.mm
+++ b/aten/src/ATen/native/mps/operations/FusedAdamAmsgradKernelImpl.mm
@@ -3,7 +3,6 @@
 
 #include <ATen/Dispatch.h>
 #include <ATen/native/ForeachUtils.h>
-#include <ATen/native/mps/operations/FusedOptimizerOps.h>
 #include <ATen/native/mps/operations/MultiTensorApply.h>
 #include <vector>
 

--- a/aten/src/ATen/native/mps/operations/FusedAdamKernelImpl.mm
+++ b/aten/src/ATen/native/mps/operations/FusedAdamKernelImpl.mm
@@ -68,4 +68,11 @@ void _fused_adam_mps_impl_(TensorList params,
                                                  eps,
                                                  maximize);
 }
+
+std::pair<id<MTLComputePipelineState>, id<MTLFunction>> getFusedAdamCPLState(
+    const std::string& fname) {
+  static MetalShaderLibrary lib(FUSED_ADAM_OPS, 0);
+  return {lib.getPipelineStateForFunc(fname), lib.getMTLFunction(fname)};
+}
+
 } // namespace at::native::mps

--- a/aten/src/ATen/native/mps/operations/FusedAdamKernelImpl.mm
+++ b/aten/src/ATen/native/mps/operations/FusedAdamKernelImpl.mm
@@ -69,8 +69,7 @@ void _fused_adam_mps_impl_(TensorList params,
                                                  maximize);
 }
 
-std::pair<id<MTLComputePipelineState>, id<MTLFunction>> getFusedAdamCPLState(
-    const std::string& fname) {
+std::pair<id<MTLComputePipelineState>, id<MTLFunction>> getFusedAdamCPLState(const std::string& fname) {
   static MetalShaderLibrary lib(FUSED_ADAM_OPS, 0);
   return {lib.getPipelineStateForFunc(fname), lib.getMTLFunction(fname)};
 }

--- a/aten/src/ATen/native/mps/operations/FusedAdamWAmsgradKernelImpl.mm
+++ b/aten/src/ATen/native/mps/operations/FusedAdamWAmsgradKernelImpl.mm
@@ -3,7 +3,6 @@
 
 #include <ATen/Dispatch.h>
 #include <ATen/native/ForeachUtils.h>
-#include <ATen/native/mps/operations/FusedOptimizerOps.h>
 #include <ATen/native/mps/operations/MultiTensorApply.h>
 #include <vector>
 

--- a/aten/src/ATen/native/mps/operations/FusedAdamWKernelImpl.mm
+++ b/aten/src/ATen/native/mps/operations/FusedAdamWKernelImpl.mm
@@ -3,7 +3,6 @@
 
 #include <ATen/Dispatch.h>
 #include <ATen/native/ForeachUtils.h>
-#include <ATen/native/mps/operations/FusedOptimizerOps.h>
 #include <ATen/native/mps/operations/MultiTensorApply.h>
 #include <vector>
 

--- a/aten/src/ATen/native/mps/operations/FusedOptimizerOps.h
+++ b/aten/src/ATen/native/mps/operations/FusedOptimizerOps.h
@@ -435,11 +435,4 @@ REGISTER_FUSED_SGD_MOMENTUM_OP(half);
 
 )METAL";
 
-static std::pair<id<MTLComputePipelineState>, id<MTLFunction>> getCPLState(
-    const std::string& fname) {
-  static MetalShaderLibrary lib(FUSED_ADAM_OPS, 0);
-  return std::make_pair(
-      lib.getPipelineStateForFunc(fname), lib.getMTLFunction(fname));
-}
-
 } // namespace at::native::mps


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #141092
* __->__ #141090
* #141089

Defining `static char shaderSource[]` in the header will instantiate it as often as it is included.
Solved the problem by renaming `static auto getCPLState(const std::string&)` into `auto getFusedAdamCPLState(const std::string&)` and instantiating it only once resulted in 500K reduction in binary size (and perhaps even more in runtime footprint)

I.e. before
```
% ls -lak lib/libtorch_cpu.dylib
-rwxr-xr-x  1 malfet  staff  183357744 Nov 19 17:58 lib/libtorch_cpu.dylib
```
and afer
```
% ls -lak lib/libtorch_cpu.dylib
-rwxr-xr-x  1 malfet  staff  183357120 Nov 19 17:57 lib/libtorch_cpu.dylib
```