### PR TITLE
fix acquire pattern in topk

### DIFF
--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -355,6 +355,8 @@ __global__ void radixFindKthValues(
 
   // accumulates counters from multiple blocks
   if (tidx < RADIX_DIGITS && blocks_per_slice > 1) {
+    // the reading thread needs to complete acquire pattern
+    __threadfence();
     digit_count = 0;
     for (int blk = 0; blk < blocks_per_slice; ++blk) {
       digit_count += counts[(slice_idx * blocks_per_slice + blk) * RADIX_DIGITS + tidx];


### PR DESCRIPTION
Similar to #128455, topk needs another threadfence to complete acquire pattern. 
