### PR TITLE
Check bounds for index select to match CPU behavior

### DIFF
--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -600,6 +600,10 @@ Tensor& index_select_out_mps(const Tensor& self, int64_t dim, const Tensor& inde
               output.size(dim),
               ".");
 
+  auto dim_size = self.size(dim);
+  auto within_range = index.max().less(dim_size).item().toBool();
+  TORCH_CHECK_INDEX(within_range, "index out of range in self");
+
   for (const auto i : irange(self.dim())) {
     if (i == dim)
       continue;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7502,6 +7502,13 @@ class TestMPS(TestCaseMPS):
         with self.assertRaisesRegex(RuntimeError, "Index to scalar can have only 1 value"):
             helper(22, 0, [])
 
+    # From https://github.com/pytorch/pytorch/issues/144824
+    def test_index_select_bounds(self):
+        with self.assertRaisesRegex(IndexError, "index out of range in self"):
+            embed = nn.Embedding(10, 2).to('mps')
+            t = torch.tensor(10).to('mps')
+            embed(t)
+
     def test_embedding_dense_backward(self):
         def helper(n, d, m, idx):
             embeddingMPS = nn.Embedding(n, d, max_norm=True, device='mps')


### PR DESCRIPTION
Fixes #144824

Checks that there is no element in the index tensor is less than zero or more than number of elements in available on the axis. MPSGraph is not performing this check but instead silently returns zeros for out of bounds elements which differs from expectations set by the CPU behavior.