### PR TITLE
[Intel GPU][Inductor] Convert Conv1D to 2D in inductor

### DIFF
--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -501,10 +501,18 @@ def convolution(
             dim=0,
         )
 
+    out_chan, in_chan, *kernel_shape = V.graph.sizevars.evaluate_static_shapes(
+        weight.get_size()
+    )
+
     # Always convert conv1D to 2D for Intel GPU.
     # Only conv2D can be converted to channel last layout,
     # which have much better performance.
-    if len(x.get_size()) == 3 and ir.get_device_type(x) == "xpu":
+    if (
+        len(x.get_size()) == 3
+        and len(kernel_shape) == 1
+        and ir.get_device_type(x) == "xpu"
+    ):
         kwargs.update(
             {
                 "stride": (1,) + stride,
@@ -522,9 +530,6 @@ def convolution(
             dim=2,
         )
 
-    out_chan, in_chan, *kernel_shape = V.graph.sizevars.evaluate_static_shapes(
-        weight.get_size()
-    )
     ndim = len(kernel_shape)
     stride = pad_listlike(stride, ndim)
     padding = pad_listlike(padding, ndim)

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -513,6 +513,7 @@ def convolution(
                 "output_padding": (0,) + output_padding,
             }
         )
+        # (N, C, L) -> (N, C, 1, L)
         x = L[aten.unsqueeze](x, dim=2)
         weight = L[aten.unsqueeze](weight, dim=2)
 
@@ -555,11 +556,7 @@ def convolution(
     ):
         return convert_1x1_conv_to_mm(x, weight, bias)
 
-    if (
-        bias is not None
-        and ir.get_device_type(x) != "cpu"
-        and ir.get_device_type(x) != "xpu"
-    ):
+    if bias is not None and ir.get_device_type(x) != "cpu":
         # peel off the bias, cudnn is slower with it
         result = convolution(x, weight, None, **kwargs)
         return L[aten.add](


### PR DESCRIPTION
Layout optimization in inductor does not apply to Conv1D. We convert Conv1D to channel last Conv2D for better performance on Intel GPU. For example, demucs fp16 inference in torchbench can improve from 149ms to 91ms on Max 1100.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov