### PR TITLE
[BE][Opinfo] Delete redundant `dtypesIfCUDA`

### DIFF
--- a/torch/testing/_internal/opinfo/definitions/signal.py
+++ b/torch/testing/_internal/opinfo/definitions/signal.py
@@ -292,7 +292,6 @@ def make_signal_windows_opinfo(
         name=name,
         ref=ref if TEST_SCIPY else None,
         dtypes=floating_types(),
-        dtypesIfCUDA=floating_types(),
         sample_inputs_func=sample_inputs_func,
         reference_inputs_func=reference_inputs_func,
         error_inputs_func=error_inputs_func,

--- a/torch/testing/_internal/opinfo/definitions/special.py
+++ b/torch/testing/_internal/opinfo/definitions/special.py
@@ -196,7 +196,6 @@ op_db: List[OpInfo] = [
         variant_test_name="special_polygamma_n_0",
         ref=reference_polygamma if TEST_SCIPY else None,
         dtypes=all_types_and(torch.bool, torch.half, torch.bfloat16),
-        dtypesIfCUDA=all_types_and(torch.bool, torch.half, torch.bfloat16),
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         sample_inputs_func=sample_inputs_polygamma,


### PR DESCRIPTION
If they are the same as CPU, no need to have that extra line

Discovered while reviewing https://github.com/pytorch/pytorch/pull/143833
