### PR TITLE
[AOTI] Improve readability of package_cpp_only

### DIFF
--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -173,19 +173,12 @@ def _aoti_compile_and_package_inner(
     assert isinstance(aoti_files, list)
 
     if package_path is None:
-        path = [
-            os.path.splitext(file)[0]
-            for file in aoti_files
-            if os.path.splitext(file)[1] == ".so"
-        ]
-        if len(path) == 0:
-            path = [
-                os.path.splitext(file)[0]
-                for file in aoti_files
-                if os.path.splitext(file)[1] == ".cpp"
-            ]
-        package_path = path[0] + ".pt2"
-
+        for file in aoti_files:
+            base_name, ext_name = os.path.splitext(file)
+            if ext_name == ".so" or (ext_name == ".cpp" and "model_" in base_name):
+                package_path = base_name + ".pt2"
+                break
+        assert package_path is not None
     res = package_aoti(package_path, aoti_files)
     assert res == package_path
 

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -153,10 +153,15 @@ class CppWrapperCpu(PythonWrapperCodegen):
         self.header.splice(self.get_device_include())
 
         if V.graph.aot_mode:
-            with open(
-                os.path.join(os.path.dirname(__file__), "aoti_runtime", "interface.cpp")
-            ) as f:
-                self.header.splice(f.read())
+            cpp_file = os.path.join(
+                os.path.dirname(__file__), "aoti_runtime", "interface.cpp"
+            )
+            if config.aot_inductor.package_cpp_only:
+                # Emit interface.cpp into a separate file instead of embedding into the main file
+                self.additional_files.append(str(cpp_file))
+            else:
+                with open(cpp_file) as f:
+                    self.header.splice(f.read())
 
         extend_aoti_c_shim_include = (
             f"torch/csrc/inductor/aoti_torch/generated/extend/c_shim_{self.device}.h"

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -686,6 +686,9 @@ class PythonWrapperCodegen(CodeGen):
         self.codegened_graph_stack = []
         self.computed_sizes_stack = []
 
+        # Additional files that are dependent to the wrapper (ex. cubin files)
+        self.additional_files = []
+
         self.write_header()
         self.write_prefix()
         self.write_kernel_autotune_defs_header()
@@ -723,9 +726,6 @@ class PythonWrapperCodegen(CodeGen):
             debug_printer_level=config.aot_inductor.debug_intermediate_value_printer,
             use_array_ref=config.aot_inductor.allow_stack_allocation,
         )
-
-        # Additional files that are dependent to the wrapper (ex. cubin files)
-        self.additional_files = []
 
     @staticmethod
     def create(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146180

Summary: Made two improvements here: 1) Emit interface.cpp into a separate file instead of embedding it to the model code; 2) Add prefix to mark the generated files as model code or weights(constants).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov