### PR TITLE
[Pipelining] Improve shape inference debug logging

### DIFF
--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -1385,7 +1385,6 @@ class PipelineStage(_PipelineStageBase):
 
         # set attributes needed for forward
         with torch.no_grad():
-            logger.debug("Shape inference: stage %s running forward", self.stage_index)
             outputs = self.submod(*args, **kwargs)
 
         # if single tensor, convert so it is always a list
@@ -1397,6 +1396,12 @@ class PipelineStage(_PipelineStageBase):
         # 2 - avoid activating a cuda context for the src rank when unpickling on the recv end!
         outputs_meta = tuple(
             tree_map_only(torch.Tensor, lambda x: x.to("meta"), outputs)
+        )
+        logger.debug(
+            "Shape inference: stage %s inputs %s, outputs %s",
+            self.stage_index,
+            self.inputs_meta,
+            outputs_meta,
         )
         self._configure_outputs_meta(outputs_meta)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #144834
* __->__ #144929

Remove log that just said "running forward" since that is not so useful
in itself, replace with somewhat equivalent log that reports both input
and output shapes after running forward.

Note: enabled by `TORCH_LOGS=+pp`

Example:
```
[rank0]:V0115 13:28:58.282000 3908366 torch/distributed/pipelining/stage.py:1400] Shape inference: stage 0 inputs (tensor(..., device='meta', size=(1, 64), dtype=torch.int64),), outputs (tensor(..., device='meta', size=(1, 64, 256), dtype=torch.bfloat16),)
```

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @d4l3k @c-p-i-o