### PR TITLE
Simplify vec128 bfloat16/half fmadds

### DIFF
--- a/aten/src/ATen/cpu/vec/vec128/vec128_bfloat16_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_bfloat16_neon.h
@@ -526,12 +526,7 @@ Vectorized<c10::BFloat16> inline fmadd(
   // elements, not the bottom and top half, so they don't seem
   // particularly useful here. Ideally we would include dot product in
   // the Vectorized interface...
-  const auto [a_float_low, a_float_high] = convert_bfloat16_float(a);
-  const auto [b_float_low, b_float_high] = convert_bfloat16_float(b);
-  const auto [c_float_low, c_float_high] = convert_bfloat16_float(c);
-  return convert_float_bfloat16(
-      fmadd(a_float_low, b_float_low, c_float_low),
-      fmadd(a_float_high, b_float_high, c_float_high));
+  return a * b + c;
 }
 
 template <>
@@ -540,12 +535,7 @@ Vectorized<c10::BFloat16> inline fmsub(
     const Vectorized<c10::BFloat16>& b,
     const Vectorized<c10::BFloat16>& c) {
   // See NOTE [BF16 FMA] above.
-  const auto [a_float_low, a_float_high] = convert_bfloat16_float(a);
-  const auto [b_float_low, b_float_high] = convert_bfloat16_float(b);
-  const auto [c_float_low, c_float_high] = convert_bfloat16_float(c);
-  return convert_float_bfloat16(
-      fmsub(a_float_low, b_float_low, c_float_low),
-      fmsub(a_float_high, b_float_high, c_float_high));
+  return a * b - c;
 }
 
 #endif // !defined(C10_MOBILE) && defined(__aarch64__)

--- a/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h
@@ -572,13 +572,7 @@ Vectorized<c10::Half> inline fmadd(
 #ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
   return Vectorized<c10::Half>(vfmaq_f16(c, a, b));
 #else
-  const auto [a_float_low, a_float_high] = convert_half_float(a);
-  const auto [b_float_low, b_float_high] = convert_half_float(b);
-  const auto [c_float_low, c_float_high] = convert_half_float(c);
-  return convert_float_half(
-      fmadd(a_float_low, b_float_low, c_float_low),
-      fmadd(a_float_high, b_float_high, c_float_high));
-#endif
+  return a * b + c;
 }
 
 template <>
@@ -589,12 +583,7 @@ Vectorized<c10::Half> inline fmsub(
 #ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
   return Vectorized<c10::Half>(vfmsq_f16(c, a, b));
 #else
-  const auto [a_float_low, a_float_high] = convert_half_float(a);
-  const auto [b_float_low, b_float_high] = convert_half_float(b);
-  const auto [c_float_low, c_float_high] = convert_half_float(c);
-  return convert_float_half(
-      fmsub(a_float_low, b_float_low, c_float_low),
-      fmsub(a_float_high, b_float_high, c_float_high));
+  return a * b - c;
 #endif
 }
 #endif // !defined(C10_MOBILE) && defined(__aarch64__)

--- a/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h
@@ -573,6 +573,7 @@ Vectorized<c10::Half> inline fmadd(
   return Vectorized<c10::Half>(vfmaq_f16(c, a, b));
 #else
   return a * b + c;
+#endif
 }
 
 template <>

--- a/aten/src/ATen/test/vec_test_all_types.cpp
+++ b/aten/src/ATen/test/vec_test_all_types.cpp
@@ -851,7 +851,7 @@ namespace {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
         CACHE_ALIGN VT test_vals[vec::size()];
         //all sets will be within 0  2^(n-1)
-        auto power_sets = 1 << (vec::size());
+        auto power_sets = 1UL << (vec::size());
         for (const auto expected : c10::irange(power_sets)) {
             // generate test_val based on expected
             for (int i = 0; i < vec::size(); ++i)

--- a/aten/src/ATen/test/vec_test_all_types.cpp
+++ b/aten/src/ATen/test/vec_test_all_types.cpp
@@ -113,7 +113,7 @@ namespace {
     TYPED_TEST_SUITE(Pow, RealFloatTestedTypes);
     TYPED_TEST_SUITE(RealTests, RealFloatTestedTypes);
     TYPED_TEST_SUITE(RangeFactories, FloatIntTestedTypes);
-    TYPED_TEST_SUITE(BitwiseFloatsAdditional, RealFloatTestedTypes);
+    TYPED_TEST_SUITE(BitwiseFloatsAdditional, RealFloatReducedFloatTestedTypes);
     TYPED_TEST_SUITE(BitwiseFloatsAdditional2, FloatTestedTypes);
     TYPED_TEST_SUITE(QuantizationTests, QuantTestedTypes);
     TYPED_TEST_SUITE(InfiniteTests, RealFloatTestedTypes);

--- a/aten/src/ATen/test/vec_test_all_types.h
+++ b/aten/src/ATen/test/vec_test_all_types.h
@@ -422,7 +422,7 @@ std::enable_if_t<std::is_floating_point_v<T>, void> filter_fmod(T& a, T& b) {
 }
 
 template <typename T>
-std::enable_if_t<std::is_floating_point_v<T>, void> filter_fmadd(T& a, T& b, T& c) {
+std::enable_if_t<std::is_floating_point_v<T> || at::vec::is_reduced_floating_point_v<T>, void> filter_fmadd(T& a, T& b, T& c) {
     // This is to setup a limit to make sure fmadd (a * b + c) won't overflow
     T max = std::sqrt(std::numeric_limits<T>::max()) / T(2.0);
     T min = ((T)0 - max);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144486

I was being silly when I wrote these; it doesn't make sense to do four conversions and two FMAs when we could do a multiply and an add.

Differential Revision: [D67985074](https://our.internmc.facebook.com/intern/diff/D67985074/)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10