### PR TITLE
Add torch distributed warning to `cuda.get_rng_state()`

### DIFF
--- a/torch/cuda/random.py
+++ b/torch/cuda/random.py
@@ -29,6 +29,11 @@ def get_rng_state(device: Union[int, str, torch.device] = "cuda") -> Tensor:
 
     .. warning::
         This function eagerly initializes CUDA.
+
+    .. warning::
+        The RNG state(s) returned by this function are only applicable to the local process.
+        In a torch distributed context, ``get_rng_state(...)`` should be used in conjunction
+        with distributed collectives to copy RNG state across processes.
     """
     _lazy_init()
     if isinstance(device, str):


### PR DESCRIPTION
I did not realize that `torch.cuda.get_rng_state(1)` would return two different tensors on rank 0 && rank 1 in a torch distributed context with 2 GPUs.

```python
import torch
import torch.distributed as dist

# Init distributed w/ at least 2 GPUs.
dist.init_process_group('nccl')
torch.cuda.set_device(r := dist.get_rank())
assert torch.cuda.device_count() > 1

# Show the RNG state of GPU0 (is different on different ranks)
print(torch.cuda.get_rng_state(0).sum())
dist.destroy_process_group()
'''
# torchrun --nproc-per-node 2 a.py
tensor(787)
tensor(671)
'''
```

This should assist other users in avoiding the same mistake.

