### PR TITLE
[aarch64] Fix libcusparselt format for CUDA sbsa docker

### DIFF
--- a/.ci/docker/common/install_cuda_aarch64.sh
+++ b/.ci/docker/common/install_cuda_aarch64.sh
@@ -20,10 +20,10 @@ function install_cusparselt_062 {
 function install_cusparselt_063 {
     # cuSparseLt license: https://docs.nvidia.com/cuda/cusparselt/license.html
     mkdir tmp_cusparselt && pushd tmp_cusparselt
-    wget -q https://developer.download.nvidia.com/compute/cusparselt/redist/libcusparse_lt/linux-x86_64/libcusparse_lt-linux-x86_64-0.6.3.2-archive.tar.xz
-    tar xf libcusparse_lt-linux-x86_64-0.6.3.2-archive.tar.xz
-    cp -a libcusparse_lt-linux-x86_64-0.6.3.2-archive/include/* /usr/local/cuda/include/
-    cp -a libcusparse_lt-linux-x86_64-0.6.3.2-archive/lib/* /usr/local/cuda/lib64/
+    wget -q https://developer.download.nvidia.com/compute/cusparselt/redist/libcusparse_lt/linux-sbsa/libcusparse_lt-linux-sbsa-0.6.3.2-archive.tar.xz
+    tar xf libcusparse_lt-linux-sbsa-0.6.3.2-archive.tar.xz
+    cp -a libcusparse_lt-linux-sbsa-0.6.3.2-archive/include/* /usr/local/cuda/include/
+    cp -a libcusparse_lt-linux-sbsa-0.6.3.2-archive/lib/* /usr/local/cuda/lib64/
     popd
     rm -rf tmp_cusparselt
 }


### PR DESCRIPTION
Corrects https://github.com/pytorch/pytorch/pull/141433/

Error whe building arm wheel https://github.com/pytorch/pytorch/actions/runs/12226514901/job/34101913511
`/opt/rh/gcc-toolset-11/root/usr/bin/ld: /usr/local/cuda/lib64/libcusparseLt.so: error adding symbols: file in wrong format`

cc @ptrblck @msaroufim @eqy @malfet @snadampal @milpuz01 @atalman @Skylion007 @nWEIdia 
