### PR TITLE
[CI] Add xpu new docker image name into docker builds workflow

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -67,6 +67,7 @@ jobs:
           pytorch-linux-jammy-py3.9-gcc11-inductor-benchmarks,
           pytorch-linux-jammy-py3.12-halide,
           pytorch-linux-jammy-xpu-2024.0-py3,
+          pytorch-linux-jammy-xpu-2025.0-py3,
           pytorch-linux-jammy-py3-clang15-asan,
           pytorch-linux-jammy-py3-clang18-asan,
           pytorch-linux-focal-py3-clang10-onnx,


### PR DESCRIPTION
Add missed new xpu docker image name to adapt the new mechanism introduced by https://github.com/pytorch/test-infra/pull/6013
Works for https://github.com/pytorch/pytorch/issues/114850