### PR TITLE
[CUDA] Change slim-wheel libraries load order

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -325,8 +325,8 @@ def _load_global_deps() -> None:
             if "nvidia/cuda_runtime/lib/libcudart.so" not in _maps:
                 return
             # If all abovementioned conditions are met, preload nvjitlink and nvrtc
-            _preload_cuda_deps("nvjitlink", "libnvJitLink.so.*[0-9]")
             _preload_cuda_deps("cuda_nvrtc", "libnvrtc.so.*[0-9]")
+            _preload_cuda_deps("nvjitlink", "libnvJitLink.so.*[0-9]")
         except Exception:
             pass
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -325,7 +325,7 @@ def _load_global_deps() -> None:
             if "nvidia/cuda_runtime/lib/libcudart.so" not in _maps:
                 return
             # If all above-mentioned conditions are met, preload nvrtc and nvjitlink
-            # Please note that order are important for CUDA-11.8 , as nvjitlink depends on nvrtc
+            # Please note that order are important for CUDA-11.8 , as nvjitlink does not exist there
             _preload_cuda_deps("cuda_nvrtc", "libnvrtc.so.*[0-9]")
             _preload_cuda_deps("nvjitlink", "libnvJitLink.so.*[0-9]")
         except Exception:

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -324,7 +324,8 @@ def _load_global_deps() -> None:
             # libtorch_global_deps.so always depends in cudart, check if its installed via wheel
             if "nvidia/cuda_runtime/lib/libcudart.so" not in _maps:
                 return
-            # If all abovementioned conditions are met, preload nvjitlink and nvrtc
+            # If all above-mentioned conditions are met, preload nvrtc and nvjitlink
+            # Please note that order are important for CUDA-11.8 , as nvjitlink depends on nvrtc
             _preload_cuda_deps("cuda_nvrtc", "libnvrtc.so.*[0-9]")
             _preload_cuda_deps("nvjitlink", "libnvJitLink.so.*[0-9]")
         except Exception:


### PR DESCRIPTION
There is no libnvjitlink in  CUDA-11.x , so attempts to load it first will abort the execution and prevent the script from preloading nvrtc

Fixes issues reported in https://github.com/pytorch/pytorch/pull/145614#issuecomment-2613107072 

cc @atalman @malfet @ptrblck @eqy @tinglvv 
