### PR TITLE
[ROCm] ROCm-specific gemm tuning parameters

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -631,6 +631,8 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         num_stages: int,
         num_warps: int,
         matrix_instr_nonkdim: int = 0,  # only used for hip to choose the shape of mfma instruction.
+        waves_per_eu: int = 0,  # only used on ROCm for scheduling waves per execution unit
+        kpack: int = 0,  # ROCm specific gemm parameters
         workspace_arg: Optional[WorkspaceArg] = None,
     ) -> None:
         super().__init__(kernel_name, input_tensor_meta, output_tensor_meta, extra_args)
@@ -640,6 +642,8 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         self.num_stages = num_stages
         self.num_warps = num_warps
         self.matrix_instr_nonkdim = matrix_instr_nonkdim
+        self.waves_per_eu = waves_per_eu
+        self.kpack = kpack
         self.workspace_arg = workspace_arg
 
     def make_run_fn(

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import cast, List, Optional, Sequence, Tuple, TYPE_CHECKING, TypedDict
+from typing import List, Optional, Sequence, TYPE_CHECKING, TypedDict
 
 import torch
 from torch._inductor.codegen.rocm.ck_conv_template import CKGroupedConvFwdTemplate
@@ -30,7 +30,7 @@ from ..utils import (
     use_triton_template,
 )
 from ..virtualized import V
-from .mm_common import build_rocm_gemm_configs, filtered_configs
+from .mm_common import build_rocm_gemm_configs, extract_configs, filtered_configs
 
 
 if TYPE_CHECKING:
@@ -72,11 +72,7 @@ kernel_configs = [
 ]
 
 # Create filtered list of configs based on conv
-platform_configs = tuple(
-    cast(Tuple[int, int, int, int, int], config["config"])
-    for config in kernel_configs
-    if config["cond"]
-)
+platform_configs, platform_args = extract_configs(kernel_configs)
 
 # On ROCm convert num_stages to 1 as pipelining provides no benefit
 if torch.version.hip:
@@ -101,7 +97,7 @@ def conv_configs(m, n, k, *, device_type, **kwargs):
             scale=0.5,
             exclude=_is_large_block_for_cpu,
         )
-    return filtered_configs(m, n, k, configs=platform_configs, extra_args={})
+    return filtered_configs(m, n, k, configs=platform_configs, extra_args=platform_args)
 
 
 LOOP_BODY_2D = """

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -97,10 +97,11 @@ def conv_configs(m, n, k, *, device_type, **kwargs):
             n,
             k,
             configs=platform_configs,
+            extra_args={},
             scale=0.5,
             exclude=_is_large_block_for_cpu,
         )
-    return filtered_configs(m, n, k, configs=platform_configs)
+    return filtered_configs(m, n, k, configs=platform_configs, extra_args={})
 
 
 LOOP_BODY_2D = """

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -2,7 +2,7 @@
 import functools
 import itertools
 import logging
-from typing import Any, cast, Dict, Sequence, Tuple
+from typing import Any, cast, Dict, List, Optional, Sequence, Tuple
 
 import sympy
 
@@ -26,6 +26,36 @@ from ..utils import (
 log = logging.getLogger(__name__)
 
 
+def _extract_configs(
+    configs: List[Dict[str, Any]]
+) -> Tuple[List[Tuple[int, int, int, int, int]], List[Optional[Dict[str, Any]]]]:
+    """
+    Extracts triton configs and additional arguments if present filtered by a condition
+    Args:
+        configs (List[Dict[str, Any]]): List of configuration dictionaries. Each dictionary must have a "config" key
+                                         and an optional "cond" key.
+    Returns:
+        Tuple[List[Tuple[int, int, int, int, int]], List[Optional[Dict[str, Any]]]]:
+            A tuple containing two lists:
+              - trion_configs: List of base configurations as tuples.
+              - extra_args: List of extra arguments supplied with the triton config.
+    """
+    triton_configs = []
+    extra_args = []
+    for config in configs:
+        if config.get("cond", False):
+            triton_configs.append(
+                cast(Tuple[int, int, int, int, int], config["config"])
+            )
+            filtered_args = {
+                k: v
+                for k, v in config.items()
+                if k not in OrderedSet(["config", "cond"])
+            }
+            extra_args.append(filtered_args)
+    return triton_configs, extra_args
+
+
 def triton_config(num_stages, num_warps, **kwargs):
     from triton import Config  # type: ignore[attr-defined]
 
@@ -42,6 +72,7 @@ def filtered_configs(
     n: int,
     k: int,
     configs: Sequence[Tuple[int, int, int, int, int]],
+    extra_args: Sequence[Optional[Dict[str, Any]]],
     has_int8_tensor=False,
     scale=1,
     exclude=lambda m, n, k: False,
@@ -85,7 +116,9 @@ def filtered_configs(
         min_block_size_k,
     )
     used = OrderedSet[tuple[int, int, int, int, int, int]]()
-    for block_m, block_n, block_k, num_stages, num_warps in configs:
+    for (block_m, block_n, block_k, num_stages, num_warps), extras in zip(
+        configs, extra_args
+    ):
         # shrink configs for small sizes
         block_m = max(min(int(block_m * scale), m), min_block_size)
         block_n = max(min(int(block_n * scale), n), min_block_size)
@@ -96,91 +129,447 @@ def filtered_configs(
 
         # each warp computes 16x16 tile = 256
         num_warps = min(num_warps, block_m * block_n // 256)
+
+        # Default args
+        group_m = 8
         if torch.version.hip:
-            for matrix_instr_nonkdim in [0, 16]:
-                if matrix_instr_nonkdim != 0 and (
-                    block_m % matrix_instr_nonkdim != 0
-                    or block_n % matrix_instr_nonkdim != 0
-                ):
-                    #  block_m and block_n must be a multiple of matrix_instr_nonkdim
-                    continue
-                if (
-                    block_m,
-                    block_n,
-                    block_k,
-                    num_stages,
-                    num_warps,
-                    matrix_instr_nonkdim,
-                ) not in used and (
-                    max_mm_configs is None or len(used) < max_mm_configs
-                ):
-                    used.add(
-                        (
-                            block_m,
-                            block_n,
-                            block_k,
-                            num_stages,
-                            num_warps,
-                            matrix_instr_nonkdim,
-                        )
-                    )
-                    yield triton_config(
-                        BLOCK_M=block_m,
-                        BLOCK_N=block_n,
-                        BLOCK_K=block_k,
-                        num_stages=num_stages,
-                        num_warps=num_warps,
-                        matrix_instr_nonkdim=matrix_instr_nonkdim,
-                    )
-        else:
-            if (block_m, block_n, block_k, num_stages, num_warps, 0) not in used and (
-                max_mm_configs is None or len(used) < max_mm_configs
+            kpack = 2
+            matrix_instr_nonkdim = 16
+            waves_per_eu = 0
+
+        # If extra args dictionary supplied then extract custom args for this triton config
+        if extras:
+            group_m = extras.get("GROUP_M", 8)
+            if torch.version.hip:
+                kpack = extras.get("kpack", 2)
+                matrix_instr_nonkdim = extras.get("mfma_size", 16)
+                waves_per_eu = extras.get("wpeu", 0)
+                if waves_per_eu != 0:
+                    waves_per_eu = int(8 // num_warps)
+
+        if torch.version.hip:
+            if matrix_instr_nonkdim != 0 and (
+                block_m % matrix_instr_nonkdim != 0
+                or block_n % matrix_instr_nonkdim != 0
             ):
-                used.add((block_m, block_n, block_k, num_stages, num_warps, 0))
+                #  block_m and block_n must be a multiple of matrix_instr_nonkdim
+                matrix_instr_non_kdim = 0
+                kpack = 1
+            # We hit a numerical issue if block_k is 16 and kpack=2, will remove once # resolved
+            if block_k == 16:
+                kpack = 1
+            if (
+                block_m,
+                block_n,
+                block_k,
+                num_stages,
+                num_warps,
+                matrix_instr_nonkdim,
+                kpack,
+                waves_per_eu,
+            ) not in used and (max_mm_configs is None or len(used) < max_mm_configs):
+                used.add(
+                    (
+                        block_m,
+                        block_n,
+                        block_k,
+                        num_stages,
+                        num_warps,
+                        group_m,
+                        matrix_instr_nonkdim,
+                        kpack,
+                        waves_per_eu,
+                    )
+                )
                 yield triton_config(
                     BLOCK_M=block_m,
                     BLOCK_N=block_n,
                     BLOCK_K=block_k,
                     num_stages=num_stages,
                     num_warps=num_warps,
+                    GROUP_M=group_m,
+                    matrix_instr_nonkdim=matrix_instr_nonkdim,
+                    kpack=kpack,
+                    waves_per_eu=waves_per_eu,
+                )
+        else:
+            if (
+                block_m,
+                block_n,
+                block_k,
+                num_stages,
+                num_warps,
+                group_m,
+            ) not in used and (max_mm_configs is None or len(used) < max_mm_configs):
+                used.add((block_m, block_n, block_k, num_stages, num_warps, group_m))
+                yield triton_config(
+                    BLOCK_M=block_m,
+                    BLOCK_N=block_n,
+                    BLOCK_K=block_k,
+                    num_stages=num_stages,
+                    num_warps=num_warps,
+                    GROUP_M=group_m,
                 )
 
 
 # List of dictionaries to store the kernel configs. Configs that evaluate to true
 # will be utilised on the target platform. The configs are as follows:
 # (BLOCK_M, BLOCK_N, BLOCK_K, num_stages, num_warps)
-mm_kernel_configs = (
-    [
-        {"config": (32, 32, 16, 1, 2), "cond": True},
-        {"config": (32, 32, 128, 2, 4), "cond": True},
-        {"config": (32, 64, 32, 5, 8), "cond": True},
-        {"config": (64, 32, 32, 5, 8), "cond": True},
-        {"config": (64, 32, 128, 5, 4), "cond": True},
-        {"config": (64, 64, 16, 2, 4), "cond": True},
-        {"config": (64, 64, 32, 2, 4), "cond": True},
-        {"config": (64, 64, 64, 3, 8), "cond": True},
-        {"config": (64, 64, 128, 5, 4), "cond": True},
-        {"config": (64, 128, 32, 3, 4), "cond": True},
-        {"config": (64, 128, 32, 4, 8), "cond": True},
-        {"config": (64, 128, 64, 3, 4), "cond": True},
-        {"config": (64, 128, 128, 4, 4), "cond": True},
-        {"config": (128, 64, 32, 3, 4), "cond": True},
-        {"config": (128, 64, 32, 4, 8), "cond": True},
-        {"config": (128, 128, 32, 2, 8), "cond": True},
-        {"config": (128, 128, 32, 3, 4), "cond": True},
-        {"config": (128, 128, 64, 3, 4), "cond": True},
-        {"config": (128, 128, 64, 5, 8), "cond": True},
-    ]
-    if inductor_config.max_autotune_gemm_search_space != "EXHAUSTIVE"
-    else [
-        {"config": (BLOCK_M, BLOCK_N, BLOCK_K, num_stages, num_warps), "cond": True}
-        for BLOCK_M, BLOCK_N, BLOCK_K in itertools.product(
-            [16, 32, 64, 128, 256], repeat=3
-        )
-        for num_stages in [1, 2, 3, 4, 5]
-        for num_warps in [2, 4, 8]
-    ]
-)
+if torch.version.hip is None:
+    mm_kernel_configs = (
+        [
+            {"config": (32, 32, 16, 1, 2), "cond": True},
+            {"config": (32, 32, 128, 2, 4), "cond": True},
+            {"config": (32, 64, 32, 5, 8), "cond": True},
+            {"config": (64, 32, 32, 5, 8), "cond": True},
+            {"config": (64, 32, 128, 5, 4), "cond": True},
+            {"config": (64, 64, 16, 2, 4), "cond": True},
+            {"config": (64, 64, 32, 2, 4), "cond": True},
+            {"config": (64, 64, 64, 3, 8), "cond": True},
+            {"config": (64, 64, 128, 5, 4), "cond": True},
+            {"config": (64, 128, 32, 3, 4), "cond": True},
+            {"config": (64, 128, 32, 4, 8), "cond": True},
+            {"config": (64, 128, 64, 3, 4), "cond": True},
+            {"config": (64, 128, 128, 4, 4), "cond": True},
+            {"config": (128, 64, 32, 3, 4), "cond": True},
+            {"config": (128, 64, 32, 4, 8), "cond": True},
+            {"config": (128, 128, 32, 2, 8), "cond": True},
+            {"config": (128, 128, 32, 3, 4), "cond": True},
+            {"config": (128, 128, 64, 3, 4), "cond": True},
+            {"config": (128, 128, 64, 5, 8), "cond": True},
+        ]
+        if inductor_config.max_autotune_gemm_search_space != "EXHAUSTIVE"
+        else [
+            {"config": (BLOCK_M, BLOCK_N, BLOCK_K, num_stages, num_warps), "cond": True}
+            for BLOCK_M, BLOCK_N, BLOCK_K in itertools.product(
+                [16, 32, 64, 128, 256], repeat=3
+            )
+            for num_stages in [1, 2, 3, 4, 5]
+            for num_warps in [2, 4, 8]
+        ]
+    )
+else:
+    rocm_num_stages = get_backend_num_stages()
+    if inductor_config.max_autotune_gemm_search_space != "EXHAUSTIVE":
+        mm_kernel_configs = [
+            {
+                "config": (128, 128, 32, rocm_num_stages, 4),
+                "GROUP_M": 16,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (128, 128, 32, rocm_num_stages, 4),
+                "GROUP_M": 16,
+                "wpeu": 2,
+                "cond": True,
+            },
+            {
+                "config": (128, 128, 32, rocm_num_stages, 8),
+                "GROUP_M": 16,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (128, 128, 64, rocm_num_stages, 4),
+                "GROUP_M": 16,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (128, 128, 64, rocm_num_stages, 4),
+                "GROUP_M": 16,
+                "wpeu": 2,
+                "cond": True,
+            },
+            {
+                "config": (128, 128, 64, rocm_num_stages, 8),
+                "GROUP_M": 16,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (128, 256, 32, rocm_num_stages, 4),
+                "GROUP_M": 16,
+                "wpeu": 2,
+                "cond": True,
+            },
+            {
+                "config": (128, 64, 16, rocm_num_stages, 4),
+                "GROUP_M": 16,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (128, 64, 32, rocm_num_stages, 8),
+                "GROUP_M": 16,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (128, 64, 32, rocm_num_stages, 4),
+                "GROUP_M": 16,
+                "wpeu": 2,
+                "cond": True,
+            },
+            {
+                "config": (128, 64, 64, rocm_num_stages, 4),
+                "GROUP_M": 16,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (128, 64, 64, rocm_num_stages, 8),
+                "GROUP_M": 16,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (16, 16, 256, rocm_num_stages, 4),
+                "GROUP_M": 4,
+                "wpeu": 2,
+                "cond": True,
+            },
+            {
+                "config": (256, 128, 32, rocm_num_stages, 8),
+                "GROUP_M": 4,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (256, 128, 32, rocm_num_stages, 4),
+                "GROUP_M": 4,
+                "wpeu": 2,
+                "cond": True,
+            },
+            {
+                "config": (32, 16, 256, rocm_num_stages, 4),
+                "GROUP_M": 4,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (32, 32, 128, rocm_num_stages, 4),
+                "GROUP_M": 8,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (32, 64, 128, rocm_num_stages, 4),
+                "GROUP_M": 8,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (32, 64, 64, rocm_num_stages, 4),
+                "GROUP_M": 4,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (64, 128, 32, rocm_num_stages, 4),
+                "GROUP_M": 4,
+                "wpeu": 2,
+                "cond": True,
+            },
+            {
+                "config": (64, 128, 32, rocm_num_stages, 8),
+                "GROUP_M": 4,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (64, 128, 64, rocm_num_stages, 4),
+                "GROUP_M": 4,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (64, 16, 128, rocm_num_stages, 4),
+                "GROUP_M": 8,
+                "wpeu": 2,
+                "cond": True,
+            },
+            {
+                "config": (64, 16, 64, rocm_num_stages, 4),
+                "GROUP_M": 8,
+                "wpeu": 2,
+                "cond": True,
+            },
+            {
+                "config": (64, 64, 64, rocm_num_stages, 4),
+                "GROUP_M": 4,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (64, 64, 128, rocm_num_stages, 4),
+                "GROUP_M": 16,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (64, 128, 64, rocm_num_stages, 4),
+                "GROUP_M": 4,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (128, 128, 128, rocm_num_stages, 8),
+                "GROUP_M": 16,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (64, 128, 128, rocm_num_stages, 4),
+                "GROUP_M": 4,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (128, 128, 64, rocm_num_stages, 4),
+                "GROUP_M": 8,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (128, 128, 64, rocm_num_stages, 4),
+                "GROUP_M": 8,
+                "wpeu": 0,
+                "mfma_size": 0,
+                "kpack": 1,
+                "cond": True,
+            },
+            {
+                "config": (64, 64, 32, rocm_num_stages, 4),
+                "GROUP_M": 8,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (256, 256, 64, rocm_num_stages, 8),
+                "GROUP_M": 4,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (256, 128, 64, rocm_num_stages, 8),
+                "GROUP_M": 4,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (128, 256, 64, rocm_num_stages, 8),
+                "GROUP_M": 4,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (128, 64, 128, rocm_num_stages, 8),
+                "GROUP_M": 8,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (32, 16, 128, rocm_num_stages, 4),
+                "GROUP_M": 8,
+                "wpeu": 0,
+                "cond": True,
+            },
+            {
+                "config": (128, 32, 32, rocm_num_stages, 4),
+                "GROUP_M": 8,
+                "wpeu": 2,
+                "cond": True,
+            },
+            {
+                "config": (32, 256, 64, rocm_num_stages, 8),
+                "GROUP_M": 8,
+                "kpack": 1,
+                "cond": True,
+            },
+            {
+                "config": (64, 128, 64, rocm_num_stages, 8),
+                "GROUP_M": 4,
+                "kpack": 1,
+                "cond": True,
+            },
+            {
+                "config": (16, 64, 128, rocm_num_stages, 8),
+                "GROUP_M": 8,
+                "cond": True,
+            },
+            {
+                "config": (128, 32, 16, rocm_num_stages, 4),
+                "GROUP_M": 16,
+                "kpack": 1,
+                "wpeu": 2,
+                "cond": True,
+            },
+            {
+                "config": (128, 64, 128, rocm_num_stages, 4),
+                "GROUP_M": 8,
+                "kpack": 1,
+                "cond": True,
+            },
+            {
+                "config": (128, 32, 16, rocm_num_stages, 4),
+                "GROUP_M": 16,
+                "kpack": 1,
+                "cond": True,
+            },
+            {
+                "config": (64, 256, 64, rocm_num_stages, 8),
+                "GROUP_M": 4,
+                "kpack": 1,
+                "mfma_size": 0,
+                "cond": True,
+            },
+            {
+                "config": (64, 256, 16, rocm_num_stages, 4),
+                "GROUP_M": 4,
+                "kpack": 1,
+                "cond": True,
+            },
+            {
+                "config": (64, 32, 32, rocm_num_stages, 4),
+                "GROUP_M": 8,
+                "kpack": 2,
+                "mfma_size": 0,
+                "cond": True,
+            },
+            {
+                "config": (128, 128, 128, rocm_num_stages, 8),
+                "GROUP_M": 4,
+                "cond": True,
+            },
+            {
+                "config": (64, 256, 32, rocm_num_stages, 8),
+                "GROUP_M": 4,
+                "cond": True,
+            },
+        ]
+    else:
+        mm_kernel_configs = [
+            {
+                "config": (BLOCK_M, BLOCK_N, BLOCK_K, num_stages, num_warps),
+                "GROUP_M": GROUP_M,
+                "wpeu": waves_per_eu,
+                "mfma_size": matrix_instr_nonkdim,
+                "kpack": kpack,
+                "cond": True,
+            }
+            for BLOCK_M, BLOCK_N, BLOCK_K in itertools.product(
+                [16, 32, 64, 128, 256], repeat=3
+            )
+            for num_stages in [2]
+            for num_warps in [4, 8]
+            for waves_per_eu in [0, 2]
+            for GROUP_M in [4, 8, 16]
+            for matrix_instr_nonkdim in [0, 16]
+            for kpack in [1, 2]
+        ]
+
 
 # these are only used in tuned_mm when AutoHeuristic is enabled
 # the idea is that when AutoHeuristic collects data to learn a heuristic, more configs are autotuned
@@ -351,83 +740,71 @@ scaled_persistent_mm_kernel_configs = [
 
 
 # Create filtered list of configs based on cond evaluation
-mm_platform_configs = tuple(
-    cast(Tuple[int, int, int, int, int], config["config"])
-    for config in mm_kernel_configs
-    if config["cond"]
+# and parse other params as extra_args
+mm_platform_configs, mm_args = _extract_configs(mm_kernel_configs)
+extra_mm_platform_configs, extra_mm_args = _extract_configs(extra_mm_kernel_configs)
+int8_mm_platform_configs, int8_mm_args = _extract_configs(int8_mm_kernel_configs)
+mixed_mm_platform_configs, mixed_mm_args = _extract_configs(mixed_mm_kernel_configs)
+persistent_mm_platform_configs, persistent_mm_args = _extract_configs(
+    persistent_mm_kernel_configs
 )
-extra_mm_platform_configs = tuple(
-    cast(Tuple[int, int, int, int, int], config["config"])
-    for config in extra_mm_kernel_configs
-    if config["cond"]
-)
-int8_platform_configs = tuple(
-    cast(Tuple[int, int, int, int, int], config["config"])
-    for config in int8_mm_kernel_configs
-    if config["cond"]
-)
-mixed_mm_platform_configs = tuple(
-    cast(Tuple[int, int, int, int, int], config["config"])
-    for config in mixed_mm_kernel_configs
-    if config["cond"]
-)
-persistent_mm_platform_configs = tuple(
-    cast(Tuple[int, int, int, int, int], config["config"])
-    for config in persistent_mm_kernel_configs
-    if config["cond"]
-)
-scaled_mm_platform_configs = tuple(
-    cast(Tuple[int, int, int, int, int], config["config"])
-    for config in scaled_mm_kernel_configs
-    if config["cond"]
-)
-scaled_persistent_mm_platform_configs = tuple(
-    cast(Tuple[int, int, int, int, int], config["config"])
-    for config in scaled_persistent_mm_kernel_configs
-    if config["cond"]
+scaled_mm_platform_configs, scaled_mm_args = _extract_configs(scaled_mm_kernel_configs)
+scaled_persistent_mm_platform_configs, scaled_persistent_mm_args = _extract_configs(
+    scaled_persistent_mm_kernel_configs
 )
 
 # On ROCm convert num_stages to improve performance
+# This can be removed when ROCm specific implementations introduced
 if torch.version.hip:
-    mm_platform_configs = build_rocm_gemm_configs(mm_platform_configs)
-    extra_mm_platform_configs = build_rocm_gemm_configs(extra_mm_platform_configs)
-    int8_platform_configs = build_rocm_gemm_configs(int8_platform_configs)
-    mixed_mm_platform_configs = build_rocm_gemm_configs(mixed_mm_platform_configs)
-    scaled_mm_platform_configs = build_rocm_gemm_configs(scaled_mm_platform_configs)
+    extra_mm_configs = build_rocm_gemm_configs(extra_mm_platform_configs)
+    int8_mm_configs = build_rocm_gemm_configs(int8_mm_platform_configs)
+    mixed_mm_configs = build_rocm_gemm_configs(mixed_mm_platform_configs)
+    persistent_mm_configs = build_rocm_gemm_configs(persistent_mm_platform_configs)
+    scaled_mm_configs = build_rocm_gemm_configs(scaled_mm_platform_configs)
+    scaled_persistent_mm_configs = build_rocm_gemm_configs(
+        scaled_persistent_mm_platform_configs
+    )
 
 mm_configs = functools.partial(
     filtered_configs,
     configs=mm_platform_configs,
+    extra_args=mm_args,
 )
 
 extra_mm_configs = functools.partial(
     filtered_configs,
     configs=extra_mm_platform_configs,
+    extra_args=extra_mm_args,
 )
 
 int8_mm_configs = functools.partial(
     filtered_configs,
-    configs=int8_platform_configs,
+    configs=int8_mm_platform_configs,
+    extra_args=int8_mm_args,
 )
 
 mixed_mm_configs = functools.partial(
     filtered_configs,
     configs=mixed_mm_platform_configs,
+    extra_args=mixed_mm_args,
 )
 
 persistent_mm_configs = functools.partial(
     filtered_configs,
     configs=persistent_mm_platform_configs,
+    extra_args=persistent_mm_args,
 )
 
 scaled_mm_configs = functools.partial(
     filtered_configs,
     configs=scaled_mm_platform_configs,
+    extra_args=scaled_mm_args,
 )
 
 scaled_persistent_mm_configs = functools.partial(
     filtered_configs,
     configs=scaled_persistent_mm_platform_configs,
+    extra_args=scaled_persistent_mm_args,
 )
 
 
@@ -466,8 +843,8 @@ def mm_options(config, sym_m, sym_n, sym_k, layout, b_prologue_cast_type=None):
         not inductor_config.force_same_precision
         or ((sym_m % 16) == 0 and (sym_n % 16) == 0 and (sym_k % 8) == 0)
     )
-    return dict(
-        GROUP_M=8,
+
+    options_dict = dict(
         EVEN_K=even_k_symbolic,
         ALLOW_TF32=allow_tf32,
         ACC_TYPE=acc_type(layout.dtype),
@@ -476,6 +853,13 @@ def mm_options(config, sym_m, sym_n, sym_k, layout, b_prologue_cast_type=None):
         num_warps=config.num_warps,
         **config.kwargs,
     )
+
+    # Add GROUP_M if it's not already specified in config.kwargs to avoid duplicate entries in dict
+    if "GROUP_M" not in config.kwargs:
+        group_m = config.kwargs.get("GROUP_M", 8)
+        options_dict["GROUP_M"] = group_m
+
+    return options_dict
 
 
 def persistent_mm_options(mat1, mat2):

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -26,7 +26,18 @@ from ..utils import (
 log = logging.getLogger(__name__)
 
 
-def _extract_configs(
+def triton_config(num_stages, num_warps, **kwargs):
+    from triton import Config  # type: ignore[attr-defined]
+
+    return Config(kwargs, num_stages=num_stages, num_warps=num_warps)
+
+
+def build_rocm_gemm_configs(configs):
+    rocm_num_stages = get_backend_num_stages()
+    return tuple((c[0], c[1], c[2], rocm_num_stages, c[4]) for c in configs)
+
+
+def extract_configs(
     configs: List[Dict[str, Any]]
 ) -> Tuple[List[Tuple[int, int, int, int, int]], List[Optional[Dict[str, Any]]]]:
     """
@@ -54,17 +65,6 @@ def _extract_configs(
             }
             extra_args.append(filtered_args)
     return triton_configs, extra_args
-
-
-def triton_config(num_stages, num_warps, **kwargs):
-    from triton import Config  # type: ignore[attr-defined]
-
-    return Config(kwargs, num_stages=num_stages, num_warps=num_warps)
-
-
-def build_rocm_gemm_configs(configs):
-    rocm_num_stages = get_backend_num_stages()
-    return tuple((c[0], c[1], c[2], rocm_num_stages, c[4]) for c in configs)
 
 
 def filtered_configs(
@@ -741,15 +741,15 @@ scaled_persistent_mm_kernel_configs = [
 
 # Create filtered list of configs based on cond evaluation
 # and parse other params as extra_args
-mm_platform_configs, mm_args = _extract_configs(mm_kernel_configs)
-extra_mm_platform_configs, extra_mm_args = _extract_configs(extra_mm_kernel_configs)
-int8_mm_platform_configs, int8_mm_args = _extract_configs(int8_mm_kernel_configs)
-mixed_mm_platform_configs, mixed_mm_args = _extract_configs(mixed_mm_kernel_configs)
-persistent_mm_platform_configs, persistent_mm_args = _extract_configs(
+mm_platform_configs, mm_args = extract_configs(mm_kernel_configs)
+extra_mm_platform_configs, extra_mm_args = extract_configs(extra_mm_kernel_configs)
+int8_mm_platform_configs, int8_mm_args = extract_configs(int8_mm_kernel_configs)
+mixed_mm_platform_configs, mixed_mm_args = extract_configs(mixed_mm_kernel_configs)
+persistent_mm_platform_configs, persistent_mm_args = extract_configs(
     persistent_mm_kernel_configs
 )
-scaled_mm_platform_configs, scaled_mm_args = _extract_configs(scaled_mm_kernel_configs)
-scaled_persistent_mm_platform_configs, scaled_persistent_mm_args = _extract_configs(
+scaled_mm_platform_configs, scaled_mm_args = extract_configs(scaled_mm_kernel_configs)
+scaled_persistent_mm_platform_configs, scaled_persistent_mm_args = extract_configs(
     scaled_persistent_mm_kernel_configs
 )
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -502,6 +502,8 @@ class CachingAutotuner(KernelInterface):
                     options["matrix_instr_nonkdim"] = compile_meta[
                         "matrix_instr_nonkdim"
                     ]
+                if "kpack" in compile_meta:
+                    options["kpack"] = compile_meta["kpack"]
             compile_kwargs = {
                 "target": target,
                 "options": options,

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -427,9 +427,14 @@ class TritonTemplateKernel(TritonKernel):
         triton_meta["configs"] = [config_of(signature)]
         for arg_num in triton_meta["configs"][0].equal_to_1:  # type: ignore[index]
             triton_meta["constants"][signature[arg_num].name] = 1  # type: ignore[index]
-        matrix_instr_nonkdim = self.meta.get("matrix_instr_nonkdim", 0)
-        if matrix_instr_nonkdim != 0:
+
+        if torch.version.hip:
+            matrix_instr_nonkdim = self.meta.get("matrix_instr_nonkdim", 0)
+            waves_per_eu = self.meta.get("waves_per_eu", 0)
+            kpack = self.meta.get("kpack", 1)
             triton_meta["matrix_instr_nonkdim"] = matrix_instr_nonkdim
+            triton_meta["waves_per_eu"] = waves_per_eu
+            triton_meta["kpack"] = kpack
 
         self.triton_meta = triton_meta
 
@@ -1194,6 +1199,8 @@ class TritonTemplate(KernelTemplate):
             num_stages=num_stages,
             num_warps=num_warps,
             matrix_instr_nonkdim=kwargs.get("matrix_instr_nonkdim", 0),
+            waves_per_eu=kwargs.get("waves_per_eu", 0),
+            kpack=kwargs.get("kpack", 2),
             input_tensor_meta=TensorMeta.from_irnodes(full_input_nodes),  # type: ignore[arg-type]
             output_tensor_meta=TensorMeta.from_irnodes(layout),
             workspace_arg=workspace_arg,
@@ -1216,6 +1223,7 @@ class TritonTemplate(KernelTemplate):
                 ),
                 "num_stages": num_stages,
                 "num_warps": num_warps,
+                "GROUP_M": kwargs.get("GROUP_M", -1),
                 "allow_tf32": str(kwargs.get("ALLOW_TF32", None)),
                 "acc_type": str(kwargs.get("ACC_TYPE", None)),
             },
@@ -1304,14 +1312,28 @@ class TritonTemplateCaller(ir.TritonTemplateCallerBase):
         if log_info is None:
             log_info = {}
         self.log_info: Dict[str, Any] = log_info
-        self.log_info.update(
-            {
-                "backend": "Triton",
-                "grid": str(self.bmreq.grid),
-                "num_stages": self.bmreq.num_stages,
-                "num_warps": self.bmreq.num_warps,
-            }
-        )
+        if torch.version.hip is None:
+            self.log_info.update(
+                {
+                    "backend": "Triton",
+                    "grid": str(self.bmreq.grid),
+                    "num_stages": self.bmreq.num_stages,
+                    "num_warps": self.bmreq.num_warps,
+                }
+            )
+        else:
+            self.log_info.update(
+                {
+                    "backend": "Triton",
+                    "grid": str(self.bmreq.grid),
+                    "num_stages": self.bmreq.num_stages,
+                    "num_warps": self.bmreq.num_warps,
+                    "matrix_instr_nonkdim": self.bmreq.matrix_instr_nonkdim,
+                    "waves_per_eu": self.bmreq.waves_per_eu,
+                    "kpack": self.bmreq.kpack,
+                }
+            )
+
         self.mutated_inputs = mutated_inputs
         self.workspace_arg = workspace_arg
         self.allowed_prologue_inps = (


### PR DESCRIPTION
Adds tuning options for extra_args in mm_common.py on ROCm side we can supply specific triton tuning args such as waves_per_eu, kpack, matrix_instr_nonkdim. This PR also introduces behavior to allow tuning for GROUP_M in triton gemm case. Also brings in specific tuning for general ROCm gemm case.

Dynamo huggingface inference benchmarks (with TORCHINDUCTOR_MAX_AUTOTUNE=1, TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_BACKENDS="TRITON", --bfloat16)
> GEOMEAN speedup   (before): | 1.36x
GEOMEAN speedup   (after): | 1.42x

We are also seeing improvement ~9% on internal addmm benchmark

This will require a follow up to see if we can prune the new config list further.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov