### PR TITLE
Perf improvements, part 1

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -21,7 +21,7 @@ import warnings
 import weakref
 from contextlib import contextmanager
 from copy import deepcopy
-from inspect import currentframe, getframeinfo
+from inspect import currentframe
 from typing import (
     Any,
     Callable,
@@ -67,6 +67,7 @@ from torch._guards import (
     GuardSource,
     Source,
     StorageOverlap,
+    TracingContext,
 )
 from torch._logging import structured
 from torch._utils_internal import justknobs_check
@@ -1736,15 +1737,16 @@ class GuardBuilder(GuardBuilderBase):
         ) or is_from_optimizer_source(source_b):
             return
 
-        code = [f"{ref_b} is {ref_a}"]
-        self._set_guard_export_info(guard, code)
-
         # Check that the guard has not been inserted already
         key = (ref_a, ref_b)
         if key in self._cached_duplicate_input_guards:
             return
+
         self._cached_duplicate_input_guards.add((ref_a, ref_b))
         self._cached_duplicate_input_guards.add((ref_b, ref_a))
+
+        code = [f"{ref_b} is {ref_a}"]
+        self._set_guard_export_info(guard, code)
 
         install_object_aliasing_guard(
             self.get_guard_manager(guard),
@@ -2079,18 +2081,17 @@ class GuardBuilder(GuardBuilderBase):
         caller = cur_frame.f_back
         del cur_frame
         assert caller is not None
-        func_name = getframeinfo(caller)[2]
+        func_name = caller.f_code.co_name
         del caller
         # We use func_name for export, so might as well get a nice defensive check out of it
-        assert func_name in dir(
-            self.__class__
+        assert (
+            func_name in self.__class__.__dict__
         ), f"_produce_guard_code must be called from inside GuardedCode. Called from {func_name}"
 
         # Not all guards have names, some can be installed globally (see asserts on HAS_GRAD)
         if provided_guarded_object is None:
-            name_valid = guard.name is not None and guard.name != ""
-
-            guarded_object = self.get(guard.name) if name_valid else None
+            name = guard.name
+            guarded_object = None if not name else self.get(name)
         else:
             guarded_object = provided_guarded_object
 
@@ -2305,7 +2306,7 @@ class CheckFunctionManager:
         if not justknobs_check("pytorch/compiler:guard_nn_modules"):
             log.warning("guard_nn_modules is turned off using justknobs killswitch")
 
-        for guard in sorted(guards or [], key=Guard.sort_key):
+        for guard in sorted(guards or (), key=Guard.sort_key):
             if (
                 not guard_on_nn_modules
                 and guard.is_specialized_nn_module()
@@ -2928,12 +2929,21 @@ def install_guard(*guards, skip=0):
         guards: guard(s) to add
         skip: number of stack frames to ignore for debug stack trace
     """
-    from torch._guards import TracingContext
+    install_guards(guards, skip)
 
+
+def install_guards(guards, skip=0):
+    """
+    Add dynamo guards to the current tracing context.
+
+    Args:
+        guards: guard(s) to add
+        skip: number of stack frames to ignore for debug stack trace
+    """
     collect_debug_stack = guards_log.isEnabledFor(
         logging.DEBUG
     ) or verbose_guards_log.isEnabledFor(logging.DEBUG)
-    add = TracingContext.get().guards_context.dynamo_guards.add
+    dynamo_guards = TracingContext.get().guards_context.dynamo_guards
     for guard in guards:
         assert isinstance(guard, Guard)
-        add(guard, collect_debug_stack=collect_debug_stack, skip=skip + 1)
+        dynamo_guards.add(guard, collect_debug_stack=collect_debug_stack, skip=skip + 1)

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -4,6 +4,8 @@ import collections
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
+import torch
+
 from .. import variables
 from ..current_scope_id import current_scope_id
 from ..exc import unimplemented
@@ -183,13 +185,11 @@ class VariableTrackerMeta(type):
 
     def __instancecheck__(cls, instance) -> bool:
         """Make isinstance work with LazyVariableTracker"""
-        if type.__instancecheck__(
-            variables.LazyVariableTracker, instance
-        ) and cls not in (
-            VariableTracker,
-            variables.LazyVariableTracker,
-        ):
-            instance = instance.realize()
+        # This is super expensive - just having it costs over 4% of tracing
+        # time!
+        if type(instance) is variables.LazyVariableTracker:
+            if cls not in (VariableTracker, variables.LazyVariableTracker):
+                instance = instance.realize()
         return type.__instancecheck__(cls, instance)
 
     def __init__(cls, name, bases, attrs) -> None:
@@ -449,12 +449,10 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         source: Optional[Source] = None,
     ) -> Any:
         """Create a new VariableTracker from a value and optional Source"""
-        from . import builder
-
         if source is None:
-            return builder.SourcelessBuilder.create(tx, value)
+            return torch._dynamo.variables.builder.SourcelessBuilder.create(tx, value)
         else:
-            return builder.VariableBuilder(tx, source)(value)
+            return torch._dynamo.variables.builder.VariableBuilder(tx, source)(value)
 
     def __init__(
         self,

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -80,7 +80,6 @@ from .user_defined import UserDefinedObjectVariable, UserDefinedVariable
 if TYPE_CHECKING:
     from torch._dynamo.symbolic_convert import InstructionTranslator
 
-
 log = logging.getLogger(__name__)
 
 
@@ -1626,14 +1625,6 @@ class BuiltinVariable(VariableTracker):
         name_var: VariableTracker,
         default=None,
     ):
-        from .. import trace_rules
-        from . import (
-            ConstantVariable,
-            GetAttrVariable,
-            TorchInGraphFunctionVariable,
-            UserFunctionVariable,
-        )
-
         name = name_var.as_python_constant()
 
         if not name_var.is_python_constant():
@@ -1703,14 +1694,14 @@ class BuiltinVariable(VariableTracker):
             try:
                 return obj.var_getattr(tx, name)
             except NotImplementedError:
-                return GetAttrVariable(obj, name, source=source)
-        elif isinstance(obj, TorchInGraphFunctionVariable):
+                return variables.GetAttrVariable(obj, name, source=source)
+        elif isinstance(obj, variables.TorchInGraphFunctionVariable):
             # Get OpOverload from an OpOverloadPacket, e.g., torch.ops.aten.add.default.
             member = getattr(obj.value, name)
             if isinstance(
                 member, (torch._ops.OpOverloadPacket, torch._ops.OpOverload)
-            ) and trace_rules.is_aten_op_or_tensor_method(member):
-                return TorchInGraphFunctionVariable(member, source=source)
+            ) and torch._dynamo.trace_rules.is_aten_op_or_tensor_method(member):
+                return variables.TorchInGraphFunctionVariable(member, source=source)
         elif isinstance(obj, DummyModule):
             # TODO(mlazos) - Do we need this?
             if obj.is_torch or name not in obj.value.__dict__:
@@ -1722,13 +1713,16 @@ class BuiltinVariable(VariableTracker):
                 tx.exec_recorder.record_module_access(obj.value, name, member)
             return VariableTracker.build(tx, member, source)
 
-        elif istype(obj, UserFunctionVariable) and name in ("__name__", "__module__"):
+        elif istype(obj, variables.UserFunctionVariable) and name in (
+            "__name__",
+            "__module__",
+        ):
             return ConstantVariable.create(getattr(obj.fn, name))
         else:
             try:
                 return obj.var_getattr(tx, name)
             except NotImplementedError:
-                return GetAttrVariable(obj, name, source=source)
+                return variables.GetAttrVariable(obj, name, source=source)
 
     def call_setattr(
         self,

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -1,6 +1,6 @@
 import collections
 import functools
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, final, Optional, Tuple, Union
 from typing_extensions import Self
 
 from .base import VariableTracker
@@ -33,6 +33,7 @@ class LazyCache:
         del self.source
 
 
+@final
 class LazyVariableTracker(VariableTracker):
     """
     A structure that defers the creation of the actual VariableTracker

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -27,7 +27,9 @@ from typing import (
     Union,
 )
 
+import torch
 from torch.utils import _pytree as pytree
+from torch.utils._backport_slots import dataclass_slots
 from torch.utils._traceback import CapturedTraceback, format_frame
 from torch.utils.weak import WeakTensorKeyDictionary
 
@@ -37,11 +39,6 @@ log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     import sympy
-
-    # Import the following modules during type checking to enable code intelligence features,
-    # such as auto-completion in tools like pylance, even when these modules are not explicitly
-    # imported in user code.
-    import torch
 
 
 """
@@ -169,6 +166,7 @@ class ShapeGuard(NamedTuple):
     sloc: SLoc
 
 
+@dataclass_slots
 @dataclasses.dataclass
 class Guard:
     # originating_source is the source that called the make_guard method to
@@ -209,11 +207,10 @@ class Guard:
     def sort_key(self):
         # Put the duplicate input guards at the end. The duplicate guards have
         # two sources while guard.name only considers one source.
-        from torch._dynamo.guards import GuardBuilder
 
         is_duplicate_input = (
             isinstance(self.create_fn, functools.partial)
-            and self.create_fn.func is GuardBuilder.DUPLICATE_INPUT
+            and self.create_fn.func is torch._dynamo.guards.GuardBuilder.DUPLICATE_INPUT
         )
         return (
             is_duplicate_input,

--- a/torch/utils/_functools.py
+++ b/torch/utils/_functools.py
@@ -1,0 +1,40 @@
+import functools
+from typing import Callable, TypeVar
+from typing_extensions import Concatenate, ParamSpec
+
+
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
+_C = TypeVar("_C")
+
+
+def cache_method(
+    f: Callable[Concatenate[_C, _P], _T]
+) -> Callable[Concatenate[_C, _P], _T]:
+    """
+    Like `@functools.cache` but for methods.
+
+    `@functools.cache` (and similarly `@functools.lru_cache`) shouldn't be used
+    on methods because it caches `self`, keeping it alive
+    forever. `@cache_method` ignores `self` so won't keep `self` alive (assuming
+    no cycles with `self` in the parameters).
+
+    Footgun warning: This decorator completely ignores self's properties so only
+    use it when you know that self is frozen or won't change in a meaningful
+    way (such as the wrapped function being pure).
+    """
+    cache_name = "_cache_method_" + f.__name__
+
+    @functools.wraps(f)
+    def wrap(self: _C, *args: _P.args, **kwargs: _P.kwargs) -> _T:
+        assert not kwargs
+        if not (cache := getattr(self, cache_name, None)):
+            cache = {}
+            setattr(self, cache_name, cache)
+        if args in cache:
+            return cache[args]
+        value = f(self, *args, **kwargs)
+        cache[args] = value
+        return value
+
+    return wrap


### PR DESCRIPTION
│ WIP C: compile perf - no re in arg_ref: 33.9 -> 33.7
│ WIP C: compile perf - c strip_function_call: 49.12 -> 47.77
│ WIP C: c++ VariableTrackerCache: 51.34 -> 50.36  │  WIP: compile perf - bytecode_transform improvements: 34.86 -> 33.9
  │  WIP: compile perf - don't call expensive _set_guard_export_info if it's a duplicate guard: 37.66 -> 34.86
  │  WIP: compile perf - don't unnecessarily call getframeinfo on the hot path: 47.26 -> 37.66
  │  WIP: compile perf - no import on hot path: 47.62 -> 47.26
  │  WIP: compile perf - slight improvement on __instancecheck__: 47.77 -> 47.62
  │  WIP: compile perf - kill import: 50.36 -> 49.12
  │  WIP: compile perf - Guard slots: 52.38 -> 51.34
  │  WIP: compile perf - install guards: 51.76 -> 52.38
  │  WIP: compile perf - direct Guard: 52.58 -> 51.76
  │  WIP: compile perf - lru on import_source: 52.9 -> 52.58
  │  WIP: compile perf - import_module: 59.92 -> 52.9
╭─╯  WIP: compile perf - import builder: 60.48 -> 59.92

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames