### PR TITLE
expose extra torch_python apis

### DIFF
--- a/torch/csrc/Storage.h
+++ b/torch/csrc/Storage.h
@@ -45,7 +45,7 @@ bool THPStorage_init(PyObject* module);
 void THPStorage_postInit(PyObject* module);
 
 void THPStorage_assertNotNull(THPStorage* storage);
-void THPStorage_assertNotNull(PyObject* obj);
+TORCH_PYTHON_API void THPStorage_assertNotNull(PyObject* obj);
 
 TORCH_PYTHON_API extern PyTypeObject THPStorageType;
 

--- a/torch/csrc/tensor/python_tensor.h
+++ b/torch/csrc/tensor/python_tensor.h
@@ -28,7 +28,7 @@ TORCH_PYTHON_API void py_set_default_dtype(PyObject* dtype_obj);
 // change.  Probably only store ScalarType, as that's the only flex point
 // we support.
 TORCH_API c10::DispatchKey get_default_dispatch_key();
-at::Device get_default_device();
+TORCH_PYTHON_API at::Device get_default_device();
 
 // Gets the ScalarType for the default tensor type.
 at::ScalarType get_default_scalar_type();

--- a/torch/csrc/utils/device_lazy_init.h
+++ b/torch/csrc/utils/device_lazy_init.h
@@ -25,7 +25,9 @@ namespace torch::utils {
  * UX.
  */
 TORCH_PYTHON_API void device_lazy_init(at::DeviceType device_type);
-void set_requires_device_init(at::DeviceType device_type, bool value);
+TORCH_PYTHON_API void set_requires_device_init(
+    at::DeviceType device_type,
+    bool value);
 
 inline bool is_device_lazy_init_supported(at::DeviceType device_type) {
   // Add more devices here to enable lazy initialization.


### PR DESCRIPTION
Fixes #144302
After checking the code of my third-party devices, I think these APIs are also relied on by us, so I exposed them according to the discussion in the issue.