### PR TITLE
Fix docs load state dict

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -69,9 +69,8 @@ specialize_float = True
 # legacy config, does nothing now!
 dynamic_shapes = True
 
-use_lazy_graph_module = (
-    os.environ.get("TORCH_COMPILE_USE_LAZY_GRAPH_MODULE", "1") == "1"
-)
+# legacy config, does nothing now!
+use_lazy_graph_module = True
 
 # This is a temporarily flag, which changes the behavior of dynamic_shapes=True.
 # When assume_static_by_default is True, we only allocate symbols for shapes marked dynamic via mark_dynamic.

--- a/torch/ao/nn/quantizable/modules/activation.py
+++ b/torch/ao/nn/quantizable/modules/activation.py
@@ -309,7 +309,9 @@ class MultiheadAttention(nn.MultiheadAttention):
               the embedding dimension. :math:`(N, S, E)` if ``batch_first`` is ``True``.
             - key_padding_mask: :math:`(N, S)` where N is the batch size, S is the source sequence length.
               If a BoolTensor is provided, the positions with the
-              value of ``True`` will be ignored while the position with the value of ``False`` will be unchanged.
+              value of ``True`` will be ignored (masked out) while the position with the value of ``False`` will be unchanged.
+              FloatTensor: specified additive penalties to the attention weights. Typically, large negatves values like -inf mask positions
+              by reducing their attention contributions, while 0.0 keeps positions unchanged.
             - attn_mask: 2D mask :math:`(L, S)` where L is the target sequence length, S is the source sequence length.
               3D mask :math:`(N*num_heads, L, S)` where N is the batch size, L is the target sequence length,
               S is the source sequence length. attn_mask ensure that position i is allowed to attend the unmasked

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2487,25 +2487,25 @@ class Module:
             the call to :attr:`load_state_dict` unless
             :func:`~torch.__future__.get_swap_module_params_on_conversion` is ``True``.
 
-        Args:
-            state_dict (dict): a dict containing parameters and
-                persistent buffers.
-            strict (bool, optional): whether to strictly enforce that the keys
-                in :attr:`state_dict` match the keys returned by this module's
-                :meth:`~torch.nn.Module.state_dict` function. Default: ``True``
-            assign (bool, optional): When ``False``, the properties of the tensors
-                in the current module are preserved while when ``True``, the
-                properties of the Tensors in the state dict are preserved. The only
-                exception is the ``requires_grad`` field of :class:`~torch.nn.Parameter`s
-                for which the value from the module is preserved.
-                Default: ``False``
+    Args:
+        state_dict (dict): A dictionary containing parameters and
+            persistent buffers.
+        strict (bool, optional): Whether to strictly enforce that the keys
+            in :attr:`state_dict` match the keys returned by this module's
+            :meth:`~torch.nn.Module.state_dict` function. Default: ``True``.
+        assign (bool, optional): When ``False``, the properties of the tensors
+            in the current module are preserved. When ``True``, the properties
+            of the tensors in the state dict are preserved. The only
+            exception is the ``requires_grad`` field of :class:`~torch.nn.Parameter`,
+            for which the value from the module is preserved.
+            Default: ``False``.
 
-        Returns:
-            ``NamedTuple`` with ``missing_keys`` and ``unexpected_keys`` fields:
-                * **missing_keys** is a list of str containing any keys that are expected
-                    by this module but missing from the provided ``state_dict``.
-                * **unexpected_keys** is a list of str containing the keys that are not
-                    expected by this module but present in the provided ``state_dict``.
+    Returns:
+        NamedTuple: A ``NamedTuple`` with ``missing_keys`` and ``unexpected_keys`` fields:
+            * **missing_keys** (list of str): Contains any keys that are expected
+              by this module but missing from the provided ``state_dict``.
+            * **unexpected_keys** (list of str): Contains keys that are not
+              expected by this module but present in the provided ``state_dict``.
 
         Note:
             If a parameter or buffer is registered as ``None`` and its corresponding key


### PR DESCRIPTION
Fixes #141364:
- Added proper indentation and formatting
- Improved readability for assign by breaking the text into shorter sentences
- Added "NamedTuple:" before the return description to clarify the type for Sphinx


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames