### PR TITLE
[state dict] Change _load_model_state_dict to enable cpu_offload, accept 2 device type and optimize memory

### DIFF
--- a/torch/distributed/_state_dict_utils.py
+++ b/torch/distributed/_state_dict_utils.py
@@ -549,7 +549,6 @@ def _distribute_tensors(
         _local_state = local_state_dict.get(key, None)
         if _local_state is None or torch.is_tensor(_local_state):
             continue
-
         local_state = _local_state[0]
         full_tensor = _local_state[1]
 
@@ -560,16 +559,21 @@ def _distribute_tensors(
             slice(cur_offset, cur_offset + cur_shape)
             for cur_shape, cur_offset in zip(shape, offset)
         ]
-        local_tensor = full_tensor[slices]
-        # TODO: currently, we cannot handle strided sharding if the dp dimension is not even. For example,
-        # one of the case that is not yet supported is when placements = (Shard(0), _StridedShard(0, sf=2)).
-        local_state_dict[key] = DTensor.from_local(
-            local_tensor,
-            local_state.device_mesh,
-            local_state.placements,
-            shape=local_state.shape,
-            stride=local_state.stride(),
-        )
+        if local_state.is_meta:
+            local_tensor = full_tensor[slices].detach().clone()
+            # TODO: currently, we cannot handle strided sharding if the dp dimension is not even. For example,
+            # one of the case that is not yet supported is when placements = (Shard(0), _StridedShard(0, sf=2)).
+            ret = DTensor.from_local(
+                local_tensor,
+                local_state.device_mesh,
+                local_state.placements,
+                shape=local_state.shape,
+                stride=local_state.stride(),
+            )
+        else:
+            ret = local_state
+            ret.to_local().copy_(full_tensor[slices])
+        local_state_dict[key] = ret
 
 
 def _broadcast_state_dict(
@@ -578,6 +582,7 @@ def _broadcast_state_dict(
     device: torch.device,
     pg: Optional[dist.ProcessGroup] = None,
     strict: bool = False,
+    cpu_offload: bool = False,
 ) -> None:
     # Broadcast from rank0's `full_state_dict` to all ranks' `local_state_dict`.
     # If strict is True, any keys in `local_state_dict` but not in `full_state_dict`
@@ -595,7 +600,6 @@ def _broadcast_state_dict(
     broadcast_list = [ret]
     dist.broadcast_object_list(broadcast_list, src=0, group=pg)
     ret = broadcast_list[0]
-
     # Gather values
     keys = []
     local_state_dict_keys = set(local_state_dict.keys())
@@ -614,6 +618,9 @@ def _broadcast_state_dict(
         # Broadcast every tensor to avoid OOM for now.
         if len(keys) >= 1:
             _broadcast_tensors(ret, local_state_dict, keys, device, pg)
+            if cpu_offload:
+                for key in keys:
+                    local_state_dict[key] = local_state_dict[key].cpu()
             keys.clear()
 
     if strict:
@@ -623,6 +630,9 @@ def _broadcast_state_dict(
 
     if keys:
         _broadcast_tensors(ret, local_state_dict, keys, device, pg)
+        if cpu_offload:
+            for key in keys:
+                local_state_dict[key] = local_state_dict[key].cpu()
 
 
 def _distribute_state_dict(

--- a/torch/distributed/_state_dict_utils.py
+++ b/torch/distributed/_state_dict_utils.py
@@ -78,7 +78,8 @@ def _all_gather_sharded_tensor(
     return tensor
 
 
-class CompanionMismatch(Exception): ...
+class CompanionMismatch(Exception):
+    ...
 
 
 def _iterate_state_dict(

--- a/torch/distributed/_state_dict_utils.py
+++ b/torch/distributed/_state_dict_utils.py
@@ -78,8 +78,7 @@ def _all_gather_sharded_tensor(
     return tensor
 
 
-class CompanionMismatch(Exception):
-    ...
+class CompanionMismatch(Exception): ...
 
 
 def _iterate_state_dict(
@@ -549,6 +548,7 @@ def _distribute_tensors(
         _local_state = local_state_dict.get(key, None)
         if _local_state is None or torch.is_tensor(_local_state):
             continue
+
         local_state = _local_state[0]
         full_tensor = _local_state[1]
 

--- a/torch/distributed/_state_dict_utils.py
+++ b/torch/distributed/_state_dict_utils.py
@@ -516,7 +516,6 @@ def _broadcast_tensors(
                 device=device,
                 dtype=tensor_info.dtype,
             )
-
         tensors.append(full_tensor)
         local_state = local_state_dict.get(key, None)
         if local_state is None:
@@ -561,6 +560,7 @@ def _distribute_tensors(
             for cur_shape, cur_offset in zip(shape, offset)
         ]
         if local_state.is_meta:
+            # Use .clone() here rather than view to clone and return only the sliced portion, minimizing memory access and cost.
             local_tensor = full_tensor[slices].detach().clone()
             # TODO: currently, we cannot handle strided sharding if the dp dimension is not even. For example,
             # one of the case that is not yet supported is when placements = (Shard(0), _StridedShard(0, sf=2)).
@@ -573,6 +573,7 @@ def _distribute_tensors(
             )
         else:
             ret = local_state
+            # Copy full_tensor[slices] into local_state.to_local() to reduce memory footprint.
             ret.to_local().copy_(full_tensor[slices])
         local_state_dict[key] = ret
 

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -150,9 +150,9 @@ class StateDictOptions:
 
 @dataclass
 class _StateDictInfo(StateDictOptions):
-    fqn_param_mapping: Dict[Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]] = (
-        field(default_factory=dict)
-    )
+    fqn_param_mapping: Dict[
+        Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]
+    ] = field(default_factory=dict)
     shared_params_mapping: Dict[
         Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]
     ] = field(default_factory=dict)
@@ -286,9 +286,9 @@ def _verify_options(
 
     options = options or StateDictOptions()
 
-    fqn_param_mapping: Dict[Union[str, torch.Tensor], Union[Set[str], torch.Tensor]] = (
-        {}
-    )
+    fqn_param_mapping: Dict[
+        Union[str, torch.Tensor], Union[Set[str], torch.Tensor]
+    ] = {}
     shared_params_mapping: Dict[
         Union[str, torch.Tensor], Union[Set[str], torch.Tensor]
     ] = {}

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -150,9 +150,9 @@ class StateDictOptions:
 
 @dataclass
 class _StateDictInfo(StateDictOptions):
-    fqn_param_mapping: Dict[
-        Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]
-    ] = field(default_factory=dict)
+    fqn_param_mapping: Dict[Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]] = (
+        field(default_factory=dict)
+    )
     shared_params_mapping: Dict[
         Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]
     ] = field(default_factory=dict)
@@ -286,9 +286,9 @@ def _verify_options(
 
     options = options or StateDictOptions()
 
-    fqn_param_mapping: Dict[
-        Union[str, torch.Tensor], Union[Set[str], torch.Tensor]
-    ] = {}
+    fqn_param_mapping: Dict[Union[str, torch.Tensor], Union[Set[str], torch.Tensor]] = (
+        {}
+    )
     shared_params_mapping: Dict[
         Union[str, torch.Tensor], Union[Set[str], torch.Tensor]
     ] = {}
@@ -571,6 +571,9 @@ def _load_model_state_dict(
             )
         elif info.full_state_dict:
             _distribute_state_dict(state_dict, local_state_dict, device=device)
+        if info.cpu_offload:
+            for fqn in local_state_dict.keys():
+                local_state_dict[fqn] = local_state_dict[fqn].to(torch.device("cpu"))
         for fqn, local_state in local_state_dict.items():
             state_dict[fqn] = local_state
 

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -567,9 +567,12 @@ def _load_model_state_dict(
         # In lora state_dict, ther could be multiple devices, with meta device inside.
         # Take the other device in the broadcast/distribtue, and set assign to True
         elif len(devices) == 2:
-            devices.remove(torch.device("meta"))
-            device = devices.pop()
-            assign = True
+            if torch.device("meta") in devices:
+                devices.remove(torch.device("meta"))
+                device = devices.pop()
+                assign = True
+            else:
+                raise ValueError("Multiple devices found")
         else:
             raise ValueError("Multiple devices found")
 

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -150,9 +150,9 @@ class StateDictOptions:
 
 @dataclass
 class _StateDictInfo(StateDictOptions):
-    fqn_param_mapping: Dict[Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]] = (
-        field(default_factory=dict)
-    )
+    fqn_param_mapping: Dict[
+        Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]
+    ] = field(default_factory=dict)
     shared_params_mapping: Dict[
         Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]
     ] = field(default_factory=dict)
@@ -286,9 +286,9 @@ def _verify_options(
 
     options = options or StateDictOptions()
 
-    fqn_param_mapping: Dict[Union[str, torch.Tensor], Union[Set[str], torch.Tensor]] = (
-        {}
-    )
+    fqn_param_mapping: Dict[
+        Union[str, torch.Tensor], Union[Set[str], torch.Tensor]
+    ] = {}
     shared_params_mapping: Dict[
         Union[str, torch.Tensor], Union[Set[str], torch.Tensor]
     ] = {}
@@ -564,8 +564,8 @@ def _load_model_state_dict(
             if device == torch.device("meta"):
                 device = dist.distributed_c10d._get_pg_default_device()
                 assign = True
-        # In lora state_dict, ther could be multiple devices, with meta device inside
-        # take the other device in the broadcast/distribtue, and set assign to True
+        # In lora state_dict, ther could be multiple devices, with meta device inside.
+        # Take the other device in the broadcast/distribtue, and set assign to True
         elif len(devices) == 2:
             devices.remove(torch.device("meta"))
             device = devices.pop()
@@ -575,13 +575,14 @@ def _load_model_state_dict(
 
         if info.broadcast_from_rank0:
             _broadcast_state_dict(
-                state_dict, local_state_dict, device=device, strict=info.strict
+                state_dict,
+                local_state_dict,
+                device=device,
+                strict=info.strict,
+                cpu_offload=info.cpu_offload,
             )
         elif info.full_state_dict:
             _distribute_state_dict(state_dict, local_state_dict, device=device)
-        if info.cpu_offload:
-            for fqn in local_state_dict.keys():
-                local_state_dict[fqn] = local_state_dict[fqn].to(torch.device("cpu"))
         for fqn, local_state in local_state_dict.items():
             state_dict[fqn] = local_state
 

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -150,9 +150,9 @@ class StateDictOptions:
 
 @dataclass
 class _StateDictInfo(StateDictOptions):
-    fqn_param_mapping: Dict[
-        Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]
-    ] = field(default_factory=dict)
+    fqn_param_mapping: Dict[Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]] = (
+        field(default_factory=dict)
+    )
     shared_params_mapping: Dict[
         Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]
     ] = field(default_factory=dict)
@@ -286,9 +286,9 @@ def _verify_options(
 
     options = options or StateDictOptions()
 
-    fqn_param_mapping: Dict[
-        Union[str, torch.Tensor], Union[Set[str], torch.Tensor]
-    ] = {}
+    fqn_param_mapping: Dict[Union[str, torch.Tensor], Union[Set[str], torch.Tensor]] = (
+        {}
+    )
     shared_params_mapping: Dict[
         Union[str, torch.Tensor], Union[Set[str], torch.Tensor]
     ] = {}
@@ -564,6 +564,8 @@ def _load_model_state_dict(
             if device == torch.device("meta"):
                 device = dist.distributed_c10d._get_pg_default_device()
                 assign = True
+        # In lora state_dict, ther could be multiple devices, with meta device inside
+        # take the other device in the broadcast/distribtue, and set assign to True
         elif len(devices) == 2:
             devices.remove(torch.device("meta"))
             device = devices.pop()

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -150,9 +150,9 @@ class StateDictOptions:
 
 @dataclass
 class _StateDictInfo(StateDictOptions):
-    fqn_param_mapping: Dict[
-        Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]
-    ] = field(default_factory=dict)
+    fqn_param_mapping: Dict[Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]] = (
+        field(default_factory=dict)
+    )
     shared_params_mapping: Dict[
         Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]
     ] = field(default_factory=dict)
@@ -286,9 +286,9 @@ def _verify_options(
 
     options = options or StateDictOptions()
 
-    fqn_param_mapping: Dict[
-        Union[str, torch.Tensor], Union[Set[str], torch.Tensor]
-    ] = {}
+    fqn_param_mapping: Dict[Union[str, torch.Tensor], Union[Set[str], torch.Tensor]] = (
+        {}
+    )
     shared_params_mapping: Dict[
         Union[str, torch.Tensor], Union[Set[str], torch.Tensor]
     ] = {}
@@ -552,6 +552,7 @@ def _load_model_state_dict(
                 state_dict[fqn_with_prefix] = state_dict.pop(fqn)
             local_state_dict[fqn_with_prefix] = value
 
+    assign = False
     if info.broadcast_from_rank0 or info.full_state_dict:
         devices = set()
         for key, value in local_state_dict.items():
@@ -561,6 +562,7 @@ def _load_model_state_dict(
         # Take the other device in the broadcast/distribtue, and set assign to True
         if torch.device("meta") in devices:
             devices.remove(torch.device("meta"))
+            assign = True
         if len(devices) == 0:
             devices.add(dist.distributed_c10d._get_pg_default_device())
         elif len(devices) > 1:
@@ -583,7 +585,7 @@ def _load_model_state_dict(
         return cast(
             _IncompatibleKeys,
             _state_dict_fn(model, "load_state_dict")(
-                state_dict=state_dict, strict=info.strict, assign=True
+                state_dict=state_dict, strict=info.strict, assign=assign
             ),
         )
 


### PR DESCRIPTION
For destributed state dict api [migration](https://github.com/pytorch/torchtune/pull/2138), make the changes here:
1. `load_from_full_model_state_dict` at TorchTune calls `set_model_state_dict` with the options on whether to have cpu_offload. Add cpu_offload at _load_model_state_dict to process to cpu if config is True
2. Change the device check as lora_finetune might hace 2 device types, accept that to be valid.
3. Some changes to optimize the memory performance:
3.1 use `.detach().clone()` instead of view directly
3.2 if local_state is not meta, copy `full_tensor[slices]` to `ret.to_local()`
4. add relative unit tests

Memory performance calling from TorchTune with llama2/7B_full:
1. cpu_offload = True
<img width="555" alt="Screenshot 2024-12-18 at 1 36 47 PM" src="https://github.com/user-attachments/assets/429261f5-1107-4592-b295-de3944a2614b" />

2. cpu_offload = False
<img width="555" alt="Screenshot 2024-12-18 at 1 36 52 PM" src="https://github.com/user-attachments/assets/40bf281a-236a-4218-826b-b1192a10c806" />


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn 