### PR TITLE
Fix torch.nn.functional.one_hot param num_classes optional description

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5301,9 +5301,9 @@ See also `One-hot on Wikipedia`_ .
 
 Arguments:
     tensor (LongTensor): class values of any shape.
-    num_classes (int):  Total number of classes. If set to -1, the number
+    num_classes (int, optional):  Total number of classes. If set to -1, the number
         of classes will be inferred as one greater than the largest class
-        value in the input tensor.
+        value in the input tensor. Default: -1
 
 Returns:
     LongTensor that has one more dimension with 1 values at the


### PR DESCRIPTION
`torch.nn.functional.one_hot` [document](https://pytorch.org/docs/stable/generated/torch.nn.functional.one_hot.html) describe param `num_classes` not optional, but user can call method without pass it.

![image](https://github.com/user-attachments/assets/4e6d4feb-691f-451f-95b5-4ac11bac7bc2)

```python
>>> import torch
>>> a = torch.arange(0, 5) % 3  # [0,1,2,0,1]
>>> torch.nn.functional.one_hot(a)
tensor([[1, 0, 0],
        [0, 1, 0],
        [0, 0, 1],
        [1, 0, 0],
        [0, 1, 0]])

```

`num_classes` has default value -1

https://github.com/pytorch/pytorch/blob/93d98aca310af96dfdb6b2507d9ca80e6b1f74b7/aten/src/ATen/native/native_functions.yaml#L6154-L6157

## Test Result

![image](https://github.com/user-attachments/assets/2c7203b7-6226-4ebc-84c8-cbf912fc48e2)


