### PR TITLE
[ca] dead code elimination for compile time

### DIFF
--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -4,8 +4,6 @@ import functools
 import operator
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
-from ordered_set import OrderedSet
-
 import torch
 from torch._dynamo.external_utils import (
     call_backward,
@@ -30,6 +28,7 @@ from torch.fx.experimental.proxy_tensor import (
 )
 from torch.fx.experimental.symbolic_shapes import DimDynamic, ShapeEnv
 from torch.fx.traceback import preserve_node_meta, set_stack_trace
+from torch.utils._ordered_set import OrderedSet
 from torch.utils._traceback import CapturedTraceback
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141289
* #141153
* #141152

Although these nodes are eventually inlined away, they increase compile time, especially when initial CA graph capture treats all shapes as dynamic

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @yf225