### PR TITLE
[BE] Include CheckFunctionExists in `FindBLAS.cmake`

### DIFF
--- a/cmake/Modules/FindBLAS.cmake
+++ b/cmake/Modules/FindBLAS.cmake
@@ -25,6 +25,7 @@ SET(WITH_BLAS "" CACHE STRING "Blas type [accelerate/acml/atlas/blis/generic/got
 # Old FindBlas
 INCLUDE(CheckCSourceRuns)
 INCLUDE(CheckFortranFunctionExists)
+INCLUDE(CheckFunctionExists)
 
 MACRO(Check_Fortran_Libraries LIBRARIES _prefix _name _flags _list)
   # This macro checks for the existence of the combination of fortran libraries


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #145850
* __->__ #145849

It's used in the script, so it must be included