### PR TITLE
Remove option for fork-based compile pool

### DIFF
--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 
 import functools
 import logging
-import multiprocessing
 import os
 import sys
-from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
-from functools import partial
 from time import time
 from typing import Any, Callable, Dict, List, Optional, Set, TYPE_CHECKING
 
@@ -27,12 +25,7 @@ from torch._inductor.codecache import (
     TritonCodeCache,
     TritonFuture,
 )
-from torch._inductor.compile_worker.subproc_pool import (
-    _warm_process_pool,
-    AnyPool,
-    SubprocPool,
-)
-from torch._inductor.compile_worker.watchdog import _async_compile_initializer
+from torch._inductor.compile_worker.subproc_pool import SubprocPool
 from torch._inductor.runtime.compile_tasks import (
     _set_triton_ptxas_path,
     _worker_compile_triton,
@@ -99,7 +92,7 @@ log = logging.getLogger(__name__)
 
 
 # Used to keep track of all process pools invoked so far.
-_pool_set: Set[AnyPool] = set()
+_pool_set: Set[SubprocPool] = set()
 
 
 def shutdown_compile_workers() -> None:
@@ -119,16 +112,6 @@ try:
     os.register_at_fork(after_in_child=after_fork)
 except AttributeError:
     pass  # register_at_fork does not exists on windows
-
-
-def get_worker_start_method() -> str:
-    """
-    Temporary for internal subprocess pool rollout. Assign config.worker_start_method
-    lazily and return it. TODO: remove after rollout.
-    """
-    if config.worker_start_method is None:
-        config.worker_start_method = config.decide_worker_start_method()
-    return config.worker_start_method
 
 
 def get_compile_threads() -> int:
@@ -158,32 +141,14 @@ class AsyncCompile:
 
     @staticmethod
     @functools.lru_cache(1)
-    def process_pool() -> AnyPool:
+    def process_pool() -> SubprocPool:
         assert get_compile_threads() > 1
-        pool: AnyPool
-        if get_worker_start_method() == "subprocess":
-            # Wrapper around ProcessPoolExecutor forks in a new process we control
-            log.info("Creating subprocess pool with %d workers", get_compile_threads())
-            pool = SubprocPool(get_compile_threads())
-        else:
-            pre_fork_setup()
-            ctx = multiprocessing.get_context(get_worker_start_method())
-            log.info(
-                "Creating forked subprocess pool with %d workers", get_compile_threads()
-            )
-            pool = ProcessPoolExecutor(
-                get_compile_threads(),
-                mp_context=ctx,
-                initializer=partial(_async_compile_initializer, os.getpid()),
-            )
-            # when this pool is created in a subprocess object, the normal exit handler
-            # doesn't run, and we need to register our own handler.
-            # exitpriority has to be high, because another one of the finalizers will
-            # kill the worker thread that sends the shutdown message to the workers...
-            multiprocessing.util.Finalize(None, pool.shutdown, exitpriority=sys.maxsize)
+        # Wrapper around ProcessPoolExecutor forks in a new process we control
+        log.info("Creating subprocess pool with %d workers", get_compile_threads())
+        pool = SubprocPool(get_compile_threads())
 
         # Set an attribute we can check to see if the pool is ready.
-        pool.ready_future = pool.submit(AsyncCompile._get_ready)  # type: ignore[union-attr]
+        pool.ready_future = pool.submit(AsyncCompile._get_ready)  # type: ignore[attr-defined]
         _pool_set.add(pool)
         return pool
 
@@ -192,7 +157,8 @@ class AsyncCompile:
         if get_compile_threads() <= 1:
             return
         _compile_start()
-        _warm_process_pool(cls.process_pool(), get_compile_threads())
+        # Pool is initialized on first access
+        cls.process_pool()
         _compile_end()
 
     @classmethod
@@ -204,7 +170,7 @@ class AsyncCompile:
     def _use_process_pool(self):
         return (
             get_compile_threads() > 1
-            and self.process_pool().ready_future.done()  # type: ignore[union-attr]
+            and self.process_pool().ready_future.done()  # type: ignore[attr-defined]
         )
 
     def triton(self, kernel_name: str, source_code: str, device_str: str = "cuda"):
@@ -343,8 +309,8 @@ if (
     or os.environ.get("TORCH_WARM_POOL", "1") != "1"
     # The subprocess pool is only used for the Triton backend
     or not has_triton_package()
-    # Skip for fbcode so we can query the worker_start_method lazily.
-    # TODO: remove once "subprocess" has rolled out internally.
+    # Skip for fbcode. We have internal reports of usages inside multiprocessing
+    # pools that lead a multiplicative number of compile subprocesses.
     or config.is_fbcode()
 ):
     pass

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -9,7 +9,6 @@ import subprocess
 import sys
 import threading
 import traceback
-import typing
 from concurrent.futures import Future, ProcessPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
 from typing import Any, BinaryIO, Callable, Dict, Tuple, TypeVar
@@ -283,14 +282,7 @@ class SubprocMain:
         return pickle.dumps(result, pickle.HIGHEST_PROTOCOL)
 
 
-AnyPool = typing.Union[ProcessPoolExecutor, SubprocPool]
-
-
-def _warm_process_pool(pool: AnyPool, n: int) -> None:
-    if isinstance(pool, SubprocPool):
-        return  # no need
-    assert isinstance(pool, ProcessPoolExecutor)
-
+def _warm_process_pool(pool: ProcessPoolExecutor, n: int) -> None:
     # We have to fork processes for compiler workers, but the more memory and other resources that are loaded, the
     # slower the os.fork time is, quite drastically. It also holds the GIL so we can't put it on another thread.
 
@@ -306,7 +298,6 @@ def _warm_process_pool(pool: AnyPool, n: int) -> None:
 
     # We force them to start here with some YOLOing of the internal methods.
 
-    # TODO(masnesral): Are these still relevant?
     if hasattr(pool, "_start_queue_management_thread"):
         pool._start_queue_management_thread()
     else:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -543,33 +543,8 @@ optimize_scatter_upon_const_tensor = (
     os.environ.get("TORCHINDUCTOR_OPTIMIZE_SCATTER_UPON_CONST_TENSOR", "1") == "1"
 )
 
-
-# The multiprocessing start method to use for inductor workers in the codecache.
-# Can be "subprocess" or "fork".
-def decide_worker_start_method() -> str:
-    # TODO: For internal rollout, we use a killswitch to disable the "subprocess"
-    # start method. The justknob check should not be performed at import, however,
-    # so for fbcode, we assign worker_start_method to None below and call this method
-    # lazily in async_compile.py. Remove this after "subprocess" rollout completes.
-    if "TORCHINDUCTOR_WORKER_START" in os.environ:
-        start_method = os.environ["TORCHINDUCTOR_WORKER_START"]
-    elif is_fbcode() and not torch._utils_internal.justknobs_check(
-        "pytorch/inductor:subprocess_parallel_compile"
-    ):
-        start_method = "fork"
-    else:
-        start_method = "subprocess"
-    assert start_method in (
-        "subprocess",
-        "fork",
-    ), f"Invalid start method: {start_method}"
-    return start_method
-
-
-# TODO: Set start method directly after internal rollout of "subprocess".
-worker_start_method: Optional[str] = (
-    None if is_fbcode() else decide_worker_start_method()
-)
+# Deprecated. This setting does nothing.
+worker_start_method: Optional[str] = None
 
 # Flags to turn on all_reduce fusion. These 2 flags should be automaticaly turned
 # on by DDP and should not be set by the users.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142001

Summary: This has been set to "subproc" for a while internally and externally, so we can remove and simplify some of the code. Note that there's no pressing need here -- just that since we've had internal outage with the legacy "fork" implementation, it doesn't seem helpful to leave it available. But if people aren't in the mood for this sort of cleanup, I won't be offended to abandon it.

Test Plan: CI

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov