### PR TITLE
Noob attempt at tensor_pointer_to_tensor_handle accepting const

### DIFF
--- a/torch/csrc/inductor/aoti_torch/utils.h
+++ b/torch/csrc/inductor/aoti_torch/utils.h
@@ -33,6 +33,11 @@ inline AtenTensorHandle tensor_pointer_to_tensor_handle(at::Tensor* tensor) {
   return reinterpret_cast<AtenTensorHandle>(tensor);
 }
 
+inline AtenTensorHandle tensor_pointer_to_tensor_handle(
+    const at::Tensor* tensor) {
+  return reinterpret_cast<AtenTensorHandle>(const_cast<at::Tensor*>(tensor));
+}
+
 inline at::Generator* generator_handle_to_generator_pointer(
     AtenGeneratorHandle handle) {
   return reinterpret_cast<at::Generator*>(handle);


### PR DESCRIPTION
Fairly certain this will fail lint but is there a reason creating an AtenTensorHandle is not const preserving?

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146171

