### PR TITLE
Add unique identifer to bmm thread_mm functions

### DIFF
--- a/torch/_inductor/codegen/cpp_bmm_template.py
+++ b/torch/_inductor/codegen/cpp_bmm_template.py
@@ -21,7 +21,7 @@ GEMM_SINGLE_THREAD_MM_STUB = r"""
     inputs={"X": X, "W": W},
     outputs={"Y": Y_2d},
     aliases=aliases,
-    function_name="single_thread_mm",
+    function_name=kernel_name+"_single_thread_mm",
     extra_sizevars=BY_sizevars + [b_index],
     placeholder="<SINGLE_THREAD_MM_DEF_FOR_BMM>")}}"""
 
@@ -30,7 +30,7 @@ GEMM_THREADED_MM_STUB = r"""
     inputs={"X": X, "W": W},
     outputs={"Y": Y_2d},
     aliases=aliases,
-    function_name="threaded_mm",
+    function_name=kernel_name+"_threaded_mm",
     extra_sizevars=BY_sizevars + [b_index],
     placeholder="<THREADED_MM_DEF_FOR_BMM>")}}"""
 
@@ -54,7 +54,7 @@ extern "C"
     for (int64_t b_start = 0; b_start < B_single_thread_block; ++b_start) {
         {{template.get_gemm_function_call(
             kernel,
-            "single_thread_mm",
+            kernel_name+"_single_thread_mm",
             "<SINGLE_THREAD_CALL_FOR_BMM>",
             b_index="b_start",
         )}}
@@ -62,7 +62,7 @@ extern "C"
     for (int64_t b_start = B_single_thread_block; b_start < B; ++b_start) {
         {{template.get_gemm_function_call(
             kernel,
-            "threaded_mm",
+            kernel_name+"_threaded_mm",
             "<THREADED_MM_CALL_FOR_BMM>",
             b_index="b_start",
         )}}
@@ -195,6 +195,7 @@ class CppBmmTemplate(CppGemmTemplate):
             if isinstance(sym, sympy.Expr)
             for s in sym.free_symbols
         ]
+        options["kernel_name"] = kernel.kernel_name
 
         return options
 


### PR DESCRIPTION
Summary:
The bmm template generates code like this

```
template<bool accum>
void cpp_fused_bmm_66_micro_gemm(...) {
    ...
}

void single_thread_mm() {
    ...
    cpp_fused_bmm_66_micro_gemm(...)
    ...
}

void threaded_mm() {
    ...
    cpp_fused_bmm_66_micro_gemm(...)
    ...
}

void cpp_fused_bmm_66(...)
{
    ...
    single_thread_mm(...);
    ...
    threaded_mm(...);
    ...
}
```

The generated  `fused_bmm` and `fused_bmm_microgemm` functions both have unique identifiers added to their names, but the `single_threaded_mm` and `threaded_mm` do not.

This diff adds unique identifies to those generated functions as well. The identifier is based on the kernel name. So for the example above we would generate a bmm template name like `cpp_fused_bmm_66_single_thread_mm()`.

Differential Revision: D68364772


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov