### PR TITLE
Changed 'standard-deviation' to 'variance' in GroupNorm documentation

### DIFF
--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -280,9 +280,9 @@ class BatchNorm1d(_BatchNorm):
     the mini-batches and :math:`\gamma` and :math:`\beta` are learnable parameter vectors
     of size `C` (where `C` is the number of features or channels of the input). By default, the
     elements of :math:`\gamma` are set to 1 and the elements of :math:`\beta` are set to 0.
-    At train time in the forward pass, the standard-deviation is calculated via the biased estimator,
+    At train time in the forward pass, the variance is calculated via the biased estimator,
     equivalent to ``torch.var(input, unbiased=False)``. However, the value stored in the
-    moving average of the standard-deviation is calculated via the unbiased  estimator, equivalent to
+    moving average of the variance is calculated via the unbiased  estimator, equivalent to
     ``torch.var(input, unbiased=True)``.
 
     Also by default, during training this layer keeps running estimates of its

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -139,7 +139,7 @@ class InstanceNorm1d(_InstanceNorm):
     The mean and standard-deviation are calculated per-dimension separately
     for each object in a mini-batch. :math:`\gamma` and :math:`\beta` are learnable parameter vectors
     of size `C` (where `C` is the number of features or channels of the input) if :attr:`affine` is ``True``.
-    The standard-deviation is calculated via the biased estimator, equivalent to
+    The variance is calculated via the biased estimator, equivalent to
     `torch.var(input, unbiased=False)`.
 
     By default, this layer uses instance statistics computed from input data in

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -236,11 +236,11 @@ class GroupNorm(Module):
 
     The input channels are separated into :attr:`num_groups` groups, each containing
     ``num_channels / num_groups`` channels. :attr:`num_channels` must be divisible by
-    :attr:`num_groups`. The mean and standard-deviation are calculated
+    :attr:`num_groups`. The mean and variance are calculated
     separately over the each group. :math:`\gamma` and :math:`\beta` are learnable
     per-channel affine transform parameter vectors of size :attr:`num_channels` if
     :attr:`affine` is ``True``.
-    The standard-deviation is calculated via the biased estimator, equivalent to
+    The variance is calculated via the biased estimator, equivalent to
     `torch.var(input, unbiased=False)`.
 
     This layer uses statistics computed from input data in both training and

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -106,7 +106,7 @@ class LayerNorm(Module):
     the last 2 dimensions of the input (i.e. ``input.mean((-2, -1))``).
     :math:`\gamma` and :math:`\beta` are learnable affine transform parameters of
     :attr:`normalized_shape` if :attr:`elementwise_affine` is ``True``.
-    The standard-deviation is calculated via the biased estimator, equivalent to
+    The variance is calculated via the biased estimator, equivalent to
     `torch.var(input, unbiased=False)`.
 
     .. note::
@@ -236,7 +236,7 @@ class GroupNorm(Module):
 
     The input channels are separated into :attr:`num_groups` groups, each containing
     ``num_channels / num_groups`` channels. :attr:`num_channels` must be divisible by
-    :attr:`num_groups`. The mean and variance are calculated
+    :attr:`num_groups`. The mean and standard-deviation are calculated
     separately over the each group. :math:`\gamma` and :math:`\beta` are learnable
     per-channel affine transform parameter vectors of size :attr:`num_channels` if
     :attr:`affine` is ``True``.


### PR DESCRIPTION
Fixes #141315 

Updated the GroupNorm documentation to replace 'standard-deviation' with 'variance' to accurately reflect the calculation
method.

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov

@pytorchbot label "topic: not user facing"