### PR TITLE
[PT2][Inductor][reland] Add runtime numeric check for the post grad pass

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -131,6 +131,7 @@ if TYPE_CHECKING:
 
     from torch._inductor.output_code import _StrideExprStr
     from torch._ops import OpOverload
+    from torch._subclasses import fake_tensor
 
     from .ir import ExternKernelNode
 
@@ -373,7 +374,12 @@ def _recursive_joint_graph_passes(gm: GraphModule) -> None:
         joint_graph_passes(gm)
 
 
-def _recursive_post_grad_passes(gm: GraphModule, is_inference: bool = False) -> None:
+def _recursive_post_grad_passes(
+    gm: GraphModule,
+    is_inference: bool = False,
+    example_inputs: Sequence[InputType] = (),
+    fake_mode: Optional[fake_tensor.FakeTensorMode] = None,
+) -> None:
     with dynamo_timed(
         "_recursive_post_grad_passes",
         log_pt2_compile_event=True,
@@ -381,8 +387,8 @@ def _recursive_post_grad_passes(gm: GraphModule, is_inference: bool = False) -> 
     ):
         for subgraph_name in _get_subgraph_names(gm):
             subgraph = getattr(gm, subgraph_name)
-            _recursive_post_grad_passes(subgraph, is_inference)
-        post_grad_passes(gm, is_inference)
+            _recursive_post_grad_passes(subgraph, is_inference, (), fake_mode)
+        post_grad_passes(gm, is_inference, example_inputs, fake_mode)
 
 
 def split_const_gm(
@@ -968,7 +974,12 @@ class _InProcessFxCompile(FxCompile):
                 # has some issues with memory in training
                 cuda_context = get_cuda_device_context(gm)
                 with cuda_context:
-                    _recursive_post_grad_passes(gm, is_inference=is_inference)
+                    _recursive_post_grad_passes(
+                        gm,
+                        is_inference=is_inference,
+                        example_inputs=example_inputs,
+                        fake_mode=fake_mode,
+                    )
                 V.debug.fx_graph_transformed(gm, example_inputs)
                 post_grad_graphs_log.debug(
                     "%s",

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -263,6 +263,7 @@ use_mixed_mm = True
 # https://pytorch.org/docs/stable/notes/numerical_accuracy.html#batched-computations-or-slice-computations
 fx_passes_numeric_check: dict[str, Any] = {
     "pre_grad": False,
+    "post_grad": False,
     "precision": 1e-4,
     "num_iterations": 1,
     "requires_optimizer": True,

--- a/torch/_inductor/fx_passes/numeric_utils.py
+++ b/torch/_inductor/fx_passes/numeric_utils.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import copy
 import gc
 import logging
 import os
@@ -12,6 +13,7 @@ import torch.optim as optim
 from torch.utils._ordered_set import OrderedSet
 
 from .. import config
+from ..pattern_matcher import stable_topological_sort
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -130,6 +132,14 @@ def compare_gradients(model_base, model_control, precision):
     )
 
 
+def compare_buffers(model_base, model_control, precision):
+    return compare_dict_tensors(
+        dict(model_base.named_buffers()),
+        dict(model_control.named_buffers()),
+        precision,
+    )
+
+
 def run_model(
     model_base, model_control, model_input, num_iterations=10, precision=1e-4
 ):
@@ -146,6 +156,9 @@ def run_model(
 
         res = compare_forward_output(pred_base, pred_control, precision)
         logger.info("compare loss/predict. Numerical result : %s", res)
+
+        res = compare_buffers(model_base, model_control, precision)
+        logger.info("compare buffers. Numerical result : %s", res)
         # tensor may not have a grad_fn
         try:
             _ = pred_base[0].sum().backward(retain_graph=True)
@@ -211,3 +224,36 @@ def numeric_check_if_enabled(
             "Runtime numeric check failed in pre grad fx passes with error: %s", e
         )
         traceback.print_exc()
+
+
+def enable_runtime_numeric_check(
+    example_inputs, fake_mode, gm_before_fx_passes, gm, fx_passes_numeric_check
+):
+    """
+    Enable runtime numeric check for fx passes.
+    """
+    if (
+        config.pattern_matcher
+        and hasattr(config, "fx_passes_numeric_check")
+        and fx_passes_numeric_check
+        and example_inputs is not None
+    ):
+        stable_topological_sort(gm.graph)
+        gm_after_fx_passes = copy.deepcopy(gm)
+        if fake_mode is not None:
+            with fake_mode:
+                numeric_check_if_enabled(
+                    gm_before_fx_passes,  # type: ignore[possibly-undefined]
+                    gm_after_fx_passes,
+                    example_inputs,
+                    config.fx_passes_numeric_check.get("num_iterations", 1),
+                    config.fx_passes_numeric_check.get("precision", 1e-4),
+                )
+        else:
+            numeric_check_if_enabled(
+                gm_before_fx_passes,  # type: ignore[possibly-undefined]
+                gm_after_fx_passes,
+                example_inputs,
+                config.fx_passes_numeric_check.get("num_iterations", 1),
+                config.fx_passes_numeric_check.get("precision", 1e-4),
+            )


### PR DESCRIPTION
Summary: We observed compilation time regression with previous diff implementation D63438718. Here we fix the issue and reland the diff

Test Plan:
### numeric check enablement test

```
buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode batch  --use_synthetic_data --flow_id 685229965 -n
```


### compilation time check

```
buck2 run mode/opt //caffe2/benchmarks/dynamo/fb:torchbench_run_nanogpt_training -- -m nanogpt -t training
```

```
torchbench_run
    duration_ms: 219528
    defaults-batch_size: 1
    defaults-speedup-x1000: 1408
    defaults-abs_latency-x1000: 29068
    defaults-compilation_latency-x1000: 93996
    defaults-compression_ratio-x1000: 924
    defaults-eager_peak_mem-x1000: 2473
    defaults-dynamo_peak_mem-x1000: 2675
    defaults-calls_captured: 1156
    defaults-unique_graphs: 3
    defaults-graph_breaks: 8
    defaults-unique_graph_breaks: 6
    defaults-autograd_captures: 0
    defaults-autograd_compiles: 0
    defaults-cudagraph_skips: 0
    cudagraphs-batch_size: 1
    cudagraphs-speedup-x1000: 5065
    cudagraphs-abs_latency-x1000: 7983
    cudagraphs-compilation_latency-x1000: 76961
    cudagraphs-compression_ratio-x1000: 1485
    cudagraphs-eager_peak_mem-x1000: 4473
    cudagraphs-dynamo_peak_mem-x1000: 3012
    cudagraphs-calls_captured: 1154
    cudagraphs-unique_graphs: 2
    cudagraphs-graph_breaks: 4
    cudagraphs-unique_graph_breaks: 4
    cudagraphs-autograd_captures: 0
    cudagraphs-autograd_compiles: 0
    cudagraphs-cudagraph_skips: 0
    cudagraphs_dynamic-batch_size: 1
    cudagraphs_dynamic-speedup-x1000: 5038
    cudagraphs_dynamic-abs_latency-x1000: 8334
    cudagraphs_dynamic-compilation_latency-x1000: 22521
    cudagraphs_dynamic-compression_ratio-x1000: 893
    cudagraphs_dynamic-eager_peak_mem-x1000: 4017
    cudagraphs_dynamic-dynamo_peak_mem-x1000: 4493
    cudagraphs_dynamic-calls_captured: 1154
    cudagraphs_dynamic-unique_graphs: 2
    cudagraphs_dynamic-graph_breaks: 4
    cudagraphs_dynamic-unique_graph_breaks: 4
    cudagraphs_dynamic-autograd_captures: 0
    cudagraphs_dynamic-autograd_compiles: 0
    cudagraphs_dynamic-cudagraph_skips: 0
```


```
servicelab create benchmark_torchbench_run_nanogpt_training -d D68979204
```

Successfully submitted experiment: https://www.internalfb.com/servicelab/experiment/4800587892/

Differential Revision: D68979204




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang @aakhundov