### PR TITLE
Remove trivial dispatch_key_allowlist_check function

### DIFF
--- a/aten/src/ATen/core/op_registration/op_allowlist.h
+++ b/aten/src/ATen/core/op_registration/op_allowlist.h
@@ -178,18 +178,4 @@ constexpr bool op_allowlist_contains_name_in_schema(std::string_view allowlist, 
   return allowlist_contains(allowlist, schema.substr(0, schema.find('(')));
 }
 
-// Returns true iff the given dispatch key is on the allowlist
-// and should be registered.  When we turn this on, the list of valid
-// mobile dispatch keys is hard coded (but you need to make sure
-// that you have the correct set of dispatch keys for this).
-constexpr bool dispatch_key_allowlist_check(DispatchKey /*k*/) {
-#ifdef C10_MOBILE
-  return true;
-  // Disabled for now: to be enabled later!
-  // return k == DispatchKey::CPU || k == DispatchKey::Vulkan || k == DispatchKey::QuantizedCPU || k == DispatchKey::BackendSelect || k == DispatchKey::CatchAll;
-#else
-  return true;
-#endif
-}
-
 } // namespace c10::impl

--- a/torch/library.h
+++ b/torch/library.h
@@ -1027,9 +1027,7 @@ class TorchLibraryInit final {
   static const torch::detail::TorchLibraryInit C10_CONCATENATE(           \
       TORCH_LIBRARY_IMPL_static_init_##ns##_##k##_, uid)(                 \
       torch::Library::IMPL,                                               \
-      (c10::impl::dispatch_key_allowlist_check(c10::DispatchKey::k)       \
-           ? &C10_CONCATENATE(TORCH_LIBRARY_IMPL_init_##ns##_##k##_, uid) \
-           : [](torch::Library&) -> void {}),                             \
+      &C10_CONCATENATE(TORCH_LIBRARY_IMPL_init_##ns##_##k##_, uid),       \
       #ns,                                                                \
       std::make_optional(c10::DispatchKey::k),                            \
       __FILE__,                                                           \


### PR DESCRIPTION
Hmmm...this _is_ removing a public function from a public C++ file. But the GH counts for this function total 83, seemingly all copying pytorch: https://github.com/search?q=dispatch_key_allowlist_check&type=code&p=1 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146169

