### PR TITLE
Fixed installing dependencies instructions in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,7 +288,7 @@ The following packages should be installed with either `conda` or `pip`:
 - `pytest` - recommended to run tests more selectively
 Running
 ```
-pip install -r requirements
+pip install -r requirements.txt
 ```
 will install these dependencies for you.
 


### PR DESCRIPTION
In the original code, “pip install -r requirements” missed the suffix “.txt”, so I'll add it.
