### PR TITLE
[mps] Massage test_full_truncation to work only on the supported dtypes.

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -49,6 +49,7 @@ class MPSBasicTests(TestCase):
     test_cat_empty = CommonTemplate.test_cat_empty
     test_cat_unbacked_empty_1d = CommonTemplate.test_cat_unbacked_empty_1d
     test_floordiv = CommonTemplate.test_floordiv
+    test_full_truncation = CommonTemplate.test_full_truncation
     test_fmod = CommonTemplate.test_fmod
     test_fmod_zero_dim = CommonTemplate.test_fmod_zero_dim
     test_index_dynamic_shapes = CommonTemplate.test_index_dynamic_shapes

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6546,9 +6546,17 @@ class CommonTemplate:
 
         device_interface = get_interface_for_device(self.device)
         for dtype in all_types():
-            ctx = contextlib.nullcontext() if device_interface.is_dtype_supported(dtype) else self.assertRaises(TypeError)
+            ctx = (
+                contextlib.nullcontext()
+                if device_interface.is_dtype_supported(dtype)
+                else self.assertRaises(TypeError)
+            )
             with ctx:
-                self.common(fn, (make_tensor(8, dtype=dtype, device=self.device),), check_lowp=False)
+                self.common(
+                    fn, 
+                    (make_tensor(8, dtype=dtype, device=self.device),),
+                    check_lowp=False
+                )
 
     def test_full_boolean(self):
         def fn(n):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6553,9 +6553,9 @@ class CommonTemplate:
             )
             with ctx:
                 self.common(
-                    fn, 
+                    fn,
                     (make_tensor(8, dtype=dtype, device=self.device),),
-                    check_lowp=False
+                    check_lowp=False,
                 )
 
     def test_full_boolean(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6544,8 +6544,11 @@ class CommonTemplate:
         def fn(a):
             return a + torch.full_like(a, 7.777)
 
+        device_interface = get_interface_for_device(self.device)
         for dtype in all_types():
-            self.common(fn, (make_tensor(8, dtype=dtype, device=self.device),))
+            ctx = contextlib.nullcontext() if device_interface.is_dtype_supported(dtype) else self.assertRaises(TypeError)
+            with ctx:
+                self.common(fn, (make_tensor(8, dtype=dtype, device=self.device),), check_lowp=False)
 
     def test_full_boolean(self):
         def fn(n):


### PR DESCRIPTION
Converted a first one to make sure the pattern was the one we wanted -- if we're OK with this, I'll probably adjust all the other failing ones in a batch or two. Let me know.

cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov