### PR TITLE
[MPSInductor] Fix maximum/minimum for int types

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -41,6 +41,7 @@ class MPSBasicTests(TestCase):
     test_add_const_int = CommonTemplate.test_add_const_int
     test_add_inplace_permuted_mps = CommonTemplate.test_add_inplace_permuted
     test_addmm = CommonTemplate.test_addmm
+    test_argmax_min_int32 = CommonTemplate.test_argmax_min_int32
     test_div1 = CommonTemplate.test_div1
     test_cat_empty = CommonTemplate.test_cat_empty
     test_floordiv = CommonTemplate.test_floordiv

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -121,14 +121,14 @@ class MetalOverrides(OpOverrides):
         typecast_a = f"static_cast<decltype({a}+{b})>({a})"
         typecast_b = f"static_cast<decltype({a}+{b})>({b})"
         max_res = f"metal::max({typecast_a}, {typecast_b})"
-        return f"metal::isnan({a} + {b}) ? {a} + {b} : {max_res}"
+        return f"isnan({a} + {b}) ? {a} + {b} : {max_res}"
 
     @staticmethod
     def minimum(a: CSEVariable, b: CSEVariable) -> str:
         typecast_a = f"static_cast<decltype({a}+{b})>({a})"
         typecast_b = f"static_cast<decltype({a}+{b})>({b})"
         min_res = f"metal::min({typecast_a}, {typecast_b})"
-        return f"metal::isnan({a} + {b})  ? {a} + {b} : {min_res}"
+        return f"isnan({a} + {b})  ? {a} + {b} : {min_res}"
 
     @staticmethod
     def logical_or(a: CSEVariable, b: CSEVariable) -> str:
@@ -275,6 +275,17 @@ class MetalKernel(SIMDKernel):
         code.writeline('torch.mps._compile_shader("""')
         idx_var_names = [v.name for v in self.active_range_trees()]
         with code.indent():
+            code.splice(
+                """
+            template<typename T> inline bool isnan(T) { return false; }
+            template<> inline bool isnan(float x) { return metal::isnan(x); }
+            template<> inline bool isnan(half x) { return metal::isnan(x); }
+            #if __METAL_VERSION__ >= 310
+            template<> inline bool isnan(bfloat x) { return metal::isnan(x); }
+            #endif
+            """,
+                strip=True,
+            )
             code.writeline("kernel void generated_kernel(")
             with code.indent():
                 for outer, inner in self.args.output_buffers.items():


### PR DESCRIPTION
`metal::isnan` is only defined for floats, so provide a generic wrapper
that is false for integral types

TODO: Figure out why type propagantion is not working (or should it?)

Fixes #ISSUE_NUMBER


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov