### PR TITLE
[Inductor][CPP] Fix bitwise shift with corner inputs

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2291,7 +2291,7 @@ class CPUReproTests(TestCase):
         self.assertEqual(res_aten_eager, res)
 
     def test_bitwise_shift_left_corner_inputs(self):
-        # Fix https://github.com/pytorch/pytorch/issues/143555
+        # Fix https://github.com/pytorch/pytorch/issues/143566
         x = torch.tensor(1000, dtype=torch.int64)
         bit_num = torch.tensor(64, dtype=torch.int64)
         res_aten_eager = torch.bitwise_left_shift(x, bit_num)

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2281,6 +2281,24 @@ class CPUReproTests(TestCase):
         res = cfn(x, bit_num)
         self.assertEqual(res_aten_eager, res)
 
+    def test_bitwise_shift_right_corner_inputs(self):
+        # Fix https://github.com/pytorch/pytorch/issues/143555
+        x = torch.tensor(1000, dtype=torch.int64)
+        bit_num = torch.tensor(64, dtype=torch.int64)
+        res_aten_eager = torch.bitwise_right_shift(x, bit_num)
+        cfn = torch.compile(torch.bitwise_right_shift)
+        res = cfn(x, bit_num)
+        self.assertEqual(res_aten_eager, res)
+
+    def test_bitwise_shift_left_corner_inputs(self):
+        # Fix https://github.com/pytorch/pytorch/issues/143555
+        x = torch.tensor(1000, dtype=torch.int64)
+        bit_num = torch.tensor(64, dtype=torch.int64)
+        res_aten_eager = torch.bitwise_left_shift(x, bit_num)
+        cfn = torch.compile(torch.bitwise_left_shift)
+        res = cfn(x, bit_num)
+        self.assertEqual(res_aten_eager, res)
+
     def test_view_dtype(self):
         def f(x):
             return x.view(torch.int32) >> 2

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2281,23 +2281,22 @@ class CPUReproTests(TestCase):
         res = cfn(x, bit_num)
         self.assertEqual(res_aten_eager, res)
 
-    def test_bitwise_shift_right_corner_inputs(self):
+    def test_bitwise_shift_corner_inputs(self):
         # Fix https://github.com/pytorch/pytorch/issues/143555
-        x = torch.tensor(1000, dtype=torch.int64)
-        bit_num = torch.tensor(64, dtype=torch.int64)
-        res_aten_eager = torch.bitwise_right_shift(x, bit_num)
-        cfn = torch.compile(torch.bitwise_right_shift)
-        res = cfn(x, bit_num)
-        self.assertEqual(res_aten_eager, res)
-
-    def test_bitwise_shift_left_corner_inputs(self):
-        # Fix https://github.com/pytorch/pytorch/issues/143566
-        x = torch.tensor(1000, dtype=torch.int64)
-        bit_num = torch.tensor(64, dtype=torch.int64)
-        res_aten_eager = torch.bitwise_left_shift(x, bit_num)
-        cfn = torch.compile(torch.bitwise_left_shift)
-        res = cfn(x, bit_num)
-        self.assertEqual(res_aten_eager, res)
+        # and https://github.com/pytorch/pytorch/issues/143566
+        bitwise_fns = (
+            torch.bitwise_left_shift,
+            torch.bitwise_right_shift,
+        )
+        for bitwise_fn in bitwise_fns:
+            torch._dynamo.reset()
+            metrics.reset()
+            x = torch.tensor(1000, dtype=torch.int64)
+            bit_num = torch.tensor(64, dtype=torch.int64)
+            res_aten_eager = bitwise_fn(x, bit_num)
+            cfn = torch.compile(bitwise_fn)
+            res = cfn(x, bit_num)
+            self.assertEqual(res_aten_eager, res)
 
     def test_view_dtype(self):
         def f(x):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143635

**Summary**
Fix issue https://github.com/pytorch/pytorch/issues/143555 and https://github.com/pytorch/pytorch/issues/143566, we can align the implementation with Eager: https://github.com/pytorch/pytorch/blob/29b586bbad98dbc3d9ced980ccbdd8125d90a04d/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp#L501 at these corner inputs.

**Test Plan**
```
python test/inductor/test_cpu_repro.py -k test_bitwise_shift_corner_inputs
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov