### PR TITLE
[PGNCCL] Make NCCLComm extendable

### DIFF
--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -169,7 +169,8 @@ std::shared_ptr<NCCLComm> createWithConfig(
 // last argument to split() API is not used to support
 // multiple implementations
 std::shared_ptr<NCCLComm> split(
-    std::shared_ptr<NCCLComm>& source,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::shared_ptr<NCCLComm> source,
     int color_id,
     int rank,
     ncclConfig_t& config,
@@ -232,7 +233,8 @@ std::shared_ptr<NCCLComm> split(
 #endif
 }
 
-void finalize(std::shared_ptr<NCCLComm>& comm) {
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+void finalize(std::shared_ptr<NCCLComm> comm) {
   LockType lock(comm->mutex_);
   if (comm->aborted_) {
     LOG(INFO) << "Rank " << comm->rank_
@@ -244,7 +246,8 @@ void finalize(std::shared_ptr<NCCLComm>& comm) {
   C10D_NCCL_CHECK_NONBLOCKING(ncclCommFinalize(ncomm), std::nullopt);
 }
 
-void destroy(std::shared_ptr<NCCLComm>& comm) {
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+void destroy(std::shared_ptr<NCCLComm> comm) {
   LockType lock(comm->mutex_);
   if (comm->aborted_) {
     LOG(INFO) << "Rank " << comm->rank_
@@ -259,7 +262,8 @@ void destroy(std::shared_ptr<NCCLComm>& comm) {
 }
 
 void abort(
-    std::shared_ptr<NCCLComm>& comm,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::shared_ptr<NCCLComm> comm,
     std::optional<std::string> commFailureReason) {
   LockType lock(comm->mutex_);
   at::cuda::OptionalCUDAGuard gpuGuard(comm->deviceIndex_);
@@ -310,7 +314,8 @@ void abort(
 #endif
 }
 
-void regMem(std::shared_ptr<NCCLComm>& comm, void* ptr, size_t size) {
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+void regMem(std::shared_ptr<NCCLComm> comm, void* ptr, size_t size) {
   LockType lock(comm->mutex_);
 #ifdef NCCL_HAS_COMM_REGISTER
   // We register only segments from cache allocator
@@ -342,7 +347,8 @@ void regMem(std::shared_ptr<NCCLComm>& comm, void* ptr, size_t size) {
 #endif
 }
 
-void deregMem(std::shared_ptr<NCCLComm>& comm, void* ptr) {
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+void deregMem(std::shared_ptr<NCCLComm> comm, void* ptr) {
   LockType lock(comm->mutex_);
 #ifdef NCCL_HAS_COMM_REGISTER
   TORCH_CHECK(
@@ -371,7 +377,8 @@ void deregMem(std::shared_ptr<NCCLComm>& comm, void* ptr) {
 }
 
 void dump(
-    std::shared_ptr<NCCLComm>& comm,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::shared_ptr<NCCLComm> comm,
     std::unordered_map<std::string, std::string>& dump) {
 #if defined(IS_NCCLX) && defined(NCCL_COMM_DUMP)
   if (comm->isAborted()) {

--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -295,20 +295,20 @@ typedef struct {
       at::DeviceIndex deviceIndex,
       ncclConfig_t& config);
   std::shared_ptr<NCCLComm> (*split)(
-      std::shared_ptr<NCCLComm>& source,
+      std::shared_ptr<NCCLComm> source,
       int color_id,
       int rank,
       ncclConfig_t& config,
       std::vector<uint64_t>& ranks_ull);
-  void (*finalize)(std::shared_ptr<NCCLComm>& comm);
-  void (*destroy)(std::shared_ptr<NCCLComm>& comm);
+  void (*finalize)(std::shared_ptr<NCCLComm> comm);
+  void (*destroy)(std::shared_ptr<NCCLComm> comm);
   void (*abort)(
-      std::shared_ptr<NCCLComm>& comm,
+      std::shared_ptr<NCCLComm> comm,
       std::optional<std::string> commFailureReason);
-  void (*regMem)(std::shared_ptr<NCCLComm>&, void* ptr, size_t size);
-  void (*deregMem)(std::shared_ptr<NCCLComm>&, void* mhandle);
+  void (*regMem)(std::shared_ptr<NCCLComm>, void* ptr, size_t size);
+  void (*deregMem)(std::shared_ptr<NCCLComm>, void* mhandle);
   void (*dump)(
-      std::shared_ptr<NCCLComm>&,
+      std::shared_ptr<NCCLComm>,
       std::unordered_map<std::string, std::string>& dump);
 } commImpl_t;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #142881
* #142826

This PR defines a set of APIs for interacting with `NCCLComm` (an existing abstraction of the real `ncclComm_t`).
This set of APIs include `create`, `split`, `destroy`, `dump`, etc, around the management of `NCCLComm`.
The previous implementation of the above methods under `NCCLComm` are now made the default impl of this API set.
And the impl of the API set is extendable out of trunk.

For example: for the implementation of dump
```
void dump(
    std::shared_ptr<NCCLComm>& comm,
    std::unordered_map<std::string, std::string>& dump) {
#if defined(IS_NCCLX) && defined(NCCL_COMM_DUMP)
  if (comm->isAborted()) {
    LOG(INFO) << "Communicator was aborted before trying to dump its state.";
    return;
  }
  C10D_NCCL_CHECK(::ncclCommDump(ncclComm_, dump), std::nullopt);
#else
  TORCH_CHECK(false, "NCCL version does not support dumping.");
#endif
}
```
One can now host the `#if defined(IS_NCCLX)` path out of trunk.

### TODO:
`ncclConfig_t` still shows up in API surface. We probably need a way to make it opaque.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o