### PR TITLE
Fix mis-categorization of clang++ as gcc.

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -174,6 +174,8 @@ def _is_clang(cpp_compiler: str) -> bool:
 def _is_gcc(cpp_compiler: str) -> bool:
     if sys.platform == "darwin" and _is_apple_clang(cpp_compiler):
         return False
+    if _is_clang(cpp_compiler): #regex for g\+\+ will match clang++
+        return False
     return bool(re.search(r"(gcc|g\+\+)", cpp_compiler))
 
 


### PR DESCRIPTION
Fixes #144601 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @BoyuanFeng