### PR TITLE
[ONNX] Support custom axis name through dynamic_shapes

### DIFF
--- a/test/onnx/exporter/test_dynamic_shapes.py
+++ b/test/onnx/exporter/test_dynamic_shapes.py
@@ -115,7 +115,6 @@ class TestDynamicShapes(common_utils.TestCase):
         dynamic_axes = _dynamic_shapes.from_dynamic_shapes_to_dynamic_axes(
             dynamic_shapes=dynamic_shapes, input_names=input_names, exception=Exception
         )
-        print(dynamic_axes)
         self.assertEqual(dynamic_axes, expected_dynamic_axes)
 
     def test_from_dynamic_shapes_to_dynamic_axes_fails_when_input_names_is_less_than_flat_dynamic_shapes(

--- a/test/onnx/exporter/test_dynamic_shapes.py
+++ b/test/onnx/exporter/test_dynamic_shapes.py
@@ -1,5 +1,5 @@
 # Owner(s): ["module: onnx"]
-"""Unit tests for the _compat module."""
+"""Unit tests for the _dynamic_shapes module."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ import tempfile
 import onnx
 
 import torch
-from torch.onnx._internal.exporter import _compat
+from torch.onnx._internal.exporter import _dynamic_shapes
 from torch.testing._internal import common_utils
 from torch.utils import _pytree
 
@@ -112,9 +112,10 @@ class TestCompat(common_utils.TestCase):
     def test_from_dynamic_shapes_to_dynamic_axes_success(
         self, dynamic_shapes, input_names, expected_dynamic_axes
     ):
-        dynamic_axes = _compat._from_dynamic_shapes_to_dynamic_axes(
+        dynamic_axes = _dynamic_shapes.from_dynamic_shapes_to_dynamic_axes(
             dynamic_shapes=dynamic_shapes, input_names=input_names, exception=Exception
         )
+        print(dynamic_axes)
         self.assertEqual(dynamic_axes, expected_dynamic_axes)
 
     def test_from_dynamic_shapes_to_dynamic_axes_fails_when_input_names_is_less_than_flat_dynamic_shapes(
@@ -128,7 +129,7 @@ class TestCompat(common_utils.TestCase):
         )
         input_names = ["input_x", "input_y", "input_z"]
         with self.assertRaises(ValueError):
-            _compat._from_dynamic_shapes_to_dynamic_axes(
+            _dynamic_shapes.from_dynamic_shapes_to_dynamic_axes(
                 dynamic_shapes=dynamic_shapes,
                 input_names=input_names,
                 exception=Exception,
@@ -197,7 +198,7 @@ class TestCompat(common_utils.TestCase):
         )
         # kwargs can still be renamed as long as it's in order
         input_names = ["input_x", "input_y", "input_z", "d", "e", "f"]
-        dynamic_axes = _compat._from_dynamic_shapes_to_dynamic_axes(
+        dynamic_axes = _dynamic_shapes.from_dynamic_shapes_to_dynamic_axes(
             dynamic_shapes=dynamic_shapes, input_names=input_names, exception=Exception
         )
         expected_dynamic_axes = {
@@ -248,7 +249,7 @@ class TestPyTreeDynamicAxesShapes(common_utils.TestCase):
             "x": {0: x_dim},
             "y": {1: y_dim},
         }
-        unflatten_dynamic_shapes = _compat._unflatten_dynamic_shapes_with_inputs_tree(
+        unflatten_dynamic_shapes = _dynamic_shapes._unflatten_dynamic_shapes_with_inputs_tree(
             inputs, dynamic_shapes
         )
 
@@ -266,7 +267,7 @@ class TestPyTreeDynamicAxesShapes(common_utils.TestCase):
             "x": {0: x_dim},
             "y": {1: y_dim},
         }
-        unflatten_dynamic_shapes = _compat._unflatten_dynamic_shapes_with_inputs_tree(
+        unflatten_dynamic_shapes = _dynamic_shapes._unflatten_dynamic_shapes_with_inputs_tree(
             inputs, dynamic_shapes
         )
 
@@ -303,7 +304,7 @@ class TestPyTreeDynamicAxesShapes(common_utils.TestCase):
             "z0": {2: z0_dim_2},
             "z1": {1: z1_dim_1},
         }
-        unflatten_dynamic_shapes = _compat._unflatten_dynamic_shapes_with_inputs_tree(
+        unflatten_dynamic_shapes = _dynamic_shapes._unflatten_dynamic_shapes_with_inputs_tree(
             inputs, dynamic_shapes
         )
         expected_dynamic_shapes = (
@@ -341,7 +342,7 @@ class TestPyTreeDynamicAxesShapes(common_utils.TestCase):
             "z0": {2: z0_dim_2},
             "z1": {1: z1_dim_1},
         }
-        unflatten_dynamic_shapes = _compat._unflatten_dynamic_shapes_with_inputs_tree(
+        unflatten_dynamic_shapes = _dynamic_shapes._unflatten_dynamic_shapes_with_inputs_tree(
             inputs, dynamic_shapes
         )
         expected_dynamic_shapes = {
@@ -464,7 +465,7 @@ class TestPyTreeDynamicAxesShapes(common_utils.TestCase):
             )
         ],
     )
-    def test__from_dynamic_axes_to_dynamic_shapes_succeeds_on_llm(
+    def test_from_dynamic_axes_to_dynamic_shapes_succeeds_on_llm(
         self,
         model,
         args,
@@ -474,7 +475,7 @@ class TestPyTreeDynamicAxesShapes(common_utils.TestCase):
         dynamic_axes,
         expected_dynamic_shapes,
     ):
-        dynamic_shapes, _, _ = _compat._from_dynamic_axes_to_dynamic_shapes(
+        dynamic_shapes, _, _ = _dynamic_shapes.from_dynamic_axes_to_dynamic_shapes(
             model,
             args,
             kwargs,

--- a/test/onnx/exporter/test_hf_models_e2e.py
+++ b/test/onnx/exporter/test_hf_models_e2e.py
@@ -12,22 +12,90 @@ from torch.onnx._internal.exporter import _testing as onnx_testing
 from torch.testing._internal import common_utils
 
 
-class DynamoExporterTest(common_utils.TestCase):
+class DynamoExporterHfModelsTest(common_utils.TestCase):
+    def export(self, model, args=(), kwargs=None, **options) -> torch.onnx.ONNXProgram:
+        onnx_program = torch.onnx.export(
+            model, args, kwargs=kwargs, dynamo=True, fallback=False, **options
+        )
+        assert onnx_program is not None
+        return onnx_program
+
     def test_onnx_export_huggingface_llm_models_with_kv_cache(self):
         model, kwargs, dynamic_axes, input_names, output_names = (
             _prepare_llm_model_gptj_to_test()
         )
-        onnx_program = torch.onnx.export(
+        onnx_program = self.export(
             model,
             kwargs=kwargs,
             input_names=input_names,
             output_names=output_names,
             dynamic_axes=dynamic_axes,
-            dynamo=True,
         )
-        # TODO(titaiwang): Investigate why ORT fails without optimization
-        onnx_program.optimize()
         onnx_testing.assert_onnx_program(onnx_program)
+
+    def test_onnx_export_with_custom_axis_names_in_dynamic_shapes(self):
+        model, kwargs, _, input_names, output_names = _prepare_llm_model_gptj_to_test()
+
+        dynamic_shapes = {
+            "input_ids": {0: "batch_size", 1: "sequence_length"},
+            "past_key_values": [
+                (
+                    {0: "batch_size", 2: "past_sequence_length"},
+                    {0: "batch_size", 2: "past_sequence_length"},
+                ),
+                (
+                    {0: "batch_size", 2: "past_sequence_length"},
+                    {0: "batch_size", 2: "past_sequence_length"},
+                ),
+                (
+                    {0: "batch_size", 2: "past_sequence_length"},
+                    {0: "batch_size", 2: "past_sequence_length"},
+                ),
+                (
+                    {0: "batch_size", 2: "past_sequence_length"},
+                    {0: "batch_size", 2: "past_sequence_length"},
+                ),
+                (
+                    {0: "batch_size", 2: "past_sequence_length"},
+                    {0: "batch_size", 2: "past_sequence_length"},
+                ),
+            ],
+            "attention_mask": {0: "batch_size", 1: "masked_sequence_length"},
+            "position_ids": {0: "batch_size", 1: "sequence_length"},
+        }
+
+        onnx_program = self.export(
+            model,
+            kwargs=kwargs,
+            input_names=input_names,
+            output_names=output_names,
+            dynamic_shapes=dynamic_shapes,
+            optimize=False,
+        )
+        onnx_testing.assert_onnx_program(onnx_program)
+
+        # Check that the dynamic axes are correctly set in the ONNX model
+        for dim, custom_name in zip(
+            onnx_program.model.graph.inputs[0].shape,
+            dynamic_shapes["input_ids"].values(),
+        ):
+            self.assertEqual(dim.value, custom_name)
+        for idx in range(1, 11):
+            shape_value = [
+                dim if isinstance(dim, int) else dim.value
+                for dim in onnx_program.model.graph.inputs[idx].shape
+            ]
+            self.assertEqual(shape_value, ["batch_size", 4, "past_sequence_length", 8])
+        for dim, custom_name in zip(
+            onnx_program.model.graph.inputs[11].shape,
+            dynamic_shapes["attention_mask"].values(),
+        ):
+            self.assertEqual(dim.value, custom_name)
+        for dim, custom_name in zip(
+            onnx_program.model.graph.inputs[12].shape,
+            dynamic_shapes["position_ids"].values(),
+        ):
+            self.assertEqual(dim.value, custom_name)
 
 
 def _prepare_llm_model_gptj_to_test() -> (
@@ -70,9 +138,9 @@ def _prepare_llm_model_gptj_to_test() -> (
     ]
     kwargs = {
         "input_ids": input_ids,
+        "past_key_values": past_key_values,
         "attention_mask": attention_mask,
         "position_ids": position_ids,
-        "past_key_values": past_key_values,
     }
 
     dynamic_axes = {

--- a/test/onnx/exporter/test_ir_passes.py
+++ b/test/onnx/exporter/test_ir_passes.py
@@ -4,44 +4,91 @@
 from __future__ import annotations
 
 import torch
-from torch.onnx._internal.exporter import _ir_passes
 from torch.onnx._internal._lazy_import import onnxscript_ir as ir
+from torch.onnx._internal.exporter import _ir_passes
 from torch.testing._internal import common_utils
+
 
 @common_utils.instantiate_parametrized_tests
 class ONNXIRPassesTest(common_utils.TestCase):
-
-    @common_utils.parametrize("shape_expr, expected_shape_expr", [
-        ("2*s1", "batch_size*sequence_length"),
-        ("s11/s1", "past_sequence_length/sequence_length"),
-        ("(s1 + s11)*2", "(masked_sequence_length)*batch_size"),
-    ]
+    @common_utils.parametrize(
+        "shape_expr, expected_shape_expr",
+        [
+            ("2*s1", "batch_size*sequence_length"),
+            ("s11/s1", "past_sequence_length/sequence_length"),
+            ("(s1 + s11)*2", "(masked_sequence_length)*batch_size"),
+        ],
     )
     def test__replace_names_in_rename_axis(self, shape_expr, expected_shape_expr):
-        rename_mapping = {"s1 + s11": "masked_sequence_length", "s11": "past_sequence_length", "s1": "sequence_length", "2": "batch_size"}
+        rename_mapping = {
+            "s1 + s11": "masked_sequence_length",
+            "s11": "past_sequence_length",
+            "s1": "sequence_length",
+            "2": "batch_size",
+        }
         new_shape_expr = _ir_passes._replace_names(shape_expr, rename_mapping)
         self.assertEqual(new_shape_expr, expected_shape_expr)
 
-    def test_rename_axis_succeeds_when_mapping_is_not_sorted_and_contains_the_str_not_in_the_model(self):
-        
+    def test_rename_axis_succeeds_when_mapping_is_not_sorted_and_contains_the_str_not_in_the_model(
+        self,
+    ):
         model = ir.Model(
             ir.Graph(
                 inputs=[
-                    ir.Value(name="input_0", type=ir.DataType.FLOAT, shape=ir.Shape(["s0", "s1"])),
-                    ir.Value(name="input_1", type=ir.DataType.FLOAT, shape=ir.Shape(["s0 + s2", "s1 + s2"])),
-                    ir.Value(name="input_2", type=ir.DataType.FLOAT, shape=ir.Shape(["s1/(s1 + s2)*2", "(s1 + s2)*2"])),
+                    ir.Value(
+                        name="input_0",
+                        type=ir.DataType.FLOAT,
+                        shape=ir.Shape(["s0", "s1"]),
+                    ),
+                    ir.Value(
+                        name="input_1",
+                        type=ir.DataType.FLOAT,
+                        shape=ir.Shape(["s0 + s2", "s1 + s2"]),
+                    ),
+                    ir.Value(
+                        name="input_2",
+                        type=ir.DataType.FLOAT,
+                        shape=ir.Shape(["s1/(s1 + s2)*2", "(s1 + s2)*2"]),
+                    ),
                 ],
-                outputs=[ir.Value(name="output", type=ir.DataType.FLOAT, shape=ir.Shape("s99"))],
+                outputs=[
+                    ir.Value(
+                        name="output", type=ir.DataType.FLOAT, shape=ir.Shape("s99")
+                    )
+                ],
                 nodes=[],
             ),
             ir_version=9,
             producer_name="pytorch",
             producer_version=torch.__version__,
         )
-        
-        mapping = {"s1": "sequence_length", "s2": "past_sequence_length", "s0": "batch_size", "s1 + s2": "masked_sequence_length", "s3": "extra_sequence_length"}
+
+        mapping = {
+            "s1": "sequence_length",
+            "s2": "past_sequence_length",
+            "s0": "batch_size",
+            "s1 + s2": "masked_sequence_length",
+            "s3": "extra_sequence_length",
+        }
         _ir_passes.rename_axis(model, mapping)
-        
-        self.assertEqual(model.graph.inputs[0].shape, ir.Shape(["batch_size", "sequence_length"]))
-        self.assertEqual(model.graph.inputs[1].shape, ir.Shape(["batch_size + past_sequence_length", "masked_sequence_length"]))
-        self.assertEqual(model.graph.inputs[2].shape, ir.Shape(["sequence_length/(masked_sequence_length)*2", "(masked_sequence_length)*2"]))
+
+        self.assertEqual(
+            model.graph.inputs[0].shape, ir.Shape(["batch_size", "sequence_length"])
+        )
+        self.assertEqual(
+            model.graph.inputs[1].shape,
+            ir.Shape(["batch_size + past_sequence_length", "masked_sequence_length"]),
+        )
+        self.assertEqual(
+            model.graph.inputs[2].shape,
+            ir.Shape(
+                [
+                    "sequence_length/(masked_sequence_length)*2",
+                    "(masked_sequence_length)*2",
+                ]
+            ),
+        )
+
+
+if __name__ == "__main__":
+    common_utils.run_tests()

--- a/test/onnx/exporter/test_ir_passes.py
+++ b/test/onnx/exporter/test_ir_passes.py
@@ -1,0 +1,47 @@
+# Owner(s): ["module: onnx"]
+"""Unit tests for the _ir_passes module."""
+
+from __future__ import annotations
+
+import torch
+from torch.onnx._internal.exporter import _ir_passes
+from torch.onnx._internal._lazy_import import onnxscript_ir as ir
+from torch.testing._internal import common_utils
+
+@common_utils.instantiate_parametrized_tests
+class ONNXIRPassesTest(common_utils.TestCase):
+
+    @common_utils.parametrize("shape_expr, expected_shape_expr", [
+        ("2*s1", "batch_size*sequence_length"),
+        ("s11/s1", "past_sequence_length/sequence_length"),
+        ("(s1 + s11)*2", "(masked_sequence_length)*batch_size"),
+    ]
+    )
+    def test__replace_names_in_rename_axis(self, shape_expr, expected_shape_expr):
+        rename_mapping = {"s1 + s11": "masked_sequence_length", "s11": "past_sequence_length", "s1": "sequence_length", "2": "batch_size"}
+        new_shape_expr = _ir_passes._replace_names(shape_expr, rename_mapping)
+        self.assertEqual(new_shape_expr, expected_shape_expr)
+
+    def test_rename_axis_succeeds_when_mapping_is_not_sorted_and_contains_the_str_not_in_the_model(self):
+        
+        model = ir.Model(
+            ir.Graph(
+                inputs=[
+                    ir.Value(name="input_0", type=ir.DataType.FLOAT, shape=ir.Shape(["s0", "s1"])),
+                    ir.Value(name="input_1", type=ir.DataType.FLOAT, shape=ir.Shape(["s0 + s2", "s1 + s2"])),
+                    ir.Value(name="input_2", type=ir.DataType.FLOAT, shape=ir.Shape(["s1/(s1 + s2)*2", "(s1 + s2)*2"])),
+                ],
+                outputs=[ir.Value(name="output", type=ir.DataType.FLOAT, shape=ir.Shape("s99"))],
+                nodes=[],
+            ),
+            ir_version=9,
+            producer_name="pytorch",
+            producer_version=torch.__version__,
+        )
+        
+        mapping = {"s1": "sequence_length", "s2": "past_sequence_length", "s0": "batch_size", "s1 + s2": "masked_sequence_length", "s3": "extra_sequence_length"}
+        _ir_passes.rename_axis(model, mapping)
+        
+        self.assertEqual(model.graph.inputs[0].shape, ir.Shape(["batch_size", "sequence_length"]))
+        self.assertEqual(model.graph.inputs[1].shape, ir.Shape(["batch_size + past_sequence_length", "masked_sequence_length"]))
+        self.assertEqual(model.graph.inputs[2].shape, ir.Shape(["sequence_length/(masked_sequence_length)*2", "(masked_sequence_length)*2"]))

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -436,6 +436,78 @@ class DynamoExporterTest(common_utils.TestCase):
         inputs = {"x": torch.randn(6, 3), "y": torch.randn(6, 3)}
         onnx_testing.assert_onnx_program(onnx_program, kwargs=inputs)
 
+    def test_export_of_rename_dynamic_axes_required_model_with_mixed_type_of_dynamic_shapes(
+        self,
+    ):
+        class NestedModel(torch.nn.Module):
+            def forward(
+                self,
+                x: torch.Tensor,
+                ys: list[torch.Tensor],
+                zs: dict[str, torch.Tensor],
+                c: torch.Tensor,
+            ):
+                y = ys[0] + ys[1] + zs["a"] + zs["b"]
+                w = 5
+                if x.shape[0] < 3 and c.shape[0] != 4:
+                    return x + w, x + y, c
+                else:
+                    return x - w, x - y, c
+
+        input = (
+            torch.ones(5),
+            [torch.zeros(5), torch.ones(5)],
+            {"a": torch.zeros(5), "b": torch.ones(5)},
+            torch.ones(6),
+        )
+
+        dynamic_shapes = (
+            {0: torch.export.Dim("dim_x", min=3)},  # _Dim
+            [("custom_name_axis_ys_0",), (torch.export.Dim.AUTO,)],  # custom name
+            {
+                "a": {0: torch.export.Dim.AUTO},
+                "b": ("custom_name_axis_zs_b_0",),
+            },  # _DimHint
+            {0: "custom_name_axis_c_0"},  # custom name
+        )
+
+        # 0. Export the model
+        # 1. Assert the warning message
+        with self.assertWarnsRegex(
+            UserWarning,
+            "# The axis name: .* will not be used, since it shares the same shape constraints with another axis: .*.",
+        ):
+            onnx_program = self.export(
+                NestedModel(), input, dynamic_shapes=dynamic_shapes, optimize=False
+            )
+        # 2. Assert the exported model
+        input = (
+            torch.ones(4),
+            [torch.zeros(4), torch.ones(4)],
+            {"a": torch.zeros(4), "b": torch.ones(4)},
+            torch.ones(5),
+        )
+        onnx_testing.assert_onnx_program(
+            onnx_program,
+            args=input,
+        )
+        # 3. Assert the dynamic axes names
+        # Some names are not respected because they share the same shape constraints,
+        # so they are the same to ExportedProgram.
+        expected_axis_names = [
+            "dim_x",
+            "dim_x",
+            "dim_x",
+            "dim_x",
+            "dim_x",
+            "custom_name_axis_c_0",
+        ]
+
+        for expected_axis_name, input in zip(
+            expected_axis_names, onnx_program.model.graph.inputs
+        ):
+            self.assertEqual(input.shape[0].value, expected_axis_name)
+
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -102,7 +102,7 @@ def export_compat(
                 ) from e
 
     dynamic_shapes_with_export_dim, need_axis_mapping = (
-        _dynamic_shapes.convert_str_to_export_dim(model, dynamic_shapes)
+        _dynamic_shapes.convert_str_to_export_dim(dynamic_shapes)
     )
 
     registry = _registration.ONNXRegistry.from_torchlib()
@@ -172,7 +172,7 @@ def export_compat(
         else:
             raise
 
-    if need_axis_mapping:
+    if need_axis_mapping and dynamic_shapes is not None:
         onnx_program._rename_dynamic_axes(dynamic_shapes)
 
     # Converter opset version and optimize

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -98,7 +98,7 @@ def export_compat(
                 raise RuntimeError(
                     "# Failed to convert 'dynamic_axes' to 'dynamic_shapes'. "
                     "Please provide 'dynamic_shapes' directly. "
-                    "Refer to the documentation of 'torch.export.export' for more information on dynamic shapes."
+                    "Refer to the documentation for 'torch.export.export' for more information on dynamic shapes."
                 ) from e
 
     dynamic_shapes_with_export_dim, need_axis_mapping = (

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -4,7 +4,6 @@
 # mypy: disable-error-code=attr-defined
 from __future__ import annotations
 
-import inspect
 import logging
 import warnings
 from collections.abc import Mapping, Sequence
@@ -12,170 +11,18 @@ from typing import Any, Callable, TYPE_CHECKING
 
 import torch
 from torch.onnx._internal._lazy_import import onnxscript_apis, onnxscript_ir as ir
-from torch.onnx._internal.exporter import _core, _onnx_program, _registration
-from torch.utils import _pytree
+from torch.onnx._internal.exporter import (
+    _core,
+    _dynamic_shapes,
+    _onnx_program,
+    _registration,
+)
 
 
 if TYPE_CHECKING:
     import os
 
 logger = logging.getLogger(__name__)
-
-
-def _signature(model) -> inspect.Signature:
-    should_be_callable = getattr(model, "forward", model)
-    if callable(should_be_callable):
-        return inspect.signature(should_be_callable)
-    raise ValueError("model has no forward method and is not callable")
-
-
-def _from_dynamic_axes_to_dynamic_shapes(
-    model,
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any] | None,
-    *,
-    dynamic_axes=None,
-    output_names: set[str],
-    input_names: Sequence[str] | None = None,
-) -> tuple[dict[str, Any | None] | None, tuple[Any, ...], dict[str, Any] | None]:
-    """
-    Converts dynamic_axes into dynamic_shapes by wrapping the axis names with torch.export.Dim.AUTO.
-
-    dynamic_axes examples:
-    (1) dynamic_axes = {"x": {0: "my_custom_axis_name_1"}, "y": {1: "my_custom_axis_name_2"}}
-    (2) dynamic_axes = {"x": [0], "y": [1]}
-
-    these will be converted to dynamic_shapes respectively:
-    (1) dynamic_shapes = {"x": {0: Dim.AUTO}, "y": {1: Dim.AUTO}}
-    (2) dynamic_shapes = {"x": {0: Dim.AUTO}, "y": {1: Dim.AUTO}}
-
-    Detail on Dim.AUTO: https://github.com/pytorch/pytorch/pull/133620
-    """
-    # https://github.com/pytorch/pytorch/pull/128371
-    # 1. The function does not need to provide dynamic_shapes to torch.export.export
-    if dynamic_axes is None:
-        return None, args, kwargs
-
-    if input_names is None:
-        input_names = []
-
-    if kwargs is None:
-        kwargs = {}
-
-    dynamic_shapes: dict[str, Any | None] = {}
-    for input_name, axes in dynamic_axes.items():
-        # TODO(titaiwang): Add ONNX IR pass to rename default dynamic axes: s0, s1, ...
-        # to the dynamic axes defined by users.
-        # NOTE: torch.export.Dim.AUTO does its best to infer the min and max values
-        # from the model, but it's not guaranteed to be dynamic.
-        if input_name in output_names:
-            # User specified an output name as a dynamic axis, so we skip it
-            continue
-        if isinstance(axes, dict):
-            if any(not isinstance(k, int) for k in axes.keys()):
-                raise ValueError(
-                    "The axis in dynamic_axes must be in the form of: dict[int, str] or list[int]."
-                )
-            dynamic_shapes[input_name] = {
-                k: torch.export.Dim.AUTO for k, _ in axes.items()
-            }
-        elif isinstance(axes, list):
-            if any(not isinstance(k, int) for k in axes):
-                raise ValueError(
-                    "The axis in dynamic_axes must be in the form of: dict[int, str] or list[int]."
-                )
-            dynamic_shapes[input_name] = {k: torch.export.Dim.AUTO for k in axes}
-        elif axes is None:
-            dynamic_shapes[input_name] = None
-        else:
-            raise ValueError(
-                "Unsupported dynamic_axes format. Please provide a dict or a list."
-            )
-
-    for input_name in input_names:
-        if input_name not in dynamic_shapes:
-            dynamic_shapes[input_name] = None
-
-    # Order the inputs according to the signature of the model
-    sig = _signature(model)
-    inputs = []
-    for idx, param_name in enumerate(sig.parameters):
-        if idx < len(args):
-            inputs.append(args[idx])
-        elif param_name in kwargs:
-            inputs.append(kwargs[param_name])
-
-    # We need tree structure to represent dynamic_shapes
-    dynamic_shapes = _unflatten_dynamic_shapes_with_inputs_tree(inputs, dynamic_shapes)
-
-    # Since the dynamic_shapes are now in the order of the model parameters,
-    # we need to convert args and kwargs to the order of the model parameters.
-    return dynamic_shapes, tuple(inputs), {}
-
-
-def _unflatten_dynamic_shapes_with_inputs_tree(
-    inputs: list[Any],
-    dynamic_shapes: dict[str, Any | None],
-) -> dict[str, Any | None]:
-    _, tree_structure = _pytree.tree_flatten(inputs)
-    return _pytree.tree_unflatten(dynamic_shapes.values(), tree_structure)
-
-
-def _from_dynamic_shapes_to_dynamic_axes(
-    dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any],
-    input_names: Sequence[str],
-    exception: Exception,
-) -> dict[str, Any] | None:
-    """
-    Converts dynamic_shapes into dynamic_axes by removing torch.export.Dim wrapping
-    and converting to list or dict form based on whether dimension names are present.
-
-    dynamic_shapes examples:
-    (1) dynamic_shapes = {"x": {0: Dim("my_custom_axis_name_1")}, "y": {1: Dim("my_custom_axis_name_2")}}
-    (2) dynamic_shapes = ({0: Dim("my_custom_axis_name_1"}, {1: Dim("my_custom_axis_name_2")})
-
-    these will be converted to dynamic_axes respectively:
-    (1) dynamic_axes = {"x": {0: "my_custom_axis_name_1"}, "y": {1: "my_custom_axis_name_2"}}
-    (2) dynamic_axes = {"x": [0], "y": [1]}
-
-    NOTE: If the model input is nested, so is the dynamic_shapes, we need to flatten the dynamic_shapes,
-    and then assign the axes to the input names in the order they are provided.
-
-    NOTE: input_names are used to assign the axes to the correct input names. If the input names are not
-    provided, or less than the dynamic inputs/axes, it raises an error.
-    """
-
-    # 0. flatten the dynamic_shapes
-    # If it's a dict with torch.export._Dim, we consider it's an axis to dim mapping
-    def is_dict_axes(x) -> bool:
-        # TODO: torch.export._Dim is not exposed, so we use a hacky way to check the type
-        return isinstance(x, dict) and all(
-            isinstance(k, int)
-            and (v is None or isinstance(v, torch.export.Dim("test").__class__))
-            for k, v in x.items()
-        )
-
-    flat_dynamic_shapes = _pytree.tree_leaves(dynamic_shapes, is_leaf=is_dict_axes)
-
-    if len(input_names) < len(flat_dynamic_shapes):
-        raise ValueError(
-            "To construct dynamic_axes from dynamic_shapes, "
-            f"number of input names ({len(input_names)}) should be greater than or equal to "
-            f"the number of graph inputs(flat) ({len(flat_dynamic_shapes)})"
-        ) from exception
-
-    dynamic_axes = {}
-    # input names are assigned in order
-    for input_name, axes in zip(input_names, flat_dynamic_shapes):
-        if axes is None:
-            continue
-        converted_axes = {}
-        for axis, dim in axes.items():
-            if dim is None:
-                continue
-            converted_axes[axis] = dim.__name__
-            dynamic_axes[input_name] = converted_axes
-    return dynamic_axes
 
 
 def _get_torch_export_args(
@@ -237,13 +84,15 @@ def export_compat(
                 UserWarning,
             )
             try:
-                dynamic_shapes, args, kwargs = _from_dynamic_axes_to_dynamic_shapes(
-                    model,
-                    args,
-                    kwargs,
-                    dynamic_axes=dynamic_axes,
-                    input_names=input_names,
-                    output_names=set(output_names or ()),
+                dynamic_shapes, args, kwargs = (
+                    _dynamic_shapes.from_dynamic_axes_to_dynamic_shapes(
+                        model,
+                        args,
+                        kwargs,
+                        dynamic_axes=dynamic_axes,
+                        input_names=input_names,
+                        output_names=set(output_names or ()),
+                    )
                 )
             except Exception as e:
                 raise RuntimeError(
@@ -251,6 +100,10 @@ def export_compat(
                     "Please provide 'dynamic_shapes' directly. "
                     "Refer to the documentation for 'torch.export.export' for more information on dynamic shapes."
                 ) from e
+
+    dynamic_shapes_with_export_dim, need_axis_mapping = (
+        _dynamic_shapes.convert_str_to_export_dim(model, dynamic_shapes)
+    )
 
     registry = _registration.ONNXRegistry.from_torchlib()
     if custom_translation_table is not None:
@@ -268,7 +121,7 @@ def export_compat(
             args,
             kwargs,
             registry=registry,
-            dynamic_shapes=dynamic_shapes,
+            dynamic_shapes=dynamic_shapes_with_export_dim,
             input_names=input_names,
             output_names=output_names,
             profile=profile,
@@ -295,7 +148,7 @@ def export_compat(
                         "Either input_names or dynamic_axes must be provided "
                         "when dynamic is requested in fallback"
                     ) from e
-                dynamic_axes = _from_dynamic_shapes_to_dynamic_axes(
+                dynamic_axes = _dynamic_shapes.from_dynamic_shapes_to_dynamic_axes(
                     dynamic_shapes=dynamic_shapes, input_names=input_names, exception=e
                 )
             torch.onnx.utils.export(
@@ -318,6 +171,9 @@ def export_compat(
             return onnx_program
         else:
             raise
+
+    if need_axis_mapping:
+        onnx_program._rename_dynamic_axes(dynamic_shapes)
 
     # Converter opset version and optimize
     onnx_program.model = onnxscript_apis.convert_version(

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -98,7 +98,7 @@ def export_compat(
                 raise RuntimeError(
                     "# Failed to convert 'dynamic_axes' to 'dynamic_shapes'. "
                     "Please provide 'dynamic_shapes' directly. "
-                    "Refer to the documentation for 'torch.export.export' for more information on dynamic shapes."
+                    "Refer to the documentation of 'torch.export.export' for more information on dynamic shapes."
                 ) from e
 
     dynamic_shapes_with_export_dim, need_axis_mapping = (

--- a/torch/onnx/_internal/exporter/_dynamic_shapes.py
+++ b/torch/onnx/_internal/exporter/_dynamic_shapes.py
@@ -1,0 +1,316 @@
+"""Compatibility functions for the torch.onnx.export API."""
+
+# mypy: allow-untyped-defs
+# mypy: disable-error-code=attr-defined
+from __future__ import annotations
+
+import re
+import torch
+import inspect
+from typing import Any, Sequence
+from torch.utils import _pytree
+from torch.onnx._internal._lazy_import import onnxscript_ir as ir
+
+
+
+def from_dynamic_axes_to_dynamic_shapes(
+    model,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any] | None,
+    *,
+    dynamic_axes=None,
+    output_names: set[str],
+    input_names: Sequence[str] | None = None,
+) -> tuple[dict[str, Any | None] | None, tuple[Any, ...], dict[str, Any] | None]:
+    """
+    Converts dynamic_axes into dynamic_shapes by wrapping the axis names with torch.export.Dim.AUTO.
+
+    dynamic_axes examples:
+    (1) dynamic_axes = {"x": {0: "my_custom_axis_name_1"}, "y": {1: "my_custom_axis_name_2"}}
+    (2) dynamic_axes = {"x": [0], "y": [1]}
+
+    these will be converted to dynamic_shapes respectively:
+    (1) dynamic_shapes = {"x": {0: Dim.AUTO}, "y": {1: Dim.AUTO}}
+    (2) dynamic_shapes = {"x": {0: Dim.AUTO}, "y": {1: Dim.AUTO}}
+
+    Detail on Dim.AUTO: https://github.com/pytorch/pytorch/pull/133620
+    """
+    # https://github.com/pytorch/pytorch/pull/128371
+    # 1. The function does not need to provide dynamic_shapes to torch.export.export
+    if dynamic_axes is None:
+        return None, args, kwargs
+
+    if input_names is None:
+        input_names = []
+
+    if kwargs is None:
+        kwargs = {}
+
+    dynamic_shapes: dict[str, Any | None] = {}
+    for input_name, axes in dynamic_axes.items():
+        # TODO(titaiwang): Add ONNX IR pass to rename default dynamic axes: s0, s1, ...
+        # to the dynamic axes defined by users.
+        # NOTE: torch.export.Dim.AUTO does its best to infer the min and max values
+        # from the model, but it's not guaranteed to be dynamic.
+        if input_name in output_names:
+            # User specified an output name as a dynamic axis, so we skip it
+            continue
+        if isinstance(axes, dict):
+            if any(not isinstance(k, int) for k in axes.keys()):
+                raise ValueError(
+                    "The axis in dynamic_axes must be in the form of: dict[int, str] or list[int]."
+                )
+            dynamic_shapes[input_name] = {
+                k: torch.export.Dim.AUTO for k, _ in axes.items()
+            }
+        elif isinstance(axes, list):
+            if any(not isinstance(k, int) for k in axes):
+                raise ValueError(
+                    "The axis in dynamic_axes must be in the form of: dict[int, str] or list[int]."
+                )
+            dynamic_shapes[input_name] = {k: torch.export.Dim.AUTO for k in axes}
+        elif axes is None:
+            dynamic_shapes[input_name] = None
+        else:
+            raise ValueError(
+                "Unsupported dynamic_axes format. Please provide a dict or a list."
+            )
+
+    for input_name in input_names:
+        if input_name not in dynamic_shapes:
+            dynamic_shapes[input_name] = None
+
+    # Order the inputs according to the signature of the model
+    sig = _signature(model)
+    inputs = []
+    for idx, param_name in enumerate(sig.parameters):
+        if idx < len(args):
+            inputs.append(args[idx])
+        elif param_name in kwargs:
+            inputs.append(kwargs[param_name])
+
+    # We need tree structure to represent dynamic_shapes
+    dynamic_shapes = _unflatten_dynamic_shapes_with_inputs_tree(inputs, dynamic_shapes)
+
+    # Since the dynamic_shapes are now in the order of the model parameters,
+    # we need to convert args and kwargs to the order of the model parameters.
+    return dynamic_shapes, tuple(inputs), {}
+
+
+def from_dynamic_shapes_to_dynamic_axes(
+    dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any],
+    input_names: Sequence[str],
+    exception: Exception,
+) -> dict[str, Any] | None:
+    """
+    Converts dynamic_shapes into dynamic_axes by removing torch.export.Dim wrapping
+    and converting to list or dict form based on whether dimension names are present.
+
+    dynamic_shapes examples:
+    (1) dynamic_shapes = {"x": {0: Dim("my_custom_axis_name_1")}, "y": {1: Dim("my_custom_axis_name_2")}}
+    (2) dynamic_shapes = ({0: Dim("my_custom_axis_name_1"}, {1: Dim("my_custom_axis_name_2")})
+
+    these will be converted to dynamic_axes respectively:
+    (1) dynamic_axes = {"x": {0: "my_custom_axis_name_1"}, "y": {1: "my_custom_axis_name_2"}}
+    (2) dynamic_axes = {"x": [0], "y": [1]}
+
+    NOTE: If the model input is nested, so is the dynamic_shapes, we need to flatten the dynamic_shapes,
+    and then assign the axes to the input names in the order they are provided.
+
+    NOTE: input_names are used to assign the axes to the correct input names. If the input names are not
+    provided, or less than the dynamic inputs/axes, it raises an error.
+    """
+
+    flat_dynamic_shapes, _ = _flatten_dynamic_shapes_to_axes(dynamic_shapes)
+
+    if len(input_names) < len(flat_dynamic_shapes):
+        raise ValueError(
+            "To construct dynamic_axes from dynamic_shapes, "
+            f"number of input names ({len(input_names)}) should be greater than or equal to "
+            f"the number of graph inputs(flat) ({len(flat_dynamic_shapes)})"
+        ) from exception
+
+    dynamic_axes = {}
+    # input names are assigned in order
+    for input_name, axes in zip(input_names, flat_dynamic_shapes):
+        if axes is None:
+            continue
+        if isinstance(axes, dict):
+            converted_axes = {}
+            for axis, dim in axes.items():
+                if dim is None:
+                    continue
+                # TODO(titaiwang): What if dim is DimHint?
+                converted_axes[axis] = dim.__name__
+            dynamic_axes[input_name] = converted_axes
+        elif isinstance(axes, (list, tuple)):
+            converted_axes = []
+            for dim in axes:
+                if dim is None:
+                    dynamic_axes[input_name] = None
+                    continue
+                # TODO(titaiwang): What if dim is DimHint?
+                converted_axes.append(dim.__name__)
+            dynamic_axes[input_name] = converted_axes
+    return dynamic_axes
+
+
+def convert_str_to_export_dim(
+    model, dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any] | None,
+) -> dict[str, Any] | tuple[Any, ...] | list[Any] | None:
+    # 1. Order inputs with model.forward signature to avoid arg mismatch
+    #    for example: {"y": {0: Dim.AUTO}, "x": {1: Dim.AUTO}}
+    #    Only happens when dynamic_shapes is a dict
+    # NOTE: We don't support the dynamic shapes that is a nested dict with messed up order
+    if isinstance(dynamic_shapes, dict):
+        sig = _signature(model)
+        ordered_dynamic_shapes = {}
+        for param_name in sig.parameters:
+            if param_name in dynamic_shapes:
+                ordered_dynamic_shapes[param_name] = dynamic_shapes[param_name]
+    
+    # 2. Convert "name" to Dim.AUTO with flattening and identify if there is any string
+    #    to be replaced with Dim.AUTO, and then unflatten it back to the original structure.
+    #    for example: {"y": {0: "dim_0"}, "x": {1: "dim_1"}}
+    #    to {"y": {0: Dim.AUTO}, "x": {1: Dim.AUTO}}
+    dynamic_shapes_with_export_dim = []
+    flat_dynamic_shapes, tree_structure = _flatten_dynamic_shapes_to_axes(ordered_dynamic_shapes)
+    for axes in flat_dynamic_shapes:
+        if axes is None:
+            continue
+        if isinstance(axes, dict):
+            converted_axes = {}
+            for axis, dim in axes.items():
+                if dim is None:
+                    continue
+                if isinstance(dim, str):
+                    converted_axes[axis] = torch.export.Dim.AUTO
+                else:
+                    converted_axes[axis] = dim
+            dynamic_shapes_with_export_dim.append(converted_axes)
+        elif isinstance(axes, (list, tuple)):
+            converted_axes = []
+            for axis, dim in enumerate(axes):
+                if dim is None:
+                    continue
+                if isinstance(dim, str):
+                    converted_axes[axis] = torch.export.Dim.AUTO
+                else:
+                    converted_axes[axis] = dim
+            dynamic_shapes_with_export_dim.append(converted_axes)
+            
+    dynamic_shapes_with_export_dim = _pytree.tree_unflatten(dynamic_shapes_with_export_dim, tree_structure)
+    
+    return (
+        dynamic_shapes_with_export_dim,
+        dynamic_shapes != dynamic_shapes_with_export_dim,
+    )
+
+
+def create_rename_mapping(
+    inputs, dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any]
+) -> dict[str, str]:
+    """Create a mapping from old names to new names for dynamic axes."""
+    # named_ios = {v.name: v for v in inputs}
+    flat_dynamic_shapes = _flatten_dynamic_shapes_to_axes(dynamic_shapes)
+    # TODO(titaiwang): Need a better error message
+    assert len(inputs) == len(flat_dynamic_shapes), (
+        "The number of ONNX graph inputs and dynamic_shapes should be the same."
+    )
+    rename_mapping = {}
+    # NOTE: We assume that the flat_dynamic_shapes is in the same order as the inputs
+    for idx, axes in enumerate(flat_dynamic_shapes):
+        input = inputs[idx]
+        if isinstance(axes, dict):
+            for dim, axis in axes.items():
+                if not isinstance(input.shape[dim], ir.SymbolicDim):
+                    continue
+                old_name = input.shape[dim].value
+                if old_name is None:
+                    continue
+                rename_mapping[input.shape[dim].value] = _get_custom_axis_name(axis)
+        elif isinstance(axes, (list, tuple)):
+            for dim, axis in enumerate(axes):
+                if not isinstance(input.shape[dim], ir.SymbolicDim):
+                    continue
+                old_name = input.shape[dim].value
+                if old_name is None:
+                    continue
+                rename_mapping[input.shape[dim].value] = _get_custom_axis_name(axis)
+    return rename_mapping
+
+def _get_custom_axis_name(axis: torch.export.Dim | str | None) -> str | None:
+    """Get the custom axis name from a torch.export.Dim."""
+    if isinstance(axis, torch.export.Dim("for_hack").__class__):
+        return axis.__name__
+    return axis
+
+def iterate_and_change_axis_names(
+    model_or_function: ir.Model | ir.Function, rename_mapping: dict[str, str]
+) -> None:
+    """Rename dynamic axes in a model according to the specified dynamic_axes names."""
+
+    for value in _all_values(model_or_function):
+        if value.shape is None:
+            continue
+        new_shape = []
+        changed = False
+        for dim in value.shape:
+            if not isinstance(dim, ir.SymbolicDim):
+                new_shape.append(dim)
+                continue
+            dim_name = dim.value
+            if dim_name in rename_mapping:
+                new_shape.append(rename_mapping[dim_name])
+                changed = True
+            elif dim_name is not None:
+                new_name = _replace_names(dim_name, rename_mapping)
+                new_shape.append(new_name)
+                if new_name != dim_name:
+                    changed = True
+            else:
+                new_shape.append(None)
+        if changed:
+            value.shape = ir.Shape(new_shape)
+
+def _unflatten_dynamic_shapes_with_inputs_tree(
+    inputs: list[Any],
+    dynamic_shapes:  dict[str, Any] | tuple[Any, ...] | list[Any],
+) -> dict[str, Any | None]:
+    _, tree_structure = _pytree.tree_flatten(inputs)
+    return _pytree.tree_unflatten(dynamic_shapes.values(), tree_structure)
+
+def _flatten_dynamic_shapes_to_axes(dynamic_shapes: dict[str, Any | None]) -> tuple[list[Any], _pytree.TreeSpec]:
+    # If it's a dict/list/tuple with torch.export._Dim, we consider it's an axis to dim mapping
+    def is_axes(x) -> bool:
+        # TODO: torch.export._Dim is not exposed, so we use a hacky way to check the type
+        return (isinstance(x, dict) and all(
+            isinstance(k, int)
+            and (v is None or isinstance(v, (torch.export.Dim("for_hack").__class__, str)))
+            for k, v in x.items()) or (isinstance(x, (list, tuple)) and all(
+                isinstance(v, (torch.export.Dim("for_hack").__class__, str)) for v in x
+            )
+        ))
+        
+    return _pytree.tree_flatten(dynamic_shapes, is_leaf=is_axes)
+
+def _replace_names(shape_expr: str, rename_mapping: dict[str, str]) -> str:
+    """Replace all known names in a shape expression with new names."""
+    for old_name, new_name in rename_mapping.items():
+        shape_expr = re.sub(rf"\b{old_name}\b", new_name, shape_expr)
+    return shape_expr
+
+def _signature(model) -> inspect.Signature:
+    should_be_callable = getattr(model, "forward", model)
+    if callable(should_be_callable):
+        return inspect.signature(should_be_callable)
+    raise ValueError("model has no forward method and is not callable")
+
+
+def _all_values(model: ir.Model):
+    """Yield all values in a model."""
+    yield from model.graph.inputs
+    yield from model.graph.initializers.values()
+    for node in ir.traversal.RecursiveGraphIterator(model.graph):
+        yield from node.outputs
+        

--- a/torch/onnx/_internal/exporter/_dynamic_shapes.py
+++ b/torch/onnx/_internal/exporter/_dynamic_shapes.py
@@ -307,10 +307,9 @@ def _flatten_dynamic_shapes_to_axes(
                 and (v is None or isinstance(v, (_Dim, _DimHint, str)))
                 for k, v in x.items()
             )
-            or (
-                isinstance(x, (list, tuple))
-                and all(isinstance(v, (_Dim, _DimHint, str)) for v in x)
-            )
+        ) or (
+            isinstance(x, (list, tuple))
+            and all(isinstance(v, (_Dim, _DimHint, str)) for v in x)
         )
 
     return _pytree.tree_flatten(dynamic_shapes, is_leaf=is_axes)

--- a/torch/onnx/_internal/exporter/_dynamic_shapes.py
+++ b/torch/onnx/_internal/exporter/_dynamic_shapes.py
@@ -172,7 +172,7 @@ def _any_str_in_dynamic_shapes(
 def convert_str_to_export_dim(
     dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any] | None,
 ) -> tuple[dict[str, Any] | tuple[Any, ...] | list[Any] | None, bool]:
-    # 0. If there is no string in dynamic_shapes, we do not touch dynamic_shapes
+    # 1. If there is no string in dynamic_shapes, we do not touch dynamic_shapes
     if dynamic_shapes is None or not _any_str_in_dynamic_shapes(dynamic_shapes):
         return dynamic_shapes, False
 

--- a/torch/onnx/_internal/exporter/_ir_passes.py
+++ b/torch/onnx/_internal/exporter/_ir_passes.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING
 
 from torch.onnx._internal._lazy_import import onnxscript_apis, onnxscript_ir as ir
@@ -28,6 +29,53 @@ def rename_outputs(model: ir.Model, new_names: Sequence[str]) -> None:
     for output, new_name in zip(model.graph.outputs, new_names):
         output.metadata_props["pkg.torch.onnx.original_node_name"] = str(output.name)
         output.name = new_name
+
+
+def _all_values(model: ir.Model):
+    """Yield all values in a model."""
+    # Yield all values in the model
+    yield from model.graph.inputs
+    yield from model.graph.initializers.values()
+    for node in ir.traversal.RecursiveGraphIterator(model.graph):
+        yield from node.outputs
+    # Yield all values in functions
+    for function in model.functions.values():
+        yield from function.inputs
+        for node in ir.traversal.RecursiveGraphIterator(function):
+            yield from node.outputs
+
+
+def _replace_names(shape_expr: str, rename_mapping: dict[str, str]) -> str:
+    """Replace all known names in a shape expression with new names."""
+    for old_name, new_name in rename_mapping.items():
+        shape_expr = re.sub(rf"\b{old_name}\b", new_name, shape_expr)
+    return shape_expr
+
+
+def rename_axis(model: ir.Model, rename_mapping: dict[str, str]) -> None:
+    """Rename dynamic axes in a model according to the specified dynamic_axes names."""
+    for value in _all_values(model):
+        if value.shape is None:
+            continue
+        new_shape = []
+        changed = False
+        for dim in value.shape:
+            if not isinstance(dim, ir.SymbolicDim):
+                new_shape.append(dim)
+                continue
+            dim_name = dim.value
+            if dim_name in rename_mapping:
+                new_shape.append(rename_mapping[dim_name])
+                changed = True
+            elif dim_name is not None:
+                new_name = _replace_names(dim_name, rename_mapping)
+                new_shape.append(new_name)
+                if new_name != dim_name:
+                    changed = True
+            else:
+                new_shape.append(None)
+        if changed:
+            value.shape = ir.Shape(new_shape)
 
 
 def add_torchlib_common_imports(model: ir.Model) -> None:

--- a/torch/onnx/_internal/exporter/_ir_passes.py
+++ b/torch/onnx/_internal/exporter/_ir_passes.py
@@ -48,12 +48,23 @@ def _all_values(model: ir.Model):
 def _replace_names(shape_expr: str, rename_mapping: dict[str, str]) -> str:
     """Replace all known names in a shape expression with new names."""
     for old_name, new_name in rename_mapping.items():
-        shape_expr = re.sub(rf"\b{old_name}\b", new_name, shape_expr)
+        shape_expr = re.sub(
+            rf"(?<!\w){re.escape(old_name)}(?!\w)", new_name, shape_expr
+        )
     return shape_expr
 
 
 def rename_axis(model: ir.Model, rename_mapping: dict[str, str]) -> None:
     """Rename dynamic axes in a model according to the specified dynamic_axes names."""
+
+    # NOTE: Mapping needs to be srted by length because the shape expression
+    # could have multiple ways to be expressed, for example,
+    # {"s1": sequence_length, "s11": "past_sequence_length", "s1 + s11": "masked_sequence_length"}
+    # We prefer the replacement starts from the longest match.
+    sorted_rename_mapping = dict(
+        sorted(rename_mapping.items(), key=lambda item: len(item[0]), reverse=True)
+    )
+
     for value in _all_values(model):
         if value.shape is None:
             continue
@@ -64,11 +75,12 @@ def rename_axis(model: ir.Model, rename_mapping: dict[str, str]) -> None:
                 new_shape.append(dim)
                 continue
             dim_name = dim.value
-            if dim_name in rename_mapping:
-                new_shape.append(rename_mapping[dim_name])
+            if dim_name in sorted_rename_mapping:
+                new_shape.append(sorted_rename_mapping[dim_name])
                 changed = True
             elif dim_name is not None:
-                new_name = _replace_names(dim_name, rename_mapping)
+                # For example: "2*s1", "s1+1", "s1-1", "s1*s2", "s1/s2"
+                new_name = _replace_names(dim_name, sorted_rename_mapping)
                 new_shape.append(new_name)
                 if new_name != dim_name:
                     changed = True

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, TYPE_CHECKING
 
 import torch
 from torch.onnx._internal._lazy_import import onnx, onnxscript_apis, onnxscript_ir as ir
-from torch.onnx._internal.exporter import _dynamic_shapes
+from torch.onnx._internal.exporter import _dynamic_shapes, _ir_passes
 from torch.utils import _pytree
 
 
@@ -263,7 +263,7 @@ ONNXProgram(
         rename_mapping = _dynamic_shapes.create_rename_mapping(
             self.model.graph.inputs, dynamic_shapes
         )
-        _dynamic_shapes.iterate_and_change_axis_names(self.model, rename_mapping)
+        _ir_passes.rename_axis(self.model, rename_mapping)
 
 
 def _process_args(args, kwargs) -> tuple[torch.Tensor, ...]:

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -257,14 +257,14 @@ ONNXProgram(
 
     def _rename_dynamic_axes(
         self,
-        dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any] | None,
+        dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any],
     ) -> None:
         """Rename dynamic axes in a model according to the specified dynamic_axes names."""
         rename_mapping = _dynamic_shapes.create_rename_mapping(
             self.model.graph.inputs, dynamic_shapes
         )
         _dynamic_shapes.iterate_and_change_axis_names(self.model, rename_mapping)
-        for model_function in self.model.graph.functions.values():
+        for model_function in self.model.functions.values():
             _dynamic_shapes.iterate_and_change_axis_names(
                 model_function, rename_mapping
             )

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -264,10 +264,6 @@ ONNXProgram(
             self.model.graph.inputs, dynamic_shapes
         )
         _dynamic_shapes.iterate_and_change_axis_names(self.model, rename_mapping)
-        for model_function in self.model.functions.values():
-            _dynamic_shapes.iterate_and_change_axis_names(
-                model_function, rename_mapping
-            )
 
 
 def _process_args(args, kwargs) -> tuple[torch.Tensor, ...]:


### PR DESCRIPTION
Fixes #143443

This PR aims to support custom dynamic axis naming through dynamic_shapes. Currently, _Dim and _DimHint do not support dynamic axis naming (#144273).

1. **the original dynamic shapes guarantee**
The axis renaming is only applied when dynamic shapes include string instead of all _Dim and _DimHint. Thus, there will not be any inconsistent behavior to dynamic_shapes with torch.export.export if the given dynamic shapes follow torch.export.export format.
2. _DimHint.AUTO is applied to the axes that are specified with custom names to avoid exporter crash. (_DimHint.DYNAMIC crashes when the export fails.)
3.  There's no need to handle cases where kwargs are out of order with the model signature,
    as torch.export.export supports dynamism only when kwargs and dynamic_shapes are provided in order.
    https://github.com/pytorch/pytorch/blob/49082f9dba3b79a344cb03652972ddbe7c3729cc/torch/export/_trace.py#L2034
4. If `torch.onnx.ExportedProgram` finds the axes share the same constraints, they will have the same name (e.g. s0, s1, ...). Therefore, even if the ONNX users specify them with different custom names, they won't be respected.

Example model:
```python
        class NestedModel(torch.nn.Module):
            def forward(
                self,
                x: torch.Tensor,
                ys: list[torch.Tensor],
                zs: dict[str, torch.Tensor],
                c: torch.Tensor,
            ):
                y = ys[0] + ys[1] + zs["a"] + zs["b"]
                w = 5
                if x.shape[0] < 3 and c.shape[0] != 4:
                    return x + w, x + y, c
                else:
                    return x - w, x - y, c

        input = (
            torch.ones(5),
            [torch.zeros(5), torch.ones(5)],
            {"a": torch.zeros(5), "b": torch.ones(5)},
            torch.ones(6),
        )

        dynamic_shapes = (
            {0: torch.export.Dim("dim_x", min=3)},  # _Dim
            [("custom_name_axis_ys_0",), (torch.export.Dim.AUTO,)],  # custom name
            {
                "a": {0: torch.export.Dim.AUTO},
                "b": ("custom_name_axis_zs_b_0",),
            },  # _DimHint
            {0: "custom_name_axis_c_0"},  # custom name
        )

```