### PR TITLE
distributed; If we are in fbcode, set a default log_line_prefix_template of

### DIFF
--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -16,6 +16,7 @@ from ..exc import (
     UnspecializeRestartAnalysis,
     Unsupported,
     UnsupportedAttribute,
+    ObservedAttributeError,
 )
 from ..guards import GuardBuilder, install_guard
 from ..mutation_guard import GenerationTracker
@@ -290,9 +291,10 @@ class NNModuleVariable(VariableTracker):
                 if result is not None:
                     return result
                 # if we can't find a __getattr__, we can't parse this, raise unimplemented
+                raise ObservedAttributeError("foo")
                 unimplemented(
                     f"missing attribute {name} - {typestr(base)}",
-                    exc_class=UnsupportedAttribute,
+                    exc_class=ObservedAttributeError,
                 )
 
         if name == "forward":

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -380,6 +380,7 @@ from torch.distributed.elastic.utils import macros
 from torch.distributed.elastic.utils.logging import get_logger
 from torch.distributed.launcher.api import elastic_launch, LaunchConfig
 from torch.utils.backend_registration import _get_custom_mod_func
+from torch._environment import is_fbcode
 
 
 logger = get_logger(__name__)
@@ -773,6 +774,8 @@ def config_from_args(args) -> tuple[LaunchConfig, Union[Callable, str], list[str
         os.environ["OMP_NUM_THREADS"] = str(omp_num_threads)
 
     log_line_prefix_template = os.getenv("TORCHELASTIC_LOG_LINE_PREFIX_TEMPLATE")
+    if is_fbcode() and not log_line_prefix_template:
+        log_line_prefix_tempatte = "[${role_name}${rank}|${local_rank}]:"
 
     rdzv_configs = _parse_rendezvous_config(args.rdzv_conf)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146450
* #145122

[${role_name}${rank}|${local_rank}]:

Summary:

This removes the need for every fbcode user to try and remember the correct way
to set this to get log filtering to work

Test Plan:
Should only have impacts on trainers which do not set this and are within
fbcode

Reviewers:


Subscribers:

Tasks:

Tags:

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames