### PR TITLE
Modify enable logic of COLLECTIVE_COMM profiler activity type

### DIFF
--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -214,11 +214,14 @@ class ExperimentalConfigWrapper {
 } // namespace
 
 bool collectivesProfilerExists() {
-#if defined(KINETO_HAS_NCCL_PROFILER) || defined(KINETO_HAS_HCCL_PROFILER)
+#if defined(KINETO_HAS_HCCL_PROFILER)
   return true;
-#else
-  return false;
 #endif
+  const char* val = std::getenv("TORCH_PROFILER_ENABLE_COLLECTIVE_PROFILING");
+  if (val == nullptr) {
+    return false;
+  }
+  return std::strcmp(val, "1") == 0;
 }
 
 #ifdef USE_KINETO


### PR DESCRIPTION
Summary:
Since `KINETO_NCCL_PROFILER` flag is not used anymore (we are moving from linking the profiler during compile time to loading it dynamically), we change the logic for enabling the profiler to use `TORCH_PROFILER_ENABLE_COLLECTIVE_PROFILING` environment variable for NCCL Collective Communication Profiler. 

For HCCL, we still keep the same logic

Test Plan: See  https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/gpu_traces/tree/traces/clientAPI/0/1737579474/devvm29927.cln0/nccl_activities_2387985.json.gz for sample trace on nccl-profiler

Differential Revision: D68515945


