### PR TITLE
Fix RMSNorm epsilon value type for BF16 or FP16

### DIFF
--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -298,14 +298,23 @@ Tensor rms_norm_symint(
         input.scalar_type(),
         "rms_norm",
         [&] {
-    using limits = std::numeric_limits<at::scalar_value_type<scalar_t>::type>;
-    scalar_t eps_val = eps.value_or(limits::epsilon());
-
     // upcast is needed for fp16 and bf16
     c10::ScalarType opmath_t = toOpMathType(input.scalar_type());
     Tensor upcasted_input = input.to(opmath_t);
 
-    auto rqrst_input = rsqrt(at::pow(upcasted_input, 2).mean(dims_to_reduce_ref, /*keepdim=*/true).add_(eps_val));
+    Tensor rqrst_input;
+
+    // opmath_t would be one of [Double, Float, ComplexFloat, ComplexDouble]
+    if (opmath_t == at::ScalarType::Float || opmath_t == at::ScalarType::ComplexFloat) {
+      using limits = std::numeric_limits<float>;
+      float eps_val = eps.value_or(limits::epsilon());
+      rqrst_input = rsqrt(at::pow(upcasted_input, 2).mean(dims_to_reduce_ref, /*keepdim=*/true).add_(eps_val));
+    } else {
+      using limits = std::numeric_limits<double>;
+      double eps_val = eps.value_or(limits::epsilon());
+      rqrst_input = rsqrt(at::pow(upcasted_input, 2).mean(dims_to_reduce_ref, /*keepdim=*/true).add_(eps_val));
+    }
+
     Tensor result = upcasted_input.mul(rqrst_input).type_as(input);
 
     if (weight_opt.has_value()) {


### PR DESCRIPTION
Fixes #140092 

Here's what this PR does:

Case 1: no `eps`  is passed to python frontend:
Use `eps` associated with opmath_t instead of than `eps` associated with`scalar_t` for intermediate computation

Case 2: `eps` is passed to python frontend 
Avoid downcasting `eps` to `scalar_t` and then upcasting it again implicitly in the `rqrst_input` computation

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10