### PR TITLE
[c10d] Add hccl distributed backend to c10d data structures

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -92,7 +92,6 @@ __all__ = [
     "is_torchelastic_launched",
     "is_ucc_available",
     "is_xccl_available",
-    "is_hccl_available",
     "isend",
     "monitored_barrier",
     "new_group",
@@ -259,13 +258,10 @@ class Backend(str):  # noqa: SLOT000
     UCC = "ucc"
     MPI = "mpi"
     XCCL = "xccl"
-    HCCL = "hccl"
 
     _BackendPlugin = namedtuple("_BackendPlugin", ["creator_fn", "extended_api"])
 
     _plugins: dict[str, _BackendPlugin] = {}
-
-    # Out-of-tree backend such as hccl will append to this list calling register_backend
 
     backend_list = [UNDEFINED, GLOO, NCCL, XCCL, UCC, MPI]
 
@@ -274,7 +270,6 @@ class Backend(str):  # noqa: SLOT000
         "cpu": GLOO,
         "cuda": NCCL,
         "xpu": XCCL,
-        "hpu": HCCL,
     }
 
     backend_capability: dict[str, list[str]] = {
@@ -283,7 +278,6 @@ class Backend(str):  # noqa: SLOT000
         XCCL: ["xpu"],
         UCC: ["cpu", "cuda"],
         MPI: ["cpu", "cuda"],
-        HCCL: ["hpu"],
     }
 
     backend_type_map: dict[str, ProcessGroup.BackendType] = {
@@ -293,7 +287,6 @@ class Backend(str):  # noqa: SLOT000
         XCCL: ProcessGroup.BackendType.XCCL,
         UCC: ProcessGroup.BackendType.UCC,
         MPI: ProcessGroup.BackendType.MPI,
-        HCCL: ProcessGroup.BackendType.CUSTOM,
     }
 
     def __new__(cls, name: str):
@@ -1251,11 +1244,6 @@ def is_ucc_available() -> bool:
 def is_xccl_available() -> bool:
     """Check if the XCCL backend is available."""
     return _XCCL_AVAILABLE
-
-
-def is_hccl_available() -> bool:
-    """Check if the HCCL backend is registered."""
-    return "hccl" in Backend.backend_list
 
 
 def is_backend_available(backend: str) -> bool:


### PR DESCRIPTION
 # MOTIVATION
Intel Gaudi is an out-of-tree PyTorch accelerator having its own device /dispatch key ```hpu``` .
With this change we add entries for Gaudi's distributed backend ```hccl``` to the c10d Backend data structures.
This is to ensure that there is no naming conflict in case a new in-tree accelerator is introduced with the same backend name.


The Out-of-tree backends are registered calling https://github.com/pytorch/pytorch/blob/fd0cd6a08f706b7bb1dedb296217b6441e4fb9ff/torch/distributed/distributed_c10d.py#L302

Successful registration adds the backend name to the list : 
https://github.com/pytorch/pytorch/blob/fd0cd6a08f706b7bb1dedb296217b6441e4fb9ff/torch/distributed/distributed_c10d.py#L265

We are binding the process group creator constructs at run-time so if there are other distributed backend with the same device name they can safely add the device type to the dictionary 

https://github.com/pytorch/pytorch/blob/fd0cd6a08f706b7bb1dedb296217b6441e4fb9ff/torch/distributed/distributed_c10d.py#L274

And add another entry to the dictionary with the same backend name ( but different device name )
https://github.com/pytorch/pytorch/blob/fd0cd6a08f706b7bb1dedb296217b6441e4fb9ff/torch/distributed/distributed_c10d.py#L268

In addition the out-of-tree devices can utilize the ```backend_list``` to check for successful backend registration  eg: APIs like ```is_hccl_available```
 


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o