### PR TITLE
[torch][ao][EASY] Change print to log in numeric debugger to avoid large output

### DIFF
--- a/torch/ao/quantization/pt2e/_numeric_debugger.py
+++ b/torch/ao/quantization/pt2e/_numeric_debugger.py
@@ -95,7 +95,7 @@ def _tensor_shape_equals(x: object, y: object) -> bool:
             all_equal = all_equal and k in y and (_tensor_shape_equals(x[k], y[k]))
         return all_equal
     else:
-        print(f"Comparing non Tensors: {x} and {y}, they must be equal")
+        log.debug("Comparing non Tensors: %s and %s, they must be equal", x, y)
         return type(x) == type(y) and x == y
 
 


### PR DESCRIPTION
Summary:
This print statement was spewing a bunch of data in logs by default, but it should
be silenceable.
Use `log.debug` instead.

Differential Revision: D68166823


