### PR TITLE
fix checking non-trivial input constraints

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -3572,7 +3572,6 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         ):
             em.module()(x)
 
-    @testing.expectedFailureRetraceabilityNonStrict
     def test_dont_duck_size_for_auto_dynamic(self):
         AUTO, STATIC = Dim.AUTO, Dim.STATIC
 
@@ -9557,7 +9556,6 @@ def forward(self, x, y):
         }
         export(f, (inputs,), dynamic_shapes=dynamic_shapes)
 
-    @testing.expectedFailureRetraceabilityNonStrict
     def test_disable_forced_specializations_ok(self):
         # check that we don't force specialization, and defer to runtime asserts
         # with allow_complex_guards_as_runtime_asserts=True to successfully export
@@ -10185,7 +10183,6 @@ def forward(self, x):
         self.assertTrue(torch.allclose(comp_mod(inp1), mod(inp1)))
         self.assertTrue(torch.allclose(comp_mod(inp2), mod(inp2)))
 
-    @testing.expectedFailureRetraceabilityNonStrict
     def test_automatic_dynamic_shapes_simple_equality(self):
         # The next 3 test cases tests for automatic dynamic shapes specs, verifying that automatic dynamism
         # leads to replacement symbols being set for equalities, and inferred relationships being checked
@@ -10257,7 +10254,6 @@ def forward(self, x):
             test_serdes=True,
         )
 
-    @testing.expectedFailureRetraceabilityNonStrict
     def test_automatic_dynamic_shapes_constant_relation(self):
         AUTO, STATIC = Dim.AUTO, Dim.STATIC
 
@@ -10303,7 +10299,6 @@ def forward(self, x):
             test_serdes=True,
         )
 
-    @testing.expectedFailureRetraceabilityNonStrict
     def test_automatic_dynamic_shapes_linear_relation(self):
         AUTO, STATIC = Dim.AUTO, Dim.STATIC
 
@@ -10612,7 +10607,6 @@ def forward(self, x):
         export(Foo(), inps)
 
     @testing.expectedFailureCppSerDes  # TODO(pianpwk): PowByNatural valuerange deserialization
-    @testing.expectedFailureRetraceabilityNonStrict
     def test_dim_dynamic(self):
         dynamic = Dim.DYNAMIC
 

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -352,12 +352,11 @@ def _check_input_constraints_for_graph(
                     # this means we deferred a guard from export analysis to runtime, let this pass
                     # we'll add a runtime assert checking equality to this replacement expression
                     continue
-                else:
-                    if arg_dim != node_dim:
-                        raise RuntimeError(
-                            f"Expected input at {get_keystr(key_path)}.shape[{j}] to be equal to "
-                            f"{node_dim}, but got {arg_dim}",
-                        )
+                elif arg_dim != node_dim:
+                    raise RuntimeError(
+                        f"Expected input at {get_keystr(key_path)}.shape[{j}] to be equal to "
+                        f"{node_dim}, but got {arg_dim}",
+                    )
         elif isinstance(node_val, (int, float, str)):
             if type(arg) != type(node_val) or arg != node_val:
                 raise RuntimeError(

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -289,8 +289,14 @@ def _check_input_constraints_for_graph(
                 )
 
             for j, (arg_dim, node_dim) in enumerate(zip(arg.shape, node_val.shape)):
-                # TODO(avik): Assert the following property in the IR verifier:
-                # node_dim is either an int or a SymInt containing an int or a unary sympy.Expr
+                if (
+                    isinstance(arg_dim, torch.SymInt)
+                    and not arg_dim.node.expr.is_number
+                ):
+                    # This can happen when, say, arg is a fake tensor.
+                    # We do not run checks on symbolic shapes of fake inputs as
+                    # such checks can affect the shape env.
+                    continue
                 if (
                     isinstance(node_dim, torch.SymInt)
                     and len(node_dim.node.expr.free_symbols) == 1
@@ -304,32 +310,23 @@ def _check_input_constraints_for_graph(
                                 f"{existing_dim}, but got {arg_dim}",
                             )
                     else:
-                        if (
-                            isinstance(arg_dim, torch.SymInt)
-                            and not arg_dim.node.expr.is_number
-                        ):
-                            # This can happen when, say, arg is a fake tensor.
-                            # We do not run checks on symbolic shapes of fake inputs as
-                            # such checks can affect the shape env.
-                            pass
+                        if isinstance(node_dim.node.expr, sympy.Symbol):
+                            # Short cut for try_solve below. Also useful in cases where
+                            # sympy.Eq(node_dim.node.expr, arg_dim) would evaluate to False
+                            # purely because symbol is constrained to be size-like,
+                            # e.g., when node_dim.node.expr = symbol and arg_dim = 0.
+                            unification_map[symbol] = int(arg_dim)
                         else:
-                            if isinstance(node_dim.node.expr, sympy.Symbol):
-                                # Short cut for try_solve below. Also useful in cases where
-                                # sympy.Eq(node_dim.node.expr, arg_dim) would evaluate to False
-                                # purely because symbol is constrained to be size-like,
-                                # e.g., when node_dim.node.expr = symbol and arg_dim = 0.
-                                unification_map[symbol] = int(arg_dim)
-                            else:
-                                solution = try_solve(
-                                    sympy.Eq(node_dim.node.expr, arg_dim), symbol
+                            solution = try_solve(
+                                sympy.Eq(node_dim.node.expr, arg_dim), symbol
+                            )
+                            if solution is None:
+                                raise RuntimeError(  # noqa: B904
+                                    f"Expected input {node.name}.shape[{j}] = {arg_dim} to be "
+                                    f"of the form {node_dim.node.expr}, where {symbol} is an integer"
                                 )
-                                if solution is None:
-                                    raise RuntimeError(  # noqa: B904
-                                        f"Expected input {node.name}.shape[{j}] = {arg_dim} to be "
-                                        f"of the form {node_dim.node.expr}, where {symbol} is an integer"
-                                    )
-                                else:
-                                    unification_map[symbol] = int(solution[1])
+                            else:
+                                unification_map[symbol] = int(solution[1])
 
                     if node_dim.node.expr in range_constraints:
                         min_val, max_val = _convert_range_to_int(
@@ -348,15 +345,15 @@ def _check_input_constraints_for_graph(
                                     f"Expected input at {get_keystr(key_path)}.shape[{j}] to be <= "
                                     f"{max_val}, but got {arg_dim}",
                                 )
+                elif (
+                    isinstance(node_dim, torch.SymInt)
+                    and not node_dim.node.expr.is_number
+                ):
+                    # this means we deferred a guard from export analysis to runtime, let this pass
+                    # we'll add a runtime assert checking equality to this replacement expression
+                    continue
                 else:
                     if arg_dim != node_dim:
-                        if (
-                            isinstance(node_dim, torch.SymInt)
-                            and not node_dim.node.expr.is_number
-                        ):
-                            # this means we deferred a guard from export analysis to runtime, let this pass
-                            # we'll add a runtime assert checking equality to this replacement expression
-                            continue
                         raise RuntimeError(
                             f"Expected input at {get_keystr(key_path)}.shape[{j}] to be equal to "
                             f"{node_dim}, but got {arg_dim}",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143442

A bunch of auto dynamic shape tests would fail non-strict retraceability because when checking input constraints, we'd compare non-trivial expressions, which would require / affect shape env.
```
... is not tracked with proxy for <torch.fx.experimental.proxy_tensor._ModuleStackTracer object ...
```

I've also observed this bug internally.

This PR does an early check on whether args passed have concrete shapes, and only then proceeds: as before, we
1. try to unify / solve with the arg dim when the corresponding placeholder node dim is symbolic in one symbol
2. check directly if the placeholder node dim is concrete
3. otherwise defer to run time.

Differential Revision: [D67359596](https://our.internmc.facebook.com/intern/diff/D67359596/)