### PR TITLE
[dcp] Minor improvements to filesystem writer

### DIFF
--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -304,7 +304,7 @@ def _split_by_size_and_type(bins: int, items: list[WriteItem]) -> list[list[Writ
     return buckets
 
 
-def _get_write_items_by_type(item: list[Writeitem]) -> tuple[list[WriteItem], list[WriteItem]]:
+def _get_write_items_by_type(item: list[WriteItem]) -> tuple[list[WriteItem], list[WriteItem]]:
     bytes_w = []
     tensor_w = []
     for wi in items:

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -304,7 +304,7 @@ def _split_by_size_and_type(bins: int, items: list[WriteItem]) -> list[list[Writ
     return buckets
 
 
-def _get_write_items_by_type(item: list[Writeitem]) -> tuple[list[WriteItem]]:
+def _get_write_items_by_type(item: list[Writeitem]) -> tuple[list[WriteItem], list[WriteItem]]:
     bytes_w = []
     tensor_w = []
     for wi in items:

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -304,7 +304,7 @@ def _split_by_size_and_type(bins: int, items: list[WriteItem]) -> list[list[Writ
     return buckets
 
 
-def _get_write_items_by_type(item: list[WriteItem]) -> tuple[list[WriteItem], list[WriteItem]]:
+def _get_write_items_by_type(items: list[WriteItem]) -> tuple[list[WriteItem], list[WriteItem]]:
     bytes_w = []
     tensor_w = []
     for wi in items:

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -120,7 +120,8 @@ class _SerialCpuLoader(_TensorLoader):
         for _, obj in self.items:
             tensor = self.resolve_fun(obj).detach()
             tensor = tensor.cpu()
-            if tensor.storage().size() != tensor.numel():
+            if tensor.untyped_storage().size() != tensor.numel() * tensor.itemsize:
+                # this forces the tensor to be both contiguous and with minimal storage
                 tensor = tensor.clone()
             yield (
                 tensor,
@@ -284,8 +285,7 @@ def _split_by_size_and_type(bins: int, items: list[WriteItem]) -> list[list[Writ
     if bins == 1:
         return [items]
 
-    bytes_w = [wi for wi in items if wi.type == WriteItemType.BYTE_IO]
-    tensor_w = [wi for wi in items if wi.type != WriteItemType.BYTE_IO]
+    bytes_w, tensor_w = _get_write_items_by_type(items)
 
     buckets: list[list[WriteItem]] = [[] for _ in range(bins)]
     bucket_sizes = [0 for _ in range(bins)]
@@ -302,6 +302,17 @@ def _split_by_size_and_type(bins: int, items: list[WriteItem]) -> list[list[Writ
         bucket_sizes[idx] += _item_size(wi)
 
     return buckets
+
+
+def _get_write_items_by_type(item: list[Writeitem]) -> tuple[list[WriteItem]]:
+    bytes_w = []
+    tensor_w = []
+    for wi in items:
+        if wi.type == WriteItemType.BYTE_IO:
+            bytes_w.append(wi)
+        else:
+            tensor_w.append(wi)
+    return bytes_w, tensor_w
 
 
 def _write_item(
@@ -393,12 +404,11 @@ def _write_files_from_queue(
                     planner.resolve_data,
                 )
 
-            tensor_w = [wi for wi in write_items if wi.type != WriteItemType.BYTE_IO]
+            bytes_w, tensor_w = _get_write_items_by_type(items)
             for write_item in tensor_w:
                 loader.add(_item_size(write_item), write_item)
             loader.start_loading()
 
-            bytes_w = [wi for wi in write_items if wi.type == WriteItemType.BYTE_IO]
             write_results = []
 
             with create_stream(file_name, "wb") as stream:
@@ -856,7 +866,7 @@ class FileSystemReader(StorageReader):
 
     # Implementing the abstract function in StorageReader
     def read_metadata(self) -> Metadata:
-        path = self.fs.concat_path(self.path, ".metadata")
+        path = self.fs.concat_path(self.path, _metadata_fn)
         with self.fs.create_stream(path, "rb") as metadata_file:
             metadata = pickle.load(metadata_file)
 


### PR DESCRIPTION
- Apply same check to `_SerialCpuLoader ` from `_OverlappingCpuLoader`  for determining when to clone non-contiguous cpu tensors
- Add minor helper function to avoid iterating over `WriteItem`s twice to collect bytes and tensor write items
- Use the metadata filename constant instead of harcoding 

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn @ekr0