### PR TITLE
[Metal] Small speedup for `sum`/`prod`

### DIFF
--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -8,11 +8,11 @@ namespace metal {
 
 template <typename T>
 opmath_t<T> threadgroup_sum(threadgroup T* data, unsigned size) {
-  opmath_t<T> rc = 0;
+  opmath_t<T> rc = data[0];
   // TODO: This should be moved to the callee
   ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
   // TODO: Use `simd_shuffle_down`
-  for (auto idx = 0; idx < size; ++idx) {
+  for (auto idx = 1; idx < size; ++idx) {
     rc += data[idx];
   }
   return rc;
@@ -20,11 +20,10 @@ opmath_t<T> threadgroup_sum(threadgroup T* data, unsigned size) {
 
 template <typename T>
 opmath_t<T> threadgroup_prod(threadgroup T* data, unsigned size) {
-  opmath_t<T> rc = 1;
+  opmath_t<T> rc = data[0];
   // TODO: This should be moved to the callee
   ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
-  // TODO: Use `simd_shuffle_down`
-  for (auto idx = 0; idx < size; ++idx) {
+  for (auto idx = 1; idx < size; ++idx) {
     rc *= data[idx];
   }
   return rc;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #146436
* #146429
* __->__ #146428
* #146423

As they can not really be invoked over empty arrays