### PR TITLE
[3.13t] use sysconfig to check for Python nogil builds

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2491,11 +2491,15 @@ def compile(
             return torch.sin(x) + torch.cos(x)
 
     """
+    import sysconfig
+
     _C._log_api_usage_once("torch.compile")
     if sys.version_info >= (3, 14):
-        raise RuntimeError("Dynamo is not supported on Python 3.14+")
-    elif sys.version_info >= (3, 13) and not sys._is_gil_enabled():
-        raise RuntimeError("Dynamo is not supported on Python with GIL disabled")
+        raise RuntimeError("torch.compile is not supported on Python 3.14+")
+    elif sysconfig.get_config_var("Py_GIL_DISABLED") == 1:
+        raise RuntimeError(
+            "torch.compile is not supported on Python built with GIL disabled"
+        )
 
     # Decorator mode
     if model is None:

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -17,6 +17,7 @@ import inspect
 import logging
 import os
 import sys
+import sysconfig
 import textwrap
 import threading
 import traceback
@@ -813,8 +814,10 @@ class _NullDecorator(contextlib.nullcontext):  # type: ignore[type-arg]
 def check_if_dynamo_supported():
     if sys.version_info >= (3, 14):
         raise RuntimeError("Python 3.14+ not yet supported for torch.compile")
-    elif sys.version_info >= (3, 13) and not sys._is_gil_enabled():
-        raise RuntimeError("Dynamo is not supported on Python with GIL disabled")
+    elif sysconfig.get_config_var("Py_GIL_DISABLED") == 1:
+        raise RuntimeError(
+            "torch.compile is not supported on Python built with GIL disabled"
+        )
 
 
 def is_dynamo_supported():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144361

`sys._is_gil_enabled()` wasn't working in certain cases, according to @atalman

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames