### PR TITLE
allow -E to be in any spot in the compiler command

### DIFF
--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -9,7 +9,7 @@ install_ubuntu() {
   # Instead use lib and headers from OpenSSL1.1 installed in `install_openssl.sh``
   apt-get install -y cargo
   echo "Checking out sccache repo"
-  git clone https://github.com/mozilla/sccache -b v0.8.2
+  git clone https://github.com/mozilla/sccache -b v0.9.0
   cd sccache
   echo "Building sccache"
   cargo build --release

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -53,8 +53,8 @@ function write_sccache_stub() {
 #!/bin/sh
 
 # sccache does not support -E flag, so we need to call the original compiler directly in order to avoid calling this wrapper recursively
-for arg in "$@"; do
-  if [ "$arg" = "-E" ]; then
+for arg in "\$@"; do
+  if [ "\$arg" = "-E" ]; then
     exec $(which $1) "\$@"
   fi
 done

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -52,9 +52,14 @@ function write_sccache_stub() {
     cat >"/opt/cache/bin/$1" <<EOF
 #!/bin/sh
 
-if [ "\$1" = "-E" ] || [ "\$2" = "-E" ] || [ "\$3" = "-E" ]; then
-  exec $(which $1) "\$@"
-elif [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then
+# sccache does not support -E flag, so we need to call the original compiler directly in order to avoid calling this wrapper recursively
+for arg in "$@"; do
+  if [ "$arg" = "-E" ]; then
+    exec $(which $1) "\$@"
+  fi
+done
+
+if [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then
   exec sccache $(which $1) "\$@"
 else
   exec $(which $1) "\$@"

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -9,7 +9,7 @@ install_ubuntu() {
   # Instead use lib and headers from OpenSSL1.1 installed in `install_openssl.sh``
   apt-get install -y cargo
   echo "Checking out sccache repo"
-  git clone https://github.com/mozilla/sccache -b v0.9.0
+  git clone https://github.com/mozilla/sccache -b v0.8.2
   cd sccache
   echo "Building sccache"
   cargo build --release


### PR DESCRIPTION
Follow up of TODO in https://github.com/pytorch/pytorch/pull/140614

It was found experimentally, that for one GPU architecture, `sccache` passes `-E` as 1st, 2nd or 3rd argument, but it's much better to do this if `-E` is passed as any argument

No need to worry about exit or elif chains, as `exec` aborts script execution
