### PR TITLE
Reuse partial reductions

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -567,7 +567,6 @@ class TestPatternMatcher(TestCase):
     @parametrize(
         "case",
         [
-            ((64, 128, 256), "cpu"),
             ((4, 8), GPU_TYPE),
             ("dynamic", GPU_TYPE),
         ],
@@ -581,7 +580,7 @@ class TestPatternMatcher(TestCase):
             return partial, full
 
         if shape == "dynamic":
-            x = torch.rand([2048, 2048], device=GPU_TYPE)
+            x = torch.rand([2048, 64], device=GPU_TYPE)
             torch._dynamo.mark_dynamic(x, 0)
         else:
             x = torch.randn(*shape, device=device)

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -35,7 +35,13 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import SM80OrLater, xfailIfSM89
 from torch.testing._internal.common_device_type import expectedFailureXPU, skipCUDAIf
-from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm, skipIfXpu
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    IS_LINUX,
+    parametrize,
+    skipIfRocm,
+    skipIfXpu,
+)
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_GPU,
@@ -48,6 +54,7 @@ from torch.utils import _pytree as pytree
 aten = torch.ops.aten
 
 
+@instantiate_parametrized_tests
 class TestPatternMatcher(TestCase):
     device_type = GPU_TYPE
 
@@ -556,6 +563,56 @@ class TestPatternMatcher(TestCase):
             torch.randint(-128, 127, (8, 8), dtype=torch.int8),
         )
         self._test_mixed_impl(fn, args, False, False)
+
+    @parametrize(
+        "case",
+        [
+            ((64, 128, 256), "cpu"),
+            ((4, 8), GPU_TYPE),
+            ("dynamic", GPU_TYPE),
+        ],
+    )
+    def test_unsuccessful_partial_reuse(self, case):
+        shape, device = case
+
+        def test_fn(x):
+            partial = torch.amax(x, [0], True)
+            full = torch.amax(x)
+            return partial, full
+
+        if shape == "dynamic":
+            x = torch.rand([2048, 2048], device=GPU_TYPE)
+            torch._dynamo.mark_dynamic(x, 0)
+        else:
+            x = torch.randn(*shape, device=device)
+
+        compiled_fn = torch.compile(test_fn)
+
+        self.assertEqual(compiled_fn(x), test_fn(x))
+        self.assertEqual(counters["inductor"]["partial_reduction_reuse"], 0)
+
+    @parametrize(
+        "case",
+        [
+            ((2048, 2048), (torch.amax, torch.amax)),
+            ((1024, 1024), (torch.amin, torch.min)),
+            ((4096, 512), (torch.amax, torch.max)),
+        ],
+    )
+    def test_successful_partial_reuse(self, case):
+        shape, (partial_fn, full_fn) = case
+
+        def test_fn(x):
+            partial = partial_fn(x, [0], True)
+            full = full_fn(x)
+            return partial, full
+
+        x = torch.randn(*shape, device=GPU_TYPE)
+
+        compiled_fn = torch.compile(test_fn)
+
+        self.assertEqual(compiled_fn(x), test_fn(x))
+        self.assertEqual(counters["inductor"]["partial_reduction_reuse"], 1)
 
     @expectedFailureXPU
     @skipCUDAIf(not SM80OrLater, "need sm_80")

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1051,6 +1051,8 @@ def register_partial_reduction_pattern():
             return
 
         partial_red, full_red = match.output_nodes()
+        if partial_red.meta["val"].numel() == 1 or full_red.meta["val"].numel() != 1:
+            return
 
         def replacement(inp: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
             partial = partial_red.target(inp, reduced_dims, keepdim)

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1056,8 +1056,12 @@ def register_partial_reduction_pattern():
 
         def replacement(inp: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
             partial = partial_red.target(inp, reduced_dims, keepdim)
+
             replaced_target = replacements.get(full_red.target, full_red.target)
-            complete = full_red.target(replaced_target(inp, reduced_dims, keepdim))
+            if replaced_target is partial_red.target:
+                complete = full_red.target(partial)
+            else:
+                complete = full_red.target(replaced_target(inp, reduced_dims, keepdim))
             return (partial, complete)
 
         counters["inductor"]["partial_reduction_reuse"] += 1

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1016,8 +1016,8 @@ def register_partial_reduction_pattern():
         aten.amin.default: aten.min.default,
     }
 
-    # TODO - could support more reductions. they have different signatures which makes
-    # this a bit more annoying
+    # TODO: to support other reductions like sum, would need to skip
+    # lower precision reductions since partial output would need to be kept at fp32.
     for red_op in (aten.amax.default, aten.amin.default):
         inp = KeywordArg("input")
         partial_reduc = CallFunction(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143600

Reuse partial reductions for complete reductions. We could expand this to more cover more types of reductions, although we'd have to be a bit more careful about keeping the intermediary, partial reduction in higher precision. 

Just doing the ops which do not depend on a higher compute_dtype_precision for now to cover the relevant use case initially.

Fix for https://github.com/pytorch/pytorch/issues/136267. Longer term, we should make sure cooperative reductions fuse partial and complete reductions.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov