### PR TITLE
[Inductor][CPU] disable bernoulli_p decomposition

### DIFF
--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -704,6 +704,7 @@ aten::bernoulli.Tensor
 aten::bernoulli.Tensor_out
 aten::bernoulli.float_out
 aten::bernoulli.out
+aten::bernoulli.p
 aten::bernoulli_.Tensor
 aten::bernoulli_.float
 aten::bincount

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -22,7 +22,6 @@ from torch.testing._internal.common_device_type import (
     onlyCUDA,
     onlyNativeDeviceTypes,
     ops,
-    skipCPUIf,
 )
 from torch.testing._internal.common_methods_invocations import (
     op_db,
@@ -609,17 +608,6 @@ class TestDecomp(TestCase):
         res = torch._decomp.decompositions.uniform(x, low=low, high=high)
         self.assertEqual(ref, res)
 
-    @skipCPUIf(True, "skip CPU device for testing bernoulli_p decomposition")
-    def test_bernoulli_p(self, device):
-        p = 0.3
-        input_t = torch.rand(100, 100).to(device)
-        torch.manual_seed(123)
-        ref = torch.ops.aten.bernoulli.p(input_t, p)
-        torch.manual_seed(123)
-        res = torch._decomp.decompositions.bernoulli_p(input_t, p)
-        ref_p = ref.sum() / torch.prod(torch.tensor(ref.size()))
-        res_p = res.sum() / torch.prod(torch.tensor(res.size()))
-        self.assertEqual(ref_p, res_p, atol=0.06 * p, rtol=0.06)
 
     def test_bernoulli_default(self, device):
         p = 0.3

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -612,7 +612,7 @@ class TestDecomp(TestCase):
     @skipCPUIf(True, "skip CPU device for testing bernoulli_p decomposition")
     def test_bernoulli_p(self, device):
         p = 0.3
-        input_t = torch.rand(100, 100)
+        input_t = torch.rand(100, 100).to(device)
         torch.manual_seed(123)
         ref = torch.ops.aten.bernoulli.p(input_t, p)
         torch.manual_seed(123)

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -608,7 +608,6 @@ class TestDecomp(TestCase):
         res = torch._decomp.decompositions.uniform(x, low=low, high=high)
         self.assertEqual(ref, res)
 
-
     def test_bernoulli_default(self, device):
         p = 0.3
         p_t = p * torch.ones(5, 5)

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -22,6 +22,7 @@ from torch.testing._internal.common_device_type import (
     onlyCUDA,
     onlyNativeDeviceTypes,
     ops,
+    skipCPUIf,
 )
 from torch.testing._internal.common_methods_invocations import (
     op_db,
@@ -608,6 +609,7 @@ class TestDecomp(TestCase):
         res = torch._decomp.decompositions.uniform(x, low=low, high=high)
         self.assertEqual(ref, res)
 
+    @skipCPUIf(True, "skip CPU device for testing bernoulli_p decomposition")
     def test_bernoulli_p(self, device):
         p = 0.3
         input_t = torch.rand(100, 100)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5119,13 +5119,15 @@ def bernoulli(
 
 @register_decomposition(aten.bernoulli.p)
 def bernoulli_p(self, p, *, generator: Optional[torch.Generator] = None):
+    if self.device.type == "cpu":
+        return NotImplemented
     if generator is None:
         raw_p = torch.rand(self.size(), dtype=torch.float32, device=self.device)
     else:
         raw_p = torch.rand(
             self.size(),
             generator=generator,
-            dtype=self.float32,
+            dtype=torch.float32,
             device=self.device,
         )
     p = (raw_p < p).to(self.dtype)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5117,23 +5117,6 @@ def bernoulli(
     return p
 
 
-@register_decomposition(aten.bernoulli.p)
-def bernoulli_p(self, p, *, generator: Optional[torch.Generator] = None):
-    if self.device.type == "cpu":
-        return NotImplemented
-    if generator is None:
-        raw_p = torch.rand(self.size(), dtype=torch.float32, device=self.device)
-    else:
-        raw_p = torch.rand(
-            self.size(),
-            generator=generator,
-            dtype=torch.float32,
-            device=self.device,
-        )
-    p = (raw_p < p).to(self.dtype)
-    return p
-
-
 def isin_default(elements, test_elements, *, invert=False):
     if elements.numel() == 0:
         return torch.empty_like(elements, dtype=torch.bool)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143460

Fix https://github.com/pytorch/pytorch/issues/142853
`fallback_random=True` should cause RNG to match between compile/eager (by having compile fall back to eager for RNG ops), but the `bernoulli_p` decompose function is not fully consistent with the eager CPU implementation. 
We remove the decomp and keep the version for` fallback_random=False`.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov