### PR TITLE
Run inductor-rocm workflow on ciflow/inductor

### DIFF
--- a/.github/workflows/inductor-rocm.yml
+++ b/.github/workflows/inductor-rocm.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/inductor-rocm.yml
+++ b/.github/workflows/inductor-rocm.yml
@@ -1,52 +1,22 @@
 name: inductor-rocm
 
 on:
-  pull_request:
-    paths:
-      # from "ciflow/inductor" in .github/labeler.yml
-      - 'torch/_decomp/**'
-      - 'torch/_dynamo/**'
-      - 'torch/_export/**'
-      - 'torch/_inductor/**'
-      - 'benchmarks/dynamo/**'
-      - 'torch/_subclasses/fake_tensor.py'
-      - 'torch/_subclasses/fake_utils.py'
-      - 'torch/_subclasses/meta_utils.py'
-      - 'test/distributed/test_dynamo_distributed.py'
-      - 'test/distributed/test_inductor_collectives.py'
-      - 'torch/_functorch/_aot_autograd/**'
-      - 'torch/_functorch/aot_autograd.py'
-      - 'torch/_functorch/partitioners.py'
-      - '.ci/docker/ci_commit_pins/**'
-      - '.github/ci_commit_pins/**'
-      - 'c10/core/Sym*'
-      - 'torch/fx/experimental/symbolic_shapes.py'
-      - 'torch/fx/experimental/recording.py'
-      - 'torch/fx/experimental/sym_node.py'
-      - 'torch/fx/experimental/validator.py'
-      - 'torch/fx/experimental/proxy_tensor.py'
-      - 'test/distributed/_tensor/test_dtensor_compile.py'
-      - 'test/distributed/tensor/parallel/test_fsdp_2d_parallel.py'
-      - 'torch/distributed/_tensor/**'
-      - 'torch/distributed/fsdp/**'
-      - 'torch/csrc/inductor/**'
-      - 'test/cpp/aoti_abi_check/**'
-      - 'test/cpp/aoti_inference/**'
-      # from "module: inductor" in .github/labeler.yml
-      - 'test/inductor/**'
   push:
     branches:
       - main
       - release/*
     tags:
       - ciflow/inductor-rocm/*
+      - ciflow/inductor/*
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}-${{ github.event.schedule }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   get-label-type:

--- a/.github/workflows/inductor-rocm.yml
+++ b/.github/workflows/inductor-rocm.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}-${{ github.event.schedule }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
The paths are almost the same as ciflow/inductor.  The only differences I could spot where that ciflow/inductor also has `test/dynamo/**` and `torch/csrc/dynamo/**`

This is to prevent failures like https://github.com/pytorch/pytorch/actions/runs/12304985383/job/34345585535 which fails due to running on a fork, which cannot set the id token.

The other option to prevent this is to stop the job from running when on a fork.

If someone adds both labels, one will be cancelled because they have the same concurrency group

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd