### PR TITLE
[export] Include metadata in FlatArgsAdapter

### DIFF
--- a/test/export/test_unflatten.py
+++ b/test/export/test_unflatten.py
@@ -244,6 +244,7 @@ class TestUnflatten(TestCase):
                     target_spec: TreeSpec,
                     input_spec: TreeSpec,
                     input_args: List[Any],
+                    metadata: dict[str, Any],
                 ) -> List[Any]:
                     while len(input_args) > 2:
                         input_args.pop(-1)

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -274,6 +274,7 @@ class FlatArgsAdapter(abc.ABC):
         target_spec: pytree.TreeSpec,
         input_spec: pytree.TreeSpec,
         input_args: list[Any],
+        metadata: Optional[dict[str, Any]] = None,
     ) -> list[Any]:
         """NOTE: This adapter may mutate given ``input_args_with_path``."""
         ...
@@ -530,6 +531,7 @@ class UnflattenedModule(torch.nn.Module):
                 target_spec=signature.in_spec,
                 input_spec=in_spec,
                 input_args=flat_args,
+                metadata=self.meta,
             )
 
             if len(flat_args) != signature.in_spec.num_leaves:


### PR DESCRIPTION
Summary:
With https://github.com/pytorch/pytorch/pull/145956, which introduces
storing a list of namedtuple field names when serializing, we now want to
expose this list to the args adapater so that APS can utilize this information
and remove extraneous inputs.

Test Plan: No-op

Differential Revision: D68928416


