### PR TITLE
Add full_like.default to list of ops with kwargs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -37,7 +37,7 @@ Copyright (c) 2024 Tri Dao.
 All rights reserved.
 
 All contributions by Arm:
-Copyright (c) 2021, 2023-2024 Arm Limited and/or its affiliates
+Copyright (c) 2021, 2023-2025 Arm Limited and/or its affiliates
 
 All contributions from Caffe:
 Copyright(c) 2013, 2014, 2015, the respective contributors

--- a/torch/ao/quantization/pt2e/prepare.py
+++ b/torch/ao/quantization/pt2e/prepare.py
@@ -431,12 +431,13 @@ def _maybe_insert_input_observers_for_node(
         )
         new_args.append(new_arg)
 
-    # Clone has a memory_format kwarg, zeros_like has a pin_memory kwarg, and
+    # Clone has a memory_format kwarg, zeros_like and full_like has a pin_memory kwarg, and
     # gelu has a has an approximate kwarg that persist in exported graph.
     # This is just a work around for these.
     assert (
         node.target == torch.ops.aten.clone.default
         or node.target == torch.ops.aten.zeros_like.default
+        or node.target == torch.ops.aten.full_like.default
         or node.target == torch.ops.aten.gelu.default
         or len(node.kwargs) == 0
     ), " expecting kwargs for aten op IR to be empty"


### PR DESCRIPTION
The _maybe_insert_input_observers_for_node function expects ops, except a few exceptions, to have zero kwargs. full_like.default seems to be one of these cases and should therefore be added to the list.

Addresses https://github.com/pytorch/pytorch/issues/146621

Fixes #146621 
