### PR TITLE
Fix typo in Reproducibility docs

### DIFF
--- a/docs/source/notes/randomness.rst
+++ b/docs/source/notes/randomness.rst
@@ -153,8 +153,8 @@ because the output will be nondeterministic. But there is nothing to actually
 prevent such invalid code from being run. So for safety,
 :attr:`torch.utils.deterministic.fill_uninitialized_memory` is set to ``True``
 by default, which will fill the uninitialized memory with a known value if
-:code:`torch.use_deterministic_algorithms(True)` is set. This will to prevent
-the possibility of this kind of nondeterministic behavior.
+:code:`torch.use_deterministic_algorithms(True)` is set. This will prevent the
+possibility of this kind of nondeterministic behavior.
 
 However, filling uninitialized memory is detrimental to performance. So if your
 program is valid and does not use uninitialized memory as the input to an


### PR DESCRIPTION
Fixes trivial issue in the docs.

cc @svekars @brycebortree @sekyondaMeta @AlannaBurke