### PR TITLE
Fix assertion failure in gemm template lowering

### DIFF
--- a/torch/_inductor/codegen/cpp_template.py
+++ b/torch/_inductor/codegen/cpp_template.py
@@ -34,8 +34,9 @@ class CppTemplate(KernelTemplate):
     ) -> None:
         super().__init__(name)
         self.input_nodes = input_nodes
+        self.index = next(self.index_counter)
         self.output_node: Union[ir.Buffer, list[ir.Buffer]] = ir.Buffer(
-            name="buf_out", layout=layout
+            name=f"buf_out{self.index}", layout=layout
         )
         self.layout = layout
         self.num_threads = num_threads
@@ -75,7 +76,7 @@ class CppTemplate(KernelTemplate):
         # since in cpp kernel, we bind it to C long
         extra_args = tuple(ctypes.c_ulonglong(x) for x in extra_args)
 
-        kernel_hash_name = f"cpp_{self.name}_{next(self.index_counter)}"
+        kernel_hash_name = f"cpp_{self.name}_{self.index}"
 
         # Create the BenchmarkRequest for CPP
         bmreq = CppBenchmarkRequest(


### PR DESCRIPTION
Summary:
This commit fixes a crash in the gemm template lowering caused by hitting an [assert](https://github.com/pytorch/pytorch/blob/fd515e4f59bfa0ac9faa5185b7a02f3222c4cd08/torch/_inductor/codegen/common.py#L1181) that a buffer was previously removed.

The assert triggers because in the first gemm lowering we use a local accumulation buffer, which causes the original buffer name to be added to the `removed_buffers` set. Then in the next gemm lowering we use the global buffer for accumulation, but that buffer name is already in the `removed_buffers` set.

The fix is to add a unique suffix to the buffer name to avoid triggering the assert from different gemm lowerings.


Differential Revision: D68814625




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang @aakhundov