### PR TITLE
Clang-format aten/src/ATen/native/Tensor*{cpp,h}

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -73,6 +73,8 @@ include_patterns = [
     'aten/src/ATen/native/cudnn/*.cpp',
     'aten/src/ATen/native/mkldnn/xpu/**/*.h',
     'aten/src/ATen/native/mkldnn/xpu/**/*.cpp',
+    'aten/src/ATen/native/Tensor*.h',
+    'aten/src/ATen/native/Tensor*.cpp',
     'c10/**/*.h',
     'c10/**/*.cpp',
     'torch/csrc/**/*.h',

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -5,8 +5,8 @@
 //  index(Tensor self, indices) -> Tensor
 //  index_put_(Tensor self, indices, value, accumulate=false)
 //
-// The index is a TensorList containing kLong, kBool or kByte tensors or nulls. Byte
-// tensors (boolean masks) are expanded to long tensors via nonzero(). Null
+// The index is a TensorList containing kLong, kBool or kByte tensors or nulls.
+// Byte tensors (boolean masks) are expanded to long tensors via nonzero(). Null
 // tensors signify that the dimension is not indexed.
 //
 // All indexes are broadcast together and iterated as *one*. From NumPy:
@@ -50,31 +50,30 @@
 // #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/ATen.h>
 
-#include <ATen/native/TensorAdvancedIndexing.h>
 #include <ATen/native/IndexKernel.h>
 #include <ATen/native/IndexingUtils.h>
+#include <ATen/native/TensorAdvancedIndexing.h>
 
-#include <ATen/core/Tensor.h>
-#include <ATen/core/IListRef.h>
 #include <ATen/Context.h>
 #include <ATen/Dispatch.h>
 #include <ATen/ExpandUtils.h>
 #include <ATen/MemoryOverlap.h>
 #include <ATen/NamedTensorUtils.h>
+#include <ATen/NumericUtils.h>
 #include <ATen/Parallel.h>
 #include <ATen/TensorIterator.h>
 #include <ATen/TensorMeta.h>
 #include <ATen/TensorOperators.h>
+#include <ATen/TensorSubclassLikeUtils.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/WrapDimUtils.h>
+#include <ATen/core/IListRef.h>
+#include <ATen/core/Tensor.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/Copy.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/ScatterGatherChecks.h>
 #include <ATen/native/TensorAdvancedIndexingUtils.h>
-#include <ATen/Parallel.h>
-#include <ATen/NumericUtils.h>
-#include <ATen/TensorSubclassLikeUtils.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -138,8 +137,8 @@
 #include <fbgemm/Utils.h>
 #endif
 
-#include <c10/util/irange.h>
 #include <c10/util/Unroll.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 #include <numeric>
@@ -156,15 +155,16 @@ AdvancedIndex make_info(Tensor self, IOptTensorListRef orig);
 namespace at::meta {
 
 TORCH_META_FUNC(gather)
-(const Tensor & self, int64_t dim, const Tensor & index, bool sparse_grad) {
+(const Tensor& self, int64_t dim, const Tensor& index, bool sparse_grad) {
   const Tensor& result = maybe_get_output(0);
   int64_t wrapped_dim = at::maybe_wrap_dim(dim, self.dim());
 
   // Memory overlap checks need to be done after resizing (if required) is done.
   // But it only makes sense to do these checks when result was defined, hence
   // the boolean variable `check_result` here.
-  // For more details, see: https://github.com/pytorch/pytorch/pull/63312#discussion_r694794832
-  // and https://github.com/pytorch/pytorch/issues/63837
+  // For more details, see:
+  // https://github.com/pytorch/pytorch/pull/63312#discussion_r694794832 and
+  // https://github.com/pytorch/pytorch/issues/63837
   bool check_result = result.defined();
   set_output_raw_strided(0, index.sizes(), {}, self.options());
   if (check_result) {
@@ -176,11 +176,12 @@ TORCH_META_FUNC(gather)
   auto is_index_empty = index.numel() == 0;
   if (!is_index_empty) {
     TORCH_CHECK(
-      index.scalar_type() == at::ScalarType::Long,
-      "gather", "(): Expected dtype int64 for index"
-    );
+        index.scalar_type() == at::ScalarType::Long,
+        "gather",
+        "(): Expected dtype int64 for index");
   }
-  if (is_index_empty) return;
+  if (is_index_empty)
+    return;
   at::native::gather_shape_check(self, wrapped_dim, index);
 }
 
@@ -230,8 +231,7 @@ TORCH_META_FUNC2(scatter, reduce)
  const std::string_view reduce) {
   TORCH_WARN_ONCE(
       "The reduce argument of torch.scatter with Tensor src is deprecated and will be removed ",
-      "in a future PyTorch release. Use torch.scatter_reduce instead for more reduction options."
-  );
+      "in a future PyTorch release. Use torch.scatter_reduce instead for more reduction options.");
   scatter_meta_impl(*this, self, dim, index, src, reduce);
 }
 
@@ -256,8 +256,9 @@ TORCH_META_FUNC2(scatter_reduce, two)
  const Tensor& src,
  const std::string_view reduce,
  bool include_self) {
-  (void) include_self;
-  scatter_meta_impl</*use_new_options=*/true>(*this, self, dim, index, src, reduce);
+  (void)include_self;
+  scatter_meta_impl</*use_new_options=*/true>(
+      *this, self, dim, index, src, reduce);
 }
 
 TORCH_PRECOMPUTE_META_FUNC(index_copy)
@@ -269,8 +270,9 @@ TORCH_PRECOMPUTE_META_FUNC(index_copy)
   // Memory overlap checks need to be done after resizing (if required) is done.
   // But it only makes sense to do these checks when result was defined, hence
   // the boolean variable `check_result` here.
-  // For more details, see: https://github.com/pytorch/pytorch/pull/63312#discussion_r694794832
-  // and https://github.com/pytorch/pytorch/issues/63837
+  // For more details, see:
+  // https://github.com/pytorch/pytorch/pull/63312#discussion_r694794832 and
+  // https://github.com/pytorch/pytorch/issues/63837
   bool check_result = result.defined();
   set_output_raw_strided(0, self.sizes(), {}, self.options());
   if (check_result) {
@@ -279,21 +281,48 @@ TORCH_PRECOMPUTE_META_FUNC(index_copy)
     at::assert_no_overlap(result, source);
   }
 
-  TORCH_CHECK_INDEX(index.dim() < 2, "index_copy_(): Index should have dimension 1 or 0 (got ", index.dim(), ")");
+  TORCH_CHECK_INDEX(
+      index.dim() < 2,
+      "index_copy_(): Index should have dimension 1 or 0 (got ",
+      index.dim(),
+      ")");
 
   int64_t numIndices = index.numel();
   if (source.dim() == 0 && numIndices != 1) {
-    TORCH_CHECK_INDEX(false, "index_copy_(): When source is scalar, index should have one element (got ", numIndices, ")");
-  } else if ((source.dim() != self.dim()) && (source.dim() != 0 && self.dim() != 0)) {
-    TORCH_CHECK_INDEX(false, "index_copy_(): When source and destination are not scalars, their dimensionality must match. Source dimensionality (",
-                   source.dim(), "), destination dimensionality (", self.dim(), ")");
+    TORCH_CHECK_INDEX(
+        false,
+        "index_copy_(): When source is scalar, index should have one element (got ",
+        numIndices,
+        ")");
+  } else if (
+      (source.dim() != self.dim()) && (source.dim() != 0 && self.dim() != 0)) {
+    TORCH_CHECK_INDEX(
+        false,
+        "index_copy_(): When source and destination are not scalars, their dimensionality must match. Source dimensionality (",
+        source.dim(),
+        "), destination dimensionality (",
+        self.dim(),
+        ")");
   }
 
-  TORCH_CHECK(index.scalar_type() == ScalarType::Long, "index_copy_(): Expected a long tensor for index, but got ", index.scalar_type());
-  TORCH_CHECK(self.scalar_type() == source.scalar_type(), "index_copy_(): self and source expected to have the same dtype, but got (self) ", self.scalar_type(), " and (source) ", source.scalar_type());
-  TORCH_CHECK(self.device() == source.device() && self.device() == index.device(),
+  TORCH_CHECK(
+      index.scalar_type() == ScalarType::Long,
+      "index_copy_(): Expected a long tensor for index, but got ",
+      index.scalar_type());
+  TORCH_CHECK(
+      self.scalar_type() == source.scalar_type(),
+      "index_copy_(): self and source expected to have the same dtype, but got (self) ",
+      self.scalar_type(),
+      " and (source) ",
+      source.scalar_type());
+  TORCH_CHECK(
+      self.device() == source.device() && self.device() == index.device(),
       "index_copy_(): self, index and source expected to be in the same device, but got (self) ",
-      self.device(), ", (index) ", index.device(), ", and (source) ", source.device());
+      self.device(),
+      ", (index) ",
+      index.device(),
+      ", and (source) ",
+      source.device());
 
   // Check that source and destination slices have the same size
   auto selfSlicedSizes = self.sizes().vec();
@@ -305,43 +334,78 @@ TORCH_PRECOMPUTE_META_FUNC(index_copy)
     sourceSlicedSizes.erase(sourceSlicedSizes.begin() + dim);
   }
   if (selfSlicedSizes.size() != sourceSlicedSizes.size() ||
-      !std::equal(selfSlicedSizes.begin(), selfSlicedSizes.end(),
-                  sourceSlicedSizes.begin())) {
+      !std::equal(
+          selfSlicedSizes.begin(),
+          selfSlicedSizes.end(),
+          sourceSlicedSizes.begin())) {
     std::stringstream ss;
     ss << "index_copy_(): Source/destination tensor must have same slice shapes. ";
-    ss << "Destination slice shape: " << selfSlicedSizes << " at dimension " << dim;
-    ss << " and source slice shape: " << sourceSlicedSizes << " at dimension 0.";
+    ss << "Destination slice shape: " << selfSlicedSizes << " at dimension "
+       << dim;
+    ss << " and source slice shape: " << sourceSlicedSizes
+       << " at dimension 0.";
     TORCH_CHECK(false, ss.str());
   }
-  TORCH_CHECK_INDEX(source.dim() == 0 || numIndices == source.size(dim),
-          "index_copy_(): Number of indices (", numIndices, ") should be equal to source.size(dim) (", source.size(dim), ")");
+  TORCH_CHECK_INDEX(
+      source.dim() == 0 || numIndices == source.size(dim),
+      "index_copy_(): Number of indices (",
+      numIndices,
+      ") should be equal to source.size(dim) (",
+      source.size(dim),
+      ")");
 
   return TORCH_PRECOMPUTE_STRUCT(index_copy)().set_dim(dim);
 }
 
 template <typename Meta>
 void index_func_meta_impl(
-  Meta& meta,
-  const Tensor& self,
-  int64_t dim,
-  const Tensor& index,
-  const Tensor& source,
-  std::string_view func) {
+    Meta& meta,
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& index,
+    const Tensor& source,
+    std::string_view func) {
   auto numel = index.numel();
 
-  TORCH_CHECK_INDEX(index.dim() <= 1, func, "_(): Index is supposed to be a vector, but got dim: ",
-                    index.dim(), " with type: ", index.scalar_type(), " and size: ", index.sizes());
-  TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
-              func, "_(): Expected dtype int32/int64 for index but got: ", index.scalar_type());
-  TORCH_CHECK(self.scalar_type() == source.scalar_type(),
-              func, "_(): self (", self.scalar_type(), ") and source (", source.scalar_type(),
-              ") must have the same scalar type");
-  TORCH_CHECK(dim == 0 || dim < source.dim(),
-              func, "_(): Indexing dim ", dim, " is out of bounds of the source tensor with dim ",
-              source.dim());
-  TORCH_CHECK(numel == (source.dim() == 0 ? 1 : source.size(dim)),
-              func, "_(): Number of indices (", numel, ") should be equal to source.size(dim): (",
-              source.size(dim), "), for dim: ", dim);
+  TORCH_CHECK_INDEX(
+      index.dim() <= 1,
+      func,
+      "_(): Index is supposed to be a vector, but got dim: ",
+      index.dim(),
+      " with type: ",
+      index.scalar_type(),
+      " and size: ",
+      index.sizes());
+  TORCH_CHECK(
+      index.scalar_type() == ScalarType::Long ||
+          index.scalar_type() == ScalarType::Int,
+      func,
+      "_(): Expected dtype int32/int64 for index but got: ",
+      index.scalar_type());
+  TORCH_CHECK(
+      self.scalar_type() == source.scalar_type(),
+      func,
+      "_(): self (",
+      self.scalar_type(),
+      ") and source (",
+      source.scalar_type(),
+      ") must have the same scalar type");
+  TORCH_CHECK(
+      dim == 0 || dim < source.dim(),
+      func,
+      "_(): Indexing dim ",
+      dim,
+      " is out of bounds of the source tensor with dim ",
+      source.dim());
+  TORCH_CHECK(
+      numel == (source.dim() == 0 ? 1 : source.size(dim)),
+      func,
+      "_(): Number of indices (",
+      numel,
+      ") should be equal to source.size(dim): (",
+      source.size(dim),
+      "), for dim: ",
+      dim);
 
   auto self_sizes = self.sizes().vec();
   auto source_sizes = source.sizes().vec();
@@ -366,17 +430,23 @@ void index_func_meta_impl(
   }
 
   // A hack to run TensorIterator checks in the meta function.
-  // See comment: https://github.com/pytorch/pytorch/pull/65993#discussion_r760307417
+  // See comment:
+  // https://github.com/pytorch/pytorch/pull/65993#discussion_r760307417
   // TODO: (@krshrimali) Try inheriting from TensorIteratorBase instead.
   if (result.device() == kMeta && result.dim() > 0) {
     auto selfSlice = result.select(dim, 0);
     auto sourceSlice = source.select(dim, 0);
-    auto iter = TensorIterator::borrowing_binary_op(selfSlice, selfSlice, sourceSlice);
+    auto iter =
+        TensorIterator::borrowing_binary_op(selfSlice, selfSlice, sourceSlice);
   }
 }
 
 TORCH_PRECOMPUTE_META_FUNC(index_add)
-(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& source, const Scalar& alpha) {
+(const Tensor& self,
+ int64_t dim,
+ const Tensor& index,
+ const Tensor& source,
+ const Scalar& alpha) {
   dim = maybe_wrap_dim(dim, self.dim());
   index_func_meta_impl(*this, self, dim, index, source, "index_add");
   return TORCH_PRECOMPUTE_STRUCT(index_add)().set_dim(dim);
@@ -390,8 +460,12 @@ TORCH_PRECOMPUTE_META_FUNC(index_reduce)
  const std::string_view reduce,
  bool include_self) {
   (void)include_self;
-  TORCH_CHECK(reduce == "prod" || reduce == "mean" || reduce == "amax" || reduce == "amin",
-              "index_reduce(): Expected reduce to be one of prod, mean, amax or amin but got ", reduce, ".");
+  TORCH_CHECK(
+      reduce == "prod" || reduce == "mean" || reduce == "amax" ||
+          reduce == "amin",
+      "index_reduce(): Expected reduce to be one of prod, mean, amax or amin but got ",
+      reduce,
+      ".");
   dim = maybe_wrap_dim(dim, self.dim());
   index_func_meta_impl(*this, self, dim, index, source, "index_reduce");
   return TORCH_PRECOMPUTE_STRUCT(index_reduce)().set_dim(dim);
@@ -413,7 +487,8 @@ static void build_index_op(
     config.add_owned_const_input(index);
   }
   if (!result.defined()) {
-    config.declare_static_dtype_and_device(info.src.scalar_type(), info.src.device());
+    config.declare_static_dtype_and_device(
+        info.src.scalar_type(), info.src.device());
   }
   iter.build(config);
 }
@@ -428,8 +503,11 @@ static void check_indices_on_cpu_or_selfdevice(
       });
   TORCH_CHECK(
       indices_on_cpu_or_dev,
-      "indices should be either on ", kCPU,
-      " or on the same device as the indexed tensor (", dev, ")");
+      "indices should be either on ",
+      kCPU,
+      " or on the same device as the indexed tensor (",
+      dev,
+      ")");
 }
 
 TORCH_PRECOMPUTE_META_FUNC2(index, Tensor)
@@ -439,7 +517,10 @@ TORCH_PRECOMPUTE_META_FUNC2(index, Tensor)
   TORCH_CHECK_INDEX(
       materialized.size() <= (size_t)self.dim(),
       "too many indices for tensor of dimension ",
-      self.dim(), " (got ", materialized.size(), ")");
+      self.dim(),
+      " (got ",
+      materialized.size(),
+      ")");
 
   // Only allow: `dev_tensor[{cpu,dev}_tensor]`.
   // See: https://github.com/pytorch/pytorch/pull/69607
@@ -448,9 +529,13 @@ TORCH_PRECOMPUTE_META_FUNC2(index, Tensor)
   const auto& result = maybe_get_output();
 
   if (result.defined()) {
-    TORCH_CHECK(self.scalar_type() == result.scalar_type(),
-                "index_out: self (", self.scalar_type(), ") and result (", result.scalar_type(),
-                ") must have the same scalar type");
+    TORCH_CHECK(
+        self.scalar_type() == result.scalar_type(),
+        "index_out: self (",
+        self.scalar_type(),
+        ") and result (",
+        result.scalar_type(),
+        ") must have the same scalar type");
     at::assert_no_internal_overlap(result);
     at::assert_no_overlap(result, self);
     for (const at::OptionalTensorRef& index : materialized) {
@@ -523,25 +608,35 @@ inline std::string shapes_as_str(TensorList tensors) {
   return os.str();
 }
 
-// Replace indexed dimensions in src with stride 0 and the size of the result tensor.
-// The offset in these dimensions is computed by the kernel using the index tensor's
-// values and the stride of src. The new shape is not meaningful. It's used to make
-// the shape compatible with the result tensor.
-static Tensor restride_src(const Tensor& src, int64_t dims_before, int64_t dims_indexed,
-                           IntArrayRef replacement_shape) {
+// Replace indexed dimensions in src with stride 0 and the size of the result
+// tensor. The offset in these dimensions is computed by the kernel using the
+// index tensor's values and the stride of src. The new shape is not meaningful.
+// It's used to make the shape compatible with the result tensor.
+static Tensor restride_src(
+    const Tensor& src,
+    int64_t dims_before,
+    int64_t dims_indexed,
+    IntArrayRef replacement_shape) {
   auto shape = DimVector(src.sizes());
   auto strides = DimVector(src.strides());
   int64_t end = dims_before + dims_indexed;
   shape.erase(shape.begin() + dims_before, shape.begin() + end);
   strides.erase(strides.begin() + dims_before, strides.begin() + end);
-  shape.insert(shape.begin() + dims_before, replacement_shape.begin(), replacement_shape.end());
+  shape.insert(
+      shape.begin() + dims_before,
+      replacement_shape.begin(),
+      replacement_shape.end());
   strides.insert(strides.begin() + dims_before, replacement_shape.size(), 0);
   return src.as_strided(shape, strides);
 }
 
-// Add dimensions of size 1 to an index tensor so that it can be broadcast to the result
-// shape and iterated over element-wise like the result tensor and the restrided src.
-static Tensor reshape_indexer(const Tensor& index, int64_t dims_before, int64_t dims_after) {
+// Add dimensions of size 1 to an index tensor so that it can be broadcast to
+// the result shape and iterated over element-wise like the result tensor and
+// the restrided src.
+static Tensor reshape_indexer(
+    const Tensor& index,
+    int64_t dims_before,
+    int64_t dims_after) {
   auto orig_shape = index.sizes();
   auto shape = DimVector();
   shape.append(dims_before, 1);
@@ -550,8 +645,7 @@ static Tensor reshape_indexer(const Tensor& index, int64_t dims_before, int64_t 
   return index.reshape(shape);
 }
 
-AdvancedIndex::AdvancedIndex(const Tensor& src, TensorList indices_list)
-{
+AdvancedIndex::AdvancedIndex(const Tensor& src, TensorList indices_list) {
   int64_t element_size_bytes = src.element_size();
   int64_t dims_before = 0, dims_after = 0, dims_indexed = 0;
   IntArrayRef replacement_shape;
@@ -575,9 +669,12 @@ AdvancedIndex::AdvancedIndex(const Tensor& src, TensorList indices_list)
   // is no number that's a valid index for an empty tensor. Normally, out of
   // bounds is handled in the indexing kernel, but this case fails earlier in
   // restride_src with an unhelpful error message.
-  if (std::find(indexed_sizes.begin(), indexed_sizes.end(), 0) != indexed_sizes.end() &&
-      std::find(replacement_shape.begin(), replacement_shape.end(), 0) == replacement_shape.end()) {
-    TORCH_CHECK_INDEX(false, "index is out of bounds for dimension with size 0");
+  if (std::find(indexed_sizes.begin(), indexed_sizes.end(), 0) !=
+          indexed_sizes.end() &&
+      std::find(replacement_shape.begin(), replacement_shape.end(), 0) ==
+          replacement_shape.end()) {
+    TORCH_CHECK_INDEX(
+        false, "index is out of bounds for dimension with size 0");
   }
 
   this->dims_before = dims_before;
@@ -590,24 +687,38 @@ AdvancedIndex::AdvancedIndex(const Tensor& src, TensorList indices_list)
     }
   }
 
-  // For CUDA/MPS/XPU tensors, force all index tensors to have the same striding to
-  // simplify the CUDA/MPS/XPU kernel.
-  if (indices.size() >= 2 && (this->src.device().type() == kCUDA || this->src.device().type() == kMPS || this->src.device().type() == kXPU)) {
+  // For CUDA/MPS/XPU tensors, force all index tensors to have the same striding
+  // to simplify the CUDA/MPS/XPU kernel.
+  if (indices.size() >= 2 &&
+      (this->src.device().type() == kCUDA ||
+       this->src.device().type() == kMPS ||
+       this->src.device().type() == kXPU)) {
     if (!all_strides_match(indices)) {
-      for (auto & indice : indices) {
+      for (auto& indice : indices) {
         indice = indice.contiguous();
       }
     }
   }
 }
 
-static TensorIterator make_index_put_iterator(const AdvancedIndex& info, const Tensor& value) {
-  TORCH_CHECK(is_expandable_to(value.sizes(), info.src.sizes()), "shape mismatch: value tensor of shape ", value.sizes(),
-             " cannot be broadcast to indexing result of shape ", info.src.sizes());
-  TORCH_CHECK(value.scalar_type() == info.src.scalar_type(),
-              "Index put requires the source and destination dtypes match, "
-              "got ", info.src.scalar_type(), " for the destination "
-              "and ", value.scalar_type(), " for the source.");
+static TensorIterator make_index_put_iterator(
+    const AdvancedIndex& info,
+    const Tensor& value) {
+  TORCH_CHECK(
+      is_expandable_to(value.sizes(), info.src.sizes()),
+      "shape mismatch: value tensor of shape ",
+      value.sizes(),
+      " cannot be broadcast to indexing result of shape ",
+      info.src.sizes());
+  TORCH_CHECK(
+      value.scalar_type() == info.src.scalar_type(),
+      "Index put requires the source and destination dtypes match, "
+      "got ",
+      info.src.scalar_type(),
+      " for the destination "
+      "and ",
+      value.scalar_type(),
+      " for the source.");
   TensorIteratorConfig config;
   // info.src is restrided by restride_src with 0 strided dimensions
   config.set_check_mem_overlap(false);
@@ -622,17 +733,16 @@ static TensorIterator make_index_put_iterator(const AdvancedIndex& info, const T
 }
 
 TORCH_IMPL_FUNC(index_out)
-(const Tensor& self,
- DimVector sizes,
- DimVector strides,
- const Tensor& result) {
+(const Tensor& self, DimVector sizes, DimVector strides, const Tensor& result) {
   index_stub(device_type(), *this, sizes, strides);
 }
 
-Tensor quantized_index(const Tensor & self, const torch::List<std::optional<Tensor>>& indices) {
+Tensor quantized_index(
+    const Tensor& self,
+    const torch::List<std::optional<Tensor>>& indices) {
   TORCH_INTERNAL_ASSERT(
       self.qscheme() == c10::kPerTensorAffine ||
-      self.qscheme() == c10::kPerTensorSymmetric,
+          self.qscheme() == c10::kPerTensorSymmetric,
       "Indexing is only supported for per-Tensor quantized Tensors.");
 
   // For now, this is a naive implementation which does dq -> index -> q.
@@ -643,69 +753,96 @@ Tensor quantized_index(const Tensor & self, const torch::List<std::optional<Tens
       result, self.q_scale(), self.q_zero_point(), self.scalar_type());
 }
 
-Tensor _unsafe_index(const Tensor& self, const torch::List<std::optional<Tensor>>& indices) {
+Tensor _unsafe_index(
+    const Tensor& self,
+    const torch::List<std::optional<Tensor>>& indices) {
   // Disallow boolean indexing since it leads to dynamic output shapes
   for (auto i : c10::irange(indices.size())) {
     auto index = indices.get(i);
     if (index.has_value()) {
       auto dtype = index->scalar_type();
-      TORCH_CHECK(dtype == kLong || dtype == kInt,
-                  "_unsafe_index found unexpected index type ", dtype);
+      TORCH_CHECK(
+          dtype == kLong || dtype == kInt,
+          "_unsafe_index found unexpected index type ",
+          dtype);
     }
   }
   return at::index(self, indices);
 }
 
-Tensor _unsafe_masked_index(const Tensor& self, const Tensor& mask, const torch::List<std::optional<Tensor>>& indices, const Scalar& fill) {
+Tensor _unsafe_masked_index(
+    const Tensor& self,
+    const Tensor& mask,
+    const torch::List<std::optional<Tensor>>& indices,
+    const Scalar& fill) {
   // Unsafe masked index is equivalent to
   //   where(mask, self[indices], fill)
-  // with the main difference being that the when the `mask` is false, the tensor
-  // `self` is not indexed using `indices`. This allows `indices` to be out-of-bounds
-  // when `mask` is false. When `mask` is true, the `indices` are expected to be
-  // in bounds and is not checked. We also assume that the `indices` are non-negative
+  // with the main difference being that the when the `mask` is false, the
+  // tensor `self` is not indexed using `indices`. This allows `indices` to be
+  // out-of-bounds when `mask` is false. When `mask` is true, the `indices` are
+  // expected to be in bounds and is not checked. We also assume that the
+  // `indices` are non-negative
   //
-  // This function is not meant to be executed on eager mode. An unoptimized version
-  // is provided here.
+  // This function is not meant to be executed on eager mode. An unoptimized
+  // version is provided here.
   //
   // compiler backends should implement this op such that `self[indices]` is not
   // loaded when `mask` is true. See inductor for a reference.
-  auto clamp = [](const std::optional<Tensor>& index, auto size) -> std::optional<Tensor> {
+  auto clamp = [](const std::optional<Tensor>& index,
+                  auto size) -> std::optional<Tensor> {
     if (!index) {
       return index;
     }
     // Disallow bool
     auto dtype = index->scalar_type();
-    TORCH_CHECK(dtype == kLong || dtype == kInt,
-                "_unsafe_masked_index found unexpected index type ", dtype);
+    TORCH_CHECK(
+        dtype == kLong || dtype == kInt,
+        "_unsafe_masked_index found unexpected index type ",
+        dtype);
     return at::clamp(*index, -size, size - 1);
   };
 
   torch::List<std::optional<Tensor>> clamped_indices(indices);
-  std::transform(indices.begin(), indices.end(), self.sizes().begin(), clamped_indices.begin(), clamp);
+  std::transform(
+      indices.begin(),
+      indices.end(),
+      self.sizes().begin(),
+      clamped_indices.begin(),
+      clamp);
 
   if (self.numel() == 0) {
-      // Returns a tensor filled with `fill` value
-      // We use a hack here since we do not have a method to get the
-      // correct size of the tensor. (except with meta impl which is
-      // not available on mobile builds)
-      std::vector<int64_t> new_sizes(self.dim());
-      auto compute_new_size = [](const std::optional<Tensor>& index, auto size) -> int64_t {
-          if (index && size == 0) {
-              return 1;
-          } else {
-              return size;
-          }
-      };
-      std::transform(indices.begin(), indices.end(), self.sizes().begin(), new_sizes.begin(), compute_new_size);
-      auto result = self.new_full(new_sizes, fill);
-      return at::_unsafe_index(result, clamped_indices);
+    // Returns a tensor filled with `fill` value
+    // We use a hack here since we do not have a method to get the
+    // correct size of the tensor. (except with meta impl which is
+    // not available on mobile builds)
+    std::vector<int64_t> new_sizes(self.dim());
+    auto compute_new_size = [](const std::optional<Tensor>& index,
+                               auto size) -> int64_t {
+      if (index && size == 0) {
+        return 1;
+      } else {
+        return size;
+      }
+    };
+    std::transform(
+        indices.begin(),
+        indices.end(),
+        self.sizes().begin(),
+        new_sizes.begin(),
+        compute_new_size);
+    auto result = self.new_full(new_sizes, fill);
+    return at::_unsafe_index(result, clamped_indices);
   }
 
   auto result = at::_unsafe_index(self, clamped_indices);
   return result.masked_fill(at::logical_not(mask), fill);
 }
 
-Tensor _unsafe_masked_index_put_accumulate(const Tensor& self, const Tensor& mask, const torch::List<std::optional<Tensor>>& indices, const Tensor& values) {
+Tensor _unsafe_masked_index_put_accumulate(
+    const Tensor& self,
+    const Tensor& mask,
+    const torch::List<std::optional<Tensor>>& indices,
+    const Tensor& values) {
   // This is the backward of _unsafe_masked_index.
   // This function is not meant to be executed on eager mode.
 
@@ -713,43 +850,77 @@ Tensor _unsafe_masked_index_put_accumulate(const Tensor& self, const Tensor& mas
     return self.clone();
   }
 
-  // We recompute the clamped indices and rely on inductor to CSE the computation
-  auto clamp = [](const std::optional<Tensor>& index, auto size) -> std::optional<Tensor> {
+  // We recompute the clamped indices and rely on inductor to CSE the
+  // computation
+  auto clamp = [](const std::optional<Tensor>& index,
+                  auto size) -> std::optional<Tensor> {
     if (!index) {
       return index;
     }
     // Disallow bool
     auto dtype = index->scalar_type();
-    TORCH_CHECK(dtype == kLong || dtype == kInt,
-                "_unsafe_masked_index found unexpected index type ", dtype);
+    TORCH_CHECK(
+        dtype == kLong || dtype == kInt,
+        "_unsafe_masked_index found unexpected index type ",
+        dtype);
     return at::clamp(*index, -size, size - 1);
   };
 
   torch::List<std::optional<Tensor>> clamped_indices(indices);
-  std::transform(indices.begin(), indices.end(), self.sizes().begin(), clamped_indices.begin(), clamp);
+  std::transform(
+      indices.begin(),
+      indices.end(),
+      self.sizes().begin(),
+      clamped_indices.begin(),
+      clamp);
 
   auto masked_value = values.masked_fill(at::logical_not(mask), 0);
   return at::_unsafe_index_put(self, clamped_indices, masked_value, true);
 }
 
-Tensor & put_(Tensor & self, const Tensor& index, const Tensor & source, const bool accumulate) {
+Tensor& put_(
+    Tensor& self,
+    const Tensor& index,
+    const Tensor& source,
+    const bool accumulate) {
   // See note [Writing Nondeterministic Operations]
-  // Nondeterministic when index contains duplicate entries and we do not accumulate
-  // If we accumulate on GPU, we use atomicGPUAdd, which is non-deterministic
+  // Nondeterministic when index contains duplicate entries and we do not
+  // accumulate If we accumulate on GPU, we use atomicGPUAdd, which is
+  // non-deterministic
   if (!accumulate || (accumulate && self.device().type() == DeviceType::CUDA)) {
     at::globalContext().alertNotDeterministic("put_");
   }
 
   // Type and device checks
-  TORCH_CHECK(index.scalar_type() == ScalarType::Long, "put_(): Expected a long tensor for index, but got ", index.scalar_type())
-  TORCH_CHECK(self.scalar_type() == source.scalar_type(), "put_(): self and source expected to have the same dtype, but got self.dtype = ", self.scalar_type(), " and source.dtype = ", source.scalar_type());
-  TORCH_CHECK(self.device() == source.device() && self.device() == index.device(),
+  TORCH_CHECK(
+      index.scalar_type() == ScalarType::Long,
+      "put_(): Expected a long tensor for index, but got ",
+      index.scalar_type())
+  TORCH_CHECK(
+      self.scalar_type() == source.scalar_type(),
+      "put_(): self and source expected to have the same dtype, but got self.dtype = ",
+      self.scalar_type(),
+      " and source.dtype = ",
+      source.scalar_type());
+  TORCH_CHECK(
+      self.device() == source.device() && self.device() == index.device(),
       "put_(): self, index and source expected to be in the same device, but got self.device = ",
-      self.device(), ", index.device = ", index.device(), ", and source.device = ", source.device());
+      self.device(),
+      ", index.device = ",
+      index.device(),
+      ", and source.device = ",
+      source.device());
 
   // index checks
-  TORCH_CHECK_INDEX(source.numel() == index.numel(), "put_(): Expected source and index to have the same number of elements, but got source.numel() = ", source.numel(), ", index.numel() = ", index.numel());
-  TORCH_CHECK_INDEX(!(self.numel() == 0 && index.numel() != 0), "put_(): Tried to put elements into an empty tensor");
+  TORCH_CHECK_INDEX(
+      source.numel() == index.numel(),
+      "put_(): Expected source and index to have the same number of elements, but got source.numel() = ",
+      source.numel(),
+      ", index.numel() = ",
+      index.numel());
+  TORCH_CHECK_INDEX(
+      !(self.numel() == 0 && index.numel() != 0),
+      "put_(): Tried to put elements into an empty tensor");
 
   at::assert_no_internal_overlap(self);
   at::assert_no_overlap(self, index);
@@ -763,36 +934,60 @@ Tensor & put_(Tensor & self, const Tensor& index, const Tensor & source, const b
   auto index_reshaped = index.reshape(source.sizes());
   // Do not iterate over self, we will compute the offsets manually
   auto iter = TensorIteratorConfig()
-    .set_check_mem_overlap(false)
-    .check_all_same_dtype(false)
-    .add_const_input(source)
-    .add_const_input(index_reshaped)
-    .build();
+                  .set_check_mem_overlap(false)
+                  .check_all_same_dtype(false)
+                  .add_const_input(source)
+                  .add_const_input(index_reshaped)
+                  .build();
 
   put_stub(iter.device_type(), iter, self, accumulate);
 
   return self;
 }
 
-Tensor put(const Tensor & self, const Tensor& index, const Tensor & source, const bool accumulate) {
+Tensor put(
+    const Tensor& self,
+    const Tensor& index,
+    const Tensor& source,
+    const bool accumulate) {
   return self.clone(at::MemoryFormat::Preserve).put_(index, source, accumulate);
 }
 
-Tensor index_put(const Tensor & self, const torch::List<std::optional<Tensor>>& indices, const Tensor & value, bool accumulate) {
-  return self.clone(at::MemoryFormat::Preserve).index_put_(indices, value, accumulate);
+Tensor index_put(
+    const Tensor& self,
+    const torch::List<std::optional<Tensor>>& indices,
+    const Tensor& value,
+    bool accumulate) {
+  return self.clone(at::MemoryFormat::Preserve)
+      .index_put_(indices, value, accumulate);
 }
 
-Tensor _unsafe_index_put(const Tensor& self, const torch::List<std::optional<Tensor>>& indices, const Tensor& value, bool accumulate) {
+Tensor _unsafe_index_put(
+    const Tensor& self,
+    const torch::List<std::optional<Tensor>>& indices,
+    const Tensor& value,
+    bool accumulate) {
   return at::index_put(self, indices, value, accumulate);
 }
 
-Tensor & _index_put_impl_(Tensor & self, const torch::List<std::optional<Tensor>>& indices, const Tensor & value, const bool accumulate, const bool unsafe) {
-  TORCH_CHECK_INDEX(indices.size() <= (size_t)self.dim(), "too many indices for tensor of dimension ", self.dim(), " (got ", indices.size(), ")");
+Tensor& _index_put_impl_(
+    Tensor& self,
+    const torch::List<std::optional<Tensor>>& indices,
+    const Tensor& value,
+    const bool accumulate,
+    const bool unsafe) {
+  TORCH_CHECK_INDEX(
+      indices.size() <= (size_t)self.dim(),
+      "too many indices for tensor of dimension ",
+      self.dim(),
+      " (got ",
+      indices.size(),
+      ")");
   if (at::has_internal_overlap(self) == MemOverlap::Yes) {
     TORCH_WARN(
-      "Use of index_put_ on expanded tensors is deprecated. "
-      "Please clone() the tensor before performing this operation. "
-      "This also applies to advanced indexing e.g. tensor[indices] = tensor");
+        "Use of index_put_ on expanded tensors is deprecated. "
+        "Please clone() the tensor before performing this operation. "
+        "This also applies to advanced indexing e.g. tensor[indices] = tensor");
   }
   if (!accumulate) {
     auto masked_fill_dispatch = canDispatchToMaskedFill(self, indices, value);
@@ -801,39 +996,68 @@ Tensor & _index_put_impl_(Tensor & self, const torch::List<std::optional<Tensor>
     }
   }
   auto value_ = value;
-  if (value.device() != self.device() && value.numel() == 1 && value.dim() == 0) {
+  if (value.device() != self.device() && value.numel() == 1 &&
+      value.dim() == 0) {
     value_ = value.to(self.device());
   }
   at::assert_no_overlap(self, value);
   // NOLINTNEXTLINE(performance-implicit-conversion-in-loop)
-  for (const std::optional<Tensor>& index: indices) {
+  for (const std::optional<Tensor>& index : indices) {
     if (index.has_value()) {
       at::assert_no_overlap(self, *index);
     }
   }
-  if ((self.device().type() == DeviceType::CUDA || self.device().type() == DeviceType::XPU) && (accumulate || globalContext().deterministicAlgorithms())) {
-      TORCH_CHECK(value_.device() == self.device(), "expected device ", self.device(), " but got device ",
-      value_.device(), " for value tensor");
-      index_put_with_sort_stub(self.device().type(), self, indices, value_, accumulate, unsafe);
-      return self;
+  if ((self.device().type() == DeviceType::CUDA ||
+       self.device().type() == DeviceType::XPU) &&
+      (accumulate || globalContext().deterministicAlgorithms())) {
+    TORCH_CHECK(
+        value_.device() == self.device(),
+        "expected device ",
+        self.device(),
+        " but got device ",
+        value_.device(),
+        " for value tensor");
+    index_put_with_sort_stub(
+        self.device().type(), self, indices, value_, accumulate, unsafe);
+    return self;
   }
 
   auto info = make_info(self, indices);
   auto iter = make_index_put_iterator(info, value_);
-  index_put_stub(iter.device_type(), iter, info.indexed_sizes, info.indexed_strides, accumulate);
+  index_put_stub(
+      iter.device_type(),
+      iter,
+      info.indexed_sizes,
+      info.indexed_strides,
+      accumulate);
   return self;
 }
 
 Tensor& take_out(const Tensor& self, const Tensor& index, Tensor& out) {
   // Type and device checks
-  TORCH_CHECK(index.scalar_type() == ScalarType::Long, "take(): Expected a long tensor for index, but got ", index.scalar_type())
-  TORCH_CHECK(self.scalar_type() == out.scalar_type(), "take(): self and out expected to have the same dtype, but got self.dtype = ", self.scalar_type(), " and out.dtype = ", out.scalar_type());
-  TORCH_CHECK(self.device() == out.device() && self.device() == index.device(),
+  TORCH_CHECK(
+      index.scalar_type() == ScalarType::Long,
+      "take(): Expected a long tensor for index, but got ",
+      index.scalar_type())
+  TORCH_CHECK(
+      self.scalar_type() == out.scalar_type(),
+      "take(): self and out expected to have the same dtype, but got self.dtype = ",
+      self.scalar_type(),
+      " and out.dtype = ",
+      out.scalar_type());
+  TORCH_CHECK(
+      self.device() == out.device() && self.device() == index.device(),
       "take(): self, index and out expected to be in the same device, but got self.device = ",
-      self.device(), ", index.device = ", index.device(), ", and out.device = ", out.device());
+      self.device(),
+      ", index.device = ",
+      index.device(),
+      ", and out.device = ",
+      out.device());
 
   // index checks
-  TORCH_CHECK_INDEX(!(self.numel() == 0 && index.numel() != 0), "take(): tried to take from an empty tensor");
+  TORCH_CHECK_INDEX(
+      !(self.numel() == 0 && index.numel() != 0),
+      "take(): tried to take from an empty tensor");
 
   at::assert_no_internal_overlap(out);
   at::assert_no_overlap(out, index);
@@ -842,11 +1066,11 @@ Tensor& take_out(const Tensor& self, const Tensor& index, Tensor& out) {
   // Do not iterate over self, we will compute the offsets manually
   // out is resized inside tensor_iterator
   auto iter = TensorIteratorConfig()
-    .set_check_mem_overlap(false)
-    .check_all_same_dtype(false)
-    .add_output(out)
-    .add_const_input(index)
-    .build();
+                  .set_check_mem_overlap(false)
+                  .check_all_same_dtype(false)
+                  .add_output(out)
+                  .add_const_input(index)
+                  .build();
 
   // Early return after out has been resized
   if (index.numel() == 0) {
@@ -859,86 +1083,99 @@ Tensor& take_out(const Tensor& self, const Tensor& index, Tensor& out) {
 }
 
 Tensor take(const Tensor& self, const Tensor& index) {
-    auto out = at::empty(index.sizes(), self.options());
-    at::native::take_out(self, index, out);
-    return out;
+  auto out = at::empty(index.sizes(), self.options());
+  at::native::take_out(self, index, out);
+  return out;
 }
 
-Tensor & index_put_(Tensor & self, const torch::List<std::optional<Tensor>>& indices, const Tensor & value, const bool accumulate) {
-  return at::_index_put_impl_(self, indices, value, accumulate, /*unsafe=*/false);
+Tensor& index_put_(
+    Tensor& self,
+    const torch::List<std::optional<Tensor>>& indices,
+    const Tensor& value,
+    const bool accumulate) {
+  return at::_index_put_impl_(
+      self, indices, value, accumulate, /*unsafe=*/false);
 }
 
 TORCH_IMPL_FUNC(index_copy_out)
-(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& source, const Tensor& result) {
-    if (!result.is_same(self)) result.copy_(self);
+(const Tensor& self,
+ int64_t dim,
+ const Tensor& index,
+ const Tensor& source,
+ const Tensor& result) {
+  if (!result.is_same(self))
+    result.copy_(self);
 
-    // See Note [Enabling Deterministic Operations]
-    if (result.is_cuda() && globalContext().deterministicAlgorithms()){
-        torch::List<std::optional<Tensor>> indices;
-        indices.resize(dim + 1);
-        indices.set(dim, index);
-        result.index_put_(indices, source, false);
-        return;
-    }
+  // See Note [Enabling Deterministic Operations]
+  if (result.is_cuda() && globalContext().deterministicAlgorithms()) {
+    torch::List<std::optional<Tensor>> indices;
+    indices.resize(dim + 1);
+    indices.set(dim, index);
+    result.index_put_(indices, source, false);
+    return;
+  }
 
-    // Handle the case when self / source is 0-dim
-    Tensor result_nonzero = result.dim() == 0 ? result.unsqueeze(0) : result;
-    Tensor source_nonzero = source.dim() == 0 ? source.unsqueeze(0) : source;
+  // Handle the case when self / source is 0-dim
+  Tensor result_nonzero = result.dim() == 0 ? result.unsqueeze(0) : result;
+  Tensor source_nonzero = source.dim() == 0 ? source.unsqueeze(0) : source;
 
-    // The only difference between the following  tensor iterator and that of index_fill_ is that
-    // this one has also source as an input. We should refactor it when if constexpr is available (C++17)
+  // The only difference between the following  tensor iterator and that of
+  // index_fill_ is that this one has also source as an input. We should
+  // refactor it when if constexpr is available (C++17)
 
-    // Prepare `index` for TensorIterator.
-    // It is restrided to be broadcastable over `self` in TensorIterator.
-    auto index_sizes = std::vector<int64_t>(result_nonzero.dim(), 1);
-    auto index_strides = std::vector<int64_t>(result_nonzero.dim(), 0);
-    index_sizes[dim] = index.numel();
-    index_strides[dim] = (index.dim() > 0) ? index.stride(0) : 1; // `index` is 1d or scalar
-    auto index_restrided = index.as_strided(
-      index_sizes, index_strides);
+  // Prepare `index` for TensorIterator.
+  // It is restrided to be broadcastable over `self` in TensorIterator.
+  auto index_sizes = std::vector<int64_t>(result_nonzero.dim(), 1);
+  auto index_strides = std::vector<int64_t>(result_nonzero.dim(), 0);
+  index_sizes[dim] = index.numel();
+  index_strides[dim] =
+      (index.dim() > 0) ? index.stride(0) : 1; // `index` is 1d or scalar
+  auto index_restrided = index.as_strided(index_sizes, index_strides);
 
-    // Prepare `result` for TensorIterator.
-    // Restride `result` to not advance in dimension `dim`.
-    // We do not use squash_dim here because `index` will
-    // need to advance in this dimension.
-    // Note that self_sizes[dim] is set to index.numel().
-    // This is done so that self_sizes[dim] and index_sizes[dim]
-    // match as required by TensorIterator (input shape should
-    // strictly broadcast over output shape, i.e.
-    // output.shape[i] >= input.shape[i] for i in range(dims)).
-    auto result_sizes = result_nonzero.sizes().vec();
-    auto result_strides = result_nonzero.strides().vec();
-    result_sizes[dim] = index.numel();
-    result_strides[dim] = 0;
-    auto result_restrided = result_nonzero.as_strided(result_sizes, result_strides);
+  // Prepare `result` for TensorIterator.
+  // Restride `result` to not advance in dimension `dim`.
+  // We do not use squash_dim here because `index` will
+  // need to advance in this dimension.
+  // Note that self_sizes[dim] is set to index.numel().
+  // This is done so that self_sizes[dim] and index_sizes[dim]
+  // match as required by TensorIterator (input shape should
+  // strictly broadcast over output shape, i.e.
+  // output.shape[i] >= input.shape[i] for i in range(dims)).
+  auto result_sizes = result_nonzero.sizes().vec();
+  auto result_strides = result_nonzero.strides().vec();
+  result_sizes[dim] = index.numel();
+  result_strides[dim] = 0;
+  auto result_restrided =
+      result_nonzero.as_strided(result_sizes, result_strides);
 
-    auto iter = TensorIteratorConfig()
-      // We do not check for overlap because `result` is restrided
-      // with zero stride. Zero strides trigger memory overlap assert
-      // within TensorIterator.
-      .set_check_mem_overlap(false)
-      .check_all_same_dtype(false)
-      .resize_outputs(false)
-      .add_output(result_restrided)
-      .add_const_input(index_restrided)
-      .add_const_input(source_nonzero)
-      .build();
+  auto iter = TensorIteratorConfig()
+                  // We do not check for overlap because `result` is restrided
+                  // with zero stride. Zero strides trigger memory overlap
+                  // assert within TensorIterator.
+                  .set_check_mem_overlap(false)
+                  .check_all_same_dtype(false)
+                  .resize_outputs(false)
+                  .add_output(result_restrided)
+                  .add_const_input(index_restrided)
+                  .add_const_input(source_nonzero)
+                  .build();
 
-    auto result_dim_size = result_nonzero.size(dim);
-    auto result_dim_stride = result_nonzero.stride(dim);
-    index_copy_stub(
-      iter.device_type(),
-      iter,
-      dim,
-      result_dim_size,
-      result_dim_stride);
+  auto result_dim_size = result_nonzero.size(dim);
+  auto result_dim_stride = result_nonzero.stride(dim);
+  index_copy_stub(
+      iter.device_type(), iter, dim, result_dim_size, result_dim_stride);
 }
 
 // Not calling into index_reduce_func_impl because of a different dtype dispatch
 TORCH_IMPL_FUNC(index_add_cpu_out)
-(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& source, const Scalar& alpha, const Tensor& result) {
+(const Tensor& self,
+ int64_t dim,
+ const Tensor& index,
+ const Tensor& source,
+ const Scalar& alpha,
+ const Tensor& result) {
   if (!result.is_same(self)) {
-     result.copy_(self);
+    result.copy_(self);
   }
   auto numel = index.numel();
 
@@ -960,16 +1197,17 @@ TORCH_IMPL_FUNC(index_add_cpu_out)
 
     // When the slice of source or result is noncontiguous,
     // original index_add is slow as it uses add for the sliced tensor,
-    // which is serial on index and parallel on sliced tensor to avoid write conflict.
-    // Doing parallel on the sliced tensor is not optimal as the size of sliced tensor
-    // may be not big enough to parallel and also causes multiple parallelizations.
-    // scatter_add is used to speedup for this case as scatter_add parallels on
-    // the outer dimension of input and is serial on the inner dimension to
-    // avoid write conflict. scatter_add only need one parallel and the size of
-    // outer dimensions is bigger to do parallel.
+    // which is serial on index and parallel on sliced tensor to avoid write
+    // conflict. Doing parallel on the sliced tensor is not optimal as the size
+    // of sliced tensor may be not big enough to parallel and also causes
+    // multiple parallelizations. scatter_add is used to speedup for this case
+    // as scatter_add parallels on the outer dimension of input and is serial on
+    // the inner dimension to avoid write conflict. scatter_add only need one
+    // parallel and the size of outer dimensions is bigger to do parallel.
 
     if ((dim == 0 || dim == self.dim() - 1) &&
-        // Data type of index should be long and alpha should be 1 to use scatter_add.
+        // Data type of index should be long and alpha should be 1 to use
+        // scatter_add.
         alpha.equal(1.0) && index_contig.scalar_type() == ScalarType::Long &&
         // scatter_add does not support ComplexHalf
         source.scalar_type() != ScalarType::ComplexHalf &&
@@ -977,12 +1215,13 @@ TORCH_IMPL_FUNC(index_add_cpu_out)
       std::vector<int64_t> ep_sizes(result.sizes().size());
       std::vector<int64_t> ep_strides(source.sizes().size());
 
-      // Check whether result and source are matched apart from the dimension dim.
-      // Note that the broadcast case:
-      // source.select(dim, i) is broadcast for result.select(dim, index_data[i])
-      // The broadcast case is not applicable for scatter_add
-      auto check_sizes = [&ep_sizes, &ep_strides, &numel](IntArrayRef a, IntArrayRef b, int64_t dim) -> bool {
-
+      // Check whether result and source are matched apart from the dimension
+      // dim. Note that the broadcast case: source.select(dim, i) is broadcast
+      // for result.select(dim, index_data[i]) The broadcast case is not
+      // applicable for scatter_add
+      auto check_sizes =
+          [&ep_sizes, &ep_strides, &numel](
+              IntArrayRef a, IntArrayRef b, int64_t dim) -> bool {
         ep_sizes[dim] = numel;
         ep_strides[dim] = 1;
         for (const int64_t i : c10::irange(a.size())) {
@@ -995,7 +1234,6 @@ TORCH_IMPL_FUNC(index_add_cpu_out)
           }
           ep_sizes[i] = a[i];
           ep_strides[i] = 0;
-
         }
         return true;
       };
@@ -1009,84 +1247,123 @@ TORCH_IMPL_FUNC(index_add_cpu_out)
 
     auto selfSlice = result.select(dim, 0);
     auto sourceSlice = source.select(dim, 0);
-    auto self_stride_bytes = result.stride(dim) * elementSize(result.scalar_type());
-    auto source_stride_bytes = source.stride(dim) * elementSize(source.scalar_type());
+    auto self_stride_bytes =
+        result.stride(dim) * elementSize(result.scalar_type());
+    auto source_stride_bytes =
+        source.stride(dim) * elementSize(source.scalar_type());
     auto self_dim_size = result.size(dim);
-    auto iter = TensorIterator::borrowing_binary_op(selfSlice, selfSlice, sourceSlice);
+    auto iter =
+        TensorIterator::borrowing_binary_op(selfSlice, selfSlice, sourceSlice);
 
-    AT_DISPATCH_INDEX_TYPES(index.scalar_type(), "index_add_cpu_", [&] () {
+    AT_DISPATCH_INDEX_TYPES(index.scalar_type(), "index_add_cpu_", [&]() {
       auto index_data = index_contig.const_data_ptr<index_t>();
       for (const auto i : c10::irange(numel)) {
-          auto self_i = index_data[i];
-          TORCH_CHECK_INDEX((self_i >= 0) && (self_i < self_dim_size), "index out of range in self");
-          auto self_data = static_cast<char*>(selfSlice.data_ptr()) + self_i * self_stride_bytes;
-          auto source_data = static_cast<const char*>(sourceSlice.const_data_ptr()) + i * source_stride_bytes;
-          iter.unsafe_replace_operand(0, self_data);
-          iter.unsafe_replace_operand(1, self_data);
-          iter.unsafe_replace_operand(2, const_cast<char*>(source_data));
-          add_stub(iter.device_type(), iter, alpha);
+        auto self_i = index_data[i];
+        TORCH_CHECK_INDEX(
+            (self_i >= 0) && (self_i < self_dim_size),
+            "index out of range in self");
+        auto self_data = static_cast<char*>(selfSlice.data_ptr()) +
+            self_i * self_stride_bytes;
+        auto source_data =
+            static_cast<const char*>(sourceSlice.const_data_ptr()) +
+            i * source_stride_bytes;
+        iter.unsafe_replace_operand(0, self_data);
+        iter.unsafe_replace_operand(1, self_data);
+        iter.unsafe_replace_operand(2, const_cast<char*>(source_data));
+        add_stub(iter.device_type(), iter, alpha);
       }
     });
   } else {
-    TORCH_CHECK(source.dim() <= 1, "source.dim() (", source.dim(), ") must one or zero for given self.dim() (", self.dim(), ")");
+    TORCH_CHECK(
+        source.dim() <= 1,
+        "source.dim() (",
+        source.dim(),
+        ") must one or zero for given self.dim() (",
+        self.dim(),
+        ")");
 
     // explicitly capture all required variables to work around windows build
-    // TODO: fix this when windows can correctly capture variables in nested lambda
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(ScalarType::Half, ScalarType::Bool, ScalarType::BFloat16, ScalarType::ComplexHalf,
-      result.scalar_type(), "index_add_", [&result, &source, &dim, &index_contig, &numel, &alpha] {
-      auto alpha_value = alpha.to<scalar_t>();
-      auto result_stride = result.dim() == 0 ? 1 : result.stride(dim);
-      auto source_stride = source.dim() == 0 ? 1 : source.stride(dim);
-      // TODO: Maybe TensorAccessor can be used here?
-      auto* result_ptr = result.data_ptr<scalar_t>();
-      auto* source_ptr = source.const_data_ptr<scalar_t>();
-      AT_DISPATCH_INDEX_TYPES(index_contig.scalar_type(), "index_add_cpu_",
-        [&index_contig, &numel, &result, &result_ptr, &result_stride, &source_ptr, &source_stride, &alpha_value] {
-        auto index_data = index_contig.const_data_ptr<index_t>();
-        for (const auto i : c10::irange(numel)) {
-            auto self_i = index_data[i];
-            TORCH_CHECK_INDEX((self_i >= 0) && (self_i < result.numel()), "index out of range in self");
-            scalar_t *self_ip = result_ptr + self_i * result_stride;
-            *self_ip += c10::load(source_ptr + i * source_stride) * alpha_value;
-        }
-      });
-    });
+    // TODO: fix this when windows can correctly capture variables in nested
+    // lambda
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(
+        ScalarType::Half,
+        ScalarType::Bool,
+        ScalarType::BFloat16,
+        ScalarType::ComplexHalf,
+        result.scalar_type(),
+        "index_add_",
+        [&result, &source, &dim, &index_contig, &numel, &alpha] {
+          auto alpha_value = alpha.to<scalar_t>();
+          auto result_stride = result.dim() == 0 ? 1 : result.stride(dim);
+          auto source_stride = source.dim() == 0 ? 1 : source.stride(dim);
+          // TODO: Maybe TensorAccessor can be used here?
+          auto* result_ptr = result.data_ptr<scalar_t>();
+          auto* source_ptr = source.const_data_ptr<scalar_t>();
+          AT_DISPATCH_INDEX_TYPES(
+              index_contig.scalar_type(),
+              "index_add_cpu_",
+              [&index_contig,
+               &numel,
+               &result,
+               &result_ptr,
+               &result_stride,
+               &source_ptr,
+               &source_stride,
+               &alpha_value] {
+                auto index_data = index_contig.const_data_ptr<index_t>();
+                for (const auto i : c10::irange(numel)) {
+                  auto self_i = index_data[i];
+                  TORCH_CHECK_INDEX(
+                      (self_i >= 0) && (self_i < result.numel()),
+                      "index out of range in self");
+                  scalar_t* self_ip = result_ptr + self_i * result_stride;
+                  *self_ip +=
+                      c10::load(source_ptr + i * source_stride) * alpha_value;
+                }
+              });
+        });
   }
 }
 
 static void index_reduce_func_impl(
-  const Tensor& self,
-  int64_t dim,
-  const Tensor& index,
-  const Tensor& source,
-  bool include_self,
-  const Tensor& result,
-  const ReductionType& op) {
-  if (!result.is_same(self)) result.copy_(self);
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& index,
+    const Tensor& source,
+    bool include_self,
+    const Tensor& result,
+    const ReductionType& op) {
+  if (!result.is_same(self))
+    result.copy_(self);
   if (!include_self) {
     AT_DISPATCH_ALL_TYPES_AND2(
-      at::ScalarType::Half, at::ScalarType::BFloat16,
-      self.scalar_type(), "index_reduce_func_exclude_input_init", [&] {
-      scalar_t init_val;
-      switch (op) {
-        case ReductionType::PROD:
-          init_val = (scalar_t)1;
-          break;
-        case ReductionType::MAX:
-          init_val = std::numeric_limits<scalar_t>::has_infinity ? -std::numeric_limits<scalar_t>::infinity()
-                     : std::numeric_limits<scalar_t>::lowest();
-          break;
-        case ReductionType::MIN:
-          init_val = std::numeric_limits<scalar_t>::has_infinity ? std::numeric_limits<scalar_t>::infinity()
-                     : std::numeric_limits<scalar_t>::max();
-          break;
-        default:
-          init_val = (scalar_t)0;
-          break;
-      }
-      // index_fill_ requires index to be a LongTensor
-      result.index_fill_(dim, index.to(at::ScalarType::Long), init_val);
-    });
+        at::ScalarType::Half,
+        at::ScalarType::BFloat16,
+        self.scalar_type(),
+        "index_reduce_func_exclude_input_init",
+        [&] {
+          scalar_t init_val;
+          switch (op) {
+            case ReductionType::PROD:
+              init_val = (scalar_t)1;
+              break;
+            case ReductionType::MAX:
+              init_val = std::numeric_limits<scalar_t>::has_infinity
+                  ? -std::numeric_limits<scalar_t>::infinity()
+                  : std::numeric_limits<scalar_t>::lowest();
+              break;
+            case ReductionType::MIN:
+              init_val = std::numeric_limits<scalar_t>::has_infinity
+                  ? std::numeric_limits<scalar_t>::infinity()
+                  : std::numeric_limits<scalar_t>::max();
+              break;
+            default:
+              init_val = (scalar_t)0;
+              break;
+          }
+          // index_fill_ requires index to be a LongTensor
+          result.index_fill_(dim, index.to(at::ScalarType::Long), init_val);
+        });
   }
 
   auto numel = index.numel();
@@ -1106,33 +1383,41 @@ static void index_reduce_func_impl(
     }
     auto selfSlice = result.select(dim, 0);
     auto sourceSlice = source.select(dim, 0);
-    auto self_stride_bytes = result.stride(dim) * elementSize(result.scalar_type());
-    auto source_stride_bytes = source.stride(dim) * elementSize(source.scalar_type());
+    auto self_stride_bytes =
+        result.stride(dim) * elementSize(result.scalar_type());
+    auto source_stride_bytes =
+        source.stride(dim) * elementSize(source.scalar_type());
     auto self_dim_size = result.size(dim);
-    auto iter = TensorIterator::borrowing_binary_op(selfSlice, selfSlice, sourceSlice);
+    auto iter =
+        TensorIterator::borrowing_binary_op(selfSlice, selfSlice, sourceSlice);
 
-    AT_DISPATCH_INDEX_TYPES(index.scalar_type(), "index_func_cpu_", [&] () {
+    AT_DISPATCH_INDEX_TYPES(index.scalar_type(), "index_func_cpu_", [&]() {
       auto index_data = index_contig.const_data_ptr<index_t>();
       for (const auto i : c10::irange(numel)) {
         auto self_i = index_data[i];
-        TORCH_CHECK_INDEX((self_i >= 0) && (self_i < self_dim_size), "index out of range in self");
-        auto self_data = static_cast<char*>(selfSlice.data_ptr()) + self_i * self_stride_bytes;
-        auto source_data = static_cast<const char*>(sourceSlice.const_data_ptr()) + i * source_stride_bytes;
+        TORCH_CHECK_INDEX(
+            (self_i >= 0) && (self_i < self_dim_size),
+            "index out of range in self");
+        auto self_data = static_cast<char*>(selfSlice.data_ptr()) +
+            self_i * self_stride_bytes;
+        auto source_data =
+            static_cast<const char*>(sourceSlice.const_data_ptr()) +
+            i * source_stride_bytes;
         iter.unsafe_replace_operand(0, self_data);
         iter.unsafe_replace_operand(1, self_data);
         iter.unsafe_replace_operand(2, const_cast<char*>(source_data));
 
         switch (op) {
-          case ReductionType::PROD :
+          case ReductionType::PROD:
             mul_stub(iter.device_type(), iter);
             break;
-          case ReductionType::MIN :
+          case ReductionType::MIN:
             minimum_stub(iter.device_type(), iter);
             break;
-          case ReductionType::MAX :
+          case ReductionType::MAX:
             maximum_stub(iter.device_type(), iter);
             break;
-          default :
+          default:
             add_stub(iter.device_type(), iter, 1);
             break;
         }
@@ -1140,7 +1425,8 @@ static void index_reduce_func_impl(
     });
 
     if (op == ReductionType::MEAN) {
-      auto counts = include_self ? at::ones_like(result) : at::zeros_like(result);
+      auto counts =
+          include_self ? at::ones_like(result) : at::zeros_like(result);
       counts.index_add_(dim, index, at::ones_like(source));
       counts.masked_fill_(counts == 0, 1);
       if (result.is_floating_point() || result.is_complex()) {
@@ -1149,53 +1435,80 @@ static void index_reduce_func_impl(
         result.div_(counts, "floor");
       }
     }
-  }
-  else {
-    TORCH_CHECK(source.dim() <= 1, "source.dim() (", source.dim(), ") must one or zero for given self.dim() (", self.dim(), ")");
+  } else {
+    TORCH_CHECK(
+        source.dim() <= 1,
+        "source.dim() (",
+        source.dim(),
+        ") must one or zero for given self.dim() (",
+        self.dim(),
+        ")");
     auto counts = include_self ? at::ones_like(result) : at::zeros_like(result);
     // explicitly capture all required variables to work around windows build
-    // TODO: fix this when windows can correctly capture variables in nested lambda
-    AT_DISPATCH_ALL_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16,
-      result.scalar_type(), "index_func_", [&result, &source, &dim, &index_contig, &numel, &op, &counts] {
-      auto result_stride = result.dim() == 0 ? 1 : result.stride(dim);
-      auto source_stride = source.dim() == 0 ? 1 : source.stride(dim);
-      auto counts_stride = counts.dim() == 0 ? 1 : counts.stride(dim);
-      // TODO: Maybe TensorAccessor can be used here?
-      auto* result_ptr = result.data_ptr<scalar_t>();
-      auto* source_ptr = source.const_data_ptr<scalar_t>();
-      auto counts_ptr = counts.data_ptr<scalar_t>();
-      AT_DISPATCH_INDEX_TYPES(index_contig.scalar_type(), "index_func_cpu_",
-        [&index_contig, &numel, &result, &result_ptr, &result_stride, &source_ptr, &source_stride, &op, &counts_ptr, &counts_stride] {
-        auto index_data = index_contig.const_data_ptr<index_t>();
-        for (const auto i : c10::irange(numel)) {
-            auto self_i = index_data[i];
-            TORCH_CHECK_INDEX((self_i >= 0) && (self_i < result.numel()), "index out of range in self");
-            scalar_t *self_ip = result_ptr + self_i * result_stride;
-            scalar_t *count_ip;
-            scalar_t val;
-            switch (op) {
-              case ReductionType::MEAN :
-                *self_ip += *(source_ptr + i * source_stride);
-                count_ip = counts_ptr + self_i * counts_stride;
-                *count_ip += 1;
-                break;
-              case ReductionType::PROD :
-                *self_ip *= *(source_ptr + i * source_stride);
-                break;
-              case ReductionType::MIN :
-                val = *(source_ptr + i * source_stride);
-                *self_ip = at::_isnan<scalar_t>(val) ? val : std::min(*self_ip, val);
-                break;
-              case ReductionType::MAX :
-                val = *(source_ptr + i * source_stride);
-                *self_ip = at::_isnan<scalar_t>(val) ? val : std::max(*self_ip, val);
-                break;
-              default:
-                break;
-            }
-        }
-      });
-    });
+    // TODO: fix this when windows can correctly capture variables in nested
+    // lambda
+    AT_DISPATCH_ALL_TYPES_AND2(
+        ScalarType::Half,
+        ScalarType::BFloat16,
+        result.scalar_type(),
+        "index_func_",
+        [&result, &source, &dim, &index_contig, &numel, &op, &counts] {
+          auto result_stride = result.dim() == 0 ? 1 : result.stride(dim);
+          auto source_stride = source.dim() == 0 ? 1 : source.stride(dim);
+          auto counts_stride = counts.dim() == 0 ? 1 : counts.stride(dim);
+          // TODO: Maybe TensorAccessor can be used here?
+          auto* result_ptr = result.data_ptr<scalar_t>();
+          auto* source_ptr = source.const_data_ptr<scalar_t>();
+          auto counts_ptr = counts.data_ptr<scalar_t>();
+          AT_DISPATCH_INDEX_TYPES(
+              index_contig.scalar_type(),
+              "index_func_cpu_",
+              [&index_contig,
+               &numel,
+               &result,
+               &result_ptr,
+               &result_stride,
+               &source_ptr,
+               &source_stride,
+               &op,
+               &counts_ptr,
+               &counts_stride] {
+                auto index_data = index_contig.const_data_ptr<index_t>();
+                for (const auto i : c10::irange(numel)) {
+                  auto self_i = index_data[i];
+                  TORCH_CHECK_INDEX(
+                      (self_i >= 0) && (self_i < result.numel()),
+                      "index out of range in self");
+                  scalar_t* self_ip = result_ptr + self_i * result_stride;
+                  scalar_t* count_ip;
+                  scalar_t val;
+                  switch (op) {
+                    case ReductionType::MEAN:
+                      *self_ip += *(source_ptr + i * source_stride);
+                      count_ip = counts_ptr + self_i * counts_stride;
+                      *count_ip += 1;
+                      break;
+                    case ReductionType::PROD:
+                      *self_ip *= *(source_ptr + i * source_stride);
+                      break;
+                    case ReductionType::MIN:
+                      val = *(source_ptr + i * source_stride);
+                      *self_ip = at::_isnan<scalar_t>(val)
+                          ? val
+                          : std::min(*self_ip, val);
+                      break;
+                    case ReductionType::MAX:
+                      val = *(source_ptr + i * source_stride);
+                      *self_ip = at::_isnan<scalar_t>(val)
+                          ? val
+                          : std::max(*self_ip, val);
+                      break;
+                    default:
+                      break;
+                  }
+                }
+              });
+        });
     if (op == ReductionType::MEAN) {
       counts.masked_fill_(counts == 0, 1);
       if (result.is_floating_point() || result.is_complex()) {
@@ -1215,7 +1528,8 @@ TORCH_IMPL_FUNC(index_reduce_cpu_out)
  const std::string_view reduce,
  bool include_input,
  const Tensor& result) {
-  TORCH_WARN_ONCE("index_reduce() is in beta and the API may change at any time.");
+  TORCH_WARN_ONCE(
+      "index_reduce() is in beta and the API may change at any time.");
   auto op = get_operator_enum(reduce, true);
   index_reduce_func_impl(self, dim, index, source, include_input, result, op);
 }
@@ -1238,9 +1552,10 @@ static void check_indexarray_range(
   }
 }
 
-static Tensor & index_select_out_cpu_dim1_(
-    Tensor & result_contig, const Tensor & self, const Tensor & index_contig) {
-
+static Tensor& index_select_out_cpu_dim1_(
+    Tensor& result_contig,
+    const Tensor& self,
+    const Tensor& index_contig) {
   auto self_contig = self.contiguous();
   const caffe2::TypeMeta dataType = self_contig.dtype();
   size_t item_bytesize = dataType.itemsize();
@@ -1261,40 +1576,46 @@ static Tensor & index_select_out_cpu_dim1_(
   auto gathered_batch_bytesize = N * block_bytesize;
 
   AT_DISPATCH_INDEX_TYPES(
-    index_contig.scalar_type(), "batch_index_select_compute", [&]() {
+      index_contig.scalar_type(), "batch_index_select_compute", [&]() {
+        const auto* idxs = index_contig.const_data_ptr<index_t>();
+        check_indexarray_range<index_t>(idxs, N, src_indexing_axis_dim);
 
-      const auto* idxs = index_contig.const_data_ptr<index_t>();
-      check_indexarray_range<index_t>(idxs, N, src_indexing_axis_dim);
+        // Special-case single-float copy for efficiency
+        if (self.scalar_type() == ScalarType::Float && block_size == 1) {
+          for (const auto batch : c10::irange(outer_dims_product)) {
+            const float* src_floats =
+                (const float*)(src_base + batch * src_batch_bytesize);
+            float* dst_floats = (float*)(out + batch * gathered_batch_bytesize);
 
-      // Special-case single-float copy for efficiency
-      if (self.scalar_type() == ScalarType::Float && block_size == 1) {
-        for (const auto batch : c10::irange(outer_dims_product)) {
-          const float* src_floats =
-              (const float*)(src_base + batch * src_batch_bytesize);
-          float* dst_floats = (float*)(out + batch * gathered_batch_bytesize);
-
-          for (const auto i : c10::irange(N)) {
-            auto idx = idxs[i];
-            dst_floats[i] = src_floats[idx];
+            for (const auto i : c10::irange(N)) {
+              auto idx = idxs[i];
+              dst_floats[i] = src_floats[idx];
+            }
+          }
+        } else {
+          // outer_dims_product specifies how many times we repeat inner
+          // dimensions, so we just iterate over it to cover all outer
+          // dimensions.
+          for (const auto batch : c10::irange(outer_dims_product)) {
+            for (const auto i : c10::irange(N)) {
+              auto idx = idxs[i];
+              auto src =
+                  src_base + batch * src_batch_bytesize + idx * block_bytesize;
+              auto dst =
+                  out + batch * gathered_batch_bytesize + i * block_bytesize;
+              memcpy(dst, src, block_bytesize);
+            }
           }
         }
-      } else {
-        // outer_dims_product specifies how many times we repeat inner dimensions,
-        // so we just iterate over it to cover all outer dimensions.
-        for (const auto batch : c10::irange(outer_dims_product)) {
-          for (const auto i : c10::irange(N)) {
-            auto idx = idxs[i];
-            auto src = src_base + batch * src_batch_bytesize + idx * block_bytesize;
-            auto dst = out + batch * gathered_batch_bytesize + i * block_bytesize;
-            memcpy(dst, src, block_bytesize);
-          }
-        }
-      }
-  });
+      });
   return result_contig;
 }
 
-Tensor & index_select_out_cpu_(const Tensor & self, int64_t dim, const Tensor & index, Tensor & result) {
+Tensor& index_select_out_cpu_(
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& index,
+    Tensor& result) {
   if (self.is_quantized()) {
     TORCH_CHECK(
         self.qscheme() == kPerTensorAffine,
@@ -1302,11 +1623,20 @@ Tensor & index_select_out_cpu_(const Tensor & self, int64_t dim, const Tensor & 
   }
   dim = maybe_wrap_dim(dim, self.dim());
   auto numel = index.numel();
-  TORCH_CHECK_INDEX(index.dim() <= 1, "index_select(): Index is supposed to be a vector");
-  TORCH_CHECK(!(self.dim() == 0 && numel != 1), "index_select(): Index to scalar can have only 1 value, got ", numel, " value(s)");
-  TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int, "index_select(): Expected dtype int32 or int64 for index");
-  TORCH_CHECK(self.scalar_type() == result.scalar_type(),
-              "index_select(): self and result must have the same scalar type");
+  TORCH_CHECK_INDEX(
+      index.dim() <= 1, "index_select(): Index is supposed to be a vector");
+  TORCH_CHECK(
+      !(self.dim() == 0 && numel != 1),
+      "index_select(): Index to scalar can have only 1 value, got ",
+      numel,
+      " value(s)");
+  TORCH_CHECK(
+      index.scalar_type() == ScalarType::Long ||
+          index.scalar_type() == ScalarType::Int,
+      "index_select(): Expected dtype int32 or int64 for index");
+  TORCH_CHECK(
+      self.scalar_type() == result.scalar_type(),
+      "index_select(): self and result must have the same scalar type");
   at::assert_no_internal_overlap(result);
   at::assert_no_overlap(result, self);
   at::assert_no_overlap(result, index);
@@ -1324,13 +1654,16 @@ Tensor & index_select_out_cpu_(const Tensor & self, int64_t dim, const Tensor & 
     }
     if (self.numel() == 0) {
       auto src_indexing_axis_dim = self.size(dim);
-      TORCH_CHECK(src_indexing_axis_dim > 0,
-                  "index_select(): self indexing axis dim should be positive");
+      TORCH_CHECK(
+          src_indexing_axis_dim > 0,
+          "index_select(): self indexing axis dim should be positive");
       AT_DISPATCH_INDEX_TYPES(
-      index_contig.scalar_type(), "index_select_empty_self_bound_check", [&]() {
-        const auto* idxs = index_contig.const_data_ptr<index_t>();
-        check_indexarray_range<index_t>(idxs, numel, src_indexing_axis_dim);
-      });
+          index_contig.scalar_type(),
+          "index_select_empty_self_bound_check",
+          [&]() {
+            const auto* idxs = index_contig.const_data_ptr<index_t>();
+            check_indexarray_range<index_t>(idxs, numel, src_indexing_axis_dim);
+          });
       return result;
     }
 
@@ -1344,156 +1677,259 @@ Tensor & index_select_out_cpu_(const Tensor & self, int64_t dim, const Tensor & 
     auto selfSlice_data = selfSlice.const_data_ptr();
     auto resultSlice_data = resultSlice.data_ptr();
     auto self_stride_bytes = self.stride(dim) * elementSize(self.scalar_type());
-    auto result_stride_bytes = result.stride(dim) * elementSize(result.scalar_type());
+    auto result_stride_bytes =
+        result.stride(dim) * elementSize(result.scalar_type());
     auto self_dim_size = self.size(dim);
     auto slice_size = selfSlice.numel();
 
     auto iter = TensorIteratorConfig()
-      .check_all_same_dtype(false)
-      .resize_outputs(false)
-      .add_output(resultSlice)
-      .add_const_input(selfSlice)
-      .build();
+                    .check_all_same_dtype(false)
+                    .resize_outputs(false)
+                    .add_output(resultSlice)
+                    .add_const_input(selfSlice)
+                    .build();
 
     auto grain_size = at::internal::GRAIN_SIZE;
     auto outer_loop =
-      // explicitly capture all required variables to work around windows build
-      // TODO: fix this when windows can correctly capture variables in nested lambda
-      [&index_contig, &iter, &self_dim_size, &selfSlice_data, &self_stride_bytes, &resultSlice_data,
-        &result_stride_bytes](int64_t start, int64_t end) {
-      auto sub_iter = TensorIterator(iter);
-      AT_DISPATCH_INDEX_TYPES(index_contig.scalar_type(), "index_select_out_cpu_",
-        [&index_contig, &start, &end, &sub_iter, &self_dim_size, &selfSlice_data, &self_stride_bytes,
-          &resultSlice_data, &result_stride_bytes] () {
-        auto index_data = index_contig.const_data_ptr<index_t>();
-        for (const auto i : c10::irange(start, end)) {
-          auto self_i = index_data[i];
-          TORCH_CHECK_INDEX((self_i >= 0) && (self_i < self_dim_size), "index out of range in self");
-          auto self_data = static_cast<const char*>(selfSlice_data) + self_i * self_stride_bytes;
-          auto result_data = static_cast<char*>(resultSlice_data) + i * result_stride_bytes;
-          sub_iter.unsafe_replace_operand(0, result_data);
-          sub_iter.unsafe_replace_operand(1, const_cast<char*>(self_data));
-          copy_stub(sub_iter.device_type(), sub_iter, false);
+        // explicitly capture all required variables to work around windows
+        // build
+        // TODO: fix this when windows can correctly capture variables in nested
+        // lambda
+        [&index_contig,
+         &iter,
+         &self_dim_size,
+         &selfSlice_data,
+         &self_stride_bytes,
+         &resultSlice_data,
+         &result_stride_bytes](int64_t start, int64_t end) {
+          auto sub_iter = TensorIterator(iter);
+          AT_DISPATCH_INDEX_TYPES(
+              index_contig.scalar_type(),
+              "index_select_out_cpu_",
+              [&index_contig,
+               &start,
+               &end,
+               &sub_iter,
+               &self_dim_size,
+               &selfSlice_data,
+               &self_stride_bytes,
+               &resultSlice_data,
+               &result_stride_bytes]() {
+                auto index_data = index_contig.const_data_ptr<index_t>();
+                for (const auto i : c10::irange(start, end)) {
+                  auto self_i = index_data[i];
+                  TORCH_CHECK_INDEX(
+                      (self_i >= 0) && (self_i < self_dim_size),
+                      "index out of range in self");
+                  auto self_data = static_cast<const char*>(selfSlice_data) +
+                      self_i * self_stride_bytes;
+                  auto result_data = static_cast<char*>(resultSlice_data) +
+                      i * result_stride_bytes;
+                  sub_iter.unsafe_replace_operand(0, result_data);
+                  sub_iter.unsafe_replace_operand(
+                      1, const_cast<char*>(self_data));
+                  copy_stub(sub_iter.device_type(), sub_iter, false);
+                };
+              });
         };
-      });
-    };
 
     // parallel on inner loop in case the slice is large enough;
     // otherwise parallel on outer loop
     if (slice_size >= grain_size) {
       outer_loop(0, numel);
     } else {
-      // use a fast loop when self and result are contiguous and of the same data type
+      // use a fast loop when self and result are contiguous and of the same
+      // data type
       if (iter.is_contiguous() && self.scalar_type() == result.scalar_type()) {
         auto slice_size_bytes = slice_size * elementSize(self.scalar_type());
-        // explicitly capture all required variables to work around windows build
-        // TODO: fix this when windows can correctly capture variables in nested lambda
-        at::parallel_for(0, numel, grain_size / slice_size,
-          [&index_contig, &slice_size_bytes, &self_dim_size, &selfSlice_data,
-            &self_stride_bytes, &resultSlice_data, &result_stride_bytes](int64_t start, int64_t end) {
-          AT_DISPATCH_INDEX_TYPES(index_contig.scalar_type(), "index_select_out_cpu_",
-            [&index_contig, &slice_size_bytes, &self_dim_size, &selfSlice_data,
-              &self_stride_bytes, &resultSlice_data, &result_stride_bytes, &start, &end] () {
-            auto index_data = index_contig.const_data_ptr<index_t>();
-            for (const auto i : c10::irange(start, end)) {
-              auto self_i = index_data[i];
-              TORCH_CHECK_INDEX((self_i >= 0) && (self_i < self_dim_size), "index out of range in self");
-              auto self_data = static_cast<const char*>(selfSlice_data) + self_i * self_stride_bytes;
-              auto result_data = static_cast<char*>(resultSlice_data) + i * result_stride_bytes;
-              memcpy(result_data, self_data, slice_size_bytes);
-            }
-          });
-        });
+        // explicitly capture all required variables to work around windows
+        // build
+        // TODO: fix this when windows can correctly capture variables in nested
+        // lambda
+        at::parallel_for(
+            0,
+            numel,
+            grain_size / slice_size,
+            [&index_contig,
+             &slice_size_bytes,
+             &self_dim_size,
+             &selfSlice_data,
+             &self_stride_bytes,
+             &resultSlice_data,
+             &result_stride_bytes](int64_t start, int64_t end) {
+              AT_DISPATCH_INDEX_TYPES(
+                  index_contig.scalar_type(),
+                  "index_select_out_cpu_",
+                  [&index_contig,
+                   &slice_size_bytes,
+                   &self_dim_size,
+                   &selfSlice_data,
+                   &self_stride_bytes,
+                   &resultSlice_data,
+                   &result_stride_bytes,
+                   &start,
+                   &end]() {
+                    auto index_data = index_contig.const_data_ptr<index_t>();
+                    for (const auto i : c10::irange(start, end)) {
+                      auto self_i = index_data[i];
+                      TORCH_CHECK_INDEX(
+                          (self_i >= 0) && (self_i < self_dim_size),
+                          "index out of range in self");
+                      auto self_data =
+                          static_cast<const char*>(selfSlice_data) +
+                          self_i * self_stride_bytes;
+                      auto result_data = static_cast<char*>(resultSlice_data) +
+                          i * result_stride_bytes;
+                      memcpy(result_data, self_data, slice_size_bytes);
+                    }
+                  });
+            });
       } else {
         at::parallel_for(0, numel, grain_size / slice_size, outer_loop);
       }
     }
   } else {
-    TORCH_CHECK(result.dim() <= 1, "result.dim() (", result.dim(), ") must one or zero for given self.dim() (", self.dim(), ")");
+    TORCH_CHECK(
+        result.dim() <= 1,
+        "result.dim() (",
+        result.dim(),
+        ") must one or zero for given self.dim() (",
+        self.dim(),
+        ")");
     // explicitly capture all required variables to work around windows build
-    // TODO: fix this when windows can correctly capture variables in nested lambda
-    if(self.is_quantized()){
-      AT_DISPATCH_QINT_TYPES(self.scalar_type(), "index_select_quant", [&index_contig, &self, &result, &dim, &numel] {
-        auto self_stride = self.dim() == 0 ? 1 : self.stride(dim);
-        auto result_stride = result.dim() == 0 ? 1 : result.stride(dim);
-        auto self_data_ptr = self.const_data_ptr<scalar_t>();
-        auto result_data_ptr = result.data_ptr<scalar_t>();
-        auto self_numel = self.numel();
-        AT_DISPATCH_INDEX_TYPES(index_contig.scalar_type(), "index_select_out_cpu_quant_",
-          [&index_contig, &numel, &self_numel, &self_data_ptr, &self_stride, &result_data_ptr, &result_stride] {
-          auto index_data = index_contig.const_data_ptr<index_t>();
-          for (const auto i : c10::irange(numel)) {
-            auto self_i = index_data[i];
-            TORCH_CHECK_INDEX((self_i >= 0) && (self_i < self_numel), "index out of range in self");
-            const scalar_t *self_ip = self_data_ptr + self_i * self_stride;
-            *(result_data_ptr + i * result_stride) = *self_ip;
-          }
-        });
-      });
+    // TODO: fix this when windows can correctly capture variables in nested
+    // lambda
+    if (self.is_quantized()) {
+      AT_DISPATCH_QINT_TYPES(
+          self.scalar_type(),
+          "index_select_quant",
+          [&index_contig, &self, &result, &dim, &numel] {
+            auto self_stride = self.dim() == 0 ? 1 : self.stride(dim);
+            auto result_stride = result.dim() == 0 ? 1 : result.stride(dim);
+            auto self_data_ptr = self.const_data_ptr<scalar_t>();
+            auto result_data_ptr = result.data_ptr<scalar_t>();
+            auto self_numel = self.numel();
+            AT_DISPATCH_INDEX_TYPES(
+                index_contig.scalar_type(),
+                "index_select_out_cpu_quant_",
+                [&index_contig,
+                 &numel,
+                 &self_numel,
+                 &self_data_ptr,
+                 &self_stride,
+                 &result_data_ptr,
+                 &result_stride] {
+                  auto index_data = index_contig.const_data_ptr<index_t>();
+                  for (const auto i : c10::irange(numel)) {
+                    auto self_i = index_data[i];
+                    TORCH_CHECK_INDEX(
+                        (self_i >= 0) && (self_i < self_numel),
+                        "index out of range in self");
+                    const scalar_t* self_ip =
+                        self_data_ptr + self_i * self_stride;
+                    *(result_data_ptr + i * result_stride) = *self_ip;
+                  }
+                });
+          });
     } else {
       AT_DISPATCH_V2(
-        self.scalar_type(), "index_select", AT_WRAP([&index_contig, &self, &result, &dim, &numel] {
-        auto self_stride = self.dim() == 0 ? 1 : self.stride(dim);
-        auto result_stride = result.dim() == 0 ? 1 : result.stride(dim);
+          self.scalar_type(),
+          "index_select",
+          AT_WRAP([&index_contig, &self, &result, &dim, &numel] {
+            auto self_stride = self.dim() == 0 ? 1 : self.stride(dim);
+            auto result_stride = result.dim() == 0 ? 1 : result.stride(dim);
 
-        auto self_data_ptr = self.const_data_ptr<scalar_t>();
-        auto result_data_ptr = result.data_ptr<scalar_t>();
-        auto self_numel = self.numel();
-        AT_DISPATCH_INDEX_TYPES(index_contig.scalar_type(), "index_select_out_cpu_",
-          [&index_contig, &numel, &self_numel, &self_data_ptr, &self_stride, &result_data_ptr, &result_stride] {
-          auto index_data = index_contig.const_data_ptr<index_t>();
-          for (const auto i : c10::irange(numel)) {
-            auto self_i = index_data[i];
-            TORCH_CHECK_INDEX((self_i >= 0) && (self_i < self_numel), "index out of range in self");
-            const scalar_t *self_ip = self_data_ptr + self_i * self_stride;
-            *(result_data_ptr + i * result_stride) = *self_ip;
-          }
-        });
-        }), AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX), ScalarType::ComplexHalf, ScalarType::Half, ScalarType::Bool, ScalarType::BFloat16, AT_EXPAND(AT_FLOAT8_TYPES));
+            auto self_data_ptr = self.const_data_ptr<scalar_t>();
+            auto result_data_ptr = result.data_ptr<scalar_t>();
+            auto self_numel = self.numel();
+            AT_DISPATCH_INDEX_TYPES(
+                index_contig.scalar_type(),
+                "index_select_out_cpu_",
+                [&index_contig,
+                 &numel,
+                 &self_numel,
+                 &self_data_ptr,
+                 &self_stride,
+                 &result_data_ptr,
+                 &result_stride] {
+                  auto index_data = index_contig.const_data_ptr<index_t>();
+                  for (const auto i : c10::irange(numel)) {
+                    auto self_i = index_data[i];
+                    TORCH_CHECK_INDEX(
+                        (self_i >= 0) && (self_i < self_numel),
+                        "index out of range in self");
+                    const scalar_t* self_ip =
+                        self_data_ptr + self_i * self_stride;
+                    *(result_data_ptr + i * result_stride) = *self_ip;
+                  }
+                });
+          }),
+          AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX),
+          ScalarType::ComplexHalf,
+          ScalarType::Half,
+          ScalarType::Bool,
+          ScalarType::BFloat16,
+          AT_EXPAND(AT_FLOAT8_TYPES));
     }
   }
 
   return result;
 }
 
-Tensor index_select_cpu_(const Tensor & self, int64_t dim, const Tensor & index) {
+Tensor index_select_cpu_(const Tensor& self, int64_t dim, const Tensor& index) {
   Tensor result = at::empty({0}, self.options());
   return at::native::index_select_out_cpu_(self, dim, index, result);
 }
 
-Tensor index_select_quantized_cpu_(const Tensor & self, int64_t dim, const Tensor & index) {
-  TORCH_CHECK(self.qscheme() == kPerTensorAffine,
-              "Only per_tensor quantized quantized tensors are supported by index_select.")
+Tensor index_select_quantized_cpu_(
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& index) {
+  TORCH_CHECK(
+      self.qscheme() == kPerTensorAffine,
+      "Only per_tensor quantized quantized tensors are supported by index_select.")
   Tensor result = at::empty_quantized({0}, self);
   return at::native::index_select_out_cpu_(self, dim, index, result);
 }
 
-Tensor index_select_backward_symint(const Tensor& grad, c10::SymIntArrayRef self_sizes, int64_t dim, const Tensor& index) {
+Tensor index_select_backward_symint(
+    const Tensor& grad,
+    c10::SymIntArrayRef self_sizes,
+    int64_t dim,
+    const Tensor& index) {
   // for composite compliance, use out-of-place variant of
   // `index_add` if index tensor is a Tensor Subclass.
   if (isTensorSubclassLike(index)) {
-    return grad.new_zeros_symint(self_sizes, grad.options()).index_add(dim, index, grad);
+    return grad.new_zeros_symint(self_sizes, grad.options())
+        .index_add(dim, index, grad);
   }
-  return grad.new_zeros_symint(self_sizes, grad.options()).index_add_(dim, index, grad);
+  return grad.new_zeros_symint(self_sizes, grad.options())
+      .index_add_(dim, index, grad);
 }
 
-Tensor & index_fill_(Tensor & self, int64_t dim, const Tensor & index, const Scalar& source) {
+Tensor& index_fill_(
+    Tensor& self,
+    int64_t dim,
+    const Tensor& index,
+    const Scalar& source) {
   at::NoNamesGuard guard;
 
   TORCH_CHECK_INDEX(
-    index.scalar_type() == ScalarType::Long,
-    "index_fill_(): Expected dtype int64 for index.");
+      index.scalar_type() == ScalarType::Long,
+      "index_fill_(): Expected dtype int64 for index.");
 
   at::assert_no_overlap(self, index);
   if (at::has_internal_overlap(self) == at::MemOverlap::Yes) {
     TORCH_WARN(
-      "Use of index_fill_ on expanded tensors is deprecated. "
-      "Please clone() the tensor before performing this operation. "
-      "This also applies to advanced indexing e.g. tensor[mask] = scalar");
+        "Use of index_fill_ on expanded tensors is deprecated. "
+        "Please clone() the tensor before performing this operation. "
+        "This also applies to advanced indexing e.g. tensor[mask] = scalar");
   }
 
   if (!self.is_complex() && source.isComplex()) {
-    TORCH_CHECK(false, "index_fill_(): Converting complex Scalar to non-complex type is not supported");
+    TORCH_CHECK(
+        false,
+        "index_fill_(): Converting complex Scalar to non-complex type is not supported");
   }
 
   // Handle the case when `self` is 0-dim
@@ -1507,9 +1943,9 @@ Tensor & index_fill_(Tensor & self, int64_t dim, const Tensor & index, const Sca
   auto index_sizes = std::vector<int64_t>(self_nonzero_dim.dim(), 1);
   auto index_strides = std::vector<int64_t>(self_nonzero_dim.dim(), 0);
   index_sizes[dim] = index.numel();
-  index_strides[dim] = (index.dim() > 0) ? index.stride(0) : 1; // `index` is 1d or scalar
-  auto index_restrided = index.as_strided(
-    index_sizes, index_strides);
+  index_strides[dim] =
+      (index.dim() > 0) ? index.stride(0) : 1; // `index` is 1d or scalar
+  auto index_restrided = index.as_strided(index_sizes, index_strides);
 
   // Prepare `self` for TensorIterator.
   // Restride `self` to not advance in dimension `dim`.
@@ -1527,40 +1963,51 @@ Tensor & index_fill_(Tensor & self, int64_t dim, const Tensor & index, const Sca
   auto self_restrided = self_nonzero_dim.as_strided(self_sizes, self_strides);
 
   auto iter = TensorIteratorConfig()
-    // We do not check for overlap because `self` is restrided
-    // with zero stride. Zero strides trigger memory overlap assert
-    // within TensorIterator.
-    .set_check_mem_overlap(false)
-    .check_all_same_dtype(false)
-    .resize_outputs(false)
-    .add_output(self_restrided)
-    .add_const_input(index_restrided)
-    .build();
+                  // We do not check for overlap because `self` is restrided
+                  // with zero stride. Zero strides trigger memory overlap
+                  // assert within TensorIterator.
+                  .set_check_mem_overlap(false)
+                  .check_all_same_dtype(false)
+                  .resize_outputs(false)
+                  .add_output(self_restrided)
+                  .add_const_input(index_restrided)
+                  .build();
 
   auto self_dim_size = (self_nonzero_dim.sizes())[dim];
   auto self_dim_stride = (self_nonzero_dim.strides())[dim];
   index_fill_stub(
-    iter.device_type(),
-    iter,
-    dim,
-    self_dim_size,
-    self_dim_stride,
-    source);
+      iter.device_type(), iter, dim, self_dim_size, self_dim_stride, source);
 
   return self;
 }
 
-Tensor & index_fill_(Tensor & self, int64_t dim, const Tensor & index, const Tensor & source) {
-  TORCH_CHECK(source.dim() == 0, "index_fill_ only supports a 0-dimensional value tensor, but got tensor "
-      "with ", source.dim(), " dimension(s).");
+Tensor& index_fill_(
+    Tensor& self,
+    int64_t dim,
+    const Tensor& index,
+    const Tensor& source) {
+  TORCH_CHECK(
+      source.dim() == 0,
+      "index_fill_ only supports a 0-dimensional value tensor, but got tensor "
+      "with ",
+      source.dim(),
+      " dimension(s).");
   return self.index_fill_(dim, index, source.item());
 }
 
-Tensor index_fill(const Tensor & self, int64_t dim, const Tensor & index, const Scalar& source) {
+Tensor index_fill(
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& index,
+    const Scalar& source) {
   return self.clone(at::MemoryFormat::Preserve).index_fill_(dim, index, source);
 }
 
-Tensor index_fill(const Tensor & self, int64_t dim, const Tensor & index, const Tensor & source) {
+Tensor index_fill(
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& index,
+    const Tensor& source) {
   return self.clone(at::MemoryFormat::Preserve).index_fill_(dim, index, source);
 }
 
@@ -1594,7 +2041,8 @@ static bool can_use_expanded_index_path(
   }
 
   // skip when having scalar tensor
-  if (self.ndimension() == 0 || index.ndimension() == 0 || src.ndimension() == 0) {
+  if (self.ndimension() == 0 || index.ndimension() == 0 ||
+      src.ndimension() == 0) {
     return false;
   }
 
@@ -1626,28 +2074,41 @@ static bool can_use_expanded_index_path(
   auto index_sizes = index.sizes().vec();
   bool is_index_expanded = index_strides[0] == 1;
   for (const auto dim : c10::irange(1, index_strides.size())) {
-    if (index_strides[dim] > 1 || (index_strides[dim] == 1 && index_sizes[dim] > 1)) {
+    if (index_strides[dim] > 1 ||
+        (index_strides[dim] == 1 && index_sizes[dim] > 1)) {
       is_index_expanded = false;
     }
   }
 
   // index is expanded
-  return dim == 0 && is_index_expanded && src.is_contiguous() && self.is_contiguous();
+  return dim == 0 && is_index_expanded && src.is_contiguous() &&
+      self.is_contiguous();
 }
 
 // gather_out_cpu_cuda
 TORCH_IMPL_FUNC(gather_out)
-(const Tensor& self, int64_t dim, const Tensor& index, bool sparse_grad, const Tensor& result) {
-  if (index.numel() == 0) return;
+(const Tensor& self,
+ int64_t dim,
+ const Tensor& index,
+ bool sparse_grad,
+ const Tensor& result) {
+  if (index.numel() == 0)
+    return;
   dim = at::maybe_wrap_dim(dim, self.dim());
-  if (can_use_expanded_index_path(result, dim, index, self, /*is_scatter_like=*/false)) {
+  if (can_use_expanded_index_path(
+          result, dim, index, self, /*is_scatter_like=*/false)) {
     gather_expanded_index_stub(result.device().type(), result, self, index);
   } else {
     gather_stub(result.device().type(), result, self, dim, index);
   }
 }
 
-Tensor gather_backward(const Tensor& grad, const Tensor& self, int64_t dim, const Tensor& index, bool sparse_grad) {
+Tensor gather_backward(
+    const Tensor& grad,
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& index,
+    bool sparse_grad) {
   if (sparse_grad) {
     return at::_gather_sparse_backward(self, dim, index, grad);
   }
@@ -1662,44 +2123,50 @@ Tensor gather_backward(const Tensor& grad, const Tensor& self, int64_t dim, cons
 }
 
 static void scatter_reduce_exclude_self_helper(
-  const Tensor& self,
-  int64_t dim,
-  const Tensor& index,
-  const ReductionType& op) {
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& index,
+    const ReductionType& op) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
-    at::ScalarType::Half, at::ScalarType::BFloat16, at::ScalarType::Bool,
-    self.scalar_type(), "scatter_reduce_exclude_input_init", [&] {
-    scalar_t init_val;
-    switch (op) {
-      case ReductionType::SUM:
-        init_val = (scalar_t)0;
-        break;
-      case ReductionType::PROD:
-        init_val = (scalar_t)1;
-        break;
-      case ReductionType::MAX:
-        init_val = std::numeric_limits<scalar_t>::has_infinity ? -std::numeric_limits<scalar_t>::infinity()
-                   : std::numeric_limits<scalar_t>::lowest();
-        break;
-      case ReductionType::MIN:
-        init_val = std::numeric_limits<scalar_t>::has_infinity ? std::numeric_limits<scalar_t>::infinity()
-                   : std::numeric_limits<scalar_t>::max();
-        break;
-      case ReductionType::MEAN:
-        init_val = (scalar_t)0;
-        break;
-    }
-    self.scatter_(dim, index, init_val);
-  });
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      at::ScalarType::Bool,
+      self.scalar_type(),
+      "scatter_reduce_exclude_input_init",
+      [&] {
+        scalar_t init_val;
+        switch (op) {
+          case ReductionType::SUM:
+            init_val = (scalar_t)0;
+            break;
+          case ReductionType::PROD:
+            init_val = (scalar_t)1;
+            break;
+          case ReductionType::MAX:
+            init_val = std::numeric_limits<scalar_t>::has_infinity
+                ? -std::numeric_limits<scalar_t>::infinity()
+                : std::numeric_limits<scalar_t>::lowest();
+            break;
+          case ReductionType::MIN:
+            init_val = std::numeric_limits<scalar_t>::has_infinity
+                ? std::numeric_limits<scalar_t>::infinity()
+                : std::numeric_limits<scalar_t>::max();
+            break;
+          case ReductionType::MEAN:
+            init_val = (scalar_t)0;
+            break;
+        }
+        self.scatter_(dim, index, init_val);
+      });
 }
 
 static void _scatter_via_index_put(
-  const Tensor& self,
-  int64_t dim,
-  const Tensor& index,
-  const Tensor& src,
-  const Tensor& mut_out,
-  bool accumulate) {
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& index,
+    const Tensor& src,
+    const Tensor& mut_out,
+    bool accumulate) {
   if (self.dim() == 1) {
     torch::List<std::optional<Tensor>> indices;
     indices.reserve(1);
@@ -1711,19 +2178,20 @@ static void _scatter_via_index_put(
     auto index_coords_sizes = index.sizes().vec();
     index_coords_sizes.push_back(self.dim());
     auto index_coords = at::empty(
-      index_coords_sizes,
-      at::TensorOptions().dtype(at::ScalarType::Long).device(self.device()));
+        index_coords_sizes,
+        at::TensorOptions().dtype(at::ScalarType::Long).device(self.device()));
 
     for (int64_t dim_other = 0; dim_other < self.dim(); dim_other++) {
       if (dim_other == dim) {
         continue;
       }
       auto dim_coord_vals = at::arange(
-        index.size(dim_other),
-        at::TensorOptions().device(self.device()));
+          index.size(dim_other), at::TensorOptions().device(self.device()));
 
-      for (int64_t dim_unsqueeze = 0; dim_unsqueeze < self.dim() - 1; dim_unsqueeze++) {
-        dim_coord_vals = dim_coord_vals.unsqueeze((dim_unsqueeze >= dim_other) ? -1 : 0);
+      for (int64_t dim_unsqueeze = 0; dim_unsqueeze < self.dim() - 1;
+           dim_unsqueeze++) {
+        dim_coord_vals =
+            dim_coord_vals.unsqueeze((dim_unsqueeze >= dim_other) ? -1 : 0);
       }
 
       auto view_sizes = index.sizes().vec();
@@ -1731,12 +2199,8 @@ static void _scatter_via_index_put(
       auto view_strides = index_coords.strides().vec();
       view_strides[self.dim()] = self.dim();
 
-      at::as_strided(
-        index_coords,
-        view_sizes,
-        view_strides,
-        dim_other
-      ).copy_(dim_coord_vals.unsqueeze(-1));
+      at::as_strided(index_coords, view_sizes, view_strides, dim_other)
+          .copy_(dim_coord_vals.unsqueeze(-1));
     }
 
     auto view_sizes = index.sizes().vec();
@@ -1744,12 +2208,8 @@ static void _scatter_via_index_put(
     auto view_strides = index_coords.strides().vec();
     view_strides[self.dim()] = self.dim();
 
-    at::as_strided(
-      index_coords,
-      view_sizes,
-      view_strides,
-      dim
-    ).copy_(index.unsqueeze(-1));
+    at::as_strided(index_coords, view_sizes, view_strides, dim)
+        .copy_(index.unsqueeze(-1));
 
     Tensor index_coords_flat = index_coords.flatten(0, -2);
 
@@ -1757,23 +2217,20 @@ static void _scatter_via_index_put(
     // TODO: Is there a utility function that already does this?
     IntArrayRef mut_out_contig_strides = mut_out_contig.strides();
     Tensor coord_strides = at::empty(
-      {mut_out_contig.dim()},
-      TensorOptions().dtype(at::ScalarType::Long).device(at::kCPU));
+        {mut_out_contig.dim()},
+        TensorOptions().dtype(at::ScalarType::Long).device(at::kCPU));
     std::memcpy(
-      coord_strides.mutable_data_ptr(),
-      mut_out_contig_strides.data(),
-      coord_strides.nbytes());
+        coord_strides.mutable_data_ptr(),
+        mut_out_contig_strides.data(),
+        coord_strides.nbytes());
     coord_strides = coord_strides.to(mut_out_contig.device());
 
     // `index_flat` contains the 1-D indices corresponding with the
     // flattened `mut_out`
     Tensor index_flat = (index_coords_flat * coord_strides).sum({-1});
     Tensor mut_out_flat = mut_out_contig.flatten();
-    Tensor src_flat = at::as_strided(
-      src,
-      index.sizes(),
-      src.strides()
-    ).flatten();
+    Tensor src_flat =
+        at::as_strided(src, index.sizes(), src.strides()).flatten();
 
     torch::List<std::optional<Tensor>> indices;
     indices.reserve(1);
@@ -1787,7 +2244,11 @@ static void _scatter_via_index_put(
   }
 }
 
-template <bool use_new_options = false, typename T, typename ReduceStub, typename FillStub>
+template <
+    bool use_new_options = false,
+    typename T,
+    typename ReduceStub,
+    typename FillStub>
 void scatter_impl(
     const Tensor& self,
     int64_t dim,
@@ -1798,7 +2259,6 @@ void scatter_impl(
     FillStub& fill_stub,
     const std::optional<std::string_view> reduce = std::nullopt,
     bool reduce_includes_self = true) {
-
   dim = at::maybe_wrap_dim(dim, self.dim());
   auto mut_out = const_cast<Tensor&>(out);
 
@@ -1806,19 +2266,24 @@ void scatter_impl(
     mut_out.copy_(self);
   }
 
-  if (index.numel() == 0) return;
+  if (index.numel() == 0)
+    return;
 
   auto op = ReductionType::SUM;
-  bool deterministic = globalContext().deterministicAlgorithms() && (self.device().type() == DeviceType::CUDA || self.device().type() == DeviceType::XPU);
+  bool deterministic = globalContext().deterministicAlgorithms() &&
+      (self.device().type() == DeviceType::CUDA ||
+       self.device().type() == DeviceType::XPU);
 
   if (reduce.has_value()) {
     op = get_operator_enum(reduce.value(), use_new_options);
     if (!reduce_includes_self) {
-      // scatter inits for reduction to appropriate indices (used by scatter_reduce.two)
+      // scatter inits for reduction to appropriate indices (used by
+      // scatter_reduce.two)
       scatter_reduce_exclude_self_helper(mut_out, dim, index, op);
     }
     // _scatter_via_index_put can only handle sum and mean reduction type
-    deterministic = deterministic && (op == ReductionType::SUM || op == ReductionType::MEAN);
+    deterministic = deterministic &&
+        (op == ReductionType::SUM || op == ReductionType::MEAN);
   }
 
   // Scalar src should already be deterministic
@@ -1844,9 +2309,7 @@ TORCH_IMPL_FUNC(scatter_src_out)
  const Tensor& index,
  const Tensor& src,
  const Tensor& out) {
-  scatter_impl(self, dim, index, src, out,
-               scatter_reduce_stub,
-               scatter_stub);
+  scatter_impl(self, dim, index, src, out, scatter_reduce_stub, scatter_stub);
 }
 
 TORCH_IMPL_FUNC(scatter_value_out)
@@ -1855,9 +2318,14 @@ TORCH_IMPL_FUNC(scatter_value_out)
  const Tensor& index,
  const Scalar& value,
  const Tensor& out) {
-  scatter_impl(self, dim, index, value, out,
-               scatter_scalar_reduce_stub,
-               scatter_fill_stub);
+  scatter_impl(
+      self,
+      dim,
+      index,
+      value,
+      out,
+      scatter_scalar_reduce_stub,
+      scatter_fill_stub);
 }
 
 TORCH_IMPL_FUNC(scatter_reduce_out)
@@ -1867,10 +2335,8 @@ TORCH_IMPL_FUNC(scatter_reduce_out)
  const Tensor& src,
  const std::string_view reduce,
  const Tensor& out) {
-  scatter_impl(self, dim, index, src, out,
-               scatter_reduce_stub,
-               scatter_stub,
-               reduce);
+  scatter_impl(
+      self, dim, index, src, out, scatter_reduce_stub, scatter_stub, reduce);
 }
 
 TORCH_IMPL_FUNC(scatter_value_reduce_out)
@@ -1880,10 +2346,15 @@ TORCH_IMPL_FUNC(scatter_value_reduce_out)
  const Scalar& value,
  const std::string_view reduce,
  const Tensor& out) {
-  scatter_impl(self, dim, index, value, out,
-               scatter_scalar_reduce_stub,
-               scatter_fill_stub,
-               reduce);
+  scatter_impl(
+      self,
+      dim,
+      index,
+      value,
+      out,
+      scatter_scalar_reduce_stub,
+      scatter_fill_stub,
+      reduce);
 }
 
 TORCH_IMPL_FUNC(scatter_add)
@@ -1899,15 +2370,20 @@ TORCH_IMPL_FUNC(scatter_add)
     mut_out.copy_(self);
   }
 
-  if (index.numel() == 0) return;
+  if (index.numel() == 0)
+    return;
 
   // See Note [Enabling Deterministic Operations]
   // Avoid gpuAtomicAdd for CUDA and XPU if deterministic mode is turned on
-  if (globalContext().deterministicAlgorithms() && (self.device().type() == DeviceType::CUDA || self.device().type() == DeviceType::XPU)) {
-    _scatter_via_index_put(self, dim, index, src, mut_out, /*accumulate*/true);
+  if (globalContext().deterministicAlgorithms() &&
+      (self.device().type() == DeviceType::CUDA ||
+       self.device().type() == DeviceType::XPU)) {
+    _scatter_via_index_put(self, dim, index, src, mut_out, /*accumulate*/ true);
   } else {
-    if (can_use_expanded_index_path(mut_out, dim, index, src, /*is_scatter_like*/true)) {
-      scatter_add_expanded_index_stub(self.device().type(), mut_out, index, src);
+    if (can_use_expanded_index_path(
+            mut_out, dim, index, src, /*is_scatter_like*/ true)) {
+      scatter_add_expanded_index_stub(
+          self.device().type(), mut_out, index, src);
     } else {
       scatter_add_stub(self.device().type(), mut_out, dim, index, src);
     }
@@ -1922,7 +2398,6 @@ TORCH_IMPL_FUNC(scatter_reduce_two)
  const std::string_view reduce,
  bool include_self,
  const Tensor& out) {
-
   dim = at::maybe_wrap_dim(dim, self.dim());
 
   if (!self.is_same(out)) {
@@ -1931,16 +2406,23 @@ TORCH_IMPL_FUNC(scatter_reduce_two)
 
   const auto op = get_operator_enum(reduce, true);
 
-  if (can_use_expanded_index_path(out, dim, index, src, /*is_scatter_like*/true)) {
-    scatter_reduce_expanded_index_stub(self.device().type(), out, index, src, op, include_self);
+  if (can_use_expanded_index_path(
+          out, dim, index, src, /*is_scatter_like*/ true)) {
+    scatter_reduce_expanded_index_stub(
+        self.device().type(), out, index, src, op, include_self);
     return;
   }
 
-  scatter_impl</*use_new_options=*/true>(self, dim, index, src, out,
-                                         scatter_reduce_two_stub,
-                                         scatter_stub,
-                                         reduce,
-                                         include_self);
+  scatter_impl</*use_new_options=*/true>(
+      self,
+      dim,
+      index,
+      src,
+      out,
+      scatter_reduce_two_stub,
+      scatter_stub,
+      reduce,
+      include_self);
 
   if (op == ReductionType::MEAN) {
     auto ones = at::ones_like(src);
@@ -1956,9 +2438,13 @@ TORCH_IMPL_FUNC(scatter_reduce_two)
   }
 }
 
-Tensor masked_scatter(const Tensor & self, const Tensor & mask, const Tensor & source) {
+Tensor masked_scatter(
+    const Tensor& self,
+    const Tensor& mask,
+    const Tensor& source) {
   auto [_mask, _self] = expand_outplace(mask, self);
-  return _self->clone(at::MemoryFormat::Contiguous).masked_scatter_(*_mask, source);
+  return _self->clone(at::MemoryFormat::Contiguous)
+      .masked_scatter_(*_mask, source);
 }
 
 Tensor masked_scatter_backward_symint(
@@ -1982,52 +2468,75 @@ Tensor masked_scatter_backward_symint(
   return mask_selected.view_symint(sizes);
 }
 
-static Tensor & masked_fill_impl_cpu(Tensor & self, const Tensor & mask, const Scalar& value) {
+static Tensor& masked_fill_impl_cpu(
+    Tensor& self,
+    const Tensor& mask,
+    const Scalar& value) {
   NoNamesGuard guard;
-  TORCH_CHECK(mask.dtype() == ScalarType::Bool, "masked_fill_ only supports boolean masks, but got mask "
-      "with dtype ", mask.dtype());
+  TORCH_CHECK(
+      mask.dtype() == ScalarType::Bool,
+      "masked_fill_ only supports boolean masks, but got mask "
+      "with dtype ",
+      mask.dtype());
 
   if (at::has_internal_overlap(self) == MemOverlap::Yes) {
     TORCH_WARN(
-      "Use of masked_fill_ on expanded tensors is deprecated. "
-      "Please clone() the tensor before performing this operation. "
-      "This also applies to advanced indexing e.g. tensor[mask] = scalar");
+        "Use of masked_fill_ on expanded tensors is deprecated. "
+        "Please clone() the tensor before performing this operation. "
+        "This also applies to advanced indexing e.g. tensor[mask] = scalar");
   }
   at::assert_no_partial_overlap(self, mask);
 
-  auto iter = TensorIteratorConfig()
-    .set_check_mem_overlap(false)  // deprecated, but not a hard error
-    .check_all_same_dtype(false)
-    .resize_outputs(false)
-    .add_output(self)
-    .add_const_input(mask)
-    .build();
+  auto iter =
+      TensorIteratorConfig()
+          .set_check_mem_overlap(false) // deprecated, but not a hard error
+          .check_all_same_dtype(false)
+          .resize_outputs(false)
+          .add_output(self)
+          .add_const_input(mask)
+          .build();
 
   masked_fill_stub(iter.device_type(), iter, value);
   return self;
 }
 
-Tensor & masked_fill__cpu(Tensor& self, const Tensor & mask, const Scalar& value) {
-  auto maybe_outnames = namedinference::broadcast_to_outnames(self, mask, "masked_fill_");
+Tensor& masked_fill__cpu(
+    Tensor& self,
+    const Tensor& mask,
+    const Scalar& value) {
+  auto maybe_outnames =
+      namedinference::broadcast_to_outnames(self, mask, "masked_fill_");
 
   masked_fill_impl_cpu(self, mask, value);
   namedinference::propagate_names_if_nonempty(self, maybe_outnames);
   return self;
 }
 
-Tensor & masked_fill__cpu(Tensor& self, const Tensor & mask, const Tensor & value) {
-  auto maybe_outnames = namedinference::broadcast_to_outnames(self, mask, "masked_fill_");
-  TORCH_CHECK(value.dim() == 0, "masked_fill_ only supports a 0-dimensional value tensor, but got tensor "
-      "with ", value.dim(), " dimension(s).");
+Tensor& masked_fill__cpu(
+    Tensor& self,
+    const Tensor& mask,
+    const Tensor& value) {
+  auto maybe_outnames =
+      namedinference::broadcast_to_outnames(self, mask, "masked_fill_");
+  TORCH_CHECK(
+      value.dim() == 0,
+      "masked_fill_ only supports a 0-dimensional value tensor, but got tensor "
+      "with ",
+      value.dim(),
+      " dimension(s).");
 
   masked_fill_impl_cpu(self, mask, value.item());
   namedinference::propagate_names_if_nonempty(self, maybe_outnames);
   return self;
 }
 
-Tensor masked_fill(const Tensor & self, const Tensor & mask, const Scalar& source) {
+Tensor masked_fill(
+    const Tensor& self,
+    const Tensor& mask,
+    const Scalar& source) {
   Tensor result;
-  auto maybe_outnames = namedinference::broadcast_to_outnames(mask, self, "masked_fill");
+  auto maybe_outnames =
+      namedinference::broadcast_to_outnames(mask, self, "masked_fill");
   {
     NoNamesGuard guard;
     auto [_mask, _self] = expand_outplace(mask, self);
@@ -2038,9 +2547,13 @@ Tensor masked_fill(const Tensor & self, const Tensor & mask, const Scalar& sourc
   return result;
 }
 
-Tensor masked_fill(const Tensor & self, const Tensor & mask, const Tensor & source) {
+Tensor masked_fill(
+    const Tensor& self,
+    const Tensor& mask,
+    const Tensor& source) {
   Tensor result;
-  auto maybe_outnames = namedinference::broadcast_to_outnames(mask, self, "masked_fill");
+  auto maybe_outnames =
+      namedinference::broadcast_to_outnames(mask, self, "masked_fill");
   {
     NoNamesGuard guard;
     auto [_mask, _self] = expand_outplace(mask, self);
@@ -2051,13 +2564,18 @@ Tensor masked_fill(const Tensor & self, const Tensor & mask, const Tensor & sour
   return result;
 }
 
-static Tensor & masked_select_out_impl_cpu(Tensor & result, const Tensor & self, const Tensor & mask) {
+static Tensor& masked_select_out_impl_cpu(
+    Tensor& result,
+    const Tensor& self,
+    const Tensor& mask) {
   NoNamesGuard guard;
 
-  TORCH_CHECK(mask.scalar_type() == ScalarType::Bool,
-              "masked_select: expected BoolTensor for mask");
-  TORCH_CHECK(self.scalar_type() == result.scalar_type(),
-              "masked_select(): self and result must have the same scalar type");
+  TORCH_CHECK(
+      mask.scalar_type() == ScalarType::Bool,
+      "masked_select: expected BoolTensor for mask");
+  TORCH_CHECK(
+      self.scalar_type() == result.scalar_type(),
+      "masked_select(): self and result must have the same scalar type");
 
   at::assert_no_internal_overlap(result);
   at::assert_no_overlap(result, self);
@@ -2078,21 +2596,25 @@ static Tensor & masked_select_out_impl_cpu(Tensor & result, const Tensor & self,
   auto result_strided = result.as_strided(shape, strides);
 
   // serial kernel
-  // serial kernel requires that src is traversed in its logical order. However, TensorIterator might
-  // have reordered dimensions so that src would be traversed in its physical order, producing wrong
-  // answers. A sufficient condition that no reorder happened is that both _self and _mask is contiguous.
-  // If it is not satisfied, use parallel kernel that handles permutations correctly
-  bool use_serial_kernel = (self.numel() < at::internal::GRAIN_SIZE || at::get_num_threads() == 1 ) &&
-  _self->is_contiguous() && _mask->is_contiguous();
+  // serial kernel requires that src is traversed in its logical order. However,
+  // TensorIterator might have reordered dimensions so that src would be
+  // traversed in its physical order, producing wrong answers. A sufficient
+  // condition that no reorder happened is that both _self and _mask is
+  // contiguous. If it is not satisfied, use parallel kernel that handles
+  // permutations correctly
+  bool use_serial_kernel =
+      (self.numel() < at::internal::GRAIN_SIZE || at::get_num_threads() == 1) &&
+      _self->is_contiguous() && _mask->is_contiguous();
   if (use_serial_kernel) {
     auto iter = TensorIteratorConfig()
-      .set_check_mem_overlap(false)  // result is intentionally zero-strided above
-      .check_all_same_dtype(false)
-      .resize_outputs(false)
-      .add_output(result_strided)
-      .add_const_input(*_self)
-      .add_const_input(*_mask)
-      .build();
+                    .set_check_mem_overlap(
+                        false) // result is intentionally zero-strided above
+                    .check_all_same_dtype(false)
+                    .resize_outputs(false)
+                    .add_output(result_strided)
+                    .add_const_input(*_self)
+                    .add_const_input(*_mask)
+                    .build();
 
     masked_select_serial_stub(iter.device_type(), iter, orig_stride);
     return result;
@@ -2100,47 +2622,59 @@ static Tensor & masked_select_out_impl_cpu(Tensor & result, const Tensor & self,
 
   // Use a prefix sum to record the output locations of the masked elements,
   // so as to parallel with TensorIterator.
-  auto mask_long = at::empty(shape, self.options().dtype(at::kLong)).copy_(*_mask);
+  auto mask_long =
+      at::empty(shape, self.options().dtype(at::kLong)).copy_(*_mask);
   auto mask_prefix_sum = at::empty(shape, self.options().dtype(at::kLong));
   auto mask_long_data = mask_long.data_ptr<int64_t>();
   auto mask_prefix_sum_data = mask_prefix_sum.data_ptr<int64_t>();
   // TODO: Here can only use std::partial_sum for C++14,
-  // use std::exclusive_scan when PyTorch upgrades to C++17, which have better performance.
-  // std::exclusive_scan(mask_long_data, mask_long_data + mask_long.numel(), mask_prefix_sum_data, 0);
-  std::partial_sum(mask_long_data, mask_long_data + mask_long.numel(), mask_prefix_sum_data);
+  // use std::exclusive_scan when PyTorch upgrades to C++17, which have better
+  // performance. std::exclusive_scan(mask_long_data, mask_long_data +
+  // mask_long.numel(), mask_prefix_sum_data, 0);
+  std::partial_sum(
+      mask_long_data, mask_long_data + mask_long.numel(), mask_prefix_sum_data);
 
   auto iter = TensorIteratorConfig()
-    .set_check_mem_overlap(false)  // result is intentionally zero-strided above
-    .check_all_same_dtype(false)
-    .resize_outputs(false)
-    .add_output(result_strided)
-    .add_const_input(*_self)
-    .add_const_input(*_mask)
-    .add_const_input(mask_prefix_sum)
-    .build();
+                  .set_check_mem_overlap(
+                      false) // result is intentionally zero-strided above
+                  .check_all_same_dtype(false)
+                  .resize_outputs(false)
+                  .add_output(result_strided)
+                  .add_const_input(*_self)
+                  .add_const_input(*_mask)
+                  .add_const_input(mask_prefix_sum)
+                  .build();
 
   masked_select_stub(iter.device_type(), iter, orig_stride);
   return result;
 }
 
-Tensor & masked_select_out_cpu(const Tensor & self, const Tensor & mask, Tensor & result) {
+Tensor& masked_select_out_cpu(
+    const Tensor& self,
+    const Tensor& mask,
+    Tensor& result) {
   namedinference::compute_broadcast_outnames(self, mask);
   return masked_select_out_impl_cpu(result, self, mask);
 }
 
-Tensor masked_select_cpu(const Tensor & self, const Tensor & mask) {
+Tensor masked_select_cpu(const Tensor& self, const Tensor& mask) {
   Tensor result = at::empty({0}, self.options());
   return at::native::masked_select_out_cpu(self, mask, result);
 }
 
-Tensor masked_select_backward(const Tensor& grad, const Tensor& input, const Tensor& mask) {
-  // The following could just be written as `zeros_like(input).masked_scatter(mask, grad)`.
-  // However, as an optimization, we call the in-place variant of masked_scatter.
-  // Unfortunately, that doesn't allow for the broadcasting of the LHS, so we need
-  // to explicitly broadcast here (the out-of-place variant of masked_scatter
-  // implicitly handles broadcasting).
+Tensor masked_select_backward(
+    const Tensor& grad,
+    const Tensor& input,
+    const Tensor& mask) {
+  // The following could just be written as
+  // `zeros_like(input).masked_scatter(mask, grad)`. However, as an
+  // optimization, we call the in-place variant of masked_scatter.
+  // Unfortunately, that doesn't allow for the broadcasting of the LHS, so we
+  // need to explicitly broadcast here (the out-of-place variant of
+  // masked_scatter implicitly handles broadcasting).
   auto result = at::zeros_like(
-      input.expand(at::infer_size(input.sizes(), mask.sizes())), at::MemoryFormat::Preserve);
+      input.expand(at::infer_size(input.sizes(), mask.sizes())),
+      at::MemoryFormat::Preserve);
 
   // for composite compliance, use out-of-place variant
   // of `masked_scatter`.
@@ -2160,10 +2694,15 @@ inline std::tuple<Tensor, Tensor, int64_t> _take_along_dim_helper(
   TORCH_CHECK(
       self.dim() == indices.dim(),
       "torch.take_along_dim(): input and indices should have the same number of dimensions, ",
-      "but got ", self.dim(), " dimensions for input, and ", indices.dim(), " dimensions for indices")
+      "but got ",
+      self.dim(),
+      " dimensions for input, and ",
+      indices.dim(),
+      " dimensions for indices")
   TORCH_CHECK(
       indices.scalar_type() == ScalarType::Long,
-      "torch.take_along_dim(): dtype of indices should be Long but got ", indices.scalar_type())
+      "torch.take_along_dim(): dtype of indices should be Long but got ",
+      indices.scalar_type())
 
   dim = at::maybe_wrap_dim(dim, self.dim());
 
@@ -2179,28 +2718,40 @@ inline std::tuple<Tensor, Tensor, int64_t> _take_along_dim_helper(
   broadcast_shape = infer_size_symint(indices_sizes, self.sym_sizes());
   auto self_broadcasted = at::broadcast_to_symint(self, broadcast_shape);
 
-  return std::make_tuple(std::move(self_broadcasted),
-                         std::move(indices_broadcasted),
-                         std::move(dim));
+  return std::make_tuple(
+      std::move(self_broadcasted),
+      std::move(indices_broadcasted),
+      std::move(dim));
 }
 
 static inline void checkDevice(CheckedFrom c, const Tensor& t, Device device) {
   TORCH_CHECK(
       !t.defined() || t.device() == device,
-      "Expected tensor to have ", device,
-      " Device, but got tensor with ", t.device(), " Device ",
-      "(while checking arguments for ", c, ")");
+      "Expected tensor to have ",
+      device,
+      " Device, but got tensor with ",
+      t.device(),
+      " Device ",
+      "(while checking arguments for ",
+      c,
+      ")");
 }
 
-static inline void checkDevice(CheckedFrom c, at::ArrayRef<Tensor> tensors, Device device) {
-  for (auto &t : tensors) {
+static inline void checkDevice(
+    CheckedFrom c,
+    at::ArrayRef<Tensor> tensors,
+    Device device) {
+  for (auto& t : tensors) {
     checkDevice(c, t, device);
   }
 }
 
 } // anonymous namespace
 
-Tensor take_along_dim(const Tensor& self, const Tensor& indices, std::optional<int64_t> opt_dim) {
+Tensor take_along_dim(
+    const Tensor& self,
+    const Tensor& indices,
+    std::optional<int64_t> opt_dim) {
   checkDevice("torch.take_along_dim():", {self, indices}, self.device());
   if (opt_dim.has_value()) {
     auto [self_broadcasted, indices_broadcasted, dim] =
@@ -2212,8 +2763,13 @@ Tensor take_along_dim(const Tensor& self, const Tensor& indices, std::optional<i
   return self.view(-1).gather(0, indices.view(-1));
 }
 
-Tensor& take_along_dim_out(const Tensor& self, const Tensor& indices, std::optional<int64_t> opt_dim, Tensor& result) {
-  checkDevice("torch.take_along_dim():", {self, indices, result}, self.device());
+Tensor& take_along_dim_out(
+    const Tensor& self,
+    const Tensor& indices,
+    std::optional<int64_t> opt_dim,
+    Tensor& result) {
+  checkDevice(
+      "torch.take_along_dim():", {self, indices, result}, self.device());
   if (opt_dim.has_value()) {
     auto [self_broadcasted, indices_broadcasted, dim] =
         _take_along_dim_helper(self, indices, opt_dim.value());
@@ -2224,27 +2780,45 @@ Tensor& take_along_dim_out(const Tensor& self, const Tensor& indices, std::optio
   return at::gather_out(result, self.view(-1), 0, indices.view(-1));
 }
 
-Tensor _gather_sparse_backward(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& grad){
-// special case scalar input and/or index
-    if (self.ndimension() == 0) return at::_sparse_coo_tensor_unsafe_symint(at::empty_symint({0,grad.sym_numel()}, index.options()), grad, self.sym_sizes());
-    if (grad.ndimension() == 0) return at::_sparse_coo_tensor_unsafe_symint(index.view({1,1}), grad, self.sym_sizes());
-    Tensor sparse_ind = at::empty_symint({self.ndimension(), grad.sym_numel()}, self.options().dtype(at::kLong));
-    SymInt grad_numel = grad.sym_numel();
-    if (grad_numel > 0) {
-      SymInt n_above = grad_numel;
-      SymInt n_below = 1;
-      if (dim < 0) dim += self.ndimension();
-      for (const auto i : c10::irange(self.ndimension())) {
-          n_above /= grad.sym_size(i);
-          if (i == dim) {
-              sparse_ind[i] = index.reshape(-1);
-          } else {
-              sparse_ind[i] = at::arange(grad.sym_size(i),self.options().dtype(at::kLong)).unsqueeze(1).expand_symint({grad.sym_size(i), n_above}).reshape(-1).repeat_symint(n_below);
-          }
-          n_below *= grad.sym_size(i);
+Tensor _gather_sparse_backward(
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& index,
+    const Tensor& grad) {
+  // special case scalar input and/or index
+  if (self.ndimension() == 0)
+    return at::_sparse_coo_tensor_unsafe_symint(
+        at::empty_symint({0, grad.sym_numel()}, index.options()),
+        grad,
+        self.sym_sizes());
+  if (grad.ndimension() == 0)
+    return at::_sparse_coo_tensor_unsafe_symint(
+        index.view({1, 1}), grad, self.sym_sizes());
+  Tensor sparse_ind = at::empty_symint(
+      {self.ndimension(), grad.sym_numel()}, self.options().dtype(at::kLong));
+  SymInt grad_numel = grad.sym_numel();
+  if (grad_numel > 0) {
+    SymInt n_above = grad_numel;
+    SymInt n_below = 1;
+    if (dim < 0)
+      dim += self.ndimension();
+    for (const auto i : c10::irange(self.ndimension())) {
+      n_above /= grad.sym_size(i);
+      if (i == dim) {
+        sparse_ind[i] = index.reshape(-1);
+      } else {
+        sparse_ind[i] =
+            at::arange(grad.sym_size(i), self.options().dtype(at::kLong))
+                .unsqueeze(1)
+                .expand_symint({grad.sym_size(i), n_above})
+                .reshape(-1)
+                .repeat_symint(n_below);
       }
+      n_below *= grad.sym_size(i);
     }
-    return at::_sparse_coo_tensor_unsafe_symint(sparse_ind, grad.reshape(-1), self.sym_sizes());
+  }
+  return at::_sparse_coo_tensor_unsafe_symint(
+      sparse_ind, grad.reshape(-1), self.sym_sizes());
 }
 
 template <typename scalar_t>
@@ -2284,7 +2858,7 @@ int64_t count_nonzero_impl(TensorIteratorBase& iter, Range range) {
   return num_nonzero;
 }
 
-Tensor count_nonzero_cuda(const Tensor& self, IntArrayRef dims){
+Tensor count_nonzero_cuda(const Tensor& self, IntArrayRef dims) {
   auto reduce = self;
   if (reduce.scalar_type() != kBool) {
     reduce = reduce != 0;
@@ -2292,7 +2866,7 @@ Tensor count_nonzero_cuda(const Tensor& self, IntArrayRef dims){
   return reduce.sum(dims);
 }
 
-Tensor count_nonzero_cpu(const Tensor& self, IntArrayRef dims){
+Tensor count_nonzero_cpu(const Tensor& self, IntArrayRef dims) {
   if (!dims.empty()) {
     auto reduce = self;
     if (reduce.scalar_type() != kBool) {
@@ -2302,20 +2876,29 @@ Tensor count_nonzero_cpu(const Tensor& self, IntArrayRef dims){
   }
 
   // Optimized all-reduce
-  auto iter = TensorIteratorConfig()
-      .add_const_input(self)
-      .build();
+  auto iter = TensorIteratorConfig().add_const_input(self).build();
 
   const auto num_threads = at::get_num_threads();
   DimVector thread_count_nonzero(num_threads);
 
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(
-      kComplexHalf, kHalf, kBFloat16, kBool, self.scalar_type(), "nonzero_count_cpu", [&] {
-    at::parallel_for(0, iter.numel(), internal::GRAIN_SIZE, [&] (int64_t begin, int64_t end) {
-      const auto tid = at::get_thread_num();
-      thread_count_nonzero[tid] = count_nonzero_impl<scalar_t>(iter, {begin, end});
-    });
-  });
+      kComplexHalf,
+      kHalf,
+      kBFloat16,
+      kBool,
+      self.scalar_type(),
+      "nonzero_count_cpu",
+      [&] {
+        at::parallel_for(
+            0,
+            iter.numel(),
+            internal::GRAIN_SIZE,
+            [&](int64_t begin, int64_t end) {
+              const auto tid = at::get_thread_num();
+              thread_count_nonzero[tid] =
+                  count_nonzero_impl<scalar_t>(iter, {begin, end});
+            });
+      });
 
   for (const auto i : c10::irange(1, num_threads)) {
     thread_count_nonzero[0] += thread_count_nonzero[i];
@@ -2325,7 +2908,6 @@ Tensor count_nonzero_cpu(const Tensor& self, IntArrayRef dims){
   return out;
 }
 
-
 Tensor count_nonzero(const Tensor& self, std::optional<int64_t> dim) {
   if (dim) {
     return at::count_nonzero(self, IntArrayRef{*dim});
@@ -2333,18 +2915,19 @@ Tensor count_nonzero(const Tensor& self, std::optional<int64_t> dim) {
   return at::count_nonzero(self, IntArrayRef{});
 }
 
-
 Tensor& nonzero_out_cpu(const Tensor& self, Tensor& result) {
-  TORCH_CHECK(result.scalar_type() == kLong,
-              "nonzero: Expected out tensor to have scalar type Long "
-              "but got scalar type", result.scalar_type());
+  TORCH_CHECK(
+      result.scalar_type() == kLong,
+      "nonzero: Expected out tensor to have scalar type Long "
+      "but got scalar type",
+      result.scalar_type());
   at::assert_no_internal_overlap(result);
   at::assert_no_overlap(result, self);
 
   auto iter = TensorIteratorConfig()
-    .add_const_input(self)
-    .enforce_linear_iteration()
-    .build();
+                  .add_const_input(self)
+                  .enforce_linear_iteration()
+                  .build();
 
   const auto numel = iter.numel();
   const auto num_threads = at::get_num_threads();
@@ -2353,13 +2936,21 @@ Tensor& nonzero_out_cpu(const Tensor& self, Tensor& result) {
 
   // Pass 1: Count nonzero element per-thread
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(
-      kComplexHalf, kHalf, kBFloat16, kBool, self.scalar_type(), "nonzero_count_cpu", [&] {
-    at::parallel_for(0, numel, internal::GRAIN_SIZE, [&] (int64_t begin, int64_t end) {
-      const auto tid = at::get_thread_num();
-      thread_begin[tid] = begin;
-      thread_count_nonzero[tid + 1] = count_nonzero_impl<scalar_t>(iter, {begin, end});
-    });
-  });
+      kComplexHalf,
+      kHalf,
+      kBFloat16,
+      kBool,
+      self.scalar_type(),
+      "nonzero_count_cpu",
+      [&] {
+        at::parallel_for(
+            0, numel, internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+              const auto tid = at::get_thread_num();
+              thread_begin[tid] = begin;
+              thread_count_nonzero[tid + 1] =
+                  count_nonzero_impl<scalar_t>(iter, {begin, end});
+            });
+      });
 
   // Convert thread-local counts to cumulative sum
   for (const auto i : c10::irange(1, thread_count_nonzero.size())) {
@@ -2382,66 +2973,80 @@ Tensor& nonzero_out_cpu(const Tensor& self, Tensor& result) {
 
   // Pass 2: Write indexes
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(
-      kComplexHalf, kHalf, kBFloat16, kBool, self.scalar_type(), "nonzero_cpu", [&] {
-    at::parallel_for(0, numel, internal::GRAIN_SIZE, [&] (int64_t begin, int64_t end) {
-      auto tid = at::get_thread_num();
-      // Work needs to be distributed the same on both passes
-      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(begin == thread_begin[tid]);
+      kComplexHalf,
+      kHalf,
+      kBFloat16,
+      kBool,
+      self.scalar_type(),
+      "nonzero_cpu",
+      [&] {
+        at::parallel_for(
+            0, numel, internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+              auto tid = at::get_thread_num();
+              // Work needs to be distributed the same on both passes
+              TORCH_INTERNAL_ASSERT_DEBUG_ONLY(begin == thread_begin[tid]);
 
-      // +1 faster than additional condition check inside loop
-      c10::SmallVector<int64_t, 33> sizes(ndim + 1, -1);
-      std::copy(self_sizes.begin(), self_sizes.end(), sizes.begin() + 1);
-      c10::SmallVector<int64_t, 33> current_idx(ndim + 1);
-      if (begin > 0) {
-        auto idx = begin;
-        for (int64_t k = ndim; idx > 0 && k > 0; --k) {
-          current_idx[k] = idx % sizes[k];
-          idx /= sizes[k];
-        }
-      }
-
-      auto out_ptr = out_accessor[thread_count_nonzero[tid]].data();
-
-      auto loop = [&](char** data, const int64_t* strides, int64_t n1, int64_t n2) {
-        // Copy into local variables to improve compiler alias analysis
-        int64_t* C10_RESTRICT local_idx = current_idx.data() + 1;
-        const int64_t* C10_RESTRICT local_sizes = sizes.data() + 1;
-        const auto in_stride = strides[0];
-        const auto out_stride1 = out_accessor.stride(1);
-        const auto out_stride0 = out_accessor.stride(0) - ndim * out_stride1;
-        const auto ndim = out_accessor.size(1);
-        int64_t* out = out_ptr;
-
-        for (const auto i : c10::irange(n2)) {
-          const char* ptr = data[0] + i * strides[1];
-          for ([[maybe_unused]] const auto j : c10::irange(n1)) {
-            const auto& val = c10::load<scalar_t>(ptr);
-            // If nonzero, write index
-            if (val != scalar_t(0)) {
-              for (const auto k : c10::irange(ndim)) {
-                *out = local_idx[k];
-                out += out_stride1;
+              // +1 faster than additional condition check inside loop
+              c10::SmallVector<int64_t, 33> sizes(ndim + 1, -1);
+              std::copy(
+                  self_sizes.begin(), self_sizes.end(), sizes.begin() + 1);
+              c10::SmallVector<int64_t, 33> current_idx(ndim + 1);
+              if (begin > 0) {
+                auto idx = begin;
+                for (int64_t k = ndim; idx > 0 && k > 0; --k) {
+                  current_idx[k] = idx % sizes[k];
+                  idx /= sizes[k];
+                }
               }
-              out += out_stride0;
-            }
-            ptr += in_stride;
 
-            // Advance current index
-            int64_t k = ndim - 1;
-            ++local_idx[k];
-            while (C10_UNLIKELY(local_idx[k] == local_sizes[k])) {
-              local_idx[k] = 0;
-              --k;
-              ++local_idx[k];
-            }
-          }
-        }
-        out_ptr = out;
-      };
-      iter.serial_for_each(loop, {begin, end});
-      TORCH_INTERNAL_ASSERT(out_ptr == out_accessor[thread_count_nonzero[tid + 1]].data());
-    });
-  });
+              auto out_ptr = out_accessor[thread_count_nonzero[tid]].data();
+
+              auto loop = [&](char** data,
+                              const int64_t* strides,
+                              int64_t n1,
+                              int64_t n2) {
+                // Copy into local variables to improve compiler alias analysis
+                int64_t* C10_RESTRICT local_idx = current_idx.data() + 1;
+                const int64_t* C10_RESTRICT local_sizes = sizes.data() + 1;
+                const auto in_stride = strides[0];
+                const auto out_stride1 = out_accessor.stride(1);
+                const auto out_stride0 =
+                    out_accessor.stride(0) - ndim * out_stride1;
+                const auto ndim = out_accessor.size(1);
+                int64_t* out = out_ptr;
+
+                for (const auto i : c10::irange(n2)) {
+                  const char* ptr = data[0] + i * strides[1];
+                  for ([[maybe_unused]] const auto j : c10::irange(n1)) {
+                    const auto& val = c10::load<scalar_t>(ptr);
+                    // If nonzero, write index
+                    if (val != scalar_t(0)) {
+                      for (const auto k : c10::irange(ndim)) {
+                        *out = local_idx[k];
+                        out += out_stride1;
+                      }
+                      out += out_stride0;
+                    }
+                    ptr += in_stride;
+
+                    // Advance current index
+                    int64_t k = ndim - 1;
+                    ++local_idx[k];
+                    while (C10_UNLIKELY(local_idx[k] == local_sizes[k])) {
+                      local_idx[k] = 0;
+                      --k;
+                      ++local_idx[k];
+                    }
+                  }
+                }
+                out_ptr = out;
+              };
+              iter.serial_for_each(loop, {begin, end});
+              TORCH_INTERNAL_ASSERT(
+                  out_ptr ==
+                  out_accessor[thread_count_nonzero[tid + 1]].data());
+            });
+      });
   return result;
 }
 
@@ -2542,7 +3147,10 @@ Tensor argwhere(const Tensor& self) {
   return self.nonzero();
 }
 
-Tensor & masked_scatter__cpu(Tensor& self, const Tensor & mask, const Tensor & source) {
+Tensor& masked_scatter__cpu(
+    Tensor& self,
+    const Tensor& mask,
+    const Tensor& source) {
   at::assert_no_internal_overlap(self);
   TORCH_CHECK(
       self.scalar_type() == source.scalar_type(),
@@ -2551,28 +3159,42 @@ Tensor & masked_scatter__cpu(Tensor& self, const Tensor & mask, const Tensor & s
       " and ",
       source.scalar_type());
 
-  TORCH_CHECK(self.device().type() == at::kCPU, "device type of self (", self.device().type(), ") is not CPU");
-  TORCH_CHECK(mask.device().type() == at::kCPU, "device type of mask (", mask.device().type(), ") is not CPU");
-  TORCH_CHECK(source.device().type() == at::kCPU, "device type of source (", source.device().type(), ") is not CPU");
+  TORCH_CHECK(
+      self.device().type() == at::kCPU,
+      "device type of self (",
+      self.device().type(),
+      ") is not CPU");
+  TORCH_CHECK(
+      mask.device().type() == at::kCPU,
+      "device type of mask (",
+      mask.device().type(),
+      ") is not CPU");
+  TORCH_CHECK(
+      source.device().type() == at::kCPU,
+      "device type of source (",
+      source.device().type(),
+      ") is not CPU");
 
-  c10::MaybeOwned<Tensor> b_mask = expand_inplace(self, mask, "masked_scatter_");
+  c10::MaybeOwned<Tensor> b_mask =
+      expand_inplace(self, mask, "masked_scatter_");
 
   if (b_mask->dtype() == ScalarType::Byte) {
-    TORCH_WARN("masked_scatter_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
-            "please use a mask with dtype torch.bool instead.");
+    TORCH_WARN(
+        "masked_scatter_ received a mask with dtype torch.uint8, this behavior is now deprecated,"
+        "please use a mask with dtype torch.bool instead.");
   }
 
   auto src_cont = source.contiguous();
 
   auto iter = TensorIteratorConfig()
-      .set_check_mem_overlap(false)
-      .check_all_same_dtype(false)
-      .resize_outputs(false)
-      // order of indexing matters
-      .enforce_linear_iteration()
-      .add_output(self)
-      .add_const_input(*b_mask)
-      .build();
+                  .set_check_mem_overlap(false)
+                  .check_all_same_dtype(false)
+                  .resize_outputs(false)
+                  // order of indexing matters
+                  .enforce_linear_iteration()
+                  .add_output(self)
+                  .add_const_input(*b_mask)
+                  .build();
 
   masked_scatter_stub(iter.device_type(), iter, src_cont);
   return self;

--- a/aten/src/ATen/native/TensorAdvancedIndexing.h
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.h
@@ -13,21 +13,62 @@ struct TensorIterator;
 
 namespace at::native {
 
-using index_put_with_sort_fn = void(*)(Tensor &, const c10::List<std::optional<Tensor>> &, const Tensor &, bool accumulate, bool unsafe);
-using index_put_with_sort_quantized_fn = void(*)(Tensor& self, const c10::List<std::optional<Tensor>>& indices, const Tensor& value, double scale, int zero_point, bool unsafe);
-using gather_fn = void (*)(const Tensor & result, const Tensor & self, int64_t dim, const Tensor & index);
-using scatter_fn = void(*)(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src);
-using scatter_fill_fn = void(*)(const Tensor& self, int64_t dim, const Tensor& index, const Scalar& src);
-using scatter_add_fn = void(*)(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src);
-using scatter_reduce_fn = void(*)(const Tensor& self, const int64_t dim, const Tensor& index,
-                                  const Tensor& src, const ReductionType& reduce);
-using scatter_scalar_reduce_fn = void(*)(const Tensor& self, const int64_t dim, const Tensor& index,
-                                         const Scalar& value, const ReductionType& reduce);
-using scatter_reduce_two_fn = void(*)(const Tensor& self, const int64_t dim, const Tensor& index,
-                                      const Tensor& src, const ReductionType& reduce);
+using index_put_with_sort_fn = void (*)(
+    Tensor&,
+    const c10::List<std::optional<Tensor>>&,
+    const Tensor&,
+    bool accumulate,
+    bool unsafe);
+using index_put_with_sort_quantized_fn = void (*)(
+    Tensor& self,
+    const c10::List<std::optional<Tensor>>& indices,
+    const Tensor& value,
+    double scale,
+    int zero_point,
+    bool unsafe);
+using gather_fn = void (*)(
+    const Tensor& result,
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& index);
+using scatter_fn = void (*)(
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& index,
+    const Tensor& src);
+using scatter_fill_fn = void (*)(
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& index,
+    const Scalar& src);
+using scatter_add_fn = void (*)(
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& index,
+    const Tensor& src);
+using scatter_reduce_fn = void (*)(
+    const Tensor& self,
+    const int64_t dim,
+    const Tensor& index,
+    const Tensor& src,
+    const ReductionType& reduce);
+using scatter_scalar_reduce_fn = void (*)(
+    const Tensor& self,
+    const int64_t dim,
+    const Tensor& index,
+    const Scalar& value,
+    const ReductionType& reduce);
+using scatter_reduce_two_fn = void (*)(
+    const Tensor& self,
+    const int64_t dim,
+    const Tensor& index,
+    const Tensor& src,
+    const ReductionType& reduce);
 
 DECLARE_DISPATCH(index_put_with_sort_fn, index_put_with_sort_stub)
-DECLARE_DISPATCH(index_put_with_sort_quantized_fn, index_put_with_sort_quantized_stub)
+DECLARE_DISPATCH(
+    index_put_with_sort_quantized_fn,
+    index_put_with_sort_quantized_stub)
 DECLARE_DISPATCH(gather_fn, gather_stub)
 DECLARE_DISPATCH(scatter_fn, scatter_stub)
 DECLARE_DISPATCH(scatter_fill_fn, scatter_fill_stub)
@@ -36,14 +77,26 @@ DECLARE_DISPATCH(scatter_reduce_fn, scatter_reduce_stub)
 DECLARE_DISPATCH(scatter_scalar_reduce_fn, scatter_scalar_reduce_stub)
 DECLARE_DISPATCH(scatter_reduce_two_fn, scatter_reduce_two_stub)
 
-TORCH_API Tensor& index_out(Tensor& result, const Tensor & self, const c10::List<std::optional<at::Tensor>>& indices);
+TORCH_API Tensor& index_out(
+    Tensor& result,
+    const Tensor& self,
+    const c10::List<std::optional<at::Tensor>>& indices);
 
-using scatter_add_expanded_index_fn = void(*)(const Tensor&, const Tensor&, const Tensor&);
-using scatter_reduce_expanded_index_fn = void(*)(const Tensor&, const Tensor&, const Tensor&, const ReductionType& reduce, bool);
-using gather_expanded_index_fn = void (*)(const Tensor&, const Tensor&, const Tensor&);
+using scatter_add_expanded_index_fn =
+    void (*)(const Tensor&, const Tensor&, const Tensor&);
+using scatter_reduce_expanded_index_fn = void (*)(
+    const Tensor&,
+    const Tensor&,
+    const Tensor&,
+    const ReductionType& reduce,
+    bool);
+using gather_expanded_index_fn =
+    void (*)(const Tensor&, const Tensor&, const Tensor&);
 
 DECLARE_DISPATCH(scatter_add_expanded_index_fn, scatter_add_expanded_index_stub)
-DECLARE_DISPATCH(scatter_reduce_expanded_index_fn, scatter_reduce_expanded_index_stub)
+DECLARE_DISPATCH(
+    scatter_reduce_expanded_index_fn,
+    scatter_reduce_expanded_index_stub)
 DECLARE_DISPATCH(gather_expanded_index_fn, gather_expanded_index_stub)
 
 } // namespace at::native

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -1,20 +1,20 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/core/Tensor.h>
 #include <ATen/Dispatch.h>
 #include <ATen/NamedTensorUtils.h>
 #include <ATen/ScalarOps.h>
 #include <ATen/TensorIndexing.h>
 #include <ATen/TensorMeta.h>
 #include <ATen/TensorOperators.h>
+#include <ATen/TensorSubclassLikeUtils.h>
 #include <ATen/WrapDimUtils.h>
+#include <ATen/core/Tensor.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/ReduceOpsUtils.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/TensorCompare.h>
 #include <ATen/native/TypeProperties.h>
-#include <ATen/TensorSubclassLikeUtils.h>
-#include <iostream>
 #include <c10/util/Exception.h>
+#include <iostream>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -22,11 +22,11 @@
 #else
 #include <ATen/ops/_aminmax_native.h>
 #include <ATen/ops/_assert_async_native.h>
-#include <ATen/ops/_functional_assert_async_native.h>
-#include <ATen/ops/_print_native.h>
 #include <ATen/ops/_assert_scalar_native.h>
+#include <ATen/ops/_functional_assert_async_native.h>
 #include <ATen/ops/_functional_assert_scalar_native.h>
 #include <ATen/ops/_make_per_tensor_quantized_tensor.h>
+#include <ATen/ops/_print_native.h>
 #include <ATen/ops/_unique.h>
 #include <ATen/ops/allclose_native.h>
 #include <ATen/ops/aminmax.h>
@@ -80,24 +80,26 @@
 namespace at::meta {
 
 static inline void check_for_unsupported_isin_dtype(const ScalarType type) {
-  // Bail out for dtypes unsupported by the sorting algorithm to keep the interface consistent.
-  TORCH_CHECK(type != ScalarType::Bool &&
-      type != ScalarType::ComplexFloat &&
-      type != ScalarType::ComplexDouble,
-      "Unsupported input type encountered for isin(): ", type);
+  // Bail out for dtypes unsupported by the sorting algorithm to keep the
+  // interface consistent.
+  TORCH_CHECK(
+      type != ScalarType::Bool && type != ScalarType::ComplexFloat &&
+          type != ScalarType::ComplexDouble,
+      "Unsupported input type encountered for isin(): ",
+      type);
 }
 
-TORCH_META_FUNC(clamp) (
-const Tensor& self,
-const OptionalScalarRef min,
-const OptionalScalarRef max) {
+TORCH_META_FUNC(clamp)
+(const Tensor& self, const OptionalScalarRef min, const OptionalScalarRef max) {
   if (!min && !max) {
-    TORCH_CHECK(false, "torch.clamp: At least one of 'min' or 'max' must not be None");
+    TORCH_CHECK(
+        false, "torch.clamp: At least one of 'min' or 'max' must not be None");
   }
-  //Manual type promotion, since scalars have to participate in it
+  // Manual type promotion, since scalars have to participate in it
   ScalarType result_type = self.scalar_type();
-  TORCH_CHECK(!isComplexType(result_type), "clamp is not supported for complex types");
-  //Floating is the highest supported
+  TORCH_CHECK(
+      !isComplexType(result_type), "clamp is not supported for complex types");
+  // Floating is the highest supported
   if (!isFloatingType(result_type)) {
     at::native::ResultTypeState state = {};
     state = at::native::update_result_type_state(self, state);
@@ -109,25 +111,32 @@ const OptionalScalarRef max) {
       state = at::native::update_result_type_state(max.get(), state);
     }
     result_type = at::native::result_type(state);
-    //disallow type promoting inplace op
-    TORCH_CHECK((result_type == self.scalar_type()) ||
-       (!(maybe_get_output().defined()) || !(maybe_get_output().is_same(self))),
-       "result type ", result_type, " can't be cast to the desired output type ",
-       self.dtype());
+    // disallow type promoting inplace op
+    TORCH_CHECK(
+        (result_type == self.scalar_type()) ||
+            (!(maybe_get_output().defined()) ||
+             !(maybe_get_output().is_same(self))),
+        "result type ",
+        result_type,
+        " can't be cast to the desired output type ",
+        self.dtype());
   }
-  //make sure scalars weren't complex
-  TORCH_CHECK(!isComplexType(result_type), "clamp is not supported for complex types");
+  // make sure scalars weren't complex
+  TORCH_CHECK(
+      !isComplexType(result_type), "clamp is not supported for complex types");
   build_unary_op(maybe_get_output(), self.to(result_type));
 }
 
-TORCH_META_FUNC2(clamp, Tensor) (
-const Tensor& self,
-const OptionalTensorRef min,
-const OptionalTensorRef max) {
-  TORCH_CHECK(min || max, "torch.clamp: At least one of 'min' or 'max' must not be None");
-  TORCH_CHECK(!isComplexType(self.scalar_type()), "clamp is not supported for complex types");
-  #define CLAMP_CONFIG()                    \
-    TensorIteratorConfig()                  \
+TORCH_META_FUNC2(clamp, Tensor)
+(const Tensor& self, const OptionalTensorRef min, const OptionalTensorRef max) {
+  TORCH_CHECK(
+      min || max,
+      "torch.clamp: At least one of 'min' or 'max' must not be None");
+  TORCH_CHECK(
+      !isComplexType(self.scalar_type()),
+      "clamp is not supported for complex types");
+#define CLAMP_CONFIG()                      \
+  TensorIteratorConfig()                    \
       .set_check_mem_overlap(true)          \
       .add_output(maybe_get_output())       \
       .add_const_input(self)                \
@@ -144,100 +153,120 @@ const OptionalTensorRef max) {
   }
 }
 
-
-TORCH_META_FUNC(clamp_max) (
-  const Tensor& self,
-  const Scalar& max
-) {
-  //we could wrap max into tensor and send to tensor overload,
-  //but relu is implemented via clamp_min, so for perf an uniformity reasons
-  //do a faster but correct thing
+TORCH_META_FUNC(clamp_max)(const Tensor& self, const Scalar& max) {
+  // we could wrap max into tensor and send to tensor overload,
+  // but relu is implemented via clamp_min, so for perf an uniformity reasons
+  // do a faster but correct thing
   ScalarType result_type = self.scalar_type();
-  TORCH_CHECK(!isComplexType(result_type), "clamp is not supported for complex types");
+  TORCH_CHECK(
+      !isComplexType(result_type), "clamp is not supported for complex types");
   TORCH_CHECK(!max.isComplex(), "clamp is not supported for complex types");
-  //Floating is the highest supported
+  // Floating is the highest supported
   if (!isFloatingType(result_type)) {
     auto result_type = at::native::result_type(self, max);
-    TORCH_CHECK((result_type == self.scalar_type()) ||
-       (!(maybe_get_output().defined()) || !(maybe_get_output().is_same(self))),
-       "result type ", result_type, " can't be cast to the desired output type ",
-       self.dtype());
+    TORCH_CHECK(
+        (result_type == self.scalar_type()) ||
+            (!(maybe_get_output().defined()) ||
+             !(maybe_get_output().is_same(self))),
+        "result type ",
+        result_type,
+        " can't be cast to the desired output type ",
+        self.dtype());
     build_unary_op(maybe_get_output(), self.to(result_type));
   } else {
     build_borrowing_unary_op(maybe_get_output(), self);
   }
 }
 
-TORCH_META_FUNC2(clamp_max, Tensor) (
-  const Tensor& self,
-  const Tensor& max
-) {
+TORCH_META_FUNC2(clamp_max, Tensor)(const Tensor& self, const Tensor& max) {
   build_borrowing_binary_op(maybe_get_output(), self, max);
 }
 
-
-TORCH_META_FUNC(clamp_min) (
-  const Tensor& self,
-  const Scalar& min
-) {
+TORCH_META_FUNC(clamp_min)(const Tensor& self, const Scalar& min) {
   ScalarType result_type = self.scalar_type();
-  TORCH_CHECK(!isComplexType(result_type), "clamp is not supported for complex types");
+  TORCH_CHECK(
+      !isComplexType(result_type), "clamp is not supported for complex types");
   TORCH_CHECK(!min.isComplex(), "clamp is not supported for complex types");
-  //Floating is the highest supported
+  // Floating is the highest supported
   if (!isFloatingType(result_type)) {
     auto result_type = at::native::result_type(self, min);
-    TORCH_CHECK((result_type == self.scalar_type() ||
-       !(maybe_get_output().defined()) || !(maybe_get_output().is_same(self))),
-       "result type ", result_type, " can't be cast to the desired output type ",
-       self.dtype());
+    TORCH_CHECK(
+        (result_type == self.scalar_type() || !(maybe_get_output().defined()) ||
+         !(maybe_get_output().is_same(self))),
+        "result type ",
+        result_type,
+        " can't be cast to the desired output type ",
+        self.dtype());
     build_unary_op(maybe_get_output(), self.to(result_type));
   } else {
     build_borrowing_unary_op(maybe_get_output(), self);
   }
 }
 
-TORCH_META_FUNC2(clamp_min, Tensor) (
-  const Tensor& self,
-  const Tensor& min
-) {
+TORCH_META_FUNC2(clamp_min, Tensor)(const Tensor& self, const Tensor& min) {
   build_borrowing_binary_op(maybe_get_output(), self, min);
 }
 
-TORCH_META_FUNC2(isin, Tensor_Tensor) (
-  const Tensor& elements, const Tensor& test_elements, bool /*assume_unique*/, bool /*invert*/
+TORCH_META_FUNC2(isin, Tensor_Tensor)
+(const Tensor& elements,
+ const Tensor& test_elements,
+ bool /*assume_unique*/,
+ bool /*invert*/
 ) {
   check_for_unsupported_isin_dtype(elements.scalar_type());
   check_for_unsupported_isin_dtype(test_elements.scalar_type());
-  set_output_raw_strided(0, elements.sizes(), {}, TensorOptions(elements.device()).dtype(ScalarType::Bool));
+  set_output_raw_strided(
+      0,
+      elements.sizes(),
+      {},
+      TensorOptions(elements.device()).dtype(ScalarType::Bool));
 }
 
-TORCH_META_FUNC2(isin, Tensor_Scalar) (
-  const Tensor& elements, const c10::Scalar& test_elements, bool /*assume_unique*/, bool /*invert*/
+TORCH_META_FUNC2(isin, Tensor_Scalar)
+(const Tensor& elements,
+ const c10::Scalar& test_elements,
+ bool /*assume_unique*/,
+ bool /*invert*/
 ) {
   check_for_unsupported_isin_dtype(elements.scalar_type());
   check_for_unsupported_isin_dtype(test_elements.type());
-  set_output_raw_strided(0, elements.sizes(), {}, TensorOptions(elements.device()).dtype(ScalarType::Bool));
+  set_output_raw_strided(
+      0,
+      elements.sizes(),
+      {},
+      TensorOptions(elements.device()).dtype(ScalarType::Bool));
 }
 
-TORCH_META_FUNC2(isin, Scalar_Tensor) (
-  const c10::Scalar& elements, const Tensor& test_elements, bool /*assume_unique*/, bool /*invert*/
+TORCH_META_FUNC2(isin, Scalar_Tensor)
+(const c10::Scalar& elements,
+ const Tensor& test_elements,
+ bool /*assume_unique*/,
+ bool /*invert*/
 ) {
   check_for_unsupported_isin_dtype(elements.type());
   check_for_unsupported_isin_dtype(test_elements.scalar_type());
-  set_output_raw_strided(0, {0}, {}, TensorOptions(test_elements.device()).dtype(ScalarType::Bool));
+  set_output_raw_strided(
+      0,
+      {0},
+      {},
+      TensorOptions(test_elements.device()).dtype(ScalarType::Bool));
 }
 
-TORCH_META_FUNC(isposinf) (const Tensor& self) {
+TORCH_META_FUNC(isposinf)(const Tensor& self) {
   TORCH_CHECK(!self.is_complex(), "isposinf does not support complex inputs.");
-  TORCH_CHECK(maybe_get_output().defined() ? maybe_get_output().dtype() == at::kBool : true,
-              "isposinf does not support non-boolean outputs.");
+  TORCH_CHECK(
+      maybe_get_output().defined() ? maybe_get_output().dtype() == at::kBool
+                                   : true,
+      "isposinf does not support non-boolean outputs.");
   build_borrowing_unary_force_boolean_op(maybe_get_output(), self);
 }
 
-TORCH_META_FUNC(isneginf) (const Tensor& self) {
+TORCH_META_FUNC(isneginf)(const Tensor& self) {
   TORCH_CHECK(!self.is_complex(), "isneginf does not support complex inputs.");
-  TORCH_CHECK(maybe_get_output().defined() ? maybe_get_output().dtype() == at::kBool : true,
-              "isneginf does not support non-boolean outputs.");
+  TORCH_CHECK(
+      maybe_get_output().defined() ? maybe_get_output().dtype() == at::kBool
+                                   : true,
+      "isneginf does not support non-boolean outputs.");
   build_borrowing_unary_force_boolean_op(maybe_get_output(), self);
 }
 
@@ -251,36 +280,53 @@ TORCH_PRECOMPUTE_META_FUNC2(max, dim)
   at::native::zero_numel_check_dims(self, dim, "max()");
   check_unsupported_complex("max()", self);
   resize_reduction_with_indices(*this, self, dim, keepdim, self.scalar_type());
-  return TORCH_PRECOMPUTE_STRUCT2(max, dim)()
-      .set_dim(maybe_wrap_dim(dim, self.dim()));
+  return TORCH_PRECOMPUTE_STRUCT2(max, dim)().set_dim(
+      maybe_wrap_dim(dim, self.dim()));
 }
 
-TORCH_PRECOMPUTE_META_FUNC2(min, dim)(const Tensor& self, int64_t dim, bool keepdim) {
+TORCH_PRECOMPUTE_META_FUNC2(min, dim)
+(const Tensor& self, int64_t dim, bool keepdim) {
   dim = maybe_wrap_dim(dim, self.dim());
   at::native::zero_numel_check_dims(self, dim, "min()");
   check_unsupported_complex("min()", self);
   resize_reduction_with_indices(*this, self, dim, keepdim, self.scalar_type());
-  return TORCH_PRECOMPUTE_STRUCT2(min, dim)()
-      .set_dim(maybe_wrap_dim(dim, self.dim()));
+  return TORCH_PRECOMPUTE_STRUCT2(min, dim)().set_dim(
+      maybe_wrap_dim(dim, self.dim()));
 }
 
 } // namespace at::meta
 
 namespace at::native {
 
-DEFINE_DISPATCH(where_kernel); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_DISPATCH(max_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_DISPATCH(min_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_DISPATCH(isposinf_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_DISPATCH(isneginf_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_DISPATCH(mode_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_DISPATCH(clamp_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_DISPATCH(clamp_scalar_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_DISPATCH(clamp_min_scalar_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_DISPATCH(clamp_max_scalar_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_DISPATCH(isin_default_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_DISPATCH(
+    where_kernel); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_DISPATCH(
+    max_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_DISPATCH(
+    min_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_DISPATCH(
+    isposinf_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_DISPATCH(
+    isneginf_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_DISPATCH(
+    mode_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_DISPATCH(
+    clamp_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_DISPATCH(
+    clamp_scalar_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_DISPATCH(
+    clamp_min_scalar_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_DISPATCH(
+    clamp_max_scalar_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_DISPATCH(
+    isin_default_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-bool allclose(const Tensor& self, const Tensor& other, double rtol, double atol, bool equal_nan) {
+bool allclose(
+    const Tensor& self,
+    const Tensor& other,
+    double rtol,
+    double atol,
+    bool equal_nan) {
   return at::isclose(self, other, rtol, atol, equal_nan).all().item<uint8_t>();
 }
 
@@ -297,25 +343,37 @@ bool allclose(const Tensor& self, const Tensor& other, double rtol, double atol,
 // TODO: use bitwise operator overloads once we add them
 // TODO: revisit complex inputs and equal_nan=true after
 //  https://github.com/numpy/numpy/issues/15959 is resolved
-Tensor isclose(const Tensor& self, const Tensor& other, double rtol, double atol, bool equal_nan) {
-  TORCH_CHECK(self.scalar_type() == other.scalar_type(), self.scalar_type(), " did not match ", other.scalar_type());
-  TORCH_CHECK(!(self.is_quantized() || other.is_quantized()),
-    "isclose is not supported for quantized inputs.");
+Tensor isclose(
+    const Tensor& self,
+    const Tensor& other,
+    double rtol,
+    double atol,
+    bool equal_nan) {
+  TORCH_CHECK(
+      self.scalar_type() == other.scalar_type(),
+      self.scalar_type(),
+      " did not match ",
+      other.scalar_type());
+  TORCH_CHECK(
+      !(self.is_quantized() || other.is_quantized()),
+      "isclose is not supported for quantized inputs.");
 
   // Checks that rtol and atol are non-negative
   // Note: consistent with Python's isclose but divergent from NumPy's, which
   //  allows negative atol and rtol.
-  TORCH_CHECK(rtol >= 0, "rtol must be greater than or equal to zero, but got ", rtol);
-  TORCH_CHECK(atol >= 0, "atol must be greater than or equal to zero, but got ", atol);
+  TORCH_CHECK(
+      rtol >= 0, "rtol must be greater than or equal to zero, but got ", rtol);
+  TORCH_CHECK(
+      atol >= 0, "atol must be greater than or equal to zero, but got ", atol);
 
   // Computes equality closeness
   Tensor close = self == other;
   if (equal_nan && (self.is_floating_point() || self.is_complex())) {
-    // For CompositeCompliance, if `other` is a CCT and `self` is a regular Tensor,
-    // then we can't perform inplace op into `self` with `other`.
-    // NOTE: Inplacing into `close` is fine because it is generated from
-    // out-of-place with args `self` and `other`. So if either of them is
-    // a CCT then `close` will also be a `CCT`.
+    // For CompositeCompliance, if `other` is a CCT and `self` is a regular
+    // Tensor, then we can't perform inplace op into `self` with `other`. NOTE:
+    // Inplacing into `close` is fine because it is generated from out-of-place
+    // with args `self` and `other`. So if either of them is a CCT then `close`
+    // will also be a `CCT`.
     if (isTensorSubclassLike(other)) {
       close.__ior__(self.isnan().bitwise_and(other.isnan()));
     } else {
@@ -323,10 +381,11 @@ Tensor isclose(const Tensor& self, const Tensor& other, double rtol, double atol
     }
   }
 
-  // In case of zero tolerances the closeness inequality degenerates to an equality check.
-  // In this case, the short-circuit prevents false positives as detailed in the paragraph below.
-  if (rtol == 0 && atol == 0){
-      return close;
+  // In case of zero tolerances the closeness inequality degenerates to an
+  // equality check. In this case, the short-circuit prevents false positives as
+  // detailed in the paragraph below.
+  if (rtol == 0 && atol == 0) {
+    return close;
   }
 
   // Note [closeness error computation]
@@ -342,7 +401,8 @@ Tensor isclose(const Tensor& self, const Tensor& other, double rtol, double atol
 
   // Computes allowed and actual error
   Tensor cast_self, cast_other;
-  cast_self = self.scalar_type() == at::kBool ? self.to(at::get_default_dtype()) : self;
+  cast_self =
+      self.scalar_type() == at::kBool ? self.to(at::get_default_dtype()) : self;
   if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
     cast_other = other.to(at::get_default_dtype());
   } else {
@@ -353,7 +413,8 @@ Tensor isclose(const Tensor& self, const Tensor& other, double rtol, double atol
   Tensor actual_error = (cast_self - cast_other).abs();
 
   // Computes finite closeness
-  close.__ior__(at::isfinite(actual_error).__iand__(actual_error <= allowed_error));
+  close.__ior__(
+      at::isfinite(actual_error).__iand__(actual_error <= allowed_error));
 
   return close;
 }
@@ -372,19 +433,16 @@ Tensor isreal(const Tensor& self) {
   return at::imag(self) == 0;
 }
 
-
 #if !defined(C10_MOBILE)
-#define _AT_DISPATCH_INF_TYPES(TYPE, NAME, ...)                          \
-        AT_DISPATCH_FLOATING_TYPES_AND3( kHalf, kBFloat16, kFloat8_e5m2, \
-            TYPE, NAME, __VA_ARGS__)
+#define _AT_DISPATCH_INF_TYPES(TYPE, NAME, ...) \
+  AT_DISPATCH_FLOATING_TYPES_AND3(              \
+      kHalf, kBFloat16, kFloat8_e5m2, TYPE, NAME, __VA_ARGS__)
 #else
-#define _AT_DISPATCH_INF_TYPES(TYPE, NAME, ...)           \
-        AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, \
-            TYPE, NAME, __VA_ARGS__)
+#define _AT_DISPATCH_INF_TYPES(TYPE, NAME, ...) \
+  AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, TYPE, NAME, __VA_ARGS__)
 #endif
 
-
-Tensor isinf(const Tensor &self) {
+Tensor isinf(const Tensor& self) {
   // Note: Integral tensor values are never infinite
   if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
     return at::zeros_like(self, at::kBool, at::MemoryFormat::Preserve);
@@ -392,8 +450,7 @@ Tensor isinf(const Tensor &self) {
 
   // Note: a complex value is infinite when either part is infinite
   if (self.is_complex()) {
-    return at::isinf(at::real(self)).__ior__
-          (at::isinf(at::imag(self)));
+    return at::isinf(at::real(self)).__ior__(at::isinf(at::imag(self)));
   }
 
   return _AT_DISPATCH_INF_TYPES(self.scalar_type(), "isinf", [&]() {
@@ -413,31 +470,41 @@ Tensor isfinite(const Tensor& self) {
   }
 
   return _AT_DISPATCH_INF_TYPES(self.scalar_type(), "isfinite", [&]() {
-    return (self == self) * (self.abs() != std::numeric_limits<scalar_t>::infinity());
+    return (self == self) *
+        (self.abs() != std::numeric_limits<scalar_t>::infinity());
   });
 }
 
 void _assert_async_cpu(const Tensor& self) {
-  TORCH_CHECK(native::is_nonzero(self), "Expected Tensor with single nonzero value, but got zero");
+  TORCH_CHECK(
+      native::is_nonzero(self),
+      "Expected Tensor with single nonzero value, but got zero");
 }
 
 void _assert_async_msg_cpu(const Tensor& self, std::string_view assert_msg) {
-  TORCH_CHECK(native::is_nonzero(self), assert_msg != "" ? assert_msg : "Assertion is failed");
+  TORCH_CHECK(
+      native::is_nonzero(self),
+      assert_msg != "" ? assert_msg : "Assertion is failed");
 }
 
 void _assert_scalar(const Scalar& scalar, std::string_view assert_msg) {
-  TORCH_SYM_CHECK(scalar.toSymBool(), assert_msg != "" ? assert_msg : "Assertion is failed");
+  TORCH_SYM_CHECK(
+      scalar.toSymBool(),
+      assert_msg != "" ? assert_msg : "Assertion is failed");
 }
 
-Tensor _functional_assert_scalar(const Scalar& scalar, std::string_view assert_msg, const Tensor& dep_token) {
+Tensor _functional_assert_scalar(
+    const Scalar& scalar,
+    std::string_view assert_msg,
+    const Tensor& dep_token) {
   _assert_scalar(scalar, assert_msg);
   return dep_token.clone();
 }
 
 Tensor _functional_assert_async_msg_cpu(
-  const Tensor& self,
-  std::string_view assert_msg,
-  const Tensor& dep_token) {
+    const Tensor& self,
+    std::string_view assert_msg,
+    const Tensor& dep_token) {
   _assert_async_msg_cpu(self, assert_msg);
   return dep_token.clone();
 }
@@ -446,7 +513,8 @@ void _print(std::string_view s) {
   std::cout << s << "\n";
 }
 
-// Sorting-based algorithm for isin(); used when the number of test elements is large.
+// Sorting-based algorithm for isin(); used when the number of test elements is
+// large.
 static void isin_sorting(
     const Tensor& elements,
     const Tensor& test_elements,
@@ -460,25 +528,29 @@ static void isin_sorting(
     elements_flat = elements.ravel();
     test_elements_flat = test_elements.ravel();
   } else {
-    std::tie(elements_flat, unique_order) = at::_unique(
-        elements, /*sorted=*/ false, /*return_inverse=*/ true);
-    std::tie(test_elements_flat, std::ignore) = at::_unique(test_elements, /*sorted=*/ false);
+    std::tie(elements_flat, unique_order) =
+        at::_unique(elements, /*sorted=*/false, /*return_inverse=*/true);
+    std::tie(test_elements_flat, std::ignore) =
+        at::_unique(test_elements, /*sorted=*/false);
   }
 
   // 2. Stable sort all elements, maintaining order indices to reverse the
   //    operation. Stable sort is necessary to keep elements before test
   //    elements within the sorted list.
-  Tensor all_elements = at::cat({std::move(elements_flat), std::move(test_elements_flat)});
+  Tensor all_elements =
+      at::cat({std::move(elements_flat), std::move(test_elements_flat)});
   auto [sorted_elements, sorted_order] = all_elements.sort(
-      /*stable=*/ true, /*dim=*/ 0, /*descending=*/ false);
+      /*stable=*/true, /*dim=*/0, /*descending=*/false);
 
   // 3. Create a mask for locations of adjacent duplicate values within the
   //    sorted list. Duplicate values are in both elements and test elements.
-  Tensor duplicate_mask = at::empty_like(sorted_elements, TensorOptions(ScalarType::Bool));
+  Tensor duplicate_mask =
+      at::empty_like(sorted_elements, TensorOptions(ScalarType::Bool));
   Tensor sorted_except_first = sorted_elements.slice(0, 1, at::indexing::None);
   Tensor sorted_except_last = sorted_elements.slice(0, 0, -1);
   duplicate_mask.slice(0, 0, -1).copy_(
-    invert ? sorted_except_first.ne(sorted_except_last) : sorted_except_first.eq(sorted_except_last));
+      invert ? sorted_except_first.ne(sorted_except_last)
+             : sorted_except_first.eq(sorted_except_last));
   duplicate_mask.index_put_({-1}, invert);
 
   // 4. Reorder the mask to match the pre-sorted element order.
@@ -495,9 +567,9 @@ static void isin_sorting(
   }
 }
 
-template<typename... Args>
-Device out_device(Args&... inps){
-  for (const auto& i : {inps...}){
+template <typename... Args>
+Device out_device(Args&... inps) {
+  for (const auto& i : {inps...}) {
     if (i.device() != at::kCPU) {
       return i.device();
     }
@@ -505,13 +577,22 @@ Device out_device(Args&... inps){
   return at::kCPU;
 }
 
-
-Tensor& where_self_out(const Tensor& condition, const Tensor& self, const Tensor& other, Tensor& out) {
+Tensor& where_self_out(
+    const Tensor& condition,
+    const Tensor& self,
+    const Tensor& other,
+    Tensor& out) {
   const auto result_type = at::native::result_type(self, other);
-  TORCH_CHECK(out.scalar_type() == result_type, "Expected out type to be ", result_type, " but got ", out.scalar_type());
+  TORCH_CHECK(
+      out.scalar_type() == result_type,
+      "Expected out type to be ",
+      result_type,
+      " but got ",
+      out.scalar_type());
 
-  auto self_ = self.scalar_type() != result_type ? self.to(result_type): self;
-  auto other_ = other.scalar_type() != result_type ? other.to(result_type): other;
+  auto self_ = self.scalar_type() != result_type ? self.to(result_type) : self;
+  auto other_ =
+      other.scalar_type() != result_type ? other.to(result_type) : other;
   auto condition_ = condition;
   auto device = out_device(condition, self_, other_);
   if (device != at::kCPU) { // allow CPU scalars on non-cpu device
@@ -519,29 +600,32 @@ Tensor& where_self_out(const Tensor& condition, const Tensor& self, const Tensor
       condition_ = condition.to(device);
     }
     if (self_.device() != device && self_.ndimension() == 0) {
-        self_ = self_.to(device);
+      self_ = self_.to(device);
     }
     if (other_.device() != device && other_.ndimension() == 0) {
-        other_ = other_.to(device);
+      other_ = other_.to(device);
     }
   }
   if (condition_.scalar_type() == ScalarType::Byte) {
-    TORCH_WARN_ONCE("where received a uint8 condition tensor. This behavior is deprecated and will be removed in a future version of PyTorch. Use a boolean condition instead.");
+    TORCH_WARN_ONCE(
+        "where received a uint8 condition tensor. This behavior is deprecated and will be removed in a future version of PyTorch. Use a boolean condition instead.");
     condition_ = condition_.to(kBool);
   }
-  TORCH_CHECK(condition_.scalar_type() == kBool, "where expected condition to be a boolean tensor, but got a tensor with dtype ", condition_.scalar_type());
+  TORCH_CHECK(
+      condition_.scalar_type() == kBool,
+      "where expected condition to be a boolean tensor, but got a tensor with dtype ",
+      condition_.scalar_type());
   // if there's still a device mismatch, let tensoriterator error out with it
   auto iter = at::TensorIteratorConfig()
-    .check_all_same_dtype(false)
-    .add_output(out)
-    .add_const_input(condition_)
-    .add_const_input(self_)
-    .add_const_input(other_)
-    .build();
+                  .check_all_same_dtype(false)
+                  .add_output(out)
+                  .add_const_input(condition_)
+                  .add_const_input(self_)
+                  .add_const_input(other_)
+                  .build();
   where_kernel(iter.device_type(), iter);
   return out;
 }
-
 
 Tensor where(const Tensor& condition, const Tensor& self, const Tensor& other) {
   auto device = out_device(condition, self, other);
@@ -553,22 +637,26 @@ Tensor where(const Tensor& condition, const Tensor& self, const Tensor& other) {
 
 Tensor where(const Tensor& condition, const Scalar& self, const Tensor& other) {
   auto result_type = at::native::result_type(other, self);
-  auto self_converted = at::scalar_tensor(self, other.options().dtype(result_type));
+  auto self_converted =
+      at::scalar_tensor(self, other.options().dtype(result_type));
   auto other_converted = other.to(result_type);
   return at::where(condition, self_converted, other_converted);
 }
 
 Tensor where(const Tensor& condition, const Tensor& self, const Scalar& other) {
   auto result_type = at::native::result_type(self, other);
-  auto other_converted = at::scalar_tensor(other, self.options().dtype(result_type));
+  auto other_converted =
+      at::scalar_tensor(other, self.options().dtype(result_type));
   auto self_converted = self.to(result_type);
   return at::where(condition, self_converted, other_converted);
 }
 
 Tensor where(const Tensor& condition, const Scalar& self, const Scalar& other) {
   auto result_type = at::native::result_type(self, other);
-  const Tensor& other_t = at::scalar_tensor(other, condition.options().dtype(result_type));
-  const Tensor& self_t = at::scalar_tensor(self, condition.options().dtype(result_type));
+  const Tensor& other_t =
+      at::scalar_tensor(other, condition.options().dtype(result_type));
+  const Tensor& self_t =
+      at::scalar_tensor(self, condition.options().dtype(result_type));
   return at::where(condition, self_t, other_t);
 }
 
@@ -582,32 +670,56 @@ std::tuple<Tensor, Tensor> mode(const Tensor& self, int64_t dim, bool keepdim) {
   return at::native::mode_out(self, dim, keepdim, values, indices);
 }
 
-std::tuple<Tensor &,Tensor &> mode_out(const Tensor& self, int64_t dim, bool keepdim,
-                                       Tensor& values, Tensor& indices) {
-  TORCH_CHECK(self.device().is_cpu() || self.is_cuda() || self.is_xpu(),
-              "mode only supports CPU, CUDA and XPU device type, got: ", self.device().type());
-  TORCH_CHECK(self.layout() == Layout::Strided,
-              "mode only supports strided layout, got: ", self.layout());
-  TORCH_CHECK(self.device() == values.device(),
-              "expected device '", self.device(), "' but got '",
-              values.device(), "' for values output");
-  TORCH_CHECK(self.device() == indices.device(),
-              "expected device '", self.device(), "' but got '",
-              indices.device(), "' for indices output");
-  TORCH_CHECK(self.scalar_type() == values.scalar_type(),
-              "expected scalar type '", self.scalar_type(), "' but got '",
-              values.scalar_type(), "' for values output");
-  TORCH_CHECK(indices.scalar_type() == ScalarType::Long,
-              "expected scalar type '", ScalarType::Long, "' but got '",
-              indices.scalar_type(), "' for indices output");
+std::tuple<Tensor&, Tensor&> mode_out(
+    const Tensor& self,
+    int64_t dim,
+    bool keepdim,
+    Tensor& values,
+    Tensor& indices) {
+  TORCH_CHECK(
+      self.device().is_cpu() || self.is_cuda() || self.is_xpu(),
+      "mode only supports CPU, CUDA and XPU device type, got: ",
+      self.device().type());
+  TORCH_CHECK(
+      self.layout() == Layout::Strided,
+      "mode only supports strided layout, got: ",
+      self.layout());
+  TORCH_CHECK(
+      self.device() == values.device(),
+      "expected device '",
+      self.device(),
+      "' but got '",
+      values.device(),
+      "' for values output");
+  TORCH_CHECK(
+      self.device() == indices.device(),
+      "expected device '",
+      self.device(),
+      "' but got '",
+      indices.device(),
+      "' for indices output");
+  TORCH_CHECK(
+      self.scalar_type() == values.scalar_type(),
+      "expected scalar type '",
+      self.scalar_type(),
+      "' but got '",
+      values.scalar_type(),
+      "' for values output");
+  TORCH_CHECK(
+      indices.scalar_type() == ScalarType::Long,
+      "expected scalar type '",
+      ScalarType::Long,
+      "' but got '",
+      indices.scalar_type(),
+      "' for indices output");
   dim = maybe_wrap_dim(dim, self.dim());
   if (self.numel() == 0) {
     auto sizes = get_zero_numel_tensor_size(self, dim, keepdim, "mode()");
     resize_output(values, sizes);
     resize_output(indices, sizes);
     return std::tie(values, indices);
-  }
-  else if (_dimreduce_return_trivial_no_ident(values, self, dim, keepdim, "mode")) {
+  } else if (_dimreduce_return_trivial_no_ident(
+                 values, self, dim, keepdim, "mode")) {
     AT_ASSERT(values.dim() == 0);
     indices.resize_({}).fill_(0);
     return std::forward_as_tuple(values, indices);
@@ -615,10 +727,12 @@ std::tuple<Tensor &,Tensor &> mode_out(const Tensor& self, int64_t dim, bool kee
     auto result = [&]() {
       NoNamesGuard guard;
       mode_stub(self.device().type(), values, indices, self, dim, keepdim);
-      return std::tuple<Tensor &,Tensor &>{values, indices};
+      return std::tuple<Tensor&, Tensor&>{values, indices};
     }();
-    namedinference::propagate_names_for_reduction(std::get<0>(result), self, dim, keepdim);
-    namedinference::propagate_names_for_reduction(std::get<1>(result), self, dim, keepdim);
+    namedinference::propagate_names_for_reduction(
+        std::get<0>(result), self, dim, keepdim);
+    namedinference::propagate_names_for_reduction(
+        std::get<1>(result), self, dim, keepdim);
     return result;
   }
 }
@@ -661,36 +775,49 @@ TORCH_IMPL_FUNC(min_out)
 }
 
 std::tuple<Tensor, Tensor> qmax(const Tensor& self, int64_t dim, bool keepdim) {
-  TORCH_CHECK(self.qscheme() == at::kPerTensorAffine, "Max operator for quantized tensors only works for per tensor quantized tensors. "
-  "Please open an issue on https://github.com/pytorch/pytorch/issues if you need per channel quantized tensor support.");
+  TORCH_CHECK(
+      self.qscheme() == at::kPerTensorAffine,
+      "Max operator for quantized tensors only works for per tensor quantized tensors. "
+      "Please open an issue on https://github.com/pytorch/pytorch/issues if you need per channel quantized tensor support.");
   Tensor max_indices = at::empty({0}, self.options().dtype(kLong));
-  Tensor max = at::empty({0}, self.options().dtype(toUnderlying(self.scalar_type())));
+  Tensor max =
+      at::empty({0}, self.options().dtype(toUnderlying(self.scalar_type())));
   at::max_outf(self.int_repr(), dim, keepdim, max, max_indices);
   // TODO: qscheme
   return std::tuple<Tensor, Tensor>(
-      at::_make_per_tensor_quantized_tensor(max, self.q_scale(), self.q_zero_point()), max_indices);
+      at::_make_per_tensor_quantized_tensor(
+          max, self.q_scale(), self.q_zero_point()),
+      max_indices);
 }
 
 std::tuple<Tensor, Tensor> qmin(const Tensor& self, int64_t dim, bool keepdim) {
-  TORCH_CHECK(self.qscheme() == at::kPerTensorAffine, "Min operator for quantized tensors only works for per tensor quantized tensors. "
-  "Please open an issue on https://github.com/pytorch/pytorch/issues if you need per channel quantized tensor support.");
+  TORCH_CHECK(
+      self.qscheme() == at::kPerTensorAffine,
+      "Min operator for quantized tensors only works for per tensor quantized tensors. "
+      "Please open an issue on https://github.com/pytorch/pytorch/issues if you need per channel quantized tensor support.");
   Tensor min_indices = at::empty({0}, self.options().dtype(kLong));
-  Tensor min = at::empty({0}, self.options().dtype(toUnderlying(self.scalar_type())));
+  Tensor min =
+      at::empty({0}, self.options().dtype(toUnderlying(self.scalar_type())));
   at::min_outf(self.int_repr(), dim, keepdim, min, min_indices);
   return std::tuple<Tensor, Tensor>(
-      at::_make_per_tensor_quantized_tensor(min, self.q_scale(), self.q_zero_point()), min_indices);
+      at::_make_per_tensor_quantized_tensor(
+          min, self.q_scale(), self.q_zero_point()),
+      min_indices);
 }
 
 // DEPRECATED: Use at::aminmax instead
-std::tuple<Tensor, Tensor> _aminmax(const Tensor& self, int64_t dim, bool keepdim) {
-  TORCH_WARN_ONCE("_aminmax is deprecated as of PyTorch 1.11 and will be removed in a future release. Use aminmax instead."
-                  " This warning will only appear once per process.");
+std::tuple<Tensor, Tensor> _aminmax(
+    const Tensor& self,
+    int64_t dim,
+    bool keepdim) {
+  TORCH_WARN_ONCE(
+      "_aminmax is deprecated as of PyTorch 1.11 and will be removed in a future release. Use aminmax instead."
+      " This warning will only appear once per process.");
   return at::aminmax(self, dim, keepdim);
 }
 
 TORCH_IMPL_FUNC(clamp_out)
-(
- const Tensor& /*self*/,
+(const Tensor& /*self*/,
  const OptionalScalarRef min,
  const OptionalScalarRef max,
  const Tensor& result) {
@@ -698,7 +825,9 @@ TORCH_IMPL_FUNC(clamp_out)
   if (min && max) {
     if (min.get().toDouble() != min.get().toDouble() ||
         max.get().toDouble() != max.get().toDouble()) {
-      at::fill_(const_cast<Tensor&>(result), std::numeric_limits<double>::quiet_NaN());
+      at::fill_(
+          const_cast<Tensor&>(result),
+          std::numeric_limits<double>::quiet_NaN());
     } else {
       clamp_scalar_stub(device_type(), *this, min.get(), max.get());
     }
@@ -710,8 +839,10 @@ TORCH_IMPL_FUNC(clamp_out)
 }
 
 TORCH_IMPL_FUNC(clamp_Tensor_out)
-(const Tensor& self, const OptionalTensorRef min,
-                  const OptionalTensorRef max, const Tensor&) {
+(const Tensor& self,
+ const OptionalTensorRef min,
+ const OptionalTensorRef max,
+ const Tensor&) {
   if (min && max) {
     clamp_stub(device_type(), *this);
   } else if (min) {
@@ -724,9 +855,9 @@ TORCH_IMPL_FUNC(clamp_Tensor_out)
 TORCH_IMPL_FUNC(clamp_max_out)
 (const Tensor& self, const Scalar& max, const Tensor& result) {
   if (max.toDouble() != max.toDouble()) {
-//TODO this is not great, building TI again is expensive, but I can't use
-//fill_stub because fill is not structured
-//this is a corner case anyway
+    // TODO this is not great, building TI again is expensive, but I can't use
+    // fill_stub because fill is not structured
+    // this is a corner case anyway
     at::fill_(const_cast<Tensor&>(result), wrapped_scalar_tensor(max));
   } else {
     clamp_max_scalar_stub(device_type(), *this, max);
@@ -753,27 +884,47 @@ TORCH_IMPL_FUNC(clamp_min_Tensor_out)
 }
 
 // Implements the "clip" alias for clamp
-Tensor& clip_out(const Tensor& self, const std::optional<Scalar>& min, const std::optional<Scalar>& max, Tensor& result) {
+Tensor& clip_out(
+    const Tensor& self,
+    const std::optional<Scalar>& min,
+    const std::optional<Scalar>& max,
+    Tensor& result) {
   return at::clamp_outf(self, min, max, result);
 }
 
-Tensor& clip_out(const Tensor& self, const std::optional<Tensor>& min, const std::optional<Tensor>& max, Tensor& result) {
+Tensor& clip_out(
+    const Tensor& self,
+    const std::optional<Tensor>& min,
+    const std::optional<Tensor>& max,
+    Tensor& result) {
   return at::clamp_outf(self, min, max, result);
 }
 
-Tensor clip(const Tensor& self, const std::optional<Scalar>& min, const std::optional<Scalar>& max) {
+Tensor clip(
+    const Tensor& self,
+    const std::optional<Scalar>& min,
+    const std::optional<Scalar>& max) {
   return at::clamp(self, min, max);
 }
 
-Tensor clip(const Tensor& self, const std::optional<Tensor>& min, const std::optional<Tensor>& max) {
+Tensor clip(
+    const Tensor& self,
+    const std::optional<Tensor>& min,
+    const std::optional<Tensor>& max) {
   return at::clamp(self, min, max);
 }
 
-Tensor& clip_(Tensor& self, const std::optional<Scalar>& min, const std::optional<Scalar>& max) {
+Tensor& clip_(
+    Tensor& self,
+    const std::optional<Scalar>& min,
+    const std::optional<Scalar>& max) {
   return at::clamp_(self, min, max);
 }
 
-Tensor& clip_(Tensor& self, const std::optional<Tensor>& min, const std::optional<Tensor>& max) {
+Tensor& clip_(
+    Tensor& self,
+    const std::optional<Tensor>& min,
+    const std::optional<Tensor>& max) {
   return at::clamp_(self, min, max);
 }
 
@@ -782,14 +933,26 @@ Tensor& clip_(Tensor& self, const std::optional<Tensor>& min, const std::optiona
 std::tuple<Tensor, Tensor> min(const Tensor& self, Dimname dim, bool keepdim) {
   return at::min(self, dimname_to_position(self, dim), keepdim);
 }
-std::tuple<Tensor &,Tensor &> min_out(const Tensor& self, Dimname dim, bool keepdim, Tensor& min, Tensor& min_indices) {
-  return at::min_out(min, min_indices, self, dimname_to_position(self, dim), keepdim);
+std::tuple<Tensor&, Tensor&> min_out(
+    const Tensor& self,
+    Dimname dim,
+    bool keepdim,
+    Tensor& min,
+    Tensor& min_indices) {
+  return at::min_out(
+      min, min_indices, self, dimname_to_position(self, dim), keepdim);
 }
 std::tuple<Tensor, Tensor> max(const Tensor& self, Dimname dim, bool keepdim) {
   return at::max(self, dimname_to_position(self, dim), keepdim);
 }
-std::tuple<Tensor&, Tensor&> max_out(const Tensor& self, Dimname dim, bool keepdim, Tensor& max, Tensor& max_indices) {
-  return at::max_out(max, max_indices, self, dimname_to_position(self, dim), keepdim);
+std::tuple<Tensor&, Tensor&> max_out(
+    const Tensor& self,
+    Dimname dim,
+    bool keepdim,
+    Tensor& max,
+    Tensor& max_indices) {
+  return at::max_out(
+      max, max_indices, self, dimname_to_position(self, dim), keepdim);
 }
 Tensor argsort(const Tensor& /*self*/, Dimname /*dim*/, bool /*keepdim*/) {
   reportNYIDimnameOverload("argsort");
@@ -797,31 +960,46 @@ Tensor argsort(const Tensor& /*self*/, Dimname /*dim*/, bool /*keepdim*/) {
 std::tuple<Tensor, Tensor> mode(const Tensor& self, Dimname dim, bool keepdim) {
   return at::mode(self, dimname_to_position(self, dim), keepdim);
 }
-std::tuple<Tensor &,Tensor &> mode_out(const Tensor& self, Dimname dim, bool keepdim, Tensor& values, Tensor& indices) {
-  return at::mode_out(values, indices, self, dimname_to_position(self, dim), keepdim);
+std::tuple<Tensor&, Tensor&> mode_out(
+    const Tensor& self,
+    Dimname dim,
+    bool keepdim,
+    Tensor& values,
+    Tensor& indices) {
+  return at::mode_out(
+      values, indices, self, dimname_to_position(self, dim), keepdim);
 }
 
-TORCH_IMPL_FUNC(isin_Tensor_Tensor_out) (
-  const Tensor& elements, const Tensor& test_elements, bool assume_unique, bool invert, const Tensor& out
-) {
+TORCH_IMPL_FUNC(isin_Tensor_Tensor_out)
+(const Tensor& elements,
+ const Tensor& test_elements,
+ bool assume_unique,
+ bool invert,
+ const Tensor& out) {
   if (elements.numel() == 0) {
     return;
   }
 
   // Heuristic taken from numpy's implementation.
-  // See https://github.com/numpy/numpy/blob/fb215c76967739268de71aa4bda55dd1b062bc2e/numpy/lib/arraysetops.py#L575
-  if (test_elements.numel() < static_cast<int64_t>(
-        10.0f * std::pow(static_cast<double>(elements.numel()), 0.145))) {
+  // See
+  // https://github.com/numpy/numpy/blob/fb215c76967739268de71aa4bda55dd1b062bc2e/numpy/lib/arraysetops.py#L575
+  if (test_elements.numel() <
+      static_cast<int64_t>(
+          10.0f * std::pow(static_cast<double>(elements.numel()), 0.145))) {
     out.fill_(invert);
-    isin_default_stub(elements.device().type(), elements, test_elements, invert, out);
+    isin_default_stub(
+        elements.device().type(), elements, test_elements, invert, out);
   } else {
     isin_sorting(elements, test_elements, assume_unique, invert, out);
   }
 }
 
-TORCH_IMPL_FUNC(isin_Tensor_Scalar_out) (
-  const Tensor& elements, const c10::Scalar& test_elements, bool assume_unique, bool invert, const Tensor& out
-) {
+TORCH_IMPL_FUNC(isin_Tensor_Scalar_out)
+(const Tensor& elements,
+ const c10::Scalar& test_elements,
+ bool assume_unique,
+ bool invert,
+ const Tensor& out) {
   // redispatch to eq / ne
   if (invert) {
     at::ne_out(const_cast<Tensor&>(out), elements, test_elements);
@@ -830,15 +1008,22 @@ TORCH_IMPL_FUNC(isin_Tensor_Scalar_out) (
   }
 }
 
-TORCH_IMPL_FUNC(isin_Scalar_Tensor_out) (
-  const c10::Scalar& elements, const Tensor& test_elements, bool assume_unique, bool invert, const Tensor& out
-) {
+TORCH_IMPL_FUNC(isin_Scalar_Tensor_out)
+(const c10::Scalar& elements,
+ const Tensor& test_elements,
+ bool assume_unique,
+ bool invert,
+ const Tensor& out) {
   // redispatch
-  at::isin_out(const_cast<Tensor&>(out), wrapped_scalar_tensor(elements, test_elements.device()),
-    test_elements, assume_unique, invert);
+  at::isin_out(
+      const_cast<Tensor&>(out),
+      wrapped_scalar_tensor(elements, test_elements.device()),
+      test_elements,
+      assume_unique,
+      invert);
 }
 
-TORCH_IMPL_FUNC(isposinf_out) (const Tensor& self, const Tensor& result) {
+TORCH_IMPL_FUNC(isposinf_out)(const Tensor& self, const Tensor& result) {
   if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
     result.fill_(false);
   } else {
@@ -846,7 +1031,7 @@ TORCH_IMPL_FUNC(isposinf_out) (const Tensor& self, const Tensor& result) {
   }
 }
 
-TORCH_IMPL_FUNC(isneginf_out) (const Tensor& self, const Tensor& result) {
+TORCH_IMPL_FUNC(isneginf_out)(const Tensor& self, const Tensor& result) {
   if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
     result.fill_(false);
   } else {

--- a/aten/src/ATen/native/TensorCompare.h
+++ b/aten/src/ATen/native/TensorCompare.h
@@ -10,7 +10,7 @@ namespace at {
 class Tensor;
 struct TensorIterator;
 struct TensorIteratorBase;
-}
+} // namespace at
 
 namespace at::native {
 
@@ -22,28 +22,35 @@ using structured_reduce_minmax_fn =
 DECLARE_DISPATCH(structured_reduce_minmax_fn, max_stub)
 DECLARE_DISPATCH(structured_reduce_minmax_fn, min_stub)
 
-using where_fn = void (*)(TensorIterator &);
+using where_fn = void (*)(TensorIterator&);
 DECLARE_DISPATCH(where_fn, where_kernel)
 
-using is_infinity_op_fn = void (*)(TensorIteratorBase &);
+using is_infinity_op_fn = void (*)(TensorIteratorBase&);
 DECLARE_DISPATCH(is_infinity_op_fn, isposinf_stub)
 DECLARE_DISPATCH(is_infinity_op_fn, isneginf_stub)
 
 using mode_fn = void (*)(Tensor&, Tensor&, const Tensor&, int64_t, bool);
 DECLARE_DISPATCH(mode_fn, mode_stub)
 
-using clamp_tensor_fn = void (*)(TensorIteratorBase &);
+using clamp_tensor_fn = void (*)(TensorIteratorBase&);
 DECLARE_DISPATCH(clamp_tensor_fn, clamp_stub)
 
 namespace detail {
-    enum class ClampLimits {Min, Max, MinMax};
+enum class ClampLimits { Min, Max, MinMax };
 }
 
-DECLARE_DISPATCH(void (*)(TensorIteratorBase &, const c10::Scalar&, const c10::Scalar&), clamp_scalar_stub)
-DECLARE_DISPATCH(void (*)(TensorIteratorBase &, c10::Scalar), clamp_min_scalar_stub)
-DECLARE_DISPATCH(void (*)(TensorIteratorBase &, c10::Scalar), clamp_max_scalar_stub)
+DECLARE_DISPATCH(
+    void (*)(TensorIteratorBase&, const c10::Scalar&, const c10::Scalar&),
+    clamp_scalar_stub)
+DECLARE_DISPATCH(
+    void (*)(TensorIteratorBase&, c10::Scalar),
+    clamp_min_scalar_stub)
+DECLARE_DISPATCH(
+    void (*)(TensorIteratorBase&, c10::Scalar),
+    clamp_max_scalar_stub)
 
-using isin_default_fn = void (*)(const Tensor&, const Tensor&, bool, const Tensor&);
+using isin_default_fn =
+    void (*)(const Tensor&, const Tensor&, bool, const Tensor&);
 DECLARE_DISPATCH(isin_default_fn, isin_default_stub)
 
 } // namespace at::native

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -1,11 +1,11 @@
 // #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/ATen.h>
-#include <ATen/core/Tensor.h>
-#include <optional>
-#include <ATen/quantized/Quantizer.h>
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
 #include <ATen/TensorOperators.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/quantized/Quantizer.h>
+#include <optional>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -20,8 +20,8 @@
 #include <ATen/ops/_sparse_bsc_tensor_unsafe_native.h>
 #include <ATen/ops/_sparse_bsr_tensor_unsafe_native.h>
 #include <ATen/ops/_sparse_compressed_tensor_unsafe_native.h>
-#include <ATen/ops/_sparse_coo_tensor_with_dims_native.h>
 #include <ATen/ops/_sparse_coo_tensor_unsafe_native.h>
+#include <ATen/ops/_sparse_coo_tensor_with_dims_native.h>
 #include <ATen/ops/_sparse_csc_tensor_unsafe_native.h>
 #include <ATen/ops/_sparse_csr_tensor_unsafe_native.h>
 #include <ATen/ops/_to_copy.h>
@@ -216,11 +216,13 @@ static inline Device ensure_has_index(Device device) {
   if (device.is_cpu() || device.has_index()) {
     return device;
   }
-  const c10::impl::DeviceGuardImplInterface* impl = c10::impl::getDeviceGuardImpl(device.type());
+  const c10::impl::DeviceGuardImplInterface* impl =
+      c10::impl::getDeviceGuardImpl(device.type());
   return impl->getDevice();
 }
 
-static inline std::optional<Device> ensure_has_index(std::optional<Device> device) {
+static inline std::optional<Device> ensure_has_index(
+    std::optional<Device> device) {
   if (!device.has_value()) {
     return std::nullopt;
   }
@@ -235,15 +237,16 @@ Tensor _to_copy(
     std::optional<bool> pin_memory,
     bool non_blocking,
     std::optional<c10::MemoryFormat> optional_memory_format) {
-  TORCH_CHECK(!layout.has_value() || self.layout() == layout.value(),
-           "to(options) doesn't support converting to a different layout, "
-           "but got self.layout being ", self.layout(),
-           " and options.layout set as ", layout.value());
-  auto options = TensorOptions()
-    .dtype(dtype)
-    .layout(layout)
-    .device(device)
-    .pinned_memory(pin_memory);
+  TORCH_CHECK(
+      !layout.has_value() || self.layout() == layout.value(),
+      "to(options) doesn't support converting to a different layout, "
+      "but got self.layout being ",
+      self.layout(),
+      " and options.layout set as ",
+      layout.value());
+  auto options =
+      TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(
+          pin_memory);
 
   if (options.has_device()) {
     options = options.device(ensure_has_index(options.device()));
@@ -255,12 +258,13 @@ Tensor _to_copy(
   // TODO: Use the dispatcher for this.
   // Currently there are unenumerated extensibility issues preventing this.
   if (self.layout() == kSparse) {
-      TORCH_CHECK(
-          memory_format == MemoryFormat::Preserve,
-          "to(options): COO only supports memory format Preserve, but got ", memory_format,
-          " instead.");
+    TORCH_CHECK(
+        memory_format == MemoryFormat::Preserve,
+        "to(options): COO only supports memory format Preserve, but got ",
+        memory_format,
+        " instead.");
     if (options.device().is_meta()) {
-        return zeros_like(self, options);
+      return zeros_like(self, options);
     }
     auto indices = self._indices();
     const auto new_indices = at::native::to(
@@ -283,52 +287,52 @@ Tensor _to_copy(
         memory_format);
 
     return at::_sparse_coo_tensor_unsafe(
-        new_indices,
-        new_values,
-        self.sizes(),
-        options, self.is_coalesced());
+        new_indices, new_values, self.sizes(), options, self.is_coalesced());
   } else if (at::sparse_csr::is_sparse_compressed(self)) {
-      TORCH_CHECK(
-          memory_format == MemoryFormat::Preserve,
-          "to(options): ", at::sparse_csr::layoutToString(self.layout()),
-          " only supports memory format Preserve, but got ", memory_format,
-          " instead.");
+    TORCH_CHECK(
+        memory_format == MemoryFormat::Preserve,
+        "to(options): ",
+        at::sparse_csr::layoutToString(self.layout()),
+        " only supports memory format Preserve, but got ",
+        memory_format,
+        " instead.");
 
-      if (options.device().is_meta()) {
-        return zeros_like(self, options);
-      }
+    if (options.device().is_meta()) {
+      return zeros_like(self, options);
+    }
 
-      auto [compressed_indices, plain_indices] = at::sparse_csr::getCompressedPlainIndices(self);
+    auto [compressed_indices, plain_indices] =
+        at::sparse_csr::getCompressedPlainIndices(self);
 
-      const auto new_values = at::native::to(
-          self.values(),
-          dtype,
-          c10::kStrided,
-          device,
-          pin_memory,
-          non_blocking,
-          true, // force copy since we are in _to_copy
-          memory_format);
+    const auto new_values = at::native::to(
+        self.values(),
+        dtype,
+        c10::kStrided,
+        device,
+        pin_memory,
+        non_blocking,
+        true, // force copy since we are in _to_copy
+        memory_format);
 
-      const auto new_compressed_indices = at::native::to(
-          compressed_indices,
-          compressed_indices.scalar_type(),
-          c10::kStrided,
-          device,
-          pin_memory,
-          non_blocking,
-          true, // force copy since we are in _to_copy
-          memory_format);
+    const auto new_compressed_indices = at::native::to(
+        compressed_indices,
+        compressed_indices.scalar_type(),
+        c10::kStrided,
+        device,
+        pin_memory,
+        non_blocking,
+        true, // force copy since we are in _to_copy
+        memory_format);
 
-      const auto new_plain_indices = at::native::to(
-          plain_indices,
-          plain_indices.scalar_type(),
-          c10::kStrided,
-          device,
-          pin_memory,
-          non_blocking,
-          true, // force copy since we are in _to_copy
-          memory_format);
+    const auto new_plain_indices = at::native::to(
+        plain_indices,
+        plain_indices.scalar_type(),
+        c10::kStrided,
+        device,
+        pin_memory,
+        non_blocking,
+        true, // force copy since we are in _to_copy
+        memory_format);
 
     return at::_sparse_compressed_tensor_unsafe(
         new_compressed_indices,
@@ -338,8 +342,9 @@ Tensor _to_copy(
         options);
   }
 
-  bool pin_out = (non_blocking && (self.is_cuda() || self.is_privateuseone())
-                  && options.device().is_cpu() && (options.layout() == c10::kStrided));
+  bool pin_out =
+      (non_blocking && (self.is_cuda() || self.is_privateuseone()) &&
+       options.device().is_cpu() && (options.layout() == c10::kStrided));
 
   if (memory_format == MemoryFormat::Preserve) {
     if (options.device().supports_as_strided()) {
@@ -352,21 +357,17 @@ Tensor _to_copy(
           set_quantizer_(r, quantizer);
         } else {
           r = at::empty_strided(
-              self.sizes(),
-              self.strides(),
-              options.pinned_memory(pin_out));
+              self.sizes(), self.strides(), options.pinned_memory(pin_out));
           r.copy_(self, non_blocking);
         }
         return r;
       } else if (!self.is_quantized() && self.layout() == kStrided) {
-          Tensor r;
-          auto strides = infer_dense_strides(self.sizes(), self.strides());
-          r = at::empty_strided(
-              self.sizes(),
-              strides,
-              options.pinned_memory(pin_out));
-          r.copy_(self, non_blocking);
-          return r;
+        Tensor r;
+        auto strides = infer_dense_strides(self.sizes(), self.strides());
+        r = at::empty_strided(
+            self.sizes(), strides, options.pinned_memory(pin_out));
+        r.copy_(self, non_blocking);
+        return r;
       } else {
         memory_format = self.suggest_memory_format();
       }
@@ -375,19 +376,26 @@ Tensor _to_copy(
     }
   }
   // See Note [Explicit nullopt MemoryFormat argument]
-  // TODO: empty_quantized does not work here. It raises an exception in CheckMemoryFormat.h prior to
+  // TODO: empty_quantized does not work here. It raises an exception in
+  // CheckMemoryFormat.h prior to
   // empty_affine_quantized/_empty_per_channel_affine_quantized calls
-  // at::empty also does not work here because there is no proper at::empty support for quantized tensors
-  // as it would return a quantized tensor with an UnknownQuantizer
-  auto r = self.is_quantized() ? at::empty_like(self, memory_format)
-                               : at::empty_symint(self.sym_sizes(),
-                                 options.memory_format(memory_format).pinned_memory(pin_out), std::nullopt);
+  // at::empty also does not work here because there is no proper at::empty
+  // support for quantized tensors as it would return a quantized tensor with an
+  // UnknownQuantizer
+  auto r = self.is_quantized()
+      ? at::empty_like(self, memory_format)
+      : at::empty_symint(
+            self.sym_sizes(),
+            options.memory_format(memory_format).pinned_memory(pin_out),
+            std::nullopt);
   r.copy_(self, non_blocking);
   return r;
 }
 
 template <typename T>
-static inline bool is_null_or_equal_to(const std::optional<T>& test, const T& value) {
+static inline bool is_null_or_equal_to(
+    const std::optional<T>& test,
+    const T& value) {
   if (!test.has_value()) {
     return true;
   }
@@ -407,11 +415,10 @@ bool to_will_alias(
   auto memory_format = optional_memory_format.value_or(MemoryFormat::Preserve);
 
   return is_null_or_equal_to(dtype, self.dtype().toScalarType()) &&
-    is_null_or_equal_to(layout, self.layout()) &&
-    is_null_or_equal_to(device, self.device()) &&
-    !copy &&
-    (memory_format == MemoryFormat::Preserve ||
-     self.suggest_memory_format() == memory_format);
+      is_null_or_equal_to(layout, self.layout()) &&
+      is_null_or_equal_to(device, self.device()) && !copy &&
+      (memory_format == MemoryFormat::Preserve ||
+       self.suggest_memory_format() == memory_format);
 }
 
 static inline Tensor to_impl(
@@ -423,22 +430,32 @@ static inline Tensor to_impl(
     bool non_blocking,
     bool copy,
     std::optional<c10::MemoryFormat> optional_memory_format) {
-
   // fast path
-  if (to_will_alias(self, dtype, layout, device, copy, optional_memory_format)) {
+  if (to_will_alias(
+          self, dtype, layout, device, copy, optional_memory_format)) {
     return self;
   }
   return at::_to_copy(
-      self, dtype, layout, device, pin_memory, non_blocking, optional_memory_format);
+      self,
+      dtype,
+      layout,
+      device,
+      pin_memory,
+      non_blocking,
+      optional_memory_format);
 }
 
 // If input tensor is fp32, cast it to fp16, otherwise leave it alone.
 // (this is intended to be used internally by the JIT autocast implementation)
-Tensor _autocast_to_reduced_precision(const Tensor& self, bool cuda_enabled, bool cpu_enabled, ScalarType cuda_dtype, ScalarType cpu_dtype) {
+Tensor _autocast_to_reduced_precision(
+    const Tensor& self,
+    bool cuda_enabled,
+    bool cpu_enabled,
+    ScalarType cuda_dtype,
+    ScalarType cpu_dtype) {
   if (self.dtype() == at::ScalarType::Float &&
       ((self.device().is_cuda() && cuda_enabled) ||
-      (self.device().is_cpu() && cpu_enabled))
-      ) {
+       (self.device().is_cpu() && cpu_enabled))) {
     at::ScalarType target = at::ScalarType::Undefined;
     if (self.device().is_cuda()) {
       target = cuda_dtype;
@@ -446,10 +463,19 @@ Tensor _autocast_to_reduced_precision(const Tensor& self, bool cuda_enabled, boo
       target = cpu_dtype;
     }
 
-    TORCH_INTERNAL_ASSERT(target != at::ScalarType::Undefined, "_autocast_to_reduced_precision requires legit ScalarType argument for given device");
+    TORCH_INTERNAL_ASSERT(
+        target != at::ScalarType::Undefined,
+        "_autocast_to_reduced_precision requires legit ScalarType argument for given device");
 
     return to_impl(
-        self, target, std::nullopt, std::nullopt, std::nullopt, false, false, std::nullopt);
+        self,
+        target,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        false,
+        false,
+        std::nullopt);
   } else {
     return self;
   }
@@ -457,28 +483,37 @@ Tensor _autocast_to_reduced_precision(const Tensor& self, bool cuda_enabled, boo
 
 // If input tensor is fp16, cast it to fp32, otherwise leave it alone.
 // (this is intended to be used internally by the JIT autocast implementation)
-Tensor _autocast_to_full_precision(const Tensor& self, bool cuda_enabled, bool cpu_enabled) {
-  if ((self.dtype() == at::ScalarType::Half || self.dtype() == at::ScalarType::BFloat16) &&
+Tensor _autocast_to_full_precision(
+    const Tensor& self,
+    bool cuda_enabled,
+    bool cpu_enabled) {
+  if ((self.dtype() == at::ScalarType::Half ||
+       self.dtype() == at::ScalarType::BFloat16) &&
       ((self.device().is_cuda() && cuda_enabled) ||
-      (self.device().is_cpu() && cpu_enabled))
-      ) {
+       (self.device().is_cpu() && cpu_enabled))) {
     return to_impl(
-        self, at::ScalarType::Float, std::nullopt, std::nullopt, std::nullopt, false, false, std::nullopt);
+        self,
+        at::ScalarType::Float,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        false,
+        false,
+        std::nullopt);
   } else {
     return self;
   }
 }
 
 Tensor to(
-  const Tensor& self,
+    const Tensor& self,
     std::optional<ScalarType> dtype,
     std::optional<Layout> layout,
     std::optional<Device> device,
     std::optional<bool> pin_memory,
-  bool non_blocking,
-  bool copy,
-  std::optional<c10::MemoryFormat> optional_memory_format
-) {
+    bool non_blocking,
+    bool copy,
+    std::optional<c10::MemoryFormat> optional_memory_format) {
   return to_impl(
       self,
       dtype,
@@ -490,7 +525,13 @@ Tensor to(
       optional_memory_format);
 }
 
-Tensor to(const Tensor& self, Device device, ScalarType dtype, bool non_blocking, bool copy, std::optional<c10::MemoryFormat> optional_memory_format) {
+Tensor to(
+    const Tensor& self,
+    Device device,
+    ScalarType dtype,
+    bool non_blocking,
+    bool copy,
+    std::optional<c10::MemoryFormat> optional_memory_format) {
   return to_impl(
       self,
       dtype,
@@ -502,7 +543,12 @@ Tensor to(const Tensor& self, Device device, ScalarType dtype, bool non_blocking
       optional_memory_format);
 }
 
-Tensor to(const Tensor& self, ScalarType dtype, bool non_blocking, bool copy, std::optional<c10::MemoryFormat> optional_memory_format) {
+Tensor to(
+    const Tensor& self,
+    ScalarType dtype,
+    bool non_blocking,
+    bool copy,
+    std::optional<c10::MemoryFormat> optional_memory_format) {
   return to_impl(
       self,
       dtype,
@@ -514,7 +560,12 @@ Tensor to(const Tensor& self, ScalarType dtype, bool non_blocking, bool copy, st
       optional_memory_format);
 }
 
-Tensor to(const Tensor& self, const Tensor& other, bool non_blocking, bool copy, std::optional<c10::MemoryFormat> optional_memory_format) {
+Tensor to(
+    const Tensor& self,
+    const Tensor& other,
+    bool non_blocking,
+    bool copy,
+    std::optional<c10::MemoryFormat> optional_memory_format) {
   auto options = other.options();
   return to_impl(
       self,
@@ -528,17 +579,21 @@ Tensor to(const Tensor& self, const Tensor& other, bool non_blocking, bool copy,
 }
 
 // This op is important primarily for lazy / graph-based backends.
-// While this vanilla implementation loops through each tensor and independently converts it to cpu,
-// a lazy backend like XLA might need to tell sync updates across tensors.
+// While this vanilla implementation loops through each tensor and independently
+// converts it to cpu, a lazy backend like XLA might need to tell sync updates
+// across tensors.
 std::vector<Tensor> _to_cpu(TensorList tensors) {
-    std::vector<Tensor> cpu_tensors;
-    for (const auto& t : tensors) {
-        cpu_tensors.push_back(t.cpu());
-    }
-    return cpu_tensors;
+  std::vector<Tensor> cpu_tensors;
+  for (const auto& t : tensors) {
+    cpu_tensors.push_back(t.cpu());
+  }
+  return cpu_tensors;
 }
 
-Tensor to_dense_backward(const Tensor& grad, const Tensor& input_, std::optional<bool> masked_grad_) {
+Tensor to_dense_backward(
+    const Tensor& grad,
+    const Tensor& input_,
+    std::optional<bool> masked_grad_) {
   /*
     For historical reasons, to_dense backward implements masked
     semantics for sparse tensors, that is, gradients with respect to
@@ -558,7 +613,8 @@ Tensor to_dense_backward(const Tensor& grad, const Tensor& input_, std::optional
       // TODO: return grad as it is
       return grad.to_dense(input_.scalar_type(), masked_grad_);
     case kSparse:
-      // Autograd operates on the coalesced assumption, i.e. no duplicate values.
+      // Autograd operates on the coalesced assumption, i.e. no duplicate
+      // values.
       if (masked_grad) {
         return grad.sparse_mask(input_.coalesce());
       } else {
@@ -569,17 +625,22 @@ Tensor to_dense_backward(const Tensor& grad, const Tensor& input_, std::optional
     case kSparseCsc:
       // TODO: add efficient CSR/CSC support for sparse_mask
       if (masked_grad) {
-        return grad.sparse_mask(input_.to_sparse(input_.sparse_dim())).to_sparse(input_layout);
+        return grad.sparse_mask(input_.to_sparse(input_.sparse_dim()))
+            .to_sparse(input_layout);
       } else {
         // TODO: return grad as it is
-        return grad.to_sparse(input_layout, /*blocksize=*/std::nullopt, /*dense_dim=*/input_.dense_dim());
+        return grad.to_sparse(
+            input_layout,
+            /*blocksize=*/std::nullopt,
+            /*dense_dim=*/input_.dense_dim());
       }
     case kSparseBsr:
     case kSparseBsc: {
       // TODO: add efficient BSR/BSC support for sparse_mask
       const auto blocksize = at::sparse_csr::getBlockSize(input_);
       if (masked_grad) {
-        return grad.sparse_mask(input_.to_sparse(input_.sparse_dim())).to_sparse(input_layout, blocksize);
+        return grad.sparse_mask(input_.to_sparse(input_.sparse_dim()))
+            .to_sparse(input_layout, blocksize);
       } else {
         // TODO: return grad as it is
         return grad.to_sparse(input_layout, blocksize, input_.dense_dim());
@@ -588,7 +649,8 @@ Tensor to_dense_backward(const Tensor& grad, const Tensor& input_, std::optional
     case kMkldnn:
       return grad.to_mkldnn(input_.scalar_type());
     default:
-      TORCH_CHECK(false, "to_dense_backward: Unsupported input layout: ", input_layout);
+      TORCH_CHECK(
+          false, "to_dense_backward: Unsupported input layout: ", input_layout);
       return Tensor{};
   }
 }
@@ -598,7 +660,10 @@ Tensor to_mkldnn_backward(const Tensor& grad, const Tensor& input_) {
   return grad.to_dense(input_.scalar_type());
 }
 
-Tensor to_dense(const Tensor& tensor, std::optional<c10::ScalarType> dtype, std::optional<bool> masked_grad) {
+Tensor to_dense(
+    const Tensor& tensor,
+    std::optional<c10::ScalarType> dtype,
+    std::optional<bool> masked_grad) {
   if (tensor.layout() == c10::kSparse) {
     return tensor._to_dense(dtype, masked_grad);
   }
@@ -621,7 +686,10 @@ Tensor to_dense(const Tensor& tensor, std::optional<c10::ScalarType> dtype, std:
   return tensor;
 }
 
-Tensor sparse_to_dense(const Tensor& self, std::optional<ScalarType> dtype, std::optional<bool> masked) {
+Tensor sparse_to_dense(
+    const Tensor& self,
+    std::optional<ScalarType> dtype,
+    std::optional<bool> masked) {
   TORCH_CHECK(
       !dtype.has_value(), "dtype argument is not supported by sparse_to_dense");
   Tensor dst = at::zeros(self.sizes(), self.options().layout(kStrided));
@@ -642,8 +710,10 @@ Tensor sparse_compressed_to_dense(
 
   auto batch_ndim = sparse_csr::numBatchDimensions(self);
 
-  auto compressed_rows = self.layout() == kSparseCsr || self.layout() == kSparseBsr;
-  auto block_sparse = self.layout() == kSparseBsr || self.layout() == kSparseBsc;
+  auto compressed_rows =
+      self.layout() == kSparseCsr || self.layout() == kSparseBsr;
+  auto block_sparse =
+      self.layout() == kSparseBsr || self.layout() == kSparseBsc;
 
   auto [compressed_indices, plain_indices] =
       sparse_csr::getCompressedPlainIndices(self);
@@ -678,7 +748,8 @@ Tensor sparse_compressed_to_dense(
   if (!block_sparse) {
     nrows = self.size(batch_ndim);
     ncols = self.size(batch_ndim + 1);
-    dense_reshaped_sizes.erase(dense_reshaped_sizes.begin(), dense_reshaped_sizes.begin() + 2);
+    dense_reshaped_sizes.erase(
+        dense_reshaped_sizes.begin(), dense_reshaped_sizes.begin() + 2);
   } else {
     std::array<int64_t, 2> blocksize = {values.size(2), values.size(3)};
     nrows = self.size(batch_ndim) / blocksize[0];
@@ -696,12 +767,14 @@ Tensor sparse_compressed_to_dense(
   // calculated this way.
   auto options = compressed_indices.options();
   auto nnz_per_batch = values.size(1);
-  auto batch_indices = at::arange(0, n_batch, options).repeat_interleave(nnz_per_batch);
+  auto batch_indices =
+      at::arange(0, n_batch, options).repeat_interleave(nnz_per_batch);
   auto ncompressed = compressed_rows ? nrows : ncols;
-  auto compressed_indices_over_all_batches =
-    at::cat({compressed_indices.slice(1, 0, ncompressed).flatten()
-            + nnz_per_batch * at::arange(0, n_batch, options).repeat_interleave(ncompressed),
-            n_batch * nnz_per_batch * at::ones({1}, options)});
+  auto compressed_indices_over_all_batches = at::cat(
+      {compressed_indices.slice(1, 0, ncompressed).flatten() +
+           nnz_per_batch *
+               at::arange(0, n_batch, options).repeat_interleave(ncompressed),
+       n_batch * nnz_per_batch * at::ones({1}, options)});
   Tensor indices = at::_convert_indices_from_csr_to_coo(
       compressed_indices_over_all_batches,
       plain_indices.flatten(),
@@ -714,7 +787,8 @@ Tensor sparse_compressed_to_dense(
   } else {
     col_indices -= batch_indices * ncols;
   }
-  auto offsets = col_indices + row_indices * ncols + batch_indices * nrows * ncols;
+  auto offsets =
+      col_indices + row_indices * ncols + batch_indices * nrows * ncols;
   dense.index_add_(0, offsets, values.flatten(0, 1));
 
   // Un-tile the result.  The final reshape uses the original
@@ -723,8 +797,7 @@ Tensor sparse_compressed_to_dense(
   if (!block_sparse) {
     return dense.reshape(self.sizes());
   } else {
-    return dense
-      .unflatten(0, {-1, nrows, ncols})
+    return dense.unflatten(0, {-1, nrows, ncols})
         .transpose(2, 3)
         .reshape(self.sizes());
   }
@@ -732,13 +805,21 @@ Tensor sparse_compressed_to_dense(
 
 // Computes the strides for view_dtype output when the view dtype is
 // smaller than the original dtype
-inline SymDimVector compute_strides_for_view_dtype_downsize(SymIntArrayRef old_strides, int64_t size_ratio, ScalarType old_dtype, ScalarType new_dtype) {
+inline SymDimVector compute_strides_for_view_dtype_downsize(
+    SymIntArrayRef old_strides,
+    int64_t size_ratio,
+    ScalarType old_dtype,
+    ScalarType new_dtype) {
   const int64_t ndim = old_strides.size();
 
   TORCH_CHECK(
-    old_strides[ndim - 1] == 1,
-    "self.stride(-1) must be 1 to view ", old_dtype, " as ", new_dtype,
-    " (different element sizes), but got ", old_strides[ndim - 1]);
+      old_strides[ndim - 1] == 1,
+      "self.stride(-1) must be 1 to view ",
+      old_dtype,
+      " as ",
+      new_dtype,
+      " (different element sizes), but got ",
+      old_strides[ndim - 1]);
 
   SymDimVector new_strides(ndim);
   for (int64_t dim_idx = 0; dim_idx < ndim - 1; dim_idx++) {
@@ -750,20 +831,36 @@ inline SymDimVector compute_strides_for_view_dtype_downsize(SymIntArrayRef old_s
 
 // Computes the strides for view_dtype output when the view dtype is
 // larger than the original dtype
-inline SymDimVector compute_strides_for_view_dtype_upsize(SymIntArrayRef old_strides, int64_t size_ratio, ScalarType old_dtype, ScalarType new_dtype) {
+inline SymDimVector compute_strides_for_view_dtype_upsize(
+    SymIntArrayRef old_strides,
+    int64_t size_ratio,
+    ScalarType old_dtype,
+    ScalarType new_dtype) {
   const int64_t ndim = old_strides.size();
   TORCH_CHECK(
-    old_strides[ndim - 1] == 1,
-    "self.stride(-1) must be 1 to view ", old_dtype, " as ", new_dtype,
-    " (different element sizes), but got ", old_strides[ndim - 1]);
+      old_strides[ndim - 1] == 1,
+      "self.stride(-1) must be 1 to view ",
+      old_dtype,
+      " as ",
+      new_dtype,
+      " (different element sizes), but got ",
+      old_strides[ndim - 1]);
 
   SymDimVector new_strides(ndim);
   for (int64_t dim_idx = 0; dim_idx < ndim - 1; dim_idx++) {
     TORCH_CHECK(
-      (old_strides[dim_idx] % size_ratio) == 0,
-      "self.stride(", dim_idx, ") must be divisible by ", size_ratio,
-      " to view ", old_dtype, " as ", new_dtype, " (different element sizes), ",
-      "but got ", old_strides[dim_idx]);
+        (old_strides[dim_idx] % size_ratio) == 0,
+        "self.stride(",
+        dim_idx,
+        ") must be divisible by ",
+        size_ratio,
+        " to view ",
+        old_dtype,
+        " as ",
+        new_dtype,
+        " (different element sizes), ",
+        "but got ",
+        old_strides[dim_idx]);
 
     new_strides[dim_idx] = old_strides[dim_idx] / size_ratio;
   }
@@ -773,10 +870,12 @@ inline SymDimVector compute_strides_for_view_dtype_upsize(SymIntArrayRef old_str
 
 Tensor view_dtype(const Tensor& self, ScalarType dtype) {
   const auto type_meta = c10::scalarTypeToTypeMeta(dtype);
-  TORCH_CHECK(!self.is_conj(),
-    "torch.Tensor.view is not supported for conjugate view tensors when converting to a different dtype.");
-  TORCH_CHECK(!self.is_neg(),
-    "torch.Tensor.view is not supported for tensors with negative bit set when converting to a different dtype.");
+  TORCH_CHECK(
+      !self.is_conj(),
+      "torch.Tensor.view is not supported for conjugate view tensors when converting to a different dtype.");
+  TORCH_CHECK(
+      !self.is_neg(),
+      "torch.Tensor.view is not supported for tensors with negative bit set when converting to a different dtype.");
 
   int64_t self_element_size = self.element_size();
   int64_t new_element_size = static_cast<int64_t>(type_meta.itemsize());
@@ -787,19 +886,24 @@ Tensor view_dtype(const Tensor& self, ScalarType dtype) {
   auto* impl = new_tensor.unsafeGetTensorImpl();
 
   if (self_element_size == new_element_size) {
-    impl->set_sizes_and_strides(self.sym_sizes(), self.sym_strides(), self.sym_storage_offset());
+    impl->set_sizes_and_strides(
+        self.sym_sizes(), self.sym_strides(), self.sym_storage_offset());
 
   } else if (self.dim() == 0) {
-    TORCH_CHECK(false,
-      "self.dim() cannot be 0 to view ", self.scalar_type(), " as ",
-      dtype, " (different element sizes)");
+    TORCH_CHECK(
+        false,
+        "self.dim() cannot be 0 to view ",
+        self.scalar_type(),
+        " as ",
+        dtype,
+        " (different element sizes)");
 
   } else if (self_element_size > new_element_size) {
     // Downsizing element size
 
     int64_t size_ratio = self_element_size / new_element_size;
     auto new_strides = compute_strides_for_view_dtype_downsize(
-      self.sym_strides(), size_ratio, self.scalar_type(), dtype);
+        self.sym_strides(), size_ratio, self.scalar_type(), dtype);
 
     auto old_sizes = self.sym_sizes();
     SymDimVector new_sizes(self.dim());
@@ -816,19 +920,30 @@ Tensor view_dtype(const Tensor& self, ScalarType dtype) {
     int64_t size_ratio = new_element_size / self_element_size;
 
     TORCH_CHECK(
-      (self.sym_size(-1) % size_ratio) == 0,
-      "self.size(-1) must be divisible by ", size_ratio, " to view ",
-      self.scalar_type(), " as ", dtype, " (different element sizes), ",
-      "but got ", self.sym_size(-1));
+        (self.sym_size(-1) % size_ratio) == 0,
+        "self.size(-1) must be divisible by ",
+        size_ratio,
+        " to view ",
+        self.scalar_type(),
+        " as ",
+        dtype,
+        " (different element sizes), ",
+        "but got ",
+        self.sym_size(-1));
 
     TORCH_CHECK(
-      (self.sym_storage_offset() % size_ratio) == 0,
-      "self.storage_offset() must be divisible by ", size_ratio, " to view ",
-      self.scalar_type(), " as ", dtype, " (different element sizes), but got ",
-      self.sym_storage_offset());
+        (self.sym_storage_offset() % size_ratio) == 0,
+        "self.storage_offset() must be divisible by ",
+        size_ratio,
+        " to view ",
+        self.scalar_type(),
+        " as ",
+        dtype,
+        " (different element sizes), but got ",
+        self.sym_storage_offset());
 
     auto new_strides = compute_strides_for_view_dtype_upsize(
-      self.sym_strides(), size_ratio, self.scalar_type(), dtype);
+        self.sym_strides(), size_ratio, self.scalar_type(), dtype);
 
     auto old_sizes = self.sym_sizes();
     SymDimVector new_sizes(self.dim());
@@ -865,14 +980,16 @@ static Tensor _tile_tensor(const Tensor& self, IntArrayRef blocksize) {
   auto block_size_0 = self.size(0) / blocksize[0];
   auto block_size_1 = self.size(1) / blocksize[1];
 
-  auto new_shape = DimVector({block_size_0, blocksize[0], block_size_1, blocksize[1]});
+  auto new_shape =
+      DimVector({block_size_0, blocksize[0], block_size_1, blocksize[1]});
   new_shape.append(DimVector(self.sizes().slice(2, self.dim() - 2)));
-  return self.reshape(new_shape)
-      .transpose(1, 2)
-      .contiguous();
+  return self.reshape(new_shape).transpose(1, 2).contiguous();
 }
 
-static Tensor _batch_tile_tensor(const Tensor& self, IntArrayRef blocksize, const int64_t dense_dim) {
+static Tensor _batch_tile_tensor(
+    const Tensor& self,
+    IntArrayRef blocksize,
+    const int64_t dense_dim) {
   if (self.dim() == 2 + dense_dim) {
     return _tile_tensor(self, blocksize);
   }
@@ -888,17 +1005,19 @@ static Tensor _batch_tile_tensor(const Tensor& self, IntArrayRef blocksize, cons
   tiled_sizes.push_back(block_size_1);
   tiled_sizes.push_back(blocksize[1]);
   tiled_sizes.append(DimVector(self.sizes().slice(n_batch_dim + 2, dense_dim)));
-  return self.reshape(tiled_sizes).transpose(n_batch_dim + 1, n_batch_dim + 2).contiguous();
+  return self.reshape(tiled_sizes)
+      .transpose(n_batch_dim + 1, n_batch_dim + 2)
+      .contiguous();
 }
 
 static Tensor _mask_to_indices(const Tensor& mask) {
   // This function returns a vector of the indices at which given
   // boolean mask is True. at::nonzero can achieve the same, but
   // we yet have to compare the performance difference.
-  TORCH_CHECK(mask.dim() == 1, "Currently _mask_to_indices only supports 1-d masks.");
+  TORCH_CHECK(
+      mask.dim() == 1, "Currently _mask_to_indices only supports 1-d masks.");
   TORCH_CHECK(mask.dtype() == at::kBool, "Expected mask to be of dtype bool.");
-  return at::native::arange(
-      mask.numel(), at::kLong, kStrided, mask.device())
+  return at::native::arange(mask.numel(), at::kLong, kStrided, mask.device())
       .masked_select(mask);
 }
 
@@ -907,7 +1026,8 @@ static std::pair<Tensor, Tensor> _not_zero_mask_to_col_row_indices(
     ScalarType index_dtype,
     Device index_device) {
   auto col_indices =
-      at::native::arange(not_zero_mask.size(-1), index_dtype, kStrided, index_device)
+      at::native::arange(
+          not_zero_mask.size(-1), index_dtype, kStrided, index_device)
           .view({1, not_zero_mask.size(-1)})
           .expand_as(not_zero_mask)
           .masked_select(not_zero_mask);
@@ -922,122 +1042,247 @@ static std::pair<Tensor, Tensor> _not_zero_mask_to_col_row_indices(
 
 // Sparse layout conversions Start
 
-static inline
-void _to_sparse_check_arguments(const std::string& funcname, const Tensor& self, const int64_t sparse_dim) {
+static inline void _to_sparse_check_arguments(
+    const std::string& funcname,
+    const Tensor& self,
+    const int64_t sparse_dim) {
   auto layout_from = self.layout();
 
-  auto layout_from_valid = layout_from == kStrided || layout_from == kSparse || at::sparse_csr::is_sparse_compressed(layout_from);
+  auto layout_from_valid = layout_from == kStrided || layout_from == kSparse ||
+      at::sparse_csr::is_sparse_compressed(layout_from);
   if (!layout_from_valid) {
     TORCH_CHECK(false, funcname, ": unexpected source layout ", layout_from);
   }
 
   if (layout_from == kStrided) {
     if (sparse_dim == 0 && self.dim() > 0) {
-      TORCH_CHECK(false, funcname, ": sparse_dim argument must be in >0 when self.dim()>0");
+      TORCH_CHECK(
+          false,
+          funcname,
+          ": sparse_dim argument must be in >0 when self.dim()>0");
     }
     if (sparse_dim < 0 || sparse_dim > self.dim()) {
-      TORCH_CHECK(false, funcname, ": sparse_dim argument must be in [0,", self.dim(), "] range, but ", sparse_dim, " is given");
+      TORCH_CHECK(
+          false,
+          funcname,
+          ": sparse_dim argument must be in [0,",
+          self.dim(),
+          "] range, but ",
+          sparse_dim,
+          " is given");
     }
   } else if (layout_from == kSparse) {
     if (sparse_dim != self.sparse_dim()) {
-      TORCH_CHECK(false, funcname, ": conversion from ", layout_from, " to ", kSparse, " with sparse_dim argument !=self.sparse_dim() is not supported");
+      TORCH_CHECK(
+          false,
+          funcname,
+          ": conversion from ",
+          layout_from,
+          " to ",
+          kSparse,
+          " with sparse_dim argument !=self.sparse_dim() is not supported");
     }
   } else if (at::sparse_csr::is_sparse_compressed(layout_from)) {
     if (sparse_dim != 2) {
-      TORCH_CHECK(false, funcname, ": conversion from ", layout_from, " to ", kSparse, " with sparse_dim argument !=2 is not supported");
+      TORCH_CHECK(
+          false,
+          funcname,
+          ": conversion from ",
+          layout_from,
+          " to ",
+          kSparse,
+          " with sparse_dim argument !=2 is not supported");
     }
   }
 }
 
-static inline
-void _to_sparse_check_arguments(const std::string& funcname, const Tensor& self, std::optional<c10::Layout> layout, OptionalIntArrayRef blocksize, std::optional<int64_t> dense_dim_opt) {
+static inline void _to_sparse_check_arguments(
+    const std::string& funcname,
+    const Tensor& self,
+    std::optional<c10::Layout> layout,
+    OptionalIntArrayRef blocksize,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_from = self.layout();
   auto layout_to = layout.value_or(kSparse);
 
-  auto layout_from_valid = layout_from == kStrided || layout_from == kSparse || at::sparse_csr::is_sparse_compressed(layout_from);
+  auto layout_from_valid = layout_from == kStrided || layout_from == kSparse ||
+      at::sparse_csr::is_sparse_compressed(layout_from);
   if (!layout_from_valid) {
     TORCH_CHECK(false, funcname, ": unexpected source layout ", layout_from);
   }
-  auto layout_to_valid = layout_to == kStrided || layout_to == kSparse || at::sparse_csr::is_sparse_compressed(layout_to);
+  auto layout_to_valid = layout_to == kStrided || layout_to == kSparse ||
+      at::sparse_csr::is_sparse_compressed(layout_to);
   if (!layout_to_valid) {
     TORCH_CHECK(false, funcname, ": unexpected source layout ", layout_from);
   }
 
   if (layout_from == kSparse && layout_to != kSparse) {
     if (self.sparse_dim() != 2) {
-      TORCH_CHECK(false, funcname, ": conversion from ", layout_from, " to ", layout_to, " for input tensors with sparse_dim()!=2 is not supported");
+      TORCH_CHECK(
+          false,
+          funcname,
+          ": conversion from ",
+          layout_from,
+          " to ",
+          layout_to,
+          " for input tensors with sparse_dim()!=2 is not supported");
     }
   }
 
   if ((layout_from == kSparseCsr || layout_from == kSparseCsc) &&
       (layout_to == kSparseBsr || layout_to == kSparseBsc)) {
     if (sparse_csr::numBatchDimensions(self) > 0) {
-      TORCH_CHECK(false, funcname, ": conversion from ", layout_from, " to ", layout_to, " for batched inputs is not supported");
+      TORCH_CHECK(
+          false,
+          funcname,
+          ": conversion from ",
+          layout_from,
+          " to ",
+          layout_to,
+          " for batched inputs is not supported");
     }
   }
 
   if (blocksize.has_value()) {
     if (blocksize.value().size() != 2) {
-      TORCH_CHECK(false, funcname, ": blocksize needs to be a tuple of size 2, but got ", blocksize.value().size());
+      TORCH_CHECK(
+          false,
+          funcname,
+          ": blocksize needs to be a tuple of size 2, but got ",
+          blocksize.value().size());
     }
     auto blocksize_to = *blocksize;
     if (blocksize_to[0] <= 0 || blocksize_to[1] <= 0) {
-      TORCH_CHECK(false, funcname, ": blocksize needs to be positive, but got ", blocksize_to);
+      TORCH_CHECK(
+          false,
+          funcname,
+          ": blocksize needs to be positive, but got ",
+          blocksize_to);
     }
 
     if (layout_to == kSparseBsr || layout_to == kSparseBsc) {
       if (layout_from == kSparseBsr || layout_from == kSparseBsc) {
         auto blocksize_from = at::sparse_csr::getBlockSize(self);
         if (!(blocksize_to == blocksize_from)) {
-          TORCH_CHECK(false, funcname, ": conversion from ", layout_from, " to ", layout_to, " with blocksize changed from ", blocksize_from, " to ", blocksize_to, " is not supported");
+          TORCH_CHECK(
+              false,
+              funcname,
+              ": conversion from ",
+              layout_from,
+              " to ",
+              layout_to,
+              " with blocksize changed from ",
+              blocksize_from,
+              " to ",
+              blocksize_to,
+              " is not supported");
         }
       } else {
-        auto dense_dim = (layout_from == kStrided) ? dense_dim_opt.value_or(0) : self.dense_dim();
+        auto dense_dim = (layout_from == kStrided) ? dense_dim_opt.value_or(0)
+                                                   : self.dense_dim();
         auto sparse_row_dim = -(dense_dim + 2);
         auto sparse_col_dim = -(dense_dim + 1);
         if ((self.size(sparse_row_dim) % blocksize_to[0] != 0) ||
             (self.size(sparse_col_dim) % blocksize_to[1] != 0)) {
-            TORCH_CHECK(false, funcname, ": tensor sparse size (", self.size(sparse_row_dim), ",", self.size(sparse_row_dim), ") must be divisible by given blocksize (", blocksize_to[0], ",", blocksize_to[1], ")");
+          TORCH_CHECK(
+              false,
+              funcname,
+              ": tensor sparse size (",
+              self.size(sparse_row_dim),
+              ",",
+              self.size(sparse_row_dim),
+              ") must be divisible by given blocksize (",
+              blocksize_to[0],
+              ",",
+              blocksize_to[1],
+              ")");
         }
       }
     } else {
-      TORCH_CHECK(false, funcname, ": conversion from ", layout_from, " to ", layout_to, " with blocksize argument given is not supported");
+      TORCH_CHECK(
+          false,
+          funcname,
+          ": conversion from ",
+          layout_from,
+          " to ",
+          layout_to,
+          " with blocksize argument given is not supported");
     }
   } else {
     if ((layout_to == kSparseBsr || layout_to == kSparseBsc) &&
         !(layout_from == kSparseBsr && layout_from == kSparseBsc)) {
-      TORCH_CHECK(false, funcname, ": conversion from ", layout_from, " to ", layout_to, " without blocksize argument given is not supported");
+      TORCH_CHECK(
+          false,
+          funcname,
+          ": conversion from ",
+          layout_from,
+          " to ",
+          layout_to,
+          " without blocksize argument given is not supported");
     }
   }
 
   if (dense_dim_opt.has_value()) {
     if (layout_from != kStrided) {
-      TORCH_CHECK(false, funcname, ": conversion from ", layout_from, " to ", layout_to, " with dense_dim argument given is not supported");
+      TORCH_CHECK(
+          false,
+          funcname,
+          ": conversion from ",
+          layout_from,
+          " to ",
+          layout_to,
+          " with dense_dim argument given is not supported");
     }
 
     auto dense_dim = *dense_dim_opt;
     if (layout_to == kSparse) {
       if (dense_dim == self.dim() && self.dim() > 0) {
-        TORCH_CHECK(false, funcname, ": dense_dim argument must be !=self.dim() when self.dim()>0");
+        TORCH_CHECK(
+            false,
+            funcname,
+            ": dense_dim argument must be !=self.dim() when self.dim()>0");
       }
       if (dense_dim < 0 || dense_dim > self.dim()) {
-        TORCH_CHECK(false, funcname, ": dense_dim argument must be in [0,", self.dim(), "] range, but ", dense_dim, " is given");
+        TORCH_CHECK(
+            false,
+            funcname,
+            ": dense_dim argument must be in [0,",
+            self.dim(),
+            "] range, but ",
+            dense_dim,
+            " is given");
       }
     } else {
       if (dense_dim < 0 || dense_dim > self.dim() - 2) {
-        TORCH_CHECK(false, funcname, ": dense_dim argument must be in [0,", self.dim() - 2, "] range, but ", dense_dim, " is given");
+        TORCH_CHECK(
+            false,
+            funcname,
+            ": dense_dim argument must be in [0,",
+            self.dim() - 2,
+            "] range, but ",
+            dense_dim,
+            " is given");
       }
     }
   }
 }
 
-template<Layout target_layout>
-static Tensor dense_to_sparse_compressed(const Tensor& self, const Tensor& self_mask, IntArrayRef blocksize, std::optional<int64_t> dense_dim_opt) {
-  static_assert(target_layout == Layout::SparseCsr || target_layout == Layout::SparseCsc
-                || target_layout == Layout::SparseBsr || target_layout == Layout::SparseBsc,
-                "invalid layout template parameter for dense_to_sparse_compressed");
-  constexpr auto compressed_rows_layout = target_layout == Layout::SparseCsr || target_layout == Layout::SparseBsr;
-  constexpr auto blocked_layout = target_layout == Layout::SparseBsr || target_layout == Layout::SparseBsc;
+template <Layout target_layout>
+static Tensor dense_to_sparse_compressed(
+    const Tensor& self,
+    const Tensor& self_mask,
+    IntArrayRef blocksize,
+    std::optional<int64_t> dense_dim_opt) {
+  static_assert(
+      target_layout == Layout::SparseCsr ||
+          target_layout == Layout::SparseCsc ||
+          target_layout == Layout::SparseBsr ||
+          target_layout == Layout::SparseBsc,
+      "invalid layout template parameter for dense_to_sparse_compressed");
+  constexpr auto compressed_rows_layout =
+      target_layout == Layout::SparseCsr || target_layout == Layout::SparseBsr;
+  constexpr auto blocked_layout =
+      target_layout == Layout::SparseBsr || target_layout == Layout::SparseBsc;
 
   int64_t dense_dim = dense_dim_opt.value_or(0);
 
@@ -1047,8 +1292,11 @@ static Tensor dense_to_sparse_compressed(const Tensor& self, const Tensor& self_
   // corresponding block and dense dims, and false otherwise.
   auto n_batch_dim = self.dim() - 2 - dense_dim;
   auto is_batched = n_batch_dim > 0;
-  auto values = blocked_layout ? _batch_tile_tensor(self, blocksize, dense_dim) :  self;
-  auto not_zero_mask = blocked_layout ? _batch_tile_tensor(self_mask, blocksize, dense_dim) : self_mask;
+  auto values =
+      blocked_layout ? _batch_tile_tensor(self, blocksize, dense_dim) : self;
+  auto not_zero_mask = blocked_layout
+      ? _batch_tile_tensor(self_mask, blocksize, dense_dim)
+      : self_mask;
   if (blocked_layout || dense_dim > 0) {
     std::vector<int64_t> reduce_dim((blocked_layout ? 2 : 0) + dense_dim);
     std::iota(reduce_dim.begin(), reduce_dim.end(), n_batch_dim + 2);
@@ -1080,108 +1328,168 @@ static Tensor dense_to_sparse_compressed(const Tensor& self, const Tensor& self_
     }
   } else {
     std::tie(row_indices, col_indices) = _not_zero_mask_to_col_row_indices(
-       not_zero_mask.transpose(1, 0), at::kLong, not_zero_mask.device());
+        not_zero_mask.transpose(1, 0), at::kLong, not_zero_mask.device());
     compressed_indices = at::_convert_indices_from_coo_to_csr(
         col_indices, not_zero_mask.size(-1), false /*out_int32*/);
     {
-      auto mask_indices = _mask_to_indices(not_zero_mask.transpose(0, 1).flatten());
-      values = values.transpose(0, 1).flatten(0, 1).index_select(0, mask_indices);
+      auto mask_indices =
+          _mask_to_indices(not_zero_mask.transpose(0, 1).flatten());
+      values =
+          values.transpose(0, 1).flatten(0, 1).index_select(0, mask_indices);
     }
   }
   Tensor& plain_indices = compressed_rows_layout ? col_indices : row_indices;
 
   if (is_batched) {
-   // Restore the batch dims and compressed dim.
+    // Restore the batch dims and compressed dim.
     reshape_2d_sparse_compressed_members_to_nd_batched(
         self.sizes(), n_batch_dim, compressed_indices, plain_indices, values);
   }
 
   // Create compressed sparse matrix with the target layout.
   return at::_sparse_compressed_tensor_unsafe(
-        compressed_indices,
-        plain_indices,
-        values,
-        self.sizes(),
-        self.options().layout(target_layout));
+      compressed_indices,
+      plain_indices,
+      values,
+      self.sizes(),
+      self.options().layout(target_layout));
 }
 
-Tensor dense_to_sparse_with_mask(const Tensor& self, const Tensor& mask, std::optional<c10::Layout> layout, OptionalIntArrayRef blocksize, std::optional<int64_t> dense_dim_opt) {
+Tensor dense_to_sparse_with_mask(
+    const Tensor& self,
+    const Tensor& mask,
+    std::optional<c10::Layout> layout,
+    OptionalIntArrayRef blocksize,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = layout.value_or(kSparse);
-  TORCH_INTERNAL_ASSERT(self.layout() != layout_to, "dense_to_sparse: unexpected same input and output layout");
-  TORCH_INTERNAL_ASSERT(self.layout() == mask.layout(),
-                        "dense_to_sparse_with_mask: expected mask layout ", self.layout(), ", got ", mask.layout());
-  TORCH_INTERNAL_ASSERT(self.sizes() == mask.sizes(),
-                        "dense_to_sparse_with_mask: expected mask size ", self.sizes(), ", got ", mask.sizes());
-  _to_sparse_check_arguments("dense_to_sparse_with_mask", self, layout, blocksize, dense_dim_opt);
+  TORCH_INTERNAL_ASSERT(
+      self.layout() != layout_to,
+      "dense_to_sparse: unexpected same input and output layout");
+  TORCH_INTERNAL_ASSERT(
+      self.layout() == mask.layout(),
+      "dense_to_sparse_with_mask: expected mask layout ",
+      self.layout(),
+      ", got ",
+      mask.layout());
+  TORCH_INTERNAL_ASSERT(
+      self.sizes() == mask.sizes(),
+      "dense_to_sparse_with_mask: expected mask size ",
+      self.sizes(),
+      ", got ",
+      mask.sizes());
+  _to_sparse_check_arguments(
+      "dense_to_sparse_with_mask", self, layout, blocksize, dense_dim_opt);
 
   switch (layout_to) {
-  case kSparse:
-    return self.sparse_mask(mask.to_sparse(self.dim() - dense_dim_opt.value_or(0)));
-  case kSparseCsr:
-    return dense_to_sparse_compressed<Layout::SparseCsr>(self, mask, {}, dense_dim_opt);
-  case kSparseCsc:
-    return dense_to_sparse_compressed<Layout::SparseCsc>(self, mask, {}, dense_dim_opt);
-  case kSparseBsr:
-    return dense_to_sparse_compressed<Layout::SparseBsr>(self, mask, *blocksize, dense_dim_opt);
-  case kSparseBsc:
-    return dense_to_sparse_compressed<Layout::SparseBsc>(self, mask, *blocksize, dense_dim_opt);
-  default:
-    break;
+    case kSparse:
+      return self.sparse_mask(
+          mask.to_sparse(self.dim() - dense_dim_opt.value_or(0)));
+    case kSparseCsr:
+      return dense_to_sparse_compressed<Layout::SparseCsr>(
+          self, mask, {}, dense_dim_opt);
+    case kSparseCsc:
+      return dense_to_sparse_compressed<Layout::SparseCsc>(
+          self, mask, {}, dense_dim_opt);
+    case kSparseBsr:
+      return dense_to_sparse_compressed<Layout::SparseBsr>(
+          self, mask, *blocksize, dense_dim_opt);
+    case kSparseBsc:
+      return dense_to_sparse_compressed<Layout::SparseBsc>(
+          self, mask, *blocksize, dense_dim_opt);
+    default:
+      break;
   }
 
-  TORCH_CHECK(false, "dense_to_sparse_with_mask: ", self.layout(), " to ", layout_to, " conversion not supported");
+  TORCH_CHECK(
+      false,
+      "dense_to_sparse_with_mask: ",
+      self.layout(),
+      " to ",
+      layout_to,
+      " conversion not supported");
   return Tensor{};
 }
 
-Tensor dense_to_sparse_csr(const Tensor& self, std::optional<int64_t> dense_dim_opt) {
+Tensor dense_to_sparse_csr(
+    const Tensor& self,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = kSparseCsr;
-  _to_sparse_check_arguments("dense_to_sparse_csr", self, layout_to, {}, dense_dim_opt);
+  _to_sparse_check_arguments(
+      "dense_to_sparse_csr", self, layout_to, {}, dense_dim_opt);
 
-  return dense_to_sparse_compressed<Layout::SparseCsr>(self, self != 0, {}, dense_dim_opt);
+  return dense_to_sparse_compressed<Layout::SparseCsr>(
+      self, self != 0, {}, dense_dim_opt);
 }
 
-Tensor dense_to_sparse_csc(const Tensor& self, std::optional<int64_t> dense_dim_opt) {
+Tensor dense_to_sparse_csc(
+    const Tensor& self,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = kSparseCsc;
-  _to_sparse_check_arguments("dense_to_sparse_csc", self, layout_to, {}, dense_dim_opt);
+  _to_sparse_check_arguments(
+      "dense_to_sparse_csc", self, layout_to, {}, dense_dim_opt);
 
-  return dense_to_sparse_compressed<Layout::SparseCsc>(self, self != 0, {}, dense_dim_opt);
+  return dense_to_sparse_compressed<Layout::SparseCsc>(
+      self, self != 0, {}, dense_dim_opt);
 }
 
-Tensor dense_to_sparse_bsr(const Tensor& self, IntArrayRef blocksize, std::optional<int64_t> dense_dim_opt) {
+Tensor dense_to_sparse_bsr(
+    const Tensor& self,
+    IntArrayRef blocksize,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = kSparseBsr;
-  _to_sparse_check_arguments("dense_to_sparse_bsr", self, layout_to, blocksize, dense_dim_opt);
+  _to_sparse_check_arguments(
+      "dense_to_sparse_bsr", self, layout_to, blocksize, dense_dim_opt);
 
-  return dense_to_sparse_compressed<Layout::SparseBsr>(self, self != 0, blocksize, dense_dim_opt);
+  return dense_to_sparse_compressed<Layout::SparseBsr>(
+      self, self != 0, blocksize, dense_dim_opt);
 }
 
-Tensor dense_to_sparse_bsc(const Tensor& self, IntArrayRef blocksize, std::optional<int64_t> dense_dim_opt) {
+Tensor dense_to_sparse_bsc(
+    const Tensor& self,
+    IntArrayRef blocksize,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = kSparseBsc;
-  _to_sparse_check_arguments("dense_to_sparse_bsc", self, layout_to, blocksize, dense_dim_opt);
+  _to_sparse_check_arguments(
+      "dense_to_sparse_bsc", self, layout_to, blocksize, dense_dim_opt);
 
-  return dense_to_sparse_compressed<Layout::SparseBsc>(self, self != 0, blocksize, dense_dim_opt);
+  return dense_to_sparse_compressed<Layout::SparseBsc>(
+      self, self != 0, blocksize, dense_dim_opt);
 }
 
-Tensor dense_to_sparse(const Tensor& self, std::optional<c10::Layout> layout, OptionalIntArrayRef blocksize, std::optional<int64_t> dense_dim_opt) {
+Tensor dense_to_sparse(
+    const Tensor& self,
+    std::optional<c10::Layout> layout,
+    OptionalIntArrayRef blocksize,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = layout.value_or(kSparse);
-  TORCH_INTERNAL_ASSERT(self.layout() != layout_to, "dense_to_sparse: unexpected same input and output layout");
-  _to_sparse_check_arguments("dense_to_sparse", self, layout, blocksize, dense_dim_opt);
+  TORCH_INTERNAL_ASSERT(
+      self.layout() != layout_to,
+      "dense_to_sparse: unexpected same input and output layout");
+  _to_sparse_check_arguments(
+      "dense_to_sparse", self, layout, blocksize, dense_dim_opt);
 
   switch (layout_to) {
-  case kSparse:
-    return self.to_sparse(self.dim() - dense_dim_opt.value_or(0));
-  case kSparseCsr:
-    return self.to_sparse_csr(dense_dim_opt);
-  case kSparseCsc:
-    return self.to_sparse_csc(dense_dim_opt);
-  case kSparseBsr:
-    return self.to_sparse_bsr(*blocksize, dense_dim_opt);
-  case kSparseBsc:
-    return self.to_sparse_bsc(*blocksize, dense_dim_opt);
-  default:
-    break;
+    case kSparse:
+      return self.to_sparse(self.dim() - dense_dim_opt.value_or(0));
+    case kSparseCsr:
+      return self.to_sparse_csr(dense_dim_opt);
+    case kSparseCsc:
+      return self.to_sparse_csc(dense_dim_opt);
+    case kSparseBsr:
+      return self.to_sparse_bsr(*blocksize, dense_dim_opt);
+    case kSparseBsc:
+      return self.to_sparse_bsc(*blocksize, dense_dim_opt);
+    default:
+      break;
   }
 
-  TORCH_CHECK(false, "dense_to_sparse: ", self.layout(), " to ", layout_to, " conversion not supported");
+  TORCH_CHECK(
+      false,
+      "dense_to_sparse: ",
+      self.layout(),
+      " to ",
+      layout_to,
+      " conversion not supported");
   return Tensor{};
 }
 
@@ -1245,26 +1553,28 @@ static Tensor sparse_compressed_to_flipped(
   //    matrix of shape (b * r, c).
   // 2. Turn the compressed indices of the matrix of shape (b * r, c) into
   //    COO indices.
-  // 3. Map these COO indices into the COO indices of a matrix of shape (r, b * c)
-  //    such that if A is a matrix of shape (b * r, c) and B is a matrix of shape
-  //    (r, b * c) such that
-  //    A[(k * r):(k * r + r), :] = B[:, (k * c):(k * c + c)] for all k in arange(b),
-  //    then A[i, j] = B[i', j'].
-  //    This is equivalent to finding indices that match values of matrices
-  //    tiled vertically to values of the same matrices tiled horizontally.
+  // 3. Map these COO indices into the COO indices of a matrix of shape (r, b *
+  // c)
+  //    such that if A is a matrix of shape (b * r, c) and B is a matrix of
+  //    shape (r, b * c) such that A[(k * r):(k * r + r), :] = B[:, (k * c):(k *
+  //    c + c)] for all k in arange(b), then A[i, j] = B[i', j']. This is
+  //    equivalent to finding indices that match values of matrices tiled
+  //    vertically to values of the same matrices tiled horizontally.
   // 4. Convert the COO indices to the CSC/BSC indices and form the output.
   //
-  // NOTE: the reason behind vertical/horizontal tiling is to be able to transform
+  // NOTE: the reason behind vertical/horizontal tiling is to be able to
+  // transform
   //       indices over all matrices in the batch in a single kernel call, since
   //       all the existing coo <-> compressed indices conversion methods assume
   //       a single matrix.
   //
-  // CSC/BSC inputs are handled in a similar fashion with a "transposed" argument.
-  // See the comments below for detailed explanations on how exactly each step
-  // is performed.
+  // CSC/BSC inputs are handled in a similar fashion with a "transposed"
+  // argument. See the comments below for detailed explanations on how exactly
+  // each step is performed.
 
   Tensor compressed_indices, plain_indices;
-  std::tie(compressed_indices, plain_indices) = at::sparse_csr::getCompressedPlainIndices(self);
+  std::tie(compressed_indices, plain_indices) =
+      at::sparse_csr::getCompressedPlainIndices(self);
   auto values = self.values();
   const auto nnz = plain_indices.size(-1);
 
@@ -1292,11 +1602,13 @@ static Tensor sparse_compressed_to_flipped(
     return sparse_dim;
   }();
 
-  // batch_sizes_nonempty stores at least one, potentially fake, batch dimension.
-  // rebatch_sizes_nonempty is equivalent to batch_sizes_nonempty.push_back(-1),
-  // and is used to unflatten batch dimensions from a dimension of size
-  // (batch_numel * dim_size,) for some dim_size.
-  const auto batch_sizes_nonempty = at::DimVector(plain_indices.sizes().slice(0, n_batches_nonzero));
+  // batch_sizes_nonempty stores at least one, potentially fake, batch
+  // dimension. rebatch_sizes_nonempty is equivalent to
+  // batch_sizes_nonempty.push_back(-1), and is used to unflatten batch
+  // dimensions from a dimension of size (batch_numel * dim_size,) for some
+  // dim_size.
+  const auto batch_sizes_nonempty =
+      at::DimVector(plain_indices.sizes().slice(0, n_batches_nonzero));
   auto rebatch_sizes_nonempty = at::DimVector(batch_sizes_nonempty);
   rebatch_sizes_nonempty.push_back(-1);
   const auto batch_numel_nonzero = std::accumulate(
@@ -1305,15 +1617,16 @@ static Tensor sparse_compressed_to_flipped(
       1,
       std::multiplies<int64_t>());
 
-  // Equivalent to (arange(batch_numel_nonzero).mul_(nnz)).reshape(batch_sizes_nonempty).
-  // We just compute it differently to use `add` kernel in place of `mul` for better
-  // performance.
+  // Equivalent to
+  // (arange(batch_numel_nonzero).mul_(nnz)).reshape(batch_sizes_nonempty). We
+  // just compute it differently to use `add` kernel in place of `mul` for
+  // better performance.
   const auto batch_nnz_offset = [&]() -> Tensor {
     const auto wrapped_nnz = at::tensor({nnz}, compressed_indices.options());
-    auto offset = wrapped_nnz
-      .expand({batch_numel_nonzero})
-      .cumsum(-1).sub_(wrapped_nnz)
-      .reshape(batch_sizes_nonempty);
+    auto offset = wrapped_nnz.expand({batch_numel_nonzero})
+                      .cumsum(-1)
+                      .sub_(wrapped_nnz)
+                      .reshape(batch_sizes_nonempty);
     return offset;
   }();
 
@@ -1328,42 +1641,46 @@ static Tensor sparse_compressed_to_flipped(
     const auto compressed_offsets = compressed_indices.slice(-1, 0, -1);
     // batch_offsets offsets each individual matrix row/col offsets by the total
     // sum of nnz's of all the matrices with the smaller batch index.
-    const auto batch_offsets = batch_nnz_offset
-      .unsqueeze(-1).expand_as(compressed_offsets);
-    // compressed_offsets + batch_offsets creates an offset vector for a 2d matrix
-    // that is stored in a compressed sparse format.
-    const auto compressed_offsets_2d = compressed_offsets.add(batch_offsets).reshape({-1});
+    const auto batch_offsets =
+        batch_nnz_offset.unsqueeze(-1).expand_as(compressed_offsets);
+    // compressed_offsets + batch_offsets creates an offset vector for a 2d
+    // matrix that is stored in a compressed sparse format.
+    const auto compressed_offsets_2d =
+        compressed_offsets.add(batch_offsets).reshape({-1});
     const auto offsets_len = compressed_offsets_2d.numel();
     auto res = at::empty({offsets_len + 1}, compressed_indices.options());
     res.slice(-1, 0, -1).copy_(compressed_offsets_2d);
-    // By appending nnz * batch_numel_nonzero to (compressed_offsets + batch_offsets)
-    // a compressed index of a 2d matrix is formed.
+    // By appending nnz * batch_numel_nonzero to (compressed_offsets +
+    // batch_offsets) a compressed index of a 2d matrix is formed.
     res.slice(-1, -1).fill_(nnz * batch_numel_nonzero);
     return res;
   }();
-  // More involved for compressed indices, but pretty easy for plain_indices and values:
-  // just squash batch dimensions.
+  // More involved for compressed indices, but pretty easy for plain_indices and
+  // values: just squash batch dimensions.
   const auto plain_indices_2d = plain_indices.flatten(0, n_batches_nonzero);
-  // NOTE: values are not 2d! They just represent values of a sparse compressed 2d matrix.
+  // NOTE: values are not 2d! They just represent values of a sparse compressed
+  // 2d matrix.
   const auto values_2d = values.flatten(0, n_batches_nonzero);
 
   const auto is_out_int32 = compressed_indices.scalar_type() == ScalarType::Int;
 
   // Step 2 & 3:
   //
-  // Turn the compressed indices of the matrix of shape (b * r, c) into COO indices.
+  // Turn the compressed indices of the matrix of shape (b * r, c) into COO
+  // indices.
   //
   // Map these COO indices into the COO indices of a matrix of shape (r, b * c)
   // such that if A is a matrix of shape (b * r, c) and B is a matrix of shape
   // (r, b * c) such that
-  // A[(k * r):(k * r + r), :] = B[:, (k * c):(k * c + c)] for all k in arange(b),
-  // then A[i, j] = B[i', j'].
-  // This is equivalent to finding indices that match values of matrices
-  // tiled vertically to values of the same matrices tiled horizontally.
+  // A[(k * r):(k * r + r), :] = B[:, (k * c):(k * c + c)] for all k in
+  // arange(b), then A[i, j] = B[i', j']. This is equivalent to finding indices
+  // that match values of matrices tiled vertically to values of the same
+  // matrices tiled horizontally.
 
   // coo <-> sparse index conversions assume CSR/BSR inputs.
   // To CSC/BSC inputs these indices will appear "transposed".
-  const auto is_transposed_indices = layout == at::kSparseCsc || layout == at::kSparseBsc;
+  const auto is_transposed_indices =
+      layout == at::kSparseCsc || layout == at::kSparseBsc;
   const auto coo_indices_2d_transposed = [&]() -> Tensor {
     auto coo_indices_2d = _convert_indices_from_csr_to_coo(
         compressed_indices_2d,
@@ -1380,7 +1697,8 @@ static Tensor sparse_compressed_to_flipped(
     // NOTE: we used transposed=true above!
     auto i = coo_indices_2d.select(0, 1);
     auto j = coo_indices_2d.select(0, 0);
-    auto b = i.div(is_transposed_indices ? sparse_dim[1] : sparse_dim[0], "trunc");
+    auto b =
+        i.div(is_transposed_indices ? sparse_dim[1] : sparse_dim[0], "trunc");
     // Modify i, j in-place.
     i.fmod_(is_transposed_indices ? sparse_dim[1] : sparse_dim[0]);
     j.add_(b * (is_transposed_indices ? sparse_dim[0] : sparse_dim[1]));
@@ -1395,26 +1713,33 @@ static Tensor sparse_compressed_to_flipped(
   // more "weight" (aka stride) placed on the "transposed" dimension.
   const auto coo_indices_2d_transposed_hashed = at::sparse::flatten_indices(
       coo_indices_2d_transposed,
-      is_transposed_indices ? at::DimVector({sparse_dim[0], sparse_dim[1] * batch_numel_nonzero})
-                            : at::DimVector({sparse_dim[1], sparse_dim[0] * batch_numel_nonzero}));
-  const auto hash_argsort = std::get<1>(coo_indices_2d_transposed_hashed.sort());
-  const auto coo_indices_2d_transposed_sorted = coo_indices_2d_transposed.index_select(1, hash_argsort);
+      is_transposed_indices
+          ? at::DimVector({sparse_dim[0], sparse_dim[1] * batch_numel_nonzero})
+          : at::DimVector(
+                {sparse_dim[1], sparse_dim[0] * batch_numel_nonzero}));
+  const auto hash_argsort =
+      std::get<1>(coo_indices_2d_transposed_hashed.sort());
+  const auto coo_indices_2d_transposed_sorted =
+      coo_indices_2d_transposed.index_select(1, hash_argsort);
 
-  const auto new_compressed_indices_coo_2d = coo_indices_2d_transposed_sorted.select(0, 0);
-  const auto new_plain_indices_2d = coo_indices_2d_transposed_sorted.select(0, 1);
+  const auto new_compressed_indices_coo_2d =
+      coo_indices_2d_transposed_sorted.select(0, 0);
+  const auto new_plain_indices_2d =
+      coo_indices_2d_transposed_sorted.select(0, 1);
   const auto new_values_2d = values_2d.index_select(0, hash_argsort);
 
-  auto new_compressed_indices = compressed_to_batched_compressed_indices(
-      _convert_indices_from_coo_to_csr(
-        new_compressed_indices_coo_2d,
-        is_transposed_indices
-          ? batch_numel_nonzero * sparse_dim[0]
-          : batch_numel_nonzero * sparse_dim[1],
-        is_out_int32),
-      batch_numel_nonzero,
-      is_out_int32)
-    .unflatten(0, batch_sizes_nonempty);
-  auto new_plain_indices = new_plain_indices_2d.unflatten(0, rebatch_sizes_nonempty);
+  auto new_compressed_indices =
+      compressed_to_batched_compressed_indices(
+          _convert_indices_from_coo_to_csr(
+              new_compressed_indices_coo_2d,
+              is_transposed_indices ? batch_numel_nonzero * sparse_dim[0]
+                                    : batch_numel_nonzero * sparse_dim[1],
+              is_out_int32),
+          batch_numel_nonzero,
+          is_out_int32)
+          .unflatten(0, batch_sizes_nonempty);
+  auto new_plain_indices =
+      new_plain_indices_2d.unflatten(0, rebatch_sizes_nonempty);
   auto new_values = new_values_2d.unflatten(0, rebatch_sizes_nonempty);
   // Kill fake batch dim if it was inserted.
   if (!n_batches) {
@@ -1431,35 +1756,54 @@ static Tensor sparse_compressed_to_flipped(
       self.options().layout(flipped_layout));
 }
 
-Tensor sparse_compressed_to_sparse_csr(const Tensor& self, std::optional<int64_t> dense_dim_opt) {
+Tensor sparse_compressed_to_sparse_csr(
+    const Tensor& self,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = kSparseCsr;
-  TORCH_INTERNAL_ASSERT(self.layout() != layout_to, "sparse_compressed_to_sparse_csr: unexpected same input and output layout");
-  _to_sparse_check_arguments("sparse_compressed_to_sparse_csr", self, layout_to, {}, dense_dim_opt);
+  TORCH_INTERNAL_ASSERT(
+      self.layout() != layout_to,
+      "sparse_compressed_to_sparse_csr: unexpected same input and output layout");
+  _to_sparse_check_arguments(
+      "sparse_compressed_to_sparse_csr", self, layout_to, {}, dense_dim_opt);
 
   if (self.layout() == kSparseCsc) {
     return sparse_compressed_to_flipped(self, std::nullopt, "to_sparse_csr");
   }
 
-  TORCH_CHECK(false, "sparse_compressed_to_sparse_csr: expected SparseCsr or SparseCsc layout but got ", self.layout());
+  TORCH_CHECK(
+      false,
+      "sparse_compressed_to_sparse_csr: expected SparseCsr or SparseCsc layout but got ",
+      self.layout());
   return Tensor{};
 }
 
-Tensor sparse_compressed_to_sparse_csc(const Tensor& self, std::optional<int64_t> dense_dim_opt) {
+Tensor sparse_compressed_to_sparse_csc(
+    const Tensor& self,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = kSparseCsc;
-  TORCH_INTERNAL_ASSERT(self.layout() != layout_to, "sparse_compressed_to_sparse_csc: unexpected same input and output layout");
-  _to_sparse_check_arguments("sparse_compressed_to_sparse_csc", self, layout_to, {}, dense_dim_opt);
+  TORCH_INTERNAL_ASSERT(
+      self.layout() != layout_to,
+      "sparse_compressed_to_sparse_csc: unexpected same input and output layout");
+  _to_sparse_check_arguments(
+      "sparse_compressed_to_sparse_csc", self, layout_to, {}, dense_dim_opt);
 
   if (self.layout() == kSparseCsr) {
     return sparse_compressed_to_flipped(self, std::nullopt, "to_sparse_csc");
   }
 
-  TORCH_CHECK(false, "sparse_compressed_to_sparse_csc: expected SparseCsr or SparseCsc layout but got ", self.layout());
+  TORCH_CHECK(
+      false,
+      "sparse_compressed_to_sparse_csc: expected SparseCsr or SparseCsc layout but got ",
+      self.layout());
   return Tensor{};
 }
 
-Tensor coo_to_sparse_csr(const Tensor& self, std::optional<int64_t> dense_dim_opt) {
+Tensor coo_to_sparse_csr(
+    const Tensor& self,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = kSparseCsr;
-  _to_sparse_check_arguments("coo_to_sparse_csr", self, layout_to, {}, dense_dim_opt);
+  _to_sparse_check_arguments(
+      "coo_to_sparse_csr", self, layout_to, {}, dense_dim_opt);
 
   auto coalesced_self = self.coalesce();
   auto row_indices = coalesced_self.indices()[0];
@@ -1476,9 +1820,12 @@ Tensor coo_to_sparse_csr(const Tensor& self, std::optional<int64_t> dense_dim_op
       coalesced_self.device());
 }
 
-Tensor coo_to_sparse_csc(const Tensor& self, std::optional<int64_t> dense_dim_opt) {
+Tensor coo_to_sparse_csc(
+    const Tensor& self,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = kSparseCsc;
-  _to_sparse_check_arguments("coo_to_sparse_csc", self, layout_to, {}, dense_dim_opt);
+  _to_sparse_check_arguments(
+      "coo_to_sparse_csc", self, layout_to, {}, dense_dim_opt);
 
   auto transposed_csr = self.transpose(0, 1).to_sparse_csr(dense_dim_opt);
   return at::native::_sparse_csc_tensor_unsafe(
@@ -1491,16 +1838,24 @@ Tensor coo_to_sparse_csc(const Tensor& self, std::optional<int64_t> dense_dim_op
       transposed_csr.device());
 }
 
-Tensor coo_to_sparse_bsr(const Tensor& self, IntArrayRef blocksize, std::optional<int64_t> dense_dim_opt) {
+Tensor coo_to_sparse_bsr(
+    const Tensor& self,
+    IntArrayRef blocksize,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = kSparseBsr;
-  _to_sparse_check_arguments("coo_to_sparse_bsr", self, layout_to, blocksize, dense_dim_opt);
+  _to_sparse_check_arguments(
+      "coo_to_sparse_bsr", self, layout_to, blocksize, dense_dim_opt);
 
   return self.to_sparse_csr(dense_dim_opt).to_sparse_bsr(blocksize);
 }
 
-Tensor coo_to_sparse_bsc(const Tensor& self, IntArrayRef blocksize, std::optional<int64_t> dense_dim_opt) {
+Tensor coo_to_sparse_bsc(
+    const Tensor& self,
+    IntArrayRef blocksize,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = kSparseBsc;
-  _to_sparse_check_arguments("coo_to_sparse_bsc", self, layout_to, blocksize, dense_dim_opt);
+  _to_sparse_check_arguments(
+      "coo_to_sparse_bsc", self, layout_to, blocksize, dense_dim_opt);
 
   return self.to_sparse_csc(dense_dim_opt).to_sparse_bsc(blocksize);
 }
@@ -1546,8 +1901,8 @@ void convert_indices_from_csr_to_coo_cpu(
   int64_t nrows = crow_indices.size(-1) - 1;
   int64_t nnz = col_indices.size(-1);
   if (nrows == 0 || nnz == 0) {
-    indices.zero_();  // is this needed as indices has a zero-valued
-                      // dimension when nrows or nnz is 0?
+    indices.zero_(); // is this needed as indices has a zero-valued
+                     // dimension when nrows or nnz is 0?
     return;
   }
   auto crow_indices_ = crow_indices.expect_contiguous();
@@ -1555,10 +1910,13 @@ void convert_indices_from_csr_to_coo_cpu(
   int64_t batch_ndim = crow_indices.dim() - 1;
   if (batch_ndim > 0) {
     auto batch_indices = indices.narrow(0, 0, batch_ndim);
-    batch_indices.copy_(at::sparse::full_coo_indices(crow_indices.sizes().slice(0, batch_ndim), crow_indices.options())
-                        .repeat_interleave(nnz, 1));
+    batch_indices.copy_(
+        at::sparse::full_coo_indices(
+            crow_indices.sizes().slice(0, batch_ndim), crow_indices.options())
+            .repeat_interleave(nnz, 1));
   }
-  const input_t* crow_indices_data_in = crow_indices_->const_data_ptr<input_t>();
+  const input_t* crow_indices_data_in =
+      crow_indices_->const_data_ptr<input_t>();
   TORCH_INTERNAL_ASSERT(indices.is_contiguous());
   auto row0 = indices.select(0, transpose ? batch_ndim + 1 : batch_ndim + 0);
   auto row1 = indices.select(0, transpose ? batch_ndim + 0 : batch_ndim + 1);
@@ -1566,13 +1924,17 @@ void convert_indices_from_csr_to_coo_cpu(
   auto col_indices_ = col_indices.expect_contiguous();
   row1.copy_(col_indices_->view({-1}));
   at::parallel_for(
-                   0, nrows * total_nnz / nnz, at::internal::GRAIN_SIZE, [&](int64_t start, int64_t end) {
-        for (const auto i_  : c10::irange(start, end)) {
+      0,
+      nrows * total_nnz / nnz,
+      at::internal::GRAIN_SIZE,
+      [&](int64_t start, int64_t end) {
+        for (const auto i_ : c10::irange(start, end)) {
           auto b = i_ / nrows;
           auto i = i_ % nrows;
           std::fill(
               &data_out[b * nnz + crow_indices_data_in[b * (nrows + 1) + i]],
-              &data_out[b * nnz + crow_indices_data_in[b * (nrows + 1) + i + 1]],
+              &data_out
+                  [b * nnz + crow_indices_data_in[b * (nrows + 1) + i + 1]],
               static_cast<output_t>(i));
         }
       });
@@ -1663,8 +2025,10 @@ void _compressed_to_block_compressed_cpu_kernel(
   for (index_t block_c = 0; block_c < n_bcompressed; block_c++) {
     // Iterate over blocks along plain dim to locate non-zero blocks,
     // this guarantees sorted plain dim indices
-    for (index_t block_p = 0; block_p < n_bplain; block_p ++) {
-      for (index_t i = input_compressed_indices[C * block_c]; i < input_compressed_indices[C * (block_c + 1)]; i++) {
+    for (index_t block_p = 0; block_p < n_bplain; block_p++) {
+      for (index_t i = input_compressed_indices[C * block_c];
+           i < input_compressed_indices[C * (block_c + 1)];
+           i++) {
         index_t p = input_plain_indices[i]; // plain dim element index
         if (p / P == block_p) {
           blocks[block_p] = result_values + CPD * n_blks;
@@ -1678,7 +2042,9 @@ void _compressed_to_block_compressed_cpu_kernel(
     // Iterate over compressed dim within block
     for (index_t cb = 0; cb < C; cb++) {
       index_t c = C * block_c + cb; // compressed dim index
-      for (index_t i = input_compressed_indices[c]; i < input_compressed_indices[c + 1]; i++) {
+      for (index_t i = input_compressed_indices[c];
+           i < input_compressed_indices[c + 1];
+           i++) {
         index_t p = input_plain_indices[i]; // plain dim index
 
         // Block corresponding to plain dim index
@@ -1691,8 +2057,11 @@ void _compressed_to_block_compressed_cpu_kernel(
         // A possible answer: Scipy code supports "uncoalesced CSR"
         // format that allows repeated plain dim indices, and
         // compressed and plain indices may be unsorted.
-        std::copy(input_values + i * D, input_values + (i + 1) * D,
-                  blocks[block_p] + (compressed_rows ? P * cb + pb : C * pb + cb) * D);
+        std::copy(
+            input_values + i * D,
+            input_values + (i + 1) * D,
+            blocks[block_p] +
+                (compressed_rows ? P * cb + pb : C * pb + cb) * D);
       }
     }
 
@@ -1723,7 +2092,7 @@ index_t compressed_count_blocks(
     const index_t P, // Block size along plain dimension
     const index_t Ac[], // Compressed indices
     const index_t Ap[] // Plain indices
-  ) {
+) {
   std::vector<index_t> mask(n_plain / P + 1, -1);
   index_t n_blks = 0;
   for (index_t c = 0; c < n_compressed; c++) {
@@ -1739,15 +2108,19 @@ index_t compressed_count_blocks(
   return n_blks;
 }
 
-template<Layout target_layout>
-Tensor _compressed_to_block_compressed_cpu(const Tensor& self, IntArrayRef blocksize) {
-  static_assert(target_layout == Layout::SparseBsr || target_layout == Layout::SparseBsc,
-                "invalid layout template parameter for _compressed_to_block_compressed_cpu");
+template <Layout target_layout>
+Tensor _compressed_to_block_compressed_cpu(
+    const Tensor& self,
+    IntArrayRef blocksize) {
+  static_assert(
+      target_layout == Layout::SparseBsr || target_layout == Layout::SparseBsc,
+      "invalid layout template parameter for _compressed_to_block_compressed_cpu");
 
   auto input_values = self.values().contiguous();
   Tensor input_compressed_indices;
   Tensor input_plain_indices;
-  std::tie(input_compressed_indices, input_plain_indices) = sparse_csr::getCompressedPlainIndices(self);
+  std::tie(input_compressed_indices, input_plain_indices) =
+      sparse_csr::getCompressedPlainIndices(self);
   input_compressed_indices = input_compressed_indices.contiguous();
   input_plain_indices = input_plain_indices.contiguous();
 
@@ -1755,39 +2128,51 @@ Tensor _compressed_to_block_compressed_cpu(const Tensor& self, IntArrayRef block
   // block, if it contains a non-zero element we will allocate values
   // and indices for it.
   int64_t num_blocks = 0;
-  auto compressed_dim = (target_layout == Layout::SparseBsr) ? self.size(0) : self.size(1);
-  auto plain_dim = (target_layout == Layout::SparseBsr) ? self.size(1) : self.size(0);
-  auto compressed_blocksize = (target_layout == Layout::SparseBsr) ? blocksize[0] : blocksize[1];
-  auto plain_blocksize = (target_layout == Layout::SparseBsr) ? blocksize[1] : blocksize[0];
+  auto compressed_dim =
+      (target_layout == Layout::SparseBsr) ? self.size(0) : self.size(1);
+  auto plain_dim =
+      (target_layout == Layout::SparseBsr) ? self.size(1) : self.size(0);
+  auto compressed_blocksize =
+      (target_layout == Layout::SparseBsr) ? blocksize[0] : blocksize[1];
+  auto plain_blocksize =
+      (target_layout == Layout::SparseBsr) ? blocksize[1] : blocksize[0];
 
   AT_DISPATCH_INDEX_TYPES(
-      input_compressed_indices.scalar_type(), "_compressed_to_block_compressed_cpu", [&] {
-        num_blocks =
-          compressed_count_blocks<index_t>(
-              compressed_dim,
-              plain_dim,
-              compressed_blocksize,
-              plain_blocksize,
-              input_compressed_indices.data_ptr<index_t>(),
-              input_plain_indices.data_ptr<index_t>());
+      input_compressed_indices.scalar_type(),
+      "_compressed_to_block_compressed_cpu",
+      [&] {
+        num_blocks = compressed_count_blocks<index_t>(
+            compressed_dim,
+            plain_dim,
+            compressed_blocksize,
+            plain_blocksize,
+            input_compressed_indices.data_ptr<index_t>(),
+            input_plain_indices.data_ptr<index_t>());
       });
   DimVector dense_shape{input_values.sizes().slice(1, input_values.dim() - 1)};
   DimVector values_shape{num_blocks, blocksize[0], blocksize[1]};
   values_shape.append(dense_shape);
 
   Tensor result_values = input_values.new_zeros(values_shape);
-  Tensor result_compressed_indices =
-      input_compressed_indices.new_empty({compressed_dim /compressed_blocksize + 1});
+  Tensor result_compressed_indices = input_compressed_indices.new_empty(
+      {compressed_dim / compressed_blocksize + 1});
   Tensor result_plain_indices = input_plain_indices.new_empty({num_blocks});
 
   // Next we copy over non-zero elements into the allocated blocks.
   auto n_dense = std::accumulate(
       dense_shape.begin(), dense_shape.end(), 1, std::multiplies<int64_t>());
   AT_DISPATCH_INDEX_TYPES(
-      input_compressed_indices.scalar_type(), "_compressed_to_block_compressed_cpu", [&] {
+      input_compressed_indices.scalar_type(),
+      "_compressed_to_block_compressed_cpu",
+      [&] {
         AT_DISPATCH_SPARSE_VALUE_TYPES(
-            input_values.scalar_type(), "_compressed_to_block_compressed_cpu", [&] {
-              _compressed_to_block_compressed_cpu_kernel<index_t, scalar_t, target_layout == Layout::SparseBsr>(
+            input_values.scalar_type(),
+            "_compressed_to_block_compressed_cpu",
+            [&] {
+              _compressed_to_block_compressed_cpu_kernel<
+                  index_t,
+                  scalar_t,
+                  target_layout == Layout::SparseBsr>(
                   compressed_dim,
                   plain_dim,
                   compressed_blocksize,
@@ -1810,148 +2195,233 @@ Tensor _compressed_to_block_compressed_cpu(const Tensor& self, IntArrayRef block
       self.options().layout(target_layout));
 }
 
-Tensor sparse_compressed_to_sparse_bsr(const Tensor& self, IntArrayRef blocksize, std::optional<int64_t> dense_dim_opt) {
+Tensor sparse_compressed_to_sparse_bsr(
+    const Tensor& self,
+    IntArrayRef blocksize,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = kSparseBsr;
-  TORCH_INTERNAL_ASSERT(self.layout() != layout_to, "sparse_compressed_to_sparse_bsr: unexpected same input and output layout");
-  _to_sparse_check_arguments("sparse_compressed_to_sparse_bsr", self, layout_to, blocksize, dense_dim_opt);
+  TORCH_INTERNAL_ASSERT(
+      self.layout() != layout_to,
+      "sparse_compressed_to_sparse_bsr: unexpected same input and output layout");
+  _to_sparse_check_arguments(
+      "sparse_compressed_to_sparse_bsr",
+      self,
+      layout_to,
+      blocksize,
+      dense_dim_opt);
 
   if (self.layout() == kSparseBsc) {
     return sparse_compressed_to_flipped(self, blocksize, "to_sparse_bsr");
   }
   if (self.layout() == kSparseCsr) {
     if (self.device() != kCPU) {
-      TORCH_WARN("sparse_compressed_to_sparse_bsr executing on the CPU device, the performance may be sub-optimal");
+      TORCH_WARN(
+          "sparse_compressed_to_sparse_bsr executing on the CPU device, the performance may be sub-optimal");
     }
-    return _compressed_to_block_compressed_cpu<kSparseBsr>(self.cpu(), blocksize).to(self.device());
+    return _compressed_to_block_compressed_cpu<kSparseBsr>(
+               self.cpu(), blocksize)
+        .to(self.device());
   }
   if (self.layout() == kSparseCsc) {
     return self.to_sparse_csr(dense_dim_opt).to_sparse_bsr(blocksize);
   }
 
-  TORCH_CHECK(false, "sparse_compressed_to_sparse_bsr: expected SparseCsr, SparseCsc, SparseBsr or SparseBsc layout but got ", self.layout());
+  TORCH_CHECK(
+      false,
+      "sparse_compressed_to_sparse_bsr: expected SparseCsr, SparseCsc, SparseBsr or SparseBsc layout but got ",
+      self.layout());
   return Tensor{};
 }
 
-Tensor sparse_compressed_to_sparse_bsc(const Tensor& self, IntArrayRef blocksize, std::optional<int64_t> dense_dim_opt) {
+Tensor sparse_compressed_to_sparse_bsc(
+    const Tensor& self,
+    IntArrayRef blocksize,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = kSparseBsc;
-  TORCH_INTERNAL_ASSERT(self.layout() != layout_to, "sparse_compressed_to_sparse_bsc: unexpected same input and output layout");
-  _to_sparse_check_arguments("sparse_compressed_to_sparse_bsc", self, layout_to, blocksize, dense_dim_opt);
+  TORCH_INTERNAL_ASSERT(
+      self.layout() != layout_to,
+      "sparse_compressed_to_sparse_bsc: unexpected same input and output layout");
+  _to_sparse_check_arguments(
+      "sparse_compressed_to_sparse_bsc",
+      self,
+      layout_to,
+      blocksize,
+      dense_dim_opt);
 
   if (self.layout() == kSparseBsr) {
     return sparse_compressed_to_flipped(self, blocksize, "to_sparse_bsc");
   }
   if (self.layout() == kSparseCsc) {
     if (self.device() != kCPU) {
-      TORCH_WARN("sparse_compressed_to_sparse_bsc executing on the CPU device, the performance may be sub-optimal");
+      TORCH_WARN(
+          "sparse_compressed_to_sparse_bsc executing on the CPU device, the performance may be sub-optimal");
     }
-    return _compressed_to_block_compressed_cpu<kSparseBsc>(self.cpu(), blocksize).to(self.device());
+    return _compressed_to_block_compressed_cpu<kSparseBsc>(
+               self.cpu(), blocksize)
+        .to(self.device());
   }
   if (self.layout() == kSparseCsr) {
     return self.to_sparse_csc(dense_dim_opt).to_sparse_bsc(blocksize);
   }
 
-  TORCH_CHECK(false, "sparse_compressed_to_sparse_bsc: expected SparseCsr, SparseCsc, SparseBsr or SparseBsc layout but got ", self.layout());
+  TORCH_CHECK(
+      false,
+      "sparse_compressed_to_sparse_bsc: expected SparseCsr, SparseCsc, SparseBsr or SparseBsc layout but got ",
+      self.layout());
   return Tensor{};
 }
 
 Tensor sparse_coo_to_sparse(const Tensor& self, const int64_t sparse_dim) {
   _to_sparse_check_arguments("sparse_coo_to_sparse", self, sparse_dim);
 
-  TORCH_CHECK(false, "sparse_coo_to_sparse: ", self.layout(), " to ", kSparse, " conversion not supported");
+  TORCH_CHECK(
+      false,
+      "sparse_coo_to_sparse: ",
+      self.layout(),
+      " to ",
+      kSparse,
+      " conversion not supported");
   return Tensor{};
 }
 
-Tensor sparse_compressed_to_sparse(const Tensor& self, const int64_t sparse_dim) {
+Tensor sparse_compressed_to_sparse(
+    const Tensor& self,
+    const int64_t sparse_dim) {
   _to_sparse_check_arguments("sparse_compressed_to_sparse", self, sparse_dim);
 
   Layout layout = self.layout();
-  auto [compressed_indices, plain_indices] = at::sparse_csr::getCompressedPlainIndices(self);
+  auto [compressed_indices, plain_indices] =
+      at::sparse_csr::getCompressedPlainIndices(self);
   Tensor values;
-  Tensor indices = at::_convert_indices_from_csr_to_coo(compressed_indices, plain_indices,
-                                                        false, (layout == kSparseCsc || layout == kSparseBsc));
+  Tensor indices = at::_convert_indices_from_csr_to_coo(
+      compressed_indices,
+      plain_indices,
+      false,
+      (layout == kSparseCsc || layout == kSparseBsc));
   const auto batch_ndim = compressed_indices.dim() - 1;
   // Only CSR is trivially coalesced
-  bool coalesced = layout == kSparseCsr || self.numel() == 0 || self._nnz() == 1;
-  AT_DISPATCH_PLAIN_SPARSE_COMPRESSED_LAYOUTS(layout, "sparse_compressed_to_sparse",
-    [&] { values = self.values().flatten(0, batch_ndim); },
-    [&] {
-      auto blocksize = DimVector(self.values().sizes().slice(batch_ndim + 1, 2));
-      DimVector batch_blocksize;
-      batch_blocksize.append(batch_ndim, 1);
-      batch_blocksize.append(blocksize);
-      const auto block_coo_indices = at::zeros({batch_ndim + 2, blocksize[0] * blocksize[1]}, indices.options());
-      block_coo_indices.narrow(0, batch_ndim, 2).copy_(at::sparse::full_coo_indices(blocksize, indices.options()));
-      indices = indices
-        // Scale indices that identify blocks to element-wise coordinates that correspond
-        // to the top-left corner of each block.
-        .mul(at::tensor(batch_blocksize, indices.options()).unsqueeze_(1))
-        // Now that we know top-left block coordinates, we offset them with element-wise
-        // coordinates in the block to get the result.
-        // NOTE: indices is mapped from (dim, nnz) to (dim, nnz, 1),
-        // and block_coo_indices is mapped from (dim, block_numel) to
-        // (dim, 1, block_numel), so the result has shape
-        // (dim, nnz, block_numel).
-        .unsqueeze_(-1).add(block_coo_indices.unsqueeze_(1))
-        // Squash the nnz and the block_numel dimension
-        // to produce valid nnz dimension of a COO tensor.
-        .flatten(-2, -1);
+  bool coalesced =
+      layout == kSparseCsr || self.numel() == 0 || self._nnz() == 1;
+  AT_DISPATCH_PLAIN_SPARSE_COMPRESSED_LAYOUTS(
+      layout,
+      "sparse_compressed_to_sparse",
+      [&] { values = self.values().flatten(0, batch_ndim); },
+      [&] {
+        auto blocksize =
+            DimVector(self.values().sizes().slice(batch_ndim + 1, 2));
+        DimVector batch_blocksize;
+        batch_blocksize.append(batch_ndim, 1);
+        batch_blocksize.append(blocksize);
+        const auto block_coo_indices = at::zeros(
+            {batch_ndim + 2, blocksize[0] * blocksize[1]}, indices.options());
+        block_coo_indices.narrow(0, batch_ndim, 2)
+            .copy_(at::sparse::full_coo_indices(blocksize, indices.options()));
+        indices = indices
+                      // Scale indices that identify blocks to element-wise
+                      // coordinates that correspond to the top-left corner of
+                      // each block.
+                      .mul(at::tensor(batch_blocksize, indices.options())
+                               .unsqueeze_(1))
+                      // Now that we know top-left block coordinates, we offset
+                      // them with element-wise coordinates in the block to get
+                      // the result. NOTE: indices is mapped from (dim, nnz) to
+                      // (dim, nnz, 1), and block_coo_indices is mapped from
+                      // (dim, block_numel) to (dim, 1, block_numel), so the
+                      // result has shape (dim, nnz, block_numel).
+                      .unsqueeze_(-1)
+                      .add(block_coo_indices.unsqueeze_(1))
+                      // Squash the nnz and the block_numel dimension
+                      // to produce valid nnz dimension of a COO tensor.
+                      .flatten(-2, -1);
 
-      values = self.values().flatten(0, batch_ndim + 2);
+        values = self.values().flatten(0, batch_ndim + 2);
 
-      // BSRs not spanning across several rows produces coalesced results.
-      coalesced |= (layout == kSparseBsr && blocksize[0] == 1 && batch_ndim == 0);
-    });
-  return at::native::_sparse_coo_tensor_unsafe(indices, values, self.sizes())._coalesced_(coalesced);
+        // BSRs not spanning across several rows produces coalesced results.
+        coalesced |=
+            (layout == kSparseBsr && blocksize[0] == 1 && batch_ndim == 0);
+      });
+  return at::native::_sparse_coo_tensor_unsafe(indices, values, self.sizes())
+      ._coalesced_(coalesced);
 }
 
-Tensor sparse_compressed_to_sparse(const Tensor& self, std::optional<c10::Layout> layout, OptionalIntArrayRef blocksize, std::optional<int64_t> dense_dim_opt) {
+Tensor sparse_compressed_to_sparse(
+    const Tensor& self,
+    std::optional<c10::Layout> layout,
+    OptionalIntArrayRef blocksize,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = layout.value_or(kSparse);
-  TORCH_INTERNAL_ASSERT(self.layout() != layout_to, "sparse_compressed_to_sparse: unexpected same input and output layout");
-  _to_sparse_check_arguments("sparse_compressed_to_sparse", self, layout_to, blocksize, dense_dim_opt);
+  TORCH_INTERNAL_ASSERT(
+      self.layout() != layout_to,
+      "sparse_compressed_to_sparse: unexpected same input and output layout");
+  _to_sparse_check_arguments(
+      "sparse_compressed_to_sparse", self, layout_to, blocksize, dense_dim_opt);
 
-  auto blocksize_ = blocksize.value_or((self.layout() == kSparseBsr || self.layout() == kSparseBsc) ? at::sparse_csr::getBlockSize(self) : at::DimVector({1, 1}));
+  auto blocksize_ = blocksize.value_or(
+      (self.layout() == kSparseBsr || self.layout() == kSparseBsc)
+          ? at::sparse_csr::getBlockSize(self)
+          : at::DimVector({1, 1}));
   switch (layout_to) {
-  case kStrided:
-    return sparse_compressed_to_dense(self, /*dtype=*/std::nullopt, /*masked_grad=*/std::nullopt);
-  case kSparse:
-    return sparse_compressed_to_sparse(self, 2);
-  case kSparseCsr:
-    return sparse_compressed_to_sparse_csr(self, dense_dim_opt);
-  case kSparseCsc:
-    return sparse_compressed_to_sparse_csc(self, dense_dim_opt);
-  case kSparseBsr:
-    return sparse_compressed_to_sparse_bsr(self, blocksize_, dense_dim_opt);
-  case kSparseBsc:
-    return sparse_compressed_to_sparse_bsc(self, blocksize_, dense_dim_opt);
-  default:
-    break;
+    case kStrided:
+      return sparse_compressed_to_dense(
+          self, /*dtype=*/std::nullopt, /*masked_grad=*/std::nullopt);
+    case kSparse:
+      return sparse_compressed_to_sparse(self, 2);
+    case kSparseCsr:
+      return sparse_compressed_to_sparse_csr(self, dense_dim_opt);
+    case kSparseCsc:
+      return sparse_compressed_to_sparse_csc(self, dense_dim_opt);
+    case kSparseBsr:
+      return sparse_compressed_to_sparse_bsr(self, blocksize_, dense_dim_opt);
+    case kSparseBsc:
+      return sparse_compressed_to_sparse_bsc(self, blocksize_, dense_dim_opt);
+    default:
+      break;
   }
 
-  TORCH_CHECK(false, "sparse_compressed_to_sparse: ", self.layout(), " to ", layout_to, " conversion not supported");
+  TORCH_CHECK(
+      false,
+      "sparse_compressed_to_sparse: ",
+      self.layout(),
+      " to ",
+      layout_to,
+      " conversion not supported");
   return Tensor{};
 }
 
-Tensor sparse_coo_to_sparse(const Tensor& self, std::optional<c10::Layout> layout, OptionalIntArrayRef blocksize, std::optional<int64_t> dense_dim_opt) {
+Tensor sparse_coo_to_sparse(
+    const Tensor& self,
+    std::optional<c10::Layout> layout,
+    OptionalIntArrayRef blocksize,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = layout.value_or(kSparse);
-  TORCH_INTERNAL_ASSERT(self.layout() != layout_to, "sparse_coo_to_sparse: unexpected same input and output layout");
-  _to_sparse_check_arguments("sparse_coo_to_sparse", self, layout_to, blocksize, dense_dim_opt);
+  TORCH_INTERNAL_ASSERT(
+      self.layout() != layout_to,
+      "sparse_coo_to_sparse: unexpected same input and output layout");
+  _to_sparse_check_arguments(
+      "sparse_coo_to_sparse", self, layout_to, blocksize, dense_dim_opt);
 
   switch (layout_to) {
-  case kStrided:
-    return self.to_dense(std::nullopt, std::nullopt);
-  case kSparseCsr:
-    return self.to_sparse_csr(dense_dim_opt);
-  case kSparseCsc:
-    return self.to_sparse_csc(dense_dim_opt);
-  case kSparseBsr:
-    return self.to_sparse_bsr(*blocksize, dense_dim_opt);
-  case kSparseBsc:
-    return self.to_sparse_bsc(*blocksize, dense_dim_opt);
-  default:
-    break;
+    case kStrided:
+      return self.to_dense(std::nullopt, std::nullopt);
+    case kSparseCsr:
+      return self.to_sparse_csr(dense_dim_opt);
+    case kSparseCsc:
+      return self.to_sparse_csc(dense_dim_opt);
+    case kSparseBsr:
+      return self.to_sparse_bsr(*blocksize, dense_dim_opt);
+    case kSparseBsc:
+      return self.to_sparse_bsc(*blocksize, dense_dim_opt);
+    default:
+      break;
   }
 
-  TORCH_CHECK(false, "sparse_coo_to_sparse: ", self.layout(), " to ", layout_to, " conversion not supported");
+  TORCH_CHECK(
+      false,
+      "sparse_coo_to_sparse: ",
+      self.layout(),
+      " to ",
+      layout_to,
+      " conversion not supported");
   return Tensor{};
 }
 
@@ -1964,10 +2434,15 @@ Tensor to_sparse(const Tensor& self, const int64_t sparse_dim) {
   return self._to_sparse(sparse_dim);
 }
 
-Tensor to_sparse(const Tensor& self, std::optional<c10::Layout> layout, OptionalIntArrayRef blocksize, std::optional<int64_t> dense_dim_opt) {
+Tensor to_sparse(
+    const Tensor& self,
+    std::optional<c10::Layout> layout,
+    OptionalIntArrayRef blocksize,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = layout.value_or(kSparse);
   if (self.layout() == layout_to) {
-    _to_sparse_check_arguments("to_sparse", self, layout, blocksize, dense_dim_opt);
+    _to_sparse_check_arguments(
+        "to_sparse", self, layout, blocksize, dense_dim_opt);
     return self;
   }
   return self._to_sparse(layout, blocksize, dense_dim_opt);
@@ -1976,7 +2451,8 @@ Tensor to_sparse(const Tensor& self, std::optional<c10::Layout> layout, Optional
 Tensor to_sparse_csr(const Tensor& self, std::optional<int64_t> dense_dim_opt) {
   auto layout_to = kSparseCsr;
   if (self.layout() == layout_to) {
-    _to_sparse_check_arguments("to_sparse_csr", self, layout_to, {}, dense_dim_opt);
+    _to_sparse_check_arguments(
+        "to_sparse_csr", self, layout_to, {}, dense_dim_opt);
     return self;
   }
   return self._to_sparse_csr(dense_dim_opt);
@@ -1985,25 +2461,34 @@ Tensor to_sparse_csr(const Tensor& self, std::optional<int64_t> dense_dim_opt) {
 Tensor to_sparse_csc(const Tensor& self, std::optional<int64_t> dense_dim_opt) {
   auto layout_to = kSparseCsc;
   if (self.layout() == layout_to) {
-    _to_sparse_check_arguments("to_sparse_csc", self, layout_to, {}, dense_dim_opt);
+    _to_sparse_check_arguments(
+        "to_sparse_csc", self, layout_to, {}, dense_dim_opt);
     return self;
   }
   return self._to_sparse_csc(dense_dim_opt);
 }
 
-Tensor to_sparse_bsr(const Tensor& self, IntArrayRef blocksize, std::optional<int64_t> dense_dim_opt) {
+Tensor to_sparse_bsr(
+    const Tensor& self,
+    IntArrayRef blocksize,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = kSparseBsr;
   if (self.layout() == layout_to) {
-    _to_sparse_check_arguments("to_sparse_bsr", self, layout_to, blocksize, dense_dim_opt);
+    _to_sparse_check_arguments(
+        "to_sparse_bsr", self, layout_to, blocksize, dense_dim_opt);
     return self;
   }
   return self._to_sparse_bsr(blocksize, dense_dim_opt);
 }
 
-Tensor to_sparse_bsc(const Tensor& self, IntArrayRef blocksize, std::optional<int64_t> dense_dim_opt) {
+Tensor to_sparse_bsc(
+    const Tensor& self,
+    IntArrayRef blocksize,
+    std::optional<int64_t> dense_dim_opt) {
   auto layout_to = kSparseBsc;
   if (self.layout() == layout_to) {
-    _to_sparse_check_arguments("to_sparse_bsc", self, layout_to, blocksize, dense_dim_opt);
+    _to_sparse_check_arguments(
+        "to_sparse_bsc", self, layout_to, blocksize, dense_dim_opt);
     return self;
   }
   return self._to_sparse_bsc(blocksize, dense_dim_opt);
@@ -2012,9 +2497,13 @@ Tensor to_sparse_bsc(const Tensor& self, IntArrayRef blocksize, std::optional<in
 // Sparse layout conversions End
 
 Tensor to_meta(const Tensor& tensor) {
-  auto out = at::native::empty_strided_meta_symint(tensor.sym_sizes(), tensor.sym_strides(), \
-/*dtype=*/tensor.scalar_type(), /*layout=*/tensor.layout(), \
-/*device=*/c10::Device(c10::kMeta), /*pin_memory=*/std::nullopt);
+  auto out = at::native::empty_strided_meta_symint(
+      tensor.sym_sizes(),
+      tensor.sym_strides(),
+      /*dtype=*/tensor.scalar_type(),
+      /*layout=*/tensor.layout(),
+      /*device=*/c10::Device(c10::kMeta),
+      /*pin_memory=*/std::nullopt);
   // needs to handle wrapped numbers, so dtype promotion works properly.
   if (tensor.unsafeGetTensorImpl()->is_wrapped_number()) {
     out.unsafeGetTensorImpl()->set_wrapped_number(true);

--- a/aten/src/ATen/native/TensorConversions.h
+++ b/aten/src/ATen/native/TensorConversions.h
@@ -7,7 +7,7 @@
 #include <optional>
 
 namespace at {
-  class Tensor;
+class Tensor;
 namespace native {
 bool to_will_alias(
     const Tensor& self,
@@ -20,7 +20,12 @@ bool to_will_alias(
 Tensor to_meta(const Tensor& tensor);
 std::optional<Tensor> to_meta(const std::optional<Tensor>& tensor);
 std::vector<Tensor> to_meta(at::ITensorListRef t_list);
-Tensor dense_to_sparse_with_mask(const Tensor& self, const Tensor& mask, std::optional<c10::Layout> layout, OptionalIntArrayRef blocksize, std::optional<int64_t> dense_dim_opt);
+Tensor dense_to_sparse_with_mask(
+    const Tensor& self,
+    const Tensor& mask,
+    std::optional<c10::Layout> layout,
+    OptionalIntArrayRef blocksize,
+    std::optional<int64_t> dense_dim_opt);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/TensorDimApply.h
+++ b/aten/src/ATen/native/TensorDimApply.h
@@ -3,10 +3,15 @@
 #include <c10/util/irange.h>
 
 namespace at::native {
-//input tensors are non-zero dim and non-empty
-template<typename T1, typename T2, typename Function>
+// input tensors are non-zero dim and non-empty
+template <typename T1, typename T2, typename Function>
 
-void tensor_dim_apply3(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim, Function func) {
+void tensor_dim_apply3(
+    const Tensor& self,
+    Tensor& values,
+    Tensor& indices,
+    int64_t dim,
+    Function func) {
   int ndims = self.dim();
   int tensor_dim_apply_has_finished = 0;
   std::vector<int64_t> counter(ndims, 0);
@@ -19,9 +24,16 @@ void tensor_dim_apply3(const Tensor& self, Tensor& values, Tensor& indices, int6
   int self_dim_size = self.size(dim);
 
   while (!tensor_dim_apply_has_finished) {
-    func(self_data, values_data, indices_data, self_dim_size, self_stride, values_stride, indices_stride);
+    func(
+        self_data,
+        values_data,
+        indices_data,
+        self_dim_size,
+        self_stride,
+        values_stride,
+        indices_stride);
     if (ndims == 1) {
-       break;
+      break;
     }
     for (const auto dim_i : c10::irange(ndims)) {
       if (dim_i == dim) {
@@ -37,18 +49,18 @@ void tensor_dim_apply3(const Tensor& self, Tensor& values, Tensor& indices, int6
       indices_data += indices.stride(dim_i);
 
       if (counter[dim_i] == self.size(dim_i)) {
-        if (dim_i == ndims-1) {
+        if (dim_i == ndims - 1) {
           tensor_dim_apply_has_finished = 1;
           break;
         } else {
-          self_data -= counter[dim_i]*self.stride(dim_i);
-          values_data -= counter[dim_i]*values.stride(dim_i);
-          indices_data -= counter[dim_i]*indices.stride(dim_i);
+          self_data -= counter[dim_i] * self.stride(dim_i);
+          values_data -= counter[dim_i] * values.stride(dim_i);
+          indices_data -= counter[dim_i] * indices.stride(dim_i);
           counter[dim_i] = 0;
         }
       } else {
         break;
-     }
+      }
     }
   }
 }

--- a/aten/src/ATen/native/TensorFactories.h
+++ b/aten/src/ATen/native/TensorFactories.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <ATen/core/Tensor.h>
-#include <ATen/EmptyTensor.h>
-#include <ATen/TensorIterator.h>
 #include <ATen/Dispatch.h>
 #include <ATen/Dispatch_v2.h>
+#include <ATen/EmptyTensor.h>
+#include <ATen/TensorIterator.h>
+#include <ATen/core/Tensor.h>
 #include <ATen/native/DispatchStub.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -41,9 +41,9 @@ inline int64_t get_tril_size(int64_t row, int64_t col, int64_t offset) {
     return 0;
   }
   // number of elements in the first row of the tril
-  auto m_first_row = offset > 0 ?
-    std::min<int64_t>(col, 1 + offset) : // upper bounded by col
-    row + offset > 0; // either 0 or 1
+  auto m_first_row = offset > 0 ? std::min<int64_t>(col, 1 + offset)
+                                : // upper bounded by col
+      row + offset > 0; // either 0 or 1
   // number of elements in the last row of the tril, bounded by [0, col]
   auto m_last_row = std::max<int64_t>(0, std::min<int64_t>(col, row + offset));
   // number of rows, bounded by [0, row]
@@ -63,35 +63,49 @@ inline int64_t get_tril_size(int64_t row, int64_t col, int64_t offset) {
 }
 
 inline void check_args(
-    int64_t row, int64_t col, std::optional<Layout> layout_opt) {
+    int64_t row,
+    int64_t col,
+    std::optional<Layout> layout_opt) {
   TORCH_CHECK(row >= 0, "row must be non-negative, got", row);
   TORCH_CHECK(col >= 0, "col must be non-negative, got", col);
   if (layout_opt.has_value()) {
     TORCH_CHECK(
-      *layout_opt == at::kStrided,
-      "only support layout=torch.strided, got",
-      *layout_opt)
+        *layout_opt == at::kStrided,
+        "only support layout=torch.strided, got",
+        *layout_opt)
   }
 }
 
 using at::check_size_nonnegative;
 
 // assumes maximum value in created tensor is n-1 (e.g., torch.randperm(n))
-inline void check_supported_max_int_with_precision(int64_t n, const Tensor& tensor) {
+inline void check_supported_max_int_with_precision(
+    int64_t n,
+    const Tensor& tensor) {
   // match defined() to behavior of checks below
-  TORCH_CHECK(at::scalar_tensor(n>0?n-1:n, tensor.options()).defined(),
-              "n is too large for result tensor type: '", tensor.toString(), "'");
+  TORCH_CHECK(
+      at::scalar_tensor(n > 0 ? n - 1 : n, tensor.options()).defined(),
+      "n is too large for result tensor type: '",
+      tensor.toString(),
+      "'");
 
   // Ensure sufficient precision for floating point representation.
   switch (tensor.scalar_type()) {
     case at::ScalarType::Half:
-      TORCH_CHECK(n <= (int64_t(1) << 11) + 1, "n cannot be greater than 2049 for Half type.");
+      TORCH_CHECK(
+          n <= (int64_t(1) << 11) + 1,
+          "n cannot be greater than 2049 for Half type.");
       break;
     case at::ScalarType::Float:
-      TORCH_CHECK(n <= (int64_t(1) << 24) + 1, "n cannot be greater than 2^24+1 for Float type.");
+      TORCH_CHECK(
+          n <= (int64_t(1) << 24) + 1,
+          "n cannot be greater than 2^24+1 for Float type.");
       break;
-    case at::ScalarType::Double:  // Unlikely to happen, but doesn't hurt to check
-      TORCH_CHECK(n <= (int64_t(1) << 53) + 1, "n cannot be greater than 2^53+1 for Double type.");
+    case at::ScalarType::Double: // Unlikely to happen, but doesn't hurt to
+                                 // check
+      TORCH_CHECK(
+          n <= (int64_t(1) << 53) + 1,
+          "n cannot be greater than 2^53+1 for Double type.");
       break;
     default:
       break;
@@ -104,14 +118,24 @@ inline void check_supported_max_int_with_precision(int64_t n, const Tensor& tens
 inline Tensor& fill_empty_deterministic_(Tensor& tensor) {
   if (tensor.is_floating_point() || tensor.is_complex()) {
     AT_DISPATCH_V2(
-      tensor.scalar_type(), "fill_empty_deterministic_", AT_WRAP([&]() {
-        tensor.fill_(std::numeric_limits<scalar_t>::quiet_NaN());
-    }), AT_EXPAND(AT_FLOATING_TYPES), AT_EXPAND(AT_COMPLEX_TYPES), AT_EXPAND(AT_FLOAT8_TYPES), kBFloat16, kHalf, kComplexHalf);
+        tensor.scalar_type(),
+        "fill_empty_deterministic_",
+        AT_WRAP([&]() {
+          tensor.fill_(std::numeric_limits<scalar_t>::quiet_NaN());
+        }),
+        AT_EXPAND(AT_FLOATING_TYPES),
+        AT_EXPAND(AT_COMPLEX_TYPES),
+        AT_EXPAND(AT_FLOAT8_TYPES),
+        kBFloat16,
+        kHalf,
+        kComplexHalf);
   } else {
     AT_DISPATCH_V2(
-      tensor.scalar_type(), "fill_empty_deterministic_", AT_WRAP([&]() {
-        tensor.fill_(std::numeric_limits<scalar_t>::max());
-    }), kBool, AT_EXPAND(AT_INTEGRAL_TYPES_V2));
+        tensor.scalar_type(),
+        "fill_empty_deterministic_",
+        AT_WRAP([&]() { tensor.fill_(std::numeric_limits<scalar_t>::max()); }),
+        kBool,
+        AT_EXPAND(AT_INTEGRAL_TYPES_V2));
   }
   return tensor;
 }
@@ -130,7 +154,10 @@ struct ZeroTensorAllocator final : public at::Allocator {
   DeleterFnPtr raw_deleter() const override {
     return deleter;
   }
-  void copy_data(void* dest [[maybe_unused]], const void* src [[maybe_unused]], std::size_t count [[maybe_unused]]) const final {}
+  void copy_data(
+      void* dest [[maybe_unused]],
+      const void* src [[maybe_unused]],
+      std::size_t count [[maybe_unused]]) const final {}
   at::Device device_;
 };
 

--- a/aten/src/ATen/native/TensorIteratorDynamicCasting.h
+++ b/aten/src/ATen/native/TensorIteratorDynamicCasting.h
@@ -1,39 +1,39 @@
 #pragma once
 
-#include <complex>
-#include <type_traits>
-#include <c10/core/ScalarType.h>
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/native/TensorIterator.h>
+#include <c10/core/ScalarType.h>
+#include <complex>
+#include <type_traits>
 
+// This file includes utilities for dynamic_casting done by TensorIterator, see
+// CUDALoops.cuh and Loops.h.
 
-// This file includes utilities for dynamic_casting done by TensorIterator, see CUDALoops.cuh and Loops.h.
-
-// dynamic_casting handles when the types expected by the iterator do not match the types of the arguments
-// to the function that is being called.
-// On CUDA, the cast is currently pushed down into the kernel (for performance reasons).
-// On CPU, there is currently an internal assert that a dynamic_cast is not needed.
+// dynamic_casting handles when the types expected by the iterator do not match
+// the types of the arguments to the function that is being called. On CUDA, the
+// cast is currently pushed down into the kernel (for performance reasons). On
+// CPU, there is currently an internal assert that a dynamic_cast is not needed.
 
 namespace at::native {
 
 // `needs_dynamic_casting` compares the types expected by iterator
 // (i.e. dtypes of the operands) with the actual type of the arguments
 // (and returns) of func_t
-template<typename func_t, int nargs=function_traits<func_t>::arity>
+template <typename func_t, int nargs = function_traits<func_t>::arity>
 struct needs_dynamic_casting {
   static bool check(TensorIteratorBase& iter) {
     using traits = function_traits<func_t>;
     using cpp_type = typename traits::template arg<nargs - 1>::type;
     using cpp_map = c10::CppTypeToScalarType<cpp_type>;
 
-    if (iter.input_dtype(nargs-1) != cpp_map::value) {
+    if (iter.input_dtype(nargs - 1) != cpp_map::value) {
       return true;
     }
     return needs_dynamic_casting<func_t, nargs - 1>::check(iter);
   }
 };
 
-template<typename func_t>
+template <typename func_t>
 struct needs_dynamic_casting<func_t, 0> {
   static bool check(TensorIteratorBase& iter) {
     using traits = function_traits<func_t>;
@@ -49,4 +49,4 @@ struct needs_dynamic_casting<func_t, 0> {
   }
 };
 
-} //namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/TensorProperties.cpp
+++ b/aten/src/ATen/native/TensorProperties.cpp
@@ -1,7 +1,7 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/core/Tensor.h>
 #include <ATen/Context.h>
 #include <ATen/NamedTensorUtils.h>
+#include <ATen/core/Tensor.h>
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <ATen/native/TensorProperties.h>
 
@@ -36,9 +36,10 @@ bool nested_is_same_size(const Tensor& self, const Tensor& other) {
   TORCH_CHECK(
       self.is_nested() && other.is_nested(),
       "Expected both self and other to be nested tensors. ",
-      "Self ", self.is_nested()? "is " : "is not ",
+      "Self ",
+      self.is_nested() ? "is " : "is not ",
       "nested. While Other ",
-      other.is_nested()? "is " : "is not ",
+      other.is_nested() ? "is " : "is not ",
       "nested.")
   const auto self_nt_size = _nested_tensor_size(self);
   const auto other_nt_size = _nested_tensor_size(other);
@@ -79,16 +80,21 @@ int64_t stride(const Tensor& self, Dimname dim) {
 }
 
 bool cudnn_is_acceptable(const TensorBase& self) {
-  if (!globalContext().userEnabledCuDNN()) return false;
-  if (!self.is_cuda()) return false;
+  if (!globalContext().userEnabledCuDNN())
+    return false;
+  if (!self.is_cuda())
+    return false;
   auto st = self.scalar_type();
-  if (!(st == kDouble || st == kFloat || st == kHalf)) return false;
-  if (!detail::getCUDAHooks().compiledWithCuDNN()) return false;
+  if (!(st == kDouble || st == kFloat || st == kHalf))
+    return false;
+  if (!detail::getCUDAHooks().compiledWithCuDNN())
+    return false;
   // cuDNN functions like grid_sampler returns CUDNN_STATUS_BAD_PARAM on empty
   // tensors. Maybe some cuDNN functions actually support empty tensors, but
   // native/THNN kernels shouldn't be much slower because the output is also
   // likely empty.
-  if (self.sym_numel() == 0) return false;
+  if (self.sym_numel() == 0)
+    return false;
   // NB: In the old Python code, there was also a test to see if the
   // cuDNN library was actually dynamically linked or not.  I'm not
   // sure if we can actually test this.
@@ -99,9 +105,10 @@ bool cudnn_is_acceptable(const Tensor& self) {
   return cudnn_is_acceptable(static_cast<const TensorBase&>(self));
 }
 
-Tensor & detach_(Tensor & self) {
-  // this just exists to give us a hook in VariableType and an entry in Declarations.yaml
-  //TORCH_CHECK(false, "detach_ is not implemented for Tensor");
+Tensor& detach_(Tensor& self) {
+  // this just exists to give us a hook in VariableType and an entry in
+  // Declarations.yaml
+  // TORCH_CHECK(false, "detach_ is not implemented for Tensor");
   return self;
 }
 
@@ -117,7 +124,8 @@ Tensor contiguous(const Tensor& self, MemoryFormat memory_format) {
 }
 
 bool is_set_to(const Tensor& self, const Tensor& src) {
-  if (self.storage().unsafeGetStorageImpl() == src.storage().unsafeGetStorageImpl() &&
+  if (self.storage().unsafeGetStorageImpl() ==
+          src.storage().unsafeGetStorageImpl() &&
       self.storage_offset() == src.storage_offset() &&
       self.dim() == src.dim()) {
     for (const auto d : c10::irange(self.dim())) {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1,9 +1,4 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/core/Tensor.h>
-#include <ATen/core/DimVector.h>
-#include <ATen/core/functional.h>
-#include <ATen/core/IListRef.h>
-#include <ATen/TensorSubclassLikeUtils.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/ExpandUtils.h>
@@ -12,9 +7,12 @@
 #include <ATen/NamedTensorUtils.h>
 #include <ATen/SparseCsrTensorUtils.h>
 #include <ATen/TensorOperators.h>
+#include <ATen/TensorSubclassLikeUtils.h>
 #include <ATen/WrapDimUtils.h>
 #include <ATen/core/DimVector.h>
 #include <ATen/core/IListRef.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/core/functional.h>
 #include <ATen/native/Copy.h>
 #include <ATen/native/NonSymbolicBC.h>
 #include <ATen/native/Resize.h>
@@ -27,10 +25,10 @@
 #include <ATen/native/cpu/StackKernel.h>
 #include <ATen/quantized/QTensorImpl.h>
 #include <c10/util/Exception.h>
-#include <optional>
 #include <c10/util/SmallVector.h>
 #include <c10/util/accumulate.h>
 #include <c10/util/irange.h>
+#include <optional>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -164,9 +162,9 @@
 #include <ATen/ops/split_with_sizes.h>
 #include <ATen/ops/split_with_sizes_copy_native.h>
 #include <ATen/ops/split_with_sizes_native.h>
+#include <ATen/ops/squeeze.h>
 #include <ATen/ops/squeeze_copy_native.h>
 #include <ATen/ops/squeeze_native.h>
-#include <ATen/ops/squeeze.h>
 #include <ATen/ops/stack_native.h>
 #include <ATen/ops/sub.h>
 #include <ATen/ops/sum.h>
@@ -217,15 +215,16 @@
 
 namespace at::meta {
 
-inline c10::MemoryFormat cat_compute_output_memory_format(const MaterializedITensorListRef& inputs) {
+inline c10::MemoryFormat cat_compute_output_memory_format(
+    const MaterializedITensorListRef& inputs) {
   std::optional<c10::MemoryFormat> format = std::nullopt;
   for (const Tensor& t : inputs) {
     auto f = t.suggest_memory_format();
     if (f == c10::MemoryFormat::Contiguous) {
-        return f;
+      return f;
     }
     if (format.has_value() && format.value() != f) {
-        return c10::MemoryFormat::Contiguous;
+      return c10::MemoryFormat::Contiguous;
     }
     format = f;
   }
@@ -233,10 +232,11 @@ inline c10::MemoryFormat cat_compute_output_memory_format(const MaterializedITen
 }
 
 TORCH_PRECOMPUTE_META_FUNC(cat)(const ITensorListRef& tensors, int64_t dim) {
-  // previously, size [0] tensors were the only possible empty tensors; thus, it wasn't possible
-  // to cat empty tensors unless all the other tensors were 1-dimensional, so we allowed these tensors
-  // to be "skipped".  We maintain this behavior for backwards compatibility, but only for this specific
-  // size (i.e. other empty sizes are not skipped).
+  // previously, size [0] tensors were the only possible empty tensors; thus, it
+  // wasn't possible to cat empty tensors unless all the other tensors were
+  // 1-dimensional, so we allowed these tensors to be "skipped".  We maintain
+  // this behavior for backwards compatibility, but only for this specific size
+  // (i.e. other empty sizes are not skipped).
   auto materialized = tensors.materialize();
 
   native::check_cat_no_zero_dim(materialized);
@@ -246,7 +246,8 @@ TORCH_PRECOMPUTE_META_FUNC(cat)(const ITensorListRef& tensors, int64_t dim) {
   auto maybe_outnames = namedinference::compute_cat_outnames(materialized);
 
   TORCH_CHECK(
-      !materialized.empty(), "torch.cat(): expected a non-empty list of Tensors");
+      !materialized.empty(),
+      "torch.cat(): expected a non-empty list of Tensors");
 
   // Look for the first valid tensor.
   size_t valid = materialized.size();
@@ -281,17 +282,20 @@ TORCH_PRECOMPUTE_META_FUNC(cat)(const ITensorListRef& tensors, int64_t dim) {
 
   // Fallback 'set_output' parameters.
   // (in case we don't find a valid tensor)
-  DimVector sizes {0};
-  TensorOptions options = materialized[0].get().options()
-      .dtype(out_dtype)
-      .memory_format(memory_format);
+  DimVector sizes{0};
+  TensorOptions options =
+      materialized[0].get().options().dtype(out_dtype).memory_format(
+          memory_format);
 
   // If we found a valid tensor, check whether the input tensors
   // are compatible, i.e. we can execute `cat` on them.
   bool found_valid_tensor = valid < materialized.size();
   if (found_valid_tensor) {
     TORCH_CHECK(
-        dim <= materialized[valid].get().dim(), "torch.cat(): dimension ", dim, "out of range");
+        dim <= materialized[valid].get().dim(),
+        "torch.cat(): dimension ",
+        dim,
+        "out of range");
 
     // Compute the output tensor size.
     // It should have the same shape as any other valid tensor,
@@ -315,9 +319,9 @@ TORCH_PRECOMPUTE_META_FUNC(cat)(const ITensorListRef& tensors, int64_t dim) {
     // Actually set the output.
     sizes = materialized[valid].get().sizes().vec();
     sizes[dim] = size_at_dim;
-    options = materialized[valid].get().options()
-        .dtype(out_dtype)
-        .memory_format(memory_format);
+    options =
+        materialized[valid].get().options().dtype(out_dtype).memory_format(
+            memory_format);
   }
 
   set_output_raw_strided(0, sizes, {}, options, maybe_outnames);
@@ -365,21 +369,36 @@ Tensor& set_(Tensor& result, Storage source) {
   return result.set_(std::move(source), 0, new_size, {});
 }
 
-
-// unify with cuda implementation?  This is not done to avoid a dispatch in resize_impl_cpu_
-Tensor& set_storage_cpu_(Tensor& result, Storage storage, int64_t storage_offset, IntArrayRef size, IntArrayRef stride) {
+// unify with cuda implementation?  This is not done to avoid a dispatch in
+// resize_impl_cpu_
+Tensor& set_storage_cpu_(
+    Tensor& result,
+    Storage storage,
+    int64_t storage_offset,
+    IntArrayRef size,
+    IntArrayRef stride) {
   checkSetStorage(result, std::move(storage), storage_offset, size, stride);
 
   result.unsafeGetTensorImpl()->set_storage_offset(storage_offset);
-  at::OptionalIntArrayRef stride_opt = stride.data() != nullptr ?
-                                          at::OptionalIntArrayRef(stride) : std::nullopt;
+  at::OptionalIntArrayRef stride_opt =
+      stride.data() != nullptr ? at::OptionalIntArrayRef(stride) : std::nullopt;
   // We can re-use this kernel for the meta device.
-  // We just need to make sure we don't actually try to resize the (null) storage.
-  at::native::resize_impl_cpu_(result.unsafeGetTensorImpl(), size, stride_opt, /*resize_storage=*/!result.is_meta());
+  // We just need to make sure we don't actually try to resize the (null)
+  // storage.
+  at::native::resize_impl_cpu_(
+      result.unsafeGetTensorImpl(),
+      size,
+      stride_opt,
+      /*resize_storage=*/!result.is_meta());
   return result;
 }
 
-Tensor& set_storage_meta__symint(Tensor& result, Storage storage, c10::SymInt storage_offset, c10::SymIntArrayRef size, c10::SymIntArrayRef stride) {
+Tensor& set_storage_meta__symint(
+    Tensor& result,
+    Storage storage,
+    c10::SymInt storage_offset,
+    c10::SymIntArrayRef size,
+    c10::SymIntArrayRef stride) {
   checkSetStorage(result, storage, storage_offset, size, stride);
 
   c10::SymDimVector contiguous_strides;
@@ -392,28 +411,33 @@ Tensor& set_storage_meta__symint(Tensor& result, Storage storage, c10::SymInt st
       contiguous_strides.at(last_idx) = 1;
       for (auto i = last_idx - 1; i >= 0; --i) {
         // TODO: max with 1
-        contiguous_strides.at(i) = contiguous_strides.at(i+1) * size.at(i+1);
+        contiguous_strides.at(i) =
+            contiguous_strides.at(i + 1) * size.at(i + 1);
       }
     }
     stride = contiguous_strides;
   }
 
   // Run this before storage setting so we can access numel
-  result.unsafeGetTensorImpl()->set_sizes_and_strides(size, stride, storage_offset);
+  result.unsafeGetTensorImpl()->set_sizes_and_strides(
+      size, stride, storage_offset);
 
   // Matches maybe_resize_storage_cpu no-numel behavior
   if (TORCH_GUARD_SIZE_OBLIVIOUS(result.sym_numel().sym_ne(0))) {
     // maybe_resize_storage_cpu can handle no storage exists at all but
     // that should never be the case here
     TORCH_INTERNAL_ASSERT(storage);
-    TORCH_CHECK(storage.resizable(), "Trying to resize storage that is not resizable");
+    TORCH_CHECK(
+        storage.resizable(), "Trying to resize storage that is not resizable");
     // All meta data pointers are the same, so we don't have to "re" allocate
     // it.  TODO: Actually this might not quite be correct if we use special
     // pointers to track whether or not fake cuda tensors are pinned or not
     const auto itemsize = result.dtype().itemsize();
     c10::SymInt new_size_bytes = result.is_contiguous()
-      ? at::detail::computeStorageNbytesContiguous(size, itemsize, std::move(storage_offset))
-      : at::detail::computeStorageNbytes(size, stride, itemsize, std::move(storage_offset));
+        ? at::detail::computeStorageNbytesContiguous(
+              size, itemsize, std::move(storage_offset))
+        : at::detail::computeStorageNbytes(
+              size, stride, itemsize, std::move(storage_offset));
     // TODO: When there are unbacked SymInts, we unconditionally skip the
     // setter.  This is technically wrong, but we cannot conveniently test
     // the real condition in many cases, because a lot of people are using
@@ -422,48 +446,59 @@ Tensor& set_storage_meta__symint(Tensor& result, Storage storage, c10::SymInt st
     //
     // The old behavior was to unconditionally set_nbytes, but I think not
     // setting it is more safe.
-    if (new_size_bytes.has_hint() && storage.sym_nbytes().has_hint() && TORCH_GUARD_SIZE_OBLIVIOUS(new_size_bytes.sym_gt(storage.sym_nbytes()))) {
+    if (new_size_bytes.has_hint() && storage.sym_nbytes().has_hint() &&
+        TORCH_GUARD_SIZE_OBLIVIOUS(
+            new_size_bytes.sym_gt(storage.sym_nbytes()))) {
       storage.set_nbytes(std::move(new_size_bytes));
     }
   }
   return result;
 }
 
-Tensor& set__symint(Tensor& result, const Tensor& storage, c10::SymInt storage_offset, c10::SymIntArrayRef size, c10::SymIntArrayRef stride) {
-  TORCH_CHECK(storage.is_contiguous(), "passed in tensor to be used as storage must be contiguous");
-  return result.set__symint(storage.storage(), storage_offset + storage.sym_storage_offset(), size, stride);
+Tensor& set__symint(
+    Tensor& result,
+    const Tensor& storage,
+    c10::SymInt storage_offset,
+    c10::SymIntArrayRef size,
+    c10::SymIntArrayRef stride) {
+  TORCH_CHECK(
+      storage.is_contiguous(),
+      "passed in tensor to be used as storage must be contiguous");
+  return result.set__symint(
+      storage.storage(),
+      storage_offset + storage.sym_storage_offset(),
+      size,
+      stride);
 }
 
 Tensor& set_tensor_(Tensor& result, const Tensor& source) {
   if (result.unsafeGetTensorImpl() != source.unsafeGetTensorImpl()) {
-    return result.set__symint(source.storage(), source.sym_storage_offset(), source.sym_sizes(), source.sym_strides());
+    return result.set__symint(
+        source.storage(),
+        source.sym_storage_offset(),
+        source.sym_sizes(),
+        source.sym_strides());
   }
   return result;
 }
 
-// this needs to be split along CPU/CUDA lines because we don't have a consistent
-// way of getting the allocator to use for a device (c10::GetAllocator is not
-// the same as at::cuda::getCUDADeviceAllocator().
+// this needs to be split along CPU/CUDA lines because we don't have a
+// consistent way of getting the allocator to use for a device
+// (c10::GetAllocator is not the same as at::cuda::getCUDADeviceAllocator().
 Tensor& set_cpu_(Tensor& result) {
   caffe2::TypeMeta dtype = result.dtype();
-  Storage storage(
-      Storage::use_byte_size_t(),
-      0,
-      c10::GetAllocator(kCPU),
-      true);
+  Storage storage(Storage::use_byte_size_t(), 0, c10::GetAllocator(kCPU), true);
   result.set_(std::move(storage), 0, {0}, {});
   TORCH_INTERNAL_ASSERT(dtype == result.dtype());
   return result;
 }
 
-// We can't re-use the cpu kernel here because we don't want to use the cpu allocator.
+// We can't re-use the cpu kernel here because we don't want to use the cpu
+// allocator.
 Tensor& set_meta_(Tensor& result) {
   caffe2::TypeMeta dtype = result.dtype();
   Storage storage(
-      Storage::use_byte_size_t(),
-      0,
-      c10::GetAllocator(kMeta),
-      true);
+      Storage::use_byte_size_t(), 0, c10::GetAllocator(kMeta), true);
   result.set_(std::move(storage), 0, {0}, {});
   TORCH_INTERNAL_ASSERT(dtype == result.dtype());
   return result;
@@ -474,14 +509,22 @@ Tensor sparse_broadcast_to(const Tensor& self, IntArrayRef size) {
 
   const auto self_size = self.sizes();
   const int64_t new_sparse_dims = size.size() - self.dim();
-  TORCH_CHECK(new_sparse_dims >= 0, "the requested broadcast shape has fewer dimensions than the input");
+  TORCH_CHECK(
+      new_sparse_dims >= 0,
+      "the requested broadcast shape has fewer dimensions than the input");
   const int64_t res_sparse_dim = new_sparse_dims + self.sparse_dim();
 
   for (int64_t i = 0; i < self.dim(); ++i) {
-    TORCH_CHECK(self_size[i] == 1 || self_size[i] == size[i + new_sparse_dims],
-                "The input's length ", self_size[i], " at dimension ", i,
-                " does not broadcast over the requested shape of length ", size[i + new_sparse_dims],
-                " at dimension ", i + new_sparse_dims);
+    TORCH_CHECK(
+        self_size[i] == 1 || self_size[i] == size[i + new_sparse_dims],
+        "The input's length ",
+        self_size[i],
+        " at dimension ",
+        i,
+        " does not broadcast over the requested shape of length ",
+        size[i + new_sparse_dims],
+        " at dimension ",
+        i + new_sparse_dims);
   }
 
   const int64_t self_nnz = self._nnz();
@@ -508,17 +551,22 @@ Tensor sparse_broadcast_to(const Tensor& self, IntArrayRef size) {
   // sparse dimensions are expanded. Possible expansion of dense
   // dimensions can be discarded as it does not affect the is_coalesce
   // property.
-  bool is_coalesced = !self.dim() || (self.is_coalesced() && (max_unchanged_dim < min_broadcast_dim || min_broadcast_dim == -1));
+  bool is_coalesced = !self.dim() ||
+      (self.is_coalesced() &&
+       (max_unchanged_dim < min_broadcast_dim || min_broadcast_dim == -1));
 
   // Replace non-broadcastable dims with 1 in the `size` vector {
-  auto res_sparse_dim_broadcast_mask = at::DimVector(size.begin(), size.begin() + res_sparse_dim);
+  auto res_sparse_dim_broadcast_mask =
+      at::DimVector(size.begin(), size.begin() + res_sparse_dim);
   for (int64_t i = new_sparse_dims; i < res_sparse_dim; ++i) {
-    res_sparse_dim_broadcast_mask[i] = (size[i] == self_size[i - new_sparse_dims]) ? 1 : size[i];
+    res_sparse_dim_broadcast_mask[i] =
+        (size[i] == self_size[i - new_sparse_dims]) ? 1 : size[i];
   }
   // }
 
-  // Then define for each sparse dim the number of reps for each nnz index/value due to broadcasting.
-  // Repetitions do not take into accout the current value of nnz - this will be taken care of later {
+  // Then define for each sparse dim the number of reps for each nnz index/value
+  // due to broadcasting. Repetitions do not take into accout the current value
+  // of nnz - this will be taken care of later {
   auto nnz_repeats = c10::DimVector(res_sparse_dim);
   nnz_repeats.back() = res_sparse_dim_broadcast_mask.back();
   for (int64_t i = res_sparse_dim - 2; i >= 0; --i) {
@@ -526,46 +574,64 @@ Tensor sparse_broadcast_to(const Tensor& self, IntArrayRef size) {
   }
   // }
 
-  // Broadcast values. Each nnz value has to be repeated nnz_expand_factor times {
+  // Broadcast values. Each nnz value has to be repeated nnz_expand_factor times
+  // {
   auto broadcast_values_shape = DimVector(size.size() - res_sparse_dim + 2);
-  std::copy(size.begin() + res_sparse_dim, size.end(), broadcast_values_shape.begin() + 2);
+  std::copy(
+      size.begin() + res_sparse_dim,
+      size.end(),
+      broadcast_values_shape.begin() + 2);
   broadcast_values_shape[0] = self_nnz;
   broadcast_values_shape[1] = nnz_expand_factor;
-  auto broadcast_values = self._values().unsqueeze(1).expand(broadcast_values_shape).flatten(0, 1);
+  auto broadcast_values =
+      self._values().unsqueeze(1).expand(broadcast_values_shape).flatten(0, 1);
   // }
 
   // We can return early if there are no broadcastable sparse dims
   if (largest_sparse_dim_len < 0) {
-    return at::sparse_coo_tensor(self._indices(), broadcast_values, size, self.options(), self.is_coalesced());
+    return at::sparse_coo_tensor(
+        self._indices(),
+        broadcast_values,
+        size,
+        self.options(),
+        self.is_coalesced());
   }
 
-  auto broadcast_indices = self._indices().new_empty(
-      {res_sparse_dim, self_nnz * nnz_expand_factor}
-  );
+  auto broadcast_indices =
+      self._indices().new_empty({res_sparse_dim, self_nnz * nnz_expand_factor});
 
-  // Repeat each individual index value in dimension dim nnz_repeats[dim] / size[dim] times,
-  // and then repeat the whole vector self_nnz * (nnz_expand_factor / nnz_repeats[dim]) times to get the final
-  // index vector - only for broadcast dims {
-  const auto dim_arange = at::arange(largest_sparse_dim_len, self._indices().options());
+  // Repeat each individual index value in dimension dim nnz_repeats[dim] /
+  // size[dim] times, and then repeat the whole vector self_nnz *
+  // (nnz_expand_factor / nnz_repeats[dim]) times to get the final index vector
+  // - only for broadcast dims {
+  const auto dim_arange =
+      at::arange(largest_sparse_dim_len, self._indices().options());
   for (int64_t i = 0; i < res_sparse_dim; ++i) {
     Tensor curr_dim_idx;
     if ((i < new_sparse_dims) || (self_size[i - new_sparse_dims] != size[i])) {
-      // If the dim is either a newly created sparse dim, or an already existing one which is broadcastable,
-      // do the reps over an arange vector
-      curr_dim_idx = dim_arange.narrow(0, 0, size[i]).unsqueeze_(0).unsqueeze_(-1).expand(
-          {self_nnz * (nnz_expand_factor / nnz_repeats[i]), size[i], nnz_repeats[i] / size[i]}
-      );
+      // If the dim is either a newly created sparse dim, or an already existing
+      // one which is broadcastable, do the reps over an arange vector
+      curr_dim_idx = dim_arange.narrow(0, 0, size[i])
+                         .unsqueeze_(0)
+                         .unsqueeze_(-1)
+                         .expand(
+                             {self_nnz * (nnz_expand_factor / nnz_repeats[i]),
+                              size[i],
+                              nnz_repeats[i] / size[i]});
     } else {
       // Otherwise over a slice of self._indices() of length self_nnz
-      curr_dim_idx = self_indices.select(0, i - new_sparse_dims).unsqueeze_(1).expand(
-          {self_nnz, nnz_expand_factor}
-      );
+      curr_dim_idx = self_indices.select(0, i - new_sparse_dims)
+                         .unsqueeze_(1)
+                         .expand({self_nnz, nnz_expand_factor});
     }
-    broadcast_indices.select(0, i).view(curr_dim_idx.sizes()).copy_(curr_dim_idx);
+    broadcast_indices.select(0, i)
+        .view(curr_dim_idx.sizes())
+        .copy_(curr_dim_idx);
   }
   // }
 
-  return at::sparse_coo_tensor(broadcast_indices, broadcast_values, size, self.options(), is_coalesced);
+  return at::sparse_coo_tensor(
+      broadcast_indices, broadcast_values, size, self.options(), is_coalesced);
 }
 
 Tensor broadcast_to_symint(const Tensor& self, SymIntArrayRef size) {
@@ -576,7 +642,9 @@ std::vector<Tensor> broadcast_tensors(TensorList tensors) {
   return expand_outplace(tensors);
 }
 
-static void fastCatOutDim0(const Tensor& out, const MaterializedITensorListRef& inputs) {
+static void fastCatOutDim0(
+    const Tensor& out,
+    const MaterializedITensorListRef& inputs) {
   auto outBytes = out.nbytes();
   char* dataPtr = reinterpret_cast<char*>(out.data_ptr());
   size_t totalBytes = 0;
@@ -589,7 +657,6 @@ static void fastCatOutDim0(const Tensor& out, const MaterializedITensorListRef& 
   }
   TORCH_CHECK(outBytes == totalBytes);
 }
-
 
 TORCH_IMPL_FUNC(cat_out_cpu)
 (const ITensorListRef& tensors,
@@ -606,20 +673,24 @@ TORCH_IMPL_FUNC(cat_out_cpu)
 
   auto materialized = tensors.materialize();
 
-  bool use_serial_kernel = result.numel() < at::internal::GRAIN_SIZE || at::get_num_threads() == 1;
+  bool use_serial_kernel =
+      result.numel() < at::internal::GRAIN_SIZE || at::get_num_threads() == 1;
   ScalarType dtype = materialized[valid].get().scalar_type();
   bool serial_dtype = at::isFloatingType(dtype);
   // fast path for single thread when both inputs and result are contiguous and
   // not empty, and concat dim is 0
-  if (use_serial_kernel && all_contiguous && all_same_dtype && (MemoryFormat::Contiguous == memory_format)) {
+  if (use_serial_kernel && all_contiguous && all_same_dtype &&
+      (MemoryFormat::Contiguous == memory_format)) {
     if (dim == 0) {
       fastCatOutDim0(result, materialized);
       return;
     }
-    // TODO: Add fast cat for higher dimensions and support multi-threaded fast cat
+    // TODO: Add fast cat for higher dimensions and support multi-threaded fast
+    // cat
   }
 
-  // fast path for single thread when both inputs and result are contiguous and not empty
+  // fast path for single thread when both inputs and result are contiguous and
+  // not empty
   if (use_serial_kernel && all_contiguous && all_same_dtype && serial_dtype) {
     cat_serial_stub(kCPU, result, materialized, dim);
     return;
@@ -632,29 +703,31 @@ TORCH_IMPL_FUNC(cat_out_cpu)
     auto slice_dim_size = source_slice.sizes()[dim];
     auto result_slice = result.narrow(dim, 0, slice_dim_size);
     auto result_slice_data = result_slice.data_ptr();
-    auto result_stride_bytes = result.stride(dim) * elementSize(result.scalar_type());
+    auto result_stride_bytes =
+        result.stride(dim) * elementSize(result.scalar_type());
 
     auto iter = TensorIteratorConfig()
-      .set_check_mem_overlap(false)
-      .resize_outputs(false)
-      .add_output(result_slice)
-      .add_const_input(source_slice)
-      .enforce_safe_casting_to_output(true)
-      .build();
+                    .set_check_mem_overlap(false)
+                    .resize_outputs(false)
+                    .add_output(result_slice)
+                    .add_const_input(source_slice)
+                    .enforce_safe_casting_to_output(true)
+                    .build();
 
     for (const Tensor& tensor : materialized) {
       if (cat_should_skip_tensor(tensor)) {
         continue;
       }
       auto source_data = static_cast<const char*>(tensor.const_data_ptr());
-      auto result_data = static_cast<char*>(result_slice_data) + offset * result_stride_bytes;
+      auto result_data =
+          static_cast<char*>(result_slice_data) + offset * result_stride_bytes;
       iter.unsafe_replace_operand(0, result_data);
       iter.unsafe_replace_operand(1, const_cast<char*>(source_data));
       copy_stub(iter.device_type(), iter, false);
       offset += slice_dim_size;
     }
   } else {
-    for (const Tensor& tensor: materialized) {
+    for (const Tensor& tensor : materialized) {
       if (cat_should_skip_tensor(tensor)) {
         continue;
       }
@@ -662,14 +735,14 @@ TORCH_IMPL_FUNC(cat_out_cpu)
       auto result_slice = result.narrow(dim, offset, slice_dim_size);
 
       auto iter = TensorIteratorConfig()
-        .set_check_mem_overlap(false)  // Already checked above
-        .resize_outputs(false)
-        .add_output(result_slice)
-        .add_const_input(tensor)
-        .promote_inputs_to_common_dtype(true)
-        .cast_common_dtype_to_outputs(true)
-        .enforce_safe_casting_to_output(true)
-        .build();
+                      .set_check_mem_overlap(false) // Already checked above
+                      .resize_outputs(false)
+                      .add_output(result_slice)
+                      .add_const_input(tensor)
+                      .promote_inputs_to_common_dtype(true)
+                      .cast_common_dtype_to_outputs(true)
+                      .enforce_safe_casting_to_output(true)
+                      .build();
       copy_stub(iter.device_type(), iter, false);
       offset += slice_dim_size;
     }
@@ -695,7 +768,7 @@ Tensor concat(TensorList tensors, Dimname dim) {
   return at::cat(tensors, dimname_to_position(tensors[0], dim));
 }
 
-Tensor & concat_out(TensorList tensors, int64_t dim, Tensor & result) {
+Tensor& concat_out(TensorList tensors, int64_t dim, Tensor& result) {
   return at::cat_out(result, tensors, dim);
 }
 
@@ -712,7 +785,7 @@ Tensor concatenate(TensorList tensors, Dimname dim) {
   return at::cat(tensors, dimname_to_position(tensors[0], dim));
 }
 
-Tensor& concatenate_out(TensorList tensors, int64_t dim, Tensor & result) {
+Tensor& concatenate_out(TensorList tensors, int64_t dim, Tensor& result) {
   return at::cat_out(result, tensors, dim);
 }
 
@@ -720,7 +793,10 @@ Tensor concatenate(TensorList tensors, int64_t dim) {
   return at::cat(tensors, dim);
 }
 
-static bool sizes_match_except(IntArrayRef s1, IntArrayRef s2, int64_t dim_except /* should already be wrapped */) {
+static bool sizes_match_except(
+    IntArrayRef s1,
+    IntArrayRef s2,
+    int64_t dim_except /* should already be wrapped */) {
   if (s1.size() != s2.size()) {
     return false;
   }
@@ -734,23 +810,46 @@ static bool sizes_match_except(IntArrayRef s1, IntArrayRef s2, int64_t dim_excep
 
 // Check to see if the shape of tensors is compatible
 // for being concatenated along a given dimension.
-static void check_cat_sparse_dims(Tensor const &t,
-  int64_t pos /* used only for debug messages */,
-  IntArrayRef sizes,
-  int64_t wrapped,
-  int64_t sparse_dim,
-  int64_t dense_dim) {
-    TORCH_CHECK(t.is_sparse(),
-            "Concatenating sparse tensors, but a dense tensor was found at position ", pos, ".");
-    TORCH_CHECK(sizes_match_except(sizes, t.sizes(), wrapped),
-            "All tensors must have the same shape: ", sizes, " (except in the concatenating dimension),"
-            " but found shape: ", t.sizes(), " at position ", pos, ".");
-    TORCH_CHECK(t.sparse_dim() == sparse_dim && t.dense_dim() == dense_dim,
-            "All tensors must have the same sparse_dim and dense_dim: ", sparse_dim, ", ", dense_dim,
-            ", but tensor at position ", pos, " has ", t.sparse_dim(), ", ", t.dense_dim(), ".");
+static void check_cat_sparse_dims(
+    Tensor const& t,
+    int64_t pos /* used only for debug messages */,
+    IntArrayRef sizes,
+    int64_t wrapped,
+    int64_t sparse_dim,
+    int64_t dense_dim) {
+  TORCH_CHECK(
+      t.is_sparse(),
+      "Concatenating sparse tensors, but a dense tensor was found at position ",
+      pos,
+      ".");
+  TORCH_CHECK(
+      sizes_match_except(sizes, t.sizes(), wrapped),
+      "All tensors must have the same shape: ",
+      sizes,
+      " (except in the concatenating dimension),"
+      " but found shape: ",
+      t.sizes(),
+      " at position ",
+      pos,
+      ".");
+  TORCH_CHECK(
+      t.sparse_dim() == sparse_dim && t.dense_dim() == dense_dim,
+      "All tensors must have the same sparse_dim and dense_dim: ",
+      sparse_dim,
+      ", ",
+      dense_dim,
+      ", but tensor at position ",
+      pos,
+      " has ",
+      t.sparse_dim(),
+      ", ",
+      t.dense_dim(),
+      ".");
 }
 
-static Tensor cat_sparse_impl(const MaterializedITensorListRef& tensors, int64_t dim) {
+static Tensor cat_sparse_impl(
+    const MaterializedITensorListRef& tensors,
+    int64_t dim) {
   std::vector<Tensor> indices;
   std::vector<Tensor> values;
   int64_t wrapped = maybe_wrap_dim(dim, tensors[0].get().dim());
@@ -798,14 +897,14 @@ static Tensor cat_sparse_impl(const MaterializedITensorListRef& tensors, int64_t
         tensors[0].get().options().layout_opt(),
         tensors[0].get().options().device_opt(),
         tensors[0].get().options().pinned_memory_opt());
-  }
-  else {
+  } else {
     // Catting along a dense dimension requires us to create new values.
     // For illustration, consider the sparse 3d tensors t1 and t2,
     // given by t1 = [[[1,2],[3,4]], ... (zeros) ..., [[5,6],[7,8]]]
     // and t2 = [... (zeros) ..., [[9, 10], [11,12]], ... (zeros) ...],
     // Their concatenation along dimension 2 is:
-    // [[[1,2,0,0],[3,4,0,0]], ... (zeros) ..., [[0,0,9,10],[0,0,11,12]], ... (zeros) ..., [[5,6,0,0],[7,8,0,0]]]
+    // [[[1,2,0,0],[3,4,0,0]], ... (zeros) ..., [[0,0,9,10],[0,0,11,12]], ...
+    // (zeros) ..., [[5,6,0,0],[7,8,0,0]]]
     //
     // Their values tensors are, respectively,
     // [[[1,2],[3,4]],[[5,6],[7,8]]] and [[[9,10],[11,12]]].
@@ -813,10 +912,12 @@ static Tensor cat_sparse_impl(const MaterializedITensorListRef& tensors, int64_t
     // and so the values tensor of their concatenation along dim 2 will be:
     // [[[1,2,0,0],[3,4,0,0]],[[5,6,0,0],[7,8,0,0]],[[0,0,9,10],[0,0,11,12]]]
     //
-    // which we can get by taking the values tensor of each tensor, catting it with zeros of the appropriate size on the left and right,
-    // and then catting all those results together.
+    // which we can get by taking the values tensor of each tensor, catting it
+    // with zeros of the appropriate size on the left and right, and then
+    // catting all those results together.
 
-    // The dimension in each tensor's values object that corresponds to the overall dimension along which we're catting.
+    // The dimension in each tensor's values object that corresponds to the
+    // overall dimension along which we're catting.
     int64_t values_dim = wrapped - sparse_dim + 1;
     // The final size along the catted dimension.
     const int64_t total_size = std::accumulate(
@@ -871,7 +972,8 @@ static Tensor cat_sparse_impl(const MaterializedITensorListRef& tensors, int64_t
 Tensor cat_sparse(const ITensorListRef& tensors, int64_t dim) {
   auto materialized = tensors.materialize();
   auto maybe_outnames = namedinference::compute_cat_outnames(materialized);
-  auto result = cat_sparse_impl(materialized, at::legacy_cat_wrap_dim(dim, materialized));
+  auto result =
+      cat_sparse_impl(materialized, at::legacy_cat_wrap_dim(dim, materialized));
   namedinference::propagate_names_if_nonempty(result, maybe_outnames);
   return result;
 }
@@ -888,11 +990,14 @@ Tensor block_diag(TensorList tensors) {
     const Tensor& tensor = tensors[tensor_idx];
 
     TORCH_CHECK(
-      tensor.device() == device,
-      "torch.block_diag: input tensors must all be on the same device.",
-      " Input 0 is on device ", device,
-      " and input ", tensor_idx, " is on device ", tensor.device()
-    );
+        tensor.device() == device,
+        "torch.block_diag: input tensors must all be on the same device.",
+        " Input 0 is on device ",
+        device,
+        " and input ",
+        tensor_idx,
+        " is on device ",
+        tensor.device());
   }
 
   ScalarType output_scalar_type = native::result_type(tensors);
@@ -907,10 +1012,12 @@ Tensor block_diag(TensorList tensors) {
     const Tensor& tensor = tensors[tensor_idx];
     int64_t ndims = tensor.dim();
     TORCH_CHECK(
-      ndims <= 2,
-      "torch.block_diag: Input tensors must have 2 or fewer dimensions. Input ",
-      tensor_idx, " has ", ndims, " dimensions"
-    );
+        ndims <= 2,
+        "torch.block_diag: Input tensors must have 2 or fewer dimensions. Input ",
+        tensor_idx,
+        " has ",
+        ndims,
+        " dimensions");
 
     int64_t dim0 = 1;
     int64_t dim1 = 1;
@@ -931,9 +1038,8 @@ Tensor block_diag(TensorList tensors) {
   }
 
   result = at::zeros(
-    {result_dim0, result_dim1},
-    tensors[0].options().dtype(output_scalar_type)
-  );
+      {result_dim0, result_dim1},
+      tensors[0].options().dtype(output_scalar_type));
 
   int64_t cur_dim0 = 0;
   int64_t cur_dim1 = 0;
@@ -942,7 +1048,9 @@ Tensor block_diag(TensorList tensors) {
   for (const auto& tensor : tensors_2D) {
     int64_t dim0 = tensor.size(0);
     int64_t dim1 = tensor.size(1);
-    result.slice(0, cur_dim0, cur_dim0+dim0).slice(1, cur_dim1, cur_dim1+dim1).copy_(tensor);
+    result.slice(0, cur_dim0, cur_dim0 + dim0)
+        .slice(1, cur_dim1, cur_dim1 + dim1)
+        .copy_(tensor);
 
     cur_dim0 += dim0;
     cur_dim1 += dim1;
@@ -952,18 +1060,18 @@ Tensor block_diag(TensorList tensors) {
 }
 
 std::vector<Tensor> chunk(const Tensor& self, int64_t chunks, int64_t dim) {
-  TORCH_CHECK(self.dim() > 0,
-           "chunk expects at least a 1-dimensional tensor");
-  TORCH_CHECK(chunks > 0,
-           "chunk expects `chunks` to be greater than 0, got: ", chunks);
+  TORCH_CHECK(self.dim() > 0, "chunk expects at least a 1-dimensional tensor");
+  TORCH_CHECK(
+      chunks > 0, "chunk expects `chunks` to be greater than 0, got: ", chunks);
 
   const auto dim_size = self.sym_size(dim);
   auto split_size = (dim_size + chunks - 1) / chunks;
 
-  // We need to call split_with_sizes in the case where split_size and dimension size are 0, because
-  // a call to split would discard the number of chunks (because we can have an arbitrary number of
-  // 0-sized chunks adding up to 0).  So, call split_with_sizes with the correct number of chunks,
-  // eventually we will do this for all cases.
+  // We need to call split_with_sizes in the case where split_size and dimension
+  // size are 0, because a call to split would discard the number of chunks
+  // (because we can have an arbitrary number of 0-sized chunks adding up to 0).
+  // So, call split_with_sizes with the correct number of chunks, eventually we
+  // will do this for all cases.
   if (split_size == 0 && dim_size == 0) {
     std::vector<c10::SymInt> split_sizes(chunks, split_size);
     split_sizes[chunks - 1] = split_size - (split_size * chunks - dim_size);
@@ -973,29 +1081,46 @@ std::vector<Tensor> chunk(const Tensor& self, int64_t chunks, int64_t dim) {
   }
 }
 
-std::vector<Tensor> tensor_split_sections_symint(const Tensor& self, c10::SymInt sym_sections, int64_t dim) {
-  TORCH_CHECK(self.dim() > 0, "tensor_split expected at least a 1-dimensional tensor, but got a tensor with ", self.dim()," dims");
+std::vector<Tensor> tensor_split_sections_symint(
+    const Tensor& self,
+    c10::SymInt sym_sections,
+    int64_t dim) {
+  TORCH_CHECK(
+      self.dim() > 0,
+      "tensor_split expected at least a 1-dimensional tensor, but got a tensor with ",
+      self.dim(),
+      " dims");
   int64_t dim_ = maybe_wrap_dim(dim, self.dim());
   // NB: intentional, sections specifies number of output tensors, which
   // cannot be polymorphic
   int64_t sections = sym_sections.guard_int(__FILE__, __LINE__);
-  TORCH_CHECK(sections > 0, "number of sections must be larger than 0, got ", sections);
+  TORCH_CHECK(
+      sections > 0, "number of sections must be larger than 0, got ", sections);
   const auto dim_size = self.sym_size(dim_);
   std::vector<Tensor> splits(sections);
   auto min_split_size = dim_size / sections;
   auto num_splits_one_extra = dim_size % sections;
   c10::SymInt start_idx = 0;
   for (const auto split_idx : c10::irange(sections)) {
-    auto split_size = (num_splits_one_extra > split_idx) ? (min_split_size + 1) : min_split_size;
-    splits[split_idx] = at::slice_symint(self, dim_, start_idx, start_idx + split_size);
+    auto split_size = (num_splits_one_extra > split_idx) ? (min_split_size + 1)
+                                                         : min_split_size;
+    splits[split_idx] =
+        at::slice_symint(self, dim_, start_idx, start_idx + split_size);
     start_idx += split_size;
   }
   return splits;
 }
 
 template <typename T>
-std::vector<Tensor> _tensor_split_indices(const Tensor& self, ArrayRef<T> indices, int64_t dim) {
-  TORCH_CHECK(self.dim() > 0, "tensor_split expected at least a 1-dimensional tensor, but got a tensor with ", self.dim()," dims");
+std::vector<Tensor> _tensor_split_indices(
+    const Tensor& self,
+    ArrayRef<T> indices,
+    int64_t dim) {
+  TORCH_CHECK(
+      self.dim() > 0,
+      "tensor_split expected at least a 1-dimensional tensor, but got a tensor with ",
+      self.dim(),
+      " dims");
   int64_t dim_ = maybe_wrap_dim(dim, self.dim());
   int64_t num_indices = indices.size();
   std::vector<Tensor> splits(num_indices + 1);
@@ -1005,29 +1130,50 @@ std::vector<Tensor> _tensor_split_indices(const Tensor& self, ArrayRef<T> indice
     splits[split_idx] = at::symint::slice<T>(self, dim_, start_idx, end_idx);
     start_idx = end_idx;
   }
-  splits[num_indices] = at::symint::slice<T>(self, dim_, start_idx, at::symint::size<T>(self, dim_));
+  splits[num_indices] = at::symint::slice<T>(
+      self, dim_, start_idx, at::symint::size<T>(self, dim_));
   return splits;
 }
 
-std::vector<Tensor> tensor_split(const Tensor& self, IntArrayRef indices, int64_t dim) {
+std::vector<Tensor> tensor_split(
+    const Tensor& self,
+    IntArrayRef indices,
+    int64_t dim) {
   return _tensor_split_indices(self, indices, dim);
 }
 
-std::vector<Tensor> tensor_split_indices_symint(const Tensor& self, SymIntArrayRef indices, int64_t dim) {
+std::vector<Tensor> tensor_split_indices_symint(
+    const Tensor& self,
+    SymIntArrayRef indices,
+    int64_t dim) {
   return _tensor_split_indices(self, indices, dim);
 }
 
-std::vector<Tensor> tensor_split(const Tensor& self, const Tensor& tensor_indices_or_sections, int64_t dim) {
-  TORCH_CHECK(self.dim() > 0, "tensor_split expected at least a 1-dimensional tensor, but got a tensor with ", self.dim()," dims");
+std::vector<Tensor> tensor_split(
+    const Tensor& self,
+    const Tensor& tensor_indices_or_sections,
+    int64_t dim) {
+  TORCH_CHECK(
+      self.dim() > 0,
+      "tensor_split expected at least a 1-dimensional tensor, but got a tensor with ",
+      self.dim(),
+      " dims");
   auto split_device = tensor_indices_or_sections.device();
-  TORCH_CHECK(split_device == kCPU,
-    "tensor_split expected tensor_indices_or_sections to be on cpu, but it's on ", split_device);
+  TORCH_CHECK(
+      split_device == kCPU,
+      "tensor_split expected tensor_indices_or_sections to be on cpu, but it's on ",
+      split_device);
   auto split_dtype = tensor_indices_or_sections.scalar_type();
-  TORCH_CHECK(split_dtype == at::kLong,
-    "tensor_split expected tensor_indices_or_sections to have dtype of long, but got ", split_dtype);
+  TORCH_CHECK(
+      split_dtype == at::kLong,
+      "tensor_split expected tensor_indices_or_sections to have dtype of long, but got ",
+      split_dtype);
   auto split_dim = tensor_indices_or_sections.dim();
-  TORCH_CHECK(split_dim == 1 || split_dim == 0,
-    "tensor_split expected tensor_indices_or_sections to be a zero-dimensional or one-dimensional tensor, but got a tensor with ", split_dim, " dims");
+  TORCH_CHECK(
+      split_dim == 1 || split_dim == 0,
+      "tensor_split expected tensor_indices_or_sections to be a zero-dimensional or one-dimensional tensor, but got a tensor with ",
+      split_dim,
+      " dims");
 
   if (split_dim == 0) {
     int64_t sections = tensor_indices_or_sections.item<int64_t>();
@@ -1045,11 +1191,13 @@ std::vector<Tensor> tensor_split(const Tensor& self, const Tensor& tensor_indice
   }
 }
 
-std::vector<Tensor> unsafe_chunk(const Tensor& self, int64_t chunks, int64_t dim) {
-  TORCH_CHECK(self.dim() > 0,
-           "chunk expects at least a 1-dimensional tensor");
-  TORCH_CHECK(chunks > 0,
-           "chunk expects `chunks` to be greater than 0, got: ", chunks);
+std::vector<Tensor> unsafe_chunk(
+    const Tensor& self,
+    int64_t chunks,
+    int64_t dim) {
+  TORCH_CHECK(self.dim() > 0, "chunk expects at least a 1-dimensional tensor");
+  TORCH_CHECK(
+      chunks > 0, "chunk expects `chunks` to be greater than 0, got: ", chunks);
 
   const auto dim_size = self.size(dim);
   int64_t split_size = (dim_size + chunks - 1) / chunks;
@@ -1068,11 +1216,20 @@ Tensor diagflat(const Tensor& self, int64_t offset) {
   return self.contiguous().view(-1).diag(offset);
 }
 
-Tensor diagonal(const Tensor& self, int64_t offset, int64_t dim1_, int64_t dim2_) {
+Tensor diagonal(
+    const Tensor& self,
+    int64_t offset,
+    int64_t dim1_,
+    int64_t dim2_) {
   int64_t nDims = self.dim();
   int64_t dim1 = maybe_wrap_dim(dim1_, nDims);
   int64_t dim2 = maybe_wrap_dim(dim2_, nDims);
-  TORCH_CHECK(dim1 != dim2, "diagonal dimensions cannot be identical ", dim1_, ", ", dim2_);
+  TORCH_CHECK(
+      dim1 != dim2,
+      "diagonal dimensions cannot be identical ",
+      dim1_,
+      ", ",
+      dim2_);
   auto outnames = namedinference::compute_diagonal_outnames(self, dim1, dim2);
   NoNamesGuard no_names_guard;
 
@@ -1087,14 +1244,17 @@ Tensor diagonal(const Tensor& self, int64_t offset, int64_t dim1_, int64_t dim2_
   // Note that we invert +/- in the second to absorb the negative
   // sign in the offset.
   if (offset >= 0) {
-    diag_size = std::max<int64_t>(std::min(self.size(dim1), self.size(dim2)-offset), 0);
+    diag_size = std::max<int64_t>(
+        std::min(self.size(dim1), self.size(dim2) - offset), 0);
   } else {
-    diag_size = std::max<int64_t>(std::min(self.size(dim1)+offset, self.size(dim2)), 0);
+    diag_size = std::max<int64_t>(
+        std::min(self.size(dim1) + offset, self.size(dim2)), 0);
   }
 
-  // NumPy allows you to specify offsets "off the end"; let's just be careful not to
-  // set a ridiculous storage_offset in that case (technically it shouldn't matter
-  // because there are no elements in the tensor, but let's be kosher).
+  // NumPy allows you to specify offsets "off the end"; let's just be careful
+  // not to set a ridiculous storage_offset in that case (technically it
+  // shouldn't matter because there are no elements in the tensor, but let's be
+  // kosher).
   if (diag_size == 0) {
     // skip
   } else if (offset >= 0) {
@@ -1103,8 +1263,9 @@ Tensor diagonal(const Tensor& self, int64_t offset, int64_t dim1_, int64_t dim2_
     storage_offset -= offset * self.stride(dim1);
   }
 
-  // construct new size and stride: we drop dim1 and dim2 (maximum first for not changing the index of the minimum)
-  // the new ("joint") dimension is appended to the end of the shape / stride to match numpy semantics
+  // construct new size and stride: we drop dim1 and dim2 (maximum first for not
+  // changing the index of the minimum) the new ("joint") dimension is appended
+  // to the end of the shape / stride to match numpy semantics
   DimVector sizes(self.sizes().begin(), self.sizes().end());
   DimVector strides(self.strides().begin(), self.strides().end());
   sizes.erase(sizes.begin() + std::max(dim1, dim2));
@@ -1112,7 +1273,7 @@ Tensor diagonal(const Tensor& self, int64_t offset, int64_t dim1_, int64_t dim2_
   sizes.erase(sizes.begin() + std::min(dim1, dim2));
   strides.erase(strides.begin() + std::min(dim1, dim2));
   sizes.push_back(diag_size);
-  strides.push_back(self.stride(dim1)+self.stride(dim2));
+  strides.push_back(self.stride(dim1) + self.stride(dim2));
 
   // return view with new parameters
   auto result = self.as_strided(sizes, strides, storage_offset);
@@ -1122,7 +1283,12 @@ Tensor diagonal(const Tensor& self, int64_t offset, int64_t dim1_, int64_t dim2_
   return result;
 }
 
-Tensor diagonal(const Tensor& self, Dimname outdim, Dimname dim1, Dimname dim2, int64_t offset) {
+Tensor diagonal(
+    const Tensor& self,
+    Dimname outdim,
+    Dimname dim1,
+    Dimname dim2,
+    int64_t offset) {
   auto result = at::diagonal(
       self,
       offset,
@@ -1136,11 +1302,20 @@ Tensor diagonal(const Tensor& self, Dimname outdim, Dimname dim1, Dimname dim2, 
   return result.refine_names(new_names);
 }
 
-Tensor diag_embed(const Tensor& self, int64_t offset, int64_t dim1_, int64_t dim2_) {
+Tensor diag_embed(
+    const Tensor& self,
+    int64_t offset,
+    int64_t dim1_,
+    int64_t dim2_) {
   int64_t nDims = self.dim() + 1;
   int64_t dim1 = maybe_wrap_dim(dim1_, nDims);
   int64_t dim2 = maybe_wrap_dim(dim2_, nDims);
-  TORCH_CHECK(dim1 != dim2, "diagonal dimensions cannot be identical ", dim1_, ", ", dim2_);
+  TORCH_CHECK(
+      dim1 != dim2,
+      "diagonal dimensions cannot be identical ",
+      dim1_,
+      ", ",
+      dim2_);
   int64_t new_dim_len = std::abs(offset) + self.size(-1);
   auto sizes = self.sizes().vec();
   sizes.pop_back();
@@ -1153,15 +1328,28 @@ Tensor diag_embed(const Tensor& self, int64_t offset, int64_t dim1_, int64_t dim
 }
 
 Tensor expand(const Tensor& self, c10::IntArrayRef size, bool /*unused*/) {
-  TORCH_CHECK(size.size() >= (size_t)self.dim(),
-           "expand(", self.toString(), "{", self.sizes(), "}, size=", size,
-           "): the number of sizes provided (", size.size(), ") ",
-           "must be greater or equal to the number of dimensions in the tensor (",
-           self.dim(), ")");
-  TORCH_CHECK(!self.is_sparse() && !at::sparse_csr::is_sparse_compressed(self),
-            "expand is unsupported for ", self.layout(), " tensors");
+  TORCH_CHECK(
+      size.size() >= (size_t)self.dim(),
+      "expand(",
+      self.toString(),
+      "{",
+      self.sizes(),
+      "}, size=",
+      size,
+      "): the number of sizes provided (",
+      size.size(),
+      ") ",
+      "must be greater or equal to the number of dimensions in the tensor (",
+      self.dim(),
+      ")");
+  TORCH_CHECK(
+      !self.is_sparse() && !at::sparse_csr::is_sparse_compressed(self),
+      "expand is unsupported for ",
+      self.layout(),
+      " tensors");
 
-  auto expandedSizesAndStrides = inferExpandGeometry_dimvector(self.sizes(), self.strides(), size);
+  auto expandedSizesAndStrides =
+      inferExpandGeometry_dimvector(self.sizes(), self.strides(), size);
 
   auto result = self.as_strided(
       expandedSizesAndStrides.sizes, expandedSizesAndStrides.strides);
@@ -1174,26 +1362,50 @@ Tensor expand_as(const Tensor& self, const Tensor& other) {
 }
 
 Tensor sum_to_size_symint(const Tensor& self, SymIntArrayRef size) {
-  TORCH_CHECK(is_expandable_to(size, self.sym_sizes()),
-           "size {", size, "} is not expandable to size {", self.sizes(), "}.");
+  TORCH_CHECK(
+      is_expandable_to(size, self.sym_sizes()),
+      "size {",
+      size,
+      "} is not expandable to size {",
+      self.sizes(),
+      "}.");
 
   return sum_to(self, size);
 }
 
-// We currently do not support per-channel quant for unfold, diagonal, expand, permute.
-// TODO: Make this an aten function and replace as_strided_qtensorimpl once that is done.
-static Tensor make_qtensor(const Tensor& self, IntArrayRef size, IntArrayRef stride, QuantizerPtr quantizer) {
+// We currently do not support per-channel quant for unfold, diagonal, expand,
+// permute.
+// TODO: Make this an aten function and replace as_strided_qtensorimpl once that
+// is done.
+static Tensor make_qtensor(
+    const Tensor& self,
+    IntArrayRef size,
+    IntArrayRef stride,
+    QuantizerPtr quantizer) {
   auto result = at::detail::make_tensor<QTensorImpl>(
-      c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype(), quantizer);
+      c10::TensorImpl::VIEW,
+      Storage(self.storage()),
+      self.key_set(),
+      self.dtype(),
+      quantizer);
   setStrided(result, size, stride, self.storage_offset());
   return result;
 }
 
-Tensor as_strided_tensorimpl(const Tensor& self, IntArrayRef size, IntArrayRef stride, std::optional<int64_t> storage_offset_) {
-  TORCH_INTERNAL_ASSERT(!self.is_mps(), "as_strided_tensorimpl does not work with MPS; call self.as_strided(...) instead");
+Tensor as_strided_tensorimpl(
+    const Tensor& self,
+    IntArrayRef size,
+    IntArrayRef stride,
+    std::optional<int64_t> storage_offset_) {
+  TORCH_INTERNAL_ASSERT(
+      !self.is_mps(),
+      "as_strided_tensorimpl does not work with MPS; call self.as_strided(...) instead");
   auto storage_offset = storage_offset_.value_or(self.storage_offset());
   auto result = at::detail::make_tensor<TensorImpl>(
-      c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype());
+      c10::TensorImpl::VIEW,
+      Storage(self.storage()),
+      self.key_set(),
+      self.dtype());
   setStrided(result, size, stride, storage_offset);
   return result;
 }
@@ -1208,51 +1420,81 @@ inline void setStridedUnchecked(
   self_->set_sizes_and_strides(size, stride, std::forward<T>(storage_offset));
 }
 
-Tensor as_strided_tensorimpl_meta_symint(const Tensor& self, SymIntArrayRef sym_size, SymIntArrayRef sym_stride, std::optional<c10::SymInt> sym_storage_offset_) {
-  auto sym_storage_offset = sym_storage_offset_.value_or(self.sym_storage_offset());
+Tensor as_strided_tensorimpl_meta_symint(
+    const Tensor& self,
+    SymIntArrayRef sym_size,
+    SymIntArrayRef sym_stride,
+    std::optional<c10::SymInt> sym_storage_offset_) {
+  auto sym_storage_offset =
+      sym_storage_offset_.value_or(self.sym_storage_offset());
   auto result = at::detail::make_tensor<TensorImpl>(
-      c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype());
+      c10::TensorImpl::VIEW,
+      Storage(self.storage()),
+      self.key_set(),
+      self.dtype());
   // NB: The reason this is unchecked is to ensure we don't generate
   // guards on the base storage itself when performing as_strided calls.
   // Although technically these guards are necessary, in practice they
   // cause a lot of guards that falsely refer to base symbols.  We will instead
   // rely on AOTAutograd to sort out if we actually have dependence on view
   // bases / storage size.
-  setStridedUnchecked(result, sym_size, sym_stride, std::move(sym_storage_offset));
+  setStridedUnchecked(
+      result, sym_size, sym_stride, std::move(sym_storage_offset));
   return result;
 }
 
-Tensor as_strided_qtensorimpl(const Tensor& self, IntArrayRef size, IntArrayRef stride, std::optional<int64_t> storage_offset_) {
+Tensor as_strided_qtensorimpl(
+    const Tensor& self,
+    IntArrayRef size,
+    IntArrayRef stride,
+    std::optional<int64_t> storage_offset_) {
   auto storage_offset = storage_offset_.value_or(self.storage_offset());
   auto quantizer = get_qtensorimpl(self)->quantizer();
   TORCH_CHECK(
       quantizer->qscheme() == QScheme::PER_TENSOR_AFFINE,
       "Setting strides is possible only on uniformly quantized tensor");
   auto result = at::detail::make_tensor<QTensorImpl>(
-      c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype(), quantizer);
+      c10::TensorImpl::VIEW,
+      Storage(self.storage()),
+      self.key_set(),
+      self.dtype(),
+      quantizer);
   setStrided(result, size, stride, storage_offset);
   return result;
 }
 
 // This is an overloaded function similar to
-// Tensor as_strided_qtensorimpl(const Tensor& self, IntArrayRef size, IntArrayRef stride, std::optional<int64_t> storage_offset_)
-// and is currently not available through the dispatcher. The additional
-// input, quantizer, is called by the select & slice methods.
+// Tensor as_strided_qtensorimpl(const Tensor& self, IntArrayRef size,
+// IntArrayRef stride, std::optional<int64_t> storage_offset_) and is currently
+// not available through the dispatcher. The additional input, quantizer, is
+// called by the select & slice methods.
 // TODO: Make this function compatible with the dispatcher
-static Tensor as_strided_qtensorimpl(const Tensor& self, IntArrayRef size, IntArrayRef stride, std::optional<int64_t> storage_offset_,
-  QuantizerPtr quantizer) {
+static Tensor as_strided_qtensorimpl(
+    const Tensor& self,
+    IntArrayRef size,
+    IntArrayRef stride,
+    std::optional<int64_t> storage_offset_,
+    QuantizerPtr quantizer) {
   auto storage_offset = storage_offset_.value_or(self.storage_offset());
   TORCH_CHECK(
       (quantizer->qscheme() == QScheme::PER_TENSOR_AFFINE) ||
-      (quantizer->qscheme() == QScheme::PER_CHANNEL_AFFINE),
+          (quantizer->qscheme() == QScheme::PER_CHANNEL_AFFINE),
       "Setting strides is possible only on uniformly or per channel quantized tensors");
   auto result = at::detail::make_tensor<QTensorImpl>(
-      c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype(), quantizer);
+      c10::TensorImpl::VIEW,
+      Storage(self.storage()),
+      self.key_set(),
+      self.dtype(),
+      quantizer);
   setStrided(result, size, stride, storage_offset);
   return result;
 }
 
-const Tensor &as_strided__symint(const Tensor& self, SymIntArrayRef size, SymIntArrayRef stride, std::optional<c10::SymInt> storage_offset_) {
+const Tensor& as_strided__symint(
+    const Tensor& self,
+    SymIntArrayRef size,
+    SymIntArrayRef stride,
+    std::optional<c10::SymInt> storage_offset_) {
   auto storage_offset = storage_offset_.value_or(self.sym_storage_offset());
   setStrided(self, size, stride, std::move(storage_offset));
   return self;
@@ -1260,22 +1502,38 @@ const Tensor &as_strided__symint(const Tensor& self, SymIntArrayRef size, SymInt
 
 // Should just use narrow_copy_out, but this API is used internally at Meta:
 // https://github.com/pytorch/pytorch/pull/87045#issuecomment-1309353561
-Tensor narrow_copy_dense_cpu(const Tensor& self, int64_t dim, int64_t start, int64_t length){
+Tensor narrow_copy_dense_cpu(
+    const Tensor& self,
+    int64_t dim,
+    int64_t start,
+    int64_t length) {
   // narrow_copy_dense_cpu_out always resize output's size, so there only create
   // a zero size tensor.
   auto output = at::empty({0}, self.options());
   return narrow_copy_dense_cpu_out(self, dim, start, length, output);
 }
 
-Tensor narrow_copy_sparse(const Tensor& self, int64_t dim, int64_t start, int64_t length) {
+Tensor narrow_copy_sparse(
+    const Tensor& self,
+    int64_t dim,
+    int64_t start,
+    int64_t length) {
   int64_t allDim = self.dim();
-  int64_t end = start+length;
+  int64_t end = start + length;
   TORCH_CHECK(allDim > 0, "narrow() cannot be applied to a 0-dim tensor.");
   TORCH_CHECK(length >= 0, "narrow(): length must be non-negative.");
-  TORCH_CHECK(dim >= 0 && dim < allDim,
-    "Dimension ", dim, " out of range. Expecting 0 <= dim < ", allDim, ".");
-  TORCH_CHECK(start >= 0 && end <= self.size(dim),
-    "Invalid range to narrow. range(start, start+length) must be a subset of range(0, ", self.size(dim), ").")
+  TORCH_CHECK(
+      dim >= 0 && dim < allDim,
+      "Dimension ",
+      dim,
+      " out of range. Expecting 0 <= dim < ",
+      allDim,
+      ".");
+  TORCH_CHECK(
+      start >= 0 && end <= self.size(dim),
+      "Invalid range to narrow. range(start, start+length) must be a subset of range(0, ",
+      self.size(dim),
+      ").")
   Tensor indices = self._indices();
   int64_t sparse_dim = self.sparse_dim();
 
@@ -1298,15 +1556,18 @@ Tensor narrow_copy_sparse(const Tensor& self, int64_t dim, int64_t start, int64_
     new_values = self._values().narrow_copy(dense_dim, start, length);
   }
 
-  return at::sparse_coo_tensor(new_indices, new_values, new_sizes, self.options(), self.is_coalesced());
+  return at::sparse_coo_tensor(
+      new_indices, new_values, new_sizes, self.options(), self.is_coalesced());
 }
 
 // Should just use narrow_copy_out, but this API is used internally at Meta:
 // https://github.com/pytorch/pytorch/pull/87045#issuecomment-1309353561
 Tensor& narrow_copy_dense_cpu_out(
-  const Tensor& self, int64_t dim, int64_t start, int64_t length, Tensor& output
-) {
-
+    const Tensor& self,
+    int64_t dim,
+    int64_t start,
+    int64_t length,
+    Tensor& output) {
   TORCH_CHECK(self.dim() > 0, "narrow() cannot be applied to a 0-dim tensor.");
   TORCH_CHECK(self.dtype() == output.dtype());
 
@@ -1323,9 +1584,14 @@ Tensor& narrow_copy_dense_cpu_out(
   // wrap start and do bound check
   const auto cur_size = self_sizes[dim];
   TORCH_CHECK_INDEX(
-    -cur_size <= start && start <= cur_size,
-    "start out of range (expected to be in range of [", -cur_size, ", ", cur_size, "], but got ", start, ")"
-  )
+      -cur_size <= start && start <= cur_size,
+      "start out of range (expected to be in range of [",
+      -cur_size,
+      ", ",
+      cur_size,
+      "], but got ",
+      start,
+      ")")
   if (start < 0) {
     start = start + cur_size;
   }
@@ -1361,7 +1627,8 @@ Tensor& narrow_copy_dense_cpu_out(
     return output;
   }
 
-  const char* src_bytes = static_cast<const char*>(self_contig->const_data_ptr());
+  const char* src_bytes =
+      static_cast<const char*>(self_contig->const_data_ptr());
   char* dst_bytes = static_cast<char*>(output.data_ptr());
 
   size_t src_block_size_bytes = itemsize * src_block_size;
@@ -1372,10 +1639,12 @@ Tensor& narrow_copy_dense_cpu_out(
   char* dst_offset_bytes = dst_bytes;
 
   for (const auto i : c10::irange(num_blocks)) {
-    const char* local_src_offset_bytes = src_offset_bytes + i * src_block_size_bytes;
+    const char* local_src_offset_bytes =
+        src_offset_bytes + i * src_block_size_bytes;
     char* local_dst_offset_bytes = dst_offset_bytes + i * dst_block_size_bytes;
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-        static_cast<const void*>(local_src_offset_bytes + dst_block_size_bytes) <=
+        static_cast<const void*>(
+            local_src_offset_bytes + dst_block_size_bytes) <=
         static_cast<const void*>(src_bytes + src_nbytes));
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
         static_cast<void*>(local_dst_offset_bytes + dst_block_size_bytes) <=
@@ -1392,49 +1661,90 @@ Tensor narrow(const Tensor& self, int64_t dim, int64_t start, int64_t length) {
   TORCH_CHECK(length >= 0, "narrow(): length must be non-negative.");
   auto cur_size = self.size(dim);
   TORCH_CHECK_INDEX(
-    -cur_size <= start && start <= cur_size,
-    "start out of range (expected to be in range of [", -cur_size, ", ", cur_size, "], but got ", start, ")"
-  )
+      -cur_size <= start && start <= cur_size,
+      "start out of range (expected to be in range of [",
+      -cur_size,
+      ", ",
+      cur_size,
+      "], but got ",
+      start,
+      ")")
   if (start < 0) {
     start = start + cur_size;
   }
-  TORCH_CHECK(start <= cur_size - length,
-           "start (", start, ") + length (", length, ") exceeds dimension size (", cur_size, ").");
+  TORCH_CHECK(
+      start <= cur_size - length,
+      "start (",
+      start,
+      ") + length (",
+      length,
+      ") exceeds dimension size (",
+      cur_size,
+      ").");
   return at::slice(self, dim, start, start + length, 1);
 }
 
-Tensor narrow_symint(const Tensor& self, int64_t dim, SymInt start, SymInt length) {
+Tensor narrow_symint(
+    const Tensor& self,
+    int64_t dim,
+    SymInt start,
+    SymInt length) {
   TORCH_CHECK(self.dim() > 0, "narrow() cannot be applied to a 0-dim tensor.");
   TORCH_SYM_CHECK(length.sym_ge(0), "narrow(): length must be non-negative.");
   auto cur_size = self.sym_size(dim);
   TORCH_CHECK_INDEX(
-    ((-cur_size).sym_le(start).sym_and(start.sym_le(cur_size))).expect_true(__FILE__, __LINE__),
-    "start out of range (expected to be in range of [", -cur_size, ", ", cur_size, "], but got ", start, ")"
-  )
+      ((-cur_size).sym_le(start).sym_and(start.sym_le(cur_size)))
+          .expect_true(__FILE__, __LINE__),
+      "start out of range (expected to be in range of [",
+      -cur_size,
+      ", ",
+      cur_size,
+      "], but got ",
+      start,
+      ")")
   if (start < 0) {
     start = start + cur_size;
   }
-  TORCH_SYM_CHECK(start.sym_le(cur_size - length),
-           "start (", start, ") + length (", length, ") exceeds dimension size (", cur_size, ").");
+  TORCH_SYM_CHECK(
+      start.sym_le(cur_size - length),
+      "start (",
+      start,
+      ") + length (",
+      length,
+      ") exceeds dimension size (",
+      cur_size,
+      ").");
   return at::slice_symint(self, dim, start, start + length, 1);
 }
 
-// This overload exists purely for XLA, because they wanted to pass in "symbolic"
-// start via Tensor.
-Tensor narrow_tensor_symint(const Tensor& self, int64_t dim, const Tensor& start, SymInt length) {
-  TORCH_CHECK(start.dim() == 0 && isIntegralType(start.scalar_type(), /*includeBool=*/false),
-              "start must be an 0-dim integral Tensor.");
+// This overload exists purely for XLA, because they wanted to pass in
+// "symbolic" start via Tensor.
+Tensor narrow_tensor_symint(
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& start,
+    SymInt length) {
+  TORCH_CHECK(
+      start.dim() == 0 &&
+          isIntegralType(start.scalar_type(), /*includeBool=*/false),
+      "start must be an 0-dim integral Tensor.");
   int64_t st = start.item<int64_t>();
   return at::narrow_symint(self, dim, c10::SymInt(st), std::move(length));
 }
 
-std::tuple<DimVector, DimVector, std::vector<int64_t>>
-static _permute_size_stride_estimation(const Tensor& self, IntArrayRef dims) {
+std::
+    tuple<DimVector, DimVector, std::vector<int64_t>> static _permute_size_stride_estimation(
+        const Tensor& self,
+        IntArrayRef dims) {
   const auto ndim = self.dim();
-  TORCH_CHECK(ndim == static_cast<int64_t>(dims.size()),
+  TORCH_CHECK(
+      ndim == static_cast<int64_t>(dims.size()),
       "permute(sparse_coo): number of dimensions in the tensor input ",
       "does not match the length of the desired ordering of dimensions ",
-      "i.e. input.dim() = ", ndim, " is not equal to len(dims) = ", dims.size());
+      "i.e. input.dim() = ",
+      ndim,
+      " is not equal to len(dims) = ",
+      dims.size());
 
   const auto is_strided_layout = self.options().layout() == at::kStrided;
   const auto old_sizes = self.sizes();
@@ -1447,8 +1757,7 @@ static _permute_size_stride_estimation(const Tensor& self, IntArrayRef dims) {
 
   for (const auto i : c10::irange(ndim)) {
     const auto d = maybe_wrap_dim(dims[i], ndim);
-    TORCH_CHECK(!seen_dims[d],
-        "permute(): duplicate dims are not allowed.");
+    TORCH_CHECK(!seen_dims[d], "permute(): duplicate dims are not allowed.");
     seen_dims[d] = true;
     wrapped_dims[i] = d;
     new_sizes[i] = old_sizes[d];
@@ -1461,12 +1770,14 @@ static _permute_size_stride_estimation(const Tensor& self, IntArrayRef dims) {
 }
 
 Tensor permute(const Tensor& self, IntArrayRef dims) {
-  auto [new_sizes, new_strides, _] = _permute_size_stride_estimation(self, dims);
+  auto [new_sizes, new_strides, _] =
+      _permute_size_stride_estimation(self, dims);
   return self.as_strided(new_sizes, new_strides);
 }
 
 Tensor permute_sparse_coo(const Tensor& self, IntArrayRef dims) {
-  auto [new_sizes, _, wrapped_dims] = _permute_size_stride_estimation(self, dims);
+  auto [new_sizes, _, wrapped_dims] =
+      _permute_size_stride_estimation(self, dims);
 
   const auto ndim = self.dim();
   const auto sparse_ndim = self.sparse_dim();
@@ -1478,61 +1789,81 @@ Tensor permute_sparse_coo(const Tensor& self, IntArrayRef dims) {
     dims_id_perm[i] = i;
     dims_sparse_dense_id_perm[i] = wrapped_dims[i];
   }
-  std::sort(dims_sparse_dense_id_perm.begin(), dims_sparse_dense_id_perm.begin() + sparse_ndim);
-  std::sort(dims_sparse_dense_id_perm.begin() + sparse_ndim, dims_sparse_dense_id_perm.end());
-  TORCH_CHECK(dims_sparse_dense_id_perm == dims_id_perm,
+  std::sort(
+      dims_sparse_dense_id_perm.begin(),
+      dims_sparse_dense_id_perm.begin() + sparse_ndim);
+  std::sort(
+      dims_sparse_dense_id_perm.begin() + sparse_ndim,
+      dims_sparse_dense_id_perm.end());
+  TORCH_CHECK(
+      dims_sparse_dense_id_perm == dims_id_perm,
       "permute(sparse_coo): transpositions between sparse and dense dimensions are not allowed.",
       "Only transpositions within sparse and dense dimensions are supported.");
 
-  const auto slice = [](std::vector<int64_t> v, size_t begin, size_t len) -> decltype(v) {
+  const auto slice =
+      [](std::vector<int64_t> v, size_t begin, size_t len) -> decltype(v) {
     return std::vector<int64_t>{v.begin() + begin, v.begin() + begin + len};
   };
 
   auto old_sparse_dims = slice(dims_id_perm, 0, sparse_ndim);
-  auto old_dense_dims = slice(std::move(dims_id_perm), sparse_ndim, ndim - sparse_ndim);
+  auto old_dense_dims =
+      slice(std::move(dims_id_perm), sparse_ndim, ndim - sparse_ndim);
   auto new_sparse_dims = slice(wrapped_dims, 0, sparse_ndim);
-  auto new_dense_dims = slice(std::move(wrapped_dims), sparse_ndim, ndim - sparse_ndim);
+  auto new_dense_dims =
+      slice(std::move(wrapped_dims), sparse_ndim, ndim - sparse_ndim);
 
   auto old_indices = self._indices();
   auto old_values = self._values();
 
   const auto new_indices = (new_sparse_dims == old_sparse_dims)
-    ? std::move(old_indices)
-    : [&]() -> Tensor {
-      auto sparse_perm_tensor = at::from_blob(reinterpret_cast<void*>(new_sparse_dims.data()),
-          {sparse_ndim}, old_indices.options().device(at::kCPU));
-      // creates new indices. It is possible to avoid that if COO
-      // is allowed to store a permutation vector.
-      return old_indices.index_select(0, sparse_perm_tensor.to(self.device().type()));
-    }();
+      ? std::move(old_indices)
+      : [&]() -> Tensor {
+    auto sparse_perm_tensor = at::from_blob(
+        reinterpret_cast<void*>(new_sparse_dims.data()),
+        {sparse_ndim},
+        old_indices.options().device(at::kCPU));
+    // creates new indices. It is possible to avoid that if COO
+    // is allowed to store a permutation vector.
+    return old_indices.index_select(
+        0, sparse_perm_tensor.to(self.device().type()));
+  }();
   const auto new_values = (new_dense_dims == old_dense_dims)
-    ? std::move(old_values)
-    : [&]() -> Tensor {
-      auto values_perm = std::vector<int64_t>(dense_ndim + 1);
-      for (const auto i : c10::irange(dense_ndim)) {
-        values_perm[i + 1] = new_dense_dims[i] - sparse_ndim + 1;
-      }
-      return old_values.permute(values_perm);
-    }();
-  const auto is_coalesced = self.is_coalesced() && (dims.empty() || dims[0] == 0);
+      ? std::move(old_values)
+      : [&]() -> Tensor {
+    auto values_perm = std::vector<int64_t>(dense_ndim + 1);
+    for (const auto i : c10::irange(dense_ndim)) {
+      values_perm[i + 1] = new_dense_dims[i] - sparse_ndim + 1;
+    }
+    return old_values.permute(values_perm);
+  }();
+  const auto is_coalesced =
+      self.is_coalesced() && (dims.empty() || dims[0] == 0);
   // TODO: apply `is_coalesced ||= new_values.size(0) < 2`.
   return _sparse_coo_tensor_with_dims_and_tensors(
-       sparse_ndim, dense_ndim, new_sizes, new_indices, new_values, self.options(), is_coalesced);
+      sparse_ndim,
+      dense_ndim,
+      new_sizes,
+      new_indices,
+      new_values,
+      self.options(),
+      is_coalesced);
 }
 
 Tensor repeat(const Tensor& self, IntArrayRef repeats) {
-  TORCH_CHECK(repeats.size() >= (size_t)self.dim(),
-           "Number of dimensions of repeat dims can not be smaller than number of dimensions of tensor");
+  TORCH_CHECK(
+      repeats.size() >= (size_t)self.dim(),
+      "Number of dimensions of repeat dims can not be smaller than number of dimensions of tensor");
 
   // Add new leading dimensions to the tensor if the
   // number of target dimensions is larger than the
   // number of source dimensions.
   int64_t num_new_dimensions = repeats.size() - self.dim();
   DimVector padded_size(num_new_dimensions, 1);
-  padded_size.insert(padded_size.end(), self.sizes().begin(), self.sizes().end());
+  padded_size.insert(
+      padded_size.end(), self.sizes().begin(), self.sizes().end());
   DimVector target_size(repeats.size());
   bool zero_tensor = false;
-  for(const auto idx : c10::irange(repeats.size())) {
+  for (const auto idx : c10::irange(repeats.size())) {
     if (repeats[idx] == 0) {
       zero_tensor = true;
     }
@@ -1566,13 +1897,13 @@ Tensor repeat(const Tensor& self, IntArrayRef repeats) {
   return result;
 }
 
-Tensor tile_symint(const Tensor& self, SymIntArrayRef reps){
+Tensor tile_symint(const Tensor& self, SymIntArrayRef reps) {
   // If self.size() > len(reps), reps is promoted to self.size() by pre-pending
   // 1’s to it to keep the same behaviour as `numpy.tile`.
   // Thus for a tensor of shape (2, 3, 4, 5), a dims of (2, 2) is treated
   // as (1, 1, 2, 2).
   const int64_t size_diff = self.dim() - static_cast<int64_t>(reps.size());
-  if (size_diff > 0){
+  if (size_diff > 0) {
     std::vector<c10::SymInt> new_reps(size_diff, 1);
     for (const auto i : c10::irange(reps.size())) {
       new_reps.emplace_back(reps[i]);
@@ -1591,18 +1922,26 @@ Tensor alias_with_sizes_and_strides(
     const Tensor& self,
     const Vec& sizes,
     const Vec& strides) {
-  //caller should make sure that sizes and strides are valid for self
-  //(storage is sufficient, strides are non-negative, strides and sizes array size is the same)
+  // caller should make sure that sizes and strides are valid for self
+  //(storage is sufficient, strides are non-negative, strides and sizes array
+  // size is the same)
   Tensor self_;
   if (self.is_quantized()) {
     self_ = at::detail::make_tensor<QTensorImpl>(
-      c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype(), get_qtensorimpl(self)->quantizer());
+        c10::TensorImpl::VIEW,
+        Storage(self.storage()),
+        self.key_set(),
+        self.dtype(),
+        get_qtensorimpl(self)->quantizer());
     auto* self_tmp_ = self_.unsafeGetTensorImpl();
     self_tmp_->set_storage_offset(self.storage_offset());
     self_tmp_->set_sizes_and_strides(sizes, strides);
   } else {
     self_ = at::detail::make_tensor<TensorImpl>(
-      c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype());
+        c10::TensorImpl::VIEW,
+        Storage(self.storage()),
+        self.key_set(),
+        self.dtype());
     auto* self_tmp_ = self_.unsafeGetTensorImpl();
     self_tmp_->set_storage_offset(self.storage_offset());
     self_tmp_->set_sizes_and_strides(sizes, strides);
@@ -1612,23 +1951,34 @@ Tensor alias_with_sizes_and_strides(
 }
 
 // specialization for symbolic shapes and strides.
-// SymIntArrayRef/ArrayRef<c10::SymInt> and SmallVector<c10::SymInt>/SymDimVector
+// SymIntArrayRef/ArrayRef<c10::SymInt> and
+// SmallVector<c10::SymInt>/SymDimVector
 template <template <typename...> typename Container>
 Tensor alias_with_sizes_and_strides(
     const Tensor& self,
     const Container<c10::SymInt>& sizes,
     const Container<c10::SymInt>& strides) {
-  //caller should make sure that sizes and strides are valid for self
-  //(storage is sufficient, strides are non-negative, strides and sizes array size is the same)
+  // caller should make sure that sizes and strides are valid for self
+  //(storage is sufficient, strides are non-negative, strides and sizes array
+  // size is the same)
   Tensor self_;
   if (self.is_quantized()) {
     self_ = at::detail::make_tensor<QTensorImpl>(
-      c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype(), get_qtensorimpl(self)->quantizer());
-    self_.unsafeGetTensorImpl()->set_sizes_and_strides(sizes, strides, self.sym_storage_offset());
+        c10::TensorImpl::VIEW,
+        Storage(self.storage()),
+        self.key_set(),
+        self.dtype(),
+        get_qtensorimpl(self)->quantizer());
+    self_.unsafeGetTensorImpl()->set_sizes_and_strides(
+        sizes, strides, self.sym_storage_offset());
   } else {
     self_ = at::detail::make_tensor<TensorImpl>(
-    c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype());
-    self_.unsafeGetTensorImpl()->set_sizes_and_strides(sizes, strides, self.sym_storage_offset());
+        c10::TensorImpl::VIEW,
+        Storage(self.storage()),
+        self.key_set(),
+        self.dtype());
+    self_.unsafeGetTensorImpl()->set_sizes_and_strides(
+        sizes, strides, self.sym_storage_offset());
   }
   namedinference::propagate_names(self_, self);
   return self_;
@@ -1651,7 +2001,8 @@ Tensor reshape_symint(const Tensor& self, c10::SymIntArrayRef proposed_shape) {
 
   // `computeStride` returns the proper strides to use if this
   // `reshape` can be just a view.
-  auto stride = at::detail::computeStride(self.sym_sizes(), self.sym_strides(), shape);
+  auto stride =
+      at::detail::computeStride(self.sym_sizes(), self.sym_strides(), shape);
 
   // NB: Even though we have viewable geometry and the target strides here,
   //     we do not just call `as_strided` on `self` because the backward
@@ -1669,16 +2020,20 @@ Tensor reshape_symint(const Tensor& self, c10::SymIntArrayRef proposed_shape) {
     //
     // We need to do the checks here instead of in `native_functions.yaml`
     // to preserve backwards compatibility.
-    if (!self.is_xla() && !self.is_lazy() && !self.is_ipu() && !at::isTensorSubclassLike(self)) {
+    if (!self.is_xla() && !self.is_lazy() && !self.is_ipu() &&
+        !at::isTensorSubclassLike(self)) {
       return self._reshape_alias_symint(shape, stride.value());
     } else {
       return self.view_symint(shape);
     }
   }
-  return at::_unsafe_view_symint(self.clone(at::MemoryFormat::Contiguous), shape);
+  return at::_unsafe_view_symint(
+      self.clone(at::MemoryFormat::Contiguous), shape);
 }
 
-Tensor _reshape_copy_symint(const Tensor& self, c10::SymIntArrayRef proposed_shape) {
+Tensor _reshape_copy_symint(
+    const Tensor& self,
+    c10::SymIntArrayRef proposed_shape) {
   if (self.is_sparse()) {
     TORCH_CHECK(0, "_reshape_copy is not implemented for sparse tensors");
   }
@@ -1691,7 +2046,8 @@ Tensor _reshape_copy_symint(const Tensor& self, c10::SymIntArrayRef proposed_sha
   if (self.is_contiguous()) {
     return self.view_symint(shape).clone(at::MemoryFormat::Contiguous);
   } else {
-    return at::_unsafe_view_symint(self.clone(at::MemoryFormat::Contiguous), shape);
+    return at::_unsafe_view_symint(
+        self.clone(at::MemoryFormat::Contiguous), shape);
   }
 }
 
@@ -1736,10 +2092,14 @@ Tensor reshape(const Tensor& self, IntArrayRef proposed_shape) {
   return at::_unsafe_view(self.clone(at::MemoryFormat::Contiguous), shape);
 }
 
-Tensor _reshape_alias(const Tensor& self, IntArrayRef sizes, IntArrayRef strides) {
-  // This is only used by `reshape` in cases where it would otherwise have dispatched
-  // to `view`. This removes the overhead of calling `view` which duplicates some of
-  // the work that's already been done (`infer_size_dv` and `computeStride`).
+Tensor _reshape_alias(
+    const Tensor& self,
+    IntArrayRef sizes,
+    IntArrayRef strides) {
+  // This is only used by `reshape` in cases where it would otherwise have
+  // dispatched to `view`. This removes the overhead of calling `view` which
+  // duplicates some of the work that's already been done (`infer_size_dv` and
+  // `computeStride`).
 
   return alias_with_sizes_and_strides(self, sizes, strides);
 }
@@ -1779,22 +2139,38 @@ static Tensor select_sparse(const Tensor& self, int64_t dim, int64_t index) {
                              std::nullopt /* pin_memory */) != dim)
                             .nonzero()
                             .view(-1);
-      auto new_indices = indices.index_select(1, nzIndices).index_select(0, dimIndices);
+      auto new_indices =
+          indices.index_select(1, nzIndices).index_select(0, dimIndices);
       return _sparse_coo_tensor_with_dims_and_tensors(
-            sparse_dim - 1, dense_dim, new_sizes, new_indices, new_values, self.options());
+          sparse_dim - 1,
+          dense_dim,
+          new_sizes,
+          new_indices,
+          new_values,
+          self.options());
     }
   } else {
     auto new_values = values.select(dim - sparse_dim + 1, index);
     return _sparse_coo_tensor_with_dims_and_tensors(
-         sparse_dim, dense_dim - 1, new_sizes, indices, new_values, self.options());
+        sparse_dim,
+        dense_dim - 1,
+        new_sizes,
+        indices,
+        new_values,
+        self.options());
   }
 }
 
 // this is an auxiliary function, called by the select&slice methods, that
 // creates a new quantizer from the given input
 // is_select is true if calling function is select()
-static QuantizerPtr create_subtensor_quantizer(const Tensor& self, bool is_select, int64_t start,
-  int64_t end, int64_t dim, int64_t step) {
+static QuantizerPtr create_subtensor_quantizer(
+    const Tensor& self,
+    bool is_select,
+    int64_t start,
+    int64_t end,
+    int64_t dim,
+    int64_t step) {
   auto quantizer_prev = get_qtensorimpl(self)->quantizer();
   if (quantizer_prev->qscheme() == QScheme::PER_TENSOR_AFFINE) {
     return quantizer_prev;
@@ -1806,19 +2182,27 @@ static QuantizerPtr create_subtensor_quantizer(const Tensor& self, bool is_selec
   auto zero_points = temp->zero_points();
   if (dim == axis) {
     // Compute scales&zps for sub-tensor
-    // *.select(0, start) could alternatively be replaced with *.slice(0, start, end, step), but
-    // select has less overhead
-    scales = is_select ? scales.select(0, start) : scales.slice(0, start, end, step);
-    zero_points = is_select ? zero_points.select(0, start) : zero_points.slice(0, start, end, step);
+    // *.select(0, start) could alternatively be replaced with *.slice(0, start,
+    // end, step), but select has less overhead
+    scales =
+        is_select ? scales.select(0, start) : scales.slice(0, start, end, step);
+    zero_points = is_select ? zero_points.select(0, start)
+                            : zero_points.slice(0, start, end, step);
   }
   if (scales.numel() > 1) {
-    // Axis only needs to be adjusted if the calling function is select(), since select() reduces
-    // the number of dimensions of the tensor by 1, and remains unchanged if calling function is slice()
-    quantizer = make_per_channel_affine_quantizer(scales, zero_points, (is_select ? axis - 1 : axis),
-                                                  quantizer_prev->scalar_type());
+    // Axis only needs to be adjusted if the calling function is select(), since
+    // select() reduces the number of dimensions of the tensor by 1, and remains
+    // unchanged if calling function is slice()
+    quantizer = make_per_channel_affine_quantizer(
+        scales,
+        zero_points,
+        (is_select ? axis - 1 : axis),
+        quantizer_prev->scalar_type());
   } else {
-    quantizer = make_per_tensor_affine_quantizer(scales.item().to<double>(), zero_points.item().to<int64_t>(),
-                                                 quantizer_prev->scalar_type());
+    quantizer = make_per_tensor_affine_quantizer(
+        scales.item().to<double>(),
+        zero_points.item().to<int64_t>(),
+        quantizer_prev->scalar_type());
   }
   return quantizer;
 }
@@ -1828,7 +2212,8 @@ Tensor select(const Tensor& self, int64_t dim, int64_t index) {
 }
 
 Tensor select(const Tensor& self, Dimname dim, int64_t index) {
-  return at::select_symint(self, dimname_to_position(self, dim), c10::SymInt{index});
+  return at::select_symint(
+      self, dimname_to_position(self, dim), c10::SymInt{index});
 }
 
 Tensor select_symint(const Tensor& self, int64_t dim, c10::SymInt index) {
@@ -1838,17 +2223,30 @@ Tensor select_symint(const Tensor& self, int64_t dim, c10::SymInt index) {
   }
   dim = maybe_wrap_dim(dim, ndim);
   auto size = self.sym_sizes()[dim];
-  // Note: `size < -index` is not equivalent to `size <= -1 - index` if index is INT64_MIN
-  // For std::numeric_limits<int64_t>::min() result of unary minus is undefined by the standard
-  // but in practice is equal to self. On the other hand, indexing wrapping is valid for all
-  // negative int64_t values, as x[INT64_MIN] is the same as x[INT64_MAX]
+  // Note: `size < -index` is not equivalent to `size <= -1 - index` if index is
+  // INT64_MIN For std::numeric_limits<int64_t>::min() result of unary minus is
+  // undefined by the standard but in practice is equal to self. On the other
+  // hand, indexing wrapping is valid for all negative int64_t values, as
+  // x[INT64_MIN] is the same as x[INT64_MAX]
   if (size <= -1 - index || size <= index) {
     if (self.has_names() && self.names()[dim] != Dimname::wildcard()) {
-      TORCH_CHECK_INDEX(false, "select(): index ", index, " out of range for tensor of size ",
-                     self.sizes(), " at dimension ", self.names()[dim]);
+      TORCH_CHECK_INDEX(
+          false,
+          "select(): index ",
+          index,
+          " out of range for tensor of size ",
+          self.sizes(),
+          " at dimension ",
+          self.names()[dim]);
     }
-    TORCH_CHECK_INDEX(false, "select(): index ", index, " out of range for tensor of size ",
-                   self.sizes(), " at dimension ", dim);
+    TORCH_CHECK_INDEX(
+        false,
+        "select(): index ",
+        index,
+        " out of range for tensor of size ",
+        self.sizes(),
+        " at dimension ",
+        dim);
   }
   if (index < 0) {
     index += size;
@@ -1867,11 +2265,15 @@ Tensor select_symint(const Tensor& self, int64_t dim, c10::SymInt index) {
     sizes.erase(sizes.begin() + dim);
     strides.erase(strides.begin() + dim);
 
-    auto quantizer = create_subtensor_quantizer(self, true, local_index, local_index + 1, dim, 1);
-    result = as_strided_qtensorimpl(self, sizes, strides, storage_offset, std::move(quantizer));
+    auto quantizer = create_subtensor_quantizer(
+        self, true, local_index, local_index + 1, dim, 1);
+    result = as_strided_qtensorimpl(
+        self, sizes, strides, storage_offset, std::move(quantizer));
   } else {
-    std::vector<c10::SymInt> sizes(self.sym_sizes().begin(), self.sym_sizes().end());
-    std::vector<c10::SymInt> strides(self.sym_strides().begin(), self.sym_strides().end());
+    std::vector<c10::SymInt> sizes(
+        self.sym_sizes().begin(), self.sym_sizes().end());
+    std::vector<c10::SymInt> strides(
+        self.sym_strides().begin(), self.sym_strides().end());
     auto storage_offset = self.sym_storage_offset() + index * strides[dim];
     sizes.erase(sizes.begin() + dim);
     strides.erase(strides.begin() + dim);
@@ -1882,29 +2284,36 @@ Tensor select_symint(const Tensor& self, int64_t dim, c10::SymInt index) {
   return result;
 }
 
-Tensor select_backward_symint(const Tensor& grad, c10::SymIntArrayRef input_sizes, int64_t dim, c10::SymInt index) {
+Tensor select_backward_symint(
+    const Tensor& grad,
+    c10::SymIntArrayRef input_sizes,
+    int64_t dim,
+    c10::SymInt index) {
   auto grad_input = at::zeros_symint(input_sizes, grad.options());
   grad_input.select_symint(dim, std::move(index)).copy_(grad);
   return grad_input;
 }
 
-Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& index) {
+Tensor index_select_sparse_cpu(
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& index) {
   /*
     Algorithm:
     index - a 1-D tensor of indices with shape (n,)
     self - sparse tensor, its shape is sizes = sparse_shape + dense_shape
       indices - 2-D tensor of indices, shape is (sparse_dims, nnz)
-      values - (1+len(dense_shape))-D tensor of values, shape is (nnz,) + dense_shape
-    index_select(dim, index) returns a sparse tensor with the following data
-      new_sizes = sizes[:dim] + (n,) + sizes[dim+1:]
-      new_indices - shape is (sparse_dims, new_nnz)
-      new_values - shape is (new_nnz,) + dense_shape
+      values - (1+len(dense_shape))-D tensor of values, shape is (nnz,) +
+    dense_shape index_select(dim, index) returns a sparse tensor with the
+    following data new_sizes = sizes[:dim] + (n,) + sizes[dim+1:] new_indices -
+    shape is (sparse_dims, new_nnz) new_values - shape is (new_nnz,) +
+    dense_shape
 
       if dim < len(sparse_shape):
           # Find new_indices[dim] of the output sparse tensor and
           # indices at which to select values/indices.
-          # The CPP code uses (binary/in a count table) search to find matches and may
-          # swap the loop order for better algorithmic complexity.
+          # The CPP code uses (binary/in a count table) search to find matches
+    and may # swap the loop order for better algorithmic complexity.
           new_dim_indices = []
           selected_dim_indices = []
           # This is a brute-force algorithms to convey the main idea.
@@ -1922,9 +2331,11 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
           new_values = values.index_select(dim - sparse_dim + 1, index);
     */
   const auto ndim = self.dim();
-  TORCH_CHECK_INDEX(ndim, "index_select() cannot be applied to a 0-dim tensor.");
   TORCH_CHECK_INDEX(
-      index.dim() == 1 && index.dtype() == at::kLong && index.options().layout() == at::kStrided,
+      ndim, "index_select() cannot be applied to a 0-dim tensor.");
+  TORCH_CHECK_INDEX(
+      index.dim() == 1 && index.dtype() == at::kLong &&
+          index.options().layout() == at::kStrided,
       "index_select() argument index must be 1-D strided (non-sparse) long-tensor.");
   dim = maybe_wrap_dim(dim, ndim);
   const auto size = self.size(dim);
@@ -1937,11 +2348,11 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
   auto res_sizes = self.sizes().vec();
   res_sizes[dim] = index_len;
 
-  // Equivalent to t.index_select(dim, idx), but vanilla index_select is not parallel,
-  // so we use gather instead.
-  // We use this method to select relevant indices/values
-  // from the intersection between indices[dim] and the index.
-  const auto index_select = [](const Tensor& t, int64_t dim, const Tensor& idx) -> Tensor {
+  // Equivalent to t.index_select(dim, idx), but vanilla index_select is not
+  // parallel, so we use gather instead. We use this method to select relevant
+  // indices/values from the intersection between indices[dim] and the index.
+  const auto index_select =
+      [](const Tensor& t, int64_t dim, const Tensor& idx) -> Tensor {
     const auto idx_len = idx.numel();
     auto out_shape = t.sizes().vec();
     out_shape[dim] = idx_len;
@@ -1959,7 +2370,12 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
       const auto res_values = index_select(values, 0, index);
 
       return _sparse_coo_tensor_with_dims_and_tensors(
-          sparse_dim, dense_dim, res_sizes, res_indices, res_values, self.options());
+          sparse_dim,
+          dense_dim,
+          res_sizes,
+          res_indices,
+          res_values,
+          self.options());
     }
 
     const auto nneg_index = [&index, index_len, &self, size, dim]() -> Tensor {
@@ -1968,96 +2384,116 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
       // nneg_index = (index < 0) * (index + size) + (index >= 0) * index
       auto* ptr_index = index_contiguous.data_ptr<int64_t>();
       auto* ptr_nneg_index = nneg_index.data_ptr<int64_t>();
-      at::parallel_for(0, index_len, at::internal::GRAIN_SIZE, [&](int64_t start, int64_t end) {
-          const auto* src = ptr_index + start;
-          auto* dst = ptr_nneg_index + start;
-          for ([[maybe_unused]] const auto _ : c10::irange(start, end)) {
-            auto idx = *src++;
-            if (idx < -size || idx >= size) {
-               // Mark self and dim as used if code is compiled with STRIP_ERROR_MESSAGES
-              (void)dim;
-              (void)self;
-              TORCH_CHECK_INDEX(false,
-                  "index_select(): index contains ", idx, " that is out of range for tensor of size ",
-                  self.sizes(), " at dimension ", dim
-              );
+      at::parallel_for(
+          0,
+          index_len,
+          at::internal::GRAIN_SIZE,
+          [&](int64_t start, int64_t end) {
+            const auto* src = ptr_index + start;
+            auto* dst = ptr_nneg_index + start;
+            for ([[maybe_unused]] const auto _ : c10::irange(start, end)) {
+              auto idx = *src++;
+              if (idx < -size || idx >= size) {
+                // Mark self and dim as used if code is compiled with
+                // STRIP_ERROR_MESSAGES
+                (void)dim;
+                (void)self;
+                TORCH_CHECK_INDEX(
+                    false,
+                    "index_select(): index contains ",
+                    idx,
+                    " that is out of range for tensor of size ",
+                    self.sizes(),
+                    " at dimension ",
+                    dim);
+              }
+              if (idx < 0) {
+                idx += size;
+              }
+              *dst++ = idx;
             }
-            if (idx < 0) {
-              idx += size;
-            }
-            *dst++ = idx;
-          }
-      });
+          });
 
       return nneg_index;
     }();
 
     const auto dim_indices = indices[dim].contiguous();
 
-    // If nnz is smaller than size, then either indices[dim] or index gets sorted,
-    // then this is followed by a binary search to find interesections.
-    const auto get_selected_indices_small_nnz_large_size = [&]() -> std::tuple<Tensor, Tensor> {
+    // If nnz is smaller than size, then either indices[dim] or index gets
+    // sorted, then this is followed by a binary search to find interesections.
+    const auto get_selected_indices_small_nnz_large_size =
+        [&]() -> std::tuple<Tensor, Tensor> {
       const auto grain_size = at::internal::GRAIN_SIZE;
       const auto n_threads_nnz = std::max<int64_t>(
-          1, std::min<int64_t>((nnz + grain_size - 1) / grain_size, at::get_num_threads())
-      );
+          1,
+          std::min<int64_t>(
+              (nnz + grain_size - 1) / grain_size, at::get_num_threads()));
       const auto n_threads_index = std::max<int64_t>(
-          1, std::min<int64_t>((index_len + grain_size - 1) / grain_size, at::get_num_threads())
-      );
+          1,
+          std::min<int64_t>(
+              (index_len + grain_size - 1) / grain_size,
+              at::get_num_threads()));
       const auto search_in_dim_indices
-        // if either dim_indices or index requires sorting, we compare
-        // the cost of sort + binary search, which is comparing
-        // (len(dim_indices) + len(index)) * log(len(index)) to
-        // (len(dim_indices) + len(index)) * log(len(dim_indices)).
-        // That simplifies to comparing len(dim_indices) to len(index).
-        // Additionally, we take into consideration potential parallel
-        // speedup.
-        = (nnz / n_threads_nnz <= index_len / n_threads_index)
-        // if self is coalesced and dim is 0, then we compare
-        // index_len * log(len(dim_indices)), which is binary search into dim_indices,
-        // to (len(index_len) + len(dim_indices)) * log(index_len).
-        // Additionally, we take into consideration potential parallel
-        // speedup.
-          || (self.is_coalesced() && dim == 0
-          && (index_len * std::log2(nnz) / n_threads_index
-            <= (nnz / n_threads_nnz + index_len) * std::log2(index_len)))
-        ? true : false;
+          // if either dim_indices or index requires sorting, we compare
+          // the cost of sort + binary search, which is comparing
+          // (len(dim_indices) + len(index)) * log(len(index)) to
+          // (len(dim_indices) + len(index)) * log(len(dim_indices)).
+          // That simplifies to comparing len(dim_indices) to len(index).
+          // Additionally, we take into consideration potential parallel
+          // speedup.
+          = (nnz / n_threads_nnz <= index_len / n_threads_index)
+              // if self is coalesced and dim is 0, then we compare
+              // index_len * log(len(dim_indices)), which is binary search into
+              // dim_indices, to (len(index_len) + len(dim_indices)) *
+              // log(index_len). Additionally, we take into consideration
+              // potential parallel speedup.
+              || (self.is_coalesced() && dim == 0 &&
+                  (index_len * std::log2(nnz) / n_threads_index <=
+                   (nnz / n_threads_nnz + index_len) * std::log2(index_len)))
+          ? true
+          : false;
 
       // src is a source of indices to binary search in sorted
       Tensor sorted, sorted_idx, src;
-      std::tie(sorted, sorted_idx, src) = [
-        &dim_indices, &nneg_index, &self,
-        search_in_dim_indices, dim, nnz
-      ](void) -> std::tuple<Tensor, Tensor, Tensor> {
+      std::tie(sorted, sorted_idx, src) =
+          [&dim_indices, &nneg_index, &self, search_in_dim_indices, dim, nnz](
+              void) -> std::tuple<Tensor, Tensor, Tensor> {
         // sort dim_indices to binary search into it
         if (search_in_dim_indices) {
           // dim_indices is already sorted if self is coalesced and dim == 0
           if (self.is_coalesced() && dim == 0) {
-            return std::make_tuple(dim_indices, at::arange(nnz, dim_indices.options()), nneg_index);
-          }
-          else {
-            auto [sorted_dim_indices, sorted_dim_indices_idx] = dim_indices.sort();
-            return std::make_tuple(sorted_dim_indices, sorted_dim_indices_idx, nneg_index);
+            return std::make_tuple(
+                dim_indices,
+                at::arange(nnz, dim_indices.options()),
+                nneg_index);
+          } else {
+            auto [sorted_dim_indices, sorted_dim_indices_idx] =
+                dim_indices.sort();
+            return std::make_tuple(
+                sorted_dim_indices, sorted_dim_indices_idx, nneg_index);
           }
         }
         // sort nneg_index to binary search into it
         else {
           auto [sorted_nneg_index, sorted_nneg_index_idx] = nneg_index.sort();
-          return std::make_tuple(sorted_nneg_index, sorted_nneg_index_idx, dim_indices);
+          return std::make_tuple(
+              sorted_nneg_index, sorted_nneg_index_idx, dim_indices);
         }
       }();
 
       const auto src_grain_size = at::internal::GRAIN_SIZE;
       const auto src_len = src.numel();
       const auto n_threads_src = std::max<int64_t>(
-          // 1 <= n_threads_src <= std::min(ceil(src.numel() / src_grain_size), max_threads)
-          1, std::min<int64_t>((src_len + src_grain_size - 1) / src_grain_size, at::get_num_threads())
-      );
+          // 1 <= n_threads_src <= std::min(ceil(src.numel() / src_grain_size),
+          // max_threads)
+          1,
+          std::min<int64_t>(
+              (src_len + src_grain_size - 1) / src_grain_size,
+              at::get_num_threads()));
       const auto chunk_size_src = (src_len + n_threads_src - 1) / n_threads_src;
 
       const std::vector<int64_t> src_n_threads_shape = {
-        n_threads_src, (src_len + n_threads_src - 1) / n_threads_src
-      };
+          n_threads_src, (src_len + n_threads_src - 1) / n_threads_src};
 
       // src_int_idx and sorted_int_idx store "i" and "j" indices indicating
       // intersections such that src_int_idx[i] == sorted_int_idx[j].
@@ -2141,7 +2577,8 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
         auto* ptr_selected_sorted = selected_sorted.data_ptr<int64_t>();
         auto* ptr_selected_src = selected_src.data_ptr<int64_t>();
 
-        const auto thread_offsets = compressed_int_counts.cumsum(0).sub_(compressed_int_counts);
+        const auto thread_offsets =
+            compressed_int_counts.cumsum(0).sub_(compressed_int_counts);
         const auto* ptr_sorted_idx = sorted_idx.const_data_ptr<int64_t>();
         at::parallel_for(
             0, n_threads_src, 1, [&](int64_t tid, [[maybe_unused]] int64_t _) {
@@ -2175,8 +2612,8 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
       }
 
       return search_in_dim_indices
-        ? std::make_tuple(selected_sorted, selected_src)
-        : std::make_tuple(selected_src, selected_sorted);
+          ? std::make_tuple(selected_sorted, selected_src)
+          : std::make_tuple(selected_src, selected_sorted);
     };
 
     // Converts a 1d sorted idx to a compressed 1d compressed idx,
@@ -2184,10 +2621,9 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
     // a parallelized and no-sync manner.
     // TODO: this function is equivalent to _convert_indices_from_coo_to_csr.
     // The mentioned function is not public yet.
-    const auto sorted_idx_to_cidx = [](
-        const Tensor& idx,
-        int64_t len,
-        bool run_in_parallel = true) -> Tensor {
+    const auto sorted_idx_to_cidx = [](const Tensor& idx,
+                                       int64_t len,
+                                       bool run_in_parallel = true) -> Tensor {
       auto cidx = at::empty({len + 1}, idx.options());
 
       const auto* ptr_idx = idx.const_data_ptr<int64_t>();
@@ -2196,38 +2632,45 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
       const auto idx_len = idx.numel();
 
       std::fill_n(ptr_cidx, ptr_idx[0] + 1, 0);
-      std::fill_n(ptr_cidx + ptr_idx[idx_len - 1] + 1, len - ptr_idx[idx_len - 1], idx_len);
+      std::fill_n(
+          ptr_cidx + ptr_idx[idx_len - 1] + 1,
+          len - ptr_idx[idx_len - 1],
+          idx_len);
 
-      const auto grain_size = run_in_parallel ? at::internal::GRAIN_SIZE : idx_len;
+      const auto grain_size =
+          run_in_parallel ? at::internal::GRAIN_SIZE : idx_len;
       at::parallel_for(0, idx_len, grain_size, [&](int64_t start, int64_t end) {
-          auto* ptr_curr_cidx = ptr_cidx + ptr_idx[start] + 1;
-          for (int64_t i = start; i < std::min(end, idx_len - 1); ++i) {
-            const auto diff = ptr_idx[i + 1] - ptr_idx[i];
-            std::fill_n(ptr_curr_cidx, diff, i + 1);
-            ptr_curr_cidx += diff;
-          }
+        auto* ptr_curr_cidx = ptr_cidx + ptr_idx[start] + 1;
+        for (int64_t i = start; i < std::min(end, idx_len - 1); ++i) {
+          const auto diff = ptr_idx[i + 1] - ptr_idx[i];
+          std::fill_n(ptr_curr_cidx, diff, i + 1);
+          ptr_curr_cidx += diff;
+        }
       });
 
       return cidx;
     };
 
-    // If nnz is (much) larger than size, then both indices[dim] and index get sorted
-    // with a count sort (faster, and no huge nnz-sized chunk memory allocations).
-    // The element-wise product between the count tables gives us all the intersections.
-    const auto get_selected_indices_large_nnz_small_size = [&]() -> std::tuple<Tensor, Tensor> {
-      const auto get_counts = [&sorted_idx_to_cidx](
-          // Writes into counts (must be preallocated and zero)
-          // and allows to use external buffers.
-          Tensor& counts,
-          const Tensor& t,
-          int64_t bins,
-          bool is_sorted = false,
-          bool run_in_parallel = true) -> void {
+    // If nnz is (much) larger than size, then both indices[dim] and index get
+    // sorted with a count sort (faster, and no huge nnz-sized chunk memory
+    // allocations). The element-wise product between the count tables gives us
+    // all the intersections.
+    const auto get_selected_indices_large_nnz_small_size =
+        [&]() -> std::tuple<Tensor, Tensor> {
+      const auto get_counts =
+          [&sorted_idx_to_cidx](
+              // Writes into counts (must be preallocated and zero)
+              // and allows to use external buffers.
+              Tensor& counts,
+              const Tensor& t,
+              int64_t bins,
+              bool is_sorted = false,
+              bool run_in_parallel = true) -> void {
         if (is_sorted) {
           const auto cidx = sorted_idx_to_cidx(t, bins, run_in_parallel);
-          at::sub_out(counts, cidx.slice(0, 1, bins + 1), cidx.slice(0, 0, bins));
-        }
-        else {
+          at::sub_out(
+              counts, cidx.slice(0, 1, bins + 1), cidx.slice(0, 0, bins));
+        } else {
           auto* ptr_counts = counts.data_ptr<int64_t>();
           const auto* ptr_vals = t.const_data_ptr<int64_t>();
           for ([[maybe_unused]] const auto _ : c10::irange(t.numel())) {
@@ -2236,16 +2679,18 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
         }
       };
 
-      const auto counts_per_thread = [&get_counts, size](
-          const Tensor& idx,
-          bool is_sorted = false,
-          int64_t grain_size = at::internal::GRAIN_SIZE
-      ) -> Tensor {
+      const auto counts_per_thread =
+          [&get_counts, size](
+              const Tensor& idx,
+              bool is_sorted = false,
+              int64_t grain_size = at::internal::GRAIN_SIZE) -> Tensor {
         const auto idx_len = idx.numel();
         // 1 <= n_threads <= min(ceil(len / grain_size), max_threads)
         const auto n_threads = std::max<int64_t>(
-            1, std::min<int64_t>((idx_len + grain_size - 1) / grain_size, at::get_num_threads())
-        );
+            1,
+            std::min<int64_t>(
+                (idx_len + grain_size - 1) / grain_size,
+                at::get_num_threads()));
         const auto chunk_size = (idx_len + n_threads - 1) / n_threads;
         const auto run_in_parallel = (n_threads == 1);
 
@@ -2272,7 +2717,8 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
           /*is_sorted=*/self.is_coalesced() && dim == 0
           /*grain_size = at::internal::GRAIN_SIZE*/
       );
-      auto dim_indices_offset_counts_per_thread = dim_indices_counts_per_thread.cumsum(0);
+      auto dim_indices_offset_counts_per_thread =
+          dim_indices_counts_per_thread.cumsum(0);
 
       auto index_counts_per_thread = counts_per_thread(
           nneg_index,
@@ -2282,7 +2728,8 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
       auto index_offset_counts_per_thread = index_counts_per_thread.cumsum(0);
 
       const auto index_counts = index_offset_counts_per_thread.select(0, -1);
-      const auto dim_indices_counts = dim_indices_offset_counts_per_thread.select(0, -1);
+      const auto dim_indices_counts =
+          dim_indices_offset_counts_per_thread.select(0, -1);
       const auto intersection_counts = index_counts.mul(dim_indices_counts);
       const auto res_len = intersection_counts.sum().item<int64_t>();
       // Short-circuit if empty intersection
@@ -2295,63 +2742,89 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
       const auto search_in_dim_indices = [&]() -> bool {
         const auto grain_size = at::internal::GRAIN_SIZE;
         const auto n_threads_index = std::max<int64_t>(
-            1, std::min<int64_t>((index_len + grain_size - 1) / grain_size, at::get_num_threads())
-        );
+            1,
+            std::min<int64_t>(
+                (index_len + grain_size - 1) / grain_size,
+                at::get_num_threads()));
         const auto n_threads_dim_indices = std::max<int64_t>(
-            1, std::min<int64_t>((nnz + grain_size - 1) / grain_size, at::get_num_threads())
-        );
+            1,
+            std::min<int64_t>(
+                (nnz + grain_size - 1) / grain_size, at::get_num_threads()));
 
         const auto index_max_copy_work_per_thread =
-          index_counts_per_thread.mul(dim_indices_counts).sum(-1).max().item<int64_t>();
-        const auto dim_indices_max_copy_work_per_thread
-          = dim_indices_counts_per_thread.mul(index_counts).sum(-1).max().item<int64_t>();
+            index_counts_per_thread.mul(dim_indices_counts)
+                .sum(-1)
+                .max()
+                .item<int64_t>();
+        const auto dim_indices_max_copy_work_per_thread =
+            dim_indices_counts_per_thread.mul(index_counts)
+                .sum(-1)
+                .max()
+                .item<int64_t>();
 
-        const auto index_max_work_per_thread = index_max_copy_work_per_thread * index_len / n_threads_index;
-        const auto dim_indices_max_work_per_thread = dim_indices_max_copy_work_per_thread * nnz / n_threads_dim_indices;
+        const auto index_max_work_per_thread =
+            index_max_copy_work_per_thread * index_len / n_threads_index;
+        const auto dim_indices_max_work_per_thread =
+            dim_indices_max_copy_work_per_thread * nnz / n_threads_dim_indices;
         return index_max_work_per_thread <= dim_indices_max_work_per_thread
-          ? true
-          : false;
+            ? true
+            : false;
       }();
 
       Tensor idx, idx_counts_per_thread, idx_offset_counts_per_thread;
       Tensor src, src_counts_per_thread, src_offset_counts_per_thread;
       std::tie(
-          idx, idx_counts_per_thread, idx_offset_counts_per_thread,
-          src, src_counts_per_thread, src_offset_counts_per_thread
-      ) = [&]() {
+          idx,
+          idx_counts_per_thread,
+          idx_offset_counts_per_thread,
+          src,
+          src_counts_per_thread,
+          src_offset_counts_per_thread) = [&]() {
         return search_in_dim_indices
-          ? std::make_tuple(
-              nneg_index, index_counts_per_thread, index_offset_counts_per_thread,
-              dim_indices, dim_indices_counts_per_thread, dim_indices_offset_counts_per_thread
-            )
-          : std::make_tuple(
-              dim_indices, dim_indices_counts_per_thread, dim_indices_counts_per_thread.cumsum(0),
-              nneg_index, index_counts_per_thread, index_counts_per_thread.cumsum(0)
-            );
+            ? std::make_tuple(
+                  nneg_index,
+                  index_counts_per_thread,
+                  index_offset_counts_per_thread,
+                  dim_indices,
+                  dim_indices_counts_per_thread,
+                  dim_indices_offset_counts_per_thread)
+            : std::make_tuple(
+                  dim_indices,
+                  dim_indices_counts_per_thread,
+                  dim_indices_counts_per_thread.cumsum(0),
+                  nneg_index,
+                  index_counts_per_thread,
+                  index_counts_per_thread.cumsum(0));
       }();
 
       const auto idx_counts = idx_offset_counts_per_thread.select(0, -1);
       const auto src_counts = src_offset_counts_per_thread.select(0, -1);
 
       Tensor src_idx, src_idx_offsets;
-      std::tie(src_idx, src_idx_offsets) = [&](
-          int64_t grain_size = at::internal::GRAIN_SIZE
-      ) -> std::tuple<Tensor, Tensor> {
+      std::tie(src_idx, src_idx_offsets) =
+          [&](int64_t grain_size =
+                  at::internal::GRAIN_SIZE) -> std::tuple<Tensor, Tensor> {
         const auto src_intersection_counts = src_counts.mul(idx_counts > 0);
         const auto src_intersection_offsets = src_intersection_counts.cumsum(0);
-        const auto src_idx_len = src_intersection_offsets.const_data_ptr<int64_t>()[size - 1];
+        const auto src_idx_len =
+            src_intersection_offsets.const_data_ptr<int64_t>()[size - 1];
         auto src_idx = at::empty({src_idx_len}, src.options());
 
         const auto* ptr_src = src.const_data_ptr<int64_t>();
-        const auto* ptr_intersection_counts = intersection_counts.const_data_ptr<int64_t>();
-        const auto* ptr_src_intersection_counts = src_intersection_counts.const_data_ptr<int64_t>();
-        const auto* ptr_src_intersection_offsets = src_intersection_offsets.const_data_ptr<int64_t>();
+        const auto* ptr_intersection_counts =
+            intersection_counts.const_data_ptr<int64_t>();
+        const auto* ptr_src_intersection_counts =
+            src_intersection_counts.const_data_ptr<int64_t>();
+        const auto* ptr_src_intersection_offsets =
+            src_intersection_offsets.const_data_ptr<int64_t>();
         auto* ptr_src_idx = src_idx.data_ptr<int64_t>();
 
         const auto src_len = src.numel();
         const auto n_threads_src = std::max<int64_t>(
-            1, std::min<int64_t>((src_len + grain_size - 1) / grain_size, at::get_num_threads())
-        );
+            1,
+            std::min<int64_t>(
+                (src_len + grain_size - 1) / grain_size,
+                at::get_num_threads()));
         const auto chunk_size = (src_len + n_threads_src - 1) / n_threads_src;
         at::parallel_for(
             0, n_threads_src, 1, [&](int64_t tid, [[maybe_unused]] int64_t _) {
@@ -2386,18 +2859,20 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
               }
             });
 
-        const auto src_idx_offsets = src_intersection_offsets.sub_(src_intersection_counts);
+        const auto src_idx_offsets =
+            src_intersection_offsets.sub_(src_intersection_counts);
 
         return std::make_tuple(src_idx, src_idx_offsets);
       }();
 
-      auto [idx_selected, src_selected] = [&](
-          int64_t grain_size = at::internal::GRAIN_SIZE
-      ) -> std::tuple<Tensor, Tensor> {
+      auto [idx_selected, src_selected] =
+          [&](int64_t grain_size =
+                  at::internal::GRAIN_SIZE) -> std::tuple<Tensor, Tensor> {
         const auto thread_offset = [&]() {
           // we do not need idx_counts_per_thread anymore,
           // so it is safe to do in-place intersection.
-          auto counts_per_thread = idx_counts_per_thread.mul_(src_counts).sum(-1);
+          auto counts_per_thread =
+              idx_counts_per_thread.mul_(src_counts).sum(-1);
           return counts_per_thread.cumsum(0).sub_(counts_per_thread);
         }();
         const auto* ptr_thread_offset = thread_offset.const_data_ptr<int64_t>();
@@ -2407,16 +2882,20 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
 
         const auto* ptr_idx = idx.const_data_ptr<int64_t>();
         const auto* ptr_src_counts = src_counts.const_data_ptr<int64_t>();
-        const auto* ptr_intersection_counts = intersection_counts.const_data_ptr<int64_t>();
+        const auto* ptr_intersection_counts =
+            intersection_counts.const_data_ptr<int64_t>();
         const auto* ptr_src_idx = src_idx.const_data_ptr<int64_t>();
-        const auto* ptr_src_idx_offsets = src_idx_offsets.const_data_ptr<int64_t>();
+        const auto* ptr_src_idx_offsets =
+            src_idx_offsets.const_data_ptr<int64_t>();
         auto* ptr_idx_selected = idx_selected.data_ptr<int64_t>();
         auto* ptr_src_selected = src_selected.data_ptr<int64_t>();
 
         const auto idx_len = idx.numel();
         const auto n_threads_idx = std::max<int64_t>(
-            1, std::min<int64_t>((idx_len + grain_size - 1) / grain_size, at::get_num_threads())
-        );
+            1,
+            std::min<int64_t>(
+                (idx_len + grain_size - 1) / grain_size,
+                at::get_num_threads()));
         const auto chunk_size = (idx_len + n_threads_idx - 1) / n_threads_idx;
         at::parallel_for(
             0, n_threads_idx, 1, [&](int64_t tid, [[maybe_unused]] int64_t _) {
@@ -2445,30 +2924,32 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
       }();
 
       return search_in_dim_indices
-        ? std::make_tuple(src_selected, idx_selected)
-        : std::make_tuple(idx_selected, src_selected);
+          ? std::make_tuple(src_selected, idx_selected)
+          : std::make_tuple(idx_selected, src_selected);
     };
 
-    const auto make_output = [&](
-        const Tensor& selected_dim_indices,
-        const Tensor& res_dim_indices) -> Tensor {
+    const auto make_output = [&](const Tensor& selected_dim_indices,
+                                 const Tensor& res_dim_indices) -> Tensor {
       auto res_indices = index_select(indices, 1, selected_dim_indices);
       res_indices[dim] = res_dim_indices;
       const auto res_values = index_select(values, 0, selected_dim_indices);
 
       return _sparse_coo_tensor_with_dims_and_tensors(
-          sparse_dim, dense_dim, res_sizes, res_indices, res_values, self.options());
+          sparse_dim,
+          dense_dim,
+          res_sizes,
+          res_indices,
+          res_values,
+          self.options());
     };
 
     // Brute-force solution for small values of nnz and index_len
-    const auto get_result_small_nnz_small_index = [&]()
-      -> Tensor {
+    const auto get_result_small_nnz_small_index = [&]() -> Tensor {
       const auto dim_indices_in_inner_loop = nnz >= index_len;
       auto [outer, inner] = [&]() -> std::tuple<Tensor, Tensor> {
         if (dim_indices_in_inner_loop) {
           return std::make_tuple(nneg_index, dim_indices);
-        }
-        else {
+        } else {
           return std::make_tuple(dim_indices, nneg_index);
         }
       }();
@@ -2490,25 +2971,22 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
         }
       }
 
-      const auto outer_selected_idx_tensor = at::from_blob(
-          outer_selected_idx.data(), {res_len}, at::kLong
-      );
-      const auto inner_selected_idx_tensor = at::from_blob(
-          inner_selected_idx.data(), {res_len}, at::kLong
-      );
+      const auto outer_selected_idx_tensor =
+          at::from_blob(outer_selected_idx.data(), {res_len}, at::kLong);
+      const auto inner_selected_idx_tensor =
+          at::from_blob(inner_selected_idx.data(), {res_len}, at::kLong);
 
       return dim_indices_in_inner_loop
-        ? make_output(inner_selected_idx_tensor, outer_selected_idx_tensor)
-        : make_output(outer_selected_idx_tensor, inner_selected_idx_tensor);
+          ? make_output(inner_selected_idx_tensor, outer_selected_idx_tensor)
+          : make_output(outer_selected_idx_tensor, inner_selected_idx_tensor);
     };
 
     constexpr int64_t BRUTE_FORCE_SIZE_LIMIT = 2 << 14; // 16384
     // NOTE: such a condition to avoid overflows in (nnz * index_len)
-    if (nnz <= BRUTE_FORCE_SIZE_LIMIT && index_len <= BRUTE_FORCE_SIZE_LIMIT
-        && (nnz * index_len) <= BRUTE_FORCE_SIZE_LIMIT) {
+    if (nnz <= BRUTE_FORCE_SIZE_LIMIT && index_len <= BRUTE_FORCE_SIZE_LIMIT &&
+        (nnz * index_len) <= BRUTE_FORCE_SIZE_LIMIT) {
       return get_result_small_nnz_small_index();
-    }
-    else {
+    } else {
       Tensor selected_dim_indices;
       Tensor res_dim_indices;
 
@@ -2518,10 +2996,11 @@ Tensor index_select_sparse_cpu(const Tensor& self, int64_t dim, const Tensor& in
       // and does not rely on runtime performance.
       // TODO: perform this analysis and find better C(nnz, size).
       if (nnz <= size) {
-        std::tie(selected_dim_indices, res_dim_indices) = get_selected_indices_small_nnz_large_size();
-      }
-      else {
-        std::tie(selected_dim_indices, res_dim_indices) = get_selected_indices_large_nnz_small_size();
+        std::tie(selected_dim_indices, res_dim_indices) =
+            get_selected_indices_small_nnz_large_size();
+      } else {
+        std::tie(selected_dim_indices, res_dim_indices) =
+            get_selected_indices_large_nnz_small_size();
       }
 
       return make_output(selected_dim_indices, res_dim_indices);
@@ -2581,8 +3060,10 @@ Tensor slice(
 
   Tensor result;
   if (self.is_quantized()) {
-    auto quantizer = create_subtensor_quantizer(self, false, start_val, end_val, dim, step);
-    result = as_strided_qtensorimpl(self, sizes, strides, storage_offset, std::move(quantizer));
+    auto quantizer =
+        create_subtensor_quantizer(self, false, start_val, end_val, dim, step);
+    result = as_strided_qtensorimpl(
+        self, sizes, strides, storage_offset, std::move(quantizer));
   } else {
     // NB: it is extremely important to perform a redispatch here for
     // the MPS backend; if you call directly to as_strided_tensorimpl,
@@ -2602,10 +3083,17 @@ Tensor slice_inverse_symint(
     std::optional<SymInt> /* end */,
     SymInt /* step */) {
   // assume self has enough to storage to be viewed with base's metadata
-  return self.as_strided_symint(base.sym_sizes(), base.sym_strides(), base.sym_storage_offset());
+  return self.as_strided_symint(
+      base.sym_sizes(), base.sym_strides(), base.sym_storage_offset());
 }
 
-Tensor slice_backward(const Tensor& grad, IntArrayRef input_sizes, int64_t dim, int64_t start, int64_t end, int64_t step) {
+Tensor slice_backward(
+    const Tensor& grad,
+    IntArrayRef input_sizes,
+    int64_t dim,
+    int64_t start,
+    int64_t end,
+    int64_t step) {
   auto grad_input = at::zeros(input_sizes, grad.options());
   grad_input.slice(dim, start, end, step).copy_(grad);
   return grad_input;
@@ -2614,7 +3102,8 @@ Tensor slice_backward(const Tensor& grad, IntArrayRef input_sizes, int64_t dim, 
 std::vector<Tensor> split(const Tensor& self, int64_t split_size, int64_t dim) {
   const auto num_splits = get_num_splits(self, split_size, dim);
   std::vector<Tensor> splits(num_splits);
-  int64_t last_split_size = split_size - (split_size * num_splits - self.size(dim));
+  int64_t last_split_size =
+      split_size - (split_size * num_splits - self.size(dim));
 
   for (const auto i : c10::irange(num_splits)) {
     auto length = i < num_splits - 1 ? split_size : last_split_size;
@@ -2623,44 +3112,87 @@ std::vector<Tensor> split(const Tensor& self, int64_t split_size, int64_t dim) {
   return splits;
 }
 
-std::vector<Tensor> split_symint(const Tensor& self, c10::SymIntArrayRef sizes, int64_t dim) {
+std::vector<Tensor> split_symint(
+    const Tensor& self,
+    c10::SymIntArrayRef sizes,
+    int64_t dim) {
   return at::split_with_sizes_symint(self, sizes, dim);
 }
 
-std::vector<Tensor> unsafe_split(const Tensor& self, int64_t split_size, int64_t dim) {
+std::vector<Tensor> unsafe_split(
+    const Tensor& self,
+    int64_t split_size,
+    int64_t dim) {
   auto result = at::native::split(self, split_size, dim);
   for (auto& t : result) {
     // TODO(Ailing): do we need to set version_counter here?
     if (!t.is_inference()) {
-      t.unsafeGetTensorImpl()->set_version_counter(c10::VariableVersion(/*version=*/0));
+      t.unsafeGetTensorImpl()->set_version_counter(
+          c10::VariableVersion(/*version=*/0));
     }
   }
   return result;
 }
 
 std::vector<Tensor> hsplit(const Tensor& self, int64_t split_size) {
-  TORCH_CHECK(self.dim() >= 1, "torch.hsplit requires a tensor with at least 1 dimension, but got a tensor with ", self.dim(), " dimensions!")
+  TORCH_CHECK(
+      self.dim() >= 1,
+      "torch.hsplit requires a tensor with at least 1 dimension, but got a tensor with ",
+      self.dim(),
+      " dimensions!")
   int64_t dim = (self.dim() == 1) ? 0 : 1;
-  TORCH_CHECK(split_size != 0 && self.sym_sizes()[dim] % split_size == 0,
-    "torch.hsplit attempted to split along dimension ", dim,", but the size of the dimension ", self.sizes()[dim], " is not divisible by the split_size ", split_size, "!");
+  TORCH_CHECK(
+      split_size != 0 && self.sym_sizes()[dim] % split_size == 0,
+      "torch.hsplit attempted to split along dimension ",
+      dim,
+      ", but the size of the dimension ",
+      self.sizes()[dim],
+      " is not divisible by the split_size ",
+      split_size,
+      "!");
   return at::tensor_split(self, split_size, dim);
 }
 
 std::vector<Tensor> vsplit(const Tensor& self, int64_t split_size) {
-  TORCH_CHECK(self.dim() >= 2, "torch.vsplit requires a tensor with at least 2 dimension, but got a tensor with ", self.dim(), " dimensions!")
-  TORCH_CHECK(split_size != 0 && self.sym_sizes()[0] % split_size == 0,
-    "torch.vsplit attempted to split along dimension ", 0,", but the size of the dimension ", self.sizes()[0], " is not divisible by the split_size ", split_size, "!");
+  TORCH_CHECK(
+      self.dim() >= 2,
+      "torch.vsplit requires a tensor with at least 2 dimension, but got a tensor with ",
+      self.dim(),
+      " dimensions!")
+  TORCH_CHECK(
+      split_size != 0 && self.sym_sizes()[0] % split_size == 0,
+      "torch.vsplit attempted to split along dimension ",
+      0,
+      ", but the size of the dimension ",
+      self.sizes()[0],
+      " is not divisible by the split_size ",
+      split_size,
+      "!");
   return at::tensor_split(self, split_size, 0);
 }
 
 std::vector<Tensor> dsplit(const Tensor& self, int64_t split_size) {
-  TORCH_CHECK(self.dim() >= 3, "torch.dsplit requires a tensor with at least 3 dimension, but got a tensor with ", self.dim(), " dimensions!")
-  TORCH_CHECK(split_size != 0 && self.sym_sizes()[2] % split_size == 0,
-    "torch.dsplit attempted to split along dimension ", 2,", but the size of the dimension ", self.sizes()[2], " is not divisible by the split_size ", split_size, "!");
+  TORCH_CHECK(
+      self.dim() >= 3,
+      "torch.dsplit requires a tensor with at least 3 dimension, but got a tensor with ",
+      self.dim(),
+      " dimensions!")
+  TORCH_CHECK(
+      split_size != 0 && self.sym_sizes()[2] % split_size == 0,
+      "torch.dsplit attempted to split along dimension ",
+      2,
+      ", but the size of the dimension ",
+      self.sizes()[2],
+      " is not divisible by the split_size ",
+      split_size,
+      "!");
   return at::tensor_split(self, split_size, 2);
 }
 
-std::vector<Tensor> split_with_sizes(const Tensor& self, IntArrayRef split_sizes, int64_t dim) {
+std::vector<Tensor> split_with_sizes(
+    const Tensor& self,
+    IntArrayRef split_sizes,
+    int64_t dim) {
   TORCH_CHECK(self.dim() != 0, "split expects at least a 1-dimensional tensor");
   const int64_t dim_size = self.size(dim);
   const int64_t num_splits = split_sizes.size();
@@ -2670,61 +3202,98 @@ std::vector<Tensor> split_with_sizes(const Tensor& self, IntArrayRef split_sizes
   splits.reserve(num_splits);
   for (const auto i : c10::irange(num_splits)) {
     auto length = split_sizes[i];
-    TORCH_CHECK(length >= 0,
-             "split_with_sizes expects split_sizes have only non-negative ",
-             "entries, but got split_sizes=", split_sizes);
-    splits.push_back(at::native::slice(self, dim, start_idx, start_idx + length, 1));
+    TORCH_CHECK(
+        length >= 0,
+        "split_with_sizes expects split_sizes have only non-negative ",
+        "entries, but got split_sizes=",
+        split_sizes);
+    splits.push_back(
+        at::native::slice(self, dim, start_idx, start_idx + length, 1));
     start_idx += length;
   }
-  TORCH_CHECK(start_idx == dim_size,
-           "split_with_sizes expects split_sizes to sum exactly to ", dim_size,
-           " (input tensor's size at dimension ", dim, "), ", "but got split_sizes=", split_sizes);
+  TORCH_CHECK(
+      start_idx == dim_size,
+      "split_with_sizes expects split_sizes to sum exactly to ",
+      dim_size,
+      " (input tensor's size at dimension ",
+      dim,
+      "), ",
+      "but got split_sizes=",
+      split_sizes);
   return splits;
 }
 
-std::vector<Tensor> unsafe_split_with_sizes(const Tensor& self, IntArrayRef split_sizes, int64_t dim) {
+std::vector<Tensor> unsafe_split_with_sizes(
+    const Tensor& self,
+    IntArrayRef split_sizes,
+    int64_t dim) {
   auto result = at::native::split_with_sizes(self, split_sizes, dim);
   for (auto& t : result) {
     // TODO(Ailing): do we need to set version_counter here?
     if (!t.is_inference()) {
-      t.unsafeGetTensorImpl()->set_version_counter(c10::VariableVersion(/*version=*/0));
+      t.unsafeGetTensorImpl()->set_version_counter(
+          c10::VariableVersion(/*version=*/0));
     }
   }
   return result;
 }
 
 std::vector<Tensor> hsplit(const Tensor& self, IntArrayRef split_sizes) {
-  TORCH_CHECK(self.dim() >= 1, "torch.hsplit requires a tensor with at least 1 dimension, but got a tensor with ", self.dim(), " dimensions!")
+  TORCH_CHECK(
+      self.dim() >= 1,
+      "torch.hsplit requires a tensor with at least 1 dimension, but got a tensor with ",
+      self.dim(),
+      " dimensions!")
   return at::tensor_split(self, split_sizes, (self.dim() == 1) ? 0 : 1);
 }
 
 std::vector<Tensor> vsplit(const Tensor& self, IntArrayRef split_sizes) {
-  TORCH_CHECK(self.dim() >= 2, "torch.vsplit requires a tensor with at least 2 dimension, but got a tensor with ", self.dim(), " dimensions!")
+  TORCH_CHECK(
+      self.dim() >= 2,
+      "torch.vsplit requires a tensor with at least 2 dimension, but got a tensor with ",
+      self.dim(),
+      " dimensions!")
   return at::tensor_split(self, split_sizes, 0);
 }
 
 std::vector<Tensor> dsplit(const Tensor& self, IntArrayRef split_sizes) {
-  TORCH_CHECK(self.dim() >= 3, "torch.dsplit requires a tensor with at least 3 dimension, but got a tensor with ", self.dim(), " dimensions!")
+  TORCH_CHECK(
+      self.dim() >= 3,
+      "torch.dsplit requires a tensor with at least 3 dimension, but got a tensor with ",
+      self.dim(),
+      " dimensions!")
   return at::tensor_split(self, split_sizes, 2);
 }
 
 // Precondition: tensors is non-empty
-static inline std::vector<Tensor> get_stack_inputs(TensorList tensors, int64_t dim) {
+static inline std::vector<Tensor> get_stack_inputs(
+    TensorList tensors,
+    int64_t dim) {
   std::vector<Tensor> inputs(tensors.size());
   at::IntArrayRef entry_shape = tensors[0].sizes();
   inputs[0] = tensors[0].unsqueeze(dim);
   for (const auto i : c10::irange(1, tensors.size())) {
-    TORCH_CHECK(tensors[i].sizes() == entry_shape,
-      "stack expects each tensor to be equal size, but got ", entry_shape,
-      " at entry 0 and ", tensors[i].sizes(), " at entry ", i);
+    TORCH_CHECK(
+        tensors[i].sizes() == entry_shape,
+        "stack expects each tensor to be equal size, but got ",
+        entry_shape,
+        " at entry 0 and ",
+        tensors[i].sizes(),
+        " at entry ",
+        i);
     inputs[i] = tensors[i].unsqueeze(dim);
   }
   return inputs;
 }
 
-bool inline maybe_native_stack(Tensor& result, TensorList tensors, int64_t dim) {
+bool inline maybe_native_stack(
+    Tensor& result,
+    TensorList tensors,
+    int64_t dim) {
   dim = maybe_wrap_dim(dim, tensors[0].dim() + 1);
-  if (detail::CanUseNativeSerialStack<TensorList, /*skip_overlap_check*/ false>::call(result, tensors, dim)) {
+  if (detail::CanUseNativeSerialStack<
+          TensorList,
+          /*skip_overlap_check*/ false>::call(result, tensors, dim)) {
     // compute the size of the result
     auto result_sizes = tensors[0].sizes().vec();
     result_sizes.insert(result_sizes.begin() + dim, tensors.size());
@@ -2732,7 +3301,8 @@ bool inline maybe_native_stack(Tensor& result, TensorList tensors, int64_t dim) 
     // skip resizing if size of result is same as expected
     // raise a warning while resizing if output has one or more elements
     // at::native::resize_output(result, result_sizes);
-    // TODO: restore the above, see https://github.com/pytorch/pytorch/issues/64709
+    // TODO: restore the above, see
+    // https://github.com/pytorch/pytorch/issues/64709
 
     if (result.sizes() != result_sizes) {
       result.resize_(result_sizes);
@@ -2759,27 +3329,38 @@ Tensor _stack_cpu(TensorList tensors, int64_t dim) {
 static void check_stack_inputs(TensorList tensors, int64_t dim) {
   at::IntArrayRef entry_shape = tensors[0].sizes();
   for (const auto i : c10::irange(1, tensors.size())) {
-    TORCH_CHECK(tensors[i].sizes() == entry_shape,
-      "stack expects each tensor to be equal size, but got ", entry_shape,
-      " at entry 0 and ", tensors[i].sizes(), " at entry ", i);
+    TORCH_CHECK(
+        tensors[i].sizes() == entry_shape,
+        "stack expects each tensor to be equal size, but got ",
+        entry_shape,
+        " at entry 0 and ",
+        tensors[i].sizes(),
+        " at entry ",
+        i);
   }
 }
 
-// Pads each tensor on `dim`-th dimension such that padded_dim % num_chunks == 0.
-static std::vector<Tensor> _pad_chunk(TensorList tensors, int64_t dim, int64_t num_chunks) {
+// Pads each tensor on `dim`-th dimension such that padded_dim % num_chunks ==
+// 0.
+static std::vector<Tensor> _pad_chunk(
+    TensorList tensors,
+    int64_t dim,
+    int64_t num_chunks) {
   auto num_tensors = tensors.size();
   std::vector<Tensor> padded_tensors;
   padded_tensors.reserve(num_tensors);
-  for (const auto & tensor : tensors) {
+  for (const auto& tensor : tensors) {
     auto tensor_size = tensor.sizes();
     std::vector<int64_t> padded_size(tensor_size.vec());
-    padded_size[dim] = (tensor_size[dim] + num_chunks - 1) / num_chunks * num_chunks;
+    padded_size[dim] =
+        (tensor_size[dim] + num_chunks - 1) / num_chunks * num_chunks;
     Tensor padded_tensor = tensor;
     if (padded_size != tensor_size) {
       padded_tensor = tensor.new_zeros(padded_size);
       padded_tensor.narrow(dim, 0, tensor_size[dim]).copy_(tensor);
     }
-    std::vector<int64_t> view_sizes(tensor_size.begin(), tensor_size.begin()+dim);
+    std::vector<int64_t> view_sizes(
+        tensor_size.begin(), tensor_size.begin() + dim);
     view_sizes.insert(view_sizes.end(), {num_chunks, -1});
     padded_tensors.push_back(padded_tensor.view(view_sizes));
   }
@@ -2787,28 +3368,35 @@ static std::vector<Tensor> _pad_chunk(TensorList tensors, int64_t dim, int64_t n
 }
 
 Tensor _chunk_cat(TensorList tensors, int64_t dim, int64_t num_chunks) {
-  auto wrapped_dim = at::native::preprocess_chunk_cat_inputs(tensors, dim, num_chunks);
-  return at::cat(_pad_chunk(tensors, wrapped_dim, num_chunks), wrapped_dim+1);
+  auto wrapped_dim =
+      at::native::preprocess_chunk_cat_inputs(tensors, dim, num_chunks);
+  return at::cat(_pad_chunk(tensors, wrapped_dim, num_chunks), wrapped_dim + 1);
 }
 
-Tensor& _chunk_cat_out(TensorList tensors, int64_t dim, int64_t num_chunks, Tensor& out) {
-  auto wrapped_dim = at::native::preprocess_chunk_cat_inputs(tensors, dim, num_chunks);
-  at::cat_out(out, _pad_chunk(tensors, wrapped_dim, num_chunks), wrapped_dim+1);
+Tensor& _chunk_cat_out(
+    TensorList tensors,
+    int64_t dim,
+    int64_t num_chunks,
+    Tensor& out) {
+  auto wrapped_dim =
+      at::native::preprocess_chunk_cat_inputs(tensors, dim, num_chunks);
+  at::cat_out(
+      out, _pad_chunk(tensors, wrapped_dim, num_chunks), wrapped_dim + 1);
   return out;
 }
 
 // TODO(msubkhankulov): refactor to use _stack
 Tensor stack(TensorList tensors, int64_t dim) {
-  TORCH_CHECK(!tensors.empty(),
-           "stack expects a non-empty TensorList");
-  auto wrapped_dim = maybe_wrap_dim(dim, tensors[0].ndimension()+1);
+  TORCH_CHECK(!tensors.empty(), "stack expects a non-empty TensorList");
+  auto wrapped_dim = maybe_wrap_dim(dim, tensors[0].ndimension() + 1);
   if (wrapped_dim < tensors[0].ndimension() && !tensors[0].is_sparse()) {
     check_stack_inputs(tensors, wrapped_dim);
     auto result_sizes = tensors[0].sizes().vec();
     result_sizes.insert(result_sizes.begin() + wrapped_dim, tensors.size());
     auto out = at::cat(tensors, wrapped_dim);
     return out.view(result_sizes); // one can always split a dimension with view
-  } else { //dim = tensors[0].ndimension() cannot be efficiently handled by view
+  } else { // dim = tensors[0].ndimension() cannot be efficiently handled by
+           // view
     return at::cat(get_stack_inputs(tensors, dim), dim);
   }
 }
@@ -2829,9 +3417,8 @@ Tensor& _stack_out(TensorList tensors, int64_t dim, Tensor& result) {
 
 // TODO(msubkhankulov): refactor to use _stack_out
 Tensor& stack_out(TensorList tensors, int64_t dim, Tensor& result) {
-  TORCH_CHECK(!tensors.empty(),
-           "stack expects a non-empty TensorList");
-  auto wrapped_dim = maybe_wrap_dim(dim, tensors[0].ndimension()+1);
+  TORCH_CHECK(!tensors.empty(), "stack expects a non-empty TensorList");
+  auto wrapped_dim = maybe_wrap_dim(dim, tensors[0].ndimension() + 1);
   if (wrapped_dim < tensors[0].ndimension() && !tensors[0].is_sparse()) {
     check_stack_inputs(tensors, wrapped_dim);
     auto result_sizes = tensors[0].sizes().vec();
@@ -2839,21 +3426,20 @@ Tensor& stack_out(TensorList tensors, int64_t dim, Tensor& result) {
     at::native::resize_output(result, result_sizes);
     auto cat_sizes = tensors[0].sizes().vec();
     cat_sizes[wrapped_dim] *= tensors.size();
-    auto strides = at::detail::computeStride(result.sizes(), result.strides(), cat_sizes);
+    auto strides =
+        at::detail::computeStride(result.sizes(), result.strides(), cat_sizes);
     if (strides.has_value()) {
-      //can take fast cat path
+      // can take fast cat path
       auto result_view = result.view(cat_sizes);
       at::cat_out(result_view, tensors, wrapped_dim);
       return result;
     }
   }
   return at::cat_out(result, get_stack_inputs(tensors, dim), dim);
-
 }
 
 Tensor hstack(TensorList tensors) {
-  TORCH_CHECK(!tensors.empty(),
-           "hstack expects a non-empty TensorList");
+  TORCH_CHECK(!tensors.empty(), "hstack expects a non-empty TensorList");
   auto rep = at::atleast_1d(tensors);
   if (rep[0].dim() == 1) {
     return at::cat(rep, 0);
@@ -2862,8 +3448,7 @@ Tensor hstack(TensorList tensors) {
 }
 
 Tensor& hstack_out(TensorList tensors, Tensor& result) {
-  TORCH_CHECK(!tensors.empty(),
-           "hstack expects a non-empty TensorList");
+  TORCH_CHECK(!tensors.empty(), "hstack expects a non-empty TensorList");
   auto rep = at::atleast_1d(tensors);
   if (rep[0].dim() == 1) {
     return at::cat_out(result, rep, 0);
@@ -2872,43 +3457,49 @@ Tensor& hstack_out(TensorList tensors, Tensor& result) {
 }
 
 Tensor vstack(TensorList tensors) {
-  TORCH_CHECK(!tensors.empty(),
-           "vstack expects a non-empty TensorList");
+  TORCH_CHECK(!tensors.empty(), "vstack expects a non-empty TensorList");
   auto rep = at::atleast_2d(tensors);
   return at::cat(rep, 0);
 }
 
 Tensor& vstack_out(TensorList tensors, Tensor& result) {
-  TORCH_CHECK(!tensors.empty(),
-           "vstack expects a non-empty TensorList");
+  TORCH_CHECK(!tensors.empty(), "vstack expects a non-empty TensorList");
   auto rep = at::atleast_2d(tensors);
   return at::cat_out(result, rep, 0);
 }
 
 Tensor dstack(TensorList tensors) {
-  TORCH_CHECK(!tensors.empty(),
-           "dstack expects a non-empty TensorList");
+  TORCH_CHECK(!tensors.empty(), "dstack expects a non-empty TensorList");
   auto rep = at::atleast_3d(tensors);
   return at::cat(rep, 2);
 }
 Tensor& dstack_out(TensorList tensors, Tensor& result) {
-  TORCH_CHECK(!tensors.empty(),
-           "dstack expects a non-empty TensorList");
+  TORCH_CHECK(!tensors.empty(), "dstack expects a non-empty TensorList");
   auto rep = at::atleast_3d(tensors);
   return at::cat_out(result, rep, 2);
 }
 
-static inline Tensor & sparse_transpose_(Tensor & self, int64_t dim0, int64_t dim1) {
+static inline Tensor& sparse_transpose_(
+    Tensor& self,
+    int64_t dim0,
+    int64_t dim1) {
   int64_t nsparse_dim = self.sparse_dim();
-  TORCH_CHECK(dim0 < nsparse_dim && dim1 < nsparse_dim,
-           "sparse transpose: transposed dimensions must be sparse ",
-           "Got sparse_dim: ", nsparse_dim, ", d0: ", dim0, ", d1: ", dim1);
+  TORCH_CHECK(
+      dim0 < nsparse_dim && dim1 < nsparse_dim,
+      "sparse transpose: transposed dimensions must be sparse ",
+      "Got sparse_dim: ",
+      nsparse_dim,
+      ", d0: ",
+      dim0,
+      ", d1: ",
+      dim1);
 
   if (self._indices().numel() == 0 && self._values().numel() == 0) {
     auto sizes = self.sizes().vec();
     std::swap(sizes[dim0], sizes[dim1]);
 
-    at::sparse::get_sparse_impl(self)->raw_resize_(self.sparse_dim(), self.dense_dim(), sizes);
+    at::sparse::get_sparse_impl(self)->raw_resize_(
+        self.sparse_dim(), self.dense_dim(), sizes);
   } else {
     auto indices = self._indices();
     auto row0 = indices.select(0, dim0);
@@ -2925,7 +3516,8 @@ static inline Tensor & sparse_transpose_(Tensor & self, int64_t dim0, int64_t di
     auto sizes = self.sizes().vec();
     std::swap(sizes[dim0], sizes[dim1]);
 
-    at::sparse::get_sparse_impl(self)->raw_resize_(self._indices().size(0), self._values().dim() - 1, sizes);
+    at::sparse::get_sparse_impl(self)->raw_resize_(
+        self._indices().size(0), self._values().dim() - 1, sizes);
   }
   return self;
 }
@@ -2948,24 +3540,20 @@ static std::vector<Tensor> reshape_input_for_column_stack(TensorList tensors) {
     }
     return input;
   };
-  std::transform(tensors.cbegin(),
-                 tensors.cend(),
-                 result.begin(),
-                 transform_lambda);
+  std::transform(
+      tensors.cbegin(), tensors.cend(), result.begin(), transform_lambda);
   return result;
 }
 
 Tensor& column_stack_out(TensorList tensors, Tensor& result) {
-  TORCH_CHECK(!tensors.empty(),
-              "column_stack expects a non-empty TensorList");
+  TORCH_CHECK(!tensors.empty(), "column_stack expects a non-empty TensorList");
 
   auto reshaped_tensors = reshape_input_for_column_stack(tensors);
   return at::hstack_out(result, reshaped_tensors);
 }
 
 Tensor column_stack(TensorList tensors) {
-  TORCH_CHECK(!tensors.empty(),
-              "column_stack expects a non-empty TensorList");
+  TORCH_CHECK(!tensors.empty(), "column_stack expects a non-empty TensorList");
 
   auto reshaped_tensors = reshape_input_for_column_stack(tensors);
   return at::hstack(reshaped_tensors);
@@ -2989,8 +3577,7 @@ Tensor transpose(const Tensor& self, Dimname dim0, Dimname dim1) {
       self, dimname_to_position(self, dim0), dimname_to_position(self, dim1));
 }
 
-
-Tensor & transpose_(Tensor & self, int64_t dim0, int64_t dim1) {
+Tensor& transpose_(Tensor& self, int64_t dim0, int64_t dim1) {
   TORCH_CHECK(
       !(self.layout() == kSparseCsr || self.layout() == kSparseCsc ||
         self.layout() == kSparseBsr || self.layout() == kSparseBsc),
@@ -3153,7 +3740,7 @@ static inline Tensor sparse_compressed_transpose(
 }
 } // namespace
 
-Tensor transpose(const Tensor & self, int64_t dim0, int64_t dim1) {
+Tensor transpose(const Tensor& self, int64_t dim0, int64_t dim1) {
   auto ndims = self.dim();
   dim0 = maybe_wrap_dim(dim0, ndims);
   dim1 = maybe_wrap_dim(dim1, ndims);
@@ -3188,36 +3775,45 @@ Tensor transpose(const Tensor & self, int64_t dim0, int64_t dim1) {
   return result;
 }
 
-static void check_t(const Tensor& self, const char *fn) {
+static void check_t(const Tensor& self, const char* fn) {
   if (self.is_sparse()) {
     int64_t sparse_dim = self.sparse_dim();
     int64_t dense_dim = self.dense_dim();
-    TORCH_CHECK(sparse_dim <= 2 && dense_dim == 0,
-             fn, " expects a tensor with <= 2 sparse and 0 dense dimensions, but got ",
-             sparse_dim, " sparse and ", dense_dim, " dense dimensions");
+    TORCH_CHECK(
+        sparse_dim <= 2 && dense_dim == 0,
+        fn,
+        " expects a tensor with <= 2 sparse and 0 dense dimensions, but got ",
+        sparse_dim,
+        " sparse and ",
+        dense_dim,
+        " dense dimensions");
   } else {
-    TORCH_CHECK(self.dim() <= 2,
-             fn, " expects a tensor with <= 2 dimensions, but self is ", self.dim(), "D");
+    TORCH_CHECK(
+        self.dim() <= 2,
+        fn,
+        " expects a tensor with <= 2 dimensions, but self is ",
+        self.dim(),
+        "D");
   }
 }
 
-Tensor t(const Tensor & self) {
+Tensor t(const Tensor& self) {
   check_t(self, "t()");
   return self.transpose(0, self.dim() < 2 ? 0 : 1);
 }
 
-Tensor & t_(Tensor & self) {
+Tensor& t_(Tensor& self) {
   check_t(self, "t_()");
   return self.transpose_(0, self.dim() < 2 ? 0 : 1);
 }
 
-std::tuple<SymDimVector, SymDimVector>
-static inferSqueezeGeometry(const Tensor &tensor) {
+std::tuple<SymDimVector, SymDimVector> static inferSqueezeGeometry(
+    const Tensor& tensor) {
   SymDimVector sizes;
   SymDimVector strides;
 
-  for(const auto d : c10::irange(tensor.dim())) {
-    if(tensor.sym_sizes()[d] != 1) {
+  for (const auto d : c10::irange(tensor.dim())) {
+    if (tensor.sym_sizes()[d] != 1) {
       sizes.push_back(tensor.sym_sizes()[d]);
       strides.push_back(tensor.sym_strides()[d]);
     }
@@ -3226,13 +3822,14 @@ static inferSqueezeGeometry(const Tensor &tensor) {
   return std::make_tuple(std::move(sizes), std::move(strides));
 }
 
-std::tuple<SymDimVector, SymDimVector>
-static inferSqueezeGeometry(const Tensor& tensor, int64_t dim) {
+std::tuple<SymDimVector, SymDimVector> static inferSqueezeGeometry(
+    const Tensor& tensor,
+    int64_t dim) {
   SymDimVector sizes;
   SymDimVector strides;
 
-  for(const auto d : c10::irange(tensor.dim())) {
-    if(d != dim || tensor.sym_sizes()[dim] != 1) {
+  for (const auto d : c10::irange(tensor.dim())) {
+    if (d != dim || tensor.sym_sizes()[dim] != 1) {
       sizes.push_back(tensor.sym_sizes()[d]);
       strides.push_back(tensor.sym_strides()[d]);
     }
@@ -3240,14 +3837,15 @@ static inferSqueezeGeometry(const Tensor& tensor, int64_t dim) {
   return std::make_tuple(std::move(sizes), std::move(strides));
 }
 
-std::tuple<SymDimVector, SymDimVector>
-static inferSqueezeGeometry(const Tensor &tensor, std::bitset<dim_bitset_size> dim_mask) {
+std::tuple<SymDimVector, SymDimVector> static inferSqueezeGeometry(
+    const Tensor& tensor,
+    std::bitset<dim_bitset_size> dim_mask) {
   const auto ndim = tensor.dim();
   const auto sym_sizes = tensor.sym_sizes();
   const auto sym_strides = tensor.sym_strides();
 
   SymDimVector out_sizes, out_strides;
-  for (const auto d: c10::irange(ndim)) {
+  for (const auto d : c10::irange(ndim)) {
     if (!dim_mask.test(d) || sym_sizes[d] != 1) {
       out_sizes.push_back(sym_sizes[d]);
       out_strides.push_back(sym_strides[d]);
@@ -3261,34 +3859,43 @@ namespace {
 // construct the vectors in place and get NRVO.
 template <typename T>
 struct InferUnsqueezeGeometryResult {
-  SmallVector<T, kDimVectorStaticSize>sizes;
+  SmallVector<T, kDimVectorStaticSize> sizes;
   SmallVector<T, kDimVectorStaticSize> strides;
-  InferUnsqueezeGeometryResult(ArrayRef<T> tensor_sizes, ArrayRef<T> tensor_strides)
-      : sizes(tensor_sizes.begin(), tensor_sizes.end())
-      , strides(tensor_strides.begin(), tensor_strides.end()) {}
+  InferUnsqueezeGeometryResult(
+      ArrayRef<T> tensor_sizes,
+      ArrayRef<T> tensor_strides)
+      : sizes(tensor_sizes.begin(), tensor_sizes.end()),
+        strides(tensor_strides.begin(), tensor_strides.end()) {}
 };
 
-InferUnsqueezeGeometryResult<c10::SymInt>
-inferUnsqueezeGeometry_symint(const Tensor& tensor, int64_t dim) {
-  InferUnsqueezeGeometryResult<c10::SymInt> result(tensor.sym_sizes(), tensor.sym_strides());
-  c10::SymInt new_stride = dim >= tensor.dim() ? 1 : result.sizes[dim] * result.strides[dim];
+InferUnsqueezeGeometryResult<c10::SymInt> inferUnsqueezeGeometry_symint(
+    const Tensor& tensor,
+    int64_t dim) {
+  InferUnsqueezeGeometryResult<c10::SymInt> result(
+      tensor.sym_sizes(), tensor.sym_strides());
+  c10::SymInt new_stride =
+      dim >= tensor.dim() ? 1 : result.sizes[dim] * result.strides[dim];
   result.sizes.insert(result.sizes.begin() + dim, 1);
   result.strides.insert(result.strides.begin() + dim, new_stride);
 
   return result;
 }
 
-InferUnsqueezeGeometryResult<int64_t>
-inferUnsqueezeGeometry(const Tensor& tensor, int64_t dim) {
-  InferUnsqueezeGeometryResult<int64_t> result(tensor.sizes(), tensor.strides());
-  int64_t new_stride = dim >= tensor.dim() ? 1 : result.sizes[dim] * result.strides[dim];
+InferUnsqueezeGeometryResult<int64_t> inferUnsqueezeGeometry(
+    const Tensor& tensor,
+    int64_t dim) {
+  InferUnsqueezeGeometryResult<int64_t> result(
+      tensor.sizes(), tensor.strides());
+  int64_t new_stride =
+      dim >= tensor.dim() ? 1 : result.sizes[dim] * result.strides[dim];
   result.sizes.insert(result.sizes.begin() + dim, 1);
   result.strides.insert(result.strides.begin() + dim, new_stride);
 
   return result;
 }
 
-// dim is present if squeezing a single dimension and absent if squeezing all dimensions
+// dim is present if squeezing a single dimension and absent if squeezing all
+// dimensions
 Tensor squeeze_qtensor(const Tensor& self, c10::OptionalIntArrayRef dims) {
   auto quantizer = get_qtensorimpl(self)->quantizer();
   const auto ndim = self.dim();
@@ -3297,31 +3904,39 @@ Tensor squeeze_qtensor(const Tensor& self, c10::OptionalIntArrayRef dims) {
       : std::bitset<dim_bitset_size>((1ull << self.dim()) - 1);
   auto [sizes, strides] = inferSqueezeGeometry(self, mask);
   if (quantizer->qscheme() == QScheme::PER_CHANNEL_AFFINE) {
-    const auto* per_channel_quantizer = static_cast<at::PerChannelAffineQuantizer*>(quantizer.get());
+    const auto* per_channel_quantizer =
+        static_cast<at::PerChannelAffineQuantizer*>(quantizer.get());
     auto axis = per_channel_quantizer->axis();
     int64_t shift = 0;
     for (const auto d : c10::irange(ndim)) {
       if (mask.test(d) && self.sizes()[d] == 1) {
-        TORCH_CHECK(axis != d, "Squeeze is only possible on non-axis dimension for Per-Channel Quantized Tensors.");
+        TORCH_CHECK(
+            axis != d,
+            "Squeeze is only possible on non-axis dimension for Per-Channel Quantized Tensors.");
         if (d < axis) {
           ++shift;
         }
       }
     }
     axis -= shift;
-    quantizer = make_per_channel_affine_quantizer(per_channel_quantizer->scales(),
-                                                  per_channel_quantizer->zero_points(),
-                                                  axis,
-                                                  quantizer->scalar_type());
+    quantizer = make_per_channel_affine_quantizer(
+        per_channel_quantizer->scales(),
+        per_channel_quantizer->zero_points(),
+        axis,
+        quantizer->scalar_type());
   }
-  // TODO: quantized Tensor support for SymInt needs to be added but basic building blocs
-  // are missing for now.
-  auto result = make_qtensor(self, C10_AS_INTARRAYREF_SLOW(sizes), C10_AS_INTARRAYREF_SLOW(strides), std::move(quantizer));
+  // TODO: quantized Tensor support for SymInt needs to be added but basic
+  // building blocs are missing for now.
+  auto result = make_qtensor(
+      self,
+      C10_AS_INTARRAYREF_SLOW(sizes),
+      C10_AS_INTARRAYREF_SLOW(strides),
+      std::move(quantizer));
   auto maybe_outnames = namedinference::compute_squeeze_outnames(self, mask);
   namedinference::propagate_names_if_nonempty(result, maybe_outnames);
   return result;
 }
-}
+} // namespace
 
 Tensor squeeze(const Tensor& self) {
   auto g = inferSqueezeGeometry(self);
@@ -3364,13 +3979,13 @@ Tensor squeeze_quantized(const Tensor& self, IntArrayRef dim) {
   return squeeze_qtensor(self, dim);
 }
 
-Tensor & squeeze_(Tensor& self) {
+Tensor& squeeze_(Tensor& self) {
   auto g = inferSqueezeGeometry(self);
   self.as_strided__symint(std::get<0>(g), std::get<1>(g));
   return self;
 }
 
-Tensor & squeeze_(Tensor& self, int64_t dim) {
+Tensor& squeeze_(Tensor& self, int64_t dim) {
   int64_t dims = self.dim();
   dim = maybe_wrap_dim(dim, self.dim());
 
@@ -3383,7 +3998,7 @@ Tensor & squeeze_(Tensor& self, int64_t dim) {
   return self;
 }
 
-Tensor & squeeze_(Tensor &self, IntArrayRef dims) {
+Tensor& squeeze_(Tensor& self, IntArrayRef dims) {
   auto mask = dim_list_to_bitset(dims, self.dim());
   auto g = inferSqueezeGeometry(self, mask);
   self.as_strided__symint(std::get<0>(g), std::get<1>(g));
@@ -3393,9 +4008,9 @@ Tensor & squeeze_(Tensor &self, IntArrayRef dims) {
 // NOTE [ Unsafe View ]
 // _unsafe_view() differs from view() in that the returned tensor isn't treated
 // as a view for the purposes of automatic differentiation. (It's not listed in
-// VIEW_FUNCTIONS in gen_inplace_or_view_type.py).  It's only safe to use if the `self` tensor
-// is temporary. For example, the viewed tensor here (a + b) is discarded immediately
-// after viewing:
+// VIEW_FUNCTIONS in gen_inplace_or_view_type.py).  It's only safe to use if the
+// `self` tensor is temporary. For example, the viewed tensor here (a + b) is
+// discarded immediately after viewing:
 //
 //  res = at::_unsafe_view(a + b, size);
 //
@@ -3403,16 +4018,15 @@ Tensor & squeeze_(Tensor &self, IntArrayRef dims) {
 // can be much more expensive than the same operations on non-view tensors.
 
 inline Tensor view_impl(const Tensor& self, IntArrayRef size) {
-
   at::DimVector inferred_size = at::infer_size_dv(size, self.numel());
-  auto stride = at::detail::computeStride(self.sizes(),
-                                          self.strides(),
-                                          inferred_size);
-  TORCH_CHECK(stride.has_value(), "view size is "
-    "not compatible with input tensor's size and stride (at least one dimension"
-    " spans across two contiguous subspaces). Use .reshape(...) instead.");
+  auto stride =
+      at::detail::computeStride(self.sizes(), self.strides(), inferred_size);
+  TORCH_CHECK(
+      stride.has_value(),
+      "view size is "
+      "not compatible with input tensor's size and stride (at least one dimension"
+      " spans across two contiguous subspaces). Use .reshape(...) instead.");
   return alias_with_sizes_and_strides(self, inferred_size, *stride);
-
 }
 
 Tensor _unsafe_view(const Tensor& self, IntArrayRef size) {
@@ -3425,7 +4039,7 @@ Tensor unsqueeze(const Tensor& self, int64_t dim) {
   return self.as_strided_symint(g.sizes, g.strides);
 }
 
-Tensor unsqueeze_sparse(Tensor const &self, int64_t dim) {
+Tensor unsqueeze_sparse(Tensor const& self, int64_t dim) {
   dim = maybe_wrap_dim(dim, self.dim() + 1);
   int64_t sparse_dim = self.sparse_dim();
   int64_t dense_dim = self.dense_dim();
@@ -3443,10 +4057,20 @@ Tensor unsqueeze_sparse(Tensor const &self, int64_t dim) {
              indices.options().pinned_memory_opt()),
          indices.narrow(0, dim, indices.size(0) - dim)});
     return _sparse_coo_tensor_with_dims_and_tensors(
-        sparse_dim + 1, dense_dim, sizes, new_indices, self._values(), self.options());
+        sparse_dim + 1,
+        dense_dim,
+        sizes,
+        new_indices,
+        self._values(),
+        self.options());
   } else {
     return _sparse_coo_tensor_with_dims_and_tensors(
-        sparse_dim, dense_dim + 1, sizes, indices, self._values().unsqueeze(dim - sparse_dim + 1), self.options());
+        sparse_dim,
+        dense_dim + 1,
+        sizes,
+        indices,
+        self._values().unsqueeze(dim - sparse_dim + 1),
+        self.options());
   }
 }
 
@@ -3455,20 +4079,22 @@ Tensor unsqueeze_quantized(const Tensor& self, int64_t dim) {
   auto g = inferUnsqueezeGeometry(self, dim);
   auto quantizer = get_qtensorimpl(self)->quantizer();
   if (quantizer->qscheme() == QScheme::PER_CHANNEL_AFFINE) {
-    const auto* per_channel_quantizer = static_cast<at::PerChannelAffineQuantizer*>(quantizer.get());
+    const auto* per_channel_quantizer =
+        static_cast<at::PerChannelAffineQuantizer*>(quantizer.get());
     auto axis = per_channel_quantizer->axis();
     if (axis >= dim) {
       axis += 1;
     }
-    quantizer = make_per_channel_affine_quantizer(per_channel_quantizer->scales(),
-                                                  per_channel_quantizer->zero_points(),
-                                                  axis,
-                                                  quantizer->scalar_type());
+    quantizer = make_per_channel_affine_quantizer(
+        per_channel_quantizer->scales(),
+        per_channel_quantizer->zero_points(),
+        axis,
+        quantizer->scalar_type());
   }
   return make_qtensor(self, g.sizes, g.strides, std::move(quantizer));
 }
 
-Tensor & unsqueeze_(Tensor& self, int64_t dim) {
+Tensor& unsqueeze_(Tensor& self, int64_t dim) {
   dim = maybe_wrap_dim(dim, self.dim() + 1);
 
   auto g = inferUnsqueezeGeometry_symint(self, dim);
@@ -3479,7 +4105,9 @@ Tensor & unsqueeze_(Tensor& self, int64_t dim) {
 Tensor flatten(const Tensor& self, int64_t start_dim, int64_t end_dim) {
   start_dim = maybe_wrap_dim(start_dim, self.dim());
   end_dim = maybe_wrap_dim(end_dim, self.dim());
-  TORCH_CHECK(start_dim <= end_dim, "flatten() has invalid args: start_dim cannot come after end_dim");
+  TORCH_CHECK(
+      start_dim <= end_dim,
+      "flatten() has invalid args: start_dim cannot come after end_dim");
 
   if (self.dim() == 0) {
     return self.reshape({1});
@@ -3488,11 +4116,13 @@ Tensor flatten(const Tensor& self, int64_t start_dim, int64_t end_dim) {
     return self;
   }
 
-  // We don't want to infer_size on the entire shape, because that can give us an extra degree
-  // of freedom we don't want; for example, consider shape [0, 1, 3, 0], with start_dim=1, end_dim=2.
-  // It's clear we want result shape [0, 3, 0] but passing [0, -1, 0] to infer_size means the -1
-  // can take on any value and satisfy the constraints.
-  auto slice_numel = c10::multiply_integers(self.sym_sizes().slice(start_dim, end_dim - start_dim + 1));
+  // We don't want to infer_size on the entire shape, because that can give us
+  // an extra degree of freedom we don't want; for example, consider shape [0,
+  // 1, 3, 0], with start_dim=1, end_dim=2. It's clear we want result shape [0,
+  // 3, 0] but passing [0, -1, 0] to infer_size means the -1 can take on any
+  // value and satisfy the constraints.
+  auto slice_numel = c10::multiply_integers(
+      self.sym_sizes().slice(start_dim, end_dim - start_dim + 1));
   std::vector<c10::SymInt> shape;
   shape.reserve(self.dim() - end_dim + start_dim);
   for (const auto i : c10::irange(start_dim)) {
@@ -3506,10 +4136,16 @@ Tensor flatten(const Tensor& self, int64_t start_dim, int64_t end_dim) {
   return native::reshape_symint(self, shape);
 }
 
-Tensor flatten(const Tensor& self, int64_t start_dim, int64_t end_dim, Dimname out_dim) {
+Tensor flatten(
+    const Tensor& self,
+    int64_t start_dim,
+    int64_t end_dim,
+    Dimname out_dim) {
   start_dim = maybe_wrap_dim(start_dim, self.dim());
   end_dim = maybe_wrap_dim(end_dim, self.dim());
-  TORCH_CHECK(start_dim <= end_dim, "flatten() has invalid args: start_dim cannot come after end_dim");
+  TORCH_CHECK(
+      start_dim <= end_dim,
+      "flatten() has invalid args: start_dim cannot come after end_dim");
 
   auto outnames = self.names().vec();
   outnames.erase(outnames.begin() + start_dim, outnames.begin() + end_dim + 1);
@@ -3524,21 +4160,31 @@ Tensor flatten(const Tensor& self, int64_t start_dim, int64_t end_dim, Dimname o
   return result;
 }
 
-Tensor flatten(const Tensor& self, Dimname start_dim, Dimname end_dim, Dimname out_dim) {
+Tensor flatten(
+    const Tensor& self,
+    Dimname start_dim,
+    Dimname end_dim,
+    Dimname out_dim) {
   auto start_pos = dimname_to_position(self, start_dim);
-  auto end_pos  = dimname_to_position(self, end_dim);
+  auto end_pos = dimname_to_position(self, end_dim);
   return native::flatten(self, start_pos, end_pos, out_dim);
 }
 
 Tensor flatten(const Tensor& self, DimnameList dims, Dimname out_dim) {
   auto positions = dimnames_to_positions(self, dims);
-  TORCH_CHECK(!positions.empty(),
+  TORCH_CHECK(
+      !positions.empty(),
       "flatten(tensor, dims, out_dim): dims cannot be empty");
   for (const auto i : c10::irange(positions.size() - 1)) {
-    if (positions[i] + 1 == positions[i + 1]) continue;
-    TORCH_CHECK(positions[i] + 1 == positions[i + 1],
-        "flatten(tensor, dims, out_dim): dims ", dims, " must be consecutive ",
-        "in Tensor", self.names());
+    if (positions[i] + 1 == positions[i + 1])
+      continue;
+    TORCH_CHECK(
+        positions[i] + 1 == positions[i + 1],
+        "flatten(tensor, dims, out_dim): dims ",
+        dims,
+        " must be consecutive ",
+        "in Tensor",
+        self.names());
   }
   return native::flatten(self, *dims.begin(), *(dims.end() - 1), out_dim);
 }
@@ -3547,34 +4193,56 @@ Tensor ravel(const Tensor& self) {
   return self.contiguous().view(-1);
 }
 
-static inline void handle_unflatten_exception(const std::runtime_error &e,
-                                              const Tensor &self,
-                                              int64_t dim,
-                                              SymIntArrayRef sizes,
-                                              std::optional <DimnameList> names) {
+static inline void handle_unflatten_exception(
+    const std::runtime_error& e,
+    const Tensor& self,
+    int64_t dim,
+    SymIntArrayRef sizes,
+    std::optional<DimnameList> names) {
   if (!strstr(e.what(), "is invalid for input of size")) {
     TORCH_CHECK(false, "unflatten got an unexpected error:\n", e.what());
   }
 
   if (self.has_names()) {
-    TORCH_CHECK(false,
-                "unflatten: Provided sizes ", sizes, " don't multiply up to the size of dim ",
-                dim, " (", self.names()[dim], ": ", self.sym_size(dim), ") in Tensor", self.names());
+    TORCH_CHECK(
+        false,
+        "unflatten: Provided sizes ",
+        sizes,
+        " don't multiply up to the size of dim ",
+        dim,
+        " (",
+        self.names()[dim],
+        ": ",
+        self.sym_size(dim),
+        ") in Tensor",
+        self.names());
 
   } else {
-    TORCH_CHECK(false,
-                "unflatten: Provided sizes ", sizes, " don't multiply up to the size of dim ",
-                dim, " (", self.sym_size(dim), ") in the input tensor");
+    TORCH_CHECK(
+        false,
+        "unflatten: Provided sizes ",
+        sizes,
+        " don't multiply up to the size of dim ",
+        dim,
+        " (",
+        self.sym_size(dim),
+        ") in the input tensor");
   }
 }
 
-static Tensor unflatten_impl(const Tensor& self, int64_t dim, SymIntArrayRef sizes, std::optional<DimnameList> names) {
+static Tensor unflatten_impl(
+    const Tensor& self,
+    int64_t dim,
+    SymIntArrayRef sizes,
+    std::optional<DimnameList> names) {
   dim = maybe_wrap_dim(dim, self.dim());
 
   TORCH_CHECK(!sizes.empty(), "unflatten: sizes must be non-empty");
   TORCH_INTERNAL_ASSERT(!names || names->size() == sizes.size());
   if (self.has_names()) {
-    TORCH_CHECK(names, "unflatten: input is a named tensor but no names were given for unflattened sizes");
+    TORCH_CHECK(
+        names,
+        "unflatten: input is a named tensor but no names were given for unflattened sizes");
   }
 
   SymDimVector inferred_size;
@@ -3582,8 +4250,8 @@ static Tensor unflatten_impl(const Tensor& self, int64_t dim, SymIntArrayRef siz
     inferred_size = at::infer_size_dv(sizes, self.sym_size(dim));
   } catch (const std::runtime_error& e) {
     // at::infer_size would throw std::runtime_error for invalid size,
-    // catch the runtime_error and display the error message in a more user-friendly way
-    // for both tensors and named tensors
+    // catch the runtime_error and display the error message in a more
+    // user-friendly way for both tensors and named tensors
     handle_unflatten_exception(e, self, dim, sizes, names);
   }
 
@@ -3611,15 +4279,20 @@ Tensor unflatten_symint(const Tensor& self, int64_t dim, SymIntArrayRef sizes) {
   return native::unflatten_impl(self, dim, sizes, std::nullopt);
 }
 
-Tensor unflatten_dimname_symint(const Tensor& self, Dimname dim, SymIntArrayRef sizes, DimnameList names) {
-  return native::unflatten_impl(self, dimname_to_position(self, dim), sizes, names);
+Tensor unflatten_dimname_symint(
+    const Tensor& self,
+    Dimname dim,
+    SymIntArrayRef sizes,
+    DimnameList names) {
+  return native::unflatten_impl(
+      self, dimname_to_position(self, dim), sizes, names);
 }
 
 Tensor view_as(const Tensor& self, const Tensor& other) {
   return self.view_symint(other.sym_sizes());
 }
 
-std::vector<Tensor> unbind(const Tensor &self, int64_t dim) {
+std::vector<Tensor> unbind(const Tensor& self, int64_t dim) {
   dim = maybe_wrap_dim(dim, self.dim());
   int64_t size = self.size(dim);
   std::vector<Tensor> tensors(size);
@@ -3634,19 +4307,23 @@ std::vector<Tensor> unbind(const Tensor& self, Dimname dim) {
 }
 
 std::vector<Tensor> meshgrid(TensorList tensors) {
-  TORCH_WARN_ONCE("torch.meshgrid: in an upcoming release, it will be required to pass the "
-                  "indexing argument.");
+  TORCH_WARN_ONCE(
+      "torch.meshgrid: in an upcoming release, it will be required to pass the "
+      "indexing argument.");
   return native::meshgrid(tensors, /*indexing=*/"ij");
 }
 
-std::vector<Tensor> meshgrid(TensorList tensors,
-                             std::string_view indexing) {
+std::vector<Tensor> meshgrid(TensorList tensors, std::string_view indexing) {
   int64_t size = tensors.size();
   TORCH_CHECK(size > 0, "meshgrid expects a non-empty TensorList");
 
-  for(const auto i: c10::irange(size - 1)){
-    TORCH_CHECK(tensors[i].dtype() == tensors[i+1].dtype(), "meshgrid expects all tensors to have the same dtype");
-    TORCH_CHECK(tensors[i].device() == tensors[i+1].device(), "meshgrid expects all tensors to have the same device");
+  for (const auto i : c10::irange(size - 1)) {
+    TORCH_CHECK(
+        tensors[i].dtype() == tensors[i + 1].dtype(),
+        "meshgrid expects all tensors to have the same dtype");
+    TORCH_CHECK(
+        tensors[i].device() == tensors[i + 1].device(),
+        "meshgrid expects all tensors to have the same device");
   }
 
   // Input tensors is of type TensorList, which is an alias to a
@@ -3657,8 +4334,8 @@ std::vector<Tensor> meshgrid(TensorList tensors,
   //
   // We are not concerned with the performance of this relative to
   // constructor a grid for each input.
-  std::vector<std::reference_wrapper<const Tensor>> tensor_refs(tensors.begin(),
-                                                                tensors.end());
+  std::vector<std::reference_wrapper<const Tensor>> tensor_refs(
+      tensors.begin(), tensors.end());
 
   // Whether or not to swap the first two tensors.
   //
@@ -3690,24 +4367,31 @@ std::vector<Tensor> meshgrid(TensorList tensors,
   } else {
     // Only "xy" and "ij" are supported, and we already checked for
     // "xy" above. Only "ij" remains as a valid mode.
-    TORCH_CHECK(indexing == "ij",
-                "torch.meshgrid: indexing must be one of \"xy\" or \"ij\", "
-                "but received: ", indexing);
+    TORCH_CHECK(
+        indexing == "ij",
+        "torch.meshgrid: indexing must be one of \"xy\" or \"ij\", "
+        "but received: ",
+        indexing);
   }
 
   std::vector<c10::SymInt> shape(size);
-  for(const auto i: c10::irange(size)){
-    TORCH_CHECK(tensor_refs[i].get().dim() <= 1,
-                "torch.meshgrid: Expected 0D or 1D tensor in the tensor list but got: ", tensor_refs[i]);
-    shape[i] = tensor_refs[i].get().sym_numel();  // treat 0D tensors as if they were a 1D tensor
+  for (const auto i : c10::irange(size)) {
+    TORCH_CHECK(
+        tensor_refs[i].get().dim() <= 1,
+        "torch.meshgrid: Expected 0D or 1D tensor in the tensor list but got: ",
+        tensor_refs[i]);
+    shape[i] = tensor_refs[i]
+                   .get()
+                   .sym_numel(); // treat 0D tensors as if they were a 1D tensor
   }
   std::vector<Tensor> grids;
   grids.reserve(size);
   std::vector<c10::SymInt> view_shape(size, 1);
-  for(const auto i: c10::irange(size)){
-    view_shape[i] = -1;  // select this dimension to infer
-    grids.push_back(tensor_refs[i].get().view_symint(view_shape).expand_symint(shape));
-    view_shape[i] = 1;  // restore to previous value
+  for (const auto i : c10::irange(size)) {
+    view_shape[i] = -1; // select this dimension to infer
+    grids.push_back(
+        tensor_refs[i].get().view_symint(view_shape).expand_symint(shape));
+    view_shape[i] = 1; // restore to previous value
   }
 
   // Remember we need to also swap the outputs if we swapped the inputs.
@@ -3719,18 +4403,18 @@ std::vector<Tensor> meshgrid(TensorList tensors,
 
 // Numpy-style `a.T`: returns the tensor
 // with dims reversed
-Tensor numpy_T(const Tensor &self) {
+Tensor numpy_T(const Tensor& self) {
   const auto n = self.dim();
   if (n != 2 && n != 0) {
     TORCH_WARN_ONCE(
         "The use of `x.T` on tensors of dimension other than 2 to reverse their shape is deprecated ",
         "and it will throw an error in a future release. Consider `x.mT` to transpose batches of matrices ",
-        "or `x.permute(*torch.arange(x.ndim - 1, -1, -1))` to reverse the dimensions of a tensor."
-    );
+        "or `x.permute(*torch.arange(x.ndim - 1, -1, -1))` to reverse the dimensions of a tensor.");
   }
   if (n == 0) {
-   // Added in PyTorch 2.0
-   TORCH_WARN_ONCE("Tensor.T is deprecated on 0-D tensors. This function is the identity in these cases.");
+    // Added in PyTorch 2.0
+    TORCH_WARN_ONCE(
+        "Tensor.T is deprecated on 0-D tensors. This function is the identity in these cases.");
   }
   DimVector transpose_dims;
   for (int64_t i = n - 1; i >= 0; --i) {
@@ -3739,14 +4423,18 @@ Tensor numpy_T(const Tensor &self) {
   return self.permute(transpose_dims);
 }
 
-Tensor matrix_H(const Tensor &self) {
+Tensor matrix_H(const Tensor& self) {
   const auto ndim = self.dim();
   if (ndim == 0) {
-   // Added in PyTorch 2.0
-   TORCH_WARN_ONCE("Tensor.H is deprecated on 0-D tensors. Consider using x.conj().");
+    // Added in PyTorch 2.0
+    TORCH_WARN_ONCE(
+        "Tensor.H is deprecated on 0-D tensors. Consider using x.conj().");
   }
-  TORCH_CHECK(ndim == 2 || ndim == 0,
-      "tensor.H is only supported on matrices (2-D tensors). Got ", ndim, "-D tensor.",
+  TORCH_CHECK(
+      ndim == 2 || ndim == 0,
+      "tensor.H is only supported on matrices (2-D tensors). Got ",
+      ndim,
+      "-D tensor.",
       ndim > 2 ? " For batches of matrices, consider using tensor.mH" : "");
   if (self.is_complex()) {
     return ndim == 0 ? self.conj() : self.transpose(-2, -1).conj();
@@ -3756,10 +4444,16 @@ Tensor matrix_H(const Tensor &self) {
 }
 
 namespace {
-Tensor _adjoint(const Tensor &self, const bool transpose, const char* const name) {
+Tensor _adjoint(
+    const Tensor& self,
+    const bool transpose,
+    const char* const name) {
   const auto ndim = self.dim();
-  TORCH_CHECK(ndim != 1,
-      "tensor.", name, " is only supported on matrices or batches of matrices. Got 1-D tensor.");
+  TORCH_CHECK(
+      ndim != 1,
+      "tensor.",
+      name,
+      " is only supported on matrices or batches of matrices. Got 1-D tensor.");
   if (transpose || !self.is_complex()) {
     return ndim == 0 ? self : self.transpose(-2, -1);
   } else {
@@ -3768,46 +4462,49 @@ Tensor _adjoint(const Tensor &self, const bool transpose, const char* const name
 }
 } // anonymous namespace
 
-Tensor mT(const Tensor &self) {
+Tensor mT(const Tensor& self) {
   if (self.dim() == 0) {
-   // Added in PyTorch 2.0
-   TORCH_WARN_ONCE("Tensor.mT is deprecated on 0-D tensors. This function is the identity in these cases.");
+    // Added in PyTorch 2.0
+    TORCH_WARN_ONCE(
+        "Tensor.mT is deprecated on 0-D tensors. This function is the identity in these cases.");
   }
   return _adjoint(self, /*transpose=*/true, "mT");
 }
 
-Tensor mH(const Tensor &self) {
+Tensor mH(const Tensor& self) {
   if (self.dim() == 0) {
     // Added in PyTorch 2.0
-   TORCH_WARN_ONCE("Tensor.mH is deprecated on 0-D tensors. Consider using x.conj().");
+    TORCH_WARN_ONCE(
+        "Tensor.mH is deprecated on 0-D tensors. Consider using x.conj().");
   }
   return _adjoint(self, /*transpose=*/false, "mH");
 }
 
-Tensor adjoint(const Tensor &self) {
+Tensor adjoint(const Tensor& self) {
   if (self.dim() == 0) {
-   TORCH_WARN_ONCE("adjoint() is deprecated on 0-D tensors. Consider using x.conj().");
+    TORCH_WARN_ONCE(
+        "adjoint() is deprecated on 0-D tensors. Consider using x.conj().");
   }
   return _adjoint(self, /*transpose=*/false, "adjoint()");
 }
 
-Tensor view(const Tensor& self,
-            at::IntArrayRef size) {
+Tensor view(const Tensor& self, at::IntArrayRef size) {
   return view_impl(self, size);
 }
 
 Tensor alias(const Tensor& self) {
-  return alias_with_sizes_and_strides(self, self.sym_sizes(), self.sym_strides());
+  return alias_with_sizes_and_strides(
+      self, self.sym_sizes(), self.sym_strides());
 }
 
 Tensor detach(const Tensor& self) {
   // NB: detach() is not the same thing as alias()! The main difference is that
   // detach does not allow metadata change while alias does.
   return Tensor(self.getIntrusivePtr()->shallow_copy_and_detach(
-    // NB: The ADInplaceOrView logic will overwrite these with the
-    // appropriate values if it runs; otherwise these are the values.
-    /*version_counter=*/0,
-    /*allow_tensor_metadata_change=*/false));
+      // NB: The ADInplaceOrView logic will overwrite these with the
+      // appropriate values if it runs; otherwise these are the values.
+      /*version_counter=*/0,
+      /*allow_tensor_metadata_change=*/false));
 }
 
 Tensor unfold(const Tensor& self, int64_t d, int64_t size, int64_t step) {
@@ -3819,8 +4516,14 @@ Tensor unfold(const Tensor& self, int64_t d, int64_t size, int64_t step) {
   auto strides = self.strides().vec();
   int64_t max_size = self.dim() == 0 ? 1 : sizes[d];
   TORCH_CHECK(size >= 0, "size is ", size, " but must be >= 0");
-  TORCH_CHECK(size <= max_size, "maximum size for tensor at dimension ", d,
-                                " is ", max_size, " but size is ", size);
+  TORCH_CHECK(
+      size <= max_size,
+      "maximum size for tensor at dimension ",
+      d,
+      " is ",
+      max_size,
+      " but size is ",
+      size);
   TORCH_CHECK(step > 0, "step is ", step, " but must be > 0");
   sizes.push_back(size);
   strides.push_back(self.dim() == 0 ? 1 : strides[d]);
@@ -3834,7 +4537,11 @@ Tensor unfold(const Tensor& self, int64_t d, int64_t size, int64_t step) {
 
 Tensor diag(const Tensor& self, int64_t offset) {
   auto ndim = self.dim();
-  TORCH_CHECK(ndim == 1 || ndim == 2, "diag(): Supports 1D or 2D tensors. Got ", self.dim(), "D");
+  TORCH_CHECK(
+      ndim == 1 || ndim == 2,
+      "diag(): Supports 1D or 2D tensors. Got ",
+      self.dim(),
+      "D");
   if (ndim == 1) {
     return at::diag_embed(self, offset);
   } else {
@@ -3845,11 +4552,17 @@ Tensor diag(const Tensor& self, int64_t offset) {
 
 Tensor& diag_out(const Tensor& self, int64_t offset, Tensor& out) {
   auto ndim = self.dim();
-  TORCH_CHECK(ndim == 1 || ndim == 2, "Supports 1D or 2D tensors. Got ", self.dim(), "D");
+  TORCH_CHECK(
+      ndim == 1 || ndim == 2,
+      "Supports 1D or 2D tensors. Got ",
+      self.dim(),
+      "D");
   if (ndim == 1) {
     TORCH_CHECK(
         canCast(self.scalar_type(), out.scalar_type()),
-        "diag: result type ", self.scalar_type(), " can't be cast to the desired out= type ",
+        "diag: result type ",
+        self.scalar_type(),
+        " can't be cast to the desired out= type ",
         out.scalar_type());
     return at::diag_embed_out(out, self, offset);
   } else {
@@ -3857,7 +4570,12 @@ Tensor& diag_out(const Tensor& self, int64_t offset, Tensor& out) {
   }
 }
 
-Tensor diagonal_backward_symint(const Tensor & grad, SymIntArrayRef input_sizes, int64_t offset, int64_t dim1, int64_t dim2) {
+Tensor diagonal_backward_symint(
+    const Tensor& grad,
+    SymIntArrayRef input_sizes,
+    int64_t offset,
+    int64_t dim1,
+    int64_t dim2) {
   auto grad_input = at::zeros_symint(input_sizes, grad.options());
   auto diag = grad_input.diagonal(offset, dim1, dim2);
   diag.copy_(grad);
@@ -3865,14 +4583,20 @@ Tensor diagonal_backward_symint(const Tensor & grad, SymIntArrayRef input_sizes,
 }
 
 Tensor movedim(const Tensor& self, IntArrayRef src, IntArrayRef dst) {
-  TORCH_CHECK(src.size() == dst.size(), "movedim: Invalid source or destination dims: source (",
-              src, " dims) should contain the same number of dims as destination (", dst, " dims)");
+  TORCH_CHECK(
+      src.size() == dst.size(),
+      "movedim: Invalid source or destination dims: source (",
+      src,
+      " dims) should contain the same number of dims as destination (",
+      dst,
+      " dims)");
 
   size_t self_dim = self.dim();
   DimVector normalized_src(src.size());
   DimVector normalized_dst(dst.size());
 
-  auto wrap_dims = [&self_dim](const IntArrayRef& vec, DimVector& normalized_vec) {
+  auto wrap_dims = [&self_dim](
+                       const IntArrayRef& vec, DimVector& normalized_vec) {
     for (const auto i : c10::irange(vec.size())) {
       normalized_vec[i] = maybe_wrap_dim(vec[i], self_dim);
     }
@@ -3887,15 +4611,24 @@ Tensor movedim(const Tensor& self, IntArrayRef src, IntArrayRef dst) {
     auto duplicate = std::adjacent_find(copy.begin(), copy.end());
     return duplicate == copy.end();
   };
-  TORCH_CHECK(all_unique(normalized_src), "movedim: repeated dim in `source` (", src, ")");
-  TORCH_CHECK(all_unique(normalized_dst), "movedim: repeated dim in `destination` (", dst, ")");
+  TORCH_CHECK(
+      all_unique(normalized_src),
+      "movedim: repeated dim in `source` (",
+      src,
+      ")");
+  TORCH_CHECK(
+      all_unique(normalized_dst),
+      "movedim: repeated dim in `destination` (",
+      dst,
+      ")");
 
   // handle the case of scalar tensor as a no-op
   if (self_dim == 0)
     return self.alias();
 
   // TODO: The algorithm below can probably be optimized.
-  // Reference: https://github.com/pytorch/pytorch/pull/41480#discussion_r456100505
+  // Reference:
+  // https://github.com/pytorch/pytorch/pull/41480#discussion_r456100505
 
   // Algorithm Walkthrough
   // Example Input
@@ -3923,9 +4656,9 @@ Tensor movedim(const Tensor& self, IntArrayRef src, IntArrayRef dst) {
   //     source_dims = -1, -1, 2, 3, 4
   //     destination_dims = 0, 1, -1, 3, -1
   for (const auto i : c10::irange(src.size())) {
-      order[normalized_dst[i]] = normalized_src[i];
-      source_dims[normalized_src[i]] = -1;
-      destination_dims[normalized_dst[i]] = -1;
+    order[normalized_dst[i]] = normalized_src[i];
+    source_dims[normalized_src[i]] = -1;
+    destination_dims[normalized_dst[i]] = -1;
   }
 
   // Remove the dims whose position we already know,
@@ -3934,11 +4667,14 @@ Tensor movedim(const Tensor& self, IntArrayRef src, IntArrayRef dst) {
   //     source_dims = 2, 3, 4
   //     destination_dims = 0, 1, 3
   auto source_iter = std::remove(source_dims.begin(), source_dims.end(), -1);
-  auto destination_iter = std::remove(destination_dims.begin(), destination_dims.end(), -1);
+  auto destination_iter =
+      std::remove(destination_dims.begin(), destination_dims.end(), -1);
 
   int64_t rest_dim = self.dim() - src.size();
-  TORCH_INTERNAL_ASSERT(std::distance(source_dims.begin(), source_iter)  == rest_dim);
-  TORCH_INTERNAL_ASSERT(std::distance(destination_dims.begin(), destination_iter)  == rest_dim);
+  TORCH_INTERNAL_ASSERT(
+      std::distance(source_dims.begin(), source_iter) == rest_dim);
+  TORCH_INTERNAL_ASSERT(
+      std::distance(destination_dims.begin(), destination_iter) == rest_dim);
 
   // Update the position of the remaining dimensions.
   // `source_dims` now contains the original position
@@ -3947,7 +4683,7 @@ Tensor movedim(const Tensor& self, IntArrayRef src, IntArrayRef dst) {
   // Variable State:
   //     order = 2, 3, 0, 4, 1
   for (const auto i : c10::irange(rest_dim)) {
-      order[destination_dims[i]] = source_dims[i];
+    order[destination_dims[i]] = source_dims[i];
   }
 
   return self.permute(order);
@@ -3982,17 +4718,21 @@ Tensor& swapdims_(Tensor& self, int64_t dim0, int64_t dim1) {
 }
 
 Tensor flatten_dense_tensors(TensorList tensors) {
-  static auto flatten = [](const Tensor &t) { return t.contiguous().view({-1}); };
+  static auto flatten = [](const Tensor& t) {
+    return t.contiguous().view({-1});
+  };
   if (tensors.size() == 1)
     return flatten(tensors[0]);
   return at::cat(fmap(tensors, flatten));
 }
 
-std::vector<Tensor> unflatten_dense_tensors(const Tensor& flat, TensorList tensors) {
+std::vector<Tensor> unflatten_dense_tensors(
+    const Tensor& flat,
+    TensorList tensors) {
   std::vector<Tensor> outputs;
   outputs.reserve(tensors.size());
   size_t offset = 0;
-  for (const auto & tensor : tensors) {
+  for (const auto& tensor : tensors) {
     auto numel = tensor.numel();
     // If unflatten an empty tensor, create a new empty tensor using
     // flat tensor Options.
@@ -4008,26 +4748,26 @@ std::vector<Tensor> unflatten_dense_tensors(const Tensor& flat, TensorList tenso
   return outputs;
 }
 
-
 // Clones a tensor by cloning the underlying storage that it came from,
-// which allows us to replicate the exact strides/storage_offset in the cloned tensor.
-// Note [*_scatter ops preserve strides]
-// In order for functionalization to preserve stride correctness, the *_scatter
-// operators that it calls must preserve the striding behavior of their inputs.
-// Specifically, the output of *_scatter(base, mutated_view, ...)
-// should have identical size/stride/storage_offset to "base".
+// which allows us to replicate the exact strides/storage_offset in the cloned
+// tensor. Note [*_scatter ops preserve strides] In order for functionalization
+// to preserve stride correctness, the *_scatter operators that it calls must
+// preserve the striding behavior of their inputs. Specifically, the output of
+// *_scatter(base, mutated_view, ...) should have identical
+// size/stride/storage_offset to "base".
 at::Tensor clone_preserve_strides(const at::Tensor& self) {
   TORCH_INTERNAL_ASSERT(self.has_storage());
-  // In cases where the input tensor has internal memory overlap, we cannot actually
-  // preserve the strides/storage_offset of the input tensor, because
+  // In cases where the input tensor has internal memory overlap, we cannot
+  // actually preserve the strides/storage_offset of the input tensor, because
   // *_scatter ops will try to copy_() into the cloned tensor.
   // However, this should **never** show up in functionalized user code;
-  // most aten ops that try to mutate a tensor with internal memory overlap would error anyway.
+  // most aten ops that try to mutate a tensor with internal memory overlap
+  // would error anyway.
   //
-  // The one place that this does come up is in autograd - if there's a select_scatter
-  // in the forward, then autograd will generate one for the backward.
-  // If the input to the select_scatter is grad_output, then this could be an expanded tensor
-  // with internal overlap.
+  // The one place that this does come up is in autograd - if there's a
+  // select_scatter in the forward, then autograd will generate one for the
+  // backward. If the input to the select_scatter is grad_output, then this
+  // could be an expanded tensor with internal overlap.
   if (at::has_internal_overlap(self) == at::MemOverlap::Yes) {
     return self.clone();
   }
@@ -4037,99 +4777,185 @@ at::Tensor clone_preserve_strides(const at::Tensor& self) {
   auto numel = nbytes / dtype_size;
   auto self_full_size = self.as_strided_symint({std::move(numel)}, {1}, 0);
   auto clone = self_full_size.clone();
-  auto out = clone.as_strided_symint(self.sym_sizes(), self.sym_strides(), self.sym_storage_offset());
+  auto out = clone.as_strided_symint(
+      self.sym_sizes(), self.sym_strides(), self.sym_storage_offset());
   return out;
 }
 
-
-at::Tensor slice_scatter(const at::Tensor& self, const at::Tensor& src, int64_t dim, std::optional<int64_t> start, std::optional<int64_t> end, int64_t step) {
-    // See Note [*_scatter ops preserve strides]
-    auto output = clone_preserve_strides(self);
-    auto slice = output.slice(dim, start, end, step);
-    TORCH_CHECK(slice.sizes() == src.sizes(), "expected src to have a size equal to the slice of self. src size = ", src.sizes(), ", slice size = ", slice.sizes());
-    slice.copy_(src);
-    return output;
+at::Tensor slice_scatter(
+    const at::Tensor& self,
+    const at::Tensor& src,
+    int64_t dim,
+    std::optional<int64_t> start,
+    std::optional<int64_t> end,
+    int64_t step) {
+  // See Note [*_scatter ops preserve strides]
+  auto output = clone_preserve_strides(self);
+  auto slice = output.slice(dim, start, end, step);
+  TORCH_CHECK(
+      slice.sizes() == src.sizes(),
+      "expected src to have a size equal to the slice of self. src size = ",
+      src.sizes(),
+      ", slice size = ",
+      slice.sizes());
+  slice.copy_(src);
+  return output;
 }
-at::Tensor select_scatter_symint(const at::Tensor& self, const at::Tensor& src, int64_t dim, c10::SymInt index) {
-    auto output = clone_preserve_strides(self);
-    auto slice = output.select_symint(dim, std::move(index));
-    TORCH_CHECK(slice.sizes() == src.sizes(), "expected src to have a size equal to the slice of self. src size = ", src.sizes(), ", slice size = ", slice.sizes());
-    slice.copy_(src);
-    return output;
+at::Tensor select_scatter_symint(
+    const at::Tensor& self,
+    const at::Tensor& src,
+    int64_t dim,
+    c10::SymInt index) {
+  auto output = clone_preserve_strides(self);
+  auto slice = output.select_symint(dim, std::move(index));
+  TORCH_CHECK(
+      slice.sizes() == src.sizes(),
+      "expected src to have a size equal to the slice of self. src size = ",
+      src.sizes(),
+      ", slice size = ",
+      slice.sizes());
+  slice.copy_(src);
+  return output;
 }
-at::Tensor diagonal_scatter(const at::Tensor& self, const at::Tensor& src, int64_t offset, int64_t dim1, int64_t dim2) {
-    // See Note [*_scatter ops preserve strides]
-    auto output = clone_preserve_strides(self);
-    auto slice = output.diagonal(offset, dim1, dim2);
-    TORCH_CHECK(slice.sizes() == src.sizes(), "expected src to have a size equal to the slice of self. src size = ", src.sizes(), ", slice size = ", slice.sizes());
-    slice.copy_(src);
-    return output;
+at::Tensor diagonal_scatter(
+    const at::Tensor& self,
+    const at::Tensor& src,
+    int64_t offset,
+    int64_t dim1,
+    int64_t dim2) {
+  // See Note [*_scatter ops preserve strides]
+  auto output = clone_preserve_strides(self);
+  auto slice = output.diagonal(offset, dim1, dim2);
+  TORCH_CHECK(
+      slice.sizes() == src.sizes(),
+      "expected src to have a size equal to the slice of self. src size = ",
+      src.sizes(),
+      ", slice size = ",
+      slice.sizes());
+  slice.copy_(src);
+  return output;
 }
-at::Tensor as_strided_scatter_symint(const at::Tensor& self, const at::Tensor& src, at::SymIntArrayRef size, at::SymIntArrayRef stride, std::optional<c10::SymInt> storage_offset) {
-    // See Note [as_strided_scatter backward support]
-    TORCH_INTERNAL_ASSERT(!self.requires_grad() || self.is_contiguous(), "as_strided_scatter is currently only supported for contiguous inputs");
-    // See Note [*_scatter ops preserve strides]
-    auto output = clone_preserve_strides(self);
-    auto slice = output.as_strided_symint(size, stride, std::move(storage_offset));
-    TORCH_CHECK(slice.sym_sizes() == src.sym_sizes(), "expected src to have a size equal to the slice of self. src size = ", src.sym_sizes(), ", slice size = ", slice.sym_sizes());
-    slice.copy_(src);
-    return output;
+at::Tensor as_strided_scatter_symint(
+    const at::Tensor& self,
+    const at::Tensor& src,
+    at::SymIntArrayRef size,
+    at::SymIntArrayRef stride,
+    std::optional<c10::SymInt> storage_offset) {
+  // See Note [as_strided_scatter backward support]
+  TORCH_INTERNAL_ASSERT(
+      !self.requires_grad() || self.is_contiguous(),
+      "as_strided_scatter is currently only supported for contiguous inputs");
+  // See Note [*_scatter ops preserve strides]
+  auto output = clone_preserve_strides(self);
+  auto slice =
+      output.as_strided_symint(size, stride, std::move(storage_offset));
+  TORCH_CHECK(
+      slice.sym_sizes() == src.sym_sizes(),
+      "expected src to have a size equal to the slice of self. src size = ",
+      src.sym_sizes(),
+      ", slice size = ",
+      slice.sym_sizes());
+  slice.copy_(src);
+  return output;
 }
 
 // The default implementation of lift is a no-op.
-// If TLS is set appropriately (for wrapper-tensor keys like Functionalize or functorch transforms),
-// then we'll dispatch to one of their implementations, which will properly lift the tensor into a wrapper.
+// If TLS is set appropriately (for wrapper-tensor keys like Functionalize or
+// functorch transforms), then we'll dispatch to one of their implementations,
+// which will properly lift the tensor into a wrapper.
 at::Tensor lift(const at::Tensor& self) {
-    return self;
+  return self;
 }
 
 // See notes in native_functions.yaml
 at::Tensor lift_fresh(const at::Tensor& self) {
-    return self;
+  return self;
 }
 
 // Autogen kernels for tensor list ops dont work on XLA. TODO(jakeszwe)
-void split_copy_Tensor_out(const at::Tensor & self, int64_t split_size, int64_t dim, at::TensorList  out) {
+void split_copy_Tensor_out(
+    const at::Tensor& self,
+    int64_t split_size,
+    int64_t dim,
+    at::TensorList out) {
   auto tmp = self.split(split_size, dim);
 
-  TORCH_CHECK(out.size() == tmp.size(), "split_copy_Tensor_out() expected an out= argument of size ", tmp.size(), ", got size ", out.size());
+  TORCH_CHECK(
+      out.size() == tmp.size(),
+      "split_copy_Tensor_out() expected an out= argument of size ",
+      tmp.size(),
+      ", got size ",
+      out.size());
   for (const auto i : c10::irange(out.size())) {
     out[i].copy_(tmp[i]);
   }
 }
 
-void split_with_sizes_copy_out(const at::Tensor & self, at::IntArrayRef split_sizes, int64_t dim, at::TensorList  out) {
+void split_with_sizes_copy_out(
+    const at::Tensor& self,
+    at::IntArrayRef split_sizes,
+    int64_t dim,
+    at::TensorList out) {
   auto tmp = self.split_with_sizes(split_sizes, dim);
 
-  TORCH_CHECK(out.size() == tmp.size(), "split_with_sizes_copy_out() expected an out= argument of size ", tmp.size(), ", got size ", out.size());
+  TORCH_CHECK(
+      out.size() == tmp.size(),
+      "split_with_sizes_copy_out() expected an out= argument of size ",
+      tmp.size(),
+      ", got size ",
+      out.size());
   for (const auto i : c10::irange(out.size())) {
     if (resize_output_check(out[i], tmp[i].sizes())) {
       out[i].resize_(tmp[i].sizes());
     }
-    TORCH_CHECK(out[i].dtype() == tmp[i].dtype(),
-        "Expected out tensor to have dtype ", tmp[i].dtype(), ", but got ", out[i].dtype(), " instead");
-    TORCH_CHECK(out[i].device() == tmp[i].device(),
-        "Expected out tensor to have device ", tmp[i].device(), ", but got ", out[i].device(), " instead");
+    TORCH_CHECK(
+        out[i].dtype() == tmp[i].dtype(),
+        "Expected out tensor to have dtype ",
+        tmp[i].dtype(),
+        ", but got ",
+        out[i].dtype(),
+        " instead");
+    TORCH_CHECK(
+        out[i].device() == tmp[i].device(),
+        "Expected out tensor to have device ",
+        tmp[i].device(),
+        ", but got ",
+        out[i].device(),
+        " instead");
     out[i].copy_(tmp[i]);
   }
 }
 
-void unbind_copy_int_out(const at::Tensor & self, int64_t dim, at::TensorList  out) {
+void unbind_copy_int_out(
+    const at::Tensor& self,
+    int64_t dim,
+    at::TensorList out) {
   auto tmp = self.unbind(dim);
 
-  TORCH_CHECK(out.size() == tmp.size(), "unbind_copy_int_out() expected an out= argument of size ", tmp.size(), ", got size ", out.size());
+  TORCH_CHECK(
+      out.size() == tmp.size(),
+      "unbind_copy_int_out() expected an out= argument of size ",
+      tmp.size(),
+      ", got size ",
+      out.size());
   for (const auto i : c10::irange(out.size())) {
     out[i].copy_(tmp[i]);
   }
 }
 
 int64_t sparse_dim_default(const Tensor& self) {
-  TORCH_CHECK(self.layout() == kStrided, "sparse_dim expected sparse or strided tensor layout but got ", self.layout());
+  TORCH_CHECK(
+      self.layout() == kStrided,
+      "sparse_dim expected sparse or strided tensor layout but got ",
+      self.layout());
   return 0;
 }
 
 int64_t dense_dim_default(const Tensor& self) {
-  TORCH_CHECK(self.layout() == kStrided, "dense_dim expected sparse or strided tensor layout but got ", self.layout());
+  TORCH_CHECK(
+      self.layout() == kStrided,
+      "dense_dim expected sparse or strided tensor layout but got ",
+      self.layout());
   return self.dim();
 }
 

--- a/aten/src/ATen/native/TensorShape.h
+++ b/aten/src/ATen/native/TensorShape.h
@@ -1,7 +1,7 @@
 #pragma once
+#include <ATen/core/IListRef.h>
 #include <ATen/core/Tensor.h>
 #include <c10/util/irange.h>
-#include <ATen/core/IListRef.h>
 
 namespace at::native {
 
@@ -11,45 +11,74 @@ inline bool cat_should_skip_tensor(const Tensor& t) {
   return t.sym_numel() == 0 && t.dim() == 1;
 }
 
- // Check to see if the shape of tensors is compatible
- // for being concatenated along a given dimension.
-inline void check_cat_shape_except_dim(const Tensor & first, const Tensor & second, int64_t dimension, int64_t index) {
-   int64_t first_dims = first.dim();
-   int64_t second_dims = second.dim();
-   TORCH_CHECK(first_dims == second_dims, "Tensors must have same number of dimensions: got ",
-               first_dims, " and ", second_dims);
-   for (const auto dim : c10::irange(first_dims)) {
-     if (dim == dimension) {
-       continue;
-     }
-     int64_t first_dim_size = first.sizes()[dim];
-     int64_t second_dim_size = second.sizes()[dim];
-     TORCH_CHECK(first_dim_size == second_dim_size, "Sizes of tensors must match except in dimension ",
-                 dimension, ". Expected size ", static_cast<long long>(first_dim_size), " but got size ", static_cast<long long>(second_dim_size), " for tensor number ", index, " in the list.");
-   }
- }
+// Check to see if the shape of tensors is compatible
+// for being concatenated along a given dimension.
+inline void check_cat_shape_except_dim(
+    const Tensor& first,
+    const Tensor& second,
+    int64_t dimension,
+    int64_t index) {
+  int64_t first_dims = first.dim();
+  int64_t second_dims = second.dim();
+  TORCH_CHECK(
+      first_dims == second_dims,
+      "Tensors must have same number of dimensions: got ",
+      first_dims,
+      " and ",
+      second_dims);
+  for (const auto dim : c10::irange(first_dims)) {
+    if (dim == dimension) {
+      continue;
+    }
+    int64_t first_dim_size = first.sizes()[dim];
+    int64_t second_dim_size = second.sizes()[dim];
+    TORCH_CHECK(
+        first_dim_size == second_dim_size,
+        "Sizes of tensors must match except in dimension ",
+        dimension,
+        ". Expected size ",
+        static_cast<long long>(first_dim_size),
+        " but got size ",
+        static_cast<long long>(second_dim_size),
+        " for tensor number ",
+        index,
+        " in the list.");
+  }
+}
 
 inline void check_cat_no_zero_dim(const MaterializedITensorListRef& tensors) {
   [[maybe_unused]] int64_t i = 0;
-  for(const Tensor& t : tensors) {
-    TORCH_CHECK(t.dim() > 0,
-             "zero-dimensional tensor (at position ", i, ") cannot be concatenated");
+  for (const Tensor& t : tensors) {
+    TORCH_CHECK(
+        t.dim() > 0,
+        "zero-dimensional tensor (at position ",
+        i,
+        ") cannot be concatenated");
     i++;
   }
 }
 
-inline int64_t get_num_splits(const Tensor& self, int64_t split_size, int64_t dim) {
+inline int64_t get_num_splits(
+    const Tensor& self,
+    int64_t split_size,
+    int64_t dim) {
   TORCH_CHECK(self.dim() != 0, "split expects at least a 1-dimensional tensor");
-  TORCH_CHECK(split_size >= 0,  "split expects split_size be non-negative, but got split_size=", split_size);
+  TORCH_CHECK(
+      split_size >= 0,
+      "split expects split_size be non-negative, but got split_size=",
+      split_size);
   int64_t dim_size = self.size(dim);
-  TORCH_CHECK(split_size > 0 || dim_size == 0,
-           "split_size can only be 0 if dimension size is 0, "
-           "but got dimension size of ", dim_size);
+  TORCH_CHECK(
+      split_size > 0 || dim_size == 0,
+      "split_size can only be 0 if dimension size is 0, "
+      "but got dimension size of ",
+      dim_size);
   // if split_size is 0 and dimension size is 0, there is 1 split.
   int64_t num_splits = 1;
   if (split_size != 0) {
-    // ensuring num_splits is at least 1 makes consistent the case where split_size > dim_size
-    // (returns a single split).  We might want to error here, but keep it for BC.
+    // ensuring num_splits is at least 1 makes consistent the case where
+    // split_size > dim_size (returns a single split).  We might want to error
+    // here, but keep it for BC.
     num_splits = std::max<int64_t>((dim_size + split_size - 1) / split_size, 1);
   }
   return num_splits;
@@ -58,7 +87,7 @@ inline int64_t get_num_splits(const Tensor& self, int64_t split_size, int64_t di
 inline bool have_same_ndims(TensorList tensors) {
   auto ndim = tensors[0].dim();
   for (const auto tensor_idx : c10::irange(tensors.size())) {
-    if(tensors[tensor_idx].dim() != ndim) {
+    if (tensors[tensor_idx].dim() != ndim) {
       return false;
     }
   }
@@ -67,35 +96,46 @@ inline bool have_same_ndims(TensorList tensors) {
 
 inline void leading_dimension_matches(TensorList tensors, int64_t dim) {
   auto tensor_zero_size = tensors[0].sizes();
-  std::vector<c10::SymInt> leading_dim_sizes(tensor_zero_size.begin(), tensor_zero_size.begin() + dim);
+  std::vector<c10::SymInt> leading_dim_sizes(
+      tensor_zero_size.begin(), tensor_zero_size.begin() + dim);
   for (const auto i : c10::irange(tensors.size())) {
     at::Tensor tensor = tensors[i];
-    for(const auto j : c10::irange(dim)) {
+    for (const auto j : c10::irange(dim)) {
       TORCH_CHECK(
-        tensor.size(j) == leading_dim_sizes[j],
-        "_chunk_cat expects same sizes of 0,...,dim-1 dimensions for all tensors"
-      );
+          tensor.size(j) == leading_dim_sizes[j],
+          "_chunk_cat expects same sizes of 0,...,dim-1 dimensions for all tensors");
     }
   }
 }
 
-inline int64_t preprocess_chunk_cat_inputs(TensorList tensors, int64_t dim, int64_t num_chunks) {
+inline int64_t preprocess_chunk_cat_inputs(
+    TensorList tensors,
+    int64_t dim,
+    int64_t num_chunks) {
   TORCH_CHECK(num_chunks >= 1, "_chunk_cat expects positive num_chunks");
-  TORCH_CHECK(!tensors.empty(),
-           "_chunk_cat expects a non-empty input tensor list");
+  TORCH_CHECK(
+      !tensors.empty(), "_chunk_cat expects a non-empty input tensor list");
   auto expected_dtype = tensors[0].dtype();
   auto expected_device = tensors[0].device();
-  for(const auto i : c10::irange(tensors.size())) {
+  for (const auto i : c10::irange(tensors.size())) {
     TORCH_CHECK(tensors[i].numel() > 0, "_chunk_cat expects non-empty tensor");
-    TORCH_CHECK(tensors[i].dtype() == expected_dtype, "_chunk_cat expects all input tensors with the same dtype");
-    TORCH_CHECK(tensors[i].device() == expected_device, "_chunk_cat expects all inputs tensors on the same device");
+    TORCH_CHECK(
+        tensors[i].dtype() == expected_dtype,
+        "_chunk_cat expects all input tensors with the same dtype");
+    TORCH_CHECK(
+        tensors[i].device() == expected_device,
+        "_chunk_cat expects all inputs tensors on the same device");
   }
   if (have_same_ndims(tensors)) {
     dim = maybe_wrap_dim(dim, tensors[0].dim());
   } else {
-    TORCH_CHECK(dim >= 0, "_chunk_cat expects non-negative dim when input tensors have different ndims")
-    for(const auto i : c10::irange(tensors.size())) {
-      TORCH_CHECK(dim < tensors[i].ndimension(), "_chunk_cat expects dim < ndim for all input tensors");
+    TORCH_CHECK(
+        dim >= 0,
+        "_chunk_cat expects non-negative dim when input tensors have different ndims")
+    for (const auto i : c10::irange(tensors.size())) {
+      TORCH_CHECK(
+          dim < tensors[i].ndimension(),
+          "_chunk_cat expects dim < ndim for all input tensors");
     }
   }
   leading_dimension_matches(tensors, dim);

--- a/aten/src/ATen/native/TensorTransformations.h
+++ b/aten/src/ATen/native/TensorTransformations.h
@@ -10,16 +10,21 @@
 
 namespace at::native {
 
-static inline Tensor roll_common(const Tensor& self, IntArrayRef shifts, IntArrayRef dims) {
+static inline Tensor roll_common(
+    const Tensor& self,
+    IntArrayRef shifts,
+    IntArrayRef dims) {
   TORCH_CHECK(!shifts.empty(), "`shifts` required");
   if (dims.empty() && shifts.size() == 1) {
     auto flattened = self.contiguous().view(self.numel());
     return roll(flattened, shifts[0], 0).view(self.sizes());
   }
   TORCH_CHECK(
-    shifts.size() == dims.size(),
-    "shifts and dimensions must align. shifts: ", shifts.size(), ", dims:", dims.size()
-  );
+      shifts.size() == dims.size(),
+      "shifts and dimensions must align. shifts: ",
+      shifts.size(),
+      ", dims:",
+      dims.size());
   AT_ASSERT(dims.size() > 1);
   auto tail_shifts = shifts.slice(1);
   auto tail_dims = dims.slice(1);
@@ -27,4 +32,4 @@ static inline Tensor roll_common(const Tensor& self, IntArrayRef shifts, IntArra
   return at::roll(first_dim_rolled, tail_shifts, tail_dims);
 }
 
-}  // namespace at::native
+} // namespace at::native


### PR DESCRIPTION
These files are relatively stable, so it should be safe to format them without incurring conflicts

cc @albanD