### PR TITLE
Fix torch.logsumexp dim description

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6236,7 +6236,7 @@ For summation index :math:`j` given by `dim` and other indices :math:`i`, the re
 
 Args:
     {input}
-    {opt_dim}
+    {dim}
     {keepdim}
 
 Keyword args:


### PR DESCRIPTION
Fixes #144339

Remove `dim` optional description in `torch.logsumexp` doc.

**Test Result**

**Before**

![image](https://github.com/user-attachments/assets/44cea233-4103-4d7f-b784-1228a6cae0ef)


**After**

![image](https://github.com/user-attachments/assets/69cecd50-7422-40b7-bed6-608a9c2398ad)
