### PR TITLE
Fix torch.normal ignores default_device

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3388,6 +3388,14 @@ class TestRandomTensorCreation(TestCase):
             with self.assertRaisesRegex(RuntimeError, r'normal expects all elements of std >= 0.0'):
                 torch.normal(input, std)
 
+    def test_normal_default_device(self, device):
+        try:
+            torch.set_default_device(device)
+            t = torch.normal(0, 1, (10, 10))
+        finally:
+            torch.set_default_device(None)
+        self.assertEqual(str(t.device), device)
+
     # https://github.com/pytorch/pytorch/issues/126834
     @xfailIfTorchDynamo
     @dtypes(torch.float, torch.double, torch.half)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1166,7 +1166,7 @@ def set_default_device(
     .. note::
 
         This doesn't affect functions that create tensors that share the same memory as the input, like:
-        :func:`torch.from_numpy` and :func:`torch.frombuffer`
+        :func:`torch.from_numpy` and :func:`torch.frombuffer`. Using :func:`torch.Tensor.to` move tensor to desired device.
 
     Args:
         device (device or string): the device to set as default

--- a/torch/utils/_device.py
+++ b/torch/utils/_device.py
@@ -31,8 +31,7 @@ def _device_constructors():
         torch.linspace,
         torch.logspace,
         torch.nested.nested_tensor,
-        # This function doesn't actually take a device argument
-        # torch.normal,
+        torch.normal,
         torch.ones,
         torch.rand,
         torch.randn,


### PR DESCRIPTION
Following #144070 to Fixes #122886
