### PR TITLE
[mps/inductor] Add support for sign().

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -74,8 +74,11 @@ class MPSBasicTests(TestCase):
     def test_atanh(self):
         self.common(lambda x: x.atanh(), (torch.rand(1024),))
 
-    def floor(self):
+    def test_floor(self):
         self.common(lambda x: x.floor(), (torch.rand(1024),))
+
+    def test_sign(self):
+        self.common(lambda x: x.sign(), (torch.rand(1024),))
 
     def test_sliced_input(self):
         self.common(

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -194,6 +194,10 @@ class MetalOverrides(OpOverrides):
     def floor(x: CSEVariable) -> str:
         return f"metal::floor({x})"
 
+    @staticmethod
+    def sign(x: CSEVariable) -> str:
+        return f"metal::sign({x})"
+
 
 class MetalKernel(SIMDKernel):
     overrides = MetalOverrides  # type: ignore[assignment]


### PR DESCRIPTION
Drive-by fix of a test name while I was at it.

cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov