### PR TITLE
Fix bazel job after #144489

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1036,6 +1036,7 @@ cc_test(
             "test/cpp/lazy/test_ir.cpp",
             "test/cpp/lazy/test_lazy_ops.cpp",
             "test/cpp/lazy/test_lazy_ops_util.cpp",
+            "test/cpp/lazy/test_lazy_graph_executor.cpp",
         ],
     ),
     linkstatic = True,


### PR DESCRIPTION
This is currently failing in trunk with the following error https://github.com/pytorch/pytorch/actions/runs/13246034191/job/36972742610

### Testing

Bazel job passing https://github.com/pytorch/pytorch/actions/runs/13247495161/job/36977571965
