### PR TITLE
[MTIA] (3/n) Implement PyTorch APIs to query/reset device peak memory usage

### DIFF
--- a/docs/source/mtia.memory.rst
+++ b/docs/source/mtia.memory.rst
@@ -11,3 +11,4 @@ The MTIA backend is implemented out of the tree, only interfaces are be defined 
     :nosignatures:
 
     memory_stats
+    max_memory_allocated

--- a/docs/source/mtia.rst
+++ b/docs/source/mtia.rst
@@ -19,6 +19,7 @@ The MTIA backend is implemented out of the tree, only interfaces are be defined 
     is_available
     is_initialized
     memory_stats
+    max_memory_allocated
     get_device_capability
     empty_cache
     set_device

--- a/torch/mtia/memory.py
+++ b/torch/mtia/memory.py
@@ -10,6 +10,19 @@ from . import _device_t, is_initialized
 from ._utils import _get_device_index
 
 
+def max_memory_allocated(device: Optional[_device_t] = None) -> int:
+    r"""Return the maximum memory allocated in bytes for a given device.
+
+    Args:
+        device (torch.device, str, or int, optional) selected device. Returns
+            statistics for the current device, given by current_device(),
+            if device is None (default).
+    """
+    if not is_initialized():
+        return 0
+    return memory_stats(device).get("dram", 0).get("peak_bytes", 0)
+
+
 def memory_stats(device: Optional[_device_t] = None) -> Dict[str, Any]:
     r"""Return a dictionary of MTIA memory allocator statistics for a given device.
 
@@ -21,18 +34,6 @@ def memory_stats(device: Optional[_device_t] = None) -> Dict[str, Any]:
     if not is_initialized():
         return {}
     return torch._C._mtia_memoryStats(_get_device_index(device, optional=True))
-
-
-def max_memory_allocated(device: Optional[_device_t] = None) -> int:
-    r"""Return the maximum memory allocated in bytes for a given device.
-
-    Args:
-        device (torch.device or int, optional): selected device. Returns
-            statistic for the current device, given by :func:`~torch.mtia.current_device`,
-            if :attr:`device` is ``None`` (default).
-    """
-
-    return memory_stats(device=device).get("allocated_bytes.all.peak", 0)
 
 
 __all__ = [


### PR DESCRIPTION
Summary: This diff implements the "max_memory_allocated" PyTorch API for MTIA devices, which returns the peak device DRAM usage

Test Plan:
Passed the local unit test
```
buck2 test //mtia/host_runtime/torch_mtia/tests:test_torch_mtia_api -- -r test_max_memory_allocated
```

https://www.internalfb.com/intern/testinfra/testrun/8444249544807192

Reviewed By: yuhc, egienvalue

Differential Revision: D67118173


