### PR TITLE
execution trace export supports gzip format

### DIFF
--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -92,8 +92,14 @@ class TestExecutionTrace(TestCase):
             _record_function_with_args_exit(rf_handle)
 
     def get_execution_trace_root(self, output_file_name) -> Json:
+        import gzip
+
         nodes = []
-        with open(output_file_name) as f:
+        with (
+            gzip.open(output_file_name)
+            if output_file_name.endswith(".gz")
+            else open(output_file_name)
+        ) as f:
             et_graph = json.load(f)
             assert "nodes" in et_graph
             nodes = et_graph["nodes"]
@@ -299,7 +305,8 @@ class TestExecutionTrace(TestCase):
             or torch.profiler.ProfilerActivity.XPU in supported_activities()
         )
         # Create a temp file to save execution trace data.
-        fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
+        # Use a gzip file to test compression codepath
+        fp = tempfile.NamedTemporaryFile("w", suffix=".et.json.gz", delete=False)
         fp.close()
         expected_loop_events = 0
 

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -888,6 +888,7 @@ class ExecutionTraceObserver(_ITraceObserver):
         self.extra_resources_collection = False
         self.resources_dir: str = ""
         self.output_file_path: str = ""
+        self.output_file_path_observer: str = ""
 
     def __del__(self):
         """
@@ -942,8 +943,17 @@ class ExecutionTraceObserver(_ITraceObserver):
         Adds ET observer to record function callbacks. The data will be
         written to output_file_path.
         """
+
+        def get_temp_uncompressed_file() -> str:
+            fp = tempfile.NamedTemporaryFile("w+b", suffix=".json", delete=False)
+            fp.close()
+            return fp.name
+
         if not self._registered:
             self.output_file_path = output_file_path
+            if output_file_path.endswith(".gz"):
+                output_file_path = get_temp_uncompressed_file()
+            self.output_file_path_observer = output_file_path
             self._registered = _add_execution_trace_observer(output_file_path)
         return self
 
@@ -997,7 +1007,7 @@ class ExecutionTraceObserver(_ITraceObserver):
         Removes ET observer from record function callbacks.
         """
 
-        def _save_triton_kernels():
+        def _save_triton_kernels() -> None:
             try:
                 resource_dir = self.get_resources_dir()
             except Exception as e:
@@ -1024,13 +1034,25 @@ class ExecutionTraceObserver(_ITraceObserver):
                 dst = os.path.join(resource_dir, name)
                 shutil.copyfile(kernel_file, dst)
 
+        def _save_gz_file(uncompressed_file: str, output_file: str) -> None:
+            print(f"Execution Trace: compressing {uncompressed_file} to {output_file}")
+            with open(uncompressed_file, "rb") as fin:
+                with gzip.open(output_file, "wb") as fout:
+                    fout.writelines(fin)
+            os.remove(uncompressed_file)
+
         if self._registered:
             self.stop()
+
             try:
                 _save_triton_kernels()
             except Exception as e:
                 warn(f"Execution trace failed to save kernels: {e}")
+
             _remove_execution_trace_observer()
+            if self.output_file_path.endswith("gz"):
+                _save_gz_file(self.output_file_path_observer, self.output_file_path)
+
             self._registered = False
 
     @property


### PR DESCRIPTION
As above, allows Chakra Execution Trace observer to support compressing files.
Usage is straightforward, just add ".gz" suffix to the output file name
```
et = ExecutionTraceObserver()
et.register_callback("my_trace.json.gz")
```

