### PR TITLE
[Inductor][CPP] Fix Mask Dtype mismatch

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2462,6 +2462,20 @@ class CPUReproTests(TestCase):
                     self.assertEqual(res_vec, res_scalar)
 
     @requires_vectorization
+    def test_bitwise_and_bool(self):
+        def fn(a, b):
+            c = (a > 1) & (b > 1)
+            return c
+
+        a = torch.ones((64), dtype=torch.int64)
+        b = torch.ones((64), dtype=torch.uint8)
+
+        with config.patch({"cpp.simdlen": None}):
+            torch._dynamo.reset()
+            metrics.reset()
+            self.common(fn, (a, b))
+
+    @requires_vectorization
     @patch("torch.cuda.is_available", lambda: False)
     def test_vec_compare_op_cpu_only(self):
         def fn(x):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1269,6 +1269,7 @@ class CppVecOverrides(CppOverrides):
 
     @staticmethod
     def bitwise_and(a, b):
+        a, b = unify_mask_base_type(V.kernel.compute, (a, b))
         return f"{a} & {b}"
 
     @staticmethod

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -69,6 +69,7 @@ from .cpp_utils import (
     DTYPE_TO_CPP,
     INDEX_TYPE,
     LocalBufferContext,
+    may_unify_binary_op_mask_type,
     promote_args,
     template_fusion_with_epilogues_supported,
     unify_mask_base_type,
@@ -1253,6 +1254,7 @@ class CppVecOverrides(CppOverrides):
 
     @staticmethod
     def logical_and(a, b):
+        a, b = may_unify_binary_op_mask_type(a, b)
         return f"{a} & {b}"
 
     @staticmethod
@@ -1261,17 +1263,17 @@ class CppVecOverrides(CppOverrides):
 
     @staticmethod
     def logical_or(a, b):
+        a, b = may_unify_binary_op_mask_type(a, b)
         return f"{a} | {b}"
 
     @staticmethod
     def logical_xor(a, b):
+        a, b = may_unify_binary_op_mask_type(a, b)
         return f"{a} ^ {b}"
 
     @staticmethod
     def bitwise_and(a, b):
-        if a.dtype == torch.bool:
-            assert b.dtype == torch.bool
-            a, b = unify_mask_base_type(V.kernel.compute, (a, b))
+        a, b = may_unify_binary_op_mask_type(a, b)
         return f"{a} & {b}"
 
     @staticmethod
@@ -1280,10 +1282,12 @@ class CppVecOverrides(CppOverrides):
 
     @staticmethod
     def bitwise_or(a, b):
+        a, b = may_unify_binary_op_mask_type(a, b)
         return f"{a} | {b}"
 
     @staticmethod
     def bitwise_xor(a, b):
+        a, b = may_unify_binary_op_mask_type(a, b)
         return f"{a} ^ {b}"
 
     @staticmethod

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1269,7 +1269,9 @@ class CppVecOverrides(CppOverrides):
 
     @staticmethod
     def bitwise_and(a, b):
-        a, b = unify_mask_base_type(V.kernel.compute, (a, b))
+        if a.dtype == torch.bool:
+            assert b.dtype == torch.bool
+            a, b = unify_mask_base_type(V.kernel.compute, (a, b))
         return f"{a} & {b}"
 
     @staticmethod

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -494,6 +494,17 @@ def unify_mask_base_type(
     return new_vars
 
 
+def may_unify_binary_op_mask_type(a, b):
+    """
+    Given two cse variables, when dtype is bool, unify them to the same mask dtype and return casted cse variable.
+    """
+    if a.dtype == torch.bool:
+        assert b.dtype == torch.bool
+        mask_dtype = torch.int32
+        return unify_mask_base_type(V.kernel.compute, (a, b), mask_dtype)
+    return a, b
+
+
 def codegen_rand(offset, code, rand_function, dst_dtype=torch.float32):
     assert is_integer_dtype(offset.dtype)
     code.writeline("[&]()")

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -484,14 +484,16 @@ def unify_mask_base_type(
     Given list of cse variables,
     Cast each to new mask base dtype and return casted cse variable.
     """
-    new_vars = (
-        V.kernel.cse.generate(
-            buffer,
-            f"{V.kernel._get_mask_cast(var, dtype)}",
+    if all(var.dtype == torch.bool for var in vars):
+        new_vars = (
+            V.kernel.cse.generate(
+                buffer,
+                f"{V.kernel._get_mask_cast(var, dtype)}",
+            )
+            for var in vars
         )
-        for var in vars
-    )
-    return new_vars
+        return new_vars
+    return vars
 
 
 def codegen_rand(offset, code, rand_function, dst_dtype=torch.float32):

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -484,16 +484,14 @@ def unify_mask_base_type(
     Given list of cse variables,
     Cast each to new mask base dtype and return casted cse variable.
     """
-    if all(var.dtype == torch.bool for var in vars):
-        new_vars = (
-            V.kernel.cse.generate(
-                buffer,
-                f"{V.kernel._get_mask_cast(var, dtype)}",
-            )
-            for var in vars
+    new_vars = (
+        V.kernel.cse.generate(
+            buffer,
+            f"{V.kernel._get_mask_cast(var, dtype)}",
         )
-        return new_vars
-    return vars
+        for var in vars
+    )
+    return new_vars
 
 
 def codegen_rand(offset, code, rand_function, dst_dtype=torch.float32):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142103

**Summary**
Fix issue: https://github.com/pytorch/pytorch/issues/141559. The `vec_mask` store data type doesn't aligned when doing `bitwise_and`.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov