### PR TITLE
[pytorch/et] Allow ET to save additional resources for completing a trace like generated kernels and index tensor data

### DIFF
--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -204,6 +204,92 @@ class TestExecutionTrace(TestCase):
             f"  rf_ids_kineto = {rf_ids_kineto}\n",
         )
 
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    @skipIfHpu
+    @skipIfTorchDynamo("profiler gets ignored if dynamo activated")
+    def test_execution_trace_env_enabled_with_kineto(self, device):
+        import os
+
+        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE"] = "1"
+        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS"] = "1"
+        trace_called_num = 0
+
+        def trace_handler(p):
+            nonlocal trace_called_num
+            trace_called_num += 1
+
+        use_device = (
+            torch.profiler.ProfilerActivity.CUDA
+            or torch.profiler.ProfilerActivity.XPU in supported_activities()
+            or torch.profiler.ProfilerActivity.HPU in supported_activities()
+        )
+        # Create a temp file to save kineto data.
+        kt = tempfile.NamedTemporaryFile(
+            mode="w+t", suffix=".kineto.json", delete=False
+        )
+        kt.close()
+
+        with profile(
+            activities=supported_activities(),
+            schedule=torch.profiler.schedule(
+                skip_first=3, wait=1, warmup=1, active=2, repeat=1
+            ),
+            on_trace_ready=trace_handler,
+        ) as p:
+            for idx in range(10):
+                with record_function(f"## LOOP {idx} ##"):
+                    self.payload(device, use_device=use_device)
+                p.step()
+
+        # Uncomment for debugging
+        # print("Output kineto = ", kt.name)
+        # print("Output ET = ", fp.name)
+
+        p.export_chrome_trace(kt.name)
+        self.assertEqual(trace_called_num, 1)
+        et_path = p.execution_trace_observer.get_output_file_path()
+        et_res_path = p.execution_trace_observer.get_resources_dir(et_path)
+        # the path should be set up due to our env variables
+        self.assertTrue(et_path is not None)
+        # et_res_path should be an empty directory
+        self.assertTrue(os.path.isdir(et_res_path))
+        self.assertEqual(len(os.listdir(et_res_path)), 0)
+        # Compare the collected Execution Trace and Kineto Trace
+        # in terms of record func
+        nodes = self.get_execution_trace_root(et_path)
+        loop_count = 0
+        found_root_node = False
+        for n in nodes:
+            assert "name" in n
+            if "[pytorch|profiler|execution_trace|process]" in n["name"]:
+                found_root_node = True
+            if n["name"].startswith("## LOOP "):
+                loop_count += 1
+        self.assertTrue(found_root_node)
+        # Since profiler trace is active for 2 iterations
+        self.assertEqual(loop_count, 2)
+
+        # Compare the collected Execution Trace and Kineto Trace
+        # in terms of record func ID (rf_id) and External IDs
+        # both of these should match for the same trace window.
+
+        with open(kt.name) as f:
+            kineto = json.load(f)
+            events = kineto["traceEvents"]
+
+        # Look up rf_ids in both Execution and Kineto trace as two lists.
+        rf_ids_et = self.get_execution_trace_rf_ids(nodes)
+        rf_ids_kineto = self.get_kineto_rf_ids(events)
+
+        self.assertCountEqual(rf_ids_et, rf_ids_kineto)
+        self.assertListEqual(
+            rf_ids_et,
+            rf_ids_kineto,
+            msg=f"ET and kineto rf_id should exactly match\n"
+            f"  rf_ids_et = {rf_ids_et}\n"
+            f"  rf_ids_kineto = {rf_ids_kineto}\n",
+        )
+
     def test_execution_trace_alone(self, device):
         use_device = (
             torch.profiler.ProfilerActivity.CUDA
@@ -243,6 +329,31 @@ class TestExecutionTrace(TestCase):
                 assert len(n["inputs"]["values"][3][0]) == tensor_tuple_size
         assert found_root_node
         assert loop_count == expected_loop_events
+
+    def test_execution_trace_env_disabled(self, device):
+        import os
+
+        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE"] = "0"
+        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS"] = "0"
+        use_device = (
+            torch.profiler.ProfilerActivity.CUDA
+            or torch.profiler.ProfilerActivity.HPU in supported_activities()
+            or torch.profiler.ProfilerActivity.XPU in supported_activities()
+        )
+
+        with profile(
+            activities=torch.profiler.supported_activities(),
+            record_shapes=True,
+            schedule=torch.profiler.schedule(
+                skip_first=3, wait=1, warmup=1, active=2, repeat=1
+            ),
+        ) as p:
+            for idx in range(10):
+                with record_function(f"## LOOP {idx} ##"):
+                    self.payload(device, use_device=use_device)
+                p.step()
+
+        self.assertTrue(p.execution_trace_observer is None)
 
     @unittest.skipIf(IS_WINDOWS, "torch.compile does not support WINDOWS")
     @unittest.skipIf(
@@ -286,6 +397,64 @@ class TestExecutionTrace(TestCase):
                 p.step()
 
         nodes = self.get_execution_trace_root(fp.name)
+        found_captured_triton_kernel_node = False
+        for n in nodes:
+            assert "name" in n
+            if "triton_" in n["name"]:
+                for attr in n["attrs"]:
+                    if attr["name"] == "kernel_file" and attr["value"] != "":
+                        found_captured_triton_kernel_node = True
+                        assert len(n["inputs"]["values"]) > 0
+                        assert len(n["outputs"]["values"]) == 0
+        assert found_captured_triton_kernel_node
+
+    @unittest.skipIf(IS_WINDOWS, "torch.compile does not support WINDOWS")
+    @unittest.skipIf(
+        sys.version_info >= (3, 12), "torch.compile is not supported on python 3.12+"
+    )
+    @unittest.skipIf(
+        (not has_triton()) or (not TEST_CUDA and not TEST_XPU),
+        "need triton and device(CUDA or XPU) availability to run",
+    )
+    @skipCPUIf(True, "skip CPU device for testing profiling triton")
+    def test_execution_trace_env_enabled_with_pt2(self, device):
+        import os
+
+        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE"] = "1"
+        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS"] = "1"
+
+        @torchdynamo.optimize("inductor")
+        def fn(a, b, c):
+            x = torch.nn.functional.linear(a, b)
+            x = x + c
+            return x.cos()
+
+        a, b, c = (torch.randn(4, 4, requires_grad=True).to(device) for _ in range(3))
+
+        inputs = [a, b, c]
+        with torch._inductor.config.patch(compile_threads=1):
+            fn(*inputs)
+
+        with profile(
+            activities=torch.profiler.supported_activities(),
+            record_shapes=True,
+            schedule=torch.profiler.schedule(
+                skip_first=3, wait=1, warmup=1, active=2, repeat=1
+            ),
+        ) as p:
+            for idx in range(10):
+                with record_function(f"## LOOP {idx} ##"):
+                    fn(*inputs)
+                p.step()
+
+        et_path = p.execution_trace_observer.get_output_file_path()
+        et_res_path = p.execution_trace_observer.get_resources_dir(et_path)
+        # the path should be set up due to our env variables
+        self.assertTrue(et_path is not None)
+        # et_res_path should be an empty directory
+        self.assertTrue(os.path.isdir(et_res_path))
+        self.assertEqual(len(os.listdir(et_res_path)), 2)
+        nodes = self.get_execution_trace_root(et_path)
         found_captured_triton_kernel_node = False
         for n in nodes:
             assert "name" in n


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143775

The resources directory lets ET observer dump any additional data like Triton kernels while capturing the ET.

This allows us to use the ET trace to replay PT2 workloads and get visibility into data like generated kernels and their usage in a model, index tensor data etc.

We also added a few ways to enable ET and ET Resources through the OS environment variables.

Setting `ENABLE_PYTORCH_EXECUTION_TRACE` will enable default Execution Tracing in Pytorch.

Additionally setting `ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS` will enable ET to collect extra resources from the ET run like Triton Kernels.

Differential Revision: [D67610542](https://our.internmc.facebook.com/intern/diff/D67610542/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D67610542/)!