### PR TITLE
[Dynamo] fix torch._dynamo.assume_constant_result when used on class method

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -597,6 +597,20 @@ class DecoratorTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(fn(x, y), torch.compile(fn)(x, y))
 
+    def test_assume_constant_result_on_class_method(self):
+        class A:
+            def __init__(self):
+                self.value = 123
+
+            @torch._dynamo.assume_constant_result
+            def b(self):
+                return self.value
+
+        def fn():
+            return A().b()
+
+        self.assertEqual(fn(), torch.compile(fn)())
+
     @torch._dynamo.config.patch("inline_inbuilt_nn_modules", True)
     def test_mark_static_nn_module(self):
         @torch._dynamo.mark_static


### PR DESCRIPTION
This PR fixes `torch._dynamo.assume_constant_result` when it is used on a class method, and the class was instantiated inside of the dynamo traced code.

The issue: Currently when an object is modified by storing attributes on it in dynamo, the side effects of those attribute stores are tracked using the `SideEffect` system, and the modifications to the class are not performed in the first place.  For example, in
```python
class A:
    def __init__(self):
        self.value = 123
```
The `self.value` field will not be set on the class `A` but rather it will only be tracked within the `SideEffect` system.

This causes a problem with `torch._dynamo.assume_constant_result` as it converts the value in dynamo back into a normal python value and invokes the function as normal python.  However, it currently does not find the `self.value` field (as it was never set on the underlying object).  This PR checks if the object passed to the `torch._dynamo.assume_constant_result` has any pending mutations from the `SideEffect` system and applies them before calling the `torch._dynamo.assume_constant_result` function.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames