### PR TITLE
[AOTI] Fix an issue when fallback op does not return a value

### DIFF
--- a/test/inductor/custom_ops.cpp
+++ b/test/inductor/custom_ops.cpp
@@ -219,6 +219,12 @@ std::tuple<Tensor, Tensor> fn_with_input_mutation_impl(
   return {t1 + 1, t1 + 2};
 }
 
+void fn_out_variant_without_return_impl(
+    const Tensor& x,
+    Tensor& out) {
+  out.add_(x);
+}
+
 // NOLINTBEGIN(clang-diagnostic-unused-parameter)
 Tensor fn_with_all_inputs_meta(
     const Tensor& tensor,
@@ -299,6 +305,11 @@ std::tuple<Tensor, Tensor> fn_with_input_mutation_meta(
   return {t1.clone(), t1.clone()};
 }
 
+void fn_out_variant_without_return_meta(
+    const Tensor& x,
+    Tensor& out) {
+}
+
 } // namespace at
 
 TORCH_LIBRARY(aoti_custom_ops, m) {
@@ -342,6 +353,7 @@ TORCH_LIBRARY(aoti_custom_ops, m) {
   m.def(
       "fn_with_input_mutation(Tensor(a!) t0, Tensor t1, Tensor(b!) t2) -> (Tensor, Tensor)");
 
+  m.def("fn_out_variant_without_return(Tensor x, Tensor(a!) out) -> ()");
 }
 
 TORCH_LIBRARY_IMPL(aoti_custom_ops, CompositeExplicitAutograd, m) {
@@ -352,6 +364,7 @@ TORCH_LIBRARY_IMPL(aoti_custom_ops, CompositeExplicitAutograd, m) {
   m.impl("fn_with_list_output", at::fn_with_list_output_impl);
   m.impl("fn_with_mix_outputs", at::fn_with_mix_outputs_impl);
   m.impl("fn_with_input_mutation", at::fn_with_input_mutation_impl);
+  m.impl("fn_out_variant_without_return", at::fn_out_variant_without_return_impl);
 }
 
 TORCH_LIBRARY_IMPL(aoti_custom_ops, Meta, m) {
@@ -361,4 +374,5 @@ TORCH_LIBRARY_IMPL(aoti_custom_ops, Meta, m) {
   m.impl("fn_with_list_output", at::fn_with_list_output_meta);
   m.impl("fn_with_mix_outputs", at::fn_with_mix_outputs_meta);
   m.impl("fn_with_input_mutation", at::fn_with_input_mutation_meta);
+  m.impl("fn_out_variant_without_return", at::fn_out_variant_without_return_meta);
 }

--- a/test/inductor/test_aot_inductor_custom_ops.py
+++ b/test/inductor/test_aot_inductor_custom_ops.py
@@ -200,6 +200,21 @@ class AOTInductorTestsTemplate:
 
         self.check_model(m, args)
 
+    def test_custom_op_out_variant_without_return(self) -> None:
+        class Model(torch.nn.Module):
+            def forward(self, x, y):
+                torch.ops.aoti_custom_ops.fn_out_variant_without_return(x, y)
+                return y
+
+        m = Model().to(device=self.device)
+        args = (
+            torch.randn(10, 10, device=self.device),
+            torch.randn(10, 10, device=self.device),
+        )
+        m(*args)
+
+        self.check_model(m, args)
+
     def test_custom_op_with_reinterpret_view_inputs(self) -> None:
         class Model(torch.nn.Module):
             def forward(self, x):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1838,7 +1838,10 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 raise AssertionError(f"Unexpected output: {type(out)}")
 
         # output_args has the same pytree structure as outputs
-        if outputs is None:
+        if op_overload and not op_overload._schema.returns:
+            # kernel does not return a value
+            output_args = []
+        elif outputs is None:
             # outputs is not specified, the default is to write to buf_name
             output_args = [buf_name]
         else:


### PR DESCRIPTION
Summary: Refine https://github.com/pytorch/pytorch/pull/137660 to support fallback op without a return value.

Differential Revision: D66939108




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang @aakhundov