### PR TITLE
inductor.config.descriptive_names = False is not actually supported

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -874,7 +874,7 @@ class cpp:
 
     # similar to config.triton.descriptive_names
     descriptive_names: Union[
-        bool, Literal["torch", "original_aten", "inductor_node"]
+        Literal["torch", "original_aten", "inductor_node"]
     ] = "original_aten"
 
     # how many nodes to allow into a single horizontal fusion
@@ -1031,12 +1031,11 @@ class triton:
     )
 
     # should we put op names in kernel names
-    # False: No special names (just triton__1, triton__2, etc.)
     # "torch": Maps to the fx op in the Dynamo graph (module name, method name, etc.)
     # "original_aten": Maps to the highest-level aten op (i.e. pre-decompositions)
     # "inductor_node": Maps to the node name in the FX graph passed to Inductor
     descriptive_names: Union[
-        bool, Literal["torch", "original_aten", "inductor_node"]
+        Literal["torch", "original_aten", "inductor_node"]
     ] = "original_aten"
 
     # use alternate codegen for smaller reductions


### PR DESCRIPTION
Summary:
This config is not supported (it throws an error when set), and doesn't really make sense imo.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov