### PR TITLE
Add support for assume_contiguous in mark_unbacked 

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -5829,7 +5829,6 @@ def forward(self, s0 : torch.SymInt, s1 : torch.SymInt, L_x_ : torch.Tensor):
 
         fn(aot6_sub_58, aot6_mul_170)
 
-
     @torch._dynamo.config.patch(guard_nn_modules=False)
     @torch._dynamo.config.patch(inline_inbuilt_nn_modules=False)
     def test_inlining_cornercase(self):

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -5812,6 +5812,24 @@ def forward(self, s0 : torch.SymInt, s1 : torch.SymInt, L_x_ : torch.Tensor):
 
         self.assertTrue(cnt.frame_count <= 2)
 
+    def test_unsqueeze_mul_strides(self):
+        # This is a case where we had an input that was marked unbacked:
+        # size=[2, u0], stride=[1, 1] which is bad. We want it to actually
+        # be size=[2, u0], stride=[u0. 1]. See more in the issue below:
+        # https://github.com/pytorch/pytorch/issues/142024
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(aot6_sub_58, aot6_mul_170):
+            aot6_unsqueeze_14 = torch.ops.aten.unsqueeze.default(aot6_mul_170, 1)
+            return torch.ops.aten.mul.Tensor(aot6_sub_58, aot6_unsqueeze_14)
+
+        aot6_sub_58 = torch.randn(2, 1)
+        torch._dynamo.decorators.mark_unbacked(aot6_sub_58, 1)
+        aot6_mul_170 = torch.randn(2)
+
+        fn(aot6_sub_58, aot6_mul_170)
+
+
     @torch._dynamo.config.patch(guard_nn_modules=False)
     @torch._dynamo.config.patch(inline_inbuilt_nn_modules=False)
     def test_inlining_cornercase(self):

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -832,7 +832,7 @@ def forward(self):
         x1 = torch.rand(3, 5, 4, 8).to(memory_format=torch.channels_last)
         x2 = torch.rand(1, 5, 4, 8).to(memory_format=torch.channels_last)
 
-        torch._dynamo.decorators.mark_unbacked(x1, 0)
+        torch._dynamo.decorators.mark_unbacked(x1, 0, assume_contiguous=False)
 
         o1_ref = main_model(x1, 2)
         o1 = opt_model(x1, 2)

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -962,7 +962,7 @@ class TestInductorDynamic(TestCase):
             return x.sum()
 
         x = torch.empty_strided((1, 4), (5, 1), device=GPU_TYPE)
-        torch._dynamo.decorators.mark_unbacked(x, 0)
+        torch._dynamo.decorators.mark_unbacked(x, 0, assume_contiguous=False)
         f(x)
 
     @torch._dynamo.config.patch(specialize_float=False, capture_scalar_outputs=True)

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -443,7 +443,6 @@ def mark_unbacked(t, index):
     # You could have copied the mark_dynamic behavior but I'm not convinced
     # it's what you want
     assert not is_traceable_wrapper_subclass(t), "not implemented yet"
-    assert t.is_contiguous(), "mark_unbacked can only be used with contiguous tensors"
 
     if isinstance(index, int):
         if not hasattr(t, "_dynamo_unbacked_indices"):

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -432,7 +432,7 @@ class _DimRange:
 
 
 @forbid_in_graph
-def mark_unbacked(t, index):
+def mark_unbacked(t, index, assume_contiguous=True):
     """
     Mark a tensor as having an unbacked dim.  This changes the semantics of operations,
     we will always report the size does not equal zero/one, we will turn asserts
@@ -443,10 +443,19 @@ def mark_unbacked(t, index):
     # You could have copied the mark_dynamic behavior but I'm not convinced
     # it's what you want
     assert not is_traceable_wrapper_subclass(t), "not implemented yet"
+    assert (
+        not assume_contiguous or assume_contiguous == t.is_contiguous()
+    ), "The tensor is not contiguous yet you assumed it to be so."
 
     if isinstance(index, int):
         if not hasattr(t, "_dynamo_unbacked_indices"):
             t._dynamo_unbacked_indices = set()
+        if not hasattr(t, "_dynamo_assume_contiguous"):
+            t._dynamo_assume_contiguous = assume_contiguous
+        assert t._dynamo_assume_contiguous == assume_contiguous, (
+            f"mark_unbacked contiguity assumption mismatch: previously assumed {t._dynamo_assume_contiguous}, "
+            f"but now {assume_contiguous}"
+        )
         t._dynamo_unbacked_indices.add(index)
         return
 

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -443,6 +443,7 @@ def mark_unbacked(t, index):
     # You could have copied the mark_dynamic behavior but I'm not convinced
     # it's what you want
     assert not is_traceable_wrapper_subclass(t), "not implemented yet"
+    assert t.is_contiguous(), "mark_unbacked can only be used with contiguous tensors"
 
     if isinstance(index, int):
         if not hasattr(t, "_dynamo_unbacked_indices"):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2742,9 +2742,10 @@ def _automatic_dynamic(
         constraint_sizes.append(constraint_size)
         constraint_strides.append(constraint_stride)
 
-        if marked_unbacked:
+        if marked_unbacked and e.is_contiguous():
+            dynamic_size = DimDynamic.SIZE_LIKE_UNBACKED_CONTIGUOUS
+        elif marked_unbacked:
             dynamic_size = DimDynamic.SIZE_LIKE_UNBACKED
-            constraint_stride = RelaxedUnspecConstraint(warn_only=True)
         elif (
             constraint_size is not None
             or marked_dynamic

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2744,6 +2744,7 @@ def _automatic_dynamic(
 
         if marked_unbacked:
             dynamic_size = DimDynamic.SIZE_LIKE_UNBACKED
+            constraint_stride = RelaxedUnspecConstraint(warn_only=True)
         elif (
             constraint_size is not None
             or marked_dynamic

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2742,7 +2742,7 @@ def _automatic_dynamic(
         constraint_sizes.append(constraint_size)
         constraint_strides.append(constraint_stride)
 
-        if marked_unbacked and e.is_contiguous():
+        if marked_unbacked and e._dynamo_assume_contiguous:
             dynamic_size = DimDynamic.SIZE_LIKE_UNBACKED_CONTIGUOUS
         elif marked_unbacked:
             dynamic_size = DimDynamic.SIZE_LIKE_UNBACKED

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -322,8 +322,8 @@ def has_symbolic_sizes_strides(elem: torch.Tensor) -> bool:
 Int: TypeAlias = Union[torch.SymInt, int]
 
 
-def create_contiguous(size: Sequence[Union[torch.SymInt, Int]]) -> List[Union[torch.SymInt, Int]]:
-    strides = [1] * len(size)
+def create_contiguous(size: Sequence[Union[torch.SymInt, Int]]) -> List[sympy.Expr]:
+    strides = [sympy.Integer(1)] * len(size)
     for i in range(len(size) - 2, -1, -1):
         strides[i] = strides[i + 1] * size[i + 1]
     return strides
@@ -3869,10 +3869,12 @@ class ShapeEnv:
         size: List[sympy.Expr] = self._produce_dyn_sizes_from_int_tuple(
             ex_size, source, symbolic_context
         )
-        if any(s is DimDynamic.SIZE_LIKE_UNBACKED for s in symbolic_context.dynamic_sizes):
+        stride: List[Optional[sympy.Expr]] = [None] * len(size)
+        if any(
+            s is DimDynamic.SIZE_LIKE_UNBACKED for s in symbolic_context.dynamic_sizes  # type: ignore[attr-defined]
+        ):
             stride = create_contiguous(size)
         else:
-            stride: List[Optional[sympy.Expr]] = [None] * len(size)
             for i, val in enumerate(ex_stride):
                 if val in (0, 1):
                     stride[i] = sympy.Integer(val)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142318

Fixes: https://github.com/pytorch/pytorch/issues/142024

Note for reviewers: I'm unclear on what should be the best default here. On the one hand, if we default this to True, we make life easier for future users who won't run into issues like #142024. On the other hand, this does break BC and old users might now have to go back and fix their models. It's hard to estimate the blast radius, but my current intuition is that it's better to do the former.

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov