### PR TITLE
remove allow-untyped-defs from torch/distributed/pipelining/_debug.py

### DIFF
--- a/torch/distributed/pipelining/_debug.py
+++ b/torch/distributed/pipelining/_debug.py
@@ -1,9 +1,9 @@
-# mypy: allow-untyped-defs
 # Copyright (c) Meta Platforms, Inc. and affiliates
+
 import torch
 
 
-def friendly_debug_info(v):
+def friendly_debug_info(v: object) -> str:
     """
     Helper function to print out debug info in a friendly way.
     """
@@ -13,7 +13,7 @@ def friendly_debug_info(v):
         return str(v)
 
 
-def map_debug_info(a):
+def map_debug_info(a: torch.fx.node.Argument) -> torch.fx.node.Argument:
     """
     Helper function to apply `friendly_debug_info` to items in `a`.
     `a` may be a list, tuple, or dict.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143606



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o