### PR TITLE
Propagate callable parameter types using ParamSpec (#142306)

### DIFF
--- a/torch/_dynamo/external_utils.py
+++ b/torch/_dynamo/external_utils.py
@@ -64,7 +64,7 @@ def call_hook(
     return result
 
 
-def wrap_numpy(f: Callable[_P, pytree.PyTree]) -> Callable[_P, pytree.PyTree]:
+def wrap_numpy(f: Callable[_P, _R]) -> Callable[_P, _R]:
     r"""Decorator that turns a function from ``np.ndarray``s to ``np.ndarray``s into a function
     from ``torch.Tensor``s to ``torch.Tensor``s.
     """

--- a/torch/_dynamo/external_utils.py
+++ b/torch/_dynamo/external_utils.py
@@ -2,8 +2,8 @@
 
 import functools
 import warnings
-from typing import Any, Callable, List, Optional, TYPE_CHECKING, Union
-from typing_extensions import deprecated
+from typing import Any, Callable, List, Optional, TYPE_CHECKING, TypeVar, Union
+from typing_extensions import deprecated, ParamSpec
 
 import torch
 import torch.utils._pytree as pytree
@@ -13,6 +13,9 @@ try:
     import numpy as np
 except ModuleNotFoundError:
     np = None  # type: ignore[assignment]
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 if TYPE_CHECKING:
     # TorchScript does not support `@deprecated`
@@ -35,13 +38,13 @@ else:
         return torch.compiler.is_compiling()
 
 
-def wrap_inline(fn: Callable[..., Any]) -> Callable[..., Any]:
+def wrap_inline(fn: Callable[_P, _R]) -> Callable[_P, _R]:
     """
     Create an extra frame around fn that is not in skipfiles.
     """
 
     @functools.wraps(fn)
-    def inner(*args: Any, **kwargs: Any) -> Any:
+    def inner(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         return fn(*args, **kwargs)
 
     return inner
@@ -61,7 +64,7 @@ def call_hook(
     return result
 
 
-def wrap_numpy(f: Callable[..., Any]) -> Callable[..., Any]:
+def wrap_numpy(f: Callable[_P, pytree.PyTree]) -> Callable[_P, pytree.PyTree]:
     r"""Decorator that turns a function from ``np.ndarray``s to ``np.ndarray``s into a function
     from ``torch.Tensor``s to ``torch.Tensor``s.
     """
@@ -69,7 +72,7 @@ def wrap_numpy(f: Callable[..., Any]) -> Callable[..., Any]:
         return f
 
     @functools.wraps(f)
-    def wrap(*args: Any, **kwargs: Any) -> Any:
+    def wrap(*args: _P.args, **kwargs: _P.kwargs) -> pytree.PyTree:
         args, kwargs = pytree.tree_map_only(
             torch.Tensor, lambda x: x.numpy(), (args, kwargs)
         )

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -20,6 +20,7 @@ from typing import (
     TypeVar,
     Union,
 )
+from typing_extensions import ParamSpec
 from unittest.mock import patch
 
 import torch
@@ -50,6 +51,8 @@ unsupported = eval_frame.unsupported
 three = 3
 
 log = logging.getLogger(__name__)
+
+_P = ParamSpec("_P")
 
 
 def clone_me(x: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
@@ -407,9 +410,9 @@ def check_dynamic_shape_capture() -> bool:
     return not config.assume_static_by_default
 
 
-def _make_fn_with_patches(fn: Callable[..., _T], *patches: Any) -> Callable[..., _T]:
+def _make_fn_with_patches(fn: Callable[_P, _T], *patches: Any) -> Callable[_P, _T]:
     @functools.wraps(fn)
-    def _fn(*args: Any, **kwargs: Any) -> _T:
+    def _fn(*args: _P.args, **kwargs: _P.kwargs) -> _T:
         with contextlib.ExitStack() as stack:
             for module, attr, val in patches:
                 stack.enter_context(patch.object(module, attr, val))

--- a/torch/_strobelight/cli_function_profiler.py
+++ b/torch/_strobelight/cli_function_profiler.py
@@ -256,7 +256,7 @@ class StrobelightCLIFunctionProfiler:
 
     def profile(
         self, work_function: Callable[_P, _R], *args: _P.args, **kwargs: _P.kwargs
-    ) -> _R | None:
+    ) -> Optional[_R]:
         self.current_run_id = None
         self.profile_result = None
 
@@ -304,13 +304,15 @@ class StrobelightCLIFunctionProfiler:
 # @strobelight(stop_at_error=True,...)
 def strobelight(
     profiler: Optional[StrobelightCLIFunctionProfiler] = None, **kwargs: Any
-) -> Callable[[Callable[_P, _R]], Callable[_P, _R | None]]:
+) -> Callable[[Callable[_P, _R]], Callable[_P, Optional[_R]]]:
     if not profiler:
         profiler = StrobelightCLIFunctionProfiler(**kwargs)
 
-    def strobelight_inner(work_function: Callable[_P, _R]) -> Callable[_P, _R | None]:
+    def strobelight_inner(
+        work_function: Callable[_P, _R]
+    ) -> Callable[_P, Optional[_R]]:
         @functools.wraps(work_function)
-        def wrapper_function(*args: _P.args, **kwargs: _P.kwargs) -> _R | None:
+        def wrapper_function(*args: _P.args, **kwargs: _P.kwargs) -> Optional[_R]:
             return profiler.profile(work_function, *args, **kwargs)
 
         return wrapper_function

--- a/torch/_strobelight/cli_function_profiler.py
+++ b/torch/_strobelight/cli_function_profiler.py
@@ -8,7 +8,8 @@ import subprocess
 import time
 from threading import Lock
 from timeit import default_timer as timer
-from typing import Any, List, Optional, Sequence
+from typing import Any, Callable, List, Optional, Sequence, TypeVar
+from typing_extensions import ParamSpec
 
 
 logger = logging.getLogger("strobelight_function_profiler")
@@ -22,6 +23,9 @@ console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 logger.setLevel(logging.INFO)
 logger.propagate = False
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 
 class StrobelightCLIProfilerError(Exception):
@@ -250,7 +254,9 @@ class StrobelightCLIFunctionProfiler:
                 self._stop_strobelight_no_throw(collect_results=False)
             return False
 
-    def profile(self, work_function: Any, *args: Any, **kwargs: Any) -> Any:
+    def profile(
+        self, work_function: Callable[_P, _R], *args: _P.args, **kwargs: _P.kwargs
+    ) -> _R | None:
         self.current_run_id = None
         self.profile_result = None
 
@@ -288,6 +294,7 @@ class StrobelightCLIFunctionProfiler:
                 self._stop_strobelight_no_throw(collect_results=False)
                 StrobelightCLIFunctionProfiler._lock.release()
                 raise error
+        return None
 
 
 # A function decorator that wraps profile, if no profiler is provided one with
@@ -297,13 +304,13 @@ class StrobelightCLIFunctionProfiler:
 # @strobelight(stop_at_error=True,...)
 def strobelight(
     profiler: Optional[StrobelightCLIFunctionProfiler] = None, **kwargs: Any
-) -> Any:
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R | None]]:
     if not profiler:
         profiler = StrobelightCLIFunctionProfiler(**kwargs)
 
-    def strobelight_inner(work_function: Any) -> Any:
+    def strobelight_inner(work_function: Callable[_P, _R]) -> Callable[_P, _R | None]:
         @functools.wraps(work_function)
-        def wrapper_function(*args: Any, **kwargs: Any) -> Any:
+        def wrapper_function(*args: _P.args, **kwargs: _P.kwargs) -> _R | None:
             return profiler.profile(work_function, *args, **kwargs)
 
         return wrapper_function

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -542,7 +542,7 @@ class FakeTensorConfig:
 #
 # Making this a descriptor may seem overly fancy, but actually it's the most
 # convenient way to ensure access to FakeTensor during access, which is
-# required for testing version counter and epoch validity.​
+# required for testing version counter and epoch validity.
 class SymNumberMemoDescriptor:
     _name: str
 
@@ -763,7 +763,7 @@ class FakeTensor(Tensor):
 
     @classmethod
     @count
-    def __torch_dispatch__(
+    def __torch_dispatch__(  # type: ignore[override] # TODO
         cls,
         func: OpOverload,
         types: Sequence[Type],

--- a/torch/distributed/_tools/fsdp2_mem_tracker.py
+++ b/torch/distributed/_tools/fsdp2_mem_tracker.py
@@ -1,7 +1,19 @@
 from copy import deepcopy
 from datetime import timedelta
 from functools import partial, wraps
-from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
+from typing_extensions import ParamSpec
 
 import torch
 import torch.distributed as dist
@@ -25,6 +37,9 @@ from torch.utils.weak import WeakIdKeyDictionary, weakref
 _TOTAL_KEY = "Total"
 
 __all__ = ["FSDPMemTracker"]
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 
 class _FSDPRefType(_RefType):
@@ -185,8 +200,8 @@ class FSDPMemTracker(MemTracker):
     def _fsdp_state_pre_forward(
         self,
         fsdp_mod: FSDPModule,
-        orig_fsdp_state_pre_fw: Callable,
-    ) -> Callable:
+        orig_fsdp_state_pre_fw: Callable[_P, Any],
+    ) -> Callable[_P, Tuple[Tuple[Any, ...], Dict[str, Any]]]:
         # We capture memory snapshots before and after ``FSDPState._pre_forward`` to attribute the `unsharded` params
         # and `all_gather` buffers.  There are three cases:
         # Case 1: If the module is not in the ``memory_tracking`` dictionary, create a new ``_FSDPModMemStats``
@@ -201,7 +216,9 @@ class FSDPMemTracker(MemTracker):
         # For Case 1 and 3, we also initialiaze the ``local_peak`` and ``PEAK_FW`` snapshot for the module.
         # For Case 2 we only capture 1 snapshot after ``FSDPState._pre_forward`` runs because it is a no-op.
         @wraps(orig_fsdp_state_pre_fw)
-        def inner(*args: Any, **kwargs: Any) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        def inner(
+            *args: _P.args, **kwargs: _P.kwargs
+        ) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
             mod_fqn = self._mod_tracker.get_known_fqn(fsdp_mod)
             assert mod_fqn is not None
             if fsdp_mod not in self.memory_tracking:
@@ -251,15 +268,15 @@ class FSDPMemTracker(MemTracker):
     def _fsdp_state_post_forward(
         self,
         fsdp_mod: FSDPModule,
-        orig_fsdp_state_post_fw: Callable,
-    ) -> Callable:
+        orig_fsdp_state_post_fw: Callable[_P, _R],
+    ) -> Callable[_P, _R]:
         # We capture memory snapshots before and after ``FSDPState._post_forward`` to capture the resharded state
         # if ``reshard_after_forward`` is not ``False``. There are two cases:
         # Case 1: This is called in backward, which means we are in the AC region. If this is the top most module
         #         in the AC region, we set the flag ``_in_ac`` to False.
         # Case 2: This is called in forward.
         @wraps(orig_fsdp_state_post_fw)
-        def inner(*args: Any, **kwargs: Any) -> Any:
+        def inner(*args: _P.args, **kwargs: _P.kwargs) -> _R:
             mod_stat = self.memory_tracking[fsdp_mod]
             if self._mod_tracker.is_bw:
                 state = _FSDPModState.POST_FW_AC
@@ -283,12 +300,12 @@ class FSDPMemTracker(MemTracker):
     def _fsdp_param_group_pre_backward(
         self,
         fsdp_mod: FSDPModule,
-        orig_fsdp_param_group_pre_backward: Callable,
-    ) -> Callable:
+        orig_fsdp_param_group_pre_backward: Callable[_P, Any],
+    ) -> Callable[_P, None]:
         # We capture memory snapshots before and after ``FSDPParamGroup.pre_backward`` to capture the pre-fetching
         # and unsharding of params. We also initialize ``local_peak`` and ``PEAK_BW`` snapshot for the module.
         @wraps(orig_fsdp_param_group_pre_backward)
-        def inner(*args: Any, **kwargs: Any) -> None:
+        def inner(*args: _P.args, **kwargs: _P.kwargs) -> None:
             mod_stat = self.memory_tracking[fsdp_mod]
             snapshot = self.get_tracker_snapshot()
             mod_stat.local_peak = {
@@ -309,13 +326,13 @@ class FSDPMemTracker(MemTracker):
     def _fsdp_param_group_post_backward(
         self,
         fsdp_mod: FSDPModule,
-        orig_fsdp_param_group_post_backward: Callable,
-    ) -> Callable:
+        orig_fsdp_param_group_post_backward: Callable[_P, Any],
+    ) -> Callable[_P, None]:
         # We capture the memory snapshots before and after ``FSDPParamGroup.post_backward`` to track and attribute
         # the `unsharded` grads before the post backward and then `sharded` grads and `reduce_scatter`  buffers
         # after the post backward.
         @wraps(orig_fsdp_param_group_post_backward)
-        def inner(*args: Any, **kwargs: Any) -> None:
+        def inner(*args: _P.args, **kwargs: _P.kwargs) -> None:
             fsdp_state = fsdp_mod._get_fsdp_state()
             if fsdp_param_group := fsdp_state._fsdp_param_group:
                 for fsdp_param in fsdp_param_group.fsdp_params:

--- a/torch/utils/_stats.py
+++ b/torch/utils/_stats.py
@@ -17,7 +17,7 @@ def count_label(label: str) -> None:
     prev = simple_call_counter.setdefault(label, 0)
     simple_call_counter[label] = prev + 1
 
-def count(fn: Callable[_P, _R]) -> Callable[..., _R]:
+def count(fn: Callable[_P, _R]) -> Callable[_P, _R]:
     @functools.wraps(fn)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         if fn.__qualname__ not in simple_call_counter:

--- a/torch/utils/_stats.py
+++ b/torch/utils/_stats.py
@@ -3,17 +3,23 @@
 # AND SCRUB AWAY TORCH NOTIONS THERE.
 import collections
 import functools
-from typing import Any, Callable, OrderedDict
+from typing import Callable, OrderedDict, TypeVar
+from typing_extensions import ParamSpec
+
 
 simple_call_counter: OrderedDict[str, int] = collections.OrderedDict()
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
 
 def count_label(label: str) -> None:
     prev = simple_call_counter.setdefault(label, 0)
     simple_call_counter[label] = prev + 1
 
-def count(fn: Callable[..., Any]) -> Callable[..., Any]:
+def count(fn: Callable[_P, _R]) -> Callable[..., _R]:
     @functools.wraps(fn)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         if fn.__qualname__ not in simple_call_counter:
             simple_call_counter[fn.__qualname__] = 0
         simple_call_counter[fn.__qualname__] = simple_call_counter[fn.__qualname__] + 1

--- a/torch/utils/_strobelight/cli_function_profiler.py
+++ b/torch/utils/_strobelight/cli_function_profiler.py
@@ -7,7 +7,8 @@ import re
 import subprocess
 import time
 from threading import Lock
-from typing import Any, List, Optional, Sequence
+from typing import Any, Callable, List, Optional, Sequence, TypeVar
+from typing_extensions import ParamSpec
 
 
 logger = logging.getLogger("strobelight_function_profiler")
@@ -21,6 +22,9 @@ console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 logger.setLevel(logging.INFO)
 logger.propagate = False
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 
 class StrobelightCLIProfilerError(Exception):
@@ -246,7 +250,9 @@ class StrobelightCLIFunctionProfiler:
                 self._stop_strobelight_no_throw(collect_results=False)
             return False
 
-    def profile(self, work_function: Any, *args: Any, **kwargs: Any) -> Any:
+    def profile(
+        self, work_function: Callable[_P, _R], *args: _P.args, **kwargs: _P.kwargs
+    ) -> _R | None:
         self.current_run_id = None
 
         if locked := StrobelightCLIFunctionProfiler._lock.acquire(False):
@@ -279,6 +285,7 @@ class StrobelightCLIFunctionProfiler:
                 self._stop_strobelight_no_throw(collect_results=False)
                 StrobelightCLIFunctionProfiler._lock.release()
                 raise error
+        return None
 
 
 # A function decorator that wraps profile, if no profiler is provided one with
@@ -288,13 +295,13 @@ class StrobelightCLIFunctionProfiler:
 # @strobelight(stop_at_error=True,...)
 def strobelight(
     profiler: Optional[StrobelightCLIFunctionProfiler] = None, **kwargs: Any
-) -> Any:
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R | None]]:
     if not profiler:
         profiler = StrobelightCLIFunctionProfiler(**kwargs)
 
-    def strobelight_inner(work_function: Any) -> Any:
+    def strobelight_inner(work_function: Callable[_P, _R]) -> Callable[_P, _R | None]:
         @functools.wraps(work_function)
-        def wrapper_function(*args: Any, **kwargs: Any) -> Any:
+        def wrapper_function(*args: _P.args, **kwargs: _P.kwargs) -> _R | None:
             return profiler.profile(work_function, *args, **kwargs)
 
         return wrapper_function

--- a/torch/utils/_strobelight/cli_function_profiler.py
+++ b/torch/utils/_strobelight/cli_function_profiler.py
@@ -252,7 +252,7 @@ class StrobelightCLIFunctionProfiler:
 
     def profile(
         self, work_function: Callable[_P, _R], *args: _P.args, **kwargs: _P.kwargs
-    ) -> _R | None:
+    ) -> Optional[_R]:
         self.current_run_id = None
 
         if locked := StrobelightCLIFunctionProfiler._lock.acquire(False):
@@ -295,13 +295,15 @@ class StrobelightCLIFunctionProfiler:
 # @strobelight(stop_at_error=True,...)
 def strobelight(
     profiler: Optional[StrobelightCLIFunctionProfiler] = None, **kwargs: Any
-) -> Callable[[Callable[_P, _R]], Callable[_P, _R | None]]:
+) -> Callable[[Callable[_P, _R]], Callable[_P, Optional[_R]]]:
     if not profiler:
         profiler = StrobelightCLIFunctionProfiler(**kwargs)
 
-    def strobelight_inner(work_function: Callable[_P, _R]) -> Callable[_P, _R | None]:
+    def strobelight_inner(
+        work_function: Callable[_P, _R]
+    ) -> Callable[_P, Optional[_R]]:
         @functools.wraps(work_function)
-        def wrapper_function(*args: _P.args, **kwargs: _P.kwargs) -> _R | None:
+        def wrapper_function(*args: _P.args, **kwargs: _P.kwargs) -> Optional[_R]:
             return profiler.profile(work_function, *args, **kwargs)
 
         return wrapper_function

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -11,9 +11,9 @@ from typing import (
     SupportsFloat,
     Tuple,
     TypeVar,
-    TypeVarTuple,
     Union,
 )
+from typing_extensions import TypeVarTuple, Unpack
 
 import sympy
 from sympy import S
@@ -102,9 +102,11 @@ def _is_symbols_binary_summation(expr: sympy.Expr) -> bool:
     )
 
 
-def _keep_float(f: Callable[[*_Ts], _T]) -> Callable[[*_Ts], Union[_T, sympy.Float]]:
+def _keep_float(
+    f: Callable[[Unpack[_Ts]], _T]
+) -> Callable[[Unpack[_Ts]], Union[_T, sympy.Float]]:
     @functools.wraps(f)
-    def inner(*args: *_Ts) -> Union[_T, sympy.Float]:
+    def inner(*args: Unpack[_Ts]) -> Union[_T, sympy.Float]:
         r: Union[_T, sympy.Float] = f(*args)
         if any(isinstance(a, sympy.Float) for a in args) and not isinstance(
             r, sympy.Float

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -4,7 +4,6 @@ import math
 import operator
 import sys
 from typing import (
-    Any,
     Callable,
     Iterable,
     List,
@@ -12,6 +11,7 @@ from typing import (
     SupportsFloat,
     Tuple,
     TypeVar,
+    TypeVarTuple,
     Union,
 )
 
@@ -32,6 +32,7 @@ from .numbers import int_oo
 
 
 _T = TypeVar("_T", bound=SupportsFloat)
+_Ts = TypeVarTuple("_Ts")
 
 # Portions of this file are adapted from the Sympy codebase, which was
 # licensed as follows:
@@ -101,9 +102,9 @@ def _is_symbols_binary_summation(expr: sympy.Expr) -> bool:
     )
 
 
-def _keep_float(f: Callable[..., _T]) -> Callable[..., Union[_T, sympy.Float]]:
+def _keep_float(f: Callable[[*_Ts], _T]) -> Callable[[*_Ts], Union[_T, sympy.Float]]:
     @functools.wraps(f)
-    def inner(*args: Any) -> Union[_T, sympy.Float]:
+    def inner(*args: *_Ts) -> Union[_T, sympy.Float]:
         r: Union[_T, sympy.Float] = f(*args)
         if any(isinstance(a, sympy.Float) for a in args) and not isinstance(
             r, sympy.Float


### PR DESCRIPTION
The codebase has a few locations where callable parameter type information is lost when the unpackings *args and **kwargs are typed as Any. Refactor these instances to retain type information using typing_extensions.ParamSpec.

Also, in these functions, enforce return type with TypeVar.

Addresses #142306

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @ezyang @malfet @xuzhao9 @gramster @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames