### PR TITLE
[distributions] Catch inf gradient in beta distribution

### DIFF
--- a/aten/src/ATen/native/Distributions.h
+++ b/aten/src/ATen/native/Distributions.h
@@ -405,7 +405,7 @@ C10_DEVICE inline scalar_t _beta_grad_beta_small(scalar_t x, scalar_t alpha, sca
     series += numer / (alpha + casted_i) * (dbetas + factor * betas);
   }
   const scalar_t result = -compat_pow(1 - x, 1 - beta) * series;
-  return isnan(result) ? static_cast<scalar_t>( 0.f ) : result;
+  return isnan(result) || std::isinf(result) ? static_cast<scalar_t>( 0.f ) : result;
 }
 
 // Approximate reparameterized gradient of Beta(x,alpha,beta) wrt alpha.

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -4629,6 +4629,14 @@ class TestRsample(DistributionsTestCase):
                 ),
             )
 
+    def test_beta_wrt_alpha_large_alpha(self):
+        alpha = torch.as_tensor([2**16 + 10.0]).requires_grad_()
+        beta = torch.as_tensor([1.5])
+        size = 1024
+        z = Beta(alpha, beta).rsample((size,))
+        z.mean().backward()
+        self.assertFalse(torch.isinf(alpha.grad).item())
+
     def test_dirichlet_multivariate(self):
         alpha_crit = 0.25 * (5.0**0.5 - 1.0)
         num_samples = 100000


### PR DESCRIPTION
Fixes #127387

Under the conditions in the issue, the calculations in [_beta_grad_beta_small](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/Distributions.h#L397) are numerically unstable (due to the `betas = betas * (beta - casted_i);` blowing up, since in that code path `beta` is large), and the gradient can end up being `nan` when `x` is close to 1 (and hence is close to 0 in that function as it uses `1-x`).
It seems that sometimes rather than become `nan`, the series ends up being `inf`, which isn't currently caught. I was able to verify this through some debug/print statements. I struggled to recreate the issue directly with a size of 1, even with directly calling the backward function with `x` values close to 1.

This PR amends the `nan` check by also checking for `inf`, and adds a test based on the failing case from the linked issue.
