### PR TITLE
Add hint message for `pack_padded_sequence`

### DIFF
--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -299,10 +299,14 @@ def pack_padded_sequence(
         lengths (Tensor or list(int)): list of sequence lengths of each batch
             element (must be on the CPU if provided as a tensor).
         batch_first (bool, optional): if ``True``, the input is expected in ``B x T x *``
-            format, ``T x B x *`` otherwise.
+            format, ``T x B x *`` otherwise. Default: ``False``.
         enforce_sorted (bool, optional): if ``True``, the input is expected to
             contain sequences sorted by length in a decreasing order. If
             ``False``, the input will get sorted unconditionally. Default: ``True``.
+
+    .. warning::
+        The dim of ``input`` tensor will be truncated if its length larger than
+        correspond value in ``length``.
 
     Returns:
         a :class:`PackedSequence` object


### PR DESCRIPTION
Fixes #144207

Add truncate hint message in docs [torch.nn.utils.rnn.pack_padded_sequence](https://pytorch.org/docs/stable/generated/torch.nn.utils.rnn.pack_padded_sequence.html)

## Test Result

![image](https://github.com/user-attachments/assets/46258f36-f6c7-4f11-9213-8513e52a9001)

