### PR TITLE
temporarily turn on keep-going/continue on error for mac

### DIFF
--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -19,6 +19,11 @@ fi
 popd
 
 if [[ "${TEST_CONFIG}" == "default" ]]; then
+  # See https://github.com/pytorch/pytorch/pull/142421
+  # Temporarily turn on CONTINUE_THROUGH_ERROR for all mac default tests in
+  # order to find all test failures.  Red signal will show up later than usual,
+  # but failing tests can also be found on HUD when clicking additional test
+  # info button
   export CONTINUE_THROUGH_ERROR=True
 fi
 

--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -18,6 +18,10 @@ if [[ ! $(python -c "import torch; print(int(torch.backends.openmp.is_available(
 fi
 popd
 
+if [[ "${TEST_CONFIG}" == "default" ]]; then
+  export CONTINUE_THROUGH_ERROR=True
+fi
+
 setup_test_python() {
   # The CircleCI worker hostname doesn't resolve to an address.
   # This environment variable makes ProcessGroupGloo default to

--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -19,7 +19,7 @@ fi
 popd
 
 if [[ "${TEST_CONFIG}" == "default" ]]; then
-  # See https://github.com/pytorch/pytorch/pull/142421
+  # See https://github.com/pytorch/pytorch/issues/142206
   # Temporarily turn on CONTINUE_THROUGH_ERROR for all mac default tests in
   # order to find all test failures.  Red signal will show up later than usual,
   # but failing tests can also be found on HUD when clicking additional test


### PR DESCRIPTION
See https://github.com/pytorch/pytorch/pull/142270 for additional info.

Make all mac default shard tests run with keep going / continue on error so we can see all the test failures.

Red signal will show up later, but you can see failing tests mid run on HUD by clicking the additional test failures button

After the job is finished, searching for "consistently: " in the logs will find the failed tests