### PR TITLE
fix non termination in unflatten + state

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -6918,6 +6918,112 @@ graph():
         self.assertTrue(torch.allclose(epm(*inp), eager))
         self.assertTrue(torch.allclose(ufm(*inp), eager))
 
+    def test_unflatten_random_dag_8_modules_state(self):
+        class N7(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.buf = torch.nn.Buffer(torch.ones(1))
+
+            def forward(self, x):
+                return x + 1
+
+        class N6(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.buf = torch.nn.Buffer(torch.ones(1))
+                self.n7 = N7()
+
+            def forward(self, x):
+                x = self.n7(x + 1)
+                return x + 1
+
+        class N5(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.buf = torch.nn.Buffer(torch.ones(1))
+                self.n6 = N6()
+
+            def forward(self, x):
+                x = x + self.n6.n7.buf
+                x = self.n6(x + 1)
+                return x + 1
+
+        class N4(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.buf = torch.nn.Buffer(torch.ones(1))
+                self.n5 = N5()
+
+            def forward(self, x):
+                x = x + self.n5.buf
+                x = self.n5(x + 1)
+                x = self.n5.n6(x + 1)
+                return x + 1
+
+        class N3(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.buf = torch.nn.Buffer(torch.ones(1))
+                self.n4 = N4()
+
+            def forward(self, x):
+                x = x + self.n4.buf
+                x = x + self.n4.n5.n6.n7.buf
+                x = self.n4(x + 1)
+                x = self.n4.n5.n6(x + 1)
+                return x + 1
+
+        class N2(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.buf = torch.nn.Buffer(torch.ones(1))
+                self.n3 = N3()
+
+            def forward(self, x):
+                x = x + self.n3.n4.n5.n6.n7.buf
+                x = self.n3(x + 1)
+                x = self.n3.n4(x + 1)
+                return x + 1
+
+        class N1(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.buf = torch.nn.Buffer(torch.ones(1))
+                self.n2 = N2()
+
+            def forward(self, x):
+                x = x + self.n2.n3.n4.n5.buf
+                x = x + self.n2.n3.n4.n5.n6.n7.buf
+                x = self.n2(x + 1)
+                x = self.n2.n3.n4(x + 1)
+                x = self.n2.n3.n4.n5(x + 1)
+                x = self.n2.n3.n4.n5.n6.n7(x + 1)
+                return x + 1
+
+        class N0(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.buf = torch.nn.Buffer(torch.ones(1))
+                self.n1 = N1()
+
+            def forward(self, x):
+                x = x + self.n1.n2.buf
+                x = x + self.n1.n2.n3.n4.buf
+                x = self.n1(x + 1)
+                x = self.n1.n2(x + 1)
+                x = self.n1.n2.n3.n4(x + 1)
+                x = self.n1.n2.n3.n4.n5.n6.n7(x + 1)
+                return x + 1
+
+        n0 = N0()
+        inp = (torch.ones(1),)
+        eager = n0(*inp)
+        ep = torch.export.export(n0, inp)
+        epm = ep.module()
+        ufm = torch.export.unflatten(ep)
+        assert torch.allclose(epm(*inp), eager)
+        assert torch.allclose(ufm(*inp), eager)
+
     def test_unflatten_no_unroll(self):
         inp = (torch.ones(1),)
 

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -1543,7 +1543,7 @@ def _sink_params(
     module: torch.nn.Module,
     inputs_to_state: Dict[str, List[str]],
     scope: List[str],
-    module_id_to_inputs_removed: Optional[Dict[int, List[str]]] = None,
+    module_id_to_inputs_removed: Optional[Dict[int, Set[str]]] = None,
 ):
     """Sink params, buffers, and constants from graph inputs into get_attr nodes.
 
@@ -1561,9 +1561,8 @@ def _sink_params(
         the module object id to the list of placeholder node names in the child module
         that were removed.
     """
-
     if module_id_to_inputs_removed is None:
-        module_id_to_inputs_removed = defaultdict(list)
+        module_id_to_inputs_removed = defaultdict(set)
 
     # We need to use _modules here instead of named_children(), because we
     # explicitly want duplicate modules to show up in the traversal.
@@ -1575,7 +1574,7 @@ def _sink_params(
             module_id_to_inputs_removed,
         )
         for k, v in submod_id_to_inputs_removed.items():
-            module_id_to_inputs_removed[k].extend(v)
+            module_id_to_inputs_removed[k].update(v)
 
     graph = getattr(module, "graph", None)
     if graph is None or len(graph.nodes) == 0:
@@ -1627,7 +1626,7 @@ def _sink_params(
         inputs_to_state_of_scope[node] = state_name
 
     # Record name of remove inputs for return purpose.
-    inputs_removed: List[str] = []
+    inputs_removed: Set[str] = set()
 
     for node, state_name in inputs_to_state_of_scope.items():
         if len(node.users) > 0:
@@ -1642,7 +1641,7 @@ def _sink_params(
             node.replace_all_uses_with(new_node, propagate_meta=True)
 
         graph.erase_node(node)  # type: ignore[union-attr, operator]
-        inputs_removed.append(node.name)
+        inputs_removed.add(node.name)
 
     if isinstance(module, InterpreterModule):
         module.finalize()


### PR DESCRIPTION
With largish systems of nn modules with buffers, sinking params suffered from some kind of exponential blowup that is easily fixed by using a set instead of a list to keep track of unlifted buffer placeholders.

Test Plan: added random dag test that failed previously

Differential Revision: D66457661
