### PR TITLE
[Dynamo] Flatten slices during graph deduplication

### DIFF
--- a/test/dynamo/test_graph_deduplication.py
+++ b/test/dynamo/test_graph_deduplication.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 import torch
 import torch.fx
+from torch._dynamo.graph_deduplication import _flatten_args_kwargs
 from torch._dynamo.test_case import TestCase
 from torch._dynamo.testing import AotEagerAndRecordGraphs, normalize_gm
 
@@ -582,6 +583,13 @@ class <lambda>(torch.nn.Module):
             add: "f32[]" = torch.ops.aten.add.Tensor(sum_2, sum_1);  sum_2 = sum_1 = None
             return (add,)
 """,
+        )
+
+    def test_flatten_with_slices(self):
+        tree = [{"x": 3}, ["x", slice(1, 2, 3), 1], [4, 5, 6, [slice(3, 4, 5)]]]
+        out = _flatten_args_kwargs(tree)
+        self.assertExpectedInline(
+            str(out), """[3, 'x', 1, 2, 3, 1, 4, 5, 6, 3, 4, 5]"""
         )
 
 


### PR DESCRIPTION
I encountered this issue while debugging torchtune - overall we need to make sure to not miss nodes that are slice arguments. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames