### PR TITLE
[Break XPU][Inductor UT] Generalize device bias code newly added in test_async_compile.py

### DIFF
--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -8,7 +8,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
 )
-from torch.testing._internal.inductor_utils import requires_gpu, requires_triton
+from torch.testing._internal.inductor_utils import requires_gpu, requires_triton, GPU_TYPE
 
 
 @instantiate_parametrized_tests
@@ -20,8 +20,8 @@ class TestAsyncCompile(TestCase):
         def fn(x, y):
             return x + y
 
-        x = torch.rand(10).cuda()
-        y = torch.rand(10).cuda()
+        x = torch.rand(10).to(GPU_TYPE)
+        y = torch.rand(10).to(GPU_TYPE)
 
         with config.patch("worker_start_method", method):
             shutdown_compile_workers()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #145039
* #145055
* __->__ #145038
* #145037
* #145036

As title.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov