### PR TITLE
FileTimerClient: add retry logic on connect

### DIFF
--- a/torch/distributed/elastic/timer/file_based_local_timer.py
+++ b/torch/distributed/elastic/timer/file_based_local_timer.py
@@ -27,6 +27,32 @@ __all__ = ["FileTimerClient", "FileTimerRequest", "FileTimerServer"]
 logger = get_logger(__name__)
 
 
+def _retry(max_retries: int, sleep_time: float) -> Callable:
+    """
+    A simple retry wrapper.
+
+    Args:
+        max_retries: int, the maximum number of retries.
+        sleep_time: float, the time to sleep between retries.
+    """
+
+    def wrapper(func: Callable) -> Callable:
+        def wrapper(*args, **kwargs):
+            for i in range(max_retries):
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    logger.exception("Error running %s. Retrying...", func.__name__)
+                    if i < max_retries - 1:
+                        time.sleep(sleep_time)
+                    else:
+                        raise
+
+        return wrapper
+
+    return wrapper
+
+
 class FileTimerRequest(TimerRequest):
     """
     Data object representing a countdown timer acquisition and release
@@ -99,23 +125,22 @@ class FileTimerClient(TimerClient):
         self._file_path = file_path
         self.signal = signal
 
+    @_retry(max_retries=10, sleep_time=0.1)
     def _open_non_blocking(self) -> Optional[io.TextIOWrapper]:
-        try:
-            fd = os.open(self._file_path, os.O_WRONLY | os.O_NONBLOCK)
-            return os.fdopen(fd, "wt")
-        except Exception:
-            return None
-
-    def _send_request(self, request: FileTimerRequest) -> None:
         # The server may have crashed or may haven't started yet.
         # In such case, calling open() in blocking model blocks the client.
         # To avoid such issue, open it in non-blocking mode, and an OSError will
         # be raised if the server is not there.
-        file = self._open_non_blocking()
-        if file is None:
+        fd = os.open(self._file_path, os.O_WRONLY | os.O_NONBLOCK)
+        return os.fdopen(fd, "wt")
+
+    def _send_request(self, request: FileTimerRequest) -> None:
+        try:
+            file = self._open_non_blocking()
+        except Exception as e:
             raise BrokenPipeError(
                 "Could not send the FileTimerRequest because FileTimerServer is not available."
-            )
+            ) from e
         with file:
             json_request = request.to_json()
             # Write request with no greater than select.PIPE_BUF is guarantee to be atomic.
@@ -250,7 +275,13 @@ class FileTimerServer:
         #  1. No client case usually does not happen.
         #  2. We are running the watchdog loop in a separate daemon
         #     thread, which will not block the process to stop.
-        with open(self._file_path) as fd:
+        try:
+            fd = open(self._file_path)
+        except Exception as e:
+            logger.exception("Could not open the FileTimerServer pipe")
+            raise
+
+        with fd:
             self._is_client_started = True
             while not self._stop_signaled:
                 try:


### PR DESCRIPTION
Fixes #143188

The fifo server binds from a thread -- under rare cases the client connects before the server thread starts. This adds a retry when opening the fifo socket in non-blocking mode. This will wait up to 1s for the server to start which balances fast error messages while still providing some wiggle room on the server side.

Test plan:

```
pytest --minutes 10 test/distributed/elastic/timer/file_based_local_timer_test.py -k test_watchdog_call_count -x
```

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @c-p-i-o @cdzhan 
