### PR TITLE
[Dynamo] Better unsupported message for Fake Tensor Exception

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1474,7 +1474,7 @@ class OutputGraph:
                     self.compiler_fn, e, inspect.currentframe()
                 ).with_traceback(e.__traceback__) from None
             msg = (
-                "Backend compiler failed with a fake tensor exception at \n"
+                "Backend compiler failed with {str(e)} at \n"
                 f"{self.root_tx.format_frame_summary()}"
                 "Adding a graph break."
             )

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1474,7 +1474,7 @@ class OutputGraph:
                     self.compiler_fn, e, inspect.currentframe()
                 ).with_traceback(e.__traceback__) from None
             msg = (
-                "Backend compiler failed with {str(e)} at \n"
+                f"Backend compiler failed with {str(e)} at \n"
                 f"{self.root_tx.format_frame_summary()}"
                 "Adding a graph break."
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146357

I cannot repro this. But this line shows up in internal logs, and I want
to know what the exception is and the context inside it. All of the
exceptions_allowed_to_be_fallback are dataclasses, so they should print
nicely.

Test Plan:
- code reading

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames