### PR TITLE
[inductor][cpu] Fix bmm b_index for dynamic expressions in inductor autotuner

### DIFF
--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -2206,8 +2206,8 @@ class TestSelectAlgorithmDynamicShapes(_DynamicShapesTestBase):
             def __init__(self):
                 super().__init__()
 
-            def forward(self, x, other):
-                return x @ other.permute(2, 0, 1)
+            def forward(self, x, weight):
+                return x @ weight.permute(2, 0, 1)
 
         counters.clear()
         u = torch.randn(bs, Mdim, Kdim).to(dtype=dtype)

--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -2126,34 +2126,10 @@ class TestSelectAlgorithmDynamicShapes(_DynamicShapesTestBase):
                 view_424 = torch.ops.aten.reshape.default(
                     bmm_36, [arg131_1, 8, 512, 512]
                 )
-                iota_5 = torch.ops.prims.iota.default(
-                    512,
-                    start=0,
-                    step=1,
-                    dtype=torch.int64,
-                    device=torch.device(type="cpu"),
-                    requires_grad=False,
-                )
-                unsqueeze_19 = torch.ops.aten.unsqueeze.default(iota_5, 1)
-                unsqueeze_20 = torch.ops.aten.unsqueeze.default(iota_5, 0)
-                sub_1213 = torch.ops.aten.sub.Tensor(unsqueeze_20, unsqueeze_19)
-                gt_1 = torch.ops.aten.gt.Scalar(sub_1213, 0)
-                type_7 = torch.ops.prims.convert_element_type.default(gt_1, torch.int64)
-                mul_4531 = torch.ops.aten.mul.Tensor(type_7, 16)
-                add_5084 = torch.ops.aten.add.Tensor(mul_4531, 0)
-                abs_2 = torch.ops.aten.abs.default(sub_1213)
+                abs_2 = torch.ones(512, 512, dtype=torch.int64)
                 lt_562 = torch.ops.aten.lt.Scalar(abs_2, 8)
-                type_8 = torch.ops.prims.convert_element_type.default(
-                    abs_2, torch.float32
-                )
-                div_22 = torch.ops.aten.div.Tensor(type_8, 8)
-                log_2 = torch.ops.aten.log.default(div_22)
-                div_23 = torch.ops.aten.div.Tensor(log_2, 2.772588722239781)
-                mul_4532 = torch.ops.aten.mul.Tensor(div_23, 8)
-                type_9 = torch.ops.prims.convert_element_type.default(
-                    mul_4532, torch.int64
-                )
-                add_5085 = torch.ops.aten.add.Tensor(type_9, 8)
+                add_5084 = torch.ones(512, 512, dtype=torch.int64)
+                add_5085 = torch.ones(512, 512, dtype=torch.int64)
                 full_default_1 = torch.ops.aten.full.default(
                     [512, 512], 15, dtype=torch.int64, layout=torch.strided
                 )
@@ -2171,11 +2147,7 @@ class TestSelectAlgorithmDynamicShapes(_DynamicShapesTestBase):
                 )
                 add_5087 = torch.ops.aten.add.Tensor(unsqueeze_21, full_default)
                 add_5103 = torch.ops.aten.add.Tensor(view_424, add_5087)
-                view_425 = torch.ops.aten.reshape.default(add_5103, [mul_91, 512, 512])
-                view_426 = torch.ops.aten.reshape.default(
-                    view_425, [arg131_1, 8, 512, 512]
-                )
-                return view_426
+                return add_5103
 
         counters.clear()
         u = torch.randn(bs, 8, 512, 64).to(dtype=dtype)

--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -2077,7 +2077,9 @@ class TestSelectAlgorithmDynamicShapes(_DynamicShapesTestBase):
     @parametrize("Kdim", (96,))
     @parametrize("Ndim", (64, 65))
     @dtypes(torch.float, torch.bfloat16, torch.half)
-    def test_bmm_with_pointwise_with_reshape_dynamic_shapes(self, bs, Mdim, Kdim, Ndim, dtype):
+    def test_bmm_with_pointwise_with_reshape_dynamic_shapes(
+        self, bs, Mdim, Kdim, Ndim, dtype
+    ):
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()

--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -2105,13 +2105,13 @@ class TestSelectAlgorithmDynamicShapes(_DynamicShapesTestBase):
         self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
         self.assertEqual(counters["inductor"]["cpp_epilogue_fusion_counter"], 1)
 
-
     @patches
     @torch.no_grad
     @unittest.skipIf(not TEST_MKL, "Test requires MKL")
     @dtypes(torch.float, torch.bfloat16)
     def test_bmm_epilogue_dynamic_reshape(self, dtype):
         bs = 5
+
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -2119,40 +2119,62 @@ class TestSelectAlgorithmDynamicShapes(_DynamicShapesTestBase):
 
             def forward(self, x, w, arg5_1):
                 arg131_1 = x.shape[0]
-                mul_91 = arg131_1*8
-                view_422: "f32[8*s0, 512, 64]" = torch.ops.aten.reshape.default(x, [mul_91, 512, 64])
-                view_423: "f32[8*s0, 64, 512]" = torch.ops.aten.reshape.default(w, [mul_91, 64, 512])
-                bmm_36: "f32[8*s0, 512, 512]" = torch.ops.aten.bmm.default(view_422, view_423);  view_422 = view_423 = None
-                view_424: "f32[s0, 8, 512, 512]" = torch.ops.aten.reshape.default(bmm_36, [arg131_1, 8, 512, 512]);  bmm_36 = None
-                iota_5: "i64[512]" = torch.ops.prims.iota.default(512, start = 0, step = 1, dtype = torch.int64, device = torch.device(type='cpu'), requires_grad = False)
-                unsqueeze_19: "i64[512, 1]" = torch.ops.aten.unsqueeze.default(iota_5, 1)
-                unsqueeze_20: "i64[1, 512]" = torch.ops.aten.unsqueeze.default(iota_5, 0);  iota_5 = None
-                sub_1213: "i64[512, 512]" = torch.ops.aten.sub.Tensor(unsqueeze_20, unsqueeze_19);  unsqueeze_19 = None
-                gt_1: "b8[512, 512]" = torch.ops.aten.gt.Scalar(sub_1213, 0)
-                convert_element_type_7: "i64[512, 512]" = torch.ops.prims.convert_element_type.default(gt_1, torch.int64);  gt_1 = None
-                mul_4531: "i64[512, 512]" = torch.ops.aten.mul.Tensor(convert_element_type_7, 16);  convert_element_type_7 = None
-                add_5084: "i64[512, 512]" = torch.ops.aten.add.Tensor(mul_4531, 0);  mul_4531 = None
-                abs_2: "i64[512, 512]" = torch.ops.aten.abs.default(sub_1213)
-                lt_562: "b8[512, 512]" = torch.ops.aten.lt.Scalar(abs_2, 8)
-                convert_element_type_8: "f32[512, 512]" = torch.ops.prims.convert_element_type.default(abs_2, torch.float32)
-                div_22: "f32[512, 512]" = torch.ops.aten.div.Tensor(convert_element_type_8, 8);  convert_element_type_8 = None
-                log_2: "f32[512, 512]" = torch.ops.aten.log.default(div_22);  div_22 = None
-                div_23: "f32[512, 512]" = torch.ops.aten.div.Tensor(log_2, 2.772588722239781);  log_2 = None
-                mul_4532: "f32[512, 512]" = torch.ops.aten.mul.Tensor(div_23, 8);  div_23 = None
-                convert_element_type_9: "i64[512, 512]" = torch.ops.prims.convert_element_type.default(mul_4532, torch.int64);  mul_4532 = None
-                add_5085: "i64[512, 512]" = torch.ops.aten.add.Tensor(convert_element_type_9, 8);  convert_element_type_9 = None
-                full_default_1: "i64[512, 512]" = torch.ops.aten.full.default([512, 512], 15, dtype = torch.int64, layout = torch.strided, device = torch.device(type='cpu'), pin_memory = False)
-                minimum_3: "i64[512, 512]" = torch.ops.aten.minimum.default(add_5085, full_default_1);  add_5085 = full_default_1 = None
-                where_2: "i64[512, 512]" = torch.ops.aten.where.self(lt_562, abs_2, minimum_3);  lt_562 = abs_2 = minimum_3 = None
-                add_5086: "i64[512, 512]" = torch.ops.aten.add.Tensor(add_5084, where_2);  add_5084 = where_2 = None
-                embedding_5: "f32[512, 512, 8]" = torch.ops.aten.embedding.default(arg5_1, add_5086);  arg5_1 = add_5086 = None
-                permute_196: "f32[8, 512, 512]" = torch.ops.aten.permute.default(embedding_5, [2, 0, 1]);  embedding_5 = None
-                unsqueeze_21: "f32[1, 8, 512, 512]" = torch.ops.aten.unsqueeze.default(permute_196, 0);  permute_196 = None
-                full_default: "f32[s0, 1, 1, 512]" = torch.ops.aten.full.default([arg131_1, 1, 1, 512], -0.0, dtype = torch.float32, layout = torch.strided, device = torch.device(type='cpu'), pin_memory = False)
-                add_5087: "f32[s0, 8, 512, 512]" = torch.ops.aten.add.Tensor(unsqueeze_21, full_default);  unsqueeze_21 = full_default = None
-                add_5103: "f32[s0, 8, 512, 512]" = torch.ops.aten.add.Tensor(view_424, add_5087);  view_424 = None
-                view_425: "f32[8*s0, 512, 512]" = torch.ops.aten.reshape.default(add_5103, [mul_91, 512, 512]);  add_5103 = None
-                view_426: "f32[s0, 8, 512, 512]" = torch.ops.aten.reshape.default(view_425, [arg131_1, 8, 512, 512]);  view_425 = None
+                mul_91 = arg131_1 * 8
+                view_422 = torch.ops.aten.reshape.default(x, [mul_91, 512, 64])
+                view_423 = torch.ops.aten.reshape.default(w, [mul_91, 64, 512])
+                bmm_36 = torch.ops.aten.bmm.default(view_422, view_423)
+                view_424 = torch.ops.aten.reshape.default(
+                    bmm_36, [arg131_1, 8, 512, 512]
+                )
+                iota_5 = torch.ops.prims.iota.default(
+                    512,
+                    start=0,
+                    step=1,
+                    dtype=torch.int64,
+                    device=torch.device(type="cpu"),
+                    requires_grad=False,
+                )
+                unsqueeze_19 = torch.ops.aten.unsqueeze.default(iota_5, 1)
+                unsqueeze_20 = torch.ops.aten.unsqueeze.default(iota_5, 0)
+                sub_1213 = torch.ops.aten.sub.Tensor(unsqueeze_20, unsqueeze_19)
+                gt_1 = torch.ops.aten.gt.Scalar(sub_1213, 0)
+                type_7 = torch.ops.prims.convert_element_type.default(gt_1, torch.int64)
+                mul_4531 = torch.ops.aten.mul.Tensor(type_7, 16)
+                add_5084 = torch.ops.aten.add.Tensor(mul_4531, 0)
+                abs_2 = torch.ops.aten.abs.default(sub_1213)
+                lt_562 = torch.ops.aten.lt.Scalar(abs_2, 8)
+                type_8 = torch.ops.prims.convert_element_type.default(
+                    abs_2, torch.float32
+                )
+                div_22 = torch.ops.aten.div.Tensor(type_8, 8)
+                log_2 = torch.ops.aten.log.default(div_22)
+                div_23 = torch.ops.aten.div.Tensor(log_2, 2.772588722239781)
+                mul_4532 = torch.ops.aten.mul.Tensor(div_23, 8)
+                type_9 = torch.ops.prims.convert_element_type.default(
+                    mul_4532, torch.int64
+                )
+                add_5085 = torch.ops.aten.add.Tensor(type_9, 8)
+                full_default_1 = torch.ops.aten.full.default(
+                    [512, 512], 15, dtype=torch.int64, layout=torch.strided
+                )
+                minimum_3 = torch.ops.aten.minimum.default(add_5085, full_default_1)
+                where_2 = torch.ops.aten.where.self(lt_562, abs_2, minimum_3)
+                add_5086 = torch.ops.aten.add.Tensor(add_5084, where_2)
+                embedding_5 = torch.ops.aten.embedding.default(arg5_1, add_5086)
+                permute_196 = torch.ops.aten.permute.default(embedding_5, [2, 0, 1])
+                unsqueeze_21 = torch.ops.aten.unsqueeze.default(permute_196, 0)
+                full_default = torch.ops.aten.full.default(
+                    [arg131_1, 1, 1, 512],
+                    -0.0,
+                    dtype=torch.float32,
+                    layout=torch.strided,
+                )
+                add_5087 = torch.ops.aten.add.Tensor(unsqueeze_21, full_default)
+                add_5103 = torch.ops.aten.add.Tensor(view_424, add_5087)
+                view_425 = torch.ops.aten.reshape.default(add_5103, [mul_91, 512, 512])
+                view_426 = torch.ops.aten.reshape.default(
+                    view_425, [arg131_1, 8, 512, 512]
+                )
                 return view_426
 
         counters.clear()
@@ -2170,6 +2192,37 @@ class TestSelectAlgorithmDynamicShapes(_DynamicShapesTestBase):
             self.common(mod, (u, v, arg5), atol=atol, rtol=rtol)
         self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
         self.assertEqual(counters["inductor"]["cpp_epilogue_fusion_counter"], 1)
+
+    @patches
+    @torch.no_grad
+    @unittest.skipIf(not TEST_MKL, "Test requires MKL")
+    def test_bmm_dynamic_stride(self):
+        bs = 8
+        Mdim = 512
+        dtype = torch.float
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, other):
+                return x.reshape(-1, Mdim, Mdim) @ other.reshape(
+                    Mdim, bs * 16, 64
+                ).permute(1, 0, 2)
+
+        counters.clear()
+        u = torch.randn(bs, 16, Mdim, Mdim).to(dtype=dtype)
+        v = torch.randn(1, bs * Mdim, 2 * Mdim).to(dtype=dtype)
+        torch._dynamo.mark_dynamic(u, 0)
+        torch._dynamo.mark_static(u, 1)
+        torch._dynamo.mark_static(u, 2)
+        torch._dynamo.mark_static(u, 3)
+        torch._dynamo.mark_static(v, 1)
+        torch._dynamo.mark_static(v, 3)
+        mod = M().to(dtype=dtype).eval()
+        with verify(dtype) as (atol, rtol):
+            self.common(mod, (u, v), atol=atol, rtol=rtol)
+        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
 
 
 instantiate_device_type_tests(TestSelectAlgorithm, globals(), only_for="cpu")

--- a/torch/_inductor/codegen/cpp_bmm_template.py
+++ b/torch/_inductor/codegen/cpp_bmm_template.py
@@ -19,7 +19,7 @@ from .cpp_utils import DTYPE_TO_CPP, GemmBlocking
 GEMM_SINGLE_THREAD_MM_STUB = r"""
 {{kernel.def_kernel(
     inputs={"X": X, "W": W},
-    outputs={"Y": Y},
+    outputs={"Y": Y_2d},
     aliases=aliases,
     function_name="single_thread_mm",
     extra_sizevars=BY_sizevars + [b_index],
@@ -28,7 +28,7 @@ GEMM_SINGLE_THREAD_MM_STUB = r"""
 GEMM_THREADED_MM_STUB = r"""
 {{kernel.def_kernel(
     inputs={"X": X, "W": W},
-    outputs={"Y": Y},
+    outputs={"Y": Y_2d},
     aliases=aliases,
     function_name="threaded_mm",
     extra_sizevars=BY_sizevars + [b_index],
@@ -184,9 +184,9 @@ class CppBmmTemplate(CppGemmTemplate):
         BX, BW, BY = options["X"], options["W"], options["Y"]
         options["BX"], options["BW"], options["BY"] = BX, BW, BY
         options["BY_2d"] = options["Y_2d"]
-        for kword in ["X", "W", "Y", "GemmOut", "Y_2d"]:
+        for kword in ["X", "W", "GemmOut", "Y_2d"]:
             options[kword] = kernel.select(options[kword], 0, self.b_index)
-        for kword in ["X", "W", "Y"]:
+        for kword in ["X", "W", "Y_2d"]:
             options[kword + "_dtype"] = DTYPE_TO_CPP[options[kword].dtype]
         options["b_index"] = self.b_index
         options["BY_sizevars"] = [

--- a/torch/_inductor/codegen/cpp_bmm_template.py
+++ b/torch/_inductor/codegen/cpp_bmm_template.py
@@ -180,7 +180,9 @@ class CppBmmTemplate(CppGemmTemplate):
         )
 
         BX, BW, BY = options["X"], options["W"], options["Y"]
-        # Create the BMM size_vars in the kernel
+        # Create the BMM output sizevars in the kernel.
+        # If sizevars are not present before adding the b_index to the kernel, then sizevars
+        # are off by 1 in naming convention, causing compiler errors for some epilogue nodes
         kernel.set_sizevars_with_buffers([BY])
         options["BX"], options["BW"], options["BY"] = BX, BW, BY
         options["BY_2d"] = options["Y_2d"]

--- a/torch/_inductor/codegen/cpp_bmm_template.py
+++ b/torch/_inductor/codegen/cpp_bmm_template.py
@@ -5,8 +5,8 @@ from unittest.mock import patch
 
 import sympy
 
-from .. import ir
 from ...fx.experimental.symbolic_shapes import has_free_symbols
+from .. import ir
 from ..select_algorithm import PartialRender
 from ..virtualized import V
 from .cpp_gemm_template import CppGemmTemplate, GEMM_TEMPLATE

--- a/torch/_inductor/codegen/cpp_bmm_template.py
+++ b/torch/_inductor/codegen/cpp_bmm_template.py
@@ -14,10 +14,13 @@ from .cpp_template_kernel import CppTemplateKernel
 from .cpp_utils import DTYPE_TO_CPP, GemmBlocking
 
 
+# We use BY as the output in order to cause sizevars in the batch dim to be set in the kernel
+# Otherwise, sizevars can be off by 1 in naming convention, causing compiler errors for epilogue nodes
+# with a dynamic size in the non-bmm inputs
 GEMM_SINGLE_THREAD_MM_STUB = r"""
 {{kernel.def_kernel(
     inputs={"X": X, "W": W},
-    outputs={"Y": Y},
+    outputs={"Y": BY},
     aliases=aliases,
     function_name="single_thread_mm",
     extra_sizevars=[b_index],
@@ -26,7 +29,7 @@ GEMM_SINGLE_THREAD_MM_STUB = r"""
 GEMM_THREADED_MM_STUB = r"""
 {{kernel.def_kernel(
     inputs={"X": X, "W": W},
-    outputs={"Y": Y},
+    outputs={"Y": BY},
     aliases=aliases,
     function_name="threaded_mm",
     extra_sizevars=[b_index],
@@ -180,10 +183,6 @@ class CppBmmTemplate(CppGemmTemplate):
         )
 
         BX, BW, BY = options["X"], options["W"], options["Y"]
-        # Create the BMM output sizevars in the kernel.
-        # If sizevars are not present before adding the b_index to the kernel, then sizevars
-        # are off by 1 in naming convention, causing compiler errors for some epilogue nodes
-        kernel.set_sizevars_with_buffers([BY])
         options["BX"], options["BW"], options["BY"] = BX, BW, BY
         options["BY_2d"] = options["Y_2d"]
         for kword in ["X", "W", "Y", "GemmOut", "Y_2d"]:

--- a/torch/_inductor/codegen/cpp_bmm_template.py
+++ b/torch/_inductor/codegen/cpp_bmm_template.py
@@ -181,7 +181,7 @@ class CppBmmTemplate(CppGemmTemplate):
 
         BX, BW, BY = options["X"], options["W"], options["Y"]
         # Create the BMM size_vars in the kernel
-        kernel.size(BY, 0)
+        kernel.set_sizevars_with_buffers([BY])
         options["BX"], options["BW"], options["BY"] = BX, BW, BY
         options["BY_2d"] = options["Y_2d"]
         for kword in ["X", "W", "Y", "GemmOut", "Y_2d"]:

--- a/torch/_inductor/codegen/cpp_bmm_template.py
+++ b/torch/_inductor/codegen/cpp_bmm_template.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 import sympy
 
-from ...fx.experimental.symbolic_shapes import has_free_symbols
 from .. import ir
 from ..select_algorithm import PartialRender
 from ..virtualized import V
@@ -106,7 +105,6 @@ class CppBmmTemplate(CppGemmTemplate):
             should_block_weights=should_block_weights,
             name=name,
         )
-        b = layout.size[0]
         self.b_index = sympy.Symbol("s_b_index", integer=True, nonnegative=True)
 
     @staticmethod

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -851,9 +851,9 @@ class CppGemmTemplate(CppTemplate):
         def normalize_shapes(inputs, layout_or_out):
             new_inputs = list(inputs)
             if not is_mkldnn_wgt and isinstance(new_inputs[1], torch.Tensor):
-                if view_size[0].is_symbol:
+                if has_free_symbols(view_size):
                     # If batch size B is dynamic, we need to infer the batch size from the input
-                    assert all(not dim.is_symbol for dim in view_size[1:])
+                    assert not has_free_symbols(view_size[1:])
                     size = torch.tensor(new_inputs[1].size()).prod()
                     fixed_size = torch.tensor(view_size[1:], dtype=torch.int).prod()
                     view_size[0] = (size // fixed_size).item()

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -6,8 +6,6 @@ from functools import lru_cache
 from typing import Any, Callable, cast, Dict, List, Optional, Union
 from unittest.mock import patch
 
-import sympy
-
 import torch
 import torch.utils
 from torch.utils._ordered_set import OrderedSet
@@ -854,23 +852,10 @@ class CppGemmTemplate(CppTemplate):
             new_inputs = list(inputs)
             if not is_mkldnn_wgt and isinstance(new_inputs[1], torch.Tensor):
                 if has_free_symbols(view_size):
-                    # If batch size B is dynamic, we need to infer the batch size from the input
+                    # If batch size B is dynamic, we need to set the batch size and possibly stride
                     assert not has_free_symbols(view_size[1:])
-                    size = torch.tensor(new_inputs[1].size()).prod()
-                    fixed_size = torch.tensor(view_size[1:], dtype=torch.int).prod()
-                    eq = sympy.Eq(view_size[0], int(size // fixed_size))
-                    view_size[0] = (size // fixed_size).item()
-
-                    # solve for any free symbols, since they might exist in stride (in HF XLNetLMHeadModel dynamic case)
-                    free_symbols_prod = math.prod(eq.free_symbols)
-                    free_symbols_equivalent = sympy.solve(eq, free_symbols_prod)[0]
-                    if has_free_symbols(view_stride):
-                        for i, sym in enumerate(view_stride):
-                            if has_free_symbols((sym,)):
-                                view_stride[i] = sym.xreplace(
-                                    {free_symbols_prod: free_symbols_equivalent}
-                                )
-
+                    view_size[:] = V.graph.sizevars.size_hints(view_size)
+                    view_stride[:] = V.graph.sizevars.size_hints(view_stride)
                 # With the assumptation that W is the storage of unwrap view
                 # thus view it back here
                 new_inputs[1] = new_inputs[1].as_strided(

--- a/torch/_inductor/codegen/cpp_template_kernel.py
+++ b/torch/_inductor/codegen/cpp_template_kernel.py
@@ -98,9 +98,7 @@ class CppTemplateKernel(CppKernel):
         )
         sizevars = sorted(unique_sizevars, key=str)
         for sizevar in sizevars:
-            # For BMM, ensure that sizevars from previous codegen are not overwritten
-            if sizevar not in self.args.sizevars:
-                self.args.sizevars[sizevar] = f"k{sizevar}"
+            self.args.sizevars[sizevar] = f"k{sizevar}"
 
         def hook():
             # remove all aliases before generate function definition

--- a/torch/_inductor/codegen/cpp_template_kernel.py
+++ b/torch/_inductor/codegen/cpp_template_kernel.py
@@ -1,6 +1,6 @@
 # mypy: allow-untyped-defs
 import itertools
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import sympy
 from sympy.parsing.sympy_parser import parse_expr
@@ -52,6 +52,31 @@ class CppTemplateKernel(CppKernel):
             template.render(kernel=self, **kwargs), self.render_hooks
         ).finalize_all()
 
+    def set_sizevars_with_buffers(
+        self,
+        *all_buffers: Iterable[ir.Buffer],
+        extra_sizevars: Optional[List[sympy.Expr]] = None,
+    ) -> None:
+        unique_sizevars = OrderedSet()
+        for buffers in all_buffers:
+            unique_sizevars.update(
+                s
+                for buf in buffers
+                if buf is not None
+                for sym in itertools.chain(buf.get_size(), buf.get_stride())
+                if isinstance(sym, sympy.Expr)
+                for s in sym.free_symbols
+            )
+        unique_sizevars.update(
+            s
+            for sym in extra_sizevars or []
+            if isinstance(sym, sympy.Expr)
+            for s in sym.free_symbols
+        )
+        sizevars = sorted(unique_sizevars, key=str)
+        for sizevar in sizevars:
+            self.args.sizevars[sizevar] = f"k{sizevar}"
+
     def def_kernel(
         self,
         inputs: Dict[str, ir.Buffer],
@@ -75,30 +100,7 @@ class CppTemplateKernel(CppKernel):
                 if orig in self.args.output_buffers:
                     self.args.output_buffers[alias] = self.args.output_buffers[orig]
 
-        unique_sizevars = OrderedSet(
-            s
-            for input in inputs.values()
-            if input is not None
-            for sym in itertools.chain(input.get_size(), input.get_stride())
-            if isinstance(sym, sympy.Expr)
-            for s in sym.free_symbols
-        )
-        unique_sizevars.update(
-            s
-            for sym in extra_sizevars or []
-            if isinstance(sym, sympy.Expr)
-            for s in sym.free_symbols
-        )
-        unique_sizevars.update(
-            s
-            for output in outputs.values()
-            for sym in itertools.chain(output.get_size(), output.get_stride())
-            if isinstance(sym, sympy.Expr)
-            for s in sym.free_symbols
-        )
-        sizevars = sorted(unique_sizevars, key=str)
-        for sizevar in sizevars:
-            self.args.sizevars[sizevar] = f"k{sizevar}"
+        self.set_sizevars_with_buffers(inputs.values(), outputs.values(), extra_sizevars=extra_sizevars)
 
         def hook():
             # remove all aliases before generate function definition

--- a/torch/_inductor/codegen/cpp_template_kernel.py
+++ b/torch/_inductor/codegen/cpp_template_kernel.py
@@ -57,7 +57,7 @@ class CppTemplateKernel(CppKernel):
         *all_buffers: Iterable[ir.Buffer],
         extra_sizevars: Optional[List[sympy.Expr]] = None,
     ) -> None:
-        unique_sizevars = OrderedSet()
+        unique_sizevars: OrderedSet[sympy.Expr] = OrderedSet()
         for buffers in all_buffers:
             unique_sizevars.update(
                 s
@@ -100,7 +100,9 @@ class CppTemplateKernel(CppKernel):
                 if orig in self.args.output_buffers:
                     self.args.output_buffers[alias] = self.args.output_buffers[orig]
 
-        self.set_sizevars_with_buffers(inputs.values(), outputs.values(), extra_sizevars=extra_sizevars)
+        self.set_sizevars_with_buffers(
+            inputs.values(), outputs.values(), extra_sizevars=extra_sizevars
+        )
 
         def hook():
             # remove all aliases before generate function definition


### PR DESCRIPTION
Fixes #143102 

Addresses 2 problems relating to dynamic batch size in BMM autotuner:
1. With dynamic batch size, when the input is a sympy Mult expression, such as `s0*8` which occurs in many dynamo benchmark models. We address this by using `size_hints` to solve for any expressions. This is safe since this section of the code is only called to generate inputs for benchmarking.
2. Some epilogue nodes may use the dynamic batch size as part of the codegen, for example when an input to the epilogue node is transposed and has dynamic batch size in the stride of other dimensions. When these epilogue nodes exist, if the sizevar is not already present in the `kernel.args`, it will create a new sizevar with a name. It is possible that subsequent calls to `def_kernel` could overwrite this variable name, so to avoid this we pass all the sizevars as `extra_sizevars` to the calls to `def_kernel` for the GEMM functions, so no variable renaming happens later in the BMM definition.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov