### PR TITLE
[Quant][PT2E][X86] annotate and convert for linear_dynamic_fp16

### DIFF
--- a/test/quantization/pt2e/test_x86inductor_quantizer.py
+++ b/test/quantization/pt2e/test_x86inductor_quantizer.py
@@ -1820,15 +1820,15 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
                     torch.nn.Linear, xiq.get_x86_inductor_linear_dynamic_fp16_config()
                 )
                 node_occurrence = {
-                    # quantize and dequantize are inserted for weight, and
-                    # quantize_per_tensor is folded during convert
+                    # 2 convert_element_type nodes are inserted for weight
                     torch.ops.quantized_decomposed.quantize_per_tensor.default: 0,
-                    torch.ops.quantized_decomposed.dequantize_per_tensor.default: 1,
+                    torch.ops.quantized_decomposed.dequantize_per_tensor.default: 0,
                     torch.ops.quantized_decomposed.quantize_per_channel.default: 0,
                     torch.ops.quantized_decomposed.dequantize_per_channel.default: 0,
+                    torch.ops.quantized_decomposed.convert_element_type.no_fuse: 2,
                 }
                 node_list = [
-                    torch.ops.quantized_decomposed.dequantize_per_tensor.default,
+                    torch.ops.quantized_decomposed.convert_element_type.no_fuse,
                     torch.ops.aten.linear.default,
                 ]
                 self._test_quantizer(

--- a/test/quantization/pt2e/test_x86inductor_quantizer.py
+++ b/test/quantization/pt2e/test_x86inductor_quantizer.py
@@ -1820,15 +1820,14 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
                     torch.nn.Linear, xiq.get_x86_inductor_linear_dynamic_fp16_config()
                 )
                 node_occurrence = {
-                    # 2 quantize and 2 dequantize ops are inserted, and
-                    # one of the quantize_per_tensor is folded during convert
-                    torch.ops.quantized_decomposed.quantize_per_tensor.default: 1,
-                    torch.ops.quantized_decomposed.dequantize_per_tensor.default: 2,
+                    # quantize and dequantize are inserted for weight, and
+                    # quantize_per_tensor is folded during convert
+                    torch.ops.quantized_decomposed.quantize_per_tensor.default: 0,
+                    torch.ops.quantized_decomposed.dequantize_per_tensor.default: 1,
                     torch.ops.quantized_decomposed.quantize_per_channel.default: 0,
                     torch.ops.quantized_decomposed.dequantize_per_channel.default: 0,
                 }
                 node_list = [
-                    torch.ops.quantized_decomposed.quantize_per_tensor.default,
                     torch.ops.quantized_decomposed.dequantize_per_tensor.default,
                     torch.ops.aten.linear.default,
                 ]

--- a/test/quantization/pt2e/test_x86inductor_quantizer.py
+++ b/test/quantization/pt2e/test_x86inductor_quantizer.py
@@ -1820,16 +1820,16 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
                     torch.nn.Linear, xiq.get_x86_inductor_linear_dynamic_fp16_config()
                 )
                 node_occurrence = {
-                    torch.ops.quantized_decomposed.quantize_per_tensor.default: 0,
-                    torch.ops.quantized_decomposed.dequantize_per_tensor.default: 0,
+                    # 2 quantize and 2 dequantize ops are inserted, and
+                    # one of the quantize_per_tensor is folded during convert
+                    torch.ops.quantized_decomposed.quantize_per_tensor.default: 1,
+                    torch.ops.quantized_decomposed.dequantize_per_tensor.default: 2,
                     torch.ops.quantized_decomposed.quantize_per_channel.default: 0,
                     torch.ops.quantized_decomposed.dequantize_per_channel.default: 0,
-                    # convert_to_fp16: 2 for input and weight
-                    # convert_to_fp32: 2 for input and weight
-                    torch.ops.prims.convert_element_type.default: 4,
                 }
                 node_list = [
-                    torch.ops.prims.convert_element_type.default,
+                    torch.ops.quantized_decomposed.quantize_per_tensor.default,
+                    torch.ops.quantized_decomposed.dequantize_per_tensor.default,
                     torch.ops.aten.linear.default,
                 ]
                 self._test_quantizer(

--- a/test/quantization/pt2e/test_x86inductor_quantizer.py
+++ b/test/quantization/pt2e/test_x86inductor_quantizer.py
@@ -1804,6 +1804,42 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
                 }
                 self._check_annotation_stat(fq_m, expected_annotation_stat)
 
+    @skipIfNoX86
+    def test_linear_dynamic_fp16(self):
+        """
+        Test pattern of linear_dynamic_fp16.
+        """
+        with override_quantized_engine("x86"), torch.no_grad():
+            for use_bias in [True, False]:
+                m = TestHelperModules.SingleLinearModule(use_bias).eval()
+                example_inputs = (torch.randn(2, 4),)
+                quantizer = X86InductorQuantizer().set_global(
+                    xiq.get_default_x86_inductor_quantization_config()
+                )
+                quantizer.set_module_type_qconfig(
+                    torch.nn.Linear, xiq.get_x86_inductor_linear_dynamic_fp16_config()
+                )
+                node_occurrence = {
+                    torch.ops.quantized_decomposed.quantize_per_tensor.default: 0,
+                    torch.ops.quantized_decomposed.dequantize_per_tensor.default: 0,
+                    torch.ops.quantized_decomposed.quantize_per_channel.default: 0,
+                    torch.ops.quantized_decomposed.dequantize_per_channel.default: 0,
+                    # convert_to_fp16: 2 for input and weight
+                    # convert_to_fp32: 2 for input and weight
+                    torch.ops.prims.convert_element_type.default: 4,
+                }
+                node_list = [
+                    torch.ops.prims.convert_element_type.default,
+                    torch.ops.aten.linear.default,
+                ]
+                self._test_quantizer(
+                    m,
+                    example_inputs,
+                    quantizer,
+                    node_occurrence,
+                    node_list,
+                )
+
     @skipIfTorchDynamo("very slow")
     @skipIfNoX86
     def test_qat_conv2d(self):

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -71,6 +71,8 @@ def quantize_per_tensor(
        Tensor with requested dtype (e.g. torch.uint8), note the quantization parameters
        are not stored in the Tensor, we are storing them in function arguments instead
     """
+    if dtype == torch.float16:
+        return input.to(dtype)
     if input.dtype in [torch.float16, torch.bfloat16]:
         input = input.to(torch.float32)
     assert (
@@ -262,6 +264,8 @@ def dequantize_per_tensor(
     ), f"Expecting input to have dtype: {dtype}, but got {input.dtype}"
     if out_dtype is None:
         out_dtype = torch.float32
+    if dtype == torch.float16:
+        return input.to(out_dtype)
     if dtype in _DTYPE_TO_QVALUE_BOUNDS:
         # TODO: investigate why
         # (input - zero_point).to(torch.float32) * scale

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -1198,7 +1198,7 @@ quantized_decomposed_lib.define(
     "CompositeExplicitAutograd",
 )
 def convert_element_type(input: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
-    return input.to(dtype)
+    return torch.ops.prims.convert_element_type.default(input, dtype)
 
 
 @impl(quantized_decomposed_lib, "convert_element_type.no_fuse", "Meta")

--- a/torch/ao/quantization/fx/convert.py
+++ b/torch/ao/quantization/fx/convert.py
@@ -343,9 +343,7 @@ def _replace_observer_with_quantize_dequantize_node_decomposed(
             graph.erase_node(node)
     elif dtype == torch.float16:
         quantize_op = torch.ops.quantized_decomposed.quantize_per_tensor.default
-        dequantize_op = (
-            torch.ops.quantized_decomposed.dequantize_per_tensor.default
-        )
+        dequantize_op = torch.ops.quantized_decomposed.dequantize_per_tensor.default
         with graph.inserting_before(node):
             input_node = node.args[0]
             quant_args = (input_node, 1.0, 0, 0, 0, torch.float16)

--- a/torch/ao/quantization/fx/convert.py
+++ b/torch/ao/quantization/fx/convert.py
@@ -342,7 +342,18 @@ def _replace_observer_with_quantize_dequantize_node_decomposed(
                 ]
             graph.erase_node(node)
     elif dtype == torch.float16:
-        raise NotImplementedError("decomposed to float16 op not implemented yet")
+        # Insert to_fp16 -> to_fp32 node
+        dtype_convert_op = torch.ops.prims.convert_element_type.default
+        with graph.inserting_before(node):
+            input_node = node.args[0]
+            convert_fp16_node = graph.create_node(
+                "call_function", dtype_convert_op, (input_node, torch.float16), {}
+            )
+            convert_fp32_node = graph.create_node(
+                "call_function", dtype_convert_op, (convert_fp16_node, torch.float), {}
+            )
+            node.replace_all_uses_with(convert_fp32_node)
+            graph.erase_node(node)
 
     # should not reach since we have checks in the beginning to make sure the
     # activation_post_process is supported

--- a/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
+++ b/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
@@ -474,7 +474,16 @@ class X86InductorQuantizer(Quantizer):
         ):
             warnings.warn("Mixed QAT and Non-QAT quantization config is not supported.")
             need_skip = True
-
+        if current_mode.dynamic_state is not None:
+            input_activation_spec = quantization_config.input_activation
+            if (
+                input_activation_spec is not None
+                and current_mode.dynamic_state != input_activation_spec.is_dynamic
+            ):
+                warnings.warn(
+                    "Mixed dynamic and static quantization config is not supported."
+                )
+                need_skip = True
         return need_skip
 
     def set_global(self, quantization_config: QuantizationConfig):

--- a/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
+++ b/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
@@ -357,7 +357,7 @@ def get_x86_inductor_linear_dynamic_fp16_config():
     )
 
     weight_quantization_spec = QuantizationSpec(
-        dtype=torch.half,
+        dtype=torch.float16,
         qscheme=torch.per_tensor_symmetric,
         is_dynamic=False,
         observer_or_fake_quant_ctr=PlaceholderObserver,

--- a/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
+++ b/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
@@ -345,30 +345,18 @@ def get_default_x86_inductor_quantization_config(
 @functools.lru_cache
 def get_x86_inductor_linear_dynamic_fp16_config():
     """
-    For linear_dynamic_fp16
-    Although it is called dynamic, it is actually static in the sense that input and weight are converted to fp16 directly.
-    So, `is_dynamic` is set to False below.
+    For linear_dynamic_fp16. The name may be confusing.
+    The op's behavior is fp32_input * (fp16_weight -> to_fp32) -> fp32_output.
     """
-    act_quantization_spec = QuantizationSpec(
-        dtype=torch.float16,
-        qscheme=torch.per_tensor_affine,
-        is_dynamic=False,
-        observer_or_fake_quant_ctr=PlaceholderObserver,
-    )
-
     weight_quantization_spec = QuantizationSpec(
         dtype=torch.float16,
-        qscheme=torch.per_tensor_symmetric,
-        is_dynamic=False,
         observer_or_fake_quant_ctr=PlaceholderObserver,
     )
-    bias_quantization_spec = None  # will use placeholder observer by default
     quantization_config = QuantizationConfig(
-        act_quantization_spec,
-        act_quantization_spec,
+        None,  # input_quantization_spec
+        None,  # output_quantization_spec
         weight_quantization_spec,
-        bias_quantization_spec,
-        is_qat=False,
+        None,  # bias_quantization_spec
     )
     return quantization_config
 

--- a/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
+++ b/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
 __all__ = [
     "X86InductorQuantizer",
     "get_default_x86_inductor_quantization_config",
+    "get_x86_inductor_linear_dynamic_fp16_config",
 ]
 
 

--- a/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
+++ b/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
@@ -341,6 +341,37 @@ def get_default_x86_inductor_quantization_config(
     return quantization_config
 
 
+@functools.lru_cache
+def get_x86_inductor_linear_dynamic_fp16_config():
+    """
+    For linear_dynamic_fp16
+    Although it is called dynamic, it is actually static in the sense that input and weight are converted to fp16 directly.
+    So, `is_dynamic` is set to False below.
+    """
+    act_quantization_spec = QuantizationSpec(
+        dtype=torch.float16,
+        qscheme=torch.per_tensor_affine,
+        is_dynamic=False,
+        observer_or_fake_quant_ctr=PlaceholderObserver,
+    )
+
+    weight_quantization_spec = QuantizationSpec(
+        dtype=torch.half,
+        qscheme=torch.per_tensor_symmetric,
+        is_dynamic=False,
+        observer_or_fake_quant_ctr=PlaceholderObserver,
+    )
+    bias_quantization_spec = None  # will use placeholder observer by default
+    quantization_config = QuantizationConfig(
+        act_quantization_spec,
+        act_quantization_spec,
+        weight_quantization_spec,
+        bias_quantization_spec,
+        is_qat=False,
+    )
+    return quantization_config
+
+
 def _annotate_nodes_not_quantize(nodes: Union[Node, List[Node]]) -> None:
     """Annotate nodes to exclude them from quantization (their `quantization_config` is `None`)."""
     if not isinstance(nodes, list):
@@ -454,16 +485,7 @@ class X86InductorQuantizer(Quantizer):
         ):
             warnings.warn("Mixed QAT and Non-QAT quantization config is not supported.")
             need_skip = True
-        if current_mode.dynamic_state is not None:
-            input_activation_spec = quantization_config.input_activation
-            if (
-                input_activation_spec is not None
-                and current_mode.dynamic_state != input_activation_spec.is_dynamic
-            ):
-                warnings.warn(
-                    "Mixed dynamic and static quantization config is not supported."
-                )
-                need_skip = True
+
         return need_skip
 
     def set_global(self, quantization_config: QuantizationConfig):

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
@@ -152,6 +152,7 @@ def get_weight_qspec(quantization_config: Optional[QuantizationConfig]):
     if quantization_spec.qscheme not in [
         torch.per_tensor_symmetric,
         torch.per_channel_symmetric,
+        None,
     ]:
         raise ValueError(
             f"Unsupported quantization_spec {quantization_spec} for weight"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #141556
* #141549
* __->__ #141480

Annotate linear node for `linear_dynamic_fp16` with `X86InductorQuantizer`
After `convert_pt2e`, the pattern will be
```
  x
  |
linear <- to_fp32 <- to_fp16 <- w
```

**Test plan**
```
pytest test/quantization/pt2e/test_x86inductor_quantizer.py -k test_linear_dynamic_fp16
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @ezyang @SherlockNoMad @EikanWang @wenzhe-nrv