### PR TITLE
relax assertion to warning for unbacked binding names

### DIFF
--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -1892,10 +1892,16 @@ class GraphModuleDeserializer(metaclass=Final):
                 # these are pending fresh unbacked symbols, so update shape env
                 if symbol_is_type(u, SymT.UNBACKED_FLOAT):
                     suffix = str(next(self.shape_env.unbacked_symfloat_counter))
-                    assert u.name.endswith(suffix)
+                    if not u.name.endswith(suffix):
+                        log.warning(
+                            "Expected symbol %s to end with suffix %s", u.name, suffix
+                        )
                 elif symbol_is_type(u, SymT.UNBACKED_INT):
                     suffix = str(next(self.shape_env.unbacked_symint_counter))
-                    assert u.name.endswith(suffix)
+                    if not u.name.endswith(suffix):
+                        log.warning(
+                            "Expected symbol %s to end with suffix %s", u.name, suffix
+                        )
                 else:
                     raise AssertionError(f"Illegal unbacked symbol {u}")
                 self.shape_env.pending_fresh_unbacked_symbols.append(u)


### PR DESCRIPTION
Summary:
Quick fix following up on https://github.com/pytorch/pytorch/pull/144894 to unblock internal tests.

Will keep investigating a more principled fix.

Test Plan: Failures in T213563826 now pass

Differential Revision: D68731710
