### PR TITLE
[ODML] Make the ML feature provider thread safe

### DIFF
--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLFeatureProvider.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLFeatureProvider.mm
@@ -15,7 +15,9 @@
 }
 
 - (void)clearInputTensors {
-  [_featureValuesForName removeAllObjects];
+  @synchronized(_featureValuesForName) {
+    [_featureValuesForName removeAllObjects];
+  }
 }
 
 - (void)setInputTensor:(const at::Tensor&)tensor forFeatureName:(NSString *)name {
@@ -40,12 +42,16 @@
      error:&error];
   MLFeatureValue *value = [MLFeatureValue featureValueWithMultiArray:mlArray];
   if (value) {
-    _featureValuesForName[name] = value;
+    @synchronized(_featureValuesForName) {
+      _featureValuesForName[name] = value;
+    }
   }
 }
 
 - (nullable MLFeatureValue *)featureValueForName:(NSString *)featureName {
-  return _featureValuesForName[featureName];
+  @synchronized(_featureValuesForName) {
+    return _featureValuesForName[featureName];
+  }
 }
 
 @end


### PR DESCRIPTION
Summary:
This PR is generated from a meta internal Diff, aiming to resolve a crash from a race condition on the dictionary.

Test Plan:

Build and run

Print out the count/name/value of the dictionary and see if the values are get/set/removed correctly.

Observe the print statement on app start within IG

@diff-train-skip-merge

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel