### PR TITLE
Implement "torch.mtia.max_memory_allocated" API

### DIFF
--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -327,6 +327,7 @@ __all__ = [
     "current_stream",
     "default_stream",
     "memory_stats",
+    "max_memory_allocated",
     "get_device_capability",
     "empty_cache",
     "set_device",

--- a/torch/mtia/memory.py
+++ b/torch/mtia/memory.py
@@ -23,6 +23,19 @@ def memory_stats(device: Optional[_device_t] = None) -> Dict[str, Any]:
     return torch._C._mtia_memoryStats(_get_device_index(device, optional=True))
 
 
+def max_memory_allocated(device: Optional[_device_t] = None) -> int:
+    r"""Return the maximum memory allocated in bytes for a given device.
+
+    Args:
+        device (torch.device or int, optional): selected device. Returns
+            statistic for the current device, given by :func:`~torch.mtia.current_device`,
+            if :attr:`device` is ``None`` (default).
+    """
+
+    return memory_stats(device=device).get("allocated_bytes.all.peak", 0)
+
+
 __all__ = [
     "memory_stats",
+    "max_memory_allocated",
 ]


### PR DESCRIPTION
Summary: This diff implements the inferface of  "torch.mtia.max_memory_allocated" API. The internal implementation will be addressed in a separate diff.

Test Plan:
Passed a local unit test: `buck run //mtia/host_runtime/torch_mtia/tests:test_torch_mtia_api`

```
----------------------------------------------------------------------
Ran 15 tests in 16.862s

OK
I1127 11:31:14.613909 2272144 afg_bindings.cpp:943] afg-aten::mul.out-dtype_Float-uqJKuNc0 executable has been unloaded
I1127 11:31:14.615438 2272144 afg_bindings.cpp:943] afg-add-dtype_Float-fa37JncC executable has been unloaded
```

Reviewed By: ttrung149, nautsimon

Differential Revision: D66553954




cc @egienvalue