### PR TITLE
[mps/BE] Fix linter warning/advice.

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6590,7 +6590,7 @@ class TestMPS(TestCaseMPS):
     def test_angle(self):
         def helper(shape, dtype):
             cpu_x = torch.randn(shape, device='cpu', dtype=dtype, requires_grad=False)
-            cpu_x.flatten()[0] = np.nan # Test that NaN is propagated correctly
+            cpu_x.flatten()[0] = np.nan  # Test that NaN is propagated correctly
             x = cpu_x.detach().clone().to('mps')
 
             angle_result = torch.angle(x)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6590,7 +6590,7 @@ class TestMPS(TestCaseMPS):
     def test_angle(self):
         def helper(shape, dtype):
             cpu_x = torch.randn(shape, device='cpu', dtype=dtype, requires_grad=False)
-            cpu_x.flatten()[0] = np.nan  # Test that NaN is propagated correctly
+            cpu_x.flatten()[0] = torch.nan  # Test that NaN is propagated correctly
             x = cpu_x.detach().clone().to('mps')
 
             angle_result = torch.angle(x)


### PR DESCRIPTION
Two spaces before an inline comment according to E261.



cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen