### PR TITLE
[dynamo][builtin-skipfiles-cleanup] Remove posixpath

### DIFF
--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -16,14 +16,12 @@ import logging
 import multiprocessing
 import operator
 import os
-import posixpath
 import random
 import re
 import selectors
 import sys
 import tempfile
 import threading
-import tokenize
 import traceback
 import types
 import typing
@@ -3166,12 +3164,10 @@ BUILTIN_SKIPLIST = (
     logging,
     multiprocessing,
     operator,
-    posixpath,
     random,
     selectors,
     tempfile,
     threading,
-    tokenize,
     traceback,
     types,
     typing,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #145559
* #145804
* __->__ #145828
* #145826
* #145753
* #145744



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames