### PR TITLE
Add manual override flag for core ATen op detection during bc check

### DIFF
--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -41,7 +41,9 @@ logging.basicConfig(level=logging.INFO, format=FORMAT)
 # [
 #   0: function name regex
 #   1: date until which the allowlist entry is valid
-#   2: (optional) function argument regex
+#   2: (optional, default: None) function argument regex
+#   3: (optional, default: False) If True, tells us that you are NOT a core ATen op
+#                                 See Note [Op removal core ATen detection]
 # ]
 #
 # NB: function name DOES NOT include overload name!
@@ -145,6 +147,7 @@ ALLOW_LIST_COMPILED = [
         re.compile(item[0]),
         item[1],
         re.compile(item[2]) if len(item) > 2 else None,
+        item[3] if len(item) > 3 else False,
     )
     for item in ALLOW_LIST
     if item[1] >= datetime.date.today()
@@ -156,9 +159,9 @@ def allow_listed(schema):
         if item[0].search(str(schema)):
             if len(item) > 2 and item[2] is not None:
                 # if arguments regex is present, use it
-                return bool(item[2].search(str(schema)))
-            return True
-    return False
+                return bool(item[2].search(str(schema))), item[3]
+            return True, item[3]
+    return False, None
 
 
 # The nightly will fail to parse newly added syntax to schema declarations
@@ -234,12 +237,26 @@ def process_version_map(version_map):
         output[operator_name][key] = schema_entries
     return output
 
-
 def is_core_aten_op(schema) -> bool:
     # Check if the schema is a core ATen op
     if "::" not in schema.name:
         return False
-    _, _, tags = torch._C._get_operation_overload(schema.name, schema.overload_name)
+    res = torch._C._get_operation_overload(schema.name, schema.overload_name)
+    if res is None:
+        # Note [Op removal core ATen detection]
+        #
+        # If the core ATen op has been removed, we cannot be sure whether it
+        # was previously a core ATen op or not via checking tags this way.
+        # Conservatively assume that you are ARE a core ATen op in this case.
+        # This means that deleting a core ATen op will still be caught.
+        # But if you're deleting an operator that is not a core ATen op
+        # and add it to the allow_list, you would need to additionally specify
+        # a flag in the ALLOW_LIST to tell us you are not a core ATen op.
+        # See the comment block above ALLOW_LIST for more info.
+        #
+        # See https://github.com/pytorch/pytorch/issues/146049
+        return True
+    _, _, tags = res
     return Tag.core in tags
 
 
@@ -249,14 +266,19 @@ def check_bc(existing_schemas):
     is_bc = True
     broken_ops = []
     for existing_schema in existing_schemas:
-        if allow_listed(existing_schema):
-            if not is_core_aten_op(existing_schema):
+        is_allow_list, trust_not_core_aten = allow_listed(existing_schema)
+        if is_allow_list:
+            if trust_not_core_aten or not is_core_aten_op(existing_schema):
                 logging.info("schema: %s found on allowlist, skipping", existing_schema)
                 continue
             else:
                 logging.info(
                     "schema: %s found on allowlist, but is a core ATen op, checking BC",
                     existing_schema,
+                    "If you have removed an operator we will conservatively assume that "
+                    "it is a core ATen op. If the operator you removed is not a core ATen op, "
+                    "please specify that in the ALLOW_LIST entry (see comment block on top "
+                    "of ALLOW_LIST more info)"
                 )
         if has_valid_upgraders(existing_schema, version_map):
             if not is_core_aten_op(existing_schema):
@@ -301,7 +323,8 @@ def check_fc(existing_schemas):
     is_fc = True
     broken_ops = []
     for existing_schema in existing_schemas:
-        if allow_listed(existing_schema):
+        is_allow_list, _ = allow_listed(existing_schema)
+        if is_allow_list:
             logging.info("schema: %s found on allowlist, skipping", existing_schema)
             continue
         logging.info("processing existing schema: %s", existing_schema)

--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -237,6 +237,7 @@ def process_version_map(version_map):
         output[operator_name][key] = schema_entries
     return output
 
+
 def is_core_aten_op(schema) -> bool:
     # Check if the schema is a core ATen op
     if "::" not in schema.name:
@@ -273,12 +274,12 @@ def check_bc(existing_schemas):
                 continue
             else:
                 logging.info(
-                    "schema: %s found on allowlist, but is a core ATen op, checking BC",
-                    existing_schema,
-                    "If you have removed an operator we will conservatively assume that "
+                    "schema: %s found on allowlist, but is a core ATen op, checking BC. "
+                    "NOTE: If you have removed an operator we will conservatively assume that "
                     "it is a core ATen op. If the operator you removed is not a core ATen op, "
                     "please specify that in the ALLOW_LIST entry (see comment block on top "
-                    "of ALLOW_LIST more info)"
+                    "of ALLOW_LIST more info)",
+                    existing_schema,
                 )
         if has_valid_upgraders(existing_schema, version_map):
             if not is_core_aten_op(existing_schema):

--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -146,7 +146,7 @@ ALLOW_LIST_COMPILED = [
     (
         re.compile(item[0]),
         item[1],
-        re.compile(item[2]) if len(item) > 2 else None,
+        re.compile(item[2]) if (len(item) > 2 and item[2] is not None) else None,
         item[3] if len(item) > 3 else False,
     )
     for item in ALLOW_LIST


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #146101
* #145922
* #141842
* #141841
* __->__ #146052

Fixes https://github.com/pytorch/pytorch/issues/146049

Today the bc detection logic ignores allow_list for core ATen ops (A PR landed 4 months ago to enable this). The problem is that if I have a PR that removes an op, the script can no longer check whether that op is core ATen op (today we just error out). 

With my fix: (1) conservatively assume core ATen op in such cases (2) allows the user to specify in their ALLOW_LIST entry that their op is not a core ATen op.)

Test plan:
- This is tested 2 PRs above

https://github.com/pytorch/pytorch/blob/016bdafdcbb22e1627e2018e53425d98c7eecd87/test/forward_backward_compatibility/check_forward_backward_compatibility.py#L129-L137
