### PR TITLE
Add Packer Build job for Windows AMI

### DIFF
--- a/.github/workflows/build-windows-ami.yml
+++ b/.github/workflows/build-windows-ami.yml
@@ -1,0 +1,47 @@
+name: Build Windows AMI
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'pytorch/test-infra branch to build from. (default: main)'
+        required: true
+        default: 'main'
+      skip_create_ami:
+        description: 'Skip creating the AMI (default: false)'
+        required: true
+        default: false
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  PACKER_VERSION: "1.11.2"
+
+jobs:
+  build-windows-ami:
+    runs-on: ubuntu-latest
+    environment: packer-build-env
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: pytorch/test-infra
+          ref: ${{ inputs.branch }}
+
+      - name: Configure AWS Credentials (PyTorch Account)
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::391835788720:role/gha-packer-role
+
+      - name: Setup Packer
+        uses: hashicorp/setup-packer@main
+        with:
+          version: ${{ env.PACKER_VERSION }}
+
+      - name: Packer Build
+        run: |
+          cd aws/ami/windows
+          packer init .
+          packer build -var 'skip_create_ami=${{ inputs.skip_create_ami }}' .


### PR DESCRIPTION
Add a job to create Windows AMIs in the PyTorch AWS Account.

Issue: pytorch/test-infra#5992