### PR TITLE
OpenReg: Refactor impl_registry

### DIFF
--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/__init__.py
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/__init__.py
@@ -3,7 +3,7 @@ import torch
 # Create our python implementation dict so that the C++ module
 # can access it during its initialization
 # Also register aten impls
-from ._aten_impl import _IMPL_REGISTRY as _IMPL_REGISTRY  # noqa: F401
+from ._aten_impl import impl_factory as impl_factory  # noqa: F401
 
 
 # Load the C++ Module

--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/_aten_impl.py
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/_aten_impl.py
@@ -13,38 +13,16 @@ from ._meta_parser import prepare_for_sending, to_device_no_copy
 _IMPL_REGISTRY = {}
 
 
-# Define all the implementations in the registry
-def _register_same_name(name, with_log=False):
+def impl_factory(name):
+    if name in _IMPL_REGISTRY:
+        return _IMPL_REGISTRY[name]
+
     def _(*args, **kwargs):
-        if with_log:
-            log.info("Calling hook %s", name)
+        log.info("Calling hook %s", name)
         return driver.exec(name, *args, **kwargs)
 
     _IMPL_REGISTRY[name] = _
-
-
-_register_same_name("deviceCount")
-_register_same_name("getDevice")
-_register_same_name("setDevice")
-_register_same_name("uncheckedSetDevice")
-_register_same_name("exchangeDevice")
-_register_same_name("malloc", True)
-_register_same_name("free", True)
-_register_same_name("isPinnedPtr", True)
-_register_same_name("hostMalloc", True)
-_register_same_name("hostFree", True)
-_register_same_name("getNewStream")
-_register_same_name("queryStream")
-_register_same_name("getStream")
-_register_same_name("exchangeStream")
-_register_same_name("synchronizeStream")
-_register_same_name("record")
-_register_same_name("destroyEvent")
-_register_same_name("synchronizeEvent")
-_register_same_name("elapsedTime")
-_register_same_name("block")
-_register_same_name("queryEvent")
-_register_same_name("hasPrimaryContext")
+    return _
 
 
 # TODO: replace it with implementing torch.openreg.device

--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/csrc/Module.cpp
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/csrc/Module.cpp
@@ -18,7 +18,7 @@ PyMODINIT_FUNC PyInit__C(void) {
 
     py::object openreg_mod = py::module_::import("pytorch_openreg");
     // Only borrowed from the python side!
-    openreg::set_impl_registry(openreg_mod.attr("_IMPL_REGISTRY").ptr());
+    openreg::set_impl_factory(openreg_mod.attr("impl_factory").ptr());
 
     return mod;
 }

--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/csrc/OpenReg.h
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/csrc/OpenReg.h
@@ -5,7 +5,7 @@
 
 namespace openreg {
 
-    void set_impl_registry(PyObject* registry);
+    void set_impl_factory(PyObject* factory);
     py::function get_method(const char* name);
 
 }

--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/csrc/OpenRegHooks.cpp
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/csrc/OpenRegHooks.cpp
@@ -12,8 +12,8 @@
 namespace openreg {
 
 namespace {
-// Python dictionary where real implementations can be found
-PyObject* py_registry;
+// Python factory function where real implementations can be found
+PyObject* py_factory;
 
 using host_ptr_t = uint64_t;
 
@@ -341,15 +341,12 @@ C10_REGISTER_GUARD_IMPL(PrivateUse1, OpenRegGuardImpl);
 } // anonymous namspaces
 
 // Setter for the python dictionary with implementations
-void set_impl_registry(PyObject* registry) {
-  py_registry = registry;
+void set_impl_factory(PyObject* factory) {
+  py_factory = factory;
 }
 
 py::function get_method(const char* name) {
-  auto dict = py::cast<py::dict>(py_registry);
-    TORCH_CHECK(dict.contains(name), "OpenReg registry does not contain ",
-        "an implementation for '", name, "' make sure to add it in the __init__.py "
-      "file and register it.")
-  return dict[name];
+  auto factory = py::cast<py::function>(py_factory);
+  return factory(name);
 }
 } // openreg


### PR DESCRIPTION
Refactor impl_registry to use `driver.exec` as fallback.

cc @albanD