### PR TITLE
[DeviceMesh] Call no_dispatch before doing tensor slicing in DeviceMesh

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -770,6 +770,7 @@ class TestMeshEnv(DTensorTestBase):
             tp_mesh = mesh_2d["TP"]
             dp_tp_mesh = mesh_2d["DP", "TP"]
 
+
 class DeviceMeshCollectiveTest(DTensorTestBase):
     @property
     def world_size(self):

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -4,6 +4,7 @@ import os
 
 import torch
 import torch.distributed._functional_collectives as funcol
+from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.distributed._tensor import DTensor
 from torch.distributed.device_mesh import _mesh_resources, DeviceMesh, init_device_mesh
 from torch.distributed.distributed_c10d import (
@@ -756,6 +757,18 @@ class TestMeshEnv(DTensorTestBase):
             all(submesh.mesh.numel() == 2 for submesh in all_submeshes), True
         )
 
+    @with_comms
+    def test_mesh_slice_fake_tensor_mode(self):
+        mesh_shape = (2, self.world_size // 2)
+        mesh_dim_names = ("DP", "TP")
+        mesh_2d = init_device_mesh(
+            self.device_type, mesh_shape, mesh_dim_names=mesh_dim_names
+        )
+
+        with FakeTensorMode():
+            dp_mesh = mesh_2d["DP"]
+            tp_mesh = mesh_2d["TP"]
+            dp_tp_mesh = mesh_2d["DP", "TP"]
 
 class DeviceMeshCollectiveTest(DTensorTestBase):
     @property

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -712,10 +712,7 @@ else:
                 slice_mesh_dims = _mesh_resources._get_slice_mesh_dims(
                     self, mesh_dim_names
                 )
-                # Cannot import it too early because it is going to cause a
-                # circular dependency.
-                from torch.utils._mode_utils import no_dispatch
-                with no_dispatch():
+                with torch._subclasses.fake_tensor.unset_fake_temporarily():
                     submesh = _mesh_resources.create_sub_mesh(
                         self, mesh_dim_names, slice_mesh_dims
                     )

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -712,6 +712,15 @@ else:
                 slice_mesh_dims = _mesh_resources._get_slice_mesh_dims(
                     self, mesh_dim_names
                 )
+                # When using FakeTensorMode to trace the model, `create_sub_mesh()` will
+                # fail as it will require a real tensor to manipulate.
+                # `unset_fake_temporarily()` will allow us to materialize the tensors
+                # within `_mesh_resources`, which should not affect modling.
+                #
+                # Note that this should be orthogonal to torch.compile(). But whether
+                # we can compile device_mesh `slicing` (no graph break) is not verified
+                # yet and need a follow-up,
+                # TODO: compiler + device_mesh slicing.
                 with torch._subclasses.fake_tensor.unset_fake_temporarily():
                     submesh = _mesh_resources.create_sub_mesh(
                         self, mesh_dim_names, slice_mesh_dims

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -712,9 +712,13 @@ else:
                 slice_mesh_dims = _mesh_resources._get_slice_mesh_dims(
                     self, mesh_dim_names
                 )
-                submesh = _mesh_resources.create_sub_mesh(
-                    self, mesh_dim_names, slice_mesh_dims
-                )
+                # Cannot import it too early because it is going to cause a
+                # circular dependency.
+                from torch.utils._mode_utils import no_dispatch
+                with no_dispatch():
+                    submesh = _mesh_resources.create_sub_mesh(
+                        self, mesh_dim_names, slice_mesh_dims
+                    )
                 return submesh
 
         def get_group(self, mesh_dim: Optional[Union[int, str]] = None) -> ProcessGroup:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142287

Summary:
DeviceMesh's tensor operation is a control plane operation not data plane and should not be affected by FakeTensorMode.

cc @H-Huang @awgu @kwen2501 @wanchaol @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @tianyu-l @XilunWu