### PR TITLE
[MPSInductor][EZ] Fix logical_[or|end] ops

### DIFF
--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -91,11 +91,11 @@ class MetalOverrides(OpOverrides):
 
     @staticmethod
     def logical_or(a: CSEVariable, b: CSEVariable) -> str:
-        return f"{a} | {b}"
+        return f"{a} || {b}"
 
     @staticmethod
     def logical_and(a: CSEVariable, b: CSEVariable) -> str:
-        return f"{a} & {b}"
+        return f"{a} && {b}"
 
     @staticmethod
     def abs(x: CSEVariable) -> str:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #143966
* #144084
* #144083
* #144050
* #144105
* __->__ #144122
* #144051
* #144055

For boolean operands it does not really matter whether `&` or `&&` is
used, but if one ever to rely on operator precedence, then bitwise ops
should have higher precendence than logical ones

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov