### PR TITLE
Back out "Add skip_first_wait to profiler.schedule"

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -2081,48 +2081,6 @@ assert KinetoStepTracker.current_step() == initial_step + 2 * niters
         else:
             os.waitpid(pid, 0)
 
-    @skipIfTorchDynamo("profiler gets ignored if dynamo activated")
-    def test_skip_first_wait(self):
-        # Other tests test when skip_first_wait is false (default) so just test the true case
-        test_schedule = torch.profiler.schedule(
-            skip_first=3, wait=5, warmup=1, active=2, repeat=2, skip_first_wait=True
-        )
-        test_schedule_expected_outputs = [
-            # repeat No. 1 begin
-            # skip first 3
-            ProfilerAction.NONE,
-            ProfilerAction.NONE,
-            ProfilerAction.NONE,
-            # warmup 1
-            ProfilerAction.WARMUP,
-            # active 1 begin
-            ProfilerAction.RECORD,
-            ProfilerAction.RECORD_AND_SAVE,
-            # active 1 end
-            # repeat No. 1 end
-            # ---
-            # repeat No. 2 begin
-            # wait 5
-            ProfilerAction.NONE,
-            ProfilerAction.NONE,
-            ProfilerAction.NONE,
-            ProfilerAction.NONE,
-            ProfilerAction.NONE,
-            # warmup 1
-            ProfilerAction.WARMUP,
-            # active 2 begin
-            ProfilerAction.RECORD,
-            ProfilerAction.RECORD_AND_SAVE,
-            # active 2 end
-            # repeat No. 2 end
-            ProfilerAction.NONE,
-            ProfilerAction.NONE,
-            ProfilerAction.NONE,
-            ProfilerAction.NONE,
-        ]
-        for step in range(len(test_schedule_expected_outputs)):
-            self.assertEqual(test_schedule(step), test_schedule_expected_outputs[step])
-
 
 class SimpleNet(nn.Module):
     def __init__(self) -> None:

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -434,13 +434,7 @@ class ProfilerAction(Enum):
 
 
 def schedule(
-    *,
-    wait: int,
-    warmup: int,
-    active: int,
-    repeat: int = 0,
-    skip_first: int = 0,
-    skip_first_wait: bool = False,
+    *, wait: int, warmup: int, active: int, repeat: int = 0, skip_first: int = 0
 ) -> Callable:
     """
     Returns a callable that can be used as profiler ``schedule`` argument. The profiler will skip
@@ -448,13 +442,6 @@ def schedule(
     then do the active recording for the next ``active`` steps and then repeat the cycle starting with ``wait`` steps.
     The optional number of cycles is specified with the ``repeat`` parameter, the zero value means that
     the cycles will continue until the profiling is finished.
-
-    The ``skip_first_wait`` parameter controls whether the first ``wait`` stage should be skipped.
-    This can be useful if a user wants to wait longer than ``skip_first`` between cycles, but not
-    for the first profile. For example, if ``skip_first`` is 10 and ``wait`` is 20, the first cycle will
-    wait 10 + 20 = 30 steps before warmup if ``skip_first_wait`` is False, but will wait only 10
-    steps if ``skip_first_wait`` is True. All subsequent cycles will then wait 20 steps between the
-    last active and warmup.
     """
 
     def schedule_fn(step: int) -> ProfilerAction:
@@ -463,9 +450,6 @@ def schedule(
             return ProfilerAction.NONE
         else:
             step -= skip_first
-        # If wait >> skip_first and we want to grab profiling early, shift left by wait if skip_first_wait is True
-        if skip_first_wait:
-            step += wait
         num_steps = wait + warmup + active
         if repeat > 0 and step / num_steps >= repeat:
             return ProfilerAction.NONE


### PR DESCRIPTION
Summary:
Original commit changeset: fcfa6360bd56

Original Phabricator Diff: D66198138

Failing https://www.internalfb.com/intern/test/562950124535491?ref_report_id=0

Test Plan:
```
buck2 test 'fbcode//mode/dev' fbcode//apf/plugin/tests:gpu_tracer_test-library-type-checking
File changed: fbsource//xplat/caffe2/torch/profiler/profiler.py
File changed: fbsource//xplat/caffe2/torch/profiler
File changed: fbsource//xplat/caffe2/torch
19 additional file change events
Buck UI: https://www.internalfb.com/buck2/dfca8d2a-affa-4cc0-83af-fe10e29b4084
Test UI: https://www.internalfb.com/intern/testinfra/testrun/12666374010802366
Network: Up: 0B  Down: 210B  (reSessionID-205eae7c-3654-432f-9962-18badf60da63)
Jobs completed: 5. Time elapsed: 2.9s.
Cache hits: 100%. Commands: 1 (cached: 1, remote: 0, local: 0)
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0
[amrelshennawy@devbig1227.ftw3 /data/users/amrelshennawy/fbsource/fbcode (525668edb)]$ 
```
```
[amrelshennawy@devbig1227.ftw3 /data/users/amrelshennawy/fbsource/fbcode (525668edb)]$ buck2 test apf/plugin/tests:gpu_tracer_test 
Buck UI: https://www.internalfb.com/buck2/767736ca-8fb6-4834-8893-a4c96956c0b1
Test UI: https://www.internalfb.com/intern/testinfra/testrun/13510798940920342
Network: Up: 752KiB  Down: 8.7GiB  (reSessionID-47496783-89ce-4e8f-950d-04a4f3463fce)
Jobs completed: 481481. Time elapsed: 3:07.9s.
Cache hits: 99%. Commands: 161608 (cached: 161596, remote: 12, local: 0)
Tests finished: Pass 11. Fail 0. Fatal 0. Skip 0. Build failure 0
```

Reviewed By: sraikund16

Differential Revision: D66416313


