### PR TITLE
[c10d] Switch all timer logging in c10d to wait_counter

### DIFF
--- a/test/distributed/test_c10d_logger.py
+++ b/test/distributed/test_c10d_logger.py
@@ -5,12 +5,11 @@ import logging
 import os
 import re
 import sys
-import time
 from functools import partial, wraps
 
 import torch
 import torch.distributed as dist
-from torch.distributed.c10d_logger import _c10d_logger, _exception_logger, _time_logger
+from torch.distributed.c10d_logger import _c10d_logger, _exception_logger
 
 
 if not dist.is_available():
@@ -148,52 +147,6 @@ class C10dErrorLoggerTest(MultiProcessTestCase):
             # In this test case, local_rank = global_rank, since we don't have multiple processes on one node.
             self.assertIn("local_rank", error_msg_dict.keys())
             self.assertIn(str(dist.get_rank()), error_msg_dict["local_rank"])
-
-    @_time_logger
-    def _dummy_sleep(self):
-        time.sleep(5)
-
-    @with_comms
-    def test_time_logger(self) -> None:
-        with self.assertLogs(_c10d_logger, level="DEBUG") as captured:
-            self._dummy_sleep()
-            msg_dict = json.loads(
-                re.search("({.+})", captured.output[0]).group(0).replace("'", '"')
-            )
-            self.assertEqual(len(msg_dict), 9)
-
-            self.assertIn("pg_name", msg_dict.keys())
-            self.assertEqual("None", msg_dict["pg_name"])
-
-            self.assertIn("func_name", msg_dict.keys())
-            self.assertEqual("_dummy_sleep", msg_dict["func_name"])
-
-            self.assertIn("backend", msg_dict.keys())
-            self.assertEqual("nccl", msg_dict["backend"])
-
-            self.assertIn("nccl_version", msg_dict.keys())
-            nccl_ver = torch.cuda.nccl.version()
-            self.assertEqual(
-                ".".join(str(v) for v in nccl_ver), msg_dict["nccl_version"]
-            )
-
-            # In this test case, group_size = world_size, since we don't have multiple processes on one node.
-            self.assertIn("group_size", msg_dict.keys())
-            self.assertEqual(str(self.world_size), msg_dict["group_size"])
-
-            self.assertIn("world_size", msg_dict.keys())
-            self.assertEqual(str(self.world_size), msg_dict["world_size"])
-
-            self.assertIn("global_rank", msg_dict.keys())
-            self.assertIn(str(dist.get_rank()), msg_dict["global_rank"])
-
-            # In this test case, local_rank = global_rank, since we don't have multiple processes on one node.
-            self.assertIn("local_rank", msg_dict.keys())
-            self.assertIn(str(dist.get_rank()), msg_dict["local_rank"])
-
-            self.assertIn("time_spent", msg_dict.keys())
-            time_ns = re.findall(r"\d+", msg_dict["time_spent"])[0]
-            self.assertEqual(5, int(float(time_ns) / pow(10, 9)))
 
 
 if __name__ == "__main__":

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -949,8 +949,9 @@ def _store_based_barrier(
             worker_count = store.add(store_key, 0)
             # Print status periodically to keep track.
             logger.debug(
-                "Waiting in store based barrier to initialize process group for "
+                "Waiting in store based barrier to initialize process group for %s seconds"
                 "rank: %s, key: %s (world_size=%s, num_workers_joined=%s, timeout=%s error=%s)",
+                time.time() - start,
                 rank,
                 store_key,
                 world_size,


### PR DESCRIPTION
Summary: The original decorator based time logger is bad in performance and capacity. So we want to replace it with pytorch `_WaitCounter` now.

Test Plan: Tested on workload and no regression has been seen: https://fburl.com/scuba/aps_instrumentation_components/mskj73ea

Differential Revision: D66218675




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @wz337 @wconstab @d4l3k @c-p-i-o