### PR TITLE
removed check for ConvTranspose3D on MPS

### DIFF
--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -700,8 +700,6 @@ Tensor _mps_convolution_transpose(const Tensor& input_t,
                                   IntArrayRef stride,
                                   IntArrayRef dilation,
                                   int64_t groups) {
-  TORCH_CHECK(input_t.dim() < 5, "ConvTranspose 3D is not supported on MPS");
-
   auto output_t =
       mps_convolution_transpose_forward(input_t, weight_t, padding, output_padding, stride, dilation, groups);
   return output_t;


### PR DESCRIPTION
Fixes #130256

I removed `TORCH_CHECK(input_t.dim() < 5, "ConvTranspose 3D is not supported on MPS");` as it is actually supported.