### PR TITLE
Teach ruff_linter to report syntax errors (fix #140228)

### DIFF
--- a/tools/linter/adapters/ruff_linter.py
+++ b/tools/linter/adapters/ruff_linter.py
@@ -16,6 +16,7 @@ from typing import Any, BinaryIO
 
 
 LINTER_CODE = "RUFF"
+SYNTAX_ERROR = "E999"
 IS_WINDOWS: bool = os.name == "nt"
 
 
@@ -188,7 +189,7 @@ def get_issue_severity(code: str) -> LintSeverity:
 
     # "F821": Undefined name
     # "E999": syntax error
-    if any(code.startswith(x) for x in ("F821", "E999", "PLE")):
+    if any(code.startswith(x) for x in ("F821", SYNTAX_ERROR, "PLE")):
         return LintSeverity.ERROR
 
     # "F": PyFlakes Error
@@ -270,27 +271,28 @@ def check_files(
     else:
         rules = {}
 
-    return [
-        LintMessage(
+    def lint_message(vuln: dict[str, Any]) -> LintMessage:
+        code = vuln["code"] or SYNTAX_ERROR
+        return LintMessage(
             path=vuln["filename"],
-            name=vuln["code"],
+            name=code,
             description=(
                 format_lint_message(
                     vuln["message"],
-                    vuln["code"],
+                    code,
                     rules,
-                    show_disable,
+                    show_disable and bool(vuln["code"]),
                 )
             ),
             line=int(vuln["location"]["row"]),
             char=int(vuln["location"]["column"]),
             code=LINTER_CODE,
-            severity=severities.get(vuln["code"], get_issue_severity(vuln["code"])),
+            severity=severities.get(code, get_issue_severity(code)),
             original=None,
             replacement=None,
         )
-        for vuln in vulnerabilities
-    ]
+
+    return [lint_message(v) for v in vulnerabilities]
 
 
 def check_file_for_fixes(


### PR DESCRIPTION
Now syntax errors look like this:

```
torch/_dynamo/variables/base.py:20:

  Error (RUFF) E999
    SyntaxError: Expected ',', found indent.
    See https://beta.ruff.rs/docs/rules/
    >>>  19  |class SourceType(Enum]:
         20  |    """
         21  |    This Enum divides VariableTracker into 2 cases, depending on the variable
         22  |    it represents:

[...more errors...]
```

Note that most syntax errors lead to a cascade of other errors, so the exception is generally wrong, but the location and name are good.

Before they looked like this:

```
>>> General linter failure:

  Error (RUFF) Linter failed
    Linter failed. This a bug, please file an issue against the linter
    maintainer.

    CONTEXT:
    Linter command failed with non-zero exit code.
    STDERR:
    <MainThread:DEBUG> $ /home/rec/.conda/envs/pytorch-dev-constant/
    bin/python3 -m ruff check --exit-zero --quiet --output-format=json
    --config=pyproject.toml /home/rec/git-constant/pytorch/torch/_dynamo/
    variables/base.py
    <MainThread:DEBUG> took 38ms
    Traceback (most recent call last):
      File "/home/rec/git-constant/pytorch/tools/linter/adapters/
    ruff_linter.py", line 465, in <module>
        main()
      File "/home/rec/git-constant/pytorch/tools/linter/adapters/
    ruff_linter.py", line 424, in main
        lint_messages = check_files(
      File "/home/rec/git-constant/pytorch/tools/linter/adapters/
    ruff_linter.py", line 273, in check_files
        return [
      File "/home/rec/git-constant/pytorch/tools/linter/adapters/
    ruff_linter.py", line 288, in <listcomp>
        severity=severities.get(vuln["code"],
    get_issue_severity(vuln["code"])),
      File "/home/rec/git-constant/pytorch/tools/linter/adapters/
    ruff_linter.py", line 172, in get_issue_severity
        if any(
      File "/home/rec/git-constant/pytorch/tools/linter/adapters/
    ruff_linter.py", line 173, in <genexpr>
        code.startswith(x)
    AttributeError: 'NoneType' object has no attribute 'startswith'


    STDOUT:
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142312

