### PR TITLE
Fix flash attention seed/offset overflow when seed/offset larger than int64 

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp
@@ -515,8 +515,8 @@ mha_fwd(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x head
             seed_t = at::empty({}, at::dtype(at::kLong).device(at::kCUDA));
             offset_t = at::empty({}, at::dtype(at::kLong).device(at::kCUDA));
         } else {
-            seed_t = at::empty({}, at::dtype(at::kLong));
-            offset_t = at::empty({}, at::dtype(at::kLong));
+            seed_t = at::empty({}, at::dtype(at::kUInt64));
+            offset_t = at::empty({}, at::dtype(at::kUInt64));
         }
 
     }

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp
@@ -501,8 +501,8 @@ mha_fwd(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x head
         at::PhiloxCudaState philox_state = gen->philox_cuda_state(counter_offset);
         if (at::cuda::currentStreamCaptureStatus() == at::cuda::CaptureStatus::None) {
           auto [seed, offset] = at::cuda::philox::unpack(philox_state);
-          seed_t = at::scalar_tensor(at::Scalar(static_cast<int64_t>(seed)), at::dtype(at::kLong));
-          offset_t = at::scalar_tensor(at::Scalar(static_cast<int64_t>(offset)), at::dtype(at::kLong));
+          seed_t = at::scalar_tensor(at::Scalar(static_cast<uint64_t>(seed)), at::dtype(at::kUInt64));
+          offset_t = at::scalar_tensor(at::Scalar(static_cast<uint64_t>(offset)), at::dtype(at::kUInt64));
         } else {
           seed_t = at::empty({}, at::dtype(at::kLong).device(at::kCUDA));
           offset_t = at::empty({}, at::dtype(at::kLong).device(at::kCUDA));
@@ -756,8 +756,8 @@ mha_varlen_fwd(const at::Tensor &q,  // total_q x num_heads x head_size, total_q
         at::PhiloxCudaState philox_state = gen->philox_cuda_state(counter_offset);
         if (at::cuda::currentStreamCaptureStatus() == at::cuda::CaptureStatus::None) {
           auto [seed, offset] = at::cuda::philox::unpack(philox_state);
-          seed_t = at::scalar_tensor(at::Scalar(static_cast<int64_t>(seed)), at::dtype(at::kLong));
-          offset_t = at::scalar_tensor(at::Scalar(static_cast<int64_t>(offset)), at::dtype(at::kLong));
+          seed_t = at::scalar_tensor(at::Scalar(static_cast<uint64_t>(seed)), at::dtype(at::kUInt64));
+          offset_t = at::scalar_tensor(at::Scalar(static_cast<uint64_t>(offset)), at::dtype(at::kUInt64));
         } else {
           seed_t = at::empty({}, at::dtype(at::kLong).device(at::kCUDA));
           offset_t = at::empty({}, at::dtype(at::kLong).device(at::kCUDA));
@@ -992,7 +992,7 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x head_si
         if (at::cuda::currentStreamCaptureStatus() ==
                 at::cuda::CaptureStatus::None)
         {
-            philox_args = at::PhiloxCudaState(*philox_seed.data_ptr<int64_t>(), *philox_offset.data_ptr<int64_t>());
+            philox_args = at::PhiloxCudaState(*philox_seed.data_ptr<uint64_t>(), *philox_offset.data_ptr<uint64_t>());
         } else { // dropout + capture
             philox_args = at::PhiloxCudaState(
                 philox_seed.data_ptr<int64_t>(), philox_offset.data_ptr<int64_t>(), 0);
@@ -1228,7 +1228,7 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
         if (at::cuda::currentStreamCaptureStatus() ==
                 at::cuda::CaptureStatus::None)
         {
-            philox_args = at::PhiloxCudaState(*philox_seed.data_ptr<int64_t>(), *philox_offset.data_ptr<int64_t>());
+            philox_args = at::PhiloxCudaState(*philox_seed.data_ptr<uint64_t>(), *philox_offset.data_ptr<uint64_t>());
         } else { // dropout + capture
             philox_args = at::PhiloxCudaState(
                 philox_seed.data_ptr<int64_t>(), philox_offset.data_ptr<int64_t>(), 0);

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5888,8 +5888,8 @@ def meta__flash_attention_forward(
     return (
         attention,
         logsumexp,
-        torch.empty((), dtype=torch.long, device="meta"),
-        torch.empty((), dtype=torch.long, device="meta"),
+        torch.empty((), dtype=torch.uint64, device="meta"),
+        torch.empty((), dtype=torch.uint64, device="meta"),
         debug_mask,
     )
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5545,8 +5545,8 @@ def meta__scaled_dot_product_flash_attention(
         None,
         max_seqlen_batch_q,
         max_seqlen_batch_k,
-        torch.empty((), dtype=torch.long, device="meta"),
-        torch.empty((), dtype=torch.long, device="meta"),
+        torch.empty((), dtype=torch.uint64, device="meta"),
+        torch.empty((), dtype=torch.uint64, device="meta"),
         debug_mask,
     )
 


### PR DESCRIPTION
Operator _scaled_dot_product_flash_attention saves seed and offset when argument dropout is larger than zero for backward gradient calculation.
Torch uses uint64 to represent seed and offset. [See here](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/cuda/detail/PhiloxCudaStateRaw.cuh#L33). However, flash attention uses int64 to save these two data. [See here](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp#L502-L503)
This will cause an overflow problem when the seed or offset is larger than int64(2^63-1).
Here is a sample for reproducing this bug. Offset has the same problem but it's harder to construct a case.
```
a = torch.randn(1).cuda() # init cuda

dtype = torch.half
shape = (2, 80, 1, 32)
q = torch.randn(shape, dtype=dtype).cuda().requires_grad_()
k = torch.randn(shape, dtype=dtype).cuda().requires_grad_()
v = torch.randn(shape, dtype=dtype).cuda().requires_grad_()

seed = (1 << 64) - 1
print('user seed:', seed)
torch.manual_seed(seed)
out = torch.ops.aten._scaled_dot_product_flash_attention(q, k, v, 0.1)
print('flash attention saved seed for backward:', out[6])

seed = (1 << 63) - 1
torch.manual_seed(seed)
print('user seed:', seed)
out = torch.ops.aten._scaled_dot_product_flash_attention(q, k, v, 0.1)
print('flash attention saved seed for backward:', out[6])

# seed wrong when seed larger than int64
user seed: 18446744073709551615
flash attention saved seed for backward: tensor(-1)
user seed: 9223372036854775807
flash attention saved seed for backward: tensor(9223372036854775807)
```
With this fix, the result is right.


```
# use same code example
# both output are right
user seed: 18446744073709551615
flash attention saved seed for backward: tensor(18446744073709551615, dtype=torch.uint64)
user seed: 9223372036854775807
flash attention saved seed for backward: tensor(9223372036854775807, dtype=torch.uint64)
```