### PR TITLE
Enabled force_shape_pad for test_pad_mm and test_slice_mm_bandwidth_computation

### DIFF
--- a/test/inductor/test_kernel_benchmark.py
+++ b/test/inductor/test_kernel_benchmark.py
@@ -387,7 +387,9 @@ class TestKernelBenchmark(TestCase):
 
     @expectedFailureXPU
     @xfailIfSM89
-    @config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    @config.patch(max_autotune=True,
+                  max_autotune_gemm_backends="TRITON",
+                  force_shape_pad=True)
     def test_slice_mm_bandwidth_computation(self):
         M, N, K = 1000, 2000, 3000
 

--- a/test/inductor/test_kernel_benchmark.py
+++ b/test/inductor/test_kernel_benchmark.py
@@ -387,9 +387,9 @@ class TestKernelBenchmark(TestCase):
 
     @expectedFailureXPU
     @xfailIfSM89
-    @config.patch(max_autotune=True,
-                  max_autotune_gemm_backends="TRITON",
-                  force_shape_pad=True)
+    @config.patch(
+        max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
+    )
     def test_slice_mm_bandwidth_computation(self):
         M, N, K = 1000, 2000, 3000
 

--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -25,9 +25,9 @@ class PadMMTest(TestCase):
         if not is_big_gpu():
             return self.skipTest("Need a big GPU to run max_autotune=True")
 
-    @inductor_config.patch(max_autotune=True,
-                           max_autotune_gemm_backends="TRITON",
-                           force_shape_pad=True)
+    @inductor_config.patch(
+        max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
+    )
     def test_pad_mm_dyn_m(self):
         M = 40
         K1 = 581
@@ -58,9 +58,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True,
-                           max_autotune_gemm_backends="TRITON",
-                           force_shape_pad=True)
+    @inductor_config.patch(
+        max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
+    )
     def test_cat_pad_mm_dyn_m(self):
         M1 = 128
         M2 = 40
@@ -95,9 +95,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True,
-                           max_autotune_gemm_backends="TRITON",
-                           force_shape_pad=True)
+    @inductor_config.patch(
+        max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
+    )
     def test_pad_mm_dyn_n(self):
         M = 20
         K = 81
@@ -124,9 +124,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True,
-                           max_autotune_gemm_backends="TRITON",
-                           force_shape_pad=True)
+    @inductor_config.patch(
+        max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
+    )
     def test_pad_mm_dyn_k(self):
         M = 21
         K = 80
@@ -193,9 +193,9 @@ class PadMMTest(TestCase):
         b = torch.randn(10, 100).cuda()
         self.assertEqual(torch.compile(addmm)(x, a, b), addmm(x, a, b))
 
-    @inductor_config.patch(max_autotune=True,
-                           max_autotune_gemm_backends="TRITON",
-                           force_shape_pad=True)
+    @inductor_config.patch(
+        max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
+    )
     def test_pad_bmm_dyn_b(self):
         B = 10
         M = 128
@@ -224,9 +224,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True,
-                           max_autotune_gemm_backends="TRITON",
-                           force_shape_pad=True)
+    @inductor_config.patch(
+        max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
+    )
     def test_pad_bmm_dyn_k(self):
         B = 10
         M = 128
@@ -255,9 +255,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"N = {aligned_n}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True,
-                           max_autotune_gemm_backends="TRITON",
-                           force_shape_pad=True)
+    @inductor_config.patch(
+        max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
+    )
     def test_pad_bmm_dyn_bm(self):
         B = 10
         M = 128
@@ -287,9 +287,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"N = {aligned_n}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True,
-                           max_autotune_gemm_backends="TRITON",
-                           force_shape_pad=True)
+    @inductor_config.patch(
+        max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
+    )
     def test_pad_addmm_dyn_m(self):
         M = 128
         K = 33
@@ -318,9 +318,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True,
-                           max_autotune_gemm_backends="TRITON",
-                           force_shape_pad=True)
+    @inductor_config.patch(
+        max_autotune=True, max_autotune_gemm_backends="TRITON", force_shape_pad=True
+    )
     def test_pad_addmm_dyn_mn(self):
         M = 128
         K = 33

--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -25,7 +25,9 @@ class PadMMTest(TestCase):
         if not is_big_gpu():
             return self.skipTest("Need a big GPU to run max_autotune=True")
 
-    @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    @inductor_config.patch(max_autotune=True,
+                           max_autotune_gemm_backends="TRITON",
+                           force_shape_pad=True)
     def test_pad_mm_dyn_m(self):
         M = 40
         K1 = 581
@@ -56,7 +58,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    @inductor_config.patch(max_autotune=True,
+                           max_autotune_gemm_backends="TRITON",
+                           force_shape_pad=True)
     def test_cat_pad_mm_dyn_m(self):
         M1 = 128
         M2 = 40
@@ -91,7 +95,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    @inductor_config.patch(max_autotune=True,
+                           max_autotune_gemm_backends="TRITON",
+                           force_shape_pad=True)
     def test_pad_mm_dyn_n(self):
         M = 20
         K = 81
@@ -118,7 +124,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    @inductor_config.patch(max_autotune=True,
+                           max_autotune_gemm_backends="TRITON",
+                           force_shape_pad=True)
     def test_pad_mm_dyn_k(self):
         M = 21
         K = 80
@@ -185,7 +193,9 @@ class PadMMTest(TestCase):
         b = torch.randn(10, 100).cuda()
         self.assertEqual(torch.compile(addmm)(x, a, b), addmm(x, a, b))
 
-    @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    @inductor_config.patch(max_autotune=True,
+                           max_autotune_gemm_backends="TRITON",
+                           force_shape_pad=True)
     def test_pad_bmm_dyn_b(self):
         B = 10
         M = 128
@@ -214,7 +224,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    @inductor_config.patch(max_autotune=True,
+                           max_autotune_gemm_backends="TRITON",
+                           force_shape_pad=True)
     def test_pad_bmm_dyn_k(self):
         B = 10
         M = 128
@@ -243,7 +255,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"N = {aligned_n}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    @inductor_config.patch(max_autotune=True,
+                           max_autotune_gemm_backends="TRITON",
+                           force_shape_pad=True)
     def test_pad_bmm_dyn_bm(self):
         B = 10
         M = 128
@@ -273,7 +287,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"N = {aligned_n}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    @inductor_config.patch(max_autotune=True,
+                           max_autotune_gemm_backends="TRITON",
+                           force_shape_pad=True)
     def test_pad_addmm_dyn_m(self):
         M = 128
         K = 33
@@ -302,7 +318,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    @inductor_config.patch(max_autotune=True,
+                           max_autotune_gemm_backends="TRITON",
+                           force_shape_pad=True)
     def test_pad_addmm_dyn_mn(self):
         M = 128
         K = 33


### PR DESCRIPTION
Some tests fail for ROCm build on navi arch because of this check: https://github.com/pytorch/pytorch/blob/f83361b2745e0f3232a211f5d2e5a464e02f6c1f/torch/_inductor/fx_passes/pad_mm.py#L211

There is no need to determine if mm is compute bound for most of the padding tests since they don't specifically test compute bound behavior. We don't have enough empirical data to fine tune this check for AMD gpus yet. I propose to force the shape padding for the tests that we had trouble with to avoid this unnecessary logic path.

Please correct me if I didn't add other tests that can potentially fail with this issue or if I added a test that is dependent on logic below the `force_shape_pad` check here: https://github.com/pytorch/pytorch/blob/f83361b2745e0f3232a211f5d2e5a464e02f6c1f/torch/_inductor/fx_passes/pad_mm.py#L444

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov