### PR TITLE
NJT linear_backward should not return inner tensor as-is

### DIFF
--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -586,7 +586,7 @@ def linear_backward_default(func, *args, **kwargs):
         dw = torch.matmul(grad_2d.t(), input_2d)
     if output_mask[2]:
         # NB: autograd engine will sum over all but the last dim to get a 1D bias grad.
-        db = grad_output._values
+        db = grad_output._values.detach()
     return (ds, dw, db)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #143415
* __->__ #143333

Fixes debug=1 use-count checks https://github.com/pytorch/pytorch/actions/runs/12187808902/job/34002323481#step:22:2521
