### PR TITLE
[dynamo][bulitin-skipfiles-cleanup] Remove traceback

### DIFF
--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -13,7 +13,6 @@ import random
 import re
 import sys
 import threading
-import traceback
 import types
 import typing
 import unittest
@@ -3150,7 +3149,6 @@ BUILTIN_SKIPLIST = (
     operator,
     random,
     threading,
-    traceback,
     types,
     unittest,
 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #145804
* #145881
* #145880
* __->__ #145879
* #145878
* #145876
* #145875
* #145856



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames