### PR TITLE
remove allow-untyped-defs from distributed/pipelining/_unflatten.py

### DIFF
--- a/torch/distributed/pipelining/_unflatten.py
+++ b/torch/distributed/pipelining/_unflatten.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 # Copyright (c) Meta Platforms, Inc. and affiliates
 from collections import defaultdict
 from typing import Dict, List, Set
@@ -7,7 +6,7 @@ import torch
 from torch.export.unflatten import _ModuleFrame, _SubmoduleEntry
 
 
-def _outline_submodules(orig_graph: torch.fx.Graph):
+def _outline_submodules(orig_graph: torch.fx.Graph) -> torch.fx.GraphModule:
     # Create an empty GraphModule to hold the outlined modules
     new_module = torch.fx.GraphModule(torch.nn.Module(), torch.fx.Graph())
     seen_nodes: Dict[str, torch.fx.Node] = {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #143916
* __->__ #143915



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o