### PR TITLE
don't use Config for compile job id since it only supports bools and not strings

### DIFF
--- a/torch/compiler/config.py
+++ b/torch/compiler/config.py
@@ -13,6 +13,7 @@ contain configuration options that affect only a specific part of the compiler:
 """
 
 import sys
+import os
 from typing import Optional
 
 from torch.utils._config_module import Config, install_config_module
@@ -29,7 +30,7 @@ __all__ = [
 # FB-internal note: you do NOT have to specify this explicitly specify this if
 # you run on MAST, we will automatically default this to
 # mast:MAST_JOB_NAME:MAST_JOB_VERSION.
-job_id: Optional[str] = Config(env_name_default="TORCH_COMPILE_JOB_ID", default=None)
+job_id: Optional[str] = os.environ.get("TORCH_COMPILE_JOB_ID", None)
 """
 Semantically, this should be an identifier that uniquely identifies, e.g., a
 training job.  You might have multiple attempts of the same job, e.g., if it was


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #146918

https://github.com/pytorch/pytorch/pull/143152 broke pgo testing locally since Config ignores all config values other than "0" or "1" since it assumes these are flags/bools: https://www.internalfb.com/code/fbsource/[a43a941905ac138a02b6d32a60c28853e2a71eec]/fbcode/caffe2/torch/utils/_config_module.py?lines=156%2C315%2C320

Maybe Config should support strings? Anyways for now let's land this so at least we can test PGO locally.

Tested via

```
TORCH_LOGS="torch._dynamo.pgo" TORCH_COMPILE_JOB_ID=123 TORCH_DYNAMO_AUTOMATIC_DYNAMIC_LOCAL_PGO=1 tlp python r9.py
```

