### PR TITLE
[MPSInductor] Fix codegen regression

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -69,6 +69,7 @@ class MPSBasicTests(TestCase):
     test_signbit = CommonTemplate.test_signbit
     test_silu = CommonTemplate.test_silu
     test_slice_scatter4 = CommonTemplate.test_slice_scatter4
+    test_sort = CommonTemplate.test_sort
     test_tanh = CommonTemplate.test_tanh
     test_view_as_complex = CommonTemplate.test_view_as_complex
     test_view_on_aliased = CommonTemplate.test_view_on_aliased

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -398,9 +398,10 @@ class MetalScheduling(SIMDScheduling):
     def __init__(self, scheduler: Scheduler) -> None:
         super().__init__(scheduler)
         wrapper = V.graph.wrapper_code
-        wrapper.header.splice(
-            "from torch._inductor.runtime.runtime_utils import compile_mps_shader"
-        )
+        if wrapper is not None:
+            wrapper.header.splice(
+                "from torch._inductor.runtime.runtime_utils import compile_mps_shader"
+            )
 
     def define_kernel(
         self, src_code: str, node_schedule: list[SchedulerNode], kernel: MetalKernel


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144924
* #144917

Caused by https://github.com/pytorch/pytorch/pull/144649

Do not try to insert anything into the header if wrapper is not ready yet

Fixes `test_sort_mps`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov