### PR TITLE
Add fused rms_norm implementation for MPS backend

### DIFF
--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -274,14 +274,12 @@ Tensor rms_norm_symint(
     const Tensor weight = weight_opt.value();
     const bool any_nested = input.is_nested() || weight.is_nested();
     const bool any_inputs_require_grad = input.requires_grad() || weight.requires_grad();
-    const bool all_contiguous = input.is_contiguous() && weight.is_contiguous();
     const bool is_input_fp = isFloatingType(input.scalar_type());
     const bool is_weight_fp = isFloatingType(weight.scalar_type());
 
-    if (!(GradMode::is_enabled() && any_inputs_require_grad) && all_contiguous && !any_nested && is_input_fp &&
-        is_weight_fp) {
+    if (!(GradMode::is_enabled() && any_inputs_require_grad) && !any_nested && is_input_fp && is_weight_fp) {
       auto eps_val = eps.value_or(std::numeric_limits<double>::epsilon());
-      return mps::rms_norm_mps_kernel(input, normalized_shape, weight, eps_val);
+      return mps::rms_norm_mps_kernel(input.contiguous(), normalized_shape, weight.contiguous(), eps_val);
     }
   }
 #endif

--- a/aten/src/ATen/native/mps/kernels/RMSNorm.metal
+++ b/aten/src/ATen/native/mps/kernels/RMSNorm.metal
@@ -1,0 +1,198 @@
+// Adapted from
+// https://github.com/ml-explore/mlx/blob/main/mlx/backend/metal/kernels/rms_norm.metal
+// Copyright © 2024 Apple Inc.
+
+#include <metal_common>
+#include <metal_simdgroup>
+#include <metal_stdlib>
+
+using namespace metal;
+
+template <typename T>
+[[kernel]] void rms_single_row(
+    constant T* x,
+    constant T* w,
+    device T* out,
+    constant float& eps,
+    constant uint& axis_size,
+    constant uint& w_stride,
+    uint gid [[threadgroup_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int SIMD_SIZE = 32;
+  constexpr int N_READS = 4;
+
+  threadgroup float local_inv_mean[1];
+  threadgroup float local_sums[SIMD_SIZE];
+
+  float acc = 0;
+  x += gid * size_t(axis_size) + lid * N_READS;
+  w += w_stride * lid * N_READS;
+  if (lid * N_READS + N_READS <= axis_size) {
+    for (int i = 0; i < N_READS; i++) {
+      float xi = x[i];
+      acc += xi * xi;
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if ((lid * N_READS + i) < axis_size) {
+        float xi = x[i];
+        acc += xi * xi;
+      }
+    }
+  }
+  acc = simd_sum(acc);
+  //  Initialize shared memory
+  if (simd_group_id == 0) {
+    local_sums[simd_lane_id] = 0;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Write simd accumulations into shared memory
+  if (simd_lane_id == 0) {
+    local_sums[simd_group_id] = acc;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Accumulate over simd groups
+  if (simd_group_id == 0) {
+    acc = simd_sum(local_sums[simd_lane_id]);
+    if (simd_lane_id == 0) {
+      local_inv_mean[0] = metal::precise::rsqrt(acc / axis_size + eps);
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Write the outputs
+  out += gid * size_t(axis_size) + lid * N_READS;
+  if (lid * N_READS + N_READS <= axis_size) {
+    for (int i = 0; i < N_READS; i++) {
+      out[i] = w[w_stride * i] * static_cast<T>(x[i] * local_inv_mean[0]);
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if ((lid * N_READS + i) < axis_size) {
+        out[i] = w[w_stride * i] * static_cast<T>(x[i] * local_inv_mean[0]);
+      }
+    }
+  }
+}
+
+template <typename T>
+[[kernel]] void rms_looped(
+    constant T* x,
+    constant T* w,
+    device T* out,
+    constant float& eps,
+    constant uint& axis_size,
+    constant uint& w_stride,
+    uint gid [[threadgroup_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int SIMD_SIZE = 32;
+  constexpr int N_READS = 4;
+  threadgroup float local_inv_mean[1];
+  threadgroup float local_sums[SIMD_SIZE];
+
+  float acc = 0;
+  x += gid * size_t(axis_size) + lid * N_READS;
+  w += w_stride * lid * N_READS;
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    if (r + lid * N_READS + N_READS <= axis_size) {
+      for (int i = 0; i < N_READS; i++) {
+        float xi = x[i + r];
+        acc += xi * xi;
+      }
+    } else {
+      for (int i = 0; i < N_READS; i++) {
+        if ((r + lid * N_READS + i) < axis_size) {
+          float xi = x[i + r];
+          acc += xi * xi;
+        }
+      }
+    }
+  }
+  acc = simd_sum(acc);
+  //  Initialize shared memory
+  if (simd_group_id == 0) {
+    local_sums[simd_lane_id] = 0;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Write simd accumulations into shared memory
+  if (simd_lane_id == 0) {
+    local_sums[simd_group_id] = acc;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Accumulate over simd groups
+  if (simd_group_id == 0) {
+    acc = simd_sum(local_sums[simd_lane_id]);
+    if (simd_lane_id == 0) {
+      local_inv_mean[0] = metal::precise::rsqrt(acc / axis_size + eps);
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Write the outputs
+  out += gid * size_t(axis_size) + lid * N_READS;
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    if (r + lid * N_READS + N_READS <= axis_size) {
+      for (int i = 0; i < N_READS; i++) {
+        out[r + i] = w[w_stride * (i + r)] *
+            static_cast<T>(x[r + i] * local_inv_mean[0]);
+      }
+    } else {
+      for (int i = 0; i < N_READS; i++) {
+        if ((r + lid * N_READS + i) < axis_size) {
+          out[r + i] = w[w_stride * (i + r)] *
+              static_cast<T>(x[r + i] * local_inv_mean[0]);
+        }
+      }
+    }
+  }
+}
+
+// clang-format off
+#define instantiate_rms_single_row(itype)                     \
+  template [[host_name("rms_norm_" #itype)]] [[kernel]] void  \
+  rms_single_row<itype>(                                      \
+      constant itype* x,                                      \
+      constant itype* w,                                      \
+      device itype* out,                                      \
+      constant float& eps,                                    \
+      constant uint& axis_size,                               \
+      constant uint& w_stride,                                \
+      uint gid [[thread_position_in_grid]],                   \
+      uint lid [[thread_position_in_threadgroup]],            \
+      uint simd_lane_id [[thread_index_in_simdgroup]],        \
+      uint simd_group_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_rms_looped(itype)                               \
+  template [[host_name("rms_norm_looped_" #itype)]] [[kernel]] void \
+  rms_looped<itype>(                                                \
+      constant itype* x,                                            \
+      constant itype* w,                                            \
+      device itype* out,                                            \
+      constant float& eps,                                          \
+      constant uint& axis_size,                                     \
+      constant uint& w_stride,                                      \
+      uint gid [[thread_position_in_grid]],                         \
+      uint lid [[thread_position_in_threadgroup]],                  \
+      uint lsize [[threads_per_threadgroup]],                       \
+      uint simd_lane_id [[thread_index_in_simdgroup]],              \
+      uint simd_group_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_rms(itype)      \
+  instantiate_rms_single_row(itype) \
+  instantiate_rms_looped(itype)
+
+instantiate_rms(float)
+instantiate_rms(half)
+#if __METAL_VERSION__ >= 310
+instantiate_rms(bfloat)
+#endif
+// clang-format on

--- a/aten/src/ATen/native/mps/kernels/RMSNorm.metal
+++ b/aten/src/ATen/native/mps/kernels/RMSNorm.metal
@@ -194,5 +194,4 @@ instantiate_rms(float)
 instantiate_rms(half)
 #if __METAL_VERSION__ >= 310
 instantiate_rms(bfloat)
-#endif
-// clang-format on
+#endif // clang-format on

--- a/aten/src/ATen/native/mps/operations/RMSNorm.h
+++ b/aten/src/ATen/native/mps/operations/RMSNorm.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <ATen/core/Tensor.h>
+#include <c10/core/SymIntArrayRef.h>
+
 namespace at::native::mps {
 
 Tensor rms_norm_mps_kernel(const Tensor& input,

--- a/aten/src/ATen/native/mps/operations/RMSNorm.h
+++ b/aten/src/ATen/native/mps/operations/RMSNorm.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace at::native::mps {
+
+Tensor rms_norm_mps_kernel(const Tensor& input,
+                           c10::SymIntArrayRef normalized_shape,
+                           const Tensor& weight,
+                           const double eps);
+
+} // namespace at::native::mps

--- a/aten/src/ATen/native/mps/operations/RMSNorm.h
+++ b/aten/src/ATen/native/mps/operations/RMSNorm.h
@@ -5,9 +5,10 @@
 
 namespace at::native::mps {
 
-Tensor rms_norm_mps_kernel(const Tensor& input,
-                           c10::SymIntArrayRef normalized_shape,
-                           const Tensor& weight,
-                           const double eps);
+Tensor rms_norm_mps_kernel(
+    const Tensor& input,
+    c10::SymIntArrayRef normalized_shape,
+    const Tensor& weight,
+    const double eps);
 
 } // namespace at::native::mps

--- a/aten/src/ATen/native/mps/operations/RMSNorm.mm
+++ b/aten/src/ATen/native/mps/operations/RMSNorm.mm
@@ -1,0 +1,103 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/empty_like.h>
+#include <ATen/ops/rms_norm_native.h>
+#endif
+#include <ATen/mps/MPSProfiler.h>
+#include <ATen/native/layer_norm.h>
+#include <ATen/native/mps/OperationUtils.h>
+#include <fmt/format.h>
+
+namespace at::native {
+
+using namespace mps;
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/RMSNorm_metallib.h>
+#endif
+
+static Tensor rms_norm_mps_kernel(const Tensor& input,
+                                  IntArrayRef normalized_shape,
+                                  const Tensor& weight,
+                                  const double eps) {
+  auto output = at::empty_like(input);
+  const int normalized_ndim = normalized_shape.size();
+  const auto input_shape = input.sizes();
+  const auto input_ndim = input.dim();
+  const int axis = input_ndim - normalized_ndim;
+  const size_t M = static_cast<size_t>(c10::multiply_integers(input_shape.cbegin(), input_shape.cbegin() + axis));
+  const size_t N = static_cast<size_t>(c10::multiply_integers(input_shape.cbegin() + axis, input_shape.cend()));
+
+  static constexpr int SIMD_SIZE = 32;
+  static constexpr int N_READS = 4;
+  static constexpr int LOOPED_LIMIT = 4096;
+  const std::string name = N > LOOPED_LIMIT ? "rms_norm_looped" : "rms_norm";
+
+  MPSStream* mpsStream = getCurrentMPSStream();
+
+  dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
+      const std::string kernel = fmt::format("{}_{}", name, scalarToMetalTypeString(output));
+      id<MTLComputePipelineState> rms_norm_pso = lib.getPipelineStateForFunc(kernel);
+      [computeEncoder setComputePipelineState:rms_norm_pso];
+      mtl_setArgs(computeEncoder, input, weight, output, eps, N, 1);
+
+      const auto maxThreadsPerGroup = static_cast<size_t>([rms_norm_pso maxTotalThreadsPerThreadgroup]);
+      size_t threadgroup_size = maxThreadsPerGroup;
+      if (N <= LOOPED_LIMIT) {
+        size_t threadgroup_needed = (N + N_READS - 1) / N_READS;
+        size_t simds_needed = (threadgroup_needed + SIMD_SIZE - 1) / SIMD_SIZE;
+        size_t threadgroup_size = SIMD_SIZE * simds_needed;
+        assert(threadgroup_size <= maxThreadsPerGroup);
+      }
+      size_t n_threads = M * threadgroup_size;
+
+      [computeEncoder dispatchThreads:MTLSizeMake(n_threads, 1, 1)
+                threadsPerThreadgroup:MTLSizeMake(threadgroup_size, 1, 1)];
+    }
+  });
+
+  return output;
+}
+
+Tensor rms_norm_mps(const Tensor& input,
+                    IntArrayRef normalized_shape,
+                    const std::optional<Tensor>& weight_opt,
+                    const std::optional<double> eps_opt) {
+  std::vector<at::SymInt> normalized_shape_symint;
+  for (const auto& val : normalized_shape) {
+    normalized_shape_symint.emplace_back(at::SymInt(val));
+  }
+
+  if (weight_opt.has_value()) {
+    const Tensor weight = weight_opt.value();
+    const bool any_nested = input.is_nested() || weight.is_nested();
+    const bool any_inputs_require_grad = input.requires_grad() || weight.requires_grad();
+    const bool all_contiguous = input.is_contiguous() && weight.is_contiguous();
+    const bool is_input_fp = input.dtype() == kBFloat16 || input.dtype() == kHalf || input.dtype() == kFloat;
+    const bool is_weight_fp = weight.dtype() == kBFloat16 || weight.dtype() == kHalf || weight.dtype() == kFloat;
+
+    if (!(at::GradMode::is_enabled() && any_inputs_require_grad) && all_contiguous && !any_nested && is_input_fp &&
+        is_weight_fp) {
+      _check_rms_norm_inputs_symint(input, normalized_shape_symint, weight);
+      double eps_val;
+      if (!eps_opt.has_value()) {
+        eps_val = std::numeric_limits<at::scalar_value_type<double>::type>::epsilon();
+      } else {
+        eps_val = eps_opt.value();
+      }
+      return rms_norm_mps_kernel(input, normalized_shape, weight, eps_val);
+    }
+  }
+
+  return rms_norm_symint(input, normalized_shape_symint, weight_opt, eps_opt);
+}
+
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/RMSNorm.mm
+++ b/aten/src/ATen/native/mps/operations/RMSNorm.mm
@@ -23,6 +23,7 @@ Tensor rms_norm_mps_kernel(const Tensor& input,
                            c10::SymIntArrayRef normalized_shape,
                            const Tensor& weight,
                            const double eps) {
+  TORCH_CHECK(input.is_contiguous() && weight.is_contiguous());
   auto output = at::empty_like(input);
   const int normalized_ndim = normalized_shape.size();
   const auto input_shape = input.sizes();

--- a/aten/src/ATen/native/mps/operations/RMSNorm.mm
+++ b/aten/src/ATen/native/mps/operations/RMSNorm.mm
@@ -5,7 +5,6 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/empty_like.h>
-#include <ATen/ops/rms_norm_native.h>
 #endif
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/mps/OperationUtils.h>

--- a/aten/src/ATen/native/mps/operations/RMSNorm.mm
+++ b/aten/src/ATen/native/mps/operations/RMSNorm.mm
@@ -6,7 +6,6 @@
 #else
 #include <ATen/ops/empty_like.h>
 #endif
-#include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/operations/RMSNorm.h>
 #include <fmt/format.h>
@@ -23,7 +22,7 @@ Tensor rms_norm_mps_kernel(const Tensor& input,
                            c10::SymIntArrayRef normalized_shape,
                            const Tensor& weight,
                            const double eps) {
-  TORCH_CHECK(input.is_contiguous() && weight.is_contiguous());
+  TORCH_CHECK(input.is_contiguous() && weight.is_contiguous(), "Expected contiguous input and weight tensors");
   auto output = at::empty_like(input);
   const int normalized_ndim = normalized_shape.size();
   const auto input_shape = input.sizes();

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3308,7 +3308,6 @@
 - func: rms_norm(Tensor input, SymInt[] normalized_shape, Tensor? weight=None, float? eps=None) -> Tensor
   dispatch:
     CompositeImplicitAutograd: rms_norm_symint
-    MPS: rms_norm_mps
 
 - func: nan_to_num(Tensor self, float? nan=None, float? posinf=None, float? neginf=None) -> Tensor
   variants: function, method

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3308,6 +3308,7 @@
 - func: rms_norm(Tensor input, SymInt[] normalized_shape, Tensor? weight=None, float? eps=None) -> Tensor
   dispatch:
     CompositeImplicitAutograd: rms_norm_symint
+    MPS: rms_norm_mps
 
 - func: nan_to_num(Tensor self, float? nan=None, float? posinf=None, float? neginf=None) -> Tensor
   variants: function, method


### PR DESCRIPTION
Adding a fused rms_norm implementation for MPS backend. This eliminates most of the current CPU overhead, making this computation GPU bound and improving latency of rms_norm by **15x** on MPS backend
The metal shader was adapted from MLX: https://github.com/ml-explore/mlx/blob/e6a7ab967530866eb89c013f833f7c525bec10ca/mlx/backend/metal/kernels/rms_norm.metal

The numbers below are averages over 1000 runs of RMSNorm, obtained on an M1 Pro.

Benchmarking Results (Before):
```
Device            :            MPS            |           CPU
Dtype             :   FP32  |  FP16  |  BF16  |  FP32  |  FP16  |  BF16
Outputs Match     :   True  |  True  |  True  |  True  |  True  |  True
Average Time (us) :  140.5  | 171.0  | 170.4  |  10.9  |  13.3  |  13.5
```

Benchmarking Results (After):
```
Device            :            MPS            |           CPU
Dtype             :   FP32  |  FP16  |  BF16  |  FP32  |  FP16  |  BF16
Outputs Match     :   True  |  True  |  True  |  True  |  True  |  True
Average Time (us) :   10.1  |  11.7  |  12.6  |  10.0  |  12.4  |  13.0
```

Profiling Results (Before):
```
-----------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                         Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
-----------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
               aten::rms_norm         2.35%       3.284ms       100.00%     140.038ms     140.038us          1000  
                    aten::mul        33.61%      47.068ms        33.61%      47.068ms      23.534us          2000  
                    aten::pow        17.04%      23.868ms        17.43%      24.402ms      24.402us          1000  
                   aten::add_        16.52%      23.130ms        16.78%      23.497ms      23.497us          1000  
                   aten::mean        15.82%      22.151ms        15.82%      22.151ms      22.151us          1000  
                  aten::rsqrt        13.63%      19.085ms        13.71%      19.198ms      19.198us          1000  
                   aten::item         0.46%     639.370us         0.56%     788.376us       0.394us          2000  
                aten::type_as         0.21%     295.507us         0.27%     371.291us       0.371us          1000  
                     aten::to         0.13%     177.742us         0.13%     177.742us       0.059us          3000  
    aten::_local_scalar_dense         0.11%     149.006us         0.11%     149.006us       0.075us          2000  
-----------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 140.038ms
```

Profiling Results (After):
```
-----------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
-----------------------  ------------  ------------  ------------  ------------  ------------  ------------  
         aten::rms_norm        63.21%     832.875us       100.00%       1.318ms       1.318us          1000  
       aten::empty_like        16.06%     211.631us        36.79%     484.681us       0.485us          1000  
    aten::empty_strided        20.72%     273.050us        20.72%     273.050us       0.273us          1000  
-----------------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 1.318ms
```

Benchmarking and profiling script:
```python
import torch
import torch.nn as nn
from torch.profiler import profile
import time

def benchmark(device, dtype):
    model = nn.RMSNorm(2048, device=device)

    # Create example inputs
    x = torch.randn(1, 1, 2048, requires_grad=False, device=device, dtype=dtype)
    w = torch.randn(2048, requires_grad=False, device=device, dtype=dtype)
    eps = 1e-5

    # Check output
    y = torch.ops.aten.rms_norm(x, [2048], w, eps)
    z = torch.ops.aten.rms_norm(x.cpu(), [2048], w.cpu(), eps)
    outputs_match = torch.allclose(y.cpu(), z)

    # Measure time manually
    torch.mps.synchronize()
    start_time = time.time() * 1000
    for _ in range(1000):
        with torch.no_grad():
            y = model(x)
    torch.mps.synchronize()
    end_time = time.time() * 1000
    manual_delta = (end_time - start_time)
    average_time = f"{manual_delta:6.1f}"

    return outputs_match, average_time


outputs_match_list = []
average_time_list = []
for device in ["mps", "cpu"]:
    for dtype in [torch.float32, torch.float16, torch.bfloat16]:
        outputs_match, average_time = benchmark(device, dtype)
        outputs_match_list.append(str(outputs_match))
        average_time_list.append(average_time)

print("\nBenchmarking Results:")
print("---------------------")
print("Device            :            MPS            |           CPU")
print("Dtype             :   FP32  |  FP16  |  BF16  |  FP32  |  FP16  |  BF16")
print(f"Outputs Match     :  ", "  |  ".join(outputs_match_list))
print(f"Average Time (us) :", "  |".join(average_time_list))

device = "mps"
dtype = torch.float32
model = nn.RMSNorm(2048, device=device)
x = torch.randn(1, 1, 2048, requires_grad=False, device=device, dtype=dtype)

# Run and profile the model
with profile() as prof:
    with torch.no_grad():
        for _ in range(1000):
            y = model(x)
        torch.mps.synchronize()

# Print profiling results
print("\n\nProfiling Results (MPS/FP32):")
print(prof.key_averages().table(sort_by="cpu_time_total", row_limit=10))
```