### PR TITLE
[CI] Fix xpu linux ci build environment duplicated issue

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -48,7 +48,7 @@ NUM_TEST_SHARDS="${NUM_TEST_SHARDS:=1}"
 
 export VALGRIND=ON
 # export TORCH_INDUCTOR_INSTALL_GXX=ON
-if [[ "$BUILD_ENVIRONMENT" == *clang9* ]]; then
+if [[ "$BUILD_ENVIRONMENT" == *clang9* || "$BUILD_ENVIRONMENT" == *xpu* ]]; then
   # clang9 appears to miscompile code involving std::optional<c10::SymInt>,
   # such that valgrind complains along these lines:
   #

--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -40,12 +40,12 @@ jobs:
         ]}
 
   linux-jammy-xpu-2025_0-py3_9-build:
-    name: linux-jammy-xpu-2025_0-py3.9
+    name: linux-jammy-xpu-2025.0-py3.9
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       runner_prefix: ${{ needs.get-label-type.outputs.label-type }}
-      build-environment: linux-jammy-xpu-py3.9
+      build-environment: linux-jammy-xpu-2025.0-py3.9
       docker-image-name: pytorch-linux-jammy-xpu-2025.0-py3
       runner: linux.12xlarge
       test-matrix: |
@@ -57,14 +57,14 @@ jobs:
         ]}
 
   linux-jammy-xpu-2025_0-py3_9-test:
-    name: linux-jammy-xpu-2025_0-py3.9
+    name: linux-jammy-xpu-2025.0-py3.9
     uses: ./.github/workflows/_xpu-test.yml
     needs: linux-jammy-xpu-2025_0-py3_9-build
     permissions:
       id-token: write
       contents: read
     with:
-      build-environment: linux-jammy-xpu-py3.9
+      build-environment: linux-jammy-xpu-2025.0-py3.9
       docker-image: ${{ needs.linux-jammy-xpu-2025_0-py3_9-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-xpu-2025_0-py3_9-build.outputs.test-matrix }}
 


### PR DESCRIPTION
We found that there are duplicated build environments in XPU linux ci test, it led to test jobs may download wrong pytorch build artifact file. Refer https://github.com/pytorch/pytorch/actions/runs/12023238798/job/33518351906#step:14:633

Works for https://github.com/pytorch/pytorch/issues/139722 and https://github.com/pytorch/pytorch/issues/114850