### PR TITLE
[MPS] Make sure that MPSStream is usable from C++

### DIFF
--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -22,6 +22,7 @@ typedef id<MTLSharedEvent> MTLSharedEvent_t;
 typedef id<MTLDevice> MTLDevice_t;
 typedef id<MTLBuffer> MTLBuffer_t;
 #else
+#include <dispatch/dispatch.h>
 typedef void* MPSCommandBuffer_t;
 typedef void* MPSGraph;
 typedef void* MPSGraphExecutionDescriptor;
@@ -29,7 +30,6 @@ typedef void* MPSGraphCompilationDescriptor;
 typedef void* MTLCommandQueue_t;
 typedef void* MTLComputeCommandEncoder_t;
 typedef void* MTLSharedEvent_t;
-typedef void* dispatch_queue_t;
 typedef void* MTLDevice_t;
 typedef void* MTLBuffer_t;
 typedef void* MTLCommandBufferHandler;

--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -15,21 +15,26 @@
 #include <Metal/Metal.h>
 #include <MetalPerformanceShaders/MetalPerformanceShaders.h>
 #include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+typedef MPSCommandBuffer* MPSCommandBuffer_t;
 typedef id<MTLCommandQueue> MTLCommandQueue_t;
-typedef id<MTLCommandBuffer> MTLCommandBuffer_t;
 typedef id<MTLComputeCommandEncoder> MTLComputeCommandEncoder_t;
 typedef id<MTLSharedEvent> MTLSharedEvent_t;
 typedef id<MTLDevice> MTLDevice_t;
+typedef id<MTLBuffer> MTLBuffer_t;
 #else
+typedef void* MPSCommandBuffer_t;
+typedef void* MPSGraph;
+typedef void* MPSGraphExecutionDescriptor;
+typedef void* MPSGraphCompilationDescriptor;
 typedef void* MTLCommandQueue_t;
-typedef void* MTLCommandQueue;
-typedef void* MTLCommandBuffer_t;
-typedef void* MTLCommandBuffer;
 typedef void* MTLComputeCommandEncoder_t;
 typedef void* MTLSharedEvent_t;
 typedef void* dispatch_queue_t;
 typedef void* MTLDevice_t;
-#define nil NULL;
+typedef void* MTLBuffer_t;
+typedef void* MTLCommandBufferHandler;
+typedef void* NSDictionary;
+#define nil NULL
 #endif
 
 namespace at::mps {
@@ -55,27 +60,29 @@ class TORCH_API MPSStream {
   explicit MPSStream(Stream stream);
 
   ~MPSStream();
+
   MTLCommandQueue_t commandQueue() const {
     return _commandQueue;
-  };
+  }
+
   dispatch_queue_t queue() const {
     return _serialQueue;
   }
 
-  MPSCommandBuffer* commandBuffer();
+  MPSCommandBuffer_t commandBuffer();
   MTLComputeCommandEncoder_t commandEncoder();
   void endKernelCoalescing();
   void synchronize(SyncType syncType);
-  void fill(id<MTLBuffer> buffer, uint8_t value, size_t length, size_t offset, SyncType syncType = SyncType::NONE);
-  void copy(id<MTLBuffer> srcBuffer,
-            id<MTLBuffer> dstBuffer,
+  void fill(MTLBuffer_t buffer, uint8_t value, size_t length, size_t offset, SyncType syncType = SyncType::NONE);
+  void copy(MTLBuffer_t srcBuffer,
+            MTLBuffer_t dstBuffer,
             size_t length,
             size_t srcOffset,
             size_t dstOffset,
             uint64_t profileId,
             SyncType syncType = SyncType::NONE);
-  void copy_and_sync(id<MTLBuffer> srcBuffer,
-                     id<MTLBuffer> dstBuffer,
+  void copy_and_sync(MTLBuffer_t srcBuffer,
+                     MTLBuffer_t dstBuffer,
                      size_t length,
                      size_t srcOffset,
                      size_t dstOffset,
@@ -94,11 +101,9 @@ class TORCH_API MPSStream {
 
   MTLCommandQueue_t stream() const {
     return _commandQueue;
-  };
-
-  MTLDevice_t device() const {
-    return [_commandQueue device];
   }
+
+  MTLDevice_t device() const;
 
   /// Explicit conversion to Stream.
   Stream unwrap() const {
@@ -108,8 +113,8 @@ class TORCH_API MPSStream {
  private:
   Stream _stream;
   MTLCommandQueue_t _commandQueue = nil;
-  MPSCommandBuffer* _commandBuffer = nil;
-  MPSCommandBuffer* _prevCommandBuffer = nil;
+  MPSCommandBuffer_t _commandBuffer = nil;
+  MPSCommandBuffer_t _prevCommandBuffer = nil;
   MTLComputeCommandEncoder_t _commandEncoder = nil;
   MPSGraphExecutionDescriptor* _executionDescriptor = nil;
   MPSGraphCompilationDescriptor* _compilationDescriptor = nil;

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -51,6 +51,10 @@ MPSCommandBuffer* MPSStream::commandBuffer() {
   return _commandBuffer;
 }
 
+id<MTLDevice> MPSStream::device() const {
+  return [_commandQueue device];
+}
+
 id<MTLComputeCommandEncoder> MPSStream::commandEncoder() {
   if (!_commandEncoder) {
     _commandEncoder = [commandBuffer() computeCommandEncoder].retain;

--- a/aten/src/ATen/test/mps_test_metal_library.cpp
+++ b/aten/src/ATen/test/mps_test_metal_library.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <stdexcept>
 #include <torch/torch.h>
+#include <ATen/mps/MPSStream.h>
 #include <ATen/native/mps/MetalShaderLibrary.h>
 
 using namespace at::native::mps;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #144561
* #144560
* __->__ #144559

It's intended to be, but this was never tested.
This change introduces no new functionality, just properly isolates ObjC implementation details from the potential C++ caller