### PR TITLE
Add torch.cat tensors type promotion description

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -2301,10 +2301,6 @@ Args:
 Keyword args:
     {out}
 
-.. note:: It is recommended to keep all `tensors` in the same dtype to avoid unintended type promotion.
-          For example, mixing `torch.int32` and `torch.int64` may result in the output being automatically
-          promoted to `torch.int64`.
-
 Example::
 
     >>> x = torch.randn(2, 3)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -2293,13 +2293,17 @@ and :func:`torch.chunk`.
     :func:`torch.stack` concatenates the given sequence along a new dimension.
 
 Args:
-    tensors (sequence of Tensors): any python sequence of tensors of the same type.
-        Non-empty tensors provided must have the same shape, except in the
-        cat dimension.
+    tensors (sequence of Tensors): Non-empty tensors provided must have the same shape,
+        except in the cat dimension.
+
     dim (int, optional): the dimension over which the tensors are concatenated
 
 Keyword args:
     {out}
+
+.. note:: It is recommended to keep all `tensors` in the same dtype to avoid unintended type promotion.
+          For example, mixing `torch.int32` and `torch.int64` may result in the output being automatically
+          promoted to `torch.int64`.
 
 Example::
 


### PR DESCRIPTION
Fixes #126964

Add note description about type promotion of `torch.cat`

**Test Result**

**Before**
![image](https://github.com/user-attachments/assets/2449f11b-48ed-406e-b73e-6d00f8eadb00)


**After**
![image](https://github.com/user-attachments/assets/cba99572-e8b1-4b9c-ba95-a963b54859ba)

cc @albanD @svekars 

