### PR TITLE
[ONNX] Use python_dispatcher in type promotion

### DIFF
--- a/torch/onnx/_internal/fx/passes/type_promotion.py
+++ b/torch/onnx/_internal/fx/passes/type_promotion.py
@@ -23,7 +23,7 @@ from torch._subclasses import fake_tensor
 from torch.fx.experimental import proxy_tensor
 from torch.onnx._internal.fx import _pass, diagnostics, type_utils as fx_type_utils
 from torch.utils import _python_dispatch, _pytree
-
+import torch._dispatch.python
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -1705,10 +1705,8 @@ class InsertTypePromotion(_pass.Transform):
         fake_args = self._fetch_fake_args()
         fake_mode = self.fake_mode
         assert fake_mode is not None, "Cannot detect fake_mode."
-
-        with fake_tensor.unset_fake_temporarily(), (
-            fake_mode
-        ), fx_traceback.preserve_node_meta():
+        dispatcher_mode = torch._dispatch.python.enable_python_dispatcher()
+        with fake_mode, dispatcher_mode, fx_traceback.preserve_node_meta():
             self.interpreter.run(*fake_args)
 
         return self.module

--- a/torch/onnx/_internal/fx/passes/type_promotion.py
+++ b/torch/onnx/_internal/fx/passes/type_promotion.py
@@ -1699,6 +1699,9 @@ class InsertTypePromotion(_pass.Transform):
         fake_args = self._fetch_fake_args()
         fake_mode = self.fake_mode
         assert fake_mode is not None, "Cannot detect fake_mode."
+
+        # Use the python dispatcher to run through some python kernels which
+        # can better handle symints. Without this, some SymInts can become static.
         dispatcher_mode = torch._dispatch.python.enable_python_dispatcher()
         with fake_mode, dispatcher_mode, fx_traceback.preserve_node_meta():
             self.interpreter.run(*fake_args)

--- a/torch/onnx/_internal/fx/passes/type_promotion.py
+++ b/torch/onnx/_internal/fx/passes/type_promotion.py
@@ -9,6 +9,7 @@ import logging
 from typing import Any, Callable, Mapping, Sequence, TYPE_CHECKING
 
 import torch
+import torch._dispatch.python
 import torch._ops
 import torch.fx
 import torch.fx.traceback as fx_traceback
@@ -19,25 +20,18 @@ from torch._prims_common import (
 )
 from torch._refs import linalg as _linalg_refs, nn as _nn_refs, special as _special_refs
 from torch._refs.nn import functional as _functional_refs
-from torch._subclasses import fake_tensor
 from torch.fx.experimental import proxy_tensor
 from torch.onnx._internal.fx import _pass, diagnostics, type_utils as fx_type_utils
 from torch.utils import _python_dispatch, _pytree
-import torch._dispatch.python
+
 
 if TYPE_CHECKING:
     from types import ModuleType
 
+    from torch._subclasses import fake_tensor
+
 
 logger = logging.getLogger(__name__)
-
-# TODO(bowbao): move to type utils.
-_SCALAR_TYPE_TENSOR_DTYPE_MAP: Mapping[type, torch.dtype] = {
-    bool: torch.bool,
-    int: torch.int64,
-    float: torch.float32,
-    complex: torch.complex32,
-}
 
 
 def _try_getclosurevars(func):

--- a/torch/onnx/_internal/fx/passes/type_promotion.py
+++ b/torch/onnx/_internal/fx/passes/type_promotion.py
@@ -1701,7 +1701,8 @@ class InsertTypePromotion(_pass.Transform):
         assert fake_mode is not None, "Cannot detect fake_mode."
 
         # Use the python dispatcher to run through some python kernels which
-        # can better handle symints. Without this, some SymInts can become static.
+        # can better handle symints. Without this, some SymInts can become static
+        # when there are dynamic shapes.
         dispatcher_mode = torch._dispatch.python.enable_python_dispatcher()
         with fake_mode, dispatcher_mode, fx_traceback.preserve_node_meta():
             self.interpreter.run(*fake_args)


### PR DESCRIPTION
Fix #143118 

Use python_dispatcher in the type promotion pass to preserve symbolic shapes according to @angelayi 's suggestions. (Thanks!)

Tested locally. I wasn't able to create a minimal repro except for using the full model