### PR TITLE
Remove stage_index_to_group_rank from schedule

### DIFF
--- a/test/distributed/pipelining/schedule_registry.py
+++ b/test/distributed/pipelining/schedule_registry.py
@@ -41,9 +41,8 @@ class ScheduleVShaped(PipelineScheduleMulti):
             stages=stages,
             n_microbatches=n_microbatches,
             loss_fn=loss_fn,
-            # TODO: placeholder remove later
-            stage_index_to_group_rank={},
             scale_grads=scale_grads,
+            loop_style="v",
         )
 
         # Go through one microbatch
@@ -91,8 +90,6 @@ class ScheduleUnbalanced(PipelineScheduleMulti):
             stages=stages,
             n_microbatches=n_microbatches,
             loss_fn=loss_fn,
-            # TODO: placeholder remove later
-            stage_index_to_group_rank={},
             scale_grads=scale_grads,
         )
 
@@ -122,6 +119,7 @@ class ScheduleUnbalanced(PipelineScheduleMulti):
                 None,
             ],
         }
+        self._validate_and_set_stage_mapping(self.pipeline_order)
 
 
 class ScheduleWithW(PipelineScheduleMulti):
@@ -183,6 +181,7 @@ class ScheduleWithW(PipelineScheduleMulti):
                 _Action(1, W, 1),
             ],
         }
+        self._validate_and_set_stage_mapping(self.pipeline_order)
 
 
 class ScheduleWithReorderedB(_PipelineScheduleRuntime):

--- a/test/distributed/pipelining/schedule_registry.py
+++ b/test/distributed/pipelining/schedule_registry.py
@@ -42,7 +42,6 @@ class ScheduleVShaped(PipelineScheduleMulti):
             n_microbatches=n_microbatches,
             loss_fn=loss_fn,
             scale_grads=scale_grads,
-            loop_style="v",
         )
 
         # Go through one microbatch
@@ -70,6 +69,7 @@ class ScheduleVShaped(PipelineScheduleMulti):
                 None,
             ],
         }
+        self._validate_and_set_stage_mapping(self.pipeline_order)
 
 
 class ScheduleUnbalanced(PipelineScheduleMulti):

--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -63,7 +63,6 @@ class MockPipelineStage(_PipelineStageBase):
         self.group_size = kwargs.get("group_size", 1)
         self.group_rank = kwargs.get("group_rank", 0)
         self.group = kwargs.get("group", None)
-        self.stage_index_to_group_rank = kwargs.get("stage_index_to_group_rank", None)
 
     def _create_grad_recv_info(self, *args, **kwargs):
         return None
@@ -720,7 +719,6 @@ class TestScheduleLowering(TestCase):
             stages,
             num_microbatches,
             loss_fn=loss_fn,
-            stage_index_to_group_rank=[0, 0],
             scale_grads=False,
         )
         schedule._load_actions(
@@ -833,7 +831,6 @@ class TestScheduleLowering(TestCase):
             stages,
             num_microbatches,
             loss_fn=loss_fn,
-            stage_index_to_group_rank=[0],
         )
         schedule._load_actions(
             {

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -432,7 +432,6 @@ class ScheduleTest(MultiProcContinousTest):
                 stages,
                 num_microbatches,
                 loss_fn=loss_fn,
-                stage_index_to_group_rank=old_schedule.stage_index_to_group_rank,
                 scale_grads=False,
             )
             tmp_schedule._load_actions(old_schedule.pipeline_order)
@@ -441,7 +440,6 @@ class ScheduleTest(MultiProcContinousTest):
                 stages,
                 num_microbatches,
                 loss_fn=loss_fn,
-                stage_index_to_group_rank=old_schedule.stage_index_to_group_rank,
                 scale_grads=False,
             )
             with tempfile.NamedTemporaryFile() as f:
@@ -452,7 +450,6 @@ class ScheduleTest(MultiProcContinousTest):
                 stages,
                 num_microbatches,
                 loss_fn=loss_fn,
-                stage_index_to_group_rank=old_schedule.stage_index_to_group_rank,
                 scale_grads=False,
             )
             one_more_schedule._load_actions(
@@ -772,28 +769,18 @@ class ScheduleTest(MultiProcContinousTest):
             for stage_module, stage_idx in zip(stage_modules, rank_stages[self.rank])
         ]
 
-        # Attach to a schedule
-        stage_index_to_group_rank = {
-            value: key for key, values in rank_stages.items() for value in values
-        }
         schedule = schedule_class(
             stages,
             num_microbatches,
             loss_fn=loss_fn,
             scale_grads=False,
         )
-        # TODO: remove this once we get rid of stage_index_to_group_rank
-        schedule.stage_index_to_group_rank = stage_index_to_group_rank
-        for stage in stages:
-            stage.stage_index_to_group_rank = stage_index_to_group_rank
-
         if use_new_runtime:
             old_schedule = schedule
             schedule = _PipelineScheduleRuntime(
                 stages,
                 num_microbatches,
                 loss_fn=loss_fn,
-                stage_index_to_group_rank=old_schedule.stage_index_to_group_rank,
             )
             schedule._load_actions(old_schedule.pipeline_order)
 

--- a/torch/distributed/pipelining/_utils.py
+++ b/torch/distributed/pipelining/_utils.py
@@ -95,14 +95,15 @@ def generate_stage_to_rank_mapping(
     Compute the stage id to rank mapping for either a looped or V-style schedule
     """
     mapping = {}
-    if num_stages % pp_size != 0:
-        raise ValueError(
-            f"num_stages {num_stages} must be evenly divisible by pp_size {pp_size}"
-        )
     if style == "loop":
         for stage_index in range(num_stages):
             mapping[stage_index] = stage_index % pp_size
     elif style == "v":
+        if num_stages % pp_size != 0:
+            raise ValueError(
+                f"num_stages {num_stages} must be evenly divisible by pp_size {pp_size} for V schedules"
+            )
+
         rank_index = 0
         for stage_index in range(num_stages):
             mapping[stage_index] = rank_index

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -9,7 +9,7 @@ import re
 from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from enum import Enum
-from typing import Any, Callable, NamedTuple, Optional, TYPE_CHECKING, Union
+from typing import Any, Callable, Dict, NamedTuple, Optional, TYPE_CHECKING, Union
 
 import torch
 import torch.distributed as dist
@@ -1025,7 +1025,7 @@ def _validate_schedule(
     pp_group_size: int,
     num_stages: int,
     num_microbatches: int,
-):
+) -> Dict[int, int]:
     assert (
         len(actions) == pp_group_size
     ), f"Schedule has incorrect number of ranks - expected {pp_group_size}, actual {len(actions)}"
@@ -1043,6 +1043,7 @@ def _validate_schedule(
         }
         for stage_id in range(num_stages)
     }
+    stage_index_to_rank_mapping = {}
     for rank in actions:
         for action in actions[rank]:
             if action is None:
@@ -1070,6 +1071,13 @@ def _validate_schedule(
                     mb_id in stage_actions[s_id][I]
                 ), f"Running Backward Weight for stage {s_id}, microbatch {mb_id} without first running Backward Input"
                 stage_actions[s_id][W].add(mb_id)
+            if s_id not in stage_index_to_rank_mapping:
+                stage_index_to_rank_mapping[s_id] = rank
+            else:
+                existing_rank = stage_index_to_rank_mapping[s_id]
+                assert (
+                    rank == existing_rank
+                ), f"Stage {s_id} is assigned to both rank {rank} and rank {existing_rank}"
 
     for s_id in stage_actions:
         f_mb = len(stage_actions[s_id][F])
@@ -1085,6 +1093,7 @@ def _validate_schedule(
             b_mb + (i_mb + w_mb) // 2 == num_microbatches
         ), f"Invalid backward microbatches for stage {s_id}: expected {num_microbatches} total backwards, \
             but got B={b_mb}, I={i_mb}, W={w_mb}"
+    return stage_index_to_rank_mapping
 
 
 class PipelineScheduleMulti(_PipelineSchedule):
@@ -1105,9 +1114,9 @@ class PipelineScheduleMulti(_PipelineSchedule):
         args_chunk_spec: Optional[tuple[TensorChunkSpec, ...]] = None,
         kwargs_chunk_spec: Optional[dict[str, TensorChunkSpec]] = None,
         output_merge_spec: Optional[Union[dict[str, Any], tuple[Any]]] = None,
-        stage_index_to_group_rank: Optional[dict[int, int]] = None,
         use_full_backward: Optional[bool] = None,
         scale_grads: bool = True,
+        loop_style: Optional[str] = None,
     ):
         # Init parent
         super().__init__(
@@ -1124,12 +1133,10 @@ class PipelineScheduleMulti(_PipelineSchedule):
         self.pp_group_size = stages[0].group_size
         self.rank = stages[0].group_rank
         # Set the pipeline stage states
-        if stage_index_to_group_rank is None:
-            self.stage_index_to_group_rank = generate_stage_to_rank_mapping(
-                self.pp_group_size, self._num_stages
-            )
-        else:
-            self.stage_index_to_group_rank = stage_index_to_group_rank
+        style = loop_style if loop_style else "loop"
+        self.stage_index_to_group_rank = generate_stage_to_rank_mapping(
+            self.pp_group_size, self._num_stages, style=style
+        )
         for stage in self._stages:
             stage.stage_index_to_group_rank = self.stage_index_to_group_rank
 
@@ -1169,6 +1176,21 @@ class PipelineScheduleMulti(_PipelineSchedule):
                 stage._prepare_backward_infra(self._n_microbatches)
         self._stages_initialized = True
 
+    def _validate_and_set_stage_mapping(
+        self, actions: dict[int, list[Optional[_Action]]]
+    ) -> None:
+        """
+        Allocates the stage index to rank mapping which is needed for communication
+        """
+        self.stage_index_to_group_rank = _validate_schedule(
+            actions,
+            self.pp_group_size,
+            self._num_stages,
+            self._n_microbatches,
+        )
+        for stage in self._stages:
+            stage.stage_index_to_group_rank = self.stage_index_to_group_rank
+
     def _dump_csv(self, filename):
         """Dump a CSV representation of the schedule into a file with the provided filename."""
         with open(filename, "w", newline="") as csvfile:
@@ -1187,12 +1209,8 @@ class PipelineScheduleMulti(_PipelineSchedule):
             reader = csv.reader(csvfile)
             for rank, row in enumerate(reader):
                 self.pipeline_order[rank] = [_Action.from_str(s) for s in row]
-        _validate_schedule(
-            self.pipeline_order,
-            self.pp_group_size,
-            self._num_stages,
-            self._n_microbatches,
-        )
+
+        self._validate_and_set_stage_mapping(self.pipeline_order)
 
     def step(self, *args, target=None, losses: Optional[list] = None, **kwargs):
         """
@@ -1434,9 +1452,9 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
         Given an in-memory representation for a simple compute-only schedule, lower it to a complex schedule including
         communication actions.  Stores the schedule in self, and must be called before running step_mo()
         """
-        assert (
-            self.stage_index_to_group_rank is not None
-        ), "stage_index_to_group_rank is required for PipelineScheduleRuntime"
+        # validate the actions are valid and sets stage_index_to_group_rank
+        super()._validate_and_set_stage_mapping(actions)
+
         self.pipeline_order_with_comms: dict[int, list[_Action]] = {}
         if format == "compute_comms":
             for rank in actions:
@@ -2282,14 +2300,8 @@ class ScheduleZBVZeroBubble(PipelineScheduleMulti):
             kwargs_chunk_spec=kwargs_chunk_spec,
             output_merge_spec=output_merge_spec,
             scale_grads=scale_grads,
+            loop_style="v",
         )
-
-        # override the default loop style created in multistage schedule
-        self.stage_index_to_group_rank = generate_stage_to_rank_mapping(
-            self.pp_group_size, self._num_stages, style="v"
-        )
-        for stage in self._stages:
-            stage.stage_index_to_group_rank = self.stage_index_to_group_rank
 
         self.n_local_stages = len(stages)
         if self.n_local_stages != 2:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146217
* #146193

This PR allows schedules loaded via CSV to automatically set their `stage_index_to_group_rank ` and removes the `stage_index_to_group_rank ` argument from the `PipelineScheduleMulti` constructor

cc @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o