### PR TITLE
Fix `AffineTransform.sign`

### DIFF
--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -776,7 +776,7 @@ class AffineTransform(Transform):
     def sign(self) -> int:
         if isinstance(self.scale, numbers.Real):
             return 1 if float(self.scale) > 0 else -1 if float(self.scale) < 0 else 0
-        return self.scale.sign()
+        return int(self.scale.sign().prod().item())  # type: ignore[union-attr]
 
     def _call(self, x):
         return self.loc + self.scale * x


### PR DESCRIPTION
Fixes a bug where `AffineTransform.sign` could return a `Tensor` instead of `int`. 

`AffineTransform` is applied element-wise, so the jacobian is diagonal and the sign of the determinant is the product of the signs of the diagonal entries.

See: https://github.com/pytorch/pytorch/pull/144197#discussion_r1907328379


cc @fritzo @neerajprad @alicanb @nikitaved