### PR TITLE
[pytorch] Sprinkle in a few `template` keywords

### DIFF
--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -195,7 +195,7 @@ struct PopResult<std::tuple<Types...>> final {
   static Result pop_to_tuple_impl(
       Stack& stack,
       std::index_sequence<indices...>) {
-    return std::make_tuple((std::move(stack[indices]).to<Types>())...);
+    return std::make_tuple((std::move(stack[indices]).template to<Types>())...);
   }
 };
 

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1780,7 +1780,7 @@ std::vector<Elem> generic_to(IValue ivalue, _fake_type<std::vector<Elem>>) {
   // We need to do a deep copy of the vector because there might be other
   // references to this same IValue that also use the list. We can't just
   // move the elements out.
-  auto list = std::move(ivalue).to<List<Elem>>();
+  auto list = std::move(ivalue).template to<List<Elem>>();
   std::vector<Elem> result;
   result.reserve(list.size());
   for (Elem v : list) {
@@ -1828,7 +1828,7 @@ c10::intrusive_ptr<T> IValue::toCustomClass() const& {
 template <typename T>
 T generic_to(IValue ivalue, _fake_type<T>) {
   using ElemType = typename std::remove_pointer<T>::type::element_type;
-  return std::move(ivalue).toCustomClass<ElemType>();
+  return std::move(ivalue).template toCustomClass<ElemType>();
 }
 
 template <typename T>
@@ -1872,7 +1872,7 @@ OptionalArray<T> generic_to(IValue ivalue, _fake_type<OptionalArray<T>>) {
     return {};
   }
   return createVectorFromList<T>(
-    std::move(ivalue).to<c10::List<T>>()
+    std::move(ivalue).template to<c10::List<T>>()
   );
 }
 
@@ -1885,7 +1885,7 @@ std::array<Elem, sizeof...(I)> generic_to_array(
   // We need to do a deep copy of the array because there might be other
   // references to this same IValue that also use the list. We can't just
   // move the elements out.
-  auto list = std::move(ivalue).to<List<Elem>>();
+  auto list = std::move(ivalue).template to<List<Elem>>();
   TORCH_CHECK(
       list.size() == sizeof...(I),
       "Tried to convert a List with ",
@@ -1930,7 +1930,7 @@ std::optional<T> generic_to(IValue ivalue, _fake_type<std::optional<T>>) {
   if (ivalue.isNone()) {
     return std::nullopt;
   }
-  return std::move(ivalue).to<T>();
+  return std::move(ivalue).template to<T>();
 }
 
 namespace detail {


### PR DESCRIPTION
Summary:
These seem to be necessary to get compilation working on Windows with
CUDA 12.8. I'm not sure whether this means that all of the previous compilers
were broken, and the new one is better, or whether this is a regression in NVCC
12.8. Either way, as long as the CI passes for existing versions, this should
unblock us from CUDA 12.8 enablement on Windows.

See D68663662 for more details on the CUDA 12.8 enablement.

Test Plan: CI!

Reviewed By: akrieger

Differential Revision: D68787925


