### PR TITLE
Revert commit that removed windows testing in VS2019-> update 

### DIFF
--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -603,12 +603,12 @@ class TestBypassFailures(TestCase):
             ].classification
             == "BROKEN_TRUNK"
         )
-        # self.assertTrue(
-        #     checks[
-        #         "trunk / win-vs2022-cpu-py3 / test (default, 2, 3, windows.4xlarge.nonephemeral)"
-        #     ].classification
-        #     == "FLAKY"
-        # )
+        self.assertTrue(
+            checks[
+                "trunk / win-vs2022-cpu-py3 / test (default, 2, 3, windows.4xlarge.nonephemeral)"
+            ].classification
+            == "FLAKY"
+        )
         self.assertTrue(
             checks[
                 "pull / linux-jammy-py3.8-gcc11 / test (distributed, 1, 2, linux.2xlarge)"

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -605,7 +605,7 @@ class TestBypassFailures(TestCase):
         )
         self.assertTrue(
             checks[
-                "trunk / win-vs2022-cpu-py3 / test (default, 2, 3, windows.4xlarge.nonephemeral)"
+                "trunk / win-vs2019-cpu-py3 / test (default, 2, 3, windows.4xlarge.nonephemeral)"
             ].classification
             == "FLAKY"
         )

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -362,6 +362,25 @@ jobs:
       test-matrix: ${{ needs.linux-focal-py3_9-clang9-xla-build.outputs.test-matrix }}
     secrets: inherit
 
+  win-vs2022-cpu-py3-build:
+    # don't run build twice on main
+    if: github.event_name == 'pull_request'
+    name: win-vs2022-cpu-py3
+    uses: ./.github/workflows/_win-build.yml
+    needs: get-label-type
+    with:
+      build-environment: win-vs2022-cpu-py3
+      cuda-version: cpu
+      sync-tag: win-cpu-build
+      runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral"
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral" },
+          { config: "default", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral" },
+          { config: "default", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral" },
+        ]}
+    secrets: inherit
+
   linux-focal-cpu-py3_10-gcc9-bazel-test:
     name: linux-focal-cpu-py3.10-gcc9-bazel-test
     uses: ./.github/workflows/_bazel-build-test.yml

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -125,6 +125,44 @@ jobs:
       test-matrix: ${{ needs.macos-py3-arm64-build.outputs.test-matrix }}
     secrets: inherit
 
+  win-vs2022-cpu-py3-build:
+    name: win-vs2022-cpu-py3
+    uses: ./.github/workflows/_win-build.yml
+    needs: get-label-type
+    with:
+      build-environment: win-vs2022-cpu-py3
+      cuda-version: cpu
+      sync-tag: win-cpu-build
+      runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral"
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral" },
+          { config: "default", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral" },
+          { config: "default", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral" },
+        ]}
+    secrets: inherit
+
+  win-vs2022-cpu-py3-test:
+    name: win-vs2022-cpu-py3
+    uses: ./.github/workflows/_win-test.yml
+    needs:
+      - win-vs2022-cpu-py3-build
+      - target-determination
+    with:
+      build-environment: win-vs2022-cpu-py3
+      cuda-version: cpu
+      test-matrix: ${{ needs.win-vs2022-cpu-py3-build.outputs.test-matrix }}
+    secrets: inherit
+
+  win-vs2022-cuda12_1-py3-build:
+    name: win-vs2022-cuda12.1-py3
+    uses: ./.github/workflows/_win-build.yml
+    needs: get-label-type
+    with:
+      build-environment: win-vs2022-cuda12.1-py3
+      cuda-version: "12.1"
+      runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral"
+    secrets: inherit
 
   linux-focal-rocm6_3-py3_10-build:
     if: ${{ startsWith(github.event.ref, 'refs/tags/ciflow/trunk') }}


### PR DESCRIPTION
This reverts commit b57b38b52ede2af27d4eb1bf6ba63868a3ee7553.

This commit removed windows testing for the VS build and needs to be added back in with the updated VS2022 build

Fixes #ISSUE_NUMBER
