### PR TITLE
[MPS] Fix crash when mm is invoked with mixed dtypes

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -202,6 +202,11 @@ static Tensor& mm_out_mps_impl(const Tensor& self, const Tensor& other, Tensor& 
 
   using CachedGraph = MPSBinaryCachedGraph;
   TORCH_CHECK(self.dim() == 2 && other.dim() == 2, "tensors must be 2-D");
+  TORCH_CHECK(self.dtype() == other.dtype(),
+              "expected mat1 and mat2 to have the same dtype, but got: ",
+              self.dtype(),
+              " != ",
+              other.dtype())
   TORCH_CHECK(supportedFloatingOrComplexType(self), "MPS device does not support mm for non-float inputs");
 
   TensorArg args[]{{output, "out", 0}, {self, "mat1", 1}, {other, "mat2", 2}};

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -52,7 +52,9 @@ HAS_CUDA = torch.cuda.is_available() and HAS_TRITON
 
 HAS_XPU = torch.xpu.is_available() and HAS_TRITON
 
-HAS_GPU = HAS_CUDA or HAS_XPU
+HAS_MPS = torch.mps.is_available()
+
+HAS_GPU = HAS_CUDA or HAS_XPU or HAS_MPS
 
 GPU_TYPE = get_gpu_type()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #143966
* #143977
* #143973
* #143949
* __->__ #143948

Simply by copy-n-pasting check from 
https://github.com/pytorch/pytorch/blob/a7915c56f6a62266490be355b3d823b1e447a475/aten/src/ATen/native/cuda/Blas.cpp#L254-L257