### PR TITLE
[S481486] Move MTIA dynamic library loading from __init__.py to a separate module

### DIFF
--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -66,7 +66,7 @@ def _lazy_init() -> None:
         if not _is_compiled():
             raise AssertionError(
                 "Torch not compiled with MTIA enabled. "
-                "Ensure you have `import mtia.host_runtime.torch_mtia` in your python "
+                "Ensure you have `import mtia.host_runtime.torch_mtia.dynamic_library` in your python "
                 "src file and include `//mtia/host_runtime/torch_mtia:torch_mtia` as "
                 "your target dependency!"
             )


### PR DESCRIPTION
Summary: As titled

Test Plan:
- Passed CI tests

buck2 test 'fbcode//mode/opt' fbcode//ai_infra/distributed_ai/pyper_local_run/tests/integration_tests:test_icvr_e2e_gpu -- --exact 'ai_infra/distributed_ai/pyper_local_run/tests/integration_tests:test_icvr_e2e_gpu - test_icvr_e2e_gpu (ai_infra.distributed_ai.pyper_local_run.tests.integration_tests.test_icvr_e2e_gpu.TestIcvrE2EGpu)' --run-disabled
```


https://www.internalfb.com/intern/testinfra/testconsole/testrun/9007199320480497/

Differential Revision: D68463242


