### PR TITLE
[BE][Ez]: Enable ruff rule E731. use `def` instead of anonymous lambda 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ ignore = [
     "C408", # C408 ignored because we like the dict keyword argument syntax
     "E501", # E501 is not flexible enough, we're using B950 instead
     "E721",
-    "E731", # Assign lambda expression
     "E741",
     "EXE001",
     "F405",

--- a/test/functorch/test_parsing.py
+++ b/test/functorch/test_parsing.py
@@ -24,7 +24,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
-from typing import Any, Callable
+from typing import Any
 from unittest import mock
 
 from functorch.einops._parsing import (
@@ -37,9 +37,8 @@ from functorch.einops._parsing import (
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
-mock_anonymous_axis_eq: Callable[[AnonymousAxis, object], bool] = (
-    lambda self, other: isinstance(other, AnonymousAxis) and self.value == other.value
-)
+def mock_anonymous_axis_eq(self: AnonymousAxis, other: object) -> bool:
+    return isinstance(other, AnonymousAxis) and self.value == other.value
 
 
 class TestAnonymousAxis(TestCase):


### PR DESCRIPTION
Not sure why this isn't enabled, only 1 fix is needed and it supports autofixes.