### PR TITLE
fix memleak, detach instead of clone to not drag around graph

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1323,7 +1323,7 @@ class TestOptimRenewed(TestCase):
                 )
 
             if kwargs.get("differentiable", False):
-                params = [param.clone()]
+                params = [param.detach()]
             else:
                 params = [param]
 
@@ -1350,14 +1350,11 @@ class TestOptimRenewed(TestCase):
         )
         param = torch.randn((5, 1), device=device, dtype=dtype, requires_grad=True)
 
-        def closure():
-            return torch.tensor([1], device=device, dtype=dtype)
-
         for optim_input in all_optim_inputs:
             kwargs = optim_input.kwargs
 
             if kwargs.get("differentiable", False):
-                params = [param.clone()]
+                params = [param.detach()]
             else:
                 params = [param]
 
@@ -1377,7 +1374,7 @@ class TestOptimRenewed(TestCase):
             old_version = params[0].grad._version
 
             for _ in range(5):
-                optimizer.step(closure)
+                optimizer.step()
                 self.assertEqual(params[0].grad._version, old_version)
 
     @optims(optim_db, dtypes=[torch.float32])

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1350,6 +1350,9 @@ class TestOptimRenewed(TestCase):
         )
         param = torch.randn((5, 1), device=device, dtype=dtype, requires_grad=True)
 
+        def closure():
+            return torch.tensor([1], device=device, dtype=dtype)
+
         for optim_input in all_optim_inputs:
             kwargs = optim_input.kwargs
 
@@ -1374,7 +1377,7 @@ class TestOptimRenewed(TestCase):
             old_version = params[0].grad._version
 
             for _ in range(5):
-                optimizer.step()
+                optimizer.step(closure)
                 self.assertEqual(params[0].grad._version, old_version)
 
     @optims(optim_db, dtypes=[torch.float32])


### PR DESCRIPTION
Thanks @clee2000 for bringing the memleak to my attention: https://github.com/pytorch/pytorch/actions/runs/12549765082/job/34996244798.

This memleak in the test was caused by the differentiable flavors. Because we had param.clone() and param persisted outside the for loop, the autograd graph would continue growing for each optimizer.step instead of being deleted after the optim input was used up.

To clarify, I had still expected (and still do expect) the test to fully clean everything up once the test is over, but I didn't get the chance to look into why that's not the case. This change would preliminarily unblock this particular test from failing the memleak CI.


Use detach instead of clone, which is...cheaper anyway :D since a detach I've learned from @soulitzer is a view with requires_grad=False

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144154

