### PR TITLE
Add Manylinux2014 and Manylinux 2.28 config to triton builds. Run auditwheel on triton binaries

### DIFF
--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -56,6 +56,7 @@ def build_triton(
     device: str = "cuda",
     py_version: Optional[str] = None,
     release: bool = False,
+    with_clang_ldd: bool = False,
 ) -> Path:
     env = os.environ.copy()
     if "MAX_JOBS" not in env:
@@ -133,8 +134,9 @@ def build_triton(
 
         # change built wheel name and version
         env["TRITON_WHEEL_NAME"] = triton_pkg_name
-        if device == "cuda":
+        if with_clang_ldd:
             env["TRITON_BUILD_WITH_CLANG_LLD"] = "1"
+
         patch_init_py(
             triton_pythondir / "triton" / "__init__.py",
             version=f"{version}",
@@ -176,18 +178,20 @@ def main() -> None:
     )
     parser.add_argument("--py-version", type=str)
     parser.add_argument("--commit-hash", type=str)
+    parser.add_argument("--with-clang-ldd", action="store_true")
     parser.add_argument("--triton-version", type=str, default=read_triton_version())
     args = parser.parse_args()
 
     build_triton(
         device=args.device,
-        commit_hash=args.commit_hash
-        if args.commit_hash
-        else read_triton_pin(args.device),
+        commit_hash=(
+            args.commit_hash if args.commit_hash else read_triton_pin(args.device)
+        ),
         version=args.triton_version,
         build_conda=args.build_conda,
         py_version=args.py_version,
         release=args.release,
+        with_clang_ldd=args.with_clang_ldd,
     )
 
 

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -132,8 +132,12 @@ jobs:
             WITH_CLANG_LDD="--with-clang-ldd"
           fi
           docker exec -t "${container_name}" bash -c "${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE $RELEASE $WITH_CLANG_LDD"
-          docker exec -t "${container_name}"  bash -c "auditwheel repair --plat ${PLATFORM} //artifacts/*.whl"
-          # after repair new wheel is located in wheelhouse subfolder
+          if [[ "${{ matrix.device }}" == "cuda" ]]; then
+            docker exec -t "${container_name}"  bash -c "auditwheel repair --plat ${PLATFORM} //artifacts/*.whl"
+          else
+            docker exec -t "${container_name}"  bash -c "mkdir //artifacts/wheelhouse"
+            docker exec -t "${container_name}"  bash -c "mv //artifacts/*.whl //artifacts/wheelhouse/"
+          fi
           docker exec -t "${container_name}" chown -R 1000.1000 /artifacts/wheelhouse
 
       - uses: actions/upload-artifact@v4.4.0

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -129,7 +129,7 @@ jobs:
 
           docker exec -t "${container_name}" yum install -y zlib-devel zip
           docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}"  -m pip install -U setuptools==67.4.0 pybind11==2.13.1 auditwheel
-          if [[ "${{ matrix.device }}" == "cuda" &&  "${PLATFORM}"" == "manylinux_2_28_x86_64" ]]; then
+          if [[ "${{ matrix.device }}" == "cuda" &&  "${PLATFORM}" == "manylinux_2_28_x86_64" ]]; then
             # With this install, it gets clang 16.0.6.
             docker exec -t "${container_name}" dnf install clang lld -y
           fi

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -128,7 +128,7 @@ jobs:
           fi
 
           docker exec -t "${container_name}" yum install -y zlib-devel zip
-          docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}"  -m pip install -U setuptools==67.4.0 pybind11==2.13.1 auditwheel
+          docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}"  -m pip install -U setuptools==67.4.0 pybind11==2.13.1 auditwheel cmake
           if [[ "${{ matrix.device }}" == "cuda" &&  "${PLATFORM}" == "manylinux_2_28_x86_64" ]]; then
             # With this install, it gets clang 16.0.6.
             docker exec -t "${container_name}" dnf install clang lld -y

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -125,11 +125,10 @@ jobs:
             docker exec -t "${container_name}" dnf install clang lld -y
           fi
           docker exec -t "${container_name}" bash -c "${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE $RELEASE"
-          docker exec -t "${container_name}" chown -R 1000.1000 /artifacts
-
-          if[[ "${BUILD_DEVICE}" == 'cuda' ]]; then
+          if [[ "${{ matrix.device }}" == "cuda" ]]; then
             docker exec -t "${container_name}" auditwheel repair --plat manylinux_2_28_x86_64 /artifacts/*.whl
           fi
+          docker exec -t "${container_name}" chown -R 1000.1000 /artifacts
 
       - uses: actions/upload-artifact@v4.4.0
         with:

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -123,7 +123,7 @@ jobs:
           fi
 
           PLATFORM="manylinux_2_28_x86_64"
-          if [[ "${{ matrix.device }}" == "pytorch/manylinux-builder:cpu" ]]; then
+          if [[ "${DOCKER_IMAGE}" == "pytorch/manylinux-builder:cpu" ]]; then
             PLATFORM="manylinux2014_x86_64"
           fi
 

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -49,7 +49,7 @@ jobs:
         docker-image: ["pytorch/manylinux-builder:cpu", "pytorch/manylinux2_28-builder:cpu"]
         exclude:
           - device: "rocm"
-            docker-image: "pytorch/manylinux2_28-builder"
+            docker-image: "pytorch/manylinux2_28-builder:cpu"
         include:
           - device: "rocm"
             rocm_version: "6.2"
@@ -129,7 +129,7 @@ jobs:
 
           docker exec -t "${container_name}" yum install -y zlib-devel zip
           docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}"  -m pip install -U setuptools==67.4.0 pybind11==2.13.1 auditwheel
-          if [[ "${{ matrix.device }}" == "cuda" ]]; then
+          if [[ "${{ matrix.device }}" == "cuda" &&  "${PLATFORM}"" == "manylinux_2_28_x86_64" ]]; then
             # With this install, it gets clang 16.0.6.
             docker exec -t "${container_name}" dnf install clang lld -y
           fi

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -46,6 +46,10 @@ jobs:
       matrix:
         py_vers: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         device: ["cuda", "rocm"]
+        docker-image: ["pytorch/manylinux-builder:cpu", "pytorch/manylinux2_28-builder:cpu"]
+        exclude:
+          - device: "rocm"
+            docker-image: "pytorch/manylinux2_28-builder"
         include:
           - device: "rocm"
             rocm_version: "6.2"
@@ -53,7 +57,7 @@ jobs:
             rocm_version: ""
     timeout-minutes: 40
     env:
-      DOCKER_IMAGE: ${{ matrix.device == 'rocm' && format('pytorch/manylinux-builder:rocm{0}', matrix.rocm_version) || 'pytorch/manylinux2_28-builder:cpu' }}
+      DOCKER_IMAGE: ${{ matrix.device == 'rocm' && format('pytorch/manylinux-builder:rocm{0}', matrix.rocm_version) || matrix.docker-image }}
       PY_VERS: ${{ matrix.py_vers }}
       BUILD_DEVICE: ${{ matrix.device }}
     steps:
@@ -118,6 +122,11 @@ jobs:
             RELEASE="--release"
           fi
 
+          PLATFORM="manylinux_2_28_x86_64"
+          if [[ "${{ matrix.device }}" == "pytorch/manylinux-builder:cpu" ]]; then
+            PLATFORM="manylinux2014_x86_64"
+          fi
+
           docker exec -t "${container_name}" yum install -y zlib-devel zip
           docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}"  -m pip install -U setuptools==67.4.0 pybind11==2.13.1 auditwheel
           if [[ "${{ matrix.device }}" == "cuda" ]]; then
@@ -126,8 +135,7 @@ jobs:
           fi
           docker exec -t "${container_name}" bash -c "${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE $RELEASE"
           if [[ "${{ matrix.device }}" == "cuda" ]]; then
-            docker exec -t "${container_name}"  bash -c "ls -las //artifacts/"
-            docker exec -t "${container_name}"  bash -c "auditwheel repair --plat manylinux_2_28_x86_64 //artifacts/*.whl"
+            docker exec -t "${container_name}"  bash -c "auditwheel repair --plat ${PLATFORM} //artifacts/*.whl"
           fi
           docker exec -t "${container_name}" chown -R 1000.1000 /artifacts
 

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -132,16 +132,15 @@ jobs:
             WITH_CLANG_LDD="--with-clang-ldd"
           fi
           docker exec -t "${container_name}" bash -c "${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE $RELEASE $WITH_CLANG_LDD"
-          if [[ "${{ matrix.device }}" == "cuda" ]]; then
-            docker exec -t "${container_name}"  bash -c "auditwheel repair --plat ${PLATFORM} //artifacts/*.whl"
-          fi
-          docker exec -t "${container_name}" chown -R 1000.1000 /artifacts
+          docker exec -t "${container_name}"  bash -c "auditwheel repair --plat ${PLATFORM} //artifacts/*.whl"
+          # after repair new wheel is located in wheelhouse subfolder
+          docker exec -t "${container_name}" chown -R 1000.1000 /artifacts/wheelhouse
 
       - uses: actions/upload-artifact@v4.4.0
         with:
           name: pytorch-triton-wheel-${{ matrix.py_vers }}-${{ matrix.device }}-${{ env.PLATFORM }}
           if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/*
+          path: ${{ runner.temp }}/artifacts/wheelhouse/*
 
       - name: Teardown Linux
         uses: pytorch/test-infra/.github/actions/teardown-linux@main

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -126,7 +126,8 @@ jobs:
           fi
           docker exec -t "${container_name}" bash -c "${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE $RELEASE"
           if [[ "${{ matrix.device }}" == "cuda" ]]; then
-            docker exec -t "${container_name}"  bash -c "auditwheel repair --plat manylinux_2_28_x86_64 ${{ runner.temp }}/artifacts/*.whl"
+            docker exec -t "${container_name}"  bash -c "ls -las //artifacts/"
+            docker exec -t "${container_name}"  bash -c "auditwheel repair --plat manylinux_2_28_x86_64 //artifacts/*.whl"
           fi
           docker exec -t "${container_name}" chown -R 1000.1000 /artifacts
 

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -118,6 +118,7 @@ jobs:
           esac
 
           RELEASE=""
+          WITH_CLANG_LDD=""
           if [[ "${IS_RELEASE_TAG}" == true ]]; then
             RELEASE="--release"
           fi
@@ -128,12 +129,13 @@ jobs:
           fi
 
           docker exec -t "${container_name}" yum install -y zlib-devel zip
-          docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}"  -m pip install -U setuptools==67.4.0 pybind11==2.13.1 auditwheel cmake
+          docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}"  -m pip install -U setuptools==67.4.0 pybind11==2.13.1 auditwheel
           if [[ "${{ matrix.device }}" == "cuda" &&  "${PLATFORM}" == "manylinux_2_28_x86_64" ]]; then
             # With this install, it gets clang 16.0.6.
             docker exec -t "${container_name}" dnf install clang lld -y
+            WITH_CLANG_LDD="--with-clang-ldd"
           fi
-          docker exec -t "${container_name}" bash -c "${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE $RELEASE"
+          docker exec -t "${container_name}" bash -c "${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE $RELEASE $WITH_CLANG_LDD"
           if [[ "${{ matrix.device }}" == "cuda" ]]; then
             docker exec -t "${container_name}"  bash -c "auditwheel repair --plat ${PLATFORM} //artifacts/*.whl"
           fi

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -126,7 +126,7 @@ jobs:
           fi
           docker exec -t "${container_name}" bash -c "${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE $RELEASE"
           if [[ "${{ matrix.device }}" == "cuda" ]]; then
-            docker exec -t "${container_name}" auditwheel repair --plat manylinux_2_28_x86_64 /artifacts/*.whl
+            docker exec -t "${container_name}"  bash -c "auditwheel repair --plat manylinux_2_28_x86_64 ${{ runner.temp }}/artifacts/*.whl"
           fi
           docker exec -t "${container_name}" chown -R 1000.1000 /artifacts
 

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -119,13 +119,17 @@ jobs:
           fi
 
           docker exec -t "${container_name}" yum install -y zlib-devel zip
-          docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}"  -m pip install -U setuptools==67.4.0 pybind11==2.13.1
+          docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}"  -m pip install -U setuptools==67.4.0 pybind11==2.13.1 auditwheel
           if [[ "${{ matrix.device }}" == "cuda" ]]; then
             # With this install, it gets clang 16.0.6.
             docker exec -t "${container_name}" dnf install clang lld -y
           fi
           docker exec -t "${container_name}" bash -c "${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE $RELEASE"
           docker exec -t "${container_name}" chown -R 1000.1000 /artifacts
+
+          if[[ "${BUILD_DEVICE}" == 'cuda' ]]; then
+            docker exec -t "${container_name}" auditwheel repair --plat manylinux_2_28_x86_64 /artifacts/*.whl
+          fi
 
       - uses: actions/upload-artifact@v4.4.0
         with:

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -60,6 +60,7 @@ jobs:
       DOCKER_IMAGE: ${{ matrix.device == 'rocm' && format('pytorch/manylinux-builder:rocm{0}', matrix.rocm_version) || matrix.docker-image }}
       PY_VERS: ${{ matrix.py_vers }}
       BUILD_DEVICE: ${{ matrix.device }}
+      PLATFORM: ${{ contains(matrix.docker-image, '2_28') && 'manylinux_2_28_x86_64' || 'manylinux2014_x86_64' }}
     steps:
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
@@ -123,11 +124,6 @@ jobs:
             RELEASE="--release"
           fi
 
-          PLATFORM="manylinux_2_28_x86_64"
-          if [[ "${DOCKER_IMAGE}" == "pytorch/manylinux-builder:cpu" ]]; then
-            PLATFORM="manylinux2014_x86_64"
-          fi
-
           docker exec -t "${container_name}" yum install -y zlib-devel zip
           docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}"  -m pip install -U setuptools==67.4.0 pybind11==2.13.1 auditwheel
           if [[ "${{ matrix.device }}" == "cuda" &&  "${PLATFORM}" == "manylinux_2_28_x86_64" ]]; then
@@ -143,7 +139,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4.4.0
         with:
-          name: pytorch-triton-wheel-${{ matrix.py_vers }}-${{ matrix.device }}
+          name: pytorch-triton-wheel-${{ matrix.py_vers }}-${{ matrix.device }}-${{ env.PLATFORM }}
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/*
 


### PR DESCRIPTION
This PR combines Manylinux 2_28 and Manylinux 2014  builds of triton under one workflow. This is required in order to support torch cpu, cuda 118, cuda 12.4 wheels built with Manylinux 2014 and torch cuda 12.6 wheels built with Manylinux 2_28.

Manylinux 2014 wheels:
``pytorch_triton-3.2.0+git35c6c7c6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl``
Manylinux 2_28 wheels:
``pytorch_triton-3.2.0+git35c6c7c6-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl``

