### PR TITLE
[FlexAttention] Fix dynamic shapes in max-autotune

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -3284,6 +3284,26 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         torch.testing.assert_close(out_eager, out_compiled, atol=3e-3, rtol=2e-3)
 
     @supported_platform
+    def test_dynamic_shapes_with_max_autotune(self):
+        make_tensor = functools.partial(
+            torch.ones,
+            (8, 8, 1024, 64),
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        query, key, value = make_tensor(), make_tensor(), make_tensor()
+        block_mask = create_block_mask(_causal_mask, None, None, 1024, 1024)
+
+        out_eager = flex_attention(query, key, value, block_mask=block_mask)
+
+        flex_compile = torch.compile(
+            flex_attention, fullgraph=True, dynamic=True, mode="max-autotune"
+        )
+        out_compiled = flex_compile(query, key, value, block_mask=block_mask)
+
+        torch.testing.assert_close(out_eager, out_compiled, atol=3e-3, rtol=2e-3)
+
+    @supported_platform
     def test_causal_block_non_divisible_with_captured_buffer(self):
         Q_S = S - 3
         KV_S = S - 3

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -823,10 +823,10 @@ def create_num_blocks_fake_generator(sparse_indices):
     # autotuning will take longer for no good reason.
     def create_num_blocks_fake(x) -> torch.Tensor:
         # Add the guards
-        num_blocks_for_autotuning = V.graph.sizevars.evaluate_static_shape(
+        num_blocks_for_autotuning = V.graph.sizevars.size_hint(
             sparse_indices.shape[-1]
         )
-        size = [V.graph.sizevars.evaluate_static_shape(i) for i in x.get_size()]
+        size = [V.graph.sizevars.size_hint(i) for i in x.get_size()]
         return torch.full(
             size,
             int(num_blocks_for_autotuning),
@@ -838,7 +838,7 @@ def create_num_blocks_fake_generator(sparse_indices):
 
 
 def create_indices_fake(x) -> torch.Tensor:
-    size = [V.graph.sizevars.evaluate_static_shape(i) for i in x.get_size()]
+    size = [V.graph.sizevars.size_hint(i) for i in x.get_size()]
     indices = torch.arange(
         0, size[-1], dtype=x.get_dtype(), device=x.get_device()
     )

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -822,14 +822,11 @@ def create_num_blocks_fake_generator(sparse_indices):
     # If it's too short then prefetching won't help. If it's too long then
     # autotuning will take longer for no good reason.
     def create_num_blocks_fake(x) -> torch.Tensor:
-        # Add the guards
-        num_blocks_for_autotuning = V.graph.sizevars.size_hint(
-            sparse_indices.shape[-1]
-        )
+        num_blocks_for_autotuning = V.graph.sizevars.size_hint(sparse_indices.shape[-1])
         size = [V.graph.sizevars.size_hint(i) for i in x.get_size()]
         return torch.full(
             size,
-            int(num_blocks_for_autotuning),
+            num_blocks_for_autotuning,
             dtype=x.get_dtype(),
             device=x.get_device(),
         )
@@ -839,9 +836,7 @@ def create_num_blocks_fake_generator(sparse_indices):
 
 def create_indices_fake(x) -> torch.Tensor:
     size = [V.graph.sizevars.size_hint(i) for i in x.get_size()]
-    indices = torch.arange(
-        0, size[-1], dtype=x.get_dtype(), device=x.get_device()
-    )
+    indices = torch.arange(0, size[-1], dtype=x.get_dtype(), device=x.get_device())
     indices = indices.expand(size).contiguous()
     return indices
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146657


# Fixes
https://github.com/pytorch/pytorch/issues/146624

### Updated

From offline discussion going w/ sizehint



However this does incur guards. I couldn't really think of a fancy way to do this. I was going to do `V.graph.sizevars.size_hint` w/ some default for num blocks, but we ultimately need some information about the input. 

I am also not sure if size_hint is ALWAYS guaranteed to return the runtime value. I think it would be okay to not supported unbacked symints (maybe).

 For instance, in the repro, we quickly hit the recompile limit.
 ```Shell
 torch._dynamo hit config.recompile_limit (8)
   function: 'flex_attention' (/home/drisspg/meta/pytorch/torch/nn/attention/flex_attention.py:1161)
   last reason: 0/0: tensor 'L['key']' size mismatch at index 2. expected 1, actual 546
To log all recompilation reasons, use TORCH_LOGS="recompiles".
To diagnose recompilation issues, see https://pytorch.org/docs/main/torch.compiler_troubleshooting.html.
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang @aakhundov @Chillee @yanboliang @BoyuanFeng