### PR TITLE
remove vulkan sdk installation on executorch build

### DIFF
--- a/.ci/docker/common/install_executorch.sh
+++ b/.ci/docker/common/install_executorch.sh
@@ -43,8 +43,6 @@ install_pip_dependencies() {
 
 setup_executorch() {
   pushd executorch
-  # Setup swiftshader and Vulkan SDK which are required to build the Vulkan delegate
-  as_jenkins bash .ci/scripts/setup-vulkan-linux-deps.sh
 
   export PYTHON_EXECUTABLE=python
   export EXECUTORCH_BUILD_PYBIND=ON


### PR DESCRIPTION
pytorch-linux-jammy-py3-clang12-executorch [started to fail](https://github.com/pytorch/pytorch/actions/runs/12244909721/job/34157668780) today due to a 404 on the Vulkan SDK we use/download (1.2.198.1, 3 years old, URL: https://sdk.lunarg.com/sdk/download/1.2.198.1/linux/vulkansdk-linux-x86_64-1.2.198.1.tar.gz )

The Vulkan SDK is probably no longer needed for building Executorch, and is not used down the line for testing.

This PR tests removing the installation of the SDK

https://github.com/pytorch/executorch/pull/7258