### PR TITLE
[Profiler] Enable Iterative Step without profiler in fbcode

### DIFF
--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -12,6 +12,7 @@ import os
 
 from torch._C._autograd import _supported_activities, DeviceType, kineto_available
 from torch._C._profiler import _ExperimentalConfig, ProfilerActivity, RecordScope
+from torch._environment import is_fbcode
 from torch.autograd.profiler import KinetoStepTracker, record_function
 from torch.optim.optimizer import register_optimizer_step_post_hook
 
@@ -46,5 +47,7 @@ def _optimizer_post_hook(optimizer, args, kwargs):
     KinetoStepTracker.increment_step("Optimizer")
 
 
-if os.environ.get("KINETO_USE_DAEMON", None):
+if os.environ.get("KINETO_USE_DAEMON", "") or (
+    is_fbcode() and os.environ.get("KINETO_FORCE_OPTIMIZER_HOOK", "")
+):
     _ = register_optimizer_step_post_hook(_optimizer_post_hook)


### PR DESCRIPTION
Summary: Adds post optimizer hook for fbcode so that we can run iterative on demand without having to use a frontend profiler interface. Since this is being used more frequently, it would be convenient for users to be able to trigger this on-demand feature without having to worry about being within some timing window.

Test Plan: Ran iterative tracing without profiler.profile

Differential Revision: D66734119


