### PR TITLE
[ROCm][TunableOp] Improve identification of fastest solution

### DIFF
--- a/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
+++ b/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
@@ -598,13 +598,6 @@ auto GetHipBlasLtTypeStringAndOps() {
         heuristic_result));
   TORCH_HIPBLASLT_CHECK(hipblasLtDestroy(handle));
 
-  // Sort heuristic_result by algo index to make sure the order of returned algos is deterministic.
-  std::sort(heuristic_result.begin(),
-      heuristic_result.end(),
-      [](hipblasLtMatmulHeuristicResult_t& a, hipblasLtMatmulHeuristicResult_t& b) {
-      return hipblaslt_ext::getIndexFromAlgo(a.algo) < hipblaslt_ext::getIndexFromAlgo(b.algo);
-      });
-
   int returned_algo_count = heuristic_result.size();
   std::vector<std::pair<std::string, std::unique_ptr<Callable<ParamsT>>>> ret;
   for (int i = 0; i < returned_algo_count; i++) {

--- a/aten/src/ATen/cuda/tunable/GemmRocblas.h
+++ b/aten/src/ATen/cuda/tunable/GemmRocblas.h
@@ -192,9 +192,6 @@ auto GetRocBlasGemmTypeStringAndOps() {
                                                             rocblas_gemm_flags_none,
                                                             solutions.data(),
                                                             &solution_size));
-  // Sort the solutions in ascending order to make the solution vector deterministic across runs
-  std::sort(solutions.begin(), solutions.end());
-
   std::vector<std::pair<std::string, std::unique_ptr<Callable<GemmParams<T>>>>> ret;
   for (size_t i = 0; i < solutions.size(); ++i) {
     auto callable = std::make_unique<RocblasGemmOp<T>>(solutions[i]);

--- a/aten/src/ATen/cuda/tunable/StreamTimer.cpp
+++ b/aten/src/ATen/cuda/tunable/StreamTimer.cpp
@@ -24,7 +24,7 @@ StreamTimer::StreamTimer() {
 StreamTimer::~StreamTimer() = default;
 
 void StreamTimer::Start() {
-  AT_CUDA_CHECK(cudaDeviceSynchronize());
+  AT_CUDA_CHECK(cudaEventSynchronize(start_));
   AT_CUDA_CHECK(cudaEventRecord(start_, at::cuda::getCurrentCUDAStream()));
 }
 

--- a/aten/src/ATen/cuda/tunable/StreamTimer.h
+++ b/aten/src/ATen/cuda/tunable/StreamTimer.h
@@ -31,4 +31,20 @@ class StreamTimer : public ITimer {
     cudaEvent_t end_{};
 };
 
+class StreamTimerNoSync : public ITimer {
+  public:
+    StreamTimerNoSync();
+    ~StreamTimerNoSync() override;
+
+    void Start() override;
+
+    void End() override;
+
+    float Duration() override;
+
+  private:
+    cudaEvent_t start_{};
+    cudaEvent_t end_{};
+};
+
 } // namespace at::cuda::tunable

--- a/aten/src/ATen/cuda/tunable/TunableGemm.h
+++ b/aten/src/ATen/cuda/tunable/TunableGemm.h
@@ -14,7 +14,6 @@
 #include <ATen/cuda/tunable/GemmHipblaslt.h>
 #include <ATen/cuda/tunable/GemmRocblas.h>
 #endif
-#include <ATen/cuda/tunable/StreamTimer.h>
 #include <ATen/cuda/tunable/TunableOp.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/util/Float8_e4m3fn.h>
@@ -192,7 +191,7 @@ inline const char* TypeName(c10::complex<float> v) {
 }
 
 template <typename T, BlasOp ALayout, BlasOp BLayout>
-class GemmTunableOp : public TunableOp<GemmParams<T>, StreamTimer> {
+class GemmTunableOp : public TunableOp<GemmParams<T>> {
  public:
   GemmTunableOp() {
     this->RegisterOp(std::string("Default"), std::make_unique<DefaultGemmOp<T>>());
@@ -217,6 +216,8 @@ class GemmTunableOp : public TunableOp<GemmParams<T>, StreamTimer> {
       }
     }
 #endif
+
+    this->RegisterOp(std::string("Default"), std::make_unique<DefaultGemmOp<T>>());
   }
 
   std::string Signature() override {
@@ -225,7 +226,7 @@ class GemmTunableOp : public TunableOp<GemmParams<T>, StreamTimer> {
 };
 
 template <typename T, BlasOp ALayout, BlasOp BLayout>
-class GemmAndBiasTunableOp : public TunableOp<GemmAndBiasParams<T>, StreamTimer> {
+class GemmAndBiasTunableOp : public TunableOp<GemmAndBiasParams<T>> {
  public:
   GemmAndBiasTunableOp() {
     this->RegisterOp(std::string("Default"), std::make_unique<DefaultGemmAndBiasOp<T>>());
@@ -243,6 +244,8 @@ class GemmAndBiasTunableOp : public TunableOp<GemmAndBiasParams<T>, StreamTimer>
       }
     }
 #endif
+
+    this->RegisterOp(std::string("Default"), std::make_unique<DefaultGemmAndBiasOp<T>>());
   }
 
   std::string Signature() override {
@@ -251,7 +254,7 @@ class GemmAndBiasTunableOp : public TunableOp<GemmAndBiasParams<T>, StreamTimer>
 };
 
 template <typename T, BlasOp ALayout, BlasOp BLayout>
-class GemmStridedBatchedTunableOp : public TunableOp<GemmStridedBatchedParams<T>, StreamTimer> {
+class GemmStridedBatchedTunableOp : public TunableOp<GemmStridedBatchedParams<T>> {
  public:
   GemmStridedBatchedTunableOp() {
     this->RegisterOp(std::string("Default"), std::make_unique<DefaultGemmStridedBatchedOp<T>>());
@@ -276,6 +279,8 @@ class GemmStridedBatchedTunableOp : public TunableOp<GemmStridedBatchedParams<T>
       }
     }
 #endif
+
+    this->RegisterOp(std::string("Default"), std::make_unique<DefaultGemmStridedBatchedOp<T>>());
   }
 
   std::string Signature() override {
@@ -284,7 +289,7 @@ class GemmStridedBatchedTunableOp : public TunableOp<GemmStridedBatchedParams<T>
 };
 
 template <typename AT, typename BT, typename CT, BlasOp ALayout, BlasOp BLayout>
-class ScaledGemmTunableOp : public TunableOp<ScaledGemmParams<CT>, StreamTimer> {
+class ScaledGemmTunableOp : public TunableOp<ScaledGemmParams<CT>> {
  public:
   ScaledGemmTunableOp() {
     this->RegisterOp(std::string("Default"), std::make_unique<DefaultScaledGemmOp<CT>>());
@@ -294,6 +299,8 @@ class ScaledGemmTunableOp : public TunableOp<ScaledGemmParams<CT>, StreamTimer> 
       this->RegisterOp(std::move(name), std::move(op));
     }
 #endif
+
+    this->RegisterOp(std::string("Default"), std::make_unique<DefaultScaledGemmOp<CT>>());
   }
 
   std::string Signature() override {

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -155,6 +155,13 @@ class TunableOp {
       TuningContext* ctx = getTuningContext();
       bool do_flush = ctx->IsICacheFlushEnabled();
       StreamTimer timer{};
+
+      // Small Mandatory Warmup
+      // Reduces outliers
+      for (size_t i = 0; i < 2; i++) {
+        TORCH_CHECK(op->Call(param[(i+offset++)%param.size()]) == OK);
+      }
+
       timer.Start();
       for (size_t i = 0; i < num_iter; i++) {
         if (do_flush) {
@@ -170,6 +177,13 @@ class TunableOp {
       TuningContext* ctx = getTuningContext();
       bool do_flush = ctx->IsICacheFlushEnabled();
       std::vector<StreamTimerNoSync> timer(num_iter);
+
+      // Small Mandatory Warmup
+      // Reduces outliers
+      for (size_t i = 0; i < 2; i++) {
+        TORCH_CHECK(op->Call(param[(i+offset++)%param.size()]) == OK);
+      }
+
       for (size_t i = 0; i < num_iter; i++) {
         if (do_flush) {
           at::cuda::flush_icache();

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -273,7 +273,7 @@ class TunableOp {
         auto s = ProfileStats(candidate, reusable_params, approx_num_iter, offset);
         double approx_duration = s._mean;
         // bail if too slow
-        if (approx_duration > 2 * min_duration_ms) {
+        if (approx_duration > 1.5 * min_duration_ms) {
           TUNABLE_LOG3("├──skip slow instance id=", i, ", ", op_sig, '(', params_sig, ") ", op_names_[i]);
           continue;
         }

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -176,7 +176,7 @@ class TunableOp {
     static Stats ProfileStats(Callable<ParamsT> *op, const std::vector<ParamsT*> &param, size_t num_iter, size_t &offset) {
       TuningContext* ctx = getTuningContext();
       bool do_flush = ctx->IsICacheFlushEnabled();
-      std::vector<StreamTimerNoSync> timer(num_iter);
+      std::vector<StreamTimer> timer(num_iter);
 
       // Small Mandatory Warmup
       // Reduces outliers

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -278,6 +278,16 @@ class TunableOp {
           continue;
         }
 
+        // 2nd phase skip, more aggressive
+        approx_num_iter = 10;
+        s = ProfileStats(candidate, reusable_params, approx_num_iter, offset);
+        approx_duration = s._mean;
+        // bail if too slow
+        if (approx_duration > 1.15 * min_duration_ms) {
+          TUNABLE_LOG3("├──2nd skip slow instance id=", i, ", ", op_sig, '(', params_sig, ") ", op_names_[i]);
+          continue;
+        }
+
         // for warmup does user set max duration, max iters, or both?
         // warmup is allowed to be skipped by setting either iterations or duration to 0
         double max_warmup_duration = ctx->GetMaxWarmupDurationMs();

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -348,6 +348,13 @@ class TunableOp {
           min_stddev_ms = s_stddev;
           id_name = op_names_[i];
         }
+        else {
+          TUNABLE_LOG3("├──found slower instance id=", i, ". " , s._mean, "ms. ", op_names_[i],
+                " min ", s._min,
+                " max ", s._max,
+                " mean ", s._mean,
+                " std ", s_stddev);
+        }
       }
 
       for (size_t i = 0; i < reusable_params.size(); i++) {

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -327,7 +327,12 @@ class TunableOp {
         auto s_stddev = s.stddev();
         // Assume normal distribution.
         // Solution with smallest mean + 2*sigma will be a better solution
-        if ((s._mean + 2*s_stddev) < (min_duration_ms + 2*min_stddev_ms)) {
+        // Additionally, assume there is 15% overhead in the non-default code path.
+        auto alpha = 1.0;
+        if (i != 0 || i != op_names_.size()) { // Default is first and last solution tested
+          alpha = 1.15;
+        }
+        if (alpha*(s._mean + 2*s_stddev) < (min_duration_ms + 2*min_stddev_ms)) {
           TUNABLE_LOG3("├──found better instance id=", i, ". " , s._mean, "ms. ", op_names_[i],
                 " min ", s._min,
                 " max ", s._max,

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -269,8 +269,9 @@ class TunableOp {
         }
 
         // collect a small profile
-        constexpr const int approx_num_iter = 3;
-        auto approx_duration = ProfileSimple(candidate, reusable_params, approx_num_iter, offset);
+        int approx_num_iter = 3;
+        auto s = ProfileStats(candidate, reusable_params, approx_num_iter, offset);
+        double approx_duration = s._mean;
         // bail if too slow
         if (approx_duration > 2 * min_duration_ms) {
           TUNABLE_LOG3("├──skip slow instance id=", i, ", ", op_sig, '(', params_sig, ") ", op_names_[i]);

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -334,7 +334,7 @@ class TunableOp {
             "instance id=", i, ", ", op_sig, "(", params_sig, ") ", op_names_[i]);
         TUNABLE_LOG3("├──offset at ", offset);
         WarmUp(candidate, reusable_params, warmup_iter, offset);
-        auto s = ProfileStats(candidate, reusable_params, tuning_iter, offset);
+        s = ProfileStats(candidate, reusable_params, tuning_iter, offset);
         auto s_stddev = s.stddev();
         // Assume normal distribution.
         // Solution with smallest mean + 2*sigma will be a better solution

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -185,10 +185,10 @@ class TunableOp {
       }
 
       for (size_t i = 0; i < num_iter; i++) {
+        timer[i].Start();
         if (do_flush) {
           at::cuda::flush_icache();
         }
-        timer[i].Start();
         TORCH_CHECK(op->Call(param[(i+offset++)%param.size()]) == OK);
         timer[i].End();
       }

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -273,7 +273,7 @@ class TunableOp {
         constexpr const int approx_num_iter = 3;
         auto approx_duration = ProfileSimple(candidate, reusable_params, approx_num_iter, offset);
         // bail if too slow
-        if (approx_duration > 3 * min_duration_ms) {
+        if (approx_duration > 2 * min_duration_ms) {
           TUNABLE_LOG3("├──skip slow instance id=", i, ", ", op_sig, '(', params_sig, ") ", op_names_[i]);
           continue;
         }

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -327,12 +327,7 @@ class TunableOp {
         auto s_stddev = s.stddev();
         // Assume normal distribution.
         // Solution with smallest mean + 2*sigma will be a better solution
-        // Additionally, assume there is 15% overhead in the non-default code path.
-        auto alpha = 1.0;
-        if (i != 0 || i != op_names_.size()) { // Default is first and last solution tested
-          alpha = 1.15;
-        }
-        if (alpha*(s._mean + 2*s_stddev) < (min_duration_ms + 2*min_stddev_ms)) {
+        if ((s._mean + 2*s_stddev) < (min_duration_ms + 2*min_stddev_ms)) {
           TUNABLE_LOG3("├──found better instance id=", i, ". " , s._mean, "ms. ", op_names_[i],
                 " min ", s._min,
                 " max ", s._max,

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -193,6 +193,7 @@ class TunableOp {
       TUNABLE_LOG2("finding fastest for ", op_sig, '(', params_sig, ')', " out of ", op_names_.size(), " candidates");
       auto min_duration_ms = std::numeric_limits<double>::infinity();
       auto min_worst_ms = std::numeric_limits<double>::infinity();
+      auto min_stddev_ms = std::numeric_limits<double>::infinity();
       std::string id_name = "Default";
       ParamsT* reference_params = nullptr;
 
@@ -310,14 +311,16 @@ class TunableOp {
         TUNABLE_LOG3("├──offset at ", offset);
         WarmUp(candidate, reusable_params, warmup_iter, offset);
         auto s = ProfileStats(candidate, reusable_params, tuning_iter, offset);
-        if (s._mean < min_duration_ms && s._max < min_worst_ms) {
+        auto s_stddev = s.stddev();
+        if (s._mean < min_duration_ms && s._max < min_worst_ms && s_stddev < min_stddev_ms) {
           TUNABLE_LOG3("├──found better instance id=", i, ". " , s._mean, "ms. ", op_names_[i],
                 " min ", s._min,
                 " max ", s._max,
                 " mean ", s._mean,
-                " std ", s.stddev());
+                " std ", s_stddev);
           min_duration_ms = s._mean;
           min_worst_ms = s._max;
+          min_stddev_ms = s_stddev;
           id_name = op_names_[i];
         }
       }

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -154,7 +154,7 @@ class TunableOp {
     static double ProfileSimple(Callable<ParamsT> *op, const std::vector<ParamsT*> &param, size_t num_iter, size_t &offset) {
       TuningContext* ctx = getTuningContext();
       bool do_flush = ctx->IsICacheFlushEnabled();
-      StreamTimer timer{};
+      StreamTimerNoSync timer{};
 
       // Small Mandatory Warmup
       // Reduces outliers
@@ -176,7 +176,7 @@ class TunableOp {
     static Stats ProfileStats(Callable<ParamsT> *op, const std::vector<ParamsT*> &param, size_t num_iter, size_t &offset) {
       TuningContext* ctx = getTuningContext();
       bool do_flush = ctx->IsICacheFlushEnabled();
-      std::vector<StreamTimer> timer(num_iter);
+      std::vector<StreamTimerNoSync> timer(num_iter);
 
       // Small Mandatory Warmup
       // Reduces outliers

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -206,7 +206,6 @@ class TunableOp {
       auto params_sig = params->Signature();
       TUNABLE_LOG2("finding fastest for ", op_sig, '(', params_sig, ')', " out of ", op_names_.size(), " candidates");
       auto min_duration_ms = std::numeric_limits<double>::infinity();
-      auto min_stddev_ms = std::numeric_limits<double>::infinity();
       std::string id_name = "Default";
       ParamsT* reference_params = nullptr;
 
@@ -346,7 +345,6 @@ class TunableOp {
                 " mean ", s._mean,
                 " std ", s_stddev);
           min_duration_ms = s._mean;
-          min_stddev_ms = s_stddev;
           id_name = op_names_[i];
         }
         else {

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -337,8 +337,9 @@ class TunableOp {
         s = ProfileStats(candidate, reusable_params, tuning_iter, offset);
         auto s_stddev = s.stddev();
         // Assume normal distribution.
-        // Solution with smallest mean + 2*sigma will be a better solution
-        if ((s._mean + 2*s_stddev) < (min_duration_ms + 2*min_stddev_ms)) {
+        // Solution with smallest mean + 2*sigma will be a better solution?
+        // if ((s._mean + 2*s_stddev) < (min_duration_ms + 2*min_stddev_ms)) {
+        if (s._mean < min_duration_ms) {
           TUNABLE_LOG3("├──found better instance id=", i, ". " , s._mean, "ms. ", op_names_[i],
                 " min ", s._min,
                 " max ", s._max,

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -186,11 +186,11 @@ class TunableOp {
 
       for (size_t i = 0; i < num_iter; i++) {
         timer[i].Start();
+        TORCH_CHECK(op->Call(param[(i+offset++)%param.size()]) == OK);
+        timer[i].End();
         if (do_flush) {
           at::cuda::flush_icache();
         }
-        TORCH_CHECK(op->Call(param[(i+offset++)%param.size()]) == OK);
-        timer[i].End();
       }
       Stats s;
       for (size_t i = 0; i < num_iter; i++) {


### PR DESCRIPTION
This PR addresses some stability issues with identifying the fastest solution on AMD GPUs, particularly the MI300.

Changes include:
- An improved timer, StreamTimerNoSync
- More aggressive skipping of slow solutions
- Additional statistics that can be used for diagnostics PYTORCH_TUNABLEOP_VERBOSE=3

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang