### PR TITLE
operator benchmark: write output to a JSON

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -4,6 +4,7 @@ import functools
 import json
 import timeit
 from collections import namedtuple
+import re
 
 import benchmark_utils
 
@@ -250,6 +251,31 @@ class BenchmarkRunner:
             else:
                 print(f"{mode} Execution Time (us) : {reported_run_time_us[0]:.3f}\n")
 
+    def _perf_result_to_dict(self, reported_run_time_us, test_case):
+        """This function is the parallel of _print_perf_result, which instead of
+        writing information to terminal, returns a dictionary.
+        """
+        if self.args.report_aibench: return {}
+        out = {
+            "test_name":     test_case.test_config.test_name,
+            "input_config":  test_case.test_config.input_config,
+            "mode":         "JIT" if self.use_jit else "Eager",
+            "run":          "Backward" if test_case.test_config.run_backward else "Forward",
+            "latency":       round(reported_run_time_us[0], 3),
+            "latency unit": "us"
+        }
+
+        # parsing test_case.test_config.input_config, adding it as entries to the 'out' dictionary
+        # input: 'M: 1, N: 1, K: 1, device: cpu'
+        # output: {'M':'1', 'N':'1', 'K':'1', 'device': 'cpu'}
+        # splitting the string on unnested commas
+        key_vals = re.split(r',(?![^(){}[\]]*[)\]}])', test_case.test_config.input_config)                    # 'M: (32, 16), ZPB: 2' -> ['M: (32, 16)', 'ZPB: 2']
+        key_vals = [(key.strip(), value.strip()) for key, value in map(lambda str: str.split(':'), key_vals)] # ['M: (32, 16)', 'ZPB: 2'] -> [('M', '(32, 16)'), ('ZPB', '2')]
+        for key, value in key_vals:
+            out[key]   = value
+
+        return out
+
     def _predict_num_iter_needed(self, i):
         return i * self.multiplier
 
@@ -399,6 +425,9 @@ class BenchmarkRunner:
     def run(self):
         self._print_header()
 
+        if self.args.output_json:
+            perf_list = []
+
         for test_metainfo in BENCHMARK_TESTER:
             for test in _build_test(*test_metainfo):
                 full_test_id, test_case = test
@@ -439,3 +468,9 @@ class BenchmarkRunner:
                 ]
 
                 self._print_perf_result(reported_time, test_case)
+                if self.args.output_json:
+                    perf_list.append(self._perf_result_to_dict(reported_time, test_case))
+
+        if self.args.output_json:
+            with open(self.args.output_json, "w") as f:
+                json.dump(perf_list, f)

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -2,9 +2,9 @@ import ast
 import copy
 import functools
 import json
+import re
 import timeit
 from collections import namedtuple
-import re
 
 import benchmark_utils
 
@@ -255,24 +255,30 @@ class BenchmarkRunner:
         """This function is the parallel of _print_perf_result, which instead of
         writing information to terminal, returns a dictionary.
         """
-        if self.args.report_aibench: return {}
+        if self.args.report_aibench:
+            return {}
         out = {
-            "test_name":     test_case.test_config.test_name,
-            "input_config":  test_case.test_config.input_config,
-            "mode":         "JIT" if self.use_jit else "Eager",
-            "run":          "Backward" if test_case.test_config.run_backward else "Forward",
-            "latency":       round(reported_run_time_us[0], 3),
-            "latency unit": "us"
+            "test_name": test_case.test_config.test_name,
+            "input_config": test_case.test_config.input_config,
+            "mode": "JIT" if self.use_jit else "Eager",
+            "run": "Backward" if test_case.test_config.run_backward else "Forward",
+            "latency": round(reported_run_time_us[0], 3),
+            "latency unit": "us",
         }
 
         # parsing test_case.test_config.input_config, adding it as entries to the 'out' dictionary
         # input: 'M: 1, N: 1, K: 1, device: cpu'
         # output: {'M':'1', 'N':'1', 'K':'1', 'device': 'cpu'}
         # splitting the string on unnested commas
-        key_vals = re.split(r',(?![^(){}[\]]*[)\]}])', test_case.test_config.input_config)                    # 'M: (32, 16), ZPB: 2' -> ['M: (32, 16)', 'ZPB: 2']
-        key_vals = [(key.strip(), value.strip()) for key, value in map(lambda str: str.split(':'), key_vals)] # ['M: (32, 16)', 'ZPB: 2'] -> [('M', '(32, 16)'), ('ZPB', '2')]
+        key_vals = re.split(
+            r",(?![^(){}[\]]*[)\]}])", test_case.test_config.input_config
+        )  # 'M: (32, 16), ZPB: 2' -> ['M: (32, 16)', 'ZPB: 2']
+        key_vals = [
+            (key.strip(), value.strip())
+            for key, value in map(lambda str: str.split(":"), key_vals)
+        ]  # ['M: (32, 16)', 'ZPB: 2'] -> [('M', '(32, 16)'), ('ZPB', '2')]
         for key, value in key_vals:
-            out[key]   = value
+            out[key] = value
 
         return out
 
@@ -469,7 +475,9 @@ class BenchmarkRunner:
 
                 self._print_perf_result(reported_time, test_case)
                 if self.args.output_json:
-                    perf_list.append(self._perf_result_to_dict(reported_time, test_case))
+                    perf_list.append(
+                        self._perf_result_to_dict(reported_time, test_case)
+                    )
 
         if self.args.output_json:
             with open(self.args.output_json, "w") as f:

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -275,7 +275,7 @@ class BenchmarkRunner:
         )  # 'M: (32, 16), ZPB: 2' -> ['M: (32, 16)', 'ZPB: 2']
         key_vals = [
             (key.strip(), value.strip())
-            for key, value in map(lambda str: str.split(":"), key_vals)
+            for key, value in map(lambda str: str.split(":"), key_vals) # noqa: C417
         ]  # ['M: (32, 16)', 'ZPB: 2'] -> [('M', '(32, 16)'), ('ZPB', '2')]
         for key, value in key_vals:
             out[key] = value

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -275,7 +275,7 @@ class BenchmarkRunner:
         )  # 'M: (32, 16), ZPB: 2' -> ['M: (32, 16)', 'ZPB: 2']
         key_vals = [
             (key.strip(), value.strip())
-            for key, value in map(lambda str: str.split(":"), key_vals) # noqa: C417
+            for key, value in map(lambda str: str.split(":"), key_vals)  # noqa: C417
         ]  # ['M: (32, 16)', 'ZPB: 2'] -> [('M', '(32, 16)'), ('ZPB', '2')]
         for key, value in key_vals:
             out[key] = value

--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -55,6 +55,13 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--output-json",
+        "--output_json",
+        help="JSON file path to write the results to",
+        default=None,
+    )
+
+    parser.add_argument(
         "--list-tests",
         "--list_tests",
         help="List all test cases without running them",


### PR DESCRIPTION
This pull request adds the functionality of writing the output of operator benchmark to an optional JSON file specified. The output is still printed in the terminal like before, but the user has the option of saving it in a JSON file as well.

Main part of the functionality is implemented using the function _perf_result_to_dict which outputs a dictionary to be put inside a JSON file. Each dictionary corresponds to a single test.
