### PR TITLE
Unbreak CUDA 11.4 build of Half.h

### DIFF
--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -54,11 +54,13 @@
 #if defined(__GNUC__) || defined(__clang__)
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || \
     defined(_M_IX86)
-#if defined(__F16C__) && \
-    !(defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__))
+#if defined(__F16C__) &&                               \
+    !(defined(__CUDA_ARCH__) || defined(__CUDACC__) || \
+      defined(__HIP_DEVICE_COMPILE__))
 #define C10_X86_F16 1
 #include <immintrin.h> // import conversion ops from f16cintrin.h
-#endif // defined(__F16C__)
+#endif // defined(__F16C__) && !(defined(__CUDA_ARCH__) || defined(__CUDACC__)
+       // || defined(__HIP_DEVICE_COMPILE__))
 #endif // __x86_64__ || _M_X64 || __i386 || _M_IX86
 #endif // __GNUC__ || __clang__
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141173

`__CUDACC__` is needed to detect CUDA builds on that platform.

Differential Revision: [D66262774](https://our.internmc.facebook.com/intern/diff/D66262774/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D66262774/)!