### PR TITLE
don't rethrow guard on data dependent errors

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2582,11 +2582,7 @@ def get_fake_value(node, tx, allow_non_graph_fake=False):
         elif isinstance(
             cause, torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode
         ):
-            raise UserError(  # noqa: B904
-                UserErrorType.CONSTRAINT_VIOLATION,
-                str(cause),
-                case_name="constrain_as_size_example",
-            )
+            raise e
         elif isinstance(cause, ValueRangeError):
             raise UserError(UserErrorType.CONSTRAINT_VIOLATION, e.args[0]) from e
         elif isinstance(cause, TypeError) and "argument" in str(cause):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143413

as discussed offline, this makes errors much easier to read/understand