### PR TITLE
Open up PT UTs  to cover additional devices

### DIFF
--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -14,7 +14,6 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     largeTensorTest,
     onlyCUDA,
-    onlyNativeDeviceTypes,
     skipCUDAIf,
     skipMeta,
     TEST_WITH_ROCM,
@@ -484,7 +483,6 @@ class TestEmbeddingNNDeviceType(NNTestCase):
     # padding indices to fill in the gaps indicated by the offset array
 
     @skipIfTorchDynamo("see https://github.com/pytorch/pytorch/pull/95621")
-    @onlyNativeDeviceTypes
     @dtypes(torch.float32, torch.float64)
     @dtypesIfCUDA(torch.half, torch.bfloat16)
     def test_embedding_bag_1D_padding_idx(self, device, dtype):
@@ -634,7 +632,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
     # Check correctness of torch.nn.functional.embedding_bag forward and
     # backward functions with padding_idx, given a 2D indices input. Compare
     # against torch.nn.functional.embedding followed by a reduction.
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float32, torch.float64)
     @dtypesIfCUDA(torch.half, torch.bfloat16)
     def test_embedding_bag_2D_padding_idx(self, device, dtype):
@@ -1582,7 +1580,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
             )
         self.assertEqual(output_non_contig, output_contig)
 
-    @onlyNativeDeviceTypes  # currently fails on XLA
+    # currently fails on XLA
     @dtypes(*itertools.product((torch.int, torch.long), (torch.int, torch.long)))
     def test_embedding_bag_bfloat16(self, device, dtypes):
         with set_default_dtype(torch.double):
@@ -1605,7 +1603,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
                 test_backward=True,
             )
 
-    @onlyNativeDeviceTypes  # currently fails on XLA
+    # currently fails on XLA
     @dtypes(*itertools.product((torch.int, torch.long), (torch.int, torch.long)))
     def test_embedding_bag_half(self, device, dtypes):
         self._test_EmbeddingBag(

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1678,8 +1678,8 @@ torch.cuda.synchronize()
 
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @dtypes(torch.float)
-    # TODO: Fails on XLA
     @gcIfJetson
+    # TODO: Fails on XLA
     def test_max_pool_nan_inf(self, device, dtype):
         for adaptive in ["", "adaptive_"]:
             for num_dim in [1, 2, 3]:

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -27,7 +27,6 @@ from torch.testing._internal.common_device_type import (
     largeTensorTest,
     onlyCPU,
     onlyCUDA,
-    onlyNativeDeviceTypes,
     skipCUDAIfRocm,
     TEST_WITH_ROCM,
 )
@@ -504,7 +503,6 @@ class TestPoolingNN(NNTestCase):
 
 
 class TestPoolingNNDeviceType(NNTestCase):
-    @onlyNativeDeviceTypes
     @dtypes(torch.float, torch.double)
     def test_adaptive_pooling_zero_batch(self, dtype, device):
         inp = torch.ones(0, 10, dtype=dtype, device=device)
@@ -523,7 +521,7 @@ class TestPoolingNNDeviceType(NNTestCase):
     # when output_size = 0, in adaptive_{avg, max}_pool and its variants.
     # These tests are explicitly written because ErrorInputs does not support backward calls
     # Issue: https://github.com/pytorch/pytorch/issues/78868
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float32, torch.float64)
     @dtypesIfCUDA(torch.float32, torch.float64, torch.bfloat16, torch.float16)
     def test_adaptive_pooling_empty_output_size(self, dtype, device):
@@ -556,7 +554,6 @@ class TestPoolingNNDeviceType(NNTestCase):
             with self.assertRaisesRegex(RuntimeError, error_msg):
                 fn(input2, output_size).sum().backward()
 
-    @onlyNativeDeviceTypes
     def test_adaptive_pooling_backward_fails(self, device):
         grad_output = torch.randn(1, 2, 7, 7, device=device)
         input = torch.randn(1, 2, 7, 7, device=device)
@@ -570,7 +567,6 @@ class TestPoolingNNDeviceType(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, "expected dimensions"):
             torch.ops.aten.adaptive_max_pool3d_backward(grad_output, input, indices)
 
-    @onlyNativeDeviceTypes
     def test_FractionalMaxPool2d_zero_batch(self, device):
         mod = nn.FractionalMaxPool2d(3, output_ratio=(0.5, 0.5))
         inp = torch.ones(0, 16, 50, 32, device=device)
@@ -580,7 +576,6 @@ class TestPoolingNNDeviceType(NNTestCase):
             inp = torch.randn(1, 0, 50, 32, device=device)
             mod(inp)
 
-    @onlyNativeDeviceTypes
     def test_FractionalMaxPool3d_zero_batch(self, device):
         mod = nn.FractionalMaxPool3d(3, output_ratio=(0.5, 0.5, 0.5)).to(device)
         inp = torch.ones(0, 16, 50, 32, 32, device=device)
@@ -590,21 +585,18 @@ class TestPoolingNNDeviceType(NNTestCase):
             inp = torch.randn(1, 0, 50, 32, 32, device=device)
             mod(inp)
 
-    @onlyNativeDeviceTypes
     def test_FractionalMaxPool2d_zero_out_size(self, device):
         mod = nn.FractionalMaxPool2d([2, 2], output_size=[0, 1])
         inp = torch.rand([16, 50, 32, 32], device=device)
         out = mod(inp)
         self.assertEqual(out, torch.empty((16, 50, 0, 1), device=device))
 
-    @onlyNativeDeviceTypes
     def test_FractionalMaxPool3d_zero_out_size(self, device):
         mod = nn.FractionalMaxPool3d([3, 2, 2], output_size=[0, 1, 1])
         inp = torch.rand([16, 50, 32, 32], device=device)
         out = mod(inp)
         self.assertEqual(out, torch.empty((16, 0, 1, 1), device=device))
 
-    @onlyNativeDeviceTypes
     def test_FractionalMaxPool2d_zero_samples(self, device):
         samples = torch.rand([0, 16, 2], device=device)
         mod = nn.FractionalMaxPool2d(
@@ -618,7 +610,6 @@ class TestPoolingNNDeviceType(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, "Expect _random_samples"):
             mod(inp1)
 
-    @onlyNativeDeviceTypes
     def test_FractionalMaxPool3d_zero_samples(self, device):
         samples = torch.rand([0, 16, 3], device=device)
         mod = nn.FractionalMaxPool3d(
@@ -632,7 +623,6 @@ class TestPoolingNNDeviceType(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, "Expect _random_samples"):
             mod(inp1)
 
-    @onlyNativeDeviceTypes
     def test_MaxPool_zero_batch_dim(self, device):
         inp = torch.randn(0, 16, 50, device=device)
         mod = torch.nn.MaxPool1d(3, stride=2).to(device)
@@ -657,7 +647,6 @@ class TestPoolingNNDeviceType(NNTestCase):
             inp = torch.ones(1, 0, 50, 44, 31, device=device)
             mod(inp)
 
-    @onlyNativeDeviceTypes
     def test_MaxUnpool_zero_batch_dim(self, device):
         pool = torch.nn.MaxPool1d(2, stride=2, return_indices=True).to(device)
         unpool = torch.nn.MaxUnpool1d(2, stride=2).to(device)
@@ -692,7 +681,6 @@ class TestPoolingNNDeviceType(NNTestCase):
         self.assertEqual(unpool_out, torch.zeros_like(unpool_out))
 
     @slowTest
-    @onlyNativeDeviceTypes
     @skipCUDAIfRocm
     @parametrize_test(
         "module_name,module_size,output_size,test_index,should_error",
@@ -801,7 +789,6 @@ torch.cuda.synchronize()
             else:
                 unpool(output, indices)
 
-    @onlyNativeDeviceTypes
     def test_AdaptiveMaxPool_zero_batch_dim(self, device):
         inp = torch.randn(0, 16, 50, device=device)
         mod = torch.nn.AdaptiveMaxPool1d(3).to(device)
@@ -827,7 +814,6 @@ torch.cuda.synchronize()
             inp = torch.ones(1, 0, 50, 44, 31, device=device)
             mod(inp)
 
-    @onlyNativeDeviceTypes
     def test_AvgPool2d_empty(self, device):
         avgpool = torch.nn.AvgPool2d(3, stride=2).to(device)
         inp = torch.randn(0, 16, 20, 32, device=device)
@@ -890,7 +876,7 @@ torch.cuda.synchronize()
         )
         self.assertEqual(y.size(), (1, 1, 3, 4))
 
-    @onlyNativeDeviceTypes  # TODO: fix on XLA
+    # TODO: fix on XLA
     def test_adaptive_avg_pool2d_output_size_one(self, device):
         def helper(size, memory_format):
             x = torch.randint(
@@ -920,7 +906,6 @@ torch.cuda.synchronize()
         for mf in (torch.contiguous_format, torch.channels_last, "non_contiguous"):
             helper((2, 3, 6, 6), mf)
 
-    @onlyNativeDeviceTypes
     def test_adaptive_avg_pool3d_output_size_one(self, device):
         x = torch.randn(
             (2, 3, 6, 6, 6), dtype=torch.float, device=device, requires_grad=True
@@ -938,7 +923,6 @@ torch.cuda.synchronize()
         self.assertEqual(out.stride(), [c, 1, 1, 1, 1])
 
     @expectedFailureMeta  # Runtime Error not raised for meta
-    @onlyNativeDeviceTypes
     @dtypes(torch.uint8, torch.int8, torch.short, torch.int, torch.long)
     def test_adaptive_pooling_no_suppot_input(self, device, dtype):
         for numel in (2, 3):
@@ -951,7 +935,6 @@ torch.cuda.synchronize()
                 with self.assertRaisesRegex(RuntimeError, "not implemented"):
                     module(input)
 
-    @onlyNativeDeviceTypes
     @gcIfJetson
     @dtypes(torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
@@ -1098,7 +1081,6 @@ torch.cuda.synchronize()
         helper(1, 100000, 32, 32, ks=4)
         helper(1, 100000, 1, 4, ks=(1, 4))  # test for max_pool1d
 
-    @onlyNativeDeviceTypes
     @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @gcIfJetson
@@ -1173,7 +1155,6 @@ torch.cuda.synchronize()
             torch.channels_last,
         )
 
-    @onlyNativeDeviceTypes
     @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @gcIfJetson
@@ -1325,7 +1306,6 @@ torch.cuda.synchronize()
         helper(2, 8, 4, 4, ks=2)
         helper(None, 3, 50, 50, ks=5)
 
-    @onlyNativeDeviceTypes
     def test_max_pool2d_with_indices_backward_fails(self, device):
         grad_output = torch.randn(1, 2, 7, 7, device=device)
         input = torch.randn(1, 2, 7, 7, device=device)
@@ -1698,7 +1678,7 @@ torch.cuda.synchronize()
 
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @dtypes(torch.float)
-    @onlyNativeDeviceTypes  # TODO: Fails on XLA
+    # TODO: Fails on XLA
     @gcIfJetson
     def test_max_pool_nan_inf(self, device, dtype):
         for adaptive in ["", "adaptive_"]:
@@ -1735,7 +1715,6 @@ torch.cuda.synchronize()
                 self.assertTrue(math.isinf(res2.item()))
 
     @expectedFailureMeta  # RuntimeError: Unrecognized tensor type ID: Meta
-    @onlyNativeDeviceTypes
     def test_fractional_max_pool2d(self, device):
         with set_default_dtype(torch.double):
             x = torch.randn(1, 2, 7, 7, requires_grad=True, device=device)
@@ -1783,7 +1762,6 @@ torch.cuda.synchronize()
                         x, (2, 2), output_size=output_size, _random_samples=samples
                     )
 
-    @onlyNativeDeviceTypes
     def test_fractional_max_pool2d_backward_fails(self, device):
         grad_output = torch.randn(1, 1, 2, 3, 3, device=device)
         input = torch.randn(1, 2, 7, 7, device=device)
@@ -1797,7 +1775,6 @@ torch.cuda.synchronize()
             )
 
     @expectedFailureMeta  # RuntimeError: Unrecognized tensor type ID: Meta
-    @onlyNativeDeviceTypes
     def test_fractional_max_pool3d(self, device):
         with set_default_dtype(torch.double):
             x = torch.randn(1, 2, 7, 7, 7, requires_grad=True, device=device)
@@ -1845,7 +1822,7 @@ torch.cuda.synchronize()
 
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @dtypes(torch.float)
-    @onlyNativeDeviceTypes  # TODO: Fails on XLA
+    # TODO: Fails on XLA
     def test_fractional_max_pool_nan_inf(self, device, dtype):
         for num_dim in [2, 3]:
             fn_name = f"FractionalMaxPool{num_dim}d"
@@ -1872,7 +1849,7 @@ torch.cuda.synchronize()
             res2.backward(torch.randn_like(res2))
             self.assertTrue(math.isinf(res2.item()))
 
-    @onlyNativeDeviceTypes  # TODO: RuntimeError message different on XLA
+    # TODO: RuntimeError message different on XLA
     def test_pooling_zero_stride(self, device):
         for op in ("max", "avg"):
             for num_dim in [1, 2, 3]:

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -26,7 +26,6 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCPU,
     onlyCUDA,
-    onlyNativeDeviceTypes,
     OpDTypes,
     ops,
     precisionOverride,
@@ -1161,7 +1160,7 @@ class TestBinaryUfuncs(TestCase):
             a += b
 
     # TODO: refactor this test into a more generic one, it's parked here currently
-    @onlyNativeDeviceTypes
+
     def test_out_resize_warning(self, device):
         a = torch.tensor((1, 2, 3), device=device, dtype=torch.float32)
         b = torch.tensor((4, 5, 6), device=device, dtype=torch.float32)
@@ -1199,7 +1198,6 @@ class TestBinaryUfuncs(TestCase):
 
     # Verifies that the inplace dunders (like idiv) actually are in place
     @expectedFailureMeta  # UserWarning not triggered
-    @onlyNativeDeviceTypes
     def test_inplace_dunders(self, device):
         t = torch.randn((1,), device=device)
         expected = t.data_ptr()
@@ -1696,7 +1694,6 @@ class TestBinaryUfuncs(TestCase):
             self.assertEqual(cpu_out, cuda_out)
 
     @skipIfTorchDynamo()
-    @onlyNativeDeviceTypes
     @dtypes(*all_types_and_complex_and(torch.half))
     def test_complex_scalar_pow_tensor(self, device, dtype):
         complexes = [0.5j, 1.0 + 1.0j, -1.5j, 2.2 - 1.6j, 1 + 0j]
@@ -1727,7 +1724,6 @@ class TestBinaryUfuncs(TestCase):
                 self._test_pow(base, first_exp)
                 self._test_pow(base, second_exp)
 
-    @onlyNativeDeviceTypes
     @skipMeta
     def test_pow_scalar_type_promotion(self, device):
         # Test against a scalar and non-scalar input
@@ -1897,7 +1893,6 @@ class TestBinaryUfuncs(TestCase):
         _scalar_helper(lambda a, b: math.floor(a / b), operator.floordiv)
         _scalar_helper(lambda a, b: math.floor(a / b), torch.floor_divide)
 
-    @onlyNativeDeviceTypes
     @skipIfTorchDynamo("Not a suitable test for TorchDynamo")
     def test_div_and_floordiv_script_vs_python(self, device):
         # Creates jitted functions of two tensors
@@ -1970,7 +1965,6 @@ class TestBinaryUfuncs(TestCase):
                     # See issue gh-52387
                     self.assertEqual(5 // a, scripted_rfloordiv_scalar(a_t))
 
-    @onlyNativeDeviceTypes
     @skipIfTorchDynamo("Not a suitable test for TorchDynamo")
     def test_idiv_and_ifloordiv_vs_python(self, device):
         def _wrapped_idiv_tensor(a, b):
@@ -2729,7 +2723,7 @@ class TestBinaryUfuncs(TestCase):
             self.assertTrue(torch.all(fn(x, 0.0).isnan()))
             self.assertTrue(torch.all(fn(x, zero).isnan()))
 
-    @onlyNativeDeviceTypes  # Check Issue https://github.com/pytorch/pytorch/issues/48130
+    # Check Issue https://github.com/pytorch/pytorch/issues/48130
     @dtypes(*integral_types())
     def test_fmod_remainder_by_zero_integral(self, device, dtype):
         fn_list = (torch.fmod, torch.remainder)
@@ -2882,7 +2876,6 @@ class TestBinaryUfuncs(TestCase):
                 expected = np.hypot(input[0].cpu().numpy(), input[1].cpu().numpy())
             self.assertEqual(actual, expected, exact_dtype=False)
 
-    @onlyNativeDeviceTypes
     @dtypes(torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
     def test_gcd(self, device, dtype):
         # Tests gcd(0, 0), gcd(0, a) cases
@@ -2907,7 +2900,6 @@ class TestBinaryUfuncs(TestCase):
             expected = np.gcd(a.cpu().numpy(), b.cpu().numpy())
             self.assertEqual(actual, expected)
 
-    @onlyNativeDeviceTypes
     @dtypes(torch.int16, torch.int32, torch.int64)
     def test_lcm(self, device, dtype):
         # Tests lcm(0, 0), lcm(0, a) cases
@@ -2924,7 +2916,6 @@ class TestBinaryUfuncs(TestCase):
         expected = np.lcm(a.cpu().numpy(), b.cpu().numpy())
         self.assertEqual(actual, expected, exact_dtype=False)
 
-    @onlyNativeDeviceTypes
     @dtypesIfCPU(torch.float32, torch.float64, torch.float16)
     @dtypes(torch.float32, torch.float64)
     def test_nextafter(self, device, dtype):
@@ -2949,7 +2940,6 @@ class TestBinaryUfuncs(TestCase):
         expected = np.nextafter(a.cpu().numpy(), b.cpu().numpy())
         self.assertEqual(actual, expected, atol=0, rtol=0)
 
-    @onlyNativeDeviceTypes
     @dtypes(torch.bfloat16)
     def test_nextafter_bfloat16(self, device, dtype):
         nan = float("nan")
@@ -3169,7 +3159,6 @@ class TestBinaryUfuncs(TestCase):
                     )  # all casts to complex128 are safe
                     compare_with_numpy_bin_op(torch_op, numpy_op, a, b, out=out)
 
-    @onlyNativeDeviceTypes
     @dtypes(torch.int8, torch.int16, torch.int32, torch.int64)
     def test_signed_shift(self, device, dtype):
         "Ensure that signed integer bit shifting works as expected."
@@ -3185,7 +3174,6 @@ class TestBinaryUfuncs(TestCase):
         self.assertEqual(a >> 1, expected_r)
         self.compare_with_numpy(lambda x: x >> 1, lambda x: np.right_shift(x, 1), a)
 
-    @onlyNativeDeviceTypes
     @dtypes(*get_all_int_dtypes())
     def test_shift_limits(self, device, dtype):
         "Ensure that integer bit shifting works as expected with out-of-limits shift values."
@@ -3235,7 +3223,6 @@ class TestBinaryUfuncs(TestCase):
                     msg=f">> {shift}",
                 )
 
-    @onlyNativeDeviceTypes
     @dtypes(
         *list(
             product(

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -20,7 +20,6 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCPU,
     onlyCUDA,
-    onlyNativeDeviceTypes,
     ops,
 )
 from torch.testing._internal.common_methods_invocations import (
@@ -555,7 +554,7 @@ class TestDecomp(TestCase):
     # NB: This actually overlaps with test_comprehensive, but it only
     # runs on things that are definitely decomposed so it's a lot faster
     # to run
-    @onlyNativeDeviceTypes
+
     @skipIfCrossRef
     @suppress_warnings
     @ops(_decomp_test_ops)
@@ -563,7 +562,6 @@ class TestDecomp(TestCase):
         self.do_cross_ref(device, dtype, op, run_all=False)
 
     @skipOps("TestDecomp", "test_quick_core_backward", core_backward_failures)
-    @onlyNativeDeviceTypes
     @skipIfCrossRef
     @suppress_warnings
     @ops(_decomp_test_ops_core_autograd, allowed_dtypes=(torch.float64,))
@@ -590,7 +588,6 @@ class TestDecomp(TestCase):
             self.check_decomposed(aten_name, mode)
 
     @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
-    @onlyNativeDeviceTypes
     @skipIfCrossRef
     @skipOps("TestDecomp", "test_comprehensive", comprehensive_failures)
     @suppress_warnings
@@ -1034,7 +1031,6 @@ instantiate_device_type_tests(TestDecomp, globals())
 
 
 class DecompOneOffTests(TestCase):
-    @onlyNativeDeviceTypes
     @skipIfCrossRef
     def test_contiguous_softmax(self, device):
         size = (2, 4, 3, 3)
@@ -1048,7 +1044,6 @@ class DecompOneOffTests(TestCase):
         res = torch._decomp.decompositions._softmax(x, -1, False)
         self.assertEqual(ref.stride(), res.stride())
 
-    @onlyNativeDeviceTypes
     @skipIfCrossRef
     def test_contiguous_log_softmax(self, device):
         size = (2, 4, 3, 3)
@@ -1113,7 +1108,6 @@ class DecompOneOffTests(TestCase):
             self.assertEqual(a.stride(), b.stride())
             self.assertEqual(a.dtype, b.dtype)
 
-    @onlyNativeDeviceTypes
     @skipIfCrossRef
     def test_elu_backward(self, device):
         size = (2, 4, 3, 3)
@@ -1125,7 +1119,6 @@ class DecompOneOffTests(TestCase):
         res = torch._decomp.decompositions.elu_backward(grad_out, 1.0, 1, 1, True, out)
         self.assertEqual(ref, res)
 
-    @onlyNativeDeviceTypes
     @skipIfCrossRef
     def test_threshold_backward_dtype(self, device):
         grad = torch.randint(10, (4,), device=device)
@@ -1135,7 +1128,6 @@ class DecompOneOffTests(TestCase):
         res = torch._decomp.decompositions.threshold_backward(grad, input_tensor, 1)
         self.assertEqual(ref.dtype, res.dtype)
 
-    @onlyNativeDeviceTypes
     @skipIfCrossRef
     def test_weight_norm_interface(self, device):
         g = torch.randn((3, 10, 10), device=device)

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -17,7 +17,6 @@ from torch.testing._internal.common_device_type import (
     dtypesIfCUDA,
     instantiate_device_type_tests,
     onlyCUDA,
-    onlyNativeDeviceTypes,
     skipXLA,
 )
 from torch.testing._internal.common_utils import (
@@ -177,7 +176,6 @@ class TestIndexing(TestCase):
 
         self.assertRaises(TypeError, delitem)
 
-    @onlyNativeDeviceTypes
     @dtypes(torch.half, torch.double)
     def test_advancedindex(self, device, dtype):
         # Tests for Integer Array Indexing, Part I - Purely integer array
@@ -941,7 +939,6 @@ class TestIndexing(TestCase):
         self.assertEqual(a[-1, -1], 14)
         self.assertEqual(a[0, -1], 1)
 
-    @onlyNativeDeviceTypes
     def test_index_put_accumulate_expanded_values(self, device):
         # checks the issue with cuda: https://github.com/pytorch/pytorch/issues/39227
         # and verifies consistency with CPU result
@@ -1058,7 +1055,6 @@ class TestIndexing(TestCase):
         out_cpu = func(t, indices, value1d)
         self.assertEqual(out_cuda.cpu(), out_cpu)
 
-    @onlyNativeDeviceTypes
     def test_index_put_accumulate_duplicate_indices(self, device):
         for i in range(1, 512):
             # generate indices by random walk, this will create indices with
@@ -1078,7 +1074,6 @@ class TestIndexing(TestCase):
 
             self.assertEqual(output, input_list)
 
-    @onlyNativeDeviceTypes
     def test_index_ind_dtype(self, device):
         x = torch.randn(4, 4, device=device)
         ind_long = torch.randint(4, (4,), dtype=torch.long, device=device)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -6800,7 +6800,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
     @unittest.skipIf(IS_WINDOWS, "Skipped on Windows!")
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
-
     @parametrize("m", [32, 64])
     @parametrize("k", [32, 64])
     @parametrize("n", [48, 64])
@@ -6869,7 +6868,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
     @unittest.skipIf(IS_WINDOWS, "Skipped on Windows!")
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
-
     @parametrize("m", [32, 64])
     @parametrize("k", [32, 64])
     @parametrize("n", [48, 64])
@@ -6921,7 +6919,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
     @unittest.skipIf(TEST_WITH_ROCM and IS_REMOTE_GPU, "ROCM is unsupported")
-
     @parametrize("k", [64, 256])
     @parametrize("n", [32, 48, 64, 128])
     def test__dyn_quant_pack_4bit_weight(self, device, k, n):
@@ -6948,7 +6945,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
     @unittest.skipIf(TEST_WITH_ROCM and IS_REMOTE_GPU, "ROCM is unsupported")
-
     @parametrize("m", [1, 32])
     @parametrize("k", [64, 128])
     @parametrize("n", [4096, 11008])
@@ -7020,7 +7016,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
     @unittest.skipIf(TEST_WITH_ROCM and IS_REMOTE_GPU, "ROCM is unsupported")
-
     @parametrize("m", [1, 32])
     @parametrize("k", [64, 128])
     @parametrize("n", [4096, 11008])
@@ -7152,7 +7147,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
             torch._C._set_cpu_allow_fp16_reduced_precision_reduction(prev)
 
     @slowTest
-
     # bfloat16 doesn't have sufficient precision to pass this test
     @dtypes(torch.half, torch.float32, torch.float64, torch.int32, torch.int64, torch.cfloat, torch.cdouble)
     @dtypesIfCUDA(torch.float32, torch.float64, torch.cfloat, torch.cdouble)
@@ -7334,7 +7328,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         self.compare_with_numpy(torch_fn, np_fn, sx[0])
 
     @precisionOverride({torch.half: 0.05, torch.bfloat16: 0.05})
-
     @dtypes(*floating_and_complex_types_and(torch.bfloat16, torch.half))
     @tf32_on_and_off(0.05)
     @bf32_on_and_off(0.05)
@@ -7447,7 +7440,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         self.assertEqual(res7, ref)
 
     @precisionOverride({torch.half: 0.05, torch.bfloat16: 0.05})
-
     @dtypes(*floating_and_complex_types_and(torch.bfloat16, torch.half))
     @tf32_on_and_off(0.05)
     @bf32_on_and_off(0.05)
@@ -7521,7 +7513,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
             self._test_addbmm_baddbmm("addbmm", b1, b2, ref, out_tensor)
 
     @precisionOverride({torch.half: 0.1, torch.bfloat16: 0.5})
-
     @dtypes(*floating_and_complex_types_and(torch.bfloat16, torch.half))
     @tf32_on_and_off(0.05)
     @bf32_on_and_off(0.05)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -25,7 +25,7 @@ from torch.testing._internal.common_utils import \
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes, has_cusolver, has_hipsolver,
      onlyCPU, skipCUDAIf, skipCUDAIfNoMagma, skipCPUIfNoLapack, precisionOverride,
-     skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, onlyNativeDeviceTypes, dtypesIfCUDA,
+     skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, dtypesIfCUDA,
      onlyCUDA, skipCUDAVersionIn, skipMeta, skipCUDAIfNoCusolver, skipCUDAIfNotRocm, skipCUDAIfRocmVersionLessThan,
      dtypesIfMPS, largeTensorTest)
 from torch.testing import make_tensor
@@ -2914,7 +2914,6 @@ class TestLinalg(TestCase):
 
     @skipCUDAIfNoMagmaAndNoCusolver
     @skipCPUIfNoLapack
-    @onlyNativeDeviceTypes   # TODO: XLA doesn't raise exception
     @dtypes(*floating_and_complex_types())
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/129882")
     def test_inverse_errors(self, device, dtype):
@@ -2935,7 +2934,6 @@ class TestLinalg(TestCase):
     @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Test fails for float64 on GPU (P100, V100) on Meta infra")
     @skipCUDAIfNoMagmaAndNoCusolver
     @skipCPUIfNoLapack
-    @onlyNativeDeviceTypes   # TODO: XLA doesn't raise exception
     @dtypes(*floating_and_complex_types())
     def test_inverse_errors_large(self, device, dtype):
         # Test batched inverse of singular matrices reports errors without crashing (gh-51930)
@@ -3427,12 +3425,12 @@ class TestLinalg(TestCase):
             x_cpu = x.expand(3).cpu()
             check(x_cpu, y.to(x.dtype), 'Expected all tensors to be on the same device')
 
-    @onlyNativeDeviceTypes
+
     def test_vdot_invalid_args(self, device):
         self._test_dot_vdot_invalid_args(device, torch.vdot)
         self._test_dot_vdot_invalid_args(device, torch.vdot, complex_dtypes=True)
 
-    @onlyNativeDeviceTypes
+
     def test_dot_invalid_args(self, device):
         self._test_dot_vdot_invalid_args(device, torch.dot)
         self._test_dot_vdot_invalid_args(device, torch.dot, complex_dtypes=True)
@@ -3613,7 +3611,7 @@ class TestLinalg(TestCase):
         self.assertEqual(matrix_rank(a).item(), 9)
         self.assertEqual(matrix_rank(a, hermitian=True).item(), 9)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.double)
     # This tests only the cases where torch.chain_matmul differs from torch.linalg.multi_dot which this is an "alias" for.
     def test_chain_matmul(self, device, dtype):
@@ -3628,7 +3626,7 @@ class TestLinalg(TestCase):
         with self.assertRaisesRegex(RuntimeError, r"Tensor dimension is 1, expected 2 instead"):
             torch.chain_matmul(make_tensor(1, dtype=dtype, device=device), make_tensor(1, dtype=dtype, device=device))
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.double, torch.cdouble)
     def test_multi_dot(self, device, dtype):
         def check(*shapes):
@@ -3663,7 +3661,7 @@ class TestLinalg(TestCase):
         check([10, 100], [100, 5], [5, 50])
         check([10, 20], [20, 30], [30, 5])
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float)
     def test_multi_dot_errors(self, device, dtype):
         def check(tensors, out, msg):
@@ -6802,7 +6800,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
     @unittest.skipIf(IS_WINDOWS, "Skipped on Windows!")
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
-    @onlyNativeDeviceTypes
+
     @parametrize("m", [32, 64])
     @parametrize("k", [32, 64])
     @parametrize("n", [48, 64])
@@ -6871,7 +6869,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
     @unittest.skipIf(IS_WINDOWS, "Skipped on Windows!")
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
-    @onlyNativeDeviceTypes
+
     @parametrize("m", [32, 64])
     @parametrize("k", [32, 64])
     @parametrize("n", [48, 64])
@@ -6923,7 +6921,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
     @unittest.skipIf(TEST_WITH_ROCM and IS_REMOTE_GPU, "ROCM is unsupported")
-    @onlyNativeDeviceTypes
+
     @parametrize("k", [64, 256])
     @parametrize("n", [32, 48, 64, 128])
     def test__dyn_quant_pack_4bit_weight(self, device, k, n):
@@ -6950,7 +6948,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
     @unittest.skipIf(TEST_WITH_ROCM and IS_REMOTE_GPU, "ROCM is unsupported")
-    @onlyNativeDeviceTypes
+
     @parametrize("m", [1, 32])
     @parametrize("k", [64, 128])
     @parametrize("n", [4096, 11008])
@@ -7022,7 +7020,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
     @unittest.skipIf(TEST_WITH_ROCM and IS_REMOTE_GPU, "ROCM is unsupported")
-    @onlyNativeDeviceTypes
+
     @parametrize("m", [1, 32])
     @parametrize("k", [64, 128])
     @parametrize("n", [4096, 11008])
@@ -7154,7 +7152,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
             torch._C._set_cpu_allow_fp16_reduced_precision_reduction(prev)
 
     @slowTest
-    @onlyNativeDeviceTypes
+
     # bfloat16 doesn't have sufficient precision to pass this test
     @dtypes(torch.half, torch.float32, torch.float64, torch.int32, torch.int64, torch.cfloat, torch.cdouble)
     @dtypesIfCUDA(torch.float32, torch.float64, torch.cfloat, torch.cdouble)
@@ -7260,7 +7258,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
             _test_mm(n, m, p, dtype, genf)
 
-    @onlyNativeDeviceTypes
+
     def test_mm_bmm_non_memory_dense(self, device):
         def _slice(tensor, fn):
             return fn(tensor)[..., ::2]
@@ -7292,7 +7290,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         self.assertEqual(torch.bmm(Ab_conj, Bb_, out=out_b), torch.bmm(Ab_conj_physical, Bb_, out=out_b))
         self.assertEqual(torch.bmm(t_b(Ab_conj), Bb_, out=out_b), torch.bmm(t_b(Ab_conj_physical), Bb_, out=out_b))
 
-    @onlyNativeDeviceTypes
+
     def test_mm_conjtranspose(self, device):
         A = torch.randn(3, 3, dtype=torch.cfloat, device=device)
         B = torch.randn(3, 3, dtype=torch.cfloat, device=device)
@@ -7312,14 +7310,14 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         out1_ref = torch.mm(A.t().conj_physical(), B.t().conj_physical())
         self.assertEqual(out1, out1_ref)
 
-    @onlyNativeDeviceTypes
+
     def test_mm_empty_inputs_mixed_dtype_errors(self, device):
         a = torch.randint(0, 10, [1, 10], dtype=torch.int16, device=device)
         b = torch.randn(10, 20, dtype=torch.float32, device=device)
         with self.assertRaisesRegex(RuntimeError, "expected .* and .* to have the same dtype, but got:"):
             torch.mm(a, b)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float32, torch.float64)
     def test_strided_mm_bmm(self, device, dtype):
         # Tests strided view case with stride smaller than corresponding dimension size
@@ -7336,7 +7334,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         self.compare_with_numpy(torch_fn, np_fn, sx[0])
 
     @precisionOverride({torch.half: 0.05, torch.bfloat16: 0.05})
-    @onlyNativeDeviceTypes
+
     @dtypes(*floating_and_complex_types_and(torch.bfloat16, torch.half))
     @tf32_on_and_off(0.05)
     @bf32_on_and_off(0.05)
@@ -7449,7 +7447,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         self.assertEqual(res7, ref)
 
     @precisionOverride({torch.half: 0.05, torch.bfloat16: 0.05})
-    @onlyNativeDeviceTypes
+
     @dtypes(*floating_and_complex_types_and(torch.bfloat16, torch.half))
     @tf32_on_and_off(0.05)
     @bf32_on_and_off(0.05)
@@ -7523,7 +7521,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
             self._test_addbmm_baddbmm("addbmm", b1, b2, ref, out_tensor)
 
     @precisionOverride({torch.half: 0.1, torch.bfloat16: 0.5})
-    @onlyNativeDeviceTypes
+
     @dtypes(*floating_and_complex_types_and(torch.bfloat16, torch.half))
     @tf32_on_and_off(0.05)
     @bf32_on_and_off(0.05)
@@ -8739,7 +8737,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         run_subtest(guess_rank, actual_rank, size, batches, device, jitted)
 
     # Ensure that nuclear_norm's out variant gives the same result as the non-out
-    @onlyNativeDeviceTypes
+
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(torch.float32, torch.float64)

--- a/test/test_masked.py
+++ b/test/test_masked.py
@@ -16,7 +16,7 @@ from torch.testing._internal.common_utils import \
 from torch.testing._internal.common_methods_invocations import \
     (op_db, SampleInput)
 from torch.testing._internal.common_device_type import \
-    (instantiate_device_type_tests, ops, onlyNativeDeviceTypes, precisionOverride)
+    (instantiate_device_type_tests, ops, precisionOverride)
 
 
 def apply_masked_reduction_along_dim(op, input, *args, **kwargs):
@@ -271,7 +271,7 @@ class TestMasked(TestCase):
             expected = torch.where(mask, expected, expected.new_zeros([]))
         self.assertEqual(strided, expected, exact_device=False)
 
-    @onlyNativeDeviceTypes
+
     @suppress_warnings
     @ops(masked_ops_with_references)
     @precisionOverride({torch.bfloat16: 5e-4, torch.float16: 5e-4})
@@ -293,7 +293,7 @@ class TestMasked(TestCase):
             self.assertEqualMasked(actual, expected, outmask)
 
     @mask_layouts()
-    @onlyNativeDeviceTypes
+
     @suppress_warnings
     @ops(masked_ops_with_non_strided_support)
     @precisionOverride({torch.bfloat16: 5e-3, torch.float16: 5e-3})

--- a/test/test_masked.py
+++ b/test/test_masked.py
@@ -293,7 +293,6 @@ class TestMasked(TestCase):
             self.assertEqualMasked(actual, expected, outmask)
 
     @mask_layouts()
-
     @suppress_warnings
     @ops(masked_ops_with_non_strided_support)
     @precisionOverride({torch.bfloat16: 5e-3, torch.float16: 5e-3})

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -43,7 +43,7 @@ from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, Criteri
 from torch.testing._internal.common_device_type import dtypesIfMPS, instantiate_device_type_tests, dtypes, \
     dtypesIfCUDA, precisionOverride, skipCUDAIfCudnnVersionLessThan, onlyCUDA, onlyCPU, \
     skipCUDAIfRocm, skipCUDAIf, skipCUDAIfNotRocm, \
-    onlyNativeDeviceTypes, deviceCountAtLeast, largeTensorTest, expectedFailureMeta, expectedFailureMPS, \
+    deviceCountAtLeast, largeTensorTest, expectedFailureMeta, expectedFailureMPS, \
     skipMeta, get_all_device_types
 
 from hypothesis import given
@@ -8471,7 +8471,7 @@ class TestNNDeviceType(NNTestCase):
             for dtype in [torch.half, torch.bfloat16]:
                 self._test_LayerNorm_cpu_mixed_dtype(device, dtype=dtype)
 
-    @onlyNativeDeviceTypes
+
     def test_LayerNorm_numeric(self, device):
         def layer_norm_ref(X, gamma, beta, normalized_shape, eps):
             feature_size = np.prod(normalized_shape)
@@ -8519,7 +8519,7 @@ class TestNNDeviceType(NNTestCase):
             x = torch.randn(shape, device=device)
             test_dtype(func(device), x, torch.bfloat16)
 
-    @onlyNativeDeviceTypes
+
     def test_GroupNorm_general(self, device):
         self._test_GroupNorm_general(device)
 
@@ -8593,7 +8593,7 @@ class TestNNDeviceType(NNTestCase):
             helper(self, (2, 9, 7, 200, 15), 3, torch.channels_last_3d, is_mixed)
             helper(self, (2, 60, 7, 200, 15), 3, torch.channels_last_3d, is_mixed)
 
-    @onlyNativeDeviceTypes
+
     def test_GroupNorm_memory_format(self, device):
         # Tests for regression reported in https://github.com/pytorch/pytorch/issues/92166
 
@@ -8619,7 +8619,7 @@ class TestNNDeviceType(NNTestCase):
             for grad_format in [torch.contiguous_format, torch.channels_last]:
                 helper(input_format, grad_format)
 
-    @onlyNativeDeviceTypes
+
     def test_GroupNorm_numeric(self, device):
         def group_norm_ref(X, gamma, beta, groups, channels, eps):
             batch_size = X.size()[0]
@@ -8649,7 +8649,7 @@ class TestNNDeviceType(NNTestCase):
             Y_cpu = group_norm(X.cpu())
             self.assertEqual(Y_cpu, Y, rtol=0, atol=1e-5)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float64, torch.complex128)
     def test_pad(self, device, dtype):
         # Assert assertion errors are raised for invalid circular padding values
@@ -8680,7 +8680,7 @@ class TestNNDeviceType(NNTestCase):
             out.fill_(4)
             self.assertTrue(torch.all(torch.abs(inputs) < 2))
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float64, torch.complex128)
     def test_ReplicationPad_empty(self, device, dtype):
         for mod, inp in [
@@ -8803,7 +8803,7 @@ class TestNNDeviceType(NNTestCase):
             out.backward(g)
             self.assertEqual(x.grad[:, :, 1:-1, 1:-1, 1:-1], g[:, :, pf + 1 : -pbk - 1, pt + 1 : -pbt - 1, pl + 1 : -pr - 1])
 
-    @onlyNativeDeviceTypes
+
     def test_Bilinear_empty(self, device):
         mod = torch.nn.Bilinear(20, 30, 40).to(device)
         inp1 = torch.randn(0, 10, 20, requires_grad=True, device=device)
@@ -8819,7 +8819,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(inp2.grad, torch.zeros_like(inp2))
 
     @expectedFailureMeta  # RuntimeError: cannot reshape tensor of 0 elements into shape [1, 0, -1]
-    @onlyNativeDeviceTypes
+
     def test_TransformerEncoderLayer_empty(self, device):
         for training in (True, False):
             for batch_first, input_shape in [(True, (0, 10, 512)),
@@ -8847,7 +8847,7 @@ class TestNNDeviceType(NNTestCase):
                     _test_module_empty_input(self, encoder_layer, input, check_size=False)
 
     @expectedFailureMeta  # RuntimeError: cannot reshape tensor of 0 elements into shape [1, 0, -1]
-    @onlyNativeDeviceTypes
+
     def test_TransformerEncoder_empty(self, device):
         for batch_first, input_shape in [(True, (0, 10, 512)),
                                          (False, (10, 0, 512))]:
@@ -8857,7 +8857,7 @@ class TestNNDeviceType(NNTestCase):
             _test_module_empty_input(self, transformer_encoder, input, check_size=False)
 
     @expectedFailureMeta  # RuntimeError: cannot reshape tensor of 0 elements into shape [1, 0, -1]
-    @onlyNativeDeviceTypes
+
     def test_TransformerDecoderLayer_empty(self, device):
         for batch_first, memory_shape, tgt_shape in [(True, (0, 10, 512), (0, 20, 512)),
                                                      (False, (10, 0, 512), (20, 0, 512))]:
@@ -8867,7 +8867,7 @@ class TestNNDeviceType(NNTestCase):
             self._test_module_empty_inputs(decoder_layer, [tgt, memory])
 
     @expectedFailureMeta  # RuntimeError: cannot reshape tensor of 0 elements into shape [1, 0, -1]
-    @onlyNativeDeviceTypes
+
     def test_TransformerDecoder_empty(self, device):
         for batch_first, memory_shape, tgt_shape in [(True, (0, 10, 512), (0, 20, 512)),
                                                      (False, (10, 0, 512), (20, 0, 512))]:
@@ -8878,7 +8878,7 @@ class TestNNDeviceType(NNTestCase):
             self._test_module_empty_inputs(transformer_decoder, [tgt, memory])
 
     @expectedFailureMeta  # RuntimeError: cannot reshape tensor of 0 elements into shape [1, 0, -1]
-    @onlyNativeDeviceTypes
+
     def test_Transformer_empty(self, device):
         for batch_first, src_shape, tgt_shape in [(True, (10, 0, 512), (20, 0, 512))]:
             transformer_model = nn.Transformer(nhead=16, num_encoder_layers=12, dtype=torch.double).to(device)
@@ -8886,7 +8886,7 @@ class TestNNDeviceType(NNTestCase):
             tgt = torch.rand(*tgt_shape, requires_grad=True, device=device, dtype=torch.double)
             self._test_module_empty_inputs(transformer_model, [src, tgt])
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float32, torch.complex64)
     def test_ReflectionPad_empty(self, device, dtype):
         for mod, inp in [
@@ -8910,7 +8910,7 @@ class TestNNDeviceType(NNTestCase):
             inp = torch.randn(3, 0, 10, 10, 10, device=device, dtype=dtype)
             mod(inp)
 
-    @onlyNativeDeviceTypes
+
     def test_ReflectionPad_fails(self, device):
         with self.assertRaisesRegex(RuntimeError, 'Only 2D, 3D, 4D, 5D'):
             mod = torch.nn.ReflectionPad1d(2)
@@ -8986,7 +8986,7 @@ class TestNNDeviceType(NNTestCase):
             # avoid this state leaking outside of this test
             torch.use_deterministic_algorithms(original_deterministic)
 
-    @onlyNativeDeviceTypes
+
     def test_LocalResponseNorm_empty(self, device):
         mod = torch.nn.LocalResponseNorm(2).to(device)
         inp = torch.ones(0, 5, 24, 24, device=device)
@@ -9013,7 +9013,7 @@ class TestNNDeviceType(NNTestCase):
 
             self.assertEqual(x.grad, ref_x.grad)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float, torch.double)
     def test_MarginLoss_empty(self, device, dtype):
         for mod, x, y in [
@@ -9053,7 +9053,7 @@ class TestNNDeviceType(NNTestCase):
             l.backward()
         self.assertTrue(len(f.getvalue()) == 0)
 
-    @onlyNativeDeviceTypes
+
     def test_Unfold_empty(self, device):
         inp = torch.randn(0, 3, 3, 4, device=device)
         unfold = torch.nn.Unfold(kernel_size=(2, 3)).to(device)
@@ -9276,7 +9276,7 @@ class TestNNDeviceType(NNTestCase):
                     verify_reduction_scalars(input, reduction, output)
 
     # verify that bogus reduction strings are errors
-    @onlyNativeDeviceTypes
+
     def test_invalid_reduction_strings(self, device):
         input = torch.randn(3, 5, requires_grad=True, device=device)
         cinput = torch.randn(3, 5, requires_grad=True, device=device, dtype=torch.cfloat)
@@ -9322,7 +9322,7 @@ class TestNNDeviceType(NNTestCase):
             # FIXME: should we allow derivatives on these?
             v(lambda: F.soft_margin_loss(input, input.sign().detach(), reduction=reduction))
 
-    @onlyNativeDeviceTypes
+
     def test_smooth_l1_loss_vs_huber_loss(self, device):
         def _make_test_tensor(shape, contiguous=True):
             if contiguous:
@@ -9763,7 +9763,7 @@ class TestNNDeviceType(NNTestCase):
     @parametrize_test("align_corners", [True, False])
     @parametrize_test("mode", ["bilinear", "bicubic"])
     @parametrize_test("memory_format", [torch.contiguous_format, torch.channels_last])
-    @onlyNativeDeviceTypes
+
     def test_upsamplingBiMode2d(self, device, antialias, align_corners, mode, memory_format):
         # Forward AD does not support XLA because XLA tensors don't have storage
         check_forward_ad = torch.device(device).type != 'xla'
@@ -9832,7 +9832,7 @@ class TestNNDeviceType(NNTestCase):
     @parametrize_test("num_channels", [3, 5])
     @parametrize_test("mode", ["nearest", "nearest-exact", "bilinear", "bicubic"])
     @parametrize_test("dtype", integral_types() + floating_types())
-    @onlyNativeDeviceTypes
+
     def test_upsamplingBiMode2d_nonsupported_dtypes(self, device, antialias, num_channels, mode, dtype):
         x = torch.ones(1, num_channels, 32, 32, dtype=dtype, device=device)
 
@@ -11145,7 +11145,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertTrue(gradcheck(F.hardsigmoid, (inputs,)))
 
     # currently fails on XLA
-    @onlyNativeDeviceTypes
+
     def test_hardswish_grad(self, device):
         inputs = (torch.randn(4, 16, 16, device=device, dtype=torch.double) - 0.5) * 10
         inputs.requires_grad = True
@@ -11351,7 +11351,7 @@ class TestNNDeviceType(NNTestCase):
             with torch.backends.cudnn.flags(enabled=False):
                 self._test_batchnorm_simple_average(device, dtype, torch.float)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float, torch.double)
     def test_grid_sample_nan_inf(self, device, dtype):
         input = torch.zeros([1, 1, 3, 3], device=device, dtype=dtype)
@@ -11658,7 +11658,7 @@ class TestNNDeviceType(NNTestCase):
         _test_bfloat16_ops(self, torch.nn.Softshrink(), device, inp_dims=(5), prec=1e-2)
         _test_bfloat16_ops(self, torch.nn.LeakyReLU(), device, inp_dims=(5), prec=1e-2)
 
-    @onlyNativeDeviceTypes
+
     def test_softmax_bfloat16(self, device):
         for dim in [0, 1, 2, 3]:
             _test_bfloat16_ops(self, torch.nn.Softmax(dim=dim), device, inp_dims=(16, 33, 15, 16), prec=1e-2)
@@ -12310,7 +12310,7 @@ if __name__ == '__main__':
             F.elu_(x)
 
     # Merge into OpInfo?
-    @onlyNativeDeviceTypes
+
     def test_elu_inplace_with_neg_alpha(self, device):
         a = torch.tensor([-1., 1.], device=device, requires_grad=True)
         b = torch.nn.functional.elu_(a.clone(), alpha=-2)
@@ -12333,7 +12333,7 @@ if __name__ == '__main__':
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
             F.silu(x, inplace=True)
 
-    @onlyNativeDeviceTypes
+
     def test_mish_inplace_overlap(self, device):
         x = torch.randn((1, 6), device=device).expand((6, 6))
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
@@ -12425,7 +12425,7 @@ if __name__ == '__main__':
         F.threshold(x, 0.5, 0.5, inplace=True)
         F.threshold_(x, 0.5, 0.5)
 
-    @onlyNativeDeviceTypes
+
     def test_triplet_margin_with_distance_loss_default_parity(self, device):
         # Test for `nn.TripletMarginWithDistanceLoss` and
         # `F.triplet_margin_with_distance_loss`.  Checks
@@ -12459,7 +12459,7 @@ if __name__ == '__main__':
             self.assertTrue(gradcheck(lambda a, p, n: loss_op(a, p, n),
                             (anchor, positive, negative)))
 
-    @onlyNativeDeviceTypes
+
     def test_triplet_margin_with_distance_loss(self, device):
         # Test for parity between `nn.TripletMarginWithDistanceLoss` and
         # `F.triplet_margin_with_distance_loss`.

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8819,7 +8819,6 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(inp2.grad, torch.zeros_like(inp2))
 
     @expectedFailureMeta  # RuntimeError: cannot reshape tensor of 0 elements into shape [1, 0, -1]
-
     def test_TransformerEncoderLayer_empty(self, device):
         for training in (True, False):
             for batch_first, input_shape in [(True, (0, 10, 512)),
@@ -8847,7 +8846,6 @@ class TestNNDeviceType(NNTestCase):
                     _test_module_empty_input(self, encoder_layer, input, check_size=False)
 
     @expectedFailureMeta  # RuntimeError: cannot reshape tensor of 0 elements into shape [1, 0, -1]
-
     def test_TransformerEncoder_empty(self, device):
         for batch_first, input_shape in [(True, (0, 10, 512)),
                                          (False, (10, 0, 512))]:
@@ -8857,7 +8855,6 @@ class TestNNDeviceType(NNTestCase):
             _test_module_empty_input(self, transformer_encoder, input, check_size=False)
 
     @expectedFailureMeta  # RuntimeError: cannot reshape tensor of 0 elements into shape [1, 0, -1]
-
     def test_TransformerDecoderLayer_empty(self, device):
         for batch_first, memory_shape, tgt_shape in [(True, (0, 10, 512), (0, 20, 512)),
                                                      (False, (10, 0, 512), (20, 0, 512))]:
@@ -8867,7 +8864,6 @@ class TestNNDeviceType(NNTestCase):
             self._test_module_empty_inputs(decoder_layer, [tgt, memory])
 
     @expectedFailureMeta  # RuntimeError: cannot reshape tensor of 0 elements into shape [1, 0, -1]
-
     def test_TransformerDecoder_empty(self, device):
         for batch_first, memory_shape, tgt_shape in [(True, (0, 10, 512), (0, 20, 512)),
                                                      (False, (10, 0, 512), (20, 0, 512))]:
@@ -8878,7 +8874,6 @@ class TestNNDeviceType(NNTestCase):
             self._test_module_empty_inputs(transformer_decoder, [tgt, memory])
 
     @expectedFailureMeta  # RuntimeError: cannot reshape tensor of 0 elements into shape [1, 0, -1]
-
     def test_Transformer_empty(self, device):
         for batch_first, src_shape, tgt_shape in [(True, (10, 0, 512), (20, 0, 512))]:
             transformer_model = nn.Transformer(nhead=16, num_encoder_layers=12, dtype=torch.double).to(device)
@@ -9763,7 +9758,6 @@ class TestNNDeviceType(NNTestCase):
     @parametrize_test("align_corners", [True, False])
     @parametrize_test("mode", ["bilinear", "bicubic"])
     @parametrize_test("memory_format", [torch.contiguous_format, torch.channels_last])
-
     def test_upsamplingBiMode2d(self, device, antialias, align_corners, mode, memory_format):
         # Forward AD does not support XLA because XLA tensors don't have storage
         check_forward_ad = torch.device(device).type != 'xla'
@@ -9832,7 +9826,6 @@ class TestNNDeviceType(NNTestCase):
     @parametrize_test("num_channels", [3, 5])
     @parametrize_test("mode", ["nearest", "nearest-exact", "bilinear", "bicubic"])
     @parametrize_test("dtype", integral_types() + floating_types())
-
     def test_upsamplingBiMode2d_nonsupported_dtypes(self, device, antialias, num_channels, mode, dtype):
         x = torch.ones(1, num_channels, 32, 32, dtype=dtype, device=device)
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -27,7 +27,6 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCPU,
     onlyCUDA,
-    onlyNativeDeviceTypesAnd,
     OpDTypes,
     ops,
     skipMeta,
@@ -354,7 +353,7 @@ class TestCommon(TestCase):
     # NumPy does computation internally using double precision for many functions
     # resulting in possible equality check failures.
     # skip windows case on CPU due to https://github.com/pytorch/pytorch/issues/129947
-    @onlyNativeDeviceTypesAnd(["hpu"])
+
     @suppress_warnings
     @ops(_ref_test_ops, allowed_dtypes=(torch.float64, torch.long, torch.complex128))
     def test_numpy_ref(self, device, dtype, op):
@@ -408,7 +407,7 @@ class TestCommon(TestCase):
     # Tests that experimental Python References can propagate shape, dtype,
     # and device metadata properly.
     # See https://github.com/pytorch/pytorch/issues/78050 for a discussion of stride propagation.
-    @onlyNativeDeviceTypesAnd(["hpu"])
+
     @ops(python_ref_db)
     @skipIfTorchInductor("Takes too long for inductor")
     def test_python_ref_meta(self, device, dtype, op):
@@ -603,7 +602,7 @@ class TestCommon(TestCase):
     # Tests that experimental Python References perform the same computation
     # as the operators they reference, when operator calls in the torch
     # namesapce are remapped to the refs namespace (torch.foo becomes refs.foo).
-    @onlyNativeDeviceTypesAnd(["hpu"])
+
     @ops(python_ref_db)
     @skipIfTorchInductor("Takes too long for inductor")
     def test_python_ref(self, device, dtype, op):
@@ -621,7 +620,7 @@ class TestCommon(TestCase):
     # Tests that experimental Python References perform the same computation
     # as the operators they reference, when operator calls in the torch
     # namespace are preserved (torch.foo remains torch.foo).
-    @onlyNativeDeviceTypesAnd(["hpu"])
+
     @ops(python_ref_db)
     @skipIfTorchInductor("Takes too long for inductor")
     def test_python_ref_torch_fallback(self, device, dtype, op):
@@ -657,7 +656,6 @@ class TestCommon(TestCase):
         self._ref_test_helper(contextlib.nullcontext, device, dtype, op)
 
     @skipMeta
-    @onlyNativeDeviceTypesAnd(["hpu"])
     @ops([op for op in op_db if op.error_inputs_func is not None], dtypes=OpDTypes.none)
     def test_errors(self, device, op):
         error_inputs = op.error_inputs(device)
@@ -668,7 +666,6 @@ class TestCommon(TestCase):
                 self.assertFalse(isinstance(out, type(NotImplemented)))
 
     @skipMeta
-    @onlyNativeDeviceTypesAnd(["hpu"])
     @ops(
         [op for op in op_db if op.error_inputs_sparse_func is not None],
         dtypes=OpDTypes.none,
@@ -691,7 +688,6 @@ class TestCommon(TestCase):
                 self.assertFalse(isinstance(out, type(NotImplemented)))
 
     @skipMeta
-    @onlyNativeDeviceTypesAnd(["hpu"])
     @ops(
         [op for op in python_ref_db if op.error_inputs_func is not None],
         dtypes=OpDTypes.none,
@@ -717,7 +713,6 @@ class TestCommon(TestCase):
     # Tests that the function produces the same result when called with
     #   noncontiguous tensors.
     @with_tf32_off
-    @onlyNativeDeviceTypesAnd(["hpu"])
     @suppress_warnings
     @ops(op_db, allowed_dtypes=(torch.float32, torch.long, torch.complex64))
     def test_noncontiguous_samples(self, device, dtype, op):
@@ -1459,7 +1454,6 @@ class TestCommon(TestCase):
     # Validates that each OpInfo specifies its forward and backward dtypes
     #   correctly for CPU and CUDA devices
     @skipMeta
-    @onlyNativeDeviceTypesAnd(["hpu"])
     @ops(ops_and_refs, dtypes=OpDTypes.none)
     def test_dtypes(self, device, op):
         # Check complex32 support only if the op claims.
@@ -1655,7 +1649,6 @@ class TestCommon(TestCase):
 
     # Validates that each OpInfo that sets promotes_int_to_float=True does as it says
     @skipMeta
-    @onlyNativeDeviceTypesAnd(["hpu"])
     @ops(
         (op for op in op_db if op.promotes_int_to_float),
         allowed_dtypes=integral_types_and(torch.bool),

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -25,7 +25,6 @@ from torch.testing._internal.common_device_type import (
     largeTensorTest,
     onlyCPU,
     onlyCUDA,
-    onlyNativeDeviceTypes,
     skipMPS,
     TEST_WITH_ROCM,
 )
@@ -52,17 +51,17 @@ FP16_REDUCED_PRECISION = {"atol": 1e-5, "rtol": 1e-4}
 
 
 def rosenbrock(tensor):
-    assert tensor.size() == torch.Size([2]), (
-        f"Requires tensor with 2 scalars but got {tensor.size()}"
-    )
+    assert tensor.size() == torch.Size(
+        [2]
+    ), f"Requires tensor with 2 scalars but got {tensor.size()}"
     x, y = tensor
     return (1 - x) ** 2 + 100 * (y - x**2) ** 2
 
 
 def drosenbrock(tensor):
-    assert tensor.size() == torch.Size([2]), (
-        f"Requires tensor with 2 scalars but got {tensor.size()}"
-    )
+    assert tensor.size() == torch.Size(
+        [2]
+    ), f"Requires tensor with 2 scalars but got {tensor.size()}"
     x, y = tensor
     return torch.stack((-400 * x * (y - x**2) - 2 * (1 - x), 200 * (y - x**2)))
 
@@ -1099,7 +1098,6 @@ class TestOptimRenewed(TestCase):
             p.grad = torch.rand_like(p)
         optimizer.step()
 
-    @onlyNativeDeviceTypes
     @largeTensorTest("64GB")
     @optims(
         [optim for optim in optim_db if "fused" in optim.supported_impls],

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1058,7 +1058,6 @@ class TestReductions(TestCase):
 
 
     @expectedFailureMeta  # mode only supports CPU and CUDA device type
-
     def test_mode_wrong_dtype(self, device):
         def test_for_dtypes(x_ty, v_ty, i_ty, message):
             x = torch.ones(10, device=device, dtype=x_ty)
@@ -2617,7 +2616,6 @@ class TestReductions(TestCase):
         self.assertEqual(a[:, ::2, :].nanmedian(-1)[0], torch.tensor([[0, 4], [6, 10]], device=device))
 
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/pull/138657 discovers a latent bug")
-
     @dtypes(torch.float, torch.double)
     def test_quantile(self, device, dtype):
         # Generate some random test cases

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -24,7 +24,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS)
 from torch.testing._internal.common_device_type import (
     OpDTypes, expectedFailureMeta, instantiate_device_type_tests, onlyCPU, dtypes, dtypesIfCUDA, dtypesIfCPU,
-    onlyNativeDeviceTypes, onlyCUDA, largeTensorTest, ops, precisionOverride)
+    onlyCUDA, largeTensorTest, ops, precisionOverride)
 from torch.testing._internal.common_methods_invocations import (
     ReductionOpInfo, ReductionPythonRefInfo, reduction_ops, reference_masked_ops)
 
@@ -1058,7 +1058,7 @@ class TestReductions(TestCase):
 
 
     @expectedFailureMeta  # mode only supports CPU and CUDA device type
-    @onlyNativeDeviceTypes
+
     def test_mode_wrong_dtype(self, device):
         def test_for_dtypes(x_ty, v_ty, i_ty, message):
             x = torch.ones(10, device=device, dtype=x_ty)
@@ -1233,7 +1233,7 @@ class TestReductions(TestCase):
     def test_amax(self, device, dtype):
         self._test_minmax_helper(torch.amax, np.amax, device, dtype)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float, torch.double, torch.bfloat16, torch.half)
     @dtypesIfCUDA(torch.half, torch.float, torch.bfloat16)
     def test_aminmax(self, device, dtype):
@@ -1247,7 +1247,7 @@ class TestReductions(TestCase):
         self._test_minmax_helper(_amin_wrapper, np.amin, device, dtype)
         self._test_minmax_helper(_amax_wrapper, np.amax, device, dtype)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(*complex_types())
     def test_invalid_0dim_aminmax(self, device, dtype):
         with self.assertRaisesRegex(RuntimeError, 'not implemented'):
@@ -1774,14 +1774,14 @@ class TestReductions(TestCase):
                                                  atol=atol, rtol=rtol, exact_dtype=exact_dtype,
                                                  with_keepdim=with_keepdim, with_extremal=with_extremal)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(*set(all_types_and(torch.half)) - {torch.uint8})
     def test_sum_vs_numpy(self, device, dtype):
         self._test_sum_reduction_vs_numpy(torch.sum, np.sum, device, dtype)
         self._test_sum_reduction_vs_numpy(torch.sum, np.sum, device, dtype, with_extremal=True)
         self._test_sum_reduction_vs_numpy(torch.sum, np.sum, device, dtype, with_keepdim=True)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(*set(all_types_and(torch.half)) - {torch.uint8})
     def test_nansum_vs_numpy(self, device, dtype):
         self._test_sum_reduction_vs_numpy(torch.nansum, np.nansum, device, dtype)
@@ -2006,7 +2006,7 @@ class TestReductions(TestCase):
                 _test_all_any_with_dim_keepdim(x, dim, keepdim=False)
 
     # TODO: part of this test covers torch.norm, with should be covered by test_linalg
-    @onlyNativeDeviceTypes
+
     def test_repeated_dim(self, device):
         ops = [torch.mean, torch.sum, torch.nansum, torch.std, torch.logsumexp, torch.std, torch.var,
                torch.norm]
@@ -2091,7 +2091,7 @@ class TestReductions(TestCase):
                 torch.sum(x, dim=[0], dtype=torch.float32, out=y)
 
     # Assert for illegal dtype would not be raised on XLA
-    @onlyNativeDeviceTypes
+
     def test_minmax_illegal_dtype(self, device):
         x = torch.randn(5, 5, dtype=torch.float32, device=device)
         valid_values = torch.empty(5, dtype=torch.float32, device=device)
@@ -2617,7 +2617,7 @@ class TestReductions(TestCase):
         self.assertEqual(a[:, ::2, :].nanmedian(-1)[0], torch.tensor([[0, 4], [6, 10]], device=device))
 
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/pull/138657 discovers a latent bug")
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float, torch.double)
     def test_quantile(self, device, dtype):
         # Generate some random test cases

--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -18,7 +18,6 @@ from torch.testing._internal.common_device_type import (
     largeTensorTest,
     onlyCPU,
     onlyCUDA,
-    onlyNativeDeviceTypes,
 )
 from torch.testing._internal.common_dtype import (
     all_types,
@@ -268,7 +267,6 @@ class TestShapeOps(TestCase):
         self.assertEqual(expected.shape, result.shape)
         self.assertEqual(expected, result)
 
-    @onlyNativeDeviceTypes
     @dtypes(*all_types())
     @dtypesIfCUDA(*all_types_and(torch.half))
     def test_trace(self, device, dtype):
@@ -773,7 +771,6 @@ class TestShapeOps(TestCase):
         self.assertEqual(traced_nontuple, expected_nontuple)
         self.assertEqual(traced_out, expected_nontuple)
 
-    @onlyNativeDeviceTypes
     def test_nonzero_discontiguous(self, device):
         shape = (4, 4)
         tensor = torch.randint(2, shape, device=device)

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -16,7 +16,6 @@ from torch.testing._internal.common_device_type import (
     largeTensorTest,
     onlyCPU,
     onlyCUDA,
-    onlyNativeDeviceTypes,
 )
 from torch.testing._internal.common_dtype import (
     all_types,
@@ -887,7 +886,6 @@ class TestSortAndSelect(TestCase):
             self.assertEqual(val, expected_val, atol=0, rtol=0)
             self.assertEqual(ind, expected_ind, atol=0, rtol=0)
 
-    @onlyNativeDeviceTypes
     @dtypesIfCUDA(*all_types_and(torch.bfloat16))
     @dtypes(*all_types_and(torch.bfloat16, torch.half))
     def test_topk_zero(self, device, dtype):
@@ -1142,7 +1140,7 @@ class TestSortAndSelect(TestCase):
             self.assertEqual(res1ind[:, :], res2ind[:, :, k - 1], atol=0, rtol=0)
 
     @dtypes(torch.float)
-    @onlyNativeDeviceTypes  # Fails on XLA
+    # Fails on XLA
     def test_kthvalue_scalar(self, device, dtype):
         # Test scalar input (test case from https://github.com/pytorch/pytorch/issues/30818)
         # Tests that passing a scalar tensor or 1D tensor with 1 element work either way

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -14,7 +14,7 @@ from torch.testing._internal.common_utils import \
     (TestCase, run_tests, TEST_NUMPY, TEST_LIBROSA, TEST_MKL, first_sample, TEST_WITH_ROCM,
      make_tensor, skipIfTorchDynamo)
 from torch.testing._internal.common_device_type import \
-    (instantiate_device_type_tests, ops, dtypes, onlyNativeDeviceTypes,
+    (instantiate_device_type_tests, ops, dtypes,
      skipCPUIfNoFFT, deviceCountAtLeast, onlyCUDA, OpDTypes, skipIf, toleranceOverride, tol)
 from torch.testing._internal.common_methods_invocations import (
     spectral_funcs, SpectralFuncType)
@@ -129,7 +129,7 @@ def skip_helper_for_fft(device, dtype):
 class TestFFT(TestCase):
     exact_dtype = True
 
-    @onlyNativeDeviceTypes
+
     @ops([op for op in spectral_funcs if op.ndimensional == SpectralFuncType.OneD],
          allowed_dtypes=(torch.float, torch.cfloat))
     def test_reference_1d(self, device, dtype, op):
@@ -171,7 +171,7 @@ class TestFFT(TestCase):
             self.assertEqual(actual, expected, exact_dtype=exact_dtype)
 
     @skipCPUIfNoFFT
-    @onlyNativeDeviceTypes
+
     @toleranceOverride({
         torch.half : tol(1e-2, 1e-2),
         torch.chalf : tol(1e-2, 1e-2),
@@ -232,7 +232,7 @@ class TestFFT(TestCase):
                     forward != torch.fft.fft or x.is_complex()))
 
     # Note: NumPy will throw a ValueError for an empty input
-    @onlyNativeDeviceTypes
+
     @ops(spectral_funcs, allowed_dtypes=(torch.half, torch.float, torch.complex32, torch.cfloat))
     def test_empty_fft(self, device, dtype, op):
         t = torch.empty(1, 0, device=device, dtype=dtype)
@@ -241,7 +241,7 @@ class TestFFT(TestCase):
         with self.assertRaisesRegex(RuntimeError, match):
             op(t)
 
-    @onlyNativeDeviceTypes
+
     def test_empty_ifft(self, device):
         t = torch.empty(2, 1, device=device, dtype=torch.complex64)
         match = r"Invalid number of data points \([-\d]*\) specified"
@@ -251,7 +251,7 @@ class TestFFT(TestCase):
             with self.assertRaisesRegex(RuntimeError, match):
                 f(t)
 
-    @onlyNativeDeviceTypes
+
     def test_fft_invalid_dtypes(self, device):
         t = torch.randn(64, device=device, dtype=torch.complex128)
 
@@ -265,7 +265,7 @@ class TestFFT(TestCase):
             torch.fft.ihfft(t)
 
     @skipCPUIfNoFFT
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.int8, torch.half, torch.float, torch.double,
             torch.complex32, torch.complex64, torch.complex128)
     def test_fft_type_promotion(self, device, dtype):
@@ -317,7 +317,7 @@ class TestFFT(TestCase):
             C = torch.fft.rfft(t)
             self.assertEqual(C.dtype, PROMOTION_MAP_R2C[dtype])
 
-    @onlyNativeDeviceTypes
+
     @ops(spectral_funcs, dtypes=OpDTypes.unsupported,
          allowed_dtypes=[torch.half, torch.bfloat16])
     def test_fft_half_and_bfloat16_errors(self, device, dtype, op):
@@ -334,7 +334,7 @@ class TestFFT(TestCase):
         with self.assertRaisesRegex(RuntimeError, err_msg):
             op(sample.input, *sample.args, **sample.kwargs)
 
-    @onlyNativeDeviceTypes
+
     @ops(spectral_funcs, allowed_dtypes=(torch.half, torch.chalf))
     def test_fft_half_and_chalf_not_power_of_two_error(self, device, dtype, op):
         t = make_tensor(13, 13, device=device, dtype=dtype)
@@ -351,7 +351,7 @@ class TestFFT(TestCase):
             op(t, **kwargs)
 
     # nd-fft tests
-    @onlyNativeDeviceTypes
+
     @unittest.skipIf(not TEST_NUMPY, 'NumPy not found')
     @ops([op for op in spectral_funcs if op.ndimensional == SpectralFuncType.ND],
          allowed_dtypes=(torch.cfloat, torch.cdouble))
@@ -384,7 +384,7 @@ class TestFFT(TestCase):
                 self.assertEqual(actual, expected, exact_dtype=exact_dtype)
 
     @skipCPUIfNoFFT
-    @onlyNativeDeviceTypes
+
     @toleranceOverride({
         torch.half : tol(1e-2, 1e-2),
         torch.chalf : tol(1e-2, 1e-2),
@@ -439,7 +439,7 @@ class TestFFT(TestCase):
                     self.assertEqual(x, y, exact_dtype=(
                         forward != torch.fft.fftn or x.is_complex()))
 
-    @onlyNativeDeviceTypes
+
     @ops([op for op in spectral_funcs if op.ndimensional == SpectralFuncType.ND],
          allowed_dtypes=[torch.float, torch.cfloat])
     def test_fftn_invalid(self, device, dtype, op):
@@ -462,7 +462,7 @@ class TestFFT(TestCase):
             op(a, s=(10, 10, 10, 10))
 
     @skipCPUIfNoFFT
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.half, torch.float, torch.double, torch.cfloat, torch.cdouble)
     def test_fftn_noop_transform(self, device, dtype):
         skip_helper_for_fft(device, dtype)
@@ -487,7 +487,7 @@ class TestFFT(TestCase):
 
 
     @skipCPUIfNoFFT
-    @onlyNativeDeviceTypes
+
     @toleranceOverride({
         torch.half : tol(1e-2, 1e-2),
     })
@@ -526,7 +526,7 @@ class TestFFT(TestCase):
             self.assertEqual(expect, actual)
 
     @skipCPUIfNoFFT
-    @onlyNativeDeviceTypes
+
     @toleranceOverride({
         torch.half : tol(1e-2, 1e-2),
     })
@@ -571,7 +571,7 @@ class TestFFT(TestCase):
 
 
     @skipCPUIfNoFFT
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.double, torch.complex128)
     def test_fft2_numpy(self, device, dtype):
         norm_modes = REFERENCE_NORM_MODES
@@ -617,7 +617,7 @@ class TestFFT(TestCase):
                     self.assertEqual(actual, expected)
 
     @skipCPUIfNoFFT
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float, torch.complex64)
     def test_fft2_fftn_equivalence(self, device, dtype):
         norm_modes = (None, "forward", "backward", "ortho")
@@ -654,7 +654,7 @@ class TestFFT(TestCase):
                 self.assertEqual(actual, expect)
 
     @skipCPUIfNoFFT
-    @onlyNativeDeviceTypes
+
     def test_fft2_invalid(self, device):
         a = torch.rand(10, 10, 10, device=device)
         fft_funcs = (torch.fft.fft2, torch.fft.ifft2,
@@ -680,7 +680,7 @@ class TestFFT(TestCase):
     # Helper functions
 
     @skipCPUIfNoFFT
-    @onlyNativeDeviceTypes
+
     @unittest.skipIf(not TEST_NUMPY, 'NumPy not found')
     @dtypes(torch.float, torch.double)
     def test_fftfreq_numpy(self, device, dtype):
@@ -706,7 +706,7 @@ class TestFFT(TestCase):
                 self.assertEqual(actual, expected, exact_dtype=False)
 
     @skipCPUIfNoFFT
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float, torch.double)
     def test_fftfreq_out(self, device, dtype):
         for func in (torch.fft.fftfreq, torch.fft.rfftfreq):
@@ -718,7 +718,7 @@ class TestFFT(TestCase):
 
 
     @skipCPUIfNoFFT
-    @onlyNativeDeviceTypes
+
     @unittest.skipIf(not TEST_NUMPY, 'NumPy not found')
     @dtypes(torch.float, torch.double, torch.complex64, torch.complex128)
     def test_fftshift_numpy(self, device, dtype):
@@ -744,7 +744,7 @@ class TestFFT(TestCase):
                 self.assertEqual(actual, expected)
 
     @skipCPUIfNoFFT
-    @onlyNativeDeviceTypes
+
     @unittest.skipIf(not TEST_NUMPY, 'NumPy not found')
     @dtypes(torch.float, torch.double)
     def test_fftshift_frequencies(self, device, dtype):
@@ -819,7 +819,7 @@ class TestFFT(TestCase):
         _test_complex((30, 55, 50, 22), 3, lambda x: x[:, 3:53, 15:40, 1:21])
 
     @skipCPUIfNoFFT
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.double)
     def test_fft_ifft_rfft_irfft(self, device, dtype):
         self._test_fft_ifft_rfft_irfft(device, dtype)
@@ -917,7 +917,7 @@ class TestFFT(TestCase):
     # passes on ROCm w/ python 2.7, fails w/ python 3.6
     @skipIfTorchDynamo("cannot set WRITEABLE flag to True of this array")
     @skipCPUIfNoFFT
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.double)
     def test_stft(self, device, dtype):
         if not TEST_LIBROSA:
@@ -991,7 +991,7 @@ class TestFFT(TestCase):
 
     @skipIfTorchDynamo("double")
     @skipCPUIfNoFFT
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.double)
     def test_istft_against_librosa(self, device, dtype):
         if not TEST_LIBROSA:
@@ -1036,7 +1036,7 @@ class TestFFT(TestCase):
             _test(4000, 1024, 512, win_sizes=(1024,), center=center)
             _test(4000, 1024, 512, win_sizes=(1024,), center=center, length=4000)
 
-    @onlyNativeDeviceTypes
+
     @skipCPUIfNoFFT
     @dtypes(torch.double, torch.cdouble)
     def test_complex_stft_roundtrip(self, device, dtype):
@@ -1078,7 +1078,7 @@ class TestFFT(TestCase):
                                       length=x.size(-1), **common_kwargs)
             self.assertEqual(x_roundtrip, x)
 
-    @onlyNativeDeviceTypes
+
     @skipCPUIfNoFFT
     @dtypes(torch.double, torch.cdouble)
     def test_stft_roundtrip_complex_window(self, device, dtype):
@@ -1138,7 +1138,7 @@ class TestFFT(TestCase):
             actual = torch.stft(*args, window=window, center=False)
             self.assertEqual(actual, expected)
 
-    @onlyNativeDeviceTypes
+
     @skipCPUIfNoFFT
     @dtypes(torch.cdouble)
     def test_complex_stft_real_equiv(self, device, dtype):
@@ -1219,14 +1219,13 @@ class TestFFT(TestCase):
             x.stft(10, pad_mode='constant', onesided=True)
 
     # stft is currently warning that it requires return-complex while an upgrader is written
-    @onlyNativeDeviceTypes
+
     @skipCPUIfNoFFT
     def test_stft_requires_complex(self, device):
         x = torch.rand(100)
         with self.assertRaisesRegex(RuntimeError, 'stft requires the return_complex parameter'):
             y = x.stft(10, pad_mode='constant')
 
-    @onlyNativeDeviceTypes
     @skipCPUIfNoFFT
     def test_stft_align_to_window_only_requires_non_center(self, device):
         x = torch.rand(100)
@@ -1235,14 +1234,14 @@ class TestFFT(TestCase):
                 y = x.stft(10, center=True, return_complex=True, align_to_window=align_to_window)
 
     # stft and istft are currently warning if a window is not provided
-    @onlyNativeDeviceTypes
+
     @skipCPUIfNoFFT
     def test_stft_requires_window(self, device):
         x = torch.rand(100)
         with self.assertWarnsOnceRegex(UserWarning, "A window was not provided"):
             y = x.stft(10, pad_mode='constant', return_complex=True)
 
-    @onlyNativeDeviceTypes
+
     @skipCPUIfNoFFT
     def test_istft_requires_window(self, device):
         stft = torch.rand((51, 5), dtype=torch.cdouble)
@@ -1270,7 +1269,7 @@ class TestFFT(TestCase):
         _ = torch.fft.irfftn(half_spectrum_copy, s=(2, 2), dim=(-2, -1))
         self.assertEqual(half_spectrum, half_spectrum_copy)
 
-    @onlyNativeDeviceTypes
+
     @skipCPUIfNoFFT
     def test_fft_plan_repeatable(self, device):
         # Regression test for gh-58724 and gh-63152
@@ -1285,7 +1284,7 @@ class TestFFT(TestCase):
             res2 = torch.fft.rfft(a.clone())
             self.assertEqual(res1, res2)
 
-    @onlyNativeDeviceTypes
+
     @skipCPUIfNoFFT
     @dtypes(torch.double)
     def test_istft_round_trip_simple_cases(self, device, dtype):
@@ -1298,7 +1297,7 @@ class TestFFT(TestCase):
         _test(torch.ones(4, dtype=dtype, device=device), 4, 4)
         _test(torch.zeros(4, dtype=dtype, device=device), 4, 4)
 
-    @onlyNativeDeviceTypes
+
     @skipCPUIfNoFFT
     @dtypes(torch.double)
     def test_istft_round_trip_various_params(self, device, dtype):
@@ -1369,7 +1368,7 @@ class TestFFT(TestCase):
         for pattern in patterns:
             _test_istft_is_inverse_of_stft(pattern)
 
-    @onlyNativeDeviceTypes
+
     @skipCPUIfNoFFT
     @dtypes(torch.double)
     def test_istft_round_trip_with_padding(self, device, dtype):
@@ -1436,7 +1435,7 @@ class TestFFT(TestCase):
         for pattern in patterns:
             _test_istft_is_inverse_of_stft_with_padding(pattern)
 
-    @onlyNativeDeviceTypes
+
     def test_istft_throws(self, device):
         """istft should throw exception for invalid parameters"""
         stft = torch.zeros((3, 5, 2), device=device)
@@ -1453,7 +1452,7 @@ class TestFFT(TestCase):
         self.assertRaises(RuntimeError, torch.istft, torch.zeros((0, 3, 2)), 2)
 
     @skipIfTorchDynamo("Failed running call_function")
-    @onlyNativeDeviceTypes
+
     @skipCPUIfNoFFT
     @dtypes(torch.double)
     def test_istft_of_sine(self, device, dtype):
@@ -1489,7 +1488,7 @@ class TestFFT(TestCase):
         _test(amplitude=80, L=9, n=6)
         _test(amplitude=99, L=10, n=7)
 
-    @onlyNativeDeviceTypes
+
     @skipCPUIfNoFFT
     @dtypes(torch.double)
     def test_istft_linearity(self, device, dtype):
@@ -1556,7 +1555,7 @@ class TestFFT(TestCase):
         for data_size, kwargs in patterns:
             _test(data_size, kwargs)
 
-    @onlyNativeDeviceTypes
+
     @skipCPUIfNoFFT
     def test_batch_istft(self, device):
         original = torch.tensor([

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -171,7 +171,6 @@ class TestFFT(TestCase):
             self.assertEqual(actual, expected, exact_dtype=exact_dtype)
 
     @skipCPUIfNoFFT
-
     @toleranceOverride({
         torch.half : tol(1e-2, 1e-2),
         torch.chalf : tol(1e-2, 1e-2),
@@ -265,7 +264,6 @@ class TestFFT(TestCase):
             torch.fft.ihfft(t)
 
     @skipCPUIfNoFFT
-
     @dtypes(torch.int8, torch.half, torch.float, torch.double,
             torch.complex32, torch.complex64, torch.complex128)
     def test_fft_type_promotion(self, device, dtype):
@@ -384,7 +382,6 @@ class TestFFT(TestCase):
                 self.assertEqual(actual, expected, exact_dtype=exact_dtype)
 
     @skipCPUIfNoFFT
-
     @toleranceOverride({
         torch.half : tol(1e-2, 1e-2),
         torch.chalf : tol(1e-2, 1e-2),
@@ -462,7 +459,6 @@ class TestFFT(TestCase):
             op(a, s=(10, 10, 10, 10))
 
     @skipCPUIfNoFFT
-
     @dtypes(torch.half, torch.float, torch.double, torch.cfloat, torch.cdouble)
     def test_fftn_noop_transform(self, device, dtype):
         skip_helper_for_fft(device, dtype)
@@ -487,7 +483,6 @@ class TestFFT(TestCase):
 
 
     @skipCPUIfNoFFT
-
     @toleranceOverride({
         torch.half : tol(1e-2, 1e-2),
     })
@@ -526,7 +521,6 @@ class TestFFT(TestCase):
             self.assertEqual(expect, actual)
 
     @skipCPUIfNoFFT
-
     @toleranceOverride({
         torch.half : tol(1e-2, 1e-2),
     })
@@ -571,7 +565,6 @@ class TestFFT(TestCase):
 
 
     @skipCPUIfNoFFT
-
     @dtypes(torch.double, torch.complex128)
     def test_fft2_numpy(self, device, dtype):
         norm_modes = REFERENCE_NORM_MODES
@@ -617,7 +610,6 @@ class TestFFT(TestCase):
                     self.assertEqual(actual, expected)
 
     @skipCPUIfNoFFT
-
     @dtypes(torch.float, torch.complex64)
     def test_fft2_fftn_equivalence(self, device, dtype):
         norm_modes = (None, "forward", "backward", "ortho")
@@ -654,7 +646,6 @@ class TestFFT(TestCase):
                 self.assertEqual(actual, expect)
 
     @skipCPUIfNoFFT
-
     def test_fft2_invalid(self, device):
         a = torch.rand(10, 10, 10, device=device)
         fft_funcs = (torch.fft.fft2, torch.fft.ifft2,
@@ -680,7 +671,6 @@ class TestFFT(TestCase):
     # Helper functions
 
     @skipCPUIfNoFFT
-
     @unittest.skipIf(not TEST_NUMPY, 'NumPy not found')
     @dtypes(torch.float, torch.double)
     def test_fftfreq_numpy(self, device, dtype):
@@ -706,7 +696,6 @@ class TestFFT(TestCase):
                 self.assertEqual(actual, expected, exact_dtype=False)
 
     @skipCPUIfNoFFT
-
     @dtypes(torch.float, torch.double)
     def test_fftfreq_out(self, device, dtype):
         for func in (torch.fft.fftfreq, torch.fft.rfftfreq):
@@ -718,7 +707,6 @@ class TestFFT(TestCase):
 
 
     @skipCPUIfNoFFT
-
     @unittest.skipIf(not TEST_NUMPY, 'NumPy not found')
     @dtypes(torch.float, torch.double, torch.complex64, torch.complex128)
     def test_fftshift_numpy(self, device, dtype):
@@ -744,7 +732,6 @@ class TestFFT(TestCase):
                 self.assertEqual(actual, expected)
 
     @skipCPUIfNoFFT
-
     @unittest.skipIf(not TEST_NUMPY, 'NumPy not found')
     @dtypes(torch.float, torch.double)
     def test_fftshift_frequencies(self, device, dtype):
@@ -819,7 +806,6 @@ class TestFFT(TestCase):
         _test_complex((30, 55, 50, 22), 3, lambda x: x[:, 3:53, 15:40, 1:21])
 
     @skipCPUIfNoFFT
-
     @dtypes(torch.double)
     def test_fft_ifft_rfft_irfft(self, device, dtype):
         self._test_fft_ifft_rfft_irfft(device, dtype)
@@ -917,7 +903,6 @@ class TestFFT(TestCase):
     # passes on ROCm w/ python 2.7, fails w/ python 3.6
     @skipIfTorchDynamo("cannot set WRITEABLE flag to True of this array")
     @skipCPUIfNoFFT
-
     @dtypes(torch.double)
     def test_stft(self, device, dtype):
         if not TEST_LIBROSA:
@@ -991,7 +976,6 @@ class TestFFT(TestCase):
 
     @skipIfTorchDynamo("double")
     @skipCPUIfNoFFT
-
     @dtypes(torch.double)
     def test_istft_against_librosa(self, device, dtype):
         if not TEST_LIBROSA:
@@ -1452,7 +1436,6 @@ class TestFFT(TestCase):
         self.assertRaises(RuntimeError, torch.istft, torch.zeros((0, 3, 2)), 2)
 
     @skipIfTorchDynamo("Failed running call_function")
-
     @skipCPUIfNoFFT
     @dtypes(torch.double)
     def test_istft_of_sine(self, device, dtype):

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -776,7 +776,6 @@ class TestTensorCreation(TestCase):
     # Note: This test failed on XLA since its test cases are created by empty_strided which
     #       doesn't support overlapping sizes/strides in XLA impl
     @skipIfTorchDynamo("TorchDynamo fails on this test for unknown reasons")
-
     def test_like_fn_stride_proparation_vs_tensoriterator_unary_op(self, device):
         # Test like functions against tensoriterator based unary operator (exp) to
         # make sure the returned tensor from like function follows the same stride propergation
@@ -1879,7 +1878,6 @@ class TestTensorCreation(TestCase):
 
     # TODO: this test should be updated
     @suppress_warnings
-
     @deviceCountAtLeast(1)
     def test_tensor_device(self, devices):
         device_type = torch.device(devices[0]).type
@@ -2724,7 +2722,6 @@ class TestTensorCreation(TestCase):
         del t
 
     @expectedFailureMeta  # RuntimeError: The tensor has a non-zero number of elements
-
     def test_tensor_ctor_device_inference(self, device):
         torch_device = torch.device(device)
         values = torch.tensor((1, 2, 3), device=device)

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -2802,7 +2802,6 @@ class TestTensorCreation(TestCase):
         self.assertTrue(torch_method(3, requires_grad=True).requires_grad)
         self.assertFalse(torch_method(3).requires_grad)
 
-
     @precisionOverride({torch.bfloat16: 5e-2, torch.half: 1e-3})
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found")
     @dtypesIfCUDA(torch.float, torch.double, torch.bfloat16, torch.half, torch.long)

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1048,9 +1048,6 @@ class TestTensorCreation(TestCase):
     # dtype's dynamic range. This can (and should) cause undefined behavior
     # errors with UBSAN. These casts are deliberate in PyTorch, however, and
     # NumPy may have the same behavior.
-
-    @unittest.skipIf(IS_MACOS or IS_JETSON, "Test is broken on MacOS and Jetson, \
-        see https://github.com/pytorch/pytorch/issues/38752")
     @unittest.skipIf(IS_PPC, "Test is broken on PowerPC, see https://github.com/pytorch/pytorch/issues/39671")
     @dtypes(torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
     def test_float_to_int_conversion_finite(self, device, dtype):

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -37,7 +37,7 @@ from torch.testing._internal.common_utils import (
     xfailIfTorchDynamo,
 )
 from torch.testing._internal.common_device_type import (
-    expectedFailureMeta, instantiate_device_type_tests, deviceCountAtLeast, onlyNativeDeviceTypes,
+    expectedFailureMeta, instantiate_device_type_tests, deviceCountAtLeast,
     onlyCPU, largeTensorTest, precisionOverride, dtypes,
     onlyCUDA, skipCPUIf, dtypesIfCUDA, dtypesIfCPU, skipMeta)
 from torch.testing._internal.common_dtype import (
@@ -116,7 +116,7 @@ class TestTensorCreation(TestCase):
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
             torch.cat([y, y], out=x)
 
-    @onlyNativeDeviceTypes
+
     def test_vander(self, device):
         x = torch.tensor([1, 2, 3, 5], device=device)
 
@@ -128,7 +128,7 @@ class TestTensorCreation(TestCase):
         with self.assertRaisesRegex(RuntimeError, "x must be a one-dimensional tensor."):
             torch.vander(torch.stack((x, x)))
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.bool, torch.uint8, torch.int8, torch.short, torch.int, torch.long,
             torch.float, torch.double,
             torch.cfloat, torch.cdouble)
@@ -437,7 +437,7 @@ class TestTensorCreation(TestCase):
 
             self.assertEqual(torch_result, scipy_result)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.half, torch.float32, torch.float64)
     def test_torch_complex(self, device, dtype):
         real = torch.tensor([1, 2], device=device, dtype=dtype)
@@ -446,7 +446,7 @@ class TestTensorCreation(TestCase):
         complex_dtype = float_to_corresponding_complex_type_map[dtype]
         self.assertEqual(torch.tensor([1.0 + 3.0j, 2.0 + 4.0j], dtype=complex_dtype), z)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float32, torch.float64)
     def test_torch_polar(self, device, dtype):
         abs = torch.tensor([1, 2, -3, -4.5, 1, 1], device=device, dtype=dtype)
@@ -459,7 +459,7 @@ class TestTensorCreation(TestCase):
                                       dtype=complex_dtype),
                          z, atol=1e-5, rtol=1e-5)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64,
             torch.complex64, torch.complex128, torch.bool)
     def test_torch_complex_floating_dtype_error(self, device, dtype):
@@ -471,7 +471,7 @@ class TestTensorCreation(TestCase):
         with self.assertRaisesRegex(RuntimeError, error):
             op(a, b)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float32, torch.float64)
     def test_torch_complex_same_dtype_error(self, device, dtype):
 
@@ -487,7 +487,7 @@ class TestTensorCreation(TestCase):
             with self.assertRaisesRegex(RuntimeError, error):
                 op(a, b)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float32, torch.float64)
     def test_torch_complex_out_dtype_error(self, device, dtype):
 
@@ -643,7 +643,7 @@ class TestTensorCreation(TestCase):
         res2 = torch.cat((x, y), out=z)
         self.assertEqual(res1, res2)
 
-    @onlyNativeDeviceTypes
+
     def test_cat_in_channels_last(self, device):
         for dim in range(4):
             x = torch.randn((4, 15, 8, 8), device=device)
@@ -665,7 +665,7 @@ class TestTensorCreation(TestCase):
             self.assertTrue(res2.is_contiguous(memory_format=torch.channels_last))
             self.assertEqual(res1, res2)
 
-    @onlyNativeDeviceTypes
+
     def test_cat_preserve_channels_last(self, device):
         x = torch.randn((4, 3, 8, 8), device=device)
         y = torch.randn(x.shape, device=device)
@@ -776,7 +776,7 @@ class TestTensorCreation(TestCase):
     # Note: This test failed on XLA since its test cases are created by empty_strided which
     #       doesn't support overlapping sizes/strides in XLA impl
     @skipIfTorchDynamo("TorchDynamo fails on this test for unknown reasons")
-    @onlyNativeDeviceTypes
+
     def test_like_fn_stride_proparation_vs_tensoriterator_unary_op(self, device):
         # Test like functions against tensoriterator based unary operator (exp) to
         # make sure the returned tensor from like function follows the same stride propergation
@@ -845,7 +845,7 @@ class TestTensorCreation(TestCase):
                 expected_error_message = dimension_error_message if len(shape) < bound else divisibiliy_error_message
                 self.assertRaisesRegex(RuntimeError, expected_error_message, lambda: torch_fn(t, arg))
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.long, torch.float32, torch.complex64)
     def test_hsplit(self, device, dtype):
         inputs = (
@@ -866,7 +866,7 @@ class TestTensorCreation(TestCase):
         )
         self._hvd_split_helper(torch.hsplit, np.hsplit, "torch.hsplit", inputs, device, dtype, 1)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.long, torch.float32, torch.complex64)
     def test_vsplit(self, device, dtype):
         inputs = (
@@ -882,7 +882,7 @@ class TestTensorCreation(TestCase):
         )
         self._hvd_split_helper(torch.vsplit, np.vsplit, "torch.vsplit", inputs, device, dtype, 0)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.long, torch.float32, torch.complex64)
     def test_dsplit(self, device, dtype):
         inputs = (
@@ -952,7 +952,7 @@ class TestTensorCreation(TestCase):
                         np_input = [input.cpu().numpy() for input in torch_input]
                         np_fn(np_input)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(*all_types_and_complex_and(torch.half))
     def test_hstack_column_stack(self, device, dtype):
         ops = ((torch.hstack, np.hstack), (torch.column_stack, np.column_stack))
@@ -971,7 +971,7 @@ class TestTensorCreation(TestCase):
         self.assertEqual(np_result,
                          torch_result)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(*all_types_and_complex_and(torch.half))
     def test_vstack_row_stack(self, device, dtype):
         ops = ((torch.vstack, np.vstack), (torch.row_stack, np.vstack))
@@ -988,7 +988,7 @@ class TestTensorCreation(TestCase):
                 expected = np_op(np_input)
                 self.assertEqual(actual, expected)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(*all_types_and_complex_and(torch.half))
     def test_dstack(self, device, dtype):
         self._test_special_stacks(2, 3, torch.dstack, np.dstack, device, dtype)
@@ -1048,7 +1048,9 @@ class TestTensorCreation(TestCase):
     # dtype's dynamic range. This can (and should) cause undefined behavior
     # errors with UBSAN. These casts are deliberate in PyTorch, however, and
     # NumPy may have the same behavior.
-    @onlyNativeDeviceTypes
+
+    @unittest.skipIf(IS_MACOS or IS_JETSON, "Test is broken on MacOS and Jetson, \
+        see https://github.com/pytorch/pytorch/issues/38752")
     @unittest.skipIf(IS_PPC, "Test is broken on PowerPC, see https://github.com/pytorch/pytorch/issues/39671")
     @dtypes(torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
     def test_float_to_int_conversion_finite(self, device, dtype):
@@ -1098,7 +1100,7 @@ class TestTensorCreation(TestCase):
                 refs = (torch.iinfo(dtype).min, ) * 3
         self._float_to_int_conversion_helper(vals, device, dtype, refs)
 
-    @onlyNativeDeviceTypes
+
     def test_complex_type_conversions(self, device):
         dtypes = [torch.float, torch.complex64, torch.complex128]
         for from_type in dtypes:
@@ -1866,7 +1868,7 @@ class TestTensorCreation(TestCase):
         self.assertTrue((to_inc - alpha * to_inc) < t.to(torch.double).max() <= to_inc)
 
     # TODO: this test should be updated
-    @onlyNativeDeviceTypes
+
     def test_empty_full(self, device):
         torch_device = torch.device(device)
         device_type = torch_device.type
@@ -1880,7 +1882,7 @@ class TestTensorCreation(TestCase):
 
     # TODO: this test should be updated
     @suppress_warnings
-    @onlyNativeDeviceTypes
+
     @deviceCountAtLeast(1)
     def test_tensor_device(self, devices):
         device_type = torch.device(devices[0]).type
@@ -1931,7 +1933,7 @@ class TestTensorCreation(TestCase):
                                  str(torch.tensor(np.random.randn(2, 3), device='cuda:1').device))
 
     # TODO: this test should be updated
-    @onlyNativeDeviceTypes
+
     def test_as_strided_neg(self, device):
         error = r'as_strided: Negative strides are not supported at the ' \
                 r'moment, got strides: \[-?[0-9]+(, -?[0-9]+)*\]'
@@ -2600,7 +2602,7 @@ class TestTensorCreation(TestCase):
             y = torch.empty(tuple(size_ones_instead_of_zeros), device=device)
             self.assertEqual(x.stride(), y.stride())
 
-    @onlyNativeDeviceTypes
+
     def test_empty_overflow(self, device):
         with self.assertRaisesRegex(RuntimeError, 'Storage size calculation overflowed'):
             torch.empty([2, 4, 2**29, 2**29], dtype=torch.float64)
@@ -2725,7 +2727,7 @@ class TestTensorCreation(TestCase):
         del t
 
     @expectedFailureMeta  # RuntimeError: The tensor has a non-zero number of elements
-    @onlyNativeDeviceTypes
+
     def test_tensor_ctor_device_inference(self, device):
         torch_device = torch.device(device)
         values = torch.tensor((1, 2, 3), device=device)
@@ -2761,7 +2763,6 @@ class TestTensorCreation(TestCase):
                 self.assertEqual(sparse_with_dtype.device, torch.device('cpu'))
 
     @onlyCUDA
-    @onlyNativeDeviceTypes
     def test_new_tensor_device(self, device):
         torch_device = torch.device(device)
         cpu_device = torch.device('cpu')
@@ -2807,7 +2808,7 @@ class TestTensorCreation(TestCase):
         self.assertTrue(torch_method(3, requires_grad=True).requires_grad)
         self.assertFalse(torch_method(3).requires_grad)
 
-    @onlyNativeDeviceTypes
+
     @precisionOverride({torch.bfloat16: 5e-2, torch.half: 1e-3})
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found")
     @dtypesIfCUDA(torch.float, torch.double, torch.bfloat16, torch.half, torch.long)
@@ -2817,7 +2818,7 @@ class TestTensorCreation(TestCase):
     def test_signal_window_functions(self, device, dtype, window):
         self._test_signal_window_functions(window, dtype, device)
 
-    @onlyNativeDeviceTypes
+
     @precisionOverride({torch.bfloat16: 5e-2, torch.half: 1e-3})
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found")
     @skipIfTorchDynamo("TorchDynamo fails with unknown reason")
@@ -2845,7 +2846,7 @@ class TestTensorCreation(TestCase):
         self.assertFalse(torch_method(3).requires_grad)
 
     # torch.signal.windows functions (except any with extra parameters)
-    @onlyNativeDeviceTypes
+
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found")
     @skipIfTorchDynamo("Not a TorchDynamo suitable test")
     @dtypes(torch.float, torch.double)
@@ -2854,7 +2855,7 @@ class TestTensorCreation(TestCase):
         self._test_signal_windows_functions(window, dtype, device)
 
     # torch.signal.windows.kaiser
-    @onlyNativeDeviceTypes
+
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found")
     @skipIfTorchDynamo("TorchDynamo fails with unknown reason")
     @dtypes(torch.float, torch.double)
@@ -3169,7 +3170,7 @@ class TestTensorCreation(TestCase):
         y = torch.logspace(0, 3, 4, base=2, device=device, dtype=dtype, out=x.narrow(1, 1, 2))
         self.assertEqual(x, torch.tensor(((0, 1, 2), (0, 4, 8)), device=device, dtype=dtype), atol=0, rtol=0)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.half, torch.float, torch.double)
     def test_full_inference(self, device, dtype):
         size = (2, 2)
@@ -3742,7 +3743,7 @@ class TestLikeTensorCreation(TestCase):
 
     # Full-like precedence is the explicit dtype then the dtype of the "like"
     # tensor.
-    @onlyNativeDeviceTypes
+
     def test_full_like_inference(self, device):
         size = (2, 2)
         like = torch.empty((5,), device=device, dtype=torch.long)

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -25,7 +25,7 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.common_device_type import \
     (PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY, PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY, dtypes,
-     get_device_type_test_bases, instantiate_device_type_tests, onlyCPU, onlyCUDA, onlyNativeDeviceTypes,
+     get_device_type_test_bases, instantiate_device_type_tests, onlyCPU, onlyCUDA,
      deviceCountAtLeast, ops, expectedFailureMeta, OpDTypes)
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal import opinfo
@@ -130,7 +130,7 @@ class TestTesting(TestCase):
 
         self._isclose_helper(tests, device, dtype, False, atol=1.5, rtol=.5)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float16, torch.float32, torch.float64)
     def test_isclose_float(self, device, dtype):
         tests = (
@@ -400,7 +400,7 @@ if __name__ == '__main__':
         self.assertIn('errors=2', stderr)
 
     @expectedFailureMeta  # This is only supported for CPU and CUDA
-    @onlyNativeDeviceTypes
+
     def test_get_supported_dtypes(self, device):
         # Test the `get_supported_dtypes` helper function.
         # We acquire the dtypes for few Ops dynamically and verify them against

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -400,7 +400,6 @@ if __name__ == '__main__':
         self.assertIn('errors=2', stderr)
 
     @expectedFailureMeta  # This is only supported for CPU and CUDA
-
     def test_get_supported_dtypes(self, device):
         # Test the `get_supported_dtypes` helper function.
         # We acquire the dtypes for few Ops dynamically and verify them against

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -249,7 +249,6 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(s, storage_type(l))
 
     @xfailIfTorchDynamo
-
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
     def test_tensor_storage_type(self, device, dtype):
         a = make_tensor((10,), dtype=dtype, device=device, low=-9, high=9)
@@ -1464,7 +1463,6 @@ else:
             torch.device(device).type == 'cuda')
 
     @dtypes(*floating_types_and(torch.half))
-
     def test_nondeterministic_alert_MaxUnpool1d(self, device, dtype):
         if dtype == torch.half and torch.device(device).type == 'cpu':
             self.skipTest('float16 not implemented on CPU')
@@ -1478,7 +1476,6 @@ else:
             'max_unpooling2d_forward_out')
 
     @dtypes(*floating_types_and(torch.half))
-
     def test_nondeterministic_alert_MaxUnpool2d(self, device, dtype):
         if dtype == torch.half and torch.device(device).type == 'cpu':
             self.skipTest('float16 not implemented on CPU')
@@ -1492,7 +1489,6 @@ else:
             'max_unpooling2d_forward_out')
 
     @dtypes(*floating_types_and(torch.half))
-
     def test_nondeterministic_alert_MaxUnpool3d(self, device, dtype):
         if dtype == torch.half and torch.device(device).type == 'cpu':
             self.skipTest('float16 not implemented on CPU')
@@ -1791,7 +1787,6 @@ else:
         self.assertEqual(b[-1, :], d[-1, :], atol=3e-5, rtol=3e-5)
 
     @expectedFailureMeta  # expected a non-determinitic error, but it was not raised
-
     def test_nondeterministic_alert_put(self, device):
         a = torch.randn(10, device=device)
         indices = torch.tensor([0, 0], device=device)
@@ -4450,7 +4445,6 @@ else:
 
     @expectedFailureMeta  # RuntimeError not raised
     @dtypes(torch.double)
-
     def test_copy_mem_overlap(self, device, dtype):
         self.check_internal_mem_overlap(
             torch.Tensor.copy_, num_inputs=2, dtype=dtype, device=device)
@@ -4461,7 +4455,6 @@ else:
 
     # FIXME: convert to ErrorInputs
     # (but have to extend ErrorInputs to handle inplace-only errors!)
-
     def test_index_add_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
         y = torch.rand((6,), device=device)
@@ -4516,7 +4509,6 @@ else:
     # FIXME: convert to ErrorInputs
     # (but have to extend ErrorInputs to handle inplace-only errors!)
     @expectedFailureMeta  # Warning not triggered
-
     def test_index_fill_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
         ind = torch.tensor([2, 1, 0], device=device)
@@ -4528,7 +4520,6 @@ else:
 
     # FIXME: convert to ErrorInputs
     @expectedFailureMeta  # RuntimeError not raised
-
     def test_shift_mem_overlap(self, device):
         x = torch.rand(3, device=device)
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
@@ -4539,7 +4530,6 @@ else:
     # FIXME: convert to ErrorInputs
     # (but have to extend ErrorInputs to handle inplace-only errors)
     @expectedFailureMeta  # RuntimeError not raised
-
     def test_bernoulli_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
 
@@ -4554,7 +4544,6 @@ else:
     # FIXME: convert to ErrorInputs
     # (but have to extend ErrorInputs to handle inplace-only errors!)
     @expectedFailureMeta  # RuntimeError not raised
-
     def test_put_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
         y = torch.rand((6,), device=device)
@@ -4576,7 +4565,6 @@ else:
     # FIXME: convert to ErrorInputs
     # (but have to extend ErrorInputs to handle inplace-only errors!)
     @expectedFailureMeta  # UserWarning not triggered
-
     def test_index_put_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
         y = torch.rand((6,), device=device)
@@ -4598,7 +4586,6 @@ else:
     # FIXME: convert to ErrorInputs
     # (but have to extend ErrorInputs to handle inplace-only errors!)
     @expectedFailureMeta  # UserWarning not triggered
-
     def test_masked_fill_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
         mask = torch.tensor([True, False, True, True, False, False], device=device)
@@ -4615,7 +4602,6 @@ else:
     # FIXME: convert to ErrorInputs
     # (but have to extend ErrorInputs to handle inplace-only errors!)
     @expectedFailureMeta  # RuntimeError not raised
-
     def test_masked_scatter_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
         src = torch.rand((3,), device=device)
@@ -5831,7 +5817,6 @@ else:
         self.assertEqual(scale, 2.0)
 
     @skipIfTorchDynamo("Failed running call_function for sparse_coo_tensor. See https://github.com/pytorch/pytorch/issues/118856")
-
     @dtypes(torch.float)
     def test_grad_scaling_unscale_sparse(self, device, dtype):
         device = torch.device(device)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -51,7 +51,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCUDA, onlyCPU,
     dtypes, dtypesIfCUDA, dtypesIfCPU, deviceCountAtLeast,
-    skipMeta, PYTORCH_CUDA_MEMCHECK, largeTensorTest, onlyNativeDeviceTypes, skipCUDAIfNotRocm,
+    skipMeta, PYTORCH_CUDA_MEMCHECK, largeTensorTest, skipCUDAIfNotRocm,
     get_all_device_types, skipXLA)
 import torch.backends.quantized
 import torch.testing._internal.data
@@ -156,7 +156,7 @@ class TestTorchDeviceType(TestCase):
         self.assertIsInstance(torch.inf, float)
         self.assertEqual(torch.inf, math.inf)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.int8, torch.uint8, torch.int16, torch.int32, torch.int64,
             torch.bool, torch.float32, torch.complex64, torch.float64,
             torch.complex128, torch.uint16, torch.uint32, torch.uint64)
@@ -214,7 +214,7 @@ class TestTorchDeviceType(TestCase):
                 bytes_to_scalar(v_s_byte[start:end], dtype, device),
                 v[dim0][dim1])
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.int8, torch.uint8, torch.int16, torch.int32, torch.int64,
             torch.bool, torch.float32, torch.complex64, torch.float64,
             torch.complex128, torch.quint8, torch.qint8, torch.qint32,
@@ -249,7 +249,7 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(s, storage_type(l))
 
     @xfailIfTorchDynamo
-    @onlyNativeDeviceTypes
+
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
     def test_tensor_storage_type(self, device, dtype):
         a = make_tensor((10,), dtype=dtype, device=device, low=-9, high=9)
@@ -259,7 +259,7 @@ class TestTorchDeviceType(TestCase):
 
         self.assertEqual(a.storage_type(), expected_storage_type)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16, torch.uint16, torch.uint32, torch.uint64))
     def test_tensor_from_storage(self, device, dtype):
         a = make_tensor((4, 5, 3), dtype=dtype, device=device, low=-9, high=9)
@@ -276,7 +276,7 @@ class TestTorchDeviceType(TestCase):
                 error_storage = a.to(error_dtype).storage()
                 torch.tensor(error_storage, device=device, dtype=dtype)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
     def test_set_storage(self, device, dtype):
         a = make_tensor((4, 5, 3), dtype=dtype, device=device, low=-9, high=9)
@@ -314,7 +314,7 @@ class TestTorchDeviceType(TestCase):
             self.assertEqual(s.dtype, s_check.dtype)
             self._check_storage_meta(s.untyped(), s_check.untyped())
 
-    @onlyNativeDeviceTypes
+
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
     def test_typed_storage_meta(self, device, dtype):
         args_list = [
@@ -328,7 +328,7 @@ class TestTorchDeviceType(TestCase):
             s = torch.TypedStorage(*args, dtype=dtype, device='meta')
             self._check_storage_meta(s, s_check)
 
-    @onlyNativeDeviceTypes
+
     def test_untyped_storage_meta(self, device):
         args_list = [
             [],
@@ -341,7 +341,7 @@ class TestTorchDeviceType(TestCase):
             s = torch.UntypedStorage(*args, device='meta')
             self._check_storage_meta(s, s_check)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
     def test_storage_meta_from_tensor(self, device, dtype):
         t_check = make_tensor((4, 5, 3), dtype=dtype, device=device, low=-9, high=9)
@@ -922,7 +922,7 @@ class TestTorchDeviceType(TestCase):
             torch.from_numpy(a)
             torch.from_numpy(a)
 
-    @onlyNativeDeviceTypes
+
     def test_complex_half_experimental_warning(self, device):
         msg = 'ComplexHalf support is experimental'
         with self.assertWarnsOnceRegex(UserWarning, msg):
@@ -1464,7 +1464,7 @@ else:
             torch.device(device).type == 'cuda')
 
     @dtypes(*floating_types_and(torch.half))
-    @onlyNativeDeviceTypes
+
     def test_nondeterministic_alert_MaxUnpool1d(self, device, dtype):
         if dtype == torch.half and torch.device(device).type == 'cpu':
             self.skipTest('float16 not implemented on CPU')
@@ -1478,7 +1478,7 @@ else:
             'max_unpooling2d_forward_out')
 
     @dtypes(*floating_types_and(torch.half))
-    @onlyNativeDeviceTypes
+
     def test_nondeterministic_alert_MaxUnpool2d(self, device, dtype):
         if dtype == torch.half and torch.device(device).type == 'cpu':
             self.skipTest('float16 not implemented on CPU')
@@ -1492,7 +1492,7 @@ else:
             'max_unpooling2d_forward_out')
 
     @dtypes(*floating_types_and(torch.half))
-    @onlyNativeDeviceTypes
+
     def test_nondeterministic_alert_MaxUnpool3d(self, device, dtype):
         if dtype == torch.half and torch.device(device).type == 'cpu':
             self.skipTest('float16 not implemented on CPU')
@@ -1791,7 +1791,7 @@ else:
         self.assertEqual(b[-1, :], d[-1, :], atol=3e-5, rtol=3e-5)
 
     @expectedFailureMeta  # expected a non-determinitic error, but it was not raised
-    @onlyNativeDeviceTypes
+
     def test_nondeterministic_alert_put(self, device):
         a = torch.randn(10, device=device)
         indices = torch.tensor([0, 0], device=device)
@@ -2020,7 +2020,7 @@ else:
                 self.assertEqual(grad, expected, atol=0, rtol=0)
 
     # FIXME: move to test_scatter_gather_ops
-    @onlyNativeDeviceTypes
+
     def test_gather_backward_deterministic_path(self, device) -> None:
         self._test_gather_backward_one_dim(device, True)
 
@@ -2030,7 +2030,7 @@ else:
         self._test_gather_backward_one_dim(device, False)
 
     # FIXME: move to test_scatter_gather_ops
-    @onlyNativeDeviceTypes
+
     def test_scatter_add_one_dim_deterministic(self, device) -> None:
         with DeterministicGuard(True):
             m = random.randint(20, 30)
@@ -2055,7 +2055,7 @@ else:
             self.assertEqual(res, expected, atol=1e-4, rtol=1e-5)
 
     # FIXME: move to test_scatter_gather_ops
-    @onlyNativeDeviceTypes
+
     def test_scatter_zero_size_index(self, device) -> None:
         null_index = torch.zeros((0, 4), dtype=torch.int64)
         null_arr = torch.zeros((0, 4))
@@ -2265,7 +2265,7 @@ else:
         if dtype != torch.int:
             yield torch.tensor([0, -2, nan, 10.2, inf], dtype=dtype, device=device)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.int, torch.float, torch.cfloat)
     def test_corrcoef(self, device, dtype):
         for x in self._generate_correlation_tensors(device, dtype):
@@ -2882,7 +2882,7 @@ else:
                 self.assertEqual(actual, expected.to(t.dtype))
 
     # All tensors appear contiguous on XLA
-    @onlyNativeDeviceTypes
+
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool))
     def test_diff_noncontig(self, device, dtype):
         shapes = (
@@ -2957,7 +2957,7 @@ else:
 
         return actual, expected
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.long, torch.float32, torch.complex64)
     def test_gradient_all(self, device, dtype):
         def create_scalar(shape):
@@ -3010,7 +3010,7 @@ else:
             actual, expected = self._inf_nan_preprocess(list(actual), self._wrap_to_list(expected))
             self.assertEqual(actual, expected, equal_nan=True, atol=1e-4, rtol=0, exact_dtype=False)
 
-    @onlyNativeDeviceTypes
+
     @slowTestIf(TEST_WITH_TORCHINDUCTOR)
     @dtypes(torch.long, torch.float32, torch.complex64)
     def test_gradient_extreme_cases(self, device, dtype):
@@ -3033,7 +3033,7 @@ else:
         expected = [np.gradient(t_np, coordinates_np, axis=0, edge_order=2)]
         self.assertEqual(actual, expected, exact_dtype=False)
 
-    @onlyNativeDeviceTypes
+
     def test_gradient_type_promotion(self, device):
         inputs = (
             make_tensor((4, 4), device=device, dtype=torch.float32),
@@ -3078,7 +3078,7 @@ else:
                 actual, expected = self._inf_nan_preprocess(list(actual), list(expected))
                 self.assertEqual(actual, expected, equal_nan=True, exact_dtype=False)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.long, torch.float32, torch.complex64)
     def test_gradient_spacing_list_length_error(self, device, dtype):
         t = make_tensor((2, 2), device=device, dtype=dtype)
@@ -3224,7 +3224,7 @@ else:
             self.assertEqual(out2, out1, atol=0, rtol=0, exact_dtype=False)
 
     # FIXME: move to data movement test suite
-    @onlyNativeDeviceTypes
+
     def test_copy_math_view(self, device):
         for dst_dtype, src_dtype in [
                 (torch.float32, torch.float32),
@@ -3265,7 +3265,7 @@ else:
             self.assertEqual(dst, src.neg().conj_physical(), exact_dtype=False)
 
     # FIXME: move to data movement test suite
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.int64, torch.float32, torch.complex64)
     def test_copy_transpose_math_view(self, device, dtype):
         src = make_tensor((100, 100), dtype=dtype, device=device).transpose(0, 1)
@@ -3468,7 +3468,7 @@ else:
     # FIXME: move to test indexing
     # onlyNativeDeviceTypes due to an XLA error:
     # https://github.com/pytorch/pytorch/issues/53256
-    @onlyNativeDeviceTypes
+
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
     def test_index_copy_scalars(self, device, dtype):
         # Create the 8 possible combinations of scalar sizes for target / index / source
@@ -3521,7 +3521,7 @@ else:
         return (x, index, src)
 
     # FIXME: move to test indexing
-    @onlyNativeDeviceTypes
+
     def test_index_copy_deterministic(self, device: torch.device) -> None:
         for dim in range(3):
             x, index, src = self._prepare_data_for_index_copy_and_add_deterministic(dim, device)
@@ -3541,7 +3541,7 @@ else:
             self.assertEqual(x0, y0, atol=0, rtol=0)
 
     # FIXME: move to test indexing
-    @onlyNativeDeviceTypes
+
     def test_index_add_deterministic(self, device: torch.device) -> None:
         for dim in range(3):
             x, index, src = self._prepare_data_for_index_copy_and_add_deterministic(dim, device)
@@ -3559,7 +3559,7 @@ else:
                     self.assertEqual(y_nd, y0, atol=1e-3, rtol=1e-5)
 
     # FIXME: find a test suite for the put operator
-    @onlyNativeDeviceTypes
+
     def test_index_put_non_accumulate_deterministic(self, device) -> None:
         with DeterministicGuard(True):
             for i in range(3):
@@ -3597,7 +3597,7 @@ else:
 
     # FIXME: move to test indexing
     # The test fails for zero-dimensional tensors on XLA
-    @onlyNativeDeviceTypes
+
     @dtypes(*all_types_complex_float8_and(torch.half, torch.bool, torch.bfloat16))
     def test_index_select(self, device, dtype):
         num_src, num_out = 3, 5
@@ -3937,7 +3937,7 @@ else:
                                             [True, False, True, False, True]], device=device))
 
     # FIXME: find a test suite for the masked scatter operator
-    @onlyNativeDeviceTypes
+
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16))
     def test_masked_scatter(self, device, dtype):
         dt = dtype
@@ -4352,7 +4352,7 @@ else:
         self.assertTrue(torch.allclose(expected_cpu, actual_cpu))  # ~20GB in allclose
 
     # FIXME: move to elementwise ternary test suite
-    @onlyNativeDeviceTypes
+
     @dtypesIfCUDA(*set(get_all_math_dtypes('cuda')))
     @dtypes(*set(get_all_math_dtypes('cpu')))
     def test_addcdiv(self, device, dtype):
@@ -4450,7 +4450,7 @@ else:
 
     @expectedFailureMeta  # RuntimeError not raised
     @dtypes(torch.double)
-    @onlyNativeDeviceTypes
+
     def test_copy_mem_overlap(self, device, dtype):
         self.check_internal_mem_overlap(
             torch.Tensor.copy_, num_inputs=2, dtype=dtype, device=device)
@@ -4461,7 +4461,7 @@ else:
 
     # FIXME: convert to ErrorInputs
     # (but have to extend ErrorInputs to handle inplace-only errors!)
-    @onlyNativeDeviceTypes
+
     def test_index_add_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
         y = torch.rand((6,), device=device)
@@ -4498,7 +4498,7 @@ else:
 
     # FIXME: convert to ErrorInputs
     # (but have to extend ErrorInputs to handle inplace-only errors!)
-    @onlyNativeDeviceTypes
+
     def test_index_copy_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
         y = torch.rand((6,), device=device)
@@ -4516,7 +4516,7 @@ else:
     # FIXME: convert to ErrorInputs
     # (but have to extend ErrorInputs to handle inplace-only errors!)
     @expectedFailureMeta  # Warning not triggered
-    @onlyNativeDeviceTypes
+
     def test_index_fill_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
         ind = torch.tensor([2, 1, 0], device=device)
@@ -4528,7 +4528,7 @@ else:
 
     # FIXME: convert to ErrorInputs
     @expectedFailureMeta  # RuntimeError not raised
-    @onlyNativeDeviceTypes
+
     def test_shift_mem_overlap(self, device):
         x = torch.rand(3, device=device)
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
@@ -4539,7 +4539,7 @@ else:
     # FIXME: convert to ErrorInputs
     # (but have to extend ErrorInputs to handle inplace-only errors)
     @expectedFailureMeta  # RuntimeError not raised
-    @onlyNativeDeviceTypes
+
     def test_bernoulli_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
 
@@ -4554,7 +4554,7 @@ else:
     # FIXME: convert to ErrorInputs
     # (but have to extend ErrorInputs to handle inplace-only errors!)
     @expectedFailureMeta  # RuntimeError not raised
-    @onlyNativeDeviceTypes
+
     def test_put_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
         y = torch.rand((6,), device=device)
@@ -4576,7 +4576,7 @@ else:
     # FIXME: convert to ErrorInputs
     # (but have to extend ErrorInputs to handle inplace-only errors!)
     @expectedFailureMeta  # UserWarning not triggered
-    @onlyNativeDeviceTypes
+
     def test_index_put_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
         y = torch.rand((6,), device=device)
@@ -4598,7 +4598,7 @@ else:
     # FIXME: convert to ErrorInputs
     # (but have to extend ErrorInputs to handle inplace-only errors!)
     @expectedFailureMeta  # UserWarning not triggered
-    @onlyNativeDeviceTypes
+
     def test_masked_fill_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
         mask = torch.tensor([True, False, True, True, False, False], device=device)
@@ -4615,7 +4615,7 @@ else:
     # FIXME: convert to ErrorInputs
     # (but have to extend ErrorInputs to handle inplace-only errors!)
     @expectedFailureMeta  # RuntimeError not raised
-    @onlyNativeDeviceTypes
+
     def test_masked_scatter_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
         src = torch.rand((3,), device=device)
@@ -4626,7 +4626,7 @@ else:
 
     # FIXME: convert to ErrorInputs
     # (but have to extend ErrorInputs to handle inplace-only errors!)
-    @onlyNativeDeviceTypes
+
     def test_scatter_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
         src = torch.rand((3,), device=device)
@@ -5654,7 +5654,7 @@ else:
                 'cpu', get_generator(mf, shape), transformation_cuda_fn, mf, default_is_preserve=True)
 
     # FIXME: move to test_serialization
-    @onlyNativeDeviceTypes
+
     def test_pickle_gradscaler(self, device):
         # This test should pass in 3 cases for cuda:
         #  1. cuda is not available.
@@ -5710,7 +5710,7 @@ else:
         self._test_multinomial_empty(device, False, 1)
         self._test_multinomial_empty(device, False, 2)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float, torch.double)
     def test_grad_scaling_unscale(self, device, dtype):
         device = torch.device(device)
@@ -5806,7 +5806,7 @@ else:
                 # inf was injected, ensures inf was found.
                 self.assertTrue(sum(v.item() for v in found_inf_per_device.values()) == 1)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float)
     def test_grad_scaling_update_scale(self, device, dtype):
         growth = 2.0
@@ -5831,7 +5831,7 @@ else:
         self.assertEqual(scale, 2.0)
 
     @skipIfTorchDynamo("Failed running call_function for sparse_coo_tensor. See https://github.com/pytorch/pytorch/issues/118856")
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float)
     def test_grad_scaling_unscale_sparse(self, device, dtype):
         device = torch.device(device)
@@ -5889,7 +5889,7 @@ else:
         found_inf = scaler._unscale_grads_(opt, inv_scale, found_inf, True)[cur]
         self.assertEqual(found_inf, 1.0)
 
-    @onlyNativeDeviceTypes
+
     def test_grad_scaling_state_dict(self, device):
         device = torch.device(device)
         GradScaler = partial(torch.GradScaler, device=device.type)
@@ -5953,7 +5953,7 @@ else:
 
                 self.assertEqual(c, s, atol=atol, rtol=1e-05)
 
-    @onlyNativeDeviceTypes
+
     @parametrize("foreach, fused", [(None, None), (True, None), (None, True)])
     @optims(
         [optim for optim in optim_db if optim.optim_cls in [torch.optim.AdamW, torch.optim.Adam, torch.optim.SGD]],
@@ -6008,7 +6008,7 @@ else:
     # Make sure that the parameters become nonsense when scaled gradients are finite
     # but they get invalidated before `optimizer.step`, after `GradScaler.unscale_`
 
-    @onlyNativeDeviceTypes
+
     @optims(
         [optim for optim in optim_db if optim.optim_cls in [torch.optim.AdamW, torch.optim.Adam, torch.optim.SGD]],
         dtypes=[torch.float32]
@@ -6041,7 +6041,7 @@ else:
 
             self.assertTrue(all((p.isnan().any() or p.isinf().any()) for p in model.parameters()))
 
-    @onlyNativeDeviceTypes
+
     def test_grad_scale_will_not_overflow(self, device):
         device = torch.device(device)
         model = torch.nn.Linear(5, 1).to(device)
@@ -6056,7 +6056,7 @@ else:
         scaler.update()
         assert scaler._scale != float("inf") and scaler._scale != float("nan")
 
-    @onlyNativeDeviceTypes
+
     def test_grad_scaling_clipping(self, device):
         device = torch.device(device)
 
@@ -6081,7 +6081,7 @@ else:
 
         self._run_scaling_case(device.type, run, unskipped=3, skipped=1, atol=1e-5)
 
-    @onlyNativeDeviceTypes
+
     def test_grad_scaling_clipping_separate_unscale(self, device):
         device = torch.device(device)
 
@@ -6107,7 +6107,6 @@ else:
 
         self._run_scaling_case(device.type, run, unskipped=3, skipped=1)
 
-    @onlyNativeDeviceTypes
     def test_grad_scaling_penalty(self, device):
         device = torch.device(device)
 
@@ -6144,7 +6143,7 @@ else:
 
         self._run_scaling_case(device.type, run, unskipped=3, skipped=1)
 
-    @onlyNativeDeviceTypes
+
     def test_grad_scaling_accumulation(self, device):
         device = torch.device(device)
 
@@ -6169,7 +6168,7 @@ else:
 
         self._run_scaling_case(device.type, run, unskipped=2, skipped=0)
 
-    @onlyNativeDeviceTypes
+
     def test_grad_scaling_multiple(self, device):
         device = torch.device(device)
         # Tests gradient scaling with 2 models and 2 optimizers that both receive gradients from 2 losses.
@@ -6222,7 +6221,7 @@ else:
                             chain(mod_scaling0.parameters(), mod_scaling1.parameters())):
                 self.assertEqual(c, s, rtol=1e-5, atol=1e-7)
 
-    @onlyNativeDeviceTypes
+
     def test_grad_scaler_pass_itself(self, device):
         device = torch.device(device)
         GradScaler = partial(torch.amp.GradScaler, device=device.type)
@@ -6262,7 +6261,7 @@ else:
         scaler.step(o2)
         scaler.update()
 
-    @onlyNativeDeviceTypes
+
     def test_grad_scaler_deprecated_warning(self, device):
         device = torch.device(device)
         GradScaler = torch.cuda.amp.GradScaler if "cuda" == device.type else torch.cpu.amp.GradScaler
@@ -6300,7 +6299,7 @@ else:
 
     # FIXME: move to elementwise ternary test suite
     # As the test fails with Runtime Error not raised on XLA
-    @onlyNativeDeviceTypes
+
     def test_where_scalar_handcrafted_values(self, device):
         # Tests ScalarxScalar, ScalarxTensor and TensorxScalar
         # variant of `where` against NumPy version with
@@ -6471,7 +6470,6 @@ else:
         with self.assertRaisesRegex(RuntimeError, "Empty tensor not supported"):
             torch.ops.aten._local_scalar_dense(input)
 
-    @onlyNativeDeviceTypes
     def test_masked_scatter_inplace_noncontiguous(self, device):
         t = torch.zeros(5, 2, dtype=torch.long, device=device)
         t_non_contig = t.transpose(0, 1)

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -9,7 +9,7 @@ import torch
 from torch.testing._internal.common_utils import (TestCase, run_tests, load_tests, make_tensor,
                                                   TEST_NUMPY, set_default_dtype, torch_to_numpy_dtype_dict,
                                                   numpy_to_torch_dtype_dict, skipIfTorchDynamo)
-from torch.testing._internal.common_device_type import (instantiate_device_type_tests, onlyNativeDeviceTypes,
+from torch.testing._internal.common_device_type import (instantiate_device_type_tests,
                                                         dtypes, onlyCPU, expectedFailureMeta, skipMeta)
 from torch.testing._internal.common_dtype import (
     all_types_and_complex_and, get_all_math_dtypes, floating_types, get_all_dtypes,
@@ -283,7 +283,7 @@ class TestTypePromotion(TestCase):
             self.assertEqual(torch.promote_types(torch.bfloat16, dtype), expected_dtype)
             self.assertEqual((bf + t).dtype, expected_dtype)
 
-    @onlyNativeDeviceTypes
+
     def test_complex_half(self, device):
         # with scalar
         chalf = torch.tensor(5.5, dtype=torch.chalf, device=device)
@@ -626,7 +626,7 @@ class TestTypePromotion(TestCase):
                     self.assertTrue(t2.dtype == dt2)
 
     # XLA tests fail for self.assertRaises for complex dtypes
-    @onlyNativeDeviceTypes
+
     def test_complex_assertraises(self, device):
         comparison_ops = [
             dict(name="lt", compare_op=operator.lt, ),
@@ -737,7 +737,7 @@ class TestTypePromotion(TestCase):
             casting_result = dividend.to(torch.get_default_dtype()) / 2
             self.assertEqual(casting_result, op(dividend, 2.))
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.float, torch.double,
             torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
     def test_div_promotion_out(self, device, dtype):
@@ -895,28 +895,28 @@ class TestTypePromotion(TestCase):
             for inplace, coalesced in itertools.product([True, False], [True, False]):
                 self._test_sparse_op(op_name, inplace, dtype1, dtype2, device, coalesced)
 
-    @onlyNativeDeviceTypes
+
     def test_sparse_add(self, device):
         self._run_all_tests_for_sparse_op('add', device,
                                           dtypes=get_all_math_dtypes(device))
 
-    @onlyNativeDeviceTypes
+
     def test_sparse_mul(self, device):
         self._run_all_tests_for_sparse_op('mul', device,
                                           dtypes=get_all_math_dtypes(device))
 
-    @onlyNativeDeviceTypes
+
     def test_sparse_div(self, device):
         self._run_all_tests_for_sparse_op('div', device,
                                           dtypes=(torch.float32, torch.float64,
                                                   torch.complex64, torch.complex128))
 
-    @onlyNativeDeviceTypes
+
     def test_sparse_sub(self, device):
         self._run_all_tests_for_sparse_op('sub', device,
                                           dtypes=get_all_math_dtypes(device))
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.bool, torch.short, torch.uint8, torch.int, torch.long)
     @float_double_default_dtype
     def test_sparse_div_promotion(self, device, dtype):
@@ -926,7 +926,7 @@ class TestTypePromotion(TestCase):
             casting_result = dividend.to(torch.get_default_dtype()) / 2
             self.assertEqual(casting_result, op(dividend_sparse, 2).to_dense())
 
-    @onlyNativeDeviceTypes
+
     @dtypes(torch.int8, torch.uint8, torch.int16, torch.int32, torch.int64)
     def test_integer_addcdiv_deprecated(self, device, dtype):
         t = torch.tensor(1, device=device, dtype=dtype)
@@ -1008,7 +1008,7 @@ class TestTypePromotion(TestCase):
                     self.fail(msg)
 
 
-    @onlyNativeDeviceTypes
+
     def test_cat_different_dtypes(self, device):
         dtypes = all_types_and_complex_and(torch.half, torch.bool)
         for x_dtype, y_dtype in itertools.product(dtypes, dtypes):
@@ -1034,7 +1034,7 @@ class TestTypePromotion(TestCase):
             res = torch.cat([x, y])
             self.assertEqual(res, expected_res, exact_dtype=True)
 
-    @onlyNativeDeviceTypes
+
     def test_cat_out_different_dtypes(self, device):
         dtypes = all_types_and_complex_and(torch.half)
         for x_dtype, y_dtype, out_dtype in itertools.product(dtypes, dtypes, dtypes):
@@ -1053,7 +1053,7 @@ class TestTypePromotion(TestCase):
                 self.assertEqual(out, expected_out, exact_dtype=True)
 
     # Verfies that unary ops require matching out types
-    @onlyNativeDeviceTypes
+
     @dtypes(*itertools.product((torch.int64,
                                 torch.float32, torch.float64,
                                 torch.complex64, torch.complex128),
@@ -1088,7 +1088,7 @@ class TestTypePromotion(TestCase):
 
     # Verifies that the out= argument doesn't affect the computation, that
     # is, out = op(...) and op(..., out=out) produce the same result.
-    @onlyNativeDeviceTypes
+
     @skipMeta
     def test_computation_ignores_out(self, device):
         t = torch.tensor(33000, dtype=torch.float16, device=device)
@@ -1109,7 +1109,7 @@ class TestTypePromotion(TestCase):
         self.assertEqual(result, a - b, exact_dtype=False)
         self.assertNotEqual(result, a.double() - b, exact_dtype=False)
 
-    @onlyNativeDeviceTypes
+
     @dtypes(*itertools.product((torch.bool, torch.int, torch.float, torch.double), repeat=3))
     def test_clamp_type_promotion(self, device, dtypes):
         dtype0, dtype1, dtype2 = dtypes
@@ -1170,7 +1170,7 @@ class TestTypePromotion(TestCase):
                     actual = torch.clamp_max_(inp, val)
                     self.assertEqual(actual, expected, exact_dtype=False)
 
-    @onlyNativeDeviceTypes
+
     def test_ternary_out_promotion(self, device):
         for op in [torch.addcdiv, torch.addcmul]:
             for dtype in [torch.float32, torch.cfloat]:

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -1259,7 +1259,6 @@ class TestUnaryUfuncs(TestCase):
     @dtypesIfCPU(torch.float16, torch.bfloat16, torch.float32, torch.float64)
     @dtypes(torch.float32, torch.float64)
     @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
-
     def test_igamma_common(self, device, dtype):
         # test igamma for reasonable range of values
         loglo = -4  # approx 0.018

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -1270,7 +1270,6 @@ class TestUnaryUfuncs(TestCase):
     @dtypesIfCPU(torch.float16, torch.bfloat16, torch.float32, torch.float64)
     @dtypes(torch.float32, torch.float64)
     @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
-
     def test_igammac_common(self, device, dtype):
         # test igammac for reasonable range of values
         loglo = -4  # approx 0.018
@@ -1281,7 +1280,6 @@ class TestUnaryUfuncs(TestCase):
 
     @dtypesIfCPU(torch.float16, torch.bfloat16, torch.float32, torch.float64)
     @dtypes(torch.float32, torch.float64)
-
     def test_igamma_edge_cases(self, device, dtype):
         tkwargs = {"dtype": dtype, "device": device}
         infs = torch.zeros((3,), **tkwargs) + float("inf")
@@ -1310,7 +1308,6 @@ class TestUnaryUfuncs(TestCase):
 
     @dtypesIfCPU(torch.float16, torch.bfloat16, torch.float32, torch.float64)
     @dtypes(torch.float32, torch.float64)
-
     def test_igammac_edge_cases(self, device, dtype):
         tkwargs = {"dtype": dtype, "device": device}
         infs = torch.zeros((3,), **tkwargs) + float("inf")

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -19,7 +19,6 @@ from torch.testing._internal.common_device_type import (
     largeTensorTest,
     onlyCPU,
     onlyCUDA,
-    onlyNativeDeviceTypes,
     ops,
     precisionOverride,
 )
@@ -1260,7 +1259,7 @@ class TestUnaryUfuncs(TestCase):
     @dtypesIfCPU(torch.float16, torch.bfloat16, torch.float32, torch.float64)
     @dtypes(torch.float32, torch.float64)
     @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
-    @onlyNativeDeviceTypes
+
     def test_igamma_common(self, device, dtype):
         # test igamma for reasonable range of values
         loglo = -4  # approx 0.018
@@ -1272,7 +1271,7 @@ class TestUnaryUfuncs(TestCase):
     @dtypesIfCPU(torch.float16, torch.bfloat16, torch.float32, torch.float64)
     @dtypes(torch.float32, torch.float64)
     @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
-    @onlyNativeDeviceTypes
+
     def test_igammac_common(self, device, dtype):
         # test igammac for reasonable range of values
         loglo = -4  # approx 0.018
@@ -1283,7 +1282,7 @@ class TestUnaryUfuncs(TestCase):
 
     @dtypesIfCPU(torch.float16, torch.bfloat16, torch.float32, torch.float64)
     @dtypes(torch.float32, torch.float64)
-    @onlyNativeDeviceTypes
+
     def test_igamma_edge_cases(self, device, dtype):
         tkwargs = {"dtype": dtype, "device": device}
         infs = torch.zeros((3,), **tkwargs) + float("inf")
@@ -1312,7 +1311,7 @@ class TestUnaryUfuncs(TestCase):
 
     @dtypesIfCPU(torch.float16, torch.bfloat16, torch.float32, torch.float64)
     @dtypes(torch.float32, torch.float64)
-    @onlyNativeDeviceTypes
+
     def test_igammac_edge_cases(self, device, dtype):
         tkwargs = {"dtype": dtype, "device": device}
         infs = torch.zeros((3,), **tkwargs) + float("inf")

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -267,7 +267,7 @@ class TestViewOps(TestCase):
 
     # Test the extra error checks that happen when the view dtype
     # has a greater element size than the original dtype
-
+    @skipXLA
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
     def test_view_dtype_upsize_errors(self, device, dtype):
         dtype_size = torch._utils._element_size(dtype)
@@ -471,6 +471,7 @@ class TestViewOps(TestCase):
         self.assertEqual(a[5:].real, a.real[5:])
         self.assertEqual(a[5:].imag, a.imag[5:])
 
+    @skipLazy
     @dtypes(*complex_types())
     def test_conj_imag_view(self, device, dtype) -> None:
         t = _make_tensor((4, 5), dtype, device)

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -13,7 +13,6 @@ from torch.testing._internal.common_device_type import (
     dtypesIfMPS,
     instantiate_device_type_tests,
     onlyCPU,
-    onlyNativeDeviceTypes,
     onlyNativeDeviceTypesAnd,
     skipLazy,
     skipMeta,
@@ -155,7 +154,6 @@ class TestViewOps(TestCase):
         self.assertTrue(s is t)
 
     @skipIfTorchDynamo("TorchDynamo fails with unknown reason")
-    @onlyNativeDeviceTypes
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool))
     def test_view_dtype_new(self, device, dtype):
         dtypes = {value: key for (key, value) in numpy_to_torch_dtype_dict.items()}
@@ -269,7 +267,7 @@ class TestViewOps(TestCase):
 
     # Test the extra error checks that happen when the view dtype
     # has a greater element size than the original dtype
-    @onlyNativeDeviceTypes
+
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
     def test_view_dtype_upsize_errors(self, device, dtype):
         dtype_size = torch._utils._element_size(dtype)
@@ -305,7 +303,6 @@ class TestViewOps(TestCase):
             ):
                 a.view(view_dtype)
 
-    @onlyNativeDeviceTypes
     def test_view_as_complex(self, device):
         def fn(contiguous_input=True, dim0=0, dim1=1):
             t = torch.randn(3, 2, 2, device=device)
@@ -370,7 +367,6 @@ class TestViewOps(TestCase):
         self.assertTrue(self.is_view_of(x, res))
         self.assertEqual(res.shape, torch.Size([0]))
 
-    @onlyNativeDeviceTypes
     @dtypes(*complex_types(), torch.complex32)
     def test_view_as_real(self, device, dtype):
         def fn(contiguous_input=True):
@@ -396,7 +392,6 @@ class TestViewOps(TestCase):
         self.assertTrue(self.is_view_of(x, res))
         self.assertEqual(res.shape, torch.Size([2]))
 
-    @onlyNativeDeviceTypes
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
     @dtypesIfMPS(
         *integral_types_and(torch.half, torch.bfloat16, torch.bool, torch.float32)
@@ -410,7 +405,6 @@ class TestViewOps(TestCase):
         for a_split_dim1_tensor in a_split_dim1:
             self.assertTrue(self.is_view_of(a, a_split_dim1_tensor))
 
-    @onlyNativeDeviceTypes
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
     def test_view_tensor_hsplit(self, device, dtype):
         t = make_tensor((4, 4, 4), dtype=dtype, device=device, low=-9, high=9)
@@ -420,7 +414,6 @@ class TestViewOps(TestCase):
         t[2, 2, 2] = 7
         self.assertEqual(t_hsplit[1][2, 0, 2], t[2, 2, 2])
 
-    @onlyNativeDeviceTypes
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
     def test_view_tensor_vsplit(self, device, dtype):
         t = make_tensor((4, 4, 4), dtype=dtype, device=device, low=-9, high=9)
@@ -430,7 +423,6 @@ class TestViewOps(TestCase):
         t[2, 2, 2] = 7
         self.assertEqual(t_vsplit[1][0, 2, 2], t[2, 2, 2])
 
-    @onlyNativeDeviceTypes
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
     def test_view_tensor_dsplit(self, device, dtype):
         t = make_tensor((4, 4, 4), dtype=dtype, device=device, low=-9, high=9)
@@ -449,7 +441,6 @@ class TestViewOps(TestCase):
         with self.assertRaises(RuntimeError):
             torch.imag(t)
 
-    @onlyNativeDeviceTypes
     @dtypes(*complex_types())
     def test_real_imag_view(self, device, dtype):
         def compare_with_numpy(contiguous_input=True):
@@ -480,7 +471,6 @@ class TestViewOps(TestCase):
         self.assertEqual(a[5:].real, a.real[5:])
         self.assertEqual(a[5:].imag, a.imag[5:])
 
-    @onlyNativeDeviceTypes
     @dtypes(*complex_types())
     def test_conj_imag_view(self, device, dtype) -> None:
         t = _make_tensor((4, 5), dtype, device)
@@ -495,7 +485,6 @@ class TestViewOps(TestCase):
             self.assertEqual(v_imag, t_numpy_conj.imag)
             self.assertTrue(v_imag.is_neg())
 
-    @onlyNativeDeviceTypes
     def test_conj_view_with_shared_memory(self, device) -> None:
         a = _make_tensor((4, 5), torch.cfloat, device)
         b = a.conj()
@@ -505,7 +494,6 @@ class TestViewOps(TestCase):
         self.assertEqual(torch.add(b, c), torch.add(b, c, out=a))
         self.assertEqual(torch.add(b, c), b.add_(c))
 
-    @onlyNativeDeviceTypes
     @dtypes(
         *product(
             complex_types(),
@@ -882,7 +870,6 @@ class TestViewOps(TestCase):
         test_writes_propagate(t, v3)
         self.assertTrue(self.is_view_of_same_base(t, v3))
 
-    @onlyNativeDeviceTypes
     def test_flatten_nonview(self, device):
         def assert_is_nonview(t, nv):
             idx_t = (0,) * t.ndim
@@ -1161,7 +1148,7 @@ class TestOldViewOps(TestCase):
         self.assertEqual((1, 0, 6, 1, 1), x.view(1, 0, 6, 1, 1).shape)
 
     # TODO: this should be refactored into the view ops test suite
-    @onlyNativeDeviceTypes
+
     def test_reshape(self, device):
         x = torch.randn(3, 3, device=device)
         self.assertEqual(x.data_ptr(), x.reshape(-1).data_ptr())
@@ -1482,7 +1469,6 @@ class TestOldViewOps(TestCase):
             (3, 10, 3, 32, 32), 3 * 10 * 3 * 32 * 32, torch.channels_last_3d, device
         )
 
-    @onlyNativeDeviceTypes
     @dtypes(torch.int64, torch.float, torch.complex128)
     def test_transpose_invalid(self, device, dtype):
         for fn in (torch.swapdims, torch.swapaxes, torch.transpose):
@@ -1823,7 +1809,6 @@ class TestOldViewOps(TestCase):
         x.set_(x.storage(), 0, x.size(), stride)
         self.assertTrue(x.is_contiguous())
 
-    @onlyNativeDeviceTypes
     # Skip BFloat16 since numpy does not support it
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool))
     def test_tensor_split_sections(self, device, dtype):
@@ -1856,7 +1841,6 @@ class TestOldViewOps(TestCase):
                         self.assertEqual(result_n, result1, msg=msg)
                         self.assertEqual(result_n, result2, msg=msg)
 
-    @onlyNativeDeviceTypes
     # Skip BFloat16 since numpy does not support it
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool))
     def test_tensor_split_indices(self, device, dtype):
@@ -1903,7 +1887,6 @@ class TestOldViewOps(TestCase):
                         self.assertEqual(result_n, result_1, msg=msg)
                         self.assertEqual(result_n, result_2, msg=msg)
 
-    @onlyNativeDeviceTypes
     def test_tensor_split_errors(self, device):
         S = 10
         test_cases = [
@@ -1983,7 +1966,6 @@ class TestOldViewOps(TestCase):
             x.resize_as_(y)
             self.assertEqual(y.shape, x.shape)
 
-    @onlyNativeDeviceTypes
     def test_resize_overflow(self, device):
         x = torch.empty((), dtype=torch.float64)
         with self.assertRaisesRegex(

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -155,6 +155,7 @@ class TestViewOps(TestCase):
 
     @skipIfTorchDynamo("TorchDynamo fails with unknown reason")
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool))
+    @skipXLA
     def test_view_dtype_new(self, device, dtype):
         dtypes = {value: key for (key, value) in numpy_to_torch_dtype_dict.items()}
         del dtypes[torch.bool]
@@ -871,6 +872,7 @@ class TestViewOps(TestCase):
         test_writes_propagate(t, v3)
         self.assertTrue(self.is_view_of_same_base(t, v3))
 
+    @skipLazy
     def test_flatten_nonview(self, device):
         def assert_is_nonview(t, nv):
             idx_t = (0,) * t.ndim


### PR DESCRIPTION
This is follow-up of https://github.com/pytorch/pytorch/pull/128584.  Covering additional files for execution.

Based on the discussion we further had with the reviewers it is decided to remove ```onlyNativeDeviceTypes``` decorator to open these up for all devices. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov