### PR TITLE
fix intermediate debug information with cpp_wrapper

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -54,6 +54,26 @@ class GpuWrapperTemplate:
 class TestGpuWrapper(InductorTestCase):
     device = GPU_TYPE
 
+    def test_aoti_debug_printer_works_on_constants(self):
+        batch_size = 32
+        seq_length = 50
+        hidden_size = 768
+
+        def test_fn():
+            inp = torch.randn(batch_size, seq_length, hidden_size, device=self.device)
+            weight = torch.randn(hidden_size, hidden_size, device=self.device)
+            matmul_output = inp @ weight
+            torch.nn.LayerNorm(hidden_size, device=self.device)(matmul_output)
+            return True
+
+        comp = torch.compile(
+            options={
+                "cpp_wrapper": True,
+                "aot_inductor.debug_intermediate_value_printer": "2",
+            }
+        )(test_fn)
+        comp()
+
 
 class DynamicShapesGpuWrapperGpuTests(InductorTestCase):
     device = GPU_TYPE

--- a/torch/_inductor/codegen/debug_utils.py
+++ b/torch/_inductor/codegen/debug_utils.py
@@ -268,7 +268,7 @@ class DebugPrinterManager:
                     ),
                 ):
                     V.graph.wrapper_code.writeline(
-                        f'printf("[  {launch_prefix} - {kernel_name} - {arg}: %ld  ]", {arg}); printf("\\n");'
+                        f'printf("[  {launch_prefix} - {kernel_name} - {arg}: %ld  ]", {arg}); printf("\\\\n");'
                     )
                 else:
                     if arg_signatures is None and self.kernel_type == "cpp" or "extern":


### PR DESCRIPTION
Summary: before fix, code like:
```cpp
    aoti_torch_print_tensor_handle(buf0, "after_launch - triton_poi_fused_randn_0 - buf0");
    aoti_torch_print_tensor_handle(buf1, "after_launch - triton_poi_fused_randn_0 - buf1");
    printf("[  after_launch - triton_poi_fused_randn_0 - 0: %ld  ]", 0); printf("
");
    printf("[  after_launch - triton_poi_fused_randn_0 - 1228800L: %ld  ]", 1228800L); printf("
");
```
was generated, which is a syntax error.

Test Plan:
New unit test.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov