### PR TITLE
Only write predicate once when there are multiple torch.cond 

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -3924,6 +3924,28 @@ class AOTInductorTestsTemplate:
         )
         self.assertEqual(new_expected, new_output)
 
+    def test_cond_share_predicte(self):
+        class Model(torch.nn.Module):
+            def forward(self, predicate, x):
+                y = torch.cond(
+                    predicate,
+                    lambda: x + 1,
+                    lambda: x + 2,
+                )
+
+                z = torch.cond(
+                    predicate,
+                    lambda: y + 1,
+                    lambda: y + 2,
+                )
+                return (z,)
+
+        example_inputs = (
+            torch.tensor([True]).to(self.device),
+            torch.tensor([1, 2, 3]).to(self.device),
+        )
+        self.check_model(Model(), example_inputs)
+
 
 class AOTInductorLoggingTest(LoggingTestCase):
     @make_logging_test(dynamic=logging.DEBUG)

--- a/test/inductor/test_aot_inductor_arrayref.py
+++ b/test/inductor/test_aot_inductor_arrayref.py
@@ -73,6 +73,7 @@ CPU_TEST_FAILURES = {
     "test_cond_with_outer_code_before_after": fail_minimal_arrayref_interface(),
     "test_cond_with_parameters": fail_minimal_arrayref_interface(),
     "test_cond_with_reinterpret_view_inputs_outputs": fail_minimal_arrayref_interface(),
+    "test_cond_share_predicte": fail_stack_allocation(is_skip=True),
     "test_foreach_multiple_dynamic": fail_minimal_arrayref_interface(),
     "test_nested_tensor_from_jagged": fail_minimal_arrayref_interface(),
     "test_poi_multiple_dynamic": fail_minimal_arrayref_interface(),

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -58,6 +58,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         self.used_cached_dtypes = set()
         self.used_cached_layouts = set()
         self.used_cached_memory_formats = set()
+        self.used_cond_predicate = set()
         self.cached_output_id = count()
         self.scalar_to_tensor_id = count()
         self.custom_op_wrapper_loaded = False
@@ -1485,11 +1486,13 @@ class CppWrapperCpu(PythonWrapperCodegen):
             # in ABI-compatible mode, we need to use the ABI shim function
             # to extract a C++ bool from the unrelying scalar bool Tensor
             predicate = f"{conditional.predicate.get_name()}_scalar"
-            self.codegen_tensor_item(
-                torch.bool,
-                conditional.predicate.codegen_reference(),
-                predicate,
-            )
+            if predicate not in self.used_cond_predicate:
+                self.codegen_tensor_item(
+                    torch.bool,
+                    conditional.predicate.codegen_reference(),
+                    predicate,
+                )
+                self.used_cond_predicate.add(predicate)
         else:
             # the predicate is not a Tensor: SymBool or Python bool
             predicate = conditional.predicate.codegen_reference()


### PR DESCRIPTION
Fixes #140606 

TEST PLAN:

```
python test/inductor/test_aot_inductor.py -k cond_share
python test/inductor/test_aot_inductor_arrayref.py -k cond_share
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov