### PR TITLE
[codemod] Decorate unused variables with `[[maybe_unused]]`

### DIFF
--- a/aten/src/ATen/test/cpu_caching_allocator_test.cpp
+++ b/aten/src/ATen/test/cpu_caching_allocator_test.cpp
@@ -23,8 +23,7 @@ TEST(CPUCachingAllocatorTest, check_alloc_outside_free_inside) {
   {
     c10::WithCPUCachingAllocatorGuard cachine_allocator_guard(
         &caching_allocator);
-    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-    float* data_ptr = a.data_ptr<float>();
+    [[maybe_unused]] float* data_ptr = a.data_ptr<float>();
     a.reset();
     a = at::rand({23, 23});
   }

--- a/aten/src/ATen/test/tensor_interop_test.cpp
+++ b/aten/src/ATen/test/tensor_interop_test.cpp
@@ -148,9 +148,9 @@ TEST(PytorchToCaffe2, Op) {
   auto at_tensor_c = at::ones({5, 5}, at::dtype(at::kFloat));
 
   // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-  auto* c2_tensor_a = BlobSetTensor(workspace.CreateBlob("a"), caffe2::Tensor(at_tensor_a));
+  [[maybe_unused]] auto* c2_tensor_a = BlobSetTensor(workspace.CreateBlob("a"), caffe2::Tensor(at_tensor_a));
   // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-  auto* c2_tensor_b = BlobSetTensor(workspace.CreateBlob("b"), caffe2::Tensor(at_tensor_b));
+  [[maybe_unused]] auto* c2_tensor_b = BlobSetTensor(workspace.CreateBlob("b"), caffe2::Tensor(at_tensor_b));
 
   // Test Alias
   {
@@ -187,9 +187,9 @@ TEST(PytorchToCaffe2, SharedStorageRead) {
   auto at_tensor_b = at_tensor_a.view({5, 5});
 
   // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-  auto* c2_tensor_a = BlobSetTensor(workspace.CreateBlob("a"), caffe2::Tensor(at_tensor_a));
+  [[maybe_unused]] auto* c2_tensor_a = BlobSetTensor(workspace.CreateBlob("a"), caffe2::Tensor(at_tensor_a));
   // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-  auto* c2_tensor_b = BlobSetTensor(workspace.CreateBlob("b"), caffe2::Tensor(at_tensor_b));
+  [[maybe_unused]] auto* c2_tensor_b = BlobSetTensor(workspace.CreateBlob("b"), caffe2::Tensor(at_tensor_b));
 
   {
     auto op = net.add_op();

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -841,7 +841,7 @@ void all2all_single_equal_split(
 
   auto type = to_nccl_data_type(input);
   size_t count = input.numel() / size;
-  size_t rankdiff = input.nbytes() / size;
+  [[maybe_unused]] size_t rankdiff = input.nbytes() / size;
   const auto* sendbuff = reinterpret_cast<const char*>(input.const_data_ptr());
   auto* recvbuff = reinterpret_cast<char*>(output.data_ptr());
   auto comm = to_nccl_comm(_comm);


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Test Plan: Sandcastle

Reviewed By: palmje




