### PR TITLE
[MPS] Release MetalShaderLibrary cached resources

### DIFF
--- a/aten/src/ATen/native/mps/MetalShaderLibrary.h
+++ b/aten/src/ATen/native/mps/MetalShaderLibrary.h
@@ -102,7 +102,7 @@ class MetalShaderLibrary {
         nparams(nparams_),
         compile_options(compile_options_) {}
   MetalShaderLibrary(const MetalShaderLibrary&) = delete;
-  virtual ~MetalShaderLibrary() = default;
+  virtual ~MetalShaderLibrary();
   std::vector<std::string> getFunctionNames();
   std::shared_ptr<MetalKernelFunction> getKernelFunction(
       const std::string& name);

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -767,7 +767,7 @@ REGISTER_MPS_ALLOCATOR_CALLBACK("mps_graph_cache_callback", MPSGraphCacheCallbac
 
 // MetalShaderLibrary implementation
 MetalShaderLibrary::~MetalShaderLibrary() {
-  for(const auto& it: cplMap) {
+  for (const auto& it : cplMap) {
     auto [cpl, func] = it.second;
     [cpl release];
     [func release];

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -765,6 +765,15 @@ class MPSGraphCacheCallback : public IMpsAllocatorCallback {
 
 REGISTER_MPS_ALLOCATOR_CALLBACK("mps_graph_cache_callback", MPSGraphCacheCallback);
 
+// MetalShaderLibrary implementation
+MetalShaderLibrary::~MetalShaderLibrary() {
+  for(const auto& it: cplMap) {
+    auto [cpl, func] = it.second;
+    [cpl release];
+    [func release];
+  }
+}
+
 id<MTLLibrary> MetalShaderLibrary::getLibrary() {
   if (C10_UNLIKELY(!library)) {
     TORCH_INTERNAL_ASSERT(nparams == 0);

--- a/aten/src/ATen/test/mps_test_metal_library.cpp
+++ b/aten/src/ATen/test/mps_test_metal_library.cpp
@@ -5,7 +5,7 @@
 
 using namespace at::native::mps;
 TEST(MPSTestMetalLibrary, ShaderCreation) {
-   MetalShaderLibrary lib("// Empty library");
+   DynamicMetalShaderLibrary lib("// Empty library");
    ASSERT_EQ(lib.getFunctionNames().size(), 0);
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #141478
* __->__ #142053
* #142052

By releasing retained `id<MTLFunction>` and `id<MTLComputePipelineState>`
Please note, that `id<MTLLibrary>` associated with class are currently leaked, which is by design, all dynamic shader allocations shoudl use `DynamicMetalShaderLibrary`

Test plan: `leaks --atExit -- ./bin/mps_test_metal_library`

Before:
```
STACK OF 1 INSTANCE OF 'ROOT LEAK: <_MTLFunctionInternal>':
18  dyld                                  0x197a94274 start + 2840
17  mps_test_metal_library                0x1002cb420 main + 68
16  mps_test_metal_library                0x1002fa388 testing::UnitTest::Run() + 124
15  mps_test_metal_library                0x1002fa40c bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) + 80
14  mps_test_metal_library                0x1002fac50 testing::internal::UnitTestImpl::RunAllTests() + 1588
13  mps_test_metal_library                0x1002e9934 testing::TestSuite::Run() + 1032
12  mps_test_metal_library                0x1002e8688 testing::TestInfo::Run() + 960
11  mps_test_metal_library                0x1002e715c testing::Test::Run() + 812
10  mps_test_metal_library                0x1002e7200 void testing::internal::HandleExceptionsInMethodIfSupported<testing::TestSuite, void>(testing::TestSuite*, void (testing::TestSuite::*)(), char const*) + 80
9   mps_test_metal_library                0x1002c5518 MPSTestMetalLibrary_ArangeShader_Test::TestBody() + 420
8   libtorch_cpu.dylib                    0x10fdd3804 at::native::mps::MetalShaderLibrary::getKernelFunction(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 56
7   libtorch_cpu.dylib                    0x10fdd3394 at::native::mps::MetalShaderLibrary::getLibraryPipelineState(id<MTLLibrary>, std::__1::basic_string<char, id<MTLLibrary>::char_traits<char>, id<MTLLibrary>::allocator<char>> const&) + 268
6   com.apple.Metal                       0x1a2be43b4 -[_MTLLibrary newFunctionWithName:] + 28
5   com.apple.Metal                       0x1a2be4498 -[_MTLLibrary newFunctionWithNameInternal:] + 148
4   com.apple.Metal                       0x1a2be4580 MTLLibraryContainer::functionWithName(NSString*, id<MTLDevice>) + 68
3   com.apple.Metal                       0x1a2be4724 MTLLibraryDataWithArchive::newFunction(NSString*, id<MTLDevice>) + 368
2   libobjc.A.dylib                       0x197a49ddc _objc_rootAllocWithZone + 48
1   libsystem_malloc.dylib                0x197c3baf8 _calloc + 88
0   libsystem_malloc.dylib                0x197c4e9bc _malloc_zone_calloc_instrumented_or_legacy + 128
====
    2 (592 bytes) ROOT LEAK: <_MTLFunctionInternal 0x1325e5550> [448]
       1 (144 bytes) _functionQueue --> <dispatch_queue_t (serial) 0x13254c340> [144]  "function queue" (from Metal)
```
After:
```
Process:         mps_test_metal_library [30687]
Path:            /Users/USER/*/mps_test_metal_library
Load Address:    0x100f74000
Identifier:      mps_test_metal_library
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [30686]

Date/Time:       2024-12-04 07:57:01.020 -0800
Launch Time:     2024-12-04 07:56:59.030 -0800
OS Version:      macOS 15.1.1 (24B2091)
Report Version:  7
Analysis Tool:   /usr/bin/leaks

Physical footprint:         177.2M
Physical footprint (peak):  236.5M
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 30687: 40691 nodes malloced for 5575 KB
Process 30687: 0 leaks for 0 total leaked bytes.
```