### PR TITLE
[MPS] Make MPSProfiler usable from C++

### DIFF
--- a/aten/src/ATen/mps/MPSProfiler.h
+++ b/aten/src/ATen/mps/MPSProfiler.h
@@ -16,6 +16,10 @@
 #include <unordered_map>
 #include <utility>
 
+#ifndef __OBJC__
+typedef void* MTLCaptureManager;
+#endif
+
 namespace at::mps {
 
 namespace Profiler {
@@ -58,24 +62,7 @@ struct BaseInfo {
   // builds a string for a tensor (format: Device:ScalarType[tensor.sizes()])
   static std::string buildTensorString(
       const Tensor& tensor,
-      bool includeBufferId = false) {
-    if (tensor.defined()) {
-      std::stringstream tensorStr;
-      auto deviceType = tensor.device().type();
-      tensorStr << c10::DeviceTypeName(deviceType);
-      // see comments for INCLUDE_BUFFER_ID
-      if (includeBufferId && deviceType == at::kMPS) {
-        id<MTLBuffer> buffer =
-            __builtin_bit_cast(id<MTLBuffer>, tensor.storage().data());
-        tensorStr << "(buf#" << (getIMPSAllocator()->getBufferId(buffer)) << ":"
-                  << buffer.retainCount << ")";
-      }
-      tensorStr << ":" << tensor.scalar_type() << tensor.sizes();
-      return tensorStr.str();
-    } else {
-      return "undefined";
-    }
-  }
+      bool includeBufferId = false);
   static uint64_t getTime() {
     return clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW);
   }

--- a/aten/src/ATen/test/mps_test_metal_library.cpp
+++ b/aten/src/ATen/test/mps_test_metal_library.cpp
@@ -2,6 +2,7 @@
 #include <stdexcept>
 #include <torch/torch.h>
 #include <ATen/mps/MPSStream.h>
+#include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/mps/MetalShaderLibrary.h>
 
 using namespace at::native::mps;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #144561
* __->__ #144560
* #144559

By moving `buildTensorString` implementation away from the header