### PR TITLE
[BE][Ez]: Enable some additional pylint ruff warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,9 +123,12 @@ select = [
     "PLR1722", # use sys exit
     "PLR1736", # unnecessary list index
     "PLW0129", # assert on string literal
+    "PLW0131", # named expr without context
     "PLW0133", # useless exception statement
+    "PLW0245", # super without brackets
     "PLW0406", # import self
     "PLW0711", # binary op exception
+    "PLW1501", # bad open mode
     "PLW1509", # preexec_fn not safe with threads
     "PLW2101", # useless lock statement
     "PLW3301", # nested min max


### PR DESCRIPTION
Some additional code hardening with some pylint warnings in ruff that usually indicate bugs.  All code currently conforms nicely to them, but this will ensure these errors can be detected statically before running / creating tests.

The follow rules:
* Ban walrus operators where they would have no effect over regular assignment; making intention more clear.
* Statically check for the common error of forgetting to put parens after the `super` call, which will cause an attribute error
* Ban bad string literal args to builtins `open`