### PR TITLE
[cutlass backend] Do not change dtype of GEMM template

### DIFF
--- a/torch/_inductor/codegen/cuda/gemm_template.py
+++ b/torch/_inductor/codegen/cuda/gemm_template.py
@@ -6,6 +6,8 @@ import re
 from abc import ABC, abstractmethod
 from typing import Optional, Union
 
+from torch._inductor.codegen.cuda.cutlass_utils import try_import_cutlass
+
 from ... import ir
 from ...config import cuda as inductor_cuda_config
 from ...ir import (
@@ -750,8 +752,12 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
         Takes memory layout, dtype and support for EVT operations into account,
         and filters potentially problematic ops.
 
-        Returns None if the op is not suitable, otherwise returns the op to be used, which might
-        have been mutated.
+        Returns None if the op is not suitable, otherwise returns the op to be used.
+
+        The return op might be mutated. However, the configuration name should stay the same.
+        This means DataType of a, b, acc, c, d, and the layouts of a and b cannot change.
+
+        TODO: figure out how alignment should be handled.
         """
 
         assert cutlass_utils.try_import_cutlass()
@@ -772,9 +778,10 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
 
         # Filter ops according to the shape match.
         if not self._shape_match(op):
+            log.debug("Skipping due to shape mismatch. op: %s", op.configuration_name())
             return None
 
-        # Filter ops by dtypes.
+        # Filter ops by dtypes. need to check A, B, acc, C (if exists), D
         accumulator_torch_dtype = cutlass_utils.get_accumulator_dtype(
             [X.get_dtype(), W.get_dtype()],
         )
@@ -782,11 +789,27 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
             cutlass_utils.dtype_match(X.get_dtype(), op.A.element)
             and cutlass_utils.dtype_match(W.get_dtype(), op.B.element)
             and cutlass_utils.dtype_match(
-                self.output_node.get_layout().dtype, op.C.element
-            )
-            and cutlass_utils.dtype_match(
                 accumulator_torch_dtype, op.accumulator_type()
             )
+        ):
+            return None
+        assert try_import_cutlass()
+        from cutlass_library.library import DataType  # type: ignore[import]
+
+        if op.C.element == DataType.void:
+            # expect no bias
+            if len(self.input_nodes) >= 3 and self.input_nodes[2] is not None:
+                return None
+        else:
+            # expect bias, need to check dtype
+            if not (
+                len(self.input_nodes) >= 3
+                and self.input_nodes[2] is not None
+                and cutlass_utils.dtype_match(W.get_dtype(), op.C.element)
+            ):
+                return None
+        if not cutlass_utils.dtype_match(
+            self.output_node.get_layout().dtype, op.D.element
         ):
             return None
 
@@ -799,6 +822,9 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
 
         # Filter ops by alignment.
         if not self._alignment_match(op):
+            log.debug(
+                "Skipping due to alignment mismatch. op: %s", op.configuration_name()
+            )
             return None
 
         # Update op.
@@ -808,11 +834,13 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
         op.D.layout = CUTLASSGemmTemplate.cutlass_layout(self.output_node.get_layout())
 
         # Filter ops by alignments and set alignments.
-        if not (
+        status = (
             self.set_alignment(X.get_layout(), op.A)
             and self.set_alignment(W.get_layout(), op.B)
             and self.set_alignment(self.output_node.get_layout(), op.D)
-        ):
+        )
+        if not status:
+            log.debug("Skipping due to alignment setting failure. op: %s", op)
             return None
 
         # Set epilogue.
@@ -830,7 +858,11 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
                 return None
 
         # Set bias layout and alignment.
-        if not self._set_bias_layout_and_alignment(op):
+        status = self._set_bias_layout_and_alignment(op)
+        if not status:
+            log.debug(
+                "Skipping due to bias layout and alignment setting failure. op: %s", op
+            )
             return None
 
         return op
@@ -859,10 +891,20 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
                     filter_res = self.filter_op(op)
                     if (
                         filter_res is not None
+                        and filter_res.configuration_name() != op.configuration_name()
+                    ):
+                        log.debug(
+                            "Detected change in configuration name. Original "
+                            "name: %s, filtered configuration name: %s",
+                            op.configuration_name(),
+                            filter_res.configuration_name(),
+                        )
+                    if (
+                        filter_res is not None
                         and res.get(filter_res.configuration_name(), None) is None
                     ):
                         res[filter_res.configuration_name()] = filter_res
-        log.debug("Got cutlass configs: total number of ops: %d, ", len(res))
+        log.info("Got cutlass configs: total number of ops: %d, ", len(res))
         return list(res.items())[: inductor_cuda_config.cutlass_max_profiling_configs]
 
     def gemm_mode(self) -> str:
@@ -1173,24 +1215,14 @@ class CUTLASS3xGemmTemplate(CUTLASSGemmTemplate):
         self,
         op: "cutlass_library.gemm_op.GemmOperation",  # type: ignore[name-defined]  # noqa: F821
     ) -> bool:
-        import cutlass_library.library as cutlass_lib
-
         if len(self.input_nodes) >= 3 and self.input_nodes[2] is not None:
+            # bias exists
             Bias = self.input_nodes[2]
             bias_layout = CUTLASSGemmTemplate.cutlass_layout(Bias.get_layout())
-            if op.gemm_kind != cutlass_lib.GemmKind.Universal3x:
-                if bias_layout != op.D.layout:
-                    # For cutlass2, bias and output layout must match
-                    return False
-            else:
-                op.C.layout = bias_layout
-            if not self.set_alignment(Bias.get_layout(), op.C):
+            op.C.layout = bias_layout
+            status = self.set_alignment(Bias.get_layout(), op.C)
+            if not status:
                 return False
-        else:
-            if op.gemm_kind == cutlass_lib.GemmKind.Universal3x:
-                op.C.element = cutlass_lib.DataType.void
-            else:
-                op.C.layout = op.D.layout
         return True
 
     def _define_gemm_instance(


### PR DESCRIPTION
I think this is a change in the right direction.

Right now, when we try to find a cutlass gemm, we generate bunch of gemm templates, and filter out those that don't fix. For example, if we are doing bf16 x bf16 matmul, the gemm template for fp32 x fp32 is generated and filtered out.

However, for the dtype of bias, we would attempt to modify the dtype of the gemm template. I think this is a bad idea, since (1) the usable template is also being generated, and (2) this messes with the configuration name of the template.

I tested this offline. There isn't much difference in performance. However, with instantiation level 2222, I noticed way less "C++ compile error". This is probably due to using the right template?

Follow-ups are needed:
1. benchmark and dashboard
2. check our logic for setting alignment 

with my change
https://www.internalfb.com/intern/paste/P1729604119/

without my change
https://www.internalfb.com/intern/paste/P1729624806/


Differential Revision: D69085556




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov