### PR TITLE
[MPSInductor] Add support for `sum` reduction

### DIFF
--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/metal/utils.h>
+#include <metal_compute>
 
 namespace c10 {
 namespace metal {
@@ -8,6 +9,8 @@ namespace metal {
 template<typename T>
 opmath_t<T> threadgroup_sum(threadgroup T* data, unsigned size) {
   opmath_t<T> rc = 0;
+  // TODO: This should be moved to the callee
+  ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
   // TODO: Use `simd_shuffle_down`
   for(auto idx = 0; idx < size; ++idx) {
     rc += data[idx];

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -6,13 +6,13 @@
 namespace c10 {
 namespace metal {
 
-template<typename T>
+template <typename T>
 opmath_t<T> threadgroup_sum(threadgroup T* data, unsigned size) {
   opmath_t<T> rc = 0;
   // TODO: This should be moved to the callee
   ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
   // TODO: Use `simd_shuffle_down`
-  for(auto idx = 0; idx < size; ++idx) {
+  for (auto idx = 0; idx < size; ++idx) {
     rc += data[idx];
   }
   return rc;

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <c10/metal/utils.h>
+
+namespace c10 {
+namespace metal {
+
+template<typename T>
+opmath_t<T> threadgroup_sum(threadgroup T* data, unsigned size) {
+  opmath_t<T> rc = 0;
+  // TODO: Use `simd_shuffle_down`
+  for(auto idx = 0; idx < size; ++idx) {
+    rc += data[idx];
+  }
+  return rc;
+}
+
+} // namespace metal
+} // namespace c10

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -158,6 +158,7 @@ for test_name in [
     "test_silu",
     "test_slice_scatter4",
     "test_sort",
+    "test_sum_keepdims",
     "test_tanh",
     "test_view_as_complex",
     "test_view_on_aliased",

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -158,6 +158,7 @@ for test_name in [
     "test_silu",
     "test_slice_scatter4",
     "test_sort",
+    "test_sum_int",
     "test_sum_keepdims",
     "test_tanh",
     "test_view_as_complex",

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -428,23 +428,10 @@ class MetalKernel(SIMDKernel):
             )
             return acc
         if reduction_type == "sum":
-            dtype = DTYPE_TO_COMPUTATION_DTYPE[dtype]
             reduction_dim = next(t for t in self.range_trees if t.is_reduction)
-            acc_buf = self._new_accvar(dtype, reduction_dim.numel)
+            acc_buf = self._new_accvar(src_dtype, reduction_dim.numel)
             self.body.splice(f"{acc_buf}[{reduction_dim.name}] = {value};")
-            line = DeferredLine(
-                acc_buf.name, f"static_cast<{self.dtype_to_str(dtype)}>(0)"
-            )
-            acc = self.cse.generate(self.stores, line, dtype=dtype)
-            # TODO: Move to reduction_utils.h and use `simd_shuffle_down
-            self.stores.splice(
-                f"""
-                for(auto idx = 0; idx < {reduction_dim.numel}; ++idx) {{
-                    {acc} += {acc_buf}[idx];
-                }}
-            """
-            )
-            return acc
+            return self.cse.generate(self.body, f"c10::metal::threadgroup_sum({acc_buf}, {reduction_dim.numel})", dtype=DTYPE_TO_COMPUTATION_DTYPE[dtype])
         raise NotImplementedError
 
     def codegen_iteration_ranges_entry(self, entry: IterationRangesEntry) -> None:
@@ -466,6 +453,8 @@ class MetalKernel(SIMDKernel):
             """,
                 strip=True,
             )
+            if self.inside_reduction:
+                code.writeline("#include <c10/metal/reduction_utils.h>")
             code.writeline("kernel void generated_kernel(")
             with code.indent():
                 for outer, inner in self.args.output_buffers.items():

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -436,7 +436,7 @@ class MetalKernel(SIMDKernel):
                 f"c10::metal::threadgroup_sum({acc_buf}, {reduction_dim.numel})",
                 dtype=DTYPE_TO_COMPUTATION_DTYPE[dtype],
             )
-        raise NotImplementedError
+        raise NotImplementedError(reduction_type)
 
     def codegen_iteration_ranges_entry(self, entry: IterationRangesEntry) -> None:
         index_expr = self.rename_indexing(entry.expr)

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -431,7 +431,11 @@ class MetalKernel(SIMDKernel):
             reduction_dim = next(t for t in self.range_trees if t.is_reduction)
             acc_buf = self._new_accvar(src_dtype, reduction_dim.numel)
             self.body.splice(f"{acc_buf}[{reduction_dim.name}] = {value};")
-            return self.cse.generate(self.body, f"c10::metal::threadgroup_sum({acc_buf}, {reduction_dim.numel})", dtype=DTYPE_TO_COMPUTATION_DTYPE[dtype])
+            return self.cse.generate(
+                self.body,
+                f"c10::metal::threadgroup_sum({acc_buf}, {reduction_dim.numel})",
+                dtype=DTYPE_TO_COMPUTATION_DTYPE[dtype],
+            )
         raise NotImplementedError
 
     def codegen_iteration_ranges_entry(self, entry: IterationRangesEntry) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #146396
* #146389
* __->__ #146380

- Add `threadgroup_sum` template to `c10/metal/reduction_utils.h` that so far uses barrier to compute the reductions

TODOs:
 - Implement efficient reduction using cooperative functions such as `simd_shuffle_down`
 - Figure out how to merge several sum reduction together
 - Implement `reduction_store` that will only write results from the first thread

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang @aakhundov