### PR TITLE
Fix memory leak in `ModuleTracker`

### DIFF
--- a/torch/utils/module_tracker.py
+++ b/torch/utils/module_tracker.py
@@ -11,6 +11,7 @@ from torch.nn.modules.module import (
 )
 from torch.utils._pytree import tree_flatten
 
+
 if TYPE_CHECKING:
     from torch.utils.hooks import RemovableHandle
 

--- a/torch/utils/module_tracker.py
+++ b/torch/utils/module_tracker.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import logging
 import weakref
-from typing import List, Set
+from typing import List, Set, TYPE_CHECKING
 
 import torch
 from torch.autograd.graph import register_multi_grad_hook
@@ -10,7 +10,9 @@ from torch.nn.modules.module import (
     register_module_forward_pre_hook,
 )
 from torch.utils._pytree import tree_flatten
-from torch.utils.hooks import RemovableHandle
+
+if TYPE_CHECKING:
+    from torch.utils.hooks import RemovableHandle
 
 
 logger = logging.getLogger(__name__)

--- a/torch/utils/module_tracker.py
+++ b/torch/utils/module_tracker.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import logging
 import weakref
-from typing import Set, List
+from typing import List, Set
 
 import torch
 from torch.autograd.graph import register_multi_grad_hook
@@ -9,8 +9,8 @@ from torch.nn.modules.module import (
     register_module_forward_hook,
     register_module_forward_pre_hook,
 )
-from torch.utils.hooks import RemovableHandle
 from torch.utils._pytree import tree_flatten
+from torch.utils.hooks import RemovableHandle
 
 
 logger = logging.getLogger(__name__)
@@ -128,7 +128,9 @@ class ModuleTracker:
         args, _ = tree_flatten(input)
         tensors = [a for a in args if isinstance(a, torch.Tensor) and a.requires_grad]
         if tensors:
-            self._hooks.append(register_multi_grad_hook(tensors, self._get_pop_fn(name, True)))
+            self._hooks.append(
+                register_multi_grad_hook(tensors, self._get_pop_fn(name, True))
+            )
 
     def _fw_post_hook(self, mod, input, output):
         name = self._get_mod_name(mod)
@@ -137,7 +139,9 @@ class ModuleTracker:
         args, _ = tree_flatten(output)
         tensors = [a for a in args if isinstance(a, torch.Tensor) and a.requires_grad]
         if tensors:
-            self._hooks.append(register_multi_grad_hook(tensors, self._get_append_fn(name, True)))
+            self._hooks.append(
+                register_multi_grad_hook(tensors, self._get_append_fn(name, True))
+            )
 
     def __enter__(self):
         self._fw_pre_handle = register_module_forward_pre_hook(self._fw_pre_hook)

--- a/torch/utils/module_tracker.py
+++ b/torch/utils/module_tracker.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import logging
 import weakref
-from typing import Set
+from typing import Set, List
 
 import torch
 from torch.autograd.graph import register_multi_grad_hook
@@ -9,6 +9,7 @@ from torch.nn.modules.module import (
     register_module_forward_hook,
     register_module_forward_pre_hook,
 )
+from torch.utils.hooks import RemovableHandle
 from torch.utils._pytree import tree_flatten
 
 
@@ -61,6 +62,7 @@ class ModuleTracker:
         self._known_modules: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
         self._seen_modules: weakref.WeakSet = weakref.WeakSet()
         self._has_callback = False
+        self._hooks: List[RemovableHandle] = []
 
     def _maybe_set_engine_callback(self):
         # This assumes no concurrent calls to backward
@@ -126,7 +128,7 @@ class ModuleTracker:
         args, _ = tree_flatten(input)
         tensors = [a for a in args if isinstance(a, torch.Tensor) and a.requires_grad]
         if tensors:
-            register_multi_grad_hook(tensors, self._get_pop_fn(name, True))
+            self._hooks.append(register_multi_grad_hook(tensors, self._get_pop_fn(name, True)))
 
     def _fw_post_hook(self, mod, input, output):
         name = self._get_mod_name(mod)
@@ -135,7 +137,7 @@ class ModuleTracker:
         args, _ = tree_flatten(output)
         tensors = [a for a in args if isinstance(a, torch.Tensor) and a.requires_grad]
         if tensors:
-            register_multi_grad_hook(tensors, self._get_append_fn(name, True))
+            self._hooks.append(register_multi_grad_hook(tensors, self._get_append_fn(name, True)))
 
     def __enter__(self):
         self._fw_pre_handle = register_module_forward_pre_hook(self._fw_pre_hook)
@@ -145,3 +147,6 @@ class ModuleTracker:
     def __exit__(self, *args):
         self._fw_pre_handle.remove()
         self._fw_post_handle.remove()
+        for hook in self._hooks:
+            hook.remove()
+        self._hooks.clear()


### PR DESCRIPTION
Thanks @drisspg and @albanD for finding the fix
cc @pragupta 

**TEST PLAN**
```
import gc
import torch
import torch.nn as nn
from torch.utils.module_tracker import ModuleTracker


class MyModel(nn.Module):
    def forward(self, x):
        return x * x

print(f"torch=={torch.__version__}")
m = MyModel()
m.cuda()
m.to(torch.bfloat16)
mt = ModuleTracker()
for i in range(1000):
    if i % 100 == 0:
        gc.collect()
        print("memory_allocated:", torch.cuda.memory_allocated())
    x = torch.randn([128, 256], device="cuda", dtype=torch.bfloat16, requires_grad=True)
    with mt:
        m(x)

```