### PR TITLE
[fr] recognize all_reduce_barrier as a valid op

### DIFF
--- a/test/distributed/flight_recorder/test_fr_analysis.py
+++ b/test/distributed/flight_recorder/test_fr_analysis.py
@@ -7,7 +7,7 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent.parent
 
 sys.path.insert(0, str(REPO_ROOT))
-from tools.flight_recorder.components.types import MatchState
+from tools.flight_recorder.components.types import COLLECTIVES, MatchState
 from tools.flight_recorder.components.utils import match_one_event
 
 
@@ -18,7 +18,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 def create_one_event(
-    collectcive_name,
+    collective_name,
     pg_info,
     input_sizes,
     output_sizes,
@@ -28,7 +28,7 @@ def create_one_event(
     output_dtypes="float32",
 ):
     return {
-        "profiling_name": f"nccl:{collectcive_name}",
+        "profiling_name": f"nccl:{collective_name}",
         "state": state,
         "process_group": pg_info,
         "input_sizes": input_sizes,
@@ -110,6 +110,17 @@ class FlightRecorderEventTest(TestCase):
             match_one_event(e10, e9, membership, "0"),
             MatchState.COLLECTIVE_DTYPE_MISMATCH,
         )
+
+    def test_all_events(self):
+        for collective in COLLECTIVES:
+            event = create_one_event(
+                collective, ("0", "default"), [[4, 4]], [[4, 4]], "scheduled", 1
+            )
+            membership = {"0": {0, 1}}
+            self.assertEqual(
+                match_one_event(event, event, membership, "0"), MatchState.FULLY_MATCHED
+            )
+            break
 
 
 if __name__ == "__main__":

--- a/tools/flight_recorder/components/types.py
+++ b/tools/flight_recorder/components/types.py
@@ -191,6 +191,7 @@ COLLECTIVES = {
     "gather",
     "scatter",
     "all_to_all",
+    "all_reduce_barrier",
 }
 
 P2P = {


### PR DESCRIPTION
Summary:
D67068632 introduced a better profiling name for barrier operations to be able to distinguish various ops.

Unfortunately, this broke Flight Recorder Analysis with the following error as reported by dmwu
```
fr_trace -m torchx-param_bench_16g_mi300x-all_to_all -a 0 --mast_job_version 98 -w 16
Traceback (most recent call last):
  File "/usr/local/fbcode/platform010/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/fbcode/platform010/lib/python3.10/runpy.py", line 86, in _run_code
```

Test Plan: Test manually.

Differential Revision: D67305997




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k