### PR TITLE
Enable Wtype-limits

### DIFF
--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -375,7 +375,6 @@ function(torch_compile_options libname)
       -Wdeprecated
       -Wno-unused-parameter
       -Wno-missing-field-initializers
-      -Wno-type-limits
       -Wno-array-bounds
       -Wno-unknown-pragmas
       -Wno-strict-overflow


### PR DESCRIPTION
Since it can detect underflow bugs of unsigned integers.