### PR TITLE
Fix deprecated pytorch_sphinx_theme editable installation in PyTorch CI

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -96,8 +96,6 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   if [ -n "$DOCS" ]; then
     apt-get update
     apt-get -y install expect-dev
-
-    # We are currently building docs with python 3.8 (min support version)
     pip_install --use-pep517 -r /opt/conda/requirements-docs.txt
   fi
 

--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -98,7 +98,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
     apt-get -y install expect-dev
 
     # We are currently building docs with python 3.8 (min support version)
-    pip_install -r /opt/conda/requirements-docs.txt
+    pip_install --use-pep517 -r /opt/conda/requirements-docs.txt
   fi
 
   popd

--- a/.ci/docker/requirements-docs.txt
+++ b/.ci/docker/requirements-docs.txt
@@ -1,7 +1,7 @@
 sphinx==5.3.0
 #Description: This is used to generate PyTorch docs
 #Pinned versions: 5.3.0
--e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
+git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 
 # TODO: sphinxcontrib.katex 0.9.0 adds a local KaTeX server to speed up pre-rendering
 # but it doesn't seem to work and hangs around idly. The initial thought is probably

--- a/.ci/docker/requirements-docs.txt
+++ b/.ci/docker/requirements-docs.txt
@@ -1,7 +1,12 @@
 sphinx==5.3.0
 #Description: This is used to generate PyTorch docs
 #Pinned versions: 5.3.0
-git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
+
+# NB: Due to https://github.com/pypa/pip/issues/11457, legacy -e will be deprecated
+# in 2025 and we need to use pip install --use-pep517 -r requirements.txt to install
+# this instead. Another approach is to update PyTorch pyproject.toml, but that change
+# has a much wider implication than just installing doc build requirements
+-e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 
 # TODO: sphinxcontrib.katex 0.9.0 adds a local KaTeX server to speed up pre-rendering
 # but it doesn't seem to work and hangs around idly. The initial thought is probably

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==5.0.0
--e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
+git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 # TODO: sphinxcontrib.katex 0.9.0 adds a local KaTeX server to speed up pre-rendering
 # but it doesn't seem to work and hangs around idly. The initial thought is probably
 # something related to Docker setup. We can investigate this later

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,9 @@
 sphinx==5.0.0
-git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
+# NB: Due to https://github.com/pypa/pip/issues/11457, legacy -e will be deprecated
+# in 2025 and we need to use pip install --use-pep517 -r requirements.txt to install
+# this instead. Another approach is to update PyTorch pyproject.toml, but that change
+# has a much wider implication than just installing doc build requirements
+-e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 # TODO: sphinxcontrib.katex 0.9.0 adds a local KaTeX server to speed up pre-rendering
 # but it doesn't seem to work and hangs around idly. The initial thought is probably
 # something related to Docker setup. We can investigate this later


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/145221

~~Pip editable install is going to be deprecated soon https://github.com/pypa/pip/issues/11457. The fix here is just to remove it and install `pytorch_sphinx_theme` normally.~~

It turns out that `-e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme` has some local resources like fonts that are needed to render the HTML pages.  So, we need to keep it and I add `--use-pep517` to properly support `-e`. Another approach is to update PyTorch pyproject.toml, but that change seems to have a much wider implication than just installing doc build requirements.

### Testing 

Doc build is working with the change:

* PR https://github.com/pytorch/pytorch/actions/runs/12901499736/job/35975042345?pr=145347
* Nightly https://github.com/pytorch/pytorch/actions/runs/12901500521/job/35975046289