### PR TITLE
Introduce aoti_call_delegate HOP

### DIFF
--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -149,6 +149,10 @@ class Verifier(metaclass=_VerifierMeta):
     def allowed_getattr_types(self) -> tuple[type[Any], ...]:
         return (torch.fx.GraphModule,)
 
+    def allowed_getattr_types_for_subgm(self) -> tuple[type[Any], ...]:
+        # subgm in HOP's argument could has have getattr(weight) nodes, thus stateful
+        return (torch.fx.GraphModule, torch.nn.parameter.Parameter)
+
     def check_valid_op(self, op):
         pass
 
@@ -165,8 +169,11 @@ class Verifier(metaclass=_VerifierMeta):
 
     @final
     def _check_graph_module(self, gm: torch.fx.GraphModule) -> None:
-        def _allowed_getattr_types() -> tuple[type[Any], ...]:
-            ret = self.allowed_getattr_types()
+        def _allowed_getattr_types(is_toplevel_gm) -> tuple[type[Any], ...]:
+            if is_toplevel_gm:
+                ret = self.allowed_getattr_types()
+            else:
+                ret = self.allowed_getattr_types_for_subgm()
             assert not any(t is object for t in ret)
             return ret
 
@@ -218,6 +225,8 @@ class Verifier(metaclass=_VerifierMeta):
             self.check_valid_op(op)
 
         for mod in gm.modules():
+            is_toplevel_gm = mod is gm
+
             if not isinstance(mod, torch.fx.GraphModule):
                 continue
 
@@ -261,11 +270,14 @@ class Verifier(metaclass=_VerifierMeta):
                                     f"processed_bytes(bytes) : {type(processed_bytes)}, "
                                     f"compile_specs(list) : {type(compile_specs)}"
                                 )
+                        elif type(attr).__name__ == "AOTInductorEPModule":
+                            continue
 
-                    if not isinstance(attr, _allowed_getattr_types()):
+
+                    if not isinstance(attr, _allowed_getattr_types(is_toplevel_gm)):
                         raise SpecViolationError(
                             f"Invalid get_attr type {type(attr)}. \n"
-                            f"Valid get_attr types: {_allowed_getattr_types()}"
+                            f"Valid get_attr types: {_allowed_getattr_types(is_toplevel_gm)}"
                         )
 
 

--- a/torch/_higher_order_ops/__init__.py
+++ b/torch/_higher_order_ops/__init__.py
@@ -1,3 +1,4 @@
+from torch._higher_order_ops.aoti_call_delegate import aoti_call_delegate
 from torch._higher_order_ops.associative_scan import associative_scan
 from torch._higher_order_ops.auto_functionalize import (
     auto_functionalized,
@@ -52,4 +53,5 @@ __all__ = [
     "wrap_with_autocast",
     "wrap_activation_checkpoint",
     "strict_mode",
+    "aoti_call_delegate",
 ]

--- a/torch/_higher_order_ops/aoti_call_delegate.py
+++ b/torch/_higher_order_ops/aoti_call_delegate.py
@@ -1,0 +1,111 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+from typing import List
+
+import torch
+import torch.utils._pytree as pytree
+from torch._ops import HigherOrderOperator
+from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+
+
+AOTI_LOWERED_MODULE = "AOTInductorEPModule"
+
+
+class AOTICallDelegate(HigherOrderOperator):
+    """aoti_call_delegate is a HOP for calling AOTInductor lowered submodule in ExportedProgram.
+
+    It has the following signature:
+    aoti_call_delegate(
+        lowered_module: AOTInductorEPModule,
+        original_gm:fx.GraphModule,
+        weight_args: List[Tensor],
+        input_args: List[Tensor],
+    ) -> outputs: List[Tensor]
+
+    where,
+    - lowered_module is the AOTInductor lowered submodule, backed by compiled .so file, supporting real tensor inputs
+    - original_gm is the original GraphModule before lowering, allowing FakeTensor propagation
+    - weight_args is the list of weights in original GraphModule, including parameters and buffers
+    - input_args is the list of flatten inputs
+
+    NOTE: aoti_call_delegate doesn't support retracing yet, as original_gm is currently stateful with weight as get_attr nodes.
+    This will fail functionalization during retrace. When we move AOTI to accept stateless GraphModule, we can enable retracing.
+
+    When serialization, we have special hanlding for aoti_call_delegate, as AOTInductorEPModule is not serializable
+    and stateful original_gm is failing the verifier.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("aoti_call_delegate")
+
+    def __call__(
+        self,
+        lowered_module: AOTI_LOWERED_MODULE,  # type: ignore[valid-type]
+        original_gm: torch.fx.GraphModule,
+        weight_args: List[torch.Tensor],
+        input_args: List[torch.Tensor],
+    ) -> List[torch.Tensor]:
+        return super().__call__(lowered_module, original_gm, weight_args, input_args)
+
+
+aoti_call_delegate = AOTICallDelegate()
+aoti_call_delegate.fallthrough(torch._C.DispatchKey.PythonDispatcher)
+aoti_call_delegate.fallthrough(torch._C.DispatchKey.PythonTLSSnapshot)
+aoti_call_delegate.fallthrough(torch._C.DispatchKey.ADInplaceOrView)
+aoti_call_delegate.fallthrough(torch._C.DispatchKey.AutocastCPU)
+
+
+@aoti_call_delegate.py_impl(torch._C.DispatchKey.CompositeExplicitAutograd)
+# pyre-ignore
+def call_delegate_cpu(
+    lowered_module: AOTI_LOWERED_MODULE,  # type: ignore[valid-type]
+    original_gm: torch.fx.GraphModule,
+    weight_args: List[torch.Tensor],
+    input_args: List[torch.Tensor],
+) -> List[torch.Tensor]:
+    # FX creates this immutable_dict/list concept. Get rid of this.
+    map_types = {
+        torch.fx.immutable_collections.immutable_dict: dict,
+        torch.fx.immutable_collections.immutable_list: list,
+    }
+    new_args = pytree.tree_map_only(
+        tuple(map_types.keys()),
+        lambda a: map_types[type(a)](a),
+        input_args,
+        lambda a: isinstance(a, tuple(map_types.keys())),
+    )
+
+    has_fake_input_args = any(isinstance(arg, FakeTensor) for arg in new_args)
+    has_fake_params = any(
+        isinstance(param, FakeTensor) for param in original_gm.parameters()
+    )
+    has_fake_buffers = any(
+        isinstance(buffer, FakeTensor) for buffer in original_gm.buffers()
+    )
+
+    if has_fake_input_args or has_fake_params or has_fake_buffers:
+        # aoti lowered module doesn't support fake tensor
+        return original_gm(*new_args)
+    else:
+        return lowered_module(new_args)  # type: ignore[misc]
+
+
+@aoti_call_delegate.py_impl(FakeTensorMode)
+# pyre-ignore
+def call_delegate_fake_tensor_mode(
+    mode: FakeTensorMode,
+    lowered_module: AOTI_LOWERED_MODULE,  # type: ignore[valid-type]
+    original_gm: torch.fx.GraphModule,
+    weight_args: List[torch.Tensor],
+    input_args: List[torch.Tensor],
+) -> List[torch.Tensor]:
+    with mode:
+        return call_delegate_cpu(lowered_module, original_gm, weight_args, input_args)

--- a/torch/testing/_internal/hop_db.py
+++ b/torch/testing/_internal/hop_db.py
@@ -97,6 +97,7 @@ FIXME_hop_that_doesnt_have_opinfo_test_allowlist = [
     "triton_kernel_wrapper_functional",
     "hints_wrapper",
     "foreach_map",
+    "aoti_call_delegate",
 ]
 
 torch.library.define(


### PR DESCRIPTION
Summary:
Previously, aoti compile node is represented as a kernel-less custom op in the exported program. The node was not eager runnable, which is a common practice for numerical validation during lowering. 

I introduce a new HOP to address this. 

The schema is following
```
aoti_call_delegate(lower_moduel: AOTInductorEPModule, original_gm: fx.GraphModule, weights: List[Tensor], inputs: List[Tensor])
```

There are a few problems exposed by HOP
- AOTI expects a FX graph with weights as getattr nodes, aka stateful graph. HOP expect graph_module arguments to be stateless. Export serializer also expect a stateless graph. Currently, to make AOTI happy, I am making `original_gm` stateful, and bypassing the serialization for `original_gm`. 
- As a result, the HOP is not re-traceable, as functionalization on stateful graph module argument will fail.

Test Plan: buck2 test 'fbcode//mode/opt' fbcode//deeplearning/aot_inductor/cpu/test:cpu_lowering_utils_test

Reviewed By: zhxchen17

Differential Revision: D68359391


