### PR TITLE
Fix one_hot inconsistent errors after compile

### DIFF
--- a/aten/src/ATen/native/Onehot.cpp
+++ b/aten/src/ATen/native/Onehot.cpp
@@ -16,10 +16,10 @@ namespace at::native {
 
 namespace {
 
-void check_num_classes(const at::Tensor& self, int64_t num_classes) {
-    if (self.device().type() != at::kCUDA && self.device().type() != at::kMPS &&
+void check_num_classes(const at::Tensor& self, int64_t num_classes, std::optional<int64_t> self_max_value = std::nullopt) {
+    if (self_max_value.has_value() && self.device().type() != at::kCUDA && self.device().type() != at::kMPS &&
         self.device().type() != at::kPrivateUse1 && self.device().type() != at::kXLA) {
-        TORCH_CHECK(num_classes > self.max().item().toLong(), "Class values must be smaller than num_classes.");
+        TORCH_CHECK(num_classes > self_max_value.value(), "Class values must be smaller than num_classes.");
     } else {
         // for cuda, assert that num_classes is at least 1
         TORCH_CHECK(num_classes >= 1, "num_classes should be positive");
@@ -66,7 +66,7 @@ Tensor one_hot(const Tensor &self, int64_t num_classes) {
     if (num_classes == -1) {
         num_classes = self.max().item().toLong() + 1;
     } else {
-        check_num_classes(self, num_classes);
+        check_num_classes(self, num_classes, std::optional<int64_t>(self.max().item().toLong()));
     }
 
     shape.push_back(num_classes);

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -2182,6 +2182,16 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         with self.assertRaises(torch._dynamo.exc.Unsupported):
             f(torch.zeros(2), A())
 
+    def test_one_hot(self):
+        @torch.compile
+        def f(x, y):
+            return torch.nn.functional.one_hot(x, y)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "Class values must be smaller than num_classes"
+        ):
+            f(torch.arange(0, 5) % 3, 0)
+
     def test_sort_out(self):
         dtype = torch.float32
         device = "cpu"

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -2187,9 +2187,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         def f(x, y):
             return torch.nn.functional.one_hot(x, y)
 
-        with self.assertRaisesRegex(
-            RuntimeError, "Class values must be smaller than num_classes"
-        ):
+        with self.assertRaisesRegex(RuntimeError, "num_classes should be positive"):
             f(torch.arange(0, 5) % 3, 0)
 
     def test_sort_out(self):


### PR DESCRIPTION
Fixes #146274

**Test Result**

```python
>>> import torch
>>> f = torch.nn.functional.one_hot
>>> a = torch.arange(0, 5) % 3  # [0,1,2,0,1]
>>> num_classes = 0
>>> torch.nn.functional.one_hot(a,num_classes)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Class values must be smaller than num_classes.

>>> torch.compile(torch.nn.functional.one_hot)(a,num_classes)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/zong/code/pytorch/torch/_dynamo/eval_frame.py", line 570, in _fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/zong/code/pytorch/torch/_dynamo/external_utils.py", line 48, in inner
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
RuntimeError: Class values must be smaller than num_classes.

```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @bdhirsh