### PR TITLE
[Torch][#142396]Resolve Failure When Uploading To Remote Storage

### DIFF
--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -12,6 +12,7 @@ import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass
+from io import UnsupportedOperation
 from pathlib import Path
 from typing import (
     Any,
@@ -331,7 +332,7 @@ def _write_files_from_queue(
                 if use_fsync:
                     try:
                         os.fsync(stream.fileno())
-                    except AttributeError:
+                    except (AttributeError, UnsupportedOperation):
                         os.sync()
             result_queue.put(write_results)
     except queue.Empty:


### PR DESCRIPTION
Summary: Catch io.UnsupportedOperation exception so that stream's without fileno support don't cause failure

Test Plan: UT

Differential Revision: D67108487




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn