### PR TITLE
s390x ci: ensure CI starts correctly if token pipe is not removed

### DIFF
--- a/.github/scripts/s390x-ci/self-hosted-builder/actions-runner@.service
+++ b/.github/scripts/s390x-ci/self-hosted-builder/actions-runner@.service
@@ -8,8 +8,8 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=always
 ExecStartPre=-/usr/bin/docker rm --force actions-runner.%i
-ExecStartPre=-/usr/local/bin/gh_token_generator.sh /etc/actions-runner/%i/appid.env /etc/actions-runner/%i/installid.env /etc/actions-runner/%i/key_private.pem /etc/actions-runner/%i/ghtoken.env
-ExecStartPre=-/usr/local/bin/gh_cat_token.sh /etc/actions-runner/%i/ghtoken.env /etc/actions-runner/%i/ghtoken.socket
+ExecStartPre=/usr/local/bin/gh_token_generator.sh /etc/actions-runner/%i/appid.env /etc/actions-runner/%i/installid.env /etc/actions-runner/%i/key_private.pem /etc/actions-runner/%i/ghtoken.env
+ExecStartPre=/usr/local/bin/gh_cat_token.sh /etc/actions-runner/%i/ghtoken.env /etc/actions-runner/%i/ghtoken.socket
 ExecStart=/usr/bin/docker run \
               --env-file=/etc/actions-runner/%i/env \
               --volume /etc/actions-runner/%i/ghtoken.socket:/run/runner_secret \
@@ -19,10 +19,10 @@ ExecStart=/usr/bin/docker run \
               --rm \
               --privileged \
               iiilinuxibmcom/actions-runner.%i
-ExecStop=/bin/sh -c "docker exec actions-runner.%i kill -INT -- -1"
-ExecStop=/bin/sh -c "docker wait actions-runner.%i"
-ExecStop=/bin/sh -c "docker rm actions-runner.%i"
-ExecStop=/usr/bin/env rm -f /etc/actions-runner/%i/ghtoken.env /etc/actions-runner/%i/ghtoken.socket
+ExecStop=-/bin/sh -c "docker exec actions-runner.%i kill -INT -- -1"
+ExecStop=-/bin/sh -c "docker wait actions-runner.%i"
+ExecStop=-/bin/sh -c "docker rm actions-runner.%i"
+ExecStop=-/usr/bin/env rm -f /etc/actions-runner/%i/ghtoken.env /etc/actions-runner/%i/ghtoken.socket
 
 [Install]
 WantedBy=multi-user.target

--- a/.github/scripts/s390x-ci/self-hosted-builder/helpers/gh_cat_token.sh
+++ b/.github/scripts/s390x-ci/self-hosted-builder/helpers/gh_cat_token.sh
@@ -3,5 +3,6 @@
 TOKEN_FILE=$1
 TOKEN_PIPE=$2
 
+rm "${TOKEN_PIPE}" 2>/dev/null ||:
 mkfifo "${TOKEN_PIPE}"
 cat "${TOKEN_FILE}" > "${TOKEN_PIPE}" &


### PR DESCRIPTION
Mark stop actions as "may fail".
Container is expected to stop on it's own in normal case.

Remove "may fail" mark from token generation steps.