### PR TITLE
[dynamo] skip frame recursively when no graph is traced

### DIFF
--- a/torch/_C/_dynamo/eval_frame.pyi
+++ b/torch/_C/_dynamo/eval_frame.pyi
@@ -7,9 +7,11 @@ from torch._dynamo.types import DynamoCallback, DynamoGuardHook
 # For typechecking
 SkipCodeRecursiveFlag = NewType("SkipCodeRecursiveFlag", object)
 CacheLimitHitFlag = NewType("CacheLimitHitFlag", object)
+SkipFrameRecursiveFlag = NewType("SkipFrameRecursiveFlag", object)
 # Flag returned by Dynamo tracer to indicate to Dynamo eval frame that we should skip frames recursively.
 skip_code_recursive_flag: SkipCodeRecursiveFlag
 cache_limit_hit_flag: CacheLimitHitFlag
+skip_frame_recursive_flag: SkipFrameRecursiveFlag
 
 def set_eval_frame(callback: DynamoCallback) -> DynamoCallback: ...
 def set_skip_guard_eval_unsafe(value: bool) -> bool: ...

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -70,6 +70,10 @@ class SkipFrame(TorchDynamoException):
     pass
 
 
+class EmptyGraph(SkipFrame):
+    pass
+
+
 class TorchRuntimeError(TorchDynamoException):
     pass
 
@@ -210,6 +214,10 @@ class SkipCodeRecursiveException(TorchDynamoException):
 
 
 class RecompileLimitExceeded(Unsupported):
+    pass
+
+
+class SkipFrameRecursiveException(TorchDynamoException):
     pass
 
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -3061,7 +3061,7 @@ class InstructionTranslator(InstructionTranslatorBase):
             and not self.symbolic_locals_contain_module_class()
             and not self.export
         ):
-            raise exc.SkipFrame("because no content in function call")
+            raise exc.EmptyGraph("because no content in function call")
         self.instruction_pointer = None
         _step_logger()(
             logging.INFO,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144712

Fixes https://github.com/pytorch/pytorch/issues/144360. cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @ydwu4 

I'm considering refactoring the code flag logic in eval_frame (i.e. SKIP_CODE, SKIP_CODE_RECURSIVE, cache_limit_hit_fag, skip_frame_recursive_flag) to make things better defined and to have a cleaner, more consistent implementation.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames