### PR TITLE
[BE] Enable Scalar.h compilation on 32-bit system

### DIFF
--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -80,8 +80,9 @@ class C10_API Scalar {
   static_assert(
       sizeof(void*) != 8 || std::is_same_v<long, int64_t>,
       "int64_t is the same as long on 64 bit Linux");
-  template<typename = std::enable_if_t<sizeof(void *) == 8>>
+#if LONG_MAX != INT_MAX
   Scalar(long long vv) : Scalar(vv, true) {}
+#endif  
 #endif
 
   Scalar(uint16_t vv) : Scalar(vv, true) {}

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -80,6 +80,7 @@ class C10_API Scalar {
   static_assert(
       sizeof(void*) != 8 || std::is_same_v<long, int64_t>,
       "int64_t is the same as long on 64 bit Linux");
+  template<typename = std::enable_if_t<sizeof(void *) == 8>>
   Scalar(long long vv) : Scalar(vv, true) {}
 #endif
 

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -82,7 +82,7 @@ class C10_API Scalar {
       "int64_t is the same as long on 64 bit Linux");
 #if LONG_MAX != INT_MAX
   Scalar(long long vv) : Scalar(vv, true) {}
-#endif  
+#endif /* not 32-bit system */
 #endif
 
   Scalar(uint16_t vv) : Scalar(vv, true) {}


### PR DESCRIPTION
By hiding ambiguous Scalar(long long) constructor behind `std::enable_if_t<sizeof(void *) == 8>`

Followup after https://github.com/pytorch/pytorch/pull/141244

Test Plan: Run `printf "#include <c10/core/Scalar.h>\n c10::Scalar x(3);" | gcc -x c++ -std=c++17 -I. -Ibuild - -c` on ARMv7 system.
Before this change it failed with:
```
In file included from <stdin>:1:
./c10/core/Scalar.h:83:3: error: ‘c10::Scalar::Scalar(long long int)’ cannot be overloaded with ‘c10::Scalar::Scalar(int64_t)’
   83 |   Scalar(long long vv) : Scalar(vv, true) {}
      |   ^~~~~~
./c10/core/Scalar.h:50:3: note: previous declaration ‘c10::Scalar::Scalar(int64_t)’
   50 |   Scalar(type vv) : Scalar(vv, true) {}
      |   ^~~~~~
./c10/core/ScalarType.h:288:3: note: in expansion of macro ‘DEFINE_IMPLICIT_CTOR’
  288 |   _(int64_t, Long)                                \
      |   ^
./c10/core/Scalar.h:52:3: note: in expansion of macro ‘AT_FORALL_SCALAR_TYPES_AND7’
   52 |   AT_FORALL_SCALAR_TYPES_AND7(
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```
