### PR TITLE
[Torch.package] Add support for UntypedStorage tensors

### DIFF
--- a/test/package/test_save_load.py
+++ b/test/package/test_save_load.py
@@ -2,8 +2,11 @@
 
 import pickle
 from io import BytesIO
+from sys import version_info
 from textwrap import dedent
+from unittest import skipIf
 
+import torch
 from torch.package import PackageExporter, PackageImporter, sys_importer
 from torch.testing._internal.common_utils import run_tests
 
@@ -264,6 +267,20 @@ class TestSaveLoad(PackageTestCase):
         with PackageExporter(buffer2, importer=(importer, sys_importer)) as exporter:
             exporter.intern("**")
             exporter.save_module("package_a.use_torch_package_importer")
+
+    @skipIf(version_info >= (3, 13), "https://github.com/pytorch/pytorch/issues/142170")
+    def test_save_load_fp8(self):
+        tensor = torch.rand(20, 20).to(torch.float8_e4m3fn)
+
+        buffer = BytesIO()
+        with PackageExporter(buffer) as exporter:
+            exporter.save_pickle("fp8_model", "model.pkl", tensor)
+
+        buffer.seek(0)
+
+        importer = PackageImporter(buffer)
+        loaded_tensor = importer.load_pickle("fp8_model", "model.pkl")
+        self.assertTrue(torch.equal(tensor, loaded_tensor))
 
 
 if __name__ == "__main__":

--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -260,7 +260,10 @@ class PackageImporter(Importer):
 
             if typename == "storage":
                 storage_type, key, location, size = data
-                dtype = storage_type.dtype
+                if storage_type is torch.UntypedStorage:
+                    dtype = torch.uint8
+                else:
+                    dtype = storage_type.dtype
 
                 if key not in loaded_storages:
                     load_tensor(


### PR DESCRIPTION
Summary: fp8 uses untyped storage. Add support for torch.package by using the same logic as in serialization.py

Differential Revision: D67684033


