### PR TITLE
Back out "Fix triton masked loading for non-block tl.loads (#144782)"

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10606,14 +10606,6 @@ class CommonTemplate:
         x = torch.rand(48, 3, 512, 512)
         self.common(fn, (x,))
 
-    def test_pad_single(self):
-        def fn(a):
-            y = torch.nn.functional.pad(a, (10, 10))
-            return y
-
-        x = torch.rand(1, 1, 1)
-        self.common(fn, (x,))
-
     def test_pad_cast(self):
         def fn(x):
             return torch.nn.functional.pad(x.to(torch.float32), (0, 3, 0, 0))

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -130,7 +130,6 @@ test_failures = {
     "test_repeat_as_strided_dynamic_shapes": TestFailure(("cpu",)),
     "test_mul_index_expr_dynamic_shapes": TestFailure(("cpu",)),
     "test_flip_cat_dynamic_shapes": TestFailure(("cpu",)),
-    "test_pad_single_dynamic_shapes": TestFailure(("cpu",)),
     #
     # Failed to find for loop/triton kernel:
     #

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1351,14 +1351,10 @@ class TritonKernelOverrides(TritonOverrides):
         assert nodes, "graph for body does not contain an output"
 
         need_where = False
-        # If we have a tl.load with a masking operator and no other value
-        # we can add the mask here and the other value to the tl.load
-        # operator to save the branching cost.
         for node in nodes:
             for arg in node.args:
-                if arg.target != "load" or should_unwrap_unspec_arg(arg.args[1]):
+                if arg.target != "load" or should_unwrap_unspec_arg(arg.args[0]):
                     need_where = True
-                    break
 
         value = None if need_where else other
 
@@ -1933,12 +1929,8 @@ class TritonKernel(SIMDKernel):
         if isinstance(index, sympy.Integer):
             expand_str = f"{copy_shape}.shape" if copy_shape else self.dense_size_str()
             index_str = f"tl.full({expand_str}, {index_str}, tl.int32)"
-            mask_vars = OrderedSet()
-            if self._load_mask:
-                mask_vars.add(self._load_mask)
-            mask_str = " & ".join(sorted(map(str, mask_vars))) if mask_vars else "None"
             return IndexingOptions(
-                index_str, mask_vars, mask_str, expand_str, has_rindex, index
+                index_str, OrderedSet(), "None", expand_str, has_rindex, index
             )
 
         if need_dense and not have_dense:
@@ -2140,7 +2132,8 @@ class TritonKernel(SIMDKernel):
                 line = indexing.codegen_broadcast_and_reshape(
                     line, indexing.block_shape, indexing.final_shape, True
                 )
-            elif isinstance(original_index, sympy.Integer) and not indexing.mask_vars:
+
+            elif isinstance(original_index, sympy.Integer):
                 line = f"tl.load({var} + ({original_index}))"
                 append_broadcast = indexing.expand_str
             else:


### PR DESCRIPTION
Summary:
Original commit changeset: 77b1206ddb61

Original Phabricator Diff: D68509889

Bisect found this diff, it regresses compile time for Ads CMF model by 20%:
https://www.internalfb.com/lab/attribution/session/888f7684-91cd-4b8f-99ea-a71ce6db1ad6#jobid=45036005935867349

Test Plan:
Metric recovered on backout diff:
https://www.internalfb.com/servicelab/experiment/4700407575/

Reviewed By: ezyang

Differential Revision: D68605114




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov