### PR TITLE
Add retain-output argument

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3229,6 +3229,13 @@ def parse_args(args=None):
         help="Enables Memory Snapshot tool for memory deep dives: https://pytorch.org/blog/understanding-gpu-memory-1/",
     )
 
+    parser.add_argument(
+        "--retain-output",
+        action="store_true",
+        help="Enables appending to the already existing output file if it exists \
+            instead of deleting it and creating a new one."
+    )
+
     group_latency = parser.add_mutually_exclusive_group()
     group_latency.add_argument(
         "--cold-start-latency",
@@ -4078,7 +4085,7 @@ def run(runner, args, original_dir=None):
             )
     else:
         metrics.purge_old_log_files()
-        if output_filename and os.path.exists(output_filename):
+        if output_filename and os.path.exists(output_filename) and not args.retain_output:
             os.unlink(output_filename)
         if original_dir:
             os.chdir(original_dir)

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3233,7 +3233,7 @@ def parse_args(args=None):
         "--retain-output",
         action="store_true",
         help="Enables appending to the already existing output file if it exists \
-            instead of deleting it and creating a new one."
+            instead of deleting it and creating a new one.",
     )
 
     group_latency = parser.add_mutually_exclusive_group()
@@ -4085,7 +4085,11 @@ def run(runner, args, original_dir=None):
             )
     else:
         metrics.purge_old_log_files()
-        if output_filename and os.path.exists(output_filename) and not args.retain_output:
+        if (
+            output_filename
+            and os.path.exists(output_filename)
+            and not args.retain_output
+        ):
             os.unlink(output_filename)
         if original_dir:
             os.chdir(original_dir)


### PR DESCRIPTION
This PR add retain-output argument which enables appending to the already existing output file if it exists instead of deleting it and creating a new one.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames