### PR TITLE
[ATen][Native][Special] Hermite polynomial prematurely return NaN if n is high

### DIFF
--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -3054,6 +3054,14 @@ inline C10_HOST_DEVICE T hermite_polynomial_h_forward(T x, int64_t n) {
         return x + x;
     }
 
+    if (std::is_same_v<T, float> && n > 128) {
+        return std::numeric_limits<T>::quiet_NaN();
+    } else if (std::is_same_v<T, double> && n > 512) {
+        return std::numeric_limits<T>::quiet_NaN();
+    } else if (n > 1024) {
+        return std::numeric_limits<T>::quiet_NaN();
+    }
+
     T p = T(1.0);
     T q = x + x;
     T r = T(0.0);
@@ -3089,6 +3097,14 @@ inline C10_HOST_DEVICE T hermite_polynomial_he_forward(T x, int64_t n) {
 
     if (n == 1) {
         return x;
+    }
+
+    if (std::is_same_v<T, float> && n > 128) {
+        return std::numeric_limits<T>::quiet_NaN();
+    } else if (std::is_same_v<T, double> && n > 512) {
+        return std::numeric_limits<T>::quiet_NaN();
+    } else if (n > 1024) {
+        return std::numeric_limits<T>::quiet_NaN();
     }
 
     T p = T(1.0);

--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -3041,6 +3041,17 @@ inline C10_HOST_DEVICE T chebyshev_polynomial_w_forward(T x, T n) {
 } // chebyshev_polynomial_w_forward(T x, T n)
 
 template<typename T>
+constexpr auto getHermitianLimit() {
+    if constexpr (std::is_same_v<T, float>) {
+        return 128;
+    } else if constexpr (std::is_same_v<T, double>) {
+        return 512;
+    } else {
+        return 1024;
+    }
+}
+
+template<typename T>
 inline C10_HOST_DEVICE T hermite_polynomial_h_forward(T x, int64_t n) {
     if (n < 0) {
         return T(0.0);
@@ -3054,11 +3065,7 @@ inline C10_HOST_DEVICE T hermite_polynomial_h_forward(T x, int64_t n) {
         return x + x;
     }
 
-    if (std::is_same_v<T, float> && n > 128) {
-        return std::numeric_limits<T>::quiet_NaN();
-    } else if (std::is_same_v<T, double> && n > 512) {
-        return std::numeric_limits<T>::quiet_NaN();
-    } else if (n > 1024) {
+    if (n > getHermitianLimit<T>()) {
         return std::numeric_limits<T>::quiet_NaN();
     }
 
@@ -3099,11 +3106,7 @@ inline C10_HOST_DEVICE T hermite_polynomial_he_forward(T x, int64_t n) {
         return x;
     }
 
-    if (std::is_same_v<T, float> && n > 128) {
-        return std::numeric_limits<T>::quiet_NaN();
-    } else if (std::is_same_v<T, double> && n > 512) {
-        return std::numeric_limits<T>::quiet_NaN();
-    } else if (n > 1024) {
+    if (n > getHermitianLimit<T>()) {
         return std::numeric_limits<T>::quiet_NaN();
     }
 

--- a/aten/src/ATen/native/cuda/Math.cuh
+++ b/aten/src/ATen/native/cuda/Math.cuh
@@ -2134,10 +2134,10 @@ const auto chebyshev_polynomial_w_string = jiterator_stringify(
 
 const auto hermite_polynomial_h_string = jiterator_stringify(
     template<typename T>
-    constexpr auto getHermitianLimit() {
-        if constexpr (sizeof(T) <= sizeof(float)) {
+    unsigned short getHermitianLimit() {
+        if (sizeof(T) <= sizeof(float)) {
             return 128;
-        } else if constexpr (sizeof(T) <= sizeof(double)) {
+        } else if (sizeof(T) <= sizeof(double)) {
             return 512;
         } else {
             return 1024;
@@ -2183,10 +2183,10 @@ const auto hermite_polynomial_h_string = jiterator_stringify(
 
 const auto hermite_polynomial_he_string = jiterator_stringify(
     template<typename T>
-    constexpr auto getHermitianLimit() {
-        if constexpr (sizeof(T) <= sizeof(float)) {
+    unsigned short getHermitianLimit() {
+        if (sizeof(T) <= sizeof(float)) {
             return 128;
-        } else if constexpr (sizeof(T) <= sizeof(double)) {
+        } else if (sizeof(T) <= sizeof(double)) {
             return 512;
         } else {
             return 1024;

--- a/aten/src/ATen/native/cuda/Math.cuh
+++ b/aten/src/ATen/native/cuda/Math.cuh
@@ -2147,6 +2147,14 @@ const auto hermite_polynomial_h_string = jiterator_stringify(
             return x + x;
         }
 
+        if (sizeof(T) <= 4 && n > 128) {
+            return NAN;
+        } else if (sizeof(T) <= 8 && n > 512) {
+            return NAN;
+        } else if (n > 1024) {
+            return NAN;
+        }
+
         T p = T(1.0);
         T q = x + x;
         T r = T(0.0);
@@ -2179,6 +2187,14 @@ const auto hermite_polynomial_he_string = jiterator_stringify(
 
         if (n == 1) {
             return x;
+        }
+
+        if (sizeof(T) <= 4 && n > 128) {
+            return NAN;
+        } else if (sizeof(T) <= 8 && n > 512) {
+            return NAN;
+        } else if (n > 1024) {
+            return NAN;
         }
 
         T p = T(1.0);

--- a/aten/src/ATen/native/cuda/Math.cuh
+++ b/aten/src/ATen/native/cuda/Math.cuh
@@ -2134,6 +2134,20 @@ const auto chebyshev_polynomial_w_string = jiterator_stringify(
 
 const auto hermite_polynomial_h_string = jiterator_stringify(
     template<typename T>
+    constexpr auto getHermitianLimit() {
+        // Not the most universal way, but it will work
+        // properly because x is always of a floating
+        // point type.
+        if constexpr (sizeof(T) <= sizeof(float)) {
+            return 128;
+        } else if constexpr (sizeof(T) <= sizeof(double)) {
+            return 512;
+        } else {
+            return 1024;
+        }
+    }
+
+    template<typename T>
     T hermite_polynomial_h_forward(T x, int64_t n) {
         if (n < 0) {
             return T(0.0);
@@ -2147,11 +2161,7 @@ const auto hermite_polynomial_h_string = jiterator_stringify(
             return x + x;
         }
 
-        if (sizeof(T) <= 4 && n > 128) {
-            return NAN;
-        } else if (sizeof(T) <= 8 && n > 512) {
-            return NAN;
-        } else if (n > 1024) {
+        if (n > getHermitianLimit<T>()) {
             return NAN;
         }
 
@@ -2176,6 +2186,20 @@ const auto hermite_polynomial_h_string = jiterator_stringify(
 
 const auto hermite_polynomial_he_string = jiterator_stringify(
     template<typename T>
+    constexpr auto getHermitianLimit() {
+        // Not the most universal way, but it will work
+        // properly because x is always of a floating
+        // point type.
+        if constexpr (sizeof(T) <= sizeof(float)) {
+            return 128;
+        } else if constexpr (sizeof(T) <= sizeof(double)) {
+            return 512;
+        } else {
+            return 1024;
+        }
+    }
+
+    template<typename T>
     T hermite_polynomial_he_forward(T x, int64_t n) {
         if (n < 0) {
             return T(0.0);
@@ -2189,11 +2213,7 @@ const auto hermite_polynomial_he_string = jiterator_stringify(
             return x;
         }
 
-        if (sizeof(T) <= 4 && n > 128) {
-            return NAN;
-        } else if (sizeof(T) <= 8 && n > 512) {
-            return NAN;
-        } else if (n > 1024) {
+        if (n > getHermitianLimit<T>()) {
             return NAN;
         }
 

--- a/aten/src/ATen/native/cuda/Math.cuh
+++ b/aten/src/ATen/native/cuda/Math.cuh
@@ -2135,9 +2135,6 @@ const auto chebyshev_polynomial_w_string = jiterator_stringify(
 const auto hermite_polynomial_h_string = jiterator_stringify(
     template<typename T>
     constexpr auto getHermitianLimit() {
-        // Not the most universal way, but it will work
-        // properly because x is always of a floating
-        // point type.
         if constexpr (sizeof(T) <= sizeof(float)) {
             return 128;
         } else if constexpr (sizeof(T) <= sizeof(double)) {
@@ -2187,9 +2184,6 @@ const auto hermite_polynomial_h_string = jiterator_stringify(
 const auto hermite_polynomial_he_string = jiterator_stringify(
     template<typename T>
     constexpr auto getHermitianLimit() {
-        // Not the most universal way, but it will work
-        // properly because x is always of a floating
-        // point type.
         if constexpr (sizeof(T) <= sizeof(float)) {
             return 128;
         } else if constexpr (sizeof(T) <= sizeof(double)) {

--- a/torch/testing/_internal/opinfo/definitions/special.py
+++ b/torch/testing/_internal/opinfo/definitions/special.py
@@ -15,11 +15,7 @@ from torch.testing._internal.common_device_type import (
     toleranceOverride,
 )
 from torch.testing._internal.common_dtype import all_types_and, floating_types
-from torch.testing._internal.common_utils import (
-    TEST_SCIPY,
-    TEST_WITH_ROCM,
-    torch_to_numpy_dtype_dict,
-)
+from torch.testing._internal.common_utils import TEST_SCIPY, torch_to_numpy_dtype_dict
 from torch.testing._internal.opinfo.core import (
     BinaryUfuncInfo,
     DecorateInfo,
@@ -466,7 +462,6 @@ op_db: List[OpInfo] = [
             DecorateInfo(unittest.skip("Skipped!"), "TestNNCOpInfo"),
             # Greatest absolute difference: inf
             DecorateInfo(unittest.expectedFailure, "TestCommon", "test_compare_cpu"),
-            DecorateInfo(unittest.skip("Hangs on ROCm 6.1"), active_if=TEST_WITH_ROCM),
         ),
         supports_one_python_scalar=True,
         supports_autograd=False,


### PR DESCRIPTION
Hermite polynomials diverge to NaN at high orders due to numerical overflow. The proposal is to prematurely return NaN of it is known that at this value it will be NaN.

According to my short test
```Python
import torch
device = "cuda"
dtype = torch.float32

x = torch.linspace(-1000, 1000, 100000, device=device, dtype=dtype)

for n in range(1024):
    if torch.special.hermite_polynomial_h(x, n).isnan().sum().item() == x.shape[0]:
        print(f"hermite_polynomial_h: all outputs are nans! n = {n}")
        break

for n in range(1024):
    if torch.special.hermite_polynomial_he(x, n).isnan().sum().item() == x.shape[0]:
        print(f"hermite_polynomial_he: all outputs are nans! n = {n}")
        break
```

The output values become NaNs at these orders:
```
hermite_polynomial_h: all outputs are nans! n = 53, dtype=torch.float32
hermite_polynomial_he: all outputs are nans! n = 61, dtype=torch.float32
hermite_polynomial_h: all outputs are nans! n = 272, dtype=torch.float64
hermite_polynomial_he: all outputs are nans! n = 304, dtype=torch.float64
```

Surely, it makes sense to increase the limit as a safety margin.

cc @msaroufim @ptrblck @eqy @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @mruberry @kshitij12345 @manuelcandales @SherlockNoMad @angelayi