### PR TITLE
[MPSInductor] Implement minimum and maximum ops

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -40,6 +40,8 @@ class MPSBasicTests(TestCase):
 
     test_add_const_int = CommonTemplate.test_add_const_int
     test_add_inplace_permuted_mps = CommonTemplate.test_add_inplace_permuted
+    test_max_min = CommonTemplate.test_max_min
+    test_views6 = CommonTemplate.test_views6
 
     @parametrize("dtype", MPS_DTYPES)
     def test_add(self, dtype):

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -68,6 +68,15 @@ class MetalOverrides(OpOverrides):
         return f"{a} ? {b} : {c}"
 
     @staticmethod
+    def maximum(a: CSEVariable, b: CSEVariable) -> str:
+        # TODO: Fix nan propagation, see https://github.com/pytorch/pytorch/issues/143976
+        return f"metal::max(static_cast<decltype({a}+{b})>({a}), static_cast<decltype({a}+{b})>({b}))"
+
+    @staticmethod
+    def minimum(a: CSEVariable, b: CSEVariable) -> str:
+        return f"metal::min(static_cast<decltype({a}+{b})>({a}), static_cast<decltype({a}+{b})>({b}))"
+
+    @staticmethod
     def logical_or(a: CSEVariable, b: CSEVariable) -> str:
         return f"{a} | {b}"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #143966
* #143998
* __->__ #143977
* #143973
* #143949
* #143948

By calling `metal::min` and `metal::max` respectively with argument
typecast to a common type to avoid ambiguous calls errors

TODO: Implement NaN propagation for both eager and compile, see https://github.com/pytorch/pytorch/issues/143976

`pytest test/inductor/test_torchinductor.py -k _mps` score is 460 failed, 291 passed, 32 skipped

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov