### PR TITLE
[CUDA][64-bit indexing] Fix some existing problematic `int64_t _ = blockIdx.* * blockDim.*` code

### DIFF
--- a/aten/src/ATen/cuda/detail/KernelUtils.h
+++ b/aten/src/ATen/cuda/detail/KernelUtils.h
@@ -13,7 +13,7 @@ namespace at::cuda::detail {
 // greater than INT_MAX.  But in that case _i_n_d_e_x >= n, so there are no
 // further iterations and the overflowed value in i=_i_n_d_e_x is not used.
 #define CUDA_KERNEL_LOOP_TYPE(i, n, index_type)                         \
-  int64_t _i_n_d_e_x = blockIdx.x * blockDim.x + threadIdx.x;           \
+  int64_t _i_n_d_e_x = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;           \
   for (index_type i=_i_n_d_e_x; _i_n_d_e_x < (n); _i_n_d_e_x+=blockDim.x * gridDim.x, i=_i_n_d_e_x)
 
 #define CUDA_KERNEL_LOOP(i, n) CUDA_KERNEL_LOOP_TYPE(i, n, int)

--- a/aten/src/ATen/native/cuda/Bucketization.cu
+++ b/aten/src/ATen/native/cuda/Bucketization.cu
@@ -70,7 +70,7 @@ __global__ void searchsorted_cuda_kernel(
   bool right,
   bool is_1d_boundaries) {
 
-  for (int64_t tid = blockIdx.x * blockDim.x + threadIdx.x; tid < numel_in; tid += blockDim.x * gridDim.x) {
+  for (int64_t tid = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x; tid < numel_in; tid += blockDim.x * gridDim.x) {
     // If boundaries tensor is 1d, we always search the entire boundary tensor
     int64_t start_bd = is_1d_boundaries ? 0 : tid / idim_in * idim_bd;
     int64_t end_bd = start_bd + idim_bd;

--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -154,7 +154,7 @@ __global__ static void cdist_backward_kernel_cuda_impl(scalar_t * buffer, const 
 template <typename scalar_t, typename F>
 __global__ static void pdist_backward_kernel_cuda_impl(scalar_t * buffer, const scalar_t * grad, const scalar_t * self, const scalar_t * dist, int64_t gs, const int64_t n, const int64_t m, const int64_t combs, const scalar_t p,
                                                        const double n2, const double n2_squared_minus_1) {
-  const int64_t k = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t k = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   const int init = blockIdx.y * blockDim.y + threadIdx.y;
   const int stride = blockDim.y * gridDim.y;
 

--- a/aten/src/ATen/native/cuda/DistributionTemplates.h
+++ b/aten/src/ATen/native/cuda/DistributionTemplates.h
@@ -68,7 +68,7 @@ __global__ void distribution_elementwise_grid_stride_kernel(int64_t numel,
                                                             const dist_t dist_func,
                                                             const transform_t transform_func) {
   auto [seed, offset] = at::cuda::philox::unpack(philox_args);
-  int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t idx = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   curandStatePhilox4_32_10_t state;
   curand_init(seed, idx, offset, &state);
 

--- a/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
@@ -60,7 +60,7 @@ __global__ void fractional_max_pool3d_out_frame(
   int64_t poolSizeT, int64_t poolSizeH, int64_t poolSizeW) {
     using accscalar_t = at::acc_type<scalar_t, /*is_cuda=*/true>;
     // Output (t, h, w) point that this thread is responsible for
-    int64_t ourOutputPoint = threadIdx.x + blockIdx.x * blockDim.x;
+    int64_t ourOutputPoint = threadIdx.x + ((int64_t) blockIdx.x) * blockDim.x;
     int64_t plane = blockIdx.y;
     int64_t batch = blockIdx.z;
     // Each thread generates a specific output point
@@ -123,7 +123,7 @@ __global__ void fractional_max_pool3d_backward_out_frame(
   PackedTensorAccessor64<const scalar_t, 5> gradOutput,
   PackedTensorAccessor64<const int64_t, 5> indices) {
   // Output (h, w) point that this thread is responsible for
-  int64_t ourOutputPoint = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t ourOutputPoint = threadIdx.x + ((int64_t) blockIdx.x) * blockDim.x;
   int64_t plane = blockIdx.y;
   int64_t batch = blockIdx.z;
 

--- a/aten/src/ATen/native/cuda/LossCTC.cu
+++ b/aten/src/ATen/native/cuda/LossCTC.cu
@@ -462,7 +462,7 @@ ctc_loss_backward_collect_nonblank_gpu_kernel(scalar_t* __restrict__ gradient_da
                                                      const int64_t* __restrict__ tg_batch_offsets, int64_t tg_target_stride,
                                               int64_t batch_size, bool zero_infinity) {
   int64_t b = threadIdx.y + blockIdx.y * blockDim.y;
-  int64_t s = threadIdx.x + blockIdx.x * blockDim.x; // note, this directly indexes into targets, not targets prime!
+  int64_t s = threadIdx.x + ((int64_t) blockIdx.x) * blockDim.x; // note, this directly indexes into targets, not targets prime!
 
   if (b >= batch_size)
     return;
@@ -516,7 +516,7 @@ ctc_loss_backward_collect_gpu_kernel(scalar_t* __restrict__ gradient_data,
 
   constexpr scalar_t neginf = -INFINITY;
   int64_t b = threadIdx.y + blockIdx.y * blockDim.y;
-  int64_t t = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t t = threadIdx.x + ((int64_t) blockIdx.x) * blockDim.x;
 
   if ((t >= max_input_length) || (b >= batch_size))
     return;
@@ -583,7 +583,7 @@ ctc_loss_zero_padded_gradients(
     int64_t batch_size, /* B */
     int64_t num_labels  /* D */ ) {
       int64_t b = threadIdx.y + blockIdx.y * blockDim.y;
-      int64_t t = threadIdx.x + blockIdx.x * blockDim.x;
+      int64_t t = threadIdx.x + ((int64_t) blockIdx.x) * blockDim.x;
 
       if (b >= batch_size || t >= max_input_length) {
         return;

--- a/aten/src/ATen/native/cuda/MaxUnpooling.cu
+++ b/aten/src/ATen/native/cuda/MaxUnpooling.cu
@@ -58,7 +58,7 @@ __global__ void max_unpooling3d_forward_kernel(
     const int64_t oH,
     const int64_t oW,
     const int64_t offsetZ) {
-  int64_t iColumn = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t iColumn = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   int64_t iRow = blockIdx.y * blockDim.y + threadIdx.y;
   int64_t iFrame = (blockIdx.z + offsetZ) % input.size(1); // input frame/time
   int64_t slice = (blockIdx.z + offsetZ) / input.size(1); // input slice/feature

--- a/aten/src/ATen/native/cuda/ReflectionPad.cu
+++ b/aten/src/ATen/native/cuda/ReflectionPad.cu
@@ -170,7 +170,7 @@ __device__ inline void parallel_reflection_pad3d(
     int64_t y_shift,
     int64_t z_shift,
     const F& f) {
-  int64_t output_id = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t output_id = threadIdx.x + ((int64_t) blockIdx.x) * blockDim.x;
 
   if (output_id >= (output.size(2) * output.size(3) * output.size(4))) {
     return;

--- a/aten/src/ATen/native/cuda/Repeat.cu
+++ b/aten/src/ATen/native/cuda/Repeat.cu
@@ -18,7 +18,7 @@ __global__ static void compute_cuda_kernel(
     int64_t size,
     int64_t result_size) {
   CUDA_KERNEL_ASSERT(result_size == cumsum_ptr[size - 1]);
-  int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t idx = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   int64_t stride = (blockDim.x * gridDim.x) / C10_WARP_SIZE;
   int warp_id = idx / C10_WARP_SIZE;
   int tid_in_warp = idx % C10_WARP_SIZE;

--- a/aten/src/ATen/native/cuda/ReplicationPadding.cu
+++ b/aten/src/ATen/native/cuda/ReplicationPadding.cu
@@ -44,7 +44,7 @@ __global__ void replication_pad_forward_kernel1d(
     const int padL,
     const int y_shift,
     const int z_shift) {
-  const int64_t outputPointId = threadIdx.x + blockIdx.x * blockDim.x;
+  const int64_t outputPointId = threadIdx.x + ((int64_t) blockIdx.x) * blockDim.x;
   const int64_t plane = blockIdx.y + y_shift;
   const int64_t batch = blockIdx.z + z_shift;
   if (outputPointId >= output.size(2)) {
@@ -68,7 +68,7 @@ __global__ void replication_pad_backward_kernel(
     const int padL,
     const int y_shift,
     const int z_shift) {
-  const int64_t outputPointId = threadIdx.x + blockIdx.x * blockDim.x;
+  const int64_t outputPointId = threadIdx.x + ((int64_t) blockIdx.x) * blockDim.x;
   const int64_t plane = blockIdx.y + y_shift;
   const int64_t batch = blockIdx.z + z_shift;
   if (outputPointId >= gradOutput.size(2)) {

--- a/aten/src/ATen/native/cuda/SegmentReduce.cu
+++ b/aten/src/ATen/native/cuda/SegmentReduce.cu
@@ -101,7 +101,7 @@ __global__ void segment_reduce_forward_kernel(
     const int64_t output_stride_axis,
     const int64_t output_size_axis,
     const int64_t lengths_cumsum_stride_axis) {
-  int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t idx = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= (outer_offset * segment_count * inner_offset)) {
     return;
   }
@@ -172,7 +172,7 @@ __global__ void segment_reduce_backward_kernel(
     const int64_t output_stride_axis,
     const int64_t output_size_axis,
     const int64_t lengths_cumsum_stride_axis) {
-  int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t idx = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= (outer_offset * segment_count * inner_offset)) {
     return;
   }

--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -248,7 +248,7 @@ void tril_indices_kernel(scalar_t * tensor,
                          int64_t col,
                          int64_t trapezoid_size,
                          int64_t tril_size) {
-  int64_t linear_index = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t linear_index = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
 
   if (linear_index < tril_size) {
     int64_t r, c;
@@ -324,7 +324,7 @@ void triu_indices_kernel(scalar_t * tensor,
                          int64_t col,
                          int64_t rectangle_size,
                          int64_t triu_size) {
-  int64_t linear_index = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t linear_index = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
 
   if (linear_index < triu_size) {
     int64_t r, c;

--- a/aten/src/ATen/native/cuda/TensorTransformations.cu
+++ b/aten/src/ATen/native/cuda/TensorTransformations.cu
@@ -57,7 +57,7 @@ __global__ void flip_cuda_kernel(
     int64_t* strides_contiguous,
     int64_t* shape,
     int64_t total_dims) {
-  int64_t linear_index = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t linear_index = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   if (linear_index >= N) {
     return;
   }
@@ -90,7 +90,7 @@ __global__ void roll_cuda_kernel(
     int64_t size,
     int64_t stride,
     int64_t total_dims) {
-  int64_t linear_index = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t linear_index = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   if (linear_index >= N) {
     return;
   }

--- a/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
@@ -93,7 +93,7 @@ __global__ void upsample_nearest2d_nhwc_out_frame(
     float width_scale,
     const size_t out_numel) {
 
-  const int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t index = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
 
   if (index < out_numel) {
     const auto c = index % channels;
@@ -122,7 +122,7 @@ __global__ void upsample_nearest2d_backward_out_frame(
     scalar_t* grad_i,
     float height_scale,
     float width_scale) {
-  int64_t dst_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t dst_idx = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   if (dst_idx >= dim_c * dst_dim_h * dst_dim_w)
     return;
 

--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -83,7 +83,7 @@ __global__ void ComputeFusedParamsCUDAKernel(
     acc_type<T, true>* a,
     acc_type<T, true>* b) {
   using T_ACC = acc_type<T, true>;
-  const int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t index = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   if (index < N * C) {
     const int64_t ng = index / (C / group);
     const int64_t c = index % C;
@@ -155,7 +155,7 @@ __global__ void GammaBeta1dBackwardCUDAKernel1(
     T* dgamma,
     T* dbeta) {
   using T_ACC = acc_type<T, true>;
-  const int64_t c = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t c = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   if (c < C) {
     const int64_t G = group;
     const int64_t D = C / G;
@@ -195,7 +195,7 @@ __global__ void GammaBeta1dBackwardCUDAKernel2(
   using T_ACC = acc_type<T, true>;
   __shared__ T_ACC g_shared[kReduceTileSize][kReduceTileSize + 1];
   __shared__ T_ACC b_shared[kReduceTileSize][kReduceTileSize + 1];
-  const int64_t c = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t c = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   T_ACC dg_sum1 = 0;
   T_ACC dg_sum2 = 0;
   T_ACC db_sum1 = 0;
@@ -365,7 +365,7 @@ __global__ void GammaBetaBackwardCUDAKernel1(
     T* dgamma,
     T* dbeta) {
   using T_ACC = acc_type<T, true>;
-  const int64_t c = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t c = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   if (c < C) {
     const int64_t G = group;
     const int64_t D = C / G;
@@ -403,7 +403,7 @@ __global__ void GammaBetaBackwardCUDAKernel2(
   using T_ACC = acc_type<T, true>;
   __shared__ T_ACC g_shared[kReduceTileSize][kReduceTileSize + 1];
   __shared__ T_ACC b_shared[kReduceTileSize][kReduceTileSize + 1];
-  const int64_t c = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t c = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   T_ACC dg_sum1 = 0;
   T_ACC dg_sum2 = 0;
   T_ACC db_sum1 = 0;

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -519,7 +519,7 @@ __global__ void GammaBetaBackwardSimpleCUDAKernel(
     const T_ACC* rstd,
     T* dg,
     T* db) {
-  const int64_t j = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t j = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   if (j < N) {
     T_ACC sum1 = 0;
     T_ACC sum2 = 0;
@@ -562,7 +562,7 @@ __global__ void GammaBetaBackwardCUDAKernel_32x32(
   T_ACC dg_sum = 0;
   T_ACC db_sum = 0;
 
-  const int64_t j = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t j = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
 
   if (j < N) {
     constexpr int unroll_factor = 8;
@@ -659,7 +659,7 @@ __global__ void GammaBetaBackwardCUDAKernel(
   T_ACC* s_dg;
   T_ACC* s_db;
 
-  const int64_t j = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t j = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
 
   T_ACC dg_sum = 0;
   T_ACC db_sum = 0;

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -511,7 +511,7 @@ __global__ void _sparse_sum_backward_cuda_kernel(
     const TensorInfo<int64_t, int64_t> input_indices_pos_ti,
     const TensorInfo<scalar_t, int64_t> grad_values_expand_ti,
     TensorInfo<scalar_t, int64_t> grad_input_values_ti) {
-  const int64_t i = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t i = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   if (i >= total_threads) return;
   const int64_t j = input_indices_pos_ti.data[i];
 
@@ -679,7 +679,7 @@ __global__ void search_end_matrix_indices_cuda_kernel(
   const TensorInfo<int64_t, int64_t> indices_1D_ti,
   const int64_t num_elements
 ){
-  const int64_t target_mat_num = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t target_mat_num = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   if (target_mat_num >= num_matrices) return;
 
   const int64_t* indices_1D = indices_1D_ti.data;


### PR DESCRIPTION
`grep` didn't surface any `blockIdx.z * blockDim.z` cases
```
git grep -l "int64_t.*=.*blockIdx.x \* blockDim.x.*" | xargs sed -i 's/int64_t \(.*\) = blockIdx.x \* blockDim.x + threadIdx.x;.*/int64_t \1 = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;/g'
git grep -l "int64_t.*=.*blockIdx.x \* blockDim.x.*" | xargs sed -i 's/int64_t \(.*\) = threadIdx.x + blockIdx.x \* blockDim.x;.*/int64_t \1 = threadIdx.x + ((int64_t) blockIdx.x) * blockDim.x;/g'
git grep -l "int64_t.*=.*blockIdx.y \* blockDim.y.*" | xargs sed -i 's/int64_t \(.*\) = blockIdx.y \* blockDim.y + threadIdx.y;.*/int64_t \1 = ((int64_t) blockIdx.y) * blockDim.y + threadIdx.y;/g'
git grep -l "int64_t.*=.*blockIdx.y \* blockDim.y.*" | xargs sed -i 's/int64_t \(.*\) = threadIdx.y + blockIdx.y \* blockDim.y;.*/int64_t \1 = threadIdx.y + ((int64_t) blockIdx.y) * blockDim.y;/g'
git grep -l "int64_t.*=.*blockDim.x \* blockIdx.x.*" | xargs sed -i 's/int64_t \(.*\) = blockDim.x \* blockIdx.x + threadIdx.x;.*/int64_t \1 = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;/g'
```

See also https://github.com/pytorch/pytorch/pull/141922/files#r1868262823 in #141999 141922

cc @ptrblck @msaroufim