### PR TITLE
ck: add explicit addmm test

### DIFF
--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -451,6 +451,32 @@ class TestCKBackend(TestCase):
             Y_eager = bmm(a=a, b=b)
             torch.testing.assert_close(Y_compiled, Y_eager)
 
+    @unittest.skipIf(not torch.version.hip, "ROCM only")
+    def test_addmm(self):
+        # This test, more than accuracy, is designed to catch issues with
+        # CK's addmm signature vs pytorch's (X, W, B) vs (B, X, W)
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+
+        M, N, K = 1024, 1024, 16384
+
+        tensor_options = {"device": "cuda", "dtype": torch.float16}
+        X = torch.randn(M, K, **tensor_options)
+        W = torch.randn(K, N, **tensor_options)
+        B = torch.randn(M, N, **tensor_options)
+        with config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "CK",
+                "autotune_in_subproc": False,
+                "rocm.ck_dir": self.ck_dir,
+                "rocm.n_max_profiling_configs": 2,
+            }
+        ):
+            @torch.compile(dynamic=False)
+            def compiled_addmm(b, x, w):
+                return torch.addmm(b, x, w)
+
+            _ = compiled_addmm(B, X, W)
 
 if __name__ == "__main__":
     from torch._inductor.utils import is_big_gpu


### PR DESCRIPTION
Summary:
# Why

keep https://github.com/pytorch/pytorch/pull/144519 from regressing

# What

run addmm through CK only with a shape that previously caused a segfault

Test Plan:
```
buck2 test mode/dev-nosan-amd-gpu fbcode//caffe2/test/inductor:test_ck_backend -- --exact 'caffe2/test/inductor:test_ck_backend - test_addmm (caffe2.test.inductor.test_ck_backend.TestCKBackend)'
```

Differential Revision: D68119352




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @BoyuanFeng