### PR TITLE
AsyncCollectiveTensor: fix _are_we_tracing() in dynamo

### DIFF
--- a/test/distributed/_tensor/test_dtensor_compile.py
+++ b/test/distributed/_tensor/test_dtensor_compile.py
@@ -573,6 +573,27 @@ class TestDTensorCompile(torch._dynamo.test_case.TestCase):
         res = opt_kwargs_fn(x)
         self.assertEqual(res, ref)
 
+    def test_dynamo_dtensor_from_local_redistribute_async(self):
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+        from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
+        # pass in tensor as inputs/outputs, create DTensor and run redistribute
+        # (allgather collective) inside the fn
+        def fn(x):
+            dt = DTensor.from_local(x, mesh, [Shard(0)], run_check=False)
+            out = dt.redistribute(mesh, [Replicate()], async_op=True).to_local()
+            if isinstance(out, AsyncCollectiveTensor):
+                return out.wait()
+            else:
+                return out
+
+        x = torch.ones(1)
+        ref = fn(x)
+        cnt = torch._dynamo.testing.CompileCounterWithBackend("aot_eager")
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+        res = opt_fn(x)
+        self.assertEqual(res, ref)
+
     def test_dtensor_dont_recompile_on_same_placement_devicemesh(self):
         cnt = torch._dynamo.testing.CompileCounterWithBackend("inductor")
 

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -807,13 +807,8 @@ class _FromTorchTensor(torch.autograd.Function):
 def _are_we_tracing() -> bool:
     if is_torchdynamo_compiling():
         return True
-    # If functionalization is turned on, we are almost definitely compiling/tracing.
-    # (In particular, AOTAutograd traces a model once with functionalization on
-    #  but proxy tracing turned of, so this is how we detect it).
-    if (
-        torch._C._get_dispatch_mode(torch._C._TorchDispatchModeKey.FUNCTIONAL)
-        is not None
-    ):
+    # If fake mode is turned on, we are almost definitely compiling/tracing.
+    if torch._C._get_dispatch_mode(torch._C._TorchDispatchModeKey.FAKE) is not None:
         return True
     return get_proxy_mode() is not None
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/142076. Under compile, functional collectives are supposed to **not** return `AsyncCollectiveTensor`, and instead immediately issue calls to `wait_tensor()` (that we rely on the compiler to reorder as necessary.

This is done with a function `_are_we_tracing()`, that tries to detect if we are running from inside of the compiler. One of the checks it performs is `is_torchdynamo_compiling()` ([here](https://github.com/pytorch/pytorch/blob/main/torch/distributed/_functional_collectives.py#L808C8-L808C34)).

Unfortunately, this will always return False, even if dynamo is indeed tracing. The problem is that this function only returns true if dynamo **intercepts** the bytecode for `is_torchdynamo_compiling()`. However, this function is called during fake-tensor propagation, which is run as part of dynamo, but is not actually intercepted by dynamo itself.

One thing that we know is the case during dynamo tracing, however, is that a `FakeTensorMode` is active. So I tweaked the logic to assume that we are tracing if there is an active fake mode.

This could potentially have consequences for anybody running functional collectives with a fake mode directly, without compile in the loop. Although hopefully it's not too unreasonable to issue wait() calls immediately if you are running with fake tensor (presumably you only care about fake tensor propagation, in which case the wait() calls should technically be a no-op).

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142075
* #141728
* #141725



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o