### PR TITLE
[c10d][fr] Fix the bug when we still mark mismatch when there are match case

### DIFF
--- a/tools/flight_recorder/components/builder.py
+++ b/tools/flight_recorder/components/builder.py
@@ -358,8 +358,8 @@ def build_collectives(
                 candidate_idx.update(found_idx)
                 found_idx.clear()
                 found_ranks.clear()
-                mismatch[pg_name] += 1
                 if expected_ranks - dumps_ranks:
+                    mismatch[pg_name] += 1
                     logger.info(
                         "We cannot decide what's wrong with this collective entry "
                         "because we missed FR dumps from ranks (%s) so we don't have enough "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144916

When we introduce partial match, we accidentally introduce the mark of mismatch for the full match case. This is wrong and this PR fix it.

