### PR TITLE
Fix floating point literals in IRPrinter

### DIFF
--- a/test/cpp/tensorexpr/test_ir_printer.cpp
+++ b/test/cpp/tensorexpr/test_ir_printer.cpp
@@ -37,6 +37,14 @@ TEST(IRPrinter, BasicValueTest02) {
   ASSERT_EQ(ss.str(), "(2.f + 3.f) - (4.f + 5.f)");
 }
 
+TEST(IRPrinter, BasicValueTest03) {
+  ExprHandle a(3.402823466385289e+38f);
+  ExprHandle b(-3.402823466385289e+38f);
+  std::stringstream ss;
+  ss << a << ", " << b;
+  ASSERT_EQ(ss.str(), "3.402823466385289e+38f, -3.402823466385289e+38f");
+}
+
 TEST(IRPrinter, CastTest) {
   VarHandle x("x", kHalf);
   VarHandle y("y", kFloat);

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -191,25 +191,27 @@ void IRPrinter::visit(const CompareSelectPtr& v) {
   withParens(v->ret_val2());
 }
 
-static void formatFPSuffix(std::ostream& os, double v) {
-  os << (v == std::ceil(v) ? ".0" : "");
+static void formatFPSuffix(std::ostream& os, double v, bool flag) {
+  os << (flag && v == std::ceil(v) ? ".0" : "");
 }
 
 template <typename T>
-static void formatFPSuffix(std::ostream& os, T v) {
-  os << (v == std::ceil(v) ? ".f" : "f");
+static void formatFPSuffix(std::ostream& os, T v, bool flag) {
+  os << (flag && v == std::ceil(v) ? ".f" : "f");
 }
 
 template <typename T, std::enable_if_t<std::is_floating_point_v<T>>* = nullptr>
 static void formatImm(std::ostream& os, T v) {
   const int precision = 16;
+  const T lower_bound = static_cast<T>(-std::pow(10, precision));
+  const T upper_bound = -lower_bound;
   if (std::isnan(v)) {
     os << "NAN";
   } else if (std::isinf(v)) {
     os << (v > 0 ? "POS_INFINITY" : "NEG_INFINITY");
   } else {
     os << std::setprecision(precision) << v;
-    formatFPSuffix(os, v);
+    formatFPSuffix(os, v, v > lower_bound && v < upper_bound);
   }
 }
 


### PR DESCRIPTION
Fixes #114035
This is a recreation of #140002 with approval from its author. Original description:
>when v larger than 1e16, the format will be error. example: v is 1.2e17, the output is 1.2e17.f, it have two point '.'

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel