### PR TITLE
remove allow-untyped-defs from distributed/elastic/multiprocessing/subprocess_handler/handlers.py

### DIFF
--- a/torch/distributed/elastic/multiprocessing/subprocess_handler/handlers.py
+++ b/torch/distributed/elastic/multiprocessing/subprocess_handler/handlers.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# mypy: allow-untyped-defs
-
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
 #
@@ -23,7 +20,7 @@ def get_subprocess_handler(
     stdout: str,
     stderr: str,
     local_rank_id: int,
-):
+) -> SubprocessHandler:
     return SubprocessHandler(
         entrypoint=entrypoint,
         args=args,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #143917



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o