### PR TITLE
[Partitioner] Reduce time consuming of partitions merger

### DIFF
--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -182,7 +182,7 @@ class CapabilityBasedPartitioner:
                 partition_map[removed_id]
             )
             del partition_map[removed_id]
-            
+
             partition_users[merge_id] = all_user_nodes
             del partition_users[removed_id]
 

--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -3,7 +3,6 @@ import collections
 import itertools
 import logging
 from collections.abc import Iterable, Sequence
-from copy import copy
 from typing import Optional
 
 from torch.fx.graph_module import GraphModule
@@ -102,6 +101,7 @@ class CapabilityBasedPartitioner:
         partitions_order: dict[
             int, int
         ] = {}  # mapping from partition_id to minimum topo order of nodes in partition
+        partition_users: dict[int, set] = {}  # mapping from partition_id to partition users
         new_partition_id = itertools.count()
 
         # try to merge partition other_id into partition self_id
@@ -109,8 +109,8 @@ class CapabilityBasedPartitioner:
         # returns `True` when merge happens, `False` otherwise.
         def maybe_merge_partition(self_id: int, other_id: int):
             # merged_nodes is the union of nodes in two partition to-be-merged
-            merged_nodes = copy(partitions_by_id[self_id].nodes)
-            merged_nodes.update(partitions_by_id[other_id].nodes)
+            self_nodes = partitions_by_id[self_id].nodes
+            other_nodes = partitions_by_id[other_id].nodes
 
             def dfs_iter_find_cycle(all_user_nodes: set[Node]):
                 for user_node in all_user_nodes:
@@ -119,7 +119,7 @@ class CapabilityBasedPartitioner:
                     for path_node in self.dependency_viewer.downstreams_of(user_node):
                         # If any of the nodes in the dfs path of this node are in the merged_nodes
                         # list then there is a cycle in the graph.
-                        if path_node in merged_nodes:
+                        if path_node in self_nodes or path_node in other_nodes:
                             return True
 
                         # If any of the nodes in the dfs path of this node are in the assignment
@@ -141,36 +141,46 @@ class CapabilityBasedPartitioner:
 
                 return False
 
-            # check if merge would create cyclic dependency.
+            # find new partition users if merge.
             all_user_nodes = set()
-            for node in merged_nodes:
-                for user_node in node.users:
-                    if user_node not in merged_nodes:
-                        all_user_nodes.add(user_node)
+            removed_candidates_list = [other_nodes, self_nodes]
+            partition_users_list = [partition_users[self_id], partition_users[other_id]]
+            for users, removed_candidates in zip(partition_users_list, removed_candidates_list):
+                for user in users:
+                    if user not in removed_candidates:
+                        all_user_nodes.add(user)
 
+            # check if merge would create cyclic dependency.
             if dfs_iter_find_cycle(all_user_nodes):
                 # return false indicating cyclic dependency found and
                 # merge is aborted
                 return False
 
+            # merge the smaller partition into the larger.
+            merge_id, removed_id = self_id, other_id
+            if len(self_nodes) < len(other_nodes):
+                merge_id, removed_id = removed_id, merge_id
             # no cyclic dependency found, move forward with the merge
             # updating partition nodes
-            partitions_by_id[self_id].nodes = merged_nodes
+            partitions_by_id[merge_id].nodes.update(partitions_by_id[removed_id].nodes)
             # updating assignment map
-            for node in partitions_by_id[other_id].nodes:
-                assignment[node] = self_id
+            for node in partitions_by_id[removed_id].nodes:
+                assignment[node] = merge_id
             # delete other partition
-            del partitions_by_id[other_id]
+            del partitions_by_id[removed_id]
 
-            partitions_order[self_id] = min(
-                partitions_order[self_id], partitions_order[other_id]
+            partitions_order[merge_id] = min(
+                partitions_order[merge_id], partitions_order[removed_id]
             )
-            del partitions_order[other_id]
+            del partitions_order[removed_id]
 
-            partition_map[self_id] = partition_map[self_id].union(
-                partition_map[other_id]
+            partition_map[merge_id] = partition_map[merge_id].union(
+                partition_map[removed_id]
             )
-            del partition_map[other_id]
+            del partition_map[removed_id]
+            
+            partition_users[merge_id] = all_user_nodes
+            del partition_users[removed_id]
 
             return True
 
@@ -201,11 +211,11 @@ class CapabilityBasedPartitioner:
             elif id not in partitions_by_id:
                 assignment[node] = id
                 partitions_by_id[id] = Partition(id=id, nodes=[node])
+                partition_users[id] = set(node.users)
                 _update_partition_map(node, id)
             else:
                 assignment[node] = id
                 partitions_by_id[id].add_node(node)
-                _update_partition_map(node, id)
 
         logger.debug("Proposing partitions...")
 

--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -145,14 +145,12 @@ class CapabilityBasedPartitioner:
 
             # find new partition users if merge.
             all_user_nodes = set()
-            removed_candidates_list = [other_nodes, self_nodes]
-            partition_users_list = [partition_users[self_id], partition_users[other_id]]
-            for users, removed_candidates in zip(
-                partition_users_list, removed_candidates_list
-            ):
-                for user in users:
-                    if user not in removed_candidates:
-                        all_user_nodes.add(user)
+            for self_user in partition_users[self_id]:
+                if self_user not in other_nodes:
+                    all_user_nodes.add(self_user)
+            for other_user in partition_users[other_id]:
+                if other_user not in self_nodes:
+                    all_user_nodes.add(other_user)
 
             # check if merge would create cyclic dependency.
             if dfs_iter_find_cycle(all_user_nodes):

--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -144,13 +144,8 @@ class CapabilityBasedPartitioner:
                 return False
 
             # find new partition users if merge.
-            all_user_nodes = set()
-            for self_user in partition_users[self_id]:
-                if self_user not in other_nodes:
-                    all_user_nodes.add(self_user)
-            for other_user in partition_users[other_id]:
-                if other_user not in self_nodes:
-                    all_user_nodes.add(other_user)
+            all_user_nodes = (partition_users[self_id] | partition_users[other_id])
+            all_user_nodes.difference_update(other_nodes, self_nodes)
 
             # check if merge would create cyclic dependency.
             if dfs_iter_find_cycle(all_user_nodes):

--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -144,7 +144,7 @@ class CapabilityBasedPartitioner:
                 return False
 
             # find new partition users if merge.
-            all_user_nodes = (partition_users[self_id] | partition_users[other_id])
+            all_user_nodes = partition_users[self_id] | partition_users[other_id]
             all_user_nodes.difference_update(other_nodes, self_nodes)
 
             # check if merge would create cyclic dependency.


### PR DESCRIPTION
This patch optimize maybe_merge_partition func through 3-ways:

Remove unnecessary copy https://github.com/pytorch/pytorch/blob/main/torch/fx/passes/infra/partitioner.py#L99. The number of copied nodes is large if we can merge all of the nodes of graph into one partition.
Record users of each partition to avoid duplicate iteration over nodes https://github.com/pytorch/pytorch/blob/main/torch/fx/passes/infra/partitioner.py#L133. The trip count of this loop maybe very large.
The nodes number of each partitions maybe not balance https://github.com/pytorch/pytorch/blob/main/torch/fx/passes/infra/partitioner.py#L145. We always encounter one issue: one partition has n nodes, but the other has one node. Merge the smaller partition into the larger can help to reduce time consuming.

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv