### PR TITLE
[inductor] optimize cpu isa check.

### DIFF
--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -68,7 +68,7 @@ extern "C" void __avx_chk_kernel() {
 """  # noqa: B950
 
     _avx_py_load = """
-import torch
+# import torch
 from ctypes import cdll
 cdll.LoadLibrary("__lib_path__")
 """


### PR DESCRIPTION
Fixes #140970

After discuss with @jgong5 about https://github.com/pytorch/pytorch/issues/140970#issuecomment-2533755182 , we found the dry-run code `import torch` is useless code. And it also slow down performance.

Before clean `import torch`, it spends 2.04s.
<img width="398" alt="image" src="https://github.com/user-attachments/assets/b8cf4d11-e9ee-4195-b4d4-233bb3b5de26">

Cleaned `import torch`, it only spends 0.87s.
<img width="527" alt="image" src="https://github.com/user-attachments/assets/9957fcb8-7541-42b0-9289-f806ad3a06a0">

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov