### PR TITLE
[Break XPU] Fix Inductor cuda bias UT

### DIFF
--- a/test/inductor/test_inplace_padding.py
+++ b/test/inductor/test_inplace_padding.py
@@ -102,9 +102,9 @@ class InplacePaddingTest(TestCase):
         # . This will allocate an extra item for the last row so that
         # inplace padding would be safe without accessing out of bound
         # memory.
-        FileCheck().check(
-            "empty_strided_cuda((2048, 2048), (2048, 1), torch.float32)."
-            + "as_strided((2048, 2047), (2048, 1))"
+        FileCheck().check_regex(
+            r"empty_strided.*\(\(2048, 2048\), \(2048, 1\), torch.float32\)."
+            r"as_strided\(\(2048, 2047\), \(2048, 1\)\)"
         ).run(code)
 
         self.assertTrue(torch.allclose(ref, act, atol=1e-2, rtol=1e-2))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #145934

# Motivation
[Break XPU] inductor ut: `inductor/test_inplace_padding.py::InplacePaddingTest::test_pad_non_zero - RuntimeError: Expected to find "empty_strided_cuda((2048, 2048), (2048, 1), torch.float32).as_strided((2048, 2047), (2048, 1))" but did not find it`

With this PR, `test_pad_non_zero` will pass on XPU.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov