### PR TITLE
[Release-Only] Remove ptx from Linux CUDA 12.6 binary builds

### DIFF
--- a/.ci/manywheel/build_cuda.sh
+++ b/.ci/manywheel/build_cuda.sh
@@ -63,7 +63,7 @@ case ${CUDA_VERSION} in
         if [[ "$GPU_ARCH_TYPE" = "cuda-aarch64" ]]; then
             TORCH_CUDA_ARCH_LIST="9.0"
         else
-            TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST};9.0+PTX"
+            TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST};9.0"
         fi
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
         ;;


### PR DESCRIPTION
These increase binary size of Manywheel builds by about 200mb.
Todo: Add to release runbook to strip ``+PTX`` from all CUDA builds as release only changes.
Please note: We want to keep +PTX in our nightly builds but we don't want to have this functionality in release because of the significant binary size increase.