### PR TITLE
fix linalg.SVD docs typo: wrong V* shape in reduced SVD

### DIFF
--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1653,7 +1653,7 @@ When `m > n` (resp. `m < n`) we can drop the last `m - n` (resp. `n - m`) column
 .. math::
 
     A = U \operatorname{diag}(S) V^{\text{H}}
-    \mathrlap{\qquad U \in \mathbb{K}^{m \times k}, S \in \mathbb{R}^k, V \in \mathbb{K}^{k \times n}}
+    \mathrlap{\qquad U \in \mathbb{K}^{m \times k}, S \in \mathbb{R}^k, V \in \mathbb{K}^{n \times k}}
 
 where :math:`\operatorname{diag}(S) \in \mathbb{K}^{k \times k}`.
 In this case, :math:`U` and :math:`V` also have orthonormal columns.


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Singular_value_decomposition#Reduced_SVDs

in reduced SVD
V* shape is (n, k)
V shape is (n, k)

in docs it was wrong

Fixes #ISSUE_NUMBER
