### PR TITLE
[ROCm][TunableOp] Add bias data type to params signature.

### DIFF
--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -583,7 +583,7 @@ struct ScaledGemmParams : OpParams {
   }
 
   std::string Signature() const override {
-    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld_rw_%d", transa, transb, m, n, k, lda, ldb, ldc, use_rowwise);
+    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld_rw_%d_bias_%s", transa, transb, m, n, k, lda, ldb, ldc, use_rowwise, at::toString(bias_dtype));
   }
 
   size_t GetSizeA() const {

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -588,15 +588,9 @@ struct ScaledGemmParams : OpParams {
     // params.bias_dtype = bias ? bias->scalar_type() : isFloat8Type(out_dtype_) ? at::ScalarType::Half : out_dtype_;
     //
     // In TunableOp, we must distinguish in param signature these two cases: with and without a bias vector.
-    std::string bias_dtype_string;
-    if (bias_ptr == nullptr) {
-      bias_dtype_string = "None";
-    }
-    else {
-      bias_dtype_string = at::toString(bias_dtype);
-    }
     return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld_rw_%d_bias_%s",
-      transa, transb, m, n, k, lda, ldb, ldc, use_rowwise, bias_dtype_string);
+      transa, transb, m, n, k, lda, ldb, ldc, use_rowwise,
+      bias_ptr == nullptr ? "None" : at::toString(bias_dtype));
   }
 
   size_t GetSizeA() const {

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -583,7 +583,20 @@ struct ScaledGemmParams : OpParams {
   }
 
   std::string Signature() const override {
-    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld_rw_%d_bias_%s", transa, transb, m, n, k, lda, ldb, ldc, use_rowwise, at::toString(bias_dtype));
+    // In Blas.cpp, code defaults to a bias_dtype of Half even when there is no bias vector.
+    // Search for this line::
+    // params.bias_dtype = bias ? bias->scalar_type() : isFloat8Type(out_dtype_) ? at::ScalarType::Half : out_dtype_;
+    //
+    // In TunableOp, we must distinguish in param signature these two cases: with and without a bias vector.
+    std::string bias_dtype_string;
+    if (bias_ptr == nullptr) {
+      bias_dtype_string = "None";
+    }
+    else {
+      bias_dtype_string = at::toString(bias_dtype);
+    }
+    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld_rw_%d_bias_%s",
+      transa, transb, m, n, k, lda, ldb, ldc, use_rowwise, bias_dtype_string);
   }
 
   size_t GetSizeA() const {

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5404,12 +5404,25 @@ class TestLinalg(TestCase):
         matA = torch.full((k, m), fillA, dtype=dtypeA, device=device)
         matB = torch.full((n, k), fillB, dtype=dtypeB, device=device).t()
 
+        # Summary of bias types that are supported:
+        # - bias vector not supported when out_dtype = fp32
+        # - bias_dtype allowed in PyTorch are Half or BFloat16
+        # - bias_dtype in hipBLASLt restrictions can be found here:
+        #   https://rocm.docs.amd.com/projects/hipBLASLt/en/develop/api-reference.html
+        fillbias = 0.10
+        biasf16 = torch.full((n,), fillbias, dtype=torch.half, device=device)
+        biasbf16 = torch.full((n,), fillbias, dtype=torch.bfloat16, device=device)
+
         # out_dtype = dtype
         torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=dtype)
+        # out_dtype = dtype with bias vector
+        torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=dtype, bias=biasf16)
         # out_dtype = float32
         torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=torch.float32)
         # out_dtype = bfloat16
         torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=torch.bfloat16)
+        # out_dtype = bfloat16 with bias vector
+        torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=torch.bfloat16, bias=biasbf16)
         # out_dtype = float16
         torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=torch.half)
 
@@ -5425,9 +5438,9 @@ class TestLinalg(TestCase):
         # There must be a four new tuning results unless you do
         # rowwise in which case there is a 5th one
         if dtype is torch.torch.float8_e4m3fnuz:  # rowwise
-            count = 5
+            count = 7
         else:
-            count = 4
+            count = 6
         self.assertEqual((total_num_results - ref_num_results), count)
 
         # disable TunableOp

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5435,8 +5435,7 @@ class TestLinalg(TestCase):
         # This stores total number of cummulative results
         total_num_results = len(torch.cuda.tunable.get_results())
 
-        # There must be a four new tuning results unless you do
-        # rowwise in which case there is a 5th one
+        # Rowwise case will have an extra solution
         if dtype is torch.torch.float8_e4m3fnuz:  # rowwise
             count = 7
         else:

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5291,7 +5291,7 @@ class TestLinalg(TestCase):
     @onlyCUDA
     @dtypes(torch.bfloat16)
     def test_gemm_bias_offline_tunableop(self, device, dtype):
-        # This test is the offline version of test_scaled_gemm_tunableop
+        # This test is the offline version of test_gemm_bias_tunableop
         import os
 
         ordinal = torch.cuda.current_device()

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4728,7 +4728,7 @@ class TestLinalg(TestCase):
     @skipCUDAIfNotRocm
     @runOnRocmArch(MI300_ARCH)
     @dtypes(torch.torch.float8_e4m3fnuz, torch.float8_e5m2fnuz)
-    def test_matmul_scaled_gemm_offline_tunableop(self, device, dtype):
+    def test_scaled_gemm_offline_tunableop(self, device, dtype):
         # This test is the offline version of test_scaled_gemm_tunableop
         import os
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4761,12 +4761,25 @@ class TestLinalg(TestCase):
             matA = torch.full((k, m), fillA, dtype=dtypeA, device=device)
             matB = torch.full((n, k), fillB, dtype=dtypeB, device=device).t()
 
+            # Summary of bias types that are supported:
+            # - bias vector not supported when out_dtype = fp32
+            # - bias_dtype allowed in PyTorch are Half or BFloat16
+            # - bias_dtype in hipBLASLt restrictions can be found here:
+            #   https://rocm.docs.amd.com/projects/hipBLASLt/en/develop/api-reference.html
+            fillbias = 0.10
+            biasf16 = torch.full((n,), fillbias, dtype=torch.half, device=device)
+            biasbf16 = torch.full((n,), fillbias, dtype=torch.bfloat16, device=device)
+
             # out_dtype = dtype
             torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=dtype)
+            # out_dtype = dtype with bias vector
+            torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=dtype, bias=biasf16)
             # out_dtype = float32
             torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=torch.float32)
             # out_dtype = bfloat16
             torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=torch.bfloat16)
+            # out_dtype = bfloat16 with bias vector
+            torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=torch.bfloat16, bias=biasbf16)
             # out_dtype = float16
             torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=torch.half)
 
@@ -4800,9 +4813,9 @@ class TestLinalg(TestCase):
             # There must be a four new tuning results unless you do
             # rowwise in which case there is a 5th one
             if dtype is torch.torch.float8_e4m3fnuz:  # rowwise
-                count = 5
+                count = 7
             else:
-                count = 4
+                count = 6
             self.assertEqual(total_num_results, count)
 
             self.assertTrue(torch.cuda.tunable.write_file())

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4810,8 +4810,7 @@ class TestLinalg(TestCase):
             # This stores total number of cummulative results
             total_num_results = new_results - ref_results
 
-            # There must be a four new tuning results unless you do
-            # rowwise in which case there is a 5th one
+            # Rowwise case will have an extra solution
             if dtype is torch.torch.float8_e4m3fnuz:  # rowwise
                 count = 7
             else:

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -530,6 +530,7 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
             if transA
             else torch.full((k, n), fillB, dtype=dtypeB, device=deviceid).t()
         )
+
         assert untuned_gemm_temp[8] == "rw"
         if untuned_gemm_temp[9] == "1":
             rowwise = True
@@ -542,7 +543,24 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
             scaleA = torch.tensor(0.8, device=deviceid)
             scaleB = torch.tensor(0.9, device=deviceid)
 
-        torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=dtypeC)
+        assert untuned_gemm_temp[10] == "bias"
+        if untuned_gemm_temp[11] == "None":
+            bias = False
+        else:
+            bias = True
+            fillbias = 0.10
+            bias_dtype = dtype_dict.get(untuned_gemm_temp[11])
+            bias_vec = (
+                torch.full((n,), fillbias, dtype=bias_dtype, device=deviceid)
+                if transA
+                else torch.full((m,), fillbias, dtype=bias_dtype, device=deviceid)
+            )
+
+        if bias:
+            torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=dtypeC, bias=bias_vec)
+        else:
+            torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=dtypeC)
+
     elif op_sig == "GemmAndBiasTunableOp":
         # y = x*A^T + b
         assert transA != transB

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -545,7 +545,9 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
 
         assert untuned_gemm_temp[10] == "bias"
         if untuned_gemm_temp[11] == "None":  # no bias vector
-            torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=dtypeC)
+            torch._scaled_mm(
+                matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=dtypeC
+            )
         else:  # bias vector present
             fillbias = 0.10
             bias_dtype = dtype_dict.get(untuned_gemm_temp[11])
@@ -554,7 +556,9 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
                 if transA
                 else torch.full((m,), fillbias, dtype=bias_dtype, device=deviceid)
             )
-            torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=dtypeC, bias=bias)
+            torch._scaled_mm(
+                matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=dtypeC, bias=bias
+            )
 
     elif op_sig == "GemmAndBiasTunableOp":
         # y = x*A^T + b


### PR DESCRIPTION
Add bias vector data type in TunableOp params signature.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang