### PR TITLE
[PGNCCL] Associate tensor allocation support with NCCL version

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -5420,16 +5420,26 @@ static void _ncclMemFree(void* ptr, size_t size, int device, void* stream) {
 
 // Create a `CUDAPluggableAllocator` that uses the above functions.
 std::shared_ptr<c10::Allocator> ProcessGroupNCCL::getMemAllocator() {
-#ifndef NCCL_HAS_MEM_ALLOC
-  TORCH_CHECK(
-      false, "NCCL mem allocator is not supported in this NCCL version");
-#endif // NCCL_HAS_MEM_ALLOC
   C10_LOG_API_USAGE_ONCE("ProcessGroupNCCL.getMemAllocator");
+  if (!supportsTensorAlloc()) {
+    TORCH_CHECK(
+        false, "NCCL mem allocator is not supported in this NCCL version");
+  }
   static std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator>
       ncclMemAllocator =
           torch::cuda::CUDAPluggableAllocator::createCustomAllocator(
               _ncclMemAlloc, _ncclMemFree);
   return ncclMemAllocator;
+}
+
+bool ProcessGroupNCCL::supportsTensorAlloc() {
+  int version = 0;
+  // Rely on link-time versioning
+  ncclGetVersion(&version);
+  if (version >= NCCL_VERSION(2, 19, 0)) {
+    return true;
+  }
+  return false;
 }
 
 at::Tensor ProcessGroupNCCL::allocateTensor(

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -777,9 +777,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // Allocate tensor from communication-optimized memory pool
   at::Tensor allocateTensor(long size, at::TensorOptions options = {}) override;
 
-  bool supportsTensorAlloc() override {
-    return true;
-  }
+  // Whether tensor allocation from NCCL memory pool is supported
+  bool supportsTensorAlloc() override;
 
   // Performs NCCL user buffer registration for all buffers in
   // the given MemPool


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146842
* #146589

This is a forward fix to #146589.
For NCCL version lower than 2.19, previous PR would see `RuntimeError: NCCL mem allocator is not supported in this NCCL version`.
This PR gates the support by checking link-time NCCL version via `ncclGetVersion`.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o