### PR TITLE
[Inductor] fix broadcast logic for Triton (#141027)

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -230,6 +230,50 @@ class TritonBlockPointerTest(InductorTestCase):
             config_patches={"triton.prefer_nd_tiling": prefer_nd_tiling},
         )
 
+    @parametrize(
+        "x_size,y_size",
+        [
+            ((32, 1), (32, 32)),
+            ((1, 8), (8, 8)),
+            # ((4, 1, 3), (4, 5, 3)), # TODO: T207754224
+            ((4, 1, 3), (4, 4, 3)),
+            ((1, 5, 5), (5, 5, 5)),
+            ((5, 5, 1), (5, 5, 5)),
+            ((5, 1, 1), (5, 5, 5)),
+            ((1, 1, 5), (5, 5, 5)),
+            ((1, 5, 1), (5, 5, 5)),
+            ((7, 1, 1, 4), (7, 3, 4, 4)),
+            ((5, 6, 1, 1), (5, 6, 4, 3)),
+        ],
+    )
+    def test_expand_broadcast(self, x_size: Tuple[int], y_size: Tuple[int]):
+        """
+        When the load and store have different shapes, we should use broadcast.
+        """
+
+        def foo(x, y_size):
+            return x.expand(y_size).clone()
+
+        def get_input(size: Tuple[int]) -> torch.Tensor:
+            device = torch.device(GPU_TYPE)
+            full = torch.randn(size).to(device)
+            view = torch.as_strided(full, size, full.stride())
+            return view
+
+        x = get_input(x_size)
+        y = y_size
+
+        # Check that input sizes are not the same
+        self.assertNotEqual(x_size, y_size)
+
+        # Check that is valid broadcast
+        self.assertEqual(len(x_size), len(y_size))
+        for i, j in zip(x_size, y_size):
+            if i != 1:
+                self.assertEqual(i, j)
+
+        result, (triton_code,) = self.run_and_compare(foo, x, y)
+
     @parametrize("prefer_nd_tiling", [False, True])
     def test_pointwise_broadcast_nonzero_strides(self, prefer_nd_tiling: bool):
         """
@@ -268,7 +312,7 @@ class TritonBlockPointerTest(InductorTestCase):
             )
             self.assertExpectedInline(
                 "\n".join(store_lines),
-                """    tl.store(tl.make_block_ptr(out_ptr0, shape=[8, 8], strides=[1, 8], block_shape=[XBLOCK, YBLOCK], order=[1, 0], offsets=[xoffset, yoffset]), tmp2.to(tl.float32), boundary_check=[0, 1])""",  # noqa: B950
+                """    tl.store(tl.make_block_ptr(out_ptr0, shape=[8, 8], strides=[1, 8], block_shape=[XBLOCK, YBLOCK], order=[1, 0], offsets=[xoffset, yoffset]), tl.broadcast_to(tmp2, [XBLOCK, YBLOCK]).to(tl.float32), boundary_check=[0, 1])""",  # noqa: B950
             )
         else:
             self.assertExpectedInline(
@@ -279,7 +323,7 @@ class TritonBlockPointerTest(InductorTestCase):
             )
             self.assertExpectedInline(
                 "\n".join(store_lines),
-                """    tl.store(tl.make_block_ptr(out_ptr0, shape=[64], strides=[1], block_shape=[XBLOCK], order=[0], offsets=[xoffset]), tmp2.to(tl.float32), boundary_check=[0])""",  # noqa: B950
+                """    tl.store(tl.make_block_ptr(out_ptr0, shape=[64], strides=[1], block_shape=[XBLOCK], order=[0], offsets=[xoffset]), tl.broadcast_to(tmp2, [XBLOCK]).to(tl.float32), boundary_check=[0])""",  # noqa: B950
             )
 
     @parametrize("prefer_nd_tiling", [False, True])

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -250,9 +250,8 @@ class BlockPtrOptions:
         # We need an explicit broadcast for stores, or if the final reshape does more
         # than add singletons.
         sizevars = V.graph.sizevars
-        if any(self.broadcasting_dims) and (
-            not allow_implicit
-            or len(pre_broadcast_shape) != len(final_shape)
+        require_broadcast = any(self.broadcasting_dims) and (
+            len(pre_broadcast_shape) != len(final_shape)
             or any(
                 not (
                     sizevars.statically_known_equals(pre_dim, 1)
@@ -260,7 +259,9 @@ class BlockPtrOptions:
                 )
                 for pre_dim, post_dim in zip(pre_broadcast_shape, final_shape)
             )
-        ):
+        )
+
+        if not allow_implicit or require_broadcast:
             value = f"tl.broadcast_to({value}, {V.kernel.index_to_str(self.broadcast_shape)})"
 
         # Reshape to the final shape.


### PR DESCRIPTION
Summary:

Fix logic for inserting broadcast on kernel with load going directly to store. In the case where load is going directly to store, we insert a tl.broadcast on the store, regardless of the block size on the load. In the case where a broadcast is not required, the downstream Triton compiler is expected to remove this no-op broadcast instruction.

Test Plan: Added tests under test_torchinductor_strided_blocks.py:test_expand_broadcast in OSS and internal test cases.

Reviewed By: blaine-rister

Differential Revision: D65518033




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov