### PR TITLE
[FlexAttention] Rename zeros_and_scatter library

### DIFF
--- a/torch/_dynamo/_trace_wrapped_higher_order_op.py
+++ b/torch/_dynamo/_trace_wrapped_higher_order_op.py
@@ -52,7 +52,7 @@ __all__ = ["trace_wrapped"]
 if not torch._running_with_deploy():
     # torch.library.custom_op does not work with torch.deploy/multipy
 
-    @torch.library.custom_op("FlexAttentionLib::zeros_and_scatter", mutates_args=())  # type: ignore[misc]
+    @torch.library.custom_op("flex_lib::zeros_and_scatter", mutates_args=())  # type: ignore[misc]
     def zeros_and_scatter(
         shape: List[int],
         indices: List[Tensor],
@@ -84,7 +84,7 @@ if not torch._running_with_deploy():
                 assert idx.shape == value.shape
                 expanded_indices.append(idx)
 
-        out = torch.ops.FlexAttentionLib.zeros_and_scatter(
+        out = torch.ops.flex_lib.zeros_and_scatter(
             shape,
             expanded_indices,
             value,
@@ -109,7 +109,7 @@ class ModIndex(torch.autograd.Function):
     def backward(ctx, gradOut):  # type: ignore[no-untyped-def]
         indices = ctx.saved_tensors
         return (
-            torch.ops.FlexAttentionLib.zeros_and_scatter(
+            torch.ops.flex_lib.zeros_and_scatter(
                 ctx.input_shape,
                 indices,
                 gradOut,

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -107,7 +107,12 @@ def build_subgraph_buffer(
     from ..subgraph_lowering import PointwiseSubgraphLowering
 
     pw_subgraph = PointwiseSubgraphLowering(
-        subgraph.graph_module, root_graph_lowering=V.graph
+        subgraph.graph_module,
+        root_graph_lowering=V.graph,
+        allow_buffer_mutations=enable_mutations,
+        additional_lowerings={
+            torch.ops.flex_lib.zeros_and_scatter.default: zeros_and_scatter_lowering
+        },
     )
     with V.set_graph_handler(pw_subgraph):  # type: ignore[arg-type]
         pw_subgraph.run(*args)

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -107,12 +107,7 @@ def build_subgraph_buffer(
     from ..subgraph_lowering import PointwiseSubgraphLowering
 
     pw_subgraph = PointwiseSubgraphLowering(
-        subgraph.graph_module,
-        root_graph_lowering=V.graph,
-        allow_buffer_mutations=enable_mutations,
-        additional_lowerings={
-            torch.ops.flex_lib.zeros_and_scatter.default: zeros_and_scatter_lowering
-        },
+        subgraph.graph_module, root_graph_lowering=V.graph
     )
     with V.set_graph_handler(pw_subgraph):  # type: ignore[arg-type]
         pw_subgraph.run(*args)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #137452
* __->__ #141185
* #141164


# Summary
Previous custom op library name was a little verbose and didn't really align with how we typically name our libraries.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov