### PR TITLE
[XPU] Fix AOTI Runner Syntax Error

### DIFF
--- a/torch/csrc/inductor/aoti_runner/model_container_runner_xpu.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner_xpu.cpp
@@ -23,7 +23,7 @@ std::vector<at::Tensor> AOTIModelContainerRunnerXpu::run_impl(
     at::xpu::XPUStream xpu_stream = c10::xpu::getCurrentXPUStream();
     stream_handle = reinterpret_cast<void*>(&(xpu_stream.queue()));
   }
-  return AOTIModelContainerRunner::run_impl(inputs, stream_handle);
+  return AOTIModelContainerRunner::run_impl(input_handles, stream_handle);
 }
 
 std::vector<at::Tensor> AOTIModelContainerRunnerXpu::run_with_xpu_stream(


### PR DESCRIPTION
Syntax error in xpu aoti runner from commit: https://github.com/pytorch/pytorch/pull/142213/ leads to XPU build failure.


cc @gujinghui @EikanWang @fengyuan14 @guangyey