### PR TITLE
Use guard_size_oblivious in debug tensor writer

### DIFF
--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -678,14 +678,14 @@ class InputWriter:
         return v
 
     def tensor(self, name, t) -> None:
-        from torch.fx.experimental.symbolic_shapes import statically_known_true
+        from torch.fx.experimental.symbolic_shapes import statically_known_true, guard_size_oblivious, sym_eq
 
         storage = self.storage(
             t.untyped_storage(), dtype_hint=t.dtype, device_hint=t.device
         )
         args = []
         # NB: this is positional, must come first
-        if _stride_or_default(None, shape=t.shape) != t.stride():
+        if guard_size_oblivious(sym_eq(_stride_or_default(None, shape=t.shape), t.stride())):
             args.append(str(tuple(t.stride())))
         if _dtype_or_default(None) != t.dtype:
             args.append(f"dtype={t.dtype!r}")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #145650
* __->__ #145403

I've been playing around with graphbreaks and found it sad that the
following code doesn't trace due to a printer calling guard_bool on
size-like strides.

previously this code wouldn't trace, but now it does

```
import torch

torch._dynamo.config.automatic_dynamic_local_pgo = False

@torch.compile()
def fn(x):
    y = torch.cat([x, x])
    torch._dynamo.graph_break()
    z = torch.cat([y, y])
    torch._dynamo.graph_break()
    return torch.cat([z, z])

x = torch.ones(5, 5)
torch._dynamo.decorators.mark_unbacked(x, 0)
torch._dynamo.decorators.mark_unbacked(x, 1)
fn(x)

```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames