### PR TITLE
Extend optimized summation in dynamic tracing to support a constant multipled with each symbol (c*s0 + c*s1 +...)

### DIFF
--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -89,6 +89,44 @@ __all__ = [
 ]
 
 
+# Return (c,symbol) for an expression of form c*symbol, note that symbol is seen as 1*symbol.
+# Return none if the expression is not symbol or c*symbol.
+def is_mult_const_symbol(expr):
+    if expr.is_symbol:
+        return (1, expr)
+    if (
+        expr.is_Mul
+        and len(expr._args) == 2
+        and expr._args[0].is_integer
+        and expr._args[1].is_symbol
+    ):
+        return (expr._args[0], expr._args[1])
+    return None
+
+
+# A base binary summation is of the form c*a + c*b or a+b,  where a!=b.
+# If the expression is not base binary summation return None else return c.
+# For a+b case c is considered to be 1.
+def _is_base_binary_summation(expr: sympy.Expr) -> Optional[int]:
+    if not expr.is_Add:
+        return None
+
+    if len(expr._args) != 2:
+        return None
+
+    side1 = is_mult_const_symbol(expr._args[0])
+    if side1 is None:
+        return None
+
+    side2 = is_mult_const_symbol(expr._args[1])
+    if side2 is None:
+        return None
+
+    if side1[0] != side2[0] or side1[1] == side2[1]:
+        return None
+    return side1[0]
+
+
 def _is_symbols_binary_summation(expr: sympy.Expr) -> bool:
     # No need to check that two args are not the same, since expr is pr-optimized but we do it anyway.
     return (


### PR DESCRIPTION
177s to 161s @2k nodes.

    We have a Custom optimization for Add used to optimize incremental binary summations of certain properties. The idea
    is when we know the expression is a summation of unique symbols each multiplied with the same constant, then 
    all we need to know is the correct order of terms, and no other optimizations are needed. We pass evaluate=false,
    with the correct order of args and save the following costs:
    1. Avoid running other optimizations when the Add is constructed.
    2. Manually figure out the order of the args for the new expression in log(n) comparisons instead of nLog(n)
    (comparing terms is expensive and shows in the profiles).
    For example if we have (10*a+10*b) +10*c, then we can construct add(10*a+10*b+10*c, evaluate=False) 
    
    The reason we assert all terms are multiplied with the same constant as opposed to each multiplied with
    any constant is the following. Consider (4*a + 3*b) + 10*a, to figure out if we a is not in the lhs we need
    to iterate over all the terms. But for the restricted case (4*a + 4*b) + 4*a a binary search is sufficient
    since there can only be one terms that have a which is 4*a if it exists.
   

Differential Revision: D66210321




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @ezyang @SherlockNoMad @EikanWang @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames