### PR TITLE
Add missing py::bytes to pybind_utils tryToInferType

### DIFF
--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -390,6 +390,9 @@ inline InferredType tryToInferType(py::handle input) {
     return InferredType(FloatType::get());
   } else if (PyComplex_CheckExact(input.ptr())) {
     return InferredType(ComplexType::get());
+  } else if (py::isinstance<py::bytes>(input)) {
+    // NOTE: We may need a ByteType in the future
+    return InferredType(StringType::get());
   } else if (py::isinstance<py::str>(input)) {
     return InferredType(StringType::get());
   } else if (THPLayout_Check(input.ptr())) {


### PR DESCRIPTION
I'm not sure what the best way to fix this is, but this does unbreak an internal test.

Test Plan: Sandcastle

Reviewed By: itamaro





cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel