### PR TITLE
Add accuracy issue support in AOTI Minifier

### DIFF
--- a/torch/_dynamo/repro/aoti.py
+++ b/torch/_dynamo/repro/aoti.py
@@ -46,21 +46,51 @@ class AOTIMinifierError(Exception):
 def dump_to_minify(
     exported_program: ExportedProgram,
     compiler_name: str,
+    command: str = "minify",
     options: Optional[dict[str, Any]] = None,
 ):
-    out = io.StringIO()
+    """
+    If command is "minify":
+        Dump exported_program to `debug_dir/minifier/minifier_launcher.py`, with minify command.
+    If command is "run":
+        Dump exported_program to `cwd/repro.py`, with run command.
+    """
+    assert command in ["minify", "run"]
+
     subdir = os.path.join(minifier_dir(), "checkpoints")
     if not os.path.exists(subdir):
         os.makedirs(subdir, exist_ok=True)
-    save_graph_repro_ep(
-        out,
-        compiler_name,
-        exported_program=exported_program,
-        save_dir=subdir,
-        command="minify",
-        config_patches=options,
-    )
-    return helper_for_dump_minify(out.getvalue())
+
+    if command == "minify":
+        out = io.StringIO()
+        save_graph_repro_ep(
+            out,
+            compiler_name,
+            exported_program=exported_program,
+            save_dir=subdir,
+            command="minify",
+            config_patches=options,
+        )
+        return helper_for_dump_minify(out.getvalue())
+    else:
+        curdir = os.getcwd()
+        file_name = os.path.join(curdir, "repro.py")
+        try:
+            with open(file_name, "w") as fd:
+                save_graph_repro_ep(
+                    fd,
+                    compiler_name,
+                    exported_program=exported_program,
+                    config_patches=options,
+                    save_dir=subdir,
+                    command="run",
+                    module_in_comment=True,
+                )
+            log.warning("Writing repro file to %s", file_name)
+            if use_buck:
+                BuckTargetWriter(file_name).write()
+        except OSError:
+            log.warning("No write permissions for %s", file_name)
 
 
 def get_module_string(gm):
@@ -262,21 +292,20 @@ def repro_get_args(options, exported_program, config_patches):
 
 
 def repro_run(options, exported_program, config_patches):
-    from torch._inductor import _aoti_compile_and_package_inner, aoti_load_package
+    from torch._inductor import _aoti_compile_and_package_inner
 
     gm, args, kwargs = repro_common(options, exported_program)
 
     from torch.cuda import synchronize
 
-    package_path = _aoti_compile_and_package_inner(
+    _aoti_compile_and_package_inner(
         gm,
         args,
         kwargs,
-        load_and_run=False,
+        load_and_run=True,
+        check_accuracy=options.accuracy,
         inductor_configs=config_patches,
     )
-    compiled = aoti_load_package(package_path)
-    assert not isinstance(compiled, str)
 
     need_sync = False
 
@@ -284,8 +313,6 @@ def repro_run(options, exported_program, config_patches):
         if isinstance(arg, torch.Tensor) and arg.is_cuda:
             need_sync = True
             break
-
-    compiled(*args, **kwargs)
 
     if need_sync:
         synchronize()  # ensure segfaults are surfaced
@@ -371,6 +398,7 @@ def repro_minify(options, exported_program, config_patches):
                 gm,
                 tuple_inputs,
                 load_and_run=True,
+                check_accuracy=options.accuracy,
                 inductor_configs=inductor_configs,
             )
             if need_sync:
@@ -389,6 +417,7 @@ def repro_minify(options, exported_program, config_patches):
             dump_compiler_graph_state,
             compiler_name=compiler_name,
             config_patches=config_patches,
+            accuracy=options.accuracy,
             strict=strict,
         ),
         save_dir=options.save_dir,
@@ -420,7 +449,6 @@ def run_repro(
 
     if accuracy is True:
         accuracy = "accuracy"
-        raise NotImplementedError("check for accuracy is not supported yet")
     elif accuracy is False:
         accuracy = ""
 
@@ -441,6 +469,55 @@ default settings on this script:
     )
 
     def common_flags(parser):
+        accuracy_group = parser.add_mutually_exclusive_group()
+        accuracy_group.add_argument(
+            "--no-accuracy",
+            dest="accuracy",
+            action="store_const",
+            const="",
+            default=accuracy,
+            help="do not test accuracy, just run the module and see if it errors",
+        )
+        accuracy_group.add_argument(
+            "--accuracy",
+            action="store_const",
+            const="accuracy",
+            default=accuracy,
+            help="""\
+test if the RMSE between the compiled module and the fp64 reference is greater
+than eager and the fp64 reference. This is usually more reliable than the
+standard allclose test, as we expect numeric differences from compiling, often
+improving accuracy over eager.  RMSE test allows for compiled module to
+diverge greatly from eager, as long as this divergence moves it closer to the
+'true' mathematical value of the network.  Caveats: (1) double precision can
+still suffer from rounding error, so it is not a perfect reference (see for
+example 'Herbie: Automatically Improving Floating Point Accuracy') for
+approaches that detect the necessary working precision and compute it in
+arbitrary precision floating point; unfortunately, this is not practical for
+tensor computation; (2) if there are not enough samples in the output being
+compared, we may get unlucky and have an unlucky greater RMSE than eager; this
+could be overcome by applying a more rigorous statistical test at some
+p-value, which we leave for future work.
+""",
+        )
+        accuracy_group.add_argument(
+            "--strict-accuracy",
+            dest="accuracy",
+            action="store_const",
+            const="strict_accuracy",
+            default=accuracy,
+            help="""\
+by default, when doing accuracy minification we will reject reductions which
+change the divergence from a floating point divergence to a integral/boolean
+divergence.  This is because some operations like ReLU involve temporarily
+sharp boundaries that smooth out again afterwards; without requiring
+divergence on floating point, the minifier will often fixate on divergent
+boolean tensor even though this is not the true source of the divergence.
+However, rejecting these reductions makes it more difficult for the minifier
+to make process.  Using this option will let the minifier progress for ALL
+divergences--you just might not end up with a useful repro in the end.""",
+        )
+
         parser.add_argument(
             "--save-dir",
             type=str,

--- a/torch/_dynamo/test_minifier_common.py
+++ b/torch/_dynamo/test_minifier_common.py
@@ -171,7 +171,9 @@ torch._inductor.config.{"cpp" if device == "cpu" else "triton"}.inject_relu_bug_
         return proc, None
 
     # Runs the minifier launcher script in `repro_dir`
-    def _run_minifier_launcher(self, repro_dir, isolate, *, minifier_args=()):
+    def _run_minifier_launcher(
+        self, repro_dir, isolate, *, minifier_args=(), repro_after=None
+    ):
         self.assertIsNotNone(repro_dir)
         launch_file = _as_posix_path(os.path.join(repro_dir, "minifier_launcher.py"))
         with open(launch_file) as f:
@@ -179,7 +181,9 @@ torch._inductor.config.{"cpp" if device == "cpu" else "triton"}.inject_relu_bug_
         self.assertTrue(os.path.exists(launch_file))
 
         args = ["python3", launch_file, "minify", *minifier_args]
-        if not isolate:
+        if not isolate and repro_after != "aot_inductor":
+            # AOTI minifier doesn't have --no-isolate flag.
+            # Everything in AOTI minifier is in no-isolate mode.
             args.append("--no-isolate")
         launch_proc = self._maybe_subprocess_run(args, isolate=isolate, cwd=repro_dir)
         print("minifier stdout:", launch_proc.stdout.decode("utf-8"))
@@ -209,20 +213,24 @@ torch._inductor.config.{"cpp" if device == "cpu" else "triton"}.inject_relu_bug_
     # `patch_code` is the code to be patched in every generated file; usually
     # just use this to turn on bugs via the config
     def _gen_test_code(self, run_code, repro_after, repro_level):
-        repro_after_line = (
-            f"""\
+        repro_after_line = ""
+        if repro_after == "aot_inductor":
+            repro_after_line = (
+                "torch._inductor.config.aot_inductor.dump_aoti_minifier = True"
+            )
+        elif repro_after:
+            repro_after_line = f"""\
 torch._dynamo.config.repro_after = "{repro_after}"
-"""
-            if repro_after
-            else ""
-        )
+        """
         return f"""\
 import torch
 import torch._dynamo
+import torch._inductor
 {_as_posix_path(torch._dynamo.config.codegen_config())}
 {_as_posix_path(torch._inductor.config.codegen_config())}
 {repro_after_line}
 torch._dynamo.config.repro_level = {repro_level}
+torch._inductor.config.aot_inductor.repro_level = {repro_level}
 torch._dynamo.config.debug_dir_root = "{_as_posix_path(self.DEBUG_DIR)}"
 {run_code}
 """
@@ -259,7 +267,10 @@ torch._dynamo.config.debug_dir_root = "{_as_posix_path(self.DEBUG_DIR)}"
         self.assertIsNotNone(repro_dir)
         print("running minifier", file=sys.stderr)
         _minifier_proc, minifier_code = self._run_minifier_launcher(
-            repro_dir, isolate=isolate, minifier_args=minifier_args
+            repro_dir,
+            isolate=isolate,
+            minifier_args=minifier_args,
+            repro_after=repro_after,
         )
         print("running repro", file=sys.stderr)
         repro_proc, repro_code = self._run_repro(repro_dir, isolate=isolate)

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -134,6 +134,7 @@ def _aoti_compile_and_package_inner(
     kwargs: Optional[dict[str, Any]] = None,
     *,
     load_and_run: bool = False,
+    check_accuracy: Optional[str] = None,
     package_path: Optional[Union[str, io.BytesIO]] = None,
     inductor_configs: Optional[dict[str, Any]] = None,
 ):
@@ -142,7 +143,19 @@ def _aoti_compile_and_package_inner(
 
     If `load_and_run` is True, this function will load the compiled model and run it.
     This is for the minifier to check the correctness of the compiled model.
+
+    If `check_accuracy` is set, this function will check the accuracy of the compiled
+    model against gm. kwargs must be None if check_accuracy is set.
+    "strict_accuracy" means "we will minify any time we see anything that
+     diverges", whereas "accuracy" is more conservative, and will only minify if there
+     is a meaningful fp64 divergence
     """
+
+    if check_accuracy:
+        assert (
+            kwargs is None or len(kwargs) == 0
+        ), "when checking for accuracy, the inputs must have been flattened and kwargs is None"
+
     from .package import package_aoti
 
     assert isinstance(gm, torch.fx.GraphModule)
@@ -169,9 +182,28 @@ def _aoti_compile_and_package_inner(
     res = package_aoti(package_path, aoti_files)
     assert res == package_path
 
-    if load_and_run:
+    if load_and_run or check_accuracy:
         compiled_model = aoti_load_package(package_path)
-        compiled_model(*args, **kwargs)
+        if check_accuracy:
+            from torch._dynamo.debug_utils import AccuracyError, same_two_models
+
+            # This might look inverted but it's not.  strict_accuracy means "we will
+            # minify any time we see anything that diverges", whereas accuracy is more
+            # conservative, and will only minify if there is a meaningful fp64
+            # divergence
+            not_strict_accuracy = check_accuracy == "accuracy"
+            if not same_two_models(
+                gm,
+                compiled_model,
+                args,
+                only_fwd=True,
+                require_fp64=not_strict_accuracy,
+                ignore_non_fp=not_strict_accuracy,
+            ):
+                raise AccuracyError("Bad accuracy detected")
+        else:
+            compiled_model(*args, **kwargs)
+
     return package_path
 
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1161,6 +1161,13 @@ class aot_inductor:
     # dump an aoti minifier if program errors
     dump_aoti_minifier: bool = os.environ.get("DUMP_AOTI_MINIFIER", "0") == "1"
 
+    # Compiler compilation debug info
+    # 1: Dumps the original graph out to repro.py if compilation fails
+    # 2: Dumps a minifier_launcher.py if aoti fails.
+    # 3: Always dumps a minifier_launcher.py. Good for segfaults.
+    # 4: Dumps a minifier_launcher.py if the accuracy fails.
+    repro_level: int = int(os.environ.get("AOTINDUCTOR_REPRO_LEVEL", 2))
+
     # Dictionary of presets that can be passed in
     presets: dict[str, Any] = {}
 
@@ -1415,6 +1422,8 @@ _save_config_ignore: list[str] = [
     "joint_custom_pre_pass",
     "joint_custom_post_pass",
     "pre_grad_custom_pass",
+    "aot_inductor.repro_level",
+    "aot_inductor.dump_aoti_minifier",
 ]
 
 _cache_config_ignore_prefix: list[str] = [

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -1,5 +1,6 @@
 import collections
 import contextlib
+import copy
 import dataclasses
 import functools
 import io
@@ -729,7 +730,10 @@ def aot_inductor_minifier_wrapper(
     inductor_configs: dict[str, Any],
     package_path: Optional[Union[str, io.BytesIO]] = None,
 ) -> str:
+    from torch._dynamo.debug_utils import AccuracyError
+    from torch._dynamo.repro.aoti import dump_to_minify
     from torch._inductor import config
+    from torch._inductor.compile_fx import _aoti_flatten_inputs
 
     use_minifier = config.aot_inductor.dump_aoti_minifier
 
@@ -739,6 +743,37 @@ def aot_inductor_minifier_wrapper(
     args, kwargs = exported_program.example_inputs
 
     try:
+        if use_minifier and config.aot_inductor.repro_level == 3:
+            # Always dump the original module in case we have segfaults
+            dump_to_minify(
+                exported_program,
+                "aot_inductor",
+                options=inductor_configs,
+            )
+        if use_minifier and config.aot_inductor.repro_level == 4:
+            # Check for accuracy
+            # We will first flatten the inputs before compiling and checking for accuracy.
+            # This is ok because we will flatten the inputs in the minifier anyway.
+            gm_copy = copy.deepcopy(gm)
+            example_inputs_copy = copy.deepcopy(exported_program.example_inputs)
+            config_copy = copy.deepcopy(inductor_configs)
+            flat_example_inputs, config_copy = _aoti_flatten_inputs(
+                gm_copy,
+                example_inputs_copy[0],
+                example_inputs_copy[1],
+                options=config_copy,
+            )
+            tuple_inputs = tuple(flat_example_inputs)
+            flattened_ep = torch.export.export(gm_copy, tuple_inputs, strict=False)
+            func(
+                flattened_ep.module(),
+                tuple_inputs,
+                inductor_configs=config_copy,
+                package_path=package_path,
+                load_and_run=True,
+                check_accuracy="accuracy",
+            )
+
         return func(
             gm,
             args,
@@ -747,14 +782,26 @@ def aot_inductor_minifier_wrapper(
             package_path=package_path,
             load_and_run=use_minifier,
         )
+    except AccuracyError as e:
+        dump_to_minify(
+            exported_program,
+            "aot_inductor_accuracy",
+            command="minify",
+            options=inductor_configs,
+        )
+        log.warning("Accuracy failed")
+        raise e
     except Exception as e:
         if use_minifier:
-            # TODO: check accuracy and re-direct to minifier
-            from torch._dynamo.repro.aoti import dump_to_minify
+            command = "minify"
+
+            if config.aot_inductor.repro_level == 1:
+                command = "run"
 
             dump_to_minify(
                 exported_program,
-                "compile_fx_aot",
+                "aot_inductor",
+                command=command,
                 options=inductor_configs,
             )
         raise e


### PR DESCRIPTION
Summary:

Add three more repro levels for AOTI minifier (level 2 already exists). They are the same as the existing dynamo minifier repro levels.

Now AOTI minifier can minify and repro programs that have numerical accuracy issues as well.


1: Dumps the original graph out to repro.py if compilation fails
2: Dumps a minifier_launcher.py if aoti fails.
3: Always dumps a minifier_launcher.py. Good for segfaults.
4: Dumps a minifier_launcher.py if the accuracy fails.


Refactor AOTI minifier unit tests to be cleaner and better re-use the existing minifier testing code. We do not need to manually patch {"aot_inductor.dump_aoti_minifier": True} to each test now, this config is generated in the test code.


Differential Revision: D68294638




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov