### PR TITLE
[SDPA][CUDA] resync sm90+ priority order for SDPA with `test_export.py`

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -9580,7 +9580,8 @@ def forward(self, q, k, v):
     _scaled_dot_product_flash_attention = torch.ops.aten._scaled_dot_product_flash_attention.default(q, k, v, 0.0, True, scale = 0.125);  q = k = v = None
     getitem = _scaled_dot_product_flash_attention[0];  _scaled_dot_product_flash_attention = None
     return (getitem,)"""
-        if SM90OrLater and not torch.version.hip:
+        # TODO(eqy): this needs to stay in sync with default SDPA priority order
+        if (False and SM90OrLater) and not torch.version.hip:
             code_str = """\
 def forward(self, q, k, v):
     _scaled_dot_product_cudnn_attention = torch.ops.aten._scaled_dot_product_cudnn_attention.default(q, k, v, None, False, 0.0, True);  q = k = v = None


### PR DESCRIPTION
Since we deprioritized cuDNN SDPA, this test fails on `sm90+`. This PR just changes the expected backend for now.

cc @csarofeen @ptrblck @xwang233 @drisspg @mikaylagawarecki