### PR TITLE
remove allow-untyped-defs from torch/distributed/elastic/multiprocessing/errors/handlers.py

### DIFF
--- a/torch/distributed/elastic/multiprocessing/errors/handlers.py
+++ b/torch/distributed/elastic/multiprocessing/errors/handlers.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# mypy: allow-untyped-defs
-
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
 #
@@ -15,5 +12,5 @@ from torch.distributed.elastic.multiprocessing.errors.error_handler import Error
 __all__ = ["get_error_handler"]
 
 
-def get_error_handler():
+def get_error_handler() -> ErrorHandler:
     return ErrorHandler()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #143606
* __->__ #143605



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o