### PR TITLE
Enable lintrunner dependency on s390x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ filelock
 fsspec
 hypothesis
 jinja2
-lintrunner ; platform_machine != "s390x"
+lintrunner
 networkx
 ninja
 numpy


### PR DESCRIPTION
New lintrunner failed to build due to old rust/cargo on builders

Fixes #142872
