### PR TITLE
Removed unused _RequiredParameter

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -61,16 +61,6 @@ _global_optimizer_post_hooks: Dict[int, GlobalOptimizerPostHook] = OrderedDict()
 _foreach_supported_types = [torch.Tensor, torch.nn.parameter.Parameter]
 
 
-class _RequiredParameter:
-    """Singleton class representing a required parameter for an Optimizer."""
-
-    def __repr__(self) -> str:
-        return "<required parameter>"
-
-
-required = _RequiredParameter()
-
-
 def _use_grad_for_differentiable(func):
     def _use_grad(self, *args, **kwargs):
         import torch._dynamo
@@ -1071,12 +1061,7 @@ class Optimizer:
                 raise ValueError("can't optimize a non-leaf Tensor")
 
         for name, default in self.defaults.items():
-            if default is required and name not in param_group:
-                raise ValueError(
-                    f"parameter group didn't specify a value of required optimization parameter {name}"
-                )
-            else:
-                param_group.setdefault(name, default)
+            param_group.setdefault(name, default)
 
         params = param_group["params"]
         if len(params) != len(set(params)):


### PR DESCRIPTION
As per this [discussion](https://discuss.pytorch.org/t/a-question-about-requiredparameter/137977), I figured that `_RequiredParameter` is no longer used.

The `required` object was initially introduced in this [PR](https://github.com/pytorch/pytorch/commit/4db66679238dae8539c270a61f60b9c0c4bb440d) as the `SGD` optimizer did not offer a default value for the learning rate. However there isn't a single place in the code base using `_RequiredParameter`, nor `required`. I am therefore removing unused `_RequiredParameter` and `required`.

Everything not included in this PR is Not a Contribution.