### PR TITLE
add pt2 callbacks for backward pass and prevent duplicate callbacks

### DIFF
--- a/test/dynamo/test_callback.py
+++ b/test/dynamo/test_callback.py
@@ -1,0 +1,67 @@
+# Owner(s): ["module: dynamo"]
+
+from unittest.mock import Mock
+
+from torch._dynamo.callback import callback_handler
+from torch._dynamo.test_case import run_tests, TestCase
+
+
+class CallbackTests(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._on_compile_start = Mock()
+        self._on_compile_end = Mock()
+        callback_handler.register_start_callback(self._on_compile_start)
+        callback_handler.register_end_callback(self._on_compile_end)
+
+    def tearDown(self) -> None:
+        return super().tearDown()
+        callback_handler.clear()
+
+    def test_callbacks_without_duplicate_prevention(self) -> None:
+        callback_handler._CompilationCallbackHandler__prevent_duplicate_callbacks = (
+            False
+        )
+
+        with callback_handler.install_callbacks(), callback_handler.install_callbacks():
+            self.assertEqual(self._on_compile_start.call_count, 2)
+        self.assertEqual(self._on_compile_end.call_count, 2)
+
+    def test_callbacks_with_duplicate_prevention(self) -> None:
+        callback_handler._CompilationCallbackHandler__prevent_duplicate_callbacks = True
+
+        with callback_handler.install_callbacks(), callback_handler.install_callbacks():
+            self._on_compile_start.assert_called_once()
+        self._on_compile_end.assert_called_once()
+
+    def test_counter(self) -> None:
+        callback_handler._CompilationCallbackHandler__prevent_duplicate_callbacks = True
+
+        with callback_handler.install_callbacks():
+            self.assertEqual(
+                callback_handler._CompilationCallbackHandler__pending_callbacks_counter,
+                1,
+            )
+        self.assertEqual(
+            callback_handler._CompilationCallbackHandler__pending_callbacks_counter, 0
+        )
+
+    def test_counter_assertion(self) -> None:
+        callback_handler._CompilationCallbackHandler__prevent_duplicate_callbacks = True
+        callback_handler._CompilationCallbackHandler__pending_callbacks_counter -= 1
+
+        with self.assertRaises(
+            AssertionError
+        ) as e, callback_handler.install_callbacks():
+            pass
+
+        self.assertIn(
+            "Pending callbacks counter cannot become negative.",
+            str(e.exception),
+        )
+
+        callback_handler._CompilationCallbackHandler__pending_callbacks_counter += 1
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -222,6 +222,7 @@ S390X_TESTLIST = [
     "dynamo/test_backward_higher_order_ops",
     "dynamo/test_base_output",
     "dynamo/test_bytecode_utils",
+    "dynamo/test_callback",
     "dynamo/test_compile",
     "dynamo/test_comptime",
     "dynamo/test_config",

--- a/torch/_dynamo/callback.py
+++ b/torch/_dynamo/callback.py
@@ -1,13 +1,24 @@
+import threading
 from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass, field  # noqa: F811
-from typing import Any, Callable
+from typing import Any, Callable, Optional
+
+from torch._utils_internal import justknobs_check
 
 
 @dataclass
 class CompilationCallbackHandler:
     start_callbacks: list[Callable[[], None]] = field(default_factory=list)
     end_callbacks: list[Callable[[], None]] = field(default_factory=list)
+
+    __prevent_duplicate_callbacks: Optional[bool] = field(
+        default=None, init=False, repr=False
+    )
+    __pending_callbacks_counter: int = field(default=0, init=False, repr=False)
+    __pending_callbacks_counter_lock: threading.Lock = field(
+        default_factory=threading.Lock, init=False, repr=False
+    )
 
     def register_start_callback(
         self, callback: Callable[[], None]
@@ -63,16 +74,40 @@ class CompilationCallbackHandler:
         for callback in self.end_callbacks:
             callback()
 
+    @property
+    def prevent_duplicate_callbacks(self) -> bool:
+        if self.__prevent_duplicate_callbacks is None:
+            self.__prevent_duplicate_callbacks = justknobs_check(
+                "pytorch/dynamo:prevent_duplicate_callbacks"
+            )
+        return self.__prevent_duplicate_callbacks
+
     @contextmanager
     def install_callbacks(self) -> Generator[None, Any, Any]:
         """
         Context manager to install the callbacks and run them when the context is exited.
         """
-        try:
-            self.run_start_callbacks()
-            yield
-        finally:
-            self.run_end_callbacks()
+        if self.prevent_duplicate_callbacks:
+            try:
+                with self.__pending_callbacks_counter_lock:
+                    if self.__pending_callbacks_counter == 0:
+                        self.run_start_callbacks()
+                    self.__pending_callbacks_counter += 1
+                yield
+            finally:
+                with self.__pending_callbacks_counter_lock:
+                    assert (
+                        self.__pending_callbacks_counter > 0
+                    ), "Pending callbacks counter cannot become negative."
+                    if self.__pending_callbacks_counter == 1:
+                        self.run_end_callbacks()
+                    self.__pending_callbacks_counter -= 1
+        else:
+            try:
+                self.run_start_callbacks()
+                yield
+            finally:
+                self.run_end_callbacks()
 
     def clear(self) -> None:
         """

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -610,6 +610,10 @@ def compile_fx_inner(
         # the counter here because we may dropped into compile_fx directly
         # from lazy backwards compilation.
         stack.enter_context(_WaitCounter("pytorch.wait_counter.dynamo_compile").guard())
+
+        if torch._dynamo.callback_handler.prevent_duplicate_callbacks:
+            stack.enter_context(torch._dynamo.callback_handler.install_callbacks())
+
         stack.enter_context(with_fresh_cache_if_config())
         stack.enter_context(DebugContext())
         CompileEventLogger.pt2_compile(


### PR DESCRIPTION
Summary: This change adds callbacks for lazy backwards compilation while preventing duplicate callbacks to be fired.

Differential Revision: D68577593




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov