### PR TITLE
[BE] Strip `#pragma once` when embedding the headers

### DIFF
--- a/torch/utils/_cpp_embed_headers.py
+++ b/torch/utils/_cpp_embed_headers.py
@@ -13,6 +13,10 @@ def _embed_headers(
     content: list[str], include_dirs: list[Path], processed_files: set[str]
 ) -> str:
     for line_idx, cur_line in enumerate(content):
+        # Eliminate warning: `#pragma once in main file`
+        if cur_line.starts_with("#pragma once"):
+            cur_line[line_idx] = ""
+            continue
         m = _match('^\\s*#include\\s*[<"]([^>"]+)[>"]', cur_line)
         if m is None:
             continue

--- a/torch/utils/_cpp_embed_headers.py
+++ b/torch/utils/_cpp_embed_headers.py
@@ -14,7 +14,7 @@ def _embed_headers(
 ) -> str:
     for line_idx, cur_line in enumerate(content):
         # Eliminate warning: `#pragma once in main file`
-        if cur_line.starts_with("#pragma once"):
+        if cur_line.startswith("#pragma once"):
             cur_line[line_idx] = ""
             continue
         m = _match('^\\s*#include\\s*[<"]([^>"]+)[>"]', cur_line)

--- a/torch/utils/_cpp_embed_headers.py
+++ b/torch/utils/_cpp_embed_headers.py
@@ -15,7 +15,7 @@ def _embed_headers(
     for line_idx, cur_line in enumerate(content):
         # Eliminate warning: `#pragma once in main file`
         if cur_line.startswith("#pragma once"):
-            cur_line[line_idx] = ""
+            content[line_idx] = ""
             continue
         m = _match('^\\s*#include\\s*[<"]([^>"]+)[>"]', cur_line)
         if m is None:


### PR DESCRIPTION
This eliminates compiler warning, for example when compiling Metal shader with embedded headers
```
 with program_source:6:9: warning: #pragma once in main file [-Wpragma-once-outside-header]
#pragma once
        ^
program_source:81:9: warning: #pragma once in main file [-Wpragma-once-outside-header]
#pragma once
        ^
program_source:588:9: warning: #pragma once in main file [-Wpragma-once-outside-header]
#pragma once
        ^
program_source:719:9: warning: #pragma once in main file [-Wpragma-once-outside-header]
#pragma once
        ^
program_source:829:29: error: use of undeclared identifier 'r0_2'
        auto tmp8 = in_ptr2[r0_2 + 768*x0];
```
