### PR TITLE
[Pipelining] Relax scale_grads assert

### DIFF
--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -586,9 +586,15 @@ class _PipelineStageBase(ABC):
         # PP scales only for its own contribution (microbatches), but relies on DP to scale further
         # for DP degree.
         if grad_scale_factor != 1:
-            for name, p in self.submod.named_parameters():
-                assert p.grad is not None, name
-                p.grad.div_(grad_scale_factor)
+            scaled_any = False
+            for p in self.submod.parameters():
+                if p.grad is not None:
+                    p.grad.div_(grad_scale_factor)
+                    scaled_any = True
+            assert scaled_any, (
+                "No gradients found for any parameter, "
+                "this is likely a composability bug between pipelining and something else."
+            )
 
     def backward_maybe_with_nosync(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

The assert is morally valid- if no gradients are scaled, then something
is definitely wrong with the setup.  In one instance, PP +
optimizer-in-backward (in torchtitan) resulted in grad=None after
running .backward() and before scaling grads.  This is obviously not a
correct scenario.

On the other hand, the existing assert is too restrictive.  It's
possible that a model used with pipelining would have some parameters
that do not receieve gradients, and we shouldn't hard-error in these
cases.  (E.g. if the parameter is literally not used, or is frozen).

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @d4l3k @c-p-i-o