### PR TITLE
[MPSInductor] Add `nan` constant generation

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -44,6 +44,7 @@ class MPSBasicTests(TestCase):
     test_cat_empty = CommonTemplate.test_cat_empty
     test_floordiv = CommonTemplate.test_floordiv
     test_inf = CommonTemplate.test_inf
+    test_isinf2 = CommonTemplate.test_isinf2
     test_max_min = CommonTemplate.test_max_min
     test_max_pool2d2 = CommonTemplate.test_max_pool2d2
     test_nan_to_num = CommonTemplate.test_nan_to_num

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -62,10 +62,14 @@ class MetalOverrides(OpOverrides):
 
     @staticmethod
     def constant(val: CSEVariable, dtype: torch.dtype) -> str:
-        if val == torch.inf:
-            return "HUGE_VALF"
-        elif val == -torch.inf:
-            return "-HUGE_VALF"
+        if isinstance(val, float):
+            if val == torch.inf:
+                return "HUGE_VALF"
+            elif val == -torch.inf:
+                return "-HUGE_VALF"
+            elif val != val:  # Only float that not equal to self is nan
+                return "NAN"
+            return str(val)
         elif isinstance(val, bool):
             return "true" if val else "false"
         return str(val)


### PR DESCRIPTION
If val is not equal to self, it's a nan (which is spelled as `NAN` in Metal)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov