### PR TITLE
log guard_size_oblivious call sites

### DIFF
--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -559,8 +559,12 @@ class SymNode:
         an unbacked one size, or a tensor reporting as non-contiguous even if it's
         contiguous if it would have been reported contiguous due to being empty.
         """
-        # TODO: use the file/line for some useful diagnostic on why a
-        # guard occurred
+        log.info(
+            'guard_size_oblivious %s File "%s:%s"',
+            self.expr,
+            file,
+            line,
+        )
         r = self.shape_env.evaluate_expr(
             self.expr, self.hint, fx_node=self.fx_node, size_oblivious=True
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143467

This makes it much easier to know what's going on when we guard on data dependent operations. Currently if we throw on guard on data dependent, we only show the python invocation that caused it (not the underlying leaf c++ call which truly causes it). 

For reviewers: I was torn on whether or not to make this a special thing separate to TORCH_LOGS="dynamic" but decided against it since dynamic is already opt in. The benefit is we now get much more visibility when users run with this flag on, but logs do get a bit more spewy. I'm still open to the idea of moving these logs somewhere else and maybe building a UI on top of it to make it easier to manage the information overload.

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv