### PR TITLE
[checkpointing][oss] Throw an error when loading a different size than saved tensor

### DIFF
--- a/test/distributed/checkpoint/test_planner.py
+++ b/test/distributed/checkpoint/test_planner.py
@@ -358,6 +358,19 @@ class TestLoadPlanner(TestCase):
                 planner=DefaultLoadPlanner(allow_partial_load=False),
             )
 
+    @with_temp_dir
+    def test_load_different_sizes_throws(self):
+        original_module = nn.Linear(2, 2)
+        dcp.save(state_dict={"module": original_module}, checkpoint_id=self.temp_dir)
+
+        new_module = nn.Linear(3, 2)
+        with self.assertRaisesRegex(CheckpointException, "Size mismatch"):
+            dcp.load(
+                state_dict={"module": new_module},
+                checkpoint_id=self.temp_dir,
+                planner=DefaultLoadPlanner(),
+            )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/checkpoint/default_planner.py
+++ b/torch/distributed/checkpoint/default_planner.py
@@ -356,6 +356,14 @@ def create_default_local_load_plan(
                 continue
 
         md = metadata.state_dict_metadata[fqn]
+        if (
+            isinstance(md, TensorStorageMetadata)
+            and getattr(obj, "size", None) is not None
+            and md.size != obj.size()
+        ):
+            raise ValueError(
+                f"Size mismatch between saved {md.size} and current: {obj.size()} for {fqn}",
+            )
         # Since DTensor supports submesh, adding extra check to ensure _create_read_items()
         # gets called only when the current rank is part of the mesh for the corresponding DTensor.
         if isinstance(obj, DTensor):


### PR DESCRIPTION
Summary: Fixing issue reported in https://github.com/pytorch/pytorch/issues/126604

Test Plan: buck2 test 'fbcode//mode/dev-nosan' fbcode//caffe2/test/distributed/checkpoint:test_planner -- --exact 'caffe2/test/distributed/checkpoint:test_planner - test_planner.TestLoadPlanner: test_strict

Differential Revision: D66389578




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn