### PR TITLE
[cumsum][CUDA][64-bit indexing] Add 64-bit indexing path for `cumsum`

### DIFF
--- a/aten/src/ATen/native/cuda/ScanUtils.cuh
+++ b/aten/src/ATen/native/cuda/ScanUtils.cuh
@@ -346,7 +346,7 @@ __device__ void tensor_kernel_scan_innermost_dim_impl(T* row_buf, T *tgt_, const
       for (index_t m = 0; m <= log_num_threads_x; ++m) {
         if (row_exists) {
           index_t s = 1 << m; // s = 2 ^ m
-          index_t a = (index_t) ((threadIdx.x >> m) << (m + 1)) | s; // a = (threadIdx.x / s) * (2 * s) + s
+          auto a = static_cast<index_t>((threadIdx.x >> m) << (m + 1)) | s; // a = (threadIdx.x / s) * (2 * s) + s
           index_t ti = a + (threadIdx.x % s);
           index_t si = a - 1;
           row_buf[ti] = binary_op(row_buf[ti], row_buf[si]);

--- a/aten/src/ATen/native/cuda/ScanUtils.cuh
+++ b/aten/src/ATen/native/cuda/ScanUtils.cuh
@@ -343,7 +343,7 @@ __device__ void tensor_kernel_scan_innermost_dim_impl(T* row_buf, T *tgt_, const
 
       // Parallel reduction with Sklansky method. The diagram can be seen on this paper:
       // https://research.nvidia.com/publication/single-pass-parallel-prefix-scan-decoupled-look-back
-      for (index_t m = 0; m <= log_num_threads_x; ++m) {
+      for (int m = 0; m <= log_num_threads_x; ++m) {
         if (row_exists) {
           index_t s = 1 << m; // s = 2 ^ m
           auto a = static_cast<index_t>((threadIdx.x >> m) << (m + 1)) | s; // a = (threadIdx.x / s) * (2 * s) + s

--- a/aten/src/ATen/native/cuda/ScanUtils.cuh
+++ b/aten/src/ATen/native/cuda/ScanUtils.cuh
@@ -299,16 +299,16 @@ __global__ void tensor_kernel_scan_outer_dim(scalar_t *tgt_, const scalar_t *src
  * Each thread block processes one or more sets of contiguous rows (processing multiple rows
  * per thread block is quicker than processing a single row, especially for short rows).
  */
-template<typename T, class BinaryFunction>
+template<typename T, typename index_t, class BinaryFunction>
 __device__ void tensor_kernel_scan_innermost_dim_impl(T* row_buf, T *tgt_, const T *src_,
                                       const uint32_t num_rows, const uint32_t row_size,
                                       const uint32_t log_num_threads_x,
                                       T init, BinaryFunction binary_op){
-  const uint32_t num_threads_x = 1 << log_num_threads_x;
-  for (uint32_t block_row = blockIdx.x * blockDim.y;
+  const index_t num_threads_x = 1 << log_num_threads_x;
+  for (index_t block_row = blockIdx.x * blockDim.y;
        block_row < num_rows;
        block_row += blockDim.y * gridDim.x) {
-    uint32_t row = block_row + threadIdx.y;
+    index_t row = block_row + threadIdx.y;
     T block_total = init;
 
     const T *row_src = src_ + row * row_size;
@@ -317,10 +317,10 @@ __device__ void tensor_kernel_scan_innermost_dim_impl(T* row_buf, T *tgt_, const
 
     // Perform scan on one block at a time, keeping track of the total value of
     // all blocks processed so far.
-    for (uint32_t block_col = 0; block_col < row_size; block_col += 2 * num_threads_x) {
+    for (index_t block_col = 0; block_col < row_size; block_col += 2 * num_threads_x) {
       // Load data into shared memory (two values per thread).
-      uint32_t col1 = block_col + threadIdx.x;
-      uint32_t col2 = block_col + num_threads_x + threadIdx.x;
+      index_t col1 = block_col + threadIdx.x;
+      index_t col2 = block_col + num_threads_x + threadIdx.x;
       if (row_exists) {
         if (col1 < row_size) {
           row_buf[threadIdx.x] = row_src[col1];
@@ -343,12 +343,12 @@ __device__ void tensor_kernel_scan_innermost_dim_impl(T* row_buf, T *tgt_, const
 
       // Parallel reduction with Sklansky method. The diagram can be seen on this paper:
       // https://research.nvidia.com/publication/single-pass-parallel-prefix-scan-decoupled-look-back
-      for (uint32_t m = 0; m <= log_num_threads_x; ++m) {
+      for (index_t m = 0; m <= log_num_threads_x; ++m) {
         if (row_exists) {
-          uint32_t s = 1 << m; // s = 2 ^ m
-          uint32_t a = ((threadIdx.x >> m) << (m + 1)) | s; // a = (threadIdx.x / s) * (2 * s) + s
-          uint32_t ti = a + (threadIdx.x % s);
-          uint32_t si = a - 1;
+          index_t s = 1 << m; // s = 2 ^ m
+          index_t a = ((threadIdx.x >> m) << (m + 1)) | s; // a = (threadIdx.x / s) * (2 * s) + s
+          index_t ti = a + (threadIdx.x % s);
+          index_t si = a - 1;
           row_buf[ti] = binary_op(row_buf[ti], row_buf[si]);
         }
         __syncthreads();
@@ -380,9 +380,13 @@ __global__ void tensor_kernel_scan_innermost_dim(
   T* sbuf2 = reinterpret_cast<T*>(sbuf);
   const uint32_t num_threads_x = 1 << log_num_threads_x;
   T* row_buf = reinterpret_cast<T*>(sbuf2 + num_threads_x * 2 * threadIdx.y);
-
-  tensor_kernel_scan_innermost_dim_impl<T>(
-      row_buf, tgt_, src_, num_rows, row_size, log_num_threads_x, init, binary_op);
+  if (num_rows * (size_t) row_size <= UINT_MAX) {
+      tensor_kernel_scan_innermost_dim_impl<T, uint32_t>(
+          row_buf, tgt_, src_, num_rows, row_size, log_num_threads_x, init, binary_op);
+  } else {
+      tensor_kernel_scan_innermost_dim_impl<T, size_t>(
+          row_buf, tgt_, src_, num_rows, row_size, log_num_threads_x, init, binary_op);
+  }
 }
 
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1788,7 +1788,7 @@ else:
         chunk = 2**30 // b.shape[-1]
         for i in range(0, b.shape[0], chunk):
             end = min(i + chunk, b.shape[0])
-            b[i:end, :].cumsum_(dim = -1)
+            b[i:end, :].cumsum_(dim=-1)
         # cheat a bit to avoid OOM
         self.assertEqual(b[0, :], d[0, :], atol=3e-5, rtol=3e-5)
         self.assertEqual(b[-1, :], d[-1, :], atol=3e-5, rtol=3e-5)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1782,7 +1782,7 @@ else:
     @largeTensorTest('24GB', device='cuda')
     @largeTensorTest('24GB', device='cpu')
     def test_cumsum_64bit_indexing(self, device):
-        b = torch.ones((2*4096*8, 100000), dtype=torch.float, device='cuda')
+        b = torch.ones(2 * 4096 * 8, 100000, dtype=torch.float, device='cuda')
         b /= 100000
         d = b.cumsum(dim=-1)
         chunk = 2**30 // b.shape[-1]

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1778,6 +1778,20 @@ else:
             res_cpu = input.cpu().cumsum(dim)
             self.assertEqual(res0, res_cpu, atol=1e-3, rtol=1e-2)
 
+    @onlyCUDA
+    @largeTensorTest('24GB', device='cuda')
+    @largeTensorTest('24GB', device='cpu')
+    def test_cumsum_64bit_indexing(self, device):
+        b = torch.ones((2*4096*8, 100000), dtype=torch.float, device='cuda')
+        b /= 100000
+        d = b.cumsum(dim=-1)
+        chunk = 2**30 // b.shape[-1]
+        for i in range(0, b.shape[0], chunk):
+            end = min(i + chunk, b.shape[0])
+            b[i:end, :].cumsum_(dim = -1)
+        # cheat a bit to avoid OOM
+        self.assertEqual(b[0, :], d[0, :], atol=3e-5, rtol=3e-5)
+        self.assertEqual(b[-1, :], d[-1, :], atol=3e-5, rtol=3e-5)
 
     @expectedFailureMeta  # expected a non-determinitic error, but it was not raised
     @onlyNativeDeviceTypes


### PR DESCRIPTION
For #143486

Interestingly enough changing the indexing type seems to degrade performance when a larger width is not needed, even on small sizes, so making this a template param rather than forcing all cases to 64-bit



cc @ptrblck @msaroufim