### PR TITLE
[pipelining] fix backward_one_chunk when the output of the model is a…

### DIFF
--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -822,7 +822,8 @@ class _PipelineStageBase(ABC):
             # to return to the user in merge_output_chunks, therefore
             # this should be detached to release autograd graph context and free memory earlier
             for t in stage_output:
-                t.detach_()
+                if not t._is_view():  # views are not detachable in-place
+                    t.detach_()
 
         logger.debug("%s Backwarded chunk %s", self.log_prefix, bwd_chunk_id)
 


### PR DESCRIPTION
fixes #142229

if any of ``stage_output`` is a view, it cannot be detached in place. Replacing it with ``t = t.detach()`` or similar would not free the graph for the output given to the user. Detaching the base tensor could cause a side effect.

The same code is used in ``_backward.py`` (https://github.com/pytorch/pytorch/blob/b64a53799312987ac22609a956b3c2befda5a385/torch/distributed/pipelining/_backward.py#L215) but does not seem to cause any issue in my case. Maybe needs some investigation.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o