### PR TITLE
[draft_export] better stack logging for strict mode

### DIFF
--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -6410,6 +6410,7 @@ class ShapeEnv:
             "guard_added",
             metadata_fn=lambda: {
                 "expr": str(g),
+                "user_stack": structured.from_traceback(TracingContext.extract_stack()),
                 "stack": structured.from_traceback(
                     CapturedTraceback.extract(skip=1).summary()
                 ),
@@ -6645,6 +6646,7 @@ class ShapeEnv:
                             metadata_fn=lambda: {
                                 "expr": repr(orig_expr),
                                 "result": repr(unsound_result),
+                                "user_stack": structured.from_traceback(TracingContext.extract_stack()),
                                 "stack": structured.from_traceback(
                                     CapturedTraceback.extract(skip=1).summary()
                                 ),


### PR DESCRIPTION
Strict-mode draft export tends to log unhelpful stack traces for guards/data-dependent errors, relying on `CapturedTraceback.extract()`, which is only accurate for non-strict. For dynamo, it's better to use `TracingContext.extract_stack()` and fallback to the former when this is empty, avoiding traces pointing to the top-level export call, or lambdas (in the case of `torch._check` calls).

e.g. before, for `test_draft_export.py -k test_offsets`:
```
    This occurred at the following stacktrace: 
        File /data/users/pianpwk/pytorch/test/export/test_draft_export.py, lineno 259, in test_offsets:
        `ep, report = draft_export(M(), inp, strict=True)`
```
after:
```
    This occurred at the following stacktrace: 
        File /data/users/pianpwk/pytorch/test/export/test_draft_export.py, lineno 254, in forward:
            `if a == 0:`
```

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv