### PR TITLE
[Flex Decoding] split_kv Schedule evening 

### DIFF
--- a/torch/_inductor/kernel/flex_decoding.py
+++ b/torch/_inductor/kernel/flex_decoding.py
@@ -208,6 +208,9 @@ flex_decoding_template = TritonTemplate(
     if HAS_FULL_BLOCKS:
         kv_indices = FULL_KV_IDX + sparse_idx_hz_offset
         kv_num_blocks = tl.load(FULL_KV_NUM_BLKS + sparse_block_hz_offset)
+        # Assign full block in a reverse order for off_t. Prioritize the last CTA.
+        block_n_start = (SPLIT_KV - off_t - 1) * TILE_KV_MULTIPLE
+        block_n_end = block_n_start + TILE_KV_MULTIPLE
         indices_idx = block_n_start // SPARSE_KV_MULTIPLE
         off_n_block_in_sparse = block_n_start % SPARSE_KV_MULTIPLE
         off_n = tl.load(kv_indices + indices_idx) * SPARSE_KV_BLOCK_SIZE + off_n_block_in_sparse * BLOCK_N
@@ -294,11 +297,13 @@ flex_decoding_template = TritonTemplate(
 )
 
 
-def get_split_k(B: int, H: int, Mk: int, SM: int = 128) -> int:
-    """Heuristic for the number of splits from xformer"""
+def get_split_k(B: int, H: int, Mk: int) -> int:
+    num_SM = torch.cuda.get_device_properties("cuda").multi_processor_count
     bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
     assert isinstance(bh, (int, sympy.Integer)), "B and H must be concrete integers"
-    split_k = SM // bh  # Each SM should at least get one block.
+    split_k = num_SM // bh * 2  # Each SM should at least get one block.
+    # TODO: workload evening at runtime for splits fully masked out.
+    # Before we have runtime workload evening, assign 2 splits per SM.
     split_k = max(split_k, 1)
 
     return split_k
@@ -504,13 +509,19 @@ def create_flex_decoding_kernel(*args, **kwargs):
             continue
 
         cur_kernel_options = original_kernel_options.copy()
+        # Remove prefix for forward kernels options and delete backward kernel options.
+        for k in list(cur_kernel_options.keys()):
+            if k.startswith("fwd_"):
+                v = cur_kernel_options.pop(k)
+                cur_kernel_options[k[4:]] = v
+            if k.startswith("bwd_"):
+                cur_kernel_options.pop(k)
         # Performance tuning
         cur_kernel_options.setdefault("BLOCK_N", BLOCK_N)
         cur_kernel_options.setdefault("SPARSE_KV_BLOCK_SIZE", SPARSE_KV_BLOCK_SIZE)
+        cur_kernel_options.setdefault("num_warps", num_warps)
+        cur_kernel_options.setdefault("num_stages", num_stages)
 
-        # Work around https://github.com/pytorch/pytorch/issues/129625
-        if num_stages == 2:
-            continue
         flex_decoding_template.maybe_append_choice(
             choices=choices,
             input_nodes=[
@@ -530,8 +541,6 @@ def create_flex_decoding_kernel(*args, **kwargs):
                 mask_mod_subgraph,
             ],
             mutated_inputs=[buf_M, buf_L],
-            num_stages=num_stages,
-            num_warps=num_warps,
             call_sizes=query.get_size(),
             **cur_kernel_options,
         )

--- a/torch/_inductor/kernel/flex_decoding.py
+++ b/torch/_inductor/kernel/flex_decoding.py
@@ -140,8 +140,7 @@ flex_decoding_template = TritonTemplate(
     sparse_idx_hz_offset = sparse_idx_z * stride_kv_z + sparse_idx_h * stride_kv_h
 
     # Calculate KV blocks that belong this CTA.
-    block_n_start = off_t * TILE_KV_MULTIPLE                        # n_offset inside sparse block
-    block_n_end = block_n_start + TILE_KV_MULTIPLE                  # end BLOCK_N
+    block_n_start = off_t
 
     q_range = stride_qg * off_g[:, None, None] + stride_qm * off_m[None, :, None] + stride_qk * offs_d[None, None, :]
 
@@ -196,9 +195,10 @@ flex_decoding_template = TritonTemplate(
         off_z, offs_hq[:, None], offs_m[:, None], offs_n[None, :],
         #block sparse data
         kv_indices, kv_num_blocks,
-        block_n_start, block_n_end if block_n_end <= block_n_last_valid else block_n_last_valid,
+        block_n_start, block_n_last_valid,
         MATMUL_PRECISION,
         IS_FULL_BLOCKS=False,
+        SPLIT_KV_STRIDE=SPLIT_KV,
     )
 
 
@@ -208,15 +208,12 @@ flex_decoding_template = TritonTemplate(
     if HAS_FULL_BLOCKS:
         kv_indices = FULL_KV_IDX + sparse_idx_hz_offset
         kv_num_blocks = tl.load(FULL_KV_NUM_BLKS + sparse_block_hz_offset)
-        # Assign full block in a reverse order for off_t. Prioritize the last CTA.
-        block_n_start = (SPLIT_KV - off_t - 1) * TILE_KV_MULTIPLE
-        block_n_end = block_n_start + TILE_KV_MULTIPLE
         indices_idx = block_n_start // SPARSE_KV_MULTIPLE
         off_n_block_in_sparse = block_n_start % SPARSE_KV_MULTIPLE
         off_n = tl.load(kv_indices + indices_idx) * SPARSE_KV_BLOCK_SIZE + off_n_block_in_sparse * BLOCK_N
 
         # last valid block according to sparse mask
-        block_n_last_valid = tl.minimum(kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
+        block_n_last_valid = tl.minimum(kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1)*BLOCK_N)
 
         K_block_ptr = tl.make_block_ptr(
             base=K + k_offset,
@@ -245,9 +242,10 @@ flex_decoding_template = TritonTemplate(
             off_z, offs_hq[:, None], offs_m[:, None], offs_n[None, :],
             #block sparse data
             kv_indices, kv_num_blocks,
-            block_n_start, block_n_end if block_n_end <= block_n_last_valid else block_n_last_valid,
+            block_n_start, block_n_last_valid,
             MATMUL_PRECISION,
             IS_FULL_BLOCKS=True,
+            SPLIT_KV_STRIDE=SPLIT_KV,
         )
 
     m_offset = off_t * stride_mt + off_z * stride_mz


### PR DESCRIPTION
`flex_decoding` divide the KV matrix along the sequence length dimension into multiple sub-sequences and assigns to different blocks to improve GPU occupancy and HBM bandwidth utilization. 

`num_splits = num_SM / Bsz / Hq`. (each SM is assigned on subsequence for one head) 

This assignment happens statically, namely before we know what the mask looks like. 
For example, for 12 SPARSE_KV blocks assigned to 4 SMs, 
block 0: [0, 1, 2]
block 1: [3, 4, 5]
block 2: [6, 7, 8]
block 3: [9, 10, 11] 


However, if the second half of the KV cache is masked out (very common case), it becomes: 
block 0: [0, 1, 2]
block 1: [3, 4, 5]
block 2: x
block 3: x 
And only 2 SMs are actually doing work. 

### New Block Schedule 
This PR changes the block schedule to: 
block 0: [0, 4, 8]
block 1: [1, 5, 9]
block 2: [2, 6, 10]
block 3: [3, 7, 11]

with the same mask, 
block 0: [0, 4, x]
block 1: [1, 5, x]
block 2: [2, x, x]
block 3: [3, x, x]

we have a more even schedule for most contiguous masks. 

# Performance

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov