### PR TITLE
avoid re-applying views for every output when there is no pending mutations. 

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -150,6 +150,9 @@ FunctionalTensorWrapper::FunctionalTensorWrapper(const Tensor& view_value, const
   view_metas_.push_back(meta);
   maybe_mark_symbolic(meta);
   storage_ = base->storage_; // alias this tensor's storage with the base tensor's
+  // Optimization: if the base already had a mutation on it,
+  // we can treat this view as already having the mutation too.
+  generation_ = base->generation_;
 }
 
 
@@ -167,7 +170,7 @@ void FunctionalTensorWrapper::commit_update() {
   // doesn't result in an unnecessary materialization of the base.
   // This optimization results in the slice temporarily haven't incorrect
   // stride/storage_offset though, and DCE should handle that optimization anyway.
-  // generation_ = storage_impl->generation();
+  generation_ = storage_impl->generation();
 }
 
 bool FunctionalTensorWrapper::is_up_to_date() const {

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -5986,11 +5986,13 @@ class TestAOTModuleSimplified(AOTTestCase):
             assert "test_aotdispatch.py" in node.stack_trace
 
         def assert_compiler(gm: torch.fx.GraphModule, _):
+            print(gm.graph)
             assert torch.ops.aten.copy_.default in [x.target for x in gm.graph.nodes]
             for node in gm.graph.nodes:
                 if node.target == torch.ops.aten.copy_.default:
                     assert "stack_trace" in node.meta
-                    assert "x_view.mul_(2)" in node.meta["stack_trace"]
+                    print(node.meta["stack_trace"])
+                    assert "return (x + x,)" in node.meta["stack_trace"]
             return gm.forward  # return a python callable
 
         x = torch.randn(128, 20)

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -1535,8 +1535,8 @@ def forward(self, primals_1, primals_2, primals_3):
     mul = torch.ops.aten.mul.Tensor(clone, 2);  clone = None
     mul_1 = torch.ops.aten.mul.Tensor(clone_1, 3);  clone_1 = None
     view = torch.ops.aten.view.default(primals_2, [2, 2]);  primals_2 = None
-    view_2 = torch.ops.aten.view.default(mul_1, [2, 2])
-    return (mul, mul_1, view, view_2)""",
+    view_1 = torch.ops.aten.view.default(mul_1, [2, 2])
+    return (mul, mul_1, view, view_1)""",
         )
 
     def test_input_output_view_metadata_mutate_multiple(self):
@@ -1568,9 +1568,9 @@ def forward(self, primals_1, primals_2, primals_3):
     mul = torch.ops.aten.mul.Tensor(clone, 3);  clone = None
     t = torch.ops.aten.t.default(view);  view = None
     view_1 = torch.ops.aten.view.default(primals_1, [2, 2]);  primals_1 = None
+    view_2 = torch.ops.aten.view.default(mul, [2, 2])
     view_3 = torch.ops.aten.view.default(t, [2, 2])
-    view_4 = torch.ops.aten.view.default(mul, [2, 2])
-    return (mul, t, view_1, view_4, view_3)""",
+    return (mul, t, view_1, view_2, view_3)""",
         )
 
     def test_input_mutation_and_output_view(self):
@@ -1591,8 +1591,8 @@ def forward(self, primals_1, primals_2, primals_3):
 def forward(self, primals_1):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
     add = torch.ops.aten.add.Tensor(clone, 1);  clone = None
-    view_1 = torch.ops.aten.view.default(add, [-1])
-    return (add, view_1)""",
+    view = torch.ops.aten.view.default(add, [-1])
+    return (add, view)""",
         )
 
     def test_input_mutation_output_view_multiple(self):
@@ -2132,10 +2132,10 @@ def forward(self, primals_1):
     t_1 = torch.ops.aten.t.default(clone);  clone = None
     select_scatter = torch.ops.aten.select_scatter.default(t_1, mul, 0, 0);  t_1 = mul = None
     t_2 = torch.ops.aten.t.default(select_scatter);  select_scatter = None
-    t_4 = torch.ops.aten.t.default(t_2)
-    t_6 = torch.ops.aten.t.default(t_2);  t_2 = None
-    view_1 = torch.ops.aten.view.default(t_6, [3, 3]);  t_6 = None
-    return (t_4, view_1)""",
+    t_3 = torch.ops.aten.t.default(t_2)
+    t_5 = torch.ops.aten.t.default(t_2);  t_2 = None
+    view_1 = torch.ops.aten.view.default(t_5, [3, 3]);  t_5 = None
+    return (t_3, view_1)""",
         )
 
     def test_view_and_inplace_view(self):
@@ -2724,10 +2724,9 @@ def forward(self, primals_1):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
     as_strided = torch.ops.aten.as_strided.default(clone, [2], [1], 0)
     add = torch.ops.aten.add.Tensor(as_strided, 1);  as_strided = None
-    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, add, [2], [1], 0);  clone = add = None
-    as_strided_2 = torch.ops.aten.as_strided.default(as_strided_scatter, [2], [1], 0)
-    as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter, [2], [1], 0)
-    add_1 = torch.ops.aten.add.Tensor(as_strided_2, as_strided_5);  as_strided_2 = as_strided_5 = None
+    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, add, [2], [1], 0);  clone = None
+    as_strided_4 = torch.ops.aten.as_strided.default(as_strided_scatter, [2], [1], 0)
+    add_1 = torch.ops.aten.add.Tensor(add, as_strided_4);  add = as_strided_4 = None
     return (as_strided_scatter, add_1)""",
         )  # noqa: B950
 
@@ -2757,10 +2756,9 @@ def forward(self, primals_1):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
     as_strided = torch.ops.aten.as_strided.default(clone, [2], [1], 0)
     add = torch.ops.aten.add.Tensor(as_strided, 1);  as_strided = None
-    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, add, [2], [1], 0);  clone = add = None
-    as_strided_2 = torch.ops.aten.as_strided.default(as_strided_scatter, [2], [1], 0)
-    as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter, [2, 2], [2, 1], 0)
-    add_1 = torch.ops.aten.add.Tensor(as_strided_2, as_strided_5);  as_strided_2 = as_strided_5 = None
+    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, add, [2], [1], 0);  clone = None
+    as_strided_4 = torch.ops.aten.as_strided.default(as_strided_scatter, [2, 2], [2, 1], 0)
+    add_1 = torch.ops.aten.add.Tensor(add, as_strided_4);  add = as_strided_4 = None
     return (as_strided_scatter, add_1)""",
         )  # noqa: B950
 
@@ -2790,8 +2788,8 @@ def forward(self, primals_1):
     as_strided = torch.ops.aten.as_strided.default(clone, [4], [1], 0)
     add = torch.ops.aten.add.Tensor(as_strided, 1);  as_strided = None
     as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, add, [4], [1], 0);  clone = add = None
-    as_strided_8 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
-    view_1 = torch.ops.aten.view.default(as_strided_8, [4]);  as_strided_8 = None
+    as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
+    view_1 = torch.ops.aten.view.default(as_strided_5, [4]);  as_strided_5 = None
     return (as_strided_scatter, view_1)""",
         )  # noqa: B950
 
@@ -2825,11 +2823,10 @@ def forward(self, primals_1, primals_2):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
     as_strided_1 = torch.ops.aten.as_strided.default(clone, [4], [1], 0)
     mul = torch.ops.aten.mul.Tensor(as_strided_1, 2);  as_strided_1 = None
-    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, mul, [4], [1], 0);  clone = mul = None
     add = torch.ops.aten.add.Tensor(primals_2, 1);  primals_2 = None
-    as_strided_7 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
-    view_1 = torch.ops.aten.view.default(as_strided_7, [-1]);  as_strided_7 = None
-    return (as_strided_scatter, add, view_1)""",
+    view = torch.ops.aten.view.default(mul, [-1])
+    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, mul, [4], [1], 0);  clone = mul = None
+    return (as_strided_scatter, add, view)""",
         )  # noqa: B950
 
     def test_input_metadata_mutation_aliases(self):
@@ -2898,8 +2895,8 @@ def forward(self, primals_1, primals_2):
     as_strided = torch.ops.aten.as_strided.default(primals_1, [4], [1], 0)
     mul = torch.ops.aten.mul.Tensor(as_strided, 2);  as_strided = None
     as_strided_scatter = torch.ops.aten.as_strided_scatter.default(primals_1, mul, [4], [1], 0);  primals_1 = mul = None
-    as_strided_3 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
-    add = torch.ops.aten.add.Tensor(as_strided_3, 1);  as_strided_3 = None
+    as_strided_2 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
+    add = torch.ops.aten.add.Tensor(as_strided_2, 1);  as_strided_2 = None
     add_1 = torch.ops.aten.add.Tensor(primals_2, 1);  primals_2 = None
     return (as_strided_scatter, add, add_1)""",
         )  # noqa: B950
@@ -2953,14 +2950,13 @@ def forward(self, primals_1, primals_2, primals_3):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
     as_strided = torch.ops.aten.as_strided.default(clone, [4], [1], 0)
     add = torch.ops.aten.add.Tensor(as_strided, 1);  as_strided = None
-    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, add, [4], [1], 0);  clone = add = None
     add_1 = torch.ops.aten.add.Tensor(primals_2, primals_3);  primals_2 = primals_3 = None
-    as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
-    unsqueeze_1 = torch.ops.aten.unsqueeze.default(as_strided_5, 0);  as_strided_5 = None
+    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, add, [4], [1], 0);  clone = None
+    as_strided_4 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
+    unsqueeze_1 = torch.ops.aten.unsqueeze.default(as_strided_4, 0);  as_strided_4 = None
     add_2 = torch.ops.aten.add.Tensor(add_1, unsqueeze_1);  add_1 = None
-    as_strided_14 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
-    view_2 = torch.ops.aten.view.default(as_strided_14, [-1]);  as_strided_14 = None
-    return (as_strided_scatter, add_2, view_2, unsqueeze_1)""",
+    view = torch.ops.aten.view.default(add, [-1]);  add = None
+    return (as_strided_scatter, add_2, view, unsqueeze_1)""",
         )  # noqa: B950
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
@@ -3026,11 +3022,10 @@ def forward(self, primals_1, primals_2):
     view = torch.ops.aten.view.default(primals_2, [2, 2]);  primals_2 = None
     as_strided_1 = torch.ops.aten.as_strided.default(clone, [4], [1], 0)
     mul = torch.ops.aten.mul.Tensor(as_strided_1, 2);  as_strided_1 = None
-    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, mul, [4], [1], 0);  clone = mul = None
-    as_strided_2 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
     t = torch.ops.aten.t.default(view);  view = None
-    as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
-    add = torch.ops.aten.add.Tensor(as_strided_5, as_strided_2);  as_strided_5 = as_strided_2 = None
+    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, mul, [4], [1], 0);  clone = None
+    as_strided_4 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
+    add = torch.ops.aten.add.Tensor(as_strided_4, mul);  as_strided_4 = mul = None
     view_1 = torch.ops.aten.view.default(add, [-1])
     t_1 = torch.ops.aten.t.default(t)
     unsqueeze = torch.ops.aten.unsqueeze.default(view_1, 0)
@@ -4170,8 +4165,8 @@ def forward(self, arg0_1, arg1_1):
     matmul = torch.ops.aten.matmul.default(arg1_1, arg1_1)
     add = torch.ops.aten.add.Tensor(matmul, 2);  matmul = None
     sum_1 = torch.ops.aten.sum.default(arg1_1);  arg1_1 = None
-    view_1 = torch.ops.aten.view.default(add, [1, 4]);  add = None
-    sum_2 = torch.ops.aten.sum.default(view_1);  view_1 = None
+    view = torch.ops.aten.view.default(add, [1, 4]);  add = None
+    sum_2 = torch.ops.aten.sum.default(view);  view = None
     add_1 = torch.ops.aten.add.Tensor(sum_1, sum_2);  sum_1 = sum_2 = None
     return (add_1,)""",
         )
@@ -4914,7 +4909,7 @@ def forward(self, arg0_1):
     gt = torch.ops.aten.gt.Scalar(sum_1, 4);  sum_1 = None
     true_graph_0 = self.true_graph_0
     false_graph_0 = self.false_graph_0
-    cond = torch.ops.higher_order.cond(gt, true_graph_0, false_graph_0, [arg0_1]);  gt = true_graph_0 = false_graph_0 = arg0_1 = None
+    cond = torch.ops.higher_order.cond(gt, true_graph_0, false_graph_0, [arg0_1, 3, 4]);  gt = true_graph_0 = false_graph_0 = arg0_1 = None
     getitem = cond[0];  cond = None
     add = torch.ops.aten.add.Tensor(getitem, 3)
     add_1 = torch.ops.aten.add.Tensor(getitem, 4);  getitem = None
@@ -4924,7 +4919,7 @@ def forward(self, arg0_1):
         self.assertExpectedInline(
             gm.true_graph_0.code.strip(),
             """\
-def forward(self, arg0_1):
+def forward(self, arg0_1, arg1_1, arg2_1):
     add = torch.ops.aten.add.Tensor(arg0_1, 4)
     add_1 = torch.ops.aten.add.Tensor(add, 5);  add = add_1 = None
     cos = torch.ops.aten.cos.default(arg0_1);  arg0_1 = None
@@ -4934,7 +4929,7 @@ def forward(self, arg0_1):
         self.assertExpectedInline(
             gm.false_graph_0.code.strip(),
             """\
-def forward(self, arg0_1):
+def forward(self, arg0_1, arg1_1, arg2_1):
     add = torch.ops.aten.add.Tensor(arg0_1, 5)
     add_1 = torch.ops.aten.add.Tensor(add, 6);  add = add_1 = None
     sin = torch.ops.aten.sin.default(arg0_1);  arg0_1 = None

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -4181,10 +4181,9 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1, arg5_1):
 def forward(self, x_1):
     view = torch.ops.aten.view.default(x_1, [4, 5])
     add = torch.ops.aten.add.Tensor(view, 1);  view = None
-    view_1 = torch.ops.aten.view.default(add, [4, 5]);  add = None
-    view_2 = torch.ops.aten.view.default(view_1, [4, 5])
-    sin = torch.ops.aten.sin.default(view_2);  view_2 = None
+    sin = torch.ops.aten.sin.default(add)
     sum_1 = torch.ops.aten.sum.default(sin);  sin = None
+    view_1 = torch.ops.aten.view.default(add, [4, 5]);  add = None
     copy_ = torch.ops.aten.copy_.default(x_1, view_1);  x_1 = view_1 = copy_ = None
     return sum_1""",
         )
@@ -4222,10 +4221,9 @@ def forward(self, x_1):
 def forward(self, x_1):
     view = torch.ops.aten.view.default(x_1, [5, 5])
     add = torch.ops.aten.add.Tensor(view, 1);  view = None
-    view_1 = torch.ops.aten.view.default(add, [5, 5]);  add = None
-    view_2 = torch.ops.aten.view.default(view_1, [5, 5])
-    cos = torch.ops.aten.cos.default(view_2);  view_2 = None
+    cos = torch.ops.aten.cos.default(add)
     sum_1 = torch.ops.aten.sum.default(cos);  cos = None
+    view_1 = torch.ops.aten.view.default(add, [5, 5]);  add = None
     copy_ = torch.ops.aten.copy_.default(x_1, view_1);  x_1 = view_1 = copy_ = None
     return sum_1""",
         )

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -4786,7 +4786,6 @@ def forward(self, x_1) -> torch.Tensor:
     view_copy = torch.ops.aten.view_copy.default(x_1, [4, 2])
     add = torch.ops.aten.add.Tensor(view_copy, ones);  view_copy = ones = None
     view_copy_1 = torch.ops.aten.view_copy.default(add, [4, 2]);  add = None
-    view_copy_2 = torch.ops.aten.view_copy.default(view_copy_1, [4, 2]);  view_copy_2 = None
     copy_ = torch.ops.aten.copy_.default(x_1, view_copy_1);  x_1 = copy_ = None
     return view_copy_1
     """,

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -4830,12 +4830,10 @@ def forward(self, x_1) -> torch.Tensor:
 def forward(self, inpt_1) -> torch.Tensor:
     empty = torch.ops.aten.empty.memory_format([], dtype = torch.float32, device = 'cpu', pin_memory = False);  empty = None
     add = torch.ops.aten.add.Tensor(inpt_1, inpt_1);  inpt_1 = None
-    view_copy = torch.ops.aten.view_copy.default(add, [4]);  view_copy = None
-    view_copy_1 = torch.ops.aten.view_copy.default(add, [4]);  add = None
-    add_1 = torch.ops.aten.add.Tensor(view_copy_1, 1);  view_copy_1 = None
-    view_copy_2 = torch.ops.aten.view_copy.default(add_1, [4]);  add_1 = None
-    view_copy_3 = torch.ops.aten.view_copy.default(view_copy_2, [4]);  view_copy_3 = None
-    return view_copy_2
+    view_copy = torch.ops.aten.view_copy.default(add, [4]);  add = None
+    add_1 = torch.ops.aten.add.Tensor(view_copy, 1);  view_copy = None
+    view_copy_1 = torch.ops.aten.view_copy.default(add_1, [4]);  add_1 = None
+    return view_copy_1
     """,
         )
 
@@ -4890,7 +4888,6 @@ def forward(self, x_1) -> torch.Tensor:
     view = torch.ops.aten.view.default(x_1, [4, 2])
     add = torch.ops.aten.add.Tensor(view, ones);  view = ones = None
     view_1 = torch.ops.aten.view.default(add, [4, 2]);  add = None
-    view_2 = torch.ops.aten.view.default(view_1, [4, 2]);  view_2 = None
     copy_ = torch.ops.aten.copy_.default(x_1, view_1);  x_1 = copy_ = None
     return view_1
     """,

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -4867,7 +4867,6 @@ def forward(self, inpt_1) -> torch.Tensor:
     getitem = aminmax[0]
     getitem_1 = aminmax[1];  aminmax = None
     view_copy_2 = torch.ops.aten.view_copy.default(getitem_1, [2, 2]);  getitem_1 = None
-    view_copy_3 = torch.ops.aten.view_copy.default(view_copy_2, [4]);  view_copy_3 = None
     return (view_copy_2, getitem)
     """,
         )

--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -440,7 +440,6 @@ def forward(self, arg0_1):
     view_copy = torch.ops.aten.view_copy.default(lift_fresh_copy, [-1]);  lift_fresh_copy = None
     add = torch.ops.aten.add.Tensor(view_copy, 1);  view_copy = None
     view_copy_1 = torch.ops.aten.view_copy.default(add, [3]);  add = None
-    view_copy_2 = torch.ops.aten.view_copy.default(view_copy_1, [-1]);  view_copy_2 = None
     return view_copy_1
     """,
         )
@@ -458,7 +457,6 @@ def forward(self, arg0_1):
     view = torch.ops.aten.view.default(lift_fresh_copy, [-1]);  lift_fresh_copy = None
     add = torch.ops.aten.add_.Tensor(view, 1);  add = None
     view_1 = torch.ops.aten.view.default(view, [3]);  view = None
-    view_2 = torch.ops.aten.view.default(view_1, [-1]);  view_2 = None
     return view_1
     """,
         )

--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -1439,14 +1439,10 @@ def forward(self, arg0_1):
 
 def forward(self, arg0_1):
     zeros = torch.ops.aten.zeros.default([2, 2], device = device(type='cpu'), pin_memory = False)
-    diagonal_copy = torch.ops.aten.diagonal_copy.default(zeros)
+    diagonal_copy = torch.ops.aten.diagonal_copy.default(zeros);  zeros = None
     copy = torch.ops.aten.copy.default(diagonal_copy, arg0_1);  diagonal_copy = None
-    diagonal_scatter = torch.ops.aten.diagonal_scatter.default(zeros, copy);  zeros = copy = None
-    diagonal_copy_1 = torch.ops.aten.diagonal_copy.default(diagonal_scatter)
-    add = torch.ops.aten.add.Tensor(diagonal_copy_1, arg0_1);  diagonal_copy_1 = arg0_1 = None
-    diagonal_scatter_1 = torch.ops.aten.diagonal_scatter.default(diagonal_scatter, add);  diagonal_scatter = add = None
-    diagonal_copy_2 = torch.ops.aten.diagonal_copy.default(diagonal_scatter_1);  diagonal_scatter_1 = None
-    return diagonal_copy_2
+    add = torch.ops.aten.add.Tensor(copy, arg0_1);  copy = arg0_1 = None
+    return add
     """,
         )
 
@@ -1461,12 +1457,10 @@ def forward(self, arg0_1):
 
 def forward(self, arg0_1):
     zeros = torch.ops.aten.zeros.default([2, 2], device = device(type='cpu'), pin_memory = False)
-    diagonal = torch.ops.aten.diagonal.default(zeros)
-    copy = torch.ops.aten.copy_.default(diagonal, arg0_1);  diagonal = copy = None
-    diagonal_1 = torch.ops.aten.diagonal.default(zeros)
-    add = torch.ops.aten.add_.Tensor(diagonal_1, arg0_1);  diagonal_1 = arg0_1 = add = None
-    diagonal_2 = torch.ops.aten.diagonal.default(zeros);  zeros = None
-    return diagonal_2
+    diagonal = torch.ops.aten.diagonal.default(zeros);  zeros = None
+    copy = torch.ops.aten.copy_.default(diagonal, arg0_1);  copy = None
+    add = torch.ops.aten.add_.Tensor(diagonal, arg0_1);  arg0_1 = add = None
+    return diagonal
     """,
         )
 
@@ -1481,14 +1475,10 @@ def forward(self, arg0_1):
 
 def forward(self, arg0_1):
     zeros = torch.ops.aten.zeros.default([2, 2], device = device(type='cpu'), pin_memory = False)
-    diagonal_copy = torch.ops.aten.diagonal_copy.default(zeros)
+    diagonal_copy = torch.ops.aten.diagonal_copy.default(zeros);  zeros = None
     copy = torch.ops.aten.copy.default(diagonal_copy, arg0_1);  diagonal_copy = None
-    diagonal_scatter = torch.ops.aten.diagonal_scatter.default(zeros, copy);  zeros = copy = None
-    diagonal_copy_1 = torch.ops.aten.diagonal_copy.default(diagonal_scatter)
-    add = torch.ops.aten.add.Tensor(diagonal_copy_1, arg0_1);  diagonal_copy_1 = arg0_1 = None
-    diagonal_scatter_1 = torch.ops.aten.diagonal_scatter.default(diagonal_scatter, add);  diagonal_scatter = add = None
-    diagonal_copy_2 = torch.ops.aten.diagonal_copy.default(diagonal_scatter_1);  diagonal_scatter_1 = None
-    return diagonal_copy_2
+    add = torch.ops.aten.add.Tensor(copy, arg0_1);  copy = arg0_1 = None
+    return add
     """,
         )
 
@@ -1503,12 +1493,10 @@ def forward(self, arg0_1):
 
 def forward(self, arg0_1):
     zeros = torch.ops.aten.zeros.default([2, 2], device = device(type='cpu'), pin_memory = False)
-    diagonal = torch.ops.aten.diagonal.default(zeros)
-    copy = torch.ops.aten.copy_.default(diagonal, arg0_1);  diagonal = copy = None
-    diagonal_1 = torch.ops.aten.diagonal.default(zeros)
-    add = torch.ops.aten.add_.Tensor(diagonal_1, arg0_1);  diagonal_1 = arg0_1 = add = None
-    diagonal_2 = torch.ops.aten.diagonal.default(zeros);  zeros = None
-    return diagonal_2
+    diagonal = torch.ops.aten.diagonal.default(zeros);  zeros = None
+    copy = torch.ops.aten.copy_.default(diagonal, arg0_1);  copy = None
+    add = torch.ops.aten.add_.Tensor(diagonal, arg0_1);  arg0_1 = add = None
+    return diagonal
     """,
         )
 
@@ -1523,14 +1511,10 @@ def forward(self, arg0_1):
 
 def forward(self, arg0_1):
     zeros = torch.ops.aten.zeros.default([2, 2], device = device(type='cpu'), pin_memory = False)
-    diagonal_copy = torch.ops.aten.diagonal_copy.default(zeros)
+    diagonal_copy = torch.ops.aten.diagonal_copy.default(zeros);  zeros = None
     copy = torch.ops.aten.copy.default(diagonal_copy, arg0_1);  diagonal_copy = None
-    diagonal_scatter = torch.ops.aten.diagonal_scatter.default(zeros, copy);  zeros = copy = None
-    diagonal_copy_1 = torch.ops.aten.diagonal_copy.default(diagonal_scatter)
-    add = torch.ops.aten.add.Tensor(diagonal_copy_1, arg0_1);  diagonal_copy_1 = arg0_1 = None
-    diagonal_scatter_1 = torch.ops.aten.diagonal_scatter.default(diagonal_scatter, add);  diagonal_scatter = add = None
-    diagonal_copy_2 = torch.ops.aten.diagonal_copy.default(diagonal_scatter_1);  diagonal_scatter_1 = None
-    return diagonal_copy_2
+    add = torch.ops.aten.add.Tensor(copy, arg0_1);  copy = arg0_1 = None
+    return add
     """,
         )  # noqa: B950
 
@@ -1545,12 +1529,10 @@ def forward(self, arg0_1):
 
 def forward(self, arg0_1):
     zeros = torch.ops.aten.zeros.default([2, 2], device = device(type='cpu'), pin_memory = False)
-    diagonal = torch.ops.aten.diagonal.default(zeros)
-    copy = torch.ops.aten.copy_.default(diagonal, arg0_1);  diagonal = copy = None
-    diagonal_1 = torch.ops.aten.diagonal.default(zeros)
-    add = torch.ops.aten.add_.Tensor(diagonal_1, arg0_1);  diagonal_1 = arg0_1 = add = None
-    diagonal_2 = torch.ops.aten.diagonal.default(zeros);  zeros = None
-    return diagonal_2
+    diagonal = torch.ops.aten.diagonal.default(zeros);  zeros = None
+    copy = torch.ops.aten.copy_.default(diagonal, arg0_1);  copy = None
+    add = torch.ops.aten.add_.Tensor(diagonal, arg0_1);  arg0_1 = add = None
+    return diagonal
     """,
         )  # noqa: B950
 
@@ -1565,14 +1547,10 @@ def forward(self, arg0_1):
 
 def forward(self, arg0_1):
     zeros = torch.ops.aten.zeros.default([2, 2], device = device(type='cpu'), pin_memory = False)
-    diagonal_copy = torch.ops.aten.diagonal_copy.default(zeros)
+    diagonal_copy = torch.ops.aten.diagonal_copy.default(zeros);  zeros = None
     copy = torch.ops.aten.copy.default(diagonal_copy, arg0_1);  diagonal_copy = None
-    diagonal_scatter = torch.ops.aten.diagonal_scatter.default(zeros, copy);  zeros = copy = None
-    diagonal_copy_1 = torch.ops.aten.diagonal_copy.default(diagonal_scatter)
-    add = torch.ops.aten.add.Tensor(diagonal_copy_1, arg0_1);  diagonal_copy_1 = arg0_1 = None
-    diagonal_scatter_1 = torch.ops.aten.diagonal_scatter.default(diagonal_scatter, add);  diagonal_scatter = add = None
-    diagonal_copy_2 = torch.ops.aten.diagonal_copy.default(diagonal_scatter_1);  diagonal_scatter_1 = None
-    return diagonal_copy_2
+    add = torch.ops.aten.add.Tensor(copy, arg0_1);  copy = arg0_1 = None
+    return add
     """,
         )  # noqa: B950
 
@@ -1587,12 +1565,10 @@ def forward(self, arg0_1):
 
 def forward(self, arg0_1):
     zeros = torch.ops.aten.zeros.default([2, 2], device = device(type='cpu'), pin_memory = False)
-    diagonal = torch.ops.aten.diagonal.default(zeros)
-    copy = torch.ops.aten.copy_.default(diagonal, arg0_1);  diagonal = copy = None
-    diagonal_1 = torch.ops.aten.diagonal.default(zeros)
-    add = torch.ops.aten.add_.Tensor(diagonal_1, arg0_1);  diagonal_1 = arg0_1 = add = None
-    diagonal_2 = torch.ops.aten.diagonal.default(zeros);  zeros = None
-    return diagonal_2
+    diagonal = torch.ops.aten.diagonal.default(zeros);  zeros = None
+    copy = torch.ops.aten.copy_.default(diagonal, arg0_1);  copy = None
+    add = torch.ops.aten.add_.Tensor(diagonal, arg0_1);  arg0_1 = add = None
+    return diagonal
     """,
         )  # noqa: B950
 

--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -247,26 +247,22 @@ def forward(self, arg0_1):
     clone = torch.ops.aten.clone.default(view_copy);  view_copy = None
     view_copy_1 = torch.ops.aten.view_copy.default(clone, [16, 64, 128, 128])
     relu = torch.ops.aten.relu.default(view_copy_1);  view_copy_1 = None
-    view_copy_2 = torch.ops.aten.view_copy.default(relu, [1, 1024, 128, 128]);  relu = None
-    view_copy_3 = torch.ops.aten.view_copy.default(view_copy_2, [16, 64, 128, 128]);  view_copy_2 = None
-    view_copy_4 = torch.ops.aten.view_copy.default(clone, [16, 64, 128, 128]);  clone = view_copy_4 = None
-    sum_1 = torch.ops.aten.sum.default(view_copy_3)
+    view_copy_2 = torch.ops.aten.view_copy.default(clone, [16, 64, 128, 128]);  clone = view_copy_2 = None
+    sum_1 = torch.ops.aten.sum.default(relu)
     ones_like = torch.ops.aten.ones_like.default(sum_1, pin_memory = False, memory_format = torch.preserve_format);  sum_1 = None
     expand_copy = torch.ops.aten.expand_copy.default(ones_like, [16, 64, 128, 128]);  ones_like = None
-    view_copy_5 = torch.ops.aten.view_copy.default(expand_copy, [1, 1024, 128, 128]);  expand_copy = None
-    new_empty_strided = torch.ops.aten.new_empty_strided.default(view_copy_5, [1, 1024, 128, 128], [16777216, 16384, 128, 1])
-    copy = torch.ops.aten.copy.default(new_empty_strided, view_copy_5);  new_empty_strided = view_copy_5 = None
-    view_copy_6 = torch.ops.aten.view_copy.default(copy, [16, 64, 128, 128]);  view_copy_6 = None
-    view_copy_7 = torch.ops.aten.view_copy.default(copy, [16, 64, 128, 128])
-    clone_1 = torch.ops.aten.clone.default(view_copy_7, memory_format = torch.contiguous_format)
-    threshold_backward = torch.ops.aten.threshold_backward.default(clone_1, view_copy_3, 0);  clone_1 = view_copy_3 = None
-    copy_1 = torch.ops.aten.copy.default(view_copy_7, threshold_backward);  view_copy_7 = threshold_backward = None
-    view_copy_8 = torch.ops.aten.view_copy.default(copy_1, [1, 1024, 128, 128]);  copy_1 = None
-    view_copy_9 = torch.ops.aten.view_copy.default(view_copy_8, [16, 64, 128, 128]);  view_copy_9 = None
-    view_copy_10 = torch.ops.aten.view_copy.default(copy, [16, 64, 128, 128]);  copy = None
-    detach_copy = torch.ops.aten.detach_copy.default(view_copy_10);  view_copy_10 = detach_copy = None
-    view_copy_11 = torch.ops.aten.view_copy.default(view_copy_8, [16, 64, 128, 128]);  view_copy_8 = None
-    detach_copy_1 = torch.ops.aten.detach_copy.default(view_copy_11);  view_copy_11 = None
+    view_copy_3 = torch.ops.aten.view_copy.default(expand_copy, [1, 1024, 128, 128]);  expand_copy = None
+    new_empty_strided = torch.ops.aten.new_empty_strided.default(view_copy_3, [1, 1024, 128, 128], [16777216, 16384, 128, 1])
+    copy = torch.ops.aten.copy.default(new_empty_strided, view_copy_3);  new_empty_strided = view_copy_3 = None
+    view_copy_4 = torch.ops.aten.view_copy.default(copy, [16, 64, 128, 128])
+    clone_1 = torch.ops.aten.clone.default(view_copy_4, memory_format = torch.contiguous_format)
+    threshold_backward = torch.ops.aten.threshold_backward.default(clone_1, relu, 0);  clone_1 = relu = None
+    copy_1 = torch.ops.aten.copy.default(view_copy_4, threshold_backward);  view_copy_4 = threshold_backward = None
+    view_copy_5 = torch.ops.aten.view_copy.default(copy, [16, 64, 128, 128]);  copy = None
+    detach_copy = torch.ops.aten.detach_copy.default(view_copy_5);  view_copy_5 = detach_copy = None
+    view_copy_6 = torch.ops.aten.view_copy.default(copy_1, [1, 1024, 128, 128]);  copy_1 = None
+    view_copy_7 = torch.ops.aten.view_copy.default(view_copy_6, [16, 64, 128, 128]);  view_copy_6 = None
+    detach_copy_1 = torch.ops.aten.detach_copy.default(view_copy_7);  view_copy_7 = None
     return detach_copy_1
     """,
         )  # noqa: B950
@@ -292,11 +288,10 @@ def forward(self, arg0_1):
     ones = torch.ops.aten.ones.default([4, 2], device = device(type='cpu'), pin_memory = False)
     view_copy = torch.ops.aten.view_copy.default(arg0_1, [4, 2])
     add = torch.ops.aten.add.Tensor(view_copy, ones);  view_copy = ones = None
-    view_copy_1 = torch.ops.aten.view_copy.default(add, [4, 2]);  add = None
-    view_copy_2 = torch.ops.aten.view_copy.default(view_copy_1, [4, 2])
+    view_copy_1 = torch.ops.aten.view_copy.default(add, [4, 2])
     mul = torch.ops.aten.mul.Tensor(view_copy_1, view_copy_1);  mul = None
     copy_ = torch.ops.aten.copy_.default(arg0_1, view_copy_1);  arg0_1 = view_copy_1 = copy_ = None
-    return view_copy_2
+    return add
     """,
         )
 
@@ -313,11 +308,10 @@ def forward(self, arg0_1):
     ones = torch.ops.aten.ones.default([4, 2], device = device(type='cpu'), pin_memory = False)
     view = torch.ops.aten.view.default(arg0_1, [4, 2])
     add = torch.ops.aten.add.Tensor(view, ones);  view = ones = None
-    view_1 = torch.ops.aten.view.default(add, [4, 2]);  add = None
-    view_2 = torch.ops.aten.view.default(view_1, [4, 2])
+    view_1 = torch.ops.aten.view.default(add, [4, 2])
     mul = torch.ops.aten.mul.Tensor(view_1, view_1);  mul = None
     copy_ = torch.ops.aten.copy_.default(arg0_1, view_1);  arg0_1 = view_1 = copy_ = None
-    return view_2
+    return add
     """,
         )
 
@@ -680,10 +674,8 @@ def forward(self, arg0_1):
 def forward(self, arg0_1):
     ones = torch.ops.aten.ones.default([2], device = device(type='cpu'), pin_memory = False)
     clone = torch.ops.aten.clone.default(arg0_1)
-    diagonal_copy = torch.ops.aten.diagonal_copy.default(clone)
-    add = torch.ops.aten.add.Tensor(diagonal_copy, ones);  diagonal_copy = ones = None
-    diagonal_scatter = torch.ops.aten.diagonal_scatter.default(clone, add);  clone = add = None
-    diagonal_copy_1 = torch.ops.aten.diagonal_copy.default(diagonal_scatter);  diagonal_scatter = diagonal_copy_1 = None
+    diagonal_copy = torch.ops.aten.diagonal_copy.default(clone);  clone = None
+    add = torch.ops.aten.add.Tensor(diagonal_copy, ones);  diagonal_copy = ones = add = None
     mul = torch.ops.aten.mul.Tensor(arg0_1, arg0_1);  arg0_1 = None
     return mul
     """,
@@ -701,9 +693,8 @@ def forward(self, arg0_1):
 def forward(self, arg0_1):
     ones = torch.ops.aten.ones.default([2], device = device(type='cpu'), pin_memory = False)
     clone = torch.ops.aten.clone.default(arg0_1)
-    diagonal = torch.ops.aten.diagonal.default(clone)
+    diagonal = torch.ops.aten.diagonal.default(clone);  clone = None
     add = torch.ops.aten.add_.Tensor(diagonal, ones);  diagonal = ones = add = None
-    diagonal_1 = torch.ops.aten.diagonal.default(clone);  clone = diagonal_1 = None
     mul = torch.ops.aten.mul.Tensor(arg0_1, arg0_1);  arg0_1 = None
     return mul
     """,
@@ -731,7 +722,6 @@ def forward(self, arg0_1):
     diagonal_copy = torch.ops.aten.diagonal_copy.default(arg0_1)
     add = torch.ops.aten.add.Tensor(diagonal_copy, ones);  diagonal_copy = ones = None
     diagonal_scatter = torch.ops.aten.diagonal_scatter.default(arg0_1, add);  add = None
-    diagonal_copy_1 = torch.ops.aten.diagonal_copy.default(diagonal_scatter);  diagonal_copy_1 = None
     copy_ = torch.ops.aten.copy_.default(arg0_1, diagonal_scatter);  arg0_1 = copy_ = None
     return diagonal_scatter
     """,
@@ -752,7 +742,6 @@ def forward(self, arg0_1):
     diagonal = torch.ops.aten.diagonal.default(arg0_1)
     add = torch.ops.aten.add.Tensor(diagonal, ones);  diagonal = ones = None
     diagonal_scatter = torch.ops.aten.diagonal_scatter.default(arg0_1, add);  add = None
-    diagonal_1 = torch.ops.aten.diagonal.default(diagonal_scatter);  diagonal_1 = None
     copy_ = torch.ops.aten.copy_.default(arg0_1, diagonal_scatter);  arg0_1 = copy_ = None
     return diagonal_scatter
     """,
@@ -805,15 +794,11 @@ def forward(self, arg0_1):
     split_copy_1 = torch.ops.aten.split_copy.Tensor(arg0_1, 2)
     getitem_2 = split_copy_1[0];  getitem_2 = None
     getitem_3 = split_copy_1[1];  split_copy_1 = None
-    diagonal_scatter = torch.ops.aten.diagonal_scatter.default(getitem_3, add);  getitem_3 = add = None
+    diagonal_scatter = torch.ops.aten.diagonal_scatter.default(getitem_3, add);  getitem_3 = None
     slice_scatter = torch.ops.aten.slice_scatter.default(arg0_1, diagonal_scatter, 0, 2, 4);  diagonal_scatter = None
-    split_copy_2 = torch.ops.aten.split_copy.Tensor(slice_scatter, 2)
-    getitem_4 = split_copy_2[0];  getitem_4 = None
-    getitem_5 = split_copy_2[1];  split_copy_2 = None
-    diagonal_copy_1 = torch.ops.aten.diagonal_copy.default(getitem_5);  getitem_5 = None
     mul = torch.ops.aten.mul.Tensor(slice_scatter, slice_scatter);  mul = None
     copy_ = torch.ops.aten.copy_.default(arg0_1, slice_scatter);  arg0_1 = slice_scatter = copy_ = None
-    return diagonal_copy_1
+    return add
     """,
         )  # noqa: B950
 
@@ -837,15 +822,11 @@ def forward(self, arg0_1):
     split_1 = torch.ops.aten.split.Tensor(arg0_1, 2)
     getitem_2 = split_1[0];  getitem_2 = None
     getitem_3 = split_1[1];  split_1 = None
-    diagonal_scatter = torch.ops.aten.diagonal_scatter.default(getitem_3, add);  getitem_3 = add = None
+    diagonal_scatter = torch.ops.aten.diagonal_scatter.default(getitem_3, add);  getitem_3 = None
     slice_scatter = torch.ops.aten.slice_scatter.default(arg0_1, diagonal_scatter, 0, 2, 4);  diagonal_scatter = None
-    split_2 = torch.ops.aten.split.Tensor(slice_scatter, 2)
-    getitem_4 = split_2[0];  getitem_4 = None
-    getitem_5 = split_2[1];  split_2 = None
-    diagonal_1 = torch.ops.aten.diagonal.default(getitem_5);  getitem_5 = None
     mul = torch.ops.aten.mul.Tensor(slice_scatter, slice_scatter);  mul = None
     copy_ = torch.ops.aten.copy_.default(arg0_1, slice_scatter);  arg0_1 = slice_scatter = copy_ = None
-    return diagonal_1
+    return add
     """,
         )  # noqa: B950
 
@@ -877,15 +858,11 @@ def forward(self, arg0_1):
     split_with_sizes_copy_1 = torch.ops.aten.split_with_sizes_copy.default(arg0_1, [2, 2])
     getitem_2 = split_with_sizes_copy_1[0]
     getitem_3 = split_with_sizes_copy_1[1];  split_with_sizes_copy_1 = getitem_3 = None
-    diagonal_scatter = torch.ops.aten.diagonal_scatter.default(getitem_2, add);  getitem_2 = add = None
+    diagonal_scatter = torch.ops.aten.diagonal_scatter.default(getitem_2, add);  getitem_2 = None
     slice_scatter = torch.ops.aten.slice_scatter.default(arg0_1, diagonal_scatter, 0, 0, 2);  diagonal_scatter = None
-    split_with_sizes_copy_2 = torch.ops.aten.split_with_sizes_copy.default(slice_scatter, [2, 2])
-    getitem_4 = split_with_sizes_copy_2[0]
-    getitem_5 = split_with_sizes_copy_2[1];  split_with_sizes_copy_2 = getitem_5 = None
-    diagonal_copy_1 = torch.ops.aten.diagonal_copy.default(getitem_4);  getitem_4 = None
     mul = torch.ops.aten.mul.Tensor(slice_scatter, slice_scatter);  mul = None
     copy_ = torch.ops.aten.copy_.default(arg0_1, slice_scatter);  arg0_1 = slice_scatter = copy_ = None
-    return diagonal_copy_1
+    return add
     """,
         )  # noqa: B950
 
@@ -909,15 +886,11 @@ def forward(self, arg0_1):
     split_with_sizes_1 = torch.ops.aten.split_with_sizes.default(arg0_1, [2, 2])
     getitem_2 = split_with_sizes_1[0]
     getitem_3 = split_with_sizes_1[1];  split_with_sizes_1 = getitem_3 = None
-    diagonal_scatter = torch.ops.aten.diagonal_scatter.default(getitem_2, add);  getitem_2 = add = None
+    diagonal_scatter = torch.ops.aten.diagonal_scatter.default(getitem_2, add);  getitem_2 = None
     slice_scatter = torch.ops.aten.slice_scatter.default(arg0_1, diagonal_scatter, 0, 0, 2);  diagonal_scatter = None
-    split_with_sizes_2 = torch.ops.aten.split_with_sizes.default(slice_scatter, [2, 2])
-    getitem_4 = split_with_sizes_2[0]
-    getitem_5 = split_with_sizes_2[1];  split_with_sizes_2 = getitem_5 = None
-    diagonal_1 = torch.ops.aten.diagonal.default(getitem_4);  getitem_4 = None
     mul = torch.ops.aten.mul.Tensor(slice_scatter, slice_scatter);  mul = None
     copy_ = torch.ops.aten.copy_.default(arg0_1, slice_scatter);  arg0_1 = slice_scatter = copy_ = None
-    return diagonal_1
+    return add
     """,
         )  # noqa: B950
 
@@ -945,10 +918,8 @@ def forward(self, arg0_1):
     transpose_copy_1 = torch.ops.aten.transpose_copy.int(arg0_1, 1, 0);  arg0_1 = None
     slice_scatter = torch.ops.aten.slice_scatter.default(transpose_copy_1, add, 0, 0, 2);  transpose_copy_1 = add = None
     transpose_copy_2 = torch.ops.aten.transpose_copy.int(slice_scatter, 1, 0);  slice_scatter = None
-    transpose_copy_3 = torch.ops.aten.transpose_copy.int(transpose_copy_2, 1, 0)
-    slice_copy_1 = torch.ops.aten.slice_copy.Tensor(transpose_copy_3, 0, 0, 2);  transpose_copy_3 = slice_copy_1 = None
-    transpose_copy_4 = torch.ops.aten.transpose_copy.int(transpose_copy_2, 1, 0);  transpose_copy_2 = None
-    return transpose_copy_4
+    transpose_copy_3 = torch.ops.aten.transpose_copy.int(transpose_copy_2, 1, 0);  transpose_copy_2 = None
+    return transpose_copy_3
     """,
         )  # noqa: B950
 
@@ -970,10 +941,8 @@ def forward(self, arg0_1):
     transpose_1 = torch.ops.aten.transpose.int(arg0_1, 1, 0);  arg0_1 = None
     slice_scatter = torch.ops.aten.slice_scatter.default(transpose_1, add, 0, 0, 2);  transpose_1 = add = None
     transpose_2 = torch.ops.aten.transpose.int(slice_scatter, 1, 0);  slice_scatter = None
-    transpose_3 = torch.ops.aten.transpose.int(transpose_2, 1, 0)
-    slice_2 = torch.ops.aten.slice.Tensor(transpose_3, 0, 0, 2);  transpose_3 = slice_2 = None
-    transpose_4 = torch.ops.aten.transpose.int(transpose_2, 1, 0);  transpose_2 = None
-    return transpose_4
+    transpose_3 = torch.ops.aten.transpose.int(transpose_2, 1, 0);  transpose_2 = None
+    return transpose_3
     """,
         )  # noqa: B950
 
@@ -1002,10 +971,8 @@ def forward(self, arg0_1):
     transpose_copy_1 = torch.ops.aten.transpose_copy.int(arg0_1, 1, 0);  arg0_1 = None
     select_scatter = torch.ops.aten.select_scatter.default(transpose_copy_1, add, 0, 0);  transpose_copy_1 = add = None
     transpose_copy_2 = torch.ops.aten.transpose_copy.int(select_scatter, 1, 0);  select_scatter = None
-    transpose_copy_3 = torch.ops.aten.transpose_copy.int(transpose_copy_2, 1, 0)
-    select_copy_1 = torch.ops.aten.select_copy.int(transpose_copy_3, 0, 0);  transpose_copy_3 = select_copy_1 = None
-    transpose_copy_4 = torch.ops.aten.transpose_copy.int(transpose_copy_2, 1, 0);  transpose_copy_2 = None
-    return transpose_copy_4
+    transpose_copy_3 = torch.ops.aten.transpose_copy.int(transpose_copy_2, 1, 0);  transpose_copy_2 = None
+    return transpose_copy_3
     """,
         )  # noqa: B950
 
@@ -1027,10 +994,8 @@ def forward(self, arg0_1):
     transpose_1 = torch.ops.aten.transpose.int(arg0_1, 1, 0);  arg0_1 = None
     select_scatter = torch.ops.aten.select_scatter.default(transpose_1, add, 0, 0);  transpose_1 = add = None
     transpose_2 = torch.ops.aten.transpose.int(select_scatter, 1, 0);  select_scatter = None
-    transpose_3 = torch.ops.aten.transpose.int(transpose_2, 1, 0)
-    select_1 = torch.ops.aten.select.int(transpose_3, 0, 0);  transpose_3 = select_1 = None
-    transpose_4 = torch.ops.aten.transpose.int(transpose_2, 1, 0);  transpose_2 = None
-    return transpose_4
+    transpose_3 = torch.ops.aten.transpose.int(transpose_2, 1, 0);  transpose_2 = None
+    return transpose_3
     """,
         )  # noqa: B950
 
@@ -1061,12 +1026,8 @@ def forward(self, arg0_1):
     transpose_copy_1 = torch.ops.aten.transpose_copy.int(arg0_1, 1, 0);  arg0_1 = None
     select_scatter = torch.ops.aten.select_scatter.default(transpose_copy_1, add, 0, 0);  transpose_copy_1 = add = None
     transpose_copy_2 = torch.ops.aten.transpose_copy.int(select_scatter, 1, 0);  select_scatter = None
-    transpose_copy_3 = torch.ops.aten.transpose_copy.int(transpose_copy_2, 1, 0)
-    unbind_copy_1 = torch.ops.aten.unbind_copy.int(transpose_copy_3);  transpose_copy_3 = None
-    getitem_2 = unbind_copy_1[0];  getitem_2 = None
-    getitem_3 = unbind_copy_1[1];  unbind_copy_1 = getitem_3 = None
-    transpose_copy_4 = torch.ops.aten.transpose_copy.int(transpose_copy_2, 1, 0);  transpose_copy_2 = None
-    return transpose_copy_4
+    transpose_copy_3 = torch.ops.aten.transpose_copy.int(transpose_copy_2, 1, 0);  transpose_copy_2 = None
+    return transpose_copy_3
     """,
         )  # noqa: B950
 
@@ -1090,12 +1051,8 @@ def forward(self, arg0_1):
     transpose_1 = torch.ops.aten.transpose.int(arg0_1, 1, 0);  arg0_1 = None
     select_scatter = torch.ops.aten.select_scatter.default(transpose_1, add, 0, 0);  transpose_1 = add = None
     transpose_2 = torch.ops.aten.transpose.int(select_scatter, 1, 0);  select_scatter = None
-    transpose_3 = torch.ops.aten.transpose.int(transpose_2, 1, 0)
-    unbind_1 = torch.ops.aten.unbind.int(transpose_3);  transpose_3 = None
-    getitem_2 = unbind_1[0];  getitem_2 = None
-    getitem_3 = unbind_1[1];  unbind_1 = getitem_3 = None
-    transpose_4 = torch.ops.aten.transpose.int(transpose_2, 1, 0);  transpose_2 = None
-    return transpose_4
+    transpose_3 = torch.ops.aten.transpose.int(transpose_2, 1, 0);  transpose_2 = None
+    return transpose_3
     """,
         )  # noqa: B950
 
@@ -1122,10 +1079,9 @@ def forward(self, arg0_1):
     arange = torch.ops.aten.arange.default(4, device = device(type='cpu'), pin_memory = False)
     arange_1 = torch.ops.aten.arange.default(4, dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
     index_put = torch.ops.aten.index_put.default(view_copy, [arange], arange_1);  view_copy = arange = arange_1 = None
-    view_copy_1 = torch.ops.aten.view_copy.default(index_put, [4, 2]);  index_put = None
-    view_copy_2 = torch.ops.aten.view_copy.default(view_copy_1, [8])
+    view_copy_1 = torch.ops.aten.view_copy.default(index_put, [4, 2])
     copy_ = torch.ops.aten.copy_.default(arg0_1, view_copy_1);  arg0_1 = view_copy_1 = copy_ = None
-    return view_copy_2
+    return index_put
     """,
         )  # noqa: B950
 
@@ -1151,10 +1107,9 @@ def forward(self, arg0_1):
     ones = torch.ops.aten.ones.default([4, 2], device = device(type='cpu'), pin_memory = False);  ones = None
     view_copy = torch.ops.aten.view_copy.default(arg0_1, [4, 2])
     add = torch.ops.aten.add.Tensor(view_copy, 1);  view_copy = None
-    view_copy_1 = torch.ops.aten.view_copy.default(add, [4, 2]);  add = None
-    view_copy_2 = torch.ops.aten.view_copy.default(view_copy_1, [4, 2])
-    mul = torch.ops.aten.mul.Tensor(view_copy_2, 2);  view_copy_2 = None
+    mul = torch.ops.aten.mul.Tensor(add, 2)
     div = torch.ops.aten.div.Tensor(mul, 1);  mul = None
+    view_copy_1 = torch.ops.aten.view_copy.default(add, [4, 2]);  add = None
     copy_ = torch.ops.aten.copy_.default(arg0_1, view_copy_1);  arg0_1 = view_copy_1 = copy_ = None
     return div
     """,
@@ -1277,41 +1232,24 @@ def forward(self, arg0_1):
     getitem = split_copy[0]
     getitem_1 = split_copy[1];  split_copy = getitem_1 = None
     add_1 = torch.ops.aten.add.Tensor(getitem, ones);  getitem = ones = None
-    view_copy_2 = torch.ops.aten.view_copy.default(add, [8]);  add = None
-    view_copy_3 = torch.ops.aten.view_copy.default(view_copy_2, [2, 4]);  view_copy_2 = None
-    transpose_copy_1 = torch.ops.aten.transpose_copy.int(view_copy_3, 1, 0);  view_copy_3 = None
+    select_copy = torch.ops.aten.select_copy.int(view_copy_1, 0, 0);  view_copy_1 = select_copy = None
+    view_copy_2 = torch.ops.aten.view_copy.default(add_1, [4])
+    view_copy_3 = torch.ops.aten.view_copy.default(add, [8]);  add = None
+    view_copy_4 = torch.ops.aten.view_copy.default(view_copy_3, [2, 4]);  view_copy_3 = None
+    transpose_copy_1 = torch.ops.aten.transpose_copy.int(view_copy_4, 1, 0);  view_copy_4 = None
     unsqueeze_copy_1 = torch.ops.aten.unsqueeze_copy.default(transpose_copy_1, 0);  transpose_copy_1 = None
     squeeze_copy_1 = torch.ops.aten.squeeze_copy.default(unsqueeze_copy_1);  unsqueeze_copy_1 = None
-    slice_scatter = torch.ops.aten.slice_scatter.default(squeeze_copy_1, add_1, 0, 0, 2);  squeeze_copy_1 = add_1 = None
+    slice_scatter = torch.ops.aten.slice_scatter.default(squeeze_copy_1, add_1, 0, 0, 2);  squeeze_copy_1 = None
     unsqueeze_copy_2 = torch.ops.aten.unsqueeze_copy.default(slice_scatter, 0);  slice_scatter = None
     squeeze_copy_2 = torch.ops.aten.squeeze_copy.dim(unsqueeze_copy_2, 0);  unsqueeze_copy_2 = None
     transpose_copy_2 = torch.ops.aten.transpose_copy.int(squeeze_copy_2, 1, 0);  squeeze_copy_2 = None
-    view_copy_4 = torch.ops.aten.view_copy.default(transpose_copy_2, [8]);  transpose_copy_2 = None
-    view_copy_5 = torch.ops.aten.view_copy.default(view_copy_4, [4, 2]);  view_copy_4 = None
-    view_copy_6 = torch.ops.aten.view_copy.default(view_copy_5, [8])
-    view_copy_7 = torch.ops.aten.view_copy.default(view_copy_6, [2, 4]);  view_copy_6 = None
-    transpose_copy_3 = torch.ops.aten.transpose_copy.int(view_copy_7, 1, 0);  view_copy_7 = None
-    unsqueeze_copy_3 = torch.ops.aten.unsqueeze_copy.default(transpose_copy_3, 0);  transpose_copy_3 = None
-    squeeze_copy_3 = torch.ops.aten.squeeze_copy.default(unsqueeze_copy_3);  unsqueeze_copy_3 = None
-    split_copy_1 = torch.ops.aten.split_copy.Tensor(squeeze_copy_3, 2);  squeeze_copy_3 = None
-    getitem_2 = split_copy_1[0]
-    getitem_3 = split_copy_1[1];  split_copy_1 = getitem_3 = None
-    select_copy = torch.ops.aten.select_copy.int(view_copy_1, 0, 0);  view_copy_1 = select_copy = None
-    view_copy_8 = torch.ops.aten.view_copy.default(getitem_2, [4]);  view_copy_8 = None
-    view_copy_9 = torch.ops.aten.view_copy.default(view_copy_5, [8])
-    view_copy_10 = torch.ops.aten.view_copy.default(view_copy_9, [2, 4]);  view_copy_9 = None
-    select_copy_1 = torch.ops.aten.select_copy.int(view_copy_10, 0, 0);  view_copy_10 = None
-    view_copy_11 = torch.ops.aten.view_copy.default(view_copy_5, [8]);  view_copy_5 = None
-    view_copy_12 = torch.ops.aten.view_copy.default(view_copy_11, [2, 4]);  view_copy_11 = None
-    transpose_copy_4 = torch.ops.aten.transpose_copy.int(view_copy_12, 1, 0);  view_copy_12 = None
-    unsqueeze_copy_4 = torch.ops.aten.unsqueeze_copy.default(transpose_copy_4, 0);  transpose_copy_4 = None
-    squeeze_copy_4 = torch.ops.aten.squeeze_copy.default(unsqueeze_copy_4);  unsqueeze_copy_4 = None
-    split_copy_2 = torch.ops.aten.split_copy.Tensor(squeeze_copy_4, 2);  squeeze_copy_4 = None
-    getitem_4 = split_copy_2[0]
-    getitem_5 = split_copy_2[1];  split_copy_2 = getitem_5 = None
-    view_copy_13 = torch.ops.aten.view_copy.default(getitem_4, [4]);  getitem_4 = None
-    add_2 = torch.ops.aten.add.Tensor(select_copy_1, view_copy_13);  select_copy_1 = view_copy_13 = add_2 = None
-    return getitem_2
+    view_copy_5 = torch.ops.aten.view_copy.default(transpose_copy_2, [8]);  transpose_copy_2 = None
+    view_copy_6 = torch.ops.aten.view_copy.default(view_copy_5, [4, 2]);  view_copy_5 = None
+    view_copy_7 = torch.ops.aten.view_copy.default(view_copy_6, [8]);  view_copy_6 = None
+    view_copy_8 = torch.ops.aten.view_copy.default(view_copy_7, [2, 4]);  view_copy_7 = None
+    select_copy_1 = torch.ops.aten.select_copy.int(view_copy_8, 0, 0);  view_copy_8 = None
+    add_2 = torch.ops.aten.add.Tensor(select_copy_1, view_copy_2);  select_copy_1 = view_copy_2 = add_2 = None
+    return add_1
     """,
         )  # noqa: B950
 
@@ -1335,7 +1273,10 @@ def forward(self, arg0_1):
     split = torch.ops.aten.split.Tensor(squeeze, 2);  squeeze = None
     getitem = split[0]
     getitem_1 = split[1];  split = getitem_1 = None
-    add_1 = torch.ops.aten.add_.Tensor(getitem, ones);  getitem = ones = add_1 = None
+    add_1 = torch.ops.aten.add_.Tensor(getitem, ones);  ones = add_1 = None
+    select = torch.ops.aten.select.int(view_1, 0, 0);  view_1 = select = None
+    clone = torch.ops.aten.clone.default(getitem, memory_format = torch.contiguous_format)
+    _unsafe_view = torch.ops.aten._unsafe_view.default(clone, [4]);  clone = None
     view_2 = torch.ops.aten.view.default(add, [8]);  add = None
     view_3 = torch.ops.aten.view.default(view_2, [2, 4]);  view_2 = None
     transpose_1 = torch.ops.aten.transpose.int(view_3, 1, 0);  view_3 = None
@@ -1346,22 +1287,11 @@ def forward(self, arg0_1):
     transpose_2 = torch.ops.aten.transpose.int(squeeze_2, 1, 0);  squeeze_2 = None
     view_4 = torch.ops.aten.view.default(transpose_2, [8]);  transpose_2 = None
     view_5 = torch.ops.aten.view.default(view_4, [4, 2]);  view_4 = None
-    view_6 = torch.ops.aten.view.default(view_5, [8])
+    view_6 = torch.ops.aten.view.default(view_5, [8]);  view_5 = None
     view_7 = torch.ops.aten.view.default(view_6, [2, 4]);  view_6 = None
-    transpose_3 = torch.ops.aten.transpose.int(view_7, 1, 0);  view_7 = None
-    unsqueeze_3 = torch.ops.aten.unsqueeze.default(transpose_3, 0);  transpose_3 = None
-    squeeze_3 = torch.ops.aten.squeeze.default(unsqueeze_3);  unsqueeze_3 = None
-    split_1 = torch.ops.aten.split.Tensor(squeeze_3, 2);  squeeze_3 = None
-    getitem_2 = split_1[0]
-    getitem_3 = split_1[1];  split_1 = getitem_3 = None
-    select = torch.ops.aten.select.int(view_1, 0, 0);  view_1 = select = None
-    clone = torch.ops.aten.clone.default(getitem_2, memory_format = torch.contiguous_format)
-    _unsafe_view = torch.ops.aten._unsafe_view.default(clone, [4]);  clone = None
-    view_8 = torch.ops.aten.view.default(view_5, [8]);  view_5 = None
-    view_9 = torch.ops.aten.view.default(view_8, [2, 4]);  view_8 = None
-    select_1 = torch.ops.aten.select.int(view_9, 0, 0);  view_9 = None
+    select_1 = torch.ops.aten.select.int(view_7, 0, 0);  view_7 = None
     add_2 = torch.ops.aten.add.Tensor(select_1, _unsafe_view);  select_1 = _unsafe_view = add_2 = None
-    return getitem_2
+    return getitem
     """,
         )
 
@@ -1385,11 +1315,10 @@ def forward(self, arg0_1):
     ones = torch.ops.aten.ones.default([4, 2], device = device(type='cpu'), pin_memory = False)
     view = torch.ops.aten.view.default(arg0_1, [4, 2])
     add = torch.ops.aten.add.Tensor(view, ones);  view = ones = None
-    view_1 = torch.ops.aten.view.default(add, [4, 2]);  add = None
-    view_2 = torch.ops.aten.view.default(view_1, [4, 2])
+    view_1 = torch.ops.aten.view.default(add, [4, 2])
     mul = torch.ops.aten.mul.Tensor(view_1, view_1);  mul = None
     copy_ = torch.ops.aten.copy_.default(arg0_1, view_1);  arg0_1 = view_1 = copy_ = None
-    return view_2
+    return add
     """,
         )
 
@@ -1610,7 +1539,6 @@ def forward(self, arg0_1):
     diagonal_copy = torch.ops.aten.diagonal_copy.default(add)
     fill = torch.ops.aten.fill.Scalar(diagonal_copy, 0);  diagonal_copy = None
     diagonal_scatter = torch.ops.aten.diagonal_scatter.default(add, fill);  add = fill = None
-    diagonal_copy_1 = torch.ops.aten.diagonal_copy.default(diagonal_scatter);  diagonal_copy_1 = None
     return diagonal_scatter
     """,
         )
@@ -1628,7 +1556,6 @@ def forward(self, arg0_1):
     add = torch.ops.aten.add.Tensor(arg0_1, arg0_1);  arg0_1 = None
     diagonal = torch.ops.aten.diagonal.default(add)
     fill = torch.ops.aten.fill_.Scalar(diagonal, 0);  diagonal = fill = None
-    diagonal_1 = torch.ops.aten.diagonal.default(add);  diagonal_1 = None
     return add
     """,
         )
@@ -1664,12 +1591,9 @@ def forward(self, arg0_1):
     view_copy_3 = torch.ops.aten.view_copy.default(add_1, [3, 3]);  add_1 = None
     as_strided_scatter = torch.ops.aten.as_strided_scatter.default(view_copy_2, view_copy_3, [3, 3], [3, 1]);  view_copy_2 = view_copy_3 = None
     view_copy_4 = torch.ops.aten.view_copy.default(as_strided_scatter, [8, 2]);  as_strided_scatter = None
-    view_copy_5 = torch.ops.aten.view_copy.default(view_copy_4, [4, 4])
+    view_copy_5 = torch.ops.aten.view_copy.default(view_copy_4, [4, 4]);  view_copy_4 = None
     as_strided_copy_2 = torch.ops.aten.as_strided_copy.default(view_copy_5, [3, 3], [3, 1]);  view_copy_5 = None
-    view_copy_6 = torch.ops.aten.view_copy.default(as_strided_copy_2, [-1]);  as_strided_copy_2 = view_copy_6 = None
-    view_copy_7 = torch.ops.aten.view_copy.default(view_copy_4, [4, 4]);  view_copy_4 = None
-    as_strided_copy_3 = torch.ops.aten.as_strided_copy.default(view_copy_7, [3, 3], [3, 1]);  view_copy_7 = None
-    add_2 = torch.ops.aten.add.Tensor(as_strided_copy_3, 1);  as_strided_copy_3 = None
+    add_2 = torch.ops.aten.add.Tensor(as_strided_copy_2, 1);  as_strided_copy_2 = None
     return add_2
     """,  # noqa: B950
         )
@@ -1694,13 +1618,10 @@ def forward(self, arg0_1):
     as_strided_1 = torch.ops.aten.as_strided.default(view_2, [3, 3], [3, 1]);  as_strided_1 = None
     view_3 = torch.ops.aten.view.default(view_1, [3, 3]);  view_1 = view_3 = None
     view_4 = torch.ops.aten.view.default(view_2, [8, 2]);  view_2 = None
-    view_5 = torch.ops.aten.view.default(view_4, [4, 4])
+    view_5 = torch.ops.aten.view.default(view_4, [4, 4]);  view_4 = None
     as_strided_2 = torch.ops.aten.as_strided.default(view_5, [3, 3], [3, 1]);  view_5 = None
-    view_6 = torch.ops.aten.view.default(as_strided_2, [-1]);  as_strided_2 = view_6 = None
-    view_7 = torch.ops.aten.view.default(view_4, [4, 4]);  view_4 = None
-    as_strided_3 = torch.ops.aten.as_strided.default(view_7, [3, 3], [3, 1]);  view_7 = None
-    add_2 = torch.ops.aten.add_.Tensor(as_strided_3, 1);  add_2 = None
-    return as_strided_3
+    add_2 = torch.ops.aten.add_.Tensor(as_strided_2, 1);  add_2 = None
+    return as_strided_2
     """,
         )
 
@@ -1743,7 +1664,6 @@ def forward(self, arg0_1):
     view_copy = torch.ops.aten.view_copy.default(resize, [25]);  resize = None
     fill = torch.ops.aten.fill.Scalar(view_copy, 1);  view_copy = None
     view_copy_1 = torch.ops.aten.view_copy.default(fill, [5, 5]);  fill = None
-    view_copy_2 = torch.ops.aten.view_copy.default(view_copy_1, [25]);  view_copy_2 = None
     add_1 = torch.ops.aten.add.Tensor(view_copy_1, 1)
     return (view_copy_1, add_1)
     """,
@@ -1764,7 +1684,6 @@ def forward(self, arg0_1):
     view = torch.ops.aten.view.default(add, [25]);  add = None
     fill = torch.ops.aten.fill_.Scalar(view, 1);  fill = None
     view_1 = torch.ops.aten.view.default(view, [5, 5]);  view = None
-    view_2 = torch.ops.aten.view.default(view_1, [25]);  view_2 = None
     add_1 = torch.ops.aten.add.Tensor(view_1, 1)
     return (view_1, add_1)
     """,
@@ -1856,7 +1775,6 @@ def forward(self, arg0_1):
     select_copy = torch.ops.aten.select_copy.int(zeros, 0, 5)
     fill = torch.ops.aten.fill.Scalar(select_copy, 1);  select_copy = None
     select_scatter = torch.ops.aten.select_scatter.default(zeros, fill, 0, 5);  zeros = fill = None
-    select_copy_1 = torch.ops.aten.select_copy.int(select_scatter, 0, 5);  select_copy_1 = None
     return select_scatter
     """,
         )  # noqa: B950
@@ -1874,7 +1792,6 @@ def forward(self, arg0_1):
     zeros = torch.ops.aten.zeros.default([10], device = device(type='cpu'), pin_memory = False)
     select = torch.ops.aten.select.int(zeros, 0, 5)
     fill = torch.ops.aten.fill_.Scalar(select, 1);  select = fill = None
-    select_1 = torch.ops.aten.select.int(zeros, 0, 5);  select_1 = None
     return zeros
     """,
         )
@@ -1924,23 +1841,19 @@ def forward(self, arg0_1, arg1_1, arg2_1):
     getitem_3 = _native_batch_norm_legit_functional[3]
     getitem_4 = _native_batch_norm_legit_functional[4];  _native_batch_norm_legit_functional = None
     alias_copy = torch.ops.aten.alias_copy.default(arg1_1)
-    view_copy_1 = torch.ops.aten.view_copy.default(getitem_3, [20, 100]);  view_copy_1 = None
-    view_copy_2 = torch.ops.aten.view_copy.default(getitem_3, [20, 100]);  getitem_3 = None
-    mean = torch.ops.aten.mean.dim(view_copy_2, [0]);  view_copy_2 = None
+    view_copy_1 = torch.ops.aten.view_copy.default(getitem_3, [20, 100]);  getitem_3 = None
+    mean = torch.ops.aten.mean.dim(view_copy_1, [0]);  view_copy_1 = None
     copy = torch.ops.aten.copy.default(alias_copy, mean);  alias_copy = mean = None
-    alias_copy_1 = torch.ops.aten.alias_copy.default(copy);  copy = None
-    alias_copy_2 = torch.ops.aten.alias_copy.default(alias_copy_1);  alias_copy_2 = None
-    alias_copy_3 = torch.ops.aten.alias_copy.default(arg2_1)
-    view_copy_3 = torch.ops.aten.view_copy.default(getitem_4, [20, 100]);  view_copy_3 = None
-    view_copy_4 = torch.ops.aten.view_copy.default(getitem_4, [20, 100]);  getitem_4 = None
-    mean_1 = torch.ops.aten.mean.dim(view_copy_4, [0]);  view_copy_4 = None
-    copy_1 = torch.ops.aten.copy.default(alias_copy_3, mean_1);  alias_copy_3 = mean_1 = None
-    alias_copy_4 = torch.ops.aten.alias_copy.default(copy_1);  copy_1 = None
-    alias_copy_5 = torch.ops.aten.alias_copy.default(alias_copy_4);  alias_copy_5 = None
-    view_copy_5 = torch.ops.aten.view_copy.default(getitem, [20, 100, 35, 45]);  getitem = None
-    copy_ = torch.ops.aten.copy_.default(arg1_1, alias_copy_1);  arg1_1 = alias_copy_1 = copy_ = None
-    copy__1 = torch.ops.aten.copy_.default(arg2_1, alias_copy_4);  arg2_1 = alias_copy_4 = copy__1 = None
-    return view_copy_5
+    alias_copy_1 = torch.ops.aten.alias_copy.default(arg2_1)
+    view_copy_2 = torch.ops.aten.view_copy.default(getitem_4, [20, 100]);  getitem_4 = None
+    mean_1 = torch.ops.aten.mean.dim(view_copy_2, [0]);  view_copy_2 = None
+    copy_1 = torch.ops.aten.copy.default(alias_copy_1, mean_1);  alias_copy_1 = mean_1 = None
+    view_copy_3 = torch.ops.aten.view_copy.default(getitem, [20, 100, 35, 45]);  getitem = None
+    alias_copy_2 = torch.ops.aten.alias_copy.default(copy);  copy = None
+    copy_ = torch.ops.aten.copy_.default(arg1_1, alias_copy_2);  arg1_1 = alias_copy_2 = copy_ = None
+    alias_copy_3 = torch.ops.aten.alias_copy.default(copy_1);  copy_1 = None
+    copy__1 = torch.ops.aten.copy_.default(arg2_1, alias_copy_3);  arg2_1 = alias_copy_3 = copy__1 = None
+    return view_copy_3
     """,  # noqa: B950
             )
 
@@ -1970,23 +1883,19 @@ def forward(self, arg0_1, arg1_1, arg2_1):
     getitem_3 = _native_batch_norm_legit_functional[3]
     getitem_4 = _native_batch_norm_legit_functional[4];  _native_batch_norm_legit_functional = None
     alias = torch.ops.aten.alias.default(arg1_1)
-    view_1 = torch.ops.aten.view.default(getitem_3, [20, 100]);  view_1 = None
-    view_2 = torch.ops.aten.view.default(getitem_3, [20, 100]);  getitem_3 = None
-    mean = torch.ops.aten.mean.dim(view_2, [0]);  view_2 = None
+    view_1 = torch.ops.aten.view.default(getitem_3, [20, 100]);  getitem_3 = None
+    mean = torch.ops.aten.mean.dim(view_1, [0]);  view_1 = None
     copy = torch.ops.aten.copy.default(alias, mean);  alias = mean = None
-    alias_1 = torch.ops.aten.alias.default(copy);  copy = None
-    alias_2 = torch.ops.aten.alias.default(alias_1);  alias_2 = None
-    alias_3 = torch.ops.aten.alias.default(arg2_1)
-    view_3 = torch.ops.aten.view.default(getitem_4, [20, 100]);  view_3 = None
-    view_4 = torch.ops.aten.view.default(getitem_4, [20, 100]);  getitem_4 = None
-    mean_1 = torch.ops.aten.mean.dim(view_4, [0]);  view_4 = None
-    copy_1 = torch.ops.aten.copy.default(alias_3, mean_1);  alias_3 = mean_1 = None
-    alias_4 = torch.ops.aten.alias.default(copy_1);  copy_1 = None
-    alias_5 = torch.ops.aten.alias.default(alias_4);  alias_5 = None
-    view_5 = torch.ops.aten.view.default(getitem, [20, 100, 35, 45]);  getitem = None
-    copy_ = torch.ops.aten.copy_.default(arg1_1, alias_1);  arg1_1 = alias_1 = copy_ = None
-    copy__1 = torch.ops.aten.copy_.default(arg2_1, alias_4);  arg2_1 = alias_4 = copy__1 = None
-    return view_5
+    alias_1 = torch.ops.aten.alias.default(arg2_1)
+    view_2 = torch.ops.aten.view.default(getitem_4, [20, 100]);  getitem_4 = None
+    mean_1 = torch.ops.aten.mean.dim(view_2, [0]);  view_2 = None
+    copy_1 = torch.ops.aten.copy.default(alias_1, mean_1);  alias_1 = mean_1 = None
+    view_3 = torch.ops.aten.view.default(getitem, [20, 100, 35, 45]);  getitem = None
+    alias_2 = torch.ops.aten.alias.default(copy);  copy = None
+    copy_ = torch.ops.aten.copy_.default(arg1_1, alias_2);  arg1_1 = alias_2 = copy_ = None
+    alias_3 = torch.ops.aten.alias.default(copy_1);  copy_1 = None
+    copy__1 = torch.ops.aten.copy_.default(arg2_1, alias_3);  arg2_1 = alias_3 = copy__1 = None
+    return view_3
     """,  # noqa: B950
             )
 
@@ -2191,9 +2100,7 @@ def forward(self, arg0_1):
     mul = torch.ops.aten.mul.Tensor(clone_1, 2);  clone_1 = None
     clone_2 = torch.ops.aten.clone.default(_conj);  _conj = None
     copy = torch.ops.aten.copy.default(clone_2, mul);  clone_2 = mul = None
-    _conj_1 = torch.ops.aten._conj.default(copy);  copy = None
-    _conj_2 = torch.ops.aten._conj.default(_conj_1);  _conj_1 = None
-    clone_3 = torch.ops.aten.clone.default(_conj_2);  _conj_2 = None
+    clone_3 = torch.ops.aten.clone.default(copy);  copy = None
     view_as_real = torch.ops.aten.view_as_real.default(clone_3);  clone_3 = None
     return view_as_real""",
         )

--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -581,7 +581,6 @@ def forward(self, arg0_1):
     as_strided_copy = torch.ops.aten.as_strided_copy.default(arg0_1, [2], [2], 1)
     add = torch.ops.aten.add.Tensor(as_strided_copy, 1);  as_strided_copy = None
     as_strided_scatter = torch.ops.aten.as_strided_scatter.default(arg0_1, add, [2], [2], 1);  add = None
-    as_strided_copy_1 = torch.ops.aten.as_strided_copy.default(as_strided_scatter, [2], [2], 1);  as_strided_copy_1 = None
     copy_ = torch.ops.aten.copy_.default(arg0_1, as_strided_scatter);  arg0_1 = copy_ = None
     return as_strided_scatter
     """,
@@ -601,7 +600,6 @@ def forward(self, arg0_1):
     as_strided = torch.ops.aten.as_strided.default(arg0_1, [2], [2], 1)
     add = torch.ops.aten.add.Tensor(as_strided, 1);  as_strided = None
     as_strided_scatter = torch.ops.aten.as_strided_scatter.default(arg0_1, add, [2], [2], 1);  add = None
-    as_strided_1 = torch.ops.aten.as_strided.default(as_strided_scatter, [2], [2], 1);  as_strided_1 = None
     copy_ = torch.ops.aten.copy_.default(arg0_1, as_strided_scatter);  arg0_1 = copy_ = None
     return as_strided_scatter
     """,

--- a/test/test_fx_reinplace_pass.py
+++ b/test/test_fx_reinplace_pass.py
@@ -193,9 +193,6 @@ def forward(self, a__1):
     add = torch.ops.aten.add_.Tensor(select_1, 1);  select_1 = add = None
     slice_2 = torch.ops.aten.slice.Tensor(clone, 0, 0, 9223372036854775807)
     select_2 = torch.ops.aten.select.int(slice_2, 1, 1);  slice_2 = select_2 = None
-    slice_3 = torch.ops.aten.slice.Tensor(clone, 0, 0, 9223372036854775807)
-    select_3 = torch.ops.aten.select.int(slice_3, 1, 1);  slice_3 = None
-    select_4 = torch.ops.aten.select.int(select_3, 0, 1);  select_3 = select_4 = None
     return clone
     """)
 

--- a/test/test_fx_reinplace_pass.py
+++ b/test/test_fx_reinplace_pass.py
@@ -356,8 +356,6 @@ def forward(self):
     slice_2 = torch.ops.aten.slice.Tensor(slice_1, 1, 2, 9223372036854775807);  slice_1 = None
     copy = torch.ops.aten.copy_.default(slice_2, ones);  slice_2 = ones = copy = None
     slice_3 = torch.ops.aten.slice.Tensor(zeros, 0, 0, 9223372036854775807);  slice_3 = None
-    slice_4 = torch.ops.aten.slice.Tensor(zeros, 0, 0, 9223372036854775807)
-    slice_5 = torch.ops.aten.slice.Tensor(slice_4, 1, 2, 9223372036854775807);  slice_4 = slice_5 = None
     return zeros
     """)
 

--- a/test/test_fx_reinplace_pass.py
+++ b/test/test_fx_reinplace_pass.py
@@ -157,10 +157,7 @@ def forward(self, a__1):
     view_4 = torch.ops.aten.view.default(view_2, []);  view_2 = view_4 = None
     view_5 = torch.ops.aten.view.default(view_3, [4]);  view_3 = None
     view_6 = torch.ops.aten.view.default(view_5, [-1])
-    select_2 = torch.ops.aten.select.int(view_6, 0, 0);  view_6 = None
-    view_7 = torch.ops.aten.view.default(select_2, [-1]);  select_2 = view_7 = None
-    view_8 = torch.ops.aten.view.default(view_5, [-1])
-    add_1 = torch.ops.aten.add_.Tensor(view_5, view_8);  view_8 = add_1 = None
+    add_1 = torch.ops.aten.add_.Tensor(view_5, view_6);  view_6 = add_1 = None
     return view_5
     """)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142118


In @bdhirsh words See https://github.com/pytorch/pytorch/issues/140835

---
It's due to this code:
```
storage = torch.empty(filesize,dtype=torch.uint8,)
torch.cat(swaps, out=storage)
swaps = storage.split(lengths)
return .... # return views of each tensor in swaps
```
When functionalized the traced program, we sync all graph outputs in case they have any pending mutations (code: https://github.com/pytorch/pytorch/blob/main/torch/_functorch/_aot_autograd/functional_utils.py#L77)

That sync logic effectively says: if there is a pending mutation on one of the aliases, we need to regenerate the current (alias) tensor by replaying all of the views from the updated base tensor (code: https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/FunctionalTensorWrapper.cpp#L363)

In the case where one of those views is a split_with_sizes call, we will just... go ahead and run the view. We will do this for every graph output (which in this case, is all N views, each of which results in a split_with_size call.

In principle this is causing us to generate a graph with some unnecessary ops, that we could rely on the compiler to optimize. Although here, it sounds like all of these extra nodes are making a pretty big impact in the E2E compile time.

For this particular case, there is probably something simpler that we can do: there really shouldn't be any pending mutations on any of the graph outputs at the time that we return them. This is because when we first generated swaps in the example above, the mutation was already applied. There are not pending mutations at the time that we generate that view.
We actually had an old optimization that did it (originally for XLA) I have a PR that adds it back here 

---