### PR TITLE
[ez] Use strip for arg sanitization in upload_metadata_file to improve readability

### DIFF
--- a/scripts/release/upload_metadata_file.py
+++ b/scripts/release/upload_metadata_file.py
@@ -35,10 +35,8 @@ def parse_args() -> argparse.Namespace:
     # slashes
     if args.bucket.startswith("s3://"):
         args.bucket = args.bucket[5:]
-    args.bucket = args.bucket.rstrip("/")
-    args.bucket = args.bucket.lstrip("/")
-    args.key_prefix = args.key_prefix.rstrip("/")
-    args.key_prefix = args.key_prefix.lstrip("/")
+    args.bucket = args.bucket.strip("/")
+    args.key_prefix = args.key_prefix.strip("/")
     return args
 
 

--- a/scripts/release/upload_metadata_file.py
+++ b/scripts/release/upload_metadata_file.py
@@ -35,12 +35,10 @@ def parse_args() -> argparse.Namespace:
     # slashes
     if args.bucket.startswith("s3://"):
         args.bucket = args.bucket[5:]
-    if args.bucket.endswith("/"):
-        args.bucket = args.bucket[:-1]
-    if args.key_prefix.startswith("/"):
-        args.key_prefix = args.key_prefix[1:]
-    if args.key_prefix.endswith("/"):
-        args.key_prefix = args.key_prefix[:-1]
+    args.bucket = args.bucket.rstrip("/")
+    args.bucket = args.bucket.lstrip("/")
+    args.key_prefix = args.key_prefix.rstrip("/")
+    args.key_prefix = args.key_prefix.lstrip("/")
     return args
 
 


### PR DESCRIPTION
Minor thing that improves readability.  I didn't realize you could specify characters for strip when I wrote this