### PR TITLE
[MPSInductor] Add `constant`, `isinf` and `isnan` ops

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -41,6 +41,8 @@ class MPSBasicTests(TestCase):
     test_add_const_int = CommonTemplate.test_add_const_int
     test_add_inplace_permuted_mps = CommonTemplate.test_add_inplace_permuted
     test_max_min = CommonTemplate.test_max_min
+    test_inf = CommonTemplate.test_inf
+    test_nan_to_num_ = CommonTemplate.test_nan_to_num_
     test_views6 = CommonTemplate.test_views6
     test_addmm = CommonTemplate.test_addmm
     test_signbit = CommonTemplate.test_signbit

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -64,6 +64,14 @@ class MetalOverrides(OpOverrides):
         return f"static_cast<{DTYPE_TO_METAL[dtype]}>({x})"
 
     @staticmethod
+    def constant(val: CSEVariable, dtype: torch.dtype) -> str:
+        if val == torch.inf:
+            return "HUGE_VALF"
+        elif val == -torch.inf:
+            return "-HUGE_VALF"
+        return str(val)
+
+    @staticmethod
     def index_expr(expr: sympy.Expr, dtype: torch.dtype) -> str:
         idx_str = mexpr(V.kernel.rename_indexing(expr))
         var = V.kernel.cse.generate(
@@ -96,6 +104,14 @@ class MetalOverrides(OpOverrides):
     @staticmethod
     def logical_and(a: CSEVariable, b: CSEVariable) -> str:
         return f"{a} && {b}"
+
+    @staticmethod
+    def isnan(x: CSEVariable) -> str:
+        return f"metal::isnan({x})"
+
+    @staticmethod
+    def isinf(x: CSEVariable) -> str:
+        return f"metal::isinf({x})"
 
     @staticmethod
     def abs(x: CSEVariable) -> str:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #143966
* #144084
* #144083
* #144050
* __->__ #144156
* #144105
* #144122
* #144051
* #144055

Per Table 6.5 of [Metal Language Specification](https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf) infinity is `HUGE_VALF`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov