### PR TITLE
[MPSInductor] Fix index generation for transpose

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -39,6 +39,7 @@ class MPSBasicTests(TestCase):
     device = "mps"
 
     test_add_const_int = CommonTemplate.test_add_const_int
+    test_add_inplace_permuted_mps = CommonTemplate.test_add_inplace_permuted
 
     @parametrize("dtype", MPS_DTYPES)
     def test_add(self, dtype):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #143966
* #143998
* #143977
* __->__ #143973
* #143949
* #143948

Alas, PythonPrinter would not work here, not would CppPrinter, so start building MetalPrinter.

`pytest test/inductor/test_torchinductor.py -k _mps` score is 474 failed, 277 passed, 32 skipped
Before this change:
`pytest test/inductor/test_torchinductor.py -k _mps` reported 506 failed, 245 passed, 32 skipped

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov