### PR TITLE
Back out "[Reland][Environment Variable][5/N] Use thread-safe getenv functions (#140594)"

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.cpp
+++ b/aten/src/ATen/core/dispatch/Dispatcher.cpp
@@ -1,9 +1,10 @@
-#include <ATen/core/PythonOpRegistrationTrampoline.h>
 #include <ATen/core/dispatch/Dispatcher.h>
+#include <ATen/core/PythonOpRegistrationTrampoline.h>
+#include <chrono>
 #include <list>
+#include <sstream>
 #include <utility>
 
-#include <c10/util/env.h>
 #ifdef FBCODE_CAFFE2
 #include <c10/util/static_tracepoint.h>
 #endif
@@ -16,18 +17,18 @@ TORCH_SDT_DEFINE_SEMAPHORE(operator_end)
 #endif
 
 bool show_dispatch_trace() {
-  static const auto envar = c10::utils::get_env("TORCH_SHOW_DISPATCH_TRACE");
+  static auto envar = std::getenv("TORCH_SHOW_DISPATCH_TRACE");
 
-  if (envar.has_value()) {
-    if (envar == "0") {
+  if (envar) {
+    if (strcmp(envar, "0") == 0) {
       return false;
     }
-    if (envar == "1") {
+    if (strcmp(envar, "1") == 0) {
       return true;
     }
     TORCH_WARN(
         "ignoring invalid value for TORCH_SHOW_DISPATCH_TRACE: ",
-        envar.value(),
+        envar,
         " valid values are 0 or 1.");
   }
 

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1364,8 +1364,8 @@ static inline int64_t get_mkldnn_matmul_min_dim() {
       //it's enabled on all Neoverse cpus.
       return is_arm_neoverse() ? 8 : 0;
     }();
-    const auto ptr = c10::utils::get_env("TORCH_MKLDNN_MATMUL_MIN_DIM");
-    return ptr.has_value() ? std::stoi(ptr.value()) : default_min_dim;
+    const char* ptr = std::getenv("TORCH_MKLDNN_MATMUL_MIN_DIM");
+    return ptr != nullptr ? std::atoi(ptr) : default_min_dim;
   }();
   return value;
 }
@@ -1378,8 +1378,8 @@ static inline int64_t get_mkldnn_matmul_min_size() {
       // it's enabled on all Neoverse cpus.
       return is_arm_neoverse() ? 8 * 1024 : 0;
     }();
-    const auto ptr = c10::utils::get_env("TORCH_MKLDNN_MATMUL_MIN_SIZE");
-    return ptr.has_value() ? std::stoi(ptr.value()) : default_min_size;
+    const char* ptr = std::getenv("TORCH_MKLDNN_MATMUL_MIN_SIZE");
+    return ptr != nullptr ? std::atoi(ptr) : default_min_size;
   }();
   return value;
 }

--- a/torch/csrc/lazy/core/config.cpp
+++ b/torch/csrc/lazy/core/config.cpp
@@ -1,4 +1,3 @@
-#include <c10/util/env.h>
 #include <torch/csrc/lazy/core/config.h>
 
 C10_DEFINE_bool(torch_lazy_ir_debug, false, "Enable lazy tensor IR debugging")
@@ -77,9 +76,9 @@ namespace torch::lazy {
 std::string& getLTCForceFallback() {
   static std::string config;
   static bool _ignore = [&]() {
-    auto env = c10::utils::get_env("LTC_FORCE_FALLBACK");
-    if (env) {
-      config = std::move(env.value());
+    char* envptr = std::getenv("LTC_FORCE_FALLBACK");
+    if (envptr) {
+      config = std::string(envptr);
     }
     return true;
   }();

--- a/torch/csrc/lazy/core/debug_util.cpp
+++ b/torch/csrc/lazy/core/debug_util.cpp
@@ -1,4 +1,3 @@
-#include <c10/util/env.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/lazy/core/debug_util.h>
 
@@ -18,8 +17,8 @@ namespace torch::lazy {
 namespace {
 
 std::string GetEnvString(const char* name, const std::string& defval) {
-  const auto env = c10::utils::get_env(name);
-  return env.has_value() ? env.value() : defval;
+  const char* env = std::getenv(name);
+  return env != nullptr ? env : defval;
 }
 
 DebugUtil::GraphFormat DefaultGraphFormat() {

--- a/torch/csrc/lazy/core/shape.cpp
+++ b/torch/csrc/lazy/core/shape.cpp
@@ -1,4 +1,3 @@
-#include <c10/util/env.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/lazy/core/shape.h>
 #include <torch/csrc/lazy/core/tensor.h>
@@ -59,7 +58,7 @@ Shape Shape::with_symbolic_dims(
 }
 
 bool symbolicShapeEnabled() {
-  static const bool enabled = c10::utils::has_env("LTC_ENABLE_SYMBOLIC_SHAPES");
+  static bool enabled = std::getenv("LTC_ENABLE_SYMBOLIC_SHAPES") != nullptr;
   return enabled || FLAGS_ltc_enable_symbolic_shapes;
 }
 


### PR DESCRIPTION
Summary: Failed to write the auto-tune result to `PYTORCH_TUNABLEOP_FILENAME` with this change (empty file) , reverting to unblock.

Test Plan: CI

Differential Revision: D66870750


