### PR TITLE
  [aoti] Add a Tracing Context with FakeTensorMode to AOT Inductor Lowering

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -4010,6 +4010,16 @@ class AOTInductorTestsTemplate:
 
         self.check_model(Model(), example_inputs)
 
+    @dynamo_config.patch({"capture_scalar_outputs": True})
+    def test_unbacked_arg(self):
+        class Model(torch.nn.Module):
+            def forward(self):
+                full = torch.full((), 11)
+                i0 = full.item()
+                return (torch.full((i0,), 0.0),)
+
+        self.check_model(Model(), ())
+
     @common_utils.parametrize("mark_unbacked", (True, False))
     def test_unbacked_equals_input_size_runtime_assertion(self, mark_unbacked: bool):
         # This test checks the unbacked symint runtime assertions, for the following cases:

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -98,9 +98,11 @@ def _freeze(
     # See the details in fx_codegen_and_compile of compile_fx.py.
     view_to_reshape(aot_autograd_gm)
 
-    if tracing_context := torch._guards.TracingContext.try_get():
+    tracing_context = torch._guards.TracingContext.try_get()
+
+    # tracing_context.params_flat_unwrap_subclasses might be None for aot export
+    if tracing_context and tracing_context.params_flat_unwrap_subclasses:
         fw_metadata = tracing_context.fw_metadata
-        assert tracing_context.params_flat_unwrap_subclasses is not None
         params_flat = tracing_context.params_flat_unwrap_subclasses
         assert fw_metadata is not None and params_flat is not None
 


### PR DESCRIPTION
Summary:

Fixes https://github.com/pytorch/pytorch/issues/118304

In the issue, we have problem with unbacked symints because the fake tensor mode is not detected by AOTI when there's no input. 

In the current implementation, AOTI can only detect fake mode from node.meta["val"] for placeholder nodes, which is problematic when there's no inputs. 

The solution is we also try to detect fake mode from other nodes' node.meta["val"] or node.meta["example_value"], and we add a tracing context with the detected fake mode around the AOTI lowering path. 

After adding the tracing context, we also need to make some changes so AOTI goes into the right branches, specifically for freezing=True config. Previously we don't have a tracing context for AOTI, so we used the`tracing_context := torch._guards.TracingContext.try_get()` check to separate the AOT and JIT inductor path when freezing the graph module. Now we change it to either explicitly guard on `V.aot_compilation` when `V` is available, or guard on `tracing_context.params_flat_unwrap_subclasses is not None` when `V` is not available. 

To summarize, the fake mode detection logic in inductor is now like this:


- In AOT inductor, we get fake_mode from placeholder node meta, val or example_values. When there's no user inputs, we look at other nodes' meta to determine the fake_mode.

- In JIT inductor, we get fake_mode from tracing context. In addition, if we are in cpp_wrapper mode and trying to create fake_tensor, we need to convert inputs to use the same fake_mode as the tracing context fake mode. The inputs might have a different fake_mode than the tracing context fake_mode if they used the fake_mode [here](https://github.com/pytorch/pytorch/blob/v2.6.0/torch/_dynamo/output_graph.py#L1373-L1379) or [here](https://github.com/pytorch/pytorch/blob/v2.6.0/torch/fx/experimental/proxy_tensor.py#L412).



Test Plan:
```
buck run @fbcode//mode/dev-nosan //caffe2/test/inductor:test_aot_inductor -- -r unbacked_arg
buck run @fbcode//mode/dev-nosan //caffe2/test/inductor:test_aot_inductor --  -r test_buffer_mutation_and_force_mmap_weights_cpu
buck run @fbcode//mode/dev-nosan //caffe2/test/inductor:test_aot_inductor -- -r test_no_args
buck run @fbcode//mode/dev-nosan //caffe2/test/inductor:test_inductor -- -r test_functionalize_rng_wrappers_cpu
buck run @fbcode//mode/dev-nosan //caffe2/test/inductor:torchinductor_dynamic_shapes -- -r aoti_eager_with_scalar_dynamic_shapes
buck run @fbcode//mode/dev-nosan //caffe2/test/inductor:test_inductor -- -r  test_aoti_eager
python test/inductor/test_cpu_cpp_wrapper.py TestCppWrapper.test_adding_tensor_offsets_cpu_cpp_wrapper

```

Differential Revision: D69158049




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @desertfire @benjaminglass1 @yf225