### PR TITLE
[RFC] Add option to support garbage collection after torch compilation

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Dict, Optional, Set, Type, TYPE_CHECKING, Unio
 
 import torch
 from torch._environment import is_fbcode
-from torch.utils._config_module import get_tristate_env, install_config_module
+from torch.utils._config_module import Config, get_tristate_env, install_config_module
 
 
 # to configure logging for dynamo, aot, and inductor
@@ -525,6 +525,12 @@ automatic_dynamic_local_pgo: bool = (
 # Like above, but using remote cache
 automatic_dynamic_remote_pgo: Optional[bool] = get_tristate_env(
     "TORCH_DYNAMO_AUTOMATIC_DYNAMIC_REMOTE_PGO"
+)
+
+# Run GC at the end of compilation
+run_gc_after_compile = Config(
+    default=True, justknob="pytorch/compiler:enable_run_gc_after_compile", 
+    env_name_default="ENABLE_RUN_GC_AFTER_TORCH_COMPILE",
 )
 
 # HACK: this is for testing custom ops profiling only

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -6,6 +6,7 @@ import contextlib
 import cProfile
 import dis
 import functools
+import gc
 import itertools
 import json
 import logging
@@ -1042,6 +1043,11 @@ def _compile(
             # dynamo_compile table, and we will not have telemetry.
             # Be extra careful when making changes here!
 
+            if torch._dynamo.config.run_gc_after_compile:
+                with dynamo_timed("gc", dynamo_compile_column_us="gc_time_us"):
+                    log.info("run_gc_after_compile: running gc")
+                    gc.collect()
+    
             if tracer:
                 tracer.output.local_scope = {}
 


### PR DESCRIPTION
Summary:
This diff is an extension of ezyang's PR https://fburl.com/6uvvzb4f.
In ezyang's PR above, it adds gc after torch compilation finished. 
The gc operation is guarded by jk: pytorch/compiler:enable_run_gc_after_compile
The gc op time cost will be logged into dynamo_compile scuba table.

This diff extends the PR to additionally introduce an environment variance which has the higher priority than the JK to control whether we do gc or not after the torch compilation. (default value set to gc enabled)
This environment variance will be used for AB testing of training jobs to compare the pt2 compilation time and memory cost.

Test Plan: WIP

Differential Revision: D67062158




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames