### PR TITLE
[Inductor][lowering] support out_dtype for dequant lowering

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1383,11 +1383,12 @@ def quantized_decomposed_dequantize_per_channel(
         scale = scales_loader(channel_idx)
         zero_point = zero_points_loader(channel_idx)
 
-        if scales.dtype != out_dtype:
-            scale = ops.to_dtype(scale, out_dtype)
-        if zero_points.dtype != out_dtype:
-            zero_point = ops.to_dtype(zero_point, out_dtype)
-        val = ops.sub(ops.to_dtype(input, out_dtype), zero_point) * scale
+        if scales.dtype != torch.float32:
+            scale = ops.to_dtype(scale, torch.float32)
+        if zero_points.dtype != torch.float32:
+            zero_point = ops.to_dtype(zero_point, torch.float32)
+        val = ops.sub(ops.to_dtype(input, torch.float32), zero_point) * scale
+        val = ops.to_dtype(val, out_dtype)
         return val
 
     return Pointwise.create(
@@ -1461,8 +1462,9 @@ def quantized_decomposed_dequantize_per_tensor_default(
 
     def inner_fn(idx, scale, zero_point):
         input = input_loader(idx)
-        scale, zero_point = _create_constants(scale, zero_point, dtype=out_dtype)
-        val = ops.sub(ops.to_dtype(input, out_dtype), zero_point) * scale
+        scale, zero_point = _create_constants(scale, zero_point, dtype=torch.float32)
+        val = ops.sub(ops.to_dtype(input, torch.float32), zero_point) * scale
+        val = ops.to_dtype(val, out_dtype)
         return val
 
     return Pointwise.create(
@@ -1557,11 +1559,12 @@ def quantized_decomposed_dequantize_per_tensor_tensor(
         input = input_loader(idx)
         _scale = scale_loader((0,) if len(scale.get_size()) == 1 else ())
         _zero_point = zero_point_loader((0,) if len(scale.get_size()) == 1 else ())
-        if scale.dtype != out_dtype:
-            _scale = ops.to_dtype(_scale, out_dtype)
-        if zero_point.dtype != out_dtype:
-            _zero_point = ops.to_dtype(_zero_point, out_dtype)
-        val = ops.sub(ops.to_dtype(input, out_dtype), _zero_point) * _scale
+        if scale.dtype != torch.float32:
+            _scale = ops.to_dtype(_scale, torch.float32)
+        if zero_point.dtype != torch.float32:
+            _zero_point = ops.to_dtype(_zero_point, torch.float32)
+        val = ops.sub(ops.to_dtype(input, torch.float32), _zero_point) * _scale
+        val = ops.to_dtype(val, out_dtype)
         return val
 
     return Pointwise.create(


### PR DESCRIPTION
In lowering, support the parameter `out_dtype` for `dequant_per_tensor` and `dequant_per_channel`.

Fix the following runtime error issue found in https://github.com/pytorch/ao/pull/1372:

```
File "/home/liaoxuan/pytorch_ao/torch/_inductor/lowering.py", line 452, in wrapped
    out = decomp_fn(*args, **kwargs)
torch._dynamo.exc.BackendCompilerFailed: backend='compile_fx_wrapper' raised:
LoweringException: TypeError: quantized_decomposed_dequantize_per_tensor_default() got an unexpected keyword argument 'out_dtype'
  target: quantized_decomposed.dequantize_per_tensor.default
  args[0]: TensorBox(StorageBox(
    InputBuffer(name='arg0_1', layout=FixedLayout('cpu', torch.uint8, size=[1, 7, 7, 9], stride=[441, 63, 9, 1]))
  ))
  args[1]: 0.01
  args[2]: 100
  args[3]: 0
  args[4]: 255
  args[5]: torch.uint8
  kwargs: {'out_dtype': torch.bfloat16}
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov