### PR TITLE
Add missing bc CI dependency

### DIFF
--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -76,7 +76,8 @@ install_ubuntu() {
     vim \
     unzip \
     gpg-agent \
-    gdb
+    gdb \
+    bc
 
   # Should resolve issues related to various apt package repository cert issues
   # see: https://github.com/pytorch/pytorch/issues/65931


### PR DESCRIPTION
The [bc](https://www.geeksforgeeks.org/bc-command-linux-examples) command that I use to calculate the MAX_JOBS in https://github.com/pytorch/pytorch/pull/142164 isn't part of the Docker image https://github.com/pytorch/pytorch/actions/runs/12230618287/job/34113698986#step:14:321.  I missed this error when landing https://github.com/pytorch/pytorch/pull/142164.

