### PR TITLE
Optimize LRScheduler docs

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -79,7 +79,22 @@ def _format_param(name: str, optimizer: Optimizer, param):
 
 
 class LRScheduler:
-    r"""Adjusts the learning rate during optimization."""
+    r"""Learning Rate Scheduler Base Class.
+
+    This is the base class for all learning rate schedulers in PyTorch. It provides
+    common functionality for adjusting the learning rate of an optimizer during training.
+
+    .. note::
+        You cannot use LRScheduler directly, see one of the concrete implementations and tutorials
+        `in here <https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate>`_.
+
+
+    Args:
+        optimizer (Optimizer): Wrapped optimizer. (Find more about
+            `optimizer <https://pytorch.org/docs/stable/optim.html#base-class>`_) .
+        last_epoch (int, optional): The index of the last training epoch to resume.
+            Default: -1, starts from first epoch.
+    """
 
     _get_lr_called_within_step: bool = False
     _is_initial: bool = False
@@ -173,7 +188,11 @@ class LRScheduler:
         raise NotImplementedError
 
     def step(self, epoch: Optional[int] = None) -> None:
-        """Perform a step."""
+        """
+        Updates the learning rate for the current epoch.
+
+        The `epoch` parameter is being deprecated, please use `scheduler.step()` to step the scheduler.
+        """
         # Raise a warning if old pattern is detected
         # https://github.com/pytorch/pytorch/issues/20124
         if self._step_count == 1:

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -180,18 +180,24 @@ class LRScheduler:
         self.__dict__.update(state_dict)
 
     def get_last_lr(self) -> list[float]:
-        """Return last computed learning rate by current scheduler."""
+        """Return last computed learning rate by current scheduler. Cached value is used, no extra cost."""
         return self._last_lr
 
     def get_lr(self) -> list[float]:
-        """Compute learning rate using chainable form of the scheduler."""
+        """Compute learning rate using chainable form of the scheduler. No concrete implementation is provided in this class,
+        child classes must override this method and implement it according to their strategy.
+        """
         raise NotImplementedError
 
     def step(self, epoch: Optional[int] = None) -> None:
         """
-        Updates the learning rate for the current epoch.
+        Adjust the learning rate of the optimizer.
 
-        The `epoch` parameter is being deprecated, please use `scheduler.step()` to step the scheduler.
+        .. deprecated:: 1.3
+            The ``epoch`` parameter is being deprecated, use ``lr_scheduler.step()``.
+
+        Please make sure to call `optimizer.step()` before `lr_scheduler.step()`. See more details in
+        `How to adjust learning rate <https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate>`_
         """
         # Raise a warning if old pattern is detected
         # https://github.com/pytorch/pytorch/issues/20124

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -93,7 +93,7 @@ class LRScheduler:
         optimizer (Optimizer): Wrapped optimizer. (Find more about
             `optimizer <https://pytorch.org/docs/stable/optim.html#base-class>`_) .
         last_epoch (int, optional): The index of the last training epoch to resume.
-            Default: -1, starts from first epoch.
+            Default: -1, starts from the optimizer lr.
     """
 
     _get_lr_called_within_step: bool = False
@@ -291,7 +291,7 @@ class LambdaLR(LRScheduler):
     """Sets the initial learning rate.
 
     The learning rate of each parameter group is set to the initial lr
-    times a given function. When last_epoch=-1, sets initial lr as lr.
+    times a given function. When last_epoch=-1, use optimizer's lr as inital lr.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
@@ -502,7 +502,7 @@ class StepLR(LRScheduler):
     """Decays the learning rate of each parameter group by gamma every step_size epochs.
 
     Notice that such decay can happen simultaneously with other changes to the learning rate
-    from outside this scheduler. When last_epoch=-1, sets initial lr as lr.
+    from outside this scheduler. When last_epoch=-1, use optimizer's lr as inital lr.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
@@ -558,7 +558,7 @@ class MultiStepLR(LRScheduler):
     """Decays the learning rate of each parameter group by gamma once the number of epoch reaches one of the milestones.
 
     Notice that such decay can happen simultaneously with other changes to the learning rate
-    from outside this scheduler. When last_epoch=-1, sets initial lr as lr.
+    from outside this scheduler. When last_epoch=-1, use optimizer's lr as inital lr.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
@@ -619,7 +619,7 @@ class ConstantLR(LRScheduler):
     The multiplication is done until the number of epoch reaches a pre-defined milestone: total_iters.
     Notice that such multiplication of the small constant factor can
     happen simultaneously with other changes to the learning rate from outside this scheduler.
-    When last_epoch=-1, sets initial lr as lr.
+    When last_epoch=-1, use optimizer's lr as inital lr.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
@@ -690,7 +690,7 @@ class LinearLR(LRScheduler):
 
     The multiplication is done until the number of epoch reaches a pre-defined milestone: total_iters.
     Notice that such decay can happen simultaneously with other changes to the learning rate
-    from outside this scheduler. When last_epoch=-1, sets initial lr as lr.
+    from outside this scheduler. When last_epoch=-1, use optimizer's lr as inital lr.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
@@ -786,7 +786,7 @@ class LinearLR(LRScheduler):
 class ExponentialLR(LRScheduler):
     """Decays the learning rate of each parameter group by gamma every epoch.
 
-    When last_epoch=-1, sets initial lr as lr.
+    When last_epoch=-1, use optimizer's lr as inital lr.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
@@ -980,7 +980,7 @@ class SequentialLR(LRScheduler):
 class PolynomialLR(LRScheduler):
     """Decays the learning rate of each parameter group using a polynomial function in the given total_iters.
 
-    When last_epoch=-1, sets initial lr as lr.
+    When last_epoch=-1, use optimizer's lr as inital lr.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.


### PR DESCRIPTION
Fixes part of #120735 via add more description about [`LRScheduler`](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.LRScheduler.html#torch.optim.lr_scheduler.LRScheduler)

## Changes

> 1. What the constructor's last_epoch argument is.
And does epoch start from 0 or 1?
Also there are two terms - "epoch", "step" - are they the same?

`last_epoch` explained via Args description, the difference might be clear after compare with `step` method description.

> 2. That the constructor [relies on/creates the 'initial_lr'](https://github.com/pytorch/pytorch/blob/v2.2.1/torch/optim/lr_scheduler.py#L51) property on the .optimizer.
(By the way, is the Optimizer class up with it?)

`initial_lr` will be set when init LRScheduler, use optimizer lr value, which is initialized when create a optimizer. But these are inner implementation, users doesn't need care about.

> 3. That .get_last_lr() and .get_lr() are totally different methods despite of naming.
Wait, there are also ._get_closed_form_lr() methods, hm...

Add description in `get_last_lr` and `get_lr`, but private method `_get_closed_form_lr` should not expose to users in docs.

> 4. That the constructor [does .step()](https://github.com/pytorch/pytorch/blob/v2.2.1/torch/optim/lr_scheduler.py#L85-L91) itself via ._initial_step() method.
> 5. Which arguments the .step() method has.
Or is it (the epoch argument) [deprecated](https://github.com/pytorch/pytorch/blob/v2.2.1/torch/optim/lr_scheduler.py#L156)?

Add deprecate `epoch` in `step` method doc

> 6. What does .step() do?
Does it modify (in some way) the .optimizer? (See also p.2.)

Update `step` doc

> 7.Are the .last_epoch, .base_lrs attributes public?
(Don't know, maybe it is not accepted to publish such information.)
(For .last_epoch, see also p.1a.)

These params seems handled by `LRScheduler` itself and not give example for use in [here](https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate), I assume users can omit these params when use `LRScheduler`.

## Test Result

### Before

![image](https://github.com/user-attachments/assets/619c3ea8-5652-4e61-936f-0cb5aa5a326b)

### After

![image](https://github.com/user-attachments/assets/594abd9f-bd57-4dd7-9962-e9bed7c79e7e)
![image](https://github.com/user-attachments/assets/ec45634b-d353-4aa3-96df-7ea30e0d55c9)

cc @janeyx99
