### PR TITLE
Fix grammar and punctuation in shared memory usage note

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ You can also pull a pre-built docker image from Docker Hub and run with docker v
 docker run --gpus all --rm -ti --ipc=host pytorch/pytorch:latest
 ```
 
-Please note that PyTorch uses shared memory to share data between processes, so if torch multiprocessing is used (e.g.
+Please note that PyTorch uses shared memory to share data between processes, so if torch multiprocessing is used (e.g.,
 for multithreaded data loaders) the default shared memory segment size that container runs with is not enough, and you
 should increase shared memory size either with `--ipc=host` or `--shm-size` command line options to `nvidia-docker run`.
 


### PR DESCRIPTION
Corrected a grammatical error in the documentation. Added a comma after "e.g." in the sentence: "Please note that PyTorch uses shared memory to share data between processes, so if torch multiprocessing is used (e.g. for multithreaded data loaders)" to read: "Please note that PyTorch uses shared memory to share data between processes, so if torch multiprocessing is used (e.g., for multithreaded data loaders)."

