### PR TITLE
emphasized two words in the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,14 +359,14 @@ You can adjust the configuration of cmake variables optionally (without building
 the following. For example, adjusting the pre-detected directories for CuDNN or BLAS can be done
 with such a step.
 
-On Linux
+**On Linux**
 ```bash
 export CMAKE_PREFIX_PATH="${CONDA_PREFIX:-'$(dirname $(which conda))/../'}:${CMAKE_PREFIX_PATH}"
 python setup.py build --cmake-only
 ccmake build  # or cmake-gui build
 ```
 
-On macOS
+**On macOS**
 ```bash
 export CMAKE_PREFIX_PATH="${CONDA_PREFIX:-'$(dirname $(which conda))/../'}:${CMAKE_PREFIX_PATH}"
 MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ python setup.py build --cmake-only


### PR DESCRIPTION
I emphasized two words in the code to maintain a consistent text format.

Fixes #ISSUE_NUMBER
