### PR TITLE
Use set -o pipefail for build.sh

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -ex -o pipefail
 
 # Required environment variable: $BUILD_ENVIRONMENT
 # (This is set by default in the Docker images we build, so you don't


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142377

This would have made https://github.com/pytorch/pytorch/pull/142359 a
hard failure.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>