### PR TITLE
[Dynamo] Eliminate single `Self` import from typing_extensions

### DIFF
--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -8,8 +8,7 @@ import logging
 import os
 import pickle
 from collections import defaultdict
-from typing import Optional, TYPE_CHECKING, TypeVar, Union
-from typing_extensions import Self
+from typing import Optional, Self, TYPE_CHECKING, TypeVar, Union
 
 import torch._dynamo.config
 import torch._utils_internal

--- a/torch/_dynamo/polyfills/pytree.py
+++ b/torch/_dynamo/polyfills/pytree.py
@@ -18,7 +18,7 @@ from ..decorators import substitute_in_graph
 if TYPE_CHECKING:
     import builtins
     from collections.abc import Iterable
-    from typing_extensions import Self
+    from typing import Self
 
     from torch.utils._cxx_pytree import PyTree
 

--- a/torch/_dynamo/profiler.py
+++ b/torch/_dynamo/profiler.py
@@ -1,7 +1,6 @@
 import dataclasses
 import os
-from typing import Any
-from typing_extensions import Self
+from typing import Any, Self
 
 import torch
 

--- a/torch/_dynamo/replay_record.py
+++ b/torch/_dynamo/replay_record.py
@@ -1,8 +1,7 @@
 import dataclasses
 from dataclasses import field
 from types import CellType, CodeType, ModuleType
-from typing import Any, IO
-from typing_extensions import Self
+from typing import Any, IO, Self
 
 from torch.utils._import_utils import import_dill
 

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -1,8 +1,7 @@
 import collections
 import functools
 import inspect
-from typing import Any, Callable, final, Optional, Union
-from typing_extensions import Self
+from typing import Any, Callable, final, Optional, Self, Union
 
 from ..utils import is_function_or_wrapper
 from .base import VariableTracker


### PR DESCRIPTION
Replace `from typing_extensions import Self` with `from typing import`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames