### PR TITLE
Don't use mypy daemon in CI

### DIFF
--- a/tools/linter/adapters/mypy_linter.py
+++ b/tools/linter/adapters/mypy_linter.py
@@ -118,6 +118,10 @@ def check_mypy_installed(code: str) -> list[LintMessage]:
         ]
 
 
+def in_github_actions() -> bool:
+    return os.getenv("GITHUB_ACTIONS", "false").lower() != "false"
+
+
 def check_files(
     filenames: list[str],
     config: str,
@@ -128,8 +132,11 @@ def check_files(
     # file names, see https://github.com/python/mypy/issues/16768
     filenames = [os.path.relpath(f) for f in filenames]
     try:
+        mypy_commands = ["dmypy", "run", "--"]
+        if in_github_actions():
+            mypy_commands = ["mypy"]
         proc = run_command(
-            ["dmypy", "run", "--", f"--config={config}"] + filenames,
+            [*mypy_commands, f"--config={config}"] + filenames,
             extra_env={},
             retries=retries,
         )

--- a/tools/linter/adapters/mypy_linter.py
+++ b/tools/linter/adapters/mypy_linter.py
@@ -119,7 +119,7 @@ def check_mypy_installed(code: str) -> list[LintMessage]:
 
 
 def in_github_actions() -> bool:
-    return os.getenv("GITHUB_ACTIONS", "false").lower() != "false"
+    return bool(os.getenv("GITHUB_ACTIONS"))
 
 
 def check_files(


### PR DESCRIPTION
This is an attempt to fix flaky mypy errors in CI that look like:

```
dmypy status --verbose
connection_name         : /var/folders/rf/qrn1jkgj0b9_tcznwp8ck46w0000gn/T/tmpjoqsid7_/dmypy.sock
pid                     :      32233
error                   :  timed out
Daemon is stuck; consider /Users/zainr/pytorch/venv/bin/dmypy kill
```

"Fix" it by not using the daemon at all, since it doesn't actually provide any perf benefits in CI.

Fixes https://github.com/pytorch/pytorch/issues/145967 (hopefully)