### PR TITLE
[WIP][Intel GPU] Disable Pad Strides on XPU Devices

### DIFF
--- a/test/inductor/test_padding.py
+++ b/test/inductor/test_padding.py
@@ -20,6 +20,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     serialTest,
 )
+from torch.testing._internal.common_utils import skipIfXpu
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, requires_gpu
 
 
@@ -467,9 +468,11 @@ class PaddingTest(TestCaseBase):
         self.do_profiling(f1, f2)
 
     @serialTest()
+    @skipIfXpu(msg="XPU will not pad strides")
     def test_nobias_LinearAndSoftmax_codegen(self):
         self.test_LinearAndSoftmax_codegen(bias=False)
 
+    @skipIfXpu(msg="XPU will not pad strides")
     def test_LinearAndSoftmax_codegen(self, bias=True):
         m_bad_shape = LinearAndSoftmax(vocab_size=30523, bias=bias)
         inputs_bad_shape = m_bad_shape.get_example_inputs()
@@ -539,6 +542,7 @@ class PaddingTest(TestCaseBase):
         x = torch.randn(3, 9)
         self.common_numeric_check(f, x)
 
+    @skipIfXpu(msg="XPU will not pad strides")
     def test_pad_strides(self):
         """
         Note that dim0's stride is also padded even though its previous value
@@ -553,6 +557,7 @@ class PaddingTest(TestCaseBase):
             expected_strides, out_strides, f"{expected_strides} v.s. {out_strides}"
         )
 
+    @skipIfXpu(msg="XPU will not pad strides")
     def test_pad_strides_skip(self):
         """
         The padding is skipped to avoid too much memory overhead.
@@ -565,6 +570,7 @@ class PaddingTest(TestCaseBase):
             expected_strides, out_strides, f"{expected_strides} v.s. {out_strides}"
         )
 
+    @skipIfXpu(msg="XPU will not pad strides")
     def test_pad_3d_tensor(self):
         """
         Constructing this test case guided by the fact that we don't pad
@@ -584,6 +590,7 @@ class PaddingTest(TestCaseBase):
         self.common_numeric_check(f, x, y, tol=1e-2)
         self.assertTrue(metrics.num_comprehensive_padding > 0)
 
+    @skipIfXpu(msg="XPU will not pad strides")
     def test_conv(self):
         """
         Padding the input for convolution may cause extra copy kernel being called.
@@ -651,6 +658,7 @@ class PaddingTest(TestCaseBase):
         )
         self.do_profiling(lambda: f(x), lambda: opt_f(x), "Eager Cat", "Compiled Cat")
 
+    @skipIfXpu(msg="XPU will not pad strides")
     def test_pad_channels_last(self):
         t = torch.randn(2, 3, 5, 1025)
         in_strides = t.stride()
@@ -665,6 +673,7 @@ class PaddingTest(TestCaseBase):
     @parametrize("alignment_bytes", (32, 128))
     @parametrize("shape", [(21, 19), (3, 5, 71)])
     @parametrize("dtype", (torch.float16, torch.float32))
+    @skipIfXpu(msg="XPU will not pad strides")
     def test_pad_outputs(
         self, dtype: torch.dtype, shape: Tuple[int], alignment_bytes: int
     ):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -710,6 +710,8 @@ padding_alignment_bytes = 128
 #
 # This change turns HF AllenaiLongformerBase amp training from a loss of 1.09x to a win of 1.05x.
 # (baseline: 71.09ms, padding w/o this change: 77.38ms, padding with this change: 67.77ms)
+#
+# XPU devices will not pad stride.
 padding_stride_threshold = 1024
 
 # Enable padding outputs, even if they would not be padded in eager mode.


### PR DESCRIPTION
This PR disables inductor to pad stride for triton kernels on XPU devices. BERT_pytorch fp16 inference in torchbench will get ~15% improvement on max 1100 and 1550. I see only 2% regression on HF AllenaiLongformerBase amp training (mentioned in comments that pad strides should have benefit on cuda).
Padding strides may cause non-dense layout on matmul (i.e. a tensor with shape [100, 100] but stride [128, 1]). Current XPU implementation on matmul and conv will add two extra copies in this case, which harms performance.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov