### PR TITLE
[torch.func] expand stack_module_state's typing

### DIFF
--- a/torch/_functorch/functional_call.py
+++ b/torch/_functorch/functional_call.py
@@ -157,7 +157,7 @@ def functional_call(
 
 @exposed_in("torch.func")
 def stack_module_state(
-    models: List[nn.Module],
+    models: Union[Sequence[nn.Module], nn.ModuleList],
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """stack_module_state(models) -> params, buffers
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142169

Summary:
https://github.com/pytorch/pytorch/pull/141894 made this API actually
typed w.r.t. pyre, which is causing some internal type failures. This PR
expands the typing for stack_module_state to squash those failures.

Test Plan:
- pyre