### PR TITLE
Remove functorch config: `_max_aliased_inputs_with_dynamic_shapes_enabled`.

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -1555,8 +1555,6 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
         # the first 50 of them. Then, make sure that none of the produced ShapeEnv
         # guards came from the overlapping computation.
 
-        torch._functorch.config._max_aliased_inputs_with_dynamic_shapes_enabled = 101
-
         def f(*args):
             for a in args:
                 a.add_(1)

--- a/test/dynamo/test_dynamic_shapes.py
+++ b/test/dynamo/test_dynamic_shapes.py
@@ -86,11 +86,6 @@ if TEST_Z3:
             DynamicShapesMiscTests.test_parameter_free_dynamic_shapes  # noqa: F821
         )
 
-unittest.expectedFailure(
-    # Test is only valid without dynamic shapes
-    DynamicShapesReproTests.test_many_views_with_mutation_dynamic_shapes  # noqa: F821
-)
-
 # Test takes too long ~700s as of 414a1fd29f04d06e41b7f895368dd1f83a4be29d
 DynamicShapesExportTests.test_retracibility_dynamic_shapes = slowTest(  # noqa: F821
     DynamicShapesExportTests.test_retracibility_dynamic_shapes  # noqa: F821

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -4600,7 +4600,6 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         else:
             self.assertExpectedInline(cnt.frame_count, """1""")
 
-    @unittest.expectedFailure
     def test_many_overlapping_inputs_does_not_explode_guards(self):
         from torch._dynamo.backends.common import aot_autograd
 

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -27,16 +27,6 @@ debug_assert = False
 
 debug_partitioner = os.environ.get("AOT_PARTITIONER_DEBUG", "0") != "0"
 
-# Today, if you are in a situation where there is "false aliasing"
-# (e.g. you have a bunch of model parameters that all alias the same underlying buffer),
-# our checks for this situation are very slow if these inputs have dynamic shapes.
-# This config is set to ensure that there aren't too many aliased inputs in this situation,
-# so that we error loudly instead of compiling forever.
-# Eventually, we should make these checks faster.
-# For now, however, you can simply turn off dynamic shapes by marking your inputs static
-# when you run into this situation.
-_max_aliased_inputs_with_dynamic_shapes_enabled = 5
-
 static_weight_shapes = True
 
 # Applies CSE to the graph before partitioning


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141680
* #140013
* #139555
* #139554

This PR removes the functorch config that set an upper limit on the number of aliased
inputs with dynamic shapes. After moving them to be run at runtime in C++, the compilation
time and runtime (in true alias cases) improved, rendering the error no longer relevant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames