### PR TITLE
Fix softmax wrong error msg

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1655,7 +1655,7 @@ class Softmax(Module):
     dim: Optional[int]
 
     def __init__(self, dim: Optional[int] = None) -> None:
-        if dim is not None and type(dim) is not int:    
+        if dim is not None and type(dim) is not int:
             raise TypeError(f"dim must be an int or None, got {type(dim).__name__}")
         super().__init__()
         self.dim = dim

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1655,6 +1655,8 @@ class Softmax(Module):
     dim: Optional[int]
 
     def __init__(self, dim: Optional[int] = None) -> None:
+        if dim is not None and type(dim) is not int:    
+            raise TypeError(f"dim must be an int or None, got {type(dim).__name__}")
         super().__init__()
         self.dim = dim
 


### PR DESCRIPTION
Fixes #133750

The `functional.Softmax` and `torch.nn.Softmax` (Softmax module) have different signatures, which can cause `PythonArgParser` to throw misleading TypeError exceptions when having softmax module initliazed with not None and non int parameters.

This fix adds type checking to the torch.nn.Softmax class to raise a clearer error.

cc @malfet @malfetb @albanD @jbschlosser @mikaylagawarecki 