### PR TITLE
[CI] Ensure ACL is obtained from GitHub

### DIFF
--- a/.ci/docker/common/install_acl.sh
+++ b/.ci/docker/common/install_acl.sh
@@ -1,7 +1,7 @@
 set -euo pipefail
 
 readonly version=v24.04
-readonly src_host=https://review.mlplatform.org/ml
+readonly src_host=https://github.com/ARM-software
 readonly src_repo=ComputeLibrary
 
 # Clone ACL


### PR DESCRIPTION
- The GitHub tagged releases is the preferred method to obtain ACL.

Please merge this before https://github.com/pytorch/pytorch/pull/138889 so that PyTorch can take GitHub releases going forward instead of mlplatform.


cc @malfet @snadampal @milpuz01