### PR TITLE
Update tag_regex in filter_test_configs.py for workflows such as `inductor-rocm`

### DIFF
--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -562,7 +562,7 @@ def main() -> None:
 
     # If the tag matches, we can get the PR number from it, this is from ciflow
     # workflow dispatcher
-    tag_regex = re.compile(r"^ciflow/\w+/(?P<pr_number>\d+)$")
+    tag_regex = re.compile(r"^ciflow/[\w\-]+/(?P<pr_number>\d+)$")
 
     labels = set()
     if pr_number:


### PR DESCRIPTION
This helps to make `continue-through-error`/`keep-going` work as expected on `inductor-rocm` workflow jobs.

Without this, the code here doesn't enter the `if` condition: https://github.com/pytorch/pytorch/blob/6ccb8ed1868984d9d2ea4e48a085508d1027cd9b/.github/scripts/filter_test_configs.py#L577

Tested via [this PR](https://github.com/pytorch/pytorch/pull/140989):
Without this change: https://hud.pytorch.org/pytorch/pytorch/pull/140989?sha=8232e18957f987d99c946efc0cf6da9be9b52067: https://github.com/pytorch/pytorch/actions/runs/12164558045/job/34192442187#step:13:144

With this change: https://hud.pytorch.org/pytorch/pytorch/pull/140989?sha=763179c5e421791ee05c8e2a600379b29a1c8c33: https://github.com/pytorch/pytorch/actions/runs/12261943684/job/34213300153#step:13:145

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd