### PR TITLE
[OSS] Add kwargs to fsspec reader/writer

### DIFF
--- a/torch/distributed/checkpoint/_fsspec_filesystem.py
+++ b/torch/distributed/checkpoint/_fsspec_filesystem.py
@@ -58,8 +58,10 @@ class FileSystem(FileSystemBase):
     ) -> Union[str, os.PathLike]:
         return os.path.join(path, suffix)
 
-    def init_path(self, path: Union[str, os.PathLike]) -> Union[str, os.PathLike]:
-        self.fs, _ = url_to_fs(path)
+    def init_path(
+        self, path: Union[str, os.PathLike], **kwargs
+    ) -> Union[str, os.PathLike]:
+        self.fs, _ = url_to_fs(path, **kwargs)
         return path
 
     def rename(
@@ -113,6 +115,7 @@ class FsspecWriter(FileSystemWriter):
         per_thread_copy_ahead: int = 10_000_000,
         overwrite: bool = True,
         _extensions: Optional[Sequence[StreamTransformExtension]] = None,
+        **kwargs,
     ) -> None:
         """
         Initialize the writer pointing to `path`.
@@ -138,7 +141,7 @@ class FsspecWriter(FileSystemWriter):
             _extensions=_extensions,
         )
         self.fs = FileSystem()
-        self.path = self.fs.init_path(path)
+        self.path = self.fs.init_path(path, **kwargs)
 
     @classmethod
     def validate_checkpoint_id(cls, checkpoint_id: Union[str, os.PathLike]) -> bool:
@@ -146,10 +149,10 @@ class FsspecWriter(FileSystemWriter):
 
 
 class FsspecReader(FileSystemReader):
-    def __init__(self, path: Union[str, os.PathLike]) -> None:
+    def __init__(self, path: Union[str, os.PathLike], **kwargs) -> None:
         super().__init__(path)
         self.fs = FileSystem()
-        self.path = self.fs.init_path(path)
+        self.path = self.fs.init_path(path, **kwargs)
 
     @classmethod
     def validate_checkpoint_id(cls, checkpoint_id: Union[str, os.PathLike]) -> bool:


### PR DESCRIPTION
Summary: Add kwargs to fsspec reader/writer. This will be used when reading/writing from huggingface because it needs a token to access the repositories

Test Plan: https://fburl.com/anp/agkrlas1 ability to read write to hf with fsspec

Differential Revision: D68738777




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn @ekr0