### PR TITLE
Undo leading underscore on ctx for breakpoint

### DIFF
--- a/torch/_dynamo/comptime.py
+++ b/torch/_dynamo/comptime.py
@@ -380,7 +380,7 @@ class _Comptime:
         """
 
         def inner(inner_ctx):
-            _ctx = inner_ctx.parent()
+            ctx = inner_ctx.parent()  # noqa: F841
             builtins.breakpoint()
 
         comptime(inner)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144864

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames