### PR TITLE
[doc] Fix the toctree level

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,7 +52,7 @@ Features described in this documentation are classified by release status:
 
 .. toctree::
    :glob:
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Python API
 
    torch


### PR DESCRIPTION
Changing this back 1 in order to not expand on the index.html page.
Before:
![Screenshot 2024-12-04 at 11 47 54 AM (2)](https://github.com/user-attachments/assets/40d730ee-61b9-4d60-ab13-9b9075cb3cba)
After: 
![Screenshot 2024-12-04 at 11 48 30 AM (2)](https://github.com/user-attachments/assets/5eb711a0-e76c-4573-9fdf-88b6b94b31a9)

cc @brycebortree @sekyondaMeta @AlannaBurke