### PR TITLE
[torchgen] Fix an unused variable in api/python.py

### DIFF
--- a/torchgen/api/python.py
+++ b/torchgen/api/python.py
@@ -994,7 +994,7 @@ def return_type_str_pyi(t: Type) -> str:
         if t.name == BaseTy.Device:
             return "_device"
         elif t.name == BaseTy.Dimname:
-            ret = "Optional[str]"
+            return "Optional[str]"
         else:
             return argument_type_str_pyi(t)
 


### PR DESCRIPTION
Extracted from https://github.com/pytorch/pytorch/pull/136359

Changes behavior, but the original code seems like it was an obvious oops.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142337

