### PR TITLE
[BE][Sparse] Get rid of gcc-5 workaround

### DIFF
--- a/aten/src/ATen/native/sparse/FlattenIndicesCommon.h
+++ b/aten/src/ATen/native/sparse/FlattenIndicesCommon.h
@@ -48,10 +48,9 @@ Tensor _flatten_indices_impl(const Tensor& indices, IntArrayRef size) {
   const auto hash_coeffs = std::get<0>(*hash_coeffs_storage);
 
   const auto hash_indices = [&]() -> Tensor {
-    // non-const because of gcc-5/clang-5 issues
-    auto sparse_dim = indices.size(0);
-    auto indices_dim_stride = indices.stride(0);
-    auto indices_nnz_stride = indices.stride(1);
+    const auto sparse_dim = indices.size(0);
+    const auto indices_dim_stride = indices.stride(0);
+    const auto indices_nnz_stride = indices.stride(1);
 
     auto hash = at::arange(indices.size(1), indices.options().dtype(kLong));
 

--- a/aten/src/ATen/native/sparse/SparseBinaryOpIntersectionCommon.h
+++ b/aten/src/ATen/native/sparse/SparseBinaryOpIntersectionCommon.h
@@ -246,8 +246,7 @@ void _sparse_binary_op_intersection_kernel_impl(
       source._indices().options());
   const auto probably_coalesced_nnz_arange = nnz_arange.narrow(-1, 0, probably_coalesced._nnz());
 
-  // non-const because of gcc-5/clang-5 issues
-  auto sparse_dim = probably_coalesced.sparse_dim();
+  const auto sparse_dim = probably_coalesced.sparse_dim();
 
   // Apply the hash function to probably_coalesced.indices
   const auto probably_coalesced_indices_hash = [&]() -> Tensor {
@@ -257,9 +256,8 @@ void _sparse_binary_op_intersection_kernel_impl(
     }
 
     const auto indices = probably_coalesced._indices();
-    // non-const because of gcc-5/clang-5 issues
-    auto indices_dim_stride = indices.stride(0);
-    auto indices_nnz_stride = indices.stride(1);
+    const auto indices_dim_stride = indices.stride(0);
+    const auto indices_nnz_stride = indices.stride(1);
 
     auto hash = at::empty({probably_coalesced._nnz()}, indices.options().dtype(kLong));
 


### PR DESCRIPTION
Discovered those comments while looking at https://github.com/pytorch/pytorch/pull/143620
