### PR TITLE
[MPSInductor][BE] NaN-propagating min/max to header

### DIFF
--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -1,0 +1,27 @@
+#include <metal_stdlib>
+
+namespace c10 {
+namespace metal {
+
+template <typename T>
+::metal::enable_if_t<::metal::is_floating_point_v<T>, T> max(T a, T b) {
+  return ::metal::isunordered(a, b) ? NAN : ::metal::max(a, b);
+}
+
+template <typename T>
+::metal::enable_if_t<::metal::is_integral_v<T>, T> max(T a, T b) {
+  return ::metal::max(a, b);
+}
+
+template <typename T>
+::metal::enable_if_t<::metal::is_floating_point_v<T>, T> min(T a, T b) {
+  return ::metal::isunordered(a, b) ? NAN : ::metal::min(a, b);
+}
+
+template <typename T>
+::metal::enable_if_t<::metal::is_integral_v<T>, T> min(T a, T b) {
+  return ::metal::min(a, b);
+}
+
+} // namespace metal
+} // namespace c10

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -134,15 +134,13 @@ class MetalOverrides(OpOverrides):
     def maximum(a: CSEVariable, b: CSEVariable) -> str:
         typecast_a = f"static_cast<decltype({a}+{b})>({a})"
         typecast_b = f"static_cast<decltype({a}+{b})>({b})"
-        max_res = f"metal::max({typecast_a}, {typecast_b})"
-        return f"isnan({a} + {b}) ? {a} + {b} : {max_res}"
+        return f"c10::metal::max({typecast_a}, {typecast_b})"
 
     @staticmethod
     def minimum(a: CSEVariable, b: CSEVariable) -> str:
         typecast_a = f"static_cast<decltype({a}+{b})>({a})"
         typecast_b = f"static_cast<decltype({a}+{b})>({b})"
-        min_res = f"metal::min({typecast_a}, {typecast_b})"
-        return f"isnan({a} + {b})  ? {a} + {b} : {min_res}"
+        return f"c10::metal::min({typecast_a}, {typecast_b})"
 
     @staticmethod
     def logical_or(a: CSEVariable, b: CSEVariable) -> str:
@@ -322,12 +320,7 @@ class MetalKernel(SIMDKernel):
             code.splice(
                 """
             #include <c10/metal/special_math.h>
-            template<typename T> inline bool isnan(T) { return false; }
-            template<> inline bool isnan(float x) { return metal::isnan(x); }
-            template<> inline bool isnan(half x) { return metal::isnan(x); }
-            #if __METAL_VERSION__ >= 310
-            template<> inline bool isnan(bfloat x) { return metal::isnan(x); }
-            #endif
+            #include <c10/metal/utils.h>
             """,
                 strip=True,
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #145160
* #145156
* #145159
* __->__ #145157

May be to be later reused from eager op as well

Also, didn't know that Metal already have type_traits
And use `metal::isunorderder(a, b)` instead of `metal::isnan(a + b)` is it is defined as function that is equivalent  `a != a || b != b`, but I suspect it might have a best native implementation for the specific architecture

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov