### PR TITLE
[Reland 2.6][dynamo][pytree] make CXX pytree traceable: `tree_{flatten,unflatten,structure,map,map_}`

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10102,6 +10102,8 @@ def ___make_guard_fn():
 
     def test_pytree_tree_flatten_unflatten(self):
         implemtations = [("python", python_pytree)]
+        if cxx_pytree is not None:
+            implemtations.append(("cxx", cxx_pytree))
 
         for name, module in implemtations:
             with self.subTest(f"pytree implement: {name}"):
@@ -10138,7 +10140,7 @@ def ___make_guard_fn():
                         torch.ones(3, 2),
                         1,
                     ]
-                    new_tree = module.tree_unflatten(leaves, treespec)
+                    new_tree = module.tree_unflatten(new_leaves, treespec)
                     return leaves, new_tree
 
             x = torch.randn(3, 2)

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10153,6 +10153,8 @@ def ___make_guard_fn():
 
     def test_pytree_tree_map(self):
         implemtations = [("python", python_pytree)]
+        if cxx_pytree is not None:
+            implemtations.append(("cxx", cxx_pytree))
 
         for name, module in implemtations:
             with self.subTest(f"pytree implement: {name}"):

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -43,6 +43,14 @@ class GlobalDummyType:
         self.y = y
 
 
+cxx_pytree.register_pytree_node(
+    GlobalDummyType,
+    lambda dummy: ([dummy.x, dummy.y], None),
+    lambda xs, _: GlobalDummyType(*xs),
+    serialized_type_name="GlobalDummyType",
+)
+
+
 class TestGenericPytree(TestCase):
     def test_aligned_public_apis(self):
         public_apis = py_pytree.__all__
@@ -1328,7 +1336,7 @@ class TestCxxPytree(TestCase):
         _, spec = cxx_pytree.tree_flatten(pytree)
         self.assertExpectedInline(
             repr(spec),
-            "PyTreeSpec((*, [*, *, [*]]), NoneIsLeaf)",
+            "PyTreeSpec((*, [*, *, [*]]), NoneIsLeaf, namespace='torch')",
         )
 
     @parametrize(
@@ -1383,12 +1391,6 @@ class TestCxxPytree(TestCase):
         self.assertEqual(roundtrip_spec.type._fields, spec.type._fields)
 
     def test_pytree_custom_type_serialize(self):
-        cxx_pytree.register_pytree_node(
-            GlobalDummyType,
-            lambda dummy: ([dummy.x, dummy.y], None),
-            lambda xs, _: GlobalDummyType(*xs),
-            serialized_type_name="GlobalDummyType",
-        )
         spec = cxx_pytree.tree_structure(GlobalDummyType(0, 1))
         serialized_spec = cxx_pytree.treespec_dumps(spec)
         roundtrip_spec = cxx_pytree.treespec_loads(serialized_spec)

--- a/torch/_dynamo/polyfills/pytree.py
+++ b/torch/_dynamo/polyfills/pytree.py
@@ -4,12 +4,13 @@ Python polyfills for torch.utils.pytree
 
 from __future__ import annotations
 
+from collections import deque
 from dataclasses import dataclass, field
 from typing import Any, Callable, Iterable, Literal, TYPE_CHECKING
 from typing_extensions import TypeIs
 
 import torch.utils._pytree as python_pytree
-from torch.utils._pytree import BUILTIN_TYPES
+from torch.utils._pytree import BUILTIN_TYPES, STANDARD_DICT_TYPES
 
 from ..decorators import substitute_in_graph
 
@@ -200,6 +201,95 @@ if python_pytree._cxx_pytree_dynamo_traceable:
         def entry(self, index: int) -> Any:
             return self._entries[index]
 
+        def flatten_up_to(self, tree: PyTree) -> list[PyTree]:
+            def helper(
+                treespec: PyTreeSpec,
+                node: PyTree,
+                subtrees: list[PyTree],
+            ) -> None:
+                if treespec.is_leaf():
+                    subtrees.append(node)
+                    return
+
+                node_type = type(node)
+                if treespec.type not in BUILTIN_TYPES:
+                    # Always require custom node types to match exactly
+                    if node_type != treespec.type:
+                        raise ValueError(
+                            f"Type mismatch; "
+                            f"expected {treespec.type!r}, but got {node_type!r}.",
+                        )
+
+                    children, metadata, *_ = optree.tree_flatten_one_level(
+                        node,
+                        none_is_leaf=True,
+                        namespace="torch",
+                    )
+                    if len(children) != treespec.num_children:
+                        raise ValueError(
+                            f"Node arity mismatch; "
+                            f"expected {treespec.num_children}, but got {len(children)}.",
+                        )
+                    if metadata != treespec._metadata:
+                        raise ValueError(
+                            f"Node context mismatch for custom node type {treespec.type!r}.",
+                        )
+                else:
+                    # For builtin dictionary types, we allow some flexibility
+                    # Otherwise, we require exact matches
+                    both_standard_dict = (
+                        treespec.type in STANDARD_DICT_TYPES
+                        and node_type in STANDARD_DICT_TYPES
+                    )
+                    if not both_standard_dict and node_type != treespec.type:
+                        raise ValueError(
+                            f"Node type mismatch; "
+                            f"expected {treespec.type!r}, but got {node_type!r}.",
+                        )
+                    if len(node) != treespec.num_children:
+                        raise ValueError(
+                            f"Node arity mismatch; "
+                            f"expected {treespec.num_children}, but got {len(node)}.",
+                        )
+
+                    if both_standard_dict:
+                        # dictionary types are compatible with each other
+                        expected_keys = treespec.entries()
+                        got_key_set = set(node)
+                        expected_key_set = set(expected_keys)
+                        if got_key_set != expected_key_set:
+                            missing_keys = expected_key_set.difference(got_key_set)
+                            extra_keys = got_key_set.difference(expected_key_set)
+                            message = ""
+                            if missing_keys:
+                                message += f"; missing key(s): {missing_keys}"
+                            if extra_keys:
+                                message += f"; extra key(s): {extra_keys}"
+                            raise ValueError(f"Node keys mismatch{message}.")
+                        children = [node[key] for key in expected_keys]
+                    else:
+                        # node_type is treespec.type
+                        children, metadata, *_ = optree.tree_flatten_one_level(
+                            node,
+                            none_is_leaf=True,
+                            namespace="torch",
+                        )
+                        if (
+                            node_type
+                            is not deque  # ignore mismatch of `maxlen` for deque
+                        ) and metadata != treespec._metadata:
+                            raise ValueError(
+                                f"Node metadata mismatch for node type {treespec.type!r}; "
+                                f"expected {treespec._metadata!r}, but got {metadata!r}.",  # namedtuple type mismatch
+                            )
+
+                for subtree, subspec in zip(children, treespec._children):
+                    helper(subspec, subtree, subtrees)
+
+            subtrees: list[PyTree] = []
+            helper(self, tree, subtrees)
+            return subtrees
+
         def unflatten(self, leaves: Iterable[Any]) -> PyTree:
             if not isinstance(leaves, (list, tuple)):
                 leaves = list(leaves)
@@ -295,3 +385,30 @@ if python_pytree._cxx_pytree_dynamo_traceable:
         return treespec.unflatten(leaves)
 
     __all__ += ["tree_unflatten"]
+
+    @substitute_in_graph(cxx_pytree.tree_map, can_constant_fold_through=True)
+    def tree_map(
+        func: Callable[..., Any],
+        tree: PyTree,
+        *rests: PyTree,
+        is_leaf: Callable[[PyTree], bool] | None = None,
+    ) -> PyTree:
+        leaves, treespec = tree_flatten(tree, is_leaf=is_leaf)
+        flat_args = [leaves] + [treespec.flatten_up_to(r) for r in rests]
+        return treespec.unflatten(map(func, *flat_args))
+
+    __all__ += ["tree_map"]
+
+    @substitute_in_graph(cxx_pytree.tree_map_, can_constant_fold_through=True)
+    def tree_map_(
+        func: Callable[..., Any],
+        tree: PyTree,
+        *rests: PyTree,
+        is_leaf: Callable[[PyTree], bool] | None = None,
+    ) -> PyTree:
+        leaves, treespec = tree_flatten(tree, is_leaf=is_leaf)
+        flat_args = [leaves] + [treespec.flatten_up_to(r) for r in rests]
+        deque(map(func, *flat_args), maxlen=0)  # consume and exhaust the iterable
+        return tree
+
+    __all__ += ["tree_map_"]

--- a/torch/_dynamo/polyfills/pytree.py
+++ b/torch/_dynamo/polyfills/pytree.py
@@ -4,14 +4,20 @@ Python polyfills for torch.utils.pytree
 
 from __future__ import annotations
 
-from typing import Any, Callable, Iterable, TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Literal, TYPE_CHECKING
+from typing_extensions import TypeIs
 
 import torch.utils._pytree as python_pytree
+from torch.utils._pytree import BUILTIN_TYPES
 
 from ..decorators import substitute_in_graph
 
 
 if TYPE_CHECKING:
+    import builtins
+    from typing_extensions import Self
+
     from torch.utils._cxx_pytree import PyTree
 
 
@@ -95,3 +101,197 @@ if python_pytree._cxx_pytree_dynamo_traceable:
         return list(tree_iter(tree, is_leaf=is_leaf))
 
     __all__ += ["tree_leaves"]
+
+    class _Asterisk(str):
+        def __new__(cls) -> Self:
+            return super().__new__(cls, "*")
+
+        def __repr__(self) -> str:
+            return "*"  # no quotes
+
+    _asterisk = _Asterisk()
+    del _Asterisk
+
+    @dataclass(frozen=True)
+    class PyTreeSpec:
+        """Analog for :class:`optree.PyTreeSpec` in Python."""
+
+        _children: tuple[PyTreeSpec, ...]
+        _type: builtins.type | None
+        _metadata: Any
+        _entries: tuple[Any, ...]
+        _unflatten_func: Callable[[Any | None, Iterable[PyTree]], PyTree] | None
+
+        num_nodes: int = field(init=False)
+        num_leaves: int = field(init=False)
+        num_children: int = field(init=False)
+        none_is_leaf: Literal[True] = field(init=False)
+        namespace: Literal["torch"] = field(init=False)
+
+        def __post_init__(self) -> None:
+            if self._type is None:
+                assert len(self._children) == 0
+                assert self._metadata is None
+                assert self._entries == ()
+                assert self._unflatten_func is None
+                num_nodes = 1
+                num_leaves = 1
+                num_children = 0
+            else:
+                assert callable(self._unflatten_func)
+                num_nodes = sum((spec.num_nodes for spec in self._children), start=1)
+                num_leaves = sum(spec.num_leaves for spec in self._children)
+                num_children = len(self._children)
+
+            object.__setattr__(self, "num_nodes", num_nodes)
+            object.__setattr__(self, "num_leaves", num_leaves)
+            object.__setattr__(self, "num_children", num_children)
+            object.__setattr__(self, "none_is_leaf", True)
+            object.__setattr__(self, "namespace", "torch")
+
+        def __repr__(self) -> str:
+            def helper(treespec: PyTreeSpec) -> str:
+                if treespec.is_leaf():
+                    assert treespec.type is None
+                    return _asterisk
+
+                assert treespec.type is not None
+                assert callable(treespec._unflatten_func)
+                children_representations = [
+                    helper(subspec) for subspec in treespec._children
+                ]
+                if (
+                    treespec.type in BUILTIN_TYPES
+                    or optree.is_namedtuple_class(treespec.type)
+                    or optree.is_structseq_class(treespec.type)
+                ):
+                    return treespec._unflatten_func(
+                        treespec._metadata,
+                        children_representations,
+                    )
+                return (
+                    f"CustomTreeNode({treespec.type.__name__}[{treespec._metadata!r}], "
+                    f"[{', '.join(children_representations)}])"
+                )
+
+            return (
+                f"PyTreeSpec({helper(self)}, NoneIsLeaf, namespace={self.namespace!r})"
+            )
+
+        def __len__(self) -> int:
+            return self.num_leaves
+
+        @property
+        def type(self) -> builtins.type | None:
+            return self._type
+
+        def is_leaf(self) -> bool:
+            return self.num_nodes == 1 and self.num_leaves == 1
+
+        def children(self) -> list[PyTreeSpec]:
+            return list(self._children)
+
+        def child(self, index: int) -> PyTreeSpec:
+            return self._children[index]
+
+        def entries(self) -> list[Any]:
+            return list(self._entries)
+
+        def entry(self, index: int) -> Any:
+            return self._entries[index]
+
+        def unflatten(self, leaves: Iterable[Any]) -> PyTree:
+            if not isinstance(leaves, (list, tuple)):
+                leaves = list(leaves)
+            if len(leaves) != self.num_leaves:
+                raise ValueError(
+                    f"treespec.unflatten(leaves): `leaves` has length {len(leaves)} "
+                    f"but the spec refers to a pytree that holds {self.num_leaves} "
+                    f"items ({self}).",
+                )
+            if self.is_leaf():
+                return leaves[0]
+
+            # Recursively unflatten the children
+            start = 0
+            end = 0
+            subtrees = []
+            for subspec in self._children:
+                end += subspec.num_leaves
+                subtrees.append(subspec.unflatten(leaves[start:end]))
+                start = end
+
+            assert callable(self._unflatten_func)
+            return self._unflatten_func(self._metadata, subtrees)
+
+    _LEAF_SPEC = PyTreeSpec((), None, None, (), None)
+
+    def _is_pytreespec_instance(obj: Any, /) -> TypeIs[PyTreeSpec]:
+        return isinstance(obj, PyTreeSpec)
+
+    @substitute_in_graph(  # type: ignore[arg-type]
+        cxx_pytree.tree_flatten,
+        # We need to disable constant folding here because we want the function to reference the
+        # PyTreeSpec class defined above, not the one in the C++ module.
+        can_constant_fold_through=False,
+    )
+    def tree_flatten(
+        tree: PyTree,
+        is_leaf: Callable[[PyTree], bool] | None = None,
+    ) -> tuple[list[Any], PyTreeSpec]:
+        def helper(node: PyTree, leaves: list[Any]) -> PyTreeSpec:
+            if tree_is_leaf(node, is_leaf=is_leaf):
+                leaves.append(node)
+                return _LEAF_SPEC
+
+            (
+                children,
+                metadata,
+                entries,
+                unflatten_func,
+            ) = optree.tree_flatten_one_level(
+                node,
+                is_leaf=is_leaf,
+                none_is_leaf=True,
+                namespace="torch",
+            )
+
+            # Recursively flatten the children
+            subspecs = tuple(helper(child, leaves) for child in children)
+            return PyTreeSpec(subspecs, type(node), metadata, entries, unflatten_func)  # type: ignore[arg-type]
+
+        leaves: list[Any] = []
+        treespec = helper(tree, leaves)
+        return leaves, treespec
+
+    __all__ += ["tree_flatten"]
+
+    @substitute_in_graph(  # type: ignore[arg-type]
+        cxx_pytree.tree_structure,
+        # We need to disable constant folding here because we want the function to reference the
+        # PyTreeSpec class defined above, not the one in the C++ module.
+        can_constant_fold_through=False,
+    )
+    def tree_structure(
+        tree: PyTree,
+        is_leaf: Callable[[PyTree], bool] | None = None,
+    ) -> PyTreeSpec:
+        return tree_flatten(tree, is_leaf=is_leaf)[1]  # type: ignore[return-value]
+
+    __all__ += ["tree_structure"]
+
+    @substitute_in_graph(  # type: ignore[arg-type]
+        cxx_pytree.tree_unflatten,
+        # We need to disable constant folding here because we want the function to reference the
+        # PyTreeSpec class defined above, not the one in the C++ module.
+        can_constant_fold_through=False,
+    )
+    def tree_unflatten(leaves: Iterable[Any], treespec: PyTreeSpec) -> PyTree:
+        if not _is_pytreespec_instance(treespec):
+            raise TypeError(
+                f"tree_unflatten(leaves, treespec): Expected `treespec` to be instance of "
+                f"PyTreeSpec but got item of type {type(treespec)}."
+            )
+        return treespec.unflatten(leaves)
+
+    __all__ += ["tree_unflatten"]

--- a/torch/utils/_cxx_pytree.py
+++ b/torch/utils/_cxx_pytree.py
@@ -293,7 +293,7 @@ def tree_flatten(
     The flattening order (i.e., the order of elements in the output list) is deterministic,
     corresponding to a left-to-right depth-first tree traversal.
 
-    >>> tree = {'b': (2, [3, 4]), 'a': 1, 'c': None, 'd': 5}
+    >>> tree = {"b": (2, [3, 4]), "a": 1, "c": None, "d": 5}
     >>> tree_flatten(tree)
     ([1, 2, 3, 4, None, 5], PyTreeSpec({'a': *, 'b': (*, [*, *]), 'c': *, 'd': *}, NoneIsLeaf))
     >>> tree_flatten(1)
@@ -306,7 +306,7 @@ def tree_flatten(
     if you want to keep the keys in the insertion order.
 
     >>> from collections import OrderedDict
-    >>> tree = OrderedDict([('b', (2, [3, 4])), ('a', 1), ('c', None), ('d', 5)])
+    >>> tree = OrderedDict([("b", (2, [3, 4])), ("a", 1), ("c", None), ("d", 5)])
     >>> tree_flatten(tree)
     ([2, 3, 4, 1, None, 5], PyTreeSpec(OrderedDict({'b': (*, [*, *]), 'a': *, 'c': *, 'd': *}), NoneIsLeaf))
 
@@ -335,7 +335,7 @@ def tree_unflatten(leaves: Iterable[Any], treespec: TreeSpec) -> PyTree:
 
     The inverse of :func:`tree_flatten`.
 
-    >>> tree = {'b': (2, [3, 4]), 'a': 1, 'c': None, 'd': 5}
+    >>> tree = {"b": (2, [3, 4]), "a": 1, "c": None, "d": 5}
     >>> leaves, treespec = tree_flatten(tree)
     >>> tree == tree_unflatten(leaves, treespec)
     True
@@ -365,7 +365,7 @@ def tree_iter(
 
     See also :func:`tree_flatten`.
 
-    >>> tree = {'b': (2, [3, 4]), 'a': 1, 'c': None, 'd': 5}
+    >>> tree = {"b": (2, [3, 4]), "a": 1, "c": None, "d": 5}
     >>> list(tree_iter(tree))
     [1, 2, 3, 4, None, 5]
     >>> list(tree_iter(1))
@@ -400,7 +400,7 @@ def tree_leaves(
 
     See also :func:`tree_flatten`.
 
-    >>> tree = {'b': (2, [3, 4]), 'a': 1, 'c': None, 'd': 5}
+    >>> tree = {"b": (2, [3, 4]), "a": 1, "c": None, "d": 5}
     >>> tree_leaves(tree)
     [1, 2, 3, 4, None, 5]
     >>> tree_leaves(1)
@@ -435,7 +435,7 @@ def tree_structure(
 
     See also :func:`tree_flatten`.
 
-    >>> tree = {'b': (2, [3, 4]), 'a': 1, 'c': None, 'd': 5}
+    >>> tree = {"b": (2, [3, 4]), "a": 1, "c": None, "d": 5}
     >>> tree_structure(tree)
     PyTreeSpec({'a': *, 'b': (*, [*, *]), 'c': *, 'd': *}, NoneIsLeaf)
     >>> tree_structure(1)
@@ -472,9 +472,9 @@ def tree_map(
 
     See also :func:`tree_map_`.
 
-    >>> tree_map(lambda x: x + 1, {'x': 7, 'y': (42, 64)})
+    >>> tree_map(lambda x: x + 1, {"x": 7, "y": (42, 64)})
     {'x': 8, 'y': (43, 65)}
-    >>> tree_map(lambda x: x is None, {'x': 7, 'y': (42, 64), 'z': None})
+    >>> tree_map(lambda x: x is None, {"x": 7, "y": (42, 64), "z": None})
     {'x': False, 'y': (False, False), 'z': True}
 
     If multiple inputs are given, the structure of the tree is taken from the first input;
@@ -572,7 +572,9 @@ def map_only(__type_or_types_or_pred: Type2[T, S]) -> MapOnlyFn[Fn2[T, S, Any]]:
 
 
 @overload
-def map_only(__type_or_types_or_pred: Type3[T, S, U]) -> MapOnlyFn[Fn3[T, S, U, Any]]:
+def map_only(
+    __type_or_types_or_pred: Type3[T, S, U],
+) -> MapOnlyFn[Fn3[T, S, U, Any]]:
     ...
 
 
@@ -588,12 +590,14 @@ def map_only(__type_or_types_or_pred: TypeAny) -> MapOnlyFn[FnAny[Any]]:
 
 
 @overload
-def map_only(__type_or_types_or_pred: Callable[[Any], bool]) -> MapOnlyFn[FnAny[Any]]:
+def map_only(
+    __type_or_types_or_pred: Callable[[Any], bool],
+) -> MapOnlyFn[FnAny[Any]]:
     ...
 
 
 def map_only(
-    __type_or_types_or_pred: Union[TypeAny, Callable[[Any], bool]]
+    __type_or_types_or_pred: Union[TypeAny, Callable[[Any], bool]],
 ) -> MapOnlyFn[FnAny[Any]]:
     """
     Suppose you are writing a tree_map over tensors, leaving everything
@@ -858,7 +862,7 @@ def broadcast_prefix(
     ValueError: list arity mismatch; expected: 3, got: 4; list: [1, 2, 3, 4].
     >>> broadcast_prefix([1, 2, 3], [1, 2, (3, 4)])
     [1, 2, 3, 3]
-    >>> broadcast_prefix([1, 2, 3], [1, 2, {'a': 3, 'b': 4, 'c': (None, 5)}])
+    >>> broadcast_prefix([1, 2, 3], [1, 2, {"a": 3, "b": 4, "c": (None, 5)}])
     [1, 2, 3, 3, 3, 3]
 
     Args:
@@ -873,13 +877,19 @@ def broadcast_prefix(
     Returns:
         A list of leaves in ``prefix_tree`` broadcasted to match the number of leaves in ``full_tree``.
     """
-    return optree.broadcast_prefix(
+    result: List[Any] = []
+
+    def add_leaves(x: Any, subtree: PyTree) -> None:
+        subtreespec = tree_structure(subtree, is_leaf=is_leaf)
+        result.extend([x] * subtreespec.num_leaves)
+
+    tree_map_(
+        add_leaves,
         prefix_tree,
         full_tree,
         is_leaf=is_leaf,
-        none_is_leaf=True,
-        namespace="torch",
     )
+    return result
 
 
 # Broadcasts a pytree to the provided TreeSpec and returns the flattened

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -744,85 +744,87 @@ class TreeSpec:
     def is_leaf(self) -> bool:
         return self.num_nodes == 1 and self.num_leaves == 1
 
-    def _flatten_up_to_helper(self, tree: PyTree, subtrees: List[PyTree]) -> None:
-        if self.is_leaf():
-            subtrees.append(tree)
-            return
+    def flatten_up_to(self, tree: PyTree) -> List[PyTree]:
+        def helper(treespec: TreeSpec, tree: PyTree, subtrees: List[PyTree]) -> None:
+            if treespec.is_leaf():
+                subtrees.append(tree)
+                return
 
-        node_type = _get_node_type(tree)
-        if self.type not in BUILTIN_TYPES:
-            # Always require custom node types to match exactly
-            if node_type != self.type:
-                raise ValueError(
-                    f"Type mismatch; "
-                    f"expected {self.type!r}, but got {node_type!r}.",
-                )
-            flatten_fn = SUPPORTED_NODES[node_type].flatten_fn
-            child_pytrees, context = flatten_fn(tree)
-            if len(child_pytrees) != self.num_children:
-                raise ValueError(
-                    f"Node arity mismatch; "
-                    f"expected {self.num_children}, but got {len(child_pytrees)}.",
-                )
-            if context != self.context:
-                raise ValueError(
-                    f"Node context mismatch for custom node type {self.type!r}.",
-                )
-        else:
-            # For builtin dictionary types, we allow some flexibility
-            # Otherwise, we require exact matches
-            both_standard_dict = (
-                self.type in STANDARD_DICT_TYPES and node_type in STANDARD_DICT_TYPES
-            )
-            if node_type != self.type and not both_standard_dict:
-                raise ValueError(
-                    f"Node type mismatch; "
-                    f"expected {self.type!r}, but got {node_type!r}.",
-                )
-            if len(tree) != self.num_children:
-                raise ValueError(
-                    f"Node arity mismatch; "
-                    f"expected {self.num_children}, but got {len(tree)}.",
-                )
-
-            if both_standard_dict:  # dictionary types are compatible with each other
-                dict_context = (
-                    self.context
-                    if self.type is not defaultdict
-                    # ignore mismatch of `default_factory` for defaultdict
-                    else self.context[1]
-                )
-                expected_keys = dict_context
-                got_key_set = set(tree)
-                expected_key_set = set(expected_keys)
-                if got_key_set != expected_key_set:
-                    missing_keys = expected_key_set.difference(got_key_set)
-                    extra_keys = got_key_set.difference(expected_key_set)
-                    message = ""
-                    if missing_keys:
-                        message += f"; missing key(s): {missing_keys}"
-                    if extra_keys:
-                        message += f"; extra key(s): {extra_keys}"
-                    raise ValueError(f"Node keys mismatch{message}.")
-                child_pytrees = [tree[key] for key in expected_keys]
-            else:
-                flatten_fn = SUPPORTED_NODES[node_type].flatten_fn
-                child_pytrees, context = flatten_fn(tree)
-                if (
-                    context != self.context
-                    and self.type is not deque  # ignore mismatch of `maxlen` for deque
-                ):
+            node_type = _get_node_type(tree)
+            if treespec.type not in BUILTIN_TYPES:
+                # Always require custom node types to match exactly
+                if node_type != treespec.type:
                     raise ValueError(
-                        f"Node context mismatch for node type {self.type!r}; "
-                        f"expected {self.context!r}, but got {context!r}.",  # namedtuple type mismatch
+                        f"Type mismatch; "
+                        f"expected {treespec.type!r}, but got {node_type!r}.",
+                    )
+                flatten_fn = SUPPORTED_NODES[node_type].flatten_fn
+                children, context = flatten_fn(tree)
+                if len(children) != treespec.num_children:
+                    raise ValueError(
+                        f"Node arity mismatch; "
+                        f"expected {treespec.num_children}, but got {len(children)}.",
+                    )
+                if context != treespec.context:
+                    raise ValueError(
+                        f"Node context mismatch for custom node type {treespec.type!r}.",
+                    )
+            else:
+                # For builtin dictionary types, we allow some flexibility
+                # Otherwise, we require exact matches
+                both_standard_dict = (
+                    treespec.type in STANDARD_DICT_TYPES
+                    and node_type in STANDARD_DICT_TYPES
+                )
+                if not both_standard_dict and node_type != treespec.type:
+                    raise ValueError(
+                        f"Node type mismatch; "
+                        f"expected {treespec.type!r}, but got {node_type!r}.",
+                    )
+                if len(tree) != treespec.num_children:
+                    raise ValueError(
+                        f"Node arity mismatch; "
+                        f"expected {treespec.num_children}, but got {len(tree)}.",
                     )
 
-        for child_pytree, child_spec in zip(child_pytrees, self.children_specs):
-            child_spec._flatten_up_to_helper(child_pytree, subtrees)
+                if both_standard_dict:
+                    # dictionary types are compatible with each other
+                    dict_context = (
+                        treespec.context
+                        if treespec.type is not defaultdict
+                        # ignore mismatch of `default_factory` for defaultdict
+                        else treespec.context[1]
+                    )
+                    expected_keys = dict_context
+                    got_key_set = set(tree)
+                    expected_key_set = set(expected_keys)
+                    if got_key_set != expected_key_set:
+                        missing_keys = expected_key_set.difference(got_key_set)
+                        extra_keys = got_key_set.difference(expected_key_set)
+                        message = ""
+                        if missing_keys:
+                            message += f"; missing key(s): {missing_keys}"
+                        if extra_keys:
+                            message += f"; extra key(s): {extra_keys}"
+                        raise ValueError(f"Node keys mismatch{message}.")
+                    children = [tree[key] for key in expected_keys]
+                else:
+                    # node_type is treespec.type
+                    flatten_fn = SUPPORTED_NODES[node_type].flatten_fn
+                    children, context = flatten_fn(tree)
+                    if (
+                        node_type is not deque  # ignore mismatch of `maxlen` for deque
+                    ) and context != treespec.context:
+                        raise ValueError(
+                            f"Node context mismatch for node type {treespec.type!r}; "
+                            f"expected {treespec.context!r}, but got {context!r}.",  # namedtuple type mismatch
+                        )
 
-    def flatten_up_to(self, tree: PyTree) -> List[PyTree]:
+            for subtree, subspec in zip(children, treespec.children_specs):
+                helper(subspec, subtree, subtrees)
+
         subtrees: List[PyTree] = []
-        self._flatten_up_to_helper(tree, subtrees)
+        helper(self, tree, subtrees)
         return subtrees
 
     def unflatten(self, leaves: Iterable[Any]) -> PyTree:

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -869,27 +869,6 @@ class LeafSpec(TreeSpec):
 _LEAF_SPEC = LeafSpec()
 
 
-def _tree_flatten_helper(
-    tree: PyTree,
-    leaves: List[Any],
-    is_leaf: Optional[Callable[[PyTree], bool]] = None,
-) -> TreeSpec:
-    if _is_leaf(tree, is_leaf=is_leaf):
-        leaves.append(tree)
-        return _LEAF_SPEC
-
-    node_type = _get_node_type(tree)
-    flatten_fn = SUPPORTED_NODES[node_type].flatten_fn
-    child_pytrees, context = flatten_fn(tree)
-
-    # Recursively flatten the children
-    children_specs = [
-        _tree_flatten_helper(child, leaves, is_leaf=is_leaf) for child in child_pytrees
-    ]
-
-    return TreeSpec(node_type, context, children_specs)
-
-
 def tree_flatten(
     tree: PyTree,
     is_leaf: Optional[Callable[[PyTree], bool]] = None,
@@ -897,9 +876,23 @@ def tree_flatten(
     """Flattens a pytree into a list of values and a TreeSpec that can be used
     to reconstruct the pytree.
     """
+
+    def helper(node: PyTree, leaves: List[Any]) -> TreeSpec:
+        if _is_leaf(node, is_leaf=is_leaf):
+            leaves.append(node)
+            return _LEAF_SPEC
+
+        node_type = _get_node_type(node)
+        flatten_fn = SUPPORTED_NODES[node_type].flatten_fn
+        children, context = flatten_fn(node)
+
+        # Recursively flatten the children
+        subspecs = [helper(child, leaves) for child in children]
+        return TreeSpec(node_type, context, subspecs)
+
     leaves: List[Any] = []
-    spec = _tree_flatten_helper(tree, leaves, is_leaf=is_leaf)
-    return leaves, spec
+    treespec = helper(tree, leaves)
+    return leaves, treespec
 
 
 def tree_unflatten(leaves: Iterable[Any], treespec: TreeSpec) -> PyTree:


### PR DESCRIPTION
Reland PRs:

- #137398
- #137399

These two PRs are in a series of PRs there the first one is in the release branch before the branch cut.

- 78543e60020b9fabd73d32ee7b1d5803a07d5e94
- #137397

This PR tries to add the follow-ups into the release branch as well.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames