### PR TITLE
remove allow-untyped-defs for distributed/rpc/_testing/__init__.py

### DIFF
--- a/torch/distributed/rpc/_testing/__init__.py
+++ b/torch/distributed/rpc/_testing/__init__.py
@@ -1,9 +1,7 @@
-# mypy: allow-untyped-defs
-
 import torch
 
 
-def is_available():
+def is_available() -> bool:
     return hasattr(torch._C, "_faulty_agent_init")
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #143153
* #143273
* #143272
* __->__ #143271



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o