### PR TITLE
[BE]: Enable RUF013 ban implicit optional

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernels/generate_kernels.py
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernels/generate_kernels.py
@@ -308,8 +308,7 @@ def write_decl_impl(
     family_name: str,
     impl_file: str,
     autogen_dir: Path,
-    # fix noqa next time bc breaking changes added
-    disable_def: str = None,  # noqa: RUF013
+    disable_def: Optional[str] = None,
 ) -> None:
     cpp_file_header = """/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernels/generate_kernels.py
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernels/generate_kernels.py
@@ -308,7 +308,8 @@ def write_decl_impl(
     family_name: str,
     impl_file: str,
     autogen_dir: Path,
-    disable_def: str = None,
+    # fix noqa next time bc breaking changes added
+    disable_def: str = None,  # noqa: RUF013
 ) -> None:
     cpp_file_header = """/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ select = [
     "Q004",  # unnecessary escaped quote
     "RSE",
     "RUF008", # mutable dataclass default
+    "RUF013", # ban implicit optional
     "RUF015", # access first ele in constant time
     "RUF016", # type error non-integer index
     "RUF017",

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -215,8 +215,7 @@ class TracerBase:
         kwargs: Dict[str, Any],
         name: Optional[str] = None,
         type_expr: Optional[Any] = None,
-        # fix noqa after next bc update
-        proxy_factory_fn: Callable[[Node], "Proxy"] = None,  # noqa: RUF013
+        proxy_factory_fn: Optional[Callable[[Node], "Proxy"]] = None,
     ):
         """
         Create a Node from the given arguments, then return the Node

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -215,7 +215,8 @@ class TracerBase:
         kwargs: Dict[str, Any],
         name: Optional[str] = None,
         type_expr: Optional[Any] = None,
-        proxy_factory_fn: Callable[[Node], "Proxy"] = None,
+        # fix noqa after next bc update
+        proxy_factory_fn: Callable[[Node], "Proxy"] = None,  # noqa: RUF013
     ):
         """
         Create a Node from the given arguments, then return the Node

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -215,7 +215,8 @@ class TracerBase:
         kwargs: Dict[str, Any],
         name: Optional[str] = None,
         type_expr: Optional[Any] = None,
-        proxy_factory_fn: Optional[Callable[[Node], "Proxy"]] = None,
+        # fix noqa when updating bc tests
+        proxy_factory_fn: Callable[[Node], "Proxy"] = None,  # noqa: RUF013
     ):
         """
         Create a Node from the given arguments, then return the Node

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1846,7 +1846,7 @@ def skipCUDAIfNotMiopenSuggestNHWC(fn):
 
 
 # Skips a test for specified CUDA versions, given in the form of a list of [major, minor]s.
-def skipCUDAVersionIn(versions: List[Tuple[int, int]] = None):
+def skipCUDAVersionIn(versions: Optional[List[Tuple[int, int]]] = None):
     def dec_fn(fn):
         @wraps(fn)
         def wrap_fn(self, *args, **kwargs):
@@ -1864,7 +1864,7 @@ def skipCUDAVersionIn(versions: List[Tuple[int, int]] = None):
 
 
 # Skips a test for CUDA versions less than specified, given in the form of [major, minor].
-def skipCUDAIfVersionLessThan(versions: Tuple[int, int] = None):
+def skipCUDAIfVersionLessThan(versions: Optional[Tuple[int, int]] = None):
     def dec_fn(fn):
         @wraps(fn)
         def wrap_fn(self, *args, **kwargs):


### PR DESCRIPTION
Enables RUF013 rule to ban implicit Optional (from areas not already checked by mypy).

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv