### PR TITLE
Implement additional properties [ mean, stddev, variance] for TransformedDistribution

### DIFF
--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -217,7 +217,7 @@ class TransformedDistribution(Distribution):
 
     @property
     def mean(self):
-        value = self.base_dist.mean
-        for transform in self.transforms:
-            value = transform.mean(value)
-        return value
+        if len(self.transforms) == 1:
+            return = transform.mean(self.base_dist.mean)
+        else raise NotImplementedError
+

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -218,6 +218,6 @@ class TransformedDistribution(Distribution):
     @property
     def mean(self):
         if len(self.transforms) == 1:
-            return = transform.mean(self.base_dist.mean)
-        else raise NotImplementedError
+            return transform.mean(self.base_dist.mean)
+        else: raise NotImplementedError
 

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -214,3 +214,10 @@ class TransformedDistribution(Distribution):
         for transform in self.transforms:
             value = transform(value)
         return value
+
+    @property
+    def mean(self):
+        value = self.base_dist.mean
+        for transform in self.transforms:
+            value = transform.mean(value)
+        return value

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -218,6 +218,6 @@ class TransformedDistribution(Distribution):
     @property
     def mean(self):
         if len(self.transforms) == 1:
-            return transform.mean(self.base_dist.mean)
+            transform = self.transforms[0]
+            return transform.mean(self.base_dist)
         else: raise NotImplementedError
-

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -135,6 +135,12 @@ class Transform:
         In general this only makes sense for bijective transforms.
         """
         raise NotImplementedError
+    
+    def mean(self, base_mean):
+        """
+        Returns the mean of the transformed distribution
+        """
+        raise NotImplementedError
 
     def with_cache(self, cache_size=1):
         if self._cache_size == cache_size:
@@ -740,6 +746,9 @@ class AffineTransform(Transform):
         if self.event_dim == 0:
             return constraints.real
         return constraints.independent(constraints.real, self.event_dim)
+    
+    def mean(self, base_mean):
+        return self.loc + self.scale * base_mean
 
     def with_cache(self, cache_size=1):
         if self._cache_size == cache_size:

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -8,7 +8,6 @@ from typing import List
 
 import torch
 import torch.nn.functional as F
-from torch.distributions import Distribution, Normal
 from torch.distributions import constraints
 from torch.distributions.utils import (
     _sum_rightmost,
@@ -137,7 +136,7 @@ class Transform:
         """
         raise NotImplementedError
     
-    def mean(self, base_dist: Distribution):
+    def mean(self, base_distribution):
         """
         Returns the mean of the transformed distribution
         """
@@ -566,7 +565,7 @@ class ExpTransform(Transform):
         return x
     
     def mean(self, base_distribution):
-        if isinstance(base_distribution, Normal):
+        if isinstance(base_distribution, torch.distributions.Normal):
             return torch.exp(base_distribution.variance/2 + base_distribution.mean)
         else:
              raise NotImplementedError
@@ -755,7 +754,7 @@ class AffineTransform(Transform):
             return constraints.real
         return constraints.independent(constraints.real, self.event_dim)
     
-    def mean(self, base_distribution: Distribution):
+    def mean(self, base_distribution):
         return self.loc + self.scale * base_distribution.mean
 
     def with_cache(self, cache_size=1):

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -563,6 +563,9 @@ class ExpTransform(Transform):
 
     def log_abs_det_jacobian(self, x, y):
         return x
+    
+    def mean(self, base_mean):
+        return super().mean(base_mean)
 
 
 class PowerTransform(Transform):


### PR DESCRIPTION
Fixes #142825
I plan to implement the mean, stddev and variance for the TransformedDistribution that currently raise a NotImplementedError.
The idea would be adding a method "mean" to as many transformations as possible.
```python
 def mean(self, base_distribution):
        """  
        Returns the mean of the transformed distribution  
        """  
        raise NotImplementedError  
```
I have currently just implemented the mean for the AffineTransformation and the ExponentialTrasformation with Normal as base distribution in order to receive some feedback about the general idea.
I will wait for some feedback and in case it is positive, I will continue with it.
For most of the other transformations there are two options I think:

* Compute the analytical solution for as many combinations of distributions and transformations as possible.
* Implement a Montecarlo simulation for the ones not implemented analitically.

Maybe it would be better not to implement anything with montecarlo, but instead keeping the NotImplementedError.


cc @fritzo @neerajprad @alicanb @nikitaved