### PR TITLE
[export] Fix tensor variants to scalar variants.

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1826,7 +1826,7 @@ graph():
     %p_p1 : [num_users=1] = placeholder[target=p_p1]
     %p_p2 : [num_users=1] = placeholder[target=p_p2]
     %x : [num_users=1] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Scalar](args = (%p_p1, 2), kwargs = {})
     %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, %p_p2), kwargs = {})
     %sum_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add,), kwargs = {})
     %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %sum_1), kwargs = {})
@@ -1842,7 +1842,7 @@ graph():
     %p_parametrizations_p2_original0 : [num_users=1] = placeholder[target=p_parametrizations_p2_original0]
     %p_parametrizations_p2_original1 : [num_users=1] = placeholder[target=p_parametrizations_p2_original1]
     %x : [num_users=1] = placeholder[target=x]
-    %mul : [num_users=2] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %mul : [num_users=2] = call_function[target=torch.ops.aten.mul.Scalar](args = (%p_p1, 2), kwargs = {})
     %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, %p_parametrizations_p2_original0), kwargs = {})
     %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, %p_parametrizations_p2_original1), kwargs = {})
     %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %add_1), kwargs = {})
@@ -1890,7 +1890,7 @@ graph():
     %p_p1 : [num_users=1] = placeholder[target=p_p1]
     %p_p2 : [num_users=1] = placeholder[target=p_p2]
     %x : [num_users=2] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Scalar](args = (%p_p1, 2), kwargs = {})
     %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %mul), kwargs = {})
     %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %p_p2), kwargs = {})
     %sum_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add_1,), kwargs = {})
@@ -1911,7 +1911,7 @@ graph():
     %p_parametrizations_p2_original2 : [num_users=1] = placeholder[target=p_parametrizations_p2_original2]
     %p_parametrizations_p2_original3 : [num_users=1] = placeholder[target=p_parametrizations_p2_original3]
     %x : [num_users=2] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Scalar](args = (%p_p1, 2), kwargs = {})
     %add : [num_users=4] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %mul), kwargs = {})
     %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %p_parametrizations_p2_original0), kwargs = {})
     %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %p_parametrizations_p2_original1), kwargs = {})
@@ -1966,7 +1966,7 @@ graph():
     %p_p2 : [num_users=1] = placeholder[target=p_p2]
     %b_b1 : [num_users=1] = placeholder[target=b_b1]
     %x : [num_users=1] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Scalar](args = (%p_p1, 2), kwargs = {})
     %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, %p_p2), kwargs = {})
     %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %b_b1), kwargs = {})
     %sum_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add_1,), kwargs = {})
@@ -2024,7 +2024,7 @@ graph():
     %p_bar_p2 : [num_users=1] = placeholder[target=p_bar_p2]
     %b_bar_b1 : [num_users=1] = placeholder[target=b_bar_b1]
     %x : [num_users=1] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_bar_p1, 2), kwargs = {})
+    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Scalar](args = (%p_bar_p1, 2), kwargs = {})
     %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, %p_bar_p2), kwargs = {})
     %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %b_bar_b1), kwargs = {})
     %sum_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add_1,), kwargs = {})
@@ -2067,9 +2067,9 @@ graph():
     %p_p1 : [num_users=1] = placeholder[target=p_p1]
     %p_p2 : [num_users=1] = placeholder[target=p_p2]
     %x : [num_users=1] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Scalar](args = (%p_p1, 2), kwargs = {})
     %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, %p_p2), kwargs = {})
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, 4), kwargs = {})
+    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%add, 4), kwargs = {})
     %getattr_22 : [num_users=1] = call_function[target=builtins.getattr](args = (%add_1, elem), kwargs = {})
     %getattr_27 : [num_users=1] = call_function[target=builtins.getattr](args = (%getattr_22, elem), kwargs = {})
     %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %getattr_27), kwargs = {})
@@ -2109,9 +2109,9 @@ graph():
     %p_p1 : [num_users=1] = placeholder[target=p_p1]
     %p_p2 : [num_users=1] = placeholder[target=p_p2]
     %x : [num_users=1] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Scalar](args = (%p_p1, 2), kwargs = {})
     %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, %p_p2), kwargs = {})
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, 4), kwargs = {})
+    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Sclar](args = (%add, 4), kwargs = {})
     %getattr_22 : [num_users=1] = call_function[target=builtins.getattr](args = (%add_1, elem), kwargs = {})
     %getattr_27 : [num_users=1] = call_function[target=builtins.getattr](args = (%getattr_22, elem), kwargs = {})
     %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %getattr_27), kwargs = {})
@@ -2152,12 +2152,12 @@ graph():
     %p_p1 : [num_users=1] = placeholder[target=p_p1]
     %p_p2 : [num_users=1] = placeholder[target=p_p2]
     %x : [num_users=1] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Scalar](args = (%p_p1, 2), kwargs = {})
     %add : [num_users=2] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, %p_p2), kwargs = {})
     %getattr_33 : [num_users=1] = call_function[target=builtins.getattr](args = (%add, a), kwargs = {})
     %getattr_38 : [num_users=1] = call_function[target=builtins.getattr](args = (%getattr_33, elem), kwargs = {})
     %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %getattr_38), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_1, 4), kwargs = {})
+    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%add_1, 4), kwargs = {})
     %getattr_45 : [num_users=1] = call_function[target=builtins.getattr](args = (%add_2, a), kwargs = {})
     %getattr_50 : [num_users=1] = call_function[target=builtins.getattr](args = (%getattr_45, elem), kwargs = {})
     %add_3 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %getattr_50), kwargs = {})
@@ -2196,12 +2196,12 @@ graph():
     %p_p1 : [num_users=1] = placeholder[target=p_p1]
     %p_p2 : [num_users=1] = placeholder[target=p_p2]
     %x : [num_users=1] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Scalar](args = (%p_p1, 2), kwargs = {})
     %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %mul), kwargs = {})
     %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %p_p2), kwargs = {})
     %getattr_21 : [num_users=1] = call_function[target=builtins.getattr](args = (%add_1, elem), kwargs = {})
     %getattr_26 : [num_users=1] = call_function[target=builtins.getattr](args = (%getattr_21, elem), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%getattr_26, 4), kwargs = {})
+    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%getattr_26, 4), kwargs = {})
     return (add_2,)""",
         )
         ep = export(m, (ref_x,))
@@ -3372,8 +3372,8 @@ def forward(self, x):
             str(ep_for_training.graph_module.code).strip(),
             """\
 def forward(self, b_buffer, x):
-    add_ = torch.ops.aten.add_.Tensor(x, 5);  x = None
-    add__1 = torch.ops.aten.add_.Tensor(b_buffer, 5);  b_buffer = None
+    add_ = torch.ops.aten.add_.Scalar(x, 5);  x = None
+    add__1 = torch.ops.aten.add_.Scalar(b_buffer, 5);  b_buffer = None
     add = torch.ops.aten.add.Tensor(add_, add__1);  add_ = add__1 = None
     return (add,)""",
         )
@@ -3384,8 +3384,8 @@ def forward(self, b_buffer, x):
 def forward(self, x):
     x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
     buffer = self.buffer
-    add_ = torch.ops.aten.add_.Tensor(x, 5);  x = None
-    add__1 = torch.ops.aten.add_.Tensor(buffer, 5);  buffer = None
+    add_ = torch.ops.aten.add_.Scalar(x, 5);  x = None
+    add__1 = torch.ops.aten.add_.Scalar(buffer, 5);  buffer = None
     add = torch.ops.aten.add.Tensor(add_, add__1);  add_ = add__1 = None
     return pytree.tree_unflatten((add,), self._out_spec)""",
         )
@@ -3482,7 +3482,7 @@ def forward(self, x):
             str(ep_for_inference.graph_module.code).strip(),
             """\
 def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
-    add = torch.ops.aten.add.Tensor(b_buffer, 5);  b_buffer = None
+    add = torch.ops.aten.add.Scalar(b_buffer, 5);  b_buffer = None
     permute = torch.ops.aten.permute.default(p_linear_weight, [1, 0]);  p_linear_weight = None
     addmm = torch.ops.aten.addmm.default(p_linear_bias, x, permute);  p_linear_bias = x = permute = None
     sum_1 = torch.ops.aten.sum.dim_IntList(add, [])
@@ -5665,10 +5665,32 @@ def forward(self, x):
     bn_running_var = self.bn.running_var
     bn_num_batches_tracked = self.bn.num_batches_tracked
     conv2d = torch.ops.aten.conv2d.default(x, conv_weight, conv_bias);  x = conv_weight = conv_bias = None
-    add_ = torch.ops.aten.add_.Tensor(bn_num_batches_tracked, 1);  bn_num_batches_tracked = add_ = None
+    add_ = torch.ops.aten.add_.Scalar(bn_num_batches_tracked, 1);  bn_num_batches_tracked = add_ = None
     batch_norm = torch.ops.aten.batch_norm.default(conv2d, bn_weight, bn_bias, bn_running_mean, bn_running_var, True, 0.1, 1e-05, True);  conv2d = bn_weight = bn_bias = bn_running_mean = bn_running_var = None
     return pytree.tree_unflatten((batch_norm,), self._out_spec)""",
         )
+
+    def test_tensor_scalar_variant(self):
+        class Module(torch.nn.Module):
+            def forward(self, x, y):
+                n = x.item()
+                return y + n, y * n, y - n
+
+        fn = Module()
+        ep = export(
+            fn,
+            (torch.tensor(1), torch.randn(4, 3)),
+        )
+        count = 0
+        for node in ep.graph.nodes:
+            if node.op == "call_function":
+                self.assertNotEqual(node.target._overloadname, "Tensor")
+                if node.target._overloadname == "Scalar":
+                    count += 1
+
+        self.assertEqual(count, 3)
+        test_inp = (torch.tensor(2), torch.randn(4, 3))
+        self.assertEqual(ep.module()(*test_inp), fn(*test_inp))
 
     def test_constrain_size_in_eager(self):
         class Module(torch.nn.Module):
@@ -6734,7 +6756,7 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, c_
     conv1d = torch.ops.aten.conv1d.default(y, p_conv1d_weight, p_conv1d_bias);  y = p_conv1d_weight = p_conv1d_bias = None
     permute = torch.ops.aten.permute.default(c_linear_weight, [1, 0]);  c_linear_weight = None
     matmul = torch.ops.aten.matmul.default(conv2d, permute);  conv2d = permute = None
-    mul = torch.ops.aten.mul.Tensor(c_linear_bias, 2);  c_linear_bias = None
+    mul = torch.ops.aten.mul.Scalar(c_linear_bias, 2);  c_linear_bias = None
     add = torch.ops.aten.add.Tensor(matmul, mul);  matmul = mul = None
     cos = torch.ops.aten.cos.default(add);  add = None
     sum_1 = torch.ops.aten.sum.default(conv1d);  conv1d = None
@@ -9283,8 +9305,8 @@ graph():
             str(ep.graph_module.code).strip(),
             """\
 def forward(self, c_params, x):
-    add = torch.ops.aten.add.Tensor(c_params, 2)
-    add_1 = torch.ops.aten.add.Tensor(c_params, 1);  c_params = None
+    add = torch.ops.aten.add.Scalar(c_params, 2)
+    add_1 = torch.ops.aten.add.Scalar(c_params, 1);  c_params = None
     sub = torch.ops.aten.sub.Tensor(add, add_1);  add = add_1 = None
     sum_1 = torch.ops.aten.sum.dim_IntList(sub, []);  sub = None
     sum_2 = torch.ops.aten.sum.dim_IntList(x, []);  x = None
@@ -9329,8 +9351,8 @@ def forward(self, c_params, x):
             str(ep.graph_module.code).strip(),
             """\
 def forward(self, c_submod_params, x):
-    add = torch.ops.aten.add.Tensor(c_submod_params, 2)
-    add_1 = torch.ops.aten.add.Tensor(c_submod_params, 1);  c_submod_params = None
+    add = torch.ops.aten.add.Scalar(c_submod_params, 2)
+    add_1 = torch.ops.aten.add.Scalar(c_submod_params, 1);  c_submod_params = None
     sub = torch.ops.aten.sub.Tensor(add, add_1);  add = add_1 = None
     sum_1 = torch.ops.aten.sum.dim_IntList(sub, []);  sub = None
     sum_2 = torch.ops.aten.sum.dim_IntList(x, []);  x = None
@@ -9457,15 +9479,15 @@ def forward(self, c_submod_params, x):
             """\
 graph():
     %x : [num_users=1] = placeholder[target=x]
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, 3), kwargs = {})
+    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%x, 3), kwargs = {})
     %n : [num_users=1] = call_module[target=n](args = (%add,), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n, 4), kwargs = {})
+    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%n, 4), kwargs = {})
     %n_1 : [num_users=1] = call_module[target=n@1](args = (%add_2,), kwargs = {})
-    %add_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n_1, 5), kwargs = {})
+    %add_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%n_1, 5), kwargs = {})
     %p : [num_users=1] = call_module[target=p](args = (%add_4,), kwargs = {})
-    %add_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p, 6), kwargs = {})
+    %add_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%p, 6), kwargs = {})
     %p_1 : [num_users=1] = call_module[target=p](args = (%add_6,), kwargs = {})
-    %add_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p_1, 7), kwargs = {})
+    %add_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%p_1, 7), kwargs = {})
     return (add_8,)""",
             ["", "n", "n@1", "p"],
             [("n@1", "p")],
@@ -9477,15 +9499,15 @@ graph():
             """\
 graph():
     %x : [num_users=1] = placeholder[target=x]
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, 3), kwargs = {})
+    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%x, 3), kwargs = {})
     %n : [num_users=1] = call_module[target=n](args = (%add,), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n, 4), kwargs = {})
+    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%n, 4), kwargs = {})
     %n_1 : [num_users=1] = call_module[target=n@1](args = (%add_2,), kwargs = {})
-    %add_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n_1, 5), kwargs = {})
+    %add_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%n_1, 5), kwargs = {})
     %p : [num_users=1] = call_module[target=p](args = (%add_4,), kwargs = {})
-    %add_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p, 6), kwargs = {})
+    %add_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%p, 6), kwargs = {})
     %p_1 : [num_users=1] = call_module[target=p@1](args = (%add_6,), kwargs = {})
-    %add_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p_1, 7), kwargs = {})
+    %add_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%p_1, 7), kwargs = {})
     return (add_8,)""",
             ["", "n", "n@1", "p", "p@1"],
             [("n", "p"), ("n@1", "p@1")],
@@ -9497,15 +9519,15 @@ graph():
             """\
 graph():
     %x : [num_users=1] = placeholder[target=x]
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, 3), kwargs = {})
+    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%x, 3), kwargs = {})
     %n : [num_users=1] = call_module[target=n](args = (%add,), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n, 4), kwargs = {})
+    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%n, 4), kwargs = {})
     %n_1 : [num_users=1] = call_module[target=n](args = (%add_2,), kwargs = {})
-    %add_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n_1, 5), kwargs = {})
+    %add_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%n_1, 5), kwargs = {})
     %p : [num_users=1] = call_module[target=p](args = (%add_4,), kwargs = {})
-    %add_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p, 6), kwargs = {})
+    %add_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%p, 6), kwargs = {})
     %p_1 : [num_users=1] = call_module[target=p@1](args = (%add_6,), kwargs = {})
-    %add_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p_1, 7), kwargs = {})
+    %add_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%p_1, 7), kwargs = {})
     return (add_8,)""",
             ["", "n", "p", "p@1"],
             [("n", "p")],
@@ -9517,15 +9539,15 @@ graph():
             """\
 graph():
     %x : [num_users=1] = placeholder[target=x]
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, 3), kwargs = {})
+    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%x, 3), kwargs = {})
     %n : [num_users=1] = call_module[target=n](args = (%add,), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n, 4), kwargs = {})
+    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%n, 4), kwargs = {})
     %n_1 : [num_users=1] = call_module[target=n@1](args = (%add_2,), kwargs = {})
-    %add_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n_1, 5), kwargs = {})
+    %add_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%n_1, 5), kwargs = {})
     %p : [num_users=1] = call_module[target=p](args = (%add_4,), kwargs = {})
-    %add_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p, 6), kwargs = {})
+    %add_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%p, 6), kwargs = {})
     %p_1 : [num_users=1] = call_module[target=p@1](args = (%add_6,), kwargs = {})
-    %add_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p_1, 7), kwargs = {})
+    %add_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Scalar](args = (%p_1, 7), kwargs = {})
     return (add_8,)""",
             ["", "n", "n@1", "p", "p@1"],
             [("n", "p@1"), ("p", "n@1")],
@@ -9775,7 +9797,7 @@ def forward(self, b_t, x, y):
             str(exported_program.graph_module.true_graph_0.submod_1.code.strip()),
             """\
 def forward(self, x, b_t, y):
-    sub = torch.ops.aten.sub.Tensor(x, 1);  x = None
+    sub = torch.ops.aten.sub.Scalar(x, 1);  x = None
     add = torch.ops.aten.add.Tensor(sub, b_t);  sub = b_t = None
     add_1 = torch.ops.aten.add.Tensor(add, y);  add = y = None
     return (add_1,)""",

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -800,13 +800,13 @@ def forward(self, token, obj_attr, x):
             """\
 def forward(self, x):
     x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
-    add = torch.ops.aten.add.Tensor(x, 1);  x = None
+    add = torch.ops.aten.add.Scalar(x, 1);  x = None
     sin = torch.ops.aten.sin.default(add);  add = None
     sum_1 = torch.ops.aten.sum.default(sin);  sin = None
     submod_4 = self.submod_2
     add_1 = torch.ops.higher_order.wrap_with_set_grad_enabled(False, submod_4, sum_1);  submod_4 = sum_1 = None
     getitem = add_1[0];  add_1 = None
-    sub = torch.ops.aten.sub.Tensor(getitem, 1)
+    sub = torch.ops.aten.sub.Scalar(getitem, 1)
     return pytree.tree_unflatten((getitem, sub), self._out_spec)
     """,
         )
@@ -819,13 +819,13 @@ def forward(self, x):
             """\
 def forward(self, x):
     x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
-    add = torch.ops.aten.add.Tensor(x, 1);  x = None
+    add = torch.ops.aten.add.Scalar(x, 1);  x = None
     sin = torch.ops.aten.sin.default(add);  add = None
     sum_1 = torch.ops.aten.sum.default(sin);  sin = None
     submod_4 = self.submod_2
     add_1 = torch.ops.higher_order.wrap_with_set_grad_enabled(False, submod_4, sum_1);  submod_4 = sum_1 = None
     getitem = add_1[0];  add_1 = None
-    sub = torch.ops.aten.sub.Tensor(getitem, 1)
+    sub = torch.ops.aten.sub.Scalar(getitem, 1)
     return pytree.tree_unflatten((getitem, sub), self._out_spec)
     """,
         )
@@ -838,13 +838,13 @@ def forward(self, x):
             """\
 def forward(self, x):
     x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
-    add = torch.ops.aten.add.Tensor(x, 1);  x = None
+    add = torch.ops.aten.add.Scalar(x, 1);  x = None
     sin = torch.ops.aten.sin.default(add);  add = None
     sum_1 = torch.ops.aten.sum.default(sin);  sin = None
     submod_3 = self.submod_1
     add_1 = torch.ops.higher_order.wrap_with_set_grad_enabled(False, submod_3, sum_1);  submod_3 = sum_1 = None
     getitem = add_1[0];  add_1 = None
-    sub = torch.ops.aten.sub.Tensor(getitem, 1)
+    sub = torch.ops.aten.sub.Scalar(getitem, 1)
     return pytree.tree_unflatten((getitem, sub), self._out_spec)
     """,
         )
@@ -857,11 +857,11 @@ def forward(self, x):
             """\
 def forward(self, x):
     x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
-    add = torch.ops.aten.add.Tensor(x, 1);  x = None
+    add = torch.ops.aten.add.Scalar(x, 1);  x = None
     submod_5 = self.submod_1
     sum_1 = torch.ops.higher_order.wrap_with_set_grad_enabled(True, submod_5, add);  submod_5 = add = None
     getitem = sum_1[0];  sum_1 = None
-    add_1 = torch.ops.aten.add.Tensor(getitem, 1);  getitem = None
+    add_1 = torch.ops.aten.add.Scalar(getitem, 1);  getitem = None
     submod_6 = self.submod_3
     sub = torch.ops.higher_order.wrap_with_set_grad_enabled(True, submod_6, add_1);  submod_6 = None
     getitem_1 = sub[0];  sub = None
@@ -877,7 +877,7 @@ def forward(self, x):
             """\
 def forward(self, x):
     x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
-    add = torch.ops.aten.add.Tensor(x, 1);  x = None
+    add = torch.ops.aten.add.Scalar(x, 1);  x = None
     sin = torch.ops.aten.sin.default(add)
     sum_1 = torch.ops.aten.sum.default(sin);  sin = None
     cos = torch.ops.aten.cos.default(add);  add = None
@@ -886,8 +886,8 @@ def forward(self, x):
     wrap_with_set_grad_enabled = torch.ops.higher_order.wrap_with_set_grad_enabled(False, submod_3, sum_1, sum_2);  submod_3 = sum_1 = sum_2 = None
     add_1 = wrap_with_set_grad_enabled[0]
     add_2 = wrap_with_set_grad_enabled[1];  wrap_with_set_grad_enabled = None
-    sub = torch.ops.aten.sub.Tensor(add_1, 1)
-    sub_1 = torch.ops.aten.sub.Tensor(add_2, 1)
+    sub = torch.ops.aten.sub.Scalar(add_1, 1)
+    sub_1 = torch.ops.aten.sub.Scalar(add_2, 1)
     return pytree.tree_unflatten((add_1, add_2, sub, sub_1), self._out_spec)
     """,  # noqa: B950
         )
@@ -902,13 +902,13 @@ def forward(self, x):
             """\
 def forward(self, x):
     x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
-    add = torch.ops.aten.add.Tensor(x, 1);  x = None
+    add = torch.ops.aten.add.Scalar(x, 1);  x = None
     submod_5 = self.submod_1
     wrap_with_set_grad_enabled = torch.ops.higher_order.wrap_with_set_grad_enabled(True, submod_5, add);  submod_5 = add = None
     sum_1 = wrap_with_set_grad_enabled[0]
     sum_2 = wrap_with_set_grad_enabled[1];  wrap_with_set_grad_enabled = None
-    add_1 = torch.ops.aten.add.Tensor(sum_1, 1);  sum_1 = None
-    add_2 = torch.ops.aten.add.Tensor(sum_2, 1);  sum_2 = None
+    add_1 = torch.ops.aten.add.Scalar(sum_1, 1);  sum_1 = None
+    add_2 = torch.ops.aten.add.Scalar(sum_2, 1);  sum_2 = None
     submod_6 = self.submod_3
     wrap_with_set_grad_enabled_1 = torch.ops.higher_order.wrap_with_set_grad_enabled(True, submod_6, add_1, add_2);  submod_6 = None
     sub = wrap_with_set_grad_enabled_1[0]
@@ -957,8 +957,8 @@ def forward(self, x1, x2):
             """\
 def forward(self, x1, x2):
     _set_grad_enabled = torch._C._set_grad_enabled(True);  _set_grad_enabled = None
-    add = torch.ops.aten.add.Tensor(x1, 1);  x1 = None
-    add_1 = torch.ops.aten.add.Tensor(x2, 1);  x2 = None
+    add = torch.ops.aten.add.Scalar(x1, 1);  x1 = None
+    add_1 = torch.ops.aten.add.Scalar(x2, 1);  x2 = None
     return (add, add_1)
     """,
         )
@@ -977,8 +977,8 @@ def forward(self, add, add_1):
             """\
 def forward(self, sin, cos):
     _set_grad_enabled_2 = torch._C._set_grad_enabled(True);  _set_grad_enabled_2 = None
-    add_2 = torch.ops.aten.add.Tensor(sin, 1);  sin = None
-    add_3 = torch.ops.aten.add.Tensor(cos, 1);  cos = None
+    add_2 = torch.ops.aten.add.Scalar(sin, 1);  sin = None
+    add_3 = torch.ops.aten.add.Scalar(cos, 1);  cos = None
     return (add_2, add_3)
     """,
         )
@@ -993,14 +993,14 @@ def forward(self, sin, cos):
 def forward(self, x):
     x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
     submod_3 = self.submod_3
-    add = torch.ops.aten.add.Tensor(x, 1);  x = None
+    add = torch.ops.aten.add.Scalar(x, 1);  x = None
     sin = torch.ops.higher_order.wrap_with_set_grad_enabled(True, submod_3, add);  submod_3 = add = None
     getitem_2 = sin[0];  sin = None
     cos = torch.ops.aten.cos.default(getitem_2);  getitem_2 = None
     submod_4 = self.submod_1
     add_1 = torch.ops.higher_order.wrap_with_autocast('cpu', None, False, None, submod_4, cos);  submod_4 = cos = None
     getitem = add_1[0];  add_1 = None
-    sub = torch.ops.aten.sub.Tensor(getitem, 1)
+    sub = torch.ops.aten.sub.Scalar(getitem, 1)
     return pytree.tree_unflatten((getitem, sub), self._out_spec)
     """,
         )
@@ -1016,7 +1016,7 @@ def forward(self, add):
             mod.submod_1.code.strip("\n"),
             """\
 def forward(self, cos):
-    add_1 = torch.ops.aten.add.Tensor(cos, 1);  cos = None
+    add_1 = torch.ops.aten.add.Scalar(cos, 1);  cos = None
     return (add_1,)
     """,
         )
@@ -1030,7 +1030,7 @@ def forward(self, cos):
             """\
 def forward(self, x):
     x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
-    add = torch.ops.aten.add.Tensor(x, 1);  x = None
+    add = torch.ops.aten.add.Scalar(x, 1);  x = None
     submod_3 = self.submod_1
     add_1 = torch.ops.higher_order.wrap_with_autocast('cpu', None, True, None, submod_3, add);  submod_3 = add = None
     getitem = add_1[0];  add_1 = None
@@ -1062,7 +1062,7 @@ def forward(self, add):
             """\
 def forward(self, x):
     x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
-    add = torch.ops.aten.add.Tensor(x, 1);  x = None
+    add = torch.ops.aten.add.Scalar(x, 1);  x = None
     submod_4 = self.submod_1
     sum_1 = torch.ops.higher_order.wrap_with_autocast('cpu', None, True, None, submod_4, add);  submod_4 = add = None
     getitem = sum_1[0];  sum_1 = None
@@ -1090,7 +1090,7 @@ def forward(self, add):
             mod.submod_2.code.strip("\n"),
             """\
 def forward(self, sum_1):
-    add_1 = torch.ops.aten.add.Tensor(sum_1, 1);  sum_1 = None
+    add_1 = torch.ops.aten.add.Scalar(sum_1, 1);  sum_1 = None
     return (add_1,)
     """,
         )
@@ -1099,7 +1099,7 @@ def forward(self, sum_1):
             mod.submod_3.code.strip("\n"),
             """\
 def forward(self, add_1):
-    sub = torch.ops.aten.sub.Tensor(add_1, 1);  add_1 = None
+    sub = torch.ops.aten.sub.Scalar(add_1, 1);  add_1 = None
     return (sub,)
     """,
         )
@@ -1112,7 +1112,7 @@ def forward(self, add_1):
             """\
 def forward(self, x):
     x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
-    add = torch.ops.aten.add.Tensor(x, 1);  x = None
+    add = torch.ops.aten.add.Scalar(x, 1);  x = None
     submod_4 = self.submod_1
     wrap_with_autocast = torch.ops.higher_order.wrap_with_autocast('cpu', None, True, None, submod_4, add);  submod_4 = add = None
     sum_1 = wrap_with_autocast[0]
@@ -1145,8 +1145,8 @@ def forward(self, add):
             mod.submod_2.code.strip("\n"),
             """\
 def forward(self, sum_1, sum_2):
-    add_1 = torch.ops.aten.add.Tensor(sum_1, 1);  sum_1 = None
-    add_2 = torch.ops.aten.add.Tensor(sum_2, 1);  sum_2 = None
+    add_1 = torch.ops.aten.add.Scalar(sum_1, 1);  sum_1 = None
+    add_2 = torch.ops.aten.add.Scalar(sum_2, 1);  sum_2 = None
     return (add_1, add_2)
     """,
         )
@@ -1155,8 +1155,8 @@ def forward(self, sum_1, sum_2):
             mod.submod_3.code.strip("\n"),
             """\
 def forward(self, add_1, add_2):
-    sub = torch.ops.aten.sub.Tensor(add_1, 1);  add_1 = None
-    sub_1 = torch.ops.aten.sub.Tensor(add_2, 1);  add_2 = None
+    sub = torch.ops.aten.sub.Scalar(add_1, 1);  add_1 = None
+    sub_1 = torch.ops.aten.sub.Scalar(add_2, 1);  add_2 = None
     return (sub, sub_1)
     """,
         )
@@ -1169,11 +1169,11 @@ def forward(self, add_1, add_2):
             """\
 def forward(self, x):
     x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
-    add = torch.ops.aten.add.Tensor(x, 1);  x = None
+    add = torch.ops.aten.add.Scalar(x, 1);  x = None
     submod_4 = self.submod_1
     sum_1 = torch.ops.higher_order.wrap_with_autocast('cpu', None, True, None, submod_4, add);  submod_4 = add = None
     getitem = sum_1[0];  sum_1 = None
-    add_1 = torch.ops.aten.add.Tensor(getitem, 1);  getitem = None
+    add_1 = torch.ops.aten.add.Scalar(getitem, 1);  getitem = None
     submod_5 = self.submod_3
     sub = torch.ops.higher_order.wrap_with_autocast('cpu', None, True, None, submod_5, add_1);  submod_5 = None
     getitem_1 = sub[0];  sub = None
@@ -1195,7 +1195,7 @@ def forward(self, add):
             mod.submod_3.code.strip("\n"),
             """\
 def forward(self, add_1):
-    sub = torch.ops.aten.sub.Tensor(add_1, 1);  add_1 = None
+    sub = torch.ops.aten.sub.Scalar(add_1, 1);  add_1 = None
     return (sub,)
     """,
         )

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -1187,8 +1187,7 @@ def forward(self, x):
     topk_default = torch.ops.aten.topk.default(x, 2);  x = None
     getitem = topk_default[0]
     getitem_1 = topk_default[1];  topk_default = None
-    mul_tensor = torch.ops.aten.mul.Tensor(getitem, 2)
-    mul = torch.ops.aten.mul.Tensor(getitem, mul_tensor);  getitem = mul_tensor = None
+    mul = torch.ops.aten.mul.Scalar(getitem, 2);  getitem = None
     return (mul, getitem_1)
     """,
         )

--- a/test/export/test_torchbind.py
+++ b/test/export/test_torchbind.py
@@ -710,7 +710,7 @@ def forward(self, token, p_linear_weight, p_linear_bias, tq, x):
     getitem_1 = with_effects[1];  with_effects = None
     with_effects_1 = torch.ops.higher_order.with_effects(getitem, torch.ops.higher_order.call_torchbind, tq, 'float_size');  getitem = None
     getitem_2 = with_effects_1[0];  with_effects_1 = None
-    add = torch.ops.aten.add.Tensor(getitem_1, 1.0);  getitem_1 = None
+    add = torch.ops.aten.add.Scalar(getitem_1, 1.0);  getitem_1 = None
     linear = torch.ops.aten.linear.default(x, p_linear_weight, p_linear_bias);  p_linear_weight = p_linear_bias = None
     add_1 = torch.ops.aten.add.Tensor(add, linear);  add = linear = None
     with_effects_2 = torch.ops.higher_order.with_effects(getitem_2, torch.ops.higher_order.call_torchbind, tq, 'is_empty');  getitem_2 = None
@@ -720,7 +720,7 @@ def forward(self, token, p_linear_weight, p_linear_bias, tq, x):
     getitem_7 = with_effects_3[1];  with_effects_3 = None
     with_effects_4 = torch.ops.higher_order.with_effects(getitem_6, torch.ops.higher_order.call_torchbind, tq, 'size');  getitem_6 = None
     getitem_8 = with_effects_4[0];  with_effects_4 = None
-    add_2 = torch.ops.aten.add.Tensor(getitem_7, 0);  getitem_7 = None
+    add_2 = torch.ops.aten.add.Scalar(getitem_7, 0);  getitem_7 = None
     add_3 = torch.ops.aten.add.Tensor(add_2, x);  add_2 = x = None
     return (getitem_8, add_3, add_1, tq)""",  # noqa: B950
         )

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -4141,8 +4141,8 @@ def forward(self, x_1):
                 """\
 def forward(self, arg0_1):
     clone = torch.ops.aten.clone.default(arg0_1);  arg0_1 = None
-    add_ = torch.ops.aten.add_.Tensor(clone, 1);  clone = None
-    add__1 = torch.ops.aten.add_.Tensor(add_, -1);  add_ = None
+    add_ = torch.ops.aten.add_.Scalar(clone, 1);  clone = None
+    add__1 = torch.ops.aten.add_.Scalar(add_, -1);  add_ = None
     sum_1 = torch.ops.aten.sum.default(add__1);  add__1 = None
     lt = torch.ops.aten.lt.Scalar(sum_1, 10);  sum_1 = None
     return lt
@@ -4153,9 +4153,9 @@ def forward(self, arg0_1):
                 """\
 def forward(self, arg0_1):
     clone = torch.ops.aten.clone.default(arg0_1);  arg0_1 = None
-    add_ = torch.ops.aten.add_.Tensor(clone, 1);  clone = None
-    add__1 = torch.ops.aten.add_.Tensor(add_, -1);  add_ = None
-    add = torch.ops.aten.add.Tensor(add__1, 1);  add__1 = None
+    add_ = torch.ops.aten.add_.Scalar(clone, 1);  clone = None
+    add__1 = torch.ops.aten.add_.Scalar(add_, -1);  add_ = None
+    add = torch.ops.aten.add.Scalar(add__1, 1);  add__1 = None
     return (add,)
     """,
             )
@@ -4176,8 +4176,8 @@ def forward(self, arg0_1):
                 """\
 def forward(self, arg0_1):
     clone = torch.ops.aten.clone.default(arg0_1);  arg0_1 = None
-    add = torch.ops.aten.add.Tensor(clone, 1);  clone = None
-    add_1 = torch.ops.aten.add.Tensor(add, -1);  add = None
+    add = torch.ops.aten.add.Scalar(clone, 1);  clone = None
+    add_1 = torch.ops.aten.add.Scalar(add, -1);  add = None
     sum_1 = torch.ops.aten.sum.default(add_1);  add_1 = None
     lt = torch.ops.aten.lt.Scalar(sum_1, 10);  sum_1 = None
     return lt
@@ -4188,9 +4188,9 @@ def forward(self, arg0_1):
                 """\
 def forward(self, arg0_1):
     clone = torch.ops.aten.clone.default(arg0_1);  arg0_1 = None
-    add = torch.ops.aten.add.Tensor(clone, 1);  clone = None
-    add_1 = torch.ops.aten.add.Tensor(add, -1);  add = None
-    add_2 = torch.ops.aten.add.Tensor(add_1, 1);  add_1 = None
+    add = torch.ops.aten.add.Scalar(clone, 1);  clone = None
+    add_1 = torch.ops.aten.add.Scalar(add, -1);  add = None
+    add_2 = torch.ops.aten.add.Scalar(add_1, 1);  add_1 = None
     return (add_2,)
     """,
             )
@@ -4211,8 +4211,8 @@ def forward(self, x_1):
                 """\
 def forward(self, arg0_1):
     clone = torch.ops.aten.clone.default(arg0_1);  arg0_1 = None
-    add = torch.ops.aten.add.Tensor(clone, 1);  clone = None
-    add_1 = torch.ops.aten.add.Tensor(add, -1);  add = None
+    add = torch.ops.aten.add.Scalar(clone, 1);  clone = None
+    add_1 = torch.ops.aten.add.Scalar(add, -1);  add = None
     sum_1 = torch.ops.aten.sum.default(add_1);  add_1 = None
     lt = torch.ops.aten.lt.Scalar(sum_1, 10);  sum_1 = None
     return lt
@@ -4223,9 +4223,9 @@ def forward(self, arg0_1):
                 """\
 def forward(self, arg0_1):
     clone = torch.ops.aten.clone.default(arg0_1);  arg0_1 = None
-    add = torch.ops.aten.add.Tensor(clone, 1);  clone = None
-    add_1 = torch.ops.aten.add.Tensor(add, -1);  add = None
-    add_2 = torch.ops.aten.add.Tensor(add_1, 1);  add_1 = None
+    add = torch.ops.aten.add.Scalar(clone, 1);  clone = None
+    add_1 = torch.ops.aten.add.Scalar(add, -1);  add = None
+    add_2 = torch.ops.aten.add.Scalar(add_1, 1);  add_1 = None
     return (add_2,)
     """,
             )
@@ -6620,7 +6620,7 @@ class GraphModule(torch.nn.Module):
             clone: "f32[s0, 3]" = torch.ops.aten.clone.default(x_1);  x_1 = None
             select: "f32[3]" = torch.ops.aten.select.int(clone, 0, it_1)
             select_1: "f32[3]" = torch.ops.aten.select.int(clone, 0, it_1)
-            add: "f32[3]" = torch.ops.aten.add.Tensor(select_1, it_1);  select_1 = None
+            add: "f32[3]" = torch.ops.aten.add.Scalar(select_1, it_1);  select_1 = None
             copy_: "f32[3]" = torch.ops.aten.copy_.default(select, add);  select = add = copy_ = None
             add_1: "Sym(u0 + 1)" = it_1 + 1;  it_1 = None
             return (add_1, clone)
@@ -6755,15 +6755,15 @@ class GraphModule(torch.nn.Module):
         add_4: "Sym(u12 + 1)" = getitem_12 + 1
         add_5: "Sym(u13 + 1)" = getitem_13 + 1
         add_6: "Sym(u14 + 1)" = getitem_14 + 1
-        add_7: "f32[2, 3]" = torch.ops.aten.add.Tensor(getitem_7, 1)
+        add_7: "f32[2, 3]" = torch.ops.aten.add.Scalar(getitem_7, 1)
 
-        add_8: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_8);  getitem_8 = None
-        add_9: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_9);  getitem_9 = None
-        add_10: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_10);  getitem_10 = None
-        add_11: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_11);  getitem_11 = None
-        add_12: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_12);  getitem_12 = None
-        add_13: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_13);  getitem_13 = None
-        add_14: "f32[2, 3]" = torch.ops.aten.add.Tensor(t, getitem_14);  getitem_14 = None
+        add_8: "f32[2, 3]" = torch.ops.aten.add.Scalar(t, getitem_8);  getitem_8 = None
+        add_9: "f32[2, 3]" = torch.ops.aten.add.Scalar(t, getitem_9);  getitem_9 = None
+        add_10: "f32[2, 3]" = torch.ops.aten.add.Scalar(t, getitem_10);  getitem_10 = None
+        add_11: "f32[2, 3]" = torch.ops.aten.add.Scalar(t, getitem_11);  getitem_11 = None
+        add_12: "f32[2, 3]" = torch.ops.aten.add.Scalar(t, getitem_12);  getitem_12 = None
+        add_13: "f32[2, 3]" = torch.ops.aten.add.Scalar(t, getitem_13);  getitem_13 = None
+        add_14: "f32[2, 3]" = torch.ops.aten.add.Scalar(t, getitem_14);  getitem_14 = None
         add_15: "f32[2, 3]" = torch.ops.aten.add.Tensor(getitem_7, t);  getitem_7 = t = None
         return pytree.tree_unflatten((add, add_1, add_2, add_3, add_4, add_5, add_6, add_7, add_8, add_9, add_10, add_11, add_12, add_13, add_14, add_15), self._out_spec)
 
@@ -6778,7 +6778,7 @@ class GraphModule(torch.nn.Module):
     class while_loop_body_graph_0(torch.nn.Module):
         def forward(self, a_1: "Sym(u1)", b_1: "Sym(u2)", c1_1: "Sym(u3)", c2_1: "Sym(u4)", c3_1: "Sym(u5)", c0_1: "Sym(u6)", u0_1: "Sym(u7)", x_1: "f32[2, 3]"):
             add: "Sym(u7 + 1)" = u0_1 + 1;  u0_1 = None
-            add_1: "f32[2, 3]" = torch.ops.aten.add.Tensor(x_1, 1);  x_1 = None
+            add_1: "f32[2, 3]" = torch.ops.aten.add.Scalar(x_1, 1);  x_1 = None
             return (b_1, c1_1, c2_1, c3_1, a_1, 0, add, add_1)
 """,  # noqa: B950
             )
@@ -6898,9 +6898,9 @@ class GraphModule(torch.nn.Module):
         add_1: "Sym(u8 + 1)" = getitem_9 + 1
         add_2: "Sym(u9 + 1)" = getitem_10 + 1
 
-        add_3: "f32[s0, 3]" = torch.ops.aten.add.Tensor(getitem_5, getitem_8);  getitem_8 = None
-        add_4: "f32[s0, 3]" = torch.ops.aten.add.Tensor(getitem_5, getitem_9);  getitem_9 = None
-        add_5: "f32[s0, 3]" = torch.ops.aten.add.Tensor(getitem_5, getitem_10);  getitem_10 = None
+        add_3: "f32[s0, 3]" = torch.ops.aten.add.Scalar(getitem_5, getitem_8);  getitem_8 = None
+        add_4: "f32[s0, 3]" = torch.ops.aten.add.Scalar(getitem_5, getitem_9);  getitem_9 = None
+        add_5: "f32[s0, 3]" = torch.ops.aten.add.Scalar(getitem_5, getitem_10);  getitem_10 = None
         return pytree.tree_unflatten((getitem_6, getitem_7, add, add_1, add_2, add_3, add_4, add_5, getitem_5), self._out_spec)
 
     class while_loop_cond_graph_0(torch.nn.Module):
@@ -6920,7 +6920,7 @@ class GraphModule(torch.nn.Module):
             add_3: "Sym(u18 + 1)" = arg3_1 + 1;  arg3_1 = None
             add_4: "Sym(u19 + 1)" = arg4_1 + 1;  arg4_1 = None
 
-            add_5: "f32[s0, 3]" = torch.ops.aten.add.Tensor(arg5_1, 1);  arg5_1 = None
+            add_5: "f32[s0, 3]" = torch.ops.aten.add.Scalar(arg5_1, 1);  arg5_1 = None
             return (add, add_1, add_2, add_3, add_4, add_5)
 """,  # noqa: B950
             )
@@ -7248,21 +7248,21 @@ class GraphModule(torch.nn.Module):
         cond = torch.ops.higher_order.cond(a, true_graph_0, false_graph_0, [c, b1, b2]);  a = true_graph_0 = false_graph_0 = c = b1 = b2 = None
         getitem: "f32[10]" = cond[0];  cond = None
 
-        mul: "f32[10]" = torch.ops.aten.mul.Tensor(getitem, 2);  getitem = None
+        mul: "f32[10]" = torch.ops.aten.mul.Scalar(getitem, 2);  getitem = None
         return pytree.tree_unflatten((mul,), self._out_spec)
 
     class true_graph_0(torch.nn.Module):
         def forward(self, c: "f32[10]", b1: "i64[1]", b2: "i64[1]"):
             item: "Sym(u0)" = torch.ops.aten.item.default(b1);  b1 = None
 
-            mul: "f32[10]" = torch.ops.aten.mul.Tensor(c, item);  c = item = None
+            mul: "f32[10]" = torch.ops.aten.mul.Scalar(c, item);  c = item = None
             return (mul,)
 
     class false_graph_0(torch.nn.Module):
         def forward(self, c: "f32[10]", b1: "i64[1]", b2: "i64[1]"):
             item: "Sym(u1)" = torch.ops.aten.item.default(b2);  b2 = None
 
-            mul: "f32[10]" = torch.ops.aten.mul.Tensor(c, item);  c = item = None
+            mul: "f32[10]" = torch.ops.aten.mul.Scalar(c, item);  c = item = None
             return (mul,)
 """,  # noqa: B950
         )
@@ -7311,12 +7311,12 @@ class GraphModule(torch.nn.Module):
 
     class true_graph_0(torch.nn.Module):
         def forward(self, x: "f32[s0, 3]", sym_size_int_4: "Sym(s1)", sym_size_int_3: "Sym(s0)", z: "f32[s0, 3]"):
-            add: "f32[s0, 3]" = torch.ops.aten.add.Tensor(x, sym_size_int_4);  x = sym_size_int_4 = None
+            add: "f32[s0, 3]" = torch.ops.aten.add.Scalar(x, sym_size_int_4);  x = sym_size_int_4 = None
             return (add,)
 
     class false_graph_0(torch.nn.Module):
         def forward(self, x: "f32[s0, 3]", sym_size_int_4: "Sym(s1)", sym_size_int_3: "Sym(s0)", z: "f32[s0, 3]"):
-            mul: "f32[s0, 3]" = torch.ops.aten.mul.Tensor(z, sym_size_int_3);  z = sym_size_int_3 = None
+            mul: "f32[s0, 3]" = torch.ops.aten.mul.Scalar(z, sym_size_int_3);  z = sym_size_int_3 = None
 
             add: "f32[s0, 3]" = torch.ops.aten.add.Tensor(x, mul);  x = mul = None
             return (add,)

--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -1277,7 +1277,7 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
                 for node in model.graph.nodes:
                     if (
                         node.op == "call_function"
-                        and node.target == torch.ops.aten.add.Tensor
+                        and node.target == torch.ops.aten.add.Scalar
                     ):
                         input_act1 = node.args[0]
                         # this is a constant, so not valid for annotation
@@ -1500,8 +1500,8 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
                 graph = torch.fx.Graph()
                 graph.graph_copy(model.graph, {})
                 for n in graph.nodes:
-                    if n.target == torch.ops.aten.add.Tensor:
-                        n.target = torch.ops.aten.mul.Tensor
+                    if n.target == torch.ops.aten.add.Scalar:
+                        n.target = torch.ops.aten.mul.Scalar
                 model = torch.fx.GraphModule(model, graph)
                 return model
 
@@ -1522,8 +1522,8 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         m = prepare_pt2e(m, quantizer)
         m(*example_inputs)
         node_occurrence = {
-            ns.call_function(torch.ops.aten.add.Tensor): 0,
-            ns.call_function(torch.ops.aten.mul.Tensor): 1,
+            ns.call_function(torch.ops.aten.add.Scalar): 0,
+            ns.call_function(torch.ops.aten.mul.Scalar): 1,
         }
         self.checkGraphModuleNodes(m, expected_node_occurrence=node_occurrence)
 


### PR DESCRIPTION
Summary:
Ensure that when we construct an ExportedProgram, instead of having patterns like
```
torch.ops.aten.add.Tensor(tensor, scalar)
```
we will always fix it to become
```
torch.ops.aten.add.Scalar(tensor, scalar)
```

Test Plan: CI

Differential Revision: D69212362


