### PR TITLE
nonzero_static with symint size

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9285,12 +9285,12 @@
     MPS: nonzero_mps
   tags: [dynamic_output_shape, core]
 
-- func: nonzero_static.out(Tensor self, *, int size, int fill_value=-1, Tensor(a!) out) -> Tensor(a!)
+- func: nonzero_static.out(Tensor self, *, SymInt size, int fill_value=-1, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: nonzero_static_out_cpu
     CUDA: nonzero_static_out_cuda
 
-- func: nonzero_static(Tensor self, *, int size, int fill_value=-1) -> Tensor
+- func: nonzero_static(Tensor self, *, SymInt size, int fill_value=-1) -> Tensor
   variants: method, function
   dispatch:
     CPU: nonzero_static_cpu

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3243,9 +3243,8 @@ def meta_complex(real, imag):
 
 @register_meta([aten.nonzero_static.default, aten.nonzero_static.out])
 @out_wrapper()
-def nonzero_static(self, *, size: int, fill_value: int = -1):
+def nonzero_static(self, *, size, fill_value: int = -1):
     return self.new_empty((size, self.dim()), dtype=torch.long)
-
 
 @register_meta([torch.ops.aten.nonzero.default, torch.ops.aten.nonzero.out])
 @out_wrapper()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Previously `nonzero_static` would force specialization on the `size` argument. This PR enables it to be used with a dynamic `size` argument.

Differential Revision: [D68874784](https://our.internmc.facebook.com/intern/diff/D68874784/)