### PR TITLE
Remove assert from partitioner.py

### DIFF
--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -182,11 +182,6 @@ class CapabilityBasedPartitioner:
                     if target_id is not None:
                         partition_map[id].add(target_id)
                         partition_map[id].update(partition_map[target_id])
-                    else:
-                        assert not self.__is_node_supported(
-                            user_node
-                        ), "Encountered user node which has not been traversed yet. \
-                            This should only happen if this is an unsupported node."
 
                 # Iterate through all the upstream nodes of this node and update the partition map
                 # to indicate that there is a path from the partition id of the upstream node to the


### PR DESCRIPTION
Remove erroneous assert assuming a dependent (user) node to be in the partition. This partially reverts #136616 by removing the assert.

Tested locally with a failing ExecuTorch Arm test using
```
$ python -m examples.arm.aot_arm_compiler --model_name mv2 --target ethos-u55-128 --delegate --quantize
```

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv