### PR TITLE
[BE] Add missing throw of `std::runtime_error` in scrc/cuda/utils.cpp

### DIFF
--- a/torch/csrc/cuda/utils.cpp
+++ b/torch/csrc/cuda/utils.cpp
@@ -34,7 +34,6 @@ THPUtils_PySequence_to_CUDAStreamList(PyObject* obj) {
     } else if (stream == Py_None) {
       streams.emplace_back();
     } else {
-      // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
       throw std::runtime_error(
           "Unknown data type found in stream list. Need torch.cuda.Stream or None");
     }

--- a/torch/csrc/cuda/utils.cpp
+++ b/torch/csrc/cuda/utils.cpp
@@ -35,7 +35,7 @@ THPUtils_PySequence_to_CUDAStreamList(PyObject* obj) {
       streams.emplace_back();
     } else {
       // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-      std::runtime_error(
+      throw std::runtime_error(
           "Unknown data type found in stream list. Need torch.cuda.Stream or None");
     }
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144962

