### PR TITLE
Fix inductor non-stable argsort/sort test

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3502,13 +3502,6 @@ class CommonTemplate:
     @skip_if_halide  # only 32-bit indexing
     @largeTensorTest("4GB", inductor=True)
     def test_large_pointwise(self):
-        # If this is running with cpp_wrapper, the auto-tuning step will generate an
-        # additional array of the same size as the input.  Numbers derived
-        # experimentally.
-        required_memory = 2**32 + 2**31 + 2**15 if config.cpp_wrapper else 2**31 + 2**15
-        if not _has_sufficient_memory(self.device, required_memory):
-            raise unittest.SkipTest("insufficient memory")
-
         def fn(a):
             return a + 1
 
@@ -5098,11 +5091,9 @@ class CommonTemplate:
 
         eager_version_counters_after = [
             # TODO: remove the + 1 after https://github.com/pytorch/pytorch/issues/120622 is fixed
-            (
-                buffer._version + 1
-                if k in ["m.running_mean", "m.running_var"]
-                else buffer._version
-            )
+            buffer._version + 1
+            if k in ["m.running_mean", "m.running_var"]
+            else buffer._version
             for k, buffer in model_for_eager.named_buffers()
         ]
 
@@ -12420,12 +12411,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         Currently inductor will skip such bad configs and pick the best one
         from the remaining configs.
         """
-        # If this is running with cpp_wrapper, the auto-tuning step will generate an
-        # additional array of the same size as the input.  Numbers derived
-        # experimentally.
-        required_memory = 2**34 + 2**32 + 2**31 if config.cpp_wrapper else 2**33 + 2**32 + 2**31
-        if not _has_sufficient_memory(self.device, required_memory):
-            raise unittest.SkipTest("insufficient memory")
 
         @torch.compile
         def fn(x, y):
@@ -14466,11 +14451,9 @@ if RUN_GPU:
                 ),
                 (
                     fn3,
-                    (
-                        "triton_poi_fused_layer_norm_relu"
-                        if torch._dynamo.config.inline_inbuilt_nn_modules
-                        else "triton_poi_fused_LayerNorm_ReLU"
-                    ),
+                    "triton_poi_fused_layer_norm_relu"
+                    if torch._dynamo.config.inline_inbuilt_nn_modules
+                    else "triton_poi_fused_LayerNorm_ReLU",
                     (torch.randn(4, 4, device=GPU_TYPE),),
                 ),
             ]

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5091,9 +5091,11 @@ class CommonTemplate:
 
         eager_version_counters_after = [
             # TODO: remove the + 1 after https://github.com/pytorch/pytorch/issues/120622 is fixed
-            buffer._version + 1
-            if k in ["m.running_mean", "m.running_var"]
-            else buffer._version
+            (
+                buffer._version + 1
+                if k in ["m.running_mean", "m.running_var"]
+                else buffer._version
+            )
             for k, buffer in model_for_eager.named_buffers()
         ]
 
@@ -14451,9 +14453,11 @@ if RUN_GPU:
                 ),
                 (
                     fn3,
-                    "triton_poi_fused_layer_norm_relu"
-                    if torch._dynamo.config.inline_inbuilt_nn_modules
-                    else "triton_poi_fused_LayerNorm_ReLU",
+                    (
+                        "triton_poi_fused_layer_norm_relu"
+                        if torch._dynamo.config.inline_inbuilt_nn_modules
+                        else "triton_poi_fused_LayerNorm_ReLU"
+                    ),
                     (torch.randn(4, 4, device=GPU_TYPE),),
                 ),
             ]

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -2,6 +2,7 @@
 import atexit
 import contextlib
 import functools
+import math
 import os
 import sys
 import unittest
@@ -964,6 +965,131 @@ inductor_one_sample["xpu"] = {
 }
 
 
+# Custom replacements for assertEquals, in cases where a difference in value
+# may not indicate correctness.
+
+
+def get_sort_argsort_assert_equal_fn(is_argsort, args, kwargs):
+    # The normal assert_equal_fn suffices for a stable sort
+    def normal_assert_fn(
+        test_case_inst, x, y, *, atol=None, rtol=None, equal_nan=True, exact_dtype=True
+    ):
+        test_case_inst.assertEqual(
+            x[0],
+            y[0],
+            atol=atol,
+            rtol=rtol,
+            equal_nan=equal_nan,
+            exact_dtype=exact_dtype,
+        )
+
+    if "stable" in kwargs.keys():
+        if kwargs["stable"]:
+            return normal_assert_fn
+
+    # In other cases, we need only check that the sort/argsort outputs are
+    # compatible.
+    orig_input = args[0]
+
+    # The sort dimension is specified as a kwarg, or the last dimension.
+    if "dim" not in kwargs:
+        dim = orig_input.dim() - 1
+    else:
+        dim = kwargs["dim"]
+
+    def argsort_sort_assert_equal(
+        test_case_inst, x, y, *, atol=None, rtol=None, equal_nan=True, exact_dtype=True
+    ):
+
+        if is_argsort:
+            assert isinstance(x, torch.Tensor)
+            assert isinstance(y, torch.Tensor)
+        else:
+            # The first tensor is the sorted values and can be asserted via
+            # the usual means
+            for t in (x, y):
+                assert isinstance(t, tuple)
+                assert len(t) == 2
+
+            test_case_inst.assertEqual(
+                x[0],
+                y[0],
+                atol=atol,
+                rtol=rtol,
+                equal_nan=equal_nan,
+                exact_dtype=exact_dtype,
+            )
+
+            # The second tensor is the same result as an argsort.
+            x = x[1]
+            y = y[1]
+
+        if exact_dtype and (x.dtype != y.dtype):
+            raise AssertionError(f"The dtypes do not match: {x.dtype} != {y.dtype}.")
+
+        assert x.shape == y.shape
+
+        def el_to_indices(el):
+            """Turn an element number into a list of indices"""
+            indices = [None] * x.dim()
+            for cur_dim in reversed(range(x.dim())):
+                indices[cur_dim] = el % x.shape[cur_dim]
+                el //= x.shape[cur_dim]
+            assert None not in indices
+            return indices
+
+        def get_val_by_ids(t, ids):
+            """Return a value from a tensor at a given list of indices"""
+            for idx in ids:
+                t = t[idx]
+            return t.item()
+
+        # Loop through every value of the tensors and check for equality or
+        # compatibility.
+        for current_el in range(x.numel()):
+            ids = el_to_indices(current_el)
+
+            # Simple case: check equality of arsort indices
+            if get_val_by_ids(x, ids) == get_val_by_ids(y, ids):
+                continue
+
+            # Complex case: check if indices refer to same value
+            x_orig_ids = ids.copy()
+            y_orig_ids = ids.copy()
+
+            x_orig_ids[dim] = get_val_by_ids(x, ids)
+            y_orig_ids[dim] = get_val_by_ids(y, ids)
+
+            x_value = get_val_by_ids(orig_input, x_orig_ids)
+            y_value = get_val_by_ids(orig_input, y_orig_ids)
+            if x_value == y_value:
+                continue
+
+            if equal_nan:
+                if math.isnan(x_value) and math.isnan(y_value):
+                    continue
+
+            raise AssertionError(
+                "Non-stable argsort outputs are " f"incompatible at {ids}"
+            )
+
+    return argsort_sort_assert_equal
+
+
+def get_argsort_assert_equal_fn(args, kwargs):
+    return get_sort_argsort_assert_equal_fn(True, args, kwargs)
+
+
+def get_sort_assert_equal_fn(args, kwargs):
+    return get_sort_argsort_assert_equal_fn(False, args, kwargs)
+
+
+CUSTOM_ASSERT_EQUALS_FNS = {
+    "argsort": get_argsort_assert_equal_fn,
+    "sort": get_sort_assert_equal_fn,
+}
+
+
 def collection_decorator(fn):
     @functools.wraps(fn)
     def inner(self, device, dtype, op):
@@ -1120,7 +1246,7 @@ class TestInductorOpInfo(TestCase):
 
             return True, rng_mode.has_rng_op
 
-        def get_contexts(has_rng_op):
+        def get_contexts(has_rng_op, args, kwargs):
             if has_rng_op:
                 # TODO - enable this, running into errors
                 return (
@@ -1137,6 +1263,15 @@ class TestInductorOpInfo(TestCase):
                 )
 
             ctx = functools.partial(maybe_skip_size_asserts, op)
+            if op_name in CUSTOM_ASSERT_EQUALS_FNS.keys():
+                assert_equal_fn = CUSTOM_ASSERT_EQUALS_FNS[op_name](args, kwargs)
+                return (
+                    (
+                        ctx,
+                        {"assert_equal": assert_equal_fn},
+                    ),
+                )
+
             return ((ctx, {}),)
 
         try:
@@ -1162,7 +1297,7 @@ class TestInductorOpInfo(TestCase):
                 #     print(f"RUNNING OP {op_name} on {device_type} with {dtype}", flush=True)
                 rtol, atol = _get_tolerances(dtype)
                 no_python, has_rng_op = do_nopython_and_has_rng(fn, args, kwargs)
-                for context_fn, kwarg_overrides in get_contexts(has_rng_op):
+                for context_fn, kwarg_overrides in get_contexts(has_rng_op, args, kwargs):
                     with context_fn():
                         # Base kwargs
                         adjusted_kwargs = {

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -1056,7 +1056,7 @@ def get_sort_argsort_assert_equal_fn(is_argsort, args, kwargs):
                     continue
 
             raise AssertionError(
-                "Non-stable argsort outputs are " f"incompatible at {ids}"
+                f"Non-stable argsort outputs are incompatible at {ids}"
             )
 
     return argsort_sort_assert_equal
@@ -1283,7 +1283,9 @@ class TestInductorOpInfo(TestCase):
                 #     print(f"RUNNING OP {op_name} on {device_type} with {dtype}", flush=True)
                 rtol, atol = _get_tolerances(dtype)
                 no_python, has_rng_op = do_nopython_and_has_rng(fn, args, kwargs)
-                for context_fn, kwarg_overrides in get_contexts(has_rng_op, args, kwargs):
+                for context_fn, kwarg_overrides in get_contexts(
+                    has_rng_op, args, kwargs
+                ):
                     with context_fn():
                         # Base kwargs
                         adjusted_kwargs = {

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -970,22 +970,9 @@ inductor_one_sample["xpu"] = {
 
 
 def get_sort_argsort_assert_equal_fn(is_argsort, args, kwargs):
-    # The normal assert_equal_fn suffices for a stable sort
-    def normal_assert_fn(
-        test_case_inst, x, y, *, atol=None, rtol=None, equal_nan=True, exact_dtype=True
-    ):
-        test_case_inst.assertEqual(
-            x[0],
-            y[0],
-            atol=atol,
-            rtol=rtol,
-            equal_nan=equal_nan,
-            exact_dtype=exact_dtype,
-        )
-
-    if "stable" in kwargs.keys():
-        if kwargs["stable"]:
-            return normal_assert_fn
+    # Use the normal assert_equal_fn suffices for a stable sort
+    if "stable" in kwargs:
+        return True
 
     # In other cases, we need only check that the sort/argsort outputs are
     # compatible.
@@ -1000,7 +987,6 @@ def get_sort_argsort_assert_equal_fn(is_argsort, args, kwargs):
     def argsort_sort_assert_equal(
         test_case_inst, x, y, *, atol=None, rtol=None, equal_nan=True, exact_dtype=True
     ):
-
         if is_argsort:
             assert isinstance(x, torch.Tensor)
             assert isinstance(y, torch.Tensor)
@@ -1263,7 +1249,7 @@ class TestInductorOpInfo(TestCase):
                 )
 
             ctx = functools.partial(maybe_skip_size_asserts, op)
-            if op_name in CUSTOM_ASSERT_EQUALS_FNS.keys():
+            if op_name in CUSTOM_ASSERT_EQUALS_FNS:
                 assert_equal_fn = CUSTOM_ASSERT_EQUALS_FNS[op_name](args, kwargs)
                 return (
                     (


### PR DESCRIPTION
- Prevent the inductor test for argsort/sort from wrongly failing when the argsort/sort output with stable=False differs from pytorch but is still a valid argsort output.
- Add functionality to allow alternative assert_equal functions in inductor tests for future cases.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @yf225 @desertfire