### PR TITLE
[ca] attach compiled autograd to its compile id in tlparse

### DIFF
--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -374,6 +374,8 @@ class AutogradCompilerInstance:
         )
         compiled_autograd_log.info("%s", lazy_graph_code)
         verbose_log.debug("%s", lazy_graph_code)
+        # TODO: remove this
+        # still needed in case dynamo errors
         trace_structured(
             "compiled_autograd_graph",
             payload_fn=lambda: graph.print_readable(print_output=False),

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3363,7 +3363,7 @@ def get_compiled_autograd_metrics(maybe_gm):
     assert type(start) == type(end)
     if not start:
         return None
-    return start, end
+    return maybe_gm, start, end
 
 
 def set_compiled_autograd_metrics(gm, start_time, end_time):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #141408
* __->__ #141362
* #140964

This delays the tlparse for compiled autograd into the dynamo call for this corresponding compiled autograd graph. Not perfect, but is an improvement over not having the graphs bundled with their torch.compile artifacts.

It means a new file will be logged for the same CA graph every time dynamo recompiles. Currently to tell if you have a recompile or not, you'd have to click into the graph and look at the name of graph e.g. CompiledAutograd0 vs CompiledAutograd1. I'm thinking of also adding the CA id to the tlparse file name.

tlparse: https://interncache-all.fbcdn.net/manifold/tlparse_reports/tree/logs/.tmpKvl4hk/index.html


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @yf225