### PR TITLE
Remove lintrunner windows exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,8 +236,6 @@ git submodule update --init --recursive
 
 ```bash
 conda install cmake ninja
-# Run this command on native Windows
-conda install rust
 # Run this command from the PyTorch directory after cloning the source code using the “Get the PyTorch Source“ section below
 pip install -r requirements.txt
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ filelock
 networkx
 jinja2
 fsspec
-lintrunner ; platform_system != "Windows"
+lintrunner
 ninja
 packaging
 optree>=0.13.0


### PR DESCRIPTION
As it's available right now, see https://pypi.org/project/lintrunner/0.12.7/#files
And no longer ask developers to install rust on the platform
