### PR TITLE
Implement blend operation for float, double, int in VEC ATen backend for SVE

### DIFF
--- a/aten/src/ATen/cpu/vec/sve/vec_double.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_double.h
@@ -49,10 +49,9 @@ public:
   }
   template <uint64_t mask>
   static Vectorized<double> blend(const Vectorized<double>& a, const Vectorized<double>& b) {
-    int VL = svcntd();  // Runtime vector length for double
     // Build an array of flags: each element is 1 if the corresponding bit in 'mask' is set, 0 otherwise.
-    int64_t flag_arr[VL];
-    for (int i = 0; i < VL; i++) {
+    __at_align__ int64_t flag_arr[size()];
+    for (int i = 0; i < size(); i++) {
       flag_arr[i] = (mask & (1ULL << i)) ? 1 : 0;
     }
     // Load the flag array into an SVE int64 vector.

--- a/aten/src/ATen/cpu/vec/sve/vec_double.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_double.h
@@ -47,6 +47,23 @@ public:
   operator svfloat64_t() const {
     return values;
   }
+  template <uint64_t mask>
+  static Vectorized<double> blend(const Vectorized<double>& a, const Vectorized<double>& b) {
+    int VL = svcntd();  // Runtime vector length for double
+    // Build an array of flags: each element is 1 if the corresponding bit in 'mask' is set, 0 otherwise.
+    int64_t flag_arr[VL];
+    for (int i = 0; i < VL; i++) {
+      flag_arr[i] = (mask & (1ULL << i)) ? 1 : 0;
+    }
+    // Load the flag array into an SVE int64 vector.
+    svint64_t int_mask = svld1_s64(svptrue_b64(), flag_arr);
+    // Compare each lane of int_mask to 0; returns an svbool_t predicate where true indicates a nonzero flag.
+    svbool_t blend_mask = svcmpne_n_s64(svptrue_b64(), int_mask, 0);
+
+    // Use svsel to select elements from b where the predicate is true, else from a.
+    svfloat64_t result = svsel(blend_mask, b.values, a.values);
+    return Vectorized<double>(result);
+  }
   static Vectorized<double> blendv(const Vectorized<double>& a, const Vectorized<double>& b,
                               const Vectorized<double>& mask_) {
     svbool_t mask = svcmpeq_s64(ptrue, svreinterpret_s64_f64(mask_),

--- a/aten/src/ATen/cpu/vec/sve/vec_float.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_float.h
@@ -47,6 +47,22 @@ public:
   operator svfloat32_t() const {
     return values;
   }
+  template <uint64_t mask>
+  static Vectorized<float> blend(const Vectorized<float>& a, const Vectorized<float>& b) {
+    int VL = svcntw();  // Runtime vector length for float
+    // Build an array of flags: each element is 1 if the corresponding bit in 'mask' is set, 0 otherwise.
+    int32_t flag_arr[VL];
+    for (int i = 0; i < VL; i++) {
+        flag_arr[i] = (mask & (1ULL << i)) ? 1 : 0;
+    }
+    // Load the flag array into an SVE int32 vector.
+    svint32_t int_mask = svld1_s32(svptrue_b32(), flag_arr);
+    // Compare each lane of int_mask to 0; returns an svbool_t predicate where true indicates a nonzero flag.
+    svbool_t blend_mask = svcmpne_n_s32(svptrue_b32(), int_mask, 0);
+    // Use svsel to select elements from b where the predicate is true, else from a.
+    svfloat32_t result = svsel_f32(blend_mask, b.values, a.values);
+    return Vectorized<float>(result);
+  }
   static Vectorized<float> blendv(const Vectorized<float>& a, const Vectorized<float>& b,
                               const Vectorized<float>& mask_) {
     svbool_t mask = svcmpeq_s32(ptrue, svreinterpret_s32_f32(mask_),

--- a/aten/src/ATen/cpu/vec/sve/vec_float.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_float.h
@@ -49,10 +49,9 @@ public:
   }
   template <uint64_t mask>
   static Vectorized<float> blend(const Vectorized<float>& a, const Vectorized<float>& b) {
-    int VL = svcntw();  // Runtime vector length for float
     // Build an array of flags: each element is 1 if the corresponding bit in 'mask' is set, 0 otherwise.
-    int32_t flag_arr[VL];
-    for (int i = 0; i < VL; i++) {
+    __at_align__ int32_t flag_arr[size()];
+    for (int i = 0; i < size(); i++) {
         flag_arr[i] = (mask & (1ULL << i)) ? 1 : 0;
     }
     // Load the flag array into an SVE int32 vector.

--- a/aten/src/ATen/cpu/vec/sve/vec_int.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_int.h
@@ -44,7 +44,7 @@ public:                                                                         
   }                                                                                                     \
   template <uint64_t mask>                                                                                      \
   static Vectorized<int##bit##_t> blend(const Vectorized<int##bit##_t>& a, const Vectorized<int##bit##_t>& b) { \
-    alignas(64) int##bit##_t flag_arr[size()];                                                                  \
+    __at_align__ int##bit##_t flag_arr[size()];                                                                 \
     for (int i = 0; i < size(); ++i) {                                                                          \
       flag_arr[i] = (i < 64 && (mask & (1ULL << i))) ? 1 : 0;                                                   \
     }                                                                                                           \

--- a/aten/src/ATen/cpu/vec/sve/vec_int.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_int.h
@@ -42,6 +42,15 @@ public:                                                                         
   operator svint##bit##_t() const {                                                                     \
     return values;                                                                                      \
   }                                                                                                     \
+  template <uint64_t mask>                                                                                      \
+  static Vectorized<int##bit##_t> blend(const Vectorized<int##bit##_t>& a, const Vectorized<int##bit##_t>& b) { \
+    alignas(64) int##bit##_t flag_arr[size()];                                                                  \
+    for (int i = 0; i < size(); ++i) {                                                                          \
+      flag_arr[i] = (i < 64 && (mask & (1ULL << i))) ? 1 : 0;                                                   \
+    }                                                                                                           \
+    svbool_t blend_mask = svcmpne_n_s##bit(svptrue_b##bit(), svld1_s##bit(svptrue_b##bit(), flag_arr), 0);      \
+    return Vectorized<int##bit##_t>(svsel_s##bit(blend_mask, b.values, a.values));                              \
+  }                                                                                                             \
   static Vectorized<int##bit##_t> blendv(const Vectorized<int##bit##_t>& a,                             \
                                         const Vectorized<int##bit##_t>& b,                             \
                                         const Vectorized<int##bit##_t>& mask_) {                       \

--- a/aten/src/ATen/test/vec_test_all_types.cpp
+++ b/aten/src/ATen/test/vec_test_all_types.cpp
@@ -1077,9 +1077,6 @@ namespace {
         blend_init(a, b);
         test_blendv<vec, VT, 0, vec::size()>(expected_val, a, b, mask);
     }
-// NOTE: In this test, blend<mask> is not required to implement SVE Vectorized::set.
-// so, this test is disabled for SVE.
-#if !defined(CPU_CAPABILITY_SVE)
     TYPED_TEST(BitwiseFloatsAdditional2, Blend) {
         using vec = TypeParam;
         using VT = ValueType<TypeParam>;
@@ -1093,7 +1090,6 @@ namespace {
         constexpr int64_t power_sets = 1LL << (vec::size());
         test_blend<vec, VT, power_sets - 1>(expected_val, a, b);
     }
-#endif
     template<typename vec, typename VT>
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
     void test_set(VT expected_val[vec::size()], VT a[vec::size()], VT b[vec::size()], int64_t count){


### PR DESCRIPTION
- Added support for SVE vectorized blend operation for float, double, int8_t, int16_t, int32_t and int64_t data types.
- Utilizes SVE ACLE intrinsic (svcntb, svcntw, svcmpne, svsel) to handle different vector lengths (VL) dynamically.
-  Ensured compatibility with SVE128, SVE256, and SVE512 hardware configurations.
-  Enabled back blend SVE vec tests 


**Testing:**
**a) Float DType:**
./vec_test_all_types_SVE256 --gtest_filter=BitwiseFloatsAdditional2/0.Blend    [Test Passed] on Graviton 3 machine (SVE256)
./vec_test_all_types_SVE128 --gtest_filter=BitwiseFloatsAdditional2/0.Blend    [Test Passed] on Graviton 4 machine (SVE128)

**b) Double DType:**
./vec_test_all_types_SVE256 --gtest_filter=BitwiseFloatsAdditional2/1.Blend    [Test Passed] on Graviton 3 machine (SVE256)
./vec_test_all_types_SVE128 --gtest_filter=BitwiseFloatsAdditional2/1.Blend    [Test Passed] on Graviton 4 machine (SVE128)

**c)Int DType:**
python3 test/inductor/test_cpu_repro.py CPUReproTests.test_vec_remainder 
[Test Passed] on Graviton 3 machine (SVE256) and on Graviton 4 machine (SVE128)
<img width="661" alt="grv4_test_case_passed" src="https://github.com/user-attachments/assets/5572fcc0-a861-4bd6-bf9e-356219ffe656" />


Fixes https://github.com/pytorch/pytorch/issues/146309


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @malfet @snadampal @milpuz01