### PR TITLE
[BE] fix ruff rule E226: add missing whitespace around operator in f-strings

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -669,7 +669,7 @@ def get_ghstack_prs(
         if not open_only or not candidate.is_closed():
             return False
         print(
-            f"Skipping {idx+1} of {len(rev_list)} PR (#{candidate.pr_num}) as its already been merged"
+            f"Skipping {idx + 1} of {len(rev_list)} PR (#{candidate.pr_num}) as its already been merged"
         )
         return True
 

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -676,7 +676,7 @@ def print_summary_table(data, print_dataframe=False):
                 print(col.ljust(width), f"mean={data[col].mean():.3f}x")
             elif col in ("accuracy"):
                 pass_rate = (data[col] == "pass").mean()
-                print(col.ljust(width), f"pass_rate={100*pass_rate:.2f}%")
+                print(col.ljust(width), f"pass_rate={100 * pass_rate:.2f}%")
             else:
                 cdata = data[col]
                 print(
@@ -4993,7 +4993,7 @@ def run(runner, args, original_dir=None):
         for i, name in enumerate(model_names):
             current_name = name
             if args.progress:
-                print(f"Running model {i+1}/{nmodels}", flush=True)
+                print(f"Running model {i + 1}/{nmodels}", flush=True)
 
             try:
                 timeout = args.timeout

--- a/benchmarks/dynamo/microbenchmarks/cache_debug_microbenchmarks.py
+++ b/benchmarks/dynamo/microbenchmarks/cache_debug_microbenchmarks.py
@@ -25,7 +25,7 @@ def main():
         return details.debug_lines()
 
     t = min(timeit.repeat(fn, number=K, repeat=3))
-    print(f"iterating over {N*K} FX nodes took {t:.1f}s ({N*K/t:.0f} nodes/s)")
+    print(f"iterating over {N * K} FX nodes took {t:.1f}s ({N * K / t:.0f} nodes/s)")
 
 
 if __name__ == "__main__":

--- a/benchmarks/dynamo/microbenchmarks/fx_microbenchmarks.py
+++ b/benchmarks/dynamo/microbenchmarks/fx_microbenchmarks.py
@@ -24,7 +24,7 @@ def main():
             pass
 
     t = min(timeit.repeat(fn, number=K, repeat=3))
-    print(f"iterating over {N*K} FX nodes took {t:.1f}s ({N*K/t:.0f} nodes/s)")
+    print(f"iterating over {N * K} FX nodes took {t:.1f}s ({N * K / t:.0f} nodes/s)")
 
 
 if __name__ == "__main__":

--- a/benchmarks/dynamo/microbenchmarks/overheads.py
+++ b/benchmarks/dynamo/microbenchmarks/overheads.py
@@ -19,7 +19,7 @@ def bench(name, fn, requires_grad):
     end = time.perf_counter()
 
     results = timeit.repeat(lambda: fn(x), number=1000, repeat=1000)
-    print(f"{name} {np.median(results)*1000:.1f}us (warmup={end-start:.1f}s)")
+    print(f"{name} {np.median(results) * 1000:.1f}us (warmup={end - start:.1f}s)")
 
 
 def main():

--- a/benchmarks/dynamo/pr_time_benchmarks/check_results.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/check_results.py
@@ -144,7 +144,7 @@ def main():
             fail = True
             print(
                 f"REGRESSION: benchmark {key} failed, actual result {result} "
-                f"is {ratio:.2f}% higher than expected {entry.expected_value} ±{entry.noise_margin*100:+.2f}% "
+                f"is {ratio:.2f}% higher than expected {entry.expected_value} ±{entry.noise_margin * 100:+.2f}% "
                 f"if this is an expected regression, please update the expected results.\n"
             )
             print(
@@ -158,7 +158,7 @@ def main():
 
             print(
                 f"WIN: benchmark {key} failed, actual result {result} is {ratio:+.2f}% lower than "
-                f"expected {entry.expected_value} ±{entry.noise_margin*100:.2f}% "
+                f"expected {entry.expected_value} ±{entry.noise_margin * 100:.2f}% "
                 f"please update the expected results. \n"
             )
             print(
@@ -170,7 +170,7 @@ def main():
         else:
             print(
                 f"PASS: benchmark {key} pass, actual result {result} {ratio:+.2f}% is within "
-                f"expected {entry.expected_value} ±{entry.noise_margin*100:.2f}%\n"
+                f"expected {entry.expected_value} ±{entry.noise_margin * 100:.2f}%\n"
             )
 
             log("pass")

--- a/benchmarks/dynamo/runner.py
+++ b/benchmarks/dynamo/runner.py
@@ -543,7 +543,7 @@ def build_summary(args):
         out_io.write(f"Number CUDA Devices: {torch.cuda.device_count()}\n")
         out_io.write(f"Device Name: {torch.cuda.get_device_name(0)}\n")
         out_io.write(
-            f"Device Memory [GB]: {torch.cuda.get_device_properties(0).total_memory/1e9}\n"
+            f"Device Memory [GB]: {torch.cuda.get_device_properties(0).total_memory / 1e9}\n"
         )
 
     title = "## Build Summary"

--- a/benchmarks/dynamo/training_loss.py
+++ b/benchmarks/dynamo/training_loss.py
@@ -193,9 +193,9 @@ def main():
     print(
         f"Train model on {args.epochs} epochs with backend {args.backend} and optimizer {args.optimizer}:"
     )
-    print(f"PyTorch spent {timedelta(seconds=native_elapsed/args.epochs)} per epoch")
+    print(f"PyTorch spent {timedelta(seconds=native_elapsed / args.epochs)} per epoch")
     print(
-        f"TorchDynamo spent {timedelta(seconds=dynamo_elapsed/args.epochs)} per epoch"
+        f"TorchDynamo spent {timedelta(seconds=dynamo_elapsed / args.epochs)} per epoch"
     )
 
 

--- a/functorch/examples/compilation/fuse_module.py
+++ b/functorch/examples/compilation/fuse_module.py
@@ -51,6 +51,6 @@ for a, b in zip(run(mod, input), run(compiled_mod, input)):
 for _ in range(5):
     i = 10000
     t = timeit.Timer("mod(input)", globals=globals()).timeit(10000)
-    print(f"eager {t/i*1e6}")
+    print(f"eager {t / i * 1e6}")
     t = timeit.Timer("compiled_mod(input)", globals=globals()).timeit(10000)
-    print(f"compiled {t/i*1e6}")
+    print(f"compiled {t / i * 1e6}")

--- a/functorch/examples/maml_omniglot/maml-omniglot-higher.py
+++ b/functorch/examples/maml_omniglot/maml-omniglot-higher.py
@@ -235,7 +235,7 @@ def test(db, net, device, epoch, log):
 
     qry_losses = torch.cat(qry_losses).mean().item()
     qry_accs = 100.0 * torch.cat(qry_accs).float().mean().item()
-    print(f"[Epoch {epoch+1:.2f}] Test Loss: {qry_losses:.2f} | Acc: {qry_accs:.2f}")
+    print(f"[Epoch {epoch + 1:.2f}] Test Loss: {qry_losses:.2f} | Acc: {qry_accs:.2f}")
     log.append(
         {
             "epoch": epoch + 1,

--- a/functorch/examples/maml_omniglot/maml-omniglot-ptonly.py
+++ b/functorch/examples/maml_omniglot/maml-omniglot-ptonly.py
@@ -225,7 +225,7 @@ def test(db, net, device, epoch, log):
 
     qry_losses = torch.cat(qry_losses).mean().item()
     qry_accs = 100.0 * torch.cat(qry_accs).float().mean().item()
-    print(f"[Epoch {epoch+1:.2f}] Test Loss: {qry_losses:.2f} | Acc: {qry_accs:.2f}")
+    print(f"[Epoch {epoch + 1:.2f}] Test Loss: {qry_losses:.2f} | Acc: {qry_accs:.2f}")
     log.append(
         {
             "epoch": epoch + 1,

--- a/functorch/examples/maml_omniglot/maml-omniglot-transforms.py
+++ b/functorch/examples/maml_omniglot/maml-omniglot-transforms.py
@@ -225,7 +225,7 @@ def test(db, net, device, epoch, log):
 
     qry_losses = torch.cat(qry_losses).mean().item()
     qry_accs = 100.0 * torch.cat(qry_accs).float().mean().item()
-    print(f"[Epoch {epoch+1:.2f}] Test Loss: {qry_losses:.2f} | Acc: {qry_accs:.2f}")
+    print(f"[Epoch {epoch + 1:.2f}] Test Loss: {qry_losses:.2f} | Acc: {qry_accs:.2f}")
     log.append(
         {
             "epoch": epoch + 1,

--- a/functorch/notebooks/jacobians_hessians.ipynb
+++ b/functorch/notebooks/jacobians_hessians.ipynb
@@ -1,952 +1,952 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Jacobians, Hessians, hvp, vhp, and more: composing functorch transforms\n",
-        "\n",
-        "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/jacobians_hessians.ipynb\">\n",
-        "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
-        "</a>\n",
-        "\n",
-        "Computing jacobians or hessians are useful in a number of non-traditional\n",
-        "deep learning models. It is difficult (or annoying) to compute these quantities\n",
-        "efficiently using a standard autodiff system like PyTorch Autograd; functorch\n",
-        "provides ways of computing various higher-order autodiff quantities efficiently."
-      ],
-      "metadata": {
-        "id": "zPbR6-eP51fe"
-      },
-      "id": "zPbR6-eP51fe"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Computing the Jacobian"
-      ],
-      "metadata": {
-        "id": "3kDj8fhn52j3"
-      },
-      "id": "3kDj8fhn52j3"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import torch\n",
-        "import torch.nn as nn\n",
-        "import torch.nn.functional as F\n",
-        "from functools import partial\n",
-        "_ = torch.manual_seed(0)"
-      ],
-      "metadata": {
-        "id": "w_IinyjzflUH"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "w_IinyjzflUH"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Let’s start with a function that we’d like to compute the jacobian of.  This is a simple linear function with non-linear activation.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "cibF_PEYflUH"
-      },
-      "id": "cibF_PEYflUH"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def predict(weight, bias, x):\n",
-        "    return F.linear(x, weight, bias).tanh()"
-      ],
-      "metadata": {
-        "id": "qhcD9hWYflUH"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "qhcD9hWYflUH"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Let's add some dummy data:   a weight, a bias, and a feature vector x.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "G8tqQrO_flUH"
-      },
-      "id": "G8tqQrO_flUH"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "D = 16\n",
-        "weight = torch.randn(D, D)\n",
-        "bias = torch.randn(D)\n",
-        "x = torch.randn(D) # feature vector"
-      ],
-      "metadata": {
-        "id": "FZ4uJfZGflUH"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "FZ4uJfZGflUH"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Let's think of `predict` as a function that maps the input `x` from $R^D -> R^D$.\n",
-        "PyTorch Autograd computes vector-Jacobian products. In order to compute the full\n",
-        "Jacobian of this $R^D -> R^D$ function, we would have to compute it row-by-row\n",
-        "by using a different unit vector each time."
-      ],
-      "metadata": {
-        "id": "uMAW-ArQflUH"
-      },
-      "id": "uMAW-ArQflUH"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def compute_jac(xp):\n",
-        "    jacobian_rows = [torch.autograd.grad(predict(weight, bias, xp), xp, vec)[0]\n",
-        "                     for vec in unit_vectors]\n",
-        "    return torch.stack(jacobian_rows)"
-      ],
-      "metadata": {
-        "id": "z-BJPtbpflUI"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "z-BJPtbpflUI"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "xp = x.clone().requires_grad_()\n",
-        "unit_vectors = torch.eye(D)\n",
-        "\n",
-        "jacobian = compute_jac(xp)\n",
-        "\n",
-        "print(jacobian.shape)\n",
-        "print(jacobian[0])  # show first row"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "f1f1ec12-56ef-40f7-8c3c-cbad7bf86644",
-        "id": "zuWGSXspflUI"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "torch.Size([16, 16])\n",
-            "tensor([-0.5956, -0.6096, -0.1326, -0.2295,  0.4490,  0.3661, -0.1672, -1.1190,\n",
-            "         0.1705, -0.6683,  0.1851,  0.1630,  0.0634,  0.6547,  0.5908, -0.1308])\n"
-          ]
-        }
-      ],
-      "id": "zuWGSXspflUI"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Instead of computing the jacobian row-by-row, we can use vmap to get rid of the for-loop and vectorize the computation. \n",
-        "We can’t directly apply vmap to PyTorch Autograd; instead, functorch provides a vjp transform:\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "mxlEOUieflUI"
-      },
-      "id": "mxlEOUieflUI"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from functorch import vmap, vjp\n",
-        "\n",
-        "_, vjp_fn = vjp(partial(predict, weight, bias), x)\n",
-        "\n",
-        "ft_jacobian, = vmap(vjp_fn)(unit_vectors)\n",
-        "\n",
-        "# lets confirm both methods compute the same result\n",
-        "assert torch.allclose(ft_jacobian, jacobian)"
-      ],
-      "metadata": {
-        "id": "DeF6uy4WflUI"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "DeF6uy4WflUI"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "In future tutorial a composition of reverse-mode AD and vmap will give us per-sample-gradients. \n",
-        "In this tutorial, composing reverse-mode AD and vmap gives us Jacobian computation! \n",
-        "Various compositions of vmap and autodiff transforms can give us different interesting quantities.\n",
-        "\n",
-        "functorch provides **jacrev** as a convenience function that performs the vmap-vjp composition to compute jacobians. **jacrev** accepts an argnums argument that says which argument we would like to compute Jacobians with respect to.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "Hy4REmwDflUI"
-      },
-      "id": "Hy4REmwDflUI"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from functorch import jacrev\n",
-        "\n",
-        "ft_jacobian = jacrev(predict, argnums=2)(weight, bias, x)\n",
-        "\n",
-        "# confirm \n",
-        "assert torch.allclose(ft_jacobian, jacobian)"
-      ],
-      "metadata": {
-        "id": "Rt7i6_YlflUI"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "Rt7i6_YlflUI"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Let’s compare the performance of the two ways to compute the jacobian. The functorch version is much faster (and becomes even faster the more outputs there are). \n",
-        "\n",
-        "In general, we expect that vectorization via vmap can help eliminate overhead and give better utilization of your hardware.\n",
-        "\n",
-        "Vmap does this magic by pushing the outer loop down into the functions primitive operations in order to obtain better performance.\n",
-        "\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "JYe2H1UcflUJ"
-      },
-      "id": "JYe2H1UcflUJ"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Let's make a quick function to evaluate performance and deal with microseconds and milliseconds measurements:"
-      ],
-      "metadata": {
-        "id": "i_143LZwflUJ"
-      },
-      "id": "i_143LZwflUJ"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def get_perf(first, first_descriptor, second, second_descriptor):\n",
-        "  \"\"\"  takes torch.benchmark objects and compares delta of second vs first. \"\"\"\n",
-        "  faster = second.times[0]\n",
-        "  slower = first.times[0]\n",
-        "  gain = (slower-faster)/slower\n",
-        "  if gain < 0: gain *=-1 \n",
-        "  final_gain = gain*100\n",
-        "  print(f\" Performance delta: {final_gain:.4f} percent improvement with {second_descriptor} \")"
-      ],
-      "metadata": {
-        "id": "II7r6jBtflUJ"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "II7r6jBtflUJ"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "And then run the performance comparison:"
-      ],
-      "metadata": {
-        "id": "r4clPnPKflUJ"
-      },
-      "id": "r4clPnPKflUJ"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from torch.utils.benchmark import Timer\n",
-        "\n",
-        "without_vmap = Timer(stmt=\"compute_jac(xp)\", globals=globals())\n",
-        "with_vmap = Timer(stmt=\"jacrev(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
-        "\n",
-        "no_vmap_timer = without_vmap.timeit(500)\n",
-        "with_vmap_timer = with_vmap.timeit(500)\n",
-        "\n",
-        "print(no_vmap_timer)\n",
-        "print(with_vmap_timer)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "cbf77a19-aac9-428d-eba1-74d337c53e49",
-        "id": "ZPtoxF6eflUJ"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "<torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a911b350>\n",
-            "compute_jac(xp)\n",
-            "  2.25 ms\n",
-            "  1 measurement, 500 runs , 1 thread\n",
-            "<torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a6a99d50>\n",
-            "jacrev(predict, argnums=2)(weight, bias, x)\n",
-            "  884.34 us\n",
-            "  1 measurement, 500 runs , 1 thread\n"
-          ]
-        }
-      ],
-      "id": "ZPtoxF6eflUJ"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Lets do a relative performance comparison of the above with our get_perf function:"
-      ],
-      "metadata": {
-        "id": "nGBBi4dZflUJ"
-      },
-      "id": "nGBBi4dZflUJ"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "get_perf(no_vmap_timer, \"without vmap\",  with_vmap_timer, \"vmap\");"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "85d0bc5f-34aa-4826-f953-6c637404490c",
-        "id": "zqV2RzEXflUJ"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            " Performance delta: 60.7170 percent improvement with vmap \n"
-          ]
-        }
-      ],
-      "id": "zqV2RzEXflUJ"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Furthemore, it’s pretty easy to flip the problem around and say we want to compute Jacobians of the parameters to our model (weight, bias) instead of the input."
-      ],
-      "metadata": {
-        "id": "EQAB99EQflUJ"
-      },
-      "id": "EQAB99EQflUJ"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# note the change in input via argnums params of 0,1 to map to weight and bias\n",
-        "ft_jac_weight, ft_jac_bias = jacrev(predict, argnums=(0, 1))(weight, bias, x)"
-      ],
-      "metadata": {
-        "id": "8UZpC8DnflUK"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "8UZpC8DnflUK"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## reverse-mode Jacobian (jacrev) vs forward-mode Jacobian (jacfwd)\n"
-      ],
-      "metadata": {
-        "id": "F3USYENIflUK"
-      },
-      "id": "F3USYENIflUK"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "We offer two APIs to compute jacobians: **jacrev** and **jacfwd**: \n",
-        "- jacrev uses reverse-mode AD. As you saw above it is a composition of our vjp and vmap transforms. \n",
-        "- jacfwd uses forward-mode AD. It is implemented as a composition of our jvp and vmap transforms. \n",
-        "\n",
-        "jacfwd and jacrev can be substituted for each other but they have different performance characteristics.\n",
-        "\n",
-        "As a general rule of thumb, if you’re computing the jacobian of an $𝑅^N \\to R^M$ function, and there are many more outputs than inputs (i.e. $M > N$) then jacfwd is preferred, otherwise use jacrev. There are exceptions to this rule, but a non-rigorous argument for this follows:\n",
-        "\n",
-        "In reverse-mode AD, we are computing the jacobian row-by-row, while in forward-mode AD (which computes Jacobian-vector products), we are computing it column-by-column. The Jacobian matrix has M rows and N columns, so if it is taller or wider one way we may prefer the method that deals with fewer rows or columns.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "V7B3vE8dflUK"
-      },
-      "id": "V7B3vE8dflUK"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from functorch import jacrev, jacfwd"
-      ],
-      "metadata": {
-        "id": "k7Tok7m3flUK"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "k7Tok7m3flUK"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "First, let's benchmark with more inputs than outputs:\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "YrV-gZAaflUL"
-      },
-      "id": "YrV-gZAaflUL"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "Din = 32\n",
-        "Dout = 2048\n",
-        "weight = torch.randn(Dout, Din)\n",
-        "\n",
-        "bias = torch.randn(Dout)\n",
-        "x = torch.randn(Din)\n",
-        "\n",
-        "# remember the general rule about taller vs wider...here we have a taller matrix:\n",
-        "print(weight.shape)\n",
-        "\n",
-        "using_fwd = Timer(stmt=\"jacfwd(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
-        "using_bwd = Timer(stmt=\"jacrev(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
-        "\n",
-        "jacfwd_timing = using_fwd.timeit(500)\n",
-        "jacrev_timing = using_bwd.timeit(500)\n",
-        "\n",
-        "print(f'jacfwd time: {jacfwd_timing}')\n",
-        "print(f'jacrev time: {jacrev_timing}')\n"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "dd882726-9723-47c0-a72f-3c7835a85aa1",
-        "id": "m5j-4hSxflUL"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "torch.Size([2048, 32])\n",
-            "jacfwd time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a5d792d0>\n",
-            "jacfwd(predict, argnums=2)(weight, bias, x)\n",
-            "  1.32 ms\n",
-            "  1 measurement, 500 runs , 1 thread\n",
-            "jacrev time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a4dee450>\n",
-            "jacrev(predict, argnums=2)(weight, bias, x)\n",
-            "  12.46 ms\n",
-            "  1 measurement, 500 runs , 1 thread\n"
-          ]
-        }
-      ],
-      "id": "m5j-4hSxflUL"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "and then do a relative benchmark:"
-      ],
-      "metadata": {
-        "id": "k_Sg-4tVflUL"
-      },
-      "id": "k_Sg-4tVflUL"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "get_perf(jacfwd_timing, \"jacfwd\", jacrev_timing, \"jacrev\", );"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "3a6586a1-269d-46d8-d119-e24f6d46277f",
-        "id": "_4T96zGjflUL"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            " Performance delta: 842.8274 percent improvement with jacrev \n"
-          ]
-        }
-      ],
-      "id": "_4T96zGjflUL"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "and now the reverse - more outputs (M) than inputs (N):"
-      ],
-      "metadata": {
-        "id": "RCDPot1yflUL"
-      },
-      "id": "RCDPot1yflUL"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "Din = 2048\n",
-        "Dout = 32\n",
-        "weight = torch.randn(Dout, Din)\n",
-        "bias = torch.randn(Dout)\n",
-        "x = torch.randn(Din)\n",
-        "\n",
-        "using_fwd = Timer(stmt=\"jacfwd(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
-        "using_bwd = Timer(stmt=\"jacrev(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
-        "\n",
-        "jacfwd_timing = using_fwd.timeit(500)\n",
-        "jacrev_timing = using_bwd.timeit(500)\n",
-        "\n",
-        "print(f'jacfwd time: {jacfwd_timing}')\n",
-        "print(f'jacrev time: {jacrev_timing}')"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "913e9ccd-3d4f-472a-a749-19cee36d0a16",
-        "id": "_DRFqzqZflUM"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "jacfwd time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a5d64790>\n",
-            "jacfwd(predict, argnums=2)(weight, bias, x)\n",
-            "  7.99 ms\n",
-            "  1 measurement, 500 runs , 1 thread\n",
-            "jacrev time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a5d67b50>\n",
-            "jacrev(predict, argnums=2)(weight, bias, x)\n",
-            "  1.09 ms\n",
-            "  1 measurement, 500 runs , 1 thread\n"
-          ]
-        }
-      ],
-      "id": "_DRFqzqZflUM"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "and a relative perf comparison:"
-      ],
-      "metadata": {
-        "id": "5SRbMCNsflUM"
-      },
-      "id": "5SRbMCNsflUM"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "get_perf(jacrev_timing, \"jacrev\", jacfwd_timing, \"jacfwd\")"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "c282ce25-4f6e-44cd-aed7-60f6f5010e5b",
-        "id": "uF_9GaoiflUM"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            " Performance delta: 635.2095 percent improvement with jacfwd \n"
-          ]
-        }
-      ],
-      "id": "uF_9GaoiflUM"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Hessian computation with functorch.hessian\n"
-      ],
-      "metadata": {
-        "id": "J29FQaBQflUM"
-      },
-      "id": "J29FQaBQflUM"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "We offer a convenience API to compute hessians: `functorch.hessian`. \n",
-        "Hessians are the jacobian of the jacobian (or the partial derivative of the partial derivative, aka second order).\n",
-        "\n",
-        "This suggests that one can just compose functorch’s jacobian transforms to compute the Hessian. \n",
-        "Indeed, under the hood, `hessian(f)` is simply `jacfwd(jacrev(f))`.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "My4DPH97flUM"
-      },
-      "id": "My4DPH97flUM"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Note: to boost performance: depending on your model, you may also want to use `jacfwd(jacfwd(f))` or `jacrev(jacrev(f))` instead to compute hessians leveraging the rule of thumb above regarding wider vs taller matrices.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "FJt038l5flUM"
-      },
-      "id": "FJt038l5flUM"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from functorch import hessian\n",
-        "\n",
-        "# lets reduce the size in order not to blow out colab. Hessians require significant memory:\n",
-        "Din = 512\n",
-        "Dout = 32\n",
-        "weight = torch.randn(Dout, Din)\n",
-        "bias = torch.randn(Dout)\n",
-        "x = torch.randn(Din)\n",
-        "\n",
-        "hess_api = hessian(predict, argnums=2)(weight, bias, x)\n",
-        "hess_fwdfwd = jacfwd(jacfwd(predict, argnums=2), argnums=2)(weight, bias, x)\n",
-        "#hess_revrev = jacrev(jacrev(predict, argnums=2), argnums=2)(weight, bias, x)\n"
-      ],
-      "metadata": {
-        "id": "jEqr2ywZflUM"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "jEqr2ywZflUM"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Let's verify we have the same result regardless of using hessian api or using jacfwd(jacfwd())"
-      ],
-      "metadata": {
-        "id": "n9BHcICQflUN"
-      },
-      "id": "n9BHcICQflUN"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "torch.allclose(hess_api, hess_fwdfwd)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "e457e3bc-f085-4f90-966d-f98893b98ea8",
-        "id": "eHiWRkjJflUN"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "True"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 18
-        }
-      ],
-      "id": "eHiWRkjJflUN"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Batch Jacobian and Batch Hessian\n"
-      ],
-      "metadata": {
-        "id": "Gjt1RO8HflUN"
-      },
-      "id": "Gjt1RO8HflUN"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "In the above examples we’ve been operating with a single feature vector. In some cases you might want to take the Jacobian of a batch of outputs with respect to a batch of inputs. That is, given a batch of inputs of shape `(B, N)` and a function that goes from $R^N \\to R^M$, we would like a Jacobian of shape `(B, M, N)`. \n",
-        "\n",
-        "The easiest way to do this is to use vmap:"
-      ],
-      "metadata": {
-        "id": "RjIzdoQNflUN"
-      },
-      "id": "RjIzdoQNflUN"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "batch_size = 64\n",
-        "Din = 31\n",
-        "Dout = 33\n",
-        "\n",
-        "weight = torch.randn(Dout, Din)\n",
-        "print(f\"weight shape = {weight.shape}\")\n",
-        "\n",
-        "bias = torch.randn(Dout)\n",
-        "\n",
-        "x = torch.randn(batch_size, Din)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "561eb618-e00f-40d5-bd99-fa51ab82051f",
-        "id": "B1eoEO4UflUN"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "weight shape = torch.Size([33, 31])\n"
-          ]
-        }
-      ],
-      "id": "B1eoEO4UflUN"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "compute_batch_jacobian = vmap(jacrev(predict, argnums=2), in_dims=(None, None, 0))\n",
-        "batch_jacobian0 = compute_batch_jacobian(weight, bias, x)"
-      ],
-      "metadata": {
-        "id": "nZ_V02NhflUN"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "nZ_V02NhflUN"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "If you have a function that goes from (B, N) -> (B, M) instead and are certain that each input produces an independent output, then it’s also sometimes possible to do this without using vmap by summing the outputs and then computing the Jacobian of that function:\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "_OLDiY3MflUN"
-      },
-      "id": "_OLDiY3MflUN"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def predict_with_output_summed(weight, bias, x):\n",
-        "    return predict(weight, bias, x).sum(0)\n",
-        "\n",
-        "batch_jacobian1 = jacrev(predict_with_output_summed, argnums=2)(weight, bias, x).movedim(1, 0)\n",
-        "assert torch.allclose(batch_jacobian0, batch_jacobian1)"
-      ],
-      "metadata": {
-        "id": "_QH4hD8PflUO"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "_QH4hD8PflUO"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "If you instead have a function that goes from $𝑅^𝑁 \\to 𝑅^𝑀$ but inputs that are batched, you compose vmap with jacrev to compute batched jacobians:\n",
-        "\n",
-        "Finally, batch hessians can be computed similarly. It’s easiest to think about them by using vmap to batch over hessian computation, but in some cases the sum trick also works.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "eUjw65cCflUO"
-      },
-      "id": "eUjw65cCflUO"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "compute_batch_hessian = vmap(hessian(predict, argnums=2), in_dims=(None, None, 0))\n",
-        "\n",
-        "batch_hess = compute_batch_hessian(weight, bias, x)\n",
-        "batch_hess.shape"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "f3135cfa-e9e5-4f18-8cb7-0655e8a37cb5",
-        "id": "3vAyQjMsflUO"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "torch.Size([64, 33, 31, 31])"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 22
-        }
-      ],
-      "id": "3vAyQjMsflUO"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Computing Hessian-vector products\n",
-        "\n",
-        "The naive way to compute a Hessian-vector product (hvp) is to materialize the full Hessian and perform a dot-product with a vector. We can do better: it turns out we don't need to materialize the full Hessian to do this. We'll go through two (of many) different strategies to compute Hessian-vector products:\n",
-        "- composing reverse-mode AD with reverse-mode AD\n",
-        "- composing reverse-mode AD with forward-mode AD\n",
-        "\n",
-        "Composing reverse-mode AD with forward-mode AD (as opposed to reverse-mode with reverse-mode) is generally the more memory efficient way to compute a hvp because forward-mode AD doesn't need to construct an Autograd graph and save intermediates for backward:"
-      ],
-      "metadata": {
-        "id": "Wa8E48sQgpkb"
-      },
-      "id": "Wa8E48sQgpkb"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from functorch import jvp, grad, vjp\n",
-        "\n",
-        "def hvp(f, primals, tangents):\n",
-        "  return jvp(grad(f), primals, tangents)[1]"
-      ],
-      "metadata": {
-        "id": "trw6WbAth6BM"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "trw6WbAth6BM"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Here's some sample usage."
-      ],
-      "metadata": {
-        "id": "DQMpRo6nitfr"
-      },
-      "id": "DQMpRo6nitfr"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def f(x):\n",
-        "  return x.sin().sum()\n",
-        "\n",
-        "x = torch.randn(2048)\n",
-        "tangent = torch.randn(2048)\n",
-        "\n",
-        "result = hvp(f, (x,), (tangent,))"
-      ],
-      "metadata": {
-        "id": "sPwg8SOdiVAK"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "sPwg8SOdiVAK"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "If PyTorch forward-AD does not have coverage for your operations, then we can instead compose reverse-mode AD with reverse-mode AD:"
-      ],
-      "metadata": {
-        "id": "zGvUIcB0j1Ez"
-      },
-      "id": "zGvUIcB0j1Ez"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def hvp_revrev(f, primals, tangents):\n",
-        "  _, vjp_fn = vjp(grad(f), *primals)\n",
-        "  return vjp_fn(*tangents)"
-      ],
-      "metadata": {
-        "id": "mdDFZdlekAOK"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "mdDFZdlekAOK"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "result_hvp_revrev = hvp_revrev(f, (x,), (tangent,))\n",
-        "assert torch.allclose(result, result_hvp_revrev[0])"
-      ],
-      "metadata": {
-        "id": "_CuCk9X0lW7C"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "_CuCk9X0lW7C"
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.3"
-    },
-    "colab": {
-      "name": "jacobians_hessians.ipynb",
-      "provenance": []
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "zPbR6-eP51fe",
+   "metadata": {
+    "id": "zPbR6-eP51fe"
+   },
+   "source": [
+    "# Jacobians, Hessians, hvp, vhp, and more: composing functorch transforms\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/jacobians_hessians.ipynb\">\n",
+    "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+    "</a>\n",
+    "\n",
+    "Computing jacobians or hessians are useful in a number of non-traditional\n",
+    "deep learning models. It is difficult (or annoying) to compute these quantities\n",
+    "efficiently using a standard autodiff system like PyTorch Autograd; functorch\n",
+    "provides ways of computing various higher-order autodiff quantities efficiently."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "3kDj8fhn52j3",
+   "metadata": {
+    "id": "3kDj8fhn52j3"
+   },
+   "source": [
+    "## Computing the Jacobian"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "w_IinyjzflUH",
+   "metadata": {
+    "id": "w_IinyjzflUH"
+   },
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F\n",
+    "from functools import partial\n",
+    "_ = torch.manual_seed(0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cibF_PEYflUH",
+   "metadata": {
+    "id": "cibF_PEYflUH"
+   },
+   "source": [
+    "Let’s start with a function that we’d like to compute the jacobian of.  This is a simple linear function with non-linear activation.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "qhcD9hWYflUH",
+   "metadata": {
+    "id": "qhcD9hWYflUH"
+   },
+   "outputs": [],
+   "source": [
+    "def predict(weight, bias, x):\n",
+    "    return F.linear(x, weight, bias).tanh()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "G8tqQrO_flUH",
+   "metadata": {
+    "id": "G8tqQrO_flUH"
+   },
+   "source": [
+    "Let's add some dummy data:   a weight, a bias, and a feature vector x.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "FZ4uJfZGflUH",
+   "metadata": {
+    "id": "FZ4uJfZGflUH"
+   },
+   "outputs": [],
+   "source": [
+    "D = 16\n",
+    "weight = torch.randn(D, D)\n",
+    "bias = torch.randn(D)\n",
+    "x = torch.randn(D) # feature vector"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "uMAW-ArQflUH",
+   "metadata": {
+    "id": "uMAW-ArQflUH"
+   },
+   "source": [
+    "Let's think of `predict` as a function that maps the input `x` from $R^D -> R^D$.\n",
+    "PyTorch Autograd computes vector-Jacobian products. In order to compute the full\n",
+    "Jacobian of this $R^D -> R^D$ function, we would have to compute it row-by-row\n",
+    "by using a different unit vector each time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "z-BJPtbpflUI",
+   "metadata": {
+    "id": "z-BJPtbpflUI"
+   },
+   "outputs": [],
+   "source": [
+    "def compute_jac(xp):\n",
+    "    jacobian_rows = [torch.autograd.grad(predict(weight, bias, xp), xp, vec)[0]\n",
+    "                     for vec in unit_vectors]\n",
+    "    return torch.stack(jacobian_rows)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "zuWGSXspflUI",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "zuWGSXspflUI",
+    "outputId": "f1f1ec12-56ef-40f7-8c3c-cbad7bf86644"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([16, 16])\n",
+      "tensor([-0.5956, -0.6096, -0.1326, -0.2295,  0.4490,  0.3661, -0.1672, -1.1190,\n",
+      "         0.1705, -0.6683,  0.1851,  0.1630,  0.0634,  0.6547,  0.5908, -0.1308])\n"
+     ]
+    }
+   ],
+   "source": [
+    "xp = x.clone().requires_grad_()\n",
+    "unit_vectors = torch.eye(D)\n",
+    "\n",
+    "jacobian = compute_jac(xp)\n",
+    "\n",
+    "print(jacobian.shape)\n",
+    "print(jacobian[0])  # show first row"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "mxlEOUieflUI",
+   "metadata": {
+    "id": "mxlEOUieflUI"
+   },
+   "source": [
+    "Instead of computing the jacobian row-by-row, we can use vmap to get rid of the for-loop and vectorize the computation. \n",
+    "We can’t directly apply vmap to PyTorch Autograd; instead, functorch provides a vjp transform:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "DeF6uy4WflUI",
+   "metadata": {
+    "id": "DeF6uy4WflUI"
+   },
+   "outputs": [],
+   "source": [
+    "from functorch import vmap, vjp\n",
+    "\n",
+    "_, vjp_fn = vjp(partial(predict, weight, bias), x)\n",
+    "\n",
+    "ft_jacobian, = vmap(vjp_fn)(unit_vectors)\n",
+    "\n",
+    "# lets confirm both methods compute the same result\n",
+    "assert torch.allclose(ft_jacobian, jacobian)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Hy4REmwDflUI",
+   "metadata": {
+    "id": "Hy4REmwDflUI"
+   },
+   "source": [
+    "In future tutorial a composition of reverse-mode AD and vmap will give us per-sample-gradients. \n",
+    "In this tutorial, composing reverse-mode AD and vmap gives us Jacobian computation! \n",
+    "Various compositions of vmap and autodiff transforms can give us different interesting quantities.\n",
+    "\n",
+    "functorch provides **jacrev** as a convenience function that performs the vmap-vjp composition to compute jacobians. **jacrev** accepts an argnums argument that says which argument we would like to compute Jacobians with respect to.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Rt7i6_YlflUI",
+   "metadata": {
+    "id": "Rt7i6_YlflUI"
+   },
+   "outputs": [],
+   "source": [
+    "from functorch import jacrev\n",
+    "\n",
+    "ft_jacobian = jacrev(predict, argnums=2)(weight, bias, x)\n",
+    "\n",
+    "# confirm \n",
+    "assert torch.allclose(ft_jacobian, jacobian)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "JYe2H1UcflUJ",
+   "metadata": {
+    "id": "JYe2H1UcflUJ"
+   },
+   "source": [
+    "Let’s compare the performance of the two ways to compute the jacobian. The functorch version is much faster (and becomes even faster the more outputs there are). \n",
+    "\n",
+    "In general, we expect that vectorization via vmap can help eliminate overhead and give better utilization of your hardware.\n",
+    "\n",
+    "Vmap does this magic by pushing the outer loop down into the functions primitive operations in order to obtain better performance.\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "i_143LZwflUJ",
+   "metadata": {
+    "id": "i_143LZwflUJ"
+   },
+   "source": [
+    "Let's make a quick function to evaluate performance and deal with microseconds and milliseconds measurements:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "II7r6jBtflUJ",
+   "metadata": {
+    "id": "II7r6jBtflUJ"
+   },
+   "outputs": [],
+   "source": [
+    "def get_perf(first, first_descriptor, second, second_descriptor):\n",
+    "  \"\"\"  takes torch.benchmark objects and compares delta of second vs first. \"\"\"\n",
+    "  faster = second.times[0]\n",
+    "  slower = first.times[0]\n",
+    "  gain = (slower - faster) / slower\n",
+    "  if gain < 0: gain *=-1 \n",
+    "  final_gain = gain * 100\n",
+    "  print(f\" Performance delta: {final_gain:.4f} percent improvement with {second_descriptor} \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "r4clPnPKflUJ",
+   "metadata": {
+    "id": "r4clPnPKflUJ"
+   },
+   "source": [
+    "And then run the performance comparison:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ZPtoxF6eflUJ",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "ZPtoxF6eflUJ",
+    "outputId": "cbf77a19-aac9-428d-eba1-74d337c53e49"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a911b350>\n",
+      "compute_jac(xp)\n",
+      "  2.25 ms\n",
+      "  1 measurement, 500 runs , 1 thread\n",
+      "<torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a6a99d50>\n",
+      "jacrev(predict, argnums=2)(weight, bias, x)\n",
+      "  884.34 us\n",
+      "  1 measurement, 500 runs , 1 thread\n"
+     ]
+    }
+   ],
+   "source": [
+    "from torch.utils.benchmark import Timer\n",
+    "\n",
+    "without_vmap = Timer(stmt=\"compute_jac(xp)\", globals=globals())\n",
+    "with_vmap = Timer(stmt=\"jacrev(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
+    "\n",
+    "no_vmap_timer = without_vmap.timeit(500)\n",
+    "with_vmap_timer = with_vmap.timeit(500)\n",
+    "\n",
+    "print(no_vmap_timer)\n",
+    "print(with_vmap_timer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nGBBi4dZflUJ",
+   "metadata": {
+    "id": "nGBBi4dZflUJ"
+   },
+   "source": [
+    "Lets do a relative performance comparison of the above with our get_perf function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "zqV2RzEXflUJ",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "zqV2RzEXflUJ",
+    "outputId": "85d0bc5f-34aa-4826-f953-6c637404490c"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Performance delta: 60.7170 percent improvement with vmap \n"
+     ]
+    }
+   ],
+   "source": [
+    "get_perf(no_vmap_timer, \"without vmap\",  with_vmap_timer, \"vmap\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "EQAB99EQflUJ",
+   "metadata": {
+    "id": "EQAB99EQflUJ"
+   },
+   "source": [
+    "Furthemore, it’s pretty easy to flip the problem around and say we want to compute Jacobians of the parameters to our model (weight, bias) instead of the input."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8UZpC8DnflUK",
+   "metadata": {
+    "id": "8UZpC8DnflUK"
+   },
+   "outputs": [],
+   "source": [
+    "# note the change in input via argnums params of 0,1 to map to weight and bias\n",
+    "ft_jac_weight, ft_jac_bias = jacrev(predict, argnums=(0, 1))(weight, bias, x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "F3USYENIflUK",
+   "metadata": {
+    "id": "F3USYENIflUK"
+   },
+   "source": [
+    "## reverse-mode Jacobian (jacrev) vs forward-mode Jacobian (jacfwd)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "V7B3vE8dflUK",
+   "metadata": {
+    "id": "V7B3vE8dflUK"
+   },
+   "source": [
+    "We offer two APIs to compute jacobians: **jacrev** and **jacfwd**: \n",
+    "- jacrev uses reverse-mode AD. As you saw above it is a composition of our vjp and vmap transforms. \n",
+    "- jacfwd uses forward-mode AD. It is implemented as a composition of our jvp and vmap transforms. \n",
+    "\n",
+    "jacfwd and jacrev can be substituted for each other but they have different performance characteristics.\n",
+    "\n",
+    "As a general rule of thumb, if you’re computing the jacobian of an $𝑅^N \\to R^M$ function, and there are many more outputs than inputs (i.e. $M > N$) then jacfwd is preferred, otherwise use jacrev. There are exceptions to this rule, but a non-rigorous argument for this follows:\n",
+    "\n",
+    "In reverse-mode AD, we are computing the jacobian row-by-row, while in forward-mode AD (which computes Jacobian-vector products), we are computing it column-by-column. The Jacobian matrix has M rows and N columns, so if it is taller or wider one way we may prefer the method that deals with fewer rows or columns.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "k7Tok7m3flUK",
+   "metadata": {
+    "id": "k7Tok7m3flUK"
+   },
+   "outputs": [],
+   "source": [
+    "from functorch import jacrev, jacfwd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "YrV-gZAaflUL",
+   "metadata": {
+    "id": "YrV-gZAaflUL"
+   },
+   "source": [
+    "First, let's benchmark with more inputs than outputs:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "m5j-4hSxflUL",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "m5j-4hSxflUL",
+    "outputId": "dd882726-9723-47c0-a72f-3c7835a85aa1"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([2048, 32])\n",
+      "jacfwd time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a5d792d0>\n",
+      "jacfwd(predict, argnums=2)(weight, bias, x)\n",
+      "  1.32 ms\n",
+      "  1 measurement, 500 runs , 1 thread\n",
+      "jacrev time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a4dee450>\n",
+      "jacrev(predict, argnums=2)(weight, bias, x)\n",
+      "  12.46 ms\n",
+      "  1 measurement, 500 runs , 1 thread\n"
+     ]
+    }
+   ],
+   "source": [
+    "Din = 32\n",
+    "Dout = 2048\n",
+    "weight = torch.randn(Dout, Din)\n",
+    "\n",
+    "bias = torch.randn(Dout)\n",
+    "x = torch.randn(Din)\n",
+    "\n",
+    "# remember the general rule about taller vs wider...here we have a taller matrix:\n",
+    "print(weight.shape)\n",
+    "\n",
+    "using_fwd = Timer(stmt=\"jacfwd(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
+    "using_bwd = Timer(stmt=\"jacrev(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
+    "\n",
+    "jacfwd_timing = using_fwd.timeit(500)\n",
+    "jacrev_timing = using_bwd.timeit(500)\n",
+    "\n",
+    "print(f'jacfwd time: {jacfwd_timing}')\n",
+    "print(f'jacrev time: {jacrev_timing}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "k_Sg-4tVflUL",
+   "metadata": {
+    "id": "k_Sg-4tVflUL"
+   },
+   "source": [
+    "and then do a relative benchmark:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "_4T96zGjflUL",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "_4T96zGjflUL",
+    "outputId": "3a6586a1-269d-46d8-d119-e24f6d46277f"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Performance delta: 842.8274 percent improvement with jacrev \n"
+     ]
+    }
+   ],
+   "source": [
+    "get_perf(jacfwd_timing, \"jacfwd\", jacrev_timing, \"jacrev\", );"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "RCDPot1yflUL",
+   "metadata": {
+    "id": "RCDPot1yflUL"
+   },
+   "source": [
+    "and now the reverse - more outputs (M) than inputs (N):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "_DRFqzqZflUM",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "_DRFqzqZflUM",
+    "outputId": "913e9ccd-3d4f-472a-a749-19cee36d0a16"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "jacfwd time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a5d64790>\n",
+      "jacfwd(predict, argnums=2)(weight, bias, x)\n",
+      "  7.99 ms\n",
+      "  1 measurement, 500 runs , 1 thread\n",
+      "jacrev time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a5d67b50>\n",
+      "jacrev(predict, argnums=2)(weight, bias, x)\n",
+      "  1.09 ms\n",
+      "  1 measurement, 500 runs , 1 thread\n"
+     ]
+    }
+   ],
+   "source": [
+    "Din = 2048\n",
+    "Dout = 32\n",
+    "weight = torch.randn(Dout, Din)\n",
+    "bias = torch.randn(Dout)\n",
+    "x = torch.randn(Din)\n",
+    "\n",
+    "using_fwd = Timer(stmt=\"jacfwd(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
+    "using_bwd = Timer(stmt=\"jacrev(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
+    "\n",
+    "jacfwd_timing = using_fwd.timeit(500)\n",
+    "jacrev_timing = using_bwd.timeit(500)\n",
+    "\n",
+    "print(f'jacfwd time: {jacfwd_timing}')\n",
+    "print(f'jacrev time: {jacrev_timing}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5SRbMCNsflUM",
+   "metadata": {
+    "id": "5SRbMCNsflUM"
+   },
+   "source": [
+    "and a relative perf comparison:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "uF_9GaoiflUM",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "uF_9GaoiflUM",
+    "outputId": "c282ce25-4f6e-44cd-aed7-60f6f5010e5b"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Performance delta: 635.2095 percent improvement with jacfwd \n"
+     ]
+    }
+   ],
+   "source": [
+    "get_perf(jacrev_timing, \"jacrev\", jacfwd_timing, \"jacfwd\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "J29FQaBQflUM",
+   "metadata": {
+    "id": "J29FQaBQflUM"
+   },
+   "source": [
+    "## Hessian computation with functorch.hessian\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "My4DPH97flUM",
+   "metadata": {
+    "id": "My4DPH97flUM"
+   },
+   "source": [
+    "We offer a convenience API to compute hessians: `functorch.hessian`. \n",
+    "Hessians are the jacobian of the jacobian (or the partial derivative of the partial derivative, aka second order).\n",
+    "\n",
+    "This suggests that one can just compose functorch’s jacobian transforms to compute the Hessian. \n",
+    "Indeed, under the hood, `hessian(f)` is simply `jacfwd(jacrev(f))`.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "FJt038l5flUM",
+   "metadata": {
+    "id": "FJt038l5flUM"
+   },
+   "source": [
+    "Note: to boost performance: depending on your model, you may also want to use `jacfwd(jacfwd(f))` or `jacrev(jacrev(f))` instead to compute hessians leveraging the rule of thumb above regarding wider vs taller matrices.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "jEqr2ywZflUM",
+   "metadata": {
+    "id": "jEqr2ywZflUM"
+   },
+   "outputs": [],
+   "source": [
+    "from functorch import hessian\n",
+    "\n",
+    "# lets reduce the size in order not to blow out colab. Hessians require significant memory:\n",
+    "Din = 512\n",
+    "Dout = 32\n",
+    "weight = torch.randn(Dout, Din)\n",
+    "bias = torch.randn(Dout)\n",
+    "x = torch.randn(Din)\n",
+    "\n",
+    "hess_api = hessian(predict, argnums=2)(weight, bias, x)\n",
+    "hess_fwdfwd = jacfwd(jacfwd(predict, argnums=2), argnums=2)(weight, bias, x)\n",
+    "#hess_revrev = jacrev(jacrev(predict, argnums=2), argnums=2)(weight, bias, x)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "n9BHcICQflUN",
+   "metadata": {
+    "id": "n9BHcICQflUN"
+   },
+   "source": [
+    "Let's verify we have the same result regardless of using hessian api or using jacfwd(jacfwd())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eHiWRkjJflUN",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "eHiWRkjJflUN",
+    "outputId": "e457e3bc-f085-4f90-966d-f98893b98ea8"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "torch.allclose(hess_api, hess_fwdfwd)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Gjt1RO8HflUN",
+   "metadata": {
+    "id": "Gjt1RO8HflUN"
+   },
+   "source": [
+    "## Batch Jacobian and Batch Hessian\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "RjIzdoQNflUN",
+   "metadata": {
+    "id": "RjIzdoQNflUN"
+   },
+   "source": [
+    "In the above examples we’ve been operating with a single feature vector. In some cases you might want to take the Jacobian of a batch of outputs with respect to a batch of inputs. That is, given a batch of inputs of shape `(B, N)` and a function that goes from $R^N \\to R^M$, we would like a Jacobian of shape `(B, M, N)`. \n",
+    "\n",
+    "The easiest way to do this is to use vmap:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "B1eoEO4UflUN",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "B1eoEO4UflUN",
+    "outputId": "561eb618-e00f-40d5-bd99-fa51ab82051f"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "weight shape = torch.Size([33, 31])\n"
+     ]
+    }
+   ],
+   "source": [
+    "batch_size = 64\n",
+    "Din = 31\n",
+    "Dout = 33\n",
+    "\n",
+    "weight = torch.randn(Dout, Din)\n",
+    "print(f\"weight shape = {weight.shape}\")\n",
+    "\n",
+    "bias = torch.randn(Dout)\n",
+    "\n",
+    "x = torch.randn(batch_size, Din)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "nZ_V02NhflUN",
+   "metadata": {
+    "id": "nZ_V02NhflUN"
+   },
+   "outputs": [],
+   "source": [
+    "compute_batch_jacobian = vmap(jacrev(predict, argnums=2), in_dims=(None, None, 0))\n",
+    "batch_jacobian0 = compute_batch_jacobian(weight, bias, x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "_OLDiY3MflUN",
+   "metadata": {
+    "id": "_OLDiY3MflUN"
+   },
+   "source": [
+    "If you have a function that goes from (B, N) -> (B, M) instead and are certain that each input produces an independent output, then it’s also sometimes possible to do this without using vmap by summing the outputs and then computing the Jacobian of that function:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "_QH4hD8PflUO",
+   "metadata": {
+    "id": "_QH4hD8PflUO"
+   },
+   "outputs": [],
+   "source": [
+    "def predict_with_output_summed(weight, bias, x):\n",
+    "    return predict(weight, bias, x).sum(0)\n",
+    "\n",
+    "batch_jacobian1 = jacrev(predict_with_output_summed, argnums=2)(weight, bias, x).movedim(1, 0)\n",
+    "assert torch.allclose(batch_jacobian0, batch_jacobian1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eUjw65cCflUO",
+   "metadata": {
+    "id": "eUjw65cCflUO"
+   },
+   "source": [
+    "If you instead have a function that goes from $𝑅^𝑁 \\to 𝑅^𝑀$ but inputs that are batched, you compose vmap with jacrev to compute batched jacobians:\n",
+    "\n",
+    "Finally, batch hessians can be computed similarly. It’s easiest to think about them by using vmap to batch over hessian computation, but in some cases the sum trick also works.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3vAyQjMsflUO",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "3vAyQjMsflUO",
+    "outputId": "f3135cfa-e9e5-4f18-8cb7-0655e8a37cb5"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([64, 33, 31, 31])"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "compute_batch_hessian = vmap(hessian(predict, argnums=2), in_dims=(None, None, 0))\n",
+    "\n",
+    "batch_hess = compute_batch_hessian(weight, bias, x)\n",
+    "batch_hess.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Wa8E48sQgpkb",
+   "metadata": {
+    "id": "Wa8E48sQgpkb"
+   },
+   "source": [
+    "## Computing Hessian-vector products\n",
+    "\n",
+    "The naive way to compute a Hessian-vector product (hvp) is to materialize the full Hessian and perform a dot-product with a vector. We can do better: it turns out we don't need to materialize the full Hessian to do this. We'll go through two (of many) different strategies to compute Hessian-vector products:\n",
+    "- composing reverse-mode AD with reverse-mode AD\n",
+    "- composing reverse-mode AD with forward-mode AD\n",
+    "\n",
+    "Composing reverse-mode AD with forward-mode AD (as opposed to reverse-mode with reverse-mode) is generally the more memory efficient way to compute a hvp because forward-mode AD doesn't need to construct an Autograd graph and save intermediates for backward:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "trw6WbAth6BM",
+   "metadata": {
+    "id": "trw6WbAth6BM"
+   },
+   "outputs": [],
+   "source": [
+    "from functorch import jvp, grad, vjp\n",
+    "\n",
+    "def hvp(f, primals, tangents):\n",
+    "  return jvp(grad(f), primals, tangents)[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "DQMpRo6nitfr",
+   "metadata": {
+    "id": "DQMpRo6nitfr"
+   },
+   "source": [
+    "Here's some sample usage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "sPwg8SOdiVAK",
+   "metadata": {
+    "id": "sPwg8SOdiVAK"
+   },
+   "outputs": [],
+   "source": [
+    "def f(x):\n",
+    "  return x.sin().sum()\n",
+    "\n",
+    "x = torch.randn(2048)\n",
+    "tangent = torch.randn(2048)\n",
+    "\n",
+    "result = hvp(f, (x,), (tangent,))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "zGvUIcB0j1Ez",
+   "metadata": {
+    "id": "zGvUIcB0j1Ez"
+   },
+   "source": [
+    "If PyTorch forward-AD does not have coverage for your operations, then we can instead compose reverse-mode AD with reverse-mode AD:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "mdDFZdlekAOK",
+   "metadata": {
+    "id": "mdDFZdlekAOK"
+   },
+   "outputs": [],
+   "source": [
+    "def hvp_revrev(f, primals, tangents):\n",
+    "  _, vjp_fn = vjp(grad(f), *primals)\n",
+    "  return vjp_fn(*tangents)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "_CuCk9X0lW7C",
+   "metadata": {
+    "id": "_CuCk9X0lW7C"
+   },
+   "outputs": [],
+   "source": [
+    "result_hvp_revrev = hvp_revrev(f, (x,), (tangent,))\n",
+    "assert torch.allclose(result, result_hvp_revrev[0])"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "jacobians_hessians.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/functorch/notebooks/jacobians_hessians.ipynb
+++ b/functorch/notebooks/jacobians_hessians.ipynb
@@ -1,952 +1,952 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "zPbR6-eP51fe",
-   "metadata": {
-    "id": "zPbR6-eP51fe"
-   },
-   "source": [
-    "# Jacobians, Hessians, hvp, vhp, and more: composing functorch transforms\n",
-    "\n",
-    "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/jacobians_hessians.ipynb\">\n",
-    "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
-    "</a>\n",
-    "\n",
-    "Computing jacobians or hessians are useful in a number of non-traditional\n",
-    "deep learning models. It is difficult (or annoying) to compute these quantities\n",
-    "efficiently using a standard autodiff system like PyTorch Autograd; functorch\n",
-    "provides ways of computing various higher-order autodiff quantities efficiently."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3kDj8fhn52j3",
-   "metadata": {
-    "id": "3kDj8fhn52j3"
-   },
-   "source": [
-    "## Computing the Jacobian"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "w_IinyjzflUH",
-   "metadata": {
-    "id": "w_IinyjzflUH"
-   },
-   "outputs": [],
-   "source": [
-    "import torch\n",
-    "import torch.nn as nn\n",
-    "import torch.nn.functional as F\n",
-    "from functools import partial\n",
-    "_ = torch.manual_seed(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cibF_PEYflUH",
-   "metadata": {
-    "id": "cibF_PEYflUH"
-   },
-   "source": [
-    "Let’s start with a function that we’d like to compute the jacobian of.  This is a simple linear function with non-linear activation.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "qhcD9hWYflUH",
-   "metadata": {
-    "id": "qhcD9hWYflUH"
-   },
-   "outputs": [],
-   "source": [
-    "def predict(weight, bias, x):\n",
-    "    return F.linear(x, weight, bias).tanh()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "G8tqQrO_flUH",
-   "metadata": {
-    "id": "G8tqQrO_flUH"
-   },
-   "source": [
-    "Let's add some dummy data:   a weight, a bias, and a feature vector x.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "FZ4uJfZGflUH",
-   "metadata": {
-    "id": "FZ4uJfZGflUH"
-   },
-   "outputs": [],
-   "source": [
-    "D = 16\n",
-    "weight = torch.randn(D, D)\n",
-    "bias = torch.randn(D)\n",
-    "x = torch.randn(D) # feature vector"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "uMAW-ArQflUH",
-   "metadata": {
-    "id": "uMAW-ArQflUH"
-   },
-   "source": [
-    "Let's think of `predict` as a function that maps the input `x` from $R^D -> R^D$.\n",
-    "PyTorch Autograd computes vector-Jacobian products. In order to compute the full\n",
-    "Jacobian of this $R^D -> R^D$ function, we would have to compute it row-by-row\n",
-    "by using a different unit vector each time."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "z-BJPtbpflUI",
-   "metadata": {
-    "id": "z-BJPtbpflUI"
-   },
-   "outputs": [],
-   "source": [
-    "def compute_jac(xp):\n",
-    "    jacobian_rows = [torch.autograd.grad(predict(weight, bias, xp), xp, vec)[0]\n",
-    "                     for vec in unit_vectors]\n",
-    "    return torch.stack(jacobian_rows)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "zuWGSXspflUI",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "zuWGSXspflUI",
-    "outputId": "f1f1ec12-56ef-40f7-8c3c-cbad7bf86644"
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "torch.Size([16, 16])\n",
-      "tensor([-0.5956, -0.6096, -0.1326, -0.2295,  0.4490,  0.3661, -0.1672, -1.1190,\n",
-      "         0.1705, -0.6683,  0.1851,  0.1630,  0.0634,  0.6547,  0.5908, -0.1308])\n"
-     ]
-    }
-   ],
-   "source": [
-    "xp = x.clone().requires_grad_()\n",
-    "unit_vectors = torch.eye(D)\n",
-    "\n",
-    "jacobian = compute_jac(xp)\n",
-    "\n",
-    "print(jacobian.shape)\n",
-    "print(jacobian[0])  # show first row"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "mxlEOUieflUI",
-   "metadata": {
-    "id": "mxlEOUieflUI"
-   },
-   "source": [
-    "Instead of computing the jacobian row-by-row, we can use vmap to get rid of the for-loop and vectorize the computation. \n",
-    "We can’t directly apply vmap to PyTorch Autograd; instead, functorch provides a vjp transform:\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "DeF6uy4WflUI",
-   "metadata": {
-    "id": "DeF6uy4WflUI"
-   },
-   "outputs": [],
-   "source": [
-    "from functorch import vmap, vjp\n",
-    "\n",
-    "_, vjp_fn = vjp(partial(predict, weight, bias), x)\n",
-    "\n",
-    "ft_jacobian, = vmap(vjp_fn)(unit_vectors)\n",
-    "\n",
-    "# lets confirm both methods compute the same result\n",
-    "assert torch.allclose(ft_jacobian, jacobian)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "Hy4REmwDflUI",
-   "metadata": {
-    "id": "Hy4REmwDflUI"
-   },
-   "source": [
-    "In future tutorial a composition of reverse-mode AD and vmap will give us per-sample-gradients. \n",
-    "In this tutorial, composing reverse-mode AD and vmap gives us Jacobian computation! \n",
-    "Various compositions of vmap and autodiff transforms can give us different interesting quantities.\n",
-    "\n",
-    "functorch provides **jacrev** as a convenience function that performs the vmap-vjp composition to compute jacobians. **jacrev** accepts an argnums argument that says which argument we would like to compute Jacobians with respect to.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "Rt7i6_YlflUI",
-   "metadata": {
-    "id": "Rt7i6_YlflUI"
-   },
-   "outputs": [],
-   "source": [
-    "from functorch import jacrev\n",
-    "\n",
-    "ft_jacobian = jacrev(predict, argnums=2)(weight, bias, x)\n",
-    "\n",
-    "# confirm \n",
-    "assert torch.allclose(ft_jacobian, jacobian)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "JYe2H1UcflUJ",
-   "metadata": {
-    "id": "JYe2H1UcflUJ"
-   },
-   "source": [
-    "Let’s compare the performance of the two ways to compute the jacobian. The functorch version is much faster (and becomes even faster the more outputs there are). \n",
-    "\n",
-    "In general, we expect that vectorization via vmap can help eliminate overhead and give better utilization of your hardware.\n",
-    "\n",
-    "Vmap does this magic by pushing the outer loop down into the functions primitive operations in order to obtain better performance.\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "i_143LZwflUJ",
-   "metadata": {
-    "id": "i_143LZwflUJ"
-   },
-   "source": [
-    "Let's make a quick function to evaluate performance and deal with microseconds and milliseconds measurements:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "II7r6jBtflUJ",
-   "metadata": {
-    "id": "II7r6jBtflUJ"
-   },
-   "outputs": [],
-   "source": [
-    "def get_perf(first, first_descriptor, second, second_descriptor):\n",
-    "  \"\"\"  takes torch.benchmark objects and compares delta of second vs first. \"\"\"\n",
-    "  faster = second.times[0]\n",
-    "  slower = first.times[0]\n",
-    "  gain = (slower - faster) / slower\n",
-    "  if gain < 0: gain *=-1 \n",
-    "  final_gain = gain * 100\n",
-    "  print(f\" Performance delta: {final_gain:.4f} percent improvement with {second_descriptor} \")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "r4clPnPKflUJ",
-   "metadata": {
-    "id": "r4clPnPKflUJ"
-   },
-   "source": [
-    "And then run the performance comparison:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ZPtoxF6eflUJ",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+      "cell_type": "markdown",
+      "source": [
+        "# Jacobians, Hessians, hvp, vhp, and more: composing functorch transforms\n",
+        "\n",
+        "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/jacobians_hessians.ipynb\">\n",
+        "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+        "</a>\n",
+        "\n",
+        "Computing jacobians or hessians are useful in a number of non-traditional\n",
+        "deep learning models. It is difficult (or annoying) to compute these quantities\n",
+        "efficiently using a standard autodiff system like PyTorch Autograd; functorch\n",
+        "provides ways of computing various higher-order autodiff quantities efficiently."
+      ],
+      "metadata": {
+        "id": "zPbR6-eP51fe"
+      },
+      "id": "zPbR6-eP51fe"
     },
-    "id": "ZPtoxF6eflUJ",
-    "outputId": "cbf77a19-aac9-428d-eba1-74d337c53e49"
-   },
-   "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a911b350>\n",
-      "compute_jac(xp)\n",
-      "  2.25 ms\n",
-      "  1 measurement, 500 runs , 1 thread\n",
-      "<torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a6a99d50>\n",
-      "jacrev(predict, argnums=2)(weight, bias, x)\n",
-      "  884.34 us\n",
-      "  1 measurement, 500 runs , 1 thread\n"
-     ]
-    }
-   ],
-   "source": [
-    "from torch.utils.benchmark import Timer\n",
-    "\n",
-    "without_vmap = Timer(stmt=\"compute_jac(xp)\", globals=globals())\n",
-    "with_vmap = Timer(stmt=\"jacrev(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
-    "\n",
-    "no_vmap_timer = without_vmap.timeit(500)\n",
-    "with_vmap_timer = with_vmap.timeit(500)\n",
-    "\n",
-    "print(no_vmap_timer)\n",
-    "print(with_vmap_timer)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "nGBBi4dZflUJ",
-   "metadata": {
-    "id": "nGBBi4dZflUJ"
-   },
-   "source": [
-    "Lets do a relative performance comparison of the above with our get_perf function:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "zqV2RzEXflUJ",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+      "cell_type": "markdown",
+      "source": [
+        "## Computing the Jacobian"
+      ],
+      "metadata": {
+        "id": "3kDj8fhn52j3"
+      },
+      "id": "3kDj8fhn52j3"
     },
-    "id": "zqV2RzEXflUJ",
-    "outputId": "85d0bc5f-34aa-4826-f953-6c637404490c"
-   },
-   "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " Performance delta: 60.7170 percent improvement with vmap \n"
-     ]
-    }
-   ],
-   "source": [
-    "get_perf(no_vmap_timer, \"without vmap\",  with_vmap_timer, \"vmap\");"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "EQAB99EQflUJ",
-   "metadata": {
-    "id": "EQAB99EQflUJ"
-   },
-   "source": [
-    "Furthemore, it’s pretty easy to flip the problem around and say we want to compute Jacobians of the parameters to our model (weight, bias) instead of the input."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8UZpC8DnflUK",
-   "metadata": {
-    "id": "8UZpC8DnflUK"
-   },
-   "outputs": [],
-   "source": [
-    "# note the change in input via argnums params of 0,1 to map to weight and bias\n",
-    "ft_jac_weight, ft_jac_bias = jacrev(predict, argnums=(0, 1))(weight, bias, x)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "F3USYENIflUK",
-   "metadata": {
-    "id": "F3USYENIflUK"
-   },
-   "source": [
-    "## reverse-mode Jacobian (jacrev) vs forward-mode Jacobian (jacfwd)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "V7B3vE8dflUK",
-   "metadata": {
-    "id": "V7B3vE8dflUK"
-   },
-   "source": [
-    "We offer two APIs to compute jacobians: **jacrev** and **jacfwd**: \n",
-    "- jacrev uses reverse-mode AD. As you saw above it is a composition of our vjp and vmap transforms. \n",
-    "- jacfwd uses forward-mode AD. It is implemented as a composition of our jvp and vmap transforms. \n",
-    "\n",
-    "jacfwd and jacrev can be substituted for each other but they have different performance characteristics.\n",
-    "\n",
-    "As a general rule of thumb, if you’re computing the jacobian of an $𝑅^N \\to R^M$ function, and there are many more outputs than inputs (i.e. $M > N$) then jacfwd is preferred, otherwise use jacrev. There are exceptions to this rule, but a non-rigorous argument for this follows:\n",
-    "\n",
-    "In reverse-mode AD, we are computing the jacobian row-by-row, while in forward-mode AD (which computes Jacobian-vector products), we are computing it column-by-column. The Jacobian matrix has M rows and N columns, so if it is taller or wider one way we may prefer the method that deals with fewer rows or columns.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "k7Tok7m3flUK",
-   "metadata": {
-    "id": "k7Tok7m3flUK"
-   },
-   "outputs": [],
-   "source": [
-    "from functorch import jacrev, jacfwd"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "YrV-gZAaflUL",
-   "metadata": {
-    "id": "YrV-gZAaflUL"
-   },
-   "source": [
-    "First, let's benchmark with more inputs than outputs:\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "m5j-4hSxflUL",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+      "cell_type": "code",
+      "source": [
+        "import torch\n",
+        "import torch.nn as nn\n",
+        "import torch.nn.functional as F\n",
+        "from functools import partial\n",
+        "_ = torch.manual_seed(0)"
+      ],
+      "metadata": {
+        "id": "w_IinyjzflUH"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "w_IinyjzflUH"
     },
-    "id": "m5j-4hSxflUL",
-    "outputId": "dd882726-9723-47c0-a72f-3c7835a85aa1"
-   },
-   "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "torch.Size([2048, 32])\n",
-      "jacfwd time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a5d792d0>\n",
-      "jacfwd(predict, argnums=2)(weight, bias, x)\n",
-      "  1.32 ms\n",
-      "  1 measurement, 500 runs , 1 thread\n",
-      "jacrev time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a4dee450>\n",
-      "jacrev(predict, argnums=2)(weight, bias, x)\n",
-      "  12.46 ms\n",
-      "  1 measurement, 500 runs , 1 thread\n"
-     ]
-    }
-   ],
-   "source": [
-    "Din = 32\n",
-    "Dout = 2048\n",
-    "weight = torch.randn(Dout, Din)\n",
-    "\n",
-    "bias = torch.randn(Dout)\n",
-    "x = torch.randn(Din)\n",
-    "\n",
-    "# remember the general rule about taller vs wider...here we have a taller matrix:\n",
-    "print(weight.shape)\n",
-    "\n",
-    "using_fwd = Timer(stmt=\"jacfwd(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
-    "using_bwd = Timer(stmt=\"jacrev(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
-    "\n",
-    "jacfwd_timing = using_fwd.timeit(500)\n",
-    "jacrev_timing = using_bwd.timeit(500)\n",
-    "\n",
-    "print(f'jacfwd time: {jacfwd_timing}')\n",
-    "print(f'jacrev time: {jacrev_timing}')\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "k_Sg-4tVflUL",
-   "metadata": {
-    "id": "k_Sg-4tVflUL"
-   },
-   "source": [
-    "and then do a relative benchmark:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "_4T96zGjflUL",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+      "cell_type": "markdown",
+      "source": [
+        "Let’s start with a function that we’d like to compute the jacobian of.  This is a simple linear function with non-linear activation.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "cibF_PEYflUH"
+      },
+      "id": "cibF_PEYflUH"
     },
-    "id": "_4T96zGjflUL",
-    "outputId": "3a6586a1-269d-46d8-d119-e24f6d46277f"
-   },
-   "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " Performance delta: 842.8274 percent improvement with jacrev \n"
-     ]
-    }
-   ],
-   "source": [
-    "get_perf(jacfwd_timing, \"jacfwd\", jacrev_timing, \"jacrev\", );"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "RCDPot1yflUL",
-   "metadata": {
-    "id": "RCDPot1yflUL"
-   },
-   "source": [
-    "and now the reverse - more outputs (M) than inputs (N):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "_DRFqzqZflUM",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+      "cell_type": "code",
+      "source": [
+        "def predict(weight, bias, x):\n",
+        "    return F.linear(x, weight, bias).tanh()"
+      ],
+      "metadata": {
+        "id": "qhcD9hWYflUH"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "qhcD9hWYflUH"
     },
-    "id": "_DRFqzqZflUM",
-    "outputId": "913e9ccd-3d4f-472a-a749-19cee36d0a16"
-   },
-   "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "jacfwd time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a5d64790>\n",
-      "jacfwd(predict, argnums=2)(weight, bias, x)\n",
-      "  7.99 ms\n",
-      "  1 measurement, 500 runs , 1 thread\n",
-      "jacrev time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a5d67b50>\n",
-      "jacrev(predict, argnums=2)(weight, bias, x)\n",
-      "  1.09 ms\n",
-      "  1 measurement, 500 runs , 1 thread\n"
-     ]
-    }
-   ],
-   "source": [
-    "Din = 2048\n",
-    "Dout = 32\n",
-    "weight = torch.randn(Dout, Din)\n",
-    "bias = torch.randn(Dout)\n",
-    "x = torch.randn(Din)\n",
-    "\n",
-    "using_fwd = Timer(stmt=\"jacfwd(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
-    "using_bwd = Timer(stmt=\"jacrev(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
-    "\n",
-    "jacfwd_timing = using_fwd.timeit(500)\n",
-    "jacrev_timing = using_bwd.timeit(500)\n",
-    "\n",
-    "print(f'jacfwd time: {jacfwd_timing}')\n",
-    "print(f'jacrev time: {jacrev_timing}')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5SRbMCNsflUM",
-   "metadata": {
-    "id": "5SRbMCNsflUM"
-   },
-   "source": [
-    "and a relative perf comparison:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "uF_9GaoiflUM",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+      "cell_type": "markdown",
+      "source": [
+        "Let's add some dummy data:   a weight, a bias, and a feature vector x.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "G8tqQrO_flUH"
+      },
+      "id": "G8tqQrO_flUH"
     },
-    "id": "uF_9GaoiflUM",
-    "outputId": "c282ce25-4f6e-44cd-aed7-60f6f5010e5b"
-   },
-   "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " Performance delta: 635.2095 percent improvement with jacfwd \n"
-     ]
-    }
-   ],
-   "source": [
-    "get_perf(jacrev_timing, \"jacrev\", jacfwd_timing, \"jacfwd\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "J29FQaBQflUM",
-   "metadata": {
-    "id": "J29FQaBQflUM"
-   },
-   "source": [
-    "## Hessian computation with functorch.hessian\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "My4DPH97flUM",
-   "metadata": {
-    "id": "My4DPH97flUM"
-   },
-   "source": [
-    "We offer a convenience API to compute hessians: `functorch.hessian`. \n",
-    "Hessians are the jacobian of the jacobian (or the partial derivative of the partial derivative, aka second order).\n",
-    "\n",
-    "This suggests that one can just compose functorch’s jacobian transforms to compute the Hessian. \n",
-    "Indeed, under the hood, `hessian(f)` is simply `jacfwd(jacrev(f))`.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "FJt038l5flUM",
-   "metadata": {
-    "id": "FJt038l5flUM"
-   },
-   "source": [
-    "Note: to boost performance: depending on your model, you may also want to use `jacfwd(jacfwd(f))` or `jacrev(jacrev(f))` instead to compute hessians leveraging the rule of thumb above regarding wider vs taller matrices.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "jEqr2ywZflUM",
-   "metadata": {
-    "id": "jEqr2ywZflUM"
-   },
-   "outputs": [],
-   "source": [
-    "from functorch import hessian\n",
-    "\n",
-    "# lets reduce the size in order not to blow out colab. Hessians require significant memory:\n",
-    "Din = 512\n",
-    "Dout = 32\n",
-    "weight = torch.randn(Dout, Din)\n",
-    "bias = torch.randn(Dout)\n",
-    "x = torch.randn(Din)\n",
-    "\n",
-    "hess_api = hessian(predict, argnums=2)(weight, bias, x)\n",
-    "hess_fwdfwd = jacfwd(jacfwd(predict, argnums=2), argnums=2)(weight, bias, x)\n",
-    "#hess_revrev = jacrev(jacrev(predict, argnums=2), argnums=2)(weight, bias, x)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "n9BHcICQflUN",
-   "metadata": {
-    "id": "n9BHcICQflUN"
-   },
-   "source": [
-    "Let's verify we have the same result regardless of using hessian api or using jacfwd(jacfwd())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "eHiWRkjJflUN",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+      "cell_type": "code",
+      "source": [
+        "D = 16\n",
+        "weight = torch.randn(D, D)\n",
+        "bias = torch.randn(D)\n",
+        "x = torch.randn(D) # feature vector"
+      ],
+      "metadata": {
+        "id": "FZ4uJfZGflUH"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "FZ4uJfZGflUH"
     },
-    "id": "eHiWRkjJflUN",
-    "outputId": "e457e3bc-f085-4f90-966d-f98893b98ea8"
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "torch.allclose(hess_api, hess_fwdfwd)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "Gjt1RO8HflUN",
-   "metadata": {
-    "id": "Gjt1RO8HflUN"
-   },
-   "source": [
-    "## Batch Jacobian and Batch Hessian\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "RjIzdoQNflUN",
-   "metadata": {
-    "id": "RjIzdoQNflUN"
-   },
-   "source": [
-    "In the above examples we’ve been operating with a single feature vector. In some cases you might want to take the Jacobian of a batch of outputs with respect to a batch of inputs. That is, given a batch of inputs of shape `(B, N)` and a function that goes from $R^N \\to R^M$, we would like a Jacobian of shape `(B, M, N)`. \n",
-    "\n",
-    "The easiest way to do this is to use vmap:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "B1eoEO4UflUN",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+      "cell_type": "markdown",
+      "source": [
+        "Let's think of `predict` as a function that maps the input `x` from $R^D -> R^D$.\n",
+        "PyTorch Autograd computes vector-Jacobian products. In order to compute the full\n",
+        "Jacobian of this $R^D -> R^D$ function, we would have to compute it row-by-row\n",
+        "by using a different unit vector each time."
+      ],
+      "metadata": {
+        "id": "uMAW-ArQflUH"
+      },
+      "id": "uMAW-ArQflUH"
     },
-    "id": "B1eoEO4UflUN",
-    "outputId": "561eb618-e00f-40d5-bd99-fa51ab82051f"
-   },
-   "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "weight shape = torch.Size([33, 31])\n"
-     ]
-    }
-   ],
-   "source": [
-    "batch_size = 64\n",
-    "Din = 31\n",
-    "Dout = 33\n",
-    "\n",
-    "weight = torch.randn(Dout, Din)\n",
-    "print(f\"weight shape = {weight.shape}\")\n",
-    "\n",
-    "bias = torch.randn(Dout)\n",
-    "\n",
-    "x = torch.randn(batch_size, Din)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "nZ_V02NhflUN",
-   "metadata": {
-    "id": "nZ_V02NhflUN"
-   },
-   "outputs": [],
-   "source": [
-    "compute_batch_jacobian = vmap(jacrev(predict, argnums=2), in_dims=(None, None, 0))\n",
-    "batch_jacobian0 = compute_batch_jacobian(weight, bias, x)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "_OLDiY3MflUN",
-   "metadata": {
-    "id": "_OLDiY3MflUN"
-   },
-   "source": [
-    "If you have a function that goes from (B, N) -> (B, M) instead and are certain that each input produces an independent output, then it’s also sometimes possible to do this without using vmap by summing the outputs and then computing the Jacobian of that function:\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "_QH4hD8PflUO",
-   "metadata": {
-    "id": "_QH4hD8PflUO"
-   },
-   "outputs": [],
-   "source": [
-    "def predict_with_output_summed(weight, bias, x):\n",
-    "    return predict(weight, bias, x).sum(0)\n",
-    "\n",
-    "batch_jacobian1 = jacrev(predict_with_output_summed, argnums=2)(weight, bias, x).movedim(1, 0)\n",
-    "assert torch.allclose(batch_jacobian0, batch_jacobian1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "eUjw65cCflUO",
-   "metadata": {
-    "id": "eUjw65cCflUO"
-   },
-   "source": [
-    "If you instead have a function that goes from $𝑅^𝑁 \\to 𝑅^𝑀$ but inputs that are batched, you compose vmap with jacrev to compute batched jacobians:\n",
-    "\n",
-    "Finally, batch hessians can be computed similarly. It’s easiest to think about them by using vmap to batch over hessian computation, but in some cases the sum trick also works.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3vAyQjMsflUO",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+      "cell_type": "code",
+      "source": [
+        "def compute_jac(xp):\n",
+        "    jacobian_rows = [torch.autograd.grad(predict(weight, bias, xp), xp, vec)[0]\n",
+        "                     for vec in unit_vectors]\n",
+        "    return torch.stack(jacobian_rows)"
+      ],
+      "metadata": {
+        "id": "z-BJPtbpflUI"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "z-BJPtbpflUI"
     },
-    "id": "3vAyQjMsflUO",
-    "outputId": "f3135cfa-e9e5-4f18-8cb7-0655e8a37cb5"
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "torch.Size([64, 33, 31, 31])"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
+      "cell_type": "code",
+      "source": [
+        "xp = x.clone().requires_grad_()\n",
+        "unit_vectors = torch.eye(D)\n",
+        "\n",
+        "jacobian = compute_jac(xp)\n",
+        "\n",
+        "print(jacobian.shape)\n",
+        "print(jacobian[0])  # show first row"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "f1f1ec12-56ef-40f7-8c3c-cbad7bf86644",
+        "id": "zuWGSXspflUI"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "torch.Size([16, 16])\n",
+            "tensor([-0.5956, -0.6096, -0.1326, -0.2295,  0.4490,  0.3661, -0.1672, -1.1190,\n",
+            "         0.1705, -0.6683,  0.1851,  0.1630,  0.0634,  0.6547,  0.5908, -0.1308])\n"
+          ]
+        }
+      ],
+      "id": "zuWGSXspflUI"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Instead of computing the jacobian row-by-row, we can use vmap to get rid of the for-loop and vectorize the computation. \n",
+        "We can’t directly apply vmap to PyTorch Autograd; instead, functorch provides a vjp transform:\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "mxlEOUieflUI"
+      },
+      "id": "mxlEOUieflUI"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from functorch import vmap, vjp\n",
+        "\n",
+        "_, vjp_fn = vjp(partial(predict, weight, bias), x)\n",
+        "\n",
+        "ft_jacobian, = vmap(vjp_fn)(unit_vectors)\n",
+        "\n",
+        "# lets confirm both methods compute the same result\n",
+        "assert torch.allclose(ft_jacobian, jacobian)"
+      ],
+      "metadata": {
+        "id": "DeF6uy4WflUI"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "DeF6uy4WflUI"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In future tutorial a composition of reverse-mode AD and vmap will give us per-sample-gradients. \n",
+        "In this tutorial, composing reverse-mode AD and vmap gives us Jacobian computation! \n",
+        "Various compositions of vmap and autodiff transforms can give us different interesting quantities.\n",
+        "\n",
+        "functorch provides **jacrev** as a convenience function that performs the vmap-vjp composition to compute jacobians. **jacrev** accepts an argnums argument that says which argument we would like to compute Jacobians with respect to.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "Hy4REmwDflUI"
+      },
+      "id": "Hy4REmwDflUI"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from functorch import jacrev\n",
+        "\n",
+        "ft_jacobian = jacrev(predict, argnums=2)(weight, bias, x)\n",
+        "\n",
+        "# confirm \n",
+        "assert torch.allclose(ft_jacobian, jacobian)"
+      ],
+      "metadata": {
+        "id": "Rt7i6_YlflUI"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "Rt7i6_YlflUI"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let’s compare the performance of the two ways to compute the jacobian. The functorch version is much faster (and becomes even faster the more outputs there are). \n",
+        "\n",
+        "In general, we expect that vectorization via vmap can help eliminate overhead and give better utilization of your hardware.\n",
+        "\n",
+        "Vmap does this magic by pushing the outer loop down into the functions primitive operations in order to obtain better performance.\n",
+        "\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "JYe2H1UcflUJ"
+      },
+      "id": "JYe2H1UcflUJ"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's make a quick function to evaluate performance and deal with microseconds and milliseconds measurements:"
+      ],
+      "metadata": {
+        "id": "i_143LZwflUJ"
+      },
+      "id": "i_143LZwflUJ"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def get_perf(first, first_descriptor, second, second_descriptor):\n",
+        "  \"\"\"  takes torch.benchmark objects and compares delta of second vs first. \"\"\"\n",
+        "  faster = second.times[0]\n",
+        "  slower = first.times[0]\n",
+        "  gain = (slower-faster)/slower\n",
+        "  if gain < 0: gain *=-1 \n",
+        "  final_gain = gain*100\n",
+        "  print(f\" Performance delta: {final_gain:.4f} percent improvement with {second_descriptor} \")"
+      ],
+      "metadata": {
+        "id": "II7r6jBtflUJ"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "II7r6jBtflUJ"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "And then run the performance comparison:"
+      ],
+      "metadata": {
+        "id": "r4clPnPKflUJ"
+      },
+      "id": "r4clPnPKflUJ"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from torch.utils.benchmark import Timer\n",
+        "\n",
+        "without_vmap = Timer(stmt=\"compute_jac(xp)\", globals=globals())\n",
+        "with_vmap = Timer(stmt=\"jacrev(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
+        "\n",
+        "no_vmap_timer = without_vmap.timeit(500)\n",
+        "with_vmap_timer = with_vmap.timeit(500)\n",
+        "\n",
+        "print(no_vmap_timer)\n",
+        "print(with_vmap_timer)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "cbf77a19-aac9-428d-eba1-74d337c53e49",
+        "id": "ZPtoxF6eflUJ"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "<torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a911b350>\n",
+            "compute_jac(xp)\n",
+            "  2.25 ms\n",
+            "  1 measurement, 500 runs , 1 thread\n",
+            "<torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a6a99d50>\n",
+            "jacrev(predict, argnums=2)(weight, bias, x)\n",
+            "  884.34 us\n",
+            "  1 measurement, 500 runs , 1 thread\n"
+          ]
+        }
+      ],
+      "id": "ZPtoxF6eflUJ"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Lets do a relative performance comparison of the above with our get_perf function:"
+      ],
+      "metadata": {
+        "id": "nGBBi4dZflUJ"
+      },
+      "id": "nGBBi4dZflUJ"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "get_perf(no_vmap_timer, \"without vmap\",  with_vmap_timer, \"vmap\");"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "85d0bc5f-34aa-4826-f953-6c637404490c",
+        "id": "zqV2RzEXflUJ"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            " Performance delta: 60.7170 percent improvement with vmap \n"
+          ]
+        }
+      ],
+      "id": "zqV2RzEXflUJ"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Furthemore, it’s pretty easy to flip the problem around and say we want to compute Jacobians of the parameters to our model (weight, bias) instead of the input."
+      ],
+      "metadata": {
+        "id": "EQAB99EQflUJ"
+      },
+      "id": "EQAB99EQflUJ"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# note the change in input via argnums params of 0,1 to map to weight and bias\n",
+        "ft_jac_weight, ft_jac_bias = jacrev(predict, argnums=(0, 1))(weight, bias, x)"
+      ],
+      "metadata": {
+        "id": "8UZpC8DnflUK"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "8UZpC8DnflUK"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## reverse-mode Jacobian (jacrev) vs forward-mode Jacobian (jacfwd)\n"
+      ],
+      "metadata": {
+        "id": "F3USYENIflUK"
+      },
+      "id": "F3USYENIflUK"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We offer two APIs to compute jacobians: **jacrev** and **jacfwd**: \n",
+        "- jacrev uses reverse-mode AD. As you saw above it is a composition of our vjp and vmap transforms. \n",
+        "- jacfwd uses forward-mode AD. It is implemented as a composition of our jvp and vmap transforms. \n",
+        "\n",
+        "jacfwd and jacrev can be substituted for each other but they have different performance characteristics.\n",
+        "\n",
+        "As a general rule of thumb, if you’re computing the jacobian of an $𝑅^N \\to R^M$ function, and there are many more outputs than inputs (i.e. $M > N$) then jacfwd is preferred, otherwise use jacrev. There are exceptions to this rule, but a non-rigorous argument for this follows:\n",
+        "\n",
+        "In reverse-mode AD, we are computing the jacobian row-by-row, while in forward-mode AD (which computes Jacobian-vector products), we are computing it column-by-column. The Jacobian matrix has M rows and N columns, so if it is taller or wider one way we may prefer the method that deals with fewer rows or columns.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "V7B3vE8dflUK"
+      },
+      "id": "V7B3vE8dflUK"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from functorch import jacrev, jacfwd"
+      ],
+      "metadata": {
+        "id": "k7Tok7m3flUK"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "k7Tok7m3flUK"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "First, let's benchmark with more inputs than outputs:\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "YrV-gZAaflUL"
+      },
+      "id": "YrV-gZAaflUL"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "Din = 32\n",
+        "Dout = 2048\n",
+        "weight = torch.randn(Dout, Din)\n",
+        "\n",
+        "bias = torch.randn(Dout)\n",
+        "x = torch.randn(Din)\n",
+        "\n",
+        "# remember the general rule about taller vs wider...here we have a taller matrix:\n",
+        "print(weight.shape)\n",
+        "\n",
+        "using_fwd = Timer(stmt=\"jacfwd(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
+        "using_bwd = Timer(stmt=\"jacrev(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
+        "\n",
+        "jacfwd_timing = using_fwd.timeit(500)\n",
+        "jacrev_timing = using_bwd.timeit(500)\n",
+        "\n",
+        "print(f'jacfwd time: {jacfwd_timing}')\n",
+        "print(f'jacrev time: {jacrev_timing}')\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "dd882726-9723-47c0-a72f-3c7835a85aa1",
+        "id": "m5j-4hSxflUL"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "torch.Size([2048, 32])\n",
+            "jacfwd time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a5d792d0>\n",
+            "jacfwd(predict, argnums=2)(weight, bias, x)\n",
+            "  1.32 ms\n",
+            "  1 measurement, 500 runs , 1 thread\n",
+            "jacrev time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a4dee450>\n",
+            "jacrev(predict, argnums=2)(weight, bias, x)\n",
+            "  12.46 ms\n",
+            "  1 measurement, 500 runs , 1 thread\n"
+          ]
+        }
+      ],
+      "id": "m5j-4hSxflUL"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "and then do a relative benchmark:"
+      ],
+      "metadata": {
+        "id": "k_Sg-4tVflUL"
+      },
+      "id": "k_Sg-4tVflUL"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "get_perf(jacfwd_timing, \"jacfwd\", jacrev_timing, \"jacrev\", );"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "3a6586a1-269d-46d8-d119-e24f6d46277f",
+        "id": "_4T96zGjflUL"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            " Performance delta: 842.8274 percent improvement with jacrev \n"
+          ]
+        }
+      ],
+      "id": "_4T96zGjflUL"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "and now the reverse - more outputs (M) than inputs (N):"
+      ],
+      "metadata": {
+        "id": "RCDPot1yflUL"
+      },
+      "id": "RCDPot1yflUL"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "Din = 2048\n",
+        "Dout = 32\n",
+        "weight = torch.randn(Dout, Din)\n",
+        "bias = torch.randn(Dout)\n",
+        "x = torch.randn(Din)\n",
+        "\n",
+        "using_fwd = Timer(stmt=\"jacfwd(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
+        "using_bwd = Timer(stmt=\"jacrev(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
+        "\n",
+        "jacfwd_timing = using_fwd.timeit(500)\n",
+        "jacrev_timing = using_bwd.timeit(500)\n",
+        "\n",
+        "print(f'jacfwd time: {jacfwd_timing}')\n",
+        "print(f'jacrev time: {jacrev_timing}')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "913e9ccd-3d4f-472a-a749-19cee36d0a16",
+        "id": "_DRFqzqZflUM"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "jacfwd time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a5d64790>\n",
+            "jacfwd(predict, argnums=2)(weight, bias, x)\n",
+            "  7.99 ms\n",
+            "  1 measurement, 500 runs , 1 thread\n",
+            "jacrev time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a5d67b50>\n",
+            "jacrev(predict, argnums=2)(weight, bias, x)\n",
+            "  1.09 ms\n",
+            "  1 measurement, 500 runs , 1 thread\n"
+          ]
+        }
+      ],
+      "id": "_DRFqzqZflUM"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "and a relative perf comparison:"
+      ],
+      "metadata": {
+        "id": "5SRbMCNsflUM"
+      },
+      "id": "5SRbMCNsflUM"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "get_perf(jacrev_timing, \"jacrev\", jacfwd_timing, \"jacfwd\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "c282ce25-4f6e-44cd-aed7-60f6f5010e5b",
+        "id": "uF_9GaoiflUM"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            " Performance delta: 635.2095 percent improvement with jacfwd \n"
+          ]
+        }
+      ],
+      "id": "uF_9GaoiflUM"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Hessian computation with functorch.hessian\n"
+      ],
+      "metadata": {
+        "id": "J29FQaBQflUM"
+      },
+      "id": "J29FQaBQflUM"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We offer a convenience API to compute hessians: `functorch.hessian`. \n",
+        "Hessians are the jacobian of the jacobian (or the partial derivative of the partial derivative, aka second order).\n",
+        "\n",
+        "This suggests that one can just compose functorch’s jacobian transforms to compute the Hessian. \n",
+        "Indeed, under the hood, `hessian(f)` is simply `jacfwd(jacrev(f))`.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "My4DPH97flUM"
+      },
+      "id": "My4DPH97flUM"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Note: to boost performance: depending on your model, you may also want to use `jacfwd(jacfwd(f))` or `jacrev(jacrev(f))` instead to compute hessians leveraging the rule of thumb above regarding wider vs taller matrices.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "FJt038l5flUM"
+      },
+      "id": "FJt038l5flUM"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from functorch import hessian\n",
+        "\n",
+        "# lets reduce the size in order not to blow out colab. Hessians require significant memory:\n",
+        "Din = 512\n",
+        "Dout = 32\n",
+        "weight = torch.randn(Dout, Din)\n",
+        "bias = torch.randn(Dout)\n",
+        "x = torch.randn(Din)\n",
+        "\n",
+        "hess_api = hessian(predict, argnums=2)(weight, bias, x)\n",
+        "hess_fwdfwd = jacfwd(jacfwd(predict, argnums=2), argnums=2)(weight, bias, x)\n",
+        "#hess_revrev = jacrev(jacrev(predict, argnums=2), argnums=2)(weight, bias, x)\n"
+      ],
+      "metadata": {
+        "id": "jEqr2ywZflUM"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "jEqr2ywZflUM"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's verify we have the same result regardless of using hessian api or using jacfwd(jacfwd())"
+      ],
+      "metadata": {
+        "id": "n9BHcICQflUN"
+      },
+      "id": "n9BHcICQflUN"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "torch.allclose(hess_api, hess_fwdfwd)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "e457e3bc-f085-4f90-966d-f98893b98ea8",
+        "id": "eHiWRkjJflUN"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "True"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 18
+        }
+      ],
+      "id": "eHiWRkjJflUN"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Batch Jacobian and Batch Hessian\n"
+      ],
+      "metadata": {
+        "id": "Gjt1RO8HflUN"
+      },
+      "id": "Gjt1RO8HflUN"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In the above examples we’ve been operating with a single feature vector. In some cases you might want to take the Jacobian of a batch of outputs with respect to a batch of inputs. That is, given a batch of inputs of shape `(B, N)` and a function that goes from $R^N \\to R^M$, we would like a Jacobian of shape `(B, M, N)`. \n",
+        "\n",
+        "The easiest way to do this is to use vmap:"
+      ],
+      "metadata": {
+        "id": "RjIzdoQNflUN"
+      },
+      "id": "RjIzdoQNflUN"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "batch_size = 64\n",
+        "Din = 31\n",
+        "Dout = 33\n",
+        "\n",
+        "weight = torch.randn(Dout, Din)\n",
+        "print(f\"weight shape = {weight.shape}\")\n",
+        "\n",
+        "bias = torch.randn(Dout)\n",
+        "\n",
+        "x = torch.randn(batch_size, Din)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "561eb618-e00f-40d5-bd99-fa51ab82051f",
+        "id": "B1eoEO4UflUN"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "weight shape = torch.Size([33, 31])\n"
+          ]
+        }
+      ],
+      "id": "B1eoEO4UflUN"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "compute_batch_jacobian = vmap(jacrev(predict, argnums=2), in_dims=(None, None, 0))\n",
+        "batch_jacobian0 = compute_batch_jacobian(weight, bias, x)"
+      ],
+      "metadata": {
+        "id": "nZ_V02NhflUN"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "nZ_V02NhflUN"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "If you have a function that goes from (B, N) -> (B, M) instead and are certain that each input produces an independent output, then it’s also sometimes possible to do this without using vmap by summing the outputs and then computing the Jacobian of that function:\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "_OLDiY3MflUN"
+      },
+      "id": "_OLDiY3MflUN"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def predict_with_output_summed(weight, bias, x):\n",
+        "    return predict(weight, bias, x).sum(0)\n",
+        "\n",
+        "batch_jacobian1 = jacrev(predict_with_output_summed, argnums=2)(weight, bias, x).movedim(1, 0)\n",
+        "assert torch.allclose(batch_jacobian0, batch_jacobian1)"
+      ],
+      "metadata": {
+        "id": "_QH4hD8PflUO"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "_QH4hD8PflUO"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "If you instead have a function that goes from $𝑅^𝑁 \\to 𝑅^𝑀$ but inputs that are batched, you compose vmap with jacrev to compute batched jacobians:\n",
+        "\n",
+        "Finally, batch hessians can be computed similarly. It’s easiest to think about them by using vmap to batch over hessian computation, but in some cases the sum trick also works.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "eUjw65cCflUO"
+      },
+      "id": "eUjw65cCflUO"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "compute_batch_hessian = vmap(hessian(predict, argnums=2), in_dims=(None, None, 0))\n",
+        "\n",
+        "batch_hess = compute_batch_hessian(weight, bias, x)\n",
+        "batch_hess.shape"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "f3135cfa-e9e5-4f18-8cb7-0655e8a37cb5",
+        "id": "3vAyQjMsflUO"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "torch.Size([64, 33, 31, 31])"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 22
+        }
+      ],
+      "id": "3vAyQjMsflUO"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Computing Hessian-vector products\n",
+        "\n",
+        "The naive way to compute a Hessian-vector product (hvp) is to materialize the full Hessian and perform a dot-product with a vector. We can do better: it turns out we don't need to materialize the full Hessian to do this. We'll go through two (of many) different strategies to compute Hessian-vector products:\n",
+        "- composing reverse-mode AD with reverse-mode AD\n",
+        "- composing reverse-mode AD with forward-mode AD\n",
+        "\n",
+        "Composing reverse-mode AD with forward-mode AD (as opposed to reverse-mode with reverse-mode) is generally the more memory efficient way to compute a hvp because forward-mode AD doesn't need to construct an Autograd graph and save intermediates for backward:"
+      ],
+      "metadata": {
+        "id": "Wa8E48sQgpkb"
+      },
+      "id": "Wa8E48sQgpkb"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from functorch import jvp, grad, vjp\n",
+        "\n",
+        "def hvp(f, primals, tangents):\n",
+        "  return jvp(grad(f), primals, tangents)[1]"
+      ],
+      "metadata": {
+        "id": "trw6WbAth6BM"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "trw6WbAth6BM"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Here's some sample usage."
+      ],
+      "metadata": {
+        "id": "DQMpRo6nitfr"
+      },
+      "id": "DQMpRo6nitfr"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def f(x):\n",
+        "  return x.sin().sum()\n",
+        "\n",
+        "x = torch.randn(2048)\n",
+        "tangent = torch.randn(2048)\n",
+        "\n",
+        "result = hvp(f, (x,), (tangent,))"
+      ],
+      "metadata": {
+        "id": "sPwg8SOdiVAK"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "sPwg8SOdiVAK"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "If PyTorch forward-AD does not have coverage for your operations, then we can instead compose reverse-mode AD with reverse-mode AD:"
+      ],
+      "metadata": {
+        "id": "zGvUIcB0j1Ez"
+      },
+      "id": "zGvUIcB0j1Ez"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def hvp_revrev(f, primals, tangents):\n",
+        "  _, vjp_fn = vjp(grad(f), *primals)\n",
+        "  return vjp_fn(*tangents)"
+      ],
+      "metadata": {
+        "id": "mdDFZdlekAOK"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "mdDFZdlekAOK"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "result_hvp_revrev = hvp_revrev(f, (x,), (tangent,))\n",
+        "assert torch.allclose(result, result_hvp_revrev[0])"
+      ],
+      "metadata": {
+        "id": "_CuCk9X0lW7C"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "_CuCk9X0lW7C"
     }
-   ],
-   "source": [
-    "compute_batch_hessian = vmap(hessian(predict, argnums=2), in_dims=(None, None, 0))\n",
-    "\n",
-    "batch_hess = compute_batch_hessian(weight, bias, x)\n",
-    "batch_hess.shape"
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.3"
+    },
+    "colab": {
+      "name": "jacobians_hessians.ipynb",
+      "provenance": []
+    }
   },
-  {
-   "cell_type": "markdown",
-   "id": "Wa8E48sQgpkb",
-   "metadata": {
-    "id": "Wa8E48sQgpkb"
-   },
-   "source": [
-    "## Computing Hessian-vector products\n",
-    "\n",
-    "The naive way to compute a Hessian-vector product (hvp) is to materialize the full Hessian and perform a dot-product with a vector. We can do better: it turns out we don't need to materialize the full Hessian to do this. We'll go through two (of many) different strategies to compute Hessian-vector products:\n",
-    "- composing reverse-mode AD with reverse-mode AD\n",
-    "- composing reverse-mode AD with forward-mode AD\n",
-    "\n",
-    "Composing reverse-mode AD with forward-mode AD (as opposed to reverse-mode with reverse-mode) is generally the more memory efficient way to compute a hvp because forward-mode AD doesn't need to construct an Autograd graph and save intermediates for backward:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "trw6WbAth6BM",
-   "metadata": {
-    "id": "trw6WbAth6BM"
-   },
-   "outputs": [],
-   "source": [
-    "from functorch import jvp, grad, vjp\n",
-    "\n",
-    "def hvp(f, primals, tangents):\n",
-    "  return jvp(grad(f), primals, tangents)[1]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "DQMpRo6nitfr",
-   "metadata": {
-    "id": "DQMpRo6nitfr"
-   },
-   "source": [
-    "Here's some sample usage."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "sPwg8SOdiVAK",
-   "metadata": {
-    "id": "sPwg8SOdiVAK"
-   },
-   "outputs": [],
-   "source": [
-    "def f(x):\n",
-    "  return x.sin().sum()\n",
-    "\n",
-    "x = torch.randn(2048)\n",
-    "tangent = torch.randn(2048)\n",
-    "\n",
-    "result = hvp(f, (x,), (tangent,))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "zGvUIcB0j1Ez",
-   "metadata": {
-    "id": "zGvUIcB0j1Ez"
-   },
-   "source": [
-    "If PyTorch forward-AD does not have coverage for your operations, then we can instead compose reverse-mode AD with reverse-mode AD:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "mdDFZdlekAOK",
-   "metadata": {
-    "id": "mdDFZdlekAOK"
-   },
-   "outputs": [],
-   "source": [
-    "def hvp_revrev(f, primals, tangents):\n",
-    "  _, vjp_fn = vjp(grad(f), *primals)\n",
-    "  return vjp_fn(*tangents)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "_CuCk9X0lW7C",
-   "metadata": {
-    "id": "_CuCk9X0lW7C"
-   },
-   "outputs": [],
-   "source": [
-    "result_hvp_revrev = hvp_revrev(f, (x,), (tangent,))\n",
-    "assert torch.allclose(result, result_hvp_revrev[0])"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "name": "jacobians_hessians.ipynb",
-   "provenance": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.3"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/functorch/notebooks/per_sample_grads.ipynb
+++ b/functorch/notebooks/per_sample_grads.ipynb
@@ -1,607 +1,607 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "a474c143-05c4-43b6-b12c-17b592d07a6a",
-   "metadata": {
-    "id": "a474c143-05c4-43b6-b12c-17b592d07a6a"
-   },
-   "source": [
-    "# Per-sample-gradients\n",
-    "\n",
-    "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/per_sample_grads.ipynb\">\n",
-    "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
-    "</a>\n",
-    "\n",
-    "## What is it?\n",
-    "\n",
-    "Per-sample-gradient computation is computing the gradient for each and every\n",
-    "sample in a batch of data. It is a useful quantity in differential privacy, meta-learning,\n",
-    "and optimization research.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "Gb-yt4VKUUuc",
-   "metadata": {
-    "id": "Gb-yt4VKUUuc"
-   },
-   "outputs": [],
-   "source": [
-    "import torch\n",
-    "import torch.nn as nn\n",
-    "import torch.nn.functional as F\n",
-    "from functools import partial\n",
-    "\n",
-    "torch.manual_seed(0);"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "tf-HKHjUUbyY",
-   "metadata": {
-    "id": "tf-HKHjUUbyY"
-   },
-   "outputs": [],
-   "source": [
-    "# Here's a simple CNN and loss function:\n",
-    "\n",
-    "class SimpleCNN(nn.Module):\n",
-    "    def __init__(self):\n",
-    "        super().__init__()\n",
-    "        self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
-    "        self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
-    "        self.fc1 = nn.Linear(9216, 128)\n",
-    "        self.fc2 = nn.Linear(128, 10)\n",
-    "\n",
-    "    def forward(self, x):\n",
-    "        x = self.conv1(x)\n",
-    "        x = F.relu(x)\n",
-    "        x = self.conv2(x)\n",
-    "        x = F.relu(x)\n",
-    "        x = F.max_pool2d(x, 2)\n",
-    "        x = torch.flatten(x, 1)\n",
-    "        x = self.fc1(x)\n",
-    "        x = F.relu(x)\n",
-    "        x = self.fc2(x)\n",
-    "        x = F.log_softmax(x, dim=1)\n",
-    "        output = x\n",
-    "        return output\n",
-    "\n",
-    "def loss_fn(predictions, targets):\n",
-    "    return F.nll_loss(predictions, targets)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "VEDPe-EoU5Fa",
-   "metadata": {
-    "id": "VEDPe-EoU5Fa"
-   },
-   "source": [
-    "Let’s generate a batch of dummy data and pretend that we’re working with an MNIST dataset.  \n",
-    "\n",
-    "The dummy images are 28 by 28 and we use a minibatch of size 64.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "WB2Qe3AHUvPN",
-   "metadata": {
-    "id": "WB2Qe3AHUvPN"
-   },
-   "outputs": [],
-   "source": [
-    "device = 'cuda'\n",
-    "\n",
-    "num_models = 10\n",
-    "batch_size = 64\n",
-    "data = torch.randn(batch_size, 1, 28, 28, device=device)\n",
-    "\n",
-    "targets = torch.randint(10, (64,), device=device)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "GOGJ-OUxVcT5",
-   "metadata": {
-    "id": "GOGJ-OUxVcT5"
-   },
-   "source": [
-    "In regular model training, one would forward the minibatch through the model, and then call .backward() to compute gradients.  This would generate an 'average' gradient of the entire mini-batch:\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "WYjMx8QTUvRu",
-   "metadata": {
-    "id": "WYjMx8QTUvRu"
-   },
-   "outputs": [],
-   "source": [
-    "model = SimpleCNN().to(device=device)\n",
-    "predictions = model(data) # move the entire mini-batch through the model\n",
-    "\n",
-    "loss = loss_fn(predictions, targets)\n",
-    "loss.backward() # back propogate the 'average' gradient of this mini-batch"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "HNw4_IVzU5Pz",
-   "metadata": {
-    "id": "HNw4_IVzU5Pz"
-   },
-   "source": [
-    "In contrast to the above approach, per-sample-gradient computation is equivalent to: \n",
-    "- for each individual sample of the data, perform a forward and a backward pass to get an individual (per-sample) gradient.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "vUsb3VfexJrY",
-   "metadata": {
-    "id": "vUsb3VfexJrY"
-   },
-   "outputs": [],
-   "source": [
-    "def compute_grad(sample, target):\n",
-    "    \n",
-    "    sample = sample.unsqueeze(0)  # prepend batch dimension for processing\n",
-    "    target = target.unsqueeze(0)\n",
-    "\n",
-    "    prediction = model(sample)\n",
-    "    loss = loss_fn(prediction, target)\n",
-    "\n",
-    "    return torch.autograd.grad(loss, list(model.parameters()))\n",
-    "\n",
-    "\n",
-    "def compute_sample_grads(data, targets):\n",
-    "    \"\"\" manually process each sample with per sample gradient \"\"\"\n",
-    "    sample_grads = [compute_grad(data[i], targets[i]) for i in range(batch_size)]\n",
-    "    sample_grads = zip(*sample_grads)\n",
-    "    sample_grads = [torch.stack(shards) for shards in sample_grads]\n",
-    "    return sample_grads\n",
-    "\n",
-    "per_sample_grads = compute_sample_grads(data, targets)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "aNkX6lFIxzcm",
-   "metadata": {
-    "id": "aNkX6lFIxzcm"
-   },
-   "source": [
-    "`sample_grads[0]` is the per-sample-grad for model.conv1.weight. `model.conv1.weight.shape` is `[32, 1, 3, 3]`; notice how there is one gradient, per sample, in the batch for a total of 64.\n",
-    "\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "C3a9_clvyPho",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "C3a9_clvyPho",
-    "outputId": "407abc1a-846f-4e50-83bc-c90719a26073"
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "torch.Size([64, 32, 1, 3, 3])\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(per_sample_grads[0].shape)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "mFJDWMM9yaYZ",
-   "metadata": {
-    "id": "mFJDWMM9yaYZ"
-   },
-   "source": [
-    "## Per-sample-grads, *the efficient way*, using functorch\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "tlkmyQyfY6XU",
-   "metadata": {
-    "id": "tlkmyQyfY6XU"
-   },
-   "source": [
-    "We can compute per-sample-gradients efficiently by using function transforms. \n",
-    "\n",
-    "First, let’s create a stateless functional version of `model` by using `functorch.make_functional_with_buffers`.  \n",
-    "\n",
-    "This will separate state (the parameters) from the model and turn the model into a pure function:\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "WiSMupvCyecd",
-   "metadata": {
-    "id": "WiSMupvCyecd"
-   },
-   "outputs": [],
-   "source": [
-    "from functorch import make_functional_with_buffers, vmap, grad\n",
-    "\n",
-    "fmodel, params, buffers = make_functional_with_buffers(model)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "wMsbppPNZklo",
-   "metadata": {
-    "id": "wMsbppPNZklo"
-   },
-   "source": [
-    "Let's review the changes - first, the model has become the stateless FunctionalModuleWithBuffers:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "Xj0cZOJMZbbB",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "Xj0cZOJMZbbB",
-    "outputId": "2e87dfde-3af2-4e1f-cd91-5c232446fb53"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "FunctionalModuleWithBuffers(\n",
-       "  (stateless_model): SimpleCNN(\n",
-       "    (conv1): Conv2d(1, 32, kernel_size=(3, 3), stride=(1, 1))\n",
-       "    (conv2): Conv2d(32, 64, kernel_size=(3, 3), stride=(1, 1))\n",
-       "    (fc1): Linear(in_features=9216, out_features=128, bias=True)\n",
-       "    (fc2): Linear(in_features=128, out_features=10, bias=True)\n",
-       "  )\n",
-       ")"
+      "cell_type": "markdown",
+      "id": "a474c143-05c4-43b6-b12c-17b592d07a6a",
+      "metadata": {
+        "id": "a474c143-05c4-43b6-b12c-17b592d07a6a"
+      },
+      "source": [
+        "# Per-sample-gradients\n",
+        "\n",
+        "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/per_sample_grads.ipynb\">\n",
+        "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+        "</a>\n",
+        "\n",
+        "## What is it?\n",
+        "\n",
+        "Per-sample-gradient computation is computing the gradient for each and every\n",
+        "sample in a batch of data. It is a useful quantity in differential privacy, meta-learning,\n",
+        "and optimization research.\n"
       ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "fmodel"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "zv4_YYPxZvvg",
-   "metadata": {
-    "id": "zv4_YYPxZvvg"
-   },
-   "source": [
-    "And the model parameters now exist independently of the model, stored as a tuple:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "tH0TAZhBZ3bS",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
     },
-    "id": "tH0TAZhBZ3bS",
-    "outputId": "97c4401f-cccb-43f6-b071-c85a18fc439b"
-   },
-   "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "torch.Size([32, 1, 3, 3])\n",
-      "torch.Size([32])\n",
-      "torch.Size([64, 32, 3, 3])\n",
-      "torch.Size([64])\n",
-      "torch.Size([128, 9216])\n",
-      "torch.Size([128])\n",
-      "torch.Size([10, 128])\n",
-      "torch.Size([10])\n",
-      "\n",
-      "<class 'tuple'>\n"
-     ]
-    }
-   ],
-   "source": [
-    "for x in params:\n",
-    "  print(f\"{x.shape}\")\n",
-    "\n",
-    "print(f\"\\n{type(params)}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cTgIIZ9Wyih8",
-   "metadata": {
-    "id": "cTgIIZ9Wyih8"
-   },
-   "source": [
-    "Next, let’s define a function to compute the loss of the model given a single input rather than a batch of inputs. It is important that this function accepts the parameters, the input, and the target, because we will be transforming over them. \n",
-    "\n",
-    "Note - because the model was originally written to handle batches, we’ll use `torch.unsqueeze` to add a batch dimension.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ItURFU3M-p98",
-   "metadata": {
-    "id": "ItURFU3M-p98"
-   },
-   "outputs": [],
-   "source": [
-    "def compute_loss_stateless_model (params, buffers, sample, target):\n",
-    "    batch = sample.unsqueeze(0)\n",
-    "    targets = target.unsqueeze(0)\n",
-    "\n",
-    "    predictions = fmodel(params, buffers, batch) \n",
-    "    loss = loss_fn(predictions, targets)\n",
-    "    return loss"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "Qo3sbDK2i_bH",
-   "metadata": {
-    "id": "Qo3sbDK2i_bH"
-   },
-   "source": [
-    "Now, let’s use functorch's `grad` to create a new function that computes the gradient with respect to the first argument of `compute_loss` (i.e. the params)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "sqRp_Sxni-Xm",
-   "metadata": {
-    "id": "sqRp_Sxni-Xm"
-   },
-   "outputs": [],
-   "source": [
-    "ft_compute_grad = grad(compute_loss_stateless_model)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2pG3Ofqjjc8O",
-   "metadata": {
-    "id": "2pG3Ofqjjc8O"
-   },
-   "source": [
-    "The `ft_compute_grad` function computes the gradient for a single (sample, target) pair. We can use vmap to get it to compute the gradient over an entire batch of samples and targets. Note that `in_dims=(None, None, 0, 0)` because we wish to map `ft_compute_grad` over the 0th dimension of the data and targets,  and use the same params and buffers for each.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "62ecNMO6inqX",
-   "metadata": {
-    "id": "62ecNMO6inqX"
-   },
-   "outputs": [],
-   "source": [
-    "ft_compute_sample_grad = vmap(ft_compute_grad, in_dims=(None, None, 0, 0))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "_alXdQ3QkETu",
-   "metadata": {
-    "id": "_alXdQ3QkETu"
-   },
-   "source": [
-    "Finally, let’s used our transformed function to compute per-sample-gradients:\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1gehVA1c-BHd",
-   "metadata": {
-    "id": "1gehVA1c-BHd"
-   },
-   "outputs": [],
-   "source": [
-    "ft_per_sample_grads = ft_compute_sample_grad(params, buffers, data, targets)\n",
-    "\n",
-    "# we can double check that the results using functorch grad and vmap match the results of hand processing each one individually:\n",
-    "for per_sample_grad, ft_per_sample_grad in zip(per_sample_grads, ft_per_sample_grads):\n",
-    "    assert torch.allclose(per_sample_grad, ft_per_sample_grad, atol=3e-3, rtol=1e-5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "BEZaNt1d_bc1",
-   "metadata": {
-    "id": "BEZaNt1d_bc1"
-   },
-   "source": [
-    "A quick note: there are limitations around what types of functions can be transformed by vmap. The best functions to transform are ones that are pure functions: a function where the outputs are only determined by the inputs, and that have no side effects (e.g. mutation). vmap is unable to handle mutation of arbitrary Python data structures, but it is able to handle many in-place PyTorch operations.\n",
-    "\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "BASP151Iml7B",
-   "metadata": {
-    "id": "BASP151Iml7B"
-   },
-   "source": [
-    "## Performance comparison"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "jr1xNpV4nJ7u",
-   "metadata": {
-    "id": "jr1xNpV4nJ7u"
-   },
-   "source": [
-    "Curious about how the performance of vmap compares?\n",
-    "\n",
-    "Currently the best results are obtained on newer GPU's such as the A100 (Ampere) where we've seen up to 25x speedups on this example, but here are some results done in Colab:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "GnAnMkYmoc-j",
-   "metadata": {
-    "id": "GnAnMkYmoc-j"
-   },
-   "outputs": [],
-   "source": [
-    "def get_perf(first, first_descriptor, second, second_descriptor):\n",
-    "  \"\"\"  takes torch.benchmark objects and compares delta of second vs first. \"\"\"\n",
-    "  second_res = second.times[0]\n",
-    "  first_res = first.times[0]\n",
-    "\n",
-    "  gain = (first_res - second_res) / first_res\n",
-    "  if gain < 0: gain *=-1 \n",
-    "  final_gain = gain * 100\n",
-    "\n",
-    "  print(f\" Performance delta: {final_gain:.4f} percent improvement with {first_descriptor} \")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "Zfnn2C2g-6Fb",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+      "cell_type": "code",
+      "source": [
+        "import torch\n",
+        "import torch.nn as nn\n",
+        "import torch.nn.functional as F\n",
+        "from functools import partial\n",
+        "\n",
+        "torch.manual_seed(0);"
+      ],
+      "metadata": {
+        "id": "Gb-yt4VKUUuc"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "Gb-yt4VKUUuc"
     },
-    "id": "Zfnn2C2g-6Fb",
-    "outputId": "922f3901-773f-446b-b562-88e78f49036c"
-   },
-   "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Per-sample-grads without vmap <torch.utils.benchmark.utils.common.Measurement object at 0x7f71ac3f1850>\n",
-      "compute_sample_grads(data, targets)\n",
-      "  79.86 ms\n",
-      "  1 measurement, 100 runs , 1 thread\n",
-      "Per-sample-grads with vmap <torch.utils.benchmark.utils.common.Measurement object at 0x7f7143e26f10>\n",
-      "ft_compute_sample_grad(params, buffers, data, targets)\n",
-      "  12.93 ms\n",
-      "  1 measurement, 100 runs , 1 thread\n"
-     ]
-    }
-   ],
-   "source": [
-    "from torch.utils.benchmark import Timer\n",
-    "\n",
-    "without_vmap = Timer( stmt=\"compute_sample_grads(data, targets)\", globals=globals())\n",
-    "with_vmap = Timer(stmt=\"ft_compute_sample_grad(params, buffers, data, targets)\",globals=globals())\n",
-    "no_vmap_timing = without_vmap.timeit(100)\n",
-    "with_vmap_timing = with_vmap.timeit(100)\n",
-    "\n",
-    "print(f'Per-sample-grads without vmap {no_vmap_timing}')\n",
-    "print(f'Per-sample-grads with vmap {with_vmap_timing}')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "NV9R3LZQoavl",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+      "cell_type": "code",
+      "source": [
+        "# Here's a simple CNN and loss function:\n",
+        "\n",
+        "class SimpleCNN(nn.Module):\n",
+        "    def __init__(self):\n",
+        "        super().__init__()\n",
+        "        self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
+        "        self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
+        "        self.fc1 = nn.Linear(9216, 128)\n",
+        "        self.fc2 = nn.Linear(128, 10)\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "        x = self.conv1(x)\n",
+        "        x = F.relu(x)\n",
+        "        x = self.conv2(x)\n",
+        "        x = F.relu(x)\n",
+        "        x = F.max_pool2d(x, 2)\n",
+        "        x = torch.flatten(x, 1)\n",
+        "        x = self.fc1(x)\n",
+        "        x = F.relu(x)\n",
+        "        x = self.fc2(x)\n",
+        "        x = F.log_softmax(x, dim=1)\n",
+        "        output = x\n",
+        "        return output\n",
+        "\n",
+        "def loss_fn(predictions, targets):\n",
+        "    return F.nll_loss(predictions, targets)"
+      ],
+      "metadata": {
+        "id": "tf-HKHjUUbyY"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "tf-HKHjUUbyY"
     },
-    "id": "NV9R3LZQoavl",
-    "outputId": "e11e8be9-287d-4e60-e517-e08f8d6909bd"
-   },
-   "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " Performance delta: 517.5791 percent improvement with vmap \n"
-     ]
+      "cell_type": "markdown",
+      "source": [
+        "Let’s generate a batch of dummy data and pretend that we’re working with an MNIST dataset.  \n",
+        "\n",
+        "The dummy images are 28 by 28 and we use a minibatch of size 64.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "VEDPe-EoU5Fa"
+      },
+      "id": "VEDPe-EoU5Fa"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "device = 'cuda'\n",
+        "\n",
+        "num_models = 10\n",
+        "batch_size = 64\n",
+        "data = torch.randn(batch_size, 1, 28, 28, device=device)\n",
+        "\n",
+        "targets = torch.randint(10, (64,), device=device)"
+      ],
+      "metadata": {
+        "id": "WB2Qe3AHUvPN"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "WB2Qe3AHUvPN"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In regular model training, one would forward the minibatch through the model, and then call .backward() to compute gradients.  This would generate an 'average' gradient of the entire mini-batch:\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "GOGJ-OUxVcT5"
+      },
+      "id": "GOGJ-OUxVcT5"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "model = SimpleCNN().to(device=device)\n",
+        "predictions = model(data) # move the entire mini-batch through the model\n",
+        "\n",
+        "loss = loss_fn(predictions, targets)\n",
+        "loss.backward() # back propogate the 'average' gradient of this mini-batch"
+      ],
+      "metadata": {
+        "id": "WYjMx8QTUvRu"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "WYjMx8QTUvRu"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In contrast to the above approach, per-sample-gradient computation is equivalent to: \n",
+        "- for each individual sample of the data, perform a forward and a backward pass to get an individual (per-sample) gradient.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "HNw4_IVzU5Pz"
+      },
+      "id": "HNw4_IVzU5Pz"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def compute_grad(sample, target):\n",
+        "    \n",
+        "    sample = sample.unsqueeze(0)  # prepend batch dimension for processing\n",
+        "    target = target.unsqueeze(0)\n",
+        "\n",
+        "    prediction = model(sample)\n",
+        "    loss = loss_fn(prediction, target)\n",
+        "\n",
+        "    return torch.autograd.grad(loss, list(model.parameters()))\n",
+        "\n",
+        "\n",
+        "def compute_sample_grads(data, targets):\n",
+        "    \"\"\" manually process each sample with per sample gradient \"\"\"\n",
+        "    sample_grads = [compute_grad(data[i], targets[i]) for i in range(batch_size)]\n",
+        "    sample_grads = zip(*sample_grads)\n",
+        "    sample_grads = [torch.stack(shards) for shards in sample_grads]\n",
+        "    return sample_grads\n",
+        "\n",
+        "per_sample_grads = compute_sample_grads(data, targets)"
+      ],
+      "metadata": {
+        "id": "vUsb3VfexJrY"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "vUsb3VfexJrY"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "`sample_grads[0]` is the per-sample-grad for model.conv1.weight. `model.conv1.weight.shape` is `[32, 1, 3, 3]`; notice how there is one gradient, per sample, in the batch for a total of 64.\n",
+        "\n",
+        "\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "aNkX6lFIxzcm"
+      },
+      "id": "aNkX6lFIxzcm"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(per_sample_grads[0].shape)"
+      ],
+      "metadata": {
+        "id": "C3a9_clvyPho",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "407abc1a-846f-4e50-83bc-c90719a26073"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "torch.Size([64, 32, 1, 3, 3])\n"
+          ]
+        }
+      ],
+      "id": "C3a9_clvyPho"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Per-sample-grads, *the efficient way*, using functorch\n",
+        "\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "mFJDWMM9yaYZ"
+      },
+      "id": "mFJDWMM9yaYZ"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can compute per-sample-gradients efficiently by using function transforms. \n",
+        "\n",
+        "First, let’s create a stateless functional version of `model` by using `functorch.make_functional_with_buffers`.  \n",
+        "\n",
+        "This will separate state (the parameters) from the model and turn the model into a pure function:\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "tlkmyQyfY6XU"
+      },
+      "id": "tlkmyQyfY6XU"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from functorch import make_functional_with_buffers, vmap, grad\n",
+        "\n",
+        "fmodel, params, buffers = make_functional_with_buffers(model)"
+      ],
+      "metadata": {
+        "id": "WiSMupvCyecd"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "WiSMupvCyecd"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's review the changes - first, the model has become the stateless FunctionalModuleWithBuffers:"
+      ],
+      "metadata": {
+        "id": "wMsbppPNZklo"
+      },
+      "id": "wMsbppPNZklo"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "fmodel"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Xj0cZOJMZbbB",
+        "outputId": "2e87dfde-3af2-4e1f-cd91-5c232446fb53"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "FunctionalModuleWithBuffers(\n",
+              "  (stateless_model): SimpleCNN(\n",
+              "    (conv1): Conv2d(1, 32, kernel_size=(3, 3), stride=(1, 1))\n",
+              "    (conv2): Conv2d(32, 64, kernel_size=(3, 3), stride=(1, 1))\n",
+              "    (fc1): Linear(in_features=9216, out_features=128, bias=True)\n",
+              "    (fc2): Linear(in_features=128, out_features=10, bias=True)\n",
+              "  )\n",
+              ")"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 15
+        }
+      ],
+      "id": "Xj0cZOJMZbbB"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "And the model parameters now exist independently of the model, stored as a tuple:"
+      ],
+      "metadata": {
+        "id": "zv4_YYPxZvvg"
+      },
+      "id": "zv4_YYPxZvvg"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "for x in params:\n",
+        "  print(f\"{x.shape}\")\n",
+        "\n",
+        "print(f\"\\n{type(params)}\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "tH0TAZhBZ3bS",
+        "outputId": "97c4401f-cccb-43f6-b071-c85a18fc439b"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "torch.Size([32, 1, 3, 3])\n",
+            "torch.Size([32])\n",
+            "torch.Size([64, 32, 3, 3])\n",
+            "torch.Size([64])\n",
+            "torch.Size([128, 9216])\n",
+            "torch.Size([128])\n",
+            "torch.Size([10, 128])\n",
+            "torch.Size([10])\n",
+            "\n",
+            "<class 'tuple'>\n"
+          ]
+        }
+      ],
+      "id": "tH0TAZhBZ3bS"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Next, let’s define a function to compute the loss of the model given a single input rather than a batch of inputs. It is important that this function accepts the parameters, the input, and the target, because we will be transforming over them. \n",
+        "\n",
+        "Note - because the model was originally written to handle batches, we’ll use `torch.unsqueeze` to add a batch dimension.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "cTgIIZ9Wyih8"
+      },
+      "id": "cTgIIZ9Wyih8"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def compute_loss_stateless_model (params, buffers, sample, target):\n",
+        "    batch = sample.unsqueeze(0)\n",
+        "    targets = target.unsqueeze(0)\n",
+        "\n",
+        "    predictions = fmodel(params, buffers, batch) \n",
+        "    loss = loss_fn(predictions, targets)\n",
+        "    return loss"
+      ],
+      "metadata": {
+        "id": "ItURFU3M-p98"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "ItURFU3M-p98"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now, let’s use functorch's `grad` to create a new function that computes the gradient with respect to the first argument of `compute_loss` (i.e. the params)."
+      ],
+      "metadata": {
+        "id": "Qo3sbDK2i_bH"
+      },
+      "id": "Qo3sbDK2i_bH"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "ft_compute_grad = grad(compute_loss_stateless_model)"
+      ],
+      "metadata": {
+        "id": "sqRp_Sxni-Xm"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "sqRp_Sxni-Xm"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The `ft_compute_grad` function computes the gradient for a single (sample, target) pair. We can use vmap to get it to compute the gradient over an entire batch of samples and targets. Note that `in_dims=(None, None, 0, 0)` because we wish to map `ft_compute_grad` over the 0th dimension of the data and targets,  and use the same params and buffers for each.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "2pG3Ofqjjc8O"
+      },
+      "id": "2pG3Ofqjjc8O"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "ft_compute_sample_grad = vmap(ft_compute_grad, in_dims=(None, None, 0, 0))"
+      ],
+      "metadata": {
+        "id": "62ecNMO6inqX"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "62ecNMO6inqX"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Finally, let’s used our transformed function to compute per-sample-gradients:\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "_alXdQ3QkETu"
+      },
+      "id": "_alXdQ3QkETu"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "ft_per_sample_grads = ft_compute_sample_grad(params, buffers, data, targets)\n",
+        "\n",
+        "# we can double check that the results using functorch grad and vmap match the results of hand processing each one individually:\n",
+        "for per_sample_grad, ft_per_sample_grad in zip(per_sample_grads, ft_per_sample_grads):\n",
+        "    assert torch.allclose(per_sample_grad, ft_per_sample_grad, atol=3e-3, rtol=1e-5)"
+      ],
+      "metadata": {
+        "id": "1gehVA1c-BHd"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "1gehVA1c-BHd"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "A quick note: there are limitations around what types of functions can be transformed by vmap. The best functions to transform are ones that are pure functions: a function where the outputs are only determined by the inputs, and that have no side effects (e.g. mutation). vmap is unable to handle mutation of arbitrary Python data structures, but it is able to handle many in-place PyTorch operations.\n",
+        "\n",
+        "\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "BEZaNt1d_bc1"
+      },
+      "id": "BEZaNt1d_bc1"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Performance comparison"
+      ],
+      "metadata": {
+        "id": "BASP151Iml7B"
+      },
+      "id": "BASP151Iml7B"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Curious about how the performance of vmap compares?\n",
+        "\n",
+        "Currently the best results are obtained on newer GPU's such as the A100 (Ampere) where we've seen up to 25x speedups on this example, but here are some results done in Colab:"
+      ],
+      "metadata": {
+        "id": "jr1xNpV4nJ7u"
+      },
+      "id": "jr1xNpV4nJ7u"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def get_perf(first, first_descriptor, second, second_descriptor):\n",
+        "  \"\"\"  takes torch.benchmark objects and compares delta of second vs first. \"\"\"\n",
+        "  second_res = second.times[0]\n",
+        "  first_res = first.times[0]\n",
+        "\n",
+        "  gain = (first_res-second_res)/first_res\n",
+        "  if gain < 0: gain *=-1 \n",
+        "  final_gain = gain*100\n",
+        "\n",
+        "  print(f\" Performance delta: {final_gain:.4f} percent improvement with {first_descriptor} \")"
+      ],
+      "metadata": {
+        "id": "GnAnMkYmoc-j"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "GnAnMkYmoc-j"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from torch.utils.benchmark import Timer\n",
+        "\n",
+        "without_vmap = Timer( stmt=\"compute_sample_grads(data, targets)\", globals=globals())\n",
+        "with_vmap = Timer(stmt=\"ft_compute_sample_grad(params, buffers, data, targets)\",globals=globals())\n",
+        "no_vmap_timing = without_vmap.timeit(100)\n",
+        "with_vmap_timing = with_vmap.timeit(100)\n",
+        "\n",
+        "print(f'Per-sample-grads without vmap {no_vmap_timing}')\n",
+        "print(f'Per-sample-grads with vmap {with_vmap_timing}')"
+      ],
+      "metadata": {
+        "id": "Zfnn2C2g-6Fb",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "922f3901-773f-446b-b562-88e78f49036c"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Per-sample-grads without vmap <torch.utils.benchmark.utils.common.Measurement object at 0x7f71ac3f1850>\n",
+            "compute_sample_grads(data, targets)\n",
+            "  79.86 ms\n",
+            "  1 measurement, 100 runs , 1 thread\n",
+            "Per-sample-grads with vmap <torch.utils.benchmark.utils.common.Measurement object at 0x7f7143e26f10>\n",
+            "ft_compute_sample_grad(params, buffers, data, targets)\n",
+            "  12.93 ms\n",
+            "  1 measurement, 100 runs , 1 thread\n"
+          ]
+        }
+      ],
+      "id": "Zfnn2C2g-6Fb"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "get_perf(with_vmap_timing, \"vmap\", no_vmap_timing,\"no vmap\" )"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "NV9R3LZQoavl",
+        "outputId": "e11e8be9-287d-4e60-e517-e08f8d6909bd"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            " Performance delta: 517.5791 percent improvement with vmap \n"
+          ]
+        }
+      ],
+      "id": "NV9R3LZQoavl"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "There are other optimized solutions (like in https://github.com/pytorch/opacus) to computing per-sample-gradients in PyTorch that also perform better than the naive method. But it’s cool that composing `vmap` and `grad` give us a nice speedup.\n",
+        "\n",
+        "\n",
+        "In general, vectorization with vmap should be faster than running a function in a for-loop and competitive with manual batching. There are some exceptions though, like if we haven’t implemented the vmap rule for a particular operation or if the underlying kernels weren’t optimized for older hardware (GPUs). If you see any of these cases, please let us know by opening an issue at our [GitHub](https://github.com/pytorch/functorch)!\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "UI74G9JarQU8"
+      },
+      "id": "UI74G9JarQU8"
     }
-   ],
-   "source": [
-    "get_perf(with_vmap_timing, \"vmap\", no_vmap_timing,\"no vmap\" )"
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.5"
+    },
+    "colab": {
+      "name": "per_sample_grads.ipynb",
+      "provenance": []
+    }
   },
-  {
-   "cell_type": "markdown",
-   "id": "UI74G9JarQU8",
-   "metadata": {
-    "id": "UI74G9JarQU8"
-   },
-   "source": [
-    "There are other optimized solutions (like in https://github.com/pytorch/opacus) to computing per-sample-gradients in PyTorch that also perform better than the naive method. But it’s cool that composing `vmap` and `grad` give us a nice speedup.\n",
-    "\n",
-    "\n",
-    "In general, vectorization with vmap should be faster than running a function in a for-loop and competitive with manual batching. There are some exceptions though, like if we haven’t implemented the vmap rule for a particular operation or if the underlying kernels weren’t optimized for older hardware (GPUs). If you see any of these cases, please let us know by opening an issue at our [GitHub](https://github.com/pytorch/functorch)!\n",
-    "\n"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "name": "per_sample_grads.ipynb",
-   "provenance": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.5"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/functorch/notebooks/per_sample_grads.ipynb
+++ b/functorch/notebooks/per_sample_grads.ipynb
@@ -1,607 +1,607 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "a474c143-05c4-43b6-b12c-17b592d07a6a",
-      "metadata": {
-        "id": "a474c143-05c4-43b6-b12c-17b592d07a6a"
-      },
-      "source": [
-        "# Per-sample-gradients\n",
-        "\n",
-        "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/per_sample_grads.ipynb\">\n",
-        "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
-        "</a>\n",
-        "\n",
-        "## What is it?\n",
-        "\n",
-        "Per-sample-gradient computation is computing the gradient for each and every\n",
-        "sample in a batch of data. It is a useful quantity in differential privacy, meta-learning,\n",
-        "and optimization research.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import torch\n",
-        "import torch.nn as nn\n",
-        "import torch.nn.functional as F\n",
-        "from functools import partial\n",
-        "\n",
-        "torch.manual_seed(0);"
-      ],
-      "metadata": {
-        "id": "Gb-yt4VKUUuc"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "Gb-yt4VKUUuc"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Here's a simple CNN and loss function:\n",
-        "\n",
-        "class SimpleCNN(nn.Module):\n",
-        "    def __init__(self):\n",
-        "        super().__init__()\n",
-        "        self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
-        "        self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
-        "        self.fc1 = nn.Linear(9216, 128)\n",
-        "        self.fc2 = nn.Linear(128, 10)\n",
-        "\n",
-        "    def forward(self, x):\n",
-        "        x = self.conv1(x)\n",
-        "        x = F.relu(x)\n",
-        "        x = self.conv2(x)\n",
-        "        x = F.relu(x)\n",
-        "        x = F.max_pool2d(x, 2)\n",
-        "        x = torch.flatten(x, 1)\n",
-        "        x = self.fc1(x)\n",
-        "        x = F.relu(x)\n",
-        "        x = self.fc2(x)\n",
-        "        x = F.log_softmax(x, dim=1)\n",
-        "        output = x\n",
-        "        return output\n",
-        "\n",
-        "def loss_fn(predictions, targets):\n",
-        "    return F.nll_loss(predictions, targets)"
-      ],
-      "metadata": {
-        "id": "tf-HKHjUUbyY"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "tf-HKHjUUbyY"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Let’s generate a batch of dummy data and pretend that we’re working with an MNIST dataset.  \n",
-        "\n",
-        "The dummy images are 28 by 28 and we use a minibatch of size 64.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "VEDPe-EoU5Fa"
-      },
-      "id": "VEDPe-EoU5Fa"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "device = 'cuda'\n",
-        "\n",
-        "num_models = 10\n",
-        "batch_size = 64\n",
-        "data = torch.randn(batch_size, 1, 28, 28, device=device)\n",
-        "\n",
-        "targets = torch.randint(10, (64,), device=device)"
-      ],
-      "metadata": {
-        "id": "WB2Qe3AHUvPN"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "WB2Qe3AHUvPN"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "In regular model training, one would forward the minibatch through the model, and then call .backward() to compute gradients.  This would generate an 'average' gradient of the entire mini-batch:\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "GOGJ-OUxVcT5"
-      },
-      "id": "GOGJ-OUxVcT5"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "model = SimpleCNN().to(device=device)\n",
-        "predictions = model(data) # move the entire mini-batch through the model\n",
-        "\n",
-        "loss = loss_fn(predictions, targets)\n",
-        "loss.backward() # back propogate the 'average' gradient of this mini-batch"
-      ],
-      "metadata": {
-        "id": "WYjMx8QTUvRu"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "WYjMx8QTUvRu"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "In contrast to the above approach, per-sample-gradient computation is equivalent to: \n",
-        "- for each individual sample of the data, perform a forward and a backward pass to get an individual (per-sample) gradient.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "HNw4_IVzU5Pz"
-      },
-      "id": "HNw4_IVzU5Pz"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def compute_grad(sample, target):\n",
-        "    \n",
-        "    sample = sample.unsqueeze(0)  # prepend batch dimension for processing\n",
-        "    target = target.unsqueeze(0)\n",
-        "\n",
-        "    prediction = model(sample)\n",
-        "    loss = loss_fn(prediction, target)\n",
-        "\n",
-        "    return torch.autograd.grad(loss, list(model.parameters()))\n",
-        "\n",
-        "\n",
-        "def compute_sample_grads(data, targets):\n",
-        "    \"\"\" manually process each sample with per sample gradient \"\"\"\n",
-        "    sample_grads = [compute_grad(data[i], targets[i]) for i in range(batch_size)]\n",
-        "    sample_grads = zip(*sample_grads)\n",
-        "    sample_grads = [torch.stack(shards) for shards in sample_grads]\n",
-        "    return sample_grads\n",
-        "\n",
-        "per_sample_grads = compute_sample_grads(data, targets)"
-      ],
-      "metadata": {
-        "id": "vUsb3VfexJrY"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "vUsb3VfexJrY"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "`sample_grads[0]` is the per-sample-grad for model.conv1.weight. `model.conv1.weight.shape` is `[32, 1, 3, 3]`; notice how there is one gradient, per sample, in the batch for a total of 64.\n",
-        "\n",
-        "\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "aNkX6lFIxzcm"
-      },
-      "id": "aNkX6lFIxzcm"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "print(per_sample_grads[0].shape)"
-      ],
-      "metadata": {
-        "id": "C3a9_clvyPho",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "407abc1a-846f-4e50-83bc-c90719a26073"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "torch.Size([64, 32, 1, 3, 3])\n"
-          ]
-        }
-      ],
-      "id": "C3a9_clvyPho"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Per-sample-grads, *the efficient way*, using functorch\n",
-        "\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "mFJDWMM9yaYZ"
-      },
-      "id": "mFJDWMM9yaYZ"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "We can compute per-sample-gradients efficiently by using function transforms. \n",
-        "\n",
-        "First, let’s create a stateless functional version of `model` by using `functorch.make_functional_with_buffers`.  \n",
-        "\n",
-        "This will separate state (the parameters) from the model and turn the model into a pure function:\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "tlkmyQyfY6XU"
-      },
-      "id": "tlkmyQyfY6XU"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from functorch import make_functional_with_buffers, vmap, grad\n",
-        "\n",
-        "fmodel, params, buffers = make_functional_with_buffers(model)"
-      ],
-      "metadata": {
-        "id": "WiSMupvCyecd"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "WiSMupvCyecd"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Let's review the changes - first, the model has become the stateless FunctionalModuleWithBuffers:"
-      ],
-      "metadata": {
-        "id": "wMsbppPNZklo"
-      },
-      "id": "wMsbppPNZklo"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "fmodel"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "Xj0cZOJMZbbB",
-        "outputId": "2e87dfde-3af2-4e1f-cd91-5c232446fb53"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "FunctionalModuleWithBuffers(\n",
-              "  (stateless_model): SimpleCNN(\n",
-              "    (conv1): Conv2d(1, 32, kernel_size=(3, 3), stride=(1, 1))\n",
-              "    (conv2): Conv2d(32, 64, kernel_size=(3, 3), stride=(1, 1))\n",
-              "    (fc1): Linear(in_features=9216, out_features=128, bias=True)\n",
-              "    (fc2): Linear(in_features=128, out_features=10, bias=True)\n",
-              "  )\n",
-              ")"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 15
-        }
-      ],
-      "id": "Xj0cZOJMZbbB"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "And the model parameters now exist independently of the model, stored as a tuple:"
-      ],
-      "metadata": {
-        "id": "zv4_YYPxZvvg"
-      },
-      "id": "zv4_YYPxZvvg"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "for x in params:\n",
-        "  print(f\"{x.shape}\")\n",
-        "\n",
-        "print(f\"\\n{type(params)}\")"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "tH0TAZhBZ3bS",
-        "outputId": "97c4401f-cccb-43f6-b071-c85a18fc439b"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "torch.Size([32, 1, 3, 3])\n",
-            "torch.Size([32])\n",
-            "torch.Size([64, 32, 3, 3])\n",
-            "torch.Size([64])\n",
-            "torch.Size([128, 9216])\n",
-            "torch.Size([128])\n",
-            "torch.Size([10, 128])\n",
-            "torch.Size([10])\n",
-            "\n",
-            "<class 'tuple'>\n"
-          ]
-        }
-      ],
-      "id": "tH0TAZhBZ3bS"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Next, let’s define a function to compute the loss of the model given a single input rather than a batch of inputs. It is important that this function accepts the parameters, the input, and the target, because we will be transforming over them. \n",
-        "\n",
-        "Note - because the model was originally written to handle batches, we’ll use `torch.unsqueeze` to add a batch dimension.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "cTgIIZ9Wyih8"
-      },
-      "id": "cTgIIZ9Wyih8"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def compute_loss_stateless_model (params, buffers, sample, target):\n",
-        "    batch = sample.unsqueeze(0)\n",
-        "    targets = target.unsqueeze(0)\n",
-        "\n",
-        "    predictions = fmodel(params, buffers, batch) \n",
-        "    loss = loss_fn(predictions, targets)\n",
-        "    return loss"
-      ],
-      "metadata": {
-        "id": "ItURFU3M-p98"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "ItURFU3M-p98"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Now, let’s use functorch's `grad` to create a new function that computes the gradient with respect to the first argument of `compute_loss` (i.e. the params)."
-      ],
-      "metadata": {
-        "id": "Qo3sbDK2i_bH"
-      },
-      "id": "Qo3sbDK2i_bH"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "ft_compute_grad = grad(compute_loss_stateless_model)"
-      ],
-      "metadata": {
-        "id": "sqRp_Sxni-Xm"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "sqRp_Sxni-Xm"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "The `ft_compute_grad` function computes the gradient for a single (sample, target) pair. We can use vmap to get it to compute the gradient over an entire batch of samples and targets. Note that `in_dims=(None, None, 0, 0)` because we wish to map `ft_compute_grad` over the 0th dimension of the data and targets,  and use the same params and buffers for each.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "2pG3Ofqjjc8O"
-      },
-      "id": "2pG3Ofqjjc8O"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "ft_compute_sample_grad = vmap(ft_compute_grad, in_dims=(None, None, 0, 0))"
-      ],
-      "metadata": {
-        "id": "62ecNMO6inqX"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "62ecNMO6inqX"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Finally, let’s used our transformed function to compute per-sample-gradients:\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "_alXdQ3QkETu"
-      },
-      "id": "_alXdQ3QkETu"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "ft_per_sample_grads = ft_compute_sample_grad(params, buffers, data, targets)\n",
-        "\n",
-        "# we can double check that the results using functorch grad and vmap match the results of hand processing each one individually:\n",
-        "for per_sample_grad, ft_per_sample_grad in zip(per_sample_grads, ft_per_sample_grads):\n",
-        "    assert torch.allclose(per_sample_grad, ft_per_sample_grad, atol=3e-3, rtol=1e-5)"
-      ],
-      "metadata": {
-        "id": "1gehVA1c-BHd"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "1gehVA1c-BHd"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "A quick note: there are limitations around what types of functions can be transformed by vmap. The best functions to transform are ones that are pure functions: a function where the outputs are only determined by the inputs, and that have no side effects (e.g. mutation). vmap is unable to handle mutation of arbitrary Python data structures, but it is able to handle many in-place PyTorch operations.\n",
-        "\n",
-        "\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "BEZaNt1d_bc1"
-      },
-      "id": "BEZaNt1d_bc1"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Performance comparison"
-      ],
-      "metadata": {
-        "id": "BASP151Iml7B"
-      },
-      "id": "BASP151Iml7B"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Curious about how the performance of vmap compares?\n",
-        "\n",
-        "Currently the best results are obtained on newer GPU's such as the A100 (Ampere) where we've seen up to 25x speedups on this example, but here are some results done in Colab:"
-      ],
-      "metadata": {
-        "id": "jr1xNpV4nJ7u"
-      },
-      "id": "jr1xNpV4nJ7u"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def get_perf(first, first_descriptor, second, second_descriptor):\n",
-        "  \"\"\"  takes torch.benchmark objects and compares delta of second vs first. \"\"\"\n",
-        "  second_res = second.times[0]\n",
-        "  first_res = first.times[0]\n",
-        "\n",
-        "  gain = (first_res-second_res)/first_res\n",
-        "  if gain < 0: gain *=-1 \n",
-        "  final_gain = gain*100\n",
-        "\n",
-        "  print(f\" Performance delta: {final_gain:.4f} percent improvement with {first_descriptor} \")"
-      ],
-      "metadata": {
-        "id": "GnAnMkYmoc-j"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "id": "GnAnMkYmoc-j"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from torch.utils.benchmark import Timer\n",
-        "\n",
-        "without_vmap = Timer( stmt=\"compute_sample_grads(data, targets)\", globals=globals())\n",
-        "with_vmap = Timer(stmt=\"ft_compute_sample_grad(params, buffers, data, targets)\",globals=globals())\n",
-        "no_vmap_timing = without_vmap.timeit(100)\n",
-        "with_vmap_timing = with_vmap.timeit(100)\n",
-        "\n",
-        "print(f'Per-sample-grads without vmap {no_vmap_timing}')\n",
-        "print(f'Per-sample-grads with vmap {with_vmap_timing}')"
-      ],
-      "metadata": {
-        "id": "Zfnn2C2g-6Fb",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "922f3901-773f-446b-b562-88e78f49036c"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Per-sample-grads without vmap <torch.utils.benchmark.utils.common.Measurement object at 0x7f71ac3f1850>\n",
-            "compute_sample_grads(data, targets)\n",
-            "  79.86 ms\n",
-            "  1 measurement, 100 runs , 1 thread\n",
-            "Per-sample-grads with vmap <torch.utils.benchmark.utils.common.Measurement object at 0x7f7143e26f10>\n",
-            "ft_compute_sample_grad(params, buffers, data, targets)\n",
-            "  12.93 ms\n",
-            "  1 measurement, 100 runs , 1 thread\n"
-          ]
-        }
-      ],
-      "id": "Zfnn2C2g-6Fb"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "get_perf(with_vmap_timing, \"vmap\", no_vmap_timing,\"no vmap\" )"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "NV9R3LZQoavl",
-        "outputId": "e11e8be9-287d-4e60-e517-e08f8d6909bd"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            " Performance delta: 517.5791 percent improvement with vmap \n"
-          ]
-        }
-      ],
-      "id": "NV9R3LZQoavl"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "There are other optimized solutions (like in https://github.com/pytorch/opacus) to computing per-sample-gradients in PyTorch that also perform better than the naive method. But it’s cool that composing `vmap` and `grad` give us a nice speedup.\n",
-        "\n",
-        "\n",
-        "In general, vectorization with vmap should be faster than running a function in a for-loop and competitive with manual batching. There are some exceptions though, like if we haven’t implemented the vmap rule for a particular operation or if the underlying kernels weren’t optimized for older hardware (GPUs). If you see any of these cases, please let us know by opening an issue at our [GitHub](https://github.com/pytorch/functorch)!\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "UI74G9JarQU8"
-      },
-      "id": "UI74G9JarQU8"
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.5"
-    },
-    "colab": {
-      "name": "per_sample_grads.ipynb",
-      "provenance": []
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a474c143-05c4-43b6-b12c-17b592d07a6a",
+   "metadata": {
+    "id": "a474c143-05c4-43b6-b12c-17b592d07a6a"
+   },
+   "source": [
+    "# Per-sample-gradients\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/per_sample_grads.ipynb\">\n",
+    "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+    "</a>\n",
+    "\n",
+    "## What is it?\n",
+    "\n",
+    "Per-sample-gradient computation is computing the gradient for each and every\n",
+    "sample in a batch of data. It is a useful quantity in differential privacy, meta-learning,\n",
+    "and optimization research.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Gb-yt4VKUUuc",
+   "metadata": {
+    "id": "Gb-yt4VKUUuc"
+   },
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F\n",
+    "from functools import partial\n",
+    "\n",
+    "torch.manual_seed(0);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "tf-HKHjUUbyY",
+   "metadata": {
+    "id": "tf-HKHjUUbyY"
+   },
+   "outputs": [],
+   "source": [
+    "# Here's a simple CNN and loss function:\n",
+    "\n",
+    "class SimpleCNN(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
+    "        self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
+    "        self.fc1 = nn.Linear(9216, 128)\n",
+    "        self.fc2 = nn.Linear(128, 10)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        x = self.conv1(x)\n",
+    "        x = F.relu(x)\n",
+    "        x = self.conv2(x)\n",
+    "        x = F.relu(x)\n",
+    "        x = F.max_pool2d(x, 2)\n",
+    "        x = torch.flatten(x, 1)\n",
+    "        x = self.fc1(x)\n",
+    "        x = F.relu(x)\n",
+    "        x = self.fc2(x)\n",
+    "        x = F.log_softmax(x, dim=1)\n",
+    "        output = x\n",
+    "        return output\n",
+    "\n",
+    "def loss_fn(predictions, targets):\n",
+    "    return F.nll_loss(predictions, targets)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "VEDPe-EoU5Fa",
+   "metadata": {
+    "id": "VEDPe-EoU5Fa"
+   },
+   "source": [
+    "Let’s generate a batch of dummy data and pretend that we’re working with an MNIST dataset.  \n",
+    "\n",
+    "The dummy images are 28 by 28 and we use a minibatch of size 64.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "WB2Qe3AHUvPN",
+   "metadata": {
+    "id": "WB2Qe3AHUvPN"
+   },
+   "outputs": [],
+   "source": [
+    "device = 'cuda'\n",
+    "\n",
+    "num_models = 10\n",
+    "batch_size = 64\n",
+    "data = torch.randn(batch_size, 1, 28, 28, device=device)\n",
+    "\n",
+    "targets = torch.randint(10, (64,), device=device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "GOGJ-OUxVcT5",
+   "metadata": {
+    "id": "GOGJ-OUxVcT5"
+   },
+   "source": [
+    "In regular model training, one would forward the minibatch through the model, and then call .backward() to compute gradients.  This would generate an 'average' gradient of the entire mini-batch:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "WYjMx8QTUvRu",
+   "metadata": {
+    "id": "WYjMx8QTUvRu"
+   },
+   "outputs": [],
+   "source": [
+    "model = SimpleCNN().to(device=device)\n",
+    "predictions = model(data) # move the entire mini-batch through the model\n",
+    "\n",
+    "loss = loss_fn(predictions, targets)\n",
+    "loss.backward() # back propogate the 'average' gradient of this mini-batch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "HNw4_IVzU5Pz",
+   "metadata": {
+    "id": "HNw4_IVzU5Pz"
+   },
+   "source": [
+    "In contrast to the above approach, per-sample-gradient computation is equivalent to: \n",
+    "- for each individual sample of the data, perform a forward and a backward pass to get an individual (per-sample) gradient.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "vUsb3VfexJrY",
+   "metadata": {
+    "id": "vUsb3VfexJrY"
+   },
+   "outputs": [],
+   "source": [
+    "def compute_grad(sample, target):\n",
+    "    \n",
+    "    sample = sample.unsqueeze(0)  # prepend batch dimension for processing\n",
+    "    target = target.unsqueeze(0)\n",
+    "\n",
+    "    prediction = model(sample)\n",
+    "    loss = loss_fn(prediction, target)\n",
+    "\n",
+    "    return torch.autograd.grad(loss, list(model.parameters()))\n",
+    "\n",
+    "\n",
+    "def compute_sample_grads(data, targets):\n",
+    "    \"\"\" manually process each sample with per sample gradient \"\"\"\n",
+    "    sample_grads = [compute_grad(data[i], targets[i]) for i in range(batch_size)]\n",
+    "    sample_grads = zip(*sample_grads)\n",
+    "    sample_grads = [torch.stack(shards) for shards in sample_grads]\n",
+    "    return sample_grads\n",
+    "\n",
+    "per_sample_grads = compute_sample_grads(data, targets)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aNkX6lFIxzcm",
+   "metadata": {
+    "id": "aNkX6lFIxzcm"
+   },
+   "source": [
+    "`sample_grads[0]` is the per-sample-grad for model.conv1.weight. `model.conv1.weight.shape` is `[32, 1, 3, 3]`; notice how there is one gradient, per sample, in the batch for a total of 64.\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "C3a9_clvyPho",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "C3a9_clvyPho",
+    "outputId": "407abc1a-846f-4e50-83bc-c90719a26073"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([64, 32, 1, 3, 3])\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(per_sample_grads[0].shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "mFJDWMM9yaYZ",
+   "metadata": {
+    "id": "mFJDWMM9yaYZ"
+   },
+   "source": [
+    "## Per-sample-grads, *the efficient way*, using functorch\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tlkmyQyfY6XU",
+   "metadata": {
+    "id": "tlkmyQyfY6XU"
+   },
+   "source": [
+    "We can compute per-sample-gradients efficiently by using function transforms. \n",
+    "\n",
+    "First, let’s create a stateless functional version of `model` by using `functorch.make_functional_with_buffers`.  \n",
+    "\n",
+    "This will separate state (the parameters) from the model and turn the model into a pure function:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "WiSMupvCyecd",
+   "metadata": {
+    "id": "WiSMupvCyecd"
+   },
+   "outputs": [],
+   "source": [
+    "from functorch import make_functional_with_buffers, vmap, grad\n",
+    "\n",
+    "fmodel, params, buffers = make_functional_with_buffers(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wMsbppPNZklo",
+   "metadata": {
+    "id": "wMsbppPNZklo"
+   },
+   "source": [
+    "Let's review the changes - first, the model has become the stateless FunctionalModuleWithBuffers:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Xj0cZOJMZbbB",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Xj0cZOJMZbbB",
+    "outputId": "2e87dfde-3af2-4e1f-cd91-5c232446fb53"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "FunctionalModuleWithBuffers(\n",
+       "  (stateless_model): SimpleCNN(\n",
+       "    (conv1): Conv2d(1, 32, kernel_size=(3, 3), stride=(1, 1))\n",
+       "    (conv2): Conv2d(32, 64, kernel_size=(3, 3), stride=(1, 1))\n",
+       "    (fc1): Linear(in_features=9216, out_features=128, bias=True)\n",
+       "    (fc2): Linear(in_features=128, out_features=10, bias=True)\n",
+       "  )\n",
+       ")"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fmodel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "zv4_YYPxZvvg",
+   "metadata": {
+    "id": "zv4_YYPxZvvg"
+   },
+   "source": [
+    "And the model parameters now exist independently of the model, stored as a tuple:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "tH0TAZhBZ3bS",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "tH0TAZhBZ3bS",
+    "outputId": "97c4401f-cccb-43f6-b071-c85a18fc439b"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([32, 1, 3, 3])\n",
+      "torch.Size([32])\n",
+      "torch.Size([64, 32, 3, 3])\n",
+      "torch.Size([64])\n",
+      "torch.Size([128, 9216])\n",
+      "torch.Size([128])\n",
+      "torch.Size([10, 128])\n",
+      "torch.Size([10])\n",
+      "\n",
+      "<class 'tuple'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "for x in params:\n",
+    "  print(f\"{x.shape}\")\n",
+    "\n",
+    "print(f\"\\n{type(params)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cTgIIZ9Wyih8",
+   "metadata": {
+    "id": "cTgIIZ9Wyih8"
+   },
+   "source": [
+    "Next, let’s define a function to compute the loss of the model given a single input rather than a batch of inputs. It is important that this function accepts the parameters, the input, and the target, because we will be transforming over them. \n",
+    "\n",
+    "Note - because the model was originally written to handle batches, we’ll use `torch.unsqueeze` to add a batch dimension.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ItURFU3M-p98",
+   "metadata": {
+    "id": "ItURFU3M-p98"
+   },
+   "outputs": [],
+   "source": [
+    "def compute_loss_stateless_model (params, buffers, sample, target):\n",
+    "    batch = sample.unsqueeze(0)\n",
+    "    targets = target.unsqueeze(0)\n",
+    "\n",
+    "    predictions = fmodel(params, buffers, batch) \n",
+    "    loss = loss_fn(predictions, targets)\n",
+    "    return loss"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Qo3sbDK2i_bH",
+   "metadata": {
+    "id": "Qo3sbDK2i_bH"
+   },
+   "source": [
+    "Now, let’s use functorch's `grad` to create a new function that computes the gradient with respect to the first argument of `compute_loss` (i.e. the params)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "sqRp_Sxni-Xm",
+   "metadata": {
+    "id": "sqRp_Sxni-Xm"
+   },
+   "outputs": [],
+   "source": [
+    "ft_compute_grad = grad(compute_loss_stateless_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2pG3Ofqjjc8O",
+   "metadata": {
+    "id": "2pG3Ofqjjc8O"
+   },
+   "source": [
+    "The `ft_compute_grad` function computes the gradient for a single (sample, target) pair. We can use vmap to get it to compute the gradient over an entire batch of samples and targets. Note that `in_dims=(None, None, 0, 0)` because we wish to map `ft_compute_grad` over the 0th dimension of the data and targets,  and use the same params and buffers for each.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62ecNMO6inqX",
+   "metadata": {
+    "id": "62ecNMO6inqX"
+   },
+   "outputs": [],
+   "source": [
+    "ft_compute_sample_grad = vmap(ft_compute_grad, in_dims=(None, None, 0, 0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "_alXdQ3QkETu",
+   "metadata": {
+    "id": "_alXdQ3QkETu"
+   },
+   "source": [
+    "Finally, let’s used our transformed function to compute per-sample-gradients:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1gehVA1c-BHd",
+   "metadata": {
+    "id": "1gehVA1c-BHd"
+   },
+   "outputs": [],
+   "source": [
+    "ft_per_sample_grads = ft_compute_sample_grad(params, buffers, data, targets)\n",
+    "\n",
+    "# we can double check that the results using functorch grad and vmap match the results of hand processing each one individually:\n",
+    "for per_sample_grad, ft_per_sample_grad in zip(per_sample_grads, ft_per_sample_grads):\n",
+    "    assert torch.allclose(per_sample_grad, ft_per_sample_grad, atol=3e-3, rtol=1e-5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "BEZaNt1d_bc1",
+   "metadata": {
+    "id": "BEZaNt1d_bc1"
+   },
+   "source": [
+    "A quick note: there are limitations around what types of functions can be transformed by vmap. The best functions to transform are ones that are pure functions: a function where the outputs are only determined by the inputs, and that have no side effects (e.g. mutation). vmap is unable to handle mutation of arbitrary Python data structures, but it is able to handle many in-place PyTorch operations.\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "BASP151Iml7B",
+   "metadata": {
+    "id": "BASP151Iml7B"
+   },
+   "source": [
+    "## Performance comparison"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "jr1xNpV4nJ7u",
+   "metadata": {
+    "id": "jr1xNpV4nJ7u"
+   },
+   "source": [
+    "Curious about how the performance of vmap compares?\n",
+    "\n",
+    "Currently the best results are obtained on newer GPU's such as the A100 (Ampere) where we've seen up to 25x speedups on this example, but here are some results done in Colab:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "GnAnMkYmoc-j",
+   "metadata": {
+    "id": "GnAnMkYmoc-j"
+   },
+   "outputs": [],
+   "source": [
+    "def get_perf(first, first_descriptor, second, second_descriptor):\n",
+    "  \"\"\"  takes torch.benchmark objects and compares delta of second vs first. \"\"\"\n",
+    "  second_res = second.times[0]\n",
+    "  first_res = first.times[0]\n",
+    "\n",
+    "  gain = (first_res - second_res) / first_res\n",
+    "  if gain < 0: gain *=-1 \n",
+    "  final_gain = gain * 100\n",
+    "\n",
+    "  print(f\" Performance delta: {final_gain:.4f} percent improvement with {first_descriptor} \")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Zfnn2C2g-6Fb",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Zfnn2C2g-6Fb",
+    "outputId": "922f3901-773f-446b-b562-88e78f49036c"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Per-sample-grads without vmap <torch.utils.benchmark.utils.common.Measurement object at 0x7f71ac3f1850>\n",
+      "compute_sample_grads(data, targets)\n",
+      "  79.86 ms\n",
+      "  1 measurement, 100 runs , 1 thread\n",
+      "Per-sample-grads with vmap <torch.utils.benchmark.utils.common.Measurement object at 0x7f7143e26f10>\n",
+      "ft_compute_sample_grad(params, buffers, data, targets)\n",
+      "  12.93 ms\n",
+      "  1 measurement, 100 runs , 1 thread\n"
+     ]
+    }
+   ],
+   "source": [
+    "from torch.utils.benchmark import Timer\n",
+    "\n",
+    "without_vmap = Timer( stmt=\"compute_sample_grads(data, targets)\", globals=globals())\n",
+    "with_vmap = Timer(stmt=\"ft_compute_sample_grad(params, buffers, data, targets)\",globals=globals())\n",
+    "no_vmap_timing = without_vmap.timeit(100)\n",
+    "with_vmap_timing = with_vmap.timeit(100)\n",
+    "\n",
+    "print(f'Per-sample-grads without vmap {no_vmap_timing}')\n",
+    "print(f'Per-sample-grads with vmap {with_vmap_timing}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "NV9R3LZQoavl",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "NV9R3LZQoavl",
+    "outputId": "e11e8be9-287d-4e60-e517-e08f8d6909bd"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Performance delta: 517.5791 percent improvement with vmap \n"
+     ]
+    }
+   ],
+   "source": [
+    "get_perf(with_vmap_timing, \"vmap\", no_vmap_timing,\"no vmap\" )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "UI74G9JarQU8",
+   "metadata": {
+    "id": "UI74G9JarQU8"
+   },
+   "source": [
+    "There are other optimized solutions (like in https://github.com/pytorch/opacus) to computing per-sample-gradients in PyTorch that also perform better than the naive method. But it’s cool that composing `vmap` and `grad` give us a nice speedup.\n",
+    "\n",
+    "\n",
+    "In general, vectorization with vmap should be faster than running a function in a for-loop and competitive with manual batching. There are some exceptions though, like if we haven’t implemented the vmap rule for a particular operation or if the underlying kernels weren’t optimized for older hardware (GPUs). If you see any of these cases, please let us know by opening an issue at our [GitHub](https://github.com/pytorch/functorch)!\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "per_sample_grads.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/test/export/random_dag.py
+++ b/test/export/random_dag.py
@@ -137,7 +137,7 @@ class Unflatten(TestGenerator):
                 code = Block()
                 code.new_line("super().__init__()")
                 if i < self.n - 1:
-                    code.new_line(f"self.n{i+1} = N{i+1}()")
+                    code.new_line(f"self.n{i + 1} = N{i + 1}()")
                 return code
 
             def gen_forward_body(self, i: int):
@@ -207,7 +207,7 @@ class ConstantUnflatten(Unflatten):
                 code.new_line("super().__init__()")
                 code.new_line("self.const = torch.ones(1)")
                 if i < self.n - 1:
-                    code.new_line(f"self.n{i+1} = N{i+1}()")
+                    code.new_line(f"self.n{i + 1} = N{i + 1}()")
                 return code
 
             def gen_forward_body(self, i: int):
@@ -249,7 +249,7 @@ class BufferUnflatten(Unflatten):
                 code.new_line("super().__init__()")
                 code.new_line("self.buf = torch.nn.Buffer(torch.ones(1))")
                 if i < self.n - 1:
-                    code.new_line(f"self.n{i+1} = N{i+1}()")
+                    code.new_line(f"self.n{i + 1} = N{i + 1}()")
                 return code
 
             def gen_forward_body(self, i: int):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -489,7 +489,7 @@ if __name__ == '__main__':
         del env[PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY]
         env[PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY] = 'cpu'
         _, stderr = TestCase.run_process_no_exception(test_filter_file_template, env=env)
-        self.assertIn(f'Ran {test_bases_count-1} test', stderr.decode('ascii'))
+        self.assertIn(f'Ran {test_bases_count - 1} test', stderr.decode('ascii'))
 
         # Test with setting both should throw exception
         env[PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY] = 'cpu'

--- a/third_party/generate-xnnpack-wrappers.py
+++ b/third_party/generate-xnnpack-wrappers.py
@@ -100,7 +100,7 @@ IGNORED_SOURCES = set((
 def handle_singleline_parse(line):
     start_index = line.find("(")
     end_index = line.find(")")
-    line = line[start_index+1:end_index]
+    line = line[start_index + 1:end_index]
     key_val = line.split(" ")
     return key_val[0], [x[4:] for x in key_val[1:]]
 

--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -312,7 +312,7 @@ class ExplainOutput:
 
         output += "Break Reasons:\n"
         for idx, break_reason in enumerate(self.break_reasons):
-            output += f"  Break Reason {idx+1}:\n"
+            output += f"  Break Reason {idx + 1}:\n"
             output += f"    Reason: {break_reason.reason}\n"
             output += "    User Stack:\n"
             for frame_summary in break_reason.user_stack:
@@ -321,14 +321,14 @@ class ExplainOutput:
         if self.ops_per_graph is not None:
             output += "Ops per Graph:\n"
             for idx, ops in enumerate(self.ops_per_graph):
-                output += f"  Ops {idx+1}:\n"
+                output += f"  Ops {idx + 1}:\n"
                 for op in ops:
                     output += f"    {op}\n"
 
         if self.out_guards is not None:
             output += "Out Guards:\n"
             for i, guard in enumerate(self.out_guards):
-                output += f"  Guard {i+1}:\n"
+                output += f"  Guard {i + 1}:\n"
                 output += f"    {str(guard)}"
 
         if self.compile_times is not None:

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -184,7 +184,7 @@ class NNModuleToString:
             example_param = next(module.parameters(), None)
             if example_param is not None and example_param.is_cuda:
                 module_str = f"{module_str}.cuda()"
-            model_str += f"{tab*2}self.{module_name} = {module_str}\n"
+            model_str += f"{tab * 2}self.{module_name} = {module_str}\n"
 
         for buffer_name, buffer in gm._buffers.items():
             if buffer is None:
@@ -203,7 +203,9 @@ class NNModuleToString:
                 )
             if buffer.is_cuda:
                 tensor_str = f"{tensor_str}.cuda()"
-            model_str += f"{tab*2}self.register_buffer('{buffer_name}', {tensor_str})\n"
+            model_str += (
+                f"{tab * 2}self.register_buffer('{buffer_name}', {tensor_str})\n"
+            )
 
         for param_name, param in gm._parameters.items():
             if param is None:
@@ -212,7 +214,7 @@ class NNModuleToString:
             if param.is_cuda:
                 maybe_device = ', device="cuda"'
             tensor_str = f"torch.nn.Parameter(torch.randn({list(param.shape)}, dtype={param.dtype}{maybe_device}))"
-            model_str += f"{tab*2}self.{param_name} = {tensor_str}\n"
+            model_str += f"{tab * 2}self.{param_name} = {tensor_str}\n"
 
         # TODO - Keep this code for now. But, I don't think we will need this.
         # attrs = dir(gm)

--- a/torch/_inductor/wrapper_benchmark.py
+++ b/torch/_inductor/wrapper_benchmark.py
@@ -396,7 +396,7 @@ def compiled_module_main(benchmark_name, benchmark_compiled_module_fn):
 
         if torch.cuda.is_available():
             peak_mem = torch.cuda.max_memory_allocated()
-            print(f"Peak GPU memory usage {peak_mem/1e6:.3f} MB")
+            print(f"Peak GPU memory usage {peak_mem / 1e6:.3f} MB")
 
         if torch.cuda.is_available() and args.cuda_memory_snapshot:
             collect_memory_snapshot(benchmark_compiled_module_fn)

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -844,7 +844,7 @@ class TorchLogsFormatter(logging.Formatter):
         filepath = make_module_path_relative(record.pathname)
 
         prefix = (
-            f"{record.rankprefix}{shortlevel}{record.asctime}.{int(record.msecs*1000):06d} {record.process} "
+            f"{record.rankprefix}{shortlevel}{record.asctime}.{int(record.msecs * 1000):06d} {record.process} "
             f"{filepath}:"
             f"{record.lineno}]{record.traceid}{record.artifactprefix}"
         )

--- a/torch/_numpy/testing/utils.py
+++ b/torch/_numpy/testing/utils.py
@@ -2274,7 +2274,7 @@ def check_free_memory(free_bytes):
             )
 
         msg = (
-            f"{free_bytes/1e9} GB memory required, but environment variable "
+            f"{free_bytes / 1e9} GB memory required, but environment variable "
             f"NPY_AVAILABLE_MEM={env_value} set"
         )
     else:
@@ -2288,9 +2288,7 @@ def check_free_memory(free_bytes):
             )
             mem_free = -1
         else:
-            msg = (
-                f"{free_bytes/1e9} GB memory required, but {mem_free/1e9} GB available"
-            )
+            msg = f"{free_bytes / 1e9} GB memory required, but {mem_free / 1e9} GB available"
 
     return msg if mem_free < free_bytes else None
 

--- a/torch/distributed/_tools/ilp_utils.py
+++ b/torch/distributed/_tools/ilp_utils.py
@@ -257,11 +257,11 @@ def display_bytes(b: int, unit: str = "MiB") -> str:
     return a string that represent the number of bytes in a desired unit
     """
     if unit == "KiB":
-        return f"{b/2**10:.2f} KiB"
+        return f"{b / 2**10:.2f} KiB"
     if unit == "MiB":
-        return f"{b/2**20:.2f} MiB"
+        return f"{b / 2**20:.2f} MiB"
     if unit == "GiB":
-        return f"{b/2**30:.2f} GiB"
+        return f"{b / 2**30:.2f} GiB"
     return f"{b:.2f} bytes"
 
 

--- a/torch/distributed/tensor/examples/convnext_example.py
+++ b/torch/distributed/tensor/examples/convnext_example.py
@@ -243,13 +243,16 @@ def train_convnext_example():
     max_reserved = torch.cuda.max_memory_reserved()
     max_allocated = torch.cuda.max_memory_allocated()
     print(
-        f"rank {rank}, {ITER_TIME} iterations, average latency {(end - start)/ITER_TIME*1000:10.2f} ms"
+        f"rank {rank}, {ITER_TIME} iterations, "
+        f"average latency {(end - start) / ITER_TIME * 1000:10.2f} ms"
     )
     print(
-        f"rank {rank}, forward {forward_time/ITER_TIME*1000:10.2f} ms, backward {backward_time/ITER_TIME*1000:10.2f} ms"
+        f"rank {rank}, forward {forward_time / ITER_TIME * 1000:10.2f} ms, "
+        f"backward {backward_time / ITER_TIME * 1000:10.2f} ms"
     )
     print(
-        f"rank {rank}, max reserved {max_reserved/1024/1024/1024:8.2f} GiB, max allocated {max_allocated/1024/1024/1024:8.2f} GiB"
+        f"rank {rank}, max reserved {max_reserved / 1024 / 1024 / 1024:8.2f} GiB, "
+        f"max allocated {max_allocated / 1024 / 1024 / 1024:8.2f} GiB"
     )
     dist.destroy_process_group()
 

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -187,7 +187,7 @@ def tril_matrix_to_vec(mat: Tensor, diag: int = 0) -> Tensor:
     """
     n = mat.shape[-1]
     if not torch._C._get_tracing_state() and (diag < -n or diag >= n):
-        raise ValueError(f"diag ({diag}) provided is outside [{-n}, {n-1}].")
+        raise ValueError(f"diag ({diag}) provided is outside [{-n}, {n - 1}].")
     arange = torch.arange(n, device=mat.device)
     tril_mask = arange < arange.view(-1, 1) + (diag + 1)
     vec = mat[..., tril_mask]

--- a/torch/distributions/wishart.py
+++ b/torch/distributions/wishart.py
@@ -107,7 +107,7 @@ class Wishart(ExponentialFamily):
 
         if self.df.le(event_shape[-1] - 1).any():
             raise ValueError(
-                f"Value of df={df} expected to be greater than ndim - 1 = {event_shape[-1]-1}."
+                f"Value of df={df} expected to be greater than ndim - 1 = {event_shape[-1] - 1}."
             )
 
         if scale_tril is not None:

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -890,7 +890,7 @@ def _add_submodule(
 def _call_name(base: str, n: int) -> str:
     # Given n >= 0, generate call names to a submodule `base` of the form
     # `base`, `base@1`, `base@2`, etc.
-    return base if n == 1 else f"{base}@{n-1}"
+    return base if n == 1 else f"{base}@{n - 1}"
 
 
 def _is_call_name(call_name: str, base: str) -> bool:

--- a/torch/profiler/_memory_profiler.py
+++ b/torch/profiler/_memory_profiler.py
@@ -1168,8 +1168,8 @@ class MemoryProfileTimeline:
         title = "\n\n".join(
             ([title] if title else [])
             + [
-                f"Max memory allocated: {max_memory_allocated/(1024**3):.2f} GiB \n"
-                f"Max memory reserved: {max_memory_reserved/(1024**3):.2f} GiB"
+                f"Max memory allocated: {max_memory_allocated / (1024**3):.2f} GiB \n"
+                f"Max memory reserved: {max_memory_reserved / (1024**3):.2f} GiB"
             ]
         )
         axes.set_title(title)

--- a/torch/profiler/_pattern_matcher.py
+++ b/torch/profiler/_pattern_matcher.py
@@ -84,7 +84,7 @@ class Pattern:
         )
         return (
             f"{self.name}: {len(events)} events matched. "
-            f"Total Estimated Speedup: {format_time(original_time - new_time)} ({round(original_time/new_time, 2)}X)"
+            f"Total Estimated Speedup: {format_time(original_time - new_time)} ({round(original_time / new_time, 2)}X)"
         )
 
     def match(self, event: _ProfilerEvent):
@@ -622,7 +622,7 @@ def report_all_anti_patterns(
     ]
     reported = set()
     summaries = []
-    message_list = [f"{'-'*40}TorchTidy Report{'-'*40}"]
+    message_list = [f"{'-' * 40}TorchTidy Report{'-' * 40}"]
     message_list.append("Matched Events:")
 
     for anti_pattern in anti_patterns:
@@ -657,6 +657,6 @@ def report_all_anti_patterns(
 
     message_list.append("Summary:")
     message_list += summaries
-    message_list.append(f"{'-'*40}TorchTidy Report{'-'*40}")
+    message_list.append(f"{'-' * 40}TorchTidy Report{'-' * 40}")
     if print_enable:
         print("\n".join(message_list))

--- a/torch/profiler/_utils.py
+++ b/torch/profiler/_utils.py
@@ -335,11 +335,11 @@ class BasicEvaluation:
 
         output += "\n".join(
             [
-                f"""{'-'*80}
+                f"""{'-' * 80}
 Event:                {event}
 Source code location: {source_code_location(event.event)}
 Percentage idle time: {self.metrics[event].fraction_idle_time * 100:.2f}%
-{'-'*80}"""
+{'-' * 80}"""
                 for event in event_list
             ]
         )

--- a/torch/testing/_internal/distributed/rpc/examples/parameter_server_test.py
+++ b/torch/testing/_internal/distributed/rpc/examples/parameter_server_test.py
@@ -112,7 +112,7 @@ def run_ps(trainers):
     torch.futures.wait_all(futs)
     stop = perf_counter()
     timed_log("Finish training")
-    timed_log(f"Time spent training: {stop-start}s")
+    timed_log(f"Time spent training: {stop - start}s")
 
 class ParameterServerTest(RpcAgentTestFixture):
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144415

The fixes are generated by:

```bash
ruff check --fix --preview --unsafe-fixes --select=E226 .
lintrunner -a --take "RUFF,PYFMT" --all-files
```

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov