### PR TITLE
[EZ] Update sympy to 1.13.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ psutil
 pyyaml
 requests
 setuptools
-sympy==1.13.1 ; python_version >= "3.9"
+sympy==1.13.3
 types-dataclasses
 typing-extensions>=4.10.0


### PR DESCRIPTION
And remove python>=3.9 check as it currently covers all supported python versions

Fixes https://github.com/pytorch/pytorch/issues/143907
