### PR TITLE
[cuda] fix printing of num_gpus

### DIFF
--- a/aten/src/ATen/cuda/CUDAContext.cpp
+++ b/aten/src/ATen/cuda/CUDAContext.cpp
@@ -29,10 +29,11 @@ void initDeviceProperty(DeviceIndex device_index) {
 
 } // anonymous namespace
 
-// We need this function to force the linking against torch_cuda(_cpp) on Windows.
-// If you need to modify this function, please specify a new function and apply
-// the changes according to https://github.com/pytorch/pytorch/pull/34288.
-// Related issue: https://github.com/pytorch/pytorch/issues/31611.
+// We need this function to force the linking against torch_cuda(_cpp) on
+// Windows. If you need to modify this function, please specify a new function
+// and apply the changes according to
+// https://github.com/pytorch/pytorch/pull/34288. Related issue:
+// https://github.com/pytorch/pytorch/issues/31611.
 /* Device info */
 int warp_size() {
   return getCurrentDeviceProperties()->warpSize;
@@ -45,17 +46,36 @@ cudaDeviceProp* getCurrentDeviceProperties() {
 
 cudaDeviceProp* getDeviceProperties(c10::DeviceIndex device) {
   c10::call_once(init_flag, initCUDAContextVectors);
-  if (device == -1) device = c10::cuda::current_device();
-  AT_ASSERT(device >= 0 && device < num_gpus, "device=", static_cast<int>(device), ", num_gpus=", num_gpus);
+  if (device == -1)
+    device = c10::cuda::current_device();
+  AT_ASSERT(
+      device >= 0 && device < num_gpus,
+      "device=",
+      static_cast<int>(device),
+      ", num_gpus=",
+      static_cast<int>(num_gpus));
   c10::call_once(device_flags[device], initDeviceProperty, device);
   return &device_properties[device];
 }
 
-bool canDeviceAccessPeer(c10::DeviceIndex device, c10::DeviceIndex peer_device) {
+bool canDeviceAccessPeer(
+    c10::DeviceIndex device,
+    c10::DeviceIndex peer_device) {
   c10::call_once(init_flag, initCUDAContextVectors);
-  if (device == -1) device = c10::cuda::current_device();
-  AT_ASSERT(device >= 0 && device < num_gpus, "device=", static_cast<int>(device), ", num_gpus=", num_gpus);
-  AT_ASSERT(peer_device >= 0 && peer_device < num_gpus, "peer_device=", static_cast<int>(peer_device), ", num_gpus=", num_gpus);
+  if (device == -1)
+    device = c10::cuda::current_device();
+  AT_ASSERT(
+      device >= 0 && device < num_gpus,
+      "device=",
+      static_cast<int>(device),
+      ", num_gpus=",
+      static_cast<int>(num_gpus));
+  AT_ASSERT(
+      peer_device >= 0 && peer_device < num_gpus,
+      "peer_device=",
+      static_cast<int>(peer_device),
+      ", num_gpus=",
+      static_cast<int>(num_gpus));
   int can_access = 0;
   AT_CUDA_CHECK(cudaDeviceCanAccessPeer(&can_access, device, peer_device));
   return can_access != 0;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146841

Previously on machines with less than 8 gpus, the device==7 case would
trigger the assert inside getDeviceProperties, and print `num_gpus=BEL`
which is ascii for 7.