### PR TITLE
Fix `stride` in TensorMetadata to always be a `Tuple[int, ...]`

### DIFF
--- a/torch/fx/passes/shape_prop.py
+++ b/torch/fx/passes/shape_prop.py
@@ -41,7 +41,7 @@ def _extract_tensor_metadata(
     shape = result.shape
     dtype = result.dtype
     requires_grad = result.requires_grad
-    stride = result.stride() if not is_sparse_any(result) else None
+    stride = result.stride() if not is_sparse_any(result) else ()
 
     memory_format = None
 


### PR DESCRIPTION
Test Plan: CI

Differential Revision: D66204410




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv