### PR TITLE
Introduce int32 index_fill and index_copy indices

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -289,7 +289,8 @@ TORCH_PRECOMPUTE_META_FUNC(index_copy)
                    source.dim(), "), destination dimensionality (", self.dim(), ")");
   }
 
-  TORCH_CHECK(index.scalar_type() == ScalarType::Long, "index_copy_(): Expected a long tensor for index, but got ", index.scalar_type());
+  TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
+          "index_copy_(): Expected a dtype int64 or int32 for index, but got ", index.scalar_type());
   TORCH_CHECK(self.scalar_type() == source.scalar_type(), "index_copy_(): self and source expected to have the same dtype, but got (self) ", self.scalar_type(), " and (source) ", source.scalar_type());
   TORCH_CHECK(self.device() == source.device() && self.device() == index.device(),
       "index_copy_(): self, index and source expected to be in the same device, but got (self) ",
@@ -1480,9 +1481,8 @@ Tensor index_select_backward_symint(const Tensor& grad, c10::SymIntArrayRef self
 Tensor & index_fill_(Tensor & self, int64_t dim, const Tensor & index, const Scalar& source) {
   at::NoNamesGuard guard;
 
-  TORCH_CHECK_INDEX(
-    index.scalar_type() == ScalarType::Long,
-    "index_fill_(): Expected dtype int64 for index.");
+  TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
+          "index_fill_(): Expected a dtype int64 or int32 for index, but got ", index.scalar_type());
 
   at::assert_no_overlap(self, index);
   if (at::has_internal_overlap(self) == at::MemOverlap::Yes) {

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -106,7 +106,7 @@ void gpu_index_kernel(TensorIteratorBase& iter, const IntArrayRef index_size, co
 // size to avoid redundant kernels for different types of the same size.
 template <int N> struct alignas(N) OpaqueType { char data[N]; };
 
-template <typename scalar_t>
+template <typename scalar_t, typename index_t>
 void index_fill_kernel_impl(
   TensorIterator& iter,
   const int64_t dim,
@@ -119,7 +119,7 @@ void index_fill_kernel_impl(
 
   if (!iter.can_use_32bit_indexing()) {
     for (auto& sub_iter : iter.with_32bit_indexing()) {
-      index_fill_kernel_impl(sub_iter, dim, self_dim_size, self_dim_stride, fill_val);
+      index_fill_kernel_impl<scalar_t, index_t>(sub_iter, dim, self_dim_size, self_dim_stride, fill_val);
     }
     return;
   }
@@ -133,7 +133,7 @@ void index_fill_kernel_impl(
     const auto offsets = offset_calc.get(i);
 
     auto* __restrict__ self_data = reinterpret_cast<scalar_t*>(self_ptr + offsets[0]);
-    auto idx = *reinterpret_cast<int64_t*>(idx_ptr + offsets[1]);
+    auto idx = *reinterpret_cast<index_t*>(idx_ptr + offsets[1]);
     CUDA_KERNEL_ASSERT(idx >= -self_dim_size && idx < self_dim_size && "index out of bounds");
     if (idx < 0) {
       idx += self_dim_size;
@@ -144,7 +144,7 @@ void index_fill_kernel_impl(
   launch_kernel<launch_size_nd, launch_bound2>(iter.numel(), loop);
 }
 
-template <typename scalar_t>
+template <typename scalar_t, typename index_t>
 void index_copy_kernel_impl(
   TensorIterator& iter,
   const int64_t dim,
@@ -156,7 +156,7 @@ void index_copy_kernel_impl(
 
   if (!iter.can_use_32bit_indexing()) {
     for (auto& sub_iter : iter.with_32bit_indexing()) {
-      index_copy_kernel_impl<scalar_t>(sub_iter, dim, self_dim_size, self_dim_stride);
+      index_copy_kernel_impl<scalar_t, index_t>(sub_iter, dim, self_dim_size, self_dim_stride);
     }
     return;
   }
@@ -171,7 +171,7 @@ void index_copy_kernel_impl(
     const auto offsets = offset_calc.get(i);
 
     auto* const __restrict__ self_data = reinterpret_cast<scalar_t*>(self_ptr + offsets[0]);
-    auto idx = *reinterpret_cast<int64_t*>(idx_ptr + offsets[1]);
+    auto idx = *reinterpret_cast<index_t*>(idx_ptr + offsets[1]);
     const auto* const __restrict__ source_data = reinterpret_cast<scalar_t*>(source_ptr + offsets[2]);
     CUDA_KERNEL_ASSERT(idx >= 0 && idx < self_dim_size && "index_copy_(): index out of bounds");
 
@@ -213,7 +213,9 @@ static void index_fill_kernel(
     using dtype = OpaqueType<sizeof(scalar_t)>;
     const auto fill_val = source.to<scalar_t>();
     const auto fill_val_opaque = *reinterpret_cast<const dtype*>(&fill_val);
-    index_fill_kernel_impl<dtype>(iter, dim, self_dim_size, self_dim_stride, fill_val_opaque);
+    AT_DISPATCH_INDEX_TYPES(iter.dtype(1), "index_fill_cuda", [&] {
+      index_fill_kernel_impl<dtype, index_t>(iter, dim, self_dim_size, self_dim_stride, fill_val_opaque);
+    });
   });
 }
 
@@ -229,7 +231,9 @@ static void index_copy_kernel(
     at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16, kComplexHalf,
     iter.dtype(), "index_copy_cuda", [&] {
     using dtype = OpaqueType<sizeof(scalar_t)>;
-    index_copy_kernel_impl<dtype>(iter, dim, self_dim_size, self_dim_stride);
+    AT_DISPATCH_INDEX_TYPES(iter.dtype(1), "index_copy_cuda", [&] {
+      index_copy_kernel_impl<dtype, index_t>(iter, dim, self_dim_size, self_dim_stride);
+    });
   });
 }
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2443,7 +2443,7 @@ match :attr:`self`, or an error will be raised.
 
 Args:
     dim (int): dimension along which to index
-    index (LongTensor): indices of :attr:`tensor` to select from
+    index (IntTensor or LongTensor): indices of :attr:`tensor` to select from
     tensor (Tensor): the tensor containing values to copy
 
 Example::
@@ -2470,7 +2470,7 @@ selecting the indices in the order given in :attr:`index`.
 
 Args:
     dim (int): dimension along which to index
-    index (LongTensor): indices of :attr:`self` tensor to fill in
+    index (IntTensor or LongTensor): indices of :attr:`self` tensor to fill in
     value (float): the value to fill with
 
 Example::


### PR DESCRIPTION
Fixes #142090
This PR extends index_fill and index_copy operations to support int32 indices in addition to the existing int64 support:

1. Memory Efficiency and potential performance for handling a large number of indices, particularly when needing to transfer to accelerator backends. In some cases, the compiler may not support 64-bit integers, and in some cases, may cause conflicting casts when used with TorchXLA. I do not see the immediate need to propagate these to the dim input, since it is tied to the APIs and is relatively negligible.
2. Framework interoperability: As mentioned above, this gives more flexibility when working with TorchXLA, since some operations require the same type of physical raw representations for the tensors as the XLA tensors. In some cases, for Neuron, XLA generates S32 types which are not compatible with some operations (e.g. casts) when needing to convert across tensors.
3. Consistency with other APIs, such as index_add and index_select.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10