### PR TITLE
[export] avoid name collision when inlining node

### DIFF
--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -635,7 +635,16 @@ def node_inline_(call_mod_node: torch.fx.Node) -> None:
         for node in body:
             new_node = gm.graph.node_copy(node)
             if node.op == "get_attr":
-                setattr(gm, node.target, getattr(sub_gm, node.target))
+                new_target_name = new_node.target
+                if hasattr(gm, new_target_name):
+                    # Loop through and find the "submod_{i}" that have no name collision
+                    i = 1
+                    new_target_name = f"submod_{i}"
+                    while hasattr(gm, new_target_name):
+                        i += 1
+                        new_target_name = f"submod_{i}"
+                new_node.target = new_target_name
+                setattr(gm, new_node.target, getattr(sub_gm, node.target))
             node_replace_(node, new_node)
 
         if len(output) > 0:


### PR DESCRIPTION
Summary:
When we have both `set_grad` and `autocast` HOP, name collision might happen when we try to inline a node.

For exmaple, for a GraphModule like this:

```
GraphModule(
  (submod_0): GraphModule(
    (submod_1): GraphModule()
  )
  (submod_1): GraphModule()
  (submod_2): GraphModule()
)

```

when we inline `submod_0`, we might accidentally overwrite `submod_1`.

In this PR, we fix this by check if the graph module already has an attribute with the same name, if so, we use the next "submod_{i}", until no name collision.

Partially fixes https://github.com/pytorch/pytorch/issues/140589.

Test Plan:
```
buck2 run 'fbcode//mode/dev-nosan' fbcode//caffe2/test:test_export -- -r  test_predispatch_autocast_and_set_grad
```

Differential Revision: D66200994


