### PR TITLE
[dynamo, eval frame] manually manage ExtraState memory

### DIFF
--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -100,6 +100,10 @@ ExtraState* get_extra_state(PyCodeObject* code) {
 }
 
 void destroy_extra_state(void* obj) {
+  if (_extra_states.empty()) {
+    // cleared - likely by atexit; prevent use-after-free
+    return;
+  }
   ExtraState* extra = (ExtraState*)obj;
   if (!is_extra_state_unset(extra)) {
     _deleted_code.push_back(extra->orig_code);

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -234,3 +234,8 @@ py::list _debug_get_cache_entry_list(const py::handle& code_obj) {
   }
   return result;
 }
+
+void _register_extra_state_memory_cleanup() {
+  auto atexit = py::module_::import("atexit");
+  atexit.attr("register")(py::cpp_function([]() { _extra_states.clear(); }));
+}

--- a/torch/csrc/dynamo/extra_state.h
+++ b/torch/csrc/dynamo/extra_state.h
@@ -40,8 +40,8 @@ typedef struct CacheEntry CacheEntry;
 #ifdef __cplusplus
 
 typedef struct VISIBILITY_HIDDEN ExtraState {
-  // A pointer to the orig_code object to prevent race conditions in invalidate
-  // function.
+  // A pointer to the original PyCodeObject referring to this ExtraState.
+  // Used to delete this ExtraState at the right time if orig_code is deleted.
   PyCodeObject* orig_code;
   // List of cache entries for compiled code objects
   std::list<CacheEntry> cache_entry_list;

--- a/torch/csrc/dynamo/extra_state.h
+++ b/torch/csrc/dynamo/extra_state.h
@@ -180,4 +180,6 @@ PyObject* get_backend(PyObject* callback);
 // Warning: returns references whose lifetimes are controlled by C++
 py::list _debug_get_cache_entry_list(const py::handle& code_obj);
 
+void _register_extra_state_memory_cleanup();
+
 #endif

--- a/torch/csrc/dynamo/init.cpp
+++ b/torch/csrc/dynamo/init.cpp
@@ -82,6 +82,8 @@ void initDynamoBindings(PyObject* torch) {
   m.def("_debug_get_cache_entry_list", &_debug_get_cache_entry_list);
   py::bind_vector<std::vector<uint8_t>>(m, "VectorUInt8");
   m.attr("py_opcode_caches") = _PyOpcode_Caches_vec;
+
+  _register_extra_state_memory_cleanup();
 }
 
 } // namespace torch::dynamo


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143340

Fixes https://github.com/pytorch/pytorch/issues/140998

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames