### PR TITLE
[inductor][cpu] Fix accuracy error in BMM benchmarking for input weight with offset

### DIFF
--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -2315,7 +2315,9 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
         (
             ((3, 4, 64, 64), slice_maker[2, :3]),  # Contiguous slice of weights
             ((3, 4, 64, 64), slice_maker[2, 1:]),  # Contiguous slice of weights
+            ((3, 4, 65, 64), slice_maker[2, 1:, :64]),  # Contiguous slice of weights
             ((3, 4, 64, 64), slice_maker[:, 2]),  # Non-contigous slice of weights
+            ((3, 4, 65, 64), slice_maker[:, 2, :64]),  # Non-contigous slice of weights
         ),
     )
     @dtypes(torch.float)

--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -2321,6 +2321,7 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
 
             def forward(self, x, w):
                 y = x @ w[2]
+                y = y @ w[:, 2]
                 return torch.mm(y[2], self.weight[2])
 
         counters.clear()
@@ -2335,7 +2336,7 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
                 (x, w),
             )
             self.assertEqual(actual, expected, atol=atol, rtol=rtol)
-        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 2)
+        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 3)
 
 
 @dynamo_config.patch({"dynamic_shapes": True, "assume_static_by_default": False})

--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -2312,6 +2312,7 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
         except Exception:
             # skip this UT if import failed
             return
+
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -2335,6 +2336,7 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
             )
             self.assertEqual(actual, expected, atol=atol, rtol=rtol)
         self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 2)
+
 
 @dynamo_config.patch({"dynamic_shapes": True, "assume_static_by_default": False})
 class _DynamicShapesTestBase(BaseTestSelectAlgorithm):

--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -2320,8 +2320,11 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
                 self.weight = torch.nn.Parameter(w, requires_grad=False)
 
             def forward(self, x, w):
+                # Test contiguous slice of weights
                 y = x @ w[2]
+                # Test non-contiguous slice of weights (will be copied)
                 y = y @ w[:, 2]
+                # Test mm slice of weight
                 return torch.mm(y[2], self.weight[2])
 
         counters.clear()

--- a/torch/_inductor/codegen/cpp_bmm_template.py
+++ b/torch/_inductor/codegen/cpp_bmm_template.py
@@ -32,7 +32,7 @@ GEMM_THREADED_MM_STUB = r"""
     aliases=aliases,
     function_name=kernel_name+"_threaded_mm",
     extra_sizevars=BY_sizevars + [b_index],
-    placeholder="<SINGLE_THREAD_MM_DEF_FOR_BMM>")}}"""
+    placeholder="<THREADED_MM_DEF_FOR_BMM>")}}"""
 
 BMM_TEMPLATE = r"""
 {{ template.codegen_microkernel_def() }}

--- a/torch/_inductor/codegen/cpp_bmm_template.py
+++ b/torch/_inductor/codegen/cpp_bmm_template.py
@@ -191,7 +191,10 @@ class CppBmmTemplate(CppGemmTemplate):
         options["b_index"] = self.b_index
         options["BY_sizevars"] = [
             s
-            for sym in itertools.chain(BY.get_size(), BY.get_stride())
+            for B_node in [BX, BW, BY]
+            for sym in itertools.chain(
+                B_node.get_size(), B_node.get_stride(), (B_node.get_layout().offset,)
+            )
             if isinstance(sym, sympy.Expr)
             for s in sym.free_symbols
         ]

--- a/torch/_inductor/codegen/cpp_bmm_template.py
+++ b/torch/_inductor/codegen/cpp_bmm_template.py
@@ -131,27 +131,6 @@ class CppBmmTemplate(CppGemmTemplate):
             else not W.is_contiguous()
         )
 
-    @staticmethod
-    def get_view_layout(node):
-        def is_slice(node: ir.IRNode):
-            if isinstance(node, ir.ReinterpretView):
-                old_layout = node.data.get_layout()
-                new_layout = node.layout
-                return (
-                    isinstance(node.data, ir.StorageBox)
-                    and old_layout.size[-len(new_layout.size) :] == new_layout.size
-                    and len(old_layout.size) > len(new_layout.size)
-                    and new_layout.is_contiguous()
-                )
-            return False
-
-        if is_slice(node):
-            # If weight is a slice of a larger tensor, we need to use the layout of the whole tensor
-            view_layout = node.data.get_layout()
-        else:
-            view_layout = node.layout
-        return view_layout.size, view_layout.stride, view_layout.offset
-
     def get_gemm_function_call(
         self,
         kernel: CppTemplateKernel,

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -869,6 +869,7 @@ class CppGemmTemplate(CppTemplate):
             return new_inputs, layout_or_out
 
         def normalize_shapes(inputs, layout_or_out):
+            nonlocal view_offset
             new_inputs = list(inputs)
             if (
                 not is_mkldnn_wgt
@@ -880,6 +881,7 @@ class CppGemmTemplate(CppTemplate):
                     assert not has_free_symbols(view_size[-2:])
                     view_size[:] = V.graph.sizevars.size_hints(view_size)
                     view_stride[:] = V.graph.sizevars.size_hints(view_stride)
+                    view_offset = V.graph.sizevars.size_hints((view_offset,))[0]
                 # With the assumptation that W is the storage of unwrap view
                 # thus view it back here
                 new_inputs[1] = new_inputs[1].as_strided(

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -298,15 +298,18 @@ GEMM_TEMPLATE = r"""
 def get_padded_n(n, block_n):
     return (n + block_n - 1) // block_n * block_n
 
+
 def is_slice(node: ir.IRNode):
-    old_layout = node.data.get_layout()
-    new_layout = node.layout
-    return (
-        isinstance(node, ir.ReinterpretView)
-        and isinstance(node.data, ir.StorageBox)
-        and old_layout.size[-len(new_layout.size):] == new_layout.size
-        and len(old_layout.size) > len(new_layout.size)
-    )
+    if isinstance(node, ir.ReinterpretView):
+        old_layout = node.data.get_layout()
+        new_layout = node.layout
+        return (
+            isinstance(node.data, ir.StorageBox)
+            and old_layout.size[-len(new_layout.size) :] == new_layout.size
+            and len(old_layout.size) > len(new_layout.size)
+        )
+    return False
+
 
 _T = TypeVar("_T", ir.IRNode, torch.Tensor)
 

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -848,6 +848,7 @@ class CppGemmTemplate(CppTemplate):
             # It shouldn't happen as viewing an mkldnn tensor, we can extend the
             # implementation if it does.
             assert not isinstance(new_inputs[1], ir.BaseView)
+        # Note that the layout of MKLDNN Tensor is with the wrong stride
         view_size, view_stride, view_offset = cls.get_view_layout(new_inputs[1])
 
         def maybe_to_dense(inputs, layout_or_out):

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -311,7 +311,6 @@ def is_slice(node: ir.IRNode):
             isinstance(node.data, ir.StorageBox)
             and V.graph.sizevars.shape_env.evaluate_expr(new_layout.offset > 0)
             and all(size_comparisons)
-            and len(old_layout.size) > len(new_layout.size)
         )
     return False
 
@@ -924,6 +923,8 @@ class CppGemmTemplate(CppTemplate):
 
         # If weight is a slice of a larger tensor, we need the entire tensor and shouldn't unwrap it
         # because the GEMM template expects the whole tensor.
+        # We shouldn't unwrap the weight if we are using VNNI blocking because we do a reshape on the
+        # slice of the weights.
         if not block_weights and is_slice(original_weight_node):
             should_unwrap_weight = False
 


### PR DESCRIPTION
Fixes #143770 

When an input weight tensor has an offset (i.e. is a slice of another larger tensor at non-zero dim) the test/benchmarking process was changing the benchmarking argument to be only the one slice instead of the entire tensor. This resulted in an accuracy error and potentially a crash if in `VERIFY` mode in `select_algorithm.py`.

As a solution, we check if the input weight is a slice of a larger node, and if so, we use the larger node for the call to `as_strided` when preprocessing the benchmarking arguments.

* Why wasn't this happening before with GEMM?
  - Since current GEMM code only supports constant weights, the blocking/packing process changed the input weight tensor so no offset was used. This is not the case for BMM.

The new UT here tests both the BMM and GEMM cases, where the GEMM input is a slice and a constant weight, and the BMM input is not constant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov