### PR TITLE
Fix unit test failures with SciPy 1.13+

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3523,10 +3523,13 @@ class TestBinaryUfuncs(TestCase):
             our_func = torch.logaddexp2
         elif dtype in (torch.complex64, torch.complex128):
             # numpy has not implemented logaddexp for complex
-            def _ref_func(x, y):
-                return scipy.special.logsumexp(np.stack((x, y), axis=0), axis=0)
+            def complex_logaddexp(x1, x2):
+                x = np.stack((x1, x2))
+                amax = np.amax(x, axis=0)
+                amax[~np.isfinite(amax)] = 0
+                return np.log(np.sum(np.exp(x - amax), axis=0)) + np.squeeze(amax)
 
-            ref_func = _ref_func
+            ref_func = complex_logaddexp
             our_func = torch.logaddexp
         else:
             ref_func = np.logaddexp


### PR DESCRIPTION
Related to #107302 

To use `numpy>=2`, we need to upgrade `scipy>=1.13.0` from `1.11.0`.
This PR fixes a failed test caused by the `scipy` upgrade.

The `scipy` implementation of `logsumexp` has changed and deviated from the torch implementation.
So, we replace it with a simple custom implementation as the ground truth.

cc @mruberry @rgommers @albanD