### PR TITLE
Fix `torch.lerp` RuntimeError when `weight` is CPU scalar while `input` & `end` are CUDA tensor

### DIFF
--- a/aten/src/ATen/native/Lerp.cpp
+++ b/aten/src/ATen/native/Lerp.cpp
@@ -19,6 +19,7 @@ TORCH_META_FUNC(lerp_Tensor)(
   TORCH_CHECK(self.dtype() == weight.dtype(), "expected dtype ", self.dtype(),
               " for `weight` but got dtype ", weight.dtype());
   build(at::TensorIteratorConfig()
+        .allow_cpu_scalars(true)
         .add_output(maybe_get_output())
         .add_const_input(self)
         .add_const_input(end)

--- a/aten/src/ATen/native/cuda/Lerp.cu
+++ b/aten/src/ATen/native/cuda/Lerp.cu
@@ -9,6 +9,10 @@
 namespace at::native {
 namespace {
 
+void lerp_scalar_kernel(
+    at::TensorIteratorBase& iter,
+    const c10::Scalar& weight);
+
 constexpr char lerp_tensor_name[] = "lerp_tensor";
 void lerp_tensor_kernel(at::TensorIteratorBase& iter) {
   auto dtype = iter.common_dtype();
@@ -24,15 +28,27 @@ void lerp_tensor_kernel(at::TensorIteratorBase& iter) {
       }
   ); // lerp_tensor_string
   AT_DISPATCH_COMPLEX_TYPES_AND(kComplexHalf, dtype, "lerp_cuda", [&] {
-        jitted_gpu_kernel<
-          /*name=*/ lerp_tensor_name,
-          /*return_dtype=*/ scalar_t,
-          /*common_dtype=*/ scalar_t,
-          /*arity=*/ 3>(iter, lerp_tensor_string);
-      });
+      if (iter.is_cpu_scalar(3)) {
+        auto weight_val = iter.scalar_value<scalar_t>(3);
+        iter.remove_operand(3);
+        return lerp_scalar_kernel(iter, weight_val);
+      }
+
+      jitted_gpu_kernel<
+        /*name=*/ lerp_tensor_name,
+        /*return_dtype=*/ scalar_t,
+        /*common_dtype=*/ scalar_t,
+        /*arity=*/ 3>(iter, lerp_tensor_string);
+    });
 #else
   AT_DISPATCH_COMPLEX_TYPES_AND(kComplexHalf, dtype, "lerp_cuda", [&] {
       using opmath_t = at::opmath_type<scalar_t>;
+      if (iter.is_cpu_scalar(3)) {
+        auto weight_val = iter.scalar_value<scalar_t>(3);
+        iter.remove_operand(3);
+        return lerp_scalar_kernel(iter, weight_val);
+      }
+
       at::native::gpu_kernel(
         iter,
         [] GPU_LAMBDA(
@@ -54,21 +70,17 @@ void lerp_tensor_kernel(at::TensorIteratorBase& iter) {
         if (iter.is_cpu_scalar(3)) {
           auto weight_val = iter.scalar_value<scalar_t>(3);
           iter.remove_operand(3);
-          at::native::gpu_kernel(
-            iter,
-            [=] GPU_LAMBDA(scalar_t self_val, scalar_t end_val) {
-              return lerp(self_val, end_val, weight_val);
-            });
-        } else {
-          at::native::gpu_kernel(
-            iter,
-            [] GPU_LAMBDA(
-                scalar_t self_val,
-                scalar_t end_val,
-                scalar_t weight_val) -> scalar_t {
-              return lerp(self_val, end_val, weight_val);
-            });
+          return lerp_scalar_kernel(iter, weight_val);
         }
+
+        at::native::gpu_kernel(
+          iter,
+          [] GPU_LAMBDA(
+              scalar_t self_val,
+              scalar_t end_val,
+              scalar_t weight_val) -> scalar_t {
+            return lerp(self_val, end_val, weight_val);
+          });
       });
   }
 }

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3470,6 +3470,7 @@ class TestBinaryUfuncs(TestCase):
             weights = [
                 torch.randn(shapes[2], device=device, dtype=dtype),
                 random.random(),
+                torch.randn([], device="cpu", dtype=dtype),
             ]
             if dtype.is_complex:
                 weights += [complex(0, 1), complex(0.4, 1.2)]


### PR DESCRIPTION
Fixes #141811


cc @albanD