### PR TITLE
Save models in OCI registry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ ninja
 packaging
 optree>=0.13.0
 cmake
+oras


### PR DESCRIPTION
Changes the save/load functions to allow users to save/load models from OCI registries.

Fixes #141350

This is a POC. Please, check the issue out for more context. If the project is interested adding this feature. I'm glad to add more tests, refine configuration options and check the `jit.save` and `jit.load` functions (if necessary)

cc @mruberry @mikaylagawarecki