### PR TITLE
remove allow-untyped-defs from torch/distributed/_checkpointable.py

### DIFF
--- a/torch/distributed/_checkpointable.py
+++ b/torch/distributed/_checkpointable.py
@@ -1,6 +1,5 @@
-# mypy: allow-untyped-defs
 # Copyright (c) Meta Platforms, Inc. and affiliates
-from typing import Any, Protocol, runtime_checkable
+from typing import List, Protocol, runtime_checkable
 
 import torch
 
@@ -13,7 +12,7 @@ class _Checkpointable(Protocol):  # noqa: PYI046
     This is to allow arbitrary objects/tensor subclasses to hook into DCP seamlessly through implementing the interface.
     """
 
-    def __create_write_items__(self, fqn: str, object: Any):
+    def __create_write_items__(self, fqn: str, object: object) -> List[object]:
         """
         Return a list of WriteItems based on object's contents.
         """
@@ -21,7 +20,7 @@ class _Checkpointable(Protocol):  # noqa: PYI046
             "_Checkpointable._create_write_items is not implemented"
         )
 
-    def __create_chunk_list__(self):
+    def __create_chunk_list__(self) -> List[object]:
         """
         Return a list of `ChunkStorageMetadata` based on object's contents.
         """
@@ -29,7 +28,7 @@ class _Checkpointable(Protocol):  # noqa: PYI046
             "_Checkpointable._create_chunk_list is not implemented"
         )
 
-    def __get_tensor_shard__(self, index) -> torch.Tensor:
+    def __get_tensor_shard__(self, index: int) -> torch.Tensor:
         """
         Return a 'torch.Tensor' shard based on 'MetadataIndex'.
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144627



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o