### PR TITLE
Some workflows to use oidc instead of AWS keys

### DIFF
--- a/.github/workflows/nightly-s3-uploads.yml
+++ b/.github/workflows/nightly-s3-uploads.yml
@@ -20,6 +20,7 @@ jobs:
   upload-stats-to-s3:
     if: github.repository_owner == 'pytorch'
     runs-on: ubuntu-22.04
+    environment: upload-stats
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main

--- a/.github/workflows/nightly-s3-uploads.yml
+++ b/.github/workflows/nightly-s3-uploads.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Authenticate with AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::749337293305:role/gha_upload_external_contrib_stats
+          role-to-assume: arn:aws:iam::308535385114:role/gha_upload_external_contrib_stats
           aws-region: us-east-1
 
       - name: Upload external contribution stats

--- a/.github/workflows/nightly-s3-uploads.yml
+++ b/.github/workflows/nightly-s3-uploads.yml
@@ -14,8 +14,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
-jobs:
+permissions:
+  id-token: write
 
+jobs:
   upload-stats-to-s3:
     if: github.repository_owner == 'pytorch'
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly-s3-uploads.yml
+++ b/.github/workflows/nightly-s3-uploads.yml
@@ -4,10 +4,10 @@ on:
   schedule:
     # Choose a random time near midnight PST because it may be delayed if there are high loads
     - cron:  37 7 * * *
-  pull_request:
-    paths:
-      - 'tools/stats/upload_external_contrib_stats.py'
-      - '.github/workflows/nightly-s3-uploads.yml'
+  # pull_request:
+  #   paths:
+  #     - 'tools/stats/upload_external_contrib_stats.py'
+  #     - '.github/workflows/nightly-s3-uploads.yml'
   push:
 
 concurrency:

--- a/.github/workflows/nightly-s3-uploads.yml
+++ b/.github/workflows/nightly-s3-uploads.yml
@@ -4,11 +4,10 @@ on:
   schedule:
     # Choose a random time near midnight PST because it may be delayed if there are high loads
     - cron:  37 7 * * *
-  # pull_request:
-  #   paths:
-  #     - 'tools/stats/upload_external_contrib_stats.py'
-  #     - '.github/workflows/nightly-s3-uploads.yml'
-  push:
+  pull_request:
+    paths:
+      - 'tools/stats/upload_external_contrib_stats.py'
+      - '.github/workflows/nightly-s3-uploads.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/nightly-s3-uploads.yml
+++ b/.github/workflows/nightly-s3-uploads.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'tools/stats/upload_external_contrib_stats.py'
       - '.github/workflows/nightly-s3-uploads.yml'
+  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
@@ -18,7 +19,6 @@ jobs:
   upload-stats-to-s3:
     if: github.repository_owner == 'pytorch'
     runs-on: ubuntu-22.04
-    environment: upload-stats
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
@@ -34,12 +34,16 @@ jobs:
       - run: |
           pip3 install requests==2.32.2 boto3==1.35.42
 
+      - name: Authenticate with AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::749337293305:role/gha_upload_external_contrib_stats
+          aws-region: us-east-1
+
       - name: Upload external contribution stats
         uses: nick-fields/retry@v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         with:
           timeout_minutes: 10
           max_attempts: 10

--- a/.github/workflows/upload_test_stats_intermediate.yml
+++ b/.github/workflows/upload_test_stats_intermediate.yml
@@ -11,7 +11,6 @@ jobs:
   intermediate_upload_test_stats:
     name: Intermediate upload test stats for ${{ inputs.workflow_id }}
     runs-on: ubuntu-22.04
-    environment: upload-stats
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
@@ -27,10 +26,14 @@ jobs:
       - run: |
           pip3 install requests==2.32.2 boto3==1.35.42
 
+      - name: Authenticate with AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::749337293305:role/gha_upload_test_stats_intermediate_workflow
+          aws-region: us-east-1
+
       - name: Upload test stats
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_RUN_ID: ${{ inputs.workflow_id }}
         run: |

--- a/.github/workflows/upload_test_stats_intermediate.yml
+++ b/.github/workflows/upload_test_stats_intermediate.yml
@@ -14,6 +14,7 @@ jobs:
   intermediate_upload_test_stats:
     name: Intermediate upload test stats for ${{ inputs.workflow_id }}
     runs-on: ubuntu-22.04
+    environment: upload-stats
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main

--- a/.github/workflows/upload_test_stats_intermediate.yml
+++ b/.github/workflows/upload_test_stats_intermediate.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Authenticate with AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::749337293305:role/gha_upload_test_stats_intermediate_workflow
+          role-to-assume: arn:aws:iam::308535385114:role/gha_upload_test_stats_intermediate_workflow
           aws-region: us-east-1
 
       - name: Upload test stats

--- a/.github/workflows/upload_test_stats_intermediate.yml
+++ b/.github/workflows/upload_test_stats_intermediate.yml
@@ -7,6 +7,9 @@ on:
         description: workflow_id of the run
         required: true
 
+permissions:
+  id-token: write
+
 jobs:
   intermediate_upload_test_stats:
     name: Intermediate upload test stats for ${{ inputs.workflow_id }}


### PR DESCRIPTION
Roles defined in https://github.com/pytorch-labs/pytorch-gha-infra/pull/563

With this, I think we can get rid of the AWS credentials in the upload-stats environment

Untestable because I can't add branches to the upload-stats environment