### PR TITLE
[Intel GPU] Avoid copy when the input of Matmul is broadcasted

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -33,8 +33,13 @@ sycl::event matmul(
   auto engine = GpuEngineManager::Instance().get_engine(cur_device);
   auto stream = GpuStreamManager::Instance().get_stream();
 
-  at::Tensor m1 = is_onednn_matmul_strides(mat1) ? mat1 : mat1.contiguous();
-  at::Tensor m2 = is_onednn_matmul_strides(mat2) ? mat2 : mat2.contiguous();
+  at::Tensor m1 = mat1;
+  at::Tensor m2 = mat2;
+  
+  undo_broadcast_on_batch(m1, m2);
+
+  m1 = is_onednn_matmul_strides(m1) ? m1 : m1.contiguous();
+  m2 = is_onednn_matmul_strides(m2) ? m2 : m2.contiguous();
   at::Tensor dst =
       is_onednn_matmul_strides(result, true) ? result : result.contiguous();
 
@@ -46,13 +51,13 @@ sycl::event matmul(
   if (dims == 3) {
     mb = dst.size(0);
     TORCH_CHECK(
-        mb == m1.size(0) && mb == m2.size(0),
+        mb == mat1.size(0) && mb == mat2.size(0),
         "batch size mismatch, dst mb: ",
         mb,
         "m1 mb",
-        m1.size(0),
+        mat1.size(0),
         " m2 mb: ",
-        m2.size(0));
+        mat2.size(0));
   }
 
   // validate bias and make it compatible with oneDNN implementation
@@ -145,8 +150,8 @@ sycl::event matmul(
     }
     dst_strides = {dst.stride(0), dst.stride(1)};
   } else {
-    m1_dims = {mb, m, k};
-    m2_dims = {mb, k, n};
+    m1_dims = {m1.size(0), m, k};
+    m2_dims = {m2.size(0), k, n};
     dst_dims = {mb, m, n};
 
     m1_strides = {m1.stride(0), m1.stride(1), m1.stride(2)};

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -35,7 +35,7 @@ sycl::event matmul(
 
   at::Tensor m1 = mat1;
   at::Tensor m2 = mat2;
-  
+
   undo_broadcast_on_batch(m1, m2);
 
   m1 = is_onednn_matmul_strides(m1) ? m1 : m1.contiguous();

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -208,11 +208,12 @@ bool is_broadcast(const at::Tensor& t) {
 }
 
 void undo_broadcast_on_batch(at::Tensor& m1, at::Tensor& m2) {
-  // onednn support one of src and wei broadcasted on batch dim
+  // oneDNN support one of src and wei broadcasted on batch dim
   auto tensor_dim = m1.dim();
   if (tensor_dim ==2)
     return;
   auto undo_broadcast = [](at::Tensor& tensor) {
+    // oneDNN does not support broadcasted tensor on m, n, k dim
     if (tensor.stride(1) == 0 || tensor.stride(2) == 0) {
       tensor = tensor.contiguous();
     }
@@ -222,7 +223,7 @@ void undo_broadcast_on_batch(at::Tensor& m1, at::Tensor& m2) {
   };
 
   if (m1.stride(0) == 0 && m2.stride(0) == 0) {
-    // onednn does not support both src and wei broadcasted on batch dim. We copy the smaller one.
+    // oneDNN does not support both src and wei broadcasted on batch dim. We copy the smaller one.
     if (m1.size(1)<m2.size(2)) {
       m1 = m1.contiguous();
     }

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -210,9 +210,9 @@ bool is_broadcast(const at::Tensor& t) {
 void undo_broadcast_on_batch(at::Tensor& m1, at::Tensor& m2) {
   // oneDNN support one of src and wei broadcasted on batch dim
   // tensor shape = [b, m, n]
-  int dim_b = 0;
-  int dim_m = 1;
-  int dim_n = 2;
+  constexpr int dim_b = 0;
+  constexpr int dim_m = 1;
+  constexpr int dim_n = 2;
   auto only_broadcasted_on_batch =
       [dim_b, dim_m, dim_n](const at::Tensor& tensor) {
         auto tensor_dim = tensor.dim();
@@ -234,17 +234,17 @@ void undo_broadcast_on_batch(at::Tensor& m1, at::Tensor& m2) {
   bool m2_only_batch_broadcasted = only_broadcasted_on_batch(m2);
   bool has_broadcast = m1_only_batch_broadcasted || m2_only_batch_broadcasted;
   bool both_broadcast = m1_only_batch_broadcasted && m2_only_batch_broadcasted;
-  if (has_broadcast) {
-    if (both_broadcast) {
-      // oneDNN does not support both src and wei broadcasted on batch dim. We
-      // copy the smaller one.
-      if (m1.size(dim_m) < m2.size(dim_n)) {
-        m1 = m1.contiguous();
-        m1_only_batch_broadcasted = false;
-      } else {
-        m2 = m2.contiguous();
-      }
+  if (both_broadcast) {
+    // oneDNN does not support both src and wei broadcasted on batch dim. We
+    // copy the smaller one.
+    if (m1.size(dim_m) < m2.size(dim_n)) {
+      m1 = m1.contiguous();
+      m1_only_batch_broadcasted = false;
+    } else {
+      m2 = m2.contiguous();
     }
+  }
+  if (has_broadcast) {
     at::Tensor& tensor = m1_only_batch_broadcasted ? m1 : m2;
     tensor = tensor
                  .as_strided(

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
@@ -39,6 +39,7 @@ dnnl::memory::desc get_onednn_md(const at::Tensor& tensor);
 
 bool onednn_strides_check(const at::Tensor& src);
 bool is_broadcast(const at::Tensor& t);
+void undo_broadcast_on_batch(at::Tensor& m1, at::Tensor& m2);
 
 bool is_onednn_matmul_strides(const at::Tensor& tensor, bool is_dst = false);
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
@@ -5,7 +5,6 @@
 #include <iostream>
 
 #include <ATen/core/grad_mode.h>
-#include <ATen/MemoryOverlap.h>
 #include <c10/core/MemoryFormat.h>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_sycl.hpp>

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
@@ -5,6 +5,7 @@
 #include <iostream>
 
 #include <ATen/core/grad_mode.h>
+#include <ATen/MemoryOverlap.h>
 #include <c10/core/MemoryFormat.h>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_sycl.hpp>


### PR DESCRIPTION
Avoid copy when the input of Matmul is 3D and broadcasted on batch dim.  oneDNN support implicit broadcast semantics i.e., src can be broadcasted into weight if the corresponding dimension in src is 1 (and vice versa). On Max 1100, timm resmlp_12_224 amp_fp16 inference with bs=128 can improve from 42ms to 13.7 ms on torch.compile and 57.5ms to 32ms on eager mode.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10