### PR TITLE
upgrade to sccache 0.9.1 - dealing with nvcc -E correctly

### DIFF
--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -9,7 +9,7 @@ install_ubuntu() {
   # Instead use lib and headers from OpenSSL1.1 installed in `install_openssl.sh``
   apt-get install -y cargo
   echo "Checking out sccache repo"
-  git clone https://github.com/mozilla/sccache -b v0.9.0
+  git clone https://github.com/mozilla/sccache -b v0.9.1
   cd sccache
   echo "Building sccache"
   cargo build --release


### PR DESCRIPTION
sccache 0.9.1 should be dealing with `nvcc -E` correctly

see https://github.com/mozilla/sccache/pull/2300

If this works as expected, we can get rid of this code: 
https://github.com/pytorch/pytorch/pull/142813/files

cc @malfet 