### PR TITLE
Modify old differentiable optimizer tests to use optim_db

### DIFF
--- a/test/optim/test_optim.py
+++ b/test/optim/test_optim.py
@@ -367,7 +367,6 @@ class TestDifferentiableOptimizer(TestCase):
             ),
         )
 
-
     def test_differentiable_lr(self):
         params = torch.rand(10, requires_grad=True, dtype=torch.float64)
         grad = torch.rand_like(params, requires_grad=True, dtype=torch.float64)

--- a/test/optim/test_optim.py
+++ b/test/optim/test_optim.py
@@ -7,7 +7,6 @@ from typing import Any
 import torch
 from torch import nn, Tensor
 from torch.optim import Optimizer, SGD
-from torch.testing._internal.common_optimizers import optim_db, OptimizerInfo, optims
 from torch.testing._internal.common_utils import (
     gradcheck,
     load_tests,
@@ -19,27 +18,6 @@ from torch.testing._internal.common_utils import (
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
 load_tests = load_tests
-
-
-def _diff_fn(p, grad, opt_differentiable_state, opt_class, kwargs, *ignored):
-    # Ignored is the list of values in `opt_differentiable_state`, we do this
-    # for `gradcheck` to correctly track the state tensors as function inputs
-    # because otherwise it can't unpack the values in the `opt_differentiable_state`
-    # dict
-    p = p.clone()
-    p.grad = grad
-    opt_differentiable_state = {
-        k: v.clone() if isinstance(v, torch.Tensor) else v
-        for k, v in opt_differentiable_state.items()
-    }
-    opt = opt_class([p], **kwargs)
-    opt.state[p].update(opt_differentiable_state)
-    opt.step()
-    return (p,) + tuple(
-        v
-        for v in opt.state[p].values()
-        if isinstance(v, torch.Tensor) and v.requires_grad
-    )
 
 
 def _multistep_backprop_diff_hyperparams_fn(
@@ -115,64 +93,6 @@ def _multistep_backprop_diff_hyperparams_fn(
         )
         + tuple(differentiable_kwargs)
     )
-
-
-def _get_optimizer_state(
-    optim_cls: type[Optimizer],
-    params: Tensor,
-    optim_kwargs: dict[str, Any],
-) -> dict[str, Any]:
-    params.grad = torch.rand_like(params)
-
-    optim = optim_cls([params], **optim_kwargs)
-    optim.step()
-
-    states = optim.state_dict()["state"]
-    # Accesses state of the first (and only) parameter. When using SGD w/ no momentum, there is no state
-    state = states[0] if 0 in states else states
-    return state
-
-
-class TestDifferentiableOptimizerOptimizerInfo(TestCase):
-    @optims(optim_db, dtypes=[torch.float64])
-    def test_optimizers_differentiable_wrt_params(
-        self, device: str, dtype: torch.dtype, optim_info: OptimizerInfo
-    ):
-        optim_cls = optim_info.optim_cls
-        if "differentiable" not in optim_info.supported_impls:
-            self.skipTest(f"Differentiable {optim_cls.__name__} not supported")
-
-        for optim_input in optim_info.optim_inputs_func(device=device):
-            mock_params = torch.rand(10, requires_grad=True, device=device, dtype=dtype)
-            mock_optim_kwargs = optim_input.kwargs.copy()
-            optim_state = _get_optimizer_state(
-                optim_cls, mock_params, mock_optim_kwargs
-            )
-
-            optim_kwargs = optim_input.kwargs
-            optim_kwargs.update({"differentiable": True})
-
-            # Cannot be capturable and differentiable
-            if "capturable" in optim_kwargs:
-                optim_kwargs.update({"capturable": False})
-
-            # sgd defaults to foreach on cuda so must explicitly specify not foreach
-            if optim_cls is SGD and device.startswith("cuda"):
-                optim_kwargs.update({"foreach": False})
-
-            params = torch.rand(10, requires_grad=True, device=device, dtype=dtype)
-            grad = torch.rand(10, requires_grad=True, device=device, dtype=dtype)
-            gradcheck(
-                _diff_fn,
-                (
-                    params,
-                    grad,
-                    optim_state,
-                    optim_cls,
-                    optim_kwargs,
-                    *optim_state.values(),
-                ),
-            )
 
 
 @skipIfTorchDynamo("Differentiable optimizers not supported")
@@ -252,6 +172,4 @@ class TestDifferentiableOptimizer(TestCase):
 
 
 if __name__ == "__main__":
-    A = TestDifferentiableOptimizerOptimizerInfo()
-    A.test_optimizers_differentiable_wrt_params("cpu", torch.float64, optim_db[-2])
     print("These tests should be run through test/test_optim.py instead")

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -8,10 +8,7 @@ from typing import Any, Dict, Tuple
 from unittest.mock import patch
 
 from optim.test_lrscheduler import TestLRScheduler  # noqa: F401
-from optim.test_optim import (  # noqa: F401
-    TestDifferentiableOptimizer,
-    TestDifferentiableOptimizerOptimizerInfo,
-)
+from optim.test_optim import TestDifferentiableOptimizer  # noqa: F401
 from optim.test_swa_utils import TestSWAUtils  # noqa: F401
 
 import torch
@@ -38,10 +35,12 @@ from torch.testing._internal.common_optimizers import (
     _get_optim_inputs_including_global_cliquey_kwargs,
     optim_db,
     OptimizerErrorEnum,
+    OptimizerInfo,
     optims,
     TensorTracker,
 )
 from torch.testing._internal.common_utils import (
+    gradcheck,
     markDynamoStrictTest,
     parametrize,
     run_tests,
@@ -2219,11 +2218,90 @@ class TestOptimRenewed(TestCase):
             for state in optim.state.values():
                 self.assertGreater(len(state), 0)
 
+    @optims(optim_db, dtypes=[torch.float64])
+    def test_optimizers_differentiable_wrt_params(
+        self, device: str, dtype: torch.dtype, optim_info: OptimizerInfo
+    ):
+        def _diff_fn(
+            p: torch.Tensor,
+            grad: torch.Tensor,
+            opt_differentiable_state: dict[str, Any],
+            opt_class: type[Optimizer],
+            kwargs: dict[str, Any],
+            *ignored,
+        ) -> tuple[torch.Tensor, ...]:
+            # Ignored is the list of values in `opt_differentiable_state`, we do this
+            # for `gradcheck` to correctly track the state tensors as function inputs
+            # because otherwise it can't unpack the values in the `opt_differentiable_state`
+            # dict
+            p = p.clone()
+            p.grad = grad
+            opt_differentiable_state = {
+                k: v.clone() if isinstance(v, torch.Tensor) else v
+                for k, v in opt_differentiable_state.items()
+            }
+            opt = opt_class([p], **kwargs)
+            opt.state[p].update(opt_differentiable_state)
+            opt.step()
+            return (p,) + tuple(
+                v
+                for v in opt.state[p].values()
+                if isinstance(v, torch.Tensor) and v.requires_grad
+            )
+
+        def _get_optimizer_state(
+            optim_cls: type[Optimizer],
+            params: torch.Tensor,
+            optim_kwargs: dict[str, Any],
+        ) -> dict[str, Any]:
+            params.grad = torch.rand_like(params)
+
+            optim = optim_cls([params], **optim_kwargs)
+            optim.step()
+
+            states = optim.state_dict()["state"]
+            # Accesses state of the first (and only) parameter. When using SGD w/ no momentum, there is no state
+            state = states[0] if 0 in states else states
+            return state
+
+        optim_cls = optim_info.optim_cls
+        if "differentiable" not in optim_info.supported_impls:
+            self.skipTest(f"Differentiable {optim_cls.__name__} not supported")
+
+        for optim_input in optim_info.optim_inputs_func(device=device):
+            mock_params = torch.rand(10, requires_grad=True, device=device, dtype=dtype)
+            mock_optim_kwargs = optim_input.kwargs.copy()
+            optim_state = _get_optimizer_state(
+                optim_cls, mock_params, mock_optim_kwargs
+            )
+
+            optim_kwargs = optim_input.kwargs
+            optim_kwargs.update({"differentiable": True})
+
+            # Cannot be capturable and differentiable
+            if "capturable" in optim_kwargs:
+                optim_kwargs.update({"capturable": False})
+
+            # sgd defaults to foreach on cuda so must explicitly specify not foreach
+            if optim_cls is SGD and device.startswith("cuda"):
+                optim_kwargs.update({"foreach": False})
+
+            params = torch.rand(10, requires_grad=True, device=device, dtype=dtype)
+            grad = torch.rand(10, requires_grad=True, device=device, dtype=dtype)
+            gradcheck(
+                _diff_fn,
+                (
+                    params,
+                    grad,
+                    optim_state,
+                    optim_cls,
+                    optim_kwargs,
+                    *optim_state.values(),
+                ),
+            )
+
 
 instantiate_device_type_tests(TestOptimRenewed, globals(), allow_mps=True)
-instantiate_device_type_tests(
-    TestDifferentiableOptimizerOptimizerInfo, globals(), allow_mps=True
-)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -8,7 +8,10 @@ from typing import Any, Dict, Tuple
 from unittest.mock import patch
 
 from optim.test_lrscheduler import TestLRScheduler  # noqa: F401
-from optim.test_optim import TestDifferentiableOptimizer  # noqa: F401
+from optim.test_optim import (  # noqa: F401
+    TestDifferentiableOptimizer,
+    TestDifferentiableOptimizerOptimizerInfo,
+)
 from optim.test_swa_utils import TestSWAUtils  # noqa: F401
 
 import torch
@@ -2218,7 +2221,9 @@ class TestOptimRenewed(TestCase):
 
 
 instantiate_device_type_tests(TestOptimRenewed, globals(), allow_mps=True)
-
+instantiate_device_type_tests(
+    TestDifferentiableOptimizerOptimizerInfo, globals(), allow_mps=True
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -6,7 +6,7 @@ import sys
 import unittest
 from copy import deepcopy
 from enum import Enum
-from typing import Any, Callable, Dict, List, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Protocol, Tuple, Type, Union
 
 import torch
 from torch import Tensor
@@ -99,6 +99,13 @@ class ErrorOptimizerInput:
         self.error_regex = error_regex
 
 
+# Typing for every optim_inputs_func
+class OptimInputsFunc(Protocol):
+    def __call__(
+        self, device: str, dtype: Optional[torch.dtype] = None
+    ) -> List[OptimizerInput]: ...
+
+
 class OptimizerInfo:
     """Optimizer information to be used in testing."""
 
@@ -109,7 +116,7 @@ class OptimizerInfo:
         # Function to generate optimizer inputs EXCLUDING params. We delegate params responsibility
         # to the test using the OptimizerInfo. OptimizerInput.params is likely None.
         # Can optionally take in device to filter out certain unsupported configs
-        optim_inputs_func: Callable[..., List[OptimizerInput]],
+        optim_inputs_func: OptimInputsFunc,
         # Tuple of lambdas to generate LRScheduler instances to run with the optimizer for the
         # LRScheduler tests like test_forloop_goes_right_direction with_lrsched.
         # We DO NOT expect to thoroughly test LRSchedulers through the optimizers, so not every

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -6,7 +6,7 @@ import sys
 import unittest
 from copy import deepcopy
 from enum import Enum
-from typing import Any, Dict, List, Optional, Protocol, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import torch
 from torch import Tensor
@@ -100,7 +100,7 @@ class ErrorOptimizerInput:
 
 
 # Typing for every optim_inputs_func
-class OptimInputsFunc(Protocol):
+class OptimInputsFunc:
     def __call__(
         self, device: str, dtype: Optional[torch.dtype] = None
     ) -> List[OptimizerInput]: ...

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -6,7 +6,7 @@ import sys
 import unittest
 from copy import deepcopy
 from enum import Enum
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Callable, Dict, List, Tuple, Type, Union
 
 import torch
 from torch import Tensor
@@ -104,12 +104,12 @@ class OptimizerInfo:
 
     def __init__(
         self,
-        optim_cls: Optimizer,  # Class object for the Optimizer under test
+        optim_cls: Type[Optimizer],  # Class object for the Optimizer under test
         *,
         # Function to generate optimizer inputs EXCLUDING params. We delegate params responsibility
         # to the test using the OptimizerInfo. OptimizerInput.params is likely None.
         # Can optionally take in device to filter out certain unsupported configs
-        optim_inputs_func,
+        optim_inputs_func: Callable[..., List[OptimizerInput]],
         # Tuple of lambdas to generate LRScheduler instances to run with the optimizer for the
         # LRScheduler tests like test_forloop_goes_right_direction with_lrsched.
         # We DO NOT expect to thoroughly test LRSchedulers through the optimizers, so not every


### PR DESCRIPTION
Fourth PR in a larger project to broaden differentiable optimizer support with @janeyx99 ! This one is the first step in Step 0.

This PR replaces the 14 old differentiable tester functions with one differentiable tester function that uses optim_db and assures that the gradient can flow through the optimizer wrt params for all accepted OptimizerInput values attributed to each OptimizerInfo.

It also revealed a potentially confusing case where SGD defaults to foreach on cuda, and as it doesn't have a differentiable flag, it just throws a normal error that makes it look like a differentiable optimizer isn't supported, so I'll create an issue that brings that up!

Also, I added one typehint and fixed another in common_optimizers. This might not be great for organization so I can move it into another PR if desired. 

The tests used to take 0.7 seconds, but now that they run every OptimizerInput test, they now take around 7 seconds. Ever time  it runs gradcheck, it prints out a warning for using a deprecated version of vmap in gradcheck (which also happened last time) -- I believe fixing this warning would cut a lot of time off the tests since it seems largely consumed by printing!

cc @vincentqb @jbschlosser @albanD @janeyx99 @crcrpar @mruberry @ZainRizvi