### PR TITLE
[bug] handle case when remote peer closes connection

### DIFF
--- a/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
@@ -123,22 +123,21 @@ class UvTcpSocket : public UvHandle {
         C10D_WARNING("Error processing client message: {}", ex.what());
         uv_socket->close();
       }
-      return;
+    } else if (nread <= 0) {
+      // Handle error and EOF cases
+      if (nread < 0) {
+        C10D_DEBUG(
+            "Read callback failed. code:{} name:{} desc:{}",
+            nread,
+            uv_err_name(nread),
+            uv_strerror(nread));
+      } else {
+        C10D_DEBUG("Remote peer closed the connection.");
+      }
+      uv_socket->close();
+      // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
+      free(buf->base);
     }
-
-    // Handle error and EOF cases
-    if (nread < 0) {
-      C10D_DEBUG(
-          "Read callback failed. code:{} name:{} desc:{}",
-          nread,
-          uv_err_name(nread),
-          uv_strerror(nread));
-    } else {
-      C10D_DEBUG("Remote peer closed the connection.");
-    }
-    uv_socket->close();
-    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
-    free(buf->base);
   }
 
  public:

--- a/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
@@ -123,7 +123,7 @@ class UvTcpSocket : public UvHandle {
         C10D_WARNING("Error processing client message: {}", ex.what());
         uv_socket->close();
       }
-    } else if (nread <= 0) {
+    } else {
       // Handle error and EOF cases
       if (nread < 0) {
         C10D_DEBUG(

--- a/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
@@ -116,17 +116,6 @@ class UvTcpSocket : public UvHandle {
       const uv_buf_t* buf) {
     auto uv_socket = UvTcpSocket::borrow(client);
 
-    if (nread < 0) {
-      C10D_DEBUG(
-          "Read callback failed. code:{} name:{} desc:{}",
-          nread,
-          uv_err_name(nread),
-          uv_strerror(nread));
-      uv_socket->close();
-      // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
-      free(buf->base);
-      return;
-    }
     if (nread > 0) {
       try {
         uv_socket->processBuf(buf, nread);
@@ -134,7 +123,22 @@ class UvTcpSocket : public UvHandle {
         C10D_WARNING("Error processing client message: {}", ex.what());
         uv_socket->close();
       }
+      return;
     }
+
+    // Handle error and EOF cases
+    if (nread < 0) {
+      C10D_DEBUG(
+          "Read callback failed. code:{} name:{} desc:{}",
+          nread,
+          uv_err_name(nread),
+          uv_strerror(nread));
+    } else {
+      C10D_DEBUG("Remote peer closed the connection.");
+    }
+    uv_socket->close();
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
+    free(buf->base);
   }
 
  public:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #145759
* __->__ #145757
* #145756

Summary:
In the case where remote peer closes the connection, nread returns 0. In
this case, we still want to free up the allocated buffer.
Also, reorder the if so that the likely success cases (nread > 0) is at
the top of the function with an early return.

Test Plan:
unit tests

Differential Revision: [D68733192](https://our.internmc.facebook.com/intern/diff/D68733192)

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k