### PR TITLE
Fixed bug in FindMKL.cmake

### DIFF
--- a/cmake/Modules/FindMKL.cmake
+++ b/cmake/Modules/FindMKL.cmake
@@ -192,7 +192,7 @@ MACRO(GET_MKL_LIB_NAMES LIBRARIES INTERFACE MKL64)
   SET(${LIBRARIES} mkl_${INTERFACE}${MKL64} mkl_core)
   IF(_THREAD)
     LIST(INSERT ${LIBRARIES} 1 ${_THREAD})
-    IF(UNIX AND ${USE_STATIC_MKL})
+    IF(UNIX AND "${USE_STATIC_MKL}")
       # The thread library defines symbols required by the other MKL libraries so also add it last
       LIST(APPEND ${LIBRARIES} ${_THREAD})
     ENDIF()

--- a/cmake/Modules/FindMKL.cmake
+++ b/cmake/Modules/FindMKL.cmake
@@ -192,7 +192,7 @@ MACRO(GET_MKL_LIB_NAMES LIBRARIES INTERFACE MKL64)
   SET(${LIBRARIES} mkl_${INTERFACE}${MKL64} mkl_core)
   IF(_THREAD)
     LIST(INSERT ${LIBRARIES} 1 ${_THREAD})
-    IF(UNIX AND "${USE_STATIC_MKL}")
+    IF(UNIX AND USE_STATIC_MKL)
       # The thread library defines symbols required by the other MKL libraries so also add it last
       LIST(APPEND ${LIBRARIES} ${_THREAD})
     ENDIF()


### PR DESCRIPTION
This PR fixes the CMake error

```
CMake Error at cmake/Modules/FindMKL.cmake:195 (IF):
  if given arguments:

    "UNIX" "AND"

  Unknown arguments specified
Call Stack (most recent call first):
  cmake/Modules/FindMKL.cmake:353 (GET_MKL_LIB_NAMES)
  cmake/Modules/FindBLAS.cmake:99 (FIND_PACKAGE)
  CMakeLists.txt:118 (find_package)
```

cc @malfet @seemethere