### PR TITLE
[inductor] Add missing get_reads() method

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4472,6 +4472,9 @@ class InputsKernel(OperationBuffer):
             index_exprs=OrderedSet(),
         )
 
+    def get_reads(self) -> OrderedSet[Dep]:
+        return self.get_read_writes().reads
+
     @classmethod
     def unwrap_storage_for_input(cls, x):  # type: ignore[no-untyped-def]
         if isinstance(x, TensorBox):
@@ -4515,6 +4518,9 @@ class InputsKernel(OperationBuffer):
 class NopKernel(InputsKernel):
     def is_no_op(self) -> bool:
         return True
+
+    def get_reads(self) -> OrderedSet[Dep]:
+        return OrderedSet()
 
 
 class ConcatKernel(NopKernel):


### PR DESCRIPTION
Summary: This is a possible fix for https://fb.workplace.com/groups/1075192433118967/permalink/794017756161443/

Test Plan:
```
buck2 test 'fbcode//mode/opt' fbcode//ai_infra/distributed_ai/pyper_test_framework/pt2_staging_tests/sw_v2:smallworld_cmf_test -- --exact 'ai_infra/distributed_ai/pyper_test_framework/pt2_staging_tests/sw_v2:smallworld_cmf_test - test_train (ai_infra.distributed_ai.pyper_test_framework.pt2_staging_tests.sw_v2.smallworld_cmf_test.CmfTest)'
```

Differential Revision: D66340927




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov