### PR TITLE
[DCP] Introduce modules metadata in the storage_meta

### DIFF
--- a/torch/distributed/checkpoint/metadata.py
+++ b/torch/distributed/checkpoint/metadata.py
@@ -131,6 +131,7 @@ class StorageMeta:
     checkpoint_id: Union[str, os.PathLike, None] = None
     save_id: Optional[str] = None
     load_id: Optional[str] = None
+    modules: list[str] = field(default_factory=list)
 
 
 @dataclass


### PR DESCRIPTION
Summary: Introduce the list of modules in the storage_meta which is shared between the planner and the storage writer. We will use it to let the storage writer know about the modules in the state dict and create module directories in the checkpoint.

Test Plan: UTs




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn @ekr0