### PR TITLE
[pytorch/profiler] Honor escape quotes arg in a profiler metadata log formatter (#141527)

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -506,7 +506,7 @@ void onFunctionExit(
     auto& extra_meta = *(kineto_ctx_ptr->event_->extra_nccl_meta_);
     // Record only the outputs in this exit callback of the record function
     torch::profiler::impl::SaveNcclMetaConfig ncclMetaConfig{
-        false, false, false, true};
+        true, false, false, true};
     auto additonal_nccl_meta =
         torch::profiler::impl::saveNcclMeta(fn, ncclMetaConfig);
     extra_meta.insert(additonal_nccl_meta.begin(), additonal_nccl_meta.end());

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -382,9 +382,17 @@ static inline std::string format_list(
     bool truncate,
     bool with_escaped_quotes = true) {
   if (truncate && list.size() > kTruncatLength) {
-    return fmt::format(
-        "\"[{}, ...]\"",
-        fmt::join(list.begin(), list.begin() + kTruncatLength, ", "));
+    if (with_escaped_quotes == true) {
+      auto x = fmt::format(
+          "\"[{}, ...]\"",
+          fmt::join(list.begin(), list.begin() + kTruncatLength, ", "));
+      return x;
+    } else {
+      auto x = fmt::format(
+          "[{}, ...]",
+          fmt::join(list.begin(), list.begin() + kTruncatLength, ", "));
+      return x;
+    }
   }
   if (with_escaped_quotes == true) {
     auto x = fmt::format("\"[{}]\"", fmt::join(list.begin(), list.end(), ", "));
@@ -949,5 +957,4 @@ bool checkFunctionInputsForLogging(const at::RecordFunction& fn) {
   }
   return true;
 }
-
 } // namespace torch::profiler::impl


### PR DESCRIPTION
Summary:

We were ignoring the with_escaped_quotes param in format_list inline function iin utils.cpp in the case where we had to truncate a list of more than kTruncatelength items.

In that case we would truncate a list into a string but always return it with an escaped quotes wrapping it. this will cause issues if this string is meant to be added to other lists which will also go through formatting. Leading to cases like `"["[a, b, c, ...]"]"`.

now the above will be well formatted as `"[[a, b, c, ...]]"` as the escape quote requests will be honored.

Differential Revision: D66521676


