### PR TITLE
Honor Dr.CI classification results on auto commit hash update

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -111,6 +111,7 @@
   - .github/ci_commit_pins/xla.txt
   approved_by:
   - pytorchbot
+  ignore_flaky_failures: false
   mandatory_checks_name:
   - EasyCLA
   - Lint

--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -79,7 +79,6 @@
   - .ci/docker/ci_commit_pins/triton.txt
   approved_by:
   - pytorchbot
-  ignore_flaky_failures: false
   mandatory_checks_name:
   - EasyCLA
   - Lint
@@ -91,7 +90,6 @@
   - test/slow_tests.json
   approved_by:
   - pytorchbot
-  ignore_flaky_failures: false
   mandatory_checks_name:
   - EasyCLA
   - Lint
@@ -103,7 +101,6 @@
   - .ci/docker/ci_commit_pins/executorch.txt
   approved_by:
   - pytorchbot
-  ignore_flaky_failures: false
   mandatory_checks_name:
   - EasyCLA
   - Lint
@@ -114,7 +111,6 @@
   - .github/ci_commit_pins/xla.txt
   approved_by:
   - pytorchbot
-  ignore_flaky_failures: false
   mandatory_checks_name:
   - EasyCLA
   - Lint


### PR DESCRIPTION
Disable `ignore_flaky_failures` was a safer choice, but it seems that this option doesn't work with the current state of the CI.  For example, https://github.com/pytorch/pytorch/pull/125806 hasn't been merged since May because there would always be a failure in one type or another.  This effectively disables the automate mechanism.

My proposal here is to relax this rule and allows the bot to merge auto commit has update with `@pytorchbot merge` like a regular PR.  Then we will at least have something working.  If this causes issue, we can revert it back and try to longer route of improving CI reliability.