### PR TITLE
Enable onednn in pytorch for ppc64le architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,11 +180,14 @@ endif()
 
 set(CPU_AARCH64 OFF)
 set(CPU_INTEL OFF)
+set(CPU_POWER OFF)
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "(AMD64|x86_64)")
   set(CPU_INTEL ON)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
   set(CPU_AARCH64 ON)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(ppc64le)")
+  set(CPU_POWER ON)
 endif()
 
 # For non-supported platforms, turn USE_DISTRIBUTED off by default. It is not
@@ -315,8 +318,8 @@ cmake_dependent_option(USE_ITT "Use Intel(R) VTune Profiler ITT functionality"
 # Ensure that an MKLDNN build is the default for x86 CPUs but optional for
 # AArch64 (dependent on -DUSE_MKLDNN).
 cmake_dependent_option(
-  USE_MKLDNN "Use MKLDNN. Only available on x86, x86_64, and AArch64."
-  "${CPU_INTEL}" "CPU_INTEL OR CPU_AARCH64" OFF)
+  USE_MKLDNN "Use MKLDNN. Only available on x86, x86_64, AArch64, and ppc64le."
+  "${CPU_INTEL}" "CPU_INTEL OR CPU_AARCH64 OR CPU_POWER" OFF)
 cmake_dependent_option(
   USE_MKLDNN_ACL "Use Compute Library for the Arm architecture." OFF
   "USE_MKLDNN AND CPU_AARCH64" OFF)

--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -348,6 +348,8 @@ void gemm(
    // MKLDNN also supports ARM for bf16, and the bypass is only
    // currently intended for x86/x86_64.
    const bool use_bf16_gemv_trans = false;
+#elif defined(__powerpc__)
+   const bool use_bf16_gemv_trans = false;
 #else
    const bool bf16_gemv_trans_would_be_faster = cpuinfo_initialize() &&
      !cpuinfo_has_x86_avx512bf16();
@@ -378,8 +380,12 @@ void gemm(
    // we should not bother checking for !cpuinfo_has_x86_avx512fp16() here,
    // because "onednn (mkldnn) won't use avx512fp16 to compute gemms by default
    // because the avx512fp16 fma would incur accuracy loss".
+#if defined(__powerpc__)
+   const bool fp16_gemv_trans_would_be_faster = false;
+#else
    const bool fp16_gemv_trans_would_be_faster = cpuinfo_initialize() &&
      cpuinfo_has_x86_f16c();
+#endif
    const bool use_fp16_gemv_trans = fp16_gemv_trans_would_be_faster &&
      transa == TransposeType::Transpose &&
      transb == TransposeType::NoTranspose && n == 1 && alpha == 1.0;

--- a/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
@@ -431,12 +431,13 @@ inline bool should_use_onednn_quant(
   // Also, the heuristics for dispatching are based on perf data on Linux.
   // So, for x86 qengine, we always use fbgemm kernels if OS is not Linux.
   // TODO Support more OSs.
+  bool vnni_available = false;
 #if !defined(__linux__)
   return false;
 #elif defined(__powerpc__)
-  bool vnni_available = true;
+  vnni_available = true;
 #else
-  bool vnni_available = cpuinfo_has_x86_avx512vnni();
+  vnni_available = cpuinfo_has_x86_avx512vnni();
 #endif
   bool w_sym_quant =
       is_weight_symmetric_quant(weight, is_transposed_conv);

--- a/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
@@ -444,7 +444,7 @@ inline bool should_use_onednn_quant(
   bool opad_all_zero =
       std::all_of(output_padding.begin(), output_padding.end(), [](int i) { return i==0; });
   return vnni_available && (groups <= 100) && w_sym_quant && opad_all_zero;
-#endif  
+#endif
 }
 
 } // onednn_utils

--- a/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
@@ -431,19 +431,20 @@ inline bool should_use_onednn_quant(
   // Also, the heuristics for dispatching are based on perf data on Linux.
   // So, for x86 qengine, we always use fbgemm kernels if OS is not Linux.
   // TODO Support more OSs.
-  bool vnni_available = false;
 #if !defined(__linux__)
   return false;
-#elif defined(__powerpc__)
-  vnni_available = true;
 #else
-  vnni_available = cpuinfo_has_x86_avx512vnni();
+#if defined(__powerpc__)
+  constexpr auto vnni_available = true;
+#else
+  const auto vnni_available = cpuinfo_has_x86_avx512vnni();
 #endif
   bool w_sym_quant =
       is_weight_symmetric_quant(weight, is_transposed_conv);
   bool opad_all_zero =
       std::all_of(output_padding.begin(), output_padding.end(), [](int i) { return i==0; });
   return vnni_available && (groups <= 100) && w_sym_quant && opad_all_zero;
+#endif  
 }
 
 } // onednn_utils


### PR DESCRIPTION
This PR will enable onednn for powerpc Architecture which will help to do quantization of the model via onednn for powerpc.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10