### PR TITLE
Fix DCe in training IR to reflect correct record function op

### DIFF
--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1514,7 +1514,7 @@ def _export_to_aten_ir_make_fx(
                 if node.op == "call_function" and node.target in (
                     torch.ops.profiler._record_function_enter.default,
                     torch.ops.profiler._record_function_enter_new.default,
-                    torch.ops.profiler._record_function_exit.default,
+                    torch.ops.profiler._record_function_exit._RecordFunction,
                 ):
                     return False
                 return True


### PR DESCRIPTION
Summary: The exit function is actually exit._recordFunction not exit.default

Test Plan: CI

Differential Revision: D66665359


