### PR TITLE
[AOTInductor] Add standalone test for compilation from ExportedProgram

### DIFF
--- a/test/cpp/aoti_inference/generate_lowered_cpu.py
+++ b/test/cpp/aoti_inference/generate_lowered_cpu.py
@@ -1,0 +1,62 @@
+import copy
+
+import click
+
+import torch
+
+
+class Serializer(torch.nn.Module):
+    def __init__(self, data):
+        super().__init__()
+        for key in data:
+            setattr(self, key, data[key])
+
+
+@click.command()
+@click.option(
+    "--input-path",
+    type=str,
+    default="",
+    required=True,
+    help="path to the ExportedProgram",
+)
+@click.option(
+    "--output-path",
+    type=str,
+    default="",
+    required=True,
+)
+def main(
+    input_path: str = "",
+    output_path: str = "",
+) -> None:
+    data = {}
+    ep = torch.export.load(input_path)
+    with torch.no_grad():
+        example_inputs = ep.example_inputs[0]
+        # Get scripted original module.
+        module = torch.jit.trace(copy.deepcopy(ep.module()), example_inputs)
+
+        # Get aot compiled module.
+        so_path = torch._inductor.aot_compile(ep.module(), example_inputs)
+        runner = torch.fx.Interpreter(ep.module())
+        output = runner.run(example_inputs)
+        if isinstance(output, (list, tuple)):
+            output = list(output)
+        else:
+            output = [output]
+
+        data.update(
+            {
+                "script_module": module,
+                "model_so_path": so_path,
+                "inputs": list(example_inputs),
+                "outputs": output,
+            }
+        )
+
+    torch.jit.script(Serializer(data)).save(output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/cpp/aoti_inference/standalone_compile.sh
+++ b/test/cpp/aoti_inference/standalone_compile.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+if [ -z "$CXX" ]; then
+    CXX="clang++"
+    echo "Using system default C++ compiler: $CXX"
+else
+    echo "Using user-provided C++ compiler: $CXX"
+fi
+
+if [ -z "$TORCH_ROOT_DIR" ]; then
+    echo "Error: The TORCH_ROOT_DIR environment variable must be set." >&2
+    echo "Example: export TORCH_ROOT_DIR=/home/$USER/local/pytorch" >&2
+    exit 1
+fi
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <input file path> <output file path>."
+    echo "Example Usage: $0 standalone_test.cpp standalone_test.out."
+    exit 1
+fi
+
+# Building the wrapper
+$CXX -I$TORCH_ROOT_DIR/build/aten/src -I$TORCH_ROOT_DIR/aten/src -I$TORCH_ROOT_DIR/build -I$TORCH_ROOT_DIR -I$TORCH_ROOT_DIR/build/caffe2/aten/src -I$TORCH_ROOT_DIR/torch/csrc/api -I$TORCH_ROOT_DIR/torch/csrc/api/include -std=gnu++17 -fPIE -o $1.o -c $1
+
+# Linking
+$CXX -rdynamic -Wl,--no-as-needed,$TORCH_ROOT_DIR/build/lib/libtorch.so $1.o -Wl,--no-as-needed,$TORCH_ROOT_DIR/build/lib/libtorch_cpu.so -Wl,--no-as-needed,$TORCH_ROOT_DIR/build/lib/libc10.so -o $2

--- a/test/cpp/aoti_inference/standalone_test.cpp
+++ b/test/cpp/aoti_inference/standalone_test.cpp
@@ -1,0 +1,81 @@
+#include <chrono>
+#include <string>
+
+#include <torch/csrc/inductor/aoti_runner/model_container_runner_cpu.h>
+#include <torch/script.h>
+#include <torch/torch.h>
+
+int main(int argc, char* argv[]) {
+  if (argc < 2) {
+    std::cerr
+        << "Usage: ./standalone_test <input file> [benchmark iter] [warm-up iter]"
+        << std::endl;
+    return 1;
+  }
+  size_t benchmark_iter = 10;
+  size_t warmup_iter = 3;
+
+  if (argc == 3) {
+    benchmark_iter = std::stoul(argv[2]);
+  } else if (argc == 4) {
+    benchmark_iter = std::stoul(argv[2]);
+    warmup_iter = std::stoul(argv[3]);
+  }
+
+  std::string data_path = argv[1];
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+  torch::jit::script::Module model =
+      data_loader.attr("script_module").toModule();
+  const auto& model_so_path = data_loader.attr("model_so_path").toStringRef();
+  const auto& script_input_tensors = data_loader.attr("inputs").toList().vec();
+  const auto& input_tensors = data_loader.attr("inputs").toTensorList().vec();
+  const auto& output_tensors = data_loader.attr("outputs").toTensorList().vec();
+
+  std::unique_ptr<torch::inductor::AOTIModelContainerRunner> runner;
+  runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCpu>(
+      model_so_path);
+
+  // Check results.
+  auto actual_output_tensors = runner->run(input_tensors);
+  assert(output_tensors.size() == actual_output_tensors.size());
+  for (size_t i = 0; i < output_tensors.size(); i++) {
+    assert(torch::allclose(output_tensors[i], actual_output_tensors[i]));
+  }
+
+  // Start benchmarking for scripted module.
+  // Warm up
+  for (size_t i = 0; i < warmup_iter; i++) {
+    model.forward(script_input_tensors);
+  }
+
+  // Benchmark
+  auto start = std::chrono::high_resolution_clock::now();
+  for (size_t i = 0; i < benchmark_iter; i++) {
+    model.forward(script_input_tensors);
+  }
+  auto end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> non_lowered_duration = end - start;
+
+  // Start benchmarking for lowered module.
+  // Warm up
+  for (size_t i = 0; i < warmup_iter; i++) {
+    runner->run(input_tensors);
+  }
+
+  // Benchmark
+  start = std::chrono::high_resolution_clock::now();
+  for (size_t i = 0; i < benchmark_iter; i++) {
+    runner->run(input_tensors);
+  }
+  end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> lowered_duration = end - start;
+
+  std::cout << "[Non-lowered] Time for " << benchmark_iter
+            << "iter(s): " << non_lowered_duration.count() << " sec(s)"
+            << std::endl;
+  std::cout << "[Lowered] Time for " << benchmark_iter
+            << "iter(s): " << lowered_duration.count() << " sec(s)"
+            << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
Summary: Provide a standalone path to compile and run a ExportedProgram in C.

Test Plan:
(1) Generate a compiled model from ExportedProgram
```
python generate_lowered_cpu.py --input-path /tmp/$USER/ep.pt --output-path /tmp/$USER/final.pt
```
(2) Compile a standalone test runner
```
TORCH_ROOT_DIR=/data/users/$USER/pytorch sh standalone_compile.sh standalone_test.cpp standalone_test.out
```
(3) Run test for the compiled model in step (1)
```
LD_LIBRARY_PATH=/data/users/$USER/pytorch/build/lib ./standalone_test.out /tmp/$USER/final.pt
```

Differential Revision: D66872380


