### PR TITLE
[CUDAGraph][Docs] add `cuda` to `torch.randn`

### DIFF
--- a/docs/source/torch.compiler_cudagraph_trees.rst
+++ b/docs/source/torch.compiler_cudagraph_trees.rst
@@ -284,7 +284,7 @@ Let’s say we are benchmarking running inference with the following code:
         y = torch.matmul(x, x)
         return y
 
-    x = torch.randn(10, 10)
+    x = torch.randn(10, 10, device="cuda")
     y1 = my_model(x)
     y2 = my_model(x)
     print(y1)


### PR DESCRIPTION
Previous doc example created `torch.randn` tensor on cpu so CUDAGraph was skipped.

Fixes #144386


cc @mcarilli @ezyang @eellison @penguinwu