### PR TITLE
[user-empathy-day][dynamo] Remove speical casing for torch.nn.Parameter tracing

### DIFF
--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -915,62 +915,6 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
                 tx, [self] + list(args), kwargs
             )
 
-    def trace_supported_methods(
-        self, tx: "InstructionTranslator", method, name, args, kwargs
-    ):
-        def get_kwargs(*names):
-            fn = getattr(self.value, name)
-            bound_args = inspect.signature(fn).bind(
-                *([x.as_python_constant() for x in args]),
-                **{k: v.as_python_constant() for k, v in kwargs.items()},
-            )
-            bound_args.apply_defaults()
-            bound_args = bound_args.arguments
-            return {k: bound_args[k] for k in names}
-
-        def get_current_parameters(module_var):
-            params_dict = module_var.var_getattr(tx, "_parameters").realize().items
-            assert isinstance(params_dict, dict)
-            params_list = list(params_dict.values())
-            params_list = [param.realize() for param in params_list]
-            # Account for mod.param = None
-            params_list = [
-                param
-                for param in params_list
-                if isinstance(param, variables.TensorVariable)
-            ]
-            return params_list
-
-        def collect_parameters(module_var, recurse):
-            params_list = []
-            assert isinstance(module_var, UnspecializedNNModuleVariable)
-            params_list = get_current_parameters(module_var)
-            modules_dict = module_var.var_getattr(tx, "_modules").realize()
-            if recurse:
-                for submodule_var in modules_dict.items.values():
-                    assert isinstance(submodule_var, UnspecializedNNModuleVariable)
-                    params_list.extend(collect_parameters(submodule_var, recurse))
-            return params_list
-
-        if method is torch.nn.Module.parameters:
-            if self.source:
-                tx.output.guard_on_key_order.add(
-                    AttrSource(self.source, "_parameters").name()
-                )
-            recurse = get_kwargs("recurse")["recurse"]
-            params_list = collect_parameters(self, recurse=recurse)
-
-            # Account for duplicated params
-            deduplicated_params = list(dict.fromkeys(params_list).keys())
-
-            return variables.ListIteratorVariable(
-                deduplicated_params, mutation_type=ValueMutationNew()
-            )
-        else:
-            raise AssertionError(
-                "Discrepancy between is_supported_nn_module_method and trace_supported_methods"
-            )
-
     def call_method(
         self,
         tx,
@@ -994,9 +938,6 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
                 method = inspect.getattr_static(type(self.value), name)
             except AttributeError:
                 method = None
-
-            if self.is_supported_nn_module_method(method):
-                return self.trace_supported_methods(tx, method, name, args, kwargs)
 
             if isinstance(method, staticmethod):
                 source = AttrSource(

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1011,13 +1011,6 @@ class UserDefinedObjectVariable(UserDefinedVariable):
 
         return key in self.value.__dict__
 
-    def is_supported_nn_module_method(self, method):
-        if not torch._dynamo.config.inline_inbuilt_nn_modules:
-            return False
-        if method is not torch.nn.Module.parameters:
-            return False
-        return istype(self.value._parameters, dict)
-
     def get_source_by_walking_mro(self, name):
         assert self.cls_source is not None
 
@@ -1154,9 +1147,6 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             isinstance(subobj, types.MethodType)
             and isinstance(self.value, torch.nn.Module)
         ):
-            if self.is_supported_nn_module_method(subobj):
-                return variables.GetAttrVariable(self, name, source=source)
-
             # Since we get subobj via self._getattr_static, which may not trigger dynamic lookup.
             # Static lookup can't tell us it's a method or function correctly,
             # so we trigger dynamic lookup here to get the correct type.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #141214
* __->__ #141209

This was done to reduce compile time ealier, but I have seen two cases in past
month where this code falters, one from the user empathy day -
https://docs.google.com/document/d/1nEX1GtKhNzid6NvNg5CaVamO6JrJoKPuJ2iueWUYFWc/edit?tab=t.0

So removing this code. It can affect compile time for a few models by a
few seconds, but its way less code to maintain.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames