### PR TITLE
[CUDA] Bump tolerances in `test_svd_lowrank_cuda_float64`

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2506,7 +2506,7 @@ class TestLinalg(TestCase):
             # check if svd_lowrank produces same singular values as linalg.svdvals
             U, S, Vh = torch.linalg.svd(a, full_matrices=False)
             V = Vh.mH
-            self.assertEqual(s, S)
+            self.assertEqual(s, S, rtol=5e-7, aotl=1e-7)
 
             if density == 1:
                 # actual_rank is known only for dense inputs

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2506,7 +2506,7 @@ class TestLinalg(TestCase):
             # check if svd_lowrank produces same singular values as linalg.svdvals
             U, S, Vh = torch.linalg.svd(a, full_matrices=False)
             V = Vh.mH
-            self.assertEqual(s, S, rtol=5e-7, aotl=1e-7)
+            self.assertEqual(s, S, rtol=5e-7, atol=1e-7)
 
             if density == 1:
                 # actual_rank is known only for dense inputs


### PR DESCRIPTION
pre-emptive bump for apparent noisy failure

cc @ptrblck @msaroufim