### PR TITLE
[fr_trace][bugfix] Log missing ranks when provided

### DIFF
--- a/tools/flight_recorder/components/types.py
+++ b/tools/flight_recorder/components/types.py
@@ -286,6 +286,7 @@ class EntryState:
                 expected_ranks=self.expected_ranks,
                 collective_state=self.collective_state,
                 collective_frames=self.collective_frames,
+                missing_ranks=getattr(self, "missing_ranks", None),
             )
         else:
             assert idx_map is not None, "idx_map is None"


### PR DESCRIPTION
Summary: For missing ranks issues, `build_collectives` doesn't log any errors (https://github.com/pytorch/pytorch/blob/5c2584a14c2283514703a17cba0a57c8bfb0d977/tools/flight_recorder/components/builder.py#L293C23-L306C24), which means that when `EntryState.to_collective` is called [here](https://github.com/pytorch/pytorch/blob/5c2584a14c2283514703a17cba0a57c8bfb0d977/tools/flight_recorder/components/builder.py#L400C21-L405C22), errors will be empty and `to_collective` will enter the first if statement. But that codepath doesn't log `missing_ranks`, meaning it will be absent from the `Collective` returned. This diff fixes that oversight.

Test Plan:
eyes

Sandcastle run

Differential Revision: D66679224


