### PR TITLE
[CUDAGraph] add skip message for unbacked symint

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -1851,7 +1851,7 @@ if HAS_CUDA and not TEST_WITH_ASAN:
             out = foo(torch.rand([4, 4], device="cuda", requires_grad=True))
             self.assertFalse(self.get_manager().new_graph_id().id == 0)
 
-        def test_unbacked_symint_warning_message(self):
+        def test_input_unbacked_symint(self):
             @torch.compile(mode="reduce-overhead")
             def foo(x):
                 return x + 1
@@ -1859,13 +1859,9 @@ if HAS_CUDA and not TEST_WITH_ASAN:
             x = torch.randn(2, 3, device="cuda")
             torch._dynamo.decorators.mark_unbacked(x, 0)
 
-            with capture_stderr() as captured_output:
-                foo(x)
+            foo(x)
 
-            FileCheck().check(
-                "skipping cudagraphs due to disabling cudagraphs due to unbacked symint arg0_1"
-            ).run(captured_output[0])
-            self.assertEqual(counters["inductor"]["cudagraph_skips"], 1)
+            self.assertEqual(counters["inductor"]["cudagraph_skips"], 0)
 
         @torch._dynamo.config.patch("capture_scalar_outputs", True)
         def test_incompatible_cudagraph_ops_item(self):

--- a/torch/_dynamo/backends/cudagraphs.py
+++ b/torch/_dynamo/backends/cudagraphs.py
@@ -99,8 +99,9 @@ def check_for_skip(aot_model: torch.fx.GraphModule, num_fixed) -> Optional[str]:
     ):
         return skip
 
-    if node := get_first_incompatible_cudagraph_node(aot_model):
-        return format_default_skip_message(f"incompatible op ({node.name})")
+    if incompatile_info := get_first_incompatible_cudagraph_node(aot_model):
+        (node, reason) = incompatile_info
+        return format_default_skip_message(f"{reason} ({node.name})")
 
     return None
 

--- a/torch/_dynamo/backends/cudagraphs.py
+++ b/torch/_dynamo/backends/cudagraphs.py
@@ -99,8 +99,8 @@ def check_for_skip(aot_model: torch.fx.GraphModule, num_fixed) -> Optional[str]:
     ):
         return skip
 
-    if incompatile_info := get_first_incompatible_cudagraph_node(aot_model):
-        (node, reason) = incompatile_info
+    if incompatible_info := get_first_incompatible_cudagraph_node(aot_model):
+        (node, reason) = incompatible_info
         return format_default_skip_message(f"{reason} ({node.name})")
 
     return None

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1152,10 +1152,11 @@ class _InProcessFxCompile(FxCompile):
                         V.graph.disable_cudagraphs_reason = disable
 
                     if cudagraphs and not V.graph.disable_cudagraphs_reason:
-                        maybe_incompat_node = get_first_incompatible_cudagraph_node(gm)
-                        if maybe_incompat_node:
-                            disable = f"disabling cudagraphs due to incompatible op {maybe_incompat_node.target}"
-                            if stack_trace := maybe_incompat_node.meta.get(
+                        maybe_incompat_info = get_first_incompatible_cudagraph_node(gm)
+                        if maybe_incompat_info:
+                            incompat_node, reason = maybe_incompat_info
+                            disable = f"disabling cudagraphs due to {reason} {incompat_node.target}"
+                            if stack_trace := incompat_node.meta.get(
                                 "stack_trace", None
                             ):
                                 disable = f"{disable} Found from {stack_trace}\n"

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -34,6 +34,7 @@ from typing import (
     NamedTuple,
     Optional,
     Protocol,
+    Tuple,
     TYPE_CHECKING,
     TypeVar,
     Union,
@@ -753,7 +754,7 @@ def any_is_symbolic(*args: Any) -> bool:
 
 def get_first_incompatible_cudagraph_node(
     gm: torch.fx.GraphModule,
-) -> Optional[torch.fx.Node]:
+) -> Optional[Tuple[torch.fx.Node, str]]:
     from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
 
     forbidden_set = OrderedSet(
@@ -792,9 +793,9 @@ def get_first_incompatible_cudagraph_node(
 
     for node in gm.graph.nodes:
         if str(node.target) in forbidden_set:
-            return node
+            return node, "incompatible op"
         if (val := node.meta.get("val")) is not None and free_unbacked_symbols(val):
-            return node
+            return node, "unbacked symint"
     return None
 
 


### PR DESCRIPTION
Add explicit skip message for unbacked symint in cudagraph, as suggested by @bdhirsh.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov