### PR TITLE
Add a check on norm_type in LPPool2d

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1126,6 +1126,9 @@ def lp_pool2d(
 
     See :class:`~torch.nn.LPPool2d` for details.
     """
+    if norm_type == 0:
+        raise ValueError("norm_type should not be 0")
+
     if has_torch_function_unary(input):
         return handle_torch_function(
             lp_pool2d,


### PR DESCRIPTION
Fixes #134841. Added a check to ensure that the norm_type is not 0 to prevent the division by 0 error. Error messaging now informs the user that norm_type should not be 0.
