### PR TITLE
[Matmul][CUDA][FP8] Skip rowwise scaling tests on non-`sm90`

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -558,6 +558,7 @@ class TestFP8MatmulCuda(TestCase):
         out_fp8_s = torch._scaled_mm(x, y, scale_a=scale_a, scale_b=scale_b, use_fast_accum=True)
         self.assertEqual(out_fp8, out_fp8_s)
 
+    @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
     @unittest.skipIf(torch.cuda.get_device_capability(0)[0] != 9, "rowwise implementation is currently sm90 specific")
     @skipIfRocm()
@@ -664,6 +665,7 @@ class TestFP8MatmulCuda(TestCase):
                 out_dtype=torch.bfloat16,
             )
 
+    @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
     @unittest.skipIf(torch.cuda.get_device_capability(0)[0] != 9, "rowwise implementation is currently sm90 specific")
     @skipIfRocm()

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -16,7 +16,6 @@ from torch.quantization._quantized_conversions import (
 from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import (
     SM53OrLater,
-    SM90OrLater,
     _get_torch_cuda_version,
     PLATFORM_SUPPORTS_FP8
 )

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -560,7 +560,7 @@ class TestFP8MatmulCuda(TestCase):
         self.assertEqual(out_fp8, out_fp8_s)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
-    @unittest.skipIf(not SM90OrLater, "rowwise implementation is currently sm90 specific")
+    @unittest.skipIf(torch.cuda.get_device_capability(0)[0] != 9, "rowwise implementation is currently sm90 specific")
     @skipIfRocm()
     @parametrize("use_fast_accum", [True, False])
     def test_float8_rowwise_scaling_sanity(self, device, use_fast_accum: bool) -> None:
@@ -666,7 +666,7 @@ class TestFP8MatmulCuda(TestCase):
             )
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
-    @unittest.skipIf(not SM90OrLater, "rowwise implementation is currently sm90 specific")
+    @unittest.skipIf(torch.cuda.get_device_capability(0)[0] != 9, "rowwise implementation is currently sm90 specific")
     @skipIfRocm()
     @parametrize("base_dtype", [torch.bfloat16])
     def test_scaled_mm_vs_emulated_row_wise(self, base_dtype):

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -34,6 +34,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     skipIfRocmVersionLessThan,
+    TEST_CUDA,
     TEST_WITH_ROCM,
     skipIfRocm,
     TestCase,

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -558,9 +558,8 @@ class TestFP8MatmulCuda(TestCase):
         out_fp8_s = torch._scaled_mm(x, y, scale_a=scale_a, scale_b=scale_b, use_fast_accum=True)
         self.assertEqual(out_fp8, out_fp8_s)
 
-    @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
-    @unittest.skipIf(torch.cuda.get_device_capability(0)[0] != 9, "rowwise implementation is currently sm90 specific")
+    @unittest.skipIf(not TEST_CUDA or torch.cuda.get_device_capability(0)[0] != 9, "rowwise implementation is currently sm90 specific")
     @skipIfRocm()
     @parametrize("use_fast_accum", [True, False])
     def test_float8_rowwise_scaling_sanity(self, device, use_fast_accum: bool) -> None:
@@ -665,9 +664,8 @@ class TestFP8MatmulCuda(TestCase):
                 out_dtype=torch.bfloat16,
             )
 
-    @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
-    @unittest.skipIf(torch.cuda.get_device_capability(0)[0] != 9, "rowwise implementation is currently sm90 specific")
+    @unittest.skipIf(not TEST_CUDA or torch.cuda.get_device_capability(0)[0] != 9, "rowwise implementation is currently sm90 specific")
     @skipIfRocm()
     @parametrize("base_dtype", [torch.bfloat16])
     def test_scaled_mm_vs_emulated_row_wise(self, base_dtype):

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -41,8 +41,10 @@ from torch.testing._internal.common_utils import (
 )
 
 _IS_SM8X = False
-if torch.cuda.is_available():
+_IS_SM9X = False
+if TEST_CUDA:
     _IS_SM8X = torch.cuda.get_device_capability(0)[0] == 8
+    _IS_SM9X = torch.cuda.get_device_capability(0)[0] == 9
 
 # Protects against includes accidentally setting the default dtype
 assert torch.get_default_dtype() is torch.float32
@@ -560,7 +562,7 @@ class TestFP8MatmulCuda(TestCase):
         self.assertEqual(out_fp8, out_fp8_s)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
-    @unittest.skipIf(not TEST_CUDA or torch.cuda.get_device_capability(0)[0] != 9, "rowwise implementation is currently sm90 specific")
+    @unittest.skipIf(not _IS_SM9X, "rowwise implementation is currently sm90 specific")
     @skipIfRocm()
     @parametrize("use_fast_accum", [True, False])
     def test_float8_rowwise_scaling_sanity(self, device, use_fast_accum: bool) -> None:
@@ -666,7 +668,7 @@ class TestFP8MatmulCuda(TestCase):
             )
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
-    @unittest.skipIf(not TEST_CUDA or torch.cuda.get_device_capability(0)[0] != 9, "rowwise implementation is currently sm90 specific")
+    @unittest.skipIf(not _IS_SM9X, "rowwise implementation is currently sm90 specific")
     @skipIfRocm()
     @parametrize("base_dtype", [torch.bfloat16])
     def test_scaled_mm_vs_emulated_row_wise(self, base_dtype):


### PR DESCRIPTION
Since the current kernel is using sm90-specific features, just pre-emptively skip the test for any non-sm90 compute capabilities

cc @yanbing-j @vkuzo @albanD @kadeng @penguinwu