### PR TITLE
[cutlass backend] Add instantiation level for generating configs

### DIFF
--- a/torch/_inductor/codegen/cuda/cutlass_utils.py
+++ b/torch/_inductor/codegen/cuda/cutlass_utils.py
@@ -135,6 +135,7 @@ class CUTLASSArgs:
 
     architectures: Optional[str] = None
     cuda_version: Optional[str] = None
+    instantiation_level: Optional[str] = None
 
     operations = "all"
     build_dir = ""
@@ -143,7 +144,6 @@ class CUTLASSArgs:
     kernels = "all"
     ignore_kernels = ""
     exclude_kernels = ""
-    instantiation_level = ""
     # TODO: these three look dead?
     kernel_filter_file: None = None
     selected_kernel_list: None = None
@@ -178,7 +178,12 @@ def _gen_ops_cached(arch, version) -> list[Any]:
         )
         return []
     arch = _normalize_cuda_arch(arch)
-    args = CUTLASSArgs(architectures=arch, cuda_version=version)
+    instantiation_level: str = config.cuda.cutlass_instantiation_level
+    args = CUTLASSArgs(
+        architectures=arch,
+        cuda_version=version,
+        instantiation_level=instantiation_level,
+    )
     manifest = cutlass_manifest.Manifest(args)
 
     if arch == "90":

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1277,6 +1277,16 @@ class cuda:
     # pattern used by some Cutlass Kernels.
     cutlass_op_denylist_regex: Optional[str] = None
 
+    # Non-negative integer which determines how many kernels are instantiated.
+    # 0 = 0000 generates the fewest kernels, 9999 generates all possible combinations.
+    # increasing first digit reduces schedule / mixed type pruning,
+    # increasing second digit generates more cluster sizes,
+    # increasing third digit generates more MMA multipliers,
+    # increasing fourth digit generates more instruction shapes.
+    cutlass_instantiation_level: str = os.environ.get(
+        "TORCHINDUCTOR_CUTLASS_INSTANTIATION_LEVEL", "0"
+    )
+
 
 class rocm:
     # Offload arch list for device code compilation, e.g. ["gfx941", "gfx942"].


### PR DESCRIPTION
Passing through instantiation level to generate more configs.

I do see some C++ compilation error. But running is fine. Using 2222 generates 1k+ configs. 


Differential Revision: D68989194

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang @aakhundov