### PR TITLE
Fix fallthrough behaviour when Meta in TLS include set

### DIFF
--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -166,7 +166,8 @@ public:
     });
     // Keys that are fallthrough should be skipped
     if (requiresBitsetPerBackend_) {
-      auto backend_idx = ks.getBackendIndex();
+      c10::impl::LocalDispatchKeySet tls = c10::impl::tls_local_dispatch_key_set();
+      auto backend_idx = ((ks | tls.included_) - tls.excluded_).getBackendIndex();
       return impl::computeDispatchKeySet(ks, nonFallthroughKeysPerBackend_[backend_idx]);
     } else {
       return impl::computeDispatchKeySet(ks, nonFallthroughKeys_);
@@ -178,7 +179,8 @@ public:
     auto ks = detail::multi_dispatch_key_set(args...);
     // Keys that are fallthrough should be skipped
     if (requiresBitsetPerBackend_) {
-      auto backend_idx = ks.getBackendIndex();
+      c10::impl::LocalDispatchKeySet tls = c10::impl::tls_local_dispatch_key_set();
+      auto backend_idx = ((ks | tls.included_) - tls.excluded_).getBackendIndex();
       return impl::computeDispatchKeySet(ks, nonFallthroughKeysPerBackend_[backend_idx]);
     } else {
       return impl::computeDispatchKeySet(ks, nonFallthroughKeys_);


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/141120

Registering a fallthrough for a backend correctly alters nonFallthroughKeysPerBackend_[backend_idx]. However, the backend_idx calculation does not take into account the local dispatch key set, which is used to temporarily turn on Meta as a backend. This means that makeFallthrough does not behave exactly as if it was a normal function which redispatched rather than a "fake function" implemented with a key mask.

So e.g. impl::computeDispatchKeySet(ks, nonFallthroughKeysPerBackend_[backend_idx]); will exclude keys like Meta which may be in the TLS include set.