### PR TITLE
Remove outdated test skipif conditions for Python3.9

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1609,10 +1609,6 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
             return a + b
         return a - b
 
-    @unittest.skipIf(
-        sys.version_info < (3, 9),
-        "SET_UPDATE was added at Python 3.9",
-    )
     @make_test
     def test_set_update_bytecode(x):
         # This produces bytecode SET_UPDATE since python 3.9
@@ -1622,10 +1618,6 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         else:
             return x - 1
 
-    @unittest.skipIf(
-        sys.version_info < (3, 9),
-        "SET_UPDATE was added at Python 3.9",
-    )
     @make_test
     def test_set_update_list_with_duplicated_items(x):
         list1 = ["apple", "banana", "apple"]

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -9356,7 +9356,6 @@ def ___make_guard_fn():
         self.assertEqual(counter.frame_count, 0)
 
     # just to be sure in case anyone tries to run this in older versions of Python
-    @unittest.skipIf(sys.version_info < (3, 7), "Made default on Python 3.7")
     def test_pep0479_convert_stopiteration(self):
         # https://peps.python.org/pep-0479/
         def generator_with_stop_iteration():

--- a/test/jit/test_scriptmod_ann.py
+++ b/test/jit/test_scriptmod_ann.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-import unittest
 import warnings
 from typing import Dict, List, Optional
 
@@ -153,9 +152,6 @@ class TestScriptModuleInstanceAttributeTypeAnnotation(JitTestCase):
             ):
                 torch.jit.script(M())
 
-    @unittest.skipIf(
-        sys.version_info[:2] < (3, 9), "Requires lowercase static typing (Python 3.9+)"
-    )
     def test_annotated_empty_list_lowercase(self):
         class M(torch.nn.Module):
             def __init__(self) -> None:
@@ -198,9 +194,6 @@ class TestScriptModuleInstanceAttributeTypeAnnotation(JitTestCase):
             ):
                 torch.jit.script(M())
 
-    @unittest.skipIf(
-        sys.version_info[:2] < (3, 9), "Requires lowercase static typing (Python 3.9+)"
-    )
     def test_annotated_empty_dict_lowercase(self):
         class M(torch.nn.Module):
             def __init__(self) -> None:
@@ -264,9 +257,6 @@ class TestScriptModuleInstanceAttributeTypeAnnotation(JitTestCase):
             ):
                 torch.jit.script(M())
 
-    @unittest.skipIf(
-        sys.version_info[:2] < (3, 9), "Requires lowercase static typing (Python 3.9+)"
-    )
     def test_annotated_with_jit_empty_list_lowercase(self):
         class M(torch.nn.Module):
             def __init__(self) -> None:
@@ -309,9 +299,6 @@ class TestScriptModuleInstanceAttributeTypeAnnotation(JitTestCase):
             ):
                 torch.jit.script(M())
 
-    @unittest.skipIf(
-        sys.version_info[:2] < (3, 9), "Requires lowercase static typing (Python 3.9+)"
-    )
     def test_annotated_with_jit_empty_dict_lowercase(self):
         class M(torch.nn.Module):
             def __init__(self) -> None:

--- a/test/package/test_dependency_api.py
+++ b/test/package/test_dependency_api.py
@@ -2,7 +2,6 @@
 
 import importlib
 from io import BytesIO
-from sys import version_info
 from textwrap import dedent
 from unittest import skipIf
 
@@ -113,7 +112,6 @@ class TestDependencyAPI(PackageTestCase):
                     ),
                 )
 
-    @skipIf(version_info < (3, 7), "mock uses __getattr__ a 3.7 feature")
     def test_mock(self):
         buffer = BytesIO()
         with PackageExporter(buffer) as he:
@@ -134,7 +132,6 @@ class TestDependencyAPI(PackageTestCase):
         with self.assertRaisesRegex(NotImplementedError, "was mocked out"):
             r()
 
-    @skipIf(version_info < (3, 7), "mock uses __getattr__ a 3.7 feature")
     def test_mock_glob(self):
         buffer = BytesIO()
         with PackageExporter(buffer) as he:
@@ -176,7 +173,6 @@ class TestDependencyAPI(PackageTestCase):
                 exporter.mock(include=["package_b.*"], allow_empty=False)
                 exporter.save_module("package_a.subpackage")
 
-    @skipIf(version_info < (3, 7), "mock uses __getattr__ a 3.7 feature")
     def test_pickle_mocked(self):
         import package_a.subpackage
 
@@ -190,7 +186,6 @@ class TestDependencyAPI(PackageTestCase):
                 he.intern("**")
                 he.save_pickle("obj", "obj.pkl", obj2)
 
-    @skipIf(version_info < (3, 7), "mock uses __getattr__ a 3.7 feature")
     def test_pickle_mocked_all(self):
         import package_a.subpackage
 
@@ -323,7 +318,6 @@ class TestDependencyAPI(PackageTestCase):
             ),
         )
 
-    @skipIf(version_info < (3, 7), "mock uses __getattr__ a 3.7 feature")
     def test_repackage_mocked_module(self):
         """Re-packaging a package that contains a mocked module should work correctly."""
         buffer = BytesIO()

--- a/test/package/test_directory_reader.py
+++ b/test/package/test_directory_reader.py
@@ -106,7 +106,6 @@ class DirectoryReaderTest(PackageTestCase):
             self.assertTrue(dir_importer.zip_reader.has_record("package_a/__init__.py"))
             self.assertFalse(dir_importer.zip_reader.has_record("package_a"))
 
-    @skipIf(version_info < (3, 7), "ResourceReader API introduced in Python 3.7")
     def test_resource_reader(self):
         """Tests DirectoryReader as the base for get_resource_reader."""
         filename = self.temp()
@@ -177,7 +176,6 @@ class DirectoryReaderTest(PackageTestCase):
 
             self.assertIsNone(importer.get_resource_reader("nonexistent_package"))
 
-    @skipIf(version_info < (3, 7), "ResourceReader API introduced in Python 3.7")
     @skipIf(version_info >= (3, 13), "https://github.com/python/cpython/issues/127012")
     def test_package_resource_access(self):
         """Packaged modules should be able to use the importlib.resources API to access
@@ -207,7 +205,6 @@ class DirectoryReaderTest(PackageTestCase):
                 "my sekrit plays",
             )
 
-    @skipIf(version_info < (3, 7), "ResourceReader API introduced in Python 3.7")
     def test_importer_access(self):
         filename = self.temp()
         with PackageExporter(filename) as he:
@@ -233,7 +230,6 @@ class DirectoryReaderTest(PackageTestCase):
             self.assertEqual(m.t, "my string")
             self.assertEqual(m.b, b"my string")
 
-    @skipIf(version_info < (3, 7), "ResourceReader API introduced in Python 3.7")
     def test_resource_access_by_path(self):
         """
         Tests that packaged code can used importlib.resources.path.

--- a/test/package/test_resources.py
+++ b/test/package/test_resources.py
@@ -16,7 +16,6 @@ except ImportError:
     from common import PackageTestCase
 
 
-@skipIf(version_info < (3, 7), "ResourceReader API introduced in Python 3.7")
 class TestResources(PackageTestCase):
     """Tests for access APIs for packaged resources."""
 

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -3546,8 +3546,6 @@ class TestFX(JitTestCase):
 
         self.checkGraphModule(M(), (torch.rand(2, 3), A()), kwargs=None)
 
-    @unittest.skipIf(sys.version_info < (3, 7), "`__future__` feature "
-                     "`annotations` is not defined in Python <3.7")
     def test_annotation_with_future(self):
         try:
             import fx.test_future    # noqa: F401

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -610,7 +610,6 @@ class SerializationMixin:
         with self.assertRaisesRegex(RuntimeError, error_msg):
             _ = torch.load(buf)
 
-    @unittest.skipIf((3, 8, 0) <= sys.version_info < (3, 8, 2), "See https://bugs.python.org/issue39681")
     def test_serialization_filelike_api_requirements(self):
         filemock = FilelikeMock(b'', has_readinto=False)
         tensor = torch.randn(3, 5)
@@ -637,7 +636,6 @@ class SerializationMixin:
         b = torch.load(data)
         self.assertTrue(torch.equal(tensor, b), msg.format(desc))
 
-    @unittest.skipIf((3, 8, 0) <= sys.version_info < (3, 8, 2), "See https://bugs.python.org/issue39681")
     def test_serialization_filelike_missing_attrs(self):
         # Test edge cases where filelike objects are missing attributes.
         # The Python io docs suggests that these attributes should really exist
@@ -652,7 +650,6 @@ class SerializationMixin:
         for desc, mock in mocks:
             self._test_serialization_filelike(to_serialize, mock, desc)
 
-    @unittest.skipIf((3, 8, 0) <= sys.version_info < (3, 8, 2), "See https://bugs.python.org/issue39681")
     def test_serialization_filelike_stress(self):
         a = torch.randn(11 * (2 ** 9) + 1, 5 * (2 ** 9))
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2297,9 +2297,6 @@ class TestImports(TestCase):
                            "torch._inductor.runtime.triton_helpers",  # depends on triton
                            "torch._inductor.codegen.cuda",  # depends on cutlass
                            ]
-        # See https://github.com/pytorch/pytorch/issues/77801
-        if not sys.version_info >= (3, 9):
-            ignored_modules.append("torch.utils.benchmark")
         if IS_WINDOWS or IS_MACOS or IS_JETSON:
             # Distributed should be importable on Windows(except nn.api.), but not on Mac
             if IS_MACOS or IS_JETSON:

--- a/test/torch_np/numpy_tests/core/test_dtype.py
+++ b/test/torch_np/numpy_tests/core/test_dtype.py
@@ -358,7 +358,6 @@ class TestFromDTypeAttribute(TestCase):
 
 
 @skip(reason="Parameteric dtypes, our stuff is simpler.")
-@skipif(sys.version_info < (3, 9), reason="Requires python 3.9")
 @instantiate_parametrized_tests
 class TestClassGetItem(TestCase):
     def test_dtype(self) -> None:

--- a/test/torch_np/numpy_tests/core/test_scalar_methods.py
+++ b/test/torch_np/numpy_tests/core/test_scalar_methods.py
@@ -165,7 +165,6 @@ class TestIsInteger(TestCase):
 
 
 @skip(reason="XXX: implementation details of the type system differ")
-@skipif(sys.version_info < (3, 9), reason="Requires python 3.9")
 @instantiate_parametrized_tests
 class TestClassGetItem(TestCase):
     @parametrize(


### PR DESCRIPTION
Fixes #ISSUE_NUMBER


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames