### PR TITLE
Set remote cache version and backend type once in compilation metrics

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -998,18 +998,17 @@ def record_compilation_metrics(
 
     if torch._inductor.utils.should_use_remote_fx_graph_cache():
         try:
-            from torch._inductor.fb.remote_cache import REMOTE_CACHE_VERSION
-            from torch._utils_internal import justknobs_check
+            from torch._inductor.fb.remote_cache import (
+                FbRemoteFxGraphCache,
+                REMOTE_CACHE_VERSION,
+            )
         except ModuleNotFoundError:
             REMOTE_CACHE_VERSION = None
+            inductor_fx_remote_cache_backend_type = None
 
         remote_cache_version = REMOTE_CACHE_VERSION
-        if (os.environ.get("TORCHINDUCTOR_USE_ZIPPYDB") == "1") or justknobs_check(
-            "pytorch/remote_cache:fx_graph_cache_use_zippydb"
-        ):
-            inductor_fx_remote_cache_backend_type = "ZippyDBCache"
-        else:
-            inductor_fx_remote_cache_backend_type = "_ManifoldCache"
+        backend = FbRemoteFxGraphCache.get_remote_backend()
+        inductor_fx_remote_cache_backend_type = type(backend).__name__
     else:
         inductor_fx_remote_cache_backend_type = None
         remote_cache_version = None

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1005,8 +1005,8 @@ def record_compilation_metrics(
 
         remote_cache_version = REMOTE_CACHE_VERSION
         if (os.environ.get("TORCHINDUCTOR_USE_ZIPPYDB") == "1") or justknobs_check(
-                "pytorch/remote_cache:fx_graph_cache_use_zippydb"
-            ):
+            "pytorch/remote_cache:fx_graph_cache_use_zippydb"
+        ):
             inductor_fx_remote_cache_backend_type = "ZippyDBCache"
         else:
             inductor_fx_remote_cache_backend_type = "_ManifoldCache"
@@ -1032,7 +1032,7 @@ def record_compilation_metrics(
             "inductor_fx_remote_cache_miss_keys"
         ),
         "remote_cache_version": remote_cache_version,
-        "inductor_fx_remote_cache_backend_type": inductor_fx_remote_cache_backend_type
+        "inductor_fx_remote_cache_backend_type": inductor_fx_remote_cache_backend_type,
     }
 
     # TODO: The following are legacy fields, populated from the fields that replace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #141911
* __->__ #141707

This is causing FbFxGraphRemoteCache.init to no longer be idempotent, i.e. only safe to call once per compile. AOTAutogradCache initializes a new remote cache for the forward and the backward.
Technically, we could make AOTAutogradCache smart and globally thread through a single FbFxGraphRemoteCache everywhere. But there's no reason to do so, as this class is just the handle to access the cache. Plus, it's very brittle for FbFxGraphRemoteCache to not be safe to call multiple times.

(Same problem, different fix of D66502138)

Differential Revision: [D66508492](https://our.internmc.facebook.com/intern/diff/D66508492/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames