### PR TITLE
[Partitioner] Remove unnecessary upstream nodes in dependency viewer

### DIFF
--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -38,14 +38,7 @@ class Partition:
 
 class _DependencyViewer:
     def __init__(self, graph_module: GraphModule):
-        self.upstreams = collections.defaultdict(set)
         self.downstreams = collections.defaultdict(set)
-
-        for node in graph_module.graph.nodes:
-            for input_node in node.all_input_nodes:
-                # add input_node and input_node's upstream dependency
-                self.upstreams[node].add(input_node)
-                self.upstreams[node].update(self.upstreams[input_node])
 
         for node in reversed(graph_module.graph.nodes):
             for output_node in node.users:
@@ -55,9 +48,6 @@ class _DependencyViewer:
 
     def downstreams_of(self, node: Node) -> set[Node]:
         return self.downstreams[node]
-
-    def upstreams_of(self, node: Node) -> set[Node]:
-        return self.upstreams[node]
 
 
 class CapabilityBasedPartitioner:
@@ -183,15 +173,6 @@ class CapabilityBasedPartitioner:
                     if target_id is not None:
                         partition_map[id].add(target_id)
                         partition_map[id].update(partition_map[target_id])
-
-                # Iterate through all the upstream nodes of this node and update the partition map
-                # to indicate that there is a path from the partition id of the upstream node to the
-                # current node's partition id.
-                upstream_nodes = self.dependency_viewer.upstreams_of(node)
-                for curr_node in upstream_nodes:
-                    source_id = assignment.get(curr_node, None)
-                    if source_id is not None:
-                        partition_map[source_id].add(id)
 
             if node in assignment:
                 partitions_by_id[assignment[node]].remove_node(node)


### PR DESCRIPTION
We iterate upstream nodes to update partition map. But actually did nothing due to we iterate nodes with reversed topological order https://github.com/pytorch/pytorch/pull/136608/files#diff-f2f9dd3903fd99955732eb694941fea0cb7301a58d59554787f3311d417e5615L193 so that there exists no upstream nodes in assignment. Remove it to reduce for-loop overhead which up to O(N * N) complexity.


cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv