### PR TITLE
Set maximum supported version of Python as 3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1166,7 +1166,7 @@ def main():
     with open(os.path.join(cwd, "README.md"), encoding="utf-8") as f:
         long_description = f.read()
 
-    version_range_max = max(sys.version_info[1], 12) + 1
+    version_range_max = max(sys.version_info[1], 13) + 1
     torch_package_data = [
         "py.typed",
         "bin/*",


### PR DESCRIPTION
Same as https://github.com/pytorch/pytorch/pull/119743 Required for Release 2.6.0