### PR TITLE
Adapt Dynamo tests to HPUs using instantiate_device_type_tests

### DIFF
--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -10,7 +10,6 @@ from torch._dynamo import debug_utils
 from torch._dynamo.debug_utils import aot_graph_input_parser, generate_env_vars_string
 from torch._dynamo.test_case import TestCase
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import TEST_HPU
 from torch.testing._internal.inductor_utils import HAS_CUDA
 
 

--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -10,7 +10,8 @@ from torch._dynamo import debug_utils
 from torch._dynamo.debug_utils import aot_graph_input_parser, generate_env_vars_string
 from torch._dynamo.test_case import TestCase
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import HAS_CUDA, TEST_HPU
+from torch.testing._internal.common_utils import TEST_HPU
+from torch.testing._internal.inductor_utils import HAS_CUDA
 
 
 requires_cuda = unittest.skipUnless(HAS_CUDA, "requires cuda")

--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -196,9 +196,7 @@ class TestDebugUtilsDevice(TestCase):
 
 instantiate_device_type_tests(TestDebugUtils, globals())
 
-devices = ["cuda"]
-if TEST_HPU:
-    devices.append("hpu")
+devices = ["cuda", "hpu"]
 instantiate_device_type_tests(TestDebugUtilsDevice, globals(), only_for=devices)
 
 if __name__ == "__main__":

--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -9,7 +9,8 @@ from functorch import make_fx
 from torch._dynamo import debug_utils
 from torch._dynamo.debug_utils import aot_graph_input_parser, generate_env_vars_string
 from torch._dynamo.test_case import TestCase
-from torch.testing._internal.inductor_utils import HAS_CUDA
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HAS_CUDA, TEST_HPU
 
 
 requires_cuda = unittest.skipUnless(HAS_CUDA, "requires cuda")
@@ -62,10 +63,28 @@ def forward(self, x_1):
     """,  # NOQA: B950
         )
 
-    @requires_cuda
-    def test_aot_graph_parser(self):
-        from torch import device
+    @patch.dict(os.environ, {"TORCHINDUCTOR_MAX_AUTOTUNE": "1", "TEST_ENV": "1"})
+    def test_generate_env_vars_string(self):
+        env_strings = generate_env_vars_string()
+        self.assertIn(
+            """os.environ['TORCHINDUCTOR_MAX_AUTOTUNE'] = '1'
+""",
+            env_strings,
+        )
+        self.assertIn(
+            """import os
+""",
+            env_strings,
+        )
+        self.assertNotIn(
+            """TEST_ENV
+""",
+            env_strings,
+        )
 
+
+class TestDebugUtilsDevice(TestCase):
+    def test_aot_graph_parser(self, device):
         def forward(
             self,
             primals_1: "f32[1001, 6]",
@@ -114,7 +133,7 @@ def forward(self, x_1):
                 1,
                 dtype=torch.int32,
                 layout=torch.strided,
-                device=device(type="cuda", index=0),
+                device=device,
                 pin_memory=False,
             )
 
@@ -123,7 +142,7 @@ def forward(self, x_1):
                 start=0,
                 step=1,
                 dtype=torch.int32,
-                device=device(type="cuda"),
+                device=device,
                 requires_grad=False,
             )
 
@@ -135,7 +154,7 @@ def forward(self, x_1):
                 start=0,
                 step=1001,
                 dtype=torch.int32,
-                device=device(type="cuda", index=0),
+                device=device,
                 requires_grad=False,
             )
             view: "i32[6150144]" = torch.ops.aten.reshape.default(mul, [-1])
@@ -148,12 +167,11 @@ def forward(self, x_1):
 
             return _embedding_bag
 
-        kwargs = aot_graph_input_parser(forward, device="cuda")
+        kwargs = aot_graph_input_parser(forward, device=device)
         # runs successfully
         forward(**kwargs)
 
-    @requires_cuda
-    def test_sym_aot_graph_parser(self):
+    def test_sym_aot_graph_parser(self, device):
         def forward(
             self,
             primals_1: "f32[1001, 6]",  # noqa: F821
@@ -165,7 +183,7 @@ def forward(self, x_1):
             _tensor_constant0: "i64[4190]" = self._tensor_constant0
 
         kwargs = aot_graph_input_parser(
-            forward, device="cuda", sym_shapes={"s0": 10}, default_sym_shape=5
+            forward, device=device, sym_shapes={"s0": 10}, default_sym_shape=5
         )
 
         self.assertEqual(list(kwargs["primals_2"].shape), [10])
@@ -174,25 +192,13 @@ def forward(self, x_1):
         self.assertEqual(list(kwargs["primals_4"].shape), [5])
         self.assertEqual(kwargs["primals_5"], 5)
 
-    @patch.dict(os.environ, {"TORCHINDUCTOR_MAX_AUTOTUNE": "1", "TEST_ENV": "1"})
-    def test_generate_env_vars_string(self):
-        env_strings = generate_env_vars_string()
-        self.assertIn(
-            """os.environ['TORCHINDUCTOR_MAX_AUTOTUNE'] = '1'
-""",
-            env_strings,
-        )
-        self.assertIn(
-            """import os
-""",
-            env_strings,
-        )
-        self.assertNotIn(
-            """TEST_ENV
-""",
-            env_strings,
-        )
 
+instantiate_device_type_tests(TestDebugUtils, globals())
+
+devices = ["cuda"]
+if TEST_HPU:
+    devices.append("hpu")
+instantiate_device_type_tests(TestDebugUtilsDevice, globals(), only_for=devices)
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -6412,7 +6412,6 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
         f(torch.ones(2, device=device, dtype=torch.float64))
 
     @requires_cuda
-    @skipIfHpu
     def test_norm_dtype(self, device):
         def foo(_stack0):
             getitem = _stack0[(slice(None, None, None), -1)]
@@ -6532,7 +6531,6 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
         self.assertEqual(out1, out2)
 
     @requires_cuda
-    @skipIfHpu
     def test_memleak_when_graph_input_has_tensor_attr(self, device):
         @torch.compile(backend="eager")
         def f(x):
@@ -6540,8 +6538,8 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
 
         mem_before = torch.cuda.memory_allocated()
 
-        x = torch.ones(2, device="cuda")
-        x.foo = torch.zeros(2, device="cuda")
+        x = torch.ones(2, device=device)
+        x.foo = torch.zeros(2, device=device)
         f(x)
         del x.foo
         del x
@@ -6554,8 +6552,8 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
             x.add_(1)
 
         mem_before = torch.cuda.memory_allocated()
-        x = torch.ones(2, device="cuda")
-        x.foo = [torch.zeros(2, device="cuda") for _ in range(5)]
+        x = torch.ones(2, device=device)
+        x.foo = [torch.zeros(2, device=device) for _ in range(5)]
         f(x)
         del x.foo
         del x
@@ -6568,8 +6566,8 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
             return x + y
 
         mem_before = torch.cuda.memory_allocated()
-        x = torch.ones(2, device="cuda")
-        y = torch.zeros(2, device="cuda")
+        x = torch.ones(2, device=device)
+        y = torch.zeros(2, device=device)
         x.foo = [y]
         y.foo = [x]
         g(x, y)
@@ -6581,7 +6579,6 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
         self.assertEqual(mem_before, mem_after)
 
     @requires_cuda
-    @skipIfHpu
     def test_sdpa_dynamic_shapes(self, device):
         def f(x, s0, s1, s2):
             q = x.view(2, s0, s2, s0)

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -54,7 +54,6 @@ from torch.testing._internal.common_utils import (
     parametrize,
     skipIfHpu,
     skipIfWindows,
-    TEST_HPU,
     TEST_WITH_ROCM,
 )
 from torch.testing._internal.two_tensor import TwoTensor
@@ -6606,9 +6605,7 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
 
 instantiate_parametrized_tests(ReproTests)
 
-devices = ["cuda"]
-if TEST_HPU:
-    devices.append("hpu")
+devices = ["cuda", "hpu"]
 instantiate_device_type_tests(ReproTestsDevice, globals(), only_for=devices)
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -47,11 +47,14 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     TEST_CUDA,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     disable_translation_validation_if_dynamic_shapes,
     instantiate_parametrized_tests,
     parametrize,
+    skipIfHpu,
     skipIfWindows,
+    TEST_HPU,
     TEST_WITH_ROCM,
 )
 from torch.testing._internal.two_tensor import TwoTensor
@@ -1061,14 +1064,6 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         opt_model = torch.compile(model, backend=cnt, fullgraph=nopython)
         self.assertTrue(same(opt_model(input), correct))
         return cnt
-
-    @requires_cuda
-    def test_sub_alpha_scalar_repro(self):
-        @torch.compile(backend="aot_eager")
-        def f(x):
-            return x.sub(1, alpha=2)
-
-        f(torch.ones(2, device="cuda", dtype=torch.float64))
 
     # https://github.com/pytorch/pytorch/issues/113010
     def test_out_overload_non_contiguous(self):
@@ -2764,29 +2759,6 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(same(f(), opt_fn()))
         self.assertEqual(cnt.frame_count, 1)
 
-    @requires_cuda
-    def test_norm_dtype(self):
-        def foo(_stack0):
-            getitem = _stack0[(slice(None, None, None), -1)]
-            _stack0 = None
-            normalize = torch.nn.functional.normalize(getitem, p=2, dim=1)
-            getitem = None
-            return (normalize,)
-
-        args = [((2, 50, 256), (1, 256, 1), torch.float16, "cuda", False)]
-        args = [
-            rand_strided(sh, st, dt, dev).requires_grad_(rg)
-            for (sh, st, dt, dev, rg) in args
-        ]
-
-        torch.compile(foo, backend="aot_eager_decomp_partition")
-        with torch.cuda.amp.autocast(enabled=True):
-            ref = foo(*args)[0]
-            res = foo(*args)[0]
-            self.assertEqual(ref.dtype, res.dtype)
-
-            self.assertTrue(same(res, ref))
-
     def test_for_loop_graph_break(self):
         def inner(x):
             return torch.sin(x)
@@ -4390,53 +4362,6 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         TEST_WITH_ROCM or not PLATFORM_SUPPORTS_FLASH_ATTENTION,
         "flash attention not supported",
     )
-    def test_flash_attn_backward_mixed_strides(self):
-        # in this repro, "grad_out" and "value" are transposed tensors,
-        # but "key" and "value" are contiguous
-        def gen_inputs(device):
-            return (
-                torch.randn(
-                    2, 513, 16, 64, dtype=torch.float16, device=device
-                ).transpose(1, 2),
-                torch.randn(2, 16, 513, 64, dtype=torch.float16, device=device),
-                torch.randn(2, 16, 513, 64, dtype=torch.float16, device=device),
-                torch.randn(
-                    2, 513, 16, 64, dtype=torch.float16, device=device
-                ).transpose(1, 2),
-                torch.randn(2, 16, 513, 64, dtype=torch.float16, device=device),
-                torch.randn(2, 16, 513, device=device),
-                None,
-                None,
-                513,
-                513,
-                0.0,
-                False,
-                torch.tensor(1, dtype=torch.int64),
-                torch.tensor(1, dtype=torch.int64),
-            )
-
-        inps_cuda = gen_inputs("cuda")
-        inps_meta = gen_inputs("meta")
-        (
-            out1_ref,
-            out2_ref,
-            out3_ref,
-        ) = torch.ops.aten._scaled_dot_product_flash_attention_backward(
-            *inps_cuda, scale=0.125
-        )
-        from torch._meta_registrations import meta__scaled_dot_product_flash_backward
-
-        out1_test, out2_test, out3_test = meta__scaled_dot_product_flash_backward(
-            *inps_meta, scale=0.125
-        )
-
-        self.assertEqual(out1_ref.shape, out1_test.shape)
-        self.assertEqual(out1_ref.stride(), out1_test.stride())
-        self.assertEqual(out2_ref.shape, out2_test.shape)
-        self.assertEqual(out2_ref.stride(), out2_test.stride())
-        self.assertEqual(out3_ref.shape, out3_test.shape)
-        self.assertEqual(out3_ref.stride(), out3_test.stride())
-
     def test_user_ctor_ctx_manager(self):
         class UserCtxManager:
             def __enter__(self):
@@ -4689,27 +4614,6 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             pass
         else:
             self.fail("expected exception")
-
-    def test_megablocks_moe(self):
-        try:
-            from megablocks.layers import moe
-            from megablocks.layers.arguments import Arguments
-        except ImportError as e:
-            raise unittest.SkipTest("requires megablocks") from e
-        bs, sl, hs, num_experts, top_k = (16, 1024, 512, 1, 1)
-        args = Arguments(
-            hidden_size=hs,
-            ffn_hidden_size=hs * 2,
-            moe_num_experts=num_experts,
-            moe_capacity_factor=1,
-            moe_top_k=top_k,
-        )
-        moe_mlp = moe.MoE(args)
-        moe_mlp.cuda(torch.cuda.current_device()).half()
-        x = torch.randn(sl, bs, hs).cuda().half()
-        out1, _ = moe_mlp(x)
-        out2, _ = torch.compile(moe_mlp, backend="eager")(x)
-        self.assertEqual(out1, out2)
 
     def test_udf_classes_reconstruction(self):
         def fn(x):
@@ -5837,54 +5741,6 @@ def forward(self, s0 : torch.SymInt, s1 : torch.SymInt, L_x_ : torch.Tensor):
         mod.eval()
         self.assertFalse(opt_mod.training)
 
-    @requires_cuda
-    def test_memleak_when_graph_input_has_tensor_attr(self):
-        @torch.compile(backend="eager")
-        def f(x):
-            x.add_(1)
-
-        mem_before = torch.cuda.memory_allocated()
-
-        x = torch.ones(2, device="cuda")
-        x.foo = torch.zeros(2, device="cuda")
-        f(x)
-        del x.foo
-        del x
-        mem_after = torch.cuda.memory_allocated()
-        self.assertEqual(mem_before, mem_after)
-
-        # check when non-tensor data structure attribute contains a tensor
-        @torch.compile(backend="eager")
-        def f(x):
-            x.add_(1)
-
-        mem_before = torch.cuda.memory_allocated()
-        x = torch.ones(2, device="cuda")
-        x.foo = [torch.zeros(2, device="cuda") for _ in range(5)]
-        f(x)
-        del x.foo
-        del x
-        mem_after = torch.cuda.memory_allocated()
-        self.assertEqual(mem_before, mem_after)
-
-        # check with tensor refcycle
-        @torch.compile(backend="eager")
-        def g(x, y):
-            return x + y
-
-        mem_before = torch.cuda.memory_allocated()
-        x = torch.ones(2, device="cuda")
-        y = torch.zeros(2, device="cuda")
-        x.foo = [y]
-        y.foo = [x]
-        g(x, y)
-        del x.foo
-        del y.foo
-        del x
-        del y
-        mem_after = torch.cuda.memory_allocated()
-        self.assertEqual(mem_before, mem_after)
-
     def test_os_fspath(self):
         @torch.compile(backend="eager", fullgraph=True)
         def fn(x):
@@ -6370,27 +6226,6 @@ def forward(self, s0 : torch.SymInt, s1 : torch.SymInt, L_x_ : torch.Tensor):
         inp = torch.randn(3, 3)
         self.assertEqual(fn(inp), opt_fn(inp))
 
-    @requires_cuda
-    def test_sdpa_dynamic_shapes(self):
-        def f(x, s0, s1, s2):
-            q = x.view(2, s0, s2, s0)
-            return torch._C._nn.scaled_dot_product_attention(
-                q, q, q, attn_mask=None, dropout_p=0.0, is_causal=True
-            )
-
-        x = torch.randn(2, 32, 4096, dtype=torch.bfloat16, device="cuda")
-        x_ref = x.clone().detach().requires_grad_()
-        s0 = 32
-        s1 = 64
-        s2 = 128
-
-        f_compiled = torch.compile(f, dynamic=True)
-
-        with torch._dynamo.config.patch(assume_static_by_default=False):
-            out_ref = f(x_ref, s0, s1, s2)
-            out = f_compiled(x, s0, s1, s2)
-            self.assertEqual(out_ref, out)
-
     def test_bitwise_op_guard(self):
         # attempt evaluating a guard with BitwiseFn_bitwise_[and/or]
         def fn(x):
@@ -6573,9 +6408,208 @@ def forward(self, s0 : torch.SymInt, s1 : torch.SymInt, L_x_ : torch.Tensor):
             self.assertEqual(actual, expected)
 
 
+class ReproTestsDevice(torch._dynamo.test_case.TestCase):
+    def test_sub_alpha_scalar_repro(self, device):
+        @torch.compile(backend="aot_eager")
+        def f(x):
+            return x.sub(1, alpha=2)
+
+        f(torch.ones(2, device=device, dtype=torch.float64))
+
+    @requires_cuda
+    @skipIfHpu
+    def test_norm_dtype(self, device):
+        def foo(_stack0):
+            getitem = _stack0[(slice(None, None, None), -1)]
+            _stack0 = None
+            normalize = torch.nn.functional.normalize(getitem, p=2, dim=1)
+            getitem = None
+            return (normalize,)
+
+        args = [((2, 50, 256), (1, 256, 1), torch.float16, device, False)]
+        args = [
+            rand_strided(sh, st, dt, dev).requires_grad_(rg)
+            for (sh, st, dt, dev, rg) in args
+        ]
+
+        torch.compile(foo, backend="aot_eager_decomp_partition")
+        with torch.cuda.amp.autocast(enabled=True):
+            ref = foo(*args)[0]
+            res = foo(*args)[0]
+            self.assertEqual(ref.dtype, res.dtype)
+
+            self.assertTrue(same(res, ref))
+
+    def test_guard_default_device(self, device):
+        try:
+            torch.set_default_device(device)
+
+            counter = torch._dynamo.testing.CompileCounter()
+
+            @torch._dynamo.optimize(counter)
+            def f():
+                x = torch.randn(3)
+                return x * 2
+
+            self.assertEqual(f().device.type + ":0", device)
+            self.assertEqual(counter.frame_count, 1)
+
+            torch.set_default_device("cpu")
+
+            self.assertEqual(f().device.type, "cpu")
+            self.assertEqual(counter.frame_count, 2)
+
+        finally:
+            torch.set_default_device(None)
+
+    @skipIfHpu
+    def test_flash_attn_backward_mixed_strides(self, device):
+        # in this repro, "grad_out" and "value" are transposed tensors,
+        # but "key" and "value" are contiguous
+        def gen_inputs(device):
+            return (
+                torch.randn(
+                    2, 513, 16, 64, dtype=torch.float16, device=device
+                ).transpose(1, 2),
+                torch.randn(2, 16, 513, 64, dtype=torch.float16, device=device),
+                torch.randn(2, 16, 513, 64, dtype=torch.float16, device=device),
+                torch.randn(
+                    2, 513, 16, 64, dtype=torch.float16, device=device
+                ).transpose(1, 2),
+                torch.randn(2, 16, 513, 64, dtype=torch.float16, device=device),
+                torch.randn(2, 16, 513, device=device),
+                None,
+                None,
+                513,
+                513,
+                0.0,
+                False,
+                torch.tensor(1, dtype=torch.int64),
+                torch.tensor(1, dtype=torch.int64),
+            )
+
+        inps_device = gen_inputs(device)
+        inps_meta = gen_inputs("meta")
+        (
+            out1_ref,
+            out2_ref,
+            out3_ref,
+        ) = torch.ops.aten._scaled_dot_product_flash_attention_backward(
+            *inps_device, scale=0.125
+        )
+        from torch._meta_registrations import meta__scaled_dot_product_flash_backward
+
+        out1_test, out2_test, out3_test = meta__scaled_dot_product_flash_backward(
+            *inps_meta, scale=0.125
+        )
+
+        self.assertEqual(out1_ref.shape, out1_test.shape)
+        self.assertEqual(out1_ref.stride(), out1_test.stride())
+        self.assertEqual(out2_ref.shape, out2_test.shape)
+        self.assertEqual(out2_ref.stride(), out2_test.stride())
+        self.assertEqual(out3_ref.shape, out3_test.shape)
+        self.assertEqual(out3_ref.stride(), out3_test.stride())
+
+    def test_megablocks_moe(self, device):
+        try:
+            from megablocks.layers import moe
+            from megablocks.layers.arguments import Arguments
+        except ImportError as e:
+            raise unittest.SkipTest("requires megablocks") from e
+        bs, sl, hs, num_experts, top_k = (16, 1024, 512, 1, 1)
+        args = Arguments(
+            hidden_size=hs,
+            ffn_hidden_size=hs * 2,
+            moe_num_experts=num_experts,
+            moe_capacity_factor=1,
+            moe_top_k=top_k,
+        )
+        moe_mlp = moe.MoE(args)
+        # moe_mlp.cuda(torch.cuda.current_device()).half()
+        moe_mlp.device(torch.device.current_device()).half()
+        x = torch.randn(sl, bs, hs).device().half()
+        out1, _ = moe_mlp(x)
+        out2, _ = torch.compile(moe_mlp, backend="eager")(x)
+        self.assertEqual(out1, out2)
+
+    @requires_cuda
+    @skipIfHpu
+    def test_memleak_when_graph_input_has_tensor_attr(self, device):
+        @torch.compile(backend="eager")
+        def f(x):
+            x.add_(1)
+
+        mem_before = torch.cuda.memory_allocated()
+
+        x = torch.ones(2, device="cuda")
+        x.foo = torch.zeros(2, device="cuda")
+        f(x)
+        del x.foo
+        del x
+        mem_after = torch.cuda.memory_allocated()
+        self.assertEqual(mem_before, mem_after)
+
+        # check when non-tensor data structure attribute contains a tensor
+        @torch.compile(backend="eager")
+        def f(x):
+            x.add_(1)
+
+        mem_before = torch.cuda.memory_allocated()
+        x = torch.ones(2, device="cuda")
+        x.foo = [torch.zeros(2, device="cuda") for _ in range(5)]
+        f(x)
+        del x.foo
+        del x
+        mem_after = torch.cuda.memory_allocated()
+        self.assertEqual(mem_before, mem_after)
+
+        # check with tensor refcycle
+        @torch.compile(backend="eager")
+        def g(x, y):
+            return x + y
+
+        mem_before = torch.cuda.memory_allocated()
+        x = torch.ones(2, device="cuda")
+        y = torch.zeros(2, device="cuda")
+        x.foo = [y]
+        y.foo = [x]
+        g(x, y)
+        del x.foo
+        del y.foo
+        del x
+        del y
+        mem_after = torch.cuda.memory_allocated()
+        self.assertEqual(mem_before, mem_after)
+
+    @requires_cuda
+    @skipIfHpu
+    def test_sdpa_dynamic_shapes(self, device):
+        def f(x, s0, s1, s2):
+            q = x.view(2, s0, s2, s0)
+            return torch._C._nn.scaled_dot_product_attention(
+                q, q, q, attn_mask=None, dropout_p=0.0, is_causal=True
+            )
+
+        x = torch.randn(2, 32, 4096, dtype=torch.bfloat16, device=device)
+        x_ref = x.clone().detach().requires_grad_()
+        s0 = 32
+        s1 = 64
+        s2 = 128
+
+        f_compiled = torch.compile(f, dynamic=True)
+
+        with torch._dynamo.config.patch(assume_static_by_default=False):
+            out_ref = f(x_ref, s0, s1, s2)
+            out = f_compiled(x, s0, s1, s2)
+            self.assertEqual(out_ref, out)
+
+
 instantiate_parametrized_tests(ReproTests)
 
-
+devices = ["cuda"]
+if TEST_HPU:
+    devices.append("hpu")
+instantiate_device_type_tests(ReproTestsDevice, globals(), only_for=devices)
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -4357,10 +4357,6 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         # frame_count should stay at 1.
         self.assertEqual(cnt.frame_count, 1)
 
-    @unittest.skipIf(
-        TEST_WITH_ROCM or not PLATFORM_SUPPORTS_FLASH_ATTENTION,
-        "flash attention not supported",
-    )
     def test_user_ctor_ctx_manager(self):
         class UserCtxManager:
             def __enter__(self):
@@ -6462,6 +6458,10 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
             torch.set_default_device(None)
 
     @skipIfHpu
+    @unittest.skipIf(
+        TEST_WITH_ROCM or not PLATFORM_SUPPORTS_FLASH_ATTENTION,
+        "flash attention not supported",
+    )
     def test_flash_attn_backward_mixed_strides(self, device):
         # in this repro, "grad_out" and "value" are transposed tensors,
         # but "key" and "value" are contiguous

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -11,7 +11,8 @@ import torch._dynamo.testing
 import torch.nn.functional as F
 from torch._dynamo.comptime import comptime
 from torch._dynamo.testing import CompileCounter, CompileCounterWithBackend, same
-from torch.testing._internal.common_utils import skipIfWindows
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import skipIfWindows, TEST_HPU
 from torch.testing._internal.logging_utils import logs_to_string
 
 
@@ -314,22 +315,6 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(cnt.frame_count, 1)
         self.assertEqual(cnt.op_count, 1)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_builtin_functions_on_cuda(self):
-        def fn(x, scaler):
-            m = torch.nn.ReLU()
-            y = m(x) * scaler
-            return y
-
-        x = torch.randn([3, 6], device="cuda")
-        scaler = 0.23  # 0.23 is unspecialized
-        ref = fn(x, scaler)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts)
-        res = opt_fn(x, scaler)
-        self.assertTrue(same(ref, res))
-        self.assertEqual(ref.device, res.device)
 
     def test_unspec_float_precision(self):
         def fn(image, scale_factor):
@@ -842,6 +827,29 @@ def forward(self):
         o1_2 = opt_model(x2, 2)
         self.assertEqual(o1_2_ref, o1_2)
 
+
+class UnspecTestsDevice(torch._dynamo.test_case.TestCase):
+    def test_builtin_functions_on_device(self, device):
+        def fn(x, scaler):
+            m = torch.nn.ReLU()
+            m.to(device)
+            y = m(x) * scaler
+            return y
+
+        x = torch.randn([3, 6], device=device)
+        scaler = 0.23  # 0.23 is unspecialized
+        ref = fn(x, scaler)
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnts)(fn)
+        res = opt_fn(x, scaler)
+        self.assertTrue(same(ref, res))
+        self.assertEqual(ref.device, res.device)
+
+
+devices = ["cuda"]
+if TEST_HPU:
+    devices.append("hpu")
+instantiate_device_type_tests(UnspecTestsDevice, globals(), only_for=devices)
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -12,7 +12,7 @@ import torch.nn.functional as F
 from torch._dynamo.comptime import comptime
 from torch._dynamo.testing import CompileCounter, CompileCounterWithBackend, same
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import skipIfWindows, TEST_HPU
+from torch.testing._internal.common_utils import skipIfWindows
 from torch.testing._internal.logging_utils import logs_to_string
 
 
@@ -846,9 +846,7 @@ class UnspecTestsDevice(torch._dynamo.test_case.TestCase):
         self.assertEqual(ref.device, res.device)
 
 
-devices = ["cuda"]
-if TEST_HPU:
-    devices.append("hpu")
+devices = ["cuda", "hpu"]
 instantiate_device_type_tests(UnspecTestsDevice, globals(), only_for=devices)
 
 if __name__ == "__main__":


### PR DESCRIPTION
**MOTIVATION**

We recently integrated support for Intel Gaudi devices (identified as 'hpu') into the common_device_type framework via the pull request at https://github.com/pytorch/pytorch/pull/126970. This integration allows tests to be automatically instantiated for Gaudi devices upon loading the relevant library. Building on this development, the current pull request extends the utility of these hooks by adapting selected CUDA tests to operate on Gaudi devices. Additionally, we have confirmed that these modifications do not interfere with the existing tests on CUDA devices.

Other accelerators can also extend the functionality by adding the device in the devices list. ( For eg: xpu ) 

**CHANGES**

Create a separate class for test functions running on CUDA devices
Extend the functionality of these tests to include HPUs
Use instantiate_device_type_tests with targeted attributes to generate device-specific test instances within the new classes
Apply skipIfHPU decorator to bypass tests that are not yet compatible with HPU devices

Previously we had submitted some changes in https://github.com/pytorch/pytorch/pull/140131 . However, deleted that PR due to merge conflicts and other issues. 
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @ankurneog 
