### PR TITLE
[ONNX] Avoid overwriting overlapped decomposed functions

### DIFF
--- a/torch/onnx/_internal/exporter/_decomp.py
+++ b/torch/onnx/_internal/exporter/_decomp.py
@@ -70,6 +70,10 @@ def create_onnx_friendly_decomposition_table(
         # If it is HOP, we filter those out as well.
         if not hasattr(op_overload, "_schema"):
             continue
+        # NOTE: torch._decomp.decomposition_table covers more ops
+        # than torch.export.default_decompositions, but the latter is
+        # more critical to torch.onnx.export.
+        if op_overload in decomposition_table:
+            continue
         decomposition_table[op_overload] = decomp_fn
-
     return decomposition_table


### PR DESCRIPTION
Fixes #141770 

The decomposed function in `torch.export.default_decompositions().items()` is overwritten by `torch._decomp.decomposition_table`. As from `torch.onnx.export()` perspective, we should rather respect the table of decompositions in `torch.export.default_decompositions().items()` and avoid overwriting it with `torch._decomp.decomposition_table`.