### PR TITLE
[export][ez] Update tag_ for union setters.

### DIFF
--- a/torch/_export/serde/schema_check.py
+++ b/torch/_export/serde/schema_check.py
@@ -268,6 +268,7 @@ struct {name} {{
 
   void set_{name}({ty} def) {{
     variant_.emplace<{idx + 1}>(std::move(def));
+    tag_ = Tag::{name.upper()};
   }}
 """
 

--- a/torch/csrc/utils/generated_serialization_types.h
+++ b/torch/csrc/utils/generated_serialization_types.h
@@ -229,6 +229,7 @@ class SymExprHint {
 
   void set_as_int(int64_t def) {
     variant_.emplace<1>(std::move(def));
+    tag_ = Tag::AS_INT;
   }
 
   const bool& get_as_bool() const {
@@ -237,6 +238,7 @@ class SymExprHint {
 
   void set_as_bool(bool def) {
     variant_.emplace<2>(std::move(def));
+    tag_ = Tag::AS_BOOL;
   }
 
   const double& get_as_float() const {
@@ -245,6 +247,7 @@ class SymExprHint {
 
   void set_as_float(double def) {
     variant_.emplace<3>(std::move(def));
+    tag_ = Tag::AS_FLOAT;
   }
 
   friend void to_json(nlohmann::json& nlohmann_json_j, const SymExprHint& nlohmann_json_t) {
@@ -333,6 +336,7 @@ class SymInt {
 
   void set_as_expr(SymExpr def) {
     variant_.emplace<1>(std::move(def));
+    tag_ = Tag::AS_EXPR;
   }
 
   const int64_t& get_as_int() const {
@@ -341,6 +345,7 @@ class SymInt {
 
   void set_as_int(int64_t def) {
     variant_.emplace<2>(std::move(def));
+    tag_ = Tag::AS_INT;
   }
 
   friend void to_json(nlohmann::json& nlohmann_json_j, const SymInt& nlohmann_json_t) {
@@ -393,6 +398,7 @@ class SymFloat {
 
   void set_as_expr(SymExpr def) {
     variant_.emplace<1>(std::move(def));
+    tag_ = Tag::AS_EXPR;
   }
 
   const double& get_as_float() const {
@@ -401,6 +407,7 @@ class SymFloat {
 
   void set_as_float(double def) {
     variant_.emplace<2>(std::move(def));
+    tag_ = Tag::AS_FLOAT;
   }
 
   friend void to_json(nlohmann::json& nlohmann_json_j, const SymFloat& nlohmann_json_t) {
@@ -453,6 +460,7 @@ class SymBool {
 
   void set_as_expr(SymExpr def) {
     variant_.emplace<1>(std::move(def));
+    tag_ = Tag::AS_EXPR;
   }
 
   const bool& get_as_bool() const {
@@ -461,6 +469,7 @@ class SymBool {
 
   void set_as_bool(bool def) {
     variant_.emplace<2>(std::move(def));
+    tag_ = Tag::AS_BOOL;
   }
 
   friend void to_json(nlohmann::json& nlohmann_json_j, const SymBool& nlohmann_json_t) {
@@ -585,6 +594,7 @@ class SymIntArgument {
 
   void set_as_name(std::string def) {
     variant_.emplace<1>(std::move(def));
+    tag_ = Tag::AS_NAME;
   }
 
   const int64_t& get_as_int() const {
@@ -593,6 +603,7 @@ class SymIntArgument {
 
   void set_as_int(int64_t def) {
     variant_.emplace<2>(std::move(def));
+    tag_ = Tag::AS_INT;
   }
 
   friend void to_json(nlohmann::json& nlohmann_json_j, const SymIntArgument& nlohmann_json_t) {
@@ -645,6 +656,7 @@ class SymFloatArgument {
 
   void set_as_name(std::string def) {
     variant_.emplace<1>(std::move(def));
+    tag_ = Tag::AS_NAME;
   }
 
   const double& get_as_float() const {
@@ -653,6 +665,7 @@ class SymFloatArgument {
 
   void set_as_float(double def) {
     variant_.emplace<2>(std::move(def));
+    tag_ = Tag::AS_FLOAT;
   }
 
   friend void to_json(nlohmann::json& nlohmann_json_j, const SymFloatArgument& nlohmann_json_t) {
@@ -705,6 +718,7 @@ class SymBoolArgument {
 
   void set_as_name(std::string def) {
     variant_.emplace<1>(std::move(def));
+    tag_ = Tag::AS_NAME;
   }
 
   const bool& get_as_bool() const {
@@ -713,6 +727,7 @@ class SymBoolArgument {
 
   void set_as_bool(bool def) {
     variant_.emplace<2>(std::move(def));
+    tag_ = Tag::AS_BOOL;
   }
 
   friend void to_json(nlohmann::json& nlohmann_json_j, const SymBoolArgument& nlohmann_json_t) {
@@ -801,6 +816,7 @@ class OptionalTensorArgument {
 
   void set_as_tensor(TensorArgument def) {
     variant_.emplace<1>(std::move(def));
+    tag_ = Tag::AS_TENSOR;
   }
 
   const bool& get_as_none() const {
@@ -809,6 +825,7 @@ class OptionalTensorArgument {
 
   void set_as_none(bool def) {
     variant_.emplace<2>(std::move(def));
+    tag_ = Tag::AS_NONE;
   }
 
   friend void to_json(nlohmann::json& nlohmann_json_j, const OptionalTensorArgument& nlohmann_json_t) {
@@ -915,6 +932,7 @@ class Argument {
 
   void set_as_none(bool def) {
     variant_.emplace<1>(std::move(def));
+    tag_ = Tag::AS_NONE;
   }
 
   const TensorArgument& get_as_tensor() const {
@@ -923,6 +941,7 @@ class Argument {
 
   void set_as_tensor(TensorArgument def) {
     variant_.emplace<2>(std::move(def));
+    tag_ = Tag::AS_TENSOR;
   }
 
   const std::vector<TensorArgument>& get_as_tensors() const {
@@ -931,6 +950,7 @@ class Argument {
 
   void set_as_tensors(std::vector<TensorArgument> def) {
     variant_.emplace<3>(std::move(def));
+    tag_ = Tag::AS_TENSORS;
   }
 
   const int64_t& get_as_int() const {
@@ -939,6 +959,7 @@ class Argument {
 
   void set_as_int(int64_t def) {
     variant_.emplace<4>(std::move(def));
+    tag_ = Tag::AS_INT;
   }
 
   const std::vector<int64_t>& get_as_ints() const {
@@ -947,6 +968,7 @@ class Argument {
 
   void set_as_ints(std::vector<int64_t> def) {
     variant_.emplace<5>(std::move(def));
+    tag_ = Tag::AS_INTS;
   }
 
   const double& get_as_float() const {
@@ -955,6 +977,7 @@ class Argument {
 
   void set_as_float(double def) {
     variant_.emplace<6>(std::move(def));
+    tag_ = Tag::AS_FLOAT;
   }
 
   const std::vector<double>& get_as_floats() const {
@@ -963,6 +986,7 @@ class Argument {
 
   void set_as_floats(std::vector<double> def) {
     variant_.emplace<7>(std::move(def));
+    tag_ = Tag::AS_FLOATS;
   }
 
   const std::string& get_as_string() const {
@@ -971,6 +995,7 @@ class Argument {
 
   void set_as_string(std::string def) {
     variant_.emplace<8>(std::move(def));
+    tag_ = Tag::AS_STRING;
   }
 
   const std::vector<std::string>& get_as_strings() const {
@@ -979,6 +1004,7 @@ class Argument {
 
   void set_as_strings(std::vector<std::string> def) {
     variant_.emplace<9>(std::move(def));
+    tag_ = Tag::AS_STRINGS;
   }
 
   const SymIntArgument& get_as_sym_int() const {
@@ -987,6 +1013,7 @@ class Argument {
 
   void set_as_sym_int(SymIntArgument def) {
     variant_.emplace<10>(std::move(def));
+    tag_ = Tag::AS_SYM_INT;
   }
 
   const std::vector<SymIntArgument>& get_as_sym_ints() const {
@@ -995,6 +1022,7 @@ class Argument {
 
   void set_as_sym_ints(std::vector<SymIntArgument> def) {
     variant_.emplace<11>(std::move(def));
+    tag_ = Tag::AS_SYM_INTS;
   }
 
   const ScalarType& get_as_scalar_type() const {
@@ -1003,6 +1031,7 @@ class Argument {
 
   void set_as_scalar_type(ScalarType def) {
     variant_.emplace<12>(std::move(def));
+    tag_ = Tag::AS_SCALAR_TYPE;
   }
 
   const MemoryFormat& get_as_memory_format() const {
@@ -1011,6 +1040,7 @@ class Argument {
 
   void set_as_memory_format(MemoryFormat def) {
     variant_.emplace<13>(std::move(def));
+    tag_ = Tag::AS_MEMORY_FORMAT;
   }
 
   const Layout& get_as_layout() const {
@@ -1019,6 +1049,7 @@ class Argument {
 
   void set_as_layout(Layout def) {
     variant_.emplace<14>(std::move(def));
+    tag_ = Tag::AS_LAYOUT;
   }
 
   const Device& get_as_device() const {
@@ -1027,6 +1058,7 @@ class Argument {
 
   void set_as_device(Device def) {
     variant_.emplace<15>(std::move(def));
+    tag_ = Tag::AS_DEVICE;
   }
 
   const bool& get_as_bool() const {
@@ -1035,6 +1067,7 @@ class Argument {
 
   void set_as_bool(bool def) {
     variant_.emplace<16>(std::move(def));
+    tag_ = Tag::AS_BOOL;
   }
 
   const std::vector<bool>& get_as_bools() const {
@@ -1043,6 +1076,7 @@ class Argument {
 
   void set_as_bools(std::vector<bool> def) {
     variant_.emplace<17>(std::move(def));
+    tag_ = Tag::AS_BOOLS;
   }
 
   const SymBoolArgument& get_as_sym_bool() const {
@@ -1051,6 +1085,7 @@ class Argument {
 
   void set_as_sym_bool(SymBoolArgument def) {
     variant_.emplace<18>(std::move(def));
+    tag_ = Tag::AS_SYM_BOOL;
   }
 
   const std::vector<SymBoolArgument>& get_as_sym_bools() const {
@@ -1059,6 +1094,7 @@ class Argument {
 
   void set_as_sym_bools(std::vector<SymBoolArgument> def) {
     variant_.emplace<19>(std::move(def));
+    tag_ = Tag::AS_SYM_BOOLS;
   }
 
   const GraphArgument& get_as_graph() const {
@@ -1067,6 +1103,7 @@ class Argument {
 
   void set_as_graph(GraphArgument def) {
     variant_.emplace<20>(std::move(def));
+    tag_ = Tag::AS_GRAPH;
   }
 
   const std::vector<OptionalTensorArgument>& get_as_optional_tensors() const {
@@ -1075,6 +1112,7 @@ class Argument {
 
   void set_as_optional_tensors(std::vector<OptionalTensorArgument> def) {
     variant_.emplace<21>(std::move(def));
+    tag_ = Tag::AS_OPTIONAL_TENSORS;
   }
 
   const CustomObjArgument& get_as_custom_obj() const {
@@ -1083,6 +1121,7 @@ class Argument {
 
   void set_as_custom_obj(CustomObjArgument def) {
     variant_.emplace<22>(std::move(def));
+    tag_ = Tag::AS_CUSTOM_OBJ;
   }
 
   const std::string& get_as_operator() const {
@@ -1091,6 +1130,7 @@ class Argument {
 
   void set_as_operator(std::string def) {
     variant_.emplace<23>(std::move(def));
+    tag_ = Tag::AS_OPERATOR;
   }
 
   const SymFloatArgument& get_as_sym_float() const {
@@ -1099,6 +1139,7 @@ class Argument {
 
   void set_as_sym_float(SymFloatArgument def) {
     variant_.emplace<24>(std::move(def));
+    tag_ = Tag::AS_SYM_FLOAT;
   }
 
   const std::vector<SymFloatArgument>& get_as_sym_floats() const {
@@ -1107,6 +1148,7 @@ class Argument {
 
   void set_as_sym_floats(std::vector<SymFloatArgument> def) {
     variant_.emplace<25>(std::move(def));
+    tag_ = Tag::AS_SYM_FLOATS;
   }
 
   friend void to_json(nlohmann::json& nlohmann_json_j, const Argument& nlohmann_json_t) {
@@ -1564,6 +1606,7 @@ class ConstantValue {
 
   void set_as_none(bool def) {
     variant_.emplace<1>(std::move(def));
+    tag_ = Tag::AS_NONE;
   }
 
   const int64_t& get_as_int() const {
@@ -1572,6 +1615,7 @@ class ConstantValue {
 
   void set_as_int(int64_t def) {
     variant_.emplace<2>(std::move(def));
+    tag_ = Tag::AS_INT;
   }
 
   const double& get_as_float() const {
@@ -1580,6 +1624,7 @@ class ConstantValue {
 
   void set_as_float(double def) {
     variant_.emplace<3>(std::move(def));
+    tag_ = Tag::AS_FLOAT;
   }
 
   const std::string& get_as_string() const {
@@ -1588,6 +1633,7 @@ class ConstantValue {
 
   void set_as_string(std::string def) {
     variant_.emplace<4>(std::move(def));
+    tag_ = Tag::AS_STRING;
   }
 
   const bool& get_as_bool() const {
@@ -1596,6 +1642,7 @@ class ConstantValue {
 
   void set_as_bool(bool def) {
     variant_.emplace<5>(std::move(def));
+    tag_ = Tag::AS_BOOL;
   }
 
   friend void to_json(nlohmann::json& nlohmann_json_j, const ConstantValue& nlohmann_json_t) {
@@ -1837,6 +1884,7 @@ class InputSpec {
 
   void set_user_input(UserInputSpec def) {
     variant_.emplace<1>(std::move(def));
+    tag_ = Tag::USER_INPUT;
   }
 
   const InputToParameterSpec& get_parameter() const {
@@ -1845,6 +1893,7 @@ class InputSpec {
 
   void set_parameter(InputToParameterSpec def) {
     variant_.emplace<2>(std::move(def));
+    tag_ = Tag::PARAMETER;
   }
 
   const InputToBufferSpec& get_buffer() const {
@@ -1853,6 +1902,7 @@ class InputSpec {
 
   void set_buffer(InputToBufferSpec def) {
     variant_.emplace<3>(std::move(def));
+    tag_ = Tag::BUFFER;
   }
 
   const InputToTensorConstantSpec& get_tensor_constant() const {
@@ -1861,6 +1911,7 @@ class InputSpec {
 
   void set_tensor_constant(InputToTensorConstantSpec def) {
     variant_.emplace<4>(std::move(def));
+    tag_ = Tag::TENSOR_CONSTANT;
   }
 
   const InputToCustomObjSpec& get_custom_obj() const {
@@ -1869,6 +1920,7 @@ class InputSpec {
 
   void set_custom_obj(InputToCustomObjSpec def) {
     variant_.emplace<5>(std::move(def));
+    tag_ = Tag::CUSTOM_OBJ;
   }
 
   const InputTokenSpec& get_token() const {
@@ -1877,6 +1929,7 @@ class InputSpec {
 
   void set_token(InputTokenSpec def) {
     variant_.emplace<6>(std::move(def));
+    tag_ = Tag::TOKEN;
   }
 
   const InputToConstantInputSpec& get_constant_input() const {
@@ -1885,6 +1938,7 @@ class InputSpec {
 
   void set_constant_input(InputToConstantInputSpec def) {
     variant_.emplace<7>(std::move(def));
+    tag_ = Tag::CONSTANT_INPUT;
   }
 
   friend void to_json(nlohmann::json& nlohmann_json_j, const InputSpec& nlohmann_json_t) {
@@ -2144,6 +2198,7 @@ class OutputSpec {
 
   void set_user_output(UserOutputSpec def) {
     variant_.emplace<1>(std::move(def));
+    tag_ = Tag::USER_OUTPUT;
   }
 
   const LossOutputSpec& get_loss_output() const {
@@ -2152,6 +2207,7 @@ class OutputSpec {
 
   void set_loss_output(LossOutputSpec def) {
     variant_.emplace<2>(std::move(def));
+    tag_ = Tag::LOSS_OUTPUT;
   }
 
   const BufferMutationSpec& get_buffer_mutation() const {
@@ -2160,6 +2216,7 @@ class OutputSpec {
 
   void set_buffer_mutation(BufferMutationSpec def) {
     variant_.emplace<3>(std::move(def));
+    tag_ = Tag::BUFFER_MUTATION;
   }
 
   const GradientToParameterSpec& get_gradient_to_parameter() const {
@@ -2168,6 +2225,7 @@ class OutputSpec {
 
   void set_gradient_to_parameter(GradientToParameterSpec def) {
     variant_.emplace<4>(std::move(def));
+    tag_ = Tag::GRADIENT_TO_PARAMETER;
   }
 
   const GradientToUserInputSpec& get_gradient_to_user_input() const {
@@ -2176,6 +2234,7 @@ class OutputSpec {
 
   void set_gradient_to_user_input(GradientToUserInputSpec def) {
     variant_.emplace<5>(std::move(def));
+    tag_ = Tag::GRADIENT_TO_USER_INPUT;
   }
 
   const UserInputMutationSpec& get_user_input_mutation() const {
@@ -2184,6 +2243,7 @@ class OutputSpec {
 
   void set_user_input_mutation(UserInputMutationSpec def) {
     variant_.emplace<6>(std::move(def));
+    tag_ = Tag::USER_INPUT_MUTATION;
   }
 
   const OutputTokenSpec& get_token() const {
@@ -2192,6 +2252,7 @@ class OutputSpec {
 
   void set_token(OutputTokenSpec def) {
     variant_.emplace<7>(std::move(def));
+    tag_ = Tag::TOKEN;
   }
 
   friend void to_json(nlohmann::json& nlohmann_json_j, const OutputSpec& nlohmann_json_t) {


### PR DESCRIPTION
Summary: ez fix to set tag for union type fields.

Test Plan: CI

Differential Revision: D69467715


