### PR TITLE
Enable torch.compile check on nightly validaitons

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -91,7 +91,7 @@ fi
 
 if [[ "\$GPU_ARCH_TYPE" != *s390x* && "\$GPU_ARCH_TYPE" != *xpu* && "\$GPU_ARCH_TYPE" != *rocm*  && "$PACKAGE_TYPE" != libtorch ]]; then
   # Exclude s390, xpu, rocm and libtorch builds from smoke testing
-  python /pytorch/.ci/pytorch/smoke_test/smoke_test.py --package=torchonly --torch-compile-check disabled
+  python /pytorch/.ci/pytorch/smoke_test/smoke_test.py --package=torchonly --runtime-error-check disabled
 fi
 
 # Clean temp files


### PR DESCRIPTION
I am seeing an error with torch.compile python 3.13. Please see https://github.com/pytorch/test-infra/issues/6077#issue-2745142173 

Error:
```
esting smoke_test_compile for cuda and torch.float16
Traceback (most recent call last):
  File "/pytorch/pytorch/.ci/pytorch/./smoke_test/smoke_test.py", line 385, in <module>
    main()
    ~~~~^^
  File "/pytorch/pytorch/.ci/pytorch/./smoke_test/smoke_test.py", line 379, in main
    smoke_test_cuda(
    ~~~~~~~~~~~~~~~^
        options.package, options.runtime_error_check, options.torch_compile_check
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/pytorch/pytorch/.ci/pytorch/./smoke_test/smoke_test.py", line 186, in smoke_test_cuda
    smoke_test_compile("cuda" if torch.cuda.is_available() else "cpu")
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pytorch/pytorch/.ci/pytorch/./smoke_test/smoke_test.py", line 286, in smoke_test_compile
    x_pt2 = torch.compile(foo)(x)
  File "/opt/conda/envs/conda-env-12375056109/lib/python3.13/site-packages/torch/_dynamo/eval_frame.py", line 573, in _fn
    return fn(*args, **kwargs)
```

Issue: https://github.com/pytorch/pytorch/issues/143406

We want to make sure to run the torch.compile check on nightly smoke testing. Runtime error check we still disable for now, since it may crash GPU.