### PR TITLE
distributed/serialization: add experimental streaming torch.save/load methods

### DIFF
--- a/test/distributed/test_serialization.py
+++ b/test/distributed/test_serialization.py
@@ -1,0 +1,170 @@
+# Owner(s): ["oncall: distributed"]
+
+import os
+import pickle
+from io import BytesIO
+from typing import cast
+
+import torch
+import torch.distributed as dist
+from torch.distributed._serialization import _streaming_load, _streaming_save
+from torch.distributed.tensor import DeviceMesh, distribute_tensor, DTensor
+from torch.testing._internal.common_utils import requires_cuda, run_tests, TestCase
+
+
+DEBUG_ENV = "TORCH_SERIALIZATION_DEBUG"
+
+
+class MyClass:
+    def __init__(self, a: int) -> None:
+        self.a = a
+
+    def __eq__(self, other: "MyClass") -> bool:
+        return self.a == other.a
+
+
+class TestSerialization(TestCase):
+    def setUp(self) -> None:
+        # disable debug asserts
+        self._old_debug = os.environ.get(DEBUG_ENV)
+        os.environ[DEBUG_ENV] = "0"
+
+    def tearDown(self):
+        if self._old_debug is not None:
+            os.environ[DEBUG_ENV] = self._old_debug
+
+    def test_scalar_tensor(self) -> None:
+        tensor = torch.tensor(42, dtype=torch.int32)
+        state_dict = {"scalar": tensor}
+        file = BytesIO()
+        _streaming_save(state_dict, file)
+        file.seek(0)
+
+        result = _streaming_load(file)
+        torch.testing.assert_close(result, state_dict)
+
+    def test_strided_tensor(self) -> None:
+        base_tensor = torch.arange(16, dtype=torch.float32).reshape(4, 4)
+        strided_tensor = base_tensor[::2, ::2]
+        state_dict = {"strided": strided_tensor}
+        file = BytesIO()
+        _streaming_save(state_dict, file)
+        file.seek(0)
+
+        result = _streaming_load(file)
+        torch.testing.assert_close(result, state_dict)
+
+    def test_tensor_with_offset(self) -> None:
+        state_dict = {
+            "offset": torch.arange(10, dtype=torch.float64)[2:],
+            "strided": torch.arange(10, dtype=torch.float64)[2::2],
+        }
+        file = BytesIO()
+        _streaming_save(state_dict, file)
+        file.seek(0)
+
+        result = _streaming_load(file)
+        torch.testing.assert_close(result, state_dict)
+
+    def test_nested_tensors(self) -> None:
+        tensor1 = torch.tensor([1, 2, 3], dtype=torch.int32)
+        tensor2 = torch.tensor([[1.5, 2.5], [3.5, 4.5]], dtype=torch.float64)
+        state_dict = {"nested": {"tensor1": tensor1, "tensor2": tensor2}}
+        file = BytesIO()
+        _streaming_save(state_dict, file)
+        file.seek(0)
+
+        result = _streaming_load(file)
+        torch.testing.assert_close(result, state_dict)
+
+    def test_various_data_types(self) -> None:
+        tensor_float32 = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32)
+        tensor_int16 = torch.tensor([1, 2, 3], dtype=torch.int16)
+        tensor_bool = torch.tensor([True, False, True], dtype=torch.bool)
+        tensor_uint16 = torch.tensor([True, False, True], dtype=torch.uint16)
+        state_dict = {
+            "float32": tensor_float32,
+            "int16": tensor_int16,
+            "bool": tensor_bool,
+            "uint16": tensor_uint16,
+        }
+        file = BytesIO()
+        _streaming_save(state_dict, file)
+        file.seek(0)
+
+        result = _streaming_load(file)
+        torch.testing.assert_close(result, state_dict)
+
+    def test_dtensor(self) -> None:
+        dist.init_process_group(
+            backend="gloo", rank=0, world_size=1, store=dist.HashStore()
+        )
+
+        device_mesh = DeviceMesh("cpu", 1)
+        tensor = torch.randn(4, 4)
+        dtensor = distribute_tensor(tensor, device_mesh, [])
+        state_dict = dtensor
+        file = BytesIO()
+        _streaming_save(state_dict, file)
+        file.seek(0)
+
+        result = cast(DTensor, _streaming_load(file))
+        torch.testing.assert_close(result.to_local(), state_dict.to_local())
+        self.assertEqual(result._spec, state_dict._spec)
+
+    def test_python_object(self) -> None:
+        state_dict = {
+            "obj": MyClass(42),
+        }
+
+        file = BytesIO()
+        _streaming_save(state_dict, file)
+        file.seek(0)
+
+        result = _streaming_load(file, weights_only=False)
+        self.assertEqual(result, state_dict)
+
+    def test_str_utf8(self) -> None:
+        state_dict = {
+            "obj": "Ü",
+        }
+
+        file = BytesIO()
+        _streaming_save(state_dict, file)
+        file.seek(0)
+
+        result = _streaming_load(file)
+        self.assertEqual(result, state_dict)
+
+    def test_weights_only(self) -> None:
+        state_dict = {
+            "obj": MyClass(42),
+        }
+
+        file = BytesIO()
+        _streaming_save(state_dict, file)
+        file.seek(0)
+
+        with self.assertRaisesRegex(pickle.UnpicklingError, "not an allowed global"):
+            _streaming_load(file)
+
+        with self.assertRaisesRegex(RuntimeError, "explicit pickle_module"):
+            _streaming_load(file, weights_only=True, pickle_module=pickle)
+
+    @requires_cuda
+    def test_cuda(self) -> None:
+        device = torch.device("cuda:0")
+
+        tensor = torch.tensor(42, dtype=torch.float, device=device)
+        state_dict = {"scalar": tensor}
+        file = BytesIO()
+        _streaming_save(state_dict, file)
+        file.seek(0)
+
+        result = _streaming_load(file)
+        torch.testing.assert_close(result, state_dict)
+        self.assertEqual(result["scalar"].device, device)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/_serialization.py
+++ b/torch/distributed/_serialization.py
@@ -1,0 +1,155 @@
+import pickle
+from dataclasses import dataclass
+from io import BufferedIOBase
+from typing import Any, Dict, List, Tuple
+
+import torch
+import torch._weights_only_unpickler as _weights_only_unpickler
+from torch.serialization import _load, _save, DEFAULT_PROTOCOL, MAP_LOCATION
+
+
+__all__: List[str] = []
+
+
+@dataclass
+class _Entry:
+    key: str
+    is_storage: bool
+    length: int
+
+
+_weights_only_unpickler._add_safe_globals([_Entry])
+
+
+class _PseudoZipFile:
+    def __init__(self) -> None:
+        self.records: Dict[str, Tuple[object, int]] = {}
+
+    def write_record(self, key: str, data: object, length: int) -> None:
+        self.records[key] = (data, length)
+
+    def write_to(self, f: BufferedIOBase) -> None:
+        entries = []
+        for key, (data, length) in self.records.items():
+            entries.append(
+                _Entry(
+                    key=key,
+                    is_storage=isinstance(data, torch.UntypedStorage),
+                    length=length,
+                )
+            )
+
+        pickle.dump(entries, f, protocol=DEFAULT_PROTOCOL)
+
+        for key, (data, length) in self.records.items():
+            if isinstance(data, bytes):
+                f.write(data)
+            elif isinstance(data, str):
+                f.write(data.encode("utf-8"))
+            elif isinstance(data, torch.UntypedStorage):
+                data._write_file(f, False, False, 1)
+            else:
+                raise TypeError(f"unknown type: {type(data)}")
+
+    def read_from(self, f: BufferedIOBase) -> None:
+        entries = _weights_only_unpickler.load(f)
+
+        for entry in entries:
+            data = f.read(entry.length)
+            if entry.is_storage:
+                storage = torch.frombuffer(
+                    data,
+                    dtype=torch.uint8,
+                ).untyped_storage()
+
+                self.records[entry.key] = (
+                    storage,
+                    entry.length,
+                )
+            else:
+                self.records[entry.key] = (data, entry.length)
+
+    def has_record(self, key: str) -> bool:
+        return key in self.records
+
+    def get_record(self, key: str) -> object:
+        return self.records[key][0]
+
+    def get_storage_from_record(
+        self, key: str, _length: int, _type: int
+    ) -> torch.Tensor:
+        return torch.tensor(self.records[key][0], dtype=torch.uint8)
+
+    def serialization_id(self) -> str:
+        return "torchft"
+
+
+def _streaming_save(
+    obj: object,
+    f: BufferedIOBase,
+    pickle_module: Any = pickle,
+    pickle_protocol: int = DEFAULT_PROTOCOL,
+) -> None:
+    """
+    Save the object to a file-like object in a streaming fashion compatible with
+    network sockets.
+
+    This behaves similarly to :func:`torch.save` with a few notable differences:
+
+    * A non-seekable file like object can be used when loading.
+    * No forwards/backwards compatiblity is provided for the serialization
+      format. This is only intended to be used with a single version of PyTorch
+      with transient storage (i.e. sockets or temp files).
+    * mmap is not supported
+
+    See :func:`torch.save` for more details on specific arguments.
+    """
+
+    zip_file = _PseudoZipFile()
+    _save(
+        obj,
+        zip_file=zip_file,
+        pickle_module=pickle_module,
+        pickle_protocol=pickle_protocol,
+        _disable_byteorder_record=False,
+    )
+    zip_file.write_to(f)
+
+
+def _streaming_load(
+    f: BufferedIOBase,
+    map_location: MAP_LOCATION = None,
+    pickle_module: Any = None,
+    *,
+    weights_only: bool = True,
+    **pickle_load_args: Any,
+) -> object:
+    """
+    Load the object from a file-like object in a streaming fashion compatible with
+    network sockets.
+
+    See :func:`_streaming_save` for more details about the streaming behavior.
+
+    See :func:`torch.load` for more details on specific arguments.
+    """
+    if weights_only:
+        if pickle_module is not None:
+            raise RuntimeError(
+                "Can not safely load weights when explicit pickle_module is specified"
+            )
+        pickle_module = _weights_only_unpickler
+    else:
+        if pickle_module is None:
+            pickle_module = pickle
+
+    if "encoding" not in pickle_load_args.keys():
+        pickle_load_args["encoding"] = "utf-8"
+
+    zip_file = _PseudoZipFile()
+    zip_file.read_from(f)
+    return _load(
+        zip_file=zip_file,
+        map_location=map_location,
+        pickle_module=pickle_module,
+        **pickle_load_args,
+    )


### PR DESCRIPTION
Summary:

This is intended for use with torchft when we need to do a streaming state dict transfer. This is strictly superior to the prior streaming method in torchft as this supports all tensor subclasses such as DTensor.

This supports 100% of the inputs to torch.save/load but is not wire compatible nor intended to have any backwards compatibility.

Security wise this fully supports weights_only and defaults to True. It does use pickle for some metadata but uses weights_only for the metadata.

Adapted from:

https://github.com/pytorch/torchft/pull/101

https://github.com/pytorch/torchft/pull/54

Test Plan:

pytest test/distributed/test_serialization.py

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @c-p-i-o