### PR TITLE
[pt2e][quant] Make move_exported_model_to_train/eval idempotent

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -2029,8 +2029,10 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
 
         # Mock m.recompile() to count how many times it's been called
         m._recompile_count = 0
+
         def _fake_recompile():
             m._recompile_count += 1
+
         m.recompile = _fake_recompile
 
         # Train idempotent

--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -2012,6 +2012,44 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         m.train()
         _assert_ops_are_correct(m, train=True)
 
+    def test_allow_exported_model_train_eval_idempotent(self):
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.bn = torch.nn.BatchNorm2d(3)
+
+            def forward(self, x):
+                x = self.bn(x)
+                return x
+
+        m = M().train()
+        example_inputs = (torch.randn(1, 3, 3, 3),)
+        m = export_for_training(m, example_inputs).module()
+        torch.ao.quantization.allow_exported_model_train_eval(m)
+
+        # Mock m.recompile() to count how many times it's been called
+        m._recompile_count = 0
+        def _fake_recompile():
+            m._recompile_count += 1
+        m.recompile = _fake_recompile
+
+        # Train idempotent
+        m.train()
+        self.assertEqual(m._recompile_count, 0)
+        m.train()
+        self.assertEqual(m._recompile_count, 0)
+
+        # Train -> eval should update the recompile count
+        m.eval()
+        self.assertNotEqual(m._recompile_count, 0)
+        new_count = m._recompile_count
+
+        # Eval idempotent
+        m.eval()
+        self.assertEqual(m._recompile_count, new_count)
+        m.eval()
+        self.assertEqual(m._recompile_count, new_count)
+
     def test_model_is_exported(self):
         m = TestHelperModules.ConvWithBNRelu(relu=True)
         example_inputs = (torch.rand(3, 3, 5, 5),)

--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -2035,22 +2035,24 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
 
         m.recompile = _fake_recompile
 
-        # Train idempotent
+        # First train after export should always recompile
         m.train()
-        self.assertEqual(m._recompile_count, 0)
-        m.train()
-        self.assertEqual(m._recompile_count, 0)
-
-        # Train -> eval should update the recompile count
-        m.eval()
         self.assertNotEqual(m._recompile_count, 0)
-        new_count = m._recompile_count
+        count1 = m._recompile_count
 
-        # Eval idempotent
+        # Train -> train should not recompile
+        m.train()
+        self.assertEqual(m._recompile_count, count1)
+
+        # Train -> eval should recompile
         m.eval()
-        self.assertEqual(m._recompile_count, new_count)
+        self.assertNotEqual(m._recompile_count, count1)
+        count2 = m._recompile_count
+
+        # Eval -> eval should not recompile
         m.eval()
-        self.assertEqual(m._recompile_count, new_count)
+        self.assertEqual(m._recompile_count, count2)
+
 
     def test_model_is_exported(self):
         m = TestHelperModules.ConvWithBNRelu(relu=True)

--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -2053,7 +2053,6 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         m.eval()
         self.assertEqual(m._recompile_count, count2)
 
-
     def test_model_is_exported(self):
         m = TestHelperModules.ConvWithBNRelu(relu=True)
         example_inputs = (torch.rand(3, 3, 5, 5),)

--- a/torch/ao/quantization/pt2e/export_utils.py
+++ b/torch/ao/quantization/pt2e/export_utils.py
@@ -195,7 +195,12 @@ def _move_exported_model_to_eval(model: torch.fx.GraphModule):
 
     This is equivalent to model.eval() but only for certain special ops like dropout, batchnorm.
     QAT users should call this before performing inference on the model.
+
+    This call is idempotent; if the model is already in eval mode, nothing will happen.
     """
+    if not model.training:
+        return model
+    model.training = False
     _replace_dropout(model, train_to_eval=True)
     _replace_batchnorm(model, train_to_eval=True)
     return model
@@ -207,7 +212,12 @@ def _move_exported_model_to_train(model: torch.fx.GraphModule):
 
     This is equivalent to model.train() but only for certain special ops like dropout, batchnorm.
     QAT users should call this before performing training on the model.
+
+    This call is idempotent; if the model is already in train mode, nothing will happen.
     """
+    if model.training:
+        return model
+    model.training = True
     _replace_dropout(model, train_to_eval=False)
     _replace_batchnorm(model, train_to_eval=False)
     return model


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142239

Summary: Before we would recompile the model unnecessarily even
if the model is already in the desired mode. For training
frameworks that assume `model.train()` is idempotent and calls
this before every single training step, this led to a bunch of
tiny graphs and poor performance. This commit makes these calls
no-ops if we're already in the target train/eval mode.

Test Plan:
python test/test_quantization -k TestQuantizePT2E.test_allow_exported_model_train_eval_idempotent