### PR TITLE
torch/accelerator: fix device type comparison

### DIFF
--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -68,6 +68,17 @@ class TestAccelerator(TestCase):
         self.assertTrue(event.query())
         self.assertEqual(c_acc.cpu(), c)
 
+    def test_current_stream_query(self):
+        s = torch.accelerator.current_stream()
+        self.assertEqual(torch.accelerator.current_stream(s.device), s)
+        self.assertEqual(torch.accelerator.current_stream(s.device.index), s)
+        self.assertEqual(torch.accelerator.current_stream(str(s.device)), s)
+        other_device = torch.device("cpu")
+        with self.assertRaisesRegex(
+            ValueError, "doesn't match the current accelerator"
+        ):
+            torch.accelerator.current_stream(other_device)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/accelerator/_utils.py
+++ b/torch/accelerator/_utils.py
@@ -11,7 +11,7 @@ def _get_device_index(device: _device_t, optional: bool = False) -> int:
         device = torch.device(device)
     device_index: Optional[int] = None
     if isinstance(device, torch.device):
-        if torch.accelerator.current_accelerator() != device.type:
+        if torch.accelerator.current_accelerator().type != device.type:
             raise ValueError(
                 f"{device.type} doesn't match the current accelerator {torch.accelerator.current_accelerator()}."
             )


### PR DESCRIPTION
This was failing without the fix:
```
python -c 'import torch; d=torch.device("xpu:0"); torch.accelerator.current_stream(d)'
```
with:
```
ValueError: xpu doesn't match the current accelerator xpu.
```

CC: @guangyey, @EikanWang 

cc @albanD @guangyey @EikanWang