### PR TITLE
[ROCm] fix torch.layer_norm invalid configuration problem when input is large tensor

### DIFF
--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -771,7 +771,7 @@ template <typename T, typename T_ACC>
 void LayerNormKernelImplInternal(
     const Tensor& X,
     const Tensor& gamma,
-    const Tensor& beta,t
+    const Tensor& beta,
     int64_t M,
     int64_t N,
     T_ACC eps,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7142,7 +7142,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
     @largeTensorTest("40GB", device="cuda")
     def test_layer_norm_large_tensor(self):
         # test for https://github.com/pytorch/pytorch/issues/136291
-        device=torch.device("cuda")
+        device = torch.device("cuda")
         b, n, dp = 16, 3000, 16
         pairwise_repr = torch.ones(b, n, n, dp)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7142,14 +7142,17 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
     @largeTensorTest("40GB", device="cuda")
     def test_layer_norm_large_tensor(self):
         # test for https://github.com/pytorch/pytorch/issues/136291
-        device = torch.device("cuda")
+        device=torch.device("cuda")
         b, n, dp = 16, 3000, 16
-        pairwise_repr = torch.randn(b, n, n, dp)
+        pairwise_repr = torch.ones(b, n, n, dp)
 
         attn_bias_norm = nn.LayerNorm(dp).to(device=device)
         pairwise_repr = pairwise_repr.to(dtype=torch.float32, device=device)
         norm = attn_bias_norm(pairwise_repr)
-        self.assertEqual(norm, torch.Size([16, 3000, 3000, 16]))
+        self.assertEqual(norm.shape, torch.Size([16, 3000, 3000, 16]))
+        # check last value to make sure it is correct. 
+        # check all values will take too long
+        self.assertEqual(norm[-1][-1][-1][-1], 0.0)
 
     def test_padding_list(self):
         # Padding can be a list, or tuple (regression test for gh-54452)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7150,7 +7150,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         pairwise_repr = pairwise_repr.to(dtype=torch.float32, device=device)
         norm = attn_bias_norm(pairwise_repr)
         self.assertEqual(norm.shape, torch.Size([16, 3000, 3000, 16]))
-        # check last value to make sure it is correct. 
+        # check last value to make sure it is correct.
         # check all values will take too long
         self.assertEqual(norm[-1][-1][-1][-1], 0.0)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7142,7 +7142,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
     @largeTensorTest("40GB", device="cuda")
     def test_layer_norm_large_tensor(self):
         # test for https://github.com/pytorch/pytorch/issues/136291
-        device=torch.device("cuda")
+        device = torch.device("cuda")
         b, n, dp = 16, 3000, 16
         pairwise_repr = torch.randn(b, n, n, dp)
 


### PR DESCRIPTION
Fixes #136291

This PR is to fix the `invalid configuration argument` problem happened on ROCm when input is a large tensor when calling `torch.layer_norm`.

```
 File "/opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/nn/functional.py", line 2573, in layer_norm
    return torch.layer_norm
RuntimeError: HIP error: invalid configuration argument
```

After investigation, I found that the reason why this error happened is: The amd compute language runtime checks whether  `gridDim.x * blockDim.x` is greater than `std::numeric_limits<uint32_t>::max()` or not. If yes, it will error out with the "invalid configuration argument" message.
  
The fix is to split the whole task to several chunks so that each chunk will not trigger the failure condition. This will ensure the correctness and completeness given the current kernel implementation logic of `vectorized_layer_norm_kernel`.

Also added a largeTensor layer_norm unit test `test_layer_norm_large_tensor` with the same shape `[16, 3000, 3000, 16]` as the one used by the pytorch issue #136291 so that the unit test can check the expected output value to ensure correctness. 

The future work may include performance optimization of layer_norm and CK layer_norm integration.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @naromero77amd