### PR TITLE
[1/N] Use std::string_view in torchgen  

### DIFF
--- a/torchgen/gen_aoti_c_shim.py
+++ b/torchgen/gen_aoti_c_shim.py
@@ -50,7 +50,7 @@ base_type_to_aten_type = {
     BaseTy.SymInt: "c10::SymInt",
     BaseTy.Scalar: "c10::Scalar",
     BaseTy.float: "double",
-    BaseTy.str: "c10::string_view",
+    BaseTy.str: "::std::string_view",
     BaseTy.DeviceIndex: "c10::DeviceIndex",
     BaseTy.Layout: "c10::Layout",
     BaseTy.MemoryFormat: "c10::MemoryFormat",

--- a/torchgen/static_runtime/generator.py
+++ b/torchgen/static_runtime/generator.py
@@ -324,6 +324,7 @@ def ivalue_type_conversion_method(
         BaseTy.str: (
             (False, "toStringView()"),
             (False, "toOptional<c10::string_view>()"),
+            (False, "toOptional<::std::string_view>()"),
         ),
     }
 


### PR DESCRIPTION
Moves remaining c10::sv to std::sv

cc @desertfire @chenyang78 @penguinwu @yushangdi @benjaminglass1