### PR TITLE
ci: Hardcode number of jobs for install_openssl

### DIFF
--- a/.ci/docker/common/install_openssl.sh
+++ b/.ci/docker/common/install_openssl.sh
@@ -9,7 +9,7 @@ tar xf "${OPENSSL}.tar.gz"
 cd "${OPENSSL}"
 ./config --prefix=/opt/openssl -d '-Wl,--enable-new-dtags,-rpath,$(LIBRPATH)'
 # NOTE: openssl install errors out when built with the -j option
-NPROC=$[$(nproc) - 2]
+NPROC=6
 make -j${NPROC}; make install_sw
 # Link the ssl libraries to the /usr/lib folder.
 sudo ln -s /opt/openssl/lib/lib* /usr/lib


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #141985

This should ideally make it so that we no longer OOM on building OpenSSL as observed in builds like https://github.com/pytorch/pytorch/actions/runs/12061405532/job/33633399861

Reverts this back to the previous behavior prior to https://github.com/pytorch/pytorch/pull/118167

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>