### PR TITLE
[ARM] Fix `test_float_to_int_conversion_nonfinite`

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1430,7 +1430,7 @@ test_executorch() {
 test_linux_aarch64() {
   python test/run_test.py --include test_modules test_mkldnn test_mkldnn_fusion test_openmp test_torch test_dynamic_shapes \
         test_transformers test_multiprocessing test_numpy_interop test_autograd test_binary_ufuncs test_complex test_spectral_ops \
-        test_foreach test_reductions test_unary_ufuncs \
+        test_foreach test_reductions test_unary_ufuncs test_tensor_creation_ops \
         --shard "$SHARD_NUMBER" "$NUM_TEST_SHARDS" --verbose
 
   # Dynamo tests

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1093,13 +1093,13 @@ class TestTensorCreation(TestCase):
         if dtype == torch.bool:
             refs = (True, True, True)
         elif IS_ARM64:
-            refs = (torch.iinfo(dtype).min, torch.iinfo(dtype).max, 0 )
+            refs = (torch.iinfo(dtype).min, torch.iinfo(dtype).max, 0)
             if dtype in (torch.int8, torch.int16):
                 refs = (0, -1, 0)
         else:
             refs = (0, 0, 0)
             if dtype in (torch.int32, torch.int64):
-                refs = ( torch.iinfo(dtype).min, ) * 3
+                refs = (torch.iinfo(dtype).min, ) * 3
         self._float_to_int_conversion_helper(vals, device, dtype, refs)
 
     @onlyNativeDeviceTypes


### PR DESCRIPTION
We have broken tests on Aarch64 which are not enabled upstream, this PR will fix and enable those tests.

```
AssertionError: Tensor-likes are not equal!

Mismatched elements: 2 / 3 (66.7%)
Greatest absolute difference: 1 at index (1,)
Greatest relative difference: 1.0842021724855044e-19 at index (1,)

To execute this test, run the following from the base repo dir:
    python test/test_tensor_creation_ops.py TestTensorCreationCPU.test_float_to_int_conversion_nonfinite_cpu_int64

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
```

cc @malfet @snadampal @milpuz01