### PR TITLE
Add analytical tests of matrix exponential backward method

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7382,10 +7382,11 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
             # Then  F^H = | -j * pi        2  |
             #             | 2          j * pi |
             (
-                torch.diag(torch.tensor([2., 1.], device=device, dtype=dtype)),
+                torch.diag(torch.tensor([2., 1.], device=device, dtype=torch.complex64 if dtype == torch.float32 else torch.complex128)),
                 lambda m: torch.linalg.matrix_exp(torch.pi * 1j * m),
+
                 torch.tensor([[-1j * torch.pi, 2], [2, 1j * torch.pi]],
-                             device=device, dtype=dtype)),
+                             device=device, dtype=torch.complex64 if dtype == torch.float32 else torch.complex128)),
         ]
 
         for A, f, F_H in testcases:

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7382,11 +7382,12 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
             # Then  F^H = | -j * pi        2  |
             #             | 2          j * pi |
             (
-                torch.diag(torch.tensor([2., 1.], device=device, dtype=torch.complex64 if dtype == torch.float32 else torch.complex128)),
+                torch.diag(torch.tensor([2., 1.], device=device,
+                                        dtype=torch.complex64 if dtype == torch.float32 else torch.complex128)),
                 lambda m: torch.linalg.matrix_exp(torch.pi * 1j * m),
-
                 torch.tensor([[-1j * torch.pi, 2], [2, 1j * torch.pi]],
-                             device=device, dtype=torch.complex64 if dtype == torch.float32 else torch.complex128)),
+                             device=device, dtype=torch.complex64 \
+                             if dtype == torch.float32 else torch.complex128)),
         ]
 
         for A, f, F_H in testcases:


### PR DESCRIPTION
Adds a couple analytical tests of the matrix exponential backward implementation. Currently there are tests for matrix exponentiation forward pass, though none for the backward method.
