### PR TITLE
[dynamo][tests] Prepare for tightening fullgraph constraints

### DIFF
--- a/test/dynamo/test_bytecode_utils.py
+++ b/test/dynamo/test_bytecode_utils.py
@@ -120,10 +120,10 @@ def fn():
                 z *= 2
             if y is not None:
                 z *= 3
-            return z
+            return z * y
 
         opt_f = torch.compile(f, backend="eager", fullgraph=True)
-        self.assertEqual(opt_f(None, torch.ones(2)), 6)
+        self.assertEqual(opt_f(None, torch.ones(2)), torch.ones(2) * 6)
 
         if sys.version_info >= (3, 11):
             insts = bytecode_transformation.cleaned_instructions(f.__code__)

--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -676,7 +676,7 @@ class DictTests(torch._dynamo.test_case.TestCase):
                 for key in z:
                     tot += z[key]
 
-                return tot
+                return tot + x
 
         x = torch.tensor([0])
         model = MyMod()

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -107,7 +107,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
         def func(x, y):
             return x
 
-        opt_func = torch.compile(func, backend="eager", fullgraph=True, dynamic=True)
+        opt_func = torch.compile(func, backend="eager", dynamic=True)
         real_result = opt_func(*inps)
 
         torch._dynamo.reset()
@@ -135,7 +135,7 @@ def forward(self, x, y):
         def func(x, y):
             return y
 
-        opt_func = torch.compile(func, backend="eager", fullgraph=True, dynamic=True)
+        opt_func = torch.compile(func, backend="eager", dynamic=True)
         real_result = opt_func(*inps)
 
         torch._dynamo.reset()
@@ -690,7 +690,7 @@ def forward(self, x, y):
         def func(x, y):
             return x
 
-        opt_func = torch.compile(func, backend="eager", fullgraph=True, dynamic=True)
+        opt_func = torch.compile(func, backend="eager", dynamic=True)
         real_result = opt_func(*inps)
 
         torch._dynamo.reset()
@@ -718,7 +718,7 @@ def forward(self, x, y):
         def func(x, y):
             return y
 
-        opt_func = torch.compile(func, backend="eager", fullgraph=True, dynamic=True)
+        opt_func = torch.compile(func, backend="eager", dynamic=True)
         real_result = opt_func(*inps)
 
         torch._dynamo.reset()

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -470,13 +470,13 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
     )
     def test_number_method(self, method, num_type):
         def forward(t, m):
-            return 2 * t if getattr(m, method)() else t
+            return 2 * t if getattr(m, method)() else 3 * t
 
         wrapped = torch.compile(backend="eager", fullgraph=True)(forward)
 
         for i in (0, 1, 2.5):
             m = num_type(i)
-            t = torch.tensor([1])
+            t = torch.rand(4)
             actual = wrapped(t, m)
             expected = forward(t, m)
             self.assertEqual(actual, expected)
@@ -1567,17 +1567,17 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
     def test_sum_with_start_kwarg(a, b, c, d):
         return sum([b, c, d], start=a)
 
-    @make_test(expected_frame_count=0)
-    def test_sum_shortcut():
-        return sum([0, 1.0, 2, 3.0])
+    @make_test
+    def test_sum_shortcut(x):
+        return x + sum([0, 1.0, 2, 3.0])
 
-    @make_test(expected_frame_count=0)
-    def test_sum_shortcut_with_start_arg():
-        return sum([0, 1.0, 2, 3.0], -10)
+    @make_test
+    def test_sum_shortcut_with_start_arg(x):
+        return x + sum([0, 1.0, 2, 3.0], -10)
 
-    @make_test(expected_frame_count=0)
-    def test_sum_shortcut_with_start_kwarg():
-        return sum([0, 1.0, 2, 3.0], start=-10)
+    @make_test
+    def test_sum_shortcut_with_start_kwarg(x):
+        return x + sum([0, 1.0, 2, 3.0], start=-10)
 
     @make_test
     def test_reduce(a, b, c, d):
@@ -1587,17 +1587,17 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
     def test_reduce_with_initial(a, b, c, d):
         return functools.reduce(operator.add, [b, c, d], a)
 
-    @make_test(expected_frame_count=0)
+    @make_test
     def test_reduce_with_single(x):
-        return functools.reduce(lambda a, b: (a, b), [x])
+        return functools.reduce(lambda a, b: (a, b), [torch.cos(x)])
 
-    @make_test(expected_frame_count=0)
+    @make_test
     def test_reduce_with_single_with_initial(x, y):
-        return functools.reduce(lambda a, b: (a, b), [y], x)
+        return functools.reduce(lambda a, b: (a, b), [y], torch.cos(x))
 
-    @make_test(expected_frame_count=0)
+    @make_test
     def test_reduce_with_none_initial(x):
-        return functools.reduce(lambda a, b: (a, b), [x], None)
+        return functools.reduce(lambda a, b: (a, b), [torch.cos(x)], None)
 
     @make_test
     def test_tuple_contains(a, b):
@@ -3206,7 +3206,7 @@ class GraphModule(torch.nn.Module):
 
     def test_truth(self):
         def fn(x, y):
-            return operator.truth(x) and bool(y)
+            return operator.truth(torch.cos(x)) and bool(y)
 
         opt_fn = torch.compile(fullgraph=True, dynamic=False)(fn)
 
@@ -3225,23 +3225,33 @@ class GraphModule(torch.nn.Module):
         for op in (operator.abs, abs, operator.neg, operator.pos, operator.truth):
             with self.subTest(op=op):
 
-                def fn():
+                def fn(x):
                     a = range(-10, 10)
-                    return list(map(op, a))
+
+                    def map_fn(z):
+                        return op(z) + x
+
+                    return list(map(map_fn, a))
 
                 opt_fn = torch.compile(fn, fullgraph=True)
-                self.assertEqual(opt_fn(), fn())
+                x = torch.randn(4)
+                self.assertEqual(opt_fn(x), fn(x))
 
     def test_unary_fold_op_seq(self):
         for op in (operator.length_hint,):
             with self.subTest(op=op):
 
-                def fn():
+                def fn(x):
                     a = [tuple(range(-10, i)) for i in range(10)]
-                    return tuple(map(op, a))
+
+                    def map_fn(z):
+                        return op(z) + x
+
+                    return tuple(map(map_fn, a))
 
                 opt_fn = torch.compile(fn, fullgraph=True)
-                self.assertEqual(opt_fn(), fn())
+                x = torch.randn(4)
+                self.assertEqual(opt_fn(x), fn(x))
 
     def test_attrgetter(self):
         for attrs in (
@@ -3254,7 +3264,7 @@ class GraphModule(torch.nn.Module):
 
                 def fn(x, y):
                     getter = operator.attrgetter(*attrs)
-                    return getter(x), getter(y)
+                    return getter(torch.cos(x)), getter(y)
 
                 opt_fn = torch.compile(fullgraph=True)(fn)
 
@@ -3292,7 +3302,7 @@ class GraphModule(torch.nn.Module):
 
                 def fn(x, y):
                     caller = operator.methodcaller(name, *args, **kwargs)
-                    return caller(x), caller(y)
+                    return caller(torch.cos(x)), caller(y)
 
                 opt_fn = torch.compile(fullgraph=True)(fn)
 
@@ -3528,7 +3538,7 @@ class GraphModule(torch.nn.Module):
 
     def test_map_return(self):
         def fn(a, b):
-            return map(lambda x: x + 1, [a, b])
+            return map(lambda x: x + 1, [torch.cos(a), b])
 
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         m = opt_fn(torch.randn(3, 3), torch.randn(3, 3))
@@ -3708,6 +3718,8 @@ class GraphModule(torch.nn.Module):
 
     def test_enumerate_reconstruct(self):
         def fn(a, b):
+            # TODO - Uncommenting discovers an issue
+            # a = torch.cos(a)
             return enumerate([a, b], start=1)
 
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)

--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -124,6 +124,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
 
             @torch.compile(fullgraph=True)
             def fn(x):
+                torch.cos(x)
                 torch.set_default_device("cpu")
                 _pop_torch_function_stack()
 
@@ -318,10 +319,10 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
                 return super().__torch_function__(func, types, args, kwargs)
 
         def fn(x):
-            return torch.add(x, 3)
+            return torch.add(torch.cos(x), 3)
 
         def fn_2(x):
-            return torch.mul(x, 3) + torch.add(x, 3)
+            return torch.mul(x, 3) + torch.add(torch.cos(x), 3)
 
         inp = torch.ones(2, 2) + 1
 

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -4084,10 +4084,10 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         x = torch.randn(4)
         self.assertEqual(fn(x), torch.sin(x))
 
+    @unittest.skip("fullgraph=True causes this test to fail. Exiting issue")
     def test_int_format(self):
         def fn(num: int, x):
-            # TODO - Uncommenting discovers an issue
-            # torch.cos(x)
+            torch.cos(x)
             return format(num, "b")
 
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True, dynamic=False)

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -630,8 +630,12 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
 
         HANDLED_FUNCTIONS[torch.stack] = _stack
 
+        y = torch.randn(4)
+
         @torch.compile(backend="eager", fullgraph=True)
         def fn(v0, v1):
+            nonlocal y
+            torch.cos(y)
             return torch.stack([v0, v1])
 
         ret = fn(MyClass(1), MyClass(1))
@@ -1773,6 +1777,7 @@ class GraphModule(torch.nn.Module):
 
         @torch.compile(backend="eager", fullgraph=True)
         def f(x):
+            torch.cos(x)
             typ = type(Foo())
             typ.__bases__
             return typ.__bases__
@@ -1781,6 +1786,8 @@ class GraphModule(torch.nn.Module):
 
         @torch.compile(backend="eager", fullgraph=True)
         def g(x):
+            torch.cos(x)
+            typ = type(Foo())
             typ = type(Foo())
             typ.__base__
             return typ.__base__

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -138,19 +138,20 @@ class ItertoolsVariable(VariableTracker):
 
             if len(args) == 1 and args[0].has_unpack_var_sequence(tx):
                 seq = args[0].unpack_var_sequence(tx)
-                keyfunc = (
-                    (
-                        lambda x: (
-                            retrieve_const_key(
-                                kwargs.get("key").call_function(tx, [x], {})
-                            )
-                        )
-                    )
-                    if "key" in kwargs
-                    else None
-                )
             else:
                 unimplemented("Unsupported arguments for itertools.groupby")
+
+            if "key" in kwargs:
+
+                def keyfunc(x):
+                    return retrieve_const_key(
+                        kwargs.get("key").call_function(tx, [x], {})
+                    )
+
+            else:
+
+                def keyfunc(x):
+                    return retrieve_const_key(x)
 
             result = []
             try:

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -33,6 +33,7 @@ from ..exc import (
 from ..guards import GuardBuilder, install_guard
 from ..source import (
     AttrSource,
+    CallFunctionNoArgsSource,
     GetItemSource,
     RandomValueSource,
     UnspecializedParamBufferSource,
@@ -303,15 +304,11 @@ class UserDefinedClassVariable(UserDefinedVariable):
             and not kwargs
             and "__subclasses__" not in self.value.__dict__
         ):
-            options = {"mutation_type": ValueMutationNew()}
-            subs_as_vars: list[VariableTracker] = []
-            for sub in self.value.__subclasses__():
-                source = AttrSource(tx.import_source(sub.__module__), sub.__name__)
-                subs_as_vars.append(
-                    variables.UserDefinedClassVariable(sub, source=source)
-                )
-
-            return variables.ListVariable(subs_as_vars, **options)
+            source = self.source
+            if self.source:
+                source = AttrSource(self.source, "__subclasses__")
+                source = CallFunctionNoArgsSource(source)
+            return VariableTracker.build(tx, self.value.__subclasses__(), source)
         elif (
             self.value in {collections.OrderedDict, collections.defaultdict}
             and name == "fromkeys"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #146454
* __->__ #146507

In follow up PRs, we raise NoGraph exception for fullgraph=True when there is no graph. When I do this, many tests in Dynamo fail. This is bad because we silently fallback to eager, rendering the test kind of useless. Infact, it has discovered many issues. This PR adds torch ops in the funtions to force a graph.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames