### PR TITLE
Instead of using node.meta read from side table directly

### DIFF
--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -786,25 +786,6 @@ def trace_triton_kernel_wrapper(
         name=func_overload.__name__ + "_proxy",
     )
 
-    from triton.runtime.autotuner import Autotuner
-
-    from torch._inductor.codegen.wrapper import (
-        user_defined_triton_kernel_transitive_closure_source_code,
-    )
-
-    kernel = kernel_side_table.get_kernel(proxy_args["kernel_idx"])
-    if isinstance(kernel, Autotuner):
-        kernel = kernel.fn
-
-    kernel_source = user_defined_triton_kernel_transitive_closure_source_code(kernel)
-    constant_args = kernel_side_table.get_constant_args(proxy_args["constant_args_idx"])
-    # we add to node here so that it gets included in the inductor cache key
-    # when the graph is pickled
-    out_proxy.node.meta["user_defined_triton_kernel_source_and_constant_args"] = (
-        kernel_source,
-        constant_args,
-    )
-
     ret = track_tensor_tree(out, out_proxy, constant=None, tracer=proxy_mode.tracer)
     return ret
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

When a transformation phase copies/modifies a node, it might drop node.meta, same as graph.meta, so they are not a good storage locations. instead directly read from the side table.

Differential Revision: [D66249968](https://our.internmc.facebook.com/intern/diff/D66249968/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov