### PR TITLE
[AOTI] Mark run_impl as optnone

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -429,6 +429,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                     )
 
                 run_impl_proto = """
+                    __attribute__ ((optnone))
                     void AOTInductorModel::run_impl(
                         AtenTensorHandle*
                             input_handles, // array of input AtenTensorHandle; handles


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144780

Summary: Optimizing a large cpp wrrapper code can be really slow. Using this PR to measure the impact of setting optnone.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang @aakhundov @BoyuanFeng