### PR TITLE
[Pytorch] respect config.realize_opcount_threshold for small values

### DIFF
--- a/test/inductor/test_perf.py
+++ b/test/inductor/test_perf.py
@@ -11,6 +11,10 @@ from torch._inductor import metrics
 from torch._inductor.compile_fx import compile_fx, compile_fx_inner
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
 
 ########################
 # Explanation of Tests #
@@ -684,6 +688,40 @@ class TilingTests(TestCase):
 
         inp = (T(10, 10, 10), T(10, 10, 10), T(10, 10, 10))
         self.assertExpectedInline(count_numel(f, *inp), """4000""")
+
+@instantiate_parametrized_tests
+class OpCountThresholdTest(self)
+    @parametrize(
+        "fusion_enabled",
+        (True, False),
+    )
+    def test_fusion_thresholds(self, fusion_enabled: bool):
+        """
+        Test that config thresholds enable/disable fusion.
+        """
+
+        inductor_config = {
+            "max_fusion_size": 1,
+            "realize_reads_threshold": 1,
+            "realize_opcount_threshold": 1,
+            "inplace_buffers": False,
+        } if not fusion_enabled else {}
+
+        def foo(x, y, z):
+            return x + y + z
+
+        inputs = [T(32) for input_idx in range(3)]
+
+        # Run and test accuracy
+        with config.patch(inductor_config):
+            result, code = run_and_get_code(torch.compile(foo), *inputs)
+        ref = foo(*inputs)
+        self.assertTrue(torch.allclose(result, ref))
+
+        # Check the number of kernels. Everything should be fused into a single kernel
+        # iff fusion is enabled.
+        num_kernels = code[0].count("triton.jit")
+        self.assertEqual(num_kernels, 1 if fusion_enabled else 2)
 
 
 class MinCutPartitioningTests(TestCase):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -419,7 +419,7 @@ warn_mix_layout = os.environ.get("TORCHINDUCTOR_WARN_MIX_LAYOUT") == "1"
 # For fanouts, rematerialization can lead to exponential blowup. So, have
 # smaller threshold
 realize_reads_threshold = 4
-realize_opcount_threshold = 30
+realize_opcount_threshold = 100
 
 # Threshold to prevent excessive accumulation of ops in one buffer during lowering
 realize_acc_reads_threshold = 8

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1617,7 +1617,7 @@ class GraphLowering(torch.fx.Interpreter):
                 curr = result.data.data
                 if isinstance(curr, Pointwise):
                     # Use inner fn as a rough proxy. Good enough.
-                    if curr.has_large_inner_fn(threshold=100):
+                    if curr.has_large_inner_fn():
                         result.realize()
 
         # This is not complete, but it doesn't have to be: origin_node

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -523,7 +523,7 @@ class IRNode:
         except NotImplementedError:
             return None
 
-    def has_large_inner_fn(self, threshold: Optional[int] = None) -> bool:
+    def has_large_inner_fn(self) -> bool:
         return False
 
     def mark_reuse(self, users: int) -> None:
@@ -752,11 +752,8 @@ class Loops(IRNode):
             self.inner_fn, *self.inner_fn_args()
         )
 
-    def has_large_inner_fn(self, threshold: Optional[int] = None) -> bool:
-        if threshold is None:
-            threshold = 0
-        threshold = max(threshold, config.realize_opcount_threshold)
-        return self.inner_fn_opcount().num_ops > threshold
+    def has_large_inner_fn(self) -> bool:
+        return self.inner_fn_opcount().num_ops > config.realize_opcount_threshold
 
     def inner_fn_free_unbacked_symbols(self) -> Set[Symbol]:
         index = self._index(self.ranges)
@@ -6806,8 +6803,8 @@ class MutableBox(IRNode):
     def get_name(self) -> str:
         return self.data.get_name()
 
-    def has_large_inner_fn(self, threshold: Optional[int] = None) -> bool:
-        return self.data.has_large_inner_fn(threshold)
+    def has_large_inner_fn(self) -> bool:
+        return self.data.has_large_inner_fn()
 
     def mark_reuse(self, users: int) -> None:
         return self.data.mark_reuse(users)


### PR DESCRIPTION
Summary: The opcount threshold is currently bumped up to 100 if it's less than that. This prevents us from forcing Inductor not to fuse things, which is useful for testing purposes. Instead of silently bumping the thershould, we can just set the default to 100 but respect the user's choice to lower it.

Differential Revision: D66529288




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov