### PR TITLE
Set capture_autograd_function=False by default

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -428,7 +428,7 @@ cudagraph_backend_support_input_mutation = False
 only_allow_pt2_compliant_ops = False
 
 # This flag is ignored and maintained for backwards compatibility.
-capture_autograd_function = True
+capture_autograd_function = False
 
 # This flag is ignored and maintained for backwards compatbility.
 capture_func_transforms = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #141933
* __->__ #141932

https://github.com/pytorch/pytorch/pull/136959 cleaned up the flag and added a warning. @Chillee pointed out that we should really default this flag to false otherwise we subject all users that go down this code path to log spew.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames