### PR TITLE
Enable swap on all Linux jobs

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -137,3 +137,15 @@ runs:
         done
         echo "Reached maximum attempts to connect to Docker. Exiting."
         exit 1
+
+    - name: Enable swap
+      shell: bash
+      continue-on-error: true
+      run: |
+        set -ex
+
+        # Testing https://github.com/pytorch/test-infra/pull/6058
+        sudo fallocate -l 3G /swapfile
+        sudo chmod 600 /swapfile
+        sudo mkswap /swapfile
+        sudo swapon /swapfile

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -137,17 +137,3 @@ runs:
         done
         echo "Reached maximum attempts to connect to Docker. Exiting."
         exit 1
-
-    - name: Enable swap
-      shell: bash
-      continue-on-error: true
-      run: |
-        set -ex
-
-        sudo swapoff /swapfile
-        sudo rm /swapfile
-        # Testing https://github.com/pytorch/test-infra/pull/6058
-        sudo fallocate -l 3G /swapfile
-        sudo chmod 600 /swapfile
-        sudo mkswap /swapfile
-        sudo swapon /swapfile

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -144,6 +144,8 @@ runs:
       run: |
         set -ex
 
+        sudo swapoff /swapfile
+        sudo rm /swapfile
         # Testing https://github.com/pytorch/test-infra/pull/6058
         sudo fallocate -l 3G /swapfile
         sudo chmod 600 /swapfile

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -227,8 +227,9 @@ jobs:
 
           # Leaving 1GB for the runner and other things
           TOTAL_AVAILABLE_MEMORY_IN_GB=$(awk '/MemTotal/ { printf "%.3f \n", $2/1024/1024 - 1 }' /proc/meminfo)
-          # https://docs.docker.com/engine/containers/resource_constraints/#--memory-swap-details
-          TOTAL_MEMORY_WITH_SWAP=$(("${TOTAL_AVAILABLE_MEMORY_IN_GB%.*}" * 2))
+          # https://docs.docker.com/engine/containers/resource_constraints/#--memory-swap-details, the 3GB swap
+          # comes from https://github.com/pytorch/test-infra/pull/6058
+          TOTAL_MEMORY_WITH_SWAP=$(("${TOTAL_AVAILABLE_MEMORY_IN_GB%.*}" + 3))
 
           # detached container should get cleaned up by teardown_ec2_linux
           # Used for JENKINS_USER, which can be empty

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -253,6 +253,12 @@ jobs:
             TEST_COMMAND=.ci/pytorch/test.sh
           fi
 
+          # Leaving 1GB for the runner and other things
+          TOTAL_AVAILABLE_MEMORY_IN_GB=$(awk '/MemTotal/ { printf "%.3f \n", $2/1024/1024 - 1 }' /proc/meminfo)
+          # https://docs.docker.com/engine/containers/resource_constraints/#--memory-swap-details, the 3GB swap
+          # comes from https://github.com/pytorch/test-infra/pull/6058
+          TOTAL_MEMORY_WITH_SWAP=$(("${TOTAL_AVAILABLE_MEMORY_IN_GB%.*}" + 3))
+
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG since that doesn't play nice
@@ -301,6 +307,8 @@ jobs:
             -e DASHBOARD_TAG \
             -e IS_A100_RUNNER \
             -e ARTIFACTS_FILE_SUFFIX \
+            --memory="${TOTAL_AVAILABLE_MEMORY_IN_GB%.*}g" \
+            --memory-swap="${TOTAL_MEMORY_WITH_SWAP}g" \
             --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
             --security-opt seccomp=unconfined \
             --cap-add=SYS_PTRACE \


### PR DESCRIPTION
A swapfile on Linux runner has been prepared by https://github.com/pytorch/test-infra/pull/6058.  So this PR does 2 things:

* Start using the swapfile on all Linux build and test jobs
* Testing the rollout https://github.com/pytorch-labs/pytorch-gha-infra/pull/582

### Testing

Run `swapon` inside the container and the swapfile shows up correctly:

```
jenkins@259dfb0a314c:~/workspace$ swapon
NAME      TYPE SIZE USED PRIO
/swapfile file   3G 256K   -2
```