### PR TITLE
add `torch.float4_e2m1fn_x2` to PyTorch

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -70,6 +70,9 @@ DLDataType getDLDataType(const Tensor& t) {
     case ScalarType::Float8_e8m0fnu:
       TORCH_CHECK(false, "float8 types are not supported by dlpack");
       break;
+    // case ScalarType::Float4_e2m1fn_x2:
+    //  TORCH_CHECK(false, "float4 types are not supported by dlpack");
+    //  break;
     case ScalarType::QInt8:
     case ScalarType::QUInt8:
     case ScalarType::QInt32:

--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -70,9 +70,9 @@ DLDataType getDLDataType(const Tensor& t) {
     case ScalarType::Float8_e8m0fnu:
       TORCH_CHECK(false, "float8 types are not supported by dlpack");
       break;
-    // case ScalarType::Float4_e2m1fn_x2:
-    //  TORCH_CHECK(false, "float4 types are not supported by dlpack");
-    //  break;
+    case ScalarType::Float4_e2m1fn_x2:
+      TORCH_CHECK(false, "float4 types are not supported by dlpack");
+      break;
     case ScalarType::QInt8:
     case ScalarType::QUInt8:
     case ScalarType::QInt32:

--- a/c10/core/ScalarType.cpp
+++ b/c10/core/ScalarType.cpp
@@ -224,6 +224,8 @@ std::pair<std::string, std::string> getDtypeNames(c10::ScalarType scalarType) {
       return std::make_pair("float8_e4m3fnuz", "");
     case c10::ScalarType::Float8_e8m0fnu:
       return std::make_pair("float8_e8m0fnu", "");
+    case c10::ScalarType::Float4_e2m1fn_x2:
+      return std::make_pair("float4_e2m1fn_x2", "");
     default:
       throw std::runtime_error("Unimplemented scalar type");
   }

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -108,9 +108,6 @@ struct dummy_int1_7_t {};
   _(c10::Float8_e8m0fnu, Float8_e8m0fnu) /* 44 */        \
   _(c10::Float4_e2m1fn_x2, Float4_e2m1fn_x2) /* 45 */
 
-// _(c10::Float8_e8m0fnu, Float8_e8m0fnu)
-// _(c10::Float4_e2m1fn_x2, Float4_e2m1fn_x2)
-
 // If you want to support ComplexHalf for real, add ComplexHalf
 // into this macro (and change the name).  But beware: convert()
 // doesn't work for all the conversions you need...
@@ -392,7 +389,8 @@ inline bool isFloat8Type(ScalarType t) {
 }
 
 inline bool isReducedFloatingType(ScalarType t) {
-  return t == ScalarType::Half || t == ScalarType::BFloat16 || isFloat8Type(t);
+  return t == ScalarType::Half || t == ScalarType::BFloat16 ||
+      isFloat8Type(t) || t == ScalarType::Float4_e2m1fn_x2;
 }
 
 inline bool isFloatingType(ScalarType t) {

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -3,6 +3,7 @@
 #include <c10/util/BFloat16.h>
 #include <c10/util/Deprecated.h>
 #include <c10/util/Exception.h>
+#include <c10/util/Float4_e2m1fn_x2.h>
 #include <c10/util/Float8_e4m3fn.h>
 #include <c10/util/Float8_e4m3fnuz.h>
 #include <c10/util/Float8_e5m2.h>
@@ -104,7 +105,11 @@ struct dummy_int1_7_t {};
   _(c10::dummy_int1_7_t<5>, Int5) /* 41 */               \
   _(c10::dummy_int1_7_t<6>, Int6) /* 42 */               \
   _(c10::dummy_int1_7_t<7>, Int7) /* 43 */               \
-  _(c10::Float8_e8m0fnu, Float8_e8m0fnu) /* 44 */
+  _(c10::Float8_e8m0fnu, Float8_e8m0fnu) /* 44 */        \
+  _(c10::Float4_e2m1fn_x2, Float4_e2m1fn_x2) /* 45 */
+
+// _(c10::Float8_e8m0fnu, Float8_e8m0fnu)
+// _(c10::Float4_e2m1fn_x2, Float4_e2m1fn_x2)
 
 // If you want to support ComplexHalf for real, add ComplexHalf
 // into this macro (and change the name).  But beware: convert()
@@ -451,6 +456,7 @@ inline ScalarType toUnderlying(ScalarType t) {
   }
 }
 
+// TODO(this PR): define numeric_limits and add float4 here
 inline bool isSignedType(ScalarType t) {
 #define CASE_ISSIGNED(name)     \
   case ScalarType::name:        \
@@ -498,6 +504,7 @@ inline bool isSignedType(ScalarType t) {
     case ScalarType::Int5:
     case ScalarType::Int6:
     case ScalarType::Int7:
+    case ScalarType::Float4_e2m1fn_x2:
       return true;
     case ScalarType::UInt1:
     case ScalarType::UInt2:

--- a/c10/util/Float4_e2m1fn_x2.h
+++ b/c10/util/Float4_e2m1fn_x2.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <cstdint>
+
+#include <c10/macros/Macros.h>
+
+namespace c10 {
+
+/**
+ * TODO(before land): write this docblock
+ */
+struct alignas(1) Float4_e2m1fn_x2 {
+  uint8_t val_;
+  Float4_e2m1fn_x2() = default;
+  C10_HOST_DEVICE explicit Float4_e2m1fn_x2(uint8_t val) : val_(val) {}
+};
+
+} // namespace c10

--- a/test/quantization/core/experimental/test_float8.py
+++ b/test/quantization/core/experimental/test_float8.py
@@ -381,6 +381,23 @@ class TestFloat8Dtype(TestCase):
         x2 = torch.empty(4, 4, device=device, dtype=dtype)
         torch.cat([x1, x2])
 
+    # TODO(this PR): move this test elsewhere
+    def test_float4(self, device):
+        # not much is supported!
+
+        # can create a tensor of dtype float4
+        x1 = torch.empty(4, 4, device=device, dtype=torch.float4_e2m1fn_x2)
+        # can view it as uint8 and print
+        x2 = x1.view(torch.uint8)
+        print(x2)
+        # can print directly
+        # TODO(next): make this work
+        print(x1)
+
+        # can view a tensor of other dtype as float4
+        x3 = torch.empty(4, 4, device=device, dtype=torch.uint8)
+        x3.view(dtype=torch.float4_e2m1fn_x2)
+
 
 instantiate_device_type_tests(TestFloat8Dtype, globals())
 

--- a/test/quantization/core/experimental/test_floatx.py
+++ b/test/quantization/core/experimental/test_floatx.py
@@ -381,25 +381,24 @@ class TestFloat8Dtype(TestCase):
         x2 = torch.empty(4, 4, device=device, dtype=dtype)
         torch.cat([x1, x2])
 
-    # TODO(this PR): move this test elsewhere
-    def test_float4(self, device):
-        # not much is supported!
 
+class TestFloat4Dtype(TestCase):
+    def test_float4_e2m1fn_x2(self, device):
         # can create a tensor of dtype float4
         x1 = torch.empty(4, 4, device=device, dtype=torch.float4_e2m1fn_x2)
-        # can view it as uint8 and print
-        x2 = x1.view(torch.uint8)
-        print(x2)
-        # can print directly
-        # TODO(next): make this work
-        print(x1)
 
-        # can view a tensor of other dtype as float4
-        x3 = torch.empty(4, 4, device=device, dtype=torch.uint8)
-        x3.view(dtype=torch.float4_e2m1fn_x2)
+        # can create a string (so printing will work)
+        str(x1)
+
+        # can view float4_e2m1fn_x2 as uint8
+        x2 = x1.view(torch.uint8)
+
+        # can view uint8 as float4_e2m1fn_x2
+        x2.view(torch.float4_e2m1fn_x2)
 
 
 instantiate_device_type_tests(TestFloat8Dtype, globals())
+instantiate_device_type_tests(TestFloat4Dtype, globals())
 
 
 class TestFloat8DtypeCPUOnly(TestCase):

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -163,15 +163,15 @@ try:
 except ImportError as e:
     logging.warning(e)
 try:
-    from quantization.core.experimental.test_float8 import TestFloat8DtypeCPU  # noqa: F401
+    from quantization.core.experimental.test_floatx import TestFloat8DtypeCPU  # noqa: F401
 except ImportError as e:
     logging.warning(e)
 try:
-    from quantization.core.experimental.test_float8 import TestFloat8DtypeCUDA  # noqa: F401
+    from quantization.core.experimental.test_floatx import TestFloat8DtypeCUDA  # noqa: F401
 except ImportError as e:
     logging.warning(e)
 try:
-    from quantization.core.experimental.test_float8 import TestFloat8DtypeCPUOnlyCPU  # noqa: F401
+    from quantization.core.experimental.test_floatx import TestFloat8DtypeCPUOnlyCPU  # noqa: F401
 except ImportError as e:
     logging.warning(e)
 

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -142,6 +142,14 @@ class _Formatter:
                 self.max_width = max(self.max_width, len(value_str))
 
         else:
+            if tensor.dtype == torch.float4_e2m1fn_x2:  # type: ignore[attr-defined]
+                # torch.float4_e2m1fn_x2 is special and does not support the casts necessary
+                # to print it, we choose to display the uint8 representation here for
+                # convenience of being able to print a tensor.
+                # TODO(future PR): extend this to other dtypes without casts defined, such
+                # as the bits, uint1..7 and int1..7 dtypes.
+                tensor_view = tensor_view.view(torch.uint8)
+
             nonzero_finite_vals = torch.masked_select(
                 tensor_view, torch.isfinite(tensor_view) & tensor_view.ne(0)
             )
@@ -255,6 +263,14 @@ def _vector_str(self, indent, summarize, formatter1, formatter2=None):
                 return real_str + "+" + imag_str
         else:
             return formatter1.format(val)
+
+    if self.dtype == torch.float4_e2m1fn_x2:  # type: ignore[attr-defined]
+        # torch.float4_e2m1fn_x2 is special and does not support the casts necessary
+        # to print it, we choose to display the uint8 representation here for
+        # convenience of being able to print a tensor.
+        # TODO(future PR): extend this to other dtypes without casts defined, such
+        # as the bits, uint1..7 and int1..7 dtypes.
+        self = self.view(torch.uint8)
 
     if summarize and not PRINT_OPTS.edgeitems:
         # Deal with edge case that negative zero is zero


### PR DESCRIPTION
Summary:

Adds the `torch.float4_e2m1fn_x2` dtype to PyTorch, as detailed in
https://github.com/pytorch/pytorch/issues/146414 . Please see the issue for a detailed definition of the format.  

Note that I decided to keep the casts out of this to significantly simplify the code, as defining casting between packed and unpacked formats will be tricky using the existing casting machinery.  

Example of basic functionality:

```python
import torch

# creation with empty
x0 = torch.empty(4, 4, dtype=torch.float4_e2m1fn_x2)

# printing, prints the uint8 representation of the stored values
print(x0)

# view as other dtype
x0.view(torch.uint8).view(torch.float4_e2m1fn_x2)
```

Done in this PR:
* tensor creation and tensor printing works (no other ops defined)

For future PRs:
* torch._scaled_mm
* PT2
* various cleanups (detailed in comments with issue numbers)

Test Plan:

```
pytest test/quantization/core/experimental/test_floatx.py -s
```

Reviewers:

Subscribers:

Tasks:

Tags:

cc @yanbing-j @albanD @kadeng @penguinwu @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10