### PR TITLE
[Redo] Set remote cache version and backend type once in compilation metrics

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1003,6 +1003,7 @@ def record_compilation_metrics(
                 FbRemoteFxGraphCache,
                 REMOTE_CACHE_VERSION,
             )
+
             remote_cache_version = REMOTE_CACHE_VERSION
             backend = FbRemoteFxGraphCache.get_remote_backend()
             inductor_fx_remote_cache_backend_type = type(backend).__name__

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -996,6 +996,23 @@ def record_compilation_metrics(
         return ",".join(safe_str(item) for item in metric)
 
     structured_logging_overhead_s = torch._logging.get_structured_logging_overhead()
+
+    if torch._inductor.utils.should_use_remote_fx_graph_cache():
+        try:
+            from torch._inductor.fb.remote_cache import (
+                FbRemoteFxGraphCache,
+                REMOTE_CACHE_VERSION,
+            )
+            remote_cache_version = REMOTE_CACHE_VERSION
+            backend = FbRemoteFxGraphCache.get_remote_backend()
+            inductor_fx_remote_cache_backend_type = type(backend).__name__
+        except ModuleNotFoundError:
+            REMOTE_CACHE_VERSION = None
+            inductor_fx_remote_cache_backend_type = None
+    else:
+        inductor_fx_remote_cache_backend_type = None
+        remote_cache_version = None
+
     common_metrics = {
         "compile_id": str(torch._guards.CompileContext.current_compile_id()),
         "start_time_us": start_time_ns // 1000,
@@ -1013,6 +1030,8 @@ def record_compilation_metrics(
         "inductor_fx_remote_cache_miss_keys": _convert_collection_to_str(
             "inductor_fx_remote_cache_miss_keys"
         ),
+        "remote_cache_version": remote_cache_version,
+        "inductor_fx_remote_cache_backend_type": inductor_fx_remote_cache_backend_type,
     }
 
     # TODO: The following are legacy fields, populated from the fields that replace

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1007,7 +1007,7 @@ def record_compilation_metrics(
             backend = FbRemoteFxGraphCache.get_remote_backend()
             inductor_fx_remote_cache_backend_type = type(backend).__name__
         except ModuleNotFoundError:
-            REMOTE_CACHE_VERSION = None
+            remote_cache_version = None
             inductor_fx_remote_cache_backend_type = None
     else:
         inductor_fx_remote_cache_backend_type = None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141967

(Got reverted due to a silly bug, fixed now.)

This is causing FbFxGraphRemoteCache.init to no longer be idempotent, i.e. only safe to call once per compile. AOTAutogradCache initializes a new remote cache for the forward and the backward.
Technically, we could make AOTAutogradCache smart and globally thread through a single FbFxGraphRemoteCache everywhere. But there's no reason to do so, as this class is just the handle to access the cache. Plus, it's very brittle for FbFxGraphRemoteCache to not be safe to call multiple times

Differential Revision: [D66701970](https://our.internmc.facebook.com/intern/diff/D66701970/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames