### PR TITLE
[Inductor] Fix cooperative reduction tests broken in recent refactor

### DIFF
--- a/test/inductor/test_cooperative_reductions.py
+++ b/test/inductor/test_cooperative_reductions.py
@@ -146,12 +146,12 @@ class TestFixedConfigs(TestCase):
     @parametrize(
         "persistent,cooperative,cfg",
         [
-            (False, False, {"XBLOCK": 1, "RBLOCK": 128}),
-            (False, False, {"XBLOCK": 2, "RBLOCK": 128}),
+            (False, False, {"XBLOCK": 1, "R0_BLOCK": 128}),
+            (False, False, {"XBLOCK": 2, "R0_BLOCK": 128}),
             (True, False, {"XBLOCK": 1}),
             (True, False, {"XBLOCK": 2}),
-            (False, True, {"XBLOCK": 1, "RBLOCK": 128, "RSPLIT": 16}),
-            (False, True, {"XBLOCK": 2, "RBLOCK": 128, "RSPLIT": 16}),
+            (False, True, {"XBLOCK": 1, "R0_BLOCK": 128, "RSPLIT": 16}),
+            (False, True, {"XBLOCK": 2, "R0_BLOCK": 128, "RSPLIT": 16}),
             (True, True, {"XBLOCK": 1, "RSPLIT": 16}),
             (True, True, {"XBLOCK": 2, "RSPLIT": 16}),
         ],


### PR DESCRIPTION
These tests were broken by https://github.com/pytorch/pytorch/pull/142020. This PR updates the fixed configs accordingly.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov