### PR TITLE
add method to collect weights from remote models in RPC #50346

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -112,6 +112,7 @@ and move it to the desired devices on the callee if necessary.
 .. autofunction:: rpc_async
 .. autofunction:: remote
 .. autofunction:: get_worker_info
+.. autofunction:: gather_remote_modules
 .. autofunction:: shutdown
 .. autoclass:: WorkerInfo
     :members:


### PR DESCRIPTION
Hello, I have faced the same problem as https://github.com/pytorch/pytorch/issues/50346 and I have implemented a first approach that I think it might be useful for many developers (at least compared with having nothing).

I have been unable to build pytorch from scratch (before any change), but I have tested it modifying the virtualenv package and I have also build the documentation to see that everything is ok.

As in the documentation the way of using this would be something like

```python
# Model
class ModAB():
    layer1
    layer2


# User split it into 2 RemoteModules, let's say remoteA, remoteB
modAB = ModAB()
remoteA.layer1 = modAB.layer1
remoteB.layer2 = modAB.layer2

# Do your training and everything

# now user get references to the modules with get_module_rref
remote_refs = [remoteA.get_module_rref(), remoteB.get_module_rref()]
# collect weights
remote_weights = dist.rpc.gather_remote_modules(remote_refs)
# now you should be able to save it
torch.save(remote_weights['all'], "path.pth")

### Later you should be able to do
modAB.load_state_dict(torch.load("path.pth", weights_only=True))
```

I'll try to address any questions/problems you may have with this

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o