### PR TITLE
Make MultiProcContinuousTest timeout configurable

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -1449,7 +1449,7 @@ class MultiProcContinousTest(TestCase):
     # Rendezvous file
     rdvz_file: Optional[str] = None
     # timeout configured per class
-    timeout: timedelta=timedelta(seconds=120)
+    timeout: timedelta = timedelta(seconds=120)
 
 
     @classmethod

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -1448,6 +1448,9 @@ class MultiProcContinousTest(TestCase):
     rank: int = -1  # unset state
     # Rendezvous file
     rdvz_file: Optional[str] = None
+    # timeout configured per class
+    timeout: timedelta=timedelta(seconds=120)
+
 
     @classmethod
     @abc.abstractmethod
@@ -1495,6 +1498,7 @@ class MultiProcContinousTest(TestCase):
             rank=cls.rank,
             store=store,
             pg_options=opts,
+            timeout=cls.timeout,
         )
         cls.pg = c10d.distributed_c10d._get_default_group()
         print(f"Rank {cls.rank} setup complete")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #145125
* #144834
* __->__ #145099
* #145011
* #145010

Allows test classes using MPCT to set their own timeout as a class
property, which is good enough since the processgroup is shared across
test instances and the timeout is set at processgroup init.

Also sets a default timeout of 2 minutes, which is probably (?) long
enough for reasonable tests, but can be changed if it causes flakyness.
It's preferable to have as short default timeout as possible, since when
debugging tests getting a timeout quickly helps.