### PR TITLE
[MPS] fix lu factor for large tensors with bs>1

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -188,7 +188,7 @@ static void linalg_lu_factor_ex_out_mps_impl(const Tensor& A,
 
       MPSMatrixDescriptor* sourceMatrixDesc = [MPSMatrixDescriptor matrixDescriptorWithRows:aRows
                                                                                     columns:aCols
-                                                                                   matrices:batchSize
+                                                                                   matrices:1
                                                                                    rowBytes:aCols * aElemSize
                                                                                 matrixBytes:aRows * aCols * aElemSize
                                                                                    dataType:getMPSDataType(A_)];

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2722,16 +2722,16 @@ class TestMPS(TestCaseMPS):
         make_fullrank = make_fullrank_matrices_with_distinct_singular_values
         make_arg = partial(make_fullrank, device="cpu", dtype=torch.float32)
 
-        def run_lu_factor_ex_test(size, *batch_dims, check_errors):
+        def run_lu_factor_ex_test(size, *batch_dims, check_errors, atol=1e-5, rtol=1e-6):
             input_cpu = make_arg(*batch_dims, size, size)
             input_mps = input_cpu.to('mps')
             out_cpu = torch.linalg.lu_factor_ex(input_cpu, check_errors=check_errors)
             out_mps = torch.linalg.lu_factor_ex(input_mps, check_errors=check_errors)
-            self.assertEqual(out_cpu, out_mps)
+            self.assertEqual(out_cpu, out_mps, atol=atol, rtol=rtol)
 
             out_cpu = torch.linalg.lu_factor_ex(input_cpu.mT, check_errors=check_errors)
             out_mps = torch.linalg.lu_factor_ex(input_mps.mT, check_errors=check_errors)
-            self.assertEqual(out_cpu, out_mps)
+            self.assertEqual(out_cpu, out_mps, atol=atol, rtol=rtol)
 
         # test with different even/odd matrix sizes
         matrix_sizes = [1, 2, 3, 4]
@@ -2744,7 +2744,9 @@ class TestMPS(TestCaseMPS):
                     run_lu_factor_ex_test(size, batch_size, check_errors=check_errors)
         # test >3D matrices
         run_lu_factor_ex_test(32, 10, 10, check_errors=False)
-        run_lu_factor_ex_test(32, 2, 2, 2, 2, 10, 10, check_errors=True)
+        run_lu_factor_ex_test(32, 2, 2, 10, 10, check_errors=True)
+        # big matrix check with batch size > 1
+        run_lu_factor_ex_test(256, 2, check_errors=False, atol=2e-5, rtol=5e-6)
 
     def test_linalg_solve(self):
         from torch.testing._internal.common_utils import make_fullrank_matrices_with_distinct_singular_values

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2746,7 +2746,7 @@ class TestMPS(TestCaseMPS):
         run_lu_factor_ex_test(32, 10, 10, check_errors=False)
         run_lu_factor_ex_test(32, 2, 2, 10, 10, check_errors=True)
         # big matrix check with batch size > 1
-        run_lu_factor_ex_test(256, 2, check_errors=False, atol=2e-5, rtol=5e-6)
+        run_lu_factor_ex_test(256, 2, check_errors=False, atol=3e-5, rtol=5e-6)
 
     def test_linalg_solve(self):
         from torch.testing._internal.common_utils import make_fullrank_matrices_with_distinct_singular_values


### PR DESCRIPTION
Try this:
```python
import torch

batch_size = 2
A = torch.eye(256, device="mps")[None, :, :].expand(batch_size, -1, -1) + 0.1 * torch.randn((batch_size, 256, 256), device="mps")
A_cpu = A.cpu()
LU_cpu, pivots_cpu = torch.linalg.lu_factor(A_cpu)
LU, pivots = torch.linalg.lu_factor(A)
torch.testing.assert_close(LU.cpu(), LU_cpu)
```
You'll get huge difference in LU tensors
<img width="706" alt="Screenshot 2025-02-08 at 12 14 39" src="https://github.com/user-attachments/assets/b45f2b3c-e0a5-49c8-aa07-42792150b781" />
