### PR TITLE
Updates to support Triton tuple-related API breaks

### DIFF
--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -247,11 +247,9 @@ def generate_ttir(
         name: arg for name, arg in ordered_args.items() if not isinstance(arg, Tensor)
     }
 
-    # Build kernel signature -- doesn't include constexpr arguments.
     signature = {
         name: kernel._type_of(kernel._key_of(arg))
         for i, (name, arg) in enumerate(ordered_args.items())
-        if i not in kernel.constexprs
     }
 
     triton._C.libtriton.ir.load_dialects(context)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3246,7 +3246,7 @@ class TritonKernel(SIMDKernel):
         # https://github.com/pytorch/pytorch/issues/120478#issuecomment-1962822307
         # https://github.com/openai/triton/blob/231efe9ed2d200be0f69a07c298e4342b08efe3d/python/triton/runtime/jit.py#L384
         for arg_num in triton_meta["configs"][0].equal_to_1:  # type: ignore[index]
-            triton_meta["constants"][signature[arg_num].name] = 1  # type: ignore[index]
+            triton_meta["constants"][signature[arg_num[0]].name] = 1  # type: ignore[index]
 
         self.triton_meta = triton_meta
 

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -52,8 +52,8 @@ if _is_triton_available():
         ):
             # Prepare the arguments for AttrsDescriptor
             kwargs = {
-                "tt.divisibility": divisible_by_16,
-                "tt.equal_to": equal_to_1,
+                "tt.divisibility": tuple([(i,) for i in divisible_by_16]),
+                "tt.equal_to": tuple([(i,) for i in equal_to_1]),
             }
 
             # Instantiate AttrsDescriptor with the prepared arguments

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -415,10 +415,19 @@ class CachingAutotuner(KernelInterface):
         if not ASTSource:
             raise RuntimeError("Installed triton version too old, please upgrade")
 
+        def fixup_signature(signature, constants):
+            signature = signature.copy()
+            for constant in constants:
+                # If it's not in the signature already, it's a constexpr
+                # argument that we need to add in
+                if constant not in signature:
+                    signature[constant] = "constexpr"
+            return signature
+
         compile_args = (
             ASTSource(
                 self.fn,
-                compile_meta["signature"],
+                fixup_signature(compile_meta["signature"], compile_meta["constants"]),
                 compile_meta["constants"],
                 compile_meta["configs"][0],
             ),


### PR DESCRIPTION
The latest commits to Triton (specifically,
https://github.com/triton-lang/triton/pull/5220) change the API for arguments: hints are now passed in as a tuple of tuples, to match the shape of potential tuple parameters in Triton. While we don't exercise this ourselves, we need to hand it a 1-element tuple for our hints. In addition, ASTNode now takes constants as part of its signature, so plumb those through as well.

This is a draft because it will break compatibility with the currently pinned version. I am sure there is some way to support both but I don't think I am in the right position to decide the best way to do that :)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov