### PR TITLE
[dynamo][source] Remove index_is_slice from GetItemSource

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1102,14 +1102,14 @@ class GuardBuilder(GuardBuilderBase):
             assert not isinstance(
                 base_example_value, (dict, collections.OrderedDict)
             ), "Use DictGetItemSource"
-            if isinstance(base_example_value, list) and not source.index_is_slice:
+            if isinstance(base_example_value, list):
                 out = base_guard_manager.list_getitem_manager(
                     key=source.index,
                     source=source_name,
                     example_value=example_value,
                     guard_manager_enum=guard_manager_enum,
                 )
-            elif isinstance(base_example_value, tuple) and not source.index_is_slice:
+            elif isinstance(base_example_value, tuple):
                 out = base_guard_manager.tuple_getitem_manager(
                     key=source.index,
                     source=source_name,
@@ -1118,8 +1118,6 @@ class GuardBuilder(GuardBuilderBase):
                 )
             else:
                 index = source.index
-                if source.index_is_slice:
-                    index = source.unpack_slice()
                 out = base_guard_manager.getitem_manager(
                     key=index,
                     source=source_name,

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -492,9 +492,6 @@ class GetItemSource(ChainedSource):
         return self.base.guard_source()
 
     def name(self):
-        # Index can be of following types
-        # 1) index is a slice - example 1:4
-        # 2) index is a constant - example string, integer
         assert not isinstance(self.index, Source)
         return f"{self.base.name()}[{self.index!r}]"
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1373,7 +1373,7 @@ class VariableBuilder:
 
             guards = []
             for i, tensor_variable in enumerate(list_variable.items):
-                source_i = GetItemSource(base=source, index=i, index_is_slice=False)
+                source_i = GetItemSource(base=source, index=i)
                 # access unpacked tensor from this list instead of from a lifted arg
                 self.tx.output.input_source_to_var[source_i] = tensor_variable
                 tensor_variable.proxy.node.meta["tensor_dict"] = _extract_tensor_dict(
@@ -2444,9 +2444,7 @@ def handle_traced_output(example_value, tx, proxy, options, subclass_type, targe
                     assert isinstance(example_value, list)
                     source = options["source"]
                     options_i = options.copy()
-                    options_i["source"] = GetItemSource(
-                        base=source, index=i, index_is_slice=False
-                    )
+                    options_i["source"] = GetItemSource(base=source, index=i)
                 else:
                     # use the same options object as parent
                     options_i = options


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146887
* #146819

Slicing on the data structures that go through GetItemSource always
result in temporary objects. So, there is never a case where we need a
source for a sliced data structure. I think it was a bug at one point of
time, and we incorrectly provided a source for sliced data structures.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames