### PR TITLE
Add optional generator to distribution sampler/rsample methods.

### DIFF
--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -1,6 +1,8 @@
 # mypy: allow-untyped-defs
+from typing import Optional
+
 import torch
-from torch import nan, Tensor
+from torch import nan, Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import (
@@ -11,7 +13,6 @@ from torch.distributions.utils import (
 )
 from torch.nn.functional import binary_cross_entropy_with_logits
 from torch.types import _Number
-
 
 __all__ = ["Bernoulli"]
 
@@ -100,10 +101,10 @@ class Bernoulli(ExponentialFamily):
     def param_shape(self) -> torch.Size:
         return self._param.size()
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=torch.Size(), generator: Optional[Generator] = None):
         shape = self._extended_shape(sample_shape)
         with torch.no_grad():
-            return torch.bernoulli(self.probs.expand(shape))
+            return torch.bernoulli(self.probs.expand(shape), generator)
 
     def log_prob(self, value):
         if self._validate_args:

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -1,12 +1,13 @@
 # mypy: allow-untyped-defs
+from typing import Optional
+
 import torch
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.dirichlet import Dirichlet
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all
 from torch.types import _Number, _size
-
 
 __all__ = ["Beta"]
 
@@ -73,8 +74,8 @@ class Beta(ExponentialFamily):
         total = self.concentration1 + self.concentration0
         return self.concentration1 * self.concentration0 / (total.pow(2) * (total + 1))
 
-    def rsample(self, sample_shape: _size = ()) -> Tensor:
-        return self._dirichlet.rsample(sample_shape).select(-1, 0)
+    def rsample(self, sample_shape: _size = (), generator: Optional[Generator] = None) -> Tensor:
+        return self._dirichlet.rsample(sample_shape, generator).select(-1, 0)
 
     def log_prob(self, value):
         if self._validate_args:

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -1,6 +1,8 @@
 # mypy: allow-untyped-defs
+from typing import Optional
+
 import torch
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import (
@@ -116,11 +118,11 @@ class Binomial(Distribution):
     def param_shape(self) -> torch.Size:
         return self._param.size()
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=torch.Size(), generator: Optional[Generator] = None):
         shape = self._extended_shape(sample_shape)
         with torch.no_grad():
             return torch.binomial(
-                self.total_count.expand(shape), self.probs.expand(shape)
+                self.total_count.expand(shape), self.probs.expand(shape), generator
             )
 
     def log_prob(self, value):

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -1,10 +1,11 @@
 # mypy: allow-untyped-defs
+from typing import Optional
+
 import torch
-from torch import nan, Tensor
+from torch import nan, Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import lazy_property, logits_to_probs, probs_to_logits
-
 
 __all__ = ["Categorical"]
 
@@ -127,11 +128,12 @@ class Categorical(Distribution):
             device=self.probs.device,
         )
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=torch.Size(), generator: Optional[Generator] = None):
         if not isinstance(sample_shape, torch.Size):
             sample_shape = torch.Size(sample_shape)
         probs_2d = self.probs.reshape(-1, self._num_events)
-        samples_2d = torch.multinomial(probs_2d, sample_shape.numel(), True).T
+        samples_2d = torch.multinomial(
+            probs_2d, sample_shape.numel(), True, generator=generator).T
         return samples_2d.reshape(self._extended_shape(sample_shape))
 
     def log_prob(self, value):

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -1,13 +1,13 @@
 # mypy: allow-untyped-defs
 import math
+from typing import Optional
 
 import torch
-from torch import inf, nan, Tensor
+from torch import inf, nan, Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
 from torch.types import _Number, _size
-
 
 __all__ = ["Cauchy"]
 
@@ -66,9 +66,9 @@ class Cauchy(Distribution):
             self._extended_shape(), inf, dtype=self.loc.dtype, device=self.loc.device
         )
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size = torch.Size(), generator: Optional[Generator] = None) -> Tensor:
         shape = self._extended_shape(sample_shape)
-        eps = self.loc.new(shape).cauchy_()
+        eps = self.loc.new(shape).cauchy_(generator=generator)
         return self.loc + eps * self.scale
 
     def log_prob(self, value):

--- a/torch/distributions/continuous_bernoulli.py
+++ b/torch/distributions/continuous_bernoulli.py
@@ -1,8 +1,9 @@
 # mypy: allow-untyped-defs
 import math
+from typing import Optional
 
 import torch
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import (
@@ -14,7 +15,6 @@ from torch.distributions.utils import (
 )
 from torch.nn.functional import binary_cross_entropy_with_logits
 from torch.types import _Number, _size
-
 
 __all__ = ["ContinuousBernoulli"]
 
@@ -168,9 +168,10 @@ class ContinuousBernoulli(ExponentialFamily):
         with torch.no_grad():
             return self.icdf(u)
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size = torch.Size(), generator: Optional[Generator] = None) -> Tensor:
         shape = self._extended_shape(sample_shape)
-        u = torch.rand(shape, dtype=self.probs.dtype, device=self.probs.device)
+        u = torch.rand(
+            shape, dtype=self.probs.dtype, device=self.probs.device, generator=generator)
         return self.icdf(u)
 
     def log_prob(self, value):

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -4,7 +4,7 @@ from typing import Optional
 from typing_extensions import deprecated
 
 import torch
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.utils import lazy_property
 from torch.types import _size
@@ -159,7 +159,7 @@ class Distribution:
         """
         return self.variance.sqrt()
 
-    def sample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def sample(self, sample_shape: _size = torch.Size(), generator: Optional[Generator] = None) -> Tensor:
         """
         Generates a sample_shape shaped sample or sample_shape shaped batch of
         samples if the distribution parameters are batched.
@@ -167,7 +167,7 @@ class Distribution:
         with torch.no_grad():
             return self.rsample(sample_shape)
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size = torch.Size(), generator: Optional[Generator] = None) -> Tensor:
         """
         Generates a sample_shape shaped reparameterized sample or sample_shape
         shaped batch of reparameterized samples if the distribution parameters

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -1,11 +1,12 @@
 # mypy: allow-untyped-defs
+from typing import Optional
+
 import torch
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all
 from torch.types import _Number, _size
-
 
 __all__ = ["Exponential"]
 
@@ -58,9 +59,9 @@ class Exponential(ExponentialFamily):
         new._validate_args = self._validate_args
         return new
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size = torch.Size(), generator: Optional[Generator] = None) -> Tensor:
         shape = self._extended_shape(sample_shape)
-        return self.rate.new(shape).exponential_() / self.rate
+        return self.rate.new(shape).exponential_(generator=generator) / self.rate
 
     def log_prob(self, value):
         if self._validate_args:

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -1,17 +1,18 @@
 # mypy: allow-untyped-defs
+from typing import Optional
+
 import torch
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all
 from torch.types import _Number, _size
 
-
 __all__ = ["Gamma"]
 
 
-def _standard_gamma(concentration):
-    return torch._standard_gamma(concentration)
+def _standard_gamma(concentration, generator):
+    return torch._standard_gamma(concentration, generator)
 
 
 class Gamma(ExponentialFamily):
@@ -68,9 +69,9 @@ class Gamma(ExponentialFamily):
         new._validate_args = self._validate_args
         return new
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size = torch.Size(), generator: Optional[Generator] = None) -> Tensor:
         shape = self._extended_shape(sample_shape)
-        value = _standard_gamma(self.concentration.expand(shape)) / self.rate.expand(
+        value = _standard_gamma(self.concentration.expand(shape), generator) / self.rate.expand(
             shape
         )
         value.detach().clamp_(

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -1,12 +1,12 @@
 # mypy: allow-untyped-defs
+from typing import Optional
 
 import torch
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import _sum_rightmost
 from torch.types import _size
-
 
 __all__ = ["Independent"]
 
@@ -100,11 +100,11 @@ class Independent(Distribution):
     def variance(self) -> Tensor:
         return self.base_dist.variance
 
-    def sample(self, sample_shape=torch.Size()) -> Tensor:
-        return self.base_dist.sample(sample_shape)
+    def sample(self, sample_shape=torch.Size(), generator: Optional[Generator] = None) -> Tensor:
+        return self.base_dist.sample(sample_shape, generator)
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
-        return self.base_dist.rsample(sample_shape)
+    def rsample(self, sample_shape: _size = torch.Size(), generator: Optional[Generator] = None) -> Tensor:
+        return self.base_dist.rsample(sample_shape, generator)
 
     def log_prob(self, value):
         log_prob = self.base_dist.log_prob(value)

--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -1,14 +1,14 @@
 # mypy: allow-untyped-defs
 import math
+from typing import Optional
 
 import torch
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.multivariate_normal import _batch_mahalanobis, _batch_mv
 from torch.distributions.utils import _standard_normal, lazy_property
 from torch.types import _size
-
 
 __all__ = ["LowRankMultivariateNormal"]
 
@@ -200,11 +200,11 @@ class LowRankMultivariateNormal(Distribution):
             self._batch_shape + self._event_shape + self._event_shape
         )
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size = torch.Size(), generator: Optional[Generator] = None) -> Tensor:
         shape = self._extended_shape(sample_shape)
         W_shape = shape[:-1] + self.cov_factor.shape[-1:]
-        eps_W = _standard_normal(W_shape, dtype=self.loc.dtype, device=self.loc.device)
-        eps_D = _standard_normal(shape, dtype=self.loc.dtype, device=self.loc.device)
+        eps_W = _standard_normal(W_shape, dtype=self.loc.dtype, device=self.loc.device, generator=generator)
+        eps_D = _standard_normal(shape, dtype=self.loc.dtype, device=self.loc.device, generator=generator)
         return (
             self.loc
             + _batch_mv(self._unbroadcasted_cov_factor, eps_W)

--- a/torch/distributions/mixture_same_family.py
+++ b/torch/distributions/mixture_same_family.py
@@ -1,10 +1,10 @@
 # mypy: allow-untyped-defs
+from typing import Optional
 
 import torch
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import Categorical, constraints
 from torch.distributions.distribution import Distribution
-
 
 __all__ = ["MixtureSameFamily"]
 
@@ -171,7 +171,7 @@ class MixtureSameFamily(Distribution):
         )  # [B, k]
         return torch.logsumexp(log_prob_x + log_mix_prob, dim=-1)  # [S, B]
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=torch.Size(), generator: Optional[Generator] = None):
         with torch.no_grad():
             sample_len = len(sample_shape)
             batch_len = len(self.batch_shape)
@@ -179,11 +179,11 @@ class MixtureSameFamily(Distribution):
             es = self.event_shape
 
             # mixture samples [n, B]
-            mix_sample = self.mixture_distribution.sample(sample_shape)
+            mix_sample = self.mixture_distribution.sample(sample_shape, generator)
             mix_shape = mix_sample.shape
 
             # component samples [n, B, k, E]
-            comp_samples = self.component_distribution.sample(sample_shape)
+            comp_samples = self.component_distribution.sample(sample_shape, generator)
 
             # Gather along the k dimension
             mix_sample_r = mix_sample.reshape(

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -1,11 +1,12 @@
 # mypy: allow-untyped-defs
+from typing import Optional
+
 import torch
-from torch import inf, Tensor
+from torch import inf, Tensor, Generator
 from torch.distributions import Categorical, constraints
 from torch.distributions.binomial import Binomial
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
-
 
 __all__ = ["Multinomial"]
 
@@ -98,10 +99,10 @@ class Multinomial(Distribution):
     def param_shape(self) -> torch.Size:
         return self._categorical.param_shape
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=torch.Size(), generator: Optional[Generator] = None):
         sample_shape = torch.Size(sample_shape)
         samples = self._categorical.sample(
-            torch.Size((self.total_count,)) + sample_shape
+            torch.Size((self.total_count,)) + sample_shape, generator
         )
         # samples.shape is (total_count, sample_shape, batch_shape), need to change it to
         # (sample_shape, batch_shape, total_count)

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -1,13 +1,13 @@
 # mypy: allow-untyped-defs
 import math
+from typing import Optional
 
 import torch
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import _standard_normal, lazy_property
 from torch.types import _size
-
 
 __all__ = ["MultivariateNormal"]
 
@@ -240,9 +240,9 @@ class MultivariateNormal(Distribution):
             .expand(self._batch_shape + self._event_shape)
         )
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size = torch.Size(), generator: Optional[Generator] = None) -> Tensor:
         shape = self._extended_shape(sample_shape)
-        eps = _standard_normal(shape, dtype=self.loc.dtype, device=self.loc.device)
+        eps = _standard_normal(shape, dtype=self.loc.dtype, device=self.loc.device, generator=generator)
         return self.loc + _batch_mv(self._unbroadcasted_scale_tril, eps)
 
     def log_prob(self, value):

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -1,7 +1,9 @@
 # mypy: allow-untyped-defs
+from typing import Optional
+
 import torch
 import torch.nn.functional as F
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.gamma import Gamma
@@ -11,7 +13,6 @@ from torch.distributions.utils import (
     logits_to_probs,
     probs_to_logits,
 )
-
 
 __all__ = ["NegativeBinomial"]
 
@@ -109,10 +110,10 @@ class NegativeBinomial(Distribution):
             validate_args=False,
         )
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=torch.Size(), generator: Optional[Generator] = None):
         with torch.no_grad():
-            rate = self._gamma.sample(sample_shape=sample_shape)
-            return torch.poisson(rate)
+            rate = self._gamma.sample(sample_shape=sample_shape, generator=generator)
+            return torch.poisson(rate, generator)
 
     def log_prob(self, value):
         if self._validate_args:

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -1,13 +1,13 @@
 # mypy: allow-untyped-defs
 import math
+from typing import Optional
 
 import torch
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import _standard_normal, broadcast_all
 from torch.types import _Number, _size
-
 
 __all__ = ["Normal"]
 
@@ -72,9 +72,9 @@ class Normal(ExponentialFamily):
         with torch.no_grad():
             return torch.normal(self.loc.expand(shape), self.scale.expand(shape))
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size = torch.Size(), generator: Optional[Generator] = None) -> Tensor:
         shape = self._extended_shape(sample_shape)
-        eps = _standard_normal(shape, dtype=self.loc.dtype, device=self.loc.device)
+        eps = _standard_normal(shape, dtype=self.loc.dtype, device=self.loc.device, generator=generator)
         return self.loc + eps * self.scale
 
     def log_prob(self, value):

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -1,11 +1,12 @@
 # mypy: allow-untyped-defs
+from typing import Optional
+
 import torch
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.categorical import Categorical
 from torch.distributions.distribution import Distribution
 from torch.types import _size
-
 
 __all__ = ["OneHotCategorical", "OneHotCategoricalStraightThrough"]
 
@@ -92,11 +93,11 @@ class OneHotCategorical(Distribution):
     def param_shape(self) -> torch.Size:
         return self._categorical.param_shape
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=torch.Size(), generator: Optional[Generator] = None):
         sample_shape = torch.Size(sample_shape)
         probs = self._categorical.probs
         num_events = self._categorical._num_events
-        indices = self._categorical.sample(sample_shape)
+        indices = self._categorical.sample(sample_shape, generator)
         return torch.nn.functional.one_hot(indices, num_events).to(probs)
 
     def log_prob(self, value):

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -1,11 +1,12 @@
 # mypy: allow-untyped-defs
+from typing import Optional
+
 import torch
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all
 from torch.types import _Number
-
 
 __all__ = ["Poisson"]
 
@@ -60,10 +61,10 @@ class Poisson(ExponentialFamily):
         new._validate_args = self._validate_args
         return new
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=torch.Size(), generator: Optional[Generator] = None):
         shape = self._extended_shape(sample_shape)
         with torch.no_grad():
-            return torch.poisson(self.rate.expand(shape))
+            return torch.poisson(self.rate.expand(shape), generator)
 
     def log_prob(self, value):
         if self._validate_args:

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -1,6 +1,8 @@
 # mypy: allow-untyped-defs
+from typing import Optional
+
 import torch
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.transformed_distribution import TransformedDistribution
@@ -13,7 +15,6 @@ from torch.distributions.utils import (
     probs_to_logits,
 )
 from torch.types import _Number, _size
-
 
 __all__ = ["LogitRelaxedBernoulli", "RelaxedBernoulli"]
 
@@ -88,11 +89,11 @@ class LogitRelaxedBernoulli(Distribution):
     def param_shape(self) -> torch.Size:
         return self._param.size()
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size = torch.Size(), generator: Optional[Generator] = None) -> Tensor:
         shape = self._extended_shape(sample_shape)
         probs = clamp_probs(self.probs.expand(shape))
         uniforms = clamp_probs(
-            torch.rand(shape, dtype=probs.dtype, device=probs.device)
+            torch.rand(shape, dtype=probs.dtype, device=probs.device, generator=generator)
         )
         return (
             uniforms.log() - (-uniforms).log1p() + probs.log() - (-probs).log1p()

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -1,6 +1,8 @@
 # mypy: allow-untyped-defs
+from typing import Optional
+
 import torch
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.categorical import Categorical
 from torch.distributions.distribution import Distribution
@@ -8,7 +10,6 @@ from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import ExpTransform
 from torch.distributions.utils import broadcast_all, clamp_probs
 from torch.types import _size
-
 
 __all__ = ["ExpRelaxedCategorical", "RelaxedOneHotCategorical"]
 
@@ -74,10 +75,10 @@ class ExpRelaxedCategorical(Distribution):
     def probs(self) -> Tensor:
         return self._categorical.probs
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size = torch.Size(), generator: Optional[Generator] = None) -> Tensor:
         shape = self._extended_shape(sample_shape)
         uniforms = clamp_probs(
-            torch.rand(shape, dtype=self.logits.dtype, device=self.logits.device)
+            torch.rand(shape, dtype=self.logits.dtype, device=self.logits.device, generator=generator)
         )
         gumbels = -((-(uniforms.log())).log())
         scores = (self.logits + gumbels) / self.temperature

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -1,14 +1,14 @@
 # mypy: allow-untyped-defs
 
 import torch
-from torch import Tensor
+from torch import Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.independent import Independent
 from torch.distributions.transforms import ComposeTransform, Transform
 from torch.distributions.utils import _sum_rightmost
 from torch.types import _size
-
+from typing import Optional
 
 __all__ = ["TransformedDistribution"]
 
@@ -130,7 +130,7 @@ class TransformedDistribution(Distribution):
     def has_rsample(self) -> bool:  # type: ignore[override]
         return self.base_dist.has_rsample
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=torch.Size(), generator: Optional[Generator] = None):
         """
         Generates a sample_shape shaped sample or sample_shape shaped batch of
         samples if the distribution parameters are batched. Samples first from
@@ -138,19 +138,19 @@ class TransformedDistribution(Distribution):
         list.
         """
         with torch.no_grad():
-            x = self.base_dist.sample(sample_shape)
+            x = self.base_dist.sample(sample_shape, generator)
             for transform in self.transforms:
                 x = transform(x)
             return x
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size = torch.Size(), generator: Optional[Generator] = None) -> Tensor:
         """
         Generates a sample_shape shaped reparameterized sample or sample_shape
         shaped batch of reparameterized samples if the distribution parameters
         are batched. Samples first from base distribution and applies
         `transform()` for every transform in the list.
         """
-        x = self.base_dist.rsample(sample_shape)
+        x = self.base_dist.rsample(sample_shape, generator)
         for transform in self.transforms:
             x = transform(x)
         return x

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -1,11 +1,12 @@
 # mypy: allow-untyped-defs
+from typing import Optional
+
 import torch
-from torch import nan, Tensor
+from torch import nan, Tensor, Generator
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
 from torch.types import _Number, _size
-
 
 __all__ = ["Uniform"]
 
@@ -74,9 +75,9 @@ class Uniform(Distribution):
     def support(self):
         return constraints.interval(self.low, self.high)
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size = torch.Size(), generator: Optional[Generator] = None) -> Tensor:
         shape = self._extended_shape(sample_shape)
-        rand = torch.rand(shape, dtype=self.low.dtype, device=self.low.device)
+        rand = torch.rand(shape, dtype=self.low.dtype, device=self.low.device, generator=generator)
         return self.low + rand * (self.high - self.low)
 
     def log_prob(self, value):


### PR DESCRIPTION
Fixes part of #45115 and #11340
Adds a generator parameter to all the sample/rsample methods of torch distribution classes

cc @fritzo @neerajprad @alicanb @nikitaved