### PR TITLE
[DRAFT] Implement getattr access for subclasses in pre-dispatch IR

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1619,15 +1619,17 @@ graph():
 graph():
     %p_p1 : [num_users=1] = placeholder[target=p_p1]
     %p_p2 : [num_users=1] = placeholder[target=p_p2]
-    %c_lifted_tensor_0 : [num_users=1] = placeholder[target=c_lifted_tensor_0]
     %x : [num_users=1] = placeholder[target=x]
     %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
     %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, %p_p2), kwargs = {})
-    %sum_1 : [num_users=0] = call_function[target=torch.ops.aten.sum.default](args = (%add,), kwargs = {})
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %c_lifted_tensor_0), kwargs = {})
+    %sum_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add,), kwargs = {})
+    %getattr_17 : [num_users=2] = call_function[target=builtins.getattr](args = (%sum_1, a), kwargs = {})
+    %detach : [num_users=0] = call_function[target=torch.ops.aten.detach.default](args = (%getattr_17,), kwargs = {})
+    %getattr_18 : [num_users=1] = call_function[target=builtins.getattr](args = (%getattr_17, b), kwargs = {})
+    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %getattr_18), kwargs = {})
     return (add_1,)"""
         )
-        ep = torch.export.export(m, (ref_x,))
+        ep = export(m, (ref_x,), strict=False)
         self.assertTrue(torch.allclose(ep.module()(ref_x), ref_out))
 
     def test_real_tensor_errors_on_aliasing_custom_op(self):

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -137,6 +137,7 @@ class Verifier(metaclass=_VerifierMeta):
             math.floor,
             math.trunc,
             round,
+            getattr,
         ]
 
     def allowed_op_types(self) -> Tuple[Type[Any], ...]:

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -181,7 +181,10 @@ def is_fake(x: object) -> TypeGuard[Tensor]:
         return True
     if is_traceable_wrapper_subclass(x):
         attrs, _ = type(x).__tensor_flatten__(x)
-        flattened_tensors = [getattr(x, attr) for attr in attrs]
+        try:
+            flattened_tensors = [getattr(x, attr) for attr in attrs]
+        except:
+            breakpoint()
         all_fake = all(is_fake(x) for x in flattened_tensors)
         any_fake = any(is_fake(x) for x in flattened_tensors)
         assert all_fake == any_fake, "got mixed fake and real tensors!"

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1,16 +1,24 @@
 # mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
+import builtins
 import dataclasses
 import functools
 import inspect
 import logging
 import re
 import time
+import types
 import warnings
 from contextlib import contextmanager, nullcontext
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from functools import partial
 
 import torch
+
+from torch.utils._python_dispatch import (
+    is_traceable_wrapper_subclass,
+)
+
 import torch._dynamo
 import torch.fx
 import torch.utils._pytree as pytree
@@ -1468,11 +1476,68 @@ def _export_to_aten_ir_make_fx(
         )
         flat_args, in_spec = pytree.tree_flatten((params_buffers_args, kwargs))
 
+        def getattr_for_tensor_subclass_inner_tensor(self, *, attr_name):
+            if torch.overrides.has_torch_function_unary(self):
+                torch.overrides.handle_torch_function(builtins.getattr, (self, ), self, attr_name)
+            return getattr(self, "_patched_reserved_" + attr_name)
+        
+        def setattr_for_tensor_subclass_inner_tensor(self, value, *, attr_name):
+            setattr(self, "_patched_reserved_" + attr_name, value)
+        
+        def delattr_for_tensor_subclass_inner_tensor(self, *, attr_name):
+            delattr(self, "_patched_reserved_" + attr_name)
+
+        @contextmanager
+        def _monkey_patch_shadow_attrs_to_subclass(args):
+            wrapper_tensor_subclasses = [arg for arg in args if is_traceable_wrapper_subclass(arg)]
+            subclass_to_extra_attrs_to_be_deleted = {}
+            for ix, wrapper_tensor_subclass in enumerate(wrapper_tensor_subclasses):
+                extra_attrs_to_be_deleted = []
+                todos = [wrapper_tensor_subclass]
+                while todos:
+                    todo = todos.pop()
+                    if is_traceable_wrapper_subclass(todo):
+                        inner_keys, _ = todo.__tensor_flatten__()
+                        for key in inner_keys: 
+                            inner_tensor = getattr(todo, key)
+                            setattr(todo, "_patched_reserved_" + key, inner_tensor)
+                            extra_attrs_to_be_deleted.append((key, todo, inner_tensor))
+                            todos.append(inner_tensor)
+                subclass_to_extra_attrs_to_be_deleted[ix] = extra_attrs_to_be_deleted
+            try:
+                yield
+            finally:
+                deleted_monkey_patched_properties = set()
+                for ix, wrapper_tensor_subclass in enumerate(wrapper_tensor_subclasses):
+                    extra_attrs_to_be_deleted = subclass_to_extra_attrs_to_be_deleted[ix]
+                    for attr_name, parent_tensor, inner_tensor in extra_attrs_to_be_deleted:
+                        if (attr_name, type(parent_tensor)) not in deleted_monkey_patched_properties:
+                            breakpoint()
+                            prop = property(partial(builtins.getattr, obj=parent_tensor), partial(builtins.setattr, obj=parent_tensor), partial(builtins.delattr, obj=parent_tensor))
+                            setattr(type(parent_tensor), attr_name, prop)
+                            deleted_monkey_patched_properties.add((attr_name, type(parent_tensor)))
+
+
+        def _override_inner_tensor_getattr(wrapper_tensor_subclass):
+            inner_keys, _ = wrapper_tensor_subclass.__tensor_flatten__()
+            for key in inner_keys: 
+                inner_tensor = getattr(wrapper_tensor_subclass, key)
+                if is_traceable_wrapper_subclass(inner_tensor):
+                    _override_inner_tensor_getattr(inner_tensor)
+                else:
+                    prop= property(partial(getattr_for_tensor_subclass_inner_tensor, attr_name=key), partial(setattr_for_tensor_subclass_inner_tensor, attr_name=key), partial(delattr_for_tensor_subclass_inner_tensor, attr_name=key))
+                    setattr(type(wrapper_tensor_subclass), key, prop)
+        
+
         @functools.wraps(flat_fn)
         def wrapped_fn(*args):
             return tuple(flat_fn(*args))
 
-        with enable_python_dispatcher():
+        with enable_python_dispatcher(), _monkey_patch_shadow_attrs_to_subclass(flat_args):
+            with torch.overrides._enable_torch_function():
+                for arg in flat_args:
+                    if is_traceable_wrapper_subclass(arg):
+                        _override_inner_tensor_getattr(arg)
             ctx = nullcontext()
             non_strict_root = getattr(mod, "_export_root", None)
             if non_strict_root is not None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143518
* #141941

This is a draft PR that tries to prototype how to capture attribute access in pre-dispatch IR. The motivating use case is: https://github.com/pytorch/ao/blob/039cef4ad546716aa04cd54c461feb173f7fe403/tutorials/developer_api_guide/export_to_executorch.py#L54 where TorchAO overrides Embedding.weight with a tensor subclass and then do attribute access inside it. We have to solve this problem in both strict and non-strict because even when dynamo translates `subclass.inner_tensor` into a fx Graph, the underlying tracer that converts torch IR to aten IR will need to handle `subclass.inner_tensor` as well. 

The basic implementation idea here is that: "We will override __getattr__ of tensors so that we can inject torch_function handler to intercept it in make_fx". But the complications here are:
1. We don't want to add override to __getattr__ in tensor because it will significantly slow down the eager performance. Some synthetic benchmarking we did showed around 15% slow down (the benchmark is bit skewed because the example we tried had lot of attr accesses) 
2. We can only intercept __getattr__ for input tensors (user inputs + param/buffers) because intercepting everything will require we do global patching. 

So we decided to monkey patch inner tensors as properties in export. Then, the main difficulty here is to correctly clean up the monkey patched attr accesses. Roughly we are doing something like this:
```
class Foo():
    bar = 2

foo = Foo()
print(foo.bar)

def patch(obj):
    obj._real_foo = obj.bar
    def my_getter(self):
        print("handle things here ")
        return self._real_foo
    def my_setter(self, new_val):
        print("Handle setter here")
        self._real_foo = new_val
    type(obj).bar = property(my_getter, my_setter)

patch(foo)
print(foo.bar)
foo.bar = 3
print(foo.bar)
```

Other approaches we considered but didn't pursue:
1. Ask subclass authors to explicitly mark inner tensors as properties which sounds bit lame
2. If user is interested in inference IR only, don't materialize pre-dispatch IR which causes some complicated story for export side. 

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv