### PR TITLE
remove allow-untyped-defs for torch/_inductor/test_operators.py

### DIFF
--- a/torch/_inductor/test_operators.py
+++ b/torch/_inductor/test_operators.py
@@ -1,4 +1,5 @@
-# mypy: allow-untyped-defs
+from typing import Any
+
 import torch.library
 from torch import Tensor
 from torch.autograd import Function
@@ -16,12 +17,13 @@ if not torch._running_with_deploy():
 
     class Realize(Function):
         @staticmethod
-        def forward(ctx, x):
+        def forward(ctx: object, x: Tensor) -> Tensor:
             return torch.ops._inductor_test.realize(x)
 
         @staticmethod
-        def backward(ctx, grad_output):
-            return grad_output
+        # types need to stay consistent with _SingleLevelFunction
+        def backward(ctx: Any, *grad_output: Any) -> Any:
+            return grad_output[0]
 
     def realize(x: Tensor) -> Tensor:
         return Realize.apply(x)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143436



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov