### PR TITLE
[aoti] Remove example inputs from aoti_compile_and_package

### DIFF
--- a/test/export/test_draft_export.py
+++ b/test/export/test_draft_export.py
@@ -417,7 +417,6 @@ class TestDraftExport(TestCase):
         with tempfile.NamedTemporaryFile(suffix=".pt2") as f:
             torch._inductor.aoti_compile_and_package(
                 draft_ep,
-                example_inputs,
                 package_path=f.name,
             )
 

--- a/test/inductor/test_minifier.py
+++ b/test/inductor/test_minifier.py
@@ -239,9 +239,7 @@ with torch.no_grad():
     ep = torch.export.export(
         model, example_inputs, kwargs
     )
-    torch._inductor.aoti_compile_and_package(
-        ep, example_inputs, kwargs
-    )
+    torch._inductor.aoti_compile_and_package(ep)
 """
         return self._run_full_test(run_code, None, expected_error, isolate=True)
 


### PR DESCRIPTION
Summary: The args were removed in https://github.com/pytorch/pytorch/pull/140991

Test Plan: CI

Differential Revision: D67998954




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov