### PR TITLE
Respect checkpointed boundaries when using knapsack formulation in the partitioner

### DIFF
--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -712,7 +712,12 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             )
             trs = self.get_world_trs()
 
-            compiled_fn = torch.compile(example, fullgraph=True, dynamic=True)
+            compiled_fn = torch.compile(
+                example,
+                fullgraph=True,
+                dynamic=True,
+                backend="aot_eager_decomp_partition",
+            )
 
             if override_with_ac:
 

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1780,8 +1780,14 @@ def choose_saved_values_set(
         ]
 
     recomputable_banned_nodes = get_recomputable_banned_nodes(banned_nodes)
-    # sort first by name, to ensure determinism when multiple nodes have same size
-    recomputable_banned_nodes = sorted(recomputable_banned_nodes, key=lambda x: x.name)
+    must_save_nodes = [
+        i
+        for i in recomputable_banned_nodes
+        if i.meta.get("recompute", False) == CheckpointPolicy.MUST_SAVE
+    ]
+    recomputable_banned_nodes = [
+        i for i in recomputable_banned_nodes if i not in must_save_nodes
+    ]
 
     # default: runtime_optimized_saved_values
     # more aggressive: more_aggressive_saved_values
@@ -1791,7 +1797,7 @@ def choose_saved_values_set(
         recomputable_banned_nodes, key=_size_of, reverse=True
     )
     if len(all_recomputable_banned_nodes) == 0:
-        return node_info.inputs
+        return node_info.inputs + must_save_nodes
     memories_banned_nodes = [
         get_normalized_size(_size_of(i)) for i in all_recomputable_banned_nodes
     ]


### PR DESCRIPTION
When multiple checkpoint regions are back-to-back with no operations in-between, we enforce the operation at the boundary to be force-saved, see https://github.com/pytorch/pytorch/blob/7ea0da2d57107b087b38ec0b7fa47ff1ab84ee75/torch/_functorch/partitioners.py#L772-L807

When using the `memory_budget` formulation on a graph which already has AC inside, we should respect the boundaries of the AC decision (which is set to `MUST_SAVE`), and thus ban those nodes from possible recomputation.

Adding tests would be nice, but not sure what's the best way to test this right now.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @yf225 @xuanzhang816 