### PR TITLE
Add a register_replacement to fix float8 delayed scaling kernel fusion issues

### DIFF
--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -1,6 +1,5 @@
 # mypy: allow-untyped-defs
 import functools
-import inspect
 import logging
 import math
 
@@ -14,6 +13,7 @@ from ..pattern_matcher import (
     gen_register_replacement,
     joint_fwd_bwd,
 )
+from ..utils import partialize_and_update_signature
 
 
 log = logging.getLogger(__name__)
@@ -607,29 +607,6 @@ def _sfdp_extra_check(scale_factor_op=None, disable_cuda=False):
         return _sfdp_params_check(match)
 
     return fn
-
-
-def partialize_and_update_signature(func, **kwargs):
-    """
-    Equivalent to functools.partial but also updates the signature on returned function
-    """
-    original_sig = inspect.signature(func)
-    parameters = original_sig.parameters
-
-    new_parameters = {
-        key: value for key, value in parameters.items() if key not in kwargs
-    }
-    new_sig = inspect.Signature(parameters=list(new_parameters.values()))
-
-    partial_func = functools.partial(func, **kwargs)
-
-    def wrapper(*args, **kwargs):
-        return partial_func(*args, **kwargs)
-
-    wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
-    wrapper.__name__ = func.__name__
-
-    return wrapper
 
 
 def _get_sfdp_patterns():

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2430,3 +2430,26 @@ def set_kernel_post_grad_provenance_tracing(node_schedule, kernel_name):
                 V.debug._inductor_triton_kernel_to_post_grad_node_info[kernel_name] = [
                     origin.name for origin in node.node.origins
                 ]
+
+
+def partialize_and_update_signature(func, **kwargs):
+    """
+    Equivalent to functools.partial but also updates the signature on returned function
+    """
+    original_sig = inspect.signature(func)
+    parameters = original_sig.parameters
+
+    new_parameters = {
+        key: value for key, value in parameters.items() if key not in kwargs
+    }
+    new_sig = inspect.Signature(parameters=list(new_parameters.values()))
+
+    partial_func = functools.partial(func, **kwargs)
+
+    def wrapper(*args, **kwargs):
+        return partial_func(*args, **kwargs)
+
+    wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
+    wrapper.__name__ = func.__name__
+
+    return wrapper


### PR DESCRIPTION
Summary:
We previously tried the `defer_reduction_split_after_fusion` way to fix the fusion issue. 
However, as we agree that the longer-term solution is cooperative reduction + tiled reduction, the defer reduction split approach will also be a shorter-term solution. And we want to keep the shorter-term solution simpler. 

This pr uses the `pattern_matcher` to match the fp8 delayed scaling pattern, simply replace every `max(abs(x))` with `max(abs(x), dim=-1), max()`. It generates the same result as the defer reduction split approach .

Test Plan:
Run float8 training script. Amax and cast are fused in delayed scaling; dynamic scaling is not affected.

The delayed scaling kernel also looks reasonable to me, https://fburl.com/phabricator/iqmlollk

```
TORCH_LOGS="fusion" TORCHINDUCTOR_LOOP_ORDERING_AFTER_FUSION=1  buck run mode/opt scripts/shuqiyang/test_inductor:test_float8 --  ~/local/tmp/20241120_test --dtype_filter float8 --scaling_type_input delayed --scaling_type_weight delayed --scaling_type_grad_output delayed  2>&1 | tee ~/test_compile.txt
```

```
TORCH_LOGS="fusion" TORCHINDUCTOR_LOOP_ORDERING_AFTER_FUSION=1  buck run mode/opt scripts/shuqiyang/test_inductor:test_float8 --  ~/local/tmp/20241120_test --dtype_filter float8 --scaling_type_input dynamic --scaling_type_weight dynamic --scaling_type_grad_output dynamic  2>&1 | tee ~/test_compile.txt
```

Differential Revision: D67135795




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov