### PR TITLE
Generate test reports for pytest when option is given

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -35,6 +35,7 @@ from torch.testing._internal.common_utils import (
     set_cwd,
     shell,
     TEST_CUDA,
+    TEST_SAVE_XML,
     TEST_WITH_ASAN,
     TEST_WITH_CROSSREF,
     TEST_WITH_ROCM,
@@ -1427,7 +1428,7 @@ def get_pytest_args(options, is_cpp_test=False, is_distributed_test=False):
         # is much slower than running them directly
         pytest_args.extend(["-n", str(NUM_PROCS)])
 
-        if IS_CI:
+        if TEST_SAVE_XML:
             # Add the option to generate XML test report here as C++ tests
             # won't go into common_utils
             test_report_path = get_report_path(pytest=True)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1230,7 +1230,7 @@ def run_tests(argv=UNITTEST_ARGS):
         if RERUN_DISABLED_TESTS:
             other_args.append("--rerun-disabled-tests")
         if TEST_SAVE_XML:
-            other_args += ['--save-xml', args.save_xml]
+            other_args += ['--save-xml', TEST_SAVE_XML]
 
         test_cases = (
             get_pytest_test_cases(argv) if USE_PYTEST else
@@ -1301,7 +1301,7 @@ def run_tests(argv=UNITTEST_ARGS):
             # Only record the test report and always return a success code when running under rerun
             # disabled tests mode
             sys.exit(0)
-    elif TEST_SAVE_XML is not None:
+    elif TEST_SAVE_XML:
         # import here so that non-CI doesn't need xmlrunner installed
         import xmlrunner  # type: ignore[import]
         from xmlrunner.result import _XMLTestResult  # type: ignore[import]


### PR DESCRIPTION
The argument needs to be appended when test reports should be generated. `IS_CI` is not necessarily set, so rather check `TEST_SAVE_XML` instead as in other places where test reports are conditionally enabled.

See also https://github.com/pytorch/pytorch/issues/126523