### PR TITLE
[ONNX] Create deprecation warning on dynamo_export

### DIFF
--- a/test/onnx/test_pytorch_onnx_no_runtime.py
+++ b/test/onnx/test_pytorch_onnx_no_runtime.py
@@ -341,22 +341,6 @@ class TestONNXExport(pytorch_test_common.ExportTestCase):
         f = io.BytesIO()
         torch.onnx.export(foo, (torch.zeros(1, 2, 3)), f)
 
-    def test_listconstruct_erasure(self):
-        class FooMod(torch.nn.Module):
-            def forward(self, x):
-                mask = x < 0.0
-                return x[mask]
-
-        f = io.BytesIO()
-        torch.onnx.export(
-            FooMod(),
-            (torch.rand(3, 4),),
-            f,
-            add_node_names=False,
-            do_constant_folding=False,
-            operator_export_type=torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK,
-        )
-
     def test_export_dynamic_slice(self):
         class DynamicSliceExportMod(torch.jit.ScriptModule):
             @torch.jit.script_method

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -165,7 +165,6 @@ def export(
     custom_opsets: Mapping[str, int] | None = None,
     export_modules_as_functions: bool | Collection[type[torch.nn.Module]] = False,
     autograd_inlining: bool = True,
-    **_: Any,  # ignored options
 ) -> ONNXProgram | None:
     r"""Exports a model into ONNX format.
 

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -476,7 +476,7 @@ def dynamo_export(
                 "You are using an experimental ONNX export logic, which currently only supports dynamic shapes. "
                 "For a more comprehensive set of export options, including advanced features, please consider using "
                 "`torch.onnx.export(..., dynamo=True)`. ",
-                category=FutureWarning,
+                category=DeprecationWarning,
             )
 
         if export_options is not None and export_options.dynamic_shapes:

--- a/torch/onnx/_deprecation.py
+++ b/torch/onnx/_deprecation.py
@@ -32,7 +32,7 @@ def deprecated(
                 f"'{function.__module__}.{function.__name__}' "
                 f"is deprecated in version {since} and will be "
                 f"removed in {removed_in}. Please {instructions}.",
-                category=FutureWarning,
+                category=DeprecationWarning,
                 stacklevel=2,
             )
             return function(*args, **kwargs)

--- a/torch/onnx/_internal/_exporter_legacy.py
+++ b/torch/onnx/_internal/_exporter_legacy.py
@@ -21,6 +21,7 @@ import logging
 import warnings
 from collections import defaultdict
 from typing import Any, Callable, TYPE_CHECKING, TypeVar
+from typing_extensions import deprecated
 
 import torch
 import torch._ops
@@ -79,6 +80,10 @@ class ONNXFakeContext:
     """List of paths of files that contain the model :meth:`state_dict`"""
 
 
+@deprecated(
+    "torch.onnx.dynamo_export is deprecated since 2.6.0. Please use torch.onnx.export(..., dynamo=True) instead.",
+    category=FutureWarning,
+)
 class OnnxRegistry:
     """Registry for ONNX functions.
 
@@ -223,6 +228,10 @@ class OnnxRegistry:
         }
 
 
+@deprecated(
+    "torch.onnx.dynamo_export is deprecated since 2.6.0. Please use torch.onnx.export(..., dynamo=True) instead.",
+    category=FutureWarning,
+)
 class ExportOptions:
     """Options to influence the TorchDynamo ONNX exporter.
 
@@ -430,6 +439,10 @@ def enable_fake_mode():
     )  # type: ignore[assignment]
 
 
+@deprecated(
+    "torch.onnx.dynamo_export is deprecated since 2.6.0. Please use torch.onnx.export(..., dynamo=True) instead.",
+    category=FutureWarning,
+)
 class ONNXRuntimeOptions:
     """Options to influence the execution of the ONNX model through ONNX Runtime.
 
@@ -684,6 +697,10 @@ def _assert_dependencies(export_options: ResolvedExportOptions):
         raise missing_opset("onnxscript")
 
 
+@deprecated(
+    "torch.onnx.dynamo_export is deprecated since 2.6.0. Please use torch.onnx.export(..., dynamo=True) instead.",
+    category=FutureWarning,
+)
 def dynamo_export(
     model: torch.nn.Module | Callable,
     /,

--- a/torch/onnx/_internal/_exporter_legacy.py
+++ b/torch/onnx/_internal/_exporter_legacy.py
@@ -82,7 +82,7 @@ class ONNXFakeContext:
 
 @deprecated(
     "torch.onnx.dynamo_export is deprecated since 2.6.0. Please use torch.onnx.export(..., dynamo=True) instead.",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 class OnnxRegistry:
     """Registry for ONNX functions.
@@ -230,7 +230,7 @@ class OnnxRegistry:
 
 @deprecated(
     "torch.onnx.dynamo_export is deprecated since 2.6.0. Please use torch.onnx.export(..., dynamo=True) instead.",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 class ExportOptions:
     """Options to influence the TorchDynamo ONNX exporter.
@@ -441,7 +441,7 @@ def enable_fake_mode():
 
 @deprecated(
     "torch.onnx.dynamo_export is deprecated since 2.6.0. Please use torch.onnx.export(..., dynamo=True) instead.",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 class ONNXRuntimeOptions:
     """Options to influence the execution of the ONNX model through ONNX Runtime.
@@ -699,7 +699,7 @@ def _assert_dependencies(export_options: ResolvedExportOptions):
 
 @deprecated(
     "torch.onnx.dynamo_export is deprecated since 2.6.0. Please use torch.onnx.export(..., dynamo=True) instead.",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 def dynamo_export(
     model: torch.nn.Module | Callable,

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -256,7 +256,6 @@ def export_compat(
     dump_exported_program: bool = False,
     artifacts_dir: str | os.PathLike = ".",
     fallback: bool = False,
-    **_,
 ) -> _onnx_program.ONNXProgram:
     if opset_version is None:
         opset_version = onnxscript_apis.torchlib_opset_version()

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -482,14 +482,14 @@ def export(
         warnings.warn(
             "Setting `operator_export_type` to something other than default is deprecated. "
             "The option will be removed in a future release.",
-            category=FutureWarning,
+            category=DeprecationWarning,
         )
     if training == _C_onnx.TrainingMode.TRAINING:
         warnings.warn(
             "Setting `training` to something other than default is deprecated. "
             "The option will be removed in a future release. Please set the training mode "
             "before exporting the model.",
-            category=FutureWarning,
+            category=DeprecationWarning,
         )
 
     args = (args,) if isinstance(args, torch.Tensor) else args

--- a/torch/onnx/verification.py
+++ b/torch/onnx/verification.py
@@ -17,10 +17,10 @@ import io
 import itertools
 import os
 import tempfile
+import typing_extensions
 import warnings
 from collections.abc import Collection, Mapping, Sequence
 from typing import Any, Callable, Union
-from typing_extensions import deprecated
 
 import numpy as np
 import numpy.typing as npt
@@ -772,7 +772,7 @@ def check_export_model_diff(
     )
 
 
-@deprecated(
+@typing_extensions.deprecated(
     "torch.onnx.verification.* is deprecated. Consider using torch.onnx.export(..., dynamo=True) "
     "and use ONNXProgram to test the ONNX model",
     category=DeprecationWarning,
@@ -864,7 +864,7 @@ def verify(
         )
 
 
-@deprecated(
+@typing_extensions.deprecated(
     "torch.onnx.verification.* is deprecated. Consider using torch.onnx.export(..., dynamo=True) "
     "and use ONNXProgram to test the ONNX model",
     category=DeprecationWarning,
@@ -1159,7 +1159,7 @@ class OnnxTestCaseRepro:
         _compare_onnx_pytorch_outputs_in_np(run_outputs, expected_outs, options)
 
 
-@deprecated(
+@typing_extensions.deprecated(
     "torch.onnx.verification.* is deprecated. Consider using torch.onnx.export(..., dynamo=True) "
     "and use ONNXProgram to test the ONNX model",
     category=DeprecationWarning,

--- a/torch/onnx/verification.py
+++ b/torch/onnx/verification.py
@@ -773,7 +773,8 @@ def check_export_model_diff(
 
 
 @deprecated(
-    "torch.onnx.verification.* is deprecated. Consider using torch.onnx.export(..., dynamo=True) and use ONNXProgram to test the ONNX model",
+    "torch.onnx.verification.* is deprecated. Consider using torch.onnx.export(..., dynamo=True) "
+    "and use ONNXProgram to test the ONNX model",
     category=DeprecationWarning,
 )
 def verify(
@@ -864,7 +865,8 @@ def verify(
 
 
 @deprecated(
-    "torch.onnx.verification.* is deprecated. Consider using torch.onnx.export(..., dynamo=True) and use ONNXProgram to test the ONNX model",
+    "torch.onnx.verification.* is deprecated. Consider using torch.onnx.export(..., dynamo=True) "
+    "and use ONNXProgram to test the ONNX model",
     category=DeprecationWarning,
 )
 def verify_aten_graph(
@@ -1158,7 +1160,8 @@ class OnnxTestCaseRepro:
 
 
 @deprecated(
-    "torch.onnx.verification.* is deprecated. Consider using torch.onnx.export(..., dynamo=True) and use ONNXProgram to test the ONNX model",
+    "torch.onnx.verification.* is deprecated. Consider using torch.onnx.export(..., dynamo=True) "
+    "and use ONNXProgram to test the ONNX model",
     category=DeprecationWarning,
 )
 @dataclasses.dataclass

--- a/torch/onnx/verification.py
+++ b/torch/onnx/verification.py
@@ -20,6 +20,7 @@ import tempfile
 import warnings
 from collections.abc import Collection, Mapping, Sequence
 from typing import Any, Callable, Union
+from typing_extensions import deprecated
 
 import numpy as np
 import numpy.typing as npt
@@ -771,6 +772,10 @@ def check_export_model_diff(
     )
 
 
+@deprecated(
+    "torch.onnx.verification.* is deprecated. Consider using torch.onnx.export(..., dynamo=True) and use ONNXProgram to test the ONNX model",
+    category=DeprecationWarning,
+)
 def verify(
     model: _ModelType,
     input_args: _InputArgsType,
@@ -858,6 +863,10 @@ def verify(
         )
 
 
+@deprecated(
+    "torch.onnx.verification.* is deprecated. Consider using torch.onnx.export(..., dynamo=True) and use ONNXProgram to test the ONNX model",
+    category=DeprecationWarning,
+)
 def verify_aten_graph(
     graph: torch.Graph,
     input_args: tuple[Any, ...],
@@ -1148,6 +1157,10 @@ class OnnxTestCaseRepro:
         _compare_onnx_pytorch_outputs_in_np(run_outputs, expected_outs, options)
 
 
+@deprecated(
+    "torch.onnx.verification.* is deprecated. Consider using torch.onnx.export(..., dynamo=True) and use ONNXProgram to test the ONNX model",
+    category=DeprecationWarning,
+)
 @dataclasses.dataclass
 class GraphInfo:
     """GraphInfo contains validation information of a TorchScript graph and its converted ONNX graph."""


### PR DESCRIPTION
Deprecation of `torch.onnx.dynamo_export`:

* [`torch/onnx/_internal/_exporter_legacy.py`](diffhunk://#diff-4d1eb96fe68ea904dcd1f8211318b9ff882dbfe4c3cb725ffc164b6c5a58b74cR83-R86): Added deprecation warnings to the `OnnxRegistry`, `ExportOptions`, `ONNXRuntimeOptions`, and `dynamo_export` functions, indicating that `torch.onnx.dynamo_export` is deprecated since version 2.6.0 and should be replaced with `torch.onnx.export(..., dynamo=True)`. [[1]](diffhunk://#diff-4d1eb96fe68ea904dcd1f8211318b9ff882dbfe4c3cb725ffc164b6c5a58b74cR83-R86) [[2]](diffhunk://#diff-4d1eb96fe68ea904dcd1f8211318b9ff882dbfe4c3cb725ffc164b6c5a58b74cR231-R234) [[3]](diffhunk://#diff-4d1eb96fe68ea904dcd1f8211318b9ff882dbfe4c3cb725ffc164b6c5a58b74cR442-R445) [[4]](diffhunk://#diff-4d1eb96fe68ea904dcd1f8211318b9ff882dbfe4c3cb725ffc164b6c5a58b74cR700-R703)

This PR also removed the `**_` kwarg on onnx.export such that users get an error when they supply an unexpected augument.

Updated to emit deprecation warning because it is more appropriate: https://docs.python.org/3/library/exceptions.html#DeprecationWarning