### PR TITLE
Test cpp_wrapper_hipify string comparison

### DIFF
--- a/test/inductor/test_cpp_wrapper_hipify.py
+++ b/test/inductor/test_cpp_wrapper_hipify.py
@@ -110,7 +110,11 @@ class TestCppWrapperHipify(TestCase):
             }
         """
         if torch.version.hip is not None:
-            expected = expected.replace("32*numWarps", "64*numWarps")
+            # Adjusting the warp size to GPU supported wavefront size on AMD GPU
+            prop = torch.cuda.get_device_properties(torch.cuda.current_device())
+            source_codes = source_codes.replace(
+                "32*numWarps", str(prop.warp_size) + "*numWarps"
+            )
         result = maybe_hipify_code_wrapper(header, True)
         self.assertEqual(result.rstrip(), expected.rstrip())
 

--- a/test/inductor/test_cpp_wrapper_hipify.py
+++ b/test/inductor/test_cpp_wrapper_hipify.py
@@ -112,7 +112,7 @@ class TestCppWrapperHipify(TestCase):
         if torch.version.hip is not None:
             # Adjusting the warp size to GPU supported wavefront size on AMD GPU
             prop = torch.cuda.get_device_properties(torch.cuda.current_device())
-            source_codes = source_codes.replace(
+            expected = expected.replace(
                 "32*numWarps", str(prop.warp_size) + "*numWarps"
             )
         result = maybe_hipify_code_wrapper(header, True)


### PR DESCRIPTION
Updating the test to match this code that takes device warpsize into account: https://github.com/pytorch/pytorch/blob/cf1d95a965e419cfc3473996aecf50ee9e360a2e/torch/_inductor/codegen/cuda/device_op_overrides.py#L120

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov