### PR TITLE
[WIP] [AOTInductor] Use AtenTensorHandle as the constant map's holder.

### DIFF
--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -287,12 +287,14 @@ AOTIRuntimeError AOTInductorModelCreate(
     AOTInductorModelHandle* model_handle,
     AOTInductorConstantMapHandle constant_map_handle){
     CONVERT_EXCEPTION_TO_ERROR_CODE({
-      auto constant_map = std::make_shared<torch::aot_inductor::ConstantMap>();
+      auto constant_map = std::make_shared<torch::aot_inductor::FreeConstantMap>();
+      auto constant_holder = std::make_shared<torch::aot_inductor::ConstantMap>();
       auto constant_array = std::make_shared<std::vector<torch::aot_inductor::ConstantHandle>>();
       auto input_map = reinterpret_cast<std::unordered_map<std::string, AtenTensorHandle>*>(constant_map_handle);
 
       auto model = new torch::aot_inductor::AOTInductorModel(
           constant_map,
+          constant_holder,
           constant_array,
           "cpu", // device_str is hardcoded, as AOTInductorModelCreate is only use for CPU models
           ""

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -629,7 +629,8 @@ class CppWrapperCpu(PythonWrapperCodegen):
         )
         self.prefix.splice(
             f"""
-            AOTInductorModel::AOTInductorModel(std::shared_ptr<ConstantMap> constants_map,
+            AOTInductorModel::AOTInductorModel(std::shared_ptr<FreeConstantMap> constants_map,
+                                               std::shared_ptr<ConstantMap> constants_holder,
                                                std::shared_ptr<std::vector<ConstantHandle>> constants_array,
                                                const std::string& device_str,
                                                std::optional<std::string> cubin_dir,
@@ -733,7 +734,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 self.prefix.writeline(
                     f"""constants_info_[{idx}].original_fqn = "{original_fqn}";"""
                 )
-            self.prefix.writeline("update_constants_map(std::move(constants_map));")
+            self.prefix.writeline(
+                "update_constants_map(std::move(constants_map), std::move(constants_holder));"
+            )
             self.prefix.writeline("update_constants_array(std::move(constants_array));")
 
             def escape_string(x):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145331

Summary:
Previously, all constants are held by RAIIAtenTensorHandle, which
implicitly indicates constants' lifetime is managed by the model itself.
We want to provide the flexibility to let users control the tensor's
lifetime instead.

This change is the first PR, aims to introduce a holder to act as the original
RAII holder managing the lifetime by the model and change the constant map to use AtenTensorHandle.
All behavior should be exactly the same as previous cases.

Test Plan:
Existing test cases. Not yet introducing new functionalities in this PR.

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @ColinPeppler @amjames @desertfire @chauhang @aakhundov

Differential Revision: [](https://our.internmc.facebook.com/intern/diff/)

Differential Revision: [D68472175](https://our.internmc.facebook.com/intern/diff/D68472175)