### PR TITLE
[EZ] Skip test_zero_grid_with_backed_symbols on Mac

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1388,6 +1388,7 @@ class AOTInductorTestsTemplate:
 
         self.check_model(M(self.device), (torch.randn(5, 5, device=self.device),))
 
+    @unittest.skipIf(IS_MACOS, "no CUDA on Mac")
     def test_zero_grid_with_backed_symbols(self):
         class Repro(torch.nn.Module):
             def __init__(self) -> None:


### PR DESCRIPTION
As it expects to load traced module on CUDA, which is not available on Mac https://github.com/pytorch/pytorch/blob/bd867d691b823b5e1288d944d325bcc4db31c1dc/test/inductor/test_aot_inductor.py#L1414


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov