### PR TITLE
[while_loop] change to guard_equals for checking output and carry

### DIFF
--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -853,7 +853,7 @@ class WhileLoopTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     # dynamic=True doesn't work due to we haven't handle lifted symbols
-    @parametrize("dynamic", [False])
+    @parametrize("dynamic", [True, False])
     def test_while_loop_with_pytree_inputs(self, device, dynamic):
         self._run_test(
             model=WhileLoopModels.PytreeCarry(),

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7326,8 +7326,16 @@ class WhileLoop(ExternKernel):
         # make sure carried_inputs and body outputs are structurally equivalent
         assert len(carried_inputs) == len(body_outputs), (carried_inputs, body_outputs)
         for i, (op, bo) in enumerate(zip(carried_inputs, body_outputs)):
-            assert op.get_size() == bo.get_size(), (i, op, bo)
-            assert op.get_stride() == bo.get_stride(), (i, op, bo)
+
+            def _guard_list_equals(
+                lhs_exprs: List[Union[int, sympy.expr]],
+                rhs_exprs: List[Union[int, sympy.expr]],
+            ) -> None:
+                for lhs, rhs in zip(lhs_exprs, rhs_exprs):
+                    V.graph.sizevars.guard_equals(lhs, rhs)
+
+            _guard_list_equals(op.get_size(), bo.get_size())
+            _guard_list_equals(op.get_stride(), bo.get_stride())
             # assume all carried_inputs and outputs are on the same device
             # as the MultiOutputLayout below requires single device
             assert op.get_device() == bo.get_device() == device, (i, op, bo, device)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #141393
* #140106
* __->__ #141734


The input with the same can be represented with different symbols e.g.
```python
def body_fn(a, b):
  return b.sin(), a.sin()
```
, where a = torch.randn(3, 4), b= torch.randn(3, 4). There could be 4 symbols allocated for a and b. So instead of checking their shapes and strides' symbol must be the same, we just use guard_equals to enforce the constraint.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov