### PR TITLE
fix incorrect literal strings / accidental tuples

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7906,9 +7906,9 @@ utils_device.CURRENT_DEVICE == None""".split(
             ]
 
         def write_state(state):
-            torch.set_grad_enabled(state[0]),
+            torch.set_grad_enabled(state[0])
             torch.use_deterministic_algorithms(state[1])
-            torch._C._set_cublas_allow_tf32(state[2]),
+            torch._C._set_cublas_allow_tf32(state[2])
 
         @torch.compile(backend=my_compiler)
         def fn(x):

--- a/test/export/test_functionalized_assertions.py
+++ b/test/export/test_functionalized_assertions.py
@@ -15,7 +15,7 @@ class TestFuntionalAssertions(TestCase):
         with self.assertRaisesRegex(RuntimeError, "test msg"):
             torch.ops.aten._functional_assert_async.msg(
                 torch.tensor(0), "test msg", dep_token
-            ),
+            )
 
     def test_functional_sym_constrain_range(self) -> None:
         dep_token = torch.ops.aten._make_dep_token()

--- a/test/export/test_tree_utils.py
+++ b/test/export/test_tree_utils.py
@@ -17,8 +17,8 @@ class TestTreeUtils(TestCase):
         reordered_kwargs = reorder_kwargs(user_kwargs, orig_spec)
 
         # Key ordering should be the same
-        self.assertEqual(reordered_kwargs.popitem()[0], original_kwargs.popitem()[0]),
-        self.assertEqual(reordered_kwargs.popitem()[0], original_kwargs.popitem()[0]),
+        self.assertEqual(reordered_kwargs.popitem()[0], original_kwargs.popitem()[0])
+        self.assertEqual(reordered_kwargs.popitem()[0], original_kwargs.popitem()[0])
 
     def test_equivalence_check(self):
         tree1 = {"a": torch.tensor(0), "b": torch.tensor(1), "c": None}

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -365,7 +365,7 @@ class TestBasicGEMM(TestCase):
             UserWarning, f"This overload of {func}_ is deprecated"
         ):
             getattr(out_tensor, func + "_")(1, b1, b2)
-        self.assertEqual(out_tensor, ref * 2),
+        self.assertEqual(out_tensor, ref * 2)
         getattr(res3, func + "_")(b1, b2, beta=1)
         self.assertEqual(out_tensor, res3)
 
@@ -383,7 +383,7 @@ class TestBasicGEMM(TestCase):
             self.assertEqual(out_tensor, getattr(torch, func)(1, out_tensor, 0, b1, b2))
 
         res4 = getattr(torch, func)(out_tensor, b1, b2, beta=1, alpha=0.5)
-        self.assertEqual(res4, ref * 3),
+        self.assertEqual(res4, ref * 3)
 
         nan = torch.full_like(out_tensor, math.nan)
         res5 = getattr(torch, func)(nan, b1, b2, beta=0, alpha=1)

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1422,7 +1422,7 @@ class UntypedStorageVariable(VariableTracker):
         example_value: torch.UntypedStorage,
         **kwargs,
     ) -> None:
-        super().__init__(**kwargs),
+        super().__init__(**kwargs)
         self.from_tensor = from_tensor
         # Example_value will always have device="meta"
         self.example_value = example_value
@@ -1478,7 +1478,7 @@ class DataPtrVariable(VariableTracker):
         from_tensor: TensorVariable,
         **kwargs,
     ) -> None:
-        super().__init__(**kwargs),
+        super().__init__(**kwargs)
         self.from_tensor = from_tensor
 
     def reconstruct(self, codegen):

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1255,7 +1255,7 @@ class CUDAGraphNode:
                     "Expected all cuda outputs in cuda graph recording. Non cuda output "
                     f"from {self.stack_traces[i] if self.stack_traces else '(unknown)'}"
                 ),
-            ),
+            )
 
             ref = static_input_persistent_storage_ptrs.get(
                 o.untyped_storage().data_ptr(), None

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4201,8 +4201,10 @@ def tensor_split(
             )
             raise ValueError(msg)
         if indices_or_sections.dtype != torch.long:
-            msg = "tensor_split: if indices_or_sections is a tensor it must have long dtype, "
-            f" but received one with dtype {indices_or_sections.dtype}"
+            msg = (
+                "tensor_split: if indices_or_sections is a tensor it must have long dtype, "
+                f" but received one with dtype {indices_or_sections.dtype}"
+            )
             raise ValueError(msg)
 
     # Case 0 -- indices_or_sections is an integer or a scalar tensor n and a is split along dim into n parts of equal-ish length
@@ -4238,8 +4240,10 @@ def tensor_split(
         indices = indices_or_sections
         if isinstance(indices_or_sections, TensorLike):
             if indices_or_sections.ndim != 1:
-                msg = "tensor_split: non-scalar indices_or_sections tensors must have only one dimension, "
-                f"but received a tensor with {indices_or_sections.ndim} dimensions"
+                msg = (
+                    "tensor_split: non-scalar indices_or_sections tensors must have only one dimension, "
+                    f"but received a tensor with {indices_or_sections.ndim} dimensions"
+                )
                 raise ValueError(msg)
 
             indices = indices_or_sections.tolist()


### PR DESCRIPTION
* `expr,` is short for `(expr,)`
* literal strings over multiple lines need to escape the newline `\` or use `(...)`.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov