### PR TITLE
[MTIA] (4/n) Implement PyTorch APIs to query/reset device peak memory usage

### DIFF
--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -354,6 +354,7 @@ __all__ = [
     "default_stream",
     "memory_stats",
     "max_memory_allocated",
+    "reset_peak_memory_stats",
     "get_device_capability",
     "record_memory_history",
     "snapshot",

--- a/torch/mtia/memory.py
+++ b/torch/mtia/memory.py
@@ -36,7 +36,22 @@ def max_memory_allocated(device: Optional[_device_t] = None) -> int:
     return memory_stats(device).get("dram", 0).get("peak_bytes", 0)
 
 
+def reset_peak_memory_stats(device: Optional[_device_t] = None) -> None:
+    r"""Reset the peak memory stats for a given device.
+
+
+    Args:
+        device (torch.device, str, or int, optional) selected device. Returns
+            statistics for the current device, given by current_device(),
+            if device is None (default).
+    """
+    if not is_initialized():
+        return
+    torch._C._mtia_resetPeakMemoryStats(_get_device_index(device, optional=True))
+
+
 __all__ = [
     "memory_stats",
     "max_memory_allocated",
+    "reset_peak_memory_stats",
 ]


### PR DESCRIPTION
Summary: Public summary (shared with Github): This diff updates the unit test for the PyTorch API "reset_peak_memory_stats".

Test Plan:
```
buck2 test //mtia/host_runtime/torch_mtia/tests:test_torch_mtia_api -- -r test_reset_peak_memory_stats
```

https://www.internalfb.com/intern/testinfra/testrun/9007199321947161

Reviewed By: yuhc

Differential Revision: D68989900


