### PR TITLE
Missing autorelease in lstm_mps caused a ton of leaked memory

### DIFF
--- a/aten/src/ATen/native/mps/operations/RnnOps.mm
+++ b/aten/src/ATen/native/mps/operations/RnnOps.mm
@@ -322,13 +322,13 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> _lstm_mps(const Tenso
     Placeholder outputPlaceholder3 = Placeholder(cachedGraph->outputTensors_[3], zState);
     Placeholder outputPlaceholder4 = Placeholder(cachedGraph->outputTensors_[4], cellStateFwd);
 
-    NSMutableDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = [@{
+    NSMutableDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = [[@{
       outputPlaceholder0.getMPSGraphTensor() : outputPlaceholder0.getMPSGraphTensorData(),
       outputPlaceholder1.getMPSGraphTensor() : outputPlaceholder1.getMPSGraphTensorData(),
       outputPlaceholder2.getMPSGraphTensor() : outputPlaceholder2.getMPSGraphTensorData(),
       outputPlaceholder3.getMPSGraphTensor() : outputPlaceholder3.getMPSGraphTensorData(),
       outputPlaceholder4.getMPSGraphTensor() : outputPlaceholder4.getMPSGraphTensorData(),
-    } mutableCopy];
+    } mutableCopy] autorelease];
 
     if (num_layers > 1) {
       Placeholder outputPlaceholder5 = Placeholder(cachedGraph->outputTensors_[5], layerOutputs);


### PR DESCRIPTION
The dictionary held onto the new MPSGraphTensorData objects and MPSNDArrays.  Regression caused by https://github.com/pytorch/pytorch/pull/95137

Fixes #145374
