### PR TITLE
When serializing treespec context, support enum as well

### DIFF
--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: pytree"]
 
 import collections
+import enum
 import inspect
 import os
 import re
@@ -9,6 +10,7 @@ import sys
 import unittest
 from collections import defaultdict, deque, namedtuple, OrderedDict, UserDict
 from dataclasses import dataclass
+from enum import auto
 from typing import Any, NamedTuple
 
 import torch
@@ -946,6 +948,15 @@ TreeSpec(tuple, None, [*,
         serialized_spec = py_pytree.treespec_dumps(spec)
         self.assertIsInstance(serialized_spec, str)
         self.assertEqual(spec, py_pytree.treespec_loads(serialized_spec))
+
+    def test_pytree_serialize_enum(self):
+        class TestEnum(enum.Enum):
+            A = auto()
+
+        spec = py_pytree.TreeSpec(dict, TestEnum.A, [py_pytree.LeafSpec()])
+
+        serialized_spec = py_pytree.treespec_dumps(spec)
+        self.assertIsInstance(serialized_spec, str)
 
     def test_pytree_serialize_namedtuple(self):
         Point1 = namedtuple("Point1", ["x", "y"])

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -24,6 +24,7 @@ import threading
 import types
 import warnings
 from collections import defaultdict, deque, namedtuple, OrderedDict
+from enum import Enum
 from typing import (
     Any,
     Callable,
@@ -108,6 +109,13 @@ class KeyEntry(Protocol):
 
     def get(self, parent: Any) -> Any:
         ...
+
+
+class EnumEncoder(json.JSONEncoder):
+    def default(self, obj: object) -> str:
+        if isinstance(obj, Enum):
+            return obj.value  # type: ignore[no-any-return]
+        return super().default(obj)  # type: ignore[no-any-return]
 
 
 Context = Any
@@ -1369,7 +1377,7 @@ def _treespec_to_json(treespec: TreeSpec) -> _TreeSpecSchema:
 
     if serialize_node_def.to_dumpable_context is None:
         try:
-            serialized_context = json.dumps(treespec.context)
+            serialized_context = json.dumps(treespec.context, cls=EnumEncoder)
         except TypeError as e:
             raise TypeError(
                 "Unable to serialize context. "


### PR DESCRIPTION
Following https://github.com/pytorch/pytorch/pull/102716, per @angelayi's suggestion.

Note that in general enum as an input is not supported.

repro:
```
class TestEnum(enum.Enum):
    A = auto()
    B = auto()

    @staticmethod
    def from_string(s):
        return TestEnum[s.upper()]


class M(torch.nn.Module):
    def forward(self, x, en):
        return x.clone()

input1 = (
    torch.rand(10, device="cuda"),
    {TestEnum.A: torch.rand(10, device="cuda")},
)
inputs = [input1]
model = M().cuda()

_ = model(*input1)

ep = torch.export.export(model, input1, strict=False)
path = torch._inductor.aot_compile(ep.module(), input1)
```

Differential Revision: D66269157