### PR TITLE
[BE] Fix edge case in translation validation bisector

### DIFF
--- a/torch/fx/experimental/validator.py
+++ b/torch/fx/experimental/validator.py
@@ -819,7 +819,13 @@ def bisect(shape_env):
     ]
 
     # Preparing the indices for binary search.
+    # The overall invariants are
+    # - for all i < left, assert_node[i] doesn't fail
+    # - for all i >= right, assert_node[i] fails
+    # - `right in exception` always holds
+    # - `left <= right` always holds
     left, mid, right = 0, 0, len(assert_nodes) - 1
+    exception[right] = check_node_fails(assert_nodes[right])
 
     while left < right:
         mid = (left + right) // 2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145414

This patch fixes a small bug for the binary-search algorithm in
translation validation bisector. Fixes #131303.

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv