### PR TITLE
Enable memory swap on Linux docker build

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -224,6 +224,12 @@ jobs:
             JENKINS_USER="--user jenkins"
             USED_IMAGE="${DOCKER_IMAGE}"
           fi
+
+          # Leaving 1GB for the runner and other things
+          TOTAL_AVAILABLE_MEMORY_IN_GB=$(awk '/MemTotal/ { printf "%.3f \n", $2/1024/1024 - 1 }' /proc/meminfo)
+          # https://docs.docker.com/engine/containers/resource_constraints/#--memory-swap-details
+          TOTAL_MEMORY_WITH_SWAP=$(("${TOTAL_AVAILABLE_MEMORY_IN_GB%.*}" * 2))
+
           # detached container should get cleaned up by teardown_ec2_linux
           # Used for JENKINS_USER, which can be empty
           # shellcheck disable=SC2086
@@ -246,6 +252,8 @@ jobs:
             -e HUGGING_FACE_HUB_TOKEN \
             -e SCRIBE_GRAPHQL_ACCESS_TOKEN \
             -e USE_SPLIT_BUILD \
+            --memory="${TOTAL_AVAILABLE_MEMORY_IN_GB%.*}g" \
+            --memory-swap="${TOTAL_MEMORY_WITH_SWAP}g" \
             --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
             --security-opt seccomp=unconfined \
             --cap-add=SYS_PTRACE \

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -199,8 +199,7 @@ jobs:
           SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
           SCCACHE_REGION: us-east-1
-          # SCCACHE_S3_KEY_PREFIX: ${{ github.workflow }}
-          SCCACHE_S3_KEY_PREFIX: debug  # Invalidate the cache
+          SCCACHE_S3_KEY_PREFIX: ${{ github.workflow }}
           XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
           PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
           TORCH_CUDA_ARCH_LIST: ${{ inputs.cuda-arch-list }}

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -199,7 +199,8 @@ jobs:
           SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
           SCCACHE_REGION: us-east-1
-          SCCACHE_S3_KEY_PREFIX: ${{ github.workflow }}
+          # SCCACHE_S3_KEY_PREFIX: ${{ github.workflow }}
+          SCCACHE_S3_KEY_PREFIX: debug  # Invalidate the cache
           XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
           PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
           TORCH_CUDA_ARCH_LIST: ${{ inputs.cuda-arch-list }}


### PR DESCRIPTION
Lots of CUDA build jobs are OOM-ing in trunk and the hotspot seems to come from building flash attention, for example https://github.com/pytorch/pytorch/actions/runs/12208390090/job/34061532155#step:14:9369.  There are several options around:

* Mimic the logic from https://github.com/Dao-AILab/flash-attention/blob/main/setup.py#L495-L508.  We are using `linux.2xlarge` for the build with 8 CPU and 16GB.  The current max number of parallel jobs is `(8 - 2)/3 = 2` while the logic from upstream repo has `16 / 9 = 1.7`, so it's very close.
* Upgrade to `linux.2xlarge.memory` with 8 CPU and 64GB for all CUDA build, it could afford up to 7 max parallel jobs according to the above logic.
* Enable swap.

These approaches can work together, so I want to experiment with swapping first as this technique, if working, could be useful in other context too.