### PR TITLE
[RFC] Apply garbage collection after putting code state into PGO caching

### DIFF
--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -19,6 +19,7 @@ import torch.distributed as dist
 from torch._dynamo.utils import dynamo_timed, get_chromium_event_logger, warn_once
 from torch._environment import is_fbcode
 from torch._logging._internal import trace_structured_artifact
+import gc
 
 
 if TYPE_CHECKING:
@@ -638,6 +639,8 @@ def put_code_state() -> None:
 
     put_local_code_state(cache_key)
     put_remote_code_state(cache_key)
+    with dynamo_timed("pgo.put_code_state.gc.collect", log_pt2_compile_event=True):
+        gc.collect()
 
 
 def put_local_code_state(cache_key: str) -> None:


### PR DESCRIPTION
Summary:
We observed 9% peak GPU memory regression in multiple training jobs.
Through bisecting, we identified that it was due to the enablement of Pytorch Dynamo PGO Remote Caching (details in: https://docs.google.com/document/d/1EPopAyYyXwTnkyVaUJ5Xa_Uw9iWv3zimK7FkagKsKIY/edit?tab=t.0#bookmark=id.e5b26tcdfl5g )
By adding garbage collection after the putting code state into PGO caching, we observe ~14% peak memory saving (see test plan for details)

Test Plan:
Baseline job with 81% peak memory usage: https://fburl.com/mlhub/w0o0m9zd
Test job with this diff shows 67% peak memory usage: https://fburl.com/mlhub/j0vxwrah

Reviewed By: ezyang

Differential Revision: D66977339


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames