### PR TITLE
[PT2][Optimus] Fix a corner case in merge splits

### DIFF
--- a/test/inductor/test_split_cat_fx_passes.py
+++ b/test/inductor/test_split_cat_fx_passes.py
@@ -258,6 +258,18 @@ class TestSplitCatFxPasses(TestCase):
 
             return torch.cat(final_items, dim=1)
 
+        def next_split_getitem_partial_used(x):
+            fs = torch.split(x, [4, 4, 24], dim=1)
+            item0 = fs[0]
+            item2 = fs[2]
+
+            final_items = [item0]
+            ns = item2.split((4, 4, 4, 4, 4, 4), 1)
+            final_items.extend(ns[0:1])
+            final_items.extend(ns[3:4])
+
+            return torch.cat(final_items, dim=1)
+
         args = [
             torch.randn(2, 32),
         ]
@@ -277,6 +289,7 @@ class TestSplitCatFxPasses(TestCase):
             (duplicate_getitems_neg_index, 1),
             (split_getitem_gap, 1),
             (split_getitem_out_of_order, 1),
+            (next_split_getitem_partial_used, 1),
             (split_partial_getitem_cat, 1),
         ]:
             expected = fn(*args)

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -629,18 +629,15 @@ def merge_splits(
                 next_split_num_to_user = {
                     user.args[1]: user for user in node.users.keys()
                 }
-                split_getitem_indices = list(next_split_num_to_user.keys())
-                # check if it is consecutive and starts from index 0
-                if split_getitem_indices[0] != 0 or not is_sorted_and_consecutive(split_getitem_indices):  # type: ignore[arg-type]
-                    return
                 # It is not necessary all getitems from the split node are used.
-                # We use the num of users to check the getitems to be merged.
-                for next_split_num in range(len(node.users.keys())):
+                for next_split_num in range(len(next_split_sections)):
                     with graph.inserting_after(new_split):
                         new_getitem = graph.call_function(
                             operator.getitem, args=(new_split, new_split_num)
                         )
                     new_split_num += 1
+                    if next_split_num not in next_split_num_to_user:
+                        continue
                     next_getitem = next_split_num_to_user[next_split_num]
                     new_getitem.meta.update(next_getitem.meta)
                     next_getitem.replace_all_uses_with(new_getitem)


### PR DESCRIPTION
Summary:
We find another corner case in the merge splits, where the first split node does not have consecutive getitem indices, we need to skip such cases.

{F1964255863}

Test Plan:
# local reproduce
```
buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode batch-split  --flow_id 666002198 2>&1 | tee ~/cmf.txt
```

P1683429791

Differential Revision: D66275387




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov