### PR TITLE
Fix random crash in PyPer

### DIFF
--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -270,36 +270,44 @@ static void writeJsonNode(
     const std::string& kernelFile = "",
     const std::string& tensor_range = "",
     const std::string& additiona_attrs = "") {
-  out << fmt::format(
-      R"JSON(
-    {{
-      "id": {}, "name": "{}", "ctrl_deps": {},
-      "inputs": {{"values": {}, "shapes": {}, "types": {}, "strides": {}}},
-      "outputs": {{"values": {}, "shapes": {}, "types": {}, "strides": {}}},
-      "attrs": [{{"name": "rf_id", "type": "uint64", "value": {}}},{{"name": "fw_parent", "type": "uint64", "value": {}}},{{"name": "seq_id", "type": "int64", "value": {}}},{{"name": "scope", "type": "uint64", "value": {}}},{{"name": "tid", "type": "uint64", "value": {}}},{{"name": "fw_tid", "type": "uint64", "value": {}}},{{"name": "op_schema", "type": "string", "value": "{}"}},{{"name": "kernel_backend", "type": "string", "value": "{}"}},{{"name": "kernel_file", "type": "string", "value": "{}"}},{{"name": "tensor_range", "type": "string", "value": "{}"}}{}]
-    }})JSON",
-      id,
-      name,
-      parent,
-      inputs,
-      inputShapes,
-      inputTypes,
-      inputStrides,
-      outputs,
-      output_shapes,
-      output_types,
-      output_strides,
-      rf_id,
-      fw_parent,
-      seq_id,
-      scope,
-      tid,
-      fw_tid,
-      operator_schema,
-      kernelBackend,
-      kernelFile,
-      tensor_range,
-      additiona_attrs);
+  if (!out.is_open() || out.fail() || out.bad()) {
+    return;
+  }
+
+  try {
+    out << fmt::format(
+        R"JSON(
+      {{
+        "id": {}, "name": "{}", "ctrl_deps": {},
+        "inputs": {{"values": {}, "shapes": {}, "types": {}, "strides": {}}},
+        "outputs": {{"values": {}, "shapes": {}, "types": {}, "strides": {}}},
+        "attrs": [{{"name": "rf_id", "type": "uint64", "value": {}}},{{"name": "fw_parent", "type": "uint64", "value": {}}},{{"name": "seq_id", "type": "int64", "value": {}}},{{"name": "scope", "type": "uint64", "value": {}}},{{"name": "tid", "type": "uint64", "value": {}}},{{"name": "fw_tid", "type": "uint64", "value": {}}},{{"name": "op_schema", "type": "string", "value": "{}"}},{{"name": "kernel_backend", "type": "string", "value": "{}"}},{{"name": "kernel_file", "type": "string", "value": "{}"}},{{"name": "tensor_range", "type": "string", "value": "{}"}}{}]
+      }})JSON",
+        id,
+        name,
+        parent,
+        inputs,
+        inputShapes,
+        inputTypes,
+        inputStrides,
+        outputs,
+        output_shapes,
+        output_types,
+        output_strides,
+        rf_id,
+        fw_parent,
+        seq_id,
+        scope,
+        tid,
+        fw_tid,
+        operator_schema,
+        kernelBackend,
+        kernelFile,
+        tensor_range,
+        additiona_attrs);
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Failed to write json node to execution trace: " << e.what();
+  }
 }
 
 static std::string timeString(const std::time_t timepoint) {


### PR DESCRIPTION
Summary: PyPer saw random crashes when writing into ET file. This DIFF is to check if the output file is in condition before writing into it, and catch the exception if something bad happens, instead of crashing.

Test Plan: buck2 run mode/opt caffe2/test:test_profiler_cuda -- profiler.test_execution_trace.TestExecutionTraceCUDA

Differential Revision: D69065509


