### PR TITLE
[XPU build] Fix XPU build error caused by wrong code change introduced by #142213

### DIFF
--- a/torch/csrc/inductor/aoti_runner/model_container_runner_xpu.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner_xpu.cpp
@@ -23,7 +23,7 @@ std::vector<at::Tensor> AOTIModelContainerRunnerXpu::run_impl(
     at::xpu::XPUStream xpu_stream = c10::xpu::getCurrentXPUStream();
     stream_handle = reinterpret_cast<void*>(&(xpu_stream.queue()));
   }
-  return AOTIModelContainerRunner::run_impl(inputs, stream_handle);
+  return AOTIModelContainerRunner::run_impl(input_handles, stream_handle);
 }
 
 std::vector<at::Tensor> AOTIModelContainerRunnerXpu::run_with_xpu_stream(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #144668
* __->__ #144667

The PR #142213 changed the function parameter name from `inputs` to `input_handles` but still use `inputs` in function, and caused XPU build failure. Since XPU CI did not gate the PR, we need to fix it here to unblock the XPU build. 
