### PR TITLE
[PT2] Enable relu_nan_to_num preset in pre_grad by default

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1187,7 +1187,7 @@ class aot_inductor:
     repro_level: int = int(os.environ.get("AOTINDUCTOR_REPRO_LEVEL", 2))
 
     # Dictionary of presets that can be passed in
-    presets: dict[str, Any] = {}
+    presets: dict[str, Any] = {"relu_nan_to_num": True}
 
     # Kill switch for allowing temporary tensors to be allocated as stack arrays. Tests
     # should be run with this flag both on and off to make sure we have coverage.


### PR DESCRIPTION
Summary: enabled for AOTI_EP https://fburl.com/code/27q2dnc2, for AOTI we also want to enable it by default, so set it directly in the config

Test Plan: sandcastle

Differential Revision: D69409881




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov