### PR TITLE
Respect ROCR_VISIBLE_DEVICES on AMD GPU device discovery

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3318,7 +3318,7 @@ print(f"{torch.cuda.device_count()}")
             {"CUDA_VISIBLE_DEVICES": None, "HIP_VISIBLE_DEVICES": "0"},
             {"CUDA_VISIBLE_DEVICES": "0,1,2,3", "HIP_VISIBLE_DEVICES": "0"},
             {"ROCR_VISIBLE_DEVICES": "1,2,3", "HIP_VISIBLE_DEVICES": "0"},
-            {"ROCR_VISIBLE_DEVICES": "0"},
+            {"ROCR_VISIBLE_DEVICES": "0", "HIP_VISIBLE_DEVICES": None},
         ]
 
         for env_config in custom_envs:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3317,6 +3317,8 @@ print(f"{torch.cuda.device_count()}")
             {"CUDA_VISIBLE_DEVICES": "0", "HIP_VISIBLE_DEVICES": None},
             {"CUDA_VISIBLE_DEVICES": None, "HIP_VISIBLE_DEVICES": "0"},
             {"CUDA_VISIBLE_DEVICES": "0,1,2,3", "HIP_VISIBLE_DEVICES": "0"},
+            {"ROCR_VISIBLE_DEVICES": "1,2,3", "HIP_VISIBLE_DEVICES": "0"},
+            {"ROCR_VISIBLE_DEVICES": "0"},
         ]
 
         for env_config in custom_envs:

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -665,7 +665,6 @@ def _parse_visible_devices() -> Union[List[int], List[str]]:
             if rocr_devices is not None:
                 var = ",".join(str(i) for i in range(max_length))
 
-
     if var is None:
         return list(range(64))
 

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -645,15 +645,26 @@ def set_stream(stream: Stream):
 def _parse_visible_devices() -> Union[List[int], List[str]]:
     r"""Parse CUDA_VISIBLE_DEVICES environment variable."""
     var = os.getenv("CUDA_VISIBLE_DEVICES")
+    max_length = None
 
     if torch.version.hip:
         hip_devices = os.getenv("HIP_VISIBLE_DEVICES")
+        rocr_devices = os.getenv("ROCR_VISIBLE_DEVICES")
+
+        if rocr_devices is not None:
+            # Mostly required for ROCm to make sure ROCr visible devices
+            # is respected, this ensures we do not return a list of devices
+            # that exceeds the total available supplied via ROCR_VISIBLE_DEVICES
+            max_length = len(rocr_devices.split(","))
+
         if hip_devices is not None:
             var = hip_devices
         else:
-            hip_devices = os.getenv("ROCR_VISIBLE_DEVICES")
-            if hip_devices is not None:
-                var = hip_devices
+            # If rocr visible devices is set without HIP_VISIBLE_DEVICES
+            # Then form an ordered list of max_length 0,1,...
+            if rocr_devices is not None:
+                var = ",".join(str(i) for i in range(max_length))
+
 
     if var is None:
         return list(range(64))
@@ -689,6 +700,8 @@ def _parse_visible_devices() -> Union[List[int], List[str]]:
     # which makes `1gpu2,2ampere` is equivalent to `1,2`
     rc: List[int] = []
     for elem in var.split(","):
+        if len(rc) == max_length:
+            break
         x = _strtoul(elem.strip())
         # Repeated ordinal results in empty set
         if x in rc:

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -657,12 +657,10 @@ def _parse_visible_devices() -> Union[List[int], List[str]]:
         if rocr_devices is not None:
             rocr_count = len(rocr_devices.split(","))
             if hip_devices is not None:
-                if hip_devices.startswith("GPU-"):
-                    raise RuntimeError(
-                        "Cannot specify both ROCR_VISIBLE_DEVICES "
-                        "and HIP_VISIBLE_DEVICES using UUIDs"
-                    )
-                if any(int(dev) >= rocr_count for dev in hip_devices.split(",")):
+                # sanity check if ROCR env var set and HIP env var not having UUIDs
+                if not hip_devices.startswith("GPU-") and any(
+                    int(dev) >= rocr_count for dev in hip_devices.split(",")
+                ):
                     raise RuntimeError(
                         "HIP_VISIBLE_DEVICES out of bounds index "
                         "after applying ROCR_VISIBLE_DEVICES"

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -645,7 +645,6 @@ def set_stream(stream: Stream):
 def _parse_visible_devices() -> Union[List[int], List[str]]:
     r"""Parse CUDA_VISIBLE_DEVICES environment variable."""
     var = os.getenv("CUDA_VISIBLE_DEVICES")
-    max_length = None
 
     if torch.version.hip:
         hip_devices = os.getenv("HIP_VISIBLE_DEVICES")
@@ -655,15 +654,18 @@ def _parse_visible_devices() -> Union[List[int], List[str]]:
             # Mostly required for ROCm to make sure ROCr visible devices
             # is respected, this ensures we do not return a list of devices
             # that exceeds the total available supplied via ROCR_VISIBLE_DEVICES
-            max_length = len(rocr_devices.split(","))
+            var = rocr_devices
 
         if hip_devices is not None:
-            var = hip_devices
-        else:
-            # If rocr visible devices is set without HIP_VISIBLE_DEVICES
-            # Then form an ordered list of max_length 0,1,...
+            # If ROCr devices have been set, the hip visible devices would
+            # be a subset of those. HIP_VISIBLE_DEVICES can only contain
+            # integer indices so we can use the ROCr visible devices as a key
             if rocr_devices is not None:
-                var = ",".join(str(i) for i in range(max_length))
+                hip_device_list = [int(dev) for dev in hip_devices.split(",")]
+                rocr_device_list = rocr_devices.split(",")
+                var = ",".join(rocr_device_list[dev] for dev in hip_device_list)
+            else:
+                var = hip_devices
 
     if var is None:
         return list(range(64))
@@ -699,8 +701,6 @@ def _parse_visible_devices() -> Union[List[int], List[str]]:
     # which makes `1gpu2,2ampere` is equivalent to `1,2`
     rc: List[int] = []
     for elem in var.split(","):
-        if len(rc) == max_length:
-            break
         x = _strtoul(elem.strip())
         # Repeated ordinal results in empty set
         if x in rc:

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -650,6 +650,10 @@ def _parse_visible_devices() -> Union[List[int], List[str]]:
         hip_devices = os.getenv("HIP_VISIBLE_DEVICES")
         if hip_devices is not None:
             var = hip_devices
+        else:
+            hip_devices = os.getenv("ROCR_VISIBLE_DEVICES")
+            if hip_devices is not None:
+                var = hip_devices
 
     if var is None:
         return list(range(64))

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -663,7 +663,7 @@ def _parse_visible_devices() -> Union[List[int], List[str]]:
             if rocr_devices is not None:
                 hip_device_list = [int(dev) for dev in hip_devices.split(",")]
                 rocr_device_list = rocr_devices.split(",")
-                var = ",".join(rocr_device_list[dev] for dev in hip_device_list)
+                var = ",".join(rocr_device_list[dev] for dev in hip_device_list if dev in rocr_device_list)
             else:
                 var = hip_devices
 

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -666,7 +666,7 @@ def _parse_visible_devices() -> Union[List[int], List[str]]:
                 var = hip_devices
             else:
                 return list(range(rocr_count))
-        else:
+        elif hip_devices is not None:
             var = hip_devices
 
     if var is None:

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -663,7 +663,11 @@ def _parse_visible_devices() -> Union[List[int], List[str]]:
             if rocr_devices is not None:
                 hip_device_list = [int(dev) for dev in hip_devices.split(",")]
                 rocr_device_list = rocr_devices.split(",")
-                var = ",".join(rocr_device_list[dev] for dev in hip_device_list if dev in rocr_device_list)
+                var = ",".join(
+                    rocr_device_list[dev]
+                    for dev in hip_device_list
+                    if dev in rocr_device_list
+                )
             else:
                 var = hip_devices
 

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -650,26 +650,28 @@ def _parse_visible_devices() -> Union[List[int], List[str]]:
         hip_devices = os.getenv("HIP_VISIBLE_DEVICES")
         rocr_devices = os.getenv("ROCR_VISIBLE_DEVICES")
 
+        # You must take care if both HIP and ROCR env vars are set as they have
+        # different meanings. ROCR only accepts a list of ints which then reduces
+        # the number of GPUs that HIP can select from. The HIP env var can accept
+        # either a list of ints or a list of UUIDs prefixed with 'GPU-'.
         if rocr_devices is not None:
-            # Mostly required for ROCm to make sure ROCr visible devices
-            # is respected, this ensures we do not return a list of devices
-            # that exceeds the total available supplied via ROCR_VISIBLE_DEVICES
-            var = rocr_devices
-
-        if hip_devices is not None:
-            # If ROCr devices have been set, the hip visible devices would
-            # be a subset of those. HIP_VISIBLE_DEVICES can only contain
-            # integer indices so we can use the ROCr visible devices as a key
-            if rocr_devices is not None:
-                hip_device_list = [int(dev) for dev in hip_devices.split(",")]
-                rocr_device_list = rocr_devices.split(",")
-                var = ",".join(
-                    rocr_device_list[dev]
-                    for dev in hip_device_list
-                    if dev in rocr_device_list
-                )
-            else:
+            rocr_count = len(rocr_devics.split(","))
+            if hip_devices is not None:
+                if hip_devices.startswith("GPU-"):
+                    raise RuntimeError(
+                        "Cannot specifiy both ROCR_VISIBLE_DEVICES "
+                        "and HIP_VISIBLE_DEVICES using UUIDs"
+                    )
+                if any(int(dev) >= rocr_count for dev in hip_devices.split(",")):
+                    raise RuntimeError(
+                        "HIP_VISIBLE_DEVICES out of bounds index "
+                        "after applying ROCR_VISIBLE_DEVICES"
+                    )
                 var = hip_devices
+            else:
+                return list(range(rocr_count))
+        else:
+            var = hip_devices
 
     if var is None:
         return list(range(64))

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -655,11 +655,11 @@ def _parse_visible_devices() -> Union[List[int], List[str]]:
         # the number of GPUs that HIP can select from. The HIP env var can accept
         # either a list of ints or a list of UUIDs prefixed with 'GPU-'.
         if rocr_devices is not None:
-            rocr_count = len(rocr_devics.split(","))
+            rocr_count = len(rocr_devices.split(","))
             if hip_devices is not None:
                 if hip_devices.startswith("GPU-"):
                     raise RuntimeError(
-                        "Cannot specifiy both ROCR_VISIBLE_DEVICES "
+                        "Cannot specify both ROCR_VISIBLE_DEVICES "
                         "and HIP_VISIBLE_DEVICES using UUIDs"
                     )
                 if any(int(dev) >= rocr_count for dev in hip_devices.split(",")):


### PR DESCRIPTION
Reland of #140320 after failing test on trunk. Fixes potential environment clobbering in test, makes ROCr+HIP devices (if specified together) more robust to index errors.

Fixes #140318



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd