### PR TITLE
include entire GraphModule instead of current node when erroring inside of fx interpreter

### DIFF
--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -173,6 +173,8 @@ class Interpreter:
                 if self.extra_traceback:
                     msg = f"While executing {node.format_node()}"
                     msg = f"{e.args[0]}\n\n{msg}" if e.args else str(msg)
+                    if isinstance(self.module, GraphModule):
+                        msg += f"\nGraphModule: {self.module.print_readable(print_output=False, include_stride=True)}\n"
                     msg += f"\nOriginal traceback:\n{node.stack_trace}"
                     e.args = (msg,) + e.args[1:]
                     if isinstance(e, KeyError):


### PR DESCRIPTION
This seems like it would make it easier to diagnose PT2 issues where the user cannot easily repro, and we need more info in the backtrace, e.g. in https://github.com/pytorch/pytorch/issues/134182#issuecomment-2628076114

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146197



cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv