### PR TITLE
handle sympy.oo in bitwise_and/or value_ranges

### DIFF
--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -517,11 +517,14 @@ class SymPyValueRangeAnalysis:
         if b.is_bool:
             b = cls._bool_to_int(b)
         lower = min(a.lower, b.lower)
-        if lower < 0 and lower != -int_oo:
+        if lower < 0 and lower != -sympy.oo and lower != -int_oo:
             # If both lower bounds are negative, then bits start like
             # 1...10..., so the smallest possible value is 1...101...1.
             # Thus, we need to find the next smallest power of 2 (inclusive).
-            lower = -(1 << int(-lower - 1).bit_length())
+            try:
+                lower = -(1 << int(-lower - 1).bit_length())
+            except Exception:
+                lower = -int_oo
         else:
             lower = 0
         return ValueRanges(lower, max(a.upper, b.upper))
@@ -538,11 +541,14 @@ class SymPyValueRangeAnalysis:
         upper = max(a.upper, b.upper)
         if upper == 0:
             upper = 0
-        elif upper > 0 and upper != int_oo:
+        elif upper > 0 and upper != sympy.oo and upper != int_oo:
             # If both upper bounds are positive, then the largest
             # possible value is 01...1, so we need to find
             # next largest power of 2 (exclusive), minus 1
-            upper = (1 << int(upper).bit_length()) - 1
+            try:
+                upper = (1 << int(upper).bit_length()) - 1
+            except Exception:
+                upper = int_oo
         elif upper < 0:
             upper = -1
         return ValueRanges(min(a.lower, b.lower), upper)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141522
* #138777

An internal test is failing due to not handling `sympy.oo` properly in bitwise_and/or value_ranges: [T208684142](https://www.internalfb.com/intern/tasks/?t=208684142). I don't know how to repro this - seems like this requires inductor to trigger as well.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @ezyang @penguinwu @bobrenjc93