### PR TITLE
[inductor] Use index_dtype (int32/int64 depending on size) for argmax accumulators

### DIFF
--- a/test/inductor/test_cooperative_reductions.py
+++ b/test/inductor/test_cooperative_reductions.py
@@ -255,6 +255,23 @@ class TestFixedConfigs(TestCase):
             )
         ]
         self._check(fn, args, persistent=persistent, cfg=cfg)
+        args = [
+            torch.stack(
+                [
+                    torch.tensor(
+                        [0.0] * 150 + [float("inf")] * 150,
+                        device="cuda",
+                        dtype=torch.float32,
+                    ),
+                    torch.tensor(
+                        [0.0] * 150 + [-float("inf")] * 150,
+                        device="cuda",
+                        dtype=torch.float32,
+                    ),
+                ]
+            )
+        ]
+        self._check(fn, args, persistent=persistent, cfg=cfg)
 
     @parametrize("persistent", [False, True])
     @parametrize("rsplit", [32, 33])

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2536,9 +2536,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
             if reduction_type in ("argmax", "argmin"):
                 accumulator_index = f"_{result_var}_index"
-                long_max = torch.iinfo(torch.int64).max
+                index_dtype = self.features.select_index_dtype()
                 self.body.writeline(
-                    f"{accumulator_index} = tl.full({self.dense_size_str()}, {long_max}, tl.int64)"
+                    f"{accumulator_index} = tl.full({self.dense_size_str()}, "
+                    f"{torch.iinfo(index_dtype).max}, {self.dtype_to_str(index_dtype)})"
                 )
                 root_op = {"argmax": "max", "argmin": "min"}[reduction_type]
 
@@ -2600,8 +2601,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 peer_val = self.codegen_cooperative_reduction_peer_combine(
                     f"{result_var}_bval", src_dtype, default
                 )
+                index_dtype = self.features.select_index_dtype()
                 peer_idx = self.codegen_cooperative_reduction_peer_combine(
-                    result_var, dtype, 0
+                    result_var, index_dtype, torch.iinfo(index_dtype).max
                 )
                 final_argreduce(self.post_loop_store, result_var, peer_val, peer_idx)
             elif is_welford_reduction(reduction_type):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146651



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang @aakhundov