### PR TITLE
[Inductor UT] Generalize device-bias code in test_triton_syntax.py.

### DIFF
--- a/test/inductor/test_triton_syntax.py
+++ b/test/inductor/test_triton_syntax.py
@@ -41,7 +41,7 @@ class TestTritonSyntacticallyValid(TestCase):
         model = nn.Sequential(
             nn.Linear(16, 16, bias=False),
             nn.Linear(16, 32, bias=False),
-        ).cuda(device=torch.device(GPU_TYPE))
+        ).to(device=torch.device(GPU_TYPE))
 
         loss = model(torch.randn(4, 16, device=torch.device(GPU_TYPE))).sum()
         loss.backward()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143178

Fix #143177

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov