### PR TITLE
[Async-TP] Port _fused_all_gather_matmul_native to cpp to reduce launching overhead

### DIFF
--- a/torch/csrc/distributed/c10d/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/SymmetricMemory.cpp
@@ -248,6 +248,9 @@ TORCH_LIBRARY_FRAGMENT(symm_mem, m) {
       "stream_write_value32_(Tensor(a!) input, int offset, int val) -> Tensor(a!)");
   m.def(
       "memset32_(Tensor(a!) input, int offset, int val, int count) -> Tensor(a!)");
+
+  m.def(
+      "_all_gather_mm(Tensor a_shard, Tensor b, str group_name) -> (Tensor, Tensor)");
 }
 
 TORCH_LIBRARY_IMPL(symm_mem, Meta, m) {

--- a/torch/csrc/distributed/c10d/cuda/AsyncMM.cu
+++ b/torch/csrc/distributed/c10d/cuda/AsyncMM.cu
@@ -5,7 +5,7 @@
 #include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
 #include <c10/cuda/CUDAGuard.h>
 
-#if false && !defined(USE_ROCM) && !defined(_WIN32) && defined(CUDA_VERSION) && \
+#if !defined(USE_ROCM) && !defined(_WIN32) && defined(CUDA_VERSION) && \
     CUDA_VERSION >= 12000
 #define BUILD_ASYNC_MM_KERNEL
 #endif
@@ -272,7 +272,7 @@ at::Tensor async_input_mm_out(
 #if defined(BUILD_ASYNC_MM_KERNEL)
   DISPATCH_LAYOUT_B(is_b_row_major, [&]() {
     // TODO(yifu): tuning
-    async_input_mm_impl<LayoutB, Shape<_128, _256, _64>, Shape<_2, _1, _1>>(
+    async_input_mm_impl<LayoutB, Shape<_128, _128, _64>, Shape<_1, _2, _1>>(
         a, b, a_chunk_signals, a_chunk_pivot, out);
   });
 #else


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #145798
* #145797
* #145796
* #145795
* __->__ #145794

`_fused_all_gather_matmul_native` schedules multiple tasks (e.g., kernel, copy engine transfers, and stream_write_value32_) onto the GPU. Previously, `fused_all_gather_matmul_native` was implemented in Python, and issuing most of these tasks incurred dispatcher overhead. When the problem size is small, the CPU overhead can exceed the GPU’s execution time. While this may be acceptable in workloads where the CPU runs ahead of the GPU, it still isn’t ideal.

This PR reduces CPU overhead by porting `_fused_all_gather_matmul_native` to C++. Specifically, it eliminates dispatcher overhead for:
- `aten.split` (calling `aten.narrow` × `world_size` times)
- `symm_mem::stream_write_value32_` × `world_size` times

<img width="842" alt="image" src="https://github.com/user-attachments/assets/176ebc89-a2e1-4c07-b340-c2d4422def09" />
<img width="455" alt="image" src="https://github.com/user-attachments/assets/3768f0c1-876f-4c66-bd22-89aa80d0889c" />

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o