### PR TITLE
[dynamo][log] Remove print torch inner stacktrace to let users focus on their code error

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -435,7 +435,6 @@ def log_graph_break(code_options, reason="", exc_info=False, user_stack=None):
         #   python test/dynamo/test_exc.py -k test_graph_break_log
         graph_break_log.debug(
             user_stack_trace,
-            exc_info=exc_info,
         )
     else:
         # This log line MUST not contain the string "Graph break in user code",


### PR DESCRIPTION
Fixes #140394

**Test Result**

```bash
TORCH_LOGS="graph_breaks" python test.py
```

```python
# test.py
from typing import List
import torch

def fn002(x):
    x = x + 1
    torch._dynamo.graph_break()
    x = x + 1
    return x

def fn001(x):
    return fn002(x)

torch.compile(fn001, backend="eager")(torch.randn(1))

```
**Before log**
```
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks] Graph break in user code at /home/zong/code/pytorch/../scripts/dynamo.py:6
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks] Reason: Unsupported: 'skip function graph_break in file /home/zong/code/pytorch/torch/_dynamo/decorators.py'
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks] User code traceback:
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/../scripts/dynamo.py", line 11, in fn001
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     return fn002(x)
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/../scripts/dynamo.py", line 6, in fn002
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     torch._dynamo.graph_break()
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks] Traceback (most recent call last):
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/symbolic_convert.py", line 641, in wrapper
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     return inner_fn(self, inst)
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]            ^^^^^^^^^^^^^^^^^^^^
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/symbolic_convert.py", line 2314, in CALL
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     self._call(inst)
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/symbolic_convert.py", line 2308, in _call
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     self.call_function(fn, args, kwargs)
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/symbolic_convert.py", line 879, in call_function
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     self.push(fn.call_function(self, args, kwargs))  # type: ignore[arg-type]
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/variables/functions.py", line 328, in call_function
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     return super().call_function(tx, args, kwargs)
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/variables/functions.py", line 129, in call_function
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     return tx.inline_user_function_return(self, [*self.self_args(), *args], kwargs)
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/symbolic_convert.py", line 885, in inline_user_function_return
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     return InliningInstructionTranslator.inline_call(self, fn, args, kwargs)
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/symbolic_convert.py", line 3045, in inline_call
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     return cls.inline_call_(parent, func, args, kwargs)
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/symbolic_convert.py", line 3171, in inline_call_
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     tracer.run()
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/symbolic_convert.py", line 1032, in run
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     while self.step():
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]           ^^^^^^^^^^^
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/symbolic_convert.py", line 944, in step
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     self.dispatch_table[inst.opcode](self, inst)
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/symbolic_convert.py", line 641, in wrapper
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     return inner_fn(self, inst)
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]            ^^^^^^^^^^^^^^^^^^^^
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/symbolic_convert.py", line 2314, in CALL
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     self._call(inst)
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/symbolic_convert.py", line 2308, in _call
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     self.call_function(fn, args, kwargs)
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/symbolic_convert.py", line 879, in call_function
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     self.push(fn.call_function(self, args, kwargs))  # type: ignore[arg-type]
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/variables/functions.py", line 708, in call_function
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     unimplemented(msg)
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/torch/_dynamo/exc.py", line 313, in unimplemented
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     raise Unsupported(msg, case_name=case_name)
V1126 16:01:41.701000 1303718 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks] torch._dynamo.exc.Unsupported: 'skip function graph_break in file /home/zong/code/pytorch/torch/_dynamo/decorators.py'
V1126 16:01:41.722000 1303718 torch/_dynamo/symbolic_convert.py:424] [1/0] [__graph_breaks] Graph break (details suppressed) in user code at /home/zong/code/pytorch/../scripts/dynamo.py:6
V1126 16:01:41.722000 1303718 torch/_dynamo/symbolic_convert.py:424] [1/0] [__graph_breaks] Reason: Unsupported: 'skip function graph_break in file /home/zong/code/pytorch/torch/_dynamo/decorators.py
```

**After log**
```
V1126 16:01:19.900000 1303438 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks] Graph break in user code at /home/zong/code/pytorch/../scripts/dynamo.py:6
V1126 16:01:19.900000 1303438 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks] Reason: Unsupported: 'skip function graph_break in file /home/zong/code/pytorch/torch/_dynamo/decorators.py'
V1126 16:01:19.900000 1303438 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks] User code traceback:
V1126 16:01:19.900000 1303438 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/../scripts/dynamo.py", line 11, in fn001
V1126 16:01:19.900000 1303438 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     return fn002(x)
V1126 16:01:19.900000 1303438 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]   File "/home/zong/code/pytorch/../scripts/dynamo.py", line 6, in fn002
V1126 16:01:19.900000 1303438 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks]     torch._dynamo.graph_break()
V1126 16:01:19.900000 1303438 torch/_dynamo/symbolic_convert.py:416] [0/0] [__graph_breaks] 
V1126 16:01:19.918000 1303438 torch/_dynamo/symbolic_convert.py:423] [1/0] [__graph_breaks] Graph break (details suppressed) in user code at /home/zong/code/pytorch/../scripts/dynamo.py:6
V1126 16:01:19.918000 1303438 torch/_dynamo/symbolic_convert.py:423] [1/0] [__graph_breaks] Reason: Unsupported: 'skip function graph_break in file /home/zong/code/pytorch/torch/_dynamo/decorators.py'
```


**Using tlparse get stacktrace**

The trace log implement for graph breaks in
https://github.com/pytorch/pytorch/blob/5318bf8baf19fecda365c185cd81196e3cfb08e3/torch/_dynamo/symbolic_convert.py#L417-L424

**Get trace log by running**

```bash
TORCH_TRACE=/tmp/my_traced_log python test.py
```

**Using tlparse to get report**

```
tlparse dedicated_log_torch_trace_9unwqrxn.log  -o out1
```

**Result**

![image](https://github.com/user-attachments/assets/01d2ff25-90ec-4b9f-bcb6-5ae59ba65b35)


strack info in `0_0_0/dynamo_graph_break_reason_0.txt `
![image](https://github.com/user-attachments/assets/c4a04bd0-496a-4862-8230-c01f85e6f3c3)



cc @ezyang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames