### PR TITLE
Add 2 more APIs to the exposed public torch python APIs

### DIFF
--- a/torch/csrc/DynamicTypes.h
+++ b/torch/csrc/DynamicTypes.h
@@ -33,5 +33,5 @@ bool isStorage(PyObject* obj);
 
 // Both methods below return a borrowed reference!
 TORCH_PYTHON_API THPDtype* getTHPDtype(at::ScalarType scalarType);
-THPLayout* getTHPLayout(at::Layout layout);
+TORCH_PYTHON_API THPLayout* getTHPLayout(at::Layout layout);
 } // namespace torch

--- a/torch/csrc/autograd/python_cpp_function.h
+++ b/torch/csrc/autograd/python_cpp_function.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <torch/csrc/Export.h>
 #include <torch/csrc/python_headers.h>
 #include <memory>
 #include <typeinfo>
@@ -104,6 +105,6 @@ PyTypeObject* createForwardFunctionPyTypeObject(
 void registerCppFunction(const std::type_info& type, PyTypeObject* pytype);
 PyObject* functionToPyObject(const std::shared_ptr<Node>& cdata);
 
-bool THPCppFunction_Check(PyObject* obj);
+TORCH_PYTHON_API bool THPCppFunction_Check(PyObject* obj);
 
 } // namespace torch::autograd

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -85,7 +85,7 @@ static const std::unordered_map<std::string, std::vector<std::string>>
 // If you modify this, you will need to adjust the blocklist in
 // tools/pyi/gen_pyi.py (and add hardcoded signatures for these
 // functions.)
-bool should_allow_numbers_as_tensors(const std::string& name) {
+TORCH_PYTHON_API bool should_allow_numbers_as_tensors(const std::string& name) {
   static std::unordered_set<std::string> allowed = {
       "add",          "add_",          "add_out",
       "div",          "div_",          "div_out",

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -85,7 +85,7 @@ static const std::unordered_map<std::string, std::vector<std::string>>
 // If you modify this, you will need to adjust the blocklist in
 // tools/pyi/gen_pyi.py (and add hardcoded signatures for these
 // functions.)
-TORCH_PYTHON_API bool should_allow_numbers_as_tensors(const std::string& name) {
+bool should_allow_numbers_as_tensors(const std::string& name) {
   static std::unordered_set<std::string> allowed = {
       "add",          "add_",          "add_out",
       "div",          "div_",          "div_out",

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -94,7 +94,7 @@ inline bool THPUtils_checkScalar(PyObject* obj) {
 
 namespace torch {
 
-bool should_allow_numbers_as_tensors(const std::string& name);
+TORCH_PYTHON_API bool should_allow_numbers_as_tensors(const std::string& name);
 
 enum class ParameterType {
   TENSOR,


### PR DESCRIPTION
These two APIs are being used internally for some projects and need to be exposed as the build for this is done using OSS toolchain.

https://github.com/pytorch/pytorch/commit/af8789c05654477649e4d99e6a253a2ebd81ad9e - this change hid most apis in torch python barring the ones explicitly specified breaking the build.