### PR TITLE
Apply clang-format for ATen/core/dispatch headers

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -60,6 +60,7 @@ include_patterns = [
     'aten/src/ATen/xpu/**/*.h',
     'aten/src/ATen/xpu/**/*.cpp',
     'aten/src/ATen/core/boxing/**/*.h',
+    'aten/src/ATen/core/dispatch/**/*.h',
     'aten/src/ATen/native/mps/**/*.metal',
     'aten/src/ATen/native/mps/**/*.mm',
     'aten/src/ATen/native/mps/**/*.h',

--- a/aten/src/ATen/core/dispatch/CppSignature.h
+++ b/aten/src/ATen/core/dispatch/CppSignature.h
@@ -1,63 +1,67 @@
 #pragma once
 
-#include <typeindex>
 #include <c10/core/DispatchKeySet.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Metaprogramming.h>
 #include <c10/util/Type.h>
+#include <typeindex>
 
 namespace c10::impl {
 
-// A CppSignature object holds RTTI information about a C++ function signature at runtime
-// and can compare them or get a debug-printable name.
+// A CppSignature object holds RTTI information about a C++ function signature
+// at runtime and can compare them or get a debug-printable name.
 class TORCH_API CppSignature final {
-public:
-    CppSignature(const CppSignature&) = default;
-    CppSignature(CppSignature&&) noexcept = default;
-    CppSignature& operator=(const CppSignature&) = default;
-    CppSignature& operator=(CppSignature&&) noexcept = default;
+ public:
+  CppSignature(const CppSignature&) = default;
+  CppSignature(CppSignature&&) noexcept = default;
+  CppSignature& operator=(const CppSignature&) = default;
+  CppSignature& operator=(CppSignature&&) noexcept = default;
 
-    template<class FuncType>
-    static CppSignature make() {
-        // Normalize functors, lambdas, function pointers, etc. into the plain function type
-        // The first argument of the schema might be of type DispatchKeySet, in which case we remove it.
-        // We do this to guarantee that all CppSignature's for an operator will match, even if they're registered
-        // with different calling conventions.
-        // See Note [Plumbing Keys Through The Dispatcher]
-        using decayed_function_type = typename c10::remove_DispatchKeySet_arg_from_func<std::decay_t<FuncType>>::func_type;
+  template <class FuncType>
+  static CppSignature make() {
+    // Normalize functors, lambdas, function pointers, etc. into the plain
+    // function type The first argument of the schema might be of type
+    // DispatchKeySet, in which case we remove it. We do this to guarantee that
+    // all CppSignature's for an operator will match, even if they're registered
+    // with different calling conventions.
+    // See Note [Plumbing Keys Through The Dispatcher]
+    using decayed_function_type =
+        typename c10::remove_DispatchKeySet_arg_from_func<
+            std::decay_t<FuncType>>::func_type;
 
-        return CppSignature(std::type_index(typeid(decayed_function_type)));
+    return CppSignature(std::type_index(typeid(decayed_function_type)));
+  }
+
+  std::string name() const {
+    return c10::demangle(signature_.name());
+  }
+
+  friend bool operator==(const CppSignature& lhs, const CppSignature& rhs) {
+    if (lhs.signature_ == rhs.signature_) {
+      return true;
+    }
+    // Without RTLD_GLOBAL, the type_index comparison could yield false because
+    // they point to different instances of the RTTI data, but the types would
+    // still be the same. Let's check for that case too.
+    // Note that there still is a case where this might not work, i.e. when
+    // linking libraries of different compilers together, they might have
+    // different ways to serialize a type name. That, together with a missing
+    // RTLD_GLOBAL, would still fail this.
+    if (0 == strcmp(lhs.signature_.name(), rhs.signature_.name())) {
+      return true;
     }
 
-    std::string name() const {
-        return c10::demangle(signature_.name());
-    }
+    return false;
+  }
 
-    friend bool operator==(const CppSignature& lhs, const CppSignature& rhs) {
-        if (lhs.signature_ == rhs.signature_) {
-            return true;
-        }
-        // Without RTLD_GLOBAL, the type_index comparison could yield false because
-        // they point to different instances of the RTTI data, but the types would
-        // still be the same. Let's check for that case too.
-        // Note that there still is a case where this might not work, i.e. when
-        // linking libraries of different compilers together, they might have
-        // different ways to serialize a type name. That, together with a missing
-        // RTLD_GLOBAL, would still fail this.
-        if (0 == strcmp(lhs.signature_.name(), rhs.signature_.name())) {
-            return true;
-        }
-
-        return false;
-    }
-
-private:
-    explicit CppSignature(std::type_index signature): signature_(std::move(signature)) {}
-    std::type_index signature_;
+ private:
+  explicit CppSignature(std::type_index signature)
+      : signature_(std::move(signature)) {}
+  std::type_index signature_;
 };
 
 inline bool operator!=(const CppSignature& lhs, const CppSignature& rhs) {
-    return !(lhs == rhs );
+  return !(lhs == rhs);
 }
 
-}
+} // namespace c10::impl

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <cstdint>
+#include <ATen/core/Variadic.h>
 #include <ATen/core/function_schema.h>
 #include <ATen/core/jit_type.h>
-#include <c10/util/Bitset.h>
-#include <c10/core/DispatchKeySet.h>
-#include <c10/util/irange.h>
-#include <ATen/core/Variadic.h>
 #include <ATen/core/stack.h>
+#include <c10/core/DispatchKeySet.h>
+#include <c10/util/Bitset.h>
+#include <c10/util/irange.h>
+#include <cstdint>
 
 namespace c10 {
 
@@ -35,9 +35,9 @@ inline DispatchKeySet computeDispatchKeySet(
     // AFTER TLS (since the backend may have been introduced for consideration
     // by the included TLS), which is why you have to pass them in to this
     // function (as opposed to just applying it to the input 'ks').
-    DispatchKeySet key_mask
-) {
-  c10::impl::LocalDispatchKeySet local = c10::impl::tls_local_dispatch_key_set();
+    DispatchKeySet key_mask) {
+  c10::impl::LocalDispatchKeySet local =
+      c10::impl::tls_local_dispatch_key_set();
   // TODO: It's a bit irritating that we have to do logical ORs here, it would
   // be nice to only do one.  Can always_included be folded into the TLS?  Well,
   // it's a bit troublesome, because fastpath TLS access requires the type of
@@ -46,67 +46,67 @@ inline DispatchKeySet computeDispatchKeySet(
   return (((ks | local.included_) - local.excluded_) & key_mask);
 }
 
-}
+} // namespace impl
 
 namespace detail {
-  // A small gadget to extract the DispatchKeySet from types which are known
-  // to have it.  Used to extract dispatch keys from unboxed calls.
-  struct MultiDispatchKeySet : at::IterArgs<MultiDispatchKeySet> {
-    DispatchKeySet ts;
-    void operator()(const at::Tensor& x) {
+// A small gadget to extract the DispatchKeySet from types which are known
+// to have it.  Used to extract dispatch keys from unboxed calls.
+struct MultiDispatchKeySet : at::IterArgs<MultiDispatchKeySet> {
+  DispatchKeySet ts;
+  void operator()(const at::Tensor& x) {
+    ts = ts | x.key_set();
+  }
+  void operator()(const std::optional<at::Tensor>& x) {
+    if (x.has_value()) {
+      ts = ts | x->key_set();
+    }
+  }
+  void operator()(at::ArrayRef<at::Tensor> xs) {
+    for (const auto& x : xs) {
       ts = ts | x.key_set();
     }
-    void operator()(const std::optional<at::Tensor>& x) {
-      if (x.has_value()) {
-        ts = ts | x->key_set();
-      }
-    }
-    void operator()(at::ArrayRef<at::Tensor> xs) {
-      for (const auto& x : xs) {
-        ts = ts | x.key_set();
-      }
-    }
-    // Tensor?[] translates to this case.
-    void operator()(const c10::List<std::optional<at::Tensor>>& xs) {
-      for (std::optional<at::Tensor> x : xs) {
-        if (x.has_value()) {
-          ts = ts | x.value().key_set();
-        }
-      }
-    }
-    // Structured Tensor[] translates to this case
-    void operator()(const at::ITensorListRef& xs) {
-      for (const auto& x : xs) {
-        ts = ts | x.key_set();
-      }
-    }
-    [[noreturn]] void operator()(at::ArrayRef<std::optional<at::Tensor>>) {
-      // Just checking that the handling of Tensor?[] didn't change.
-      TORCH_INTERNAL_ASSERT(false);
-    }
-    void operator()(const at::Generator& gen) {
-      if (gen.defined()) {
-        ts = ts | gen.key_set();
-      }
-    }
-    void operator()(const std::optional<at::Generator>& gen) {
-      if (gen.has_value() && gen->defined()) {
-        ts = ts | gen->key_set();
-      }
-    }
-    template <typename T>
-    void operator()(const T&) {
-      // do nothing
-    }
-  };
-
-  // NB: take by const reference (Don't do universal forwarding here! You
-  // don't want to move into this function!)
-  template <typename... Args>
-  DispatchKeySet multi_dispatch_key_set(const Args&... args) {
-    return MultiDispatchKeySet().apply(args...).ts;
   }
+  // Tensor?[] translates to this case.
+  void operator()(const c10::List<std::optional<at::Tensor>>& xs) {
+    for (std::optional<at::Tensor> x : xs) {
+      if (x.has_value()) {
+        ts = ts | x.value().key_set();
+      }
+    }
+  }
+  // Structured Tensor[] translates to this case
+  void operator()(const at::ITensorListRef& xs) {
+    for (const auto& x : xs) {
+      ts = ts | x.key_set();
+    }
+  }
+  [[noreturn]] void operator()(at::ArrayRef<std::optional<at::Tensor>>) {
+    // Just checking that the handling of Tensor?[] didn't change.
+    TORCH_INTERNAL_ASSERT(false);
+  }
+  void operator()(const at::Generator& gen) {
+    if (gen.defined()) {
+      ts = ts | gen.key_set();
+    }
+  }
+  void operator()(const std::optional<at::Generator>& gen) {
+    if (gen.has_value() && gen->defined()) {
+      ts = ts | gen->key_set();
+    }
+  }
+  template <typename T>
+  void operator()(const T&) {
+    // do nothing
+  }
+};
+
+// NB: take by const reference (Don't do universal forwarding here! You
+// don't want to move into this function!)
+template <typename... Args>
+DispatchKeySet multi_dispatch_key_set(const Args&... args) {
+  return MultiDispatchKeySet().apply(args...).ts;
 }
+} // namespace detail
 
 /**
  * An instance of DispatchKeyExtractor knows how to get a dispatch key given
@@ -121,11 +121,11 @@ namespace detail {
  *    varies from operator, as some operators may have overridden the
  *    fallthrough with custom behavior.
  *
- *   Note - this should maintain identical impl to the py dispatcher key extraction logic
- *   at pytorch/torch/dispatcher.py
+ *   Note - this should maintain identical impl to the py dispatcher key
+ * extraction logic at pytorch/torch/dispatcher.py
  */
 struct TORCH_API DispatchKeyExtractor final {
-public:
+ public:
   static DispatchKeyExtractor make(const FunctionSchema& schema) {
     return DispatchKeyExtractor(makeBitsetForDispatchArgs(schema));
   }
@@ -144,7 +144,8 @@ public:
 
   DispatchKeySet getDispatchKeySetBoxed(const torch::jit::Stack* stack) const {
     DispatchKeySet ks;
-    dispatch_arg_indices_reverse_.for_each_set_bit([&] (size_t reverse_arg_index) {
+    dispatch_arg_indices_reverse_.for_each_set_bit([&](size_t
+                                                           reverse_arg_index) {
       const auto& ivalue = torch::jit::peek(*stack, 0, reverse_arg_index + 1);
       if (C10_LIKELY(ivalue.isTensor())) {
         // NB: Take care not to introduce a refcount bump (there's
@@ -166,22 +167,28 @@ public:
     });
     // Keys that are fallthrough should be skipped
     if (requiresBitsetPerBackend_) {
-      c10::impl::LocalDispatchKeySet tls = c10::impl::tls_local_dispatch_key_set();
-      auto backend_idx = ((ks | tls.included_) - tls.excluded_).getBackendIndex();
-      return impl::computeDispatchKeySet(ks, nonFallthroughKeysPerBackend_[backend_idx]);
+      c10::impl::LocalDispatchKeySet tls =
+          c10::impl::tls_local_dispatch_key_set();
+      auto backend_idx =
+          ((ks | tls.included_) - tls.excluded_).getBackendIndex();
+      return impl::computeDispatchKeySet(
+          ks, nonFallthroughKeysPerBackend_[backend_idx]);
     } else {
       return impl::computeDispatchKeySet(ks, nonFallthroughKeys_);
     }
   }
 
-  template<class... Args>
+  template <class... Args>
   DispatchKeySet getDispatchKeySetUnboxed(const Args&... args) const {
     auto ks = detail::multi_dispatch_key_set(args...);
     // Keys that are fallthrough should be skipped
     if (requiresBitsetPerBackend_) {
-      c10::impl::LocalDispatchKeySet tls = c10::impl::tls_local_dispatch_key_set();
-      auto backend_idx = ((ks | tls.included_) - tls.excluded_).getBackendIndex();
-      return impl::computeDispatchKeySet(ks, nonFallthroughKeysPerBackend_[backend_idx]);
+      c10::impl::LocalDispatchKeySet tls =
+          c10::impl::tls_local_dispatch_key_set();
+      auto backend_idx =
+          ((ks | tls.included_) - tls.excluded_).getBackendIndex();
+      return impl::computeDispatchKeySet(
+          ks, nonFallthroughKeysPerBackend_[backend_idx]);
     } else {
       return impl::computeDispatchKeySet(ks, nonFallthroughKeys_);
     }
@@ -192,11 +199,15 @@ public:
   std::string dumpState() const;
   void checkInvariants(const FunctionSchema& schema) const;
 
-private:
-  static c10::utils::bitset makeBitsetForDispatchArgs(const FunctionSchema& schema) {
-    TORCH_CHECK(schema.arguments().size() <= c10::utils::bitset::NUM_BITS(),
-        "The function schema has ", schema.arguments().size(),
-        " arguments but this PyTorch build only supports ", c10::utils::bitset::NUM_BITS());
+ private:
+  static c10::utils::bitset makeBitsetForDispatchArgs(
+      const FunctionSchema& schema) {
+    TORCH_CHECK(
+        schema.arguments().size() <= c10::utils::bitset::NUM_BITS(),
+        "The function schema has ",
+        schema.arguments().size(),
+        " arguments but this PyTorch build only supports ",
+        c10::utils::bitset::NUM_BITS());
     c10::utils::bitset dispatch_arg_indices_reverse;
     for (const auto index : c10::irange(schema.arguments().size())) {
       if (schema.arguments()[index].type()->isSubtypeOf(*TensorType::get()) ||
@@ -213,9 +224,9 @@ private:
   }
 
   explicit DispatchKeyExtractor(c10::utils::bitset dispatch_arg_indices_reverse)
-  : dispatch_arg_indices_reverse_(dispatch_arg_indices_reverse)
-  , nonFallthroughKeys_(DispatchKeySet::FULL)
-  , requiresBitsetPerBackend_(false) {
+      : dispatch_arg_indices_reverse_(dispatch_arg_indices_reverse),
+        nonFallthroughKeys_(DispatchKeySet::FULL),
+        requiresBitsetPerBackend_(false) {
     for (const auto i : c10::irange(nonFallthroughKeysPerBackend_.size())) {
       nonFallthroughKeysPerBackend_[i] = DispatchKeySet::FULL;
     }
@@ -227,18 +238,21 @@ private:
   // dispatch_arg_indices_reverse_[i] == true, then the i-th argument from
   // the top of the stack (i.e. the i-th last argument of the function)
   // is relevant for dispatch.
-  // dispatch_arg_indices_reverse_ is allowed to have zero bits set; that just means you must do the
-  // fallthrough
+  // dispatch_arg_indices_reverse_ is allowed to have zero bits set; that just
+  // means you must do the fallthrough
   c10::utils::bitset dispatch_arg_indices_reverse_;
 
-  // Set of functionality keys for which the operator does NOT have fallthrough kernel.
+  // Set of functionality keys for which the operator does NOT have fallthrough
+  // kernel.
   DispatchKeySet nonFallthroughKeys_;
-  // Set of functionality keys for which the operator does NOT have fallthrough kernel, defined PER BACKEND.
-  // This is only needed if we know that the operator has a different set of fallthroughs defined for some backends.
+  // Set of functionality keys for which the operator does NOT have fallthrough
+  // kernel, defined PER BACKEND. This is only needed if we know that the
+  // operator has a different set of fallthroughs defined for some backends.
   std::array<DispatchKeySet, num_backends> nonFallthroughKeysPerBackend_;
-  // Flag to tell us if we can use the single set of nonFallthroughKeys_ (fast path),
-  // or if we need to fall back to the slower path and check nonFallthroughKeysPerBackend_
+  // Flag to tell us if we can use the single set of nonFallthroughKeys_ (fast
+  // path), or if we need to fall back to the slower path and check
+  // nonFallthroughKeysPerBackend_
   bool requiresBitsetPerBackend_;
 };
 
-}
+} // namespace c10

--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -3,20 +3,20 @@
 #include <ATen/SequenceNumber.h>
 #include <ATen/core/boxing/KernelFunction.h>
 #include <ATen/core/boxing/impl/boxing.h>
-#include <ATen/core/dispatch/OperatorEntry.h>
 #include <ATen/core/dispatch/CppSignature.h>
+#include <ATen/core/dispatch/OperatorEntry.h>
 #include <ATen/core/dispatch/RegistrationHandleRAII.h>
 #include <ATen/record_function.h>
+#include <c10/core/SafePyObject.h>
 #include <c10/util/Exception.h>
 #include <c10/util/LeftRight.h>
+#include <condition_variable>
 #include <list>
 #include <mutex>
-#include <condition_variable>
 #include <type_traits>
-#include <c10/core/SafePyObject.h>
 
-#include <ATen/core/grad_mode.h>
 #include <ATen/core/enum_tag.h>
+#include <ATen/core/grad_mode.h>
 
 #ifndef NDEBUG
 #include <iostream>
@@ -30,12 +30,17 @@ TORCH_API void dispatch_trace_nesting_decr();
 TORCH_API int64_t dispatch_trace_nesting_value();
 
 struct DispatchTraceNestingGuard {
-  DispatchTraceNestingGuard() { dispatch_trace_nesting_incr(); }
-  ~DispatchTraceNestingGuard() { dispatch_trace_nesting_decr(); }
+  DispatchTraceNestingGuard() {
+    dispatch_trace_nesting_incr();
+  }
+  ~DispatchTraceNestingGuard() {
+    dispatch_trace_nesting_decr();
+  }
 };
 
 class TORCH_API OperatorHandle;
-template<class FuncType> class TypedOperatorHandle;
+template <class FuncType>
+class TypedOperatorHandle;
 
 /**
  * Implement this interface and register your instance with the dispatcher
@@ -46,7 +51,7 @@ template<class FuncType> class TypedOperatorHandle;
  * on 'impl' or 'fallback' calls.
  */
 class TORCH_API OpRegistrationListener {
-public:
+ public:
   virtual ~OpRegistrationListener();
 
   virtual void onOperatorRegistered(const OperatorHandle& op) = 0;
@@ -64,13 +69,12 @@ class SchemaRegistrationHandleRAII;
  * ops look in op_registration
  */
 class TORCH_API Dispatcher final {
-private:
+ private:
   // For direct access to backend fallback information
   friend class impl::OperatorEntry;
 
   struct OperatorDef final {
-    explicit OperatorDef(OperatorName&& op_name)
-    : op(std::move(op_name)) {}
+    explicit OperatorDef(OperatorName&& op_name) : op(std::move(op_name)) {}
 
     impl::OperatorEntry op;
 
@@ -88,7 +92,8 @@ private:
     size_t def_and_impl_count = 0;
   };
   friend class OperatorHandle;
-  template<class> friend class TypedOperatorHandle;
+  template <class>
+  friend class TypedOperatorHandle;
 
   struct Guard final {
     Guard() : alive(true), mutex() {}
@@ -96,12 +101,12 @@ private:
     std::mutex mutex;
   };
 
-public:
+ public:
   ~Dispatcher();
 
-  // Implementation note: this class abstracts over the fact that we have per-operator
-  // dispatch tables.  This could be easily adjusted to have a single global hash
-  // table.
+  // Implementation note: this class abstracts over the fact that we have
+  // per-operator dispatch tables.  This could be easily adjusted to have a
+  // single global hash table.
   static Dispatcher& realSingleton();
 
   C10_ALWAYS_INLINE static Dispatcher& singleton() {
@@ -166,37 +171,58 @@ public:
   //
   // ------------------------------------------------------------------------
 
-  template<class Return, class... Args>
-  Return call(const TypedOperatorHandle<Return (Args...)>& op, Args... args) const;
+  template <class Return, class... Args>
+  Return call(const TypedOperatorHandle<Return(Args...)>& op, Args... args)
+      const;
 
+  template <class Return, class... Args>
+  static Return callWithDispatchKeySlowPath(
+      const TypedOperatorHandle<Return(Args...)>& op,
+      at::StepCallbacks& stepCallbacks,
+      DispatchKeySet dispatchKeySet,
+      const KernelFunction& kernel,
+      Args... args);
 
-  template<class Return, class... Args>
-  static Return callWithDispatchKeySlowPath(const TypedOperatorHandle<Return (Args...)>& op, at::StepCallbacks& stepCallbacks, DispatchKeySet dispatchKeySet, const KernelFunction& kernel, Args... args);
-
-  // Like call, but intended for use in a redispatch in kernels that have explicitly performed the DispatchKey update calculatulation.
-  // This will take the DispatchKeySet completely as is and dispatch to the kernel of the corresponding highest priority key in the set.
-  // Note that this version of redispatch treats the inputted DispatchKeySet *as is*, and does NOT mask out the highest priority key.
-  // See Note [Plumbing Keys Through The Dispatcher]
-  template<class Return, class... Args>
-  Return redispatch(const TypedOperatorHandle<Return (Args...)>& op, DispatchKeySet currentDispatchKeySet, Args... args) const;
+  // Like call, but intended for use in a redispatch in kernels that have
+  // explicitly performed the DispatchKey update calculatulation. This will take
+  // the DispatchKeySet completely as is and dispatch to the kernel of the
+  // corresponding highest priority key in the set. Note that this version of
+  // redispatch treats the inputted DispatchKeySet *as is*, and does NOT mask
+  // out the highest priority key. See Note [Plumbing Keys Through The
+  // Dispatcher]
+  template <class Return, class... Args>
+  Return redispatch(
+      const TypedOperatorHandle<Return(Args...)>& op,
+      DispatchKeySet currentDispatchKeySet,
+      Args... args) const;
 
   // Invoke an operator via the boxed calling convention using an IValue stack
   void callBoxed(const OperatorHandle& op, Stack* stack) const;
-  void callBoxedForDispatchKey(const OperatorHandle& op, DispatchKey dk, Stack* stack) const;
+  void callBoxedForDispatchKey(
+      const OperatorHandle& op,
+      DispatchKey dk,
+      Stack* stack) const;
 
-  // TODO: This will only be useful if we write a backend fallback that plumbs dispatch keys (currently there are none)
-  // See Note [Plumbing Keys Through The Dispatcher]
-  void redispatchBoxed(const OperatorHandle& op, DispatchKeySet dispatchKeySet, Stack* stack) const;
+  // TODO: This will only be useful if we write a backend fallback that plumbs
+  // dispatch keys (currently there are none) See Note [Plumbing Keys Through
+  // The Dispatcher]
+  void redispatchBoxed(
+      const OperatorHandle& op,
+      DispatchKeySet dispatchKeySet,
+      Stack* stack) const;
 
   bool hasBackendFallbackForDispatchKey(DispatchKey dk) {
     auto dispatch_ix = getDispatchTableIndexForDispatchKey(dk);
-    if (dispatch_ix < 0) return false;
+    if (dispatch_ix < 0)
+      return false;
     return backendFallbackKernels_[dispatch_ix].kernel.isValid();
   }
 
   // Used by torchdeploy/multipy for multiple interpreters racing.
   void waitForDef(const FunctionSchema& schema);
-  void waitForImpl(const OperatorName& op_name, std::optional<DispatchKey> dispatch_key);
+  void waitForImpl(
+      const OperatorName& op_name,
+      std::optional<DispatchKey> dispatch_key);
 
   // ------------------------------------------------------------------------
   //
@@ -210,7 +236,10 @@ public:
    * If a schema with the same operator name and overload name already exists,
    * this function will check that both schemas are exactly identical.
    */
-  RegistrationHandleRAII registerDef(FunctionSchema schema, std::string debug, std::vector<at::Tag> tags = {});
+  RegistrationHandleRAII registerDef(
+      FunctionSchema schema,
+      std::string debug,
+      std::vector<at::Tag> tags = {});
 
   /**
    * Register a kernel to the dispatch table for an operator.
@@ -221,20 +250,30 @@ public:
    */
   // NB: steals the inferred function schema, as we may need to hold on to
   // it for a bit until the real schema turns up
-  RegistrationHandleRAII registerImpl(OperatorName op_name, std::optional<DispatchKey> dispatch_key, KernelFunction kernel, std::optional<impl::CppSignature> cpp_signature, std::unique_ptr<FunctionSchema> inferred_function_schema, std::string debug);
+  RegistrationHandleRAII registerImpl(
+      OperatorName op_name,
+      std::optional<DispatchKey> dispatch_key,
+      KernelFunction kernel,
+      std::optional<impl::CppSignature> cpp_signature,
+      std::unique_ptr<FunctionSchema> inferred_function_schema,
+      std::string debug);
 
   /**
-   * Given an operator, tells the Dispatcher that we have implemented a fake impl
-   * for this op in the given Python module. Call this a "pystub".
+   * Given an operator, tells the Dispatcher that we have implemented a fake
+   * impl for this op in the given Python module. Call this a "pystub".
    */
-  RegistrationHandleRAII registerPythonModule(const OperatorName& op_name, const char* pymodule, const char* context);
+  RegistrationHandleRAII registerPythonModule(
+      const OperatorName& op_name,
+      const char* pymodule,
+      const char* context);
 
   /**
    * Given an operator, throws if we have a pystub.
    */
   void throwIfHasPythonModule(OperatorName op_name);
 
-  std::optional<std::pair<const char*, const char*>> getPyStub(OperatorName op_name);
+  std::optional<std::pair<const char*, const char*>> getPyStub(
+      OperatorName op_name);
 
   /**
    * Register a new operator by name.
@@ -247,7 +286,10 @@ public:
    * key of the given operator arguments, it will check if there is such a
    * fallback kernel for the given dispatch key and, if yes, call that one.
    */
-  RegistrationHandleRAII registerFallback(DispatchKey dispatch_key, KernelFunction kernel, std::string debug);
+  RegistrationHandleRAII registerFallback(
+      DispatchKey dispatch_key,
+      KernelFunction kernel,
+      std::string debug);
 
   /**
    * Use to register whenever we had a TORCH_LIBRARY declaration in the frontend
@@ -263,12 +305,13 @@ public:
   // ------------------------------------------------------------------------
 
   /**
-   * Add a listener that gets called whenever a new op is registered or an existing
-   * op is deregistered. Immediately after registering, this listener gets called
-   * for all previously registered ops, so it can be used to keep track of ops
-   * registered with this dispatcher.
+   * Add a listener that gets called whenever a new op is registered or an
+   * existing op is deregistered. Immediately after registering, this listener
+   * gets called for all previously registered ops, so it can be used to keep
+   * track of ops registered with this dispatcher.
    */
-  RegistrationHandleRAII addRegistrationListener(std::unique_ptr<OpRegistrationListener> listener);
+  RegistrationHandleRAII addRegistrationListener(
+      std::unique_ptr<OpRegistrationListener> listener);
 
   void checkInvariants() const;
 
@@ -281,64 +324,85 @@ public:
 
   /**
    * For testing purposes.
-   * Returns a list of all operators that were created through calls to registerImpl(),
-   * without any corresponding calls to registerDef(). After static initialization
-   * is done this is almost certainly a bug, as the created OperatorHandle won't have
-   * any schema associated with it and users calling the op through the dispatcher
-   * won't be able to access it
+   * Returns a list of all operators that were created through calls to
+   * registerImpl(), without any corresponding calls to registerDef(). After
+   * static initialization is done this is almost certainly a bug, as the
+   * created OperatorHandle won't have any schema associated with it and users
+   * calling the op through the dispatcher won't be able to access it
    *
-   * Note that we cannot enforce this invariant "as we go" during static initialization,
-   * due to undefined static initialization order- we have no guarantees over the order
-   * in which .def() and .impl() calls are registered in the dispatcher at static
-   * initialization time. So this function should only be called after static initialization.
+   * Note that we cannot enforce this invariant "as we go" during static
+   * initialization, due to undefined static initialization order- we have no
+   * guarantees over the order in which .def() and .impl() calls are registered
+   * in the dispatcher at static initialization time. So this function should
+   * only be called after static initialization.
    */
   std::vector<OperatorHandle> findDanglingImpls() const;
 
   /**
    * Useful for inspecting global Dispatcher registration state.
-   * Returns the names of all operators with a kernel registered for the specified DispatchKey.
-   * If no DispatchKey is specified, it returns all registered operators.
+   * Returns the names of all operators with a kernel registered for the
+   * specified DispatchKey. If no DispatchKey is specified, it returns all
+   * registered operators.
    */
-  std::vector<OperatorName> getRegistrationsForDispatchKey(std::optional<DispatchKey> k) const;
+  std::vector<OperatorName> getRegistrationsForDispatchKey(
+      std::optional<DispatchKey> k) const;
 
-private:
+ private:
   Dispatcher();
 
-  static int64_t sequenceNumberForRunningRecordFunction(DispatchKey dispatchKey, DispatchKeySet dispatchKeySet);
-  static void runRecordFunction(at::RecordFunction& guard, at::RecordFunction::schema_ref_t schema_ref, DispatchKey dispatchKey, DispatchKeySet dispatchKeySet);
-  static void runRecordFunction(at::RecordFunction& guard, at::RecordFunction::schema_ref_t schema_ref, DispatchKey dispatchKey, DispatchKeySet dispatchKeySet, c10::ArrayRef<const c10::IValue> args);
+  static int64_t sequenceNumberForRunningRecordFunction(
+      DispatchKey dispatchKey,
+      DispatchKeySet dispatchKeySet);
+  static void runRecordFunction(
+      at::RecordFunction& guard,
+      at::RecordFunction::schema_ref_t schema_ref,
+      DispatchKey dispatchKey,
+      DispatchKeySet dispatchKeySet);
+  static void runRecordFunction(
+      at::RecordFunction& guard,
+      at::RecordFunction::schema_ref_t schema_ref,
+      DispatchKey dispatchKey,
+      DispatchKeySet dispatchKeySet,
+      c10::ArrayRef<const c10::IValue> args);
 
-  #ifdef FBCODE_CAFFE2
+#ifdef FBCODE_CAFFE2
   static bool profilingOperatorEvents();
   static void fireOpStartUSDT(at::RecordFunction::schema_ref_t schema_ref);
   static void fireOpEndUSDT(at::RecordFunction::schema_ref_t schema_ref);
-  #endif // FBCODE_CAFFE2
+#endif // FBCODE_CAFFE2
 
   OperatorHandle findOrRegisterSchema_(FunctionSchema&& schema);
   OperatorHandle findOrRegisterName_(const OperatorName& op_name);
 
   void deregisterDef_(const OperatorHandle& op, const OperatorName& op_name);
   void deregisterImpl_(
-    const OperatorHandle& op,
-    const OperatorName& op_name,
-    std::optional<DispatchKey> dispatch_key,
-    impl::OperatorEntry::AnnotatedKernelContainerIterator kernel_handle);
+      const OperatorHandle& op,
+      const OperatorName& op_name,
+      std::optional<DispatchKey> dispatch_key,
+      impl::OperatorEntry::AnnotatedKernelContainerIterator kernel_handle);
   void deregisterName_(const OperatorHandle& op, const OperatorName& op_name);
   void deregisterFallback_(DispatchKey dispatchKey);
   void deregisterLibrary_(const std::string& ns);
   void cleanup(const OperatorHandle& op, const OperatorName& op_name);
-  void checkSchemaCompatibility(const OperatorHandle& op, const FunctionSchema& schema, const std::string& debug);
+  void checkSchemaCompatibility(
+      const OperatorHandle& op,
+      const FunctionSchema& schema,
+      const std::string& debug);
 
   std::list<OperatorDef> operators_;
 #if !defined(C10_MOBILE)
-  LeftRight<ska::flat_hash_map<OperatorName, OperatorHandle>> operatorLookupTable_;
+  LeftRight<ska::flat_hash_map<OperatorName, OperatorHandle>>
+      operatorLookupTable_;
 #else
-  RWSafeLeftRightWrapper<ska::flat_hash_map<OperatorName, OperatorHandle>> operatorLookupTable_;
+  RWSafeLeftRightWrapper<ska::flat_hash_map<OperatorName, OperatorHandle>>
+      operatorLookupTable_;
 #endif
-  // Map from namespace to debug string (saying, e.g., where the library was defined)
+  // Map from namespace to debug string (saying, e.g., where the library was
+  // defined)
   ska::flat_hash_map<std::string, std::string> libraries_;
 
-  std::array<impl::AnnotatedKernel, num_runtime_entries> backendFallbackKernels_;
+  std::array<impl::AnnotatedKernel, num_runtime_entries>
+      backendFallbackKernels_;
 
   std::unique_ptr<detail::RegistrationListenerList> listeners_;
 
@@ -369,9 +433,10 @@ private:
  * to lookup a kernel for a certain set of arguments.
  */
 class TORCH_API OperatorHandle {
-  template <typename T> friend struct std::hash;
+  template <typename T>
+  friend struct std::hash;
 
-public:
+ public:
   OperatorHandle(OperatorHandle&&) noexcept = default;
   OperatorHandle& operator=(OperatorHandle&&) noexcept = default;
   OperatorHandle(const OperatorHandle&) = default;
@@ -432,7 +497,7 @@ public:
   }
 
   bool hasTag(const at::Tag& tag) const {
-    for(const auto& tag_: getTags()) {
+    for (const auto& tag_ : getTags()) {
       if (tag == tag_) {
         return true;
       }
@@ -440,7 +505,7 @@ public:
     return false;
   }
 
-  template<class FuncType>
+  template <class FuncType>
   TypedOperatorHandle<FuncType> typed() const {
     // NB: This assert is not 100% sound: you can retrieve a typed() operator
     // handle prior to ANY C++ signature being registered on the operator
@@ -451,7 +516,8 @@ public:
 #if !defined C10_MOBILE
     operatorDef_->op.assertSignatureIsCorrect<FuncType>();
     if (fn_has_symint<FuncType>::value) {
-      operatorDef_->op.assertSignatureIsCorrect<typename fn_remove_symint<FuncType>::type>();
+      operatorDef_->op.assertSignatureIsCorrect<
+          typename fn_remove_symint<FuncType>::type>();
     }
 #endif
     return TypedOperatorHandle<FuncType>(operatorIterator_);
@@ -474,7 +540,9 @@ public:
   }
 
   template <typename F>
-  PyObject* getPythonOp(c10::impl::PyInterpreter* self_interpreter, F slow_accessor) const {
+  PyObject* getPythonOp(
+      c10::impl::PyInterpreter* self_interpreter,
+      F slow_accessor) const {
     return operatorDef_->op.getPythonOp(self_interpreter, slow_accessor);
   }
 
@@ -486,11 +554,13 @@ public:
     return operatorDef_ != other.operatorDef_;
   }
 
-private:
-  explicit OperatorHandle(std::list<Dispatcher::OperatorDef>::iterator operatorIterator)
-  : operatorDef_(&*operatorIterator), operatorIterator_(operatorIterator)  {}
+ private:
+  explicit OperatorHandle(
+      std::list<Dispatcher::OperatorDef>::iterator operatorIterator)
+      : operatorDef_(&*operatorIterator), operatorIterator_(operatorIterator) {}
   friend class Dispatcher;
-  template<class> friend class TypedOperatorHandle;
+  template <class>
+  friend class TypedOperatorHandle;
 
   // Storing a direct pointer to the OperatorDef even though we
   // already have the iterator saves an instruction in the critical
@@ -514,36 +584,45 @@ private:
  * on the operator arguments and allows calling the operator in an
  * unboxed way.
  */
-template<class FuncType>
+template <class FuncType>
 class TypedOperatorHandle final {
-  static_assert(guts::false_t<FuncType>(), "FuncType in OperatorHandle::typed<FuncType> was not a valid function type");
+  static_assert(
+      guts::false_t<FuncType>(),
+      "FuncType in OperatorHandle::typed<FuncType> was not a valid function type");
 };
-template<class Return, class... Args>
-class TypedOperatorHandle<Return (Args...)> final : public OperatorHandle {
-public:
+template <class Return, class... Args>
+class TypedOperatorHandle<Return(Args...)> final : public OperatorHandle {
+ public:
   TypedOperatorHandle(TypedOperatorHandle&&) noexcept = default;
   TypedOperatorHandle& operator=(TypedOperatorHandle&&) noexcept = default;
   TypedOperatorHandle(const TypedOperatorHandle&) = default;
   TypedOperatorHandle& operator=(const TypedOperatorHandle&) = default;
 
-  // See [Note: Argument forwarding in the dispatcher] for why Args doesn't use &&
+  // See [Note: Argument forwarding in the dispatcher] for why Args doesn't use
+  // &&
   C10_ALWAYS_INLINE Return call(Args... args) const {
-    return c10::Dispatcher::singleton().call<Return, Args...>(*this, std::forward<Args>(args)...);
+    return c10::Dispatcher::singleton().call<Return, Args...>(
+        *this, std::forward<Args>(args)...);
   }
 
-  // See [Note: Argument forwarding in the dispatcher] for why Args doesn't use &&
-  C10_ALWAYS_INLINE Return redispatch(DispatchKeySet currentDispatchKeySet, Args... args) const {
-    return c10::Dispatcher::singleton().redispatch<Return, Args...>(*this, currentDispatchKeySet, std::forward<Args>(args)...);
+  // See [Note: Argument forwarding in the dispatcher] for why Args doesn't use
+  // &&
+  C10_ALWAYS_INLINE Return
+  redispatch(DispatchKeySet currentDispatchKeySet, Args... args) const {
+    return c10::Dispatcher::singleton().redispatch<Return, Args...>(
+        *this, currentDispatchKeySet, std::forward<Args>(args)...);
   }
 
-private:
-  explicit TypedOperatorHandle(std::list<Dispatcher::OperatorDef>::iterator operatorIterator)
-  : OperatorHandle(operatorIterator) {}
+ private:
+  explicit TypedOperatorHandle(
+      std::list<Dispatcher::OperatorDef>::iterator operatorIterator)
+      : OperatorHandle(operatorIterator) {}
   friend class OperatorHandle;
 };
 
 namespace detail {
-template <class... Args> inline void unused_arg_(const Args&...) {}
+template <class... Args>
+inline void unused_arg_(const Args&...) {}
 
 // CaptureKernelCall is intended to capture return values from Dispatcher
 // unboxed kernel calls. A record function may request to get outputs from the
@@ -607,13 +686,21 @@ struct CaptureKernelCall<void> {
   void release() && {}
 };
 
-TORCH_API void _print_dispatch_trace(const std::string& label, const std::string& op_name, const DispatchKeySet& dispatchKeySet);
+TORCH_API void _print_dispatch_trace(
+    const std::string& label,
+    const std::string& op_name,
+    const DispatchKeySet& dispatchKeySet);
 
 } // namespace detail
 
 // See [Note: Argument forwarding in the dispatcher] for why Args doesn't use &&
-template<class Return, class... Args>
-inline Return Dispatcher::callWithDispatchKeySlowPath(const TypedOperatorHandle<Return(Args...)>& op, at::StepCallbacks& stepCallbacks, DispatchKeySet dispatchKeySet, const KernelFunction& kernel, Args... args) {
+template <class Return, class... Args>
+inline Return Dispatcher::callWithDispatchKeySlowPath(
+    const TypedOperatorHandle<Return(Args...)>& op,
+    at::StepCallbacks& stepCallbacks,
+    DispatchKeySet dispatchKeySet,
+    const KernelFunction& kernel,
+    Args... args) {
   // If callbacks need inputs, we box the arguments and pass them to the guard.
   // Note: For perf reasons we wouldn't want to prematurely box the arguments.
   at::RecordFunction guard(std::move(stepCallbacks));
@@ -636,9 +723,15 @@ inline Return Dispatcher::callWithDispatchKeySlowPath(const TypedOperatorHandle<
       TORCH_INTERNAL_ASSERT_DEBUG_ONLY(lastArgIdx == num_boxed_args);
       // I don't *think* we need std::launder here, because IValue has
       // no subclasses and no const or reference fields.
-      runRecordFunction(guard, schema_ref, dispatchKey, dispatchKeySet, c10::ArrayRef<const c10::IValue>(reinterpret_cast<IValue *>(boxedArgs), num_boxed_args));
+      runRecordFunction(
+          guard,
+          schema_ref,
+          dispatchKey,
+          dispatchKeySet,
+          c10::ArrayRef<const c10::IValue>(
+              reinterpret_cast<IValue*>(boxedArgs), num_boxed_args));
       for (size_t ii = 0; ii < num_boxed_args; ++ii) {
-        reinterpret_cast<IValue *>(&boxedArgs[ii])->~IValue();
+        reinterpret_cast<IValue*>(&boxedArgs[ii])->~IValue();
       }
     } else {
       runRecordFunction(guard, schema_ref, dispatchKey, dispatchKeySet);
@@ -658,82 +751,119 @@ inline Return Dispatcher::callWithDispatchKeySlowPath(const TypedOperatorHandle<
   }
 
   // keeping the guard alive while executing the kernel
-  return kernel.template call<Return, Args...>(op, dispatchKeySet, std::forward<Args>(args)...);
+  return kernel.template call<Return, Args...>(
+      op, dispatchKeySet, std::forward<Args>(args)...);
 }
 
 // See [Note: Argument forwarding in the dispatcher] for why Args doesn't use &&
-template<class Return, class... Args>
-C10_ALWAYS_INLINE_UNLESS_MOBILE Return Dispatcher::call(const TypedOperatorHandle<Return(Args...)>& op, Args... args) const {
-  detail::unused_arg_(args...);  // workaround for a false-positive warning about unused parameters in gcc 5
-  auto dispatchKeySet = op.operatorDef_->op.dispatchKeyExtractor()
-    .template getDispatchKeySetUnboxed<Args...>(args...);
+template <class Return, class... Args>
+C10_ALWAYS_INLINE_UNLESS_MOBILE Return Dispatcher::call(
+    const TypedOperatorHandle<Return(Args...)>& op,
+    Args... args) const {
+  detail::unused_arg_(args...); // workaround for a false-positive warning about
+                                // unused parameters in gcc 5
+  auto dispatchKeySet =
+      op.operatorDef_->op.dispatchKeyExtractor()
+          .template getDispatchKeySetUnboxed<Args...>(args...);
 #ifndef NDEBUG
   DispatchTraceNestingGuard debug_guard;
   if (show_dispatch_trace()) {
-    detail::_print_dispatch_trace("[call]", toString(op.operator_name()), dispatchKeySet);
+    detail::_print_dispatch_trace(
+        "[call]", toString(op.operator_name()), dispatchKeySet);
   }
 #endif
   const KernelFunction& kernel = op.operatorDef_->op.lookup(dispatchKeySet);
 #ifndef PYTORCH_DISABLE_PER_OP_PROFILING
-  auto step_callbacks = at::getStepCallbacksUnlessEmpty(at::RecordScope::FUNCTION);
-  if (C10_UNLIKELY(step_callbacks.has_value() && op.operatorDef_->op.isObserved())) {
-    return callWithDispatchKeySlowPath<Return, Args...>(op, *step_callbacks, dispatchKeySet, kernel, std::forward<Args>(args)...);
+  auto step_callbacks =
+      at::getStepCallbacksUnlessEmpty(at::RecordScope::FUNCTION);
+  if (C10_UNLIKELY(
+          step_callbacks.has_value() && op.operatorDef_->op.isObserved())) {
+    return callWithDispatchKeySlowPath<Return, Args...>(
+        op,
+        *step_callbacks,
+        dispatchKeySet,
+        kernel,
+        std::forward<Args>(args)...);
   }
-#endif  // PYTORCH_DISABLE_PER_OP_PROFILING
+#endif // PYTORCH_DISABLE_PER_OP_PROFILING
 
 #ifdef FBCODE_CAFFE2
-  if(profilingOperatorEvents()) {
+  if (profilingOperatorEvents()) {
     struct FireOpRAII {
-       FireOpRAII(at::RecordFunction::schema_ref_t schema_ref) : schema_ref_(schema_ref) {
-           fireOpStartUSDT(schema_ref);
-        }
-       ~FireOpRAII() { fireOpEndUSDT(schema_ref_); }
-       at::RecordFunction::schema_ref_t schema_ref_;
+      FireOpRAII(at::RecordFunction::schema_ref_t schema_ref)
+          : schema_ref_(schema_ref) {
+        fireOpStartUSDT(schema_ref);
+      }
+      ~FireOpRAII() {
+        fireOpEndUSDT(schema_ref_);
+      }
+      at::RecordFunction::schema_ref_t schema_ref_;
     } event(op.schema());
-    return kernel.template call<Return, Args...>(op, dispatchKeySet, std::forward<Args>(args)...);
+    return kernel.template call<Return, Args...>(
+        op, dispatchKeySet, std::forward<Args>(args)...);
   } else {
-    return kernel.template call<Return, Args...>(op, dispatchKeySet, std::forward<Args>(args)...);
+    return kernel.template call<Return, Args...>(
+        op, dispatchKeySet, std::forward<Args>(args)...);
   }
 #else
-    return kernel.template call<Return, Args...>(op, dispatchKeySet, std::forward<Args>(args)...);
+  return kernel.template call<Return, Args...>(
+      op, dispatchKeySet, std::forward<Args>(args)...);
 #endif // FBCODE_CAFFE2
 }
 
 // See [Note: Argument forwarding in the dispatcher] for why Args doesn't use &&
-template<class Return, class... Args>
-inline Return Dispatcher::redispatch(const TypedOperatorHandle<Return (Args...)>& op, DispatchKeySet currentDispatchKeySet, Args... args) const {
-  detail::unused_arg_(args...);  // workaround for a false-positive warning about unused parameters in gcc 5
+template <class Return, class... Args>
+inline Return Dispatcher::redispatch(
+    const TypedOperatorHandle<Return(Args...)>& op,
+    DispatchKeySet currentDispatchKeySet,
+    Args... args) const {
+  detail::unused_arg_(args...); // workaround for a false-positive warning about
+                                // unused parameters in gcc 5
   // do not use RecordFunction on redispatch
 #ifndef NDEBUG
   DispatchTraceNestingGuard debug_guard;
   if (show_dispatch_trace()) {
-    detail::_print_dispatch_trace("[redispatch]", toString(op.operator_name()), currentDispatchKeySet);
+    detail::_print_dispatch_trace(
+        "[redispatch]", toString(op.operator_name()), currentDispatchKeySet);
   }
 #endif
-  const KernelFunction& kernel = op.operatorDef_->op.lookup(currentDispatchKeySet);
-  return kernel.template call<Return, Args...>(op, currentDispatchKeySet, std::forward<Args>(args)...);
+  const KernelFunction& kernel =
+      op.operatorDef_->op.lookup(currentDispatchKeySet);
+  return kernel.template call<Return, Args...>(
+      op, currentDispatchKeySet, std::forward<Args>(args)...);
 }
 
-inline void Dispatcher::callBoxed(const OperatorHandle& op, Stack* stack) const {
-  // note: this doesn't need the mutex because write operations on the list keep iterators intact.
+inline void Dispatcher::callBoxed(const OperatorHandle& op, Stack* stack)
+    const {
+  // note: this doesn't need the mutex because write operations on the list keep
+  // iterators intact.
   const auto& entry = op.operatorDef_->op;
-  auto dispatchKeySet = entry.dispatchKeyExtractor().getDispatchKeySetBoxed(stack);
+  auto dispatchKeySet =
+      entry.dispatchKeyExtractor().getDispatchKeySetBoxed(stack);
 #ifndef NDEBUG
   DispatchTraceNestingGuard debug_guard;
   if (show_dispatch_trace()) {
-    detail::_print_dispatch_trace("[callBoxed]", toString(op.operator_name()), dispatchKeySet);
+    detail::_print_dispatch_trace(
+        "[callBoxed]", toString(op.operator_name()), dispatchKeySet);
   }
 #endif
   const auto& kernel = entry.lookup(dispatchKeySet);
 #ifndef PYTORCH_DISABLE_PER_OP_PROFILING
-  auto step_callbacks = at::getStepCallbacksUnlessEmpty(at::RecordScope::FUNCTION);
+  auto step_callbacks =
+      at::getStepCallbacksUnlessEmpty(at::RecordScope::FUNCTION);
   if (C10_UNLIKELY(step_callbacks.has_value() && entry.isObserved())) {
     at::RecordFunction guard(std::move(*step_callbacks));
     auto dispatchKey = dispatchKeySet.highestPriorityTypeId();
     auto& schema = op.schema();
     auto schema_ref = std::reference_wrapper<const FunctionSchema>(schema);
-    guard.needsInputs() ? runRecordFunction(guard, schema_ref, dispatchKey, dispatchKeySet, c10::ArrayRef<const c10::IValue>(stack->data(), stack->size()))
-                        : runRecordFunction(guard, schema_ref, dispatchKey, dispatchKeySet);
+    guard.needsInputs()
+        ? runRecordFunction(
+              guard,
+              schema_ref,
+              dispatchKey,
+              dispatchKeySet,
+              c10::ArrayRef<const c10::IValue>(stack->data(), stack->size()))
+        : runRecordFunction(guard, schema_ref, dispatchKey, dispatchKeySet);
 
     // keeping the guard alive while executing the kernel
     kernel.callBoxed(op, dispatchKeySet, stack);
@@ -743,17 +873,22 @@ inline void Dispatcher::callBoxed(const OperatorHandle& op, Stack* stack) const 
     }
     return;
   }
-#endif  // PYTORCH_DISABLE_PER_OP_PROFILING
+#endif // PYTORCH_DISABLE_PER_OP_PROFILING
   kernel.callBoxed(op, dispatchKeySet, stack);
 }
 
 // NB: this doesn't count as a "true" dispatcher jump, so no instrumentation
-inline void Dispatcher::callBoxedForDispatchKey(const OperatorHandle& op, DispatchKey dk, Stack* stack) const {
-  // note: this doesn't need the mutex because write operations on the list keep iterators intact.
+inline void Dispatcher::callBoxedForDispatchKey(
+    const OperatorHandle& op,
+    DispatchKey dk,
+    Stack* stack) const {
+  // note: this doesn't need the mutex because write operations on the list keep
+  // iterators intact.
   const auto& entry = op.operatorDef_->op;
   // We still compute this as we're obligated to pass it on to the internal
   // kernel, if it is a boxed fallback
-  auto dispatchKeySet = entry.dispatchKeyExtractor().getDispatchKeySetBoxed(stack);
+  auto dispatchKeySet =
+      entry.dispatchKeyExtractor().getDispatchKeySetBoxed(stack);
   const auto& kernel = ([&]() {
     if (op.hasKernelForDispatchKey(dk)) {
       return entry.kernelForDispatchKey(dk);
@@ -766,13 +901,18 @@ inline void Dispatcher::callBoxedForDispatchKey(const OperatorHandle& op, Dispat
   kernel.callBoxed(op, dispatchKeySet, stack);
 }
 
-inline void Dispatcher::redispatchBoxed(const OperatorHandle& op, DispatchKeySet dispatchKeySet, Stack* stack) const {
-  // note: this doesn't need the mutex because write operations on the list keep iterators intact.
+inline void Dispatcher::redispatchBoxed(
+    const OperatorHandle& op,
+    DispatchKeySet dispatchKeySet,
+    Stack* stack) const {
+  // note: this doesn't need the mutex because write operations on the list keep
+  // iterators intact.
   const auto& entry = op.operatorDef_->op;
 #ifndef NDEBUG
   DispatchTraceNestingGuard debug_guard;
   if (show_dispatch_trace()) {
-    detail::_print_dispatch_trace("[redispatchBoxed]", toString(op.operator_name()), dispatchKeySet);
+    detail::_print_dispatch_trace(
+        "[redispatchBoxed]", toString(op.operator_name()), dispatchKeySet);
   }
 #endif
   const auto& kernel = entry.lookup(dispatchKeySet);

--- a/aten/src/ATen/core/dispatch/OperatorEntry.h
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.h
@@ -1,23 +1,23 @@
 #pragma once
 
+#include <ATen/core/boxing/KernelFunction.h>
+#include <ATen/core/dispatch/DispatchKeyExtractor.h>
 #include <ATen/core/function_schema.h>
-#include <c10/util/Metaprogramming.h>
-#include <c10/util/flat_hash_map.h>
+#include <ATen/core/ivalue.h>
 #include <c10/core/DispatchKey.h>
 #include <c10/core/PyHandleCache.h>
 #include <c10/core/SafePyObject.h>
-#include <ATen/core/ivalue.h>
-#include <ATen/core/boxing/KernelFunction.h>
-#include <ATen/core/dispatch/DispatchKeyExtractor.h>
+#include <c10/util/Metaprogramming.h>
+#include <c10/util/flat_hash_map.h>
 
-#include <ATen/core/dispatch/OperatorOptions.h>
 #include <ATen/core/dispatch/CppSignature.h>
+#include <ATen/core/dispatch/OperatorOptions.h>
 #include <ATen/core/dispatch/RegistrationHandleRAII.h>
 #include <ATen/core/enum_tag.h>
 
-#include <optional>
 #include <array>
 #include <list>
+#include <optional>
 
 #ifdef C10_MOBILE
 #define C10_DISPATCHER_ONE_KERNEL_PER_DISPATCH_KEY
@@ -35,11 +35,13 @@ namespace impl {
 // we don't put AnnotatedKernel in the actual DispatchTable), but is useful for
 // giving good error messages.
 struct AnnotatedKernel final {
-  AnnotatedKernel(KernelFunction k, std::unique_ptr<FunctionSchema> s, std::string d)
-    : kernel(std::move(k))
-    , inferred_function_schema(std::move(s))
-    , debug(std::move(d))
-    {}
+  AnnotatedKernel(
+      KernelFunction k,
+      std::unique_ptr<FunctionSchema> s,
+      std::string d)
+      : kernel(std::move(k)),
+        inferred_function_schema(std::move(s)),
+        debug(std::move(d)) {}
   AnnotatedKernel() = default;
   KernelFunction kernel;
   std::unique_ptr<FunctionSchema> inferred_function_schema;
@@ -53,9 +55,7 @@ struct AnnotatedKernel final {
 // where the registration of this schema occurred
 struct AnnotatedSchema final {
   AnnotatedSchema(FunctionSchema s, std::string d)
-    : schema(std::move(s))
-    , debug(std::move(d))
-    {}
+      : schema(std::move(s)), debug(std::move(d)) {}
   FunctionSchema schema;
   std::string debug;
 };
@@ -68,7 +68,7 @@ struct AnnotatedSchema final {
 // lock (this is important because some methods in OperatorEntry access
 // dispatcher state)
 class TORCH_API OperatorEntry final {
-public:
+ public:
   explicit OperatorEntry(OperatorName&& operator_name);
 
   OperatorEntry(const OperatorEntry&) = delete;
@@ -77,7 +77,11 @@ public:
   OperatorEntry& operator=(OperatorEntry&&) noexcept = delete;
 
   const FunctionSchema& schema() const {
-    TORCH_INTERNAL_ASSERT(schema_.has_value(), "Tried to access the schema for ", name_, " which doesn't have a schema registered yet");
+    TORCH_INTERNAL_ASSERT(
+        schema_.has_value(),
+        "Tried to access the schema for ",
+        name_,
+        " which doesn't have a schema registered yet");
     return schema_->schema;
   }
   const std::string& debug() const {
@@ -100,7 +104,10 @@ public:
   // attempt to register a schema when one is already present or vice
   // versa that is an error.  (Refcounting for the registrations is
   // handled in the OperatorHandle in Dispatcher)
-  void registerSchema(FunctionSchema&&, std::string&& debug, std::vector<at::Tag> tags = {});
+  void registerSchema(
+      FunctionSchema&&,
+      std::string&& debug,
+      std::vector<at::Tag> tags = {});
   void deregisterSchema();
 
   const OperatorName& operator_name() const {
@@ -128,26 +135,21 @@ public:
   // Precondition: Dispatcher::mutex_ is held
   // Postcondition: caller is responsible for disposing of the kernel
   AnnotatedKernelContainerIterator registerKernel(
-    const Dispatcher& dispatcher,
-    std::optional<DispatchKey> dispatch_key,
-    KernelFunction kernel,
-    std::optional<CppSignature> cpp_signature,
-    std::unique_ptr<FunctionSchema> inferred_function_schema,
-    std::string debug
-  );
+      const Dispatcher& dispatcher,
+      std::optional<DispatchKey> dispatch_key,
+      KernelFunction kernel,
+      std::optional<CppSignature> cpp_signature,
+      std::unique_ptr<FunctionSchema> inferred_function_schema,
+      std::string debug);
 
   // Precondition: Dispatcher::mutex_ is held
   void deregisterKernel_(
-    const Dispatcher& dispatcher,
-    std::optional<DispatchKey> dispatch_key,
-    AnnotatedKernelContainerIterator kernel
-  );
+      const Dispatcher& dispatcher,
+      std::optional<DispatchKey> dispatch_key,
+      AnnotatedKernelContainerIterator kernel);
 
   // Precondition: Dispatcher::mutex_ is held
-  void updateFallback(
-    const Dispatcher& dispatcher,
-    DispatchKey dispatch_key
-  );
+  void updateFallback(const Dispatcher& dispatcher, DispatchKey dispatch_key);
 
   // Precondition: Dispatcher::mutex_ is held
   void updateSchemaAliasAnalysis(AliasAnalysisKind a) {
@@ -159,15 +161,21 @@ public:
   std::string dumpState() const;
   void checkInvariants() const;
 
-  const DispatchKeyExtractor& dispatchKeyExtractor() const { return dispatchKeyExtractor_; }
-
-  // Asserts that the given FuncType is correct for calling this operator in an unboxed way.
-  template<class FuncType>
-  inline void assertSignatureIsCorrect() {
-    assertSignatureIsCorrect(CppSignature::make<FuncType>(), fn_has_symint<FuncType>::value);
+  const DispatchKeyExtractor& dispatchKeyExtractor() const {
+    return dispatchKeyExtractor_;
   }
 
-  void assertSignatureIsCorrect(const CppSignature& call_signature, bool has_symint) const;
+  // Asserts that the given FuncType is correct for calling this operator in an
+  // unboxed way.
+  template <class FuncType>
+  inline void assertSignatureIsCorrect() {
+    assertSignatureIsCorrect(
+        CppSignature::make<FuncType>(), fn_has_symint<FuncType>::value);
+  }
+
+  void assertSignatureIsCorrect(
+      const CppSignature& call_signature,
+      bool has_symint) const;
 
   [[noreturn]] void reportError(DispatchKey dispatchKey) const;
 
@@ -198,8 +206,8 @@ public:
   // Invariant: There are no alias keys in the passed-in dispatch key set.
   // Note [No Alias Keys in DispatchKeySet]
   // Alias keys should be checked using `hasKernelForDispatchKey`
-  // Alias keys shouldn't go inside of a DispatchKeySet, since they can technically
-  // have a value > 63 (causing overflow).
+  // Alias keys shouldn't go inside of a DispatchKeySet, since they can
+  // technically have a value > 63 (causing overflow).
   bool hasKernelForAnyDispatchKey(DispatchKeySet ks) const;
   // Returns true if kernel_ has entry for a particular key.
   bool hasKernelForDispatchKey(DispatchKey k) const;
@@ -214,17 +222,17 @@ public:
   void setReportErrorCallback_(std::unique_ptr<c10::SafePyObject> callback);
 
   template <typename F>
-  PyObject* getPythonOp(PyInterpreter* self_interpreter, F slow_accessor) const {
+  PyObject* getPythonOp(PyInterpreter* self_interpreter, F slow_accessor)
+      const {
     return py_cache_.ptr_or(self_interpreter, slow_accessor);
   }
 
-private:
-
+ private:
   OperatorName name_;
   std::optional<AnnotatedSchema> schema_;
-  #ifndef C10_MOBILE
-    std::vector<at::Tag> tags_;
-  #endif
+#ifndef C10_MOBILE
+  std::vector<at::Tag> tags_;
+#endif
   std::array<KernelFunction, c10::num_runtime_entries> dispatchTable_;
   DispatchKeyExtractor dispatchKeyExtractor_;
   // Pointer to the torch.ops.ns.op.overload object for speed
@@ -232,8 +240,8 @@ private:
 
   // kernels_ stores all registered kernels for the corresponding dispatch key
   // and catchAllKernels_ stores the catch-all kernels.
-  // If an operator library gets loaded that overwrites an already existing kernel,
-  // both kernels will be in that list but only the newer one will be in
+  // If an operator library gets loaded that overwrites an already existing
+  // kernel, both kernels will be in that list but only the newer one will be in
   // dispatchTable. If any of the kernels go away (say the library gets
   // unloaded), we remove the kernel from this list and update the
   // dispatchTable if necessary.
@@ -261,14 +269,16 @@ private:
   // re-executed and then only allow one kernel here, i.e. error if a kernel
   // is already registered, but that's a lot of effort to implement and
   // currently not high-pri.
-  ska::flat_hash_map<DispatchKey,
+  ska::flat_hash_map<
+      DispatchKey,
 #ifdef C10_DISPATCHER_ONE_KERNEL_PER_DISPATCH_KEY
-                     // On mobile, we needn't worry about Jupyter notebooks.
-                     std::array<AnnotatedKernel, 1>
+      // On mobile, we needn't worry about Jupyter notebooks.
+      std::array<AnnotatedKernel, 1>
 #else
-                     std::list<AnnotatedKernel>
+      std::list<AnnotatedKernel>
 #endif
-                     > kernels_;
+      >
+      kernels_;
 
   const AnnotatedKernel& missingKernel() const;
   const AnnotatedKernel& ambiguousAutogradOtherKernel() const;
@@ -293,20 +303,32 @@ private:
   // Whether this operator needs to be observed with RecordFunction
   const bool is_observed_;
 
-  [[noreturn]] void reportSignatureError(const CppSignature& call_signature, const CppSignatureWithDebug& saved_signature) const;
-  const KernelFunction& computeDispatchTableEntry(const c10::Dispatcher& dispatcher, DispatchKey dispatch_key) const;
-  std::pair<const AnnotatedKernel&, const char*> computeDispatchTableEntryWithDebug(
-    const c10::Dispatcher& dispatcher, DispatchKey dispatch_key
-  ) const;
+  [[noreturn]] void reportSignatureError(
+      const CppSignature& call_signature,
+      const CppSignatureWithDebug& saved_signature) const;
+  const KernelFunction& computeDispatchTableEntry(
+      const c10::Dispatcher& dispatcher,
+      DispatchKey dispatch_key) const;
+  std::pair<const AnnotatedKernel&, const char*>
+  computeDispatchTableEntryWithDebug(
+      const c10::Dispatcher& dispatcher,
+      DispatchKey dispatch_key) const;
   // This function re-establishes the invariant that dispatchTable
-  // contains the front element from the kernels list for a given runtime dispatch key.
-  void updateDispatchTableEntry_(const c10::Dispatcher& dispatcher, DispatchKey dispatch_key);
+  // contains the front element from the kernels list for a given runtime
+  // dispatch key.
+  void updateDispatchTableEntry_(
+      const c10::Dispatcher& dispatcher,
+      DispatchKey dispatch_key);
   // Like above, but also handles alias dispatch keys.
-  void updateDispatchTable_(const c10::Dispatcher& dispatcher, DispatchKey dispatch_key);
+  void updateDispatchTable_(
+      const c10::Dispatcher& dispatcher,
+      DispatchKey dispatch_key);
   // Like above, but for ALL entries in the dispatch table.
   void updateDispatchTableFull_(const c10::Dispatcher& dispatcher);
-  // Retrieves a pointer to AnnotatedKernel at kernels_.at(dispatch_key).front().
-  const AnnotatedKernel* getKernelForDispatchKey(DispatchKey dispatch_key) const;
+  // Retrieves a pointer to AnnotatedKernel at
+  // kernels_.at(dispatch_key).front().
+  const AnnotatedKernel* getKernelForDispatchKey(
+      DispatchKey dispatch_key) const;
 };
 
 } // namespace impl

--- a/aten/src/ATen/core/dispatch/OperatorOptions.h
+++ b/aten/src/ATen/core/dispatch/OperatorOptions.h
@@ -13,18 +13,18 @@ enum class AliasAnalysisKind : uint8_t {
 };
 
 #if !defined(_MSC_VER)
-constexpr // Our current MSVC version has a bug that doesn't allow this to be constexpr.
+constexpr // Our current MSVC version has a bug that doesn't allow this to be
+          // constexpr.
 #endif
-inline const char* toString(AliasAnalysisKind aliasAnalysisKind) {
-  return (aliasAnalysisKind == AliasAnalysisKind::CONSERVATIVE)
-      ? "CONSERVATIVE"
-      : (aliasAnalysisKind == AliasAnalysisKind::FROM_SCHEMA)
-          ? "FROM_SCHEMA"
-          : (aliasAnalysisKind == AliasAnalysisKind::PURE_FUNCTION)
-              ? "PURE_FUNCTION"
-              : (aliasAnalysisKind == AliasAnalysisKind::INTERNAL_SPECIAL_CASE)
-                  ? "INTERNAL_SPECIAL_CASE"
-                  : "UNKNOWN";
+    inline const char*
+    toString(AliasAnalysisKind aliasAnalysisKind) {
+  return (aliasAnalysisKind == AliasAnalysisKind::CONSERVATIVE) ? "CONSERVATIVE"
+      : (aliasAnalysisKind == AliasAnalysisKind::FROM_SCHEMA)   ? "FROM_SCHEMA"
+      : (aliasAnalysisKind == AliasAnalysisKind::PURE_FUNCTION)
+      ? "PURE_FUNCTION"
+      : (aliasAnalysisKind == AliasAnalysisKind::INTERNAL_SPECIAL_CASE)
+      ? "INTERNAL_SPECIAL_CASE"
+      : "UNKNOWN";
 }
 
 } // namespace c10

--- a/aten/src/ATen/core/dispatch/RegistrationHandleRAII.h
+++ b/aten/src/ATen/core/dispatch/RegistrationHandleRAII.h
@@ -5,7 +5,7 @@
 namespace c10 {
 
 class RegistrationHandleRAII final {
-public:
+ public:
   explicit RegistrationHandleRAII(std::function<void()> onDestruction)
       : onDestruction_(std::move(onDestruction)) {}
 
@@ -29,8 +29,8 @@ public:
     return *this;
   }
 
-private:
+ private:
   std::function<void()> onDestruction_;
 };
 
-}
+} // namespace c10


### PR DESCRIPTION
Code change via add path config in `.lintrunner.toml` file and running

```bash
 $ lintrunner -a --take CLANGFORMAT --all-files
```

cc @ezyang 