### PR TITLE
[CI] Reduce distributed test timeout to 60s

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -3449,7 +3449,7 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
         with _functional_collectives.allow_inflight_collective_as_graph_input_ctx():
             self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 0)
             input = torch.full(
-                (10240, 10240), float(self.rank), device=f"cuda:{self.rank}"
+                (1024, 1024), float(self.rank), device=f"cuda:{self.rank}"
             )
             dist.all_reduce(input, op=dist.ReduceOp.SUM, async_op=True)
             # Non-functional collectives run under the context manager is registered in the work registry.
@@ -3461,7 +3461,7 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
         # Case 2: Run collectives not under context manager, and don't call wait on them.
         # NOTE: Here we intentionally test memory-stressed case.
         self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 2)
-        for _ in range(50000):
+        for _ in range(1000):
             input = torch.full(
                 (1024, 1024), float(self.rank), device=f"cuda:{self.rank}"
             )

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -426,7 +426,7 @@ if TEST_WITH_TSAN:
     # TSAN runs much slower.
     TIMEOUT_DEFAULT = 500
 else:
-    TIMEOUT_DEFAULT = int(os.getenv('DISTRIBUTED_TESTS_DEFAULT_TIMEOUT', '300'))
+    TIMEOUT_DEFAULT = int(os.getenv('DISTRIBUTED_TESTS_DEFAULT_TIMEOUT', '60'))
 TIMEOUT_OVERRIDE = {"test_ddp_uneven_inputs": 400}
 
 

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -34,6 +34,7 @@ from torch._C._distributed_c10d import _SymmetricMemory
 import torch.nn as nn
 from torch.testing._internal.common_utils import (
     FILE_SCHEMA,
+    TEST_CUDA,
     find_free_port,
     IS_SANDCASTLE,
     retry_on_connect_failures,
@@ -422,17 +423,28 @@ def create_tcp_store(
         )
 
 
-if TEST_WITH_TSAN:
-    # TSAN runs much slower.
-    TIMEOUT_DEFAULT = 500
-else:
-    TIMEOUT_DEFAULT = int(os.getenv('DISTRIBUTED_TESTS_DEFAULT_TIMEOUT', '60'))
-TIMEOUT_OVERRIDE = {"test_ddp_uneven_inputs": 400}
+# Try env setting first
+TIMEOUT_DEFAULT = int(os.getenv('DISTRIBUTED_TESTS_DEFAULT_TIMEOUT', '0'))
+
+# If not set, use some default values
+if TIMEOUT_DEFAULT == 0:
+    if TEST_WITH_TSAN:
+        # TSAN runs much slower.
+        TIMEOUT_DEFAULT = 500
+    elif TEST_WITH_ROCM:
+        # ROCM runs slower.
+        TIMEOUT_DEFAULT = 120
+    elif TEST_CUDA:
+        TIMEOUT_DEFAULT = 60
+    else:
+        # CPU runs slower.
+        TIMEOUT_DEFAULT = 120
 
 
-# https://github.com/pytorch/pytorch/issues/75665
-if TEST_WITH_ROCM:
-    TIMEOUT_OVERRIDE["test_join_kwargs"] = 200
+TIMEOUT_OVERRIDE = {
+    "test_ddp_uneven_inputs": 400,
+    "test_index": 300,
+}
 
 
 def create_device(interface=None):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141168

Pulling a PR to test viability. 
Today's timeout is 300s, which could waste quite some machine time if a hang happens in CI.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o

Differential Revision: [D66275756](https://our.internmc.facebook.com/intern/diff/D66275756)