### PR TITLE
Add option to split Linear gates for Quantizable LSTM into separate ops

### DIFF
--- a/torch/ao/nn/quantizable/modules/rnn.py
+++ b/torch/ao/nn/quantizable/modules/rnn.py
@@ -21,6 +21,11 @@ class LSTMCell(torch.nn.Module):
 
     For the description and the argument types, please, refer to :class:`~torch.nn.LSTMCell`
 
+    `split_gates`: specify True to compute the input/forget/cell/output gates separately
+    to avoid an intermediate tensor which is subsequently chunk'd. This optimization can
+    be beneficial for on-device inference latency. This flag is cascaded down from the
+    parent classes.
+
     Examples::
 
         >>> import torch.ao.nn.quantizable as nnqa
@@ -34,6 +39,7 @@ class LSTMCell(torch.nn.Module):
         ...     output.append(hx)
     """
     _FLOAT_MODULE = torch.nn.LSTMCell
+    __constants__ = ["split_gates"]  # for jit.script
 
     def __init__(
         self,
@@ -42,20 +48,40 @@ class LSTMCell(torch.nn.Module):
         bias: bool = True,
         device=None,
         dtype=None,
+        *,
+        split_gates=False,
     ) -> None:
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
         self.input_size = input_dim
         self.hidden_size = hidden_dim
         self.bias = bias
+        self.split_gates = split_gates
 
-        self.igates = torch.nn.Linear(
-            input_dim, 4 * hidden_dim, bias=bias, **factory_kwargs
-        )
-        self.hgates = torch.nn.Linear(
-            hidden_dim, 4 * hidden_dim, bias=bias, **factory_kwargs
-        )
-        self.gates = torch.ao.nn.quantized.FloatFunctional()
+        if not split_gates:
+            self.igates: torch.nn.Module = torch.nn.Linear(
+                input_dim, 4 * hidden_dim, bias=bias, **factory_kwargs
+            )
+            self.hgates: torch.nn.Module = torch.nn.Linear(
+                hidden_dim, 4 * hidden_dim, bias=bias, **factory_kwargs
+            )
+            self.gates: torch.nn.Module = torch.ao.nn.quantized.FloatFunctional()
+        else:
+            # keep separate Linear layers for each gate
+            self.igates = torch.nn.ModuleDict()
+            self.hgates = torch.nn.ModuleDict()
+            self.gates = torch.nn.ModuleDict()
+            for g in ["input", "forget", "cell", "output"]:
+                # pyre-fixme[29]: `Union[torch._tensor.Tensor, torch.nn.modules.module.Module]`
+                self.igates[g] = torch.nn.Linear(
+                    input_dim, hidden_dim, bias=bias, **factory_kwargs
+                )
+                # pyre-fixme[29]: `Union[torch._tensor.Tensor, torch.nn.modules.module.Module]`
+                self.hgates[g] = torch.nn.Linear(
+                    hidden_dim, hidden_dim, bias=bias, **factory_kwargs
+                )
+                # pyre-fixme[29]: `Union[torch._tensor.Tensor, torch.nn.modules.module.Module]`
+                self.gates[g] = torch.ao.nn.quantized.FloatFunctional()
 
         self.input_gate = torch.nn.Sigmoid()
         self.forget_gate = torch.nn.Sigmoid()
@@ -80,16 +106,31 @@ class LSTMCell(torch.nn.Module):
             hidden = self.initialize_hidden(x.shape[0], x.is_quantized)
         hx, cx = hidden
 
-        igates = self.igates(x)
-        hgates = self.hgates(hx)
-        gates = self.gates.add(igates, hgates)
+        if not self.split_gates:
+            igates = self.igates(x)
+            hgates = self.hgates(hx)
+            gates = self.gates.add(igates, hgates)  # type: ignore[operator]
 
-        input_gate, forget_gate, cell_gate, out_gate = gates.chunk(4, 1)
+            input_gate, forget_gate, cell_gate, out_gate = gates.chunk(4, 1)
 
-        input_gate = self.input_gate(input_gate)
-        forget_gate = self.forget_gate(forget_gate)
-        cell_gate = self.cell_gate(cell_gate)
-        out_gate = self.output_gate(out_gate)
+            input_gate = self.input_gate(input_gate)
+            forget_gate = self.forget_gate(forget_gate)
+            cell_gate = self.cell_gate(cell_gate)
+            out_gate = self.output_gate(out_gate)
+        else:
+            # apply each input + hidden projection and add together
+            gate = {}
+            for (key, gates), igates, hgates in zip(
+                self.gates.items(),  # type: ignore[operator]
+                self.igates.values(),  # type: ignore[operator]
+                self.hgates.values(),  # type: ignore[operator]
+            ):
+                gate[key] = gates.add(igates(x), hgates(hx))
+
+            input_gate = self.input_gate(gate["input"])
+            forget_gate = self.forget_gate(gate["forget"])
+            cell_gate = self.cell_gate(gate["cell"])
+            out_gate = self.output_gate(gate["output"])
 
         fgate_cx = self.fgate_cx.mul(forget_gate, cx)
         igate_cgate = self.igate_cgate.mul(input_gate, cell_gate)
@@ -122,7 +163,7 @@ class LSTMCell(torch.nn.Module):
         return "QuantizableLSTMCell"
 
     @classmethod
-    def from_params(cls, wi, wh, bi=None, bh=None):
+    def from_params(cls, wi, wh, bi=None, bh=None, split_gates=False):
         """Uses the weights and biases to create a new LSTM cell.
 
         Args:
@@ -132,25 +173,52 @@ class LSTMCell(torch.nn.Module):
         assert (bi is None) == (bh is None)  # Either both None or both have values
         input_size = wi.shape[1]
         hidden_size = wh.shape[1]
-        cell = cls(input_dim=input_size, hidden_dim=hidden_size, bias=(bi is not None))
-        cell.igates.weight = torch.nn.Parameter(wi)
-        if bi is not None:
-            cell.igates.bias = torch.nn.Parameter(bi)
-        cell.hgates.weight = torch.nn.Parameter(wh)
-        if bh is not None:
-            cell.hgates.bias = torch.nn.Parameter(bh)
+        cell = cls(
+            input_dim=input_size,
+            hidden_dim=hidden_size,
+            bias=(bi is not None),
+            split_gates=split_gates,
+        )
+
+        if not split_gates:
+            cell.igates.weight = torch.nn.Parameter(wi)
+            if bi is not None:
+                cell.igates.bias = torch.nn.Parameter(bi)
+            cell.hgates.weight = torch.nn.Parameter(wh)
+            if bh is not None:
+                cell.hgates.bias = torch.nn.Parameter(bh)
+        else:
+            # split weight/bias
+            for w, b, gates in zip([wi, wh], [bi, bh], [cell.igates, cell.hgates]):
+                for w_chunk, gate in zip(w.chunk(4, dim=0), gates.values()):  # type: ignore[operator]
+                    gate.weight = torch.nn.Parameter(w_chunk)
+
+                if b is not None:
+                    for b_chunk, gate in zip(b.chunk(4, dim=0), gates.values()):  # type: ignore[operator]
+                        gate.bias = torch.nn.Parameter(b_chunk)
+
         return cell
 
     @classmethod
-    def from_float(cls, other, use_precomputed_fake_quant=False):
+    def from_float(cls, other, use_precomputed_fake_quant=False, split_gates=False):
         assert type(other) == cls._FLOAT_MODULE
         assert hasattr(other, "qconfig"), "The float module must have 'qconfig'"
         observed = cls.from_params(
-            other.weight_ih, other.weight_hh, other.bias_ih, other.bias_hh
+            other.weight_ih,
+            other.weight_hh,
+            other.bias_ih,
+            other.bias_hh,
+            split_gates=split_gates,
         )
         observed.qconfig = other.qconfig
         observed.igates.qconfig = other.qconfig
         observed.hgates.qconfig = other.qconfig
+        if split_gates:
+            # also apply qconfig directly to Linear modules
+            for g in observed.igates.values():
+                g.qconfig = other.qconfig
+            for g in observed.hgates.values():
+                g.qconfig = other.qconfig
         return observed
 
 
@@ -168,10 +236,14 @@ class _LSTMSingleLayer(torch.nn.Module):
         bias: bool = True,
         device=None,
         dtype=None,
+        *,
+        split_gates=False,
     ) -> None:
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
-        self.cell = LSTMCell(input_dim, hidden_dim, bias=bias, **factory_kwargs)
+        self.cell = LSTMCell(
+            input_dim, hidden_dim, bias=bias, split_gates=split_gates, **factory_kwargs
+        )
 
     def forward(self, x: Tensor, hidden: Optional[Tuple[Tensor, Tensor]] = None):
         result = []
@@ -185,7 +257,9 @@ class _LSTMSingleLayer(torch.nn.Module):
     @classmethod
     def from_params(cls, *args, **kwargs):
         cell = LSTMCell.from_params(*args, **kwargs)
-        layer = cls(cell.input_size, cell.hidden_size, cell.bias)
+        layer = cls(
+            cell.input_size, cell.hidden_size, cell.bias, split_gates=cell.split_gates
+        )
         layer.cell = cell
         return layer
 
@@ -202,17 +276,23 @@ class _LSTMLayer(torch.nn.Module):
         bidirectional: bool = False,
         device=None,
         dtype=None,
+        *,
+        split_gates=False,
     ) -> None:
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
         self.batch_first = batch_first
         self.bidirectional = bidirectional
         self.layer_fw = _LSTMSingleLayer(
-            input_dim, hidden_dim, bias=bias, **factory_kwargs
+            input_dim, hidden_dim, bias=bias, split_gates=split_gates, **factory_kwargs
         )
         if self.bidirectional:
             self.layer_bw = _LSTMSingleLayer(
-                input_dim, hidden_dim, bias=bias, **factory_kwargs
+                input_dim,
+                hidden_dim,
+                bias=bias,
+                split_gates=split_gates,
+                **factory_kwargs,
             )
 
     def forward(self, x: Tensor, hidden: Optional[Tuple[Tensor, Tensor]] = None):
@@ -283,22 +363,34 @@ class _LSTMLayer(torch.nn.Module):
         bias = kwargs.get("bias", other.bias)
         batch_first = kwargs.get("batch_first", other.batch_first)
         bidirectional = kwargs.get("bidirectional", other.bidirectional)
+        split_gates = kwargs.get("split_gates", False)
 
-        layer = cls(input_size, hidden_size, bias, batch_first, bidirectional)
+        layer = cls(
+            input_size,
+            hidden_size,
+            bias,
+            batch_first,
+            bidirectional,
+            split_gates=split_gates,
+        )
         layer.qconfig = getattr(other, "qconfig", qconfig)
         wi = getattr(other, f"weight_ih_l{layer_idx}")
         wh = getattr(other, f"weight_hh_l{layer_idx}")
         bi = getattr(other, f"bias_ih_l{layer_idx}", None)
         bh = getattr(other, f"bias_hh_l{layer_idx}", None)
 
-        layer.layer_fw = _LSTMSingleLayer.from_params(wi, wh, bi, bh)
+        layer.layer_fw = _LSTMSingleLayer.from_params(
+            wi, wh, bi, bh, split_gates=split_gates
+        )
 
         if other.bidirectional:
             wi = getattr(other, f"weight_ih_l{layer_idx}_reverse")
             wh = getattr(other, f"weight_hh_l{layer_idx}_reverse")
             bi = getattr(other, f"bias_ih_l{layer_idx}_reverse", None)
             bh = getattr(other, f"bias_hh_l{layer_idx}_reverse", None)
-            layer.layer_bw = _LSTMSingleLayer.from_params(wi, wh, bi, bh)
+            layer.layer_bw = _LSTMSingleLayer.from_params(
+                wi, wh, bi, bh, split_gates=split_gates
+            )
         return layer
 
 
@@ -342,6 +434,8 @@ class LSTM(torch.nn.Module):
         bidirectional: bool = False,
         device=None,
         dtype=None,
+        *,
+        split_gates: bool = False,
     ) -> None:
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
@@ -386,6 +480,7 @@ class LSTM(torch.nn.Module):
                 self.bias,
                 batch_first=False,
                 bidirectional=self.bidirectional,
+                split_gates=split_gates,
                 **factory_kwargs,
             )
         ]
@@ -396,6 +491,7 @@ class LSTM(torch.nn.Module):
                 self.bias,
                 batch_first=False,
                 bidirectional=self.bidirectional,
+                split_gates=split_gates,
                 **factory_kwargs,
             )
             for layer in range(1, num_layers)
@@ -461,7 +557,7 @@ class LSTM(torch.nn.Module):
         return "QuantizableLSTM"
 
     @classmethod
-    def from_float(cls, other, qconfig=None):
+    def from_float(cls, other, qconfig=None, split_gates=False):
         assert isinstance(other, cls._FLOAT_MODULE)
         assert hasattr(other, "qconfig") or qconfig
         observed = cls(
@@ -472,11 +568,12 @@ class LSTM(torch.nn.Module):
             other.batch_first,
             other.dropout,
             other.bidirectional,
+            split_gates=split_gates,
         )
         observed.qconfig = getattr(other, "qconfig", qconfig)
         for idx in range(other.num_layers):
             observed.layers[idx] = _LSTMLayer.from_float(
-                other, idx, qconfig, batch_first=False
+                other, idx, qconfig, batch_first=False, split_gates=split_gates
             )
 
         # Prepare the model

--- a/torch/ao/nn/quantized/modules/rnn.py
+++ b/torch/ao/nn/quantized/modules/rnn.py
@@ -49,7 +49,7 @@ class LSTM(torch.ao.nn.quantizable.LSTM):
 
     @classmethod
     def from_observed(cls, other):
-        assert type(other) == cls._FLOAT_MODULE  # type: ignore[has-type]
+        assert isinstance(other, cls._FLOAT_MODULE)
         converted = torch.ao.quantization.convert(
             other, inplace=False, remove_qconfig=True
         )

--- a/torch/ao/quantization/fx/lstm_utils.py
+++ b/torch/ao/quantization/fx/lstm_utils.py
@@ -25,6 +25,7 @@ def _get_lstm_with_individually_observed_parts(
     tanh_obs_ctr: Optional[_PartialWrapper] = None,
     cell_state_obs_ctr: Optional[_PartialWrapper] = None,
     hidden_state_obs_ctr: Optional[_PartialWrapper] = None,
+    split_gates: bool = False,
 ) -> torch.ao.nn.quantizable.LSTM:
     """
     Return an observed `torch.ao.nn.quantizable.LSTM` created from a `torch.nn.LSTM`
@@ -75,6 +76,7 @@ def _get_lstm_with_individually_observed_parts(
         float_lstm.batch_first,
         float_lstm.dropout,
         float_lstm.bidirectional,
+        split_gates=split_gates,
     )
     quantizable_lstm.qconfig = float_lstm.qconfig
 
@@ -82,7 +84,11 @@ def _get_lstm_with_individually_observed_parts(
         quantizable_lstm.layers[
             idx
         ] = torch.ao.nn.quantizable.modules.rnn._LSTMLayer.from_float(
-            float_lstm, idx, float_lstm.qconfig, batch_first=False
+            float_lstm,
+            idx,
+            float_lstm.qconfig,
+            batch_first=False,
+            split_gates=split_gates,
         )
 
     # Build QConfigMapping for the LSTM cell
@@ -105,13 +111,25 @@ def _get_lstm_with_individually_observed_parts(
         # to configure these ops in FX graph mode quantization today. This is because
         # the FloatFunctional modules simply disappear from the graph after tracing.
         # In the future, we should rewrite quantizable LSTM without FloatFunctionals.
-        op_index_to_activation_post_process_ctr = {
-            (torch.add, 0): linear_output_obs_ctr,  # gates.add
-            (torch.mul, 0): cell_state_obs_ctr,  # fgate_cx.mul
-            (torch.mul, 1): cell_state_obs_ctr,  # igate_cgate.mul
-            (torch.add, 1): cell_state_obs_ctr,  # fgate_cx_igate_cgate.add
-            (torch.mul, 2): hidden_state_obs_ctr,  # ogate_cy.mul
-        }
+        if not split_gates:
+            op_index_to_activation_post_process_ctr = {
+                (torch.add, 0): linear_output_obs_ctr,  # gates.add
+                (torch.mul, 0): cell_state_obs_ctr,  # fgate_cx.mul
+                (torch.mul, 1): cell_state_obs_ctr,  # igate_cgate.mul
+                (torch.add, 1): cell_state_obs_ctr,  # fgate_cx_igate_cgate.add
+                (torch.mul, 2): hidden_state_obs_ctr,  # ogate_cy.mul
+            }
+        else:
+            op_index_to_activation_post_process_ctr = {
+                (torch.add, 0): linear_output_obs_ctr,  # gates.add (input)
+                (torch.add, 1): linear_output_obs_ctr,  # gates.add (forget)
+                (torch.add, 2): linear_output_obs_ctr,  # gates.add (cell)
+                (torch.add, 3): linear_output_obs_ctr,  # gates.add (output)
+                (torch.mul, 0): cell_state_obs_ctr,  # fgate_cx.mul
+                (torch.mul, 1): cell_state_obs_ctr,  # igate_cgate.mul
+                (torch.add, 4): cell_state_obs_ctr,  # fgate_cx_igate_cgate.add
+                (torch.mul, 2): hidden_state_obs_ctr,  # ogate_cy.mul
+            }
         add_count = 0
         mul_count = 0
         for node in cell.graph.nodes:


### PR DESCRIPTION
Summary:
Reattempt to land D65283170

For LSTM, the input and hidden state are projected with Linear layers to construct the 4 gates. This is typically performed together as a single Linear (for each state) with output channel count `4 * hidden_dim` for efficiency.
https://www.internalfb.com/code/fbsource/[ebef7c4238aa55948b2b444044f2c8ed2040de55]/fbcode/caffe2/torch/ao/nn/quantizable/modules/rnn.py?lines=52-58
The output is then ultimately split into 4:
https://www.internalfb.com/code/fbsource/[ebef7c4238aa55948b2b444044f2c8ed2040de55]/fbcode/caffe2/torch/ao/nn/quantizable/modules/rnn.py?lines=83-87

For on-device latency (and possibly memory) considerations, we want to avoid constructing the intermediate `gates` tensor (which can be relatively large), by splitting `igates` and `hgates` first (as 4x `Linear(hidden_dim, hidden_dim)` each), applying add separately, then proceeding as usual.

This functionality can be enabled by specifying `split_gates=True` (default False is original behavior) at any entry point (directly with `torch.ao.nn.quantizable.LSTM`  or via `_get_lstm_with_individually_observed_parts`).

Test Plan:
piggy back on existing test to check for correct swap handling, numerics, and jit.script during prepare/convert
```
buck2 test 'fbcode//mode/opt' fbcode//caffe2/test/quantization:test_quantization -- --exact 'caffe2/test/quantization:test_quantization - test_custom_module_lstm (caffe2.test.quantization.core.test_quantized_op.TestQuantizedOps)'
```
https://www.internalfb.com/intern/testinfra/testrun/11540474102848372

This test is quite long running now (more than double original).

Differential Revision: D66380336




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv