### PR TITLE
[dynamo] Install guard when branching on empty dictionary

### DIFF
--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -725,6 +725,20 @@ class DictTests(torch._dynamo.test_case.TestCase):
         foo.scalar = 12
         self.assertEqual(fn(d, inp), opt_fn(d, inp))
 
+    def test_branch_on_dict(self):
+        def fn(x, d):
+            if d:
+                return x + 1
+            return x + 2
+
+        x = torch.ones(1)
+        d = {}
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x, d), opt_fn(x, d))
+
+        d["a"] = 1
+        self.assertEqual(fn(x, d), opt_fn(x, d))
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -918,8 +918,12 @@ def istype(obj: object, allowed_types: Iterable[type]) -> bool:
 
 def istype(obj, allowed_types):
     """isinstance() without subclasses"""
+    from .variables import LazyVariableTracker
+
     if isinstance(allowed_types, (tuple, list, set)):
         return type(obj) in allowed_types
+    if isinstance(obj, LazyVariableTracker):
+        obj = obj.realize()
     return type(obj) is allowed_types
 
 

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -60,6 +60,12 @@ class LazyVariableTracker(VariableTracker):
         assert isinstance(_cache, LazyCache)
         super().__init__(**kwargs)
         self._cache = _cache
+        # NOTE: The value of `mutation_type` is decided in the underlying `VT`
+        # (after it's been realized), thus we remove `mutation_type` from Lazy
+        # VT's instance __dict__, and have force any `lazy_vt.mutation_type` to
+        # route through `__getattr__` below, rather than returning the default
+        # `None` assigned in `VariableTracker.__init__`.
+        del self.mutation_type
 
     def realize(self) -> VariableTracker:
         """Force construction of the real VariableTracker"""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145405

This fixes an internal test failure on guarding NN module hooks, which
started failing after #143997 stopped eagerly guard on dictionary
length.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames