### PR TITLE
[inductor] Parenthesize expression in _helper_sqrt

### DIFF
--- a/test/inductor/test_triton_syntax.py
+++ b/test/inductor/test_triton_syntax.py
@@ -1,0 +1,57 @@
+# Owner(s): ["module: inductor"]
+
+import torch
+from torch._inductor.test_case import TestCase
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, requires_gpu
+
+
+class TestTritonSyntacticallyValid(TestCase):
+    @requires_gpu()
+    def test_triton_sqrt(self):
+        # https://github.com/pytorch/pytorch/issues/142328
+        import math
+
+        import torch.nn as nn
+
+        def newtonschulz5(G, steps: int, eps=1e-7):
+            assert len(G.shape) == 2
+            a, b, c = (3.4445, -4.7750, 2.0315)
+            X = G.bfloat16()
+            X /= X.norm() + eps  # ensure top singular value <= 1
+            if G.size(0) > G.size(1):
+                X = X.T
+            for _ in range(steps):
+                A = X @ X.T
+                B = b * A + c * A @ A
+                X = a * X + B @ X
+            if G.size(0) > G.size(1):
+                X = X.T
+            return X
+
+        @torch.compile(backend="inductor")
+        def scaled_newton_schulz(G, steps: int):
+            shape = G.shape
+            dtype = G.dtype
+            G = G.reshape(shape[0], -1)
+            G = newtonschulz5(G, steps)
+            G = G.reshape(shape).type(dtype)
+            G = G * math.sqrt(max(1, shape[0] / G[0].numel()))
+            return G
+
+        model = nn.Sequential(
+            nn.Linear(16, 16, bias=False),
+            nn.Linear(16, 32, bias=False),
+        ).cuda(device=torch.device(GPU_TYPE))
+
+        loss = model(torch.randn(4, 16, device=torch.device(GPU_TYPE))).sum()
+        loss.backward()
+
+        scaled_newton_schulz(model[0].weight.grad, 6)
+        scaled_newton_schulz(model[1].weight.grad, 6)
+
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    if HAS_GPU:
+        run_tests()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -573,7 +573,7 @@ class TritonPrinter(PythonPrinter):
         return f"libdevice.ceil({self._print(expr.args[0])}).to({V.kernel.index_dtype})"
 
     def _helper_sqrt(self, expr):
-        return f"libdevice.sqrt({self._print(expr)}.to(tl.float32))"
+        return f"libdevice.sqrt(({self._print(expr)}).to(tl.float32))"
 
     def _print_FloatPow(self, expr):
         return (


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/142328. The implied cast-then-sqrt order matches the behavior of the `halide` backend.

https://github.com/pytorch/pytorch/blob/2cc01cc6d3ad2aff47e8460667ba654b2e4c9f21/torch/_inductor/codegen/halide.py#L115-L116

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov