### PR TITLE
[metal] Add a missing cast to make the call to copysign unambiguous.

### DIFF
--- a/c10/metal/special_math.h
+++ b/c10/metal/special_math.h
@@ -444,7 +444,7 @@ inline float digamma(T0 x) {
   } else if (x == 0.0f) {
     // As per C++ standard for gamma related functions and SciPy,
     // If the argument is ±0, ±∞ is returned
-    return ::metal::copysign(INFINITY, -x);
+    return ::metal::copysign(INFINITY, static_cast<float>(-x));
   } else {
     return calc_digamma_positive_domain(x);
   }


### PR DESCRIPTION
cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen