### PR TITLE
Enable both training and inference perf benchmark on GPU by default when using workflow dispatch

### DIFF
--- a/.github/workflows/inductor-perf-test-nightly-a10g.yml
+++ b/.github/workflows/inductor-perf-test-nightly-a10g.yml
@@ -16,10 +16,10 @@ on:
         type: boolean
         default: true
       inference:
-        description: Run inference (off by default)?
+        description: Run inference (on by default)?
         required: false
         type: boolean
-        default: false
+        default: true
       default:
         description: Run inductor_default?
         required: false

--- a/.github/workflows/inductor-perf-test-nightly-macos.yml
+++ b/.github/workflows/inductor-perf-test-nightly-macos.yml
@@ -12,10 +12,10 @@ on:
         type: boolean
         default: true
       inference:
-        description: Run inference (off by default)?
+        description: Run inference (on by default)?
         required: false
         type: boolean
-        default: false
+        default: true
       benchmark_configs:
         description: The list of configs used the benchmark
         required: false

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -14,10 +14,10 @@ on:
         type: boolean
         default: true
       inference:
-        description: Run inference (off by default)?
+        description: Run inference (on by default)?
         required: false
         type: boolean
-        default: false
+        default: true
       default:
         description: Run inductor_default?
         required: false


### PR DESCRIPTION
A feedback from @bobrenjc93 that while https://github.com/pytorch/pytorch/actions/workflows/inductor-perf-test-nightly.yml didn't run inference perf by default, the dashboard shows that mode on its landing page https://hud.pytorch.org/benchmark/compilers.  This is a source of confusion because folks won't see their branches unless they choose the correct mode.

IMO, it makes sense to run both training and inference by default when using workflow dispatch. This ensures that the branch will show up in both modes.