### PR TITLE
update xnnpack for disable libm on Windows  [submodule XNNPACK]

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -785,6 +785,10 @@ if(HAVE_SOVERSION)
 endif()
 torch_compile_options(torch_cpu)  # see cmake/public/utils.cmake
 
+if(Win32)
+  target_compile_options(torch_cpu PRIVATE "/Zc:static_assert")
+endif()
+
 # Ignore Wdeprecated-XXX errors from third-party libraries
 if(NOT MSVC)
   set_source_files_properties(${PROJECT_SOURCE_DIR}/torch/csrc/distributed/c10d/socket.cpp PROPERTIES COMPILE_OPTIONS "-Wno-error=deprecated")

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -786,7 +786,7 @@ endif()
 torch_compile_options(torch_cpu)  # see cmake/public/utils.cmake
 
 if(Win32)
-  target_compile_options(torch_cpu PRIVATE "/Zc:static_assert")
+  target_compile_options(torch_cpu PRIVATE "/std:c++17")
 endif()
 
 # Ignore Wdeprecated-XXX errors from third-party libraries

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -785,10 +785,6 @@ if(HAVE_SOVERSION)
 endif()
 torch_compile_options(torch_cpu)  # see cmake/public/utils.cmake
 
-if(Win32)
-  target_compile_options(torch_cpu PRIVATE "/std:c++17")
-endif()
-
 # Ignore Wdeprecated-XXX errors from third-party libraries
 if(NOT MSVC)
   set_source_files_properties(${PROJECT_SOURCE_DIR}/torch/csrc/distributed/c10d/socket.cpp PROPERTIES COMPILE_OPTIONS "-Wno-error=deprecated")

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -539,6 +539,12 @@ if(USE_XNNPACK AND NOT USE_SYSTEM_XNNPACK)
     set(__caffe2_CMAKE_POSITION_INDEPENDENT_CODE_FLAG ${CMAKE_POSITION_INDEPENDENT_CODE})
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+    if(Win32)
+      # Windows MSVC is not have libm, and this option possible to bring in linker issue:
+      # https://github.com/pytorch/pytorch/issues/134989
+      set(XNNPACK_BUILD_WITH_LIBM OFF CACHE BOOL "")
+    endif()
+
     add_subdirectory(
       "${XNNPACK_SOURCE_DIR}"
       "${CONFU_DEPENDENCIES_BINARY_DIR}/XNNPACK")

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -540,8 +540,8 @@ if(USE_XNNPACK AND NOT USE_SYSTEM_XNNPACK)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
     if(Win32)
-      # Windows MSVC is not have libm, and this option possible to bring in linker issue:
-      # https://github.com/pytorch/pytorch/issues/134989
+      # Disable libm dependency explicitly to avoid symbol conflict for XNNPACK as 
+      # Windows runtime has provided the math functions - #134989
       set(XNNPACK_BUILD_WITH_LIBM OFF CACHE BOOL "")
     endif()
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -540,7 +540,7 @@ if(USE_XNNPACK AND NOT USE_SYSTEM_XNNPACK)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
     if(Win32)
-      # Disable libm dependency explicitly to avoid symbol conflict for XNNPACK as 
+      # Disable libm dependency explicitly to avoid symbol conflict for XNNPACK as
       # Windows runtime has provided the math functions - #134989
       set(XNNPACK_BUILD_WITH_LIBM OFF CACHE BOOL "")
     endif()


### PR DESCRIPTION
This PR is implement of RFC: https://github.com/pytorch/pytorch/issues/141946 
Changes:
1. Update `XNNPACK` to contains it's PRS: https://github.com/google/XNNPACK/pull/7456, https://github.com/google/XNNPACK/pull/7535 and other build fixing PRs.
2. Set `XNNPACK_BUILD_WITH_LIBM` to `OFF`, it is turn off CMake find_library(libm) of `XNNPACK`.


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10