### PR TITLE
Apply clang-format for ATen/core/boxing cpp files

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -60,6 +60,7 @@ include_patterns = [
     'aten/src/ATen/xpu/**/*.h',
     'aten/src/ATen/xpu/**/*.cpp',
     'aten/src/ATen/core/boxing/**/*.h',
+    'aten/src/ATen/core/boxing/**/*.cpp',
     'aten/src/ATen/core/dispatch/**/*.h',
     'aten/src/ATen/native/mps/**/*.metal',
     'aten/src/ATen/native/mps/**/*.mm',

--- a/aten/src/ATen/core/boxing/KernelFunction.cpp
+++ b/aten/src/ATen/core/boxing/KernelFunction.cpp
@@ -10,36 +10,54 @@ namespace c10 {
 // be handled specially.  Its semantics is that it redispatches to the
 // *next* dispatch key that would have been processed, skipping the current
 // one.
-void fallthrough_kernel(OperatorKernel*, const OperatorHandle&, DispatchKeySet, Stack*) {
-  TORCH_INTERNAL_ASSERT(0,
-    "fallthrough_kernel was executed but it should have been short-circuited by the dispatcher. "
-    "This could occur if you registered a fallthrough kernel as a override for a specific operator "
-    "(as opposed to a backend fallback); this is NOT currently supported, and we do not intend to "
-    "add support for it in the near future.  If you do find yourself in need of this, "
-    "let us know in the bug tracker.");
+void fallthrough_kernel(
+    OperatorKernel*,
+    const OperatorHandle&,
+    DispatchKeySet,
+    Stack*) {
+  TORCH_INTERNAL_ASSERT(
+      0,
+      "fallthrough_kernel was executed but it should have been short-circuited by the dispatcher. "
+      "This could occur if you registered a fallthrough kernel as a override for a specific operator "
+      "(as opposed to a backend fallback); this is NOT currently supported, and we do not intend to "
+      "add support for it in the near future.  If you do find yourself in need of this, "
+      "let us know in the bug tracker.");
 }
 
-void ambiguous_autogradother_kernel(OperatorKernel*, const OperatorHandle& op, DispatchKeySet, Stack*) {
-  TORCH_INTERNAL_ASSERT(0,
-    op.operator_name(), " has kernels registered to both CompositeImplicitAutograd and a backend mapped to AutogradOther. "
-    "This makes the backend kernel unreachable; the dispatcher will always prefer the CompositeImplicitAutograd lowering "
-    "(see Note [Ambiguity in AutogradOther kernel]). "
-    "If you want to override CompositeImplicitAutograd, please open an issue to request a dedicated "
-    "Autograd dispatch key for the backend.\n",
-    "If you only want to run inference instead of training, in C++, add `c10::InferenceMode mode;` "
-    "before model.forward(); in Python, use `torch.inference_mode()` as a context manager (see "
-    "https://pytorch.org/docs/stable/generated/torch.inference_mode.html).",
-    "\nCanonical state\n~~~~~~~~~~~\n", op.dumpState(), "\n\n");
+void ambiguous_autogradother_kernel(
+    OperatorKernel*,
+    const OperatorHandle& op,
+    DispatchKeySet,
+    Stack*) {
+  TORCH_INTERNAL_ASSERT(
+      0,
+      op.operator_name(),
+      " has kernels registered to both CompositeImplicitAutograd and a backend mapped to AutogradOther. "
+      "This makes the backend kernel unreachable; the dispatcher will always prefer the CompositeImplicitAutograd lowering "
+      "(see Note [Ambiguity in AutogradOther kernel]). "
+      "If you want to override CompositeImplicitAutograd, please open an issue to request a dedicated "
+      "Autograd dispatch key for the backend.\n",
+      "If you only want to run inference instead of training, in C++, add `c10::InferenceMode mode;` "
+      "before model.forward(); in Python, use `torch.inference_mode()` as a context manager (see "
+      "https://pytorch.org/docs/stable/generated/torch.inference_mode.html).",
+      "\nCanonical state\n~~~~~~~~~~~\n",
+      op.dumpState(),
+      "\n\n");
 }
 
-void named_not_supported_kernel(OperatorKernel*, const OperatorHandle& op, DispatchKeySet, Stack*) {
+void named_not_supported_kernel(
+    OperatorKernel*,
+    const OperatorHandle& op,
+    DispatchKeySet,
+    Stack*) {
   // DO NOT LOOK AT STACK, YOU HAVE SHORT CIRCUITED BOXING
   // See Note [named_not_supported_kernel]
-  TORCH_CHECK(0,
-    op.operator_name(), " is not yet supported with named tensors. Please drop names via "
-    "`tensor = tensor.rename(None)`, call the op with an unnamed tensor, "
-    "and set names on the result of the operation."
-    );
+  TORCH_CHECK(
+      0,
+      op.operator_name(),
+      " is not yet supported with named tensors. Please drop names via "
+      "`tensor = tensor.rename(None)`, call the op with an unnamed tensor, "
+      "and set names on the result of the operation.");
 }
 
 // single line summary of state
@@ -60,7 +78,7 @@ std::string KernelFunction::dumpState() const {
 
 bool KernelFunction::_equalsBoxedAndUnboxed(const KernelFunction& other) const {
   return boxed_kernel_func_.getFnPtr() == other.boxed_kernel_func_.getFnPtr() &&
-         unboxed_kernel_func_ == other.unboxed_kernel_func_;
+      unboxed_kernel_func_ == other.unboxed_kernel_func_;
 }
 
 } // namespace c10

--- a/aten/src/ATen/core/boxing/KernelFunction_test.cpp
+++ b/aten/src/ATen/core/boxing/KernelFunction_test.cpp
@@ -1,17 +1,17 @@
-#include <gtest/gtest.h>
 #include <ATen/ATen.h>
 #include <ATen/core/boxing/KernelFunction.h>
 #include <ATen/core/boxing/impl/test_helpers.h>
 #include <ATen/core/op_registration/op_registration.h>
+#include <gtest/gtest.h>
 
-using std::vector;
-using std::tuple;
-using std::optional;
 using c10::IValue;
-using c10::OperatorKernel;
-using c10::OperatorHandle;
-using c10::Stack;
 using c10::KernelFunction;
+using c10::OperatorHandle;
+using c10::OperatorKernel;
+using c10::Stack;
+using std::optional;
+using std::tuple;
+using std::vector;
 
 namespace {
 
@@ -26,33 +26,38 @@ namespace kernels {
 
 optional<tuple<int64_t, int64_t>> called_with_args;
 
-
-// The calling convention in the dispatcher requires that calls to KernelFunction::call()/callBoxed()
-// take in a DispatchKeySet.
-// The value itself is meaningless for all of the tests that use kernels without a DispatchKeySet argument.
-// See Note [Plumbing Keys Through The Dispatcher] for details.
+// The calling convention in the dispatcher requires that calls to
+// KernelFunction::call()/callBoxed() take in a DispatchKeySet. The value itself
+// is meaningless for all of the tests that use kernels without a DispatchKeySet
+// argument. See Note [Plumbing Keys Through The Dispatcher] for details.
 c10::DispatchKeySet CPU_TEST_SET = c10::DispatchKeySet(c10::DispatchKey::CPU);
 
 void boxed_func_with_return(const OperatorHandle& /*opHandle*/, Stack* stack) {
   EXPECT_EQ(2, stack->size());
   EXPECT_TRUE(stack->at(0).isInt());
   EXPECT_TRUE(stack->at(1).isInt());
-  called_with_args = tuple<int64_t, int64_t>(stack->at(0).toInt(), stack->at(1).toInt());
+  called_with_args =
+      tuple<int64_t, int64_t>(stack->at(0).toInt(), stack->at(1).toInt());
 
   stack->clear();
   stack->push_back(5);
 }
 
-void boxed_func_without_return(const OperatorHandle& /*opHandle*/, Stack* stack) {
+void boxed_func_without_return(
+    const OperatorHandle& /*opHandle*/,
+    Stack* stack) {
   EXPECT_EQ(2, stack->size());
   EXPECT_TRUE(stack->at(0).isInt());
   EXPECT_TRUE(stack->at(1).isInt());
-  called_with_args = tuple<int64_t, int64_t>(stack->at(0).toInt(), stack->at(1).toInt());
+  called_with_args =
+      tuple<int64_t, int64_t>(stack->at(0).toInt(), stack->at(1).toInt());
 
   stack->clear();
 }
 
-void boxed_func_with_multi_return(const OperatorHandle& /*opHandle*/, Stack* stack) {
+void boxed_func_with_multi_return(
+    const OperatorHandle& /*opHandle*/,
+    Stack* stack) {
   EXPECT_EQ(2, stack->size());
   EXPECT_TRUE(stack->at(0).isInt());
   int64_t a = stack->at(0).toInt();
@@ -99,12 +104,12 @@ void unboxed_function_without_return(int64_t a, int64_t b) {
   called_with_args = tuple<int64_t, int64_t>(a, b);
 }
 
-auto unboxed_lambda_with_return = [] (int64_t a, int64_t b) -> int64_t {
+auto unboxed_lambda_with_return = [](int64_t a, int64_t b) -> int64_t {
   called_with_args = tuple<int64_t, int64_t>(a, b);
   return 5;
 };
 
-auto unboxed_lambda_without_return = [] (int64_t a, int64_t b) -> void{
+auto unboxed_lambda_without_return = [](int64_t a, int64_t b) -> void {
   called_with_args = tuple<int64_t, int64_t>(a, b);
 };
 
@@ -114,10 +119,13 @@ OperatorHandle makeDummyOperatorHandle() {
 }
 
 //
-// boxed kernels that return refs to tensor arguments, a la inplace/outplace kernels
+// boxed kernels that return refs to tensor arguments, a la inplace/outplace
+// kernels
 //
 
-void boxed_func_for_inplace_op(const OperatorHandle& /*opHandle*/, Stack* stack) {
+void boxed_func_for_inplace_op(
+    const OperatorHandle& /*opHandle*/,
+    Stack* stack) {
   // (Tensor(a!), Scalar) -> Tensor(a!)
   EXPECT_EQ(2, stack->size());
 
@@ -133,7 +141,9 @@ void boxed_func_for_inplace_op(const OperatorHandle& /*opHandle*/, Stack* stack)
   torch::jit::push(stack, t);
 }
 
-void boxed_func_for_outofplace_op(const OperatorHandle& /*opHandle*/, Stack* stack) {
+void boxed_func_for_outofplace_op(
+    const OperatorHandle& /*opHandle*/,
+    Stack* stack) {
   // (Scalar, Tensor(a!)) -> Tensor(a!)
   EXPECT_EQ(2, stack->size());
 
@@ -149,7 +159,9 @@ void boxed_func_for_outofplace_op(const OperatorHandle& /*opHandle*/, Stack* sta
   torch::jit::push(stack, t);
 }
 
-void boxed_func_for_outofplace_multi_op(const OperatorHandle& /*opHandle*/, Stack* stack) {
+void boxed_func_for_outofplace_multi_op(
+    const OperatorHandle& /*opHandle*/,
+    Stack* stack) {
   // (Scalar, Scalar, Tensor(a!), Tensor(b!)) -> (Tensor(a!), Tensor(b!))
   EXPECT_EQ(4, stack->size());
 
@@ -181,7 +193,7 @@ void boxed_func_for_outofplace_multi_op(const OperatorHandle& /*opHandle*/, Stac
 
 void expectBoxedCallingWithReturnWorks(const KernelFunction& func) {
   called_with_args = std::nullopt;
-  vector<IValue> stack {3, 4};
+  vector<IValue> stack{3, 4};
   OperatorHandle dummy = makeDummyOperatorHandle();
 
   func.callBoxed(dummy, CPU_TEST_SET, &stack);
@@ -195,7 +207,7 @@ void expectBoxedCallingWithReturnWorks(const KernelFunction& func) {
 
 void expectBoxedCallingWithoutReturnWorks(const KernelFunction& func) {
   called_with_args = std::nullopt;
-  vector<IValue> stack {3, 4};
+  vector<IValue> stack{3, 4};
   OperatorHandle dummy = makeDummyOperatorHandle();
 
   func.callBoxed(dummy, CPU_TEST_SET, &stack);
@@ -207,7 +219,7 @@ void expectBoxedCallingWithoutReturnWorks(const KernelFunction& func) {
 
 void expectBoxedCallingWithMultiReturnWorks(const KernelFunction& func) {
   called_with_args = std::nullopt;
-  vector<IValue> stack {3, 4};
+  vector<IValue> stack{3, 4};
   OperatorHandle dummy = makeDummyOperatorHandle();
 
   func.callBoxed(dummy, CPU_TEST_SET, &stack);
@@ -230,7 +242,7 @@ void expectInPlaceBoxedCallingWorks(const KernelFunction& func) {
 
   auto t = at::zeros({1});
   auto s = 1.0f;
-  vector<IValue> stack {t, s};
+  vector<IValue> stack{t, s};
   func.callBoxed(dummy, CPU_TEST_SET, &stack);
 
   // kernel should have updated out arg and returned it
@@ -245,7 +257,7 @@ void expectOutOfPlaceBoxedCallingWorks(const KernelFunction& func) {
 
   auto s = 1.0f;
   auto t = at::zeros({1});
-  vector<IValue> stack {s, t};
+  vector<IValue> stack{s, t};
   func.callBoxed(dummy, CPU_TEST_SET, &stack);
 
   // kernel should have updated out arg and returned it on the stack
@@ -262,7 +274,7 @@ void expectOutOfPlaceMultiBoxedCallingWorks(const KernelFunction& func) {
   auto s2 = 2.0f;
   auto t1 = at::zeros({1});
   auto t2 = at::zeros({1});
-  vector<IValue> stack {s1, s2, t1, t2};
+  vector<IValue> stack{s1, s2, t1, t2};
   func.callBoxed(dummy, CPU_TEST_SET, &stack);
 
   // kernel should have updated output args and returned them on the stack
@@ -287,7 +299,8 @@ void expectUnboxedCallingWithReturnWorks(const KernelFunction& func) {
   called_with_args = std::nullopt;
   OperatorHandle dummy = makeDummyOperatorHandle();
 
-  int64_t result = func.call<int64_t, int64_t, int64_t>(dummy, CPU_TEST_SET, 3, 4);
+  int64_t result =
+      func.call<int64_t, int64_t, int64_t>(dummy, CPU_TEST_SET, 3, 4);
 
   EXPECT_TRUE(called_with_args.has_value());
   EXPECT_EQ((tuple<int64_t, int64_t>(3, 4)), *called_with_args);
@@ -313,7 +326,8 @@ void expectUnboxedCallingWithMultiReturnWorks(const KernelFunction& func) {
   called_with_args = std::nullopt;
   OperatorHandle dummy = makeDummyOperatorHandle();
 
-  auto result = func.call<std::tuple<int64_t, int64_t>, int64_t, int64_t>(dummy, CPU_TEST_SET, 3, 4);
+  auto result = func.call<std::tuple<int64_t, int64_t>, int64_t, int64_t>(
+      dummy, CPU_TEST_SET, 3, 4);
 
   EXPECT_TRUE(called_with_args.has_value());
   EXPECT_EQ((tuple<int64_t, int64_t>(3, 4)), *called_with_args);
@@ -327,7 +341,8 @@ void expectInPlaceUnboxedCallingWorks(const KernelFunction& func) {
   OperatorHandle dummy = makeDummyOperatorHandle();
 
   auto t = at::zeros({1});
-  at::Tensor& t_out = func.call<at::Tensor&, at::Tensor&, at::Scalar>(dummy, CPU_TEST_SET, t, 1.0f);
+  at::Tensor& t_out = func.call<at::Tensor&, at::Tensor&, at::Scalar>(
+      dummy, CPU_TEST_SET, t, 1.0f);
 
   // should have updated first arg and returned it
   EXPECT_EQ(t.item().toFloat(), 1.0f);
@@ -338,7 +353,8 @@ void expectOutOfPlaceUnboxedCallingWorks(const KernelFunction& func) {
   OperatorHandle dummy = makeDummyOperatorHandle();
 
   auto t = at::zeros({1});
-  at::Tensor& t_out = func.call<at::Tensor&, at::Scalar, at::Tensor&>(dummy, CPU_TEST_SET, 1.0f, t);
+  at::Tensor& t_out = func.call<at::Tensor&, at::Scalar, at::Tensor&>(
+      dummy, CPU_TEST_SET, 1.0f, t);
 
   // should have updated out arg and returned it
   EXPECT_EQ(t.item().toFloat(), 1.0f);
@@ -354,8 +370,11 @@ void expectOutOfPlaceMultiUnboxedCallingWorks(const KernelFunction& func) {
   auto t2 = at::zeros({1});
 
   const auto [t1_out, t2_out] = func.call<
-    std::tuple<at::Tensor&, at::Tensor&>, at::Scalar, at::Scalar, at::Tensor&, at::Tensor&
-  >(dummy, CPU_TEST_SET, s1, s2, t1, t2);
+      std::tuple<at::Tensor&, at::Tensor&>,
+      at::Scalar,
+      at::Scalar,
+      at::Tensor&,
+      at::Tensor&>(dummy, CPU_TEST_SET, s1, s2, t1, t2);
 
   // kernel should have updated out args and returned them in a tuple
   EXPECT_EQ(t1.item().toFloat(), 1.0f);
@@ -368,158 +387,250 @@ void expectOutOfPlaceMultiUnboxedCallingWorks(const KernelFunction& func) {
   EXPECT_TRUE(t2_out.is_same(t2));
 }
 
-}
+} // namespace kernels
 
 // functional, boxed calling
 
-TEST(KernelFunctionTest, givenBoxedFunction_withReturn_whenCallingBoxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromBoxedFunction<&kernels::boxed_func_with_return>();
+TEST(
+    KernelFunctionTest,
+    givenBoxedFunction_withReturn_whenCallingBoxed_thenWorks) {
+  KernelFunction func =
+      KernelFunction::makeFromBoxedFunction<&kernels::boxed_func_with_return>();
   kernels::expectBoxedCallingWithReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenBoxedFunction_withoutReturn_whenCallingBoxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromBoxedFunction<&kernels::boxed_func_without_return>();
+TEST(
+    KernelFunctionTest,
+    givenBoxedFunction_withoutReturn_whenCallingBoxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromBoxedFunction<
+      &kernels::boxed_func_without_return>();
   kernels::expectBoxedCallingWithoutReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenBoxedFunction_withMultiReturn_whenCallingBoxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromBoxedFunction<&kernels::boxed_func_with_multi_return>();
+TEST(
+    KernelFunctionTest,
+    givenBoxedFunction_withMultiReturn_whenCallingBoxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromBoxedFunction<
+      &kernels::boxed_func_with_multi_return>();
   kernels::expectBoxedCallingWithMultiReturnWorks(func);
 }
 
 // in/out, boxed calling
 
-TEST(KernelFunctionTest, givenBoxedFunction_withInPlaceSignature_whenCallingBoxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromBoxedFunction<&kernels::boxed_func_for_inplace_op>();
+TEST(
+    KernelFunctionTest,
+    givenBoxedFunction_withInPlaceSignature_whenCallingBoxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromBoxedFunction<
+      &kernels::boxed_func_for_inplace_op>();
   kernels::expectInPlaceBoxedCallingWorks(func);
 }
 
-TEST(KernelFunctionTest, givenBoxedFunction_withOutOfPlaceSignature_whenCallingBoxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromBoxedFunction<&kernels::boxed_func_for_outofplace_op>();
+TEST(
+    KernelFunctionTest,
+    givenBoxedFunction_withOutOfPlaceSignature_whenCallingBoxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromBoxedFunction<
+      &kernels::boxed_func_for_outofplace_op>();
   kernels::expectOutOfPlaceBoxedCallingWorks(func);
 }
 
-TEST(KernelFunctionTest, givenBoxedFunction_withOutOfPlaceMultiSignature_whenCallingBoxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromBoxedFunction<&kernels::boxed_func_for_outofplace_multi_op>();
+TEST(
+    KernelFunctionTest,
+    givenBoxedFunction_withOutOfPlaceMultiSignature_whenCallingBoxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromBoxedFunction<
+      &kernels::boxed_func_for_outofplace_multi_op>();
   kernels::expectOutOfPlaceMultiBoxedCallingWorks(func);
 }
 
 // functional, unboxed calling
 
-TEST(KernelFunctionTest, givenBoxedFunction_withReturn_whenCallingUnboxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromBoxedFunction<&kernels::boxed_func_with_return>();
+TEST(
+    KernelFunctionTest,
+    givenBoxedFunction_withReturn_whenCallingUnboxed_thenWorks) {
+  KernelFunction func =
+      KernelFunction::makeFromBoxedFunction<&kernels::boxed_func_with_return>();
   kernels::expectUnboxedCallingWithReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenBoxedFunction_withoutReturn_whenCallingUnboxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromBoxedFunction<&kernels::boxed_func_without_return>();
+TEST(
+    KernelFunctionTest,
+    givenBoxedFunction_withoutReturn_whenCallingUnboxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromBoxedFunction<
+      &kernels::boxed_func_without_return>();
   kernels::expectUnboxedCallingWithoutReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenBoxedFunction_withMultiReturn_whenCallingUnboxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromBoxedFunction<&kernels::boxed_func_with_multi_return>();
+TEST(
+    KernelFunctionTest,
+    givenBoxedFunction_withMultiReturn_whenCallingUnboxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromBoxedFunction<
+      &kernels::boxed_func_with_multi_return>();
   kernels::expectUnboxedCallingWithMultiReturnWorks(func);
 }
 
 // in/out, unboxed calling
 
-TEST(KernelFunctionTest, givenBoxedFunction_withInPlaceSignature_whenCallingUnboxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromBoxedFunction<&kernels::boxed_func_for_inplace_op>();
+TEST(
+    KernelFunctionTest,
+    givenBoxedFunction_withInPlaceSignature_whenCallingUnboxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromBoxedFunction<
+      &kernels::boxed_func_for_inplace_op>();
   kernels::expectInPlaceUnboxedCallingWorks(func);
 }
 
-TEST(KernelFunctionTest, givenBoxedFunction_withOutOfPlaceSignature_whenCallingUnboxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromBoxedFunction<&kernels::boxed_func_for_outofplace_op>();
+TEST(
+    KernelFunctionTest,
+    givenBoxedFunction_withOutOfPlaceSignature_whenCallingUnboxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromBoxedFunction<
+      &kernels::boxed_func_for_outofplace_op>();
   kernels::expectOutOfPlaceUnboxedCallingWorks(func);
 }
 
-TEST(KernelFunctionTest, givenBoxedFunction_withOutOfPlaceMultiSignature_whenCallingUnboxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromBoxedFunction<&kernels::boxed_func_for_outofplace_multi_op>();
+TEST(
+    KernelFunctionTest,
+    givenBoxedFunction_withOutOfPlaceMultiSignature_whenCallingUnboxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromBoxedFunction<
+      &kernels::boxed_func_for_outofplace_multi_op>();
   kernels::expectOutOfPlaceMultiUnboxedCallingWorks(func);
 }
 
 // functors etc.
 
-TEST(KernelFunctionTest, givenUnboxedFunctor_withReturn_whenCallingBoxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromUnboxedFunctor<false, kernels::unboxed_functor_with_return>(std::unique_ptr<OperatorKernel>(std::make_unique<kernels::unboxed_functor_with_return>()));
+TEST(
+    KernelFunctionTest,
+    givenUnboxedFunctor_withReturn_whenCallingBoxed_thenWorks) {
+  KernelFunction func = KernelFunction::
+      makeFromUnboxedFunctor<false, kernels::unboxed_functor_with_return>(
+          std::unique_ptr<OperatorKernel>(
+              std::make_unique<kernels::unboxed_functor_with_return>()));
   kernels::expectBoxedCallingWithReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenUnboxedFunctor_withoutReturn_whenCallingBoxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromUnboxedFunctor<false, kernels::unboxed_functor_without_return>(std::unique_ptr<OperatorKernel>(std::make_unique<kernels::unboxed_functor_without_return>()));
+TEST(
+    KernelFunctionTest,
+    givenUnboxedFunctor_withoutReturn_whenCallingBoxed_thenWorks) {
+  KernelFunction func = KernelFunction::
+      makeFromUnboxedFunctor<false, kernels::unboxed_functor_without_return>(
+          std::unique_ptr<OperatorKernel>(
+              std::make_unique<kernels::unboxed_functor_without_return>()));
   kernels::expectBoxedCallingWithoutReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenUnboxedFunctor_withReturn_whenCallingUnboxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromUnboxedFunctor<false, kernels::unboxed_functor_with_return>(std::unique_ptr<OperatorKernel>(std::make_unique<kernels::unboxed_functor_with_return>()));
+TEST(
+    KernelFunctionTest,
+    givenUnboxedFunctor_withReturn_whenCallingUnboxed_thenWorks) {
+  KernelFunction func = KernelFunction::
+      makeFromUnboxedFunctor<false, kernels::unboxed_functor_with_return>(
+          std::unique_ptr<OperatorKernel>(
+              std::make_unique<kernels::unboxed_functor_with_return>()));
   kernels::expectUnboxedCallingWithReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenUnboxedFunctor_withoutReturn_whenCallingUnboxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromUnboxedFunctor<false, kernels::unboxed_functor_without_return>(std::unique_ptr<OperatorKernel>(std::make_unique<kernels::unboxed_functor_without_return>()));
+TEST(
+    KernelFunctionTest,
+    givenUnboxedFunctor_withoutReturn_whenCallingUnboxed_thenWorks) {
+  KernelFunction func = KernelFunction::
+      makeFromUnboxedFunctor<false, kernels::unboxed_functor_without_return>(
+          std::unique_ptr<OperatorKernel>(
+              std::make_unique<kernels::unboxed_functor_without_return>()));
   kernels::expectUnboxedCallingWithoutReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenUnboxedFunction_withReturn_whenCallingBoxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromUnboxedFunction(TORCH_FN(kernels::unboxed_function_with_return));
+TEST(
+    KernelFunctionTest,
+    givenUnboxedFunction_withReturn_whenCallingBoxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromUnboxedFunction(
+      TORCH_FN(kernels::unboxed_function_with_return));
   kernels::expectBoxedCallingWithReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenUnboxedFunction_withoutReturn_whenCallingBoxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromUnboxedFunction(TORCH_FN(kernels::unboxed_function_without_return));
+TEST(
+    KernelFunctionTest,
+    givenUnboxedFunction_withoutReturn_whenCallingBoxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromUnboxedFunction(
+      TORCH_FN(kernels::unboxed_function_without_return));
   kernels::expectBoxedCallingWithoutReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenUnboxedFunction_withReturn_whenCallingUnboxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromUnboxedFunction(TORCH_FN(kernels::unboxed_function_with_return));
+TEST(
+    KernelFunctionTest,
+    givenUnboxedFunction_withReturn_whenCallingUnboxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromUnboxedFunction(
+      TORCH_FN(kernels::unboxed_function_with_return));
   kernels::expectUnboxedCallingWithReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenUnboxedFunction_withoutReturn_whenCallingUnboxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromUnboxedFunction(TORCH_FN(kernels::unboxed_function_without_return));
+TEST(
+    KernelFunctionTest,
+    givenUnboxedFunction_withoutReturn_whenCallingUnboxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromUnboxedFunction(
+      TORCH_FN(kernels::unboxed_function_without_return));
   kernels::expectUnboxedCallingWithoutReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenUnboxedRuntimeFunction_withReturn_whenCallingBoxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromUnboxedRuntimeFunction(&kernels::unboxed_function_with_return);
+TEST(
+    KernelFunctionTest,
+    givenUnboxedRuntimeFunction_withReturn_whenCallingBoxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromUnboxedRuntimeFunction(
+      &kernels::unboxed_function_with_return);
   kernels::expectBoxedCallingWithReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenUnboxedRuntimeFunction_withoutReturn_whenCallingBoxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromUnboxedRuntimeFunction(&kernels::unboxed_function_without_return);
+TEST(
+    KernelFunctionTest,
+    givenUnboxedRuntimeFunction_withoutReturn_whenCallingBoxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromUnboxedRuntimeFunction(
+      &kernels::unboxed_function_without_return);
   kernels::expectBoxedCallingWithoutReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenUnboxedRuntimeFunction_withReturn_whenCallingUnboxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromUnboxedRuntimeFunction(&kernels::unboxed_function_with_return);
+TEST(
+    KernelFunctionTest,
+    givenUnboxedRuntimeFunction_withReturn_whenCallingUnboxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromUnboxedRuntimeFunction(
+      &kernels::unboxed_function_with_return);
   kernels::expectUnboxedCallingWithReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenUnboxedRuntimeFunction_withoutReturn_whenCallingUnboxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromUnboxedRuntimeFunction(&kernels::unboxed_function_without_return);
+TEST(
+    KernelFunctionTest,
+    givenUnboxedRuntimeFunction_withoutReturn_whenCallingUnboxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromUnboxedRuntimeFunction(
+      &kernels::unboxed_function_without_return);
   kernels::expectUnboxedCallingWithoutReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenUnboxedLambda_withReturn_whenCallingBoxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromUnboxedLambda(kernels::unboxed_lambda_with_return);
+TEST(
+    KernelFunctionTest,
+    givenUnboxedLambda_withReturn_whenCallingBoxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromUnboxedLambda(
+      kernels::unboxed_lambda_with_return);
   kernels::expectBoxedCallingWithReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenUnboxedLambda_withoutReturn_whenCallingBoxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromUnboxedLambda(kernels::unboxed_lambda_without_return);
+TEST(
+    KernelFunctionTest,
+    givenUnboxedLambda_withoutReturn_whenCallingBoxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromUnboxedLambda(
+      kernels::unboxed_lambda_without_return);
   kernels::expectBoxedCallingWithoutReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenUnboxedLambda_withReturn_whenCallingUnboxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromUnboxedLambda(kernels::unboxed_lambda_with_return);
+TEST(
+    KernelFunctionTest,
+    givenUnboxedLambda_withReturn_whenCallingUnboxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromUnboxedLambda(
+      kernels::unboxed_lambda_with_return);
   kernels::expectUnboxedCallingWithReturnWorks(func);
 }
 
-TEST(KernelFunctionTest, givenUnboxedLambda_withoutReturn_whenCallingUnboxed_thenWorks) {
-  KernelFunction func = KernelFunction::makeFromUnboxedLambda(kernels::unboxed_lambda_without_return);
+TEST(
+    KernelFunctionTest,
+    givenUnboxedLambda_withoutReturn_whenCallingUnboxed_thenWorks) {
+  KernelFunction func = KernelFunction::makeFromUnboxedLambda(
+      kernels::unboxed_lambda_without_return);
   kernels::expectUnboxedCallingWithoutReturnWorks(func);
 }
 
-}
+} // namespace
 
 // TODO Also test different variants of calling unboxed with wrong signatures

--- a/aten/src/ATen/core/boxing/impl/kernel_function_test.cpp
+++ b/aten/src/ATen/core/boxing/impl/kernel_function_test.cpp
@@ -1,20 +1,20 @@
-#include <gtest/gtest.h>
 #include <ATen/core/boxing/impl/test_helpers.h>
+#include <gtest/gtest.h>
 
-#include <ATen/core/op_registration/op_registration.h>
 #include <ATen/core/Tensor.h>
+#include <ATen/core/op_registration/op_registration.h>
 #include <torch/csrc/jit/frontend/function_schema_parser.h>
 #include <torch/library.h>
 
 #include <ATen/core/LegacyTypeDispatch.h>
 
-using c10::RegisterOperators;
+using at::Tensor;
+using c10::Dict;
 using c10::DispatchKey;
+using c10::intrusive_ptr;
+using c10::RegisterOperators;
 using c10::Stack;
 using std::make_unique;
-using c10::intrusive_ptr;
-using c10::Dict;
-using at::Tensor;
 using std::string;
 using std::unique_ptr;
 
@@ -55,43 +55,72 @@ void expectCallsDecrement(DispatchKey dispatch_key) {
   EXPECT_EQ(4, result[0].toInt());
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernel_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators().op("_test::my_op(Tensor dummy, int input) -> int", RegisterOperators::options().kernel<decltype(incrementKernel), &incrementKernel>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernel_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::my_op(Tensor dummy, int input) -> int",
+      RegisterOperators::options()
+          .kernel<decltype(incrementKernel), &incrementKernel>(
+              DispatchKey::CPU));
   expectCallsIncrement(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernel_whenRegisteredWithTorchLibraryAndTorchFn_thenCanBeCalled) {
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernel_whenRegisteredWithTorchLibraryAndTorchFn_thenCanBeCalled) {
   auto m = MAKE_TORCH_LIBRARY(_test);
   m.def("my_op(Tensor dummy, int input) -> int");
   m.impl("my_op", DispatchKey::CPU, TORCH_FN(incrementKernel));
   expectCallsIncrement(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenCatchAllKernel_whenRegisteredWithTorchLibraryAndTorchFn_thenCanBeCalled) {
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenCatchAllKernel_whenRegisteredWithTorchLibraryAndTorchFn_thenCanBeCalled) {
   auto m = MAKE_TORCH_LIBRARY(_test);
   m.def("my_op(Tensor dummy, int input) -> int", TORCH_FN(incrementKernel));
   expectCallsIncrement(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenMultipleOperatorsAndKernels_whenRegisteredInOneRegistrar_thenCallsRightKernel) {
-  auto registrar = RegisterOperators()
-      .op("_test::my_op(Tensor dummy, int input) -> int", RegisterOperators::options().kernel<decltype(incrementKernel), &incrementKernel>(DispatchKey::CPU)
-                                                                                      .kernel<decltype(errorKernel), &errorKernel>(DispatchKey::CUDA))
-      .op("_test::error(Tensor dummy, int input) -> int", RegisterOperators::options().kernel<decltype(errorKernel), &errorKernel>(DispatchKey::CPU)
-                                                                                      .kernel<decltype(errorKernel), &errorKernel>(DispatchKey::CUDA));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenMultipleOperatorsAndKernels_whenRegisteredInOneRegistrar_thenCallsRightKernel) {
+  auto registrar =
+      RegisterOperators()
+          .op("_test::my_op(Tensor dummy, int input) -> int",
+              RegisterOperators::options()
+                  .kernel<decltype(incrementKernel), &incrementKernel>(
+                      DispatchKey::CPU)
+                  .kernel<decltype(errorKernel), &errorKernel>(
+                      DispatchKey::CUDA))
+          .op("_test::error(Tensor dummy, int input) -> int",
+              RegisterOperators::options()
+                  .kernel<decltype(errorKernel), &errorKernel>(DispatchKey::CPU)
+                  .kernel<decltype(errorKernel), &errorKernel>(
+                      DispatchKey::CUDA));
   expectCallsIncrement(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenMultipleOperatorsAndKernels_whenRegisteredInMultipleRegistrars_thenCallsRightKernel) {
-  auto registrar1 = RegisterOperators().op("_test::my_op(Tensor dummy, int input) -> int", RegisterOperators::options().kernel<decltype(incrementKernel), &incrementKernel>(DispatchKey::CPU)
-                                                                                                                       .kernel<decltype(errorKernel), &errorKernel>(DispatchKey::CUDA));
-  auto registrar2 = RegisterOperators().op("_test::error(Tensor dummy, int input) -> int", RegisterOperators::options().kernel<decltype(errorKernel), &errorKernel>(DispatchKey::CPU)
-                                                                                                                       .kernel<decltype(errorKernel), &errorKernel>(DispatchKey::CUDA));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenMultipleOperatorsAndKernels_whenRegisteredInMultipleRegistrars_thenCallsRightKernel) {
+  auto registrar1 = RegisterOperators().op(
+      "_test::my_op(Tensor dummy, int input) -> int",
+      RegisterOperators::options()
+          .kernel<decltype(incrementKernel), &incrementKernel>(DispatchKey::CPU)
+          .kernel<decltype(errorKernel), &errorKernel>(DispatchKey::CUDA));
+  auto registrar2 = RegisterOperators().op(
+      "_test::error(Tensor dummy, int input) -> int",
+      RegisterOperators::options()
+          .kernel<decltype(errorKernel), &errorKernel>(DispatchKey::CPU)
+          .kernel<decltype(errorKernel), &errorKernel>(DispatchKey::CUDA));
   expectCallsIncrement(DispatchKey::CPU);
 }
 
-
-TEST(NewOperatorRegistrationTestFunctionBasedKernel, givenKernel_whenRegistrationRunsOutOfScope_thenCannotBeCalledAnymore) {
+TEST(
+    NewOperatorRegistrationTestFunctionBasedKernel,
+    givenKernel_whenRegistrationRunsOutOfScope_thenCannotBeCalledAnymore) {
   {
     auto m = MAKE_TORCH_LIBRARY(_test);
     m.def("_test::my_op(Tensor dummy, int input) -> int");
@@ -106,7 +135,8 @@ TEST(NewOperatorRegistrationTestFunctionBasedKernel, givenKernel_whenRegistratio
       expectCallsDecrement(DispatchKey::CUDA);
     }
 
-    // now registrar2 is destructed. Assert that schema is still present but cpu kernel is not
+    // now registrar2 is destructed. Assert that schema is still present but cpu
+    // kernel is not
     expectCallsIncrement(DispatchKey::CPU);
     expectDoesntFindKernel("_test::my_op", DispatchKey::CUDA);
   }
@@ -121,8 +151,14 @@ void kernelWithoutOutput(const Tensor&) {
   was_called = true;
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators().op("_test::no_return(Tensor dummy) -> ()", RegisterOperators::options().kernel<decltype(kernelWithoutOutput), &kernelWithoutOutput>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::no_return(Tensor dummy) -> ()",
+      RegisterOperators::options()
+          .kernel<decltype(kernelWithoutOutput), &kernelWithoutOutput>(
+              DispatchKey::CPU));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::no_return", ""});
   ASSERT_TRUE(op.has_value());
@@ -137,10 +173,17 @@ std::tuple<> kernelWithZeroOutputs(const Tensor&) {
   return std::make_tuple();
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithZeroOutputs_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators().op("_test::zero_outputs(Tensor dummy) -> ()", RegisterOperators::options().kernel<decltype(kernelWithZeroOutputs), &kernelWithZeroOutputs>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithZeroOutputs_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::zero_outputs(Tensor dummy) -> ()",
+      RegisterOperators::options()
+          .kernel<decltype(kernelWithZeroOutputs), &kernelWithZeroOutputs>(
+              DispatchKey::CPU));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::zero_outputs", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::zero_outputs", ""});
   ASSERT_TRUE(op.has_value());
   was_called = false;
   auto result = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -152,9 +195,14 @@ int64_t kernelWithIntOutput(Tensor, int64_t a, int64_t b) {
   return a + b;
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithIntOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::int_output(Tensor dummy, int a, int b) -> int", RegisterOperators::options().kernel<decltype(kernelWithIntOutput), &kernelWithIntOutput>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithIntOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::int_output(Tensor dummy, int a, int b) -> int",
+      RegisterOperators::options()
+          .kernel<decltype(kernelWithIntOutput), &kernelWithIntOutput>(
+              DispatchKey::CPU));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::int_output", ""});
   ASSERT_TRUE(op.has_value());
@@ -168,12 +216,19 @@ Tensor kernelWithTensorOutput(const Tensor& input) {
   return input;
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithTensorOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::returning_tensor(Tensor input) -> Tensor", RegisterOperators::options().kernel<decltype(kernelWithTensorOutput), &kernelWithTensorOutput>(DispatchKey::CPU)
-                                                                                         .kernel<decltype(kernelWithTensorOutput), &kernelWithTensorOutput>(DispatchKey::CUDA));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithTensorOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::returning_tensor(Tensor input) -> Tensor",
+      RegisterOperators::options()
+          .kernel<decltype(kernelWithTensorOutput), &kernelWithTensorOutput>(
+              DispatchKey::CPU)
+          .kernel<decltype(kernelWithTensorOutput), &kernelWithTensorOutput>(
+              DispatchKey::CUDA));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::returning_tensor", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::returning_tensor", ""});
   ASSERT_TRUE(op.has_value());
 
   auto result = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -185,32 +240,57 @@ TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithTensorOutput_wh
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result[0].toTensor()));
 }
 
-c10::List<Tensor> kernelWithTensorListOutput(const Tensor& input1, const Tensor& input2, const Tensor& input3) {
+c10::List<Tensor> kernelWithTensorListOutput(
+    const Tensor& input1,
+    const Tensor& input2,
+    const Tensor& input3) {
   return c10::List<Tensor>({input1, input2, input3});
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithTensorListOutput_whenRegistered_thenCanBeCalled) {
-    auto registrar = RegisterOperators()
-      .op("_test::list_output(Tensor input1, Tensor input2, Tensor input3) -> Tensor[]", RegisterOperators::options().kernel<decltype(kernelWithTensorListOutput), &kernelWithTensorListOutput>(DispatchKey::CUDA));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithTensorListOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::list_output(Tensor input1, Tensor input2, Tensor input3) -> Tensor[]",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernelWithTensorListOutput),
+              &kernelWithTensorListOutput>(DispatchKey::CUDA));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::list_output", ""});
   ASSERT_TRUE(op.has_value());
 
-  auto result = callOp(*op, dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CUDA), dummyTensor(DispatchKey::CPU));
+  auto result = callOp(
+      *op,
+      dummyTensor(DispatchKey::CPU),
+      dummyTensor(DispatchKey::CUDA),
+      dummyTensor(DispatchKey::CPU));
   EXPECT_EQ(1, result.size());
   EXPECT_EQ(3, result[0].toTensorVector().size());
-  EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(result[0].toTensorVector()[0]));
-  EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result[0].toTensorVector()[1]));
-  EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(result[0].toTensorVector()[2]));
+  EXPECT_EQ(
+      DispatchKey::CPU, extractDispatchKey(result[0].toTensorVector()[0]));
+  EXPECT_EQ(
+      DispatchKey::CUDA, extractDispatchKey(result[0].toTensorVector()[1]));
+  EXPECT_EQ(
+      DispatchKey::CPU, extractDispatchKey(result[0].toTensorVector()[2]));
 }
 
-c10::List<int64_t> kernelWithIntListOutput(const Tensor&, int64_t input1, int64_t input2, int64_t input3) {
+c10::List<int64_t> kernelWithIntListOutput(
+    const Tensor&,
+    int64_t input1,
+    int64_t input2,
+    int64_t input3) {
   return c10::List<int64_t>({input1, input2, input3});
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithIntListOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::list_output(Tensor dummy, int input1, int input2, int input3) -> int[]", RegisterOperators::options().kernel<decltype(kernelWithIntListOutput), &kernelWithIntListOutput>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithIntListOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::list_output(Tensor dummy, int input1, int input2, int input3) -> int[]",
+      RegisterOperators::options()
+          .kernel<decltype(kernelWithIntListOutput), &kernelWithIntListOutput>(
+              DispatchKey::CPU));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::list_output", ""});
   ASSERT_TRUE(op.has_value());
@@ -223,24 +303,42 @@ TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithIntListOutput_w
   EXPECT_EQ(6, result[0].toIntVector()[2]);
 }
 
-std::tuple<Tensor, int64_t, c10::List<Tensor>, std::optional<int64_t>, Dict<string, Tensor>> kernelWithMultipleOutputs(Tensor) {
+std::tuple<
+    Tensor,
+    int64_t,
+    c10::List<Tensor>,
+    std::optional<int64_t>,
+    Dict<string, Tensor>>
+kernelWithMultipleOutputs(Tensor) {
   Dict<string, Tensor> dict;
   dict.insert("first", dummyTensor(DispatchKey::CPU));
   dict.insert("second", dummyTensor(DispatchKey::CUDA));
-  return std::tuple<Tensor, int64_t, c10::List<Tensor>, std::optional<int64_t>, Dict<string, Tensor>>(
-    dummyTensor(DispatchKey::CUDA),
-    5,
-    c10::List<Tensor>({dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CUDA)}),
-    std::optional<int64_t>(std::in_place, 0),
-    dict
-  );
+  return std::tuple<
+      Tensor,
+      int64_t,
+      c10::List<Tensor>,
+      std::optional<int64_t>,
+      Dict<string, Tensor>>(
+      dummyTensor(DispatchKey::CUDA),
+      5,
+      c10::List<Tensor>(
+          {dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CUDA)}),
+      std::optional<int64_t>(std::in_place, 0),
+      dict);
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithMultipleOutputs_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-     .op("_test::multiple_outputs(Tensor dummy) -> (Tensor, int, Tensor[], int?, Dict(str, Tensor))", RegisterOperators::options().kernel<decltype(kernelWithMultipleOutputs), &kernelWithMultipleOutputs>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithMultipleOutputs_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::multiple_outputs(Tensor dummy) -> (Tensor, int, Tensor[], int?, Dict(str, Tensor))",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernelWithMultipleOutputs),
+              &kernelWithMultipleOutputs>(DispatchKey::CPU));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::multiple_outputs", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::multiple_outputs", ""});
   ASSERT_TRUE(op.has_value());
 
   auto result = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -248,10 +346,13 @@ TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithMultipleOutputs
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result[0].toTensor()));
   EXPECT_EQ(5, result[1].toInt());
   EXPECT_EQ(2, result[2].toTensorVector().size());
-  EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(result[2].toTensorVector()[0]));
-  EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result[2].toTensorVector()[1]));
+  EXPECT_EQ(
+      DispatchKey::CPU, extractDispatchKey(result[2].toTensorVector()[0]));
+  EXPECT_EQ(
+      DispatchKey::CUDA, extractDispatchKey(result[2].toTensorVector()[1]));
   EXPECT_EQ(0, result[3].toInt());
-  auto result_dict = c10::impl::toTypedDict<string, Tensor>(result[4].toGenericDict());
+  auto result_dict =
+      c10::impl::toTypedDict<string, Tensor>(result[4].toGenericDict());
   EXPECT_EQ(2, result_dict.size());
   EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(result_dict.at("first")));
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result_dict.at("second")));
@@ -265,12 +366,21 @@ Tensor kernelWithTensorInputByValueWithOutput(Tensor input1) {
   return input1;
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithTensorInputByReference_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_input(Tensor input) -> Tensor", RegisterOperators::options().kernel<decltype(kernelWithTensorInputByReferenceWithOutput), &kernelWithTensorInputByReferenceWithOutput>(DispatchKey::CPU)
-                                                                                     .kernel<decltype(kernelWithTensorInputByReferenceWithOutput), &kernelWithTensorInputByReferenceWithOutput>(DispatchKey::CUDA));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithTensorInputByReference_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_input(Tensor input) -> Tensor",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernelWithTensorInputByReferenceWithOutput),
+              &kernelWithTensorInputByReferenceWithOutput>(DispatchKey::CPU)
+          .kernel<
+              decltype(kernelWithTensorInputByReferenceWithOutput),
+              &kernelWithTensorInputByReferenceWithOutput>(DispatchKey::CUDA));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
   ASSERT_TRUE(op.has_value());
 
   auto result = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -282,12 +392,21 @@ TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithTensorInputByRe
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result[0].toTensor()));
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithTensorInputByValue_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_input(Tensor input) -> Tensor", RegisterOperators::options().kernel<decltype(kernelWithTensorInputByValueWithOutput), &kernelWithTensorInputByValueWithOutput>(DispatchKey::CPU)
-                                                                                     .kernel<decltype(kernelWithTensorInputByValueWithOutput), &kernelWithTensorInputByValueWithOutput>(DispatchKey::CUDA));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithTensorInputByValue_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_input(Tensor input) -> Tensor",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernelWithTensorInputByValueWithOutput),
+              &kernelWithTensorInputByValueWithOutput>(DispatchKey::CPU)
+          .kernel<
+              decltype(kernelWithTensorInputByValueWithOutput),
+              &kernelWithTensorInputByValueWithOutput>(DispatchKey::CUDA));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
   ASSERT_TRUE(op.has_value());
 
   auto result = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -309,12 +428,22 @@ void kernelWithTensorInputByValueWithoutOutput(Tensor input1) {
   captured_input = input1;
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithTensorInputByReference_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_input(Tensor input) -> ()", RegisterOperators::options().kernel<decltype(kernelWithTensorInputByReferenceWithoutOutput), &kernelWithTensorInputByReferenceWithoutOutput>(DispatchKey::CPU)
-                                                                                 .kernel<decltype(kernelWithTensorInputByReferenceWithoutOutput), &kernelWithTensorInputByReferenceWithoutOutput>(DispatchKey::CUDA));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithTensorInputByReference_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_input(Tensor input) -> ()",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernelWithTensorInputByReferenceWithoutOutput),
+              &kernelWithTensorInputByReferenceWithoutOutput>(DispatchKey::CPU)
+          .kernel<
+              decltype(kernelWithTensorInputByReferenceWithoutOutput),
+              &kernelWithTensorInputByReferenceWithoutOutput>(
+              DispatchKey::CUDA));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
   ASSERT_TRUE(op.has_value());
 
   auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -326,12 +455,21 @@ TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithTensorInputByRe
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(captured_input));
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithTensorInputByValue_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_input(Tensor input) -> ()", RegisterOperators::options().kernel<decltype(kernelWithTensorInputByValueWithoutOutput), &kernelWithTensorInputByValueWithoutOutput>(DispatchKey::CPU)
-                                                                                 .kernel<decltype(kernelWithTensorInputByValueWithoutOutput), &kernelWithTensorInputByValueWithoutOutput>(DispatchKey::CUDA));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithTensorInputByValue_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_input(Tensor input) -> ()",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernelWithTensorInputByValueWithoutOutput),
+              &kernelWithTensorInputByValueWithoutOutput>(DispatchKey::CPU)
+          .kernel<
+              decltype(kernelWithTensorInputByValueWithoutOutput),
+              &kernelWithTensorInputByValueWithoutOutput>(DispatchKey::CUDA));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
   ASSERT_TRUE(op.has_value());
 
   auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -349,9 +487,15 @@ void kernelWithIntInputWithoutOutput(Tensor, int64_t input1) {
   captured_int_input = input1;
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithIntInput_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::int_input(Tensor dummy, int input) -> ()", RegisterOperators::options().kernel<decltype(kernelWithIntInputWithoutOutput), &kernelWithIntInputWithoutOutput>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithIntInput_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::int_input(Tensor dummy, int input) -> ()",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernelWithIntInputWithoutOutput),
+              &kernelWithIntInputWithoutOutput>(DispatchKey::CPU));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::int_input", ""});
   ASSERT_TRUE(op.has_value());
@@ -366,9 +510,15 @@ int64_t kernelWithIntInputWithOutput(Tensor, int64_t input1) {
   return input1 + 1;
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithIntInput_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::int_input(Tensor dummy, int input) -> int", RegisterOperators::options().kernel<decltype(kernelWithIntInputWithOutput), &kernelWithIntInputWithOutput>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithIntInput_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::int_input(Tensor dummy, int input) -> int",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernelWithIntInputWithOutput),
+              &kernelWithIntInputWithOutput>(DispatchKey::CPU));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::int_input", ""});
   ASSERT_TRUE(op.has_value());
@@ -380,35 +530,55 @@ TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithIntInput_withOu
 
 int64_t captured_input_list_size = 0;
 
-void kernelWithIntListInputWithoutOutput(Tensor, const c10::List<int64_t>& input1) {
+void kernelWithIntListInputWithoutOutput(
+    Tensor,
+    const c10::List<int64_t>& input1) {
   captured_input_list_size = input1.size();
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithIntListInput_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::int_list_input(Tensor dummy, int[] input) -> ()", RegisterOperators::options().kernel<decltype(kernelWithIntListInputWithoutOutput), &kernelWithIntListInputWithoutOutput>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithIntListInput_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::int_list_input(Tensor dummy, int[] input) -> ()",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernelWithIntListInputWithoutOutput),
+              &kernelWithIntListInputWithoutOutput>(DispatchKey::CPU));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::int_list_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::int_list_input", ""});
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::List<int64_t>({2, 4, 6}));
+  auto outputs =
+      callOp(*op, dummyTensor(DispatchKey::CPU), c10::List<int64_t>({2, 4, 6}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(3, captured_input_list_size);
 }
 
-int64_t kernelWithIntListInputWithOutput(Tensor, const c10::List<int64_t>& input1) {
+int64_t kernelWithIntListInputWithOutput(
+    Tensor,
+    const c10::List<int64_t>& input1) {
   return input1.size();
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithIntListInput_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::int_list_input(Tensor dummy, int[] input) -> int", RegisterOperators::options().kernel<decltype(kernelWithIntListInputWithOutput), &kernelWithIntListInputWithOutput>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithIntListInput_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::int_list_input(Tensor dummy, int[] input) -> int",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernelWithIntListInputWithOutput),
+              &kernelWithIntListInputWithOutput>(DispatchKey::CPU));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::int_list_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::int_list_input", ""});
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::List<int64_t>({2, 4, 6}));
+  auto outputs =
+      callOp(*op, dummyTensor(DispatchKey::CPU), c10::List<int64_t>({2, 4, 6}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(3, outputs[0].toInt());
 }
@@ -417,15 +587,25 @@ void kernelWithTensorListInputWithoutOutput(const c10::List<Tensor>& input1) {
   captured_input_list_size = input1.size();
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithTensorListInput_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_list_input(Tensor[] input) -> ()", RegisterOperators::options().kernel<decltype(kernelWithTensorListInputWithoutOutput), &kernelWithTensorListInputWithoutOutput>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithTensorListInput_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_list_input(Tensor[] input) -> ()",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernelWithTensorListInputWithoutOutput),
+              &kernelWithTensorListInputWithoutOutput>(DispatchKey::CPU));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, c10::List<Tensor>({dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
+  auto outputs = callOp(
+      *op,
+      c10::List<Tensor>(
+          {dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(2, captured_input_list_size);
 }
@@ -434,14 +614,24 @@ int64_t kernelWithTensorListInputWithOutput(const c10::List<Tensor>& input1) {
   return input1.size();
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithTensorListInput_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_list_input(Tensor[] input) -> int", RegisterOperators::options().kernel<decltype(kernelWithTensorListInputWithOutput), &kernelWithTensorListInputWithOutput>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithTensorListInput_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_list_input(Tensor[] input) -> int",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernelWithTensorListInputWithOutput),
+              &kernelWithTensorListInputWithOutput>(DispatchKey::CPU));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, c10::List<Tensor>({dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
+  auto outputs = callOp(
+      *op,
+      c10::List<Tensor>(
+          {dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(2, outputs[0].toInt());
 }
@@ -452,9 +642,15 @@ void kernelWithDictInputWithoutOutput(Dict<string, Tensor> input1) {
   captured_dict_size = input1.size();
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithDictInput_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::dict_input(Dict(str, Tensor) input) -> ()", RegisterOperators::options().catchAllKernel<decltype(kernelWithDictInputWithoutOutput), &kernelWithDictInputWithoutOutput>());
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithDictInput_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::dict_input(Dict(str, Tensor) input) -> ()",
+      RegisterOperators::options()
+          .catchAllKernel<
+              decltype(kernelWithDictInputWithoutOutput),
+              &kernelWithDictInputWithoutOutput>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::dict_input", ""});
   ASSERT_TRUE(op.has_value());
@@ -472,9 +668,15 @@ string kernelWithDictInputWithOutput(Dict<string, string> input1) {
   return input1.at("key2");
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithDictInput_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::dict_input(Dict(str, str) input) -> str", RegisterOperators::options().catchAllKernel<decltype(kernelWithDictInputWithOutput), &kernelWithDictInputWithOutput>());
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithDictInput_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::dict_input(Dict(str, str) input) -> str",
+      RegisterOperators::options()
+          .catchAllKernel<
+              decltype(kernelWithDictInputWithOutput),
+              &kernelWithDictInputWithOutput>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::dict_input", ""});
   ASSERT_TRUE(op.has_value());
@@ -491,9 +693,15 @@ Dict<string, string> kernelWithDictOutput(Dict<string, string> input) {
   return input;
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithDictOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::dict_output(Dict(str, str) input) -> Dict(str, str)", RegisterOperators::options().catchAllKernel<decltype(kernelWithDictOutput), &kernelWithDictOutput>());
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithDictOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::dict_output(Dict(str, str) input) -> Dict(str, str)",
+      RegisterOperators::options()
+          .catchAllKernel<
+              decltype(kernelWithDictOutput),
+              &kernelWithDictOutput>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::dict_output", ""});
   ASSERT_TRUE(op.has_value());
@@ -503,7 +711,8 @@ TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithDictOutput_when
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  auto output = c10::impl::toTypedDict<string, string>(outputs[0].toGenericDict());
+  auto output =
+      c10::impl::toTypedDict<string, string>(outputs[0].toGenericDict());
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ("value1", output.at("key1"));
@@ -516,14 +725,21 @@ void kernelWithoutInputs() {
   called = true;
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenFallbackKernelWithoutAnyArguments_whenRegistered_thenCanBeCalled) {
-  // note: non-fallback kernels without tensor arguments don't work because there
-  // is no way to get the dispatch key. For operators that only have a fallback
-  // kernel, this must work for backwards compatibility.
-  auto registrar = RegisterOperators()
-      .op("_test::no_tensor_args() -> ()", RegisterOperators::options().catchAllKernel<decltype(kernelWithoutInputs), &kernelWithoutInputs>());
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenFallbackKernelWithoutAnyArguments_whenRegistered_thenCanBeCalled) {
+  // note: non-fallback kernels without tensor arguments don't work because
+  // there is no way to get the dispatch key. For operators that only have a
+  // fallback kernel, this must work for backwards compatibility.
+  auto registrar = RegisterOperators().op(
+      "_test::no_tensor_args() -> ()",
+      RegisterOperators::options()
+          .catchAllKernel<
+              decltype(kernelWithoutInputs),
+              &kernelWithoutInputs>());
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
   ASSERT_TRUE(op.has_value());
 
   called = false;
@@ -535,14 +751,21 @@ int64_t kernelWithoutTensorInputs(int64_t arg) {
   return arg + 1;
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenFallbackKernelWithoutTensorArguments_whenRegistered_thenCanBeCalled) {
-  // note: non-fallback kernels without tensor arguments don't work because there
-  // is no way to get the dispatch key. For operators that only have a fallback
-  // kernel, this must work for backwards compatibility.
-  auto registrar = RegisterOperators()
-      .op("_test::no_tensor_args(int arg) -> int", RegisterOperators::options().catchAllKernel<decltype(kernelWithoutTensorInputs), &kernelWithoutTensorInputs>());
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenFallbackKernelWithoutTensorArguments_whenRegistered_thenCanBeCalled) {
+  // note: non-fallback kernels without tensor arguments don't work because
+  // there is no way to get the dispatch key. For operators that only have a
+  // fallback kernel, this must work for backwards compatibility.
+  auto registrar = RegisterOperators().op(
+      "_test::no_tensor_args(int arg) -> int",
+      RegisterOperators::options()
+          .catchAllKernel<
+              decltype(kernelWithoutTensorInputs),
+              &kernelWithoutTensorInputs>());
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
   ASSERT_TRUE(op.has_value());
 
   auto outputs = callOp(*op, 3);
@@ -554,20 +777,36 @@ std::optional<Tensor> called_arg2 = std::nullopt;
 std::optional<int64_t> called_arg3 = std::nullopt;
 std::optional<std::string> called_arg4 = std::nullopt;
 
-void kernelWithOptInputWithoutOutput(Tensor arg1, const std::optional<Tensor>& arg2, std::optional<int64_t> arg3, std::optional<std::string> arg4) {
+void kernelWithOptInputWithoutOutput(
+    Tensor arg1,
+    const std::optional<Tensor>& arg2,
+    std::optional<int64_t> arg3,
+    std::optional<std::string> arg4) {
   called = true;
   called_arg2 = arg2;
   called_arg3 = arg3;
   called_arg4 = arg4;
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithOptionalInputs_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators().op("_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> ()", RegisterOperators::options().kernel<decltype(kernelWithOptInputWithoutOutput), &kernelWithOptInputWithoutOutput>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithOptionalInputs_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> ()",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernelWithOptInputWithoutOutput),
+              &kernelWithOptInputWithoutOutput>(DispatchKey::CPU));
   auto op = c10::Dispatcher::singleton().findSchema({"_test::opt_input", ""});
   ASSERT_TRUE(op.has_value());
 
   called = false;
-  auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU), c10::IValue(), std::string("text"));
+  auto outputs = callOp(
+      *op,
+      dummyTensor(DispatchKey::CPU),
+      dummyTensor(DispatchKey::CPU),
+      c10::IValue(),
+      std::string("text"));
   EXPECT_EQ(0, outputs.size());
 
   EXPECT_TRUE(called);
@@ -578,7 +817,8 @@ TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithOptionalInputs_
   EXPECT_EQ(*called_arg4, "text");
 
   called = false;
-  outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
+  outputs = callOp(
+      *op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
   EXPECT_EQ(0, outputs.size());
 
   EXPECT_TRUE(called);
@@ -588,7 +828,11 @@ TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithOptionalInputs_
   EXPECT_FALSE(called_arg4.has_value());
 }
 
-std::optional<Tensor> kernelWithOptInputWithOutput(Tensor arg1, const std::optional<Tensor>& arg2, std::optional<int64_t> arg3, std::optional<std::string> arg4) {
+std::optional<Tensor> kernelWithOptInputWithOutput(
+    Tensor arg1,
+    const std::optional<Tensor>& arg2,
+    std::optional<int64_t> arg3,
+    std::optional<std::string> arg4) {
   called = true;
   called_arg2 = arg2;
   called_arg3 = arg3;
@@ -596,13 +840,25 @@ std::optional<Tensor> kernelWithOptInputWithOutput(Tensor arg1, const std::optio
   return arg2;
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithOptionalInputs_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators().op("_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> Tensor?", RegisterOperators::options().kernel<decltype(kernelWithOptInputWithOutput), &kernelWithOptInputWithOutput>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithOptionalInputs_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> Tensor?",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernelWithOptInputWithOutput),
+              &kernelWithOptInputWithOutput>(DispatchKey::CPU));
   auto op = c10::Dispatcher::singleton().findSchema({"_test::opt_input", ""});
   ASSERT_TRUE(op.has_value());
 
   called = false;
-  auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU), c10::IValue(), std::string("text"));
+  auto outputs = callOp(
+      *op,
+      dummyTensor(DispatchKey::CPU),
+      dummyTensor(DispatchKey::CPU),
+      c10::IValue(),
+      std::string("text"));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(outputs[0].toTensor()));
 
@@ -614,7 +870,8 @@ TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithOptionalInputs_
   EXPECT_EQ(*called_arg4, "text");
 
   called = false;
-  outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
+  outputs = callOp(
+      *op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
   EXPECT_EQ(1, outputs.size());
   EXPECT_TRUE(outputs[0].isNone());
 
@@ -625,30 +882,54 @@ TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithOptionalInputs_
   EXPECT_FALSE(called_arg4.has_value());
 }
 
-std::tuple<std::optional<Tensor>, std::optional<int64_t>, std::optional<std::string>>
-kernelWithOptInputWithMultipleOutputs(Tensor arg1, const std::optional<Tensor>& arg2, std::optional<int64_t> arg3, std::optional<std::string> arg4) {
+std::tuple<
+    std::optional<Tensor>,
+    std::optional<int64_t>,
+    std::optional<std::string>>
+kernelWithOptInputWithMultipleOutputs(
+    Tensor arg1,
+    const std::optional<Tensor>& arg2,
+    std::optional<int64_t> arg3,
+    std::optional<std::string> arg4) {
   return std::make_tuple(arg2, arg3, arg4);
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernelWithOptionalInputs_withMultipleOutputs_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators().op("_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> (Tensor?, int?, str?)", RegisterOperators::options().kernel<decltype(kernelWithOptInputWithMultipleOutputs), &kernelWithOptInputWithMultipleOutputs>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernelWithOptionalInputs_withMultipleOutputs_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> (Tensor?, int?, str?)",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernelWithOptInputWithMultipleOutputs),
+              &kernelWithOptInputWithMultipleOutputs>(DispatchKey::CPU));
   auto op = c10::Dispatcher::singleton().findSchema({"_test::opt_input", ""});
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU), c10::IValue(), std::string("text"));
+  auto outputs = callOp(
+      *op,
+      dummyTensor(DispatchKey::CPU),
+      dummyTensor(DispatchKey::CPU),
+      c10::IValue(),
+      std::string("text"));
   EXPECT_EQ(3, outputs.size());
   EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(outputs[0].toTensor()));
   EXPECT_TRUE(outputs[1].isNone());
   EXPECT_EQ("text", outputs[2].toStringRef());
 
-  outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
+  outputs = callOp(
+      *op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
   EXPECT_EQ(3, outputs.size());
   EXPECT_TRUE(outputs[0].isNone());
   EXPECT_EQ(4, outputs[1].toInt());
   EXPECT_TRUE(outputs[2].isNone());
 }
 
-std::string concatKernel(const Tensor& tensor1, std::string a, const std::string& b, int64_t c) {
+std::string concatKernel(
+    const Tensor& tensor1,
+    std::string a,
+    const std::string& b,
+    int64_t c) {
   return a + b + std::to_string(c);
 }
 
@@ -658,196 +939,374 @@ void expectCallsConcatUnboxed(DispatchKey dispatch_key) {
   // assert that schema and cpu kernel are present
   auto op = c10::Dispatcher::singleton().findSchema({"_test::my_op", ""});
   ASSERT_TRUE(op.has_value());
-  std::string result = callOpUnboxed<std::string, const Tensor&, std::string, const std::string&, int64_t>(*op, dummyTensor(dispatch_key), "1", "2", 3);
+  std::string result = callOpUnboxed<
+      std::string,
+      const Tensor&,
+      std::string,
+      const std::string&,
+      int64_t>(*op, dummyTensor(dispatch_key), "1", "2", 3);
   EXPECT_EQ("123", result);
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernel_whenRegistered_thenCanBeCalledUnboxed) {
-  auto registrar = RegisterOperators().op("_test::my_op(Tensor dummy, str a, str b, int c) -> str", RegisterOperators::options().kernel<decltype(concatKernel), &concatKernel>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernel_whenRegistered_thenCanBeCalledUnboxed) {
+  auto registrar = RegisterOperators().op(
+      "_test::my_op(Tensor dummy, str a, str b, int c) -> str",
+      RegisterOperators::options()
+          .kernel<decltype(concatKernel), &concatKernel>(DispatchKey::CPU));
   expectCallsConcatUnboxed(DispatchKey::CPU);
 }
 
-std::tuple<int64_t, Tensor> kernelForSchemaInference(Tensor arg1, int64_t arg2, const c10::List<Tensor>& arg3) {
+std::tuple<int64_t, Tensor> kernelForSchemaInference(
+    Tensor arg1,
+    int64_t arg2,
+    const c10::List<Tensor>& arg3) {
   return {};
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
-  auto registrar = RegisterOperators()
-      .op("_test::no_schema_specified", RegisterOperators::options().catchAllKernel<decltype(kernelForSchemaInference), &kernelForSchemaInference>());
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
+  auto registrar = RegisterOperators().op(
+      "_test::no_schema_specified",
+      RegisterOperators::options()
+          .catchAllKernel<
+              decltype(kernelForSchemaInference),
+              &kernelForSchemaInference>());
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::no_schema_specified", ""});
+  auto op = c10::Dispatcher::singleton().findSchema(
+      {"_test::no_schema_specified", ""});
   ASSERT_TRUE(op.has_value());
 
-  std::optional<std::string> differences = c10::findSchemaDifferences(torch::jit::parseSchema("_test::no_schema_specified(Tensor arg1, int arg2, Tensor[] arg3) -> (int, Tensor)"), op->schema());
+  std::optional<std::string> differences = c10::findSchemaDifferences(
+      torch::jit::parseSchema(
+          "_test::no_schema_specified(Tensor arg1, int arg2, Tensor[] arg3) -> (int, Tensor)"),
+      op->schema());
   EXPECT_FALSE(differences.has_value());
 }
 
-template<class Return, class... Args> struct kernel_func final {
-  static Return func(Args...) { return {}; }
+template <class Return, class... Args>
+struct kernel_func final {
+  static Return func(Args...) {
+    return {};
+  }
 };
-template<class... Args> struct kernel_func<void, Args...> final {
+template <class... Args>
+struct kernel_func<void, Args...> final {
   static void func(Args...) {}
 };
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenMismatchedKernel_withDifferentNumArguments_whenRegistering_thenFails) {
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenMismatchedKernel_withDifferentNumArguments_whenRegistering_thenFails) {
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> int", RegisterOperators::options().kernel<decltype(kernel_func<int64_t, Tensor>::func), &kernel_func<int64_t, Tensor>::func>(DispatchKey::CPU));
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> int",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernel_func<int64_t, Tensor>::func),
+              &kernel_func<int64_t, Tensor>::func>(DispatchKey::CPU));
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg, Tensor arg2) -> int", RegisterOperators::options().kernel<decltype(kernel_func<int64_t, Tensor>::func), &kernel_func<int64_t, Tensor>::func>(DispatchKey::CPU));
-    }, "The number of arguments is different. 2 vs 1"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg, Tensor arg2) -> int",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<int64_t, Tensor>::func),
+                    &kernel_func<int64_t, Tensor>::func>(DispatchKey::CPU));
+      },
+      "The number of arguments is different. 2 vs 1");
 
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg, Tensor arg2) -> ()", RegisterOperators::options().kernel<decltype(kernel_func<void, Tensor, Tensor>::func), &kernel_func<void, Tensor, Tensor>::func>(DispatchKey::CPU));
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg, Tensor arg2) -> ()",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernel_func<void, Tensor, Tensor>::func),
+              &kernel_func<void, Tensor, Tensor>::func>(DispatchKey::CPU));
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch() -> ()", RegisterOperators::options().kernel<decltype(kernel_func<void, Tensor, Tensor>::func), &kernel_func<void, Tensor, Tensor>::func>(DispatchKey::CPU));
-    }, "The number of arguments is different. 0 vs 2"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch() -> ()",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<void, Tensor, Tensor>::func),
+                    &kernel_func<void, Tensor, Tensor>::func>(
+                    DispatchKey::CPU));
+      },
+      "The number of arguments is different. 0 vs 2");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> ()", RegisterOperators::options().kernel<decltype(kernel_func<void, Tensor, Tensor>::func), &kernel_func<void, Tensor, Tensor>::func>(DispatchKey::CPU));
-    }, "The number of arguments is different. 1 vs 2"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> ()",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<void, Tensor, Tensor>::func),
+                    &kernel_func<void, Tensor, Tensor>::func>(
+                    DispatchKey::CPU));
+      },
+      "The number of arguments is different. 1 vs 2");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg, Tensor arg2, Tensor arg3) -> ()", RegisterOperators::options().kernel<decltype(kernel_func<void, Tensor, Tensor>::func), &kernel_func<void, Tensor, Tensor>::func>(DispatchKey::CPU));
-    }, "The number of arguments is different. 3 vs 2"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg, Tensor arg2, Tensor arg3) -> ()",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<void, Tensor, Tensor>::func),
+                    &kernel_func<void, Tensor, Tensor>::func>(
+                    DispatchKey::CPU));
+      },
+      "The number of arguments is different. 3 vs 2");
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenMismatchedKernel_withDifferentArgumentType_whenRegistering_thenFails) {
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenMismatchedKernel_withDifferentArgumentType_whenRegistering_thenFails) {
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg1, int arg2) -> int", RegisterOperators::options().kernel<decltype(kernel_func<int64_t, Tensor, int64_t>::func), &kernel_func<int64_t, Tensor, int64_t>::func>(DispatchKey::CPU));
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg1, int arg2) -> int",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernel_func<int64_t, Tensor, int64_t>::func),
+              &kernel_func<int64_t, Tensor, int64_t>::func>(DispatchKey::CPU));
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg1, float arg2) -> int", RegisterOperators::options().kernel<decltype(kernel_func<int64_t, Tensor, int64_t>::func), &kernel_func<int64_t, Tensor, int64_t>::func>(DispatchKey::CPU));
-    }, "Type mismatch in argument 2: float vs int"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg1, float arg2) -> int",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<int64_t, Tensor, int64_t>::func),
+                    &kernel_func<int64_t, Tensor, int64_t>::func>(
+                    DispatchKey::CPU));
+      },
+      "Type mismatch in argument 2: float vs int");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(int arg1, int arg2) -> int", RegisterOperators::options().kernel<decltype(kernel_func<int64_t, Tensor, int64_t>::func), &kernel_func<int64_t, Tensor, int64_t>::func>(DispatchKey::CPU));
-    }, "Type mismatch in argument 1: int vs Tensor"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(int arg1, int arg2) -> int",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<int64_t, Tensor, int64_t>::func),
+                    &kernel_func<int64_t, Tensor, int64_t>::func>(
+                    DispatchKey::CPU));
+      },
+      "Type mismatch in argument 1: int vs Tensor");
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenMismatchedKernel_withDifferentNumReturns_whenRegistering_thenFails) {
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenMismatchedKernel_withDifferentNumReturns_whenRegistering_thenFails) {
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> int", RegisterOperators::options().kernel<decltype(kernel_func<int64_t, Tensor>::func), &kernel_func<int64_t, Tensor>::func>(DispatchKey::CPU));
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> int",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernel_func<int64_t, Tensor>::func),
+              &kernel_func<int64_t, Tensor>::func>(DispatchKey::CPU));
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> ()", RegisterOperators::options().kernel<decltype(kernel_func<int64_t, Tensor>::func), &kernel_func<int64_t, Tensor>::func>(DispatchKey::CPU));
-    }, "The number of returns is different. 0 vs 1"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> ()",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<int64_t, Tensor>::func),
+                    &kernel_func<int64_t, Tensor>::func>(DispatchKey::CPU));
+      },
+      "The number of returns is different. 0 vs 1");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> (int, int)", RegisterOperators::options().kernel<decltype(kernel_func<int64_t, Tensor>::func), &kernel_func<int64_t, Tensor>::func>(DispatchKey::CPU));
-    }, "The number of returns is different. 2 vs 1"
-  );
-
-  // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> ()", RegisterOperators::options().kernel<decltype(kernel_func<void, Tensor>::func), &kernel_func<void, Tensor>::func>(DispatchKey::CPU));
-
-  // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> Tensor", RegisterOperators::options().kernel<decltype(kernel_func<void, Tensor>::func), &kernel_func<void, Tensor>::func>(DispatchKey::CPU));
-    }, "The number of returns is different. 1 vs 0"
-  );
-
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> (Tensor, Tensor)", RegisterOperators::options().kernel<decltype(kernel_func<void, Tensor>::func), &kernel_func<void, Tensor>::func>(DispatchKey::CPU));
-    }, "The number of returns is different. 2 vs 0"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> (int, int)",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<int64_t, Tensor>::func),
+                    &kernel_func<int64_t, Tensor>::func>(DispatchKey::CPU));
+      },
+      "The number of returns is different. 2 vs 1");
 
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> (Tensor, Tensor)", RegisterOperators::options().kernel<decltype(kernel_func<std::tuple<Tensor, Tensor>, Tensor>::func), &kernel_func<std::tuple<Tensor, Tensor>, Tensor>::func>(DispatchKey::CPU));
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> ()",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernel_func<void, Tensor>::func),
+              &kernel_func<void, Tensor>::func>(DispatchKey::CPU));
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> ()", RegisterOperators::options().kernel<decltype(kernel_func<std::tuple<Tensor, Tensor>, Tensor>::func), &kernel_func<std::tuple<Tensor, Tensor>, Tensor>::func>(DispatchKey::CPU));
-    }, "The number of returns is different. 0 vs 2"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> Tensor",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<void, Tensor>::func),
+                    &kernel_func<void, Tensor>::func>(DispatchKey::CPU));
+      },
+      "The number of returns is different. 1 vs 0");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> Tensor", RegisterOperators::options().kernel<decltype(kernel_func<std::tuple<Tensor, Tensor>, Tensor>::func), &kernel_func<std::tuple<Tensor, Tensor>, Tensor>::func>(DispatchKey::CPU));
-    }, "The number of returns is different. 1 vs 2"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> (Tensor, Tensor)",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<void, Tensor>::func),
+                    &kernel_func<void, Tensor>::func>(DispatchKey::CPU));
+      },
+      "The number of returns is different. 2 vs 0");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> (Tensor, Tensor, Tensor)", RegisterOperators::options().kernel<decltype(kernel_func<std::tuple<Tensor, Tensor>, Tensor>::func), &kernel_func<std::tuple<Tensor, Tensor>, Tensor>::func>(DispatchKey::CPU));
-    }, "The number of returns is different. 3 vs 2"
-  );
+  // assert this does not fail because it matches
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> (Tensor, Tensor)",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernel_func<std::tuple<Tensor, Tensor>, Tensor>::func),
+              &kernel_func<std::tuple<Tensor, Tensor>, Tensor>::func>(
+              DispatchKey::CPU));
+
+  // and now a set of mismatching schemas
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> ()",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<std::tuple<Tensor, Tensor>, Tensor>::
+                                 func),
+                    &kernel_func<std::tuple<Tensor, Tensor>, Tensor>::func>(
+                    DispatchKey::CPU));
+      },
+      "The number of returns is different. 0 vs 2");
+
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> Tensor",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<std::tuple<Tensor, Tensor>, Tensor>::
+                                 func),
+                    &kernel_func<std::tuple<Tensor, Tensor>, Tensor>::func>(
+                    DispatchKey::CPU));
+      },
+      "The number of returns is different. 1 vs 2");
+
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> (Tensor, Tensor, Tensor)",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<std::tuple<Tensor, Tensor>, Tensor>::
+                                 func),
+                    &kernel_func<std::tuple<Tensor, Tensor>, Tensor>::func>(
+                    DispatchKey::CPU));
+      },
+      "The number of returns is different. 3 vs 2");
 }
 
-TEST(OperatorRegistrationTestFunctionBasedKernel, givenMismatchedKernel_withDifferentReturnTypes_whenRegistering_thenFails) {
+TEST(
+    OperatorRegistrationTestFunctionBasedKernel,
+    givenMismatchedKernel_withDifferentReturnTypes_whenRegistering_thenFails) {
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> int", RegisterOperators::options().kernel<decltype(kernel_func<int64_t, Tensor>::func), &kernel_func<int64_t, Tensor>::func>(DispatchKey::CPU));
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> int",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernel_func<int64_t, Tensor>::func),
+              &kernel_func<int64_t, Tensor>::func>(DispatchKey::CPU));
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> Tensor", RegisterOperators::options().kernel<decltype(kernel_func<int64_t, Tensor>::func), &kernel_func<int64_t, Tensor>::func>(DispatchKey::CPU));
-    }, "Type mismatch in return 1: Tensor vs int"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> Tensor",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<int64_t, Tensor>::func),
+                    &kernel_func<int64_t, Tensor>::func>(DispatchKey::CPU));
+      },
+      "Type mismatch in return 1: Tensor vs int");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> float", RegisterOperators::options().kernel<decltype(kernel_func<int64_t, Tensor>::func), &kernel_func<int64_t, Tensor>::func>(DispatchKey::CPU));
-    }, "Type mismatch in return 1: float vs int"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> float",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<int64_t, Tensor>::func),
+                    &kernel_func<int64_t, Tensor>::func>(DispatchKey::CPU));
+      },
+      "Type mismatch in return 1: float vs int");
 
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> Tensor", RegisterOperators::options().kernel<decltype(kernel_func<Tensor, Tensor>::func), &kernel_func<Tensor, Tensor>::func>(DispatchKey::CPU));
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> Tensor",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernel_func<Tensor, Tensor>::func),
+              &kernel_func<Tensor, Tensor>::func>(DispatchKey::CPU));
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> float", RegisterOperators::options().kernel<decltype(kernel_func<Tensor, Tensor>::func), &kernel_func<Tensor, Tensor>::func>(DispatchKey::CPU));
-    }, "Type mismatch in return 1: float vs Tensor"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> float",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<Tensor, Tensor>::func),
+                    &kernel_func<Tensor, Tensor>::func>(DispatchKey::CPU));
+      },
+      "Type mismatch in return 1: float vs Tensor");
 
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> (Tensor, int)", RegisterOperators::options().kernel<decltype(kernel_func<std::tuple<Tensor, int64_t>, Tensor>::func), &kernel_func<std::tuple<Tensor, int64_t>, Tensor>::func>(DispatchKey::CPU));
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> (Tensor, int)",
+      RegisterOperators::options()
+          .kernel<
+              decltype(kernel_func<std::tuple<Tensor, int64_t>, Tensor>::func),
+              &kernel_func<std::tuple<Tensor, int64_t>, Tensor>::func>(
+              DispatchKey::CPU));
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> (Tensor, float)", RegisterOperators::options().kernel<decltype(kernel_func<std::tuple<Tensor, int64_t>, Tensor>::func), &kernel_func<std::tuple<Tensor, int64_t>, Tensor>::func>(DispatchKey::CPU));
-    }, "Type mismatch in return 2: float vs int"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> (Tensor, float)",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<std::tuple<Tensor, int64_t>, Tensor>::
+                                 func),
+                    &kernel_func<std::tuple<Tensor, int64_t>, Tensor>::func>(
+                    DispatchKey::CPU));
+      },
+      "Type mismatch in return 2: float vs int");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> (int, int)", RegisterOperators::options().kernel<decltype(kernel_func<std::tuple<Tensor, int64_t>, Tensor>::func), &kernel_func<std::tuple<Tensor, int64_t>, Tensor>::func>(DispatchKey::CPU));
-    }, "Type mismatch in return 1: int vs Tensor"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> (int, int)",
+            RegisterOperators::options()
+                .kernel<
+                    decltype(kernel_func<std::tuple<Tensor, int64_t>, Tensor>::
+                                 func),
+                    &kernel_func<std::tuple<Tensor, int64_t>, Tensor>::func>(
+                    DispatchKey::CPU));
+      },
+      "Type mismatch in return 1: int vs Tensor");
 }
 
-}
+} // namespace

--- a/aten/src/ATen/core/boxing/impl/kernel_lambda_legacy_test.cpp
+++ b/aten/src/ATen/core/boxing/impl/kernel_lambda_legacy_test.cpp
@@ -4,9 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
+#include <ATen/core/Tensor.h>
 #include <ATen/core/boxing/impl/test_helpers.h>
 #include <ATen/core/op_registration/op_registration.h>
-#include <ATen/core/Tensor.h>
 #include <torch/csrc/jit/frontend/function_schema_parser.h>
 
 #include <ATen/core/LegacyTypeDispatch.h>
@@ -18,13 +18,13 @@
  * >    .op("myfunc(Tensor a) -> Tensor", [] (Tensor a) -> Tensor {...});
  */
 
-using c10::RegisterOperators;
+using at::Tensor;
+using c10::Dict;
 using c10::DispatchKey;
+using c10::intrusive_ptr;
+using c10::RegisterOperators;
 using c10::Stack;
 using std::make_unique;
-using c10::intrusive_ptr;
-using c10::Dict;
-using at::Tensor;
 using std::string;
 using std::unique_ptr;
 
@@ -41,48 +41,65 @@ void expectCallsIncrement(DispatchKey dispatch_key) {
   EXPECT_EQ(6, result[0].toInt());
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernel_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators().op("_test::my_op(Tensor dummy, int input) -> int", [] (const Tensor& tensor, int64_t input) -> int64_t {
-      return input + 1;
-    });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernel_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::my_op(Tensor dummy, int input) -> int",
+      [](const Tensor& tensor, int64_t input) -> int64_t { return input + 1; });
   expectCallsIncrement(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernel_whenRegisteredInConstructor_thenCanBeCalled) {
-  auto registrar = RegisterOperators("_test::my_op(Tensor dummy, int input) -> int", [] (const Tensor& tensor, int64_t input) -> int64_t {
-      return input + 1;
-    });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernel_whenRegisteredInConstructor_thenCanBeCalled) {
+  auto registrar = RegisterOperators(
+      "_test::my_op(Tensor dummy, int input) -> int",
+      [](const Tensor& tensor, int64_t input) -> int64_t { return input + 1; });
   expectCallsIncrement(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenMultipleOperatorsAndKernels_whenRegisteredInOneRegistrar_thenCallsRightKernel) {
-  auto registrar = RegisterOperators()
-      .op("_test::my_op(Tensor dummy, int input) -> int", [] (const Tensor& tensor, int64_t input) -> int64_t {
-          return input + 1;
-        })
-      .op("_test::error(Tensor dummy, int input) -> int", [] (const Tensor& tensor, int64_t input) -> int64_t {
-          EXPECT_TRUE(false); // this kernel should never be called
-          return 0;
-        });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenMultipleOperatorsAndKernels_whenRegisteredInOneRegistrar_thenCallsRightKernel) {
+  auto registrar =
+      RegisterOperators()
+          .op("_test::my_op(Tensor dummy, int input) -> int",
+              [](const Tensor& tensor, int64_t input) -> int64_t {
+                return input + 1;
+              })
+          .op("_test::error(Tensor dummy, int input) -> int",
+              [](const Tensor& tensor, int64_t input) -> int64_t {
+                EXPECT_TRUE(false); // this kernel should never be called
+                return 0;
+              });
   expectCallsIncrement(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenMultipleOperatorsAndKernels_whenRegisteredInMultipleRegistrars_thenCallsRightKernel) {
-  auto registrar1 = RegisterOperators().op("_test::my_op(Tensor dummy, int input) -> int", [] (const Tensor& tensor, int64_t input) -> int64_t {
-      return input + 1;
-    });
-  auto registrar2 = RegisterOperators().op("_test::error(Tensor dummy, int input) -> int", [] (const Tensor& tensor, int64_t input) -> int64_t {
-      EXPECT_TRUE(false); // this kernel should never be called
-      return 0;
-    });
-  expectCallsIncrement(DispatchKey::CPU);
-}
-
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernel_whenRegistrationRunsOutOfScope_thenCannotBeCalledAnymore) {
-  {
-    auto registrar = RegisterOperators().op("_test::my_op(Tensor dummy, int input) -> int", [] (const Tensor& tensor, int64_t input) -> int64_t {
-        return input + 1;
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenMultipleOperatorsAndKernels_whenRegisteredInMultipleRegistrars_thenCallsRightKernel) {
+  auto registrar1 = RegisterOperators().op(
+      "_test::my_op(Tensor dummy, int input) -> int",
+      [](const Tensor& tensor, int64_t input) -> int64_t { return input + 1; });
+  auto registrar2 = RegisterOperators().op(
+      "_test::error(Tensor dummy, int input) -> int",
+      [](const Tensor& tensor, int64_t input) -> int64_t {
+        EXPECT_TRUE(false); // this kernel should never be called
+        return 0;
       });
+  expectCallsIncrement(DispatchKey::CPU);
+}
+
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernel_whenRegistrationRunsOutOfScope_thenCannotBeCalledAnymore) {
+  {
+    auto registrar = RegisterOperators().op(
+        "_test::my_op(Tensor dummy, int input) -> int",
+        [](const Tensor& tensor, int64_t input) -> int64_t {
+          return input + 1;
+        });
 
     expectCallsIncrement(DispatchKey::CPU);
   }
@@ -93,10 +110,12 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernel_whenRegistrati
 
 bool was_called = false;
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators().op("_test::no_return(Tensor dummy) -> ()", [] (const Tensor&) -> void {
-    was_called = true;
-  });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::no_return(Tensor dummy) -> ()",
+      [](const Tensor&) -> void { was_called = true; });
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::no_return", ""});
   ASSERT_TRUE(op.has_value());
@@ -106,13 +125,18 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithoutOutput_w
   EXPECT_EQ(0, result.size());
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithZeroOutputs_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators().op("_test::zero_outputs(Tensor dummy) -> ()", [] (const Tensor&) -> std::tuple<> {
-    was_called = true;
-    return std::make_tuple();
-  });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithZeroOutputs_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::zero_outputs(Tensor dummy) -> ()",
+      [](const Tensor&) -> std::tuple<> {
+        was_called = true;
+        return std::make_tuple();
+      });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::zero_outputs", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::zero_outputs", ""});
   ASSERT_TRUE(op.has_value());
   was_called = false;
   auto result = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -120,11 +144,12 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithZeroOutputs
   EXPECT_EQ(0, result.size());
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithIntOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::int_output(Tensor dummy, int a, int b) -> int", [] (Tensor, int64_t a, int64_t b) -> int64_t {
-        return a + b;
-      });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithIntOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::int_output(Tensor dummy, int a, int b) -> int",
+      [](Tensor, int64_t a, int64_t b) -> int64_t { return a + b; });
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::int_output", ""});
   ASSERT_TRUE(op.has_value());
@@ -134,13 +159,15 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithIntOutput_w
   EXPECT_EQ(9, result[0].toInt());
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithTensorOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::returning_tensor(Tensor input) -> Tensor", [] (const Tensor& input) -> Tensor {
-        return input;
-      });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithTensorOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::returning_tensor(Tensor input) -> Tensor",
+      [](const Tensor& input) -> Tensor { return input; });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::returning_tensor", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::returning_tensor", ""});
   ASSERT_TRUE(op.has_value());
 
   auto result = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -152,26 +179,42 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithTensorOutpu
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result[0].toTensor()));
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithTensorListOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::list_output(Tensor input1, Tensor input2, Tensor input3) -> Tensor[]", [] (const Tensor& input1, const Tensor& input2, const Tensor& input3) -> std::vector<Tensor> {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithTensorListOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::list_output(Tensor input1, Tensor input2, Tensor input3) -> Tensor[]",
+      [](const Tensor& input1,
+         const Tensor& input2,
+         const Tensor& input3) -> std::vector<Tensor> {
         return {input1, input2, input3};
       });
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::list_output", ""});
   ASSERT_TRUE(op.has_value());
 
-  auto result = callOp(*op, dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CUDA), dummyTensor(DispatchKey::CPU));
+  auto result = callOp(
+      *op,
+      dummyTensor(DispatchKey::CPU),
+      dummyTensor(DispatchKey::CUDA),
+      dummyTensor(DispatchKey::CPU));
   EXPECT_EQ(1, result.size());
   EXPECT_EQ(3, result[0].toTensorVector().size());
-  EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(result[0].toTensorVector()[0]));
-  EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result[0].toTensorVector()[1]));
-  EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(result[0].toTensorVector()[2]));
+  EXPECT_EQ(
+      DispatchKey::CPU, extractDispatchKey(result[0].toTensorVector()[0]));
+  EXPECT_EQ(
+      DispatchKey::CUDA, extractDispatchKey(result[0].toTensorVector()[1]));
+  EXPECT_EQ(
+      DispatchKey::CPU, extractDispatchKey(result[0].toTensorVector()[2]));
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithIntListOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::list_output(Tensor dummy, int input1, int input2, int input3) -> int[]", [](const Tensor&, int64_t input1, int64_t input2, int64_t input3) -> std::vector<int64_t> {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithIntListOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::list_output(Tensor dummy, int input1, int input2, int input3) -> int[]",
+      [](const Tensor&, int64_t input1, int64_t input2, int64_t input3)
+          -> std::vector<int64_t> {
         return {input1, input2, input3};
       });
 
@@ -186,22 +229,35 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithIntListOutp
   EXPECT_EQ(6, result[0].toIntVector()[2]);
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithMultipleOutputs_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-     .op("_test::multiple_outputs(Tensor dummy) -> (Tensor, int, Tensor[], int?, Dict(str, Tensor))", [] (Tensor) -> std::tuple<Tensor, int64_t, std::vector<Tensor>, std::optional<int64_t>, Dict<string, Tensor>> {
-       Dict<string, Tensor> dict;
-       dict.insert("first", dummyTensor(DispatchKey::CPU));
-       dict.insert("second", dummyTensor(DispatchKey::CUDA));
-       return std::tuple<Tensor, int64_t, std::vector<Tensor>, std::optional<int64_t>, Dict<string, Tensor>>(
-         dummyTensor(DispatchKey::CUDA),
-         5,
-         {dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CUDA)},
-         std::optional<int64_t>(std::in_place, 0),
-         dict
-       );
-     });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithMultipleOutputs_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::multiple_outputs(Tensor dummy) -> (Tensor, int, Tensor[], int?, Dict(str, Tensor))",
+      [](Tensor) -> std::tuple<
+                     Tensor,
+                     int64_t,
+                     std::vector<Tensor>,
+                     std::optional<int64_t>,
+                     Dict<string, Tensor>> {
+        Dict<string, Tensor> dict;
+        dict.insert("first", dummyTensor(DispatchKey::CPU));
+        dict.insert("second", dummyTensor(DispatchKey::CUDA));
+        return std::tuple<
+            Tensor,
+            int64_t,
+            std::vector<Tensor>,
+            std::optional<int64_t>,
+            Dict<string, Tensor>>(
+            dummyTensor(DispatchKey::CUDA),
+            5,
+            {dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CUDA)},
+            std::optional<int64_t>(std::in_place, 0),
+            dict);
+      });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::multiple_outputs", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::multiple_outputs", ""});
   ASSERT_TRUE(op.has_value());
 
   auto result = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -209,22 +265,27 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithMultipleOut
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result[0].toTensor()));
   EXPECT_EQ(5, result[1].toInt());
   EXPECT_EQ(2, result[2].toTensorVector().size());
-  EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(result[2].toTensorVector()[0]));
-  EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result[2].toTensorVector()[1]));
+  EXPECT_EQ(
+      DispatchKey::CPU, extractDispatchKey(result[2].toTensorVector()[0]));
+  EXPECT_EQ(
+      DispatchKey::CUDA, extractDispatchKey(result[2].toTensorVector()[1]));
   EXPECT_EQ(0, result[3].toInt());
-  auto result_dict = c10::impl::toTypedDict<string, Tensor>(result[4].toGenericDict());
+  auto result_dict =
+      c10::impl::toTypedDict<string, Tensor>(result[4].toGenericDict());
   EXPECT_EQ(2, result_dict.size());
   EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(result_dict.at("first")));
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result_dict.at("second")));
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithTensorInputByReference_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_input(Tensor input) -> Tensor", [] (const Tensor& input1) -> Tensor {
-        return input1;
-      });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithTensorInputByReference_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_input(Tensor input) -> Tensor",
+      [](const Tensor& input1) -> Tensor { return input1; });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
   ASSERT_TRUE(op.has_value());
 
   auto result = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -236,13 +297,15 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithTensorInput
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result[0].toTensor()));
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithTensorInputByValue_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_input(Tensor input) -> Tensor", [](Tensor input1) -> Tensor {
-        return input1;
-      });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithTensorInputByValue_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_input(Tensor input) -> Tensor",
+      [](Tensor input1) -> Tensor { return input1; });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
   ASSERT_TRUE(op.has_value());
 
   auto result = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -256,13 +319,15 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithTensorInput
 
 Tensor captured_input;
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithTensorInputByReference_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_input(Tensor input) -> ()", [] (const Tensor& input1) -> void {
-        captured_input = input1;
-      });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithTensorInputByReference_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_input(Tensor input) -> ()",
+      [](const Tensor& input1) -> void { captured_input = input1; });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
   ASSERT_TRUE(op.has_value());
 
   auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -274,13 +339,15 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithTensorInput
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(captured_input));
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithTensorInputByValue_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_input(Tensor input) -> ()", [] (Tensor input1) -> void {
-        captured_input = input1;
-      });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithTensorInputByValue_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_input(Tensor input) -> ()",
+      [](Tensor input1) -> void { captured_input = input1; });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
   ASSERT_TRUE(op.has_value());
 
   auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -294,11 +361,12 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithTensorInput
 
 int64_t captured_int_input = 0;
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithIntInput_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::int_input(Tensor dummy, int input) -> ()", [](Tensor, int64_t input1) -> void {
-        captured_int_input = input1;
-      });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithIntInput_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::int_input(Tensor dummy, int input) -> ()",
+      [](Tensor, int64_t input1) -> void { captured_int_input = input1; });
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::int_input", ""});
   ASSERT_TRUE(op.has_value());
@@ -309,11 +377,12 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithIntInput_wi
   EXPECT_EQ(3, captured_int_input);
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithIntInput_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::int_input(Tensor dummy, int input) -> int", [] (Tensor, int64_t input1) -> int64_t {
-        return input1 + 1;
-      });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithIntInput_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::int_input(Tensor dummy, int input) -> int",
+      [](Tensor, int64_t input1) -> int64_t { return input1 + 1; });
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::int_input", ""});
   ASSERT_TRUE(op.has_value());
@@ -325,129 +394,181 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithIntInput_wi
 
 int64_t captured_input_list_size = 0;
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithIntListInput_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::int_list_input(Tensor dummy, int[] input) -> ()", [] (Tensor, const std::vector<int64_t>& input1) -> void {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithIntListInput_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::int_list_input(Tensor dummy, int[] input) -> ()",
+      [](Tensor, const std::vector<int64_t>& input1) -> void {
         captured_input_list_size = input1.size();
       });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::int_list_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::int_list_input", ""});
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::List<int64_t>({2, 4, 6}));
+  auto outputs =
+      callOp(*op, dummyTensor(DispatchKey::CPU), c10::List<int64_t>({2, 4, 6}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(3, captured_input_list_size);
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithIntListInput_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::int_list_input(Tensor dummy, int[] input) -> int", [](Tensor, const std::vector<int64_t>& input1) -> int64_t {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithIntListInput_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::int_list_input(Tensor dummy, int[] input) -> int",
+      [](Tensor, const std::vector<int64_t>& input1) -> int64_t {
         return input1.size();
       });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::int_list_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::int_list_input", ""});
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::List<int64_t>({2, 4, 6}));
+  auto outputs =
+      callOp(*op, dummyTensor(DispatchKey::CPU), c10::List<int64_t>({2, 4, 6}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(3, outputs[0].toInt());
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithTensorListInput_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_list_input(Tensor[] input) -> ()", [] (const std::vector<Tensor>& input1) -> void {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithTensorListInput_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_list_input(Tensor[] input) -> ()",
+      [](const std::vector<Tensor>& input1) -> void {
         captured_input_list_size = input1.size();
       });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, c10::List<Tensor>({dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
+  auto outputs = callOp(
+      *op,
+      c10::List<Tensor>(
+          {dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(2, captured_input_list_size);
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithTensorVectorInput_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_list_input(Tensor[] input) -> int", [] (const std::vector<Tensor>& input1) -> int64_t {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithTensorVectorInput_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_list_input(Tensor[] input) -> int",
+      [](const std::vector<Tensor>& input1) -> int64_t {
         return input1.size();
       });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, c10::List<Tensor>({dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
+  auto outputs = callOp(
+      *op,
+      c10::List<Tensor>(
+          {dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(2, outputs[0].toInt());
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithLegacyTensorVectorInput_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_list_input(Tensor[] input) -> ()", [] (const std::vector<Tensor>& input1) -> void {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithLegacyTensorVectorInput_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_list_input(Tensor[] input) -> ()",
+      [](const std::vector<Tensor>& input1) -> void {
         captured_input_list_size = input1.size();
       });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, c10::List<Tensor>({dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
+  auto outputs = callOp(
+      *op,
+      c10::List<Tensor>(
+          {dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(2, captured_input_list_size);
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithLegacyTensorVectorInput_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_list_input(Tensor[] input) -> int", [] (const std::vector<Tensor>& input1) -> int64_t {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithLegacyTensorVectorInput_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_list_input(Tensor[] input) -> int",
+      [](const std::vector<Tensor>& input1) -> int64_t {
         return input1.size();
       });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, c10::List<Tensor>({dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
+  auto outputs = callOp(
+      *op,
+      c10::List<Tensor>(
+          {dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(2, outputs[0].toInt());
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithLegacyTensorListInput_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_list_input(Tensor[] input) -> ()", [] (std::vector<Tensor> input1) -> void {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithLegacyTensorListInput_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_list_input(Tensor[] input) -> ()",
+      [](std::vector<Tensor> input1) -> void {
         captured_input_list_size = input1.size();
       });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, c10::List<Tensor>({dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
+  auto outputs = callOp(
+      *op,
+      c10::List<Tensor>(
+          {dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(2, captured_input_list_size);
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithLegacyTensorListInput_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_list_input(Tensor[] input) -> int", [] (std::vector<Tensor> input1) -> int64_t {
-        return input1.size();
-      });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithLegacyTensorListInput_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_list_input(Tensor[] input) -> int",
+      [](std::vector<Tensor> input1) -> int64_t { return input1.size(); });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, c10::List<Tensor>({dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
+  auto outputs = callOp(
+      *op,
+      c10::List<Tensor>(
+          {dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(2, outputs[0].toInt());
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithStringListOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::stringlist_output(str[] input) -> str[]", [](std::vector<std::string> input) {
-        return input;
-      });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithStringListOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::stringlist_output(str[] input) -> str[]",
+      [](std::vector<std::string> input) { return input; });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::stringlist_output", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::stringlist_output", ""});
   ASSERT_TRUE(op.has_value());
 
   c10::List<std::string> list({"value1", "value2"});
@@ -460,13 +581,14 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithStringListO
   EXPECT_EQ("value2", output.get(1).toStringRef());
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithDictInput_withoutOutput_whenRegistered_thenCanBeCalled) {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithDictInput_withoutOutput_whenRegistered_thenCanBeCalled) {
   int captured_dict_size = 0;
 
-  auto registrar = RegisterOperators()
-      .op("_test::dict_input(Dict(str, Tensor) input) -> ()", [&] (Dict<string, Tensor> input1) {
-        captured_dict_size = input1.size();
-      });
+  auto registrar = RegisterOperators().op(
+      "_test::dict_input(Dict(str, Tensor) input) -> ()",
+      [&](Dict<string, Tensor> input1) { captured_dict_size = input1.size(); });
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::dict_input", ""});
   ASSERT_TRUE(op.has_value());
@@ -480,11 +602,12 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithDictInput_w
   EXPECT_EQ(2, captured_dict_size);
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithDictInput_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::dict_input(Dict(str, str) input) -> str", [&] (Dict<string, string> input1) {
-        return input1.at("key2");
-      });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithDictInput_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::dict_input(Dict(str, str) input) -> str",
+      [&](Dict<string, string> input1) { return input1.at("key2"); });
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::dict_input", ""});
   ASSERT_TRUE(op.has_value());
@@ -497,11 +620,12 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithDictInput_w
   EXPECT_EQ("value2", outputs[0].toStringRef());
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithDictOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-    .op("_test::dict_output(Dict(str, str) input) -> Dict(str, str)", [] (Dict<string, string> input) {
-      return input;
-    });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithDictOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::dict_output(Dict(str, str) input) -> Dict(str, str)",
+      [](Dict<string, string> input) { return input; });
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::dict_output", ""});
   ASSERT_TRUE(op.has_value());
@@ -511,18 +635,22 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithDictOutput_
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  auto output = c10::impl::toTypedDict<string, string>(outputs[0].toGenericDict());
+  auto output =
+      c10::impl::toTypedDict<string, string>(outputs[0].toGenericDict());
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ("value1", output.at("key1"));
   EXPECT_EQ("value2", output.at("key2"));
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithUnorderedMapInput_withoutOutput_whenRegistered_thenCanBeCalled) {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithUnorderedMapInput_withoutOutput_whenRegistered_thenCanBeCalled) {
   int captured_dict_size = 0;
 
-  auto registrar = RegisterOperators()
-      .op("_test::dict_input(Dict(str, Tensor) input) -> ()", [&] (std::unordered_map<string, Tensor> input1) {
+  auto registrar = RegisterOperators().op(
+      "_test::dict_input(Dict(str, Tensor) input) -> ()",
+      [&](std::unordered_map<string, Tensor> input1) {
         captured_dict_size = input1.size();
       });
 
@@ -538,9 +666,12 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithUnorderedMa
   EXPECT_EQ(2, captured_dict_size);
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithUnorderedMapInput_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::dict_input(Dict(str, str) input) -> str", [&] (std::unordered_map<string, string> input1) {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithUnorderedMapInput_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::dict_input(Dict(str, str) input) -> str",
+      [&](std::unordered_map<string, string> input1) {
         return input1.at("key2");
       });
 
@@ -555,11 +686,12 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithUnorderedMa
   EXPECT_EQ("value2", outputs[0].toStringRef());
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithUnorderedMapOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-    .op("_test::dict_output(Dict(str, str) input) -> Dict(str, str)", [] (std::unordered_map<string, string> input) {
-      return input;
-    });
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithUnorderedMapOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::dict_output(Dict(str, str) input) -> Dict(str, str)",
+      [](std::unordered_map<string, string> input) { return input; });
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::dict_output", ""});
   ASSERT_TRUE(op.has_value());
@@ -569,16 +701,20 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithUnorderedMa
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  auto output = c10::impl::toTypedDict<string, string>(outputs[0].toGenericDict());
+  auto output =
+      c10::impl::toTypedDict<string, string>(outputs[0].toGenericDict());
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ("value1", output.at("key1"));
   EXPECT_EQ("value2", output.at("key2"));
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithMapOfList_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::dict_output(Dict(str, int[]) input) -> Dict(str, int[])", [](std::unordered_map<string, std::vector<int64_t>> input) {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithMapOfList_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::dict_output(Dict(str, int[]) input) -> Dict(str, int[])",
+      [](std::unordered_map<string, std::vector<int64_t>> input) {
         return input;
       });
 
@@ -590,7 +726,8 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithMapOfList_w
   dict.insert("key2", c10::List<int64_t>({30, 40}));
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  auto output = c10::impl::toTypedDict<string, c10::List<int64_t>>(outputs[0].toGenericDict());
+  auto output = c10::impl::toTypedDict<string, c10::List<int64_t>>(
+      outputs[0].toGenericDict());
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ(2, output.at("key1").size());
@@ -601,10 +738,14 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithMapOfList_w
   EXPECT_EQ(40, output.at("key2").get(1));
 }
 
-
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithMapOfListOfMap_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::dict_output(Dict(str, Dict(int,str)[]) input) -> Dict(str, Dict(int,str)[])", [](std::unordered_map<string, std::vector<std::unordered_map<int64_t, string>>> input) {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithMapOfListOfMap_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::dict_output(Dict(str, Dict(int,str)[]) input) -> Dict(str, Dict(int,str)[])",
+      [](std::unordered_map<
+          string,
+          std::vector<std::unordered_map<int64_t, string>>> input) {
         return input;
       });
 
@@ -622,7 +763,9 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithMapOfListOf
   dict.insert("key2", c10::List<c10::Dict<int64_t, string>>({dict2}));
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  auto output = c10::impl::toTypedDict<string, c10::List<std::unordered_map<int64_t, string>>>(outputs[0].toGenericDict());
+  auto output = c10::impl::
+      toTypedDict<string, c10::List<std::unordered_map<int64_t, string>>>(
+          outputs[0].toGenericDict());
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ(1, output.at("key1").size());
@@ -634,9 +777,12 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithMapOfListOf
   EXPECT_EQ("40", output.at("key2").get(0).at(40));
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithListOfMap_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::list_output(Dict(str, int)[] input) -> Dict(str, int)[]", [](std::vector<std::unordered_map<string, int64_t>> input) {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithListOfMap_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::list_output(Dict(str, int)[] input) -> Dict(str, int)[]",
+      [](std::vector<std::unordered_map<string, int64_t>> input) {
         return input;
       });
 
@@ -663,9 +809,12 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithListOfMap_w
   EXPECT_EQ(4, output.get(1).toGenericDict().at("4").toInt());
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithListOfMapOfIntList_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::list_output(Dict(str, int[])[] input) -> Dict(str, int[])[]", [](std::vector<std::unordered_map<string, std::vector<int64_t>>> input) {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithListOfMapOfIntList_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::list_output(Dict(str, int[])[] input) -> Dict(str, int[])[]",
+      [](std::vector<std::unordered_map<string, std::vector<int64_t>>> input) {
         return input;
       });
 
@@ -678,7 +827,7 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithListOfMapOf
   c10::Dict<string, c10::List<int64_t>> dict2;
   dict2.insert("5", c10::List<int64_t>({5, 6}));
   dict2.insert("7", c10::List<int64_t>({7, 8}));
-  c10::List<c10::Dict<string, c10::List<int64_t>>> list({ dict1, dict2 });
+  c10::List<c10::Dict<string, c10::List<int64_t>>> list({dict1, dict2});
   auto outputs = callOp(*op, list);
   EXPECT_EQ(1, outputs.size());
   c10::impl::GenericList output = std::move(outputs[0]).toList();
@@ -699,15 +848,18 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithListOfMapOf
   EXPECT_EQ(8, output.get(1).toGenericDict().at("7").toIntVector()[1]);
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenFallbackKernelWithoutAnyArguments_whenRegistered_thenCanBeCalled) {
-  // note: non-fallback kernels without tensor arguments don't work because there
-  // is no way to get the dispatch key. For operators that only have a fallback
-  // kernel, this must work for backwards compatibility.
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenFallbackKernelWithoutAnyArguments_whenRegistered_thenCanBeCalled) {
+  // note: non-fallback kernels without tensor arguments don't work because
+  // there is no way to get the dispatch key. For operators that only have a
+  // fallback kernel, this must work for backwards compatibility.
   bool called = false;
-  auto registrar = RegisterOperators()
-      .op("_test::no_tensor_args() -> ()", [&] () {called = true;});
+  auto registrar = RegisterOperators().op(
+      "_test::no_tensor_args() -> ()", [&]() { called = true; });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
   ASSERT_TRUE(op.has_value());
 
   called = false;
@@ -715,14 +867,18 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenFallbackKernelWithout
   EXPECT_TRUE(called);
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenFallbackKernelWithoutTensorArguments_whenRegistered_thenCanBeCalled) {
-  // note: non-fallback kernels without tensor arguments don't work because there
-  // is no way to get the dispatch key. For operators that only have a fallback
-  // kernel, this must work for backwards compatibility.
-  auto registrar = RegisterOperators()
-      .op("_test::no_tensor_args(int arg) -> int", [] (int64_t arg) {return arg + 1;});
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenFallbackKernelWithoutTensorArguments_whenRegistered_thenCanBeCalled) {
+  // note: non-fallback kernels without tensor arguments don't work because
+  // there is no way to get the dispatch key. For operators that only have a
+  // fallback kernel, this must work for backwards compatibility.
+  auto registrar = RegisterOperators().op(
+      "_test::no_tensor_args(int arg) -> int",
+      [](int64_t arg) { return arg + 1; });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
   ASSERT_TRUE(op.has_value());
 
   auto outputs = callOp(*op, 3);
@@ -730,25 +886,35 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenFallbackKernelWithout
   EXPECT_EQ(4, outputs[0].toInt());
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithOptionalInputs_withoutOutput_whenRegistered_thenCanBeCalled) {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithOptionalInputs_withoutOutput_whenRegistered_thenCanBeCalled) {
   bool called = false;
   std::optional<Tensor> called_arg2 = std::nullopt;
   std::optional<int64_t> called_arg3 = std::nullopt;
   std::optional<std::string> called_arg4 = std::nullopt;
 
   auto registrar = RegisterOperators().op(
-    "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> ()",
-    [&] (Tensor arg1, const std::optional<Tensor>& arg2, std::optional<int64_t> arg3, std::optional<std::string> arg4) {
-      called = true;
-      called_arg2 = arg2;
-      called_arg3 = arg3;
-      called_arg4 = arg4;
-    });
+      "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> ()",
+      [&](Tensor arg1,
+          const std::optional<Tensor>& arg2,
+          std::optional<int64_t> arg3,
+          std::optional<std::string> arg4) {
+        called = true;
+        called_arg2 = arg2;
+        called_arg3 = arg3;
+        called_arg4 = arg4;
+      });
   auto op = c10::Dispatcher::singleton().findSchema({"_test::opt_input", ""});
   ASSERT_TRUE(op.has_value());
 
   called = false;
-  auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CUDA), c10::IValue(), std::string("text"));
+  auto outputs = callOp(
+      *op,
+      dummyTensor(DispatchKey::CPU),
+      dummyTensor(DispatchKey::CUDA),
+      c10::IValue(),
+      std::string("text"));
   EXPECT_EQ(0, outputs.size());
 
   EXPECT_TRUE(called);
@@ -759,7 +925,8 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithOptionalInp
   EXPECT_EQ(*called_arg4, "text");
 
   called = false;
-  outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
+  outputs = callOp(
+      *op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
   EXPECT_EQ(0, outputs.size());
 
   EXPECT_TRUE(called);
@@ -769,26 +936,36 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithOptionalInp
   EXPECT_FALSE(called_arg4.has_value());
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithOptionalInputs_withOutput_whenRegistered_thenCanBeCalled) {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithOptionalInputs_withOutput_whenRegistered_thenCanBeCalled) {
   bool called = false;
   std::optional<Tensor> called_arg2 = std::nullopt;
   std::optional<int64_t> called_arg3 = std::nullopt;
   std::optional<std::string> called_arg4 = std::nullopt;
 
   auto registrar = RegisterOperators().op(
-    "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> Tensor?",
-    [&] (Tensor arg1, const std::optional<Tensor>& arg2, std::optional<int64_t> arg3, std::optional<std::string> arg4) {
-      called = true;
-      called_arg2 = arg2;
-      called_arg3 = arg3;
-      called_arg4 = arg4;
-      return arg2;
-    });
+      "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> Tensor?",
+      [&](Tensor arg1,
+          const std::optional<Tensor>& arg2,
+          std::optional<int64_t> arg3,
+          std::optional<std::string> arg4) {
+        called = true;
+        called_arg2 = arg2;
+        called_arg3 = arg3;
+        called_arg4 = arg4;
+        return arg2;
+      });
   auto op = c10::Dispatcher::singleton().findSchema({"_test::opt_input", ""});
   ASSERT_TRUE(op.has_value());
 
   called = false;
-  auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CUDA), c10::IValue(), std::string("text"));
+  auto outputs = callOp(
+      *op,
+      dummyTensor(DispatchKey::CPU),
+      dummyTensor(DispatchKey::CUDA),
+      c10::IValue(),
+      std::string("text"));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(outputs[0].toTensor()));
 
@@ -800,7 +977,8 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithOptionalInp
   EXPECT_EQ(*called_arg4, "text");
 
   called = false;
-  outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
+  outputs = callOp(
+      *op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
   EXPECT_EQ(1, outputs.size());
   EXPECT_TRUE(outputs[0].isNone());
 
@@ -811,22 +989,33 @@ TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithOptionalInp
   EXPECT_FALSE(called_arg4.has_value());
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernelWithOptionalInputs_withMultipleOutputs_whenRegistered_thenCanBeCalled) {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernelWithOptionalInputs_withMultipleOutputs_whenRegistered_thenCanBeCalled) {
   auto registrar = RegisterOperators().op(
-    "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> (Tensor?, int?, str?)",
-    [] (Tensor arg1, const std::optional<Tensor>& arg2, std::optional<int64_t> arg3, std::optional<std::string> arg4) {
-      return std::make_tuple(arg2, arg3, arg4);
-    });
+      "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> (Tensor?, int?, str?)",
+      [](Tensor arg1,
+         const std::optional<Tensor>& arg2,
+         std::optional<int64_t> arg3,
+         std::optional<std::string> arg4) {
+        return std::make_tuple(arg2, arg3, arg4);
+      });
   auto op = c10::Dispatcher::singleton().findSchema({"_test::opt_input", ""});
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CUDA), c10::IValue(), std::string("text"));
+  auto outputs = callOp(
+      *op,
+      dummyTensor(DispatchKey::CPU),
+      dummyTensor(DispatchKey::CUDA),
+      c10::IValue(),
+      std::string("text"));
   EXPECT_EQ(3, outputs.size());
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(outputs[0].toTensor()));
   EXPECT_TRUE(outputs[1].isNone());
   EXPECT_EQ("text", outputs[2].toStringRef());
 
-  outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
+  outputs = callOp(
+      *op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
   EXPECT_EQ(3, outputs.size());
   EXPECT_TRUE(outputs[0].isNone());
   EXPECT_EQ(4, outputs[1].toInt());
@@ -839,190 +1028,257 @@ void expectCallsConcatUnboxed(DispatchKey dispatch_key) {
   // assert that schema and cpu kernel are present
   auto op = c10::Dispatcher::singleton().findSchema({"_test::my_op", ""});
   ASSERT_TRUE(op.has_value());
-  std::string result = callOpUnboxed<std::string, const Tensor&, std::string, const std::string&, int64_t>(*op, dummyTensor(dispatch_key), "1", "2", 3);
+  std::string result = callOpUnboxed<
+      std::string,
+      const Tensor&,
+      std::string,
+      const std::string&,
+      int64_t>(*op, dummyTensor(dispatch_key), "1", "2", 3);
   EXPECT_EQ("prefix123", result);
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernel_whenRegistered_thenCanBeCalledUnboxed) {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernel_whenRegistered_thenCanBeCalledUnboxed) {
   std::string prefix = "prefix";
-  auto registrar = RegisterOperators().op("_test::my_op(Tensor dummy, str a, str b, int c) -> str", [&] (const Tensor& tensor1, std::string a, const std::string& b, int64_t c) {
-    return prefix + a + b + std::to_string(c);
-  });
+  auto registrar = RegisterOperators().op(
+      "_test::my_op(Tensor dummy, str a, str b, int c) -> str",
+      [&](const Tensor& tensor1,
+          std::string a,
+          const std::string& b,
+          int64_t c) { return prefix + a + b + std::to_string(c); });
   expectCallsConcatUnboxed(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
-  auto registrar = RegisterOperators()
-      .op("_test::no_schema_specified", [] (Tensor arg1, int64_t arg2, const std::vector<Tensor>& arg3) -> std::tuple<int64_t, Tensor> {return {};});
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
+  auto registrar = RegisterOperators().op(
+      "_test::no_schema_specified",
+      [](Tensor arg1, int64_t arg2, const std::vector<Tensor>& arg3)
+          -> std::tuple<int64_t, Tensor> { return {}; });
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::no_schema_specified", ""});
+  auto op = c10::Dispatcher::singleton().findSchema(
+      {"_test::no_schema_specified", ""});
   ASSERT_TRUE(op.has_value());
 
-  std::optional<std::string> differences = c10::findSchemaDifferences(torch::jit::parseSchema("_test::no_schema_specified(Tensor arg1, int arg2, Tensor[] arg3) -> (int, Tensor)"), op->schema());
+  std::optional<std::string> differences = c10::findSchemaDifferences(
+      torch::jit::parseSchema(
+          "_test::no_schema_specified(Tensor arg1, int arg2, Tensor[] arg3) -> (int, Tensor)"),
+      op->schema());
   EXPECT_FALSE(differences.has_value());
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenMismatchedKernel_withDifferentNumArguments_whenRegistering_thenFails) {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenMismatchedKernel_withDifferentNumArguments_whenRegistering_thenFails) {
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> int", [] (Tensor) -> int64_t {return 0;});
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> int",
+      [](Tensor) -> int64_t { return 0; });
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg, Tensor arg2) -> int", [] (Tensor) -> int64_t {return 0;});
-    }, "The number of arguments is different. 2 vs 1"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg, Tensor arg2) -> int",
+            [](Tensor) -> int64_t { return 0; });
+      },
+      "The number of arguments is different. 2 vs 1");
 
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg, Tensor arg2) -> ()", [] (Tensor, Tensor) -> void {});
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg, Tensor arg2) -> ()",
+      [](Tensor, Tensor) -> void {});
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch() -> ()", [] (Tensor, Tensor) -> void {});
-    }, "The number of arguments is different. 0 vs 2"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch() -> ()", [](Tensor, Tensor) -> void {});
+      },
+      "The number of arguments is different. 0 vs 2");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> ()", [] (Tensor, Tensor) -> void {});
-    }, "The number of arguments is different. 1 vs 2"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> ()", [](Tensor, Tensor) -> void {});
+      },
+      "The number of arguments is different. 1 vs 2");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg, Tensor arg2, Tensor arg3) -> ()", [] (Tensor, Tensor) -> void {});
-    }, "The number of arguments is different. 3 vs 2"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg, Tensor arg2, Tensor arg3) -> ()",
+            [](Tensor, Tensor) -> void {});
+      },
+      "The number of arguments is different. 3 vs 2");
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenMismatchedKernel_withDifferentArgumentType_whenRegistering_thenFails) {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenMismatchedKernel_withDifferentArgumentType_whenRegistering_thenFails) {
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg1, int arg2) -> int", [] (Tensor, int64_t) -> int64_t {return 0;});
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg1, int arg2) -> int",
+      [](Tensor, int64_t) -> int64_t { return 0; });
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg1, float arg2) -> int", [] (Tensor, int64_t) -> int64_t {return 0;});
-    }, "Type mismatch in argument 2: float vs int"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg1, float arg2) -> int",
+            [](Tensor, int64_t) -> int64_t { return 0; });
+      },
+      "Type mismatch in argument 2: float vs int");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(int arg1, int arg2) -> int", [] (Tensor, int64_t) -> int64_t {return 0;});
-    }, "Type mismatch in argument 1: int vs Tensor"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(int arg1, int arg2) -> int",
+            [](Tensor, int64_t) -> int64_t { return 0; });
+      },
+      "Type mismatch in argument 1: int vs Tensor");
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenMismatchedKernel_withDifferentNumReturns_whenRegistering_thenFails) {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenMismatchedKernel_withDifferentNumReturns_whenRegistering_thenFails) {
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> int", [] (Tensor) -> int64_t {return 0;});
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> int",
+      [](Tensor) -> int64_t { return 0; });
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> ()", [] (Tensor) -> int64_t {return 0;});
-    }, "The number of returns is different. 0 vs 1"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> ()",
+            [](Tensor) -> int64_t { return 0; });
+      },
+      "The number of returns is different. 0 vs 1");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> (int, int)", [] (Tensor) -> int64_t {return 0;});
-    }, "The number of returns is different. 2 vs 1"
-  );
-
-  // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> ()", [] (Tensor) -> void {});
-
-  // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> Tensor", [] (Tensor) -> void {});
-    }, "The number of returns is different. 1 vs 0"
-  );
-
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> (Tensor, Tensor)", [] (Tensor) -> void {});
-    }, "The number of returns is different. 2 vs 0"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> (int, int)",
+            [](Tensor) -> int64_t { return 0; });
+      },
+      "The number of returns is different. 2 vs 1");
 
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> (Tensor, Tensor)", [] (Tensor) -> std::tuple<Tensor, Tensor> {return {};});
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> ()", [](Tensor) -> void {});
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> ()", [] (Tensor) -> std::tuple<Tensor, Tensor> {return {};});
-    }, "The number of returns is different. 0 vs 2"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> Tensor", [](Tensor) -> void {});
+      },
+      "The number of returns is different. 1 vs 0");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> Tensor", [] (Tensor) -> std::tuple<Tensor, Tensor> {return {};});
-    }, "The number of returns is different. 1 vs 2"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> (Tensor, Tensor)",
+            [](Tensor) -> void {});
+      },
+      "The number of returns is different. 2 vs 0");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> (Tensor, Tensor, Tensor)", [] (Tensor) -> std::tuple<Tensor, Tensor> {return {};});
-    }, "The number of returns is different. 3 vs 2"
-  );
+  // assert this does not fail because it matches
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> (Tensor, Tensor)",
+      [](Tensor) -> std::tuple<Tensor, Tensor> { return {}; });
+
+  // and now a set of mismatching schemas
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> ()",
+            [](Tensor) -> std::tuple<Tensor, Tensor> { return {}; });
+      },
+      "The number of returns is different. 0 vs 2");
+
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> Tensor",
+            [](Tensor) -> std::tuple<Tensor, Tensor> { return {}; });
+      },
+      "The number of returns is different. 1 vs 2");
+
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> (Tensor, Tensor, Tensor)",
+            [](Tensor) -> std::tuple<Tensor, Tensor> { return {}; });
+      },
+      "The number of returns is different. 3 vs 2");
 }
 
-TEST(OperatorRegistrationTestLegacyLambdaBasedKernel, givenMismatchedKernel_withDifferentReturnTypes_whenRegistering_thenFails) {
+TEST(
+    OperatorRegistrationTestLegacyLambdaBasedKernel,
+    givenMismatchedKernel_withDifferentReturnTypes_whenRegistering_thenFails) {
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> int", [] (Tensor) -> int64_t {return 0;});
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> int",
+      [](Tensor) -> int64_t { return 0; });
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> Tensor", [] (Tensor) -> int64_t {return 0;});
-    }, "Type mismatch in return 1: Tensor vs int"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> Tensor",
+            [](Tensor) -> int64_t { return 0; });
+      },
+      "Type mismatch in return 1: Tensor vs int");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> float", [] (Tensor) -> int64_t {return 0;});
-    }, "Type mismatch in return 1: float vs int"
-  );
-
-  // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> Tensor", [] (Tensor) -> Tensor {return {};});
-
-  // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> float", [] (Tensor) -> Tensor {return {};});
-    }, "Type mismatch in return 1: float vs Tensor"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> float",
+            [](Tensor) -> int64_t { return 0; });
+      },
+      "Type mismatch in return 1: float vs int");
 
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> (Tensor, int)", [] (Tensor) -> std::tuple<Tensor, int64_t> {return {};});
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> Tensor",
+      [](Tensor) -> Tensor { return {}; });
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> (Tensor, float)", [] (Tensor) -> std::tuple<Tensor, int64_t> {return {};});
-    }, "Type mismatch in return 2: float vs int"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> float",
+            [](Tensor) -> Tensor { return {}; });
+      },
+      "Type mismatch in return 1: float vs Tensor");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> (int, int)", [] (Tensor) -> std::tuple<Tensor, int64_t> {return {};});
-    }, "Type mismatch in return 1: int vs Tensor"
-  );
+  // assert this does not fail because it matches
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> (Tensor, int)",
+      [](Tensor) -> std::tuple<Tensor, int64_t> { return {}; });
+
+  // and now a set of mismatching schemas
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> (Tensor, float)",
+            [](Tensor) -> std::tuple<Tensor, int64_t> { return {}; });
+      },
+      "Type mismatch in return 2: float vs int");
+
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> (int, int)",
+            [](Tensor) -> std::tuple<Tensor, int64_t> { return {}; });
+      },
+      "Type mismatch in return 1: int vs Tensor");
 }
 
-}
+} // namespace
 
 #pragma GCC diagnostic pop

--- a/aten/src/ATen/core/boxing/impl/kernel_lambda_test.cpp
+++ b/aten/src/ATen/core/boxing/impl/kernel_lambda_test.cpp
@@ -1,20 +1,20 @@
-#include <gtest/gtest.h>
 #include <ATen/core/boxing/impl/test_helpers.h>
+#include <gtest/gtest.h>
 
-#include <ATen/core/op_registration/op_registration.h>
 #include <ATen/core/Tensor.h>
+#include <ATen/core/op_registration/op_registration.h>
 #include <torch/csrc/jit/frontend/function_schema_parser.h>
 #include <torch/library.h>
 
 #include <ATen/core/LegacyTypeDispatch.h>
 
-using c10::RegisterOperators;
+using at::Tensor;
+using c10::Dict;
 using c10::DispatchKey;
+using c10::intrusive_ptr;
+using c10::RegisterOperators;
 using c10::Stack;
 using std::make_unique;
-using c10::intrusive_ptr;
-using c10::Dict;
-using at::Tensor;
 using std::string;
 using std::unique_ptr;
 
@@ -42,50 +42,104 @@ void expectCallsDecrement(DispatchKey dispatch_key) {
   EXPECT_EQ(4, result[0].toInt());
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernel_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators().op("_test::my_op(Tensor dummy, int input) -> int", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, int64_t i) {return i+1;}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernel_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::my_op(Tensor dummy, int input) -> int",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU, [](Tensor, int64_t i) { return i + 1; }));
   expectCallsIncrement(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenOutOfLineKernel_whenRegistered_thenCanBeCalled) {
-  auto my_kernel = [] (Tensor, int64_t i) {return i+1;};
-  auto registrar = RegisterOperators().op("_test::my_op(Tensor dummy, int input) -> int", RegisterOperators::options().kernel(DispatchKey::CPU, my_kernel));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenOutOfLineKernel_whenRegistered_thenCanBeCalled) {
+  auto my_kernel = [](Tensor, int64_t i) { return i + 1; };
+  auto registrar = RegisterOperators().op(
+      "_test::my_op(Tensor dummy, int input) -> int",
+      RegisterOperators::options().kernel(DispatchKey::CPU, my_kernel));
   expectCallsIncrement(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenMultipleOperatorsAndKernels_whenRegisteredInOneRegistrar_thenCallsRightKernel) {
-  auto registrar = RegisterOperators()
-      .op("_test::my_op(Tensor dummy, int input) -> int", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, int64_t i) {return i+1;})
-                                                                                      .kernel(DispatchKey::CUDA, [] (Tensor, int64_t) -> int64_t {EXPECT_TRUE(false); return 0;}))
-      .op("_test::error(Tensor dummy, int input) -> int", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, int64_t) -> int64_t {EXPECT_TRUE(false); return 0;})
-                                                                                      .kernel(DispatchKey::CUDA, [] (Tensor, int64_t) -> int64_t {EXPECT_TRUE(false); return 0;}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenMultipleOperatorsAndKernels_whenRegisteredInOneRegistrar_thenCallsRightKernel) {
+  auto registrar =
+      RegisterOperators()
+          .op("_test::my_op(Tensor dummy, int input) -> int",
+              RegisterOperators::options()
+                  .kernel(
+                      DispatchKey::CPU, [](Tensor, int64_t i) { return i + 1; })
+                  .kernel(
+                      DispatchKey::CUDA,
+                      [](Tensor, int64_t) -> int64_t {
+                        EXPECT_TRUE(false);
+                        return 0;
+                      }))
+          .op("_test::error(Tensor dummy, int input) -> int",
+              RegisterOperators::options()
+                  .kernel(
+                      DispatchKey::CPU,
+                      [](Tensor, int64_t) -> int64_t {
+                        EXPECT_TRUE(false);
+                        return 0;
+                      })
+                  .kernel(DispatchKey::CUDA, [](Tensor, int64_t) -> int64_t {
+                    EXPECT_TRUE(false);
+                    return 0;
+                  }));
   expectCallsIncrement(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenMultipleOperatorsAndKernels_whenRegisteredInMultipleRegistrars_thenCallsRightKernel) {
-  auto registrar1 = RegisterOperators().op("_test::my_op(Tensor dummy, int input) -> int", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, int64_t i) {return i+1;})
-                                                                                                                       .kernel(DispatchKey::CUDA, [] (Tensor, int64_t) -> int64_t {EXPECT_TRUE(false); return 0;}));
-  auto registrar3 = RegisterOperators().op("_test::error(Tensor dummy, int input) -> int", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, int64_t) -> int64_t {EXPECT_TRUE(false); return 0;})
-                                                                                                                       .kernel(DispatchKey::CUDA, [] (Tensor, int64_t) -> int64_t {EXPECT_TRUE(false); return 0;}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenMultipleOperatorsAndKernels_whenRegisteredInMultipleRegistrars_thenCallsRightKernel) {
+  auto registrar1 = RegisterOperators().op(
+      "_test::my_op(Tensor dummy, int input) -> int",
+      RegisterOperators::options()
+          .kernel(DispatchKey::CPU, [](Tensor, int64_t i) { return i + 1; })
+          .kernel(DispatchKey::CUDA, [](Tensor, int64_t) -> int64_t {
+            EXPECT_TRUE(false);
+            return 0;
+          }));
+  auto registrar3 = RegisterOperators().op(
+      "_test::error(Tensor dummy, int input) -> int",
+      RegisterOperators::options()
+          .kernel(
+              DispatchKey::CPU,
+              [](Tensor, int64_t) -> int64_t {
+                EXPECT_TRUE(false);
+                return 0;
+              })
+          .kernel(DispatchKey::CUDA, [](Tensor, int64_t) -> int64_t {
+            EXPECT_TRUE(false);
+            return 0;
+          }));
   expectCallsIncrement(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernel_whenRegistrationRunsOutOfScope_thenCannotBeCalledAnymore) {
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernel_whenRegistrationRunsOutOfScope_thenCannotBeCalledAnymore) {
   {
     auto m = MAKE_TORCH_LIBRARY(_test);
     m.def("_test::my_op(Tensor dummy, int input) -> int");
     auto m_cpu = MAKE_TORCH_LIBRARY_IMPL(_test, CPU);
-    m_cpu.impl("my_op", DispatchKey::CPU, [] (Tensor, int64_t i) {return i+1;});
+    m_cpu.impl(
+        "my_op", DispatchKey::CPU, [](Tensor, int64_t i) { return i + 1; });
     {
       auto m_cuda = MAKE_TORCH_LIBRARY_IMPL(_test, CUDA);
-      m_cuda.impl("my_op", DispatchKey::CUDA, [] (Tensor, int64_t i) {return i-1;});
+      m_cuda.impl(
+          "my_op", DispatchKey::CUDA, [](Tensor, int64_t i) { return i - 1; });
 
       // assert that schema and cpu kernel are present
       expectCallsIncrement(DispatchKey::CPU);
       expectCallsDecrement(DispatchKey::CUDA);
     }
 
-    // now registrar2 is destructed. Assert that schema is still present but cpu kernel is not
+    // now registrar2 is destructed. Assert that schema is still present but cpu
+    // kernel is not
     expectCallsIncrement(DispatchKey::CPU);
     expectDoesntFindKernel("_test::my_op", DispatchKey::CUDA);
   }
@@ -96,10 +150,13 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernel_whenRegistrationRuns
 
 bool was_called = false;
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators().op("_test::no_return(Tensor dummy) -> ()",
-    RegisterOperators::options()
-      .kernel(DispatchKey::CPU, [] (const Tensor&) -> void {was_called = true;}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::no_return(Tensor dummy) -> ()",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU, [](const Tensor&) -> void { was_called = true; }));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::no_return", ""});
   ASSERT_TRUE(op.has_value());
@@ -109,11 +166,19 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithoutOutput_whenReg
   EXPECT_EQ(0, result.size());
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithZeroOutputs_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators().op("_test::zero_outputs(Tensor dummy) -> ()",
-    RegisterOperators::options().kernel(DispatchKey::CPU, [] (const Tensor&) -> std::tuple<> {was_called = true; return {};}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithZeroOutputs_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::zero_outputs(Tensor dummy) -> ()",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU, [](const Tensor&) -> std::tuple<> {
+            was_called = true;
+            return {};
+          }));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::zero_outputs", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::zero_outputs", ""});
   ASSERT_TRUE(op.has_value());
   was_called = false;
   auto result = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -121,10 +186,14 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithZeroOutputs_whenR
   EXPECT_EQ(0, result.size());
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithIntOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::int_output(Tensor dummy, int a, int b) -> int",
-        RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, int64_t a, int64_t b) {return a+b;}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithIntOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::int_output(Tensor dummy, int a, int b) -> int",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU,
+          [](Tensor, int64_t a, int64_t b) { return a + b; }));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::int_output", ""});
   ASSERT_TRUE(op.has_value());
@@ -134,13 +203,17 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithIntOutput_whenReg
   EXPECT_EQ(9, result[0].toInt());
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithTensorOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::returning_tensor(Tensor input) -> Tensor",
-        RegisterOperators::options().kernel(DispatchKey::CPU, [] (const Tensor& a) {return a;})
-                                    .kernel(DispatchKey::CUDA, [] (const Tensor& a) {return a;}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithTensorOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::returning_tensor(Tensor input) -> Tensor",
+      RegisterOperators::options()
+          .kernel(DispatchKey::CPU, [](const Tensor& a) { return a; })
+          .kernel(DispatchKey::CUDA, [](const Tensor& a) { return a; }));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::returning_tensor", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::returning_tensor", ""});
   ASSERT_TRUE(op.has_value());
 
   auto result = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -152,26 +225,47 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithTensorOutput_when
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result[0].toTensor()));
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithTensorListOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::list_output(Tensor input1, Tensor input2, Tensor input3) -> Tensor[]",
-        RegisterOperators::options().kernel(DispatchKey::CUDA, [] (const Tensor& a, const Tensor& b, const Tensor& c) -> c10::List<Tensor> {return c10::List<Tensor>({a, b, c});}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithTensorListOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::list_output(Tensor input1, Tensor input2, Tensor input3) -> Tensor[]",
+      RegisterOperators::options().kernel(
+          DispatchKey::CUDA,
+          [](const Tensor& a, const Tensor& b, const Tensor& c)
+              -> c10::List<Tensor> {
+            return c10::List<Tensor>({a, b, c});
+          }));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::list_output", ""});
   ASSERT_TRUE(op.has_value());
 
-  auto result = callOp(*op, dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CUDA), dummyTensor(DispatchKey::CPU));
+  auto result = callOp(
+      *op,
+      dummyTensor(DispatchKey::CPU),
+      dummyTensor(DispatchKey::CUDA),
+      dummyTensor(DispatchKey::CPU));
   EXPECT_EQ(1, result.size());
   EXPECT_EQ(3, result[0].toTensorVector().size());
-  EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(result[0].toTensorVector()[0]));
-  EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result[0].toTensorVector()[1]));
-  EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(result[0].toTensorVector()[2]));
+  EXPECT_EQ(
+      DispatchKey::CPU, extractDispatchKey(result[0].toTensorVector()[0]));
+  EXPECT_EQ(
+      DispatchKey::CUDA, extractDispatchKey(result[0].toTensorVector()[1]));
+  EXPECT_EQ(
+      DispatchKey::CPU, extractDispatchKey(result[0].toTensorVector()[2]));
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithIntListOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::list_output(Tensor dummy, int input1, int input2, int input3) -> int[]",
-        RegisterOperators::options().kernel(DispatchKey::CPU, [] (const Tensor&, int64_t a, int64_t b, int64_t c) -> c10::List<int64_t> {return c10::List<int64_t>({a,b,c});}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithIntListOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::list_output(Tensor dummy, int input1, int input2, int input3) -> int[]",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU,
+          [](const Tensor&, int64_t a, int64_t b, int64_t c)
+              -> c10::List<int64_t> {
+            return c10::List<int64_t>({a, b, c});
+          }));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::list_output", ""});
   ASSERT_TRUE(op.has_value());
@@ -184,23 +278,39 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithIntListOutput_whe
   EXPECT_EQ(6, result[0].toIntVector()[2]);
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithMultipleOutputs_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-     .op("_test::multiple_outputs(Tensor dummy) -> (Tensor, int, Tensor[], int?, Dict(str, Tensor))",
-       RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> std::tuple<Tensor, int64_t, c10::List<Tensor>, std::optional<int64_t>, Dict<string, Tensor>> {
-         Dict<string, Tensor> dict;
-         dict.insert("first", dummyTensor(DispatchKey::CPU));
-         dict.insert("second", dummyTensor(DispatchKey::CUDA));
-         return std::tuple<Tensor, int64_t, c10::List<Tensor>, std::optional<int64_t>, Dict<string, Tensor>>(
-           dummyTensor(DispatchKey::CUDA),
-           5,
-           c10::List<Tensor>({dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CUDA)}),
-           std::optional<int64_t>(std::in_place, 0),
-           dict
-         );
-       }));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithMultipleOutputs_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::multiple_outputs(Tensor dummy) -> (Tensor, int, Tensor[], int?, Dict(str, Tensor))",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU,
+          [](Tensor) -> std::tuple<
+                         Tensor,
+                         int64_t,
+                         c10::List<Tensor>,
+                         std::optional<int64_t>,
+                         Dict<string, Tensor>> {
+            Dict<string, Tensor> dict;
+            dict.insert("first", dummyTensor(DispatchKey::CPU));
+            dict.insert("second", dummyTensor(DispatchKey::CUDA));
+            return std::tuple<
+                Tensor,
+                int64_t,
+                c10::List<Tensor>,
+                std::optional<int64_t>,
+                Dict<string, Tensor>>(
+                dummyTensor(DispatchKey::CUDA),
+                5,
+                c10::List<Tensor>(
+                    {dummyTensor(DispatchKey::CPU),
+                     dummyTensor(DispatchKey::CUDA)}),
+                std::optional<int64_t>(std::in_place, 0),
+                dict);
+          }));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::multiple_outputs", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::multiple_outputs", ""});
   ASSERT_TRUE(op.has_value());
 
   auto result = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -208,22 +318,29 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithMultipleOutputs_w
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result[0].toTensor()));
   EXPECT_EQ(5, result[1].toInt());
   EXPECT_EQ(2, result[2].toTensorVector().size());
-  EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(result[2].toTensorVector()[0]));
-  EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result[2].toTensorVector()[1]));
+  EXPECT_EQ(
+      DispatchKey::CPU, extractDispatchKey(result[2].toTensorVector()[0]));
+  EXPECT_EQ(
+      DispatchKey::CUDA, extractDispatchKey(result[2].toTensorVector()[1]));
   EXPECT_EQ(0, result[3].toInt());
-  auto result_dict = c10::impl::toTypedDict<string, Tensor>(result[4].toGenericDict());
+  auto result_dict =
+      c10::impl::toTypedDict<string, Tensor>(result[4].toGenericDict());
   EXPECT_EQ(2, result_dict.size());
   EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(result_dict.at("first")));
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result_dict.at("second")));
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithTensorInputByReference_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_input(Tensor input) -> Tensor",
-        RegisterOperators::options().kernel(DispatchKey::CPU, [] (const Tensor& a) {return a;})
-                                    .kernel(DispatchKey::CUDA, [] (const Tensor& a) {return a;}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithTensorInputByReference_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_input(Tensor input) -> Tensor",
+      RegisterOperators::options()
+          .kernel(DispatchKey::CPU, [](const Tensor& a) { return a; })
+          .kernel(DispatchKey::CUDA, [](const Tensor& a) { return a; }));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
   ASSERT_TRUE(op.has_value());
 
   auto result = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -235,13 +352,17 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithTensorInputByRefe
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(result[0].toTensor()));
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithTensorInputByValue_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_input(Tensor input) -> Tensor",
-        RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor a) {return a;})
-                                    .kernel(DispatchKey::CUDA, [] (Tensor a) {return a;}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithTensorInputByValue_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_input(Tensor input) -> Tensor",
+      RegisterOperators::options()
+          .kernel(DispatchKey::CPU, [](Tensor a) { return a; })
+          .kernel(DispatchKey::CUDA, [](Tensor a) { return a; }));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
   ASSERT_TRUE(op.has_value());
 
   auto result = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -255,13 +376,21 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithTensorInputByValu
 
 Tensor captured_input;
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithTensorInputByReference_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_input(Tensor input) -> ()",
-        RegisterOperators::options().kernel(DispatchKey::CPU, [] (const Tensor& a) -> void {captured_input = a;})
-                                    .kernel(DispatchKey::CUDA, [] (const Tensor& a) -> void {captured_input = a;}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithTensorInputByReference_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_input(Tensor input) -> ()",
+      RegisterOperators::options()
+          .kernel(
+              DispatchKey::CPU,
+              [](const Tensor& a) -> void { captured_input = a; })
+          .kernel(DispatchKey::CUDA, [](const Tensor& a) -> void {
+            captured_input = a;
+          }));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
   ASSERT_TRUE(op.has_value());
 
   auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -273,13 +402,19 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithTensorInputByRefe
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(captured_input));
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithTensorInputByValue_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_input(Tensor input) -> ()",
-        RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor a) -> void {captured_input = a;})
-                                    .kernel(DispatchKey::CUDA, [] (Tensor a) -> void {captured_input = a;}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithTensorInputByValue_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_input(Tensor input) -> ()",
+      RegisterOperators::options()
+          .kernel(
+              DispatchKey::CPU, [](Tensor a) -> void { captured_input = a; })
+          .kernel(
+              DispatchKey::CUDA, [](Tensor a) -> void { captured_input = a; }));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_input", ""});
   ASSERT_TRUE(op.has_value());
 
   auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU));
@@ -293,10 +428,14 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithTensorInputByValu
 
 int64_t captured_int_input = 0;
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithIntInput_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::int_input(Tensor dummy, int input) -> ()",
-        RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, int64_t a) -> void {captured_int_input = a;}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithIntInput_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::int_input(Tensor dummy, int input) -> ()",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU,
+          [](Tensor, int64_t a) -> void { captured_int_input = a; }));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::int_input", ""});
   ASSERT_TRUE(op.has_value());
@@ -307,10 +446,13 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithIntInput_withoutO
   EXPECT_EQ(3, captured_int_input);
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithIntInput_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::int_input(Tensor dummy, int input) -> int",
-        RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, int64_t a) {return a + 1;}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithIntInput_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::int_input(Tensor dummy, int input) -> int",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU, [](Tensor, int64_t a) { return a + 1; }));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::int_input", ""});
   ASSERT_TRUE(op.has_value());
@@ -322,67 +464,102 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithIntInput_withOutp
 
 int64_t captured_input_list_size = 0;
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithIntListInput_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::int_list_input(Tensor dummy, int[] input) -> ()",
-        RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, const c10::List<int64_t>& a) {captured_input_list_size = a.size();}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithIntListInput_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::int_list_input(Tensor dummy, int[] input) -> ()",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU, [](Tensor, const c10::List<int64_t>& a) {
+            captured_input_list_size = a.size();
+          }));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::int_list_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::int_list_input", ""});
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::List<int64_t>({2, 4, 6}));
+  auto outputs =
+      callOp(*op, dummyTensor(DispatchKey::CPU), c10::List<int64_t>({2, 4, 6}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(3, captured_input_list_size);
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithIntListInput_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::int_list_input(Tensor dummy, int[] input) -> int",
-        RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, const c10::List<int64_t>& a) -> int64_t {return a.size();}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithIntListInput_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::int_list_input(Tensor dummy, int[] input) -> int",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU, [](Tensor, const c10::List<int64_t>& a) -> int64_t {
+            return a.size();
+          }));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::int_list_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::int_list_input", ""});
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::List<int64_t>({2, 4, 6}));
+  auto outputs =
+      callOp(*op, dummyTensor(DispatchKey::CPU), c10::List<int64_t>({2, 4, 6}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(3, outputs[0].toInt());
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithTensorListInput_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_list_input(Tensor[] input) -> ()",
-        RegisterOperators::options().kernel(DispatchKey::CPU, [] (const c10::List<Tensor>& a) -> void {captured_input_list_size = a.size();}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithTensorListInput_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_list_input(Tensor[] input) -> ()",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU, [](const c10::List<Tensor>& a) -> void {
+            captured_input_list_size = a.size();
+          }));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, c10::List<Tensor>({dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
+  auto outputs = callOp(
+      *op,
+      c10::List<Tensor>(
+          {dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(2, captured_input_list_size);
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithTensorListInput_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::tensor_list_input(Tensor[] input) -> int",
-         RegisterOperators::options().kernel(DispatchKey::CPU, [] (const c10::List<Tensor>& a) -> int64_t {return a.size();}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithTensorListInput_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::tensor_list_input(Tensor[] input) -> int",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU,
+          [](const c10::List<Tensor>& a) -> int64_t { return a.size(); }));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::tensor_list_input", ""});
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, c10::List<Tensor>({dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
+  auto outputs = callOp(
+      *op,
+      c10::List<Tensor>(
+          {dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU)}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(2, outputs[0].toInt());
 }
 
 int captured_dict_size = 0;
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithDictInput_withoutOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::dict_input(Dict(str, Tensor) input) -> ()", RegisterOperators::options().catchAllKernel([] (Dict<string, Tensor> input1) {
-        captured_dict_size = input1.size();
-      }));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithDictInput_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::dict_input(Dict(str, Tensor) input) -> ()",
+      RegisterOperators::options().catchAllKernel(
+          [](Dict<string, Tensor> input1) {
+            captured_dict_size = input1.size();
+          }));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::dict_input", ""});
   ASSERT_TRUE(op.has_value());
@@ -396,11 +573,13 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithDictInput_without
   EXPECT_EQ(2, captured_dict_size);
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithDictInput_withOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-      .op("_test::dict_input(Dict(str, str) input) -> str", RegisterOperators::options().catchAllKernel([] (Dict<string, string> input1) {
-        return input1.at("key2");
-      }));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithDictInput_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::dict_input(Dict(str, str) input) -> str",
+      RegisterOperators::options().catchAllKernel(
+          [](Dict<string, string> input1) { return input1.at("key2"); }));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::dict_input", ""});
   ASSERT_TRUE(op.has_value());
@@ -413,11 +592,13 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithDictInput_withOut
   EXPECT_EQ("value2", outputs[0].toStringRef());
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithDictOutput_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators()
-    .op("_test::dict_output(Dict(str, str) input) -> Dict(str, str)", RegisterOperators::options().catchAllKernel([] (Dict<string, string> input) {
-      return input;
-    }));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithDictOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::dict_output(Dict(str, str) input) -> Dict(str, str)",
+      RegisterOperators::options().catchAllKernel(
+          [](Dict<string, string> input) { return input; }));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::dict_output", ""});
   ASSERT_TRUE(op.has_value());
@@ -427,7 +608,8 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithDictOutput_whenRe
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  auto output = c10::impl::toTypedDict<string, string>(outputs[0].toGenericDict());
+  auto output =
+      c10::impl::toTypedDict<string, string>(outputs[0].toGenericDict());
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ("value1", output.at("key1"));
@@ -436,14 +618,18 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithDictOutput_whenRe
 
 bool called = false;
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenFallbackKernelWithoutAnyArguments_whenRegistered_thenCanBeCalled) {
-  // note: non-fallback kernels without tensor arguments don't work because there
-  // is no way to get the dispatch key. For operators that only have a fallback
-  // kernel, this must work for backwards compatibility.
-  auto registrar = RegisterOperators()
-      .op("_test::no_tensor_args() -> ()", RegisterOperators::options().catchAllKernel([] () {called = true;}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenFallbackKernelWithoutAnyArguments_whenRegistered_thenCanBeCalled) {
+  // note: non-fallback kernels without tensor arguments don't work because
+  // there is no way to get the dispatch key. For operators that only have a
+  // fallback kernel, this must work for backwards compatibility.
+  auto registrar = RegisterOperators().op(
+      "_test::no_tensor_args() -> ()",
+      RegisterOperators::options().catchAllKernel([]() { called = true; }));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
   ASSERT_TRUE(op.has_value());
 
   called = false;
@@ -451,14 +637,19 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenFallbackKernelWithoutAnyArg
   EXPECT_TRUE(called);
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenFallbackKernelWithoutTensorArguments_whenRegistered_thenCanBeCalled) {
-  // note: non-fallback kernels without tensor arguments don't work because there
-  // is no way to get the dispatch key. For operators that only have a fallback
-  // kernel, this must work for backwards compatibility.
-  auto registrar = RegisterOperators()
-      .op("_test::no_tensor_args(int arg) -> int", RegisterOperators::options().catchAllKernel([] (int64_t arg) {return arg + 1;}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenFallbackKernelWithoutTensorArguments_whenRegistered_thenCanBeCalled) {
+  // note: non-fallback kernels without tensor arguments don't work because
+  // there is no way to get the dispatch key. For operators that only have a
+  // fallback kernel, this must work for backwards compatibility.
+  auto registrar = RegisterOperators().op(
+      "_test::no_tensor_args(int arg) -> int",
+      RegisterOperators::options().catchAllKernel(
+          [](int64_t arg) { return arg + 1; }));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
   ASSERT_TRUE(op.has_value());
 
   auto outputs = callOp(*op, 3);
@@ -470,20 +661,32 @@ std::optional<Tensor> called_arg2 = std::nullopt;
 std::optional<int64_t> called_arg3 = std::nullopt;
 std::optional<std::string> called_arg4 = std::nullopt;
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithOptionalInputs_withoutOutput_whenRegistered_thenCanBeCalled) {
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithOptionalInputs_withoutOutput_whenRegistered_thenCanBeCalled) {
   auto registrar = RegisterOperators().op(
-    "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> ()",
-    RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor arg1, const std::optional<Tensor>& arg2, std::optional<int64_t> arg3, std::optional<std::string> arg4) {
-      called = true;
-      called_arg2 = arg2;
-      called_arg3 = arg3;
-      called_arg4 = arg4;
-    }));
+      "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> ()",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU,
+          [](Tensor arg1,
+             const std::optional<Tensor>& arg2,
+             std::optional<int64_t> arg3,
+             std::optional<std::string> arg4) {
+            called = true;
+            called_arg2 = arg2;
+            called_arg3 = arg3;
+            called_arg4 = arg4;
+          }));
   auto op = c10::Dispatcher::singleton().findSchema({"_test::opt_input", ""});
   ASSERT_TRUE(op.has_value());
 
   called = false;
-  auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU), c10::IValue(), std::string("text"));
+  auto outputs = callOp(
+      *op,
+      dummyTensor(DispatchKey::CPU),
+      dummyTensor(DispatchKey::CPU),
+      c10::IValue(),
+      std::string("text"));
   EXPECT_EQ(0, outputs.size());
 
   EXPECT_TRUE(called);
@@ -494,7 +697,8 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithOptionalInputs_wi
   EXPECT_EQ(*called_arg4, "text");
 
   called = false;
-  outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
+  outputs = callOp(
+      *op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
   EXPECT_EQ(0, outputs.size());
 
   EXPECT_TRUE(called);
@@ -504,21 +708,33 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithOptionalInputs_wi
   EXPECT_FALSE(called_arg4.has_value());
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithOptionalInputs_withOutput_whenRegistered_thenCanBeCalled) {
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithOptionalInputs_withOutput_whenRegistered_thenCanBeCalled) {
   auto registrar = RegisterOperators().op(
-    "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> Tensor?",
-    RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor arg1, const std::optional<Tensor>& arg2, std::optional<int64_t> arg3, std::optional<std::string> arg4) {
-      called = true;
-      called_arg2 = arg2;
-      called_arg3 = arg3;
-      called_arg4 = arg4;
-      return arg2;
-    }));
+      "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> Tensor?",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU,
+          [](Tensor arg1,
+             const std::optional<Tensor>& arg2,
+             std::optional<int64_t> arg3,
+             std::optional<std::string> arg4) {
+            called = true;
+            called_arg2 = arg2;
+            called_arg3 = arg3;
+            called_arg4 = arg4;
+            return arg2;
+          }));
   auto op = c10::Dispatcher::singleton().findSchema({"_test::opt_input", ""});
   ASSERT_TRUE(op.has_value());
 
   called = false;
-  auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU), c10::IValue(), std::string("text"));
+  auto outputs = callOp(
+      *op,
+      dummyTensor(DispatchKey::CPU),
+      dummyTensor(DispatchKey::CPU),
+      c10::IValue(),
+      std::string("text"));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(outputs[0].toTensor()));
 
@@ -530,7 +746,8 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithOptionalInputs_wi
   EXPECT_EQ(*called_arg4, "text");
 
   called = false;
-  outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
+  outputs = callOp(
+      *op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
   EXPECT_EQ(1, outputs.size());
   EXPECT_TRUE(outputs[0].isNone());
 
@@ -541,22 +758,35 @@ TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithOptionalInputs_wi
   EXPECT_FALSE(called_arg4.has_value());
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernelWithOptionalInputs_withMultipleOutputs_whenRegistered_thenCanBeCalled) {
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernelWithOptionalInputs_withMultipleOutputs_whenRegistered_thenCanBeCalled) {
   auto registrar = RegisterOperators().op(
-    "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> (Tensor?, int?, str?)",
-    RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor arg1, const std::optional<Tensor>& arg2, std::optional<int64_t> arg3, std::optional<std::string> arg4) {
-      return std::make_tuple(arg2, arg3, arg4);
-    }));
+      "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> (Tensor?, int?, str?)",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU,
+          [](Tensor arg1,
+             const std::optional<Tensor>& arg2,
+             std::optional<int64_t> arg3,
+             std::optional<std::string> arg4) {
+            return std::make_tuple(arg2, arg3, arg4);
+          }));
   auto op = c10::Dispatcher::singleton().findSchema({"_test::opt_input", ""});
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, dummyTensor(DispatchKey::CPU), dummyTensor(DispatchKey::CPU), c10::IValue(), std::string("text"));
+  auto outputs = callOp(
+      *op,
+      dummyTensor(DispatchKey::CPU),
+      dummyTensor(DispatchKey::CPU),
+      c10::IValue(),
+      std::string("text"));
   EXPECT_EQ(3, outputs.size());
   EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(outputs[0].toTensor()));
   EXPECT_TRUE(outputs[1].isNone());
   EXPECT_EQ("text", outputs[2].toStringRef());
 
-  outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
+  outputs = callOp(
+      *op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
   EXPECT_EQ(3, outputs.size());
   EXPECT_TRUE(outputs[0].isNone());
   EXPECT_EQ(4, outputs[1].toInt());
@@ -569,188 +799,297 @@ void expectCallsConcatUnboxed(DispatchKey dispatch_key) {
   // assert that schema and cpu kernel are present
   auto op = c10::Dispatcher::singleton().findSchema({"_test::my_op", ""});
   ASSERT_TRUE(op.has_value());
-  std::string result = callOpUnboxed<std::string, const Tensor&, std::string, const std::string&, int64_t>(*op, dummyTensor(dispatch_key), "1", "2", 3);
+  std::string result = callOpUnboxed<
+      std::string,
+      const Tensor&,
+      std::string,
+      const std::string&,
+      int64_t>(*op, dummyTensor(dispatch_key), "1", "2", 3);
   EXPECT_EQ("123", result);
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernel_whenRegistered_thenCanBeCalledUnboxed) {
-  auto registrar = RegisterOperators().op("_test::my_op(Tensor dummy, str a, str b, int c) -> str", torch::RegisterOperators::options()
-    .kernel(DispatchKey::CPU, [] (const Tensor& tensor1, std::string a, const std::string& b, int64_t c) {
-      return a + b + std::to_string(c);
-    }));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernel_whenRegistered_thenCanBeCalledUnboxed) {
+  auto registrar = RegisterOperators().op(
+      "_test::my_op(Tensor dummy, str a, str b, int c) -> str",
+      torch::RegisterOperators::options().kernel(
+          DispatchKey::CPU,
+          [](const Tensor& tensor1,
+             std::string a,
+             const std::string& b,
+             int64_t c) { return a + b + std::to_string(c); }));
   expectCallsConcatUnboxed(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
-  auto registrar = RegisterOperators()
-      .op("_test::no_schema_specified", RegisterOperators::options().catchAllKernel([] (Tensor arg1, int64_t arg2, const c10::List<Tensor>& arg3) -> std::tuple<int64_t, Tensor> {return {};}));
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
+  auto registrar = RegisterOperators().op(
+      "_test::no_schema_specified",
+      RegisterOperators::options().catchAllKernel(
+          [](Tensor arg1, int64_t arg2, const c10::List<Tensor>& arg3)
+              -> std::tuple<int64_t, Tensor> { return {}; }));
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::no_schema_specified", ""});
+  auto op = c10::Dispatcher::singleton().findSchema(
+      {"_test::no_schema_specified", ""});
   ASSERT_TRUE(op.has_value());
 
-  std::optional<std::string> differences = c10::findSchemaDifferences(torch::jit::parseSchema("_test::no_schema_specified(Tensor arg1, int arg2, Tensor[] arg3) -> (int, Tensor)"), op->schema());
+  std::optional<std::string> differences = c10::findSchemaDifferences(
+      torch::jit::parseSchema(
+          "_test::no_schema_specified(Tensor arg1, int arg2, Tensor[] arg3) -> (int, Tensor)"),
+      op->schema());
   EXPECT_FALSE(differences.has_value());
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenMismatchedKernel_withDifferentNumArguments_whenRegistering_thenFails) {
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenMismatchedKernel_withDifferentNumArguments_whenRegistering_thenFails) {
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> int", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> int64_t {return {};}));
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> int",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU, [](Tensor) -> int64_t { return {}; }));
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg, Tensor arg2) -> int", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> int64_t {return {};}));
-    }, "The number of arguments is different. 2 vs 1"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg, Tensor arg2) -> int",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU, [](Tensor) -> int64_t { return {}; }));
+      },
+      "The number of arguments is different. 2 vs 1");
 
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg, Tensor arg2) -> ()", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, Tensor) -> void {}));
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg, Tensor arg2) -> ()",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU, [](Tensor, Tensor) -> void {}));
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch() -> ()", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, Tensor) -> void {}));
-    }, "The number of arguments is different. 0 vs 2"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch() -> ()",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU, [](Tensor, Tensor) -> void {}));
+      },
+      "The number of arguments is different. 0 vs 2");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> ()", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, Tensor) -> void {}));
-    }, "The number of arguments is different. 1 vs 2"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> ()",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU, [](Tensor, Tensor) -> void {}));
+      },
+      "The number of arguments is different. 1 vs 2");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg, Tensor arg2, Tensor arg3) -> ()", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, Tensor) -> void {}));
-    }, "The number of arguments is different. 3 vs 2"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg, Tensor arg2, Tensor arg3) -> ()",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU, [](Tensor, Tensor) -> void {}));
+      },
+      "The number of arguments is different. 3 vs 2");
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenMismatchedKernel_withDifferentArgumentType_whenRegistering_thenFails) {
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenMismatchedKernel_withDifferentArgumentType_whenRegistering_thenFails) {
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg1, int arg2) -> int", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, int64_t) -> int64_t {return {};}));
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg1, int arg2) -> int",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU, [](Tensor, int64_t) -> int64_t { return {}; }));
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg1, float arg2) -> int", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, int64_t) -> int64_t {return {};}));
-    }, "Type mismatch in argument 2: float vs int"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg1, float arg2) -> int",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU,
+                [](Tensor, int64_t) -> int64_t { return {}; }));
+      },
+      "Type mismatch in argument 2: float vs int");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(int arg1, int arg2) -> int", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor, int64_t) -> int64_t {return {};}));
-    }, "Type mismatch in argument 1: int vs Tensor"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(int arg1, int arg2) -> int",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU,
+                [](Tensor, int64_t) -> int64_t { return {}; }));
+      },
+      "Type mismatch in argument 1: int vs Tensor");
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenMismatchedKernel_withDifferentNumReturns_whenRegistering_thenFails) {
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenMismatchedKernel_withDifferentNumReturns_whenRegistering_thenFails) {
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> int", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> int64_t {return {};}));
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> int",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU, [](Tensor) -> int64_t { return {}; }));
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> ()", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> int64_t {return {};}));
-    }, "The number of returns is different. 0 vs 1"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> ()",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU, [](Tensor) -> int64_t { return {}; }));
+      },
+      "The number of returns is different. 0 vs 1");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> (int, int)", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> int64_t {return {};}));
-    }, "The number of returns is different. 2 vs 1"
-  );
-
-  // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> ()", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> void {}));
-
-  // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> Tensor", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> void {}));
-    }, "The number of returns is different. 1 vs 0"
-  );
-
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> (Tensor, Tensor)", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> void {}));
-    }, "The number of returns is different. 2 vs 0"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> (int, int)",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU, [](Tensor) -> int64_t { return {}; }));
+      },
+      "The number of returns is different. 2 vs 1");
 
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> (Tensor, Tensor)", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> std::tuple<Tensor, Tensor> {return {};}));
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> ()",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU, [](Tensor) -> void {}));
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> ()", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> std::tuple<Tensor, Tensor> {return {};}));
-    }, "The number of returns is different. 0 vs 2"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> Tensor",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU, [](Tensor) -> void {}));
+      },
+      "The number of returns is different. 1 vs 0");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> Tensor", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> std::tuple<Tensor, Tensor> {return {};}));
-    }, "The number of returns is different. 1 vs 2"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> (Tensor, Tensor)",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU, [](Tensor) -> void {}));
+      },
+      "The number of returns is different. 2 vs 0");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> (Tensor, Tensor, Tensor)", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> std::tuple<Tensor, Tensor> {return {};}));
-    }, "The number of returns is different. 3 vs 2"
-  );
+  // assert this does not fail because it matches
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> (Tensor, Tensor)",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU,
+          [](Tensor) -> std::tuple<Tensor, Tensor> { return {}; }));
+
+  // and now a set of mismatching schemas
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> ()",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU,
+                [](Tensor) -> std::tuple<Tensor, Tensor> { return {}; }));
+      },
+      "The number of returns is different. 0 vs 2");
+
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> Tensor",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU,
+                [](Tensor) -> std::tuple<Tensor, Tensor> { return {}; }));
+      },
+      "The number of returns is different. 1 vs 2");
+
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> (Tensor, Tensor, Tensor)",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU,
+                [](Tensor) -> std::tuple<Tensor, Tensor> { return {}; }));
+      },
+      "The number of returns is different. 3 vs 2");
 }
 
-TEST(OperatorRegistrationTestLambdaBasedKernel, givenMismatchedKernel_withDifferentReturnTypes_whenRegistering_thenFails) {
+TEST(
+    OperatorRegistrationTestLambdaBasedKernel,
+    givenMismatchedKernel_withDifferentReturnTypes_whenRegistering_thenFails) {
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> int", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> int64_t {return {};}));
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> int",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU, [](Tensor) -> int64_t { return {}; }));
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> Tensor", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> int64_t {return {};}));
-    }, "Type mismatch in return 1: Tensor vs int"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> Tensor",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU, [](Tensor) -> int64_t { return {}; }));
+      },
+      "Type mismatch in return 1: Tensor vs int");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> float", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> int64_t {return {};}));
-    }, "Type mismatch in return 1: float vs int"
-  );
-
-  // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> Tensor", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> Tensor {return {};}));
-
-  // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> float", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> Tensor {return {};}));
-    }, "Type mismatch in return 1: float vs Tensor"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> float",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU, [](Tensor) -> int64_t { return {}; }));
+      },
+      "Type mismatch in return 1: float vs int");
 
   // assert this does not fail because it matches
-  RegisterOperators()
-      .op("_test::mismatch(Tensor arg) -> (Tensor, int)", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> std::tuple<Tensor, int64_t> {return {};}));
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> Tensor",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU, [](Tensor) -> Tensor { return {}; }));
 
   // and now a set of mismatching schemas
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> (Tensor, float)", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> std::tuple<Tensor, int64_t> {return {};}));
-    }, "Type mismatch in return 2: float vs int"
-  );
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> float",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU, [](Tensor) -> Tensor { return {}; }));
+      },
+      "Type mismatch in return 1: float vs Tensor");
 
-  expectThrows<c10::Error>([] {
-    RegisterOperators()
-        .op("_test::mismatch(Tensor arg) -> (int, int)", RegisterOperators::options().kernel(DispatchKey::CPU, [] (Tensor) -> std::tuple<Tensor, int64_t> {return {};}));
-    }, "Type mismatch in return 1: int vs Tensor"
-  );
+  // assert this does not fail because it matches
+  RegisterOperators().op(
+      "_test::mismatch(Tensor arg) -> (Tensor, int)",
+      RegisterOperators::options().kernel(
+          DispatchKey::CPU,
+          [](Tensor) -> std::tuple<Tensor, int64_t> { return {}; }));
+
+  // and now a set of mismatching schemas
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> (Tensor, float)",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU,
+                [](Tensor) -> std::tuple<Tensor, int64_t> { return {}; }));
+      },
+      "Type mismatch in return 2: float vs int");
+
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::mismatch(Tensor arg) -> (int, int)",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU,
+                [](Tensor) -> std::tuple<Tensor, int64_t> { return {}; }));
+      },
+      "Type mismatch in return 1: int vs Tensor");
 }
 
-}
+} // namespace

--- a/aten/src/ATen/core/boxing/impl/kernel_stackbased_test.cpp
+++ b/aten/src/ATen/core/boxing/impl/kernel_stackbased_test.cpp
@@ -1,19 +1,19 @@
 
-#include <gtest/gtest.h>
 #include <ATen/core/boxing/impl/test_helpers.h>
+#include <gtest/gtest.h>
 
-#include <ATen/core/op_registration/op_registration.h>
 #include <ATen/core/Tensor.h>
+#include <ATen/core/op_registration/op_registration.h>
 #include <torch/csrc/jit/frontend/function_schema_parser.h>
 #include <torch/library.h>
 
 #include <ATen/core/LegacyTypeDispatch.h>
 
-using c10::RegisterOperators;
 using c10::DispatchKey;
+using c10::OperatorHandle;
+using c10::RegisterOperators;
 using c10::Stack;
 using std::make_unique;
-using c10::OperatorHandle;
 using std::unique_ptr;
 
 namespace {
@@ -35,10 +35,16 @@ void decrementKernel(const OperatorHandle&, Stack* stack) {
 }
 
 bool called_redispatching_kernel = false;
-void redispatchingKernel_with_DispatchKeySet(const OperatorHandle& op, c10::DispatchKeySet ks, Stack* stack) {
+void redispatchingKernel_with_DispatchKeySet(
+    const OperatorHandle& op,
+    c10::DispatchKeySet ks,
+    Stack* stack) {
   // this kernel is a no-op- it just redispatches to the lower-priority kernel
   called_redispatching_kernel = true;
-  auto updated_ks = ks & c10::DispatchKeySet(c10::DispatchKeySet::FULL_AFTER, c10::DispatchKey::TESTING_ONLY_GenericWrapper);
+  auto updated_ks = ks &
+      c10::DispatchKeySet(
+                        c10::DispatchKeySet::FULL_AFTER,
+                        c10::DispatchKey::TESTING_ONLY_GenericWrapper);
   op.redispatchBoxed(updated_ks, stack);
 }
 
@@ -63,7 +69,8 @@ void expectCallsIncrementUnboxed(DispatchKey dispatch_key) {
   // assert that schema and cpu kernel are present
   auto op = c10::Dispatcher::singleton().findSchema({"_test::my_op", ""});
   ASSERT_TRUE(op.has_value());
-  int64_t result = callOpUnboxed<int64_t, at::Tensor, int64_t>(*op, dummyTensor(dispatch_key), 5);
+  int64_t result = callOpUnboxed<int64_t, at::Tensor, int64_t>(
+      *op, dummyTensor(dispatch_key), 5);
   EXPECT_EQ(6, result);
 }
 
@@ -78,44 +85,71 @@ void expectCallsDecrement(DispatchKey dispatch_key) {
   EXPECT_EQ(4, result[0].toInt());
 }
 
-TEST(OperatorRegistrationTestStackBasedKernel, givenKernel_whenRegistered_thenCanBeCalled) {
-  auto registrar = RegisterOperators().op("_test::my_op(Tensor dummy, int input) -> int", RegisterOperators::options().kernel<&incrementKernel>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestStackBasedKernel,
+    givenKernel_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+      "_test::my_op(Tensor dummy, int input) -> int",
+      RegisterOperators::options().kernel<&incrementKernel>(DispatchKey::CPU));
   expectCallsIncrement(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestStackBasedKernel, givenMultipleOperatorsAndKernels_whenRegisteredInOneRegistrar_thenCallsRightKernel) {
+TEST(
+    OperatorRegistrationTestStackBasedKernel,
+    givenMultipleOperatorsAndKernels_whenRegisteredInOneRegistrar_thenCallsRightKernel) {
   auto registrar = RegisterOperators()
-      .op("_test::my_op(Tensor dummy, int input) -> int", RegisterOperators::options().kernel<&incrementKernel>(DispatchKey::CPU)
-                                                                                      .kernel<&errorKernel>(DispatchKey::CUDA))
-      .op("_test::error(Tensor dummy, int input) -> int", RegisterOperators::options().kernel<&errorKernel>(DispatchKey::CPU)
-                                                                                      .kernel<&errorKernel>(DispatchKey::CUDA));
+                       .op("_test::my_op(Tensor dummy, int input) -> int",
+                           RegisterOperators::options()
+                               .kernel<&incrementKernel>(DispatchKey::CPU)
+                               .kernel<&errorKernel>(DispatchKey::CUDA))
+                       .op("_test::error(Tensor dummy, int input) -> int",
+                           RegisterOperators::options()
+                               .kernel<&errorKernel>(DispatchKey::CPU)
+                               .kernel<&errorKernel>(DispatchKey::CUDA));
   expectCallsIncrement(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestStackBasedKernel, givenMultipleOperatorsAndKernels_whenRegisteredInMultipleRegistrars_thenCallsRightKernel) {
-  auto registrar1 = RegisterOperators().op("_test::my_op(Tensor dummy, int input) -> int", RegisterOperators::options().kernel<&incrementKernel>(DispatchKey::CPU)
-                                                                                                                       .kernel<&errorKernel>(DispatchKey::CUDA));
-  auto registrar2 = RegisterOperators().op("_test::error(Tensor dummy, int input) -> int", RegisterOperators::options().kernel<&errorKernel>(DispatchKey::CPU)
-                                                                                                                       .kernel<&errorKernel>(DispatchKey::CUDA));
+TEST(
+    OperatorRegistrationTestStackBasedKernel,
+    givenMultipleOperatorsAndKernels_whenRegisteredInMultipleRegistrars_thenCallsRightKernel) {
+  auto registrar1 = RegisterOperators().op(
+      "_test::my_op(Tensor dummy, int input) -> int",
+      RegisterOperators::options()
+          .kernel<&incrementKernel>(DispatchKey::CPU)
+          .kernel<&errorKernel>(DispatchKey::CUDA));
+  auto registrar2 = RegisterOperators().op(
+      "_test::error(Tensor dummy, int input) -> int",
+      RegisterOperators::options()
+          .kernel<&errorKernel>(DispatchKey::CPU)
+          .kernel<&errorKernel>(DispatchKey::CUDA));
   expectCallsIncrement(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestStackBasedKernel, givenKernel_whenRegistrationRunsOutOfScope_thenCannotBeCalledAnymore) {
+TEST(
+    OperatorRegistrationTestStackBasedKernel,
+    givenKernel_whenRegistrationRunsOutOfScope_thenCannotBeCalledAnymore) {
   {
     auto m = MAKE_TORCH_LIBRARY(_test);
     m.def("_test::my_op(Tensor dummy, int input) -> int");
     auto m_cpu = MAKE_TORCH_LIBRARY_IMPL(_test, CPU);
-    m_cpu.impl("my_op", DispatchKey::CPU, torch::CppFunction::makeFromBoxedFunction<incrementKernel>());
+    m_cpu.impl(
+        "my_op",
+        DispatchKey::CPU,
+        torch::CppFunction::makeFromBoxedFunction<incrementKernel>());
     {
       auto m_cuda = MAKE_TORCH_LIBRARY_IMPL(_test, CUDA);
-      m_cuda.impl("my_op", DispatchKey::CUDA, torch::CppFunction::makeFromBoxedFunction<decrementKernel>());
+      m_cuda.impl(
+          "my_op",
+          DispatchKey::CUDA,
+          torch::CppFunction::makeFromBoxedFunction<decrementKernel>());
 
       // assert that schema and cpu kernel are present
       expectCallsIncrement(DispatchKey::CPU);
       expectCallsDecrement(DispatchKey::CUDA);
     }
 
-    // now registrar2 is destructed. Assert that schema is still present but cpu kernel is not
+    // now registrar2 is destructed. Assert that schema is still present but cpu
+    // kernel is not
     expectCallsIncrement(DispatchKey::CPU);
     expectDoesntFindKernel("_test::my_op", DispatchKey::CUDA);
   }
@@ -130,14 +164,18 @@ void kernelWithoutInputs(const OperatorHandle&, Stack*) {
   called = true;
 }
 
-TEST(OperatorRegistrationTestStackBasedKernel, givenFallbackKernelWithoutAnyArguments_whenRegistered_thenCanBeCalled) {
-  // note: non-fallback kernels without tensor arguments don't work because there
-  // is no way to get the dispatch key. For operators that only have a fallback
-  // kernel, this must work for backwards compatibility.
-  auto registrar = RegisterOperators()
-      .op("_test::no_tensor_args() -> ()", RegisterOperators::options().catchAllKernel<&kernelWithoutInputs>());
+TEST(
+    OperatorRegistrationTestStackBasedKernel,
+    givenFallbackKernelWithoutAnyArguments_whenRegistered_thenCanBeCalled) {
+  // note: non-fallback kernels without tensor arguments don't work because
+  // there is no way to get the dispatch key. For operators that only have a
+  // fallback kernel, this must work for backwards compatibility.
+  auto registrar = RegisterOperators().op(
+      "_test::no_tensor_args() -> ()",
+      RegisterOperators::options().catchAllKernel<&kernelWithoutInputs>());
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
   ASSERT_TRUE(op.has_value());
 
   called = false;
@@ -149,14 +187,19 @@ void kernelWithoutTensorInputs(const OperatorHandle&, Stack* stack) {
   stack->back() = stack->back().toInt() + 1;
 }
 
-TEST(OperatorRegistrationTestStackBasedKernel, givenFallbackKernelWithoutTensorArguments_whenRegistered_thenCanBeCalled) {
-  // note: non-fallback kernels without tensor arguments don't work because there
-  // is no way to get the dispatch key. For operators that only have a fallback
-  // kernel, this must work for backwards compatibility.
-  auto registrar = RegisterOperators()
-      .op("_test::no_tensor_args(int arg) -> int", RegisterOperators::options().catchAllKernel<&kernelWithoutTensorInputs>());
+TEST(
+    OperatorRegistrationTestStackBasedKernel,
+    givenFallbackKernelWithoutTensorArguments_whenRegistered_thenCanBeCalled) {
+  // note: non-fallback kernels without tensor arguments don't work because
+  // there is no way to get the dispatch key. For operators that only have a
+  // fallback kernel, this must work for backwards compatibility.
+  auto registrar = RegisterOperators().op(
+      "_test::no_tensor_args(int arg) -> int",
+      RegisterOperators::options()
+          .catchAllKernel<&kernelWithoutTensorInputs>());
 
-  auto op = c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
+  auto op =
+      c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
   ASSERT_TRUE(op.has_value());
 
   auto outputs = callOp(*op, 3);
@@ -164,34 +207,47 @@ TEST(OperatorRegistrationTestStackBasedKernel, givenFallbackKernelWithoutTensorA
   EXPECT_EQ(4, outputs[0].toInt());
 }
 
-void kernelForSchemaInference(const OperatorHandle&, Stack* stack) {
+void kernelForSchemaInference(const OperatorHandle&, Stack* stack) {}
+
+TEST(
+    OperatorRegistrationTestStackBasedKernel,
+    givenKernel_whenRegisteredWithoutSpecifyingSchema_thenFailsBecauseItCannotInferFromStackBasedKernel) {
+  expectThrows<c10::Error>(
+      [] {
+        RegisterOperators().op(
+            "_test::no_schema_specified",
+            RegisterOperators::options()
+                .catchAllKernel<&kernelForSchemaInference>());
+      },
+      "Cannot infer operator schema for this kind of kernel in registration of operator _test::no_schema_specified");
 }
 
-TEST(OperatorRegistrationTestStackBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenFailsBecauseItCannotInferFromStackBasedKernel) {
-  expectThrows<c10::Error>([] {
-      RegisterOperators().op("_test::no_schema_specified", RegisterOperators::options().catchAllKernel<&kernelForSchemaInference>());
-  }, "Cannot infer operator schema for this kind of kernel in registration of operator _test::no_schema_specified");
-}
-
-TEST(OperatorRegistrationTestStackBasedKernel, givenKernel_whenRegistered_thenCanAlsoBeCalledUnboxed) {
-  auto registrar = RegisterOperators().op("_test::my_op(Tensor dummy, int input) -> int", RegisterOperators::options().kernel<&incrementKernel>(DispatchKey::CPU));
+TEST(
+    OperatorRegistrationTestStackBasedKernel,
+    givenKernel_whenRegistered_thenCanAlsoBeCalledUnboxed) {
+  auto registrar = RegisterOperators().op(
+      "_test::my_op(Tensor dummy, int input) -> int",
+      RegisterOperators::options().kernel<&incrementKernel>(DispatchKey::CPU));
   expectCallsIncrementUnboxed(DispatchKey::CPU);
 }
 
-TEST(OperatorRegistrationTestStackBasedKernel, callKernelsWithDispatchKeySetConvention_redispatchesToLowerPriorityKernels) {
+TEST(
+    OperatorRegistrationTestStackBasedKernel,
+    callKernelsWithDispatchKeySetConvention_redispatchesToLowerPriorityKernels) {
   auto m = MAKE_TORCH_LIBRARY(_test);
   m.def("my_op(Tensor dummy, int input) -> int");
   auto m_cpu = MAKE_TORCH_LIBRARY_IMPL(_, CPU);
   m_cpu.fallback(torch::CppFunction::makeFromBoxedFunction<&incrementKernel>());
   auto m_testing = MAKE_TORCH_LIBRARY_IMPL(_, TESTING_ONLY_GenericWrapper);
-  m_testing.fallback(torch::CppFunction::makeFromBoxedFunction<&redispatchingKernel_with_DispatchKeySet>());
+  m_testing.fallback(torch::CppFunction::makeFromBoxedFunction<
+                     &redispatchingKernel_with_DispatchKeySet>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::my_op", ""});
   ASSERT_TRUE(op.has_value());
 
   auto testing_cpu_set = c10::DispatchKeySet()
-                                    .add(c10::DispatchKey::TESTING_ONLY_GenericWrapper)
-                                    .add(c10::DispatchKey::CPU);
+                             .add(c10::DispatchKey::TESTING_ONLY_GenericWrapper)
+                             .add(c10::DispatchKey::CPU);
   called_redispatching_kernel = false;
 
   // call CPU (and not TESTING_ONLY_GenericWrapper)
@@ -203,4 +259,4 @@ TEST(OperatorRegistrationTestStackBasedKernel, callKernelsWithDispatchKeySetConv
   ASSERT_TRUE(called_redispatching_kernel);
 }
 
-}
+} // namespace


### PR DESCRIPTION
Code change via add path config in .lintrunner.toml file and running

```bash
lintrunner -a --take CLANGFORMAT --all-files
```