### PR TITLE
[Inductor] Add convolution output size checking to the meta function

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -12201,10 +12201,10 @@ class CommonTemplate:
             inputs = torch.randn((1,) * (dim + 2))
             model = Model(dim)
 
-            with self.assertRaisesRegex(ValueError, "Output size is too small"):
+            with self.assertRaisesRegex(RuntimeError, "Output size is too small"):
                 _ = model(inputs)
 
-            with self.assertRaisesRegex(ValueError, "Output size is too small"):
+            with self.assertRaisesRegex(RuntimeError, "Output size is too small"):
                 _ = torch.compile(model)(inputs)
 
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -12201,10 +12201,10 @@ class CommonTemplate:
             inputs = torch.randn((1,) * (dim + 2))
             model = Model(dim)
 
-            with self.assertRaisesRegex(RuntimeError, "Output size is too small"):
+            with self.assertRaisesRegex(ValueError, "Output size is too small"):
                 _ = model(inputs)
 
-            with self.assertRaisesRegex(RuntimeError, "Output size is too small"):
+            with self.assertRaisesRegex(ValueError, "Output size is too small"):
                 _ = torch.compile(model)(inputs)
 
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -12182,6 +12182,31 @@ class CommonTemplate:
         self.assertEqual(res1, ref1)
         self.assertEqual(res2, ref2)
 
+    def test_conv_shape_check(self):
+        # https://github.com/pytorch/pytorch/issues/144013
+        class Model(torch.nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                conv_t_cls = eval(f"torch.nn.ConvTranspose{dim}d")
+                self.conv_t = conv_t_cls(
+                    1, 1, kernel_size=(2,) * dim, padding=(1,) * dim
+                )
+
+            def forward(self, x):
+                x = self.conv_t(x)
+                x = torch.sigmoid(x)  # tigger condition
+                return x
+
+        for dim in (1, 2, 3):
+            inputs = torch.randn((1,) * (dim + 2))
+            model = Model(dim)
+
+            with self.assertRaisesRegex(RuntimeError, "Output size is too small"):
+                _ = model(inputs)
+
+            with self.assertRaisesRegex(RuntimeError, "Output size is too small"):
+                _ = torch.compile(model)(inputs)
+
 
 @dataclasses.dataclass
 class TestFailure:

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2254,7 +2254,9 @@ def calc_conv_nd_return_shape(
             )
     torch._check(
         any(x > 0 for x in ret_shape[2:]),
-        lambda: f"Given input size per channel: {list(dims)}. Calculated output size per channel: {ret_shape[2:]}. Output size is too small",
+        lambda: f"Given input size per channel: {list(dims)}. "
+        f"Calculated output size per channel: {ret_shape[2:]}. "
+        f"Output size is too small",
     )
 
     return ret_shape

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2252,6 +2252,10 @@ def calc_conv_nd_return_shape(
             ret_shape.append(
                 _formula(dims[i], padding[i], dilation[i], kernel_size[i], stride[i])
             )
+    torch._check(
+        any(x > 0 for x in ret_shape[2:]),
+        lambda: f"Given input size per channel: {list(dims)}. Calculated output size per channel: {ret_shape[2:]}. Output size is too small",
+    )
 
     return ret_shape
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2252,7 +2252,7 @@ def calc_conv_nd_return_shape(
             ret_shape.append(
                 _formula(dims[i], padding[i], dilation[i], kernel_size[i], stride[i])
             )
-    torch._check_value(
+    torch._check(
         any(x > 0 for x in ret_shape[2:]),
         lambda: f"Given input size per channel: {list(dims)}. "
         f"Calculated output size per channel: {ret_shape[2:]}. "

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2252,7 +2252,7 @@ def calc_conv_nd_return_shape(
             ret_shape.append(
                 _formula(dims[i], padding[i], dilation[i], kernel_size[i], stride[i])
             )
-    torch._check(
+    torch._check_value(
         any(x > 0 for x in ret_shape[2:]),
         lambda: f"Given input size per channel: {list(dims)}. "
         f"Calculated output size per channel: {ret_shape[2:]}. "


### PR DESCRIPTION
Fixes #144013

Adding a size check to the meta function, similar to which in the CUDA/CPU aten op.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov