### PR TITLE
Use _cvtss_sh and _cvtsh_ss for scalar conversion of Half on AVX512

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_half.h
+++ b/aten/src/ATen/cpu/vec/vec_half.h
@@ -9,15 +9,12 @@ inline namespace CPU_CAPABILITY {
 #if (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && \
     !defined(__APPLE__)
 static inline uint16_t float2half_scalar(float val) {
-#if defined(CPU_CAPABILITY_AVX2)
 #if defined(_MSC_VER)
+#if defined(CPU_CAPABILITY_AVX2)
   __m256 v = _mm256_set1_ps(val);
   __m128i o =
       _mm256_cvtps_ph(v, (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
   return static_cast<std::uint16_t>(_mm_cvtsi128_si32(o));
-#else
-  return _cvtss_sh(val, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
-#endif
 #elif defined(CPU_CAPABILITY_AVX512)
   __m512 v = _mm512_set1_ps(val);
   __m256i o =
@@ -25,22 +22,25 @@ static inline uint16_t float2half_scalar(float val) {
   return static_cast<std::uint16_t>(
       _mm_cvtsi128_si32(_mm256_castsi256_si128(o)));
 #endif
+#else
+  return _cvtss_sh(val, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+#endif
 }
 
 static inline float half2float_scalar(uint16_t val) {
-#if defined(CPU_CAPABILITY_AVX2)
 #if defined(_MSC_VER)
+#if defined(CPU_CAPABILITY_AVX2)
   __m128i v = _mm_cvtsi32_si128(val);
   __m256 o = _mm256_cvtph_ps(v);
   return _mm256_cvtss_f32(o);
-#else
-  return _cvtsh_ss(val);
-#endif
 #elif defined(CPU_CAPABILITY_AVX512)
   __m256i v =
       _mm256_setr_epi16(val, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
   __m512 o = _mm512_cvtph_ps(v);
   return _mm512_cvtss_f32(o);
+#endif
+#else
+  return _cvtsh_ss(val);
 #endif
 }
 

--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -305,7 +305,7 @@ if(INTERN_BUILD_ATEN_OPS)
     if(MSVC)
       list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG}/arch:AVX512")
     else(MSVC)
-      list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG} -mavx512f -mavx512bw -mavx512vl -mavx512dq -mfma")
+      list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG} -mavx512f -mavx512bw -mavx512vl -mavx512dq -mfma -mf16c")
     endif(MSVC)
   endif(CXX_AVX512_FOUND)
 

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -45,7 +45,7 @@ else()
   # Platforms where avx512f is supported by not avx512dq and avx512vl as of
   # Jan 15 2019 : linux_manywheel_2.7mu_cpu_build and
   # linux_conda_3.7_cu100_build
-  set(CMAKE_REQUIRED_FLAGS "-mavx512f -mavx512dq -mavx512vl")
+  set(CMAKE_REQUIRED_FLAGS "-mavx512f -mavx512dq -mavx512vl -mf16c")
 endif()
 CHECK_CXX_SOURCE_COMPILES(
     "#if defined(_MSC_VER)

--- a/cmake/Modules/FindAVX.cmake
+++ b/cmake/Modules/FindAVX.cmake
@@ -76,8 +76,8 @@ ENDMACRO()
 
 CHECK_SSE(C "AVX" " ;-mavx;/arch:AVX")
 CHECK_SSE(C "AVX2" " ;-mavx2 -mfma -mf16c;/arch:AVX2")
-CHECK_SSE(C "AVX512" " ;-mavx512f -mavx512dq -mavx512vl -mavx512bw -mfma;/arch:AVX512")
+CHECK_SSE(C "AVX512" " ;-mavx512f -mavx512dq -mavx512vl -mavx512bw -mfma -mf16c;/arch:AVX512")
 
 CHECK_SSE(CXX "AVX" " ;-mavx;/arch:AVX")
 CHECK_SSE(CXX "AVX2" " ;-mavx2 -mfma -mf16c;/arch:AVX2")
-CHECK_SSE(CXX "AVX512" " ;-mavx512f -mavx512dq -mavx512vl -mavx512bw -mfma;/arch:AVX512")
+CHECK_SSE(CXX "AVX512" " ;-mavx512f -mavx512dq -mavx512vl -mavx512bw -mfma -mf16c;/arch:AVX512")

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -188,7 +188,7 @@ class VecAVX512(VecISA):
     _bit_width = 512
     _macro = ["CPU_CAPABILITY_AVX512"]
     _arch_flags = (
-        "-mavx512f -mavx512dq -mavx512vl -mavx512bw -mfma"
+        "-mavx512f -mavx512dq -mavx512vl -mavx512bw -mfma -mf16c"
         if not _IS_WINDOWS
         else "/arch:AVX512"
     )  # TODO: use cflags


### PR DESCRIPTION
Using `_cvtss_sh` and `_cvtsh_ss` on AVX512 can get better performance for scalar conversion of Half.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov