### PR TITLE
[BE] Clean up ExecuTorch Export Docstring

### DIFF
--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -474,8 +474,6 @@ def load(
     :func:`torch.export.save <torch.export.save>`.
 
     Args:
-        ep (ExportedProgram): The exported program to save.
-
         f (Union[str, os.PathLike, io.BytesIO): A file-like object (has to
          implement write and flush) or a string containing a file name.
 


### PR DESCRIPTION
Summary: I noticed when looking at the docs for [`torch.export.load`](https://pytorch.org/docs/stable/_modules/torch/export.html#load) that it looked like there was a copy and paste error from the save command docstring since ep is not an actual parameter for load and it says "The exported program to save." This diff removes it from the docstring.

Test Plan: Automated Testing

Differential Revision: D66385366


