### PR TITLE
[BE] Fix incompatible-std-redefinition warning

### DIFF
--- a/tools/rules_cc/cuda_support.patch
+++ b/tools/rules_cc/cuda_support.patch
@@ -15,7 +15,7 @@ index ba992fc..e4e8364 100644
          repository_ctx,
          "BAZEL_CXXOPTS",
 -        "-std=c++0x",
-+        "-std=c++11",
++        "-std=c++17",
          False,
      ), ":")
  


### PR DESCRIPTION
Fixes following warning during CUDA bazel builds
```
nvcc-real warning : incompatible redefinition for option 'std', the last value of this option was used
```
