### PR TITLE
[FlexAttention] Remove ValueError on checking batch dimension equality

### DIFF
--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -1209,21 +1209,6 @@ def flex_attention(
                 f"Expect number of query heads to be a multiple of kv heads for GQA "
                 f"but got Hq={Hq} and Hkv={Hkv}."
             )
-    if query.size(0) != key.size(0):
-        if block_mask is None:
-            raise ValueError(
-                f"Expect query and key/value to have the same batch size, "
-                f"or non-none block_mask, "
-                f"but got block_mask=None, Bq={query.size(0)}, and Bkv={key.size(0)}."
-            )
-
-        if block_mask.kv_num_blocks.size(0) != query.size(0):
-            raise ValueError(
-                f"Expect query and key/value to have the same batch size, "
-                f"or block_mask and query to have the same batch size, "
-                f"but got Bq={query.size(0)}, Bkv={key.size(0)}, B_block_mask={block_mask.kv_num_blocks.size(0)}."
-            )
-
     if score_mod is None:
         score_mod = _identity
     elif query.is_nested:


### PR DESCRIPTION
Removes unnecessary checks.