### PR TITLE
Introduce int32 index_fill and index_copy indices

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -289,7 +289,8 @@ TORCH_PRECOMPUTE_META_FUNC(index_copy)
                    source.dim(), "), destination dimensionality (", self.dim(), ")");
   }
 
-  TORCH_CHECK(index.scalar_type() == ScalarType::Long, "index_copy_(): Expected a long tensor for index, but got ", index.scalar_type());
+  TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
+          "index_copy_(): Expected a dtype int64 or int32 for index, but got ", index.scalar_type());
   TORCH_CHECK(self.scalar_type() == source.scalar_type(), "index_copy_(): self and source expected to have the same dtype, but got (self) ", self.scalar_type(), " and (source) ", source.scalar_type());
   TORCH_CHECK(self.device() == source.device() && self.device() == index.device(),
       "index_copy_(): self, index and source expected to be in the same device, but got (self) ",
@@ -1480,9 +1481,8 @@ Tensor index_select_backward_symint(const Tensor& grad, c10::SymIntArrayRef self
 Tensor & index_fill_(Tensor & self, int64_t dim, const Tensor & index, const Scalar& source) {
   at::NoNamesGuard guard;
 
-  TORCH_CHECK_INDEX(
-    index.scalar_type() == ScalarType::Long,
-    "index_fill_(): Expected dtype int64 for index.");
+  TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
+          "index_fill_(): Expected a dtype int64 or int32 for index, but got ", index.scalar_type());
 
   at::assert_no_overlap(self, index);
   if (at::has_internal_overlap(self) == at::MemOverlap::Yes) {

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2443,7 +2443,7 @@ match :attr:`self`, or an error will be raised.
 
 Args:
     dim (int): dimension along which to index
-    index (LongTensor): indices of :attr:`tensor` to select from
+    index (IntTensor or LongTensor): indices of :attr:`tensor` to select from
     tensor (Tensor): the tensor containing values to copy
 
 Example::
@@ -2470,7 +2470,7 @@ selecting the indices in the order given in :attr:`index`.
 
 Args:
     dim (int): dimension along which to index
-    index (LongTensor): indices of :attr:`self` tensor to fill in
+    index (IntTensor or LongTensor): indices of :attr:`self` tensor to fill in
     value (float): the value to fill with
 
 Example::


### PR DESCRIPTION
This PR extends index_fill and index_copy operations to support int32 indices in addition to the existing int64 support:

1. Memory Efficiency and potential performance for handling a large number of indices, particularly when needing to transfer to accelerator backends. In some cases, the compiler may not support 64-bit integers, and in some cases, may cause conflicting casts when used with TorchXLA. I do not see the immediate need to propagate these to the dim input, since it is tied to the APIs and is relatively negligible.
2. Framework interoperability: As mentioned above, this gives more flexibility when working with TorchXLA, since some operations require the same type of physical raw representations for the tensors as the XLA tensors. In some cases, for Neuron, XLA generates S32 types which are not compatible with some operations (e.g. casts) when needing to convert across tensors.
3. Consistency with other APIs, such as index_add and index_select.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10