### PR TITLE
Friendly handle mem_get_info's runtime error message

### DIFF
--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -380,8 +380,11 @@ static void initXpuMethodBindings(PyObject* module) {
   m.def("_xpu_getMemoryInfo", [](c10::DeviceIndex device_index) {
 #if SYCL_COMPILER_VERSION >= 20250000
     auto total = at::xpu::getDeviceProperties(device_index)->global_mem_size;
-    auto free = c10::xpu::get_raw_device(device_index)
-                    .get_info<sycl::ext::intel::info::device::free_memory>();
+    auto& device = c10::xpu::get_raw_device(device_index);
+    TORCH_CHECK(
+        device.has(sycl::aspect::ext_intel_free_memory),
+        "The device doesn't support querying the available free memory.");
+    auto free = device.get_info<sycl::ext::intel::info::device::free_memory>();
     return std::make_tuple(free, total);
 #else
   TORCH_CHECK_NOT_IMPLEMENTED(

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -384,7 +384,7 @@ static void initXpuMethodBindings(PyObject* module) {
     TORCH_CHECK(
         device.has(sycl::aspect::ext_intel_free_memory),
         "The device (",
-        c10::xpu::getDeviceProperties(device_index)->name,
+        at::xpu::getDeviceProperties(device_index)->name,
         ") doesn't support querying the available free memory. ",
         "You can file an issue at https://github.com/pytorch/pytorch/issues ",
         "to help us prioritize its implementation.");

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -383,7 +383,11 @@ static void initXpuMethodBindings(PyObject* module) {
     auto& device = c10::xpu::get_raw_device(device_index);
     TORCH_CHECK(
         device.has(sycl::aspect::ext_intel_free_memory),
-        "The device doesn't support querying the available free memory.");
+        "The device (",
+        c10::xpu::getDeviceProperties(device_index)->name,
+        ") doesn't support querying the available free memory. ",
+        "You can file an issue at https://github.com/pytorch/pytorch/issues ",
+        "to help us prioritize its implementation.");
     auto free = device.get_info<sycl::ext::intel::info::device::free_memory>();
     return std::make_tuple(free, total);
 #else


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146899

# Motivation
Friendly handle the runtime error message if the device doesn't support querying the available free memory. See https://github.com/intel/torch-xpu-ops/issues/1352
