### PR TITLE
Fix `pt2-bug-report.yml` formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: >
-      #### Note: Please write your bug report in English to ensure it can be understood and addressed by the development team.
+        #### Note: Please write your bug report in English to ensure it can be understood and addressed by the development team.
   - type: markdown
     attributes:
       value: >

--- a/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
@@ -6,8 +6,11 @@ body:
   - type: markdown
     attributes:
       value: >
-        #### Note: Please write your bug report in English to ensure it can be understood and addressed by the development team.
+      #### Note: Please write your bug report in English to ensure it can be understood and addressed by the development team.
 
+  - type: markdown
+    attributes:
+      value: >
         #### Before submitting a bug, please make sure the issue hasn't been already addressed by searching through [the
         existing and past issues](https://github.com/pytorch/pytorch/issues)
         It's likely that your bug will be resolved by checking our FAQ or troubleshooting guide [documentation](https://pytorch.org/docs/main/dynamo/index.html)

--- a/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
@@ -7,6 +7,7 @@ body:
     attributes:
       value: >
       #### Note: Please write your bug report in English to ensure it can be understood and addressed by the development team.
+
   - type: markdown
     attributes:
       value: >

--- a/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
@@ -7,7 +7,6 @@ body:
     attributes:
       value: >
       #### Note: Please write your bug report in English to ensure it can be understood and addressed by the development team.
-
   - type: markdown
     attributes:
       value: >

--- a/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
@@ -6,11 +6,8 @@ body:
   - type: markdown
     attributes:
       value: >
-      #### Note: Please write your bug report in English to ensure it can be understood and addressed by the development team.
+        #### Note: Please write your bug report in English to ensure it can be understood and addressed by the development team.
 
-  - type: markdown
-    attributes:
-      value: >
         #### Before submitting a bug, please make sure the issue hasn't been already addressed by searching through [the
         existing and past issues](https://github.com/pytorch/pytorch/issues)
         It's likely that your bug will be resolved by checking our FAQ or troubleshooting guide [documentation](https://pytorch.org/docs/main/dynamo/index.html)


### PR DESCRIPTION
This is a 2nd regression caused by https://github.com/pytorch/pytorch/pull/144574

Test plan: `python3 -c "import yaml; foo=yaml.safe_load(open('pt2-bug-report.yml'));print(foo['body'][0])"`
Before it printed
```
% python3 -c "import yaml; foo=yaml.safe_load(open('pt2-bug-report.yml'));print(foo['body'][0])"
{'type': 'markdown', 'attributes': {'value': ''}}
```
After
```
% python3 -c "import yaml; foo=yaml.safe_load(open('pt2-bug-report.yml'));print(foo['body'][0])"
{'type': 'markdown', 'attributes': {'value': '#### Note: Please write your bug report in English to ensure it can be understood and addressed by the development team.\n'}}
```

Fixes https://github.com/pytorch/pytorch/issues/144970
