### PR TITLE
Use inductor backend for NJT compile tests

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -8631,6 +8631,7 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
 
                     self.assertEqualNoncontigAware(grads, grads_ref)
 
+    @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     @ops(
         [op for op in njt_op_db if op.supports_njt],
         allowed_dtypes=(torch.float32,),
@@ -8683,6 +8684,7 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
                     else:
                         self.assertEqual(sample.input, out_ref)
 
+    @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     @ops(
         [op for op in njt_op_db if op.supports_njt and op.supports_autograd],
         allowed_dtypes=(torch.float32,),

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -8652,7 +8652,7 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
                     return op_fn(*args, **kwargs)
 
                 compiled_f = torch.compile(
-                    f, fullgraph=True, backend="aot_eager_decomp_partition"
+                    f, fullgraph=True, backend="inductor"
                 )
 
                 out_ref = f(sample.input, *sample.args, **sample.kwargs)
@@ -8676,7 +8676,7 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
                         return op_fn(*args, **kwargs)
 
                     compiled_in_f = torch.compile(
-                        in_f, fullgraph=True, backend="aot_eager_decomp_partition"
+                        in_f, fullgraph=True, backend="inductor"
                     )
 
                     compiled_in_f(sample.input, *sample.args, **sample.kwargs)
@@ -8706,7 +8706,7 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
                     return op_fn(*args, **kwargs)
 
                 compiled_f = torch.compile(
-                    f, fullgraph=True, backend="aot_eager_decomp_partition"
+                    f, fullgraph=True, backend="inductor"
                 )
 
                 out_ref = f(sample.input, *sample.args, **sample.kwargs)

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -8651,9 +8651,7 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
                 def f(*args, **kwargs):
                     return op_fn(*args, **kwargs)
 
-                compiled_f = torch.compile(
-                    f, fullgraph=True, backend="inductor"
-                )
+                compiled_f = torch.compile(f, fullgraph=True, backend="inductor")
 
                 out_ref = f(sample.input, *sample.args, **sample.kwargs)
                 out_compile = compiled_f(sample.input, *sample.args, **sample.kwargs)
@@ -8705,9 +8703,7 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
                 def f(*args, **kwargs):
                     return op_fn(*args, **kwargs)
 
-                compiled_f = torch.compile(
-                    f, fullgraph=True, backend="inductor"
-                )
+                compiled_f = torch.compile(f, fullgraph=True, backend="inductor")
 
                 out_ref = f(sample.input, *sample.args, **sample.kwargs)
                 out_compile = compiled_f(sample.input, *sample.args, **sample.kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #146722
* __->__ #146721

We've been using `backend="aot_eager_decomp_partition"` for NJT compile testing, but this can let inductor bugs slip through. This PR switches the compile tests to use `backend="inductor"`; let's see if test runtime is an issue after this.