### PR TITLE
[inductor][BE] don't try/except ImportError for AttrsDescriptor versions

### DIFF
--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -46,7 +46,10 @@ if _is_triton_available():
     import triton.backends.compiler
     import triton.compiler.compiler
 
-    if (AttrsDescriptor := getattr(triton.backends.compiler, "AttrsDescriptor", None)) is not None:
+    if (
+        AttrsDescriptor := getattr(triton.backends.compiler, "AttrsDescriptor", None)
+    ) is not None:
+
         def AttrsDescriptorWrapper(
             divisible_by_16=None,
             equal_to_1=None,
@@ -65,7 +68,10 @@ if _is_triton_available():
             assert res.property_values["tt.equal_to"] == 1
             return res
 
-    elif (AttrsDescriptor := getattr(triton.compiler.compiler, "AttrsDescriptor", None)) is not None:
+    elif (
+        AttrsDescriptor := getattr(triton.compiler.compiler, "AttrsDescriptor", None)
+    ) is not None:
+
         def AttrsDescriptorWrapper(
             divisible_by_16=None,
             equal_to_1=None,

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -67,7 +67,7 @@ if _is_triton_available():
             assert res.property_values["tt.equal_to"] == 1
             return res
 
-    elif hasattr(triton.compiler.compiler, "AttrsDescriptor"):
+    else:
         from triton.compiler.compiler import AttrsDescriptor
 
         def AttrsDescriptorWrapper(

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -43,9 +43,10 @@ def _is_triton_available() -> bool:
 
 # Define `AttrsDescriptorWrapper` function with clear conditional handling
 if _is_triton_available():
-    try:
-        from triton.backends.compiler import AttrsDescriptor
+    import triton.backends.compiler
+    import triton.compiler.compiler
 
+    if (AttrsDescriptor := getattr(triton.backends.compiler, "AttrsDescriptor", None)) is not None:
         def AttrsDescriptorWrapper(
             divisible_by_16=None,
             equal_to_1=None,
@@ -64,9 +65,7 @@ if _is_triton_available():
             assert res.property_values["tt.equal_to"] == 1
             return res
 
-    except ImportError:
-        from triton.compiler.compiler import AttrsDescriptor
-
+    elif (AttrsDescriptor := getattr(triton.compiler.compiler, "AttrsDescriptor", None)) is not None:
         def AttrsDescriptorWrapper(
             divisible_by_16=None,
             equal_to_1=None,

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -46,9 +46,8 @@ if _is_triton_available():
     import triton.backends.compiler
     import triton.compiler.compiler
 
-    if (
-        AttrsDescriptor := getattr(triton.backends.compiler, "AttrsDescriptor", None)
-    ) is not None:
+    if hasattr(triton.backends.compiler, "AttrsDescriptor"):
+        from triton.backends.compiler import AttrsDescriptor
 
         def AttrsDescriptorWrapper(
             divisible_by_16=None,
@@ -68,9 +67,8 @@ if _is_triton_available():
             assert res.property_values["tt.equal_to"] == 1
             return res
 
-    elif (
-        AttrsDescriptor := getattr(triton.compiler.compiler, "AttrsDescriptor", None)
-    ) is not None:
+    elif hasattr(triton.compiler.compiler, "AttrsDescriptor"):
+        from triton.compiler.compiler import AttrsDescriptor
 
         def AttrsDescriptorWrapper(
             divisible_by_16=None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144807

motivation: Ed's advice to avoid `except ImportError` (i.e. based on the fact that your target module/class might in fact exist, but you might run into some different ImportError whose stacktrace you now ignore).

additional motivation: I'm going to add some more cases to this list, and would like to avoid this pattern:
```
try:
   ...
except ImportError:
    try:
        ...
    except ImportError:
        try:
            ...
```

suggestions on better ways to do this would be appreciated!

test: ran with triton commit e5be006a (last working commit) and 34a6a2ff8 (in june, when AttrsDescriptor was still in triton.compiler.compiler)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @BoyuanFeng