### PR TITLE
[ROCm]scatter_add: use deterministic approach+prefetch duplicated idx

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -1902,6 +1902,10 @@ TORCH_IMPL_FUNC(scatter_add)
   if (index.numel() == 0) return;
 
   // See Note [Enabling Deterministic Operations]
+#if (defined(USE_ROCM))
+  //For MI300, sort implementation is faster, enforce this path
+    _scatter_via_index_put(self, dim, index, src, mut_out, /*accumulate*/true);
+#else
   // Avoid gpuAtomicAdd for CUDA and XPU if deterministic mode is turned on
   if (globalContext().deterministicAlgorithms() && (self.device().type() == DeviceType::CUDA || self.device().type() == DeviceType::XPU)) {
     _scatter_via_index_put(self, dim, index, src, mut_out, /*accumulate*/true);
@@ -1912,6 +1916,7 @@ TORCH_IMPL_FUNC(scatter_add)
       scatter_add_stub(self.device().type(), mut_out, dim, index, src);
     }
   }
+#endif
 }
 
 TORCH_IMPL_FUNC(scatter_reduce_two)

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -196,8 +196,17 @@ __global__ void indexing_backward_kernel_stride_1(
     if ((idx < numel) &&
         (idx == 0 || crnt_sorted_idx != sorted_indices[idx - 1]))
     {
-      // Determine the number of duplicates in advance
       int64_t num_duplicates = 1;
+#if defined(USE_ROCM)
+      // pretch 32x...
+#define BLK_ 32
+      while ((idx + num_duplicates + BLK_ - 1) < numel) {
+	if (sorted_indices[idx + num_duplicates + BLK_ -1] != crnt_sorted_idx) 
+	  break;
+	num_duplicates += BLK_;
+      }
+#endif
+      // Determine the number of duplicates in advance
       while (((idx + num_duplicates) < numel) && (sorted_indices[idx + num_duplicates] == crnt_sorted_idx)) {
         num_duplicates++;
       }


### PR DESCRIPTION
On MI300, we are relying on the deterministic
sort approach to make scatter_add work faster. However, since sorting
ensures that we are reading from same index or adjacent index, we can
optimize this approach by prefetching 32x before processing.

With this approach, scatter_add with deterministic path has a
performance of 0.57ms as compared to 2.70ms before this for this repro:

```
dtype = torch.float32
dim = 1305301
ind_range = 100
a = torch.zeros(ind_range, device="cuda", dtype=dtype)
index = torch.randint(0, ind_range, (dim,), device="cuda")
src = torch.ones(dim, device="cuda", dtype=dtype)

print("=" * 20)
print(
    triton.testing.do_bench(
        lambda: a.scatter_add(0, index, src),
        return_mode="median",
    )
)
print("=" * 20)
```


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd