### PR TITLE
[DO NOT MERGE][WIP] CI: Dispatch PR events to the out-of-tree test infra

### DIFF
--- a/.github/workflows/out-of-tree-test-infra.yml
+++ b/.github/workflows/out-of-tree-test-infra.yml
@@ -1,0 +1,52 @@
+name: Dispatch PR Events to Out-of-tree TestInfra
+
+on:
+  pull_request:
+
+jobs:
+  dispatch-event:
+    if: ${{ github.repository_owner == 'pytorch' }}
+    name: Dispatch events to the out-of-tree test infra repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create a repository dispatch event
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PYTORCH_BOT_TOKEN }} # TODO: Who will do this work?
+          repository: pytorch-fdn/oota
+          event-type: pytorch-pr-event
+          client-payload: |-
+            {
+              "owner": "${{ github.repository_owner }}",
+              "repo": "${{ github.repository }}",
+              "event_name": "${{ github.event_name }}",
+              "event": {
+                "action": "${{ github.event.action }}"
+              },
+              "pull_request": {
+                "title": "${{ github.event.pull_request.title }}",
+                "base": {
+                  "ref": "${{ github.event.pull_request.base.ref }}",
+                  "repo": {
+                    "name": "${{ github.event.pull_request.base.repo.name }}",
+                    "full_name": "${{ github.event.pull_request.base.repo.full_name }}",
+                    "owner": {
+                      "login": "${{ github.event.pull_request.base.repo.owner.login }}"
+                    }
+                  }
+                },
+                "head": {
+                  "ref": "${{ github.event.pull_request.head.ref }}",
+                  "repo": {
+                    "name": "${{ github.event.pull_request.head.repo.name }}",
+                    "full_name": "${{ github.event.pull_request.head.repo.full_name }}",
+                    "owner": {
+                      "login": "${{ github.event.pull_request.head.repo.owner.login }}"
+                    }
+                  }
+                }
+              }
+            }


### PR DESCRIPTION
**The Goal**:

Without blocking PyTorch CI/CD, let the out-of-tree accelerator perceive the PR events in PyTorch, so that the out-of-tree backend has the opportunity to find possible problems as early as possible and leave relevant comments on the PR that raised the problem, making the PR more reasonable;

I would like to add that the comments left for the PR are only a reminder, not a mandatory one.

**Refer to the diagram below for the more informations:**

<img width="1105" alt="image" src="https://github.com/user-attachments/assets/6ccb025c-e907-4d93-bedd-8c1ceb5a0ab2">

cc: @ezyang @albanD @bsochack @FFFrog @zeshengzong 
