### PR TITLE
[FlexAttention] Allow to pass mod_type info to `create_mask` via arg or keyword.

### DIFF
--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -776,11 +776,11 @@ def _create_sparse_block_from_block_mask(
 
 
 def create_mask(
-    mod_fn: Optional[Union[_score_mod_signature, _mask_mod_signature]] = None,
-    B: int = 1,
-    H: int = 1,
-    Q_LEN: int = 4096,
-    KV_LEN: int = 4096,
+    mod_fn: Optional[Union[_score_mod_signature, _mask_mod_signature]],
+    B: Optional[int],
+    H: Optional[int],
+    Q_LEN: int,
+    KV_LEN: int,
     device: str = "cuda",
     *,
     mask_mod: Optional[_mask_mod_signature] = None,
@@ -793,8 +793,8 @@ def create_mask(
         mod_fn (Optional[Union[_score_mod_signature, _mask_mod_signature]]): Function to modify attention scores.
             If provided, the type of function will be infered from the number of arguments.
             The type can be specified via mod_type or pass mask_mod/score_mod instead.
-        B (int): Batch size.
-        H (int): Number of query heads.
+        B (Optional[int]): Batch size.
+        H (Optional[int]): Number of query heads.
         Q_LEN (int): Sequence length of query.
         KV_LEN (int): Sequence length of key/value.
         device (str): Device to run the mask creation on.
@@ -819,6 +819,11 @@ def create_mask(
         assert (
             mask_mod is None or score_mod is None
         ), "cannot provide both mask_mod and score_mod"
+
+    if B is None:
+        B = 1
+    if H is None:
+        H = 1
 
     b = torch.arange(0, B, device=device)
     h = torch.arange(0, H, device=device)

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -816,7 +816,9 @@ def create_mask(
         elif mod_type == _ModificationType.SCORE_MOD:
             score_mod = mod_fn
     elif mask_mod is not None or score_mod is not None:
-        assert mask_mod is None or score_mod is None, "cannot provide both mask_mod and score_mod"
+        assert (
+            mask_mod is None or score_mod is None
+        ), "cannot provide both mask_mod and score_mod"
 
     b = torch.arange(0, B, device=device)
     h = torch.arange(0, H, device=device)

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -782,10 +782,10 @@ def create_mask(
     Q_LEN: int = 4096,
     KV_LEN: int = 4096,
     device: str = "cuda",
-    mod_type: _ModificationType = _ModificationType.UNKNOWN,
     *,
     mask_mod: Optional[_mask_mod_signature] = None,
     score_mod: Optional[_score_mod_signature] = None,
+    mod_type: _ModificationType = _ModificationType.UNKNOWN,
 ) -> Tensor:
     r"""This function creates a mask tensor from a mod_fn function.
 


### PR DESCRIPTION
`_get_mod_type` does not always work, e.g. `def some_score(score, *args)` in https://github.com/pytorch-labs/attention-gym/pull/103/commits/29f43391be8c952e86307c6cb1682022abf7de00. This PR allows user to specific the type (mask/score) via `create_mask(mod_fn, mod_type=_ModificationType.SCORE, ...)` or `create_mask(score_mod=mod_fn, ...)`

@drisspg
