### PR TITLE
print out partial fx graph for all data-dependent errors

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1088,7 +1088,7 @@ class InstructionTranslatorBase(
             except BackendCompilerFailed:
                 raise
             except RuntimeError as e:
-                if hasattr(e, "msg") and "Could not guard on data-dependent" in e.msg:
+                if hasattr(e, "msg") and "data-dependent" in e.msg:
                     print(
                         "\n"
                         + torch.fx.GraphModule({}, self.output.graph).print_readable(

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -842,7 +842,7 @@ class Tracer(TracerBase):
         except RuntimeError as e:
             if (
                 isinstance(e.args[0], str)
-                and "Could not guard on data-dependent" in e.args[0]
+                and "data-dependent" in e.args[0]
             ):
                 print(
                     "\n"

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -840,10 +840,7 @@ class Tracer(TracerBase):
 
             self.submodule_paths = None
         except RuntimeError as e:
-            if (
-                isinstance(e.args[0], str)
-                and "data-dependent" in e.args[0]
-            ):
+            if isinstance(e.args[0], str) and "data-dependent" in e.args[0]:
                 print(
                     "\n"
                     + self.graph.python_code(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146363
* #146296
* #146298

The previous implementation didn't catch the following type of errors

```
torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode: Could not extract specialized integer from data-dependent expression u2 (unhinted: u2).  (Size-like symbols: none)
```

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames