### PR TITLE
[AOTInductor] Align behavior between CPU and GPU

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -42,11 +42,26 @@ extern uint8_t _binary_constants_bin_start[];
 // NOLINTNEXTLINE(*array*)
 extern uint8_t _binary_constants_bin_end[];
 
-#define AOTI_CONST_GPU_ALIGNMENT 64
+#if defined(USE_CUDA) || defined(USE_XPU)
+// Compute required blob size with 64-alignment if on GPU.
+#define AOTI_CONST_ALIGNMENT 64
+#else
+// Use 64-alignment (use something >=64)for better performance on CPU.
+#define AOTI_CONST_ALIGNMENT 64
+#endif
 
 namespace {
 
 using RAIIDataPtr = std::unique_ptr<void, std::function<void(void*)>>;
+
+RAIIDataPtr RAII_cpuMalloc(size_t num_bytes) {
+  void* data_ptr = std::malloc(num_bytes);
+  if (!data_ptr) {
+    throw std::bad_alloc();
+  }
+  auto deleter = [](void* ptr) { std::free(ptr); };
+  return RAIIDataPtr(data_ptr, deleter);
+}
 
 #ifdef USE_CUDA
 
@@ -260,13 +275,13 @@ class AOTInductorModelBase {
     constants_map_->reserve(num_constants);
 
     std::vector<size_t> constants_internal_offset(num_constants);
-    if (device_type_ != aoti_torch_device_type_cpu()) {
-      size_t blob_size = 0;
-      compute_gpu_constant_blob(blob_size, constants_internal_offset);
+    size_t blob_size = 0;
+    compute_constant_blob(blob_size, constants_internal_offset);
 #if defined(USE_CUDA) || defined(USE_XPU)
-      constant_blob_ = RAII_gpuMalloc(blob_size);
+    constant_blob_ = RAII_gpuMalloc(blob_size);
+#else
+    constant_blob_ = RAII_cpuMalloc(blob_size);
 #endif
-    }
     if (!include_weights) {
       return;
     }
@@ -274,12 +289,9 @@ class AOTInductorModelBase {
     size_t bytes_read = 0;
     for (size_t i = 0; i < num_constants; i++) {
       bool from_folded = this->constant_from_folded(i);
-#if not defined(USE_XPU) && not defined(USE_CUDA)
       if (from_folded) {
-        // We do not reallocate and copy for CPU.
         continue;
       }
-#endif // USE_CUDA
       std::string name = this->constant_name(i);
       size_t data_size = this->constant_data_size(i);
       uint8_t* internal_ptr = (data_size != 0)
@@ -343,10 +355,8 @@ class AOTInductorModelBase {
       size_t bytes_read,
       size_t data_size,
       bool skip_copy) {
-#if defined(USE_CUDA) || defined(USE_XPU)
     auto* constants_ptr = static_cast<uint8_t*>(constant_blob_.get());
     uint8_t* internal_ptr = constants_ptr + constant_offset;
-    // Copy data to GPU memory
     // TODO: Handle shared storage case.
     if (!skip_copy) {
 #ifdef USE_XPU
@@ -355,41 +365,33 @@ class AOTInductorModelBase {
       queue_ptr
           ->memcpy(internal_ptr, _get_constants_start() + bytes_read, data_size)
           .wait();
-
-#else
+#elif USE_CUDA
       AOTI_RUNTIME_DEVICE_CHECK(cudaMemcpy(
           internal_ptr,
           _get_constants_start() + bytes_read,
           data_size,
           cudaMemcpyHostToDevice));
+#else
+      memcpy(internal_ptr, _get_constants_start() + bytes_read, data_size);
 #endif
     }
     return internal_ptr;
-
-#else
-    // get pointer to constant which is packed in model during compile time.
-    AOTI_RUNTIME_CHECK(!skip_copy, "pure cpu mode doesn't support skip copy");
-    return _get_constants_start() + bytes_read;
-#endif // USE_CUDA
   }
 
-  void compute_gpu_constant_blob(
+  void compute_constant_blob(
       size_t& blob_size,
       std::vector<size_t>& constants_internal_offset) {
-#if defined(USE_CUDA) || defined(USE_XPU)
     size_t num_constants = this->num_constants();
-    // Compute required blob size with 64-alignment if on GPU.
     blob_size = 0;
     for (size_t i = 0; i < num_constants; i++) {
       size_t data_size = this->constant_data_size(i);
-      if (data_size % AOTI_CONST_GPU_ALIGNMENT) {
-        data_size = AOTI_CONST_GPU_ALIGNMENT +
-            (data_size / AOTI_CONST_GPU_ALIGNMENT) * AOTI_CONST_GPU_ALIGNMENT;
+      if (data_size % AOTI_CONST_ALIGNMENT) {
+        data_size = AOTI_CONST_ALIGNMENT +
+            (data_size / AOTI_CONST_ALIGNMENT) * AOTI_CONST_ALIGNMENT;
       }
       constants_internal_offset[i] = blob_size;
       blob_size += data_size;
     }
-#endif // USE_CUDA
   }
 
   size_t num_inputs() const {

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -52,11 +52,9 @@ class AOTInductorModelContainer {
       output_names_.emplace_back(model->output_name(static_cast<int64_t>(i)));
     }
     model->load_constants();
-#if defined(USE_CUDA) || defined(USE_XPU)
     constant_blob_ = model->release_constant_blob();
     constants_internal_offset_.resize(model->num_constants());
-    model->compute_gpu_constant_blob(blob_size_, constants_internal_offset_);
-#endif
+    model->compute_constant_blob(blob_size_, constants_internal_offset_);
 
     for (auto& model : models_) {
       model->update_constants_map(constants_map_);
@@ -90,7 +88,7 @@ class AOTInductorModelContainer {
         auto folded_const_map = model->run_const_fold(
             stream, proxy_executor, /* initialization = */ true);
         update_constant_buffer(
-            folded_const_map,
+            std::move(folded_const_map),
             /* use_inactive = */ false,
             /* validate_full_update = */ false);
         constant_folded_ = true;
@@ -176,7 +174,7 @@ class AOTInductorModelContainer {
       try {
         auto folded_const_map = model->run_const_fold(stream, proxy_executor);
         update_constant_buffer(
-            folded_const_map,
+            std::move(folded_const_map),
             /* use_inactive = */ false,
             /* validate_full_update = */ false);
       } catch (...) {
@@ -199,7 +197,7 @@ class AOTInductorModelContainer {
 
         auto folded_const_map = model->run_const_fold(stream, proxy_executor);
         update_constant_buffer(
-            folded_const_map,
+            std::move(folded_const_map),
             /* use_inactive = */ true,
             /* validate_full_update = */ false);
 
@@ -228,44 +226,48 @@ class AOTInductorModelContainer {
     return constant_type == ConstantType::TensorConstant;
   }
 
-  // This function updates the buffer for storing constants.
-  // It will update the buffer, the mapping and the array mapping.
+  void assert_all_constants(
+      const std::unordered_map<std::string, AtenTensorHandle>& constants_map) {
+    auto num_constants = models_[0]->num_constants();
+    for (size_t idx = 0; idx < num_constants; idx++) {
+      if (models_[0]->constant_from_folded(static_cast<int64_t>(idx))) {
+        continue;
+      }
+
+      auto constant_name =
+          std::string(models_[0]->constant_name(static_cast<int64_t>(idx)));
+      auto it = constants_map.find(constant_name);
+      if (it == constants_map.end()) {
+        if (_should_skip_update(idx)) {
+          // tracing sometimes creates tensors that are non-existent in
+          // original graph. We could skip those and do a direct copy.
+          std::cerr << "[WARNING] Found constant " << constant_name
+                    << " in model, but not provided by user!\n";
+          continue;
+        }
+        throw std::runtime_error(
+            std::string("Cannot find constants ") + constant_name +
+            std::string(" in constants_map!"));
+      }
+    }
+  }
+
+  // We directly take ownership from AtenTensorHandle if constants are moved.
   void update_constant_buffer(
-      const std::unordered_map<std::string, AtenTensorHandle>& constants_map,
+      std::unordered_map<std::string, AtenTensorHandle>&& constants_map,
       bool use_inactive,
       bool validate_full_update) {
     if (this->num_models() == 0) {
       throw std::runtime_error("No model available in container!");
     }
-    auto num_constants = models_[0]->num_constants();
-
     if (validate_full_update) {
-      for (size_t idx = 0; idx < num_constants; idx++) {
-        if (models_[0]->constant_from_folded(static_cast<int64_t>(idx))) {
-          continue;
-        }
-
-        auto constant_name =
-            std::string(models_[0]->constant_name(static_cast<int64_t>(idx)));
-        auto it = constants_map.find(constant_name);
-        if (it == constants_map.end()) {
-          if (_should_skip_update(idx)) {
-            // tracing sometimes creates tensors that are non-existent in
-            // original graph. We could skip those and do a direct copy.
-            std::cerr << "[WARNING] Found constant " << constant_name
-                      << " in model, but not provided by user!\n";
-            continue;
-          }
-          throw std::runtime_error(
-              std::string("Cannot find constants ") + constant_name +
-              std::string(" in constants_map!"));
-        }
-      }
+      assert_all_constants(constants_map);
     }
 
     auto original_constants_map = get_constants_map(!use_inactive);
     auto constants_map_to_update = get_constants_map(use_inactive);
 
+    auto num_constants = models_[0]->num_constants();
     for (size_t idx = 0; idx < num_constants; idx++) {
       auto constant_name =
           std::string(models_[0]->constant_name(static_cast<int64_t>(idx)));
@@ -275,7 +277,47 @@ class AOTInductorModelContainer {
         continue;
       }
 
-#if defined(USE_CUDA) || defined(USE_XPU)
+      AtenTensorHandle tensor;
+      if (_should_skip_update(idx) && use_inactive) {
+        aoti_torch_clone(
+            original_constants_map->find(constant_name)->second.get(), &tensor);
+      } else {
+        tensor = it->second;
+      }
+
+      constants_map_to_update->insert_or_assign(constant_name, tensor);
+    }
+    // Update the inactive constant array.
+    update_array_from_map(
+        get_constants_array(use_inactive), constants_map_to_update);
+  }
+
+  // This function updates the buffer for storing constants.
+  // It will update the buffer, the mapping and the array mapping.
+  void update_constant_buffer(
+      const std::unordered_map<std::string, AtenTensorHandle>& constants_map,
+      bool use_inactive,
+      bool validate_full_update) {
+    if (this->num_models() == 0) {
+      throw std::runtime_error("No model available in container!");
+    }
+    if (validate_full_update) {
+      assert_all_constants(constants_map);
+    }
+
+    auto original_constants_map = get_constants_map(!use_inactive);
+    auto constants_map_to_update = get_constants_map(use_inactive);
+
+    auto num_constants = models_[0]->num_constants();
+    for (size_t idx = 0; idx < num_constants; idx++) {
+      auto constant_name =
+          std::string(models_[0]->constant_name(static_cast<int64_t>(idx)));
+      auto it = constants_map.find(constant_name);
+      if (it == constants_map.end() &&
+          !(_should_skip_update(idx) && use_inactive)) {
+        continue;
+      }
+
       AtenTensorHandle tensor;
       if (_should_skip_update(idx) && use_inactive) {
         tensor = original_constants_map->find(constant_name)->second.get();
@@ -298,13 +340,14 @@ class AOTInductorModelContainer {
       queue_ptr
           ->memcpy(internal_constants_ptr, user_constant_ptr, constant_size)
           .wait();
-
-#else
+#elif USE_CUDA
       AOTI_RUNTIME_DEVICE_CHECK(cudaMemcpy(
           internal_constants_ptr,
           user_constant_ptr,
           constant_size,
           cudaMemcpyDefault));
+#else
+      memcpy(internal_constants_ptr, user_constant_ptr, constant_size);
 #endif
       // Generate Tensor from container handled blob.
       // We extract stride and offset from provided Tensor since we do not
@@ -327,13 +370,10 @@ class AOTInductorModelContainer {
           device_type,
           device_idx,
           &tensor_handle));
-#else // USE_CUDA
-      AtenTensorHandle tensor_handle = it->second;
-#endif // USE_CUDA
 
       // Now place the tensor to constants_map. Note at this point the ownership
       // of the tensor_handle will be taken over.
-      constants_map_to_update->emplace(constant_name, tensor_handle);
+      constants_map_to_update->insert_or_assign(constant_name, tensor_handle);
     }
     // Update the inactive constant array.
     update_array_from_map(
@@ -409,9 +449,7 @@ class AOTInductorModelContainer {
   RAIIDataPtr constant_blob_;
   RAIIDataPtr constant_blob_secondary_;
 
-#if defined(USE_CUDA) || defined(USE_XPU)
   size_t blob_size_;
-#endif
   std::vector<size_t> constants_internal_offset_;
 
   // Determine which constants is being used for the model.
@@ -467,19 +505,21 @@ class AOTInductorModelContainer {
   // make sure no one is executing the model.
   std::shared_mutex model_exec_mutex_;
 
-#if defined(USE_CUDA) || defined(USE_XPU)
   void* get_constant_blob_ptr(bool get_inactive) {
     if ((get_inactive && use_secondary_) ||
         (!get_inactive && !use_secondary_)) {
       return constant_blob_.get();
     } else {
       if (!constant_blob_secondary_) {
+#if defined(USE_CUDA) || defined(USE_XPU)
         constant_blob_secondary_ = RAII_gpuMalloc(blob_size_);
+#else
+        constant_blob_secondary_ = RAII_cpuMalloc(blob_size_);
+#endif // USE_CUDA
       }
       return constant_blob_secondary_.get();
     }
   }
-#endif // USE_CUDA
 
   std::shared_ptr<ConstantMap> get_constants_map(bool get_inactive) {
     if ((get_inactive && use_secondary_) ||


### PR DESCRIPTION
Summary:
(1) Make sure CPU and GPU doesn't have different implementation and behavior when calling from the same path and API. Only difference between CPU and GPU after this PR should ONLY be the running hardware.
(2) This PR fixes the issue of memory access when it==constants_map.end()
(3) This PR resolves T179437596

Test Plan: buck2 run mode/dev sigmoid/inference/test:e2e_test_cpu

Differential Revision: D68540744


