### PR TITLE
add float8 types to LoggingTensor

### DIFF
--- a/torch/testing/_internal/logging_tensor.py
+++ b/torch/testing/_internal/logging_tensor.py
@@ -27,6 +27,10 @@ _dtype_abbrs = {
     torch.int64: "i64",
     torch.bool: "b8",
     torch.uint8: "u8",
+    torch.float8_e4m3fn: "f8e4m3fn",
+    torch.float8_e5m2: "f8e5m2",
+    torch.float8_e4m3fnuz: "f8e4m3fnuz",
+    torch.float8_e5m2fnuz: "f8e5m2fnuz",
 }
 
 # How the chain of calls works for LoggingTensor:


### PR DESCRIPTION
Summary:

float8 dtypes were missing from this map, adding

Test Plan:

CI, and unbreaks debugging in torchao

If there is an existing test I can add this to - lmk

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #ISSUE_NUMBER
