### PR TITLE
General Changes for multi accelerators

### DIFF
--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -12,18 +12,23 @@ from torch.distributed.distributed_c10d import _get_default_group
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, MixedPrecision
 from torch.distributed.fsdp.fully_sharded_data_parallel import ShardingStrategy
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     requires_nccl,
     requires_nccl_version,
     skip_but_pass_in_sandcastle_if,
     skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_fsdp import FSDPTest
+from torch.testing._internal.common_fsdp import FSDPTest, get_devtype
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_CUDA,
+    TEST_HPU,
 )
+
+
+device_type = torch.device(get_devtype())
 
 
 if not dist.is_available():
@@ -31,8 +36,11 @@ if not dist.is_available():
     sys.exit(0)
 
 # bfloat16 is only supported by CUDA 11+
-BFLOAT16_AVAILABLE = torch.cuda.is_available() and (
-    torch.version.cuda is not None or torch.version.hip is not None
+BFLOAT16_AVAILABLE = (
+    True
+    if (TEST_CUDA and (torch.version.cuda is not None or torch.version.hip is not None))
+    or TEST_HPU
+    else False
 )
 
 
@@ -40,7 +48,6 @@ class Net(nn.Module):
     def __init__(self, has_wrapping, sharding_strategy, mixed_precision=None):
         # to ensure determinism
         torch.manual_seed(0)
-        torch.cuda.manual_seed(0)
         super().__init__()
 
         if has_wrapping:
@@ -50,12 +57,12 @@ class Net(nn.Module):
                     nn.ReLU(),
                     FSDP(
                         nn.Linear(16, 8),
-                        device_id=torch.cuda.current_device(),
+                        device_id=device_type,
                         sharding_strategy=sharding_strategy,
                         mixed_precision=mixed_precision,
                     ),
                 ),
-                device_id=torch.cuda.current_device(),
+                device_id=device_type,
                 sharding_strategy=sharding_strategy,
                 mixed_precision=mixed_precision,
             )
@@ -134,13 +141,13 @@ class TestCommunicationHooks(FSDPTest):
         """
         out_dim = self.world_size
         net = torch.nn.Linear(1, out_dim, bias=False)
-        inpt = torch.tensor([self.rank]).float().cuda(self.rank)
+        inpt = torch.tensor([self.rank]).float().to(device_type.type)
 
         net_default_hook = FSDP(
             net,
-            device_id=torch.cuda.current_device(),
+            device_id=device_type,
             sharding_strategy=sharding_strategy,
-        ).to(self.rank)
+        ).to(device_type.type)
 
         # Check that by default, `_comm_hook` is None
         for entry in FSDP.fsdp_modules(net_default_hook):
@@ -172,13 +179,12 @@ class TestCommunicationHooks(FSDPTest):
         ]
 
     def _init_model(self, core, sharding_strategy, mixed_precision=None):
-        device = torch.device("cuda")
         return FSDP(
             core,
-            device_id=torch.cuda.current_device(),
+            device_id=device_type,
             sharding_strategy=sharding_strategy,
             mixed_precision=mixed_precision,
-        ).to(device)
+        ).to(device_type)
 
     @skip_if_lt_x_gpu(2)
     @parametrize("has_wrapping", [True, False])
@@ -277,9 +283,10 @@ class TestCommunicationHooks(FSDPTest):
             ShardingStrategy.HYBRID_SHARD,
             ShardingStrategy._HYBRID_SHARD_ZERO2,
         ):
-            model = Net(False, None, None).cuda()
+            model = Net(False, None, None).to(device_type)
             fsdp_model = FSDP(
                 model,
+                device_id=device_type,
                 auto_wrap_policy=ModuleWrapPolicy({nn.Linear}),
                 sharding_strategy=sharding_strategy,
             )
@@ -337,7 +344,6 @@ class TestCommunicationHooks(FSDPTest):
     ):
         # keep everything deterministic for input data
         torch.manual_seed(0)
-        torch.cuda.manual_seed(0)
 
         fsdp_with_hook = self._init_model(
             Net(has_wrapping=has_wrapping, sharding_strategy=sharding_strategy),
@@ -359,7 +365,7 @@ class TestCommunicationHooks(FSDPTest):
         optim_hook = torch.optim.SGD(fsdp_with_hook.parameters(), lr=0.1)
         optim_mp = torch.optim.SGD(fsdp_with_mp.parameters(), lr=0.1)
 
-        in_data = torch.rand(16, 8).cuda()
+        in_data = torch.rand(16, 8).to(device_type)
         fsdp_with_hook.train()
         fsdp_with_mp.train()
         loss_hook = fsdp_with_hook(in_data).sum()
@@ -426,7 +432,7 @@ class TestCommunicationHooks(FSDPTest):
         )
 
 
-instantiate_parametrized_tests(TestCommunicationHooks)
-
+devices = ("cuda", "hpu")
+instantiate_device_type_tests(TestCommunicationHooks, globals(), only_for=devices)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_ignored_modules.py
+++ b/test/distributed/fsdp/test_fsdp_ignored_modules.py
@@ -8,22 +8,28 @@ import torch
 import torch.distributed.fsdp._traversal_utils as traversal_utils
 import torch.nn as nn
 from torch import distributed as dist
+from torch._utils import _get_device_module
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy, transformer_auto_wrap_policy
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
+    get_devtype,
     TransformerWithSharedParams,
 )
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
     parametrize,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
 )
 
+
+device_type = torch.device(get_devtype())
+
+DEVICE_COUNT = _get_device_module(device_type.type).device_count()
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -94,9 +100,9 @@ class ModelWithIgnoredModules(Model):
 class TestFSDPIgnoredModules(FSDPTest):
     @property
     def world_size(self):
-        return min(torch.cuda.device_count(), 2)
+        return min(DEVICE_COUNT, 2)
 
-    def _train_model(self, model, optim, num_iters, device=torch.device("cuda")):
+    def _train_model(self, model, optim, num_iters, device=device_type):
         for _ in range(num_iters):
             module = model.module if isinstance(model, FSDP) else model
             inp = module.get_input(device)
@@ -132,7 +138,10 @@ class TestFSDPIgnoredModules(FSDPTest):
             DEVICEInitMode.DEVICE_BEFORE,
             deterministic=True,
         )
-        fsdp_kwargs = {"process_group": self.process_group}
+        fsdp_kwargs = {
+            "process_group": self.process_group,
+            "device_id": device_type,
+        }
         if use_auto_wrap:
             # Unshare the output projection weight and embedding weight to be
             # able to auto wrap every linear correctly
@@ -198,7 +207,7 @@ class TestFSDPIgnoredModules(FSDPTest):
         # Initialize an FSDP-wrapped nested model that first wraps the nested
         # sequential's second linear layer (`layer1[1]`) and then wraps the
         # overall model while ignoring the nested sequential (`layer1`)
-        model = Model().cuda()
+        model = Model().to(device_type)
         fsdp_fn = functools.partial(FSDP, use_orig_params=use_orig_params)
         model.layer1[1] = fsdp_fn(model.layer1[1])
         if ignore_modules:
@@ -246,7 +255,7 @@ class TestFSDPIgnoredModules(FSDPTest):
         )
 
     def _test_ignored_states_auto_wrap(self, policy, ignore_bias: bool):
-        model = Model().cuda()
+        model = Model().to(device_type)
         ignored_states = [model.layer1[1].weight]
         if ignore_bias:
             ignored_states.append(model.layer1[1].bias)
@@ -285,7 +294,7 @@ class TestFSDPIgnoredModules(FSDPTest):
     def test_ignored_modules_invalid(self):
         """Tests that passing an FSDP module as an ignored module or the
         top-level module itself errors."""
-        model = Model().cuda()
+        model = Model().to(device_type)
         wrap_cls = FSDP
         model.layer1 = wrap_cls(model.layer1)
         # Passing an FSDP module as an ignored module should error
@@ -302,8 +311,9 @@ class TestFSDPIgnoredModules(FSDPTest):
         ):
             # FSDP does not allow to wrap the same model twice, so create
             # a new local model here.
-            new_model = Model().cuda()
-            wrap_cls(new_model, ignored_modules=[new_model])
+            new_model = Model().to(device_type)
+            fsdp_kwargs = {"device_id": device_type}
+            wrap_cls(new_model, ignored_modules=[new_model], **fsdp_kwargs)
 
     @skip_if_lt_x_gpu(2)
     def test_diff_ignored_modules_across_ranks(self):
@@ -334,7 +344,7 @@ class TestFSDPIgnoredModules(FSDPTest):
         # we wrap `layer3` with FSDP, where `layer3` is registered as a module
         # after `layer1`, which has the variable number of ignored modules
         wrap_cls = FSDP
-        model = ModelWithIgnoredModules(num_ignored=self.rank + 1).cuda()
+        model = ModelWithIgnoredModules(num_ignored=self.rank + 1).to(device_type)
         layer1_ignored_modules = [
             m for m in model.layer1.modules() if isinstance(m, IgnoredModule)
         ]
@@ -370,7 +380,7 @@ class TestFSDPIgnoredModules(FSDPTest):
     @skip_if_lt_x_gpu(2)
     @parametrize("ignore_modules", [True, False])
     def test_ignored_modules_not_under_wrapped_root(self, ignore_modules: bool):
-        model = Model().cuda()
+        model = Model().to(device_type)
         ignored_modules = list(model.layer1.children())[1:]
 
         ignore_kwargs = (
@@ -409,7 +419,7 @@ class TestFSDPIgnoredModules(FSDPTest):
         )
 
     def _test_ignored_states_check(self, ignore_modules: bool):
-        model = Model().cuda()
+        model = Model().to(device_type)
         ignored_modules = list(model.layer1.children())[1:]
         ignored_params = {p for m in ignored_modules for p in m.parameters()}
         ignored_states = ignored_params.union(set(ignored_modules))
@@ -445,7 +455,7 @@ class TestFSDPIgnoredModules(FSDPTest):
                 FSDP(model, ignored_states=ignored_states)
 
 
-instantiate_parametrized_tests(TestFSDPIgnoredModules)
-
+devices = ("cuda", "hpu")
+instantiate_device_type_tests(TestFSDPIgnoredModules, globals(), only_for=devices)
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Intend to generailze the framework for multiple accelerators.
Major changes includes:
> Add TEST_CUDA & TEST_HPU condition for generalization at common place.
> Move ".cuda()" to ".to(device_type)" call


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o