### PR TITLE
Improve Typing for Loss Functions to Fix VSCode Autocomplete

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -37,6 +37,9 @@ __all__ = [
 
 class _Loss(Module):
     reduction: str
+    # Add type annotations to __call__ method, so that the type checker can infer the correct return type.
+    # See https://github.com/microsoft/pyright/issues/3249
+    __call__: Callable[..., Tensor]
 
     def __init__(self, size_average=None, reduce=None, reduction: str = "mean") -> None:
         super().__init__()


### PR DESCRIPTION
Fixes #146831 by adding a type annotation to `_Loss.__call__`, as proposed in https://github.com/microsoft/pyright/issues/3249