### PR TITLE
[WIP][XPU] Fix path to sycl home if `ONEAPI_ROOT` is defined

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -145,6 +145,8 @@ def _find_sycl_home() -> Optional[str]:
     """Find the OneAPI install path."""
     # Guess #1
     sycl_home = os.environ.get('ONEAPI_ROOT')
+    if sycl_home is not None:
+        sycl_home = os.path.join(sycl_home, "compiler", "latest")
     if sycl_home is None:
         # Guess #2
         icpx_path = shutil.which('icpx')


### PR DESCRIPTION
Fixes:
```bash
FAILED [4.7235s] inductor/test_triton_kernels.py::CustomOpTests::test_autotune_unbacked - torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
FileNotFoundError: [Errno 2] No such file or directory: '/opt/intel/oneapi/bin/icpx'
```
