### PR TITLE
dynamo: Add fallback error message for unimplemented tensor methods

### DIFF
--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -588,14 +588,17 @@ class TensorVariable(VariableTracker):
 
         from .builder import wrap_fx_proxy
 
-        return wrap_fx_proxy(
-            tx,
-            tx.output.create_proxy(
-                "call_method",
-                name,
-                *proxy_args_kwargs([self, *args], kwargs),
-            ),
-        )
+        try:
+            return wrap_fx_proxy(
+                tx,
+                tx.output.create_proxy(
+                    "call_method",
+                    name,
+                    *proxy_args_kwargs([self, *args], kwargs),
+                ),
+            )
+        except TypeError as e:
+            unimplemented(f"unhandled args for {name}: {e}")
 
     def method_size(self, *args, **kwargs):
         return self._method_size_stride("size", *args, **kwargs)


### PR DESCRIPTION
Add explicit "Not Yet Implemented" error message when tensor methods lack handlers. 

- Keeping existing proxy creation attempt and TypeError handling
- Adding clear NYI message for unhandled tensor methods

Fixes [#140591](https://github.com/pytorch/pytorch/issues/140591)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames