### PR TITLE
add fp8 support to index_cuda

### DIFF
--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -193,11 +193,23 @@ void index_put_kernel_impl(TensorIterator& iter, const IntArrayRef index_size, c
   });
 }
 
-static void index_kernel(TensorIteratorBase& iter, const IntArrayRef index_size, const IntArrayRef index_stride) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(kComplexHalf, kHalf, kBool, kBFloat16, iter.dtype(), "index_cuda", [&] {
-    using dtype = OpaqueType<sizeof(scalar_t)>;
-    index_kernel_impl<dtype>(iter, index_size, index_stride);
-  });
+static void index_kernel(
+    TensorIteratorBase& iter,
+    const IntArrayRef index_size,
+    const IntArrayRef index_stride) {
+  AT_DISPATCH_V2(
+      iter.dtype(),
+      "index_cuda",
+      AT_WRAP([&] {
+        using dtype = OpaqueType<sizeof(scalar_t)>;
+        index_kernel_impl<dtype>(iter, index_size, index_stride);
+      }),
+      AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX),
+      AT_EXPAND(AT_FLOAT8_TYPES),
+      kComplexHalf,
+      kHalf,
+      kBool,
+      kBFloat16);
 }
 
 static void index_fill_kernel(

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -165,6 +165,21 @@ class FakeTensorTest(TestCase):
             out = x[torch.zeros([36], dtype=torch.int64)]
             self.checkType(out, "cuda", [36])
 
+    @unittest.skipIf(
+        TEST_WITH_TORCHDYNAMO, "isinstance check for FakeTensor won't work with compile"
+    )
+    @unittest.skipIf(not RUN_CUDA, "requires cuda")
+    @parametrize(
+        "fp8_dtype",
+        [torch.float8_e4m3fn, torch.float8_e5m2],
+    )
+    def test_index_cuda_fp8(self, fp8_dtype):
+        with FakeTensorMode():
+            x = torch.ones([2048], device="cuda", dtype=fp8_dtype)
+            out = x[torch.zeros([36], dtype=torch.int64, device="cuda")]
+            self.checkType(out, "cuda", [36])
+            self.assertEqual(out.dtype, fp8_dtype)
+
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_shape_take_not_device(self):
         with FakeTensorMode():

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -161,7 +161,7 @@ class FakeTensorTest(TestCase):
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     @parametrize(
         "dtype",
-        [    
+        [
             torch.float32,
             torch.float64,
             torch.float16,

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -159,26 +159,31 @@ class FakeTensorTest(TestCase):
         TEST_WITH_TORCHDYNAMO, "isinstance check for FakeTensor won't work with compile"
     )
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
-    def test_index_cuda_with_cpu(self):
+    @parametrize(
+        "dtype",
+        [    
+            torch.float32,
+            torch.float64,
+            torch.float16,
+            torch.bfloat16,
+            torch.uint8,
+            torch.int8,
+            torch.int16,
+            torch.int32,
+            torch.int64,
+            torch.bool,
+            torch.complex64,
+            torch.complex128,
+            torch.float8_e4m3fn,
+            torch.float8_e5m2
+        ],
+    )
+    def test_index_cuda_with_cpu(self, dtype):
         with FakeTensorMode():
-            x = torch.rand([2048], device="cuda")
+            x = torch.ones([2048], device="cuda", dtype=dtype)
             out = x[torch.zeros([36], dtype=torch.int64)]
             self.checkType(out, "cuda", [36])
-
-    @unittest.skipIf(
-        TEST_WITH_TORCHDYNAMO, "isinstance check for FakeTensor won't work with compile"
-    )
-    @unittest.skipIf(not RUN_CUDA, "requires cuda")
-    @parametrize(
-        "fp8_dtype",
-        [torch.float8_e4m3fn, torch.float8_e5m2],
-    )
-    def test_index_cuda_fp8(self, fp8_dtype):
-        with FakeTensorMode():
-            x = torch.ones([2048], device="cuda", dtype=fp8_dtype)
-            out = x[torch.zeros([36], dtype=torch.int64, device="cuda")]
-            self.checkType(out, "cuda", [36])
-            self.assertEqual(out.dtype, fp8_dtype)
+            self.assertEqual(out.dtype, dtype)
 
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_shape_take_not_device(self):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -66,6 +66,7 @@ from torch.testing._internal.common_utils import (
     TestCase,
     xfailIfTorchDynamo,
 )
+from torch.testing._internal.common_dtype import all_types_complex_float8_and
 from torch.testing._internal.custom_op_db import custom_op_db
 
 from torch.testing._internal.inductor_utils import GPU_TYPE
@@ -161,22 +162,7 @@ class FakeTensorTest(TestCase):
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     @parametrize(
         "dtype",
-        [
-            torch.float32,
-            torch.float64,
-            torch.float16,
-            torch.bfloat16,
-            torch.uint8,
-            torch.int8,
-            torch.int16,
-            torch.int32,
-            torch.int64,
-            torch.bool,
-            torch.complex64,
-            torch.complex128,
-            torch.float8_e4m3fn,
-            torch.float8_e5m2
-        ],
+        all_types_complex_float8_and(),
     )
     def test_index_cuda_with_cpu(self, dtype):
         with FakeTensorMode():


### PR DESCRIPTION
Fixes #133605

**Summary**

This PR adds support for FP8 data types to the `index_cuda` op. 

It uses `AT_DISPATCH_V2` which is a new macro that can handle arbitrary number of dtypes, as opposed to the old implementations which had a separate macro for each possible number of dtype arguments (e.g. `AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND{2,3,4,5...}`).

**Test plan**

Updated test `index_cuda_with_cpu` in `test/test_fake_tensor.py` to have cases for all dtypes handled by `index_cuda`, including fp8 dtypes.
