### PR TITLE
Small improvements to NJT matrix multiplies

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -3160,14 +3160,18 @@ class TestNestedTensorAutograd(NestedTensorTestCase):
         assert torch.autograd.gradcheck(grad_test_func, inputs=data)
 
     def test_njt_dense_matmul_backward(self, device):
+        a = torch.randn(2, 6, dtype=torch.float64, device=device)
+        b = torch.randn(3, 6, dtype=torch.float64, device=device)
+        c = torch.randn(2, 6, dtype=torch.float64, device=device)
+        d = torch.randn(3, 6, dtype=torch.float64, device=device)
         nt0 = torch.nested.nested_tensor(
-            [torch.randn((2, 6)), torch.randn((3, 6))],
+            [a, b],
             requires_grad=True,
             device=device,
             layout=torch.jagged,
         )
         nt1 = torch.nested.nested_tensor_from_jagged(
-            torch.cat([torch.randn((2, 6)), torch.randn((3, 6))]),
+            torch.cat([c, d]),
             offsets=nt0.offsets(),
         ).requires_grad_(True)
 

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -2248,38 +2248,6 @@ class TestNestedTensorDeviceType(NestedTensorTestCase):
         )
 
     @dtypes(torch.float, torch.double)
-    def test_mamtul_dense_x_njt(self, device, dtype):
-        # T (B, D, E) with NJT (B, *, E, C) broadcasting case
-        # T x NT.tranpose
-        nt = random_nt_from_dims(
-            [3, None, 4], device=device, dtype=dtype, layout=torch.jagged
-        )
-        nt_t = nt.transpose(1, 2)
-        t = torch.randn(3, 5, 4, device=device, dtype=dtype)
-        output = torch.matmul(t, nt_t)
-
-        # should be equivalent to matmul-ing each component with the dense tensor
-        self.assertEqual(nt_t.size(0), output.size(0))
-        for component, t_component, out_component in zip(nt_t, t, output):
-            self.assertEqual(out_component, torch.matmul(t_component, component))
-
-    @dtypes(torch.float, torch.double)
-    def test_mamtul_dense_x_njt_with_broadcasting(self, device, dtype):
-        # T (D, E) with NJT (B, *, E) broadcasting case
-        # T x NT.tranpose
-        nt = random_nt_from_dims(
-            [3, None, 4], device=device, dtype=dtype, layout=torch.jagged
-        )
-        nt_t = nt.transpose(1, 2)
-        t = torch.randn(5, 4, device=device, dtype=dtype)
-        output = torch.matmul(t, nt_t)
-
-        # should be equivalent to matmul-ing each component with the dense tensor
-        self.assertEqual(nt_t.size(0), output.size(0))
-        for component, out_component in zip(nt_t, output):
-            self.assertEqual(out_component, torch.matmul(t, component))
-
-    @dtypes(torch.float, torch.double)
     def test_linear(self, device, dtype):
         a = torch.randn(1, 2, device=device, dtype=dtype)
         b = torch.randn(2, 2, device=device, dtype=dtype)
@@ -3141,61 +3109,6 @@ class TestNestedTensorAutograd(NestedTensorTestCase):
 
         self.assertEqual(torch.nested.to_padded_tensor(nt0.grad, 0.0), pt0.grad)
         self.assertEqual(torch.nested.to_padded_tensor(nt1.grad, 0.0), pt1.grad)
-
-    def test_njt_dense_matmul_gradcheck(self, device):
-        a = torch.randn(2, 6, requires_grad=True, dtype=torch.float64, device=device)
-        b = torch.randn(3, 6, requires_grad=True, dtype=torch.float64, device=device)
-        c = torch.randn(2, 6, requires_grad=True, dtype=torch.float64, device=device)
-        d = torch.randn(3, 6, requires_grad=True, dtype=torch.float64, device=device)
-
-        def grad_test_func(a, b, c, d):
-            nt0 = torch.nested.as_nested_tensor([a, b], layout=torch.jagged)
-            nt1 = torch.nested.nested_tensor_from_jagged(
-                values=torch.cat([c, d], dim=0), offsets=nt0.offsets()
-            )
-            result = torch.matmul(nt0.transpose(1, 2), nt1)
-            return result
-
-        data = (a, b, c, d)
-        assert torch.autograd.gradcheck(grad_test_func, inputs=data)
-
-    def test_njt_dense_matmul_backward(self, device):
-        a = torch.randn(2, 6, dtype=torch.float64, device=device)
-        b = torch.randn(3, 6, dtype=torch.float64, device=device)
-        c = torch.randn(2, 6, dtype=torch.float64, device=device)
-        d = torch.randn(3, 6, dtype=torch.float64, device=device)
-        nt0 = torch.nested.nested_tensor(
-            [a, b],
-            requires_grad=True,
-            device=device,
-            layout=torch.jagged,
-        )
-        nt1 = torch.nested.nested_tensor_from_jagged(
-            torch.cat([c, d]),
-            offsets=nt0.offsets(),
-        ).requires_grad_(True)
-
-        with torch.no_grad():
-            pt0 = torch.nested.to_padded_tensor(
-                torch.nested.nested_tensor(list(nt0.unbind())), 0.0
-            ).requires_grad_(True)
-            pt1 = torch.nested.to_padded_tensor(
-                torch.nested.nested_tensor(list(nt1.unbind())), 0.0
-            ).requires_grad_(True)
-
-        ynt = torch.matmul(nt0.transpose(-2, -1), nt1)
-        ypt = torch.matmul(pt0.transpose(-2, -1), pt1)
-        ynt.backward(ynt.clone())
-        ypt.backward(ypt.clone())
-
-        nt0_padded_grad = torch.nested.to_padded_tensor(
-            torch.nested.nested_tensor(list(nt0.grad.unbind())), 0.0
-        )
-        nt1_padded_grad = torch.nested.to_padded_tensor(
-            torch.nested.nested_tensor(list(nt1.grad.unbind())), 0.0
-        )
-        self.assertEqual(nt0_padded_grad, pt0.grad)
-        self.assertEqual(nt1_padded_grad, pt1.grad)
 
     def test_nested_tensor_transpose_gradcheck(self, device):
         a = torch.randn(2, 5, requires_grad=True, device=device)

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -1144,7 +1144,7 @@ def cat_default(func, *args, **kwargs):
     )
 
 
-@register_jagged_func(torch.ops.aten.matmul.default, "self: jt_all, other: any")
+@register_jagged_func(torch.ops.aten.matmul.default, "self: any, other: any")
 def matmul_default(func, *args, **kwargs):
     _, new_kwargs = normalize_function(  # type: ignore[misc]
         func, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True
@@ -1153,14 +1153,23 @@ def matmul_default(func, *args, **kwargs):
     inp = new_kwargs.pop("input")
     other = new_kwargs.pop("other")
 
+    if not inp.is_nested and not other.is_nested:
+        raise ValueError(
+            "matmul_default: expected one of [self, other] to be a nested tensor"
+        )
+
     def _unbind_impl(a, b):
         return [
             func(a_comp, b_comp) for (a_comp, b_comp) in zip(a.unbind(), b.unbind())
         ]
 
-    def _padded_impl(a, b):
-        assert a.is_nested and not b.is_nested
-        nt = a
+    def _padded_impl(a, b, lh_nested):
+        if lh_nested:
+            assert a.is_nested and not b.is_nested
+            nt = a
+        else:
+            assert b.is_nested and not a.is_nested
+            nt = b
 
         from .nested_tensor import nested_from_padded
 
@@ -1178,8 +1187,12 @@ def matmul_default(func, *args, **kwargs):
             *nt.shape[nt._ragged_idx + 1 :],
         )
         padded_nt = nt.to_padded_tensor(0.0, output_size=padded_shape)
+        if lh_nested:
+            padded_t = func(padded_nt, b)
+        else:
+            padded_t = func(a, padded_nt)
         return nested_from_padded(
-            func(padded_nt, b),
+            padded_t,
             offsets=nt._offsets,
             ragged_idx=nt._ragged_idx,
             sum_S=total_L,
@@ -1193,7 +1206,7 @@ def matmul_default(func, *args, **kwargs):
         # (B, j1, D) x (B, D, E) => (B, j1, E)
         if inp.dim() >= 3 and inp.dim() == other.dim():
             # convert to padded for this
-            return _padded_impl(inp, other)
+            return _padded_impl(inp, other, True)
         # Support broadcasting the dense:
         # (B, j1, D) x (D, E) => (B, j1, E)
         # (B, j1, D, E) x (E, F) => (B, j1, D, F)
@@ -1202,6 +1215,21 @@ def matmul_default(func, *args, **kwargs):
             return NestedTensor(
                 func(inp._values, other, **new_kwargs), **extract_kwargs(inp)
             )
+    # Dense x NJT
+    elif not inp.is_nested and other.is_nested:
+        # (B, D, E) x (B, E, j1) => (B, E, j1)
+        if other.dim() >= 3 and other.dim() == inp.dim():
+            # convert to padded for this
+            return _padded_impl(inp, other, False)
+        # Support broadcasting the dense:
+        # (D, E) x (B, E, j1) => (B, D, j1)
+        # (D, E) x (B, E, j1, F) => (B, D, j1, F)
+        # etc.
+        elif inp.dim() == 2 and other.dim() > inp.dim():
+            return NestedTensor(
+                func(inp, other._values, **new_kwargs), **extract_kwargs(other)
+            )
+
     # NJT x NJT
     elif inp.is_nested and other.is_nested:
         # Support ragged batch dim:
@@ -2547,7 +2575,7 @@ def frexp_Tensor(func, *args, **kwargs):
 
 @register_jagged_func(
     torch.ops.aten.matmul_backward.default,
-    "grad: jt_all, self: jt_all, other: any, mask: any",
+    "grad: any, self: any, other: any, mask: any",
 )
 def matmul_backward_default(func, *args, **kwargs):
     _, new_kwargs = normalize_function(  # type: ignore[misc]
@@ -2558,6 +2586,14 @@ def matmul_backward_default(func, *args, **kwargs):
     inp = new_kwargs.pop("input")
     other = new_kwargs.pop("other")
     grad_input_mask = new_kwargs.pop("mask")
+
+    if grad is None:
+        return (None, None)
+
+    if not inp.is_nested and not other.is_nested:
+        raise ValueError(
+            "matmul_backward_default: expected one of [self, other] to be a nested tensor"
+        )
 
     grad_self = None
     if grad_input_mask[0]:

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -2590,11 +2590,6 @@ def matmul_backward_default(func, *args, **kwargs):
     if grad is None:
         return (None, None)
 
-    if not inp.is_nested and not other.is_nested:
-        raise ValueError(
-            "matmul_backward_default: expected one of [self, other] to be a nested tensor"
-        )
-
     grad_self = None
     if grad_input_mask[0]:
         grad_self = torch.matmul(grad, other.transpose(-1, -2))

--- a/torch/testing/_internal/opinfo/definitions/nested.py
+++ b/torch/testing/_internal/opinfo/definitions/nested.py
@@ -1054,9 +1054,9 @@ def sample_inputs_matmul(
         # (B, E, j1) x (B, j1, F) => (B, E, F)
         if njt_3d._ragged_idx == 2 and njt_3d.is_contiguous():
             B, E, _ = njt_3d.shape
-            j1 = len(njt_3d.values())
+            sum_j1 = len(njt_3d.values())
             other_cont = torch.randn(
-                j1, E + 2, device=device, dtype=dtype, requires_grad=requires_grad
+                sum_j1, E + 2, device=device, dtype=dtype, requires_grad=requires_grad
             )
             other_njt = torch.nested.nested_tensor_from_jagged(
                 other_cont, njt_3d.offsets(), lengths=njt_3d._lengths

--- a/torch/testing/_internal/opinfo/definitions/nested.py
+++ b/torch/testing/_internal/opinfo/definitions/nested.py
@@ -1021,6 +1021,53 @@ def sample_inputs_matmul(
                 name=f"{njt_desc}: (B, j, D, E) x (E, F)",
             )
 
+    # Dense x NJT cases
+    for njt_3d in _sample_njts(
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+        dims=[3],
+    ):
+        # (B, F, E) x (B, E, j1) => (B, F, j1)
+        if njt_3d._ragged_idx == 2:
+            B = njt_3d.shape[0]
+            E = njt_3d.shape[1]
+            F = E + 2
+            njt_desc = _describe_njt(njt_3d)
+            dense_t = torch.randn(
+                B, F, E, device=device, dtype=dtype, requires_grad=requires_grad
+            )
+            dense_t._batch_dim = 0  # for unbind_reference()
+            yield SampleInput(
+                dense_t,
+                args=(_clone(njt_3d),),
+                name=f"{njt_desc}: (B, F, E) x (B, E, j1)",
+            )
+
+    # NJT x NJT => Dense case
+    for njt_3d in _sample_njts(
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+        dims=[3],
+    ):
+        # (B, E, j1) x (B, j1, F) => (B, E, F)
+        if njt_3d._ragged_idx == 2 and njt_3d.is_contiguous():
+            B, E, _ = njt_3d.shape
+            j1 = len(njt_3d.values())
+            other_cont = torch.randn(
+                j1, E + 2, device=device, dtype=dtype, requires_grad=requires_grad
+            )
+            other_njt = torch.nested.nested_tensor_from_jagged(
+                other_cont, njt_3d.offsets(), lengths=njt_3d._lengths
+            )
+            njt_desc = _describe_njt(njt_3d)
+            yield SampleInput(
+                _clone(njt_3d),
+                kwargs={"other": _clone(other_njt)},
+                name=f"{njt_desc}: (B, E, j1) x (B, j1, F)",
+            )
+
         # TODO (need factory functions):
         # (B, j1, D, E) x (B, j1, E, F) => (B, j1, D, F)
 


### PR DESCRIPTION
Fixes #146404

Adds changes to the matmul and matmul_backward operation for nested jagged tensors, to support back propagation when the output is a regular strided tensor.
This required adding support for the nested matmul operation to work when the nested tensor wasn't 'self', i.e
`A@B` where `A` isn't nested but `B` is.

The operation schemas had to be updated to reflect that either input can be a strided tensor instead (and the gradient), so an extra assertion is added in an edge case where neither input is nested.

Unit tests are also added.
