### PR TITLE
[RFC] Fix CudaEventCache for dangling references

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -438,6 +438,29 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         with self.assertRaises(ValueError):
             dist.all_reduce(t1)
 
+    @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_cuda_event_cache(self):
+        import threading
+
+        # initiate collectives here
+        def init_collective_task(t):
+            dist.all_reduce(t)
+            dist.all_reduce(t)
+            dist.all_reduce(t)
+
+        os.environ["TORCH_NCCL_CUDA_EVENT_CACHE"] = "1"
+        store = c10d.FileStore(self.file_name, self.world_size)
+        self._create_process_group_nccl(store, self.opts())
+        device = self.rank_to_GPU[self.rank][0]
+
+        t = torch.rand(10, 10, device=device)
+        # First allreduce to initialize state.
+        side_thread = threading.Thread(target=init_collective_task, args=(t,))
+        side_thread.start()
+        side_thread.join()
+        torch.cuda.synchronize()
+
     CUDA_12_AND_ABOVE = torch.cuda.is_available() and (
         torch.version.cuda is not None and int(torch.version.cuda.split(".")[0]) >= 12
     )

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -456,6 +456,9 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 
         t = torch.rand(10, 10, device=device)
         # First allreduce to initialize state.
+        dist.all_reduce(t)
+        dist.all_reduce(t)
+        dist.all_reduce(t)
         side_thread = threading.Thread(target=init_collective_task, args=(t,))
         side_thread.start()
         side_thread.join()

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -440,7 +440,10 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_cuda_event_cache(self):
+    def test_cuda_event_cache_mthd_race(self):
+        # This unit test is to test the case when the collective is launched in
+        # a side thread and the thread dies before the cache has been fully recycled.
+        # More details can be found in this issue: https://github.com/pytorch/pytorch/issues/143470.
         import threading
 
         # initiate collectives here

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -807,12 +807,12 @@ std::shared_ptr<at::cuda::CUDAEvent> ProcessGroupNCCL::CUDAEventCache::create(
     bool timing) {
   // register the deleter as a callback when the WorkNCCL object is destroyed.
   auto deleter = [lockPtr = this->cacheMutexPtr_,
-                  eventPtr = this->eventsArrayPtr_,
+                  eventsArrayPtr = this->eventsArrayPtr_,
                   timing](at::cuda::CUDAEvent* event) {
     std::lock_guard<std::mutex> lock(*lockPtr);
     // We put the event back to the cache deque once the WorkNCCL object is
     // destroyed.
-    (*eventPtr)[timing ? 1 : 0].push_back(event);
+    (*eventsArrayPtr)[timing ? 1 : 0].push_back(event);
   };
   at::cuda::CUDAEvent* event = nullptr;
   {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -462,12 +462,12 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     static CUDAEventCache& get(at::DeviceIndex device);
 
    private:
-    std::mutex cacheMutex_;
+    std::shared_ptr<std::mutex> cacheMutexPtr_;
     // NOTE: We intentionally store raw pointers so that
     // we do not attempt to destroy the event objects on process exit,
     // because cuda may be gone.
-    std::array<std::deque<at::cuda::CUDAEvent*>, 2>
-        eventsArray_; // 0 for timing=false, 1 for timing=true
+    std::shared_ptr<std::array<std::deque<at::cuda::CUDAEvent*>, 2>>
+        eventsArrayPtr_; // 0 for timing=false, 1 for timing=true
   };
 
   struct Options : Backend::Options {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -462,12 +462,14 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     static CUDAEventCache& get(at::DeviceIndex device);
 
    private:
-    std::shared_ptr<std::mutex> cacheMutexPtr_;
+    std::shared_ptr<std::mutex> cacheMutexPtr_ = std::make_shared<std::mutex>();
     // NOTE: We intentionally store raw pointers so that
     // we do not attempt to destroy the event objects on process exit,
     // because cuda may be gone.
     std::shared_ptr<std::array<std::deque<at::cuda::CUDAEvent*>, 2>>
-        eventsArrayPtr_; // 0 for timing=false, 1 for timing=true
+        eventsArrayPtr_ = std::make_shared<std::array<
+            std::deque<at::cuda::CUDAEvent*>,
+            2>>(); // 0 for timing=false, 1 for timing=true
   };
 
   struct Options : Backend::Options {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144301

Reported in https://github.com/pytorch/pytorch/issues/143470, we have a dangling references in CudaEventCache. So we want to fix it.
1. We add a unit test to repro the issue mentioned in the issue.
2. We tried to convert variables to shared pointers as suggested by @suo in the issue.


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @wz337 @wconstab @d4l3k @c-p-i-o