### PR TITLE
[Inductor] Implement primitive Metal compiler

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -1,0 +1,39 @@
+# Owner(s): ["module: mps"]
+import importlib
+import os
+import sys
+
+import torch
+
+
+importlib.import_module("filelock")
+
+pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(pytorch_test_dir)
+
+from inductor.test_torchinductor import (  # @manual=fbcode//caffe2/test/inductor:test_inductor-library
+    check_model_gpu,
+    TestCase,
+)
+
+
+# TODO: Remove this file.
+# This tests basic MPS compile functionality
+
+
+class MPSBasicTests(TestCase):
+    common = check_model_gpu
+    device = "mps"
+
+    def test_add(self):
+        self.common(lambda a, b: a + b, (torch.rand(1024), torch.rand(1024)))
+
+    def test_acos(self):
+        self.common(lambda a: a.acos(), (torch.rand(1024),))
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    if torch.backends.mps.is_available():
+        run_tests(needs="filelock")

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -70,6 +70,13 @@ class MPSBasicTests(TestCase):
     def test_broadcast(self):
         self.common(torch.add, (torch.rand(32, 1024), torch.rand(1024)))
 
+    def test_inplace(self):
+        def inc_(x):
+            x += 1
+            return x
+
+        self.common(inc_, (torch.rand(1024),))
+
 
 instantiate_parametrized_tests(MPSBasicTests)
 

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -50,6 +50,10 @@ class MPSBasicTests(TestCase):
     def test_acos(self):
         self.common(lambda a: a.acos(), (torch.rand(1024),))
 
+    @parametrize("dtype", MPS_DTYPES)
+    def test_cast(self, dtype):
+        self.common(lambda a: a.to(dtype), (torch.rand(1024),))
+
 
 instantiate_parametrized_tests(MPSBasicTests)
 

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -48,7 +48,20 @@ class MPSBasicTests(TestCase):
         )
 
     def test_acos(self):
-        self.common(lambda a: a.acos(), (torch.rand(1024),))
+        self.common(lambda x: x.acos(), (torch.rand(1024),))
+
+    def test_sliced_input(self):
+        self.common(
+            lambda x: x[:, ::2].sin() + x[:, 1::2].cos(), (torch.rand(32, 1024),)
+        )
+
+    def test_where(self):
+        def foo(x):
+            rc = x.abs().sqrt()
+            rc[x < 0] = -5
+            return rc
+
+        self.common(foo, (torch.rand(1024),))
 
     @parametrize("dtype", MPS_DTYPES)
     def test_cast(self, dtype):

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -67,6 +67,9 @@ class MPSBasicTests(TestCase):
     def test_cast(self, dtype):
         self.common(lambda a: a.to(dtype), (torch.rand(1024),))
 
+    def test_broadcast(self):
+        self.common(torch.add, (torch.rand(32, 1024), torch.rand(1024)))
+
 
 instantiate_parametrized_tests(MPSBasicTests)
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1782,6 +1782,7 @@ def get_selected_tests(options) -> List[str]:
             "nn/test_pooling",
             "test_view_ops",
             "test_nn",
+            "inductor/test_mps_basic",
         ]
     else:
         # Exclude all mps tests otherwise

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -361,6 +361,7 @@ def init_backend_registration():
     from .cpp_wrapper_gpu import CppWrapperGpu
     from .cuda_combined_scheduling import CUDACombinedScheduling
     from .halide import HalideScheduling
+    from .mps import MetalScheduling
     from .triton import TritonScheduling
     from .wrapper import PythonWrapperCodegen
 
@@ -393,6 +394,14 @@ def init_backend_registration():
         register_backend_for_device(
             "xpu",
             TritonScheduling,
+            PythonWrapperCodegen,
+            CppWrapperGpu,
+        )
+
+    if get_scheduling_for_device("mps") is None:
+        register_backend_for_device(
+            "mps",
+            MetalScheduling,
             PythonWrapperCodegen,
             CppWrapperGpu,
         )

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -55,11 +55,11 @@ class MetalOverrides(OpOverrides):
 
     @staticmethod
     def sin(x: CSEVariable) -> str:
-        return f"metal::sin({x})"
+        return f"metal::precise::sin({x})"
 
     @staticmethod
     def cos(x: CSEVariable) -> str:
-        return f"metal::cos({x})"
+        return f"metal::precise::cos({x})"
 
     @staticmethod
     def tan(x: CSEVariable) -> str:

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -2,6 +2,8 @@
 # This is not a feature-complete compiler backend end
 # Just an early prototype that shows that one can compile
 # Easy models to Metal
+from typing import Optional
+
 import sympy
 
 import torch
@@ -31,18 +33,26 @@ class MetalOverrides(OpOverrides):
     def to_dtype(
         x,
         dtype: torch.dtype,
-        src_dtype: torch.dtype | None = None,
+        src_dtype: Optional[torch.dtype] = None,
         use_compute_types=True,
     ):
         return f"static_cast<{DTYPE_TO_METAL[dtype]}>({x})"
+
+    @staticmethod
+    def where(a, b, c):
+        return f"{a} ? {b} : {c}"
 
     @staticmethod
     def logical_or(a, b):
         return f"{a} | {b}"
 
     @staticmethod
-    def atan(x):
-        return f"metal::atan({x})"
+    def logical_and(a, b):
+        return f"{a} & {b}"
+
+    @staticmethod
+    def abs(x):
+        return f"metal::abs({x})"
 
     @staticmethod
     def sin(x):
@@ -53,8 +63,24 @@ class MetalOverrides(OpOverrides):
         return f"metal::cos({x})"
 
     @staticmethod
+    def tan(x):
+        return f"metal::tan({x})"
+
+    @staticmethod
+    def asin(x):
+        return f"metal::asin({x})"
+
+    @staticmethod
     def acos(x):
         return f"metal::acos({x})"
+
+    @staticmethod
+    def atan(x):
+        return f"metal::atan({x})"
+
+    @staticmethod
+    def sqrt(x):
+        return f"metal::sqrt({x})"
 
 
 class MetalKernel(SIMDKernel):

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -28,6 +28,15 @@ DTYPE_TO_METAL = {
 
 class MetalOverrides(OpOverrides):
     @staticmethod
+    def to_dtype(
+        x,
+        dtype: torch.dtype,
+        src_dtype: torch.dtype | None = None,
+        use_compute_types=True,
+    ):
+        return f"static_cast<{DTYPE_TO_METAL[dtype]}>({x})"
+
+    @staticmethod
     def logical_or(a, b):
         return f"{a} | {b}"
 

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -129,6 +129,8 @@ class MetalKernel(SIMDKernel):
             code.writeline("kernel void kernel_0(")
             with code.indent():
                 for outer, inner in self.args.output_buffers.items():
+                    if outer in self.removed_buffers:
+                        continue
                     dtype_str = self.dtype_to_str(V.graph.get_dtype(outer))
                     code.writeline(f"device {dtype_str}* {inner},")
                 for outer, inner in self.args.input_buffers.items():
@@ -147,6 +149,7 @@ class MetalKernel(SIMDKernel):
         """Codegen a call to this kernel"""
         wrapper = V.graph.wrapper_code
         args = [*self.args.output_buffers.keys(), *self.args.input_buffers.keys()]
+        args = [arg for arg in args if arg not in self.removed_buffers]
         wrapper.generate_kernel_call(
             name,
             args,

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -1,5 +1,7 @@
 # mypy: allow-untyped-defs
-
+# This is not a feature-complete compiler backend end
+# Just an early prototype that shows that one can compile
+# Easy models to Metal
 import sympy
 
 import torch
@@ -12,6 +14,12 @@ from .simd import SIMDKernel, SIMDScheduling
 
 
 DTYPE_TO_METAL = {
+    torch.bool: "bool",
+    torch.int8: "char",
+    torch.int16: "short",
+    torch.int32: "int",
+    torch.int64: "long",
+    torch.uint8: "uchar",
     torch.float: "float",
     torch.half: "half",
     torch.bfloat16: "bfloat",
@@ -19,6 +27,10 @@ DTYPE_TO_METAL = {
 
 
 class MetalOverrides(OpOverrides):
+    @staticmethod
+    def logical_or(a, b):
+        return f"{a} | {b}"
+
     @staticmethod
     def atan(x):
         return f"metal::atan({x})"

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -1,0 +1,123 @@
+# mypy: allow-untyped-defs
+
+import sympy
+
+import torch
+
+from ..ops_handler import StoreMode
+from ..utils import get_kernel_metadata
+from ..virtualized import V
+from .common import CSEVariable, DeferredLine, IndentedBuffer, OpOverrides
+from .simd import SIMDKernel, SIMDScheduling
+
+
+DTYPE_TO_METAL = {
+    torch.float: "float",
+    torch.half: "half",
+    torch.bfloat16: "bfloat",
+}
+
+
+class MetalOverrides(OpOverrides):
+    @staticmethod
+    def atan(x):
+        return f"metal::atan({x})"
+
+    @staticmethod
+    def sin(x):
+        return f"metal::sin({x})"
+
+    @staticmethod
+    def cos(x):
+        return f"metal::cos({x})"
+
+    @staticmethod
+    def acos(x):
+        return f"metal::acos({x})"
+
+
+class MetalKernel(SIMDKernel):
+    overrides = MetalOverrides  # type: ignore[assignment]
+    suffix = ";"
+    newvar_prefix = "auto "
+
+    def __init__(
+        self,
+        tiling: dict[str, sympy.Expr],
+        **kwargs,
+    ) -> None:
+        super().__init__(tiling, **kwargs)
+        self.compute = self.body
+        self.loads = self.body
+        self.stores = self.body
+
+    def dtype_to_str(self, dtype: torch.dtype) -> str:
+        return DTYPE_TO_METAL[dtype]
+
+    def load(self, name: str, index: sympy.Expr):
+        """Codegen a load from an InputBuffer"""
+        var = self.args.input(name)
+        index = self.prepare_indexing(index)
+        line = f"{var}[{index}]"
+        return self.cse.generate(self.body, line)
+
+    def store(
+        self, name: str, index: sympy.Expr, value: CSEVariable, mode: StoreMode = None
+    ) -> None:
+        var = self.args.output(name)
+        index = self.prepare_indexing(index)
+        dtype_str = self.dtype_to_str(V.graph.get_dtype(name))
+        line = f"{var}[{index}] = static_cast<{dtype_str}>({value});"
+        self.body.writeline(DeferredLine(name, line))
+
+    def codegen_kernel(self, name=None):
+        """Called at the end to generate a final kernel string"""
+        code = IndentedBuffer()
+        code.writeline('torch.mps._compile_shader("""')
+        with code.indent():
+            code.writeline("kernel void kernel_0(")
+            with code.indent():
+                for outer, inner in self.args.output_buffers.items():
+                    dtype_str = self.dtype_to_str(V.graph.get_dtype(outer))
+                    code.writeline(f"device {dtype_str}* {inner},")
+                for outer, inner in self.args.input_buffers.items():
+                    dtype_str = self.dtype_to_str(V.graph.get_dtype(outer))
+                    code.writeline(f"constant {dtype_str}* {inner},")
+                code.writeline("uint x0 [[thread_position_in_grid]]")
+            code.writeline(") {")
+            with code.indent():
+                code.splice(self.body)
+            code.writeline("}")
+        code.writeline('""")')
+
+        return code.getvalue()
+
+    def call_kernel(self, name: str, node=None):
+        """Codegen a call to this kernel"""
+        wrapper = V.graph.wrapper_code
+        args = list(self.args.output_buffers.keys()) + list(
+            self.args.input_buffers.keys()
+        )
+        wrapper.generate_kernel_call(
+            name,
+            args,
+            gpu=False,  # TODO: Fix me
+            triton=False,
+        )
+
+
+class MetalScheduling(SIMDScheduling):
+    kernel_type = MetalKernel  # type: ignore[assignment]
+
+    def define_kernel(self, src_code, node_schedule, kernel):
+        wrapper = V.graph.wrapper_code
+        if src_code in wrapper.src_to_kernel:
+            kernel_name = wrapper.src_to_kernel[src_code]
+        else:
+            kernel_name = f"mps_lib.kernel_{wrapper.next_kernel_suffix()}"
+            wrapper.src_to_kernel[src_code] = kernel_name
+            origins, detailed_origins = get_kernel_metadata(node_schedule, wrapper)
+            metadata_comment = f"{origins}\n{detailed_origins}"
+            wrapper.define_kernel("mps_lib", src_code, metadata_comment)
+
+        return kernel_name


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143893
* #143892

Still work in progress, only works for element wise operations. Current implementation could be used to turn something like
```python
def f(x):
  return x[:,::2].sin() + x[:, 1::2].cos()
```
into the following shader
```python
# Topologically Sorted Source Nodes: [sin, cos, add], Original ATen: [aten.sin, aten.cos, aten.add]
# Source node to ATen node mapping:
#   add => add
#   cos => cos
#   sin => sin
# Graph fragment:
#   %sin : [num_users=1] = call_function[target=torch.ops.aten.sin.default](args = (%slice_2,), kwargs = {})
#   %cos : [num_users=1] = call_function[target=torch.ops.aten.cos.default](args = (%slice_4,), kwargs = {})
#   %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%sin, %cos), kwargs = {})
mps_lib = torch.mps._compile_shader("""
    kernel void kernel_0(
        device float* out_ptr0,
        constant float* in_ptr0,
        uint xindex [[thread_position_in_grid]]
    ) {
        int x0 = xindex;
        auto tmp0 = in_ptr0[2*x0];
        auto tmp1 = metal::precise::sin(tmp0);
        auto tmp2 = in_ptr0[2*x0 + 1];
        auto tmp3 = metal::precise::cos(tmp2);
        auto tmp4 = tmp1 + tmp3;
        out_ptr0[x0] = static_cast<float>(tmp4);
    }
""")
```

Please note, that `torch.compile` in 2.7 is an early prototype and one should wait with migration until 2.8 is out, see progress tracker here: https://github.com/pytorch/pytorch/issues/150121

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov