### PR TITLE
Use TORCH_CHECK instead of std::runtime_error in stack.h and ivalue.h

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -918,7 +918,7 @@ struct TORCH_API IValue final {
       return toSymFloat();
     else if (isSymBool())
       return toSymBool();
-    throw std::runtime_error("IValue is not a Scalar");
+    TORCH_CHECK(false, "IValue is not a Scalar");
   }
 
   // Device

--- a/aten/src/ATen/core/stack.h
+++ b/aten/src/ATen/core/stack.h
@@ -103,9 +103,7 @@ inline void drop(Stack* stack, size_t n) {
   drop(*stack, n);
 }
 inline IValue pop(Stack& stack) {
-  if (stack.empty()) {
-    throw std::runtime_error("pop() called on empty stack");
-  }
+  TORCH_CHECK(not stack.empty(), "pop() called on empty stack");
   auto r = std::move(stack.back());
   stack.pop_back();
   return r;

--- a/aten/src/ATen/core/stack.h
+++ b/aten/src/ATen/core/stack.h
@@ -103,7 +103,7 @@ inline void drop(Stack* stack, size_t n) {
   drop(*stack, n);
 }
 inline IValue pop(Stack& stack) {
-  TORCH_CHECK(not stack.empty(), "pop() called on empty stack");
+  TORCH_CHECK(!stack.empty(), "pop() called on empty stack");
   auto r = std::move(stack.back());
   stack.pop_back();
   return r;


### PR DESCRIPTION
TORCH_CHECK will preserve the stacktrace for when TORCH_CPP_SHOW_STACKTRACES=1, whereas std::runtime_error will not.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145280

