### PR TITLE
[BE]: Remove redundant copy in torch chunk shard

### DIFF
--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py
@@ -162,7 +162,9 @@ class ChunkShardingSpec(ShardingSpec):
                         narrowed_tensor.detach().clone().resize_(scatter_shape)
                     )
                 else:
-                    tensor_to_scatter = narrowed_tensor.detach().clone().contiguous()
+                    tensor_to_scatter = narrowed_tensor.detach().clone(
+                        memory_format=torch.contiguous_format
+                    )
 
                 tensors_to_scatter[
                     dist.get_group_rank(process_group, remote_global_rank)


### PR DESCRIPTION
Fixes an issue noticed in recent all_gather PR. Some parts of the codebase have a double copy with `clone().contiguous()` which could be fused into a single copy op.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o