### PR TITLE
[DTensor] fix stride of fake tensor produced by `shard_dim_alltoall`

### DIFF
--- a/test/distributed/_tensor/test_redistribute.py
+++ b/test/distributed/_tensor/test_redistribute.py
@@ -443,6 +443,7 @@ class RedistributeTest(DTensorTestBase):
         new_meta_tensor = shard_dim_alltoall(meta_tensor, 0, 1, mesh, 0)
 
         self.assertEqual(new_tensor.shape, new_meta_tensor.shape)
+        self.assertEqual(new_tensor.stride(), new_meta_tensor.stride())
 
 
 class MultiDimRedistributeTest(DTensorTestBase):

--- a/torch/distributed/tensor/_collective_utils.py
+++ b/torch/distributed/tensor/_collective_utils.py
@@ -64,7 +64,7 @@ def shard_dim_alltoall(input, gather_dim, shard_dim, mesh, mesh_dim):
         out = torch.chunk(out, mesh.size(mesh_dim), dim=shard_dim)[
             mesh.get_local_rank(mesh_dim)
         ]
-        return out.contiguous() if not out.is_contiguous() else out
+        return out.contiguous()
 
     group_name = funcol._resolve_group_name((mesh, mesh_dim))
     # TODO: enable async op for shard_dim_alltoall

--- a/torch/distributed/tensor/_collective_utils.py
+++ b/torch/distributed/tensor/_collective_utils.py
@@ -8,13 +8,11 @@ from typing import List, Optional
 import torch
 import torch.distributed._functional_collectives as funcol
 import torch.distributed.tensor._dtensor_spec as dtensor_spec
-from torch._C._distributed_c10d import _resolve_process_group
 from torch.distributed.device_mesh import _mesh_resources, DeviceMesh
 from torch.distributed.distributed_c10d import (
     _get_group_size_by_name,
     broadcast,
     get_global_rank,
-    get_group_rank,
     get_rank,
     GroupMember,
     ProcessGroup,


### PR DESCRIPTION
currently, DTensor redistributions involving all2all `Shard(n)->Shard(m)` will generate faulty inductor code when compiled:
```python
# torchrun --nproc_per_node=2 crash.py
import torch
from torch.distributed.device_mesh import init_device_mesh
from torch.distributed.tensor import Shard, DTensor

mesh = init_device_mesh('cuda', (2,), mesh_dim_names=('ep',))
dt = DTensor.from_local(torch.randn(2, 4, device='cuda'), mesh, [Shard(0)]).requires_grad_()
def f(dt): return dt.redistribute(placements=[Shard(1)]).to_local()
f(dt).sum().backward() # no crash
f = torch.compile(f)
f(dt).sum().backward() # crash
```
resulting:
```python
[rank1]: Traceback (most recent call last):
[rank1]:   File "/crash.py", line 11, in <module>
[rank1]:     f(dt).sum().backward() # crash
[rank1]:     ^^^^^
...
[rank1]:   File "/tmp/torchinductor_main/gu/cgurkeb7tzx7kfsnooolsjefrgoizzylrldrugc52n4avmgiccas.py", line 41, in call
[rank1]:     assert_size_stride(buf0, (4, 2), (4, 1))
[rank1]: AssertionError: expected size 4==4, stride 2==4 at dim=0
```

This happens because the current [`register_fake` implementation for `shard_dim_alltoall` ops](https://github.com/pytorch/pytorch/blob/5deca07c0dcf1482eba99bf93b805cf1cc41ad6c/torch/distributed/tensor/_collective_utils.py#L32) returns an erroneous stride:

```python
import torch
import torch.distributed as dist
from torch._C._distributed_c10d import _register_process_group
from torch.distributed.device_mesh import init_device_mesh
from torch.distributed.tensor._collective_utils import _shard_dim_alltoall_meta, _get_group_size_by_name

mesh = init_device_mesh('cuda', (2,), mesh_dim_names=('ep',))
_register_process_group('ep', mesh['ep'].get_group())
x = torch.randn(2, 4, device='meta')
y = _shard_dim_alltoall_meta(x, 0, 1, 'ep')
if dist.get_rank() == 0:
    print(x.shape, x.stride()) # torch.Size([2, 4]) (4, 1)
    print(y.shape, y.stride()) # torch.Size([4, 2]) (4, 1)
```

---

The proposed fix in the pull request causes the provided example code to compile correctly && stop erroring. However, I know very little about torch internals, and expect there to be something wrong with this patch. Any corrections are appreciated. 

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o