### PR TITLE
update aotdispatcher_inference_subclass_cpu results

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -50,7 +50,7 @@ aotdispatcher_inference_nosubclass_cpu,compile_time_instruction_count,2018000000
 
 
 
-aotdispatcher_inference_subclass_cpu,compile_time_instruction_count,5764000000,0.015
+aotdispatcher_inference_subclass_cpu,compile_time_instruction_count,5815000000,0.015
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145887

The regression comes from https://github.com/pytorch/pytorch/pull/145420.

I'm not sure if there's a fixed way to determine what the new value should be - but I estimated a ~0.9% increase based on the last few days of benchmark results.

<img width="953" alt="Screenshot 2025-01-28 at 2 39 39 PM" src="https://github.com/user-attachments/assets/59d8287c-6c67-4617-842e-38623ef664cf" />


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames