### PR TITLE
Fix timeout check workflow lint job

### DIFF
--- a/.github/scripts/ensure_actions_will_cancel.py
+++ b/.github/scripts/ensure_actions_will_cancel.py
@@ -28,18 +28,19 @@ def should_check(filename: Path) -> bool:
 if __name__ == "__main__":
     errors_found = False
     files = [f for f in WORKFLOWS.glob("*.yml") if should_check(f)]
+    print(files)
     names = set()
-    for filename in files:
-        with open(filename) as f:
-            data = yaml.safe_load(f)
-
-        name = data.get("name")
-        if name is not None and name in names:
-            print("ERROR: duplicate workflow name:", name, file=sys.stderr)
-            errors_found = True
-        names.add(name)
-        print(f"==== {name}")
-        print(filename.name)
+#    for filename in files:
+#        with open(filename) as f:
+#            data = yaml.safe_load(f)
+#
+#        name = data.get("name")
+#        if name is not None and name in names:
+#            print("ERROR: duplicate workflow name:", name, file=sys.stderr)
+#            errors_found = True
+#        names.add(name)
+#        print(f"==== {name}")
+#        print(filename.name)
         #actual = data.get("concurrency", {})
         #print(actual)
         #if filename.name == "create_release.yml":

--- a/.github/scripts/ensure_actions_will_cancel.py
+++ b/.github/scripts/ensure_actions_will_cancel.py
@@ -28,11 +28,6 @@ def should_check(filename: Path) -> bool:
 if __name__ == "__main__":
     errors_found = False
     files = [f for f in WORKFLOWS.glob("*.yml") if should_check(f)]
-
-    # DEBUG
-    print(files)
-    sys.exit(0)
-
     names = set()
     for filename in files:
         with open(filename) as f:
@@ -43,37 +38,38 @@ if __name__ == "__main__":
             print("ERROR: duplicate workflow name:", name, file=sys.stderr)
             errors_found = True
         names.add(name)
-        actual = data.get("concurrency", {})
-        if filename.name == "create_release.yml":
-            if not actual.get("group", "").startswith(EXPECTED_GROUP_PREFIX):
-                print(
-                    f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
-                    file=sys.stderr,
-                )
-                print(
-                    f"concurrency group should start with {EXPECTED_GROUP_PREFIX} but found {actual.get('group', None)}",
-                    file=sys.stderr,
-                )
-                errors_found = True
-        elif not actual.get("group", "").startswith(EXPECTED_GROUP):
-            print(
-                f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
-                file=sys.stderr,
-            )
-            print(
-                f"concurrency group should start with {EXPECTED_GROUP} but found {actual.get('group', None)}",
-                file=sys.stderr,
-            )
-            errors_found = True
-        if not actual.get("cancel-in-progress", False):
-            print(
-                f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
-                file=sys.stderr,
-            )
-            print(
-                f"concurrency cancel-in-progress should be True but found {actual.get('cancel-in-progress', None)}",
-                file=sys.stderr,
-            )
+        print(f"==== {name}")
+        #actual = data.get("concurrency", {})
+        #if filename.name == "create_release.yml":
+        #    if not actual.get("group", "").startswith(EXPECTED_GROUP_PREFIX):
+        #        print(
+        #            f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
+        #            file=sys.stderr,
+        #        )
+        #        print(
+        #            f"concurrency group should start with {EXPECTED_GROUP_PREFIX} but found {actual.get('group', None)}",
+        #            file=sys.stderr,
+        #        )
+        #        errors_found = True
+        #elif not actual.get("group", "").startswith(EXPECTED_GROUP):
+        #    print(
+        #        f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
+        #        file=sys.stderr,
+        #    )
+        #    print(
+        #        f"concurrency group should start with {EXPECTED_GROUP} but found {actual.get('group', None)}",
+        #        file=sys.stderr,
+        #    )
+        #    errors_found = True
+        #if not actual.get("cancel-in-progress", False):
+        #    print(
+        #        f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
+        #        file=sys.stderr,
+        #    )
+        #    print(
+        #        f"concurrency cancel-in-progress should be True but found {actual.get('cancel-in-progress', None)}",
+        #        file=sys.stderr,
+        #    )
 
     if errors_found:
         sys.exit(1)

--- a/.github/scripts/ensure_actions_will_cancel.py
+++ b/.github/scripts/ensure_actions_will_cancel.py
@@ -39,7 +39,9 @@ if __name__ == "__main__":
             errors_found = True
         names.add(name)
         print(f"==== {name}")
-        #actual = data.get("concurrency", {})
+        print(filename.name)
+        actual = data.get("concurrency", {})
+        print(actual)
         #if filename.name == "create_release.yml":
         #    if not actual.get("group", "").startswith(EXPECTED_GROUP_PREFIX):
         #        print(

--- a/.github/scripts/ensure_actions_will_cancel.py
+++ b/.github/scripts/ensure_actions_will_cancel.py
@@ -38,37 +38,40 @@ if __name__ == "__main__":
             print("ERROR: duplicate workflow name:", name, file=sys.stderr)
             errors_found = True
         names.add(name)
-        actual = data.get("concurrency", {})
-        if filename.name == "create_release.yml":
-            if not actual.get("group", "").startswith(EXPECTED_GROUP_PREFIX):
-                print(
-                    f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
-                    file=sys.stderr,
-                )
-                print(
-                    f"concurrency group should start with {EXPECTED_GROUP_PREFIX} but found {actual.get('group', None)}",
-                    file=sys.stderr,
-                )
-                errors_found = True
-        elif not actual.get("group", "").startswith(EXPECTED_GROUP):
-            print(
-                f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
-                file=sys.stderr,
-            )
-            print(
-                f"concurrency group should start with {EXPECTED_GROUP} but found {actual.get('group', None)}",
-                file=sys.stderr,
-            )
-            errors_found = True
-        if not actual.get("cancel-in-progress", False):
-            print(
-                f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
-                file=sys.stderr,
-            )
-            print(
-                f"concurrency cancel-in-progress should be True but found {actual.get('cancel-in-progress', None)}",
-                file=sys.stderr,
-            )
+        print(f"==== {name}")
+        print(filename.name)
+        #actual = data.get("concurrency", {})
+        #print(actual)
+        #if filename.name == "create_release.yml":
+        #    if not actual.get("group", "").startswith(EXPECTED_GROUP_PREFIX):
+        #        print(
+        #            f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
+        #            file=sys.stderr,
+        #        )
+        #        print(
+        #            f"concurrency group should start with {EXPECTED_GROUP_PREFIX} but found {actual.get('group', None)}",
+        #            file=sys.stderr,
+        #        )
+        #        errors_found = True
+        #elif not actual.get("group", "").startswith(EXPECTED_GROUP):
+        #    print(
+        #        f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
+        #        file=sys.stderr,
+        #    )
+        #    print(
+        #        f"concurrency group should start with {EXPECTED_GROUP} but found {actual.get('group', None)}",
+        #        file=sys.stderr,
+        #    )
+        #    errors_found = True
+        #if not actual.get("cancel-in-progress", False):
+        #    print(
+        #        f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
+        #        file=sys.stderr,
+        #    )
+        #    print(
+        #        f"concurrency cancel-in-progress should be True but found {actual.get('cancel-in-progress', None)}",
+        #        file=sys.stderr,
+        #    )
 
     if errors_found:
         sys.exit(1)

--- a/.github/scripts/ensure_actions_will_cancel.py
+++ b/.github/scripts/ensure_actions_will_cancel.py
@@ -20,9 +20,10 @@ def should_check(filename: Path) -> bool:
     with open(filename) as f:
         content = f.read()
 
-    data = yaml.safe_load(content)
-    on = data.get("on", data.get(True, {}))
-    return "pull_request" in on
+    return True
+    #data = yaml.safe_load(content)
+    #on = data.get("on", data.get(True, {}))
+    #return "pull_request" in on
 
 
 if __name__ == "__main__":

--- a/.github/scripts/ensure_actions_will_cancel.py
+++ b/.github/scripts/ensure_actions_will_cancel.py
@@ -27,6 +27,7 @@ def should_check(filename: Path) -> bool:
 
 if __name__ == "__main__":
     errors_found = False
+    print(WORKFLOWS)
     files = [f for f in WORKFLOWS.glob("*.yml") if should_check(f)]
     print(files)
     names = set()

--- a/.github/scripts/ensure_actions_will_cancel.py
+++ b/.github/scripts/ensure_actions_will_cancel.py
@@ -38,10 +38,7 @@ if __name__ == "__main__":
             print("ERROR: duplicate workflow name:", name, file=sys.stderr)
             errors_found = True
         names.add(name)
-        print(f"==== {name}")
-        print(filename.name)
         actual = data.get("concurrency", {})
-        print(actual)
         if filename.name == "create_release.yml":
             if not actual.get("group", "").startswith(EXPECTED_GROUP_PREFIX):
                 print(

--- a/.github/scripts/ensure_actions_will_cancel.py
+++ b/.github/scripts/ensure_actions_will_cancel.py
@@ -29,9 +29,9 @@ def should_check(filename: Path) -> bool:
 if __name__ == "__main__":
     errors_found = False
     print(WORKFLOWS)
-    files = [f for f in WORKFLOWS.glob("*.yml") if should_check(f)]
-    print(files)
-    names = set()
+    # files = [f for f in WORKFLOWS.glob("*.yml") if should_check(f)]
+    # print(files)
+    # names = set()
 #    for filename in files:
 #        with open(filename) as f:
 #            data = yaml.safe_load(f)

--- a/.github/scripts/ensure_actions_will_cancel.py
+++ b/.github/scripts/ensure_actions_will_cancel.py
@@ -63,15 +63,15 @@ if __name__ == "__main__":
                 file=sys.stderr,
             )
             errors_found = True
-        #if not actual.get("cancel-in-progress", False):
-        #    print(
-        #        f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
-        #        file=sys.stderr,
-        #    )
-        #    print(
-        #        f"concurrency cancel-in-progress should be True but found {actual.get('cancel-in-progress', None)}",
-        #        file=sys.stderr,
-        #    )
+        if not actual.get("cancel-in-progress", False):
+            print(
+                f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
+                file=sys.stderr,
+            )
+            print(
+                f"concurrency cancel-in-progress should be True but found {actual.get('cancel-in-progress', None)}",
+                file=sys.stderr,
+            )
 
     if errors_found:
         sys.exit(1)

--- a/.github/scripts/ensure_actions_will_cancel.py
+++ b/.github/scripts/ensure_actions_will_cancel.py
@@ -28,6 +28,11 @@ def should_check(filename: Path) -> bool:
 if __name__ == "__main__":
     errors_found = False
     files = [f for f in WORKFLOWS.glob("*.yml") if should_check(f)]
+
+    # DEBUG
+    print(files)
+    sys.exit(0)
+
     names = set()
     for filename in files:
         with open(filename) as f:

--- a/.github/scripts/ensure_actions_will_cancel.py
+++ b/.github/scripts/ensure_actions_will_cancel.py
@@ -20,61 +20,55 @@ def should_check(filename: Path) -> bool:
     with open(filename) as f:
         content = f.read()
 
-    return True
-    #data = yaml.safe_load(content)
-    #on = data.get("on", data.get(True, {}))
-    #return "pull_request" in on
+    data = yaml.safe_load(content)
+    on = data.get("on", data.get(True, {}))
+    return "pull_request" in on
 
 
 if __name__ == "__main__":
     errors_found = False
-    print(WORKFLOWS)
-    # files = [f for f in WORKFLOWS.glob("*.yml") if should_check(f)]
-    # print(files)
-    # names = set()
-#    for filename in files:
-#        with open(filename) as f:
-#            data = yaml.safe_load(f)
-#
-#        name = data.get("name")
-#        if name is not None and name in names:
-#            print("ERROR: duplicate workflow name:", name, file=sys.stderr)
-#            errors_found = True
-#        names.add(name)
-#        print(f"==== {name}")
-#        print(filename.name)
-        #actual = data.get("concurrency", {})
-        #print(actual)
-        #if filename.name == "create_release.yml":
-        #    if not actual.get("group", "").startswith(EXPECTED_GROUP_PREFIX):
-        #        print(
-        #            f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
-        #            file=sys.stderr,
-        #        )
-        #        print(
-        #            f"concurrency group should start with {EXPECTED_GROUP_PREFIX} but found {actual.get('group', None)}",
-        #            file=sys.stderr,
-        #        )
-        #        errors_found = True
-        #elif not actual.get("group", "").startswith(EXPECTED_GROUP):
-        #    print(
-        #        f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
-        #        file=sys.stderr,
-        #    )
-        #    print(
-        #        f"concurrency group should start with {EXPECTED_GROUP} but found {actual.get('group', None)}",
-        #        file=sys.stderr,
-        #    )
-        #    errors_found = True
-        #if not actual.get("cancel-in-progress", False):
-        #    print(
-        #        f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
-        #        file=sys.stderr,
-        #    )
-        #    print(
-        #        f"concurrency cancel-in-progress should be True but found {actual.get('cancel-in-progress', None)}",
-        #        file=sys.stderr,
-        #    )
+    files = [f for f in WORKFLOWS.glob("*.yml") if should_check(f)]
+    names = set()
+    for filename in files:
+        with open(filename) as f:
+            data = yaml.safe_load(f)
+
+        name = data.get("name")
+        if name is not None and name in names:
+            print("ERROR: duplicate workflow name:", name, file=sys.stderr)
+            errors_found = True
+        names.add(name)
+        actual = data.get("concurrency", {})
+        if filename.name == "create_release.yml":
+            if not actual.get("group", "").startswith(EXPECTED_GROUP_PREFIX):
+                print(
+                    f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
+                    file=sys.stderr,
+                )
+                print(
+                    f"concurrency group should start with {EXPECTED_GROUP_PREFIX} but found {actual.get('group', None)}",
+                    file=sys.stderr,
+                )
+                errors_found = True
+        elif not actual.get("group", "").startswith(EXPECTED_GROUP):
+            print(
+                f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
+                file=sys.stderr,
+            )
+            print(
+                f"concurrency group should start with {EXPECTED_GROUP} but found {actual.get('group', None)}",
+                file=sys.stderr,
+            )
+            errors_found = True
+        if not actual.get("cancel-in-progress", False):
+            print(
+                f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
+                file=sys.stderr,
+            )
+            print(
+                f"concurrency cancel-in-progress should be True but found {actual.get('cancel-in-progress', None)}",
+                file=sys.stderr,
+            )
 
     if errors_found:
         sys.exit(1)

--- a/.github/scripts/ensure_actions_will_cancel.py
+++ b/.github/scripts/ensure_actions_will_cancel.py
@@ -42,17 +42,17 @@ if __name__ == "__main__":
         print(filename.name)
         actual = data.get("concurrency", {})
         print(actual)
-        #if filename.name == "create_release.yml":
-        #    if not actual.get("group", "").startswith(EXPECTED_GROUP_PREFIX):
-        #        print(
-        #            f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
-        #            file=sys.stderr,
-        #        )
-        #        print(
-        #            f"concurrency group should start with {EXPECTED_GROUP_PREFIX} but found {actual.get('group', None)}",
-        #            file=sys.stderr,
-        #        )
-        #        errors_found = True
+        if filename.name == "create_release.yml":
+            if not actual.get("group", "").startswith(EXPECTED_GROUP_PREFIX):
+                print(
+                    f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
+                    file=sys.stderr,
+                )
+                print(
+                    f"concurrency group should start with {EXPECTED_GROUP_PREFIX} but found {actual.get('group', None)}",
+                    file=sys.stderr,
+                )
+                errors_found = True
         #elif not actual.get("group", "").startswith(EXPECTED_GROUP):
         #    print(
         #        f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",

--- a/.github/scripts/ensure_actions_will_cancel.py
+++ b/.github/scripts/ensure_actions_will_cancel.py
@@ -53,16 +53,16 @@ if __name__ == "__main__":
                     file=sys.stderr,
                 )
                 errors_found = True
-        #elif not actual.get("group", "").startswith(EXPECTED_GROUP):
-        #    print(
-        #        f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
-        #        file=sys.stderr,
-        #    )
-        #    print(
-        #        f"concurrency group should start with {EXPECTED_GROUP} but found {actual.get('group', None)}",
-        #        file=sys.stderr,
-        #    )
-        #    errors_found = True
+        elif not actual.get("group", "").startswith(EXPECTED_GROUP):
+            print(
+                f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
+                file=sys.stderr,
+            )
+            print(
+                f"concurrency group should start with {EXPECTED_GROUP} but found {actual.get('group', None)}",
+                file=sys.stderr,
+            )
+            errors_found = True
         #if not actual.get("cancel-in-progress", False):
         #    print(
         #        f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",

--- a/.github/scripts/report_git_status.sh
+++ b/.github/scripts/report_git_status.sh
@@ -3,6 +3,7 @@
 set -eux
 
 CHANGES=$(git status --porcelain "$1")
-#echo "$CHANGES"
-#git diff "$1"
+echo "$CHANGES"
+# NB: Use --no-pager here to avoid git diff asking for a prompt to continue
+git --no-pager diff "$1"
 [ -z "$CHANGES" ]

--- a/.github/scripts/report_git_status.sh
+++ b/.github/scripts/report_git_status.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-#CHANGES=$(git status --porcelain "$1")
+
+set -eux
+
+CHANGES=$(git status --porcelain "$1")
 #echo "$CHANGES"
-git diff "$1"
-#[ -z "$CHANGES" ]
+#git diff "$1"
+[ -z "$CHANGES" ]

--- a/.github/scripts/report_git_status.sh
+++ b/.github/scripts/report_git_status.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-CHANGES=$(git status --porcelain "$1")
-echo "$CHANGES"
+#CHANGES=$(git status --porcelain "$1")
+#echo "$CHANGES"
 git diff "$1"
-[ -z "$CHANGES" ]
+#[ -z "$CHANGES" ]

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -3172,19 +3172,6 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
-        uses: malfet/checkout@silent-checkout
-        with:
-          ref: main
-          submodules: recursive
-          repository: pytorch/builder
-          path: builder
-          quiet-checkout: true
-      - name: Clean pytorch/builder checkout
-        run: |
-          # Remove any artifacts from the previous checkouts
-          git clean -fxd
-        working-directory: builder
       - name: ROCm set GPU_FLAG
         run: |
           echo "GPU_FLAG=--device=/dev/mem --device=/dev/kfd --device=/dev/dri --group-add video --group-add daemon" >> "${GITHUB_ENV}"
@@ -3285,19 +3272,6 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
-        uses: malfet/checkout@silent-checkout
-        with:
-          ref: main
-          submodules: recursive
-          repository: pytorch/builder
-          path: builder
-          quiet-checkout: true
-      - name: Clean pytorch/builder checkout
-        run: |
-          # Remove any artifacts from the previous checkouts
-          git clean -fxd
-        working-directory: builder
       - name: ROCm set GPU_FLAG
         run: |
           echo "GPU_FLAG=--device=/dev/mem --device=/dev/kfd --device=/dev/dri --group-add video --group-add daemon" >> "${GITHUB_ENV}"
@@ -3858,19 +3832,6 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
-        uses: malfet/checkout@silent-checkout
-        with:
-          ref: main
-          submodules: recursive
-          repository: pytorch/builder
-          path: builder
-          quiet-checkout: true
-      - name: Clean pytorch/builder checkout
-        run: |
-          # Remove any artifacts from the previous checkouts
-          git clean -fxd
-        working-directory: builder
       - name: ROCm set GPU_FLAG
         run: |
           echo "GPU_FLAG=--device=/dev/mem --device=/dev/kfd --device=/dev/dri --group-add video --group-add daemon" >> "${GITHUB_ENV}"
@@ -3971,19 +3932,6 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
-        uses: malfet/checkout@silent-checkout
-        with:
-          ref: main
-          submodules: recursive
-          repository: pytorch/builder
-          path: builder
-          quiet-checkout: true
-      - name: Clean pytorch/builder checkout
-        run: |
-          # Remove any artifacts from the previous checkouts
-          git clean -fxd
-        working-directory: builder
       - name: ROCm set GPU_FLAG
         run: |
           echo "GPU_FLAG=--device=/dev/mem --device=/dev/kfd --device=/dev/dri --group-add video --group-add daemon" >> "${GITHUB_ENV}"

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -3172,6 +3172,19 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
+      - name: Checkout pytorch/builder
+        uses: malfet/checkout@silent-checkout
+        with:
+          ref: main
+          submodules: recursive
+          repository: pytorch/builder
+          path: builder
+          quiet-checkout: true
+      - name: Clean pytorch/builder checkout
+        run: |
+          # Remove any artifacts from the previous checkouts
+          git clean -fxd
+        working-directory: builder
       - name: ROCm set GPU_FLAG
         run: |
           echo "GPU_FLAG=--device=/dev/mem --device=/dev/kfd --device=/dev/dri --group-add video --group-add daemon" >> "${GITHUB_ENV}"
@@ -3272,6 +3285,19 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
+      - name: Checkout pytorch/builder
+        uses: malfet/checkout@silent-checkout
+        with:
+          ref: main
+          submodules: recursive
+          repository: pytorch/builder
+          path: builder
+          quiet-checkout: true
+      - name: Clean pytorch/builder checkout
+        run: |
+          # Remove any artifacts from the previous checkouts
+          git clean -fxd
+        working-directory: builder
       - name: ROCm set GPU_FLAG
         run: |
           echo "GPU_FLAG=--device=/dev/mem --device=/dev/kfd --device=/dev/dri --group-add video --group-add daemon" >> "${GITHUB_ENV}"
@@ -3832,6 +3858,19 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
+      - name: Checkout pytorch/builder
+        uses: malfet/checkout@silent-checkout
+        with:
+          ref: main
+          submodules: recursive
+          repository: pytorch/builder
+          path: builder
+          quiet-checkout: true
+      - name: Clean pytorch/builder checkout
+        run: |
+          # Remove any artifacts from the previous checkouts
+          git clean -fxd
+        working-directory: builder
       - name: ROCm set GPU_FLAG
         run: |
           echo "GPU_FLAG=--device=/dev/mem --device=/dev/kfd --device=/dev/dri --group-add video --group-add daemon" >> "${GITHUB_ENV}"
@@ -3932,6 +3971,19 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
+      - name: Checkout pytorch/builder
+        uses: malfet/checkout@silent-checkout
+        with:
+          ref: main
+          submodules: recursive
+          repository: pytorch/builder
+          path: builder
+          quiet-checkout: true
+      - name: Clean pytorch/builder checkout
+        run: |
+          # Remove any artifacts from the previous checkouts
+          git clean -fxd
+        working-directory: builder
       - name: ROCm set GPU_FLAG
         run: |
           echo "GPU_FLAG=--device=/dev/mem --device=/dev/kfd --device=/dev/dri --group-add video --group-add daemon" >> "${GITHUB_ENV}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -125,6 +125,8 @@ jobs:
       submodules: true
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
+        set -eux
+
         # The generic Linux job chooses to use base env, not the one setup by the image
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
         conda activate "${CONDA_ENV}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -132,20 +132,20 @@ jobs:
         # Regenerate workflows
         .github/scripts/generate_ci_workflows.py
 
-        #RC=0
-        ## Assert that regenerating the workflows didn't change them
-        #if ! .github/scripts/report_git_status.sh .github/workflows; then
-        #  echo
-        #  echo 'As shown by the above diff, the committed .github/workflows'
-        #  echo 'are not up to date according to .github/templates.'
-        #  echo 'Please run this command, commit, and push again to your PR:'
-        #  echo
-        #  echo '    .github/scripts/generate_ci_workflows.py'
-        #  echo
-        #  echo 'If running that command does nothing, you may need to rebase'
-        #  echo 'onto a more recent commit from the PyTorch main branch.'
-        #  RC=1
-        #fi
+        RC=0
+        # Assert that regenerating the workflows didn't change them
+        if ! .github/scripts/report_git_status.sh .github/workflows; then
+          echo
+          echo 'As shown by the above diff, the committed .github/workflows'
+          echo 'are not up to date according to .github/templates.'
+          echo 'Please run this command, commit, and push again to your PR:'
+          echo
+          echo '    .github/scripts/generate_ci_workflows.py'
+          echo
+          echo 'If running that command does nothing, you may need to rebase'
+          echo 'onto a more recent commit from the PyTorch main branch.'
+          RC=1
+        fi
 
         ## Check that jobs will be cancelled
         #.github/scripts/ensure_actions_will_cancel.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -207,8 +207,8 @@ jobs:
         conda activate "${CONDA_ENV}"
 
         # Test tools
-        python3 -m unittest discover -s tools/test -p 'test_*.py'
-        python3 -m unittest discover -s .github/scripts -p 'test_*.py'
+        PYTHONPATH=$(pwd) pytest tools/test/test_*.py
+        PYTHONPATH=$(pwd) pytest .github/scripts/test_*.py
 
   test_run_test:
     name: Test `run_test.py` is usable without boto3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -132,25 +132,25 @@ jobs:
         # Regenerate workflows
         .github/scripts/generate_ci_workflows.py
 
-        RC=0
-        # Assert that regenerating the workflows didn't change them
-        if ! .github/scripts/report_git_status.sh .github/workflows; then
-          echo
-          echo 'As shown by the above diff, the committed .github/workflows'
-          echo 'are not up to date according to .github/templates.'
-          echo 'Please run this command, commit, and push again to your PR:'
-          echo
-          echo '    .github/scripts/generate_ci_workflows.py'
-          echo
-          echo 'If running that command does nothing, you may need to rebase'
-          echo 'onto a more recent commit from the PyTorch main branch.'
-          RC=1
-        fi
+        #RC=0
+        ## Assert that regenerating the workflows didn't change them
+        #if ! .github/scripts/report_git_status.sh .github/workflows; then
+        #  echo
+        #  echo 'As shown by the above diff, the committed .github/workflows'
+        #  echo 'are not up to date according to .github/templates.'
+        #  echo 'Please run this command, commit, and push again to your PR:'
+        #  echo
+        #  echo '    .github/scripts/generate_ci_workflows.py'
+        #  echo
+        #  echo 'If running that command does nothing, you may need to rebase'
+        #  echo 'onto a more recent commit from the PyTorch main branch.'
+        #  RC=1
+        #fi
 
-        # Check that jobs will be cancelled
-        .github/scripts/ensure_actions_will_cancel.py
+        ## Check that jobs will be cancelled
+        #.github/scripts/ensure_actions_will_cancel.py
 
-        exit $RC
+        #exit $RC
 
   toc:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -147,10 +147,10 @@ jobs:
           RC=1
         fi
 
-        ## Check that jobs will be cancelled
-        #.github/scripts/ensure_actions_will_cancel.py
+        # Check that jobs will be cancelled
+        .github/scripts/ensure_actions_will_cancel.py
 
-        #exit $RC
+        exit $RC
 
   toc:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -125,8 +125,6 @@ jobs:
       submodules: true
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
-        set -eux
-
         # The generic Linux job chooses to use base env, not the one setup by the image
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
         conda activate "${CONDA_ENV}"
@@ -150,7 +148,8 @@ jobs:
         fi
 
         # Check that jobs will be cancelled
-        .github/scripts/ensure_actions_will_cancel.py
+        # DEBUG
+        # .github/scripts/ensure_actions_will_cancel.py
 
         exit $RC
 
@@ -209,8 +208,8 @@ jobs:
         conda activate "${CONDA_ENV}"
 
         # Test tools
-        python3 -m unittest discover -vs tools/test -p 'test_*.py'
-        python3 -m unittest discover -vs .github/scripts -p 'test_*.py'
+        python3 -m unittest discover -s tools/test -p 'test_*.py'
+        python3 -m unittest discover -s .github/scripts -p 'test_*.py'
 
   test_run_test:
     name: Test `run_test.py` is usable without boto3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -148,8 +148,7 @@ jobs:
         fi
 
         # Check that jobs will be cancelled
-        # DEBUG
-        # .github/scripts/ensure_actions_will_cancel.py
+        .github/scripts/ensure_actions_will_cancel.py
 
         exit $RC
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/142485

The workflow check lint job timed out in trunk, i.e. https://github.com/pytorch/pytorch/actions/runs/12261226178/job/34207762939, and here was what happened:

1. https://github.com/pytorch/pytorch/pull/142294 landed yesterday to build ROCm on 3.13, but the PR had a landrace with https://github.com/pytorch/pytorch/pull/142282 in the generated workflow file
2. The trunk lint check caught that in https://github.com/pytorch/pytorch/blob/main/.github/scripts/report_git_status.sh#L2
3. However, the script also attempted to print the difference with `git diff .github/workflows`.  This command was the one that stuck because `git diff` uses page by default and requires a prompt to display the next page ¯\_(ツ)_/¯

It took so long to debug this because a timeout Nova GHA doesn't print any progress.  I'll create an issue for this.

Bonus:

I also fix the broken print from test tool lint job that confuses GitHub https://github.com/pytorch/pytorch/actions/runs/12261226178 with an annotation failure `Credentials could not be loaded, please check your action inputs`

