### PR TITLE
[Metal][BE] Fix the arguments of `polygamma`

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Gamma.metal
+++ b/aten/src/ATen/native/mps/kernels/Gamma.metal
@@ -81,7 +81,7 @@ kernel void polygamma(
     constant int64_t& order [[buffer(2)]],
     uint id [[thread_position_in_grid]]) {
   // already blocked if n <= 1
-  output[id] = static_cast<T1>(c10::metal::polygamma(input[id], order));
+  output[id] = static_cast<T1>(c10::metal::polygamma(order, input[id]));
 }
 
 #define INSTANTIATE_GAMMA_KERNELS(DTYPE0, DTYPE1)                             \

--- a/c10/metal/special_math.h
+++ b/c10/metal/special_math.h
@@ -383,7 +383,7 @@ inline float zeta(float x, float q) {
 }
 
 template <typename T0>
-inline float polygamma(const T0 input, const int64_t order) {
+inline float polygamma(const int64_t order, const T0 input) {
   float x = input;
   float n = order;
   float sgn = ((order % 2) ? 1 : -1);

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -253,11 +253,7 @@ class MetalOverrides(OpOverrides):
 
     @staticmethod
     def polygamma(n: CSEVariable, x: CSEVariable) -> str:
-        # polygamma's API takes order as first argument
-        # and the input tensor as second, while the
-        # metal shader has these inverted.
-        # TODO (dcci): make this more uniform.
-        return f"c10::metal::polygamma({x}, {n})"
+        return f"c10::metal::polygamma({n}, {x})"
 
     @staticmethod
     def digamma(x: CSEVariable) -> str:


### PR DESCRIPTION
In the public API, order comes before input, while here they're
 reversed. Match for consistency (and make this less error prone).


cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang @aakhundov