### PR TITLE
When using a third-party device to  test DeviceMesh,the error check for 'test_raises_invalid_device_type' can only prints 'GPU'

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -252,7 +252,7 @@ class DeviceMeshTest(DTensorTestBase):
     def test_raises_invalid_device_type(self):
         with self.assertRaisesRegex(
             RuntimeError,
-            "Device type with GPU index is not supported",
+            "Device type with index is not supported",
         ):
             # test init_device_mesh with an invalid device type that contains a GPU index
             mesh_shape = (2, self.world_size // 2)

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -982,7 +982,7 @@ else:
         # assume valid device types are all letters
         if device_type and not device_type.isalpha():
             raise RuntimeError(
-                f"Device type with GPU index is not supported but got {device_type}. ",
+                f"Device type with index is not supported but got {device_type}. ",
                 "If you maintained a 'torch.device' object, it's recommended to pass in 'device.type'.",
             )
 


### PR DESCRIPTION
Fixes #ISSUE_NUMBER


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o