### PR TITLE
[MPSInductor] Fix min/max for bfloat16

### DIFF
--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -101,21 +101,22 @@ template <typename T>
   return ::metal::isunordered(a, b) ? NAN : ::metal::min(a, b);
 }
 
-
 template <typename T>
 ::metal::enable_if_t<::metal::is_integral_v<T>, T> min(T a, T b) {
   return ::metal::min(a, b);
 }
 
 #if __METAL_VERSION__ >= 310
-template<>
+template <>
 bfloat min(bfloat a, bfloat b) {
-  return bfloat(::metal::isunordered(a, b) ? NAN : ::metal::min(float(a), float(b)));
+  return bfloat(
+      ::metal::isunordered(a, b) ? NAN : ::metal::min(float(a), float(b)));
 }
 
-template<>
+template <>
 bfloat max(bfloat a, bfloat b) {
-  return bfloat(::metal::isunordered(a, b) ? NAN : ::metal::max(float(a), float(b)));
+  return bfloat(
+      ::metal::isunordered(a, b) ? NAN : ::metal::max(float(a), float(b)));
 }
 #endif
 

--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -101,10 +101,23 @@ template <typename T>
   return ::metal::isunordered(a, b) ? NAN : ::metal::min(a, b);
 }
 
+
 template <typename T>
 ::metal::enable_if_t<::metal::is_integral_v<T>, T> min(T a, T b) {
   return ::metal::min(a, b);
 }
+
+#if __METAL_VERSION__ >= 310
+template<>
+bfloat min(bfloat a, bfloat b) {
+  return bfloat(::metal::isunordered(a, b) ? NAN : ::metal::min(float(a), float(b)));
+}
+
+template<>
+bfloat max(bfloat a, bfloat b) {
+  return bfloat(::metal::isunordered(a, b) ? NAN : ::metal::max(float(a), float(b)));
+}
+#endif
 
 template <typename T>
 using vec2type_t = typename detail::vectypes<T>::type2;

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -131,6 +131,7 @@ class MPSBasicTests(TestCase):
 
 # Copy tests
 for test_name in [
+    "test_min_max_reduction",
     "test_add_const_int",
     "test_add_inplace_permuted",
     "test_addmm",

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2395,7 +2395,7 @@ class CommonTemplate:
             )
 
         dtypes = [torch.float, torch.float16]
-        if not (self.device == "cuda" and not SM80OrLater):
+        if self.is_dtype_supported(torch.bfloat16):
             dtypes += [torch.bfloat16]
         for dtype in dtypes:
             self.common(fn, (torch.randn(8, 8).to(dtype), torch.randn(8, 8).to(dtype)))

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -445,7 +445,7 @@ class MetalKernel(SIMDKernel):
             )
         if reduction_type in ["max", "min", "argmax", "argmin"]:
             acc_buf = self._new_accvar(src_dtype, reduction_dim.numel)
-            self.body.splice(f"{acc_buf}[{reduction_dim.name}] = {value};")
+            self.body.splice(f"{acc_buf}[{reduction_dim.name}] = static_cast<{DTYPE_TO_METAL[src_dtype]}>({value});")
             return self.cse.generate(
                 self.body,
                 f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {reduction_dim.numel})",

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -445,7 +445,9 @@ class MetalKernel(SIMDKernel):
             )
         if reduction_type in ["max", "min", "argmax", "argmin"]:
             acc_buf = self._new_accvar(src_dtype, reduction_dim.numel)
-            self.body.splice(f"{acc_buf}[{reduction_dim.name}] = static_cast<{DTYPE_TO_METAL[src_dtype]}>({value});")
+            self.body.splice(
+                f"{acc_buf}[{reduction_dim.name}] = static_cast<{DTYPE_TO_METAL[src_dtype]}>({value});"
+            )
             return self.cse.generate(
                 self.body,
                 f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {reduction_dim.numel})",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146552

By introducing a full specialization that upcasts everything to float, as bfloat does not have a native min/max

Test by runing `test_min_max_reduction`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang @aakhundov