### PR TITLE
Build a storage reader/writer to write checkpoints in HF format

### DIFF
--- a/test/distributed/checkpoint/test_hf_storage.py
+++ b/test/distributed/checkpoint/test_hf_storage.py
@@ -1,0 +1,194 @@
+# Owner(s): ["oncall: distributed checkpointing"]
+
+import json
+import os
+import pathlib
+import sys
+import tempfile
+from unittest.mock import MagicMock
+
+import torch
+from torch.distributed.checkpoint._hf_storage import (
+    _HuggingFaceStorageReader,
+    _HuggingFaceStorageWriter,
+    _metadata_fn,
+)
+from torch.distributed.checkpoint.default_planner import (
+    DefaultLoadPlanner,
+    DefaultSavePlanner,
+)
+from torch.distributed.checkpoint.filesystem import _StorageInfo, FileSystem
+from torch.distributed.checkpoint.metadata import (
+    BytesStorageMetadata,
+    Metadata,
+    MetadataIndex,
+)
+from torch.distributed.checkpoint.planner import LoadPlan, SavePlan
+from torch.distributed.checkpoint.planner_helpers import (
+    _create_read_items,
+    _create_write_item_for_tensor,
+)
+from torch.distributed.checkpoint.storage import WriteResult
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestHfStorage(TestCase):
+    def test_write_data_hf(self) -> None:
+        mock_module = MagicMock()
+        sys.modules["safetensors"] = mock_module
+        sys.modules["huggingface_hub"] = mock_module
+
+        mock_module = MagicMock()
+        mock_module.save.return_value = b""
+        sys.modules["safetensors.torch"] = mock_module
+
+        with tempfile.TemporaryDirectory() as path:
+            writer = _HuggingFaceStorageWriter(
+                path=path,
+                fqn_to_index_mapping={"tensor_0": 1, "tensor_1": 1},
+            )
+            writer.fs = FileSystem()
+
+            tensor0 = torch.rand(4)
+            tensor1 = torch.rand(10)
+            write_item_1 = _create_write_item_for_tensor("tensor_0", tensor0)
+            write_item_2 = _create_write_item_for_tensor("tensor_1", tensor1)
+
+            state_dict = {"tensor_0": tensor0, "tensor_1": tensor1}
+
+            save_plan = SavePlan(
+                [write_item_1, write_item_2],
+                storage_data={"tensor_0": 1, "tensor_1": 1},
+            )
+            save_planner = DefaultSavePlanner()
+            save_planner.set_up_planner(state_dict=state_dict)
+
+            write_results = writer.write_data(save_plan, save_planner)
+
+            write_results.wait()
+            actual_write_results = write_results.value()
+
+            expected_write_results = [
+                WriteResult(
+                    index=MetadataIndex(
+                        fqn="tensor_0", offset=torch.Size([0]), index=None
+                    ),
+                    size_in_bytes=tensor0.numel() * tensor0.element_size(),
+                    storage_data=_StorageInfo(
+                        relative_path="model-00001-of-00001.safetensors",
+                        offset=0,
+                        length=tensor0.numel() * tensor0.element_size(),
+                    ),
+                ),
+                WriteResult(
+                    index=MetadataIndex(
+                        fqn="tensor_1", offset=torch.Size([0]), index=None
+                    ),
+                    size_in_bytes=tensor1.numel() * tensor1.element_size(),
+                    storage_data=_StorageInfo(
+                        relative_path="model-00001-of-00001.safetensors",
+                        offset=0,
+                        length=tensor1.numel() * tensor1.element_size(),
+                    ),
+                ),
+            ]
+
+            self.assertEqual(
+                actual_write_results,
+                expected_write_results,
+            )
+
+    def test_read_data_hf(self) -> None:
+        mock_module = MagicMock()
+        sys.modules["safetensors"] = mock_module
+        sys.modules["huggingface_hub"] = mock_module
+
+        name = "tensor_0"
+        tensor_0 = torch.rand(4)
+        mock_module = MagicMock()
+        mock_module.load.return_value = {name: tensor_0}
+        sys.modules["safetensors.torch"] = mock_module
+
+        with tempfile.TemporaryDirectory() as path:
+            reader = _HuggingFaceStorageReader(path=path)
+            reader.fs = FileSystem()
+            file_name = "model-00001-of-00001"
+
+            pathlib.Path(os.path.join(path, file_name)).touch()
+
+            reader.set_up_storage_reader(
+                Metadata(
+                    state_dict_metadata={name: BytesStorageMetadata()},
+                    storage_data={name: file_name},
+                ),
+                is_coordinator=True,
+            )
+
+            read_items = _create_read_items(name, BytesStorageMetadata(), file_name)
+            load_plan = LoadPlan(read_items)
+            load_planner = DefaultLoadPlanner()
+            load_planner.set_up_planner(state_dict={name: torch.rand(4)})
+
+            read_data = reader.read_data(load_plan, load_planner)
+            read_data.wait()
+
+            loaded_tensor = load_planner.original_state_dict[name]
+            self.assertEqual(loaded_tensor, tensor_0)
+
+    def test_metadata_hf(self) -> None:
+        mock_module = MagicMock()
+        sys.modules["huggingface_hub"] = mock_module
+        with tempfile.TemporaryDirectory() as path:
+            file_name = "model-00001-of-00001"
+            write_results = [
+                WriteResult(
+                    index=MetadataIndex(fqn="tensor_0", offset=None, index=None),
+                    size_in_bytes=100,
+                    storage_data=_StorageInfo(
+                        relative_path=file_name, offset=0, length=100
+                    ),
+                ),
+                WriteResult(
+                    index=MetadataIndex(fqn="tensor_1", offset=None, index=None),
+                    size_in_bytes=100,
+                    storage_data=_StorageInfo(
+                        relative_path=file_name, offset=0, length=100
+                    ),
+                ),
+            ]
+
+            writer = _HuggingFaceStorageWriter(
+                path=path,
+                fqn_to_index_mapping={},
+            )
+            writer.fs = FileSystem()
+            writer.finish(
+                Metadata(
+                    state_dict_metadata={
+                        "tensor_0": BytesStorageMetadata(),
+                        "tensor_1": BytesStorageMetadata(),
+                    }
+                ),
+                results=[write_results],
+            )
+            metadata_file = os.path.join(path, _metadata_fn)
+
+            expected_metadata = {
+                "metadata": {"total_size": 200},
+                "weight_map": {
+                    "tensor_0": "model-00001-of-00001",
+                    "tensor_1": "model-00001-of-00001",
+                },
+            }
+            with open(metadata_file) as f:
+                metadata = json.load(f)
+                self.assertEqual(metadata, expected_metadata)
+
+            reader = _HuggingFaceStorageReader(path=path)
+            reader.fs = FileSystem()
+            metadata = reader.read_metadata()
+            self.assertEqual(metadata.storage_data, expected_metadata["weight_map"])
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/checkpoint/__init__.py
+++ b/torch/distributed/checkpoint/__init__.py
@@ -1,4 +1,5 @@
 from . import _extension
+from ._hf_storage import _HuggingFaceStorageReader, _HuggingFaceStorageWriter
 from .api import CheckpointException
 from .default_planner import DefaultLoadPlanner, DefaultSavePlanner
 from .filesystem import FileSystemReader, FileSystemWriter

--- a/torch/distributed/checkpoint/_fsspec_filesystem.py
+++ b/torch/distributed/checkpoint/_fsspec_filesystem.py
@@ -8,7 +8,11 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional, TYPE_CHECKING, Union
 
-from fsspec.core import url_to_fs
+
+try:
+    from fsspec.core import url_to_fs
+except ImportError:
+    pass
 
 from torch.distributed.checkpoint._extension import StreamTransformExtension
 from torch.distributed.checkpoint.filesystem import (

--- a/torch/distributed/checkpoint/_hf_storage.py
+++ b/torch/distributed/checkpoint/_hf_storage.py
@@ -1,0 +1,200 @@
+# mypy: allow-untyped-defs
+import dataclasses
+import json
+import queue
+from typing import Dict, List, Optional
+
+from torch.distributed.checkpoint._fsspec_filesystem import FsspecReader, FsspecWriter
+from torch.distributed.checkpoint.metadata import (
+    BytesStorageMetadata,
+    Metadata,
+    StorageMeta,
+)
+from torch.distributed.checkpoint.planner import (
+    LoadPlan,
+    LoadPlanner,
+    ReadItem,
+    SavePlan,
+    SavePlanner,
+    WriteItem,
+)
+from torch.distributed.checkpoint.storage import WriteResult
+from torch.futures import Future
+
+
+__all__ = ["_HuggingFaceStorageWriter", "_HuggingFaceStorageReader"]
+
+_metadata_fn: str = "model.safetensors.index.json"
+
+FILE_NAME = "model-{cpt_idx}-of-{num_shards}"
+SUFFIX = ".safetensors"
+
+
+class _HuggingFaceStorageWriter(FsspecWriter):
+    """
+    A writer that writes to a huggingface repository in the huggingface format.
+    Uses in Fsspec back-end to communicate with the huggingface hub.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        fqn_to_index_mapping: Dict[str, int],
+        token: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize the huggingface writer pointing to path.
+
+        Args:
+            path: hf directory where the checkpoint will be written to. Should begin with hf://.
+            token: The token to use to authenticate with huggingface hub.
+            fqn_to_index_mapping: A mapping from tensor FQN to the index of the file that the tensor should be written to.
+                              Indices are from 1 to N, where N is the number of files.
+
+        """
+
+        import fsspec
+        from huggingface_hub import HfFileSystem
+
+        if HfFileSystem.protocol not in fsspec.available_protocols():
+            fsspec.register_implementation(HfFileSystem.protocol, HfFileSystem)
+
+        super().__init__(path=path, token=token)
+        self._fqn_to_index_mapping: Dict[str, int] = fqn_to_index_mapping
+
+    def prepare_local_plan(self, plan: SavePlan) -> SavePlan:
+        super().prepare_local_plan(plan)
+        return dataclasses.replace(plan, storage_data=self._fqn_to_index_mapping)
+
+    def prepare_global_plan(self, plans: list[SavePlan]) -> list[SavePlan]:
+        assert len(plans) == 1, "distributed checkpointing is not yet supported"
+        return plans
+
+    def write_data(
+        self,
+        plan: SavePlan,
+        planner: SavePlanner,
+    ) -> Future[List[WriteResult]]:
+        # storage_plan is a map from key to file index
+        storage_plan: Dict[str, int] = plan.storage_data
+
+        buckets = self._split_by_storage_plan(storage_plan, plan.items)
+        highest_index = max(buckets.keys())
+
+        file_queue: queue.Queue = queue.Queue()
+        for file_index, write_items in buckets.items():
+            file_name = self._gen_file_name(file_index, highest_index)
+            file_queue.put(
+                (self.fs.concat_path(self.path, file_name), file_name, write_items)
+            )
+
+        return super()._write_data(planner, file_queue, safe_tensors=True)
+
+    def finish(self, metadata: Metadata, results: list[list[WriteResult]]) -> None:
+        metadata_to_write = {}
+        storage_md = {}
+        total_size = 0
+        for wr_list in results:
+            storage_md.update(
+                {wr.index.fqn: wr.storage_data.relative_path for wr in wr_list}
+            )
+            total_size += sum([wr.storage_data.length for wr in wr_list])
+        metadata_to_write["metadata"] = {"total_size": total_size}
+        metadata_to_write["weight_map"] = storage_md
+
+        metadata_path = self.fs.concat_path(self.path, f"{_metadata_fn}")
+        with self.fs.create_stream(metadata_path, "w") as metadata_file:
+            json.dump(metadata_to_write, metadata_file, indent=2)
+
+    def _split_by_storage_plan(
+        self, storage_plan: Dict[str, int], items: List[WriteItem]
+    ) -> Dict[int, List[WriteItem]]:
+        # storage_plan is a map from key to index
+        buckets = {}
+        for item in items:
+            key = item.index.fqn
+            idx = storage_plan[key]
+            if idx not in buckets:
+                buckets[idx] = [item]
+            else:
+                buckets[idx].append(item)
+
+        return buckets
+
+    def _gen_file_name(self, index: int, largest_index: int) -> str:
+        return (
+            FILE_NAME.format(
+                cpt_idx=f"{index}".zfill(5), num_shards=f"{largest_index}".zfill(5)
+            )
+            + SUFFIX
+        )
+
+    @property
+    def metadata_path(self) -> str:
+        return _metadata_fn
+
+
+class _HuggingFaceStorageReader(FsspecReader):
+    """
+    A reader that reads from a huggingface repository in the huggingface format.
+    Uses in Fsspec back-end to communicate with the huggingface hub.
+    """
+
+    def __init__(self, path: str, token: Optional[str] = None) -> None:
+        """
+        Initialize the huggingface reader pointing to path.
+
+        Args:
+            path: hf directory where the checkpoint will be read from. Should begin with hf://.
+            token: The token to use to authenticate with huggingface hub.
+        """
+        import fsspec
+        from huggingface_hub import HfFileSystem
+
+        if HfFileSystem.protocol not in fsspec.available_protocols():
+            fsspec.register_implementation(HfFileSystem.protocol, HfFileSystem)
+        super().__init__(path=path, token=token)
+        self.storage_data: Dict[str, str] = {}
+
+    def read_data(self, plan: LoadPlan, planner: LoadPlanner) -> Future[None]:
+        from safetensors.torch import load
+
+        per_file: Dict[str, List[ReadItem]] = {}
+
+        for read_item in plan.items:
+            file_name = self.storage_data[read_item.storage_index.fqn]
+            per_file.setdefault(file_name, []).append(read_item)
+
+        for file_name, reqs in per_file.items():
+            new_path = self.fs.concat_path(self.path, file_name)
+            with self.fs.create_stream(new_path, "rb") as stream:
+                loaded_tensors = load(stream.read())
+                for req in reqs:
+                    tensor = loaded_tensors[req.dest_index.fqn]
+
+                    target_tensor = planner.resolve_tensor(req).detach()
+                    target_tensor.resize_(tensor.size())
+                    target_tensor.copy_(tensor)
+                    planner.commit_tensor(req, target_tensor)
+
+        fut: Future = Future()
+        fut.set_result(None)
+        return fut
+
+    def read_metadata(self) -> Metadata:
+        path = self.fs.concat_path(self.path, _metadata_fn)
+        with self.fs.create_stream(path, "r") as metadata_file:
+            metadata = json.load(metadata_file)
+
+        state_dict_metadata: Dict[str, BytesStorageMetadata] = {}
+        for key in metadata["weight_map"].keys():
+            state_dict_metadata[key] = BytesStorageMetadata()
+        metadata = Metadata(
+            state_dict_metadata=state_dict_metadata, storage_data=metadata["weight_map"]
+        )
+
+        if getattr(metadata, "storage_meta", None) is None:
+            metadata.storage_meta = StorageMeta()
+        metadata.storage_meta.load_id = self.load_id
+
+        return metadata

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -303,6 +303,7 @@ def _write_item(
     data: Union[io.BytesIO, torch.Tensor],
     write_item: WriteItem,
     storage_key: str,
+    safe_tensors: bool = False,
 ) -> WriteResult:
     offset = stream.tell()
 
@@ -316,10 +317,15 @@ def _write_item(
     else:
         assert isinstance(data, torch.Tensor)
         assert data.device == torch.device("cpu")
-        torch.save(data, transform_to)
+        if not safe_tensors:
+            torch.save(data, transform_to)
+
     transform_to.close()
 
-    length = stream.tell() - offset
+    if not safe_tensors or isinstance(data, io.BytesIO):
+        length = stream.tell() - offset
+    else:
+        length = data.numel() * data.element_size()
 
     # For consistency with earlier versions, leave this field out of the
     # metadata if there are no extensions.
@@ -348,6 +354,7 @@ def _write_files_from_queue(
     inflight_threshhold: int,
     use_fsync: bool,
     thread_count: int,
+    safe_tensors: bool,
 ) -> None:
     try:
         while True:
@@ -389,14 +396,35 @@ def _write_files_from_queue(
                 for write_item in bytes_w:
                     data = planner.resolve_data(write_item)
                     write_results.append(
-                        _write_item(transforms, stream, data, write_item, storage_key)
+                        _write_item(
+                            transforms,
+                            stream,
+                            data,
+                            write_item,
+                            storage_key,
+                            safe_tensors,
+                        )
                     )
 
+                tensor_dict = {}
                 for tensor, write_item in loader.values():
                     assert tensor.is_cpu
                     write_results.append(
-                        _write_item(transforms, stream, tensor, write_item, storage_key)
+                        _write_item(
+                            transforms,
+                            stream,
+                            tensor,
+                            write_item,
+                            storage_key,
+                            safe_tensors,
+                        )
                     )
+                    tensor_dict[write_item.index.fqn] = tensor
+
+                if safe_tensors:
+                    from safetensors.torch import save
+
+                    stream.write(save(tensor_dict))
 
                 if use_fsync:
                     try:
@@ -512,7 +540,6 @@ class FileSystem(FileSystemBase):
 
 
 class _FileSystemWriter(StorageWriter):
-
     """
     Basic implementation of StorageWriter using file IO.
 
@@ -618,6 +645,14 @@ class _FileSystemWriter(StorageWriter):
                 path = self.fs.concat_path(self.path, file_name)
                 file_queue.put((path, file_name, [item]))
 
+        return self._write_data(planner, file_queue)
+
+    def _write_data(
+        self,
+        planner: SavePlanner,
+        file_queue: queue.Queue,
+        safe_tensors: bool = False,
+    ) -> Future[list[WriteResult]]:
         result_queue: queue.Queue = queue.Queue()
 
         threads = []
@@ -633,6 +668,7 @@ class _FileSystemWriter(StorageWriter):
                     self.per_thread_copy_ahead,
                     self.sync_files,
                     self.thread_count,
+                    safe_tensors,
                 ),
             )
             t.start()
@@ -647,6 +683,7 @@ class _FileSystemWriter(StorageWriter):
             inflight_threshhold=self.per_thread_copy_ahead,
             use_fsync=self.sync_files,
             thread_count=self.thread_count,
+            safe_tensors=safe_tensors,
         )
 
         for t in threads:


### PR DESCRIPTION
Summary: Title - we want to write checkpoints in HF format with DCP, this diff allows this for the non-distributed use case.

Test Plan:
buck2 test 'fbcode//mode/dev-nosan' fbcode//caffe2/test/distributed/checkpoint:test_hf_torchtune_storage

N6476188 --> able to save and load tensor in hf format

Differential Revision: D68444967




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn @ekr0