### PR TITLE
fix: all_gather_intotensor in torch.compile graph

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1046,7 +1046,7 @@ These schemas intentionally match torch.distributed.distributed_c10d.* ops that 
 def all_gather_tensor_inplace(
     output_tensor: torch.Tensor,
     input_tensor: torch.Tensor,
-    group,  # TODO add a type,
+    group=None,  # TODO add a type
     async_op: bool = False,
     tag: str = "",
     gather_dim: int = 0,


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
My PR request is to fix the bug in torch.compile.
An example of the error is as follows:
```
import os
import torch
import torch.distributed as dist
torch._logging.set_logs(graph=True, graph_code=True)
class allgather_in_tensor(torch.nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, out_tensor, x):
        torch.distributed.all_gather_into_tensor(out_tensor, x)
        return out_tensor


def test_allgather_in_tensor_static(rank, world_size):
    torch.cuda.set_device("cuda:" + str(rank))
    dist.init_process_group("nccl", rank=rank, world_size=world_size)
    x = torch.ones(2, 2, dtype=torch.int64).to("cuda:" + str(rank)) + 1 + 2 * rank
    print("x-----===:", x)
    tensor_list = torch.zeros(4, 2, dtype=torch.int64).to("cuda:" + str(rank))
    print("tensor_list-----===:", tensor_list)
    mod = allgather_in_tensor()
    mod = mod.to("cuda:" + str(rank))
    ori_result = mod(tensor_list, x)
    print("ori_result:", ori_result)
    torch._dynamo.reset()
    opt_mod = torch.compile(mod, dynamic=False, fullgraph=True)
    compile_result = opt_mod(tensor_list, x)
    print("compile_result:", compile_result)
    assert ori_result.equal(compile_result)
	
def mp():
    world_size = 2
    torch.multiprocessing.spawn(test_allgather_in_tensor_static, args=(world_size,), nprocs=world_size, join=True)


if __name__ == '__main__':
    os.environ["MASTER_ADDR"] = "localhost"
    os.environ["MASTER_PORT"] = "29506"
    mp()
```
This test case triggers the following error. This problem can be solved by using the modification in the PR.
```
  File "/data1/anaconda/envs/yxr_py310/lib/python3.10/site-packages/torch/_dynamo/symbolic_convert.py", line 749, in inline_user_function_return
    return InliningInstructionTranslator.inline_call(self, fn, args, kwargs)
  File "/data1/anaconda/envs/yxr_py310/lib/python3.10/site-packages/torch/_dynamo/symbolic_convert.py", line 2666, in inline_call
    return cls.inline_call_(parent, func, args, kwargs)
  File "/data1/anaconda/envs/yxr_py310/lib/python3.10/site-packages/torch/_dynamo/symbolic_convert.py", line 2716, in inline_call_
    raise ArgsMismatchError(  # noqa: B904
torch._dynamo.exc.ArgsMismatchError: missing a required argument: 'group'.
  func = 'all_gather_tensor_inplace' /data1/anaconda/envs/yxr_py310/lib/python3.10/site-packages/torch/distributed/_functional_collectives.py:1003, args = [], kwargs = {'output_tensor': LazyVariableTracker(), 'input_tensor': LazyVariableTracker()}

from user code:
   File "/home/yxr/allgather_test/allgather_error2.py", line 10, in forward
    torch.distributed.all_gather_into_tensor(out_tensor, x)

Set TORCH_LOGS="+dynamo" and TORCHDYNAMO_VERBOSE=1 for more information


You can suppress this exception and fall back to eager by setting:
    import torch._dynamo
    torch._dynamo.config.suppress_errors = True

```

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o