### PR TITLE
[BE] Only print MKL version on x86 platforms

### DIFF
--- a/aten/src/ATen/ParallelCommon.cpp
+++ b/aten/src/ATen/ParallelCommon.cpp
@@ -62,7 +62,7 @@ std::string get_parallel_info() {
   ss << "\tomp_get_max_threads() : " << omp_get_max_threads() << '\n';
 #endif
 
-#if defined(__x86_64__) || defined(_M_X64)    
+#if defined(__x86_64__) || defined(_M_X64)
   ss << at::get_mkl_version() << '\n';
 #endif
 #if AT_MKL_ENABLED()

--- a/aten/src/ATen/ParallelCommon.cpp
+++ b/aten/src/ATen/ParallelCommon.cpp
@@ -62,7 +62,9 @@ std::string get_parallel_info() {
   ss << "\tomp_get_max_threads() : " << omp_get_max_threads() << '\n';
 #endif
 
+#if defined(__x86_64__) || defined(_M_X64)    
   ss << at::get_mkl_version() << '\n';
+#endif
 #if AT_MKL_ENABLED()
   ss << "\tmkl_get_max_threads() : " << mkl_get_max_threads() << '\n';
 #endif
@@ -75,8 +77,10 @@ std::string get_parallel_info() {
   ss << "Environment variables:" << '\n';
   ss << "\tOMP_NUM_THREADS : "
      << get_env_var("OMP_NUM_THREADS", "[not set]") << '\n';
+#if defined(__x86_64__) || defined(_M_X64)    
   ss << "\tMKL_NUM_THREADS : "
      << get_env_var("MKL_NUM_THREADS", "[not set]") << '\n';
+#endif
 
   ss << "ATen parallel backend: ";
   #if AT_PARALLEL_OPENMP

--- a/aten/src/ATen/ParallelCommon.cpp
+++ b/aten/src/ATen/ParallelCommon.cpp
@@ -77,7 +77,7 @@ std::string get_parallel_info() {
   ss << "Environment variables:" << '\n';
   ss << "\tOMP_NUM_THREADS : "
      << get_env_var("OMP_NUM_THREADS", "[not set]") << '\n';
-#if defined(__x86_64__) || defined(_M_X64)    
+#if defined(__x86_64__) || defined(_M_X64)
   ss << "\tMKL_NUM_THREADS : "
      << get_env_var("MKL_NUM_THREADS", "[not set]") << '\n';
 #endif


### PR DESCRIPTION
As it will obviously be missing on ARM/S390, etc

Test plan: run `python3 -c "import torch;print(torch.__config__.parallel_info())"` on both x86 and non-x86 system