### PR TITLE
Remove unnecessary once flag usage

### DIFF
--- a/aten/src/ATen/detail/CUDAHooksInterface.cpp
+++ b/aten/src/ATen/detail/CUDAHooksInterface.cpp
@@ -1,7 +1,4 @@
-#include "c10/util/Registry.h"
 #include <ATen/detail/CUDAHooksInterface.h>
-
-#include <memory>
 
 namespace at {
 namespace detail {

--- a/aten/src/ATen/detail/CUDAHooksInterface.cpp
+++ b/aten/src/ATen/detail/CUDAHooksInterface.cpp
@@ -1,3 +1,4 @@
+#include "c10/util/Registry.h"
 #include <ATen/detail/CUDAHooksInterface.h>
 
 #include <memory>
@@ -22,16 +23,15 @@ namespace detail {
 // you're probably losing only a word (the vptr in the allocated object.)
 
 const CUDAHooksInterface& getCUDAHooks() {
-  auto create_impl= [] {
+  auto create_impl = [] {
 #if !defined C10_MOBILE
-    auto cuda_hooks =
-        CUDAHooksRegistry()->Create("CUDAHooks", CUDAHooksArgs{});
-    if (cuda_hooks) {
-      return cuda_hooks;
+    auto hooks = CUDAHooksRegistry()->Create("CUDAHooks", CUDAHooksArgs{});
+    if (hooks) {
+      return hooks;
     }
 #endif
     return std::make_unique<CUDAHooksInterface>();
-    };
+  };
   // NB: The static initialization here implies that if you try to call any CUDA
   // functionality before libATen_cuda.so is loaded, CUDA is permanently
   // disabled for that copy of ATen.  In principle, we can relax this
@@ -39,8 +39,8 @@ const CUDAHooksInterface& getCUDAHooks() {
   // for an example where we relax this restriction (but if you try to avoid
   // needing a lock, be careful; it doesn't look like Registry.h is thread
   // safe...)
-  static auto cuda_hooks = create_impl();
-  return *cuda_hooks;
+  static auto hooks = create_impl();
+  return *hooks;
 }
 } // namespace detail
 

--- a/aten/src/ATen/detail/HIPHooksInterface.cpp
+++ b/aten/src/ATen/detail/HIPHooksInterface.cpp
@@ -1,9 +1,5 @@
 #include <ATen/detail/HIPHooksInterface.h>
 
-#include <c10/util/Registry.h>
-
-#include <memory>
-
 namespace at {
 namespace detail {
 

--- a/aten/src/ATen/detail/HIPHooksInterface.cpp
+++ b/aten/src/ATen/detail/HIPHooksInterface.cpp
@@ -1,6 +1,5 @@
 #include <ATen/detail/HIPHooksInterface.h>
 
-#include <c10/util/CallOnce.h>
 #include <c10/util/Registry.h>
 
 #include <memory>
@@ -10,21 +9,17 @@ namespace detail {
 
 // See getCUDAHooks for some more commentary
 const HIPHooksInterface& getHIPHooks() {
-  static std::unique_ptr<HIPHooksInterface> hip_hooks;
+  auto create_impl = [] {
 #if !defined C10_MOBILE
-  static c10::once_flag once;
-  c10::call_once(once, [] {
-    hip_hooks = HIPHooksRegistry()->Create("HIPHooks", HIPHooksArgs{});
-    if (!hip_hooks) {
-      hip_hooks = std::make_unique<HIPHooksInterface>();
+    auto hooks = HIPHooksRegistry()->Create("HIPHooks", HIPHooksArgs{});
+    if (hooks) {
+      return hooks;
     }
-  });
-#else
-  if (hip_hooks == nullptr) {
-    hip_hooks = std::make_unique<HIPHooksInterface>();
-  }
 #endif
-  return *hip_hooks;
+    return std::make_unique<HIPHooksInterface>();
+  };
+  static auto hooks = create_impl();
+  return *hooks;
 }
 } // namespace detail
 

--- a/aten/src/ATen/detail/HPUHooksInterface.cpp
+++ b/aten/src/ATen/detail/HPUHooksInterface.cpp
@@ -1,5 +1,4 @@
 #include <ATen/detail/HPUHooksInterface.h>
-#include <memory>
 
 namespace at {
 namespace detail {

--- a/aten/src/ATen/detail/IPUHooksInterface.cpp
+++ b/aten/src/ATen/detail/IPUHooksInterface.cpp
@@ -6,14 +6,14 @@ namespace at {
 namespace detail {
 
 const IPUHooksInterface& getIPUHooks() {
-  static std::unique_ptr<IPUHooksInterface> hooks;
-  static c10::once_flag once;
-  c10::call_once(once, [] {
-    hooks = IPUHooksRegistry()->Create("IPUHooks", IPUHooksArgs{});
-    if (!hooks) {
-      hooks = std::make_unique<IPUHooksInterface>();
+  auto create_impl = [] {
+    auto hooks = IPUHooksRegistry()->Create("IPUHooks", IPUHooksArgs{});
+    if (hooks) {
+      return hooks;
     }
-  });
+    return std::make_unique<IPUHooksInterface>();
+  };
+  static auto hooks = create_impl();
   return *hooks;
 }
 

--- a/aten/src/ATen/detail/IPUHooksInterface.cpp
+++ b/aten/src/ATen/detail/IPUHooksInterface.cpp
@@ -1,7 +1,5 @@
 #include <ATen/detail/IPUHooksInterface.h>
 
-#include <c10/util/CallOnce.h>
-
 namespace at {
 namespace detail {
 

--- a/aten/src/ATen/detail/MAIAHooksInterface.cpp
+++ b/aten/src/ATen/detail/MAIAHooksInterface.cpp
@@ -1,9 +1,5 @@
 #include <ATen/detail/MAIAHooksInterface.h>
 
-#include <c10/util/Registry.h>
-
-#include <memory>
-
 namespace at {
 namespace detail {
 

--- a/aten/src/ATen/detail/MAIAHooksInterface.cpp
+++ b/aten/src/ATen/detail/MAIAHooksInterface.cpp
@@ -1,9 +1,7 @@
 #include <ATen/detail/MAIAHooksInterface.h>
 
-#include <c10/util/CallOnce.h>
 #include <c10/util/Registry.h>
 
-#include <cstddef>
 #include <memory>
 
 namespace at {
@@ -11,15 +9,15 @@ namespace detail {
 
 // See getCUDAHooks for some more commentary
 const MAIAHooksInterface& getMAIAHooks() {
-  static std::unique_ptr<MAIAHooksInterface> maia_hooks;
-  static c10::once_flag once;
-  c10::call_once(once, [] {
-    maia_hooks = MAIAHooksRegistry()->Create("MAIAHooks", {});
-    if (!maia_hooks) {
-      maia_hooks = std::make_unique<MAIAHooksInterface>();
+  auto create_impl = [] {
+    auto hooks = MAIAHooksRegistry()->Create("MAIAHooks", {});
+    if (hooks) {
+      return hooks;
     }
-  });
-  return *maia_hooks;
+    return std::make_unique<MAIAHooksInterface>();
+  };
+  static auto hooks = create_impl();
+  return *hooks;
 }
 } // namespace detail
 

--- a/aten/src/ATen/detail/MPSHooksInterface.cpp
+++ b/aten/src/ATen/detail/MPSHooksInterface.cpp
@@ -7,21 +7,17 @@ namespace at {
 namespace detail {
 
 const MPSHooksInterface& getMPSHooks() {
-  static std::unique_ptr<MPSHooksInterface> mps_hooks;
+  auto create_impl = [] {
 #if !defined C10_MOBILE
-  static c10::once_flag once;
-  c10::call_once(once, [] {
-    mps_hooks = MPSHooksRegistry()->Create("MPSHooks", MPSHooksArgs{});
-    if (!mps_hooks) {
-      mps_hooks = std::make_unique<MPSHooksInterface>();
+    auto hooks = MPSHooksRegistry()->Create("MPSHooks", MPSHooksArgs{});
+    if (hooks) {
+      return hooks;
     }
-  });
-#else
-  if (mps_hooks == nullptr) {
-    mps_hooks = std::make_unique<MPSHooksInterface>();
-  }
 #endif
-  return *mps_hooks;
+    return std::make_unique<MPSHooksInterface>();
+  };
+  static auto hooks = create_impl();
+  return *hooks;
 }
 } // namespace detail
 

--- a/aten/src/ATen/detail/MPSHooksInterface.cpp
+++ b/aten/src/ATen/detail/MPSHooksInterface.cpp
@@ -1,7 +1,6 @@
 //  Copyright © 2022 Apple Inc.
 
 #include <ATen/detail/MPSHooksInterface.h>
-#include <c10/util/CallOnce.h>
 
 namespace at {
 namespace detail {

--- a/aten/src/ATen/detail/MTIAHooksInterface.cpp
+++ b/aten/src/ATen/detail/MTIAHooksInterface.cpp
@@ -1,22 +1,20 @@
 #include <ATen/detail/MTIAHooksInterface.h>
 
-#include <c10/util/CallOnce.h>
-
 #include <memory>
 
 namespace at {
 namespace detail {
 
 const MTIAHooksInterface& getMTIAHooks() {
-  static std::unique_ptr<MTIAHooksInterface> mtia_hooks = nullptr;
-  static c10::once_flag once;
-  c10::call_once(once, [] {
-    mtia_hooks = MTIAHooksRegistry()->Create("MTIAHooks", MTIAHooksArgs{});
-    if (!mtia_hooks) {
-      mtia_hooks = std::make_unique<MTIAHooksInterface>();
+  auto create_impl = [] {
+    auto hooks = MTIAHooksRegistry()->Create("MTIAHooks", MTIAHooksArgs{});
+    if (hooks) {
+      return hooks;
     }
-  });
-  return *mtia_hooks;
+    return std::make_unique<MTIAHooksInterface>();
+  };
+  static auto hooks = create_impl();
+  return *hooks;
 }
 
 bool isMTIAHooksBuilt() {

--- a/aten/src/ATen/detail/MTIAHooksInterface.cpp
+++ b/aten/src/ATen/detail/MTIAHooksInterface.cpp
@@ -1,7 +1,5 @@
 #include <ATen/detail/MTIAHooksInterface.h>
 
-#include <memory>
-
 namespace at {
 namespace detail {
 

--- a/aten/src/ATen/detail/XPUHooksInterface.cpp
+++ b/aten/src/ATen/detail/XPUHooksInterface.cpp
@@ -6,16 +6,15 @@ namespace at {
 namespace detail {
 
 const XPUHooksInterface& getXPUHooks() {
-  static XPUHooksInterface* xpu_hooks = nullptr;
-  static c10::once_flag once;
-  c10::call_once(once, [] {
-    xpu_hooks =
-        XPUHooksRegistry()->Create("XPUHooks", XPUHooksArgs{}).release();
-    if (!xpu_hooks) {
-      xpu_hooks = new XPUHooksInterface();
+  auto create_impl = [] {
+    auto hooks = XPUHooksRegistry()->Create("XPUHooks", XPUHooksArgs{});
+    if (hooks) {
+      return hooks;
     }
-  });
-  return *xpu_hooks;
+    return std::make_unique<XPUHooksInterface>();
+  };
+  static auto hooks = create_impl();
+  return *hooks;
 }
 } // namespace detail
 

--- a/aten/src/ATen/detail/XPUHooksInterface.cpp
+++ b/aten/src/ATen/detail/XPUHooksInterface.cpp
@@ -1,7 +1,5 @@
 #include <ATen/detail/XPUHooksInterface.h>
 
-#include <c10/util/CallOnce.h>
-
 namespace at {
 namespace detail {
 

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1359,8 +1359,11 @@ void Engine::initialize_device_threads_pool() {
       !in_bad_autograd_fork,
       "Unable to handle autograd's threading in combination with fork-based multiprocessing. "
       "See https://github.com/pytorch/pytorch/wiki/Autograd-and-Fork");
-  c10::call_once(
-      start_device_threads_flag_, &Engine::start_device_threads, this);
+  // Ensures device_ready_queues_ are initialized only once
+  static bool start_device_threads_flag_ [[maybe_unused]] = [this]() {
+    this->start_device_threads();
+    return true;
+  }();
 }
 
 c10::intrusive_ptr<at::ivalue::Future> Engine::execute_with_graph_task(

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -230,9 +230,6 @@ struct TORCH_API Engine {
   void reentrant_thread_init();
   void add_thread_pool_task(const std::weak_ptr<GraphTask>& graph_task);
 
-  // Ensures device_ready_queues_ are initialized only once
-  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
-  c10::once_flag start_device_threads_flag_;
   // Safe to read device_ready_queues_ without synchronization after
   // initialization
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)


### PR DESCRIPTION
Static variables in C++11 is guaranteed to be initialised exactly once, as mentioned [here](https://en.cppreference.com/w/cpp/language/storage_duration)
```
If multiple threads attempt to initialize the same static local variable concurrently, 
the initialization occurs exactly once 
(similar behavior can be obtained for arbitrary functions with std::call_once.
Usual implementations of this feature use variants 
of the double-checked locking pattern, 
which reduces runtime overhead for already-initialized local statics
 to a single non-atomic boolean comparison.
```
Given that static c10::once_flag is used before, why not just use the associated function to initialised the related static variables? That is the motivation behind this PR.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o