### PR TITLE
Remove unused optional type renaming

### DIFF
--- a/c10/test/core/SymInt_test.cpp
+++ b/c10/test/core/SymInt_test.cpp
@@ -8,7 +8,7 @@ using namespace c10;
 #ifndef C10_MOBILE
 static void check(int64_t value) {
   const auto i = SymInt(value);
-  EXPECT_EQ(i.maybe_as_int(), std::make_optional(value));
+  EXPECT_EQ(i.maybe_as_int(), value);
 }
 
 TEST(SymIntTest, ConcreteInts) {

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -10,13 +10,7 @@
 
 namespace c10 {
 // NOLINTNEXTLINE(misc-unused-using-decls)
-using std::bad_optional_access;
-// NOLINTNEXTLINE(misc-unused-using-decls)
-using std::make_optional;
-// NOLINTNEXTLINE(misc-unused-using-decls)
 using std::nullopt;
-// NOLINTNEXTLINE(misc-unused-using-decls)
-using std::nullopt_t;
 // NOLINTNEXTLINE(misc-unused-using-decls)
 using std::optional;
 


### PR DESCRIPTION
No use cases in PyTorch organization.