### PR TITLE
ci: Add ciflow/split-build label to probot config

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -23,6 +23,7 @@ ciflow_push_tags:
 - ciflow/xpu
 - ciflow/torchbench
 - ciflow/autoformat
+- ciflow/split-build
 retryable_workflows:
 - pull
 - trunk


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #141600
* __->__ #141599
* #141359

Adds ciflow/split-build as a possible label, currently a no-op but
functionality will be added later on.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>