### PR TITLE
Implement deepcopy for AOTICompiledModel

### DIFF
--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -474,6 +474,28 @@ class TestAOTInductorPackage(TestCase):
         output = compiled(test_inputs)
         self.assertEqual(expected, output)
 
+    def test_deepcopy_compiled_model(self):
+        class Model(torch.nn.Module):
+            def forward(self, x, y):
+                return x + y
+
+        example_inputs = (
+            torch.randn(10, 10, device=self.device),
+            torch.randn(10, 10, device=self.device),
+        )
+
+        model = Model()
+
+        compiled = compile(model, example_inputs)
+
+        copmiled_copy = copy.deepcopy(compiled)
+
+        expected = model(*example_inputs)
+        output = compiled(*example_inputs)
+        output_copy = copmiled_copy(*example_inputs)
+        self.assertEqual(expected, output)
+        self.assertEqual(expected, output_copy)
+
     @skipif(
         lambda device, package_cpp_only: device == "cpu" or package_cpp_only,
         "No support for cpp only and cpu",

--- a/torch/_inductor/package/package.py
+++ b/torch/_inductor/package/package.py
@@ -7,7 +7,7 @@ import subprocess
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import torch
 import torch._inductor
@@ -267,6 +267,12 @@ class AOTICompiledModel:
 
     def get_constant_fqns(self) -> list[str]:
         return self.loader.get_constant_fqns()  # type: ignore[attr-defined]
+
+    def __deepcopy__(self, memo: Optional[Dict[Any, Any]]) -> "AOTICompiledModel":
+        log.warning(
+            "AOTICompiledModel deepcopy warning: AOTICompiledModel.loader is not deepcopied."
+        )
+        return AOTICompiledModel(self.loader)  # type: ignore[attr-defined]
 
 
 def load_package(path: Union[str, io.BytesIO], model_name: str = "model") -> AOTICompiledModel:  # type: ignore[type-arg]


### PR DESCRIPTION
Summary: 

Fix https://github.com/pytorch/pytorch/issues/145411

Support deepcopying AOTICompiledModel. The `loader` is shallow copied.

Test Plan:
```
buck2 run fbcode//mode/opt //caffe2/test/inductor:aot_inductor_package -- -r deepcopy
```

Differential Revision: D68524673




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov