### PR TITLE
Update documentation for torch.mean() to note behavior with empty tensors

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6697,6 +6697,12 @@ add_docstr(
     r"""
 mean(input, *, dtype=None) -> Tensor
 
+.. note::
+    If the `input` tensor is empty, ``torch.mean()`` returns ``nan``.
+    This behavior is consistent with NumPy and follows the definition
+    that the mean over an empty set is undefined.
+
+
 Returns the mean value of all elements in the :attr:`input` tensor. Input must be floating point or complex.
 
 Args:


### PR DESCRIPTION
This PR updates the documentation for `torch.mean()` to explicitly mention that computing the mean over an empty tensor returns `nan`. This clarification helps users understand the behavior and handle it appropriately in their code.

Fixes #141057

