### PR TITLE
Proper modeling of recursive types

### DIFF
--- a/benchmarks/instruction_counts/core/types.py
+++ b/benchmarks/instruction_counts/core/types.py
@@ -2,7 +2,7 @@
 
 # mypy: ignore-errors
 
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 from core.api import AutoLabels, GroupedBenchmark, TimerArgs
 

--- a/benchmarks/instruction_counts/core/types.py
+++ b/benchmarks/instruction_counts/core/types.py
@@ -69,21 +69,9 @@ TL;DR
 Label = Tuple[str, ...]
 _Label = Union[Label, Optional[str]]
 
-# MyPy does not currently support recursive types:
-#   https://github.com/python/mypy/issues/731
-#
-# So while the correct type definition would be:
-#   _Value = Union[
-#       # Base case:
-#       Union[TimerArgs, GroupedBenchmark],
-#
-#       # Recursive case:
-#       Dict[Label, "_Value"],
-#   ]
-# we instead have to use Any and rely on runtime asserts when flattening.
 _Value = Union[
     Union[TimerArgs, GroupedBenchmark],
-    Dict[_Label, Any],
+    Dict[_Label, "_Value"],
 ]
 
 Definition = Dict[_Label, _Value]

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -606,7 +606,7 @@ def check_permute(node: torch.fx.Node) -> bool:
         and node.kwargs["permutation"] is not None
         and len(node.kwargs["permutation"]) > 2  # type: ignore[arg-type]
     ):
-        permutation = [i % ranks for i in node.kwargs["permutation"]]  # type: ignore[union-attr]
+        permutation = [i % ranks for i in node.kwargs["permutation"]]  # type: ignore[operator, union-attr]
     else:
         return False
     allowed_permutation = list(range(ranks))

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -862,10 +862,10 @@ class SplitCatSimplifier:
                         user_input[0] : user_input[1] + 1
                     ]
                     # All sections should be equal
-                    if len(set(subset_split_sections)) != 1:
+                    if len(set(subset_split_sections)) != 1:  # type: ignore[arg-type]
                         return None
 
-                    num_splits = len(subset_split_sections)
+                    num_splits = len(subset_split_sections)  # type: ignore[arg-type]
                     unflatten_params = (split_dim, (num_splits, -1))
                     movedim_params = (
                         (split_dim, cat_dim) if split_dim != cat_dim else None
@@ -1498,7 +1498,7 @@ def merge_getitem_cat(match: Match, split_sections: List[int], dim: int):
             indices = [arg.args[1] for arg in cat_user.args[0]]  # type: ignore[union-attr]
             # the gettitems to be merged must be consecutive, otherwise
             # returned sliced tensor could be wrong
-            if not is_sorted_and_consecutive(indices):
+            if not is_sorted_and_consecutive(indices):  # type: ignore[arg-type]
                 continue
             # update the arg of cat user, only keep the first getitem
             cat_user.update_arg(0, cat_user.args[0][0])  # type: ignore[index]
@@ -1508,12 +1508,12 @@ def merge_getitem_cat(match: Match, split_sections: List[int], dim: int):
                 if i in indices:
                     fused_tensor_size += split_node.args[1][i]  # type: ignore[operator, assignment, index]
             # update the split sections
-            split_sections[indices[0]] = calculate_fused_tensor_size(
-                split_node, indices
+            split_sections[indices[0]] = calculate_fused_tensor_size(  # type: ignore[index]
+                split_node, indices  # type: ignore[arg-type]
             )
             # padding others with zeros to keep the same dict size
             for i in indices[1:]:
-                split_sections[i] = 0
+                split_sections[i] = 0  # type: ignore[index]
             # remove all unused indexes in the split_node
             new_split_sections, index_mapping = remove_zeros(split_sections)
             with graph.inserting_after(split_node):
@@ -1599,7 +1599,7 @@ def mutate_cat_node(match: Match, split_sections: List[int], dim: int):
                 idx_to_getitem[getitem.args[1]] = getitem  # type: ignore[union-attr]
             # the gettitems to be merged must be consecutive, otherwise
             # returned sliced tensor could be wrong
-            if not is_sorted_and_consecutive(indices):
+            if not is_sorted_and_consecutive(indices):  # type: ignore[arg-type]
                 continue
             # case 1: the cat uses all getitems from the split
             if len(split_sections) == len(cat_user.args[0]):  # type: ignore[arg-type]
@@ -1612,10 +1612,10 @@ def mutate_cat_node(match: Match, split_sections: List[int], dim: int):
             elif is_node_meta_valid(split_node.args[0]):  # type: ignore[arg-type]
                 # check the split dim, and construct the slice tuple
                 start_fused_size = calculate_fused_tensor_size(
-                    split_node, list(range(indices[0]))
+                    split_node, list(range(indices[0]))  # type: ignore[arg-type]
                 )
                 end_fused_size = start_fused_size + calculate_fused_tensor_size(
-                    split_node, indices
+                    split_node, indices  # type: ignore[arg-type]
                 )
                 slice_list = []
                 for i in range(len(split_node.args[0].meta["example_value"].shape)):  # type: ignore[union-attr]

--- a/torch/ao/ns/fx/n_shadows_utils.py
+++ b/torch/ao/ns/fx/n_shadows_utils.py
@@ -358,7 +358,7 @@ def create_submodule_from_subgraph(
                     new_kwarg = []
                     for inner_kwarg in kwarg:
                         p = _add_placeholder(
-                            g, inner_kwarg, seen_names, old_name_to_new_node
+                            g, inner_kwarg, seen_names, old_name_to_new_node  # type: ignore[arg-type]
                         )
                         new_kwarg.append(p)
                     cur_kwargs_copy[kwarg_name] = new_kwarg
@@ -578,7 +578,7 @@ def create_one_transformed_and_logged_copy_of_subgraph(
                     new_kwargs[name] = old_kwarg
                 elif isinstance(old_kwarg, (list, tuple)) and len(old_kwarg):
                     # TODO(future PR): clarify why we are adding kwargs to args
-                    new_args.extend(old_kwarg)
+                    new_args.extend(old_kwarg)  # type: ignore[arg-type]
 
             new_args = tuple(new_args)  # type: ignore[assignment]
 

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
@@ -1009,7 +1009,7 @@ def _annotate_cat(
             input_qspec_map[input_act0] = input_act_qspec
 
         shared_with_input0_qspec = SharedQuantizationSpec((input_act0, cat_node))  # type: ignore[arg-type]
-        for input_act in inputs[1:]:  # type: ignore[index]
+        for input_act in inputs[1:]:  # type: ignore[index, union-attr]
             if input_act not in input_qspec_map:
                 input_qspec_map[input_act] = shared_with_input0_qspec  # type: ignore[index]
 

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -539,7 +539,7 @@ class _PipelineStageBase(ABC):
                 raise AssertionError(f"Expected _RecvInfo but got {type(info)}")
 
         tensors = map_aggregate(
-            recv_infos,
+            recv_infos,  # type: ignore[arg-type]
             get_recv_tensor,
         )
 

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -45,9 +45,9 @@ Target = Union[Callable[..., Any], str]
 
 Argument = Optional[
     Union[
-        Tuple[Any, ...],  # actually Argument, but mypy can't represent recursive types
-        List[Any],  # actually Argument
-        Dict[str, Any],  # actually Argument
+        Tuple[Argument, ...],
+        List[Argument],
+        Dict[str, Argument],
         slice,  # Slice[Argument, Argument, Argument], but slice is not a templated type in typing
         range,
         "Node",

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -4,7 +4,6 @@ import inspect
 import types
 import warnings
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -14,6 +13,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    TYPE_CHECKING,
     Union,
 )
 

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -3,7 +3,19 @@ import builtins
 import inspect
 import types
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TYPE_CHECKING, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 import torch
 from torch._C import _NodeBase
@@ -45,9 +57,9 @@ Target = Union[Callable[..., Any], str]
 
 Argument = Optional[
     Union[
-        Tuple[Argument, ...],
-        List[Argument],
-        Dict[str, Argument],
+        Tuple["Argument", ...],
+        Sequence["Argument"],
+        Mapping[str, "Argument"],
         slice,  # Slice[Argument, Argument, Argument], but slice is not a templated type in typing
         range,
         "Node",

--- a/torch/onnx/_internal/exporter/_dispatching.py
+++ b/torch/onnx/_internal/exporter/_dispatching.py
@@ -276,7 +276,7 @@ def get_matching_overload(
                 if isinstance(arg, (list, tuple)) and any(
                     isinstance(t, torch.fx.Node) for t in arg
                 ):
-                    first_tensor = _get_first_tensor_in_node_list(arg)
+                    first_tensor = _get_first_tensor_in_node_list(arg)  # type: ignore[arg-type]
                     assert first_tensor is not None
                     # FIXME: Handle symfloat here
                     arg = ir.SequenceType(_get_type_from_tensor(first_tensor))  # type: ignore[assignment]

--- a/torch/onnx/_internal/fx/fx_onnx_interpreter.py
+++ b/torch/onnx/_internal/fx/fx_onnx_interpreter.py
@@ -184,7 +184,7 @@ def _retrieve_or_adapt_input_to_graph_set(
         ] = []
         for tensor in onnx_tensor:
             sequence_elements.append(
-                fx_name_to_onnxscript_value[tensor.name] if tensor is not None else None
+                fx_name_to_onnxscript_value[tensor.name] if tensor is not None else None  # type: ignore[index, union-attr]
             )
         return sequence_elements
     if isinstance(onnx_tensor, torch.dtype):

--- a/torch/onnx/_internal/fx/type_utils.py
+++ b/torch/onnx/_internal/fx/type_utils.py
@@ -4,22 +4,21 @@
 from __future__ import annotations
 
 from typing import (
-    TYPE_CHECKING,
     Any,
-    Dict,
-    List,
     Mapping,
     Optional,
     Protocol,
+    runtime_checkable,
     Sequence,
     Tuple,
+    TYPE_CHECKING,
     Union,
-    runtime_checkable,
 )
 
 import numpy
 
 import onnx
+
 import torch
 from torch._subclasses import fake_tensor
 
@@ -33,8 +32,7 @@ if TYPE_CHECKING:
 @runtime_checkable
 class TensorLike(Protocol):
     @property
-    def dtype(self) -> torch.dtype | None:
-        ...
+    def dtype(self) -> torch.dtype | None: ...
 
 
 def is_torch_complex_dtype(tensor_dtype: torch.dtype) -> bool:

--- a/torch/onnx/_internal/fx/type_utils.py
+++ b/torch/onnx/_internal/fx/type_utils.py
@@ -4,21 +4,22 @@
 from __future__ import annotations
 
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     List,
+    Mapping,
     Optional,
     Protocol,
-    runtime_checkable,
+    Sequence,
     Tuple,
-    TYPE_CHECKING,
     Union,
+    runtime_checkable,
 )
 
 import numpy
 
 import onnx
-
 import torch
 from torch._subclasses import fake_tensor
 
@@ -32,7 +33,8 @@ if TYPE_CHECKING:
 @runtime_checkable
 class TensorLike(Protocol):
     @property
-    def dtype(self) -> torch.dtype | None: ...
+    def dtype(self) -> torch.dtype | None:
+        ...
 
 
 def is_torch_complex_dtype(tensor_dtype: torch.dtype) -> bool:
@@ -246,8 +248,8 @@ BaseArgumentTypes = Union[
 Argument = Optional[
     Union[
         Tuple["Argument", ...],
-        List["Argument"],
-        Dict[str, "Argument"],
+        Sequence["Argument"],
+        Mapping[str, "Argument"],
         slice,  # Slice[Argument, Argument, Argument], but slice is not a templated type in typing
         range,
         "torch.fx.Node",

--- a/torch/onnx/_internal/fx/type_utils.py
+++ b/torch/onnx/_internal/fx/type_utils.py
@@ -245,9 +245,9 @@ BaseArgumentTypes = Union[
 ]
 Argument = Optional[
     Union[
-        Tuple[Any, ...],  # actually Argument, but mypy can't represent recursive types
-        List[Any],  # actually Argument
-        Dict[str, Any],  # actually Argument
+        Tuple["Argument", ...],
+        List["Argument"],
+        Dict[str, "Argument"],
         slice,  # Slice[Argument, Argument, Argument], but slice is not a templated type in typing
         range,
         "torch.fx.Node",


### PR DESCRIPTION
Currently there are a few type annotations that falsely state that mypy doesn't support recursive types.

Recursive type support is available in mypy for a few years already. It has been officially enabled in [version 0.991](https://mypy-lang.blogspot.com/2022/11/mypy-0990-released.html). Pyright even had support for recursive types earlier (https://github.com/microsoft/pyright/issues/569), so there is probably no reason not to model these types correctly.

This PR models these types properly now. Since this has turned a few implicit `Any` into fully typed variables that are not narrowed cleanly, a small number of type ignores were necessary.

Note that regarding the `Argument` it is desirable to model it in a covariant way (i.e. using `Sequence` and `Mapping`) instead of making it invariant unnecessarily (using `List` and `Dict`). If it were modeled invariant, it would for instance mean that a `List[Node]` would not type check as `Argument`, because invariance would mean that it really has to be a `List[Argument]` (i.e., including all the branches of the union type). Since even the name of the type "argument" strongly suggest that it is semantically used as "argument", having covariance natural anyway.

There are no chances in this PR that affect runtime behavior.

CC @Skylion007 

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov