### PR TITLE
[ROCm] Improvements for vectorized elementwise kernels

### DIFF
--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -78,13 +78,46 @@ constexpr auto io_block_work_size() {
   return num_threads() * elems_per_thread<io_sizes>();
 }
 
+#ifdef USE_ROCM
+template <typename result_t, typename args_t, size_t... Is>
+constexpr auto check_sizes(result_t res, args_t args, std::index_sequence<Is...>) {
+  if constexpr (sizeof...(Is) == 0) {
+    return sizeof(res);
+  } else {
+    return sizeof(std::tuple_element_t<0, args_t>);
+  }
+}
+
+template <int vec_size, int dtype_size>
+constexpr auto calc_optimal_vec_size() {
+  static_assert(vec_size != 0);
+  static_assert(dtype_size != 0);
+  if constexpr (dtype_size == 1 && vec_size >= 16) {
+    return 16;
+  } else if constexpr (dtype_size <= 2 && vec_size >= 8) {
+    return 8;
+  } else if constexpr (dtype_size <= 4 && vec_size >= 4) {
+    return 4;
+  } else if constexpr (vec_size >= 2) {
+    return 2;
+  } else {
+    return 1;
+  }
+}
+#endif
+
 template <typename func_t>
 constexpr auto calc_io_size(){
   using traits = function_traits<func_t>;
   using args_t = typename traits::ArgsTuple;
+#ifdef USE_ROCM
+  using result_t = typename traits::result_type;
+  return at::native::check_sizes(result_t{}, args_t{}, std::make_index_sequence<std::tuple_size_v<args_t>>{});
+#else
   constexpr auto input_size = at::native::sum_of_sizes(args_t{}, std::make_index_sequence<std::tuple_size_v<args_t>>{});
   constexpr auto output_size = sizeof(typename traits::result_type);
   return input_size + output_size;
+#endif
 }
 
 template <int vec_size, typename func_t, typename array_t>
@@ -111,8 +144,13 @@ __global__ void vectorized_elementwise_kernel(int N, func_t f, array_t data) {
     elementwise_kernel_helper(f, policy);
   } else { // if this block has a full `block_work_size` data to handle, use
            // vectorized memory access
+#ifdef USE_ROCM
+    constexpr auto optimal_vec_size = calc_optimal_vec_size<vec_size, io_size>();
+#else
+    constexpr auto optimal_vec_size = vec_size;
+#endif
     elementwise_kernel_helper(
-        f, memory::policies::vectorized<vec_size, array_t, elems_per_thread<io_size>()>(data));
+        f, memory::policies::vectorized<optimal_vec_size, array_t, elems_per_thread<io_size>()>(data));
   }
 }
 
@@ -154,6 +192,18 @@ static inline void launch_vectorized_kernel(
   int vec_size = memory::can_vectorize_up_to<func_t>(data);
 
   switch (vec_size) {
+#ifdef USE_ROCM
+    case 16:
+      vectorized_elementwise_kernel<16, func_t, array_t>
+          <<<grid, num_threads(), 0, stream>>>(N, f, data);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+      break;
+     case 8:
+      vectorized_elementwise_kernel<8, func_t, array_t>
+          <<<grid, num_threads(), 0, stream>>>(N, f, data);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+      break;
+ #endif
     case 4:
       vectorized_elementwise_kernel<4, func_t, array_t>
           <<<grid, num_threads(), 0, stream>>>(N, f, data);

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -353,10 +353,7 @@ inline C10_HOST_DEVICE int can_vectorize_up_to(const char *pointer) {
   constexpr int vec4_alignment = std::alignment_of_v<aligned_vector<scalar_t, 4>>;
 #ifdef USE_ROCM
   constexpr int vec8_alignment = std::alignment_of_v<aligned_vector<scalar_t, 8>>;
-  constexpr int vec16_alignment = std::alignment_of_v<aligned_vector<scalar_t, 16>>;
-  if (address % vec16_alignment == 0) {
-    return 16;
-  } else if (address % vec8_alignment == 0) {
+  if (address % vec8_alignment == 0) {
     return 8;
   } else if (address % vec4_alignment == 0) {
     return 4;

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -351,11 +351,25 @@ inline C10_HOST_DEVICE int can_vectorize_up_to(const char *pointer) {
   uint64_t address = reinterpret_cast<uint64_t>(pointer);
   constexpr int vec2_alignment = std::alignment_of_v<aligned_vector<scalar_t, 2>>;
   constexpr int vec4_alignment = std::alignment_of_v<aligned_vector<scalar_t, 4>>;
+#ifdef USE_ROCM
+  constexpr int vec8_alignment = std::alignment_of_v<aligned_vector<scalar_t, 8>>;
+  constexpr int vec16_alignment = std::alignment_of_v<aligned_vector<scalar_t, 16>>;
+  if (address % vec16_alignment == 0) {
+    return 16;
+  } else if (address % vec8_alignment == 0) {
+    return 8;
+  } else if (address % vec4_alignment == 0) {
+    return 4;
+  } else if (address % vec2_alignment == 0) {
+    return 2;
+  }
+#else
   if (address % vec4_alignment == 0) {
     return 4;
   } else if (address % vec2_alignment == 0) {
     return 2;
   }
+#endif
   return 1;
 }
 

--- a/aten/src/ATen/native/cuda/thread_constants.h
+++ b/aten/src/ATen/native/cuda/thread_constants.h
@@ -18,5 +18,5 @@ constexpr uint32_t num_threads() {
 }
 #endif
 
-constexpr int thread_work_size() { return 4; }
+constexpr int thread_work_size() { return 8; }
 constexpr int block_work_size() { return thread_work_size() * num_threads(); }


### PR DESCRIPTION
*  Make calc_io_size() return the size based on the input or output datatype, rather than the summaztion of all sizes
   * for e.g, for torch.add() on half dtypes (bfloat16/float16), calc_io_size() returns 6 causing elems_per_thread to be 4
   * But elems_per_thread = 8 works better on half datypes for AMD gpus
* Enable *_load_dwordx4 ISA for 16-bit and 8-bit dtypes and by using vector size of 8 and 16 respectively

Co-author: @akadutta

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd