### PR TITLE
[provenance_tracking] Dump inductor_triton_kernel_to_post_grad_nodes.json info in debug_trace

### DIFF
--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -1,0 +1,89 @@
+# Owner(s): ["module: inductor"]
+
+import json
+import logging
+import re
+import tempfile
+from pathlib import Path
+
+import torch
+from torch._inductor import config
+from torch._inductor.test_case import run_tests, TestCase
+from torch.testing._internal.triton_utils import requires_cuda
+
+
+try:
+    from .test_aot_inductor_utils import AOTIRunnerUtil
+except ImportError:
+    from test_aot_inductor_utils import AOTIRunnerUtil
+
+
+class Model(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, a, b, c):
+        x = a * 3.14
+        y = torch.addmm(c, x, b)
+        z = torch.nn.functional.gelu(y)
+        return z
+
+
+@requires_cuda
+@config.patch("trace.enabled", True)
+class TestProvenanceTracingArtifact(TestCase):
+    """
+    This test checks that generated provenance tracing artifact from "post_grad" to
+    corresponding "inductor triton kernel node" is expected.
+    """
+
+    def test_triton_kernel_post_grad_mapping_aot_inductor(self):
+        a = torch.randn(10, 20, device="cuda")
+        b = torch.randn(20, 30, device="cuda")
+        c = torch.randn(10, 30, device="cuda")
+        example_inputs = (a, b, c)
+
+        model = Model()
+        ep = torch.export._trace._export(model, example_inputs)
+        gm = ep.module()
+
+        # check that the generated provenance tracing artifact is expected
+        expected_data = {
+            "triton_poi_fused_mul_0": ["mul"],
+            "triton_poi_fused_addmm_gelu_1": [
+                "mul_3",
+                "erf",
+                "add_tensor",
+                "mul_1",
+                "add",
+                "mul_2",
+            ],
+        }
+
+        with config.patch(
+            {
+                "trace.debug_dir": tempfile.mkdtemp(),
+                "force_disable_caches": True,
+            }
+        ):
+            with self.assertLogs(
+                logging.getLogger("torch._inductor.debug"), level=logging.WARNING
+            ) as cm:
+                so_path = torch._inductor.aot_compile(gm, example_inputs)
+                optimized = AOTIRunnerUtil.load("cuda", so_path)
+                optimized(*example_inputs)
+
+        self.assertEqual(len(cm.output), 1)
+        m = re.match(r"WARNING.* debug trace: (.*)", cm.output[0])
+        self.assertTrue(m)
+        filename = Path(m.group(1))
+        self.assertTrue(filename.is_dir())
+        with open(filename / "inductor_triton_kernel_to_post_grad_nodes.json") as f:
+            actual_data = json.load(f)
+
+        # Compare the actual and expected data
+        self.assertEqual(sorted(actual_data), sorted(expected_data))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -56,6 +56,7 @@ from ..utils import (
     IndentedBuffer,
     Placeholder,
     prefix_is_reduction,
+    set_kernel_post_grad_provenance_tracing,
     sympy_index_symbol,
     sympy_product,
     sympy_subs,
@@ -1319,6 +1320,8 @@ class SIMDScheduling(BaseScheduling):
             with V.set_kernel_handler(kernel):
                 src_code = kernel.codegen_kernel()
             kernel_name = self.define_kernel(src_code, node_schedule, kernel)
+            if config.trace.enabled:
+                set_kernel_post_grad_provenance_tracing(node_schedule, kernel_name)
             log.debug("Generating kernel code with kernel_name: %s", kernel_name)
             kernel.kernel_name = kernel_name
             kernel.code_hash = code_hash(src_code)
@@ -1519,6 +1522,9 @@ class SIMDScheduling(BaseScheduling):
                 return src_code
 
             kernel_name = self.define_kernel(src_code, node_schedule, kernel)
+
+            if config.trace.enabled:
+                set_kernel_post_grad_provenance_tracing(node_schedule, kernel_name)
 
         self.codegen_comment(node_schedule)
         kernel.call_kernel(kernel_name, template_node.node)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1336,6 +1336,9 @@ class trace:
 
     log_autotuning_results: bool = False
 
+    # Save mapping info from inductor generated triton kernel to post_grad fx nodes
+    log_inductor_triton_kernel_to_post_grad_node_info: bool = True
+
 
 _save_config_ignore = [
     # workaround: "Can't pickle <function ...>"

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1920,6 +1920,9 @@ class GraphLowering(torch.fx.Interpreter):
                 V.graph.all_codegen_kernel_names,
             )
 
+            # Dump the inductor_triton_kernel_to_post_grad_node_info to a json file for debugging trace
+            V.debug.log_inductor_triton_kernel_to_post_grad_node_info()
+
             result = self.wrapper_code.generate(self.is_inference)
             self.wrapper_code.pop_codegened_graph()
             return result

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2413,3 +2413,15 @@ def get_donated_idxs() -> Optional[List[int]]:
     if tracing_context is not None and tracing_context.fw_metadata:
         return tracing_context.fw_metadata.bw_donated_idxs
     return None
+
+
+def set_kernel_post_grad_provenance_tracing(node_schedule, kernel_name):
+    from .codegen.simd_kernel_features import DisableReduction, EnableReduction
+    from .virtualized import V
+
+    for node in node_schedule:
+        if node not in (EnableReduction, DisableReduction):
+            if node.node is not None:
+                V.debug._inductor_triton_kernel_to_post_grad_node_info[kernel_name] = [
+                    origin.name for origin in node.node.origins
+                ]


### PR DESCRIPTION
Summary:
This diff mainly adds code changes to dump `inductor_triton_kernel_to_post_grad_nodes.json` artifact which contains mapping info from post_grad -> inductor kernel code:
`{"inductor_triton_kernel_name": [post_grad_node_0, post_grad_node_1, ..., ], "..."}.`

Example paste: P1695235000 verified on the test model.  See "Test Plan":

We use this artifact to demonstrate provenance tracking in the frontend 3-tab highlighter tool:
https://github.com/YUNQIUGUO/compiler_explorer (copy/pasted the input files for demo purpose for now and will integrate with Shangdi's tool to 4-tab)

https://pxl.cl/66BzK

Note: Currently only supports mapping for inductor's`TritonKernel` type. TODO for enhancing more support for `ExternKernel` and other inductor generated kernel type, etc.

Test Plan:
test_model_coverage.sh:
```
#!/bin/sh
MODEL_ENTITY_ID=644688112
SNAPSHOT_ID=32
MODULE=merge

# buck2 build --show-output mode/opt -c=python.package_style=inplace -c fbcode.enable_gpu_sections=true -c fbcode.platform=platform010 -c fbcode.split-dwarf=true -c fbcode.nvcc_arch=a100,h100 caffe2/torch/fb/model_transform/experimental/benchmark:mts_gpu_benchmark

TORCH_COMPILE_DEBUG=1 CUDA_VISIBLE_DEVICES=0 TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 TORCH_LOGS="+inductor, schedule, fusion, output_code" TORCH_TRACE="tmp/guorachel_tt" TORCHINDUCTOR_MAX_AUTOTUNE=1 TORCHINDUCTOR_UNIQUE_KERNEL_NAMES=1 ../buck-out/v2/gen/fbcode/d29ee94b913014f1/caffe2/torch/fb/model_transform/experimental/benchmark/__mts_gpu_benchmark__/mts_gpu_benchmark.par --model-path manifold://ads_storage_fblearner/tree/user/facebook/fblearner/predictor/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/gpu_lowering/input.predictor.disagg.gpu.merge --lower-backend AOT_INDUCTOR_EP --gpu-trace --aot-inductor-config="{'max_autotune': True}" 2>&1 | tee output.txt
```
 {F1973765026}


```
buck2 test 'fbcode//mode/opt' fbcode//caffe2/test/inductor:provenance_tracing -- --exact 'caffe2/test/inductor:provenance_tracing - test_triton_kernel_post_grad_mapping_aot_inductor (caffe2.test.inductor.test_provenance_tracing.TestProvenanceTracingArtifact)'
```

```
TORCH_LOGS="+inductor, output_code" buck2 run -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=h100 @//mode/opt fbcode//caffe2/test/inductor:provenance_tracing -- -r test_triton_kernel_post_grad_mapping_aot_inductor
```

Differential Revision: D66967510




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov