### PR TITLE
[1/n] Implement Conditional Dependency for Auto AC Commericial Solvers - OSS

### DIFF
--- a/torch/_functorch/_activation_checkpointing/commercial_solvers.py
+++ b/torch/_functorch/_activation_checkpointing/commercial_solvers.py
@@ -1,0 +1,15 @@
+from typing import List
+
+from torch import fx
+
+
+def backwards_pass_aware_graph_solver(
+    memory: List[float],
+    joint_graph: fx.Graph,
+    max_memory: float,
+    node_info,
+    all_recomputable_banned_nodes: List[fx.Node],
+):
+    raise ValueError(
+        "Backwards pass aware graph solver implementation is currently not supported."
+    )

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -28,6 +28,9 @@ from torch.fx.passes import graph_drawer
 from torch.utils.checkpoint import CheckpointPolicy
 
 from . import config
+from ._activation_checkpointing.commercial_solvers import (
+    backwards_pass_aware_graph_solver,
+)
 from ._activation_checkpointing.knapsack import (
     dp_knapsack,
     greedy_knapsack,
@@ -1403,9 +1406,13 @@ def _optimize_runtime_with_given_memory(
         return ilp_knapsack(memory, runtimes, max_memory)
     elif SOLVER == "dp":
         return dp_knapsack(memory, runtimes, max_memory)
-    elif callable(SOLVER):
-        saved_node_idx, recomp_node_idx = SOLVER(
-            memory, joint_graph, max_memory, node_info, all_recomputable_banned_nodes
+    elif SOLVER == "bwpa":
+        saved_node_idx, recomp_node_idx = backwards_pass_aware_graph_solver(
+            memory=memory,
+            joint_graph=joint_graph,
+            max_memory=max_memory,
+            node_info=node_info,
+            all_recomputable_banned_nodes=all_recomputable_banned_nodes,
         )
         return (0.0, saved_node_idx, recomp_node_idx)
     else:


### PR DESCRIPTION
Summary:
The reason we needed to make this change is because [xpress](https://www.internalfb.com/intern/wiki/Interview_Builder/System_Design/Interview_Loop_Solver/Xpress_and_Solver_Mechanics/) is a commercial solver and we are unable to use it directly as a dependency in Pytorch.

Full Context: https://docs.google.com/document/d/1fDrV4nTPmlFrQrgHkFQ0ARkM7PbSxWQ2nCX5uP-Dmbc/edit?usp=sharing

Test Plan:
# Local Testing Training Run

```
CUDA_VISIBLE_DEVICES=5,6 AOT_PARTITIONER_DEBUG=1 PARTITIONER_MEMORY_BUDGET_PARETO=0 buck2 run mode/opt //aps_models/ads/icvr:icvr_launcher -- mode=local_fb_fm_v4 launcher.num_workers=2 2>&1 | tee log_2024-11-2320:41:50.757256__bento_trigger.txt
```

Output Summary Paste: P1685697066

Differential Revision: D63797051


