### PR TITLE
Require Config to have a default

### DIFF
--- a/torch/testing/_internal/fake_config_module.py
+++ b/torch/testing/_internal/fake_config_module.py
@@ -20,7 +20,7 @@ magic_cache_config_ignored = True
 # [@compile_ignored: debug]
 e_compile_ignored = True
 e_config = Config(default=True)
-e_jk = Config(justknob="does_not_exist")
+e_jk = Config(justknob="does_not_exist", default=True)
 e_jk_false = Config(justknob="does_not_exist", default=False)
 e_env_default = Config(env_name_default="ENV_TRUE", default=False)
 e_env_default_FALSE = Config(env_name_default="ENV_FALSE", default=True)

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -51,7 +51,7 @@ class Config:
             default behaviour. I.e. user overrides take preference.
     """
 
-    default: Any = True
+    default: Any
     justknob: Optional[str] = None
     env_name_default: Optional[str] = None
     env_name_force: Optional[str] = None
@@ -59,7 +59,7 @@ class Config:
 
     def __init__(
         self,
-        default: Any = True,
+        default: Any,
         justknob: Optional[str] = None,
         env_name_default: Optional[str] = None,
         env_name_force: Optional[str] = None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #143152
* #143151
* __->__ #143150


With aliases coming soon, we want to reject alias + default combo, so we need defaults to be passed in. On top of this, this simplifies statically type checking config.

