### PR TITLE
[cuBLAS][cuBLASLt] Unify `cuBLASLt` workspaces with `cuBLAS` workspaces

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -233,7 +233,7 @@ void* _getWorkspaceWithoutHandle() {
 }
 
 void* _getWorkspace(size_t& workspaceSize) {
-  #ifdef USE_ROCM
+  #ifdef (USE_ROCM || IS_FBCODE)
     // See https://github.com/pytorch/pytorch/issues/73328 for reasoning behind
     // setting this to 1M.
     workspaceSize = _getWorkspaceSize();

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -241,7 +241,7 @@ void* _getWorkspace(size_t& workspaceSize) {
     workspaceSize = at::cuda::getChosenWorkspaceSize();
   #endif
 
-  #ifdef USE_ROCM || defined(IS_FBCODE)
+  #ifdef (USE_ROCM || IS_FBCODE)
     auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
     auto workspace = allocator.allocate(workspaceSize);
     auto workspace_ptr = workspace.mutable_get();

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -241,7 +241,7 @@ void* _getWorkspace(size_t& workspaceSize) {
     workspaceSize = at::cuda::getChosenWorkspaceSize();
   #endif
 
-  #ifdef USE_ROCM || IS_FBCODE
+  #ifdef USE_ROCM || defined(IS_FBCODE)
     auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
     auto workspace = allocator.allocate(workspaceSize);
     auto workspace_ptr = workspace.mutable_get();

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -233,16 +233,16 @@ void* _getWorkspaceWithoutHandle() {
 }
 
 void* _getWorkspace(size_t& workspaceSize) {
-  #ifdef (USE_ROCM || IS_FBCODE)
-    workspaceSize = _getWorkspaceSize();
-    auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
-    auto workspace = allocator.allocate(workspaceSize);
-    auto workspace_ptr = workspace.mutable_get();
-    TORCH_CHECK(workspace_ptr != nullptr, "OOM trying to allocate workspace for cublaslt");
-  #else
-    workspaceSize = at::cuda::getChosenWorkspaceSize();
-    auto workspace_ptr = _getWorkspaceWithoutHandle();
-  #endif
+#ifdef (USE_ROCM || IS_FBCODE)
+  workspaceSize = _getWorkspaceSize();
+  auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
+  auto workspace = allocator.allocate(workspaceSize);
+  auto workspace_ptr = workspace.mutable_get();
+  TORCH_CHECK(workspace_ptr != nullptr, "OOM trying to allocate workspace for cublaslt");
+#else
+  workspaceSize = at::cuda::getChosenWorkspaceSize();
+  auto workspace_ptr = _getWorkspaceWithoutHandle();
+#endif
   return workspace_ptr;
 }
 

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -233,7 +233,7 @@ void* _getWorkspaceWithoutHandle() {
 }
 
 void* _getWorkspace(size_t& workspaceSize) {
-#ifdef (USE_ROCM || IS_FBCODE)
+#ifdef (defined(USE_ROCM) || defined(IS_FBCODE))
   workspaceSize = _getWorkspaceSize();
   auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
   auto workspace = allocator.allocate(workspaceSize);

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -234,19 +234,13 @@ void* _getWorkspaceWithoutHandle() {
 
 void* _getWorkspace(size_t& workspaceSize) {
   #ifdef (USE_ROCM || IS_FBCODE)
-    // See https://github.com/pytorch/pytorch/issues/73328 for reasoning behind
-    // setting this to 1M.
     workspaceSize = _getWorkspaceSize();
-  #else
-    workspaceSize = at::cuda::getChosenWorkspaceSize();
-  #endif
-
-  #ifdef (USE_ROCM || IS_FBCODE)
     auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
     auto workspace = allocator.allocate(workspaceSize);
     auto workspace_ptr = workspace.mutable_get();
     TORCH_CHECK(workspace_ptr != nullptr, "OOM trying to allocate workspace for cublaslt");
   #else
+    workspaceSize = at::cuda::getChosenWorkspaceSize();
     auto workspace_ptr = _getWorkspaceWithoutHandle();
   #endif
   return workspace_ptr;

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -228,7 +228,7 @@ void* _getWorkspaceWithoutHandle() {
   cudaStream_t _stream = stream;
   auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
   auto workspace_it = at::cuda::cublas_handle_stream_to_workspace().find(key);
-  TORCH_CHECK(workspace_it != at::cuda::cublas_handle_stream_to_workspace().end());
+  TORCH_INTERNAL_ASSERT(workspace_it != at::cuda::cublas_handle_stream_to_workspace().end());
   return workspace_it->second.mutable_get();
 }
 
@@ -238,11 +238,11 @@ void* _getWorkspace(size_t& workspaceSize) {
   auto cublasWorkspaceSize = at::cuda::getChosenWorkspaceSize();
   if (cublasWorkspaceSize < workspaceSize) {
     TORCH_WARN_ONCE("Requested CUBLASLT workspace size of ", workspaceSize,
-		    " bytes exceeds CUBLAS workspace size of ", cublasWorkspaceSize,
-		    " bytes. Please increase CUBLAS workspace size",
-		    " via CUBLAS_WORKSPACE_CONFIG or decrease requested"
+                    " bytes exceeds CUBLAS workspace size of ", cublasWorkspaceSize,
+                    " bytes. Please increase CUBLAS workspace size",
+                    " via CUBLAS_WORKSPACE_CONFIG or decrease requested"
                     " CUBLASLT_WORKSPACE_SIZE. Otherwise CUBLASLT workspace"
-		    " size will be limited to the CUBLAS workspace size.");
+                    " size will be limited to the CUBLAS workspace size.");
     workspaceSize = cublasWorkspaceSize;
   }
 // #else

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -233,7 +233,7 @@ void* _getWorkspaceWithoutHandle() {
 }
 
 void* _getWorkspace(size_t& workspaceSize) {
-#ifdef (defined(USE_ROCM) || defined(IS_FBCODE))
+#ifdef (defined(USE_ROCM) || defined(FBCODE_CAFFE2))
   workspaceSize = _getWorkspaceSize();
   auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
   auto workspace = allocator.allocate(workspaceSize);

--- a/aten/src/ATen/cuda/CUDAContextLight.h
+++ b/aten/src/ATen/cuda/CUDAContextLight.h
@@ -2,6 +2,7 @@
 // Light-weight version of CUDAContext.h with fewer transitive includes
 
 #include <cstdint>
+#include <map>
 
 #include <cuda_runtime_api.h>
 #include <cusparse.h>
@@ -87,6 +88,8 @@ TORCH_CUDA_CPP_API cublasHandle_t getCurrentCUDABlasHandle();
 TORCH_CUDA_CPP_API cublasLtHandle_t getCurrentCUDABlasLtHandle();
 
 TORCH_CUDA_CPP_API void clearCublasWorkspaces();
+TORCH_CUDA_CPP_API std::map<std::tuple<void *, void *>, at::DataPtr>& cublas_handle_stream_to_workspace();
+TORCH_CUDA_CPP_API size_t getChosenWorkspaceSize();
 
 #if defined(CUDART_VERSION) || defined(USE_ROCM)
 TORCH_CUDA_CPP_API cusolverDnHandle_t getCurrentCUDASolverDnHandle();

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -83,11 +83,6 @@ static hipblasStatus_t hipblasSetWorkspace_replacement(hipblasHandle_t handle, v
 
 #endif
 
-std::map<std::tuple<void *, void *>, at::DataPtr>& cublas_handle_stream_to_workspace() {
-  static auto& instance = *new std::map<std::tuple<void *, void *>, at::DataPtr>;
-  return instance;
-}
-
 void createCublasHandle(cublasHandle_t *handle) {
   TORCH_CUDABLAS_CHECK(cublasCreate(handle));
 }
@@ -108,6 +103,11 @@ void destroyCublasHandle(cublasHandle_t handle) {
 using CuBlasPoolType = DeviceThreadHandlePool<cublasHandle_t, createCublasHandle, destroyCublasHandle>;
 
 } // namespace
+
+std::map<std::tuple<void *, void *>, at::DataPtr>& cublas_handle_stream_to_workspace() {
+  static auto& instance = *new std::map<std::tuple<void *, void *>, at::DataPtr>;
+  return instance;
+}
 
 void clearCublasWorkspaces() {
   cublas_handle_stream_to_workspace().clear();

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3595,6 +3595,7 @@ def run(runner, args, original_dir=None):
         if args.only is not None and args.only in {
             "DebertaForQuestionAnswering",
             "nvidia_deeprecommender",
+            "volo_d1_224",
         }:
             # These seem unhappy with numerics of larger cuBLASLt workspace
             # sizes following #145130 (due to enabling split-k?)

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3592,15 +3592,16 @@ def run(runner, args, original_dir=None):
             # some of the models do not support use_deterministic_algorithms
             torch.use_deterministic_algorithms(True)
         os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
-        if args.only is not None and args.only in {
-            "DebertaForQuestionAnswering",
-            "RobertaForQuestionAnswering",
-            "nvidia_deeprecommender",
-            "volo_d1_224",
-        }:
-            # These seem unhappy with numerics of larger cuBLASLt workspace
-            # sizes following #145130 (due to enabling split-k?)
-            torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+        # TODO(eqy): revisit when cuBLASLt workspace size is bumped
+        # if args.only is not None and args.only in {
+        #     "DebertaForQuestionAnswering",
+        #     "RobertaForQuestionAnswering",
+        #     "nvidia_deeprecommender",
+        #     "volo_d1_224",
+        # }:
+        #     # These seem unhappy with numerics of larger cuBLASLt workspace
+        #     # sizes following #145130 (due to enabling split-k?)
+        #     torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.allow_tf32 = False
         torch.backends.cudnn.benchmark = False

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3594,6 +3594,7 @@ def run(runner, args, original_dir=None):
         os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
         if args.only is not None and args.only in {
             "DebertaForQuestionAnswering",
+            "RobertaForQuestionAnswering",
             "nvidia_deeprecommender",
             "volo_d1_224",
         }:

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3592,6 +3592,13 @@ def run(runner, args, original_dir=None):
             # some of the models do not support use_deterministic_algorithms
             torch.use_deterministic_algorithms(True)
         os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+        if args.only is not None and args.only in {
+            "DebertaForQuestionAnswering",
+            "nvidia_deeprecommender",
+        }:
+            # These seem unhappy with numerics of larger cuBLASLt workspace
+            # sizes following #145130 (due to enabling split-k?)
+            torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.allow_tf32 = False
         torch.backends.cudnn.benchmark = False


### PR DESCRIPTION
As `cuBLAS` workspaces are already per-stream, there shouldn't be kernel execution overlap with `cuBLASLt` kernels.

This PR reuses `cuBLAS` workspaces for `cuBLASLt` for the following benefits:

+ caching (`cuBLAS` workspaces were already cached, so now we get that for `cuBLASLt`)
+ "free" workspace size bump for `cuBLASLt` `cuBLASLt` workspace sizes were previously smaller than those for `cuBLAS` by default which potentially hurts performance, and we encountered difficulty in increasing the size due to downstream OOMs , see also #120925
+ fixes behavior broken behavior with the memtracker; https://github.com/pytorch/pytorch/pull/139442 attempted to handle peaky allocation behavior that broke memtracker equivalence tests but it didn't seem to fully work, here the cached/reused `cuBLAS` workspace seems to fix it
+ one environment variable to rule them all: `CUBLAS_WORKSPACE_CONFIG` applies directly to `cuBLASLt` without a confusing `CUBLASLT_WORKSPACE_SIZE` that users would also need to consider

Edit: for now, CUBLASLT_WORKSPACE_SIZE still exists to preserve previous behavior (we noticed some accuracy differences when automatically enabling larger workspace for CUBLASLT)

cc @ptrblck @msaroufim @csarofeen @xwang233 @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames