### PR TITLE
Add support for cpu scalar in addcdiv

### DIFF
--- a/aten/src/ATen/native/PointwiseOps.cpp
+++ b/aten/src/ATen/native/PointwiseOps.cpp
@@ -48,7 +48,15 @@ TORCH_META_FUNC(addcdiv)
         "The future addcdiv behavior is just the latter implementation: ",
         "(input + value * tensor1 / tensor2), for all dtypes.");
   }
-  build_ternary_op(maybe_get_output(), self, tensor1, tensor2);
+  build(TensorIteratorConfig()
+      .allow_cpu_scalars(true)
+      .promote_inputs_to_common_dtype(true)
+      .cast_common_dtype_to_outputs(true)
+      .enforce_safe_casting_to_output(true)
+      .add_owned_output(maybe_get_output())
+      .add_owned_const_input(self)
+      .add_owned_const_input(tensor1)
+      .add_owned_const_input(tensor2));
 }
 
 } // namespace at::meta

--- a/aten/src/ATen/native/PointwiseOps.cpp
+++ b/aten/src/ATen/native/PointwiseOps.cpp
@@ -32,21 +32,21 @@ TORCH_META_FUNC(addcmul)
 
 TORCH_META_FUNC(addcdiv)
 (const Tensor& self,
- const Tensor& tensor1,
- const Tensor& tensor2,
+ const Tensor& numerator,
+ const Tensor& denominator,
  const Scalar& value) {
-  if (isIntegralType(tensor1.scalar_type(), /*includeBool=*/true) &&
-      isIntegralType(tensor2.scalar_type(), /*includeBool=*/true)) {
+  if (isIntegralType(numerator.scalar_type(), /*includeBool=*/true) &&
+      isIntegralType(denominator .scalar_type(), /*includeBool=*/true)) {
     TORCH_CHECK(
         false,
         "Integer division with addcdiv is no longer supported, and in a future  ",
-        "release addcdiv will perform a true division of tensor1 and tensor2. ",
+        "release addcdiv will perform a true division of numerator and denominator. ",
         "The historic addcdiv behavior can be implemented as ",
-        "(input + value * torch.trunc(tensor1 / tensor2)).to(input.dtype) ",
+        "(input + value * torch.trunc(numerator / denominator)).to(input.dtype) ",
         "for integer inputs and as ",
-        "(input + value * tensor1 / tensor2) for float inputs. ",
+        "(input + value * numerator / denominator) for float inputs. ",
         "The future addcdiv behavior is just the latter implementation: ",
-        "(input + value * tensor1 / tensor2), for all dtypes.");
+        "(input + value * numerator / denominator), for all dtypes.");
   }
   build(TensorIteratorConfig()
       .allow_cpu_scalars(true)
@@ -55,8 +55,8 @@ TORCH_META_FUNC(addcdiv)
       .enforce_safe_casting_to_output(true)
       .add_owned_output(maybe_get_output())
       .add_owned_const_input(self)
-      .add_owned_const_input(tensor1)
-      .add_owned_const_input(tensor2));
+      .add_owned_const_input(numerator)
+      .add_owned_const_input(denominator));
 }
 
 } // namespace at::meta

--- a/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
@@ -145,11 +145,31 @@ void addcmul_cuda_scalar_tensor2_kernel(TensorIteratorBase& iter, const Scalar& 
   }
 }
 
+void addcdiv_cuda_scalar_tensor2_kernel(
+  TensorIteratorBase& iter,
+  const Scalar& scalar_tensor2,
+  const Scalar& value
+);
+
 #if AT_USE_JITERATOR() && CUDA_VERSION >= 11050
 // return a + alpha * (b / static_cast<accscalar_t>(c));
 constexpr char addcdiv_name[] = "addcdiv";
 #endif
 void addcdiv_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
+  TORCH_CHECK(
+    !iter.is_cpu_scalar(1),
+    "CPU Scalar support for self argument is not supported when "
+    "calling addcdiv on CUDA tensors."
+  );
+
+  TORCH_CHECK(
+    !iter.is_cpu_scalar(2),
+    "CPU Scalar support for tensor1 argument is not supported when "
+    "calling addcdiv on CUDA tensors. "
+    "However, CPU Scalar support for tensor2 is supported, "
+    "please swap your tensor1 and tensor2 terms."
+  );
+
   auto dtype = iter.common_dtype();
   if (at::isComplexType(dtype)) {
     // When using Jiterator, addcmul and addcdiv kernels get stuck during a
@@ -161,6 +181,11 @@ void addcdiv_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
         static const auto addcdiv_string =
             jiterator_stringify(template <typename T> T addcdiv(
                 T a, T b, T c, T alpha) { return a + alpha * (b / c); });
+        if (iter.is_cpu_scalar(3)) {
+          auto tensor2_val = iter.scalar_value<scalar_t>(3);
+          iter.remove_operand(3);
+          return addcdiv_cuda_scalar_tensor2_kernel(iter, tensor2_val, value);
+        }
         jitted_gpu_kernel<
             /*name=*/addcdiv_name,
             /*return_dtype=*/scalar_t,
@@ -174,8 +199,71 @@ void addcdiv_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
       });
     #else
       AT_DISPATCH_COMPLEX_TYPES(dtype, "addcdiv_cuda", [&]() {
+        if (iter.is_cpu_scalar(3)) {
+          auto tensor2_val = iter.scalar_value<scalar_t>(3);
+          iter.remove_operand(3);
+          return addcdiv_cuda_scalar_tensor2_kernel(iter, tensor2_val, value);
+        }
+
         auto alpha = value.to<scalar_t>();
         gpu_kernel(iter, [alpha]GPU_LAMBDA(scalar_t a, scalar_t b, scalar_t c) -> scalar_t {
+          return a + alpha * (b / c);
+        });
+      });
+    #endif
+  } else {
+    AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, dtype, "addcdiv_cuda", [&]() {
+      if (iter.is_cpu_scalar(3)) {
+        auto tensor2_val = iter.scalar_value<scalar_t>(3);
+        iter.remove_operand(3);
+        return addcdiv_cuda_scalar_tensor2_kernel(iter, tensor2_val, value);
+      }
+      // note(mkozuki): If scalar_t is fp16 or bfloat16, cast scalar to float
+      // and do math in fp32 for better accuracy.
+      using accscalar_t = at::acc_type<scalar_t, true>;
+      auto alpha = value.to<accscalar_t>();
+      gpu_kernel(iter, [alpha]GPU_LAMBDA(scalar_t a, scalar_t b, scalar_t c) -> scalar_t {
+        return a + alpha * (b / static_cast<accscalar_t>(c));
+      });
+    });
+  }
+}
+
+
+#if AT_USE_JITERATOR() && CUDA_VERSION >= 11050
+// return a + alpha * (b / static_cast<accscalar_t>(c));
+constexpr char addcdiv_scalar_tensor2_name[] = "addcdiv_scalar_tensor2";
+#endif
+void addcdiv_cuda_scalar_tensor2_kernel(TensorIteratorBase& iter, const Scalar& scalar_tensor2, const Scalar& value) {
+  auto dtype = iter.common_dtype();
+
+  if (at::isComplexType(dtype)) {
+    // When using Jiterator, addcmul and addcdiv kernels get stuck during a
+    // promotion test on CUDA 11.3, so only enable that from CUDA 11.5:
+    // https://github.com/pytorch/pytorch/pull/74234#issuecomment-1100932209
+    #if AT_USE_JITERATOR() && CUDA_VERSION >= 11050
+      AT_DISPATCH_COMPLEX_TYPES(dtype, "addcdiv_cuda", [&]() {
+        auto c = scalar_tensor2.to<scalar_t>();
+        auto alpha = value.to<scalar_t>();
+        static const auto addcdiv_scalar_tensor2_string =
+            jiterator_stringify(template <typename T> T addcdiv_scalar_tensor2(
+                T a, T b, T c, T alpha) { return a + alpha * (b / c); });
+        jitted_gpu_kernel<
+            /*name=*/addcdiv_scalar_tensor2_name,
+            /*return_dtype=*/scalar_t,
+            /*common_dtype=*/scalar_t,
+            /*arity=*/2>(
+            iter,
+            addcdiv_scalar_tensor2_string,
+            /*scalar_pos=*/at::cuda::jit::BinaryFuncVariant::NoScalar,
+            /*scalar_val=*/0,
+            /*extra_args=*/std::make_tuple(c, alpha));
+      });
+    #else
+      AT_DISPATCH_COMPLEX_TYPES(dtype, "addcdiv_cuda", [&]() {
+        auto c = scalar_tensor2.to<scalar_t>();
+        auto alpha = value.to<scalar_t>();
+        gpu_kernel(iter, [alpha, c]GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
           return a + alpha * (b / c);
         });
       });
@@ -185,8 +273,9 @@ void addcdiv_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
       // note(mkozuki): If scalar_t is fp16 or bfloat16, cast scalar to float
       // and do math in fp32 for better accuracy.
       using accscalar_t = at::acc_type<scalar_t, true>;
+      auto c = scalar_tensor2.to<accscalar_t>();
       auto alpha = value.to<accscalar_t>();
-      gpu_kernel(iter, [alpha]GPU_LAMBDA(scalar_t a, scalar_t b, scalar_t c) -> scalar_t {
+      gpu_kernel(iter, [alpha, c]GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return a + alpha * (b / static_cast<accscalar_t>(c));
       });
     });

--- a/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
@@ -162,7 +162,7 @@ void addcdiv_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
     "calling addcdiv on CUDA tensors."
   );
 
-  TORCH_CHECK(
+  TORCH_CHECK_VALUE(
     !iter.is_cpu_scalar(2),
     "CPU Scalar support for tensor1 argument is not supported when "
     "calling addcdiv on CUDA tensors. "

--- a/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
@@ -156,7 +156,7 @@ void addcdiv_cuda_scalar_tensor2_kernel(
 constexpr char addcdiv_name[] = "addcdiv";
 #endif
 void addcdiv_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
-  TORCH_CHECK(
+  TORCH_CHECK_VALUE(
     !iter.is_cpu_scalar(1),
     "CPU Scalar support for self argument is not supported when "
     "calling addcdiv on CUDA tensors."

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4410,9 +4410,10 @@ else:
         c = torch.rand((2, 2), device=device)
         scalar = torch.rand([], device="cpu")
 
-        with self.assertRaisesRegex(RuntimeError, r'CPU Scalar support for tensor1 argument'):
+
+        with self.assertRaisesRegex(ValueError, r'CPU Scalar support for tensor1 argument'):
             torch.addcdiv(a, scalar, c, value=alpha)
-        with self.assertRaisesRegex(RuntimeError, r'CPU Scalar support for self argument'):
+        with self.assertRaisesRegex(ValueError, r'CPU Scalar support for self argument'):
             torch.addcdiv(scalar, b, c, value=alpha)
 
     def test_nullary_op_mem_overlap(self, device):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4348,9 +4348,10 @@ else:
 
     # FIXME: move to elementwise ternary test suite
     @onlyNativeDeviceTypes
+    @parametrize("use_cpu_scalar", [True, False])
     @dtypesIfCUDA(*set(get_all_math_dtypes('cuda')))
     @dtypes(*set(get_all_math_dtypes('cpu')))
-    def test_addcdiv(self, device, dtype):
+    def test_addcdiv(self, device, dtype, use_cpu_scalar):
         # Returns floating or integral scalar corresponding to dtype
         def _number(floating, integer, dtype):
             if dtype in [torch.half, torch.float, torch.double, torch.bfloat16]:
@@ -4372,7 +4373,10 @@ else:
         def _test_addcdiv():
             a = non_zero_rand((2, 2), dtype=dtype, device=device)
             b = non_zero_rand((2, 2), dtype=dtype, device=device)
-            c = non_zero_rand((2, 2), dtype=dtype, device=device)
+            if use_cpu_scalar:
+                c = non_zero_rand([], device="cpu", dtype=dtype)
+            else:
+                c = non_zero_rand((2, 2), dtype=dtype, device=device)
             alpha = _number(0.5, 3, dtype)
 
             expected = a + (alpha * b) / c
@@ -4396,6 +4400,20 @@ else:
             c = torch.tensor([1.0], device=device, dtype=dtype)
             out = torch.addcmul(a, b, c, value=-2)
             self.assertTrue(not (out.isnan() or out.isinf()))
+
+    @onlyCUDA
+    def test_addcdiv_cuda_errors_with_cpu_scalars(self, device):
+        alpha = 0.5
+
+        a = torch.rand((2, 2), device=device)
+        b = torch.rand((2, 2), device=device)
+        c = torch.rand((2, 2), device=device)
+        scalar = torch.rand([], device="cpu")
+
+        with self.assertRaisesRegex(RuntimeError, r'CPU Scalar support for tensor1 argument'):
+            torch.addcdiv(a, scalar, c, value=alpha)
+        with self.assertRaisesRegex(RuntimeError, r'CPU Scalar support for self argument'):
+            torch.addcdiv(scalar, b, c, value=alpha)
 
     def test_nullary_op_mem_overlap(self, device):
         ops = (

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4410,7 +4410,6 @@ else:
         c = torch.rand((2, 2), device=device)
         scalar = torch.rand([], device="cpu")
 
-
         with self.assertRaisesRegex(ValueError, r'CPU Scalar support for tensor1 argument'):
             torch.addcdiv(a, scalar, c, value=alpha)
         with self.assertRaisesRegex(ValueError, r'CPU Scalar support for self argument'):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4403,12 +4403,11 @@ else:
 
     @onlyCUDA
     def test_addcdiv_cuda_errors_with_cpu_scalars(self, device):
-        alpha = 0.5
-
         a = torch.rand((2, 2), device=device)
         b = torch.rand((2, 2), device=device)
         c = torch.rand((2, 2), device=device)
         scalar = torch.rand([], device="cpu")
+        alpha = 0.5
 
         with self.assertRaisesRegex(ValueError, r'CPU Scalar support for tensor1 argument'):
             torch.addcdiv(a, scalar, c, value=alpha)


### PR DESCRIPTION
Fixes #143306


Adds support for CPU scalar for tensor_2 in addcdiv. For example:
```
import torch
a = torch.rand(2, 2, device="cuda")
b = torch.tensor(1e-3)

torch.add(a, b)
torch.addcdiv(a, a, b)  # used to fail, now works
```

Nearly identical to #143264