### PR TITLE
use collective_comm activity for hccl traces

### DIFF
--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -214,7 +214,7 @@ class ExperimentalConfigWrapper {
 } // namespace
 
 bool collectivesProfilerExists() {
-#ifdef KINETO_HAS_NCCL_PROFILER
+#if defined(KINETO_HAS_NCCL_PROFILER) || defined(KINETO_HAS_HCCL_PROFILER)
   return true;
 #else
   return false;


### PR DESCRIPTION
Summary: Use existing collective_comm (currently used for nccl traces) for hccl traces as well. Only init the nccl profiler when KINETO_HAS_NCCL_PROFILER is defined so as to not init it when the build is for MTIA/HCCL

Test Plan: CIs

Differential Revision: D67285333


