### PR TITLE
Fix torch.normal ignores default_device

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3382,6 +3382,15 @@ class TestRandomTensorCreation(TestCase):
             with self.assertRaisesRegex(RuntimeError, r'normal expects all elements of std >= 0.0'):
                 torch.normal(input, std)
 
+    def test_normal_default_device(self, device):
+        try:
+            old_device = torch.get_default_device()
+            torch.set_default_device(device)
+            t = torch.normal(0, 1, (10, 10))
+        finally:
+            torch.set_default_device(old_device)
+        self.assertEqual(str(t.device), device)
+
     # https://github.com/pytorch/pytorch/issues/126834
     @xfailIfTorchDynamo
     @dtypes(torch.float, torch.double, torch.half)

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3384,11 +3384,10 @@ class TestRandomTensorCreation(TestCase):
 
     def test_normal_default_device(self, device):
         try:
-            old_device = torch.get_default_device()
             torch.set_default_device(device)
             t = torch.normal(0, 1, (10, 10))
         finally:
-            torch.set_default_device(old_device)
+            torch.set_default_device(None)
         self.assertEqual(str(t.device), device)
 
     # https://github.com/pytorch/pytorch/issues/126834

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1141,7 +1141,7 @@ def set_default_device(
     .. note::
 
         This doesn't affect functions that create tensors that share the same memory as the input, like:
-        :func:`torch.from_numpy` and :func:`torch.frombuffer`. Using :func:`to()` move tensor to desired device.
+        :func:`torch.from_numpy` and :func:`torch.frombuffer`. Using :func:`torch.Tensor.to` move tensor to desired device.
 
     Args:
         device (device or string): the device to set as default

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1141,7 +1141,7 @@ def set_default_device(
     .. note::
 
         This doesn't affect functions that create tensors that share the same memory as the input, like:
-        :func:`torch.from_numpy` and :func:`torch.frombuffer`
+        :func:`torch.from_numpy` and :func:`torch.frombuffer`. Using :func:`to()` move tensor to desired device.
 
     Args:
         device (device or string): the device to set as default

--- a/torch/utils/_device.py
+++ b/torch/utils/_device.py
@@ -31,8 +31,7 @@ def _device_constructors():
         torch.linspace,
         torch.logspace,
         torch.nested.nested_tensor,
-        # This function doesn't actually take a device argument
-        # torch.normal,
+        torch.normal,
         torch.ones,
         torch.rand,
         torch.randn,


### PR DESCRIPTION
Fixes #122886

1. Enable `torch.normal` working with `DeviceContext` to get default device which set via `set_default_device`.
2. Add hint in `set_default_device` doc, suggest use `torch.Tensor.to` method move to desired device explicitly.

**Test Result**
1. **Doc Preview**
![image](https://github.com/user-attachments/assets/eb69c334-be2b-4dc5-bdce-567da21e1635)

2. **Local Test**
```python
>>> import torch
>>> torch.normal(0.,1., (10,10)).device
device(type='cpu')
>>> torch.set_default_device('cuda')
>>> torch.normal(0.,1., (10,10)).device
device(type='cuda', index=0)
```

```bash
pytest test/test_tensor_creation_ops.py
```

![image](https://github.com/user-attachments/assets/8b466b55-f162-4b83-8b20-71de2c1d0914)

```bash
lintrunner
```
![image](https://github.com/user-attachments/assets/5b269c50-da57-47ed-8500-4edf2c2295e4)


cc @fritzo @neerajprad @alicanb @nikitaved