### PR TITLE
Backout PEP585 use of Iterable

### DIFF
--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -3,8 +3,8 @@ import bisect
 import itertools
 import math
 import warnings
-from collections.abc import Iterable, Sequence
-from typing import cast, Generic, Optional, TypeVar, Union
+from collections.abc import Sequence
+from typing import cast, Generic, Iterable, Optional, TypeVar, Union
 from typing_extensions import deprecated
 
 # No 'default_generator' in torch/__init__.pyi


### PR DESCRIPTION
Summary:
Importing Iterable from collections.abc here causes an internal product to fail
MRO discovery causing a collision between Iterable and Generic.

This fixes the failure on D68461304

Differential Revision: D68531443
