### PR TITLE
[c10d] implement ReduceOp.unbox()

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -888,7 +888,13 @@ This class does not support ``__members__`` property.)");
             } else {
               return ::c10d::makeNCCLPreMulSum(t[1].cast<at::Tensor>());
             }
-          }));
+          }))
+      .def_static("unbox", [](py::object obj) {
+        auto typePtr =
+            torch::getCustomClass("__torch__.torch.classes.c10d.ReduceOp");
+        auto ivalue = torch::jit::toIValue(std::move(obj), typePtr);
+        return ivalue.toCustomClass<::c10d::ReduceOp>();
+      });
 
   py::enum_<::c10d::ReduceOp::RedOpType>(reduce_op, "RedOpType")
       .value("SUM", ::c10d::ReduceOp::RedOpType::SUM)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145652
* #144886

```python
>>> import torch
>>> op = torch.classes.c10d.ReduceOp()
>>> op
<torch.ScriptObject object at 0x5b688b0>
>>> torch.distributed.ReduceOp.unbox(op)
<torch.distributed.distributed_c10d.ReduceOp object at 0x7fd9e3066ff0>
>>> torch.distributed.ReduceOp.unbox(op).op
<RedOpType.SUM: 0>
```


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o