### PR TITLE
[BE]: Add TypeGuard to is_symbolic

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -32,6 +32,7 @@ from typing import (
     List,
     NamedTuple,
     Optional,
+    overload,
     Protocol,
     Sequence,
     Set,
@@ -41,7 +42,7 @@ from typing import (
     Union,
     ValuesView,
 )
-from typing_extensions import Concatenate, dataclass_transform, ParamSpec
+from typing_extensions import Concatenate, dataclass_transform, ParamSpec, TypeGuard
 from unittest import mock
 
 import sympy
@@ -447,7 +448,7 @@ def pad_listlike(x, size):
 
 
 # Used to ensure that iterating over a set is deterministic
-def tuple_sorted(x):
+def tuple_sorted(x: Tuple[_T, ...]) -> List[_T]:
     if len(x) == 0:
         return []
 
@@ -731,7 +732,17 @@ def sympy_subs(expr: sympy.Expr, replacements: Dict[sympy.Expr, Any]) -> sympy.E
     )
 
 
-def is_symbolic(a: Any) -> bool:
+@overload
+def is_symbolic(a: torch.SymInt) -> TypeGuard[torch.SymInt]:
+    ...
+
+
+@overload
+def is_symbolic(a: torch.Tensor) -> TypeGuard[torch.Tensor]:
+    ...
+
+
+def is_symbolic(a: Any) -> TypeGuard[Union[torch.SymInt, torch.Tensor]]:
     return isinstance(a, torch.SymInt) or (
         isinstance(a, torch.Tensor)
         and any(is_symbolic(x) for x in itertools.chain(a.size(), a.stride()))

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -32,7 +32,6 @@ from typing import (
     List,
     NamedTuple,
     Optional,
-    overload,
     Protocol,
     Sequence,
     Set,
@@ -730,16 +729,6 @@ def sympy_subs(expr: sympy.Expr, replacements: Dict[sympy.Expr, Any]) -> sympy.E
     return sympy.sympify(expr).xreplace(
         {k: to_symbol(k, v) for k, v in replacements.items()}
     )
-
-
-@overload
-def is_symbolic(a: torch.SymInt) -> TypeGuard[torch.SymInt]:
-    ...
-
-
-@overload
-def is_symbolic(a: torch.Tensor) -> TypeGuard[torch.Tensor]:
-    ...
 
 
 def is_symbolic(a: Any) -> TypeGuard[Union[torch.SymInt, torch.Tensor]]:


### PR DESCRIPTION
Improves type inference for is_symbolic. If it's True, it must be either a SymInt or Torch Tensor currently.

cc @ezyang @malfet @xuzhao9 @gramster @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov