### PR TITLE
[Experiment] Fix an unaligned memory access issue in mm_template

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -446,9 +446,6 @@ class AOTInductorTestsTemplate:
                 self.check_model(LinearModel(self.device), example_inputs)
 
     def test_linear_dynamic_maxautotune(self):
-        if self.device != "cuda":
-            raise unittest.SkipTest("CUDA test only")
-
         class Model(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -90,11 +90,11 @@ mm_template = TritonTemplate(
 
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    if (stride_am == 1 and stride_ak == M) or (stride_am == K and stride_ak == 1):
+    if M >= BLOCK_M and ((stride_am == 1 and stride_ak == M) or (stride_am == K and stride_ak == 1)):
         offs_a_m = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
     else:
         offs_a_m = rm % M
-    if (stride_bk == 1 and stride_bn == K) or (stride_bk == N and stride_bn == 1):
+    if N >= BLOCK_N and ((stride_bk == 1 and stride_bn == K) or (stride_bk == N and stride_bn == 1)):
         offs_b_n = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
     else:
         offs_b_n = rn % N


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146384

Summary:

Fixes a corner case in the Triton MM template, where the dimension M (dynamic size) can be smaller than BLOCK_M (similarly for the N dimenstion) can trigger unaligned memory access error.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov