### PR TITLE
Add option in data loader for out of order data

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -185,6 +185,8 @@ class DataLoader(Generic[_T_co]):
             maintain the workers `Dataset` instances alive. (default: ``False``)
         pin_memory_device (str, optional): the device to :attr:`pin_memory` to if ``pin_memory`` is
             ``True``.
+        allow_out_of_order (bool, optional): If ``True``, the data loader will not enforce that batches
+            are returned in a first-in, first-out order when ``num_workers > 0``. (default: ``False``)
 
 
     .. warning:: If the ``spawn`` start method is used, :attr:`worker_init_fn`
@@ -212,6 +214,8 @@ class DataLoader(Generic[_T_co]):
 
     .. warning:: See :ref:`reproducibility`, and :ref:`dataloader-workers-random-seed`, and
                  :ref:`data-loading-randomness` notes for random seed related questions.
+
+    .. warning:: Setting `allow_out_of_order` to `True` can harm reproducibility.
 
     .. _multiprocessing context:
         https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
@@ -248,6 +252,7 @@ class DataLoader(Generic[_T_co]):
         prefetch_factor: Optional[int] = None,
         persistent_workers: bool = False,
         pin_memory_device: str = "",
+        allow_out_of_order: bool = False,
     ):
         torch._C._log_api_usage_once("python.data_loader")
 
@@ -281,6 +286,7 @@ class DataLoader(Generic[_T_co]):
         self.timeout = timeout
         self.worker_init_fn = worker_init_fn
         self.multiprocessing_context = multiprocessing_context
+        self.allow_out_of_order = allow_out_of_order
 
         # Adds forward compatibilities so classic DataLoader can work with DataPipes:
         #   _DataPipeSerializationWrapper container makes it easier to serialize without redefining pickler
@@ -1074,6 +1080,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
         super().__init__(loader)
 
         self._prefetch_factor = loader.prefetch_factor
+        self._allow_out_of_order = loader.allow_out_of_order
 
         assert self._num_workers > 0
         assert self._prefetch_factor > 0
@@ -1423,13 +1430,14 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
             # call and `_IterableDatasetStopIteration` check below can mark
             # extra worker(s) as dead.
             while self._rcvd_idx < self._send_idx:
-                info = self._task_info[self._rcvd_idx]
-                worker_id = info[0]
-                if (
-                    len(info) == 2 or self._workers_status[worker_id]
-                ):  # has data or is still active
-                    break
-                del self._task_info[self._rcvd_idx]
+                info = self._task_info.get(self._rcvd_idx, None)
+                if info:
+                    worker_id = info[0]
+                    if (
+                        len(info) == 2 or self._workers_status[worker_id]
+                    ):  # has data or is still active
+                        break
+                    del self._task_info[self._rcvd_idx]
                 self._rcvd_idx += 1
             else:
                 # no valid `self._rcvd_idx` is found (i.e., didn't break)
@@ -1442,6 +1450,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
             # Check if the next sample has already been generated
             if len(self._task_info[self._rcvd_idx]) == 2:
                 data = self._task_info.pop(self._rcvd_idx)[1]
+                self._rcvd_idx += 1
                 return self._process_data(data)
 
             assert not self._shutdown and self._tasks_outstanding > 0
@@ -1458,10 +1467,15 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
                     continue
 
             if idx != self._rcvd_idx:
+                if self._allow_out_of_order:
+                    # don't store it for later, process now
+                    del self._task_info[idx]
+                    return self._process_data(data)
                 # store out-of-order samples
                 self._task_info[idx] += (data,)
             else:
                 del self._task_info[idx]
+                self._rcvd_idx += 1
                 return self._process_data(data)
 
     def _try_put_index(self):
@@ -1485,7 +1499,6 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
         self._send_idx += 1
 
     def _process_data(self, data):
-        self._rcvd_idx += 1
         self._try_put_index()
         if isinstance(data, ExceptionWrapper):
             data.reraise()


### PR DESCRIPTION
Fixes #105203

Facing a similar problem to the linked issue, where variable sized input data can mean that a handful of slow to process samples holds up smaller and faster to process samples from being used. This also leads to lower GPU utilization as well. In certain cases, e.g. evaluation epochs, inference pipelines or other cases where reproducibility isn't important, this can bring significant speed ups.

This PR adds an `allow_out_of_order` bool input to the `DataLoader` class, defaulting to `false`, which when set to `true` will returning data from workers in whatever order they are ready/processed in, rather in the strict index order.
Instead of storing data that was returned out of order, it is passed directly to the main thread and the entry in `_task_info` is deleted. The main changes are they to check that an entry in `_task_info` does exist, and only increasing `self._rcvd_idx` when the lowest index remaining gets returned.

Two tests are added to test this for iterable type datasets and index type datasets.


cc @andrewkho @divyanshk @SsnL @VitalyFedyunin @dzhulgakov