### PR TITLE
[torch] fix exception types in custom class magic setattr/getattr

### DIFF
--- a/test/jit/test_torchbind.py
+++ b/test/jit/test_torchbind.py
@@ -445,6 +445,10 @@ class TestTorchbind(JitTestCase):
 
         self.checkScript(fn, (1,))
 
+    def test_hasattr(self):
+        ss = torch.classes._TorchScriptTesting._StackString(["foo", "bar"])
+        self.assertFalse(hasattr(ss, "baz"))
+
     def test_default_args(self):
         def fn() -> int:
             obj = torch.classes._TorchScriptTesting._DefaultArgs()

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -785,7 +785,8 @@ void initJitScriptBindings(PyObject* module) {
                 try {
                   return toPyObject(self.attr(name));
                 } catch (const ObjectAttributeError& err) {
-                  throw AttributeError("%s", err.what());
+                  pybind11::set_error(PyExc_AttributeError, err.what());
+                  throw py::error_already_set();
                 }
               })
           .def(
@@ -806,7 +807,8 @@ void initJitScriptBindings(PyObject* module) {
                   }
                   return toPyObject(self.attr(name));
                 } catch (const ObjectAttributeError& err) {
-                  throw AttributeError("%s", err.what());
+                  pybind11::set_error(PyExc_AttributeError, err.what());
+                  throw py::error_already_set();
                 }
               })
           .def(
@@ -836,7 +838,8 @@ void initJitScriptBindings(PyObject* module) {
                   auto ivalue = toIValue(std::move(value), type);
                   self.setattr(name, ivalue);
                 } catch (const ObjectAttributeError& err) {
-                  throw AttributeError("%s", err.what());
+                  pybind11::set_error(PyExc_AttributeError, err.what());
+                  throw py::error_already_set();
                 }
               })
           .def(


### PR DESCRIPTION
Summary:
`c10::AttributeError` is not automatically converted to Python AttributeError, it needs some special macros (e.g. `HANDLE_TH_ERRORS`).

Some Python functions like `hasattr` rely on the type of the throw exception to be correct.

We don't need the fully generality of those macros, so just do a targeted error type conversion here.

Test Plan: added unit test

Differential Revision: D69197217




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel