### PR TITLE
[ROCm] Add miopen_batch_norm to meta_registrations to fix AOTI issue

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2283,10 +2283,15 @@ def meta_miopen_batch_norm(
         return torch.contiguous_format
 
     out = input_tensor.new_empty(out_shape).to(memory_format=pick_memory_format())
-    save_mean = input_tensor.new_empty(save_mean_shape)
-    save_var = input_tensor.new_empty(save_var_shape)
 
-    return out, save_mean, save_var
+    if training:
+        save_mean = input_tensor.new_empty(save_mean_shape)
+        save_var = input_tensor.new_empty(save_var_shape)
+    else:
+        save_mean = input_tensor.new_empty((0,))
+        save_var = input_tensor.new_empty((0,))
+        
+        return out, save_mean, save_var
 
 @register_meta(aten.convolution.default)
 def meta_conv(

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2256,6 +2256,7 @@ def calc_conv_nd_return_shape(
 def is_channels_last(ten):
     return torch._prims_common.suggest_memory_format(ten) == torch.channels_last
 
+
 @register_meta(aten.miopen_batch_norm.default)
 def meta_miopen_batch_norm(
     input_tensor: torch.Tensor,
@@ -2290,8 +2291,9 @@ def meta_miopen_batch_norm(
     else:
         save_mean = input_tensor.new_empty((0,))
         save_var = input_tensor.new_empty((0,))
-        
+
     return out, save_mean, save_var
+
 
 @register_meta(aten.convolution.default)
 def meta_conv(

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2291,7 +2291,7 @@ def meta_miopen_batch_norm(
         save_mean = input_tensor.new_empty((0,))
         save_var = input_tensor.new_empty((0,))
         
-        return out, save_mean, save_var
+    return out, save_mean, save_var
 
 @register_meta(aten.convolution.default)
 def meta_conv(


### PR DESCRIPTION
Currently the upstream example for AOTI usage breaks on ROCm (https://pytorch.org/tutorials/recipes/torch_export_aoti_python.html)

```
File "/root/upstream/torch/_dynamo/exc.py", line 317, in unimplemented
    raise Unsupported(msg, case_name=case_name)
torch._dynamo.exc.Unsupported: unsupported operator: aten.miopen_batch_norm.default (see https://docs.google.com/document/d/1GgvOe7C8_NVOMLOCwDaYV1mXXyHMXY7ExoewHqooxrs/edit#heading=h.64r4npvq0w0 for how to fix)

from user code:
   File "/root/vision/torchvision/models/resnet.py", line 285, in forward
    return self._forward_impl(x)
  File "/root/vision/torchvision/models/resnet.py", line 269, in _forward_impl
    x = self.bn1(x)
```

This PR adds a meta_registration for miopen_batch_norm to resolve this issue

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang @naromero77amd