### PR TITLE
Unconditional dependency on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1119,7 +1119,7 @@ def main():
     install_requires = [
         "filelock",
         "typing-extensions>=4.10.0",
-        'setuptools ; python_version >= "3.12"',
+        "setuptools",
         "sympy>=1.13.3",
         "networkx",
         "jinja2",


### PR DESCRIPTION
In [segmentation-models.pytorch](https://github.com/qubvel-org/segmentation_models.pytorch/actions/runs/12753548754/job/35545453127#step:6:3442), we noticed that actions like `torch.compile` actually require setuptools for all Python versions. Setuptools is unconditionally imported in `torch/utils/cpp_extension.py`. This PR changes the setuptools dependency to be required at runtime for all Python versions.