### PR TITLE
Allow Nones in Tensor[] for IValues

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -572,15 +572,15 @@ class TestPythonRegistration(TestCase):
 
     def test_undefined_tensors(self):
         with torch.library._scoped_library(self.test_ns, "FRAGMENT") as lib:
-            lib.define("foo(Tensor[] ts) -> Tensor[]")
+            lib.define("foos(Tensor[] ts) -> Tensor[]")
 
             def foo_impl(ts):
                 return [t.clone() if t is not None else None for t in ts]
 
-            lib.impl("foo", foo_impl, "CompositeImplicitAutograd")
+            lib.impl("foos", foo_impl, "CompositeImplicitAutograd")
 
             ts = [None, torch.randn(3), None, torch.randn(4)]
-            results = foo_impl(ts)
+            results = getattr(torch.ops, self.test_ns).foos(ts)
             self.assertEqual(results, ts)
 
     def test_returning_symint(self) -> None:

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -370,7 +370,7 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
         case TypeKind::BoolType:
           return IValue(py::cast<std::vector<bool>>(obj));
         case TypeKind::TensorType:
-          return IValue(py::cast<std::optional<std::vector<at::Tensor>>>(obj));
+          return IValue(py::cast<std::vector<std::optional<at::Tensor>>>(obj));
         default:
           return createGenericList(obj, elem_type);
       }

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -370,7 +370,7 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
         case TypeKind::BoolType:
           return IValue(py::cast<std::vector<bool>>(obj));
         case TypeKind::TensorType:
-          return IValue(py::cast<std::vector<at::Tensor>>(obj));
+          return IValue(py::cast<std::optional<std::vector<at::Tensor>>>(obj));
         default:
           return createGenericList(obj, elem_type);
       }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143168
* #143167
* #143166

When we parse IValues from Python to C++, we treat Nones as Tensors
(these get parsed into undefined tensors). Before this PR, this logic
only happened for Tensor (and not Tensor[]). For example, we could
create a custom operator foo(Tensor x) and it would accept None as
input.

This PR makes the behavior consistent by extending it to Tensor[].

I need this behavior later on when parsing lists of grad_output which
look like they are List[Tensor] in C++ but become List[Optional[Tensor]]
in Python (because undefined tensor in C++ maps to Python None).

Test Plan:
- new test

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel