### PR TITLE
[pipelining] forward fix for _validate_schedule

### DIFF
--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -866,14 +866,21 @@ class TestScheduleLowering(TestCase):
 
 class TestValidateSchedule(TestCase):
     def test_valid_schedule(self):
-        actions = {
-            0: [_Action(0, F, 0), _Action(0, B, 0)],
-            1: [_Action(1, F, 0), _Action(1, B, 0)],
-        }
+        schedule_actions = [
+            {
+                0: [_Action(0, F, 0), _Action(0, B, 0)],
+                1: [_Action(1, F, 0), _Action(1, B, 0)],
+            },
+            {
+                0: [_Action(0, F, 0), _Action(0, I, 0), _Action(0, W, 0)],
+                1: [_Action(1, F, 0), _Action(1, I, 0), _Action(1, W, 0)],
+            },
+        ]
         pp_group_size = 2
         num_stages = 2
         num_microbatches = 1
-        _validate_schedule(actions, pp_group_size, num_stages, num_microbatches)
+        for actions in schedule_actions:
+            _validate_schedule(actions, pp_group_size, num_stages, num_microbatches)
 
     def test_invalid_schedule_missing_rank(self):
         actions = {

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -1047,8 +1047,8 @@ def _validate_schedule(
                 stage_actions[s_id][I].add(mb_id)
             elif ctype == W:
                 assert (
-                    mb_id in stage_actions[s_id][B]
-                ), f"Running Backward Weight for stage {s_id}, microbatch {mb_id} without first running Backward"
+                    mb_id in stage_actions[s_id][I]
+                ), f"Running Backward Weight for stage {s_id}, microbatch {mb_id} without first running Backward Input"
                 stage_actions[s_id][W].add(mb_id)
 
     for s_id in stage_actions:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142211
* #142009

https://github.com/pytorch/pytorch/pull/142009 broke CSV loading since it can no longer handle schedules with `I` and `W`. This was caught in the torchtitan tests which loads a custom CSV file using `I` and `W` https://github.com/pytorch/torchtitan/actions/runs/12188167461/job/34000683921?pr=689.

Follow up would be to test a real custom schedule in PyTorch rather than torchtitan. The custom schedule in titan is here:  https://github.com/pytorch/torchtitan/blob/main/test/assets/custom_schedule.csv

cc @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o