### PR TITLE
[c10/metal] Add a vectype variant for `short`/`int`/`long`

### DIFF
--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -37,6 +37,20 @@ struct vectypes<short> {
   using type2 = short2;
 }
 
+template <>
+struct vectypes<int> {
+  using type4 = int4;
+  using type3 = int3;
+  using type2 = int2;
+}
+
+template <>
+struct vectypes<long> {
+  using type4 = short4;
+  using type3 = short3;
+  using type2 = short2;
+}
+
 } // namespace detail
 
 template <typename T>

--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -29,6 +29,14 @@ struct vectypes<bfloat> {
   using type2 = bfloat2;
 };
 #endif
+
+template <>
+struct vectypes<short> {
+  using type4 = short4;
+  using type3 = short3;
+  using type2 = short2;
+}
+
 } // namespace detail
 
 template <typename T>

--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -35,21 +35,21 @@ struct vectypes<short> {
   using type4 = short4;
   using type3 = short3;
   using type2 = short2;
-}
+};
 
 template <>
 struct vectypes<int> {
   using type4 = int4;
   using type3 = int3;
   using type2 = int2;
-}
+};
 
 template <>
 struct vectypes<long> {
   using type4 = short4;
   using type3 = short3;
   using type2 = short2;
-}
+};
 
 } // namespace detail
 


### PR DESCRIPTION
Some of the kernels (exp_complex/atan_complex) need the specialization.

cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov