### PR TITLE
s390x: disable test_model_exports_to_core_aten.py test

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -436,7 +436,6 @@ S390X_TESTLIST = [
     "test_mkldnn_verbose",
     "test_mkl_verbose",
     "test_mobile_optimizer",
-    "test_model_exports_to_core_aten",
     "test_module_tracker",
     "test_monitor",
     "test_namedtuple_return_api",


### PR DESCRIPTION
It often gets killed by OOM.
Disable it while investigating.
