### PR TITLE
torch/accelerator: fix device type comparison (#143541)

### DIFF
--- a/torch/accelerator/_utils.py
+++ b/torch/accelerator/_utils.py
@@ -11,7 +11,7 @@ def _get_device_index(device: _device_t, optional: bool = False) -> int:
         device = torch.device(device)
     device_index: Optional[int] = None
     if isinstance(device, torch.device):
-        if torch.accelerator.current_accelerator() != device.type:
+        if torch.accelerator.current_accelerator().type != device.type:
             raise ValueError(
                 f"{device.type} doesn't match the current accelerator {torch.accelerator.current_accelerator()}."
             )


### PR DESCRIPTION
This was failing without the fix:
```
python -c 'import torch; d=torch.device("xpu:0"); torch.accelerator.current_stream(d)'
```
with:
```
ValueError: xpu doesn't match the current accelerator xpu.
```

CC: @guangyey, @EikanWang

Pull Request resolved: https://github.com/pytorch/pytorch/pull/143541
Approved by: https://github.com/guangyey, https://github.com/albanD

(cherry picked from commit 7314cf44ae719dfbc9159496030ce84d152686e4)

Fixes #ISSUE_NUMBER
