### PR TITLE
[Inductor] Fix _can_be_inplace function

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -923,6 +923,27 @@ class TestPatternMatcher(TestPatternMatcherBase):
             )
             self.assertEqual(metrics.generated_kernel_count, 1 if not acl_bf16 else 2)
 
+    def test_conv2d_linear_add_broadcast_shapes_cpu(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 16, kernel_size=3, stride=1)
+                self.linear = torch.nn.Linear(3, 16)
+
+            def forward(self, x1, x2):
+                return self.conv(x1) + self.linear(x2)[:, :, None, None]
+
+        metrics.reset()
+        mod = M().eval()
+        x1 = torch.randn(2, 3, 56, 56)
+        x2 = torch.randn(2, 3)
+
+        def matcher_check_fn():
+            self.assertEqual(counters["inductor"]["mkldnn_conv_binary_unary_fusion_matcher_nodes"], 2)
+            self.assertEqual(counters["inductor"]["mkldnn_conv_weight_pack_matcher_nodes"], 1)
+
+        self._test_common(mod, (x1, x2), matcher_check_fn)
+
     def test_multi_linear_share_same_input(self):
         # llama pattern.
         class M(torch.nn.Module):

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -923,6 +923,9 @@ class TestPatternMatcher(TestPatternMatcherBase):
             )
             self.assertEqual(metrics.generated_kernel_count, 1 if not acl_bf16 else 2)
 
+    @skipIfNoDynamoSupport
+    @skipIfNoONEDNN
+    @skipIfRocm
     def test_conv2d_linear_add_broadcast_shapes_cpu(self):
         class M(torch.nn.Module):
             def __init__(self):
@@ -939,8 +942,10 @@ class TestPatternMatcher(TestPatternMatcherBase):
         x2 = torch.randn(2, 3)
 
         def matcher_check_fn():
+            match_nodes = 0 if TEST_ACL else 2
             self.assertEqual(
-                counters["inductor"]["mkldnn_conv_binary_unary_fusion_matcher_nodes"], 2
+                counters["inductor"]["mkldnn_conv_binary_unary_fusion_matcher_nodes"],
+                match_nodes,
             )
             self.assertEqual(
                 counters["inductor"]["mkldnn_conv_weight_pack_matcher_nodes"], 1

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -939,8 +939,12 @@ class TestPatternMatcher(TestPatternMatcherBase):
         x2 = torch.randn(2, 3)
 
         def matcher_check_fn():
-            self.assertEqual(counters["inductor"]["mkldnn_conv_binary_unary_fusion_matcher_nodes"], 2)
-            self.assertEqual(counters["inductor"]["mkldnn_conv_weight_pack_matcher_nodes"], 1)
+            self.assertEqual(
+                counters["inductor"]["mkldnn_conv_binary_unary_fusion_matcher_nodes"], 2
+            )
+            self.assertEqual(
+                counters["inductor"]["mkldnn_conv_weight_pack_matcher_nodes"], 1
+            )
 
         self._test_common(mod, (x1, x2), matcher_check_fn)
 

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -521,13 +521,10 @@ if torch._C._has_mkldnn:
         return fn
 
     def _can_be_inplace(_other):
-        if isinstance(_other.data, ir.View):
-            return _can_be_inplace(_other.data)
-        else:
-            return not (
-                isinstance(_other.data, ir.ReinterpretView)
-                or len(_other.data.get_inputs_that_alias_output()) > 0
-            )
+        return not (
+            isinstance(_other.data, ir.BaseView)
+            or len(_other.get_inputs_that_alias_output()) > 0
+        )
 
     def _register_binary_unary_maybe_inplace_fusion_lowering(
         pattern,

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -526,7 +526,7 @@ if torch._C._has_mkldnn:
         else:
             return not (
                 isinstance(_other.data, ir.ReinterpretView)
-                or len(_other.get_inputs_that_alias_output()) > 0
+                or len(_other.data.get_inputs_that_alias_output()) > 0
             )
 
     def _register_binary_unary_maybe_inplace_fusion_lowering(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143279

Summary:
Modify _can_be_inplace function: return False if `_other.data` is an instance of `ir.BaseView`.

Fix https://github.com/pytorch/pytorch/issues/143280.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov