### PR TITLE
Use Magma-cuda 12.8 for libtorch

### DIFF
--- a/.ci/docker/common/install_magma.sh
+++ b/.ci/docker/common/install_magma.sh
@@ -7,12 +7,6 @@ function do_install() {
     cuda_version=$1
     cuda_version_nodot=${1/./}
 
-    # Temporary WAR to be updated for CUDA 12.8
-    if [ "$cuda_version_nodot" == "128" ]; then
-        # Set it to 12.6 if it matches
-        cuda_version_nodot="126"
-    fi
-
     MAGMA_VERSION="2.6.1"
     magma_archive="magma-cuda${cuda_version_nodot}-${MAGMA_VERSION}-1.tar.bz2"
 


### PR DESCRIPTION
https://github.com/pytorch/pytorch/issues/145570

Build failure for libtorch wheel
`CUDAContext.cpp:(.text+0x157): additional relocation overflows omitted from the output
/usr/bin/ld: failed to convert GOTPCREL relocation; relink with --no-relax
collect2: error: ld returned 1 exit status`

Unsure if this is related, fixing as a start