### PR TITLE
[Fix]: Disable KleidiAI if unsupported gcc/clang compiler is detected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -704,6 +704,13 @@ if(ANDROID
   endif()
 endif()
 
+if(USE_KLEIDIAI AND CMAKE_C_COMPILER_VERSION)
+    if(CMAKE_C_COMPILER_VERSION VERSION_LESS 11)
+      set(USE_KLEIDIAI OFF)
+      message(WARNING "Disabling KleidiAI: Requires atleast GCC 11 or Clang 11")
+    endif()
+endif()
+
 # INTERN_BUILD_ATEN_OPS is used to control whether to build ATen/TH operators.
 set(INTERN_BUILD_ATEN_OPS ON)
 


### PR DESCRIPTION
Fixes: https://github.com/pytorch/pytorch/issues/146740

Description:
1. KleidiAI officially supports GCC>=11 and Clang>=11. Certain hardware features are tied to compiler version and KleidiAI compilation will fail in such cases.


Change-Id: Ib43d6b5bf66ef5ea48c481a2774801c573ec205c


