### PR TITLE
Remove unused setDataLoaderSignalHandlers

### DIFF
--- a/torch/csrc/DataLoader.cpp
+++ b/torch/csrc/DataLoader.cpp
@@ -102,8 +102,6 @@ static void handler_SIGTERM(int sig, siginfo_t* info, void* ctx) {
   }
 }
 
-__attribute__((weak)) void setDataLoaderSignalHandlers() {}
-
 static PyObject* THPModule_setWorkerSignalHandlers(
     PyObject* module,
     PyObject* arg) {
@@ -112,7 +110,6 @@ static PyObject* THPModule_setWorkerSignalHandlers(
   setSignalHandler(SIGSEGV, &handler_SIGSEGV, nullptr);
   setSignalHandler(SIGTERM, &handler_SIGTERM, nullptr);
   setSignalHandler(SIGFPE, &handler_SIGFPE, nullptr);
-  setDataLoaderSignalHandlers();
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }


### PR DESCRIPTION
setDataLoaderSignalHandlers isn't used in repositories under the PyTorch organization.

cc @andrewkho @divyanshk @SsnL @VitalyFedyunin @dzhulgakov