### PR TITLE
[torch] fix builds for older pybind

### DIFF
--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -785,7 +785,7 @@ void initJitScriptBindings(PyObject* module) {
                 try {
                   return toPyObject(self.attr(name));
                 } catch (const ObjectAttributeError& err) {
-                  pybind11::set_error(PyExc_AttributeError, err.what());
+                  PyErr_SetString(PyExc_AttributeError, err.what());
                   throw py::error_already_set();
                 }
               })
@@ -807,7 +807,7 @@ void initJitScriptBindings(PyObject* module) {
                   }
                   return toPyObject(self.attr(name));
                 } catch (const ObjectAttributeError& err) {
-                  pybind11::set_error(PyExc_AttributeError, err.what());
+                  PyErr_SetString(PyExc_AttributeError, err.what());
                   throw py::error_already_set();
                 }
               })
@@ -838,7 +838,7 @@ void initJitScriptBindings(PyObject* module) {
                   auto ivalue = toIValue(std::move(value), type);
                   self.setattr(name, ivalue);
                 } catch (const ObjectAttributeError& err) {
-                  pybind11::set_error(PyExc_AttributeError, err.what());
+                  PyErr_SetString(PyExc_AttributeError, err.what());
                   throw py::error_already_set();
                 }
               })


### PR DESCRIPTION
Summary:
some versions of pybind we build with don't have `py::set_error`.

So just use the underlying python C API.

Test Plan: unit tests

Differential Revision: D69254629




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel