### PR TITLE
Fix var CUDA_PATH_V128 in cuda128.bat file

### DIFF
--- a/.ci/pytorch/windows/cuda128.bat
+++ b/.ci/pytorch/windows/cuda128.bat
@@ -43,8 +43,8 @@ IF "%BUILD_VISION%" == "" (
     set NVCC_FLAGS=-D__CUDA_NO_HALF_OPERATORS__ --expt-relaxed-constexpr -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_80,code=compute_80 -gencode=arch=compute_86,code=compute_86 -gencode=arch=compute_90,code=compute_90 -gencode=arch=compute_100,code=compute_100 -gencode=arch=compute_120,code=compute_120
 )
 
-set "CUDA_PATH=%CUDA_PATH_V126%"
-set "PATH=%CUDA_PATH_V126%\bin;%PATH%"
+set "CUDA_PATH=%CUDA_PATH_V128%"
+set "PATH=%CUDA_PATH_V128%\bin;%PATH%"
 
 :optcheck
 


### PR DESCRIPTION
Followup after: https://github.com/pytorch/pytorch/pull/146653
This should fix upcoming CUDA 12.8 windows builds.
Issue found during pytorch-canary Windows AMI test.
