### PR TITLE
[dynamo] support `list.sort` sort non-constant iterable with constant keys

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1867,6 +1867,15 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
             sorted(tmp.items(), key=operator.itemgetter(1), reverse=True),
         )
 
+    @make_test
+    def test_sorted_const_key_non_const_items(x):
+        tmp = {1: x, 10: x - 1, 3: 2 * x, 0: torch.ones(3, 4)}
+        return (
+            sorted(tmp),
+            sorted(tmp.items(), key=operator.itemgetter(0)),
+            sorted(tmp.items(), key=operator.itemgetter(0), reverse=True),
+        )
+
     def test_dict_hasattr(self):
         def fn(x):
             if hasattr(x, "to"):

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1868,12 +1868,16 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         )
 
     @make_test
-    def test_sorted_const_key_non_const_items(x):
-        tmp = {1: x, 10: x - 1, 3: 2 * x, 0: torch.ones(3, 4)}
+    def test_sorted_const_key_non_const_items(x, y):
+        tmp = {1: x, 10: x - 1, 3: 2 * x, -1: y + 2, 0: torch.ones(3, 4)}
         return (
             sorted(tmp),
+            sorted(tmp, key=lambda k: tmp[k].shape),
+            sorted(tmp, key=lambda k: tmp[k].shape, reverse=True),
             sorted(tmp.items(), key=operator.itemgetter(0)),
             sorted(tmp.items(), key=operator.itemgetter(0), reverse=True),
+            sorted(tmp.values(), key=lambda t: t.shape),
+            sorted(tmp.values(), key=lambda t: t.shape, reverse=True),
         )
 
     def test_dict_hasattr(self):

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1872,12 +1872,8 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         tmp = {1: x, 10: x - 1, 3: 2 * x, -1: y + 2, 0: torch.ones(3, 4)}
         return (
             sorted(tmp),
-            sorted(tmp, key=lambda k: tmp[k].shape),
-            sorted(tmp, key=lambda k: tmp[k].shape, reverse=True),
             sorted(tmp.items(), key=operator.itemgetter(0)),
             sorted(tmp.items(), key=operator.itemgetter(0), reverse=True),
-            sorted(tmp.values(), key=lambda t: t.shape),
-            sorted(tmp.values(), key=lambda t: t.shape, reverse=True),
         )
 
     def test_dict_hasattr(self):

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -441,26 +441,27 @@ class ListVariable(CommonListMethodsVariable):
             ).as_python_constant()
             assert len(kwargs) == 0
 
-            if not all(x.is_python_constant() for x in self.items):
-                # TODO: support `key(x)` is Python constant and sortable. The `key` function should
-                #       be a pure function and should not have any side effects.
-                return super().call_method(tx, name, args, kwargs)  # try next handler
-
             if (
                 key_fn_var.is_python_constant()
                 and key_fn_var.as_python_constant() is None
             ):
-
-                def key_fn(x):
-                    return x.as_python_constant()
-
+                keys = self.items.copy()
             else:
+                keys = [key_fn_var.call_function(tx, [x], {}) for x in self.items]
 
-                def key_fn(x):
-                    return key_fn_var.call_function(tx, [x], {}).as_python_constant()
+            if not all(k.is_python_constant() for k in keys):
+                unimplemented("sort with non-constant keys")
 
             tx.output.side_effects.mutation(self)
-            self.items.sort(key=key_fn, reverse=reverse)
+            sorted_items_with_keys = sorted(
+                (
+                    (x, k.as_python_constant(), i)
+                    for i, (k, x) in enumerate(zip(keys, self.items))
+                ),
+                key=operator.itemgetter(1, 2),
+                reverse=reverse,
+            )
+            self.items[:] = [x for x, *_ in sorted_items_with_keys]
             return ConstantVariable.create(None)
 
         return super().call_method(tx, name, args, kwargs)

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -455,7 +455,7 @@ class ListVariable(CommonListMethodsVariable):
             tx.output.side_effects.mutation(self)
             sorted_items_with_keys = sorted(
                 (
-                    (x, k.as_python_constant(), i)
+                    (x, k.as_python_constant(), -i if reverse else i)
                     for i, (k, x) in enumerate(zip(keys, self.items))
                 ),
                 key=operator.itemgetter(1, 2),

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -455,7 +455,11 @@ class ListVariable(CommonListMethodsVariable):
             tx.output.side_effects.mutation(self)
             sorted_items_with_keys = sorted(
                 (
-                    (x, k.as_python_constant(), -i if reverse else i)
+                    (
+                        x,
+                        k.as_python_constant(),
+                        -i if reverse else i,  # extra key to ensure stable sort
+                    )
                     for i, (k, x) in enumerate(zip(keys, self.items))
                 ),
                 key=operator.itemgetter(1, 2),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141485



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames