### PR TITLE
Enhance "from_node" node meta to track source recursively

### DIFF
--- a/test/fx/test_fx_traceback.py
+++ b/test/fx/test_fx_traceback.py
@@ -1,0 +1,172 @@
+# Owner(s): ["module: fx"]
+import json
+
+import torch
+from torch._inductor.compile_fx import aot_export_module
+from torch.fx.traceback import get_graph_provenance_json, NodeSource, NodeSourceAction
+from torch.testing._internal.common_utils import TestCase
+
+
+class TestFXNodeSource(TestCase):
+    def test_node_source(self):
+        node_source = NodeSource(
+            node=None, pass_name="test_pass", action=NodeSourceAction.CREATE
+        )
+        self.assertExpectedInline(
+            node_source.print_readable().strip(),
+            """(name=, pass_name=test_pass, action=create, graph_id=-1)""",
+        )
+        dummy_source_dict = {
+            "name": "",
+            "target": "",
+            "pass_name": "test_pass",
+            "action": NodeSourceAction.CREATE,
+            "graph_id": -1,
+            "from_node": [],
+        }
+        self.assertEqual(
+            node_source.to_dict(),
+            dummy_source_dict,
+        )
+
+        # Dummy node
+        node = torch.fx.Node(
+            graph=torch.fx.Graph(),
+            name="add",
+            op="call_function",
+            target=torch.ops.aten.add.Tensor,  # type: ignore[attr-defined]
+            args=(torch.tensor(3), torch.tensor(4)),
+            kwargs={},
+        )
+        node.meta["from_node"] = [node_source]
+
+        graph_id = id(node.graph)
+        node_source = NodeSource(
+            node=node, pass_name="test_pass", action=NodeSourceAction.CREATE
+        )
+        self.assertExpectedInline(
+            node_source.print_readable().strip(),
+            f"""\
+(name=add, pass_name=test_pass, action=create, graph_id={graph_id})
+    (name=, pass_name=test_pass, action=create, graph_id=-1)""",
+        )
+        self.assertEqual(
+            node_source.to_dict(),
+            {
+                "name": "add",
+                "target": "aten.add.Tensor",
+                "pass_name": "test_pass",
+                "action": NodeSourceAction.CREATE,
+                "graph_id": graph_id,
+                "from_node": [dummy_source_dict],
+            },
+        )
+
+    def test_graph_provenance(self):
+        def check_node_source(node_source_dict, name, pass_name, action):
+            self.assertEqual(node_source_dict["name"], name)
+            self.assertEqual(node_source_dict["pass_name"], pass_name)
+            self.assertEqual(node_source_dict["action"], action)
+
+        def get_first_node_source_and_check(node_source_dict):
+            """
+            Get the first node source from the from_node list.
+            """
+            self.assertEqual(len(node_source_dict["from_node"]), 1)
+            return node_source_dict["from_node"][0]
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fc1 = torch.nn.Linear(10, 16)
+                self.relu = torch.nn.ReLU()
+                self.fc2 = torch.nn.Linear(16, 1)
+                self.sigmoid = torch.nn.Sigmoid()
+
+            def forward(self, x):
+                x = self.fc1(x)
+                x = self.relu(x)
+                x = self.fc2(x)
+                x = self.sigmoid(x)
+                return (x,)
+
+        model = Model()
+        example_inputs = (torch.randn(8, 10),)
+        ep = torch.export.export(
+            model,
+            example_inputs,
+        )
+        gm = ep.module()
+        provenance = get_graph_provenance_json(gm.graph)
+        provenance = json.loads(provenance)
+        self.assertEqual(
+            set(provenance.keys()), {"relu", "linear", "sigmoid", "linear_1"}
+        )
+
+        # Check node "linear" is created from node "x" in PropagateUnbackedSymInts
+        key_provenance = provenance["linear"]
+        self.assertEqual(len(key_provenance), 1)
+        key_provenance = key_provenance[0]
+        check_node_source(
+            key_provenance,
+            "x",
+            "Interpreter_PropagateUnbackedSymInts",
+            NodeSourceAction.CREATE,
+        )
+
+        # Check node "x" is then created from another node "x" in FlattenInputOutputSignature
+        key_provenance = get_first_node_source_and_check(key_provenance)
+        check_node_source(
+            key_provenance,
+            "x",
+            "Interpreter_FlattenInputOutputSignature",
+            NodeSourceAction.CREATE,
+        )
+
+        gm, graph_signature = aot_export_module(
+            gm,
+            example_inputs,
+            trace_joint=False,
+        )
+
+        provenance = get_graph_provenance_json(gm.graph)
+        provenance = json.loads(provenance)
+
+        self.assertEqual(
+            set(provenance.keys()), {"t", "addmm", "relu", "t_1", "addmm_1", "sigmoid"}
+        )
+        for key in ["t", "addmm"]:
+            # The node provenance hierarchy should be:
+            # t -> linear -> x -> x
+            #
+            # x -> y means x is created from y
+
+            key_provenance = provenance[key]
+            self.assertEqual(len(key_provenance), 1)
+            key_provenance = key_provenance[0]
+
+            # Check node "t" and "addmm" is created from node "linear" in PropagateUnbackedSymInts
+            check_node_source(
+                key_provenance,
+                "linear",
+                "Interpreter_PropagateUnbackedSymInts",
+                NodeSourceAction.CREATE,
+            )
+
+            # Check node "linear" is then created from node "x" in PropagateUnbackedSymInts
+            key_provenance = get_first_node_source_and_check(key_provenance)
+            check_node_source(
+                key_provenance,
+                "x",
+                "Interpreter_PropagateUnbackedSymInts",
+                NodeSourceAction.CREATE,
+            )
+
+            # Check node "x" is then created from another node "x" in FlattenInputOutputSignature
+            key_provenance = get_first_node_source_and_check(key_provenance)
+            check_node_source(
+                key_provenance,
+                "x",
+                "Interpreter_FlattenInputOutputSignature",
+                NodeSourceAction.CREATE,
+            )

--- a/test/quantization/pt2e/test_metadata_porting.py
+++ b/test/quantization/pt2e/test_metadata_porting.py
@@ -74,8 +74,8 @@ class TestMetaDataPorting(QuantizationTestCase):
                         f"from_node metadata is of type {type(from_node_meta)}, but expected list"
                     )
                 for meta in from_node_meta:
-                    node_target = meta[1]
-                    if node_target == from_node:
+                    node_target = meta.target
+                    if node_target == str(from_node):
                         node_tag = n.meta.get("quantization_tag", None)
                         if node_tag is None or tag != node_tag:
                             not_found_nodes += str(n.target) + ", "

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -587,7 +587,7 @@ def get_kernel_metadata(node_schedule, wrapper):
             key = str(node.meta["original_aten"]._overloadpacket)
             original_aten_dict[key].append(node.name)
         if "from_node" in node.meta:
-            key = node.meta["from_node"][0][0]
+            key = node.meta["from_node"][0].name
             from_node_dict[key].append(node.name)
     sort_str = "Topologically Sorted" if single_graph is not None else "Unsorted"
     metadata = (

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -719,7 +719,7 @@ def _get_updated_module_call_graph(
     provenance: Dict[str, str] = {}
     for node in gm.graph.nodes:
         if history := node.meta.get("from_node", []):
-            provenance[history[-1][0]] = node.name
+            provenance[history[-1].name] = node.name
 
     # map old names to new names in module call signatures
     for entry in new_module_call_graph:

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -204,7 +204,9 @@ class Interpreter:
 
     @contextmanager
     def _set_current_node(self, node):
-        with fx_traceback.set_current_meta(node):
+        with fx_traceback.set_current_meta(
+            node, f"Interpreter_{self.__class__.__name__}"
+        ):
             yield
 
     @compatibility(is_backward_compatible=True)


### PR DESCRIPTION
Summary:
Change the "from_node" node meta format to be able to track the provenance of nodes recursively.

The new "from_node" format is a a list node NodeSource:

```
class NodeSource:
	self.node_name: str
	self.target: str
	self.graph_id: int
	self.pass_name: str
	self.action: str
	self.from_node: List[NoedSource]
```

This is in preparation for the inductor provenance tracking. For background, the inductor provenance tracking doc: https://docs.google.com/document/d/1dGh9myqNhywmbfP0Quzx_f04bghDFlj8cawj8MopiO8/edit?fbclid=IwZXh0bgNhZW0CMTEAAR0jUQ0Tf4ROLDED8Y_eIzrU0KVZVdRmyIQLp-avt-kGRPI_VgYVNyjH_q0_aem_HCQ_pxHDiwOkO9mQyWB2-g&tab=t.0 (internal only),

Test Plan:
```
buck2 run 'fbcode//mode/dev-nosan' fbcode//caffe2/test:test_export -- -r test_unflatten_multiple_graphs_state
buck run mode/dev-nosan caffe2/test:fx -- -r node_source
```

Differential Revision: D66737916




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov