### PR TITLE
Expose remaining sharedMem cudaDeviceProps to python

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1021,8 +1021,7 @@ static void registerCudaDeviceProperties(PyObject* module) {
 #ifndef USE_ROCM
       // NVIDIA-only properties
       .def_readonly(
-          "shared_memory_per_block",
-          &cudaDeviceProp::sharedMemPerBlock)
+          "shared_memory_per_block", &cudaDeviceProp::sharedMemPerBlock)
       .def_readonly(
           "shared_memory_per_block_optin",
           &cudaDeviceProp::sharedMemPerBlockOptin)

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1019,7 +1019,13 @@ static void registerCudaDeviceProperties(PyObject* module) {
           &cudaDeviceProp::maxThreadsPerMultiProcessor)
       .def_readonly("warp_size", &cudaDeviceProp::warpSize)
 #ifndef USE_ROCM
-      // NVIDIA-only property
+      // NVIDIA-only properties
+      .def_readonly(
+          "shared_memory_per_block",
+          &cudaDeviceProp::sharedMemPerBlock)
+      .def_readonly(
+          "shared_memory_per_block_optin",
+          &cudaDeviceProp::sharedMemPerBlockOptin)
       .def_readonly(
           "shared_memory_per_multiprocessor",
           &cudaDeviceProp::sharedMemPerMultiprocessor)


### PR DESCRIPTION
Was a bit too fast with my earlier PR, `sharedMemPerMultiprocessor` includes some memory that is reserved for the system. The amount a kernel can actually use is limited by `sharedMemPerBlockOptin`.

I also expose `sharedMemPerBlock` for completeness.
