### PR TITLE
[1/N][Memory Profiling] Add mtia_tracer to store trace entry

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -369,9 +369,7 @@ core_sources_full_mobile_no_backend_interface_xplat = [
     "torch/csrc/jit/tensorexpr/types.cpp",
     "torch/csrc/jit/tensorexpr/unique_name_manager.cpp",
     "torch/csrc/jit/testing/file_check.cpp",
-    "torch/csrc/profiler/unwind/unwind.cpp",
     "torch/csrc/profiler/unwind/unwind_fb.cpp",
-    "torch/csrc/profiler/combined_traceback.cpp",
     "torch/csrc/jit/testing/hooks_for_testing.cpp",
     "torch/csrc/utils/cpp_stacktraces.cpp",
     "torch/csrc/utils/schema_info.cpp",
@@ -769,6 +767,18 @@ torch_cpp_srcs = [
     "torch/csrc/api/src/xpu.cpp",
 ]
 
+libtorch_memory_profiler_sources = [
+    "torch/csrc/profiler/unwind/unwind.cpp",
+    "torch/csrc/profiler/python/combined_traceback.cpp",
+    "torch/csrc/profiler/combined_traceback.cpp",
+]
+
+libtorch_memory_profiler_headers = [
+    "torch/csrc/profiler/unwind/unwind.h",
+    "torch/csrc/profiler/combined_traceback.h",
+    "torch/csrc/profiler/python/combined_traceback.h",
+]
+
 libtorch_python_cuda_core_sources = [
     "torch/csrc/cuda/Event.cpp",
     "torch/csrc/cuda/Module.cpp",
@@ -901,7 +911,6 @@ libtorch_python_core_sources = [
     "torch/csrc/multiprocessing/init.cpp",
     "torch/csrc/onnx/init.cpp",
     "torch/csrc/profiler/python/init.cpp",
-    "torch/csrc/profiler/python/combined_traceback.cpp",
     "torch/csrc/serialization.cpp",
     "torch/csrc/tensor/python_tensor.cpp",
     "torch/csrc/utils/init.cpp",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143138
* #143149

Design Doc: https://fburl.com/gdoc/47zpuweb
Prototyping:  D66469341

In this diff, we create the data struct for memory profiling, including:
* MTIATraceEntry: Represent each allocation/free operation of mtia_allocator
* RingBuffer: Store the list of mtia trace with fixed size
* SnapshotInfo: Store all data we traced.

Differential Revision: [D66766630](https://our.internmc.facebook.com/intern/diff/D66766630/)