### PR TITLE
[Intel GPU] fix memory leak in deconv backward

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
@@ -303,7 +303,8 @@ sycl::event deconvolution_backward_data(
           _dilation,
           _padding,
           _padding,
-          deconv_fwd_pd);
+          deconv_fwd_pd,
+          pattr);
 
   // create memory
   dnnl::memory diff_dst_m, wei_m, diff_src_m;


### PR DESCRIPTION
Fixes #143807

We need manage onednn scratchpad in pytorch, otherwise onednn will always allocate scratchpad memory during primitive execution and causes memory leak.


cc @gujinghui @EikanWang @fengyuan14 @guangyey @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10