### PR TITLE
Remove optimization pass to reduce number of copies in export IR

### DIFF
--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -121,6 +121,7 @@ def _insert_copy_for_mutations(
             copy_node = gm.graph.call_function(
                 torch.ops.aten.copy_.default, (mutated_node, return_node)
             )
+            copy_node.meta = return_node.meta
             return_nodes_to_copy[return_node] = copy_node
 
     output_args = [

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -506,10 +506,6 @@ def _decompose_and_get_gm_with_new_signature_constants(
         _verify_stack_trace(gm)
         _verify_placeholder_names(gm, new_graph_signature)
 
-        gm, new_graph_signature = _remove_unneccessary_copy_op_pass(
-            gm, new_graph_signature
-        )
-
         # When we apply parameterixzation rule to unwrap
         # subclasses, the state dict will now have different
         # desugared parameters. We need to manually filter those


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144762


This pass seems like a big headache because it fails to distinguish user-introduced copy_ vs the ones export introduce. The original motivation was that when we do run_decompositions, we unlift the exported program which introduces some inplace-update nodes at the end of the graph to the buffers that have been mutated. This is necessary because we don't want to have extra outputs for unlifted module since it should have same calling convention as eager module. 

These inplace-update nodes, however, get functionalized which is bad for perf now that we have extra copy nodes in the end of graph. Let's see what happens when we try disabling it. If it causes some performance regressions, then we should solve this for real. Some ideas:
1. Make the copy_ for the final update HOP that we special handle in decompositions.
2. When doing inference-to-inference, instead of retracing, we just only local decompositions per operator. We kind of used to do that but it is hard to keep this in sync with rest of export as time goes. 

Differential Revision: [D68152886](https://our.internmc.facebook.com/intern/diff/D68152886)