### PR TITLE
feat: update error message in get_backend() more detail

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1342,7 +1342,11 @@ def get_backend(group: Optional[ProcessGroup] = None) -> Backend:
     pg = group or _get_default_group()
     if _rank_not_in_group(pg):
         raise ValueError("Invalid process group specified")
-    pg_store = _world.pg_map[pg] if pg in _world.pg_map else None
+    
+    pg_store = _world.pg_map.get(pg, None)
+    if pg_store is None:
+        raise ValueError(f"Process group {pg} is not initialized in the world group map. Please initialize the group first.")
+    
     return Backend(not_none(pg_store)[0])
 
 


### PR DESCRIPTION
When attempting to reconfigure the environment without properly handling the PyTorch-related settings, you may encounter the following message. 
```
                             │ /root/.cache/pypoetry/virtualenvs/app-rag-sample-9TtSrW0h-py3.10/lib/python3.10/site-packages/torch/distributed/distribut │               
                             │ ed_c10d.py:1215 in get_backend                                                                                            │               
                             │                                                                                                                           │               
                             │   1212 │   if _rank_not_in_group(pg):                                                                                     │               
                             │   1213 │   │   raise ValueError("Invalid process group specified")                                                        │               
                             │   1214 │   pg_store = _world.pg_map[pg] if pg in _world.pg_map else None                                                  │               
                             │ ❱ 1215 │   return Backend(not_none(pg_store)[0])                                                                          │               
                             │   1216                                                                                                                    │               
                             │   1217                                                                                                                    │               
                             │   1218 def _get_process_group_uid(pg: ProcessGroup) -> int:                                                               │               
                             │                                                                                                                           │               
                             │ /root/.cache/pypoetry/virtualenvs/app-rag-sample-9TtSrW0h-py3.10/lib/python3.10/site-packages/torch/utils/_typing_utils.p │               
                             │ y:13 in not_none                                                                                                          │               
                             │                                                                                                                           │               
                             │   10                                                                                                                      │               
                             │   11 def not_none(obj: Optional[T]) -> T:                                                                                 │               
                             │   12 │   if obj is None:                                                                                                  │               
                             │ ❱ 13 │   │   raise TypeError("Invariant encountered: value was None when it should not be")                               │               
                             │   14 │   return obj                                                                                                       │               
                             │   15                                                                                                                      │               
                             ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯               
                             TypeError: Invariant encountered: value was None when it should not be                                                                      
Exception ignored in: <function Vllm.__del__ at 0x7f35f96b6dd0>
```
Since this message can cause confusion for multiple developers, the purpose of this PR is to suggest additional details to help clarify the situation.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o