### PR TITLE
[BE][Ez]: Enable ruff rule banning print in assert

### DIFF
--- a/benchmarks/dynamo/runner.py
+++ b/benchmarks/dynamo/runner.py
@@ -711,9 +711,9 @@ class ParsePerformanceLogs(Parser):
             for idx, (batch_a, batch_b) in enumerate(
                 zip(batch_sizes, frame_batch_sizes)
             ):
-                assert batch_a == batch_b or batch_a == 0 or batch_b == 0, print(
-                    f"a={batch_a}, b={batch_b}"
-                )
+                assert (
+                    batch_a == batch_b or batch_a == 0 or batch_b == 0
+                ), f"a={batch_a}, b={batch_b}"
                 batch_sizes[idx] = max(batch_a, batch_b)
         for frame in frames:
             frame["batch_size"] = batch_sizes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,8 +148,6 @@ select = [
     "RUF024", # from keys mutable
     "RUF026", # default factory kwarg
     "RUF030", # No print statement in assert
-    "RUF032", # Decimal literal
-    "RUF033", # post init defaults
     "SLOT",
     "TCH",
     "TRY002", # ban vanilla raise (todo fix NOQAs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,9 @@ select = [
     "RUF019", # unnecessary-key-check
     "RUF024", # from keys mutable
     "RUF026", # default factory kwarg
+    "RUF030", # No print statement in assert
+    "RUF032", # Decimal literal
+    "RUF033", # post init defaults
     "SLOT",
     "TCH",
     "TRY002", # ban vanilla raise (todo fix NOQAs)


### PR DESCRIPTION
Enables a few ruff rules
* Ban print statements within asserts (likely bugs)
* ~Use string for Decimal literal to prevent loss of precision~ 
* ~Do not use default args for __post__init__ in dataclasses, they likely were meant to go into the factory method, the __init__, or somewhere else. The default values are useless here.~

Wait until ruff upgrade for the last 2

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @StrongerXi