### PR TITLE
Don't fail if fresh_inductor_cache fails to clean up its tmp dir.

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -861,7 +861,9 @@ def fresh_inductor_cache(cache_entries=None, dir=None, delete=True):
                 # Windows, we can't delete the loaded modules because the module binaries
                 # are open.
                 onerror=lambda func, path, exc_info: log.warning(
-                    "Failed to remove temporary cache dir at %s", inductor_cache_dir
+                    "Failed to remove temporary cache dir at %s",
+                    inductor_cache_dir,
+                    exc_info=exc_info,
                 ),
             )
     except Exception:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -855,15 +855,16 @@ def fresh_inductor_cache(cache_entries=None, dir=None, delete=True):
                             }
                         )
         if delete:
-            shutil.rmtree(inductor_cache_dir)
+            try:
+                shutil.rmtree(inductor_cache_dir)
+            except OSError:
+                # Let's not fail if we can't clean up the temp dir. Also note that for
+                # Windows, we can't delete the loaded modules because the module binaries
+                # are open.
+                log.warning("Failed to remove temporary cache dir at %s", inductor_cache_dir)
     except Exception:
-        if not _IS_WINDOWS:
-            """
-            Windows can't delete the loaded modules, because the modules binaries are opened.
-            TODO: discuss if have better solution to handle this issue.
-            """
-            log.warning("on error, temporary cache dir kept at %s", inductor_cache_dir)
-            raise
+        log.warning("on error, temporary cache dir kept at %s", inductor_cache_dir)
+        raise
     finally:
         clear_inductor_caches()
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -855,13 +855,15 @@ def fresh_inductor_cache(cache_entries=None, dir=None, delete=True):
                             }
                         )
         if delete:
-            try:
-                shutil.rmtree(inductor_cache_dir)
-            except OSError:
+            shutil.rmtree(
+                inductor_cache_dir,
                 # Let's not fail if we can't clean up the temp dir. Also note that for
                 # Windows, we can't delete the loaded modules because the module binaries
                 # are open.
-                log.warning("Failed to remove temporary cache dir at %s", inductor_cache_dir)
+                onerror=lambda func, path, exc_info: log.warning(
+                    "Failed to remove temporary cache dir at %s", inductor_cache_dir
+                ),
+            )
     except Exception:
         log.warning("on error, temporary cache dir kept at %s", inductor_cache_dir)
         raise


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145513

Summary: I see we have a test failure due to an error removing the tmp dir: https://github.com/pytorch/pytorch/issues/141761. Seems like we should not raise an exception for this case in general. Also, let's clean up the exception handling related to windows. The comment makes it sound like we want to specifically ignore failures cleaning up, but the current impl is swallowing all exceptions.

Fixes #141761

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov