### PR TITLE
[EZ] Update sccache to 0.9.0

### DIFF
--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -9,7 +9,7 @@ install_ubuntu() {
   # Instead use lib and headers from OpenSSL1.1 installed in `install_openssl.sh``
   apt-get install -y cargo
   echo "Checking out sccache repo"
-  git clone https://github.com/mozilla/sccache -b v0.8.2
+  git clone https://github.com/mozilla/sccache -b v0.9.0
   cd sccache
   echo "Building sccache"
   cargo build --release


### PR DESCRIPTION
Now that we know, that 0.8.2 works, 0.9.0 update should be easy
