### PR TITLE
[be] fix flaky test aot_export_ cond caused by free symbol lifting and automatic dynamic shape

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -3960,6 +3960,10 @@ class TestMod(torch.nn.Module):
 
 
 class TestAOTExport(AOTTestCase):
+    def setUp(self):
+        super().setUp()
+        torch._dynamo.reset()
+
     def test_aot_export_ban_dropout_mut_pre_dispatch(self):
         def fn(p, x):
             y = torch.ops.aten.dropout.default(x, 0.1, train=False)
@@ -4220,8 +4224,6 @@ def forward(self, arg0_1, arg1_1):
         not torchdynamo.is_dynamo_supported(), "TorchDynamo is not supported"
     )
     def test_aot_export_predispatch_with_cond_nested(self):
-        torch._dynamo.reset()
-
         class M(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -4300,8 +4302,6 @@ def forward(self, arg0_1):
         not torchdynamo.is_dynamo_supported(), "TorchDynamo is not supported"
     )
     def test_aot_export_predispatch_map_1(self):
-        torch._dynamo.reset()
-
         class M(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -4429,8 +4429,6 @@ def forward(self, arg0_1, arg1_1):
         not torchdynamo.is_dynamo_supported(), "TorchDynamo is not supported"
     )
     def test_aot_export_predispatch_with_cond(self):
-        torch._dynamo.reset()
-
         class M(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -4867,8 +4865,6 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         not torch._dynamo.is_dynamo_supported(), "Cond needs dynamo to run"
     )
     def test_aot_export_with_torch_cond(self):
-        torch._dynamo.reset()
-
         class M(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -4220,6 +4220,8 @@ def forward(self, arg0_1, arg1_1):
         not torchdynamo.is_dynamo_supported(), "TorchDynamo is not supported"
     )
     def test_aot_export_predispatch_with_cond_nested(self):
+        torch._dynamo.reset()
+
         class M(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -4298,6 +4300,8 @@ def forward(self, arg0_1):
         not torchdynamo.is_dynamo_supported(), "TorchDynamo is not supported"
     )
     def test_aot_export_predispatch_map_1(self):
+        torch._dynamo.reset()
+
         class M(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -4425,6 +4429,8 @@ def forward(self, arg0_1, arg1_1):
         not torchdynamo.is_dynamo_supported(), "TorchDynamo is not supported"
     )
     def test_aot_export_predispatch_with_cond(self):
+        torch._dynamo.reset()
+
         class M(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -4861,6 +4867,8 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         not torch._dynamo.is_dynamo_supported(), "Cond needs dynamo to run"
     )
     def test_aot_export_with_torch_cond(self):
+        torch._dynamo.reset()
+
         class M(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145330

Fixes https://github.com/pytorch/pytorch/issues/139998#issuecomment-2605908426.

It seems to be an issue caused by the interaction between dynamoed hop X automatic dynamic shape X auto_lift_free symbols. The immediate error is that the asserteExpectedInline of the graph can sometimes be different e.g. see https://hud.pytorch.org/flakytest?name=test_aot_export_with_torch_cond&suite=TestAOTExport&limit=100, where sometimes the shapes are lifted as input to the cond and sometimes they're not. 

The root cause of the flakyness is that the two invocations of torch.cond triggers two torch.compile on the same code object ([code](https://github.com/pytorch/pytorch/blob/main/torch/_higher_order_ops/cond.py#L192)), and triggers automatic dynamic shape because in test_aot_export_with_torch_cond, x has shape (3, 4) while the pre_dispatch one has shape (2, 2). Because of we auto lift free symbols for dynamic shaped input, this causes cond sometimes have the shape as arguments and sometimes not.

This PR adds a simple fix by adding a _dynamo.reset before each torch.cond tests. This fixes the error by not triggering automatic dynamic shape.