### PR TITLE
[fx] low overhead checking of nondeterministic_seeded

### DIFF
--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -688,8 +688,8 @@ class OpOverload(OperatorBase):
         self._overloadname = (
             "default" if schema.overload_name == "" else schema.overload_name
         )
-        if tags:
-            self._nondeterministic_seeded = torch.Tag.nondeterministic_seeded in tags
+        if tags and torch.Tag.nondeterministic_seeded in tags:
+            self._nondeterministic_seeded = True
         self._name = self._schema.name
         if schema.overload_name:
             self._name += "." + schema.overload_name

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -764,7 +764,8 @@ class Node(_NodeBase):
                 # impure since it mutates inputs
                 return True
 
-            if getattr(self.target, "_nondeterministic_seeded", False):
+            # intentionally avoiding getattr overhead here: https://github.com/pytorch/pytorch/issues/144775
+            if "_nondeterministic_seeded" in self.__dict__:
                 # impure since it mutates RNG state
                 return True
 


### PR DESCRIPTION
FIXES https://github.com/pytorch/pytorch/issues/144775

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145464

```
dev,name,batch_size,accuracy,calls_captured,unique_graphs,graph_breaks,unique_graph_breaks,autograd_captures,autograd_compiles,cudagraph_skips,compilation_latency
cuda,BartForConditionalGeneration,1,pass,1794,1,0,0,0,0,0,47.229793 # after this PR
cuda,BartForConditionalGeneration,1,pass,1794,1,0,0,0,0,0,56.271855 # before this PR
cuda,BartForConditionalGeneration,1,pass,1794,1,0,0,0,0,0,46.973284 # before https://github.com/pytorch/pytorch/pull/144319

```


cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv