### PR TITLE
setitem node shouldn't be deadcode eliminated

### DIFF
--- a/test/fx/test_dce_pass.py
+++ b/test/fx/test_dce_pass.py
@@ -192,6 +192,33 @@ class TestDCE(TestCase):
         # because it's known to.
         self._run_dce_and_test(TestModule(), expect_dce_changes=False)
 
+    def test_keep_setitem(self):
+        """
+        Fix issue: https://github.com/pytorch/pytorch/issues/145697
+        Test that DCE doesn't remove operator.setitem since it has side effects.
+        """
+
+        class TestModule(torch.nn.Module):
+            def forward(self, a: torch.Tensor) -> torch.Tensor:
+                a[0, 0, 0, 0] *= 2.0
+                return a * 2
+
+        def dce_backend(gm, inputs, **kwargs):
+            import torch._inductor.constant_folding
+
+            torch._inductor.constant_folding.constant_fold(gm)
+            return gm
+
+        x = torch.randn(1, 3, 224, 224)
+        dce_x = x.detach().clone()
+        model = TestModule().eval()
+        dce_mod = torch.compile(copy.deepcopy(model), backend=dce_backend)
+
+        with torch.inference_mode():
+            eager_out = model(x)
+            out = dce_mod(dce_x)
+        torch.testing.assert_close(eager_out, out, atol=1e-5, rtol=1e-5)
+
     def test_impure_nodes_args(self):
         """
         Test that DCE doesn't remove call_function nodes with side effects.

--- a/test/fx/test_dce_pass.py
+++ b/test/fx/test_dce_pass.py
@@ -217,7 +217,7 @@ class TestDCE(TestCase):
         with torch.inference_mode():
             eager_out = model(x)
             out = dce_mod(dce_x)
-        torch.testing.assert_close(eager_out, out, atol=1e-5, rtol=1e-5)
+        self.assertEqual(eager_out, out, atol=1e-5, rtol=1e-5)
 
     def test_impure_nodes_args(self):
         """

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -1,6 +1,7 @@
 # Nodes represent a definition of a value in our graph of operators.
 import builtins
 import inspect
+import operator
 import types
 import warnings
 from collections.abc import Mapping, Sequence
@@ -88,6 +89,7 @@ _side_effectful_functions: set[Callable] = {
     _ops.profiler._record_function_enter_new,
     _ops.profiler._record_function_exit,
     _ops.inductor.accumulate_grad_.default,
+    operator.setitem,
 } | _side_effectful_need_to_be_preserved_pre_dispatch
 if hasattr(_ops.inductor, "resize_storage_bytes_"):
     _side_effectful_functions.add(_ops.inductor.resize_storage_bytes_.default)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145714

**Summary**
Fix issue https://github.com/pytorch/pytorch/issues/145697. The `operator.setitem` has been eliminated as dead code, causing a correctness issue. Mark it as impure in this PR to avoid this side effect.

**TestPlan**
```
python -u -m pytest -s -v test/fx/test_dce_pass.py -k test_keep_setitem
```

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv