### PR TITLE
[ca][bug_fix] Fix ref counting of objects in the set_autograd_compiler function.

### DIFF
--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -1086,9 +1086,11 @@ static PyObject* set_autograd_compiler(PyObject* dummy, PyObject* args) {
   }
 
   if (prior_compiler == nullptr) {
+    Py_INCREF(Py_None);
     prior_compiler = Py_None;
   }
   PyObject* prior = PyTuple_New(2);
+  Py_INCREF(prior_dynamic);
   PyTuple_SET_ITEM(prior, 0, prior_compiler);
   PyTuple_SET_ITEM(prior, 1, prior_dynamic);
   return prior;


### PR DESCRIPTION
PR#141153 exposed the option to collect sizes as dynamic. After this
change, the function set_autograd_compiler returns PyTuple object which
is populated using PyTuple_SET_ITEM function. Yet, that function steals
reference to the object and doesn't INCREF it. So currently we are
missing INCREF on prior_compiler when it is Py_None and INCREF on
prior_dynamic which is either Py_False or Py_True. This bug may lead to
the possible memory corruption.

@xmfan @jansel @albanD 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @xmfan @yf225