### PR TITLE
[dynamo] Fix read/write conflicts in a cuda test

### DIFF
--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -461,6 +461,9 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
                     torch.mm(x, x, out=foo)
                     event.record()
                 out = fn(foo)
+                # let `fn` finish reading `food` before writing to it in the
+                # next iteration or `run_iters` call.
+                torch.cuda.current_stream().synchronize()
             return out
 
         ref = run_iters(func, compile=False)

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -461,8 +461,8 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
                     torch.mm(x, x, out=foo)
                     event.record()
                 out = fn(foo)
-                # let `fn` finish reading `food` before writing to it in the
-                # next iteration or `run_iters` call.
+                # let `fn` finish reading `foo` before writing to it in the next
+                # iteration or `run_iters` call.
                 torch.cuda.current_stream().synchronize()
             return out
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145658

Prior to this patch, the `test_cuda_event_created_outside_of_graph`
is flaky in CI, and that's because we have read and write to the same
`foo` tensor buffer from 2 different streams. This patch eliminates that
by adding a synchronization to wait till read finishes before starting
the write.

Fixes #133837, #133828.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames