### PR TITLE
Skip uploading benchmark records when there is no model name

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -420,6 +420,10 @@ def output_json(filename, headers, row):
             if header in ("dev", "name", "batch_size"):
                 continue
 
+            # Make sure that the record is valid
+            if not current_name:
+                continue
+
             record = {
                 "benchmark": {
                     "name": "TorchInductor",


### PR DESCRIPTION
A small fix I just realize after https://github.com/pytorch/pytorch/pull/141087.  

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames