### PR TITLE
remove allow-untyped-defs for torch/nn/parallel/__init__.py

### DIFF
--- a/torch/nn/parallel/__init__.py
+++ b/torch/nn/parallel/__init__.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 from typing_extensions import deprecated
 
 from torch.nn.parallel.data_parallel import data_parallel, DataParallel


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143437



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o