### PR TITLE
Fix erroneous at_vreinterpretq_u16_bf16 call

### DIFF
--- a/aten/src/ATen/cpu/vec/vec128/vec128_bfloat16_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_bfloat16_neon.h
@@ -274,7 +274,7 @@ class Vectorized<c10::BFloat16> : public Vectorized16<at_bfloat16x8_t, c10::BFlo
     Vectorized<c10::BFloat16> vec(
         at_vreinterpretq_bf16_u16(
             vbslq_u16(
-                at_vreinterpretq_u16_bf16(mask),
+                mask,
                 at_vreinterpretq_u16_bf16(b.values),
                 at_vreinterpretq_u16_bf16(a.values))));
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144883

Here, `mask` is definitely a `uint16x8_t`, not an `at_bfloat16x8_t`, so we shouldn't be reintepreting it. Candidate fix for #144818 .

Differential Revision: [D68224128](https://our.internmc.facebook.com/intern/diff/D68224128/)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10