### PR TITLE
[Intel GPU] Fallback embedding_dense_backward on XPU

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1474,7 +1474,7 @@ def _addmm_activation(
 ):
     out = addmm(self, mat1, mat2, beta, alpha)
     if use_gelu:
-        if self.is_cuda:
+        if self.is_cuda or self.is_xpu:
             return aten.gelu(out, approximate="tanh")
         else:
             return aten.gelu(out)

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -119,6 +119,9 @@ decomps_to_exclude = [
     aten.baddbmm,  # upcasts to fp32, perf issue
 ]
 
+if torch.xpu.is_available():
+    decomps_to_exclude.append(aten.embedding_dense_backward)
+
 remove_decompositions(decompositions, decomps_to_exclude)
 
 


### PR DESCRIPTION
Do not decompose embedding_dense_backward for torch.compile. Current XPU devices have hardware limitations on atomic ops. Fallback to eager and we use sort to implement this op. hf_T5 amp bf16 training in torchbench can get 2x improvement on Max 1550. I also align with cuda on gelu decomposition in _addmm_activation

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov