### PR TITLE
remove allow-untyped-defs from _inductor/compile_worker/watchdog.py

### DIFF
--- a/torch/_inductor/compile_worker/watchdog.py
+++ b/torch/_inductor/compile_worker/watchdog.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 import os
 import signal
 from threading import Thread
@@ -15,7 +14,7 @@ from typing import Optional
 #
 # This function cannot be an inner function since otherwise mp_context="spawn" would
 # not work for ProcessPoolExecutor since inner functions cannot be pickled.
-def _async_compile_initializer(orig_ppid) -> None:
+def _async_compile_initializer(orig_ppid: int) -> None:
     def run() -> None:
         while True:
             sleep(1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #143944
* #143943
* #143942
* __->__ #143941



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov