### PR TITLE
[MPS] Fix regression in con-contig bitwise ops

### DIFF
--- a/aten/src/ATen/native/mps/operations/BitwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/BitwiseOps.mm
@@ -226,7 +226,7 @@ static void _bitwise_op_out_mps(const Tensor& self,
 
   auto output_size = at::infer_size_dimvector(self.sizes(), other.sizes());
   resize_output(output, output_size);
-  if (needsGather(output)) {
+  if (!output.is_contiguous()) {
     output = output.contiguous();
     needs_output_copy = true;
   }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4442,6 +4442,16 @@ class TestMPS(TestCaseMPS):
                     getattr(torch.tensor(val1, dtype=dtype1, device='cpu'), binop)
                            (torch.full(full_shape, val2, dtype=dtype2, device='cpu')))
 
+    def test_xor_non_contigous(self):
+        # See https://github.com/pytorch/pytorch/issues/145203
+        x_mps = torch.randint(-16000, 16000, (10, 2), dtype=torch.int16, device="mps")
+        x_cpu = x_mps.detach().cpu()
+
+        x_mps[:, 0] ^= 3
+        x_cpu[:, 0] ^= 3
+
+        self.assertEqual(x_mps.cpu(), x_cpu)
+
     def test_nansum(self):
         def helper(dtype, noncontiguous, dim):
             zero_cpu = torch.zeros((), dtype=dtype)


### PR DESCRIPTION
Caused by https://github.com/pytorch/pytorch/pull/128393 that change semantic of `needsGather`, which resulted in silent correctness errors on MacOS-15+ if output tensor is non-contiguous

Fixes https://github.com/pytorch/pytorch/issues/145203
