### PR TITLE
[Utilization] Convert timestamp to str for datetime64 

### DIFF
--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -45,7 +45,6 @@ from tools.stats.utilization_stats_lib import (
     UtilizationMetadata,
     UtilizationRecord,
     UtilizationStats,
-    getCurrentTimestampStr,
 )
 
 
@@ -191,7 +190,7 @@ class UsageLogger:
             job_name=_job_name,
             workflow_id=_workflow_run_id,
             workflow_name=_workflow_name,
-            start_at= getCurrentTimestampStr(),
+            start_at=datetime.datetime.now().timestamp(),
         )
         self._data_collect_interval = data_collect_interval
         self._has_pynvml = pynvml_enabled
@@ -254,14 +253,14 @@ class UsageLogger:
         """
         output the data.
         """
-        self._metadata.start_at = getCurrentTimestampStr()
+        self._metadata.start_at = datetime.datetime.now().timestamp()
         self.log_json(self._metadata.to_json())
 
         while not self.exit_event.is_set():
             collecting_start_time = time.time()
             stats = UtilizationRecord(
                 level="record",
-                timestamp=getCurrentTimestampStr(),
+                timestamp=datetime.datetime.now().timestamp(),
             )
 
             try:
@@ -307,7 +306,7 @@ class UsageLogger:
             except Exception as e:
                 stats = UtilizationRecord(
                     level="record",
-                    timestamp= getCurrentTimestampStr(),
+                    timestamp=datetime.datetime.now().timestamp(),
                     error=str(e),
                 )
             finally:
@@ -320,7 +319,6 @@ class UsageLogger:
                 time.sleep(self._log_interval)
         # shut down gpu connections when exiting
         self._shutdown_gpu_connections()
-
 
     def _calculate_gpu_utilization(self, data_list: list[UsageData]) -> list[GpuUsage]:
         """

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -39,12 +39,12 @@ import psutil  # type: ignore[import]
 
 from tools.stats.utilization_stats_lib import (
     getDataModelVersion,
+    getTsNow,
     GpuUsage,
     RecordData,
     UtilizationMetadata,
     UtilizationRecord,
     UtilizationStats,
-    getTsNow,
 )
 
 
@@ -190,7 +190,7 @@ class UsageLogger:
             job_name=_job_name,
             workflow_id=_workflow_run_id,
             workflow_name=_workflow_name,
-            start_at= getTsNow(),
+            start_at=getTsNow(),
         )
         self._data_collect_interval = data_collect_interval
         self._has_pynvml = pynvml_enabled

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -28,7 +28,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 import argparse
 import copy
 import dataclasses
-import datetime
 import os
 import signal
 import threading
@@ -45,6 +44,7 @@ from tools.stats.utilization_stats_lib import (
     UtilizationMetadata,
     UtilizationRecord,
     UtilizationStats,
+    getTsNow,
 )
 
 
@@ -190,7 +190,7 @@ class UsageLogger:
             job_name=_job_name,
             workflow_id=_workflow_run_id,
             workflow_name=_workflow_name,
-            start_at=datetime.datetime.now().timestamp(),
+            start_at= getTsNow(),
         )
         self._data_collect_interval = data_collect_interval
         self._has_pynvml = pynvml_enabled
@@ -253,14 +253,14 @@ class UsageLogger:
         """
         output the data.
         """
-        self._metadata.start_at = datetime.datetime.now().timestamp()
+        self._metadata.start_at = getTsNow()
         self.log_json(self._metadata.to_json())
 
         while not self.exit_event.is_set():
             collecting_start_time = time.time()
             stats = UtilizationRecord(
                 level="record",
-                timestamp=datetime.datetime.now().timestamp(),
+                timestamp=getTsNow(),
             )
 
             try:
@@ -306,7 +306,7 @@ class UsageLogger:
             except Exception as e:
                 stats = UtilizationRecord(
                     level="record",
-                    timestamp=datetime.datetime.now().timestamp(),
+                    timestamp=getTsNow(),
                     error=str(e),
                 )
             finally:

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -45,6 +45,7 @@ from tools.stats.utilization_stats_lib import (
     UtilizationMetadata,
     UtilizationRecord,
     UtilizationStats,
+    getCurrentTimestampStr,
 )
 
 
@@ -190,7 +191,7 @@ class UsageLogger:
             job_name=_job_name,
             workflow_id=_workflow_run_id,
             workflow_name=_workflow_name,
-            start_at=datetime.datetime.now().timestamp(),
+            start_at= getCurrentTimestampStr(),
         )
         self._data_collect_interval = data_collect_interval
         self._has_pynvml = pynvml_enabled
@@ -253,14 +254,14 @@ class UsageLogger:
         """
         output the data.
         """
-        self._metadata.start_at = datetime.datetime.now().timestamp()
+        self._metadata.start_at = getCurrentTimestampStr()
         self.log_json(self._metadata.to_json())
 
         while not self.exit_event.is_set():
             collecting_start_time = time.time()
             stats = UtilizationRecord(
                 level="record",
-                timestamp=datetime.datetime.now().timestamp(),
+                timestamp=getCurrentTimestampStr(),
             )
 
             try:
@@ -306,7 +307,7 @@ class UsageLogger:
             except Exception as e:
                 stats = UtilizationRecord(
                     level="record",
-                    timestamp=datetime.datetime.now().timestamp(),
+                    timestamp= getCurrentTimestampStr(),
                     error=str(e),
                 )
             finally:
@@ -319,6 +320,7 @@ class UsageLogger:
                 time.sleep(self._log_interval)
         # shut down gpu connections when exiting
         self._shutdown_gpu_connections()
+
 
     def _calculate_gpu_utilization(self, data_list: list[UsageData]) -> list[GpuUsage]:
         """

--- a/tools/stats/upload_utilization_stats/test_upload_utilization_stats.py
+++ b/tools/stats/upload_utilization_stats/test_upload_utilization_stats.py
@@ -194,3 +194,12 @@ def get_base_test_records() -> list[UtilizationRecord]:
 
 if __name__ == "__main__":
     unittest.main()
+
+
+
+def getTimestampStr(timestamp: float) -> str:
+    return f"{timestamp:.0f}"
+
+def getCurrentTimestampStr() -> str:
+    timestamp_now =  datetime.now().timestamp()
+    return getTimestampStr(timestamp_now)

--- a/tools/stats/upload_utilization_stats/test_upload_utilization_stats.py
+++ b/tools/stats/upload_utilization_stats/test_upload_utilization_stats.py
@@ -29,6 +29,7 @@ TEST_TS_PLUS_15S = TEST_DT_PLUS_15S.timestamp()
 TEST_TS_PLUS_30S = TEST_DT_PLUS_30S.timestamp()
 TEST_TS_PLUS_40S = TEST_DT_PLUS_40S.timestamp()
 
+
 # test cmd names
 PYTEST1_NAME = "python test1.py"
 PYTEST2_NAME = "python test2.py"
@@ -155,8 +156,8 @@ class TestSegmentGenerator(unittest.TestCase):
         self, segment: OssCiSegmentV1, name: str, start_at: float, end_at: float
     ) -> None:
         self.assertEqual(segment.name, name)
-        self.assertEqual(segment.start_at, start_at)
-        self.assertEqual(segment.end_at, end_at)
+        self.assertEqual(segment.start_at, str(int(start_at)))
+        self.assertEqual(segment.end_at, str(int(end_at)))
 
 
 def get_base_test_records() -> list[UtilizationRecord]:

--- a/tools/stats/upload_utilization_stats/test_upload_utilization_stats.py
+++ b/tools/stats/upload_utilization_stats/test_upload_utilization_stats.py
@@ -196,10 +196,10 @@ if __name__ == "__main__":
     unittest.main()
 
 
-
 def getTimestampStr(timestamp: float) -> str:
     return f"{timestamp:.0f}"
 
+
 def getCurrentTimestampStr() -> str:
-    timestamp_now =  datetime.now().timestamp()
+    timestamp_now = datetime.now().timestamp()
     return getTimestampStr(timestamp_now)

--- a/tools/stats/upload_utilization_stats/test_upload_utilization_stats.py
+++ b/tools/stats/upload_utilization_stats/test_upload_utilization_stats.py
@@ -191,6 +191,5 @@ def get_base_test_records() -> list[UtilizationRecord]:
     )
     return [record1, record2, record3, record4, record5, record6]
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/tools/stats/upload_utilization_stats/test_upload_utilization_stats.py
+++ b/tools/stats/upload_utilization_stats/test_upload_utilization_stats.py
@@ -191,5 +191,6 @@ def get_base_test_records() -> list[UtilizationRecord]:
     )
     return [record1, record2, record3, record4, record5, record6]
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/stats/upload_utilization_stats/test_upload_utilization_stats.py
+++ b/tools/stats/upload_utilization_stats/test_upload_utilization_stats.py
@@ -22,12 +22,12 @@ TEST_DT_PLUS_30S = TEST_DT_BASE + timedelta(seconds=30)
 TEST_DT_PLUS_40S = TEST_DT_BASE + timedelta(seconds=40)
 
 # timestamps from January 1, 2022 12:00:00
-TEST_TS_BASE = TEST_DT_BASE.timestamp()
-TEST_TS_PLUS_5S = TEST_DT_PLUS_5S.timestamp()
-TEST_TS_PLUS_10S = TEST_DT_PLUS_10S.timestamp()
-TEST_TS_PLUS_15S = TEST_DT_PLUS_15S.timestamp()
-TEST_TS_PLUS_30S = TEST_DT_PLUS_30S.timestamp()
-TEST_TS_PLUS_40S = TEST_DT_PLUS_40S.timestamp()
+TEST_TS_BASE = int(TEST_DT_BASE.timestamp())
+TEST_TS_PLUS_5S = int(TEST_DT_PLUS_5S.timestamp())
+TEST_TS_PLUS_10S = int(TEST_DT_PLUS_10S.timestamp())
+TEST_TS_PLUS_15S = int(TEST_DT_PLUS_15S.timestamp())
+TEST_TS_PLUS_30S = int(TEST_DT_PLUS_30S.timestamp())
+TEST_TS_PLUS_40S = int(TEST_DT_PLUS_40S.timestamp())
 
 
 # test cmd names
@@ -156,8 +156,8 @@ class TestSegmentGenerator(unittest.TestCase):
         self, segment: OssCiSegmentV1, name: str, start_at: float, end_at: float
     ) -> None:
         self.assertEqual(segment.name, name)
-        self.assertEqual(segment.start_at, str(int(start_at)))
-        self.assertEqual(segment.end_at, str(int(end_at)))
+        self.assertEqual(segment.start_at, start_at)
+        self.assertEqual(segment.end_at, end_at)
 
 
 def get_base_test_records() -> list[UtilizationRecord]:

--- a/tools/stats/upload_utilization_stats/test_upload_utilization_stats.py
+++ b/tools/stats/upload_utilization_stats/test_upload_utilization_stats.py
@@ -96,12 +96,12 @@ class TestSegmentGenerator(unittest.TestCase):
         test_gap_dt1 = TEST_DT_PLUS_30S + timedelta(seconds=80)
         test_gap_dt2 = TEST_DT_PLUS_30S + timedelta(seconds=85)
         record_gap_1 = UtilizationRecord(
-            timestamp=test_gap_dt1.timestamp(),
+            timestamp=int(test_gap_dt1.timestamp()),
             cmd_names=[PYTEST1_NAME],
             level="PYTHON_CMD",
         )
         record_gap_2 = UtilizationRecord(
-            timestamp=test_gap_dt2.timestamp(),
+            timestamp=int(test_gap_dt2.timestamp()),
             cmd_names=[PYTEST1_NAME],
             level="PYTHON_CMD",
         )

--- a/tools/stats/upload_utilization_stats/upload_utilization_stats.py
+++ b/tools/stats/upload_utilization_stats/upload_utilization_stats.py
@@ -20,7 +20,8 @@ import pandas as pd  # type: ignore[import]
 from tools.stats.upload_stats_lib import download_s3_artifacts, upload_to_s3
 from tools.stats.utilization_stats_lib import (
     getDataModelVersion,
-    getTimestampString,
+    getTimestampStr,
+    getCurrentTimestampStr,
     OssCiSegmentV1,
     OssCiUtilizationMetadataV1,
     OssCiUtilizationTimeSeriesV1,
@@ -81,8 +82,8 @@ class SegmentGenerator:
                 segment = OssCiSegmentV1(
                     level=CMD_PYTHON_LEVEL,
                     name=value,
-                    start_at=getTimestampString(row["start_time"].timestamp()),
-                    end_at=getTimestampString(row["end_time"].timestamp()),
+                    start_at=getTimestampStr(row["start_time"].timestamp()),
+                    end_at=getTimestampStr(row["end_time"].timestamp()),
                     extra_info={},
                 )
                 segments.append(segment)
@@ -125,10 +126,10 @@ class UtilizationDbConverter:
         self.metadata = metadata
         self.records = records
         self.segments = segments
-        self.created_at = getTimestampString(datetime.now().timestamp())
+        self.created_at = getCurrentTimestampStr()
         self.info = info
         end_time_stamp = max([record.timestamp for record in records])
-        self.end_at = getTimestampString(end_time_stamp)
+        self.end_at = end_time_stamp
 
     def convert(
         self,
@@ -151,7 +152,7 @@ class UtilizationDbConverter:
             gpu_count=self.metadata.gpu_count if self.metadata.gpu_count else 0,
             cpu_count=self.metadata.cpu_count if self.metadata.cpu_count else 0,
             gpu_type=self.metadata.gpu_type if self.metadata.gpu_type else "",
-            start_at=getTimestampString(self.metadata.start_at),
+            start_at= self.metadata.start_at,
             end_at=self.end_at,
             segments=self.segments,
             tags=[],
@@ -170,7 +171,7 @@ class UtilizationDbConverter:
             created_at=self.created_at,
             type=type,
             tags=tags,
-            time_stamp=getTimestampString(record.timestamp),
+            time_stamp=record.timestamp,
             repo=self.info.repo,
             workflow_id=self.info.workflow_run_id,
             run_attempt=self.info.run_attempt,

--- a/tools/stats/upload_utilization_stats/upload_utilization_stats.py
+++ b/tools/stats/upload_utilization_stats/upload_utilization_stats.py
@@ -20,8 +20,6 @@ import pandas as pd  # type: ignore[import]
 from tools.stats.upload_stats_lib import download_s3_artifacts, upload_to_s3
 from tools.stats.utilization_stats_lib import (
     getDataModelVersion,
-    getTimestampStr,
-    getCurrentTimestampStr,
     OssCiSegmentV1,
     OssCiUtilizationMetadataV1,
     OssCiUtilizationTimeSeriesV1,
@@ -82,8 +80,8 @@ class SegmentGenerator:
                 segment = OssCiSegmentV1(
                     level=CMD_PYTHON_LEVEL,
                     name=value,
-                    start_at=getTimestampStr(row["start_time"].timestamp()),
-                    end_at=getTimestampStr(row["end_time"].timestamp()),
+                    start_at=get_ts_str(row["start_time"].timestamp()),
+                    end_at=get_ts_str(row["end_time"].timestamp()),
                     extra_info={},
                 )
                 segments.append(segment)
@@ -126,7 +124,7 @@ class UtilizationDbConverter:
         self.metadata = metadata
         self.records = records
         self.segments = segments
-        self.created_at = getCurrentTimestampStr()
+        self.created_at = get_crt_ts_str()
         self.info = info
         end_time_stamp = max([record.timestamp for record in records])
         self.end_at = end_time_stamp
@@ -152,8 +150,8 @@ class UtilizationDbConverter:
             gpu_count=self.metadata.gpu_count if self.metadata.gpu_count else 0,
             cpu_count=self.metadata.cpu_count if self.metadata.cpu_count else 0,
             gpu_type=self.metadata.gpu_type if self.metadata.gpu_type else "",
-            start_at= self.metadata.start_at,
-            end_at=self.end_at,
+            start_at= get_ts_str(self.metadata.start_at),
+            end_at= get_ts_str(self.end_at),
             segments=self.segments,
             tags=[],
         )
@@ -171,7 +169,7 @@ class UtilizationDbConverter:
             created_at=self.created_at,
             type=type,
             tags=tags,
-            time_stamp=record.timestamp,
+            time_stamp=get_ts_str(record.timestamp),
             repo=self.info.repo,
             workflow_id=self.info.workflow_run_id,
             run_attempt=self.info.run_attempt,
@@ -368,6 +366,11 @@ def unzip_file(path: Path, file_name: str) -> str:
         print(f"::warning trying to download test log {object} failed by: {e}")
         return ""
 
+def get_ts_str(timestamp: float) -> str:
+    return f"{timestamp:.0f}"
+
+def get_crt_ts_str():
+    return get_ts_str(datetime.now().timestamp())
 
 def parse_args() -> argparse.Namespace:
     """

--- a/tools/stats/upload_utilization_stats/upload_utilization_stats.py
+++ b/tools/stats/upload_utilization_stats/upload_utilization_stats.py
@@ -150,8 +150,8 @@ class UtilizationDbConverter:
             gpu_count=self.metadata.gpu_count if self.metadata.gpu_count else 0,
             cpu_count=self.metadata.cpu_count if self.metadata.cpu_count else 0,
             gpu_type=self.metadata.gpu_type if self.metadata.gpu_type else "",
-            start_at= get_ts_str(self.metadata.start_at),
-            end_at= get_ts_str(self.end_at),
+            start_at=get_ts_str(self.metadata.start_at),
+            end_at=get_ts_str(self.end_at),
             segments=self.segments,
             tags=[],
         )
@@ -366,11 +366,14 @@ def unzip_file(path: Path, file_name: str) -> str:
         print(f"::warning trying to download test log {object} failed by: {e}")
         return ""
 
+
 def get_ts_str(timestamp: float) -> str:
     return f"{timestamp:.0f}"
 
-def get_crt_ts_str():
+
+def get_crt_ts_str() -> str:
     return get_ts_str(datetime.now().timestamp())
+
 
 def parse_args() -> argparse.Namespace:
     """

--- a/tools/stats/upload_utilization_stats/upload_utilization_stats.py
+++ b/tools/stats/upload_utilization_stats/upload_utilization_stats.py
@@ -19,13 +19,13 @@ import pandas as pd  # type: ignore[import]
 from tools.stats.upload_stats_lib import download_s3_artifacts, upload_to_s3
 from tools.stats.utilization_stats_lib import (
     getDataModelVersion,
+    getTsNow,
     OssCiSegmentV1,
     OssCiUtilizationMetadataV1,
     OssCiUtilizationTimeSeriesV1,
     UtilizationMetadata,
     UtilizationRecord,
     WorkflowInfo,
-    getTsNow,
 )
 
 

--- a/tools/stats/upload_utilization_stats/upload_utilization_stats.py
+++ b/tools/stats/upload_utilization_stats/upload_utilization_stats.py
@@ -20,6 +20,7 @@ import pandas as pd  # type: ignore[import]
 from tools.stats.upload_stats_lib import download_s3_artifacts, upload_to_s3
 from tools.stats.utilization_stats_lib import (
     getDataModelVersion,
+    getTimestampString,
     OssCiSegmentV1,
     OssCiUtilizationMetadataV1,
     OssCiUtilizationTimeSeriesV1,
@@ -365,10 +366,6 @@ def unzip_file(path: Path, file_name: str) -> str:
     except Exception as e:
         print(f"::warning trying to download test log {object} failed by: {e}")
         return ""
-
-
-def getTimestampString(timestamp: float) -> str:
-    return f"{timestamp:.0f}"
 
 
 def parse_args() -> argparse.Namespace:

--- a/tools/stats/upload_utilization_stats/upload_utilization_stats.py
+++ b/tools/stats/upload_utilization_stats/upload_utilization_stats.py
@@ -58,7 +58,7 @@ class SegmentGenerator:
                 for process in (record.cmd_names or [])
             ]
         )
-        df[time_col_name] = pd.to_datetime(df[time_col_name], unit="s",utc=True)
+        df[time_col_name] = pd.to_datetime(df[time_col_name], unit="s", utc=True)
 
         # get unique cmd names
         unique_cmds_df = pd.DataFrame(df[cmd_col_name].unique(), columns=[cmd_col_name])
@@ -81,7 +81,7 @@ class SegmentGenerator:
                     level=CMD_PYTHON_LEVEL,
                     name=value,
                     start_at=int(row["start_time"].timestamp()),
-                    end_at= int(row["end_time"].timestamp()),
+                    end_at=int(row["end_time"].timestamp()),
                     extra_info={},
                 )
                 segments.append(segment)
@@ -365,6 +365,7 @@ def unzip_file(path: Path, file_name: str) -> str:
     except Exception as e:
         print(f"::warning trying to download test log {object} failed by: {e}")
         return ""
+
 
 def parse_args() -> argparse.Namespace:
     """

--- a/tools/stats/utilization_stats_lib.py
+++ b/tools/stats/utilization_stats_lib.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Optional
 
 from dataclasses_json import DataClassJsonMixin
-from datetime import datetime, timezone
+
+
 _DATA_MODEL_VERSION = 1.0
 
 
@@ -63,6 +65,7 @@ class OssCiSegmentV1(DataClassJsonMixin):
     end_at: int
     extra_info: dict[str, str]
 
+
 @dataclass
 class OssCiUtilizationMetadataV1:
     created_at: int
@@ -90,7 +93,7 @@ class OssCiUtilizationTimeSeriesV1:
     created_at: int
     type: str
     tags: list[str]
-    time_stamp: str
+    time_stamp: int
     repo: str
     workflow_id: int
     run_attempt: int
@@ -103,9 +106,11 @@ class OssCiUtilizationTimeSeriesV1:
 def getDataModelVersion() -> float:
     return _DATA_MODEL_VERSION
 
+
 def getTsNow() -> int:
     ts = datetime.now().timestamp()
     return int(ts)
+
 
 @dataclass
 class WorkflowInfo:

--- a/tools/stats/utilization_stats_lib.py
+++ b/tools/stats/utilization_stats_lib.py
@@ -54,6 +54,8 @@ class UtilizationRecord(DataClassJsonMixin):
     log_duration: Optional[str] = None
 
 
+# the db schema related to this is:
+# https://github.com/pytorch/test-infra/blob/main/clickhouse_db_schema/oss_ci_utilization/oss_ci_utilization_metadata_schema.sql
 @dataclass
 class OssCiSegmentV1(DataClassJsonMixin):
     level: str
@@ -63,8 +65,6 @@ class OssCiSegmentV1(DataClassJsonMixin):
     extra_info: dict[str, str]
 
 
-# the db schema related to this is:
-# https://github.com/pytorch/test-infra/blob/main/clickhouse_db_schema/oss_ci_utilization/oss_ci_utilization_metadata_schema.sql
 @dataclass
 class OssCiUtilizationMetadataV1:
     created_at: str
@@ -105,6 +105,7 @@ class OssCiUtilizationTimeSeriesV1:
 def getDataModelVersion() -> float:
     return _DATA_MODEL_VERSION
 
+
 @dataclass
 class WorkflowInfo:
     workflow_run_id: int
@@ -113,4 +114,3 @@ class WorkflowInfo:
     run_attempt: int
     job_name: str
     repo: str = "pytorch/pytorch"
-

--- a/tools/stats/utilization_stats_lib.py
+++ b/tools/stats/utilization_stats_lib.py
@@ -106,6 +106,10 @@ def getDataModelVersion() -> float:
     return _DATA_MODEL_VERSION
 
 
+def getTimestampString(timestamp: float) -> str:
+    return f"{timestamp:.0f}"
+
+
 @dataclass
 class WorkflowInfo:
     workflow_run_id: int

--- a/tools/stats/utilization_stats_lib.py
+++ b/tools/stats/utilization_stats_lib.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from dataclasses_json import DataClassJsonMixin
-
+from datetime import datetime
 
 _DATA_MODEL_VERSION = 1.0
 
@@ -23,7 +23,7 @@ class UtilizationMetadata(DataClassJsonMixin):
     job_name: str
     usage_collect_interval: float
     data_model_version: float
-    start_at: float
+    start_at: str
     gpu_count: Optional[int] = None
     cpu_count: Optional[int] = None
     gpu_type: Optional[str] = None
@@ -47,7 +47,7 @@ class RecordData(DataClassJsonMixin):
 @dataclass
 class UtilizationRecord(DataClassJsonMixin):
     level: str
-    timestamp: float
+    timestamp: str
     data: Optional[RecordData] = None
     cmd_names: Optional[list[str]] = None
     error: Optional[str] = None
@@ -105,9 +105,12 @@ class OssCiUtilizationTimeSeriesV1:
 def getDataModelVersion() -> float:
     return _DATA_MODEL_VERSION
 
-
-def getTimestampString(timestamp: float) -> str:
+def getTimestampStr(timestamp: float) -> str:
     return f"{timestamp:.0f}"
+
+def getCurrentTimestampStr() -> str:
+    timestamp_now =  datetime.now().timestamp()
+    return getTimestampStr(timestamp_now)
 
 
 @dataclass

--- a/tools/stats/utilization_stats_lib.py
+++ b/tools/stats/utilization_stats_lib.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from dataclasses_json import DataClassJsonMixin
-from datetime import datetime
+
 
 _DATA_MODEL_VERSION = 1.0
 
@@ -23,7 +23,7 @@ class UtilizationMetadata(DataClassJsonMixin):
     job_name: str
     usage_collect_interval: float
     data_model_version: float
-    start_at: str
+    start_at: float
     gpu_count: Optional[int] = None
     cpu_count: Optional[int] = None
     gpu_type: Optional[str] = None
@@ -47,7 +47,7 @@ class RecordData(DataClassJsonMixin):
 @dataclass
 class UtilizationRecord(DataClassJsonMixin):
     level: str
-    timestamp: str
+    timestamp: float
     data: Optional[RecordData] = None
     cmd_names: Optional[list[str]] = None
     error: Optional[str] = None
@@ -105,14 +105,6 @@ class OssCiUtilizationTimeSeriesV1:
 def getDataModelVersion() -> float:
     return _DATA_MODEL_VERSION
 
-def getTimestampStr(timestamp: float) -> str:
-    return f"{timestamp:.0f}"
-
-def getCurrentTimestampStr() -> str:
-    timestamp_now =  datetime.now().timestamp()
-    return getTimestampStr(timestamp_now)
-
-
 @dataclass
 class WorkflowInfo:
     workflow_run_id: int
@@ -121,3 +113,4 @@ class WorkflowInfo:
     run_attempt: int
     job_name: str
     repo: str = "pytorch/pytorch"
+

--- a/tools/stats/utilization_stats_lib.py
+++ b/tools/stats/utilization_stats_lib.py
@@ -58,8 +58,8 @@ class UtilizationRecord(DataClassJsonMixin):
 class OssCiSegmentV1(DataClassJsonMixin):
     level: str
     name: str
-    start_at: float
-    end_at: float
+    start_at: str
+    end_at: str
     extra_info: dict[str, str]
 
 
@@ -67,7 +67,7 @@ class OssCiSegmentV1(DataClassJsonMixin):
 # https://github.com/pytorch/test-infra/blob/main/clickhouse_db_schema/oss_ci_utilization/oss_ci_utilization_metadata_schema.sql
 @dataclass
 class OssCiUtilizationMetadataV1:
-    created_at: float
+    created_at: str
     repo: str
     workflow_id: int
     run_attempt: int
@@ -79,8 +79,8 @@ class OssCiUtilizationMetadataV1:
     gpu_count: int
     cpu_count: int
     gpu_type: str
-    start_at: float
-    end_at: float
+    start_at: str
+    end_at: str
     segments: list[OssCiSegmentV1]
     tags: list[str] = field(default_factory=list)
 
@@ -89,10 +89,10 @@ class OssCiUtilizationMetadataV1:
 # https://github.com/pytorch/test-infra/blob/main/clickhouse_db_schema/oss_ci_utilization/oss_ci_utilization_time_series_schema.sql
 @dataclass
 class OssCiUtilizationTimeSeriesV1:
-    created_at: float
+    created_at: str
     type: str
     tags: list[str]
-    time_stamp: float
+    time_stamp: str
     repo: str
     workflow_id: int
     run_attempt: int

--- a/tools/stats/utilization_stats_lib.py
+++ b/tools/stats/utilization_stats_lib.py
@@ -2,8 +2,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from dataclasses_json import DataClassJsonMixin
-
-
+from datetime import datetime, timezone
 _DATA_MODEL_VERSION = 1.0
 
 
@@ -23,7 +22,7 @@ class UtilizationMetadata(DataClassJsonMixin):
     job_name: str
     usage_collect_interval: float
     data_model_version: float
-    start_at: float
+    start_at: int
     gpu_count: Optional[int] = None
     cpu_count: Optional[int] = None
     gpu_type: Optional[str] = None
@@ -47,7 +46,7 @@ class RecordData(DataClassJsonMixin):
 @dataclass
 class UtilizationRecord(DataClassJsonMixin):
     level: str
-    timestamp: float
+    timestamp: int
     data: Optional[RecordData] = None
     cmd_names: Optional[list[str]] = None
     error: Optional[str] = None
@@ -60,14 +59,13 @@ class UtilizationRecord(DataClassJsonMixin):
 class OssCiSegmentV1(DataClassJsonMixin):
     level: str
     name: str
-    start_at: str
-    end_at: str
+    start_at: int
+    end_at: int
     extra_info: dict[str, str]
-
 
 @dataclass
 class OssCiUtilizationMetadataV1:
-    created_at: str
+    created_at: int
     repo: str
     workflow_id: int
     run_attempt: int
@@ -79,8 +77,8 @@ class OssCiUtilizationMetadataV1:
     gpu_count: int
     cpu_count: int
     gpu_type: str
-    start_at: str
-    end_at: str
+    start_at: int
+    end_at: int
     segments: list[OssCiSegmentV1]
     tags: list[str] = field(default_factory=list)
 
@@ -89,7 +87,7 @@ class OssCiUtilizationMetadataV1:
 # https://github.com/pytorch/test-infra/blob/main/clickhouse_db_schema/oss_ci_utilization/oss_ci_utilization_time_series_schema.sql
 @dataclass
 class OssCiUtilizationTimeSeriesV1:
-    created_at: str
+    created_at: int
     type: str
     tags: list[str]
     time_stamp: str
@@ -105,6 +103,9 @@ class OssCiUtilizationTimeSeriesV1:
 def getDataModelVersion() -> float:
     return _DATA_MODEL_VERSION
 
+def getTsNow() -> int:
+    ts = datetime.now().timestamp()
+    return int(ts)
 
 @dataclass
 class WorkflowInfo:


### PR DESCRIPTION
Convert all timestamp(float) to int  timestamp during data pipeline for db type datetime64.
float does not work when try to insert into clickhouse using jsonExtract.
