### PR TITLE
[DynamoBench] Handle accuracy results in benchmark records

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -505,7 +505,8 @@ test_perf_for_dashboard() {
       if [[ "$DASHBOARD_TAG" == *default-true* ]]; then
         $TASKSET python "benchmarks/dynamo/$suite.py" \
             "${target_flag[@]}" --"$mode" --"$dtype" --backend "$backend" --disable-cudagraphs "$@" \
-            --output "$TEST_REPORTS_DIR/${backend}_no_cudagraphs_${suite}_${dtype}_${mode}_${device}_${target}.csv"
+            --output "$TEST_REPORTS_DIR/${backend}_no_cudagraphs_${suite}_${dtype}_${mode}_${device}_${target}.csv" \
+            --only BERT_pytorch  # DEBUG: TO BE REMOVE
       fi
       if [[ "$DASHBOARD_TAG" == *cudagraphs-true* ]]; then
         $TASKSET python "benchmarks/dynamo/$suite.py" \

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -505,8 +505,7 @@ test_perf_for_dashboard() {
       if [[ "$DASHBOARD_TAG" == *default-true* ]]; then
         $TASKSET python "benchmarks/dynamo/$suite.py" \
             "${target_flag[@]}" --"$mode" --"$dtype" --backend "$backend" --disable-cudagraphs "$@" \
-            --output "$TEST_REPORTS_DIR/${backend}_no_cudagraphs_${suite}_${dtype}_${mode}_${device}_${target}.csv" \
-            --only BERT_pytorch  # DEBUG: TO BE REMOVE
+            --output "$TEST_REPORTS_DIR/${backend}_no_cudagraphs_${suite}_${dtype}_${mode}_${device}_${target}.csv"
       fi
       if [[ "$DASHBOARD_TAG" == *cudagraphs-true* ]]; then
         $TASKSET python "benchmarks/dynamo/$suite.py" \

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -437,11 +437,26 @@ def output_json(filename, headers, row):
                     "backend": current_backend,
                     "origins": [origin],
                 },
-                "metric": {
+            }
+
+            # NB: When the metric is accuracy, its value is actually a string, i.e. pass, and
+            # not a number. ClickHouse doesn't support mix types atm. It has a Variant type
+            # https://clickhouse.com/docs/en/sql-reference/data-types/variant, but this isn't
+            # recommended by CH team themselves. The workaround here is to store that value
+            # in the extra_info field instead.
+            if isinstance(value, str):
+                record["metric"] = {
+                    "name": header,
+                    "extra_info": {
+                        "benchmark_values": [value]
+                    }
+                }
+            else:
+                record["metric"] = {
                     "name": header,
                     "benchmark_values": [value],
-                },
-            }
+                }
+
             print(json.dumps(record), file=f)
 
 

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -447,9 +447,7 @@ def output_json(filename, headers, row):
             if isinstance(value, str):
                 record["metric"] = {
                     "name": header,
-                    "extra_info": {
-                        "benchmark_values": [value]
-                    }
+                    "extra_info": {"benchmark_values": [value]},
                 }
             else:
                 record["metric"] = {


### PR DESCRIPTION
I discovered this issue when trying to search for the accuracy results on the database and couldn't find any.  It turns out that the results is there on the JSON file, for example `"metric": {"name": "accuracy", "benchmark_values": ["pass_due_to_skip"]}`, but inserting them into the database fails because benchmark values is a list of strings here while the expectation is that it's a list of numbers.

ClickHouse doesn't support mix types atm. It has a Variant type https://clickhouse.com/docs/en/sql-reference/data-types/variant, but this isn't recommended by CH team themselves.  So, the remaining option is to store this in the `extra_info` field.  This field is a dictionary, so it can goes there.

### Testing

https://github.com/pytorch/pytorch/actions/runs/12421747715

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames