### PR TITLE
[Break XPU][Inductor UT] Skip newly added test case `test__int_mm` for XPU

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -4196,6 +4196,7 @@ class AOTInductorTestsTemplate:
                 dynamic_shapes=dynamic_shapes,
             )
 
+    @skipIfXpu(msg="The operator 'aten::_int_mm' is not currently implemented for the XPU device")
     def test__int_mm(self):
         class Model(torch.nn.Module):
             def __init__(self) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #145039
* #145055
* #145038
* __->__ #145037
* #145036

Skip as int mm not implemented for XPU.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov