### PR TITLE
Add support for CPU scalar in addcmul

### DIFF
--- a/aten/src/ATen/native/PointwiseOps.cpp
+++ b/aten/src/ATen/native/PointwiseOps.cpp
@@ -19,7 +19,15 @@ TORCH_META_FUNC(addcmul)
  const Tensor& tensor1,
  const Tensor& tensor2,
  const Scalar& value) {
-  build_ternary_op(maybe_get_output(), self, tensor1, tensor2);
+  build(TensorIteratorConfig()
+      .allow_cpu_scalars(true)
+      .promote_inputs_to_common_dtype(true)
+      .cast_common_dtype_to_outputs(true)
+      .enforce_safe_casting_to_output(true)
+      .add_owned_output(maybe_get_output())
+      .add_owned_const_input(self)
+      .add_owned_const_input(tensor1)
+      .add_owned_const_input(tensor2));
 }
 
 TORCH_META_FUNC(addcdiv)
@@ -40,6 +48,7 @@ TORCH_META_FUNC(addcdiv)
         "The future addcdiv behavior is just the latter implementation: ",
         "(input + value * tensor1 / tensor2), for all dtypes.");
   }
+  // TODO: add support for cpu_scalar in addcdiv
   build_ternary_op(maybe_get_output(), self, tensor1, tensor2);
 }
 

--- a/aten/src/ATen/native/PointwiseOps.cpp
+++ b/aten/src/ATen/native/PointwiseOps.cpp
@@ -48,7 +48,6 @@ TORCH_META_FUNC(addcdiv)
         "The future addcdiv behavior is just the latter implementation: ",
         "(input + value * tensor1 / tensor2), for all dtypes.");
   }
-  // TODO: add support for cpu_scalar in addcdiv
   build_ternary_op(maybe_get_output(), self, tensor1, tensor2);
 }
 

--- a/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
@@ -21,6 +21,18 @@ void addcmul_cuda_scalar_tensor2_kernel(
 constexpr char addcmul_name[] = "addcmul";
 #endif
 void addcmul_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
+  TORCH_CHECK(
+    !iter.is_cpu_scalar(1),
+    "CPU Scalar support for self argument is not supported."
+  );
+
+  TORCH_CHECK(
+    !iter.is_cpu_scalar(2),
+    "CPU Scalar support for tensor1 argument is not supported. "
+    "However, CPU Scalar support for tensor2 is supported, "
+    "please swap your tensor1 and tensor2 terms."
+  );
+
   auto dtype = iter.common_dtype();
   if (at::isComplexType(dtype)) {
     // When using Jiterator, addcmul and addcdiv kernels get stuck during a

--- a/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
@@ -79,7 +79,9 @@ void addcmul_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
   }
 }
 
+#if AT_USE_JITERATOR() && CUDA_VERSION >= 11050
 constexpr char addcmul_scalar_tensor2_name[] = "addcmul_scalar_tensor2";
+#endif
 void addcmul_cuda_scalar_tensor2_kernel(TensorIteratorBase& iter, const Scalar& tensor2_scalar, const Scalar& value) {
   auto dtype = iter.common_dtype();
 

--- a/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
@@ -93,7 +93,7 @@ void addcmul_cuda_scalar_tensor2_kernel(TensorIteratorBase& iter, const Scalar& 
         auto alpha = value.to<scalar_t>();
 
         static const auto addcmul_scalar_tensor2_string = jiterator_stringify(
-          template <typename T> T addcmul_scalar_tensor2(T a, T b, T c, T alpha) { return a + alpha * (c * b); });
+          template <typename T> T addcmul_scalar_tensor2(T a, T b, T c, T alpha) { return a + alpha * (b * c); });
 
         jitted_gpu_kernel<
             /*name=*/addcmul_scalar_tensor2_name,

--- a/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
@@ -23,12 +23,14 @@ constexpr char addcmul_name[] = "addcmul";
 void addcmul_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
   TORCH_CHECK(
     !iter.is_cpu_scalar(1),
-    "CPU Scalar support for self argument is not supported."
+    "CPU Scalar support for self argument is not supported when "
+    "calling addcmul on CUDA tensors."
   );
 
   TORCH_CHECK(
     !iter.is_cpu_scalar(2),
-    "CPU Scalar support for tensor1 argument is not supported. "
+    "CPU Scalar support for tensor1 argument is not supported when "
+    "calling addcmul on CUDA tensors. "
     "However, CPU Scalar support for tensor2 is supported, "
     "please swap your tensor1 and tensor2 terms."
   );

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3273,9 +3273,10 @@ else:
         self.assertTrue(y.stride() == (1, 4))
 
     # FIXME: move to elementwise ternary test suite
+    @parametrize("use_cpu_scalar", [True, False])
     @dtypesIfCUDA(*set(get_all_math_dtypes('cuda')))
     @dtypes(*set(get_all_math_dtypes('cpu')))
-    def test_addcmul(self, device, dtype):
+    def test_addcmul(self, device, dtype, use_cpu_scalar):
         # Returns floating or integral scalar corresponding to dtype
         def _number(floating, integer, dtype):
             if dtype in [torch.half, torch.float, torch.double, torch.bfloat16]:
@@ -3295,7 +3296,10 @@ else:
 
         a = rand_tensor((2, 2), dtype=dtype, device=device)
         b = rand_tensor((2, 2), dtype=dtype, device=device)
-        c = rand_tensor((2, 2), dtype=dtype, device=device)
+        if use_cpu_scalar:
+            c = rand_tensor([], device="cpu", dtype=dtype)
+        else:
+            c = rand_tensor((2, 2), dtype=dtype, device=device)
 
         alpha = _number(0.5, 3, dtype)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3319,7 +3319,7 @@ else:
             out = torch.addcmul(a, b, c, value=-1)
             self.assertTrue(not (out.isnan() or out.isinf()))
 
-    def test_addcmul_cpu_scalar_errors(self, device):
+    def test_addcmul_cpu_scalars(self, device):
         # Logic is dtype agnostic, so dtype isn't tested
         alpha = 0.5
 
@@ -3328,20 +3328,18 @@ else:
         c = torch.rand((2, 2), device=device)
         scalar = torch.rand([], device="cpu")
 
-        torch.addcmul(a, b, c, value=alpha)
-        torch.addcmul(a, b, scalar, value=alpha)  # supported on both
-
         if device == "cpu":
-            torch.addcmul(a, scalar, c, value=alpha)
-            torch.addcmul(scalar, b, c, value=alpha)
-        elif device == "cuda:0":
+            self.assertEqual(torch.addcmul(a, scalar, c, value=alpha),
+                             a + scalar * c * alpha)
+            self.assertEqual(torch.addcmul(a, scalar, c, value=alpha),
+                             a + scalar * c * alpha)
+        elif device[0:4] == "cuda":
             with self.assertRaisesRegex(RuntimeError, r'CPU Scalar support for tensor1 argument'):
                 torch.addcmul(a, scalar, c, value=alpha)
             with self.assertRaisesRegex(RuntimeError, r'CPU Scalar support for self argument'):
                 torch.addcmul(scalar, b, c, value=alpha)
         else:
             raise RuntimeError(f"Unexpected device {device} encountered")
-
 
     # FIXME: move to shape ops test suite
     def test_narrow_empty(self, device):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3319,7 +3319,8 @@ else:
             out = torch.addcmul(a, b, c, value=-1)
             self.assertTrue(not (out.isnan() or out.isinf()))
 
-    def test_addcmul_cpu_scalars(self, device):
+    @onlyCUDA
+    def test_addcmul_cuda_errors_with_cpu_scalars(self, device):
         # Logic is dtype agnostic, so dtype isn't tested
         alpha = 0.5
 
@@ -3328,18 +3329,10 @@ else:
         c = torch.rand((2, 2), device=device)
         scalar = torch.rand([], device="cpu")
 
-        if device == "cpu":
-            self.assertEqual(torch.addcmul(a, scalar, c, value=alpha),
-                             a + scalar * c * alpha)
-            self.assertEqual(torch.addcmul(a, scalar, c, value=alpha),
-                             a + scalar * c * alpha)
-        elif device.startswith("cuda"):
-            with self.assertRaisesRegex(RuntimeError, r'CPU Scalar support for tensor1 argument'):
-                torch.addcmul(a, scalar, c, value=alpha)
-            with self.assertRaisesRegex(RuntimeError, r'CPU Scalar support for self argument'):
-                torch.addcmul(scalar, b, c, value=alpha)
-        else:
-            raise RuntimeError(f"Unexpected device {device} encountered")
+        with self.assertRaisesRegex(RuntimeError, r'CPU Scalar support for tensor1 argument'):
+            torch.addcmul(a, scalar, c, value=alpha)
+        with self.assertRaisesRegex(RuntimeError, r'CPU Scalar support for self argument'):
+            torch.addcmul(scalar, b, c, value=alpha)
 
     # FIXME: move to shape ops test suite
     def test_narrow_empty(self, device):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3333,7 +3333,7 @@ else:
                              a + scalar * c * alpha)
             self.assertEqual(torch.addcmul(a, scalar, c, value=alpha),
                              a + scalar * c * alpha)
-        elif device[0:4] == "cuda":
+        elif device.startswith("cuda"):
             with self.assertRaisesRegex(RuntimeError, r'CPU Scalar support for tensor1 argument'):
                 torch.addcmul(a, scalar, c, value=alpha)
             with self.assertRaisesRegex(RuntimeError, r'CPU Scalar support for self argument'):


### PR DESCRIPTION
Step required for performance in #143122 

Adds support for CPU scalar for tensor_2 in addcmul. For example:
```
import torch
a = torch.rand(2, 2, device="cuda")
b = torch.tensor(1e-3)

torch.add(a, b)
torch.addcmul(a, a, b)  # used to fail, now works
```