### PR TITLE
Add doc preview command

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,9 +417,12 @@ readthedocs theme.
 ```bash
 cd docs/
 pip install -r requirements.txt
+make html
+make serve
 ```
-You can then build the documentation by running `make <format>` from the
-`docs/` folder. Run `make` to get a list of all available output formats.
+
+
+Run `make` to get a list of all available output formats.
 
 If you get a katex error run `npm install katex`.  If it persists, try
 `npm install -g katex`

--- a/README.md
+++ b/README.md
@@ -421,7 +421,6 @@ make html
 make serve
 ```
 
-
 Run `make` to get a list of all available output formats.
 
 If you get a katex error run `npm install katex`.  If it persists, try

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -41,7 +41,10 @@ html-stable:
 	# See conf.py for more details.
 	RELEASE=1 make html
 
-.PHONY: help Makefile docset onnx exportdb
+.PHONY: help Makefile docset onnx exportdb serve
+
+serve:
+	@cd $(BUILDDIR)/html && $(PYCMD) -m http.server $(PORT)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
Convenience, when we build pytorch docs
1. Docs for build weren't clear that `make html` is the main command intended to be ran
2. Once you run `make html` you need to visualize the work, opening up a simple http server seems like the simplest solution so adding a `make serve command`

Usage 

```shell
numpy ❯ make serve PORT=8080 # Add port optionally
Serving HTTP on :: port 8080 (http://[::]:8080/) ...
::1 - - [26/Nov/2024 10:05:41] "GET / HTTP/1.1" 200 -
::1 - - [26/Nov/2024 10:05:41] "GET /_static/copybutton.css HTTP/1.1" 200 -
::1 - - [26/Nov/2024 10:05:41] "GET /_static/katex-math.css HTTP/1.1" 200 -
```

![Screenshot 2024-11-26 at 10 05 46 AM](https://github.com/user-attachments/assets/3b275c33-1515-4e21-b540-f5a68c8a8e55)

