### PR TITLE
NOCOMMIT: does adding -march=armv8.2-a+bf16 to aarch64 builds cause them to detect ARM_FEATURE_BF16 problems?

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -97,6 +97,8 @@ if [[ "$BUILD_ENVIRONMENT" == *aarch64* ]]; then
   export USE_MKLDNN=1
   export USE_MKLDNN_ACL=1
   export ACL_ROOT_DIR=/ComputeLibrary
+  export CFLAGS="-march=armv8.2-a+bf16"
+  export CXXFLAGS="-march=armv8.2-a+bf16"
 fi
 
 if [[ "$BUILD_ENVIRONMENT" == *libtorch* ]]; then


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142760
* #142501

Differential Revision: [D67054864](https://our.internmc.facebook.com/intern/diff/D67054864/)