### PR TITLE
Document decoupled_weight_decay for Adam for consistency with N/RAdam

### DIFF
--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -319,6 +319,9 @@ Adam.__doc__ = (
         eps (float, optional): term added to the denominator to improve
             numerical stability (default: 1e-8)
         weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
+        decoupled_weight_decay (bool, optional): if True, this optimizer is
+            equivalent to AdamW and the algorithm will not accumulate weight
+            decay in the momentum nor variance. (default: False)
         amsgrad (bool, optional): whether to use the AMSGrad variant of this
             algorithm from the paper `On the Convergence of Adam and Beyond`_
             (default: False)


### PR DESCRIPTION
Followup from #144972 and #143710

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144984

