### PR TITLE
[aoti] Add load_constants to package api

### DIFF
--- a/torch/_inductor/package/package.py
+++ b/torch/_inductor/package/package.py
@@ -247,6 +247,27 @@ class AOTICompiledModel:
     def get_metadata(self) -> Dict[str, str]:
         return self.loader.get_metadata()  # type: ignore[attr-defined]
 
+    def load_constants(
+        self,
+        constants_map: Dict[str, torch.Tensor],
+        *,
+        check_full_update: bool,
+    ) -> None:
+        """
+        Given a mapping of constant fqns to tensors, load the constants into the model.
+        You can use ``get_constant_fqns`` to get the list of constant fqns that
+        are needed in the compiled model.
+
+        Args:
+            constants_map: A mapping of constant fqns to tensors.
+            check_full_update: Whether to add check to see if all the constants
+            are updated and have values.
+        """
+        self.loader.load_constants(constants_map, False, check_full_update)  # type: ignore[attr-defined]
+
+    def get_constant_fqns(self) -> List[str]:
+        return self.loader.get_constant_fqns()  # type: ignore[attr-defined]
+
 
 def load_package(path: Union[str, io.BytesIO], model_name: str = "model") -> AOTICompiledModel:  # type: ignore[type-arg]
     assert isinstance(path, io.BytesIO) or (

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -472,5 +472,39 @@ std::vector<std::string> AOTIModelPackageLoader::get_call_spec() {
   return runner_->get_call_spec();
 }
 
+void AOTIModelPackageLoader::load_constants(
+    std::unordered_map<std::string, at::Tensor>& constants_map,
+    bool use_inactive,
+    bool check_full_update) {
+  std::unordered_map<std::string, std::string> constant_name_to_fqn =
+      runner_->getConstantNamesToOriginalFQNs();
+  std::unordered_map<std::string, at::string> fqn_to_constant_name;
+  for (const auto& it : constant_name_to_fqn) {
+    fqn_to_constant_name.emplace(it.second, it.first);
+  }
+
+  std::unordered_map<std::string, at::Tensor> updated_constants_map;
+  for (const auto& it : constants_map) {
+    if (fqn_to_constant_name.find(it.first) != fqn_to_constant_name.end()) {
+      updated_constants_map.emplace(fqn_to_constant_name[it.first], it.second);
+    } else {
+      throw std::runtime_error("Constant not found: " + it.first);
+    }
+  }
+
+  return runner_->update_constant_buffer(
+      updated_constants_map, use_inactive, check_full_update);
+}
+
+std::vector<std::string> AOTIModelPackageLoader::get_constant_fqns() {
+  std::unordered_map<std::string, std::string> constant_name_to_fqn =
+      runner_->getConstantNamesToOriginalFQNs();
+  std::vector<std::string> constant_fqns;
+  for (const auto& it : constant_name_to_fqn) {
+    constant_fqns.push_back(it.second);
+  }
+  return constant_fqns;
+}
+
 } // namespace torch::inductor
 #endif

--- a/torch/csrc/inductor/aoti_package/model_package_loader.h
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.h
@@ -17,6 +17,11 @@ class TORCH_API AOTIModelPackageLoader {
   std::unordered_map<std::string, std::string> get_metadata();
   std::vector<at::Tensor> run(const std::vector<at::Tensor>& inputs);
   std::vector<std::string> get_call_spec();
+  void load_constants(
+      std::unordered_map<std::string, at::Tensor>& constants_map,
+      bool use_inactive,
+      bool check_full_update);
+  std::vector<std::string> get_constant_fqns();
 
  private:
   std::string temp_dir_;

--- a/torch/csrc/inductor/aoti_package/pybind.cpp
+++ b/torch/csrc/inductor/aoti_package/pybind.cpp
@@ -19,6 +19,8 @@ void initAOTIPackageBindings(PyObject* module) {
       .def(py::init<const std::string&>())
       .def("get_metadata", &AOTIModelPackageLoader::get_metadata)
       .def("run", &AOTIModelPackageLoader::run)
-      .def("get_call_spec", &AOTIModelPackageLoader::get_call_spec);
+      .def("get_call_spec", &AOTIModelPackageLoader::get_call_spec)
+      .def("load_constants", &AOTIModelPackageLoader::load_constants)
+      .def("get_constant_fqns", &AOTIModelPackageLoader::get_constant_fqns);
 }
 } // namespace torch::inductor


### PR DESCRIPTION
Summary:
With the changes in https://github.com/pytorch/pytorch/pull/140755 and https://github.com/pytorch/pytorch/pull/141997, I added a load_constants function to the packaging API. Currently this doesn't work for cpu.

The workflow is something like:

```
ep = torch.export.export(model, example_inputs)
package = torch._inductor.aoti_compile_and_package(ep, inductor_configs=inductor_configs)
compiled = torch._inductor.aoti_load_package(package)

print(compiled.get_constant_fqns())  # see what are the fqns needed/available

compiled.load_constants(new_state_dict, check_full_update=True)  # update the constants in AOTI
```

You can also use the `aot_inductor.package_constants_in_so` config to stop including the constants in the so:
```
package = torch._inductor.aoti_compile_and_package(ep, inductor_configs={`aot_inductor.package_constants_in_so`: False)
compiled = torch._inductor.aoti_load_package(package)
compiled(*inputs)  # segfaults because there are no constants --> we should probably have a better error msg

compiled.load_constants(new_state_dict, check_full_update=True)
compiled(*inputs)
```

Test Plan: `buck2 run @//mode/dev-nosan //caffe2/test/inductor:aot_inductor_package -- -r "test_so_without_weight"  `

Differential Revision: D66796206


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov