### PR TITLE
[ez] add lint commits to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -44,3 +44,97 @@ a53cda1ddc15336dc1ff0ce1eff2a49cdc5f882e
 d80939e5e9337e8078f11489afefec59fd42f93b
 # 2024-06-28 enable UFMT in `torch.utils.data`
 7cf0b90e49689d45be91aa539fdf54cf2ea8a9a3
+# 2024-06-29 [BE] enforce style for empty lines in import segments (#129751)
+f5ff1a3ab9ef279655308266029faf6543a8a1ca
+# 2024-06-29 [BE] enforce style for empty lines in import segments (#129751)
+7837a12474c792fb61e316f4bebbace1bdc99fe0
+# 2024-06-30 Enable UFMT on test/test_public_bindings.py (#128389)
+fe5424d0f8604f6e66d827ae9f94b05cb7119d55
+# 2024-07-02 [Ez][BE]: Enable new stable ruff rules (#129825)
+6c2a8b6b3877ff196534a68fda7045cfe8d4809f
+# 2024-07-03 Enable UFMT on test/test_public_bindings.py (#128389)
+c686304277f7cd72331f685605325498cff94a0b
+# 2024-07-15 Enable UFMT on all of torch/sparse (#130545)
+535016967ae65a6027f83d6b935a985996223d49
+# 2024-07-15 [BE][Easy][1/19] enforce style for empty lines in import segments (#129752)
+a3abfa5cb57203b6a8ba7dff763f4057db8282a8
+# 2024-07-15 [BE][Easy][2/19] enforce style for empty lines in import segments in `.ci/` and `.github/` (#129753)
+47b38c131e22d2fabb9149dca069cc9d3eb2e43
+# 2024-07-16 [BE][Easy][6/19] enforce style for empty lines in import segments in `test/` (#129757)
+ba48cf653541e9160dfdefa7bfea885c22e48608
+# 2024-07-16 [BE][Easy][5/19] enforce style for empty lines in import segments in `tools/` and `torchgen/` (#129756)
+f6838d521a243dbedc50ae96575720bf2cc8a8ad
+# 2024-07-17 [BE][Easy][9/19] enforce style for empty lines in import segments in `test/[e-h]*/` (#129760)
+76169cf69184bd462b9add40f893f57675f8a057
+# 2024-07-16 [BE][Easy][3/19] enforce style for empty lines in import segments in `benchmarks/` (#129754)
+c0ed38e644aed812d76b0ec85fae2f6019bf462b
+# 2024-07-17 [BE][Easy][10/19] enforce style for empty lines in import segments in `test/d*/` (#129761)
+b3290846e430cb2470b0cad3296c89783c22035
+# 2024-07-16 [BE][Easy][4/19] enforce style for empty lines in import segments in `functorch/` (#129755)
+740fb229660f388feddc288c127ab12c82e67d36
+# 2024-07-17 [BE][Easy][12/19] enforce style for empty lines in import segments in `test/i*/` (#129763)
+aecc746fccc4495313167e3a7f94210daf457e1d
+# 2024-07-18 Revert "[BE][Easy][12/19] enforce style for empty lines in import segments in `test/i*/` (#129763)"
+b732b52f1e4378f8486ceb5e7026be3321c2651c
+# 2024-07-18 [BE][Easy][12/19] enforce style for empty lines in import segments in `test/i*/` (#129763)
+134bc4fc34bb02795aa694e66b132dcea5dde1e1
+# 2024-07-20 [BE][Easy][16/19] enforce style for empty lines in import segments in `torch/_i*/` (#129768)
+6d477fd5688f43aa0ea20d7cbcd60e86e8a6553
+# 2024-07-27 [BE][Easy][11/19] enforce style for empty lines in import segments in `test/dy*/` (#129762)
+18ece4f4d8e19f1fc7bcc6baba4735340c6200a
+# 2024-07-26 [BE][Easy][8/19] enforce style for empty lines in import segments in `test/[k-p]*/` (#129759)
+fbe6f42dcf1834213e0baa87b87529161df3c4d7
+# 2024-07-31 [BE][Easy][14/19] enforce style for empty lines in import segments in `torch/_[a-c]*/` and `torch/_[e-h]*/` and `torch/_[j-z]*/` (#129765)
+e7eeee473c6cb45942e87de5a616b0eb635513d6
+# 2024-07-26 [BE][Easy][7/19] enforce style for empty lines in import segments in `test/[a-c]*/` and `test/[q-z]*/` (#129758)
+48c460bf1f0efe10ace8c046de0d34e8efbe2ab
+# 2024-07-31 Fix lint after PR #130572 (#132316)
+d72e863b3ecd3de4c8ea00518e110da964583f4f
+# 2024-07-31 [BE][Easy][15/19] enforce style for empty lines in import segments in `torch/_d*/` (#129767)
+e74ba1b34a476b46e76b4e32afe2d481f97e9a47
+# 2024-07-31 [BE][Easy][18/19] enforce style for empty lines in import segments in `torch/d*/` (#129770)
+b25ef91bf158ce459d8654e33c50c8e6ed8db716
+# 2024-07-20 [BE][Easy][13/19] enforce style for empty lines in import segments in `test/j*/` (#129764)
+6ff1e43a416c43cd82b210e22ac47384494c172e
+# 2024-07-31 [BE][Easy][19/19] enforce style for empty lines in import segments in `torch/[o-z]*/` (#129771)
+0293319a8ffa483be80cbe5f33cfde3ef576fe6
+# 2024-08-04 Remove lint dependency `ufmt` (#132573)
+d2dc173664da5fec74acee9122694baddc2d7639
+# 2024-08-04 [BE] Format uncategorized Python files with `ruff format` (#132576)
+226ed15853517dec163fb85656a0a788ff060e7
+# 2024-08-14 [lint] fix lint broken by #131912 (#133428)
+54a5ba95881a2369fc2c5d04ecfabdb07ef9510
+# 2024-08-20 [BE] Fix lint issues in qlinear_prepack.cpp (#133797)
+2f57ac6278385293f44623523c7ca35eee74f4e
+# 2024-08-26 Fix lint failures (#134488)
+f82dc816aa5ff17366c9c978a14c826b4393bc6
+# 2024-09-13 Fix lint errors in fbcode (#135614)
+c356ce3daf3f57b23c35569fa0315f970a9ae78
+# 2024-09-26 Fix lint (#136781)
+656a603b24ba1e3cdeae8839ef18f6364c458f5
+# 2024-09-30 Fix lint (#137023)
+0f80a70fab672e96a088796fa1b742a70b93070
+# 2024-10-19 Fix lint
+0879d0c2111ffa9efed66225b4fe815c4641d47
+# 2024-11-01 [Lint] Clang-format all metal kernels (#139530)
+b3ad45733bd908b7358959ca1e1f8d026f4507eb
+# 2024-11-12 Fix lint after #138899 (#140446)
+4675875d16cf8e11a6e2105dcd24c549d59a44d5
+# 2024-11-17 [BE][MPS] Apply clang-format to mps headers (#140906)
+99014a297c179862af38ee86bac2051434d3db41
+# 2024-11-20 Forward fix lint after #140443 (#141088)
+5e0c009a5a4484bcb4254bcce20faf6fcabb0769
+# 2024-11-27 Apply clang-format for ATen/core/boxing headers (#141105)
+19d01a1ef0c0d65768eb0a5c97a25328eec57fbd
+# 2024-12-05 fix the lint from D66795414 (#142122)
+65c2086d452ae6966ce9d7fb3cb2eef2fd0d2add
+# 2024-12-20 Apply clang-format for ATen/core/dispatch headers (#143620)
+cee06e74eeb54994b97000a02b715a4e63a97951
+# 2024-12-22 Better fix for f-strings in set_linter for py3.12 (#143725)
+eebc93d41eeffb936cbf20c9052e1e813d0cc052
+# 2025-01-04 [mps/BE] Fix linter warning/advice. (#144199)
+0dc1e6be192b260f1c072d70e1b06a3ac8e109fa
+# 2025-01-07 Fix lint in `test_provenance_tracing.py` (#144296)
+61c0a3d1cbaf6420e40ab0f9c9019daa21145e69
+# 2025-01-09 [BE] fix ruff rule E226: add missing whitespace around operator in f-strings (#144415)
+dcc3cf7066b4d8cab63ecb73daf1e36b01220a4e

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -43,15 +43,7 @@ a53cda1ddc15336dc1ff0ce1eff2a49cdc5f882e
 # 2024-06-28 enable UFMT in `torch/storage.py`
 d80939e5e9337e8078f11489afefec59fd42f93b
 # 2024-06-28 enable UFMT in `torch.utils.data`
-7cf0b90e49689d45be91aa539fdf54cf2ea8a9a3
-# 2024-06-29 [BE] enforce style for empty lines in import segments (#129751)
-f5ff1a3ab9ef279655308266029faf6543a8a1ca
-# 2024-06-29 [BE] enforce style for empty lines in import segments (#129751)
-7837a12474c792fb61e316f4bebbace1bdc99fe0
-# 2024-06-30 Enable UFMT on test/test_public_bindings.py (#128389)
 fe5424d0f8604f6e66d827ae9f94b05cb7119d55
-# 2024-07-02 [Ez][BE]: Enable new stable ruff rules (#129825)
-6c2a8b6b3877ff196534a68fda7045cfe8d4809f
 # 2024-07-03 Enable UFMT on test/test_public_bindings.py (#128389)
 c686304277f7cd72331f685605325498cff94a0b
 # 2024-07-15 Enable UFMT on all of torch/sparse (#130545)
@@ -59,8 +51,6 @@ c686304277f7cd72331f685605325498cff94a0b
 # 2024-07-15 [BE][Easy][1/19] enforce style for empty lines in import segments (#129752)
 a3abfa5cb57203b6a8ba7dff763f4057db8282a8
 # 2024-07-15 [BE][Easy][2/19] enforce style for empty lines in import segments in `.ci/` and `.github/` (#129753)
-47b38c131e22d2fabb9149dca069cc9d3eb2e43
-# 2024-07-16 [BE][Easy][6/19] enforce style for empty lines in import segments in `test/` (#129757)
 ba48cf653541e9160dfdefa7bfea885c22e48608
 # 2024-07-16 [BE][Easy][5/19] enforce style for empty lines in import segments in `tools/` and `torchgen/` (#129756)
 f6838d521a243dbedc50ae96575720bf2cc8a8ad
@@ -68,8 +58,6 @@ f6838d521a243dbedc50ae96575720bf2cc8a8ad
 76169cf69184bd462b9add40f893f57675f8a057
 # 2024-07-16 [BE][Easy][3/19] enforce style for empty lines in import segments in `benchmarks/` (#129754)
 c0ed38e644aed812d76b0ec85fae2f6019bf462b
-# 2024-07-17 [BE][Easy][10/19] enforce style for empty lines in import segments in `test/d*/` (#129761)
-b3290846e430cb2470b0cad3296c89783c22035
 # 2024-07-16 [BE][Easy][4/19] enforce style for empty lines in import segments in `functorch/` (#129755)
 740fb229660f388feddc288c127ab12c82e67d36
 # 2024-07-17 [BE][Easy][12/19] enforce style for empty lines in import segments in `test/i*/` (#129763)
@@ -78,16 +66,10 @@ aecc746fccc4495313167e3a7f94210daf457e1d
 b732b52f1e4378f8486ceb5e7026be3321c2651c
 # 2024-07-18 [BE][Easy][12/19] enforce style for empty lines in import segments in `test/i*/` (#129763)
 134bc4fc34bb02795aa694e66b132dcea5dde1e1
-# 2024-07-20 [BE][Easy][16/19] enforce style for empty lines in import segments in `torch/_i*/` (#129768)
-6d477fd5688f43aa0ea20d7cbcd60e86e8a6553
-# 2024-07-27 [BE][Easy][11/19] enforce style for empty lines in import segments in `test/dy*/` (#129762)
-18ece4f4d8e19f1fc7bcc6baba4735340c6200a
 # 2024-07-26 [BE][Easy][8/19] enforce style for empty lines in import segments in `test/[k-p]*/` (#129759)
 fbe6f42dcf1834213e0baa87b87529161df3c4d7
 # 2024-07-31 [BE][Easy][14/19] enforce style for empty lines in import segments in `torch/_[a-c]*/` and `torch/_[e-h]*/` and `torch/_[j-z]*/` (#129765)
 e7eeee473c6cb45942e87de5a616b0eb635513d6
-# 2024-07-26 [BE][Easy][7/19] enforce style for empty lines in import segments in `test/[a-c]*/` and `test/[q-z]*/` (#129758)
-48c460bf1f0efe10ace8c046de0d34e8efbe2ab
 # 2024-07-31 Fix lint after PR #130572 (#132316)
 d72e863b3ecd3de4c8ea00518e110da964583f4f
 # 2024-07-31 [BE][Easy][15/19] enforce style for empty lines in import segments in `torch/_d*/` (#129767)
@@ -96,34 +78,12 @@ e74ba1b34a476b46e76b4e32afe2d481f97e9a47
 b25ef91bf158ce459d8654e33c50c8e6ed8db716
 # 2024-07-20 [BE][Easy][13/19] enforce style for empty lines in import segments in `test/j*/` (#129764)
 6ff1e43a416c43cd82b210e22ac47384494c172e
-# 2024-07-31 [BE][Easy][19/19] enforce style for empty lines in import segments in `torch/[o-z]*/` (#129771)
-0293319a8ffa483be80cbe5f33cfde3ef576fe6
-# 2024-08-04 Remove lint dependency `ufmt` (#132573)
-d2dc173664da5fec74acee9122694baddc2d7639
-# 2024-08-04 [BE] Format uncategorized Python files with `ruff format` (#132576)
-226ed15853517dec163fb85656a0a788ff060e7
-# 2024-08-14 [lint] fix lint broken by #131912 (#133428)
-54a5ba95881a2369fc2c5d04ecfabdb07ef9510
-# 2024-08-20 [BE] Fix lint issues in qlinear_prepack.cpp (#133797)
-2f57ac6278385293f44623523c7ca35eee74f4e
-# 2024-08-26 Fix lint failures (#134488)
-f82dc816aa5ff17366c9c978a14c826b4393bc6
-# 2024-09-13 Fix lint errors in fbcode (#135614)
-c356ce3daf3f57b23c35569fa0315f970a9ae78
-# 2024-09-26 Fix lint (#136781)
-656a603b24ba1e3cdeae8839ef18f6364c458f5
 # 2024-09-30 Fix lint (#137023)
 0f80a70fab672e96a088796fa1b742a70b93070
-# 2024-10-19 Fix lint
-0879d0c2111ffa9efed66225b4fe815c4641d47
 # 2024-11-01 [Lint] Clang-format all metal kernels (#139530)
 b3ad45733bd908b7358959ca1e1f8d026f4507eb
-# 2024-11-12 Fix lint after #138899 (#140446)
-4675875d16cf8e11a6e2105dcd24c549d59a44d5
 # 2024-11-17 [BE][MPS] Apply clang-format to mps headers (#140906)
 99014a297c179862af38ee86bac2051434d3db41
-# 2024-11-20 Forward fix lint after #140443 (#141088)
-5e0c009a5a4484bcb4254bcce20faf6fcabb0769
 # 2024-11-27 Apply clang-format for ATen/core/boxing headers (#141105)
 19d01a1ef0c0d65768eb0a5c97a25328eec57fbd
 # 2024-12-05 fix the lint from D66795414 (#142122)

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -78,8 +78,6 @@ e74ba1b34a476b46e76b4e32afe2d481f97e9a47
 b25ef91bf158ce459d8654e33c50c8e6ed8db716
 # 2024-07-20 [BE][Easy][13/19] enforce style for empty lines in import segments in `test/j*/` (#129764)
 6ff1e43a416c43cd82b210e22ac47384494c172e
-# 2024-09-30 Fix lint (#137023)
-0f80a70fab672e96a088796fa1b742a70b93070
 # 2024-11-01 [Lint] Clang-format all metal kernels (#139530)
 b3ad45733bd908b7358959ca1e1f8d026f4507eb
 # 2024-11-17 [BE][MPS] Apply clang-format to mps headers (#140906)

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -43,6 +43,8 @@ a53cda1ddc15336dc1ff0ce1eff2a49cdc5f882e
 # 2024-06-28 enable UFMT in `torch/storage.py`
 d80939e5e9337e8078f11489afefec59fd42f93b
 # 2024-06-28 enable UFMT in `torch.utils.data`
+7cf0b90e49689d45be91aa539fdf54cf2ea8a9a3
+# 2024-07-03 Enable UFMT on test/test_public_bindings.py (#128389)
 fe5424d0f8604f6e66d827ae9f94b05cb7119d55
 # 2024-07-03 Enable UFMT on test/test_public_bindings.py (#128389)
 c686304277f7cd72331f685605325498cff94a0b


### PR DESCRIPTION
Test Plan: Ran git blame on .lintrunner.toml and github's linter (+ manual testing) shows all commits exist