### PR TITLE
[ca] eliminate duplicate getitem graph nodes for shape inputs

### DIFF
--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -201,7 +201,7 @@ class AutogradCompilerInstance:
             self.wrap_fake(x, self.source("inputs", idx))
             for idx, x in enumerate(inputs)
         ]
-        self.bind_tensors_to_proxies(inputs, args_proxy, inputs_origins)
+        self.bind_objects_to_proxies(inputs, args_proxy, inputs_origins)
 
         # size inputs to symints
         sizes = [
@@ -212,7 +212,7 @@ class AutogradCompilerInstance:
             )
             for idx, val in enumerate(sizes)
         ]
-        proxies = self.bind_tensors_to_proxies(sizes, self.sizes_proxy, sizes_origins)
+        proxies = self.bind_objects_to_proxies(sizes, self.sizes_proxy, sizes_origins)
         for i, symint in enumerate(sizes):
             self.symnode_proxy_lookup[symint.node] = proxies[i]
 
@@ -236,7 +236,7 @@ class AutogradCompilerInstance:
                 )
             else:
                 raise AssertionError("Unexpected scalar type: ", type(val))
-        self.bind_tensors_to_proxies(scalars, self.scalars_proxy, scalars_origins)
+        self.bind_objects_to_proxies(scalars, self.scalars_proxy, scalars_origins)
         for i, symval in enumerate(scalars):
             self.symnode_proxy_lookup[symval.node] = self.scalars_proxy[i]  # type: ignore[union-attr]
 
@@ -391,7 +391,7 @@ class AutogradCompilerInstance:
             outputs = [
                 dummy() if isinstance(o, torch.fx.Proxy) else o for o in poutputs
             ]
-            self.bind_tensors_to_proxies(outputs, poutputs)
+            self.bind_objects_to_proxies(outputs, poutputs)
             return outputs
 
         outputs = copy_paste_aot_backward_graph()
@@ -411,7 +411,7 @@ class AutogradCompilerInstance:
             )
 
             output = self.allocate_dummy()
-            self.bind_tensors_to_proxies([output], [poutput])
+            self.bind_objects_to_proxies([output], [poutput])
             return output
 
         results = torch._functorch._aot_autograd.runtime_wrappers._backward_epilogue_functional(
@@ -471,7 +471,7 @@ class AutogradCompilerInstance:
                 grad_ins.append(
                     torch.empty(size=size, dtype=dtype, layout=layout, device=device)
                 )
-            self.bind_tensors_to_proxies(grad_ins, proxies)
+            self.bind_objects_to_proxies(grad_ins, proxies)
         return tuple(grad_ins)
 
     def call_copy_slices_prologue(self, inputs, base, view):
@@ -515,7 +515,7 @@ class AutogradCompilerInstance:
             "call_function", fn, args=proxy_args, kwargs={}
         )
         result = [self.allocate_dummy() for _ in output_metadata]
-        self.bind_tensors_to_proxies(result, [proxy_out[i] for i in range(len(result))])
+        self.bind_objects_to_proxies(result, [proxy_out[i] for i in range(len(result))])
         return result
 
     def validate_outputs(self, _, outputs, args, output_metadata):
@@ -526,7 +526,7 @@ class AutogradCompilerInstance:
             "call_function", op, args=proxy_args, kwargs={}
         )
         assert len(output_metadata) == len(outputs)
-        self.bind_tensors_to_proxies(outputs, new_proxy_outputs)
+        self.bind_objects_to_proxies(outputs, new_proxy_outputs)
         return outputs
 
     def accumulate(self, old_var, new_var):
@@ -536,7 +536,7 @@ class AutogradCompilerInstance:
             "call_function", torch.add, args=(old_var_proxy, new_var_proxy), kwargs={}
         )
         result = self.allocate_dummy()
-        self.bind_tensors_to_proxies([result], [proxy_out])
+        self.bind_objects_to_proxies([result], [proxy_out])
         return result
 
     def proxy_call_hook(self, hook, *args, **kwargs):
@@ -560,7 +560,7 @@ class AutogradCompilerInstance:
         )
         with disable_proxy_modes_tracing():
             inputs[i] = maybe_clone(inputs[i])
-            self.bind_tensors_to_proxies([inputs[i]], [proxy])
+            self.bind_objects_to_proxies([inputs[i]], [proxy])
         return inputs
 
     def pre_hook(self, inputs, hook_id):
@@ -573,7 +573,7 @@ class AutogradCompilerInstance:
         )
         with disable_proxy_modes_tracing():
             inputs = [maybe_clone(x) for x in inputs]
-            self.bind_tensors_to_proxies(inputs, proxies)
+            self.bind_objects_to_proxies(inputs, proxies)
         return inputs
 
     def post_hook(self, outputs, inputs, hook_id):
@@ -587,7 +587,7 @@ class AutogradCompilerInstance:
         )
         with disable_proxy_modes_tracing():
             outputs = [maybe_clone(x) for x in outputs]
-            self.bind_tensors_to_proxies(outputs, proxies)
+            self.bind_objects_to_proxies(outputs, proxies)
         return outputs
 
     def post_acc_grad_hook(self, input, hook_id):
@@ -601,7 +601,7 @@ class AutogradCompilerInstance:
         )
         with disable_proxy_modes_tracing():
             input = [maybe_clone(input)]
-            self.bind_tensors_to_proxies(input, [proxy])
+            self.bind_objects_to_proxies(input, [proxy])
         return input
 
     # Note: [Compiled autograd and cudagraphs]
@@ -1127,23 +1127,23 @@ class AutogradCompilerInstance:
         assert isinstance(proxy_tensor, torch.fx.experimental.proxy_tensor._ProxyTensor)
         return proxy_tensor.proxy
 
-    def bind_tensors_to_proxies(
-        self, tensors, proxies, origins: Optional[list[tuple[int, str]]] = None
+    def bind_objects_to_proxies(
+        self, objects, proxies, origins: Optional[list[tuple[int, str]]] = None
     ):
         if isinstance(proxies, torch.fx.Proxy):
             if origins:
-                assert len(origins) == len(tensors)
+                assert len(origins) == len(objects)
                 bound_proxies = []
-                for i in range(len(tensors)):
+                for i in range(len(objects)):
                     nodecall_index, node_name = origins[i]
                     self.set_node_origin(node_name, nodecall_index, None)
                     bound_proxies.append(proxies[i])  # type: ignore[index]
                 proxies = bound_proxies
             else:
-                proxies = [proxies[i] for i in range(len(tensors))]  # type: ignore[index]
+                proxies = [proxies[i] for i in range(len(objects))]  # type: ignore[index]
 
-        assert len(tensors) == len(proxies)
-        track_tensor_tree(tensors, proxies, constant=None, tracer=self.fx_tracer)
+        assert len(objects) == len(proxies)
+        track_tensor_tree(objects, proxies, constant=None, tracer=self.fx_tracer)
         return proxies
 
     def bind_backward_state(self, index: int):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #147021
* __->__ #146875
* #146735

should reuse existing proxies instead of creating new ones

before: https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmpL7hmHe/0_-_-_0/compiled_autograd_graph_3.txt?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=100
```python
class CompiledAutograd0(torch.nn.Module):
    def forward(self, inputs, sizes, scalars, hooks):
        # No stacktrace found for following nodes
        getitem = inputs[0]
        getitem_1 = inputs[1]
        getitem_2 = inputs[2];  inputs = None
        getitem_3 = sizes[0];  getitem_3 = None
        getitem_4 = sizes[1];  getitem_4 = None
        getitem_5 = sizes[2];  getitem_5 = None
        getitem_6 = sizes[3];  getitem_6 = None
        getitem_7 = sizes[4];  getitem_7 = None
        getitem_8 = sizes[5];  getitem_8 = None
        getitem_9 = sizes[6];  getitem_9 = None
        getitem_10 = sizes[7];  getitem_10 = None
        getitem_11 = sizes[8];  getitem_11 = None
        getitem_12 = sizes[9];  getitem_12 = None
        getitem_13 = sizes[10];  getitem_13 = None
        getitem_14 = sizes[11];  getitem_14 = None
        getitem_15 = sizes[12];  getitem_15 = None
        getitem_16 = sizes[13];  getitem_16 = None
        getitem_17 = sizes[14];  getitem_17 = None
        getitem_18 = sizes[15];  getitem_18 = None
        getitem_19 = sizes[0]
        getitem_20 = sizes[1]
        getitem_21 = sizes[2]
        getitem_22 = sizes[3]
        getitem_23 = sizes[4]
        getitem_24 = sizes[5]
        getitem_25 = sizes[6]
        getitem_26 = sizes[7]
        getitem_27 = sizes[8]
        getitem_28 = sizes[9]
        getitem_29 = sizes[10]
        getitem_30 = sizes[11]
        getitem_31 = sizes[12]
        getitem_32 = sizes[13]
        getitem_33 = sizes[14]
        getitem_34 = sizes[15];  sizes = None
```

after: https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmpCo5T6B/0_-_-_0/compiled_autograd_graph_1.txt?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=100
```python
class CompiledAutograd0(torch.nn.Module):
    def forward(self, inputs, sizes, scalars, hooks):
        # No stacktrace found for following nodes
        getitem = inputs[0]
        getitem_1 = inputs[1]
        getitem_2 = inputs[2];  inputs = None
        getitem_3 = sizes[0]
        getitem_4 = sizes[1]
        getitem_5 = sizes[2]
        getitem_6 = sizes[3]
        getitem_7 = sizes[4]
        getitem_8 = sizes[5]
        getitem_9 = sizes[6]
        getitem_10 = sizes[7]
        getitem_11 = sizes[8]
        getitem_12 = sizes[9]
        getitem_13 = sizes[10]
        getitem_14 = sizes[11]
        getitem_15 = sizes[12]
        getitem_16 = sizes[13]
        getitem_17 = sizes[14]
        getitem_18 = sizes[15];  sizes = None
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @StrongerXi @yf225