### PR TITLE
Fix NJT backward tests

### DIFF
--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4151,8 +4151,8 @@ class TestVmapOperatorsOpInfo(TestCase):
                 )
             aliases, inplace_aliases = discover_variants(op)
             check_shape_only = op.name in ("empty_like", "new_empty")
-            for sample_input, subtest_ctx in sample_inputs_itr:
-                with subtest_ctx(self):
+            for sample_input, subtest_ctx, skip_xfail_ctx in sample_inputs_itr:
+                with subtest_ctx(self), skip_xfail_ctx(self):
                     args = (sample_input.input,) + sample_input.args
                     if not any(isinstance(arg, torch.Tensor) for arg in args):
                         # Atleast one tensor required for vmap.

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -68,6 +68,7 @@ from torch.testing._internal.opinfo.core import (
     BinaryUfuncInfo,
     ReductionOpInfo,
     sample_skips_and_xfails,
+    SkipRule,
     XFailRule,
 )
 from torch.testing._internal.opinfo.definitions.nested import njt_op_db
@@ -8149,7 +8150,187 @@ FORWARD_SKIPS_AND_XFAILS = [
 ]
 
 BACKWARD_SKIPS_AND_XFAILS = [
+    # segfaults, so skip. It's trying to use the NST logic for NJT
+    SkipRule(
+        op_match_fn=lambda device, op: op.full_name == "split_with_sizes",
+        name="split_with_sizes_backward_segfault",
+    ),
     *FORWARD_SKIPS_AND_XFAILS,
+    # Backwards is generally broken for non-contiguous NJTs with holes. Rather than
+    # determine the exceptions in detail, just skip for now. Fix is to ensure
+    # that summing over gradients during backwards after broadcasting takes into
+    # account holes / lengths.
+    SkipRule(
+        op_match_fn=lambda device, op: (
+            isinstance(op, BinaryUfuncInfo)
+            or op.full_name in {"mean", "where", "unsqueeze"}
+        ),
+        sample_match_fn=lambda device, sample: ("noncontig_holes" in sample.name),
+        name="broken_noncontig_holes_backward",
+    ),
+    # mean(): need to examine backwards formula
+    XFailRule(
+        error_type=RuntimeError,
+        error_msg="SymIntArrayRef expected to contain only concrete integers",
+        op_match_fn=lambda device, op: (op.full_name in {"mean"}),
+        sample_match_fn=lambda device, sample: (
+            "full reduction" not in sample.name
+            and "normal dim reduction" not in sample.name
+        ),
+        name="broken_mean_backward",
+    ),
+    # RuntimeError: expand(): cannot expand shape (3, 3, 1, j44) -> [3, 3, 7, j44]
+    # with noncontig transposed inputs to mean()
+    XFailRule(
+        error_type=RuntimeError,
+        error_msg="cannot expand shape",
+        op_match_fn=lambda device, op: (op.full_name == "mean"),
+        sample_match_fn=lambda device, sample: (
+            "normal dim reduction" in sample.name
+            and "noncontig_transposed" in sample.name
+        ),
+        name="broken_mean_backward2",
+    ),
+    # unsqueeze() backward tries to call squeeze with noncontig transposed,
+    # but that's not supported
+    XFailRule(
+        error_type=ValueError,
+        error_msg="expected self to be a contiguous jagged layout NestedTensor",
+        op_match_fn=lambda device, op: (op.full_name == "unsqueeze"),
+        sample_match_fn=lambda device, sample: (
+            "noncontig_transposed" in sample.name or "ragged_dim" in sample.name
+        ),
+        name="broken_unsqueeze_backward",
+    ),
+    # RuntimeError: view(): cannot view shape (3, j62, 1, 7, 3) as [3, j58, 7, 3]
+    # with unflatten()
+    XFailRule(
+        error_type=RuntimeError,
+        error_msg="cannot view shape",
+        op_match_fn=lambda device, op: (op.full_name in {"unflatten"}),
+        sample_match_fn=lambda device, sample: ("noncontig_holes" in sample.name),
+        name="broken_unflatten_backward",
+    ),
+    # -> CPU device conversion backwards is broken
+    XFailRule(
+        error_type=RuntimeError,
+        error_msg="Unknown layout in record_stream_any_impl",
+        op_match_fn=lambda device, op: (op.full_name == "to"),
+        sample_match_fn=lambda device, sample: (
+            sample.kwargs.get("device", None) == "cpu"
+        ),
+        name="broken_to_backward",
+    ),
+    # sum() backward is not implemented for non-full reductions
+    XFailRule(
+        error_type=NotImplementedError,
+        error_msg="aten._nested_sum_backward.default",
+        op_match_fn=lambda device, op: (op.full_name == "sum"),
+        sample_match_fn=lambda device, sample: ("full reduction" not in sample.name),
+        name="broken_sum_backward",
+    ),
+    # squeeze(): invalid gradient shape; need to check formula
+    XFailRule(
+        error_type=RuntimeError,
+        error_msg="returned an invalid gradient at index 0",
+        op_match_fn=lambda device, op: (op.full_name == "squeeze"),
+        sample_match_fn=lambda device, sample: (
+            sample.name == "5D_contig_with_seqlen_cache: normal_dim"
+            and sample.kwargs["dim"] == 3
+        ),
+        name="broken_squeeze_backward",
+    ),
+    # sgn() / masked_select(): backwards formulas don't work at all
+    XFailRule(
+        error_type=RuntimeError,
+        error_msg="NestedTensor does not support directly calling torch.ops.aten.size",
+        op_match_fn=lambda device, op: (op.full_name in {"sgn", "masked_select"}),
+        name="broken_sgn_masked_select_backward",
+    ),
+    # select(): grad_output is an NJT for non-batch-dim operation
+    XFailRule(
+        error_type=ValueError,
+        error_msg="expected grad_output to be a tensor",
+        op_match_fn=lambda device, op: (op.full_name == "select"),
+        sample_match_fn=lambda device, sample: ("batch_dim" not in sample.name),
+        name="broken_select_backward",
+    ),
+    # prod(): completely broken in every way
+    XFailRule(
+        op_match_fn=lambda device, op: (op.full_name == "prod"),
+        name="broken_prod_backward",
+    ),
+    # pow() / float_power(): use where() underneath; broken for (NT, T) broadcasting cases
+    XFailRule(
+        error_type=ValueError,
+        error_msg="expected condition to be a jagged layout NestedTensor",
+        op_match_fn=lambda device, op: (op.full_name in {"pow", "float_power"}),
+        sample_match_fn=lambda device, sample: ("(NT, T)" in sample.name),
+        name="broken_pow_backward",
+    ),
+    # __rpow__() backward is also broken, but for the reverse (T, NT) broadcasting cases
+    XFailRule(
+        error_type=ValueError,
+        error_msg="expected condition to be a jagged layout NestedTensor",
+        op_match_fn=lambda device, op: (op.full_name == "__rpow__"),
+        sample_match_fn=lambda device, sample: ("(T, NT)" in sample.name),
+        name="broken_rpow_backward",
+    ),
+    # linear(): some formula problem when bias is used
+    XFailRule(
+        error_type=RuntimeError,
+        # result2.use_count() <= 1 INTERNAL ASSERT FAILED
+        error_msg="INTERNAL ASSERT FAILED",
+        op_match_fn=lambda device, op: (op.full_name == "nn.functional.linear"),
+        sample_match_fn=lambda device, sample: ("with bias" in sample.name),
+        name="broken_linear_backward",
+    ),
+    # narrow(): unimplemented backward
+    XFailRule(
+        error_type=RuntimeError,
+        error_msg="derivative for aten::narrow is not implemented",
+        op_match_fn=lambda device, op: (op.full_name == "narrow"),
+        name="broken_narrow_backward",
+    ),
+    # min / max: need to examine backwards formula for non-full reduction
+    XFailRule(
+        error_type=RuntimeError,
+        error_msg="SymIntArrayRef expected to contain only concrete integers",
+        op_match_fn=lambda device, op: (
+            op.full_name in {"max.reduction_with_dim", "min.reduction_with_dim"}
+        ),
+        sample_match_fn=lambda device, sample: ("full reduction" not in sample.name),
+        name="broken_min_max_reduction_with_dim_backward",
+    ),
+    # matmul(): unimplemented backward
+    XFailRule(
+        error_type=NotImplementedError,
+        error_msg="aten.matmul_backward.default",
+        op_match_fn=lambda device, op: (op.full_name == "matmul"),
+        name="broken_matmul_backward",
+    ),
+    # copysign(): formula is broken for (T, NT) broadcasting
+    XFailRule(
+        error_type=RuntimeError,
+        error_msg="SymIntArrayRef expected to contain only concrete integers",
+        op_match_fn=lambda device, op: (op.full_name == "copysign"),
+        sample_match_fn=lambda device, sample: ("(T, NT)" in sample.name),
+        name="broken_copysign_backward",
+    ),
+    # chunk(): backward doesn't work for the batch dim yet
+    XFailRule(
+        error_type=RuntimeError,
+        error_msg="Nested Tensor doesn't support chunk backward on dim=0 yet",
+        op_match_fn=lambda device, op: (op.full_name == "chunk"),
+        sample_match_fn=lambda device, sample: ("batch_dim" in sample.name),
+        name="broken_chunk_backward",
+    ),
+    # amin() / amax(): broken in a host of ways I don't think it's a good use of time
+    # to try to sift through
+    SkipRule(
+        op_match_fn=lambda device, op: (op.full_name in {"amin", "amax"}),
+        name="broken_amin_amax_backward",
+    ),
     XFailRule(
         error_type=RuntimeError,
         error_msg="reducing across the ragged dimension is not supported for non-contiguous",
@@ -8180,16 +8361,7 @@ BACKWARD_SKIPS_AND_XFAILS = [
             "for outputs with complex dtype"
         ),
         op_match_fn=lambda device, op: (op.full_name in {"cdouble", "cfloat", "chalf"}),
-        sample_match_fn=lambda device, sample: ("with_seqlen_cache" in sample.name),
         name="no_complex_autodiff",
-    ),
-    # bad derivative formula or something
-    XFailRule(
-        error_type=RuntimeError,
-        error_msg="NestedTensor does not support directly calling torch.ops.aten.size",
-        op_match_fn=lambda device, op: (op.full_name in {"sgn", "masked_select"}),
-        sample_match_fn=lambda device, sample: ("with_seqlen_cache" in sample.name),
-        name="direct_size_call_with_seqlen_cache",
     ),
     # Bug: need to use the correct nested int in the return shape
     XFailRule(
@@ -8206,12 +8378,8 @@ BACKWARD_SKIPS_AND_XFAILS = [
         error_type=NotImplementedError,
         error_msg="aten.masked_fill_.Scalar",
         op_match_fn=lambda device, op: (
-            op.full_name in {"max.binary", "min.binary", "minimum", "maximum"}
-        ),
-        sample_match_fn=lambda device, sample: (
-            "(NT, T) broadcasting all 1s" in sample.name
-            or "(NT, T) broadcasting 1 over ragged" in sample.name
-            or "(NT, T) mixed broadcasting" in sample.name
+            op.full_name
+            in {"max.binary", "min.binary", "minimum", "maximum", "copysign"}
         ),
         name="unimplemented_masked_fill",
     ),
@@ -8271,12 +8439,61 @@ COMPILE_FORWARD_SKIPS_AND_XFAILS = [
 ]
 
 COMPILE_BACKWARD_SKIPS_AND_XFAILS = [
+    # non-contiguous with holes inputs + torch.compile doesn't work great today; need
+    # torch._check() statements. Skip these and handle them later.
+    SkipRule(
+        op_match_fn=lambda device, op: True,
+        sample_match_fn=lambda device, sample: ("noncontig_holes" in sample.name),
+        name="noncontig_holes_data_dependency",
+    ),
+    # chunk(): broken in several ways on the batch dim; revisit after similar
+    # data-dependency issues are handled for narrow()
+    SkipRule(
+        op_match_fn=lambda device, op: (op.full_name == "chunk"),
+        sample_match_fn=lambda device, sample: ("batch_dim" in sample.name),
+        name="broken_chunk_compile_backward_on_batch_dim",
+    ),
+    # mean(): weird bug
+    XFailRule(
+        error_type=torch._dynamo.exc.BackendCompilerFailed,
+        error_msg="'NestedIntNode' object has no attribute 'sub'",
+        op_match_fn=lambda device, op: (op.full_name == "mean"),
+        sample_match_fn=lambda device, sample: (
+            "full reduction" not in sample.name
+            and "normal dim reduction" not in sample.name
+        ),
+        name="broken_mean_compile_backward",
+    ),
+    # min() / max(): weird bug
+    XFailRule(
+        error_type=AttributeError,
+        error_msg="'ConstantIntNode' object has no attribute 'add'",
+        op_match_fn=lambda device, op: (
+            op.full_name in {"max.reduction_with_dim", "min.reduction_with_dim"}
+        ),
+        sample_match_fn=lambda device, sample: ("full reduction" not in sample.name),
+        name="broken_min_max_compile_backward",
+    ),
+    # to() fails with data-dependent guards OR Unknown layout in record_stream_any_impl;
+    # need to fix with torch._check(), etc.
+    XFailRule(
+        op_match_fn=lambda device, op: (op.full_name == "to"),
+        sample_match_fn=lambda device, sample: ("-> cpu" in sample.name),
+        name="to_data_dependency",
+    ),
+    # copysign(): formula is broken for (T, NT) broadcasting
+    XFailRule(
+        error_type=AttributeError,
+        error_msg="'ConstantIntNode' object has no attribute 'add'",
+        op_match_fn=lambda device, op: (op.full_name == "copysign"),
+        sample_match_fn=lambda device, sample: ("(T, NT)" in sample.name),
+        name="broken_copysign_compile_backward",
+    ),
     # in compile, these complex ops use view_as_real(), which isn't implemented
     XFailRule(
         error_type=NotImplementedError,
         error_msg="aten.view_as_real.default",
         op_match_fn=lambda device, op: (op.full_name in {"cdouble", "cfloat", "chalf"}),
-        sample_match_fn=lambda device, sample: ("with_seqlen_cache" in sample.name),
         name="unimplemented_view_as_real",
     ),
     # torch._subclasses.fake_tensor.DataDependentOutputException: aten._local_scalar_dense.default
@@ -8334,6 +8551,14 @@ COMPILE_BACKWARD_SKIPS_AND_XFAILS = [
         ),
         name="clone_unbind_data_dependency_backward",
     ),
+    # select(): pending unbacked symints not in returned output (needs fix)
+    XFailRule(
+        error_type=torch._dynamo.exc.InternalTorchDynamoError,
+        error_msg="Pending unbacked symbols",
+        op_match_fn=lambda device, op: (op.full_name == "select"),
+        sample_match_fn=lambda device, sample: ("batch_dim" in sample.name),
+        name="broken_select_backward_unbacked",
+    ),
     *COMPILE_FORWARD_SKIPS_AND_XFAILS,
     *BACKWARD_SKIPS_AND_XFAILS,
 ]
@@ -8351,9 +8576,13 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
     # TODO: move this
     def _gen_grad_outputs(self, out_val):
         if isinstance(out_val, (list, tuple)):
-            return tuple(torch.ones_like(c) for c in out_val)
+            need_grad_outs = tuple(o for o in out_val if o.grad_fn is not None)
+            grad_outputs = tuple(
+                torch.ones_like(o) for o in out_val if o.grad_fn is not None
+            )
+            return need_grad_outs, grad_outputs
         else:
-            return (torch.ones_like(out_val),)
+            return out_val, (torch.ones_like(out_val),)
 
     @ops(
         [op for op in njt_op_db if op.supports_njt],
@@ -8361,13 +8590,13 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
     )
     @sample_skips_and_xfails(FORWARD_SKIPS_AND_XFAILS)
     def test_forward(self, device, dtype, op):
-        for sample, subtest_ctx in op.sample_inputs(
+        for sample, subtest_ctx, skip_xfail_ctx in op.sample_inputs(
             device=device,
             dtype=dtype,
             requires_grad=False,
             use_subtests=True,
         ):
-            with subtest_ctx(self):
+            with subtest_ctx(self), skip_xfail_ctx(self):
                 # compare to reference, but expect different nested int
                 out = op.op(sample.input, *sample.args, **sample.kwargs)
                 out_ref = op.ref(op, sample)
@@ -8389,10 +8618,10 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
     )
     @sample_skips_and_xfails(BACKWARD_SKIPS_AND_XFAILS)
     def test_backward(self, device, dtype, op):
-        for sample, subtest_ctx in op.sample_inputs(
+        for sample, subtest_ctx, skip_xfail_ctx in op.sample_inputs(
             device=device, dtype=dtype, requires_grad=True, use_subtests=True
         ):
-            with subtest_ctx(self):
+            with subtest_ctx(self), skip_xfail_ctx(self):
                 # compare to reference, but expect different nested int
                 out = op.op(sample.input, *sample.args, **sample.kwargs)
                 out_ref = op.ref(op, sample)
@@ -8409,14 +8638,14 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
                     if isinstance(inp, torch.Tensor) and inp.requires_grad
                 ]
                 if len(g_inps) > 0:
+                    need_grad_outs, grad_outputs = self._gen_grad_outputs(out)
                     grads = torch.autograd.grad(
-                        out, inputs=g_inps, grad_outputs=self._gen_grad_outputs(out)
+                        need_grad_outs, inputs=g_inps, grad_outputs=grad_outputs
                     )
 
+                    need_grad_outs, grad_outputs = self._gen_grad_outputs(out_ref)
                     grads_ref = torch.autograd.grad(
-                        out_ref,
-                        inputs=g_inps,
-                        grad_outputs=self._gen_grad_outputs(out_ref),
+                        need_grad_outs, inputs=g_inps, grad_outputs=grad_outputs
                     )
 
                     self.assertEqualNoncontigAware(grads, grads_ref)
@@ -8428,10 +8657,10 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
     )
     @sample_skips_and_xfails(COMPILE_FORWARD_SKIPS_AND_XFAILS)
     def test_compile_forward(self, device, dtype, op):
-        for sample, subtest_ctx in op.sample_inputs(
+        for sample, subtest_ctx, skip_xfail_ctx in op.sample_inputs(
             device=device, dtype=dtype, requires_grad=False, use_subtests=True
         ):
-            with subtest_ctx(self):
+            with subtest_ctx(self), skip_xfail_ctx(self):
                 torch.compiler.reset()
 
                 op_fn = op.op
@@ -8480,11 +8709,14 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
     @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
     @sample_skips_and_xfails(COMPILE_BACKWARD_SKIPS_AND_XFAILS)
     def test_compile_backward(self, device, dtype, op):
-        for sample, subtest_ctx in op.sample_inputs(
+        for sample, subtest_ctx, skip_xfail_ctx in op.sample_inputs(
             device=device, dtype=dtype, requires_grad=True, use_subtests=True
         ):
-            with subtest_ctx(self):
+            with subtest_ctx(self), skip_xfail_ctx(self):
                 torch.compiler.reset()
+                # must be set to avoid:
+                # DataDependentOutputException: aten._local_scalar_dense.default
+                torch._dynamo.config.capture_scalar_outputs = True
 
                 op_fn = op.op
 
@@ -8514,16 +8746,18 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
                     if isinstance(inp, torch.Tensor) and inp.requires_grad
                 ]
                 if len(g_inps) > 0:
+                    need_grad_outs, grad_outputs = self._gen_grad_outputs(out_compile)
                     grads_compile = torch.autograd.grad(
-                        out_compile,
+                        need_grad_outs,
                         inputs=g_inps,
-                        grad_outputs=self._gen_grad_outputs(out_compile),
+                        grad_outputs=grad_outputs,
                     )
 
+                    need_grad_outs, grad_outputs = self._gen_grad_outputs(out_ref)
                     grads_ref = torch.autograd.grad(
-                        out_ref,
+                        need_grad_outs,
                         inputs=g_inps,
-                        grad_outputs=self._gen_grad_outputs(out_ref),
+                        grad_outputs=grad_outputs,
                     )
 
                     self.assertEqualNoncontigAware(grads_compile, grads_ref)

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -8276,11 +8276,10 @@ BACKWARD_SKIPS_AND_XFAILS = [
         sample_match_fn=lambda device, sample: ("(T, NT)" in sample.name),
         name="broken_rpow_backward",
     ),
-    # linear(): some formula problem when bias is used
-    XFailRule(
-        error_type=RuntimeError,
+    # linear(): some formula problem when bias is used; seems to be platform-specific
+    # (fails locally but not in CI)
+    SkipRule(
         # result2.use_count() <= 1 INTERNAL ASSERT FAILED
-        error_msg="INTERNAL ASSERT FAILED",
         op_match_fn=lambda device, op: (op.full_name == "nn.functional.linear"),
         sample_match_fn=lambda device, sample: ("with bias" in sample.name),
         name="broken_linear_backward",

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -43,11 +43,7 @@ from torchgen.utils import dataclass_repr
 
 
 # setup logging
-# log = logging.getLogger(__name__)
-
-logging.basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 # Reasonable testing sizes for dimensions
 L = 20

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -43,7 +43,11 @@ from torchgen.utils import dataclass_repr
 
 
 # setup logging
+# log = logging.getLogger(__name__)
+
+logging.basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
 
 # Reasonable testing sizes for dimensions
 L = 20
@@ -1206,14 +1210,16 @@ class OpInfo:
         Returns None if the operator has no inplace operator variant"""
         return self.inplace_operator_variant
 
-    # Returns a callable from TestCase -> subtest context manager xfailing / skipping only
-    # for expected errors.
+    # Returns a tuple of callables:
+    # (TestCase -> subtest context, TestCase -> skip / xfail context)
+    # I'd love to combine these into one but I haven't figured out how to do it
+    # in a way that works like it should, and I tried a LOT of things.
     def _maybe_skip_or_xfail(self, rules, device, sample, idx):
         def _subtest_fn(test_case, sample=sample, idx=idx):
             return test_case.subTest(sample=sample, idx=idx)
 
         if rules is None or len(rules) == 0:
-            return _subtest_fn
+            return (_subtest_fn, lambda _: contextlib.nullcontext())
 
         # NB: match first rule only (order matters!)
         for rule in rules:
@@ -1229,15 +1235,13 @@ class OpInfo:
 
                 # Provide a context for the test case to run the sample input
                 # through as a subtest AND handle skip / xfail for it as needed.
-                return lambda test_case: SubtestRuleCtx(
-                    sample=sample,
-                    idx=idx,
-                    rule=rule,
-                    test_case=test_case,
+                return (
+                    _subtest_fn,
+                    lambda test_case, rule=rule: rule.get_context(test_case),
                 )
 
         log.debug("matched no rules: %s %s %s", self.full_name, device, sample)
-        return _subtest_fn
+        return (_subtest_fn, lambda _: contextlib.nullcontext())
 
     def _sample_callback_fn(self, use_subtests, device):
         # Get sample-specific skips / xfails.
@@ -1249,12 +1253,12 @@ class OpInfo:
             raise RuntimeError(
                 """Sample-specific skips / xfails require use_subtests=True.
 Please pass this to the sample generation function and run the test logic within the
-returned subtest context. For example:
+returned contexts (NB: order matters!). For example:
 
 def test_foo(self, device, dtype, op):
-    for sample, subtest_ctx in op.sample_inputs(..., use_subtests=True):
-        # the subtest context handles skips / xfails
-        with subtest_ctx(self):
+    for sample, subtest_ctx, skip_xfail_ctx in op.sample_inputs(..., use_subtests=True):
+        # these contexts handle running within subtests and skips / xfails
+        with subtest_ctx(self), skip_xfail_ctx(self):
             # test logic here
             ..."""
             )
@@ -1275,7 +1279,9 @@ def test_foo(self, device, dtype, op):
             # for xfails / skips to work properly.
             return (
                 sample,
-                self._maybe_skip_or_xfail(sample_skips_and_xfails, device, sample, idx),
+                *self._maybe_skip_or_xfail(
+                    sample_skips_and_xfails, device, sample, idx
+                ),
             )
 
         return _f
@@ -1641,59 +1647,6 @@ class sample_skips_and_xfails:
 
         fn.sample_skips_and_xfails = self.rules
         return fn
-
-
-# A combined subTest() + rule-specific context manager. In practice, this is used to treat each
-# sample input as a subtest AND properly skip / xfail it as necessary. I found it difficult to
-# combine these in a less verbose way, mainly due to the skip context not behaving as a proper
-# context manager. If there's a better way to do this, please fix it!
-class SubtestRuleCtx:
-    def __init__(self, sample, idx, rule, test_case):
-        self.sample = sample
-        self.idx = idx
-        self.rule = rule
-        self.test_case = test_case
-
-    def __enter__(self):
-        # Enter subTest() context to ensure sample is run through as a subtest
-        self.subtest_ctx = self.test_case.subTest(sample=self.sample, idx=self.idx)
-        self.subtest_ctx.__enter__()
-
-        # Enter rule-specific context (either skip / xfail)
-        self.rule_ctx = None
-        try:
-            self.rule_ctx = self.rule.get_context(self.test_case)
-            self.rule_ctx.__enter__()
-        except unittest.SkipTest as e:
-            # exit the subtest context, indicating skipped
-            self.rule_ctx = None
-            self.subtest_ctx.__exit__(type(e), e, e.__traceback__)
-            self.subtest_ctx = None
-
-        return self
-
-    def __exit__(self, exc_type, exc, exc_tb):
-        # NB: exit should be performed in opposite order as enter - rule then subtest
-        if self.rule_ctx is not None:
-            try:
-                if self.rule_ctx.__exit__(exc_type, exc, exc_tb):
-                    # indicate subtest success (i.e. the expected error was seen for an xfail)
-                    self.subtest_ctx.__exit__(None, None, None)
-                    return True
-            except AssertionError as e:
-                # This is thrown if an expected error is not raised.
-                # Hack in the rule name to help out with debugging.
-                if len(e.args) >= 1:
-                    e.args = (
-                        f"{e.args[0]}\nAssociated {self.rule.type} rule: {self.rule.name}",
-                        *e.args[1:],
-                    )
-                # indicate subtest failure (i.e. the expected error was -not- seen for an xfail)
-                return self.subtest_ctx.__exit__(type(e), e, None)
-
-        if self.subtest_ctx is not None:
-            return self.subtest_ctx.__exit__(exc_type, exc, exc_tb)
-        return True
 
 
 def _generate_reduction_inputs(device, dtype, requires_grad, **kwargs):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #142063
* #142062
* __->__ #143072

This PR fixes some issues with NJT backward / compile backward tests:
1. `requires_grad` was not being propagated appropriately during `SampleInput` generation, so a LOT of backward cases were untested before (sad times). This PR utilizes a helper function `_clone()` to clone() / detach() NJTs for SampleInputs while preserving `requires_grad` status. Note: the clone() / detach() stuff is for autograd; can't have two SampleInputs as part of the same autograd graph.
2. Per-sample skips weren't -fully- working; the op logic would still be invoked even with a skip. I found this out thanks to `split_with_sizes`, which segfaults during backwards because it tries to use an NST-specific formula. As annoying as it is, I tried a ton of things but ultimately had to split the `subtest_ctx` into that + a `skip_xfail_ctx` to run the subtests within.
    * Updated all uses of per-sample skips / xfails: 4 in `test_nestedtensor.py` and 1 in `test_vmap.py`
3. Added the appropriate skips / xfails to get everything passing. There are a shitton of bugs to fix!