### PR TITLE
Fix workarea compute in lapackSyevd

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -256,7 +256,8 @@ void apply_lapack_eigh(const Tensor& values, const Tensor& vectors, const Tensor
   lapackSyevd<scalar_t, value_t>(jobz, uplo, n, vectors_data, lda, values_data,
     &lwork_query, lwork, &rwork_query, lrwork, &iwork_query, liwork, infos_data);
 
-  lwork = std::max<int>(1, real_impl<scalar_t, value_t>(lwork_query));
+  lwork = std::max<int>(1, real_impl<scalar_t, value_t>(lwork_query)+1);
+
   Tensor work = at::empty({lwork}, vectors.options());
   auto work_data = work.mutable_data_ptr<scalar_t>();
 

--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -256,7 +256,8 @@ void apply_lapack_eigh(const Tensor& values, const Tensor& vectors, const Tensor
   lapackSyevd<scalar_t, value_t>(jobz, uplo, n, vectors_data, lda, values_data,
     &lwork_query, lwork, &rwork_query, lrwork, &iwork_query, liwork, infos_data);
 
-  lwork = std::max<int>(1,ceil(real_impl<scalar_t, value_t>(lwork_query) + 2.0*std::numeric_limits<float>::epsilon()));
+  value_t next_after_lw = std::nextafter(real_impl<scalar_t, value_t>(lwork_query), std::numeric_limits<value_t>::infinity());
+  lwork = std::max<int>(1, ceil(next_after_lw));
 
   Tensor work = at::empty({lwork}, vectors.options());
   auto work_data = work.mutable_data_ptr<scalar_t>();
@@ -268,7 +269,8 @@ void apply_lapack_eigh(const Tensor& values, const Tensor& vectors, const Tensor
   Tensor rwork;
   value_t* rwork_data = nullptr;
   if (vectors.is_complex()) {
-    lrwork = std::max<int>(1, rwork_query);
+    value_t next_after_rwork_query = std::nextafter(rwork_query, std::numeric_limits<value_t>::infinity());
+    lrwork = std::max<int>(1, ceil(next_after_rwork_query));
     rwork = at::empty({lrwork}, values.options());
     rwork_data = rwork.mutable_data_ptr<value_t>();
   }

--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -256,7 +256,7 @@ void apply_lapack_eigh(const Tensor& values, const Tensor& vectors, const Tensor
   lapackSyevd<scalar_t, value_t>(jobz, uplo, n, vectors_data, lda, values_data,
     &lwork_query, lwork, &rwork_query, lrwork, &iwork_query, liwork, infos_data);
 
-  lwork = std::max<int>(1, real_impl<scalar_t, value_t>(lwork_query)+1);
+  lwork = std::max<int>(1,ceil(real_impl<scalar_t, value_t>(lwork_query) + 2.0*std::numeric_limits<float>::epsilon()));
 
   Tensor work = at::empty({lwork}, vectors.options());
   auto work_data = work.mutable_data_ptr<scalar_t>();

--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -257,7 +257,7 @@ void apply_lapack_eigh(const Tensor& values, const Tensor& vectors, const Tensor
     &lwork_query, lwork, &rwork_query, lrwork, &iwork_query, liwork, infos_data);
 
   value_t next_after_lw = std::nextafter(real_impl<scalar_t, value_t>(lwork_query), std::numeric_limits<value_t>::infinity());
-  lwork = std::max<int>(1, ceil(next_after_lw));
+  lwork = std::max<int>(1, std::ceil(next_after_lw));
 
   Tensor work = at::empty({lwork}, vectors.options());
   auto work_data = work.mutable_data_ptr<scalar_t>();
@@ -270,7 +270,7 @@ void apply_lapack_eigh(const Tensor& values, const Tensor& vectors, const Tensor
   value_t* rwork_data = nullptr;
   if (vectors.is_complex()) {
     value_t next_after_rwork_query = std::nextafter(rwork_query, std::numeric_limits<value_t>::infinity());
-    lrwork = std::max<int>(1, ceil(next_after_rwork_query));
+    lrwork = std::max<int>(1, std::ceil(next_after_rwork_query));
     rwork = at::empty({lrwork}, values.options());
     rwork_data = rwork.mutable_data_ptr<value_t>();
   }

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1119,6 +1119,15 @@ class TestLinalg(TestCase):
             with self.assertRaisesRegex(RuntimeError, "tensors to be on the same device"):
                 torch.linalg.eigvalsh(t, out=out)
 
+    @onlyCPU
+    @skipCPUIfNoLapack
+    @dtypes(*floating_and_complex_types())
+    def test_eigh_lwork_lapack(self, device, dtype):
+        # test that the calculated lwork does not cause a crash, see https://github.com/pytorch/pytorch/issues/145801
+        t = torch.randn(3000, 3000)
+        y = torch.linalg.eigh(t)
+        self.assertEqual(y.eigenvalues.shape, (3000,))
+
     @dtypes(*floating_and_complex_types())
     def test_kron(self, device, dtype):
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1124,7 +1124,7 @@ class TestLinalg(TestCase):
     @dtypes(*floating_and_complex_types())
     def test_eigh_lwork_lapack(self, device, dtype):
         # test that the calculated lwork does not cause a crash, see https://github.com/pytorch/pytorch/issues/145801
-        t = torch.randn(3000, 3000)
+        t = torch.rand(3000, 3000, device=device, dtype=dtype)
         y = torch.linalg.eigh(t)
         self.assertEqual(y.eigenvalues.shape, (3000,))
 


### PR DESCRIPTION
work-query APIs return floating point values, that could loose precision when converted back to int. Solve this by using `nextafter` and `ceil`
Add regression test 

Fixes #145801
