### PR TITLE
Stop poisoning fork on Dataloader creation when pin_memory is enabled

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -152,7 +152,19 @@ us to use the current accelerator as the default device for relevant concepts su
 Stream device_type, FSDP, etc.
 
 As of today, accelerator devices are (in no particular order) :doc:`"CUDA" <cuda>`, :doc:`"MTIA" <mtia>`,
-:doc:`"XPU" <xpu>`, and PrivateUse1 (many device not in the PyTorch repo itself).
+:doc:`"XPU" <xpu>`, :doc:`"MPS" <mps>`, "HPU", and PrivateUse1 (many device not in the PyTorch repo itself).
+
+Many tools in the PyTorch Ecosystem use fork to create subprocesses (for example dataloading
+or intra-op parallelism), it is thus important to delay as much as possible any
+operation that would prevent further forks. This is especially important here as most accelerator's initialization has such effect.
+In practice, you should keep in mind that checking :func:`torch.accelerator.current_accelerator`
+is a compile-time check by default, it is thus always fork-safe.
+On the contrary, passing the ``check_available=True`` flag to this function or calling
+:func:`torch.accelerator.is_available()` will usually prevent later fork.
+
+Some backends provide an experimental opt-in option to make the runtime availability
+check fork-safe. When using the CUDA device ``PYTORCH_NVML_BASED_CUDA_CHECK=1`` can be
+used for example.
 
 .. autosummary::
     :toctree: generated

--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -43,7 +43,16 @@ def is_available() -> bool:
 
         >>> assert torch.accelerator.is_available() "No available accelerators detected."
     """
-    return device_count() > 0
+    # Why not just check "device_count() > 0" like other is_available call?
+    # Because device like CUDA have a python implementation of is_available that is
+    # non-poisoning and some features like Dataloader rely on it.
+    # So we are careful to delegate to the Python version of the accelerator here
+    acc = current_accelerator()
+    if acc is None:
+        return False
+
+    mod = torch.get_device_module(acc)
+    return mod.is_available()
 
 
 def current_accelerator() -> torch.device:

--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -2,6 +2,7 @@ r"""
 This package introduces support for the current :ref:`accelerator<accelerators>` in python.
 """
 
+from typing import Optional
 from typing_extensions import deprecated
 
 import torch
@@ -57,7 +58,7 @@ def is_available() -> bool:
     return mod.is_available()
 
 
-def current_accelerator(check_available: bool = False) -> torch.device | None:
+def current_accelerator(check_available: bool = False) -> Optional[torch.device]:
     r"""Return the device of the accelerator available at compilation time.
     If no accelerator were available at compilation time, returns None.
     See :ref:`accelerator<accelerators>` for details.

--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -57,7 +57,7 @@ def is_available() -> bool:
     return mod.is_available()
 
 
-def current_accelerator(check_available: bool = False) -> torch.device:
+def current_accelerator(check_available: bool = False) -> torch.device | None:
     r"""Return the device of the accelerator available at compilation time.
     If no accelerator were available at compilation time, returns None.
     See :ref:`accelerator<accelerators>` for details.
@@ -78,8 +78,9 @@ def current_accelerator(check_available: bool = False) -> torch.device:
 
         >>> # xdoctest:
         >>> # If an accelerator is available, sent the model to it
+        >>> model = torch.nn.Linear(2, 2)
         >>> if current_device := current_accelerator(check_available=True) is not None:
-        >>>     mod.to(current_device)
+        >>>     model.to(current_device)
     """
     if (acc := torch._C._accelerator_getAccelerator()) is not None:
         if (not check_available) or (check_available and is_available()):

--- a/torch/accelerator/_utils.py
+++ b/torch/accelerator/_utils.py
@@ -11,7 +11,10 @@ def _get_device_index(device: _device_t, optional: bool = False) -> int:
         device = torch.device(device)
     device_index: Optional[int] = None
     if isinstance(device, torch.device):
-        if torch.accelerator.current_accelerator().type != device.type:
+        acc = torch.accelerator.current_accelerator()
+        if acc is None:
+            raise RuntimeError("Accelerator expected")
+        if acc.type != device.type:
             raise ValueError(
                 f"{device.type} doesn't match the current accelerator {torch.accelerator.current_accelerator()}."
             )

--- a/torch/csrc/DeviceAccelerator.cpp
+++ b/torch/csrc/DeviceAccelerator.cpp
@@ -6,9 +6,14 @@ namespace torch::accelerator {
 void initModule(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
 
-  m.def("_accelerator_getAccelerator", []() {
-    // If no accelerator is currently available, raise an exception.
-    return c10::Device(at::getAccelerator(true).value());
+  m.def("_accelerator_getAccelerator", []() -> std::optional<c10::Device> {
+    // If no accelerator was available at compile time, return None.
+    auto acc = at::getAccelerator(false);
+    if (acc.has_value()) {
+      return acc.value();
+    } else {
+      return std::nullopt;
+    }
   });
 
   m.def("_accelerator_deviceCount", []() {

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1214,9 +1214,13 @@ def _save(
 
                 if (
                     config.save.use_pinned_memory_for_d2h
-                    and torch.accelerator.is_available()
-                    and torch.accelerator.current_accelerator().type
-                    == storage.device.type
+                    and (
+                        acc := torch.accelerator.current_accelerator(
+                            check_available=True
+                        )
+                    )
+                    is not None
+                    and acc.type == storage.device.type
                 ):
                     new_storage = torch.empty(
                         num_bytes, dtype=torch.uint8, device="cpu", pin_memory=True

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -672,7 +672,8 @@ class _BaseDataLoaderIter:
             # memory allocation for MPS is fixed.
             if (
                 self._pin_memory
-                and torch.accelerator.current_accelerator().type == "mps"
+                and (acc := torch.accelerator.current_accelerator()) is not None
+                and acc.type == "mps"
             ):
                 self._pin_memory = False
                 warn_msg = (


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/144687
Needs https://github.com/pytorch/pytorch/pull/146098 that already landed to fix the issue above

A longer-term fix would be to move cuda's non-poisoning is_available() check to c++. But that would be quite a bit of work.

This PR also updates the behavior of current_accelerator() in python to match getAccelerator() in C++ and update all docs to reflect that.