### PR TITLE
(WIP) Update NJT ops to check data for raggedness check

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6303,6 +6303,11 @@
   dispatch:
     CPU, CUDA: _nested_compute_contiguous_strides_offsets
 
+- func: _nested_assert_metadata_equal(Tensor lhs, Tensor rhs) -> Tensor
+  variants: function
+  device_check: NoCheck
+  dispatch: {}
+
 - func: _trilinear(Tensor i1, Tensor i2, Tensor i3, int[] expand1, int[] expand2, int[] expand3, int[] sumdim, int unroll_dim=1) -> Tensor
   dispatch:
     # calls unsqueeze

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6303,11 +6303,6 @@
   dispatch:
     CPU, CUDA: _nested_compute_contiguous_strides_offsets
 
-- func: _nested_assert_metadata_equal(Tensor lhs, Tensor rhs, str msg) -> ()
-  variants: function
-  device_check: NoCheck
-  dispatch: {}
-
 - func: _nested_assert_expandable_to(Tensor tgt, SymInt[] src_shape, str msg) -> ()
   variants: function
   device_check: NoCheck

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6303,7 +6303,12 @@
   dispatch:
     CPU, CUDA: _nested_compute_contiguous_strides_offsets
 
-- func: _nested_assert_metadata_equal(Tensor lhs, Tensor rhs) -> Tensor
+- func: _nested_assert_metadata_equal(Tensor lhs, Tensor rhs, str msg) -> ()
+  variants: function
+  device_check: NoCheck
+  dispatch: {}
+
+- func: _nested_assert_expandable_to(Tensor tgt, SymInt[] src_shape, str msg) -> ()
   variants: function
   device_check: NoCheck
   dispatch: {}

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5842,6 +5842,7 @@
   device_guard: False
   dispatch:
     CompositeImplicitAutograd: sum_to_size_symint
+    NestedTensorCPU, NestedTensorCUDA: sum_to_size_nested_symint
 
 - func: sqrt(Tensor self) -> Tensor
   device_check: NoCheck   # TensorIterator

--- a/aten/src/ATen/native/nested/NestedTensorUtils.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.cpp
@@ -11,6 +11,7 @@
 #include <ATen/ops/chunk_native.h>
 #include <ATen/ops/split_with_sizes_native.h>
 #include <ATen/ops/value_selecting_reduction_backward_native.h>
+#include <ATen/ops/sum_to_size_native.h>
 #endif
 
 namespace at::native {
@@ -175,6 +176,12 @@ Tensor value_selecting_reduction_backward_nested_symint(
     bool keepdim) {
   TORCH_INTERNAL_ASSERT(
       false, "value_selecting_reduction_backward(): expected to be implemented in Python"
+  );
+}
+
+Tensor sum_to_size_nested_symint(const at::Tensor& self, c10::SymIntArrayRef size) {
+  TORCH_INTERNAL_ASSERT(
+      false, "sum_to_size_nested(): expected to be implemented in Python"
   );
 }
 

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -2471,7 +2471,7 @@ class GraphModule(torch.nn.Module):
         clone: "f64[s0, s1]" = torch.ops.aten.clone.default(primals_4);  primals_4 = None
 
         mul: "f64[s0, s1]" = torch.ops.aten.mul.Tensor(clone, primals_1);  clone = None
-        return (mul, primals_5, primals_6, primals_7, primals_8, primals_10, primals_10, primals_1, primals_8, primals_10)
+        return (mul, primals_5, primals_6, primals_7, primals_8, primals_10, primals_10, primals_5, primals_1, primals_8, primals_10)
 """,  # noqa: B950
         )
 
@@ -2479,9 +2479,23 @@ class GraphModule(torch.nn.Module):
             normalize_gm(bw[0].print_readable(print_output=False)),
             """\
 class GraphModule(torch.nn.Module):
-    def forward(self, primals_1: "Sym(s2)", primals_8: "Sym(s2)", primals_10: "Sym(s1)", tangents_1: "f64[s0, s1]", tangents_2: "i64[s2 + 1]", tangents_3: "f32[s5, 0]", tangents_4: "f32[s6, 0]"):
+    def forward(self, primals_1: "Sym(s2)", primals_8: "Sym(s2)", primals_10: "Sym(s1)", primals_5: "i64[s2 + 1]", tangents_1: "f64[s0, s1]", tangents_2: "i64[s2 + 1]", tangents_3: "f32[s5, 0]", tangents_4: "f32[s6, 0]", tangents_token: "f32[0]"):
+        with_effects = torch.ops.higher_order.with_effects(tangents_token, torch.ops.nested._assert_equal.default, primals_5, tangents_2, 'invalid gradient at index 0 - got [s2, s3, s1] but expected shape compatible with [s2, s3, s1]');  tangents_token = None
+        getitem: "f32[0]" = with_effects[0];  with_effects = None
+        with_effects_1 = torch.ops.higher_order.with_effects(getitem, torch.ops.nested._assert_equal.default, tangents_2, primals_5, 'sum_to_size(): sizes unsupported');  getitem = None
+        getitem_2: "f32[0]" = with_effects_1[0];  with_effects_1 = None
+
         mul_1: "f64[s0, s1]" = torch.ops.aten.mul.Tensor(tangents_1, primals_1);  tangents_1 = primals_1 = None
-        return (None, None, None, mul_1, tangents_2, tangents_3, tangents_4, primals_8, primals_10, primals_10)
+        with_effects_2 = torch.ops.higher_order.with_effects(getitem_2, torch.ops.nested._assert_equal.default, primals_5, tangents_2, 'invalid gradient at index 0 - got [s2, s3, s1] but expected shape compatible with [s2, s3, s1]');  getitem_2 = None
+        getitem_4: "f32[0]" = with_effects_2[0];  with_effects_2 = None
+        with_effects_3 = torch.ops.higher_order.with_effects(getitem_4, torch.ops.nested._assert_equal.default, tangents_2, primals_5, 'sum_to_size(): sizes unsupported');  getitem_4 = None
+        getitem_6: "f32[0]" = with_effects_3[0];  with_effects_3 = None
+
+        with_effects_4 = torch.ops.higher_order.with_effects(getitem_6, torch.ops.nested._assert_equal.default, primals_5, tangents_2, 'invalid gradient at index 0 - got [s2, s3, s1] but expected shape compatible with [s2, s3, s1]');  getitem_6 = None
+        getitem_8: "f32[0]" = with_effects_4[0];  with_effects_4 = None
+        with_effects_5 = torch.ops.higher_order.with_effects(getitem_8, torch.ops.nested._assert_equal.default, tangents_2, primals_5, 'sum_to_size(): sizes unsupported');  getitem_8 = primals_5 = None
+        getitem_10: "f32[0]" = with_effects_5[0];  with_effects_5 = None
+        return (None, None, None, mul_1, tangents_2, tangents_3, tangents_4, primals_8, primals_10, primals_10, getitem_10)
 """,  # noqa: B950
         )
 
@@ -2505,7 +2519,7 @@ class GraphModule(torch.nn.Module):
 
         cat: "f64[s0, 2*s1]" = torch.ops.aten.cat.default([clone, clone], 1);  clone = None
         add_2: "Sym(2*s1)" = primals_10 + primals_10
-        return (cat, primals_5, primals_6, primals_7, primals_8, add_2, add_2, primals_8, primals_10, add_2)
+        return (cat, primals_5, primals_6, primals_7, primals_8, add_2, add_2, primals_5, primals_8, primals_10, add_2)
 """,  # noqa: B950
         )
 
@@ -2513,12 +2527,32 @@ class GraphModule(torch.nn.Module):
             normalize_gm(bw[0].print_readable(print_output=False)),
             """\
 class GraphModule(torch.nn.Module):
-    def forward(self, primals_8: "Sym(s2)", primals_10: "Sym(s1)", add_2: "Sym(2*s1)", tangents_1: "f64[s0, 2*s1]", tangents_2: "i64[s2 + 1]", tangents_3: "f32[s5, 0]", tangents_4: "f32[s6, 0]"):
+    def forward(self, primals_8: "Sym(s2)", primals_10: "Sym(s1)", add_2: "Sym(2*s1)", primals_5: "i64[s2 + 1]", tangents_1: "f64[s0, 2*s1]", tangents_2: "i64[s2 + 1]", tangents_3: "f32[s5, 0]", tangents_4: "f32[s6, 0]", tangents_token: "f32[0]"):
+        with_effects = torch.ops.higher_order.with_effects(tangents_token, torch.ops.nested._assert_equal.default, primals_5, tangents_2, 'invalid gradient at index 0 - got [s2, s3, 2*s1] but expected shape compatible with [s2, s3, 2*s1]');  tangents_token = None
+        getitem: "f32[0]" = with_effects[0];  with_effects = None
+        with_effects_1 = torch.ops.higher_order.with_effects(getitem, torch.ops.nested._assert_equal.default, tangents_2, primals_5, 'sum_to_size(): sizes unsupported');  getitem = None
+        getitem_2: "f32[0]" = with_effects_1[0];  with_effects_1 = None
+
         slice_1: "f64[s0, s1]" = torch.ops.aten.slice.Tensor(tangents_1, 1, 0, primals_10)
         slice_2: "f64[s0, s1]" = torch.ops.aten.slice.Tensor(tangents_1, 1, primals_10, add_2);  tangents_1 = add_2 = None
+        with_effects_2 = torch.ops.higher_order.with_effects(getitem_2, torch.ops.nested._assert_equal.default, primals_5, tangents_2, 'invalid gradient at index 0 - got [s2, s3, s1] but expected shape compatible with [s2, s3, s1]');  getitem_2 = None
+        getitem_4: "f32[0]" = with_effects_2[0];  with_effects_2 = None
+        with_effects_3 = torch.ops.higher_order.with_effects(getitem_4, torch.ops.nested._assert_equal.default, tangents_2, primals_5, 'sum_to_size(): sizes unsupported');  getitem_4 = None
+        getitem_6: "f32[0]" = with_effects_3[0];  with_effects_3 = None
+        with_effects_4 = torch.ops.higher_order.with_effects(getitem_6, torch.ops.nested._assert_equal.default, primals_5, tangents_2, 'invalid gradient at index 1 - got [s2, s3, s1] but expected shape compatible with [s2, s3, s1]');  getitem_6 = None
+        getitem_8: "f32[0]" = with_effects_4[0];  with_effects_4 = None
+        with_effects_5 = torch.ops.higher_order.with_effects(getitem_8, torch.ops.nested._assert_equal.default, tangents_2, primals_5, 'sum_to_size(): sizes unsupported');  getitem_8 = None
+        getitem_10: "f32[0]" = with_effects_5[0];  with_effects_5 = None
 
+        with_effects_6 = torch.ops.higher_order.with_effects(getitem_10, torch.ops.nested._assert_equal.default, tangents_2, tangents_2, 'cannot call binary pointwise function add.Tensor with inputs of shapes (s2, s3, s1) and (s2, s3, s1)');  getitem_10 = None
+        getitem_12: "f32[0]" = with_effects_6[0];  with_effects_6 = None
         add_4: "f64[s0, s1]" = torch.ops.aten.add.Tensor(slice_1, slice_2);  slice_1 = slice_2 = None
-        return (None, None, None, add_4, tangents_2, tangents_3, tangents_4, primals_8, primals_10, primals_10)
+
+        with_effects_7 = torch.ops.higher_order.with_effects(getitem_12, torch.ops.nested._assert_equal.default, primals_5, tangents_2, 'invalid gradient at index 0 - got [s2, s3, s1] but expected shape compatible with [s2, s3, s1]');  getitem_12 = None
+        getitem_14: "f32[0]" = with_effects_7[0];  with_effects_7 = None
+        with_effects_8 = torch.ops.higher_order.with_effects(getitem_14, torch.ops.nested._assert_equal.default, tangents_2, primals_5, 'sum_to_size(): sizes unsupported');  getitem_14 = primals_5 = None
+        getitem_16: "f32[0]" = with_effects_8[0];  with_effects_8 = None
+        return (None, None, None, add_4, tangents_2, tangents_3, tangents_4, primals_8, primals_10, primals_10, getitem_16)
 """,  # noqa: B950
         )
 
@@ -3145,8 +3179,6 @@ class GraphModule(torch.nn.Module):
     @requires_cuda
     @fresh_tensor_registry
     def test_different_devices(self):
-        from torch.utils._sympy.singleton_int import SingletonInt
-
         def get_njt(device):
             return torch.nested.nested_tensor(
                 [torch.randn(2, 5), torch.randn(3, 5), torch.randn(18, 5)],
@@ -3194,34 +3226,37 @@ class GraphModule(torch.nn.Module):
 
         fn(t_cpu_cleared, t_cuda)
 
-        singleton_int_0 = SingletonInt((frozenset(), frozenset({0})))
+        def get_str(d):
+            return "\n".join(f"{k}: {v}" for k, v in d.items())
 
-        expected_var_to_val = {
-            "s0": singleton_int_0,
-            "s1": 18,
-            "s2": 2,
-            "s3": 23,
-            "s4": singleton_int_0,
-            "s5": singleton_int_0,
-            "s6": 23,
-            "s7": 23,
-            "s8": singleton_int_0,
-        }
-        # We create extraneous symbols, but for we make sure to reuse symbols for
-        # the common case, e.g. raggedness/metadata preserving operations like pointwise.
-        expected_var_to_sources = {
-            "s0": "L['a']._base.size()[1]",
-            "s1": "L['a']._base.size()[1].node.nested_int_cache()._max_seqlen_tensor.size()[0]",
-            "s2": "L['a']._base.size()[1].node.nested_int_cache()._min_seqlen_tensor.size()[0]",
-            "s3": "L['a']._base._values.size()[0]",
-            "s4": "<ephemeral: intermediate_offsets_or_lengths>",
-            "s5": "L['a'].size()[1]",
-            "s6": "L['a']._values.size()[0]",
-            "s7": "L['b']._base.size()[0]",
-            "s8": "L['b'].size()[1]",
-        }
-        self.assertEqual(curr_var_to_val, expected_var_to_val)
-        self.assertEqual(curr_var_to_sources, expected_var_to_sources)
+        self.assertExpectedInline(
+            get_str(curr_var_to_val),
+            """\
+s0: SingletonInt((frozenset(), frozenset({0})))
+s1: 18
+s2: 2
+s3: 23
+s4: SingletonInt((frozenset(), frozenset({0})))
+s5: SingletonInt((frozenset(), frozenset({0})))
+s6: 23
+s7: 23
+s8: SingletonInt((frozenset(), frozenset({0})))""",
+        )
+
+        self.assertExpectedInline(
+            get_str(curr_var_to_sources),
+            """\
+s0: L['a']._base.size()[1]
+s1: L['a']._base.size()[1].node.nested_int_cache()._max_seqlen_tensor.size()[0]
+s2: L['a']._base.size()[1].node.nested_int_cache()._min_seqlen_tensor.size()[0]
+s3: L['a']._base._values.size()[0]
+s4: <ephemeral: intermediate_offsets_or_lengths>
+s5: L['a'].size()[1]
+s6: L['a']._values.size()[0]
+s7: L['b']._base.size()[0]
+s8: L['b'].size()[1]""",
+        )
+
         self.assertExpectedInline(
             "\n".join(guards),
             """\

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -459,6 +459,7 @@ aten::_nested_from_padded_tensor
 aten::_nested_get_jagged_metadata
 aten::_nested_get_non_contig_offsets
 aten::_nested_get_ragged_idx
+aten::_nested_assert_expandable_to
 aten::_nested_get_values
 aten::_nested_get_values_copy
 aten::_nested_get_values_copy.out

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -458,6 +458,7 @@ aten::_nested_from_padded_and_nested_example.out
 aten::_nested_from_padded_tensor
 aten::_nested_get_jagged_metadata
 aten::_nested_get_non_contig_offsets
+aten::_nested_assert_expandable_to
 aten::_nested_get_ragged_idx
 aten::_nested_assert_expandable_to
 aten::_nested_get_values

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -450,6 +450,7 @@ aten::_native_multi_head_attention.out
 aten::_neg_view
 aten::_neg_view_copy
 aten::_neg_view_copy.out
+aten::_nested_assert_expandable_to
 aten::_nested_compute_contiguous_strides_offsets
 aten::_nested_from_padded
 aten::_nested_from_padded.out
@@ -458,9 +459,7 @@ aten::_nested_from_padded_and_nested_example.out
 aten::_nested_from_padded_tensor
 aten::_nested_get_jagged_metadata
 aten::_nested_get_non_contig_offsets
-aten::_nested_assert_expandable_to
 aten::_nested_get_ragged_idx
-aten::_nested_assert_expandable_to
 aten::_nested_get_values
 aten::_nested_get_values_copy
 aten::_nested_get_values_copy.out

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -9010,7 +9010,7 @@ class TestNestedInt(torch.testing._internal.common_utils.TestCase):
         dict_tensor1 = DictTensor(metadata1)
         dict_tensor2 = DictTensor(metadata2)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(RuntimeError):
             _nested_assert_metadata_equal(dict_tensor1, dict_tensor2, "hello")
 
 

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -8980,6 +8980,7 @@ class TestNestedInt(torch.testing._internal.common_utils.TestCase):
 
     def test_assertion(self):
         from torch.nested._internal.dict_tensor import DictTensor
+        from torch.nested._internal.nested_int import _nested_assert_metadata_equal
 
         a = torch.tensor([1, 2, 3], dtype=torch.float32)
         b = torch.tensor([4, 5, 6], dtype=torch.float32)
@@ -8987,22 +8988,30 @@ class TestNestedInt(torch.testing._internal.common_utils.TestCase):
 
         # Correct case
         metadata1 = {"_host_lengths": a, "_host_offsets": None, "_device_offsets": c}
-        metadata2 = {"_host_lengths": None, "_host_offsets": b, "_device_offsets": c.clone()}
+        metadata2 = {
+            "_host_lengths": None,
+            "_host_offsets": b,
+            "_device_offsets": c.clone(),
+        }
 
         dict_tensor1 = DictTensor(metadata1)
         dict_tensor2 = DictTensor(metadata2)
 
-        torch._nested_assert_metadata_equal(dict_tensor1, dict_tensor2, "hello")
+        _nested_assert_metadata_equal(dict_tensor1, dict_tensor2, "hello")
 
         # Failure case
         metadata1 = {"_host_lengths": a, "_host_offsets": None, "_device_offsets": c}
-        metadata2 = {"_host_lengths": None, "_host_offsets": b, "_device_offsets": a.clone()}
+        metadata2 = {
+            "_host_lengths": None,
+            "_host_offsets": b,
+            "_device_offsets": a.clone(),
+        }
 
         dict_tensor1 = DictTensor(metadata1)
         dict_tensor2 = DictTensor(metadata2)
 
         with self.assertRaises(AssertionError):
-            torch._nested_assert_metadata_equal(dict_tensor1, dict_tensor2, "hello")
+            _nested_assert_metadata_equal(dict_tensor1, dict_tensor2, "hello")
 
 
 instantiate_parametrized_tests(TestNestedTensor)

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -8969,6 +8969,32 @@ class TestNestedInt(torch.testing._internal.common_utils.TestCase):
 
         self.assertFalse(a == b)
 
+    def test_assertion(self):
+        from torch.nested._internal.dict_tensor import DictTensor
+
+        a = torch.tensor([1, 2, 3], dtype=torch.float32)
+        b = torch.tensor([4, 5, 6], dtype=torch.float32)
+        c = torch.tensor([7, 8, 9], dtype=torch.float32)
+
+        # Correct case
+        metadata1 = {"_host_lengths": a, "_host_offsets": None, "_device_offsets": c}
+        metadata2 = {"_host_lengths": None, "_host_offsets": b, "_device_offsets": c.clone()}
+
+        dict_tensor1 = DictTensor(metadata1)
+        dict_tensor2 = DictTensor(metadata2)
+
+        torch._nested_assert_metadata_equal(dict_tensor1, dict_tensor2)
+
+        # Failure case
+        metadata1 = {"_host_lengths": a, "_host_offsets": None, "_device_offsets": c}
+        metadata2 = {"_host_lengths": None, "_host_offsets": b, "_device_offsets": a.clone()}
+
+        dict_tensor1 = DictTensor(metadata1)
+        dict_tensor2 = DictTensor(metadata2)
+
+        with self.assertRaises(AssertionError):
+            torch._nested_assert_metadata_equal(dict_tensor1, dict_tensor2)
+
 
 instantiate_parametrized_tests(TestNestedTensor)
 instantiate_device_type_tests(TestNestedTensorDeviceType, globals())

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -8341,7 +8341,7 @@ BACKWARD_SKIPS_AND_XFAILS = [
     # squeeze(): invalid gradient shape; need to check formula
     XFailRule(
         error_type=RuntimeError,
-        error_msg="returned an invalid gradient at index 0",
+        error_msg="invalid gradient at index 0",
         op_match_fn=lambda device, op: (op.full_name == "squeeze"),
         sample_match_fn=lambda device, sample: (
             sample.name == "5D_contig_with_seqlen_cache: normal_dim"
@@ -8460,7 +8460,7 @@ BACKWARD_SKIPS_AND_XFAILS = [
     # Bug: need to use the correct nested int in the return shape
     XFailRule(
         error_type=RuntimeError,
-        error_msg="Function CloneBackward0 returned an invalid gradient",
+        error_msg="invalid gradient at index 0",
         op_match_fn=lambda device, op: (op.full_name == "clone"),
         sample_match_fn=lambda device, sample: (
             sample.kwargs.get("memory_format", None) == torch.contiguous_format

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -3920,11 +3920,7 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
         nt1 = torch.nested.as_nested_tensor([a, b, c], layout=torch.jagged)
         nt2 = torch.nested.as_nested_tensor([a, b, d], layout=torch.jagged)
 
-        self.assertRaisesRegex(
-            RuntimeError,
-            "cannot call binary pointwise function .* with inputs of shapes",
-            lambda: nt1 * nt2,
-        )
+        self.assertRaises(RuntimeError, lambda: nt1 * nt2)
 
     def test_binary_pointwise_transposed(self, device):
         a, b, c = (

--- a/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
@@ -310,6 +310,7 @@ def collect_fw_donated_buffer_idxs(
         if (
             t is not None
             and not is_sparse_any(t)
+            and isinstance(t, torch.Tensor)
             and StorageWeakRef(t.untyped_storage()) not in storage_refs
         ):
             donated_buffer_idxs.append(i)

--- a/torch/csrc/autograd/input_metadata.cpp
+++ b/torch/csrc/autograd/input_metadata.cpp
@@ -66,18 +66,18 @@ at::Tensor InputMetadata::maybe_reduce(
   // careful oblivious logic as seen below
   if (is_nested_ || is_cpp_nested_tensor() || grad.is_nested() ||
       ::torch::autograd::is_cpp_nested_tensor(grad)) {
-    if (!maybe_expandable_to(grad)) {
-      if (is_same_shape(grad)) {
-        return grad;
-      }
-      fail();
+    if (maybe_expandable_to(grad)) {
+      at::_nested_assert_expandable_to_symint(
+          grad,
+          shape_as_dim_vector(),
+          incompatible_shape_error_message(i, grad).str());
+      // Should be a no-op if the shapes are actually the same
+      return reduce_grad(grad);
     }
-    at::_nested_assert_expandable_to_symint(
-        grad,
-        shape_as_dim_vector(),
-        incompatible_shape_error_message(i, grad).str());
-    // Should be a no-op if the shapes are actually the same
-    return reduce_grad(grad);
+    if (is_same_shape(grad)) {
+      return grad;
+    }
+    fail();
   }
 
   auto shape = shape_as_dim_vector();

--- a/torch/csrc/autograd/input_metadata.cpp
+++ b/torch/csrc/autograd/input_metadata.cpp
@@ -66,7 +66,6 @@ at::Tensor InputMetadata::maybe_reduce(
   // careful oblivious logic as seen below
   if (is_nested_ || is_cpp_nested_tensor() || grad.is_nested() ||
       ::torch::autograd::is_cpp_nested_tensor(grad)) {
-
     if (!maybe_expandable_to(grad)) {
       if (is_same_shape(grad)) {
         return grad;
@@ -74,10 +73,9 @@ at::Tensor InputMetadata::maybe_reduce(
       fail();
     }
     at::_nested_assert_expandable_to_symint(
-      grad,
-      shape_as_dim_vector(),
-      incompatible_shape_error_message(i, grad).str()
-    );
+        grad,
+        shape_as_dim_vector(),
+        incompatible_shape_error_message(i, grad).str());
     // Should be a no-op if the shapes are actually the same
     return reduce_grad(grad);
   }

--- a/torch/csrc/autograd/input_metadata.cpp
+++ b/torch/csrc/autograd/input_metadata.cpp
@@ -72,7 +72,7 @@ at::Tensor InputMetadata::maybe_reduce(
           shape_as_dim_vector(),
           incompatible_shape_error_message(i, grad).str());
       // Should be a no-op if the shapes are actually the same
-      return reduce_grad(grad);
+      return at::symint::sum_to_size<c10::SymInt>(grad, shape_as_dim_vector());
     }
     if (is_same_shape(grad)) {
       return grad;

--- a/torch/csrc/autograd/input_metadata.h
+++ b/torch/csrc/autograd/input_metadata.h
@@ -17,6 +17,7 @@
 #include <ATen/Functions.h>
 #else
 #include <ATen/ops/zeros.h>
+#include <ATen/ops/_nested_assert_expandable_to.h>
 #endif
 
 namespace torch::autograd {

--- a/torch/csrc/autograd/input_metadata.h
+++ b/torch/csrc/autograd/input_metadata.h
@@ -16,8 +16,8 @@
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #else
-#include <ATen/ops/zeros.h>
 #include <ATen/ops/_nested_assert_expandable_to.h>
+#include <ATen/ops/zeros.h>
 #endif
 
 namespace torch::autograd {

--- a/torch/csrc/autograd/input_metadata.h
+++ b/torch/csrc/autograd/input_metadata.h
@@ -17,6 +17,7 @@
 #include <ATen/Functions.h>
 #else
 #include <ATen/ops/_nested_assert_expandable_to.h>
+#include <ATen/ops/sum_to_size.h>
 #include <ATen/ops/zeros.h>
 #endif
 

--- a/torch/nested/_internal/nested_int.py
+++ b/torch/nested/_internal/nested_int.py
@@ -248,6 +248,8 @@ def _nested_assert_metadata_equal(
         return _DEVICE_PAIR_SCORES[(candidate[0][0], candidate[1][0])]
 
     candidates = sorted(candidates, key=score)
+    if len(candidates) == 0:
+        raise RuntimeError(msg)
     pair = candidates[0]
 
     _lhs = getattr(lhs, src_field_name(pair[0][0], pair[0][1]))

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -201,7 +201,7 @@ def assert_raggedness_matches(nt, size, msg):
     if not len(nt_ragged) == len(size_ragged):
         raise RuntimeError(msg)
     for ns, s in zip(nt_ragged, size_ragged):
-        if s == -1:
+        if not is_nested_int(s) and s == -1:
             continue
         if ns != s:
             if not (is_nested_int(ns) and is_nested_int(s)):
@@ -2443,7 +2443,8 @@ def _nested_assert_expandable_to(func, *args, **kwargs):
     for i in range(len(shape)):
         src_s = shape[-i - 1]
         tgt_s = desired[-i - 1]
-        if src_s == 1:
+        if not is_nested_int(src_s) and src_s == 1:
+            # Avoid comparing nested int with 1
             continue
         if src_s != tgt_s:
             if not (is_nested_int(src_s) and is_nested_int(tgt_s)):

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -1569,7 +1569,7 @@ def sum_to_size_default(func, *args, **kwargs):
     from torch.fx.experimental.symbolic_shapes import is_nested_int
     from torch.nested._internal.nested_int import _nested_assert_metadata_equal
 
-    _, new_kwargs = normalize_function(
+    _, new_kwargs = normalize_function(  # type: ignore[misc]
         func, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True
     )
     inp = new_kwargs.pop("input")

--- a/torchgen/native_function_generation.py
+++ b/torchgen/native_function_generation.py
@@ -67,7 +67,6 @@ FUNCTIONAL_OPS_THAT_CANNOT_GET_AN_OUT_VARIANT = [
     "_local_scalar_dense",  # returns a Scalar
     "_nested_tensor_from_mask_left_aligned",  # returns a boolean
     "_nnz",  # returns an int
-    "_nested_assert_metadata_equal",  # no return
     "_nested_assert_expandable_to",  # no return
     "_use_cudnn_ctc_loss",  # returns a boolean
     "_use_cudnn_ctc_loss.Tensor",  # returns a boolean

--- a/torchgen/native_function_generation.py
+++ b/torchgen/native_function_generation.py
@@ -67,6 +67,8 @@ FUNCTIONAL_OPS_THAT_CANNOT_GET_AN_OUT_VARIANT = [
     "_local_scalar_dense",  # returns a Scalar
     "_nested_tensor_from_mask_left_aligned",  # returns a boolean
     "_nnz",  # returns an int
+    "_nested_assert_metadata_equal",  # no return
+    "_nested_assert_expandable_to",  # no return
     "_use_cudnn_ctc_loss",  # returns a boolean
     "_use_cudnn_ctc_loss.Tensor",  # returns a boolean
     "_validate_compressed_sparse_indices",  # no return


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #146172
* __->__ #146101
* #145922
* #141842
* #141841
* #146052


Some Issues:

1. The way we use ephemeral sources doesn't work well with this case https://github.com/pytorch/pytorch/pull/145957#issuecomment-2632338330 so the backward function needs to somehow stash the intermediates somewhere

2. There are some duplicate runtime asserts created, e.g. if  I do a binary op requiring runtime assert during forward assert(j0 == j1), (1) I might end up doing that same j0 == j1 assert later during forward. (2)  I will also almost always do the same j0 == j1 when I compute gradients. I wonder how severe the slow down is. If it is concerning, for compile, maybe we can dedupe them with some graph pass? For eager, could we have some kind of eager-only union find?

3. Previously whether j0 == j1 succeeds is consistent with whether nt * nt2, succeeds. Now that we allow nt * nt2 to succed, we are no longer consistent. One way forward is to just document this clearly. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames