### PR TITLE
[WIP] Add definition interval [a,b] to Beta distribution instead of forcing [0,1] 

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -177,10 +177,14 @@ def _get_examples():
                 {
                     "concentration1": torch.randn(2, 3).exp().requires_grad_(),
                     "concentration0": torch.randn(2, 3).exp().requires_grad_(),
+                    "low": torch.zeros(2, 3).requires_grad_(),
+                    "high": torch.ones(2, 3).requires_grad_()
                 },
                 {
                     "concentration1": torch.randn(4).exp().requires_grad_(),
                     "concentration0": torch.randn(4).exp().requires_grad_(),
+                    "low": torch.zeros(4).requires_grad_(),
+                    "high": torch.ones(4).requires_grad_()
                 },
             ],
         ),
@@ -6734,6 +6738,8 @@ class TestJit(DistributionsTestCase):
                 param["low"] = param["low"] - torch.rand(param["low"].shape)
                 param["high"] = param["high"] + torch.rand(param["high"].shape)
                 values = [param[key] for key in keys]
+            elif Dist is Beta:
+                pass
             else:
                 values = [
                     self._perturb_tensor(

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -186,6 +186,12 @@ def _get_examples():
                     "low": torch.zeros(4).requires_grad_(),
                     "high": torch.ones(4).requires_grad_()
                 },
+                {
+                    "concentration1": torch.randn(3, 2).exp().requires_grad_(),
+                    "concentration0": torch.randn(3, 2).exp().requires_grad_(),
+                    "low": -3 * torch.ones(3, 2).requires_grad_(),
+                    "high": +2 * torch.ones(3, 2).requires_grad_()
+                },
             ],
         ),
         Example(
@@ -6733,13 +6739,11 @@ class TestJit(DistributionsTestCase):
 
     def _perturb(self, Dist, keys, values, sample):
         with torch.no_grad():
-            if Dist is Uniform:
+            if Dist is Uniform or Dist is Beta:
                 param = dict(zip(keys, values))
                 param["low"] = param["low"] - torch.rand(param["low"].shape)
                 param["high"] = param["high"] + torch.rand(param["high"].shape)
                 values = [param[key] for key in keys]
-            elif Dist is Beta:
-                pass
             else:
                 values = [
                     self._perturb_tensor(

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -3828,12 +3828,12 @@ class TestDistributions(DistributionsTestCase):
             x = dist.sample()
             dirichlet_sample = (x - low) / scale
             #TODO numerical instabilities that needs to be fixed
-            if dirichlet_sample > 1 - 1e-5 or dirichlet_sample < 1e-5:
+            if dirichlet_sample > 1 - 1e-4 or dirichlet_sample < 1e-4:
                 continue
             actual_log_prob = dist.log_prob(x).sum()
             expected_log_prob = scipy.stats.beta.logpdf(x, con1, con0, loc=low, scale=scale)
             self.assertEqual(
-                float(actual_log_prob), float(expected_log_prob), atol=1e-2, rtol=0
+                float(actual_log_prob), float(expected_log_prob), atol=1e-3*scale, rtol=0
             )
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
@@ -5394,7 +5394,7 @@ class TestKL(DistributionsTestCase):
             Binomial(torch.tensor([3, 4]), torch.tensor([0.4, 0.6])),
             Binomial(torch.tensor([3, 4]), torch.tensor([0.5, 0.8])),
         )
-        beta = pairwise(Beta, [1.0, 2.5, 1.0, 2.5], [1.5, 1.5, 3.5, 3.5])
+        beta = pairwise(Beta, [1.0, 2.5, 1.0, 2.5], [1.5, 1.5, 3.5, 3.5], [0.0, 3.0, 0.0, -1.0], [1.0, 4.0, 0.5, 2.0])
         categorical = pairwise(
             Categorical,
             [[0.4, 0.3, 0.3], [0.2, 0.7, 0.1], [0.33, 0.33, 0.34], [0.2, 0.2, 0.6]],

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -109,7 +109,7 @@ class Beta(ExponentialFamily):
         return self._dirichlet.log_prob(heads_tails)
 
     def entropy(self):
-        return self._dirichlet.entropy() + torch.log(self.scale)
+        return self._dirichlet.entropy()
 
     @property
     def concentration1(self):

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -38,12 +38,12 @@ from .uniform import Uniform
 from .utils import _sum_rightmost, euler_constant as _euler_gamma
 
 
-_KL_REGISTRY: Dict[
-    Tuple[Type, Type], Callable
-] = {}  # Source of truth mapping a few general (type, type) pairs to functions.
-_KL_MEMOIZE: Dict[
-    Tuple[Type, Type], Callable
-] = {}  # Memoized version mapping many specific (type, type) pairs to functions.
+_KL_REGISTRY: Dict[Tuple[Type, Type], Callable] = (
+    {}
+)  # Source of truth mapping a few general (type, type) pairs to functions.
+_KL_MEMOIZE: Dict[Tuple[Type, Type], Callable] = (
+    {}
+)  # Memoized version mapping many specific (type, type) pairs to functions.
 
 __all__ = ["register_kl", "kl_divergence"]
 
@@ -224,7 +224,8 @@ def _kl_beta_beta(p, q):
     t3 = (p.concentration1 - q.concentration1) * torch.digamma(p.concentration1)
     t4 = (p.concentration0 - q.concentration0) * torch.digamma(p.concentration0)
     t5 = (sum_params_q - sum_params_p) * torch.digamma(sum_params_p)
-    return t1 - t2 + t3 + t4 + t5
+    t6 = torch.log(p.scale / q.scale)
+    return t1 - t2 + t3 + t4 + t5 + t6
 
 
 @register_kl(Binomial, Binomial)

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -198,3 +198,28 @@ def vec_to_tril_matrix(vec: torch.Tensor, diag: int = 0) -> torch.Tensor:
     tril_mask = arange < arange.view(-1, 1) + (diag + 1)
     mat[..., tril_mask] = vec
     return mat
+
+def is_identically_zero(x):
+    """
+    Check if argument is exactly the number zero. True for the number zero;
+    false for other numbers; false for :class:`~torch.Tensor`s.
+    """
+    if isinstance(x, Number):
+        return x == 0
+    if not torch._C._get_tracing_state():
+        if isinstance(x, torch.Tensor) and x.dtype == torch.int64 and not x.shape:
+            return x.item() == 0
+    return False
+
+
+def is_identically_one(x):
+    """
+    Check if argument is exactly the number one. True for the number one;
+    false for other numbers; false for :class:`~torch.Tensor`s.
+    """
+    if isinstance(x, Number):
+        return x == 1
+    if not torch._C._get_tracing_state():
+        if isinstance(x, torch.Tensor) and x.dtype == torch.int64 and not x.shape:
+            return x.item() == 1
+    return False


### PR DESCRIPTION
Fixes #142825
This PR extends the  Beta distribution with two additional parameters "high" and "low".
`  def __init__(
        self, concentration1, concentration0, low=0.0, high=1.0, validate_args=None
    )` 
The Beta distribution can be defined on custom intervals and not only on [0,1], like it is possible to do with scipy.stats.beta.
I am facing some numerical instabilities, I will try to fix the problem in the next days.


cc @fritzo @neerajprad @alicanb @nikitaved