### PR TITLE
Add generate_stage_to_rank_mapping utility

### DIFF
--- a/test/distributed/pipelining/schedule_registry.py
+++ b/test/distributed/pipelining/schedule_registry.py
@@ -34,7 +34,6 @@ class ScheduleVShaped(PipelineScheduleMulti):
         self,
         stages: list[_PipelineStageBase],
         n_microbatches: int,
-        stage_index_to_group_rank: dict[int, int],
         loss_fn: Optional[Callable] = None,
         scale_grads: bool = True,
     ):
@@ -42,7 +41,8 @@ class ScheduleVShaped(PipelineScheduleMulti):
             stages=stages,
             n_microbatches=n_microbatches,
             loss_fn=loss_fn,
-            stage_index_to_group_rank=stage_index_to_group_rank,
+            # TODO: placeholder remove later
+            stage_index_to_group_rank={},
             scale_grads=scale_grads,
         )
 
@@ -84,7 +84,6 @@ class ScheduleUnbalanced(PipelineScheduleMulti):
         self,
         stages: list[_PipelineStageBase],
         n_microbatches: int,
-        stage_index_to_group_rank: dict[int, int],
         loss_fn: Optional[Callable] = None,
         scale_grads: bool = True,
     ):
@@ -92,7 +91,8 @@ class ScheduleUnbalanced(PipelineScheduleMulti):
             stages=stages,
             n_microbatches=n_microbatches,
             loss_fn=loss_fn,
-            stage_index_to_group_rank=stage_index_to_group_rank,
+            # TODO: placeholder remove later
+            stage_index_to_group_rank={},
             scale_grads=scale_grads,
         )
 

--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -15,6 +15,7 @@ from torch.distributed.pipelining import (
     ScheduleInterleavedZeroBubble,
     ScheduleLoopedBFS,
 )
+from torch.distributed.pipelining._utils import generate_stage_to_rank_mapping
 from torch.distributed.pipelining.schedules import (
     _Action,
     _add_send_recv,
@@ -926,6 +927,74 @@ class TestValidateSchedule(TestCase):
         num_microbatches = 1
         with self.assertRaises(AssertionError):
             _validate_schedule(actions, pp_group_size, num_stages, num_microbatches)
+
+
+class ScheduleUtilTests(TestCase):
+    def test_generate_stage_to_rank_mapping(self):
+        stage_to_rank = generate_stage_to_rank_mapping(2, 2)
+        self.assertEqual(
+            stage_to_rank,
+            {
+                0: 0,
+                1: 1,
+            },
+        )
+        stage_to_rank = generate_stage_to_rank_mapping(2, 4)
+        self.assertEqual(stage_to_rank, {0: 0, 1: 1, 2: 0, 3: 1})
+        stage_to_rank = generate_stage_to_rank_mapping(4, 8)
+        self.assertEqual(
+            stage_to_rank, {0: 0, 1: 1, 2: 2, 3: 3, 4: 0, 5: 1, 6: 2, 7: 3}
+        )
+        stage_to_rank = generate_stage_to_rank_mapping(2, 4, style="v")
+        self.assertEqual(
+            stage_to_rank,
+            {
+                0: 0,
+                1: 1,
+                2: 1,
+                3: 0,
+            },
+        )
+        stage_to_rank = generate_stage_to_rank_mapping(4, 12, style="v")
+        self.assertEqual(
+            stage_to_rank,
+            {
+                0: 0,
+                1: 1,
+                2: 2,
+                3: 3,
+                4: 3,
+                5: 2,
+                6: 1,
+                7: 0,
+                8: 0,
+                9: 1,
+                10: 2,
+                11: 3,
+            },
+        )
+        stage_to_rank = generate_stage_to_rank_mapping(4, 16, style="v")
+        self.assertEqual(
+            stage_to_rank,
+            {
+                0: 0,
+                1: 1,
+                2: 2,
+                3: 3,
+                4: 3,
+                5: 2,
+                6: 1,
+                7: 0,
+                8: 0,
+                9: 1,
+                10: 2,
+                11: 3,
+                12: 3,
+                13: 2,
+                14: 1,
+                15: 0,
+            },
+        )
 
 
 instantiate_parametrized_tests(TestScheduleLowering)

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -779,10 +779,13 @@ class ScheduleTest(MultiProcContinousTest):
         schedule = schedule_class(
             stages,
             num_microbatches,
-            stage_index_to_group_rank=stage_index_to_group_rank,
             loss_fn=loss_fn,
             scale_grads=False,
         )
+        # TODO: remove this once we get rid of stage_index_to_group_rank
+        schedule.stage_index_to_group_rank = stage_index_to_group_rank
+        for stage in stages:
+            stage.stage_index_to_group_rank = stage_index_to_group_rank
 
         if use_new_runtime:
             old_schedule = schedule

--- a/torch/distributed/pipelining/_utils.py
+++ b/torch/distributed/pipelining/_utils.py
@@ -2,7 +2,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import logging
 from dataclasses import dataclass
-from typing import Union
+from typing import Dict, Union
 
 import torch
 from torch import fx
@@ -86,6 +86,36 @@ def validate_tensors_metadata(
         validate_tensor_metadata(
             f"{desc}: value {i}", expected_tensors[i], actual_tensors[i]
         )
+
+
+def generate_stage_to_rank_mapping(
+    pp_size: int, num_stages: int, style: str = "loop"
+) -> Dict[int, int]:
+    """
+    Compute the stage id to rank mapping for either a looped or V-style schedule
+    """
+    mapping = {}
+    if num_stages % pp_size != 0:
+        raise ValueError(
+            f"num_stages {num_stages} must be evenly divisible by pp_size {pp_size}"
+        )
+    if style == "loop":
+        for stage_index in range(num_stages):
+            mapping[stage_index] = stage_index % pp_size
+    elif style == "v":
+        rank_index = 0
+        for stage_index in range(num_stages):
+            mapping[stage_index] = rank_index
+            # dont change rank if we are on the border (to keep v shape)
+            if (stage_index + 1) % pp_size == 0:
+                continue
+            if (stage_index // pp_size) % 2 == 0:
+                rank_index += 1
+            else:
+                rank_index -= 1
+    else:
+        raise ValueError(f"Style {style} is not supported.")
+    return mapping
 
 
 @dataclass

--- a/torch/distributed/pipelining/_utils.py
+++ b/torch/distributed/pipelining/_utils.py
@@ -92,7 +92,10 @@ def generate_stage_to_rank_mapping(
     pp_size: int, num_stages: int, style: str = "loop"
 ) -> Dict[int, int]:
     """
-    Compute the stage id to rank mapping for either a looped or V-style schedule
+    Compute the stage id to rank mapping for either a looped or V-style schedule.
+
+    Most commonly num_stages == pp_size * 2, but this function can be used to
+    compute the mapping for any number of stages per rank.
     """
     mapping = {}
     if num_stages % pp_size != 0:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #146217
* __->__ #146193

We use `stage_index_to_group_rank` in the stage to determine what send/recv ops and in the schedule for IR generation. However, we don't need to expose this as an argument in our schedule class, so this stack of PRs is to remove it.

This PR creates a `stage_index_to_group_rank` utility function and removes the arg for the ZBVschedule. In a following PR I will add code to infer the `stage_index_to_group_rank` for the CSV schedule path and we will be able to remove this argument from our classes entirely.

Related comment from @wconstab https://github.com/pytorch/torchtitan/issues/774#issuecomment-2619793741

cc @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o