### PR TITLE
Add Structured Tracing for Traced Graph Edge Details for AC Debugging

### DIFF
--- a/test/functorch/test_ac_logging.py
+++ b/test/functorch/test_ac_logging.py
@@ -1,0 +1,151 @@
+# Owner(s): ["module: functorch"]
+from typing import Dict, List, Tuple
+from unittest.mock import MagicMock, patch
+
+from torch._functorch._activation_checkpointing.ac_logging_utils import (
+    create_activation_checkpointing_logging_structure_payload,
+    create_joint_graph_edges,
+    create_joint_graph_node_information,
+    create_structured_trace_for_min_cut_info,
+)
+from torch.fx import Graph, Node
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestAcLogging(TestCase):
+    def setUp(self) -> None:
+        self.graph: MagicMock = MagicMock(spec=Graph)
+        self.node1: MagicMock = MagicMock(spec=Node)
+        self.node2: MagicMock = MagicMock(spec=Node)
+
+        self.node1.name = "node1"
+        self.node1.target = "target1"
+        self.node1.meta = {
+            "tensor_meta": MagicMock(shape=(2, 2)),
+            "stack_trace": "trace1",
+        }
+        self.node1.all_input_nodes = []
+
+        self.node2.name = "node2"
+        self.node2.target = "target2"
+        self.node2.meta = {"tensor_meta": None, "stack_trace": "trace2"}
+        self.node2.all_input_nodes = [self.node1]
+
+        self.graph.nodes = [self.node1, self.node2]
+
+        self.all_recomputable_banned_nodes: List[Node] = [self.node1]
+        self.saved_node_idxs: List[int] = [0]
+        self.recomputable_node_idxs: List[int] = []
+        self.expected_runtime: int = 100
+        self.memories_banned_nodes: List[int] = [50]
+        self.runtimes_banned_nodes: List[int] = [10]
+        self.min_cut_saved_values: List[Node] = [self.node1]
+
+    def test_create_joint_graph_node_information(self) -> None:
+        recomputable_node_info: Dict[str, int] = {"node1": 0}
+        expected_output: Dict[str, Dict] = {
+            "node1": {
+                "index": 0,
+                "name": "node1",
+                "is_recomputable_candidate": True,
+                "target": "target1",
+                "shape": "(2, 2)",
+                "input_arguments": [],
+                "stack_trace": "trace1",
+                "recomputable_candidate_info": {"recomputable_node_idx": 0},
+            },
+            "node2": {
+                "index": 1,
+                "name": "node2",
+                "is_recomputable_candidate": False,
+                "target": "target2",
+                "shape": "[]",
+                "input_arguments": ["node1"],
+                "stack_trace": "trace2",
+            },
+        }
+        result = create_joint_graph_node_information(self.graph, recomputable_node_info)
+        self.assertEqual(result, expected_output)
+
+    def test_create_joint_graph_edges(self) -> None:
+        expected_edges: List[Tuple[str, str]] = [("node1", "node2")]
+        result = create_joint_graph_edges(self.graph)
+        self.assertEqual(result, expected_edges)
+
+    def test_create_activation_checkpointing_logging_structure_payload(self) -> None:
+        input_joint_graph_node_information: Dict[str, Dict] = {
+            "node1": {
+                "index": 0,
+                "name": "node1",
+                "is_recomputable_candidate": True,
+                "target": "target1",
+                "shape": "(2, 2)",
+                "input_arguments": [],
+                "stack_trace": "trace1",
+                "recomputable_candidate_info": {"recomputable_node_idx": 0},
+            }
+        }
+        joint_graph_edges: List[Tuple[str, str]] = [("node1", "node2")]
+        expected_payload: Dict[str, any] = {
+            "Joint Graph Size": 2,
+            "Joint Graph Edges": {"Total": 1, "Edges": joint_graph_edges},
+            "Joint Graph Node Information": input_joint_graph_node_information,
+            "Recomputable Banned Nodes Order": ["node1"],
+            "Expected Runtime": self.expected_runtime,
+            "Knapsack Saved Nodes": self.saved_node_idxs,
+            "Knapsack Recomputed Nodes": self.recomputable_node_idxs,
+            "Knapsack Input Memories": self.memories_banned_nodes,
+            "Knapsack Input Runtimes": self.runtimes_banned_nodes,
+            "Min Cut Solution Saved Values": ["node1"],
+        }
+        result = create_activation_checkpointing_logging_structure_payload(
+            self.graph,
+            input_joint_graph_node_information,
+            joint_graph_edges,
+            self.all_recomputable_banned_nodes,
+            self.expected_runtime,
+            self.saved_node_idxs,
+            self.recomputable_node_idxs,
+            self.memories_banned_nodes,
+            self.runtimes_banned_nodes,
+            self.min_cut_saved_values,
+        )
+        self.assertEqual(result, expected_payload)
+
+    @patch(
+        "torch._functorch._activation_checkpointing.ac_logging_utils.trace_structured"
+    )
+    @patch("json.dumps", return_value="mocked_payload")
+    def test_create_structured_trace_for_min_cut_info(
+        self, mock_json_dumps: MagicMock, mock_trace_structured: MagicMock
+    ) -> None:
+        create_structured_trace_for_min_cut_info(
+            self.graph,
+            self.all_recomputable_banned_nodes,
+            self.saved_node_idxs,
+            self.recomputable_node_idxs,
+            self.expected_runtime,
+            self.memories_banned_nodes,
+            self.runtimes_banned_nodes,
+            self.min_cut_saved_values,
+        )
+
+        self.assertEqual(mock_trace_structured.call_count, 1)
+
+        metadata_fn_result = mock_trace_structured.call_args[1]["metadata_fn"]()
+        payload_fn_result = mock_trace_structured.call_args[1]["payload_fn"]()
+
+        self.assertEqual(
+            metadata_fn_result,
+            {
+                "name": "min_cut_information",
+                "encoding": "json",
+            },
+        )
+        self.assertEqual(payload_fn_result, "mocked_payload")
+
+        mock_json_dumps.assert_called_once()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_functorch/_activation_checkpointing/ac_logging_utils.py
+++ b/torch/_functorch/_activation_checkpointing/ac_logging_utils.py
@@ -1,0 +1,145 @@
+import json
+import logging
+from typing import Any, Dict, List, Tuple
+
+from torch._logging import trace_structured
+from torch.fx import Graph, Node
+
+
+log: logging.Logger = logging.getLogger(__name__)
+
+
+def create_joint_graph_node_information(
+    joint_graph: Graph,
+    recomputable_node_info: Dict[str, int],
+) -> Dict[str, Any]:
+    joint_graph_node_information: Dict[str, Any] = {}
+
+    for i, joint_graph_node in enumerate(joint_graph.nodes):
+        is_recomputable_candidate: bool = (
+            joint_graph_node.name in recomputable_node_info
+        )
+        tensor_meta = joint_graph_node.meta.get("tensor_meta")
+        shape = getattr(tensor_meta, "shape", []) if tensor_meta else []
+
+        node_info: Dict[str, Any] = {
+            "index": i,
+            "name": joint_graph_node.name,
+            "is_recomputable_candidate": is_recomputable_candidate,
+            "target": str(joint_graph_node.target),
+            "shape": str(shape),
+            "input_arguments": [inp.name for inp in joint_graph_node.all_input_nodes],
+            "stack_trace": joint_graph_node.meta.get("stack_trace", ""),
+        }
+
+        if is_recomputable_candidate:
+            idx: int = recomputable_node_info[joint_graph_node.name]
+            node_info["recomputable_candidate_info"] = {
+                "recomputable_node_idx": idx,
+            }
+
+        joint_graph_node_information[joint_graph_node.name] = node_info
+
+    return joint_graph_node_information
+
+
+def create_joint_graph_edges(joint_graph: Graph) -> List[Tuple[str, str]]:
+    joint_graph_edges: List[Tuple[str, str]] = [
+        (inp.name, node.name)
+        for node in joint_graph.nodes
+        for inp in node.all_input_nodes
+    ]
+    return joint_graph_edges
+
+
+def create_activation_checkpointing_logging_structure_payload(
+    joint_graph: Graph,
+    joint_graph_node_information: Dict[str, Any],
+    joint_graph_edges: List[Tuple[str, str]],
+    all_recomputable_banned_nodes: List[Node],
+    expected_runtime: float,
+    saved_node_idxs: List[int],
+    recomputable_node_idxs: List[int],
+    memories_banned_nodes: List[float],
+    runtimes_banned_nodes: List[float],
+    min_cut_saved_values: List[Node],
+) -> Dict[str, Any]:
+    activation_checkpointing_logging_structure_payload: Dict[str, Any] = {
+        "Joint Graph Size": len(joint_graph.nodes),
+        "Joint Graph Edges": {
+            "Total": len(joint_graph_edges),
+            "Edges": joint_graph_edges,
+        },
+        "Joint Graph Node Information": joint_graph_node_information,
+        "Recomputable Banned Nodes Order": [
+            node.name for node in all_recomputable_banned_nodes
+        ],
+        "Expected Runtime": expected_runtime,
+        "Knapsack Saved Nodes": saved_node_idxs,
+        "Knapsack Recomputed Nodes": recomputable_node_idxs,
+        "Knapsack Input Memories": memories_banned_nodes,
+        "Knapsack Input Runtimes": runtimes_banned_nodes,
+        "Min Cut Solution Saved Values": [node.name for node in min_cut_saved_values],
+    }
+    return activation_checkpointing_logging_structure_payload
+
+
+def create_structured_trace_for_min_cut_info(
+    joint_graph: Graph,
+    all_recomputable_banned_nodes: List[Node],
+    saved_node_idxs: List[int],
+    recomputable_node_idxs: List[int],
+    expected_runtime: float,
+    memories_banned_nodes: List[float],
+    runtimes_banned_nodes: List[float],
+    min_cut_saved_values: List[Node],
+) -> None:
+    recomputable_node_info: Dict[str, int] = {
+        node.name: idx for idx, node in enumerate(all_recomputable_banned_nodes)
+    }
+    joint_graph_node_information = create_joint_graph_node_information(
+        joint_graph, recomputable_node_info
+    )
+
+    for node_name, node_info in joint_graph_node_information.items():
+        if node_info["is_recomputable_candidate"]:
+            idx = recomputable_node_info[node_name]
+            node_info["recomputable_candidate_info"]["memory"] = memories_banned_nodes[
+                idx
+            ]
+            node_info["recomputable_candidate_info"]["runtime"] = runtimes_banned_nodes[
+                idx
+            ]
+            node_info["recomputable_candidate_info"]["is_saved"] = (
+                idx in saved_node_idxs
+            )
+            node_info["recomputable_candidate_info"]["is_recomputed"] = (
+                idx in recomputable_node_idxs
+            )
+
+    joint_graph_edges = create_joint_graph_edges(joint_graph)
+    activation_checkpointing_logging_structure_payload = (
+        create_activation_checkpointing_logging_structure_payload(
+            joint_graph,
+            joint_graph_node_information,
+            joint_graph_edges,
+            all_recomputable_banned_nodes,
+            expected_runtime,
+            saved_node_idxs,
+            recomputable_node_idxs,
+            memories_banned_nodes,
+            runtimes_banned_nodes,
+            min_cut_saved_values,
+        )
+    )
+
+    trace_structured(
+        "artifact",
+        metadata_fn=lambda: {
+            "name": "min_cut_information",
+            "encoding": "json",
+        },
+        payload_fn=lambda: json.dumps(
+            activation_checkpointing_logging_structure_payload
+        ),
+    )


### PR DESCRIPTION
Summary:
Updating the structured trace infrastructure so that we are able to output to Zoomer and have an E2E solution.

Context Doc: https://docs.google.com/document/d/1T6omIBEWVhbOiwDLSLffgQwjxiT2rQv8QvvQwXkw4fY/edit?usp=sharing

Test Plan:
### Testing Structured Log + tlparse locally

Command:
```
TORCH_TRACE=/data/users/basilwong/fbsource/fbcode/log_torch_trace buck2 run mode/opt //aps_models/ads/icvr:icvr_launcher -- mode=local_fb_fm_v4 launcher.num_workers=2
```

Torch Trace Logs (local then sent to paste): P1686419449
```
cat log_torch_trace/dedicated_log_torch_trace_rank_0_2lg012xo.log | pastry
P1686419449
```

tlparse output: https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmpyiv5wj/rank_1/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=100

tlparse graph edge details output: https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmpyiv5wj/rank_1/9_0_0/joint_graph_information_397.txt?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=100

Differential Revision: D61557220


