### PR TITLE
[export][dynamic shapes] use size-oblivious upper bound reasoning for backed symbols

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -7258,6 +7258,22 @@ graph():
         self.assertEqual(a.size(), torch.Size([11]))
         self.assertEqual(a, torch.zeros(11))
 
+    def test_backed_symint_endofbounds(self):
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(10))
+
+            def forward(self, x):
+                self.cache[0 : x.shape[0]] = x
+                return x
+
+        max_size = 10
+        min_size = 1
+        dim = Dim(name="dim", min=min_size, max=max_size)
+        ep = export(Foo(), (torch.randn(10),), dynamic_shapes={"x": {0: dim}})
+        print(ep)
+
     def test_pad_sequence(self):
         class Module(torch.nn.Module):
             def forward(self, x):

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1972,15 +1972,18 @@ def _maybe_evaluate_static_worker(
             # for jagged layout NestedTensors today
             continue
         assert vr is not None
-        if size_oblivious and is_size_like:
-            lower = max(2, vr.lower)
-            # Clamping size-oblivious to some quantity below sys.maxsize
-            # helps us determine that f(u0) != sys.maxsize, which is a
-            # test that is looking for sys.maxsize as a sentinel, but you
-            # don't really want to worry about it for unbacked SymInts.
-            # This is similar to the flavor where size oblivious omits
-            # 0/1, it changes semantics but in a benign way.
-            upper = min(2**48, vr.upper)
+        if size_oblivious and (is_size_like or re.match(r"s\d+", str(k))):
+            if is_size_like:
+                lower = max(2, vr.lower)
+                # Clamping size-oblivious to some quantity below sys.maxsize
+                # helps us determine that f(u0) != sys.maxsize, which is a
+                # test that is looking for sys.maxsize as a sentinel, but you
+                # don't really want to worry about it for unbacked SymInts.
+                # This is similar to the flavor where size oblivious omits
+                # 0/1, it changes semantics but in a benign way.
+                upper = min(2**48, vr.upper)
+            else:
+                lower, upper = vr.lower, vr.upper
             # Excluding the very upper bound can be helpful
             if upper > lower:
                 upper = upper - 1
@@ -6577,8 +6580,6 @@ class ShapeEnv:
                 self.log.debug(
                     "eval %s == %s [statically known]", orig_expr, static_expr
                 )
-                if hint is not None:
-                    assert static_expr == hint, f"{static_expr} != {hint}"
                 return static_expr
 
             transmute_into_runtime_assert = False


### PR DESCRIPTION
cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv