### PR TITLE
[Optimus] Include more corner cases in the select cat aten pass

### DIFF
--- a/test/inductor/test_split_cat_fx_aten_passes.py
+++ b/test/inductor/test_split_cat_fx_aten_passes.py
@@ -52,7 +52,7 @@ class TestSelectCat(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor, y: torch.Tensor):
         select = torch.ops.aten.select.int(x, 1, 0)
         select_1 = torch.ops.aten.select.int(x, 1, 1)
         select_2 = torch.ops.aten.select.int(x, 1, 2)
@@ -62,7 +62,19 @@ class TestSelectCat(torch.nn.Module):
         cat = torch.ops.aten.cat.default(
             [select, select_1, select_2, select_3, select_4, select_5], 1
         )
-        return cat
+        cat1 = torch.ops.aten.cat.default(
+            [select, select_1, select_2, select_3, select_4], 1
+        )
+        cat2 = torch.ops.aten.cat.default([select, select_2, select_4], 1)
+        select_6 = torch.ops.aten.select.int(y, 1, 0)
+        select_7 = torch.ops.aten.select.int(y, 1, 1)
+        select_8 = torch.ops.aten.select.int(y, 1, 2)
+        select_9 = torch.ops.aten.select.int(y, 1, 3)
+        select_10 = torch.ops.aten.select.int(y, 1, 4)
+        cat3 = torch.ops.aten.cat.default(
+            [select_6, select_7, select_8, select_9, select_10], 1
+        )
+        return cat, cat1, cat2, cat3
 
 
 class TestSplitCatAten(TestCase):
@@ -130,13 +142,14 @@ class TestSplitCatAten(TestCase):
         counters.clear()
         inputs = [
             torch.randn(1024, 6, 128, device=torch.device(device=GPU_TYPE)),
+            torch.randn(1024, 6, 128, device=torch.device(device=GPU_TYPE)),
         ]
         module = TestSelectCat()
         traced = torch.compile(module)
         ref = module(*inputs)
         res = traced(*inputs)
         self.compare_pred(module, traced, inputs)
-        self.assertEqual(counters["inductor"]["normalization_aten_pass"], 1)
+        self.assertEqual(counters["inductor"]["normalization_aten_pass"], 4)
         self.assertEqual(counters["inductor"]["select_cat_aten_pass"], 1)
         self.assertEqual(ref, res, rtol=1e-8, atol=1e-8)
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -1747,38 +1747,43 @@ def merge_select_cat_aten(match: Match, *args, **kwargs):
     node_input = get_arg_value(node, 0, "tensors")
     # get the select nodes from the node
     select_nodes = list(node_input.users.keys())
-    cat_node = next(iter(select_nodes[0].users.keys()))
-    cat_dim = get_arg_value(cat_node, 1, "dim")
-    cat_inputs = get_arg_value(cat_node, 0, "tensors")
-    # check all select nodes has same slice dim
-    if not all(
-        select_node.args[1] == select_nodes[0].args[1] for select_node in select_nodes
-    ):
-        return
-    # We only consider the case where selece slice dim and cat node has same dim
-    if select_nodes[0].args[1] != cat_dim:
-        return
-    if not is_node_meta_valid(cat_node):
-        return
-    # check the cat node has consecutive indices
-    indices = [select.args[2] for select in cat_node.args[0]]  # type: ignore[union-attr]
-    if not is_sorted_and_consecutive(indices) and len(select_nodes) != len(cat_inputs):  # type: ignore[arg-type]
-        return
-    # reshape the node input to be the same shape as the cat node
-    with graph.inserting_before(node):
-        view_node = graph.call_function(
-            torch.ops.aten.view.default,
-            args=(node_input, cat_node.meta["val"].shape),
-        )
-    # replace the node input with the new node
-    cat_node.replace_all_uses_with(view_node)
-    view_node.meta.update(cat_node.meta)
-    # remove the cat node
-    graph.erase_node(cat_node)
-    for select_node in select_nodes:
-        if len(select_node.users) == 0:
-            graph.erase_node(select_node)
-    counters["inductor"]["select_cat_aten_pass"] += 1
+    for cat_node in list(node.users.keys()):
+        if cat_node.target == torch.ops.aten.cat.default:
+            cat_dim = get_arg_value(cat_node, 1, "dim")
+            cat_inputs = get_arg_value(cat_node, 0, "tensors")
+            # check all select nodes has same slice dim
+            if not all(
+                select_node.args[1] == select_nodes[0].args[1]
+                for select_node in select_nodes
+            ):
+                continue
+            # We only consider the case where selece slice dim and cat node has same dim
+            if select_nodes[0].args[1] != cat_dim:
+                continue
+            if not is_node_meta_valid(cat_node):
+                continue
+            # check the cat node has consecutive indices
+            indices = [select.args[2] for select in cat_node.args[0]]  # type: ignore[union-attr]
+            if not is_sorted_and_consecutive(indices) or len(select_nodes) != len(cat_inputs):  # type: ignore[arg-type]
+                continue
+            # check all the select nodes can be merged to the cat node input
+            if len(indices) != select_nodes[0].args[0].meta["val"].shape[cat_dim]:  # type: ignore[union-attr]
+                continue
+            # reshape the node input to be the same shape as the cat node
+            with graph.inserting_before(node):
+                view_node = graph.call_function(
+                    torch.ops.aten.view.default,
+                    args=(node_input, cat_node.meta["val"].shape),
+                )
+            # replace the node input with the new node
+            cat_node.replace_all_uses_with(view_node)
+            view_node.meta.update(cat_node.meta)
+            # remove the cat node
+            graph.erase_node(cat_node)
+            for select_node in select_nodes:
+                if len(select_node.users) == 0:
+                    graph.erase_node(select_node)
+            counters["inductor"]["select_cat_aten_pass"] += 1
 
 
 @register_graph_pattern(


### PR DESCRIPTION
Summary: Thanks to Shuai for reporting the bug in the pattern. We found there's a typo in the pass, where we should make sure all the selects will go to the cat node.

Test Plan:
buck2 test 'fbcode//mode/dev-nosan' fbcode//caffe2/test/inductor:split_cat_fx_aten_passes -- test_select_cat_post_grad


Buck UI: https://www.internalfb.com/buck2/2cd0888e-d803-43a8-8530-d97e6bc281b3
Test UI: https://www.internalfb.com/intern/testinfra/testrun/6192449699305108
Network: Up: 110KiB  Down: 35KiB  (reSessionID-687be0fa-031a-47a0-8780-5ab4cf4bbd94)
Executing actions. Remaining     0/4                                                                              6.6s exec time total
Command: test.     Finished 2 local
Time elapsed: 2:12.0s
Tests finished: Pass 2. Fail 0. Fatal 0. Skip 0. Build failure 0

Differential Revision: D69278487




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang @aakhundov