### PR TITLE
[mps/inductor] Skip "double" tests as 64-bits FP is not supported.

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -335,6 +335,8 @@ class InputGen:
         return torch.randn((1,), device=self.device)
 
     def double(self):
+        if self.device == "mps":
+            raise unittest.SkipTest("MPS does not support torch.float64")
         return torch.randn((self.n, self.n), device=self.device, dtype=torch.double)
 
     def int(self):
@@ -733,13 +735,9 @@ class SweepInputs2:
         "broadcast1",
         "broadcast2",
         "broadcast3",
+        "double",
         "int",
     ]
-
-    # MPS doesn't support 64-bits floating point
-    if GPU_TYPE != "mps":
-        input_gen_types1.append("double")
-
     input_gen_types2 = input_gen_types1
     gen = None
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -733,9 +733,13 @@ class SweepInputs2:
         "broadcast1",
         "broadcast2",
         "broadcast3",
-        "double",
         "int",
     ]
+
+    # MPS doesn't support 64-bits floating point
+    if GPU_TYPE != "mps":
+        input_gen_types1.append("double")
+
     input_gen_types2 = input_gen_types1
     gen = None
 


### PR DESCRIPTION
257 tests failed (before) -> 242 tests failed (after)


cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov