### PR TITLE
[cpu/aarch64] fix compilation for Vec:bf16 (128bit)

### DIFF
--- a/aten/src/ATen/cpu/vec/vec128/vec128_bfloat16_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_bfloat16_neon.h
@@ -543,7 +543,7 @@ Vectorized<c10::BFloat16> inline fmsub(
     const Vectorized<c10::BFloat16>& c) {
   // See NOTE [BF16 FMA] above.
 #ifdef __ARM_FEATURE_BF16
-  return 2Vectorized<c10::BFloat16>(vfmsq_f16(c, a, b));
+  return Vectorized<c10::BFloat16>(vfmsq_f16(c, a, b));
 #else
   const auto [a_float_low, a_float_high] = convert_bfloat16_float(a);
   const auto [b_float_low, b_float_high] = convert_bfloat16_float(b);


### PR DESCRIPTION
Fix typo causing compilation error on aarch64 architecture with BF16 support. (#139090) 

tag: @swolchok 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @malfet @snadampal @milpuz01