### PR TITLE
Test on in-graph constructed NJTs

### DIFF
--- a/torch/testing/_internal/opinfo/definitions/nested.py
+++ b/torch/testing/_internal/opinfo/definitions/nested.py
@@ -1484,6 +1484,10 @@ def sample_inputs_where(op_info, device, dtype, requires_grad, **kwargs):
         sample.name = sample.name.replace("(", "(NT, ")
         yield sample
 
+        # in addition to scalar tensor, also test with actual scalar
+        if isinstance(other, torch.Tensor) and other.shape == ():
+            yield _update_sample(sample, {"other": other.item()})
+
 
 # === END OP-SPECIFIC SAMPLE INPUTS FUNCS / REFERENCES ===
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146722
* #146721

A recent set of bugs has been cropping up related to NJTs that constructed in-graph within a compiled function. This exercises different paths related to symbolic nested ints, etc. Some examples:
* #145874
* #146644

To get ahead of these, we should do NJT testing for this case as well.

This PR parametrizes the OpInfo tests for compile + forward to cover both in-graph constructed NJT and normal input cases. TBD what fails..

TODO:
* Do this for compile + backward tests also (?)