### PR TITLE
Refactor "torch.mtia.memory_stats" API

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -71,6 +71,7 @@ Features described in this documentation are classified by release status:
    mps
    xpu
    mtia
+   mtia.memory
    meta
    torch.backends <backends>
    torch.export <export>

--- a/docs/source/mtia.memory.rst
+++ b/docs/source/mtia.memory.rst
@@ -1,0 +1,13 @@
+torch.mtia.memory
+===================================
+
+The MTIA backend is implemented out of the tree, only interfaces are be defined here.
+
+.. automodule:: torch.mtia.memory
+.. currentmodule:: torch.mtia.memory
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    memory_stats

--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -15,7 +15,7 @@ from torch.types import Device
 from ._utils import _get_device_index
 
 
-_device_t = Union[_device, str, int, None]
+_device_t = Union[_device, str, int]
 
 # torch.mtia.Event/Stream is alias of torch.Event/Stream
 Event = torch.Event
@@ -149,19 +149,6 @@ def default_stream(device: Optional[_device_t] = None) -> Stream:
             (default).
     """
     return torch._C._mtia_getDefaultStream(_get_device_index(device, optional=True))
-
-
-def memory_stats(device: Optional[_device_t] = None) -> Dict[str, Any]:
-    r"""Return a dictionary of MTIA memory allocator statistics for a given device.
-
-    Args:
-        device (torch.device or int, optional) selected device. Returns
-            statistics for the current device, given by current_device(),
-            if device is None (default).
-    """
-    if not is_initialized():
-        return {}
-    return torch._C._mtia_memoryStats(_get_device_index(device, optional=True))
 
 
 def get_device_capability(device: Optional[_device_t] = None) -> Tuple[int, int]:
@@ -325,6 +312,9 @@ def set_rng_state(
         UserWarning,
         stacklevel=2,
     )
+
+
+from .memory import *  # noqa: F403
 
 
 __all__ = [

--- a/torch/mtia/memory.py
+++ b/torch/mtia/memory.py
@@ -1,0 +1,28 @@
+# pyre-strict
+
+r"""This package adds support for device memory management implemented in MTIA."""
+
+from typing import Any, Dict, Optional
+
+import torch
+
+from . import _device_t, is_initialized
+from ._utils import _get_device_index
+
+
+def memory_stats(device: Optional[_device_t] = None) -> Dict[str, Any]:
+    r"""Return a dictionary of MTIA memory allocator statistics for a given device.
+
+    Args:
+        device (torch.device, str, or int, optional) selected device. Returns
+            statistics for the current device, given by current_device(),
+            if device is None (default).
+    """
+    if not is_initialized():
+        return {}
+    return torch._C._mtia_memoryStats(_get_device_index(device, optional=True))
+
+
+__all__ = [
+    "memory_stats",
+]


### PR DESCRIPTION
Summary:
This diff refactors the code for the "torch.mtia.memory_stats" API to maintain the same file hierarchy as its CUDA counterpart:
- All device memory APIs are now located under ".../mtia/memory.py".
- Device memory APIs can be accessed using either "torch.mtia.XYZ" or "torch.mtia.memory.XYZ".

Test Plan:
Passed a local unit test: `buck run //mtia/host_runtime/torch_mtia/tests:test_torch_mtia_api`

```
Ran 14 tests in 16.657s

OK
I1127 11:06:06.505201 2133030 afg_bindings.cpp:943] afg-aten::mul.out-dtype_Float-bBtLGD6Y executable has been unloaded
I1127 11:06:06.506654 2133030 afg_bindings.cpp:943] afg-add-dtype_Float-fa37JncC executable has been unloaded
W1127 11:06:08.731138 2133030 HazptrDomain.h:148] Tagged objects remain. This may indicate a higher-level leak of object(s) that use hazptr_obj_cohort.
```

Differential Revision: D66549179




cc @egienvalue