### PR TITLE
[dtensor] improve doc of the DTensor class

### DIFF
--- a/docs/source/distributed.tensor.rst
+++ b/docs/source/distributed.tensor.rst
@@ -49,8 +49,8 @@ In addition to existing ``torch.Tensor`` methods, it also offers a set of additi
 on all devices, etc.
 
 .. autoclass:: DTensor
-    :members:
-    :member-order: bysource
+    :members: from_local, to_local, full_tensor, redistribute, device_mesh, placements
+    :member-order: groupwise
 
 
 DeviceMesh as the distributed communicator
@@ -85,6 +85,8 @@ DTensor supports the following types of :class:`Placement` on each :class:`Devic
   :members:
   :undoc-members:
 
+
+.. _create_dtensor:
 
 Different ways to create a DTensor
 ---------------------------------------

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -229,6 +229,9 @@ class DTensor(torch.Tensor):
     To ensure numerical correctness of the ``DTensor`` sharded computation when calling PyTorch operators, ``DTensor``
     requires every Tensor argument of the operator be DTensor.
 
+    .. note:: Directly using the Tensor subclass constructor here is not the recommended way to create a ``DTensor``
+        (i.e. it does not handle autograd correctly hence is not the public API). Please refer to the `create_dtensor`_
+        section to see how to create a ``DTensor``.
     """
 
     _local_tensor: torch.Tensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #144100
* __->__ #144099

as titled: explicitly list all public members to make sure the public
API stays consistent, also use groupwise as the member order to make doc
look better

cc @H-Huang @awgu @kwen2501 @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o