### PR TITLE
Better fix for f-strings in set_linter for py3.12

### DIFF
--- a/tools/linter/adapters/_linter.py
+++ b/tools/linter/adapters/_linter.py
@@ -16,13 +16,8 @@ from typing import Any, Iterator, Sequence
 from typing_extensions import Never
 
 
-FSTRING_TOKENS = dict.fromkeys(
-    [
-        getattr(token, "FSTRING_START", -1),
-        getattr(token, "FSTRING_MIDDLE", -1),
-        getattr(token, "FSTRING_END", -1),
-    ]
-)
+FSTRING_START = getattr(token, "FSTRING_START", None)  # py3.12+
+FSTRING_END = getattr(token, "FSTRING_END", None)
 EMPTY_TOKENS = dict.fromkeys(
     [
         token.COMMENT,
@@ -294,10 +289,18 @@ def bracket_pairs(tokens: Sequence[TokenInfo]) -> dict[int, int]:
             elif inv := BRACKETS_INV.get(t.string):
                 ParseError.check(stack, t, "Never opened")
                 begin = stack.pop()
-                braces[begin] = i
+
+                if not (stack and stack[-1] == FSTRING_START):
+                    braces[begin] = i
 
                 b = tokens[begin].string
                 ParseError.check(b == inv, t, f"Mismatched braces '{b}' at {begin}")
+        elif FSTRING_START and t.type == FSTRING_START:
+            stack.append(FSTRING_START)
+        elif FSTRING_END and t.type == FSTRING_END:
+            ParseError.check(
+                stack.pop() == FSTRING_START, t, "Mismatched FSTRING_START/FSTRING_END"
+            )
 
     if tokens:
         ParseError.check(not stack, t, "Left open")

--- a/tools/linter/adapters/set_linter.py
+++ b/tools/linter/adapters/set_linter.py
@@ -131,11 +131,7 @@ class TokenLine:
         return True
 
     def is_braced_set(self, begin: int, end: int) -> bool:
-        if (
-            begin + 1 == end
-            or self.tokens[begin].string != "{"
-            or self.tokens[begin - 1].type in _linter.FSTRING_TOKENS
-        ):
+        if begin + 1 == end or self.tokens[begin].string != "{":
             return False
         i = begin + 1
         empty = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143725

#143628 didn't handle a few cases right for example:
```py
$ python3 tools/linter/adapters/set_linter.py torch/_inductor/scheduler.py
torch/_inductor/scheduler.py:261:24: Builtin `set` is deprecated
  259 |                 multiline=False,
  260 |             )
  261 |         return f"{self}{data_str}"
                               ^
  262 |
  263 |     def log_details(self) -> None:

torch/_inductor/scheduler.py:261:33: Builtin `set` is deprecated
  259 |                 multiline=False,
  260 |             )
  261 |         return f"{self}{data_str}"
                                        ^
  262 |
  263 |     def log_details(self) -> None:
```
also multi-line fstrings