### PR TITLE
remove allow-untyped-defs from _inductor/codegen/cpu_device_op_overrides.py

### DIFF
--- a/torch/_inductor/codegen/cpu_device_op_overrides.py
+++ b/torch/_inductor/codegen/cpu_device_op_overrides.py
@@ -1,11 +1,10 @@
-# mypy: allow-untyped-defs
 from textwrap import dedent
 
 from .common import DeviceOpOverrides, register_device_op_overrides
 
 
 class CpuDeviceOpOverrides(DeviceOpOverrides):
-    def import_get_raw_stream_as(self, name):
+    def import_get_raw_stream_as(self, name: str) -> str:
         return dedent(
             """
             def get_raw_stream(_):
@@ -13,13 +12,13 @@ class CpuDeviceOpOverrides(DeviceOpOverrides):
             """
         )
 
-    def set_device(self, device_idx):
+    def set_device(self, device_idx: int) -> str:
         return "pass"
 
-    def synchronize(self):
+    def synchronize(self) -> str:
         return "pass"
 
-    def device_guard(self, device_idx):
+    def device_guard(self, device_idx: int) -> str:
         return "pass"
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143881



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov