### PR TITLE
[dynamo] Ability to inline fn with unused Callable arg

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -85,6 +85,7 @@ from torch.testing._internal.optests import (
 )
 from torch.testing._internal.subclasses import WrapperSubclass
 from torch.testing._internal.two_tensor import TwoTensor, TwoTensorMode
+from torch.utils._python_dispatch import return_and_correct_aliasing
 
 
 USE_TORCHVISION = False
@@ -6331,6 +6332,69 @@ metadata incorrectly.
         self.assertEqual(ref_out, out)
         out.sum().backward()
         self.assertEqual(ref_x.grad, x.grad)
+
+    def test_unwrap_subclass_parameters_with_unused_callable_arg_in_ctor(self):
+        def _test_callable(x):
+            return x
+
+        class SC(WrapperSubclass):
+            @staticmethod
+            def __new__(cls, a, fn, outer_size=None, outer_stride=None):
+                return WrapperSubclass.__new__(cls, a, outer_size, outer_stride)
+
+            def __init__(self, a, fn, outer_size=None, outer_stride=None):
+                self.a = a
+                self.fn = fn
+
+            def __tensor_flatten__(self):
+                return ["a"], [self.fn]
+
+            @staticmethod
+            def __tensor_unflatten__(inner_tensors, meta, outer_size, outer_stride):
+                a = inner_tensors["a"]
+                fn = meta[0]
+                return SC(a, fn, outer_size, outer_stride)
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args, kwargs):
+                if kwargs is None:
+                    kwargs = {}
+                args_a = pytree.tree_map_only(cls, lambda x: x.a, args)
+                kwargs_a = pytree.tree_map_only(cls, lambda x: x.a, kwargs)
+
+                out_a = func(*args_a, **kwargs_a)
+                out_a_flat, spec = pytree.tree_flatten(out_a)
+                out_flat = [
+                    cls(o_a, _test_callable) if isinstance(o_a, torch.Tensor) else o_a
+                    for o_a in out_a_flat
+                ]
+                out = pytree.tree_unflatten(out_flat, spec)
+                from torch._higher_order_ops.cond import cond_op
+
+                if func is cond_op:
+                    return out
+                else:
+                    return return_and_correct_aliasing(func, args, kwargs, out)
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.p1 = torch.nn.Parameter(torch.ones(3, 4))
+                self.p2 = torch.nn.Parameter(SC(torch.ones(3, 4), _test_callable))
+
+            def forward(self, x):
+                return x + 2 * self.p1 + self.p2
+
+        m = M()
+        from torch._functorch._aot_autograd.subclass_parametrization import (
+            unwrap_tensor_subclass_parameters,
+        )
+
+        unwrap_tensor_subclass_parameters(m)
+
+        x = torch.randn(3, 4)
+        comp_fn = torch.compile(m, backend="aot_eager", fullgraph=True)
+        out = comp_fn(x)
 
     def test_rrelu_with_noise_mutation(self):
         def fn_functional(x):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -6333,6 +6333,7 @@ metadata incorrectly.
         out.sum().backward()
         self.assertEqual(ref_x.grad, x.grad)
 
+    @torch._dynamo.config.patch({"capture_function_args": True})
     def test_unwrap_subclass_parameters_with_unused_callable_arg_in_ctor(self):
         from torch.testing._utils import _dummy_test_fn_with_module
 

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -6334,8 +6334,9 @@ metadata incorrectly.
         self.assertEqual(ref_x.grad, x.grad)
 
     def test_unwrap_subclass_parameters_with_unused_callable_arg_in_ctor(self):
-        def _test_callable(x):
-            return x
+        from torch.testing._utils import _dummy_test_fn_with_module
+
+        _test_fn = _dummy_test_fn_with_module
 
         class SC(WrapperSubclass):
             @staticmethod
@@ -6365,7 +6366,7 @@ metadata incorrectly.
                 out_a = func(*args_a, **kwargs_a)
                 out_a_flat, spec = pytree.tree_flatten(out_a)
                 out_flat = [
-                    cls(o_a, _test_callable) if isinstance(o_a, torch.Tensor) else o_a
+                    cls(o_a, _test_fn) if isinstance(o_a, torch.Tensor) else o_a
                     for o_a in out_a_flat
                 ]
                 out = pytree.tree_unflatten(out_flat, spec)
@@ -6380,7 +6381,7 @@ metadata incorrectly.
             def __init__(self):
                 super().__init__()
                 self.p1 = torch.nn.Parameter(torch.ones(3, 4))
-                self.p2 = torch.nn.Parameter(SC(torch.ones(3, 4), _test_callable))
+                self.p2 = torch.nn.Parameter(SC(torch.ones(3, 4), _test_fn))
 
             def forward(self, x):
                 return x + 2 * self.p1 + self.p2

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -538,6 +538,9 @@ automatic_dynamic_remote_pgo: Optional[bool] = get_tristate_env(
     "TORCH_DYNAMO_AUTOMATIC_DYNAMIC_REMOTE_PGO"
 )
 
+# Allow Dynamo to use user function as argument in the graph
+capture_function_args: bool = False
+
 # HACK: this is for testing custom ops profiling only
 _custom_ops_profile: Optional[Any] = None
 

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -171,6 +171,9 @@ class UserFunctionVariable(BaseUserFunctionVariable):
         # subclasses (such as methods) usually aren't a constant
         return super().as_python_constant()
 
+    def as_proxy(self):
+        return self.fn
+
     def self_args(self):
         return []
 

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -172,6 +172,9 @@ class UserFunctionVariable(BaseUserFunctionVariable):
         return super().as_python_constant()
 
     def as_proxy(self):
+        if not torch._dynamo.config.capture_function_args:
+            raise Unsupported("UserFunctionVariable.as_proxy() is not supported")
+
         if self.fn.__module__ in ("__main__"):
             raise Unsupported("Local function can not be put in the graph")
         return self.fn

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -172,6 +172,8 @@ class UserFunctionVariable(BaseUserFunctionVariable):
         return super().as_python_constant()
 
     def as_proxy(self):
+        if self.fn.__module__ in ("__main__"):
+            raise Unsupported("Local function can not be put in the graph")
         return self.fn
 
     def self_args(self):

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -549,6 +549,8 @@ class CodeGen:
                 return "[" + ", ".join(_get_repr(a) for a in arg) + "]"
             elif isinstance(arg, slice):
                 return f"slice({_get_repr(arg.start)}, {_get_repr(arg.stop)}, {_get_repr(arg.step)})"
+            elif callable(arg):
+                return f"{arg.__module__}.{arg.__name__}"
             else:
                 return blue(repr(arg))
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -549,7 +549,7 @@ class CodeGen:
                 return "[" + ", ".join(_get_repr(a) for a in arg) + "]"
             elif isinstance(arg, slice):
                 return f"slice({_get_repr(arg.start)}, {_get_repr(arg.stop)}, {_get_repr(arg.step)})"
-            elif callable(arg):
+            elif inspect.isfunction(arg):
                 return f"{arg.__module__}.{arg.__name__}"
             else:
                 return blue(repr(arg))

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -348,6 +348,9 @@ class TracerBase:
         elif isinstance(a, (*base_types, enum.Enum)) or a is None or a is ...:
             return a
 
+        elif callable(a):
+            return a
+
         raise NotImplementedError(f"argument of type: {type(a)}")
 
     @compatibility(is_backward_compatible=True)

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -348,7 +348,7 @@ class TracerBase:
         elif isinstance(a, (*base_types, enum.Enum)) or a is None or a is ...:
             return a
 
-        elif callable(a):
+        elif inspect.isfunction(a):
             return a
 
         raise NotImplementedError(f"argument of type: {type(a)}")

--- a/torch/testing/_utils.py
+++ b/torch/testing/_utils.py
@@ -50,3 +50,7 @@ def freeze_rng_state():
             if torch.cuda.is_available():
                 torch.cuda.set_rng_state(cuda_rng_state)  # type: ignore[possibly-undefined]
             torch.set_rng_state(rng_state)
+
+
+def _dummy_test_fn_with_module():
+    pass

--- a/torch/testing/_utils.py
+++ b/torch/testing/_utils.py
@@ -52,5 +52,6 @@ def freeze_rng_state():
             torch.set_rng_state(rng_state)
 
 
+# Used for tests as a function on module level
 def _dummy_test_fn_with_module():
     pass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143044

We want to be able to use `torch._functorch._aot_autograd.subclass_parametrization.unwrap_tensor_subclass_parameters` parametrization for TorchAO Quantization Subclasses. Usually they quantize every Linear in the model, which results in ~30us wrap/unwrap overhead per each quantized linear.

To use unwrap_tensor_subclass_parameters we need to be able to dynamo trace through Subclasses constructor.

TorchAO uses Callable (python functions in their case) in constructor arguments, which is not used in the constructor and only set as a property.

E.g. input_quant_func argument: https://github.com/pytorch/ao/blob/main/torchao/quantization/linear_activation_quantized_tensor.py#L55

This is not dynamo traceable so far. This diff makes it traceable, by adding:

1. as_proxy() to UserFunctionVariable that returns just function
2. Support for callable() case in fx/proxy and fx/graph to render it as `f"{fn.__module__}.{fn.__name__}"` to produce correct python syntax.

As a result the dynamo graph for test example is:
```
def forward(self, L_self_parameters_p1_: "f32[3, 4][4, 1]cpu", L_x_: "f32[3, 4][4, 1]cpu", L_self_modules_parametrizations_modules_p2_parameters_original0_: "f32[3, 4][4, 1]cpu"):
    l_self_parameters_p1_ = L_self_parameters_p1_
    l_x_ = L_x_
    l_self_modules_parametrizations_modules_p2_parameters_original0_ = L_self_modules_parametrizations_modules_p2_parameters_original0_
    mul: "f32[3, 4][4, 1]cpu" = 2 * l_self_parameters_p1_;  l_self_parameters_p1_ = None
    add: "f32[3, 4][4, 1]cpu" = l_x_ + mul;  l_x_ = mul = None
    rebuilt: "f32[3, 4][4, 1]cpu" = __main___SC(l_self_modules_parametrizations_modules_p2_parameters_original0_, __main__._test_callable, None, None);  l_self_modules_parametrizations_modules_p2_parameters_original0_ = None
    add_1: "f32[3, 4][4, 1]cpu" = add + rebuilt;  add = rebuilt = None
    return (add_1,)
```
dummy callable is `__main__._test_callable`

Testing:

```
python test/functorch/test_aotdispatch.py -k test_unwrap_subclass_parameters_with_unused_callable_arg_in_ctor
```





cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames