### PR TITLE
use DTRACE_ENV_VAR as the trace logs directory of set

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -986,8 +986,9 @@ def _init_logs(log_file_name=None):
     # configuration
     trace_dir_name = os.environ.get(TRACE_ENV_VAR, None)
 
-    if os.environ.get(DTRACE_ENV_VAR, None):
+    if dtrace_dir_name := os.environ.get(DTRACE_ENV_VAR, None):
         GET_DTRACE_STRUCTURED = True
+        trace_dir_name = dtrace_dir_name
 
     # This handler may remove itself if trace_dir_name is None and we are not
     # actually in an FB environment.  This allows us to defer actually


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #146413
* __->__ #146412
* #145848

```
(/home/bobren/local/a/pytorch-env) [7:47] devgpu035:/home/bobren/local/a/pytorch TORCH_DTRACE=/tmp/bb python r1.py
```