### PR TITLE
[64-bit Indexing][CUDA] Another 64-bit indexing fix for `distribution_elementwise_grid_stride_kernel `

### DIFF
--- a/aten/src/ATen/native/cuda/DistributionTemplates.h
+++ b/aten/src/ATen/native/cuda/DistributionTemplates.h
@@ -75,7 +75,7 @@ __global__ void distribution_elementwise_grid_stride_kernel(int64_t numel,
               std::get<1>(seeds),
               &state);
 
-  int64_t rounded_size = ((numel - 1)/(blockDim.x * gridDim.x * unroll_factor)+1) *
+  int64_t rounded_size = ((numel - 1)/(((int64_t) blockDim.x) * gridDim.x * unroll_factor)+1) *
       blockDim.x * gridDim.x * unroll_factor;
   for(int64_t linear_index = idx; linear_index < rounded_size; linear_index += blockDim.x * gridDim.x * unroll_factor) {
     auto rand = dist_func(&state);


### PR DESCRIPTION
Previous fix in #141613 is technically incomplete e.g.,

```
#include <iostream>

int main() {
        int a = 4456448;
        int b = 1024;
        int64_t c = a * b;
        int64_t d = (int64_t) a * b;
        std::cout << (c == d) << std::endl;
        std::cout << c << std::endl;
        std::cout << d << std::endl;
}
```

cc @ptrblck @msaroufim