### PR TITLE
Apply clang-format for ATen/core/op_registration headers

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -61,6 +61,7 @@ include_patterns = [
     'aten/src/ATen/xpu/**/*.cpp',
     'aten/src/ATen/core/boxing/**/*.h',
     'aten/src/ATen/core/dispatch/**/*.h',
+    'aten/src/ATen/core/op_registration/**/*.h',
     'aten/src/ATen/native/mps/**/*.metal',
     'aten/src/ATen/native/mps/**/*.mm',
     'aten/src/ATen/native/mps/**/*.h',

--- a/aten/src/ATen/core/op_registration/adaption.h
+++ b/aten/src/ATen/core/op_registration/adaption.h
@@ -9,8 +9,8 @@
  * [Note: hacky wrapper removal for optional tensor]
  *
  * The kernel implementation takes an optional tensor marked in the schema as
- * Tensor? but the C++ function takes Tensor instead of the std::optional<Tensor>
- * expected by the dispatcher.
+ * Tensor? but the C++ function takes Tensor instead of the
+ * std::optional<Tensor> expected by the dispatcher.
  *
  * To remove the hacky wrapper, the C++ function is changed to take
  * std::optional<Tensor> and unwrap the Tensor value at the beginning of
@@ -42,9 +42,17 @@
 
 namespace c10::impl {
 
-TORCH_API void common_device_check_failure(Device common_device, const at::Tensor& tensor, at::CheckedFrom methodName, at::CheckedFrom argName);
+TORCH_API void common_device_check_failure(
+    Device common_device,
+    const at::Tensor& tensor,
+    at::CheckedFrom methodName,
+    at::CheckedFrom argName);
 
-inline void check_and_update_common_device(std::optional<Device>& common_device, const at::Tensor& tensor, at::CheckedFrom methodName, at::CheckedFrom argName) {
+inline void check_and_update_common_device(
+    std::optional<Device>& common_device,
+    const at::Tensor& tensor,
+    at::CheckedFrom methodName,
+    at::CheckedFrom argName) {
   // TODO: Remove this once the following issue is addressed:
   // https://github.com/pytorch/pytorch/issues/57380
   if (!tensor.defined()) {
@@ -61,19 +69,32 @@ inline void check_and_update_common_device(std::optional<Device>& common_device,
   }
 }
 
-inline void check_and_update_common_device(std::optional<Device>& common_device, const std::optional<at::Tensor>& tensor, at::CheckedFrom methodName, at::CheckedFrom argName) {
+inline void check_and_update_common_device(
+    std::optional<Device>& common_device,
+    const std::optional<at::Tensor>& tensor,
+    at::CheckedFrom methodName,
+    at::CheckedFrom argName) {
   if (tensor.has_value()) {
-    check_and_update_common_device(common_device, tensor.value(), methodName, argName);
+    check_and_update_common_device(
+        common_device, tensor.value(), methodName, argName);
   }
 }
 
-inline void check_and_update_common_device(std::optional<Device>& common_device, at::ITensorListRef tensors, at::CheckedFrom methodName, at::CheckedFrom argName) {
+inline void check_and_update_common_device(
+    std::optional<Device>& common_device,
+    at::ITensorListRef tensors,
+    at::CheckedFrom methodName,
+    at::CheckedFrom argName) {
   for (const auto& tensor : tensors) {
     check_and_update_common_device(common_device, tensor, methodName, argName);
   }
 }
 
-inline void check_and_update_common_device(std::optional<Device>& common_device, const List<std::optional<at::Tensor>>& tensors, at::CheckedFrom methodName, at::CheckedFrom argName) {
+inline void check_and_update_common_device(
+    std::optional<Device>& common_device,
+    const List<std::optional<at::Tensor>>& tensors,
+    at::CheckedFrom methodName,
+    at::CheckedFrom argName) {
   for (const auto& tensor : tensors) {
     check_and_update_common_device(common_device, tensor, methodName, argName);
   }

--- a/aten/src/ATen/core/op_registration/infer_schema.h
+++ b/aten/src/ATen/core/op_registration/infer_schema.h
@@ -20,78 +20,91 @@ struct ArgumentDef final {
   using GetTypeFn = TypePtr();
   GetTypeFn* getTypeFn;
   GetTypeFn* getFakeTypeFn;
-  constexpr ArgumentDef(): getTypeFn(nullptr), getFakeTypeFn(nullptr) {}
-  explicit constexpr ArgumentDef(GetTypeFn *getTypeFn, GetTypeFn *getFakeTypeFn): getTypeFn(getTypeFn), getFakeTypeFn(getFakeTypeFn) {}
+  constexpr ArgumentDef() : getTypeFn(nullptr), getFakeTypeFn(nullptr) {}
+  explicit constexpr ArgumentDef(GetTypeFn* getTypeFn, GetTypeFn* getFakeTypeFn)
+      : getTypeFn(getTypeFn), getFakeTypeFn(getFakeTypeFn) {}
 };
 
-template<bool V>
+template <bool V>
 struct bool_t {};
-template<> struct bool_t<true> : std::true_type {};
-template<> struct bool_t<false> : std::false_type {};
+template <>
+struct bool_t<true> : std::true_type {};
+template <>
+struct bool_t<false> : std::false_type {};
 
-/// Checks the static C++ types `Types` for correctness to catch common error cases.
+/// Checks the static C++ types `Types` for correctness to catch common error
+/// cases.
 template <class... Types>
 constexpr int checkStaticTypes() {
- // Give nice error messages for some of the common error cases.
- // Use a LOUD ERROR MESSAGE SO USERS SEE THE STATIC_ASSERT
- static_assert(std::conjunction<
-     bool_t<!std::is_integral_v<Types> || std::is_same_v<Types, int8_t> || std::is_same_v<Types, int64_t> || std::is_same_v<Types, bool>>...
-   >::value, "INVALID TYPE: Only int8_t, int64_t and bool are supported as an integral argument type");
- static_assert(std::conjunction<
-     bool_t<!std::is_same_v<Types, float>>...
-   >::value, "INVALID TYPE: float is not supported as an argument type, use double instead");
- return 0;
+  // Give nice error messages for some of the common error cases.
+  // Use a LOUD ERROR MESSAGE SO USERS SEE THE STATIC_ASSERT
+  static_assert(
+      std::conjunction<bool_t<
+          !std::is_integral_v<Types> || std::is_same_v<Types, int8_t> ||
+          std::is_same_v<Types, int64_t> ||
+          std::is_same_v<Types, bool>>...>::value,
+      "INVALID TYPE: Only int8_t, int64_t and bool are supported as an integral argument type");
+  static_assert(
+      std::conjunction<bool_t<!std::is_same_v<Types, float>>...>::value,
+      "INVALID TYPE: float is not supported as an argument type, use double instead");
+  return 0;
 }
 
 template <typename... Ts, size_t... Is>
-constexpr std::array<ArgumentDef, sizeof...(Ts)> createArgumentVectorFromTypes(std::index_sequence<Is...>) {
+constexpr std::array<ArgumentDef, sizeof...(Ts)> createArgumentVectorFromTypes(
+    std::index_sequence<Is...>) {
   return (
-    // Check types for common errors
-    checkStaticTypes<Ts...>(),
+      // Check types for common errors
+      checkStaticTypes<Ts...>(),
 
-    // Create the return value
-    std::array<ArgumentDef, sizeof...(Ts)>{
-      ArgumentDef(&getTypePtrCopy<std::decay_t<Ts>>, &getFakeTypePtrCopy<std::decay_t<Ts>>)...}
-  );
+      // Create the return value
+      std::array<ArgumentDef, sizeof...(Ts)>{ArgumentDef(
+          &getTypePtrCopy<std::decay_t<Ts>>,
+          &getFakeTypePtrCopy<std::decay_t<Ts>>)...});
 }
 
-/// Creates a vector of `ArgumentDef` from a list of C++ types that are specified
-/// as template arguments.
-template<class ParameterTypes> struct createArguments final {};
-template<class... ParameterTypes>
+/// Creates a vector of `ArgumentDef` from a list of C++ types that are
+/// specified as template arguments.
+template <class ParameterTypes>
+struct createArguments final {};
+template <class... ParameterTypes>
 struct createArguments<guts::typelist::typelist<ParameterTypes...>> final {
   static constexpr std::array<ArgumentDef, sizeof...(ParameterTypes)> call() {
     return createArgumentVectorFromTypes<ParameterTypes...>(
-        std::make_index_sequence<sizeof...(ParameterTypes)>()
-    );
+        std::make_index_sequence<sizeof...(ParameterTypes)>());
   }
 };
 
-/// Creates a vector of `ArgumentDef` from a list of C++ types that are specified
-/// as a tuple (i.e. in the way c10 kernels return values).
-/// It can be a tuple<A, B, C> if there's three output arguments with types A, B, C.
-/// It can be an empty tuple<>, or void for kernels that don't return anything.
-/// It can be a single type A (i.e. no tuple) for the case where a kernel just
+/// Creates a vector of `ArgumentDef` from a list of C++ types that are
+/// specified as a tuple (i.e. in the way c10 kernels return values). It can be
+/// a tuple<A, B, C> if there's three output arguments with types A, B, C. It
+/// can be an empty tuple<>, or void for kernels that don't return anything. It
+/// can be a single type A (i.e. no tuple) for the case where a kernel just
 /// returns one value.
-template<class ReturnTypeTuple, class Enable = void> struct createReturns final {};
+template <class ReturnTypeTuple, class Enable = void>
+struct createReturns final {};
 
-template<class... ReturnTypes>
+template <class... ReturnTypes>
 struct createReturns<std::tuple<ReturnTypes...>, void> final {
   static constexpr std::array<ArgumentDef, sizeof...(ReturnTypes)> call() {
     return createArgumentVectorFromTypes<ReturnTypes...>(
-        std::make_index_sequence<sizeof...(ReturnTypes)>()
-    );
+        std::make_index_sequence<sizeof...(ReturnTypes)>());
   }
 };
 
-template<class ReturnType>
-struct createReturns<ReturnType, std::enable_if_t<!std::is_same_v<void, ReturnType> && !guts::is_instantiation_of<std::tuple, ReturnType>::value>> final {
+template <class ReturnType>
+struct createReturns<
+    ReturnType,
+    std::enable_if_t<
+        !std::is_same_v<void, ReturnType> &&
+        !guts::is_instantiation_of<std::tuple, ReturnType>::value>>
+    final {
   static constexpr std::array<ArgumentDef, 1> call() {
     return createReturns<std::tuple<ReturnType>>::call();
   }
 };
 
-template<>
+template <>
 struct createReturns<void, void> final {
   static constexpr std::array<ArgumentDef, 0> call() {
     return createReturns<std::tuple<>>::call();
@@ -101,57 +114,74 @@ struct createReturns<void, void> final {
 template <typename ReturnType>
 struct createSingleReturn {
   static constexpr std::array<ArgumentDef, 1> call() {
-    return createArgumentVectorFromTypes<ReturnType>(std::make_index_sequence<1>());
+    return createArgumentVectorFromTypes<ReturnType>(
+        std::make_index_sequence<1>());
   }
 };
 
-TORCH_API FunctionSchema make_function_schema(std::string&& name, std::string&& overload_name, c10::ArrayRef<ArgumentDef> arguments, c10::ArrayRef<ArgumentDef> returns);
-TORCH_API FunctionSchema make_function_schema(c10::ArrayRef<ArgumentDef> arguments, c10::ArrayRef<ArgumentDef> returns);
+TORCH_API FunctionSchema make_function_schema(
+    std::string&& name,
+    std::string&& overload_name,
+    c10::ArrayRef<ArgumentDef> arguments,
+    c10::ArrayRef<ArgumentDef> returns);
+TORCH_API FunctionSchema make_function_schema(
+    c10::ArrayRef<ArgumentDef> arguments,
+    c10::ArrayRef<ArgumentDef> returns);
 
 /// Creates a `FunctionSchema` object from a `FunctionTraits` type for a
 /// function. Flattens std::tuple returns into multiple return types
 template <typename FunctionTraits>
 FunctionSchema createFunctionSchemaFromTraitsFlattenedReturns() {
- using ReturnType = typename FunctionTraits::return_type;
- using ParameterTypes = typename FunctionTraits::parameter_types;
+  using ReturnType = typename FunctionTraits::return_type;
+  using ParameterTypes = typename FunctionTraits::parameter_types;
 
- // arguments and returns are computed into a std::array at compile time and embedded into the binary.
- // The only code executed at runtime here is the one that creates a std::vector
- // of the arguments/returns from the std::array.
- constexpr auto arguments = createArguments<ParameterTypes>::call();
- constexpr auto returns = createReturns<ReturnType>::call();
+  // arguments and returns are computed into a std::array at compile time and
+  // embedded into the binary. The only code executed at runtime here is the one
+  // that creates a std::vector of the arguments/returns from the std::array.
+  constexpr auto arguments = createArguments<ParameterTypes>::call();
+  constexpr auto returns = createReturns<ReturnType>::call();
 
- return make_function_schema(arguments, returns);
+  return make_function_schema(arguments, returns);
 }
 
 /// Creates a `FunctionSchema` object from a `FunctionTraits` type for a
 /// function. Preserves std::tuple returns as a Tuple return type
 template <typename FunctionTraits>
-FunctionSchema createFunctionSchemaFromTraitsSingleReturn(std::string&& name, std::string&& overload_name) {
- using ReturnType = typename FunctionTraits::return_type;
- using ParameterTypes = typename FunctionTraits::parameter_types;
+FunctionSchema createFunctionSchemaFromTraitsSingleReturn(
+    std::string&& name,
+    std::string&& overload_name) {
+  using ReturnType = typename FunctionTraits::return_type;
+  using ParameterTypes = typename FunctionTraits::parameter_types;
 
- // arguments and returns are computed into a std::array at compile time and embedded into the binary.
- // The only code executed at runtime here is the one that creates a std::vector
- // of the arguments/returns from the std::array.
- constexpr auto arguments = createArguments<ParameterTypes>::call();
- constexpr auto returns = createSingleReturn<ReturnType>::call();
+  // arguments and returns are computed into a std::array at compile time and
+  // embedded into the binary. The only code executed at runtime here is the one
+  // that creates a std::vector of the arguments/returns from the std::array.
+  constexpr auto arguments = createArguments<ParameterTypes>::call();
+  constexpr auto returns = createSingleReturn<ReturnType>::call();
 
- return make_function_schema(std::move(name), std::move(overload_name), arguments, returns);
+  return make_function_schema(
+      std::move(name), std::move(overload_name), arguments, returns);
 }
 
-}
+} // namespace detail::infer_schema
 
-template<class FuncType>
+template <class FuncType>
 FunctionSchema inferFunctionSchemaFlattenedReturns() {
-  return detail::infer_schema::createFunctionSchemaFromTraitsFlattenedReturns<guts::infer_function_traits_t<FuncType>>();
+  return detail::infer_schema::createFunctionSchemaFromTraitsFlattenedReturns<
+      guts::infer_function_traits_t<FuncType>>();
 }
 
-template<class FuncType>
-FunctionSchema inferFunctionSchemaSingleReturn(std::string&& name, std::string&& overload_name) {
-  return detail::infer_schema::createFunctionSchemaFromTraitsSingleReturn<guts::infer_function_traits_t<FuncType>>(std::move(name), std::move(overload_name));
+template <class FuncType>
+FunctionSchema inferFunctionSchemaSingleReturn(
+    std::string&& name,
+    std::string&& overload_name) {
+  return detail::infer_schema::createFunctionSchemaFromTraitsSingleReturn<
+      guts::infer_function_traits_t<FuncType>>(
+      std::move(name), std::move(overload_name));
 }
 
-TORCH_API std::optional<std::string> findSchemaDifferences(const FunctionSchema& inferred, const FunctionSchema& specified);
+TORCH_API std::optional<std::string> findSchemaDifferences(
+    const FunctionSchema& inferred,
+    const FunctionSchema& specified);
 
-}
+} // namespace c10

--- a/aten/src/ATen/core/op_registration/op_allowlist.h
+++ b/aten/src/ATen/core/op_registration/op_allowlist.h
@@ -25,10 +25,9 @@
  * will fail (and the operator will be included in the binary anyway).
  */
 
-#include <c10/util/string_view.h>
 #include <c10/core/DispatchKey.h>
 #include <c10/macros/Macros.h>
-
+#include <c10/util/string_view.h>
 
 #if defined(ENABLE_RECORD_KERNEL_FUNCTION_DTYPE)
 #include <ATen/record_function.h>
@@ -36,7 +35,9 @@
 
 namespace c10::impl {
 
-constexpr bool allowlist_contains(string_view allowlist, string_view item);  // Forward Declare
+constexpr bool allowlist_contains(
+    string_view allowlist,
+    string_view item); // Forward Declare
 
 /**
  * In selective build mode returns true/false depending on whether a build
@@ -52,9 +53,7 @@ constexpr bool is_build_feature_available(const char* name) {
   (void)name;
   return true;
 #else
-  return allowlist_contains(
-    C10_STRINGIZE(TORCH_BUILD_FEATURE_ALLOWLIST),
-    name);
+  return allowlist_contains(C10_STRINGIZE(TORCH_BUILD_FEATURE_ALLOWLIST), name);
 #endif
 
 #else
@@ -64,7 +63,8 @@ constexpr bool is_build_feature_available(const char* name) {
 #endif
 }
 
-[[noreturn]] void build_feature_required_feature_not_available(const char* feature);
+[[noreturn]] void build_feature_required_feature_not_available(
+    const char* feature);
 
 /**
  * Use BUILD_FEATURE_REQUIRED macro in user-code.
@@ -77,50 +77,49 @@ constexpr bool is_build_feature_available(const char* name) {
  * In instrumenting mode (tracing mode), registers (as a side effect)
  * the presence of this specific build feature being triggered.
  */
-#if !defined(ENABLE_RECORD_KERNEL_FUNCTION_DTYPE)  // selective build mode
+#if !defined(ENABLE_RECORD_KERNEL_FUNCTION_DTYPE) // selective build mode
 
 #if defined(TORCH_BUILD_FEATURE_ALLOWLIST)
 #define BUILD_FEATURE_REQUIRED(NAME)                                 \
   if (!c10::impl::is_build_feature_available(NAME)) {                \
     ::c10::impl::build_feature_required_feature_not_available(NAME); \
   }
-#else  // Everything trivially selected
+#else // Everything trivially selected
 #define BUILD_FEATURE_REQUIRED(NAME)
 
 #endif
 
-#else  // trace mode
-#define BUILD_FEATURE_REQUIRED(NAME)  \
-  RECORD_FUNCTION_WITH_SCOPE(         \
-      at::RecordScope::BUILD_FEATURE, \
-      std::string(NAME),              \
-      {});
+#else // trace mode
+#define BUILD_FEATURE_REQUIRED(NAME) \
+  RECORD_FUNCTION_WITH_SCOPE(        \
+      at::RecordScope::BUILD_FEATURE, std::string(NAME), {});
 #endif
 
 // Use this macro, and not is_build_feature_available
-#define BUILD_FEATURE_AVAILABLE(NAME) ::c10::impl::is_build_feature_available(NAME)
+#define BUILD_FEATURE_AVAILABLE(NAME) \
+  ::c10::impl::is_build_feature_available(NAME)
 
 // returns true iff allowlist contains item
 // allowlist_contains("a;bc;d", "bc") == true
 constexpr bool allowlist_contains(string_view allowlist, string_view item) {
-    //Choose a really big value for next so that if something goes wrong
-    //this code will blow up in a hopefully detectable way.
-    size_t next = std::numeric_limits<size_t>::max();
-    for (size_t cur = 0; cur <= allowlist.size(); cur = next) {
-      next = allowlist.find(';', cur);
-      if (next != string_view::npos) {
-        if (allowlist.substr(cur, next - cur).compare(item) == 0) {
-          return true;
-        }
-        next++;
-      } else {
-        if (allowlist.substr(cur).compare(item) == 0) {
-          return true;
-        }
-        break;
+  // Choose a really big value for next so that if something goes wrong
+  // this code will blow up in a hopefully detectable way.
+  size_t next = std::numeric_limits<size_t>::max();
+  for (size_t cur = 0; cur <= allowlist.size(); cur = next) {
+    next = allowlist.find(';', cur);
+    if (next != string_view::npos) {
+      if (allowlist.substr(cur, next - cur).compare(item) == 0) {
+        return true;
       }
+      next++;
+    } else {
+      if (allowlist.substr(cur).compare(item) == 0) {
+        return true;
+      }
+      break;
     }
-    return false;
+  }
+  return false;
 }
 
 // Returns true iff the given op name is on the allowlist
@@ -137,14 +136,14 @@ constexpr bool op_allowlist_check(string_view op_name [[maybe_unused]]) {
   return true;
 #else
   return allowlist_contains(
-    C10_STRINGIZE(TORCH_OPERATOR_WHITELIST),
-    // This function is majorly used for mobile selective build with
-    // root operators, where the overload is included in the allowlist.
-    op_name);
-    // // Strip overload name (as allowlist doesn't contain overloads)
-    // // Another function based on this may be added when there's usage
-    // // on op names without overload.
-    // OperatorNameView::parse(op_name).name);
+      C10_STRINGIZE(TORCH_OPERATOR_WHITELIST),
+      // This function is majorly used for mobile selective build with
+      // root operators, where the overload is included in the allowlist.
+      op_name);
+  // // Strip overload name (as allowlist doesn't contain overloads)
+  // // Another function based on this may be added when there's usage
+  // // on op names without overload.
+  // OperatorNameView::parse(op_name).name);
 #endif
 }
 
@@ -168,14 +167,15 @@ constexpr bool custom_class_allowlist_check(string_view custom_class_name) {
   return true;
 #else
   return allowlist_contains(
-    C10_STRINGIZE(TORCH_CUSTOM_CLASS_ALLOWLIST),
-    custom_class_name);
+      C10_STRINGIZE(TORCH_CUSTOM_CLASS_ALLOWLIST), custom_class_name);
 #endif
 }
 
-// schema_allowlist_check() implicitly depends on a macro, TORCH_OPERATOR_WHITELIST.
-// Add this API to pass arbitrary allowlist.
-constexpr bool op_allowlist_contains_name_in_schema(string_view allowlist, string_view schema) {
+// schema_allowlist_check() implicitly depends on a macro,
+// TORCH_OPERATOR_WHITELIST. Add this API to pass arbitrary allowlist.
+constexpr bool op_allowlist_contains_name_in_schema(
+    string_view allowlist,
+    string_view schema) {
   return allowlist_contains(allowlist, schema.substr(0, schema.find("(")));
 }
 
@@ -187,7 +187,9 @@ constexpr bool dispatch_key_allowlist_check(DispatchKey /*k*/) {
 #ifdef C10_MOBILE
   return true;
   // Disabled for now: to be enabled later!
-  // return k == DispatchKey::CPU || k == DispatchKey::Vulkan || k == DispatchKey::QuantizedCPU || k == DispatchKey::BackendSelect || k == DispatchKey::CatchAll;
+  // return k == DispatchKey::CPU || k == DispatchKey::Vulkan || k ==
+  // DispatchKey::QuantizedCPU || k == DispatchKey::BackendSelect || k ==
+  // DispatchKey::CatchAll;
 #else
   return true;
 #endif

--- a/aten/src/ATen/core/op_registration/op_registration.h
+++ b/aten/src/ATen/core/op_registration/op_registration.h
@@ -5,13 +5,13 @@
  * functionality needed to do so for you.
  */
 
-#include <c10/core/DispatchKey.h>
-#include <c10/core/DispatchKeySet.h>
-#include <c10/core/CompileTimeFunctionPointer.h>
 #include <ATen/core/boxing/KernelFunction.h>
 #include <ATen/core/dispatch/CppSignature.h>
 #include <ATen/core/dispatch/RegistrationHandleRAII.h>
 #include <ATen/core/op_registration/infer_schema.h>
+#include <c10/core/CompileTimeFunctionPointer.h>
+#include <c10/core/DispatchKey.h>
+#include <c10/core/DispatchKeySet.h>
 #if defined(EXPOSE_C2_OPS) || !defined(CAFFE2_IS_XPLAT_BUILD)
 #include <torch/csrc/jit/frontend/function_schema_parser.h>
 #endif
@@ -20,16 +20,18 @@
 namespace c10 {
 
 namespace detail {
-// The first argument of the schema might be of type DispatchKeySet, in which case we remove it.
-// We do this because every argument in a function schema is expected to be convertable
-// to an ivalue, but DispatchKeySet is not a type we want the jit to be aware of.
-// See Note [Plumbing Keys Through The Dispatcher]
-template<class KernelFunctor>
+// The first argument of the schema might be of type DispatchKeySet, in which
+// case we remove it. We do this because every argument in a function schema is
+// expected to be convertable to an ivalue, but DispatchKeySet is not a type we
+// want the jit to be aware of. See Note [Plumbing Keys Through The Dispatcher]
+template <class KernelFunctor>
 std::unique_ptr<FunctionSchema> inferFunctionSchemaFromFunctor() {
-  using func_type = typename c10::remove_DispatchKeySet_arg_from_func<KernelFunctor>::func_type;
-  return std::make_unique<FunctionSchema>(inferFunctionSchemaFlattenedReturns<func_type>());
+  using func_type = typename c10::remove_DispatchKeySet_arg_from_func<
+      KernelFunctor>::func_type;
+  return std::make_unique<FunctionSchema>(
+      inferFunctionSchemaFlattenedReturns<func_type>());
 }
-}
+} // namespace detail
 
 /**
  * An instance of this class handles the registration for one or more operators.
@@ -51,7 +53,7 @@ std::unique_ptr<FunctionSchema> inferFunctionSchemaFromFunctor() {
  * >         .kernel<my_kernel_cpu>(DispatchKey::CPU));
  */
 class TORCH_API RegisterOperators final {
-public:
+ public:
   RegisterOperators() = default;
   ~RegisterOperators() = default;
 
@@ -61,29 +63,39 @@ public:
   RegisterOperators& operator=(RegisterOperators&&) noexcept = default;
 
   class TORCH_API Options final {
-  public:
+   public:
     Options(const Options&) = delete;
     Options(Options&&) noexcept = delete;
     Options& operator=(const Options&) = delete;
     Options& operator=(Options&&) noexcept = delete;
 
     // internal-only for registering stack based kernels
-    template<KernelFunction::BoxedKernelFunction* kernel_func>
+    template <KernelFunction::BoxedKernelFunction* kernel_func>
     Options&& kernel(DispatchKey dispatch_key) && {
-      return std::move(*this).kernel(dispatch_key, KernelFunction::makeFromBoxedFunction<kernel_func>(), std::nullopt, nullptr);
+      return std::move(*this).kernel(
+          dispatch_key,
+          KernelFunction::makeFromBoxedFunction<kernel_func>(),
+          std::nullopt,
+          nullptr);
     }
 
     // internal-only for registering stack based catch-all kernels
-    template<KernelFunction::BoxedKernelFunction* kernel_func>
+    template <KernelFunction::BoxedKernelFunction* kernel_func>
     Options&& catchAllKernel() && {
-      return std::move(*this).kernel(std::nullopt, KernelFunction::makeFromBoxedFunction<kernel_func>(), std::nullopt, nullptr);
+      return std::move(*this).kernel(
+          std::nullopt,
+          KernelFunction::makeFromBoxedFunction<kernel_func>(),
+          std::nullopt,
+          nullptr);
     }
 
     // internal only for registering caffe2 ops
     Options&& schema(FunctionSchema&& schema) {
-        TORCH_CHECK(!schemaOrName_.has_value(), "You can only specify the schema once per operator registration.");
-        schemaOrName_ = FunctionSchema(std::move(schema));
-        return std::move(*this);
+      TORCH_CHECK(
+          !schemaOrName_.has_value(),
+          "You can only specify the schema once per operator registration.");
+      schemaOrName_ = FunctionSchema(std::move(schema));
+      return std::move(*this);
     }
 
     /**
@@ -107,21 +119,27 @@ public:
      * >         .kernel<my_kernel_cpu>(DispatchKey::CPU));
      */
     Options&& schema(const std::string& schemaOrName) {
-      TORCH_CHECK(!schemaOrName_.has_value(), "Tried to register operator ", schemaOrName," but specified schema multiple times. You can only specify the schema once per operator registration.");
+      TORCH_CHECK(
+          !schemaOrName_.has_value(),
+          "Tried to register operator ",
+          schemaOrName,
+          " but specified schema multiple times. You can only specify the schema once per operator registration.");
 
-      #if !defined(EXPOSE_C2_OPS) && defined(CAFFE2_IS_XPLAT_BUILD)
-        throw std::logic_error("Tried to register operator " + schemaOrName + ". We don't support registering c10 ops on mobile yet because the function schema parser isn't present in the mobile build.");
-      #else
-        schemaOrName_ = torch::jit::parseSchemaOrName(schemaOrName);
-      #endif
+#if !defined(EXPOSE_C2_OPS) && defined(CAFFE2_IS_XPLAT_BUILD)
+      throw std::logic_error(
+          "Tried to register operator " + schemaOrName +
+          ". We don't support registering c10 ops on mobile yet because the function schema parser isn't present in the mobile build.");
+#else
+      schemaOrName_ = torch::jit::parseSchemaOrName(schemaOrName);
+#endif
 
       return std::move(*this);
     }
 
     /**
-     * Use this to register an operator whose kernel is implemented as a functor.
-     * The kernel is only called for inputs matching the given dispatch key.
-     * You can register multiple kernels for different dispatch keys.
+     * Use this to register an operator whose kernel is implemented as a
+     * functor. The kernel is only called for inputs matching the given dispatch
+     * key. You can register multiple kernels for different dispatch keys.
      *
      * Example:
      *
@@ -144,8 +162,8 @@ public:
      * > namespace {
      * >   class my_kernel_cpu final : public c10::OperatorKernel {
      * >   public:
-     * >     explicit my_kernel_cpu(std::string some_configuration, int a, bool b)
-     * >         : ... {...}
+     * >     explicit my_kernel_cpu(std::string some_configuration, int a, bool
+     * b) >         : ... {...}
      * >
      * >     Tensor operator()(Tensor a, Tensor b) {...}
      * >   };
@@ -154,26 +172,35 @@ public:
      * > static auto registry = c10::RegisterOperators()
      * >     .op(c10::RegisterOperators::options()
      * >         .schema("my_op")
-     * >         .kernel<my_kernel_cpu>(DispatchKey::CPU, "some_configuration", 3, true));
+     * >         .kernel<my_kernel_cpu>(DispatchKey::CPU, "some_configuration",
+     * 3, true));
      */
-    template<class KernelFunctor, class... ConstructorParameters>
+    template <class KernelFunctor, class... ConstructorParameters>
     // enable_if: only enable it if KernelFunctor is actually a functor
-    std::enable_if_t<guts::is_functor<KernelFunctor>::value, Options&&> kernel(DispatchKey dispatch_key, ConstructorParameters&&... constructorParameters) && {
-      static_assert(std::is_base_of_v<OperatorKernel, KernelFunctor>, "Tried to register a kernel functor using the kernel<Functor>() API, but it doesn't inherit from c10::OperatorKernel. Please have the functor inherit from it.");
-      static_assert(std::is_constructible_v<KernelFunctor, ConstructorParameters...>, "Wrong argument list for constructor of kernel functor. The arguments to kernel<Functor>(arguments...) must match one of the constructors of Functor.");
+    std::enable_if_t<guts::is_functor<KernelFunctor>::value, Options&&> kernel(
+        DispatchKey dispatch_key,
+        ConstructorParameters&&... constructorParameters) && {
+      static_assert(
+          std::is_base_of_v<OperatorKernel, KernelFunctor>,
+          "Tried to register a kernel functor using the kernel<Functor>() API, but it doesn't inherit from c10::OperatorKernel. Please have the functor inherit from it.");
+      static_assert(
+          std::is_constructible_v<KernelFunctor, ConstructorParameters...>,
+          "Wrong argument list for constructor of kernel functor. The arguments to kernel<Functor>(arguments...) must match one of the constructors of Functor.");
 
       return std::move(*this).kernel(
-        dispatch_key,
-        KernelFunction::makeFromUnboxedFunctor<false, KernelFunctor>(std::make_unique<KernelFunctor>(std::forward<ConstructorParameters>(constructorParameters)...)),
-        impl::CppSignature::make<KernelFunctor>(),
-        detail::inferFunctionSchemaFromFunctor<KernelFunctor>()
-      );
+          dispatch_key,
+          KernelFunction::makeFromUnboxedFunctor<false, KernelFunctor>(
+              std::make_unique<KernelFunctor>(
+                  std::forward<ConstructorParameters>(
+                      constructorParameters)...)),
+          impl::CppSignature::make<KernelFunctor>(),
+          detail::inferFunctionSchemaFromFunctor<KernelFunctor>());
     }
 
     /**
-     * Use this to register an operator whose kernel is implemented as a functor.
-     * The kernel is a catch-all kernel, meaning it's called independent from
-     * the input. Dispatch is disabled for this operator.
+     * Use this to register an operator whose kernel is implemented as a
+     * functor. The kernel is a catch-all kernel, meaning it's called
+     * independent from the input. Dispatch is disabled for this operator.
      *
      * Example:
      *
@@ -196,8 +223,8 @@ public:
      * > namespace {
      * >   class my_kernel_cpu final : public c10::OperatorKernel {
      * >   public:
-     * >     explicit my_kernel_cpu(std::string some_configuration, int a, bool b)
-     * >         : ... {...}
+     * >     explicit my_kernel_cpu(std::string some_configuration, int a, bool
+     * b) >         : ... {...}
      * >
      * >     Tensor operator()(Tensor a, Tensor b) {...}
      * >   };
@@ -208,24 +235,32 @@ public:
      * >         .schema("my_op")
      * >         .catchAllKernel<my_kernel_cpu>("some_configuration", 3, true));
      */
-    template<class KernelFunctor, class... ConstructorParameters>
+    template <class KernelFunctor, class... ConstructorParameters>
     // enable_if: only enable it if KernelFunctor is actually a functor
-    std::enable_if_t<guts::is_functor<KernelFunctor>::value, Options&&> catchAllKernel(ConstructorParameters&&... constructorParameters) && {
-      static_assert(std::is_base_of_v<OperatorKernel, KernelFunctor>, "Tried to register a kernel functor using the kernel<Functor>() API, but it doesn't inherit from c10::OperatorKernel. Please have the functor inherit from it.");
-      static_assert(std::is_constructible_v<KernelFunctor, ConstructorParameters...>, "Wrong argument list for constructor of kernel functor. The arguments to kernel<Functor>(arguments...) must match one of the constructors of Functor.");
+    std::enable_if_t<guts::is_functor<KernelFunctor>::value, Options&&>
+    catchAllKernel(ConstructorParameters&&... constructorParameters) && {
+      static_assert(
+          std::is_base_of_v<OperatorKernel, KernelFunctor>,
+          "Tried to register a kernel functor using the kernel<Functor>() API, but it doesn't inherit from c10::OperatorKernel. Please have the functor inherit from it.");
+      static_assert(
+          std::is_constructible_v<KernelFunctor, ConstructorParameters...>,
+          "Wrong argument list for constructor of kernel functor. The arguments to kernel<Functor>(arguments...) must match one of the constructors of Functor.");
 
       return std::move(*this).kernel(
-        std::nullopt,
-        KernelFunction::makeFromUnboxedFunctor<false, KernelFunctor>(std::make_unique<KernelFunctor>(std::forward<ConstructorParameters>(constructorParameters)...)),
-        impl::CppSignature::make<KernelFunctor>(),
-        detail::inferFunctionSchemaFromFunctor<KernelFunctor>()
-      );
+          std::nullopt,
+          KernelFunction::makeFromUnboxedFunctor<false, KernelFunctor>(
+              std::make_unique<KernelFunctor>(
+                  std::forward<ConstructorParameters>(
+                      constructorParameters)...)),
+          impl::CppSignature::make<KernelFunctor>(),
+          detail::inferFunctionSchemaFromFunctor<KernelFunctor>());
     }
 
     /**
-     * Use this to register an operator whose kernel is implemented by a function.
-     * The kernel is only called for inputs matching the given dispatch key.
-     * You can register multiple kernels for different dispatch keys.
+     * Use this to register an operator whose kernel is implemented by a
+     * function. The kernel is only called for inputs matching the given
+     * dispatch key. You can register multiple kernels for different dispatch
+     * keys.
      *
      * Example:
      *
@@ -234,27 +269,33 @@ public:
      * > static auto registry = c10::RegisterOperators()
      * >     .op(c10::RegisterOperators::options()
      * >         .schema("my_op")
-     * >         .kernel<decltype(my_kernel_cpu), &my_kernel_cpu>(DispatchKey::CPU));
+     * >         .kernel<decltype(my_kernel_cpu),
+     * &my_kernel_cpu>(DispatchKey::CPU));
      */
-    template<class FuncType, FuncType* kernel_func>
+    template <class FuncType, FuncType* kernel_func>
     // enable_if: only enable it if FuncType is actually a function
-    std::enable_if_t<guts::is_function_type<FuncType>::value, Options&&> kernel(DispatchKey dispatch_key) && {
-      static_assert(!std::is_same_v<FuncType, KernelFunction::BoxedKernelFunction>, "Tried to register a stackbased (i.e. internal) kernel function using the public kernel<...>() API. Please either use the internal kernel(...) API or also implement the kernel function as defined by the public API.");
-      static_assert(kernel_func != nullptr, "Kernel function cannot be nullptr");
+    std::enable_if_t<guts::is_function_type<FuncType>::value, Options&&> kernel(
+        DispatchKey dispatch_key) && {
+      static_assert(
+          !std::is_same_v<FuncType, KernelFunction::BoxedKernelFunction>,
+          "Tried to register a stackbased (i.e. internal) kernel function using the public kernel<...>() API. Please either use the internal kernel(...) API or also implement the kernel function as defined by the public API.");
+      static_assert(
+          kernel_func != nullptr, "Kernel function cannot be nullptr");
 
       return std::move(*this).kernel(
-        dispatch_key,
-        KernelFunction::makeFromUnboxedFunction(TORCH_FN(kernel_func)),
-        impl::CppSignature::make<FuncType>(),
-        // TODO Do schema inference without relying on WrapFunctionIntoFunctor
-        detail::inferFunctionSchemaFromFunctor<typename impl::WrapFunctionIntoFunctor<CompileTimeFunctionPointer<FuncType, kernel_func>>::type>()
-      );
+          dispatch_key,
+          KernelFunction::makeFromUnboxedFunction(TORCH_FN(kernel_func)),
+          impl::CppSignature::make<FuncType>(),
+          // TODO Do schema inference without relying on WrapFunctionIntoFunctor
+          detail::inferFunctionSchemaFromFunctor<
+              typename impl::WrapFunctionIntoFunctor<
+                  CompileTimeFunctionPointer<FuncType, kernel_func>>::type>());
     }
 
     /**
-     * Use this to register an operator whose kernel is implemented by a function.
-     * The kernel is a catch-all kernel, meaning it's called independent from
-     * the input. Dispatch is disabled for this operator.
+     * Use this to register an operator whose kernel is implemented by a
+     * function. The kernel is a catch-all kernel, meaning it's called
+     * independent from the input. Dispatch is disabled for this operator.
      *
      * Example:
      *
@@ -265,49 +306,63 @@ public:
      * >         .schema("my_op")
      * >         .catchAllKernel<decltype(my_kernel_cpu), &my_kernel_cpu>());
      */
-    template<class FuncType, FuncType* kernel_func>
+    template <class FuncType, FuncType* kernel_func>
     // enable_if: only enable it if FuncType is actually a function
-    std::enable_if_t<guts::is_function_type<FuncType>::value, Options&&> catchAllKernel() && {
-      static_assert(!std::is_same_v<FuncType, KernelFunction::BoxedKernelFunction>, "Tried to register a stackbased (i.e. internal) kernel function using the public kernel<...>() API. Please either use the internal kernel(...) API or also implement the kernel function as defined by the public API.");
-      static_assert(kernel_func != nullptr, "Kernel function cannot be nullptr");
+    std::enable_if_t<guts::is_function_type<FuncType>::value, Options&&>
+    catchAllKernel() && {
+      static_assert(
+          !std::is_same_v<FuncType, KernelFunction::BoxedKernelFunction>,
+          "Tried to register a stackbased (i.e. internal) kernel function using the public kernel<...>() API. Please either use the internal kernel(...) API or also implement the kernel function as defined by the public API.");
+      static_assert(
+          kernel_func != nullptr, "Kernel function cannot be nullptr");
 
       return std::move(*this).kernel(
-        std::nullopt,
-        KernelFunction::makeFromUnboxedFunction(TORCH_FN(kernel_func)),
-        impl::CppSignature::make<FuncType>(),
-        // TODO Do schema inference without relying on WrapFunctionIntoFunctor
-        detail::inferFunctionSchemaFromFunctor<typename impl::WrapFunctionIntoFunctor<CompileTimeFunctionPointer<FuncType, kernel_func>>::type>()
-      );
+          std::nullopt,
+          KernelFunction::makeFromUnboxedFunction(TORCH_FN(kernel_func)),
+          impl::CppSignature::make<FuncType>(),
+          // TODO Do schema inference without relying on WrapFunctionIntoFunctor
+          detail::inferFunctionSchemaFromFunctor<
+              typename impl::WrapFunctionIntoFunctor<
+                  CompileTimeFunctionPointer<FuncType, kernel_func>>::type>());
     }
 
-    template<class FuncType>
+    template <class FuncType>
     // enable_if: only enable it if FuncType is actually a function
-    std::enable_if_t<guts::is_function_type<FuncType>::value, Options&&> kernel(DispatchKey dispatch_key, FuncType* kernel_func) && {
-      static_assert(!std::is_same_v<FuncType, KernelFunction::BoxedKernelFunction>, "Tried to register a stackbased (i.e. internal) kernel function using the public kernel<...>() API. Please either use the internal kernel(...) API or also implement the kernel function as defined by the public API.");
-      TORCH_INTERNAL_ASSERT(kernel_func != nullptr, "Kernel function cannot be nullptr");
+    std::enable_if_t<guts::is_function_type<FuncType>::value, Options&&> kernel(
+        DispatchKey dispatch_key,
+        FuncType* kernel_func) && {
+      static_assert(
+          !std::is_same_v<FuncType, KernelFunction::BoxedKernelFunction>,
+          "Tried to register a stackbased (i.e. internal) kernel function using the public kernel<...>() API. Please either use the internal kernel(...) API or also implement the kernel function as defined by the public API.");
+      TORCH_INTERNAL_ASSERT(
+          kernel_func != nullptr, "Kernel function cannot be nullptr");
 
       return std::move(*this).kernel(
-        dispatch_key,
-        KernelFunction::makeFromUnboxedRuntimeFunction(kernel_func),
-        impl::CppSignature::make<FuncType>(),
-        // TODO Do schema inference without relying on WrapFunctionIntoFunctor
-        detail::inferFunctionSchemaFromFunctor<impl::WrapFunctionIntoRuntimeFunctor<std::decay_t<FuncType>>>()
-      );
+          dispatch_key,
+          KernelFunction::makeFromUnboxedRuntimeFunction(kernel_func),
+          impl::CppSignature::make<FuncType>(),
+          // TODO Do schema inference without relying on WrapFunctionIntoFunctor
+          detail::inferFunctionSchemaFromFunctor<
+              impl::WrapFunctionIntoRuntimeFunctor<std::decay_t<FuncType>>>());
     }
 
-    template<class FuncType>
+    template <class FuncType>
     // enable_if: only enable it if FuncType is actually a function
-    std::enable_if_t<guts::is_function_type<FuncType>::value, Options&&> catchAllKernel(FuncType* kernel_func) && {
-      static_assert(!std::is_same_v<FuncType, KernelFunction::BoxedKernelFunction>, "Tried to register a stackbased (i.e. internal) kernel function using the public kernel<...>() API. Please either use the internal kernel(...) API or also implement the kernel function as defined by the public API.");
-      TORCH_INTERNAL_ASSERT(kernel_func != nullptr, "Kernel function cannot be nullptr");
+    std::enable_if_t<guts::is_function_type<FuncType>::value, Options&&>
+    catchAllKernel(FuncType* kernel_func) && {
+      static_assert(
+          !std::is_same_v<FuncType, KernelFunction::BoxedKernelFunction>,
+          "Tried to register a stackbased (i.e. internal) kernel function using the public kernel<...>() API. Please either use the internal kernel(...) API or also implement the kernel function as defined by the public API.");
+      TORCH_INTERNAL_ASSERT(
+          kernel_func != nullptr, "Kernel function cannot be nullptr");
 
       return std::move(*this).kernel(
-        std::nullopt,
-        KernelFunction::makeFromUnboxedRuntimeFunction(kernel_func),
-        impl::CppSignature::make<FuncType>(),
-        // TODO Do schema inference without relying on WrapFunctionIntoFunctor
-        detail::inferFunctionSchemaFromFunctor<impl::WrapFunctionIntoRuntimeFunctor<std::decay_t<FuncType>>>()
-      );
+          std::nullopt,
+          KernelFunction::makeFromUnboxedRuntimeFunction(kernel_func),
+          impl::CppSignature::make<FuncType>(),
+          // TODO Do schema inference without relying on WrapFunctionIntoFunctor
+          detail::inferFunctionSchemaFromFunctor<
+              impl::WrapFunctionIntoRuntimeFunctor<std::decay_t<FuncType>>>());
     }
 
     /**
@@ -326,29 +381,40 @@ public:
      * >         .schema("my_op")
      * >         .kernel(DispatchKey::CPU, [] (Tensor a) -> Tensor {...}));
      */
-    template<class Lambda>
-    // enable_if: only enable it if Lambda is a functor (note: lambdas are functors)
+    template <class Lambda>
+    // enable_if: only enable it if Lambda is a functor (note: lambdas are
+    // functors)
     std::enable_if_t<
-        guts::is_functor<std::decay_t<Lambda>>::value
-        && !std::is_same<typename guts::infer_function_traits_t<std::decay_t<Lambda>>::func_type, KernelFunction::BoxedKernelFunction>::value,
-        Options&&> kernel(DispatchKey dispatch_key, Lambda&& functor) && {
-      static_assert(!std::is_base_of<OperatorKernel, std::decay_t<Lambda>>::value, "The kernel(x) API for registering a kernel is only meant to be used with lambdas. Your kernel is a functor. Please use the kernel<Functor>() API instead.");
+        guts::is_functor<std::decay_t<Lambda>>::value &&
+            !std::is_same<
+                typename guts::infer_function_traits_t<
+                    std::decay_t<Lambda>>::func_type,
+                KernelFunction::BoxedKernelFunction>::value,
+        Options&&>
+    kernel(DispatchKey dispatch_key, Lambda&& functor) && {
+      static_assert(
+          !std::is_base_of<OperatorKernel, std::decay_t<Lambda>>::value,
+          "The kernel(x) API for registering a kernel is only meant to be used with lambdas. Your kernel is a functor. Please use the kernel<Functor>() API instead.");
 
-      // We don't support stateful lambdas (i.e. lambdas with a capture), because their
-      // behavior would be nonobvious. A functor kernel with cache gets a new instance of
-      // its cache each time the kernel is looked up from the dispatch table.
-      // A lambda with a capture would be global and share its capture between all kernel lookups.
-      // So, instead of making users having to think about it (including the thread-safety
-      // issues this causes), let's just forbid stateful lambdas altogether.
-      static_assert(guts::is_stateless_lambda<std::decay_t<Lambda>>::value, "The kernel(x) API for registering a kernel only works for stateless lambdas (i.e. lambdas without captures). If you need a cache, please use the functor based API kernel<Functor>() instead.");
+      // We don't support stateful lambdas (i.e. lambdas with a capture),
+      // because their behavior would be nonobvious. A functor kernel with cache
+      // gets a new instance of its cache each time the kernel is looked up from
+      // the dispatch table. A lambda with a capture would be global and share
+      // its capture between all kernel lookups. So, instead of making users
+      // having to think about it (including the thread-safety issues this
+      // causes), let's just forbid stateful lambdas altogether.
+      static_assert(
+          guts::is_stateless_lambda<std::decay_t<Lambda>>::value,
+          "The kernel(x) API for registering a kernel only works for stateless lambdas (i.e. lambdas without captures). If you need a cache, please use the functor based API kernel<Functor>() instead.");
 
       return std::move(*this).kernel(
-        dispatch_key,
-        KernelFunction::makeFromUnboxedLambda(std::forward<Lambda>(functor)),
-        impl::CppSignature::make<Lambda>(),
-        // TODO Do schema inference without relying on WrapFunctionIntoRuntimeFunctor
-        detail::inferFunctionSchemaFromFunctor<impl::WrapFunctionIntoRuntimeFunctor<std::decay_t<Lambda>>>()
-      );
+          dispatch_key,
+          KernelFunction::makeFromUnboxedLambda(std::forward<Lambda>(functor)),
+          impl::CppSignature::make<Lambda>(),
+          // TODO Do schema inference without relying on
+          // WrapFunctionIntoRuntimeFunctor
+          detail::inferFunctionSchemaFromFunctor<
+              impl::WrapFunctionIntoRuntimeFunctor<std::decay_t<Lambda>>>());
     }
 
     /**
@@ -367,39 +433,55 @@ public:
      * >         .schema("my_op")
      * >         .catchAllKernel([] (Tensor a) -> Tensor {...}));
      */
-    template<class Lambda>
-    // enable_if: only enable it if Lambda is a functor (note: lambdas are functors)
+    template <class Lambda>
+    // enable_if: only enable it if Lambda is a functor (note: lambdas are
+    // functors)
     std::enable_if_t<
-        guts::is_functor<std::decay_t<Lambda>>::value
-        && !std::is_same<typename guts::infer_function_traits_t<std::decay_t<Lambda>>::func_type, KernelFunction::BoxedKernelFunction>::value,
-        Options&&> catchAllKernel(Lambda&& lambda) && {
-      static_assert(!std::is_base_of<OperatorKernel, std::decay_t<Lambda>>::value, "The kernel(x) API for registering a kernel is only meant to be used with lambdas. Your kernel is a functor. Please use the kernel<Functor>() API instead.");
+        guts::is_functor<std::decay_t<Lambda>>::value &&
+            !std::is_same<
+                typename guts::infer_function_traits_t<
+                    std::decay_t<Lambda>>::func_type,
+                KernelFunction::BoxedKernelFunction>::value,
+        Options&&>
+    catchAllKernel(Lambda&& lambda) && {
+      static_assert(
+          !std::is_base_of<OperatorKernel, std::decay_t<Lambda>>::value,
+          "The kernel(x) API for registering a kernel is only meant to be used with lambdas. Your kernel is a functor. Please use the kernel<Functor>() API instead.");
 
-      // We don't support stateful lambdas (i.e. lambdas with a capture), because their
-      // behavior would be nonobvious.
-      // A lambda with a capture would be global and share its capture between all kernel lookups.
-      // This would be a likely source for unexpected race conditions, so we forbid it.
-      // If a kernel really needs global state, they can just have regular global state
-      // in their .cpp file next to the kernel lambda.
-      static_assert(guts::is_stateless_lambda<std::decay_t<Lambda>>::value, "The kernel(x) API for registering a kernel only works for stateless lambdas (i.e. lambdas without captures). If you need a cache, please use the functor based API kernel<Functor>() instead.");
+      // We don't support stateful lambdas (i.e. lambdas with a capture),
+      // because their behavior would be nonobvious. A lambda with a capture
+      // would be global and share its capture between all kernel lookups. This
+      // would be a likely source for unexpected race conditions, so we forbid
+      // it. If a kernel really needs global state, they can just have regular
+      // global state in their .cpp file next to the kernel lambda.
+      static_assert(
+          guts::is_stateless_lambda<std::decay_t<Lambda>>::value,
+          "The kernel(x) API for registering a kernel only works for stateless lambdas (i.e. lambdas without captures). If you need a cache, please use the functor based API kernel<Functor>() instead.");
 
       return std::move(*this).kernel(
-        std::nullopt,
-        KernelFunction::makeFromUnboxedLambda(std::forward<Lambda>(lambda)),
-        impl::CppSignature::make<Lambda>(),
-        // TODO Do schema inference without relying on WrapFunctionIntoRuntimeFunctor
-        detail::inferFunctionSchemaFromFunctor<impl::WrapFunctionIntoRuntimeFunctor<std::decay_t<Lambda>>>()
-      );
+          std::nullopt,
+          KernelFunction::makeFromUnboxedLambda(std::forward<Lambda>(lambda)),
+          impl::CppSignature::make<Lambda>(),
+          // TODO Do schema inference without relying on
+          // WrapFunctionIntoRuntimeFunctor
+          detail::inferFunctionSchemaFromFunctor<
+              impl::WrapFunctionIntoRuntimeFunctor<std::decay_t<Lambda>>>());
     }
 
     Options&& aliasAnalysis(AliasAnalysisKind aliasAnalysisKind) && {
-      TORCH_CHECK(!aliasAnalysisKind_.has_value(), "You can only call aliasAnalysis() once per operator registration.");
+      TORCH_CHECK(
+          !aliasAnalysisKind_.has_value(),
+          "You can only call aliasAnalysis() once per operator registration.");
       aliasAnalysisKind_ = aliasAnalysisKind;
       return std::move(*this);
     }
 
-  private:
-    Options&& kernel(std::optional<DispatchKey> dispatch_key, KernelFunction&& func, std::optional<impl::CppSignature> cpp_signature, std::unique_ptr<FunctionSchema>&& inferred_function_schema) && {
+   private:
+    Options&& kernel(
+        std::optional<DispatchKey> dispatch_key,
+        KernelFunction&& func,
+        std::optional<impl::CppSignature> cpp_signature,
+        std::unique_ptr<FunctionSchema>&& inferred_function_schema) && {
       KernelRegistrationConfig config;
       config.dispatch_key = dispatch_key;
       config.func = std::move(func);
@@ -410,20 +492,18 @@ public:
     }
 
     Options()
-    : schemaOrName_(std::nullopt)
-    , kernels()
-    , aliasAnalysisKind_(std::nullopt)
-    {}
+        : schemaOrName_(std::nullopt),
+          kernels(),
+          aliasAnalysisKind_(std::nullopt) {}
 
     // KernelRegistrationConfig accumulates all information from the config
     // parameters passed to a RegisterOperators::op() call into one object.
     struct KernelRegistrationConfig final {
       KernelRegistrationConfig()
-        : dispatch_key(std::nullopt)
-        , func()
-        , cpp_signature(std::nullopt)
-        , inferred_function_schema(nullptr)
-      {}
+          : dispatch_key(std::nullopt),
+            func(),
+            cpp_signature(std::nullopt),
+            inferred_function_schema(nullptr) {}
 
       std::optional<DispatchKey> dispatch_key;
       KernelFunction func;
@@ -468,7 +548,9 @@ public:
    * specify the operator schema outside of the options parameter.
    * See class doc comment for examples.
    */
-  RegisterOperators&& op(const std::string& schemaOrName, Options&& options = RegisterOperators::options()) && {
+  RegisterOperators&& op(
+      const std::string& schemaOrName,
+      Options&& options = RegisterOperators::options()) && {
     return std::move(*this).op(std::move(options).schema(schemaOrName));
   }
 
@@ -477,10 +559,14 @@ public:
     return std::move(*this).op(std::move(options).schema(std::move(schema)));
   }
 
-  template<class FuncType>
-  explicit RegisterOperators(const std::string& schemaOrName, FuncType&& func, Options&& options = RegisterOperators::options())
-  : RegisterOperators() {
-    std::move(*this).op(schemaOrName, std::forward<FuncType>(func), std::move(options));
+  template <class FuncType>
+  explicit RegisterOperators(
+      const std::string& schemaOrName,
+      FuncType&& func,
+      Options&& options = RegisterOperators::options())
+      : RegisterOperators() {
+    std::move(*this).op(
+        schemaOrName, std::forward<FuncType>(func), std::move(options));
   }
 
   /**
@@ -516,72 +602,111 @@ public:
    * >     .op("my_op", c10::RegisterOperators::options()
    * >         .kernel<my_kernel_cpu>());
    */
-   template<class FuncType>
-   // enable_if: only enable it if FuncType is actually a function, but not a stack based BoxedKernelFunction.
-   std::enable_if_t<guts::is_function_type<FuncType>::value && !std::is_same_v<FuncType, KernelFunction::BoxedKernelFunction>, RegisterOperators&&>
-   op(const std::string& schemaOrName, FuncType* func, Options&& options = RegisterOperators::options()) && {
-     constexpr bool AllowLegacyTypes = true;
-     return std::move(*this).op(std::move(options).schema(schemaOrName).kernel(
-       std::nullopt,
-       KernelFunction::makeFromUnboxedRuntimeFunction<AllowLegacyTypes>(func),
-       impl::CppSignature::make<FuncType>(),
-       // TODO Do schema inference without relying on WrapFunctionIntoRuntimeFunctor
-       detail::inferFunctionSchemaFromFunctor<impl::WrapFunctionIntoRuntimeFunctor<std::decay_t<FuncType>>>()
-     ));
-   }
+  template <class FuncType>
+  // enable_if: only enable it if FuncType is actually a function, but not a
+  // stack based BoxedKernelFunction.
+  std::enable_if_t<
+      guts::is_function_type<FuncType>::value &&
+          !std::is_same_v<FuncType, KernelFunction::BoxedKernelFunction>,
+      RegisterOperators&&>
+  op(const std::string& schemaOrName,
+     FuncType* func,
+     Options&& options = RegisterOperators::options()) && {
+    constexpr bool AllowLegacyTypes = true;
+    return std::move(*this).op(
+        std::move(options)
+            .schema(schemaOrName)
+            .kernel(
+                std::nullopt,
+                KernelFunction::makeFromUnboxedRuntimeFunction<
+                    AllowLegacyTypes>(func),
+                impl::CppSignature::make<FuncType>(),
+                // TODO Do schema inference without relying on
+                // WrapFunctionIntoRuntimeFunctor
+                detail::inferFunctionSchemaFromFunctor<
+                    impl::WrapFunctionIntoRuntimeFunctor<
+                        std::decay_t<FuncType>>>()));
+  }
 
-   /**
-    * This API registers an operator based on a kernel lambda.
-    *
-    * This API looks like:
-    *
-    * > static auto registry = c10::RegisterOperators()
-    * >     .op("my_op", [] (Tensor a, Tensor b) {...});
-    *
-    * This is equivalent to:
-    *
-    * > static auto registry = c10::RegisterOperators()
-    * >     .op("my_op", c10::RegisterOperators::options()
-    * >         .catchAllKernel([] (Tensor a, Tensor b) {...}));
-    *
-    */
-    template<class Lambda>
-    // enable_if: only enable it if Lambda is actually a stateless lambda
-    std::enable_if_t<guts::is_functor<Lambda>::value && guts::is_stateless_lambda<std::decay_t<Lambda>>::value, RegisterOperators&&>
-    op(const std::string& schemaOrName, Lambda&& lambda, Options&& options = RegisterOperators::options()) && {
-      static_assert(!std::is_base_of_v<OperatorKernel, Lambda>, "c10::OperatorKernel is part of the new kernel registration API and shouldn't be used together with the deprecated registration API. Please use the new RegisterOperators::options().kernel() based API instead.");
+  /**
+   * This API registers an operator based on a kernel lambda.
+   *
+   * This API looks like:
+   *
+   * > static auto registry = c10::RegisterOperators()
+   * >     .op("my_op", [] (Tensor a, Tensor b) {...});
+   *
+   * This is equivalent to:
+   *
+   * > static auto registry = c10::RegisterOperators()
+   * >     .op("my_op", c10::RegisterOperators::options()
+   * >         .catchAllKernel([] (Tensor a, Tensor b) {...}));
+   *
+   */
+  template <class Lambda>
+  // enable_if: only enable it if Lambda is actually a stateless lambda
+  std::enable_if_t<
+      guts::is_functor<Lambda>::value &&
+          guts::is_stateless_lambda<std::decay_t<Lambda>>::value,
+      RegisterOperators&&>
+  op(const std::string& schemaOrName,
+     Lambda&& lambda,
+     Options&& options = RegisterOperators::options()) && {
+    static_assert(
+        !std::is_base_of_v<OperatorKernel, Lambda>,
+        "c10::OperatorKernel is part of the new kernel registration API and shouldn't be used together with the deprecated registration API. Please use the new RegisterOperators::options().kernel() based API instead.");
 
-      constexpr bool AllowLegacyTypes = true;
-      return std::move(*this).op(std::move(options).schema(schemaOrName).kernel(
-        std::nullopt,
-        KernelFunction::makeFromUnboxedLambda<AllowLegacyTypes>(std::forward<Lambda>(lambda)),
-        impl::CppSignature::make<Lambda>(),
-        // TODO Do schema inference without relying on WrapFunctionIntoRuntimeFunctor
-        detail::inferFunctionSchemaFromFunctor<impl::WrapFunctionIntoRuntimeFunctor<std::decay_t<Lambda>>>()
-      ));
-    }
+    constexpr bool AllowLegacyTypes = true;
+    return std::move(*this).op(
+        std::move(options)
+            .schema(schemaOrName)
+            .kernel(
+                std::nullopt,
+                KernelFunction::makeFromUnboxedLambda<AllowLegacyTypes>(
+                    std::forward<Lambda>(lambda)),
+                impl::CppSignature::make<Lambda>(),
+                // TODO Do schema inference without relying on
+                // WrapFunctionIntoRuntimeFunctor
+                detail::inferFunctionSchemaFromFunctor<
+                    impl::WrapFunctionIntoRuntimeFunctor<
+                        std::decay_t<Lambda>>>()));
+  }
 
-    template<class Lambda>
-    C10_DEPRECATED_MESSAGE("Registering operator kernels with stateful lambdas (i.e. lambdas with a capture) has non-obvious behavior. This is deprecated. Please use a lambda without a capture or a functor class instead.")
-    // enable_if: only enable it if Lambda is actually a functor but not a stateless lambda
-    std::enable_if_t<guts::is_functor<Lambda>::value && !guts::is_stateless_lambda<std::decay_t<Lambda>>::value, RegisterOperators&&>
-    op(const std::string& schemaOrName, Lambda&& lambda, Options&& options = RegisterOperators::options()) && {
-      static_assert(!std::is_base_of_v<OperatorKernel, Lambda>, "c10::OperatorKernel is part of the new kernel registration API and shouldn't be used together with the deprecated registration API. Please use the new RegisterOperators::options().kernel() based API instead.");
+  template <class Lambda>
+  C10_DEPRECATED_MESSAGE(
+      "Registering operator kernels with stateful lambdas (i.e. lambdas with a capture) has non-obvious behavior. This is deprecated. Please use a lambda without a capture or a functor class instead.")
+  // enable_if: only enable it if Lambda is actually a functor but not a
+  // stateless lambda
+  std::enable_if_t<
+      guts::is_functor<Lambda>::value &&
+          !guts::is_stateless_lambda<std::decay_t<Lambda>>::value,
+      RegisterOperators&&> op(const std::string& schemaOrName, Lambda&& lambda, Options&& options = RegisterOperators::options()) && {
+    static_assert(
+        !std::is_base_of_v<OperatorKernel, Lambda>,
+        "c10::OperatorKernel is part of the new kernel registration API and shouldn't be used together with the deprecated registration API. Please use the new RegisterOperators::options().kernel() based API instead.");
 
-      constexpr bool AllowLegacyTypes = true;
-      return std::move(*this).op(std::move(options).schema(schemaOrName).kernel(
-        std::nullopt,
-        KernelFunction::makeFromUnboxedLambda<AllowLegacyTypes>(std::forward<Lambda>(lambda)),
-        impl::CppSignature::make<Lambda>(),
-        // TODO Do schema inference without relying on WrapFunctionIntoRuntimeFunctor
-        detail::inferFunctionSchemaFromFunctor<impl::WrapFunctionIntoRuntimeFunctor<std::decay_t<Lambda>>>()
-      ));
-    }
+    constexpr bool AllowLegacyTypes = true;
+    return std::move(*this).op(
+        std::move(options)
+            .schema(schemaOrName)
+            .kernel(
+                std::nullopt,
+                KernelFunction::makeFromUnboxedLambda<AllowLegacyTypes>(
+                    std::forward<Lambda>(lambda)),
+                impl::CppSignature::make<Lambda>(),
+                // TODO Do schema inference without relying on
+                // WrapFunctionIntoRuntimeFunctor
+                detail::inferFunctionSchemaFromFunctor<
+                    impl::WrapFunctionIntoRuntimeFunctor<
+                        std::decay_t<Lambda>>>()));
+  }
 
-private:
+ private:
   void checkSchemaAndRegisterOp_(Options&& config);
 
-  static c10::FunctionSchema inferSchemaFromKernels_(const OperatorName& opNameStr, const Options& options);
+  static c10::FunctionSchema inferSchemaFromKernels_(
+      const OperatorName& opNameStr,
+      const Options& options);
   void checkNoDuplicateKernels_(const Options& options);
   void registerOp_(Options&& options);
 
@@ -591,6 +716,6 @@ private:
 } // namespace c10
 
 namespace torch {
-  // Old-style API
-  using RegisterOperators = c10::RegisterOperators;
-}
+// Old-style API
+using RegisterOperators = c10::RegisterOperators;
+} // namespace torch


### PR DESCRIPTION
Code change via add path config in `.lintrunner.toml` file and running

```bash
 $ lintrunner -a --take CLANGFORMAT --all-files
```

cc @malfet  