### PR TITLE
[c10] Fix static_assert for 32-bit systems

### DIFF
--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -76,11 +76,18 @@ class C10_API Scalar {
       "int64_t is the same as long long on Windows");
   Scalar(long vv) : Scalar(vv, true) {}
 #endif
-#if defined(__linux__) && !defined(__ANDROID__)
+#if defined(__linux__) 
+#if INTPTR_MAX == INT32_MAX // 32-bit linux
+  // Should a different constructor declaration be here?
+
+#elif INTPTR_MAX == INT64_MAX // 64 bit linux
   static_assert(
       std::is_same_v<long, int64_t>,
-      "int64_t is the same as long on Linux");
+      "int64_t is the same as long on 64 bit Linux");
   Scalar(long long vv) : Scalar(vv, true) {}
+#else
+    #error "CPU Architecture is neither 32 nor 64 bit?"
+#endif
 #endif
 
   Scalar(uint16_t vv) : Scalar(vv, true) {}

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -76,18 +76,11 @@ class C10_API Scalar {
       "int64_t is the same as long long on Windows");
   Scalar(long vv) : Scalar(vv, true) {}
 #endif
-#if defined(__linux__) 
-#if INTPTR_MAX == INT32_MAX // 32-bit linux
-  // Should a different constructor declaration be here?
-
-#elif INTPTR_MAX == INT64_MAX // 64 bit linux
+#if defined(__linux__) && !defined(__ANDROID__)
   static_assert(
-      std::is_same_v<long, int64_t>,
+      sizeof(void*) == 4 || std::is_same_v<long, int64_t>,
       "int64_t is the same as long on 64 bit Linux");
   Scalar(long long vv) : Scalar(vv, true) {}
-#else
-    #error "CPU Architecture is neither 32 nor 64 bit?"
-#endif
 #endif
 
   Scalar(uint16_t vv) : Scalar(vv, true) {}

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -78,7 +78,7 @@ class C10_API Scalar {
 #endif
 #if defined(__linux__) && !defined(__ANDROID__)
   static_assert(
-      sizeof(void*) == 4 || std::is_same_v<long, int64_t>,
+      sizeof(void*) != 8 || std::is_same_v<long, int64_t>,
       "int64_t is the same as long on 64 bit Linux");
   Scalar(long long vv) : Scalar(vv, true) {}
 #endif


### PR DESCRIPTION
the `__ANDROID__` macro was used as a proxy to check whether compilation is targeting a 32 or 64 bit system, causing build failure on non-android 32 bit linux targets like arm v7. 

This modification adjusts the check to fail if and only if int64_t and long and not the same on 64-bit systems, on systems where `sizeof(void*) == 8`

Like I said in the issue #141043 , I'm not sure whether a different `Scalar` constructor should be defined in the 32 bit case. My code does not break but I'm not sure other people's code won't.

Fixes #141043 
