### PR TITLE
[easy] Set feature use for aot autograd remote cache

### DIFF
--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -31,6 +31,7 @@ from torch._dynamo.utils import (
     dynamo_timed,
     get_chromium_event_logger,
     preserve_rng_state,
+    set_feature_use,
 )
 from torch._guards import detect_fake_mode
 from torch._inductor.output_code import OutputCode
@@ -1142,6 +1143,7 @@ def aot_module_simplified(
         local = should_use_local_autograd_cache()
         remote = should_use_remote_autograd_cache()
         if local or remote:
+            set_feature_use("aot_autograd_remote_cache", remote)
             compiled_fn = AOTAutogradCache.load(
                 dispatch_and_compile,
                 mod,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143674

Use set_feature_use for logging aot autograd cache so that dynamo_compile has this data as well as PT2 Compile Events.

Differential Revision: [D67536293](https://our.internmc.facebook.com/intern/diff/D67536293/)