### PR TITLE
fix RNN doc-string

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -501,7 +501,7 @@ class RNN(RNNBase):
                         + h_t_minus_1[layer] @ weight_hh[layer].T
                         + bias_hh[layer]
                     )
-                output.append(h_t[-1])
+                output.append(h_t[-1].clone())
                 h_t_minus_1 = h_t
             output = torch.stack(output)
             if batch_first:


### PR DESCRIPTION
There is a bug in the implementation of the function intended to replicate the behavior of `torch.nn.RNN`, which causes it to deviate from the expected equivalence. Specifically, the line `output.append(h_t[-1])` is problematic because it appends a reference to the last state rather than creating a copy. As a result, during subsequent iterations, modifications to the state overwrite previous entries in the `output` list. This leads to a final result where the `output` contains repeated instances of the last state of the sequence, instead of the correct sequence of states. 

The following code snippet demonstrates the problem:

```python
import torch

batch_first=False
num_layers = 1
hidden_size = 5
input_size = 2 

rnn = torch.nn.RNN(
    input_size=input_size, 
    hidden_size=hidden_size, 
    num_layers=num_layers
)

weight_ih = [rnn.weight_ih_l0.data]
bias_ih = [rnn.bias_ih_l0.data]
weight_hh = [rnn.weight_hh_l0.data]
bias_hh = [rnn.bias_hh_l0.data]

def forward(x, h_0=None):
    if batch_first:
        x = x.transpose(0, 1)
    seq_len, batch_size, _ = x.size()
    if h_0 is None:
        h_0 = torch.zeros(num_layers, batch_size, hidden_size)
    h_t_minus_1 = h_0
    h_t = h_0
    output = []
    for t in range(seq_len):
        for layer in range(num_layers):
            h_t[layer] = torch.tanh(
                x[t] @ weight_ih[layer].T
                + bias_ih[layer]
                + h_t_minus_1[layer] @ weight_hh[layer].T
                + bias_hh[layer]
            )
        output.append(h_t[-1])
        h_t_minus_1 = h_t
    output = torch.stack(output)
    if batch_first:
        output = output.transpose(0, 1)
    return output, h_t


example_input = torch.randn(3, 4, input_size)

print(rnn(example_input)[0])
print(forward(example_input)[0])
```
