### PR TITLE
[BE]: Follow detach().clone() pattern for SGD

### DIFF
--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -352,7 +352,7 @@ def _single_tensor_sgd(
             buf = momentum_buffer_list[i]
 
             if buf is None:
-                buf = torch.clone(grad).detach()
+                buf = torch.clone(grad.detach())
                 momentum_buffer_list[i] = buf
             else:
                 buf.mul_(momentum).add_(grad, alpha=1 - dampening)
@@ -441,7 +441,7 @@ def _multi_tensor_sgd(
                     if device_momentum_buffer_list[i] is None:
                         buf = device_momentum_buffer_list[i] = momentum_buffer_list[
                             indices[i]
-                        ] = torch.clone(device_grads[i]).detach()
+                        ] = torch.clone(device_grads[i].detach())
                     else:
                         buf = cast(Tensor, device_momentum_buffer_list[i])
                         buf.mul_(momentum).add_(device_grads[i], alpha=1 - dampening)


### PR DESCRIPTION
Clone() copies the gradients too, but we immediately detach them. Detach returns a view of the tensor without it's gradients, and the copies only that subset. Related to #144270
