### PR TITLE
[ROCm] Fix unit test: matmul_offline_tunableop

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4967,7 +4967,8 @@ class TestLinalg(TestCase):
     @onlyCUDA
     @dtypes(torch.half)
     def test_minimum_tuning_iteration_tunableop(self, device, dtype):
-        # Make sure that there is at least one tuning iteration under various scenarios
+        # Make sure that there is at least one tuning iteration when the tuning duration
+        # is set to zero
 
         # Test in try-finally block to avoid leaking state
         # if test is interrupted.

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4994,26 +4994,6 @@ class TestLinalg(TestCase):
         # There must be a new tuning result
         self.assertEqual((total_num_results - ref_num_results), 1)
 
-        # Set tuning iterations to zero
-        # Tune a single GEMM and verify that we get a new tuning result
-        os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_ITERATIONS"] = "0"
-        self.assertGreater(torch.cuda.tunable.get_max_tuning_iterations(), 0)
-        os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_ITERATIONS"] = "100"  # reset to default
-
-        # Reference number of results
-        ref_num_results = total_num_results
-
-        N = M = K = 16
-        A = torch.randn(N, K, device=device, dtype=dtype)
-        B = torch.randn(K, M, device=device, dtype=dtype)
-        C = torch.matmul(A, B)
-
-        # This stores total number of cummulative results
-        total_num_results = len(torch.cuda.tunable.get_results())
-
-        # There must be a new tuning result
-        self.assertEqual((total_num_results - ref_num_results), 1)
-
         # disable TunableOp
         torch.cuda.tunable.enable(False)
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4967,18 +4967,15 @@ class TestLinalg(TestCase):
     @onlyCUDA
     @dtypes(torch.half)
     def test_minimum_tuning_iteration_tunableop(self, device, dtype):
-        # Make sure that there is at least one tuning iteration when the tuning duration
-        # is set to zero
-
+        # Make sure that there is at least one tuning iteration occurs
+        # when the max tuning duration and max tuning iteration are set
+        # to zero.
         set_tunableop_defaults()
         torch.cuda.tunable.enable()
 
-        # Set tuning duration to zero milliseconds
         # Tune a single GEMM and verify that we get a new tuning result
-        import os
-        os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_DURATION_MS"] = "0"
-        self.assertGreater(torch.cuda.tunable.get_max_tuning_iterations(), 0)
-        os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_DURATION_MS"] = "30"  # reset to default
+        torch.cuda.tunable.set_max_tuning_duration(0)
+        torch.cuda.tunable.set_max_tuning_iterations(0)
 
         # Reference number of results
         ref_num_results = len(torch.cuda.tunable.get_results())

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5070,60 +5070,58 @@ class TestLinalg(TestCase):
         # PYTORCH_TUNABLEOP_TUNING=0
         # is no longer tuning GEMMs.
 
+        set_tunableop_defaults()
+        torch.cuda.tunable.enable()
+        # set these to single iterations to keep it short but still exercise the code
+        torch.cuda.tunable.set_max_tuning_iterations(1)
+
+        # Reference number of results
+        ref_num_results = len(torch.cuda.tunable.get_results())
+
+        # Tune one GEMMs to make sure TunableOp is enabled
+        M = 3
+        N = 3
+        K = 3
+        A = torch.randn(N, K, device=device, dtype=dtype)
+        B = torch.randn(K, M, device=device, dtype=dtype)
+        C = torch.matmul(A, B)
+
+        # This stores total number of cummulative results
+        total_num_results = len(torch.cuda.tunable.get_results())
+
+        # Take the difference to calculate the number of results from
+        # this test. There should be one additional tuned GEMM
+        self.assertEqual((total_num_results - ref_num_results), 1)
+
+        # New total number of results becomes new reference result
+        ref_num_results = total_num_results
+
+        # Now disable further tuning, while keeping TunableOp Enabled
+        torch.cuda.tunable.tuning_enable(False)
+
+        # Try to tune one more GEMM
+        M = 3
+        N = 3
+        K = 4
+        A = torch.randn(N, K, device=device, dtype=dtype)
+        B = torch.randn(K, M, device=device, dtype=dtype)
+        C = torch.matmul(A, B)
+
+        # Take the difference to calculate the number of results from
+        # this test. There should be no change in the number of results
+        # since tuning is disabe.
+        self.assertEqual((total_num_results - ref_num_results), 0)
+
+        # disable TunableOp
+        torch.cuda.tunable.enable(False)
+
+        # clean up, remove any file that was generated
         try:
-            set_tunableop_defaults()
-            torch.cuda.tunable.enable()
-            # set these to single iterations to keep it short but still exercise the code
-            torch.cuda.tunable.set_max_tuning_iterations(1)
-
-            # Reference number of results
-            ref_num_results = len(torch.cuda.tunable.get_results())
-
-            # Tune one GEMMs to make sure TunableOp is enabled
-            M = 3
-            N = 3
-            K = 3
-            A = torch.randn(N, K, device=device, dtype=dtype)
-            B = torch.randn(K, M, device=device, dtype=dtype)
-            C = torch.matmul(A, B)
-
-            # This stores total number of cummulative results
-            total_num_results = len(torch.cuda.tunable.get_results())
-
-            # Take the difference to calculate the number of results from
-            # this test. There should be one additional tuned GEMM
-            self.assertEqual((total_num_results - ref_num_results), 1)
-
-            # New total number of results becomes new reference result
-            ref_num_results = total_num_results
-
-            # Now disable further tuning, while keeping TunableOp Enabled
-            torch.cuda.tunable.tuning_enable(False)
-
-            # Try to tune one more GEMM
-            M = 3
-            N = 3
-            K = 4
-            A = torch.randn(N, K, device=device, dtype=dtype)
-            B = torch.randn(K, M, device=device, dtype=dtype)
-            C = torch.matmul(A, B)
-
-            # Take the difference to calculate the number of results from
-            # this test. There should be no change in the number of results
-            # since tuning is disabe.
-            self.assertEqual((total_num_results - ref_num_results), 0)
-
-        finally:
-            # disable TunableOp
-            torch.cuda.tunable.enable(False)
-
-            # clean up, remove any file that was generated
-            try:
-                import os
-                filename = torch.cuda.tunable.get_filename()
-                os.remove(filename)
-            except FileNotFoundError:
-                pass
+            import os
+            filename = torch.cuda.tunable.get_filename()
+            os.remove(filename)
+        except FileNotFoundError:
+            pass
 
     @onlyCUDA
     @dtypes(torch.float)


### PR DESCRIPTION
Fixes #137936

The PR contains:
* Fix for `matmul_offline_tunableop`
* Clean-up try-finally blocks in UTs that don't use environment variables (`test_validator_tunableop_rocm`, `test_minimum_tuning_iteration_tunableop`, `test_disable_tuning_tunableop`)
* Avoid the use of environment variables in `minimum_tuning_iteration_tunableop`




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang