### PR TITLE
skip test_torch_dynamo_codegen_pow if CPU backend is not cpp

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -32,6 +32,7 @@ import numpy as np
 import torch
 import torch._dynamo.testing
 import torch._inductor.test_case
+import torch._inductor.config
 import torch.onnx.operators
 import torch.utils._pytree as python_pytree
 import torch.utils.cpp_extension
@@ -10627,6 +10628,9 @@ ShapeEnv not equal: field values don't match:
 
     @skipIfWindows(
         msg="AssertionError: False is not true : Encountered an unexpected fallback to 'aten pow' in dynamo compiled code"
+    @unittest.skipIf(
+        torch._inductor.config.cpu_backend != "cpp", 
+        "Skip for non cpp backend CPU as comments contain 'aten.pow' "
     )
     def test_torch_dynamo_codegen_pow(self):
         def pow(x):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -31,8 +31,8 @@ import numpy as np
 
 import torch
 import torch._dynamo.testing
-import torch._inductor.test_case
 import torch._inductor.config
+import torch._inductor.test_case
 import torch.onnx.operators
 import torch.utils._pytree as python_pytree
 import torch.utils.cpp_extension
@@ -10628,9 +10628,10 @@ ShapeEnv not equal: field values don't match:
 
     @skipIfWindows(
         msg="AssertionError: False is not true : Encountered an unexpected fallback to 'aten pow' in dynamo compiled code"
+    )
     @unittest.skipIf(
-        torch._inductor.config.cpu_backend != "cpp", 
-        "Skip for non cpp backend CPU as comments contain 'aten.pow' "
+        torch._inductor.config.cpu_backend != "cpp",
+        "Skip for non cpp backend CPU as comments contain 'aten.pow' ",
     )
     def test_torch_dynamo_codegen_pow(self):
         def pow(x):


### PR DESCRIPTION
The test asserts that `aten.pow` is not present in the generated kernel code. When using a CPU backend other than cpp, the kernel contains comments referencing the aten ops that produced the kernel in this case `aten.pow`. 

This PR skips that test case if the CPU backend is not cpp.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames