### PR TITLE
[ROCm] Tune 3d tensor sums when not using fastest dimension

### DIFF
--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -1159,6 +1159,8 @@ ReduceConfig setReduceConfig(const TensorIterator& iter){
       config.ctas_per_output = div_up(num_mp, 2);
     else if (config.ctas_per_output < 16)
       config.ctas_per_output = 1;
+    if (iter.ndim() == 3 && !reduction_on_fastest_striding_dimension)
+      config.ctas_per_output = 4;
 #endif
     if (config.ctas_per_output > 1) {
       config.input_mult[2] = config.split_input(config.ctas_per_output);


### PR DESCRIPTION
Tune 3d tensor sums when not using fastest dimension.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd