### PR TITLE
[c10d][UCC] Support coalesing in `c10d::ProcessGroupUCC` through alltoallv

### DIFF
--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -367,7 +367,7 @@ class ProcessGroupUCCTest(MultiProcessTestCase):
         pg = self._create_process_group_ucc()
 
         pg._start_coalescing()
-        if (self.rank == 0):
+        if self.rank == 0:
             for i in range(self.world_size):
                 send_buf = fn(torch.full((1,), float(i)))
                 pg.send([send_buf], i, 0)


### PR DESCRIPTION
# What 
Add support for coalescing communication in `ProcessGroupUCC`, by implementing the methods `startCoalescing` and `endCoalescing`.

We need to impose several restrictions to the coalesced group:
1) we can only coalesce `send` and `recv` ops
2) we can only coalesce one `send` and one `recv` maximum per pair of ranks
3) all ranks must participate in the `startCoalescing` and `endCoalescing` calls, even if the group is empty.
4) we do not support tags for coalesced groups.

# Why

Despite the above restrictions, we cover a number of useful data patterns, such as ring p2p, allgather, broadcast, alltoall, etc. Those data patterns or other custom ones are conveniently written in terms of coalesced send/recv calls, which this patch makes possible.

Recall that for a p2p bidirectional transfer, the send and recv need to be coalesced to enjoy full bidirectional bandwidth

# How

Since UCC does not natively support Coalescing, we implement it at the ProcessGroup level. The implementation relies on calling UCC's alltoallv, setting the count to `0` and displacement to `nullptr` for ranks that do not exchange data.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o