### PR TITLE
[SymmetricMemory] use the python version of empty() and rendezvous() for tests and library ops

### DIFF
--- a/torch/csrc/distributed/c10d/CUDASymmetricMemoryOps.cu
+++ b/torch/csrc/distributed/c10d/CUDASymmetricMemoryOps.cu
@@ -154,7 +154,7 @@ at::Tensor multimem_all_reduce_(
       reduce_op == "sum",
       "multimem_all_reduce_: only sum is supported for now.");
 
-  auto symm_mem = c10d::symmetric_memory::rendezvous(input);
+  auto symm_mem = c10d::symmetric_memory::rendezvous(input, group_name);
   TORCH_CHECK(
       symm_mem != nullptr,
       "multimem_all_reduce_: input must be allocated with empty_strided_p2p().");
@@ -240,7 +240,7 @@ at::Tensor multimem_one_shot_all_reduce_out(
       reduce_op == "sum",
       "multimem_one_shot_all_reduce: only sum is supported for now.");
 
-  auto symm_mem = c10d::symmetric_memory::rendezvous(input);
+  auto symm_mem = c10d::symmetric_memory::rendezvous(input, group_name);
   TORCH_CHECK(
       symm_mem != nullptr,
       "multimem_one_shot_all_reduce: input must be allocated with empty_strided_p2p().");
@@ -343,7 +343,7 @@ at::Tensor one_shot_all_reduce_out(
       reduce_op == "sum",
       "one_shot_all_reduce: only sum is supported for now.");
 
-  auto symm_mem = c10d::symmetric_memory::rendezvous(input);
+  auto symm_mem = c10d::symmetric_memory::rendezvous(input, group_name);
   TORCH_CHECK(
       symm_mem != nullptr,
       "one_shot_all_reduce: input must be allocated with empty_strided_p2p().");
@@ -453,7 +453,7 @@ at::Tensor two_shot_all_reduce_(
       reduce_op == "sum",
       "two_shot_all_reduce: only sum is supported for now.");
 
-  auto symm_mem = c10d::symmetric_memory::rendezvous(input);
+  auto symm_mem = c10d::symmetric_memory::rendezvous(input, group_name);
   TORCH_CHECK(
       symm_mem != nullptr,
       "two_shot_all_reduce: input must be allocated with empty_strided_p2p().");

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -667,7 +667,7 @@ def _fused_all_gather_matmul_native(
     B: torch.Tensor,
     group_name: str,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    symm_mem = _SymmetricMemory.rendezvous(A_shard)
+    symm_mem = rendezvous(A_shard, group_name)
     if symm_mem is None:
         symm_mem = get_symm_mem_workspace(
             group_name, A_shard.numel() * A_shard.element_size()
@@ -1235,7 +1235,7 @@ def _low_contention_all_gather(
           symmetric memory workspace.
         - Symmetric memory workspace size requirement: the size of `tensor`.
     """
-    symm_mem = _SymmetricMemory.rendezvous(tensor)
+    symm_mem = rendezvous(tensor, group_name)
     if symm_mem is not None:
         input_is_symm_mem = True
     else:
@@ -1376,7 +1376,7 @@ def _low_contention_reduce_scatter(
     TODO(yifu): the SM-based copy can be avoided with a list-based reduction
     kernel.
     """
-    symm_mem = _SymmetricMemory.rendezvous(tensor)
+    symm_mem = rendezvous(tensor, group_name)
     if symm_mem is not None:
         return _low_contention_reduce_scatter_with_symm_mem_input(
             tensor, reduce_op, symm_mem


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142154



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o