### PR TITLE
restore 'unused' variable to fix test_cuda_device_memory_allocated

### DIFF
--- a/test/test_cuda_multigpu.py
+++ b/test/test_cuda_multigpu.py
@@ -1303,6 +1303,7 @@ t2.start()
 
         device_count = torch.cuda.device_count()
         current_alloc = [memory_allocated(idx) for idx in range(device_count)]
+        x = torch.ones(10, device="cuda:0")  # noqa: F841
         self.assertGreater(memory_allocated(0), current_alloc[0])
         self.assertTrue(
             all(

--- a/test/test_cuda_multigpu.py
+++ b/test/test_cuda_multigpu.py
@@ -1303,7 +1303,7 @@ t2.start()
 
         device_count = torch.cuda.device_count()
         current_alloc = [memory_allocated(idx) for idx in range(device_count)]
-        x = torch.ones(10, device="cuda:0")  # noqa: F841
+        _x = torch.ones(10, device="cuda:0")
         self.assertGreater(memory_allocated(0), current_alloc[0])
         self.assertTrue(
             all(


### PR DESCRIPTION
This PR fix `test_cuda_multigpu.py::TestCudaMultiGPU::test_cuda_device_memory_allocated`
by restoring a deleted 'unused' variable from commit https://github.com/pytorch/pytorch/commit/d8c8ba24404ef892d4d948eb095b69d90b9ba7e6

cc @jithunnair-amd @jeffdaily @pruthvistony 