### PR TITLE
[AOTI] Fix an autotune block grid computation issue

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -723,6 +723,11 @@ class TritonTemplateKernel(TritonKernel):
                 name,
                 call_args,
                 grid=self.grid_fn(*grid),
+                # Calling self.grid_fn(*grid) already computes grid as a tuple,
+                # so we need to explicitly set grid_fn as empty here. Otherwise, the
+                # generated wrapper code will wrap the tuple as grid(tuple), which can
+                # cause incorrect grid computation in some corner cases.
+                grid_fn="",
                 arg_types=arg_types,
                 triton_meta=self.triton_meta,
             )


### PR DESCRIPTION
Summary: There is a grid computation issue after switching to one-pass codegen in https://github.com/pytorch/pytorch/pull/141980. When max-autotune is turned on, there is an incorrect grid codegen in some cases.

Reviewed By: henrylhtsang

Differential Revision: D67120987




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang @aakhundov