### PR TITLE
[user triton] Fix grid codegen for configs with empty kwargs

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -226,9 +226,16 @@ def user_defined_kernel_grid_fn_code(
             assert len(grids) > 1
             assert len(grids) == len(configs)
             seen = set()
-            for grid, c in zip(grids, configs):
+            # sort the configs from the largest # of kwargs to the smallest to
+            # emit the grids in the order of (approximately) decreasing specificity
+            # TODO(aakhundov): the sorting below is generally not sufficient, so
+            # maybe we'll need to restrict the supported cases to identical kwarg
+            # names in all autotuning configs.
+            for grid, c in sorted(
+                zip(grids, configs), key=lambda x: len(x[1].kwargs), reverse=True
+            ):
                 guards = [f"meta['{name}'] == {val}" for name, val in c.kwargs.items()]
-                guards = " and ".join(guards)
+                guards = " and ".join(guards) or "True"  # for configs with empty kwargs
                 grid, example_grid = determine_grid(grid)
                 statement = f"if {guards}: return {grid}"
                 if statement in seen:

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -234,8 +234,11 @@ def user_defined_kernel_grid_fn_code(
             for grid, c in sorted(
                 zip(grids, configs), key=lambda x: len(x[1].kwargs), reverse=True
             ):
-                guards = [f"meta['{name}'] == {val}" for name, val in c.kwargs.items()]
-                guards = " and ".join(guards) or "True"  # for configs with empty kwargs
+                if c.kwargs:
+                    guards = [f"meta['{name}'] == {val}" for name, val in c.kwargs.items()]
+                    guards = " and ".join(guards)
+                else:
+                    guards = "True"  # for configs with empty kwargs
                 grid, example_grid = determine_grid(grid)
                 statement = f"if {guards}: return {grid}"
                 if statement in seen:

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -235,7 +235,9 @@ def user_defined_kernel_grid_fn_code(
                 zip(grids, configs), key=lambda x: len(x[1].kwargs), reverse=True
             ):
                 if c.kwargs:
-                    guards = [f"meta['{name}'] == {val}" for name, val in c.kwargs.items()]
+                    guards = [
+                        f"meta['{name}'] == {val}" for name, val in c.kwargs.items()
+                    ]
                     guards = " and ".join(guards)
                 else:
                     guards = "True"  # for configs with empty kwargs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141824

Fixes #141823 by adding special handling of the codegen `if <config kwargs>: return <grid>` for the cases when there are no kwargs in the config.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang