### PR TITLE
Use `pip` corresponding to python executable

### DIFF
--- a/tools/linter/adapters/pip_init.py
+++ b/tools/linter/adapters/pip_init.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     if uv_available:
         pip_args = ["uv", "pip", "install"]
     else:
-        pip_args = ["pip", "install"]
+        pip_args = [sys.executable, "-mpip", "install"]
 
     # If we are in a global install, use `--user` to install so that you do not
     # need root access in order to initialize linters.

--- a/tools/linter/adapters/pip_init.py
+++ b/tools/linter/adapters/pip_init.py
@@ -56,8 +56,10 @@ if __name__ == "__main__":
 
     if uv_available:
         pip_args = ["uv", "pip", "install"]
-    else:
+    elif sys.executable:
         pip_args = [sys.executable, "-mpip", "install"]
+    else:
+        pip_args = ["pip3", "install"]
 
     # If we are in a global install, use `--user` to install so that you do not
     # need root access in order to initialize linters.


### PR DESCRIPTION
Sometimes `python3` and `pip` are aliased to different runtimes, so it's better to always use `pip3`, but as linter should install packages into the same python environment, it's even better to just call sys.executable with `-mpip install XYZ` arguments

Fixes regression introduced by https://github.com/pytorch/pytorch/pull/124033
