### PR TITLE
[Intel GPU] Support SparseCsrXPU codegen

### DIFF
--- a/aten/src/ATen/SparseCsrTensorImpl.cpp
+++ b/aten/src/ATen/SparseCsrTensorImpl.cpp
@@ -56,10 +56,12 @@ SparseCsrTensorImpl::SparseCsrTensorImpl(
 
   TORCH_INTERNAL_ASSERT(((key_set.has(DispatchKey::SparseCsrCPU) && device().type() == kCPU)
                          || (key_set.has(DispatchKey::SparseCsrCUDA) && device().type() == kCUDA)
-                         || (key_set.has(DispatchKey::SparseCsrMeta) && device().type() == kMeta)
+                         || (key_set.has(DispatchKey::SparseCsrXPU) && device().type() == kXPU)
+			 || (key_set.has(DispatchKey::SparseCsrMeta) && device().type() == kMeta)
                          || (key_set.has(DispatchKey::SparseCsrCPU) && device().type() == kMeta)   // fake tensor
                          || (key_set.has(DispatchKey::SparseCsrCUDA) && device().type() == kMeta)  // fake tensor
-                         || (key_set.has(DispatchKey::SparseCsrPrivateUse1) && device().type() == kPrivateUse1)),
+                         || (key_set.has(DispatchKey::SparseCsrXPU) && device().type() == kMeta)   // fake tensor
+			 || (key_set.has(DispatchKey::SparseCsrPrivateUse1) && device().type() == kPrivateUse1)),
                         "Inconsistent key_set (=", key_set, ") and device (=", device(), ")");
 
   set_storage_access_should_throw();

--- a/aten/src/ATen/SparseCsrTensorImpl.cpp
+++ b/aten/src/ATen/SparseCsrTensorImpl.cpp
@@ -57,11 +57,11 @@ SparseCsrTensorImpl::SparseCsrTensorImpl(
   TORCH_INTERNAL_ASSERT(((key_set.has(DispatchKey::SparseCsrCPU) && device().type() == kCPU)
                          || (key_set.has(DispatchKey::SparseCsrCUDA) && device().type() == kCUDA)
                          || (key_set.has(DispatchKey::SparseCsrXPU) && device().type() == kXPU)
-			 || (key_set.has(DispatchKey::SparseCsrMeta) && device().type() == kMeta)
+                         || (key_set.has(DispatchKey::SparseCsrMeta) && device().type() == kMeta)
                          || (key_set.has(DispatchKey::SparseCsrCPU) && device().type() == kMeta)   // fake tensor
                          || (key_set.has(DispatchKey::SparseCsrCUDA) && device().type() == kMeta)  // fake tensor
                          || (key_set.has(DispatchKey::SparseCsrXPU) && device().type() == kMeta)   // fake tensor
-			 || (key_set.has(DispatchKey::SparseCsrPrivateUse1) && device().type() == kPrivateUse1)),
+                         || (key_set.has(DispatchKey::SparseCsrPrivateUse1) && device().type() == kPrivateUse1)),
                         "Inconsistent key_set (=", key_set, ") and device (=", device(), ")");
 
   set_storage_access_should_throw();

--- a/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
@@ -360,6 +360,9 @@ static SparseCsrTensor new_compressed_tensor(const TensorOptions& options) {
   case kCUDA:
     dispatch_key = DispatchKey::SparseCsrCUDA;
     break;
+  case kXPU:
+    dispatch_key = DispatchKey::SparseCsrXPU;
+    break;
   case kMeta:
     dispatch_key = DispatchKey::SparseCsrMeta;
     break;

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -283,6 +283,7 @@ dispatch_keys = [
     DispatchKey.MPS,
     DispatchKey.XPU,
     DispatchKey.SparseXPU,
+    DispatchKey.SparseCsrXPU,
     DispatchKey.SparseCUDA,
     DispatchKey.SparseCsrCUDA,
     DispatchKey.QuantizedCPU,


### PR DESCRIPTION
Adding a new dispatch key - `SparseCsrXPU`  to enable Intel GPU support for SparseCsr Tensor.

Similar PR: https://github.com/pytorch/pytorch/pull/139267