### PR TITLE
tuned_addmm: fix CK

### DIFF
--- a/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
@@ -816,6 +816,7 @@ class CKGemmTemplate(CKTemplate):
         alpha=1,
         beta=0,
         input_reorder=None,
+        autotune_arg_order=None
     ):
         """
         Add Composable Kernel Universal GEMM instance choices to the auto-tuning list.
@@ -829,10 +830,14 @@ class CKGemmTemplate(CKTemplate):
         )
         ops = template.gen_ops()
         for op in ops:
-            template.maybe_append_choice(
+            # Forward the autotune_arg_order to the choice we just appended
+            e = template.maybe_append_choice(
                 choices,
                 op=op,
             )
+            if e is None:
+                # This means we successfully added a choice
+                choices[-1].autotune_arg_order = autotune_arg_order
 
     def size_args(self):
         X = self.input_nodes[0]

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4373,6 +4373,17 @@ class ChoiceCaller:
         # An additional description used to describe the choice (useful for
         # knowing what autotuning is choosing)
         self.description = description
+        # The order in which arguments are passed through for autotuning.
+        # Note: this is similar, but different from the `input_reorder`
+        # present in some choices. Here, we're just concerned with ordering
+        # the input nodes when benchmarking for autotuning
+        # For example
+        # - some choices expect (X, W, Bias)
+        # - others expect (Bias, X, W)
+        # configuring the choice here with |autotune_arg_order| = (2,0,1)
+        # allows all choices to be called with the same list of parameters,
+        # and the choice to know internally how to pass its own arguments down
+        self.autotune_arg_order = None
 
     def benchmark(self, *args, out) -> float:  # type: ignore[no-untyped-def]
         algo = self.to_callable()

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -567,6 +567,10 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
             [mat1, mat2, inp_expanded],
             alpha=alpha,
             beta=beta,
+            # As you can see below, we pass Bias, X, W for the benchmarking
+            # but configure the kernel with X, W, Bias
+            # indicate this here for the ChoiceCaller
+            autotune_arg_order=(1,2,0)
         )
 
     if use_cpp_gemm_template(layout, mat1, mat2):

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1982,6 +1982,15 @@ class AlgorithmSelectorCache(PersistentCache):
             is_extern = isinstance(choice, ExternKernelCaller)
             benchmark_tensors = autotune_args.get_benchmark_tensors(is_extern)
             inpts, output = benchmark_tensors.unpack()
+            if choice.autotune_arg_order is not None:
+                # reorder the input choices
+                if len(choice.autotune_arg_order) != len(inpts):
+                    # can't really do anything, just report infinity as the choice is invalid
+                    log.error(f"invalid autotune_arg_order for choice {choice.name}, got {choice.autotune_arg_order} but expected {len(inpts)} args. Skipping.")
+                    return float("inf")
+                else:
+                    # reorder the inputs
+                    inpts = [inpts[i] for i in choice.autotune_arg_order]
             output.zero_()
             result = choice.benchmark(*inpts, out=output)
             device_type = next(


### PR DESCRIPTION
Summary:
# Background

The CK backend on addmm seems to fail because during autotuning we pass in (B, X, W) whereas the kernel is expecting (W,X,B) as its arguments.

# What

This change fixes that by passing through the modified ordering *for the choices during autotuning only* as the graph already seems to correctly handle passing the args through in regular invocation

# Why

## at all

without this, addmm is hard to use on the CK backend

## not use `input_reorder`

there is a lot of overloading in the ROCm code (and in general) going on with templates and input_reorder. It's never used, and since it's never used it's partially broken. Particularly all of scaled_mm, addmm, mm, have shared code that at various parts refers to arguments as X, W, B, alpha, beta, scales, etc, and adjusts accordingly.

There is probably a cleaner way to do this that requires a medium size tracing and refactoring but for now, this accomplishes two main things

1. addmm works with the CK backend without crashing
2. we explicitly tell the choices about argument reordering right when we pass in the arguments in different order(s), making it more readable

Test Plan:
added unit test

```
buck2 test mode/dev-nosan-amd-gpu -c fbcode.re_gpu_tests=False fbcode//caffe2/test/inductor:test_ck_backend -- --exact 'caffe2/test/inductor:test_ck_backend - test_addmm (caffe2.test.inductor.test_ck_backend.TestCKBackend)'
```

with the change

```
Buck UI: https://www.internalfb.com/buck2/c293fe0d-2a8b-45ff-b904-3a8a6331fbdd
Test UI: https://www.internalfb.com/intern/testinfra/testrun/6755399687317126
Network: Up: 0B  Down: 10MiB  (reSessionID-bbfca263-51ca-4cf6-8629-fe01f77f2e0a)
Analyzing targets. Remaining      0/66491
Executing actions. Remaining      0/426985                                                                                                     3.9s exec time total
Command: test.     Finished 1 local, 1 cache (50% hit)                                                                                         3.7s exec time cached (95%)
Time elapsed: 39.8s
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0
```

without the change

```
Memory access fault by GPU node-2 (Agent handle: 0x7f1c8e140e00) on address 0x7edbfcb00000. Reason: Unknown.
GPU core dump failed

Test was never completed. The test process might have crashed.
Buck UI: https://www.internalfb.com/buck2/2c739b18-a5ea-4f42-b5ef-f5244e707d5c
Test UI: https://www.internalfb.com/intern/testinfra/testrun/2533275055276985
Network: Up: 7.5KiB  Down: 3.6KiB  (reSessionID-a1a6f21e-63b6-40dc-84c9-3699640b626e)
Analyzing targets. Remaining      0/66491
Executing actions. Remaining      0/426985                                                                                                     0.5s exec time total
Command: test.     Finished 2 local
Time elapsed: 40.9s
Tests finished: Pass 0. Fail 1. Fatal 0. Skip 0. Build failure 0
```

Differential Revision: D67882293




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @BoyuanFeng