### PR TITLE
[Inductor] Generalize tiling algorithm to handle fused reductions

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5198,17 +5198,24 @@ class CommonTemplate:
             (torch.randn([1, 2, 4, 8]),),
         )
 
-    def test_var_mean(self):
+    @parametrize("tile_reduction", (False, True))
+    def test_var_mean(self, tile_reduction: bool):
         def fn(x):
             return (
                 *torch.var_mean(x, -1),
                 *torch.var_mean(x, [1, 3]),
             )
 
-        self.common(
-            fn,
-            (torch.randn([1, 2, 4, 8]),),
-        )
+        with config.patch(
+            {
+                "triton.prefer_nd_tiling": tile_reduction,
+                "triton.tile_reductions": tile_reduction,
+            }
+        ):
+            self.common(
+                fn,
+                (torch.randn([1, 2, 4, 8]),),
+            )
 
     def test_var_correction(self):
         def fn(x):

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -591,6 +591,7 @@ class CommonTemplate:
             ((129, 129), 3, 2, torch.sum),  # Large size, with loops.
             ((3, 3), 1, 1, torch.argmax),
             ((129, 129), 1, 1, torch.argmax),
+            ((5, 5), 1, 1, torch.var_mean),  # Reduction + pointwise fusion.
         ],
     )
     def test_2d_reduction_odd_shapes(

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -685,10 +685,15 @@ class SIMDKernel(Kernel):
             return False
 
     def split_and_set_ranges(self, lengths: Sequence[Sequence[sympy.Expr]]):
-        groups = [rt.numel for rt in self.range_trees]
+        tiling = {rt.prefix: rt.numel for rt in self.range_trees}
         if not self.inside_reduction:
-            groups[-1] = sympy.S.One
+            reduction_prefixes = [
+                prefix for prefix in tiling if prefix_is_reduction(prefix)
+            ]
+            for prefix in reduction_prefixes:
+                tiling[prefix] = sympy.S.One
 
+        groups = [*tiling.values()]
         return self.map_kernel_groups_to_node_sizes(groups, lengths, self.set_ranges)
 
     @classmethod

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1800,7 +1800,7 @@ class SIMDScheduling(BaseScheduling):
         is_pointwise = "x" in tiling
 
         total_numel = numel * reduction_numel
-        missing_tiling = [sympy_product(splits) / total_numel]
+        missing_tiling = [total_numel / sympy_product(splits)]
 
         tiling_args = (
             (splits, missing_tiling) if is_pointwise else (missing_tiling, splits)
@@ -1811,7 +1811,7 @@ class SIMDScheduling(BaseScheduling):
     def get_nd_tilings(
         cls,
         node_schedule,
-        numel,
+        pointwise_numel,
         reduction_numel,
     ) -> List[Dict[str, Tuple[sympy.Expr]]]:
         """
@@ -1835,7 +1835,6 @@ class SIMDScheduling(BaseScheduling):
             # Use the node ranges as the default tiling candidate.
             ranges_to_tile = node_ranges[0 if is_pointwise else 1]
             node_tilings = [ranges_to_tile]
-            pointwise_numel = sympy_product(node_ranges[0])
 
             # Search the indexing expressions for more candidates.
             # If we see modular indexing, try to subdivide ranges into their implied
@@ -1906,7 +1905,7 @@ class SIMDScheduling(BaseScheduling):
                 tilings.add(
                     cls.complete_partial_tiling(
                         cls.create_partial_tiling(collapsed_splits, is_pointwise),
-                        numel,
+                        pointwise_numel,
                         reduction_numel,
                     )
                 )

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -663,8 +663,21 @@ class SIMDKernel(Kernel):
 
     @classmethod
     def is_compatible(
-        cls, groups: Iterable[sympy.Expr], lengths: Sequence[Sequence[sympy.Expr]]
+        cls,
+        groups: Iterable[sympy.Expr],
+        lengths: Sequence[Sequence[sympy.Expr]],
+        reduction_numel: sympy.Expr = sympy.S.One,
     ):
+        # Fill in the reduction numel, in case the node is missing it.
+        sizevars = V.graph.sizevars
+        if len(lengths[1]) == 0 and (
+            sizevars.statically_known_equals(
+                sympy_product(groups),
+                sympy_product(lengths[0]) * reduction_numel,
+            )
+        ):
+            lengths = (lengths[0], [reduction_numel])
+
         try:
             cls._split_iteration_ranges(groups, lengths)
             return True
@@ -1626,7 +1639,9 @@ class SIMDScheduling(BaseScheduling):
 
     @classmethod
     @functools.lru_cache(32)
-    def candidate_tilings(cls, node, is_pointwise: bool) -> List[CandidateTiling]:
+    def candidate_tilings(cls, node, reduction_numel) -> List[CandidateTiling]:
+        is_pointwise = reduction_numel == 1
+
         def tile_ranges(is_pointwise: bool, ranges, rw) -> List[CandidateTiling]:
             """
             Compute tiling candidates by dividing up the iteration ranges.
@@ -1712,7 +1727,7 @@ class SIMDScheduling(BaseScheduling):
                                     collapse_ranges(ranges[:split]),
                                     collapse_ranges(ranges[split:]),
                                 ],
-                                is_pointwise,
+                                reduction_numel,
                             ),
                             score=score,
                             name=dep.name,
@@ -1736,7 +1751,9 @@ class SIMDScheduling(BaseScheduling):
         # Fill in the missing ranges.
         full_tilings = [
             CandidateTiling(
-                tiling=cls.complete_partial_tiling(tiling.tiling, node),
+                tiling=cls.complete_partial_tiling(
+                    tiling.tiling, node, reduction_numel
+                ),
                 score=tiling.score,
                 name=tiling.name,
             )
@@ -1771,18 +1788,22 @@ class SIMDScheduling(BaseScheduling):
 
     @classmethod
     def complete_partial_tiling(
-        cls, tiling: Dict[str, sympy.Expr], node
+        cls, tiling: Dict[str, sympy.Expr], node, reduction_numel: sympy.Expr
     ) -> Dict[str, sympy.Expr]:
         """
         Given a tiling for only pointwise or reduction dimensions, adds the missing one.
         """
         splits = list(tiling.values())
         is_pointwise = "x" in tiling
-        missing_ranges = node.get_ranges()[1 if is_pointwise else 0]
-        missing_numel = [sympy_product(missing_ranges)]
+
+        # Use the global reduction numel, as the node may not have reduction ranges.
+        missing_numel = (
+            sympy_product(node.get_ranges()[0]) if is_pointwise else reduction_numel
+        )
+        missing_tiling = [missing_numel]
 
         tiling_args = (
-            (splits, missing_numel) if is_pointwise else (missing_numel, splits)
+            (splits, missing_tiling) if is_pointwise else (missing_tiling, splits)
         )
         return cls.create_tiling(*tiling_args)
 
@@ -1790,7 +1811,7 @@ class SIMDScheduling(BaseScheduling):
     def get_nd_tilings(
         cls,
         node_schedule,
-        is_pointwise: bool,
+        reduction_numel,
     ) -> List[Dict[str, Tuple[sympy.Expr]]]:
         """
         Creates N-dimensional tiling candidiates, attempting to simplify loads/stores
@@ -1798,13 +1819,19 @@ class SIMDScheduling(BaseScheduling):
 
         Returns a list of tilings ranked by dimensionality.
         """
+        is_pointwise = reduction_numel == 1
         tilings = OrderedSet[Dict[str, sympy.Expr]]()
         for node in EnableReduction.filter(node_schedule):
             if not isinstance(node, scheduler.SchedulerNode):
                 continue
 
-            # Use the node ranges as the default tiling candidate.
+            # If this is a reduction schedule, skip nodes which are missing their
+            # reduction ranges.
             node_ranges = node.get_ranges()
+            if not is_pointwise and len(node_ranges[1]) == 0:
+                continue
+
+            # Use the node ranges as the default tiling candidate.
             ranges_to_tile = node_ranges[0 if is_pointwise else 1]
             node_tilings = [ranges_to_tile]
             pointwise_numel = sympy_product(node_ranges[0])
@@ -1877,7 +1904,9 @@ class SIMDScheduling(BaseScheduling):
                 )
                 tilings.add(
                     cls.complete_partial_tiling(
-                        cls.create_partial_tiling(collapsed_splits, is_pointwise), node
+                        cls.create_partial_tiling(collapsed_splits, is_pointwise),
+                        node,
+                        reduction_numel,
                     )
                 )
 
@@ -1916,7 +1945,7 @@ class SIMDScheduling(BaseScheduling):
                 for node in EnableReduction.filter(node_schedule):
                     if (
                         not config.triton.tile_reductions
-                        and len(cls.candidate_tilings(node, is_pointwise)) > 0
+                        and len(cls.candidate_tilings(node, reduction_numel)) > 0
                     ):
                         perf_hint_log.info(
                             textwrap.dedent(
@@ -1932,7 +1961,7 @@ class SIMDScheduling(BaseScheduling):
         seen_names = OrderedSet[str]()
         candidate_tiles: Counter[CandidateTiling] = collections.Counter()
         for node in EnableReduction.filter(node_schedule):
-            for candidate_tiling in cls.candidate_tilings(node, is_pointwise):
+            for candidate_tiling in cls.candidate_tilings(node, reduction_numel):
                 if candidate_tiling.name in seen_names:
                     continue
                 elif candidate_tiling.name is not None:
@@ -1989,13 +2018,15 @@ class SIMDScheduling(BaseScheduling):
         # Optionally, prefer tiling into as many dimensions as possible.
         if config.triton.prefer_nd_tiling:
             ranked_tilings = (
-                cls.get_nd_tilings(node_schedule, is_pointwise) + ranked_tilings
+                cls.get_nd_tilings(node_schedule, reduction_numel) + ranked_tilings
             )
 
         for tiling in ranked_tilings:
             assert isinstance(tiling, dict)
             if all(
-                SIMDKernel.is_compatible(tiling.values(), node.get_ranges())
+                SIMDKernel.is_compatible(
+                    tiling.values(), node.get_ranges(), reduction_numel=reduction_numel
+                )
                 for node in node_schedule
                 if isinstance(node, scheduler.SchedulerNode)
             ):

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -687,11 +687,9 @@ class SIMDKernel(Kernel):
     def split_and_set_ranges(self, lengths: Sequence[Sequence[sympy.Expr]]):
         tiling = {rt.prefix: rt.numel for rt in self.range_trees}
         if not self.inside_reduction:
-            reduction_prefixes = [
-                prefix for prefix in tiling if prefix_is_reduction(prefix)
-            ]
-            for prefix in reduction_prefixes:
-                tiling[prefix] = sympy.S.One
+            for prefix in tiling:
+                if prefix_is_reduction(prefix):
+                    tiling[prefix] = sympy.S.One
 
         groups = [*tiling.values()]
         return self.map_kernel_groups_to_node_sizes(groups, lengths, self.set_ranges)


### PR DESCRIPTION
# Issue

This PR cleans up an edge case that wasn't handled by https://github.com/pytorch/pytorch/pull/137243. The existing tiling code assumes that `node.get_ranges()` is a reliable source of pointwise and reduction numels. This is true for pointwise kernels, but the situation is more complicated with reductions. Since reductions change the number of elements in a tensor, not all ops within a reduction kernel will have the same number of iterations. For example, `var_mean` fuses pointwise division with the output of reduction sum, and the division lacks the corresponding reduction ranges.

# Fix

Instead of getting numels from `node.get_ranges()`, explicitly pass the global pointwise and reduction numels to the relevant tiling functions. In `SIMDKernel.complete_partial_tiling`, we solve for the missing numel by diving the global numel by the partial tiling's numel. This ensures all tilings have the correct global numel.

Also, in `SIMDKernel.is_compatible`, add the global reduction numel to node ranges that are missing it. For example, `{"x": 8, "r0_": 8}` is compatible with  a node of ranges `([8], [])` when we have `reduction_numel=8`.

Finally, this PR generalizes some of the existing codegen to handle multiple reduction dims. We already had code to ignore reduction splits for pointwise kernels, but it only worked for 1D reductions. Now it can handle ND.

# Test plan

This PR parametrizes the existing CI test for `var_mean` to also run with tiled reductions. It also adds a new test checking that `var_mean` generates 2D tilings (with tiled reduction enabled). These new tests would fail on the current main branch. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov