### PR TITLE
[MPSInductor] Support `abs` in MetalPrintExpr

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -61,6 +61,7 @@ class MPSBasicTests(TestCase):
     test_nan_to_num = CommonTemplate.test_nan_to_num
     test_remainder = CommonTemplate.test_remainder
     test_remove_no_ops = CommonTemplate.test_remove_no_ops
+    test_reflection_pad2d = CommonTemplate.test_reflection_pad2d
     test_rsqrt = CommonTemplate.test_rsqrt
     test_signbit = CommonTemplate.test_signbit
     test_silu = CommonTemplate.test_silu

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -73,6 +73,10 @@ class MetalExprPrinter(ExprPrinter_):
             raise RuntimeError("metal::max only supported for 2 args")
         return f"metal::max({', '.join(map(self._print, expr.args))})"
 
+    def _print_Abs(self, expr: sympy.Expr) -> str:
+        assert len(expr.args) == 1
+        return f"metal::abs({self._print(expr.args[0])})"
+
 
 class MetalOverrides(OpOverrides):
     @staticmethod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #144827
* __->__ #144826
* #144796
* #144795



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov