### PR TITLE
Make computeStorageNbytes a bit more lazy, don't directly guard size oblivious

### DIFF
--- a/aten/src/ATen/EmptyTensor.cpp
+++ b/aten/src/ATen/EmptyTensor.cpp
@@ -152,11 +152,10 @@ SymInt computeStorageNbytes(
   // of the last element according to stride
   SymInt size = 1;
   for (const auto i : c10::irange(sizes.size())) {
-    if (TORCH_GUARD_SIZE_OBLIVIOUS(sizes[i].sym_eq(0))) {
+    if (definitely_true(sizes[i].sym_eq(0), __FILE__, __LINE__)) {
       return 0;
     }
-
-    size += strides[i] * (sizes[i] - 1);
+    size += strides[i] * (sizes[i] - 1).max(0);
   }
   return itemsize_bytes * (storage_offset + size);
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141418

Signed-off-by: Edward Z. Yang <ezyang@meta.com>