### PR TITLE
Fix potentially undefined behaviour in index_put sample input

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -948,7 +948,7 @@ def mps_ops_modifier(ops):
         # See https://github.com/pytorch/pytorch/issues/111479
         'nn.functional.multi_head_attention_forward': [torch.float32, torch.float16, torch.bfloat16],
 
-        'index_put': [torch.bool, torch.uint8, torch.int8, torch.int16, torch.int64,torch.float16, torch.bfloat16],
+        'index_put': [torch.bool, torch.uint8, torch.int8, torch.int16, torch.int64, torch.float16, torch.bfloat16],
         # zero to negative integer powers are undefined
         '__rpow__': [torch.int8, torch.int16, torch.int32, torch.int64],
         'resize_': [torch.float16, torch.float32, torch.bfloat16],

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -948,8 +948,6 @@ def mps_ops_modifier(ops):
         # See https://github.com/pytorch/pytorch/issues/111479
         'nn.functional.multi_head_attention_forward': [torch.float32, torch.float16, torch.bfloat16],
 
-        # duplicate indices are used in the testcase - undefined behaviour
-        'index_put': None,
         # zero to negative integer powers are undefined
         '__rpow__': [torch.int8, torch.int16, torch.int32, torch.int64],
         'resize_': [torch.float16, torch.float32, torch.bfloat16],

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -948,6 +948,7 @@ def mps_ops_modifier(ops):
         # See https://github.com/pytorch/pytorch/issues/111479
         'nn.functional.multi_head_attention_forward': [torch.float32, torch.float16, torch.bfloat16],
 
+        'index_put': [torch.bool, torch.uint8, torch.int8, torch.int16, torch.int64,torch.float16, torch.bfloat16],
         # zero to negative integer powers are undefined
         '__rpow__': [torch.int8, torch.int16, torch.int32, torch.int64],
         'resize_': [torch.float16, torch.float32, torch.bfloat16],

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3287,8 +3287,9 @@ def sample_inputs_index_put(op_info, device, dtype, requires_grad, **kwargs):
         # Test with indices arg
         yield SampleInput(
             make_arg((S, S,)),
-            (index_variable(2, S, device=device),),
-            make_arg((2, S)),
+            # As defined in the docs, if accumulate is false, duplicate indices are not supported
+            (index_variable(2 if accumulate else 1, S, device=device),),
+            make_arg((2 if accumulate else 1, S)),
             accumulate=accumulate)
 
         # Test with mask arg


### PR DESCRIPTION
From the [docs](https://pytorch.org/docs/stable/generated/torch.Tensor.index_put_.html) for index_put_: 

> If accumulate is True, the elements in values are added to self. If accumulate is False, the behavior is undefined if indices contain duplicate elements.

Currently the sample inputs for `index_put` generates 2 indices. Because they are generated randomly, they could be the same leading to undefined behaviour if `accumulate=False`.

This PR changes the input generation to only generate a single index if `accumulate=False` preventing duplicate indices and undefined behaviour.
