### PR TITLE
Refactor FxGraphDrawer to use HTML-like labels (#137726) (#137726)

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -252,6 +252,7 @@ case "$image" in
     SWIFTSHADER=yes
     CONDA_CMAKE=yes
     TRITON=yes
+    GRAPHVIZ=yes
     ;;
   pytorch-linux-focal-py3.9-gcc9)
     ANACONDA_PYTHON_VERSION=3.9

--- a/.ci/docker/common/install_graphviz.sh
+++ b/.ci/docker/common/install_graphviz.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ex
+
+source "$(dirname "${BASH_SOURCE[0]}")/common_utils.sh"
+
+if [ -n "${UBUNTU_VERSION}" ]; then
+    apt update
+    apt-get install -y graphviz
+elif [ -n "${CENTOS_VERSION}" ]; then
+    dnf update
+    dnf install -y graphviz
+else
+    echo "Unsupported Linux distribution"
+    exit 1
+fi

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -213,6 +213,11 @@ xdoctest==1.1.0
 #Pinned versions: 1.1.0
 #test that import:
 
+pydot==3.0.1
+#Description: Needed for testing FxGraphDrawer
+#Pinned versions:
+#test that import:
+
 pygments==2.15.0
 #Description: support doctest highlighting
 #Pinned versions: 2.12.0

--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -171,6 +171,13 @@ RUN if [ -n "${ACL}" ]; then bash ./install_acl.sh; fi
 RUN rm install_acl.sh
 ENV INSTALLED_ACL ${ACL}
 
+# (optional) install graphviz
+ARG GRAPHVIZ
+COPY ./common/install_graphviz.sh install_graphviz.sh
+RUN if [ -n "${GRAPHVIZ}" ]; then bash ./install_graphviz.sh; fi
+RUN rm install_graphviz.sh
+ENV INSTALLED_GRAPHVIZ ${GRAPHVIZ}
+
 # Install ccache/sccache (do this last, so we get priority in PATH)
 ARG SKIP_SCCACHE_INSTALL
 COPY ./common/install_cache.sh install_cache.sh

--- a/test/fx/test_graph_drawer.py
+++ b/test/fx/test_graph_drawer.py
@@ -1,0 +1,43 @@
+# Owner(s): ["oncall: fx"]
+
+import os
+import tempfile
+
+import torch
+import torch._dynamo as dynamo
+from torch.fx.passes.graph_drawer import FxGraphDrawer
+from torch.nn import LayerNorm
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestGraphDrawer(TestCase):
+    def test_that_graph_with_subgraph_draws_successfully(self):
+        # covering regression: https://github.com/pytorch/pytorch/issues/137499
+        if os.environ.get("INSTALLED_GRAPHVIZ", "") == "yes":
+            batch_size = 32
+            seq_length = 50
+            hidden_size = 768
+            layer_norm = LayerNorm(hidden_size)
+
+            torch.set_grad_enabled(False)
+
+            @torch.compile
+            def fn(inp, weight):
+                matmul_output = inp @ weight
+                final_output = layer_norm(matmul_output)
+                return final_output
+
+            inp = torch.randn(batch_size, seq_length, hidden_size)
+            weight = torch.randn(hidden_size, hidden_size)
+
+            graph_module = dynamo.export(fn)(inp, weight)[0]
+
+            g = FxGraphDrawer(graph_module, name="fn")
+            dot = g.get_main_dot_graph()
+            out_name = tempfile.NamedTemporaryFile(delete=True).name + ".svg"
+            # This should succeed
+            dot.write_svg(out_name)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -46,6 +46,7 @@ from fx.test_fx_param_shape_control_flow import TestConstParamShapeInControlFlow
 from fx.test_pass_infra import TestPassManager  # noqa: F401
 from fx.test_common_passes import TestCommonPass  # noqa: F401
 from fx.test_cse_pass import TestCSEPass  # noqa: F401
+from fx.test_graph_drawer import TestGraphDrawer  # noqa: F401
 from fx.test_matcher_utils import TestMatcher  # noqa: F401
 from fx.test_source_matcher_utils import TestSourceMatcher  # noqa: F401
 

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1908,7 +1908,6 @@ def draw_graph(
     clear_meta: bool = True,
     prog: Optional[Union[str, List[str]]] = None,
     parse_stack_trace: bool = False,
-    dot_graph_shape: Optional[str] = None,
 ) -> None:
     if clear_meta:
         new_graph = copy.deepcopy(traced.graph)
@@ -1923,7 +1922,6 @@ def draw_graph(
         traced,
         figname,
         parse_stack_trace=parse_stack_trace,
-        dot_graph_shape=dot_graph_shape,
     )
     x = g.get_main_dot_graph()
     write_method = getattr(x, "write_" + ext.lstrip("."))

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1313,16 +1313,6 @@ class trace:
     # SVG figure showing fx with fusion
     draw_orig_fx_graph = os.environ.get("INDUCTOR_ORIG_FX_SVG", "0") == "1"
 
-    # We draw our fx graphs with the "record" shape attribute by default.
-    # Sometimes, when the graph is very complex, we may hit dot errors like below:
-    #   "flat edge between adjacent nodes one of which has a record shape -
-    #    replace records with HTML-like labels"
-    # and thus fail to generate a graph. So, let's give the user an option
-    # to specify the shape attribute for the dot graph. For example, passing
-    # INDUCTOR_DOT_GRAPH_SHAPE_SVG = "none" would let us generate HTML-like lables
-    # to workaround the above failure.
-    dot_graph_shape = os.environ.get("INDUCTOR_DOT_GRAPH_SHAPE_SVG", None)
-
     # If not None, this is the URL that saves the SVG files of the input/output
     # graph of each pass that changed the graph
     # The nodes that are being transformed in each pass will be colored in yellow

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -94,9 +94,7 @@ def draw_buffers(
     gm = GraphModule({}, graph)
     legalize_graph(gm)
     gm.graph.lint()
-    draw_graph(
-        gm, fname, clear_meta=False, dot_graph_shape=config.trace.dot_graph_shape
-    )
+    draw_graph(gm, fname, clear_meta=False)
 
 
 def create_fx_from_snodes(snodes: List[BaseSchedulerNode]) -> fx.Graph:
@@ -541,7 +539,6 @@ class DebugFormatter:
             clear_meta=False,
             prog=GRAPHVIZ_COMMAND_SCALABLE,
             parse_stack_trace=True,
-            dot_graph_shape=config.trace.dot_graph_shape,
         )
 
     def output_code(self, filename: str) -> None:


### PR DESCRIPTION
Summary:
Fixes https://github.com/pytorch/pytorch/issues/137499
Testing: Added a new unit test to make sure that the regression case succeeds.
I'm debating about whether to make the borders visible. I'm partial to no borders, but it might make it harder for some people to read?
![68a2b0e3-orig_fx_graph_diagram](https://github.com/user-attachments/assets/fbc2fd98-9e76-488e-8ebe-c64fbf206932)
Vs.
![2bfe1c4f-orig_fx_graph_diagram](https://github.com/user-attachments/assets/b6bc88ba-dda2-4cf7-84ac-a615e1e03a74)

Approved by: https://github.com/eellison, https://github.com/malfet

Test Plan: contbuild & OSS CI, see https://hud.pytorch.org/commit/pytorch/pytorch/1e738420296a84406cd0a1626074ea6447a6603a

Reviewed By: jingsh, dulinriley

Differential Revision: D65460378

Pulled By: exclamaforte




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @BoyuanFeng