### PR TITLE
Fix ARM bfloat16 fmsub & improve vec_test_all_types coverage

### DIFF
--- a/aten/src/ATen/cpu/vec/vec128/vec128_bfloat16_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_bfloat16_neon.h
@@ -542,16 +542,12 @@ Vectorized<c10::BFloat16> inline fmsub(
     const Vectorized<c10::BFloat16>& b,
     const Vectorized<c10::BFloat16>& c) {
   // See NOTE [BF16 FMA] above.
-#ifdef __ARM_FEATURE_BF16
-  return Vectorized<c10::BFloat16>(vfmsq_f16(c, a, b));
-#else
   const auto [a_float_low, a_float_high] = convert_bfloat16_float(a);
   const auto [b_float_low, b_float_high] = convert_bfloat16_float(b);
   const auto [c_float_low, c_float_high] = convert_bfloat16_float(c);
   return convert_float_bfloat16(
       fmsub(a_float_low, b_float_low, c_float_low),
       fmsub(a_float_high, b_float_high, c_float_high));
-#endif
 }
 
 #endif // !defined(C10_MOBILE) && defined(__aarch64__)

--- a/aten/src/ATen/test/vec_test_all_types.h
+++ b/aten/src/ATen/test/vec_test_all_types.h
@@ -568,7 +568,7 @@ private:
     uint64_t seed;
 };
 
-template <typename T, bool is_floating_point = std::is_floating_point_v<T>, bool is_complex = is_complex<T>::value>
+template <typename T, bool is_floating_point = std::is_floating_point_v<T> || std::is_reduced_floating_point_v<T>, bool is_complex = is_complex<T>::value>
 struct ValueGen
 {
     std::uniform_int_distribution<int64_t> dis;
@@ -591,10 +591,13 @@ struct ValueGen
 };
 
 template <typename T>
+using reduced_fp_to_float_t = std::conditional_t<std::is_reduced_floating_point_v<T>, float, T>;
+
+template <typename T>
 struct ValueGen<T, true, false>
 {
     std::mt19937 gen;
-    std::normal_distribution<T> normal;
+    std::normal_distribution<reduced_fp_to_float_t<T>> normal;
     std::uniform_int_distribution<int> roundChance;
     T _start;
     T _stop;
@@ -613,7 +616,7 @@ struct ValueGen<T, true, false>
         //make it  normal +-3sigma
         T divRange = static_cast<T>(6.0);
         T stdev = std::abs(stop / divRange - start / divRange);
-        normal = std::normal_distribution<T>{ mean, stdev };
+        normal = std::normal_distribution<reduced_fp_to_float_t<T>>{ mean, stdev };
         // in real its hard to get rounded value
         // so we will force it by  uniform chance
         roundChance = std::uniform_int_distribution<int>(0, 5);
@@ -1278,6 +1281,13 @@ std::enable_if_t<!is_complex<T>::value, T> local_fmadd(T a, T b, T c) {
     PreventFma noFma;
     T ab = a * b;
     return noFma.add(ab, c);
+}
+
+template <typename T>
+std::enable_if_t<!is_complex<T>::value, T> local_fmsub(T a, T b, T c) {
+    PreventFma noFma;
+    T ab = a * b;
+    return noFma.sub(ab, c);
 }
 
 template <typename T>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142499

This function was very broken and untested. Now it is tested, and vec_test_all_types is passing internally as well.

Differential Revision: [D67036894](https://our.internmc.facebook.com/intern/diff/D67036894/)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10