### PR TITLE
Add manylinux_2_28_x86_64 tags to wheel builds

### DIFF
--- a/.ci/manywheel/build_common.sh
+++ b/.ci/manywheel/build_common.sh
@@ -425,6 +425,7 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*linux*.w
 
     # tag the wheel with approproiate tags
     if [[ $PLATFORM == "manylinux_2_28_x86_64" && $GPU_ARCH_TYPE != "cpu-s390x" ]]; then
+        LD_LIBRARY_PATH="/usr/local/nvidia/lib64/:${LD_LIBRARY_PATH}"
         auditwheel repair --plat ${PLATFORM} $(basename $pkg)
         # replace original wheel with audited
         mv //wheelhouse/*.whl /$WHEELHOUSE_DIR/

--- a/.ci/manywheel/build_common.sh
+++ b/.ci/manywheel/build_common.sh
@@ -425,7 +425,7 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*linux*.w
 
     # tag the wheel with approproiate tags
     if [[ $PLATFORM == "manylinux_2_28_x86_64" && $GPU_ARCH_TYPE != "cpu-s390x" ]]; then
-        LD_LIBRARY_PATH="/usr/local/nvidia/lib64/:${LD_LIBRARY_PATH}"
+        LD_LIBRARY_PATH="/usr/local/cuda/lib64/:${LD_LIBRARY_PATH}"
         auditwheel repair --plat ${PLATFORM} $(basename $pkg)
         # replace original wheel with audited
         mv //wheelhouse/*.whl /$WHEELHOUSE_DIR/

--- a/.ci/manywheel/build_common.sh
+++ b/.ci/manywheel/build_common.sh
@@ -425,7 +425,7 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*linux*.w
 
     # tag the wheel with approproiate tags
     if [[ $PLATFORM == "manylinux_2_28_x86_64" && $GPU_ARCH_TYPE != "cpu-s390x" ]]; then
-        LD_LIBRARY_PATH="/usr/local/cuda/extras/CUPTI/lib64/:/usr/local/cuda/lib64/:${LD_LIBRARY_PATH}"
+        LD_LIBRARY_PATH="/usr/local/cuda/extras/CUPTI/lib64/:/usr/local/cuda/lib64/:/usr/lib64/:${LD_LIBRARY_PATH}"
         auditwheel repair --plat ${PLATFORM} $(basename $pkg)
         # replace original wheel with audited
         mv //wheelhouse/*.whl /$WHEELHOUSE_DIR/

--- a/.ci/manywheel/build_common.sh
+++ b/.ci/manywheel/build_common.sh
@@ -425,7 +425,7 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*linux*.w
 
     # tag the wheel with approproiate tags
     if [[ $PLATFORM == "manylinux_2_28_x86_64" && $GPU_ARCH_TYPE != "cpu-s390x" ]]; then
-        LD_LIBRARY_PATH="/usr/local/cuda/lib64/:${LD_LIBRARY_PATH}"
+        LD_LIBRARY_PATH="/usr/local/cuda/extras/CUPTI/lib64/:/usr/local/cuda/lib64/:${LD_LIBRARY_PATH}"
         auditwheel repair --plat ${PLATFORM} $(basename $pkg)
         # replace original wheel with audited
         mv //wheelhouse/*.whl /$WHEELHOUSE_DIR/

--- a/.ci/manywheel/build_common.sh
+++ b/.ci/manywheel/build_common.sh
@@ -420,15 +420,18 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*linux*.w
 
     # zip up the wheel back
     zip -rq $(basename $pkg) $PREIX*
+    # remove original wheel
+    rm -f $pkg
 
     # tag the wheel with approproiate tags
-    if [[ $PLATFORM == "manylinux_2_28_x86_64" ]]; then
-        auditwheel repair --inplace --plat ${PLATFORM} $(basename $pkg)
+    if [[ $PLATFORM == "manylinux_2_28_x86_64" && $GPU_ARCH_TYPE != "cpu-s390x" ]]; then
+        auditwheel repair --plat ${PLATFORM} $(basename $pkg)
+        # replace original wheel with audited
+        mv //wheelhouse/*.whl /$WHEELHOUSE_DIR/
+    else
+        # replace original wheel
+        mv $(basename $pkg) $pkg
     fi
-
-    # replace original wheel
-    rm -f $pkg
-    mv $(basename $pkg) $pkg
 
     cd ..
     rm -rf tmp

--- a/.ci/manywheel/build_common.sh
+++ b/.ci/manywheel/build_common.sh
@@ -382,7 +382,7 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*linux*.w
     # create Manylinux 2_28 tag this needs to happen before regenerate the RECORD
     if [[ $PLATFORM == "manylinux_2_28_x86_64" && $GPU_ARCH_TYPE != "cpu-s390x" && $GPU_ARCH_TYPE != "xpu" ]]; then
         wheel_file=$(echo $(basename $pkg) | sed -e 's/-cp.*$/.dist-info\/WHEEL/g')
-        sed -i -e s#@linux_x86_64#@"${PLATFORM}"# $wheel_file;
+        sed -i -e s#linux_x86_64#"${PLATFORM}"# $wheel_file;
     fi
 
     # regenerate the RECORD file with new hashes
@@ -426,7 +426,7 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*linux*.w
 
     # Rename wheel for Manylinux 2_28
     if [[ $PLATFORM == "manylinux_2_28_x86_64" && $GPU_ARCH_TYPE != "cpu-s390x" && $GPU_ARCH_TYPE != "xpu" ]]; then
-        pkg_name=$(echo $(basename $pkg) | sed -e s#@linux_x86_64#@"${PLATFORM}"#)
+        pkg_name=$(echo $(basename $pkg) | sed -e s#linux_x86_64#"${PLATFORM}"#)
         zip -rq $pkg_name $PREIX*
         rm -f $pkg
         mv $pkg_name $(dirname $pkg)/$pkg_name

--- a/.ci/manywheel/build_common.sh
+++ b/.ci/manywheel/build_common.sh
@@ -382,7 +382,7 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*linux*.w
     # create Manylinux 2_28 tag this needs to happen before regenerate the RECORD
     if [[ $PLATFORM == "manylinux_2_28_x86_64" && $GPU_ARCH_TYPE != "cpu-s390x" && $GPU_ARCH_TYPE != "xpu" ]]; then
         wheel_file=$(echo $(basename $pkg) | sed -e 's/-cp.*$/.dist-info\/WHEEL/g')
-        sed -i -e s#@linux_x86_64#@"${$PLATFORM}"# $wheel_file;
+        sed -i -e s#@linux_x86_64#@"${PLATFORM}"# $wheel_file;
     fi
 
     # regenerate the RECORD file with new hashes
@@ -426,7 +426,7 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*linux*.w
 
     # Rename wheel for Manylinux 2_28
     if [[ $PLATFORM == "manylinux_2_28_x86_64" && $GPU_ARCH_TYPE != "cpu-s390x" && $GPU_ARCH_TYPE != "xpu" ]]; then
-        pkg_name=$(echo $(basename $pkg) | sed -e 's#@linux_x86_64#@"${$PLATFORM}"#')
+        pkg_name=$(echo $(basename $pkg) | sed -e s#@linux_x86_64#@"${PLATFORM}"#)
         zip -rq $pkg_name $PREIX*
         rm -f $pkg
         mv $pkg_name $(dirname $pkg)/$pkg_name

--- a/.ci/manywheel/build_common.sh
+++ b/.ci/manywheel/build_common.sh
@@ -426,7 +426,7 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*linux*.w
     # tag the wheel with approproiate tags
     if [[ $PLATFORM == "manylinux_2_28_x86_64" && $GPU_ARCH_TYPE != "cpu-s390x" ]]; then
         LD_LIBRARY_PATH="/usr/local/cuda/extras/CUPTI/lib64/:/usr/local/cuda/lib64/:/usr/lib64/:${LD_LIBRARY_PATH}"
-        auditwheel repair --plat ${PLATFORM} $(basename $pkg)
+        auditwheel repair --exclude libcuda.so.1 --plat ${PLATFORM} $(basename $pkg)
         # replace original wheel with audited
         mv //wheelhouse/*.whl /$WHEELHOUSE_DIR/
     else


### PR DESCRIPTION
Tag the Wheels with appropriate Manylinx 2.28 tags
Initially used auditwheel but it does much more that just adding tags. It also tries to package multiple libs into wheel, which we don't want at this point. Hence just changed tag and filename. If no librs are repackages by auditwheel all ti does is to tag and rename.

cc @seemethere @malfet @osalpekar