### PR TITLE
[3/N] Remove events from Flight Recorder

### DIFF
--- a/torch/csrc/distributed/c10d/FlightRecorder.hpp
+++ b/torch/csrc/distributed/c10d/FlightRecorder.hpp
@@ -104,7 +104,6 @@ struct TraceBuffer {
     capture_cpp_stack_ = getCvarBool({"TORCH_NCCL_TRACE_CPP_STACK"}, false);
     enabled_ = max_entries_ > 0;
   }
-  using Event = at::cuda::CUDAEvent;
   struct Entry {
     size_t id_; // incremented id in the trace buffer
                 // used to figure out where in the circular entries
@@ -125,10 +124,6 @@ struct TraceBuffer {
     std::string profiling_name_;
 
     std::shared_ptr<torch::CapturedTraceback> traceback_;
-    // we borrow pointers to start_ and end_ so we can query the state
-    // on reporting. However, once the event is completed, the call
-    // to `complete` will clear these.
-    Event *start_, *end_;
 
     // timestamp when the entry was created, likely close to the time the work
     // was 'enqueued'- not necessarily started
@@ -186,8 +181,6 @@ struct TraceBuffer {
       std::string profiling_name,
       const std::vector<at::Tensor>& inputs,
       const std::vector<at::Tensor>& outputs,
-      Event* start,
-      Event* end,
       std::chrono::milliseconds timeout_ms,
       std::shared_ptr<ProcessGroupStatus> pg_status,
       bool isP2P);
@@ -196,13 +189,16 @@ struct TraceBuffer {
       const std::tuple<std::string, std::string>& pg_name,
       std::vector<uint64_t> ranks);
 
-  void update_state(Entry& r);
+  void markStart(std::optional<size_t> id);
+  void markEnd(
+      std::optional<size_t> id,
+      std::optional<float> duration = std::nullopt);
 
   std::vector<Entry> dump_entries();
 
   // Returns the entry with the given id, if it exists. Otherwise, returns
   // std::nullopt.
-  std::optional<Entry> getEntry(std::optional<size_t> id);
+  std::optional<Entry*> getEntry(std::optional<size_t> id);
 
   /*
   Mark an Event as completed and free its events.
@@ -214,7 +210,7 @@ struct TraceBuffer {
   never hang. (timing must also be enabled for compute_duration - see
   TORCH_NCCL_ENABLE_TIMING).
   */
-  void retire_id(std::optional<size_t> id, bool compute_duration = true);
+  void retire_id(std::optional<size_t> id);
 
   const c10::List<c10::IValue> getCollectiveTrace(
       bool includeStacktraces,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141737
* #141712
* #141648

Initially we just want to generalize `CUDAEvent` to `c10::Event` to make FR device agnostic. But we realized that the conversion is not available today without change in `aten::cuda::CUDAEvent`. Thus we consider an alternative which removes Events from FR.

### How are events used in FR today? Are they replaceable?
In two places:
1. To calculate work duration in `retire_id`;
2. To `update_state` of an entry during `dump`, where the states relate to start time & complete time.

Re 1:
Watchdog is calling `retire_id` anyway. So it doesn't hurt for watchdog to calculate the duration and give it to FR.
This PR changes `retire_id` signature from:
`retire_id(id, bool compute_duration)` to
`retire_id(id, std::optional duration)`.

Re 2:
The `update_state` call seems to be for a case where watchdog hanged and did not update the state of an entry in time. FR updates it later when dumping the trace. Personally I doubt this works because the hang of watchdog means CUDA is already obstructed and there is little chance FR can do it instead. Moreover, it introduced CUDA calls in the dump behavior (executed by the heartbeat thread), making it hang'able too which is not desired.

### Other Considerations
3. **If NCCL comm is aborting, no "complete" information is reliable afterwards**. Thus we prefer watchdog to explicitly mark complete than FR doing so in the background or near the end of the program (dumping).

4. It is a higher bar to ask **all** accelerators to never hang in event query, once FR is generalized. Or at least, there are unknowns. Thus this PR takes a conservative mental model.

5. Today FR keeps a raw pointer of the events, which poses a leak to the event cache that is based on shared_ptr?

Per the above considerations, this PR removes events from FR.

To compensate for start/complete/duration info, this PR adds `markStart` method and provides duration to `retire_id`.

CC: @c-p-i-o @fduwjj @wconstab 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o 