### PR TITLE
[typing] Add type hints to `@property` and `@lazy_property` in `torch.distributions`.

### DIFF
--- a/test/typing/pass/distributions.py
+++ b/test/typing/pass/distributions.py
@@ -1,0 +1,11 @@
+from typing_extensions import assert_type
+
+import torch
+from torch import distributions, Tensor
+
+
+dist = distributions.Normal(0, 1)
+assert_type(dist.mean, Tensor)
+
+dist = distributions.MultivariateNormal(torch.zeros(2), torch.eye(2))
+assert_type(dist.covariance_matrix, Tensor)

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -76,17 +76,17 @@ class Bernoulli(ExponentialFamily):
         return self._param.new(*args, **kwargs)
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.probs
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         mode = (self.probs >= 0.5).to(self.probs)
         mode[self.probs == 0.5] = nan
         return mode
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return self.probs * (1 - self.probs)
 
     @lazy_property
@@ -98,7 +98,7 @@ class Bernoulli(ExponentialFamily):
         return logits_to_probs(self.logits, is_binary=True)
 
     @property
-    def param_shape(self):
+    def param_shape(self) -> torch.Size:
         return self._param.size()
 
     def sample(self, sample_shape=torch.Size()):
@@ -125,7 +125,7 @@ class Bernoulli(ExponentialFamily):
         return values
 
     @property
-    def _natural_params(self):
+    def _natural_params(self) -> tuple[Tensor]:
         return (torch.logit(self.probs),)
 
     def _log_normalizer(self, x):

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -2,7 +2,7 @@
 from numbers import Number
 
 import torch
-from torch import nan
+from torch import nan, Tensor
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import (
@@ -12,7 +12,7 @@ from torch.distributions.utils import (
     probs_to_logits,
 )
 from torch.nn.functional import binary_cross_entropy_with_logits
-from torch import Tensor
+
 
 __all__ = ["Bernoulli"]
 

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -12,7 +12,7 @@ from torch.distributions.utils import (
     probs_to_logits,
 )
 from torch.nn.functional import binary_cross_entropy_with_logits
-
+from torch import Tensor
 
 __all__ = ["Bernoulli"]
 
@@ -90,11 +90,11 @@ class Bernoulli(ExponentialFamily):
         return self.probs * (1 - self.probs)
 
     @lazy_property
-    def logits(self):
+    def logits(self) -> Tensor:
         return probs_to_logits(self.probs, is_binary=True)
 
     @lazy_property
-    def probs(self):
+    def probs(self) -> Tensor:
         return logits_to_probs(self.logits, is_binary=True)
 
     @property

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -63,15 +63,15 @@ class Beta(ExponentialFamily):
         return new
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.concentration1 / (self.concentration1 + self.concentration0)
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return self._dirichlet.mode[..., 0]
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         total = self.concentration1 + self.concentration0
         return self.concentration1 * self.concentration0 / (total.pow(2) * (total + 1))
 
@@ -88,7 +88,7 @@ class Beta(ExponentialFamily):
         return self._dirichlet.entropy()
 
     @property
-    def concentration1(self):
+    def concentration1(self) -> Tensor:
         result = self._dirichlet.concentration[..., 0]
         if isinstance(result, Number):
             return torch.tensor([result])
@@ -96,7 +96,7 @@ class Beta(ExponentialFamily):
             return result
 
     @property
-    def concentration0(self):
+    def concentration0(self) -> Tensor:
         result = self._dirichlet.concentration[..., 1]
         if isinstance(result, Number):
             return torch.tensor([result])
@@ -104,7 +104,7 @@ class Beta(ExponentialFamily):
             return result
 
     @property
-    def _natural_params(self):
+    def _natural_params(self) -> tuple[Tensor, Tensor]:
         return (self.concentration1, self.concentration0)
 
     def _log_normalizer(self, x, y):

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -1,8 +1,8 @@
 # mypy: allow-untyped-defs
 from numbers import Number, Real
-from torch import Tensor
 
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.dirichlet import Dirichlet
 from torch.distributions.exp_family import ExponentialFamily

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 from numbers import Number, Real
+from torch import Tensor
 
 import torch
 from torch.distributions import constraints
@@ -74,7 +75,7 @@ class Beta(ExponentialFamily):
         total = self.concentration1 + self.concentration0
         return self.concentration1 * self.concentration0 / (total.pow(2) * (total + 1))
 
-    def rsample(self, sample_shape: _size = ()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = ()) -> Tensor:
         return self._dirichlet.rsample(sample_shape).select(-1, 0)
 
     def log_prob(self, value):

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import (
@@ -8,7 +9,6 @@ from torch.distributions.utils import (
     logits_to_probs,
     probs_to_logits,
 )
-from torch import Tensor
 
 
 __all__ = ["Binomial"]

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -8,6 +8,7 @@ from torch.distributions.utils import (
     logits_to_probs,
     probs_to_logits,
 )
+from torch import Tensor
 
 
 __all__ = ["Binomial"]
@@ -104,11 +105,11 @@ class Binomial(Distribution):
         return self.total_count * self.probs * (1 - self.probs)
 
     @lazy_property
-    def logits(self):
+    def logits(self) -> Tensor:
         return probs_to_logits(self.probs, is_binary=True)
 
     @lazy_property
-    def probs(self):
+    def probs(self) -> Tensor:
         return logits_to_probs(self.logits, is_binary=True)
 
     @property

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -93,15 +93,15 @@ class Binomial(Distribution):
         return constraints.integer_interval(0, self.total_count)
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.total_count * self.probs
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return ((self.total_count + 1) * self.probs).floor().clamp(max=self.total_count)
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return self.total_count * self.probs * (1 - self.probs)
 
     @lazy_property
@@ -113,7 +113,7 @@ class Binomial(Distribution):
         return logits_to_probs(self.logits, is_binary=True)
 
     @property
-    def param_shape(self):
+    def param_shape(self) -> torch.Size:
         return self._param.size()
 
     def sample(self, sample_shape=torch.Size()):

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -103,11 +103,11 @@ class Categorical(Distribution):
         return logits_to_probs(self.logits)
 
     @property
-    def param_shape(self):
+    def param_shape(self) -> torch.Size:
         return self._param.size()
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return torch.full(
             self._extended_shape(),
             nan,
@@ -116,11 +116,11 @@ class Categorical(Distribution):
         )
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return self.probs.argmax(dim=-1)
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return torch.full(
             self._extended_shape(),
             nan,

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -4,6 +4,7 @@ from torch import nan
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import lazy_property, logits_to_probs, probs_to_logits
+from torch import Tensor
 
 
 __all__ = ["Categorical"]
@@ -94,11 +95,11 @@ class Categorical(Distribution):
         return constraints.integer_interval(0, self._num_events - 1)
 
     @lazy_property
-    def logits(self):
+    def logits(self) -> Tensor:
         return probs_to_logits(self.probs)
 
     @lazy_property
-    def probs(self):
+    def probs(self) -> Tensor:
         return logits_to_probs(self.logits)
 
     @property
@@ -116,7 +117,7 @@ class Categorical(Distribution):
 
     @property
     def mode(self):
-        return self.probs.argmax(axis=-1)
+        return self.probs.argmax(dim=-1)
 
     @property
     def variance(self):

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -1,10 +1,9 @@
 # mypy: allow-untyped-defs
 import torch
-from torch import nan
+from torch import nan, Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import lazy_property, logits_to_probs, probs_to_logits
-from torch import Tensor
 
 
 __all__ = ["Categorical"]

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -8,6 +8,7 @@ from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["Cauchy"]
@@ -67,7 +68,7 @@ class Cauchy(Distribution):
             self._extended_shape(), inf, dtype=self.loc.dtype, device=self.loc.device
         )
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
         shape = self._extended_shape(sample_shape)
         eps = self.loc.new(shape).cauchy_()
         return self.loc + eps * self.scale

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -53,17 +53,17 @@ class Cauchy(Distribution):
         return new
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return torch.full(
             self._extended_shape(), nan, dtype=self.loc.dtype, device=self.loc.device
         )
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return self.loc
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return torch.full(
             self._extended_shape(), inf, dtype=self.loc.dtype, device=self.loc.device
         )

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -3,12 +3,11 @@ import math
 from numbers import Number
 
 import torch
-from torch import inf, nan
+from torch import inf, nan, Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["Cauchy"]

--- a/torch/distributions/chi2.py
+++ b/torch/distributions/chi2.py
@@ -32,5 +32,5 @@ class Chi2(Gamma):
         return super().expand(batch_shape, new)
 
     @property
-    def df(self):
+    def df(self) -> Tensor:
         return self.concentration * 2

--- a/torch/distributions/chi2.py
+++ b/torch/distributions/chi2.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 from torch.distributions import constraints
 from torch.distributions.gamma import Gamma
+from torch import Tensor
 
 
 __all__ = ["Chi2"]

--- a/torch/distributions/chi2.py
+++ b/torch/distributions/chi2.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.gamma import Gamma
-from torch import Tensor
 
 
 __all__ = ["Chi2"]

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -119,13 +119,13 @@ class _Dependent(Constraint):
         super().__init__()
 
     @property
-    def is_discrete(self):
+    def is_discrete(self) -> bool:  # type: ignore[override]
         if self._is_discrete is NotImplemented:
             raise NotImplementedError(".is_discrete cannot be determined statically")
         return self._is_discrete
 
     @property
-    def event_dim(self):
+    def event_dim(self) -> int:  # type: ignore[override]
         if self._event_dim is NotImplemented:
             raise NotImplementedError(".event_dim cannot be determined statically")
         return self._event_dim
@@ -233,11 +233,11 @@ class _IndependentConstraint(Constraint):
         super().__init__()
 
     @property
-    def is_discrete(self):
+    def is_discrete(self) -> bool:  # type: ignore[override]
         return self.base_constraint.is_discrete
 
     @property
-    def event_dim(self):
+    def event_dim(self) -> int:  # type: ignore[override]
         return self.base_constraint.event_dim + self.reinterpreted_batch_ndims
 
     def check(self, value):
@@ -599,11 +599,11 @@ class _Cat(Constraint):
         super().__init__()
 
     @property
-    def is_discrete(self):
+    def is_discrete(self) -> bool:  # type: ignore[override]
         return any(c.is_discrete for c in self.cseq)
 
     @property
-    def event_dim(self):
+    def event_dim(self) -> int:  # type: ignore[override]
         return max(c.event_dim for c in self.cseq)
 
     def check(self, value):
@@ -631,11 +631,11 @@ class _Stack(Constraint):
         super().__init__()
 
     @property
-    def is_discrete(self):
+    def is_discrete(self) -> bool:  # type: ignore[override]
         return any(c.is_discrete for c in self.cseq)
 
     @property
-    def event_dim(self):
+    def event_dim(self) -> int:  # type: ignore[override]
         dim = max(c.event_dim for c in self.cseq)
         if self.dim + dim < 0:
             dim += 1

--- a/torch/distributions/continuous_bernoulli.py
+++ b/torch/distributions/continuous_bernoulli.py
@@ -53,7 +53,7 @@ class ContinuousBernoulli(ExponentialFamily):
 
     def __init__(
         self, probs=None, logits=None, lims=(0.499, 0.501), validate_args=None
-    ):
+    ) -> None:
         if (probs is None) == (logits is None):
             raise ValueError(
                 "Either `probs` or `logits` must be specified, but not both."
@@ -128,7 +128,7 @@ class ContinuousBernoulli(ExponentialFamily):
         return torch.where(self._outside_unstable_region(), log_norm, taylor)
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         cut_probs = self._cut_probs()
         mus = cut_probs / (2.0 * cut_probs - 1.0) + 1.0 / (
             torch.log1p(-cut_probs) - torch.log(cut_probs)
@@ -138,11 +138,11 @@ class ContinuousBernoulli(ExponentialFamily):
         return torch.where(self._outside_unstable_region(), mus, taylor)
 
     @property
-    def stddev(self):
+    def stddev(self) -> Tensor:
         return torch.sqrt(self.variance)
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         cut_probs = self._cut_probs()
         vars = cut_probs * (cut_probs - 1.0) / torch.pow(
             1.0 - 2.0 * cut_probs, 2
@@ -160,7 +160,7 @@ class ContinuousBernoulli(ExponentialFamily):
         return clamp_probs(logits_to_probs(self.logits, is_binary=True))
 
     @property
-    def param_shape(self):
+    def param_shape(self) -> torch.Size:
         return self._param.size()
 
     def sample(self, sample_shape=torch.Size()):
@@ -221,7 +221,7 @@ class ContinuousBernoulli(ExponentialFamily):
         )
 
     @property
-    def _natural_params(self):
+    def _natural_params(self) -> tuple[Tensor]:
         return (self.logits,)
 
     def _log_normalizer(self, x):

--- a/torch/distributions/continuous_bernoulli.py
+++ b/torch/distributions/continuous_bernoulli.py
@@ -14,6 +14,7 @@ from torch.distributions.utils import (
 )
 from torch.nn.functional import binary_cross_entropy_with_logits
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["ContinuousBernoulli"]
@@ -151,11 +152,11 @@ class ContinuousBernoulli(ExponentialFamily):
         return torch.where(self._outside_unstable_region(), vars, taylor)
 
     @lazy_property
-    def logits(self):
+    def logits(self) -> Tensor:
         return probs_to_logits(self.probs, is_binary=True)
 
     @lazy_property
-    def probs(self):
+    def probs(self) -> Tensor:
         return clamp_probs(logits_to_probs(self.logits, is_binary=True))
 
     @property
@@ -168,7 +169,7 @@ class ContinuousBernoulli(ExponentialFamily):
         with torch.no_grad():
             return self.icdf(u)
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
         shape = self._extended_shape(sample_shape)
         u = torch.rand(shape, dtype=self.probs.dtype, device=self.probs.device)
         return self.icdf(u)

--- a/torch/distributions/continuous_bernoulli.py
+++ b/torch/distributions/continuous_bernoulli.py
@@ -3,6 +3,7 @@ import math
 from numbers import Number
 
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import (
@@ -14,7 +15,6 @@ from torch.distributions.utils import (
 )
 from torch.nn.functional import binary_cross_entropy_with_logits
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["ContinuousBernoulli"]

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -5,6 +5,7 @@ from torch.autograd.function import once_differentiable
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["Dirichlet"]
@@ -71,7 +72,7 @@ class Dirichlet(ExponentialFamily):
         new._validate_args = self._validate_args
         return new
 
-    def rsample(self, sample_shape: _size = ()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = ()) -> Tensor:
         shape = self._extended_shape(sample_shape)
         concentration = self.concentration.expand(shape)
         return _Dirichlet.apply(concentration)

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -1,11 +1,11 @@
 # mypy: allow-untyped-defs
 import torch
+from torch import Tensor
 from torch.autograd import Function
 from torch.autograd.function import once_differentiable
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["Dirichlet"]

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -87,11 +87,11 @@ class Dirichlet(ExponentialFamily):
         )
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.concentration / self.concentration.sum(-1, True)
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         concentrationm1 = (self.concentration - 1).clamp(min=0.0)
         mode = concentrationm1 / concentrationm1.sum(-1, True)
         mask = (self.concentration < 1).all(axis=-1)
@@ -101,7 +101,7 @@ class Dirichlet(ExponentialFamily):
         return mode
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         con0 = self.concentration.sum(-1, True)
         return (
             self.concentration
@@ -120,7 +120,7 @@ class Dirichlet(ExponentialFamily):
         )
 
     @property
-    def _natural_params(self):
+    def _natural_params(self) -> tuple[Tensor]:
         return (self.concentration,)
 
     def _log_normalizer(self, x):

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -1,6 +1,6 @@
 # mypy: allow-untyped-defs
 import warnings
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 from typing_extensions import deprecated
 
 import torch
@@ -114,7 +114,7 @@ class Distribution:
         return self._event_shape
 
     @property
-    def arg_constraints(self) -> Dict[str, constraints.Constraint]:
+    def arg_constraints(self) -> dict[str, constraints.Constraint]:
         """
         Returns a dictionary from argument names to
         :class:`~torch.distributions.constraints.Constraint` objects that

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -1,6 +1,6 @@
 # mypy: allow-untyped-defs
 import warnings
-from typing import Any, Optional
+from typing import Optional
 from typing_extensions import deprecated
 
 import torch
@@ -124,7 +124,7 @@ class Distribution:
         raise NotImplementedError
 
     @property
-    def support(self) -> Optional[Any]:
+    def support(self) -> Optional[constraints.Constraint]:
         """
         Returns a :class:`~torch.distributions.constraints.Constraint` object
         representing this distribution's support.

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -7,6 +7,7 @@ import torch
 from torch.distributions import constraints
 from torch.distributions.utils import lazy_property
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["Distribution"]
@@ -131,34 +132,34 @@ class Distribution:
         raise NotImplementedError
 
     @property
-    def mean(self) -> torch.Tensor:
+    def mean(self) -> Tensor:
         """
         Returns the mean of the distribution.
         """
         raise NotImplementedError
 
     @property
-    def mode(self) -> torch.Tensor:
+    def mode(self) -> Tensor:
         """
         Returns the mode of the distribution.
         """
         raise NotImplementedError(f"{self.__class__} does not implement mode")
 
     @property
-    def variance(self) -> torch.Tensor:
+    def variance(self) -> Tensor:
         """
         Returns the variance of the distribution.
         """
         raise NotImplementedError
 
     @property
-    def stddev(self) -> torch.Tensor:
+    def stddev(self) -> Tensor:
         """
         Returns the standard deviation of the distribution.
         """
         return self.variance.sqrt()
 
-    def sample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def sample(self, sample_shape: _size = torch.Size()) -> Tensor:
         """
         Generates a sample_shape shaped sample or sample_shape shaped batch of
         samples if the distribution parameters are batched.
@@ -166,7 +167,7 @@ class Distribution:
         with torch.no_grad():
             return self.rsample(sample_shape)
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
         """
         Generates a sample_shape shaped reparameterized sample or sample_shape
         shaped batch of reparameterized samples if the distribution parameters
@@ -178,14 +179,14 @@ class Distribution:
         "`sample_n(n)` will be deprecated. Use `sample((n,))` instead.",
         category=FutureWarning,
     )
-    def sample_n(self, n: int) -> torch.Tensor:
+    def sample_n(self, n: int) -> Tensor:
         """
         Generates n samples or n batches of samples if the distribution
         parameters are batched.
         """
         return self.sample(torch.Size((n,)))
 
-    def log_prob(self, value: torch.Tensor) -> torch.Tensor:
+    def log_prob(self, value: Tensor) -> Tensor:
         """
         Returns the log of the probability density/mass function evaluated at
         `value`.
@@ -195,7 +196,7 @@ class Distribution:
         """
         raise NotImplementedError
 
-    def cdf(self, value: torch.Tensor) -> torch.Tensor:
+    def cdf(self, value: Tensor) -> Tensor:
         """
         Returns the cumulative density/mass function evaluated at
         `value`.
@@ -205,7 +206,7 @@ class Distribution:
         """
         raise NotImplementedError
 
-    def icdf(self, value: torch.Tensor) -> torch.Tensor:
+    def icdf(self, value: Tensor) -> Tensor:
         """
         Returns the inverse cumulative density/mass function evaluated at
         `value`.
@@ -215,7 +216,7 @@ class Distribution:
         """
         raise NotImplementedError
 
-    def enumerate_support(self, expand: bool = True) -> torch.Tensor:
+    def enumerate_support(self, expand: bool = True) -> Tensor:
         """
         Returns tensor containing all values supported by a discrete
         distribution. The result will enumerate over dimension 0, so the shape
@@ -239,7 +240,7 @@ class Distribution:
         """
         raise NotImplementedError
 
-    def entropy(self) -> torch.Tensor:
+    def entropy(self) -> Tensor:
         """
         Returns entropy of distribution, batched over batch_shape.
 
@@ -248,7 +249,7 @@ class Distribution:
         """
         raise NotImplementedError
 
-    def perplexity(self) -> torch.Tensor:
+    def perplexity(self) -> Tensor:
         """
         Returns perplexity of distribution, batched over batch_shape.
 
@@ -271,7 +272,7 @@ class Distribution:
             sample_shape = torch.Size(sample_shape)
         return torch.Size(sample_shape + self._batch_shape + self._event_shape)
 
-    def _validate_sample(self, value: torch.Tensor) -> None:
+    def _validate_sample(self, value: Tensor) -> None:
         """
         Argument validation for distribution methods such as `log_prob`,
         `cdf` and `icdf`. The rightmost dimensions of a value to be

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -4,10 +4,10 @@ from typing import Any, Optional
 from typing_extensions import deprecated
 
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.utils import lazy_property
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["Distribution"]

--- a/torch/distributions/exp_family.py
+++ b/torch/distributions/exp_family.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import torch
 from torch.distributions.distribution import Distribution
+from torch import Tensor
 
 
 __all__ = ["ExponentialFamily"]

--- a/torch/distributions/exp_family.py
+++ b/torch/distributions/exp_family.py
@@ -29,7 +29,7 @@ class ExponentialFamily(Distribution):
     """
 
     @property
-    def _natural_params(self):
+    def _natural_params(self) -> tuple[Tensor, ...]:
         """
         Abstract method for natural parameters. Returns a tuple of Tensors based
         on the distribution
@@ -44,7 +44,7 @@ class ExponentialFamily(Distribution):
         raise NotImplementedError
 
     @property
-    def _mean_carrier_measure(self):
+    def _mean_carrier_measure(self) -> float:
         """
         Abstract method for expected carrier measure, which is required for computing
         entropy.

--- a/torch/distributions/exp_family.py
+++ b/torch/distributions/exp_family.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import torch
-from torch.distributions.distribution import Distribution
 from torch import Tensor
+from torch.distributions.distribution import Distribution
 
 
 __all__ = ["ExponentialFamily"]

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -2,11 +2,11 @@
 from numbers import Number
 
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["Exponential"]

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -32,19 +32,19 @@ class Exponential(ExponentialFamily):
     _mean_carrier_measure = 0
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.rate.reciprocal()
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return torch.zeros_like(self.rate)
 
     @property
-    def stddev(self):
+    def stddev(self) -> Tensor:
         return self.rate.reciprocal()
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return self.rate.pow(-2)
 
     def __init__(self, rate, validate_args=None):
@@ -81,7 +81,7 @@ class Exponential(ExponentialFamily):
         return 1.0 - torch.log(self.rate)
 
     @property
-    def _natural_params(self):
+    def _natural_params(self) -> tuple[Tensor]:
         return (-self.rate,)
 
     def _log_normalizer(self, x):

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -6,6 +6,7 @@ from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["Exponential"]
@@ -59,7 +60,7 @@ class Exponential(ExponentialFamily):
         new._validate_args = self._validate_args
         return new
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
         shape = self._extended_shape(sample_shape)
         return self.rate.new(shape).exponential_() / self.rate
 

--- a/torch/distributions/fishersnedecor.py
+++ b/torch/distributions/fishersnedecor.py
@@ -2,13 +2,12 @@
 from numbers import Number
 
 import torch
-from torch import nan
+from torch import nan, Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.gamma import Gamma
 from torch.distributions.utils import broadcast_all
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["FisherSnedecor"]

--- a/torch/distributions/fishersnedecor.py
+++ b/torch/distributions/fishersnedecor.py
@@ -8,6 +8,7 @@ from torch.distributions.distribution import Distribution
 from torch.distributions.gamma import Gamma
 from torch.distributions.utils import broadcast_all
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["FisherSnedecor"]
@@ -77,7 +78,7 @@ class FisherSnedecor(Distribution):
             / (self.df1 * (df2 - 2).pow(2) * (df2 - 4))
         )
 
-    def rsample(self, sample_shape: _size = torch.Size(())) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size(())) -> Tensor:
         shape = self._extended_shape(sample_shape)
         #   X1 ~ Gamma(df1 / 2, 1 / df1), X2 ~ Gamma(df2 / 2, 1 / df2)
         #   Y = df2 * df1 * X1 / (df1 * df2 * X2) = X1 / X2 ~ F(df1, df2)

--- a/torch/distributions/fishersnedecor.py
+++ b/torch/distributions/fishersnedecor.py
@@ -56,19 +56,19 @@ class FisherSnedecor(Distribution):
         return new
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         df2 = self.df2.clone(memory_format=torch.contiguous_format)
         df2[df2 <= 2] = nan
         return df2 / (df2 - 2)
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         mode = (self.df1 - 2) / self.df1 * self.df2 / (self.df2 + 2)
         mode[self.df1 <= 2] = nan
         return mode
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         df2 = self.df2.clone(memory_format=torch.contiguous_format)
         df2[df2 <= 4] = nan
         return (

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -42,15 +42,15 @@ class Gamma(ExponentialFamily):
     _mean_carrier_measure = 0
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.concentration / self.rate
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return ((self.concentration - 1) / self.rate).clamp(min=0)
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return self.concentration / self.rate.pow(2)
 
     def __init__(self, concentration, rate, validate_args=None):
@@ -100,7 +100,7 @@ class Gamma(ExponentialFamily):
         )
 
     @property
-    def _natural_params(self):
+    def _natural_params(self) -> tuple[Tensor, Tensor]:
         return (self.concentration - 1, -self.rate)
 
     def _log_normalizer(self, x, y):

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -6,6 +6,7 @@ from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["Gamma"]
@@ -69,7 +70,7 @@ class Gamma(ExponentialFamily):
         new._validate_args = self._validate_args
         return new
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
         shape = self._extended_shape(sample_shape)
         value = _standard_gamma(self.concentration.expand(shape)) / self.rate.expand(
             shape

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -2,11 +2,11 @@
 from numbers import Number
 
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["Gamma"]

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -11,6 +11,7 @@ from torch.distributions.utils import (
     probs_to_logits,
 )
 from torch.nn.functional import binary_cross_entropy_with_logits
+from torch import Tensor
 
 
 __all__ = ["Geometric"]
@@ -96,11 +97,11 @@ class Geometric(Distribution):
         return (1.0 / self.probs - 1.0) / self.probs
 
     @lazy_property
-    def logits(self):
+    def logits(self) -> Tensor:
         return probs_to_logits(self.probs, is_binary=True)
 
     @lazy_property
-    def probs(self):
+    def probs(self) -> Tensor:
         return logits_to_probs(self.logits, is_binary=True)
 
     def sample(self, sample_shape=torch.Size()):

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -2,6 +2,7 @@
 from numbers import Number
 
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import (
@@ -11,7 +12,6 @@ from torch.distributions.utils import (
     probs_to_logits,
 )
 from torch.nn.functional import binary_cross_entropy_with_logits
-from torch import Tensor
 
 
 __all__ = ["Geometric"]

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -85,15 +85,15 @@ class Geometric(Distribution):
         return new
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return 1.0 / self.probs - 1.0
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return torch.zeros_like(self.probs)
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return (1.0 / self.probs - 1.0) / self.probs
 
     @lazy_property

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -8,6 +8,7 @@ from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import AffineTransform, ExpTransform
 from torch.distributions.uniform import Uniform
 from torch.distributions.utils import broadcast_all, euler_constant
+from torch import Tensor
 
 
 __all__ = ["Gumbel"]

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -65,19 +65,19 @@ class Gumbel(TransformedDistribution):
         return (y - y.exp()) - self.scale.log()
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.loc + self.scale * euler_constant
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return self.loc
 
     @property
-    def stddev(self):
+    def stddev(self) -> Tensor:
         return (math.pi / math.sqrt(6)) * self.scale
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return self.stddev.pow(2)
 
     def entropy(self):

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -3,12 +3,12 @@ import math
 from numbers import Number
 
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import AffineTransform, ExpTransform
 from torch.distributions.uniform import Uniform
 from torch.distributions.utils import broadcast_all, euler_constant
-from torch import Tensor
 
 
 __all__ = ["Gumbel"]

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -2,12 +2,11 @@
 import math
 
 import torch
-from torch import inf
+from torch import inf, Tensor
 from torch.distributions import constraints
 from torch.distributions.cauchy import Cauchy
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import AbsTransform
-from torch import Tensor
 
 
 __all__ = ["HalfCauchy"]

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -7,6 +7,7 @@ from torch.distributions import constraints
 from torch.distributions.cauchy import Cauchy
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import AbsTransform
+from torch import Tensor
 
 
 __all__ = ["HalfCauchy"]

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -43,11 +43,11 @@ class HalfCauchy(TransformedDistribution):
         return super().expand(batch_shape, _instance=new)
 
     @property
-    def scale(self):
+    def scale(self) -> Tensor:
         return self.base_dist.scale
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return torch.full(
             self._extended_shape(),
             math.inf,
@@ -56,11 +56,11 @@ class HalfCauchy(TransformedDistribution):
         )
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return torch.zeros_like(self.scale)
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return self.base_dist.variance
 
     def log_prob(self, value):

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -43,19 +43,19 @@ class HalfNormal(TransformedDistribution):
         return super().expand(batch_shape, _instance=new)
 
     @property
-    def scale(self):
+    def scale(self) -> Tensor:
         return self.base_dist.scale
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.scale * math.sqrt(2 / math.pi)
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return torch.zeros_like(self.scale)
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return self.scale.pow(2) * (1 - 2 / math.pi)
 
     def log_prob(self, value):

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -2,12 +2,11 @@
 import math
 
 import torch
-from torch import inf
+from torch import inf, Tensor
 from torch.distributions import constraints
 from torch.distributions.normal import Normal
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import AbsTransform
-from torch import Tensor
 
 
 __all__ = ["HalfNormal"]

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -7,6 +7,7 @@ from torch.distributions import constraints
 from torch.distributions.normal import Normal
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import AbsTransform
+from torch import Tensor
 
 
 __all__ = ["HalfNormal"]

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -1,5 +1,4 @@
 # mypy: allow-untyped-defs
-from typing import Dict
 
 import torch
 from torch.distributions import constraints
@@ -41,7 +40,7 @@ class Independent(Distribution):
         reinterpreted_batch_ndims (int): the number of batch dims to
             reinterpret as event dims
     """
-    arg_constraints: Dict[str, constraints.Constraint] = {}
+    arg_constraints: dict[str, constraints.Constraint] = {}
 
     def __init__(
         self, base_distribution, reinterpreted_batch_ndims, validate_args=None

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -6,6 +6,7 @@ from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import _sum_rightmost
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["Independent"]
@@ -103,7 +104,7 @@ class Independent(Distribution):
     def sample(self, sample_shape=torch.Size()):
         return self.base_dist.sample(sample_shape)
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
         return self.base_dist.rsample(sample_shape)
 
     def log_prob(self, value):

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -73,11 +73,11 @@ class Independent(Distribution):
         return new
 
     @property
-    def has_rsample(self):
+    def has_rsample(self) -> bool:  # type: ignore[override]
         return self.base_dist.has_rsample
 
     @property
-    def has_enumerate_support(self):
+    def has_enumerate_support(self) -> bool:  # type: ignore[override]
         if self.reinterpreted_batch_ndims > 0:
             return False
         return self.base_dist.has_enumerate_support
@@ -90,18 +90,18 @@ class Independent(Distribution):
         return result
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.base_dist.mean
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return self.base_dist.mode
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return self.base_dist.variance
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=torch.Size()) -> Tensor:
         return self.base_dist.sample(sample_shape)
 
     def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -1,11 +1,11 @@
 # mypy: allow-untyped-defs
 
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import _sum_rightmost
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["Independent"]

--- a/torch/distributions/inverse_gamma.py
+++ b/torch/distributions/inverse_gamma.py
@@ -4,6 +4,7 @@ from torch.distributions import constraints
 from torch.distributions.gamma import Gamma
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import PowerTransform
+from torch import Tensor
 
 
 __all__ = ["InverseGamma"]

--- a/torch/distributions/inverse_gamma.py
+++ b/torch/distributions/inverse_gamma.py
@@ -50,24 +50,24 @@ class InverseGamma(TransformedDistribution):
         return super().expand(batch_shape, _instance=new)
 
     @property
-    def concentration(self):
+    def concentration(self) -> Tensor:
         return self.base_dist.concentration
 
     @property
-    def rate(self):
+    def rate(self) -> Tensor:
         return self.base_dist.rate
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         result = self.rate / (self.concentration - 1)
         return torch.where(self.concentration > 1, result, torch.inf)
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return self.rate / (self.concentration + 1)
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         result = self.rate.square() / (
             (self.concentration - 1).square() * (self.concentration - 2)
         )

--- a/torch/distributions/inverse_gamma.py
+++ b/torch/distributions/inverse_gamma.py
@@ -1,10 +1,10 @@
 # mypy: allow-untyped-defs
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.gamma import Gamma
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import PowerTransform
-from torch import Tensor
 
 
 __all__ = ["InverseGamma"]

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -5,7 +5,7 @@ from functools import total_ordering
 from typing import Callable
 
 import torch
-from torch import inf
+from torch import inf, Tensor
 
 from .bernoulli import Bernoulli
 from .beta import Beta
@@ -36,7 +36,6 @@ from .poisson import Poisson
 from .transformed_distribution import TransformedDistribution
 from .uniform import Uniform
 from .utils import _sum_rightmost, euler_constant as _euler_gamma
-from torch import Tensor
 
 
 _KL_REGISTRY: dict[

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -2,7 +2,7 @@
 import math
 import warnings
 from functools import total_ordering
-from typing import Callable, Tuple, Type
+from typing import Callable, Type
 
 import torch
 from torch import inf
@@ -40,10 +40,10 @@ from torch import Tensor
 
 
 _KL_REGISTRY: dict[
-    Tuple[Type, Type], Callable
+    tuple[Type, Type], Callable
 ] = {}  # Source of truth mapping a few general (type, type) pairs to functions.
 _KL_MEMOIZE: dict[
-    Tuple[Type, Type], Callable
+    tuple[Type, Type], Callable
 ] = {}  # Memoized version mapping many specific (type, type) pairs to functions.
 
 __all__ = ["register_kl", "kl_divergence"]

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -2,7 +2,7 @@
 import math
 import warnings
 from functools import total_ordering
-from typing import Callable, Type
+from typing import Callable
 
 import torch
 from torch import inf
@@ -40,10 +40,10 @@ from torch import Tensor
 
 
 _KL_REGISTRY: dict[
-    tuple[Type, Type], Callable
+    tuple[type, type], Callable
 ] = {}  # Source of truth mapping a few general (type, type) pairs to functions.
 _KL_MEMOIZE: dict[
-    tuple[Type, Type], Callable
+    tuple[type, type], Callable
 ] = {}  # Memoized version mapping many specific (type, type) pairs to functions.
 
 __all__ = ["register_kl", "kl_divergence"]

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -36,6 +36,7 @@ from .poisson import Poisson
 from .transformed_distribution import TransformedDistribution
 from .uniform import Uniform
 from .utils import _sum_rightmost, euler_constant as _euler_gamma
+from torch import Tensor
 
 
 _KL_REGISTRY: Dict[
@@ -161,7 +162,7 @@ def _batch_trace_XXT(bmat):
     return flat_trace.reshape(bmat.shape[:-2])
 
 
-def kl_divergence(p: Distribution, q: Distribution) -> torch.Tensor:
+def kl_divergence(p: Distribution, q: Distribution) -> Tensor:
     r"""
     Compute Kullback-Leibler divergence :math:`KL(p \| q)` between two distributions.
 

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -2,7 +2,7 @@
 import math
 import warnings
 from functools import total_ordering
-from typing import Callable, Dict, Tuple, Type
+from typing import Callable, Tuple, Type
 
 import torch
 from torch import inf
@@ -39,10 +39,10 @@ from .utils import _sum_rightmost, euler_constant as _euler_gamma
 from torch import Tensor
 
 
-_KL_REGISTRY: Dict[
+_KL_REGISTRY: dict[
     Tuple[Type, Type], Callable
 ] = {}  # Source of truth mapping a few general (type, type) pairs to functions.
-_KL_MEMOIZE: Dict[
+_KL_MEMOIZE: dict[
     Tuple[Type, Type], Callable
 ] = {}  # Memoized version mapping many specific (type, type) pairs to functions.
 

--- a/torch/distributions/kumaraswamy.py
+++ b/torch/distributions/kumaraswamy.py
@@ -1,12 +1,11 @@
 # mypy: allow-untyped-defs
 import torch
-from torch import nan
+from torch import nan, Tensor
 from torch.distributions import constraints
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import AffineTransform, PowerTransform
 from torch.distributions.uniform import Uniform
 from torch.distributions.utils import broadcast_all, euler_constant
-from torch import Tensor
 
 
 __all__ = ["Kumaraswamy"]

--- a/torch/distributions/kumaraswamy.py
+++ b/torch/distributions/kumaraswamy.py
@@ -6,6 +6,7 @@ from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import AffineTransform, PowerTransform
 from torch.distributions.uniform import Uniform
 from torch.distributions.utils import broadcast_all, euler_constant
+from torch import Tensor
 
 
 __all__ = ["Kumaraswamy"]

--- a/torch/distributions/kumaraswamy.py
+++ b/torch/distributions/kumaraswamy.py
@@ -68,11 +68,11 @@ class Kumaraswamy(TransformedDistribution):
         return super().expand(batch_shape, _instance=new)
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return _moments(self.concentration1, self.concentration0, 1)
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         # Evaluate in log-space for numerical stability.
         log_mode = (
             self.concentration0.reciprocal() * (-self.concentration0).log1p()
@@ -82,7 +82,7 @@ class Kumaraswamy(TransformedDistribution):
         return log_mode.exp()
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return _moments(self.concentration1, self.concentration0, 2) - torch.pow(
             self.mean, 2
         )

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -32,19 +32,19 @@ class Laplace(Distribution):
     has_rsample = True
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.loc
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return self.loc
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return 2 * self.scale.pow(2)
 
     @property
-    def stddev(self):
+    def stddev(self) -> Tensor:
         return (2**0.5) * self.scale
 
     def __init__(self, loc, scale, validate_args=None):

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -6,6 +6,7 @@ from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["Laplace"]
@@ -63,7 +64,7 @@ class Laplace(Distribution):
         new._validate_args = self._validate_args
         return new
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
         shape = self._extended_shape(sample_shape)
         finfo = torch.finfo(self.loc.dtype)
         if torch._C._get_tracing_state():

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -2,11 +2,11 @@
 from numbers import Number
 
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["Laplace"]

--- a/torch/distributions/lkj_cholesky.py
+++ b/torch/distributions/lkj_cholesky.py
@@ -14,6 +14,7 @@ import torch
 from torch.distributions import Beta, constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
+from torch import Tensor
 
 
 __all__ = ["LKJCholesky"]

--- a/torch/distributions/lkj_cholesky.py
+++ b/torch/distributions/lkj_cholesky.py
@@ -14,7 +14,6 @@ import torch
 from torch.distributions import Beta, constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
-from torch import Tensor
 
 
 __all__ = ["LKJCholesky"]

--- a/torch/distributions/log_normal.py
+++ b/torch/distributions/log_normal.py
@@ -1,9 +1,9 @@
 # mypy: allow-untyped-defs
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.normal import Normal
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import ExpTransform
-from torch import Tensor
 
 
 __all__ = ["LogNormal"]

--- a/torch/distributions/log_normal.py
+++ b/torch/distributions/log_normal.py
@@ -3,6 +3,7 @@ from torch.distributions import constraints
 from torch.distributions.normal import Normal
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import ExpTransform
+from torch import Tensor
 
 
 __all__ = ["LogNormal"]

--- a/torch/distributions/log_normal.py
+++ b/torch/distributions/log_normal.py
@@ -41,23 +41,23 @@ class LogNormal(TransformedDistribution):
         return super().expand(batch_shape, _instance=new)
 
     @property
-    def loc(self):
+    def loc(self) -> Tensor:
         return self.base_dist.loc
 
     @property
-    def scale(self):
+    def scale(self) -> Tensor:
         return self.base_dist.scale
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return (self.loc + self.scale.pow(2) / 2).exp()
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return (self.loc - self.scale.square()).exp()
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         scale_sq = self.scale.pow(2)
         return scale_sq.expm1() * (2 * self.loc + scale_sq).exp()
 

--- a/torch/distributions/logistic_normal.py
+++ b/torch/distributions/logistic_normal.py
@@ -1,9 +1,9 @@
 # mypy: allow-untyped-defs
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.normal import Normal
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import StickBreakingTransform
-from torch import Tensor
 
 
 __all__ = ["LogisticNormal"]

--- a/torch/distributions/logistic_normal.py
+++ b/torch/distributions/logistic_normal.py
@@ -49,9 +49,9 @@ class LogisticNormal(TransformedDistribution):
         return super().expand(batch_shape, _instance=new)
 
     @property
-    def loc(self):
+    def loc(self) -> Tensor:
         return self.base_dist.base_dist.loc
 
     @property
-    def scale(self):
+    def scale(self) -> Tensor:
         return self.base_dist.base_dist.scale

--- a/torch/distributions/logistic_normal.py
+++ b/torch/distributions/logistic_normal.py
@@ -3,6 +3,7 @@ from torch.distributions import constraints
 from torch.distributions.normal import Normal
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import StickBreakingTransform
+from torch import Tensor
 
 
 __all__ = ["LogisticNormal"]

--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -7,6 +7,7 @@ from torch.distributions.distribution import Distribution
 from torch.distributions.multivariate_normal import _batch_mahalanobis, _batch_mv
 from torch.distributions.utils import _standard_normal, lazy_property
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["LowRankMultivariateNormal"]
@@ -151,13 +152,13 @@ class LowRankMultivariateNormal(Distribution):
         return self.loc
 
     @lazy_property
-    def variance(self):
+    def variance(self) -> Tensor:  # type: ignore[override]
         return (
             self._unbroadcasted_cov_factor.pow(2).sum(-1) + self._unbroadcasted_cov_diag
         ).expand(self._batch_shape + self._event_shape)
 
     @lazy_property
-    def scale_tril(self):
+    def scale_tril(self) -> Tensor:
         # The following identity is used to increase the numerically computation stability
         # for Cholesky decomposition (see http://www.gaussianprocess.org/gpml/, Section 3.4.3):
         #     W @ W.T + D = D1/2 @ (I + D-1/2 @ W @ W.T @ D-1/2) @ D1/2
@@ -174,7 +175,7 @@ class LowRankMultivariateNormal(Distribution):
         )
 
     @lazy_property
-    def covariance_matrix(self):
+    def covariance_matrix(self) -> Tensor:
         covariance_matrix = torch.matmul(
             self._unbroadcasted_cov_factor, self._unbroadcasted_cov_factor.mT
         ) + torch.diag_embed(self._unbroadcasted_cov_diag)
@@ -183,7 +184,7 @@ class LowRankMultivariateNormal(Distribution):
         )
 
     @lazy_property
-    def precision_matrix(self):
+    def precision_matrix(self) -> Tensor:
         # We use "Woodbury matrix identity" to take advantage of low rank form::
         #     inv(W @ W.T + D) = inv(D) - inv(D) @ W @ inv(C) @ W.T @ inv(D)
         # where :math:`C` is the capacitance matrix.
@@ -199,7 +200,7 @@ class LowRankMultivariateNormal(Distribution):
             self._batch_shape + self._event_shape + self._event_shape
         )
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
         shape = self._extended_shape(sample_shape)
         W_shape = shape[:-1] + self.cov_factor.shape[-1:]
         eps_W = _standard_normal(W_shape, dtype=self.loc.dtype, device=self.loc.device)

--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -2,12 +2,12 @@
 import math
 
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.multivariate_normal import _batch_mahalanobis, _batch_mv
 from torch.distributions.utils import _standard_normal, lazy_property
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["LowRankMultivariateNormal"]

--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -144,11 +144,11 @@ class LowRankMultivariateNormal(Distribution):
         return new
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.loc
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return self.loc
 
     @lazy_property

--- a/torch/distributions/mixture_same_family.py
+++ b/torch/distributions/mixture_same_family.py
@@ -4,6 +4,7 @@ from typing import Dict
 import torch
 from torch.distributions import Categorical, constraints
 from torch.distributions.distribution import Distribution
+from torch import Tensor
 
 
 __all__ = ["MixtureSameFamily"]

--- a/torch/distributions/mixture_same_family.py
+++ b/torch/distributions/mixture_same_family.py
@@ -56,8 +56,8 @@ class MixtureSameFamily(Distribution):
     has_rsample = False
 
     def __init__(
-        self, mixture_distribution, component_distribution, validate_args=None
-    ):
+        self, mixture_distribution: Categorical, component_distribution: Distribution, validate_args=None
+    ) -> None:
         self._mixture_distribution = mixture_distribution
         self._component_distribution = component_distribution
 
@@ -125,22 +125,22 @@ class MixtureSameFamily(Distribution):
         return self._component_distribution.support
 
     @property
-    def mixture_distribution(self):
+    def mixture_distribution(self) -> Categorical:
         return self._mixture_distribution
 
     @property
-    def component_distribution(self):
+    def component_distribution(self) -> Distribution:
         return self._component_distribution
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         probs = self._pad_mixture_dimensions(self.mixture_distribution.probs)
         return torch.sum(
             probs * self.component_distribution.mean, dim=-1 - self._event_ndims
         )  # [B, E]
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         # Law of total variance: Var(Y) = E[Var(Y|X)] + Var(E[Y|X])
         probs = self._pad_mixture_dimensions(self.mixture_distribution.probs)
         mean_cond_var = torch.sum(

--- a/torch/distributions/mixture_same_family.py
+++ b/torch/distributions/mixture_same_family.py
@@ -1,5 +1,4 @@
 # mypy: allow-untyped-defs
-from typing import Dict
 
 import torch
 from torch.distributions import Categorical, constraints
@@ -52,7 +51,7 @@ class MixtureSameFamily(Distribution):
         component_distribution: `torch.distributions.Distribution`-like
             instance. Right-most batch dimension indexes component.
     """
-    arg_constraints: Dict[str, constraints.Constraint] = {}
+    arg_constraints: dict[str, constraints.Constraint] = {}
     has_rsample = False
 
     def __init__(

--- a/torch/distributions/mixture_same_family.py
+++ b/torch/distributions/mixture_same_family.py
@@ -1,9 +1,9 @@
 # mypy: allow-untyped-defs
 
 import torch
+from torch import Tensor
 from torch.distributions import Categorical, constraints
 from torch.distributions.distribution import Distribution
-from torch import Tensor
 
 
 __all__ = ["MixtureSameFamily"]
@@ -55,7 +55,10 @@ class MixtureSameFamily(Distribution):
     has_rsample = False
 
     def __init__(
-        self, mixture_distribution: Categorical, component_distribution: Distribution, validate_args=None
+        self,
+        mixture_distribution: Categorical,
+        component_distribution: Distribution,
+        validate_args=None,
     ) -> None:
         self._mixture_distribution = mixture_distribution
         self._component_distribution = component_distribution

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -1,11 +1,10 @@
 # mypy: allow-untyped-defs
 import torch
-from torch import inf
+from torch import inf, Tensor
 from torch.distributions import Categorical, constraints
 from torch.distributions.binomial import Binomial
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
-from torch import Tensor
 
 
 __all__ = ["Multinomial"]

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -52,11 +52,11 @@ class Multinomial(Distribution):
     total_count: int
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.probs * self.total_count
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return self.total_count * self.probs * (1 - self.probs)
 
     def __init__(self, total_count=1, probs=None, logits=None, validate_args=None):
@@ -88,15 +88,15 @@ class Multinomial(Distribution):
         return constraints.multinomial(self.total_count)
 
     @property
-    def logits(self):
+    def logits(self) -> Tensor:
         return self._categorical.logits
 
     @property
-    def probs(self):
+    def probs(self) -> Tensor:
         return self._categorical.probs
 
     @property
-    def param_shape(self):
+    def param_shape(self) -> torch.Size:
         return self._categorical.param_shape
 
     def sample(self, sample_shape=torch.Size()):

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -5,6 +5,7 @@ from torch.distributions import Categorical, constraints
 from torch.distributions.binomial import Binomial
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
+from torch import Tensor
 
 
 __all__ = ["Multinomial"]

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -6,6 +6,7 @@ from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import _standard_normal, lazy_property
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["MultivariateNormal"]
@@ -206,19 +207,19 @@ class MultivariateNormal(Distribution):
         return new
 
     @lazy_property
-    def scale_tril(self):
+    def scale_tril(self) -> Tensor:
         return self._unbroadcasted_scale_tril.expand(
             self._batch_shape + self._event_shape + self._event_shape
         )
 
     @lazy_property
-    def covariance_matrix(self):
+    def covariance_matrix(self) -> Tensor:
         return torch.matmul(
             self._unbroadcasted_scale_tril, self._unbroadcasted_scale_tril.mT
         ).expand(self._batch_shape + self._event_shape + self._event_shape)
 
     @lazy_property
-    def precision_matrix(self):
+    def precision_matrix(self) -> Tensor:
         return torch.cholesky_inverse(self._unbroadcasted_scale_tril).expand(
             self._batch_shape + self._event_shape + self._event_shape
         )
@@ -239,7 +240,7 @@ class MultivariateNormal(Distribution):
             .expand(self._batch_shape + self._event_shape)
         )
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
         shape = self._extended_shape(sample_shape)
         eps = _standard_normal(shape, dtype=self.loc.dtype, device=self.loc.device)
         return self.loc + _batch_mv(self._unbroadcasted_scale_tril, eps)

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -2,11 +2,11 @@
 import math
 
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import _standard_normal, lazy_property
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["MultivariateNormal"]

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -225,15 +225,15 @@ class MultivariateNormal(Distribution):
         )
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.loc
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return self.loc
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return (
             self._unbroadcasted_scale_tril.pow(2)
             .sum(-1)

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -1,15 +1,16 @@
 # mypy: allow-untyped-defs
 import torch
 import torch.nn.functional as F
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
+from torch.distributions.gamma import Gamma
 from torch.distributions.utils import (
     broadcast_all,
     lazy_property,
     logits_to_probs,
     probs_to_logits,
 )
-from torch import Tensor
 
 
 __all__ = ["NegativeBinomial"]
@@ -100,9 +101,9 @@ class NegativeBinomial(Distribution):
         return self._param.size()
 
     @lazy_property
-    def _gamma(self) -> torch.distributions.Gamma:
+    def _gamma(self) -> Gamma:
         # Note we avoid validating because self.total_count can be zero.
-        return torch.distributions.Gamma(
+        return Gamma(
             concentration=self.total_count,
             rate=torch.exp(-self.logits),
             validate_args=False,

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -9,6 +9,7 @@ from torch.distributions.utils import (
     logits_to_probs,
     probs_to_logits,
 )
+from torch import Tensor
 
 
 __all__ = ["NegativeBinomial"]
@@ -87,11 +88,11 @@ class NegativeBinomial(Distribution):
         return self.mean / torch.sigmoid(-self.logits)
 
     @lazy_property
-    def logits(self):
+    def logits(self) -> Tensor:
         return probs_to_logits(self.probs, is_binary=True)
 
     @lazy_property
-    def probs(self):
+    def probs(self) -> Tensor:
         return logits_to_probs(self.logits, is_binary=True)
 
     @property
@@ -99,7 +100,7 @@ class NegativeBinomial(Distribution):
         return self._param.size()
 
     @lazy_property
-    def _gamma(self):
+    def _gamma(self) -> torch.distributions.Gamma:
         # Note we avoid validating because self.total_count can be zero.
         return torch.distributions.Gamma(
             concentration=self.total_count,

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -76,15 +76,15 @@ class NegativeBinomial(Distribution):
         return self._param.new(*args, **kwargs)
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.total_count * torch.exp(self.logits)
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return ((self.total_count - 1) * self.logits.exp()).floor().clamp(min=0.0)
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return self.mean / torch.sigmoid(-self.logits)
 
     @lazy_property
@@ -96,7 +96,7 @@ class NegativeBinomial(Distribution):
         return logits_to_probs(self.logits, is_binary=True)
 
     @property
-    def param_shape(self):
+    def param_shape(self) -> torch.Size:
         return self._param.size()
 
     @lazy_property

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -7,6 +7,7 @@ from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import _standard_normal, broadcast_all
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["Normal"]
@@ -72,7 +73,7 @@ class Normal(ExponentialFamily):
         with torch.no_grad():
             return torch.normal(self.loc.expand(shape), self.scale.expand(shape))
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
         shape = self._extended_shape(sample_shape)
         eps = _standard_normal(shape, dtype=self.loc.dtype, device=self.loc.device)
         return self.loc + eps * self.scale

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -36,19 +36,19 @@ class Normal(ExponentialFamily):
     _mean_carrier_measure = 0
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.loc
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return self.loc
 
     @property
-    def stddev(self):
+    def stddev(self) -> Tensor:
         return self.scale
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return self.stddev.pow(2)
 
     def __init__(self, loc, scale, validate_args=None):
@@ -106,7 +106,7 @@ class Normal(ExponentialFamily):
         return 0.5 + 0.5 * math.log(2 * math.pi) + torch.log(self.scale)
 
     @property
-    def _natural_params(self):
+    def _natural_params(self) -> tuple[Tensor, Tensor]:
         return (self.loc / self.scale.pow(2), -0.5 * self.scale.pow(2).reciprocal())
 
     def _log_normalizer(self, x, y):

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -3,11 +3,11 @@ import math
 from numbers import Number, Real
 
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import _standard_normal, broadcast_all
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["Normal"]

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -63,33 +63,33 @@ class OneHotCategorical(Distribution):
         return self._categorical._new(*args, **kwargs)
 
     @property
-    def _param(self):
+    def _param(self) -> Tensor:
         return self._categorical._param
 
     @property
-    def probs(self):
+    def probs(self) -> Tensor:
         return self._categorical.probs
 
     @property
-    def logits(self):
+    def logits(self) -> Tensor:
         return self._categorical.logits
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self._categorical.probs
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         probs = self._categorical.probs
         mode = probs.argmax(dim=-1)
         return torch.nn.functional.one_hot(mode, num_classes=probs.shape[-1]).to(probs)
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return self._categorical.probs * (1 - self._categorical.probs)
 
     @property
-    def param_shape(self):
+    def param_shape(self) -> torch.Size:
         return self._categorical.param_shape
 
     def sample(self, sample_shape=torch.Size()):

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -4,6 +4,7 @@ from torch.distributions import constraints
 from torch.distributions.categorical import Categorical
 from torch.distributions.distribution import Distribution
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["OneHotCategorical", "OneHotCategoricalStraightThrough"]
@@ -80,7 +81,7 @@ class OneHotCategorical(Distribution):
     @property
     def mode(self):
         probs = self._categorical.probs
-        mode = probs.argmax(axis=-1)
+        mode = probs.argmax(dim=-1)
         return torch.nn.functional.one_hot(mode, num_classes=probs.shape[-1]).to(probs)
 
     @property
@@ -126,7 +127,7 @@ class OneHotCategoricalStraightThrough(OneHotCategorical):
     """
     has_rsample = True
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
         samples = self.sample(sample_shape)
         probs = self._categorical.probs  # cached via @lazy_property
         return samples + (probs - probs.detach())

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -1,10 +1,10 @@
 # mypy: allow-untyped-defs
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.categorical import Categorical
 from torch.distributions.distribution import Distribution
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["OneHotCategorical", "OneHotCategoricalStraightThrough"]

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -4,6 +4,7 @@ from torch.distributions.exponential import Exponential
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import AffineTransform, ExpTransform
 from torch.distributions.utils import broadcast_all
+from torch import Tensor
 
 
 __all__ = ["Pareto"]

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -1,10 +1,10 @@
 # mypy: allow-untyped-defs
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.exponential import Exponential
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import AffineTransform, ExpTransform
 from torch.distributions.utils import broadcast_all
-from torch import Tensor
 
 
 __all__ = ["Pareto"]

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -40,17 +40,17 @@ class Pareto(TransformedDistribution):
         return super().expand(batch_shape, _instance=new)
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         # mean is inf for alpha <= 1
         a = self.alpha.clamp(min=1)
         return a * self.scale / (a - 1)
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return self.scale
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         # var is inf for alpha <= 2
         a = self.alpha.clamp(min=2)
         return self.scale.pow(2) * a / ((a - 1).pow(2) * (a - 2))

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -2,10 +2,10 @@
 from numbers import Number
 
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all
-from torch import Tensor
 
 
 __all__ = ["Poisson"]

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -34,15 +34,15 @@ class Poisson(ExponentialFamily):
     support = constraints.nonnegative_integer
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.rate
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return self.rate.floor()
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return self.rate
 
     def __init__(self, rate, validate_args=None):
@@ -73,7 +73,7 @@ class Poisson(ExponentialFamily):
         return value.xlogy(rate) - rate - (value + 1).lgamma()
 
     @property
-    def _natural_params(self):
+    def _natural_params(self) -> tuple[Tensor]:
         return (torch.log(self.rate),)
 
     def _log_normalizer(self, x):

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -5,6 +5,7 @@ import torch
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all
+from torch import Tensor
 
 
 __all__ = ["Poisson"]

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -14,6 +14,7 @@ from torch.distributions.utils import (
     probs_to_logits,
 )
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["LogitRelaxedBernoulli", "RelaxedBernoulli"]
@@ -78,18 +79,18 @@ class LogitRelaxedBernoulli(Distribution):
         return self._param.new(*args, **kwargs)
 
     @lazy_property
-    def logits(self):
+    def logits(self) -> Tensor:
         return probs_to_logits(self.probs, is_binary=True)
 
     @lazy_property
-    def probs(self):
+    def probs(self) -> Tensor:
         return logits_to_probs(self.logits, is_binary=True)
 
     @property
     def param_shape(self):
         return self._param.size()
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
         shape = self._extended_shape(sample_shape)
         probs = clamp_probs(self.probs.expand(shape))
         uniforms = clamp_probs(

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -87,7 +87,7 @@ class LogitRelaxedBernoulli(Distribution):
         return logits_to_probs(self.logits, is_binary=True)
 
     @property
-    def param_shape(self):
+    def param_shape(self) -> torch.Size:
         return self._param.size()
 
     def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
@@ -141,13 +141,13 @@ class RelaxedBernoulli(TransformedDistribution):
         return super().expand(batch_shape, _instance=new)
 
     @property
-    def temperature(self):
+    def temperature(self) -> Tensor:
         return self.base_dist.temperature
 
     @property
-    def logits(self):
+    def logits(self) -> Tensor:
         return self.base_dist.logits
 
     @property
-    def probs(self):
+    def probs(self) -> Tensor:
         return self.base_dist.probs

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -2,6 +2,7 @@
 from numbers import Number
 
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.transformed_distribution import TransformedDistribution
@@ -14,7 +15,6 @@ from torch.distributions.utils import (
     probs_to_logits,
 )
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["LogitRelaxedBernoulli", "RelaxedBernoulli"]

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -63,15 +63,15 @@ class ExpRelaxedCategorical(Distribution):
         return self._categorical._new(*args, **kwargs)
 
     @property
-    def param_shape(self):
+    def param_shape(self) -> torch.Size:
         return self._categorical.param_shape
 
     @property
-    def logits(self):
+    def logits(self) -> Tensor:
         return self._categorical.logits
 
     @property
-    def probs(self):
+    def probs(self) -> Tensor:
         return self._categorical.probs
 
     def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
@@ -131,13 +131,13 @@ class RelaxedOneHotCategorical(TransformedDistribution):
         return super().expand(batch_shape, _instance=new)
 
     @property
-    def temperature(self):
+    def temperature(self) -> Tensor:
         return self.base_dist.temperature
 
     @property
-    def logits(self):
+    def logits(self) -> Tensor:
         return self.base_dist.logits
 
     @property
-    def probs(self):
+    def probs(self) -> Tensor:
         return self.base_dist.probs

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.categorical import Categorical
 from torch.distributions.distribution import Distribution
@@ -7,7 +8,6 @@ from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import ExpTransform
 from torch.distributions.utils import broadcast_all, clamp_probs
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["ExpRelaxedCategorical", "RelaxedOneHotCategorical"]

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -7,6 +7,7 @@ from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import ExpTransform
 from torch.distributions.utils import broadcast_all, clamp_probs
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["ExpRelaxedCategorical", "RelaxedOneHotCategorical"]
@@ -73,7 +74,7 @@ class ExpRelaxedCategorical(Distribution):
     def probs(self):
         return self._categorical.probs
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
         shape = self._extended_shape(sample_shape)
         uniforms = clamp_probs(
             torch.rand(shape, dtype=self.logits.dtype, device=self.logits.device)

--- a/torch/distributions/studentT.py
+++ b/torch/distributions/studentT.py
@@ -2,12 +2,11 @@
 import math
 
 import torch
-from torch import inf, nan
+from torch import inf, nan, Tensor
 from torch.distributions import Chi2, constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import _standard_normal, broadcast_all
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["StudentT"]

--- a/torch/distributions/studentT.py
+++ b/torch/distributions/studentT.py
@@ -39,17 +39,17 @@ class StudentT(Distribution):
     has_rsample = True
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         m = self.loc.clone(memory_format=torch.contiguous_format)
         m[self.df <= 1] = nan
         return m
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return self.loc
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         m = self.df.clone(memory_format=torch.contiguous_format)
         m[self.df > 2] = (
             self.scale[self.df > 2].pow(2)

--- a/torch/distributions/studentT.py
+++ b/torch/distributions/studentT.py
@@ -7,6 +7,7 @@ from torch.distributions import Chi2, constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import _standard_normal, broadcast_all
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["StudentT"]
@@ -76,7 +77,7 @@ class StudentT(Distribution):
         new._validate_args = self._validate_args
         return new
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
         # NOTE: This does not agree with scipy implementation as much as other distributions.
         # (see https://github.com/fritzo/notebooks/blob/master/debug-student-t.ipynb). Using DoubleTensor
         # parameters seems to help.

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -1,5 +1,4 @@
 # mypy: allow-untyped-defs
-from typing import Dict
 
 import torch
 from torch.distributions import constraints
@@ -47,7 +46,7 @@ class TransformedDistribution(Distribution):
     :class:`~torch.distributions.relaxed_bernoulli.RelaxedBernoulli` and
     :class:`~torch.distributions.relaxed_categorical.RelaxedOneHotCategorical`
     """
-    arg_constraints: Dict[str, constraints.Constraint] = {}
+    arg_constraints: dict[str, constraints.Constraint] = {}
 
     def __init__(self, base_distribution, transforms, validate_args=None):
         if isinstance(transforms, Transform):

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -1,13 +1,13 @@
 # mypy: allow-untyped-defs
 
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.independent import Independent
 from torch.distributions.transforms import ComposeTransform, Transform
 from torch.distributions.utils import _sum_rightmost
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["TransformedDistribution"]

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -8,6 +8,7 @@ from torch.distributions.independent import Independent
 from torch.distributions.transforms import ComposeTransform, Transform
 from torch.distributions.utils import _sum_rightmost
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["TransformedDistribution"]
@@ -143,7 +144,7 @@ class TransformedDistribution(Distribution):
                 x = transform(x)
             return x
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
         """
         Generates a sample_shape shaped reparameterized sample or sample_shape
         shaped batch of reparameterized samples if the distribution parameters

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -128,7 +128,7 @@ class TransformedDistribution(Distribution):
         return support
 
     @property
-    def has_rsample(self):
+    def has_rsample(self) -> bool:  # type: ignore[override]
         return self.base_dist.has_rsample
 
     def sample(self, sample_shape=torch.Size()):

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -17,6 +17,7 @@ from torch.distributions.utils import (
     vec_to_tril_matrix,
 )
 from torch.nn.functional import pad, softplus
+from torch import Tensor
 
 
 __all__ = [
@@ -327,11 +328,11 @@ class ComposeTransform(Transform):
         return codomain
 
     @lazy_property
-    def bijective(self):
+    def bijective(self) -> bool:  # type: ignore[override]
         return all(p.bijective for p in self.parts)
 
     @lazy_property
-    def sign(self):
+    def sign(self) -> int:
         sign = 1
         for p in self.parts:
             sign = sign * p.sign
@@ -577,7 +578,7 @@ class PowerTransform(Transform):
         return PowerTransform(self.exponent, cache_size=cache_size)
 
     @lazy_property
-    def sign(self):
+    def sign(self) -> Tensor:
         return self.exponent.sign()
 
     def __eq__(self, other):
@@ -1053,11 +1054,11 @@ class CatTransform(Transform):
         self.dim = dim
 
     @lazy_property
-    def event_dim(self):
+    def event_dim(self) -> Tensor:
         return max(t.event_dim for t in self.transforms)
 
     @lazy_property
-    def length(self):
+    def length(self) -> Tensor:
         return sum(self.lengths)
 
     def with_cache(self, cache_size=1):

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -17,7 +17,6 @@ from torch.distributions.utils import (
     vec_to_tril_matrix,
 )
 from torch.nn.functional import pad, softplus
-from torch import Tensor
 
 
 __all__ = [
@@ -95,7 +94,7 @@ class Transform:
 
     def __init__(self, cache_size=0):
         self._cache_size = cache_size
-        self._inv: Optional[Transform] = None
+        self._inv: Optional[weakref.ReferenceType[Transform]] = None
         if cache_size == 0:
             pass  # default behavior
         elif cache_size == 1:
@@ -221,7 +220,7 @@ class _InverseTransform(Transform):
 
     def __init__(self, transform: Transform):
         super().__init__(cache_size=transform._cache_size)
-        self._inv: Transform = transform
+        self._inv: Transform = transform  # type: ignore[assignment]
 
     @constraints.dependent_property(is_discrete=False)
     def domain(self):

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -2,12 +2,11 @@
 from numbers import Number
 
 import torch
-from torch import nan
+from torch import nan, Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["Uniform"]

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -37,19 +37,19 @@ class Uniform(Distribution):
     has_rsample = True
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return (self.high + self.low) / 2
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return nan * self.high
 
     @property
-    def stddev(self):
+    def stddev(self) -> Tensor:
         return (self.high - self.low) / 12**0.5
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return (self.high - self.low).pow(2) / 12
 
     def __init__(self, low, high, validate_args=None):

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -7,6 +7,7 @@ from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["Uniform"]
@@ -76,7 +77,7 @@ class Uniform(Distribution):
     def support(self):
         return constraints.interval(self.low, self.high)
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
         shape = self._extended_shape(sample_shape)
         rand = torch.rand(shape, dtype=self.low.dtype, device=self.low.device)
         return self.low + rand * (self.high - self.low)

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 from functools import update_wrapper
 from numbers import Number
-from typing import Any, Callable, Generic, overload
+from typing import Any, Callable, Generic, overload, Union
 from typing_extensions import TypeVar
 
 import torch
@@ -159,7 +159,7 @@ class lazy_property(Generic[T, R]):
         ...
 
     def __get__(
-        self, instance: T | None, obj_type: Any = None
+        self, instance: Union[T, None], obj_type: Any = None
     ) -> "R | _lazy_property_and_property[T, R]":
         if instance is None:
             return _lazy_property_and_property(self.wrapped)

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, Generic, overload, TypeVar
 import torch
 import torch.nn.functional as F
 from torch.overrides import is_tensor_like
+from torch import Tensor
 
 
 euler_constant = 0.57721566490153286060  # Euler Mascheroni Constant
@@ -177,7 +178,7 @@ class _lazy_property_and_property(lazy_property[T], property):
         property.__init__(self, wrapped)
 
 
-def tril_matrix_to_vec(mat: torch.Tensor, diag: int = 0) -> torch.Tensor:
+def tril_matrix_to_vec(mat: Tensor, diag: int = 0) -> Tensor:
     r"""
     Convert a `D x D` matrix or a batch of matrices into a (batched) vector
     which comprises of lower triangular elements from the matrix in row order.
@@ -191,7 +192,7 @@ def tril_matrix_to_vec(mat: torch.Tensor, diag: int = 0) -> torch.Tensor:
     return vec
 
 
-def vec_to_tril_matrix(vec: torch.Tensor, diag: int = 0) -> torch.Tensor:
+def vec_to_tril_matrix(vec: Tensor, diag: int = 0) -> Tensor:
     r"""
     Convert a vector or a batch of vectors into a batched `D x D`
     lower triangular matrix containing elements from the vector in row order.

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 from functools import update_wrapper
 from numbers import Number
-from typing import Any, Callable, Dict, Generic, overload, TypeVar
+from typing import Any, Callable, Generic, overload, TypeVar
 
 import torch
 import torch.nn.functional as F
@@ -44,7 +44,7 @@ def broadcast_all(*values):
             "torch.Tensor or objects implementing __torch_function__."
         )
     if not all(is_tensor_like(v) for v in values):
-        options: Dict[str, Any] = dict(dtype=torch.get_default_dtype())
+        options: dict[str, Any] = dict(dtype=torch.get_default_dtype())
         for value in values:
             if isinstance(value, torch.Tensor):
                 options = dict(dtype=value.dtype, device=value.device)

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -5,8 +5,8 @@ from typing import Any, Callable, Generic, overload, TypeVar
 
 import torch
 import torch.nn.functional as F
-from torch.overrides import is_tensor_like
 from torch import Tensor
+from torch.overrides import is_tensor_like
 
 
 euler_constant = 0.57721566490153286060  # Euler Mascheroni Constant

--- a/torch/distributions/von_mises.py
+++ b/torch/distributions/von_mises.py
@@ -3,10 +3,10 @@ import math
 
 import torch
 import torch.jit
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all, lazy_property
-from torch import Tensor
 
 
 __all__ = ["VonMises"]

--- a/torch/distributions/von_mises.py
+++ b/torch/distributions/von_mises.py
@@ -6,6 +6,7 @@ import torch.jit
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all, lazy_property
+from torch import Tensor
 
 
 __all__ = ["VonMises"]
@@ -143,15 +144,15 @@ class VonMises(Distribution):
         return log_prob
 
     @lazy_property
-    def _loc(self):
+    def _loc(self) -> Tensor:
         return self.loc.to(torch.double)
 
     @lazy_property
-    def _concentration(self):
+    def _concentration(self) -> Tensor:
         return self.concentration.to(torch.double)
 
     @lazy_property
-    def _proposal_r(self):
+    def _proposal_r(self) -> Tensor:
         kappa = self._concentration
         tau = 1 + (1 + 4 * kappa**2).sqrt()
         rho = (tau - (2 * tau).sqrt()) / (2 * kappa)
@@ -198,7 +199,7 @@ class VonMises(Distribution):
         return self.loc
 
     @lazy_property
-    def variance(self):
+    def variance(self) -> Tensor:  # type: ignore[override]
         """
         The provided variance is the circular one.
         """

--- a/torch/distributions/von_mises.py
+++ b/torch/distributions/von_mises.py
@@ -188,14 +188,14 @@ class VonMises(Distribution):
             return type(self)(loc, concentration, validate_args=validate_args)
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         """
         The provided mean is the circular one.
         """
         return self.loc
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return self.loc
 
     @lazy_property

--- a/torch/distributions/weibull.py
+++ b/torch/distributions/weibull.py
@@ -60,11 +60,11 @@ class Weibull(TransformedDistribution):
         return new
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.scale * torch.exp(torch.lgamma(1 + self.concentration_reciprocal))
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         return (
             self.scale
             * ((self.concentration - 1) / self.concentration)
@@ -72,7 +72,7 @@ class Weibull(TransformedDistribution):
         )
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         return self.scale.pow(2) * (
             torch.exp(torch.lgamma(1 + 2 * self.concentration_reciprocal))
             - torch.exp(2 * torch.lgamma(1 + self.concentration_reciprocal))

--- a/torch/distributions/weibull.py
+++ b/torch/distributions/weibull.py
@@ -6,6 +6,7 @@ from torch.distributions.gumbel import euler_constant
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import AffineTransform, PowerTransform
 from torch.distributions.utils import broadcast_all
+from torch import Tensor
 
 
 __all__ = ["Weibull"]

--- a/torch/distributions/weibull.py
+++ b/torch/distributions/weibull.py
@@ -1,12 +1,12 @@
 # mypy: allow-untyped-defs
 import torch
+from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.exponential import Exponential
 from torch.distributions.gumbel import euler_constant
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import AffineTransform, PowerTransform
 from torch.distributions.utils import broadcast_all
-from torch import Tensor
 
 
 __all__ = ["Weibull"]

--- a/torch/distributions/wishart.py
+++ b/torch/distributions/wishart.py
@@ -76,10 +76,10 @@ class Wishart(ExponentialFamily):
 
     def __init__(
         self,
-        df: Union[torch.Tensor, Number],
-        covariance_matrix: Optional[torch.Tensor] = None,
-        precision_matrix: Optional[torch.Tensor] = None,
-        scale_tril: Optional[torch.Tensor] = None,
+        df: Union[Tensor, Number],
+        covariance_matrix: Optional[Tensor] = None,
+        precision_matrix: Optional[Tensor] = None,
+        scale_tril: Optional[Tensor] = None,
         validate_args=None,
     ):
         assert (covariance_matrix is not None) + (scale_tril is not None) + (

--- a/torch/distributions/wishart.py
+++ b/torch/distributions/wishart.py
@@ -5,13 +5,12 @@ from numbers import Number
 from typing import Optional, Union
 
 import torch
-from torch import nan
+from torch import nan, Tensor
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.multivariate_normal import _precision_to_scale_tril
 from torch.distributions.utils import lazy_property
 from torch.types import _size
-from torch import Tensor
 
 
 __all__ = ["Wishart"]

--- a/torch/distributions/wishart.py
+++ b/torch/distributions/wishart.py
@@ -11,6 +11,7 @@ from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.multivariate_normal import _precision_to_scale_tril
 from torch.distributions.utils import lazy_property
 from torch.types import _size
+from torch import Tensor
 
 
 __all__ = ["Wishart"]
@@ -18,7 +19,7 @@ __all__ = ["Wishart"]
 _log_2 = math.log(2)
 
 
-def _mvdigamma(x: torch.Tensor, p: int) -> torch.Tensor:
+def _mvdigamma(x: Tensor, p: int) -> Tensor:
     assert x.gt((p - 1) / 2).all(), "Wrong domain for multivariate digamma function."
     return torch.digamma(
         x.unsqueeze(-1)
@@ -26,7 +27,7 @@ def _mvdigamma(x: torch.Tensor, p: int) -> torch.Tensor:
     ).sum(-1)
 
 
-def _clamp_above_eps(x: torch.Tensor) -> torch.Tensor:
+def _clamp_above_eps(x: Tensor) -> Tensor:
     # We assume positive input for this function
     return x.clamp(min=torch.finfo(x.dtype).eps)
 
@@ -178,20 +179,20 @@ class Wishart(ExponentialFamily):
         return new
 
     @lazy_property
-    def scale_tril(self):
+    def scale_tril(self) -> Tensor:
         return self._unbroadcasted_scale_tril.expand(
             self._batch_shape + self._event_shape
         )
 
     @lazy_property
-    def covariance_matrix(self):
+    def covariance_matrix(self) -> Tensor:
         return (
             self._unbroadcasted_scale_tril
             @ self._unbroadcasted_scale_tril.transpose(-2, -1)
         ).expand(self._batch_shape + self._event_shape)
 
     @lazy_property
-    def precision_matrix(self):
+    def precision_matrix(self) -> Tensor:
         identity = torch.eye(
             self._event_shape[-1],
             device=self._unbroadcasted_scale_tril.device,
@@ -238,7 +239,7 @@ class Wishart(ExponentialFamily):
 
     def rsample(
         self, sample_shape: _size = torch.Size(), max_try_correction=None
-    ) -> torch.Tensor:
+    ) -> Tensor:
         r"""
         .. warning::
             In some cases, sampling algorithm based on Bartlett decomposition may return singular matrix samples.

--- a/torch/distributions/wishart.py
+++ b/torch/distributions/wishart.py
@@ -203,17 +203,17 @@ class Wishart(ExponentialFamily):
         )
 
     @property
-    def mean(self):
+    def mean(self) -> Tensor:
         return self.df.view(self._batch_shape + (1, 1)) * self.covariance_matrix
 
     @property
-    def mode(self):
+    def mode(self) -> Tensor:
         factor = self.df - self.covariance_matrix.shape[-1] - 1
         factor[factor <= 0] = nan
         return factor.view(self._batch_shape + (1, 1)) * self.covariance_matrix
 
     @property
-    def variance(self):
+    def variance(self) -> Tensor:
         V = self.covariance_matrix  # has shape (batch_shape x event_shape)
         diag_V = V.diagonal(dim1=-2, dim2=-1)
         return self.df.view(self._batch_shape + (1, 1)) * (
@@ -327,7 +327,7 @@ class Wishart(ExponentialFamily):
         )
 
     @property
-    def _natural_params(self):
+    def _natural_params(self) -> tuple[Tensor, Tensor]:
         nu = self.df  # has shape (batch_shape)
         p = self._event_shape[-1]  # has singleton shape
         return -self.precision_matrix / 2, (nu - p - 1) / 2


### PR DESCRIPTION
Fixes #76772, #144196
Extends #144106

- added type annotations to `lazy_property`.
- added type annotation to all `@property` and `@lazy_property` inside `torch.distributions` module.
- added simply type-check unit test to ensure type inference is working.
- replaced deprecated annotations like `typing.List` with the corresponding counterpart.
- simplified `torch.Tensor` hints with plain `Tensor`, otherwise signatures can become very verbose.

cc @fritzo @neerajprad @alicanb @nikitaved @ezyang @malfet @xuzhao9 @gramster