### PR TITLE
Align CPU behavior with CUDA for `ConvTranspose` when `out_channels=0`

### DIFF
--- a/aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp
+++ b/aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp
@@ -78,8 +78,8 @@ static inline void slow_conv_transpose2d_shape_check(
 
   if (weight.defined()) {
     TORCH_CHECK(
-        weight.numel() != 0 && (weight.dim() == 2 || weight.dim() == 4),
-        "non-empty 2D or 4D weight tensor expected, but got: ",
+        (weight.dim() == 2 || weight.dim() == 4),
+        "2D or 4D weight tensor expected, but got: ",
         weight.sizes());
     if (bias.defined()) {
       check_dim_size(bias, 1, 0, weight.size(1));

--- a/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp
+++ b/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp
@@ -98,8 +98,8 @@ static inline void slow_conv_transpose3d_shape_check(
   if (weight.defined()) {
     /* TODO: TORCH_CHECK just have 2 args: condition and message */
     TORCH_CHECK(
-        weight.numel() != 0 && weight.dim() == 5,
-        "non-empty 5D (n_output_plane x n_input_plane x kernel_depth",
+        weight.dim() == 5,
+        "5D (n_output_plane x n_input_plane x kernel_depth",
         " x kernel_height x kernel_width) tensor ",
         "expected for weight, but got: ",
         weight.sizes());

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -653,6 +653,32 @@ class TestConvolutionNN(NNTestCase):
                 dtype,
             )
 
+    def test_ConvTranspose_output_channels_0(self):
+        class Model(nn.Module):
+            def __init__(self, operator, dim):
+                super().__init__()
+                self.op = eval(
+                    f"torch.nn.{operator}{dim}d(in_channels=1, out_channels=0, kernel_size={tuple([1] * dim)})"
+                )
+
+            def forward(self, x):
+                x = self.op(x)
+                return x
+
+        for dim in [1, 2, 3]:
+            x = torch.randn([1] * (dim + 1))
+            model = Model("ConvTranspose", dim)
+            y = model(x)
+            self.assertEqual(
+                y.size(),
+                tuple(
+                    [
+                        0,
+                    ]
+                    + [1] * dim
+                ),
+            )
+
     def test_ConvTranspose2d_output_size(self):
         m = nn.ConvTranspose2d(3, 4, 3, 3, 0, 2)
         i = torch.randn(2, 3, 6, 6)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143101

