### PR TITLE
EZ fix to make sure local pytest run succeeds in export

### DIFF
--- a/test/export/test_export_legacy.py
+++ b/test/export/test_export_legacy.py
@@ -66,10 +66,12 @@ tests = [
     test_export.TestDynamismExpression,
     test_export.TestExport,
 ]
-for test in tests:
-    make_dynamic_cls(test, True)
-    make_dynamic_cls(test, False)
-del test
+
+if IS_FBCODE:
+    for test in tests:
+        make_dynamic_cls(test, True)
+        make_dynamic_cls(test, False)
+    del test
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144764


Previously run_tests() was protected under IS_FBCODE flag so that following works:
```
python test/export/test_export_legacy.py
```

But it fails on:
```
pytest test/export/test_export_legacy.py
```

This is because pytest doesn't seem to get triggered through run_tests().

Differential Revision: [D68152737](https://our.internmc.facebook.com/intern/diff/D68152737)