### PR TITLE
[C10D] Update docs for wait()

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -414,8 +414,7 @@ is guaranteed to support two methods:
   returns ``True`` if the operation has been successfully enqueued onto a CUDA stream and the output can be utilized on the
   default stream without further synchronization.
 * ``wait()`` - in the case of CPU collectives, will block the process until the operation is completed. In the case
-  of CUDA collectives, will block until the operation has been successfully enqueued onto a CUDA stream and the
-  output can be utilized on the default stream without further synchronization.
+  of CUDA collectives, will block the currently active CUDA stream until the operation is completed (but will not block the CPU).
 * ``get_future()`` - returns ``torch._C.Future`` object. Supported for NCCL, also supported for most operations on GLOO
   and MPI, except for peer to peer operations.
   Note: as we continue adopting Futures and merging APIs, ``get_future()`` call might become redundant.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143305

Clarify that currently active stream, not default stream, is the one
that will be blocked by a call to wait(), and also point out that the
CPU is not blocked by the call for CUDA/nccl collectives.