### PR TITLE
Update the Triton DeviceInterface in test/inductor/extension_backends/triton/device_interface.py

### DIFF
--- a/test/inductor/extension_backends/triton/device_interface.py
+++ b/test/inductor/extension_backends/triton/device_interface.py
@@ -108,9 +108,9 @@ class DeviceInterface(device_interface.DeviceInterface):
     def synchronize(device) -> None:
         pass
 
-    @staticmethod
-    def get_device_properties(device) -> DeviceProperties:
-        raise NotImplementedError
+    @classmethod
+    def get_device_properties(cls, device = None) -> DeviceProperties:
+        return cls.Worker.get_device_properties(device)
 
     # Can be mock patched by @patch decorator.
     @staticmethod

--- a/test/inductor/extension_backends/triton/device_interface.py
+++ b/test/inductor/extension_backends/triton/device_interface.py
@@ -109,7 +109,7 @@ class DeviceInterface(device_interface.DeviceInterface):
         pass
 
     @classmethod
-    def get_device_properties(cls, device = None) -> DeviceProperties:
+    def get_device_properties(cls, device=None) -> DeviceProperties:
         return cls.Worker.get_device_properties(device)
 
     # Can be mock patched by @patch decorator.


### PR DESCRIPTION
Following the changes to how `DeviceInterface` is used in this [PR](https://github.com/pytorch/pytorch/pull/142033), the `DeviceInterface` in `extension_backend/triton/device_interface.py` should by updated to return the `DeviceProperties` instead of raising a NotImplementedError.

This PR mirrors the [changes](https://github.com/pytorch/pytorch/pull/142033/files#diff-06553e25e48e1d60f3030458bc46d52067d3d0c3eef2d5fcea29f7e8126bd7c9L112-R114) made in Dynamo when the PR landed.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov