### PR TITLE
[Inductor][CPP] Enable Bias add for Group GEMM Template

### DIFF
--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -1738,7 +1738,15 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
     @parametrize("batch_size", (16,))
     @parametrize("in_features", (52,))
     @parametrize("out_features", (32,))
-    @parametrize("bias", ([True, True],))
+    @parametrize(
+        "bias",
+        (
+            [True, True],
+            [True, False],
+            [False, True],
+            [False, False],
+        ),
+    )
     @dtypes(
         torch.bfloat16,
     )

--- a/torch/_inductor/codegen/cpp_group_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_group_gemm_template.py
@@ -406,7 +406,7 @@ class CppGroupGemmTemplate(CppGemmTemplate):
             )
 
         assert (
-            not self.epilogue_creator
+            not self.epilogue_creator and not epilogue_nodes
         ), "Epilogue fusion is not implemented yet in Group GEMM Template"
 
         kernel_args = {}

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -458,7 +458,6 @@ class LocalBufferContext:
 
         def wrap_inner_fn_for_node(node: ir.IRNode):
             loops = node.data if isinstance(node, ir.ComputedBuffer) else node
-            print("loops is: {}".format(loops), flush=True)
             assert isinstance(loops, ir.Loops)
             new_inner_fn = self.localize_function(
                 loops.inner_fn,

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -458,6 +458,7 @@ class LocalBufferContext:
 
         def wrap_inner_fn_for_node(node: ir.IRNode):
             loops = node.data if isinstance(node, ir.ComputedBuffer) else node
+            print("loops is: {}".format(loops), flush=True)
             assert isinstance(loops, ir.Loops)
             new_inner_fn = self.localize_function(
                 loops.inner_fn,

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -47,7 +47,6 @@ if torch._C._has_mkldnn:
             (
                 node.args[0] != act
                 or (node.args[1] == wgt and gemm_idx != 0)
-                or node.args[2]  # <TODO> support bias through epilogue fusion
                 or node.args[1].meta.get("val").dtype != torch.bfloat16  # type: ignore[union-attr]
             )
             for gemm_idx, node in enumerate(computation_nodes)
@@ -92,7 +91,7 @@ if torch._C._has_mkldnn:
                             (
                                 act,
                                 [user.all_input_nodes[1] for user in users],
-                                [None for _ in users],
+                                [user.args[2] for user in users],
                             ),
                         )
                         group_gemm_node.meta["val"] = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #143850
* __->__ #143820
* #143796

**Summary**
In this PR, we move the `store_output` and `store_pointwise_nodes` to standalone functions for Group GEMM epilogue fusion to prepare for following Epilogue fusion PR. And we support Bias add as the epilogue fusion for Group GEMM.

**Test Plan**
```
python -u -m pytest -s -v test/inductor/test_cpu_select_algorithm.py -k test_group_linear_epilogue
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov