### PR TITLE
Add missing test for type NestedTensor

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -5452,6 +5452,46 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
             self.assertTrue(nt.is_pinned())
 
     @dtypes(torch.float, torch.double, torch.half)
+    @parametrize("components_require_grad", [False, True])
+    def test_jagged_serialization_as_nested_tensor(
+        self, device, dtype, components_require_grad
+    ):
+        for tensor_list in self._get_example_tensor_lists(
+            include_list_of_lists=False, include_requires_grad=components_require_grad
+        ):
+            nt = torch.nested.as_nested_tensor(
+                tensor_list, device=device, dtype=dtype, layout=torch.jagged
+            )
+            expected_dim = tensor_list[0].dim() + 1
+            expected_batch_size = len(tensor_list)
+            expected_contiguous = True
+            expected_min_seqlen = min(
+                (torch.tensor(t) if isinstance(t, list) else t).shape[0]
+                for t in tensor_list
+            )
+            expected_max_seqlen = max(
+                (torch.tensor(t) if isinstance(t, list) else t).shape[0]
+                for t in tensor_list
+            )
+
+            with tempfile.NamedTemporaryFile() as f:
+                torch.save(nt, f)
+                f.seek(0)
+                nt2 = torch.load(f, weights_only=False)
+                self._validate_nt(
+                    nt,
+                    device,
+                    dtype,
+                    torch.jagged,
+                    components_require_grad,
+                    expected_dim,
+                    expected_batch_size,
+                    expected_contiguous,
+                    expected_min_seqlen,
+                    expected_max_seqlen,
+                )
+
+    @dtypes(torch.float, torch.double, torch.half)
     @parametrize("requires_grad", [False, True])
     @parametrize("values_is_view", [False, True])
     def test_jagged_view_from_values_offsets(

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -5479,7 +5479,7 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
                 f.seek(0)
                 nt2 = torch.load(f, weights_only=False)
                 self._validate_nt(
-                    nt,
+                    nt2,
                     device,
                     dtype,
                     torch.jagged,


### PR DESCRIPTION
Fixes #126453.

Currently, there are existing serialization tests in test_tensor.py, but they use nested tensors initialized with torch.nested.nested_tensor (which returns a nested_tensor type).

Following the approach outlined on this [page](https://pytorch.org/docs/stable/nested.html#constructor-functions:~:text=torch.nested.as_nested_tensor(ts%2C%20dtype%3DNone%2C%20device%3DNone%2C%20layout%3DNone)), we are implementing a serialization test for the NestedTensor type which is initialized with 'as_nested_tensor' function.

@mikaylagawarecki 

cc @cpuhrsch @jbschlosser @bhosmer @drisspg @soulitzer @davidberard98 @YuqingJ