### PR TITLE
[AOTInductor] Refactor CPU and GPU to remove ifdef macros

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -46,32 +46,30 @@ extern uint8_t _binary_constants_bin_end[];
 
 namespace {
 
+using RAIIDataPtr = std::unique_ptr<void, std::function<void(void*)>>;
+
 #ifdef USE_CUDA
 
-using GPUPtr = std::unique_ptr<void, std::function<void(void*)>>;
-
-GPUPtr RAII_gpuMalloc(size_t num_bytes) {
+RAIIDataPtr RAII_gpuMalloc(size_t num_bytes) {
   void* data_ptr;
   AOTI_RUNTIME_DEVICE_CHECK(cudaMalloc((void**)&data_ptr, num_bytes));
   auto deleter = [](void* ptr) { AOTI_RUNTIME_DEVICE_CHECK(cudaFree(ptr)); };
-  return GPUPtr(data_ptr, deleter);
+  return RAIIDataPtr(data_ptr, deleter);
 }
 
 #endif // USE_CUDA
 
 #ifdef USE_XPU
 
-using GPUPtr = std::unique_ptr<void, std::function<void(void*)>>;
-
-GPUPtr RAII_gpuMalloc(size_t num_bytes) {
+RAIIDataPtr RAII_gpuMalloc(size_t num_bytes) {
   sycl::queue* queue_ptr = nullptr;
   aoti_torch_get_current_sycl_queue((void**)&queue_ptr);
   void* data_ptr = sycl::malloc_device(num_bytes, *queue_ptr);
   auto deleter = [queue_ptr](void* ptr) { sycl::free(ptr, *queue_ptr); };
-  return GPUPtr(data_ptr, deleter);
+  return RAIIDataPtr(data_ptr, deleter);
 }
 
-#endif // USE_CUDA
+#endif // USE_XPU
 
 } // anonymous namespace
 
@@ -342,14 +340,16 @@ class AOTInductorModelBase {
     }
   }
 
-#if defined(USE_CUDA) || defined(USE_XPU)
-  GPUPtr&& release_constant_blob() {
+  RAIIDataPtr&& release_constant_blob() {
     return std::move(constant_blob_);
   }
-#endif
 
   std::shared_ptr<std::vector<ConstantHandle>> get_constants_array() {
     return constants_;
+  }
+
+  int32_t get_device_type() const {
+    return device_type_;
   }
 
   int32_t get_device_idx() const {
@@ -643,10 +643,8 @@ class AOTInductorModelBase {
   std::shared_ptr<ConstantMap> constants_map_;
   std::shared_ptr<std::vector<ConstantHandle>> constants_;
 
-#if defined(USE_CUDA) || defined(USE_XPU)
-  // Holds the blob storage for constants' at::Tensor for CUDA.
-  GPUPtr constant_blob_;
-#endif // USE_CUDA
+  // Holds the blob storage for constants' at::Tensor.
+  RAIIDataPtr constant_blob_;
 
 #ifdef USE_MMAP_SELF
   uint8_t* self_mmap = NULL;

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -312,6 +312,7 @@ class AOTInductorModelContainer {
       AtenTensorHandle tensor_handle;
       int64_t* stride;
       int64_t offset;
+      int device_type = models_[0]->get_device_type();
       int device_idx = models_[0]->get_device_idx();
       AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_strides(tensor, &stride));
       AOTI_TORCH_ERROR_CODE_CHECK(
@@ -323,11 +324,7 @@ class AOTInductorModelContainer {
           stride,
           offset,
           models_[0]->constant_dtype(idx),
-#ifdef USE_XPU
-          aoti_torch_device_type_xpu(),
-#else
-          aoti_torch_device_type_cuda(),
-#endif
+          device_type,
           device_idx,
           &tensor_handle));
 #else // USE_CUDA
@@ -407,16 +404,13 @@ class AOTInductorModelContainer {
   const char* in_spec_;
   const char* out_spec_;
 
-#if defined(USE_CUDA) || defined(USE_XPU)
-  // Holds the blob storage for constants' at::Tensor for CUDA.
-  GPUPtr constant_blob_;
-  GPUPtr constant_blob_secondary_;
+  // Holds the blob storage for constants' at::Tensor within the container.
+  // This blob of memory will be managed by the container.
+  RAIIDataPtr constant_blob_;
+  RAIIDataPtr constant_blob_secondary_;
 
-  // Let's place this within USE_CUDA at the moment before we fully support
-  // update for CPU cases.
   size_t blob_size_;
   std::vector<size_t> constants_internal_offset_;
-#endif // USE_CUDA
 
   // Determine which constants is being used for the model.
   // If true,


### PR DESCRIPTION
Summary: Remove #ifdef USE_CUDA macros through some refactor

Test Plan: Refactor code, existing tests.

Differential Revision: D68636743


