### PR TITLE
fix indirect broadcast

### DIFF
--- a/test/inductor/test_debug_trace.py
+++ b/test/inductor/test_debug_trace.py
@@ -81,9 +81,9 @@ class TestDebugTrace(test_torchinductor.TestCase):
             """\
 BEFORE FUSION
 op0: SchedulerNode(ComputedBuffer)
-op0.writes = [MemoryDep('buf0', c0, {c0: 256})]
+op0.writes = [   MemoryDep('buf0', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
 op0.unmet_dependencies = []
-op0.met_dependencies = [MemoryDep('arg0_1', c0, {c0: 256})]
+op0.met_dependencies = [   MemoryDep('arg0_1', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
 op0.outputs = [
     buf0: ComputedBuffer
     buf0.layout = FixedLayout('cpu', torch.float32, size=[16, 16], stride=[16, 1])
@@ -108,8 +108,8 @@ class op0_loop_body:
 
 
 op1: SchedulerNode(ComputedBuffer)
-op1.writes = [MemoryDep('buf1', c0, {c0: 256})]
-op1.unmet_dependencies = [MemoryDep('buf0', c0, {c0: 256})]
+op1.writes = [   MemoryDep('buf1', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
+op1.unmet_dependencies = [   MemoryDep('buf0', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
 op1.met_dependencies = []
 op1.outputs = [
     buf1: ComputedBuffer
@@ -152,9 +152,11 @@ op2.node.kernel = extern_kernels.mm""",
             """\
 AFTER FUSION
 op0_op1: FusedSchedulerNode(SchedulerNode,SchedulerNode)
-op0_op1.writes = [MemoryDep('buf0', c0, {c0: 256}), MemoryDep('buf1', c0, {c0: 256})]
+op0_op1.writes = 
+    [   MemoryDep('buf0', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=()),
+        MemoryDep('buf1', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
 op0_op1.unmet_dependencies = []
-op0_op1.met_dependencies = [MemoryDep('arg0_1', c0, {c0: 256})]
+op0_op1.met_dependencies = [   MemoryDep('arg0_1', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
 op0_op1.outputs = [
     buf0: ComputedBuffer
     buf0.layout = FixedLayout('cpu', torch.float32, size=[16, 16], stride=[16, 1])
@@ -165,9 +167,9 @@ op0_op1.outputs = [
 ]
 op0_op1.snodes[0] =
 op0: SchedulerNode(ComputedBuffer)
-op0.writes = [MemoryDep('buf0', c0, {c0: 256})]
+op0.writes = [   MemoryDep('buf0', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
 op0.unmet_dependencies = []
-op0.met_dependencies = [MemoryDep('arg0_1', c0, {c0: 256})]
+op0.met_dependencies = [   MemoryDep('arg0_1', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
 op0.outputs = [
     buf0: ComputedBuffer
     buf0.layout = FixedLayout('cpu', torch.float32, size=[16, 16], stride=[16, 1])
@@ -191,8 +193,8 @@ class op0_loop_body:
         return store
 op0_op1.snodes[1] =
 op1: SchedulerNode(ComputedBuffer)
-op1.writes = [MemoryDep('buf1', c0, {c0: 256})]
-op1.unmet_dependencies = [MemoryDep('buf0', c0, {c0: 256})]
+op1.writes = [   MemoryDep('buf1', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
+op1.unmet_dependencies = [   MemoryDep('buf0', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
 op1.met_dependencies = []
 op1.outputs = [
     buf1: ComputedBuffer

--- a/test/inductor/test_debug_trace.py
+++ b/test/inductor/test_debug_trace.py
@@ -81,9 +81,9 @@ class TestDebugTrace(test_torchinductor.TestCase):
             """\
 BEFORE FUSION
 op0: SchedulerNode(ComputedBuffer)
-op0.writes = [   MemoryDep('buf0', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
+op0.writes = [MemoryDep('buf0', c0, {c0: 256})]
 op0.unmet_dependencies = []
-op0.met_dependencies = [   MemoryDep('arg0_1', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
+op0.met_dependencies = [MemoryDep('arg0_1', c0, {c0: 256})]
 op0.outputs = [
     buf0: ComputedBuffer
     buf0.layout = FixedLayout('cpu', torch.float32, size=[16, 16], stride=[16, 1])
@@ -108,8 +108,8 @@ class op0_loop_body:
 
 
 op1: SchedulerNode(ComputedBuffer)
-op1.writes = [   MemoryDep('buf1', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
-op1.unmet_dependencies = [   MemoryDep('buf0', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
+op1.writes = [MemoryDep('buf1', c0, {c0: 256})]
+op1.unmet_dependencies = [MemoryDep('buf0', c0, {c0: 256})]
 op1.met_dependencies = []
 op1.outputs = [
     buf1: ComputedBuffer
@@ -152,11 +152,9 @@ op2.node.kernel = extern_kernels.mm""",
             """\
 AFTER FUSION
 op0_op1: FusedSchedulerNode(SchedulerNode,SchedulerNode)
-op0_op1.writes = 
-    [   MemoryDep('buf0', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=()),
-        MemoryDep('buf1', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
+op0_op1.writes = [MemoryDep('buf0', c0, {c0: 256}), MemoryDep('buf1', c0, {c0: 256})]
 op0_op1.unmet_dependencies = []
-op0_op1.met_dependencies = [   MemoryDep('arg0_1', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
+op0_op1.met_dependencies = [MemoryDep('arg0_1', c0, {c0: 256})]
 op0_op1.outputs = [
     buf0: ComputedBuffer
     buf0.layout = FixedLayout('cpu', torch.float32, size=[16, 16], stride=[16, 1])
@@ -167,9 +165,9 @@ op0_op1.outputs = [
 ]
 op0_op1.snodes[0] =
 op0: SchedulerNode(ComputedBuffer)
-op0.writes = [   MemoryDep('buf0', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
+op0.writes = [MemoryDep('buf0', c0, {c0: 256})]
 op0.unmet_dependencies = []
-op0.met_dependencies = [   MemoryDep('arg0_1', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
+op0.met_dependencies = [MemoryDep('arg0_1', c0, {c0: 256})]
 op0.outputs = [
     buf0: ComputedBuffer
     buf0.layout = FixedLayout('cpu', torch.float32, size=[16, 16], stride=[16, 1])
@@ -193,8 +191,8 @@ class op0_loop_body:
         return store
 op0_op1.snodes[1] =
 op1: SchedulerNode(ComputedBuffer)
-op1.writes = [   MemoryDep('buf1', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
-op1.unmet_dependencies = [   MemoryDep('buf0', c0, {c0: 256}, replacement=((d0, c0),), indirect_broadcast=())]
+op1.writes = [MemoryDep('buf1', c0, {c0: 256})]
+op1.unmet_dependencies = [MemoryDep('buf0', c0, {c0: 256})]
 op1.met_dependencies = []
 op1.outputs = [
     buf1: ComputedBuffer

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7597,7 +7597,7 @@ class CommonTemplate:
             "x1 = xindex",
             "tmp0 = tl.load(in_ptr0 + (x1), None,",
         ]:
-            self.assertTrue(string, code)
+            self.assertTrue(string in code)
 
     def test_roi_align(self):
         if not has_torchvision_roi_align():

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7595,7 +7595,7 @@ class CommonTemplate:
         for string in [
             "xnumel = 16384",
             "xoffset = tl.program_id(0) * XBLOCK",
-            "xindex = xoffset + tl.arange(0, XBLOCK)[:, None]",
+            "xindex = xoffset + tl.arange(0, XBLOCK)[None, :]",
             "x1 = xindex",
             "tmp0 = tl.load(in_ptr0 + (x1), None,",
         ]:

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7579,6 +7579,7 @@ class CommonTemplate:
             ),
         )
 
+    @skip_if_triton_cpu
     @requires_gpu()
     def test_indirect_broadcast_embedding(self):
         B, T, D, V = (8, 2048, 4096, 2048)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7579,15 +7579,13 @@ class CommonTemplate:
             ),
         )
 
+    @requires_gpu()
     def test_indirect_broadcast_embedding(self):
         B, T, D, V = (8, 2048, 4096, 2048)
         op = nn.Embedding(V, D).to(self.device).to(torch.float32)
-        shared_weight = op.weight.data
-        tmp_op = nn.Embedding(V, D).to(self.device).to(torch.float32)
-        tmp_op.weight.data.copy_(shared_weight)
         _input = torch.randint(0, V, (B, T), device=self.device)
-        self.common(op, (_input,))
-        compiled_op = torch.compile(tmp_op)
+        self.common(op, (_input,), check_lowp=False)
+        compiled_op = torch.compile(op)
         code = run_and_get_triton_code(
             compiled_op,
             _input,

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -59,6 +59,9 @@ test_failures = {
         ("cpu", "cuda", "xpu")
     ),
     "test_randint_distribution_dynamic_shapes": TestFailure(("cuda", "xpu")),
+    "test_indirect_broadcast_embedding_dynamic_shapes": TestFailure(
+        ("cpu", "cuda", "xpu"), is_skip=True
+    ),
 }
 if not torch._inductor.config.cpp_wrapper:
     test_failures["test_conv_inference_heuristics_dynamic_shapes"] = TestFailure(

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2057,8 +2057,8 @@ class SIMDScheduling(BaseScheduling):
             perf_hint_log.info("possibly bad tiling: %s", ranked_tilings)
         indirect_broadcast = False
         # save iter vars in indirect broadcast memory reads
-        iter_vars_symbols = OrderedSet()
-        other_dims = []
+        iter_vars_symbols: OrderedSet[sympy.Symbol] = OrderedSet()
+        other_dims: list[sympy.Symbol] = []
 
         if len(node_schedule) == 1:
             indices = OrderedSet(
@@ -2075,31 +2075,31 @@ class SIMDScheduling(BaseScheduling):
                         if not INDIRECT_PATTERN.search(asymbol.name):
                             iter_vars_symbols.add(asymbol)
             if indirect_broadcast:
-                indices = list(indices)
-                indices.sort(key=lambda d: d.name)
-                assert len(indices) == len(node_schedule[0]._body.iter_vars), (
-                    indices,
+                indices_list = list(indices)
+                indices_list.sort(key=lambda d: d.name)
+                assert len(indices_list) == len(node_schedule[0]._body.iter_vars), (
+                    indices_list,
                     node_schedule[0]._body.iter_vars,
                 )
                 assert all(
-                    v not in node_schedule[0]._body.iter_vars for v in indices
-                ), f"{node_schedule[0]._body.iter_vars=}, {indices=}"
+                    v not in node_schedule[0]._body.iter_vars for v in indices_list
+                ), f"{node_schedule[0]._body.iter_vars=}, {indices_list=}"
                 # map iter vars in mem deps to ir iter vars
-                replacements = dict(zip(indices, node_schedule[0]._body.iter_vars))
-                iter_vars_symbols = [
+                replacements = dict(zip(indices_list, node_schedule[0]._body.iter_vars))
+                iter_vars_symbols_list = [
                     replacements[iter_var] for iter_var in iter_vars_symbols
                 ]
                 other_dims = [
                     iter_var
                     for iter_var in node_schedule[0]._body.iter_vars
-                    if iter_var not in iter_vars_symbols
+                    if iter_var not in iter_vars_symbols_list
                 ]
-                iter_vars_symbols.sort(
+                iter_vars_symbols_list.sort(
                     key=lambda iter_var: node_schedule[0]._body.var_ranges[iter_var]
                 )
                 new_order = [
                     node_schedule[0]._body.iter_vars.index(dim)
-                    for dim in iter_vars_symbols
+                    for dim in iter_vars_symbols_list
                 ] + [node_schedule[0]._body.iter_vars.index(dim) for dim in other_dims]
                 # we only check iter vars, not reduction vars
                 if new_order != list(range(len(node_schedule[0]._body.sizes[0]))):

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2059,19 +2059,27 @@ class SIMDScheduling(BaseScheduling):
         indirect_broadcast_pairs: list[tuple[sympy.Symbol, sympy.Symbol]] = []
         if len(node_schedule) == 1:
             for read in node_schedule[0].read_writes.reads:
-                if isinstance(read, MemoryDep) and hasattr(read, "indirect_broadcast") and read.indirect_broadcast:
+                if (
+                    isinstance(read, MemoryDep)
+                    and hasattr(read, "indirect_broadcast")
+                    and read.indirect_broadcast
+                ):
                     indirect_broadcast_pairs.append(read.indirect_broadcast)
 
             if indirect_broadcast_pairs:
-                tail = []
+                tail: list[int] = []
                 for pair in indirect_broadcast_pairs:
                     idx_first = node_schedule[0]._body.iter_vars.index(pair[0])
                     idx_second = node_schedule[0]._body.iter_vars.index(pair[1])
-                for idx in [idx_second, idx_first]:
-                    if idx in tail:
-                        tail.remove(idx)
-                    tail.append(idx)
-                remaining = [i for i in range(len(node_schedule[0]._body.iter_vars)) if i not in tail]
+                    for idx in [idx_second, idx_first]:
+                        if idx in tail:
+                            tail.remove(idx)
+                        tail.append(idx)
+                remaining = [
+                    i
+                    for i in range(len(node_schedule[0]._body.iter_vars))
+                    if i not in tail
+                ]
                 new_order = remaining + tail
                 if new_order != list(range(len(node_schedule[0]._body.sizes[0]))):
                     node_schedule[0].apply_new_loop_order(new_order)

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2051,9 +2051,15 @@ class SIMDScheduling(BaseScheduling):
 
         if len(ranked_tilings) > 1:
             perf_hint_log.info("possibly bad tiling: %s", ranked_tilings)
+        indirect_broadcast = False
+        for read in node.read_writes.reads:
+            if read.indirect_broadcast:
+                # If we have an indirect broadcast, we can't tile the kernel.
+                # return default_tiling
+                indirect_broadcast = True
 
         # Optionally, prefer tiling into as many dimensions as possible.
-        if config.triton.prefer_nd_tiling:
+        if config.triton.prefer_nd_tiling or indirect_broadcast:
             ranked_tilings = (
                 cls.get_nd_tilings(node_schedule, numel, reduction_numel)
                 + ranked_tilings

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2052,7 +2052,7 @@ class SIMDScheduling(BaseScheduling):
         if len(ranked_tilings) > 1:
             perf_hint_log.info("possibly bad tiling: %s", ranked_tilings)
         have_indirect_broadcast = False
-        for node in node_schedule:
+        for node in EnableReduction.filter(node_schedule):
             # save iter vars in indirect broadcast memory reads
             indirect_broadcast_pairs: list[tuple[sympy.Symbol, sympy.Symbol]] = []
             for read in node.read_writes.reads:

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2057,9 +2057,8 @@ class SIMDScheduling(BaseScheduling):
         other_dims = []
         
         if len(node_schedule) == 1:
-            
             indices = set()
-            for index, read in enumerate(node_schedule[0].read_writes.reads):
+            for read in node_schedule[0].read_writes.reads:
                 if hasattr(read, 'indirect_broadcast') and read.indirect_broadcast:
                     indirect_broadcast = True
                     for asymbol in read.index.free_symbols:
@@ -2068,7 +2067,6 @@ class SIMDScheduling(BaseScheduling):
                             indirect_dims.add(asymbol)
                 indices.update(read.var_names)
             
-            # index = list(node_schedule[0].read_writes.var_ranges.keys())
             indices = list(indices)
             indices.sort(key=lambda d:d.name)
             assert len(indices) == len(node_schedule[0]._body.iter_vars), (indices, node_schedule[0]._body.iter_vars)

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2052,11 +2052,20 @@ class SIMDScheduling(BaseScheduling):
         if len(ranked_tilings) > 1:
             perf_hint_log.info("possibly bad tiling: %s", ranked_tilings)
         indirect_broadcast = False
-        for read in node.read_writes.reads:
-            if read.indirect_broadcast:
-                # If we have an indirect broadcast, we can't tile the kernel.
-                # return default_tiling
-                indirect_broadcast = True
+        indirect_dims = []
+        other_dims = []
+        
+        if len(node_schedule) == 1:
+            for index, read in enumerate(node_schedule[0].read_writes.reads):
+                if hasattr(read, 'indirect_broadcast') and read.indirect_broadcast:
+                    indirect_broadcast = True
+                    indirect_dims.append(index)
+            if indirect_broadcast and len(node_schedule) == 1:
+                indirect_dims.sort(key=lambda d: V.graph.sizevars.size_hint(node_schedule[0]._body.sizes[0][d]))
+                other_dims = [d for d in range(len(node_schedule[0]._body.sizes[0])) if d not in indirect_dims]
+                new_order = indirect_dims + other_dims
+                if new_order != list(range(len(node_schedule[0]._body.sizes[0]))):
+                    node_schedule[0].apply_new_loop_order(new_order)
 
         # Optionally, prefer tiling into as many dimensions as possible.
         if config.triton.prefer_nd_tiling or indirect_broadcast:

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
 
 import re
 
+
 log = logging.getLogger(__name__)
 perf_hint_log = torch._logging.getArtifactLogger(__name__, "perf_hints")
 schedule_log = torch._logging.getArtifactLogger(__name__, "schedule")
@@ -79,6 +80,7 @@ pexpr = PythonPrinter().doprint
 all_prefixes = OrderedSet(["z", "y", "x", "r0_", "r1_"])
 
 INDIRECT_PATTERN = re.compile(r"indirect|tmp")
+
 
 @dataclasses.dataclass
 class IterationRanges:
@@ -2055,34 +2057,50 @@ class SIMDScheduling(BaseScheduling):
             perf_hint_log.info("possibly bad tiling: %s", ranked_tilings)
         indirect_broadcast = False
         # save iter vars in indirect broadcast memory reads
-        iter_vars_symbols = set()
+        iter_vars_symbols = OrderedSet()
         other_dims = []
-        
+
         if len(node_schedule) == 1:
-            indices = {
-                var
-                for read in node_schedule[0].read_writes.reads
-                for var in read.var_names
-            }
+            indices = OrderedSet(
+                [
+                    var
+                    for read in node_schedule[0].read_writes.reads
+                    for var in read.var_names
+                ]
+            )
             for read in node_schedule[0].read_writes.reads:
-                if hasattr(read, 'indirect_broadcast') and read.indirect_broadcast:
+                if hasattr(read, "indirect_broadcast") and read.indirect_broadcast:
                     indirect_broadcast = True
                     for asymbol in read.index.free_symbols:
                         if not INDIRECT_PATTERN.search(asymbol.name):
                             iter_vars_symbols.add(asymbol)
             if indirect_broadcast:
                 indices = list(indices)
-                indices.sort(key=lambda d:d.name)
-                assert len(indices) == len(node_schedule[0]._body.iter_vars), (indices, node_schedule[0]._body.iter_vars)
+                indices.sort(key=lambda d: d.name)
+                assert len(indices) == len(node_schedule[0]._body.iter_vars), (
+                    indices,
+                    node_schedule[0]._body.iter_vars,
+                )
                 assert all(
                     v not in node_schedule[0]._body.iter_vars for v in indices
                 ), f"{node_schedule[0]._body.iter_vars=}, {indices=}"
                 # map iter vars in mem deps to ir iter vars
                 replacements = dict(zip(indices, node_schedule[0]._body.iter_vars))
-                iter_vars_symbols = [replacements[iter_var] for iter_var in iter_vars_symbols]
-                other_dims = [iter_var for iter_var in node_schedule[0]._body.iter_vars if iter_var not in iter_vars_symbols]
-                iter_vars_symbols.sort(key=lambda iter_var: node_schedule[0]._body.var_ranges[iter_var])
-                new_order = [node_schedule[0]._body.iter_vars.index(dim) for dim in iter_vars_symbols] + [node_schedule[0]._body.iter_vars.index(dim) for dim in other_dims]
+                iter_vars_symbols = [
+                    replacements[iter_var] for iter_var in iter_vars_symbols
+                ]
+                other_dims = [
+                    iter_var
+                    for iter_var in node_schedule[0]._body.iter_vars
+                    if iter_var not in iter_vars_symbols
+                ]
+                iter_vars_symbols.sort(
+                    key=lambda iter_var: node_schedule[0]._body.var_ranges[iter_var]
+                )
+                new_order = [
+                    node_schedule[0]._body.iter_vars.index(dim)
+                    for dim in iter_vars_symbols
+                ] + [node_schedule[0]._body.iter_vars.index(dim) for dim in other_dims]
                 # we only check iter vars, not reduction vars
                 if new_order != list(range(len(node_schedule[0]._body.sizes[0]))):
                     node_schedule[0].apply_new_loop_order(new_order)

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -66,8 +66,6 @@ from .simd_kernel_features import (
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Sequence
 
-import re
-
 
 log = logging.getLogger(__name__)
 perf_hint_log = torch._logging.getArtifactLogger(__name__, "perf_hints")
@@ -78,8 +76,6 @@ fusion_log = torch._logging.getArtifactLogger(__name__, "fusion")
 pexpr = PythonPrinter().doprint
 
 all_prefixes = OrderedSet(["z", "y", "x", "r0_", "r1_"])
-
-INDIRECT_PATTERN = re.compile(r"indirect|tmp")
 
 
 @dataclasses.dataclass

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2061,13 +2061,6 @@ class SIMDScheduling(BaseScheduling):
         other_dims: list[sympy.Symbol] = []
 
         if len(node_schedule) == 1:
-            indices = OrderedSet(
-                [
-                    var
-                    for read in node_schedule[0].read_writes.reads
-                    for var in read.var_names
-                ]
-            )
             for read in node_schedule[0].read_writes.reads:
                 if hasattr(read, "indirect_broadcast") and read.indirect_broadcast:
                     indirect_broadcast = True
@@ -2075,6 +2068,13 @@ class SIMDScheduling(BaseScheduling):
                         if not INDIRECT_PATTERN.search(asymbol.name):
                             iter_vars_symbols.add(asymbol)
             if indirect_broadcast:
+                indices = OrderedSet(
+                    [
+                        var
+                        for read in node_schedule[0].read_writes.reads
+                        for var in read.var_names
+                    ]
+                )
                 indices_list = list(indices)
                 indices_list.sort(key=lambda d: d.name)
                 assert len(indices_list) == len(node_schedule[0]._body.iter_vars), (

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2051,6 +2051,7 @@ class SIMDScheduling(BaseScheduling):
 
         if len(ranked_tilings) > 1:
             perf_hint_log.info("possibly bad tiling: %s", ranked_tilings)
+        have_indirect_broadcast = False
         for node in node_schedule:
             # save iter vars in indirect broadcast memory reads
             indirect_broadcast_pairs: list[tuple[sympy.Symbol, sympy.Symbol]] = []
@@ -2063,13 +2064,16 @@ class SIMDScheduling(BaseScheduling):
                     indirect_broadcast_pairs.append(read.indirect_broadcast)
 
             if indirect_broadcast_pairs:
+                have_indirect_broadcast = True
                 tail: list[int] = []
                 for pair in indirect_broadcast_pairs:
                     # indirect load dimension
                     idx_first = node._body.iter_vars.index(pair[0])
                     # broadcast dimension
                     idx_second = node._body.iter_vars.index(pair[1])
-                    # move the indirect load dimension to the end of the list, where it will be the innermost dimension. if we have multiple pairs sharing the indirect load dimension, e.g. [(p1, p0), (p1, p0)], we will move the shared dimension p0 to the end of the list, which is the innermost dimension.
+                    # move the indirect load dimension to the end of the list, where it will be the innermost dimension.
+                    # if we have multiple pairs sharing the indirect load dimension, e.g. [(p1, p0), (p1, p0)],
+                    # we will move the shared dimension p0 to the end of the list, which is the innermost dimension.
                     for idx in [idx_second, idx_first]:
                         if idx in tail:
                             tail.remove(idx)
@@ -2082,7 +2086,7 @@ class SIMDScheduling(BaseScheduling):
                     node.apply_new_loop_order(new_order)
 
         # Optionally, prefer tiling into as many dimensions as possible.
-        if config.triton.prefer_nd_tiling or indirect_broadcast_pairs:
+        if config.triton.prefer_nd_tiling or have_indirect_broadcast:
             ranked_tilings = (
                 cls.get_nd_tilings(node_schedule, numel, reduction_numel)
                 + ranked_tilings

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -70,6 +70,7 @@ class MemoryDep(Dep):
     var_names: tuple[sympy.Symbol, ...]
     size: tuple[sympy.Expr, ...]
     mode: Optional[str] = None
+    # need to be updated with more information rather than just True/False
     indirect_broadcast: bool = False
 
     def __repr__(self) -> str:
@@ -698,6 +699,7 @@ def extract_loop_body_with_args(
                 if free_symbol in repl_reverse:
                     for node in fn.root_block.graph.nodes:
                         if node.name == f"set_{repl_reverse[free_symbol].name}" and len(node.args) == 1 and node.args[0].name.startswith("load"):
+                            # not sure if this is the correct way to update deps
                             read_new = read.set_indirect_broadcast_to_True()
                             replacement_mem_dep[read] = read_new
     for read,read_new in replacement_mem_dep.items():

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -156,7 +156,7 @@ class MemoryDep(Dep):
         this method does not reorder loops while normalize_with_stride_order reorder
         loops based on stride order.
         """
-        index, var_names, sizes, replacement = _RecordLoadStoreInner.canonicalize(
+        index, var_names, sizes, replacement = _RecordLoadStoreInner._normalize(
             self.index, self.ranges
         )
         return MemoryDep(

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -293,10 +293,6 @@ class MemoryDep(Dep):
     def is_indirect(self) -> bool:
         return any(is_indirect(v.name) for v in self.index.free_symbols)  # type: ignore[attr-defined]
 
-    def __hash__(self) -> int:
-        # Hash must be consistent with __eq__
-        return hash((self.name, self.index, self.var_names, self.size, self.mode))
-
 
 @dataclasses.dataclass(frozen=True)
 class StarDep(Dep):

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -2,6 +2,7 @@ import abc
 import dataclasses
 import itertools
 import logging
+from os import replace
 import re
 from collections.abc import Iterable, Sequence
 from typing import Any, Callable, Optional, TypeVar, Union
@@ -69,6 +70,7 @@ class MemoryDep(Dep):
     var_names: tuple[sympy.Symbol, ...]
     size: tuple[sympy.Expr, ...]
     mode: Optional[str] = None
+    indirect_broadcast: bool = False
 
     def __repr__(self) -> str:
         maybe_mode = ""
@@ -287,6 +289,16 @@ class MemoryDep(Dep):
 
     def is_indirect(self) -> bool:
         return any(is_indirect(v.name) for v in self.index.free_symbols)  # type: ignore[attr-defined]
+
+    def set_indirect_broadcast_to_True(self) -> "MemoryDep":
+        return MemoryDep(
+            name=self.name,
+            index=self.index,
+            var_names=self.var_names,
+            size=self.size,
+            mode=self.mode,
+            indirect_broadcast=True,
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -641,6 +653,8 @@ def extract_loop_body_with_args(
     # Fast path to avoid tracing when we already have a LoopBody
     inner = _RecordLoadStoreInner(var_ranges=var_ranges, normalize=normalize)
     name_to_index = fn.indexing_from_args(args)
+    repl = {}
+
     if fn.indirect_vars:
         # mimic the `tmpX` naming tracing gives us
         repl = {v: make_symbol(SymT.TMP, i) for i, v in enumerate(fn.indirect_vars)}
@@ -675,6 +689,20 @@ def extract_loop_body_with_args(
             None,  # type: ignore[arg-type]
         )
     # fn.memory_usage[MemoryUsageType.CHECK_BOUNDS] intentionally skipped
+    # detect indirect broadcast
+    repl_reverse = {v: k for k, v in repl.items()}  # type: ignore[assignment]
+    replacement_mem_dep = {}
+    for i, read in enumerate(inner._reads):
+        if isinstance(read, MemoryDep):
+            for free_symbol in read.index.free_symbols:
+                if free_symbol in repl_reverse:
+                    for node in fn.root_block.graph.nodes:
+                        if node.name == f"set_{repl_reverse[free_symbol].name}" and len(node.args) == 1 and node.args[0].name.startswith("load"):
+                            read_new = read.set_indirect_broadcast_to_True()
+                            replacement_mem_dep[read] = read_new
+    for read,read_new in replacement_mem_dep.items():
+        inner._reads.remove(read)
+        inner._reads.add(read_new)
     return inner
 
 

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -500,9 +500,7 @@ class _RecordLoadStoreInner(V.MockHandler):  # type: ignore[name-defined]
             sizes.pop()
 
     @classmethod
-    def _normalize(
-        cls, index: sympy.Expr, var_ranges: VarRanges
-    ) -> tuple[
+    def _normalize(cls, index: sympy.Expr, var_ranges: VarRanges) -> tuple[
         sympy.Expr,
         tuple[sympy.Symbol, ...],
         tuple[sympy.Expr, ...],
@@ -530,9 +528,7 @@ class _RecordLoadStoreInner(V.MockHandler):  # type: ignore[name-defined]
         cls.drop_unused_symbols(index, new_vars, new_sizes)
         return index, tuple(new_vars), tuple(new_sizes), tuple(replacement.items())  # type: ignore[arg-type]
 
-    def canonicalize(
-        self, index: sympy.Expr
-    ) -> tuple[
+    def canonicalize(self, index: sympy.Expr) -> tuple[
         sympy.Expr,
         tuple[sympy.Symbol, ...],
         tuple[sympy.Expr, ...],
@@ -729,7 +725,7 @@ def extract_loop_body_with_args(
     # detect indirect broadcast
     repl_reverse = {v: k for k, v in repl.items()}  # type: ignore[assignment]
     replacement_mem_dep = {}
-    name_to_node = {node.name: node for node in fn.root_block.graph.nodes}
+    name_to_node = {node.target: node for node in fn.get_nodes()}
     for read in inner._reads:
         if isinstance(read, MemoryDep) and read.replacement:
             indirect_load_dim_indexing_expr = None
@@ -742,9 +738,11 @@ def extract_loop_body_with_args(
                 continue
             indirect_var = indirect_vars[0]
             set_indirect_node = name_to_node[f"set_{repl_reverse[indirect_var].name}"]
-            if len(set_indirect_node.args) == 1 and set_indirect_node.args[
-                0
-            ].name.startswith("load"):
+            if (
+                len(set_indirect_node.args) == 1
+                and set_indirect_node.args[0].target.startswith("load")
+                and "load_seed" not in set_indirect_node.args[0].target
+            ):
                 the_load_node = set_indirect_node.args[0]
                 arg_pattern = [str(arg) for arg in the_load_node.args]
                 if (

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -807,7 +807,8 @@ def extract_loop_body_with_args(
             broadcast_dim_indexing = None
             replacement = dict(read.replacement)
             replacement_reverse = {v: k for k, v in replacement.items()}
-            assert additive_symbol in replacement_reverse
+            if additive_symbol not in replacement_reverse:
+                continue
             d_symbol = replacement_reverse[additive_symbol]
             d_p_replacement = {v: k for k, v in fn.replacement.items()}
             broadcast_dim_indexing = d_p_replacement[d_symbol]

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -740,7 +740,18 @@ def extract_loop_body_with_args(
             ):
                 continue
             # check if the coefficient is the stride
+            buffer = None
+            if read.name in V.graph.name_to_buffer:
+                buffer = V.graph.name_to_buffer[read.name]
+            elif read.name in V.graph.graph_inputs:
+                buffer = V.graph.graph_inputs[read.name]
 
+            if buffer is None or not isinstance(
+                buffer.layout, torch._inductor.ir.FixedLayout
+            ):
+                continue
+            if coefficient not in buffer.layout.stride:
+                continue
             # check the indirect variable
             indirect_load_dim_indexing_expr = None
             indirect_var = multiplied_symbol

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -2,7 +2,6 @@ import abc
 import dataclasses
 import itertools
 import logging
-from os import replace
 import re
 from collections.abc import Iterable, Sequence
 from typing import Any, Callable, Optional, TypeVar, Union
@@ -698,11 +697,15 @@ def extract_loop_body_with_args(
             for free_symbol in read.index.free_symbols:
                 if free_symbol in repl_reverse:
                     for node in fn.root_block.graph.nodes:
-                        if node.name == f"set_{repl_reverse[free_symbol].name}" and len(node.args) == 1 and node.args[0].name.startswith("load"):
+                        if (
+                            node.name == f"set_{repl_reverse[free_symbol].name}"
+                            and len(node.args) == 1
+                            and node.args[0].name.startswith("load")
+                        ):
                             # not sure if this is the correct way to update deps
                             read_new = read.set_indirect_broadcast_to_True()
                             replacement_mem_dep[read] = read_new
-    for read,read_new in replacement_mem_dep.items():
+    for read, read_new in replacement_mem_dep.items():
         inner._reads.remove(read)
         inner._reads.add(read_new)
     return inner

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -760,17 +760,13 @@ def extract_loop_body_with_args(
             ):
                 continue
             # check if the coefficient is the stride
-            buffer = None
-            if read.name in V.graph.name_to_buffer:
-                buffer = V.graph.name_to_buffer[read.name]  # type: ignore[assignment]
-            elif read.name in V.graph.graph_inputs:
-                buffer = V.graph.graph_inputs[read.name]  # type: ignore[assignment]
+            buffer = V.graph.try_get_buffer(read.name)
 
             if buffer is None or not isinstance(
-                buffer.layout, torch._inductor.ir.FixedLayout
+                buffer.get_layout(), torch._inductor.ir.FixedLayout
             ):
                 continue
-            if coefficient not in buffer.layout.stride:
+            if coefficient not in buffer.get_stride():
                 continue
             # check the indirect variable
             indirect_load_dim_indexing_expr = None

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -775,7 +775,6 @@ def extract_loop_body_with_args(
             # check the indirect variable
             indirect_load_dim_indexing_expr = None
             indirect_var = multiplied_symbol
-            # Fix: Check that indirect_var is not None before accessing .name
             if indirect_var is None or not is_indirect(indirect_var.name):
                 continue
             # find out its corresponding set_indirect node, e.g. set_indirect0
@@ -799,7 +798,6 @@ def extract_loop_body_with_args(
                         # argument and the indexX's expression should be in
                         # fn.iter_vars, e.g. index0 = p0
                         indexing = fn.indexing_exprs.get(the_load_index_node.args[0])
-                        # do we need to consider cases like index0 = p0 + 32*p1?
                         if indexing is not None and indexing in fn.iter_vars:
                             indirect_load_dim_indexing_expr = indexing
             if indirect_load_dim_indexing_expr is None:

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -122,6 +122,7 @@ class LoopBody:
             self._init_with_tracing(fn, args)
 
         self.indexing = None
+        self.replacement = {}
 
     def _init_with_tracing(self, fn, args):
         """Do an FX trace of an arbitrary callable to construct self"""
@@ -397,6 +398,7 @@ class LoopBody:
             f"{self.var_ranges=}, {indices=}"
         )
         replacements = dict(zip(self.var_ranges.keys(), index))
+        self.replacement = replacements
         return {
             name: sympy_subs(expr, replacements)
             for name, expr in self.indexing_exprs.items()


### PR DESCRIPTION
Fixes #142250
```bash
python run.py --op embedding --mode fwd --precision fp32 --metrics latency,speedup --csv
```
The performance data is collected as below. 
| (B, T, D, V)            | latency |       |                     |                    | speedup |                     |                    |
| ----------------------- | ------- | ----- | ------------------- | ------------------ | ------- | ------------------- | ------------------ |
|                         | torch   | liger | inductor-before-fix | inductor-after-fix | liger   | inductor-before-fix | inductor-after-fix |
| (32, 512, 768, 1024)    | 0.086   | 0.029 | 0.029               | 0.029              | 2.954   | 3.014               | 3.023              |
| (32, 512, 768, 2048)    | 0.088   | 0.032 | 0.032               | 0.032              | 2.783   | 2.743               | 2.753              |
| (32, 512, 768, 4096)    | 0.091   | 0.034 | 0.037               | 0.035              | 2.642   | **2.444**           | 2.575              |
| (32, 512, 768, 8192)    | 0.095   | 0.039 | 0.042               | 0.040              | 2.423   | **2.236**           | 2.387              |
| (32, 512, 768, 16384)   | 0.099   | 0.045 | 0.047               | 0.045              | 2.224   | **2.117**           | 2.213              |
| (32, 512, 768, 32768)   | 0.102   | 0.048 | 0.050               | 0.049              | 2.136   | **2.059**           | 2.103              |
| (32, 512, 768, 65536)   | 0.105   | 0.050 | 0.052               | 0.051              | 2.092   | 2.027               | 2.053              |
| (32, 512, 768, 131072)  | 0.107   | 0.052 | 0.052               | 0.052              | 2.062   | 2.053               | 2.046              |
| (8, 2048, 4096, 1024)   | 0.431   | 0.144 | 0.173               | 0.137              | 3.002   | **2.495**           | 3.145              |
| (8, 2048, 4096, 2048)   | 0.459   | 0.153 | 0.204               | 0.149              | 2.995   | **2.249**           | 3.075              |
| (8, 2048, 4096, 4096)   | 0.484   | 0.168 | 0.226               | 0.166              | 2.883   | **2.139**           | 2.906              |
| (8, 2048, 4096, 8192)   | 0.495   | 0.189 | 0.238               | 0.190              | 2.615   | **2.084**           | 2.608              |
| (8, 2048, 4096, 16384)  | 0.506   | 0.215 | 0.246               | 0.216              | 2.355   | **2.063**           | 2.349              |
| (8, 2048, 4096, 32768)  | 0.513   | 0.235 | 0.249               | 0.234              | 2.184   | **2.063**           | 2.195              |
| (8, 2048, 4096, 65536)  | 0.516   | 0.245 | 0.250               | 0.244              | 2.110   | 2.066               | 2.117              |
| (8, 2048, 4096, 131072) | 0.516   | 0.252 | 0.251               | 0.250              | 2.051   | 2.059               | 2.067              |


When building memory dependencies for a scheduler node, we check if this memory dependency is an indirect broadcast (i.e., indirect load indices from a tensor via one dimension and broadcasting them to another dimension to index the current memory dependency). If so, we record the dimensions for the pairs of (indirect load dimension, broadcast dimension). When deciding whether tiling needs to be applied, this information is used to generate a new loop order for the dimensions. If the loop order differs from the current one, we apply the new loop order and apply tilings if possible.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov