### PR TITLE
[inductor] let inplace-padding support cpp-wrapper

### DIFF
--- a/test/inductor/test_inplace_padding.py
+++ b/test/inductor/test_inplace_padding.py
@@ -118,10 +118,39 @@ class InplacePaddingTest(TestCase):
         x = torch.randn(2048, 2047, device=GPU_TYPE)
 
         ref = f(x)
-        act, (code,) = run_and_get_code(torch.compile(f), x)
+        from torch._inductor.codegen.cpp_wrapper_gpu import CppWrapperGpu
+
+        orig_generate_and_run_autotune_block = (
+            CppWrapperGpu.generate_and_run_autotune_block
+        )
+        compile_time_autotune_called = False
+
+        def mock_generate_and_run_autotune_block(wrapper):
+            nonlocal compile_time_autotune_called
+            compile_time_autotune_called = True
+            out = orig_generate_and_run_autotune_block(wrapper)
+            call_code = wrapper.kernel_autotune_calls.getvalue()
+            FileCheck().check(
+                "buf0 = generate_example_value((2048, 2047), (2048, 1), 'cuda:0', torch.float32, 0, (2048, 2048))"
+            ).run(call_code)
+            return out
+
+        with unittest.mock.patch.object(
+            CppWrapperGpu,
+            "generate_and_run_autotune_block",
+            mock_generate_and_run_autotune_block,
+        ):
+            act, (code,) = run_and_get_code(torch.compile(f), x)
+
+        # Buf0 should be over-allocated and then strided.
+        FileCheck().check(
+            "aoti_torch_as_strided(buf0_handle, &buf0_handle_restrided,"
+        ).run(code)
 
         self.assertTrue(torch.allclose(ref, act, atol=1e-2, rtol=1e-2))
-        self.assertEqual(num_inplace_padding(), 0)
+
+        self.assertEqual(num_inplace_padding(), 1)
+        self.assertTrue(compile_time_autotune_called)
 
     def test_pad_too_large(self):
         def f(x, y):

--- a/test/inductor/test_inplace_padding.py
+++ b/test/inductor/test_inplace_padding.py
@@ -143,8 +143,8 @@ class InplacePaddingTest(TestCase):
             act, (code,) = run_and_get_code(torch.compile(f), x)
 
         # Buf0 should be over-allocated and then strided.
-        FileCheck().check(
-            "aoti_torch_as_strided(buf0_handle, &buf0_handle_restrided,"
+        FileCheck().check_regex(
+            r"aoti_torch_as_strided\(buf0_handle, .*, &buf0_handle_restrided\)"
         ).run(code)
 
         self.assertTrue(torch.allclose(ref, act, atol=1e-2, rtol=1e-2))

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1346,22 +1346,41 @@ class CppWrapperCpu(PythonWrapperCodegen):
             buffer.get_dtype(),
             buffer.get_size(),
             buffer.get_stride(),
+            V.graph.get_allocation_size(buffer),
         )
 
     def make_allocation(
         self, name, device, dtype, shape, stride, allocation_shape=None
     ):
+        if allocation_shape is None:
+            allocation_shape = shape
+
         orig_stride = stride
         device_str = self.codegen_device(device)
         dtype_code = self.codegen_dtype(dtype)
         size = self.codegen_shape_tuple(shape)
+        allocation_size = self.codegen_shape_tuple(allocation_shape)
         stride = self.codegen_shape_tuple(orig_stride)
+
         size_array_var = self.codegen_int_array_var(
             size,
             self.wrapper_call.writeline,
             known_statically=self.is_statically_known_list_of_ints(shape),
             graph=self.get_codegened_graph(),
         )
+
+        if allocation_size != size:
+            allocation_size_array_var = self.codegen_int_array_var(
+                allocation_size,
+                self.wrapper_call.writeline,
+                known_statically=self.is_statically_known_list_of_ints(
+                    allocation_shape
+                ),
+                graph=self.get_codegened_graph(),
+            )
+        else:
+            allocation_size_array_var = size_array_var
+
         stride_array_var = self.codegen_int_array_var(
             stride,
             self.wrapper_call.writeline,
@@ -1371,22 +1390,36 @@ class CppWrapperCpu(PythonWrapperCodegen):
         device_type, device_id = device_str.split(",")
         device_idx = "this->device_idx_" if V.graph.aot_mode else device_id
 
+        handle_name = f"{name}_handle"
         args = [
             str(len(shape)),
-            size_array_var,
+            allocation_size_array_var,
             stride_array_var,
             dtype_code,
             device_type,
             device_idx,
-            f"&{name}_handle",
+            f"&{handle_name}",
         ]
 
-        self.wrapper_call.writeline(f"AtenTensorHandle {name}_handle;")
+        self.wrapper_call.writeline(f"AtenTensorHandle {handle_name};")
         self.wrapper_call.writeline(
             f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_empty_strided({', '.join(args)}));"
         )
 
-        return f"RAIIAtenTensorHandle {name}({name}_handle);"
+        if allocation_size != size:
+            old_handle_name, handle_name = handle_name, f"{name}_handle_restrided"
+            self.wrapper_call.writeline(f"AtenTensorHandle {handle_name};")
+            args = [
+                old_handle_name,
+                f"&{handle_name}",
+                size_array_var,
+                stride_array_var,
+            ]
+            self.wrapper_call.writeline(
+                f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_as_strided({', '.join(args)}));"
+            )
+
+        return f"RAIIAtenTensorHandle {name}({handle_name});"
 
     def codegen_alloc_from_pool(self, name, offset, dtype, shape, stride) -> str:
         size = self.codegen_shape_tuple(shape)

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1411,9 +1411,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
             self.wrapper_call.writeline(f"AtenTensorHandle {handle_name};")
             args = [
                 old_handle_name,
-                f"&{handle_name}",
                 size_array_var,
                 stride_array_var,
+                f"&{handle_name}",
             ]
             self.wrapper_call.writeline(
                 f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_as_strided({', '.join(args)}));"

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1886,6 +1886,13 @@ class PythonWrapperCodegen(CodeGen):
                 )
                 for e in buf.get_size()
             )
+            allocation_size = tuple(
+                V.graph.sizevars.atomically_apply_size_hint(
+                    e,
+                    fallback=config.unbacked_symint_fallback,
+                )
+                for e in V.graph.get_allocation_size(buf)
+            )
             stride = tuple(
                 V.graph.sizevars.atomically_apply_size_hint(
                     e,
@@ -1899,7 +1906,7 @@ class PythonWrapperCodegen(CodeGen):
                 buf.get_layout().offset,
                 fallback=config.unbacked_symint_fallback,
             )
-            value = f"generate_example_value({size}, {stride}, '{device}', {dtype}, {offset})"
+            value = f"generate_example_value({size}, {stride}, '{device}', {dtype}, {offset}, {allocation_size})"
             self.kernel_autotune_calls.writeline(f"{buf_name} = {value}")
 
             if isinstance(raw_arg, ir.TMADescriptor):

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1510,7 +1510,6 @@ def get_cpp_wrapper_config() -> dict[str, object]:
         "triton.autotune_cublasLt": False,
         "triton.cudagraphs": False,  # TODO: to be removed
         "triton.store_cubin": True,
-        "inplace_padding": False,
     }
 
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2180,7 +2180,7 @@ class AlgorithmSelectorCache(PersistentCache):
         # sizes/strides
         return AlgorithmSelectorCache.generate_example_value(
             V.graph.sizevars.size_hints(
-                V.graph.get_allocation_size(node),
+                node.get_size(),
                 fallback=config.unbacked_symint_fallback,
             ),
             V.graph.sizevars.size_hints(
@@ -2190,29 +2190,35 @@ class AlgorithmSelectorCache(PersistentCache):
             node.get_device(),
             node.get_dtype(),
             node.layout.offset,
-        ).as_strided(
             V.graph.sizevars.size_hints(
-                node.get_size(),
-                fallback=config.unbacked_symint_fallback,
-            ),
-            V.graph.sizevars.size_hints(
-                node.get_stride(),
+                V.graph.get_allocation_size(node),
                 fallback=config.unbacked_symint_fallback,
             ),
         )
 
     @staticmethod
-    def generate_example_value(size, stride, device, dtype, extra_size):
+    def generate_example_value(
+        size, stride, device, dtype, extra_size, allocation_size=None
+    ):
         # preserve rng states to avoid the rand_strided call below changes
         # the rng states for the real model code.
         with preserve_rng_state():
-            return rand_strided(
-                size,
-                stride,
-                device=device,
-                dtype=dtype,
-                extra_size=extra_size,
-            )
+            if allocation_size is None or allocation_size == size:
+                return rand_strided(
+                    size,
+                    stride,
+                    device=device,
+                    dtype=dtype,
+                    extra_size=extra_size,
+                )
+            else:
+                return rand_strided(
+                    allocation_size,
+                    stride,
+                    device=device,
+                    dtype=dtype,
+                    extra_size=extra_size,
+                ).as_strided(size, stride)
 
     @staticmethod
     def key_of(node):

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -303,9 +303,9 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_empty_strided(
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_as_strided(
     AtenTensorHandle self,
-    AtenTensorHandle* ret,
     const int64_t* sizes_ptr,
-    const int64_t* strides_ptr);
+    const int64_t* strides_ptr,
+    AtenTensorHandle* ret);
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_create_tensor_from_blob(
     void* data,

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -301,6 +301,12 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_empty_strided(
     AtenTensorHandle* ret_new_tensor // returns new reference
 );
 
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_as_strided(
+    AtenTensorHandle self,
+    AtenTensorHandle* ret,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr);
+
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_create_tensor_from_blob(
     void* data,
     int64_t ndim,

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -797,9 +797,9 @@ AOTITorchError aoti_torch_clone(AtenTensorHandle self, AtenTensorHandle* ret) {
 
 AOTITorchError aoti_torch_as_strided(
     AtenTensorHandle self,
-    AtenTensorHandle* ret,
     const int64_t* sizes_ptr,
-    const int64_t* strides_ptr) {
+    const int64_t* strides_ptr,
+    AtenTensorHandle* ret) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     int64_t ndim = self_tensor->dim();

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -795,6 +795,21 @@ AOTITorchError aoti_torch_clone(AtenTensorHandle self, AtenTensorHandle* ret) {
   });
 }
 
+AOTITorchError aoti_torch_as_strided(
+    AtenTensorHandle self,
+    AtenTensorHandle* ret,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
+    int64_t ndim = self_tensor->dim();
+    c10::IntArrayRef sizes(sizes_ptr, ndim);
+    c10::IntArrayRef strides(strides_ptr, ndim);
+    at::Tensor ret_tensor = self_tensor->as_strided(sizes, strides);
+    *ret = new_tensor_handle(std::move(ret_tensor));
+  });
+}
+
 AOTITorchError aoti_torch_clone_preserve_strides(
     AtenTensorHandle self,
     AtenTensorHandle* ret) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #145410
* __->__ #145325
* #140249

Some context: Inplace padding is an optimization to do padding in place. E.g., if a tensor has size [2048, 2047] and stride [2048, 1]. When we need pad one extra element to the end of each row (e.g. during mm padding), we can just reuse the original tensor and do the padding inplace. This saves memory and bandwidth.  One caveat for this optimization is, PyTorch does not allocate 2048 elements for the last row of the original tensor. It only allocate 2047 elements. So assuming the last row having enough space for 2048 elements may be wrong and cause OOB memory access (although I never see this happen maybe due to overallocation in the CUDACachingAllocation, this should better be fixed).

The fix is when we allocate the tensor, instead of doing something like:
```
  buf0 = randn_strided([2048, 2047], [2048, 1])
```
we do some small overallocation
```
  buf0 = randn_strided([2048, 2048], [2048, 1]).as_strided([2048, 2047], [2048, 1])
```

cpp_wrapper needs special handling since memory allocation goes thru different code path to python wrapper.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov