### PR TITLE
RFC: Use plain metal kernel for MPS mul

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -2,6 +2,7 @@
 #include <ATen/core/TensorBase.h>
 #include <ATen/native/mps/MetalShaderLibrary.h>
 #include <functional>
+#include <sstream>
 #include <stdexcept>
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/TensorIterator.h>
@@ -178,7 +179,9 @@ MPSDataType getMPSScalarType(ScalarType scalar_type) {
 }
 
 // use short_name to avoid getting extra long cached graph keys with ops such as cat_out(), etc.
-std::string getMPSTypeString(ScalarType scalar_type, bool short_name) {
+namespace {
+// Would be nice to roll this out to replace getMPSTypeString.
+std::string_view getMPSTypeStringConstant(ScalarType scalar_type, bool short_name) {
   switch (scalar_type) {
     case ScalarType::Double:
     case ScalarType::Float:
@@ -206,6 +209,12 @@ std::string getMPSTypeString(ScalarType scalar_type, bool short_name) {
     default:
       return "Undefined";
   }
+}
+} // namespace
+
+std::string getMPSTypeString(ScalarType scalar_type, bool short_name) {
+  const auto sv = getMPSTypeStringConstant(scalar_type, short_name);
+  return std::string(sv.data(), sv.size());
 }
 
 std::string scalarToMetalTypeString(const c10::ScalarType& scalar_type) {
@@ -285,29 +294,35 @@ std::string getArrayRefString(const IntArrayRef s) {
 }
 
 std::string getTensorsStringKey(const TensorList& tensors, bool short_dtype, bool exclude_shape) {
-  std::string str;
+  std::ostringstream str;
   // The key format per tensor would look like ":Float32[1,1,1,10]:"
   for (const Tensor& tensor : tensors) {
-    str += ":";
+    str << ':';
     if (tensor.defined()) {
-      str += getMPSTypeString(tensor.scalar_type(), short_dtype) + "[";
+      str << getMPSTypeStringConstant(tensor.scalar_type(), short_dtype) << '[';
       // if tensor is a scalar
       if (tensor.dim() == 0) {
-        str += "Scalar";
+        str << "Scalar";
       } else {
         if (exclude_shape) {
-          str += "[-1]";
+          str << "[-1]";
         } else {
-          str +=
-              std::string([[getMPSShape(tensor) valueForKey:@"description"] componentsJoinedByString:@","].UTF8String);
+          bool first = true;
+          for (const auto size: tensor.sizes()) {
+            if (!first) {
+              str << ',';
+            }
+            first = false;
+            str << size;
+          }
         }
       }
-      str += "]";
+      str << ']';
     } else {
-      str += "Undefined";
+      str << "Undefined";
     }
   }
-  return str;
+  return str.str();
 }
 
 Tensor getTensorView(const Tensor& t, MPSShape* shape) {

--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -57,6 +57,20 @@ kernel void copysign_integral(
   *out = copysign(static_cast<float>(*input), static_cast<float>(*other));
 }
 
+template <typename T>
+kernel void real_mul(
+    constant void* input_ [[buffer(0)]],
+    constant void* other_ [[buffer(1)]],
+    device void* out_ [[buffer(2)]],
+    constant uint3* offsets [[buffer(3)]],
+    uint tid [[thread_position_in_grid]]) {
+  device T* out = (device T*)((device uint8_t*)out_ + offsets[tid].x);
+  constant T* input = (constant T*)((constant uint8_t*)input_ + offsets[tid].y);
+  constant T* other = (constant T*)((constant uint8_t*)other_ + offsets[tid].z);
+
+  *out = *input * *other;
+}
+
 #define REGISTER_FMAX_OP(DTYPE)                                   \
   template [[host_name("fmax_" #DTYPE)]] kernel void fmax<DTYPE>( \
       constant void* input_ [[buffer(0)]],                        \
@@ -90,16 +104,35 @@ kernel void copysign_integral(
       constant uint3* offsets [[buffer(3)]],             \
       uint tid [[thread_position_in_grid]]);
 
+#define REGISTER_REAL_MUL_OP(DTYPE)                               \
+  template [[host_name("real_mul_" #DTYPE)]] kernel void real_mul<DTYPE>( \
+      constant void* input_ [[buffer(0)]],                        \
+      constant void* other_ [[buffer(1)]],                        \
+      device void* out_ [[buffer(2)]],                            \
+      constant uint3* offsets [[buffer(3)]],                      \
+      uint tid [[thread_position_in_grid]]);
+
 REGISTER_FMAX_OP(float);
 REGISTER_FMAX_OP(half);
 REGISTER_FMIN_OP(float);
 REGISTER_FMIN_OP(half);
 REGISTER_COPYSIGN_OP(float);
 REGISTER_COPYSIGN_OP(half);
+REGISTER_REAL_MUL_OP(float);
+REGISTER_REAL_MUL_OP(half);
+REGISTER_REAL_MUL_OP(int);
+REGISTER_REAL_MUL_OP(uint);
+REGISTER_REAL_MUL_OP(long);
+REGISTER_REAL_MUL_OP(short);
+REGISTER_REAL_MUL_OP(ushort);
+REGISTER_REAL_MUL_OP(char);
+REGISTER_REAL_MUL_OP(uchar);
+REGISTER_REAL_MUL_OP(bool);
 #if __METAL_VERSION__ >= 310
 REGISTER_FMAX_OP(bfloat);
 REGISTER_FMIN_OP(bfloat);
 REGISTER_COPYSIGN_OP(bfloat);
+REGISTER_REAL_MUL_OP(bfloat);
 #endif
 REGISTER_COPYSIGN_INTEGRAL_OP(int);
 REGISTER_COPYSIGN_INTEGRAL_OP(long);

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.h
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.h
@@ -9,4 +9,12 @@ void real_mul_out(
     const Tensor& input,
     const Tensor& other,
     const Tensor& output);
+void add_out(
+    const Tensor& input,
+    const Tensor& other,
+    const Tensor& output);
+void sub_out(
+    const Tensor& input,
+    const Tensor& other,
+    const Tensor& output);
 }

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.h
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.h
@@ -5,4 +5,8 @@ void complex_mul_out(
     const Tensor& input,
     const Tensor& other,
     const Tensor& output);
+void real_mul_out(
+    const Tensor& input,
+    const Tensor& other,
+    const Tensor& output);
 }

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -83,6 +83,22 @@ void complex_mul_out(const Tensor& input, const Tensor& other, const Tensor& out
   mps::binary_mps_impl(iter, "complex_mul");
 }
 
+void real_mul_out(const Tensor& input, const Tensor& other, const Tensor& output) {
+  auto new_size = at::infer_size(input.sizes(), other.sizes());
+  if (!output.sizes().equals(new_size)) {
+    output.resize_(new_size);
+  }
+  uint32_t length = output.numel();
+  if (length == 0) {
+    return;
+  }
+  auto common_dtype = output.scalar_type();
+  auto iter =
+    TensorIteratorConfig().add_output(output).add_owned_input(input.to(kMPS, common_dtype)).add_owned_input(other.to(kMPS, common_dtype)).build();
+
+  mps::binary_mps_impl(iter, "real_mul");
+}
+
 } // namespace mps
 
 static void fmax_mps_kernel(TensorIteratorBase& iter) {

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -384,9 +384,11 @@ CREATE_MPS_BINARY_COMPARISON_OP_FUNC(logical_or_out_mps, logicalOR, Tensor);
 CREATE_MPS_BINARY_COMPARISON_OP_FUNC(logical_xor_out_mps, logicalXOR, Tensor);
 
 TORCH_IMPL_FUNC(mul_out_mps)(const Tensor& self, const Tensor& other, const Tensor& output) {
-  if (!mps::supportsComplex() && (c10::isComplexType(self.scalar_type()) || c10::isComplexType(other.scalar_type()))) {
+  if (c10::isComplexType(self.scalar_type()) || c10::isComplexType(other.scalar_type())) {
     return mps::complex_mul_out(self, other, output);
   }
+  return mps::real_mul_out(self, other, output);
+#if 0
   mps::binaryOpTensor(
       self, other, Scalar(1.0), output, "mul", ^BinaryOpFn(cachedGraph, primaryCastTensor, secondaryCastTensor) {
         MPSGraph* mpsGraph = cachedGraph->graph();
@@ -394,6 +396,7 @@ TORCH_IMPL_FUNC(mul_out_mps)(const Tensor& self, const Tensor& other, const Tens
                                          secondaryTensor:secondaryCastTensor
                                                     name:nil];
       });
+#endif
 }
 TORCH_IMPL_FUNC(atan2_out_mps)(const Tensor& self, const Tensor& other, const Tensor& output) {
   TORCH_CHECK(self.scalar_type() != ScalarType::Long, "MPS does not support atan2 op with int64 input");


### PR DESCRIPTION
I suspect that torchchat MPS generation speed may be limited by dispatch overheads.

Test command: python3 torchchat.py generate llama3.2-1b-base --device mps --dtype float --num-samples=3

Run 3 + total average result (the first run drags the average down, which is why I'm also including run 3 results) before:
```
Time for inference 3: 3.0606 sec total
Time to first token: 0.0307 sec with parallel prefill.

      Total throughput: 23.1982 tokens/sec, 0.0431 s/token
First token throughput: 32.5849 tokens/sec, 0.0307 s/token
 Next token throughput: 23.1031 tokens/sec, 0.0433 s/token

Bandwidth achieved: 139.05 GB/s

========================================

Warning: Excluding compile in calculations
      Average tokens/sec (total): 22.36
Average tokens/sec (first token): 23.41
Average tokens/sec (next tokens): 22.48
```

After (just the mul kernel):
```
Time for inference 3: 3.5690 sec total
Time to first token: 0.0217 sec with parallel prefill.

      Total throughput: 23.5357 tokens/sec, 0.0425 s/token
First token throughput: 46.1805 tokens/sec, 0.0217 s/token
 Next token throughput: 23.3975 tokens/sec, 0.0427 s/token

Bandwidth achieved: 141.07 GB/s

========================================

Warning: Excluding compile in calculations
      Average tokens/sec (total): 22.50
Average tokens/sec (first token): 32.93
Average tokens/sec (next tokens): 22.71
```

After including #143630 and adding a simple add/sub kernel (which required basic mixed dtype support to get through llama3.2 1B inference): 

```
Time for inference 3: 3.4373 sec total
Time to first token: 0.0159 sec with parallel prefill.

      Total throughput: 22.9830 tokens/sec, 0.0435 s/token
First token throughput: 63.0393 tokens/sec, 0.0159 s/token
 Next token throughput: 22.7973 tokens/sec, 0.0439 s/token

Bandwidth achieved: 137.76 GB/s

========================================


Warning: Excluding compile in calculations
      Average tokens/sec (total): 23.13
Average tokens/sec (first token): 43.94
Average tokens/sec (next tokens): 23.12
```

prefill continuing to trend way way up. To me, this validates the approach of getting intermediate libraries out of the way and dispatching direct to plain old .metal kernels. Thoughts?

