### PR TITLE
Introduce cache clearing APIs for the lazy graph executor

### DIFF
--- a/test/cpp/lazy/CMakeLists.txt
+++ b/test/cpp/lazy/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LAZY_TEST_SRCS
   ${LAZY_TEST_ROOT}/test_shape.cpp
   ${LAZY_TEST_ROOT}/test_trie_cache.cpp
   ${LAZY_TEST_ROOT}/test_util.cpp
+  ${LAZY_TEST_ROOT}/test_lazy_graph_executor.cpp
 )
 if(BUILD_LAZY_TS_BACKEND)
     list(APPEND LAZY_TEST_SRCS

--- a/test/cpp/lazy/test_lazy_graph_executor.cpp
+++ b/test/cpp/lazy/test_lazy_graph_executor.cpp
@@ -1,0 +1,97 @@
+#include <gtest/gtest.h>
+
+#include <test/cpp/lazy/test_lazy_ops_util.h>
+#include <torch/csrc/lazy/core/lazy_graph_executor.h>
+
+#include <vector>
+
+namespace torch {
+namespace lazy {
+namespace {
+
+class LazyGraphExecutorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    executor_ = LazyGraphExecutor::Get();
+  }
+
+  using CachedComputationType = LazyGraphExecutor::CachedComputation;
+
+  std::shared_ptr<CachedComputationType> GetCachedComputation(hash_t hash) {
+    return executor_->GetComputationCache()->Get(hash);
+  }
+
+  void EnsureComputationIsCached(
+      std::vector<LazyTensorPtr>& tensors,
+      hash_t hash) {
+    // Force computation to be cached by syncing the tensors.
+    executor_->SyncTensorsGraph(
+        &tensors, /* devices */ {}, /* wait */ true, /* sync_ltc_data */ true);
+
+    // Ensure that the computation cache entry exists.
+    auto cached_computation = GetCachedComputation(hash);
+    EXPECT_NE(cached_computation, nullptr)
+        << "Computation should be cached after sync";
+  }
+
+  LazyGraphExecutor* executor_;
+};
+
+TEST_F(LazyGraphExecutorTest, TestClearComputationCache) {
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor tensor_a =
+        torch::rand({2, 2}, at::TensorOptions(torch::kFloat));
+    torch::Tensor tensor_b =
+        torch::rand({2, 2}, at::TensorOptions(torch::kFloat));
+
+    torch::Tensor xla_tensor_a = CopyToDevice(tensor_a, device);
+    torch::Tensor xla_tensor_b = CopyToDevice(tensor_b, device);
+    torch::Tensor result = xla_tensor_a + xla_tensor_b;
+
+    std::vector<LazyTensorPtr> tensors{TryGetLtcTensor(result)};
+    hash_t hash = executor_->GetGraphHash(tensors);
+    EnsureComputationIsCached(tensors, hash);
+    EXPECT_EQ(executor_->GetComputationCache()->Numel(), 1);
+
+    // Clear the entire computation cache.
+    executor_->ClearComputationCache();
+
+    // Ensure that there are no cache entries.
+    EXPECT_EQ(executor_->GetComputationCache()->Numel(), 0);
+    auto cached_computation = GetCachedComputation(hash);
+    EXPECT_EQ(cached_computation, nullptr)
+        << "Cache entry should be null after clearing";
+  });
+}
+
+TEST_F(LazyGraphExecutorTest, TestRemoveSpecificCacheEntry) {
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor tensor_a =
+        torch::rand({2, 2}, at::TensorOptions(torch::kFloat));
+    torch::Tensor tensor_b =
+        torch::rand({2, 2}, at::TensorOptions(torch::kFloat));
+
+    torch::Tensor xla_tensor_a = CopyToDevice(tensor_a, device);
+    torch::Tensor xla_tensor_b = CopyToDevice(tensor_b, device);
+    torch::Tensor result = xla_tensor_a + xla_tensor_b;
+
+    std::vector<LazyTensorPtr> tensors{TryGetLtcTensor(result)};
+    hash_t hash = executor_->GetGraphHash(tensors);
+    EnsureComputationIsCached(tensors, hash);
+
+    // Remove a specific cache entry.
+    executor_->RemoveFromComputationCache(hash);
+
+    // Ensure that the cache entry has been removed.
+    auto cached_computation = GetCachedComputation(hash);
+    EXPECT_EQ(cached_computation, nullptr)
+        << "Cache entry should be null after removal";
+
+    // Attempting to remove again should not do anything.
+    executor_->RemoveFromComputationCache(hash);
+  });
+}
+
+} // namespace
+} // namespace lazy
+} // namespace torch

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -1073,4 +1073,16 @@ hash_t LazyGraphExecutor::GetGraphHash(
   return coll.hash;
 }
 
+void LazyGraphExecutor::ClearComputationCache() {
+  VLOG(4) << "Clearing the computation cache";
+  GetComputationCache()->Clear();
+}
+
+void LazyGraphExecutor::RemoveFromComputationCache(const hash_t& hash) {
+  VLOG(4) << "Removing computation cache for hash " << hash;
+  if (!GetComputationCache()->Erase(hash)) {
+    LOG(ERROR) << "There is no cached computation for hash " << hash << '\n';
+  }
+}
+
 } // namespace torch::lazy

--- a/torch/csrc/lazy/core/lazy_graph_executor.h
+++ b/torch/csrc/lazy/core/lazy_graph_executor.h
@@ -131,6 +131,11 @@ class TORCH_API LazyGraphExecutor {
 
   hash_t GetGraphHash(const std::vector<LazyTensorPtr>& tensors);
 
+  // Clear the computation cache.
+  void ClearComputationCache();
+  // Remove a specific computation cache entry from its hash.
+  void RemoveFromComputationCache(const hash_t& hash);
+
  protected:
   // TODO(alanwaketan): Revisit if all of them need to be accessible to
   // derived classes.


### PR DESCRIPTION
This PR introduces two new methods to the LazyGraphExecutor class:

- ClearComputationCache(): Allows clearing the entire computation cache.
- RemoveFromComputationCache(hash): Enables removal of specific cache entries based on their hash.

The main objective is to expose cache management functionality for debugging cache hits and misses across different computations. For instance:
- Reset the cache state in tests, allowing reuse of the same computation client to evaluate cache logic consistently.
- Selectively remove cache entries to analyze the impact on subsequent computations.
- Improve observability into the cache behavior, aiding in the investigation of cache-related issues or optimizations.

On the XLA lazy graph executor, we want to run a series of tests that modify some parts of the HLO module proto of the computation, and we need a means to ensure that the hash is agnostic to some elements (OpMetadata in the XLA proto data). Hence, it would be easy to parameterize the test, clear the cache and validate that the resulting hash is the same between runs. Otherwise, we'd need to hardcode the resulting serialized hash.

Simultaneously, **another motivation**, is that users could also clear some computation hashes for an added flexibility in their applications, by introducing their own custom strategies for maintaining the cache (without relying on the default LRU).

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov