### PR TITLE
remove Windows XPU build workaround.

### DIFF
--- a/.ci/pytorch/windows/xpu.bat
+++ b/.ci/pytorch/windows/xpu.bat
@@ -29,9 +29,10 @@ call "%XPU_BUNDLE_ROOT%\ocloc\latest\env\vars.bat"
 IF ERRORLEVEL 1 goto :eof
 
 :: Workaround for https://github.com/pytorch/pytorch/issues/134989
-set CMAKE_SHARED_LINKER_FLAGS=/FORCE:MULTIPLE
-set CMAKE_MODULE_LINKER_FLAGS=/FORCE:MULTIPLE
-set CMAKE_EXE_LINKER_FLAGS=/FORCE:MULTIPLE
+:: We can comment these workaround due to we have fixed it by https://github.com/pytorch/pytorch/issues/141946 
+:: set CMAKE_SHARED_LINKER_FLAGS=/FORCE:MULTIPLE
+:: set CMAKE_MODULE_LINKER_FLAGS=/FORCE:MULTIPLE
+:: set CMAKE_EXE_LINKER_FLAGS=/FORCE:MULTIPLE
 
 if exist "%NIGHTLIES_PYTORCH_ROOT%" cd %NIGHTLIES_PYTORCH_ROOT%\..
 call %~dp0\internal\copy_cpu.bat

--- a/.ci/pytorch/windows/xpu.bat
+++ b/.ci/pytorch/windows/xpu.bat
@@ -28,12 +28,6 @@ call "%XPU_BUNDLE_ROOT%\compiler\latest\env\vars.bat"
 call "%XPU_BUNDLE_ROOT%\ocloc\latest\env\vars.bat"
 IF ERRORLEVEL 1 goto :eof
 
-:: Workaround for https://github.com/pytorch/pytorch/issues/134989
-:: We can comment these workaround due to we have fixed it by https://github.com/pytorch/pytorch/issues/141946 
-:: set CMAKE_SHARED_LINKER_FLAGS=/FORCE:MULTIPLE
-:: set CMAKE_MODULE_LINKER_FLAGS=/FORCE:MULTIPLE
-:: set CMAKE_EXE_LINKER_FLAGS=/FORCE:MULTIPLE
-
 if exist "%NIGHTLIES_PYTORCH_ROOT%" cd %NIGHTLIES_PYTORCH_ROOT%\..
 call %~dp0\internal\copy_cpu.bat
 IF ERRORLEVEL 1 goto :eof

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -540,7 +540,7 @@ if(USE_XNNPACK AND NOT USE_SYSTEM_XNNPACK)
     set(__caffe2_CMAKE_POSITION_INDEPENDENT_CODE_FLAG ${CMAKE_POSITION_INDEPENDENT_CODE})
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-    if(Win32)
+    if(WIN32)
       # Disable libm dependency explicitly to avoid symbol conflict for XNNPACK as
       # Windows runtime has provided the math functions - #134989
       set(XNNPACK_BUILD_WITH_LIBM OFF CACHE BOOL "")


### PR DESCRIPTION
From the RFC: https://github.com/pytorch/pytorch/issues/141946
Fixes https://github.com/pytorch/pytorch/issues/134989

After we land these fixing PRs:
1. https://github.com/pytorch/pytorch/pull/142245
2. https://github.com/pytorch/pytorch/pull/141943

We can remove the Windows XPU workaround.

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @gujinghui @EikanWang @fengyuan14 @guangyey