### PR TITLE
Enable readability-qualified-auto in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,6 +54,7 @@ performance-*,
 readability-container-size-empty,
 readability-delete-null-pointer,
 readability-duplicate-include
+readability-qualified-auto,
 readability-misplaced-array-index,
 readability-redundant-function-ptr-dereference,
 readability-redundant-smartptr-get,

--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -147,7 +147,7 @@ inline bool _apply_preamble(ArrayRef<Tensor> tensors) {
   if (!_all_equal_numel(tensors))
     TORCH_CHECK(false, _all_equal_numel_error(tensors));
   // An empty tensor has no elements
-  for (auto& t : tensors)
+  for (const auto& t : tensors)
     if (t.numel() == 0)
       return false;
   return true;
@@ -155,7 +155,7 @@ inline bool _apply_preamble(ArrayRef<Tensor> tensors) {
 
 inline int64_t _max_dim_tensors(ArrayRef<Tensor> tensors) {
   int64_t dim = 0;
-  for (auto& t : tensors)
+  for (const auto& t : tensors)
     dim = std::max(dim, t.ndimension());
   return dim;
 }

--- a/aten/src/ATen/CPUGeneratorImpl.cpp
+++ b/aten/src/ATen/CPUGeneratorImpl.cpp
@@ -174,7 +174,7 @@ void CPUGeneratorImpl::set_state(const c10::TensorImpl& new_state) {
       double_normal_sample = std::optional<double>(r * ::sin(theta));
     }
   } else if (new_state_size == size_current) {
-    auto rng_state = (CPUGeneratorImplState*)new_state.data();
+    auto *rng_state = (CPUGeneratorImplState*)new_state.data();
     legacy_pod = &rng_state->legacy_pod;
     // update next_float_normal_sample
     if (rng_state->is_next_float_normal_sample_valid) {
@@ -222,7 +222,7 @@ c10::intrusive_ptr<c10::TensorImpl> CPUGeneratorImpl::get_state() const {
   static_assert(std::is_standard_layout_v<CPUGeneratorImplState>, "CPUGeneratorImplState is not a PODType");
 
   auto state_tensor = at::detail::empty_cpu({(int64_t)size}, ScalarType::Byte, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
-  auto rng_state = state_tensor.data_ptr();
+  auto *rng_state = state_tensor.data_ptr();
 
   // accumulate generator data to be copied into byte tensor
   auto accum_state = std::make_unique<CPUGeneratorImplState>();
@@ -342,7 +342,7 @@ std::shared_ptr<CPUGeneratorImpl> CPUGeneratorImpl::clone() const {
  * See Note [Acquire lock when using random generators]
  */
 CPUGeneratorImpl* CPUGeneratorImpl::clone_impl() const {
-  auto gen = new CPUGeneratorImpl();
+  auto *gen = new CPUGeneratorImpl();
   gen->set_engine(engine_);
   gen->set_next_float_normal_sample(next_float_normal_sample_);
   gen->set_next_double_normal_sample(next_double_normal_sample_);

--- a/aten/src/ATen/EmptyTensor.cpp
+++ b/aten/src/ATen/EmptyTensor.cpp
@@ -259,7 +259,7 @@ TensorBase empty_strided_symint_generic(
 
 TensorBase empty_cpu(IntArrayRef size, ScalarType dtype, bool pin_memory,
                      std::optional<c10::MemoryFormat> memory_format_opt) {
-  auto allocator = GetCPUAllocatorMaybePinned(pin_memory);
+  auto *allocator = GetCPUAllocatorMaybePinned(pin_memory);
   constexpr c10::DispatchKeySet cpu_ks(c10::DispatchKey::CPU);
   return empty_generic(size, allocator, cpu_ks, dtype, memory_format_opt);
 }
@@ -292,7 +292,7 @@ TensorBase empty_cpu(
 
 TensorBase empty_strided_cpu(IntArrayRef size, IntArrayRef stride,
                              ScalarType dtype, bool pin_memory) {
-  auto allocator = at::detail::GetCPUAllocatorMaybePinned(pin_memory);
+  auto *allocator = at::detail::GetCPUAllocatorMaybePinned(pin_memory);
   constexpr c10::DispatchKeySet cpu_ks(c10::DispatchKey::CPU);
   return at::detail::empty_strided_generic(
       size, stride, allocator, cpu_ks, dtype);

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -76,7 +76,7 @@ inline bool are_expandable(IntArrayRef shape1, IntArrayRef shape2) {
 inline void check_defined(
     std::initializer_list<std::reference_wrapper<const Tensor>> tensors,
     const char* api_name) {
-  for (auto& t : tensors) {
+  for (const auto& t : tensors) {
     if (!t.get().defined()) {
       TORCH_CHECK(false, api_name, "(...) called with an undefined Tensor");
     }

--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -158,7 +158,7 @@ functionalization::FunctionalStorageImpl* FunctionalTensorWrapper::functional_st
 }
 
 void FunctionalTensorWrapper::commit_update() {
-  auto storage_impl = functional_storage_impl();
+  auto *storage_impl = functional_storage_impl();
   storage_impl->add_update(value_, view_metas_);
   // As an optimization, we used to mark the tensor here as "up-to-date",
   // That way, code like:
@@ -381,7 +381,7 @@ Tensor FunctionalTensorWrapper::apply_view_metas(const Tensor& base) {
 
 void FunctionalTensorWrapper::regenerate_from_base() {
   at::AutoDispatchSkipFunctionalize guard;
-  auto storage_impl = functional_storage_impl();
+  auto *storage_impl = functional_storage_impl();
   auto t = storage_impl->base();
 
   TORCH_INTERNAL_ASSERT(!at::functionalization::impl::isFunctionalTensor(t));
@@ -394,7 +394,7 @@ void FunctionalTensorWrapper::regenerate_from_base() {
 
 bool FunctionalTensorWrapper::apply_updates() {
   // Apply all updates on alias_
-  auto storage_impl = functional_storage_impl();
+  auto *storage_impl = functional_storage_impl();
   return storage_impl->apply_updates();
 }
 
@@ -474,7 +474,7 @@ c10::intrusive_ptr<TensorImpl> FunctionalTensorWrapper::shallow_copy_and_detach(
 
 void FunctionalTensorWrapper::shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) {
     AT_ASSERT(has_compatible_shallow_copy_type(impl->key_set()));
-    auto functional_impl =
+    auto *functional_impl =
         static_cast<FunctionalTensorWrapper*>(impl.get());
     copy_tensor_metadata_and_refresh(
         /*src_impl=*/functional_impl,
@@ -558,7 +558,7 @@ Tensor from_functional_tensor(const Tensor& tensor, bool assert_functional) {
       return tensor;
   }
   if (isFunctionalTensor(tensor)) {
-    auto impl = unsafeGetFunctionalWrapper(tensor);
+    auto *impl = unsafeGetFunctionalWrapper(tensor);
     return impl->value();
   } else {
     // If the current tensor is not functional, then raise an error
@@ -610,7 +610,7 @@ void sync(const Tensor& t) {
   if (!at::functionalization::impl::isFunctionalTensor(t)) {
     return;
   }
-  auto functional_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(t);
+  auto *functional_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(t);
   functional_impl->sync_();
 }
 void sync(const std::optional<Tensor>& t) {
@@ -755,14 +755,14 @@ bool isFunctionalTensor(ITensorListRef list) {
 
 void freeze_functional_tensor(const Tensor& tensor) {
   TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(tensor));
-  auto functional_base_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(tensor);
+  auto *functional_base_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(tensor);
   functional_base_impl->freeze_storage();
 }
 
 Tensor create_functional_tensor_with_view_meta(const at::Tensor& view_to_wrap, const at::Tensor& base, functionalization::ViewMeta meta, int64_t out_idx) {
   TORCH_INTERNAL_ASSERT(!at::functionalization::impl::isFunctionalTensor(view_to_wrap));
   TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(base));
-  auto functional_base_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(base);
+  auto *functional_base_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(base);
   if (out_idx != 0) {
     // Note [out_idx in ViewMeta]
     // When a view op outputs multiple tensors, each output needs its own separate ViewMeta.
@@ -784,7 +784,7 @@ std::vector<Tensor> create_functional_tensor_with_view_meta(ITensorListRef view_
 
 void mutate_view_meta(const at::Tensor& self, const functionalization::ViewMeta& meta) {
   TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(self));
-  auto self_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(self);
+  auto *self_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(self);
   self_impl->mutate_view_meta(meta);
 }
 

--- a/aten/src/ATen/FunctionalTensorWrapper.h
+++ b/aten/src/ATen/FunctionalTensorWrapper.h
@@ -290,7 +290,7 @@ namespace impl {
 
 TORCH_API inline FunctionalTensorWrapper* unsafeGetFunctionalWrapper(
     const Tensor& tensor) {
-  auto functional_impl =
+  auto* functional_impl =
       static_cast<FunctionalTensorWrapper*>(tensor.unsafeGetTensorImpl());
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(functional_impl != nullptr);
   return functional_impl;

--- a/aten/src/ATen/FunctionalizeFallbackKernel.cpp
+++ b/aten/src/ATen/FunctionalizeFallbackKernel.cpp
@@ -156,7 +156,7 @@ static const at::Tensor & resize__functionalization(c10::DispatchKeySet dispatch
   if (needs_resize_storage) {
     // If resize_() actually increases the size of the storage, then we need to tell FunctionalTensorWrapper about it.
     // See Note[resize_() in functionalization pass]
-    auto func_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(self);
+    auto *func_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(self);
     func_impl->maybe_replace_storage(tmp_output);
     // See the note - we're guaranteed at this point that "self" is *not* a view (and has no outstanding views)
     // So we don't need to treat the output of resize as view tensor.
@@ -337,8 +337,8 @@ static at::Tensor& set__functionalize(at::Tensor& self, const at::Tensor& src) {
 
   TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(self));
   TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(src));
-  auto self_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(self);
-  auto src_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(src);
+  auto *self_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(self);
+  auto *src_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(src);
   // See Note [Ordering of resize_() and set_()]
   TORCH_CHECK(!self_impl->was_inductor_storage_resized(),
     "storage_resize_() followed by set_() in torch.compile is not supported today");

--- a/aten/src/ATen/LegacyBatchedFallback.cpp
+++ b/aten/src/ATen/LegacyBatchedFallback.cpp
@@ -179,8 +179,8 @@ static void batchedTensorInplaceForLoopFallback(const c10::OperatorHandle& op, t
   // of the arguments onto `stack`, and call `op`.
   for (const auto linear_idx : c10::irange(num_batches)) {
     auto index = computeIndex(linear_idx, batch_sizes);
-    auto batched_tensor_inputs_pos_iter = batched_tensor_inputs_position.begin();
-    auto input_physical_views_iter = input_physical_views.begin();
+    auto *batched_tensor_inputs_pos_iter = batched_tensor_inputs_position.begin();
+    const auto *input_physical_views_iter = input_physical_views.begin();
     for (const auto arg_idx : c10::irange(num_arguments)) {
       // We assume that torch::jit::Stack is backed by vector<IValue> for
       // simplicity. When that is not the case, this code should be updated.
@@ -322,8 +322,8 @@ void batchedTensorForLoopFallback(const c10::OperatorHandle& op, torch::jit::Sta
 
   for (const auto linear_idx : c10::irange(num_batches)) {
     auto index = computeIndex(linear_idx, batch_sizes);
-    auto batched_tensor_inputs_pos_iter = batched_tensor_inputs_position.begin();
-    auto input_physical_views_iter = input_physical_views.begin();
+    auto *batched_tensor_inputs_pos_iter = batched_tensor_inputs_position.begin();
+    const auto *input_physical_views_iter = input_physical_views.begin();
     for (const auto arg_idx : c10::irange(num_arguments)) {
       // We assume that torch::jit::Stack is backed by vector<IValue> for
       // simplicity. When that is not the case, this code should be updated.

--- a/aten/src/ATen/LegacyBatchingRegistrations.cpp
+++ b/aten/src/ATen/LegacyBatchingRegistrations.cpp
@@ -281,7 +281,7 @@ Tensor squeeze_batching_rule(const Tensor& self) {
       squeezed_sizes.end(),
       physical_sizes.begin(),
       physical_sizes.begin() + num_batch_dims);
-  for (auto it = physical_sizes.begin() + num_batch_dims; it != physical_sizes.end(); ++it) {
+  for (const auto *it = physical_sizes.begin() + num_batch_dims; it != physical_sizes.end(); ++it) {
     if (*it != 1) {
       squeezed_sizes.push_back(*it);
     }
@@ -489,9 +489,9 @@ Tensor view_as_complex_batching_rule(const Tensor& self) {
 // stride. This is something we can support but we choose not to because it's
 // potentially error prone.
 static void checkBatchDimsAtFrontInLayout(IntArrayRef physical_strides, int64_t num_batch_dims) {
-  auto smallest_batch_stride = std::min_element(
+  const auto *smallest_batch_stride = std::min_element(
       physical_strides.begin(), physical_strides.begin() + num_batch_dims);
-  auto largest_example_stride = std::max_element(
+  const auto *largest_example_stride = std::max_element(
       physical_strides.begin() + num_batch_dims, physical_strides.end());
   if (largest_example_stride == physical_strides.end()) {
     // No example dimensions

--- a/aten/src/ATen/MemoryOverlap.cpp
+++ b/aten/src/ATen/MemoryOverlap.cpp
@@ -63,10 +63,10 @@ MemOverlapStatus get_overlap_status(const TensorImpl* a, const TensorImpl* b) {
   // which we will miss.
   const auto& a_storage = a->unsafe_storage();
   if (a_storage && a_storage.is_alias_of(b->unsafe_storage())) {
-    const auto a_begin = static_cast<const char*>(a->data());
-    const auto a_end = a_begin + a->numel() * a->itemsize();
-    const auto b_begin = static_cast<const char*>(b->data());
-    const auto b_end = b_begin + b->numel() * b->itemsize();
+    const auto *a_begin = static_cast<const char*>(a->data());
+    const auto *a_end = a_begin + a->numel() * a->itemsize();
+    const auto *b_begin = static_cast<const char*>(b->data());
+    const auto *b_end = b_begin + b->numel() * b->itemsize();
 
     if (a_begin == b_begin && a_end == b_end) {
       return (a->strides() == b->strides()) ?

--- a/aten/src/ATen/NamedTensorUtils.cpp
+++ b/aten/src/ATen/NamedTensorUtils.cpp
@@ -24,7 +24,7 @@ int64_t dimname_to_position(const Tensor& tensor, Dimname dim) {
       "Name ", dim, " not found in ", toDimnameRepr(tensor), ".");
   const auto names = tensor.names();
 
-  const auto it = std::find(names.begin(), names.end(), dim);
+  const auto *it = std::find(names.begin(), names.end(), dim);
   TORCH_CHECK(it != names.end(),
       "Name ", dim, " not found in ", toDimnameRepr(tensor), ".");
 
@@ -61,7 +61,7 @@ static void check_for_misalignment(
   if (name.isWildcard()) {
     return;
   }
-  auto it = std::find(other_names.begin(), other_names.end(), name);
+  const auto *it = std::find(other_names.begin(), other_names.end(), name);
   // TODO(zou3519): Can improve message by checking if names are alignable and suggesting workarounds
   TORCH_CHECK(it == other_names.end(),
       "Misaligned dims when attempting to ", action, " dims ", names, " and dims ",

--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -346,14 +346,14 @@ int64_t get_numel_from_nested_size_tensor(const at::Tensor& tensor) {
       static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
       static_cast<uint64_t>(std::numeric_limits<size_t>::max()));
 
-  const int64_t* sizes_ptr = tensor.const_data_ptr<int64_t>();
+  const auto *sizes_ptr = tensor.const_data_ptr<int64_t>();
   const auto nt_dim = tensor.size(1);
   uint64_t num_elements{0};
 
   for (const auto i : c10::irange(tensor.size(0))) {
     uint64_t n = 1;
-    const auto start{sizes_ptr + i * nt_dim};
-    const auto end{start + nt_dim};
+    const auto *start{sizes_ptr + i * nt_dim};
+    const auto *end{start + nt_dim};
     bool overflows = c10::safe_multiplies_u64(start, end, &n);
     num_elements += n;
     overflows |= (num_elements > numel_max);

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -373,7 +373,7 @@ struct TORCH_API SparseTensorImpl : public TensorImpl {
    */
   void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) override {
     AT_ASSERT(has_compatible_shallow_copy_type(impl->key_set()));
-    auto sparse_impl = static_cast<const SparseTensorImpl*>(impl.get());
+    const auto* sparse_impl = static_cast<const SparseTensorImpl*>(impl.get());
     copy_tensor_metadata(
         /*src_sparse_impl=*/sparse_impl,
         /*dest_sparse_impl=*/this,

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -346,9 +346,9 @@ inline int64_t count_specified_dimensions(
     const ArrayRef<TensorIndex>& indices) {
   // Count the number of indexed dimensions (everything but ellipsis and None)
   int64_t count = 0;
-  for (auto& obj : indices) {
+  for (const auto& obj : indices) {
     if (obj.is_tensor()) {
-      auto& tensor = obj.tensor();
+      const auto& tensor = obj.tensor();
       if (tensor.scalar_type() == kByte || tensor.scalar_type() == kBool) {
         count += tensor.dim();
       } else {
@@ -536,7 +536,7 @@ inline Tensor applySlicing(
 
   Tensor result = self;
   for (const auto i : c10::irange(indices.size())) {
-    auto& obj = indices[i];
+    const auto& obj = indices[i];
     // See NOTE [nested tensor size for indexing]
     std::optional<SymIntArrayRef> result_sizes = result.is_nested()
         ? std::optional<SymIntArrayRef>(std::nullopt)

--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -699,7 +699,7 @@ int64_t TensorIteratorBase::numel() const {
 StrideVector TensorIteratorBase::get_dim_strides(int dim) const {
   auto dims = ndim();
   auto inner_strides = StrideVector();
-  for (auto& op : operands_) {
+  for (const auto& op : operands_) {
     inner_strides.push_back(dims == 0 ? 0 : op.stride_bytes[dim]);
   }
   return inner_strides;
@@ -712,7 +712,7 @@ SmallVector<char*, 4> TensorIteratorBase::get_base_ptrs() const {
 }
 
 bool TensorIteratorBase::is_dim_reduced(int dim) const {
-  for (auto& op : operands_) {
+  for (const auto& op : operands_) {
     if (op.is_output && op.stride_bytes[dim] == 0 && shape_[dim] > 1) {
       return true;
     }
@@ -1301,7 +1301,7 @@ bool TensorIteratorBase::can_use_32bit_indexing() const {
   if (numel() > max_value) {
     return false;
   }
-  for (auto& op : operands_) {
+  for (const auto& op : operands_) {
     int64_t max_offset = 1;
     for (const auto dim : c10::irange(ndim())) {
       max_offset += (shape_[dim] - 1) * op.stride_bytes[dim];
@@ -1338,7 +1338,7 @@ int TensorIteratorBase::get_dim_to_split() const {
     if (size == 0) {
       continue;
     }
-    for (auto& op : operands_) {
+    for (const auto& op : operands_) {
       // std::abs is necessary to handle some special cases where we support negative strides
       // see the CUDA backend of at::flip
       const int64_t extent = (size - 1) * std::abs(op.stride_bytes[dim]);

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -392,7 +392,7 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   /// value from tensor_base.
   template <typename T>
   T original_scalar_value(int64_t arg) {
-    auto& original_tensor_base = operands_[arg].original_tensor_base();
+    const auto& original_tensor_base = operands_[arg].original_tensor_base();
     if (original_tensor_base.defined()) {
       TORCH_INTERNAL_ASSERT(
           original_tensor_base.scalar_type() != common_dtype());

--- a/aten/src/ATen/TensorNames.cpp
+++ b/aten/src/ATen/TensorNames.cpp
@@ -1,15 +1,23 @@
+#include "ATen/core/Dimname.h"
+#include "c10/util/Exception.h"
+#include "c10/util/ArrayRef.h"
 #include <ATen/TensorNames.h>
 #include <ATen/WrapDimUtils.h>
+#include <algorithm>
 #include <c10/util/irange.h>
+#include <cstdint>
+#include <ostream>
+#include <vector>
 
 namespace at::namedinference {
-
 
 Dimname TensorName::toDimname() const {
   return name_;
 }
 
-const TensorName& TensorName::unify(const TensorName& other, const char* op_name) const {
+const TensorName& TensorName::unify(
+    const TensorName& other,
+    const char* op_name) const {
   // unify(None, None)
   if (name_.isWildcard() && other.name_.isWildcard()) {
     return *this;
@@ -22,11 +30,19 @@ const TensorName& TensorName::unify(const TensorName& other, const char* op_name
 
   // unify(A, None)
   if (other.name_.isWildcard()) {
-    const auto it = std::find(other.origin_.begin(), other.origin_.end(), name_);
-    TORCH_CHECK(it == other.origin_.end(),
-        op_name, ":",
-        " Cannot match ", *this, " with ", other,
-        " because the latter names already have ", name_, ".",
+    const auto* it =
+        std::find(other.origin_.begin(), other.origin_.end(), name_);
+    TORCH_CHECK(
+        it == other.origin_.end(),
+        op_name,
+        ":",
+        " Cannot match ",
+        *this,
+        " with ",
+        other,
+        " because the latter names already have ",
+        name_,
+        ".",
         " Are your tensors misaligned?");
     return *this;
   }
@@ -37,10 +53,14 @@ const TensorName& TensorName::unify(const TensorName& other, const char* op_name
   }
 
   // unify(A, B)
-  TORCH_CHECK(name_ == other.name_,
-      op_name, ":",
-      " Expected ", *this,
-      " to match ", other,
+  TORCH_CHECK(
+      name_ == other.name_,
+      op_name,
+      ":",
+      " Expected ",
+      *this,
+      " to match ",
+      other,
       " but they do not match.");
   return *this;
 }
@@ -53,7 +73,7 @@ TensorNames::TensorNames(ArrayRef<Dimname> names) {
 }
 
 TensorNames::TensorNames(ArrayRef<Dimname> names, int64_t start, int64_t end) {
-  int64_t names_size = static_cast<int64_t>(names.size());
+  auto const names_size = static_cast<int64_t>(names.size());
   start = maybe_wrap_dim(start, names_size);
   end = maybe_wrap_dim(end, names_size);
   names_.reserve(end - start);
@@ -62,8 +82,9 @@ TensorNames::TensorNames(ArrayRef<Dimname> names, int64_t start, int64_t end) {
   }
 }
 
-TensorNames& TensorNames::unifyFromRightInplace(const TensorNames& other, const char* op_name) {
-
+TensorNames& TensorNames::unifyFromRightInplace(
+    const TensorNames& other,
+    const char* op_name) {
   if (names_.size() > other.names_.size()) {
     const auto size_diff = names_.size() - other.names_.size();
     for (const auto idx : c10::irange(size_diff, names_.size())) {
@@ -73,9 +94,7 @@ TensorNames& TensorNames::unifyFromRightInplace(const TensorNames& other, const 
     const auto size_diff = other.names_.size() - names_.size();
     // pad names_ to the same length as other.names_ before unification
     names_.insert(
-        names_.begin(),
-        other.names_.begin(),
-        other.names_.begin() + size_diff);
+        names_.begin(), other.names_.begin(), other.names_.begin() + size_diff);
     for (const auto idx : c10::irange(size_diff, names_.size())) {
       names_[idx] = names_[idx].unify(other.names_[idx], op_name);
     }
@@ -93,16 +112,27 @@ void TensorNames::checkUnique(const char* op_name) const {
   // doesn't matter unless benchmarking tells us it does. The alternative is
   // to create some sort of set data structure but the overhead of that
   // might dominate for small sizes.
-  for (auto it = names_.begin(); it != names_.end(); ++it) {
+  for (const auto* it = names_.begin(); it != names_.end(); ++it) {
     const auto name = it->toDimname();
-    if (name.isWildcard()) continue;
+    if (name.isWildcard()) {
+      continue;
+}
 
-    auto dup = std::find_if(it + 1, names_.end(),
-        [&](const TensorName& other) { return other.toDimname() == name; });
-    TORCH_CHECK(dup == names_.end(),
-        op_name, ": ",
-        "Attempted to propagate dims ", *it, " and ", *dup, " to the output, ",
-        "but that would create a tensor with duplicate names [", toDimnameVec(),
+    const auto* dup =
+        std::find_if(it + 1, names_.end(), [&](const TensorName& other) {
+          return other.toDimname() == name;
+        });
+    TORCH_CHECK(
+        dup == names_.end(),
+        op_name,
+        ": ",
+        "Attempted to propagate dims ",
+        *it,
+        " and ",
+        *dup,
+        " to the output, ",
+        "but that would create a tensor with duplicate names [",
+        toDimnameVec(),
         "]. Please rename your inputs with Tensor.rename to prevent this.");
   }
 }
@@ -125,6 +155,5 @@ std::vector<Dimname> TensorNames::toDimnameVec() const {
   }
   return result;
 }
-
 
 } // namespace at::namedinference

--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -61,7 +61,7 @@ void checkContiguous(CheckedFrom c, const TensorGeometryArg& t) {
 }
 
 void checkAllContiguous(CheckedFrom c, at::ArrayRef<TensorArg> ts) {
-  for (auto& t : ts) {
+  for (const auto& t : ts) {
     if (!t->defined()) continue;
     checkContiguous(c, t);
   }
@@ -101,7 +101,7 @@ void checkSize_symint(CheckedFrom c, const TensorGeometryArg& t, int64_t dim, co
 
 static void checkAllSame(CheckedFrom c, ArrayRef<TensorArg> tensors, void(*fn)(CheckedFrom, const TensorArg&, const TensorArg&)) {
   const TensorArg* t0 = nullptr;
-  for (auto& t : tensors) {
+  for (const auto& t : tensors) {
     if (!t->defined()) continue;
     if (t0 != nullptr) {
       fn(c, *t0, t);
@@ -239,7 +239,7 @@ static void checkBackend(CheckedFrom c, const Tensor& t, Backend backend) {
 }
 
 void checkBackend(CheckedFrom c, at::ArrayRef<Tensor> tensors, at::Backend backend) {
-  for (auto &t : tensors) {
+  for (const auto &t : tensors) {
     checkBackend(c, t, backend);
   }
 }
@@ -253,7 +253,7 @@ static void checkDeviceType(CheckedFrom c, const Tensor& t, DeviceType device_ty
 }
 
 void checkDeviceType(CheckedFrom c, at::ArrayRef<Tensor> tensors, at::DeviceType device_type) {
-  for (auto &t : tensors) {
+  for (const auto &t : tensors) {
     checkDeviceType(c, t, device_type);
   }
 }
@@ -267,7 +267,7 @@ void checkLayout(CheckedFrom c, const Tensor& t, Layout layout) {
 }
 
 void checkLayout(CheckedFrom c, at::ArrayRef<Tensor> tensors, at::Layout layout) {
-  for (auto &t : tensors) {
+  for (const auto &t : tensors) {
     checkLayout(c, t, layout);
   }
 }

--- a/aten/src/ATen/WrapDimUtils.h
+++ b/aten/src/ATen/WrapDimUtils.h
@@ -107,7 +107,7 @@ inline void maybe_wrap_dims(
 inline int64_t legacy_cat_wrap_dim(
     int64_t dim,
     const std::vector<std::vector<int64_t>>& tensor_sizes) {
-  for (auto& sizes : tensor_sizes) {
+  for (const auto& sizes : tensor_sizes) {
     if (sizes.size() == 1 && sizes[0] == 0) {
       continue;
     }
@@ -119,7 +119,7 @@ inline int64_t legacy_cat_wrap_dim(
 inline int64_t legacy_cat_wrap_dim_symint(
     int64_t dim,
     const std::vector<std::vector<c10::SymInt>>& tensor_sizes) {
-  for (auto& sizes : tensor_sizes) {
+  for (const auto& sizes : tensor_sizes) {
     if (sizes.size() == 1) {
       if (TORCH_GUARD_SIZE_OBLIVIOUS(sizes[0].sym_eq(0))) {
         continue;

--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -76,7 +76,7 @@ static std::tuple<double, int> __printFormat(std::ostream& stream, const Tensor&
     return std::make_tuple(1., 0);
   }
   bool intMode = true;
-  auto self_p = self.const_data_ptr<double>();
+  const auto *self_p = self.const_data_ptr<double>();
   for (const auto i : c10::irange(size)) {
     auto z = self_p[i];
     if(std::isfinite(z)) {
@@ -331,7 +331,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
 
     // Proxy check for if autograd was built
     if (tensor.getIntrusivePtr()->autograd_meta()) {
-      auto& fw_grad = tensor._fw_grad(/* level */ 0);
+      const auto& fw_grad = tensor._fw_grad(/* level */ 0);
       if (fw_grad.defined()) {
         stream << ", tangent:" << '\n' << fw_grad;
       }

--- a/aten/src/ATen/core/NamedTensor.cpp
+++ b/aten/src/ATen/core/NamedTensor.cpp
@@ -37,9 +37,9 @@ DimnameList default_names(size_t len) {
 static void check_unique_names(DimnameList names) {
   // Strategy: Compare each element with the ones that come after it.
   // Although this is O(N^2), in practice N is small (no more than 25).
-  for (auto it = names.begin(); it != names.end(); ++it) {
+  for (const auto *it = names.begin(); it != names.end(); ++it) {
     if (it->isWildcard()) continue;
-    auto dup = std::find(it + 1, names.end(), *it);
+    const auto *dup = std::find(it + 1, names.end(), *it);
     while (dup != names.end()) {
       TORCH_CHECK(false,
           "Cannot construct a tensor with duplicate names. Got names: ",

--- a/aten/src/ATen/core/Vitals.cpp
+++ b/aten/src/ATen/core/Vitals.cpp
@@ -41,7 +41,7 @@ bool torchVitalEnabled() {
   // If this is a performance hit, make `enabled` variable static
   // and return `const bool&` instead
   bool enabled = []() {
-    auto e = getenv("TORCH_VITAL");
+    auto *e = getenv("TORCH_VITAL");
     if (e != nullptr) {
       return e[0] != '\0';
     }

--- a/aten/src/ATen/core/alias_info.h
+++ b/aten/src/ATen/core/alias_info.h
@@ -129,19 +129,19 @@ template <>
       // because hash_combine is order dependent. Instead, we choose to
       // use XOR as the combining function as XOR is commutative.
       size_t before_set_hash_seed = 0;
-      for (auto &e: aliasInfo.beforeSets()) {
+      for (const auto &e: aliasInfo.beforeSets()) {
         auto symbol_hash = std::hash<c10::Symbol>()(e);
         before_set_hash_seed = before_set_hash_seed ^ symbol_hash;
       }
       size_t after_set_hash_seed = 0;
-      for (auto &e: aliasInfo.afterSets()) {
+      for (const auto &e: aliasInfo.afterSets()) {
         auto symbol_hash = std::hash<c10::Symbol>()(e);
         after_set_hash_seed = after_set_hash_seed ^ symbol_hash;
       }
 
       hash = c10::hash_combine(hash, before_set_hash_seed);
       hash = c10::hash_combine(hash, after_set_hash_seed);
-      for (auto &e: aliasInfo.containedTypes()) {
+      for (const auto &e: aliasInfo.containedTypes()) {
         auto contained_type_hash = std::hash<c10::AliasInfo>()(e);
         hash = c10::hash_combine(hash, contained_type_hash);
       }

--- a/aten/src/ATen/core/class_type.cpp
+++ b/aten/src/ATen/core/class_type.cpp
@@ -329,7 +329,7 @@ void ClassType::checkForwardHookSchema(
 }
 
 torch::jit::Function* ClassType::findMethod(const std::string& name) const {
-  for (auto method : methods_) {
+  for (auto *method : methods_) {
     if (name == method->name()) {
       return method;
     }
@@ -337,7 +337,7 @@ torch::jit::Function* ClassType::findMethod(const std::string& name) const {
   return nullptr;
 }
 torch::jit::Function& ClassType::getMethod(const std::string& name) const {
-  auto method = findMethod(name);
+  auto *method = findMethod(name);
   TORCH_CHECK(
       method != nullptr,
       "Couldn't find method: '",
@@ -349,7 +349,7 @@ torch::jit::Function& ClassType::getMethod(const std::string& name) const {
 }
 
 torch::jit::Function* ClassType::findHook(const std::string& name) const {
-  auto hook = findForwardHook(name);
+  auto *hook = findForwardHook(name);
   if (hook == nullptr) {
     hook = findForwardPreHook(name);
   }
@@ -383,7 +383,7 @@ void ClassType::addStaticMethod(torch::jit::Function* method) {
 }
 
 torch::jit::Function* ClassType::findStaticMethod(const std::string& name) const {
-  for (auto method : staticmethods_) {
+  for (auto *method : staticmethods_) {
     if (name == method->name()) {
       return method;
     }
@@ -393,7 +393,7 @@ torch::jit::Function* ClassType::findStaticMethod(const std::string& name) const
 
 void ClassType::unsafeRemoveMethod(const std::string& name) {
   size_t slot = 0;
-  for (auto method : methods_) {
+  for (auto *method : methods_) {
     if (method->name() == name) {
       methods_.erase(methods_.begin() + static_cast<std::ptrdiff_t>(slot));
       return;
@@ -441,7 +441,7 @@ bool ClassType::isSubtypeOfExt(const Type& rhs, std::ostream* why_not) const {
       return false;
     }
     for (const FunctionSchema& schema : iface->methods()) {
-      auto self_method = findMethod(schema.name());
+      auto *self_method = findMethod(schema.name());
       if (!self_method) {
         if (why_not) {
           *why_not << "Class '" << repr_str() << "' does not have method '"

--- a/aten/src/ATen/core/class_type.h
+++ b/aten/src/ATen/core/class_type.h
@@ -84,7 +84,7 @@ struct TORCH_API ClassType : public NamedType {
     if (this == &rhs) {
       return true;
     }
-    if (auto user_rhs = rhs.castRaw<ClassType>()) {
+    if (const auto *user_rhs = rhs.castRaw<ClassType>()) {
       const auto& lhs_name = name();
       const auto& rhs_name = user_rhs->name();
       return lhs_name.has_value() && lhs_name == rhs_name &&

--- a/aten/src/ATen/core/custom_class.cpp
+++ b/aten/src/ATen/core/custom_class.cpp
@@ -154,7 +154,7 @@ c10::FunctionSchema class_base::withNewArguments(
   // Skip self.
   size_t argIdx = 1;
   for (const auto& default_arg : default_args) {
-    auto& old_arg = old_args[argIdx++];
+    const auto& old_arg = old_args[argIdx++];
     new_args.emplace_back(
         default_arg.name_,
         old_arg.type(),

--- a/aten/src/ATen/core/dynamic_type.cpp
+++ b/aten/src/ATen/core/dynamic_type.cpp
@@ -79,7 +79,7 @@ DynamicType::~DynamicType() {
 }
 
 std::shared_ptr<const DynamicType> DynamicType::create(const Type& other) {
-  if (auto dynRaw = other.castRaw<DynamicType>()) {
+  if (const auto *dynRaw = other.castRaw<DynamicType>()) {
     TORCH_INTERNAL_ASSERT(
         !dynRaw->weak_from_this().expired(),
         "Error creating dynamic type instance not managed by shared_ptr: ",
@@ -92,7 +92,7 @@ std::shared_ptr<const DynamicType> DynamicType::create(const Type& other) {
 }
 
 DynamicTypePtr DynamicType::create(Type& other) {
-  if (auto dynRaw = other.castRaw<DynamicType>()) {
+  if (auto *dynRaw = other.castRaw<DynamicType>()) {
     TORCH_INTERNAL_ASSERT(
         !dynRaw->weak_from_this().expired(),
         "Error creating dynamic type instance not managed by shared_ptr: ",
@@ -116,11 +116,11 @@ DynamicType::DynamicType(Tag tag, std::string_view name, Arguments arguments)
 DynamicType::DynamicType(const Type& other) : SharedType(DynamicType::Kind) {
   auto kind = other.kind();
   TORCH_INTERNAL_ASSERT(kind != Kind);
-  if (auto n = other.castRaw<NamedType>()) {
+  if (const auto *n = other.castRaw<NamedType>()) {
     if (const auto& qn = n->name()) {
       name_ = qn->qualifiedName();
     }
-  } else if (auto v = other.castRaw<VarType>()) {
+  } else if (const auto *v = other.castRaw<VarType>()) {
     name_ = v->name();
   }
 
@@ -147,7 +147,7 @@ DynamicType::DynamicType(const Type& other) : SharedType(DynamicType::Kind) {
     return;
   }
 
-  if (auto tup = other.castRaw<TupleType>()) {
+  if (const auto *tup = other.castRaw<TupleType>()) {
     if (auto names = tup->names()) {
       new (&arguments_) Arguments(*names, args);
       return;

--- a/aten/src/ATen/core/enum_type.h
+++ b/aten/src/ATen/core/enum_type.h
@@ -49,7 +49,7 @@ struct TORCH_API EnumType : public NamedType {
   }
 
   bool equals(const Type& rhs) const override {
-    if (auto* enum_rhs = rhs.castRaw<EnumType>()) {
+    if (const auto* enum_rhs = rhs.castRaw<EnumType>()) {
       return name().has_value() && name() == enum_rhs->name() &&
           *getValueType() == *(enum_rhs->getValueType()) &&
           this->compilation_unit() == enum_rhs->compilation_unit();

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -168,7 +168,7 @@ void IValue::visit(const std::function<bool (const IValue &)>& visitor) const {
       } else {
         elems = this->toListRef();
       }
-      for (auto& elem : elems) {
+      for (const auto& elem : elems) {
         elem.visit(visitor);
       }
       break;
@@ -217,7 +217,7 @@ void IValue::getSubValues(HashAliasedIValues& subValues) const {
       } else {
         elems = this->toListRef();
       }
-      for (auto& elem : elems) {
+      for (const auto& elem : elems) {
         elem.getSubValues(subValues);
       }
       break;
@@ -268,7 +268,7 @@ bool IValue::overlaps(const IValue& rhs) const {
   HashAliasedIValues rhsSubValues, thisSubValues;
   rhs.getSubValues(rhsSubValues);
   getSubValues(thisSubValues);
-  for (auto& sub : thisSubValues) {
+  for (const auto& sub : thisSubValues) {
     if (rhsSubValues.count(sub)) {
       return true;
     }
@@ -665,7 +665,7 @@ static bool simpleClassTypeArg(const Argument& arg, const ClassTypePtr& type) {
 }
 
 torch::jit::Function* checkObjectSortSchema(const c10::ClassTypePtr& t, std::stringstream& why_not) {
-  if (auto method = t->findMethod("__lt__")) {
+  if (auto *method = t->findMethod("__lt__")) {
       const auto& lt_schema = method->getSchema();
       const auto& schema_args = lt_schema.arguments();
       bool error =
@@ -842,7 +842,7 @@ std::ostream& operator<<(std::ostream & out, const IValue & v) {
     case IValue::Tag::GenericDict:
       return printDict(out, v.toGenericDict(), formatter);
     case IValue::Tag::PyObject: {
-      auto py_obj = v.toPyObject();
+      auto *py_obj = v.toPyObject();
       return out << "<PyObject at" << py_obj << ">";
     }
     case IValue::Tag::Generator:

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -924,7 +924,7 @@ struct TORCH_API DictType : public SharedType {
 
   static DictTypePtr create(TypePtr key, TypePtr value) {
     auto kind = key->kind();
-    if (auto dyn = key->castRaw<DynamicType>()) {
+    if (auto *dyn = key->castRaw<DynamicType>()) {
       kind = dyn->dynamicKind();
     }
     switch (kind) {
@@ -978,7 +978,7 @@ struct TORCH_API DictType : public SharedType {
   }
 
   bool equals(const Type& rhs) const override {
-    if (auto* dict_rhs = rhs.castRaw<DictType>()) {
+    if (const auto* dict_rhs = rhs.castRaw<DictType>()) {
       return *getKeyType() == *(dict_rhs->getKeyType()) &&
           *getValueType() == *(dict_rhs->getValueType());
     }
@@ -1035,7 +1035,7 @@ struct TORCH_API FutureType
     if (Type::isSubtypeOfExt(rhs, why_not)) {
       return true;
     }
-    if (auto rhs_ = rhs.castRaw<FutureType>()) {
+    if (const auto *rhs_ = rhs.castRaw<FutureType>()) {
       return getElementType()->isSubtypeOfExt(*rhs_->getElementType(), why_not);
     }
     return false;
@@ -1077,7 +1077,7 @@ struct TORCH_API AwaitType
     if (Type::isSubtypeOfExt(rhs, why_not)) {
       return true;
     }
-    if (auto rhs_ = rhs.castRaw<AwaitType>()) {
+    if (const auto *rhs_ = rhs.castRaw<AwaitType>()) {
       return getElementType()->isSubtypeOfExt(*rhs_->getElementType(), why_not);
     }
     return false;
@@ -2173,7 +2173,7 @@ struct TORCH_API InterfaceType : public NamedType {
       QualifiedName qualifiedName, bool is_module=false);
 
   bool equals(const Type& rhs) const override {
-    if (auto user_rhs = rhs.castRaw<InterfaceType>()) {
+    if (const auto *user_rhs = rhs.castRaw<InterfaceType>()) {
       return isSubTypeImpl(*this, *user_rhs, nullptr) &&
           isSubTypeImpl(*user_rhs, *this, nullptr);
     }

--- a/aten/src/ATen/core/union_type.cpp
+++ b/aten/src/ATen/core/union_type.cpp
@@ -443,9 +443,9 @@ bool OptionalType::equals(const Type& rhs) const {
 }
 
 bool OptionalType::isSubtypeOfExt(const Type& rhs, std::ostream* why_not) const {
-  if (auto optional_rhs = rhs.castRaw<OptionalType>()) {
+  if (const auto *optional_rhs = rhs.castRaw<OptionalType>()) {
     return getElementType()->isSubtypeOfExt(*optional_rhs->getElementType(), why_not);
-  } else if (auto union_rhs = rhs.castRaw<UnionType>()) {
+  } else if (const auto *union_rhs = rhs.castRaw<UnionType>()) {
     if (!union_rhs->canHoldType(*NoneType::get())) {
       if (why_not) {
         *why_not << rhs.repr_str() << " cannot hold None";

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -727,7 +727,7 @@ inline void bgemm_tunable(CUDABLAS_BGEMM_ARGTYPES(DType)) {
 
 template <>
 void bgemm<double>(CUDABLAS_BGEMM_ARGTYPES(double)) {
-  auto tuning_ctx = at::cuda::tunable::getTuningContext();
+  auto *tuning_ctx = at::cuda::tunable::getTuningContext();
   if (tuning_ctx->IsTunableOpEnabled()) {
     bgemm_tunable<double>(CUDABLAS_BGEMM_ARGS(double));
   }
@@ -738,7 +738,7 @@ void bgemm<double>(CUDABLAS_BGEMM_ARGTYPES(double)) {
 
 template <>
 void bgemm<float>(CUDABLAS_BGEMM_ARGTYPES(float)) {
-  auto tuning_ctx = at::cuda::tunable::getTuningContext();
+  auto *tuning_ctx = at::cuda::tunable::getTuningContext();
   if (tuning_ctx->IsTunableOpEnabled()) {
     bgemm_tunable<float>(CUDABLAS_BGEMM_ARGS(float));
   }
@@ -749,7 +749,7 @@ void bgemm<float>(CUDABLAS_BGEMM_ARGTYPES(float)) {
 
 template <>
 void bgemm<c10::complex<double>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<double>)) {
-  auto tuning_ctx = at::cuda::tunable::getTuningContext();
+  auto *tuning_ctx = at::cuda::tunable::getTuningContext();
   if (tuning_ctx->IsTunableOpEnabled()) {
     bgemm_tunable<c10::complex<double>>(CUDABLAS_BGEMM_ARGS(c10::complex<double>));
   }
@@ -760,7 +760,7 @@ void bgemm<c10::complex<double>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<double>)) 
 
 template <>
 void bgemm<c10::complex<float>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<float>)) {
-  auto tuning_ctx = at::cuda::tunable::getTuningContext();
+  auto *tuning_ctx = at::cuda::tunable::getTuningContext();
   if (tuning_ctx->IsTunableOpEnabled()) {
     bgemm_tunable<c10::complex<float>>(CUDABLAS_BGEMM_ARGS(c10::complex<float>));
   }
@@ -771,7 +771,7 @@ void bgemm<c10::complex<float>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<float>)) {
 
 template <>
 void bgemm<at::Half>(CUDABLAS_BGEMM_ARGTYPES(at::Half)) {
-  auto tuning_ctx = at::cuda::tunable::getTuningContext();
+  auto *tuning_ctx = at::cuda::tunable::getTuningContext();
   if (tuning_ctx->IsTunableOpEnabled()) {
     bgemm_tunable<at::Half>(CUDABLAS_BGEMM_ARGS(at::Half));
   }
@@ -782,7 +782,7 @@ void bgemm<at::Half>(CUDABLAS_BGEMM_ARGTYPES(at::Half)) {
 
 template <>
 void bgemm<at::BFloat16>(CUDABLAS_BGEMM_ARGTYPES(at::BFloat16)) {
-  auto tuning_ctx = at::cuda::tunable::getTuningContext();
+  auto *tuning_ctx = at::cuda::tunable::getTuningContext();
   if (tuning_ctx->IsTunableOpEnabled()) {
     bgemm_tunable<at::BFloat16>(CUDABLAS_BGEMM_ARGS(at::BFloat16));
   }
@@ -1144,7 +1144,7 @@ inline void gemm_tunable(CUDABLAS_GEMM_ARGTYPES(DType)) {
 
 template <>
 void gemm<double>(CUDABLAS_GEMM_ARGTYPES(double)) {
-  auto tuning_ctx = at::cuda::tunable::getTuningContext();
+  auto *tuning_ctx = at::cuda::tunable::getTuningContext();
   if (tuning_ctx->IsTunableOpEnabled()) {
     gemm_tunable<double>(CUDABLAS_GEMM_ARGS(double));
   }
@@ -1155,7 +1155,7 @@ void gemm<double>(CUDABLAS_GEMM_ARGTYPES(double)) {
 
 template <>
 void gemm<float>(CUDABLAS_GEMM_ARGTYPES(float)) {
-  auto tuning_ctx = at::cuda::tunable::getTuningContext();
+  auto *tuning_ctx = at::cuda::tunable::getTuningContext();
   if (tuning_ctx->IsTunableOpEnabled()) {
     gemm_tunable<float>(CUDABLAS_GEMM_ARGS(float));
   }
@@ -1166,7 +1166,7 @@ void gemm<float>(CUDABLAS_GEMM_ARGTYPES(float)) {
 
 template <>
 void gemm<c10::complex<double>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<double>)) {
-  auto tuning_ctx = at::cuda::tunable::getTuningContext();
+  auto *tuning_ctx = at::cuda::tunable::getTuningContext();
   if (tuning_ctx->IsTunableOpEnabled()) {
     gemm_tunable<c10::complex<double>>(CUDABLAS_GEMM_ARGS(c10::complex<double>));
   }
@@ -1177,7 +1177,7 @@ void gemm<c10::complex<double>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<double>)) {
 
 template <>
 void gemm<c10::complex<float>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<float>)) {
-  auto tuning_ctx = at::cuda::tunable::getTuningContext();
+  auto *tuning_ctx = at::cuda::tunable::getTuningContext();
   if (tuning_ctx->IsTunableOpEnabled()) {
     gemm_tunable<c10::complex<float>>(CUDABLAS_GEMM_ARGS(c10::complex<float>));
   }
@@ -1188,7 +1188,7 @@ void gemm<c10::complex<float>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<float>)) {
 
 template <>
 void gemm<at::Half>(CUDABLAS_GEMM_ARGTYPES(at::Half)) {
-  auto tuning_ctx = at::cuda::tunable::getTuningContext();
+  auto *tuning_ctx = at::cuda::tunable::getTuningContext();
   if (tuning_ctx->IsTunableOpEnabled()) {
     gemm_tunable<at::Half>(CUDABLAS_GEMM_ARGS(at::Half));
   }
@@ -1199,7 +1199,7 @@ void gemm<at::Half>(CUDABLAS_GEMM_ARGTYPES(at::Half)) {
 
 template <>
 void gemm<at::BFloat16>(CUDABLAS_GEMM_ARGTYPES(at::BFloat16)) {
-  auto tuning_ctx = at::cuda::tunable::getTuningContext();
+  auto *tuning_ctx = at::cuda::tunable::getTuningContext();
   if (tuning_ctx->IsTunableOpEnabled()) {
     gemm_tunable<at::BFloat16>(CUDABLAS_GEMM_ARGS(at::BFloat16));
   }
@@ -2120,7 +2120,7 @@ void geqrfBatched<c10::complex<double>>(
 template <>
 void getrfBatched<double>(
     int n, double** dA_array, int ldda, int* ipiv_array, int* info_array, int batchsize) {
-  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  auto *handle = at::cuda::getCurrentCUDABlasHandle();
   TORCH_CUDABLAS_CHECK(cublasDgetrfBatched(
       handle, n, dA_array, ldda, ipiv_array, info_array, batchsize));
 }
@@ -2128,7 +2128,7 @@ void getrfBatched<double>(
 template <>
 void getrfBatched<float>(
     int n, float** dA_array, int ldda, int* ipiv_array, int* info_array, int batchsize) {
-  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  auto *handle = at::cuda::getCurrentCUDABlasHandle();
   TORCH_CUDABLAS_CHECK(cublasSgetrfBatched(
       handle, n, dA_array, ldda, ipiv_array, info_array, batchsize));
 }
@@ -2141,7 +2141,7 @@ void getrfBatched<c10::complex<double>>(
     int* ipiv_array,
     int* info_array,
     int batchsize) {
-  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  auto *handle = at::cuda::getCurrentCUDABlasHandle();
   TORCH_CUDABLAS_CHECK(cublasZgetrfBatched(
       handle,
       n,
@@ -2160,7 +2160,7 @@ void getrfBatched<c10::complex<float>>(
     int* ipiv_array,
     int* info_array,
     int batchsize) {
-  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  auto *handle = at::cuda::getCurrentCUDABlasHandle();
   TORCH_CUDABLAS_CHECK(cublasCgetrfBatched(
       handle,
       n,

--- a/aten/src/ATen/cuda/CUDAGeneratorImpl.cpp
+++ b/aten/src/ATen/cuda/CUDAGeneratorImpl.cpp
@@ -72,7 +72,7 @@ Generator createCUDAGenerator(DeviceIndex device_index) {
   }
   TORCH_CHECK(idx >= 0 && idx < num_gpus, "The device_index is invalid.");
   auto gen = make_generator<CUDAGeneratorImpl>(idx);
-  auto cuda_gen = check_generator<CUDAGeneratorImpl>(gen);
+  auto *cuda_gen = check_generator<CUDAGeneratorImpl>(gen);
   cuda_gen->set_current_seed(default_rng_seed_val);
   cuda_gen->set_philox_offset_per_thread(0);
   return gen;
@@ -329,7 +329,7 @@ c10::intrusive_ptr<c10::TensorImpl> CUDAGeneratorImpl::get_state() const {
   static const size_t total_size = seed_size + offset_size;
 
   auto state_tensor = at::detail::empty_cpu({(int64_t)total_size}, ScalarType::Byte, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
-  auto rng_state = state_tensor.data_ptr<uint8_t>();
+  auto *rng_state = state_tensor.data_ptr<uint8_t>();
   auto current_seed = this->current_seed();
   auto offset = static_cast<int64_t>(this->philox_offset_per_thread()); // Note that old THCGeneratorState had offset as std::atomic<int64_t>
   memcpy(rng_state, &current_seed, seed_size);
@@ -362,7 +362,7 @@ void CUDAGeneratorImpl::set_state(const c10::TensorImpl& new_state) {
   }
 
   uint64_t input_seed = 0;
-  auto new_rng_state = new_state.data_dtype_initialized<uint8_t>();
+  const auto *new_rng_state = new_state.data_dtype_initialized<uint8_t>();
   memcpy(&input_seed, new_rng_state, seed_size);
   this->set_current_seed(input_seed);
   int64_t philox_offset = 0;
@@ -500,7 +500,7 @@ std::shared_ptr<CUDAGeneratorImpl> CUDAGeneratorImpl::clone() const {
  */
 CUDAGeneratorImpl* CUDAGeneratorImpl::clone_impl() const {
   at::cuda::assertNotCapturing("Cannot call CUDAGeneratorImpl::clone_impl");
-  auto gen = new CUDAGeneratorImpl(this->device().index(), state_->clone());
+  auto *gen = new CUDAGeneratorImpl(this->device().index(), state_->clone());
   return gen;
 }
 

--- a/aten/src/ATen/cuda/CuSparseHandlePool.cpp
+++ b/aten/src/ATen/cuda/CuSparseHandlePool.cpp
@@ -38,7 +38,7 @@ cusparseHandle_t getCurrentCUDASparseHandle() {
   thread_local std::unique_ptr<CuSparsePoolType::PoolWindow> myPoolWindow(
       pool->newPoolWindow());
 
-  auto handle = myPoolWindow->reserve(device);
+  auto *handle = myPoolWindow->reserve(device);
   TORCH_CUDASPARSE_CHECK(cusparseSetStream(handle, c10::cuda::getCurrentCUDAStream()));
   return handle;
 }

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -198,7 +198,7 @@ cublasHandle_t getCurrentCUDABlasHandle() {
   thread_local std::unique_ptr<CuBlasPoolType::PoolWindow> myPoolWindow(
       pool->newPoolWindow());
 
-  auto handle = myPoolWindow->reserve(device);
+  auto *handle = myPoolWindow->reserve(device);
   auto stream = c10::cuda::getCurrentCUDAStream();
   TORCH_CUDABLAS_CHECK(cublasSetStream(handle, stream));
   // We explicitly set the cublas workspace even though CUDA 12.2+ fixed the

--- a/aten/src/ATen/cudnn/Handle.cpp
+++ b/aten/src/ATen/cudnn/Handle.cpp
@@ -49,7 +49,7 @@ cudnnHandle_t getCudnnHandle() {
   thread_local std::unique_ptr<CudnnPoolType::PoolWindow> myPoolWindow(
       pool->newPoolWindow());
 
-  auto handle = myPoolWindow->reserve(device);
+  auto *handle = myPoolWindow->reserve(device);
   AT_CUDNN_CHECK(cudnnSetStream(handle, c10::cuda::getCurrentCUDAStream()));
   return handle;
 }

--- a/aten/src/ATen/functorch/ADInterpreters.cpp
+++ b/aten/src/ATen/functorch/ADInterpreters.cpp
@@ -193,7 +193,7 @@ static void autogradBasedTransformSendToNext(
     if (!ivalue.isTensor()) {
       continue;
     }
-    auto maybe_tensor_wrapper = maybeGetTensorWrapper(ivalue.toTensor());
+    auto *maybe_tensor_wrapper = maybeGetTensorWrapper(ivalue.toTensor());
     if (!maybe_tensor_wrapper) {
       continue;
     }

--- a/aten/src/ATen/functorch/BatchedFallback.cpp
+++ b/aten/src/ATen/functorch/BatchedFallback.cpp
@@ -184,8 +184,8 @@ static void batchedTensorInplaceForLoopFallback(const c10::OperatorHandle& op, t
   // of the arguments onto `stack`, and call `op`.
   for (int64_t linear_idx = 0; linear_idx < num_batches; ++linear_idx) {
     auto index = computeIndex(linear_idx, batch_sizes);
-    auto batched_tensor_inputs_pos_iter = batched_tensor_inputs_position.begin();
-    auto input_physical_views_iter = input_physical_views.begin();
+    auto *batched_tensor_inputs_pos_iter = batched_tensor_inputs_position.begin();
+    const auto *input_physical_views_iter = input_physical_views.begin();
     for (const auto arg_idx : c10::irange(0, num_arguments)) {
       // We assume that torch::jit::Stack is backed by vector<IValue> for
       // simplicity. When that is not the case, this code should be updated.
@@ -338,8 +338,8 @@ void batchedTensorForLoopFallback(const c10::OperatorHandle& op, torch::jit::Sta
 
   for (int64_t linear_idx = 0; linear_idx < num_batches; ++linear_idx) {
     auto index = computeIndex(linear_idx, batch_sizes);
-    auto batched_tensor_inputs_pos_iter = batched_tensor_inputs_position.begin();
-    auto input_physical_views_iter = input_physical_views.begin();
+    auto *batched_tensor_inputs_pos_iter = batched_tensor_inputs_position.begin();
+    const auto *input_physical_views_iter = input_physical_views.begin();
     for (const auto arg_idx : c10::irange(0, num_arguments)) {
       // We assume that torch::jit::Stack is backed by vector<IValue> for
       // simplicity. When that is not the case, this code should be updated.
@@ -467,7 +467,7 @@ void batchedNestedTensorForLoopFallback(const c10::OperatorHandle& op, torch::ji
   std::vector<Tensor> output_shards(num_components * num_returns);
   for (const auto component_idx : c10::irange(0, num_components)) {
     auto batched_idx = 0;
-    auto batched_tensor_inputs_pos_iter = batched_tensor_inputs_position.begin();
+    auto *batched_tensor_inputs_pos_iter = batched_tensor_inputs_position.begin();
     for (const auto arg_idx : c10::irange(0, num_arguments)) {
       // We assume that torch::jit::Stack is backed by vector<IValue> for
       // simplicity. When that is not the case, this code should be updated.

--- a/aten/src/ATen/functorch/FunctionalizeInterpreter.cpp
+++ b/aten/src/ATen/functorch/FunctionalizeInterpreter.cpp
@@ -31,7 +31,7 @@ void FunctionalizeInterpreterPtr::processImpl(
   foreachTensorInplace(*stack, static_cast<std::ptrdiff_t>(stack->size() - ret_size), static_cast<std::ptrdiff_t>(stack->size()),
     [&](const Tensor& tensor) {
       if (at::functionalization::impl::isFunctionalTensor(tensor)) {
-        auto wrapper = at::functionalization::impl::unsafeGetFunctionalWrapper(tensor);
+        auto *wrapper = at::functionalization::impl::unsafeGetFunctionalWrapper(tensor);
         // Functorch is responsible for setting the level on the wrapper, since we don't
         // have that info available in core (for now).
         // We could just "propagate" the level from the input tensors inside of the functionalize kernels,

--- a/aten/src/ATen/functorch/TensorWrapper.cpp
+++ b/aten/src/ATen/functorch/TensorWrapper.cpp
@@ -70,7 +70,7 @@ static Tensor unsafeMakeTensorWrapper(
     int64_t level,
     bool is_immutable,
     const std::shared_ptr<bool>& life_handle) {
-  auto wrapped = maybeGetTensorWrapper(tensor);
+  auto *wrapped = maybeGetTensorWrapper(tensor);
   if (wrapped) {
     TORCH_INTERNAL_ASSERT(wrapped->level() < level);
   }

--- a/aten/src/ATen/native/nested/NestedTensorBackward.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorBackward.cpp
@@ -77,8 +77,8 @@ Tensor nested_softmax_backward(
   TORCH_INTERNAL_ASSERT(grad.is_nested(), "Should be nested grad")
   TORCH_INTERNAL_ASSERT(output.is_nested(), "Should be nested output")
 
-  auto output_ptr = get_nested_tensor_impl(output);
-  auto grad_ptr = get_nested_tensor_impl(grad);
+  auto *output_ptr = get_nested_tensor_impl(output);
+  auto *grad_ptr = get_nested_tensor_impl(grad);
   int64_t ntensors = output_ptr->size(0);
   if (ntensors == 0) {
     return grad.clone();
@@ -118,8 +118,8 @@ Tensor _nested_sum_backward_cpu(
   const Tensor& nested_self,
   OptionalIntArrayRef opt_dims,
   bool keepdim) {
-  auto nt_self = get_nested_tensor_impl(nested_self);
-  auto nt_grad = get_nested_tensor_impl(grad);
+  auto *nt_self = get_nested_tensor_impl(nested_self);
+  auto *nt_grad = get_nested_tensor_impl(grad);
   const Tensor& grad_buffer = nt_grad->get_buffer();
   const Tensor& self_buffer = nt_self->get_buffer();
   auto grad_sizes = nt_grad->get_nested_sizes();
@@ -163,7 +163,7 @@ Tensor _nested_select_backward_symint(
   int64_t dim,
   // NOLINTNEXTLINE(performance-unnecessary-value-param)
   c10::SymInt index) {
-  auto nt_self = get_nested_tensor_impl(nested_self);
+  auto *nt_self = get_nested_tensor_impl(nested_self);
   const Tensor& self_buffer = nt_self->get_buffer();
   const auto self_sizes = nt_self->get_nested_sizes();
   const Tensor& self_grad_buffer = self_buffer.new_zeros(self_buffer.sizes());

--- a/aten/src/ATen/native/nested/NestedTensorBinaryOps.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorBinaryOps.cpp
@@ -38,8 +38,8 @@ static get_elementwise_nested_tensor_impl(
         "Expected both self and other to be nested, but got a non-nested self and non-nested other");
   }
 
-  auto self_ptr = get_nested_tensor_impl(self);
-  auto other_ptr = get_nested_tensor_impl(other);
+  auto *self_ptr = get_nested_tensor_impl(self);
+  auto *other_ptr = get_nested_tensor_impl(other);
 
   TORCH_CHECK(
       self.dim() == other.dim(),
@@ -82,7 +82,7 @@ Tensor NestedTensor_elementwise_Tensor(
   Tensor other_contiguous = other;
   // self is a scalar
   if (!self.is_nested() && self.dim() == 0 && self.numel() == 1) {
-    auto other_impl = get_nested_tensor_impl(other);
+    auto *other_impl = get_nested_tensor_impl(other);
     return wrap_buffer(
       f(self, other_impl->get_unsafe_storage_as_tensor()),
       other_impl->get_nested_sizes().clone(),
@@ -92,7 +92,7 @@ Tensor NestedTensor_elementwise_Tensor(
   }
   // other is a scalar
   if (!other.is_nested() && other.dim() == 0 && other.numel() == 1) {
-    auto self_impl = get_nested_tensor_impl(self);
+    auto *self_impl = get_nested_tensor_impl(self);
     return wrap_buffer(
       f(self_impl->get_unsafe_storage_as_tensor(), other),
       self_impl->get_nested_sizes().clone(),
@@ -102,7 +102,7 @@ Tensor NestedTensor_elementwise_Tensor(
   }
   // special case when other is dense (CUDA only for now)
   if (self.is_nested() && !other.is_nested() && self.is_cuda() && other.is_cuda()) {
-    auto self_ptr = get_nested_tensor_impl(self);
+    auto *self_ptr = get_nested_tensor_impl(self);
     auto other_ = other;
     // check for the [B, *, D], [B, 1, D] case -> use custom kernel
     // TODO: this if statement is ugly and hopefully we will remove this in the near future
@@ -241,13 +241,13 @@ Tensor& NestedTensor_elementwise__Tensor(
     Func f) {
   // self is a scalar
   if (!self.is_nested() && self.dim() == 0 && self.numel() == 1) {
-    auto other_impl = get_nested_tensor_impl(other);
+    auto *other_impl = get_nested_tensor_impl(other);
     f(self, other_impl->get_buffer());
     return self;
   }
   // other is a scalar
   if (!other.is_nested() && other.dim() == 0 && other.numel() == 1) {
-    auto self_impl = get_nested_tensor_impl(self);
+    auto *self_impl = get_nested_tensor_impl(self);
     f(self_impl->get_buffer(), other);
     return self;
   }

--- a/aten/src/ATen/native/nested/NestedTensorFactories.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorFactories.cpp
@@ -43,7 +43,7 @@ Tensor empty_like_nested(
     std::optional<c10::MemoryFormat> optional_memory_format) {
   auto options = verify_empty_parameters(
       self, dtype, layout, device, pin_memory, optional_memory_format);
-  auto self_nt = get_nested_tensor_impl(self);
+  auto *self_nt = get_nested_tensor_impl(self);
   auto memory_format = options.memory_format_opt().value_or(MemoryFormat::Preserve);
   if (memory_format == MemoryFormat::Contiguous) {
     auto nested_size = self_nt->get_nested_sizes().clone();
@@ -133,7 +133,7 @@ Tensor clone_nested(
     const Tensor& self,
     std::optional<c10::MemoryFormat> optional_memory_format) {
   auto memory_format = optional_memory_format.value_or(c10::MemoryFormat::Preserve);
-  auto self_ptr = get_nested_tensor_impl(self);
+  auto *self_ptr = get_nested_tensor_impl(self);
   if (memory_format == c10::MemoryFormat::Preserve ||
   (memory_format == c10::MemoryFormat::Contiguous && self.is_contiguous())) {
     const Tensor& buffer = self_ptr->get_unsafe_storage_as_tensor(),
@@ -175,7 +175,7 @@ std::vector<at::Tensor> NestedTensor_unbind(
       "got dimension ",
       dim,
       " instead.");
-  auto self_ptr = get_nested_tensor_impl(self);
+  auto *self_ptr = get_nested_tensor_impl(self);
   int64_t ntensors = self_ptr->size(0);
   std::vector<at::Tensor> result_tensors(ntensors);
   if (ntensors == 0) {
@@ -212,7 +212,7 @@ Tensor narrow_nested_symint(const at::Tensor& self, int64_t dim, SymInt start, S
   auto nested_sizes = nt_impl->get_nested_sizes();
   auto nested_strides = nt_impl->get_nested_strides();
   auto storage_offsets = nt_impl->get_storage_offsets();
-  auto storage_offsets_ptr = storage_offsets.data_ptr<int64_t>();
+  auto *storage_offsets_ptr = storage_offsets.data_ptr<int64_t>();
 
   auto start_int = start.guard_int(__FILE__, __LINE__);
   auto length_int = length.guard_int(__FILE__, __LINE__);

--- a/aten/src/ATen/native/nested/NestedTensorMatmul.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMatmul.cpp
@@ -75,8 +75,8 @@ static Tensor matmul_with_bmm_nested(const Tensor& self, const Tensor& mat2) {
   // Tensor mat2 = mat2_.contiguous();
   // self [N, n_heads, *, head_dim]
   // mat2 [N, n_heads, head_dim, *]
-  const auto self_ptr = get_nested_tensor_impl(self);
-  const auto mat2_ptr = get_nested_tensor_impl(mat2);
+  auto *const self_ptr = get_nested_tensor_impl(self);
+  auto *const mat2_ptr = get_nested_tensor_impl(mat2);
   // metadata for self
   std::vector<IntArrayRef> self_sizes = NestedTensor_get_sizes(self_ptr);
   std::vector<IntArrayRef> self_strides = NestedTensor_get_strides(self_ptr);
@@ -196,7 +196,7 @@ static Tensor matmul_nested_with_broadcasted_dense(
   const auto E = other.size(-1);
   const auto component_dim = nt.dim() - 1;
   auto new_sizes = nt_impl->get_nested_sizes().clone();
-  auto new_sizes_ptr = new_sizes.data_ptr<int64_t>();
+  auto *new_sizes_ptr = new_sizes.data_ptr<int64_t>();
   for (const auto i : c10::irange(nt.size(0))) {
     new_sizes_ptr[i * component_dim + 2] = E;
   }
@@ -233,8 +233,8 @@ Tensor matmul_nested(const Tensor& self, const Tensor& mat2) {
   auto self_contig = self.contiguous();
   auto mat2_contig = mat2.contiguous();
   // dispatcher should have guaranteed that at least one is nested
-  const auto self_ptr = get_nested_tensor_impl(self_contig);
-  const auto mat2_ptr = get_nested_tensor_impl(mat2_contig);
+  auto *const self_ptr = get_nested_tensor_impl(self_contig);
+  auto *const mat2_ptr = get_nested_tensor_impl(mat2_contig);
   int64_t self_dim = self_ptr->dim(), mat2_dim = mat2_ptr->dim();
   TORCH_CHECK(
       self_dim >= 3,
@@ -311,7 +311,7 @@ Tensor& matmul_out_nested(
   // TODO: this is a very quick and dirty implementation
   //       should improve it to avoid the intermediate memory usage
   Tensor function_result = at::matmul(tensor1, tensor2);
-  auto function_result_ptr = get_nested_tensor_impl(function_result);
+  auto *function_result_ptr = get_nested_tensor_impl(function_result);
   // TODO: this is to reproduce function_result_ptr->opt_sizes_
   //       if an accessor is provided in the future, can replace this
   std::vector<int64_t> sizes;

--- a/aten/src/ATen/native/nested/NestedTensorUnaryOps.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUnaryOps.cpp
@@ -39,7 +39,7 @@ DEFINE_TORCH_NESTED_TENSOR_UNARY_OP(tanh)
 #undef DEFINE_TORCH_NESTED_TENSOR_UNARY_OP
 
 Tensor& NestedTensor_abs_(Tensor& self) {
-  auto self_ptr = get_nested_tensor_impl(self);
+  auto *self_ptr = get_nested_tensor_impl(self);
   check_numel_equals_buffer_size(self_ptr);
   auto buffer = self_ptr->get_buffer();
   at::abs_(buffer);
@@ -51,8 +51,8 @@ Tensor NestedTensor_where(const Tensor& condition, const Tensor& self, const Ten
   TORCH_CHECK(other.is_nested(), "other must be nested");
   TORCH_CHECK(!self.is_nested(), "self must not be nested");
 
-  auto condition_ptr = get_nested_tensor_impl(condition);
-  auto other_ptr = get_nested_tensor_impl(other);
+  auto *condition_ptr = get_nested_tensor_impl(condition);
+  auto *other_ptr = get_nested_tensor_impl(other);
 
   int64_t ntensors = condition_ptr->size(0);
   TORCH_CHECK(other_ptr->size(0) == ntensors, "condition and other must have the same number of tensors");
@@ -90,9 +90,9 @@ Tensor& NestedTensor_where_out(const Tensor& condition, const Tensor& self, cons
   TORCH_CHECK(!self.is_nested(), "self must not be nested");
   TORCH_CHECK(out.is_nested(), "out must be nested");
 
-  auto condition_ptr = get_nested_tensor_impl(condition);
-  auto other_ptr = get_nested_tensor_impl(other);
-  auto out_ptr = get_nested_tensor_impl(out);
+  auto *condition_ptr = get_nested_tensor_impl(condition);
+  auto *other_ptr = get_nested_tensor_impl(other);
+  auto *out_ptr = get_nested_tensor_impl(out);
 
   int64_t ntensors = condition_ptr->size(0);
   TORCH_CHECK(other_ptr->size(0) == ntensors, "condition and other must have the same number of tensors");
@@ -116,7 +116,7 @@ Tensor& NestedTensor_where_out(const Tensor& condition, const Tensor& self, cons
 }
 
 Tensor& NestedTensor_sgn_(Tensor& self) {
-  auto self_ptr = get_nested_tensor_impl(self);
+  auto *self_ptr = get_nested_tensor_impl(self);
   check_numel_equals_buffer_size(self_ptr);
   auto buffer = self_ptr->get_buffer();
   buffer.sgn_();
@@ -124,7 +124,7 @@ Tensor& NestedTensor_sgn_(Tensor& self) {
 }
 
 Tensor& NestedTensor_logical_not_(Tensor& self){
-  auto self_ptr = get_nested_tensor_impl(self);
+  auto *self_ptr = get_nested_tensor_impl(self);
   check_numel_equals_buffer_size(self_ptr);
   auto buffer = self_ptr->get_buffer();
   buffer.logical_not_();
@@ -133,7 +133,7 @@ Tensor& NestedTensor_logical_not_(Tensor& self){
 
 
 Tensor& NestedTensor_relu_(Tensor& self) {
-  auto self_ptr = get_nested_tensor_impl(self);
+  auto *self_ptr = get_nested_tensor_impl(self);
   check_numel_equals_buffer_size(self_ptr);
   auto buffer = self_ptr->get_buffer();
   at::relu_(buffer);
@@ -141,7 +141,7 @@ Tensor& NestedTensor_relu_(Tensor& self) {
 }
 
 Tensor& NestedTensor_gelu_(Tensor& self, std::string_view approximate) {
-  auto self_ptr = get_nested_tensor_impl(self);
+  auto *self_ptr = get_nested_tensor_impl(self);
   check_numel_equals_buffer_size(self_ptr);
   auto buffer = self_ptr->get_buffer();
   at::gelu_(buffer, approximate);
@@ -157,7 +157,7 @@ Tensor NestedTensor_gelu(const Tensor& self, std::string_view approximate) {
 }
 
 Tensor& NestedTensor_tanh_(Tensor& self) {
-  auto self_ptr = get_nested_tensor_impl(self);
+  auto *self_ptr = get_nested_tensor_impl(self);
   check_numel_equals_buffer_size(self_ptr);
   auto buffer = self_ptr->get_buffer();
   at::tanh_(buffer);
@@ -165,7 +165,7 @@ Tensor& NestedTensor_tanh_(Tensor& self) {
 }
 
 Tensor& NestedTensor_neg_(Tensor& self) {
-  auto self_ptr = get_nested_tensor_impl(self);
+  auto *self_ptr = get_nested_tensor_impl(self);
   check_numel_equals_buffer_size(self_ptr);
   auto buffer = self_ptr->get_buffer();
   at::neg_(buffer);
@@ -179,7 +179,7 @@ Tensor& zero_nested_(Tensor& self) {
 }
 
 Tensor& NestedTensor_silu_(Tensor& self){
-  auto self_ptr = get_nested_tensor_impl(self);
+  auto *self_ptr = get_nested_tensor_impl(self);
   check_numel_equals_buffer_size(self_ptr);
   auto buffer = self_ptr->get_buffer();
   at::silu_(buffer);

--- a/aten/src/ATen/native/nested/NestedTensorUtils.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.cpp
@@ -36,7 +36,7 @@ std::vector<int64_t> NestedTensor_get_max_size_from_size_tensor(
   if (sizes.dim() == 0) {
     return {};
   }
-  const auto sizes_ptr = sizes.data_ptr<int64_t>();
+  auto *const sizes_ptr = sizes.data_ptr<int64_t>();
   const auto sizes_size_0 = sizes.sizes()[0];
   const auto sizes_size_1 = sizes.sizes()[1];
   TORCH_INTERNAL_ASSERT(sizes_size_1 > 0);
@@ -76,7 +76,7 @@ std::vector<Tensor> chunk_nested_tensor(const Tensor& self, int64_t chunks, int6
            "Chunk for nested tensors is currently only supported for the last dimension.");
   TORCH_CHECK(chunks > 0,"chunk expects `chunks` to be greater than 0, got: ", chunks);
   TORCH_CHECK(self.is_contiguous(), "chunk expects `self` to be contiguous.");
-  auto self_impl = get_nested_tensor_impl(self);
+  auto *self_impl = get_nested_tensor_impl(self);
   const int64_t last_dim_size = get_consistent_last_dim_of_nested_tensor(*self_impl);
     TORCH_CHECK(last_dim_size % chunks == 0,
            "Chunk for nested tensors is only supported for nested tensors with trailing dimension divisible by chunks, got: ",
@@ -131,7 +131,7 @@ std::vector<Tensor> split_with_sizes_nested(
   for (const auto split_size : split_sizes) {
       total_size += split_size;
   }
-  auto self_impl = get_nested_tensor_impl(self);
+  auto *self_impl = get_nested_tensor_impl(self);
   auto self_size = get_consistent_last_dim_of_nested_tensor(*self_impl);
   TORCH_CHECK(total_size == self_size,
           "split_with_sizes expects split_sizes to sum exactly to ", self_size,

--- a/aten/src/ATen/native/nested/NestedTensorUtils.h
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.h
@@ -167,7 +167,7 @@ inline std::vector<IntArrayRef> NestedTensor_get_strides(
 }
 
 inline void check_numel_equals_buffer_size(const at::Tensor& self) {
-  auto self_impl = get_nested_tensor_impl(self);
+  auto *self_impl = get_nested_tensor_impl(self);
   TORCH_CHECK(
       self.numel() == static_cast<int64_t>(self_impl->get_buffer_size()),
       "Number of elements in nested tensor must match number of elements in buffer.");

--- a/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
+++ b/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
@@ -62,9 +62,9 @@ Tensor nested_from_padded_cuda(
         at::cat({target_size_sizes, padded_sizes_tensor, target_offsets});
     metadata = metadata.to(at::Device(kCUDA), kInt, true, true);
 
-    auto output_size_ptr = metadata.data_ptr<int>();
-    auto input_size_ptr = output_size_ptr + target_size_sizes.numel();
-    auto offsets_ptr = input_size_ptr + padded_sizes_tensor.numel();
+    auto *output_size_ptr = metadata.data_ptr<int>();
+    auto *input_size_ptr = output_size_ptr + target_size_sizes.numel();
+    auto *offsets_ptr = input_size_ptr + padded_sizes_tensor.numel();
 
     Tensor padded_contiguous = padded.contiguous();
     if (padded.dtype() == kFloat) {

--- a/c10/core/CPUAllocator.cpp
+++ b/c10/core/CPUAllocator.cpp
@@ -81,8 +81,8 @@ class DefaultMobileCPUAllocator final : public at::Allocator {
     }
     // TODO: enable with better TLS support on mobile
     // profiledCPUMemoryReporter().Delete(pointer);
-    auto allocator_ptr = GetThreadLocalCachingAllocator();
-    auto profiling_allocator_ptr = GetThreadLocalProfilingAllocator();
+    auto* allocator_ptr = GetThreadLocalCachingAllocator();
+    auto* profiling_allocator_ptr = GetThreadLocalProfilingAllocator();
     if (allocator_ptr != nullptr) {
       allocator_ptr->free(pointer);
     } else if (profiling_allocator_ptr != nullptr) {
@@ -93,7 +93,7 @@ class DefaultMobileCPUAllocator final : public at::Allocator {
       // caching allocator is not enabled.
       // NOLINTNEXTLINE(clang-analyzer-unix.Malloc)
       CPUCachingAllocator::record_free(pointer);
-      auto allocation_planner = GetThreadLocalAllocationPlanner();
+      auto* allocation_planner = GetThreadLocalAllocationPlanner();
       if (allocation_planner != nullptr) {
         allocation_planner->record_free(pointer);
       }
@@ -112,8 +112,8 @@ class DefaultMobileCPUAllocator final : public at::Allocator {
 
     auto alloc_size = PreGuardBytes + nbytes + PostGuardBytes;
     void* data = nullptr;
-    auto allocator_ptr = GetThreadLocalCachingAllocator();
-    auto profiling_allocator_ptr = GetThreadLocalProfilingAllocator();
+    auto* allocator_ptr = GetThreadLocalCachingAllocator();
+    auto* profiling_allocator_ptr = GetThreadLocalProfilingAllocator();
     if (allocator_ptr != nullptr) {
       data = allocator_ptr->allocate(alloc_size);
     } else if (profiling_allocator_ptr != nullptr) {
@@ -125,7 +125,7 @@ class DefaultMobileCPUAllocator final : public at::Allocator {
         profiledCPUMemoryReporter().OutOfMemory(alloc_size);
         throw e;
       }
-      auto allocation_planner = GetThreadLocalAllocationPlanner();
+      auto* allocation_planner = GetThreadLocalAllocationPlanner();
       if (allocation_planner != nullptr) {
         allocation_planner->record_allocation(alloc_size, data);
       }

--- a/c10/core/Contiguity.h
+++ b/c10/core/Contiguity.h
@@ -41,7 +41,7 @@ bool _compute_channels_last_contiguous_2d(
   switch (sizes.size()) {
     case 4: {
       T expected = 1;
-      for (auto& d : {1, 3, 2, 0}) {
+      for (const auto& d : {1, 3, 2, 0}) {
         const auto& size_d = sizes[d];
         if (TORCH_GUARD_SIZE_OBLIVIOUS(sym_ne(size_d, 1))) {
           if (TORCH_GUARD_SIZE_OBLIVIOUS(sym_ne(strides[d], expected))) {
@@ -70,7 +70,7 @@ bool _compute_channels_last_contiguous_3d(
   switch (sizes.size()) {
     case 5: {
       T expected = 1;
-      for (auto& d : {1, 4, 3, 2, 0}) {
+      for (const auto& d : {1, 4, 3, 2, 0}) {
         const auto& size_d = sizes[d];
         if (TORCH_GUARD_SIZE_OBLIVIOUS(sym_ne(size_d, 1))) {
           if (TORCH_GUARD_SIZE_OBLIVIOUS(sym_ne(strides[d], expected))) {

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -41,7 +41,7 @@ DeviceType parse_type(const std::string& device_string) {
         "'mkldnn' is no longer used as device type. So torch.device('mkldnn') will be "
         "deprecated and removed in the future. Please use other valid device types instead.");
   }
-  auto device = std::find_if(
+  const auto* device = std::find_if(
       types.begin(),
       types.end(),
       [&device_string](const std::pair<const char*, DeviceType>& p) {

--- a/c10/core/GeneratorImpl.cpp
+++ b/c10/core/GeneratorImpl.cpp
@@ -25,7 +25,7 @@ GeneratorImpl::GeneratorImpl(Device device_in, DispatchKeySet key_set)
  * method for copying for Generators in ATen.
  */
 c10::intrusive_ptr<GeneratorImpl> GeneratorImpl::clone() const {
-  auto res = this->clone_impl();
+  auto* res = this->clone_impl();
   c10::raw::intrusive_ptr::incref(res);
   c10::raw::weak_intrusive_ptr::incref(res);
   return c10::intrusive_ptr<GeneratorImpl>::reclaim(res);

--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -135,7 +135,7 @@ inline bool is_channels_last_strides_2d_s4(
     return false;
   }
   // loop strides indices
-  for (auto& d : {1, 3, 2, 0}) {
+  for (const auto& d : {1, 3, 2, 0}) {
     if (sizes[d] == 0) {
       return false;
     }
@@ -175,7 +175,7 @@ inline bool is_channels_last_strides_3d_s5(
   if (strides[1] == 0) {
     return false;
   }
-  for (auto& d : {1, 4, 3, 2, 0}) {
+  for (const auto& d : {1, 4, 3, 2, 0}) {
     if (sizes[d] == 0) {
       return false;
     }

--- a/c10/core/SafePyObject.h
+++ b/c10/core/SafePyObject.h
@@ -64,7 +64,7 @@ struct C10_API SafePyObject {
 
   // stop tracking the current object, and return it
   PyObject* release() {
-    auto rv = data_;
+    auto* rv = data_;
     data_ = nullptr;
     return rv;
   }

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -73,7 +73,7 @@ struct C10_API Storage {
   // that can be temporarily created with Caffe2 APIs. See the note on top of
   // TensorImpl.h for details.
   static Storage create_legacy(at::Device device) {
-    auto allocator = GetAllocator(device.type());
+    auto* allocator = GetAllocator(device.type());
     return Storage(c10::make_intrusive<StorageImpl>(
         StorageImpl::use_byte_size_t(),
         0,

--- a/c10/core/impl/DeviceGuardImplInterface.h
+++ b/c10/core/impl/DeviceGuardImplInterface.h
@@ -358,7 +358,8 @@ inline const DeviceGuardImplInterface* getDeviceGuardImpl(DeviceType type) {
   //   https://fb.workplace.com/groups/llvm.gcc/permalink/4053565044692080/
   // for more details
   static_assert(sizeof(DeviceType) == 1, "DeviceType is not 8-bit");
-  auto p = device_guard_impl_registry[static_cast<size_t>(type) & 0xFF].load();
+  const auto* p =
+      device_guard_impl_registry[static_cast<size_t>(type) & 0xFF].load();
 
   // This seems to be the first place where you make use of a device
   // when you pass devices to factory functions.  Give a nicer error

--- a/c10/core/impl/PyObjectSlot.cpp
+++ b/c10/core/impl/PyObjectSlot.cpp
@@ -40,7 +40,7 @@ void PyObjectSlot::unchecked_clear_pyobj(PyInterpreter* interpreter) {
 }
 
 PyInterpreter& PyObjectSlot::load_pyobj_interpreter() const {
-  auto interpreter = pyobj_interpreter_.load(std::memory_order_acquire);
+  auto* interpreter = pyobj_interpreter_.load(std::memory_order_acquire);
   if (interpreter) {
     return *interpreter;
   }

--- a/c10/core/thread_pool.cpp
+++ b/c10/core/thread_pool.cpp
@@ -78,7 +78,7 @@ size_t ThreadPool::numAvailable() const {
 }
 
 bool ThreadPool::inThreadPool() const {
-  for (auto& thread : threads_) {
+  for (const auto& thread : threads_) {
     if (thread.get_id() == std::this_thread::get_id()) {
       return true;
     }

--- a/c10/cuda/CUDAAllocatorConfig.h
+++ b/c10/cuda/CUDAAllocatorConfig.h
@@ -79,7 +79,7 @@ class C10_CUDA_API CUDAAllocatorConfig {
 
   static CUDAAllocatorConfig& instance() {
     static CUDAAllocatorConfig* s_instance = ([]() {
-      auto inst = new CUDAAllocatorConfig();
+      auto* inst = new CUDAAllocatorConfig();
       const char* env = getenv("PYTORCH_CUDA_ALLOC_CONF");
       inst->parseArgs(env);
       return inst;

--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -334,7 +334,7 @@ void mallocAsync(
   if (!capture_underway &&
       !ungraphed_ptrs_defer_free_until_no_capture.empty()) {
     // See Note [Avoid freeing uncaptured ptrs during CUDA graph capture]
-    for (const auto ptr : ungraphed_ptrs_defer_free_until_no_capture) {
+    for (auto* const ptr : ungraphed_ptrs_defer_free_until_no_capture) {
       auto it = ptr_info.find(ptr);
       TORCH_INTERNAL_ASSERT(it != ptr_info.end(), "ptr not found in ptr_info");
       free_impl(it);
@@ -608,7 +608,7 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
 
   void recordStream(const DataPtr& ptr, cuda::CUDAStream stream) override {
     std::lock_guard<std::mutex> lk(general_mutex);
-    auto ptr_val = ptr.get();
+    auto* ptr_val = ptr.get();
     // Empty tensor's storage().data() might be a null ptr. As there is no
     // blocks associated with those tensors, it is fine to do nothing here.
     if (!ptr_val) {

--- a/c10/cuda/impl/CUDAGuardImpl.h
+++ b/c10/cuda/impl/CUDAGuardImpl.h
@@ -107,7 +107,7 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
       const noexcept override {
     if (!event)
       return;
-    auto cuda_event = static_cast<cudaEvent_t>(event);
+    auto* cuda_event = static_cast<cudaEvent_t>(event);
     DeviceIndex orig_device{-1};
     C10_CUDA_CHECK_WARN(c10::cuda::GetDevice(&orig_device));
     C10_CUDA_CHECK_WARN(c10::cuda::SetDevice(device_index));

--- a/c10/mobile/CPUCachingAllocator.cpp
+++ b/c10/mobile/CPUCachingAllocator.cpp
@@ -77,7 +77,7 @@ void CPUCachingAllocator::record_free(void* ptr) {
 
 void CPUCachingAllocator::free_cached() {
   for (const auto& it : available_map_) {
-    for (const auto ptr : it.second) {
+    for (auto* const ptr : it.second) {
       c10::free_cpu(ptr);
       // When cached memory is return to OS, it must be removed
       // from allocation_map.

--- a/c10/test/core/impl/cow_test.cpp
+++ b/c10/test/core/impl/cow_test.cpp
@@ -237,7 +237,7 @@ TEST(materialize_test, copy_on_write) {
   auto new_storage = cow::lazy_clone_storage(original_storage);
   ASSERT_THAT(new_storage, testing::NotNull());
 
-  auto context = new_storage->data_ptr().cast_context<cow::COWDeleterContext>(
+  auto* context = new_storage->data_ptr().cast_context<cow::COWDeleterContext>(
       cow::cow_deleter);
   ASSERT_THAT(context, testing::NotNull());
 

--- a/c10/test/util/lazy_test.cpp
+++ b/c10/test/util/lazy_test.cpp
@@ -26,7 +26,7 @@ TEST(LazyTest, OptimisticLazy) {
   for (size_t i = 0; i < kNumThreads; ++i) {
     threads.emplace_back([&] {
       auto* p = &s.ensure(factory);
-      auto old = address.exchange(p);
+      auto* old = address.exchange(p);
       if (old != nullptr) {
         // Even racing ensure()s should return a stable reference.
         EXPECT_EQ(old, p);

--- a/c10/util/DynamicCounter.cpp
+++ b/c10/util/DynamicCounter.cpp
@@ -14,12 +14,12 @@ using DynamicCounterBackends =
     std::vector<std::shared_ptr<detail::DynamicCounterBackendIf>>;
 
 Synchronized<DynamicCounterBackends>& dynamicCounterBackends() {
-  static auto instance = new Synchronized<DynamicCounterBackends>();
+  static auto* instance = new Synchronized<DynamicCounterBackends>();
   return *instance;
 }
 
 Synchronized<std::unordered_set<std::string>>& registeredCounters() {
-  static auto instance = new Synchronized<std::unordered_set<std::string>>();
+  static auto* instance = new Synchronized<std::unordered_set<std::string>>();
   return *instance;
 }
 } // namespace

--- a/c10/util/Gauge.cpp
+++ b/c10/util/Gauge.cpp
@@ -16,7 +16,7 @@ using GaugeBackendFactories =
     std::vector<std::shared_ptr<GaugeBackendFactoryIf>>;
 
 Synchronized<GaugeBackendFactories>& gaugeBackendFactories() {
-  static auto instance = new Synchronized<GaugeBackendFactories>();
+  static auto* instance = new Synchronized<GaugeBackendFactories>();
   return *instance;
 }
 } // namespace

--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -214,7 +214,7 @@ void SetGlobalRank(int64_t rank) {
 }
 
 void LogAPIUsage(const std::string& event) try {
-  if (auto logger = GetAPIUsageLogger())
+  if (auto* logger = GetAPIUsageLogger())
     (*logger)(event);
   // NOLINTNEXTLINE(bugprone-empty-catch)
 } catch (std::bad_function_call&) {
@@ -224,7 +224,7 @@ void LogAPIUsage(const std::string& event) try {
 void LogAPIUsageMetadata(
     const std::string& context,
     const std::map<std::string, std::string>& metadata_map) try {
-  if (auto logger = GetAPIUsageMetadataLogger())
+  if (auto* logger = GetAPIUsageMetadataLogger())
     (*logger)(context, metadata_map);
   // NOLINTNEXTLINE(bugprone-empty-catch)
 } catch (std::bad_function_call&) {
@@ -232,7 +232,7 @@ void LogAPIUsageMetadata(
 }
 
 void LogPyTorchDDPUsage(const DDPLoggingData& ddpData) try {
-  if (auto logger = GetDDPUsageLogger())
+  if (auto* logger = GetDDPUsageLogger())
     (*logger)(ddpData);
   // NOLINTNEXTLINE(bugprone-empty-catch)
 } catch (std::bad_function_call&) {
@@ -241,7 +241,7 @@ void LogPyTorchDDPUsage(const DDPLoggingData& ddpData) try {
 
 namespace detail {
 bool LogAPIUsageFakeReturn(const std::string& event) try {
-  if (auto logger = GetAPIUsageLogger())
+  if (auto* logger = GetAPIUsageLogger())
     (*logger)(event);
   return true;
   // NOLINTNEXTLINE(bugprone-empty-catch)

--- a/c10/util/NetworkFlow.cpp
+++ b/c10/util/NetworkFlow.cpp
@@ -200,7 +200,7 @@ struct DinicFlowGraph {
     while (!q.empty()) {
       auto x = q.front();
       q.pop();
-      for (auto& edge_idx : adj[x]) {
+      for (const auto& edge_idx : adj[x]) {
         // the edge that goes u -> v where v == x
         const auto& e = reverse_edge(edges[edge_idx]);
         if (!e.residual_capacity()) {

--- a/c10/util/SmallVector.cpp
+++ b/c10/util/SmallVector.cpp
@@ -113,7 +113,7 @@ void* SmallVectorBase<Size_T>::mallocForGrow(
     size_t& NewCapacity) {
   NewCapacity = getNewCapacity<Size_T>(MinSize, TSize, this->capacity());
   // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
-  auto Result = std::malloc(NewCapacity * TSize);
+  auto* Result = std::malloc(NewCapacity * TSize);
   if (Result == nullptr) {
     throw std::bad_alloc();
   }

--- a/c10/util/WaitCounter.cpp
+++ b/c10/util/WaitCounter.cpp
@@ -22,7 +22,7 @@ using WaitCounterBackendFactories =
     std::vector<std::shared_ptr<WaitCounterBackendFactoryIf>>;
 
 Synchronized<WaitCounterBackendFactories>& waitCounterBackendFactories() {
-  static auto instance = new Synchronized<WaitCounterBackendFactories>();
+  static auto* instance = new Synchronized<WaitCounterBackendFactories>();
   return *instance;
 }
 

--- a/c10/util/WaitCounter.h
+++ b/c10/util/WaitCounter.h
@@ -59,7 +59,7 @@ class C10_API WaitCounterHandle {
     }
 
     void stop() {
-      if (auto handle = std::exchange(handle_, nullptr)) {
+      if (auto* handle = std::exchange(handle_, nullptr)) {
         handle->stop(ctxs_);
       }
     }

--- a/c10/util/env.cpp
+++ b/c10/util/env.cpp
@@ -52,7 +52,7 @@ std::optional<std::string> get_env(const char* name) noexcept {
 #pragma warning(disable : 4996)
 #endif
   // NOLINTNEXTLINE(concurrency-mt-unsafe)
-  auto envar = std::getenv(name);
+  auto* envar = std::getenv(name);
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif

--- a/c10/util/error.cpp
+++ b/c10/util/error.cpp
@@ -15,7 +15,7 @@ std::string str_error(int errnum) {
   auto res [[maybe_unused]] = strerror_s(buf.data(), buf.size(), errnum);
   buf.resize(strlen(buf.c_str()));
 #else
-  auto res [[maybe_unused]] = strerror_r(errnum, buf.data(), buf.size());
+  auto* res [[maybe_unused]] = strerror_r(errnum, buf.data(), buf.size());
   if constexpr (std::is_same_v<decltype(res), int>) {
     buf.resize(strlen(buf.c_str()));
   } else {

--- a/c10/util/numa.cpp
+++ b/c10/util/numa.cpp
@@ -34,7 +34,7 @@ void NUMABind(int numa_node_id) {
       numa_node_id,
       " is unavailable");
 
-  auto bm = numa_allocate_nodemask();
+  auto* bm = numa_allocate_nodemask();
   numa_bitmask_setbit(bm, numa_node_id);
   numa_bind(bm);
   numa_bitmask_free(bm);

--- a/c10/util/signal_handler.cpp
+++ b/c10/util/signal_handler.cpp
@@ -127,7 +127,7 @@ FatalSignalHandler::signal_handler FatalSignalHandler::kSignalHandlers[] = {
     {nullptr, 0, {}}};
 
 struct sigaction* FatalSignalHandler::getPreviousSigaction(int signum) {
-  for (auto handler = kSignalHandlers; handler->name != nullptr; handler++) {
+  for (auto* handler = kSignalHandlers; handler->name != nullptr; handler++) {
     if (handler->signum == signum) {
       return &handler->previous;
     }
@@ -136,7 +136,7 @@ struct sigaction* FatalSignalHandler::getPreviousSigaction(int signum) {
 }
 
 const char* FatalSignalHandler::getSignalName(int signum) {
-  for (auto handler = kSignalHandlers; handler->name != nullptr; handler++) {
+  for (auto* handler = kSignalHandlers; handler->name != nullptr; handler++) {
     if (handler->signum == signum) {
       return handler->name;
     }

--- a/c10/util/typeid.cpp
+++ b/c10/util/typeid.cpp
@@ -54,9 +54,9 @@ detail::TypeMetaData* TypeMeta::typeMetaDatas() {
 
 uint16_t TypeMeta::existingMetaDataIndexForType(TypeIdentifier identifier) {
   auto* metaDatas = typeMetaDatas();
-  const auto end = metaDatas + nextTypeIndex;
+  auto* const end = metaDatas + nextTypeIndex;
   // MaxTypeIndex is not very large; linear search should be fine.
-  auto it = std::find_if(metaDatas, end, [identifier](const auto& metaData) {
+  auto* it = std::find_if(metaDatas, end, [identifier](const auto& metaData) {
     return metaData.id_ == identifier;
   });
   if (it == end) {

--- a/torch/csrc/CudaIPCTypes.cpp
+++ b/torch/csrc/CudaIPCTypes.cpp
@@ -237,7 +237,7 @@ at::DataPtr GetNewRefCountedSentData(void* data, at::Device device) {
     }
   }
   cuda_ipc_global_entities.next_available_ref_counters_file_->set_counter(1);
-  auto sent_data = new CudaIPCSentData(
+  auto* sent_data = new CudaIPCSentData(
       cuda_ipc_global_entities.next_available_ref_counters_file_->handle(),
       cuda_ipc_global_entities.next_available_ref_counters_file_->get_offset(),
       cuda_ipc_global_entities.next_available_ref_counters_file_->counter_ptr(),

--- a/torch/csrc/Device.cpp
+++ b/torch/csrc/Device.cpp
@@ -18,11 +18,11 @@
 static PyObject* THPUpperModuleOfDevice = nullptr;
 
 PyObject* THPDevice_New(const at::Device& device) {
-  auto type = (PyTypeObject*)&THPDeviceType;
+  auto* type = (PyTypeObject*)&THPDeviceType;
   auto self = THPObjectPtr{type->tp_alloc(type, 0)};
   if (!self)
     throw python_error();
-  auto self_ = reinterpret_cast<THPDevice*>(self.get());
+  auto* self_ = reinterpret_cast<THPDevice*>(self.get());
   self_->device = device;
   return self.release();
 }
@@ -150,7 +150,7 @@ static PyObject* THPDevice_rc(PyObject* a, PyObject* b, int op) {
 
 static PyObject* THPDevice_reduce(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  auto self = (THPDevice*)_self;
+  auto* self = (THPDevice*)_self;
   auto ret = THPObjectPtr{PyTuple_New(2)};
   if (!ret)
     throw python_error();

--- a/torch/csrc/Dtype.cpp
+++ b/torch/csrc/Dtype.cpp
@@ -15,11 +15,11 @@
 PyObject* THPDtype_New(at::ScalarType scalar_type, const std::string& name) {
   HANDLE_TH_ERRORS
   AT_ASSERT(name.length() < DTYPE_NAME_LEN);
-  auto type = (PyTypeObject*)&THPDtypeType;
+  auto* type = (PyTypeObject*)&THPDtypeType;
   auto self = THPObjectPtr{type->tp_alloc(type, 0)};
   if (!self)
     throw python_error();
-  auto self_ = reinterpret_cast<THPDtype*>(self.get());
+  auto* self_ = reinterpret_cast<THPDtype*>(self.get());
   self_->scalar_type = scalar_type;
   std::strncpy(self_->name, name.c_str(), DTYPE_NAME_LEN);
   return self.release();
@@ -69,7 +69,7 @@ static PyObject* THPDtype_reduce(PyObject* _self, PyObject* noargs) {
    * For singletons, a string is returned. The string should be interpreted
    * as the name of a global variable.
    */
-  auto self = (THPDtype*)_self;
+  auto* self = (THPDtype*)_self;
   return THPUtils_packString(self->name);
   END_HANDLE_TH_ERRORS
 }
@@ -178,7 +178,7 @@ void THPDtype_init(PyObject* module) {
   auto dict = THPObjectPtr(PyDict_New());
   if (!dict)
     throw python_error();
-  auto torch = THPUtils_packString("torch");
+  auto* torch = THPUtils_packString("torch");
   if (!torch)
     throw python_error();
   if (PyDict_SetItemString(dict, "__module__", torch) < 0) {

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -36,7 +36,7 @@ void registerLayoutObject(THPLayout* thp_layout, at::Layout layout) {
 }
 
 THPDtype* getTHPDtype(at::ScalarType scalarType) {
-  auto dtype = dtype_registry[static_cast<int>(scalarType)];
+  auto* dtype = dtype_registry[static_cast<int>(scalarType)];
   if (!dtype) {
     throw std::invalid_argument("unsupported scalarType");
   }
@@ -44,7 +44,7 @@ THPDtype* getTHPDtype(at::ScalarType scalarType) {
 }
 
 THPLayout* getTHPLayout(at::Layout layout) {
-  auto thp_layout = layout_registry[static_cast<int>(layout)];
+  auto* thp_layout = layout_registry[static_cast<int>(layout)];
   if (!thp_layout) {
     throw std::invalid_argument("unsupported at::Layout");
   }

--- a/torch/csrc/Event.cpp
+++ b/torch/csrc/Event.cpp
@@ -69,10 +69,10 @@ static PyObject* THPEvent_pynew(
 }
 
 PyObject* THPEvent_new(c10::DeviceType device_type, c10::EventFlag flag) {
-  auto type = (PyTypeObject*)&THPEventType;
+  auto* type = (PyTypeObject*)&THPEventType;
   auto self = THPObjectPtr{type->tp_alloc(type, 0)};
   TORCH_CHECK(self, "Failed to allocate memory for Event");
-  auto self_ = reinterpret_cast<THPEvent*>(self.get());
+  auto* self_ = reinterpret_cast<THPEvent*>(self.get());
   new (&self_->event) c10::Event(device_type, flag);
   return self.release();
 }
@@ -96,7 +96,7 @@ static PyObject* THPEvent_record(
     PyObject* args,
     PyObject* kwargs) {
   HANDLE_TH_ERRORS
-  auto self = (THPEvent*)_self;
+  auto* self = (THPEvent*)_self;
   PyObject* _stream = Py_None;
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   constexpr const char* accepted_args[] = {"stream", nullptr};
@@ -111,7 +111,7 @@ static PyObject* THPEvent_record(
     return nullptr;
   }
   if (_stream != Py_None) {
-    auto stream = (THPStream*)_stream;
+    auto* stream = (THPStream*)_stream;
     self->event.record(c10::Stream::unpack3(
         stream->stream_id,
         static_cast<c10::DeviceIndex>(stream->device_index),
@@ -130,7 +130,7 @@ static PyObject* THPEvent_from_ipc_handle(
     PyObject* args,
     PyObject* kwargs) {
   HANDLE_TH_ERRORS
-  auto type = (PyTypeObject*)_type;
+  auto* type = (PyTypeObject*)_type;
 
   static torch::PythonArgParser parser({
       "from_ipc_handle(Device device, std::string ipc_handle)",
@@ -174,7 +174,7 @@ static PyObject* THPEvent_wait(
     PyObject* args,
     PyObject* kwargs) {
   HANDLE_TH_ERRORS {
-    auto self = (THPEvent*)_self;
+    auto* self = (THPEvent*)_self;
     PyObject* _stream = Py_None;
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
     constexpr const char* accepted_args[] = {"stream", nullptr};
@@ -189,7 +189,7 @@ static PyObject* THPEvent_wait(
       return nullptr;
     }
     if (_stream != Py_None) {
-      auto stream = (THPStream*)_stream;
+      auto* stream = (THPStream*)_stream;
       self->event.block(c10::Stream::unpack3(
           stream->stream_id,
           static_cast<c10::DeviceIndex>(stream->device_index),
@@ -206,15 +206,15 @@ static PyObject* THPEvent_wait(
 
 static PyObject* THPEvent_query(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  auto self = (THPEvent*)_self;
+  auto* self = (THPEvent*)_self;
   return PyBool_FromLong(self->event.query());
   END_HANDLE_TH_ERRORS
 }
 
 static PyObject* THPEvent_elapsed_time(PyObject* _self, PyObject* _other) {
   HANDLE_TH_ERRORS
-  auto self = (THPEvent*)_self;
-  auto other = (THPEvent*)_other;
+  auto* self = (THPEvent*)_self;
+  auto* other = (THPEvent*)_other;
   return PyFloat_FromDouble(self->event.elapsedTime(other->event));
   END_HANDLE_TH_ERRORS
 }
@@ -222,7 +222,7 @@ static PyObject* THPEvent_elapsed_time(PyObject* _self, PyObject* _other) {
 static PyObject* THPEvent_synchronize(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS {
     pybind11::gil_scoped_release no_gil{};
-    auto self = (THPEvent*)_self;
+    auto* self = (THPEvent*)_self;
     self->event.synchronize();
   }
   Py_RETURN_NONE;
@@ -231,7 +231,7 @@ static PyObject* THPEvent_synchronize(PyObject* _self, PyObject* noargs) {
 
 static PyObject* THPEvent_evend_id(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  auto self = (THPEvent*)_self;
+  auto* self = (THPEvent*)_self;
   return PyLong_FromVoidPtr(self->event.eventId());
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -21,17 +21,17 @@ using namespace torch;
 PyObject* THPGeneratorClass = nullptr;
 
 PyObject* THPGenerator_initDefaultGenerator(const at::Generator& cdata) {
-  auto type = (PyTypeObject*)THPGeneratorClass;
+  auto* type = (PyTypeObject*)THPGeneratorClass;
   auto self = THPObjectPtr{type->tp_alloc(type, 0)};
   if (!self)
     throw python_error();
-  auto self_ = reinterpret_cast<THPGenerator*>(self.get());
+  auto* self_ = reinterpret_cast<THPGenerator*>(self.get());
   self_->cdata = std::move(cdata);
   return self.release();
 }
 
 static void THPGenerator_dealloc(PyObject* _self) {
-  auto self = reinterpret_cast<THPGenerator*>(_self);
+  auto* self = reinterpret_cast<THPGenerator*>(_self);
   if (self->cdata.defined()) {
     self->cdata.set_pyobj(nullptr);
     self->cdata.~Generator();
@@ -86,7 +86,7 @@ static PyObject* THPGenerator_setState(PyObject* _self, PyObject* _new_state) {
         "expected a torch.ByteTensor, but got %s",
         Py_TYPE(_new_state)->tp_name);
   }
-  auto self = (THPGenerator*)_self;
+  auto* self = (THPGenerator*)_self;
   auto& gen = self->cdata;
   const auto& new_state_tensor = THPVariable_Unpack(_new_state);
 
@@ -136,7 +136,7 @@ static PyObject* THPGenerator_graphSafeSetState(
     PyObject* _self,
     PyObject* _state) {
   HANDLE_TH_ERRORS
-  auto self = (THPGenerator*)_self;
+  auto* self = (THPGenerator*)_self;
   auto& gen = self->cdata;
 
   // See Note [Acquire lock when using random generators]
@@ -161,7 +161,7 @@ static PyObject* THPGenerator_cloneState(PyObject* _self, PyObject* noargs) {
 
 static PyObject* THPGenerator_manualSeed(PyObject* _self, PyObject* seed) {
   HANDLE_TH_ERRORS
-  auto self = (THPGenerator*)_self;
+  auto* self = (THPGenerator*)_self;
   auto generator = self->cdata;
   TORCH_CHECK(
       THPUtils_checkLong(seed),
@@ -179,7 +179,7 @@ static PyObject* THPGenerator_manualSeed(PyObject* _self, PyObject* seed) {
 
 static PyObject* THPGenerator_setOffset(PyObject* _self, PyObject* offset) {
   HANDLE_TH_ERRORS
-  auto self = (THPGenerator*)_self;
+  auto* self = (THPGenerator*)_self;
   auto generator = self->cdata;
   TORCH_CHECK(
       THPUtils_checkLong(offset),
@@ -198,7 +198,7 @@ static PyObject* THPGenerator_setOffset(PyObject* _self, PyObject* offset) {
 static PyObject* THPGenerator_seed(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   // See Note [Acquire lock when using random generators]
-  auto self = (THPGenerator*)_self;
+  auto* self = (THPGenerator*)_self;
   std::scoped_lock<std::mutex> lock(self->cdata.mutex());
   uint64_t seed_val = self->cdata.seed();
   return THPUtils_packUInt64(seed_val);
@@ -207,14 +207,14 @@ static PyObject* THPGenerator_seed(PyObject* _self, PyObject* noargs) {
 
 static PyObject* THPGenerator_initialSeed(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  auto self = (THPGenerator*)_self;
+  auto* self = (THPGenerator*)_self;
   return THPUtils_packUInt64(self->cdata.current_seed());
   END_HANDLE_TH_ERRORS
 }
 
 static PyObject* THPGenerator_getOffset(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  auto self = (THPGenerator*)_self;
+  auto* self = (THPGenerator*)_self;
   return THPUtils_packUInt64(self->cdata.get_offset());
   END_HANDLE_TH_ERRORS
 }
@@ -227,7 +227,7 @@ static PyObject* THPGenerator_get_device(THPGenerator* self, void* unused) {
 
 PyObject* THPGenerator_reduce(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  auto self = (THPGenerator*)_self;
+  auto* self = (THPGenerator*)_self;
   auto& gen = self->cdata;
 
   auto ret = THPObjectPtr{PyTuple_New(3)};
@@ -370,7 +370,7 @@ PyObject* THPGenerator_Wrap(const Generator& gen) {
     Py_RETURN_NONE;
   }
 
-  if (auto obj = pyobj(gen)) {
+  if (auto* obj = pyobj(gen)) {
     Py_INCREF(obj);
     return obj;
   }
@@ -391,7 +391,7 @@ at::Generator THPGenerator_Unwrap(PyObject* state) {
 PyObject* THPGenerator_NewWithVar(PyTypeObject* type, Generator gen) {
   PyObject* obj = type->tp_alloc(type, 0);
   if (obj) {
-    auto g = (THPGenerator*)obj;
+    auto* g = (THPGenerator*)obj;
     new (&g->cdata) Generator(std::move(gen));
     set_pyobj(g->cdata, obj);
   }

--- a/torch/csrc/Layout.cpp
+++ b/torch/csrc/Layout.cpp
@@ -11,11 +11,11 @@
 #include <string>
 
 PyObject* THPLayout_New(at::Layout layout, const std::string& name) {
-  auto type = (PyTypeObject*)&THPLayoutType;
+  auto* type = (PyTypeObject*)&THPLayoutType;
   auto self = THPObjectPtr{type->tp_alloc(type, 0)};
   if (!self)
     throw python_error();
-  auto self_ = reinterpret_cast<THPLayout*>(self.get());
+  auto* self_ = reinterpret_cast<THPLayout*>(self.get());
   self_->layout = layout;
   std::strncpy(self_->name, name.c_str(), LAYOUT_NAME_LEN);
   self_->name[LAYOUT_NAME_LEN] = '\0';

--- a/torch/csrc/MemoryFormat.cpp
+++ b/torch/csrc/MemoryFormat.cpp
@@ -13,11 +13,11 @@
 PyObject* THPMemoryFormat_New(
     at::MemoryFormat memory_format,
     const std::string& name) {
-  auto type = (PyTypeObject*)&THPMemoryFormatType;
+  auto* type = (PyTypeObject*)&THPMemoryFormatType;
   auto self = THPObjectPtr{type->tp_alloc(type, 0)};
   if (!self)
     throw python_error();
-  auto self_ = reinterpret_cast<THPMemoryFormat*>(self.get());
+  auto* self_ = reinterpret_cast<THPMemoryFormat*>(self.get());
   self_->memory_format = memory_format;
   std::strncpy(self_->name, name.c_str(), MEMORY_FORMAT_NAME_LEN);
   self_->name[MEMORY_FORMAT_NAME_LEN] = '\0';

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -273,7 +273,7 @@ static PyObject* THPModule_crashIfvptrUBSAN(PyObject* module, PyObject* noarg) {
     virtual ~Baz() = default;
   };
   Baz x{};
-  auto y = static_cast<Foo*>(static_cast<void*>(&x));
+  auto* y = static_cast<Foo*>(static_cast<void*>(&x));
   auto rc = y->bar();
   return THPUtils_packInt32(rc);
 }
@@ -1261,7 +1261,8 @@ static PyObject* THPModule_willEngineExecuteNode(
       "_will_engine_execute_node expects an grad_fn, "
       "but got ",
       THPUtils_typename(arg));
-  const auto exec_info = torch::autograd::get_current_graph_task_exec_info();
+  const auto* const exec_info =
+      torch::autograd::get_current_graph_task_exec_info();
   TORCH_CHECK(
       exec_info,
       "_get_should_execute_nodes should only be called during the backward pass");
@@ -1273,7 +1274,7 @@ static PyObject* THPModule_willEngineExecuteNode(
   } else {
     node = ((torch::autograd::THPCppFunction*)arg)->cdata.get();
   }
-  const auto nodes_in_graph =
+  const auto* const nodes_in_graph =
       torch::autograd::get_current_graph_task_nodes_in_graph();
   bool ret = nodes_in_graph->find(node) != nodes_in_graph->end();
   if (ret && !exec_info->empty()) {
@@ -2212,7 +2213,7 @@ Call this whenever a new thread is created in order to propagate values from
   py_module.def("_get_obj_in_tls", [](const std::string& key) -> py::handle {
     auto safe_pyobject =
         at::impl::ThreadLocalPythonObjects::get_state().get(key);
-    auto obj = safe_pyobject->ptr(getPyInterpreter());
+    auto* obj = safe_pyobject->ptr(getPyInterpreter());
     return py::handle(obj);
   });
 

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -589,7 +589,7 @@ static void set_tensor_attr_with_capsule(
       getPyInterpreter(), /*ignore_hermetic_tls=*/false);
   TORCH_CHECK(
       mb_obj.has_value(), "Tensor subclass's PyInterpreter has no value");
-  auto obj = mb_obj.value();
+  auto* obj = mb_obj.value();
   py::handle(obj).attr(attr_name) = capsule;
 }
 
@@ -617,7 +617,7 @@ static c10::ArrayRef<T> get_set_cached_attr(
       tensor->pyobj_slot()->check_pyobj(getPyInterpreter());
   TORCH_CHECK(
       mb_obj.has_value(), "Tensor subclass's PyInterpreter has no value");
-  auto tensor_obj = mb_obj.value();
+  auto* tensor_obj = mb_obj.value();
   auto buffer_len_attr_name = std::string(base_attr_name) + std::string("_len");
 
   bool is_buffer_allocated = false;

--- a/torch/csrc/QScheme.cpp
+++ b/torch/csrc/QScheme.cpp
@@ -11,11 +11,11 @@
 #include <string>
 
 PyObject* THPQScheme_New(at::QScheme qscheme, const std::string& name) {
-  auto type = (PyTypeObject*)&THPQSchemeType;
+  auto* type = (PyTypeObject*)&THPQSchemeType;
   auto self = THPObjectPtr{type->tp_alloc(type, 0)};
   if (!self)
     throw python_error();
-  auto self_ = reinterpret_cast<THPQScheme*>(self.get());
+  auto* self_ = reinterpret_cast<THPQScheme*>(self.get());
   self_->qscheme = qscheme;
   std::strncpy(self_->name, name.c_str(), QSCHEME_NAME_LEN);
   self_->name[QSCHEME_NAME_LEN] = '\0';
@@ -23,7 +23,7 @@ PyObject* THPQScheme_New(at::QScheme qscheme, const std::string& name) {
 }
 
 PyObject* THPQScheme_reduce(PyObject* _self, PyObject* noargs) {
-  auto self = (THPQScheme*)_self;
+  auto* self = (THPQScheme*)_self;
   return THPUtils_packString(self->name);
 }
 

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -62,7 +62,7 @@ PyObject* THPSize_NewFromSymSizes(const at::Tensor& self_) {
       TORCH_CHECK(
           !torch::jit::tracer::isTracing(),
           "JIT Tracing of SymInts isn't supported");
-      auto py_symint = py::cast(si).release().ptr();
+      auto* py_symint = py::cast(si).release().ptr();
       if (!py_symint)
         throw python_error();
       PyTuple_SET_ITEM(ret.get(), i, py_symint);
@@ -87,7 +87,7 @@ PyObject* THPSize_NewFromSymSizes(const at::Tensor& self_) {
 static bool isTracedZeroDimVar(PyObject* item) {
   if (!THPVariable_Check(item))
     return false;
-  auto& var = THPVariable_Unpack(item);
+  const auto& var = THPVariable_Unpack(item);
   return var.dim() == 0 && torch::jit::tracer::getValueTrace(var);
 }
 
@@ -137,7 +137,7 @@ static PyObject* THPSize_repr(THPSize* self) {
     if (i != 0) {
       repr += ", ";
     }
-    auto item = PyTuple_GET_ITEM(self, i);
+    auto* item = PyTuple_GET_ITEM(self, i);
     auto ih = py::handle(item);
 
     repr += torch::is_symint(ih)
@@ -189,7 +189,7 @@ static PyMappingMethods THPSize_as_mapping = {
 
 static PyObject* THPSize_numel(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  auto self = (THPSize*)_self;
+  auto* self = (THPSize*)_self;
   int64_t numel = 1;
   for (Py_ssize_t i = 0; i < PyTuple_Size((PyObject*)self); ++i) {
     numel *= THPUtils_unpackLong(PyTuple_GET_ITEM(self, i));
@@ -200,12 +200,12 @@ static PyObject* THPSize_numel(PyObject* _self, PyObject* noargs) {
 
 static PyObject* THPSize_reduce(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  auto self = (THPSize*)_self;
+  auto* self = (THPSize*)_self;
   auto ret = THPObjectPtr{PyTuple_New(2)};
   if (!ret)
     throw python_error();
 
-  auto obj = (PyObject*)(&THPSizeType);
+  auto* obj = (PyObject*)(&THPSizeType);
   Py_INCREF(&THPSizeType);
   PyTuple_SET_ITEM(ret.get(), 0, obj);
 
@@ -213,7 +213,7 @@ static PyObject* THPSize_reduce(PyObject* _self, PyObject* noargs) {
   if (!t)
     throw python_error();
   for (Py_ssize_t i = 0; i < PyTuple_Size((PyObject*)self); ++i) {
-    auto d = PyTuple_GET_ITEM(self, i);
+    auto* d = PyTuple_GET_ITEM(self, i);
     Py_INCREF(d);
     PyTuple_SET_ITEM(t.get(), i, d);
   }

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -231,7 +231,7 @@ static PyObject* THPStorage_fromBuffer(
   TORCH_CHECK(
       THPDtype_Check(dtype_obj),
       "argument 'dtype' must be of type torch.dtype");
-  auto dtype = reinterpret_cast<THPDtype*>(dtype_obj);
+  auto* dtype = reinterpret_cast<THPDtype*>(dtype_obj);
   scalar_type = dtype->scalar_type;
 
   const bool is_endian_independent = (scalar_type == at::kByte) ||
@@ -504,7 +504,7 @@ static PyObject* THPStorage_setFromFile(PyObject* self, PyObject* args) {
   // advanced position
   const auto fd_current_pos = LSEEK(fd, 0, SEEK_CUR);
   LSEEK(fd, fd_original_pos, SEEK_SET);
-  const auto seek_return =
+  auto* const seek_return =
       PyObject_CallMethod(file, "seek", "Li", (long long)fd_current_pos, 0);
   if (seek_return == nullptr) {
     return nullptr;
@@ -517,7 +517,7 @@ static PyObject* THPStorage_setFromFile(PyObject* self, PyObject* args) {
 
 static PyObject* THPStorage__setCdata(PyObject* _self, PyObject* new_cdata) {
   HANDLE_TH_ERRORS
-  auto self = (THPStorage*)_self;
+  auto* self = (THPStorage*)_self;
   TORCH_CHECK(
       THPUtils_checkLong(new_cdata),
       "given an invalid argument to "
@@ -556,17 +556,17 @@ static PyObject* THPStorage_byteswap(PyObject* self, PyObject* args) {
       elem_size);
 
   if (elem_size == 2) {
-    auto buffer = static_cast<uint16_t*>(storage.mutable_data());
+    auto* buffer = static_cast<uint16_t*>(storage.mutable_data());
     for (uint64_t i = 0; i < count; i++, buffer++) {
       *buffer = thp_bswap16(*buffer);
     }
   } else if (elem_size == 4) {
-    auto buffer = static_cast<uint32_t*>(storage.mutable_data());
+    auto* buffer = static_cast<uint32_t*>(storage.mutable_data());
     for (uint64_t i = 0; i < count; i++, buffer++) {
       *buffer = thp_bswap32(*buffer);
     }
   } else if (elem_size == 8) {
-    auto buffer = static_cast<uint64_t*>(storage.mutable_data());
+    auto* buffer = static_cast<uint64_t*>(storage.mutable_data());
     for (uint64_t i = 0; i < count; i++, buffer++) {
       *buffer = thp_bswap64(*buffer);
     }

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -325,7 +325,7 @@ static PyObject* THPStorage_shareCuda(PyObject* self, PyObject* noargs) {
     at::DataPtr sent_data_ptr = torch::GetNewRefCountedSentData(
         storage.mutable_data(), storage.device());
     auto old_data_ptr = storage.set_data_ptr(std::move(sent_data_ptr));
-    auto sent_data =
+    auto* sent_data =
         static_cast<torch::CudaIPCSentData*>(storage.data_ptr().get_context());
     sent_data->set_original_ptr(std::move(old_data_ptr));
     _ref_counter = PyBytes_FromString((sent_data->handle()).c_str());
@@ -468,8 +468,9 @@ static PyObject* THPStorage_newSharedCuda(PyObject* _unused, PyObject* args) {
     if (s_ipc_event_handle.empty()) {
       return nullptr;
     }
-    auto ipc_event_handle = reinterpret_cast<const cudaIpcEventHandle_t*>(
-        s_ipc_event_handle.c_str());
+    const auto* ipc_event_handle =
+        reinterpret_cast<const cudaIpcEventHandle_t*>(
+            s_ipc_event_handle.c_str());
     cudaEvent_t event = nullptr;
     cudaIpcOpenEventHandle(&event, *ipc_event_handle);
     C10_CUDA_CHECK(

--- a/torch/csrc/Stream.cpp
+++ b/torch/csrc/Stream.cpp
@@ -101,7 +101,7 @@ static PyObject* THPStream_pynew(
 
 PyObject* THPStream_Wrap(const c10::Stream& stream) {
   HANDLE_TH_ERRORS
-  auto type = (PyTypeObject*)THPStreamClass;
+  auto* type = (PyTypeObject*)THPStreamClass;
   THPObjectPtr ptr(type->tp_alloc(type, 0));
   if (!ptr) {
     throw python_error();
@@ -130,7 +130,7 @@ static PyObject* THPStream_get_device(THPStream* self, void* unused) {
 
 static PyObject* THPStream_query(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  auto self = (THPStream*)_self;
+  auto* self = (THPStream*)_self;
 
   return PyBool_FromLong(c10::Stream::unpack3(
                              self->stream_id,
@@ -144,7 +144,7 @@ static PyObject* THPStream_query(PyObject* _self, PyObject* noargs) {
 static PyObject* THPStream_synchronize(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS {
     pybind11::gil_scoped_release no_gil;
-    auto self = (THPStream*)_self;
+    auto* self = (THPStream*)_self;
 
     c10::Stream::unpack3(
         self->stream_id,
@@ -158,8 +158,8 @@ static PyObject* THPStream_synchronize(PyObject* _self, PyObject* noargs) {
 
 static PyObject* THPStream_wait_event(PyObject* _self, PyObject* _event) {
   HANDLE_TH_ERRORS {
-    auto self = (THPStream*)_self;
-    auto event = (THPEvent*)_event;
+    auto* self = (THPStream*)_self;
+    auto* event = (THPEvent*)_event;
     c10::Stream::unpack3(
         self->stream_id,
         static_cast<c10::DeviceIndex>(self->device_index),
@@ -172,8 +172,8 @@ static PyObject* THPStream_wait_event(PyObject* _self, PyObject* _event) {
 
 static PyObject* THPStream_wait_stream(PyObject* _self, PyObject* _other) {
   HANDLE_TH_ERRORS {
-    auto self = (THPStream*)_self;
-    auto other_stream = (THPStream*)_other;
+    auto* self = (THPStream*)_self;
+    auto* other_stream = (THPStream*)_other;
     c10::Event new_event(
         static_cast<c10::DeviceType>(other_stream->device_type),
         c10::EventFlag::PYTORCH_DEFAULT);
@@ -196,7 +196,7 @@ static PyObject* THPStream_record_event(
     PyObject* args,
     PyObject* kwargs) {
   HANDLE_TH_ERRORS
-  auto self = (THPStream*)_self;
+  auto* self = (THPStream*)_self;
   PyObject* _new_event = nullptr;
   PyObject* _event = Py_None;
 
@@ -220,7 +220,7 @@ static PyObject* THPStream_record_event(
         static_cast<c10::DeviceType>(self->device_type),
         c10::EventFlag::PYTORCH_DEFAULT);
   }
-  auto new_event = (THPEvent*)_new_event;
+  auto* new_event = (THPEvent*)_new_event;
   TORCH_CHECK(new_event, "event must not be null");
   new_event->event.record(c10::Stream::unpack3(
       self->stream_id,

--- a/torch/csrc/TypeInfo.cpp
+++ b/torch/csrc/TypeInfo.cpp
@@ -18,21 +18,21 @@
 #include <sstream>
 
 static PyObject* THPFInfo_New(const at::ScalarType& type) {
-  auto finfo = (PyTypeObject*)&THPFInfoType;
+  auto* finfo = (PyTypeObject*)&THPFInfoType;
   auto self = THPObjectPtr{finfo->tp_alloc(finfo, 0)};
   if (!self)
     throw python_error();
-  auto self_ = reinterpret_cast<THPDTypeInfo*>(self.get());
+  auto* self_ = reinterpret_cast<THPDTypeInfo*>(self.get());
   self_->type = c10::toRealValueType(type);
   return self.release();
 }
 
 static PyObject* THPIInfo_New(const at::ScalarType& type) {
-  auto iinfo = (PyTypeObject*)&THPIInfoType;
+  auto* iinfo = (PyTypeObject*)&THPIInfoType;
   auto self = THPObjectPtr{iinfo->tp_alloc(iinfo, 0)};
   if (!self)
     throw python_error();
-  auto self_ = reinterpret_cast<THPDTypeInfo*>(self.get());
+  auto* self_ = reinterpret_cast<THPDTypeInfo*>(self.get());
   self_->type = type;
   return self.release();
 }
@@ -245,7 +245,7 @@ static PyObject* THPFInfo_dtype(THPFInfo* self, void*) {
 
 static PyObject* THPFInfo_str(THPFInfo* self) {
   std::ostringstream oss;
-  const auto dtypeStr = THPFInfo_dtype(self, nullptr);
+  auto* const dtypeStr = THPFInfo_dtype(self, nullptr);
   oss << "finfo(resolution="
       << PyFloat_AsDouble(THPFInfo_resolution(self, nullptr));
   oss << ", min=" << PyFloat_AsDouble(THPFInfo_min(self, nullptr));
@@ -263,7 +263,7 @@ static PyObject* THPFInfo_str(THPFInfo* self) {
 static PyObject* THPIInfo_str(THPIInfo* self) {
   std::ostringstream oss;
 
-  const auto dtypeStr = THPIInfo_dtype(self, nullptr);
+  auto* const dtypeStr = THPIInfo_dtype(self, nullptr);
   oss << "iinfo(min=" << PyLong_AsDouble(THPIInfo_min(self, nullptr));
   oss << ", max=" << PyLong_AsDouble(THPIInfo_max(self, nullptr));
   if (dtypeStr) {

--- a/torch/csrc/api/include/torch/nn/modules/container/moduledict.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/moduledict.h
@@ -220,7 +220,7 @@ class ModuleDictImpl : public Cloneable<ModuleDictImpl> {
   void update(
       const std::vector<std::pair<std::string, std::shared_ptr<Module>>>&
           modules) {
-    for (auto& item : modules) {
+    for (const auto& item : modules) {
       insert(item.first, item.second);
     }
   }

--- a/torch/csrc/api/include/torch/nn/utils/clip_grad.h
+++ b/torch/csrc/api/include/torch/nn/utils/clip_grad.h
@@ -26,7 +26,7 @@ inline double clip_grad_norm_(
   std::vector<Tensor> params_with_grad;
 
   for (const auto& param : parameters) {
-    auto& grad = param.grad();
+    const auto& grad = param.grad();
     if (grad.defined()) {
       params_with_grad.push_back(param);
     }

--- a/torch/csrc/api/include/torch/optim/serialize.h
+++ b/torch/csrc/api/include/torch/optim/serialize.h
@@ -192,7 +192,7 @@ void serialize(serialize::InputArchive& archive, Optimizer& optimizer) {
         "loaded state dict contains a parameter group that has a different size than the optimizer's parameter group");
 
     for (const auto idx : c10::irange(params.size())) {
-      auto param_group_old_key =
+      auto* param_group_old_key =
           // NOLINTNEXTLINE(performance-no-int-to-ptr)
           reinterpret_cast<void*>(std::stoull(param_group_old_keys[idx]));
       if (saved_state.find(param_group_old_key) != saved_state.end()) {

--- a/torch/csrc/api/include/torch/serialize.h
+++ b/torch/csrc/api/include/torch/serialize.h
@@ -66,7 +66,7 @@ template <typename... SaveToArgs>
 void save(const std::vector<torch::Tensor>& tensor_vec, SaveToArgs&&... args) {
   serialize::OutputArchive archive(std::make_shared<jit::CompilationUnit>());
   for (const auto i : c10::irange(tensor_vec.size())) {
-    auto& value = tensor_vec[i];
+    const auto& value = tensor_vec[i];
     archive.write(std::to_string(i), value);
   }
   archive.save_to(std::forward<SaveToArgs>(args)...);

--- a/torch/csrc/api/src/nn/modules/adaptive.cpp
+++ b/torch/csrc/api/src/nn/modules/adaptive.cpp
@@ -67,8 +67,8 @@ void AdaptiveLogSoftmaxWithLossImpl::reset() {
 void AdaptiveLogSoftmaxWithLossImpl::reset_parameters() {
   head->reset_parameters();
   for (const auto i : c10::irange(tail->size())) {
-    auto i2h = tail[i]->children()[0]->as<Linear>();
-    auto h2o = tail[i]->children()[1]->as<Linear>();
+    auto* i2h = tail[i]->children()[0]->as<Linear>();
+    auto* h2o = tail[i]->children()[1]->as<Linear>();
     i2h->reset_parameters();
     h2o->reset_parameters();
   }

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1074,7 +1074,7 @@ std::vector<Tensor> cat_tensors_backward(
     } else {
       grad_val = grad;
     }
-    auto& shape = sizes[i];
+    const auto& shape = sizes[i];
     // If input was empty tensor, gradInput should be empty tensor.
     if (shape.size() == 1) {
       if (TORCH_GUARD_SIZE_OBLIVIOUS(shape[0].sym_eq(0))) {
@@ -1131,7 +1131,7 @@ std::vector<Tensor> block_diag_backward(
         ? real_view_of_grad
         : grad;
 
-    auto& shape = sizes[i];
+    const auto& shape = sizes[i];
     // If input was empty tensor, gradInput should be empty tensor.
     if (shape.size() == 1 && shape[0] == 0) {
       grad_inputs[i] = at::zeros({0}, grad_val.options());
@@ -1669,7 +1669,7 @@ Tensor repeat_backward(
     Tensor grad,
     c10::SymIntArrayRef repeats,
     c10::SymIntArrayRef input_shape) {
-  auto find_iter = std::find(repeats.cbegin(), repeats.cend(), 0);
+  const auto* find_iter = std::find(repeats.cbegin(), repeats.cend(), 0);
   if (find_iter != repeats.cend()) {
     return at::zeros_symint(input_shape, grad.options());
   }
@@ -2131,7 +2131,7 @@ Tensor _nested_split_with_sizes_backward(
     } else {
       const auto& length = split_sizes[i].guard_int(__FILE__, __LINE__);
       auto nt_split_size = nt_sizes.clone();
-      auto nt_split_size_ptr = nt_split_size.data_ptr<int64_t>();
+      auto* nt_split_size_ptr = nt_split_size.data_ptr<int64_t>();
       for (int64_t j : c10::irange(static_cast<int64_t>(nt_sizes.size(0)))) {
         // subtract 1 to account for batch dim
         nt_split_size_ptr
@@ -2200,7 +2200,7 @@ Tensor glu_double_backward(
     const Tensor& grad_output,
     const Tensor& input,
     int64_t dim) {
-  auto& gO = grad_output;
+  const auto& gO = grad_output;
   auto input_size = input.size(dim) / 2;
   auto first_half = input.narrow(dim, 0, input_size);
   auto second_half = input.narrow(dim, input_size, input_size);
@@ -6036,7 +6036,7 @@ Tensor stack_jvp(at::TensorList tensors, int64_t dim) {
   if (any_defined) {
     std::vector<Tensor> fw_grads;
 
-    for (auto& t : tensors) {
+    for (const auto& t : tensors) {
       fw_grads.push_back(
           isFwGradDefined(t)
               ? t._fw_grad(/*level*/ 0)

--- a/torch/csrc/autograd/TraceTypeManual.cpp
+++ b/torch/csrc/autograd/TraceTypeManual.cpp
@@ -17,7 +17,7 @@ Tensor& copy_(Tensor& self, const Tensor& src, bool non_blocking) {
   jit::Value* output = nullptr;
   if (torch::jit::tracer::isTracing()) {
     const jit::tracer::TracingState& state = *jit::tracer::getTracingState();
-    auto& graph = state.graph;
+    const auto& graph = state.graph;
     if (state.force_outplace && self.storage().use_count() <= 1) {
       // if you have no views of self, then an in place copy is equivalent to
       // making sure we expand src to the same size as self

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -121,7 +121,7 @@ namespace {
 
 // Taken from codegened version
 Tensor _fw_primal(c10::DispatchKeySet ks, const Tensor& self, int64_t level) {
-  auto& self_ = unpack(self, "self", 0);
+  const auto& self_ = unpack(self, "self", 0);
   std::shared_ptr<Identity> grad_fn;
   if (compute_requires_grad(self)) {
     grad_fn = std::make_shared<Identity>();
@@ -164,8 +164,8 @@ Tensor _make_dual(
       "already has a forward gradient at the same level ",
       level,
       " is not supported.");
-  auto& primal_ = unpack(primal, "primal", 0);
-  auto& tangent_ = unpack(tangent, "tangent", 0);
+  const auto& primal_ = unpack(primal, "primal", 0);
+  const auto& tangent_ = unpack(tangent, "tangent", 0);
   std::shared_ptr<ViewBackward0> grad_fn;
   if (compute_requires_grad(primal_)) {
     grad_fn = std::make_shared<ViewBackward0>();
@@ -197,7 +197,7 @@ Tensor& copy_(
   // TODO: once copy is exposed in Declarations.yaml we may be able to bind
   // it automatically
   auto& self_ = unpack(self, "self", 0);
-  auto& src_ = unpack(src, "src", 1);
+  const auto& src_ = unpack(src, "src", 1);
   std::shared_ptr<CopyBackwards> grad_fn;
   auto requires_grad = compute_requires_grad(self, src);
   requires_grad &= isDifferentiableType(self.scalar_type());
@@ -243,7 +243,7 @@ const Tensor& resize_(
     const Tensor& self,
     SymIntArrayRef size,
     std::optional<MemoryFormat> optional_memory_format) {
-  auto& self_ = unpack(self, "self", 0);
+  const auto& self_ = unpack(self, "self", 0);
   if (self.requires_grad()) {
     TORCH_CHECK(false, "cannot resize variables that require grad");
   }
@@ -265,8 +265,8 @@ const Tensor& resize_as_(
     const Tensor& self,
     const Tensor& the_template,
     std::optional<MemoryFormat> optional_memory_format) {
-  auto& self_ = unpack(self, "self", 0);
-  auto& the_template_ = unpack(the_template, "the_template", 1);
+  const auto& self_ = unpack(self, "self", 0);
+  const auto& the_template_ = unpack(the_template, "the_template", 1);
   if (self.requires_grad()) {
     TORCH_CHECK(false, "cannot resize variables that require grad");
   }
@@ -288,7 +288,7 @@ const Tensor& resize_as_(
 }
 
 Tensor detach(c10::DispatchKeySet ks, const Tensor& self) {
-  auto& self_ = unpack(self, "self", 0);
+  const auto& self_ = unpack(self, "self", 0);
   RECORD_FUNCTION("detach", std::vector<c10::IValue>({self}));
   auto result = ([&]() {
     at::AutoDispatchBelowAutograd guard;
@@ -321,7 +321,7 @@ Tensor& detach_(c10::DispatchKeySet ks, Tensor& self) {
   // grad_fn and output_nr; there's other metadata like debug name
   // and hooks which aren't cleared.  Is this function supposed to
   // clear those too? I'm not too sure, so I'm leaving it be for now.
-  auto autograd_meta = impl::materialize_autograd_meta(self);
+  auto* autograd_meta = impl::materialize_autograd_meta(self);
   autograd_meta->set_requires_grad(false, self.unsafeGetTensorImpl());
   autograd_meta->grad_fn_.reset();
   autograd_meta->output_nr_ = 0;

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -49,7 +49,7 @@ inline can_mutate_inplace_result can_mutate_inplace(
   if (!requires_grad || !GradMode::is_enabled()) {
     return can_mutate_inplace_result::success;
   }
-  auto diff_view_meta = impl::get_view_autograd_meta(tensor);
+  auto* diff_view_meta = impl::get_view_autograd_meta(tensor);
   if (diff_view_meta && diff_view_meta->has_bw_view()) {
     if (diff_view_meta->get_creation_meta() != CreationMeta::DEFAULT) {
       return can_mutate_inplace_result::non_default_backward_view;
@@ -144,7 +144,7 @@ inline void rebase_history(
     const std::vector<Variable>& vars,
     const std::shared_ptr<Node>& grad_fn) {
   if (grad_fn) {
-    for (auto& var : vars) {
+    for (const auto& var : vars) {
       if (var.defined()) {
         auto output_nr = grad_fn->add_input_metadata(var);
         impl::rebase_history(var, {grad_fn, output_nr});
@@ -202,7 +202,7 @@ inline at::Tensor as_view(
   if (base.is_inference())
     return tensor;
 
-  auto diff_view_meta = torch::autograd::impl::get_view_autograd_meta(base);
+  auto* diff_view_meta = torch::autograd::impl::get_view_autograd_meta(base);
 
   // To speed up the most common case, we specially handle when both the forward
   // and backward view infos are the same, and so a single shared ViewInfo can
@@ -314,7 +314,7 @@ inline void check_no_requires_grad(
   if (!GradMode::is_enabled()) {
     return;
   }
-  for (auto& tensor : tensors) {
+  for (const auto& tensor : tensors) {
     check_no_requires_grad(tensor, name, fn_name, /*check_grad_mode*/ false);
   }
 }

--- a/torch/csrc/autograd/anomaly_mode.cpp
+++ b/torch/csrc/autograd/anomaly_mode.cpp
@@ -56,7 +56,7 @@ void AnomalyMetadata::print_stack(const std::string& current_node_name) {
   // if there is no "parent_" in metadata, then it means this metadata's node
   // is the root and stop printing the traceback
   while (cur_parent) {
-    auto parent_metadata = cur_parent->metadata();
+    auto* parent_metadata = cur_parent->metadata();
     TORCH_WARN(
         "\n\n",
         "Previous calculation was induced by ",

--- a/torch/csrc/autograd/autograd_meta.cpp
+++ b/torch/csrc/autograd/autograd_meta.cpp
@@ -199,7 +199,7 @@ void AutogradMeta::set_fw_grad(
         ".");
 
     if (is_inplace_op && is_view_) {
-      auto this_view_meta = static_cast<DifferentiableViewMeta*>(this);
+      auto* this_view_meta = static_cast<DifferentiableViewMeta*>(this);
 
       // For inplace ops on a Tensor that does not already have a forward grad
       // and is a view, we propagate the tangent to the base and ensure that the
@@ -212,8 +212,8 @@ void AutogradMeta::set_fw_grad(
       //   - Copy the given new_grad into this view
       //   - Use this view as the new new_grad
       if (this_view_meta->has_fw_view()) {
-        auto& view_info = this_view_meta->get_forward_view();
-        auto& base = view_info.base_;
+        const auto& view_info = this_view_meta->get_forward_view();
+        const auto& base = view_info.base_;
 
         if (!base._fw_grad(level).defined()) {
           // Enforce same meta here to make sure that the view op below is
@@ -251,7 +251,7 @@ void AutogradMeta::set_fw_grad(
     // Enforce the basic layout constraint
     if (!utils::has_same_meta(new_grad, self)) {
       if (is_view_) {
-        auto this_view_meta = static_cast<DifferentiableViewMeta*>(this);
+        auto* this_view_meta = static_cast<DifferentiableViewMeta*>(this);
         TORCH_INTERNAL_ASSERT(
             !this_view_meta->has_fw_view(),
             "Expected the output of forward differentiable view operations to have the tangent have the same layout as primal")
@@ -285,7 +285,7 @@ const Variable& AutogradMeta::fw_grad(
     // For view that don't have a forward grad, check if their base has one that
     // has been defined by an inplace operation.
     // This ensure that case 5 from [Forward Grad View/inplace] above works fine
-    auto const_view_meta =
+    const auto* const_view_meta =
         static_cast<const torch::autograd::DifferentiableViewMeta*>(this);
     // This is ok to do as we ONLY modify fw_grad_ and this field is properly
     // locked in all methods

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -437,7 +437,7 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
     TORCH_CHECK(output_edge_index < num_outputs(), "Index out of range");
     const auto& next = next_edges_[output_edge_index];
     if (next.is_valid()) {
-      const auto exec_info = get_current_graph_task_exec_info();
+      const auto* const exec_info = get_current_graph_task_exec_info();
       if (exec_info && !exec_info->empty()) {
         auto it = exec_info->find(next.function.get());
         if (it == exec_info->end() || !it->second.should_execute()) {

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -25,10 +25,10 @@ struct DelayedErrorCtor {
         PyTuple_GET_SIZE(args) == 2,
         "Requires two arguments, got ",
         PyTuple_GET_SIZE(args));
-    auto arg1 = PyTuple_GET_ITEM(args, 0);
+    auto* arg1 = PyTuple_GET_ITEM(args, 0);
     TORCH_CHECK(THPUtils_checkString(arg1), "argument 'msg' must be a string");
     std::string msg = THPUtils_unpackString(arg1);
-    auto arg2 = PyTuple_GET_ITEM(args, 1);
+    auto* arg2 = PyTuple_GET_ITEM(args, 1);
     TORCH_CHECK(
         THPUtils_checkLong(arg2), "argument 'num_inputs' must be an int");
     auto num_inputs = THPUtils_unpackLong(arg2);
@@ -105,7 +105,7 @@ PyObject* getValueAttr(PyObject* obj, void* _unused) {
 
 static PyObject* accumulateGradVar(PyObject* _self, void* _unused) {
   THPCppFunction* self = (THPCppFunction*)_self;
-  auto grad_acc = (AccumulateGrad*)self->cdata.get();
+  auto* grad_acc = (AccumulateGrad*)self->cdata.get();
   return THPVariable_Wrap(grad_acc->variable);
 }
 

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -117,13 +117,13 @@ inline variable_list CopySlices::apply_impl(
   // block Since the gradient edge for the 0th input is different between `this`
   // and `fn`, make sure that the one from `fn` has the same metadata in the
   // current GraphTask's exec_info as the one on `this`.
-  const auto exec_info = get_current_graph_task_exec_info();
+  const auto* const exec_info = get_current_graph_task_exec_info();
   if (exec_info && !exec_info->empty()) {
     const auto& fn_edge = fn->next_edge(0);
     const auto& this_edge = this->next_edge(0);
     TORCH_INTERNAL_ASSERT(fn_edge.is_valid() == this_edge.is_valid());
     if (fn_edge.is_valid()) {
-      const auto fn_next_node = fn_edge.function.get();
+      auto* const fn_next_node = fn_edge.function.get();
       auto it = exec_info->find(fn_next_node);
       if (it == exec_info->end()) {
         // Node is not in the exec_info already

--- a/torch/csrc/autograd/functions/utils.h
+++ b/torch/csrc/autograd/functions/utils.h
@@ -82,7 +82,7 @@ inline void set_history(
 inline void set_history(
     const std::vector<Variable>& variables,
     const std::shared_ptr<Node>& grad_fn) {
-  for (auto& variable : variables) {
+  for (const auto& variable : variables) {
     set_history(variable, grad_fn);
   }
 }
@@ -93,7 +93,7 @@ inline bool isFwGradDefined(const std::optional<at::Tensor>& t) {
 
 inline bool isFwGradDefinedTensorList(const at::ITensorListRef& variables) {
   bool ret = false;
-  for (auto& variable : variables) {
+  for (const auto& variable : variables) {
     ret |= isFwGradDefined(variable);
   }
   return ret;

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -456,7 +456,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
   _C_m.def(
       "_register_py_class_for_device",
       [](const std::string& device, py::object python_type_class) {
-        auto cls = python_type_class.ptr();
+        auto* cls = python_type_class.ptr();
         registerPythonTensorClass(device, cls);
       });
   _C_m.def("_set_autograd_fallback_mode", [](const std::string& mode) {

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -93,7 +93,7 @@ void PythonEngine::thread_init(
     // TODO: call disarm once PyThreadState_Clear can safely be called from
     // finalize NOTE: deploy.cpp calls `PyInterpreterState_Delete` to destruct
     // PyThreadState, so avoid use-after-free here.
-    auto ptr = gil.release();
+    auto* ptr = gil.release();
     operator delete(ptr);
   }
 #endif
@@ -104,7 +104,7 @@ void PythonEngine::thread_on_exception(
     const std::shared_ptr<Node>& fn,
     std::exception& e) {
   // See Note [ Persisting PyErr state across autograd engine threads ]
-  auto python_err = dynamic_cast<python_error*>(&e);
+  auto* python_err = dynamic_cast<python_error*>(&e);
   if (python_err) {
     python_err->persist();
   }

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -69,7 +69,7 @@ bool _call_hooks(PyObject* dict, PyObject* args) {
   for (Py_ssize_t idx = 0; idx < len; ++idx) {
     // Note that this call is NoGil safe as the list is created just above and
     // not accessible by any other thread
-    const auto hook = PyList_GetItem(hooks, idx);
+    auto* const hook = PyList_GetItem(hooks, idx);
 
     THPObjectPtr res(PyObject_CallObject(hook, args));
     if (!res)

--- a/torch/csrc/autograd/python_legacy_variable.cpp
+++ b/torch/csrc/autograd/python_legacy_variable.cpp
@@ -154,7 +154,7 @@ void init_legacy_variable(PyObject* module) {
   if (PyType_Ready(&THPLegacyVariableType) < 0) {
     throw python_error();
   }
-  auto obj = (PyObject*)&THPLegacyVariableType;
+  auto* obj = (PyObject*)&THPLegacyVariableType;
   Py_INCREF(obj);
   if (PyModule_AddObject(module, "_LegacyVariableBase", obj) < 0) {
     throw python_error();

--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -306,7 +306,7 @@ static PyObject* THPVariable_frombuffer(
   auto r = parser.parse(args, kwargs, parsed_args);
 
   if (r.idx == 0) {
-    auto buffer = r.pyobject(0);
+    auto* buffer = r.pyobject(0);
     auto dtype = r.scalartype(1);
     auto count = r.toInt64(2);
     auto offset = r.toInt64(3);
@@ -343,7 +343,7 @@ static PyObject* THPVariable_asarray(
   }
 
   if (r.idx == 0) {
-    auto obj = r.pyobject(0);
+    auto* obj = r.pyobject(0);
     auto dtype = r.scalartypeOptional(1);
     auto device = r.deviceOptional(2);
     auto copy = r.toBoolOptional(3);
@@ -615,7 +615,7 @@ void initTorchFunctions(PyObject* module) {
       "_functionalize_was_inductor_storage_resized", [](const at::Tensor& t) {
         TORCH_INTERNAL_ASSERT(
             at::functionalization::impl::isFunctionalTensor(t));
-        auto impl = at::functionalization::impl::unsafeGetFunctionalWrapper(t);
+        auto* impl = at::functionalization::impl::unsafeGetFunctionalWrapper(t);
         return impl->was_inductor_storage_resized();
       });
   py_module.def(
@@ -638,13 +638,13 @@ void initTorchFunctions(PyObject* module) {
       [](const at::Tensor& tensor, const at::Tensor& base) {
         TORCH_INTERNAL_ASSERT(
             at::functionalization::impl::isFunctionalTensor(tensor));
-        auto impl =
+        auto* impl =
             at::functionalization::impl::unsafeGetFunctionalWrapper(tensor);
         return impl->apply_view_metas(base);
       });
   py_module.def("_functionalize_is_symbolic", [](const at::Tensor& t) {
     TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(t));
-    auto impl = at::functionalization::impl::unsafeGetFunctionalWrapper(t);
+    auto* impl = at::functionalization::impl::unsafeGetFunctionalWrapper(t);
     return impl->is_symbolic();
   });
   py_module.def("_functionalize_sync", [](const at::Tensor& t) {
@@ -669,7 +669,7 @@ void initTorchFunctions(PyObject* module) {
   });
   py_module.def("_functionalize_is_multi_output_view", [](const at::Tensor& t) {
     TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(t));
-    auto t_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(t);
+    auto* t_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(t);
     return t_impl->is_multi_output_view();
   });
   py_module.def(
@@ -686,32 +686,32 @@ void initTorchFunctions(PyObject* module) {
       "_functionalize_has_metadata_mutation", [](const at::Tensor& t) {
         TORCH_INTERNAL_ASSERT(
             at::functionalization::impl::isFunctionalTensor(t));
-        auto t_impl =
+        auto* t_impl =
             at::functionalization::impl::unsafeGetFunctionalWrapper(t);
         return t_impl->has_metadata_mutation();
       });
   py_module.def("_functionalize_has_data_mutation", [](const at::Tensor& t) {
     TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(t));
-    auto t_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(t);
+    auto* t_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(t);
     return t_impl->has_data_mutation();
   });
   py_module.def(
       "_functionalize_get_storage_size", [](const at::Tensor& t, bool before) {
         TORCH_INTERNAL_ASSERT(
             at::functionalization::impl::isFunctionalTensor(t));
-        auto wrapper =
+        auto* wrapper =
             at::functionalization::impl::unsafeGetFunctionalWrapper(t);
         auto size = wrapper->get_storage_size(/*before=*/before);
         return size;
       });
   py_module.def("_functionalize_set_storage_changed", [](const at::Tensor& t) {
     TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(t));
-    auto wrapper = at::functionalization::impl::unsafeGetFunctionalWrapper(t);
+    auto* wrapper = at::functionalization::impl::unsafeGetFunctionalWrapper(t);
     wrapper->set_storage_changed();
   });
   py_module.def("_functionalize_was_storage_changed", [](const at::Tensor& t) {
     TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(t));
-    auto wrapper = at::functionalization::impl::unsafeGetFunctionalWrapper(t);
+    auto* wrapper = at::functionalization::impl::unsafeGetFunctionalWrapper(t);
     return wrapper->was_storage_changed();
   });
   py_module.def(
@@ -777,7 +777,7 @@ void initTorchFunctions(PyObject* module) {
         // Here, we unsafely set the grad function on the wrapper to be the same
         // as the inner. We expect this grad_fn to NEVER be used. It's needed so
         // that .is_leaf metadata is accurate on the wrapper
-        auto inner_autograd_meta = impl::get_autograd_meta(src_);
+        auto* inner_autograd_meta = impl::get_autograd_meta(src_);
         if (inner_autograd_meta) {
           dst_.set_requires_grad(src_.requires_grad());
           if (dst_.requires_grad()) {

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -271,7 +271,7 @@ PyObject* THPVariable_Wrap(const at::TensorBase& var) {
           getPyInterpreter(), /*ignore_hermetic_tls=*/false);
   c10::impl::PyInterpreterStatus status{};
   if (mb_obj.has_value()) {
-    auto obj = *mb_obj;
+    auto* obj = *mb_obj;
     if (obj) {
       if (var.unsafeGetTensorImpl()->pyobj_slot()->owns_pyobj()) {
         // C++ owns the Python object; this implies there weren't any other
@@ -310,7 +310,7 @@ PyObject* THPVariable_Wrap(const at::TensorBase& var) {
     return THPVariable_NewWithVar((PyTypeObject*)THPVariableClass, var, status);
   }
 
-  if (auto clazz = getPythonTensorClass(var.device())) {
+  if (auto* clazz = getPythonTensorClass(var.device())) {
     return THPVariable_NewWithVar((PyTypeObject*)clazz, var, status);
   }
 
@@ -449,7 +449,7 @@ std::vector<at::Tensor> map_py_func(
     const std::vector<at::Tensor>& items) {
   std::vector<at::Tensor> new_items;
   new_items.reserve(items.size());
-  for (auto& item : items) {
+  for (const auto& item : items) {
     auto output = func(item);
     if (output.is(py::none())) {
       // treat None value as an undefined tensor
@@ -480,7 +480,7 @@ static PyObject* view_func_impl(
 
   // Ensure that self is indeed a backward differentiable view
   // If not, we return an undefined Tensor (None) and let the user handle it.
-  auto diff_view_meta = torch::autograd::impl::get_view_autograd_meta(self);
+  auto* diff_view_meta = torch::autograd::impl::get_view_autograd_meta(self);
   at::Tensor out;
   if (diff_view_meta && diff_view_meta->has_bw_view()) {
     const auto& view_info = diff_view_meta->get_backward_view();
@@ -489,7 +489,7 @@ static PyObject* view_func_impl(
         torch::autograd::utils::has_same_meta(new_base, view_info.base_)) {
       // Do the actual view replay
       if (view_info.has_view_fn()) {
-        auto& view_func = view_info.view_fn();
+        const auto& view_func = view_info.view_fn();
 
         // Determine new SymInt / tensor state as needed.
         std::optional<std::vector<c10::SymInt>> new_symints = std::nullopt;
@@ -546,7 +546,7 @@ static PyObject* rev_view_func_impl(PyObject* self_, PyObject* arg) {
 
   // Ensure that self is indeed a backward differentiable view
   // If not, we return an undefined Tensor (None) and let the user handle it.
-  auto diff_view_meta = torch::autograd::impl::get_view_autograd_meta(self);
+  auto* diff_view_meta = torch::autograd::impl::get_view_autograd_meta(self);
   at::Tensor out;
   if (diff_view_meta && diff_view_meta->has_bw_view()) {
     const auto& view_info = diff_view_meta->get_backward_view();
@@ -1284,7 +1284,7 @@ PyObject* THPVariable_is_cpu(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_cpu");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.is_cpu());
   END_HANDLE_TH_ERRORS
 }
@@ -1294,7 +1294,7 @@ PyObject* THPVariable_is_cuda(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_cuda");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.is_cuda());
   END_HANDLE_TH_ERRORS
 }
@@ -1304,7 +1304,7 @@ PyObject* THPVariable_is_mtia(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_mtia");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.is_mtia());
   END_HANDLE_TH_ERRORS
 }
@@ -1314,7 +1314,7 @@ PyObject* THPVariable_is_xla(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_xla");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.is_xla());
   END_HANDLE_TH_ERRORS
 }
@@ -1324,7 +1324,7 @@ PyObject* THPVariable_is_ipu(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_ipu");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.is_ipu());
   END_HANDLE_TH_ERRORS
 }
@@ -1334,7 +1334,7 @@ PyObject* THPVariable_is_xpu(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_xpu");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.is_xpu());
   END_HANDLE_TH_ERRORS
 }
@@ -1344,7 +1344,7 @@ PyObject* THPVariable_is_sparse(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_sparse");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.is_sparse());
   END_HANDLE_TH_ERRORS
 }
@@ -1354,7 +1354,7 @@ PyObject* THPVariable_is_sparse_csr(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_sparse_csr");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.is_sparse_csr());
   END_HANDLE_TH_ERRORS
 }
@@ -1364,7 +1364,7 @@ PyObject* THPVariable_is_mkldnn(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_mkldnn");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.is_mkldnn());
   END_HANDLE_TH_ERRORS
 }
@@ -1374,7 +1374,7 @@ PyObject* THPVariable_is_mps(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_mps");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.is_mps());
   END_HANDLE_TH_ERRORS
 }
@@ -1384,7 +1384,7 @@ PyObject* THPVariable_is_maia(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_maia");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.is_maia());
   END_HANDLE_TH_ERRORS
 }
@@ -1394,7 +1394,7 @@ PyObject* THPVariable_is_vulkan(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_vulkan");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.is_vulkan());
   END_HANDLE_TH_ERRORS
 }
@@ -1404,7 +1404,7 @@ PyObject* THPVariable_is_quantized(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_quantized");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.is_quantized());
   END_HANDLE_TH_ERRORS
 }
@@ -1414,7 +1414,7 @@ PyObject* THPVariable_is_meta(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_meta");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.is_meta());
   END_HANDLE_TH_ERRORS
 }
@@ -1424,7 +1424,7 @@ PyObject* THPVariable_is_complex(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_complex");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.is_complex());
   END_HANDLE_TH_ERRORS
 }
@@ -1434,7 +1434,7 @@ PyObject* THPVariable_is_nested(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_nested");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.is_nested());
   END_HANDLE_TH_ERRORS
 }
@@ -1443,7 +1443,7 @@ PyObject* THPVariable_has_symbolic_sizes_strides(
     THPVariable* self,
     void* unused) {
   HANDLE_TH_ERRORS
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(
       self_.unsafeGetTensorImpl()->has_symbolic_sizes_strides());
   END_HANDLE_TH_ERRORS
@@ -1454,7 +1454,7 @@ static PyObject* THPVariable_dtype(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "dtype");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.scalar_type());
   END_HANDLE_TH_ERRORS
 }
@@ -1464,7 +1464,7 @@ static PyObject* THPVariable_layout(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "layout");
   }
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   return torch::autograd::utils::wrap(self_.layout());
   END_HANDLE_TH_ERRORS
 }
@@ -1498,7 +1498,7 @@ static PyObject* THPVariable_get_itemsize(THPVariable* self, void* unused) {
 
 int THPVariable_set_real(PyObject* self, PyObject* real, void* unused) {
   HANDLE_TH_ERRORS
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   auto self_real = at::real(self_);
   auto real_ = valueToTensor(self_real.options(), real, self_real.device());
   {
@@ -1511,7 +1511,7 @@ int THPVariable_set_real(PyObject* self, PyObject* real, void* unused) {
 
 int THPVariable_set_imag(PyObject* self, PyObject* imag, void* unused) {
   HANDLE_TH_ERRORS
-  auto& self_ = THPVariable_Unpack(self);
+  const auto& self_ = THPVariable_Unpack(self);
   auto self_imag = at::imag(self_);
   auto imag_ = valueToTensor(self_imag.options(), imag, self_imag.device());
   {
@@ -2108,7 +2108,7 @@ static PyObject* THPVariable_NewWithVar(
 
   PyObject* obj = type->tp_alloc(type, 0);
   if (obj) {
-    auto v = (THPVariable*)obj;
+    auto* v = (THPVariable*)obj;
     // TODO: named constructor to avoid default initialization
     new (&v->cdata) MaybeOwned<Variable>();
     if (c10::impl::HermeticPyObjectTLS::get_state()) {
@@ -2189,7 +2189,7 @@ static int traverse_slots(
     visitproc visit,
     void* arg) {
   auto n = Py_SIZE(type);
-  auto mp = type->tp_members;
+  auto* mp = type->tp_members;
   for (Py_ssize_t i = 0; i < n; i++, mp++) {
     if (mp->type == T_OBJECT_EX) {
       char* addr = (char*)self + mp->offset;
@@ -2275,7 +2275,7 @@ static int THPVariable_subclass_traverse(
       // object, which requires the GIL to be accessed. Note that this is only
       // valid as long as user don't share non-owning references across
       // different threads (which is crazy and should never be done).
-      auto autograd_meta = torch::autograd::impl::get_autograd_meta(tensor);
+      auto* autograd_meta = torch::autograd::impl::get_autograd_meta(tensor);
       if (tensor.use_count() == 1) {
         if (autograd_meta) {
           // Do NOT call grad_fn() here as that might trigger a recompute
@@ -2284,7 +2284,7 @@ static int THPVariable_subclass_traverse(
             // All Node can have a pyobj (stored in "pyobj_")
             Py_VISIT(grad_fn->pyobj());
             // PyNode are special as they also have an "obj" field
-            if (auto py_node_fn = dynamic_cast<PyNode*>(grad_fn.get())) {
+            if (auto* py_node_fn = dynamic_cast<PyNode*>(grad_fn.get())) {
               Py_VISIT(py_node_fn->obj);
             }
           }
@@ -2292,7 +2292,7 @@ static int THPVariable_subclass_traverse(
       }
       if (autograd_meta) {
         for (const auto& hook : torch::autograd::impl::hooks(tensor)) {
-          if (auto pyhook =
+          if (auto* pyhook =
                   dynamic_cast<PyFunctionTensorPreHook*>(hook.get())) {
             Py_VISIT(pyhook->dict);
           }

--- a/torch/csrc/copy_utils.h
+++ b/torch/csrc/copy_utils.h
@@ -22,7 +22,7 @@ inline bool tryTHPCopy(
     PyObject* src,
     bool non_blocking,
     bool broadcast) {
-  for (auto& i : v) {
+  for (const auto& i : v) {
     if (i.non_blocking == non_blocking &&
         PyType_IsSubtype(Py_TYPE(src), i.srcType)) {
       (i.copy)(dst, src, broadcast);

--- a/torch/csrc/cuda/Event.cpp
+++ b/torch/csrc/cuda/Event.cpp
@@ -60,7 +60,7 @@ static PyObject* THCPEvent_from_ipc_handle(
     PyObject* args,
     PyObject* kwargs) {
   HANDLE_TH_ERRORS
-  auto type = (PyTypeObject*)_type;
+  auto* type = (PyTypeObject*)_type;
 
   static torch::PythonArgParser parser({
       "from_ipc_handle(Device device, std::string ipc_handle)",
@@ -124,8 +124,8 @@ static PyObject* THCPEvent_get_device(THCPEvent* self, void* unused) {
 
 static PyObject* THCPEvent_record(PyObject* _self, PyObject* _stream) {
   HANDLE_TH_ERRORS {
-    auto self = (THCPEvent*)_self;
-    auto stream = (THCPStream*)_stream;
+    auto* self = (THCPEvent*)_self;
+    auto* stream = (THCPStream*)_stream;
     pybind11::gil_scoped_release no_gil{};
     self->cuda_event.record(stream->cuda_stream);
   }
@@ -135,8 +135,8 @@ static PyObject* THCPEvent_record(PyObject* _self, PyObject* _stream) {
 
 static PyObject* THCPEvent_wait(PyObject* _self, PyObject* _stream) {
   HANDLE_TH_ERRORS {
-    auto self = (THCPEvent*)_self;
-    auto stream = (THCPStream*)_stream;
+    auto* self = (THCPEvent*)_self;
+    auto* stream = (THCPStream*)_stream;
     pybind11::gil_scoped_release no_gil{};
     self->cuda_event.block(stream->cuda_stream);
   }
@@ -146,22 +146,22 @@ static PyObject* THCPEvent_wait(PyObject* _self, PyObject* _stream) {
 
 static PyObject* THCPEvent_query(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  auto self = (THCPEvent*)_self;
+  auto* self = (THCPEvent*)_self;
   return PyBool_FromLong(self->cuda_event.query());
   END_HANDLE_TH_ERRORS
 }
 
 static PyObject* THCPEvent_elapsed_time(PyObject* _self, PyObject* _other) {
   HANDLE_TH_ERRORS
-  auto self = (THCPEvent*)_self;
-  auto other = (THCPEvent*)_other;
+  auto* self = (THCPEvent*)_self;
+  auto* other = (THCPEvent*)_other;
   return PyFloat_FromDouble(self->cuda_event.elapsed_time(other->cuda_event));
   END_HANDLE_TH_ERRORS
 }
 
 static PyObject* THCPEvent_synchronize(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS {
-    auto self = (THCPEvent*)_self;
+    auto* self = (THCPEvent*)_self;
     pybind11::gil_scoped_release no_gil{};
     self->cuda_event.synchronize();
   }
@@ -171,7 +171,7 @@ static PyObject* THCPEvent_synchronize(PyObject* _self, PyObject* noargs) {
 
 static PyObject* THCPEvent_ipc_handle(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  auto self = (THCPEvent*)_self;
+  auto* self = (THCPEvent*)_self;
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   cudaIpcEventHandle_t handle;
   self->cuda_event.ipc_handle(&handle);

--- a/torch/csrc/cuda/Stream.cpp
+++ b/torch/csrc/cuda/Stream.cpp
@@ -109,7 +109,7 @@ static PyObject* THCPStream_priority_range(
 
 static PyObject* THCPStream_query(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  auto self = (THCPStream*)_self;
+  auto* self = (THCPStream*)_self;
   return PyBool_FromLong(self->cuda_stream.query());
   END_HANDLE_TH_ERRORS
 }
@@ -117,7 +117,7 @@ static PyObject* THCPStream_query(PyObject* _self, PyObject* noargs) {
 static PyObject* THCPStream_synchronize(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS {
     pybind11::gil_scoped_release no_gil;
-    auto self = (THCPStream*)_self;
+    auto* self = (THCPStream*)_self;
     self->cuda_stream.synchronize();
   }
   Py_RETURN_NONE;
@@ -126,8 +126,8 @@ static PyObject* THCPStream_synchronize(PyObject* _self, PyObject* noargs) {
 
 static PyObject* THCPStream_eq(PyObject* _self, PyObject* _other) {
   HANDLE_TH_ERRORS
-  auto self = (THCPStream*)_self;
-  auto other = (THCPStream*)_other;
+  auto* self = (THCPStream*)_self;
+  auto* other = (THCPStream*)_other;
   return PyBool_FromLong(self->cuda_stream == other->cuda_stream);
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -371,7 +371,7 @@ static at::Tensor& _gather_out_impl(
     int64_t dim) {
   std::vector<int64_t> chunk_sizes;
   chunk_sizes.reserve(tensors.size());
-  for (auto& tensor : tensors) {
+  for (const auto& tensor : tensors) {
     chunk_sizes.emplace_back(tensor.size(dim));
   }
   auto chunks =
@@ -388,7 +388,7 @@ at::Tensor& gather_out(
     int64_t dim) {
   TORCH_CHECK(!tensors.empty(), "Expected at least one tensor to gather from");
   int64_t total_size = 0;
-  auto& first = tensors.front();
+  const auto& first = tensors.front();
   const auto first_size = first.sizes();
   dim = at::maybe_wrap_dim(dim, first);
   std::vector<int64_t> expected_size(first_size.begin(), first_size.end());
@@ -442,7 +442,7 @@ at::Tensor gather(
     std::optional<int32_t> destination_index) {
   TORCH_CHECK(!tensors.empty(), "Expected at least one tensor to gather from");
   int64_t total_size = 0;
-  auto& first = tensors.front();
+  const auto& first = tensors.front();
   const auto first_size = first.sizes();
   dim = at::maybe_wrap_dim(dim, first);
   std::vector<int64_t> expected_size(first_size.begin(), first_size.end());

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -337,7 +337,7 @@ std::string _memory_snapshot_pickled() {
       trace_entry.insert(size_s, (int64_t)te.size_);
       trace_entry.insert(stream_s, int64_t(te.stream_));
       if (te.context_) {
-        auto sc = getFromContext(te.context_);
+        auto* sc = getFromContext(te.context_);
         frame_tracebacks.push_back(sc);
         frame_dict.push_back(trace_entry);
       }

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -475,7 +475,7 @@ AutoNcclGroup::~AutoNcclGroup() noexcept(false) {
 bool is_available(TensorList tensors) {
 #ifdef USE_NCCL
   device_set devices;
-  for (auto& tensor : tensors) {
+  for (const auto& tensor : tensors) {
     if (!tensor.is_cuda() || tensor.is_sparse())
       return false;
     if (!tensor.is_contiguous())
@@ -611,7 +611,7 @@ void broadcast(
     auto device = tensors[i].get_device();
     device_guard.set_index(device);
     // Default to the current stream
-    const auto stream = (streams.empty() || !streams[i])
+    auto* const stream = (streams.empty() || !streams[i])
         ? at::cuda::getCurrentCUDAStream(device).stream()
         : streams[i]->stream();
     TORCH_CHECK(
@@ -663,7 +663,7 @@ void reduce(
     auto device = inputs[i].device().index();
     device_guard.set_index(device);
     // Default to the current stream
-    const auto stream = (streams.empty() || !streams[i])
+    auto* const stream = (streams.empty() || !streams[i])
         ? at::cuda::getCurrentCUDAStream(device).stream()
         : streams[i]->stream();
 
@@ -717,7 +717,7 @@ void all_reduce(
     auto device = inputs[i].device().index();
     device_guard.set_index(device);
     // Default to the current stream
-    const auto stream = (streams.empty() || !streams[i])
+    auto* const stream = (streams.empty() || !streams[i])
         ? at::cuda::getCurrentCUDAStream(device).stream()
         : streams[i]->stream();
 
@@ -759,7 +759,7 @@ void reduce_scatter(
     auto device = inputs[i].device().index();
     device_guard.set_index(device);
     // Default to the current stream
-    const auto stream = (streams.empty() || !streams[i])
+    auto* const stream = (streams.empty() || !streams[i])
         ? at::cuda::getCurrentCUDAStream(device).stream()
         : streams[i]->stream();
 
@@ -800,7 +800,7 @@ void all_gather(
     auto device = inputs[i].device().index();
     device_guard.set_index(device);
     // Default to the current stream
-    const auto stream = (streams.empty() || !streams[i])
+    auto* const stream = (streams.empty() || !streams[i])
         ? at::cuda::getCurrentCUDAStream(device).stream()
         : streams[i]->stream();
 
@@ -844,7 +844,7 @@ void all2all_single_equal_split(
   [[maybe_unused]] size_t rankdiff = input.nbytes() / size;
   const auto* sendbuff = reinterpret_cast<const char*>(input.const_data_ptr());
   auto* recvbuff = reinterpret_cast<char*>(output.data_ptr());
-  auto comm = to_nccl_comm(_comm);
+  auto* comm = to_nccl_comm(_comm);
 #if defined(USE_ROCM) || defined(NCCL_ALLTOALL_SUPPORTED)
   // NCCL_ALLTOALL_SUPPORTED is used so NCCL can differentiate send/recv
   // operations issued as a part of the collective (e.g. alltoall) vs those
@@ -893,7 +893,7 @@ void all2all_single_unequal_split(
   using namespace torch::cuda::nccl::detail;
 
   auto type = to_nccl_data_type(_type);
-  auto comm = to_nccl_comm(_comm);
+  auto* comm = to_nccl_comm(_comm);
 #if defined(USE_ROCM) || defined(NCCL_ALLTOALLV_SUPPORTED)
   // NCCL_ALLTOALLV_SUPPORTED is used so NCCL can differentiate send/recv
   // operations issued as a part of the collective (e.g. alltoallv) vs those
@@ -955,7 +955,7 @@ void all2all(
 #if defined(NCCL_MAJOR) && \
     ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
-  auto comm = to_nccl_comm(_comm);
+  auto* comm = to_nccl_comm(_comm);
 
 #ifdef NCCL_ALLTOALLV_SUPPORTED
   // NCCL_ALLTOALLV_SUPPORTED is used so NCCL can differentiate send/recv
@@ -1120,7 +1120,7 @@ void gather(
     ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
 
-  auto comm = to_nccl_comm(_comm);
+  auto* comm = to_nccl_comm(_comm);
   int numranks = 0, cur_rank = 0;
   NCCL_CHECK(ncclCommCount(comm, &numranks));
   NCCL_CHECK(ncclCommUserRank(comm, &cur_rank));
@@ -1169,7 +1169,7 @@ void scatter(
     ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
 
-  auto comm = to_nccl_comm(_comm);
+  auto* comm = to_nccl_comm(_comm);
   int numranks = 0, cur_rank = 0;
 #ifndef NCCL_HAS_COMM_NONBLOCKING
   NCCL_CHECK(ncclCommCount(comm, &numranks));

--- a/torch/csrc/distributed/autograd/context/context.cpp
+++ b/torch/csrc/distributed/autograd/context/context.cpp
@@ -234,8 +234,8 @@ const c10::Dict<torch::Tensor, torch::Tensor> DistAutogradContext::
   std::lock_guard<std::mutex> guard(lock_);
   // block current streams before accessing gradients to make sure that
   // gradient computations are finished before use.
-  for (auto& entry : gradReadyEvents_) {
-    auto& event = entry.second;
+  for (const auto& entry : gradReadyEvents_) {
+    const auto& event = entry.second;
     event.block(impl_.getStream(event.device()));
   }
   return accumulatedGrads_;

--- a/torch/csrc/distributed/autograd/engine/dist_engine.cpp
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.cpp
@@ -225,7 +225,7 @@ void DistEngine::computeDependencies(
   // Traverse the graph.
   auto& dependencies = graphTask->dependencies_;
   while (!queue.empty()) {
-    auto fn = queue.front();
+    auto* fn = queue.front();
     queue.pop();
 
     if (!will_use_accelerator) {
@@ -233,7 +233,7 @@ void DistEngine::computeDependencies(
     }
 
     for (const auto& edge : fn->next_edges()) {
-      if (auto nextFn = edge.function.get()) {
+      if (auto* nextFn = edge.function.get()) {
         dependencies[nextFn] += 1;
         const bool wasInserted = seen.insert(nextFn).second;
         if (wasInserted) {
@@ -310,10 +310,10 @@ void DistEngine::computeDependencies(
       if (!execInfo.captures_) {
         continue;
       }
-      auto fn = mapEntry.first;
+      auto* fn = mapEntry.first;
       // There may be nodes other than 'AccumulateGrad', e.g. RecvRPCBackward,
       // to be captured.
-      if (auto accumulateGradFn = dynamic_cast<AccumulateGrad*>(fn)) {
+      if (auto* accumulateGradFn = dynamic_cast<AccumulateGrad*>(fn)) {
         for (auto& capture : *execInfo.captures_) {
           // Capture hooks are technically deprecated, but as an exception below
           // is the single and only instance of capture hooks usage that we

--- a/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.cpp
@@ -25,7 +25,7 @@ c10::intrusive_ptr<rpc::Message> CleanupAutogradContextReq::toMessageImpl() && {
 std::unique_ptr<CleanupAutogradContextReq> CleanupAutogradContextReq::
     fromMessage(const rpc::Message& message) {
   // unpickle and get the context_id we need to clean up
-  auto payload = static_cast<const char*>(message.payload().data());
+  const auto* payload = static_cast<const char*>(message.payload().data());
   auto payload_size = message.payload().size();
   IValue ivalue_context_id = jit::unpickle(
       payload,

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.cpp
@@ -47,7 +47,7 @@ c10::intrusive_ptr<Message> PropagateGradientsReq::toMessageImpl() && {
 std::unique_ptr<PropagateGradientsReq> PropagateGradientsReq::fromMessage(
     const Message& message) {
   // Unpickle the message and retrieve tupleElements.
-  auto payload = static_cast<const char*>(message.payload().data());
+  const auto* payload = static_cast<const char*>(message.payload().data());
   auto payload_size = message.payload().size();
   IValue tuple = jit::unpickle(
       payload,

--- a/torch/csrc/distributed/autograd/rpc_messages/rref_backward_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/rref_backward_req.cpp
@@ -37,7 +37,7 @@ c10::intrusive_ptr<Message> RRefBackwardReq::toMessageImpl() && {
 std::unique_ptr<RRefBackwardReq> RRefBackwardReq::fromMessage(
     const Message& message) {
   // Unpickle the message and retrieve tupleElements.
-  auto payload = static_cast<const char*>(message.payload().data());
+  const auto* payload = static_cast<const char*>(message.payload().data());
   auto payload_size = message.payload().size();
   IValue tuple = jit::unpickle(
       payload,

--- a/torch/csrc/distributed/c10d/CudaDMAConnectivity.cpp
+++ b/torch/csrc/distributed/c10d/CudaDMAConnectivity.cpp
@@ -50,7 +50,7 @@ struct C10_EXPORT NVLinkDetector : public c10d::DMAConnectivityDetector {
     static const char* warning_msg =
         "PyTorch features that use NVLinkDetector may assume no NVLink presence.";
 
-    auto driver_api = c10::cuda::DriverAPI::get();
+    auto* driver_api = c10::cuda::DriverAPI::get();
     if (driver_api->nvmlInit_v2_() != NVML_SUCCESS) {
       LOG(WARNING)
           << "NVLinkDetector: Failed to initialize NVML via nvmlInit_v2. "

--- a/torch/csrc/distributed/c10d/FileStore.cpp
+++ b/torch/csrc/distributed/c10d/FileStore.cpp
@@ -405,7 +405,7 @@ int64_t FileStore::addHelper(const std::string& key, int64_t i) {
   const auto& value = cache_[key];
   int64_t ti = i;
   if (!value.empty()) {
-    auto buf = reinterpret_cast<const char*>(value.data());
+    const auto* buf = reinterpret_cast<const char*>(value.data());
     auto len = value.size();
     ti += std::stoll(std::string(buf, len));
   }

--- a/torch/csrc/distributed/c10d/FlightRecorder.cpp
+++ b/torch/csrc/distributed/c10d/FlightRecorder.cpp
@@ -465,7 +465,7 @@ const c10::List<c10::IValue> FlightRecorder::getCollectiveTrace(
       dict.insert(duration_key, *e.duration_);
     }
 
-    auto it = e.sizes_.begin();
+    auto* it = e.sizes_.begin();
     auto read_sizes = [&](const c10::SmallVector<int64_t, 4>& dims) {
       auto sizes = new_list();
       for (auto dim : dims) {
@@ -603,7 +603,7 @@ std::string FlightRecorder::dump_json(
       if (e.duration_) {
         j[duration_key_str] = *e.duration_;
       }
-      auto it = e.sizes_.begin();
+      auto* it = e.sizes_.begin();
       auto read_sizes = [&](const c10::SmallVector<int64_t, 4>& dims) {
         auto sizes = std::list<std::list<int64_t>>();
         for (auto dim : dims) {

--- a/torch/csrc/distributed/c10d/GlooDeviceFactory.cpp
+++ b/torch/csrc/distributed/c10d/GlooDeviceFactory.cpp
@@ -129,7 +129,7 @@ namespace {
 std::shared_ptr<::gloo::transport::Device> makeGlooDevice(
     const std::string& interfaceName,
     const std::string& hostName) {
-  static auto transportName = getenv("GLOO_DEVICE_TRANSPORT");
+  static auto* transportName = getenv("GLOO_DEVICE_TRANSPORT");
   if (transportName) {
     return GlooDeviceRegistry()->Create(transportName, interfaceName, hostName);
   }

--- a/torch/csrc/distributed/c10d/HashStore.cpp
+++ b/torch/csrc/distributed/c10d/HashStore.cpp
@@ -84,7 +84,7 @@ int64_t HashStore::add(const std::string& key, int64_t i) {
   const auto& value = map_[key];
   int64_t ti = i;
   if (!value.empty()) {
-    auto buf = reinterpret_cast<const char*>(value.data());
+    const auto* buf = reinterpret_cast<const char*>(value.data());
     auto len = value.size();
     ti += std::stoll(std::string(buf, len));
   }
@@ -136,7 +136,7 @@ std::vector<std::vector<uint8_t>> HashStore::multiGet(
   std::vector<std::vector<uint8_t>> res;
   res.reserve(keys.size());
 
-  for (auto& key : keys) {
+  for (const auto& key : keys) {
     auto it = map_.find(key);
     if (it != map_.end()) {
       res.emplace_back(it->second);

--- a/torch/csrc/distributed/c10d/PrefixStore.cpp
+++ b/torch/csrc/distributed/c10d/PrefixStore.cpp
@@ -84,7 +84,7 @@ std::vector<std::vector<uint8_t>> PrefixStore::multiGet(
     const std::vector<std::string>& keys) {
   std::vector<std::string> prefixed_keys;
   prefixed_keys.reserve(keys.size());
-  for (auto& key : keys) {
+  for (const auto& key : keys) {
     prefixed_keys.push_back(joinKey(key));
   }
   return store_->multiGet(prefixed_keys);
@@ -95,7 +95,7 @@ void PrefixStore::multiSet(
     const std::vector<std::vector<uint8_t>>& values) {
   std::vector<std::string> prefixed_keys;
   prefixed_keys.reserve(keys.size());
-  for (auto& key : keys) {
+  for (const auto& key : keys) {
     prefixed_keys.push_back(joinKey(key));
   }
   store_->multiSet(prefixed_keys, values);

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -794,7 +794,7 @@ ProcessGroupGloo::ProcessGroupGloo(
     try {
       context->connectFullMesh(store, options_->devices[i]);
     } catch (const std::runtime_error& e) {
-      auto err = e.what();
+      const auto* err = e.what();
       // TORCH_CHECK to print the cpp stacktrace.
       auto msg = c10::str("Gloo connectFullMesh failed with ", err);
       logAndThrow(msg, msg);
@@ -2823,7 +2823,7 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::send(
     int tag) {
   auto& tensor = checkSingleTensor(tensors);
   auto utag = checkTag(tag);
-  auto ptr = tensor.const_data_ptr();
+  const auto* ptr = tensor.const_data_ptr();
   auto size = tensor.numel() * tensor.element_size();
 
   // Construct unbound buffer.
@@ -2844,7 +2844,7 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::recv(
     int tag) {
   auto& tensor = checkSingleTensor(tensors);
   auto utag = checkTag(tag);
-  auto ptr = tensor.mutable_data_ptr();
+  auto* ptr = tensor.mutable_data_ptr();
   auto size = tensor.numel() * tensor.element_size();
 
   // Construct unbound buffer.
@@ -2864,7 +2864,7 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::recvAnysource(
     int tag) {
   auto& tensor = checkSingleTensor(tensors);
   auto utag = checkTag(tag);
-  auto ptr = tensor.mutable_data_ptr();
+  auto* ptr = tensor.mutable_data_ptr();
   auto size = tensor.numel() * tensor.element_size();
 
   // Construct unbound buffer.
@@ -3000,7 +3000,7 @@ void ProcessGroupGloo::monitoredBarrier(
 
   auto waitLoop = [&](const std::map<int, c10::intrusive_ptr<Work>>& works) {
     std::vector<int> processedRanks;
-    for (auto& work : works) {
+    for (const auto& work : works) {
       bool rankResponded = false;
       try {
         // Note: if waitAllRanks=false, we recompute the time remaining in

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
@@ -459,7 +459,7 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::reduce(
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
       [opts, this](std::unique_ptr<WorkEntry>& entry) {
         auto data = (entry->src)[0];
-        auto dataPtr = (entry->src)[0].data_ptr();
+        auto* dataPtr = (entry->src)[0].data_ptr();
         void* sendbuf = (rank_ == opts.rootRank) ? MPI_IN_PLACE : dataPtr;
         void* recvbuf = (rank_ == opts.rootRank) ? dataPtr : nullptr;
 

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -317,7 +317,7 @@ struct CollectiveFingerPrint {
     int64_t data_size = static_cast<int64_t>(data->size());
     // Need to release here and get the ptr due to C++ parameter evaluation
     // order.
-    auto d = data.release();
+    auto* d = data.release();
     at::Tensor serialized_tensor =
         at::for_blob(d->data(), {data_size})
             .context(

--- a/torch/csrc/distributed/c10d/Store.cpp
+++ b/torch/csrc/distributed/c10d/Store.cpp
@@ -48,7 +48,7 @@ std::vector<std::vector<uint8_t>> Store::multiGet(
     const std::vector<std::string>& keys) {
   std::vector<std::vector<uint8_t>> result;
   result.reserve(keys.size());
-  for (auto& key : keys) {
+  for (const auto& key : keys) {
     result.emplace_back(get(key));
   }
   return result;

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -363,7 +363,7 @@ void TCPStore::waitForWorkers() {
     while (true) {
       // TODO: Any chance to make this cleaner?
       std::vector<uint8_t> value = doGet(initKey_);
-      auto buf = reinterpret_cast<const char*>(value.data());
+      const auto* buf = reinterpret_cast<const char*>(value.data());
       auto len = value.size();
       int numWorkersCompleted = std::stoi(std::string(buf, len));
       if (numWorkersCompleted >= static_cast<int>(*numWorkers_)) {

--- a/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
@@ -372,7 +372,7 @@ void TCPStoreMasterDaemon::addHandler(int socket) {
 
   auto it = tcpStore_.find(key);
   if (it != tcpStore_.end()) {
-    auto buf = reinterpret_cast<const char*>(it->second.data());
+    const auto* buf = reinterpret_cast<const char*>(it->second.data());
     auto len = it->second.size();
     addVal += std::stoll(std::string(buf, len));
   }

--- a/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
@@ -77,7 +77,7 @@ class UvHandle : public c10::intrusive_ptr_target {
 
  private:
   static c10::intrusive_ptr<UvHandle> reclaim(uv_handle_t* handle) {
-    auto h = (UvHandle*)uv_handle_get_data(handle);
+    auto* h = (UvHandle*)uv_handle_get_data(handle);
     return c10::intrusive_ptr<UvHandle>::reclaim(h);
   }
 
@@ -96,7 +96,7 @@ class UvTcpSocket : public UvHandle {
   }
 
   static c10::intrusive_ptr<UvTcpSocket> borrow(uv_stream_t* handle) {
-    auto h = (UvTcpSocket*)uv_handle_get_data((uv_handle_t*)handle);
+    auto* h = (UvTcpSocket*)uv_handle_get_data((uv_handle_t*)handle);
     return h->iptr();
   }
 
@@ -333,7 +333,7 @@ class UvTcpServer : public UvTcpSocket {
   }
 
   static c10::intrusive_ptr<UvTcpServer> borrow(uv_stream_t* handle) {
-    auto h = (UvTcpServer*)uv_handle_get_data((uv_handle_t*)handle);
+    auto* h = (UvTcpServer*)uv_handle_get_data((uv_handle_t*)handle);
     return h->iptr();
   }
 
@@ -370,7 +370,7 @@ class WriterPayload : public c10::intrusive_ptr_target {
   static c10::intrusive_ptr<WriterPayload> reclaim(uv_write_t* request) {
     /* This method returns a intrusive_ptr that does not increase the refcount.
      */
-    auto h = (WriterPayload*)uv_req_get_data((uv_req_t*)request);
+    auto* h = (WriterPayload*)uv_req_get_data((uv_req_t*)request);
     return c10::intrusive_ptr<WriterPayload>::reclaim(h);
   }
 
@@ -1290,7 +1290,7 @@ int64_t LibUVStoreDaemon::add(const std::string& key, int64_t addVal) {
   auto it = tcpStore_.find(key);
   if (it != tcpStore_.end()) {
     oldData = it->second;
-    auto buf = reinterpret_cast<const char*>(it->second.data());
+    const auto* buf = reinterpret_cast<const char*>(it->second.data());
     auto len = it->second.size();
     addVal += std::stoll(std::string(buf, len));
   }
@@ -1318,7 +1318,7 @@ bool LibUVStoreDaemon::waitKeys(
     return true;
   }
   int numKeysToAwait = 0;
-  for (auto& key : keys) {
+  for (const auto& key : keys) {
     // Only count keys that have not already been set
     if (tcpStore_.find(key) == tcpStore_.end()) {
       waitingSockets_[key].push_back(client);

--- a/torch/csrc/distributed/c10d/TraceUtils.h
+++ b/torch/csrc/distributed/c10d/TraceUtils.h
@@ -97,7 +97,7 @@ inline std::string ranksToString(const std::vector<int>& ranks) {
 inline std::string ranksFromTrace(
     const std::vector<std::pair<int, std::string>>& items) {
   std::string ranks;
-  for (auto& p : items) {
+  for (const auto& p : items) {
     if (ranks.empty()) {
       ranks = std::to_string(p.first);
     } else {
@@ -119,7 +119,7 @@ inline std::string analyzeLaggingRanks(const TraceMap& traceMap) {
   uint64_t lagSeq = traceMap.begin()->first;
   std::vector<int> startRanks;
   std::vector<int> endRanks;
-  for (auto& p : traceMap.begin()->second) {
+  for (const auto& p : traceMap.begin()->second) {
     if (p.second.second == kEventStart) {
       startRanks.push_back(p.first);
     } else {

--- a/torch/csrc/distributed/c10d/Utils.cpp
+++ b/torch/csrc/distributed/c10d/Utils.cpp
@@ -20,7 +20,7 @@ std::vector<at::Tensor> getTensorShapes(
 
 size_t getTensorsNumel(const std::vector<at::Tensor>& tensors) {
   size_t numel = 0;
-  for (auto& tensor : tensors) {
+  for (const auto& tensor : tensors) {
     numel += tensor.numel();
   }
   return numel;

--- a/torch/csrc/distributed/c10d/control_plane/PythonHandlers.cpp
+++ b/torch/csrc/distributed/c10d/control_plane/PythonHandlers.cpp
@@ -16,7 +16,7 @@ RegisterHandler tracebackHandler{
     [](const Request&, Response& res) {
       auto tmpfile = c10::make_tempfile("torch-dump_traceback");
 
-      auto cfile = ::fopen(tmpfile.name.c_str(), "w");
+      auto* cfile = ::fopen(tmpfile.name.c_str(), "w");
       if (!cfile) {
         throw std::runtime_error("failed to open file for writing");
       }

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -171,7 +171,7 @@ std::vector<uint8_t> toVec8(const std::string& data) {
 std::vector<std::vector<uint8_t>> toVec8(const std::vector<std::string>& data) {
   std::vector<std::vector<uint8_t>> out;
   out.reserve(data.size());
-  for (auto& data_ : data) {
+  for (const auto& data_ : data) {
     out.emplace_back(toVec8(data_));
   }
   return out;
@@ -1097,7 +1097,7 @@ This class does not support ``__members__`` property.)");
           "buffer_ptrs",
           [](const c10::intrusive_ptr<SymmetricMemory>& symm_mem) {
             std::vector<uintptr_t> ret;
-            for (auto ptr : symm_mem->get_buffer_ptrs()) {
+            for (auto* ptr : symm_mem->get_buffer_ptrs()) {
               ret.push_back(reinterpret_cast<uintptr_t>(ptr));
             }
             return ret;
@@ -1111,7 +1111,7 @@ This class does not support ``__members__`` property.)");
           "signal_pad_ptrs",
           [](const c10::intrusive_ptr<SymmetricMemory>& symm_mem) {
             std::vector<uintptr_t> ret;
-            for (auto ptr : symm_mem->get_signal_pad_ptrs()) {
+            for (auto* ptr : symm_mem->get_signal_pad_ptrs()) {
               ret.push_back(reinterpret_cast<uintptr_t>(ptr));
             }
             return ret;

--- a/torch/csrc/distributed/c10d/logger.cpp
+++ b/torch/csrc/distributed/c10d/logger.cpp
@@ -103,7 +103,7 @@ void Logger::set_env_variables() {
         getCvarString({"GLOO_DEVICE_TRANSPORT"}, "N/A");
 
 #ifdef USE_C10D_GLOO
-    auto gloo_pg = static_cast<c10d::ProcessGroupGloo*>(
+    auto* gloo_pg = static_cast<c10d::ProcessGroupGloo*>(
         reducer_->process_group_
             ->getBackend(c10d::ProcessGroup::BackendType::GLOO)
             .get());

--- a/torch/csrc/distributed/c10d/socket.cpp
+++ b/torch/csrc/distributed/c10d/socket.cpp
@@ -262,7 +262,7 @@ struct formatter<c10d::detail::SocketImpl> {
       FormatContext& ctx) const {
     ::sockaddr_storage addr_s{};
 
-    auto addr_ptr = reinterpret_cast<::sockaddr*>(&addr_s);
+    auto* addr_ptr = reinterpret_cast<::sockaddr*>(&addr_s);
 
     ::socklen_t addr_len = sizeof(addr_s);
 
@@ -306,7 +306,7 @@ SocketImpl::~SocketImpl() {
 std::unique_ptr<SocketImpl> SocketImpl::accept() const {
   ::sockaddr_storage addr_s{};
 
-  auto addr_ptr = reinterpret_cast<::sockaddr*>(&addr_s);
+  auto* addr_ptr = reinterpret_cast<::sockaddr*>(&addr_s);
 
   ::socklen_t addr_len = sizeof(addr_s);
 

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -250,8 +250,8 @@ py::object PyRRef::createRRefProxy(
     float timeoutSeconds) const {
   auto& pythonRpcHandler = PythonRpcHandler::getInstance();
   pybind11::gil_scoped_acquire ag;
-  auto& functions = pythonRpcHandler.getRRefProxyFunctions();
-  auto& ctor = functions.rrefProxyCtor_;
+  const auto& functions = pythonRpcHandler.getRRefProxyFunctions();
+  const auto& ctor = functions.rrefProxyCtor_;
   switch (type) {
     case RRefProxyType::RPC_SYNC: {
       return ctor(*this, functions.rpcSync_, timeoutSeconds);
@@ -273,7 +273,7 @@ py::object PyRRef::getRRefType(float timeout, bool blocking) {
   if (!type_.has_value()) {
     pybind11::gil_scoped_release release;
     auto& pythonRpcHandler = PythonRpcHandler::getInstance();
-    auto& typeFuncs = pythonRpcHandler.getRRefTypeFunctions();
+    const auto& typeFuncs = pythonRpcHandler.getRRefTypeFunctions();
     pybind11::gil_scoped_acquire acquire;
     type_ = isOwner() ? typeFuncs.onOwner_(*this, blocking)
                       : typeFuncs.onUser_(*this, timeout, blocking);

--- a/torch/csrc/distributed/rpc/python_remote_call.cpp
+++ b/torch/csrc/distributed/rpc/python_remote_call.cpp
@@ -32,7 +32,7 @@ c10::intrusive_ptr<Message> PythonRemoteCall::toMessageImpl() && {
 
 std::unique_ptr<PythonRemoteCall> PythonRemoteCall::fromMessage(
     const Message& message) {
-  auto payload = static_cast<const char*>(message.payload().data());
+  const auto* payload = static_cast<const char*>(message.payload().data());
   auto payload_size = message.payload().size();
 
   auto value = jit::unpickle(

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -150,7 +150,7 @@ void RpcAgent::retryExpiredRpcs() {
     // the outcome of the current send. Then, we clean up the rpcRetryMap_.
     for (auto it = earliestRpcList.begin(); it != earliestRpcList.end();
          /* no increment */) {
-      auto& earliestRpc = *it;
+      const auto& earliestRpc = *it;
       c10::intrusive_ptr<JitFuture> jitFuture;
 
       // send() will throw an exception if an RPC is retried while the agent is

--- a/torch/csrc/distributed/rpc/rref_context.cpp
+++ b/torch/csrc/distributed/rpc/rref_context.cpp
@@ -304,9 +304,9 @@ void RRefContext::delAllUsersAndUnforkedOwners(
 c10::intrusive_ptr<RRef> RRefContext::getOrCreateRRef(
     const RRefForkData& rrefForkData,
     const TypePtr& type) {
-  auto& ownerId = rrefForkData.ownerId_;
-  auto& rrefId = rrefForkData.rrefId_;
-  auto& forkId = rrefForkData.forkId_;
+  const auto& ownerId = rrefForkData.ownerId_;
+  const auto& rrefId = rrefForkData.rrefId_;
+  const auto& forkId = rrefForkData.forkId_;
   if (ownerId == getWorkerId()) {
     return getOrCreateOwnerRRef(rrefId, type);
   } else {

--- a/torch/csrc/distributed/rpc/rref_proto.cpp
+++ b/torch/csrc/distributed/rpc/rref_proto.cpp
@@ -15,7 +15,7 @@ c10::ivalue::TupleElements toIValues(const Message& message, MessageType type) {
       type,
       ", but got ",
       message.type());
-  auto payload = static_cast<const char*>(message.payload().data());
+  const auto* payload = static_cast<const char*>(message.payload().data());
   auto payload_size = message.payload().size();
 
   auto value = jit::unpickle(

--- a/torch/csrc/distributed/rpc/script_call.cpp
+++ b/torch/csrc/distributed/rpc/script_call.cpp
@@ -49,7 +49,7 @@ std::vector<at::IValue>& ScriptCall::stackRef() {
 }
 
 void ScriptCall::toIValues(std::vector<at::IValue>& ivalues) const {
-  for (auto& value : stack_) {
+  for (const auto& value : stack_) {
     ivalues.push_back(value);
   }
 
@@ -127,7 +127,7 @@ c10::intrusive_ptr<Message> ScriptCall::toMessageImpl() && {
 }
 
 std::unique_ptr<ScriptCall> ScriptCall::fromMessage(const Message& message) {
-  auto payload = static_cast<const char*>(message.payload().data());
+  const auto* payload = static_cast<const char*>(message.payload().data());
   auto payload_size = message.payload().size();
   auto value = jit::unpickle(
       payload,

--- a/torch/csrc/distributed/rpc/script_remote_call.cpp
+++ b/torch/csrc/distributed/rpc/script_remote_call.cpp
@@ -65,7 +65,7 @@ c10::intrusive_ptr<Message> ScriptRemoteCall::toMessageImpl() && {
 
 std::unique_ptr<ScriptRemoteCall> ScriptRemoteCall::fromMessage(
     const Message& message) {
-  auto payload = static_cast<const char*>(message.payload().data());
+  const auto* payload = static_cast<const char*>(message.payload().data());
   auto payload_size = message.payload().size();
 
   auto value = jit::unpickle(

--- a/torch/csrc/distributed/rpc/script_resp.cpp
+++ b/torch/csrc/distributed/rpc/script_resp.cpp
@@ -20,7 +20,7 @@ c10::intrusive_ptr<Message> ScriptResp::toMessageImpl() && {
 }
 
 std::unique_ptr<ScriptResp> ScriptResp::fromMessage(const Message& message) {
-  auto payload = static_cast<const char*>(message.payload().data());
+  const auto* payload = static_cast<const char*>(message.payload().data());
   auto payload_size = message.payload().size();
   auto value = jit::unpickle(
       payload,

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -1198,7 +1198,7 @@ const WorkerInfo& TensorPipeAgent::getWorkerInfo(worker_id_t workerId) const {
 std::vector<WorkerInfo> TensorPipeAgent::getWorkerInfos() const {
   std::vector<WorkerInfo> workerInfos;
   workerInfos.reserve(workerNameToInfo_.size());
-  for (auto& item : workerNameToInfo_) {
+  for (const auto& item : workerNameToInfo_) {
     workerInfos.emplace_back(item.second);
   }
   return workerInfos;

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -120,7 +120,7 @@ struct TORCH_API TensorPipeRpcBackendOptions : public RpcBackendOptions {
     if (iter == deviceMaps.end()) {
       deviceMaps[workerName] = deviceMap;
     } else {
-      for (auto& entry : deviceMap) {
+      for (const auto& entry : deviceMap) {
         // c10::Device has no default constructor, hence map[device] dosn't work
         // In C++-17 we can use insert_or_assign.
         auto entryIter = iter->second.find(entry.first);

--- a/torch/csrc/distributed/rpc/utils.cpp
+++ b/torch/csrc/distributed/rpc/utils.cpp
@@ -506,7 +506,7 @@ std::vector<at::IValue> readWrappedPayload(
       payload.size(),
       " but additional payload size is ",
       additionalPayloadSize);
-  auto wrappedPayloadBegin =
+  const auto* wrappedPayloadBegin =
       static_cast<const char*>(message.payload().data()) + payload.size() -
       additionalPayloadSize;
   std::vector<torch::Tensor> tensorTable;
@@ -525,8 +525,8 @@ void populateRemoteProfiledEvents(
     const ProfilerConfig& profilingConfig,
     const std::vector<std::vector<LegacyEvent>>& eventLists) {
   // Gather all events into a vector
-  for (auto& l : eventLists) {
-    for (auto& e : l) {
+  for (const auto& l : eventLists) {
+    for (const auto& e : l) {
       profiledEvents.push_back(e);
     }
   }

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -140,7 +140,7 @@ struct TensorArgs {
     if (!tensor.defined()) {
       return _undefined;
     }
-    auto impl = tensor.unsafeGetTensorImpl();
+    auto* impl = tensor.unsafeGetTensorImpl();
     auto it = _args.find(impl);
     if (it == _args.end()) {
       TORCH_INTERNAL_ASSERT(create && inputs.size() == _next_id - 1);

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -1208,7 +1208,7 @@ class StorageOverlapChecker {
 
   void reset(bool overlapping) {
     auto& vec = _get(overlapping);
-    for (auto item : vec) {
+    for (auto* item : vec) {
       Py_DECREF(item);
     }
     vec.clear();
@@ -3113,7 +3113,7 @@ class TORCH_FUNCTION_MODE_STACK : public LeafGuard {
     Py_ssize_t len = PyList_Size(initial_stack.ptr());
     for (Py_ssize_t idx = 0; idx < len; idx++) {
       PyObject* mode = PyList_GetItem(initial_stack.ptr(), idx); // borrowed ref
-      auto type = Py_TYPE(mode);
+      auto* type = Py_TYPE(mode);
       this->_ref_stack.push_back(type);
     }
   }
@@ -4768,7 +4768,7 @@ PyObject* torch_c_dynamo_guards_init() {
   if (PyType_Ready(&GlobalStateGuardType) < 0)
     return nullptr;
 
-  auto m = PyModule_Create(&_module);
+  auto* m = PyModule_Create(&_module);
   if (m == nullptr)
     return nullptr;
 

--- a/torch/csrc/dynamo/utils.cpp
+++ b/torch/csrc/dynamo/utils.cpp
@@ -21,7 +21,7 @@ static struct PyModuleDef _module = {
     _methods.data()};
 
 PyObject* torch_c_dynamo_utils_init() {
-  auto m = PyModule_Create(&_module);
+  auto* m = PyModule_Create(&_module);
   if (m == nullptr)
     return nullptr;
 

--- a/torch/csrc/functorch/init.cpp
+++ b/torch/csrc/functorch/init.cpp
@@ -52,9 +52,9 @@ void _assert_wrapped_functional(
       at::functionalization::impl::isFunctionalTensor(wrapped));
   TORCH_INTERNAL_ASSERT(
       !at::functionalization::impl::isFunctionalTensor(unwrapped));
-  auto wrapped_impl =
+  auto* wrapped_impl =
       at::functionalization::impl::unsafeGetFunctionalWrapper(wrapped);
-  auto& wrapped_inner = wrapped_impl->value();
+  const auto& wrapped_inner = wrapped_impl->value();
   TORCH_INTERNAL_ASSERT(
       unwrapped.unsafeGetTensorImpl() == wrapped_inner.unsafeGetTensorImpl())
 }
@@ -66,12 +66,12 @@ void _propagate_functional_input_mutation(
       at::functionalization::impl::isFunctionalTensor(wrapped));
   TORCH_INTERNAL_ASSERT(
       !at::functionalization::impl::isFunctionalTensor(unwrapped));
-  auto wrapped_impl =
+  auto* wrapped_impl =
       at::functionalization::impl::unsafeGetFunctionalWrapper(wrapped);
   // Ensure that the input is up to date by committing any pending updates to
   // the alias.
   wrapped_impl->sync_();
-  auto& wrapped_inner = wrapped_impl->value();
+  const auto& wrapped_inner = wrapped_impl->value();
   // It would probably be more reasonable to check that the two tensors are
   // aliased, but we can't do that unless we give BatchedTensorImpl a notion of
   // storage.
@@ -171,7 +171,7 @@ Tensor _unwrap_functional_tensor(const Tensor& self, bool add_back_views) {
   // which case the current tensors should always be wrapped in a
   // FunctionalTensorWrapper.
   TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(self));
-  auto functional =
+  auto* functional =
       at::functionalization::impl::unsafeGetFunctionalWrapper(self);
 
   // when regenerating the (potentially mutated) input tensors, the

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -100,37 +100,37 @@ std::tuple<std::string, std::string> get_cpp_compile_command(
   std::string target_file = output_dir + filename + file_ext;
 
   std::string cflags_args = "";
-  for (auto& arg : compile_options["cflags"]) {
+  for (const auto& arg : compile_options["cflags"]) {
     cflags_args += "-" + arg.get<std::string>() + " ";
   }
 
   std::string definitions_args = "";
-  for (auto& arg : compile_options["definitions"]) {
+  for (const auto& arg : compile_options["definitions"]) {
     definitions_args += "-D " + arg.get<std::string>() + " ";
   }
 
   std::string include_dirs_args = "";
-  for (auto& arg : compile_options["include_dirs"]) {
+  for (const auto& arg : compile_options["include_dirs"]) {
     include_dirs_args += "-I" + arg.get<std::string>() + " ";
   }
 
   std::string ldflags_args = "";
-  for (auto& arg : compile_options["ldflags"]) {
+  for (const auto& arg : compile_options["ldflags"]) {
     ldflags_args += "-" + arg.get<std::string>() + " ";
   }
 
   std::string libraries_dirs_args = "";
-  for (auto& arg : compile_options["libraries_dirs"]) {
+  for (const auto& arg : compile_options["libraries_dirs"]) {
     libraries_dirs_args += "-L" + arg.get<std::string>() + " ";
   }
 
   std::string libraries_args = "";
-  for (auto& arg : compile_options["libraries"]) {
+  for (const auto& arg : compile_options["libraries"]) {
     libraries_args += "-l" + arg.get<std::string>() + " ";
   }
 
   std::string passthrough_parameters_args = "";
-  for (auto& arg : compile_options["passthrough_args"]) {
+  for (const auto& arg : compile_options["passthrough_args"]) {
     passthrough_parameters_args += arg.get<std::string>() + " ";
   }
 
@@ -320,7 +320,7 @@ void AOTIModelPackageLoader::load_metadata(const std::string& cpp_filename) {
 
   const nlohmann::json metadata_json_obj = load_json_file(metadata_json_path);
 
-  for (auto& item : metadata_json_obj.items()) {
+  for (const auto& item : metadata_json_obj.items()) {
     metadata_[item.key()] = item.value().get<std::string>();
   }
 }

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
@@ -22,7 +22,7 @@ void OSSProxyExecutor::prefill_stack_with_static_arguments(
 
   TORCH_CHECK(serialized_arg.size() == 1);
   std::string serialized_arg_type = serialized_arg.begin().key();
-  auto& serialized_arg_val = serialized_arg.begin().value();
+  const auto& serialized_arg_val = serialized_arg.begin().value();
 
   switch (schema_arg_type->kind()) {
     case c10::TypeKind::TensorType: {
@@ -348,7 +348,7 @@ void OSSProxyExecutor::get_input_info_from_serialized(
   int index = 0;
   for (const auto& named_argument : serialized_node["inputs"]) {
     const auto& arg = named_argument["arg"];
-    auto& schema_arg = schema_args[index];
+    const auto& schema_arg = schema_args[index];
 
     prefill_stack_with_static_arguments(
         index++, schema_arg.real_type(), arg, op_kernel);
@@ -374,9 +374,9 @@ void OSSProxyExecutor::get_output_info_from_serialized(
   for (const auto& serialized_output : serialized_node["outputs"]) {
     TORCH_CHECK(serialized_output.size() == 1);
     std::string serialized_output_type = serialized_output.begin().key();
-    auto& serialized_output_val = serialized_output.begin().value();
+    const auto& serialized_output_val = serialized_output.begin().value();
 
-    auto& schema_return = schema_returns[output_index];
+    const auto& schema_return = schema_returns[output_index];
     const at::TypePtr& schema_return_type = schema_return.real_type();
 
     switch (schema_return_type->kind()) {

--- a/torch/csrc/inductor/aoti_torch/tensor_converter.cpp
+++ b/torch/csrc/inductor/aoti_torch/tensor_converter.cpp
@@ -8,7 +8,7 @@ std::vector<AtenTensorHandle> unsafe_alloc_new_handles_from_tensors(
   std::vector<AtenTensorHandle> result;
   result.reserve(tensors.size());
   for (auto tensor : tensors) {
-    auto allocated = new at::Tensor(std::move(tensor));
+    auto* allocated = new at::Tensor(std::move(tensor));
     result.push_back(tensor_pointer_to_tensor_handle(allocated));
   }
   return result;

--- a/torch/csrc/inductor/resize_storage_bytes.cpp
+++ b/torch/csrc/inductor/resize_storage_bytes.cpp
@@ -40,7 +40,7 @@ static void resize_storage_bytes__functionalize(
     return;
   }
   // Don't functionalize, call the mutable op on the inner tensor.
-  auto functional_impl =
+  auto* functional_impl =
       at::functionalization::impl::unsafeGetFunctionalWrapper(variable);
   {
     at::AutoDispatchSkipFunctionalize guard;

--- a/torch/csrc/lazy/backend/backend_device.cpp
+++ b/torch/csrc/lazy/backend/backend_device.cpp
@@ -55,7 +55,7 @@ c10::Device backendDeviceToAtenDevice(const BackendDevice& device) {
 }
 
 std::optional<BackendDevice> GetBackendDevice(at::ITensorListRef tensors) {
-  for (auto& tensor : tensors) {
+  for (const auto& tensor : tensors) {
     if (auto lt = TryGetLtcTensor(tensor)) {
       return lt->GetDevice();
     }

--- a/torch/csrc/lazy/backend/backend_interface.cpp
+++ b/torch/csrc/lazy/backend/backend_interface.cpp
@@ -14,7 +14,7 @@ bool hasBackend() {
 }
 
 const BackendImplInterface* getBackend() {
-  auto* interface = backend_impl_registry.load();
+  const auto* interface = backend_impl_registry.load();
   TORCH_CHECK(interface, "Lazy tensor backend not registered.");
   return interface;
 }

--- a/torch/csrc/lazy/core/debug_util.cpp
+++ b/torch/csrc/lazy/core/debug_util.cpp
@@ -103,7 +103,7 @@ std::string DebugUtil::GetTensorsGraphInfo(
       }
     }
   } else {
-    for (auto& tensor : tensors) {
+    for (const auto& tensor : tensors) {
       torch::lazy::Value ir_value = tensor->CurrentIrValue();
       if (ir_value) {
         root_nodes.push_back(ir_value.node.get());

--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -77,7 +77,7 @@ Node::Node(
       std::make_move_iterator(shapes.begin()),
       std::make_move_iterator(shapes.end()));
 
-  for (auto& operand : operands) {
+  for (const auto& operand : operands) {
     // Ideally, optional operands should be filtered by the leaf node classes,
     // but it's just much easier to do it here.
     // TODO(alanwaketan): Find a way to move the below logic to the leaf node

--- a/torch/csrc/lazy/core/ir_dump_util.cpp
+++ b/torch/csrc/lazy/core/ir_dump_util.cpp
@@ -86,7 +86,7 @@ std::optional<AttrTag> ParseAttrTag(
 
 NodeIdMap GenerateIdMap(c10::ArrayRef<const Node*> post_order) {
   NodeIdMap id_map;
-  for (auto node : post_order) {
+  for (const auto* node : post_order) {
     TORCH_CHECK(id_map.emplace(node, id_map.size()).second, node->ToString());
   }
   return id_map;
@@ -163,7 +163,7 @@ std::string GenerateTextNodeSpec(const Node* node, const NodeIdMap& id_map) {
   std::stringstream ss;
   ss << node->shapes() << " " << node->op() << "(";
   size_t count = 0;
-  for (auto& output : node->operands()) {
+  for (const auto& output : node->operands()) {
     if (count > 0) {
       ss << ", ";
     }
@@ -194,7 +194,7 @@ std::string DumpUtil::PostOrderToDot(
   NodeIdMap id_map = GenerateIdMap(post_order);
   std::stringstream ss;
   ss << "digraph G {\n";
-  for (auto node : post_order) {
+  for (const auto* node : post_order) {
     ss << "  node" << id_map.at(node) << " ["
        << GenerateDotNodeSpec(node, roots_ids) << "]\n";
   }
@@ -234,7 +234,7 @@ std::string DumpUtil::PostOrderToText(
   NodeIdMap id_map = GenerateIdMap(post_order);
   std::stringstream ss;
   ss << "IR {\n";
-  for (auto node : post_order) {
+  for (const auto* node : post_order) {
     auto opt_root_id = GetRootNodeId(node, roots_ids);
     ss << "  %" << id_map.at(node) << " = "
        << GenerateTextNodeSpec(node, id_map);
@@ -252,7 +252,7 @@ std::string DumpUtil::ToBackend(
     c10::ArrayRef<Value> values,
     const BackendDevice& device) {
   auto lowering_ctx = LoweringContext::Create("IrToBackend", device);
-  for (auto& ir_value : values) {
+  for (const auto& ir_value : values) {
     lowering_ctx->AddResult(ir_value);
   }
   auto computation = lowering_ctx->Build();

--- a/torch/csrc/lazy/core/ir_metadata.cpp
+++ b/torch/csrc/lazy/core/ir_metadata.cpp
@@ -25,7 +25,7 @@ std::ostream& operator<<(
     std::ostream& stream,
     const std::vector<SourceLocation>& frames) {
   stream << "Frames:\n";
-  for (auto& location : frames) {
+  for (const auto& location : frames) {
     stream << "  " << location.function << " (" << location.file << ":"
            << location.line << ")\n";
   }

--- a/torch/csrc/lazy/core/ir_util.cpp
+++ b/torch/csrc/lazy/core/ir_util.cpp
@@ -17,7 +17,7 @@ std::vector<const Node*> Util::ComputePostOrder(
     auto it = emap->find(node);
     if (it == emap->end()) {
       (*emap)[node] = kEmitting;
-      for (auto& output : node->operands()) {
+      for (const auto& output : node->operands()) {
         auto oit = emap->find(output.node);
         if (oit == emap->end()) {
           node_stack.push(output.node);
@@ -29,7 +29,7 @@ std::vector<const Node*> Util::ComputePostOrder(
         }
       }
     } else if (it->second == kEmitting) {
-      for (auto& output : node->operands()) {
+      for (const auto& output : node->operands()) {
         auto oit = emap->find(output.node);
         TORCH_CHECK(
             oit != emap->end() && oit->second == kEmitted,
@@ -51,7 +51,7 @@ std::vector<const Node*> Util::ComputePostOrder(
     c10::ArrayRef<const Node*> nodes,
     EmissionMap* emap) {
   std::vector<const Node*> post_order;
-  for (auto node : nodes) {
+  for (const auto* node : nodes) {
     auto node_post_order = ComputePostOrder(node, emap);
     post_order.insert(
         post_order.end(), node_post_order.begin(), node_post_order.end());

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -171,7 +171,7 @@ void LazyGraphExecutor::DeviceContextArena::ForAllDeviceContexts(
     const std::function<void(DeviceContext*)>& fn,
     const BackendDevice* device) {
   if (device == nullptr) {
-    for (auto devctx : GetAllDeviceContexts()) {
+    for (auto* devctx : GetAllDeviceContexts()) {
       fn(devctx);
     }
   } else {
@@ -252,7 +252,7 @@ std::vector<ExceptionCleanup> LazyGraphExecutor::DeviceLockerArena::LockDevices(
     const std::set<BackendDevice>& devices) {
   std::vector<ExceptionCleanup> unlocker;
   unlocker.reserve(devices.size());
-  for (auto& device : devices) {
+  for (const auto& device : devices) {
     unlocker.emplace_back(LockDevice(device));
   }
   return unlocker;
@@ -435,7 +435,7 @@ void LazyGraphExecutor::MarkStep(const BackendDevice& device) {
 void LazyGraphExecutor::WaitDeviceOps(c10::ArrayRef<BackendDevice> devices) {
   std::set<BackendDevice> wait_devices;
   if (!devices.empty()) {
-    for (auto& device : devices) {
+    for (const auto& device : devices) {
       wait_devices.insert(device);
     }
   } else {
@@ -467,7 +467,7 @@ size_t LazyGraphExecutor::IncTrimCounter() const {
 std::string LazyGraphExecutor::DumpBackendComputation(
     const std::vector<LazyTensorPtr>& tensors) {
   std::vector<Value> ir_values;
-  for (auto& tensor : tensors) {
+  for (const auto& tensor : tensors) {
     Value ir_value = tensor->CurrentIrValue();
     if (ir_value) {
       ir_values.push_back(std::move(ir_value));
@@ -711,7 +711,7 @@ LazyGraphExecutor::PostOrderData LazyGraphExecutor::RunPostOrder(
   PostOrderData po_data;
   po_data.post_order = Util::ComputePostOrder(roots, &po_data.emission_map);
   std::unordered_map<BackendData::Handle, size_t> data_handles;
-  for (auto node : po_data.post_order) {
+  for (const auto* node : po_data.post_order) {
     const auto backend_data = getBackend()->GetComputationDataFromNode(node);
     if (backend_data) {
       /* Acceptable race condition: HasValue may return false. This is OK

--- a/torch/csrc/lazy/core/shape.cpp
+++ b/torch/csrc/lazy/core/shape.cpp
@@ -69,7 +69,7 @@ static c10::SymbolicShape get_symbolic_shape(at::Tensor& tensor) {
     return c10::SymbolicShape(tensor.sizes());
   }
   const Shape& input_shape = ltc_tensor->GetIrValue()->shape();
-  auto& is_symbolic = input_shape.is_symbolic();
+  const auto& is_symbolic = input_shape.is_symbolic();
   if (!is_symbolic.has_value()) {
     return c10::SymbolicShape();
   }

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -507,7 +507,7 @@ std::vector<Shape> compute_shape_cat(at::TensorList tensors, int64_t dim) {
 
   dim = at::maybe_wrap_dim(dim, tensors);
   size_t extended_dim_shape = 0;
-  for (auto& tensor : tensors) {
+  for (const auto& tensor : tensors) {
     extended_dim_shape += tensor.sizes()[dim];
   }
   TORCH_CHECK(!out_shape.empty(), "Scalar tensors are not supported in cat.");

--- a/torch/csrc/lazy/python/python_util.cpp
+++ b/torch/csrc/lazy/python/python_util.cpp
@@ -42,7 +42,7 @@ std::vector<SourceLocation> GetPythonFrames() {
       loc.file = THPUtils_unpackString(code->co_filename);
       loc.function = THPUtils_unpackString(code->co_name);
       frames.push_back(std::move(loc));
-      auto new_frame = PyFrame_GetBack(frame);
+      auto* new_frame = PyFrame_GetBack(frame);
       Py_DECREF(frame);
       frame = new_frame;
     }

--- a/torch/csrc/lazy/ts_backend/dynamic_ir.cpp
+++ b/torch/csrc/lazy/ts_backend/dynamic_ir.cpp
@@ -14,7 +14,8 @@ TSOpVector SizeNode::Lower(
   std::vector<torch::jit::NamedValue> arguments;
   std::vector<torch::jit::NamedValue> kwarguments;
   arguments.reserve(2);
-  auto index = loctx->graph()->insertConstant(static_cast<int64_t>(this->dim_));
+  auto* index =
+      loctx->graph()->insertConstant(static_cast<int64_t>(this->dim_));
   arguments.emplace_back(loctx->GetOutputOp(operand(0)));
   arguments.emplace_back(index);
   torch::lazy::TSOpVector size_out =

--- a/torch/csrc/lazy/ts_backend/ts_backend_impl.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_backend_impl.cpp
@@ -114,7 +114,7 @@ class TSBackendImpl : public torch::lazy::BackendImplInterface {
 
   torch::lazy::BackendDataPtr GetComputationDataFromNode(
       const Node* node) const override {
-    auto* device_data_node = DeviceData::Cast(node);
+    const auto* device_data_node = DeviceData::Cast(node);
     if (!device_data_node) {
       return nullptr;
     }
@@ -123,7 +123,7 @@ class TSBackendImpl : public torch::lazy::BackendImplInterface {
 
   std::string GetComputationBackendText(
       const torch::lazy::ComputationPtr computation) const override {
-    auto ts_computation =
+    auto* ts_computation =
         static_cast<torch::lazy::TSComputation*>(computation.get());
     return ts_computation->graph()->toString();
   }
@@ -194,7 +194,7 @@ torch::lazy::BackendDataPtr TSBackendImpl::CreateDataPlaceholder(
 std::vector<torch::lazy::ComputationPtr> TSBackendImpl::Compile(
     std::vector<torch::lazy::ComputationPtr> instances) const {
   for (const auto& instance : instances) {
-    auto ts_computation =
+    auto* ts_computation =
         static_cast<torch::lazy::TSComputation*>(instance.get());
     if (!ts_computation->in_mark_step) {
       LOG(WARNING) << "Compile outside of mark step";

--- a/torch/csrc/lazy/ts_backend/ts_lowering_context.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_lowering_context.cpp
@@ -28,13 +28,13 @@ TSLoweringContext::TSLoweringContext(
       graph_(std::make_shared<torch::jit::Graph>()),
       function_(
           std::make_shared<torch::jit::GraphFunction>(name, graph_, nullptr)) {
-  for (auto node : post_order) {
+  for (const auto* node : post_order) {
     Lower(node);
   }
 }
 
 void TSLoweringContext::Lower(const Node* node) {
-  if (auto* tsnode = dynamic_cast<const torch::lazy::TsNode*>(node)) {
+  if (const auto* tsnode = dynamic_cast<const torch::lazy::TsNode*>(node)) {
     // First, we call the node lowering function, which exists for newly
     // codegenned or refactored nodes
     TSOpVector ops = tsnode->Lower(function_, this);

--- a/torch/csrc/lazy/ts_backend/ts_lowering_context.h
+++ b/torch/csrc/lazy/ts_backend/ts_lowering_context.h
@@ -101,7 +101,7 @@ class TORCH_API TSLoweringContext : public LoweringContext {
     auto it = emitted_outputs_.find(output);
     if (it == emitted_outputs_.end()) {
       auto post_order = Util::ComputePostOrder(output.node, &emit_status_);
-      for (auto node : post_order) {
+      for (const auto* node : post_order) {
         Lower(node);
       }
       // At this point the output better be present, otherwise there is an issue

--- a/torch/csrc/lazy/ts_backend/ts_node.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_node.cpp
@@ -3,7 +3,7 @@
 
 namespace {
 std::string GetFirstUserFrameInPythonIfEnabled() {
-  static const auto LTC_ENABLE_SOURCE_INFO =
+  static auto* const LTC_ENABLE_SOURCE_INFO =
       std::getenv("LTC_ENABLE_SOURCE_INFO");
   if (!LTC_ENABLE_SOURCE_INFO) {
     return {};
@@ -21,7 +21,7 @@ static hash_t OperandHashes(
     const hash_t& seed,
     bool bakeInSizes) {
   hash_t hash = seed;
-  for (auto& operand : operands) {
+  for (const auto& operand : operands) {
     if (!operand) {
       hash = HashCombine(hash, static_cast<uint64_t>(kNullOpt));
       continue;
@@ -29,7 +29,7 @@ static hash_t OperandHashes(
     auto operand_hash = bakeInSizes ? operand.shapeHash() : operand.hash();
     hash = HashCombine(hash, operand_hash);
   }
-  for (auto& shape : shapes) {
+  for (const auto& shape : shapes) {
     hash = HashCombine(hash, shape.hash(bakeInSizes));
   }
   return hash;
@@ -95,7 +95,7 @@ TSOpVector TensorList::Lower(
     tensor_list.emplace_back(loctx->GetOutputOp(operand));
   }
   auto graph = function->graph();
-  auto listnode =
+  auto* listnode =
       graph->insertNode(graph->createList(tensor_list[0]->type(), tensor_list));
   return {listnode->output()};
 }

--- a/torch/csrc/lazy/ts_backend/ts_node_lowering.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_node_lowering.cpp
@@ -44,7 +44,7 @@ TSOpVector LowerTSBuiltin(
     const auto tuple_call_result = sv.asTuple({}, *function);
     TSOpVector tuple_result;
     for (const auto& tuple_component : tuple_call_result) {
-      auto tuple_component_sv =
+      auto* tuple_component_sv =
           dynamic_cast<torch::jit::SimpleValue*>(tuple_component.get());
       tuple_result.push_back(tuple_component_sv->getValue());
     }
@@ -90,8 +90,8 @@ torch::lazy::TSOpVector Cast::Lower(
 torch::lazy::TSOpVector DeviceData::Lower(
     std::shared_ptr<torch::jit::GraphFunction> function,
     torch::lazy::TSLoweringContext* loctx) const {
-  auto infoptr = data_->info();
-  auto deviceDataInfoPtr =
+  auto* infoptr = data_->info();
+  auto* deviceDataInfoPtr =
       (torch::lazy::LazyGraphExecutor::DeviceDataInfo*)infoptr;
   if (GRAPH_DUMP_ENABLED) {
     LOG(ERROR) << "Lowering device data node, tensor id "

--- a/torch/csrc/monitor/events.cpp
+++ b/torch/csrc/monitor/events.cpp
@@ -32,7 +32,7 @@ class EventHandlers {
   }
 
   static EventHandlers& get() noexcept {
-    static auto ehsPtr = new EventHandlers();
+    static auto* ehsPtr = new EventHandlers();
     return *ehsPtr;
   }
 

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -815,7 +815,7 @@ using result_activity_t = std::pair<Result*, libkineto::GenericTraceActivity*>;
 std::vector<result_activity_t> torch_events;
 
 for (const auto idx : c10::irange(cpu_trace->activities.size())) {
-  auto& profiler_result = results[idx];
+  const auto& profiler_result = results[idx];
   auto& activity = cpu_trace->activities[idx];
 
   // add information about an associated forward op, if a sequence number
@@ -936,7 +936,7 @@ class TransferEvents {
       std::vector<std::shared_ptr<Result>>& results,
       trace_ptr_t& trace)
       : results_{results} {
-    auto* trace_activities_ptr = trace->get()->activities();
+    const auto* trace_activities_ptr = trace->get()->activities();
     TORCH_INTERNAL_ASSERT(trace_activities_ptr != nullptr);
     trace_activities_ = *trace_activities_ptr;
     reassociate();

--- a/torch/csrc/profiler/combined_traceback.cpp
+++ b/torch/csrc/profiler/combined_traceback.cpp
@@ -11,7 +11,7 @@ std::shared_ptr<CapturedTraceback> CapturedTraceback::gather(
     bool cpp) {
   auto r = std::make_shared<CapturedTraceback>();
   if (python) {
-    auto p = python_support_.load();
+    auto* p = python_support_.load();
     while (p && r->frames_.empty()) {
       r->frames_ = p->gather();
       r->python_ = p;

--- a/torch/csrc/profiler/python/combined_traceback.cpp
+++ b/torch/csrc/profiler/python/combined_traceback.cpp
@@ -40,7 +40,7 @@ struct PythonTraceback : public CapturedTraceback::Python {
     while (f) {
       frames.emplace_back(
           CapturedTraceback::PyFrame{PyFrame_GetCode(f), PyFrame_GetLasti(f)});
-      auto f_back = PyFrame_GetBack(f);
+      auto* f_back = PyFrame_GetBack(f);
       Py_XDECREF(f);
       f = f_back;
     }
@@ -85,7 +85,7 @@ struct PythonTraceback : public CapturedTraceback::Python {
       }
     }
     for (const auto& f : to_symbolize) {
-      auto f_code = (PyCodeObject*)f.code;
+      auto* f_code = (PyCodeObject*)f.code;
       py::handle filename = f_code->co_filename;
       py::handle funcname = f_code->co_name;
       auto lineno = PyCode_Addr2Line(f_code, f.lasti);

--- a/torch/csrc/profiler/python/init.cpp
+++ b/torch/csrc/profiler/python/init.cpp
@@ -161,7 +161,7 @@ int RecordFunctionFast_init(
     PyObject* selfGeneric,
     PyObject* args,
     PyObject* kwargs) {
-  auto self = (RecordFunctionFast*)selfGeneric;
+  auto* self = (RecordFunctionFast*)selfGeneric;
   // NOLINTNEXTLINE(*-c-arrays*)
   constexpr const char* kwlist[] = {
       "name", "input_values", "keyword_values", nullptr};
@@ -203,7 +203,7 @@ int RecordFunctionFast_init(
 }
 
 void RecordFunctionFast_dealloc(PyObject* selfGeneric) {
-  auto self = (RecordFunctionFast*)selfGeneric;
+  auto* self = (RecordFunctionFast*)selfGeneric;
   Py_CLEAR(self->name);
   Py_CLEAR(self->input_values);
   Py_CLEAR(self->keyword_values);
@@ -216,7 +216,7 @@ void RecordFunctionFast_dealloc(PyObject* selfGeneric) {
 PyObject* RecordFunctionFast_enter(PyObject* selfGeneric, PyObject* unused) {
   HANDLE_TH_ERRORS
   if (torch::profiler::impl::ProfilerStateBase::get() != nullptr) {
-    auto self = (RecordFunctionFast*)selfGeneric;
+    auto* self = (RecordFunctionFast*)selfGeneric;
     TORCH_INTERNAL_ASSERT(
         !self->guard,
         "Trying to enter a new record_function_fast context but the guard is unexpectedly already set");
@@ -271,7 +271,7 @@ PyObject* RecordFunctionFast_enter(PyObject* selfGeneric, PyObject* unused) {
 PyObject* RecordFunctionFast_exit(PyObject* selfGeneric, PyObject* unused) {
   HANDLE_TH_ERRORS
   if (torch::profiler::impl::ProfilerStateBase::get() != nullptr) {
-    auto self = (RecordFunctionFast*)selfGeneric;
+    auto* self = (RecordFunctionFast*)selfGeneric;
     TORCH_INTERNAL_ASSERT(
         self->guard,
         "Trying to exit an active record_function_fast context but no guard is set");

--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -391,7 +391,7 @@ convertIValue(
     std::string tensor_shape, tensor_stride, tensor_type, tensor_value;
 
     const auto& tensor = val.toTensor();
-    const auto tensor_impl = tensor.unsafeGetTensorImpl();
+    auto* const tensor_impl = tensor.unsafeGetTensorImpl();
     if (tensor.defined() && !tensor_impl->has_symbolic_sizes_strides()) {
       // tensor shape
       tensor_shape = vectorToString(tensor.sizes().vec());
@@ -414,7 +414,7 @@ convertIValue(
     // symbolic sizes/strides implies t->storage_offset() will fail
     if (tensor_impl->has_storage() &&
         !tensor_impl->has_symbolic_sizes_strides()) {
-      auto& t_storage = tensor_impl->storage();
+      const auto& t_storage = tensor_impl->storage();
       storage_id = getObjectID(ob, t_storage.data());
       offset = tensor_impl->storage_offset();
       numel = tensor_impl->numel();
@@ -577,7 +577,7 @@ inline std::string getCommsNodeAttrs(const RecordFunction& fn) { // NOLINT
 
 #ifdef USE_DISTRIBUTED
   // We rely on paramcommsdebug object that is available in thread local info
-  auto debugInfo = dynamic_cast<ParamCommsDebugInfo*>(
+  auto* debugInfo = dynamic_cast<ParamCommsDebugInfo*>(
       c10::ThreadLocalDebugInfo::get(c10::DebugInfoKind::PARAM_COMMS_INFO));
   if (debugInfo == nullptr) {
     LOG(WARNING) << "ParamCommsDebugInfo not available for function: "
@@ -706,7 +706,7 @@ static void recordOperatorStart(
 static std::unique_ptr<ObserverContext> onFunctionEnter(
     const RecordFunction& fn) {
   using RunState = ExecutionTraceObserver::RunState;
-  auto ob = ObserverManager::get();
+  auto* ob = ObserverManager::get();
   if (ob != nullptr && ob->getState() == RunState::enabled) {
     // record op
     auto fc_ptr = std::make_unique<FunctionCallContext>();
@@ -745,12 +745,12 @@ static std::string json_str_escape(const std::string& str) {
 
 static void onFunctionExit(const RecordFunction& fn, ObserverContext* ctx_ptr) {
   using RunState = ExecutionTraceObserver::RunState;
-  auto ob = ObserverManager::get();
+  auto* ob = ObserverManager::get();
   if (ob == nullptr || ctx_ptr == nullptr) {
     return;
   }
   if (ob->getState() == RunState::enabled) {
-    auto fc_ptr = dynamic_cast<FunctionCallContext*>(ctx_ptr);
+    auto* fc_ptr = dynamic_cast<FunctionCallContext*>(ctx_ptr);
     // TORCH_INTERNAL_ASSERT(fc_ptr != nullptr);
     if (fc_ptr == nullptr) {
       LOG(WARNING) << "FunctionCallContext is nullptr.";
@@ -847,7 +847,7 @@ bool addExecutionTraceObserver(const std::string& output_file_path) {
 
     // check if the environment variable is set to force recording integer
     // tensors
-    auto env_variable =
+    auto* env_variable =
         getenv("ENABLE_PYTORCH_EXECUTION_TRACE_INTEGRAL_TENSOR_RANGE");
     if (env_variable != nullptr) {
       ob.record_integral_tensor_range = true;
@@ -869,7 +869,7 @@ bool addExecutionTraceObserver(const std::string& output_file_path) {
 }
 
 void removeExecutionTraceObserver() {
-  auto ob = ObserverManager::get();
+  auto* ob = ObserverManager::get();
   if (ob != nullptr) {
     if (ob->getState() != ExecutionTraceObserver::RunState::disabled) {
       disableExecutionTraceObserver();

--- a/torch/csrc/profiler/standalone/itt_observer.cpp
+++ b/torch/csrc/profiler/standalone/itt_observer.cpp
@@ -24,7 +24,7 @@ struct ITTThreadLocalState : ProfilerStateBase {
   }
 
   static ITTThreadLocalState* getTLS() {
-    auto tls = ProfilerStateBase::get(/*global=*/false);
+    auto* tls = ProfilerStateBase::get(/*global=*/false);
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
         tls == nullptr || tls->profilerType() == ActiveProfilerType::ITT);
     return static_cast<ITTThreadLocalState*>(tls);
@@ -50,7 +50,7 @@ void pushITTCallbacks(
       c10::DebugInfoKind::PROFILER_STATE,
       std::make_shared<ITTThreadLocalState>(config));
 
-  auto state_ptr = ITTThreadLocalState::getTLS();
+  auto* state_ptr = ITTThreadLocalState::getTLS();
   TORCH_INTERNAL_ASSERT(state_ptr, "Expected profiler state set");
 
   auto handle = at::addThreadLocalCallback(

--- a/torch/csrc/profiler/standalone/nvtx_observer.cpp
+++ b/torch/csrc/profiler/standalone/nvtx_observer.cpp
@@ -24,7 +24,7 @@ struct NVTXThreadLocalState : ProfilerStateBase {
   }
 
   static NVTXThreadLocalState* getTLS() {
-    auto tls = ProfilerStateBase::get(/*global=*/false);
+    auto* tls = ProfilerStateBase::get(/*global=*/false);
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
         tls == nullptr || tls->profilerType() == ActiveProfilerType::NVTX);
     return static_cast<NVTXThreadLocalState*>(tls);
@@ -66,7 +66,7 @@ std::pair<at::RecordFunctionHandle, int> NVTXThreadLocalState::getOpIdFromInput(
 static std::list<std::pair<at::RecordFunctionHandle, int>> flattenOpIdList(
     const c10::List<c10::IValue>& list) {
   std::list<std::pair<at::RecordFunctionHandle, int>> input_op_id_list;
-  auto state_ptr = NVTXThreadLocalState::getTLS();
+  auto* state_ptr = NVTXThreadLocalState::getTLS();
   TORCH_INTERNAL_ASSERT(state_ptr, "Expected profiler state set");
   for (const c10::IValue& input : list) {
     if (input.isTensor()) {
@@ -82,7 +82,7 @@ static std::list<std::pair<at::RecordFunctionHandle, int>> getInputTensorOpIds(
     const at::RecordFunction& fn) {
   std::pair<at::RecordFunctionHandle, int> undefined_op_pair(0, -1);
   std::list<std::pair<at::RecordFunctionHandle, int>> input_producer_ops_;
-  auto state_ptr = NVTXThreadLocalState::getTLS();
+  auto* state_ptr = NVTXThreadLocalState::getTLS();
   TORCH_INTERNAL_ASSERT(state_ptr, "Expected profiler state set");
   for (const c10::IValue& input_item : fn.inputs()) {
     if (input_item.isTensor()) {
@@ -109,13 +109,13 @@ static std::list<std::pair<at::RecordFunctionHandle, int>> getInputTensorOpIds(
 
 static void updateOutputTensorTracker(const at::RecordFunction& fn) {
   int output_nr = 0;
-  auto state_ptr = NVTXThreadLocalState::getTLS();
+  auto* state_ptr = NVTXThreadLocalState::getTLS();
   TORCH_INTERNAL_ASSERT(state_ptr, "Expected profiler state set");
   for (const c10::IValue& s_tensor : fn.outputs()) {
     if (s_tensor.isTensor()) {
       const at::Tensor& tensor = s_tensor.toTensor();
       if (tensor.defined()) {
-        auto ten_addr = tensor.unsafeGetTensorImpl();
+        auto* ten_addr = tensor.unsafeGetTensorImpl();
         state_ptr->setProducerTensorMap(ten_addr, fn.handle(), output_nr);
       }
     }
@@ -153,7 +153,7 @@ void pushNVTXCallbacks(
       c10::DebugInfoKind::PROFILER_STATE,
       std::make_shared<NVTXThreadLocalState>(config));
 
-  auto state_ptr = NVTXThreadLocalState::getTLS();
+  auto* state_ptr = NVTXThreadLocalState::getTLS();
   TORCH_INTERNAL_ASSERT(state_ptr, "Expected profiler state set");
 
   auto handle = at::addThreadLocalCallback(

--- a/torch/csrc/profiler/stubs/cuda.cpp
+++ b/torch/csrc/profiler/stubs/cuda.cpp
@@ -61,8 +61,8 @@ struct CUDAMethods : public ProfilerStubs {
   float elapsed(
       const ProfilerVoidEventStub* event_,
       const ProfilerVoidEventStub* event2_) const override {
-    auto event = (const ProfilerEventStub*)(event_);
-    auto event2 = (const ProfilerEventStub*)(event2_);
+    const auto* event = (const ProfilerEventStub*)(event_);
+    const auto* event2 = (const ProfilerEventStub*)(event2_);
     TORCH_CUDA_CHECK(cudaEventSynchronize(event->get()));
     TORCH_CUDA_CHECK(cudaEventSynchronize(event2->get()));
     float ms = 0;

--- a/torch/csrc/profiler/unwind/fast_symbolizer.h
+++ b/torch/csrc/profiler/unwind/fast_symbolizer.h
@@ -26,7 +26,7 @@ struct FastSymbolizer {
     frame.funcname = "??";
     frame.filename = library;
     frame.lineno = offset;
-    auto s = getOrCreateSections(library);
+    auto* s = getOrCreateSections(library);
     if (auto e = s->findSubprogramName(offset)) {
       frame.funcname = *e;
     } else {
@@ -84,7 +84,7 @@ struct FastSymbolizer {
       Sections* s,
       uint64_t offset) {
     if (auto idx = s->findDebugInfoOffset(offset)) {
-      auto r = line_number_programs_.at(*idx).get();
+      auto* r = line_number_programs_.at(*idx).get();
       try {
         r->parse();
       } catch (UnwindError& err) {

--- a/torch/csrc/profiler/unwind/fde.h
+++ b/torch/csrc/profiler/unwind/fde.h
@@ -68,7 +68,7 @@ struct FDE {
     if (augmentation_string_ && *augmentation_string_ == 'z') {
       augmentation_length_ = static_cast<int64_t>(LC.readULEB128());
       Lexer A(LC.loc());
-      for (auto ap = augmentation_string_ + 1; *ap; ap++) {
+      for (const auto* ap = augmentation_string_ + 1; *ap; ap++) {
         switch (*ap) {
           case 'L':
             lsda_enc = A.read<uint8_t>();
@@ -317,7 +317,7 @@ struct FDE {
             auto reg = L.readULEB128();
             auto len = L.readULEB128();
             // NOLINTNEXTLINE(performance-no-int-to-ptr)
-            auto end = (void*)((uint64_t)L.loc() + len);
+            auto* end = (void*)((uint64_t)L.loc() + len);
             auto op = L.read<uint8_t>();
             if ((op & 0xF0) == 0x70) { // DW_bregX
               auto rhs_reg = (op & 0xF);
@@ -333,7 +333,7 @@ struct FDE {
           case DW_CFA_def_cfa_expression: {
             auto len = L.readULEB128();
             // NOLINTNEXTLINE(performance-no-int-to-ptr)
-            auto end = (void*)((uint64_t)L.loc() + len);
+            auto* end = (void*)((uint64_t)L.loc() + len);
             auto op = L.read<uint8_t>();
             if ((op & 0xF0) == 0x70) { // DW_bregX
               auto rhs_reg = (op & 0xF);

--- a/torch/csrc/profiler/unwind/lexer.h
+++ b/torch/csrc/profiler/unwind/lexer.h
@@ -18,7 +18,7 @@ struct LexerImpl {
   template <typename T>
   T read() {
     T result;
-    auto end = next_ + sizeof(T);
+    const auto* end = next_ + sizeof(T);
     UNWIND_CHECK(
         !checked || end <= end_,
         "read out of bounds {} >= {}",
@@ -67,7 +67,7 @@ struct LexerImpl {
     return Value;
   }
   const char* readCString() {
-    auto result = next_;
+    const auto* result = next_;
     if (!checked) {
       next_ += strlen(next_) + 1;
       return result;

--- a/torch/csrc/profiler/unwind/line_number_program.h
+++ b/torch/csrc/profiler/unwind/line_number_program.h
@@ -115,7 +115,7 @@ struct LineNumberProgram {
     } else {
       include_directories_.emplace_back(""); // implicit cwd
       while (true) {
-        auto str = L.readCString();
+        const auto* str = L.readCString();
         if (*str == '\0') {
           break;
         }
@@ -124,7 +124,7 @@ struct LineNumberProgram {
       file_names_.emplace_back("");
       file_directory_index_.emplace_back(0);
       while (true) {
-        auto str = L.readCString();
+        const auto* str = L.readCString();
         if (*str == '\0') {
           break;
         }

--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -152,9 +152,9 @@ struct UnwindCache {
         [](struct dl_phdr_info* info,
            size_t size [[maybe_unused]],
            void* data) {
-          auto self = (UnwindCache*)data;
+          auto* self = (UnwindCache*)data;
           uint64_t last_addr = 0;
-          auto segments = (Elf64_Phdr*)info->dlpi_phdr;
+          auto* segments = (Elf64_Phdr*)info->dlpi_phdr;
           for (auto i : c10::irange(info->dlpi_phnum)) {
             if (segments[i].p_type == PT_LOAD) {
               auto begin = ((uint64_t)info->dlpi_addr + segments[i].p_vaddr);
@@ -166,7 +166,7 @@ struct UnwindCache {
               if (library_name.empty()) {
                 library_name = process_name();
               }
-              auto eh_frame_hdr =
+              auto* eh_frame_hdr =
                   // NOLINTNEXTLINE(performance-no-int-to-ptr)
                   (void*)(segments[i].p_vaddr + info->dlpi_addr);
               self->all_libraries_.emplace_back(
@@ -227,7 +227,7 @@ struct UnwindCache {
       refreshLibraries();
       last_version_ = current_version;
     }
-    auto* r = searchFor(addr);
+    const auto* r = searchFor(addr);
     if (!r) {
       if (current_version.adds_ != last_version_.adds_) {
         refreshLibraries();
@@ -239,7 +239,7 @@ struct UnwindCache {
   }
 
   const LibraryInfo& libraryFor(uint64_t addr) {
-    auto* r = findLibraryFor(addr);
+    const auto* r = findLibraryFor(addr);
     if (!r) {
       for ([[maybe_unused]] const auto& l : libraries_with_no_unwind_) {
         TORCH_WARN("Did not find a PT_GNU_EH_FRAME segment for ", l);
@@ -321,7 +321,7 @@ static std::string dladdr_lookup(void* addr) {
 
 struct Symbolizer {
   Symbolizer() {
-    auto envar = std::getenv("TORCH_ADDR2LINE_BINARY");
+    auto* envar = std::getenv("TORCH_ADDR2LINE_BINARY");
     if (envar != nullptr) {
       // currently we take user's input as is without checking
       addr2line_binary_ = envar;
@@ -474,12 +474,12 @@ static std::vector<Frame> symbolize_addr2line(
     const std::vector<void*>& frames) {
   auto guard = Symbolizer::guard();
   Symbolizer& s = Symbolizer::get();
-  for (auto f : frames) {
+  for (auto* f : frames) {
     s.request(f);
   }
   std::vector<Frame> results;
   results.reserve(frames.size());
-  for (auto f : frames) {
+  for (auto* f : frames) {
     results.emplace_back(s.lookup(f));
   }
   return results;

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -126,9 +126,9 @@ std::vector<FileLineFunc> prepareCallstack(
   std::vector<FileLineFunc> entries;
   entries.reserve(cs.size());
   for (const auto& entry : cs) {
-    auto& range = entry.range;
+    const auto& range = entry.range;
     if (range.source()) {
-      auto& src = range.source();
+      const auto& src = range.source();
       if (src && src->filename()) {
         auto line =
             src->starting_line_no() + src->lineno_for_offset(range.start());
@@ -454,7 +454,7 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
     const SaveNcclMetaConfig& config) {
   std::unordered_map<std::string, std::string> map;
 #ifdef USE_DISTRIBUTED
-  auto debugInfo = dynamic_cast<ParamCommsDebugInfo*>(
+  auto* debugInfo = dynamic_cast<ParamCommsDebugInfo*>(
       c10::ThreadLocalDebugInfo::get(c10::DebugInfoKind::PARAM_COMMS_INFO));
 
   if (config.introspectMetadata) {
@@ -463,7 +463,7 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
                    << fn.name();
       return map;
     }
-    auto& collective_name = debugInfo->getCollectiveName();
+    const auto& collective_name = debugInfo->getCollectiveName();
     map.emplace(kCommsName, fmt::format("\"{}\"", collective_name));
     map.emplace(
         kDtype, fmt::format("\"{}\"", c10::toString(debugInfo->getDType())));
@@ -471,10 +471,10 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
     map.emplace(
         kOutMsgNelems, std::to_string(debugInfo->getOutMessageNelems()));
 
-    auto& inSplitSizes = debugInfo->getInputSplitSizes();
+    const auto& inSplitSizes = debugInfo->getInputSplitSizes();
     map.emplace(kInSplit, format_list(inSplitSizes, config.truncate));
 
-    auto& outSplitSizes = debugInfo->getOutputSplitSizes();
+    const auto& outSplitSizes = debugInfo->getOutputSplitSizes();
     map.emplace(kOutSplit, format_list(outSplitSizes, config.truncate));
 
     auto globalRankStart = debugInfo->getGlobalRankStart();
@@ -486,15 +486,15 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
       map.emplace(kGlobalRankStride, std::to_string(globalRankStride));
     }
     map.emplace(kGroupSize, std::to_string(debugInfo->getWorldSize()));
-    auto& group_name = debugInfo->getProcessGroupName();
+    const auto& group_name = debugInfo->getProcessGroupName();
     if (!group_name.empty()) {
       map.emplace(kProcessGroupName, fmt::format("\"{}\"", group_name));
     }
-    auto& group_desc = debugInfo->getProcessGroupDesc();
+    const auto& group_desc = debugInfo->getProcessGroupDesc();
     if (!group_desc.empty()) {
       map.emplace(kProcessGroupDesc, fmt::format("\"{}\"", group_desc));
     }
-    auto& groupRanks = debugInfo->getGroupRanks();
+    const auto& groupRanks = debugInfo->getGroupRanks();
     map.emplace(kGroupRanks, format_list(groupRanks, config.truncate));
 
     auto rank = debugInfo->getRank();
@@ -923,7 +923,7 @@ uint64_t computeFlops(
 // Currently it returns int representation of the last 20 bits of the address
 // value
 int getTensorStartHint(const at::Tensor& t) {
-  const auto tensor_impl = t.unsafeGetTensorImpl();
+  auto* const tensor_impl = t.unsafeGetTensorImpl();
   uintptr_t storage_addr = 0;
   storage_addr = reinterpret_cast<uintptr_t>(tensor_impl->storage().data());
   int last_bits = static_cast<int>(storage_addr & 0xFFFFF);

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -93,7 +93,7 @@ static PyObject* Tensor_new(
 // we add...
 static PyObject* Tensor_instancecheck(PyObject* _self, PyObject* arg) {
   HANDLE_TH_ERRORS
-  auto self = (PyTensorType*)_self;
+  auto* self = (PyTensorType*)_self;
   if (THPVariable_Check(arg)) {
     const auto& var = THPVariable_Unpack(arg);
     // NB: This is a little unfortunate, in that if I do an isinstance check
@@ -224,7 +224,7 @@ static std::string get_name(Backend backend, ScalarType scalarType) {
 }
 
 static THPObjectPtr get_storage_obj(Backend backend, ScalarType dtype) {
-  auto module_name = torch::utils::backend_to_string(backend);
+  const auto* module_name = torch::utils::backend_to_string(backend);
   auto module_obj = THPObjectPtr(PyImport_ImportModule(module_name));
   if (!module_obj)
     throw python_error();
@@ -268,7 +268,7 @@ static THPObjectPtr get_tensor_dict() {
   if (!tensor_class)
     throw python_error();
 
-  auto tensor_type = (PyTypeObject*)tensor_class.get();
+  auto* tensor_type = (PyTypeObject*)tensor_class.get();
   TORCH_CHECK(tensor_type->tp_base, "missing base type for Tensor");
 
   auto res = THPObjectPtr(PyDict_New());
@@ -401,7 +401,7 @@ static void py_bind_tensor_types(
   if (!tensor_classes)
     throw python_error();
 
-  for (auto& tensor_type : tensor_types) {
+  for (const auto& tensor_type : tensor_types) {
     auto name = std::string(tensor_type->name);
     auto idx = name.rfind('.');
     auto type_name = name.substr(idx + 1);

--- a/torch/csrc/utils/cpp_stacktraces.cpp
+++ b/torch/csrc/utils/cpp_stacktraces.cpp
@@ -8,7 +8,7 @@
 namespace torch {
 namespace {
 bool compute_cpp_stack_traces_enabled() {
-  auto envar = std::getenv("TORCH_SHOW_CPP_STACKTRACES");
+  auto* envar = std::getenv("TORCH_SHOW_CPP_STACKTRACES");
   if (envar) {
     if (strcmp(envar, "0") == 0) {
       return false;
@@ -25,7 +25,7 @@ bool compute_cpp_stack_traces_enabled() {
 }
 
 bool compute_disable_addr2line() {
-  auto envar = std::getenv("TORCH_DISABLE_ADDR2LINE");
+  auto* envar = std::getenv("TORCH_DISABLE_ADDR2LINE");
   if (envar) {
     if (strcmp(envar, "0") == 0) {
       return false;
@@ -48,7 +48,7 @@ bool get_cpp_stacktraces_enabled() {
 }
 
 static torch::unwind::Mode compute_symbolize_mode() {
-  auto envar_c = std::getenv("TORCH_SYMBOLIZE_MODE");
+  auto* envar_c = std::getenv("TORCH_SYMBOLIZE_MODE");
   if (envar_c) {
     std::string envar = envar_c;
     if (envar == "dladdr") {

--- a/torch/csrc/utils/disable_torch_function.cpp
+++ b/torch/csrc/utils/disable_torch_function.cpp
@@ -275,7 +275,7 @@ PyObject* THPModule_disable_torch_dispatch(PyObject* self, PyObject* a) {
       // included in AFTER, so it is included in the negation (and that's
       // correct: we want to exclude Python key and everything BEFORE it.)
   );
-  auto r = PyObject_Call(func, py_args.ptr(), kwargs);
+  auto* r = PyObject_Call(func, py_args.ptr(), kwargs);
   if (r == nullptr)
     throw python_error();
   return r;

--- a/torch/csrc/utils/invalid_arguments.cpp
+++ b/torch/csrc/utils/invalid_arguments.cpp
@@ -321,9 +321,9 @@ std::string _argDesc(
     const std::vector<PyObject*>& arguments,
     const std::unordered_map<std::string, PyObject*>& kwargs) {
   std::string result = "(";
-  for (auto& arg : arguments)
+  for (const auto& arg : arguments)
     result += std::string(py_typename(arg)) + ", ";
-  for (auto& kwarg : kwargs)
+  for (const auto& kwarg : kwargs)
     result += kwarg.first + "=" + py_typename(kwarg.second) + ", ";
   if (!arguments.empty())
     result.erase(result.length() - 2);
@@ -341,7 +341,7 @@ std::vector<std::string> _tryMatchKwargs(
     start_idx--;
   if (start_idx < 0)
     start_idx = 0;
-  for (auto& entry : kwargs) {
+  for (const auto& entry : kwargs) {
     bool found = false;
     for (unsigned int i = start_idx; i < option.arguments.size(); i++) {
       if (option.arguments[i].name == entry.first) {
@@ -413,7 +413,7 @@ std::string format_invalid_args(
     error_msg += "got ";
     error_msg += _argDesc(args, kwargs);
     error_msg += ", but expected one of:\n";
-    for (auto& option_str : options) {
+    for (const auto& option_str : options) {
       auto pair = _parseOption(option_str, kwargs);
       auto& option = pair.first;
       auto& printable_option_str = pair.second;

--- a/torch/csrc/utils/pybind.cpp
+++ b/torch/csrc/utils/pybind.cpp
@@ -17,10 +17,10 @@ bool type_caster<c10::SymInt>::load(py::handle src, bool) {
     return true;
   }
 
-  auto raw_obj = src.ptr();
+  auto* raw_obj = src.ptr();
 
   if (THPVariable_Check(raw_obj)) {
-    auto& var = THPVariable_Unpack(raw_obj);
+    const auto& var = THPVariable_Unpack(raw_obj);
     if (var.numel() == 1 &&
         at::isIntegralType(var.dtype().toScalarType(), /*include_bool*/ true)) {
       auto scalar = var.item();
@@ -69,7 +69,7 @@ bool type_caster<c10::SymFloat>::load(py::handle src, bool) {
     return true;
   }
 
-  auto raw_obj = src.ptr();
+  auto* raw_obj = src.ptr();
   if (THPUtils_checkDouble(raw_obj)) {
     value = c10::SymFloat{THPUtils_unpackDouble(raw_obj)};
     return true;
@@ -99,7 +99,7 @@ bool type_caster<c10::SymBool>::load(py::handle src, bool) {
     return true;
   }
 
-  auto raw_obj = src.ptr();
+  auto* raw_obj = src.ptr();
   if (THPUtils_checkBool(raw_obj)) {
     value = c10::SymBool{THPUtils_unpackBool(raw_obj)};
     return true;

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -292,7 +292,7 @@ static py::object dispatch_on_subclass(
     std::optional<c10::impl::TorchDispatchModeKey> maybe_mode_key =
         std::nullopt) {
   py::object ret;
-  for (auto& arg : overloaded_args) {
+  for (const auto& arg : overloaded_args) {
     py::object torch_function =
         PyObject_FastGetAttrString(arg, torch_function_name_str);
     if (!torch_function) {
@@ -471,7 +471,7 @@ auto handle_torch_function_no_python_arg_parser(
   // necessarily types
   std::vector<py::object> overloaded_types;
   overloaded_types.reserve(overloaded_args.size());
-  for (auto& arg : overloaded_args) {
+  for (const auto& arg : overloaded_args) {
     overloaded_types.push_back(
         py::reinterpret_borrow<py::object>(get_type_of_overloaded_arg(arg)));
   }
@@ -581,7 +581,7 @@ auto handle_torch_function_no_python_arg_parser(
     if (mode_obj) {
       ss << "  - mode object " << py::repr(mode_obj) << "\n";
     }
-    for (auto& arg : overloaded_args) {
+    for (const auto& arg : overloaded_args) {
       ss << "  - tensor subclass " << py::repr(get_type_of_overloaded_arg(arg))
          << "\n";
     }
@@ -866,7 +866,7 @@ static bool is_int_or_symint(PyObject* obj) {
   // that we still allow for fake tensors in this case, but
   // for regular tensors it's redundant with the test below.
   if (THPVariable_Check(obj)) {
-    auto& var = THPVariable_Unpack(obj);
+    const auto& var = THPVariable_Unpack(obj);
     if (TORCH_GUARD_SIZE_OBLIVIOUS(var.sym_numel().sym_eq(1)) &&
         at::isIntegralType(var.dtype().toScalarType(), /*include_bool*/ true)) {
       return true;
@@ -1362,7 +1362,7 @@ std::string FunctionSignature::toString() const {
   bool keyword_already = false;
   ss << "(";
   int i = 0;
-  for (auto& param : params) {
+  for (const auto& param : params) {
     if (i != 0) {
       ss << ", ";
     }
@@ -1409,7 +1409,7 @@ std::string FunctionSignature::toString() const {
   int num_missing = 0;
   std::stringstream ss;
 
-  auto& params = signature.params;
+  const auto& params = signature.params;
   for (auto it = params.begin() + idx; it != params.end(); ++it) {
     if (!it->optional) {
       if (num_missing > 0) {
@@ -1621,7 +1621,7 @@ PythonArgParser::PythonArgParser(
     bool traceable)
     : max_args(0), traceable(traceable) {
   int index = 0;
-  for (auto& fmt : fmts) {
+  for (const auto& fmt : fmts) {
     signatures_.emplace_back(fmt, index);
     ++index;
   }
@@ -1720,7 +1720,7 @@ void PythonArgParser::print_error(
 
 std::vector<std::string> PythonArgParser::get_signatures() const {
   std::vector<std::string> options;
-  for (auto& signature : signatures_) {
+  for (const auto& signature : signatures_) {
     if (!signature.hidden) {
       options.push_back(signature.toString());
     }
@@ -1803,7 +1803,7 @@ at::Tensor PythonArgs::tensor_slow(int i) {
 
 at::Scalar PythonArgs::scalar_slow(int i) {
   if (traceable && jit::tracer::isTracing() && THPVariable_Check(args[i])) {
-    auto& var = THPVariable_Unpack(args[i]);
+    const auto& var = THPVariable_Unpack(args[i]);
     jit::tracer::ArgumentStash::stashValue(
         signature.params[i].name, idx, var, c10::NumberType::get());
   }

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -506,7 +506,7 @@ inline std::vector<int64_t> PythonArgs::intlist(int i) {
 
 inline PyObject* toPyObject(const c10::SymInt& symint) {
   if (symint.is_symbolic()) {
-    auto r = py::cast(symint).release().ptr();
+    auto* r = py::cast(symint).release().ptr();
     TORCH_INTERNAL_ASSERT(r);
     return r;
   } else {
@@ -565,7 +565,7 @@ inline std::vector<c10::SymInt> PythonArgs::symintlist(int i) {
     // Elements of torch.Size are tensors during tracing, and we need to
     // record extra information before they are turned into an IntArrayRef
     if (traceable && jit::tracer::isTracing() && THPVariable_Check(obj)) {
-      auto& var = THPVariable_Unpack(obj);
+      const auto& var = THPVariable_Unpack(obj);
       jit::tracer::ArgumentStash::stashIntArrayRefElem(
           signature.params[i].name, size2, idx, var);
       try {
@@ -586,7 +586,7 @@ inline std::vector<c10::SymInt> PythonArgs::symintlist(int i) {
           throw_intlist_exception(this, i, obj, idx, e);
         }
       } else if (THPVariable_Check(obj)) {
-        auto& var = THPVariable_Unpack(obj);
+        const auto& var = THPVariable_Unpack(obj);
         if (var.numel() != 1 ||
             !at::isIntegralType(
                 var.dtype().toScalarType(), /*include_bool*/ true)) {
@@ -637,7 +637,7 @@ inline std::vector<int64_t> PythonArgs::intlistWithDefault(
     // Elements of torch.Size are tensors during tracing, and we need to
     // record extra information before they are turned into an IntArrayRef
     if (traceable && jit::tracer::isTracing() && THPVariable_Check(obj)) {
-      auto& var = THPVariable_Unpack(obj);
+      const auto& var = THPVariable_Unpack(obj);
       jit::tracer::ArgumentStash::stashIntArrayRefElem(
           signature.params[i].name, size2, idx, var);
       try {
@@ -660,7 +660,7 @@ inline std::vector<int64_t> PythonArgs::intlistWithDefault(
         res[idx] = py::cast<c10::SymInt>(py::handle(obj))
                        .guard_int(__FILE__, __LINE__);
       } else if (THPVariable_Check(obj)) {
-        auto& var = THPVariable_Unpack(obj);
+        const auto& var = THPVariable_Unpack(obj);
         if (var.numel() != 1 ||
             !at::isIntegralType(
                 var.dtype().toScalarType(), /*include_bool*/ true)) {
@@ -786,7 +786,7 @@ inline std::optional<at::ScalarType> PythonArgs::scalartypeOptional(int i) {
 }
 
 inline at::Layout toLayout(PyObject* obj) {
-  const auto layout = reinterpret_cast<THPLayout*>(obj);
+  auto* const layout = reinterpret_cast<THPLayout*>(obj);
   return layout->layout;
 }
 
@@ -820,7 +820,7 @@ inline at::Device deviceFromLong(int64_t device_index) {
 
 inline at::Device toDevice(PyObject* obj) {
   if (THPDevice_Check(obj)) {
-    const auto device = reinterpret_cast<THPDevice*>(obj);
+    auto* const device = reinterpret_cast<THPDevice*>(obj);
     return device->device;
   }
   if (THPUtils_checkLong(obj)) {
@@ -899,7 +899,7 @@ inline at::MemoryFormat PythonArgs::memoryformat(int i) {
   TORCH_CHECK(
       THPMemoryFormat_Check(args[i]),
       "memory_format arg must be an instance of the torch.memory_format");
-  const auto memory_format = reinterpret_cast<THPMemoryFormat*>(args[i]);
+  auto* const memory_format = reinterpret_cast<THPMemoryFormat*>(args[i]);
   return memory_format->memory_format;
 }
 
@@ -915,7 +915,7 @@ inline at::QScheme PythonArgs::toQScheme(int i) {
   TORCH_CHECK(
       THPQScheme_Check(args[i]),
       "qscheme arg must be an instance of the torch.qscheme");
-  const auto qscheme = reinterpret_cast<THPQScheme*>(args[i]);
+  auto* const qscheme = reinterpret_cast<THPQScheme*>(args[i]);
   return qscheme->qscheme;
 }
 
@@ -959,7 +959,7 @@ inline int64_t PythonArgs::toInt64(int i) {
   if (!args[i])
     return signature.params[i].default_int;
   if (traceable && jit::tracer::isTracing() && THPVariable_Check(args[i])) {
-    auto& var = THPVariable_Unpack(args[i]);
+    const auto& var = THPVariable_Unpack(args[i]);
     jit::tracer::ArgumentStash::stashValue(
         signature.params[i].name, idx, var, c10::IntType::get());
   }
@@ -976,7 +976,7 @@ inline c10::SymInt PythonArgs::toSymInt(int i) {
   }
 
   if (traceable && jit::tracer::isTracing() && THPVariable_Check(args[i])) {
-    auto& var = THPVariable_Unpack(args[i]);
+    const auto& var = THPVariable_Unpack(args[i]);
     jit::tracer::ArgumentStash::stashValue(
         signature.params[i].name, idx, var, c10::IntType::get());
   }
@@ -989,7 +989,7 @@ inline c10::SymBool PythonArgs::toSymBool(int i) {
     return c10::SymBool(signature.params[i].default_bool);
   }
   if (traceable && jit::tracer::isTracing() && THPVariable_Check(args[i])) {
-    auto& var = THPVariable_Unpack(args[i]);
+    const auto& var = THPVariable_Unpack(args[i]);
     jit::tracer::ArgumentStash::stashValue(
         signature.params[i].name, idx, var, c10::BoolType::get());
   }

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -898,7 +898,7 @@ void initDispatchBindings(PyObject* module) {
   m.def(
       "_dispatch_set_report_error_callback",
       [](c10::OperatorHandle& handle, py::object callback) {
-        auto obj = callback.release().ptr();
+        auto* obj = callback.release().ptr();
         auto callback_obj =
             std::make_unique<c10::SafePyObject>(obj, getPyInterpreter());
         handle.setReportErrorCallback_(std::move(callback_obj));

--- a/torch/csrc/utils/python_scalars.h
+++ b/torch/csrc/utils/python_scalars.h
@@ -126,11 +126,11 @@ inline PyObject* load_scalar(const void* data, at::ScalarType scalarType) {
     case at::kDouble:
       return PyFloat_FromDouble(*(double*)data);
     case at::kComplexHalf: {
-      auto data_ = reinterpret_cast<const c10::complex<at::Half>*>(data);
+      const auto* data_ = reinterpret_cast<const c10::complex<at::Half>*>(data);
       return PyComplex_FromDoubles(data_->real(), data_->imag());
     }
     case at::kComplexFloat: {
-      auto data_ = reinterpret_cast<const c10::complex<float>*>(data);
+      const auto* data_ = reinterpret_cast<const c10::complex<float>*>(data);
       return PyComplex_FromDoubles(data_->real(), data_->imag());
     }
     case at::kComplexDouble:

--- a/torch/csrc/utils/python_symnode.h
+++ b/torch/csrc/utils/python_symnode.h
@@ -164,8 +164,8 @@ class PythonSymNodeImpl : public c10::SymNodeImpl {
       const char* fname,
       const c10::SymNode& other,
       const c10::SymNode& third) {
-    auto pother = dynamic_cast<PythonSymNodeImpl*>(other.get());
-    auto pthird = dynamic_cast<PythonSymNodeImpl*>(third.get());
+    auto* pother = dynamic_cast<PythonSymNodeImpl*>(other.get());
+    auto* pthird = dynamic_cast<PythonSymNodeImpl*>(third.get());
     TORCH_CHECK(pother);
     TORCH_CHECK(pthird);
     py::gil_scoped_acquire acquire;
@@ -174,7 +174,7 @@ class PythonSymNodeImpl : public c10::SymNodeImpl {
   }
 
   c10::SymNode dispatch_common_(const char* fname, const c10::SymNode& other) {
-    auto pother = dynamic_cast<PythonSymNodeImpl*>(other.get());
+    auto* pother = dynamic_cast<PythonSymNodeImpl*>(other.get());
     TORCH_CHECK(pother);
     py::gil_scoped_acquire acquire;
     auto r = getPyObj().attr(fname)(pother->getPyObj());

--- a/torch/csrc/utils/tensor_flatten.cpp
+++ b/torch/csrc/utils/tensor_flatten.cpp
@@ -71,7 +71,7 @@ void reorder_tensors_like(std::vector<Tensor>& tensors, TensorList order) {
   std::unordered_map<size_t, size_t> type_id_to_type_used;
   std::vector<Tensor> ordered_tensors;
   ordered_tensors.reserve(tensors.size());
-  for (auto& tmpl_tensor : order) {
+  for (const auto& tmpl_tensor : order) {
     size_t tmpl_type_id = type_id(tmpl_tensor);
     auto& indices = type_id_to_indices[tmpl_type_id];
     auto& used = type_id_to_type_used[tmpl_type_id];
@@ -114,7 +114,7 @@ std::vector<at::Tensor> unflatten_sparse_tensors(
   std::vector<at::Tensor> outputs;
   outputs.reserve(tensors.size());
   for (size_t i = 0, num_tensors = tensors.size(); i < num_tensors; ++i) {
-    auto& ref_t = tensors[i];
+    const auto& ref_t = tensors[i];
     auto t =
         at::_sparse_coo_tensor_unsafe(indices[i], values[i], ref_t.sizes());
     outputs.emplace_back(t._coalesced_(ref_t.is_coalesced()));

--- a/torch/csrc/utils/tensor_memoryformats.cpp
+++ b/torch/csrc/utils/tensor_memoryformats.cpp
@@ -17,7 +17,7 @@ std::array<PyObject*, static_cast<int>(at::MemoryFormat::NumOptions)>
 } // anonymous namespace
 
 PyObject* getTHPMemoryFormat(at::MemoryFormat memory_format) {
-  auto py_memory_format =
+  auto* py_memory_format =
       memory_format_registry[static_cast<int>(memory_format)];
   if (!py_memory_format) {
     throw std::invalid_argument("unsupported memory_format");

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -183,7 +183,7 @@ ScalarType infer_scalar_type(PyObject* obj) {
       THPObjectPtr handle(PySequence_GetItem(obj, i));
       if (!handle)
         throw python_error();
-      auto cur_item = handle.get();
+      auto* cur_item = handle.get();
       TORCH_CHECK_TYPE(
           cur_item != obj, "new(): self-referential lists are incompatible");
       ScalarType item_scalarType = infer_scalar_type(cur_item);
@@ -625,7 +625,7 @@ Tensor legacy_sparse_tensor_generic_ctor_new(
           "  Please use torch.sparse_coo_tensor(x._indices(), x._values(), x.shape).");
     }
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
-    auto cdata = reinterpret_cast<void*>(r.toInt64(0));
+    auto* cdata = reinterpret_cast<void*>(r.toInt64(0));
     return at::unsafeTensorFromTH(cdata, true);
   } else if (r.idx == 2) {
     if (ctor_or_new == CtorOrNew::CTOR) {
@@ -748,7 +748,7 @@ Tensor legacy_tensor_generic_ctor_new(
     return new_with_storage(options, scalar_type, storage);
   } else if (r.idx == 2) {
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
-    auto cdata = reinterpret_cast<void*>(r.toInt64(0));
+    auto* cdata = reinterpret_cast<void*>(r.toInt64(0));
     return at::unsafeTensorFromTH(cdata, true);
   } else if (r.idx == 3) {
     const auto& other = r.tensor(0);
@@ -920,7 +920,7 @@ static Tensor sparse_compressed_tensor_ctor_worker(
     // Clear error indicator if attribute does not exists.
     // Otherwise subsequent Python C API calls might return bogus values.
     // See https://github.com/pytorch/pytorch/issues/58520 for more details
-    auto rc = PyObject_GetAttrString(o, attr_name);
+    auto* rc = PyObject_GetAttrString(o, attr_name);
     if (!rc) {
       if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
         throw python_error();
@@ -1572,7 +1572,7 @@ Tensor tensor_frombuffer(
   THPObjectPtr obj(view.obj);
 
   auto len = view.len;
-  auto buf = view.buf;
+  auto* buf = view.buf;
   PyBuffer_Release(&view);
 
   TORCH_CHECK_VALUE(
@@ -1622,7 +1622,7 @@ Tensor tensor_frombuffer(
       len,
       " bytes)");
 
-  auto offset_buf = static_cast<char*>(buf) + offset;
+  auto* offset_buf = static_cast<char*>(buf) + offset;
   auto options = TensorOptions().dtype(dtype).device(c10::kCPU);
 
   auto tensor = at::for_blob(offset_buf, static_cast<int64_t>(actual_count))
@@ -1706,7 +1706,7 @@ Tensor asarray(
 
     if (is_numpy_array || is_numpy_scalar) {
       THPObjectPtr ptr;
-      auto arr = obj;
+      auto* arr = obj;
 
       // PyArray_CheckScalar is true for both scalars and 0-dim arrays, per
       // https://numpy.org/devdocs/reference/c-api/array.html#c.PyArray_CheckScalar

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -68,9 +68,9 @@ bool is_numpy_available() {
     std::string message = "Failed to initialize NumPy";
     PyObject *type = nullptr, *value = nullptr, *traceback = nullptr;
     PyErr_Fetch(&type, &value, &traceback);
-    if (auto str = value ? PyObject_Str(value) : nullptr) {
-      if (auto enc_str = PyUnicode_AsEncodedString(str, "utf-8", "strict")) {
-        if (auto byte_str = PyBytes_AS_STRING(enc_str)) {
+    if (auto* str = value ? PyObject_Str(value) : nullptr) {
+      if (auto* enc_str = PyUnicode_AsEncodedString(str, "utf-8", "strict")) {
+        if (auto* byte_str = PyBytes_AS_STRING(enc_str)) {
           message += ": " + std::string(byte_str);
         }
         Py_XDECREF(enc_str);
@@ -220,7 +220,7 @@ at::Tensor tensor_from_numpy(
       "expected np.ndarray (got ",
       Py_TYPE(obj)->tp_name,
       ")");
-  auto array = (PyArrayObject*)obj;
+  auto* array = (PyArrayObject*)obj;
 
   // warn_if_not_writable is true when a copy of numpy variable is created.
   // the warning is suppressed when a copy is being created.

--- a/torch/csrc/utils/tensor_qschemes.cpp
+++ b/torch/csrc/utils/tensor_qschemes.cpp
@@ -33,7 +33,7 @@ void initializeQSchemes() {
 }
 
 PyObject* getTHPQScheme(at::QScheme qscheme) {
-  auto qscheme_ = thp_qscheme_array[static_cast<int>(qscheme)];
+  auto* qscheme_ = thp_qscheme_array[static_cast<int>(qscheme)];
   if (!qscheme_) {
     throw std::invalid_argument("unsupported QScheme");
   }

--- a/torch/csrc/utils/tensor_types.cpp
+++ b/torch/csrc/utils/tensor_types.cpp
@@ -108,7 +108,7 @@ at::TensorOptions options_from_string(const std::string& str) {
           .first == cuda_prefix.end()) {
     // torch.cuda. is prefix of str
     c10::call_once(cuda_once, []() {
-      for (auto type : autograd::VariableType::allCUDATypes()) {
+      for (auto* type : autograd::VariableType::allCUDATypes()) {
         cuda_map.emplace(type_to_string(*type), type);
       }
     });
@@ -118,7 +118,7 @@ at::TensorOptions options_from_string(const std::string& str) {
       xpu_prefix.end()) {
     // torch.xpu. is prefix of str
     c10::call_once(xpu_once, []() {
-      for (auto type : autograd::VariableType::allXPUTypes()) {
+      for (auto* type : autograd::VariableType::allXPUTypes()) {
         xpu_map.emplace(type_to_string(*type), type);
       }
     });
@@ -129,14 +129,14 @@ at::TensorOptions options_from_string(const std::string& str) {
           .first == privateUser_prefix.end()) {
     // torch.foo. foo is privateUser1 name
     c10::call_once(privateUser1_once, []() {
-      for (auto type : autograd::VariableType::allPrivateUser1Types()) {
+      for (auto* type : autograd::VariableType::allPrivateUser1Types()) {
         privateUser1_map.emplace(type_to_string(*type), type);
       }
     });
     map = &privateUser1_map;
   } else {
     c10::call_once(cpu_once, []() {
-      for (auto type : autograd::VariableType::allCPUTypes()) {
+      for (auto* type : autograd::VariableType::allCPUTypes()) {
         cpu_map.emplace(type_to_string(*type), type);
       }
     });
@@ -168,8 +168,8 @@ std::vector<std::pair<Backend, ScalarType>> all_declared_types() {
       ScalarType::Bool,
       ScalarType::BFloat16};
 
-  for (auto& backend : backends) {
-    for (auto& scalar_type : scalar_types) {
+  for (const auto& backend : backends) {
+    for (const auto& scalar_type : scalar_types) {
       // there is no sparse bool type.
       if (scalar_type == ScalarType::Bool &&
           (backend == Backend::SparseCUDA || backend == Backend::SparseCPU)) {


### PR DESCRIPTION
Auto * indicates that the type is pointer. Another benefit is const when possible.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @xmfan @yf225