### PR TITLE
[hop][be] add utils for more comprehensive input alias and mutation

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -101,6 +101,18 @@ def compile_mode_helper(fct, compile_mode):
         return fct
 
 
+ALIAS_FN = [
+    lambda x: x,
+    lambda x: x.view(-1),
+    lambda x: x.reshape(-1),
+    lambda x: x.squeeze(0),
+    lambda x: x.unsqueeze(0),
+    lambda x: x.transpose(0, 1),
+    lambda x: x.flatten(),
+    lambda x: x.expand(1, *x.size()),
+]
+
+
 def get_scan_combine_fn(name, associative=True):
     def add(x: torch.Tensor, y: torch.Tensor):
         return x + y
@@ -6973,6 +6985,33 @@ class GraphModule(torch.nn.Module):
             return (add, add_1, add_2, add_3, add_4, child_1)
 """,  # noqa: B950
             )
+
+    def test_input_alias(self):
+        def fn(f, *args):
+            return torch.cond(args[0].sum() > 0, f, f, args)
+
+        x = torch.randn(2, 2)
+        for f in ALIAS_FN:
+            with self.assertRaisesRegex(
+                torch._dynamo.exc.BackendCompilerFailed, "might be aliasing the input"
+            ):
+                torch.compile(fn)(f, x)
+
+    def test_input_mutation(self):
+        def fn(view_f, *args):
+            def mutate_f(x):
+                v = view_f(x)
+                v.add_(1)
+                return v.sin()
+
+            return torch.cond(args[0].sum() > 0, mutate_f, mutate_f, args)
+
+        x = torch.randn(2, 2)
+        for f in ALIAS_FN:
+            with self.assertRaisesRegex(
+                torch._dynamo.exc.BackendCompilerFailed, "might be modifying the input"
+            ):
+                torch.compile(fn)(f, x)
 
 
 _hop_schema_test_schema_types = [

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -487,7 +487,7 @@ def cond_func(ctx, pred, true_fn, false_fn, inputs):
         functional_true = ctx.functionalize(_maybe_run_with_interpreter(true_fn))
         functional_false = ctx.functionalize(_maybe_run_with_interpreter(false_fn))
         pre_dispatch = hasattr(ctx, "mode") and ctx.mode.pre_dispatch
-        for branch in [functional_true, functional_false]:
+        for branch in [true_fn, false_fn]:
             if _has_potential_branch_input_mutation(
                 branch, unwrapped_inputs, pre_dispatch=pre_dispatch
             ):

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -421,7 +421,7 @@ def flex_attention_functionalize(
         pre_dispatch = hasattr(ctx, "mode") and ctx.mode.pre_dispatch
         with TransformGetItemToIndex():
             mutates = _has_potential_branch_input_mutation(
-                functional_score_mod, example_vals, pre_dispatch
+                score_mod, example_vals, pre_dispatch
             )
         # The only care about mutations of existing buffers since we can't replay these.
         # However, we can just error if anything is detected

--- a/torch/_higher_order_ops/hints_wrap.py
+++ b/torch/_higher_order_ops/hints_wrap.py
@@ -98,13 +98,13 @@ def hints_wrapper_functionalize(ctx, body_fn, args, kwargs, hints):
         functional_body_fn = ctx.functionalize(body_fn)
         pre_dispatch = hasattr(ctx, "mode") and ctx.mode.pre_dispatch
         if _has_potential_branch_input_mutation(
-            functional_body_fn, unwrapped_args, pre_dispatch=pre_dispatch
+            body_fn, unwrapped_args, pre_dispatch=pre_dispatch
         ):
             raise UnsupportedAliasMutationException(
                 "body_fn of hints_wrapper might be modifying the input!"
             )
         if _has_potential_branch_input_alias(
-            functional_body_fn, unwrapped_args, pre_dispatch=pre_dispatch
+            body_fn, unwrapped_args, pre_dispatch=pre_dispatch
         ):
             raise UnsupportedAliasMutationException(
                 "body_fn of hints_wrapper might be aliasing the input!"

--- a/torch/_higher_order_ops/scan.py
+++ b/torch/_higher_order_ops/scan.py
@@ -455,13 +455,13 @@ def scan_functionalize(ctx, combine_fn, init, xs, dim, reverse, additional_input
             )
         )
         if _has_potential_branch_input_mutation(
-            functional_combine_fn, sample_inputs, pre_dispatch=pre_dispatch
+            combine_fn, sample_inputs, pre_dispatch=pre_dispatch
         ):
             raise UnsupportedAliasMutationException(
                 "Combine_fn might be modifying the input!"
             )
         if _has_potential_branch_input_alias(
-            functional_combine_fn, sample_inputs, pre_dispatch=pre_dispatch
+            combine_fn, sample_inputs, pre_dispatch=pre_dispatch
         ):
             raise UnsupportedAliasMutationException(
                 "Combine_fn might be aliasing the input!"

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -596,7 +596,9 @@ def check_input_alias_and_mutation(
         out_alias_map = {
             i: out_storage_map[_tensor_storage(out)]
             for i, out in enumerate(outputs)
-            if isinstance(out, torch.Tensor) and _tensor_storage(out) in out_storage_map
+            if isinstance(out, torch.Tensor)
+            and _tensor_storage(out) in out_storage_map
+            and out_storage_map[_tensor_storage(out)] != i
         }
         inp_alias_map = {
             i: out_storage_map[_tensor_storage(inp)]

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -451,8 +451,8 @@ def while_loop_func(ctx, cond_fn, body_fn, carried_inputs, additional_inputs):
         functional_body_fn = ctx.functionalize(_maybe_run_with_interpreter(body_fn))
         pre_dispatch = hasattr(ctx, "mode") and ctx.mode.pre_dispatch
         for fn, fn_name in [
-            (functional_cond_fn, "cond_fn"),
-            (functional_body_fn, "body_fn"),
+            (cond_fn, "cond_fn"),
+            (body_fn, "body_fn"),
         ]:
             if _has_potential_branch_input_mutation(
                 fn, unwrapped_inputs, pre_dispatch=pre_dispatch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145298

This PR implements  the idea of checking input mutations through tensor version and check aliasing via storage  from @zou3519. Previously, we rely on whether there's a in place op that takes placeholder input, which doesn't take views into account.

When writing the PR, I also noticed a bug in previous input mutation checking logic: we were checking the whether there are operators functionalized_f where all the mutating ops have been replaced so we won't be able to detect any thing.