### PR TITLE
[dynamo][builtin-skipfiles-cleanup] Remove operator

### DIFF
--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3146,7 +3146,6 @@ BUILTIN_SKIPLIST = (
     collections,
     inspect,
     multiprocessing,
-    operator,
     random,
     threading,
     types,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #145804
* #145881
* __->__ #145880
* #145879
* #145878
* #145876
* #145875
* #145856



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames