### PR TITLE
Fix comments regarding the description of debugging handle in file backend_debug_handler.h

### DIFF
--- a/torch/csrc/jit/backends/backend_debug_handler.h
+++ b/torch/csrc/jit/backends/backend_debug_handler.h
@@ -76,7 +76,9 @@ namespace torch::jit {
  *
  *  So why does debug handle map to DebugInfoTuple = {source range and inlined
  *  cs}? {debug_handle, source_range_tag, serialized_callstack} Take this
- *  example: class L(nn.Module): def __init__(self) -> None:
+ *  example: 
+ *  class L(nn.Module): 
+ *    def __init__(self) -> None:
  *      ...
  *    def forward(self, x):
  *      return x * 5
@@ -87,11 +89,13 @@ namespace torch::jit {
  *      return x - 2
  *  class N(nn.Module):
  *    def __init__(self) -> None:
+ *      self.l = L()
  *      self.m = M()
  *    def forward(self, x):
- *      return self.m(x) + 3
+ *      return self.m(self.l(x)) + 3
  *  m = torch.jit.script(N())
- *  Once you inline m's forward method, m.forward.graph will look something
+ *   
+ *  Once you inline l's and m's forward method, m.forward.graph will look something
  *  like this
  *  graph(%self...):
  *   %x = aten::mul(..)


### PR DESCRIPTION
Fix comments regarding the description of debugging handle in JIT compiler.

Based on the computation graph generated, the calculation should to be: x is first multiplied by 5 (by class L) and then subtracted by 2 (by class M), and finally added 3 (by class N).

However in the original comments, class L is unused, which is incorrect.

I modified code in the comments to make it consistent with the description of the graph to reduce confusion.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel