### PR TITLE
OpenReg: Use device agnostic API

### DIFF
--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/__init__.py
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/__init__.py
@@ -4,7 +4,6 @@ import torch
 # can access it during its initialization
 # Also register aten impls
 from ._aten_impl import _IMPL_REGISTRY as _IMPL_REGISTRY  # noqa: F401
-from ._device_daemon import NUM_DEVICES as NUM_DEVICES
 
 
 # Load the C++ Module

--- a/test/cpp_extensions/open_registration_extension/test/test_openreg.py
+++ b/test/cpp_extensions/open_registration_extension/test/test_openreg.py
@@ -3,7 +3,7 @@
 import os
 
 import psutil
-import pytorch_openreg
+import pytorch_openreg  # noqa: F401
 
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
@@ -28,7 +28,7 @@ class TestOpenReg(TestCase):
                 thread_name = file.read().strip()
             all_thread_names.add(thread_name)
 
-        for i in range(pytorch_openreg.NUM_DEVICES):
+        for i in range(torch.accelerator.device_count()):
             self.assertIn(f"pt_autograd_{i}", all_thread_names)
 
     def test_factory(self):


### PR DESCRIPTION
Use `torch.accelerator.device_count()` to get the number of devices.

cc @albanD