### PR TITLE
[Inductor-CPU] Avoid redundant compute of index in AVX512 FP32 acc GEMM micro-kernel

### DIFF
--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -454,7 +454,7 @@ inline void {{kernel_name}}_kernel(
 {%- endif %}
         }
 
-        vc[i] = at::vec::fmadd(va, vb[col], vc[idx]);
+        vc[i] = at::vec::fmadd(va, vb[col], vc[i]);
     };
 
     for (int k = 0; k < K; ++k) {

--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -454,8 +454,7 @@ inline void {{kernel_name}}_kernel(
 {%- endif %}
         }
 
-        constexpr int idx = row * COLS + col;
-        vc[idx] = at::vec::fmadd(va, vb[col], vc[idx]);
+        vc[i] = at::vec::fmadd(va, vb[col], vc[idx]);
     };
 
     for (int k = 0; k < K; ++k) {


### PR DESCRIPTION
`constexpr int idx` doesn't seem to help here since `idx` is equal to `i`:

```cpp
        constexpr int row = i / COLS;
        constexpr int col = i % COLS;

       // some other code

        constexpr int idx = row * COLS + col;
        vc[idx] = at::vec::fmadd(va, vb[col], vc[idx]);
```

TODO
- [ ] Although it's known at the time of compilation as to what various values of `i` would be due to forced-unrolling of `compute` lambda calls, check if the compiler really computes values of `row`, `col` and `idx` corresponding to each value of `i` at compile-time.
 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang @aakhundov