### PR TITLE
Move knapsack algorithms into separate filing

### DIFF
--- a/torch/_functorch/_activation_checkpointing/__init__.py
+++ b/torch/_functorch/_activation_checkpointing/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torch/_functorch/_activation_checkpointing/knapsack.py
+++ b/torch/_functorch/_activation_checkpointing/knapsack.py
@@ -1,0 +1,125 @@
+# mypy: ignore-errors
+
+from typing import List, Tuple
+
+import torch
+
+
+def greedy_knapsack(
+    memory: List[float], runtimes: List[float], max_memory: float
+) -> Tuple[float, List[int], List[int]]:
+    n = len(runtimes)
+    items = list(range(n))
+
+    # Sort items based on the ratio of runtime to memory in descending order
+    items = sorted(items, key=lambda i: runtimes[i] / memory[i], reverse=True)
+
+    total_memory = 0.0
+    total_runtime = 0.0
+    items_to_save = []
+    items_to_allow_recomputing = []
+
+    for i in items:
+        if total_memory + memory[i] <= max_memory:
+            total_memory += memory[i]
+            total_runtime += runtimes[i]
+            items_to_save.append(i)
+        else:
+            items_to_allow_recomputing.append(i)
+    return total_runtime, items_to_save, items_to_allow_recomputing
+
+
+def ilp_knapsack(
+    memory: List[float], runtimes: List[float], max_memory: float
+) -> Tuple[float, List[int], List[int]]:
+    import numpy as np
+
+    try:
+        from scipy.optimize import Bounds, LinearConstraint, milp
+    except ImportError:
+        raise RuntimeError(
+            "To use the ILP for memory budget checkpointing you need to install scipy"
+        ) from None
+
+    np_memory = np.array(memory)
+    np_runtimes = np.array(runtimes)
+    c = -np_runtimes  # type: ignore[operator]
+
+    memory_constraint = LinearConstraint(A=np_memory, ub=np.array(max_memory))
+    constraints = [memory_constraint]
+
+    integrality = np.ones_like(c)
+    res = milp(
+        c=c, constraints=constraints, integrality=integrality, bounds=Bounds(0, 1)
+    )
+    if not res.success:
+        raise RuntimeError("Somehow scipy solving failed")
+
+    items_to_save = []
+    items_to_allow_recomputing = []
+    for idx, i in enumerate(res.x):
+        if i == 1:
+            items_to_save.append(idx)
+        else:
+            items_to_allow_recomputing.append(idx)
+    return -res.fun, items_to_save, items_to_allow_recomputing
+
+
+def dp_knapsack(
+    memory: List[float], runtime: List[float], max_memory: float
+) -> Tuple[float, List[int], List[int]]:
+    # Scaling factor to convert floating point weights to integers
+    S = 10000
+
+    # Quantize the memory weights
+    quantized_memory = torch.tensor(
+        [int(round(m * S)) for m in memory], dtype=torch.long, device="cpu"
+    )
+    runtimes = torch.tensor(runtime, dtype=torch.float32, device="cpu")
+
+    # Quantized pseudopolynomial DP for 0-1 Knapsack
+    quantized_max_memory = int(round(max_memory * S))
+
+    n = len(memory)
+
+    # Initialize the DP table
+    # TODO(chilli): I think if needed, this memory can be optimized with sliding
+    # window trick + Hirschberg trick:
+    # https://codeforces.com/blog/entry/47247?#comment-316200
+    dp = torch.zeros(
+        (n + 1, quantized_max_memory + 1), dtype=torch.float32, device="cpu"
+    )
+
+    for i in range(1, n + 1):
+        current_memory = quantized_memory[i - 1]
+        current_runtime = runtimes[i - 1]
+
+        # Copy the previous row
+        dp[i, :] = dp[i - 1, :]
+
+        # Update dp[i, j] for all j >= current_memory
+        if current_memory == 0:
+            dp[i, :] = dp[i - 1, :] + current_runtime
+        else:
+            dp[i, current_memory:] = torch.maximum(
+                dp[i - 1, current_memory:],
+                dp[i - 1, :-current_memory] + current_runtime,
+            )
+
+    # Backtrack to find the items included in the knapsack
+    saved_items = []
+    recomputable_items = []
+    j: int = quantized_max_memory
+    for i in range(n, 0, -1):
+        if dp[i][j] != dp[i - 1][j]:
+            saved_items.append(i - 1)  # Include this item (indexing from 0)
+            j -= int(quantized_memory[i - 1].item())
+        else:
+            recomputable_items.append(i - 1)
+
+    saved_items.reverse()  # To get items in the order they were added
+
+    # The maximum runtime that can be achieved within the max_memory constraint
+    max_runtime = dp[n][quantized_max_memory].item()
+
+    return max_runtime, saved_items, recomputable_items

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -28,6 +28,11 @@ from torch.fx.passes import graph_drawer
 from torch.utils.checkpoint import CheckpointPolicy
 
 from . import config
+from ._activation_checkpointing.knapsack import (
+    dp_knapsack,
+    greedy_knapsack,
+    ilp_knapsack,
+)
 from ._aot_autograd.logging_utils import get_aot_graph_name
 from ._aot_autograd.utils import is_with_effects
 from .compile_utils import fx_graph_cse, get_aten_target
@@ -1382,126 +1387,6 @@ def get_name_to_node(graph: fx.Graph):
     for node in graph.nodes:
         name_to_node[node.name] = node
     return name_to_node
-
-
-def greedy_knapsack(
-    memory: List[float], runtimes: List[float], max_memory: float
-) -> Tuple[float, List[int], List[int]]:
-    n = len(runtimes)
-    items = list(range(n))
-
-    # Sort items based on the ratio of runtime to memory in descending order
-    items = sorted(items, key=lambda i: runtimes[i] / memory[i], reverse=True)
-
-    total_memory = 0.0
-    total_runtime = 0.0
-    items_to_save = []
-    items_to_allow_recomputing = []
-
-    for i in items:
-        if total_memory + memory[i] <= max_memory:
-            total_memory += memory[i]
-            total_runtime += runtimes[i]
-            items_to_save.append(i)
-        else:
-            items_to_allow_recomputing.append(i)
-    return total_runtime, items_to_save, items_to_allow_recomputing
-
-
-def ilp_knapsack(
-    memory: List[float], runtimes: List[float], max_memory: float
-) -> Tuple[float, List[int], List[int]]:
-    import numpy as np
-
-    try:
-        from scipy.optimize import Bounds, LinearConstraint, milp
-    except ImportError:
-        raise RuntimeError(
-            "To use the ILP for memory budget checkpointing you need to install scipy"
-        ) from None
-
-    np_memory = np.array(memory)
-    np_runtimes = np.array(runtimes)
-    c = -np_runtimes  # type: ignore[operator]
-
-    memory_constraint = LinearConstraint(A=np_memory, ub=np.array(max_memory))
-    constraints = [memory_constraint]
-
-    integrality = np.ones_like(c)
-    res = milp(
-        c=c, constraints=constraints, integrality=integrality, bounds=Bounds(0, 1)
-    )
-    if not res.success:
-        raise RuntimeError("Somehow scipy solving failed")
-
-    items_to_save = []
-    items_to_allow_recomputing = []
-    for idx, i in enumerate(res.x):
-        if i == 1:
-            items_to_save.append(idx)
-        else:
-            items_to_allow_recomputing.append(idx)
-    return -res.fun, items_to_save, items_to_allow_recomputing
-
-
-def dp_knapsack(
-    memory: List[float], runtimes: List[float], max_memory: float
-) -> Tuple[float, List[int], List[int]]:
-    # Scaling factor to convert floating point weights to integers
-    S = 10000
-
-    # Quantize the memory weights
-    quantized_memory = torch.tensor(
-        [int(round(m * S)) for m in memory], dtype=torch.long, device="cpu"
-    )
-    runtimes = torch.tensor(runtimes, dtype=torch.float32, device="cpu")
-
-    # Quantized pseudopolynomial DP for 0-1 Knapsack
-    quantized_max_memory = int(round(max_memory * S))
-
-    n = len(memory)
-
-    # Initialize the DP table
-    # TODO(chilli): I think if needed, this memory can be optimized with sliding
-    # window trick + Hirschberg trick:
-    # https://codeforces.com/blog/entry/47247?#comment-316200
-    dp = torch.zeros(
-        (n + 1, quantized_max_memory + 1), dtype=torch.float32, device="cpu"
-    )
-
-    for i in range(1, n + 1):
-        current_memory = quantized_memory[i - 1]
-        current_runtime = runtimes[i - 1]
-
-        # Copy the previous row
-        dp[i, :] = dp[i - 1, :]
-
-        # Update dp[i, j] for all j >= current_memory
-        if current_memory == 0:
-            dp[i, :] = dp[i - 1, :] + current_runtime
-        else:
-            dp[i, current_memory:] = torch.maximum(
-                dp[i - 1, current_memory:],
-                dp[i - 1, :-current_memory] + current_runtime,
-            )
-
-    # Backtrack to find the items included in the knapsack
-    saved_items = []
-    recomputable_items = []
-    j: int = quantized_max_memory
-    for i in range(n, 0, -1):
-        if dp[i][j] != dp[i - 1][j]:
-            saved_items.append(i - 1)  # Include this item (indexing from 0)
-            j -= int(quantized_memory[i - 1].item())
-        else:
-            recomputable_items.append(i - 1)
-
-    saved_items.reverse()  # To get items in the order they were added
-
-    # The maximum runtime that can be achieved within the max_memory constraint
-    max_runtime = dp[n][quantized_max_memory].item()
-
-    return max_runtime, saved_items, recomputable_items
 
 
 def _optimize_runtime_with_given_memory(


### PR DESCRIPTION
Summary:
Original Context Doc: https://docs.google.com/document/d/1Gv5ZqN3UY7kTuCUd0JLU3L_onwVIr2vd3AiZyim1Muc/edit?disco=AAABZX_tqdk

### Changes

This diff restructures the Partitioners.py file in the _functorch package.

* Moves the three knapsack problem algorithems (greedy, ilp, dp) into a separate file

Test Plan:
### Unit Testing

```
$ buck test mode/opt //caffe2/test/functorch:test_ac
File changed: fbsource//xplat/caffe2/test/functorch/TARGETS
File changed: fbsource//xplat/caffe2/test/functorch
File changed: fbsource//xplat/caffe2/test
7 additional file change events
Soft Error: source_directory_includes_subpackage: Directory `v2.17.1-1` of package `fbsource//third-party/nccl` may not cover any subpackages, but includes subpackage `v2.17.1-1/src/tests`.
Soft Error: source_directory_includes_subpackage: Directory `v2.18.3-1` of package `fbsource//third-party/nccl` may not cover any subpackages, but includes subpackage `v2.18.3-1/src/tests`.
Soft Error: source_directory_includes_subpackage: Directory `v2.19.3-1` of package `fbsource//third-party/nccl` may not cover any subpackages, but includes subpackage `v2.19.3-1/src/tests`.
Buck UI: https://www.internalfb.com/buck2/a2f91f8a-5326-435e-9075-5af0de930b8b
Test UI: https://www.internalfb.com/intern/testinfra/testrun/7036874660108924
Network: Up: 28MiB  Down: 3.5GiB  (reSessionID-19af3d71-7528-448c-9126-5615d27b3bd7)
Jobs completed: 423656. Time elapsed: 3:57.2s.
Cache hits: 99%. Commands: 146147 (cached: 145758, remote: 317, local: 72)
Tests finished: Pass 8. Fail 0. Fatal 0. Skip 0. Build failure 0

```

### Tested on Local Training Run

```
CUDA_VISIBLE_DEVICES=5,6 AOT_PARTITIONER_DEBUG=1 PARTITIONER_MEMORY_BUDGET_PARETO=0 buck2 run mode/opt //aps_models/ads/icvr:icvr_launcher -- mode=local_fb_fm_v4 launcher.num_workers=2 2>&1 | tee log_2024-11-2320:41:50.757256__bento_trigger.txt
```

Output Summary Paste: P1685697066

Differential Revision: D65800097


