### PR TITLE
Fix a bug for conj_physical

### DIFF
--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -620,11 +620,7 @@ Tensor _conj_physical(const Tensor& self) {
   if (self.is_conj()) {
     return self.conj().clone();
   }
-  auto options = self.options();
-  if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
-    options = options.dtype(c10::get_default_dtype());
-  }
-  auto result = at::empty_like(self, options);
+  auto result = at::empty_like(self);
   return at::conj_physical_out(result, self);
 }
 


### PR DESCRIPTION
Fixes #141426

fix a bug in previous [PR](https://github.com/pytorch/pytorch/pull/141427), which shouldn't convert the data type for conj.