### PR TITLE
[inductor] run builtin sym functions on symbols during lowering

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1406,16 +1406,8 @@ class GraphLowering(torch.fx.Interpreter):
                         f"Unknown triton_kernel_default_layout_constraint: {config.triton_kernel_default_layout_constraint}"
                     )
             elif is_magic_method(n.target):
-                # TODO: this is sus, it probably should be handled in the
-                # lowerings themselves similarly to sym_size/sym-stride
-                # https://github.com/pytorch/pytorch/issues/127789
                 debug("is_magic_method")
-                if isinstance(
-                    n.meta["val"], (torch.SymInt, torch.SymFloat, torch.SymBool)
-                ):
-                    result = n.meta["val"].node.expr
-                else:
-                    result = super().run_node(n)
+                result = super().run_node(n)
             else:
                 debug("")
                 result = super().run_node(n)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #141393
* #140106
* __->__ #141193
* #141181
* #141172
* #140334

The context is we want to auto transform a symint inputs into unbacked symints. The subgraph returns an sunbacked ymint expression based on the unbacked symint input. 

To do this, we cannot rely on the node.meta["val"].expr because  it's using the expression of the previous fake propagation symbols but not the newly created one.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov