### PR TITLE
[ROCm][TunableOp] hipblaslt tf32 support

### DIFF
--- a/aten/src/ATen/cuda/tunable/GemmRocblas.h
+++ b/aten/src/ATen/cuda/tunable/GemmRocblas.h
@@ -140,6 +140,8 @@ class RocblasGemmOp : public Callable<GemmParams<T>> {
     RocblasGemmOp(int solution) : solution_{solution} {}
 
     TuningStatus Call(const GemmParams<T>* params) override {
+      if (at::globalContext().allowTF32CuBLAS()) return FAIL;  // no support for TF32 in rocBLAS
+
       auto input_output_type = RocBlasDataTypeFor<T>();
       auto compute_type = RocBlasComputeTypeFor<T>();
       auto h_a = DoCastForHalfOrBfloat16(params->alpha);
@@ -206,6 +208,8 @@ class RocblasGemmStridedBatchedOp : public Callable<GemmStridedBatchedParams<T>>
     RocblasGemmStridedBatchedOp(int solution) : solution_{solution} {}
 
     TuningStatus Call(const GemmStridedBatchedParams<T>* params) override {
+      if (at::globalContext().allowTF32CuBLAS()) return FAIL;  // no support for TF32 in rocBLAS
+
       auto input_output_type = RocBlasDataTypeFor<T>();
       auto compute_type = RocBlasComputeTypeFor<T>();
       auto h_a = DoCastForHalfOrBfloat16(params->alpha);

--- a/aten/src/ATen/cuda/tunable/GemmRocblas.h
+++ b/aten/src/ATen/cuda/tunable/GemmRocblas.h
@@ -140,9 +140,9 @@ class RocblasGemmOp : public Callable<GemmParams<T>> {
     RocblasGemmOp(int solution) : solution_{solution} {}
 
     TuningStatus Call(const GemmParams<T>* params) override {
-      if (at::globalContext().allowTF32CuBLAS()) return FAIL;  // no support for TF32 in rocBLAS
-
       auto input_output_type = RocBlasDataTypeFor<T>();
+      if (at::globalContext().allowTF32CuBLAS() && input_output_type == rocblas_datatype_f32_r)
+        return FAIL;  // no support for TF32 in rocBLAS
       auto compute_type = RocBlasComputeTypeFor<T>();
       auto h_a = DoCastForHalfOrBfloat16(params->alpha);
       auto h_b = DoCastForHalfOrBfloat16(params->beta);
@@ -208,9 +208,9 @@ class RocblasGemmStridedBatchedOp : public Callable<GemmStridedBatchedParams<T>>
     RocblasGemmStridedBatchedOp(int solution) : solution_{solution} {}
 
     TuningStatus Call(const GemmStridedBatchedParams<T>* params) override {
-      if (at::globalContext().allowTF32CuBLAS()) return FAIL;  // no support for TF32 in rocBLAS
-
       auto input_output_type = RocBlasDataTypeFor<T>();
+      if (at::globalContext().allowTF32CuBLAS() && input_output_type == rocblas_datatype_f32_r)
+        return FAIL;  // no support for TF32 in rocBLAS
       auto compute_type = RocBlasComputeTypeFor<T>();
       auto h_a = DoCastForHalfOrBfloat16(params->alpha);
       auto h_b = DoCastForHalfOrBfloat16(params->beta);


### PR DESCRIPTION
TF32 is supported by hipblaslt. Support added by #143549.  This PR expands integration to the TunableOp feature.

cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd