### PR TITLE
leaking c++ singleton specifically

### DIFF
--- a/torch/csrc/monitor/events.cpp
+++ b/torch/csrc/monitor/events.cpp
@@ -32,8 +32,8 @@ class EventHandlers {
   }
 
   static EventHandlers& get() noexcept {
-    static EventHandlers ehs;
-    return ehs;
+    static auto ehsPtr = new EventHandlers();
+    return *ehsPtr;
   }
 
  private:


### PR DESCRIPTION
Summary:
fix forward for S477887

leaking c++ singleton specifically

when c++ shutdown, it tries to destruct the singleton and acquire GIL, at this moment python runtime exists already, causing undefined behavior.
Leaking here specifically so that we won't try to destroy singleton at the shutdown phase

Test Plan: n/a

Differential Revision: D67400633


