### PR TITLE
[MPSInductor] Fix multi rangevar kernel invocation

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -43,6 +43,7 @@ class MPSBasicTests(TestCase):
     test_max_min = CommonTemplate.test_max_min
     test_views6 = CommonTemplate.test_views6
     test_addmm = CommonTemplate.test_addmm
+    test_view_as_complex = CommonTemplate.test_view_as_complex
 
     @parametrize("dtype", MPS_DTYPES)
     def test_add(self, dtype):

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -158,6 +158,7 @@ class MetalKernel(SIMDKernel):
         """Called at the end to generate a final kernel string"""
         code = IndentedBuffer()
         code.writeline('torch.mps._compile_shader("""')
+        idx_var_names = [v.name for v in self.active_range_trees()]
         with code.indent():
             code.writeline("kernel void generated_kernel(")
             with code.indent():
@@ -169,9 +170,23 @@ class MetalKernel(SIMDKernel):
                 for outer, inner in self.args.input_buffers.items():
                     dtype_str = self.dtype_to_str(V.graph.get_dtype(outer))
                     code.writeline(f"constant {dtype_str}* {inner},")
-                code.writeline("uint xindex [[thread_position_in_grid]]")
+                if len(idx_var_names) == 1:
+                    code.writeline(
+                        f"uint {idx_var_names[0]} [[thread_position_in_grid]]"
+                    )
+                else:
+                    assert (
+                        len(idx_var_names) < 4
+                    ), "Up to 3 index variables are supported"
+                    code.writeline(
+                        f"uint{len(idx_var_names)} thread_pos [[thread_position_in_grid]]"
+                    )
+
             code.writeline(") {")
             with code.indent():
+                if len(idx_var_names) > 1:
+                    for idx, name in enumerate(idx_var_names):
+                        code.writeline(f"auto {name} = thread_pos.{chr(120+idx)};")
                 code.splice(self.body)
             code.writeline("}")
         code.writeline('""")')
@@ -183,6 +198,11 @@ class MetalKernel(SIMDKernel):
         wrapper = V.graph.wrapper_code
         args = [*self.args.output_buffers.keys(), *self.args.input_buffers.keys()]
         args = [arg for arg in args if arg not in self.removed_buffers]
+        if len(self.active_range_trees()) > 0:
+            args += [
+                f"threads=[{', '.join(str(v.numel) for v in self.active_range_trees())}]"
+            ]
+
         wrapper.generate_kernel_call(
             name,
             args,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #143966
* #144084
* #144083
* __->__ #144050
* #144156
* #144105
* #144122
* #144051
* #144055

By changing `thread_position_in_grid` type to uint{n} and passing
dimentions during the kernel call

`pytest test/inductor/test_torchinductor.py -k _mps` score is 445 failed, 309 passed, 32 skipped

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov