### PR TITLE
[MPSInductor] Add signbit op support

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -43,6 +43,7 @@ class MPSBasicTests(TestCase):
     test_max_min = CommonTemplate.test_max_min
     test_views6 = CommonTemplate.test_views6
     test_addmm = CommonTemplate.test_addmm
+    test_signbit = CommonTemplate.test_signbit
 
     @parametrize("dtype", MPS_DTYPES)
     def test_add(self, dtype):

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -86,6 +86,10 @@ class MetalOverrides(OpOverrides):
         return f"metal::abs({x})"
 
     @staticmethod
+    def signbit(x: CSEVariable) -> str:
+        return f"metal::signbit({x})"
+
+    @staticmethod
     def sin(x: CSEVariable) -> str:
         return f"metal::precise::sin({x})"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #143966
* #144084
* #144083
* #144050
* #144156
* __->__ #144105
* #144122
* #144051
* #144055

By mapping it to `metal::signbit`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov