### PR TITLE
[MPSInductor] Properly convert index

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -65,6 +65,7 @@ class MPSBasicTests(TestCase):
     test_reflection_pad2d = CommonTemplate.test_reflection_pad2d
     test_rsqrt = CommonTemplate.test_rsqrt
     test_scalar_output = CommonTemplate.test_scalar_output
+    test_setitem_with_int_parameter = CommonTemplate.test_setitem_with_int_parameter
     test_signbit = CommonTemplate.test_signbit
     test_silu = CommonTemplate.test_silu
     test_slice_scatter4 = CommonTemplate.test_slice_scatter4

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -64,6 +64,7 @@ class MPSBasicTests(TestCase):
     test_remove_no_ops = CommonTemplate.test_remove_no_ops
     test_reflection_pad2d = CommonTemplate.test_reflection_pad2d
     test_rsqrt = CommonTemplate.test_rsqrt
+    test_scalar_output = CommonTemplate.test_scalar_output
     test_signbit = CommonTemplate.test_signbit
     test_silu = CommonTemplate.test_silu
     test_slice_scatter4 = CommonTemplate.test_slice_scatter4

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -288,7 +288,7 @@ class MetalKernel(SIMDKernel):
         """Codegen a load from an InputBuffer"""
         var = self.args.input(name)
         index = self.prepare_indexing(index)
-        line = f"{var}[{self.sexpr(index)}]"
+        line = f"{var}[{self.index_to_str(index)}]"
         return self.cse.generate(self.body, line, dtype=V.graph.get_dtype(name))
 
     def store(
@@ -382,8 +382,9 @@ class MetalKernel(SIMDKernel):
             return
         # TODO(malfet): support asserts
         # See https://github.com/pytorch/pytorch/issues/144634
-        lower_expr = f"{self.sexpr(expr)} < 0" if lower else ""
-        upper_expr = f"{self.sexpr(expr)} >= {self.sexpr(size)}" if upper else ""
+        expr_str = self.index_to_str(expr)
+        lower_expr = f"{expr_str} < 0" if lower else ""
+        upper_expr = f"{expr_str} >= {self.index_to_str(size)}" if upper else ""
         if lower and upper:
             line = f"if (({lower_expr}) && ({upper_expr})) return"
         else:

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -297,7 +297,7 @@ class MetalKernel(SIMDKernel):
         var = self.args.output(name)
         index = self.prepare_indexing(index)
         dtype_str = self.dtype_to_str(V.graph.get_dtype(name))
-        line = f"{var}[{index}] = static_cast<{dtype_str}>({value});"
+        line = f"{var}[{self.index_to_str(index)}] = static_cast<{dtype_str}>({value});"
         self.body.writeline(DeferredLine(name, line))
 
     def codegen_iteration_ranges_entry(self, entry: IterationRangesEntry) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #144924
* __->__ #144917

By calling `self.index_to_str` from `load`,`store` and `check_bounds` in order to properly handle sizevars variables renames

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov