### PR TITLE
Prefer normal stride selection logic when tensor is contiguous

### DIFF
--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -251,6 +251,7 @@ class MetaTensorDescriber:
     ) -> MetaTensorDesc:
         is_leaf = safe_is_leaf(t)
         is_view = t._is_view()
+        is_contiguous = t.is_contiguous()
         is_sparse = t.is_sparse
         layout = t.layout
         is_nested = t.is_nested
@@ -368,6 +369,7 @@ class MetaTensorDescriber:
             is_legacy_batchedtensor=is_legacy_batchedtensor_v,
             is_gradtrackingtensor=is_gradtrackingtensor_v,
             is_view=is_view,
+            is_contiguous=is_contiguous,
             is_conj=t.is_conj(),
             is_neg=t.is_neg(),
             is_parameter=isinstance(t, torch.nn.Parameter),
@@ -509,6 +511,7 @@ class MetaTensorDesc(Generic[_TensorT]):
     is_legacy_batchedtensor: bool = False
     is_gradtrackingtensor: bool = False
     is_view: bool = False
+    is_contiguous: bool = False
     is_nested: bool = False
     # We eagerly symbolicize the associated nested int for e.g. offsets / lengths
     # metadata if that offsets is already associated with a nested int.
@@ -843,6 +846,7 @@ class MetaConverter(Generic[_TensorT]):
                         t_storage_offset,
                         [d in t.dynamo_dynamic_indices for d in range(t.ndim)],
                         src,
+                        is_contiguous=t.is_contiguous,
                         symbolic_context=symbolic_context,
                     )
             else:

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3746,7 +3746,7 @@ class ShapeEnv:
             ex_storage_offset,
             [_is_dim_dynamic(ex, i) for i in range(ex.dim())],
             source,
-            is_contiguous= ex.is_contiguous(),
+            is_contiguous=ex.is_contiguous(),
             symbolic_context=symbolic_context,
         )
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3873,9 +3873,21 @@ class ShapeEnv:
         )
         stride: List[Optional[sympy.Expr]] = [None] * len(size)
         if is_contiguous:
-            stride = [sympy.Integer(1)] * len(size)
+            contiguous_striding = True
             for i in range(len(size) - 2, -1, -1):
-                stride[i] = stride[i + 1] * size[i + 1]
+                # Even though a tensor is contiguous, it may not
+                # conform to stride[i] = size[i+1] * stride[i+1]
+                contiguous_stride = ex_stride[i + 1] * size[i + 1]
+                if (
+                    not isinstance(contiguous_stride, sympy.Symbol)
+                    and ex_stride[i] != contiguous_stride
+                ):
+                    contiguous_striding = False
+
+            if contiguous_striding:
+                stride = [sympy.Integer(1)] * len(size)
+                for i in range(len(size) - 2, -1, -1):
+                    stride[i] = stride[i + 1] * size[i + 1]
         else:
             for i, val in enumerate(ex_stride):
                 if val in (0, 1):

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3746,6 +3746,7 @@ class ShapeEnv:
             ex_storage_offset,
             [_is_dim_dynamic(ex, i) for i in range(ex.dim())],
             source,
+            is_contiguous= ex.is_contiguous(),
             symbolic_context=symbolic_context,
         )
 
@@ -3804,6 +3805,7 @@ class ShapeEnv:
         ex_storage_offset: Union[int, SymInt],
         is_dim_dynamic: Sequence[bool],
         source: Source,
+        is_contiguous: bool,
         *,
         symbolic_context: Optional[SymbolicContext] = None,
     ) -> Tuple[
@@ -3870,9 +3872,14 @@ class ShapeEnv:
             ex_size, source, symbolic_context
         )
         stride: List[Optional[sympy.Expr]] = [None] * len(size)
-        for i, val in enumerate(ex_stride):
-            if val in (0, 1):
-                stride[i] = sympy.Integer(val)
+        if is_contiguous:
+            stride = [sympy.Integer(1)] * len(size)
+            for i in range(len(size) - 2, -1, -1):
+                stride[i] = stride[i + 1] * size[i + 1]
+        else:
+            for i, val in enumerate(ex_stride):
+                if val in (0, 1):
+                    stride[i] = sympy.Integer(val)
         while any(x is None for x in stride):
             candidates = {
                 ex_size[i] * ex_stride[i]: size[i] * stride[i]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142497

Note for reviewers: One thing I'm a bit unclear about is the guarding of this code. If a user does a first invocation with a contiguous tensor but for the next invocation passes in a non contiguous tensor, won't this technically be UB since we traced with the assumption of contiguity? I generated a tlp for the test and don't see anything guarding on contiguity (https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/bobren/712bbe5b-462b-44a5-aa54-2f3488a36059/custom/0_0_0/dynamo_cpp_guards_str_1.txt?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=100). Is there something I'm missing? Does it not matter that we trace with a contiguity assumption but potentially allow non contiguous tensors at runtime because it's unlikely to occur?

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames