### PR TITLE
Add `_benchmark_func` convenience method

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12622,6 +12622,12 @@ class TestMetalLibrary(TestCaseMPS):
         # Passing no tensors asserts
         self.assertRaises(RuntimeError, lambda: lib.full(12))
 
+class TestPerformance(TestCaseMPS):
+    def test_add_perf(self):
+        n = 32768
+        time_mps = torch.testing._benchmark_func(torch.add, (n, n), device="mps").mean
+        # This mostly measures synchronization time, but it shoudl still be less than 200ms
+        self.assertLess(time_mps, 1e-2)
 
 # TODO: Actually instantiate that test for the "mps" device to better reflect what it is doing.
 # This requires mps to be properly registered in the device generic test framework which is not the

--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -1,5 +1,6 @@
 from torch._C import FileCheck as FileCheck
 
 from . import _utils
+from ._benchmark import benchmark_func as _benchmark_func
 from ._comparison import assert_allclose, assert_close as assert_close
 from ._creation import make_tensor as make_tensor

--- a/torch/testing/_benchmark.py
+++ b/torch/testing/_benchmark.py
@@ -1,0 +1,46 @@
+from typing import Callable, List, Union
+
+import torch
+
+
+def benchmark_func(
+    func: Callable,
+    sizes: Union[int, List[Union[List[int], int]]],
+    device: str = "cpu",
+    dtype: torch.dtype = torch.float32,
+) -> "torch.utils.benchmark.Measurement":
+    """Convenienence  wrapper for benchmarking an individual operators with specific input sizes and dtypes
+    Measures the wall clock time of running the function , and synchronizing on device if needed.
+    Example:
+
+      >>> torch.testing._benchmark_func(torch.sin, [1024,])
+      <torch.utils.benchmark.utils.common.Measurement object at 0x10b2a96a0>
+      f(*args);
+      setup: args = [torch.testing.make_tensor(s, dtype=torch.float32, device='cpu') for s in [1024]]
+      Median: 1.29 us
+      IQR:    0.13 us (1.29 to 1.42)
+      148525 measurements, 1 runs per measurement, 1 thread
+    """
+    from timeit import default_timer
+
+    from torch.utils.benchmark import Timer
+
+    if device == "mps":
+        sync_cmd = "torch.mps.synchronize()"
+    elif device == "cuda":
+        sync_cmd = "torch.cuda.synchronize()"
+    else:
+        sync_cmd = ""
+
+    if isinstance(sizes, int):
+        sizes = [sizes]
+    t = Timer(
+        stmt=f"f(*args);{sync_cmd}",
+        setup=f"args = [torch.testing.make_tensor(s, dtype={dtype}, device='{device}') for s in {sizes}]",
+        globals={
+            "f": func,
+        },
+        language="python",
+        timer=default_timer,
+    )
+    return t.blocked_autorange()


### PR DESCRIPTION
Which could be used to benchmark simple ops with just one line of code, for example:
```shell
%  python -c "import torch;print(torch.testing._benchmark_func(torch.add, (1024, 1024), device='mps', dtype=torch.int32))"
<torch.utils.benchmark.utils.common.Measurement object at 0x1081dee40>
f(*args);torch.mps.synchronize()
setup: args = [torch.testing.make_tensor(s, dtype=torch.int32, device='mps') for s in (1024, 1024)]
  Median: 145.63 us
  IQR:    21.00 us (130.33 to 151.33)
  1397 measurements, 1 runs per measurement, 1 thread
  WARNING: Interquartile range is 14.4% of the median measurement.
           This could indicate system fluctuation.

```
