### PR TITLE
Enable preparing module named parameters and buffers in tracing context for non-Inductor backends to implement graph freezing.

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -346,6 +346,42 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
             )
             opt_fn(input)
 
+    def test_backend_graph_freeze(self):
+        from functorch.compile import make_boxed_func
+        from torch._dynamo.backends.common import aot_autograd
+
+        backend_run = False
+
+        def my_compiler(gm, example_inputs):
+            nonlocal backend_run
+            if tracing_context := torch._guards.TracingContext.try_get():
+                fw_metadata = tracing_context.fw_metadata
+                params_flat = tracing_context.params_flat
+                self.assertTrue(fw_metadata is not None)
+                self.assertTrue(params_flat is not None)
+                self.assertTrue(len(params_flat) == 2)
+            backend_run = True
+            return make_boxed_func(gm.forward)
+
+        my_backend = aot_autograd(fw_compiler=my_compiler)
+
+        class MyClass(torch.nn.Module):
+            def __init__(self, *args, **kwargs) -> None:
+                super().__init__(*args, **kwargs)
+                self.p1 = torch.nn.Parameter(torch.randn(2, 3))
+                self.p2 = torch.nn.Parameter(torch.randn(2, 3))
+
+            @torch._dynamo.config.patch("prepare_freezing", True)
+            def forward(self, x):
+                t = self.p1 + x
+                out = t / self.p2
+                return out
+
+        mod = MyClass()
+
+        opt_mod = torch.compile(mod, backend=my_backend)
+        opt_mod(torch.randn(2, 3))
+        self.assertTrue(backend_run)
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -121,6 +121,11 @@ guard_nn_modules = True
 # once we have reached stability for the guard_nn_modules_using_dict_tags.
 guard_nn_modules_using_dict_tags = True
 
+# Flag to enable preparation for graph freezing, so that the named parameters and
+# buffers are passed as params_flat in tracing context by AOT autograd.
+# Non-Inductor backends can use this list for graph freezing.
+prepare_freezing = os.environ.get("TORCHDYNAMO_PREPARE_FREEZING", "0") == "1"
+
 # This feature doesn't really work.  We offer this flag for experimental
 # purposes / if you want to help us build out support.
 #

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1545,7 +1545,7 @@ class VariableBuilder:
             is_static_input = True
 
         make_graph_attribute = is_static_input and (
-            not config.inline_inbuilt_nn_modules or is_parameter_freezing()
+            not config.inline_inbuilt_nn_modules or is_parameter_freezing() or torch._dynamo.config.prepare_freezing
         )
 
         if (


### PR DESCRIPTION
…

Fixes #139902


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames