### PR TITLE
[async-TP] Fix scheduling in matmul+reduce-scatter for 2 ranks

### DIFF
--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -429,6 +429,10 @@ def _pipelined_produce_and_all2all(
             # chunk_producer after all peers have finished reading from it.
             symm_mem.barrier(channel=step % 2)
 
+    # If the sleep wasn't issued in the above loop, do it now.
+    if group_size == 2:
+        torch.cuda._sleep(100)
+
     chunk_producer(rank, out_chunks[rank])
     torch.cuda.current_stream().wait_stream(backend_stream)
     symm_mem.barrier(channel=0)


### PR DESCRIPTION
There's a sleep that is issued in order to "nudge" CUDA to do the right scheduling decision, but this is issued on iteration number 2. However, when the world size is 2, we never reach that iteration, which led to a suboptimal scheduling.


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o