### PR TITLE
Enable grep_linter to use -a

### DIFF
--- a/tools/linter/adapters/grep_linter.py
+++ b/tools/linter/adapters/grep_linter.py
@@ -61,18 +61,13 @@ def run_command(
 
 
 def lint_file(
-    matching_line: str,
+    filename: str,
     allowlist_pattern: str,
     replace_pattern: str,
     linter_name: str,
     error_name: str,
     error_description: str,
 ) -> LintMessage | None:
-    # matching_line looks like:
-    #   tools/linter/clangtidy_linter.py:13:import foo.bar.baz
-    split = matching_line.split(":")
-    filename = split[0]
-
     if allowlist_pattern:
         try:
             proc = run_command(["grep", "-nEHI", allowlist_pattern, filename])
@@ -144,8 +139,8 @@ def lint_file(
             )
 
     return LintMessage(
-        path=split[0],
-        line=int(split[1]) if len(split) > 1 else None,
+        path=filename,
+        line=None,
         char=None,
         code=linter_name,
         severity=LintSeverity.ERROR,
@@ -257,9 +252,15 @@ def main() -> None:
         sys.exit(0)
 
     lines = proc.stdout.decode().splitlines()
-    for line in lines:
+    # matching_line looks like:
+    #   tools/linter/clangtidy_linter.py:13:import foo.bar.baz
+    files = set(
+        line.split(":")[0]
+        for line in lines
+    )
+    for file in files:
         lint_message = lint_file(
-            line,
+            file,
             args.allowlist_pattern,
             args.replace_pattern,
             args.linter_name,

--- a/tools/linter/adapters/grep_linter.py
+++ b/tools/linter/adapters/grep_linter.py
@@ -254,10 +254,7 @@ def main() -> None:
     lines = proc.stdout.decode().splitlines()
     # matching_line looks like:
     #   tools/linter/clangtidy_linter.py:13:import foo.bar.baz
-    files = set(
-        line.split(":")[0]
-        for line in lines
-    )
+    files = {line.split(":")[0] for line in lines}
     for file in files:
         lint_message = lint_file(
             file,


### PR DESCRIPTION
Lintrunner can only apply changes (-a) if only one suggestion is made per file.  The grep_linter makes a suggestion for every line it finds incorrect, so it creates multiple suggestions per file if there are multiple lines that it wants to change

This sets the `line` parameter of the LintMessage to None for all of grep_linter, but I'm not sure if that entry did anything

I'm not sure if enabling -a is the best idea, since its currently used for tabs and tab width might differ each time?  I had one instance where running with -a cause the spacing to change.  On the other hand, -a would have already worked if only one line was bad