### PR TITLE
[logging] Add triton_compile_time_us column to dynamo_compile

### DIFF
--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -181,6 +181,7 @@ class TestDynamoTimed(TestCase):
 {'_recursive_joint_graph_passes': 0.0,
  '_recursive_post_grad_passes': 0.0,
  '_recursive_pre_grad_passes': 0.0,
+ 'async_compile.wait': 0.0,
  'backend_compile': 0.0,
  'code_gen': 0.0,
  'entire_backward_compile': 0.0,
@@ -276,7 +277,7 @@ class TestDynamoTimed(TestCase):
  'start_time_us': 100,
  'structured_logging_overhead_s': 0.0,
  'structured_logging_overhead_us': 0,
- 'triton_compile_time_us': None,
+ 'triton_compile_time_us': 0,
  'triton_version': None}""",  # noqa: B950
         )
 
@@ -350,7 +351,7 @@ class TestDynamoTimed(TestCase):
  'start_time_us': 100,
  'structured_logging_overhead_s': 0.0,
  'structured_logging_overhead_us': 0,
- 'triton_compile_time_us': None,
+ 'triton_compile_time_us': 0,
  'triton_version': None}""",  # noqa: B950
         )
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -856,7 +856,7 @@ class CompilationMetrics:
     aot_autograd_cumulative_compile_time_us: Optional[int] = None
     inductor_cumulative_compile_time_us: Optional[int] = None
     inductor_code_gen_cumulative_compile_time_us: Optional[int] = None
-    triton_compile_time_us: Optional[int] = None  # TODO: instrument
+    triton_compile_time_us: Optional[int] = None
     runtime_cudagraphify_time_us: Optional[int] = None  # TODO: instrument
     runtime_triton_autotune_time_us: Optional[int] = None  # TODO: instrument
     dynamo_compile_time_before_restart_us: Optional[int] = None

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -315,7 +315,7 @@ class AsyncCompile:
             "async_compile.wait",
             log_pt2_compile_event=True,
             dynamo_compile_column_us="triton_compile_time_us",
-            log_waitcounter=True
+            log_waitcounter=True,
         ):
             num_kernels = len(
                 [

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -241,6 +241,7 @@ class AsyncCompile:
             with dynamo_timed(
                 "async_compile.precompile",
                 log_pt2_compile_event=True,
+                dynamo_compile_column_us="triton_compile_time_us",
                 log_waitcounter=True,
             ):
                 kernel.precompile()
@@ -311,7 +312,10 @@ class AsyncCompile:
 
     def wait(self, scope: Dict[str, Any]) -> None:
         with dynamo_timed(
-            "async_compile.wait", log_pt2_compile_event=True, log_waitcounter=True
+            "async_compile.wait",
+            log_pt2_compile_event=True,
+            dynamo_compile_column_us="triton_compile_time_us",
+            log_waitcounter=True
         ):
             num_kernels = len(
                 [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142068

Test Plan: See internal diff [D66799565](https://www.internalfb.com/diff/D66799565)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov

Differential Revision: [D66799565](https://our.internmc.facebook.com/intern/diff/D66799565)