### PR TITLE
[Inductor] Fix FX Graph Cache with constant adding in lowering

### DIFF
--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -375,8 +375,10 @@ class CompiledFxGraph(OutputCode):
         self.mutated_inputs = OrderedSet(graph.mutated_inputs)
         self.mutated_input_idxs = OrderedSet(graph.mutated_input_idxs)
         if has_frozen_params(gm):
+            # When freezing turns on, the frozen parameters can be fetched
+            # from the Graph Module by name. So we only need to store the
+            # constant added by the graph lowering.
             self.allocated_constant_name = graph.allocated_constant_name
-            # skip the constant from freeze module to save storage
             self.constants = {
                 key: value
                 for key, value in graph.constants.items()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143563

**Summary**
Fix https://github.com/pytorch/pytorch/issues/143144, the issue happens due to we add new constant into `GraphLowering` when `freezing` turns on. We record these new constants and set it into the loaded Python Module in this PR.

**Test Plan**
```
python -u -m pytest -s -v test/inductor/test_codecache.py -k test_cpp_max_autotune
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov