### PR TITLE
[Profiler] Enable CUPTI teardown to reduce profiler overhead

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2285,10 +2285,12 @@ class _TorchCompileInductorWrapper:
         self.apply_options(options)
         self.apply_options(CompilerBisector.get_config_change("inductor"))
 
+        from torch.version import cuda as cuda_version
+
         if self.config.get("triton.cudagraphs", False) and not (
-            torch.version.cuda
-            and int(torch.version.cuda.split(".")[0]) >= 12
-            and int(torch.version.cuda.split(".")[1]) >= 6
+            cuda_version
+            and int(cuda_version.split(".")[0]) >= 12
+            and int(cuda_version.split(".")[1]) >= 6
         ):
             os.environ["DISABLE_CUPTI_LAZY_REINIT"] = "1"
             # FIXME: CUDA Graph does not work well with CUPTI teardown.

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2285,13 +2285,21 @@ class _TorchCompileInductorWrapper:
         self.apply_options(options)
         self.apply_options(CompilerBisector.get_config_change("inductor"))
 
-        if self.config.get("triton.cudagraphs", False):
+        if self.config.get("triton.cudagraphs", False) and not (
+            torch.version.cuda
+            and int(torch.version.cuda.split(".")[0]) >= 12
+            and int(torch.version.cuda.split(".")[1]) >= 6
+        ):
             os.environ["DISABLE_CUPTI_LAZY_REINIT"] = "1"
             # FIXME: CUDA Graph does not work well with CUPTI teardown.
             #   1) crashes on 1st lazy CUPTI re-init after teardown (CUDA 11)
             #   2) crashes on 2nd non-lazy CUPTI re-init after teardown (CUDA 12)
             # Workaround: turn off CUPTI teardown when using CUDA Graphs.
+            # This was fixed in CUDA 12.6, but we keep the workaround for older versions.
             os.environ["TEARDOWN_CUPTI"] = "0"
+        else:
+            os.environ["DISABLE_CUPTI_LAZY_REINIT"] = "0"
+            os.environ["TEARDOWN_CUPTI"] = "1"
 
     def __eq__(self, other):
         return (

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2289,8 +2289,8 @@ class _TorchCompileInductorWrapper:
 
         if self.config.get("triton.cudagraphs", False) and not (
             cuda_version
-            and int(cuda_version.split(".")[0]) >= 12
-            and int(cuda_version.split(".")[1]) >= 6
+            and builtins.int(cuda_version.split(".")[0]) >= 12
+            and builtins.int(cuda_version.split(".")[1]) >= 6
         ):
             os.environ["DISABLE_CUPTI_LAZY_REINIT"] = "1"
             # FIXME: CUDA Graph does not work well with CUPTI teardown.

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2285,23 +2285,21 @@ class _TorchCompileInductorWrapper:
         self.apply_options(options)
         self.apply_options(CompilerBisector.get_config_change("inductor"))
 
-        from torch.version import cuda as cuda_version
-
         if self.config.get("triton.cudagraphs", False) and not (
-            cuda_version
-            and builtins.int(cuda_version.split(".")[0]) >= 12
-            and builtins.int(cuda_version.split(".")[1]) >= 6
+            hasattr(torch.version, "cuda") and torch.version.cuda
+            and builtins.int(torch.version.cuda.split(".")[0]) >= 12
+            and builtins.int(torch.version.cuda.split(".")[1]) >= 6
         ):
             os.environ["DISABLE_CUPTI_LAZY_REINIT"] = "1"
-            # FIXME: CUDA Graph does not work well with CUPTI teardown.
+            # CUDA Graph does not work well with CUPTI teardown.
             #   1) crashes on 1st lazy CUPTI re-init after teardown (CUDA 11)
             #   2) crashes on 2nd non-lazy CUPTI re-init after teardown (CUDA 12)
             # Workaround: turn off CUPTI teardown when using CUDA Graphs.
             # This was fixed in CUDA 12.6, but we keep the workaround for older versions.
             os.environ["TEARDOWN_CUPTI"] = "0"
         else:
-            os.environ["DISABLE_CUPTI_LAZY_REINIT"] = "0"
-            os.environ["TEARDOWN_CUPTI"] = "1"
+            os.environ["DISABLE_CUPTI_LAZY_REINIT"] = os.environ.get("DISABLE_CUPTI_LAZY_REINIT", 0)
+            os.environ["TEARDOWN_CUPTI"] = os.environ.get("TEARDOWN_CUPTI", 1)
 
     def __eq__(self, other):
         return (

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -221,14 +221,23 @@ class _KinetoProfile:
             if hasattr(torch, "_inductor"):
                 import torch._inductor.config as inductor_config
 
-                if inductor_config.triton.cudagraphs:
+                if inductor_config.triton.cudagraphs and not (
+                    torch.version.cuda
+                    and int(torch.version.cuda.split(".")[0]) >= 12
+                    and int(torch.version.cuda.split(".")[1]) >= 6
+                ):
                     os.environ["DISABLE_CUPTI_LAZY_REINIT"] = "1"
                     self.add_metadata_json("DISABLE_CUPTI_LAZY_REINIT", "1")
-                    # FIXME: CUDA Graph does not work well with CUPTI teardown.
+                    # CUDA Graph does not work well with CUPTI teardown.
                     #   1) crashes on 1st lazy CUPTI re-init after teardown (CUDA 11)
                     #   2) crashes on 2nd non-lazy CUPTI re-init after teardown (CUDA 12)
                     # Workaround: turn off CUPTI teardown when using CUDA Graphs.
+                    # This was fixed in CUDA 12.6, but we keep the workaround for older versions.
                     os.environ["TEARDOWN_CUPTI"] = "0"
+                else:
+                    os.environ["DISABLE_CUPTI_LAZY_REINIT"] = "0"
+                    self.add_metadata_json("DISABLE_CUPTI_LAZY_REINIT", "0")
+                    os.environ["TEARDOWN_CUPTI"] = "1"
 
             # Insert the preset user metadata to the trace
             for k, v in self.preset_metadata.items():

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -222,7 +222,8 @@ class _KinetoProfile:
                 import torch._inductor.config as inductor_config
 
                 if inductor_config.triton.cudagraphs and not (
-                    torch.version.cuda
+                    hasattr(torch.version, "cuda")
+                    and torch.version.cuda
                     and int(torch.version.cuda.split(".")[0]) >= 12
                     and int(torch.version.cuda.split(".")[1]) >= 6
                 ):
@@ -235,9 +236,9 @@ class _KinetoProfile:
                     # This was fixed in CUDA 12.6, but we keep the workaround for older versions.
                     os.environ["TEARDOWN_CUPTI"] = "0"
                 else:
-                    os.environ["DISABLE_CUPTI_LAZY_REINIT"] = "0"
+                    os.environ["DISABLE_CUPTI_LAZY_REINIT"] = os.environ.get("DISABLE_CUPTI_LAZY_REINIT", 0)
+                    os.environ["TEARDOWN_CUPTI"] = os.environ.get("TEARDOWN_CUPTI", 1)
                     self.add_metadata_json("DISABLE_CUPTI_LAZY_REINIT", "0")
-                    os.environ["TEARDOWN_CUPTI"] = "1"
 
             # Insert the preset user metadata to the trace
             for k, v in self.preset_metadata.items():


### PR DESCRIPTION
The problem is that the profiler slowed down
training by roughly 10-20% even after completion
because cuptiFinalize was not called in Kineto due to TEARDOWN_CUPTI=0. Disabling CUPTI teardown was a workaround for crashes which occured when CUDA graphs were used. This issue was fixed in CUDA 12.6. Also there is no point in disabling CUPTI teardown if CUDA Graphs are not used.

Fixes #144455 


cc @robieta @chaekit @guotuofeng @guyang3532 @dzhulgakov @davidberard98 @briancoutinho @sraikund16 @sanrise