### PR TITLE
improve typings in unflatten

### DIFF
--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -125,7 +125,7 @@ class InterpreterModule(torch.nn.Module):
     and makes it easier to debug execution.
     """
 
-    graph_module: torch.fx.GraphModule | None
+    graph_module: Optional[torch.fx.GraphModule]
 
     def __init__(
         self,
@@ -825,7 +825,7 @@ def _generate_flatten(gm: torch.fx.GraphModule, node) -> torch.fx.Node:
 
 
 def _generate_flatten_spec(
-    gm: torch.fx.GraphModule | InterpreterModule | UnflattenedModule, node, spec
+    gm: Union[torch.fx.GraphModule, InterpreterModule, UnflattenedModule], node, spec
 ) -> torch.fx.Node:
     name = _add_spec(gm, spec)
     spec_node = gm.graph.get_attr(name)
@@ -833,7 +833,7 @@ def _generate_flatten_spec(
 
 
 def _generate_unflatten(
-    gm: torch.fx.GraphModule | InterpreterModule | UnflattenedModule, nodes, spec
+    gm: Union[torch.fx.GraphModule, InterpreterModule, UnflattenedModule], nodes, spec
 ) -> torch.fx.Node:
     name = _add_spec(gm, spec)
     spec_node = gm.graph.get_attr(name)
@@ -898,7 +898,7 @@ class _ModuleFrame:
         module_stack: List[Tuple[str, int]],
         module_id,
         module_call_graph: Dict[str, ModuleCallSignature],
-        module: Optional[torch.fx.GraphModule | UnflattenedModule] = None,
+        module: Optional[Union[torch.fx.GraphModule, UnflattenedModule]] = None,
     ):
         self.flat_graph = flat_graph
         self.nodes = nodes
@@ -916,7 +916,7 @@ class _ModuleFrame:
         # generate call name for self.fqn
         self.child_fqn = _call_name(self.fqn, num_calls + 1)
 
-        self.module: torch.fx.GraphModule | UnflattenedModule | InterpreterModule
+        self.module: Union[torch.fx.GraphModule, UnflattenedModule, InterpreterModule]
         if module is not None:
             self.module = module
             self.ivals = module.ivals if hasattr(module, "ivals") else {}  # type: ignore[var-annotated]

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -125,6 +125,8 @@ class InterpreterModule(torch.nn.Module):
     and makes it easier to debug execution.
     """
 
+    graph_module: torch.fx.GraphModule | None
+
     def __init__(
         self,
         graph: torch.fx.Graph,
@@ -143,7 +145,7 @@ class InterpreterModule(torch.nn.Module):
             # GraphModule codegen in this instance.
             # Patch the codegened forward to run with this InterpreterModule,
             # so attribute accesses, etc. are on this module instead.
-            return type(self.graph_module).forward(self, *args, **kwargs)  # type: ignore[operator, union-attr]
+            return type(self.graph_module).forward(self, *args, **kwargs)
         else:
             if kwargs:
                 # Handle **kwargs. FX only natively supports positional
@@ -816,22 +818,26 @@ def _add_spec(gm: torch.nn.Module, spec) -> str:
     return name
 
 
-def _generate_flatten(gm: torch.nn.Module, node) -> torch.fx.Node:
-    flatten = gm.graph.call_function(pytree.tree_flatten, (node,))  # type: ignore[operator, union-attr]
-    getitem_0 = gm.graph.call_function(operator.getitem, (flatten, 0))  # type: ignore[operator, union-attr]
+def _generate_flatten(gm: torch.fx.GraphModule, node) -> torch.fx.Node:
+    flatten = gm.graph.call_function(pytree.tree_flatten, (node,))
+    getitem_0 = gm.graph.call_function(operator.getitem, (flatten, 0))
     return getitem_0
 
 
-def _generate_flatten_spec(gm: torch.nn.Module, node, spec) -> torch.fx.Node:
+def _generate_flatten_spec(
+    gm: torch.fx.GraphModule | InterpreterModule | UnflattenedModule, node, spec
+) -> torch.fx.Node:
     name = _add_spec(gm, spec)
-    spec_node = gm.graph.get_attr(name)  # type: ignore[union-attr, operator]
-    return gm.graph.call_function(fx_pytree.tree_flatten_spec, (node, spec_node))  # type: ignore[union-attr, operator]
+    spec_node = gm.graph.get_attr(name)
+    return gm.graph.call_function(fx_pytree.tree_flatten_spec, (node, spec_node))
 
 
-def _generate_unflatten(gm: torch.nn.Module, nodes, spec) -> torch.fx.Node:
+def _generate_unflatten(
+    gm: torch.fx.GraphModule | InterpreterModule | UnflattenedModule, nodes, spec
+) -> torch.fx.Node:
     name = _add_spec(gm, spec)
-    spec_node = gm.graph.get_attr(name)  # type: ignore[union-attr, operator]
-    return gm.graph.call_function(pytree.tree_unflatten, (nodes, spec_node))  # type: ignore[union-attr, operator]
+    spec_node = gm.graph.get_attr(name)
+    return gm.graph.call_function(pytree.tree_unflatten, (nodes, spec_node))
 
 
 def _get_submodule(mod: torch.nn.Module, target: str):
@@ -892,7 +898,7 @@ class _ModuleFrame:
         module_stack: List[Tuple[str, int]],
         module_id,
         module_call_graph: Dict[str, ModuleCallSignature],
-        module: Optional[torch.nn.Module] = None,
+        module: Optional[torch.fx.GraphModule | UnflattenedModule] = None,
     ):
         self.flat_graph = flat_graph
         self.nodes = nodes
@@ -910,6 +916,7 @@ class _ModuleFrame:
         # generate call name for self.fqn
         self.child_fqn = _call_name(self.fqn, num_calls + 1)
 
+        self.module: torch.fx.GraphModule | UnflattenedModule | InterpreterModule
         if module is not None:
             self.module = module
             self.ivals = module.ivals if hasattr(module, "ivals") else {}  # type: ignore[var-annotated]
@@ -947,21 +954,21 @@ class _ModuleFrame:
             assert args_spec.context is None
             assert kwargs_spec.context is not None
 
-            with self.graph.inserting_after(None):  # type: ignore[union-attr, operator]
+            with self.graph.inserting_after(None):
                 arg_nodes = [
-                    self.graph.placeholder(f"_positional_arg_{idx}")  # type: ignore[union-attr, operator]
+                    self.graph.placeholder(f"_positional_arg_{idx}")
                     for idx in range(args_spec.num_children)
                 ]
                 kwarg_nodes = {}
                 for name in kwargs_spec.context:
-                    kwarg_nodes[name] = self.graph.placeholder(name)  # type: ignore[union-attr, operator]
+                    kwarg_nodes[name] = self.graph.placeholder(name)
                 flat_args = _generate_flatten_spec(
                     self.module,
                     (tuple(arg_nodes), kwarg_nodes),
                     signature.in_spec,
                 )
                 for idx, arg in enumerate(signature.inputs):
-                    flat_arg_node = self.graph.create_node(  # type: ignore[union-attr, operator]
+                    flat_arg_node = self.graph.create_node(
                         op="call_function",
                         target=operator.getitem,
                         args=(flat_args, idx),
@@ -1019,15 +1026,15 @@ class _ModuleFrame:
                 }
             assert self.parent_call_module is not None
             self.parent_call_module.args = tuple(arg_nodes)
-            self.parent_call_module.kwargs = kwarg_nodes
+            self.parent_call_module.kwargs = kwarg_nodes  # type: ignore[assignment]
 
     def add_placeholder(self, x):
         assert self.fqn != "", f"Cannot add placeholder {x} to root module"
         assert x.graph is self.flat_graph
         # x is not in subgraph, create a new placeholder for subgraph
-        with self.graph.inserting_before(None):  # type: ignore[union-attr, operator]
-            placeholder_node = self.graph.placeholder(x.name, type_expr=x.type)  # type: ignore[union-attr, operator]
-        # copy all meta fields, even if some fields might be irrelvant for
+        with self.graph.inserting_before(None):
+            placeholder_node = self.graph.placeholder(x.name, type_expr=x.type)
+        # copy all meta fields, even if some fields might be irrelevant for
         # the placeholder node
         placeholder_node.meta = copy.copy(x.meta)
         self.node_to_placeholder[x] = placeholder_node
@@ -1041,7 +1048,7 @@ class _ModuleFrame:
         # should not be deduplicated in the first place.
         args = pytree.tree_map_only(torch.fx.Node, self.remap_input, x.args)
         kwargs = pytree.tree_map_only(torch.fx.Node, self.remap_input, x.kwargs)
-        node = self.graph.call_function(x.target, args, kwargs)  # type: ignore[operator, union-attr]
+        node = self.graph.call_function(x.target, args, kwargs)
         node.meta = copy.copy(x.meta)
         self.node_map[x] = node
         return node
@@ -1148,7 +1155,7 @@ class _ModuleFrame:
 
         assert isinstance(graph_outputs, (list, torch.fx.Node))
 
-        self.graph.output(graph_outputs)  # type: ignore[union-attr, operator]
+        self.graph.output(graph_outputs)
 
         # Rewrite outputs in parent module
         if parent_out is None:
@@ -1173,7 +1180,7 @@ class _ModuleFrame:
 
     def copy_node(self, node):
         self.print("copying", node.format_node())
-        self.node_map[node] = self.graph.node_copy(node, self.remap_input)  # type: ignore[union-attr, operator]
+        self.node_map[node] = self.graph.node_copy(node, self.remap_input)
         self.seen_nodes[node.name] = node
 
     def run_outer(self):
@@ -1515,7 +1522,7 @@ def _sink_params(
     To replicate eager's semantics, we need to get them from the module state
     via get_attr instead.
 
-    module: GraphModule, potentially containining nested submodules.
+    module: GraphModule, potentially containing nested submodules.
     inputs_to_state: mapping graph input names to the corresponding key in the state_dict.
     scope: tracks where we are in the module hierarchy, so that we can emit the
         right `getattr(self, "foo.bar")` calls, etc.
@@ -1538,11 +1545,13 @@ def _sink_params(
         return module_id_to_inputs_removed
 
     graph = module.graph
-    inputs = list(filter(lambda n: n.op == "placeholder", graph.nodes))  # type: ignore[arg-type, union-attr, var-annotated]
+    assert isinstance(graph, torch.fx.Graph)
+
+    inputs = list(filter(lambda n: n.op == "placeholder", graph.nodes))
     the_last_input = inputs[-1]
 
     # Also remove from call_module nodes
-    call_module_nodes = filter(lambda n: n.op == "call_module", graph.nodes)  # type: ignore[arg-type, union-attr, var-annotated]
+    call_module_nodes = filter(lambda n: n.op == "call_module", graph.nodes)
     for node in call_module_nodes:
         submodule = _get_attr(module, node.target)
         # remove placeholder from call_module node arguments, only if we've
@@ -1568,8 +1577,8 @@ def _sink_params(
                 state_name = sn_split
                 break
 
-        # If there's a mismatch beteewn scope name and state name, then
-        # there must be multuple scopes pointing to the same state name,
+        # If there's a mismatch between scope name and state name, then
+        # there must be multiple scopes pointing to the same state name,
         # meaning some modules are shared. In such case, we can simply skip
         # updating the current node because another later iteration will
         # take care of this input node when the unique match between scope
@@ -1592,12 +1601,12 @@ def _sink_params(
             assert isinstance(state_attr, (torch.Tensor, torch.ScriptObject))
 
             # Make sure the newly created get_attr node is placed after the last placeholder node
-            with graph.inserting_after(the_last_input):  # type: ignore[union-attr, operator]
-                new_node = graph.create_node("get_attr", ".".join(attr_path))  # type: ignore[union-attr, operator]
+            with graph.inserting_after(the_last_input):
+                new_node = graph.create_node("get_attr", ".".join(attr_path))
 
             node.replace_all_uses_with(new_node, propagate_meta=True)
 
-        graph.erase_node(node)  # type: ignore[union-attr, operator]
+        graph.erase_node(node)
         inputs_removed.append(node.name)
 
     if isinstance(module, InterpreterModule):


### PR DESCRIPTION
A first follow-up to https://github.com/pytorch/pytorch/pull/115074 / https://github.com/pytorch/pytorch/pull/141240 following the strategy discussed there (https://github.com/pytorch/pytorch/pull/115074#issuecomment-2480992230).

This PR improves the type annotations around `unflatten.py` which had been inaccurate due to the previously suppressed type checking on `torch.nn.Module`.

CC @Skylion007 @ezyang 




cc @ezyang @malfet @xuzhao9 @gramster