### PR TITLE
[Reopen] [Intel GPU] Set higher tolerance for some models only on XPU Device

### DIFF
--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -417,6 +417,11 @@ class TorchBenchmarkRunner(BenchmarkRunner):
     def use_larger_multiplier_for_smaller_tensor(self, name):
         return name in self._require_larger_multiplier_for_smaller_tensor
 
+    def xpu_higher_tolerance(self, current_device):
+        return (
+            self._tolerance["higher_fp16_bf16_xpu"] if current_device == "xpu" else []
+        )
+
     def get_tolerance_and_cosine_flag(self, is_training, current_device, name):
         tolerance = 1e-4
         cosine = self.args.cosine
@@ -429,14 +434,18 @@ class TorchBenchmarkRunner(BenchmarkRunner):
                     return 1e-2, cosine
                 elif even_higher and name in even_higher:
                     return 8 * 1e-2, cosine
-            if name in self._tolerance["higher_fp16"]:
+            if name in self._tolerance["higher_fp16"] | self.xpu_higher_tolerance(
+                current_device
+            ):
                 return 1e-2, cosine
             elif name in self._tolerance["even_higher"]:
                 return 8 * 1e-2, cosine
             return 1e-3, cosine
 
         if self.args.bfloat16:
-            if name in self._tolerance["higher_bf16"]:
+            if name in self._tolerance["higher_bf16"] | self.xpu_higher_tolerance(
+                current_device
+            ):
                 return 1e-2, cosine
 
         if is_training and (current_device == "cuda" or current_device == "xpu"):

--- a/benchmarks/dynamo/torchbench.yaml
+++ b/benchmarks/dynamo/torchbench.yaml
@@ -54,6 +54,10 @@ tolerance:
     - drq
     - hf_Whisper
 
+  higher_fp16_bf16_xpu:
+    - phlippe_resnet
+    - timm_regnet
+
   freezing:
     # Similar logic to timm_models.py:get_tolerance_and_cosine_flag
     # the conv-batchnorm fusion used under freezing may cause relatively


### PR DESCRIPTION
Reopen the previous stale closed PR https://github.com/pytorch/pytorch/pull/134192

We need to increase the tolerance slightly to ensure that certain models pass accuracy check on the XPU device.
This pull request preserves the original tolerance threshold for the CUDA device and introduces a new key higher_fp16_bf16_xpu, which only impacts the XPU device.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames