### PR TITLE
check tensor grad requirement before dispatching

### DIFF
--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -315,6 +315,9 @@ static T dispatch_to(const Tensor & self) {
   pybind11::gil_scoped_release no_gil;
   OptionalDeviceGuard device_guard(device_of(self));
   TORCH_CHECK_VALUE(self.sym_numel() == 1, "only one element tensors can be converted to Python scalars");
+  TORCH_CHECK(
+        !(at::GradMode::is_enabled() && self.requires_grad()),
+        "Can't dispatch a Tensor that requires grad. Use tensor.detach() first.");
   return self.template item<T>();
 }
 


### PR DESCRIPTION
Fixes #143071 

Before, dispatching disregarded whether tensor had a requires_grad or not. Now if we dispatch such a tensor, it will ask user to detach the tensor first so we avoid unexpected errors such as the one listed in the issue. This is already done for numpy. For example if we do this:
```
import numpy as np
import torch


x = torch.tensor(2.0, requires_grad=True)
np.log2(x)
```
It gives an error:
`RuntimeError: Can't call numpy() on Tensor that requires grad. Use tensor.detach().numpy() instead.`

But for:
```
import math
import torch


x = torch.tensor(2.0, requires_grad=True)
math.log2(x)
```
No error