### PR TITLE
Add test cases of fp8 datatypes in pt2e

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -1184,8 +1184,8 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
             info_fun = torch.iinfo if quant_dtype == torch.int16 else torch.finfo
             activate_qspec = QuantizationSpec(
                 dtype=quant_dtype,
-                quant_min=int(info_fun(quant_dtype).min),
-                quant_max=int(info_fun(quant_dtype).max),
+                quant_min=info_fun(quant_dtype).min,
+                quant_max=info_fun(quant_dtype).max,
                 qscheme=torch.per_tensor_affine,
                 is_dynamic=False,
                 observer_or_fake_quant_ctr=observer.default_observer,

--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -1184,8 +1184,8 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
             info_fun = torch.iinfo if quant_dtype == torch.int16 else torch.finfo
             activate_qspec = QuantizationSpec(
                 dtype=quant_dtype,
-                quant_min=info_fun(quant_dtype).min,
-                quant_max=info_fun(quant_dtype).max,
+                quant_min=int(info_fun(quant_dtype).min),
+                quant_max=int(info_fun(quant_dtype).max),
                 qscheme=torch.per_tensor_affine,
                 is_dynamic=False,
                 observer_or_fake_quant_ctr=observer.default_observer,

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -1369,7 +1369,7 @@ class PT2EQuantizationTestCase(QuantizationTestCase):
         m = convert_pt2e(m)
         return m
 
-    def _get_pt2e_quantized_linear(self, is_per_channel=False) -> torch.fx.GraphModule:
+    def _get_pt2e_quantized_linear(self, is_per_channel=False, quantizer=None) -> torch.fx.GraphModule:
         class M(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -1378,9 +1378,10 @@ class PT2EQuantizationTestCase(QuantizationTestCase):
             def forward(self, x):
                 return self.linear(x)
 
-        quantizer = XNNPACKQuantizer()
-        operator_config = get_symmetric_quantization_config(is_per_channel=is_per_channel)
-        quantizer.set_global(operator_config)
+        if quantizer is None:
+            quantizer = XNNPACKQuantizer()
+            operator_config = get_symmetric_quantization_config(is_per_channel=is_per_channel)
+            quantizer.set_global(operator_config)
         example_inputs = (torch.randn(2, 2),)
         m = M().eval()
         return self._quantize(m, quantizer, example_inputs)


### PR DESCRIPTION
As fp8 datatypes have been added to torch export serialization, this PR aims to add test cases of fp8 datatypes in pt2e quantization.
