### PR TITLE
[inductor/profiler] add kernel kwargs instrumentation

### DIFF
--- a/test/inductor/test_profiler.py
+++ b/test/inductor/test_profiler.py
@@ -274,9 +274,9 @@ class DynamoProfilerTests(torch._inductor.test_case.TestCase):
             )
 
             self.assertTrue("kernel_kwargs" in args, msg=f"event = {e}")
-            # Note: Exact match below could fail if inductor
-            # starts using a different block size for this example program.
-            self.assertEqual(args["kernel_kwargs"], "XBLOCK=16", msg=f"event = {e}")
+            self.assertTrue(
+                args["kernel_kwargs"].startswith("XBLOCK="), msg=f"event = {e}"
+            )
 
         for e in triton_events:
             check_triton_event(e)

--- a/test/inductor/test_profiler.py
+++ b/test/inductor/test_profiler.py
@@ -235,7 +235,7 @@ class DynamoProfilerTests(torch._inductor.test_case.TestCase):
                 prof.step()
 
         prof.export_chrome_trace(fp.name)
-        print("Trace written to {fp.name}, set debug=True to retain file.")
+        print(f"Trace written to {fp.name}, set debug=True to retain file.")
 
         triton_events = []
         with open(fp.name) as f:
@@ -272,6 +272,11 @@ class DynamoProfilerTests(torch._inductor.test_case.TestCase):
             self.assertEqual(
                 args["kernel_hash"], get_hash(kernel_file), msg=f"event = {e}"
             )
+
+            self.assertTrue("kernel_kwargs" in args, msg=f"event = {e}")
+            # Note: Exact match below could fail if inductor
+            # starts using a different block size for this example program.
+            self.assertEqual(args["kernel_kwargs"], "XBLOCK=16", msg=f"event = {e}")
 
         for e in triton_events:
             check_triton_event(e)

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -899,16 +899,25 @@ class CachingAutotuner(KernelInterface):
             else:
                 grid_info = getattr(grid, "grid_fn_str", "")
 
+            kernel_kwargs_str = ",".join(
+                f"{k}={v}" for (k, v) in launcher.config.kwargs.items()
+            )
+
+            profiler_kwargs = {
+                "kernel_file": (self.filename or ""),
+                "kernel_hash": self.kernel_hash,
+                "kernel_backend": "triton",
+                "grid": grid_info,
+                "stream": stream,
+                "num_warps": launcher.config.num_warps,
+                "num_stages": launcher.config.num_stages,
+                "kernel_kwargs": kernel_kwargs_str,
+            }
+
             with torch._C._profiler._RecordFunctionFast(
                 self.inductor_meta.get("kernel_name", "triton kernel"),
                 args,
-                {
-                    "kernel_file": (self.filename or ""),
-                    "kernel_hash": self.kernel_hash,
-                    "kernel_backend": "triton",
-                    "grid": grid_info,
-                    "stream": stream,
-                },
+                profiler_kwargs,
             ):
                 return launcher(
                     *args,


### PR DESCRIPTION
## About

As above, record the kernel launch kwargs. These tends to be contexpr arguments to triton kernels like block size etc.

## Test program

Note, install triton before proceeding (pip install triton)

triton_test.py>>>
```
import torch
from torch.profiler import profile, ProfilerActivity

def foo(x, y):
    a = torch.sin(x)
    b = torch.cos(y)
    return a + b

def main():
    x = torch.randn(10, 10).cuda()
    y = torch.randn(10, 10).cuda()
    opt_foo = torch.compile(foo)
    z = opt_foo(x, y)

    # Profile the kernel function on the GPU
    with profile(
        activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], record_shapes=True
    ) as prof:
        z = opt_foo(x, y)

    # Export the trace to a file
    prof.export_chrome_trace("my_kernel_trace.json")

if __name__ == "__main__":
    main()
```

Run it and we should get a trace file my_kernel_trace.json


Output has triton event with the kernel_kwargs attribute.
```
  {
    "ph": "X", "cat": "cpu_op", "name": "triton_poi_fused_add_cos_sin_0", "pid": 2480815, "tid": 2480815,
    "ts": 2045246693014.959, "dur": 75.662,
    "args": {
      ...
      "kernel_backend": "triton", 
      "num_warps": 4, 
      "kernel_kwargs": "XBLOCK=128", "num_stages": 1, "grid": "grid(100,)", 
      "kernel_file": "/tmp/torchinductor_bcoutinho/ow/cowpmkdpla4qfqj6jupnq4d7og7iz7eeb5wergubivubxd4xapor.py", 
      "kernel_hash": "cowpmkdpla4qfqj6jupnq4d7og7iz7eeb5wergubivubxd4xapor"
    }
  },
```

## Unit Test
Updated unit test:
```
pytest test/inductor/test_profiler.py -k test_pt2_triton_attributes
```



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov