### PR TITLE
[mps/BE] Enable a test that now passes.

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -42,6 +42,7 @@ class MPSBasicTests(TestCase):
     test_add_inplace_permuted_mps = CommonTemplate.test_add_inplace_permuted
     test_addmm = CommonTemplate.test_addmm
     test_cat_empty = CommonTemplate.test_cat_empty
+    test_floordiv = CommonTemplate.test_floordiv
     test_inf = CommonTemplate.test_inf
     test_max_min = CommonTemplate.test_max_min
     test_max_pool2d2 = CommonTemplate.test_max_pool2d2


### PR DESCRIPTION
After the implementation of floordiv in https://github.com/pytorch/pytorch/commit/464b50dbd7e0692970a2e34aac5b2eeb088741c6 landed, this now passes.

cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov