### PR TITLE
Update scipy, numba, pandas, numpy pins in CI

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -108,9 +108,8 @@ networkx==2.8.8
 #Pinned versions: 1.10.0.post1
 #test that import: run_test.py, test_cpp_extensions_aot.py,test_determination.py
 
-numba==0.49.0 ; python_version < "3.9"
-numba==0.55.2 ; python_version == "3.9"
-numba==0.55.2 ; python_version == "3.10"
+numba==0.58.1 ; python_version < "3.10"
+numba==0.60.0 ; python_version >= "3.10" and python_version < "3.13"
 #Description: Just-In-Time Compiler for Numerical Functions
 #Pinned versions: 0.54.1, 0.49.0, <=0.49.1
 #test that import: test_numba_integration.py
@@ -128,12 +127,12 @@ numba==0.55.2 ; python_version == "3.10"
 #test_nn.py, test_namedtensor.py, test_linalg.py, test_jit_cuda_fuser.py,
 #test_jit.py, test_indexing.py, test_datapipe.py, test_dataloader.py,
 #test_binary_ufuncs.py
-numpy==1.22.4; python_version == "3.9" or python_version == "3.10"
-numpy==1.26.2; python_version == "3.11" or python_version == "3.12"
+numpy==1.26.2; python_version < "3.10"
+numpy==2.0.2; python_version >= "3.10" and python_version < "3.13"
 numpy==2.1.2; python_version >= "3.13"
 
-pandas==2.0.3; python_version < "3.13"
-pandas==2.2.3; python_version >= "3.13"
+pandas==2.0.3; python_version < "3.10"
+pandas==2.2.3; python_version >= "3.10"
 
 #onnxruntime
 #Description: scoring engine for Open Neural Network Exchange (ONNX) models
@@ -233,8 +232,8 @@ pygments==2.15.0
 #Pinned versions: 10.9.0
 #test that import:
 
-scikit-image==0.19.3 ; python_version < "3.10"
-scikit-image==0.22.0 ; python_version >= "3.10"
+scikit-image==0.22.0 ; python_version < "3.10"
+scikit-image==0.24.0 ; python_version >= "3.10"
 #Description: image processing routines
 #Pinned versions:
 #test that import: test_nn.py
@@ -244,8 +243,8 @@ scikit-image==0.22.0 ; python_version >= "3.10"
 #Pinned versions: 0.20.3
 #test that import:
 
-scipy==1.10.1 ; python_version <= "3.11"
-scipy==1.14.1 ; python_version >= "3.12"
+scipy==1.12.0 ; python_version < "3.10"
+scipy==1.13.1 ; python_version >= "3.10"
 # Pin SciPy because of failing distribution tests (see #60347)
 #Description: scientific python
 #Pinned versions: 1.10.1


### PR DESCRIPTION
### Summary

Test with the following configuration

For python<3.10

 - numba 0.58.1, numpy 1.26.2, pandas 2.0.3, scipy 1.12.0, scikit-image 0.22.0

For python>=3.10

 - numba 0.60.0, numpy 2.0.2, pandas 2.2.3, scipy 1.13.1, scikit-image 0.24.0


### Test Plan

- Tried locally with various conda environments (python 3.9, 3.10, 3.11)

- Waiting for CI