### PR TITLE
[XPU] Fix Syntax Error due to Clang-tidy

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -456,6 +456,8 @@ TORCH_LIBRARY_IMPL(aten, XPU, m) {
 }
 } // namespace at::native::xpu
 
+namespace at::native {
+
 TORCH_IMPL_FUNC(addmm_out_xpu)
 (const Tensor& self,
  const Tensor& mat1,
@@ -510,3 +512,4 @@ TORCH_IMPL_FUNC(addmv_out_xpu)
  const Tensor& result) {
   xpu::addmv_out(self, mat, vec, beta, alpha, const_cast<Tensor&>(result));
 }
+} // namespace at::native


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

Recent changes to `aten/src/ATen/native/mkldnn/xpu/Blas.cpp` from PR:https://github.com/pytorch/pytorch/pull/144014, leads to build failures.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10