### PR TITLE
Remove unneeded CUDA logic from _create_build_env

### DIFF
--- a/tools/build_pytorch_libs.py
+++ b/tools/build_pytorch_libs.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import platform
 import subprocess
-from glob import glob
 from pathlib import Path
 
 from .setup_helpers.cmake import CMake, USE_NINJA

--- a/tools/build_pytorch_libs.py
+++ b/tools/build_pytorch_libs.py
@@ -67,15 +67,6 @@ def _create_build_env() -> dict[str, str]:
     # you should NEVER add something to this list. It is bad practice to
     # have cmake read the environment
     my_env = os.environ.copy()
-    if (
-        "CUDA_HOME" in my_env
-    ):  # Keep CUDA_HOME. This env variable is still used in other part.
-        my_env["CUDA_BIN_PATH"] = my_env["CUDA_HOME"]
-    elif IS_WINDOWS:  # we should eventually make this as part of FindCUDA.
-        cuda_win = glob("C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v*.*")
-        if len(cuda_win) > 0:
-            my_env["CUDA_BIN_PATH"] = cuda_win[0]
-
     if IS_WINDOWS and USE_NINJA:
         # When using Ninja under Windows, the gcc toolchain will be chosen as
         # default. But it should be set to MSVC as the user's first choice.


### PR DESCRIPTION
Because FindCUDAToolkit.cmake has that logic.
