### PR TITLE
Fix torch._refs.tensor error with empty list

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3226,8 +3226,9 @@ class TestTensorCreation(TestCase):
         t = torch.randn(2, 5, device=device)
         self.assertIsNone(t.untyped_storage().filename)
 
-    def test_refs_tensor(self, device):
-        self.assertEqual(torch._refs.tensor([], device=device), torch.tensor([], device=device))
+    @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
+    def test_refs_tensor(self, device, dtype):
+        self.assertEqual(torch._refs.tensor([], device=device, dtype=dtype), torch.tensor([], device=device, dtype=dtype))
 
 
 # Class for testing random tensor creation ops, like torch.randint

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3226,6 +3226,9 @@ class TestTensorCreation(TestCase):
         t = torch.randn(2, 5, device=device)
         self.assertIsNone(t.untyped_storage().filename)
 
+    def test_refs_tensor(self, device):
+        self.assertEqual(torch._refs.tensor([], device=device), torch.tensor([], device=device))
+
 
 # Class for testing random tensor creation ops, like torch.randint
 class TestRandomTensorCreation(TestCase):

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -6542,7 +6542,11 @@ def _recursive_build(
 
     # seq can be a list of tensors
     seq = obj
-    return torch.stack([_recursive_build(scalarType, item) for item in seq])
+    return (
+        torch.tensor([])
+        if not seq
+        else torch.stack([_recursive_build(scalarType, item) for item in seq])
+    )
 
 
 # xref: internal_new_from_data in torch/csrc/utils/tensor_new.cpp

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -6543,7 +6543,7 @@ def _recursive_build(
     # seq can be a list of tensors
     seq = obj
     return (
-        torch.tensor([])
+        torch.empty(0)
         if not seq
         else torch.stack([_recursive_build(scalarType, item) for item in seq])
     )


### PR DESCRIPTION
Fixes #143216

**Test Result**

**Before**

```python
>>> import torch
>>> torch._refs.tensor([]) 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/zong/code/pytorch/torch/_refs/__init__.py", line 6614, in tensor
    new_tensor = _internal_new_from_data(
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zong/code/pytorch/torch/_refs/__init__.py", line 6596, in _internal_new_from_data
    tensor = _recursive_build(inferred_scalar_type, data)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zong/code/pytorch/torch/_refs/__init__.py", line 6545, in _recursive_build
    return torch.stack([_recursive_build(scalarType, item) for item in seq])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: stack expects a non-empty TensorList

```

**After**

```python
>>> torch._refs.tensor([]) 
tensor([])
>>> torch._refs.tensor([], device='cuda') 
tensor([], device='cuda:0')
```

```bash
$ pytest test/test_tensor_creation_ops.py -k test_refs_tensor
```

![image](https://github.com/user-attachments/assets/5be4c17a-bea6-4b7b-bec1-b4fcb417a8cd)

```bash
$ lintrunner
```
![image](https://github.com/user-attachments/assets/e8f88f41-78ac-4337-b53f-2e524de2bec0)

cc @ezyang @albanD 
