### PR TITLE
Micro-optimization in Graph.nodes.__iter__

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1982,20 +1982,18 @@ reflectable_magic_methods = {
     "matmul": "{} @ {}",
 }
 
-magic_methods = dict(
-    {
-        "eq": "{} == {}",
-        "ne": "{} != {}",
-        "lt": "{} < {}",
-        "gt": "{} > {}",
-        "le": "{} <= {}",
-        "ge": "{} >= {}",
-        "pos": "+{}",
-        "neg": "-{}",
-        "invert": "~{}",
-    },
+magic_methods = {
+    "eq": "{} == {}",
+    "ne": "{} != {}",
+    "lt": "{} < {}",
+    "gt": "{} > {}",
+    "le": "{} <= {}",
+    "ge": "{} >= {}",
+    "pos": "+{}",
+    "neg": "-{}",
+    "invert": "~{}",
     **reflectable_magic_methods,
-)
+}
 
 inplace_methods = {
     "iadd": "{} += {}",

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -291,7 +291,7 @@ class _InsertPoint:
 
 class _node_list:
     def __init__(self, graph: "Graph", direction: str = "_next"):
-        assert direction in ["_next", "_prev"]
+        assert direction in ("_next", "_prev")
         self.graph = graph
         self.direction = direction
 
@@ -299,8 +299,7 @@ class _node_list:
         return self.graph._len
 
     def __iter__(self):
-        assert self.direction == "_prev" or self.direction == "_next"
-        yield from _NodeIter(self.graph._root, self.direction == "_prev")
+        return _NodeIter(self.graph._root, self.direction == "_prev")
 
     def __reversed__(self):
         return _node_list(self.graph, "_next" if self.direction == "_prev" else "_prev")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144631

This generates slightly better code (removing a generator frame) and
drops a redundant assert.

```py
>>> import timeit
>>> def a():
...   yield from range(3)
... 
>>> def b():
...   return range(3)
... 
>>> timeit.timeit(lambda: [*a()])
0.2714634328149259
>>> timeit.timeit(lambda: [*b()])
0.12076826114207506
>>> 
```

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv