### PR TITLE
[REFACTOR] Implement AOTDispatchCompiler wrapper

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -41,7 +41,11 @@ from functorch.compile import (
 from functorch.experimental import control_flow
 from torch._decomp import decomposition_table
 from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
-from torch._functorch.aot_autograd import aot_export_joint_simple, aot_export_module
+from torch._functorch.aot_autograd import (
+    aot_export_joint_simple,
+    aot_export_module,
+    AOTDispatchCompiler,
+)
 from torch._higher_order_ops.out_dtype import out_dtype
 from torch._inductor.codecache import compiled_fx_graph_hash
 from torch._inductor.output_code import MockFXGraphCacheOutput
@@ -6825,12 +6829,13 @@ class TestAOTAutogradWithCache(TestAOTAutogradWithDynamo):
     def make_compiler(self, fw_graph_cell):
         mock_inductor_cache = self.inductor_cache
 
-        def compiler(gm, inputs):
+        def compiler(gm, example_inputs):
             nonlocal mock_inductor_cache, fw_graph_cell
-            result = mock_inductor_cache.load(gm, inputs)
+            result = mock_inductor_cache.load(gm, example_inputs)
             fw_graph_cell[0] = gm
             return result
 
+        compiler = AOTDispatchCompiler(MockFXGraphCacheOutput, compiler)
         return compiler
 
     def run_autograd(

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -44,7 +44,7 @@ from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
 from torch._functorch.aot_autograd import (
     aot_export_joint_simple,
     aot_export_module,
-    AOTDispatchCompiler,
+    AOTDispatchCompilerWithOutput,
 )
 from torch._higher_order_ops.out_dtype import out_dtype
 from torch._inductor.codecache import compiled_fx_graph_hash
@@ -6835,7 +6835,7 @@ class TestAOTAutogradWithCache(TestAOTAutogradWithDynamo):
             fw_graph_cell[0] = gm
             return result
 
-        compiler = AOTDispatchCompiler(MockFXGraphCacheOutput, compiler)
+        compiler = AOTDispatchCompilerWithOutput(MockFXGraphCacheOutput, compiler)
         return compiler
 
     def run_autograd(

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -44,7 +44,7 @@ from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
 from torch._functorch.aot_autograd import (
     aot_export_joint_simple,
     aot_export_module,
-    AOTDispatchCompilerWithOutput,
+    SerializableAOTDispatchCompiler,
 )
 from torch._higher_order_ops.out_dtype import out_dtype
 from torch._inductor.codecache import compiled_fx_graph_hash
@@ -6835,7 +6835,7 @@ class TestAOTAutogradWithCache(TestAOTAutogradWithDynamo):
             fw_graph_cell[0] = gm
             return result
 
-        compiler = AOTDispatchCompilerWithOutput(MockFXGraphCacheOutput, compiler)
+        compiler = SerializableAOTDispatchCompiler(MockFXGraphCacheOutput, compiler)
         return compiler
 
     def run_autograd(

--- a/torch/_dynamo/backends/common.py
+++ b/torch/_dynamo/backends/common.py
@@ -9,7 +9,7 @@ import torch
 from torch._dynamo import disable
 from torch._dynamo.exc import TensorifyScalarRestartAnalysis
 from torch._dynamo.utils import counters, defake, flatten_graph_inputs
-from torch._functorch.aot_autograd import aot_module_simplified
+from torch._functorch.aot_autograd import aot_module_simplified, AOTDispatchCompiler
 from torch.utils._python_dispatch import _disable_current_modes
 
 
@@ -45,14 +45,21 @@ class AotAutograd:
             counters["aot_autograd"]["not_ok"] += 1
             return gm
 
-        # OK attempt to compile
+        def wrap_bw_compiler(bw_compiler_fn):
+            def _wrapped_bw_compiler(*args, **kwargs):
+                # stop TorchDynamo from trying to compile our generated backwards pass
+                return disable(disable(bw_compiler_fn)(*args, **kwargs))
 
-        def _wrapped_bw_compiler(*args, **kwargs):
-            # stop TorchDynamo from trying to compile our generated backwards pass
-            return disable(disable(bw_compiler)(*args, **kwargs))
+            return _wrapped_bw_compiler
 
         bw_compiler = self.kwargs.get("bw_compiler") or self.kwargs["fw_compiler"]
-        self.kwargs["bw_compiler"] = _wrapped_bw_compiler
+
+        if isinstance(bw_compiler, AOTDispatchCompiler):
+            bw_compiler.compiler_fn = wrap_bw_compiler(bw_compiler.compiler_fn)
+        else:
+            bw_compiler = wrap_bw_compiler(bw_compiler)
+
+        self.kwargs["bw_compiler"] = bw_compiler
         self.kwargs["inference_compiler"] = (
             self.kwargs.get("inference_compiler") or self.kwargs["fw_compiler"]
         )

--- a/torch/_dynamo/backends/common.py
+++ b/torch/_dynamo/backends/common.py
@@ -11,7 +11,7 @@ from torch._dynamo.exc import TensorifyScalarRestartAnalysis
 from torch._dynamo.utils import counters, defake, flatten_graph_inputs
 from torch._functorch.aot_autograd import (
     aot_module_simplified,
-    AOTDispatchCompilerWithOutput,
+    SerializableAOTDispatchCompiler,
 )
 from torch.utils._python_dispatch import _disable_current_modes
 
@@ -57,7 +57,7 @@ class AotAutograd:
 
         bw_compiler = self.kwargs.get("bw_compiler") or self.kwargs["fw_compiler"]
 
-        if isinstance(bw_compiler, AOTDispatchCompilerWithOutput):
+        if isinstance(bw_compiler, SerializableAOTDispatchCompiler):
             bw_compiler.compiler_fn = wrap_bw_compiler(bw_compiler.compiler_fn)
         else:
             bw_compiler = wrap_bw_compiler(bw_compiler)

--- a/torch/_dynamo/backends/common.py
+++ b/torch/_dynamo/backends/common.py
@@ -9,7 +9,10 @@ import torch
 from torch._dynamo import disable
 from torch._dynamo.exc import TensorifyScalarRestartAnalysis
 from torch._dynamo.utils import counters, defake, flatten_graph_inputs
-from torch._functorch.aot_autograd import aot_module_simplified, AOTDispatchCompiler
+from torch._functorch.aot_autograd import (
+    aot_module_simplified,
+    AOTDispatchCompilerWithOutput,
+)
 from torch.utils._python_dispatch import _disable_current_modes
 
 
@@ -54,7 +57,7 @@ class AotAutograd:
 
         bw_compiler = self.kwargs.get("bw_compiler") or self.kwargs["fw_compiler"]
 
-        if isinstance(bw_compiler, AOTDispatchCompiler):
+        if isinstance(bw_compiler, AOTDispatchCompilerWithOutput):
             bw_compiler.compiler_fn = wrap_bw_compiler(bw_compiler.compiler_fn)
         else:
             bw_compiler = wrap_bw_compiler(bw_compiler)

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -665,6 +665,7 @@ class AOTAutogradCache:
         """
         Load a result from the cache, and reconstruct a runtime wrapper around the object
         """
+
         gm = mod.gm if isinstance(mod, torch._dynamo.utils.GmWrapper) else mod
         with sanitize_gm_for_cache(gm):
             compiled_fn = None

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -465,10 +465,10 @@ class AOTDispatchCompiler(Protocol):
 
 
 # TODO: bikeshed on this name
-class AOTDispatchCompilerWithOutput(AOTDispatchCompiler):
+class SerializableAOTDispatchCompiler(AOTDispatchCompiler):
     """
     Represents an AOTDispatchCompiler that returns an OutputCode, and is
-    therefore cacheable. AOTDispatchCompilerWithOutput always return an OutputCode.
+    therefore cacheable. SerializableAOTDispatchCompiler always return an OutputCode.
     A _CompileFxCallable usually gets converted into an AOTDispatchCompiler after binding all of
     the kwargs in _CompileFxKwargs.
     """
@@ -1141,7 +1141,7 @@ def aot_module_simplified(
     remote = should_use_remote_autograd_cache()
     local = should_use_local_autograd_cache()
     # We only care if the forward will return an OutputCode.
-    if (local or remote) and isinstance(fw_compiler, AOTDispatchCompilerWithOutput):
+    if (local or remote) and isinstance(fw_compiler, SerializableAOTDispatchCompiler):
         compiled_fn = AOTAutogradCache.load(
             dispatch_and_compile,
             mod,

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -54,7 +54,7 @@ from torch._dynamo.utils import (
 from torch._functorch import config as functorch_config
 from torch._functorch.aot_autograd import (
     aot_export_module,
-    AOTDispatchCompiler,
+    AOTDispatchCompilerWithOutput,
     make_boxed_func,
 )
 from torch._inductor.codecache import code_hash, FxGraphCache, output_code_log
@@ -1749,7 +1749,7 @@ def compile_fx(
         fw_compiler: Callable[
             [GraphModule, Sequence[InputType]], OutputCode
         ] = functools.partial(fw_compiler_base, is_inference=False)
-        fw_compiler = AOTDispatchCompiler(OutputCode, fw_compiler)
+        fw_compiler = AOTDispatchCompilerWithOutput(OutputCode, fw_compiler)
 
         if config.freezing and not torch.is_grad_enabled():
             inference_compiler: Callable[..., Any] = functools.partial(
@@ -1763,7 +1763,9 @@ def compile_fx(
             )
         else:
             inference_compiler = functools.partial(fw_compiler_base, is_inference=True)
-            inference_compiler = AOTDispatchCompiler(OutputCode, inference_compiler)
+            inference_compiler = AOTDispatchCompilerWithOutput(
+                OutputCode, inference_compiler
+            )
 
         def partition_fn(
             gm: GraphModule,
@@ -1811,7 +1813,7 @@ def compile_fx(
                         boxed_forward_device_index=forward_device,
                     )
 
-        bw_compiler = AOTDispatchCompiler(OutputCode, bw_compiler)
+        bw_compiler = AOTDispatchCompilerWithOutput(OutputCode, bw_compiler)
 
         fake_mode = detect_fake_mode(
             example_inputs_

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -54,8 +54,8 @@ from torch._dynamo.utils import (
 from torch._functorch import config as functorch_config
 from torch._functorch.aot_autograd import (
     aot_export_module,
-    AOTDispatchCompilerWithOutput,
     make_boxed_func,
+    SerializableAOTDispatchCompiler,
 )
 from torch._inductor.codecache import code_hash, FxGraphCache, output_code_log
 from torch._inductor.cudagraph_utils import BoxedDeviceIndex, PlaceholderInfo
@@ -1749,7 +1749,7 @@ def compile_fx(
         fw_compiler: Callable[
             [GraphModule, Sequence[InputType]], OutputCode
         ] = functools.partial(fw_compiler_base, is_inference=False)
-        fw_compiler = AOTDispatchCompilerWithOutput(OutputCode, fw_compiler)
+        fw_compiler = SerializableAOTDispatchCompiler(OutputCode, fw_compiler)
 
         if config.freezing and not torch.is_grad_enabled():
             inference_compiler: Callable[..., Any] = functools.partial(
@@ -1763,7 +1763,7 @@ def compile_fx(
             )
         else:
             inference_compiler = functools.partial(fw_compiler_base, is_inference=True)
-            inference_compiler = AOTDispatchCompilerWithOutput(
+            inference_compiler = SerializableAOTDispatchCompiler(
                 OutputCode, inference_compiler
             )
 
@@ -1813,7 +1813,7 @@ def compile_fx(
                         boxed_forward_device_index=forward_device,
                     )
 
-        bw_compiler = AOTDispatchCompilerWithOutput(OutputCode, bw_compiler)
+        bw_compiler = SerializableAOTDispatchCompiler(OutputCode, bw_compiler)
 
         fake_mode = detect_fake_mode(
             example_inputs_

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -52,7 +52,11 @@ from torch._dynamo.utils import (
     set_feature_use,
 )
 from torch._functorch import config as functorch_config
-from torch._functorch.aot_autograd import aot_export_module, make_boxed_func
+from torch._functorch.aot_autograd import (
+    aot_export_module,
+    AOTDispatchCompiler,
+    make_boxed_func,
+)
 from torch._inductor.codecache import code_hash, FxGraphCache, output_code_log
 from torch._inductor.cudagraph_utils import BoxedDeviceIndex, PlaceholderInfo
 from torch._inductor.debug import save_args_for_compile_fx_inner
@@ -1663,20 +1667,20 @@ def compile_fx(
         )
 
         def fw_compiler_base(
-            model: GraphModule,
-            example_inputs: List[InputType],
+            gm: GraphModule,
+            example_inputs: Sequence[InputType],
             is_inference: bool,
         ) -> OutputCode:
             with dynamo_utils.dynamo_timed("compile_fx.<locals>.fw_compiler_base"):
                 if is_inference:
                     # partition_fn won't be called
-                    _recursive_joint_graph_passes(model)
+                    _recursive_joint_graph_passes(gm)
 
                 fixed = torch._inductor.utils.num_fw_fixed_arguments(
                     num_example_inputs, len(example_inputs)
                 )
 
-                model_outputs_node = output_node(model)
+                model_outputs_node = output_node(gm)
                 if config.keep_output_stride:
                     model_outputs = pytree.arg_tree_leaves(*model_outputs_node.args)
                     num_model_outputs = len(model_outputs)
@@ -1733,7 +1737,7 @@ def compile_fx(
                     model_outputs_node.meta["user_visible_output_idxs"] = []
 
                 return inner_compile(
-                    model,
+                    gm,
                     example_inputs,
                     static_input_idxs=get_static_input_idxs(fixed),
                     cudagraphs=cudagraphs,
@@ -1742,7 +1746,10 @@ def compile_fx(
                     boxed_forward_device_index=forward_device,
                 )
 
-        fw_compiler = functools.partial(fw_compiler_base, is_inference=False)
+        fw_compiler: Callable[
+            [GraphModule, Sequence[InputType]], OutputCode
+        ] = functools.partial(fw_compiler_base, is_inference=False)
+        fw_compiler = AOTDispatchCompiler(OutputCode, fw_compiler)
 
         if config.freezing and not torch.is_grad_enabled():
             inference_compiler: Callable[..., Any] = functools.partial(
@@ -1756,6 +1763,7 @@ def compile_fx(
             )
         else:
             inference_compiler = functools.partial(fw_compiler_base, is_inference=True)
+            inference_compiler = AOTDispatchCompiler(OutputCode, inference_compiler)
 
         def partition_fn(
             gm: GraphModule,
@@ -1771,14 +1779,14 @@ def compile_fx(
 
         @compile_time_strobelight_meta(phase_name="backward")
         def bw_compiler(
-            model: GraphModule, example_inputs: List[InputType]
+            gm: GraphModule, example_inputs: Sequence[InputType]
         ) -> OutputCode:
             from torch._dynamo.convert_frame import compile_lock
 
             with dynamo_utils.dynamo_timed(
                 "compile_fx.<locals>.bw_compiler"
             ), compile_lock:
-                model_outputs_node = output_node(model)
+                model_outputs_node = output_node(gm)
                 if config.bw_outputs_user_visible:
                     model_outputs = pytree.arg_tree_leaves(*model_outputs_node.args)
                     model_outputs_node.meta["user_visible_output_idxs"] = [
@@ -1789,12 +1797,12 @@ def compile_fx(
                 else:
                     model_outputs_node.meta["user_visible_output_idxs"] = []
 
-                fixed = count_tangents(model)
+                fixed = count_tangents(gm)
                 with config.patch(
                     get_cpp_wrapper_config()
                 ) if config.cpp_wrapper else contextlib.nullcontext():
                     return inner_compile(
-                        model,
+                        gm,
                         example_inputs,
                         static_input_idxs=list(range(fixed)),
                         cudagraphs=cudagraphs,
@@ -1802,6 +1810,8 @@ def compile_fx(
                         graph_id=graph_id,
                         boxed_forward_device_index=forward_device,
                     )
+
+        bw_compiler = AOTDispatchCompiler(OutputCode, bw_compiler)
 
         fake_mode = detect_fake_mode(
             example_inputs_


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #141981
* __->__ #142205

This implements a new wrapper class AOTDispatchCompiler wrapper, which is just a wrapper around a callable that returns an OutputCode. We can then use it in AOTDispatch to decide whether or not to use the cache: if fw_compiler, bw_compiler and inference_compiler are all AOTDispatchCompilers, then we enable caching. 

This type is pretty close to _CompiledFxGraphCallable, except it's not allowed to take any kwargs. Not sure how to consolidate the two ideas together just yet: unfortunately, there's no way to properly annotate the types to make them related. But a lot of the time, the input to this function will be a partially applied _CompiledFxGraphCallable.

This allows the PR above this one to enable AOTAutogradCache everywhere, but not increase instruction count or enable cache on unit tests that use aot_eager or other non inductor compilers.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov