### PR TITLE
[BE] stop using deprecated _vmap in our library

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -10512,7 +10512,7 @@ class TestAutogradForwardModeBatchedGrad(TestCase):
                 x = fwAD.make_dual(input, tangent)
                 return fwAD.unpack_dual(x)[1]
 
-        x_tangent = torch._vmap_internals._vmap(jvp, 0, 0)(tangent)
+        x_tangent = torch.vmap(jvp, 0, 0)(tangent)
 
         self.assertIsNot(x_tangent, tangent)
 
@@ -10532,9 +10532,7 @@ class TestAutogradForwardModeBatchedGrad(TestCase):
                     fwAD.unpack_dual(view._base)[1],
                 )
 
-        x_tangent, view_tangent, base_tangent = torch._vmap_internals._vmap(jvp, 0, 0)(
-            tangent
-        )
+        x_tangent, view_tangent, base_tangent = torch.vmap(jvp, 0, 0)(tangent)
 
         self.assertFalse(
             view_tangent._is_view()
@@ -10557,9 +10555,7 @@ class TestAutogradForwardModeBatchedGrad(TestCase):
                     fwAD.unpack_dual(view._base)[1],
                 )
 
-        x_tangent, view_tangent, base_tangent = torch._vmap_internals._vmap(jvp, 0, 0)(
-            tangent
-        )
+        x_tangent, view_tangent, base_tangent = torch.vmap(jvp, 0, 0)(tangent)
 
         self.assertIs(view_tangent._base, base_tangent)
         self.assertIs(x_tangent, tangent)
@@ -10586,7 +10582,7 @@ class TestAutogradForwardModeBatchedGrad(TestCase):
                     dual.as_strided((5,), (1,), 0)
             return unpacked_tangent
 
-        torch._vmap_internals._vmap(jvp, 0, 0)(tangent)
+        torch.vmap(jvp, 0, 0)(tangent)
 
 
 class TestAutogradForwardMode(TestCase):

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -12,7 +12,6 @@ import warnings
 from typing import cast, List, Optional, Sequence, Tuple, Union
 
 import torch
-from torch import _vmap_internals
 from torch.overrides import handle_torch_function, has_torch_function, is_tensor_like
 from torch.types import _size, _TensorOrTensors, _TensorOrTensorsOrGradEdge
 
@@ -489,9 +488,7 @@ def grad(
                 accumulate_grad=False,
             )
 
-        result = _vmap_internals._vmap(vjp, 0, 0, allow_none_pass_through=True)(
-            grad_outputs_
-        )
+        result = torch.vmap(vjp, 0, 0, allow_none_pass_through=True)(grad_outputs_)
     else:
         result = _engine_run_backward(
             outputs,

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -488,7 +488,7 @@ def grad(
                 accumulate_grad=False,
             )
 
-        result = torch.vmap(vjp, 0, 0, allow_none_pass_through=True)(grad_outputs_)
+        result = torch.vmap(vjp, 0, 0)(grad_outputs_)
     else:
         result = _engine_run_backward(
             outputs,

--- a/torch/autograd/functional.py
+++ b/torch/autograd/functional.py
@@ -2,7 +2,6 @@
 from typing import List, Tuple
 
 import torch
-from torch._vmap_internals import _vmap
 
 from . import forward_ad as fwAD
 
@@ -545,7 +544,7 @@ def _jacfwd(func, inputs, strict=False, vectorize=False):
                 output_info.append(primal_outs)
                 return tuple(jv)
 
-        outputs_before_split = _vmap(jvp)(tangents)
+        outputs_before_split = torch.vmap(jvp)(tangents)
         is_outputs_tuple, outputs = output_info
         # Step 3: for each of the output tangents, split along dim 0
         jacobian_input_output = []

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -8,7 +8,6 @@ from typing_extensions import deprecated
 
 import torch
 import torch.testing
-from torch._vmap_internals import _vmap, vmap
 from torch.overrides import is_tensor_like
 from torch.types import _TensorOrTensors
 
@@ -1099,7 +1098,7 @@ def _test_batched_grad_forward_ad(func, inputs) -> bool:
         expected = [torch.stack(shards) for shards in zip(*expected)]
 
         try:
-            result = _vmap(jvp)(torch.stack(tangents))
+            result = torch.vmap(jvp)(torch.stack(tangents))
         except RuntimeError as ex:
             # Rethrow to provide a better error message
             raise GradcheckError(
@@ -1153,7 +1152,7 @@ def _test_batched_grad(input, output, output_idx) -> bool:
         warnings.filterwarnings("ignore", message="There is a performance drop")
         warnings.filterwarnings("ignore", message="Please use torch.vmap")
         try:
-            result = vmap(vjp)(torch.stack(grad_outputs))
+            result = torch.vmap(vjp)(torch.stack(grad_outputs))
         except RuntimeError as ex:
             # It's OK that we're not raising the error at the correct callsite.
             # That's because the callsite is always going to inside the Python


### PR DESCRIPTION
This was causing warnings for those using gradcheck among other APIs potentially, thanks @EmmettBicker for raising this to our awareness in https://github.com/pytorch/pytorch/pull/143938!

Tests should pass as this should be a functional no-op, and there should be fewer printouts. => I was wrong. Jeffrey is right to be scared of this change. I've opened #144287 instead.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144283

