### PR TITLE
fix: resolve recursion overflow issue by hashing weak references

### DIFF
--- a/torch/utils/weak.py
+++ b/torch/utils/weak.py
@@ -49,7 +49,7 @@ class WeakIdRef(weakref.ref):
         # time the user attempts to hash the weakref, we can eagerly
         # cache the id of the key as we know this is definitely the hash
         # method
-        self._id = id(key)
+        self._id = id(ref(key))
         super().__init__(key, callback)  # type: ignore[call-arg]
 
     def __call__(self):


### PR DESCRIPTION
Issue
Using `weakref` with recursive objects in PyTorch causes recursion overflow due to the __hash__ method using id(key).

Fix
Changed self._id = id(key) to self._id = id(ref(key)) in the `__hash__` method to base the hash on the weak reference, preventing recursion overflow.

Fixes #ISSUE_NUMBER
