### PR TITLE
[CPU Stream] Add noop for CPU stream record_event() and wait_event()

### DIFF
--- a/torch/cpu/__init__.py
+++ b/torch/cpu/__init__.py
@@ -95,6 +95,12 @@ class Stream:
     def wait_stream(self, stream) -> None:
         pass
 
+    def record_event(self) -> None:
+        pass
+
+    def wait_event(self, event) -> None:
+        pass
+
 
 class Event:
     def query(self) -> bool:


### PR DESCRIPTION
Summary: Adds wait_event and record_event endpoints to CPU stream in order to facilitate device-agnostic code. Both methods are noops.

Test Plan: CI

Differential Revision: D68833927




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10