### PR TITLE
Removing cmake from requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,3 @@ lintrunner
 ninja
 packaging
 optree>=0.13.0
-cmake


### PR DESCRIPTION
Reverting https://github.com/pytorch/pytorch/pull/140491

Hypothesis is that it is regressing MacOS wheels (OMP not being built in wheels) per https://github.com/pytorch/pytorch/issues/142266