### PR TITLE
[CD][MacOS] Don't install `libuv` from conda

### DIFF
--- a/.ci/wheel/build_wheel.sh
+++ b/.ci/wheel/build_wheel.sh
@@ -190,9 +190,8 @@ retry pip install -r "${pytorch_rootdir}/requirements.txt" || true
 retry pip uninstall -y cmake
 retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -y  llvm-openmp=14.0.6 cmake
 
-# For USE_DISTRIBUTED=1 on macOS, need libuv and pkg-config to find libuv.
+# For USE_DISTRIBUTED=1 on macOS, need libuv, which is build as part of tensorpipe submodule
 export USE_DISTRIBUTED=1
-retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -y libuv pkg-config
 
 if [[ -n "$CROSS_COMPILE_ARM64" ]]; then
     export CMAKE_OSX_ARCHITECTURES=arm64


### PR DESCRIPTION
As one can see from build logs, it's been build as part of TensorPipe dependency:
```
2025-01-28T21:22:21.8630760Z [3444/5234] Building C object third_party/tensorpipe/tensorpipe/CMakeFiles/tensorpipe_uv.dir/__/third_party/libuv/src/random.c.o
2025-01-28T21:22:21.8731260Z [3445/5234] Building C object third_party/tensorpipe/tensorpipe/CMakeFiles/tensorpipe_uv.dir/__/third_party/libuv/src/fs-poll.c.o
2025-01-28T21:22:21.8833110Z [3446/5234] Building C object third_party/tensorpipe/tensorpipe/CMakeFiles/tensorpipe_uv.dir/__/third_party/libuv/src/idna.c.o
2025-01-28T21:22:21.8934190Z [3447/5234] Building C object third_party/tensorpipe/tensorpipe/CMakeFiles/tensorpipe_uv.dir/__/third_party/libuv/src/inet.c.o
```

Partially addresses https://github.com/pytorch/pytorch/issues/145872

Test plan: Run https://pytorch.org/tutorials/intermediate/TCPStore_libuv_backend.html