### PR TITLE
improve typings around torch.export

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -992,7 +992,7 @@ def explain(f, *extra_args, **extra_kwargs):
         return inner
 
 
-class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
+class FlattenInputOutputSignature(torch.fx.Transformer):
     def __init__(
         self,
         m: torch.fx.GraphModule,

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -75,7 +75,7 @@ def capture_pre_autograd_graph_warning():
 def print_export_warning():
     log.warning("Using torch.export.export_for_training(...,strict=True)")
 
-def gm_using_training_ir(graph_module):
+def gm_using_training_ir(graph_module: torch.fx.GraphModule) -> bool:
     """
     Returns true if the graph module is detected to use training IR.
 
@@ -232,7 +232,7 @@ def capture_pre_autograd_graph(
             )
 
             setattr(module, "capture_pre_autograd_graph_tag", True)  # noqa: B010
-            for node in module.graph.nodes:  # type: ignore[union-attr]
+            for node in module.graph.nodes:
                 node.meta["capture_pre_autograd_graph_tag"] = True
 
     error_message = \

--- a/torch/_export/passes/collect_tracepoints_pass.py
+++ b/torch/_export/passes/collect_tracepoints_pass.py
@@ -1,9 +1,17 @@
 # mypy: allow-untyped-defs
+from __future__ import annotations
+
 import operator
+from typing import Dict, TYPE_CHECKING
 
 import torch
 from torch.export.exported_program import ConstantArgument, TensorArgument
 from torch.fx.passes.infra.pass_base import PassBase, PassResult
+
+
+if TYPE_CHECKING:
+    from torch.export.exported_program import ModuleCallSignature
+    from torch.export.graph_signature import ExportGraphSignature
 
 
 __all__ = ["CollectTracepointsPass"]
@@ -14,7 +22,9 @@ class CollectTracepointsPass(PassBase):
     Performs constant folding and constant propagation.
     """
 
-    def __init__(self, specs, sig) -> None:
+    def __init__(
+        self, specs: Dict[str, ModuleCallSignature], sig: ExportGraphSignature
+    ) -> None:
         super().__init__()
         self.specs = specs
         self.sig = sig

--- a/torch/_export/passes/collect_tracepoints_pass.py
+++ b/torch/_export/passes/collect_tracepoints_pass.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import operator
-from typing import Dict, TYPE_CHECKING
+from typing import Dict, Optional, TYPE_CHECKING, Union
 
 import torch
 from torch.export.exported_program import ConstantArgument, TensorArgument
@@ -29,8 +29,8 @@ class CollectTracepointsPass(PassBase):
         self.specs = specs
         self.sig = sig
 
-    def call(self, gm):
-        def get_arg_spec(arg):
+    def call(self, gm: torch.fx.GraphModule) -> Optional[PassResult]:
+        def get_arg_spec(arg) -> Union[TensorArgument, ConstantArgument]:
             if isinstance(arg, torch.fx.Node):
                 if isinstance(arg.meta.get("val"), torch.Tensor):
                     return TensorArgument(name=arg.name)
@@ -77,7 +77,7 @@ class CollectTracepointsPass(PassBase):
                 else:
                     nn_module_stack = None
 
-        def copy_sig(sig):
+        def copy_sig(sig) -> ModuleCallSignature:
             from torch.export.exported_program import ModuleCallSignature
 
             return ModuleCallSignature(
@@ -142,3 +142,5 @@ class CollectTracepointsPass(PassBase):
                         gm.graph.erase_node(user)
                     gm.graph.erase_node(node)
             return PassResult(gm, True)
+
+        return None

--- a/torch/_export/passes/constant_folding.py
+++ b/torch/_export/passes/constant_folding.py
@@ -49,8 +49,8 @@ def replace_node_with_constant(gm, node, constant, name=None):
 class ConstantFolder(torch.fx.Interpreter):
     def __init__(
         self,
-        gm,
-        skip_constructors=False,
+        gm: torch.fx.GraphModule,
+        skip_constructors: bool = False,
     ):
         super().__init__(gm)
         self.node_replacements: Dict[torch.fx.Node, Any] = {}
@@ -62,7 +62,7 @@ class ConstantFolder(torch.fx.Interpreter):
         # is the output
         self.user_to_last_uses = self.node_to_last_non_output_use()
 
-    def is_impure(self, node: torch.fx.node.Node):
+    def is_impure(self, node: torch.fx.Node) -> bool:
         if (
             node.target == torch.ops.prims.convert_element_type.default
             and node.args[0].op == "get_attr"  # type: ignore[union-attr]
@@ -202,7 +202,10 @@ class ConstantFolder(torch.fx.Interpreter):
         return super().run(initial_env=env)
 
 
-def constant_fold(gm, constraint_fn: Optional[Callable[[torch.fx.Node], bool]] = None):
+def constant_fold(
+    gm: torch.fx.GraphModule,
+    constraint_fn: Optional[Callable[[torch.fx.Node], bool]] = None,
+):
     with torch.utils._python_dispatch._disable_current_modes():
         cf = ConstantFolder(gm, skip_constructors=True)
         cf.run()
@@ -242,7 +245,7 @@ def constant_fold(gm, constraint_fn: Optional[Callable[[torch.fx.Node], bool]] =
         gm.recompile()
 
 
-def constant_graph_tag(gm: torch.fx.GraphModule):
+def constant_graph_tag(gm: torch.fx.GraphModule) -> None:
     with torch.utils._python_dispatch._disable_current_modes():
         cf = ConstantFolder(gm, skip_constructors=True)
         cf.run()

--- a/torch/_export/passes/replace_autocast_with_hop_pass.py
+++ b/torch/_export/passes/replace_autocast_with_hop_pass.py
@@ -1,5 +1,7 @@
 # mypy: allow-untyped-defs
-from typing import List
+from __future__ import annotations
+
+from typing import List, Optional, Tuple, TYPE_CHECKING, Union
 
 import torch
 from torch._higher_order_ops.wrap import wrap_with_autocast
@@ -12,7 +14,11 @@ from .replace_with_hop_pass_util import (
 )
 
 
-def _is_autocast_node(node: torch.fx.Node):
+if TYPE_CHECKING:
+    from torch.export.graph_signature import ExportGraphSignature
+
+
+def _is_autocast_node(node: torch.fx.Node) -> Union[torch.fx.Node, bool]:
     return (
         node
         and node.op == "call_function"
@@ -24,7 +30,7 @@ def _is_autocast_node(node: torch.fx.Node):
     )
 
 
-def _is_enter_autocast_node(node: torch.fx.Node):
+def _is_enter_autocast_node(node: torch.fx.Node) -> Union[torch.fx.Node, bool]:
     return (
         node
         and node.op == "call_function"
@@ -32,7 +38,7 @@ def _is_enter_autocast_node(node: torch.fx.Node):
     )
 
 
-def _is_exit_autocast_node(node: torch.fx.Node):
+def _is_exit_autocast_node(node: torch.fx.Node) -> Union[torch.fx.Node, bool]:
     return (
         node
         and node.op == "call_function"
@@ -40,7 +46,7 @@ def _is_exit_autocast_node(node: torch.fx.Node):
     )
 
 
-def _is_autocast_sub_mod(node: torch.fx.Node):
+def _is_autocast_sub_mod(node: torch.fx.Node) -> bool:
     """
     Check if the first non-placeholder node is `torch.amp.autocast_mode._enter_autocast`.
     """
@@ -61,15 +67,18 @@ def _is_autocast_sub_mod(node: torch.fx.Node):
     return False
 
 
-def _check_valid_autocast_block(enter_autocast_node, exit_autocast_node):
+def _check_valid_autocast_block(
+    enter_autocast_node: torch.fx.Node, exit_autocast_node: torch.fx.Node
+) -> None:
     assert _is_enter_autocast_node(enter_autocast_node)
     assert _is_exit_autocast_node(exit_autocast_node)
     assert exit_autocast_node.args[0] == enter_autocast_node
 
 
-def _replace_with_hop(node: torch.fx.Node):
+def _replace_with_hop(node: torch.fx.Node) -> None:
     assert node.op == "call_module"
     graph: torch.fx.Graph = node.graph
+    assert graph.owning_module is not None
     gm: torch.fx.GraphModule = graph.owning_module
     assert isinstance(node.target, str)
     sub_gm = getattr(gm, node.target)
@@ -112,7 +121,7 @@ def _split_autocast(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
     enter_autocast_node_stack: List[torch.fx.Node] = []
     first_node_after_outer_most_exit: bool = False
 
-    def node_call_back(node: torch.fx.Node):
+    def node_call_back(node: torch.fx.Node) -> bool:
         nonlocal enter_autocast_node_stack, first_node_after_outer_most_exit
         increment_id = False
         if first_node_after_outer_most_exit or (
@@ -137,8 +146,8 @@ def _split_autocast(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
 
 
 def _sequential_split_and_maybe_inline_subgraphs(
-    gm: torch.fx.GraphModule, graph_signature
-):
+    gm: torch.fx.GraphModule, graph_signature: Optional[ExportGraphSignature]
+) -> Tuple[torch.fx.GraphModule, Optional[ExportGraphSignature]]:
     """
     Helper function for replace_autocast_with_hop_pass().
     Split the graph module into multiple subgraphs based on the autocast nodes.
@@ -155,7 +164,7 @@ def _sequential_split_and_maybe_inline_subgraphs(
     # args names. We need to fix the graph signature in `_sequential_split_and_maybe_inline_subgraphs_helper`.
     new_gm = _split_autocast(gm)
 
-    def _maybe_inline_or_replace_with_hop(node: torch.fx.Node):
+    def _maybe_inline_or_replace_with_hop(node: torch.fx.Node) -> None:
         if _is_autocast_sub_mod(node):
             _replace_with_hop(node)
         else:
@@ -168,7 +177,9 @@ def _sequential_split_and_maybe_inline_subgraphs(
     )
 
 
-def replace_autocast_with_hop_pass(gm: torch.fx.GraphModule, graph_signature):
+def replace_autocast_with_hop_pass(
+    gm: torch.fx.GraphModule, graph_signature: Optional[ExportGraphSignature]
+) -> Tuple[torch.fx.GraphModule, Optional[ExportGraphSignature]]:
     """
     Split gm into sub-graph-modules using `sequential_split_and_maybe_inline_subgraphs`, and
     then recursively call itself on each of the submodules.

--- a/torch/_export/passes/replace_set_grad_with_hop_pass.py
+++ b/torch/_export/passes/replace_set_grad_with_hop_pass.py
@@ -1,4 +1,7 @@
 # mypy: allow-untyped-defs
+from __future__ import annotations
+
+from typing import Optional, Tuple, TYPE_CHECKING, Union
 
 import torch
 from torch._higher_order_ops.wrap import wrap_with_set_grad_enabled
@@ -11,7 +14,11 @@ from .replace_with_hop_pass_util import (
 )
 
 
-def _is_set_grad_enabled_node(node: torch.fx.Node):
+if TYPE_CHECKING:
+    from torch.export.graph_signature import ExportGraphSignature
+
+
+def _is_set_grad_enabled_node(node: torch.fx.Node) -> Union[torch.fx.Node, bool]:
     return (
         node
         and node.op == "call_function"
@@ -19,7 +26,9 @@ def _is_set_grad_enabled_node(node: torch.fx.Node):
     )
 
 
-def _is_set_grad_enabled_sub_mod(node: torch.fx.Node, omit_if_same_with_ambient=False):
+def _is_set_grad_enabled_sub_mod(
+    node: torch.fx.Node, omit_if_same_with_ambient: bool = False
+) -> Union[bool, torch.Tensor]:
     if node.op == "call_module":
         assert isinstance(node.target, str)
         subgm = getattr(node.graph.owning_module, node.target)
@@ -39,9 +48,10 @@ def _is_set_grad_enabled_sub_mod(node: torch.fx.Node, omit_if_same_with_ambient=
     return False
 
 
-def _replace_with_hop(node: torch.fx.Node):
+def _replace_with_hop(node: torch.fx.Node) -> None:
     assert node.op == "call_module"
     graph: torch.fx.Graph = node.graph
+    assert graph.owning_module is not None
     gm: torch.fx.GraphModule = graph.owning_module
     assert isinstance(node.target, str)
     sub_gm = getattr(gm, node.target)
@@ -56,9 +66,10 @@ def _replace_with_hop(node: torch.fx.Node):
         sub_graph.erase_node(set_grad_node)
 
 
-def _remove_set_grad_and_inline(node: torch.fx.Node):
+def _remove_set_grad_and_inline(node: torch.fx.Node) -> None:
     assert node.op == "call_module"
     graph: torch.fx.Graph = node.graph
+    assert graph.owning_module is not None
     gm: torch.fx.GraphModule = graph.owning_module
     assert isinstance(node.target, str)
     sub_gm = getattr(gm, node.target)
@@ -71,8 +82,8 @@ def _remove_set_grad_and_inline(node: torch.fx.Node):
 
 
 def _sequential_split_and_maybe_inline_subgraphs(
-    gm: torch.fx.GraphModule, graph_signature
-):
+    gm: torch.fx.GraphModule, graph_signature: Optional[ExportGraphSignature]
+) -> Tuple[torch.fx.GraphModule, Optional[ExportGraphSignature]]:
     """
     Helper function for replace_set_grad_with_hop_pass().
     Split the graph module into multiple subgraphs based on the set_grad_enabled nodes.
@@ -98,7 +109,9 @@ def _sequential_split_and_maybe_inline_subgraphs(
     )
 
 
-def replace_set_grad_with_hop_pass(gm: torch.fx.GraphModule, graph_signature):
+def replace_set_grad_with_hop_pass(
+    gm: torch.fx.GraphModule, graph_signature: Optional[ExportGraphSignature]
+) -> Tuple[torch.fx.GraphModule, Optional[ExportGraphSignature]]:
     """
     Split gm into sub-graph-modules using `sequential_split_and_maybe_inline_subgraphs`, and
     then recursively call itself on each of the submodules.

--- a/torch/_export/passes/replace_with_hop_pass_util.py
+++ b/torch/_export/passes/replace_with_hop_pass_util.py
@@ -1,14 +1,19 @@
 # mypy: allow-untyped-defs
+from __future__ import annotations
 
 import contextlib
 import copy
 import operator
-from typing import Callable
+from typing import Callable, Optional, Tuple, TYPE_CHECKING
 
 import torch
-from torch._ops import HigherOrderOperator
 
 from ..utils import node_replace_, nodes_map
+
+
+if TYPE_CHECKING:
+    from torch._ops import HigherOrderOperator
+    from torch.export.graph_signature import ExportGraphSignature
 
 
 def _replace_with_hop_helper(
@@ -16,8 +21,9 @@ def _replace_with_hop_helper(
     enter_block_node: torch.fx.Node,
     node_filter: Callable,
     wrap_hoo: HigherOrderOperator,
-):
+) -> None:
     graph: torch.fx.Graph = node.graph
+    assert graph.owning_module is not None
     gm: torch.fx.GraphModule = graph.owning_module
     assert isinstance(node.target, str)
     sub_gm = getattr(gm, node.target)
@@ -101,9 +107,9 @@ def _replace_with_hop_helper(
 
 def _sequential_split_and_maybe_inline_subgraphs_helper(
     new_gm: torch.fx.GraphModule,
-    graph_signature,
+    graph_signature: Optional[ExportGraphSignature],
     maybe_inline_or_replace_with_hop: Callable[[torch.fx.Node], None],
-):
+) -> Tuple[torch.fx.GraphModule, Optional[ExportGraphSignature]]:
     """
     Helper function for replacing graph nodse with higher order nodes.
     For each subgraph in `new_gm`, decides whether to construct a HOO subgraph, or inline the calls
@@ -126,7 +132,7 @@ def _sequential_split_and_maybe_inline_subgraphs_helper(
             new_gm_out_node.args[0], new_signature.output_specs
         ):
             if arg_node is None:
-                assert out_spec.arg.value is None
+                assert out_spec.arg.value is None  # type: ignore[union-attr]
             elif (
                 isinstance(arg_node, torch.fx.Node)
                 and out_spec.arg.name != arg_node.name
@@ -151,9 +157,12 @@ def _sequential_split_and_maybe_inline_subgraphs_helper(
 
 def _replace_with_hop_pass_helper(
     gm: torch.fx.GraphModule,
-    graph_signature,
-    sequential_split_and_maybe_inline_subgraphs: Callable,
-):
+    graph_signature: Optional[ExportGraphSignature],
+    sequential_split_and_maybe_inline_subgraphs: Callable[
+        [torch.fx.GraphModule, Optional[ExportGraphSignature]],
+        Tuple[torch.fx.GraphModule, Optional[ExportGraphSignature]],
+    ],
+) -> Tuple[torch.fx.GraphModule, Optional[ExportGraphSignature]]:
     """
     Split gm into sub-graph-modules using `sequential_split_and_maybe_inline_subgraphs`, and
     then recursively call itself on each of the submodules.

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -19,6 +19,7 @@ from typing import (
     Tuple,
     Type,
     TYPE_CHECKING,
+    Union,
 )
 
 import torch
@@ -502,7 +503,10 @@ def get_lifted_tensor_constant(
     return None
 
 
-def sequential_split(gm: torch.fx.GraphModule, node_call_back) -> torch.fx.GraphModule:
+def sequential_split(
+    gm: torch.fx.GraphModule,
+    node_call_back: Callable[[torch.fx.Node], Union[torch.fx.Node, bool]],
+) -> torch.fx.GraphModule:
     """
     sequential_split creates a new graph module that splits the input graph module into multiple submodules
     based on the node_call_back. It doesn't mutate the input graph module. The node_call_back should return
@@ -535,7 +539,7 @@ def nodes_filter(nodes: List[torch.fx.Node], node_call_back) -> List[torch.fx.No
     return [node for node in nodes if node_call_back(node)]
 
 
-def apply_runtime_assertion_pass(gm, graph_signature):
+def apply_runtime_assertion_pass(gm: torch.fx.GraphModule, graph_signature):
     from torch._export.passes._node_metadata_hook import (
         _node_metadata_hook,
         _set_node_metadata_hook,
@@ -610,13 +614,14 @@ def _update_gm_meta_if_possible(gm: torch.fx.GraphModule, mod: torch.nn.Module) 
         gm.meta.update({"custom": mod.meta["custom"]})
 
 
-def node_inline_(call_mod_node: torch.fx.Node) -> None:
+def node_inline_(call_mod_node: torch.fx.Node) -> Optional[torch.fx.GraphModule]:
     """
     Inline the submodule of the given node into the parent module.
     Note: we only support the case where submodule takes tensors inputs.
     """
     assert call_mod_node.op == "call_module"
     gm = call_mod_node.graph.owning_module
+    assert gm is not None
 
     assert isinstance(call_mod_node.target, str)
     sub_gm = getattr(gm, call_mod_node.target)
@@ -688,7 +693,7 @@ def node_inline_(call_mod_node: torch.fx.Node) -> None:
     return gm
 
 
-def _get_torch_jit_trace_forward_signature(mod: torch.nn.Module):
+def _get_torch_jit_trace_forward_signature(mod: torch.nn.Module) -> inspect.Signature:
     """
     Get source code and parse argument names using AST. The function returns
     a signature of the forward() function.

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -410,7 +410,7 @@ def _remap_constants(
 
 def _produce_aten_artifact(
     *,
-    gm,
+    gm: torch.fx.GraphModule,
     mod,
     constant_attrs,
     graph_signature,
@@ -443,6 +443,7 @@ def _produce_aten_artifact(
     )
     set_missing_meta_vals(gm, flat_fake_args, total_non_user_inputs)
 
+    export_graph_signature: Optional[ExportGraphSignature]
     export_graph_signature = _convert_to_export_graph_signature(
         graph_signature, gm, _get_non_persistent_buffers(mod)
     )
@@ -483,6 +484,7 @@ def _produce_aten_artifact(
                 node.meta.pop("stack_trace", None)
 
     # Prettify names for placeholder nodes.
+    assert export_graph_signature is not None
     placeholder_naming_pass(
         gm,
         export_graph_signature,

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -703,8 +703,8 @@ def _export_to_aten_ir(
     transform=lambda x: x,  # TODO(zhxchen17) Revisit if this is needed later.
     pre_dispatch=False,
     decomp_table=None,
-    _check_autograd_state=True,
-    _is_torch_jit_trace=False,
+    _check_autograd_state: bool = True,
+    _is_torch_jit_trace: bool = False,
 ) -> ATenExportArtifact:
     # [NOTE] If the user is exporting under training mode, we want to detect if there is any
     # state change in the autograd global state and error. If the user is exporting under inference
@@ -854,7 +854,7 @@ def _rewrite_dynamo_tensor_constants(
     traced_mod_buffers: Dict[str, torch.Tensor],
     graph_signature: ExportGraphSignature,
     constants: Dict[str, Union[torch.Tensor, FakeScriptObject, torch.ScriptObject]],
-):
+) -> None:
     """
     Dynamo erroneously marks tensor attributes on modules as buffers.
     Rewrite them to be tensor constants.
@@ -875,7 +875,7 @@ def _move_non_persistent_buffers_to_tensor_constants(
     orig_mod: torch.nn.Module,
     graph_signature: ExportGraphSignature,
     constants: Dict[str, Union[torch.Tensor, FakeScriptObject, torch.ScriptObject]],
-):
+) -> None:
     """
     Moves non-persistent buffers to tensor constants.
     """
@@ -955,7 +955,9 @@ def _verify_stack_trace(graph_module: torch.fx.GraphModule) -> None:
                     )
 
 
-def _verify_placeholder_names(gm: torch.fx.GraphModule, sig: ExportGraphSignature):
+def _verify_placeholder_names(
+    gm: torch.fx.GraphModule, sig: ExportGraphSignature
+) -> None:
     """
     Performs a sanity check on the placeholder node names.
     - User input nodes: no restrictions, should match the original forward() signature
@@ -1089,7 +1091,7 @@ def _get_module_call_graph(
     preserve_module_call_signature: Tuple[str, ...],
     strict_mode_export: bool,
     forward_arg_names: Optional[List[str]] = None,
-):
+) -> Tuple[torch.fx.GraphModule, List[ModuleCallEntry]]:
     """
     In-place modify the graph module in export_artifact, remove _export_tracepoint nodes and
     return module_call_graph.
@@ -1102,7 +1104,7 @@ def _get_module_call_graph(
     out_spec: TreeSpec = export_artifact.out_spec
 
     # Make module signatures.
-    module_call_signatures = {}
+    module_call_signatures: Dict[str, ModuleCallSignature] = {}
     for fqn, specs in module_call_specs.items():
         mod_fqn = _strip_root(fqn) if not strict_mode_export else fqn
         module_call_signatures[mod_fqn] = ModuleCallSignature(

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -275,10 +275,10 @@ class _StatefulGraphModule(torch.fx.GraphModule, metaclass=_StatefulGraphModuleF
 def _create_stateful_graph_module(
     plain_graph_module: torch.fx.GraphModule,
     range_constraints,
-    # TODO(suo) this should not be optional, but is since we still ahve
+    # TODO(suo) this should not be optional, but is since we still have
     # capture_pre_autograd_graph grr
     ep: Optional[ExportedProgram] = None,
-):
+) -> _StatefulGraphModule:
     stateful_gm = _StatefulGraphModule._create(
         plain_graph_module,
         plain_graph_module.graph,


### PR DESCRIPTION
This is another follow-up to https://github.com/pytorch/pytorch/pull/115074 / https://github.com/pytorch/pytorch/pull/141240 following the strategy discussed there (https://github.com/pytorch/pytorch/pull/115074#issuecomment-2480992230).

This PR improves the type annotations around `torch._export`. Even though the PR introduces a few runtime type asserts, the runtime behavior should stay equivalent, because the failed assertions should have been immediate crashes anyway.

CC @Skylion007 @ezyang 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames