### PR TITLE
[WIP][CUDA][cuDNN] Experimental `cudnn_rms_norm`

### DIFF
--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -1544,7 +1544,7 @@ std::tuple<Tensor, Tensor> cudnn_rms_norm(at::Tensor const& input, c10::ArrayRef
 
 //const Tensor& dY, const Tensor& X, const Tensor& rstd, const Tensor& gamma, int64_t M, int64_t N, Tensor* dX,  Tensor* dgamma, Tensor* dbeta) {
 
-std::tuple<Tensor, Tensor> cudnn_rms_norm_backward(at::Tensor const& input, at::SymIntArrayRef normalized_shape, at::Tensor const& grad_output, at::Tensor const& save_rstd, std::optional<at::Tensor> const& weight) {
+std::tuple<Tensor, Tensor> cudnn_rms_norm_backward_symint(at::Tensor const& input, at::SymIntArrayRef normalized_shape, at::Tensor const& grad_output, at::Tensor const& save_rstd, std::optional<at::Tensor> const& weight) {
   // potentially unused
   auto grad_input = at::native::empty_like(input);
   auto grad_weight = Tensor();

--- a/aten/src/ATen/native/cudnn/RMSNorm_v8.cpp
+++ b/aten/src/ATen/native/cudnn/RMSNorm_v8.cpp
@@ -1,0 +1,311 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+
+#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
+
+#if AT_CUDNN_ENABLED()
+
+#include <ATen/cudnn/cudnn-wrapper.h>
+
+#include <c10/macros/Macros.h>
+
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wsuggest-override")
+#include <cudnn_frontend.h>
+C10_DIAGNOSTIC_POP()
+
+#include <cudnn_frontend_find_plan.h>
+#include <cudnn_frontend_get_plan.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/TensorUtils.h>
+#include <ATen/cuda/Exceptions.h>
+#include <ATen/native/cudnn/RMSNorm_v8.h>
+#include <ATen/native/utils/ParamsHash.h>
+#include <ATen/cudnn/Handle.h>
+#include <ATen/TensorUtils.h>
+
+#include <c10/util/env.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+
+#include <unordered_map>
+#include <list>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#else
+#include <ATen/ops/empty.h>
+#endif
+
+#ifdef __linux__
+#include <dlfcn.h>
+#endif
+
+#include <cudnn_frontend.h>
+
+namespace at { namespace native {
+
+
+
+auto get_fe_dtype(const Tensor& t) {
+  namespace fe = cudnn_frontend;
+  auto dtype = t.scalar_type();
+  auto fe_dtype = fe::DataType_t::FLOAT;
+  if (dtype == at::ScalarType::Half) {
+    fe_dtype = fe::DataType_t::HALF;
+  } else if (dtype == at::ScalarType::BFloat16) {
+    fe_dtype = fe::DataType_t::BFLOAT16;
+  } else {
+    TORCH_INTERNAL_ASSERT("cuDNN rmsnorm got unsupported dtype", dtype);
+  }
+  return fe_dtype;
+}
+
+ namespace { 
+ namespace fe = cudnn_frontend;
+using graph_and_tensors_forward = std::tuple<
+                                    std::shared_ptr<fe::graph::Graph>,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // X,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // inv_var,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // scale,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // bias,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // epsilon,
+                                    std::shared_ptr<fe::graph::Tensor_attributes> // Y
+                        >;
+using graph_and_tensors_backward = std::tuple<
+                                    std::shared_ptr<fe::graph::Graph>,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // X,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // DY,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // inv_variance,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // scale,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // dscale,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // dbias,
+                                    std::shared_ptr<fe::graph::Tensor_attributes> // DX
+                        >;
+
+struct RMSNormParams {
+  c10::DeviceIndex device_id;
+  fe::DataType_t dataType;
+  int64_t M;
+  int64_t N; 
+  bool train;
+};
+
+void setRMSNormParams(RMSNormParams& params, const Tensor& X, int64_t M, int64_t N, bool train) {
+  memset(&params, 0, sizeof(params));
+  params.device_id = at::cuda::current_device();
+  params.dataType = get_fe_dtype(X);
+  params.M = M;
+  params.N = N;
+  params.train = train;
+}
+
+struct RMSNormCacheKeyWrapper : ParamsWrapper<RMSNormParams> {
+  RMSNormCacheKeyWrapper(const Tensor& X, int64_t M, int64_t N, bool train) {
+    setRMSNormParams(this->pod, X, M, N, train);
+  }
+};
+
+ template <typename T, typename KeyType>
+struct RMSNormGraphCache {
+std::unordered_map<KeyType, T, ParamsWrapperHash<KeyType>> engine_cache;
+
+// no mutexes here as caches are now thread local for v8, can also return a pointer
+// to the Execution Plan if we know it will not be invalidated by another thread
+T* find(const KeyType& key) {
+  auto it = engine_cache.find(key);
+  if (it == engine_cache.end()) {
+    return nullptr;
+  }
+  return &(it->second);
+}
+
+void update(const KeyType& key, T& results) {
+  engine_cache.erase(key);
+  engine_cache.emplace(key, std::move(results));
+}
+
+};
+
+// @eqy: use thread local caches as cuDNN Execution Plans are not guaranteed to be thread safe across all engines
+// see Limitations in https://docs.nvidia.com/deeplearning/cudnn/release-notes/index.html
+thread_local RMSNormGraphCache<graph_and_tensors_forward, RMSNormCacheKeyWrapper> rmsnorm_forward_graph_cache;
+thread_local RMSNormGraphCache<graph_and_tensors_backward, RMSNormCacheKeyWrapper> rmsnorm_backward_graph_cache;
+
+ }
+
+void raw_cudnn_rmsnorm_forward_out(const Tensor& X, const Tensor& scale, const Tensor& bias, float epsilon, Tensor* rstd, Tensor* Y, int64_t M, int64_t N) {
+  namespace fe = cudnn_frontend;
+  auto key = RMSNormCacheKeyWrapper(X, M, N, X.requires_grad());
+  auto graph_and_tensors_forward_ptr = rmsnorm_forward_graph_cache.find(key);
+  auto rmsnorm_graph = std::make_shared<fe::graph::Graph>();
+  graph_and_tensors_forward graph_and_tensors_forward_values;
+  std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack;
+  if (graph_and_tensors_forward_ptr) {
+    auto [graph, X_fe, inv_variance_fe, scale_fe, bias_fe, epsilon_fe, Y_fe] = *graph_and_tensors_forward_ptr;
+    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack_ = {
+      {X_fe, X.data_ptr()},
+      {inv_variance_fe, rstd->data_ptr()},
+      {scale_fe, scale.data_ptr()},
+      // {bias_fe, bias.data_ptr()},
+      {epsilon_fe, &epsilon},
+      {Y_fe, Y->data_ptr()}};
+    variant_pack = std::move(variant_pack_);
+    rmsnorm_graph = std::move(graph);
+    if (bias.defined()) {
+      variant_pack[bias_fe] = bias.data_ptr();
+    }
+    if (X.requires_grad()) {
+      variant_pack[inv_variance_fe] = rstd->data_ptr();
+    }
+  } else {
+    rmsnorm_graph->set_io_data_type(get_fe_dtype(X))
+        .set_intermediate_data_type(fe::DataType_t::FLOAT)
+        .set_compute_data_type(fe::DataType_t::FLOAT);
+    // cuDNN only seems to care about non-normalized and normalized dimensions, and we can only have one non-normalized-dimension, so...
+    // we reshape to
+    // N, M, 1, 1 because cuDNN also has the restruction that everything must be in 4-D
+    auto X_reshaped = X.reshape({M, N, 1, 1});
+    auto X_fe = rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
+                             .set_name("X")
+                             .set_dim(std::vector<int64_t>(X_reshaped.sizes().begin(), X_reshaped.sizes().end()))
+                             .set_stride(std::vector<int64_t>(X_reshaped.strides().begin(), X_reshaped.strides().end())));
+    auto scale_fe = rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
+                                  .set_name("scale")
+                                  .set_dim({1, N, 1, 1})
+                                  .set_stride({N, 1, N, N})
+                                  .set_data_type(get_fe_dtype(scale)));
+    auto bias_fe  = rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
+                                 .set_name("bias")
+                                 .set_dim({1, N, 1, 1})
+                                 .set_stride({N, 1, N, N})
+                                 .set_data_type(get_fe_dtype(bias)));
+    auto epsilon_fe = rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
+                                    .set_name("epsilon")
+                                    .set_dim({1, 1, 1, 1})
+                                    .set_stride({1, 1, 1, 1})
+                                    .set_data_type(fe::DataType_t::FLOAT));
+    auto phase = X.requires_grad() ? fe::NormFwdPhase_t::TRAINING : fe::NormFwdPhase_t::INFERENCE;
+    auto rmsnorm_options =
+        fe::graph::Rmsnorm_attributes().set_forward_phase(phase).set_epsilon(epsilon_fe);
+    auto [Y_fe, inv_variance_fe] = rmsnorm_graph->rmsnorm(X_fe, scale_fe, rmsnorm_options);
+    if (bias.defined()) {
+      rmsnorm_options.set_bias(bias_fe);
+    }
+    inv_variance_fe->set_output(true).set_data_type(get_fe_dtype(*rstd));
+    Y_fe->set_output(true);
+
+    cudnnHandle_t handle = getCudnnHandle();
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->validate().is_good());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->build_operation_graph(handle).is_good());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->create_execution_plans({fe::HeurMode_t::FALLBACK}).is_good());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->check_support(handle).is_good(), rmsnorm_graph->check_support(handle).get_message());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->build_plans(handle).is_good());
+    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack_ = {
+      {X_fe, X.data_ptr()},
+      {scale_fe, scale.data_ptr()},
+      //{bias_fe, bias.data_ptr()},
+      {epsilon_fe, &epsilon},
+      {Y_fe, Y->data_ptr()}};
+    variant_pack = std::move(variant_pack_);
+    auto result = std::make_tuple(rmsnorm_graph, X_fe, inv_variance_fe, scale_fe, bias_fe, epsilon_fe, Y_fe);
+    rmsnorm_forward_graph_cache.update(key, result);
+    if (bias.defined()) {
+      variant_pack[bias_fe] = bias.data_ptr();
+    }
+    if (X.requires_grad()) {
+      variant_pack[inv_variance_fe] = rstd->data_ptr();
+    }
+  }
+  cudnnHandle_t handle = getCudnnHandle();
+  size_t workspace_size = rmsnorm_graph->get_workspace_size();
+  auto workspace_ptr = c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  TORCH_INTERNAL_ASSERT(!workspace_size || workspace_ptr);
+  TORCH_INTERNAL_ASSERT(rmsnorm_graph->execute(handle, variant_pack, workspace_ptr.get()).is_good());
+}
+
+void raw_cudnn_rmsnorm_backward_out(const Tensor& dY, const Tensor& X, const Tensor& rstd, const Tensor& gamma, int64_t M, int64_t N, Tensor* dX,  Tensor* dgamma, Tensor* dbeta) {
+  namespace fe = cudnn_frontend;
+  auto key = RMSNormCacheKeyWrapper(X, M, N, true);
+  auto graph_and_tensors_backward_ptr = rmsnorm_backward_graph_cache.find(key);
+  auto rmsnorm_graph = std::make_shared<fe::graph::Graph>();
+  graph_and_tensors_backward graph_and_tensors_backward_values;
+  std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack;
+  if (graph_and_tensors_backward_ptr) {
+    auto [graph, X_fe, DY_fe, inv_variance_fe, scale_fe, dscale_fe, dbias_fe, DX_fe] = *graph_and_tensors_backward_ptr;
+    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack_ = {
+      {X_fe, X.data_ptr()},
+      {DY_fe, dY.data_ptr()},
+      {inv_variance_fe, rstd.data_ptr()},
+      {scale_fe, gamma.data_ptr()},
+      {dscale_fe, dgamma->data_ptr()},
+      //{dbias_fe, dbeta->data_ptr()},
+      {DX_fe, dX->data_ptr()}};
+    variant_pack = std::move(variant_pack_);
+    rmsnorm_graph = std::move(graph);
+    if (dbeta) {
+      variant_pack[dbias_fe] = dbeta->data_ptr();
+    }
+  } else {
+    rmsnorm_graph->set_io_data_type(get_fe_dtype(X))
+        .set_intermediate_data_type(fe::DataType_t::FLOAT)
+        .set_compute_data_type(fe::DataType_t::FLOAT);
+    // cuDNN only seems to care about non-normalized and normalized dimensions, and we can only have one non-normalized-dimension, so...
+    // we reshape to
+    // N, M, 1, 1 because cuDNN also has the restruction that everything must be in 4-D
+    auto X_reshaped = X.reshape({M, N, 1, 1});
+    auto DY_reshaped = dY.reshape({M, N, 1, 1});
+    auto X_fe = rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
+                             .set_name("X")
+                             .set_dim(std::vector<int64_t>(X_reshaped.sizes().begin(), X_reshaped.sizes().end()))
+                             .set_stride({N, 1, N, N}));
+    auto DY_fe = rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
+                             .set_name("DY")
+                             .set_dim(std::vector<int64_t>(DY_reshaped.sizes().begin(), DY_reshaped.sizes().end()))
+                             .set_stride({N, 1, N, N}));
+    auto scale_fe = rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
+                                  .set_name("scale")
+                                  .set_dim({1, N, 1, 1})
+                                  .set_stride({N, 1, N, N})
+                                  .set_data_type(get_fe_dtype(gamma)));
+    auto inv_variance_fe  = rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
+                                 .set_name("inv_variance")
+                                 .set_dim({M, 1, 1, 1})
+                                 .set_stride({1, 1, 1, 1})
+                                 .set_data_type(get_fe_dtype(rstd)));
+    auto rmsnorm_options = fe::graph::Rmsnorm_backward_attributes().has_dbias(dbeta);
+    auto [DX_fe, dscale_fe, dbias_fe] = rmsnorm_graph->rmsnorm_backward(DY_fe, X_fe, scale_fe, inv_variance_fe, rmsnorm_options);
+    DX_fe->set_output(true);
+    dscale_fe->set_output(true).set_data_type(get_fe_dtype(*dgamma));
+    dbias_fe->set_output(true).set_data_type(get_fe_dtype(*dbeta));
+    cudnnHandle_t handle = getCudnnHandle();
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->validate().is_good());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->build_operation_graph(handle).is_good());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->create_execution_plans({fe::HeurMode_t::FALLBACK}).is_good());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->check_support(handle).is_good(), rmsnorm_graph->check_support(handle).get_message());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->build_plans(handle).is_good());
+    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack_ = {
+      {X_fe, X.data_ptr()},
+      {DY_fe, dY.data_ptr()},
+      {inv_variance_fe, rstd.data_ptr()},
+      {scale_fe, gamma.data_ptr()},
+      {dscale_fe, dgamma->data_ptr()},
+      //{dbias_fe, dbeta->data_ptr()},
+      {DX_fe, dX->data_ptr()}};
+    variant_pack = std::move(variant_pack_);
+    if (dbeta) {
+      variant_pack[dbias_fe] = dbeta->data_ptr();
+    }
+    auto result = std::make_tuple(rmsnorm_graph, X_fe, DY_fe, inv_variance_fe, scale_fe, dscale_fe, dbias_fe, DX_fe);
+    rmsnorm_backward_graph_cache.update(key, result);
+  }
+  cudnnHandle_t handle = getCudnnHandle();
+  size_t workspace_size = rmsnorm_graph->get_workspace_size();
+  auto workspace_ptr = c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  TORCH_INTERNAL_ASSERT(!workspace_size || workspace_ptr);
+  TORCH_INTERNAL_ASSERT(rmsnorm_graph->execute(handle, variant_pack, workspace_ptr.get()).is_good());
+}
+
+
+
+}} // at::native
+
+#endif  // AT_CUDNN_ENABLED

--- a/aten/src/ATen/native/cudnn/RMSNorm_v8.h
+++ b/aten/src/ATen/native/cudnn/RMSNorm_v8.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <ATen/core/Tensor.h>
+
+#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
+
+#include <ATen/cudnn/cudnn-wrapper.h>
+#include <ATen/cudnn/Descriptors.h>
+#include <ATen/cudnn/Types.h>
+
+namespace at { namespace native {
+
+
+#if AT_CUDNN_ENABLED()
+
+void raw_cudnn_rmsnorm_forward_out(const Tensor& X, const Tensor& scale, const Tensor& bias, float epsilon, Tensor* rstd, Tensor* Y, int64_t M, int64_t N);
+void raw_cudnn_rmsnorm_backward_out(const Tensor& dY, const Tensor& X, const Tensor& rstd, const Tensor& gamma, int64_t M, int64_t N, Tensor* dX,  Tensor* dgamma, Tensor* dbeta);
+
+#endif
+}}

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1885,13 +1885,13 @@
     CUDA: cudnn_batch_norm_backward
   autogen: cudnn_batch_norm_backward.out
 
-- func: cudnn_rms_norm(Tensor input, Tensor? weight, float epsilon, SymInt[] normalized_shape) -> (Tensor, Tensor)
+- func: cudnn_rms_norm(Tensor input, SymInt[] normalized_shape, Tensor? weight, float? epsilon=None) -> (Tensor, Tensor)
   dispatch:
     CUDA: cudnn_rms_norm
 
-- func: cudnn_rms_norm_backward(Tensor input, Tensor grad_output, Tensor save_rstd, Tensor? weight) -> (Tensor, Tensor, Tensor)
+- func: cudnn_rms_norm_backward(Tensor input, SymInt[] normalized_shape, Tensor grad_output, Tensor save_rstd, Tensor? weight) -> (Tensor, Tensor)
   dispatch:
-    CUDA: cudnn_rms_norm_backward
+    CUDA: cudnn_rms_norm_backward_symint
 
 - func: cudnn_convolution(Tensor self, Tensor weight, SymInt[] padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1885,6 +1885,14 @@
     CUDA: cudnn_batch_norm_backward
   autogen: cudnn_batch_norm_backward.out
 
+- func: cudnn_rms_norm(Tensor input, Tensor? weight, float epsilon, SymInt[] normalized_shape) -> (Tensor, Tensor)
+  dispatch:
+    CUDA: cudnn_rms_norm
+
+- func: cudnn_rms_norm_backward(Tensor input, Tensor grad_output, Tensor save_rstd, Tensor? weight) -> (Tensor, Tensor, Tensor)
+  dispatch:
+    CUDA: cudnn_rms_norm_backward
+
 - func: cudnn_convolution(Tensor self, Tensor weight, SymInt[] padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor
   dispatch:
     CUDA: cudnn_convolution

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2748,8 +2748,8 @@
   reserveSpace: not_implemented("cudnn_batch_norm_backward reserveSpace")
   input, weight, grad_output: batchnorm_double_backward(input, weight, grads[0], grads[1], grads[2], grad_output, running_mean, running_var, true, epsilon, save_mean, save_var, grad_input_mask)
 
-- name: cudnn_rms_norm(Tensor input, Tensor? weight, float epsilon, SymInt[] normalized_shape) -> (Tensor, Tensor)
-  input, weight: "cudnn_rms_norm_backward(input, grad, result1, weight)"
+- name: cudnn_rms_norm(Tensor input, SymInt[] normalized_shape, Tensor? weight, float? epsilon=None) -> (Tensor, Tensor)
+  input, weight: "cudnn_rms_norm_backward_symint(input, normalized_shape, grad, result1, weight)"
 
 # nnpack
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2748,6 +2748,9 @@
   reserveSpace: not_implemented("cudnn_batch_norm_backward reserveSpace")
   input, weight, grad_output: batchnorm_double_backward(input, weight, grads[0], grads[1], grads[2], grad_output, running_mean, running_var, true, epsilon, save_mean, save_var, grad_input_mask)
 
+- name: cudnn_rms_norm(Tensor input, Tensor? weight, float epsilon, SymInt[] normalized_shape) -> (Tensor, Tensor)
+  input, weight: "cudnn_rms_norm_backward(input, grad, result1, weight)"
+
 # nnpack
 
 - name: _nnpack_spatial_convolution(Tensor input, Tensor weight, Tensor? bias, SymInt[2] padding, SymInt[2] stride=1) -> Tensor


### PR DESCRIPTION
opt-in for now behind two new native functions---the plan would be to eventually add it as the `CUDA:` backend to `rms_norm`

Initial experiments show forward ~4-5x speed, up fwd+bwd ~3x speedup

cc @csarofeen @ptrblck @xwang233 @msaroufim