### PR TITLE
[Don't merge] add debug time.

### DIFF
--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -122,6 +122,9 @@ cdll.LoadLibrary("__lib_path__")
                 if not os.path.isfile(output_path):
                     status, target_file = x86_isa_help_builder.build()
 
+                import time
+
+                start = time.time()
                 # Check build result
                 subprocess.check_call(
                     [
@@ -133,6 +136,8 @@ cdll.LoadLibrary("__lib_path__")
                     stderr=subprocess.DEVNULL,
                     env={**os.environ, "PYTHONPATH": ":".join(sys.path)},
                 )
+                end = time.time()
+                print("subprocess.check_call time: ", end - start)
             except Exception as e:
                 return False
 


### PR DESCRIPTION
Original issue: https://github.com/pytorch/pytorch/issues/140970 

Test steps:
1. Apply this PR and build PyTorch.
2. Run pick_isa code:
```python
import torch
from torch._inductor.cpu_vec_isa import pick_vec_isa
import time

start = time.time()
out = pick_vec_isa()
end = time.time()
# 9.106s on my machine
print("pick isa first time(no cache):", end - start)

start = time.time()
out = pick_vec_isa()
end = time.time()
# 9.106s on my machine
print("pick isa second time(with cache):", end - start)
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov