### PR TITLE
[MPSInductor] Add `min`/`max` to MetalExprPrinter

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -42,6 +42,7 @@ class MPSBasicTests(TestCase):
     test_add_inplace_permuted_mps = CommonTemplate.test_add_inplace_permuted
     test_addmm = CommonTemplate.test_addmm
     test_argmax_min_int32 = CommonTemplate.test_argmax_min_int32
+    test_avg_pool2d5 = CommonTemplate.test_avg_pool2d5
     test_avg_pool2d8 = CommonTemplate.test_avg_pool2d8
     test_div1 = CommonTemplate.test_div1
     test_div3 = CommonTemplate.test_div3

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -42,6 +42,7 @@ class MPSBasicTests(TestCase):
     test_add_inplace_permuted_mps = CommonTemplate.test_add_inplace_permuted
     test_addmm = CommonTemplate.test_addmm
     test_argmax_min_int32 = CommonTemplate.test_argmax_min_int32
+    test_avg_pool2d8 = CommonTemplate.test_avg_pool2d8
     test_div1 = CommonTemplate.test_div1
     test_div3 = CommonTemplate.test_div3
     test_cat_empty = CommonTemplate.test_cat_empty

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -63,6 +63,11 @@ class MetalExprPrinter(ExprPrinter_):
         mod = self.doprint(mod)
         return f"({x}) % ({mod})"
 
+    def _print_Min(self, expr: sympy.Expr) -> str:
+        if len(expr.args) != 2:
+            raise RuntimeError("Min only supported for 2 or 3 args")
+        return f"metal::min({', '.join(map(self._print, expr.args))})"
+
 
 class MetalOverrides(OpOverrides):
     @staticmethod

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -68,6 +68,10 @@ class MetalExprPrinter(ExprPrinter_):
             raise RuntimeError("metal::min only supported for 2 args")
         return f"metal::min({', '.join(map(self._print, expr.args))})"
 
+    def _print_Max(self, expr: sympy.Expr) -> str:
+        if len(expr.args) != 2:
+            raise RuntimeError("metal::max only supported for 2 args")
+        return f"metal::max({', '.join(map(self._print, expr.args))})"
 
 class MetalOverrides(OpOverrides):
     @staticmethod

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -73,6 +73,7 @@ class MetalExprPrinter(ExprPrinter_):
             raise RuntimeError("metal::max only supported for 2 args")
         return f"metal::max({', '.join(map(self._print, expr.args))})"
 
+
 class MetalOverrides(OpOverrides):
     @staticmethod
     def to_dtype(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #144796
* #144795
* __->__ #144798

After that `GPUTests::test_avg_pool2d8_mps` and `GPUTests::test_avg_pool2d5_mps` passes

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @BoyuanFeng