### PR TITLE
#129777 Fix libnvrtc.so shorthash by regressing to ${Python_EXECUTABLE}

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -132,7 +132,7 @@ set(CUDA_NVRTC_LIB "${CUDA_nvrtc_LIBRARY}" CACHE FILEPATH "")
 if(CUDA_NVRTC_LIB AND NOT CUDA_NVRTC_SHORTHASH)
   find_package(Python COMPONENTS Interpreter)
   execute_process(
-    COMMAND Python::Interpreter -c
+    COMMAND ${Python_EXECUTABLE} -c
     "import hashlib;hash=hashlib.sha256();hash.update(open('${CUDA_NVRTC_LIB}','rb').read());print(hash.hexdigest()[:8])"
     RESULT_VARIABLE _retval
     OUTPUT_VARIABLE CUDA_NVRTC_SHORTHASH)


### PR DESCRIPTION
Fixes #129777 


cc @malfet @seemethere