### PR TITLE
Fix document for tensorboard

### DIFF
--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -61,7 +61,7 @@ class FileWriter:
           log_dir: A string. Directory where event file will be written.
           max_queue: Integer. Size of the queue for pending events and
             summaries before one of the 'add' calls forces a flush to disk.
-            Default is ten items.
+            Default is 10 bytes.
           flush_secs: Number. How often, in seconds, to flush the
             pending events and summaries to disk. Default is every two minutes.
           filename_suffix: A string. Suffix added to all event filenames
@@ -205,7 +205,7 @@ class SummaryWriter:
               Note that crashed and resumed experiments should have the same ``log_dir``.
             max_queue (int): Size of the queue for pending events and
               summaries before one of the 'add' calls forces a flush to disk.
-              Default is ten items.
+              Default is 10 bytes.
             flush_secs (int): How often, in seconds, to flush the
               pending events and summaries to disk. Default is every two minutes.
             filename_suffix (str): Suffix added to all event filenames in


### PR DESCRIPTION
Change 10 items to 10 bytes.

In tensorboard document:

https://github.com/tensorflow/tensorboard/blob/862a9da9b6b8dd5523b829278eb57648cd060e34/tensorboard/summary/writer/event_file_writer.py#L54-L70

and their implementation:

https://github.com/tensorflow/tensorboard/blob/862a9da9b6b8dd5523b829278eb57648cd060e34/tensorboard/summary/writer/event_file_writer.py#L156-L160

the queue size is number of bytes, not items.