### PR TITLE
[codemod] Fix a few unused-variable issues in pytorch

### DIFF
--- a/test/cpp/profiler/containers.cpp
+++ b/test/cpp/profiler/containers.cpp
@@ -32,7 +32,7 @@ TEST(ProfilerTest, AppendOnlyList_ref) {
   const int n = 512;
   torch::profiler::impl::AppendOnlyList<std::pair<int, int>, 64> list;
   std::vector<std::pair<int, int>*> refs;
-  for (const auto _ : c10::irange(n)) {
+  for ([[maybe_unused]] const auto _ : c10::irange(n)) {
     refs.push_back(list.emplace_back());
   }
 
@@ -53,7 +53,7 @@ TEST(ProfilerTest, clock_converter) {
   std::vector<
       c10::ApproximateClockToUnixTimeConverter::UnixAndApproximateTimePair>
       pairs;
-  for (const auto i : c10::irange(n)) {
+  for ([[maybe_unused]] const auto i : c10::irange(n)) {
     pairs.push_back(c10::ApproximateClockToUnixTimeConverter::measurePair());
   }
   auto count_to_ns = converter.makeConverter();

--- a/test/cpp/profiler/perf_events.cpp
+++ b/test/cpp/profiler/perf_events.cpp
@@ -27,7 +27,7 @@ TEST(ProfilerTest, LinuxPerf) {
     profiler.Configure(standard_events);
 
     profiler.Enable();
-    auto pi = calc_pi();
+    calc_pi();
     profiler.Disable(counters);
   } catch (const c10::Error&) {
     // Bail here if something bad happened during the profiling, we don't want
@@ -84,19 +84,19 @@ TEST(ProfilerTest, LinuxPerfNestedDepth) {
     //
 
     profiler.Enable();
-    auto A = calc_pi();
+    calc_pi();
 
     profiler.Enable();
-    auto B = calc_pi();
+    calc_pi();
 
     profiler.Enable();
-    auto C = calc_pi();
+    calc_pi();
     profiler.Disable(counters_C);
 
-    auto B2 = calc_pi();
+    calc_pi();
     profiler.Disable(counters_B);
 
-    auto A2 = calc_pi();
+    calc_pi();
     profiler.Disable(counters_A);
   } catch (const c10::Error&) {
     // Bail here if something bad happened during the profiling, we don't want
@@ -153,20 +153,20 @@ TEST(ProfilerTest, LinuxPerfNestedMultiple) {
     //      B  +-**-+ B    C +-*--+ C
 
     profiler.Enable();
-    auto A1 = calc_pi();
+    calc_pi();
 
     profiler.Enable();
-    auto B1 = calc_pi();
-    auto B2 = calc_pi();
+    calc_pi();
+    calc_pi();
     profiler.Disable(counters_B);
 
-    auto A2 = calc_pi();
+    calc_pi();
 
     profiler.Enable();
-    auto C1 = calc_pi();
+    calc_pi();
     profiler.Disable(counters_C);
 
-    auto A3 = calc_pi();
+    calc_pi();
     profiler.Disable(counters_A);
   } catch (const c10::Error&) {
     // Bail here if something bad happened during the profiling, we don't want
@@ -218,7 +218,7 @@ TEST(ProfilerTest, LinuxPerfNestedSingle) {
     profiler.Enable();
     profiler.Enable();
     profiler.Enable();
-    auto A1 = calc_pi();
+    calc_pi();
     profiler.Disable(counters_C);
     profiler.Disable(counters_B);
     profiler.Disable(counters_A);

--- a/test/cpp/profiler/record_function.cpp
+++ b/test/cpp/profiler/record_function.cpp
@@ -207,7 +207,7 @@ TEST(RecordFunctionTest, Sampling) {
   std::vector<int> expected_counts;
   int running_count = 0;
   for (const auto i : c10::irange(outcomes.size())) {
-    for (const auto j : c10::irange(outcomes[i])) {
+    for ([[maybe_unused]] const auto j : c10::irange(outcomes[i])) {
       expected_counts.push_back(running_count);
     }
     expected_counts.push_back(++running_count);
@@ -255,12 +255,6 @@ TEST(RecordFunctionTest, MultipleCallbacks) {
   static std::array<int, 4> counts_from_rec_fn;
   counts_from_rec_fn.fill(0);
 
-  auto start_callback_0 =
-      [](const at::RecordFunction& fn) -> std::unique_ptr<at::ObserverContext> {
-    ++counts_from_rec_fn[0];
-    return nullptr;
-  };
-
   auto end_callback = [](const at::RecordFunction& fn, at::ObserverContext*) {};
 
 #define REGISTER_CALLBACK(register_fn, index)                   \
@@ -289,7 +283,7 @@ TEST(RecordFunctionTest, MultipleCallbacks) {
     next_call[i] = sample(probabilities[i]);
   }
 
-  for (const auto i : c10::irange(50)) {
+  for ([[maybe_unused]] const auto i : c10::irange(50)) {
     RECORD_FUNCTION("Test", {});
     for (const auto j : c10::irange(next_call.size())) {
       if (!(--next_call[j])) {


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Test Plan: Sandcastle

Reviewed By: palmje



