### PR TITLE
[Pipelining] fix test_schedule.py (missing destroy_process_group

### DIFF
--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -222,6 +222,8 @@ class ScheduleTest(TestCase):
         with self.assertRaises(RuntimeError):
             ScheduleInterleavedZeroBubble([stage], 2)
 
+        torch.distributed.destroy_process_group()
+
 
 instantiate_parametrized_tests(ScheduleTest)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144734
* #144596
* #144352



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @d4l3k @c-p-i-o