### PR TITLE
[mps/inductor] Add support for `erfinv`.

### DIFF
--- a/aten/src/ATen/native/mps/kernels/UnaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/UnaryKernel.metal
@@ -1,36 +1,8 @@
+#include <c10/metal/special_math.h>
 #include <c10/metal/utils.h>
 #include <metal_stdlib>
-using namespace c10::metal;
 using namespace metal;
-
-template <typename T>
-float erfinv(T y) {
-  /* coefficients in rational expansion */
-  constexpr float a[4] = {0.886226899, -1.645349621, 0.914624893, -0.140543331};
-  constexpr float b[4] = {-2.118377725, 1.442710462, -0.329097515, 0.012229801};
-  constexpr float c[4] = {-1.970840454, -1.624906493, 3.429567803, 1.641345311};
-  constexpr float d[2] = {3.543889200, 1.637067800};
-
-  float x, z, num, dem; /*working variables */
-
-  float y_abs = abs(static_cast<float>(y));
-  if (y_abs >= 1.0f) {
-    return y_abs > 1.0f ? NAN : copysign(INFINITY, static_cast<float>(y));
-  }
-  if (y_abs <= 0.7f) {
-    z = y * y;
-    num = ((a[3] * z + a[2]) * z + a[1]) * z + a[0];
-    dem = (((b[3] * z + b[2]) * z + b[1]) * z + b[0]) * z + 1.0f;
-    x = y * num / dem;
-  } else {
-    z = sqrt(-1.0f * log((1.0 - y_abs) / 2.0));
-    num = ((c[3] * z + c[2]) * z + c[1]) * z + c[0];
-    dem = (d[1] * z + d[0]) * z + 1.0f;
-    x = copysign(num, static_cast<float>(y)) / dem;
-  }
-
-  return x;
-}
+using namespace c10::metal;
 
 template <typename T0, typename T1>
 kernel void erfinv_kernel(

--- a/c10/metal/special_math.h
+++ b/c10/metal/special_math.h
@@ -30,6 +30,36 @@ T erf(T x) {
   return sign * y;
 }
 
+template <typename T>
+float erfinv(T y) {
+  /* coefficients in rational expansion */
+  constexpr float a[4] = {0.886226899, -1.645349621, 0.914624893, -0.140543331};
+  constexpr float b[4] = {-2.118377725, 1.442710462, -0.329097515, 0.012229801};
+  constexpr float c[4] = {-1.970840454, -1.624906493, 3.429567803, 1.641345311};
+  constexpr float d[2] = {3.543889200, 1.637067800};
+
+  float x, z, num, dem; /*working variables */
+
+  float y_abs = ::metal::abs(static_cast<float>(y));
+  if (y_abs >= 1.0f) {
+    return y_abs > 1.0f ? NAN
+                        : ::metal::copysign(INFINITY, static_cast<float>(y));
+  }
+  if (y_abs <= 0.7f) {
+    z = y * y;
+    num = ((a[3] * z + a[2]) * z + a[1]) * z + a[0];
+    dem = (((b[3] * z + b[2]) * z + b[1]) * z + b[0]) * z + 1.0f;
+    x = y * num / dem;
+  } else {
+    z = ::metal::sqrt(-1.0f * ::metal::log((1.0 - y_abs) / 2.0));
+    num = ((c[3] * z + c[2]) * z + c[1]) * z + c[0];
+    dem = (d[1] * z + d[0]) * z + 1.0f;
+    x = ::metal::copysign(num, static_cast<float>(y)) / dem;
+  }
+
+  return x;
+}
+
 /*
  * For licensing information and documentation, please refer to the cpu
  * implementation located in "ATen/native/Math.h".

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -150,6 +150,7 @@ for test_name in [
     "test_builtins_round",
     "test_builtins_round_float_ndigits_neg",
     "test_lgamma",
+    "test_erfinv",
 ]:
     setattr(MPSBasicTests, test_name, getattr(CommonTemplate, test_name))
 

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -223,6 +223,10 @@ class MetalOverrides(OpOverrides):
         return f"c10::metal::erf({x})"
 
     @staticmethod
+    def erfinv(x: CSEVariable) -> str:
+        return f"c10::metal::erfinv({x})"
+
+    @staticmethod
     def lgamma(x: CSEVariable) -> str:
         return f"c10::metal::log_gamma({x})"
 


### PR DESCRIPTION
After several rounds of refactoring, this seems to be done now.

cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov