### PR TITLE
Enable fx_quantization for arm

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -435,6 +435,11 @@ at::QEngine Context::qEngine() const {
       qengine = at::kX86;
     }
 #endif
+
+#if defined(__aarch64__)
+    qengine = at::kArm;
+#endif//__aarch64__
+
     return qengine;
   }();
   return quantized_engine.value_or(_quantized_engine);
@@ -455,6 +460,9 @@ const std::vector<at::QEngine>& Context::supportedQEngines() {
     // Engines are listed in priority order: later one wins
     // By default we prefer FBGEMM if we're running on server side
     // QNNPACK on server side has some issue, so we disable it by default.
+#if defined(__aarch64__)
+    engines.push_back(at::kArm);
+#endif//__aarch64__
 #ifdef C10_MOBILE
     engines.push_back(at::kNoQEngine);
 #ifdef USE_PYTORCH_QNNPACK

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1200,9 +1200,20 @@ class QLinearLeakyReluInt8 final {
       double output_scale,
       int64_t output_zero_point,
       double negative_slope) {
-#if AT_MKLDNN_ENABLED() || !defined(STRIP_ERROR_MESSAGES)
+
     auto& ctx = at::globalContext();
-#endif
+#if  defined(__aarch64__)
+    if (ctx.qEngine() == at::QEngine::Arm) {
+      #if AT_MKLDNN_ENABLED()
+      return dynamic_cast<PackedLinearWeightsOnednn*>(packed_weight.get())->apply_leaky_relu(
+          std::move(input), output_scale, output_zero_point, negative_slope);
+      #endif
+      TORCH_CHECK(
+        false,
+        "linear_leaky_relu :: is not supported without ONEDNN in qengine",
+        toString(ctx.qEngine()));
+    }
+#endif//__aarch64__
 #if AT_MKLDNN_ENABLED()
     if (ctx.qEngine() == at::QEngine::ONEDNN) {
       return dynamic_cast<PackedLinearWeightsOnednn*>(packed_weight.get())->apply_leaky_relu(
@@ -1224,9 +1235,20 @@ class QLinearTanhInt8 final {
       const c10::intrusive_ptr<LinearPackedParamsBase>& packed_weight,
       double output_scale,
       int64_t output_zero_point) {
-#if AT_MKLDNN_ENABLED() || !defined(STRIP_ERROR_MESSAGES)
+
     auto& ctx = at::globalContext();
-#endif
+#if  defined(__aarch64__)
+      if (ctx.qEngine() == at::QEngine::Arm) {
+        #if AT_MKLDNN_ENABLED()
+          return dynamic_cast<PackedLinearWeightsOnednn*>(packed_weight.get())->apply_tanh(
+          std::move(input), output_scale, output_zero_point);
+        #endif
+        TORCH_CHECK(
+        false,
+        "linear_tanh :: is not supported without ONEDNN in qengine",
+        toString(ctx.qEngine()));
+    }
+#endif//__aarch64__
 #if AT_MKLDNN_ENABLED()
     if (ctx.qEngine() == at::QEngine::ONEDNN) {
       return dynamic_cast<PackedLinearWeightsOnednn*>(packed_weight.get())->apply_tanh(

--- a/c10/core/QEngine.h
+++ b/c10/core/QEngine.h
@@ -17,6 +17,7 @@ enum class QEngine : uint8_t {
   QNNPACK = 2,
   ONEDNN = 3,
   X86 = 4,
+  Arm = 5,
 };
 
 constexpr auto kNoQEngine = QEngine::NoQEngine;
@@ -24,6 +25,7 @@ constexpr auto kFBGEMM = QEngine::FBGEMM;
 constexpr auto kQNNPACK = QEngine::QNNPACK;
 constexpr auto kONEDNN = QEngine::ONEDNN;
 constexpr auto kX86 = QEngine::X86;
+constexpr auto kArm = QEngine::Arm;
 
 inline std::string toString(QEngine qengine) {
   switch (qengine) {
@@ -37,6 +39,8 @@ inline std::string toString(QEngine qengine) {
       return "ONEDNN";
     case kX86:
       return "X86";
+    case kArm:
+      return "Arm";
     default:
       TORCH_CHECK(
           false, "Unrecognized Quantized Engine: ", static_cast<int>(qengine));

--- a/torch/ao/quantization/backend_config/arm.py
+++ b/torch/ao/quantization/backend_config/arm.py
@@ -1,0 +1,121 @@
+import torch
+
+from ._common_operator_config_utils import (
+    _get_binary_op_configs,
+    _get_bn_configs,
+    _get_cat_config,
+    _get_conv_configs,
+    _get_default_op_configs,
+    _get_embedding_op_configs,
+    _get_fixed_qparams_op_configs,
+    _get_linear_configs,
+    _get_rnn_op_configs,
+    _get_share_qparams_op_configs,
+    _get_tensor_info_op_configs,
+)
+
+from .backend_config import BackendConfig, DTypeConfig
+
+
+__all__ = ["get_arm_backend_config",]
+# ===================
+# |  DTYPE CONFIGS  |
+# ===================
+
+
+arm_weighted_op_int8_dtype_config = DTypeConfig(
+    input_dtype=torch.quint8,
+    output_dtype=torch.quint8,
+    weight_dtype=torch.qint8,
+    bias_dtype=torch.float,
+)
+
+arm_default_op_quint8_dtype_config = DTypeConfig(
+    input_dtype=torch.quint8,
+    output_dtype=torch.quint8,
+)
+
+arm_default_op_fp16_dtype_config = DTypeConfig(
+    input_dtype=torch.float16,
+    output_dtype=torch.float16,
+    weight_dtype=torch.float16,
+    bias_dtype=torch.float16,
+)
+
+arm_default_dynamic_int8_dtype_config = DTypeConfig(
+    input_dtype=torch.quint8,
+    output_dtype=torch.float,
+    weight_dtype=torch.qint8,
+    bias_dtype=torch.float,
+    is_dynamic=True,
+)
+
+arm_default_dynamic_float16_dtype_config = DTypeConfig(
+    input_dtype=torch.float16,
+    output_dtype=torch.float,
+    weight_dtype=torch.float16,
+    bias_dtype=torch.float,
+    is_dynamic=True,
+)
+
+arm_weight_only_quint8_dtype_config = DTypeConfig(
+    input_dtype=torch.float,
+    output_dtype=torch.float,
+    weight_dtype=torch.quint8,
+)
+
+arm_weight_only_quint4x2_dtype_config = DTypeConfig(
+    input_dtype=torch.float,
+    output_dtype=torch.float,
+    weight_dtype=torch.quint4x2,
+)
+
+# =====================
+# |  BACKEND CONFIGS  |
+# =====================
+
+def get_arm_backend_config() -> BackendConfig:
+    """
+    Return the `BackendConfig` for PyTorch's native arm backend.
+    """
+    conv_dtype_configs = [arm_weighted_op_int8_dtype_config]
+    linear_dtype_configs = [
+        arm_weighted_op_int8_dtype_config,
+        arm_default_dynamic_int8_dtype_config,
+        arm_default_dynamic_float16_dtype_config,
+    ]
+    binary_op_dtype_configs = [arm_weighted_op_int8_dtype_config]
+    default_op_dtype_configs = [arm_default_op_quint8_dtype_config]
+    fixed_qparams_op_dtype_configs = [arm_weighted_op_int8_dtype_config]
+    share_qparams_op_dtype_configs = [arm_default_op_quint8_dtype_config]
+    tensor_info_op_dtype_configs = [arm_default_op_quint8_dtype_config]
+    rnn_op_dtype_configs = [
+        arm_default_dynamic_int8_dtype_config,
+        arm_default_dynamic_float16_dtype_config,
+    ]
+    embedding_op_dtype_configs = [
+        arm_weight_only_quint8_dtype_config,
+        arm_weight_only_quint4x2_dtype_config,
+    ]
+    return (
+        BackendConfig("arm")
+        .set_backend_pattern_configs(_get_conv_configs(conv_dtype_configs))
+        .set_backend_pattern_configs(_get_linear_configs(linear_dtype_configs))
+        .set_backend_pattern_configs(_get_binary_op_configs(binary_op_dtype_configs))
+        .set_backend_pattern_config(_get_cat_config(default_op_dtype_configs))
+        .set_backend_pattern_configs(_get_default_op_configs(default_op_dtype_configs))
+        .set_backend_pattern_configs(
+            _get_fixed_qparams_op_configs(fixed_qparams_op_dtype_configs)
+        )
+        .set_backend_pattern_configs(
+            _get_share_qparams_op_configs(share_qparams_op_dtype_configs)
+        )
+        .set_backend_pattern_configs(
+            _get_tensor_info_op_configs(tensor_info_op_dtype_configs)
+        )
+        .set_backend_pattern_configs(_get_bn_configs(default_op_dtype_configs))
+        .set_backend_pattern_configs(_get_rnn_op_configs(rnn_op_dtype_configs))
+        .set_backend_pattern_configs(
+            _get_embedding_op_configs(embedding_op_dtype_configs)
+        )
+    )

--- a/torch/backends/quantized/__init__.py
+++ b/torch/backends/quantized/__init__.py
@@ -18,6 +18,8 @@ def _get_qengine_id(qengine: str) -> int:
         ret = 3
     elif qengine == "x86":
         ret = 4
+    elif qengine == "arm":
+        ret = 5
     else:
         ret = -1
         raise RuntimeError(f"{qengine} is not a valid value for quantized engine")
@@ -26,7 +28,7 @@ def _get_qengine_id(qengine: str) -> int:
 
 # This function should correspond to the enums present in c10/core/QEngine.h
 def _get_qengine_str(qengine: int) -> str:
-    all_engines = {0: "none", 1: "fbgemm", 2: "qnnpack", 3: "onednn", 4: "x86"}
+    all_engines = {0: "none", 1: "fbgemm", 2: "qnnpack", 3: "onednn", 4: "x86", 5: "arm"}
     return all_engines.get(qengine, "*undefined")
 
 


### PR DESCRIPTION
FX Graph Mode Quantization (https://pytorch.org/docs/stable/quantization.html) is an automated quantization workflow in PyTorch and It improves upon Eager Mode Quantization by adding support for functionals and automating the quantization process.

Currently, this flow is enabled for CPU's only on x86 platforms.

**Goal of this PR:**
Enables FX Graph Mode Quantization for ARM CPU's

*This flow on ARM leverages ONEDNN kernels for computation and also picks the best pre-defined config for your choice/method of quantization.

*This PR also Introduces optimizations for few utility functions.
- Optimized utility functions (hsum, hsum_sq) using SIMD vectorization.

**Performance gain w.r.t Utility functions optimized:-**
 **At function level** -> We observe 2x performance boost w.r.t utility functions introduced in comparison to scalar implementation (current OSS Implementation)

**At Model level :-**
**Model :-** vit_b_16
**with scalar implementation** -> 26772 microsec.
**with vectorized implementation** -> 26002 microsec.   

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @malfet @snadampal @milpuz01