### PR TITLE
`Dirichlet.mode`: use `dim=` instead of `axis=`

### DIFF
--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -94,9 +94,9 @@ class Dirichlet(ExponentialFamily):
     def mode(self) -> Tensor:
         concentrationm1 = (self.concentration - 1).clamp(min=0.0)
         mode = concentrationm1 / concentrationm1.sum(-1, True)
-        mask = (self.concentration < 1).all(axis=-1)
+        mask = (self.concentration < 1).all(dim=-1)
         mode[mask] = torch.nn.functional.one_hot(
-            mode[mask].argmax(axis=-1), concentrationm1.shape[-1]
+            mode[mask].argmax(dim=-1), concentrationm1.shape[-1]
         ).to(mode)
         return mode
 


### PR DESCRIPTION
`axis=` is undocumented and will raise typing errors when #144197 is merged.


See: https://github.com/pytorch/pytorch/pull/144197#pullrequestreview-2537398866

cc @fritzo @neerajprad @alicanb @nikitaved