### PR TITLE
Fix cuda arch full version for 12.6

### DIFF
--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -17,7 +17,7 @@ from typing import Dict, List, Optional, Tuple
 
 # NOTE: Also update the CUDA sources in tools/nightly.py when changing this list
 CUDA_ARCHES = ["11.8", "12.4", "12.6"]
-CUDA_ARCHES_FULL_VERSION = {"11.8": "11.8.0", "12.4": "12.4.1", "12.6": "12.6.2"}
+CUDA_ARCHES_FULL_VERSION = {"11.8": "11.8.0", "12.4": "12.4.1", "12.6": "12.6.3"}
 CUDA_ARCHES_CUDNN_VERSION = {"11.8": "9", "12.4": "9", "12.6": "9"}
 
 ROCM_ARCHES = ["6.1", "6.2"]


### PR DESCRIPTION
follow up for https://github.com/pytorch/pytorch/pull/141433/files
build still showing up as 12.6.2 in the name, see latest https://github.com/pytorch/pytorch/actions/runs/12134985224/job/33833276884.

related to https://github.com/pytorch/pytorch/issues/138440
cc @atalman @nWEIdia 
