### PR TITLE
(MTIA) Move "empty_cache" API

### DIFF
--- a/docs/source/mtia.memory.rst
+++ b/docs/source/mtia.memory.rst
@@ -10,5 +10,6 @@ The MTIA backend is implemented out of the tree, only interfaces are be defined 
     :toctree: generated
     :nosignatures:
 
+    empty_cache
     memory_stats
     max_memory_allocated

--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -187,11 +187,6 @@ def get_device_capability(device: Optional[_device_t] = None) -> Tuple[int, int]
     return torch._C._mtia_getDeviceCapability(_get_device_index(device, optional=True))
 
 
-def empty_cache() -> None:
-    r"""Empty the MTIA device cache."""
-    return torch._C._mtia_emptyCache()
-
-
 def set_stream(stream: Stream):
     r"""Set the current stream.This is a wrapper API to set the stream.
         Usage of this function is discouraged in favor of the ``stream``

--- a/torch/mtia/memory.py
+++ b/torch/mtia/memory.py
@@ -10,6 +10,11 @@ from . import _device_t, is_initialized
 from ._utils import _get_device_index
 
 
+def empty_cache() -> None:
+    r"""Empty the MTIA device cache."""
+    return torch._C._mtia_emptyCache()
+
+
 def max_memory_allocated(device: Optional[_device_t] = None) -> int:
     r"""Return the maximum memory allocated in bytes for a given device.
 
@@ -37,6 +42,7 @@ def memory_stats(device: Optional[_device_t] = None) -> Dict[str, Any]:
 
 
 __all__ = [
+    "empty_cache",
     "memory_stats",
     "max_memory_allocated",
 ]


### PR DESCRIPTION
Summary: This diff moves one of memory-related APIs to the consolidated location, which is `mtia/memory.py`.

Test Plan:
```
buck2 test //mtia/host_runtime/torch_mtia/tests:test_torch_mtia_api
```

https://www.internalfb.com/intern/testinfra/testrun/13510798943184259

Reviewed By: nautsimon

Differential Revision: D67148738


