### PR TITLE
[dynamo] Added cuda and triton versions to dynamo_compile

### DIFF
--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -201,6 +201,8 @@ class TestDynamoTimed(TestCase):
             e.co_filename = None
             e.co_firstlineno = None
             e.inductor_config = None
+            e.cuda_version = None
+            e.triton_version = None
 
         # First event is for the forward. Formatting makes reading diffs
         # much easier.
@@ -221,6 +223,7 @@ class TestDynamoTimed(TestCase):
  'config_inline_inbuilt_nn_modules': False,
  'config_suppress_errors': False,
  'cuda_synchronize_time_us': None,
+ 'cuda_version': None,
  'distributed_ephemeral_timeout_us': None,
  'duration_us': 0,
  'dynamo_compile_time_before_restart_us': 0,
@@ -264,7 +267,8 @@ class TestDynamoTimed(TestCase):
  'start_time_us': 100,
  'structured_logging_overhead_s': 0.0,
  'structured_logging_overhead_us': 0,
- 'triton_compile_time_us': None}""",  # noqa: B950
+ 'triton_compile_time_us': None,
+ 'triton_version': None}""",  # noqa: B950
         )
 
         # Second event is for the backward
@@ -285,6 +289,7 @@ class TestDynamoTimed(TestCase):
  'config_inline_inbuilt_nn_modules': None,
  'config_suppress_errors': None,
  'cuda_synchronize_time_us': None,
+ 'cuda_version': None,
  'distributed_ephemeral_timeout_us': None,
  'duration_us': 0,
  'dynamo_compile_time_before_restart_us': None,
@@ -328,7 +333,8 @@ class TestDynamoTimed(TestCase):
  'start_time_us': 100,
  'structured_logging_overhead_s': None,
  'structured_logging_overhead_us': 0,
- 'triton_compile_time_us': None}""",  # noqa: B950
+ 'triton_compile_time_us': None,
+ 'triton_version': None}""",  # noqa: B950
         )
 
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -864,6 +864,8 @@ class CompilationMetrics:
     joint_graph_pass_time_us: Optional[int] = None
     log_format_version: int = LOG_FORMAT_VERSION
     inductor_config: Optional[str] = None
+    cuda_version: Optional[str] = None
+    triton_version: Optional[str] = None
 
 
 DEFAULT_COMPILATION_METRICS_LIMIT = 64
@@ -963,6 +965,8 @@ def record_compilation_metrics(metrics: Dict[str, Any]):
 
     common_metrics = {
         "inductor_config": _scrubbed_inductor_config_for_logging(),
+        "cuda_version": torch.version.cuda,
+        "triton_version": triton.__version__ if has_triton() else "",
         # -------- Any future common metircs go here --------
         #
         # Legacy metircs go here(TODO: Temporary; populate legacy fields from their replacements.)


### PR DESCRIPTION
Summary: Add cuda and triton versions to dynamo_compile logging site.

Test Plan:
$ buck2 run mode/opt //scripts/oulgen:runner
File changed: fbcode//caffe2/torch/_dynamo/convert_frame.py
Buck UI: https://www.internalfb.com/buck2/1a8ada1f-d54e-44b2-a368-b2ff2030e113
Network: Up: 65KiB  Down: 0B  (reSessionID-8f4d1d6d-a680-4ecc-8e73-c29c932d824b)
Jobs completed: 2166. Time elapsed: 7.0s.
Cache hits: 0%. Commands: 3 (cached: 0, remote: 0, local: 3)
BUILD SUCCEEDED
...
Cuda: 12.4.0
Triton: 3.0.0

Differential Revision: D66181508




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames