### PR TITLE
Fix broken meta function for flex-attention backwards

### DIFF
--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -895,19 +895,19 @@ def sdpa_dense_backward(
     grad_key = torch.sum(grad_key, 2, keepdim=False)
     grad_value = torch.sum(grad_value, 2, keepdim=False)
 
+    # Fill to correctly strided outputs
+    actual_grad_query.copy_(grad_query)
+    actual_grad_key.copy_(grad_key)
+    actual_grad_value.copy_(grad_value)
+
     if Bq != Bkv:
         assert (
             Bq > 1 and Bkv == 1
         ), f"Bq and Bkv must broadcast. Got Bq={Bq} and Bkv={Bkv}"
 
-        # Reduce DK, DV along broadcasted batches.
-        actual_grad_key.copy_(grad_key)
-        actual_grad_value.copy_(grad_value)
-
         actual_grad_key = torch.sum(actual_grad_key, 0, keepdim=True)
         actual_grad_value = torch.sum(actual_grad_value, 0, keepdim=True)
 
-    actual_grad_query.copy_(grad_query)
     score_mod_other_buffer_grads = [
         actual_grad.copy_(grad) if isinstance(actual_grad, torch.Tensor) else None
         for actual_grad, grad in zip(

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -785,7 +785,6 @@ def sdpa_dense_backward(
 
     # Get outputs before calling repeat interleave and permute to input stride orders
     actual_grad_query = torch.empty_like(query)
-    actual_grad_query = _permute_strides(actual_grad_query, query.stride())
 
     actual_grad_key = key.new_empty((Bq, Hkv, seq_len_kv, qk_head_dim))
     actual_grad_key = _permute_strides(actual_grad_key, key.stride())
@@ -1163,7 +1162,6 @@ def flex_attention_backward_fake_tensor_mode(
         Bkv, Hkv, seq_len_kv, v_head_dim = value.shape
 
         grad_query = torch.empty_like(query)
-        grad_query = _permute_strides(grad_query, query.stride())
         # zeros_and_scatter creates a contiguous zeros tensor -> contiguous_format
         grad_score_mod_captured = tuple(
             [

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -780,7 +780,7 @@ def sdpa_dense_backward(
 ]:
     from torch._dynamo._trace_wrapped_higher_order_op import TransformGetItemToIndex
 
-    Bq, Hq, seq_len_q, qk_head_dim = query.shape
+    Bq, _, _, qk_head_dim = query.shape
     Bkv, Hkv, seq_len_kv, v_head_dim = value.shape
 
     # Get outputs before calling repeat interleave and permute to input stride orders
@@ -1158,7 +1158,7 @@ def flex_attention_backward_fake_tensor_mode(
     torch.Tensor, torch.Tensor, torch.Tensor, tuple[Optional[torch.Tensor], ...]
 ]:
     with mode:
-        Bq, Hq, seq_len_q, qk_head_dim = query.shape
+        Bq, _, _, qk_head_dim = query.shape
         Bkv, Hkv, seq_len_kv, v_head_dim = value.shape
 
         grad_query = torch.empty_like(query)

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -35,6 +35,7 @@ from ..lowering import (
     _full,
     check_and_broadcast_indices,
     empty,
+    empty_like,
     empty_strided,
     expand,
     index_output_size_and_inner_fn,
@@ -2337,16 +2338,8 @@ def flex_attention_backward(*args, **kwargs):
 
     grad_lse_exp2, delta = maybe_realize([grad_lse_exp2, delta])
 
-    # see NOTE:[TritonTemplates with multiple outputs]
-    query_size = list(query.get_size())
-    fill_order = get_fill_order(query.get_stride(), V.graph.sizevars.shape_env)
-    query_strides = construct_strides(query_size, fill_order)
-    grad_query = empty_strided(
-        query_size,
-        stride=[sympy.sympify(s) for s in query_strides],
-        dtype=query.get_dtype(),
-        device=query.get_device(),
-    )
+    # # see NOTE:[TritonTemplates with multiple outputs]
+    grad_query = empty_like(query)
 
     # Construct output layout with stride order matching value
     value_size = [Bq, Hkv, seq_len_kv, v_head_dim]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146563


# Summary

Fixes https://github.com/pytorch/pytorch/issues/146377

So what was the original problem: we were codegening a really weird epilogue:

```Python
        # first compute broadcasted dk of shape [Bq, Hkv, KV_LEN, V_HEAD_DIM]
        # then reduce to dk of shape [Bkv, Hkv, KV_LEN, V_HEAD_DIM]
        xindex = index_k + 64*index_n + 64*off_hkv*ks2 + 128*off_zq*ks2
        tl.store(out_ptr0 + (tl.broadcast_to(index_k + 64*index_n + off_hkv*ks1, dk.shape)), dk, mask)
        x5 = (xindex % ks3)
        tmp2 = tl.load(out_ptr0 + (x5 + ks1*off_hkv), mask, eviction_policy='evict_last')
        tl.store(out_ptr1 + (tl.broadcast_to(xindex, dk.shape)), tmp2, mask)
 ```
 
 This epilogue was writing and then reading from overlapping regions of memory causing a race condition.
 
 ### Why were we generating this epilgoue
 
 During the lowering we created a buffer w/ a different size/stride from the expected return strides. I :think this added an implicit node (for doing the permutation of this wrongly strided output to the the expected one from the meta func. The scheduler for some reason thought it was okay to fuse this into the epilogue, tbh I dont know why. 
 
 
 This fixes the broken meta func and the original repro. I will add a test but it is hard to pop, better than nothing
 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang @aakhundov @Chillee @yanboliang @BoyuanFeng