### PR TITLE
Revert "[compiled autograd] support Tensor Subclasses in AOTBackward (#144115)"

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -22,7 +22,6 @@ from torch import _inductor as inductor
 from torch._dynamo import compiled_autograd, config
 from torch._dynamo.backends.debugging import aot_eager
 from torch._dynamo.device_interface import get_interface_for_device
-from torch._dynamo.testing import normalize_gm
 from torch._dynamo.utils import counters
 from torch._inductor import config as inductor_config
 from torch._inductor.test_case import run_tests, TestCase
@@ -3131,120 +3130,6 @@ TORCH_LIBRARY(test_cudagraphs_cpu_scalar_used_in_cpp_custom_op, m) {
         ]
 
         self.assertEqual(sum(1 for e in unexpected_logs if e in logs.getvalue()), 0)
-
-    def test_tensor_subclass_basic(self):
-        from torch.testing._internal.two_tensor import TwoTensor, TwoTensorMode
-
-        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
-            lib.define("to_twotensor(Tensor a, Tensor b) -> Tensor")
-            lib.define("from_twotensor(Tensor c) -> (Tensor, Tensor)")
-
-            def to_twotensor_backward(ctx, grad):
-                return torch.ops.mylib.from_twotensor(grad)
-
-            def from_twotensor_backward(ctx, grad_a, grad_b):
-                raise AssertionError("shouldn't get hit")
-
-            torch.library.register_autograd(
-                "mylib::to_twotensor", to_twotensor_backward, lib=lib
-            )
-            torch.library.register_autograd(
-                "mylib::from_twotensor", from_twotensor_backward, lib=lib
-            )
-
-            @torch.library.register_torch_dispatch(
-                "mylib::to_twotensor", TwoTensorMode, lib=lib
-            )
-            def _(_0, _1, _2, args, kwargs):
-                assert not kwargs
-                a, b = args
-                return TwoTensor(a.clone(), b.clone())
-
-            @torch.library.register_torch_dispatch(
-                "mylib::from_twotensor", TwoTensor, lib=lib
-            )
-            def _(_0, _1, _2, args, kwargs):
-                assert not kwargs
-                (c,) = args
-                return c.a.clone(), c.b.clone()
-
-            @torch.compile(backend="aot_eager", fullgraph=True)
-            def fn(x):
-                return x * x + 2
-
-            param1 = torch.randn(4, 4, requires_grad=True)
-            param2 = torch.randn(4, 4, requires_grad=True)
-            with TwoTensorMode():
-                x = torch.ops.mylib.to_twotensor(param1, param2)
-
-            inner_compiler_fn = make_compiler_fn(fullgraph=True, backend="aot_eager")
-            graphs = []
-
-            def compiler_fn(gm):
-                graphs.append(gm)
-                return inner_compiler_fn(gm)
-
-            with compiled_autograd._enable(compiler_fn):
-                res = fn(x)
-                res.sum().backward()
-
-            self.assertEqual(param1.grad, 2 * param1)
-            self.assertEqual(param2.grad, 2 * param2)
-            self.assertEqual(len(graphs), 1)
-
-            graph_code = normalize_gm(graphs[0].print_readable(print_output=False))
-            # The graph should have make_subclass calls in it.
-            self.assertExpectedInline(
-                graph_code,
-                """\
-class CompiledAutograd0(torch.nn.Module):
-    def forward(self, inputs, sizes, scalars, hooks):
-        getitem = inputs[0]
-        getitem_1 = inputs[1]
-        getitem_2 = inputs[2]
-        getitem_3 = inputs[3]
-        getitem_4 = inputs[4];  inputs = None
-
-        validate_outputs = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem], [((None, None, device(type='cpu'), 6, 0, None), [], True)]);  getitem = None
-        getitem_5 = validate_outputs[0];  validate_outputs = None
-
-        sum_backward0 = torch__dynamo_compiled_autograd_ops_SumBackward0([getitem_5], [True], [4, 4]);  getitem_5 = None
-        getitem_6 = sum_backward0[0];  sum_backward0 = None
-        validate_outputs_1 = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem_6], [((None, None, device(type='cpu'), 6, 0, None), [4, 4], True)]);  getitem_6 = None
-        getitem_7 = validate_outputs_1[0];  validate_outputs_1 = None
-
-        getitem_8 = hooks[0];  getitem_8 = None
-        call_aot_bwd_prologue = torch__dynamo_compiled_autograd_call_aot_bwd_prologue((getitem_1, getitem_2), [], getitem_7);  getitem_1 = getitem_2 = getitem_7 = None
-        aot0_primals_1 = call_aot_bwd_prologue[0]
-        aot0_primals_2 = call_aot_bwd_prologue[1]
-        aot0_tangents_1 = call_aot_bwd_prologue[2]
-        aot0_tangents_2 = call_aot_bwd_prologue[3];  call_aot_bwd_prologue = None
-
-        aot0_mul_2 = torch.ops.aten.mul.Tensor(aot0_tangents_1, aot0_primals_1);  aot0_tangents_1 = aot0_primals_1 = None
-        aot0_mul_3 = torch.ops.aten.mul.Tensor(aot0_tangents_2, aot0_primals_2);  aot0_tangents_2 = aot0_primals_2 = None
-
-        aot0_add_2 = torch.ops.aten.add.Tensor(aot0_mul_2, aot0_mul_2);  aot0_mul_2 = None
-        aot0_add_3 = torch.ops.aten.add.Tensor(aot0_mul_3, aot0_mul_3);  aot0_mul_3 = None
-
-        make_subclass = torch__dynamo_compiled_autograd_make_subclass(aot0_add_2, aot0_add_3);  aot0_add_2 = aot0_add_3 = None
-
-        getitem_13 = hooks[1];  hooks = None
-        call_backward = torch__dynamo_external_utils_call_backward(getitem_13, (), make_subclass);  getitem_13 = make_subclass = None
-        getitem_16 = call_backward[0]
-        getitem_17 = call_backward[1];  call_backward = None
-        validate_outputs_2 = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem_16, getitem_17], [((None, None, device(type='cpu'), 6, 0, None), [4, 4], False), ((None, None, device(type='cpu'), 6, 0, None), [4, 4], False)]);  getitem_16 = getitem_17 = None
-        getitem_19 = validate_outputs_2[0]
-
-        accumulate_grad__1 = torch.ops.inductor.accumulate_grad_.default(getitem_4, getitem_19);  getitem_4 = getitem_19 = accumulate_grad__1 = None
-
-        getitem_20 = validate_outputs_2[1];  validate_outputs_2 = None
-
-        accumulate_grad_ = torch.ops.inductor.accumulate_grad_.default(getitem_3, getitem_20);  getitem_3 = getitem_20 = accumulate_grad_ = None
-
-        _exec_final_callbacks_stub = torch__dynamo_external_utils__exec_final_callbacks_stub();  _exec_final_callbacks_stub = None
-        return []
-""",  # noqa: B950
-            )
 
     # https://github.com/pytorch/pytorch/issues/138920
     def test_compiled_autograd_does_not_specialize_on_bw_symints(self):

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -376,29 +376,11 @@ class AutogradCompilerInstance:
 
         outputs = copy_paste_aot_backward_graph()
 
-        def proxy_subclass_constructor(subclass_meta, is_runtime, unwrapped_args):
-            @torch._dynamo.allow_in_graph
-            def make_subclass(*unwrapped_args):
-                return subclass_meta.creation_fn(unwrapped_args, is_runtime=is_runtime)
-
-            punwrapped_args = pytree.tree_map(self.to_proxy, unwrapped_args)
-
-            poutput = self.fx_tracer.create_proxy(
-                kind="call_function",
-                target=make_subclass,
-                args=tuple(punwrapped_args),
-                kwargs={},
-            )
-
-            output = self.allocate_dummy()
-            self.bind_tensors_to_proxies([output], [poutput])
-            return output
-
+        # TODO(rzou): follow-up PR: tracing through backward_epilogue_functional
+        # is incorrect if there are any Tensor subclasses.
+        # This is a pre-existing problem and will be fixed in a follow-up.
         results = torch._functorch._aot_autograd.runtime_wrappers._backward_epilogue_functional(
-            metadata,
-            maybe_subclass_metadata,
-            outputs,
-            make_subclass_override=proxy_subclass_constructor,
+            metadata, maybe_subclass_metadata, outputs
         )
         presults = pytree.tree_map(self.to_proxy, results)
         return presults

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -1670,9 +1670,7 @@ def _backward_prologue_functional(
 
 
 # NOTE: this function must be torch._dynamo.allow_in_graph-able. Non tensor/symnode inputs must be constants.
-def _backward_epilogue_functional(
-    metadata, maybe_subclass_metadata, out, *, make_subclass_override=None
-):
+def _backward_epilogue_functional(metadata, maybe_subclass_metadata, out):
     # Toss out the backward output tokens
     num_bw_tokens = metadata.num_backward_tokens
     if num_bw_tokens > 0:
@@ -1692,7 +1690,6 @@ def _backward_epilogue_functional(
             subclass_metas=maybe_subclass_metadata.grad_input_metas,
             included_subclass_symints=True,
             is_runtime=True,
-            make_subclass_override=make_subclass_override,
         )
         return outs_wrapped
     return out

--- a/torch/_functorch/_aot_autograd/subclass_utils.py
+++ b/torch/_functorch/_aot_autograd/subclass_utils.py
@@ -8,7 +8,7 @@ and this includes tensor subclasses that implement __torch_dispatch__.
 import collections
 import typing
 from collections.abc import Iterable
-from typing import Any, Callable, Optional, TypeVar, Union
+from typing import Any, Optional, TypeVar, Union
 
 import torch
 import torch.utils._pytree as pytree
@@ -326,7 +326,6 @@ def wrap_tensor_subclasses(
     num_fw_outs_saved_for_bw: Optional[int] = None,
     included_subclass_symints: bool = False,
     is_runtime: bool = False,
-    make_subclass_override: Optional[Callable] = None,
 ) -> tuple[Any, ...]:
     wrapped_args = []
     num_args_tallied = 0
@@ -337,15 +336,9 @@ def wrap_tensor_subclasses(
         else:
             assert isinstance(subclass_meta, SubclassCreationMeta)
             assert subclass_meta.included_subclass_symints == included_subclass_symints
-
-            if make_subclass_override:
-                wrapped_args.append(
-                    make_subclass_override(subclass_meta, is_runtime, unwrapped_args)
-                )
-            else:
-                wrapped_args.append(
-                    subclass_meta.creation_fn(unwrapped_args, is_runtime=is_runtime)
-                )
+            wrapped_args.append(
+                subclass_meta.creation_fn(unwrapped_args, is_runtime=is_runtime)
+            )
             num_args_tallied += subclass_meta.arg_count
 
     # Note: [Partitioner handling for Subclasses, Part 2]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This reverts commit 082c28c3c655984ce65c13336cff822db95ee470.

Reverted https://github.com/pytorch/pytorch/pull/144115 on behalf of https://github.com/izaitsevfb due to breaking internal tests T213390054 ([comment](https://github.com/pytorch/pytorch/pull/143296#issuecomment-2611224926))

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @xmfan