### PR TITLE
Fix not inlining functions used in metal files

### DIFF
--- a/c10/metal/special_math.h
+++ b/c10/metal/special_math.h
@@ -31,7 +31,7 @@ T erf(T x) {
 }
 
 template <typename T>
-float erfinv(T y) {
+inline float erfinv(T y) {
   /* coefficients in rational expansion */
   constexpr float a[4] = {0.886226899, -1.645349621, 0.914624893, -0.140543331};
   constexpr float b[4] = {-2.118377725, 1.442710462, -0.329097515, 0.012229801};
@@ -66,7 +66,7 @@ float erfinv(T y) {
  */
 
 template <typename T>
-T chbevl(T x, const float array[], const int len) {
+inline T chbevl(T x, const float array[], const int len) {
   T b0, b1, b2;
 
   b0 = array[0];
@@ -195,7 +195,7 @@ T i1(T _x) {
 
 // gamma, lgamma
 template <typename T>
-float log_gamma(const T);
+inline float log_gamma(const T);
 
 template <typename T>
 float gamma(const T x) {
@@ -263,7 +263,7 @@ float gamma(const T x) {
 }
 
 template <typename T>
-float log_gamma(const T x) {
+inline float log_gamma(const T x) {
   constexpr float LOG_PI = 1.14472988584940017414342735135305;
   constexpr float HALF_LOG_TWO_PI = 0.91893853320467274178032973640562;
   constexpr float LGAMMA_EXPANSION_COEF[8] = {
@@ -313,7 +313,7 @@ float log_gamma(const T x) {
   return LOG_PI - rc - ::metal::log(log_arg);
 }
 
-float zeta(float x, float q) {
+inline float zeta(float x, float q) {
   constexpr float MACHEP = 1.11022302462515654042E-16;
   constexpr float ZETA_EXPANSION[] = {
       12.0,
@@ -383,14 +383,14 @@ float zeta(float x, float q) {
 }
 
 template <typename T0>
-float polygamma(const T0 input, const int64_t order) {
+inline float polygamma(const T0 input, const int64_t order) {
   float x = input;
   float n = order;
   float sgn = ((order % 2) ? 1 : -1);
   return sgn * gamma(n + 1) * zeta(n + 1, x);
 }
 
-float calc_digamma_positive_domain(float x) {
+inline float calc_digamma_positive_domain(float x) {
   constexpr float DIGAMMA_COEF[7] = {
       8.33333333333333333333E-2,
       -2.10927960927960927961E-2,
@@ -425,7 +425,7 @@ float calc_digamma_positive_domain(float x) {
 }
 
 template <typename T0>
-float digamma(T0 x) {
+inline float digamma(T0 x) {
   if (x < 0.0f) {
     if (x == ::metal::trunc(x)) {
       // As per C++ standard for gamma related functions and SciPy,


### PR DESCRIPTION
Fixes issue when building PyTorch with Xcode installed after https://github.com/pytorch/pytorch/pull/146231
```
FAILED: caffe2/aten/src/ATen/kernels_basic.metallib /Users/Irakli_Salia/Desktop/pytorch/build/caffe2/aten/src/ATen/kernels_basic.metallib 
cd /Users/Irakli_Salia/Desktop/pytorch/build/caffe2/aten/src/ATen && xcrun metallib -o kernels_basic.metallib BinaryKernel_30.air Bucketization_30.air CrossKernel_30.air FusedOptimizerOps_30.air Gamma_30.air HistogramKernel_30.air Im2Col_30.air Indexing_30.air LinearAlgebra_30.air Quantized_30.air RMSNorm_30.air RenormKernel_30.air Repeat_30.air SpecialOps_30.air TriangularOps_30.air UnaryKernel_30.air UnfoldBackward_30.air UpSample_30.air
LLVM ERROR: multiple symbols ('_ZN3c105metal4zetaEff')!
[3835/5420] Building CXX object c10/test/CMakeFiles/c10_small_vector_test.dir/util/small_vector_test.cpp.o
ninja: build stopped: subcommand failed.
```

AI to @malfet: Add linter that ensures that `c10/metal/` headers do not have any functions there, only templates