### PR TITLE
Remove the `_stacklevel` arg from `log_softmax`, `softmax` and `softmin`

### DIFF
--- a/torch/ao/nn/quantized/modules/activation.py
+++ b/torch/ao/nn/quantized/modules/activation.py
@@ -204,11 +204,10 @@ class Softmax(torch.nn.Softmax):
     def forward(self, input):
         dim = self.dim
         if dim is None:
-            stacklevel = 3
             # Note: adding the mypy ignore on _get_softmax_dim seems less bad
             # than making `_get_softmax_dim` an official API.
             dim = torch.nn.functional._get_softmax_dim(  # type: ignore[attr-defined]
-                "softmax", input.dim(), stacklevel
+                "softmax", input.dim()
             )
         return torch.ops.quantized.softmax(input, dim, self.scale, self.zero_point)
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2054,7 +2054,7 @@ See :class:`~torch.nn.Softplus` for more details.
 )
 
 
-def _get_softmax_dim(name: str, ndim: int, stacklevel: int) -> int:
+def _get_softmax_dim(name: str, ndim: int, stacklevel: int = 3) -> int:
     warnings.warn(
         f"Implicit dimension choice for {name} has been deprecated. "
         "Change the call to include dim=X as an argument.",
@@ -2070,7 +2070,6 @@ def _get_softmax_dim(name: str, ndim: int, stacklevel: int) -> int:
 def softmin(
     input: Tensor,
     dim: Optional[int] = None,
-    _stacklevel: int = 3,
     dtype: Optional[DType] = None,
 ) -> Tensor:
     r"""Apply a softmin function.
@@ -2088,11 +2087,9 @@ def softmin(
           is performed. This is useful for preventing data type overflows. Default: None.
     """
     if has_torch_function_unary(input):
-        return handle_torch_function(
-            softmin, (input,), input, dim=dim, _stacklevel=_stacklevel, dtype=dtype
-        )
+        return handle_torch_function(softmin, (input,), input, dim=dim, dtype=dtype)
     if dim is None:
-        dim = _get_softmax_dim("softmin", input.dim(), _stacklevel)
+        dim = _get_softmax_dim("softmin", input.dim())
     if dtype is None:
         ret = (-input).softmax(dim)
     else:
@@ -2103,7 +2100,6 @@ def softmin(
 def softmax(
     input: Tensor,
     dim: Optional[int] = None,
-    _stacklevel: int = 3,
     dtype: Optional[DType] = None,
 ) -> Tensor:
     r"""Apply a softmax function.
@@ -2131,11 +2127,9 @@ def softmax(
 
     """
     if has_torch_function_unary(input):
-        return handle_torch_function(
-            softmax, (input,), input, dim=dim, _stacklevel=_stacklevel, dtype=dtype
-        )
+        return handle_torch_function(softmax, (input,), input, dim=dim, dtype=dtype)
     if dim is None:
-        dim = _get_softmax_dim("softmax", input.dim(), _stacklevel)
+        dim = _get_softmax_dim("softmax", input.dim())
     if dtype is None:
         ret = input.softmax(dim)
     else:
@@ -2220,7 +2214,6 @@ def gumbel_softmax(
 def log_softmax(
     input: Tensor,
     dim: Optional[int] = None,
-    _stacklevel: int = 3,
     dtype: Optional[DType] = None,
 ) -> Tensor:
     r"""Apply a softmax followed by a logarithm.
@@ -2239,11 +2232,9 @@ def log_softmax(
           is performed. This is useful for preventing data type overflows. Default: None.
     """
     if has_torch_function_unary(input):
-        return handle_torch_function(
-            log_softmax, (input,), input, dim=dim, _stacklevel=_stacklevel, dtype=dtype
-        )
+        return handle_torch_function(log_softmax, (input,), input, dim=dim, dtype=dtype)
     if dim is None:
-        dim = _get_softmax_dim("log_softmax", input.dim(), _stacklevel)
+        dim = _get_softmax_dim("log_softmax", input.dim())
     if dtype is None:
         ret = input.log_softmax(dim)
     else:

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1605,7 +1605,7 @@ class Softmin(Module):
             self.dim = None
 
     def forward(self, input: Tensor) -> Tensor:
-        return F.softmin(input, self.dim, _stacklevel=5)
+        return F.softmin(input, self.dim)
 
     def extra_repr(self):
         return f"dim={self.dim}"
@@ -1664,7 +1664,7 @@ class Softmax(Module):
             self.dim = None
 
     def forward(self, input: Tensor) -> Tensor:
-        return F.softmax(input, self.dim, _stacklevel=5)
+        return F.softmax(input, self.dim)
 
     def extra_repr(self) -> str:
         return f"dim={self.dim}"
@@ -1697,7 +1697,7 @@ class Softmax2d(Module):
             raise ValueError(
                 f"Softmax2d: expected input to be 3D or 4D, got {input.dim()}D instead"
             )
-        return F.softmax(input, -3, _stacklevel=5)
+        return F.softmax(input, -3)
 
 
 class LogSoftmax(Module):
@@ -1740,7 +1740,7 @@ class LogSoftmax(Module):
             self.dim = None
 
     def forward(self, input: Tensor) -> Tensor:
-        return F.log_softmax(input, self.dim, _stacklevel=5)
+        return F.log_softmax(input, self.dim)
 
     def extra_repr(self):
         return f"dim={self.dim}"

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -907,7 +907,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.nn.functional.leaky_relu: lambda input, negative_slope=0.01, inplace=False: -1,
         torch.nn.functional.linear: lambda input, weight, bias=None: -1,
         torch.nn.functional.local_response_norm: lambda input, size, alpha=0.0001, beta=0.75, k=1.0: -1,
-        torch.nn.functional.log_softmax: lambda input, dim=None, _stacklevel=3, dtype=None: -1,
+        torch.nn.functional.log_softmax: lambda input, dim=None, dtype=None: -1,
         torch.nn.functional.logsigmoid: lambda input: -1,
         torch.nn.functional.lp_pool1d: lambda input, norm_type, kernel_size, stride=None, ceil_mode=False: -1,
         torch.nn.functional.lp_pool2d: lambda input, norm_type, kernel_size, stride=None, ceil_mode=False: -1,
@@ -971,8 +971,8 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.nn.functional.smooth_l1_loss: lambda input, target, size_average=None, reduce=None, reduction="mean", beta=1.0: -1,  # noqa: B950
         torch.nn.functional.huber_loss: lambda input, target, reduction="mean", delta=1.0, weight=None: -1,
         torch.nn.functional.soft_margin_loss: lambda input, target, size_average=None, reduce=None, reduction="mean": -1,  # noqa: B950
-        torch.nn.functional.softmax: lambda input, dim=None, _stacklevel=3, dtype=None: -1,
-        torch.nn.functional.softmin: lambda input, dim=None, _stacklevel=3, dtype=None: -1,
+        torch.nn.functional.softmax: lambda input, dim=None, dtype=None: -1,
+        torch.nn.functional.softmin: lambda input, dim=None, dtype=None: -1,
         torch.nn.functional.softplus: lambda input, beta=1, threshold=20: -1,
         torch.nn.functional.softshrink: lambda input, lambd=0.5: -1,
         torch.nn.functional.softsign: lambda input: -1,


### PR DESCRIPTION
Fixes #83163

Remove `_stacklevel` parameter

**Test Result**

**Before**

![image](https://github.com/user-attachments/assets/8bd2e4d9-06a2-4ef0-b832-040ca47e9760)

![image](https://github.com/user-attachments/assets/7f756c08-65b7-4351-bb4d-d17df342722a)

![image](https://github.com/user-attachments/assets/e8a2719f-70ff-4d70-9e37-8dfe7fef6f4e)


**After**

![image](https://github.com/user-attachments/assets/31fade7f-b100-4ee8-a833-ae29363f2423)

![image](https://github.com/user-attachments/assets/a73e1349-0e8c-4b79-a77e-acc28c5f5702)

![image](https://github.com/user-attachments/assets/9b8a2099-a5cb-4c1b-8987-c4670f13a9a7)
