### PR TITLE
Restore support for other types of async_compile pools (spawn, fork)

### DIFF
--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -1,0 +1,37 @@
+# Owner(s): ["module: inductor"]
+import torch
+from torch._inductor import config
+from torch._inductor.async_compile import AsyncCompile, shutdown_compile_workers
+from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.utils import fresh_inductor_cache
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
+from torch.testing._internal.inductor_utils import requires_gpu, requires_triton
+
+
+@instantiate_parametrized_tests
+class TestAsyncCompile(TestCase):
+    @requires_gpu()
+    @requires_triton()
+    @parametrize("method", ("subprocess", "fork", "spawn"))
+    def test_pool(self, method):
+        def fn(x, y):
+            return x + y
+
+        x = torch.rand(10).cuda()
+        y = torch.rand(10).cuda()
+
+        with config.patch("worker_start_method", method):
+            shutdown_compile_workers()
+            pool = AsyncCompile.process_pool()
+            pool.ready_future.result(timeout=120)
+
+            with fresh_inductor_cache():
+                compiled_fn = torch.compile(fn)
+                self.assertEqual(fn(x, y), compiled_fn(x, y))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 import atexit
 import functools
 import logging
+import multiprocessing
 import os
 import sys
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
+from functools import partial
 from time import time
 from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
@@ -26,7 +28,8 @@ from torch._inductor.codecache import (
     TritonCodeCache,
     TritonFuture,
 )
-from torch._inductor.compile_worker.subproc_pool import SubprocPool
+from torch._inductor.compile_worker.subproc_pool import AnyPool, SubprocPool
+from torch._inductor.compile_worker.watchdog import _async_compile_initializer
 from torch._inductor.runtime.compile_tasks import (
     _set_triton_ptxas_path,
     _worker_compile_triton,
@@ -93,7 +96,7 @@ _IS_WINDOWS = sys.platform == "win32"
 log = logging.getLogger(__name__)
 
 # Used to keep track of all process pools invoked so far.
-_pool_set = OrderedSet[SubprocPool]()
+_pool_set = OrderedSet[AnyPool]()
 
 
 def shutdown_compile_workers() -> None:
@@ -142,14 +145,34 @@ class AsyncCompile:
 
     @staticmethod
     @functools.lru_cache(1)
-    def process_pool() -> SubprocPool:
+    def process_pool() -> AnyPool:
         assert get_compile_threads() > 1
-        # Wrapper around ProcessPoolExecutor forks in a new process we control
-        log.info("Creating subprocess pool with %d workers", get_compile_threads())
-        pool = SubprocPool(get_compile_threads())
+        log.info(
+            "Creating '%s' pool with %d workers",
+            config.worker_start_method,
+            get_compile_threads(),
+        )
+
+        pool: AnyPool
+        if config.worker_start_method == "subprocess":
+            # Wrapper around ProcessPoolExecutor forks in a new process we control
+            pool = SubprocPool(get_compile_threads())
+        else:
+            pre_fork_setup()
+            ctx = multiprocessing.get_context(config.worker_start_method)
+            pool = ProcessPoolExecutor(
+                get_compile_threads(),
+                mp_context=ctx,
+                initializer=partial(_async_compile_initializer, os.getpid()),
+            )
+            # when this pool is created in a subprocess object, the normal exit handler
+            # doesn't run, and we need to register our own handler.
+            # exitpriority has to be high, because another one of the finalizers will
+            # kill the worker thread that sends the shutdown message to the workers...
+            multiprocessing.util.Finalize(None, pool.shutdown, exitpriority=sys.maxsize)
 
         # Set an attribute we can check to see if the pool is ready.
-        pool.ready_future = pool.submit(AsyncCompile._get_ready)  # type: ignore[attr-defined]
+        pool.ready_future = pool.submit(AsyncCompile._get_ready)  # type: ignore[union-attr]
         _pool_set.add(pool)
         return pool
 
@@ -171,7 +194,7 @@ class AsyncCompile:
     def use_process_pool(self):
         return (
             get_compile_threads() > 1
-            and self.process_pool().ready_future.done()  # type: ignore[attr-defined]
+            and self.process_pool().ready_future.done()  # type: ignore[union-attr]
         )
 
     def triton(self, kernel_name: str, source_code: str, device_str: str = "cuda"):

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -158,6 +158,9 @@ class AsyncCompile:
             # Wrapper around ProcessPoolExecutor forks in a new process we control
             pool = SubprocPool(get_compile_threads())
         else:
+            if config.worker_start_method == "spawn":
+                # Avoid creating pools in the spawned subprocs themselves:
+                os.environ["TORCH_WARM_POOL"] = "0"
             pre_fork_setup()
             ctx = multiprocessing.get_context(config.worker_start_method)
             pool = ProcessPoolExecutor(

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -340,6 +340,9 @@ class SubprocMain:
         return pickler.dumps(result)
 
 
+AnyPool = typing.Union[ProcessPoolExecutor, SubprocPool]
+
+
 def _warm_process_pool(pool: ProcessPoolExecutor, n: int) -> None:
     # We have to fork processes for compiler workers, but the more memory and other resources that are loaded, the
     # slower the os.fork time is, quite drastically. It also holds the GIL so we can't put it on another thread.

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -549,8 +549,22 @@ optimize_scatter_upon_const_tensor = (
     os.environ.get("TORCHINDUCTOR_OPTIMIZE_SCATTER_UPON_CONST_TENSOR", "1") == "1"
 )
 
-# Deprecated. This setting does nothing.
-worker_start_method: Optional[str] = None
+
+# The multiprocessing start method to use for inductor workers in the codecache.
+def decide_worker_start_method() -> str:
+    if "TORCHINDUCTOR_WORKER_START" in os.environ:
+        start_method = os.environ["TORCHINDUCTOR_WORKER_START"]
+    else:
+        start_method = "subprocess"
+    assert start_method in (
+        "subprocess",
+        "fork",
+        "spawn",
+    ), f"Invalid start method: {start_method}"
+    return start_method
+
+
+worker_start_method: str = decide_worker_start_method()
 
 # Flags to turn on all_reduce fusion. These 2 flags should be automaticaly turned
 # on by DDP and should not be set by the users.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144491

Summary: https://github.com/pytorch/pytorch/pull/142001 removed support for process pools other than "subprocess", but some OSS users still find it useful; put it back.

Test Plan: New unit test

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @BoyuanFeng