### PR TITLE
Handle meta tensors in FX quantization

### DIFF
--- a/torch/ao/quantization/quantize.py
+++ b/torch/ao/quantization/quantize.py
@@ -300,8 +300,8 @@ def _add_observer_(
 
 
 def _get_unique_devices_(module):
-    return {p.device for p in module.parameters()} | {
-        p.device for p in module.buffers()
+    return {p.device for p in module.parameters() if p.device.type != "meta"} | {
+        p.device for p in module.buffers() if p.device.type != "meta"
     }
 
 
@@ -778,8 +778,8 @@ def swap_module(
 
             # respect device affinity when swapping modules
             devices = _get_unique_devices_(mod)
-            assert (
-                len(devices) <= 1
+            assert len(devices) <= 1 or (
+                len(devices) == 2 and torch.device("meta") in devices
             ), f"swap_module only works with cpu or single-device CUDA modules, but got devices {devices}"
             device = next(iter(devices)) if len(devices) > 0 else None
             if device:


### PR DESCRIPTION
Summary:
D66895899 got reverted in D67565250 because of pytorch OSS linter failure.
Adding back with the format the linter suggested
https://github.com/pytorch/pytorch/actions/runs/12443655335/job/34743090791

Test Plan: buck run fbcode//mode/dev-nosan fbcode//torchrec/fb/quant/tests:test_embedding_modules

Reviewed By: emlin

Differential Revision: D68132568


