### PR TITLE
remote_cache: Add a waitcounter for gets and sets

### DIFF
--- a/torch/_inductor/remote_cache.py
+++ b/torch/_inductor/remote_cache.py
@@ -14,8 +14,8 @@ from typing import Any, Callable, Dict, Generic, List, Optional, Type, TypeVar, 
 from typing_extensions import override, TypeAlias
 
 from torch._dynamo.utils import dynamo_timed
-from torch.monitor import _WaitCounter
 from torch._inductor import config
+from torch.monitor import _WaitCounter
 
 
 try:

--- a/torch/_inductor/remote_cache.py
+++ b/torch/_inductor/remote_cache.py
@@ -178,7 +178,7 @@ class RemoteCache(Generic[_T]):
     # valid value even if _T supports it (because you can't tell the difference
     # between `None` and a missing cache entry).
     def put(self, key: str, value: _T) -> None:
-        with _WaitCounter("pytorch.remote_cache.put"):
+        with _WaitCounter("pytorch.remote_cache.put").guard():
             assert value is not None
             sample = self._create_sample()
             try:

--- a/torch/_inductor/remote_cache.py
+++ b/torch/_inductor/remote_cache.py
@@ -163,7 +163,7 @@ class RemoteCache(Generic[_T]):
     # See if the cache contains `key`. Returns `None` if the value is not
     # present in the cache.
     def get(self, key: str) -> Optional[_T]:
-        with _WaitCounter("pytorch.remote_cache.get"):
+        with _WaitCounter("pytorch.remote_cache.get").guard():
             sample = self._create_sample()
             try:
                 result = self._get(key, sample)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141307

This adds a basic waitcounter to help show if we're spending a lot of
time doing gets and sets to remote caches

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov