### PR TITLE
[cuDNN][SDPA] Update cuDNN grad output layout check

### DIFF
--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -748,7 +748,8 @@ void run_cudnn_SDP_bprop(
   if (!same_strides(o, dO)) {
     TORCH_WARN_ONCE(
         "cuDNN SDPA backward got grad_output.strides() != output.strides(), "
-        "attempting to materialize a grad_output with matching strides...");
+        "attempting to materialize a grad_output with matching strides."
+	"Consider upgrading cuDNN v9.5.1+ to avoid this warning.");
     permute_to_matching_layout(o, dO_);
   }
   TORCH_INTERNAL_ASSERT(
@@ -759,10 +760,6 @@ void run_cudnn_SDP_bprop(
 #else
   const auto innermost_dO_stride = dO.strides()[dO.strides().size() - 1];
   if (innermost_dO_stride != 1) {
-    TORCH_WARN_ONCE(
-        "cuDNN SDPA backward got grad_output with an innermost stride != 1 "
-        "(likely due to e.g., .sum().backward()),"
-	"materializing a grad_output for innermost stride 1 for cuDNN...");
     permute_to_matching_layout(o, dO_);
   }
 #endif

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -749,7 +749,7 @@ void run_cudnn_SDP_bprop(
     TORCH_WARN_ONCE(
         "cuDNN SDPA backward got grad_output.strides() != output.strides(), "
         "attempting to materialize a grad_output with matching strides."
-	"Consider upgrading cuDNN v9.5.1+ to avoid this warning.");
+        "Consider upgrading cuDNN v9.5.1+ to avoid this warning.");
     permute_to_matching_layout(o, dO_);
   }
   TORCH_INTERNAL_ASSERT(


### PR DESCRIPTION
Thanks to https://github.com/pytorch/pytorch/pull/137978 from @Skylion007 which bumps to cuDNN 9.5.1 the broken assumption of dO strides == O strides is fixed

Note that there is still the restriction that the innermost stride of the grad output is 1 (this is almost always guaranteed because this condition is required of the input tensors). The main exception would be in test code that does e.g., `.sum().backward()` which yields grad output tensors with strides `[0, 0, 0, 0]`.

CC @drisspg 

cc @csarofeen @ptrblck @xwang233 @drisspg @mikaylagawarecki