### PR TITLE
Fix test_serialization_zipfile_actually_jit when weights_only is not default

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1017,7 +1017,7 @@ class TestSerialization(TestCase, SerializationMixin):
                 RuntimeError,
                 re.escape("Cannot use ``weights_only=True`` with TorchScript archives passed to ``torch.load``")
             ):
-                torch.load(f)
+                torch.load(f, weights_only=True)
             f.seek(0)
             torch.load(f, weights_only=False)
 


### PR DESCRIPTION
Fails in fbcode where weights_only isn't default

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143668
* #143403
* #143326

