### PR TITLE
[BE] Use `value_or` in layer_norm.cpp

### DIFF
--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -278,7 +278,7 @@ Tensor rms_norm_symint(
         input.scalar_type(),
         "rms_norm",
         [&] {
-    using limits =  std::numeric_limits<at::scalar_value_type<scalar_t>::type>;
+    using limits = std::numeric_limits<at::scalar_value_type<scalar_t>::type>;
     scalar_t eps_val = eps.value_or(limits::epsilon());
 
     // upcast is needed for fp16 and bf16

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -278,7 +278,7 @@ Tensor rms_norm_symint(
         input.scalar_type(),
         "rms_norm",
         [&] {
-    using limits =  std::numeric_limits<at::scalar_value_type<scalar_t>::type>;        
+    using limits =  std::numeric_limits<at::scalar_value_type<scalar_t>::type>;
     scalar_t eps_val = eps.value_or(limits::epsilon());
 
     // upcast is needed for fp16 and bf16

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -278,12 +278,8 @@ Tensor rms_norm_symint(
         input.scalar_type(),
         "rms_norm",
         [&] {
-    scalar_t eps_val;
-    if (!eps.has_value()) {
-      eps_val = std::numeric_limits<at::scalar_value_type<scalar_t>::type>::epsilon();
-    } else {
-      eps_val = eps.value();
-    }
+    using limits =  std::numeric_limits<at::scalar_value_type<scalar_t>::type>;        
+    scalar_t eps_val = eps.value_or(limits::epsilon());
 
     // upcast is needed for fp16 and bf16
     c10::ScalarType opmath_t = toOpMathType(input.scalar_type());


### PR DESCRIPTION
Now that we have proper optional, no need to do `if (has_value) value else default_value;`
