### PR TITLE
[ROCm][TunableOp] Future proof TunableOp unit test.

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4600,7 +4600,7 @@ class TestLinalg(TestCase):
                 validators[key] = value
             if torch.version.hip:
                 assert "HIPBLASLT_VERSION" in validators
-                assert re.match(r'^\d{3,}-[a-z0-9]{8}$', validators["HIPBLASLT_VERSION"])
+                assert re.match(r'^\d+-[a-z0-9]+$', validators["HIPBLASLT_VERSION"])
             assert len(torch.cuda.tunable.get_results()) > 0
 
             assert torch.cuda.tunable.write_file()  # use default filename


### PR DESCRIPTION
TunableOp UT will fail because the regular expression in the test will not work for future versions of ROCm.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang