### PR TITLE
Eager style export V0 API.

### DIFF
--- a/test/export/test_fullgraph_package.py
+++ b/test/export/test_fullgraph_package.py
@@ -1,0 +1,161 @@
+# Owner(s): ["oncall: export"]
+
+import os
+import pathlib
+
+import torch
+
+from torch.testing._internal.common_utils import TestCase
+
+
+class TestFullgraphPackage(TestCase):
+    def tearDown(self):
+        super().tearDown()
+        pathlib.Path(self.path()).unlink(missing_ok=True)
+
+    def path(self):
+        return os.path.expandvars(f"/tmp/torchinductor_$USER/model_{self.id()}.pt2")
+
+    def test_basic_function(self):
+        @torch.compile(fullgraph=True)
+        def f(x, y):
+            return x + y
+
+        with torch.compiler._fullgraph_package(path=self.path()):
+            f(torch.randn(3), torch.randn(3))
+
+        self.assertTrue(os.path.exists(self.path()))
+
+        inputs = torch.randn(3), torch.randn(3)
+        with torch.compiler._fullgraph_package(mode="load", path=self.path()):
+            results = f(*inputs)
+
+        expected = f(*inputs)
+
+        self.assertEqual(results, expected)
+
+    def test_basic_module(self):
+        class Module(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(3, 3)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        mod = torch.compile(Module(), fullgraph=True)
+
+        with torch.compiler._fullgraph_package(path=self.path()):
+            mod(torch.randn(3))
+
+        self.assertTrue(os.path.exists(self.path()))
+
+        inputs = (torch.randn(3),)
+        with torch.compiler._fullgraph_package(mode="load", path=self.path()):
+            results = mod(*inputs)
+
+        expected = mod(*inputs)
+
+        self.assertEqual(results, expected)
+
+    def test_basic_function_dynamo(self):
+        @torch.compile(fullgraph=True)
+        def f(x, y):
+            return x + y
+
+        with torch.compiler._fullgraph_package(path=self.path()):
+            f(torch.randn(3), torch.randn(3))
+
+        self.assertTrue(os.path.exists(self.path()))
+
+        inputs = torch.randn(3), torch.randn(3)
+        with torch.compiler._fullgraph_package(
+            mode="load", path=self.path(), frontend="dynamo"
+        ):
+            results = f(*inputs)
+
+        expected = f(*inputs)
+
+        self.assertEqual(results, expected)
+
+    def test_basic_module_dynamo(self):
+        class Module(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(3, 3)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        mod = torch.compile(Module(), fullgraph=True)
+
+        with torch.compiler._fullgraph_package(path=self.path()):
+            mod(torch.randn(3))
+
+        self.assertTrue(os.path.exists(self.path()))
+
+        inputs = (torch.randn(3),)
+        with torch.compiler._fullgraph_package(
+            mode="load", path=self.path(), frontend="dynamo"
+        ):
+            results = mod(*inputs)
+
+        expected = mod(*inputs)
+
+        self.assertEqual(results, expected)
+
+    def test_multiple_compilations(self):
+        def f(x, y):
+            return x + y
+
+        f0 = torch.compile(f, fullgraph=True)
+        f1 = torch.compile(f, fullgraph=True)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Multiple compilations to the same model name.*are not supported",
+        ):
+            with torch.compiler._fullgraph_package(path=self.path()):
+                f0(torch.randn(3), torch.randn(3))
+                f1(torch.randn(4, 2), torch.randn(4, 2))
+
+    def test_reentry(self):
+        @torch.compile(fullgraph=True)
+        def f(x, y):
+            return x + y
+
+        with self.assertRaisesRegex(RuntimeError, "is already enabled"):
+            with torch.compiler._fullgraph_package(path=self.path()):
+                with torch.compiler._fullgraph_package(path=self.path() + ".0"):
+                    f(torch.randn(4, 2), torch.randn(4, 2))
+
+
+    def test_multiple_models(self):
+        @torch.compile(fullgraph=True)
+        def g(x, y):
+            return x == y
+
+        @torch.compile(fullgraph=True)
+        def h(ret, x):
+            return ret + x
+
+        def f(x, y):
+            ret = torch.zeros_like(x)
+            for i in range(y.shape[0]):
+                if g(x[i], y[i]):
+                    break
+                ret = h(ret, x[i])
+            return ret
+
+        with torch.compiler._fullgraph_package(path=self.path()):
+            f(torch.arange(3, dtype=torch.float32), torch.ones(3))
+
+        self.assertTrue(os.path.exists(self.path()))
+
+        inputs = torch.randn(3), torch.randn(3)
+        with torch.compiler._fullgraph_package(mode="load", path=self.path()):
+            results = f(*inputs)
+
+        expected = f(*inputs)
+
+        self.assertEqual(results, expected)

--- a/torch/_fullgraph.py
+++ b/torch/_fullgraph.py
@@ -1,0 +1,143 @@
+import dataclasses
+import functools
+import inspect
+import logging
+import os
+import weakref
+from typing import Any, Dict, Optional
+
+import torch
+import torch._inductor.package
+
+logger = logging.getLogger(__name__)
+
+@dataclasses.dataclass
+class _Compilation:
+    name: str
+    model: Any
+    path: str
+    version: int
+
+
+class _Package:
+    def __init__(
+        self,
+        *,
+        mode: str = "package",
+        path: Optional[str] = None,
+        frontend: str = "aot_autograd",
+    ):
+        self.mode = mode
+        self.path = path or os.path.expandvars("/tmp/torchinductor_$USER/model.pt2")
+        if os.path.exists(self.path) and os.path.isdir(self.path):
+            raise RuntimeError(
+                f"File {self.path} already exists as a directory. Please specify a file path."
+            )
+        self.frontend = frontend
+        self._compilations: Dict[str, _Compilation] = {}
+
+    def __call__(self, model: Any, name: str, version: int) -> Any:
+        assert callable(model)
+        assert isinstance(name, str)
+        assert isinstance(version, int)
+
+        @functools.wraps(model)
+        def _(*args, **kwargs):  # type: ignore[no-untyped-def]
+            if name in self._compilations:
+                # Making sure for each compilation name, it's only coming from a single torch.compile call.
+                if self._compilations[name].model is not model:
+                    raise RuntimeError(
+                        f"Multiple compilations to different objects are found with the same model name '{name}'. "
+                        + "Please specify a unique name for each compilation with torch.compile."
+                    )
+
+                if self._compilations[name].version != version:
+                    raise RuntimeError(
+                        f"Multiple compilations to the same model name '{name}' are not supported. "
+                        + "Please instead specify a unique name for each compilation with torch.compile."
+                    )
+
+            if self.mode == "package":
+                if isinstance(model, torch.nn.Module):
+                    module = model
+                else:
+
+                    class Module(torch.nn.Module):
+                        def __init__(self) -> None:
+                            super().__init__()
+                            self.model = model
+
+                        def forward(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+                            return self.model(*args, **kwargs)
+
+                    module = Module()
+
+                if self.frontend == "aot_autograd":
+                    strict = False
+                elif self.frontend == "dynamo":
+                    strict = True
+                else:
+                    raise RuntimeError(f"Unknown frontend {self.frontend}")
+                ep = torch.export.export(module, args, kwargs, strict=strict)
+
+                args, kwargs = ep.example_inputs
+                options = {
+                    "aot_inductor.package": True,
+                }
+                path = torch._inductor.aot_compile(
+                    ep.module(),  # type: ignore[arg-type]
+                    args,
+                    kwargs,
+                    options=options,
+                )
+                assert isinstance(path, list) and all(isinstance(p, str) for p in path)
+                self._compilations[name] = _Compilation(
+                    name=name,
+                    model=model,
+                    path=path,
+                    version=version,
+                )
+
+                runner = model
+            elif self.mode == "load":
+                # TODO Cache the loaded packages.
+                runner = torch._inductor.package.load_package(self.path, name)
+            else:
+                raise RuntimeError(
+                    f"Unknown mode {self.mode}. Supported options: package, load"
+                )
+
+            return runner(*args, **kwargs)
+
+        return _
+
+    def finalize(self) -> None:
+        if self.mode == "package":
+            if len(self._compilations) == 0:
+                logger.warning("No compiled models found for packaging.")
+            else:
+                torch._inductor.package.package_aoti(
+                    self.path, {c.name: c.path for c in self._compilations.values()}
+                )
+        self._compilations.clear()
+
+
+_optimized_versions: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+
+
+def _bump_optimized_version(obj: Any) -> int:
+    version = _optimized_versions.get(obj, 0)
+    _optimized_versions[obj] = version + 1
+    return version
+
+
+def _get_model_name(model: Any) -> str:
+    if isinstance(model, torch.nn.Module):
+        name = model.__class__.__qualname__ + ".forward"
+    elif inspect.ismethod(model) or inspect.isfunction(model):
+        name = model.__qualname__
+    else:
+        raise RuntimeError(f"Unknown model type {type(model)}")
+
+    module_name = model.__module__
+    return module_name + "." + name


### PR DESCRIPTION
Summary:
Prototype of an end-to-end export workflow to call a torch.compiled model eagerly and package every single compiled model in the wrapped region of the code.

Code sample:

```
@torch.compile(fullgraph=True)
def f(x, y):
    return x + y

# Compile the model and save it on disk
with torch.compiler._fullgraph_package(mode="package", path="/tmp/model.pt2", frontend="dynamo"):
    f(torch.randn(3), torch.randn(3))

# Load the saved model back and call it in-place.
with torch.compiler._fullgraph_package(mode="load", path="/tmp/model.pt2"):
    f(torch.randn(3), torch.randn(3))
```
Internally, fullgraph_package will call export and aoti step by step and finally package all the compiled models into a single package when we exit the context. (see test_fullgraph_package.py for more information)

Since this is an AOT workflow, we have to assume that the package file(s) saved from this API are likely to be used in a different environment, despite the fact that it may or may not cause soundness issue. To make this BC-safe, we need to give each compilation a unique name so that the models being loaded are addressable from a different process.

(Right now we just assign the unique compilatin name/id using the function's FQN. Ideally user should be able to specify the compilation name directly on torch.compile())

For now, the plan of record is we want to make this ctx manager API standalone because we need to put at least three arguments here:
1. `mode` which indicates whether we're saving or loading the packages
2. `path` to specify where we store the compiled package.
3. `frontend` to speciy whether the programming model.

We haven't made a final decision on where to put this funtionality, and the purpose of this diff is to demonstrate what an ideal workflow to do partial model capture for torchnative.

Test Plan:
buck test mode/opt caffe2/test:test_export -- -r FullgraphPackage

OSS: test_fullgraph_package.py

Differential Revision: D67353701




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames