### PR TITLE
Fix get_source_partitions when weights are tied

### DIFF
--- a/test/fx/test_source_matcher_utils.py
+++ b/test/fx/test_source_matcher_utils.py
@@ -443,5 +443,37 @@ class TestSourceMatcher(JitTestCase):
         self.assertEqual(len(module_partitions["linear"]), 4)
         self.assertEqual(len(module_partitions["relu"]), 2)
 
+    @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
+    @parametrize("strict", (True, False))
+    def test_module_partitioner_weight_tied(self, strict: bool):
+        # real-world example: https://github.com/pytorch/pytorch/issues/142035
+        class M(torch.nn.Module):
+            def __init__(self, input_size, output_size):
+                super().__init__()
+                # Define a linear layer
+                self.linear = torch.nn.Linear(input_size, output_size)
+                self.tied_weight = self.linear.weight
+
+            def forward(self, x):
+                # Forward pass through the linear layer
+                b = self.tied_weight + 1
+                return self.linear(x), b
+
+        inputs = (torch.randn(1, 10),)
+        gm = torch.export.export(
+            M(input_size=10, output_size=1), inputs, strict=strict
+        ).module()
+        gm.graph.eliminate_dead_code()
+
+        k = torch.nn.Linear if strict else "linear"
+        module_partitions = get_source_partitions(gm.graph, [k])
+
+        self.assertEqual(len(module_partitions), 1)
+        self.assertEqual(len(module_partitions[k]), 1)
+        self.assertEqual(len(module_partitions[k][0].output_nodes), 1)
+        self.assertEqual(module_partitions[k][0].output_nodes[0].name, "linear")
+        input_node_names = {node.name for node in module_partitions[k][0].input_nodes}
+        self.assertEqual(input_node_names, {"x"})
+
 
 instantiate_parametrized_tests(TestSourceMatcher)

--- a/torch/fx/passes/utils/source_matcher_utils.py
+++ b/torch/fx/passes/utils/source_matcher_utils.py
@@ -40,6 +40,7 @@ class SourcePartition:
     source: Any
 
     # Nodes in the graph that are needed as inputs to the partition
+    # These do not include the params of the partition
     input_nodes: List[Node] = field(default_factory=list)
 
     # Nodes in the partition that are being used by nodes outside of the
@@ -103,11 +104,13 @@ def get_source_partitions(
         params = set()
         for node in nodes:
             for arg in node.args:
-                if isinstance(arg, Node) and arg not in nodes:
+                if isinstance(arg, Node) and arg not in nodes and arg.op != "get_attr":
                     input_nodes.add(arg)
 
             if node.op == "get_attr":
                 params.add(node)
+                # get_attr nodes won't be output nodes
+                continue
 
             for user in node.users.keys():
                 if user not in nodes:


### PR DESCRIPTION
Summary:
Fix https://github.com/pytorch/pytorch/issues/142035 and  https://github.com/pytorch/pytorch/issues/143621



When Linear module params are tied to another parameter, like this:

```
class SimpleLinearModel(nn.Module):
    def __init__(self, input_size, output_size):
        super(SimpleLinearModel, self).__init__()
        # Define a linear layer
        self.linear = nn.Linear(input_size, output_size)
        self.tied_weight = self.linear.weight

    def forward(self, x):
        # Forward pass through the linear layer
        b = self.tied_weight + 1
        return self.linear(x), b
```

We get a graph like below:

```
graph():
    %p_tied_weight : [num_users=0] = placeholder[target=p_tied_weight]
    %p_linear_weight : [num_users=2] = placeholder[target=p_linear_weight]
    %p_linear_bias : [num_users=1] = placeholder[target=p_linear_bias]
    %x : [num_users=1] = placeholder[target=x]
    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p_linear_weight, 1), kwargs = {})
    %linear : [num_users=1] = call_function[target=torch.ops.aten.linear.default](args = (%x, %p_linear_weight, %p_linear_bias), kwargs = {})
    return (linear, add)
```

Notice that ` %p_linear_weight : [num_users=2]`.

When we get source partitions, we should exclude attributes nodes like `p_linear_weight` from outputs.


A real world example where people do something like this is in https://github.com/pytorch/pytorch/issues/142035.

Test Plan:
```
 buck2 run 'fbcode//mode/dev-nosan' fbcode//caffe2/test:fx -- -r test_module_partitioner_weight_tied
```

Differential Revision: D66998592




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv