### PR TITLE
[BE] typing for decorators

### DIFF
--- a/torch/_compile.py
+++ b/torch/_compile.py
@@ -1,13 +1,32 @@
-# mypy: allow-untyped-defs
 """
 APIs related to torch.compile which lazily import torch._dynamo to avoid
 circular dependencies.
 """
 
 import functools
+from typing import Callable, Literal, Optional, overload, TypeVar, Union
+from typing_extensions import ParamSpec
 
 
-def _disable_dynamo(fn=None, recursive=True):
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
+
+
+@overload
+def _disable_dynamo(
+    fn: Callable[_P, _T], recursive: bool = True
+) -> Callable[_P, _T]: ...
+
+
+@overload
+def _disable_dynamo(
+    fn: Literal[None] = None, recursive: bool = True
+) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]: ...
+
+
+def _disable_dynamo(
+    fn: Optional[Callable[_P, _T]] = None, recursive: bool = True
+) -> Union[Callable[_P, _T], Callable[[Callable[_P, _T]], Callable[_P, _T]]]:
     """
     This API should be only used inside torch, external users should still use
     torch._dynamo.disable. The main goal of this API is to avoid circular
@@ -20,14 +39,14 @@ def _disable_dynamo(fn=None, recursive=True):
     if fn is not None:
 
         @functools.wraps(fn)
-        def inner(*args, **kwargs):
+        def inner(*args: _P.args, **kwargs: _P.kwargs) -> _T:
             # cache this on the first invocation to avoid adding too much overhead.
             disable_fn = getattr(fn, "__dynamo_disable", None)
             if disable_fn is None:
                 import torch._dynamo
 
                 disable_fn = torch._dynamo.disable(fn, recursive)
-                fn.__dynamo_disable = disable_fn
+                fn.__dynamo_disable = disable_fn  # type: ignore[attr-defined]
 
             return disable_fn(*args, **kwargs)
 

--- a/torch/_functorch/apis.py
+++ b/torch/_functorch/apis.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 # NOTE: We allow Dynamo to see this file (via torch/_dynamo/trace_rules.py) so that it can
 #       trace through functorch transforms.

--- a/torch/_functorch/functional_call.py
+++ b/torch/_functorch/functional_call.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -4,7 +4,8 @@ import logging
 import math
 import sys
 import typing
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
+from typing_extensions import ParamSpec
 
 import torch
 import torch._decomp as decomp
@@ -39,6 +40,9 @@ from .utils import (
     use_scatter_fallback,
 )
 
+
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
 
 log = logging.getLogger(__name__)
 aten = torch.ops.aten
@@ -119,7 +123,7 @@ remove_decompositions(decompositions, decomps_to_exclude)
 
 def register_decomposition(
     ops: List[Union[torch._ops.OperatorBase, torch._ops.OpOverloadPacket]]
-) -> Callable[..., Any]:
+) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
     for op in [ops] if callable(ops) else ops:  # type: ignore[attr-defined]
         if op in decompositions:
             log.warning("duplicate decomp: %s", ops)

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -5,7 +5,8 @@ import itertools
 import logging
 import operator
 from collections import Counter, defaultdict
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
+from typing_extensions import ParamSpec
 
 import torch
 import torch._inductor as inductor
@@ -54,6 +55,9 @@ from .pre_grad import is_same_dict, save_inductor_dict
 from .reinplace import reinplace_inplaceable_ops
 from .split_cat import POST_GRAD_PATTERNS
 
+
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
 
 log = logging.getLogger(__name__)
 aten = torch.ops.aten
@@ -213,7 +217,9 @@ def reorder_for_locality(graph: torch.fx.Graph):
         torch.fx.map_arg((node.args, node.kwargs), visit)
 
 
-def register_lowering_pattern(pattern, extra_check=_return_true, pass_number=1):
+def register_lowering_pattern(
+    pattern, extra_check=_return_true, pass_number=1
+) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
     """
     Register an aten to inductor IR replacement pattern
     """

--- a/torch/_inductor/jagged_lowerings.py
+++ b/torch/_inductor/jagged_lowerings.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 from typing import List, Optional, Tuple, Union
 

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -1,9 +1,8 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
 import logging
-from typing import cast, List, Optional, Sequence, Tuple, TYPE_CHECKING, TypedDict
+from typing import cast, Optional, Sequence, Tuple, TYPE_CHECKING, TypedDict
 
 import torch
 from torch._inductor.codegen.rocm.ck_conv_template import CKGroupedConvFwdTemplate
@@ -460,12 +459,12 @@ def convert_1x1_conv_to_mm(x, weight, bias):
 def convolution(
     x: TensorBox,
     weight: TensorBox,
-    bias: TensorBox,
-    stride: List[int],
-    padding: List[int],
-    dilation: List[int],
+    bias: Optional[TensorBox],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
     transposed: bool,
-    output_padding: List[int],
+    output_padding: Sequence[int],
     groups: int,
 ):
     stride = tuple(stride)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 import dataclasses
 import functools
@@ -10,7 +9,8 @@ import os
 import warnings
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, TypeVar, Union
+from typing_extensions import ParamSpec
 from unittest.mock import patch
 
 import sympy
@@ -76,6 +76,9 @@ from .utils import (
 )
 from .virtualized import ops, V
 
+
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
 
 # TODO(jansel): we should implement decomps or lowerings for these
 # https://github.com/pytorch/torchdynamo/issues/327
@@ -466,7 +469,7 @@ def register_lowering(
         ELEMENTWISE_TYPE_PROMOTION_KIND
     ] = ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     convert_input_to_bool=False,
-):
+) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
     """
     Shim to support decorator syntax.
     """
@@ -6416,7 +6419,7 @@ def sym_numel(a):
 
 
 for method, func in magic_methods.items():
-    register_lowering(method_to_operator(method))(func)
+    register_lowering(method_to_operator(method))(func)  # type: ignore[arg-type]
 
 
 @register_lowering(torch.sym_sum)

--- a/torch/_inductor/mkldnn_lowerings.py
+++ b/torch/_inductor/mkldnn_lowerings.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 import functools
 from typing import List, Optional

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -1,10 +1,21 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 import inspect
 import logging
 import weakref
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    overload,
+    Sequence,
+    Set,
+    Union,
+)
 
 import torch
 from torch import _C, _ops, Tensor
@@ -17,6 +28,32 @@ device_types_t = Optional[Union[str, Sequence[str]]]
 log = logging.getLogger(__name__)
 
 
+@overload
+def custom_op(
+    name: str,
+    fn: Literal[None] = None,
+    /,
+    *,
+    mutates_args: Union[str, Iterable[str]],
+    device_types: device_types_t = None,
+    schema: Optional[str] = None,
+) -> Callable[[Callable[..., object]], "CustomOpDef"]:
+    ...
+
+
+@overload
+def custom_op(
+    name: str,
+    fn: Callable[..., object],
+    /,
+    *,
+    mutates_args: Union[str, Iterable[str]],
+    device_types: device_types_t = None,
+    schema: Optional[str] = None,
+) -> "CustomOpDef":
+    ...
+
+
 @exposed_in("torch.library")
 def custom_op(
     name: str,
@@ -26,7 +63,7 @@ def custom_op(
     mutates_args: Union[str, Iterable[str]],
     device_types: device_types_t = None,
     schema: Optional[str] = None,
-) -> Any:
+) -> Union[Callable[[Callable[..., object]], "CustomOpDef"], "CustomOpDef"]:
     """Wraps a function into custom operator.
 
     Reasons why you may want to create a custom op include:
@@ -114,7 +151,7 @@ def custom_op(
 
     """
 
-    def inner(fn):
+    def inner(fn: Callable[..., object]) -> CustomOpDef:
         import torch
 
         if schema is None:

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 import inspect
 import typing

--- a/torch/_library/triton.py
+++ b/torch/_library/triton.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Generator, Iterable, Optional, Union
 
 from torch.utils._exposed_in import exposed_in
 
-from .custom_ops import custom_op
+from .custom_ops import custom_op, CustomOpDef
 from .infer_schema import infer_schema
 
 
@@ -106,7 +106,7 @@ def triton_op(
 
     """
 
-    def dec(fn: Callable) -> Any:
+    def dec(fn: Callable[..., object]) -> CustomOpDef:
         def backend_fn(*args, **kwargs):  # type: ignore[no-untyped-def]
             # Optimization: we're passing regular Tensors into the triton kernel, so
             # no need to go through HOP dispatch

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1,9 +1,9 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 import math
 from enum import Enum
 from functools import wraps
-from typing import List, Optional, Sequence, Tuple, Union
+from typing import Callable, List, Optional, Sequence, Tuple, TypeVar, Union
+from typing_extensions import ParamSpec
 
 import torch
 import torch._prims_common as utils
@@ -39,13 +39,16 @@ from torch._refs import _broadcast_shapes, _maybe_broadcast
 from torch.utils import _pytree as pytree
 
 
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
+
 aten = torch.ops.aten
 
 _meta_lib_dont_use_me_use_register_meta = torch.library.Library("aten", "IMPL", "Meta")
 MODE_SUM, MODE_MEAN, MODE_MAX = range(3)
 
 
-def register_meta(op):
+def register_meta(op) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
     def wrapper(fn):
         fn = _convert_out_params(fn)
 

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -2,7 +2,8 @@
 # mypy: allow-untyped-defs
 import math
 from functools import wraps
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, TypeVar, Union
+from typing_extensions import Concatenate, ParamSpec
 
 import torch
 import torch._prims as prims
@@ -67,6 +68,9 @@ __all__ = [
     "triplet_margin_loss",
 ]
 
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
+
 Tensor = torch.Tensor
 aten = torch._ops.ops.aten
 DispatchKey = torch._C.DispatchKey  # type: ignore[attr-defined]
@@ -129,22 +133,27 @@ def alpha_dropout(
     return self * dropout_mask + b
 
 
-def _inplace_wrapper(fn):
+def _inplace_wrapper(fn: Callable[_P, _T]) -> Callable[_P, _T]:
     """
     Given a nn.functional non-linearity, implements its `inplace: bool` argument
     """
 
     # nb. We use the name of the first argument used in the unary references
     @wraps(fn)
-    def _fn(a, *args, inplace=False, **kwargs):
-        if inplace:
+    def _fn(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+        a = args[0]
+        if "inplace" not in kwargs:
+            kwargs["inplace"] = False
+        if kwargs["inplace"]:
             torch._check(
                 "out" not in kwargs,
                 lambda: "Cannot set inplace=True and pass out= at the same time",
             )
-            return fn(a, *args, inplace=False, out=a, **kwargs)
+            kwargs["inplace"] = False
+            kwargs["out"] = a
+            return fn(*args, **kwargs)
         else:
-            return fn(a, *args, inplace=False, **kwargs)
+            return fn(*args, **kwargs)
 
     return _fn
 

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 import itertools
 from dataclasses import dataclass
@@ -70,8 +69,8 @@ AnnotatorType = Callable[
 OP_TO_ANNOTATOR: Dict[str, AnnotatorType] = {}
 
 
-def register_annotator(op: str):
-    def decorator(annotator: AnnotatorType):
+def register_annotator(op: str) -> Callable[[AnnotatorType], None]:
+    def decorator(annotator: AnnotatorType) -> None:
         OP_TO_ANNOTATOR[op] = annotator
 
     return decorator

--- a/torch/distributed/_composable/checkpoint_activation.py
+++ b/torch/distributed/_composable/checkpoint_activation.py
@@ -1,7 +1,6 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 from contextlib import contextmanager, nullcontext
-from typing import Any, ContextManager, Dict, Optional, Tuple
+from typing import Any, ContextManager, Dict, Generator, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -10,7 +9,7 @@ from torch.utils.checkpoint import (
     _DEFAULT_DETERMINISM_MODE,
 )
 
-from .contract import contract
+from .contract import _State, contract
 
 
 @contextmanager
@@ -29,7 +28,12 @@ def _no_hook(module: nn.Module, user_ctx: Optional[ContextManager] = None):
             checkpoint.state(module).enable_hook = orig_enable_hook
 
 
-@contract()
+class _CheckpointState(_State):
+    enable_hook: bool = False
+    _ac_generator: Optional[Generator[None, None, None]]
+
+
+@contract(_CheckpointState)
 def checkpoint(module: nn.Module, **kwargs) -> nn.Module:
     r"""
     This is a composable activation checkpointing API. Unlike functional
@@ -92,9 +96,7 @@ def checkpoint(module: nn.Module, **kwargs) -> nn.Module:
                 else:
                     return nullcontext(), _no_hook(module)
 
-            checkpoint.state(
-                module
-            )._ac_generator = _checkpoint_without_reentrant_generator(
+            gen = _checkpoint_without_reentrant_generator(
                 module,
                 preserve_rng_state,
                 context_fns,
@@ -103,12 +105,15 @@ def checkpoint(module: nn.Module, **kwargs) -> nn.Module:
                 *args,
                 **kwargs,
             )
-            next(checkpoint.state(module)._ac_generator)
+            checkpoint.state(module)._ac_generator = gen
+            next(gen)
 
     def forward_hook(module: nn.Module, inputs: Tuple[Any, ...], output: Any) -> Any:
         if checkpoint.state(module).enable_hook:
             try:
-                next(checkpoint.state(module)._ac_generator)
+                gen = checkpoint.state(module)._ac_generator
+                assert gen is not None
+                next(gen)
             except StopIteration:
                 pass
             else:

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -644,7 +644,7 @@ class _PipelineStageBase(ABC):
                     fsdp_module.set_is_last_backward(True)
                     fsdp_module.set_reshard_after_backward(True)
                     fsdp_module.set_requires_gradient_sync(True)
-                    fsdp_state = fully_shard.state(fsdp_module)
+                    fsdp_state = fully_shard.state(fsdp_module)  # type: ignore[arg-type]
                     for state in fsdp_state._state_ctx.all_states:
                         if state._fsdp_param_group:
                             state._fsdp_param_group.post_backward()

--- a/torch/distributed/tensor/__init__.py
+++ b/torch/distributed/tensor/__init__.py
@@ -68,7 +68,7 @@ if DTensor not in _optim_foreach_supported_types:
     _optim_foreach_supported_types.append(DTensor)
 
 if DTensor not in _util_foreach_supported_types:
-    _util_foreach_supported_types.append(DTensor)
+    _util_foreach_supported_types.append(DTensor)  # type: ignore[arg-type]
 
 
 # Set namespace for exposed private names

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -74,7 +74,7 @@ def found_inf_reduce_handler(
 ) -> None:
     op_info = dtensor.DTensor._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
     local_tensor_args = pytree.tree_unflatten(
-        cast(List[object], op_info.local_args), op_info.args_tree_spec
+        cast(List[object], op_info.local_args), op_info.args_tree_spec  # type: ignore[arg-type]
     )
     local_tensor_args = cast(Tuple[object, ...], local_tensor_args)
     op_call(*local_tensor_args, **op_info.local_kwargs)

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -23,6 +23,7 @@ from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._op_schema import (
     OpSchema,
     OpStrategy,
+    OutputSharding,
     PlacementList,
     PlacementStrategy,
     RuntimeSchemaInfo,
@@ -46,11 +47,15 @@ _P = ParamSpec("_P")
 def register_prop_rule(
     op: Union[torch._ops.OpOverload, List[torch._ops.OpOverload]],
     schema_info: Optional[RuntimeSchemaInfo] = None,
-) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
+) -> Callable[
+    [Callable[[OpSchema], OutputSharding]], Callable[[OpSchema], OutputSharding]
+]:
     # pyre-fixme[53]: Captured variable `func` is not annotated.
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
-    def wrapper(impl: Callable[_P, _T]) -> Callable[_P, _T]:
+    def wrapper(
+        impl: Callable[[OpSchema], OutputSharding]
+    ) -> Callable[[OpSchema], OutputSharding]:
         overloads = op if isinstance(op, list) else [op]
         for overload in overloads:
             DTensor._op_dispatcher.sharding_propagator.register_sharding_prop_rule(

--- a/torch/distributed/tensor/experimental/_tp_transform.py
+++ b/torch/distributed/tensor/experimental/_tp_transform.py
@@ -229,7 +229,7 @@ def _mark_sharding(
                         op_schema,
                     )
                 else:
-                    output_sharding = DTensor._op_dispatcher.sharding_propagator.propagate_op_sharding(
+                    output_sharding = DTensor._op_dispatcher.sharding_propagator.propagate_op_sharding(  # type: ignore[assignment]
                         op_schema,
                     )
                 placement_strategies[node] = PlacementStrategy(

--- a/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
@@ -1,8 +1,8 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 import operator
 import warnings
-from typing import Callable, Dict, Iterable
+from typing import Callable, Dict, Iterable, TypeVar
+from typing_extensions import ParamSpec
 
 import torch
 from torch.fx._symbolic_trace import _assert_is_none
@@ -54,13 +54,66 @@ from torch.nn.modules.batchnorm import BatchNorm2d
 from torch.nn.modules.conv import Conv2d
 
 
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
+
 _INFERENCE_RULES: Dict[Target, Callable] = {}
 
 MAX_TENSOR_RANK = 4
 
+__all__ = [
+    "ConstraintGenerator",
+    "adaptive_inference_rule",
+    "add_layer_norm_constraints",
+    "add_linear_constraints",
+    "arange_inference_rule",
+    "assert_inference_rule",
+    "batchnorm_inference_rule",
+    "bmm_inference_rule",
+    "broadcasting_inference_rule",
+    "conv2d_inference_rule",
+    "cumsum_inference_rule",
+    "embedding_inference_rule",
+    "embedding_inference_rule_functional",
+    "eq_inference_rule",
+    "equality_inference_rule",
+    "expand_inference_rule",
+    "flatten_inference_rule",
+    "full_inference_rule",
+    "gen_broadcasting_constraints",
+    "gen_embedding_rules",
+    "gen_layer_norm_constraints",
+    "generate_flatten_constraints",
+    "get_attr_inference_rule",
+    "getitem_inference_rule",
+    "gt_inference_rule",
+    "index_select_inference_rule",
+    "layer_norm_functional",
+    "layer_norm_inference_rule",
+    "linear_constraints",
+    "linear_inference_rule",
+    "lt_inference_rule",
+    "masked_fill_inference_rule",
+    "maxpool_inference_rule",
+    "neq_inference_rule",
+    "range_check",
+    "register_inference_rule",
+    "relu_inference_rule",
+    "reshape_inference_rule",
+    "size_inference_rule",
+    "tensor_inference_rule",
+    "torch_dim_inference_rule",
+    "torch_linear_inference_rule",
+    "transpose_inference_rule",
+    "type_inference_rule",
+    "view_inference_rule",
+]
 
-def register_inference_rule(call_target):
-    def register(fn):
+
+def register_inference_rule(
+    call_target: Target,
+) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
+    def register(fn: Callable[_P, _T]) -> Callable[_P, _T]:
         if call_target in _INFERENCE_RULES:
             raise RuntimeError(f"Inference rule already registered for {call_target}!")
         _INFERENCE_RULES[call_target] = fn

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -2126,7 +2126,7 @@ class _MakefxTracer:
         # TODO: kind of a bad way to do it, should maybe figure out a better way
         if self.tracing_mode == "symbolic":
             assert self.fake_tensor_mode is not None
-            t.shape_env = self.fake_tensor_mode.shape_env
+            t.shape_env = self.fake_tensor_mode.shape_env  # type: ignore[assignment]
         return t
 
     def trace(self, f: Callable, *args: object) -> fx.GraphModule:

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 from typing import Any, cast, Dict, List, Optional, Union
 

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 from typing import cast, List, Optional, Tuple, Union
 

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 from typing import cast, List, Optional, Tuple, Union
 

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 from typing import List, Optional, Tuple, Union
 

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 from typing import cast, List, Optional, Tuple, Union
 

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 r"""Implementation for the NAdam algorithm."""
 from typing import cast, List, Optional, Tuple, Union

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 r"""Implementation for the RAdam algorithm."""
 from typing import cast, List, Optional, Tuple, Union

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 r"""Implementation for the RMSprop algorithm."""
 from typing import cast, List, Optional, Union

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 r"""Implementation for the Resilient backpropagation."""
 from typing import cast, List, Optional, Tuple, Union

--- a/torch/signal/windows/windows.py
+++ b/torch/signal/windows/windows.py
@@ -1,7 +1,6 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 from math import sqrt
-from typing import Iterable, Optional
+from typing import Callable, Iterable, Optional, TypeVar
 
 import torch
 from torch import Tensor
@@ -22,6 +21,8 @@ __all__ = [
     "nuttall",
 ]
 
+_T = TypeVar("_T")
+
 window_common_args = merge_dicts(
     parse_kwargs(
         """
@@ -39,7 +40,7 @@ window_common_args = merge_dicts(
 )
 
 
-def _add_docstr(*args):
+def _add_docstr(*args: str) -> Callable[[_T], _T]:
     r"""Adds docstrings to a given decorated function.
 
     Specially useful when then docstrings needs string interpolation, e.g., with
@@ -51,7 +52,7 @@ def _add_docstr(*args):
         args (str):
     """
 
-    def decorator(o):
+    def decorator(o: _T) -> _T:
         o.__doc__ = "".join(args)
         return o
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -13,6 +13,7 @@ from enum import Enum
 from functools import partial, wraps
 from typing import (
     Any,
+    Callable,
     ClassVar,
     Dict,
     Iterable,
@@ -21,8 +22,10 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    TypeVar,
     Union,
 )
+from typing_extensions import ParamSpec
 
 import torch
 from torch._inductor.utils import GPU_TYPES
@@ -61,6 +64,9 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 
+
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
 
 try:
     import psutil  # type: ignore[import]
@@ -1440,9 +1446,9 @@ class deviceCountAtLeast:
 
 
 # Only runs the test on the native device type (currently CPU, CUDA, Meta and PRIVATEUSE1)
-def onlyNativeDeviceTypes(fn):
+def onlyNativeDeviceTypes(fn: Callable[_P, _T]) -> Callable[_P, _T]:
     @wraps(fn)
-    def only_fn(self, *args, **kwargs):
+    def only_fn(self, *args: _P.args, **kwargs: _P.kwargs) -> _T:
         if self.device_type not in NATIVE_DEVICES:
             reason = f"onlyNativeDeviceTypes: doesn't run on {self.device_type}"
             raise unittest.SkipTest(reason)

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -1500,7 +1500,7 @@ def test_compiled_fsdp(compile_compute_on_module: Optional[type] = None):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            original_fully_shard = torch.distributed.fsdp.fully_shard
+            original_fully_shard: Any = torch.distributed.fsdp.fully_shard
             for mode in FullyShardMode:
                 if mode != FullyShardMode.EAGER and not has_triton():
                     warnings.warn("Inductor on GPU needs Triton and recent GPU arch")

--- a/torch/testing/_internal/custom_op_db.py
+++ b/torch/testing/_internal/custom_op_db.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 import torch
 import functools

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 import contextlib
 import platform

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -1,18 +1,19 @@
 # mypy: allow-untyped-defs
-# mypy: allow-untyped-decorators
 import torch
 from torch.utils._pytree import tree_map, tree_flatten, tree_unflatten
 from .module_tracker import ModuleTracker
-from typing import List, Any, Dict, Optional, Union, Tuple, Iterator
+from typing import List, Any, Dict, Optional, Union, Tuple, Iterator, TypeVar, Callable
+from typing_extensions import ParamSpec
 from collections import defaultdict
 from torch.utils._python_dispatch import TorchDispatchMode
 from math import prod
 from functools import wraps
 import warnings
 
-
-
 __all__ = ["FlopCounterMode", "register_flop_formula"]
+
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
 
 aten = torch.ops.aten
 
@@ -30,8 +31,8 @@ def shape_wrapper(f):
         return f(*args, out_shape=out_shape, **kwargs)
     return nf
 
-def register_flop_formula(targets, get_raw=False):
-    def register_fun(flop_formula):
+def register_flop_formula(targets, get_raw=False) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
+    def register_fun(flop_formula: Callable[_P, _T]) -> Callable[_P, _T]:
         if not get_raw:
             flop_formula = shape_wrapper(flop_formula)
 


### PR DESCRIPTION
Summary:
Untyped decorators strip annotations from the decorated items.

- _compile
- _inductor/fx_passes/post_grad
- _inductor/lowering
- _library/custom_ops
- _meta_registrations
- _ops
- _refs/nn/functional
- ao/quantization/quantizer/xnnpack_quantizer_utils
- distributed/_composable/contract
- fx/experimental/graph_gradual_typechecker
- fx/experimental/migrate_gradual_types/constraint_generator
- optim/optimizer
- signal/windows/windows
- testing/_internal/common_device_type
- torch/_inductor/decomposition
- utils/flop_counter

Test Plan: unit tests

Differential Revision: D62302684


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov