### PR TITLE
Implement a storage reader and writer for HuggingFace

### DIFF
--- a/docs/source/distributed.checkpoint.rst
+++ b/docs/source/distributed.checkpoint.rst
@@ -90,6 +90,14 @@ We provide a filesystem based storage layer:
 .. autoclass:: torch.distributed.checkpoint.FileSystemWriter
   :members:
 
+We provide a storage layer that interacts with HuggingFace:
+
+.. autoclass:: torch.distributed.checkpoint.HuggingFaceHubReader
+  :members:
+
+.. autoclass:: torch.distributed.checkpoint.HuggingFaceHubWriter
+  :members:
+
 We provide default implementations of `LoadPlanner` and `SavePlanner` that
 can handle all of torch.distributed constructs such as FSDP, DDP, ShardedTensor and DistributedTensor.
 

--- a/test/distributed/checkpoint/test_hugging_face_storage.py
+++ b/test/distributed/checkpoint/test_hugging_face_storage.py
@@ -1,0 +1,100 @@
+import io
+import tempfile
+from unittest.mock import ANY, patch
+
+import torch
+from torch.distributed.checkpoint._hugging_face_storage import (
+    _StorageInfo,
+    _StoragePrefix,
+    HuggingFaceHubReader,
+    HuggingFaceHubWriter,
+)
+from torch.distributed.checkpoint.default_planner import (
+    DefaultLoadPlanner,
+    DefaultSavePlanner,
+)
+from torch.distributed.checkpoint.metadata import (
+    BytesStorageMetadata,
+    Metadata,
+    MetadataIndex,
+)
+from torch.distributed.checkpoint.planner import (
+    LoadPlan,
+    SavePlan,
+)
+from torch.distributed.checkpoint.planner_helpers import (
+    _create_read_items,
+    _create_write_item_for_tensor,
+)
+from torch.distributed.checkpoint.storage import WriteResult
+from torch.testing._internal.common_utils import TestCase
+
+
+class TestHuggingFaceStorage(TestCase):
+    @patch("huggingface_hub.HfApi.upload_file")
+    @patch("huggingface_hub.create_repo")
+    def test_write_data_hf(self, _mock_create_repo, mock_upload_file) -> None:
+        repo_id = "test_repo_id"
+        writer = HuggingFaceHubWriter(
+            repo_id=repo_id,
+        )
+
+        tensor0 = torch.rand(4)
+        tensor1 = torch.rand(10)
+        write_item_1 = _create_write_item_for_tensor("tensor_0", tensor0)
+        write_item_2 = _create_write_item_for_tensor("tensor_1", tensor1)
+
+        state_dict = {"tensor_0": tensor0, "tensor_1": tensor1}
+
+        save_plan = SavePlan([write_item_1, write_item_2], storage_data=_StoragePrefix("test"))
+        save_planner = DefaultSavePlanner()
+        save_planner.set_up_planner(state_dict=state_dict)
+
+        write_results = writer.write_data(save_plan, save_planner)
+
+        mock_upload_file.assert_any_call(
+                    path_or_fileobj=ANY,
+                    path_in_repo="test0.distcp",
+                    repo_id=repo_id,
+                    repo_type="model",
+                    token=None,)
+
+        write_results.wait()
+        actual_write_results = write_results.value()
+        
+        expected_write_results = [WriteResult(index=MetadataIndex(fqn='tensor_0', offset=torch.Size([0]), index = None), size_in_bytes=ANY,
+        storage_data=_StorageInfo(relative_path="test0.distcp", offset=0, length=ANY)),
+         WriteResult(index=MetadataIndex(fqn='tensor_1', offset=torch.Size([0]), index = None), size_in_bytes=ANY,
+        storage_data=_StorageInfo(relative_path="test0.distcp", offset=ANY, length=ANY))]
+        
+        self.assertEqual(actual_write_results, expected_write_results)
+
+    @patch("huggingface_hub.snapshot_download")
+    def test_read_data_hf(self, mock_snapshot_download) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            mock_snapshot_download.return_value = temp_dir
+
+            reader = HuggingFaceHubReader(repo_id="test_repo_id")
+            name = "blob_0"
+            bytes_data_write = b"blob 0 text"
+            with open(f"{temp_dir}/{name}.txt", "wb") as file:
+                torch.save(bytes_data_write, file)
+
+            metadata_index = MetadataIndex(fqn='blob_0', offset=None, index=None)
+            reader.set_up_storage_reader(
+                Metadata(
+                    state_dict_metadata = {name: BytesStorageMetadata()},
+                    storage_data={metadata_index: _StorageInfo(relative_path="blob_0.txt", offset=0, length=864)}),
+                is_coordinator=True)
+
+            
+            read_items = _create_read_items(name, BytesStorageMetadata(), name + ".txt")
+            load_plan = LoadPlan(read_items)
+            load_planner = DefaultLoadPlanner()
+            load_planner.set_up_planner(state_dict={name: io.BytesIO()})
+
+            read_data = reader.read_data(load_plan, load_planner)
+            read_data.wait()
+
+            loaded_blob = load_planner.original_state_dict[name]
+            self.assertEqual(loaded_blob, bytes_data_write)

--- a/torch/distributed/checkpoint/__init__.py
+++ b/torch/distributed/checkpoint/__init__.py
@@ -1,6 +1,7 @@
 from .api import CheckpointException
 from .default_planner import DefaultLoadPlanner, DefaultSavePlanner
 from .filesystem import FileSystemReader, FileSystemWriter
+from ._hugging_face_storage import HuggingFaceHubReader, HuggingFaceHubWriter
 from .metadata import (
     BytesStorageMetadata,
     ChunkStorageMetadata,

--- a/torch/distributed/checkpoint/_hugging_face_storage.py
+++ b/torch/distributed/checkpoint/_hugging_face_storage.py
@@ -1,0 +1,369 @@
+import dataclasses
+import io
+import pickle
+import queue
+import threading
+import uuid
+import warnings
+from dataclasses import dataclass
+from typing import Any, cast, IO, List, Optional, Union
+
+import torch
+from torch.distributed.checkpoint import FileSystemReader
+from torch.distributed.checkpoint.filesystem import (
+    _item_size,
+    _OverlappingCpuLoader,
+    _SerialCpuLoader,
+    _split_by_size_and_type,
+    _TensorLoader,
+)
+from torch.distributed.checkpoint.metadata import Metadata, StorageMeta
+from torch.distributed.checkpoint.planner import (
+    SavePlan,
+    SavePlanner,
+    WriteItem,
+    WriteItemType,
+)
+from torch.distributed.checkpoint.storage import StorageWriter, WriteResult
+from torch.futures import Future
+
+
+__all__ = ["HuggingFaceWriter", "HuggingFaceReader"]
+
+_metadata_fn: str = ".metadata"
+
+@dataclass
+class _StorageInfo:
+    """This is the per entry storage info."""
+
+    relative_path: str
+    offset: int
+    length: int
+
+
+@dataclass
+class _StoragePrefix:
+    prefix: str
+
+DEFAULT_SUFFIX = ".distcp"
+
+def _generate_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+class HuggingFaceHubWriter(StorageWriter):
+    """
+    Basic implementation of StorageWriter using file IO.
+
+    This implementation makes the following assumptions and simplifications:
+
+    * The checkpoint path is an empty or non-existing directory.
+    * File creation is atomic
+
+    The checkpoint consist of one file per write request plus
+    a `.metadata` file with the serialized metadata.
+
+    """
+
+    def __init__(
+        self,
+        repo_id: str,
+        single_file_per_rank: bool = True,
+        thread_count: int = 1,
+        per_thread_copy_ahead: int = 10_000_000,
+        overwrite: bool = False,
+        token: Optional[str] = None,
+        private: bool = False,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Initialize the huggingface writer for repo_id.
+
+        Args:
+            repo_id: huggingface repo where the checkpoint will be written to.
+            single_file_per_rank: Produce one file per rank instead of one file per tensor/blob. Default to True.
+            thread_count: Number of IO threads to use to write. Default to 1.
+            per_thread_copy_ahead: How many bytes to copy from the GPU ahead of saving then. Default 10Mb.
+            overwrite: Whether to allow overwriting existing checkpoints. Defaults to True.
+            token: The token to use to authenticate with the huggingface hub.
+            private: Whether to create a private repo. Defaults to False.
+        """
+        super().__init__()
+
+        import huggingface_hub
+
+        self.api = huggingface_hub.HfApi()
+        huggingface_hub.create_repo(repo_id, token=token, exist_ok = overwrite, private=private)
+        self.repo_id = repo_id
+        self.single_file_per_rank = single_file_per_rank
+        self.thread_count = thread_count
+        self.per_thread_copy_ahead = per_thread_copy_ahead
+        self.save_id = _generate_uuid()
+        self.overwrite = overwrite
+        self.token = token
+        self.private = private
+
+    def reset(self, repo_id: Union[str, None] = None) -> None:
+        from huggingface_hub import create_repo
+        
+        self.save_id = _generate_uuid()
+        if repo_id:
+            self.repo_id = create_repo(repo_id, token=self.token, exist_ok =self.overwrite, private=self.private).repo_id
+
+    def set_up_storage_writer(self, is_coordinator: bool) -> None:
+        pass
+
+    def prepare_local_plan(self, plan: SavePlan) -> SavePlan:
+        if self.api.file_exists(repo_id=self.repo_id, filename=self.metadata_path):
+            if self.overwrite:
+                warnings.warn(
+                    f"Detected an existing checkpoint in {self.metadata_path}, overwriting since {self.overwrite=}."
+                )
+            else:
+                raise RuntimeError(f"Checkpoint already exists and {self.overwrite=}.")
+
+        return plan
+
+    def prepare_global_plan(self, plans: List[SavePlan]) -> List[SavePlan]:
+        new_plans = [
+            dataclasses.replace(plan, storage_data=_StoragePrefix(f"__{i}_"))
+            for i, plan in enumerate(plans)
+        ]
+        return new_plans
+
+    def write_data(
+        self,
+        plan: SavePlan,
+        planner: SavePlanner,
+    ) -> Future[List[WriteResult]]:
+        storage_plan: _StoragePrefix = plan.storage_data
+        file_count = 0
+
+        def gen_file():
+            nonlocal file_count
+            file_name = f"{storage_plan.prefix}{file_count}{DEFAULT_SUFFIX}"
+            file_count += 1
+            return file_name
+
+        file_queue: queue.Queue = queue.Queue()
+        if self.single_file_per_rank:
+            for bucket in _split_by_size_and_type(self.thread_count, plan.items):
+                file_name = gen_file()
+                file_queue.put((file_name, bucket))
+        else:
+            for item in plan.items:
+                file_name = gen_file()
+                file_queue.put((file_name, [item]))
+
+        result_queue: queue.Queue = queue.Queue()
+
+        threads = []
+        for _ in range(1, self.thread_count):
+            t = threading.Thread(
+                target=self._write_files_from_queue,
+                args=(
+                    file_queue,
+                    result_queue,
+                    planner,
+                    self.per_thread_copy_ahead,
+                    self.thread_count,
+                ),
+            )
+            t.start()
+            threads.append(t)
+
+        self._write_files_from_queue(
+            file_queue=file_queue,
+            result_queue=result_queue,
+            planner=planner,
+            inflight_threshhold=self.per_thread_copy_ahead,
+            thread_count=self.thread_count,
+        )
+
+        for t in threads:
+            t.join()
+
+        res = []
+        try:
+            while True:
+                res += result_queue.get_nowait()
+        except queue.Empty:
+            fut: Future[List[WriteResult]] = Future()
+            fut.set_result(res)
+            return fut
+
+    def _write_files_from_queue(
+        self,
+        file_queue: queue.Queue,
+        result_queue: queue.Queue,
+        planner: SavePlanner,
+        inflight_threshhold: int,
+        thread_count: int,
+) -> None:
+        try:
+            while True:
+                file_name, write_items = file_queue.get_nowait()
+                loader: _TensorLoader
+
+                custom_backend_name = torch._C._get_privateuse1_backend_name()
+                custom_device_mod = getattr(torch, custom_backend_name, None)
+
+                # TODO: Using the OverlappingCpuLoader with multiple threads creates significant
+                # performance degredation, observed as being related to cuda stream syncs. We
+                # should try to fix this and use _OverlappingCpuLoader for all threaded cases
+                if (
+                thread_count == 1
+                and (
+                    torch.cuda.is_available()
+                    or (custom_device_mod and custom_device_mod.is_available())
+                )
+                and inflight_threshhold > 0
+                ):
+                    loader = _OverlappingCpuLoader(
+                    planner.resolve_data,
+                    inflight_threshhold=inflight_threshhold,
+                    )
+                else:
+                    loader = _SerialCpuLoader(
+                    planner.resolve_data,
+                    )
+
+                tensor_w = [wi for wi in write_items if wi.type != WriteItemType.BYTE_IO]
+                for write_item in tensor_w:
+                    loader.add(_item_size(write_item), write_item)
+                loader.start_loading()
+
+                bytes_w = [wi for wi in write_items if wi.type == WriteItemType.BYTE_IO]
+                write_results = []
+
+                bytes_io = io.BytesIO()
+
+                for write_item in bytes_w:
+                    data = planner.resolve_data(write_item)
+                    write_results.append(
+                        self._write_item(bytes_io, data, write_item, file_name)
+                    )
+
+                for tensor, write_item in loader.values():
+                    assert tensor.is_cpu
+                    write_results.append(
+                    self._write_item(bytes_io, tensor, write_item, file_name,)
+                    )
+                
+                self.api.upload_file(
+                    path_or_fileobj=bytes_io,
+                    path_in_repo=file_name,
+                    repo_id=self.repo_id,
+                    repo_type="model",
+                    token=self.token,
+                )
+                result_queue.put(write_results)
+        except queue.Empty:
+            pass
+
+    def _write_item(
+        self,
+        bytes_io: io.BytesIO,
+        data: Union[io.BytesIO, torch.Tensor],
+        write_item: WriteItem,
+        storage_key: str,
+    ) -> WriteResult:
+        offset  = bytes_io.tell()
+        if write_item.type == WriteItemType.BYTE_IO:
+            assert isinstance(data, io.BytesIO)
+            bytes_io.write(data.getbuffer())
+        else:
+            assert isinstance(data, torch.Tensor)
+            assert data.device == torch.device("cpu")
+
+            torch.save(data, cast(IO[bytes], bytes_io))
+
+        length = bytes_io.tell() - offset
+            
+        return WriteResult(
+            index=write_item.index,
+            size_in_bytes=length,
+            storage_data=_StorageInfo(storage_key, offset, length),
+        )
+
+
+    def finish(self, metadata: Metadata, results: List[List[WriteResult]]) -> None:
+        storage_md = {}
+        for wr_list in results:
+            storage_md.update({wr.index: wr.storage_data for wr in wr_list})
+        metadata.storage_data = storage_md
+
+        metadata.storage_meta = self.storage_meta()
+
+        metadata_bytes_io = io.BytesIO()
+        pickle.dump(metadata, metadata_bytes_io)
+
+        self.api.upload_file(
+            path_or_fileobj=metadata_bytes_io,
+            path_in_repo=self.metadata_path,
+            repo_id=self.repo_id,
+            repo_type="model",
+            token=self.token,
+        )
+           
+
+    def storage_meta(self) -> Optional[StorageMeta]:
+        return StorageMeta(checkpoint_id=self.checkpoint_id, save_id=self.save_id)
+
+    @property
+    def checkpoint_id(self) -> str:
+        """
+        return the checkpoint_id that will be used to save the checkpoint.
+        """
+        return self.repo_id
+
+    @property
+    def metadata_path(self) -> str:
+        return _metadata_fn
+
+    @classmethod
+    def validate_checkpoint_id(cls, checkpoint_id: str) -> bool:
+        import huggingface_hub
+        
+        return huggingface_hub.HfApi().repo_exists(checkpoint_id)
+
+
+class HuggingFaceHubReader(FileSystemReader):
+   
+    def __init__(self, repo_id: str, token : Optional[str] = None) -> None:
+        """
+        Initialize the huggingface reader for repo_id.
+
+        Args:
+            repo_id: huggingface repo where the checkpoint will be read from.
+            token: The token to use to authenticate with the huggingface hub.
+        """
+
+        from huggingface_hub import snapshot_download
+        
+        self.repo_id = repo_id
+        self.path = snapshot_download(self.repo_id, token=token)
+        super().__init__(path=self.path)
+
+    def reset(self, repo_id: Union[str, None] = None) -> None:
+        from huggingface_hub import snapshot_download
+
+        self.storage_data = {}
+        if repo_id:
+            self.repo_id = repo_id
+            self.path = snapshot_download(self.repo_id)
+        self.load_id = _generate_uuid()
+
+    @property
+    def checkpoint_id(self) -> str:
+        """
+        return the checkpoint_id that will be used to load the checkpoint.
+        """
+        return self.repo_id
+
+    @classmethod
+    def validate_checkpoint_id(cls, checkpoint_id: str) -> bool:
+        import huggingface_hub
+       
+        return huggingface_hub.HfApi().repo_exists(checkpoint_id)

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -385,13 +385,17 @@ class FileSystem(FileSystemBase):
     def create_stream(
         self, path: Union[str, os.PathLike], mode: str
     ) -> Generator[io.IOBase, None, None]:
-        with cast(Path, path).open(mode) as stream:
+        if not isinstance(path, Path):
+            path = Path(path)
+        with path.open(mode) as stream:
             yield cast(io.IOBase, stream)
 
     def concat_path(
         self, path: Union[str, os.PathLike], suffix: str
     ) -> Union[str, os.PathLike]:
-        return cast(Path, path) / suffix
+        if not isinstance(path, Path):
+            path = Path(path)
+        return path / suffix
 
     def init_path(self, path: Union[str, os.PathLike]) -> Union[str, os.PathLike]:
         if not isinstance(path, Path):


### PR DESCRIPTION
Summary: Currently for torchtune users have to download and upload to hugging face manually since our existing storage reader/writer only reads locally. This new storage writer can work with hugging face directly

Test Plan:
N6381603 shows the functionality working of saving and loading a checkpoint working end to end with the hugging face reader and writer.

buck2 test fbcode//mode/opt fbcode//caffe2/test/distributed/checkpoint:test_hugging_face_storage
File changed: fbcode//caffe2/test/distributed/checkpoint/test_hugging_face_storage.py
Buck UI: https://www.internalfb.com/buck2/4f13eb8c-8171-47cc-bfcf-07694204ad49
Test UI: https://www.internalfb.com/intern/testinfra/testrun/844425328401897
Network: Up: 0B  Down: 0B  (reSessionID-694b7fb8-00cc-4902-b3ef-6402eba81677)
Executing actions. Remaining     0/2                                                                                          0.1s exec time total
Command: test.     Finished 1 local                                                                                                                                                                
Time elapsed: 33.1s
Tests finished: Pass 2. Fail 0. Fatal 0. Skip 0. Build failure 0

Differential Revision: D67407067




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn @ekr0