### PR TITLE
[ROCm] Enable inductor GEMM lowering for gfx11

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1110,6 +1110,9 @@ def is_big_gpu(index) -> bool:
     # Arbitrarily skipping the older models
     if torch.version.hip is not None:
         if prop.major < 9 or prop.major == 10:
+            log.warning(
+                "GPU arch does not support max_autotune_gemm mode usage"
+            )
             return False
         return True
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1108,7 +1108,7 @@ def is_big_gpu(index) -> bool:
 
     # SM logic is not relevant to ROCm gpus
     # Arbitrarily skipping the older models
-    if torch.version.hip is not None:
+    if torch.version.hip:
         if prop.major < 9 or prop.major == 10:
             log.warning(
                 "GPU arch does not support max_autotune_gemm mode usage"

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1104,8 +1104,17 @@ class DelayReplaceLine(DeferredLineBase):
 
 @functools.lru_cache(None)
 def is_big_gpu(index) -> bool:
+    prop = torch.cuda.get_device_properties(index)
+
+    # SM logic is not relevant to ROCm gpus
+    # Arbitrarily skipping the older models
+    if torch.version.hip is not None:
+        if prop.major < 9 or prop.major == 10:
+            return False
+        return True
+
     min_sms = 68  # 3080
-    avail_sms = torch.cuda.get_device_properties(index).multi_processor_count
+    avail_sms = prop.multi_processor_count
     if avail_sms < min_sms:
         log.warning(
             "Not enough SMs to use max_autotune_gemm mode",

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1110,9 +1110,7 @@ def is_big_gpu(index) -> bool:
     # Arbitrarily skipping the older models
     if torch.version.hip:
         if prop.major < 9 or prop.major == 10:
-            log.warning(
-                "GPU arch does not support max_autotune_gemm mode usage"
-            )
+            log.warning("GPU arch does not support max_autotune_gemm mode usage")
             return False
         return True
 


### PR DESCRIPTION
This check doesn't make sense for some of the AMD gpus since they have the right amount of CUs but multi_processor_count returns WGPs on RDNA while still performing adequately. A lot of tests fail on modern archs due to this check defaulting them to not using the GEMMs backend.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov