### PR TITLE
Fix lint in `test_provenance_tracing.py`

### DIFF
--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -84,9 +84,8 @@ class TestProvenanceTracingArtifact(TestCase):
                             optimized = AOTIRunnerUtil.load("cuda", so_path)
                             optimized(*example_inputs)
                         else:
-                            compiled = torch.compile(gm, backend=backend)(
-                                *example_inputs
-                            )
+                            compiled = torch.compile(gm, backend=backend)
+                            compiled(*example_inputs)
                     self.assertEqual(len(cm.output), 1)
                     m = re.match(r"WARNING.* debug trace: (.*)", cm.output[0])
                     self.assertTrue(m)


### PR DESCRIPTION
Regression introduced by https://github.com/pytorch/pytorch/pull/143684/ that somehow did not surface on PR CI

IMO this also makes two branches of the test(compile vs aoti) more readable

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov