### PR TITLE
Remove stable_partition for ARM AOTI Runtimes

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -513,11 +513,19 @@ class AOTInductorModelContainer {
   }
 
   void reclaim_finished_models(std::unique_lock<std::mutex>& lk) {
+#ifdef __aarch64__
+    // push finished model instances to the end of pending_models_
+    auto it = std::partition(
+        pending_models_.begin(),
+        pending_models_.end(),
+        [](AOTInductorModel* m) { return !m->is_finished(); });
+#else
     // push finished model instances to the end of pending_models_
     auto it = std::stable_partition(
         pending_models_.begin(),
         pending_models_.end(),
         [](AOTInductorModel* m) { return !m->is_finished(); });
+#endif
 
     if (it != pending_models_.end()) {
       // We have finished model instances that can be pushed into


### PR DESCRIPTION
Summary: This function call will cause OOM issues on ARM machines with multi-threaded predictors (reason behind this is still being investigated), we replace it with the standard partition instead.



Differential Revision: D66904296


