### PR TITLE
Enable CPP Extension Open Registration tests on Arm

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1512,7 +1512,7 @@ test_executorch() {
 test_linux_aarch64() {
   python test/run_test.py --include test_modules test_mkldnn test_mkldnn_fusion test_openmp test_torch test_dynamic_shapes \
         test_transformers test_multiprocessing test_numpy_interop test_autograd test_binary_ufuncs test_complex test_spectral_ops \
-        test_foreach test_reductions test_unary_ufuncs test_tensor_creation_ops test_ops \
+        test_foreach test_reductions test_unary_ufuncs test_tensor_creation_ops test_ops test_cpp_extensions_open_device_registration \
         --shard "$SHARD_NUMBER" "$NUM_TEST_SHARDS" --verbose
 
   # Dynamo tests

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -16,7 +16,6 @@ import torch.testing._internal.common_utils as common
 import torch.utils.cpp_extension
 from torch.serialization import safe_globals
 from torch.testing._internal.common_utils import (
-    IS_ARM64,
     skipIfTorchDynamo,
     TemporaryFileName,
     TEST_CUDA,
@@ -288,7 +287,6 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         sys.version_info >= (3, 13),
         "Error: Please register PrivateUse1HooksInterface by `RegisterPrivateUse1HooksInterface` first.",
     )
-    @unittest.skipIf(IS_ARM64, "Does not work on arm")
     @skipIfTorchDynamo("unsupported aten.is_pinned.default")
     def test_open_device_storage_pin_memory(self):
         # Check if the pin_memory is functioning properly on custom device
@@ -493,7 +491,6 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         np.__version__ < "1.25",
         "versions < 1.25 serialize dtypes differently from how it's serialized in data_legacy_numpy",
     )
-    @unittest.skipIf(IS_ARM64, "Does not work on arm")
     def test_open_device_numpy_serialization(self):
         """
         This tests the legacy _rebuild_device_tensor_from_numpy serialization path

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -36,7 +36,6 @@ def generate_faked_module():
     return _OpenRegMod()
 
 
-@unittest.skipIf(IS_ARM64, "Does not work on arm")
 @unittest.skipIf(TEST_XPU, "XPU does not support cppextension currently")
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestCppExtensionOpenRgistration(common.TestCase):
@@ -289,6 +288,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         sys.version_info >= (3, 13),
         "Error: Please register PrivateUse1HooksInterface by `RegisterPrivateUse1HooksInterface` first.",
     )
+    @unittest.skipIf(IS_ARM64, "Does not work on arm")
     @skipIfTorchDynamo("unsupported aten.is_pinned.default")
     def test_open_device_storage_pin_memory(self):
         # Check if the pin_memory is functioning properly on custom device
@@ -493,6 +493,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         np.__version__ < "1.25",
         "versions < 1.25 serialize dtypes differently from how it's serialized in data_legacy_numpy",
     )
+    @unittest.skipIf(IS_ARM64, "Does not work on arm")
     def test_open_device_numpy_serialization(self):
         """
         This tests the legacy _rebuild_device_tensor_from_numpy serialization path


### PR DESCRIPTION
Enables most tests under CPP Extension Open Registration as they pass on Arm now.


cc @malfet @zou3519 @snadampal @milpuz01 @aditew01 @nikhil-arm @fadara01