### PR TITLE
Don't throw on setting metric twice if the metric value hasn't changed

### DIFF
--- a/torch/_dynamo/metrics_context.py
+++ b/torch/_dynamo/metrics_context.py
@@ -65,9 +65,9 @@ class MetricsContext:
         """
         if self._level == 0:
             raise RuntimeError(f"Cannot set {metric} outside of a MetricsContext")
-        if metric in self._metrics:
+        if metric in self._metrics and self._metrics[metric] != value:
             raise RuntimeError(
-                f"Metric '{metric}' has already been set in the current context"
+                f"Metric '{metric}' has already been set to a different value ({self._metrics[metric]}) in the current context"
             )
         self._metrics[metric] = value
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141582

This is causing FbFxGraphRemoteCache.__init__ to no longer be idempotent, i.e. only safe to call once per compile. AOTAutogradCache initializes a new remote cache for the forward and the backward.

Technically, we could make AOTAutogradCache smart and globally thread through a single FbFxGraphRemoteCache everywhere. But there's no reason to do so, as this class is just the handle to access the cache. Plus, it's very brittle for FbFxGraphRemoteCache to not be safe to call multiple times.

Differential Revision: [D66502138](https://our.internmc.facebook.com/intern/diff/D66502138/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames