### PR TITLE
bump counters for unbacked binding names

### DIFF
--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -2060,7 +2060,9 @@ class GraphModuleDeserializer(metaclass=Final):
             # deserialization does analysis with checks on 0/1, so we create fake range constraints and
             # restore the original range constraints afterwards
             self.symbol_name_to_range = {}
-            max_unbacked_symfloat, max_unbacked_symint = -1, -1
+            # we also need to bump unbacked sym[float,int] counters in the
+            # shape env to accommodate unbacked symbols in the exported program
+            count_unbacked_symfloat, count_unbacked_symint = -1, -1
             unbacked_symfloat_prefix, unbacked_symint_prefix = (
                 prefix_str[t] for t in [SymT.UNBACKED_FLOAT, SymT.UNBACKED_INT]
             )
@@ -2072,14 +2074,14 @@ class GraphModuleDeserializer(metaclass=Final):
                     self.symbol_name_to_range[k] = symbolic_shapes.ValueRanges(_int_to_sympy_int(lower, -int_oo), vr.upper)
                     if k.startswith(unbacked_symfloat_prefix):
                         i = int(k[len(unbacked_symfloat_prefix):])
-                        max_unbacked_symfloat = max(max_unbacked_symfloat, i)
+                        count_unbacked_symfloat = max(count_unbacked_symfloat, i)
                     elif k.startswith(unbacked_symint_prefix):
                         i = int(k[len(unbacked_symint_prefix):])
-                        max_unbacked_symint = max(max_unbacked_symint, i)
+                        count_unbacked_symint = max(count_unbacked_symint, i)
 
-            for _ in range(max_unbacked_symfloat + 1):
+            for _ in range(count_unbacked_symfloat + 1):
                 next(self.shape_env.unbacked_symfloat_counter)
-            for _ in range(max_unbacked_symint + 1):
+            for _ in range(count_unbacked_symint + 1):
                 next(self.shape_env.unbacked_symint_counter)
 
             if example_inputs is not None and len(example_inputs) > 0:

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -42,7 +42,7 @@ from torch.fx.experimental import symbolic_shapes
 from torch.utils import _pytree as pytree
 from torch.utils._pytree import treespec_dumps, treespec_loads
 from torch.utils._sympy.numbers import int_oo
-from torch.utils._sympy.symbol import symbol_is_type, SymT
+from torch.utils._sympy.symbol import prefix_str, SymT
 from torch.utils._sympy.value_ranges import ValueRanges
 
 from ..utils import remove_proxy_from_state_dict
@@ -1890,20 +1890,6 @@ class GraphModuleDeserializer(metaclass=Final):
             for u_name in serialized_node.metadata["unbacked_bindings"].split(","):
                 u = self.symbol_name_to_symbol[u_name]
                 # these are pending fresh unbacked symbols, so update shape env
-                if symbol_is_type(u, SymT.UNBACKED_FLOAT):
-                    suffix = str(next(self.shape_env.unbacked_symfloat_counter))
-                    if not u.name.endswith(suffix):
-                        log.warning(
-                            "Expected symbol %s to end with suffix %s", u.name, suffix
-                        )
-                elif symbol_is_type(u, SymT.UNBACKED_INT):
-                    suffix = str(next(self.shape_env.unbacked_symint_counter))
-                    if not u.name.endswith(suffix):
-                        log.warning(
-                            "Expected symbol %s to end with suffix %s", u.name, suffix
-                        )
-                else:
-                    raise AssertionError(f"Illegal unbacked symbol {u}")
                 self.shape_env.pending_fresh_unbacked_symbols.append(u)
             # consume pending fresh unbacked symbols and reconstruct key paths to them
             unbacked_bindings = symbolic_shapes.compute_unbacked_bindings(
@@ -2074,12 +2060,27 @@ class GraphModuleDeserializer(metaclass=Final):
             # deserialization does analysis with checks on 0/1, so we create fake range constraints and
             # restore the original range constraints afterwards
             self.symbol_name_to_range = {}
+            max_unbacked_symfloat, max_unbacked_symint = -1, -1
+            unbacked_symfloat_prefix, unbacked_symint_prefix = (
+                prefix_str[t] for t in [SymT.UNBACKED_FLOAT, SymT.UNBACKED_INT]
+            )
             if symbol_name_to_range:
                 for k, vr in symbol_name_to_range.items():
                     lower = vr.lower
                     if vr.upper >= 2:  # max is >= 2, not sym bool range
                         lower = max(2, lower)
                     self.symbol_name_to_range[k] = symbolic_shapes.ValueRanges(_int_to_sympy_int(lower, -int_oo), vr.upper)
+                    if k.startswith(unbacked_symfloat_prefix):
+                        i = int(k[len(unbacked_symfloat_prefix):])
+                        max_unbacked_symfloat = max(max_unbacked_symfloat, i)
+                    elif k.startswith(unbacked_symint_prefix):
+                        i = int(k[len(unbacked_symint_prefix):])
+                        max_unbacked_symint = max(max_unbacked_symint, i)
+
+            for _ in range(max_unbacked_symfloat + 1):
+                next(self.shape_env.unbacked_symfloat_counter)
+            for _ in range(max_unbacked_symint + 1):
+                next(self.shape_env.unbacked_symint_counter)
 
             if example_inputs is not None and len(example_inputs) > 0:
                 self.example_inputs = deserialize_torch_artifact(example_inputs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145882

Instead of bumping symint counters when we process unbacked bindings during deserialization, it's better to bump them at the beginning based on what the symbols in the original shape env before serialization were. This allows symbols in unbacked bindings to have "gaps" that bumping alone would not be able to match.

Why is bumping counters important at all? It is because when the shape env coming out of deserialization is used later for propagating symints, say in run_decompositions, we don't want new names to clash with existing names (bad things happen).

Differential Revision: [D68798191](https://our.internmc.facebook.com/intern/diff/D68798191/)