### PR TITLE
[ATen][Native][CUDA][SCALED_MM] limit f8f8bf16 rowwise scaled matmul to sm_90

### DIFF
--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -791,7 +791,7 @@ void check_inputs(
     const std::optional<at::Tensor>& bias,
     const at::Tensor& out) {
   auto dprops = at::cuda::getCurrentDeviceProperties();
-  TORCH_CHECK(dprops->major == 9, "f8f8bf16_rowwise is sm_90 specific.");
+  TORCH_CHECK(dprops->major <= 9, "f8f8bf16_rowwise is sm_90 specific.");
 
   TORCH_CHECK(a.is_cuda());
   TORCH_CHECK(a.device() == b.device());

--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -708,13 +708,13 @@ void dispatch_fp8_rowwise_kernel_on_sm(
     at::Tensor out) {
   cudaDeviceProp* properties = at::cuda::getCurrentDeviceProperties();
   const bool sm89 = properties != nullptr && properties->major == 8 && properties->minor == 9;
-  const bool sm90OrLater = properties != nullptr && properties->major >= 9;
-  if (!(sm89 || sm90OrLater)) {
+  const bool sm9x = properties != nullptr && properties->major == 9;
+  if (!(sm89 || sm9x)) {
     TORCH_CHECK(
         false, "Rowwise scaling is not currently supported on your device");
   }
 
-  if (sm90OrLater) {
+  if (sm9x) {
     dispatch_fp8_rowwise_kernel_on_cluster_size_and_transpose<Types...>(XQ, WQ, x_scale, w_scale, bias, out);
   } else {
     f8f8bf16_rowwise_impl_sm89<Types...>(XQ, WQ, x_scale, w_scale, bias, out);
@@ -790,9 +790,6 @@ void check_inputs(
     const at::Tensor& scale_b,
     const std::optional<at::Tensor>& bias,
     const at::Tensor& out) {
-  auto dprops = at::cuda::getCurrentDeviceProperties();
-  TORCH_CHECK(dprops->major <= 9, "f8f8bf16_rowwise is sm_90 specific.");
-
   TORCH_CHECK(a.is_cuda());
   TORCH_CHECK(a.device() == b.device());
   TORCH_CHECK(scale_a.device() == a.device());

--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -790,6 +790,9 @@ void check_inputs(
     const at::Tensor& scale_b,
     const std::optional<at::Tensor>& bias,
     const at::Tensor& out) {
+  auto dprops = at::cuda::getCurrentDeviceProperties();
+  TORCH_CHECK(dprops->major == 9, "f8f8bf16_rowwise is sm_90 specific.");
+
   TORCH_CHECK(a.is_cuda());
   TORCH_CHECK(a.device() == b.device());
   TORCH_CHECK(scale_a.device() == a.device());

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -662,10 +662,11 @@ class TestFP8MatmulCuda(TestCase):
             )
 
         if _IS_SM10X:
-            # Note re.compile is used, not re.escape. This is to accomodate fn vs fnuz type message.
             with self.assertRaisesRegex(
                 RuntimeError,
-                r"f8f8bf16_rowwise is not implemented on sm_100 or later.",
+                re.escape(
+                    "f8f8bf16_rowwise is not implemented on sm_100 or later.",
+                ),
             ):
                 torch._scaled_mm(
                     x_fp8,

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -665,7 +665,7 @@ class TestFP8MatmulCuda(TestCase):
             with self.assertRaisesRegex(
                 RuntimeError,
                 re.escape(
-                    "f8f8bf16_rowwise is not implemented on sm_100 or later.",
+                    "Rowwise scaling is not currently supported on your device",
                 ),
             ):
                 torch._scaled_mm(

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -661,33 +661,18 @@ class TestFP8MatmulCuda(TestCase):
                 out_dtype=torch.bfloat16,
             )
 
-        if _IS_SM10X:
-            with self.assertRaisesRegex(
-                RuntimeError,
-                re.escape(
-                    "Rowwise scaling is not currently supported on your device",
-                ),
-            ):
-                torch._scaled_mm(
-                    x_fp8,
-                    y_fp8.to(e5m2_type),
-                    scale_a=torch.ones((M, 1), device="cuda"),
-                    scale_b=torch.ones((1, N), device="cuda"),
-                    out_dtype=torch.bfloat16,
-                )
-        else:
-            # Note re.compile is used, not re.escape. This is to accomodate fn vs fnuz type message.
-            with self.assertRaisesRegex(
-                RuntimeError,
-                r"Expected b\.dtype\(\) == at::kFloat8_e4m3fnu?z? to be true, but got false\.",
-            ):
-                torch._scaled_mm(
-                    x_fp8,
-                    y_fp8.to(e5m2_type),
-                    scale_a=torch.ones((M, 1), device="cuda"),
-                    scale_b=torch.ones((1, N), device="cuda"),
-                    out_dtype=torch.bfloat16,
-                )
+        # Note re.compile is used, not re.escape. This is to accomodate fn vs fnuz type message.
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Expected b\.dtype\(\) == at::kFloat8_e4m3fnu?z? to be true, but got false\.",
+        ):
+            torch._scaled_mm(
+                x_fp8,
+                y_fp8.to(e5m2_type),
+                scale_a=torch.ones((M, 1), device="cuda"),
+                scale_b=torch.ones((1, N), device="cuda"),
+                out_dtype=torch.bfloat16,
+            )
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
     @unittest.skipIf(not _IS_SM9X, "rowwise implementation is currently sm90 specific")

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -43,11 +43,9 @@ from torch.testing._internal.common_utils import (
 
 _IS_SM8X = False
 _IS_SM9X = False
-_IS_SM10X = False
 if TEST_CUDA:
     _IS_SM8X = torch.cuda.get_device_capability(0)[0] == 8
     _IS_SM9X = torch.cuda.get_device_capability(0)[0] == 9
-    _IS_SM10X = torch.cuda.get_device_capability(0)[0] == 10
 
 # Protects against includes accidentally setting the default dtype
 assert torch.get_default_dtype() is torch.float32


### PR DESCRIPTION
The CUTLASS-based kernel for f8f8bf16 rowwise scaled matmul is specific to Hopper devices only. It is not re-usable on newer devices without modifications. This PR adds a guard for this matmul to be sm_90 specific. Once the kernel is there, the guard may be removed.

cc @ptrblck @msaroufim @eqy @yanbing-j @vkuzo @albanD @kadeng @penguinwu @manuelcandales @SherlockNoMad @angelayi