### PR TITLE
[WIP][1/2] Fix Symbol conflict between libm.lib and ucrt.lib on Windows: XNNPACK

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -785,6 +785,10 @@ if(HAVE_SOVERSION)
 endif()
 torch_compile_options(torch_cpu)  # see cmake/public/utils.cmake
 
+if(Win32)
+  target_compile_options(torch_cpu PRIVATE "/Zc:static_assert")
+endif()
+
 # Ignore Wdeprecated-XXX errors from third-party libraries
 if(NOT MSVC)
   set_source_files_properties(${PROJECT_SOURCE_DIR}/torch/csrc/distributed/c10d/socket.cpp PROPERTIES COMPILE_OPTIONS "-Wno-error=deprecated")

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -786,7 +786,7 @@ endif()
 torch_compile_options(torch_cpu)  # see cmake/public/utils.cmake
 
 if(Win32)
-  target_compile_options(torch_cpu PRIVATE "/Zc:static_assert")
+  target_compile_options(torch_cpu PRIVATE "/std:c++17")
 endif()
 
 # Ignore Wdeprecated-XXX errors from third-party libraries

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -785,10 +785,6 @@ if(HAVE_SOVERSION)
 endif()
 torch_compile_options(torch_cpu)  # see cmake/public/utils.cmake
 
-if(Win32)
-  target_compile_options(torch_cpu PRIVATE "/std:c++17")
-endif()
-
 # Ignore Wdeprecated-XXX errors from third-party libraries
 if(NOT MSVC)
   set_source_files_properties(${PROJECT_SOURCE_DIR}/torch/csrc/distributed/c10d/socket.cpp PROPERTIES COMPILE_OPTIONS "-Wno-error=deprecated")

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -539,6 +539,12 @@ if(USE_XNNPACK AND NOT USE_SYSTEM_XNNPACK)
     set(__caffe2_CMAKE_POSITION_INDEPENDENT_CODE_FLAG ${CMAKE_POSITION_INDEPENDENT_CODE})
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+    if(Win32)
+      # Windows MSVC is not have libm, and this option possible to bring in linker issue:
+      # https://github.com/pytorch/pytorch/issues/134989
+      set(XNNPACK_BUILD_WITH_LIBM OFF CACHE BOOL "")
+    endif()
+
     add_subdirectory(
       "${XNNPACK_SOURCE_DIR}"
       "${CONFU_DEPENDENCIES_BINARY_DIR}/XNNPACK")


### PR DESCRIPTION
Analysys:

1. We find the Intel compiler build option to disable its `libm`: https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/2024-2/no-intel-lib-qno-intel-lib.html . But it is doesn't work.
    Because of the `torch_cpu.dll` is built by MSVC, but not by intel compiler.
2. For the `libm` bringed in, I did some research.
    a. Some PyTorch third party submodules, such as `sleef`, `xnnpack`. Their cmake files may call `find_library(m)` to search `libm`. Usually, they can't find the libm on Windows MSVC environment.
    b. When we build `XPU` version of PyTorch, we need to source Intel compiler environment. And it will bring its `libm` to build environment. So, step a on `XPU` build environment would bring in `libm` into dependency.

Solution:
As `libm` shouldn't have existing on Windows, we can add a build option to `sleef` and `xnnpack` to turn off `libm`. It is the first PR for `xnnpack`.

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10