### PR TITLE
Remove some unused type ignores (round 1)

### DIFF
--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -701,7 +701,7 @@ def _get_torch_jit_trace_forward_signature(mod: torch.nn.Module) -> inspect.Sign
     # TODO: Directly provide inspect.signature compatible TS-d module.
     """
     ast_mod = ast.parse(mod.code)  # type: ignore[call-overload]
-    ast_func_def: ast.FunctionDef = ast_mod.body[0]  # type: ignore[assignment]
+    ast_func_def: ast.FunctionDef = ast_mod.body[0]
 
     # FIXME(jiashenc): TorchScript should only allow positional or keywords arguments.
     arg_type_map = {"args": Parameter.POSITIONAL_OR_KEYWORD}

--- a/torch/_higher_order_ops/effects.py
+++ b/torch/_higher_order_ops/effects.py
@@ -261,12 +261,12 @@ def handle_effects(
 
     ctx = PythonFunctionalizeAPI()
 
-    unwrapped_token = ctx.unwrap_tensors([token])[0]  # type: ignore[arg-type]
-    unwrapped_args = ctx.unwrap_tensors(args)  # type: ignore[arg-type]
+    unwrapped_token = ctx.unwrap_tensors([token])[0]
+    unwrapped_args = ctx.unwrap_tensors(args)
     unwrapped_kwargs = ctx.unwrap_tensors(kwargs)  # type: ignore[arg-type]
     with ctx.redispatch_to_next():
         (new_token, *unwrapped_outs) = with_effects(
-            unwrapped_token, op, *unwrapped_args, **unwrapped_kwargs  # type: ignore[arg-type]
+            unwrapped_token, op, *unwrapped_args, **unwrapped_kwargs
         )
 
     schema = _get_schema(op, unwrapped_args)
@@ -285,4 +285,4 @@ def handle_effects(
     assert isinstance(wrapped_token, torch.Tensor)
     tokens[key] = wrapped_token
 
-    return ctx.wrap_tensors(unwrapped_outs)  # type: ignore[arg-type]
+    return ctx.wrap_tensors(unwrapped_outs)

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -176,12 +176,19 @@ def derived_types(
         ]
 
     if list_base:
-        result.extend((seq_typ, f"{cpp_type}[]") for seq_typ in derived_seq_types(base_type))  # type: ignore[valid-type]
+        result.extend(
+            (seq_typ, f"{cpp_type}[]") for seq_typ in derived_seq_types(base_type)
+        )
     if optional_base_list:
-        result.extend((seq_typ, f"{cpp_type}?[]") for seq_typ in derived_seq_types(typing.Optional[base_type]))  # type: ignore[valid-type]
+        result.extend(
+            (seq_typ, f"{cpp_type}?[]")
+            for seq_typ in derived_seq_types(typing.Optional[base_type])
+        )
     if optional_list_base:
-        # type: ignore[valid-type]
-        result.extend((typing.Optional[seq_typ], f"{cpp_type}[]?") for seq_typ in derived_seq_types(base_type))  # type: ignore[valid-type]
+        result.extend(
+            (typing.Optional[seq_typ], f"{cpp_type}[]?")
+            for seq_typ in derived_seq_types(base_type)
+        )
     return result
 
 
@@ -263,7 +270,7 @@ def tuple_to_list(tuple_type: typing.Type[typing.Tuple]) -> typing.Type[typing.L
     elif len(type_args) == 1:
         # General case: create a List with the same type arguments
         return typing.List[type_args[0]]  # type: ignore[valid-type]
-    elif len(type_args) == 2 and type_args[1] is Ellipsis:  # type: ignore[valid-type]
+    elif len(type_args) == 2 and type_args[1] is Ellipsis:
         return typing.List[type_args[0]]  # type: ignore[valid-type]
     else:
         return typing.List[typing.Union[tuple(type_args)]]  # type: ignore[misc, return-value]

--- a/torch/ao/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/ao/nn/intrinsic/qat/modules/conv_fused.py
@@ -225,7 +225,7 @@ class _ConvBnNd(nn.modules.conv._ConvNd, nni._FusedModule):
             conv_bn = self._conv_forward(input, scaled_weight, zero_bias)
 
             avg_dims = [0] + list(range(2, len(self.weight.shape)))
-            batch_mean = conv_out.mean(avg_dims)  # type: ignore[possibly-undefined]
+            batch_mean = conv_out.mean(avg_dims)
             batch_var = torch.square(conv_out - batch_mean.reshape(bias_shape)).mean(
                 avg_dims
             )
@@ -365,7 +365,7 @@ class _ConvBnNd(nn.modules.conv._ConvNd, nni._FusedModule):
             "qat."
             + cls.__name__
             + ".from_float only works for "
-            + cls._FLOAT_MODULE.__name__  # type: ignore[attr-defined]
+            + cls._FLOAT_MODULE.__name__
         )
         assert hasattr(mod, "qconfig"), "Input float module must have qconfig defined"
         assert mod.qconfig, "Input float module must have a valid qconfig"
@@ -393,7 +393,7 @@ class _ConvBnNd(nn.modules.conv._ConvNd, nni._FusedModule):
         qat_convbn.bn.running_mean = bn.running_mean
         qat_convbn.bn.running_var = bn.running_var
         # mypy error: Cannot determine type of 'num_batches_tracked'
-        qat_convbn.bn.num_batches_tracked = bn.num_batches_tracked  # type: ignore[has-type]
+        qat_convbn.bn.num_batches_tracked = bn.num_batches_tracked
         return qat_convbn
 
     def to_float(self):
@@ -439,7 +439,7 @@ class _ConvBnNd(nn.modules.conv._ConvNd, nni._FusedModule):
             return conv
 
 
-class ConvBn1d(_ConvBnNd, nn.Conv1d):  # type: ignore[misc]
+class ConvBn1d(_ConvBnNd, nn.Conv1d):
     r"""
     A ConvBn1d module is a module fused from Conv1d and BatchNorm1d,
     attached with FakeQuantize modules for weight,
@@ -458,7 +458,7 @@ class ConvBn1d(_ConvBnNd, nn.Conv1d):  # type: ignore[misc]
     """
     _FLOAT_BN_MODULE: ClassVar[Type[nn.BatchNorm1d]] = nn.BatchNorm1d
     _FLOAT_RELU_MODULE: ClassVar[Optional[Type[nn.Module]]] = None
-    _FLOAT_MODULE: ClassVar[Type[nn.Module]] = nni.ConvBn1d  # type: ignore[assignment,misc]
+    _FLOAT_MODULE: ClassVar[Type[nn.Module]] = nni.ConvBn1d  # type: ignore[assignment]
     _FLOAT_CONV_MODULE: ClassVar[Type[nn.Conv1d]] = nn.Conv1d
 
     def __init__(
@@ -525,7 +525,7 @@ class ConvBnReLU1d(ConvBn1d):
 
     """
     # base class defines _FLOAT_MODULE as "ConvBn1d"
-    _FLOAT_MODULE: ClassVar[Type[nn.Module]] = nni.ConvBnReLU1d  # type: ignore[assignment,misc]
+    _FLOAT_MODULE: ClassVar[Type[nn.Module]] = nni.ConvBnReLU1d
     _FLOAT_CONV_MODULE: ClassVar[Type[nn.Conv1d]] = nn.Conv1d
     _FLOAT_BN_MODULE: ClassVar[Type[nn.BatchNorm1d]] = nn.BatchNorm1d
     _FLOAT_RELU_MODULE: ClassVar[Optional[Type[nn.Module]]] = nn.ReLU
@@ -590,7 +590,7 @@ class ConvReLU1d(nnqat.Conv1d, nni._FusedModule):
         weight_fake_quant: fake quant module for weight
 
     """
-    _FLOAT_MODULE: ClassVar[Type[nni.ConvReLU1d]] = nni.ConvReLU1d  # type: ignore[assignment, misc]
+    _FLOAT_MODULE: ClassVar[Type[nni.ConvReLU1d]] = nni.ConvReLU1d  # type: ignore[assignment]
     _FLOAT_CONV_MODULE: ClassVar[Type[nn.Conv1d]] = nn.Conv1d
     _FLOAT_BN_MODULE: ClassVar[Optional[Type[nn.Module]]] = None
     _FLOAT_RELU_MODULE: ClassVar[Optional[Type[nn.Module]]] = nn.ReLU
@@ -636,7 +636,7 @@ class ConvReLU1d(nnqat.Conv1d, nni._FusedModule):
         )
 
 
-class ConvBn2d(_ConvBnNd, nn.Conv2d):  # type: ignore[misc]
+class ConvBn2d(_ConvBnNd, nn.Conv2d):
     r"""
     A ConvBn2d module is a module fused from Conv2d and BatchNorm2d,
     attached with FakeQuantize modules for weight,
@@ -653,7 +653,7 @@ class ConvBn2d(_ConvBnNd, nn.Conv2d):  # type: ignore[misc]
         weight_fake_quant: fake quant module for weight
 
     """
-    _FLOAT_MODULE: ClassVar[Type[nni.ConvBn2d]] = nni.ConvBn2d  # type: ignore[assignment,misc]
+    _FLOAT_MODULE: ClassVar[Type[nni.ConvBn2d]] = nni.ConvBn2d  # type: ignore[assignment]
     _FLOAT_CONV_MODULE: ClassVar[Type[nn.Conv2d]] = nn.Conv2d
     _FLOAT_BN_MODULE: ClassVar[Optional[Type[nn.Module]]] = nn.BatchNorm2d
     _FLOAT_RELU_MODULE: ClassVar[Optional[Type[nn.Module]]] = None
@@ -722,10 +722,10 @@ class ConvBnReLU2d(ConvBn2d):
 
     """
     # base class defines _FLOAT_MODULE as "ConvBn2d"
-    _FLOAT_MODULE: ClassVar[Type[nni.ConvBnReLU2d]] = nni.ConvBnReLU2d  # type: ignore[assignment, misc]
+    _FLOAT_MODULE: ClassVar[Type[nni.ConvBnReLU2d]] = nni.ConvBnReLU2d  # type: ignore[assignment]
     _FLOAT_CONV_MODULE: ClassVar[Type[nn.Conv2d]] = nn.Conv2d
     _FLOAT_BN_MODULE: ClassVar[Type[nn.BatchNorm2d]] = nn.BatchNorm2d
-    _FLOAT_RELU_MODULE: ClassVar[Optional[Type[nn.Module]]] = nn.ReLU  # type: ignore[assignment,misc]
+    _FLOAT_RELU_MODULE: ClassVar[Optional[Type[nn.Module]]] = nn.ReLU
     # module class after fusing bn into conv
     _FUSED_FLOAT_MODULE: ClassVar[Optional[Type[nni.ConvReLU2d]]] = nni.ConvReLU2d
 
@@ -787,7 +787,7 @@ class ConvReLU2d(nnqat.Conv2d, nni._FusedModule):
         weight_fake_quant: fake quant module for weight
 
     """
-    _FLOAT_MODULE: ClassVar[Type[nn.Module]] = nni.ConvReLU2d  # type: ignore[assignment, misc]
+    _FLOAT_MODULE: ClassVar[Type[nn.Module]] = nni.ConvReLU2d  # type: ignore[assignment]
     _FLOAT_CONV_MODULE: ClassVar[Type[nn.Conv2d]] = nn.Conv2d
     _FLOAT_BN_MODULE: ClassVar[Optional[Type[nn.Module]]] = None
     _FLOAT_RELU_MODULE: ClassVar[Optional[Type[nn.Module]]] = nn.ReLU
@@ -833,7 +833,7 @@ class ConvReLU2d(nnqat.Conv2d, nni._FusedModule):
         )
 
 
-class ConvBn3d(_ConvBnNd, nn.Conv3d):  # type: ignore[misc]
+class ConvBn3d(_ConvBnNd, nn.Conv3d):
     r"""
     A ConvBn3d module is a module fused from Conv3d and BatchNorm3d,
     attached with FakeQuantize modules for weight,
@@ -850,7 +850,7 @@ class ConvBn3d(_ConvBnNd, nn.Conv3d):  # type: ignore[misc]
         weight_fake_quant: fake quant module for weight
 
     """
-    _FLOAT_MODULE: ClassVar[Type[nni.ConvBn3d]] = nni.ConvBn3d  # type: ignore[assignment,misc]
+    _FLOAT_MODULE: ClassVar[Type[nni.ConvBn3d]] = nni.ConvBn3d  # type: ignore[assignment]
     _FLOAT_CONV_MODULE: ClassVar[Type[nn.Conv3d]] = nn.Conv3d
     _FLOAT_BN_MODULE: ClassVar[Optional[Type[nn.Module]]] = nn.BatchNorm3d
     _FLOAT_RELU_MODULE: ClassVar[Optional[Type[nn.Module]]] = None
@@ -918,10 +918,10 @@ class ConvBnReLU3d(ConvBn3d):
         weight_fake_quant: fake quant module for weight
 
     """
-    _FLOAT_MODULE: ClassVar[Type[nni.ConvBnReLU3d]] = nni.ConvBnReLU3d  # type: ignore[assignment, misc]
+    _FLOAT_MODULE: ClassVar[Type[nni.ConvBnReLU3d]] = nni.ConvBnReLU3d  # type: ignore[assignment]
     _FLOAT_CONV_MODULE: ClassVar[Type[nn.Conv3d]] = nn.Conv3d
     _FLOAT_BN_MODULE: ClassVar[Type[nn.BatchNorm3d]] = nn.BatchNorm3d
-    _FLOAT_RELU_MODULE: ClassVar[Optional[Type[nn.ReLU]]] = nn.ReLU  # type: ignore[assignment, misc]
+    _FLOAT_RELU_MODULE: ClassVar[Optional[Type[nn.ReLU]]] = nn.ReLU
     # module class after fusing bn into conv
     _FUSED_FLOAT_MODULE: ClassVar[Optional[Type[nni.ConvReLU3d]]] = nni.ConvReLU3d
 
@@ -985,7 +985,7 @@ class ConvReLU3d(nnqat.Conv3d, nni._FusedModule):
         weight_fake_quant: fake quant module for weight
 
     """
-    _FLOAT_MODULE: ClassVar[Type[nni.ConvReLU3d]] = nni.ConvReLU3d  # type: ignore[assignment,misc]
+    _FLOAT_MODULE: ClassVar[Type[nni.ConvReLU3d]] = nni.ConvReLU3d  # type: ignore[assignment]
     _FLOAT_CONV_MODULE: ClassVar[Type[nn.Conv3d]] = nn.Conv3d
     _FLOAT_BN_MODULE: ClassVar[Optional[Type[nn.Module]]] = None
     _FLOAT_RELU_MODULE: ClassVar[Optional[Type[nn.Module]]] = nn.ReLU

--- a/torch/ao/nn/qat/modules/conv.py
+++ b/torch/ao/nn/qat/modules/conv.py
@@ -66,12 +66,12 @@ class _ConvNd(nn.modules.conv._ConvNd):
             "qat."
             + cls.__name__
             + ".from_float only works for "
-            + cls._FLOAT_MODULE.__name__  # type: ignore[attr-defined]
+            + cls._FLOAT_MODULE.__name__
         )
         assert hasattr(mod, "qconfig"), "Input float module must have qconfig defined"
         assert mod.qconfig, "Input float module must have a valid qconfig"
         if issubclass(type(mod), _FusedModule):
-            mod = mod[0]  # type: ignore[index]
+            mod = mod[0]
         qconfig = mod.qconfig
         qat_conv = cls(
             mod.in_channels,
@@ -94,13 +94,13 @@ class _ConvNd(nn.modules.conv._ConvNd):
         to convert the qat module to a floating point module
         """
         cls = type(self)
-        conv = cls._FLOAT_CONV_MODULE(  # type: ignore[attr-defined, operator]
+        conv = cls._FLOAT_CONV_MODULE(  # type: ignore[attr-defined]
             self.in_channels,
             self.out_channels,
-            self.kernel_size,  # type: ignore[arg-type]
-            self.stride,  # type: ignore[arg-type]
-            self.padding,  # type: ignore[arg-type]
-            self.dilation,  # type: ignore[arg-type]
+            self.kernel_size,
+            self.stride,
+            self.padding,
+            self.dilation,
             self.groups,
             self.bias is not None,
             self.padding_mode,
@@ -112,9 +112,9 @@ class _ConvNd(nn.modules.conv._ConvNd):
         if issubclass(cls, _FusedModule):
             modules = [conv]
             assert hasattr(cls, "_FLOAT_RELU_MODULE")
-            relu = cls._FLOAT_RELU_MODULE()  # type: ignore[attr-defined]
+            relu = cls._FLOAT_RELU_MODULE()
             modules.append(relu)
-            fused = cls._FLOAT_MODULE(*modules)  # type: ignore[arg-type, attr-defined, operator]
+            fused = cls._FLOAT_MODULE(*modules)
             fused.train(self.training)
             return fused
         else:
@@ -134,7 +134,7 @@ class Conv1d(_ConvNd, nn.Conv1d):
     Attributes:
         weight_fake_quant: fake quant module for weight
     """
-    _FLOAT_MODULE: ClassVar[Type[nn.Conv1d]] = nn.Conv1d  # type: ignore[assignment,misc]
+    _FLOAT_MODULE: ClassVar[Type[nn.Conv1d]] = nn.Conv1d
     _FLOAT_CONV_MODULE: ClassVar[Type[nn.Conv1d]] = nn.Conv1d
 
     def __init__(
@@ -195,7 +195,7 @@ class Conv2d(_ConvNd, nn.Conv2d):
     Attributes:
         weight_fake_quant: fake quant module for weight
     """
-    _FLOAT_MODULE: ClassVar[Type[nn.Conv2d]] = nn.Conv2d  # type: ignore[assignment,misc]
+    _FLOAT_MODULE: ClassVar[Type[nn.Conv2d]] = nn.Conv2d
     _FLOAT_CONV_MODULE: ClassVar[Type[nn.Conv2d]] = nn.Conv2d
 
     def __init__(
@@ -259,7 +259,7 @@ class Conv3d(_ConvNd, nn.Conv3d):
     Attributes:
         weight_fake_quant: fake quant module for weight
     """
-    _FLOAT_MODULE: ClassVar[Type[nn.Conv3d]] = nn.Conv3d  # type: ignore[assignment,misc]
+    _FLOAT_MODULE: ClassVar[Type[nn.Conv3d]] = nn.Conv3d
     _FLOAT_CONV_MODULE: ClassVar[Type[nn.Conv3d]] = nn.Conv3d
 
     def __init__(

--- a/torch/ao/nn/quantizable/modules/activation.py
+++ b/torch/ao/nn/quantizable/modules/activation.py
@@ -134,8 +134,8 @@ class MultiheadAttention(nn.MultiheadAttention):
 
         # Set the linear weights
         # for the type: ignores, see https://github.com/pytorch/pytorch/issues/58969
-        observed.out_proj.weight = other.out_proj.weight  # type: ignore[has-type]
-        observed.out_proj.bias = other.out_proj.bias  # type: ignore[has-type]
+        observed.out_proj.weight = other.out_proj.weight
+        observed.out_proj.bias = other.out_proj.bias
         if other._qkv_same_embed_dim:
             # Use separate params
             bias = other.in_proj_bias
@@ -168,9 +168,9 @@ class MultiheadAttention(nn.MultiheadAttention):
             observed.linear_K.weight = nn.Parameter(other.k_proj_weight)
             observed.linear_V.weight = nn.Parameter(other.v_proj_weight)
             if other.in_proj_bias is None:
-                observed.linear_Q.bias = None  # type: ignore[assignment]
-                observed.linear_K.bias = None  # type: ignore[assignment]
-                observed.linear_V.bias = None  # type: ignore[assignment]
+                observed.linear_Q.bias = None
+                observed.linear_K.bias = None
+                observed.linear_V.bias = None
             else:
                 observed.linear_Q.bias = nn.Parameter(
                     other.in_proj_bias[0 : other.embed_dim]

--- a/torch/ao/nn/quantized/modules/linear.py
+++ b/torch/ao/nn/quantized/modules/linear.py
@@ -309,10 +309,14 @@ class Linear(WeightedQuantizedModule):
             # the type mismatch in assignment. Also, mypy has an issue with
             # iterables not being implemented, so we are ignoring those too.
             if not isinstance(cls._FLOAT_MODULE, Iterable):
-                cls._FLOAT_MODULE = [cls._FLOAT_MODULE]  # type: ignore[assignment]
-            supported_modules = ", ".join([float_mod.__name__ for float_mod in cls._FLOAT_MODULE])  # type: ignore[attr-defined]
+                cls._FLOAT_MODULE = [cls._FLOAT_MODULE]
+            supported_modules = ", ".join(
+                [float_mod.__name__ for float_mod in cls._FLOAT_MODULE]
+            )
             error_msg = f"nnq.{cls.__name__}.from_float only works for {supported_modules}, but got: {type(mod)}"
-            assert type_before_parametrizations(mod) in cls._FLOAT_MODULE, error_msg.format()  # type: ignore[attr-defined]
+            assert (
+                type_before_parametrizations(mod) in cls._FLOAT_MODULE
+            ), error_msg.format()
             assert hasattr(
                 mod, "qconfig"
             ), "Input float module must have qconfig defined"

--- a/torch/ao/nn/sparse/quantized/linear.py
+++ b/torch/ao/nn/sparse/quantized/linear.py
@@ -267,7 +267,7 @@ class Linear(torch.nn.Module):
         )
         qlinear.set_weight_bias(
             qweight, mod.bias, row_block_size, col_block_size  # type: ignore[arg-type]
-        )  # type: ignore[arg-type]
+        )
         qlinear.scale = float(act_scale)
         qlinear.zero_point = int(act_zp)
         return qlinear

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -146,7 +146,7 @@ class ObserverBase(ABC, nn.Module):
         or static quantization
     """
 
-    def __init__(self, dtype, is_dynamic=False):
+    def __init__(self, dtype, is_dynamic: bool = False):
         super().__init__()
         self.dtype = dtype
         self.is_dynamic = is_dynamic
@@ -1510,7 +1510,7 @@ class RecordingObserver(ObserverBase):
     __annotations__ = {"tensor_val": List[Optional[torch.Tensor]]}
 
     def __init__(self, dtype=torch.quint8):
-        super().__init__(dtype=dtype, is_dynamic=False)  # type: ignore[call-arg]
+        super().__init__(dtype=dtype, is_dynamic=False)
         self.tensor_val = []
 
     def forward(self, x):

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -969,4 +969,4 @@ def _add_kl_info():
         )
     kl_info = "\n\t".join(rows)
     if kl_divergence.__doc__:
-        kl_divergence.__doc__ += kl_info  # type: ignore[operator]
+        kl_divergence.__doc__ += kl_info

--- a/torch/export/dynamic_shapes.py
+++ b/torch/export/dynamic_shapes.py
@@ -430,11 +430,11 @@ def _process_equalities(
         # branch based on the root of the _DerivedConstraint
         if not isinstance(constraint.root, _PhantomRoot):
             # either root points to an input source
-            root = get_sources(constraint.root.t_id, constraint.root.dim)[0]  # type: ignore[assignment]
+            root = get_sources(constraint.root.t_id, constraint.root.dim)[0]
         else:
             # or root points to a phantom symbol
             if constraint.root.name in phantom_symbols:
-                root = phantom_symbols[constraint.root.name]  # type: ignore[assignment]
+                root = phantom_symbols[constraint.root.name]
             else:
                 # create a phantom symbol in the shape env based on the _PhantomRoot
                 root = shape_env.create_symbol(
@@ -443,7 +443,7 @@ def _process_equalities(
                     dynamic_dim=torch.fx.experimental.symbolic_shapes.DimDynamic.DYNAMIC,
                     constraint_dim=constraint.root.constraint_range,
                 )
-                phantom_symbols[constraint.root.name] = root  # type: ignore[assignment]
+                phantom_symbols[constraint.root.name] = root
 
         fn = constraint.fn
         # A derived equality (source, root, fn) informally corresponds to source = fn(root).
@@ -825,7 +825,7 @@ def _process_dynamic_shapes(
             expr = dim.fn(symbol)
             solution = try_solve(sympy.Eq(expr, tensor.shape[i]), symbol)
             if solution is not None:
-                return int(solution[1])  # type: ignore[call-overload]
+                return int(solution[1])
             else:
                 raise UserError(  # noqa: B904
                     UserErrorType.CONSTRAINT_VIOLATION,
@@ -965,7 +965,7 @@ def _process_dynamic_shapes(
     for dynamic_dims in symbols.values():
         constraints.extend(dynamic_dims)
 
-    return constraints  # type: ignore[return-value]
+    return constraints
 
 
 def _get_dim_name_mapping(
@@ -1065,7 +1065,7 @@ def refine_dynamic_shapes_from_suggested_fixes(
             expr = sympy.sympify(expr)
             if isinstance(expr, sympy.Number):
                 # static, integer
-                shape_fixes[name] = int(expr)  # type: ignore[assignment]
+                shape_fixes[name] = int(expr)
             else:
                 # relation or derived dim
                 shape_fixes[name] = expr
@@ -1101,11 +1101,11 @@ def refine_dynamic_shapes_from_suggested_fixes(
                 else:
                     symbol = next(iter(fix.free_symbols))
                     # try to locate symbol
-                    if symbol.name in shape_fixes:  # type: ignore[attr-defined]
-                        root = shape_fixes[symbol.name]  # type: ignore[attr-defined]
+                    if symbol.name in shape_fixes:
+                        root = shape_fixes[symbol.name]
                     else:
-                        assert symbol.name in name_to_dim  # type: ignore[attr-defined]
-                        root = name_to_dim[symbol.name]  # type: ignore[attr-defined]
+                        assert symbol.name in name_to_dim
+                        root = name_to_dim[symbol.name]
                     # figure out value of fix
                     modulus, remainder = sympy.polys.polytools.div(fix, symbol)
                     dim = root

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -399,7 +399,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
         # Fix the graph output signature to be tuple if scalar
         out_spec = mod._out_spec
 
-        orig_arg_names = mod.graph._codegen.pytree_info.orig_args  # type: ignore[attr-defined]
+        orig_arg_names = mod.graph._codegen.pytree_info.orig_args
 
         # aot_export expect the return type to always be a tuple.
         if out_spec.type not in (list, tuple):
@@ -1051,7 +1051,7 @@ class ExportedProgram:
             kwargs = reorder_kwargs(kwargs, in_spec)
         flat_args_with_path, received_spec = pytree.tree_flatten_with_path(
             (args, kwargs)
-        )  # type: ignore[possibly-undefined]
+        )
         self._check_input_constraints(flat_args_with_path)
         flat_args = tuple(x[1] for x in flat_args_with_path)
         return flat_args, received_spec

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -1330,7 +1330,7 @@ def _outline_submodules(orig_graph: torch.fx.Graph, root_module: UnflattenedModu
         "",
         {
             entry.fqn: entry.signature
-            for entry in root_module.module_call_graph  # type: ignore[union-attr]
+            for entry in root_module.module_call_graph
             if entry.signature
         },
         module=root_module,
@@ -1497,7 +1497,7 @@ def _deduplicate_modules(partitions):
                         seen_target = _compute_accessor(
                             entry.parent_fqn, seen_child_fqn
                         )
-                        entry.parent_call_module.target = seen_target  # type: ignore[union-attr]
+                        entry.parent_call_module.target = seen_target
                         redirected_call_indices[child_fqn] = seen_child_fqn
                         break
                     elif not deduplicated:

--- a/torch/jit/_script.pyi
+++ b/torch/jit/_script.pyi
@@ -195,7 +195,7 @@ def script(
     example_inputs: list[tuple] | dict[Callable, list[tuple]] | None = None,
 ) -> Never: ...
 @overload
-def script(  # type: ignore[misc]
+def script(
     obj: dict,
     optimize: bool | None = None,
     _frames_up: int = 0,
@@ -203,7 +203,7 @@ def script(  # type: ignore[misc]
     example_inputs: list[tuple] | dict[Callable, list[tuple]] | None = None,
 ) -> torch.ScriptDict: ...
 @overload
-def script(  # type: ignore[misc]
+def script(
     obj: list,
     optimize: bool | None = None,
     _frames_up: int = 0,
@@ -211,7 +211,7 @@ def script(  # type: ignore[misc]
     example_inputs: list[tuple] | dict[Callable, list[tuple]] | None = None,
 ) -> torch.ScriptList: ...
 @overload
-def script(  # type: ignore[misc]
+def script(  # type: ignore[overload-overlap]
     obj: Module,
     optimize: bool | None = None,
     _frames_up: int = 0,
@@ -219,7 +219,7 @@ def script(  # type: ignore[misc]
     example_inputs: list[tuple] | dict[Callable, list[tuple]] | None = None,
 ) -> RecursiveScriptModule: ...
 @overload
-def script(  # type: ignore[misc]
+def script(  # type: ignore[overload-overlap]
     obj: _ClassVar,
     optimize: bool | None = None,
     _frames_up: int = 0,
@@ -227,7 +227,7 @@ def script(  # type: ignore[misc]
     example_inputs: list[tuple] | dict[Callable, list[tuple]] | None = None,
 ) -> _ClassVar: ...
 @overload
-def script(  # type: ignore[misc]
+def script(
     obj: Callable,
     optimize: bool | None = None,
     _frames_up: int = 0,

--- a/torch/jit/_serialization.py
+++ b/torch/jit/_serialization.py
@@ -149,10 +149,10 @@ def load(f, map_location=None, _extra_files=None, _restore_shapes=False):
         os.remove("scriptmodule.pt")
     """
     if isinstance(f, (str, os.PathLike)):
-        if not os.path.exists(f):  # type: ignore[type-var]
-            raise ValueError(f"The provided filename {f} does not exist")  # type: ignore[str-bytes-safe]
+        if not os.path.exists(f):
+            raise ValueError(f"The provided filename {f} does not exist")
         if os.path.isdir(f):
-            raise ValueError(f"The provided filename {f} is a directory")  # type: ignore[str-bytes-safe]
+            raise ValueError(f"The provided filename {f} is a directory")
 
     map_location = validate_map_location(map_location)
     if _extra_files is None:

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -80,7 +80,7 @@ def _get_total_norm(
     )  # type: ignore[assignment]
 
     norms: List[Tensor] = []
-    for (device, _), ([device_tensors], _) in grouped_tensors.items():  # type: ignore[assignment]
+    for (device, _), ([device_tensors], _) in grouped_tensors.items():
         if (foreach is None and _has_foreach_support(device_tensors, device)) or (
             foreach and _device_has_foreach_support(device)
         ):
@@ -157,7 +157,7 @@ def _clip_grads_with_norm_(
     # avoids a `if clip_coef < 1:` conditional which can require a CPU <=> device synchronization
     # when the gradients do not reside in CPU memory.
     clip_coef_clamped = torch.clamp(clip_coef, max=1.0)
-    for (device, _), ([device_grads], _) in grouped_grads.items():  # type: ignore[assignment]
+    for (device, _), ([device_grads], _) in grouped_grads.items():
         if (foreach is None and _has_foreach_support(device_grads, device)) or (
             foreach and _device_has_foreach_support(device)
         ):
@@ -266,7 +266,7 @@ def clip_grad_value_(
     grads = [p.grad for p in parameters if p.grad is not None]
     grouped_grads = _group_tensors_by_device_and_dtype([grads])
 
-    for (device, _), ([grads], _) in grouped_grads.items():  # type: ignore[assignment]
+    for (device, _), ([grads], _) in grouped_grads.items():
         if (
             foreach is None
             and _has_foreach_support(cast(List[Tensor], grads), device=device)

--- a/torch/onnx/_internal/fx/decomposition_table.py
+++ b/torch/onnx/_internal/fx/decomposition_table.py
@@ -94,7 +94,7 @@ def create_onnx_friendly_decomposition_table(
     # NOTE: If we import torch._decomp, we will get RuntimeError: Only a single
     # TORCH_LIBRARY can be used to register the namespace nvprims; please put all of your
     # definitions in a single TORCH_LIBRARY block.
-    for op_overload, decomp_fn in torch._decomp.decomposition_table.items():  # type: ignore[attr-defined]
+    for op_overload, decomp_fn in torch._decomp.decomposition_table.items():
         # Skip decomposition into "prim::*" ops (defined in 'torch._refs'), because they
         # are not generally supported by ONNX.
         # Skip decomposition for op_overload as long as that op_overload has a corresponding ONNX

--- a/torch/onnx/_internal/io_adapter.py
+++ b/torch/onnx/_internal/io_adapter.py
@@ -603,7 +603,7 @@ class PrependParamsBuffersConstantAotAutogradInputStep(InputAdaptStep):
                 ordered_buffers.append(model.state_dict[name])  # type: ignore[union-attr,index]
         ordered_constant_tensors = tuple(
             model.constants[fqn]  # type: ignore[union-attr,index]
-            for fqn in model.graph_signature.lifted_tensor_constants  # type: ignore[union-attr,operator]
+            for fqn in model.graph_signature.lifted_tensor_constants  # type: ignore[union-attr]
         )
 
         # NOTE: calling convention is first params, then buffers, then args as user supplied them.

--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -453,14 +453,14 @@ class SWALR(LRScheduler):
         """Get learning rate."""
         # `_get_lr_called_within_step` is only available `_enable_get_lr_call`,
         # so we ignore the type error here. See `LRScheduler.step()` for more details.
-        if not self._get_lr_called_within_step:  # type: ignore[attr-defined]
+        if not self._get_lr_called_within_step:
             warnings.warn(
                 "To get the last learning rate computed by the scheduler, "
                 "please use `get_last_lr()`.",
                 UserWarning,
             )
         # Set in `LRScheduler._initial_step()`
-        step = self._step_count - 1  # type: ignore[attr-defined]
+        step = self._step_count - 1
         if self.anneal_epochs == 0:
             step = max(1, step)
         prev_t = max(0, min(1, (step - 1) / max(1, self.anneal_epochs)))

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2080,7 +2080,7 @@ def _get_build_directory(name: str, verbose: bool) -> str:
     if root_extensions_directory is None:
         root_extensions_directory = get_default_build_root()
         cu_str = ('cpu' if torch.version.cuda is None else
-                  f'cu{torch.version.cuda.replace(".", "")}')  # type: ignore[attr-defined]
+                  f'cu{torch.version.cuda.replace(".", "")}')
         python_version = f'py{sys.version_info.major}{sys.version_info.minor}{getattr(sys, "abiflags", "")}'
         build_folder = f'{python_version}_{cu_str}'
 

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -12,7 +12,7 @@ from torch.utils.data.datapipes.datapipe import IterDataPipe, MapDataPipe
 __all__ = ["traverse", "traverse_dps"]
 
 DataPipe = Union[IterDataPipe, MapDataPipe]
-DataPipeGraph = Dict[int, Tuple[DataPipe, "DataPipeGraph"]]  # type: ignore[misc]
+DataPipeGraph = Dict[int, Tuple[DataPipe, "DataPipeGraph"]]
 
 
 def _stub_unpickler():
@@ -39,10 +39,10 @@ def _list_connected_datapipes(
     def getstate_hook(ori_state):
         state = None
         if isinstance(ori_state, dict):
-            state = {}  # type: ignore[assignment]
+            state = {}
             for k, v in ori_state.items():
                 if isinstance(v, (IterDataPipe, MapDataPipe, Collection)):
-                    state[k] = v  # type: ignore[attr-defined]
+                    state[k] = v
         elif isinstance(ori_state, (tuple, list)):
             state = []  # type: ignore[assignment]
             for v in ori_state:

--- a/torch/utils/data/graph_settings.py
+++ b/torch/utils/data/graph_settings.py
@@ -121,7 +121,7 @@ def apply_shuffle_settings(
         datapipe = datapipe.shuffle()
         shufflers = [
             datapipe,
-        ]  # type: ignore[list-item]
+        ]
 
     for shuffler in shufflers:
         shuffler.set_shuffle(shuffle)


### PR DESCRIPTION
Over time, a large number of the existing type ignores have become irrelevant/unused/dead as a result of improvements in annotations and type checking.

Having these `# type: ignore` linger around is not ideal for two reasons:

- They are verbose/ugly syntatically.
- They could hide genuine bugs in the future, if a refactoring would actually introduce a bug but it gets hidden by the ignore.

I'm counting over 1500 unused ignores already. This is a first PR that removes some of them. Note that I haven't touched type ignores that looked "conditional" like the import challenge mentioned in https://github.com/pytorch/pytorch/pull/60006#issuecomment-2480604728. I will address these at a later point, and eventually would enable `warn_unused_ignores = True` in the mypy configuration as discussed in that comment to prevent accumulating more dead ignores going forward.

This PR should have no effect on runtime at all.


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @ezyang @SherlockNoMad