### PR TITLE
[draft_export] Clear pending unbacked symbols when overriding mismatched fake kernels

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2225,7 +2225,10 @@ class FakeTensorMode(TorchDispatchMode):
                         real_out,
                     )
                 else:
-                    # make it clear this can override the output only when the flag is True
+                    # the pending unbacked symbols have to be cleared first
+                    if self.shape_env is not None:
+                        self.shape_env.pending_fresh_unbacked_symbols.clear()
+                    # this can override the output only when the flag is True
                     fake_out = self._maybe_infer_fake_kernel_from_pytree_out(  # type: ignore[assignment]
                         func,
                         (args, kwargs),


### PR DESCRIPTION
Summary:
When encountering a mismatched fake kernel that also creates unbacked symbols, draft export will fail with `PendingUnbackedSymbolNotFound` error.

Clearing `shape_env.pending_fresh_unbacked_symbols` fixes this issue.

Test Plan:
```
buck2 run mode/dev-nosan caffe2/test:test_export -- -r test_override_mismatched_fake_kernel_with_unbacked_symbols
```

Differential Revision: D68920990


