### PR TITLE
Improve the caching allocator test for raw alloc

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3905,8 +3905,11 @@ class TestCudaMallocAsync(TestCase):
         # relevant field in data structure
         def requested_bytes_alloc_stats(raw_alloc_size, stream):
             start = torch.cuda.memory_stats()["requested_bytes.all.allocated"]
-            torch._C._cuda_cudaCachingAllocator_raw_alloc(raw_alloc_size, stream)
+            mem_ptr = torch._C._cuda_cudaCachingAllocator_raw_alloc(
+                raw_alloc_size, stream
+            )
             finish = torch.cuda.memory_stats()["requested_bytes.all.allocated"]
+            torch.cuda.caching_allocator_delete(mem_ptr)
             return finish - start
 
         torch.cuda.empty_cache()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3909,7 +3909,7 @@ class TestCudaMallocAsync(TestCase):
                 raw_alloc_size, stream
             )
             finish = torch.cuda.memory_stats()["requested_bytes.all.allocated"]
-            torch.cuda.caching_allocator_delete(mem_ptr)
+            torch._C._cuda_cudaCachingAllocator_raw_delete(mem_ptr)
             return finish - start
 
         torch.cuda.empty_cache()


### PR DESCRIPTION
1 Prevent block allocated by torch._C._cuda_cudaCachingAllocator_raw_alloc from affecting torch.cuda.empty_cache() in other unit tests
2 Additionally, tested the changes to raw_delete in https://github.com/pytorch/pytorch/pull/131114   

@jeffdaily @albanD @houseroad @eqy @aaronenyeshi 