### PR TITLE
[mps/inductor] Add support for tanh().

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -52,6 +52,7 @@ class MPSBasicTests(TestCase):
     test_remainder = CommonTemplate.test_remainder
     test_rsqrt = CommonTemplate.test_rsqrt
     test_signbit = CommonTemplate.test_signbit
+    test_tanh = CommonTemplate.test_tanh
     test_view_as_complex = CommonTemplate.test_view_as_complex
     test_views6 = CommonTemplate.test_views6
     test_zero_dim_reductions = CommonTemplate.test_zero_dim_reductions

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -184,6 +184,10 @@ class MetalOverrides(OpOverrides):
         return f"metal::rsqrt({x})"
 
     @staticmethod
+    def tanh(x: CSEVariable) -> str:
+        return f"metal::tanh({x})"
+
+    @staticmethod
     def atanh(x: CSEVariable) -> str:
         return f"metal::atanh({x})"
 


### PR DESCRIPTION
Fixes test_tanh() in the inductor testsuite.

cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov