### PR TITLE
[Intel CPU] Fix issue #143482.

### DIFF
--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -143,14 +143,11 @@ Tensor embedding_dense_backward_cpu(
       counts.reset(new index_t[num_weights]);
       for (const auto i : c10::irange(numel)) {
         TORCH_CHECK(indices_data[i] < num_weights,
-          "Out-of-bound array access is not allowed, indices_data[i] should be less than num_weights."
-          )
+          "Index out of range, expect index less than ", num_weights, ", got ", indices_data[i]
+            )
         counts[indices_data[i]] = 0;
       }
       for (const auto i : c10::irange(numel)) {
-        TORCH_CHECK(indices_data[i] < num_weights,
-          "Out-of-bound array access is not allowed, indices_data[i] should be less than num_weights."
-          )
         counts[indices_data[i]]++;
       }
     }

--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -142,9 +142,15 @@ Tensor embedding_dense_backward_cpu(
     if (scale_grad_by_freq) {
       counts.reset(new index_t[num_weights]);
       for (const auto i : c10::irange(numel)) {
+        TORCH_CHECK(indices_data[i] < num_weights,
+          "Out-of-bound array access is not allowed, indices_data[i] should be less than num_weights."
+          )
         counts[indices_data[i]] = 0;
       }
       for (const auto i : c10::irange(numel)) {
+        TORCH_CHECK(indices_data[i] < num_weights,
+          "Out-of-bound array access is not allowed, indices_data[i] should be less than num_weights."
+          )
         counts[indices_data[i]]++;
       }
     }

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -480,19 +480,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
 
     def test_embedding_indices_larger_than_num_weights(self, device):
         # Test case from https://github.com/pytorch/pytorch/pull/144760 (only on CPU device)
-        grad = torch.full(
-            (
-                8,
-                0,
-                3,
-                7,
-                6,
-                1,
-                0,
-            ),
-            0,
-            dtype=torch.float,
-        )
+        grad = torch.full((0,), 0)
         indices = torch.full((2,), 1250999896764, dtype=torch.long)
         num_weights = 536870912
         padding_idx = 0


### PR DESCRIPTION
Fix issue in https://github.com/pytorch/pytorch/issues/143482.
 To aviod out-of-bound aceess, values in indices should be less than num_weights.