### PR TITLE
Silent TD warnings when there is no td_results.json

### DIFF
--- a/.github/actions/download-td-artifacts/action.yml
+++ b/.github/actions/download-td-artifacts/action.yml
@@ -26,4 +26,4 @@ runs:
       shell: bash
       run: |
         mkdir -p .additional_ci_files
-        mv td_results.json .additional_ci_files/td_results.json
+        mv td_results.json .additional_ci_files/td_results.json || true


### PR DESCRIPTION
Despite the fact that we have `continue-on-error: true` there, GH behaves noisily when `td_results.json` doesn't exist. 
 For example, all benchmark jobs in https://github.com/pytorch/pytorch/actions/runs/12149624686 finished successfully but they all showed up as errors on GH UI.  To make this worst, log classifier sometimes pick up the error https://github.com/pytorch/pytorch/actions/runs/12149624686/job/33882285001#step:16:37