### PR TITLE
Make init_method deprecated to fix TCP connection refused error

### DIFF
--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -6,6 +6,7 @@ import itertools
 import math
 import pickle
 import sys
+import os
 
 import torch
 import torch.distributed as dist
@@ -1335,12 +1336,12 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
     @requires_nccl()
     def test_load_state_dict_errors(self):
         self.init_rpc()
-
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "29600"
         dist.init_process_group(
             backend="nccl",
             world_size=self.world_size,
-            rank=self.rank,
-            init_method=f"file://{self.file_name}",
+            rank=self.rank
         )
 
         spec = ChunkShardingSpec(

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -756,7 +756,6 @@ class TestAutoWrap(TestCase):
         file_name = tempfile.NamedTemporaryFile(delete=False).name
         torch.distributed.init_process_group(
             backend="nccl",
-            init_method=f"{FILE_SCHEMA}_{file_name}",
             rank=0,
             world_size=1,
         )

--- a/test/distributed/test_backends.py
+++ b/test/distributed/test_backends.py
@@ -36,7 +36,7 @@ class TestMiscCollectiveUtils(TestCase):
 
         backend = dist.get_default_backend_for_device(device)
         dist.init_process_group(
-            backend=backend, rank=0, world_size=1, init_method="env://"
+            backend=backend, rank=0, world_size=1
         )
         pg = dist.distributed_c10d._get_default_group()
         backend_pg = pg._get_backend_name()

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -196,7 +196,7 @@ class RendezvousEnvTest(TestCase):
 
         previous_handlers = logging.root.handlers
 
-        c10d.init_process_group(backend="gloo", init_method="env://")
+        c10d.init_process_group(backend="gloo")
 
         current_handlers = logging.root.handlers
         self.assertEqual(len(previous_handlers), len(current_handlers))
@@ -1790,10 +1790,10 @@ class DistributedDataParallelTest(
             def forward(self, x):
                 x = self.relu(self.fc1(x))
                 return F.softmax(x, dim=1)
-
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "29600"
         pg = dist.init_process_group(
             "gloo",
-            init_method=f"file://{self.file_name}",
             world_size=self.world_size,
             rank=self.rank,
         )
@@ -1844,9 +1844,10 @@ class DistributedDataParallelTest(
     @requires_gloo()
     @skip_if_lt_x_gpu(2)
     def test_save_load_checkpoint(self):
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "29600"
         dist.init_process_group(
             "gloo",
-            init_method=f"file://{self.file_name}",
             world_size=self.world_size,
             rank=self.rank,
         )

--- a/test/distributed/test_c10d_logger.py
+++ b/test/distributed/test_c10d_logger.py
@@ -11,7 +11,6 @@ import torch
 import torch.distributed as dist
 from torch.distributed.c10d_logger import _c10d_logger, _exception_logger
 
-
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
@@ -77,11 +76,12 @@ class C10dErrorLoggerTest(MultiProcessTestCase):
         dist.destroy_process_group()
 
     def dist_init(self):
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "29600"
         dist.init_process_group(
             backend=BACKEND,
             world_size=self.world_size,
-            rank=self.rank,
-            init_method=f"file://{self.file_name}",
+            rank=self.rank
         )
 
         # set device for nccl pg for collectives

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1166,6 +1166,8 @@ class DistributedDataParallelTest(
         # TORCH_NCCL_BLOCKING_WAIT overrides TORCH_NCCL_ASYNC_ERROR_HANDLING hence tests
         # that use TORCH_NCCL_BLOCKING_WAIT will test it as expected.
         os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = "1"
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(common.find_free_port())
         self._spawn_processes()
 
     def _get_process_group(self):
@@ -1479,8 +1481,7 @@ class DistributedDataParallelTest(
         dist.init_process_group(
             backend="nccl",
             world_size=self.world_size,
-            rank=self.rank,
-            init_method=f"file://{self.file_name}",
+            rank=self.rank
         )
         process_group = c10d.distributed_c10d._get_default_group()
 
@@ -1867,7 +1868,6 @@ class DistributedDataParallelTest(
     def test_pass_default_pg(self):
         dist.init_process_group(
             "nccl",
-            init_method=f"file://{self.file_name}",
             world_size=self.world_size,
             rank=self.rank,
         )

--- a/test/distributed/test_c10d_object_collectives.py
+++ b/test/distributed/test_c10d_object_collectives.py
@@ -6,7 +6,6 @@ from functools import partial, wraps
 import torch
 import torch.distributed as dist
 
-
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)

--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -126,7 +126,7 @@ class RendezvousEnvTest(TestCase):
 
         previous_handlers = logging.root.handlers
 
-        c10d.init_process_group(backend="ucc", init_method="env://")
+        c10d.init_process_group(backend="ucc")
 
         current_handlers = logging.root.handlers
         self.assertEqual(len(previous_handlers), len(current_handlers))
@@ -678,9 +678,10 @@ class DistributedDataParallelTest(
     @requires_ucc()
     @skip_if_lt_x_gpu(2)
     def test_save_load_checkpoint(self):
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "29600"
         dist.init_process_group(
             "ucc",
-            init_method=f"file://{self.file_name}",
             world_size=self.world_size,
             rank=self.rank,
         )

--- a/test/inductor/test_layout_optim.py
+++ b/test/inductor/test_layout_optim.py
@@ -51,9 +51,10 @@ class TestLayoutOptim(TestCase):
                     backend = "nccl"
                 elif GPU_TYPE == "xpu":
                     backend = "ccl"
+                os.environ["MASTER_PORT"] = str(port)
+                os.environ["MASTER_ADDR"] = "localhost"
                 dist.init_process_group(
                     backend=backend,
-                    init_method=f"tcp://localhost:{port}",
                     world_size=1,
                     rank=0,
                 )


### PR DESCRIPTION
```
import os
os.environ["TORCH_CPP_LOG_LEVEL"] = "INFO"
os.environ["TORCH_DISTRIBUTED_DEBUG"] = "DETAIL"
import torch
import torch.distributed as dist

def main():
    rank = int(os.environ["RANK"]) if "RANK" in os.environ else 0
    world_size = int(
        os.environ["WORLD_SIZE"]) if "WORLD_SIZE" in os.environ else 1
    dist.init_process_group("gloo", rank=rank, world_size=world_size,init_method="tcp://localhost:35980")
    dist.destroy_process_group()


if __name__ == "__main__":
    main()
```
Save the above code to `test_init_process.py,`  then run `torchrun --nproc_per_node=4  test_init_process.py` will result in the following errors`[I1226 11:25:16.460453259 socket.cpp:919] [c10d - trace] The server socket on localhost:35980 is not yet listening (errno: 111 - Connection refused), will retry.` 
you must use `torchrun --nproc_per_node=4 --rdzv-endpoint localhost:35980  test_init_process.py` can be executed normally.

Because the default IP and port set by  [https://github.com/pytorch/pytorch/blob/v2.6.0-rc3/torch/distributed/run.py#L597-L616](https://github.com/pytorch/pytorch/blob/v2.6.0-rc3/torch/distributed/run.py#L597-L616) are not consistent with the settings the parameter init_method of method init_process_group.
BTW,The default IP and port settings will prevent [this code](https://github.com/pytorch/pytorch/blob/v2.6.0-rc3/torch/distributed/launcher/api.py#L170-L173) from running,Should we remove the default IP and port settings?


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov