### PR TITLE
[RFC][LOGS] Add options to show cutlass logs

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -247,6 +247,7 @@ def set_logs(
     cudagraph_static_inputs: bool = False,
     benchmarking: bool = False,
     graph_region_expansion: bool = False,
+    cutlass: bool = False,
 ):
     """
     Sets the log level for individual components and toggles individual log
@@ -429,6 +430,9 @@ def set_logs(
         graph_region_expansion (:class:`bool`):
             Whether to emit the detailed steps of the duplicate graph region tracker expansion algorithm. Default: ``False``
 
+        cutlass (:class:`bool`):
+            Whether to emit debug info for inductor cutlass backend. Default: ``False``
+
 
     Example::
 
@@ -529,6 +533,7 @@ def set_logs(
         cudagraph_static_inputs=cudagraph_static_inputs,
         benchmarking=benchmarking,
         graph_region_expansion=graph_region_expansion,
+        cutlass=cutlass,
     )
 
 

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -52,6 +52,13 @@ register_log(
         "torch._export.serde.serialize",
     ],
 )
+register_log(
+    "cutlass",
+    [
+        "cutlass",
+        "cutlass_library",
+    ],
+)
 
 register_artifact(
     "guards",


### PR DESCRIPTION
Summary:
Use `os.environ["TORCH_LOGS"] = "+cutlass"` to see CUTLASS backend logs.

For example,
```
cutlass-3/python/cutlass_library/manifest.py:731] [0/0] Culled cutlass_tensorop_i168256xorgemm_b1_256x64_1024x4_tn_align128 from manifest
...
cutlass_library/generator.py:58] [0/0] ***   CreateConvOperator3x
cutlass_library/generator.py:58] [0/0] ***     conv_kind: 1
cutlass_library/generator.py:58] [0/0] ***     ConvOperation3x::init: conv_kind: 1
cutlass_library.library.TileDescription object at 0x7feea280c640>
```

Test Plan: tested offline.

Differential Revision: D69082809




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames