### PR TITLE
Update module.py as per #142306

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -50,11 +50,11 @@ _grad_t = Union[Tuple[Tensor, ...], Tensor]
 # of `T` to annotate `self`. Many methods of `Module` return `self` and we want those return values to be
 # the type of the subclass, not the looser type of `Module`.
 T = TypeVar("T", bound="Module")
-P = ParamSpec('P')
-R = TypeVar('R')
-Module_T = TypeVar('Module_T', bound='Module')
-Input = TypeVar('Input')
-Output = TypeVar('Output')
+_P = ParamSpec('_P')
+_R = TypeVar('_R')
+_Module_T = TypeVar('_Module_T', bound='Module')
+_Input = TypeVar('_Input')
+_Output = TypeVar('_Output')
 
 class _IncompatibleKeys(
     namedtuple("IncompatibleKeys", ["missing_keys", "unexpected_keys"]),

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -23,7 +23,6 @@ from typing import (
 from typing_extensions import (
   Self,
   ParamSpec,
-  TypeVar,
 )
 
 import torch

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -52,7 +52,6 @@ _grad_t = Union[Tuple[Tensor, ...], Tensor]
 T = TypeVar("T", bound="Module")
 _P = ParamSpec('_P')
 _R = TypeVar('_R')
-_Module_T = TypeVar('_Module_T', bound='Module')
 _Input = TypeVar('_Input')
 _Output = TypeVar('_Output')
 
@@ -1587,10 +1586,10 @@ class Module:
     def register_forward_pre_hook(
         self,
         hook: Union[
-            Callable[[T, Tuple[Input, ...]], Optional[Tuple[Input, ...]]],
+            Callable[[T, Tuple[_Input, ...]], Optional[Tuple[_Input, ...]]],
             Callable[
-                [T, Tuple[Input, ...], Dict[str, Any]],
-                Optional[Tuple[Tuple[Input, ...], Dict[str, Any]]],
+                [T, Tuple[_Input, ...], Dict[str, Any]],
+                Optional[Tuple[Tuple[_Input, ...], Dict[str, Any]]],
             ],
         ],
         *,
@@ -1653,8 +1652,8 @@ class Module:
     def register_forward_hook(
         self,
         hook: Union[
-            Callable[[T, Tuple[Input, ...], Output], Optional[Output]],
-            Callable[[T, Tuple[Input, ...], Dict[str, Any], Output], Optional[Output]],
+            Callable[[T, Tuple[_Input, ...], _Output], Optional[_Output]],
+            Callable[[T, Tuple[_Input, ...], Dict[str, Any], _Output], Optional[_Output]],
         ],
         *,
         prepend: bool = False,

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -20,7 +20,11 @@ from typing import (
     TypeVar,
     Union,
 )
-from typing_extensions import Self
+from typing_extensions import (
+  Self,
+  ParamSpec,
+  TypeVar,
+)
 
 import torch
 from torch import device, dtype, Tensor
@@ -47,7 +51,11 @@ _grad_t = Union[Tuple[Tensor, ...], Tensor]
 # of `T` to annotate `self`. Many methods of `Module` return `self` and we want those return values to be
 # the type of the subclass, not the looser type of `Module`.
 T = TypeVar("T", bound="Module")
-
+P = ParamSpec('P')
+R = TypeVar('R')
+Module_T = TypeVar('Module_T', bound='Module')
+Input = TypeVar('Input')
+Output = TypeVar('Output')
 
 class _IncompatibleKeys(
     namedtuple("IncompatibleKeys", ["missing_keys", "unexpected_keys"]),
@@ -1580,10 +1588,10 @@ class Module:
     def register_forward_pre_hook(
         self,
         hook: Union[
-            Callable[[T, Tuple[Any, ...]], Optional[Any]],
+            Callable[[T, Tuple[Input, ...]], Optional[Tuple[Input, ...]]],
             Callable[
-                [T, Tuple[Any, ...], Dict[str, Any]],
-                Optional[Tuple[Any, Dict[str, Any]]],
+                [T, Tuple[Input, ...], Dict[str, Any]],
+                Optional[Tuple[Tuple[Input, ...], Dict[str, Any]]],
             ],
         ],
         *,
@@ -1646,8 +1654,8 @@ class Module:
     def register_forward_hook(
         self,
         hook: Union[
-            Callable[[T, Tuple[Any, ...], Any], Optional[Any]],
-            Callable[[T, Tuple[Any, ...], Dict[str, Any], Any], Optional[Any]],
+            Callable[[T, Tuple[Input, ...], Output], Optional[Output]],
+            Callable[[T, Tuple[Input, ...], Dict[str, Any], Output], Optional[Output]],
         ],
         *,
         prepend: bool = False,


### PR DESCRIPTION
release notes: fx Issue  #142306
Minor work in Improve typing of args and kwargs with ParamSpec

**register_forward_hook**
    
      Key changes:
    
      1. Replace Any with Input/Output type vars for inputs/outputs
      2. Ensure the output type of the hook matches its input type
      3. Keep the Dict[str, Any] for kwargs as those are arbitrary
    
**register_forward_pre_hook**
    
      Key changes:
    
      1. Replace Any with Input type var for inputs
      2. Ensure the return type matches the input type structure
      3. Keep Dict[str, Any] for kwargs