### PR TITLE
[codemod] c10::string_view -> std::string_view in fields

### DIFF
--- a/aten/src/ATen/core/dynamic_type.cpp
+++ b/aten/src/ATen/core/dynamic_type.cpp
@@ -258,7 +258,7 @@ TypePtr DynamicType::fallback() const {
         fallbacks.push_back(elem.ty->fallback());
       }
       if (name_) {
-        std::vector<c10::string_view> fields;
+        std::vector<std::string_view> fields;
         fields.reserve(arguments_.elems.size());
         for (const auto& elem : arguments_.elems) {
           // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
@@ -382,7 +382,7 @@ TORCH_API TupleTypePtr ivalue::TupleTypeFactory<TupleType>::fallback(
   return nullptr;
 #else
   const auto& dyn = type.expectRef<DynamicType>();
-  std::vector<c10::string_view> fields;
+  std::vector<std::string_view> fields;
   std::vector<TypePtr> types;
 
   for (const auto& elem : dyn.arguments().elems) {

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1154,7 +1154,7 @@ struct TORCH_API TupleType : public NamedType {
       const std::vector<TypePtr>& field_types);
 
   static TupleTypePtr createNamed(const std::optional<c10::QualifiedName>& name,
-      const std::vector<c10::string_view>& field_names,
+      const std::vector<std::string_view>& field_names,
       const std::vector<TypePtr>& field_types);
 
   static TupleTypePtr create(
@@ -1190,7 +1190,7 @@ struct TORCH_API TupleType : public NamedType {
   const std::shared_ptr<FunctionSchema>& schema() const {
     return schema_;
   }
-  std::optional<std::vector<c10::string_view>> names() const;
+  std::optional<std::vector<std::string_view>> names() const;
 
   static const TypeKind Kind = TypeKind::TupleType;
 

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -728,7 +728,7 @@ TupleTypePtr TupleType::createNamed(
 
 TupleTypePtr TupleType::createNamed(
     const std::optional<c10::QualifiedName>& qualName,
-    const std::vector<c10::string_view>& field_names,
+    const std::vector<std::string_view>& field_names,
     const std::vector<TypePtr>& field_types) {
   std::vector<IValue> empty_defaults;
   return createWithSpec(qualName, field_names, field_types, empty_defaults);
@@ -784,11 +784,11 @@ TupleTypePtr TupleType::createWithSpec(const std::optional<c10::QualifiedName>& 
       field_types, qualName, std::move(schema))); // NOLINT(modernize-make-shared)
 }
 
-std::optional<std::vector<c10::string_view>> TupleType::names() const {
+std::optional<std::vector<std::string_view>> TupleType::names() const {
   if (!schema_) {
     return {};
   }
-  std::vector<c10::string_view> ret;
+  std::vector<std::string_view> ret;
   for (const auto& arg : schema_->arguments()) {
     ret.emplace_back(arg.name());
   }

--- a/aten/src/ATen/core/type_factory.cpp
+++ b/aten/src/ATen/core/type_factory.cpp
@@ -61,7 +61,7 @@ const std::unordered_map<std::string, c10::TypePtr>& DefaultTypeFactory::
 
 c10::TypePtr DefaultTypeFactory::createNamedTuple(
     const std::string& name,
-    const std::vector<c10::string_view>& fields,
+    const std::vector<std::string_view>& fields,
     const std::vector<c10::TypePtr>& types) {
   return c10::TupleType::createNamed(name, fields, types);
 }

--- a/aten/src/ATen/core/type_factory.h
+++ b/aten/src/ATen/core/type_factory.h
@@ -80,7 +80,7 @@ struct TORCH_API TypeFactoryBase<c10::Type> {
   }
   static c10::TypePtr createNamedTuple(
       const std::string& name,
-      const std::vector<c10::string_view>& fields,
+      const std::vector<std::string_view>& fields,
       const std::vector<c10::TypePtr>& types);
   template <typename T>
   C10_ERASE static c10::TypePtr createNamed(const std::string& name) {


### PR DESCRIPTION
Summary: `c10::string_view` is being removed, so we need to migrate.

Test Plan: Sandcastle

Reviewed By: palmje

Differential Revision: D65830276


