### PR TITLE
Revert "[dynamo] Added cuda and triton versions to dynamo_compile"

### DIFF
--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -201,8 +201,6 @@ class TestDynamoTimed(TestCase):
             e.co_filename = None
             e.co_firstlineno = None
             e.inductor_config = None
-            e.cuda_version = None
-            e.triton_version = None
 
         # First event is for the forward. Formatting makes reading diffs
         # much easier.
@@ -223,7 +221,6 @@ class TestDynamoTimed(TestCase):
  'config_inline_inbuilt_nn_modules': False,
  'config_suppress_errors': False,
  'cuda_synchronize_time_us': None,
- 'cuda_version': None,
  'distributed_ephemeral_timeout_us': None,
  'duration_us': 0,
  'dynamo_compile_time_before_restart_us': 0,
@@ -267,8 +264,7 @@ class TestDynamoTimed(TestCase):
  'start_time_us': 100,
  'structured_logging_overhead_s': 0.0,
  'structured_logging_overhead_us': 0,
- 'triton_compile_time_us': None,
- 'triton_version': None}""",  # noqa: B950
+ 'triton_compile_time_us': None}""",  # noqa: B950
         )
 
         # Second event is for the backward
@@ -289,7 +285,6 @@ class TestDynamoTimed(TestCase):
  'config_inline_inbuilt_nn_modules': None,
  'config_suppress_errors': None,
  'cuda_synchronize_time_us': None,
- 'cuda_version': None,
  'distributed_ephemeral_timeout_us': None,
  'duration_us': 0,
  'dynamo_compile_time_before_restart_us': None,
@@ -333,8 +328,7 @@ class TestDynamoTimed(TestCase):
  'start_time_us': 100,
  'structured_logging_overhead_s': None,
  'structured_logging_overhead_us': 0,
- 'triton_compile_time_us': None,
- 'triton_version': None}""",  # noqa: B950
+ 'triton_compile_time_us': None}""",  # noqa: B950
         )
 
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -864,8 +864,6 @@ class CompilationMetrics:
     joint_graph_pass_time_us: Optional[int] = None
     log_format_version: int = LOG_FORMAT_VERSION
     inductor_config: Optional[str] = None
-    cuda_version: Optional[str] = None
-    triton_version: Optional[str] = None
 
 
 DEFAULT_COMPILATION_METRICS_LIMIT = 64
@@ -965,8 +963,6 @@ def record_compilation_metrics(metrics: Dict[str, Any]):
 
     common_metrics = {
         "inductor_config": _scrubbed_inductor_config_for_logging(),
-        "cuda_version": torch.version.cuda,
-        "triton_version": triton.__version__ if has_triton() else "",
         # -------- Any future common metircs go here --------
         #
         # Legacy metircs go here(TODO: Temporary; populate legacy fields from their replacements.)


### PR DESCRIPTION
Reverts pytorch/pytorch#141140

reason: conflicts with https://github.com/pytorch/pytorch/pull/141190 and wasn't merged using mergebot

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames