### PR TITLE
Update test_c10d_object_collectives.py with DistributedTestBase class

### DIFF
--- a/test/distributed/test_c10d_object_collectives.py
+++ b/test/distributed/test_c10d_object_collectives.py
@@ -2,139 +2,117 @@
 
 import os
 import sys
-from functools import partial, wraps
+from functools import wraps, partial
 
 import torch
 import torch.distributed as dist
-
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
-from torch.testing._internal.common_distributed import MultiProcessTestCase, TEST_SKIPS
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_distributed import (
+    MultiProcessTestCase,
+    skip_if_lt_x_gpu,
+    DistributedTestBase,
+    TEST_SKIPS,
+)
 
+
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+    TEST_CUDA,
+    TEST_HPU,
+    skipIfHpu
+)
 
 if TEST_WITH_DEV_DBG_ASAN:
-    print(
-        "Skip dev-asan as torch + multiprocessing spawn have known issues",
-        file=sys.stderr,
-    )
+    print("Skip dev-asan as torch + multiprocessing spawn have known issues", file=sys.stderr)
     sys.exit(0)
 
-BACKEND = dist.Backend.NCCL if torch.cuda.is_available() else dist.Backend.GLOO
+if TEST_HPU:
+    BACKEND = dist.Backend.HCCL
+    device_count = torch.hpu.device_count()
+    DEVICE = "hpu"
+elif TEST_CUDA:
+    BACKEND = dist.Backend.NCCL 
+    device_count = torch.cuda.device_count()
+    DEVICE = "cuda"
+else :
+    BACKEND = dist.Backend.GLOO
+    DEVICE = "cpu"
+
+
+WORLD_SIZE = min(4, max(2, device_count))
 
 
 def with_comms(func=None):
     if func is None:
-        return partial(
-            with_comms,
-        )
+        return partial(with_comms)
 
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         if BACKEND == dist.Backend.NCCL and torch.cuda.device_count() < self.world_size:
             sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
-        self.dist_init()
-        func(self)
-        self.destroy_comms()
+
+        kwargs["device"] = DEVICE
+        self.pg = self.create_pg(device=DEVICE)
+        try:
+            return func(self, *args, **kwargs)
+        finally:
+            torch.distributed.destroy_process_group()
 
     return wrapper
 
+class TestObjectCollectives(DistributedTestBase):
 
-class TestObjectCollectives(MultiProcessTestCase):
-    def setUp(self):
-        super().setUp()
-        os.environ["WORLD_SIZE"] = str(self.world_size)
-        os.environ["BACKEND"] = BACKEND
-        self._spawn_processes()
-
-    @property
-    def device(self):
-        return (
-            torch.device("cuda", self.rank % torch.cuda.device_count())
-            if BACKEND == dist.Backend.NCCL
-            else torch.device("cpu")
-        )
-
-    @property
-    def world_size(self):
-        if BACKEND == dist.Backend.NCCL:
-            return torch.cuda.device_count()
-        return super().world_size
-
-    @property
-    def process_group(self):
-        return dist.group.WORLD
-
-    def destroy_comms(self):
-        # Wait for all ranks to reach here before starting shutdown.
-        dist.barrier()
-        dist.destroy_process_group()
-
-    def dist_init(self):
-        dist.init_process_group(
-            backend=BACKEND,
-            world_size=self.world_size,
-            rank=self.rank,
-            init_method=f"file://{self.file_name}",
-        )
-
-        # set device for nccl pg for collectives
-        if BACKEND == "nccl":
-            torch.cuda.set_device(self.rank)
 
     @with_comms()
-    def test_all_gather_object(self):
+    def test_all_gather_object(self, device):        
         output = [None] * dist.get_world_size()
-        dist.all_gather_object(object_list=output, obj=self.rank)
+        dist.all_gather_object(
+            object_list=output,
+            obj=self.rank)
 
         for i, v in enumerate(output):
             self.assertEqual(i, v, f"rank: {self.rank}")
+        
+        
 
     @with_comms()
-    def test_gather_object(self):
+    def test_gather_object(self, device):        
         output = [None] * dist.get_world_size() if self.rank == 0 else None
-        dist.gather_object(obj=self.rank, object_gather_list=output)
+        dist.gather_object(
+            obj=self.rank,
+            object_gather_list=output)
 
         if self.rank == 0:
             for i, v in enumerate(output):
                 self.assertEqual(i, v, f"rank: {self.rank}")
+        
 
     @with_comms()
-    def test_send_recv_object_list(self):
-        val = 99 if self.rank == 0 else None
-        object_list = [val] * dist.get_world_size()
-        if self.rank == 0:
-            dist.send_object_list(object_list, 1)
-        if self.rank == 1:
-            dist.recv_object_list(object_list, 0)
-
-        if self.rank < 2:
-            self.assertEqual(99, object_list[0])
-        else:
-            self.assertEqual(None, object_list[0])
-
-    @with_comms()
-    def test_broadcast_object_list(self):
+    def test_broadcast_object_list(self, device):       
         val = 99 if self.rank == 0 else None
         object_list = [val] * dist.get_world_size()
         # TODO test with broadcast_object_list's device argument
         dist.broadcast_object_list(object_list=object_list)
 
         self.assertEqual(99, object_list[0])
+        
 
     @with_comms()
-    def test_scatter_object_list(self):
+    def test_scatter_object_list(self, device):        
         input_list = list(range(dist.get_world_size())) if self.rank == 0 else None
         output_list = [None]
         dist.scatter_object_list(
-            scatter_object_output_list=output_list, scatter_object_input_list=input_list
-        )
+            scatter_object_output_list=output_list,
+            scatter_object_input_list=input_list)
 
         self.assertEqual(self.rank, output_list[0])
-
+        
     # Test Object Collectives With Sub Pg
 
     def setup_sub_pg(self):
@@ -144,37 +122,44 @@ class TestObjectCollectives(MultiProcessTestCase):
         my_pg = dist.new_group(ranks, use_local_synchronization=True)
         return rank, ranks, my_pg
 
+    @skipIfHpu
     @with_comms()
-    def test_subpg_scatter_object(self):
+    def test_subpg_scatter_object(self, device):       
         rank, ranks, my_pg = self.setup_sub_pg()
         out_list = [None]
         dist.scatter_object_list(out_list, ranks, src=ranks[0], group=my_pg)
         self.assertEqual(rank, out_list[0])
+        
 
+    @skipIfHpu
     @with_comms()
-    def test_subpg_all_gather_object(self):
+    def test_subpg_all_gather_object(self, device):        
         rank, ranks, my_pg = self.setup_sub_pg()
         out_list = [None] * len(ranks)
         dist.all_gather_object(out_list, rank, group=my_pg)
         self.assertEqual(ranks, out_list)
+        
 
+    @skipIfHpu
     @with_comms()
-    def test_subpg_gather_object(self):
+    def test_subpg_gather_object(self, device):        
         rank, ranks, my_pg = self.setup_sub_pg()
         out_list = [None] * len(ranks) if rank == ranks[0] else None
         dist.gather_object(rank, out_list, dst=ranks[0], group=my_pg)
         if rank == ranks[0]:
             self.assertEqual(ranks, out_list)
-
+       
+    @skipIfHpu
     @with_comms()
-    def test_subpg_broadcast_object(self):
+    def test_subpg_broadcast_object(self, device):       
         rank, ranks, my_pg = self.setup_sub_pg()
         out_list = [None]
         if rank == ranks[0]:
             out_list[0] = rank
         dist.broadcast_object_list(out_list, src=ranks[0], group=my_pg)
-        self.assertEqual(ranks[0], out_list[0])
+        self.assertEqual(ranks[0], out_list[0])        
 
-
+devices=["cpu","cuda","hpu"]
+instantiate_device_type_tests(TestObjectCollectives, globals(), only_for=devices)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_c10d_object_collectives.py
+++ b/test/distributed/test_c10d_object_collectives.py
@@ -1,35 +1,32 @@
 # Owner(s): ["oncall: distributed"]
 
-import os
 import sys
-from functools import wraps, partial
+from functools import partial, wraps
 
 import torch
 import torch.distributed as dist
+
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_distributed import (
-    MultiProcessTestCase,
-    skip_if_lt_x_gpu,
-    DistributedTestBase,
-    TEST_SKIPS,
-)
-
-
+from torch.testing._internal.common_distributed import DistributedTestBase, TEST_SKIPS
 from torch.testing._internal.common_utils import (
     run_tests,
-    TEST_WITH_DEV_DBG_ASAN,
+    skipIfHpu,
     TEST_CUDA,
     TEST_HPU,
-    skipIfHpu
+    TEST_WITH_DEV_DBG_ASAN,
 )
 
+
 if TEST_WITH_DEV_DBG_ASAN:
-    print("Skip dev-asan as torch + multiprocessing spawn have known issues", file=sys.stderr)
+    print(
+        "Skip dev-asan as torch + multiprocessing spawn have known issues",
+        file=sys.stderr,
+    )
     sys.exit(0)
 
 if TEST_HPU:
@@ -37,24 +34,26 @@ if TEST_HPU:
     device_count = torch.hpu.device_count()
     DEVICE = "hpu"
 elif TEST_CUDA:
-    BACKEND = dist.Backend.NCCL 
+    BACKEND = dist.Backend.NCCL
     device_count = torch.cuda.device_count()
     DEVICE = "cuda"
-else :
+else:
     BACKEND = dist.Backend.GLOO
     DEVICE = "cpu"
 
 
-WORLD_SIZE = min(4, max(2, device_count))
-
-
 def with_comms(func=None):
     if func is None:
-        return partial(with_comms)
+        return partial(
+            with_comms,
+        )
 
     @wraps(func)
     def wrapper(self, *args, **kwargs):
-        if BACKEND == dist.Backend.NCCL and torch.cuda.device_count() < self.world_size:
+        if (
+            BACKEND == (dist.Backend.NCCL or dist.Backend.HCCL)
+            and device_count() < self.world_size
+        ):
             sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
 
         kwargs["device"] = DEVICE
@@ -66,53 +65,44 @@ def with_comms(func=None):
 
     return wrapper
 
+
 class TestObjectCollectives(DistributedTestBase):
-
-
     @with_comms()
-    def test_all_gather_object(self, device):        
+    def test_all_gather_object(self, device):
         output = [None] * dist.get_world_size()
-        dist.all_gather_object(
-            object_list=output,
-            obj=self.rank)
+        dist.all_gather_object(object_list=output, obj=self.rank)
 
         for i, v in enumerate(output):
             self.assertEqual(i, v, f"rank: {self.rank}")
-        
-        
 
     @with_comms()
-    def test_gather_object(self, device):        
+    def test_gather_object(self, device):
         output = [None] * dist.get_world_size() if self.rank == 0 else None
-        dist.gather_object(
-            obj=self.rank,
-            object_gather_list=output)
+        dist.gather_object(obj=self.rank, object_gather_list=output)
 
         if self.rank == 0:
             for i, v in enumerate(output):
                 self.assertEqual(i, v, f"rank: {self.rank}")
-        
 
     @with_comms()
-    def test_broadcast_object_list(self, device):       
+    def test_broadcast_object_list(self, device):
         val = 99 if self.rank == 0 else None
         object_list = [val] * dist.get_world_size()
         # TODO test with broadcast_object_list's device argument
         dist.broadcast_object_list(object_list=object_list)
 
         self.assertEqual(99, object_list[0])
-        
 
     @with_comms()
-    def test_scatter_object_list(self, device):        
+    def test_scatter_object_list(self, device):
         input_list = list(range(dist.get_world_size())) if self.rank == 0 else None
         output_list = [None]
         dist.scatter_object_list(
-            scatter_object_output_list=output_list,
-            scatter_object_input_list=input_list)
+            scatter_object_output_list=output_list, scatter_object_input_list=input_list
+        )
 
         self.assertEqual(self.rank, output_list[0])
-        
+
     # Test Object Collectives With Sub Pg
 
     def setup_sub_pg(self):
@@ -124,42 +114,41 @@ class TestObjectCollectives(DistributedTestBase):
 
     @skipIfHpu
     @with_comms()
-    def test_subpg_scatter_object(self, device):       
+    def test_subpg_scatter_object(self, device):
         rank, ranks, my_pg = self.setup_sub_pg()
         out_list = [None]
         dist.scatter_object_list(out_list, ranks, src=ranks[0], group=my_pg)
         self.assertEqual(rank, out_list[0])
-        
 
     @skipIfHpu
     @with_comms()
-    def test_subpg_all_gather_object(self, device):        
+    def test_subpg_all_gather_object(self, device):
         rank, ranks, my_pg = self.setup_sub_pg()
         out_list = [None] * len(ranks)
         dist.all_gather_object(out_list, rank, group=my_pg)
         self.assertEqual(ranks, out_list)
-        
 
     @skipIfHpu
     @with_comms()
-    def test_subpg_gather_object(self, device):        
+    def test_subpg_gather_object(self, device):
         rank, ranks, my_pg = self.setup_sub_pg()
         out_list = [None] * len(ranks) if rank == ranks[0] else None
         dist.gather_object(rank, out_list, dst=ranks[0], group=my_pg)
         if rank == ranks[0]:
             self.assertEqual(ranks, out_list)
-       
+
     @skipIfHpu
     @with_comms()
-    def test_subpg_broadcast_object(self, device):       
+    def test_subpg_broadcast_object(self, device):
         rank, ranks, my_pg = self.setup_sub_pg()
         out_list = [None]
         if rank == ranks[0]:
             out_list[0] = rank
         dist.broadcast_object_list(out_list, src=ranks[0], group=my_pg)
-        self.assertEqual(ranks[0], out_list[0])        
+        self.assertEqual(ranks[0], out_list[0])
 
-devices=["cpu","cuda","hpu"]
+
+devices = ("cpu", "cuda", "hpu")
 instantiate_device_type_tests(TestObjectCollectives, globals(), only_for=devices)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_c10d_object_collectives.py
+++ b/test/distributed/test_c10d_object_collectives.py
@@ -52,7 +52,7 @@ def with_comms(func=None):
     def wrapper(self, *args, **kwargs):
         if (
             BACKEND == (dist.Backend.NCCL or dist.Backend.HCCL)
-            and device_count() < self.world_size
+            and device_count < self.world_size
         ):
             sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
 


### PR DESCRIPTION
# MOTIVATION
To generalize distributed test cases for non-CUDA devices, we are leveraging the DistributedTestBase class introduced in [PR #138216](https://github.com/pytorch/pytorch/pull/138216). This new class is derived from MultiProcessTestCase and abstracts the creation/deletion of process groups and other functionality for specific devices. In this PR, we extend the scope of these tests to support HPUs.

# CHANGES

Replaced MultiProcessTestCase with the DistributedTestBase class.
Extended test functionality to include support for HPUs.
Utilized instantiate_device_type_tests with targeted attributes to generate device-specific test instances.
Applied the skipIfHPU decorator to skip tests that are not yet compatible with HPU devices.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @ankurneog 