### PR TITLE
[BE][Metal] Fix signed unsigned comparison warning

### DIFF
--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -12,7 +12,7 @@ opmath_t<T> threadgroup_sum(threadgroup T* data, unsigned size) {
   // TODO: This should be moved to the callee
   ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
   // TODO: Use `simd_shuffle_down`
-  for (auto idx = 1; idx < size; ++idx) {
+  for (unsigned idx = 1; idx < size; ++idx) {
     rc += data[idx];
   }
   return rc;
@@ -23,7 +23,7 @@ opmath_t<T> threadgroup_prod(threadgroup T* data, unsigned size) {
   opmath_t<T> rc = data[0];
   // TODO: This should be moved to the callee
   ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
-  for (auto idx = 1; idx < size; ++idx) {
+  for (unsigned idx = 1; idx < size; ++idx) {
     rc *= data[idx];
   }
   return rc;
@@ -34,7 +34,7 @@ T threadgroup_max(threadgroup T* data, unsigned size) {
   // TODO: This should be moved to the callee
   ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
   T rc = data[0];
-  for (auto idx = 1; idx < size; ++idx) {
+  for (unsigned idx = 1; idx < size; ++idx) {
     rc = ::c10::metal::max(rc, data[idx]);
   }
   return rc;
@@ -45,7 +45,7 @@ T threadgroup_min(threadgroup T* data, unsigned size) {
   // TODO: This should be moved to the callee
   ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
   T rc = data[0];
-  for (auto idx = 1; idx < size; ++idx) {
+  for (unsigned idx = 1; idx < size; ++idx) {
     rc = ::c10::metal::min(rc, data[idx]);
   }
   return rc;
@@ -56,7 +56,7 @@ long threadgroup_argmax(threadgroup T* data, unsigned size) {
   // TODO: This should be moved to the callee
   ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
   long rc = 0;
-  for (auto idx = 1; idx < size; ++idx) {
+  for (unsigned idx = 1; idx < size; ++idx) {
     if (data[idx] > data[rc]) {
       rc = idx;
     }
@@ -69,7 +69,7 @@ T threadgroup_argmin(threadgroup T* data, unsigned size) {
   // TODO: This should be moved to the callee
   ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
   long rc = 0;
-  for (auto idx = 1; idx < size; ++idx) {
+  for (unsigned idx = 1; idx < size; ++idx) {
     if (data[idx] < data[rc]) {
       rc = idx;
     }


### PR DESCRIPTION
I wish I knew how to extract Metal warnings during JIT compilation but https://developer.apple.com/documentation/metal/mtldevice/makelibrary(source:options:)?changes=_7&language=objc is a lie as `error:` stays `nil` unless shader compilation fails. But when it does following warnings are thrown
```
program_source:666:26: warning: comparison of integers of different signs: 'int' and 'unsigned int' [-Wsign-compare]
  for (auto idx = 1; idx < size; ++idx) {
                     ~~~ ^ ~~~~
program_source:677:26: warning: comparison of integers of different signs: 'int' and 'unsigned int' [-Wsign-compare]
  for (auto idx = 1; idx < size; ++idx) {
                     ~~~ ^ ~~~~
program_source:688:26: warning: comparison of integers of different signs: 'int' and 'unsigned int' [-Wsign-compare]
  for (auto idx = 1; idx < size; ++idx) {
                     ~~~ ^ ~~~~
program_source:699:26: warning: comparison of integers of different signs: 'int' and 'unsigned int' [-Wsign-compare]
  for (auto idx = 1; idx < size; ++idx) {
                     ~~~ ^ ~~~~
program_source:710:26: warning: comparison of integers of different signs: 'int' and 'unsigned int' [-Wsign-compare]
  for (auto idx = 1; idx < size; ++idx) {
                     ~~~ ^ ~~~~
program_source:723:26: warning: comparison of integers of different signs: 'int' and 'unsigned int' [-Wsign-compare]
  for (auto idx = 1; idx < size; ++idx) {

```
