### PR TITLE
[EZ][BE] Cleanup `test_mps_basic`

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -57,8 +57,8 @@ class MPSBasicTests(TestCase):
         self.common(
             lambda a, b: a + b,
             (
-                make_tensor(1024, dtype=dtype),
-                make_tensor(1024, dtype=dtype),
+                make_tensor(1024, dtype=dtype, device=self.device),
+                make_tensor(1024, dtype=dtype, device=self.device),
             ),
             check_lowp=False,
         )

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -40,26 +40,27 @@ class MPSBasicTests(TestCase):
 
     test_add_const_int = CommonTemplate.test_add_const_int
     test_add_inplace_permuted_mps = CommonTemplate.test_add_inplace_permuted
-    test_max_min = CommonTemplate.test_max_min
-    test_inf = CommonTemplate.test_inf
-    test_nan_to_num = CommonTemplate.test_nan_to_num
-    test_zero_dim_reductions = CommonTemplate.test_zero_dim_reductions
-    test_views6 = CommonTemplate.test_views6
     test_addmm = CommonTemplate.test_addmm
+    test_cat_empty = CommonTemplate.test_cat_empty
+    test_inf = CommonTemplate.test_inf
+    test_max_min = CommonTemplate.test_max_min
+    test_max_pool2d2 = CommonTemplate.test_max_pool2d2
+    test_nan_to_num = CommonTemplate.test_nan_to_num
+    test_remainder = CommonTemplate.test_remainder
     test_signbit = CommonTemplate.test_signbit
     test_view_as_complex = CommonTemplate.test_view_as_complex
-    test_remainder = CommonTemplate.test_remainder
-    test_max_pool2d2 = CommonTemplate.test_max_pool2d2
-    test_cat_empty = CommonTemplate.test_cat_empty
+    test_views6 = CommonTemplate.test_views6
+    test_zero_dim_reductions = CommonTemplate.test_zero_dim_reductions
 
     @parametrize("dtype", MPS_DTYPES)
     def test_add(self, dtype):
         self.common(
             lambda a, b: a + b,
             (
-                make_tensor(1024, device="mps", dtype=dtype),
-                make_tensor(1024, dtype=dtype, device="mps"),
+                make_tensor(1024, dtype=dtype),
+                make_tensor(1024, dtype=dtype),
             ),
+            check_lowp=False,
         )
 
     def test_log(self):


### PR DESCRIPTION
- Sort imported tests alphabetically
- Run `add` tests with `check_lowp=False` as it is tested explicitly by parametrization
- Do not hardcode device, but rather use `self.device` property

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov