### PR TITLE
easy: Fix missing tab in test/dynamo/test_compile.py

### DIFF
--- a/test/dynamo/test_compile.py
+++ b/test/dynamo/test_compile.py
@@ -175,7 +175,7 @@ class InPlaceCompilationTests(TestCase):
 
         x = torch.randn(10, 10)
         with self.assertRaises(NameError):
-        fn(x)
+            fn(x)
 
     def test_compilation_tensor_invalid_method(self):
         @torch.compile(backend="eager")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145013

It turns out that if you request a merge on a pytorch PR, and then push a fix for a bad rebase, and the test is
relativley new, the merge will go through with the previous commit and not notice the test break.

Explicitly running the test now passes vs failing, and this is just the last missing commit from https://github.com/pytorch/pytorch/pull/144817

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames