### PR TITLE
Fix type annotation of `Linear.bias`

### DIFF
--- a/torch/ao/pruning/_experimental/pruner/base_structured_sparsifier.py
+++ b/torch/ao/pruning/_experimental/pruner/base_structured_sparsifier.py
@@ -265,7 +265,7 @@ class BaseStructuredSparsifier(BaseSparsifier):
                     module.prune_bias = prune_bias
 
                 module.register_forward_hook(
-                    BiasHook(module.parametrizations.weight[0], prune_bias)
+                    BiasHook(module.parametrizations.weight[0], prune_bias)  # type: ignore[union-attr, index]
                 )
 
     def prune(self) -> None:

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -7,6 +7,7 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.nn.init import constant_, xavier_normal_, xavier_uniform_
 from torch.nn.parameter import Parameter
+from torch.utils._typing_utils import not_none
 
 from .linear import NonDynamicallyQuantizableLinear
 from .module import Module
@@ -1122,6 +1123,7 @@ class MultiheadAttention(Module):
             xavier_uniform_(self.v_proj_weight)
 
         if self.in_proj_bias is not None:
+            assert self.out_proj.bias is not None
             constant_(self.in_proj_bias, 0.0)
             constant_(self.out_proj.bias, 0.0)
         if self.bias_k is not None:
@@ -1319,7 +1321,7 @@ class MultiheadAttention(Module):
                         self.in_proj_weight,
                         self.in_proj_bias,
                         self.out_proj.weight,
-                        self.out_proj.bias,
+                        not_none(self.out_proj.bias),
                         merged_mask,
                         need_weights,
                         average_attn_weights,

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -1,6 +1,6 @@
 # mypy: allow-untyped-defs
 import math
-from typing import Any
+from typing import Any, Optional, TYPE_CHECKING
 
 import torch
 from torch import Tensor
@@ -89,6 +89,8 @@ class Linear(Module):
     in_features: int
     out_features: int
     weight: Tensor
+    if TYPE_CHECKING:
+        bias: Optional[Tensor]
 
     def __init__(
         self,
@@ -190,6 +192,8 @@ class Bilinear(Module):
     in2_features: int
     out_features: int
     weight: Tensor
+    if TYPE_CHECKING:
+        bias: Optional[Tensor]
 
     def __init__(
         self,

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 from torch.nn.init import xavier_uniform_
+from torch.utils._typing_utils import not_none
 
 from .activation import MultiheadAttention
 from .container import ModuleList
@@ -847,15 +848,15 @@ class TransformerEncoderLayer(Module):
                 self.self_attn.in_proj_weight,
                 self.self_attn.in_proj_bias,
                 self.self_attn.out_proj.weight,
-                self.self_attn.out_proj.bias,
+                not_none(self.self_attn.out_proj.bias),
                 self.norm1.weight,
                 self.norm1.bias,
                 self.norm2.weight,
                 self.norm2.bias,
                 self.linear1.weight,
-                self.linear1.bias,
+                not_none(self.linear1.bias),
                 self.linear2.weight,
-                self.linear2.bias,
+                not_none(self.linear2.bias),
             )
 
             # We have to use list comprehensions below because TorchScript does not support
@@ -891,7 +892,7 @@ class TransformerEncoderLayer(Module):
                     self.self_attn.in_proj_weight,
                     self.self_attn.in_proj_bias,
                     self.self_attn.out_proj.weight,
-                    self.self_attn.out_proj.bias,
+                    not_none(self.self_attn.out_proj.bias),
                     self.activation_relu_or_gelu == 2,
                     self.norm_first,
                     self.norm1.eps,
@@ -900,9 +901,9 @@ class TransformerEncoderLayer(Module):
                     self.norm2.weight,
                     self.norm2.bias,
                     self.linear1.weight,
-                    self.linear1.bias,
+                    not_none(self.linear1.bias),
                     self.linear2.weight,
-                    self.linear2.bias,
+                    not_none(self.linear2.bias),
                     merged_mask,
                     mask_type,
                 )

--- a/torch/utils/_typing_utils.py
+++ b/torch/utils/_typing_utils.py
@@ -1,6 +1,6 @@
 """Miscellaneous utilities to aid with typing."""
 
-from typing import Optional, TypeVar
+from typing import Optional, TYPE_CHECKING, TypeVar
 
 
 # Helper to turn Optional[T] into T when we know None either isn't
@@ -8,7 +8,19 @@ from typing import Optional, TypeVar
 T = TypeVar("T")
 
 
-def not_none(obj: Optional[T]) -> T:
-    if obj is None:
-        raise TypeError("Invariant encountered: value was None when it should not be")
-    return obj
+# TorchScript cannot handle the type signature of `not_none` at runtime, because it trips
+# over the `Optional[T]`. To allow using `not_none` from inside a TorchScript method/module,
+# we split the implementation, and hide the runtime type information from TorchScript.
+if TYPE_CHECKING:
+
+    def not_none(obj: Optional[T]) -> T:
+        ...
+
+else:
+
+    def not_none(obj):
+        if obj is None:
+            raise TypeError(
+                "Invariant encountered: value was None when it should not be"
+            )
+        return obj


### PR DESCRIPTION
Currently the `bias` attribute of `torch.nn.Linear` (and `Bilinear`) is typed incorrectly, because it relies on the implicit `Module.__getattr__` which types it as `Tensor | Module`. This has two issues:

- It hides the fact that `bias` is optional, and can be `None`, which in turn can hide actual bugs on user side.
- It blurs the type due to having `Module` in the union, which can require unnecessary `isistance(linear.bias, Tensor)` on user side.

This PR types the `bias` attribute explicitly to fix these issues.

CC @ezyang @Skylion007 


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @xmfan @kwen2501 @c-p-i-o @yf225 @ColinPeppler @desertfire @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn @ekr0