### PR TITLE
Only enable aotriton on x86_64 and aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -864,12 +864,13 @@ endif()
 
 include(cmake/Dependencies.cmake)
 
+# aotriton requires CUDA, only available on x86_64 and aarch64
 cmake_dependent_option(
   USE_FLASH_ATTENTION
   "Whether to build the flash_attention kernel for scaled dot product attention.\
   Will be disabled if not supported by the platform"
   ON
-  "USE_CUDA OR USE_ROCM;NOT MSVC"
+  "CPU_INTEL OR CPU_AARCH64;USE_CUDA OR USE_ROCM;NOT MSVC"
   OFF)
 
 # We are currenlty not using alibi attention for Flash So we disable this
@@ -883,7 +884,7 @@ cmake_dependent_option(
   USE_MEM_EFF_ATTENTION
   "Enable memory-efficient attention for scaled dot product attention.\
   Will be disabled if not supported by the platform" ON
-  "USE_CUDA OR USE_ROCM" OFF)
+  "CPU_INTEL OR CPU_AARCH64;USE_CUDA OR USE_ROCM" OFF)
 
 #
 # Cannot be put into Dependencies.cmake due circular dependency:


### PR DESCRIPTION
Make `USE_FLASH_ATTENTION` and `USE_MEM_EFF_ATTENTION` depend on `CPU_INTEL OR CPU_AARCH64`.

[aotriton pre-built](https://github.com/ROCm/aotriton/releases) is only available on x86_64.

Although `AOTRITON_INSTALL_FROM_SOURCE` can be specified to build from source, building aotriton requires CUDA, so on architectures without CUDA support (like riscv64), it still needs to be disabled.