### PR TITLE
cpp_wrapper AOTI: Move #includes to per-device header files

### DIFF
--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -251,9 +251,6 @@ class DeviceOpOverrides:
     def kernel_driver(self):
         raise NotImplementedError
 
-    def abi_compatible_header(self):
-        raise NotImplementedError
-
     def cpp_stream_type(self):
         raise NotImplementedError
 

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -83,7 +83,7 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
 
     def get_device_include(self):
         if V.graph.aot_mode:
-            return super().get_device_include()
+            return f"#include <torch/csrc/inductor/cpp_wrapper_array_ref/aoti_{self.device}.h>"
         return f"#include <torch/csrc/inductor/cpp_wrapper_array_ref/{self.device}.h>"
 
     def codegen_input_numel_asserts(self):

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -203,10 +203,6 @@ class CppWrapperGpu(CppWrapperCpu):
             return
 
         super().write_header()
-
-        if V.graph.aot_mode:
-            self.header.splice("#include <filesystem>")
-            self.header.splice(self.device_codegen.abi_compatible_header())
         self.header.splice(
             maybe_hipify_code_wrapper(self.device_codegen.kernel_driver())
         )

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -225,9 +225,6 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
             #endif
         """
 
-    def abi_compatible_header(self):
-        return "#include <torch/csrc/inductor/aoti_runtime/utils_cuda.h>"
-
     def cpp_stream_type(self):
         return "cudaStream_t"
 

--- a/torch/_inductor/codegen/debug_utils.py
+++ b/torch/_inductor/codegen/debug_utils.py
@@ -53,13 +53,13 @@ class DebugPrinterManager:
     def __init__(
         self,
         debug_printer_level,
+        use_array_ref: bool,
         args_to_print_or_save: Optional[List[str]] = None,
         kernel_name: str = "",
         kernel=None,
-        arg_signatures: Optional[List[type]] = None,
-        kernel_type=None,
     ):
         self.debug_printer_level = IntermediateValueDebuggingLevel(debug_printer_level)
+        self.use_array_ref = use_array_ref
         if args_to_print_or_save is None:
             args_to_print_or_save = []
         self.args_to_print_or_save = args_to_print_or_save
@@ -155,12 +155,15 @@ class DebugPrinterManager:
             ]
             self.args_to_print_or_save = args_to_print_or_save_extern
         elif kernel_type == "cpp":
-            args_to_print_or_save_cpp = [
-                f"copy_arrayref_tensor_to_tensor({arg})"
+            self.args_to_print_or_save = [
+                (
+                    f"copy_arrayref_tensor_to_tensor({arg})"
+                    if self.use_array_ref
+                    else arg
+                )
                 for arg in args_to_print_or_save
                 if arg.startswith(("buf", "arg"))
             ]
-            self.args_to_print_or_save = args_to_print_or_save_cpp
         else:
             self.args_to_print_or_save = args_to_print_or_save
         self.kernel_name = kernel_name

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -722,7 +722,8 @@ class PythonWrapperCodegen(CodeGen):
 
         # intermediate tensor value printing utility
         self.debug_printer = DebugPrinterManager(
-            debug_printer_level=config.aot_inductor.debug_intermediate_value_printer
+            debug_printer_level=config.aot_inductor.debug_intermediate_value_printer,
+            use_array_ref=config.aot_inductor.allow_stack_allocation,
         )
 
         # Additional files that are dependent to the wrapper (ex. cubin files)

--- a/torch/_inductor/codegen/xpu/device_op_overrides.py
+++ b/torch/_inductor/codegen/xpu/device_op_overrides.py
@@ -57,12 +57,6 @@ class XPUDeviceOpOverrides(DeviceOpOverrides):
         """
         return source_codes
 
-    def abi_compatible_header(self):
-        return """
-        #include <torch/csrc/inductor/aoti_runtime/utils_xpu.h>
-        #include <torch/csrc/inductor/aoti_runtime/sycl_runtime_wrappers.h>
-        """
-
     def cpp_stream_type(self):
         return "sycl::queue*"
 

--- a/torch/csrc/inductor/cpp_wrapper/aoti_common.h
+++ b/torch/csrc/inductor/cpp_wrapper/aoti_common.h
@@ -1,0 +1,20 @@
+#ifndef TORCH_CSRC_INDUCTOR_CPP_WRAPPER_AOTI_COMMON
+#define TORCH_CSRC_INDUCTOR_CPP_WRAPPER_AOTI_COMMON
+
+#include <filesystem>
+#include <optional>
+
+#include <torch/csrc/inductor/aoti_runtime/interface.h>
+#include <torch/csrc/inductor/aoti_runtime/model.h>
+
+#include <c10/util/generic_math.h>
+#include <torch/csrc/inductor/aoti_runtime/scalar_to_tensor.h>
+using half = at::Half;
+using bfloat16 = at::BFloat16;
+
+// Round up to the nearest multiple of 64
+[[maybe_unused]] inline int64_t align(int64_t nbytes) {
+  return (nbytes + 64 - 1) & -64;
+}
+
+#endif // TORCH_CSRC_INDUCTOR_CPP_WRAPPER_AOTI_COMMON

--- a/torch/csrc/inductor/cpp_wrapper/aoti_cpu.h
+++ b/torch/csrc/inductor/cpp_wrapper/aoti_cpu.h
@@ -1,0 +1,7 @@
+#ifndef TORCH_CSRC_INDUCTOR_CPP_WRAPPER_AOTI_CPU
+#define TORCH_CSRC_INDUCTOR_CPP_WRAPPER_AOTI_CPU
+
+#include <torch/csrc/inductor/cpp_wrapper/aoti_common.h>
+#include <torch/csrc/inductor/cpp_wrapper/device_internal/cpu.h>
+
+#endif // TORCH_CSRC_INDUCTOR_CPP_WRAPPER_AOTI_CPU

--- a/torch/csrc/inductor/cpp_wrapper/aoti_cuda.h
+++ b/torch/csrc/inductor/cpp_wrapper/aoti_cuda.h
@@ -1,0 +1,7 @@
+#ifndef TORCH_CSRC_INDUCTOR_CPP_WRAPPER_AOTI_CUDA
+#define TORCH_CSRC_INDUCTOR_CPP_WRAPPER_AOTI_CUDA
+
+#include <torch/csrc/inductor/cpp_wrapper/aoti_common.h>
+#include <torch/csrc/inductor/cpp_wrapper/device_internal/cuda.h>
+
+#endif // TORCH_CSRC_INDUCTOR_CPP_WRAPPER_AOTI_CUDA

--- a/torch/csrc/inductor/cpp_wrapper/aoti_xpu.h
+++ b/torch/csrc/inductor/cpp_wrapper/aoti_xpu.h
@@ -1,0 +1,7 @@
+#ifndef TORCH_CSRC_INDUCTOR_CPP_WRAPPER_AOTI_XPU
+#define TORCH_CSRC_INDUCTOR_CPP_WRAPPER_AOTI_XPU
+
+#include <torch/csrc/inductor/cpp_wrapper/aoti_common.h>
+#include <torch/csrc/inductor/cpp_wrapper/device_internal/xpu.h>
+
+#endif // TORCH_CSRC_INDUCTOR_CPP_WRAPPER_AOTI_XPU

--- a/torch/csrc/inductor/cpp_wrapper_array_ref/aoti_common.h
+++ b/torch/csrc/inductor/cpp_wrapper_array_ref/aoti_common.h
@@ -1,0 +1,11 @@
+#ifndef TORCH_CSRC_INDUCTOR_CPP_WRAPPER_ARRAY_REF_AOTI_COMMON
+#define TORCH_CSRC_INDUCTOR_CPP_WRAPPER_ARRAY_REF_AOTI_COMMON
+
+#include <torch/csrc/inductor/cpp_wrapper/aoti_common.h>
+
+#include <torch/csrc/inductor/aoti_runtime/arrayref_tensor.h>
+#include <torch/csrc/inductor/aoti_runtime/thread_local.h>
+
+#include <torch/csrc/inductor/cpp_wrapper_array_ref/implementation.h>
+
+#endif // TORCH_CSRC_INDUCTOR_CPP_WRAPPER_ARRAY_REF_AOTI_COMMON

--- a/torch/csrc/inductor/cpp_wrapper_array_ref/aoti_cpu.h
+++ b/torch/csrc/inductor/cpp_wrapper_array_ref/aoti_cpu.h
@@ -1,0 +1,7 @@
+#ifndef TORCH_CSRC_INDUCTOR_CPP_WRAPPER_ARRAY_REF_AOTI_CPU
+#define TORCH_CSRC_INDUCTOR_CPP_WRAPPER_ARRAY_REF_AOTI_CPU
+
+#include <torch/csrc/inductor/cpp_wrapper/device_internal/cpu.h>
+#include <torch/csrc/inductor/cpp_wrapper_array_ref/aoti_common.h>
+
+#endif // TORCH_CSRC_INDUCTOR_CPP_WRAPPER_ARRAY_REF_AOTI_CPU

--- a/torch/csrc/inductor/cpp_wrapper_array_ref/aoti_cuda.h
+++ b/torch/csrc/inductor/cpp_wrapper_array_ref/aoti_cuda.h
@@ -1,0 +1,7 @@
+#ifndef TORCH_CSRC_INDUCTOR_CPP_WRAPPER_ARRAY_REF_AOTI_CUDA
+#define TORCH_CSRC_INDUCTOR_CPP_WRAPPER_ARRAY_REF_AOTI_CUDA
+
+#include <torch/csrc/inductor/cpp_wrapper/device_internal/cuda.h>
+#include <torch/csrc/inductor/cpp_wrapper_array_ref/aoti_common.h>
+
+#endif // TORCH_CSRC_INDUCTOR_CPP_WRAPPER_ARRAY_REF_AOTI_CUDA

--- a/torch/csrc/inductor/cpp_wrapper_array_ref/aoti_xpu.h
+++ b/torch/csrc/inductor/cpp_wrapper_array_ref/aoti_xpu.h
@@ -1,0 +1,7 @@
+#ifndef TORCH_CSRC_INDUCTOR_CPP_WRAPPER_ARRAY_REF_AOTI_XPU
+#define TORCH_CSRC_INDUCTOR_CPP_WRAPPER_ARRAY_REF_AOTI_XPU
+
+#include <torch/csrc/inductor/cpp_wrapper/device_internal/xpu.h>
+#include <torch/csrc/inductor/cpp_wrapper_array_ref/aoti_common.h>
+
+#endif // TORCH_CSRC_INDUCTOR_CPP_WRAPPER_ARRAY_REF_AOTI_XPU


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #144124
* __->__ #144123
* #144002
* #143909
* #143421
* #143223
* #141371



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov