### PR TITLE
[PT2] Fix callbacks to account for entire execution in compilation

### DIFF
--- a/torch/_dynamo/callback.py
+++ b/torch/_dynamo/callback.py
@@ -1,5 +1,6 @@
+from contextlib import contextmanager
 from dataclasses import dataclass, field  # noqa: F811
-from typing import Callable, List
+from typing import Any, Callable, Generator, List
 
 
 @dataclass
@@ -60,6 +61,17 @@ class CompilationCallbackHandler:
         """
         for callback in self.end_callbacks:
             callback()
+
+    @contextmanager
+    def install_callbacks(self) -> Generator[None, Any, Any]:
+        """
+        Context manager to install the callbacks and run them when the context is exited.
+        """
+        try:
+            self.run_start_callbacks()
+            yield
+        finally:
+            self.run_end_callbacks()
 
     def clear(self) -> None:
         """

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -713,6 +713,7 @@ def _compile(
             stack.enter_context(
                 _WaitCounter("pytorch.wait_counter.dynamo_compile").guard()
             )
+            stack.enter_context(torch._dynamo.callback_handler.install_callbacks())
             stack.enter_context(CompileTimeInstructionCounter.record())
             return _compile_inner(code, one_graph, hooks, transform)
 
@@ -892,7 +893,6 @@ def _compile(
             distributed_state = DistributedState(compile_pg, LocalState())
         else:
             distributed_state = None
-        torch._dynamo.callback_handler.run_start_callbacks()
 
         # Check recompilations
         recompile_reasons = None
@@ -1165,7 +1165,6 @@ def _compile(
             chromium_event_log.log_event_end(
                 "dynamo", time.time_ns(), {}, chromium_start_time, True
             )
-            torch._dynamo.callback_handler.run_end_callbacks()
             # === END WARNING WARNING WARNING ===
 
 


### PR DESCRIPTION
Summary:
In SJD, we register the callbacks to get notified of an active compilation. Using this information, we can basically allow for an increase time for the training loop

The callbacks currently do not account for entire time and in several cases, the end callback is not called at all.

This leads to a bunch of APS jobs getting terminated incorrectly: https://fburl.com/scuba/mast_hpc_job_run_status/ondwzt2w

In this diff, we basically install a context manager which will call the start and end callbacks, similar to how we log counters and other information.

Test Plan:
```
buck2 run mode/opt //aps_models/examples/dlrm:dlrm_train_app -- --config-name train_mast_fsdp_torchdynamo launcher.data_project=apf_ai_infra launcher.fbl_entitlement=ai_infra_training_rnd_tc  launcher.hardware=TC_ANY_80G
```
Led to https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-atuljangra-ef2285ba9a?job_attempt=0&version=0&env=prod


https://fburl.com/ai_infra/sv0a213y confirms that callback was correctly called and a lease was properly installed, which takes over the training loop lease.

{F1965137027}

Differential Revision: D66347023




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames