### PR TITLE
[MPSInductor] Add rand support

### DIFF
--- a/c10/metal/random.h
+++ b/c10/metal/random.h
@@ -1,0 +1,62 @@
+// Philox Counter based RNG implemntation for Metal
+// Borrowed from aten/src/ATen/core/PhiloxRNGEngine.h
+// Which in turn borrowed from http://www.thesalmons.org/john/random123/papers/random123sc11.pdf
+#pragma once
+#include <metal_stdlib>
+
+namespace c10 {
+namespace metal {
+namespace philox4 {
+
+inline uint2 splitlong(ulong v) {
+  return uint2(v >> 32, v & 0xffffffff);
+}
+uint2 mulhilo(uint a, uint b) {
+  auto rc = static_cast<ulong>(a) * b;
+  return splitlong(rc);
+}
+uint4 single_round(uint4 ctr, uint2 key) {
+  constexpr uint kPhiloxSA = 0xD2511F53;
+  constexpr uint kPhiloxSB = 0xCD9E8D57;
+  auto rc0 = mulhilo(kPhiloxSA, ctr.x);
+  auto rc1 = mulhilo(kPhiloxSB, ctr.z);
+  return uint4(rc1.y ^ ctr.y ^ key.x, rc1.x, rc0.y ^ ctr.w ^ key.y, rc0.x);
+}
+
+
+uint4 multiple_rounds(uint4 ctr, uint2 key, uint rounds) {
+  constexpr uint2 kPhilox10 = {0x9E3779B9, 0xBB67AE85};
+  for(uint round = 0; round < rounds - 1; ++round) {
+    ctr = single_round(ctr, key);
+    key += kPhilox10;
+  }
+}
+
+uint4 rand(long seed, long index) {
+  uint4 ctr = 0;
+  ctr.zw = splitlong(index);
+  return multiple_rounds(ctr, splitlong(seed), 10);
+}
+
+} // namespace philox4
+
+namespace detail {
+
+constexpr float uint32_to_uniform_float(uint32_t value) {
+  // maximum value such that `MAX_INT * scale < 1.0` (with float rounding)
+  constexpr float scale = 4.6566127342e-10;
+  return static_cast<float>(value & 0x7FFFFFFF) * scale;
+}
+
+} // namespace detail
+
+float randn(long seed, long index) {
+   auto value = philox4::rand(seed, index);
+   float u1 = 1.0 - detail::uint32_to_uniform_float(value.x);
+   float u2 = 1.0 - detail::uint32_to_uniform_float(value.y);
+   return ::metal::sqrt(-2.0 * ::metal::log(u1)) * ::metal::cos ( 2.0 * M_PI_F  * u2);
+}
+} // namespace metal
+} // namespace c10
+
+

--- a/c10/metal/random.h
+++ b/c10/metal/random.h
@@ -70,7 +70,8 @@ long randint64(long seed, long index, long low, long high) {
   auto range = high - low;
   auto value = philox4::rand(seed, index);
   // TODO: Implement better algorithm for large ranges
-  return low + static_cast<long>(detail::uint32_to_uniform_float(value.x)*range);
+  return low +
+      static_cast<long>(detail::uint32_to_uniform_float(value.x) * range);
 }
 
 } // namespace metal

--- a/c10/metal/random.h
+++ b/c10/metal/random.h
@@ -59,5 +59,11 @@ float randn(long seed, long index) {
   return ::metal::sqrt(-2.0 * ::metal::log(u1)) *
       ::metal::cos(2.0 * M_PI_F * u2);
 }
+
+float rand(long seed, long index) {
+  auto value = philox4::rand(seed, index);
+  return detail::uint32_to_uniform_float(value.x);
+}
+
 } // namespace metal
 } // namespace c10

--- a/c10/metal/random.h
+++ b/c10/metal/random.h
@@ -42,6 +42,7 @@ uint4 multiple_rounds(uint4 ctr, uint2 key, uint rounds) {
     ctr = single_round(ctr, key);
     key += kPhilox10;
   }
+  return ctr;
 }
 
 uint4 rand(long seed, long index) {
@@ -63,6 +64,13 @@ float randn(long seed, long index) {
 float rand(long seed, long index) {
   auto value = philox4::rand(seed, index);
   return detail::uint32_to_uniform_float(value.x);
+}
+
+long randint64(long seed, long index, long low, long high) {
+  auto range = high - low;
+  auto value = philox4::rand(seed, index);
+  // TODO: Implement better algorithm for large ranges
+  return low + static_cast<long>(detail::uint32_to_uniform_float(value.x)*range);
 }
 
 } // namespace metal

--- a/c10/metal/random.h
+++ b/c10/metal/random.h
@@ -1,44 +1,12 @@
 // Philox Counter based RNG implemntation for Metal
 // Borrowed from aten/src/ATen/core/PhiloxRNGEngine.h
-// Which in turn borrowed from http://www.thesalmons.org/john/random123/papers/random123sc11.pdf
+// Which in turn borrowed from
+// http://www.thesalmons.org/john/random123/papers/random123sc11.pdf
 #pragma once
 #include <metal_stdlib>
 
 namespace c10 {
 namespace metal {
-namespace philox4 {
-
-inline uint2 splitlong(ulong v) {
-  return uint2(v >> 32, v & 0xffffffff);
-}
-uint2 mulhilo(uint a, uint b) {
-  auto rc = static_cast<ulong>(a) * b;
-  return splitlong(rc);
-}
-uint4 single_round(uint4 ctr, uint2 key) {
-  constexpr uint kPhiloxSA = 0xD2511F53;
-  constexpr uint kPhiloxSB = 0xCD9E8D57;
-  auto rc0 = mulhilo(kPhiloxSA, ctr.x);
-  auto rc1 = mulhilo(kPhiloxSB, ctr.z);
-  return uint4(rc1.y ^ ctr.y ^ key.x, rc1.x, rc0.y ^ ctr.w ^ key.y, rc0.x);
-}
-
-
-uint4 multiple_rounds(uint4 ctr, uint2 key, uint rounds) {
-  constexpr uint2 kPhilox10 = {0x9E3779B9, 0xBB67AE85};
-  for(uint round = 0; round < rounds - 1; ++round) {
-    ctr = single_round(ctr, key);
-    key += kPhilox10;
-  }
-}
-
-uint4 rand(long seed, long index) {
-  uint4 ctr = 0;
-  ctr.zw = splitlong(index);
-  return multiple_rounds(ctr, splitlong(seed), 10);
-}
-
-} // namespace philox4
 
 namespace detail {
 
@@ -48,15 +16,48 @@ constexpr float uint32_to_uniform_float(uint32_t value) {
   return static_cast<float>(value & 0x7FFFFFFF) * scale;
 }
 
+inline uint2 splitlong(ulong v) {
+  return uint2(v >> 32, v & 0xffffffff);
+}
+
 } // namespace detail
 
+namespace philox4 {
+
+uint2 mulhilo(uint a, uint b) {
+  auto rc = static_cast<ulong>(a) * b;
+  return detail::splitlong(rc);
+}
+uint4 single_round(uint4 ctr, uint2 key) {
+  constexpr uint kPhiloxSA = 0xD2511F53;
+  constexpr uint kPhiloxSB = 0xCD9E8D57;
+  auto rc0 = mulhilo(kPhiloxSA, ctr.x);
+  auto rc1 = mulhilo(kPhiloxSB, ctr.z);
+  return uint4(rc1.y ^ ctr.y ^ key.x, rc1.x, rc0.y ^ ctr.w ^ key.y, rc0.x);
+}
+
+uint4 multiple_rounds(uint4 ctr, uint2 key, uint rounds) {
+  constexpr uint2 kPhilox10 = {0x9E3779B9, 0xBB67AE85};
+  for (uint round = 0; round < rounds - 1; ++round) {
+    ctr = single_round(ctr, key);
+    key += kPhilox10;
+  }
+}
+
+uint4 rand(long seed, long index) {
+  uint4 ctr = 0;
+  ctr.zw = detail::splitlong(index);
+  return multiple_rounds(ctr, detail::splitlong(seed), 10);
+}
+
+} // namespace philox4
+
 float randn(long seed, long index) {
-   auto value = philox4::rand(seed, index);
-   float u1 = 1.0 - detail::uint32_to_uniform_float(value.x);
-   float u2 = 1.0 - detail::uint32_to_uniform_float(value.y);
-   return ::metal::sqrt(-2.0 * ::metal::log(u1)) * ::metal::cos ( 2.0 * M_PI_F  * u2);
+  auto value = philox4::rand(seed, index);
+  float u1 = 1.0 - detail::uint32_to_uniform_float(value.x);
+  float u2 = 1.0 - detail::uint32_to_uniform_float(value.y);
+  return ::metal::sqrt(-2.0 * ::metal::log(u1)) *
+      ::metal::cos(2.0 * M_PI_F * u2);
 }
 } // namespace metal
 } // namespace c10
-
-

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -151,6 +151,7 @@ for test_name in [
     "test_builtins_round_float_ndigits_neg",
     "test_lgamma",
     "test_erfinv",
+    "test_randint_int64_mod",
     "test_randn_generator",
 ]:
     setattr(MPSBasicTests, test_name, getattr(CommonTemplate, test_name))

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -151,6 +151,7 @@ for test_name in [
     "test_builtins_round_float_ndigits_neg",
     "test_lgamma",
     "test_erfinv",
+    "test_randn_generator",
 ]:
     setattr(MPSBasicTests, test_name, getattr(CommonTemplate, test_name))
 

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -300,7 +300,7 @@ class MetalOverrides(OpOverrides):
         return f"metal::ceil({x})"
 
     @staticmethod
-    def randn(seed, offset) -> str:
+    def randn(seed: CSEVariable, offset: CSEVariable) -> str:
         return f"c10::metal::randn({seed}, {offset})"
 
     @staticmethod

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -300,6 +300,10 @@ class MetalOverrides(OpOverrides):
         return f"metal::ceil({x})"
 
     @staticmethod
+    def rand(seed: CSEVariable, offset: CSEVariable) -> str:
+        return f"c10::metal::rand({seed}, {offset})"
+
+    @staticmethod
     def randn(seed: CSEVariable, offset: CSEVariable) -> str:
         return f"c10::metal::randn({seed}, {offset})"
 

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -300,6 +300,10 @@ class MetalOverrides(OpOverrides):
         return f"metal::ceil({x})"
 
     @staticmethod
+    def randn(seed, offset) -> str:
+        return f"c10::metal::randn({seed}, {offset})"
+
+    @staticmethod
     def round(x: CSEVariable) -> str:
         return f"metal::round({x})"
 
@@ -360,6 +364,7 @@ class MetalKernel(SIMDKernel):
         with code.indent():
             code.splice(
                 """
+            #include <c10/metal/random.h>
             #include <c10/metal/special_math.h>
             #include <c10/metal/utils.h>
             """,

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -308,6 +308,12 @@ class MetalOverrides(OpOverrides):
         return f"c10::metal::randn({seed}, {offset})"
 
     @staticmethod
+    def randint64(
+        seed: CSEVariable, offset: CSEVariable, low: CSEVariable, high: CSEVariable
+    ) -> str:
+        return f"c10::metal::randint64({seed}, {offset}, {low}, {high})"
+
+    @staticmethod
     def round(x: CSEVariable) -> str:
         return f"metal::round({x})"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #145718
* __->__ #145705

Using Philox4 as PRNG

Test plan (other that CI)
Run
```python
mport torch
from torch._inductor.utils import run_and_get_code
from contextlib import nullcontext

def foo(x):
   return x * torch.randn_like(x)

foo_c = torch.compile(foo)

x = torch.ones(100, 100, device="mps")

y = foo_c(x)

print(y.mean().item(), y.std().item())
for i in range(25):
  print(y[i].mean(), y[i].std())
```
And observe that printed values are close to 0 and 1

TODO: Better `randint` algorithm for large ranges

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov