### PR TITLE
Cleanup gpt_fast benchmark

### DIFF
--- a/benchmarks/gpt_fast/benchmark.py
+++ b/benchmarks/gpt_fast/benchmark.py
@@ -63,12 +63,7 @@ def run_mlp_layer_norm_gelu(device: str = "cuda"):
             for _ in range(WARMUP_ITER):
                 compiled_mod(x)
 
-            benchmark_fn = (
-                benchmarker.benchmark_gpu
-                if device == "cuda"
-                else benchmarker.benchmark_cpu
-            )
-            us_per_iter = benchmark_fn(lambda: compiled_mod(x)) * 1000
+            us_per_iter = benchmarker.benchmark(compiled_mod, (x,)) * 1000
             flops_utilization += us_per_iter * flops / 1e9 / A100_40G_BF16_TFLOPS
 
         flops_utilization = flops_utilization / len(input_shapes)
@@ -107,12 +102,7 @@ def run_layer_norm(device: str = "cuda"):
             for _ in range(WARMUP_ITER):
                 compiled_mod(x)
 
-            benchmark_fn = (
-                benchmarker.benchmark_gpu
-                if device == "cuda"
-                else benchmarker.benchmark_cpu
-            )
-            us_per_iter = benchmark_fn(lambda: compiled_mod(x)) * 1000
+            us_per_iter = benchmarker.benchmark(compiled_mod, (x,)) * 1000
             memory_bandwidth += (1e6 / us_per_iter) * 2 * BS * D * dtype.itemsize / 1e9
 
         memory_bandwidth = memory_bandwidth / len(input_shapes)
@@ -157,12 +147,7 @@ def run_gather_gemv(device: str = "cuda"):
             for _ in range(WARMUP_ITER):
                 compiled_fn(W, score_idxs, x)
 
-            benchmark_fn = (
-                benchmarker.benchmark_gpu
-                if device == "cuda"
-                else benchmarker.benchmark_cpu
-            )
-            us_per_iter = benchmark_fn(lambda: compiled_fn(W, score_idxs, x)) * 1000
+            us_per_iter = benchmarker.benchmark(compiled_fn, (W, score_idxs, x,)) * 1000
             memory_bandwidth += (1e6 / us_per_iter) * 2 * D * D * dtype.itemsize / 1e9
 
         memory_bandwidth = memory_bandwidth / len(input_shapes)
@@ -205,12 +190,7 @@ def run_gemv(device: str = "cuda"):
             for _ in range(WARMUP_ITER):
                 compiled_fn(W, x)
 
-            benchmark_fn = (
-                benchmarker.benchmark_gpu
-                if device == "cuda"
-                else benchmarker.benchmark_cpu
-            )
-            us_per_iter = benchmark_fn(lambda: compiled_fn(W, x)) * 1000
+            us_per_iter = benchmarker.benchmark(compiled_fn, (W, x,)) * 1000
             memory_bandwidth += (1e6 / us_per_iter) * D * D * dtype.itemsize / 1e9
 
         memory_bandwidth = memory_bandwidth / len(input_shapes)

--- a/benchmarks/gpt_fast/benchmark.py
+++ b/benchmarks/gpt_fast/benchmark.py
@@ -147,7 +147,17 @@ def run_gather_gemv(device: str = "cuda"):
             for _ in range(WARMUP_ITER):
                 compiled_fn(W, score_idxs, x)
 
-            us_per_iter = benchmarker.benchmark(compiled_fn, (W, score_idxs, x,)) * 1000
+            us_per_iter = (
+                benchmarker.benchmark(
+                    compiled_fn,
+                    (
+                        W,
+                        score_idxs,
+                        x,
+                    ),
+                )
+                * 1000
+            )
             memory_bandwidth += (1e6 / us_per_iter) * 2 * D * D * dtype.itemsize / 1e9
 
         memory_bandwidth = memory_bandwidth / len(input_shapes)
@@ -190,7 +200,16 @@ def run_gemv(device: str = "cuda"):
             for _ in range(WARMUP_ITER):
                 compiled_fn(W, x)
 
-            us_per_iter = benchmarker.benchmark(compiled_fn, (W, x,)) * 1000
+            us_per_iter = (
+                benchmarker.benchmark(
+                    compiled_fn,
+                    (
+                        W,
+                        x,
+                    ),
+                )
+                * 1000
+            )
             memory_bandwidth += (1e6 / us_per_iter) * D * D * dtype.itemsize / 1e9
 
         memory_bandwidth = memory_bandwidth / len(input_shapes)


### PR DESCRIPTION
Prefer to use `benchmarker.benchmark` instead of explicitly selecting `benchmarker.benchmark_cpu` or `benchmarker.benchmark_gpu`

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144484

