### PR TITLE
Make all-reduce input contiguous in `distributed.nn.all_reduce`

### DIFF
--- a/torch/distributed/nn/functional.py
+++ b/torch/distributed/nn/functional.py
@@ -443,7 +443,7 @@ class _AllReduce(Function):
     def forward(ctx, op, group, tensor):
         ctx.group = group
         ctx.op = op
-        tensor = tensor.clone().contiguous()
+        tensor = tensor.clone(memory_format=torch.contiguous_format)
         dist.all_reduce(tensor, op=op, group=group)
         return tensor
 

--- a/torch/distributed/nn/functional.py
+++ b/torch/distributed/nn/functional.py
@@ -443,7 +443,7 @@ class _AllReduce(Function):
     def forward(ctx, op, group, tensor):
         ctx.group = group
         ctx.op = op
-        tensor = tensor.clone()
+        tensor = tensor.clone().contiguous()
         dist.all_reduce(tensor, op=op, group=group)
         return tensor
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144267

Fixes https://github.com/pytorch/pytorch/issues/144060

I confirmed that the unit test fails without the `.contiguous()` fix.

cc @H-Huang @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o