### PR TITLE
dynamo_timed: Add a log_waitcounter option.

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -364,10 +364,12 @@ def dynamo_timed(
     )
 
     try:
-        with torch.profiler.record_function(f"{key} (dynamo_timed)"), _WaitCounter(
-            f"pytorch.dynamo_timed.{key}"
-        ).guard():
-            yield
+        with torch.profiler.record_function(f"{key} (dynamo_timed)"):
+            if log_waitcounter:
+                with _WaitCounter(f"pytorch.dynamo_timed.{key}").guard():
+                    yield
+            else:
+                yield
     finally:
         end_ns = time.time_ns()
         time_spent_ns = end_ns - start_ns

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -82,10 +82,10 @@ from torch._utils_internal import (
     signpost_event,
 )
 from torch.fx._utils import _format_graph_code, lazy_format_graph_code
+from torch.monitor import _WaitCounter
 from torch.nn.modules.lazy import LazyModuleMixin
 from torch.utils._triton import has_triton, has_triton_package
 from torch.utils.hooks import RemovableHandle
-from torch.monitor import _WaitCounter
 
 
 try:
@@ -364,7 +364,9 @@ def dynamo_timed(
     )
 
     try:
-        with torch.profiler.record_function(f"{key} (dynamo_timed)"), _WaitCounter(f"pytorch.dynamo_timed.{key}").guard():
+        with torch.profiler.record_function(f"{key} (dynamo_timed)"), _WaitCounter(
+            f"pytorch.dynamo_timed.{key}"
+        ).guard():
             yield
     finally:
         end_ns = time.time_ns()

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -85,6 +85,7 @@ from torch.fx._utils import _format_graph_code, lazy_format_graph_code
 from torch.nn.modules.lazy import LazyModuleMixin
 from torch.utils._triton import has_triton, has_triton_package
 from torch.utils.hooks import RemovableHandle
+from torch.monitor import _WaitCounter
 
 
 try:
@@ -300,6 +301,7 @@ def dynamo_timed(
     log_pt2_compile_event: bool = False,
     metadata: Optional[Dict[str, object]] = None,
     dynamo_compile_column_us: Optional[str] = None,
+    log_waitcounter: bool = False,
 ) -> Generator[Any, None, None]:
     """
     dynamo_timed is a context manager
@@ -333,6 +335,7 @@ def dynamo_timed(
     - dynamo_compile_column_us: If provided, updates the specified CompilationMetrics
       field to be logged to dyname_compile column. We expect all columns to be _us;
       therefore, the field name must end with "_us".
+    - log_waitcounter: If set, we'll log a waitcounter of the form "pytorch.dynamo_timed.{key}"
     """
     # We're standardizing on microseconds for dynamo_compile timings.
     if dynamo_compile_column_us is not None:
@@ -361,7 +364,7 @@ def dynamo_timed(
     )
 
     try:
-        with torch.profiler.record_function(f"{key} (dynamo_timed)"):
+        with torch.profiler.record_function(f"{key} (dynamo_timed)"), _WaitCounter(f"pytorch.dynamo_timed.{key}").guard():
             yield
     finally:
         end_ns = time.time_ns()

--- a/torch/_inductor/remote_cache.py
+++ b/torch/_inductor/remote_cache.py
@@ -46,6 +46,7 @@ remote_fx_cache_get_timed = functools.partial(
     phase_name="remote_fx_graph_cache_get",
     log_pt2_compile_event=False,
     dynamo_compile_column_us="remote_fx_graph_cache_get_time_us",
+    log_waitcounter=True,
 )
 remote_fx_cache_put_timed = functools.partial(
     dynamo_timed,
@@ -53,6 +54,7 @@ remote_fx_cache_put_timed = functools.partial(
     phase_name="remote_fx_graph_cache_put",
     log_pt2_compile_event=False,
     dynamo_compile_column_us="remote_fx_graph_cache_put_time_us",
+    log_waitcounter=True,
 )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #141920
* __->__ #141402

This logs a waitcounter of the name pytorch.dynamo_timed.{key}.

Primarily sending this now to make sure everyone likes the API, then
I'll add tests, and migrate one dynamo_timed to use it. (likely starting
with
https://github.com/pytorch/pytorch/pull/141379).

Testing is a bit harder, since we don't normally have any way to read
_WaitCounter state AFAICT. I want to poke around and see if I can figure
out a way to read the state, otherwise I'll just mock it to at least
make sure it's mostly working.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov