### PR TITLE
inductor: remove duplicate triton configs for autotuning

### DIFF
--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -28,7 +28,7 @@ def triton_config(num_stages, num_warps, **kwargs):
 
 def build_rocm_gemm_configs(configs):
     rocm_num_stages = get_backend_num_stages()
-    return tuple((c[0], c[1], c[2], rocm_num_stages, c[4]) for c in configs)
+    return tuple({(c[0], c[1], c[2], rocm_num_stages, c[4]) for c in configs})
 
 
 def filtered_configs(


### PR DESCRIPTION
Summary:
# Why

- sampling the same config multiple times is wasteful, especially on exhaustive
- for AMD we rewrite the configs to have a specific number of stages, which might lead to some configs appearing multiple times

# What

cast the configs, already defined as a tuple, through a set to remove duplicates

Test Plan:
taken from the `mm_kernel_configs` logic in the same file
```
>>> mm_kernel_configs = [        {"config": (BLOCK_M, BLOCK_N, BLOCK_K, num_stages, num_warps), "cond": True}        for BLOCK_M, BLOCK_N, BLOCK_K in itertools.product(            [16, 32, 64, 128, 256], repeat=3        )        for num_stages in [1, 2, 3, 4, 5]        for num_warps in [2, 4, 8]    ]
>>> configs = [c['config'] for c in mm_kernel_configs]
>>> a = tuple((c[0], c[1], c[2], 0, c[4]) for c in configs)
>>> len(set(a))
375
>>> len(a)
1875
>>>
```

Differential Revision: D66893774




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov