### PR TITLE
Update libgfortran version in aarch64 Docker

### DIFF
--- a/.ci/docker/manywheel/Dockerfile_aarch64
+++ b/.ci/docker/manywheel/Dockerfile_aarch64
@@ -61,7 +61,7 @@ RUN git config --global --add safe.directory "*"
 # NOTE: Need a better way to get this library as Ubuntu's package can be removed by the vender, or changed
 ###############################################################################
 RUN cd ~/ \
-  && curl -L -o ~/libgfortran-10-dev.deb http://ports.ubuntu.com/ubuntu-ports/pool/universe/g/gcc-10/libgfortran-10-dev_10.5.0-1ubuntu1_arm64.deb \
+  && curl -L -o ~/libgfortran-10-dev.deb http://ports.ubuntu.com/ubuntu-ports/pool/universe/g/gcc-10/libgfortran-10-dev_10.5.0-4ubuntu2_arm64.deb \
   && ar x ~/libgfortran-10-dev.deb \
   && tar --use-compress-program=unzstd -xvf data.tar.zst -C ~/ \
   && cp -f ~/usr/lib/gcc/aarch64-linux-gnu/10/libgfortran.a /opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/


### PR DESCRIPTION
From `libgfortran-10-dev_10.5.0-1ubuntu1_arm64.deb` to `libgfortran-10-dev_10.5.0-4ubuntu2_arm64.deb` as former is no longer available:
```
% curl --head http://ports.ubuntu.com/ubuntu-ports/pool/universe/g/gcc-10/libgfortran-10-dev_10.5.0-1ubuntu1_arm64.deb
HTTP/1.1 404 Not Found
Date: Tue, 26 Nov 2024 16:58:10 GMT
Server: Apache/2.4.29 (Ubuntu)
Content-Type: text/html; charset=iso-8859-1
```
vs
```
% curl --head http://ports.ubuntu.com/ubuntu-ports/pool/universe/g/gcc-10/libgfortran-10-dev_10.5.0-4ubuntu2_arm64.deb
HTTP/1.1 200 OK
Date: Tue, 26 Nov 2024 16:58:48 GMT
Server: Apache/2.4.29 (Ubuntu)
Last-Modified: Sun, 31 Mar 2024 10:51:08 GMT
ETag: "713d4-614f2a681d48b"
Accept-Ranges: bytes
Content-Length: 463828
Content-Type: application/x-debian-package
```

Here is the failure: https://github.com/pytorch/pytorch/actions/runs/12032016986/job/33542862322