### PR TITLE
[MPSInductor] Add `Worker.current_device` method

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -42,6 +42,7 @@ class MPSBasicTests(TestCase):
     test_add_const_int = CommonTemplate.test_add_const_int
     test_add_inplace_permuted_mps = CommonTemplate.test_add_inplace_permuted
     test_addmm = CommonTemplate.test_addmm
+    test_arange5 = CommonTemplate.test_arange5
     test_argmax_min_int32 = CommonTemplate.test_argmax_min_int32
     test_avg_pool2d5 = CommonTemplate.test_avg_pool2d5
     test_avg_pool2d8 = CommonTemplate.test_avg_pool2d8

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -382,6 +382,10 @@ class MpsInterface(DeviceInterface):
         def get_device_properties(device: _device_t = None):
             return {}
 
+        @staticmethod
+        def current_device():
+            return 0
+
 
 device_interfaces: Dict[str, Type[DeviceInterface]] = {}
 _device_initialized = False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145023

That just returns 0, as multi-gpu is not currently supported by MPS

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov