### PR TITLE
Disable scuba logging for autotuning

### DIFF
--- a/test/dynamo/test_structured_trace.py
+++ b/test/dynamo/test_structured_trace.py
@@ -255,7 +255,6 @@ class StructuredTraceTest(TestCase):
 {"artifact": {"name": "aotautograd_cache_hash", "encoding": "json"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_cpp_guards_str": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"compilation_metrics": "METRICS", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
-{"compilation_metrics_runtime": "METRICS", "stack": "STACK"}
 """,  # noqa: B950
         )
 
@@ -283,7 +282,6 @@ class StructuredTraceTest(TestCase):
 {"artifact": {"name": "aotautograd_cache_hash", "encoding": "json"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_cpp_guards_str": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"compilation_metrics": "METRICS", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
-{"compilation_metrics_runtime": "METRICS", "stack": "STACK"}
 """,  # noqa: B950
         )
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -761,7 +761,8 @@ class CachingAutotuner(KernelInterface):
             "CachingAutotuner.benchmark_all_configs",
             log_pt2_compile_event=True,
             metadata={"kernel_name": self.inductor_meta.get("kernel_name")},
-            dynamo_compile_runtime_column_us="runtime_triton_autotune_time_us",
+            # TODO(masnesral): Enable this when we figure out how to get the CompileId:
+            # dynamo_compile_runtime_column_us="runtime_triton_autotune_time_us",
         ):
             timings = {
                 launcher: self.bench(launcher, *args, **kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144568

Summary: the compile IDs are currently null, which is confusing. Turn it off until we have a solution.

Test Plan: https://fburl.com/scuba/dynamo_compile/sandbox/g2d2g5xs

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov