### PR TITLE
[Dynamo] Stop importing transformers

### DIFF
--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -940,7 +940,8 @@ class CustomizedDictVariable(ConstDictVariable):
 
 @functools.lru_cache(None)
 def _install_PretrainedConfig_patch():
-    import transformers
+    mod = sys.modules.get("transformers.configuration_utils")
+    assert mod is not None, "Caller is responsible for ensuring this was imported"
 
     # We need to monkeypatch transformers here, sadly.
     # TODO(voz): Upstream to transformers lib
@@ -950,9 +951,7 @@ def _install_PretrainedConfig_patch():
             return False
         return self.__dict__ == other.__dict__
 
-    transformers.configuration_utils.PretrainedConfig.__eq__ = (
-        _dynamo_overriden_transformers_eq
-    )
+    mod.PretrainedConfig.__eq__ = _dynamo_overriden_transformers_eq
 
 
 class HFPretrainedConfigVariable(VariableTracker):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #142508
* #142503
* __->__ #142502

This import was free because transformers should already have been
imported by this time.

Test Plan:
- CI

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames