### PR TITLE
Support multiple prefetches

### DIFF
--- a/torch/distributed/fsdp/_exec_order_utils.py
+++ b/torch/distributed/fsdp/_exec_order_utils.py
@@ -86,10 +86,10 @@ class _ExecOrderData:
     def is_first_iter(self) -> bool:
         return self._iter == 0
 
-    def get_handle_to_backward_prefetch(
+    def get_handles_to_backward_prefetch(
         self,
         current_handle: FlatParamHandle,
-    ) -> Optional[FlatParamHandle]:
+    ) -> List[FlatParamHandle]:
         """
         Returns a :class:`list` of the handles keys of the handles to backward
         prefetch given the current handles key. If there are no valid handles
@@ -97,20 +97,20 @@ class _ExecOrderData:
         """
         current_index = current_handle._post_forward_index
         if current_index is None:
-            return None
+            return []
         target_index = current_index - 1
-        target_handle: Optional[FlatParamHandle] = None
+        target_handles: List[FlatParamHandle] = []
         for _ in range(self._backward_prefetch_limit):
             if target_index < 0:
                 break
-            target_handle = self.handles_post_forward_order[target_index]
+            target_handles.append(self.handles_post_forward_order[target_index])
             target_index -= 1
-        return target_handle
+        return target_handles
 
-    def get_handle_to_forward_prefetch(
+    def get_handles_to_forward_prefetch(
         self,
         current_handle: FlatParamHandle,
-    ) -> Optional[FlatParamHandle]:
+    ) -> List[FlatParamHandle]:
         """
         Returns a :class:`list` of the handles keys of the handles to forward
         prefetch given the current handles key. If there are no valid handles
@@ -118,15 +118,15 @@ class _ExecOrderData:
         """
         current_index = current_handle._pre_forward_order_index
         if current_index is None:
-            return None
+            return []
         target_index = current_index + 1
-        target_handle: Optional[FlatParamHandle] = None
+        target_handles: List[FlatParamHandle] = []
         for _ in range(self._forward_prefetch_limit):
             if target_index >= len(self.handles_pre_forward_order):
                 break
-            target_handle = self.handles_pre_forward_order[target_index]
+            target_handles.append(self.handles_pre_forward_order[target_index])
             target_index += 1
-        return target_handle
+        return target_handles
 
     def record_post_forward(self, handle: Optional[FlatParamHandle]) -> None:
         """

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -430,6 +430,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             Optional[Iterable[torch.nn.Parameter]], Optional[Iterable[torch.nn.Module]]
         ] = None,
         device_mesh: Optional[DeviceMesh] = None,
+        num_modules_to_prefetch: int = 1,
     ):
         torch._C._log_api_usage_once("torch.distributed.fsdp")
         super().__init__()
@@ -489,8 +490,9 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
                 FullyShardedDataParallel,
             )
 
-        backward_prefetch_limit = 1
-        forward_prefetch_limit = 1
+        assert num_modules_to_prefetch >= 1, f"num_modules_to_prefetch should be >= 1, but found {num_modules_to_prefetch}"
+        backward_prefetch_limit = num_modules_to_prefetch
+        forward_prefetch_limit = num_modules_to_prefetch
         _init_core_state(
             self,
             sharding_strategy,


### PR DESCRIPTION
This will prefetch multiple modules. It's useful to increase the overlap. Although most of the time this will only cause extra prefetches in the first module call.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o