### PR TITLE
[cherry-pick][dtensor] expose the __create_chunk_list__ in the doc (#144100)

### DIFF
--- a/docs/source/distributed.tensor.rst
+++ b/docs/source/distributed.tensor.rst
@@ -49,8 +49,9 @@ In addition to existing ``torch.Tensor`` methods, it also offers a set of additi
 on all devices, etc.
 
 .. autoclass:: DTensor
-    :members:
-    :member-order: bysource
+    :members: from_local, to_local, full_tensor, redistribute, device_mesh, placements
+    :member-order: groupwise
+    :special-members: __create_chunk_list__
 
 
 DeviceMesh as the distributed communicator

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -603,6 +603,16 @@ class DTensor(torch.Tensor):
             raise RuntimeError("Unsupported tensor type!")
 
     def __create_chunk_list__(self):
+        """
+        Return a list of ChunkStorageMetadata, which is a dataclass that describes the size/offset of the local shard/replica
+        on current rank. For DTensor, each rank will have a single local shard/replica, so the returned list usually only
+        has one element.
+
+        This dunder method is primariy used for distributed checkpoint purpose.
+
+        Returns:
+            A List[:class:`ChunkStorageMetadata`] object that represents the shard size/offset on the current rank.
+        """
         from torch.distributed.checkpoint.planner_helpers import (
             _create_chunk_from_dtensor,
         )


### PR DESCRIPTION
as titled, this PR expose this dunder method as a public API in the doc, so that different checkpoint implementations can leverage this protocol, instead of exposing a separate API

Pull Request resolved: https://github.com/pytorch/pytorch/pull/144100
Approved by: https://github.com/awgu
ghstack dependencies: #144099

(cherry picked from commit eb7a303d21c247b50e095b0b4768d5b5c4ac2285)

Fixes #ISSUE_NUMBER


cc @H-Huang @awgu @kwen2501 @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o