### PR TITLE
Resolve affine quantization namespace collision with torchao

### DIFF
--- a/torch/ao/quantization/pt2e/_affine_quantization.py
+++ b/torch/ao/quantization/pt2e/_affine_quantization.py
@@ -184,7 +184,7 @@ def _register_custom_op(lib):
     return decorator
 
 
-quant_lib = torch.library.Library("quant", "FRAGMENT")  # noqa: TOR901
+quant_lib = torch.library.Library("pt2e_quant", "FRAGMENT")  # noqa: TOR901
 
 register_custom_op = _register_custom_op(quant_lib)
 


### PR DESCRIPTION
Summary:
https://github.com/pytorch/pytorch/pull/141421
duplicated affine quantization custom ops from torchao into
the PT2E quantization flow, but these ops are registered under
the same namespace with the same name, causing "Duplicate
registration" errors for the new ops for use cases that import
from both repos. This commit fixes this by moving the PT2E
versions of the ops to a new namespace. In the long term,
we expect to migrate PT2E into torchao so users can migrate
back to the old namespace if they wish to.

Test Plan: python test/test_quantization.py -k test_channel_group_quantization

Differential Revision: D68838437


