### PR TITLE
[ARM] Fix bf32 and tf32 precision for tensordot unit test

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -8466,7 +8466,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
                          fn(torch.slogdet, (0, 0)))
 
     @tf32_on_and_off(0.005)
-    @bf32_on_and_off(0.005)
+    @bf32_on_and_off(0.07)
     def test_tensordot(self, device):
         a = torch.arange(60., device=device).reshape(3, 4, 5)
         b = torch.arange(24., device=device).reshape(4, 3, 2)


### PR DESCRIPTION
Fixes unit test failure on aarch64 ( neoverse-v1 )

cc @malfet @snadampal @milpuz01