### PR TITLE
Fix lerp weight type promotion

### DIFF
--- a/aten/src/ATen/native/Lerp.cpp
+++ b/aten/src/ATen/native/Lerp.cpp
@@ -16,7 +16,15 @@ TORCH_META_FUNC(lerp_Tensor)(
     const Tensor& self, const Tensor& end, const Tensor& weight) {
   TORCH_CHECK(self.dtype() == end.dtype(), "expected dtype ", self.dtype(),
               " for `end` but got dtype ", end.dtype());
-  auto weight_ = self.dtype() == weight.dtype() ? weight : weight.to(self.dtype());
+
+  auto weight_ = weight;
+  if (self.dtype() != weight.dtype()) {
+    auto promote_type = c10::promoteTypes(self.scalar_type(), weight.scalar_type());
+    TORCH_CHECK(promote_type == self.scalar_type(), "Unable to promote `input` dtype to ", promote_type,
+                ", change `weight` dtype ", weight.dtype(), " same as `input` dtype ", self.dtype());
+    weight_ = weight.to(promote_type);
+  }
+
   build(at::TensorIteratorConfig()
         .allow_cpu_scalars(true)
         .add_output(maybe_get_output())

--- a/aten/src/ATen/native/Lerp.cpp
+++ b/aten/src/ATen/native/Lerp.cpp
@@ -14,11 +14,12 @@ namespace at::meta {
 
 TORCH_META_FUNC(lerp_Tensor)(
     const Tensor& self, const Tensor& end, const Tensor& weight) {
-  bool all_same_dtype = (self.dtype() == end.dtype() && self.dtype() == weight.dtype());
+  TORCH_CHECK(self.dtype() == end.dtype(), "expected dtype ", self.dtype(),
+              " for `end` but got dtype ", end.dtype());
 
   build(at::TensorIteratorConfig()
         .allow_cpu_scalars(true)
-        .promote_inputs_to_common_dtype(!all_same_dtype)
+        .promote_inputs_to_common_dtype(true)
         .add_output(maybe_get_output())
         .add_const_input(self)
         .add_const_input(end)
@@ -27,6 +28,8 @@ TORCH_META_FUNC(lerp_Tensor)(
 
 TORCH_META_FUNC(lerp_Scalar)(
     const Tensor& self, const Tensor& end, const Scalar& /*weight*/) {
+  TORCH_CHECK(self.dtype() == end.dtype(), "expected dtype ", self.dtype(),
+              " for `end` but got dtype ", end.dtype());
   build_binary_op(maybe_get_output(), self, end);
 }
 

--- a/aten/src/ATen/native/Lerp.cpp
+++ b/aten/src/ATen/native/Lerp.cpp
@@ -16,14 +16,13 @@ TORCH_META_FUNC(lerp_Tensor)(
     const Tensor& self, const Tensor& end, const Tensor& weight) {
   TORCH_CHECK(self.dtype() == end.dtype(), "expected dtype ", self.dtype(),
               " for `end` but got dtype ", end.dtype());
-  TORCH_CHECK(self.dtype() == weight.dtype(), "expected dtype ", self.dtype(),
-              " for `weight` but got dtype ", weight.dtype());
+  auto weight_ = self.dtype() == weight.dtype() ? weight : weight.to(self.dtype());
   build(at::TensorIteratorConfig()
         .allow_cpu_scalars(true)
         .add_output(maybe_get_output())
         .add_const_input(self)
         .add_const_input(end)
-        .add_const_input(weight));
+        .add_const_input(weight_));
 }
 
 TORCH_META_FUNC(lerp_Scalar)(

--- a/aten/src/ATen/native/Lerp.cpp
+++ b/aten/src/ATen/native/Lerp.cpp
@@ -16,10 +16,14 @@ TORCH_META_FUNC(lerp_Tensor)(
     const Tensor& self, const Tensor& end, const Tensor& weight) {
   TORCH_CHECK(self.dtype() == end.dtype(), "expected dtype ", self.dtype(),
               " for `end` but got dtype ", end.dtype());
-
+  bool promote_weight = weight.dim() == 0 && self.dtype() != weight.dtype();
+  if (!promote_weight) {
+    TORCH_CHECK(self.dtype() == weight.dtype(), "expected dtype ", self.dtype(),
+                " for `weight` but got dtype ", weight.dtype());
+  }
   build(at::TensorIteratorConfig()
         .allow_cpu_scalars(true)
-        .promote_inputs_to_common_dtype(true)
+        .promote_inputs_to_common_dtype(promote_weight)
         .add_output(maybe_get_output())
         .add_const_input(self)
         .add_const_input(end)

--- a/aten/src/ATen/native/Lerp.cpp
+++ b/aten/src/ATen/native/Lerp.cpp
@@ -16,7 +16,7 @@ TORCH_META_FUNC(lerp_Tensor)(
     const Tensor& self, const Tensor& end, const Tensor& weight) {
   TORCH_CHECK(self.dtype() == end.dtype(), "expected dtype ", self.dtype(),
               " for `end` but got dtype ", end.dtype());
-  bool promote_weight = weight.dim() == 0 && self.dtype() != weight.dtype();
+  bool promote_weight = weight.dim() == 0;
   if (!promote_weight) {
     TORCH_CHECK(self.dtype() == weight.dtype(), "expected dtype ", self.dtype(),
                 " for `weight` but got dtype ", weight.dtype());
@@ -24,6 +24,8 @@ TORCH_META_FUNC(lerp_Tensor)(
   build(at::TensorIteratorConfig()
         .allow_cpu_scalars(true)
         .promote_inputs_to_common_dtype(promote_weight)
+        .enforce_safe_casting_to_output(promote_weight)
+        .cast_common_dtype_to_outputs(promote_weight)
         .add_output(maybe_get_output())
         .add_const_input(self)
         .add_const_input(end)

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3529,16 +3529,6 @@ class TestBinaryUfuncs(TestCase):
         expected = start + weight.to(dtype) * (end - start)
         self.assertEqual(expected, actual)
 
-    @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
-    def test_lerp_scalar_type_promotion(self, device, dtype):
-        start = make_tensor((5, 5), dtype=dtype, device=device, low=1, high=100)
-        end = make_tensor((5, 5), dtype=torch.float, device=device, low=1, high=100)
-        weight = torch.rand(1).item()
-
-        actual = torch.lerp(start, end, weight)
-        expected = start + weight * (end.to(dtype) - start)
-        self.assertEqual(expected, actual)
-
     def _test_logaddexp(self, device, dtype, base2):
         if base2:
             ref_func = np.logaddexp2

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3523,7 +3523,7 @@ class TestBinaryUfuncs(TestCase):
     def test_lerp_tensor_type_promotion(self, device, dtype):
         start = make_tensor((5, 5), dtype=dtype, device=device, low=1, high=100)
         end = make_tensor((5, 5), dtype=dtype, device=device, low=1, high=100)
-        weight = make_tensor((5, 5), dtype=torch.float, device=device, low=1, high=100)
+        weight = torch.rand((), dtype=torch.float, device=device)
 
         actual = torch.lerp(start, end, weight)
         expected = start + weight.to(dtype) * (end - start)

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3519,6 +3519,18 @@ class TestBinaryUfuncs(TestCase):
                 expected = torch.lerp(xref, yref, wref).to(dtype)
                 self.assertEqual(actual, expected, atol=0.0, rtol=0.0)
 
+    @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
+    def test_lerp_weight_type_promotion(self, device, dtype):
+        shape = (5, 5)
+        start = torch.randn(shape, device=device, dtype=dtype)
+        end = torch.randn(shape, device=device, dtype=dtype)
+        weight = torch.randn(shape, device=device, dtype=torch.float)
+
+        actual = torch.lerp(start, end, weight)
+        expected = start + weight * (end - start)
+        self.assertEqual(expected, actual)
+
+
     def _test_logaddexp(self, device, dtype, base2):
         if base2:
             ref_func = np.logaddexp2

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3520,7 +3520,7 @@ class TestBinaryUfuncs(TestCase):
                 self.assertEqual(actual, expected, atol=0.0, rtol=0.0)
 
     @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
-    def test_lerp_tensor_type_promotion(self, device, dtype):
+    def test_lerp_weight_scalar_tensor_promotion(self, device, dtype):
         start = make_tensor((5, 5), dtype=dtype, device=device, low=1, high=100)
         end = make_tensor((5, 5), dtype=dtype, device=device, low=1, high=100)
         weight = torch.rand((), dtype=torch.float, device=device)
@@ -3528,6 +3528,14 @@ class TestBinaryUfuncs(TestCase):
         actual = torch.lerp(start, end, weight)
         expected = start + weight.to(dtype) * (end - start)
         self.assertEqual(expected, actual)
+
+    @dtypes(torch.double, torch.cfloat, torch.cdouble)
+    def test_lerp_weight_tensor_promotion_error(self, device, dtype):
+        start = make_tensor((5, 5), dtype=dtype, device=device, low=1, high=100)
+        end = make_tensor((5, 5), dtype=dtype, device=device, low=1, high=100)
+        weight = torch.rand((5, 5), dtype=torch.float, device=device)
+        with self.assertRaisesRegex(RuntimeError, "expected dtype"):
+            torch.lerp(start, end, weight)
 
     def _test_logaddexp(self, device, dtype, base2):
         if base2:

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6971,10 +6971,6 @@ def lerp(start, end, weight):
     )
     args = [start, end]
     if isinstance(weight, TensorLike):
-        torch._check(
-            start.dtype == weight.dtype,
-            lambda: f"expected dtype {start.dtype} for `weight`, but got dtype {weight.dtype}",
-        )
         args.append(weight)
     return elementwise_meta(
         *args, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6971,6 +6971,11 @@ def lerp(start, end, weight):
     )
     args = [start, end]
     if isinstance(weight, TensorLike):
+        if weight.ndim != 0:
+            torch._check(
+                start.dtype == weight.dtype,
+                lambda: f"expected dtype {start.dtype} for `weight`, but got dtype {weight.dtype}",
+            )
         args.append(weight)
     return elementwise_meta(
         *args, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT


### PR DESCRIPTION
Fixes #140601

Enable `promote_inputs_to_common_dtype` when tensors not same dtype when invoke `lerp` function.

For `lerp_Tensor`
- Check whether same `dtype` of tensors, enable promote if not
- Remove type check assert

For `lerp_Scalar`
- Seems already enable `promote_inputs_to_common_dtype` by default, just remove the type check. Make sure promote behavior consistent with `lerp_Tensor`

`lerp_Scalar` get TensorIteratorConfig from here
https://github.com/pytorch/pytorch/blob/c37185c76ae4068899869e48a8388e78437508e8/aten/src/ATen/TensorIterator.cpp#L979-L985


**Test Result**
Test case in issue passed

```python
>>> import torch
>>> 
>>> x = torch.ones(2, 2, dtype=torch.float64)
>>> w = torch.ones(2, 2, dtype=torch.float64)
>>> s = torch.tensor(2.2) 
>>> x.lerp_(w, s)
tensor([[1., 1.],
        [1., 1.]], dtype=torch.float64)

>>> x = torch.ones(2, 2, dtype=torch.float16)
>>> w = torch.ones(2, 2, dtype=torch.float16)
>>> s = torch.tensor(2.2) 
>>> x.lerp_(w, s)
tensor([[1., 1.],
        [1., 1.]], dtype=torch.float16)

```


```bash
$ pytest test/test_binary_ufuncs.py -k 'test_lerp_tensor_type_promotion or test_lerp_scalar_type_promotion'
```
![image](https://github.com/user-attachments/assets/288a5294-a9ee-47f3-bbf7-d4ff986f3ba8)


```bash
$ lintrunner
```
![image](https://github.com/user-attachments/assets/d469836f-5c49-4d89-a2fd-379cad4db3af)

cc @janeyx99
