### PR TITLE
[PrivateUse1] Support parseDispatchKey with modified PrivateUse1

### DIFF
--- a/c10/core/DispatchKey.cpp
+++ b/c10/core/DispatchKey.cpp
@@ -384,6 +384,12 @@ c10::DispatchKey parseDispatchKey(const std::string& k) {
        c10::DispatchKey::FuncTorchBatchedDecomposition},
   };
   auto it = key_map.find(k);
+  if (it == key_map.end() && c10::get_privateuse1_backend() != "PrivateUse1") {
+    std::string pu1_backend_name = c10::get_privateuse1_backend();
+    std::transform(pu1_backend_name.begin(), pu1_backend_name.end(), pu1_backend_name.begin(), ::toupper);
+    std::string processed_k = std::regex_replace(k, std::regex(pu1_backend_name), "PrivateUse1");
+    it = key_map.find(processed_k);
+  }
   TORCH_CHECK(it != key_map.end(), "could not parse dispatch key: ", k);
   return it->second;
 }

--- a/c10/core/DispatchKey.cpp
+++ b/c10/core/DispatchKey.cpp
@@ -387,8 +387,13 @@ c10::DispatchKey parseDispatchKey(const std::string& k) {
   auto it = key_map.find(k);
   if (it == key_map.end() && c10::get_privateuse1_backend() != "PrivateUse1") {
     std::string pu1_backend_name = c10::get_privateuse1_backend();
-    std::transform(pu1_backend_name.begin(), pu1_backend_name.end(), pu1_backend_name.begin(), ::toupper);
-    std::string processed_k = std::regex_replace(k, std::regex(pu1_backend_name), "PrivateUse1");
+    std::transform(
+        pu1_backend_name.begin(),
+        pu1_backend_name.end(),
+        pu1_backend_name.begin(),
+        ::toupper);
+    std::string processed_k =
+        std::regex_replace(k, std::regex(pu1_backend_name), "PrivateUse1");
     it = key_map.find(processed_k);
   }
   TORCH_CHECK(it != key_map.end(), "could not parse dispatch key: ", k);

--- a/c10/core/DispatchKey.cpp
+++ b/c10/core/DispatchKey.cpp
@@ -1,6 +1,7 @@
 #include <c10/core/DispatchKey.h>
 #include <c10/core/DispatchKeySet.h>
 
+#include <regex>
 #include <unordered_map>
 
 namespace c10 {


### PR DESCRIPTION
PyTorch now support many private1 backend names like `AutogradPrivateUse1` or `QuantizedPrivateUse1`, not mentioned the original `PrivateUse1` backend.

However, users that implement `PrivateUse1` funtionalities would modified the backend name by calling  `torch.utils.rename_privateuse1_backend("my_backend")`, in that case, all `PrivateUse1` backend string would not be found when we call other functions related to it. For example, we utilize `torch.library` to register some customize functions to our new backend, we would use "my_backend" as the backend name instead of "PrivateUse1", in which the error will be throw:
```
could not parse dispatch key 'my_backend'
```

So, this PR changed the function `c10::DispatchKey parseDispatchKey(const std::string& k)`, it would double check if the `PrivateUse1` has been modified, and if so, we would change `k` to adapt new backend name then find it again.



cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens