### PR TITLE
[Inductor] Fix the lowering of squeeze when input is not contiguous

### DIFF
--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -385,9 +385,6 @@ class TestUnbackedSymints(InductorTestCase):
     @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     @dynamo_config.patch(capture_dynamic_output_shape_ops=True)
     def test_issue_143498(self, device):
-        if device == "cpu":
-            raise unittest.SkipTest("CPU Failure")
-
         class Model(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2769,7 +2769,9 @@ class View(GenericView):
                 # TODO: unbacked should not diverge from backed in determining striding
                 # Need to require contiguous here instead of realize, see:
                 # https://github.com/pytorch/pytorch/issues/145561
-                x = ExternKernel.require_contiguous(x)
+                x = ExternKernel.require_exact_strides(
+                    x, FlexibleLayout.contiguous_strides(x.get_size())
+                )
 
             storage, old_layout = as_storage_and_layout(x, want_contiguous=True)
             new_layout = FixedLayout(

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1008,7 +1008,7 @@ def squeeze(x, dim=None):
     new_shape = []
     new_stride = []
     is_storage_and_layout = ir.is_storage_and_layout(x)
-    original_stride = x.get_stride() if is_storage_and_layout else None
+    original_stride = x.get_stride() if is_storage_and_layout else []
     new_offset = x.get_layout().offset if is_storage_and_layout else None
     for d, s in enumerate(x.get_size()):
         if not (
@@ -1017,7 +1017,6 @@ def squeeze(x, dim=None):
         ):
             new_shape.append(s)
             if is_storage_and_layout:
-                assert isinstance(original_stride, list)
                 new_stride.append(original_stride[d])
 
     # squeeze does nothing if the size isn't 1

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1006,15 +1006,18 @@ def squeeze(x, dim=None):
     dims = OrderedSet((dim,) if not isinstance(dim, tuple) else dim)
 
     new_shape = []
+    new_stride = []
+    original_stride = x.get_stride()
     for d, s in enumerate(x.get_size()):
         if not (
             d in dims
             and V.graph.sizevars.evaluate_expr(sympy.Eq(s, 1), size_oblivious=True)
         ):
             new_shape.append(s)
+            new_stride.append(original_stride[d])
 
     # squeeze does nothing if the size isn't 1
-    return view(x, new_shape) if new_shape != x.get_size() else x
+    return as_strided(x, new_shape, new_stride) if new_shape != x.get_size() else x
 
 
 @register_lowering(aten.squeeze_copy, type_promotion_kind=None)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1006,29 +1006,15 @@ def squeeze(x, dim=None):
     dims = OrderedSet((dim,) if not isinstance(dim, tuple) else dim)
 
     new_shape = []
-    new_stride = []
-    is_storage_and_layout = ir.is_storage_and_layout(x)
-    original_stride = x.get_stride() if is_storage_and_layout else []
-    new_offset = x.get_layout().offset if is_storage_and_layout else None
     for d, s in enumerate(x.get_size()):
         if not (
             d in dims
             and V.graph.sizevars.evaluate_expr(sympy.Eq(s, 1), size_oblivious=True)
         ):
             new_shape.append(s)
-            if is_storage_and_layout:
-                new_stride.append(original_stride[d])
 
     # squeeze does nothing if the size isn't 1
-    return (
-        (
-            as_strided(x, new_shape, new_stride, new_offset)
-            if is_storage_and_layout
-            else view(x, new_shape)
-        )
-        if new_shape != x.get_size()
-        else x
-    )
+    return view(x, new_shape) if new_shape != x.get_size() else x
 
 
 @register_lowering(aten.squeeze_copy, type_promotion_kind=None)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146746

**Summary**
Fix issue https://github.com/pytorch/pytorch/issues/143498. The issue happens when we lowering `select = torch.ops.aten.select.int(cat, 1, 0)`. 

For example, when `cat` is contiguous with size[2, 2] stride[2,1]

- for eager, it returns a view of size[2,] stride[2,]
- for Inductor lowering, it returns wrong stride 1 instead of 2
```
TensorBox(
  ReinterpretView(
    StorageBox(
      ConcatKernel(name='buf10', layout=FixedLayout('cpu', torch.int64, size=[u0, 2], stride=[2, 1]), inputs=[ComputedBuffer(name='buf8', layout=NonOwningLayout('cpu', torch.int64, size=[u0, 1], stride=[2, 1]), data=Pointwise(device=device(type='cpu'), dtype=torch.int64, inner_fn=<function ReinterpretView.make_loader.<locals>.loader at 0x7f6b856449d0>, ranges=[u0, 1])), ComputedBuffer(name='buf9', layout=NonOwningLayout('cpu', torch.int64, size=[u0, 1], stride=[2, 1]), data=Pointwise(device=device(type='cpu'), dtype=torch.int64, inner_fn=<function ReinterpretView.make_loader.<locals>.loader at 0x7f6b85644790>, ranges=[u0, 1]))])
    ),
    FixedLayout('cpu', torch.int64, size=[u0], stride=[**1**]),
    origins=OrderedSet([select])
  )
)
```

To fix this issue, we give the right stride when lowering of `squeeze`.

**Test Plan**
```
python -u -m pytest -s -v test/inductor/test_unbacked_symints.py -k test_issue_143498
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov