### PR TITLE
[mps/inductor] Add support for exp().

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -165,15 +165,14 @@ class NormalizeIRTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(same(ref, res))
 
 
-class MPSNotSupportedTest(torch._dynamo.test_case.TestCase):
+class MPSSupportedTest(torch._dynamo.test_case.TestCase):
     @unittest.skipIf(not torch.backends.mps.is_available(), "requires mps")
-    def test_mps_not_supported(self):
+    def test_mps_supported(self):
         model = Seq().to("mps")
         example_input = torch.randn(1, 10).to("mps")
-        self.assertRaises(
-            RuntimeError,
-            lambda: torch.compile(model, backend="inductor")(example_input),
-        )
+        rc_eager = model(example_input)
+        rc = torch.compile(model, backend="inductor")(example_input)
+        self.assertEqual(rc, rc_eager)
 
 
 class TestExplainWithBackend(torch._dynamo.test_case.TestCase):

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -55,6 +55,7 @@ class MPSBasicTests(TestCase):
     test_remainder = CommonTemplate.test_remainder
     test_rsqrt = CommonTemplate.test_rsqrt
     test_signbit = CommonTemplate.test_signbit
+    test_silu = CommonTemplate.test_silu
     test_tanh = CommonTemplate.test_tanh
     test_view_as_complex = CommonTemplate.test_view_as_complex
     test_views6 = CommonTemplate.test_views6

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -145,6 +145,10 @@ class MetalOverrides(OpOverrides):
         return f"metal::log({x})"
 
     @staticmethod
+    def exp(x: CSEVariable) -> str:
+        return f"metal::exp({x})"
+
+    @staticmethod
     def abs(x: CSEVariable) -> str:
         return f"metal::abs({x})"
 


### PR DESCRIPTION
inductor/test_silu now passes after this change.

cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov