### PR TITLE
[cpu/sorting] Throw an error when trying to sort complex numbers.

### DIFF
--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -74,6 +74,12 @@ TORCH_META_FUNC2(sort, stable)
 (const Tensor& self, std::optional<bool> stable, int64_t dim, bool descending) {
   maybe_wrap_dim(dim, self.dim());
 
+  const auto self_dtype = self.dtype();
+  TORCH_CHECK_VALUE(
+    self_dtype != ScalarType::ComplexFloat &&
+    self_dtype != ScalarType::ComplexDouble,
+    "Sort currently does not support complex dtypes on CPU.");
+
   // See issue: https://github.com/pytorch/pytorch/issues/65863
   // Strides should be dense, so as not to allocate too much memory.
   // We either use 'self' strides, or infer dense strides from them.

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -175,6 +175,14 @@ class TestSortAndSelect(TestCase):
         y = x.sort(stable=None).values
         self.assertTrue(torch.all(y == torch.ones(10)).item())
 
+    @onlyCPU
+    def test_complex_unsupported_cpu(self):
+        x = torch.tensor([3.0 + 2j, 4.0 + 3j])
+        with self.assertRaisesRegex(
+            ValueError, "Sort currently does not support complex dtypes on CPU."
+        ):
+            torch.sort(input=x)
+
     @onlyCUDA
     def test_sort_large_slice(self, device):
         # tests direct cub path


### PR DESCRIPTION
It doesn't really make sense to sort complex numbers as they are not comparable.

Fixes #129296
