### PR TITLE
Fix test_indexing on MacOS

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -14,8 +14,8 @@ from torch._inductor.sizevars import SizeVarAllocator
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_triton_code
 from torch.testing._internal.common_utils import (
-    IS_MACOS,
     instantiate_parametrized_tests,
+    IS_MACOS,
     parametrize,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
@@ -324,7 +324,9 @@ class ExprPrinterTests(InductorTestCase):
         x = sympy.Symbol("x", integer=True)
         expr = Mod(x - 1, 2)
         self.assertExpectedInline(pexpr(expr), """((-1) + x) % 2""")
-        self.assertExpectedInline(cexpr(expr), f"""((-1{LONG_SUFFIX}) + x) % 2{LONG_SUFFIX}""")
+        self.assertExpectedInline(
+            cexpr(expr), f"""((-1{LONG_SUFFIX}) + x) % 2{LONG_SUFFIX}"""
+        )
         self.assertExpectedInline(texpr(expr), """((-1) + x) % 2""")
 
         expr = (x - 10) % x


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142440

Where int64_t is long long rather than long

This fixes test regression introduced by https://github.com/pytorch/pytorch/pull/140597 that went undetected due to https://github.com/pytorch/pytorch/issues/142206

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov