### PR TITLE
Fix an unnecessary CPU to GPU copy within flex_attention

### DIFF
--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -186,7 +186,7 @@ def _math_attention_inner(
         post_mod_scores = torch.where(
             mask_mod(b, h, m, n, *mask_mod_other_buffers),
             score_mod(scores, b, h, m, n, *score_mod_other_buffers),
-            torch.tensor(-float("inf"), dtype=working_precision, device=scores.device),
+            torch.full((), -float("inf"), dtype=working_precision, device=scores.device),
         )
 
     return scores, post_mod_scores


### PR DESCRIPTION
There are a few unnecessary CPU to GPU copies within flex_attention that cause unnecessary `cudaStreamSynchronize`s to occur. This decreases GPU utilization.

The existing code creates a `-inf` tensor on CPU and copies it to GPU (along with a synchronize).

The updated code no longer causes a cudaStreamSynchronize (validated with local profiling).

See #143927 for more details.

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki @Chillee @drisspg @yanboliang @BoyuanFeng