### PR TITLE
[PT2] Support add/remove passes in pre_grad

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -340,19 +340,22 @@ def _get_subgraph_names(gm: GraphModule) -> Generator[str, None, None]:
 
 
 def _recursive_pre_grad_passes(
-    gm: GraphModule, example_inputs: Sequence[InputType]
+    gm: GraphModule,
+    example_inputs: Sequence[InputType],
 ) -> GraphModule:
     with dynamo_timed(
         "_recursive_pre_grad_passes",
         log_pt2_compile_event=True,
         dynamo_compile_column_us="pre_grad_pass_time_us",
     ):
+        add_passes = config.add_pre_grad_passes
+        remove_passes = config.remove_pre_grad_passes
         for subgraph_name in _get_subgraph_names(gm):
             subgraph = getattr(gm, subgraph_name)
             # as we don't have recursive example inputs, passing empty set here
             new_subgraph = _recursive_pre_grad_passes(subgraph, ())
             setattr(gm, subgraph_name, new_subgraph)
-        return pre_grad_passes(gm, example_inputs)
+        return pre_grad_passes(gm, example_inputs, add_passes, remove_passes)
 
 
 def _recursive_joint_graph_passes(gm: GraphModule) -> None:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -608,6 +608,10 @@ optimize_scatter_upon_const_tensor = (
     os.environ.get("TORCHINDUCTOR_OPTIMIZE_SCATTER_UPON_CONST_TENSOR", "1") == "1"
 )
 
+# options in caffe2/torch/_inductor/fx_passes/pre_grad.py
+add_pre_grad_passes: Optional[str] = None
+remove_pre_grad_passes: Optional[str] = None
+
 
 # The multiprocessing start method to use for inductor workers in the codecache.
 def decide_worker_start_method() -> str:

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -2,6 +2,7 @@
 import copy
 import itertools
 import logging
+import types
 from collections.abc import Sequence
 from typing import Optional
 
@@ -73,6 +74,10 @@ def is_same_dict(inductor_dict, optimus_dict):
     return True
 
 
+def shape_prop(mod) -> None:
+    return None
+
+
 def normalize_node_kwargs_pass(graph):
     return None
 
@@ -83,6 +88,10 @@ def fuse_parallel_linear_pass(graph):
 
 def remove_split_ops(graph, shape_prop):
     return None
+
+
+def remove_split_ops_pass(graph):
+    remove_split_ops(graph.owning_module, shape_prop)
 
 
 def fuse_chunk_reshape_unsqueeze_concat_pass(graph):
@@ -117,8 +126,105 @@ def lazy_init():
         from . import fb  # type: ignore[attr-defined]  # noqa: F401
 
 
+def _get_pass_name_func(p):
+    if isinstance(p, PatternMatcherPass):
+        pass_name = p.pass_name
+        pass_func = p.apply
+    elif isinstance(p, types.FunctionType):
+        pass_name = p.__name__
+        pass_func = p
+    else:
+        pass_name = None
+        pass_func = None
+
+    return pass_name, pass_func
+
+
+def _run_pre_dispatch_passes(
+    gm: torch.fx.GraphModule,
+    example_inputs: Sequence[object] = (),
+    add_passes: Optional[str] = None,
+    remove_passes: Optional[str] = None,
+) -> None:
+    # order matters
+    default_pass_list = [
+        # normalize passes, must be called as the first passes
+        normalization_pass_aten,
+        normalize_node_kwargs_pass,
+        remove_noop_pass,
+        relu_nan_to_num,
+        fuse_chunk_reshape_concat_pass,
+        group_batch_fusion_passes,
+        normalize_node_kwargs_pass,
+        fuse_chunk_squeeze_cat_pass,
+        merge_concats_pass,
+        fuse_split_linear_add_pass,
+        remove_reshape_pass,
+        fuse_parallel_linear_pass,
+        remove_split_ops_pass,
+        stack_to_unsqueeze_pass,  # run before fuse_chunk_reshape_unsqueeze_concat_pass
+        fuse_chunk_reshape_unsqueeze_concat_pass,
+    ]
+
+    full_pass_list = default_pass_list + []
+
+    log.info(
+        f"pre_grad_passes: add_passes: {add_passes}, remove_pass: {remove_passes}"  # noqa: G004
+    )
+    add_passes_list = []
+    remove_passes_list = []
+    if add_passes:
+        add_passes_list = add_passes.split(",")
+    if remove_passes:
+        remove_passes_list = remove_passes.split(",")
+
+    shape_prop = lambda mod: ShapeProp(  # noqa: E731
+        gm=mod,
+        # pyre-fixme[16]: Module `torch._dynamo.utils` has no attribute `detect_fake_mode`
+        fake_mode=detect_fake_mode(example_inputs),
+    ).propagate(*tuple(example_inputs))
+
+    for p in default_pass_list:
+        pass_name, pass_func = _get_pass_name_func(p)
+        # should not happen
+        if pass_name is None or pass_func is None:
+            continue
+        if pass_name in remove_passes_list:
+            continue
+        pass_execution_and_save(
+            pass_func,
+            gm,
+            example_inputs,
+            f"[Pre grad(predispatch IR)] Apply {pass_name} pass",
+        )
+
+    for p in full_pass_list:
+        pass_name, pass_func = _get_pass_name_func(p)
+        if pass_name is None or pass_func is None:
+            continue
+        if pass_name in add_passes_list:
+            pass_execution_and_save(
+                pass_func,
+                gm,
+                example_inputs,
+                f"[Pre grad(predispatch IR)] Apply {pass_name} pass",
+            )
+
+    # Remove noops at the end, which may be generated other passes.
+    pass_execution_and_save(
+        remove_noop_pass,
+        gm,
+        example_inputs,
+        "[Pre grad(predispatch IR)]Apply remove_noop pass",
+    )
+    shape_prop(gm)
+
+
 def pre_grad_passes(
-    gm: torch.fx.GraphModule, example_inputs: Sequence[object] = ()
+    gm: torch.fx.GraphModule,
+    example_inputs: Sequence[object] = (),
+    add_passes: Optional[str] = None,
+    remove_passes: Optional[str] = None,
 ) -> torch.fx.GraphModule:
     """
     Apply passes on the input FX graph using Torch IR.
@@ -139,116 +245,7 @@ def pre_grad_passes(
             gm_before_fx_passes = gm.__copy__()
         # explicitly run with predispatch atenIR based passes
         if config.is_predispatch:
-
-            def shape_prop(mod) -> None:
-                ShapeProp(
-                    gm=mod,
-                    # pyre-fixme[16]: Module `torch._dynamo.utils` has no attribute `detect_fake_mode`
-                    fake_mode=detect_fake_mode(example_inputs),
-                ).propagate(*tuple(example_inputs))
-
-            # normalization pass
-            pass_execution_and_save(
-                normalization_pass_aten.apply,
-                gm,
-                example_inputs,
-                "[Pre grad(predispatch IR)]Apply normalization pass",
-            )
-            # normalize kwargs, must be called as the first pass
-            pass_execution_and_save(
-                normalize_node_kwargs_pass,
-                gm,
-                example_inputs,
-                "[Pre grad(predispatch IR)]Apply normalize_node_kwargs_pass",
-            )
-            pass_execution_and_save(
-                remove_noop_pass,
-                gm,
-                example_inputs,
-                "[Pre grad(predispatch IR)]Apply remove_noop pass",
-            )
-            pass_execution_and_save(
-                relu_nan_to_num,
-                gm,
-                example_inputs,
-                "[Pre grad(predispatch IR)]Apply relu_nan_to_num pass",
-            )
-            pass_execution_and_save(
-                fuse_chunk_reshape_concat_pass,
-                gm,
-                example_inputs,
-                "[Pre grad(predispatch IR)] Apply fuse_chunk_reshape_concat_pass",
-            )
-            pass_execution_and_save(
-                group_batch_fusion_passes,
-                gm,
-                example_inputs,
-                "[Pre grad(predispatch IR)] Apply group_batch_fusion",
-            )
-            pass_execution_and_save(
-                normalize_node_kwargs_pass,
-                gm,
-                example_inputs,
-                "[Pre grad(predispatch IR)]Apply normalize_node_kwargs_pass",
-            )
-            pass_execution_and_save(
-                fuse_chunk_squeeze_cat_pass.apply,
-                gm,
-                example_inputs,
-                "[Pre grad(predispatch IR)] Apply fuse_chunk_squeeze_cat_pass",
-            )
-            pass_execution_and_save(
-                merge_concats_pass,
-                gm,
-                example_inputs,
-                "[Pre grad(predispatch IR)] Apply merge_concats_pass",
-            )
-            pass_execution_and_save(
-                fuse_split_linear_add_pass.apply,
-                gm,
-                example_inputs,
-                "[Pre grad(predispatch IR)] Apply fuse_split_linear_add_pass",
-            )
-            pass_execution_and_save(
-                remove_reshape_pass.apply,
-                gm,
-                example_inputs,
-                "[Pre grad(predispatch IR)] Apply remove_reshape_pass",
-            )
-            pass_execution_and_save(
-                fuse_parallel_linear_pass,
-                gm,
-                example_inputs,
-                "[Pre grad(predispatch IR)] Apply fuse_parallel_linear_pass",
-            )
-            pass_execution_and_save(
-                lambda graph: remove_split_ops(graph.owning_module, shape_prop),
-                gm,
-                example_inputs,
-                "[Pre grad(predispatch IR)] Apply remove_split_ops",
-            )
-            # run before fuse_chunk_reshape_unsqueeze_concat_pass
-            pass_execution_and_save(
-                stack_to_unsqueeze_pass,
-                gm,
-                example_inputs,
-                "[Pre grad(predispatch IR)] Apply stack_to_unsqueeze_pass",
-            )
-            pass_execution_and_save(
-                fuse_chunk_reshape_unsqueeze_concat_pass,
-                gm,
-                example_inputs,
-                "[Pre grad(predispatch IR)] Apply fuse_chunk_reshape_unsqueeze_concat_pass",
-            )
-            # Remove noops at the end, which may be generated other passes.
-            pass_execution_and_save(
-                remove_noop_pass,
-                gm,
-                example_inputs,
-                "[Pre grad(predispatch IR)]Apply remove_noop pass",
-            )
-            shape_prop(gm)
-
+            _run_pre_dispatch_passes(gm, example_inputs, add_passes, remove_passes)
         else:
             # We only log the graph with changes to avoid the excessive compilation time
             # https://fb.workplace.com/groups/257735836456307/permalink/633533465543207/


### PR DESCRIPTION
Summary:
support the same functionality with acc_tracer disabled, add a new config for pre_grad add/remove_passes, at the front end it still uses the same interface

some minor updates in pre_grad passes to make sure the passes are run in desired order, after added passes, still run pass like remove_noops at the end

Test Plan: add new UT, please see stacked diff for add pass tests (TODO: update diff link)

Differential Revision: D68909278




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov