### PR TITLE
[linter] Grep linter batches long command

### DIFF
--- a/tools/linter/adapters/grep_linter.py
+++ b/tools/linter/adapters/grep_linter.py
@@ -75,7 +75,6 @@ def lint_file(
 
     if allowlist_pattern:
         try:
-            print(f"grep -nEHI {allowlist_pattern} {filename}")
             proc = run_command(["grep", "-nEHI", allowlist_pattern, filename])
         except Exception as err:
             return LintMessage(
@@ -227,7 +226,7 @@ def main() -> None:
     lines = []
     try:
         # Split the grep command into multiple batches to avoid hitting the
-        # command line length limit of ~1M
+        # command line length limit
         arg_length = sum(len(x) for x in args.filenames)
         batches = arg_length // 750000 + 1
         batch_size = len(args.filenames) // batches

--- a/tools/linter/adapters/grep_linter.py
+++ b/tools/linter/adapters/grep_linter.py
@@ -226,7 +226,7 @@ def main() -> None:
     lines = []
     try:
         # Split the grep command into multiple batches to avoid hitting the
-        # command line length limit
+        # command line length limit of ~1M on my machine
         arg_length = sum(len(x) for x in args.filenames)
         batches = arg_length // 750000 + 1
         batch_size = len(args.filenames) // batches

--- a/tools/linter/adapters/grep_linter.py
+++ b/tools/linter/adapters/grep_linter.py
@@ -232,7 +232,13 @@ def main() -> None:
         batch_size = len(args.filenames) // batches
         for i in range(0, len(args.filenames), batch_size):
             proc = run_command(
-                ["grep", "-nEHI", *files_with_matches, args.pattern, *args.filenames[i : i + batch_size]]
+                [
+                    "grep",
+                    "-nEHI",
+                    *files_with_matches,
+                    args.pattern,
+                    *args.filenames[i : i + batch_size],
+                ]
             )
             lines.extend(proc.stdout.decode().splitlines())
     except Exception as err:


### PR DESCRIPTION
If the command is too long, the linter fails with 
```
Failed due to OSError:
[Errno 7] Argument list too long: 'grep'
```
Fix this by batching the command so it is shorter

Limit of 750k was chosen due to `getconf ARG_MAX` returns ~1M on my mac.  My guess is that most people shouldn't hit this unless they run --all-files and the directory length is long.

cc @wdvr 