### PR TITLE
Don't install lintrunner on S390

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ filelock
 networkx
 jinja2
 fsspec
-lintrunner
+lintrunner ; platform_machine != "s390x"
 ninja
 packaging
 optree>=0.13.0


### PR DESCRIPTION
Not sure if there are many users of this platform, but hopefully this will fix https://github.com/pytorch/pytorch/issues/142872
