### PR TITLE
[inductor] fix TORCH_LOGS="benchmarking"

### DIFF
--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -34,7 +34,7 @@ def maybe_time(
     @wraps(fn)
     def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> T:
         start_t = time.perf_counter()
-        result = fn(*args, **kwargs)
+        result = fn(self, *args, **kwargs)
         logger.debug(
             "Call `benchmarking.%s.%s(*args=%r, **kwargs=%r)` took %f milliseconds.",
             self.__class__.__name__,


### PR DESCRIPTION
Saw this error with TORCH_LOGS="benchmarking"
```
  File "/data/users/colinpeppler/pytorch/torch/_inductor/runtime/benchmarking.py", line 37, in wrapper
    result = fn(*args, **kwargs)
  File "/data/users/colinpeppler/pytorch/torch/_inductor/runtime/benchmarking.py", line 66, in wrapper
    return fn(self, *args, **kwargs)
torch._inductor.exc.InductorError: TypeError: Benchmarker.benchmark() missing 1 required positional argument: 'fn_kwargs'
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #144997



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang @aakhundov