### PR TITLE
[inductor] skip _test_insignificant_strides on rocm

### DIFF
--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -161,6 +161,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
                     check_train=False,
                 )
 
+    @skipIfRocm  # https://github.com/pytorch/pytorch/issues/146848
     def _test_insignificant_strides(self):
         f32 = torch.float32
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146849
* #145904


Check https://github.com/pytorch/pytorch/issues/146848 , the rocm kernel for _scaled_dot_product_attention does not match the meta kernel regarding output shape. cuda kernel is fine.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov