### PR TITLE
Fix old-compiler-unfriendly zero init of bfloat16_t array

### DIFF
--- a/aten/src/ATen/cpu/vec/vec128/vec128_bfloat16_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_bfloat16_neon.h
@@ -285,9 +285,7 @@ class Vectorized<c10::BFloat16> : public Vectorized16<at_bfloat16x8_t, c10::BFlo
       return at_vld1q_bf16(reinterpret_cast<const at_bfloat16_t*>(ptr));
     }
     __at_align__ at_bfloat16_t tmp_values[size()];
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    std::memset(tmp_values, 0, sizeof(tmp_values));
     std::memcpy(
         tmp_values,
         reinterpret_cast<const at_bfloat16_t*>(ptr),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

clang versions before 17 don't like to assign 0 to a bfloat16_t. gcc versions before 13 also won't assign 0.0 to a bfloat16_t. (Citation: https://godbolt.org/z/Gzs5ebdej)

Differential Revision: [D67396740](https://our.internmc.facebook.com/intern/diff/D67396740/)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10