### PR TITLE
[ROCm] TunableOp use thread-safe getenv functions

### DIFF
--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -433,8 +433,13 @@ void TuningContext::EnableTunableOp(bool value) {
 }
 
 bool TuningContext::IsTunableOpEnabled() const {
+<<<<<<< HEAD
   static const char *env = std::getenv("PYTORCH_TUNABLEOP_ENABLED");
   if (env != nullptr && strcmp(env, "1") == 0) {
+=======
+  static const bool eval = c10::utils::get_env("PYTORCH_TUNABLEOP_ENABLED") == "1";
+  if (eval) {
+>>>>>>> 72c632c4a32 (Fix TunableOp environment variables due to recent breakage after switch to c10::utils::get_env.)
     return true;
   }
   return enable_;
@@ -460,16 +465,26 @@ void TuningContext::EnableRecordUntuned(bool value) {
 }
 
 bool TuningContext::IsTuningEnabled() const {
+<<<<<<< HEAD
   static const char *env = std::getenv("PYTORCH_TUNABLEOP_TUNING");
   if (env != nullptr && strcmp(env, "0") == 0) {
+=======
+  static const bool eval = c10::utils::get_env("PYTORCH_TUNABLEOP_TUNING") == "0";
+  if (eval) {
+>>>>>>> 72c632c4a32 (Fix TunableOp environment variables due to recent breakage after switch to c10::utils::get_env.)
     return false;
   }
   return tuning_enable_;
 }
 
 bool TuningContext::IsRecordUntunedEnabled() const {
+<<<<<<< HEAD
   static const char *env = std::getenv("PYTORCH_TUNABLEOP_RECORD_UNTUNED");
   if (env != nullptr && strcmp(env, "1") == 0) {
+=======
+  static const bool eval = c10::utils::get_env("PYTORCH_TUNABLEOP_RECORD_UNTUNED") == "1";
+  if (eval) {
+>>>>>>> 72c632c4a32 (Fix TunableOp environment variables due to recent breakage after switch to c10::utils::get_env.)
     return true;
   }
   return record_untuned_enable_;

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -434,13 +434,8 @@ void TuningContext::EnableTunableOp(bool value) {
 }
 
 bool TuningContext::IsTunableOpEnabled() const {
-<<<<<<< HEAD
-  static const char *env = std::getenv("PYTORCH_TUNABLEOP_ENABLED");
-  if (env != nullptr && strcmp(env, "1") == 0) {
-=======
   static const bool eval = c10::utils::get_env("PYTORCH_TUNABLEOP_ENABLED") == "1";
   if (eval) {
->>>>>>> 72c632c4a32 (Fix TunableOp environment variables due to recent breakage after switch to c10::utils::get_env.)
     return true;
   }
   return enable_;
@@ -466,26 +461,16 @@ void TuningContext::EnableRecordUntuned(bool value) {
 }
 
 bool TuningContext::IsTuningEnabled() const {
-<<<<<<< HEAD
-  static const char *env = std::getenv("PYTORCH_TUNABLEOP_TUNING");
-  if (env != nullptr && strcmp(env, "0") == 0) {
-=======
   static const bool eval = c10::utils::get_env("PYTORCH_TUNABLEOP_TUNING") == "0";
   if (eval) {
->>>>>>> 72c632c4a32 (Fix TunableOp environment variables due to recent breakage after switch to c10::utils::get_env.)
     return false;
   }
   return tuning_enable_;
 }
 
 bool TuningContext::IsRecordUntunedEnabled() const {
-<<<<<<< HEAD
-  static const char *env = std::getenv("PYTORCH_TUNABLEOP_RECORD_UNTUNED");
-  if (env != nullptr && strcmp(env, "1") == 0) {
-=======
   static const bool eval = c10::utils::get_env("PYTORCH_TUNABLEOP_RECORD_UNTUNED") == "1";
   if (eval) {
->>>>>>> 72c632c4a32 (Fix TunableOp environment variables due to recent breakage after switch to c10::utils::get_env.)
     return true;
   }
   return record_untuned_enable_;

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -13,6 +13,7 @@
 #include <ATen/cuda/tunable/Tunable.h>
 #include <c10/util/Exception.h>
 #include <c10/util/StringUtil.h>
+#include <c10/util/env.h>
 #include <torch/version.h>
 
 #ifndef _WIN32

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -493,8 +493,8 @@ bool TuningContext::IsRecordUntunedEnabled() const {
 
 std::ofstream& TuningContext::GetUntunedFile(){
   if (!untuned_file_.is_open()) {
-    const char *env = std::getenv("PYTORCH_TUNABLEOP_UNTUNED_FILENAME");
-    std::string filename = (env == nullptr) ? "tunableop_untuned.csv" : env;
+    const auto env = c10::utils::get_env("PYTORCH_TUNABLEOP_UNTUNED_FILENAME");
+    std::string filename = (!env.has_value()) ? "tunableop_untuned.csv" : env.value();
 
     std::string device = c10::str(int(c10::cuda::current_device()));
     std::size_t found = filename.rfind('.');
@@ -531,9 +531,9 @@ void TuningContext::SetMaxTuningDurationMs(int max_duration_ms) {
 }
 
 int TuningContext::GetMaxTuningDurationMs() const {
-  static const char *env = std::getenv("PYTORCH_TUNABLEOP_MAX_TUNING_DURATION_MS");
-  if (env != nullptr) {
-    int val = atoi(env);
+  static const auto env = c10::utils::get_env("PYTORCH_TUNABLEOP_MAX_TUNING_DURATION_MS");
+  if (env.has_value()) {
+    int val = stoi(env.value());
     return val < 0 ? 0 : val;
   }
   return max_tuning_duration_ms_;
@@ -544,9 +544,9 @@ void TuningContext::SetMaxTuningIterations(int max_iter) {
 }
 
 int TuningContext::GetMaxTuningIterations() const {
-  static const char *env = std::getenv("PYTORCH_TUNABLEOP_MAX_TUNING_ITERATIONS");
-  if (env != nullptr) {
-    int val = atoi(env);
+  static const auto env = c10::utils::get_env("PYTORCH_TUNABLEOP_MAX_TUNING_ITERATIONS");
+  if (env.has_value()) {
+    int val = stoi(env.value());
     return val < 0 ? 0 : val;
   }
   return max_tuning_iterations_;
@@ -557,9 +557,9 @@ void TuningContext::SetMaxWarmupDurationMs(int max_duration_ms) {
 }
 
 int TuningContext::GetMaxWarmupDurationMs() const {
-  static const char *env = std::getenv("PYTORCH_TUNABLEOP_MAX_WARMUP_DURATION_MS");
-  if (env != nullptr) {
-    int val = atoi(env);
+  static const auto env = c10::utils::get_env("PYTORCH_TUNABLEOP_MAX_WARMUP_DURATION_MS");
+  if (env.has_value()) {
+    int val = stoi(env.value());
     return val < 0 ? 0 : val;
   }
   return max_warmup_duration_ms_;
@@ -570,9 +570,9 @@ void TuningContext::SetMaxWarmupIterations(int max_iter) {
 }
 
 int TuningContext::GetMaxWarmupIterations() const {
-  static const char *env = std::getenv("PYTORCH_TUNABLEOP_MAX_WARMUP_ITERATIONS");
-  if (env != nullptr) {
-    int val = atoi(env);
+  static const auto env = c10::utils::get_env("PYTORCH_TUNABLEOP_MAX_WARMUP_ITERATIONS");
+  if (env.has_value()) {
+    int val = stoi(env.value());
     return val < 0 ? 0 : val;
   }
   return max_warmup_iterations_;
@@ -583,8 +583,8 @@ void TuningContext::EnableICacheFlush(bool value) {
 }
 
 bool TuningContext::IsICacheFlushEnabled() const {
-  static const char *env = std::getenv("PYTORCH_TUNABLEOP_ICACHE_FLUSH_ENABLED");
-  if (env != nullptr && strcmp(env, "0") == 0) {
+  static const auto env = c10::utils::get_env("PYTORCH_TUNABLEOP_ICACHE_FLUSH_ENABLED");
+  if (env == "0") {
     return false;
   }
   return icache_flush_;
@@ -595,10 +595,10 @@ void TuningContext::SetRotatingBufferSize(int size) {
 }
 
 int TuningContext::GetRotatingBufferSize() const {
-  static const char *env = std::getenv("PYTORCH_TUNABLEOP_ROTATING_BUFFER_SIZE");
-  if (env != nullptr) {
+  static const auto env = c10::utils::get_env("PYTORCH_TUNABLEOP_ROTATING_BUFFER_SIZE");
+  if (env.has_value()) {
     constexpr int MB = 1024 * 1024;
-    int val = atoi(env);
+    int val = stoi(env.value());
     return val < 0 ? 0 : val * MB;  // env var is specified as MB, returned as bytes
   }
   else {
@@ -618,8 +618,8 @@ TuningResultsManager& TuningContext::GetTuningResultsManager() {
     manager_initialized_ = true;
     if (GetFilename().empty()) {
       // if SetFilename() was not already called, call it now with the default or env var
-      const char *env = std::getenv("PYTORCH_TUNABLEOP_FILENAME");
-      std::string filename = (env == nullptr) ? "tunableop_results.csv" : env;
+      const auto env = c10::utils::get_env("PYTORCH_TUNABLEOP_FILENAME");
+      std::string filename = (!env.has_value()) ? "tunableop_results.csv" : env.value();
       SetFilename(filename, true);
     }
     auto filename = GetFilename();

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5124,7 +5124,12 @@ class TestLinalg(TestCase):
         ordinal = torch.cuda.current_device()
         filename = f"tunableop_results{ordinal}.csv"
 
-        mp.set_start_method("spawn")
+        # force=True needed according to:
+        # https://docs.python.org/3/library/multiprocessing.html#multiprocessing.set_start_method
+        # This is because a different test in this process could have
+        # already set the start method
+        mp.set_start_method("spawn", force=True)
+
         p = mp.Process(target=tunableop_matmul, args=(device, dtype))
         p.start()
         p.join()

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -67,16 +67,17 @@ def set_tunableop_defaults():
     torch.cuda.tunable.set_max_tuning_duration(30)
     torch.cuda.tunable.set_max_tuning_iterations(100)
 
-def tunableop_matmul(filename, device, dtype):
+def tunableop_matmul(device, dtype):
     # Helper function to test TunableOp in a subprocess
     # requires helper function since lambda function
     # not supported by multiprocessing module
-    torch.cuda.tunable.enable(True)
+    import os
+    os.environ["PYTORCH_TUNABLEOP_ENABLED"] = "1"
     torch.cuda.tunable.set_max_tuning_duration(1)
-    torch.cuda.tunable.set_filename(filename)
     A = torch.randn((17, 17), device=device, dtype=dtype)
     B = torch.randn((17, 17), device=device, dtype=dtype)
     C = torch.matmul(A, B)
+    del os.environ["PYTORCH_TUNABLEOP_ENABLED"]
 
 class TestLinalg(TestCase):
     def setUp(self):
@@ -5124,7 +5125,7 @@ class TestLinalg(TestCase):
         filename = f"tunableop_results{ordinal}.csv"
 
         mp.set_start_method("spawn")
-        p = mp.Process(target=tunableop_matmul, args=(filename, device, dtype))
+        p = mp.Process(target=tunableop_matmul, args=(device, dtype))
         p.start()
         p.join()
 


### PR DESCRIPTION
Fixes #142403 

~~PR fixes breakage due to this commit
https://github.com/pytorch/pytorch/commit/8cd7ad8b48a187df36bdc9ac1fcaf25db950eed6~~

PR is a partial reland of this https://github.com/pytorch/pytorch/pull/140594 with a unit test.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang