### PR TITLE
[CUDA][SDPA] Compute reference in `test_triton_scaled_dot_product_attention_block_size_16_cuda_float32` in `float64`

### DIFF
--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -3768,8 +3768,8 @@ class TestSparseCompressedTritonKernels(TestCase):
                 )
 
                 for mask_dtype in (torch.bool, dtype):
-                    res = _scaled_dot_product_attention(query, key, value, attn_mask_bsr.to(mask_dtype), scale=scale)
-                    self.assertEqual(res, expected)
+                    res = _scaled_dot_product_attention(query.double(), key.double(), value.double(), attn_mask_bsr.to(mask_dtype), scale=scale)
+                    self.assertEqual(res, expected.to(res.dtype))
 
 
     @parametrize("block_size", [16, 32, 64])

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -3764,11 +3764,11 @@ class TestSparseCompressedTritonKernels(TestCase):
                 if scale is None and query.size(-1) == 0:
                     scale = 1
                 expected = torch.nn.functional.scaled_dot_product_attention(
-                    *broadcast_input(query, key, value, attn_mask), scale=scale
+                    *broadcast_input(query.double(), key.double(), value.double(), attn_mask), scale=scale
                 )
 
                 for mask_dtype in (torch.bool, dtype):
-                    res = _scaled_dot_product_attention(query.double(), key.double(), value.double(), attn_mask_bsr.to(mask_dtype), scale=scale)
+                    res = _scaled_dot_product_attention(query, key, value, attn_mask_bsr.to(mask_dtype), scale=scale)
                     self.assertEqual(res, expected.to(res.dtype))
 
 

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -3763,13 +3763,15 @@ class TestSparseCompressedTritonKernels(TestCase):
             for scale in (None, 1. / 16):
                 if scale is None and query.size(-1) == 0:
                     scale = 1
+                # We cast to double here as this dispatches to the MATH backend which
+                # introduces additional rounding steps over the fused implementations
                 expected = torch.nn.functional.scaled_dot_product_attention(
                     *broadcast_input(query.double(), key.double(), value.double(), attn_mask), scale=scale
-                )
+                ).to(dtype)
 
                 for mask_dtype in (torch.bool, dtype):
                     res = _scaled_dot_product_attention(query, key, value, attn_mask_bsr.to(mask_dtype), scale=scale)
-                    self.assertEqual(res, expected.to(res.dtype))
+                    self.assertEqual(res, expected)
 
 
     @parametrize("block_size", [16, 32, 64])


### PR DESCRIPTION
Seems to currently fail with mismatches in the 1e-4 range presumably due to sdpa calling into the `MATH` backend here which is less fused than a triton kernel. Doing the ref computation in `float64` appears to fix it.

cc @alexsamardzic @nikitaved @pearu @cpuhrsch @amjames @bhosmer @jcaip @ptrblck @msaroufim