### PR TITLE
[WIP] Add test_torchinductor_opinfo.py to triton-cpu tests

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -659,7 +659,7 @@ test_inductor_halide() {
 }
 
 test_inductor_triton_cpu() {
-  python test/run_test.py --include inductor/test_triton_cpu_backend.py inductor/test_torchinductor_strided_blocks.py --verbose
+  python test/run_test.py --include inductor/test_triton_cpu_backend.py inductor/test_torchinductor_strided_blocks.py inductor/test_torchinductor_opinfo.py --verbose
   assert_git_not_dirty
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145865

I'm guessing this isn't going to pass, but I want to see how long the CI takes.