### PR TITLE
Replace reduce(operator.mul) with math.prod for computing product of dimensions

### DIFF
--- a/torch/autograd/_functions/utils.py
+++ b/torch/autograd/_functions/utils.py
@@ -1,6 +1,6 @@
 # mypy: allow-untyped-defs
-import operator
-from functools import reduce
+import math
+
 
 
 def maybe_view(tensor, size, check_same_size=True):
@@ -40,8 +40,8 @@ def check_onnx_broadcast(dims1, dims2):
     supported = True
     len1 = len(dims1)
     len2 = len(dims2)
-    numel1 = reduce(operator.mul, dims1)
-    numel2 = reduce(operator.mul, dims2)
+    numel1 = math.prod(dims1)
+    numel2 = math.prod(dims2)
     if len1 < len2:
         broadcast = True
         if numel2 != 1:

--- a/torch/autograd/_functions/utils.py
+++ b/torch/autograd/_functions/utils.py
@@ -2,7 +2,6 @@
 import math
 
 
-
 def maybe_view(tensor, size, check_same_size=True):
     if check_same_size and tensor.size() == size:
         return tensor


### PR DESCRIPTION
Replaced `reduce(operator.mul, dims)` with `math.prod(dims)` in `check_onnx_broadcast` function within `torch/autograd/_functions/utils.py`.

This change improves readability and adopts modern Python features.

Fixes #140888
