### PR TITLE
[export] Change fx graph _replace_hook to a list of Callable

### DIFF
--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -528,7 +528,7 @@ class GraphModule(torch.nn.Module):
 
         # Dictionary to store metadata
         self.meta: Dict[str, Any] = {}
-        self._replace_hook = None
+        self._replace_hooks: List[Callable] = []
         self._create_node_hooks: List[Callable] = []
         self._erase_node_hooks: List[Callable] = []
 
@@ -885,7 +885,7 @@ class {module_name}(torch.nn.Module):
             "_state_dict_hooks",
             "_load_state_dict_pre_hooks",
             "_load_state_dict_post_hooks",
-            "_replace_hook",
+            "_replace_hooks",
             "_create_node_hooks",
             "_erase_node_hooks",
         ]
@@ -946,11 +946,29 @@ class {module_name}(torch.nn.Module):
         user node which consumes the old node to be replaced.
         """
         assert callable(f), "Replace hook must be a callable."
-        prev, self._replace_hook = self._replace_hook, f
+        self._register_replace_node_hook(f)
         try:
             yield
         finally:
-            self._replace_hook = prev
+            self._unregister_replace_node_hook(f)
+
+    def _register_replace_node_hook(self, f):
+        """
+        Takes a callable which will be called everytime when we replace a node
+        to a new node, or change the node's name. Callable takes three arguments:
+        the old node we're changing, and NAME of the new node, followed by the
+        user node which consumes the old node to be replaced.
+        """
+        assert callable(f), "create_node hook must be a callable."
+        self._replace_hooks.append(f)
+
+    def _unregister_replace_node_hook(self, f):
+        """
+        Takes a callable which was previously registered to be called everytime when we replace a node.
+        This function will unregister that callable so it is no longer invoked on node replacement.
+        """
+        assert callable(f), "create_node hook must be a callable."
+        self._replace_hooks.remove(f)
 
     def _register_create_node_hook(self, f):
         """

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -731,8 +731,9 @@ class Node(_NodeBase):
                 else:
                     return n
 
-            if getattr(m, "_replace_hook", None):
-                m._replace_hook(old=self, new=replace_with.name, user=use_node)
+            if getattr(m, "_replace_hooks", None):
+                for replace_hook in m._replace_hooks:
+                    replace_hook(old=self, new=replace_with.name, user=use_node)
 
             new_args = map_arg(use_node.args, maybe_replace_node)
             new_kwargs = map_arg(use_node.kwargs, maybe_replace_node)
@@ -836,8 +837,9 @@ class Node(_NodeBase):
             return new_input if n == old_input else n
 
         m = self.graph.owning_module
-        if getattr(m, "_replace_hook", None):
-            m._replace_hook(old=old_input, new=new_input.name, user=self)
+        if getattr(m, "_replace_hooks", None):
+            for replace_hook in m._replace_hooks:
+                replace_hook(old=old_input, new=new_input.name, user=self)
 
         new_args = map_arg(self.args, maybe_replace_node)
         new_kwargs = map_arg(self.kwargs, maybe_replace_node)
@@ -855,10 +857,11 @@ class Node(_NodeBase):
     def __setattr__(self, name: str, value: Any) -> None:
         if name == "name" and hasattr(self, "name"):
             m = self.graph.owning_module
-            if getattr(m, "_replace_hook", None):
+            if getattr(m, "_replace_hooks", None):
                 assert isinstance(value, str)
                 for user in self.users:
-                    m._replace_hook(old=self, new=value, user=user)
+                    for replace_hook in m._replace_hooks:
+                        replace_hook(old=self, new=value, user=user)
         update = False
         if (
             hasattr(self, name)


### PR DESCRIPTION
Summary: Change fx graph module's _replace_hook from a single hook, to a list of hooks. This is to prepare to registering more hooks for inductor provenance tracking, where we might need to register multiple hooks for node replacement.

Test Plan:
```
buck run mode/dev-nosan caffe2/test:fx -- -r test_hooks_for_node_update
buck run mode/dev-nosan caffe2/test:test_export -- -r test_replace_hook
```

Differential Revision: D66726724




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv