### PR TITLE
[mps/inductor] Add support for `round()`

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -64,6 +64,7 @@ class MPSBasicTests(TestCase):
     test_slice_scatter4 = CommonTemplate.test_slice_scatter4
     test_tanh = CommonTemplate.test_tanh
     test_view_as_complex = CommonTemplate.test_view_as_complex
+    test_view_on_aliased = CommonTemplate.test_view_on_aliased
     test_views3 = CommonTemplate.test_views3
     test_views6 = CommonTemplate.test_views6
     test_views7 = CommonTemplate.test_views7

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -239,6 +239,10 @@ class MetalOverrides(OpOverrides):
     def ceil(x: CSEVariable) -> str:
         return f"metal::ceil({x})"
 
+    @staticmethod
+    def round(x: CSEVariable) -> str:
+        return f"metal::round({x})"
+
 
 class MetalKernel(SIMDKernel):
     overrides = MetalOverrides  # type: ignore[assignment]


### PR DESCRIPTION
With this change, inductor/test_view_on_aliased passes.

cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @BoyuanFeng