### PR TITLE
[torch][ao] Do no crash numerics debugger if the shape of the tensors do not match

### DIFF
--- a/torch/ao/quantization/pt2e/_numeric_debugger.py
+++ b/torch/ao/quantization/pt2e/_numeric_debugger.py
@@ -274,10 +274,16 @@ def compare_results(
             )
             continue
         actual_name, actual_stack, actual_stats = actual_results[debug_handle]
+        for a, b in zip(actual_stats, ref_stats):
+            if a.shape != b.shape:
+                log.warning(
+                    f"Cannot compare tensors with different shapes: actual={a.shape} vs ref={b.shape}"
+                )
         try:
             results = [
                 QuantizationComparisonResult(actual=a, ref=b)
                 for a, b in zip(actual_stats, ref_stats)
+                if a.shape == b.shape
             ]
         except Exception as e:
             # Add extra information for an exception from QuantizationComparisonResult


### PR DESCRIPTION
Summary: Occasionally we see the loss function to crash because the shapes of `a` and `b` tensors are different. This diff avoids crashing is such scenarios and lets the comparison work for other nodes where the shapes match.

Test Plan: - CI

Reviewed By: dulinriley

Differential Revision: D66245053


