### PR TITLE
Cap size of thread pool in select_algorithm to cpu count

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1707,7 +1707,7 @@ class AlgorithmSelectorCache(PersistentCache):
             ):
                 return no_op
 
-            num_workers = get_num_workers()
+            num_workers = min(get_num_workers(), len(choices))
 
             if num_workers <= 0:
                 return no_op


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146071

Summary: With changes from https://github.com/pytorch/pytorch/pull/144829, we can see more autotune configs and the size of the pool can get outta hand when using the cutlass backend.

See internal discussion at: https://fburl.com/workplace/7g4vz0zy

Test Plan: `python test/inductor/test_cutlass_backend.py`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov