### PR TITLE
[CI] Run aarch64 tests on Graviton3

### DIFF
--- a/.github/workflows/linux-aarch64.yml
+++ b/.github/workflows/linux-aarch64.yml
@@ -41,6 +41,10 @@ jobs:
           { config: "default", shard: 2, num_shards: 4, runner: "linux.arm64.2xlarge" },
           { config: "default", shard: 3, num_shards: 4, runner: "linux.arm64.2xlarge" },
           { config: "default", shard: 4, num_shards: 4, runner: "linux.arm64.2xlarge" },
+          { config: "default", shard: 1, num_shards: 3, runner: "linux.arm64.m7g.4xlarge" },
+          { config: "default", shard: 2, num_shards: 3, runner: "linux.arm64.m7g.4xlarge" },
+          { config: "default", shard: 3, num_shards: 3, runner: "linux.arm64.m7g.4xlarge" },
+          
         ]}
     secrets: inherit
 

--- a/.github/workflows/linux-aarch64.yml
+++ b/.github/workflows/linux-aarch64.yml
@@ -44,7 +44,6 @@ jobs:
           { config: "default", shard: 1, num_shards: 3, runner: "linux.arm64.m7g.4xlarge" },
           { config: "default", shard: 2, num_shards: 3, runner: "linux.arm64.m7g.4xlarge" },
           { config: "default", shard: 3, num_shards: 3, runner: "linux.arm64.m7g.4xlarge" },
-          
         ]}
     secrets: inherit
 

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -662,6 +662,9 @@ class TestPatternMatcher(TestPatternMatcherBase):
             generated_kernel_count = cal_conv_generated_kernel_number(
                 mod, v, dtype, dim
             )
+            # TODO: Removeme, when https://github.com/pytorch/pytorch/issues/143146 is fixed
+            if TEST_ACL and dtype == torch.bfloat16 and memory_format != torch.contiguous_format:
+                continue
             self.assertEqual(metrics.generated_kernel_count, generated_kernel_count)
 
     @skipIfNoDynamoSupport

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -298,7 +298,12 @@ class TestPatternMatcher(TestPatternMatcherBase):
             generated_kernel_count = cal_conv_generated_kernel_number(
                 mod, v, dtype, dim
             )
-            if TEST_ACL and dtype == torch.bfloat16 and memory_format != torch.contiguous_format:
+            # TODO: Remove when https://github.com/pytorch/pytorch/issues/143146 is fixed
+            if (
+                TEST_ACL
+                and dtype == torch.bfloat16
+                and memory_format != torch.contiguous_format
+            ):
                 continue
             self.assertEqual(metrics.generated_kernel_count, generated_kernel_count)
 
@@ -664,8 +669,12 @@ class TestPatternMatcher(TestPatternMatcherBase):
             generated_kernel_count = cal_conv_generated_kernel_number(
                 mod, v, dtype, dim
             )
-            # TODO: Removeme, when https://github.com/pytorch/pytorch/issues/143146 is fixed
-            if TEST_ACL and dtype == torch.bfloat16 and memory_format != torch.contiguous_format:
+            # TODO: Remove when https://github.com/pytorch/pytorch/issues/143146 is fixed
+            if (
+                TEST_ACL
+                and dtype == torch.bfloat16
+                and memory_format != torch.contiguous_format
+            ):
                 continue
             self.assertEqual(metrics.generated_kernel_count, generated_kernel_count)
 

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -564,7 +564,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
                     torch.bfloat16,
                 ) and self._check_unary_is_decomposed(unary_fn):
                     # Has extra dtype conversion nodes for autocast.
-                    match_nodes += 2
+                    match_nodes += 2 if not TEST_ACL else 0
                 self.assertEqual(
                     counters["inductor"]["mkldnn_unary_fusion_matcher_nodes"],
                     match_nodes,

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -298,6 +298,8 @@ class TestPatternMatcher(TestPatternMatcherBase):
             generated_kernel_count = cal_conv_generated_kernel_number(
                 mod, v, dtype, dim
             )
+            if TEST_ACL and dtype == torch.bfloat16 and memory_format != torch.contiguous_format:
+                continue
             self.assertEqual(metrics.generated_kernel_count, generated_kernel_count)
 
     @skipIfNoDynamoSupport


### PR DESCRIPTION
Which is armv8.6 that has SVE and BF16 capability

mkldnn_pattern_matcher skips are tracked in https://github.com/pytorch/pytorch/issues/143146
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov