### PR TITLE
Allowing EmbeddingBag.cu to use BFLOAT16

### DIFF
--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -541,8 +541,8 @@ Tensor _embedding_bag_per_sample_weights_backward_cuda(
     return output;
   }
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-    grad.scalar_type(), "_embedding_bag_per_sample_weights_backward_cuda", [&]() {
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+    at::ScalarType::Half, at::ScalarType::BFloat16, grad.scalar_type(), "_embedding_bag_per_sample_weights_backward_cuda", [&]() {
       AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "_embedding_bag_per_sample_weights_backward_cuda", [&]() {
         _embedding_bag_per_sample_weights_backward_kernel<scalar_t, index_t>
           <<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(


### PR DESCRIPTION
Hi everyone,

Some GPUs like H100 now support atomic_add with bfloat16. Since EmbeddingBag's backward pass uses atomic_add, it used to be impossible to use EmbeddingBag with bfloat16. This change removes this limitation, and EmbeddingBag can now be used with bfloat16 on GPUs that support atomic_add for that type.
