### PR TITLE
Added Diffentiable per_sample_weights Check to EmbeddingBag.cpp

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -1241,9 +1241,9 @@ embedding_bag(const Tensor &weight, const Tensor &indices,
     padding_idx = maybe_wrap_dim(padding_idx, weight.size(0));
   }
   std::tuple<Tensor, Tensor, Tensor, Tensor> out;
-  bool needs_grad_path = weight.requires_grad() || 
+  bool needs_grad_path = weight.requires_grad() ||
                       weight._fw_grad(/*level=*/0).defined() ||
-                      (per_sample_weights_opt.has_value() && 
+                      (per_sample_weights_opt.has_value() &&
                        per_sample_weights_opt.value().defined() &&
                        per_sample_weights_opt.value().requires_grad());
 

--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -1241,7 +1241,13 @@ embedding_bag(const Tensor &weight, const Tensor &indices,
     padding_idx = maybe_wrap_dim(padding_idx, weight.size(0));
   }
   std::tuple<Tensor, Tensor, Tensor, Tensor> out;
-  if (!weight.requires_grad() && !weight._fw_grad(/*level=*/0).defined()) {
+  bool needs_grad_path = weight.requires_grad() || 
+                      weight._fw_grad(/*level=*/0).defined() ||
+                      (per_sample_weights_opt.has_value() && 
+                       per_sample_weights_opt.value().defined() &&
+                       per_sample_weights_opt.value().requires_grad());
+
+  if (!needs_grad_path) {
     out = at::_embedding_bag_forward_only(
       weight, indices.contiguous(), offsets.contiguous(), scale_grad_by_freq,
       mode, sparse, per_sample_weights, include_last_offset, padding_idx);

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -142,6 +142,7 @@ class TestEmbeddingNN(NNTestCase):
         "bag_use_grad,per_sample_weights_use_grad",
         [(True, True), (True, False), (False, True), (False, False)],
     )
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_embedding_bag_per_sample_weights_grad_cuda(
         self, bag_use_grad: bool, per_sample_weights_use_grad: bool
     ):

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -124,35 +124,6 @@ class TestEmbeddingNN(NNTestCase):
         output = embedding(input, torch.arange(input.size(0)))
         self.assertEqual(a, output)
 
-    @parametrize_test(
-        "bag_use_grad,per_sample_weights_use_grad",
-        [(True, True), (True, False), (False, True), (False, False)],
-    )
-    def test_embedding_bag_per_sample_weights_grad_cpu(
-        self, bag_use_grad: bool, per_sample_weights_use_grad: bool
-    ):
-        device = "cpu"
-        bag = torch.nn.EmbeddingBag(256, 256, mode="sum", device=device)
-        bag.requires_grad_(bag_use_grad)
-        x = torch.arange(1, 5, device=device).expand(3, -1)
-        w = torch.rand(3, 4, device=device, requires_grad=per_sample_weights_use_grad)
-        bag(x, per_sample_weights=F.softmax(w, dim=-1))
-
-    @parametrize_test(
-        "bag_use_grad,per_sample_weights_use_grad",
-        [(True, True), (True, False), (False, True), (False, False)],
-    )
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    def test_embedding_bag_per_sample_weights_grad_cuda(
-        self, bag_use_grad: bool, per_sample_weights_use_grad: bool
-    ):
-        device = "cuda"
-        bag = torch.nn.EmbeddingBag(256, 256, mode="sum", device=device)
-        bag.requires_grad_(bag_use_grad)
-        x = torch.arange(1, 5, device=device).expand(3, -1)
-        w = torch.rand(3, 4, device=device, requires_grad=per_sample_weights_use_grad)
-        bag(x, per_sample_weights=F.softmax(w, dim=-1))
-
     def test_embedding_from_pretrained_padding_idx(self):
         padding_idx = 2
         padding_vec = torch.ones(3) * 7
@@ -1646,6 +1617,19 @@ class TestEmbeddingNNDeviceType(NNTestCase):
             odtype=dtypes[1],
             test_backward=True,
         )
+        
+    @parametrize_test(
+        "bag_use_grad,per_sample_weights_use_grad",
+        [(True, True), (True, False), (False, True), (False, False)],
+    )
+    def test_embedding_bag_per_sample_weights_grad(
+        self, device, bag_use_grad: bool, per_sample_weights_use_grad: bool
+    ):
+        bag = torch.nn.EmbeddingBag(256, 256, mode="sum", device=device)
+        bag.requires_grad_(bag_use_grad)
+        x = torch.arange(1, 5, device=device).expand(3, -1)
+        w = torch.rand(3, 4, device=device, requires_grad=per_sample_weights_use_grad)
+        bag(x, per_sample_weights=F.softmax(w, dim=-1))
 
 
 instantiate_device_type_tests(TestEmbeddingNNDeviceType, globals())

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -124,6 +124,34 @@ class TestEmbeddingNN(NNTestCase):
         output = embedding(input, torch.arange(input.size(0)))
         self.assertEqual(a, output)
 
+    @parametrize_test(
+        "bag_use_grad,per_sample_weights_use_grad",
+        [(True, True), (True, False), (False, True), (False, False)],
+    )
+    def test_embedding_bag_per_sample_weights_grad_cpu(
+        self, bag_use_grad: bool, per_sample_weights_use_grad: bool
+    ):
+        device = "cpu"
+        bag = torch.nn.EmbeddingBag(256, 256, mode="sum", device=device)
+        bag.requires_grad_(bag_use_grad)
+        x = torch.arange(1, 5, device=device).expand(3, -1)
+        w = torch.rand(3, 4, device=device, requires_grad=per_sample_weights_use_grad)
+        bag(x, per_sample_weights=F.softmax(w, dim=-1))
+
+    @parametrize_test(
+        "bag_use_grad,per_sample_weights_use_grad",
+        [(True, True), (True, False), (False, True), (False, False)],
+    )
+    def test_embedding_bag_per_sample_weights_grad_cuda(
+        self, bag_use_grad: bool, per_sample_weights_use_grad: bool
+    ):
+        device = "cuda"
+        bag = torch.nn.EmbeddingBag(256, 256, mode="sum", device=device)
+        bag.requires_grad_(bag_use_grad)
+        x = torch.arange(1, 5, device=device).expand(3, -1)
+        w = torch.rand(3, 4, device=device, requires_grad=per_sample_weights_use_grad)
+        bag(x, per_sample_weights=F.softmax(w, dim=-1))
+
     def test_embedding_from_pretrained_padding_idx(self):
         padding_idx = 2
         padding_vec = torch.ones(3) * 7

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -1617,7 +1617,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
             odtype=dtypes[1],
             test_backward=True,
         )
-        
+
     @parametrize_test(
         "bag_use_grad,per_sample_weights_use_grad",
         [(True, True), (True, False), (False, True), (False, False)],


### PR DESCRIPTION
Added a check in aten/src/ATen/native/EmbeddingBag.cpp that checks if per_sample_weights needs a gradient in order to determine if at::_embedding_bag_forward_only or at::_embedding_bag should run.

Also, added two tests in test_embedding.py that check if the command now works.

Fixes #136457