### PR TITLE
Set -DPy_LIMITED_API flag for py_limited_api=True extensions

### DIFF
--- a/test/cpp_extensions/python_agnostic_extension/python_agnostic/csrc/ultra_norm.cu
+++ b/test/cpp_extensions/python_agnostic_extension/python_agnostic/csrc/ultra_norm.cu
@@ -2,7 +2,7 @@
 #include <ATen/ops/cat_cuda_dispatch.h>
 #include <ATen/ops/norm_cuda_dispatch.h>
 #include <ATen/ops/unsqueeze.h>
-#include <torch/extension.h>
+#include <torch/library.h>
 
 at::Tensor ultra_norm(at::TensorList inputs) {
     auto res = at::native::foreach_tensor_norm_cuda(inputs);

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -573,6 +573,14 @@ class BuildExtension(build_ext):
                         extension.extra_compile_args[ext] = []
 
             self._add_compile_flag(extension, '-DTORCH_API_INCLUDE_EXTENSION_H')
+
+            if extension.py_limited_api:
+                 # compile any extension that has passed in py_limited_api to the
+                 # Extension constructor with the Py_LIMITED_API flag set to our
+                 # min supported CPython version, here, 3.9.
+                 # See https://docs.python.org/3/c-api/stable.html#c.Py_LIMITED_API
+                self._add_compile_flag(extension, '-DPy_LIMITED_API=0x03090000')
+
             # See note [Pybind11 ABI constants]
             for name in ["COMPILER_TYPE", "STDLIB", "BUILD_ABI"]:
                 val = getattr(torch._C, f"_PYBIND11_{name}")

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -289,6 +289,8 @@ PLAT_TO_VCVARS = {
     'win-amd64' : 'x86_amd64',
 }
 
+PY3_9_HEXCODE = "0x03090000"
+
 def get_cxx_compiler():
     if IS_WINDOWS:
         compiler = os.environ.get('CXX', 'cl')
@@ -575,17 +577,20 @@ class BuildExtension(build_ext):
             self._add_compile_flag(extension, '-DTORCH_API_INCLUDE_EXTENSION_H')
 
             if extension.py_limited_api:
-                 # compile any extension that has passed in py_limited_api to the
-                 # Extension constructor with the Py_LIMITED_API flag set to our
-                 # min supported CPython version, here, 3.9.
-                 # See https://docs.python.org/3/c-api/stable.html#c.Py_LIMITED_API
-                self._add_compile_flag(extension, '-DPy_LIMITED_API=0x03090000')
-
-            # See note [Pybind11 ABI constants]
-            for name in ["COMPILER_TYPE", "STDLIB", "BUILD_ABI"]:
-                val = getattr(torch._C, f"_PYBIND11_{name}")
-                if val is not None and not IS_WINDOWS:
-                    self._add_compile_flag(extension, f'-DPYBIND11_{name}="{val}"')
+                # compile any extension that has passed in py_limited_api to the
+                # Extension constructor with the Py_LIMITED_API flag set to our
+                # min supported CPython version, here, 3.9.
+                # See https://docs.python.org/3/c-api/stable.html#c.Py_LIMITED_API
+                self._add_compile_flag(extension, f'-DPy_LIMITED_API={PY3_9_HEXCODE}')
+            else:
+                # pybind11 is not CPython API stable so don't add these flags used when
+                # compiling pybind11 when pybind11 is not even used. otherwise, the build
+                # logs are confusing.
+                # See note [Pybind11 ABI constants]
+                for name in ["COMPILER_TYPE", "STDLIB", "BUILD_ABI"]:
+                    val = getattr(torch._C, f"_PYBIND11_{name}")
+                    if val is not None and not IS_WINDOWS:
+                        self._add_compile_flag(extension, f'-DPYBIND11_{name}="{val}"')
             self._define_torch_extension_name(extension)
             self._add_gnu_cpp_abi_flag(extension)
 
@@ -980,7 +985,7 @@ def CppExtension(name, sources, *args, **kwargs):
     constructor. Full list arguments can be found at
     https://setuptools.pypa.io/en/latest/userguide/ext_modules.html#extension-api-reference
 
-    .. note::
+    .. warning::
         The PyTorch python API (as provided in libtorch_python) cannot be built
         with the flag ``py_limited_api=True``.  When this flag is passed, it is
         the user's responsibility in their library to not use APIs from
@@ -988,6 +993,12 @@ def CppExtension(name, sources, *args, **kwargs):
         APIs from libtorch (aten objects, operators and the dispatcher). For
         example, to give access to custom ops from python, the library should
         register the ops through the dispatcher.
+
+        Contrary to CPython setuptools, who does not define -DPy_LIMITED_API
+        as a compile flag when py_limited_api is specified as an option for
+        the "bdist_wheel" command in ``setup``, PyTorch does! We will specify
+        -DPy_LIMITED_API=<hexcode of the minimum supported Python version> to best
+        enforce consistency, safety, and sanity in order to encourage best practices.
 
     Example:
         >>> # xdoctest: +SKIP
@@ -1044,7 +1055,7 @@ def CUDAExtension(name, sources, *args, **kwargs):
     constructor. Full list arguments can be found at
     https://setuptools.pypa.io/en/latest/userguide/ext_modules.html#extension-api-reference
 
-    .. note::
+    .. warning::
         The PyTorch python API (as provided in libtorch_python) cannot be built
         with the flag ``py_limited_api=True``.  When this flag is passed, it is
         the user's responsibility in their library to not use APIs from
@@ -1052,6 +1063,12 @@ def CUDAExtension(name, sources, *args, **kwargs):
         APIs from libtorch (aten objects, operators and the dispatcher). For
         example, to give access to custom ops from python, the library should
         register the ops through the dispatcher.
+
+        Contray to CPython setuptools, who does not define -DPy_LIMITED_API
+        as a compile flag when py_limited_api is specified as an option for
+        the "bdist_wheel" command in ``setup``, PyTorch does! We will specify
+        -DPy_LIMITED_API=<hexcode of the minimum supported Python version> to best
+        enforce consistency, safety, and sanity in order to encourage best practices.
 
     Example:
         >>> # xdoctest: +SKIP
@@ -1416,10 +1433,6 @@ def _get_pybind11_abi_build_flags():
     # that can cause a hard to debug segfaults.
     # For PyTorch extensions we want to relax those restrictions and pass compiler, stdlib and abi properties
     # captured during PyTorch native library compilation in torch/csrc/Module.cpp
-    #
-    # Note that these flags don't have side effects even if the PyTorch extension does not
-    # require nor use pybind, so we do not do anything differently for them in the py_limited_api
-    # case.
 
     abi_cflags = []
     for pname in ["COMPILER_TYPE", "STDLIB", "BUILD_ABI"]:

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -289,7 +289,7 @@ PLAT_TO_VCVARS = {
     'win-amd64' : 'x86_amd64',
 }
 
-PY3_9_HEXCODE = "0x03090000"
+min_supported_cpython = "0x03090000"  # Python 3.9 hexcode
 
 def get_cxx_compiler():
     if IS_WINDOWS:
@@ -579,9 +579,9 @@ class BuildExtension(build_ext):
             if extension.py_limited_api:
                 # compile any extension that has passed in py_limited_api to the
                 # Extension constructor with the Py_LIMITED_API flag set to our
-                # min supported CPython version, here, 3.9.
+                # min supported CPython version.
                 # See https://docs.python.org/3/c-api/stable.html#c.Py_LIMITED_API
-                self._add_compile_flag(extension, f'-DPy_LIMITED_API={PY3_9_HEXCODE}')
+                self._add_compile_flag(extension, f'-DPy_LIMITED_API={min_supported_cpython}')
             else:
                 # pybind11 is not CPython API stable so don't add these flags used when
                 # compiling pybind11 when pybind11 is not even used. otherwise, the build
@@ -997,8 +997,10 @@ def CppExtension(name, sources, *args, **kwargs):
         Contrary to CPython setuptools, who does not define -DPy_LIMITED_API
         as a compile flag when py_limited_api is specified as an option for
         the "bdist_wheel" command in ``setup``, PyTorch does! We will specify
-        -DPy_LIMITED_API=<hexcode of the minimum supported Python version> to best
-        enforce consistency, safety, and sanity in order to encourage best practices.
+        -DPy_LIMITED_API=min_supported_cpython to best enforce consistency,
+        safety, and sanity in order to encourage best practices. To target a
+        different version, set min_supported_cpython to the hexcode of the
+        CPython version of choice.
 
     Example:
         >>> # xdoctest: +SKIP
@@ -1064,11 +1066,13 @@ def CUDAExtension(name, sources, *args, **kwargs):
         example, to give access to custom ops from python, the library should
         register the ops through the dispatcher.
 
-        Contray to CPython setuptools, who does not define -DPy_LIMITED_API
+        Contrary to CPython setuptools, who does not define -DPy_LIMITED_API
         as a compile flag when py_limited_api is specified as an option for
         the "bdist_wheel" command in ``setup``, PyTorch does! We will specify
-        -DPy_LIMITED_API=<hexcode of the minimum supported Python version> to best
-        enforce consistency, safety, and sanity in order to encourage best practices.
+        -DPy_LIMITED_API=min_supported_cpython to best enforce consistency,
+        safety, and sanity in order to encourage best practices. To target a
+        different version, set min_supported_cpython to the hexcode of the
+        CPython version of choice.
 
     Example:
         >>> # xdoctest: +SKIP


### PR DESCRIPTION
This could be BC breaking, because there was a period of time when we use py_limited_api=True but don't enforce the flag, and now that we will start enforcing the flag, people's custom extensions may fail to build.

This is strictly still better behavior, as it is sketchy to claim CPython agnosticism without the flag, but calling this out as potential people yelling at us. Ways to mitigate this risk + reasons this may not be too big a deal:
- People haven't known about py_limited_api for extensions much due to lack of docs from python so usage is low right now
- My current tutorial is in store to make new users of py_limited_api pass this flag, so it'd be a noop for them.

Test plan:
* Locally i'm confident as I tried rebuilding ao with this change and it reliably failed (cuz importing torch/extension.h is a nono)
* Unit test wise, the normal python_agnostic one I added should work

______
## BC-breaking note - C++ Extensions `py_limited_api=True` is now built with `-DPy_LIMITED_API`

We formally began respecting the `py_limited_api=True` kwarg in 2.6 and stopped linking libtorch_python.so when the flag was specified, as libtorch_python.so does not guarantee using APIs from from the stable Python limited API. In 2.7, we go further by specifying the `-DPy_LIMITED_API` flag which will enforce that the extension is buildable with the limited API. As a result of this enforcement, **custom extensions that set `py_limited_api=True` but do not abide by the limited API may fail to build**. For an example, see #152243.

This is strictly better behavior as it is sketchy to claim CPython agnosticism without enforcing with the flag. If you run into this issue, please ensure that the extension you are building does not use any APIs which are outside of the Python limited API, e.g., `pybind`.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #145784
* __->__ #145764

