### PR TITLE
[minifier] Fix config generator for callables

### DIFF
--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -12,6 +12,7 @@ from typing import Optional
 from torch.testing._internal import (
     fake_config_module as config,
     fake_config_module2 as config2,
+    fake_config_module3 as config3,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.utils._config_module import _UNSET_SENTINEL, Config
@@ -177,6 +178,23 @@ torch.testing._internal.fake_config_module.e_env_default = True
 torch.testing._internal.fake_config_module.e_env_default_FALSE = False
 torch.testing._internal.fake_config_module.e_env_force = True
 torch.testing._internal.fake_config_module._save_config_ignore = ['e_ignored']""",
+        )
+
+    def test_codegen_config_function(self):
+        import logging
+        import warnings
+
+        config3.e_list = [print, warnings.warn, logging.warn]
+        config3.e_set = {print}
+        config3.e_func = warnings.warn
+        code = config3.codegen_config()
+        self.assertIn("import _warnings", code)
+        self.assertIn("import logging", code)
+        self.assertIn(
+            """torch.testing._internal.fake_config_module3.e_list = ['print', '_warnings.warn', 'logging.warn']
+torch.testing._internal.fake_config_module3.e_set = { print }
+torch.testing._internal.fake_config_module3.e_func = _warnings.warn""",
+            code,
         )
 
     def test_get_hash(self):

--- a/torch/testing/_internal/fake_config_module3.py
+++ b/torch/testing/_internal/fake_config_module3.py
@@ -1,0 +1,11 @@
+import sys
+from typing import Callable, Optional
+
+from torch.utils._config_module import install_config_module
+
+
+e_list = [1]
+e_set = {1}
+e_func: Optional[Callable] = None
+
+install_config_module(sys.modules[__name__])


### PR DESCRIPTION
Summary:
When config contains callables, the current configs generated cannot be run:

```
torch._dynamo.config.reorderable_logging_functions = {<built-in function print>, <function warning at 0x7f774c595630>, <function log at 0x7f774c595870>, <function error at 0x7f774c595510>, <function info at 0x7f774c595750>, <built-in function warn>, <function exception at 0x7f774c5955a0>, <function debug at 0x7f774c5957e0>, <function critical at 0x7f774c5953f0>}
```

We fix the config to generate the right string, so the config is runnable, like below

```
import logging
import warnings
torch._dynamo.config.reorderable_logging_functions = { warnings.warn, logging.warn, print }
```

Test Plan:
```
buck2 run 'fbcode//mode/dev-nosan' fbcode//caffe2/test:utils -- -r test_codegen_config
```

Differential Revision: D67998703


