### PR TITLE
[CI][CUDA][Blackwell] sm_\d\d no longer matches sm_100. 

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -159,7 +159,7 @@ class TestCppExtensionJIT(common.TestCase):
                     f"Output: {output} "
                 )
 
-            actual_arches = sorted(re.findall(r"sm_\d\d", output))
+            actual_arches = sorted(re.findall(r"sm_\d+", output))
             expected_arches = sorted(["sm_" + xx for xx in expected_values])
             self.assertEqual(
                 actual_arches,


### PR DESCRIPTION
Therefore making it sm_\d+

Fixes this unit test failure: python test/test_cpp_extensions_jit.py -k TestCppExtensionJIT.test_jit_cuda_archflags

cc @atalman @malfet @ptrblck @eqy @tinglvv 