### PR TITLE
Try to simplify FloorDiv axioms implications when needed during evaluations.

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -44,6 +44,7 @@ from torch.testing._internal.common_utils import (
 from torch.utils import _pytree as pytree
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._sympy.functions import (
+    CleanDiv,
     FloorDiv,
     IsNonOverlappingAndDenseIndicator,
     Mod,
@@ -921,6 +922,30 @@ def forward(self, x_1):
         _a = sympy.Symbol("_a")
         args = _binary_search_insert_arg(args, _a)
         self.assertEqual(args, [_a, a, a1, a2, b, c, c1])
+
+    def test_floor_clean_div_axioms(self):
+        # Test that if we add an axiom that have FloorDiv, after which the
+        # shapeEnv changed such that it can be simplified it to CleanDiv, then
+        # We still correctly replace CleanDiv with the axiom value of FloorDiv.
+        shape_env = ShapeEnv()
+        a = shape_env.create_unbacked_symint()
+
+        shape_env.defer_runtime_assert((a // 3 == 1).node.expr, " test")
+
+        from sympy import Eq
+
+        test1 = Eq(FloorDiv(a.node.expr, 3), 1)
+        test2 = Eq(CleanDiv(a.node.expr, 3), 1)
+
+        self.assertTrue(shape_env.evaluate_expr(test1))
+        self.assertEqual(shape_env._maybe_evaluate_static(test2), None)
+
+        # After this FloorDiv(a, 3) is simplified to CleanDiv(a, 3)
+        shape_env.defer_runtime_assert(Eq(Mod(a, 3), 0), " test")
+        self.assertEqual(test2, shape_env.simplify(test1))
+
+        self.assertTrue(shape_env.evaluate_expr(test1))
+        self.assertTrue(shape_env.evaluate_expr(test2))
 
     def test_sympy_optimized_add(self):
         shape_env = ShapeEnv()

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3174,6 +3174,9 @@ class ShapeEnv:
         self._prev_cache_key = self._get_key()
         self._version_counter = 0
 
+        # Each time divisible is changed this should be set to True, this is set in _update_version_counter.
+        self._resimplify_floor_div_axioms = True
+
         # Cache for FX nodes.
         # Maps an already built node a tuple of:
         #   1. node's target
@@ -3287,6 +3290,7 @@ class ShapeEnv:
             # source locations are OK to diverge
             "var_to_range_sloc",
             "replacements_slocs",
+            "_resimplify_floor_div_axioms",
         )
 
         # Mapping of the value of each to-be-compared field into the values that
@@ -3620,7 +3624,7 @@ class ShapeEnv:
         """Context manager to ignore all guards generated inside"""
         return _suppress_guards(self)
 
-    def _get_key(self) -> object:
+    def _get_key(self) -> Tuple[int, int, int, int]:
         """
         Defines the current "state" of the guards we've accumulated in this ShapeEnv.
         Determines when we need to invalidate our cache
@@ -3633,12 +3637,20 @@ class ShapeEnv:
         )
 
     def _update_version_counter(self) -> None:
+        # if the change to shape env effects self.divisible set
+        # _resimplify_floor_div_axioms.
+        # This is used to trigger a resimplication of FloorDiv to CleanDivs
+        # in implication inside the function resimplify_floor_div.
+        if len(self.divisible) != self._prev_cache_key[1]:
+            self._resimplify_floor_div_axioms = True
+
         # The shape environment is queried orders of magnitude more often than
         # it is changed, so we summarise the cache key into a linearly
         # increasing version counter which is cheaper to check in _lru_cache
 
         # Only update version counter if the state actually changed
         cur_key = self._get_key()
+
         if self._prev_cache_key != cur_key:
             self._prev_cache_key = cur_key
             self._version_counter += 1
@@ -5391,7 +5403,6 @@ class ShapeEnv:
 
         # axioms with compute hint NYE
         assert not compute_hint or not axioms
-
         expr = self.simplify(expr)
 
         if compute_hint:
@@ -5399,14 +5410,32 @@ class ShapeEnv:
 
         expr = canonicalize_bool_expr(expr)
 
+        def resimplify_floor_div(axioms: Dict[sympy.Expr, sympy.Expr]) -> None:
+            if not self._resimplify_floor_div_axioms:
+                return
+            self._resimplify_floor_div_axioms = False
+            new_items = {}
+            for k, v in axioms.items():
+                # A FloorDiv in implications could have became CleanDiv at this point, due to new facts
+                # to the shapeEnv. This handles such issue but its not ideal. This is the only expression
+                # simplification that depends on the global state of shape env.
+                # TODO try to get rid of CleanDiv since it breaks the invariant thats simplifications of sympy
+                # expressions only depend on the expression itself.
+                if k.has(FloorDiv):
+                    new_items.update({self.simplify(k): v})
+            axioms.update(new_items)
+
         # Pattern matching
         if axioms is None:
+            resimplify_floor_div(self.axioms)
             subst = self.axioms
         else:
             subst = {}
             for e in axioms:
                 if e.free_symbols.issubset(expr.free_symbols):
                     subst.update(dict(self.get_implications(self.simplify(e))))
+
+            resimplify_floor_div(subst)
 
         expr = expr.xreplace(subst)
         # TODO: compute hint might have gotten broken here


### PR DESCRIPTION
Summary:
This very much the same solution proposed by bobrenjc93 except that it restrict it to expressions and axioms that have FloorDiv, since those are the only ones that could have became CleanDiv. and the only one that can changes as shape env changes. 

This also does not break torchrec benchmarks, it might be worth it to know why the generalization of this does break the torchrec benchmarks, but we could just be hitting another bug or NYI situation.

ovearhead?
None on
```
buck2 run fbcode//mode/opt fbcode//torchrec/distributed/tests:pt2_compile_benchmark -- --num-features=1000
```

Differential Revision: D66307433




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames