### PR TITLE
[BE] Fix extra-semi warnings in int4mm_kernel.cpp

### DIFF
--- a/aten/src/ATen/native/cpu/int4mm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/int4mm_kernel.cpp
@@ -995,7 +995,7 @@ static void ref_dyn_quant_matmul_4bit_channelwise_kernel(
       dst_f32 += 1;
     }
   }
-};
+}
 
 static void ref_dyn_quant_matmul_4bit_groupwise_kernel(
     size_t m,
@@ -1066,7 +1066,7 @@ static void ref_dyn_quant_matmul_4bit_groupwise_kernel(
         dst_ptr += sizeof(int8_t);
       }
     }
-  };
+  }
 
   auto lhs_qa8dx_buffer = std::make_unique<int8_t[]>(
       m * (k + sizeof(float) + sizeof(int32_t))); // Allocate for LHS

--- a/aten/src/ATen/native/cpu/int4mm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/int4mm_kernel.cpp
@@ -1066,7 +1066,7 @@ static void ref_dyn_quant_matmul_4bit_groupwise_kernel(
         dst_ptr += sizeof(int8_t);
       }
     }
-  }
+  };
 
   auto lhs_qa8dx_buffer = std::make_unique<int8_t[]>(
       m * (k + sizeof(float) + sizeof(int32_t))); // Allocate for LHS


### PR DESCRIPTION
Fixes
```
In file included from /Users/nshulga/git/pytorch/pytorch/build/aten/src/ATen/native/cpu/int4mm_kernel.cpp.DEFAULT.cpp:1:
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/cpu/int4mm_kernel.cpp:998:2: warning: extra ';' outside of a function is incompatible with C++98 [-Wc++98-compat-extra-semi]
};
 ^

```


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10