### PR TITLE
[AArch64] Build on Graviton 3 so that SVE is used in Graviton 3 tests

### DIFF
--- a/.github/workflows/linux-aarch64.yml
+++ b/.github/workflows/linux-aarch64.yml
@@ -34,7 +34,7 @@ jobs:
       runner_prefix: ${{ needs.get-label-type.outputs.label-type }}
       build-environment: linux-jammy-aarch64-py3.10
       docker-image-name: pytorch-linux-jammy-aarch64-py3.10-gcc11
-      runner: linux.arm64.2xlarge
+      runner: linux.arm64.m7g.4xlarge
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 4, runner: "linux.arm64.2xlarge" },

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -59,13 +59,16 @@ from torch.testing._internal.common_utils import (
     gradcheck,
     iter_indices,
     numpy_to_torch_dtype_dict,
+    parametrize,
     run_tests,
     set_default_dtype,
     skipIfTorchDynamo,
     slowTest,
+    subtest,
     TEST_SCIPY,
     TestCase,
     torch_to_numpy_dtype_dict,
+    xfailIfSVE256,
     xfailIfTorchDynamo,
 )
 
@@ -3458,7 +3461,17 @@ class TestBinaryUfuncs(TestCase):
         )
         self.assertEqual(torch.ldexp(mantissas, exponents), expected)
 
-    @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
+    @parametrize(
+        "dtype",
+        [
+            torch.float,
+            torch.double,
+            # TODO: create GH issue
+            # AssertionError: Tensor-likes are not close!
+            subtest([torch.cfloat], decorators=[xfailIfSVE256]),
+            torch.cdouble,
+        ],
+    )
     def test_lerp(self, device, dtype):
         start_end_weight_shapes = [(), (5,), (5, 5)]
         for shapes in product(

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3467,9 +3467,12 @@ class TestBinaryUfuncs(TestCase):
             torch.float,
             torch.double,
             # https://github.com/pytorch/pytorch/issues/146155
-            subtest([torch.cfloat], decorators=[xfailIfSVE256]),
+            subtest(torch.cfloat, decorators=[xfailIfSVE256]),
             torch.cdouble,
         ],
+        # Let instantiate_device_type_tests handle the naming
+        # to avoid duplicating the dtype in the test suffix
+        name_fn=lambda *args, **kwargs: "",
     )
     def test_lerp(self, device, dtype):
         start_end_weight_shapes = [(), (5,), (5, 5)]

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3466,8 +3466,7 @@ class TestBinaryUfuncs(TestCase):
         [
             torch.float,
             torch.double,
-            # TODO: create GH issue
-            # AssertionError: Tensor-likes are not close!
+            # https://github.com/pytorch/pytorch/issues/146155
             subtest([torch.cfloat], decorators=[xfailIfSVE256]),
             torch.cdouble,
         ],

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1596,6 +1596,12 @@ def xpassIfTorchDynamo_np(func):
 def xfailIfACL(func):
     return unittest.expectedFailure(func) if TEST_ACL else func
 
+def xfailIfSVE256(func):
+    return (
+        unittest.expectedFailure(func)
+        if torch.backends.cpu.get_cpu_capability() == "SVE256"
+        else func
+    )
 
 def xfailIfTorchDynamo(func):
     return unittest.expectedFailure(func) if TEST_WITH_TORCHDYNAMO else func


### PR DESCRIPTION
Currently the linux aarch64 CI that runs on pushes to main builds pytorch on Graviton 2, and tests on Graviton 2 and 3. However, by building on Graviton 2, CPU_CAPABILITY_SVE code paths are not available when the tests on Graviton 3 are run:

```yaml
  linux-jammy-aarch64-py3_10-build:
    name: linux-jammy-aarch64-py3.10
    uses: ./.github/workflows/_linux-build.yml
    needs: get-label-type
    with:
      runner_prefix: ${{ needs.get-label-type.outputs.label-type }}
      build-environment: linux-jammy-aarch64-py3.10
      docker-image-name: pytorch-linux-jammy-aarch64-py3.10-gcc11
      runner: linux.arm64.2xlarge <--- Graviton 2
      test-matrix: |
        { include: [
          { config: "default", shard: 1, num_shards: 4, runner: "linux.arm64.2xlarge" },
          { config: "default", shard: 2, num_shards: 4, runner: "linux.arm64.2xlarge" },
          { config: "default", shard: 3, num_shards: 4, runner: "linux.arm64.2xlarge" },
          { config: "default", shard: 4, num_shards: 4, runner: "linux.arm64.2xlarge" },
          { config: "default", shard: 1, num_shards: 3, runner: "linux.arm64.m7g.4xlarge" },
          { config: "default", shard: 2, num_shards: 3, runner: "linux.arm64.m7g.4xlarge" },
          { config: "default", shard: 3, num_shards: 3, runner: "linux.arm64.m7g.4xlarge" },
        ]}
    secrets: inherit

```

This is in contrast to the release [CI](https://github.com/pytorch/pytorch/blob/main/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml) which builds on Graviton 3, and therefore has CPU_CAPABILITY_SVE enabled. There is currently a test failure that is encountered in the release wheel, but not in the tests that are run on pushes to main due to the above reason.

This PR changes the runner to a Graviton 3 machine for builds that occur on pushes to main so that release wheels for aarch64 are fully tested. 

Fixes #ISSUE_NUMBER

CC @malfet 