### PR TITLE
Fix ruff warnings in caffe2 and functorch

### DIFF
--- a/functorch/dim/__init__.py
+++ b/functorch/dim/__init__.py
@@ -1,6 +1,7 @@
 import dis
 import inspect
-from typing import Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 import functorch._C
 import torch

--- a/functorch/einops/_parsing.py
+++ b/functorch/einops/_parsing.py
@@ -27,7 +27,11 @@ from __future__ import annotations
 
 import keyword
 import warnings
-from typing import Collection, List, Mapping, Optional, Set, Tuple, Union
+from typing import List, Optional, Set, Tuple, TYPE_CHECKING, Union
+
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Mapping
 
 
 _ellipsis: str = "\u2026"  # NB, this is a single unicode symbol. String is used as it is not a list, but can be iterated

--- a/functorch/einops/rearrange.py
+++ b/functorch/einops/rearrange.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-from typing import Callable, Dict, List, Sequence, Tuple, Union
+from typing import Callable, Dict, List, Tuple, TYPE_CHECKING, Union
 
 import torch
 from functorch._C import dim as _C
@@ -13,6 +13,10 @@ from ._parsing import (
     parse_pattern,
     validate_rearrange_expressions,
 )
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 __all__ = ["rearrange"]


### PR DESCRIPTION
In preparation for upgrading ruff config to py3.9.