### PR TITLE
[MPSInductor] Fix multiple kernel generation

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -42,6 +42,7 @@ class MPSBasicTests(TestCase):
     test_add_inplace_permuted_mps = CommonTemplate.test_add_inplace_permuted
     test_max_min = CommonTemplate.test_max_min
     test_views6 = CommonTemplate.test_views6
+    test_addmm = CommonTemplate.test_addmm
 
     @parametrize("dtype", MPS_DTYPES)
     def test_add(self, dtype):

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -161,7 +161,7 @@ class MetalKernel(SIMDKernel):
         code = IndentedBuffer()
         code.writeline('torch.mps._compile_shader("""')
         with code.indent():
-            code.writeline("kernel void kernel_0(")
+            code.writeline("kernel void generated_kernel(")
             with code.indent():
                 for outer, inner in self.args.output_buffers.items():
                     if outer in self.removed_buffers:
@@ -203,10 +203,13 @@ class MetalScheduling(SIMDScheduling):
         if src_code in wrapper.src_to_kernel:
             kernel_name = wrapper.src_to_kernel[src_code]
         else:
-            kernel_name = f"mps_lib.kernel_{wrapper.next_kernel_suffix()}"
+            # TODO: Merge multiple kernels into a single library
+            # Either using MultiKernel concept or overriding SIMDScheduling.codegen_node_scheduling
+            mps_lib_name = f"mps_lib_{wrapper.next_kernel_suffix()}"
+            kernel_name = f"{mps_lib_name}.generated_kernel"
             wrapper.src_to_kernel[src_code] = kernel_name
             origins, detailed_origins = get_kernel_metadata(node_schedule, wrapper)
             metadata_comment = f"{origins}\n{detailed_origins}"
-            wrapper.define_kernel("mps_lib", src_code, metadata_comment)
+            wrapper.define_kernel(mps_lib_name, src_code, metadata_comment)
 
         return kernel_name


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #143966
* __->__ #143998
* #143977
* #143973
* #143949
* #143948

At the moment by generating multiple MetalLibraries

`pytest test/inductor/test_torchinductor.py -k _mps` score is 434 failed, 317 passed, 32 skipped

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov