### PR TITLE
[ROCm] Guard triton backend call around cuda.is_available

### DIFF
--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -79,7 +79,7 @@ platform_configs = tuple(
 )
 
 # On ROCm convert num_stages to 1 as pipelining provides no benefit
-if torch.version.hip:
+if torch.version.hip and torch.cuda.is_available:
     platform_configs = build_rocm_gemm_configs(platform_configs)
 
 

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -79,7 +79,7 @@ platform_configs = tuple(
 )
 
 # On ROCm convert num_stages to 1 as pipelining provides no benefit
-if torch.version.hip and torch.cuda.is_available:
+if torch.version.hip and torch.cuda.is_available():
     platform_configs = build_rocm_gemm_configs(platform_configs)
 
 

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -388,7 +388,7 @@ scaled_persistent_mm_platform_configs = tuple(
 )
 
 # On ROCm convert num_stages to improve performance
-if torch.version.hip:
+if torch.version.hip and torch.cuda.is_available():
     mm_platform_configs = build_rocm_gemm_configs(mm_platform_configs)
     extra_mm_platform_configs = build_rocm_gemm_configs(extra_mm_platform_configs)
     int8_platform_configs = build_rocm_gemm_configs(int8_platform_configs)


### PR DESCRIPTION
To resolve: https://github.com/pytorch/test-infra/issues/6082

Calling into Triton's get_backend_options will initialise CUDA and break CPU-only environments that may have hip installed. 

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov