### PR TITLE
Enhance provenance tracing unit test to cover `torch.compile()`

### DIFF
--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import re
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -37,16 +38,11 @@ class TestProvenanceTracingArtifact(TestCase):
     corresponding "inductor triton kernel node" is expected.
     """
 
-    def test_triton_kernel_post_grad_mapping_aot_inductor(self):
-        a = torch.randn(10, 20, device="cuda")
-        b = torch.randn(20, 30, device="cuda")
-        c = torch.randn(10, 30, device="cuda")
-        example_inputs = (a, b, c)
-
-        model = Model()
-        ep = torch.export._trace._export(model, example_inputs)
-        gm = ep.module()
-
+    def _check_provenance_tracing_artifact(self, filepath):
+        self.assertTrue(filepath.is_dir())
+        filename = Path(filepath) / "inductor_triton_kernel_to_post_grad_nodes.json"
+        with open(filename) as f:
+            actual_data = json.load(f)
         # check that the generated provenance tracing artifact is expected
         expected_data = {
             "triton_poi_fused_mul_0": ["mul"],
@@ -59,30 +55,45 @@ class TestProvenanceTracingArtifact(TestCase):
                 "mul_2",
             ],
         }
-
-        with config.patch(
-            {
-                "trace.debug_dir": tempfile.mkdtemp(),
-                "force_disable_caches": True,
-            }
-        ):
-            with self.assertLogs(
-                logging.getLogger("torch._inductor.debug"), level=logging.WARNING
-            ) as cm:
-                so_path = torch._inductor.aot_compile(gm, example_inputs)
-                optimized = AOTIRunnerUtil.load("cuda", so_path)
-                optimized(*example_inputs)
-
-        self.assertEqual(len(cm.output), 1)
-        m = re.match(r"WARNING.* debug trace: (.*)", cm.output[0])
-        self.assertTrue(m)
-        filename = Path(m.group(1))
-        self.assertTrue(filename.is_dir())
-        with open(filename / "inductor_triton_kernel_to_post_grad_nodes.json") as f:
-            actual_data = json.load(f)
-
-        # Compare the actual and expected data
         self.assertEqual(sorted(actual_data), sorted(expected_data))
+
+    def test_triton_kernel_to_post_grad_tracing(self):
+        a = torch.randn(10, 20, device="cuda")
+        b = torch.randn(20, 30, device="cuda")
+        c = torch.randn(10, 30, device="cuda")
+        example_inputs = (a, b, c)
+
+        model = Model()
+        ep = torch.export._trace._export(model, example_inputs)
+        gm = ep.module()
+
+        for backend in ["aot_inductor", "inductor"]:
+            try:
+                with config.patch(
+                    {
+                        "trace.debug_dir": tempfile.mkdtemp(),
+                        "force_disable_caches": True,
+                    }
+                ):
+                    with self.assertLogs(
+                        logging.getLogger("torch._inductor.debug"),
+                        level=logging.WARNING,
+                    ) as cm:
+                        if backend == "aot_inductor":
+                            so_path = torch._inductor.aot_compile(gm, example_inputs)
+                            optimized = AOTIRunnerUtil.load("cuda", so_path)
+                            optimized(*example_inputs)
+                        else:
+                            compiled = torch.compile(gm, backend=backend)(
+                                *example_inputs
+                            )
+                    self.assertEqual(len(cm.output), 1)
+                    m = re.match(r"WARNING.* debug trace: (.*)", cm.output[0])
+                    self.assertTrue(m)
+                    filepath = Path(m.group(1))
+                    self._check_provenance_tracing_artifact(filepath)
+            finally:
+                shutil.rmtree(filepath)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: Follow up as title.

Test Plan:
```
buck2 run -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=h100 @//mode/opt fbcode//caffe2/test/inductor:provenance_tracing -- -r test_triton_kernel_to_post_grad_tracing
```

Differential Revision: D67543556




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov