### PR TITLE
Fix aten.to when input is a tensor constant

### DIFF
--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -547,7 +547,10 @@ class FunctionalTensorMode(TorchDispatchMode):
                                     and kwargs["dtype"] != args_unwrapped[0].dtype
                                 )
 
-                            if must_copy():
+                            # `args_unwrapped` might be a tensor constant, not a functional tensor.
+                            if must_copy() and torch._is_functional_tensor(
+                                args_unwrapped[0]
+                            ):
                                 # We can further relax to args_unwrapped[0] != kwargs["dtype"], but I don't think
                                 # we have an aten op for that.
                                 torch.ops.aten._assert_tensor_metadata.default(


### PR DESCRIPTION
Summary:
Fix aten.to when input is a tensor constant.

In this case, `args_unwrapped` could just be a constant, so not a functional tensor.

Test Plan:
```
buck2 run 'fbcode//mode/dev-nosan' fbcode//caffe2/test:test_export  -- -r  tensor_constant_aten_to
```

Differential Revision: D68984244


