### PR TITLE
[Inductor][CPP] Remove redundant Buffers after Grouped GEMM Fusion

### DIFF
--- a/torch/_inductor/codegen/cpp_template_kernel.py
+++ b/torch/_inductor/codegen/cpp_template_kernel.py
@@ -478,6 +478,7 @@ class CppTemplateKernel(CppKernel):
                             and self.args.output_buffers[multi_output_name] != "REMOVED"
                         ):
                             self.remove_buffer(multi_output_name)
+                        if self.args.output_buffers[multi_output_name] == "REMOVED":
                             assert isinstance(
                                 multi_output_buffers[gemm_idx],
                                 ir.MultiOutput,

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -487,7 +487,8 @@ class AllocateLine(MemoryPlanningLine):
         ):
             assert isinstance(self.node.outputs, Iterable)
             for output in self.node.outputs:
-                code.writeline(self.wrapper.make_buffer_allocation(output))
+                if output.get_name() not in self.node.outputs_removed:
+                    code.writeline(self.wrapper.make_buffer_allocation(output))
         else:
             line = self.wrapper.make_buffer_allocation(self.node)
             code.writeline(line)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4435,6 +4435,7 @@ class CppTemplateBuffer(TemplateBuffer):
         self.template = template
         self.choice = choice
         self.outputs: Optional[List[Buffer]] = None
+        self.outputs_removed: List[str] = []
 
     def get_layout(self) -> Layout:
         if isinstance(self.layout, MultiOutputLayout):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143904
* #143897
* #143796

**Summary**
In this PR, we remove the extra kernel arguments and the extra buffers allocation when any `MultiOutput Buffer` is consumed by an out-template epilogue. If any `MultiOutput Buffer` is consumed by an out-template epilogue, the `Grouped GEMM Template` should bypass storing it in the `MultiOutput Buffer` and instead write it directly to the corresponding out-template epilogue.

**Remove extra kernel arguments**
For the case listed above, a `MultiOutput Buffer` shouldn't exist in the Kernel's args if it's consumed by an out-template epilogue. We mark this `MultiOutput Buffer` as `REMOVED` for this case.

**Remove the extra buffers allocation**
For the case listed above, a `MultiOutput Buffer` shouldn't be allocated. We introduce the `outputs_removed` attribute in the `CppTemplateBuffer`. This attribute tracks `MultiOutput Buffers` that are directly used by out-template epilogues. During code generation, if a `MultiOutput Buffer` is listed in `outputs_removed`, its buffer allocation line is omitted to prevent unnecessary memory usage.

**Test Plan**
```
python -u -m pytest -s -v test/inductor/test_cpu_select_algorithm.py -k test_grouped_linear_epilogue
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov