### PR TITLE
[2/N][Memory Profiling] Record memory allocation/free

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -901,7 +901,6 @@ libtorch_python_core_sources = [
     "torch/csrc/multiprocessing/init.cpp",
     "torch/csrc/onnx/init.cpp",
     "torch/csrc/profiler/python/init.cpp",
-    "torch/csrc/profiler/python/combined_traceback.cpp",
     "torch/csrc/serialization.cpp",
     "torch/csrc/tensor/python_tensor.cpp",
     "torch/csrc/utils/init.cpp",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Design Doc: https://fburl.com/gdoc/47zpuweb
Prototyping:  D66469341

In this diff, we implement the logic to record, store and export memory trace which will be involved by mtia hooks later.
* Add RingBuffer<MTIATraceEntry> to mtia_allocator to store trace
* Implement record_trace() to add trace entry for allocation and free
* Add record_histroy_ as enablement flag of profiler and record_histroy() to toggle the state


To avoid the duplicate symbol error, we remove the python/combined_traceback from srcs of C_impl_cuda and add libtorch_memory_profiler to dependency.

Differential Revision: [D66776251](https://our.internmc.facebook.com/intern/diff/D66776251/)