### PR TITLE
[AOTI] Remove more AOTI_TORCH_EXPORT

### DIFF
--- a/torch/csrc/inductor/aoti_torch/shim_cuda.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_cuda.cpp
@@ -46,8 +46,9 @@ AOTITorchError aoti_torch_delete_cuda_stream_guard(
       { delete reinterpret_cast<at::cuda::CUDAStreamGuard*>(guard); });
 }
 
-AOTI_TORCH_EXPORT AOTITorchError
-aoti_torch_get_current_cuda_stream(int32_t device_index, void** ret_stream) {
+AOTITorchError aoti_torch_get_current_cuda_stream(
+    int32_t device_index,
+    void** ret_stream) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     *(cudaStream_t*)(ret_stream) = at::cuda::getCurrentCUDAStream(device_index);
   });

--- a/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
@@ -149,8 +149,7 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise(
   });
 }
 
-AOTI_TORCH_EXPORT AOTITorchError
-aoti_torch_cpu_mkldnn__convolution_transpose_pointwise(
+AOTITorchError aoti_torch_cpu_mkldnn__convolution_transpose_pointwise(
     AtenTensorHandle X,
     AtenTensorHandle W,
     AtenTensorHandle* B,
@@ -281,7 +280,7 @@ AOTITorchError aoti_torch_cpu__linear_pointwise_binary(
   });
 }
 
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__qlinear_pointwise_tensor(
+AOTITorchError aoti_torch_cpu__qlinear_pointwise_tensor(
     AtenTensorHandle X,
     AtenTensorHandle act_scale,
     AtenTensorHandle act_zero_point,
@@ -322,8 +321,7 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__qlinear_pointwise_tensor(
   });
 }
 
-AOTI_TORCH_EXPORT AOTITorchError
-aoti_torch_cpu__qlinear_pointwise_binary_tensor(
+AOTITorchError aoti_torch_cpu__qlinear_pointwise_binary_tensor(
     AtenTensorHandle X,
     AtenTensorHandle act_scale,
     AtenTensorHandle act_zero_point,
@@ -374,7 +372,7 @@ aoti_torch_cpu__qlinear_pointwise_binary_tensor(
   });
 }
 
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__qconv2d_pointwise_tensor(
+AOTITorchError aoti_torch_cpu__qconv2d_pointwise_tensor(
     AtenTensorHandle X,
     AtenTensorHandle act_scale,
     AtenTensorHandle act_zero_point,
@@ -433,8 +431,7 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__qconv2d_pointwise_tensor(
   });
 }
 
-AOTI_TORCH_EXPORT AOTITorchError
-aoti_torch_cpu__qconv2d_pointwise_binary_tensor(
+AOTITorchError aoti_torch_cpu__qconv2d_pointwise_binary_tensor(
     AtenTensorHandle X,
     AtenTensorHandle act_scale,
     AtenTensorHandle act_zero_point,
@@ -505,7 +502,7 @@ aoti_torch_cpu__qconv2d_pointwise_binary_tensor(
 
 #if AT_MKL_ENABLED()
 
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__mkl_linear(
+AOTITorchError aoti_torch_cpu__mkl_linear(
     AtenTensorHandle X,
     AtenTensorHandle W,
     AtenTensorHandle origin_W,

--- a/torch/csrc/inductor/aoti_torch/shim_xpu.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_xpu.cpp
@@ -49,25 +49,24 @@ AOTITorchError aoti_torch_delete_xpu_stream_guard(XPUStreamGuardHandle guard) {
       { delete reinterpret_cast<at::StreamGuard*>(guard); });
 }
 
-AOTI_TORCH_EXPORT AOTITorchError
-aoti_torch_get_current_xpu_stream(int32_t device_index, void** ret_stream) {
+AOTITorchError aoti_torch_get_current_xpu_stream(
+    int32_t device_index,
+    void** ret_stream) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
       { *ret_stream = &(at::xpu::getCurrentXPUStream(device_index).queue()); });
 }
 
-AOTI_TORCH_EXPORT AOTITorchError
-aoti_torch_get_current_xpu_device(int32_t* device_index) {
+AOTITorchError aoti_torch_get_current_xpu_device(int32_t* device_index) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
       { *device_index = static_cast<int32_t>(c10::xpu::current_device()); });
 }
 
-AOTI_TORCH_EXPORT AOTITorchError
-aoti_torch_set_current_xpu_device(const int32_t& device_index) {
+AOTITorchError aoti_torch_set_current_xpu_device(const int32_t& device_index) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
       { c10::xpu::set_device(static_cast<int8_t>(device_index)); });
 }
 
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch_get_current_sycl_queue(void** ret) {
+AOTITorchError aoti_torch_get_current_sycl_queue(void** ret) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     int32_t device_index = static_cast<int32_t>(c10::xpu::current_device());
     *ret = &(at::xpu::getCurrentXPUStream(device_index).queue());


### PR DESCRIPTION
Summary: Similar to https://github.com/pytorch/pytorch/pull/142500, remove redundant AOTI_TORCH_EXPORT from several cpp files, to solve a windows build issue.

Differential Revision: D67762069


