### PR TITLE
[dynamo] Expand support of enum attribute access

### DIFF
--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 from .. import variables
 from ..current_scope_id import current_scope_id
 from ..exc import unimplemented
-from ..guards import GuardBuilder, install_guard
 from ..source import AttrSource, Source
 from ..utils import istype
 
@@ -320,18 +319,19 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         raise NotImplementedError
 
     def const_getattr(self, tx: "InstructionTranslator", name: str) -> Any:
-        """getattr(self, name) returning a python constant"""
+        """
+        This method implements `getattr(object_represented_by_self, name)` and
+        returns a python object, while accounting for any side-effect. In most
+        cases the override will be for constant-like object with the default
+        side-effect-free `__getattr__`.
+        """
         raise NotImplementedError
 
     def var_getattr(self, tx: "InstructionTranslator", name: str) -> "VariableTracker":
         """getattr(self, name) returning a new variable"""
         value = self.const_getattr(tx, name)
-        if not variables.ConstantVariable.is_literal(value):
-            raise NotImplementedError
         source = self.source and AttrSource(self.source, name)
-        if source:
-            install_guard(source.make_guard(GuardBuilder.CONSTANT_MATCH))
-        return variables.ConstantVariable.create(value, source=source)
+        return VariableTracker.build(tx, value, source)
 
     def is_proxy(self):
         try:

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -7,7 +7,7 @@ import torch
 from torch._dynamo.source import GetItemSource
 
 from .. import variables
-from ..exc import unimplemented, UserError, UserErrorType
+from ..exc import unimplemented
 from ..utils import common_constant_types, istype, np
 from .base import typestr, VariableTracker
 
@@ -110,10 +110,7 @@ its type to `common_constant_types`.
             raise NotImplementedError from e
 
     def const_getattr(self, tx: "InstructionTranslator", name):
-        member = getattr(self.value, name)
-        if callable(member):
-            raise NotImplementedError
-        return member
+        return getattr(self.value, name)
 
     def call_method(
         self,
@@ -220,7 +217,4 @@ class EnumVariable(VariableTracker):
         return self.value
 
     def const_getattr(self, tx: "InstructionTranslator", name):
-        member = getattr(self.value, name)
-        if callable(member):
-            raise NotImplementedError
-        return member
+        return getattr(self.value, name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142268
* #142267

This patch changes `EnumVariable` to support access to all types of
attributes, not just non-callable literals.

Fixes #142050.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames