### PR TITLE
[IntraNodeComm] fix a recent breakage

### DIFF
--- a/torch/csrc/distributed/c10d/intra_node_comm.cu
+++ b/torch/csrc/distributed/c10d/intra_node_comm.cu
@@ -10,8 +10,8 @@ static constexpr size_t kTwoShotThreshBytes = 10 * 1024 * 1024;
 
 static void checkInput(const at::Tensor& input, int deviceIdx) {
   TORCH_CHECK(
-      input.dtype() == at::kBFloat16,
-      "oneShotAllReduce only supports bf16 for now");
+      input.dtype() == at::kBFloat16 || input.dtype() == at::kFloat,
+      "oneShotAllReduce only supports float and bf16 for now");
   TORCH_CHECK(input.is_non_overlapping_and_dense());
   TORCH_CHECK(input.device().is_cuda());
   TORCH_CHECK(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141200

- Pass `group_name` to `CUDASymmetricMemory::alloc()` instead of `CUDASymmetricMemory::rendezvous()`. We can only move the argument to rendezvous() once all the underlying operators do the same.
- Added `float` to the allowlist for intra-node all-reduces.
- Added a warning when `IntraNodeComm::rendezvous()` is performed with overlapping devices among participants.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o