### PR TITLE
[sympy] Make solve of Mul for Eq int replacement friendly

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -1862,6 +1862,18 @@ class GraphModule(torch.nn.Module):
 
         fn(torch.ones(4), x, torch.ones(4))
 
+    @parametrize("dynamic", [False, True])
+    def test_ephemeral_source_symbol_evaporates_with_slice_view(self, dynamic):
+        # See https://github.com/pytorch/pytorch/pull/133337#issuecomment-2302417084
+        @torch.compile(backend="eager", dynamic=dynamic)
+        def f(t):
+            return t._base + 1
+
+        x_a = torch.randn(4, 4, requires_grad=True)
+        x = TwoTensor(x_a, x_a.clone())
+        out = f(x[3])
+        self.assertEqual(out.shape, x_a.shape)
+
     # copied from common_utils.py::NestedTensorTestCase
     def assertEqualIgnoringNestedInts(self, a, b):
         # unbinding NJTs allows us to compare them as essentially equal without

--- a/torch/utils/_sympy/solve.py
+++ b/torch/utils/_sympy/solve.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Tuple, Type
 
 import sympy
 
-from torch.utils._sympy.functions import FloorDiv
+from torch.utils._sympy.functions import CleanDiv, FloorDiv
 
 
 log = logging.getLogger(__name__)
@@ -120,8 +120,15 @@ def _try_isolate_lhs(
             not isinstance(e, INEQUALITY_TYPES) and rhs.is_zero
         ):
             # Divide both sides by 'other'.
-            lhs = lhs / other
-            rhs = rhs / other
+            if isinstance(e, sympy.Eq) and rhs.is_integer and other.is_integer:
+                # If we have an equality and both sides are integers,
+                # the division of rhs by other is integer.
+                # Use CleanDiv to allow int replacements lhs -> rhs / other.
+                lhs = CleanDiv(lhs, other)
+                rhs = CleanDiv(rhs, other)
+            else:
+                lhs = lhs / other
+                rhs = rhs / other
 
             # If 'e' is an inequality and 'other' is negative, we have to
             # mirror the expression.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141347

Iteration on Joel's PR with good explanation:
https://github.com/pytorch/pytorch/pull/135635

The original issue: 
https://github.com/pytorch/pytorch/pull/133337#issuecomment-2302417084

During NJT fakifikation we calculate view_from_base.

If we have slice of the tensor, the index is symint-fied as ephemeral symbol s2.
dynamic shapes knows s1 = s0 * s2
But originally `solve` will deduce `e = Eq(s2, s1/s0)`, and `e.is_integer == False`.

Adding branch, that if we know s1 = s0 * s2 and all of them are integers. Then use `CleanDiv` to instruct sympy that result is guranteed to be integer. And `is_integer==True` and replacement of ephmeral s2 happens.
```
python test/dynamo/test_subclasses.py -k test_ephemeral_source
```
Before: fails with error that ephemeral symint was not eliminated.
After: passes
cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames