### PR TITLE
Clarify that compile(module) only affects the forward method

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2458,6 +2458,11 @@ def compile(
     If you are compiling an :class:`torch.nn.Module`, you can also use :meth:`torch.nn.Module.compile`
     to compile the module inplace without changing its structure.
 
+    .. note::
+
+        When compiling an :class:`torch.nn.Module`, `torch.compile` directly compiles the `forward` method
+        and those functions called within the `forward` method. Other methods will not be compiled.
+
     Concretely, for every frame executed within the compiled region, we will attempt
     to compile it and cache the compiled result on the code object for future
     use.  A single frame may be compiled multiple times if previous compiled
@@ -2490,8 +2495,9 @@ def compile(
 
         - Experimental or debug in-tree backends can be seen with `torch._dynamo.list_backends(None)`
 
-        - To register an out-of-tree custom backend:
-          https://pytorch.org/docs/main/torch.compiler_custom_backends.html#registering-custom-backends
+        - To register an out-of-tree custom backend, following the
+          `tutorial <https://pytorch.org/docs/main/torch.compiler_custom_backends.html#registering-custom-backends>`_.
+
        mode (str): Can be either "default", "reduce-overhead", "max-autotune" or "max-autotune-no-cudagraphs"
 
         - "default" is the default mode, which is a good balance between performance and overhead


### PR DESCRIPTION
Fixes #141616

## Changes

- Add `Note` to Clarify how compile works with `nn.Module`
- Optimize plain url address with clickable description

## Test Result

### Before

![image](https://github.com/user-attachments/assets/15ff9985-7e91-4d71-be7d-cdd38eacd3f9)
![image](https://github.com/user-attachments/assets/26e27ba4-52da-4336-b72d-a0f9d0ebe839)


### After

![image](https://github.com/user-attachments/assets/5eaa8421-19e8-4186-af3d-dab4323d2c95)
![image](https://github.com/user-attachments/assets/a96a8a79-6320-4748-931f-33f4dbc640eb)

