### PR TITLE
Support static method of torchbind attributes in torch.compile with inductor backend

### DIFF
--- a/test/inductor/test_torchbind.py
+++ b/test/inductor/test_torchbind.py
@@ -5,8 +5,12 @@ import torch._functorch
 import torch._inductor
 import torch._inductor.decomposition
 from torch._higher_order_ops.torchbind import enable_torchbind_tracing
+from torch._inductor import ir
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.torchbind_impls import init_torchbind_implementations
+from torch.testing._internal.torchbind_impls import (
+    _empty_tensor_queue,
+    init_torchbind_implementations,
+)
 
 
 class TestTorchbind(TestCase):
@@ -31,7 +35,8 @@ class TestTorchbind(TestCase):
                 a = torch.ops._TorchScriptTesting.takes_foo_tuple_return(self.attr, x)
                 y = a[0] + a[1]
                 b = torch.ops._TorchScriptTesting.takes_foo(self.attr, y)
-                return x + b
+                c = self.attr.add_tensor(x)
+                return x + b + c
 
         m = M()
         inputs = (torch.ones(2, 3),)
@@ -41,14 +46,40 @@ class TestTorchbind(TestCase):
         with enable_torchbind_tracing():
             ep = torch.export.export(m, inputs, strict=False)
 
-        return ep, inputs, orig_res
+        return ep, inputs, orig_res, m
 
     def test_torchbind_inductor(self):
-        ep, inputs, orig_res = self.get_exported_model()
+        ep, inputs, orig_res, _ = self.get_exported_model()
         compiled = torch._inductor.compile(ep.module(), inputs)
 
         new_res = compiled(*inputs)
         self.assertTrue(torch.allclose(orig_res, new_res))
+
+    def test_torchbind_compile(self):
+        _, inputs, orig_res, mod = self.get_exported_model()
+        new_res = torch.compile(mod, backend="inductor")(*inputs)
+        self.assertTrue(torch.allclose(orig_res, new_res))
+
+    def test_torchbind_get_buf_bytes(self):
+        a = torch.classes._TorchScriptTesting._Foo(10, 20)
+        buffer = ir.TorchBindObject(name="a", value=a)
+        size = buffer.get_buf_bytes()
+        self.assertEqual(size, 0)
+
+        t = torch.randn(2, 3)
+        b = torch.classes._TorchScriptTesting._ContainsTensor(t)
+        buffer = ir.TorchBindObject(name="b", value=b)
+        size = buffer.get_buf_bytes()
+        self.assertEqual(size, 2 * 3 * 4)
+
+        q = _empty_tensor_queue()
+        buffer = ir.TorchBindObject(name="q", value=q)
+        size = buffer.get_buf_bytes()
+        self.assertEqual(size, 0)
+
+        q.push(torch.ones(2, 3))
+        size = buffer.get_buf_bytes()
+        self.assertEqual(size, 2 * 3 * 4)
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -61,6 +61,7 @@ from torch._dynamo.debug_utils import (
 from torch._dynamo.trace_rules import is_fbcode
 from torch._dynamo.utils import clone_inputs, counters, same
 from torch._inductor.output_code import OutputCode
+from torch._library.fake_class_registry import FakeScriptObject
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.symbolic_shapes import (
     fx_placeholder_targets,
@@ -372,7 +373,9 @@ def save_graph_repro(
         accuracy = "_accuracy" in compiler_name
     if tracing_mode is None:
         tracing_mode = "real"
-        if any(has_free_symbols(a) for a in args):
+        if any(
+            has_free_symbols(a) for a in args if not isinstance(a, FakeScriptObject)
+        ):
             tracing_mode = "symbolic"
     fd.write("if __name__ == '__main__':\n")
     fd.write("    from torch._dynamo.repro.after_aot import run_repro\n")

--- a/torch/_higher_order_ops/effects.py
+++ b/torch/_higher_order_ops/effects.py
@@ -7,6 +7,7 @@ import torch
 import torch.utils._pytree as pytree
 from torch._C import DispatchKey
 from torch._higher_order_ops.torchbind import call_torchbind
+from torch._library.fake_class_registry import FakeScriptObject
 from torch._ops import HigherOrderOperator
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
@@ -116,7 +117,7 @@ def get_effect_key(op, args, kwargs) -> Optional[_EffectType]:
         return SIDE_EFFECTS[op]
 
     for arg in args:
-        if isinstance(arg, torch.ScriptObject):
+        if isinstance(arg, (torch.ScriptObject, FakeScriptObject)):
             # Add it to the table so that next time we see the same op we don't
             # have to parse through the args again
             SIDE_EFFECTS[op] = _EffectType.ORDERED

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1323,7 +1323,8 @@ class SIMDScheduling(BaseScheduling):
 
     @staticmethod
     def can_use_32bit_indexing(
-        numel: sympy.Expr, buffers: Iterable[Union[ir.Buffer, ir.TensorBox]]
+        numel: sympy.Expr,
+        buffers: Iterable[Union[ir.Buffer, ir.TensorBox, ir.TorchBindObject]],
     ) -> bool:
         int_max = torch.iinfo(torch.int32).max
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -881,7 +881,7 @@ class PythonWrapperCodegen(CodeGen):
 
     def codegen_input_size_asserts(self) -> None:
         for name, buf in V.graph.graph_inputs.items():
-            if isinstance(buf, sympy.Expr):
+            if isinstance(buf, (sympy.Expr, ir.TorchBindObject)):
                 continue
 
             # comparing strides for 0 size tensor is tricky. Ignore them for now.
@@ -894,7 +894,7 @@ class PythonWrapperCodegen(CodeGen):
     def codegen_input_nan_asserts(self) -> None:
         self.prefix.writeline("# make sure graph inputs are not nan/inf")
         for name, buf in V.graph.graph_inputs.items():
-            if isinstance(buf, sympy.Expr):
+            if isinstance(buf, (sympy.Expr, ir.TorchBindObject)):
                 continue
 
             line = f"assert not {name}.isnan().any().item()"
@@ -1345,6 +1345,8 @@ class PythonWrapperCodegen(CodeGen):
                 if isinstance(stride, sympy.Symbol) and stride not in bound_vars:
                     code.writeline(f"{stride} = {strideof(name)}[{dim}]")
                     bound_vars.add(stride)
+        elif isinstance(value, ir.TorchBindObject):
+            pass
         else:
             raise AssertionError(f"Unknown value type: {type(value)}")
 
@@ -1488,6 +1490,8 @@ class PythonWrapperCodegen(CodeGen):
         def add_torchbind_input(name, value):
             import pickle
 
+            assert isinstance(value, torch.ScriptObject)
+
             output.writeline(f"{name} = pickle.loads({pickle.dumps(value)!r})")
 
         output.writelines(
@@ -1526,7 +1530,13 @@ class PythonWrapperCodegen(CodeGen):
                     # SingletonInts belong to metadata that should only live on
                     # the subclass.
                     continue
-                if isinstance(value, sympy.Expr):  # Don't need to add symbolic
+                if isinstance(value, ir.TorchBindObject):
+                    if len(V.graph.torchbind_constants) == 0:
+                        # otherwise we have already imported the pickle package
+                        output.writeline("import pickle")
+                    output.writeline(f"global {name}")
+                    add_torchbind_input(name, value.get_real_obj())
+                elif isinstance(value, sympy.Expr):  # Don't need to add symbolic
                     # TODO: this fallback and those below actually will generate possibly
                     # invalid benchmark code, because it's not guaranteed 42
                     # is actually a valid value for the kernel in question.
@@ -2251,7 +2261,7 @@ class PythonWrapperCodegen(CodeGen):
     def make_tensor_alias(self, new_name, old_name, comment=""):
         return f"{self.declare}{new_name} = {old_name}{self.ending}  {self.comment} {comment}"
 
-    def make_buffer_free(self, buffer: BufferLike):
+    def make_buffer_free(self, buffer: Union[BufferLike, ir.TorchBindObject]):
         return f"del {buffer.get_name()}"
 
     def make_free_by_names(self, names_to_del: list[str]):
@@ -2334,7 +2344,7 @@ class PythonWrapperCodegen(CodeGen):
         name = buffer.get_name()
 
         # can be freed but not reused
-        if isinstance(buffer, ir.InputBuffer):
+        if isinstance(buffer, (ir.InputBuffer, ir.TorchBindObject)):
             self.writeline(self.make_buffer_free(buffer))
             return
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4952,6 +4952,7 @@ class ExternKernel(InputsKernel):
         args_flat, args_spec = pytree.tree_flatten(binded_args)
 
         is_arg_tensor = []
+        # tensor_args can be either tensor or torchbind objects
         tensor_args = []
         non_tensor_args: list[Any] = []
         for arg in args_flat:
@@ -5001,6 +5002,8 @@ class ExternKernel(InputsKernel):
                 and x.get_name() in V.graph.torchbind_constants
             ):
                 example_args.append(V.graph.torchbind_constants[x.get_name()])
+            elif isinstance(x, TorchBindObject):
+                example_args.append(x.get_real_obj())
             else:
                 example_args.append(ir_node_to_tensor(x, guard_shape=True))
 
@@ -6563,12 +6566,14 @@ class FallbackKernel(ExternKernelAlloc):
             self.get_kwargs_value(key, **kwargs)
             for key in self.ordered_kwargs_for_cpp_kernel
         ]
+        target = self.op_overload
+
         if not V.graph.aot_mode:
             # No need to serialize in the cpp wrapper JIT mode
             return [*args, *ordered_kwargs]
 
         serializer = GraphModuleSerializer(None, None)  # type: ignore[arg-type]
-        named_arguments = serializer.serialize_inputs(self.op_overload, args, kwargs)
+        named_arguments = serializer.serialize_inputs(target, args, kwargs)
 
         # serialize_outputs
         def handle_single_output(return_type, output):  # type: ignore[no-untyped-def]
@@ -6594,7 +6599,6 @@ class FallbackKernel(ExternKernelAlloc):
             else:
                 raise RuntimeError(f"Unsupported return type {type(return_type)}")
 
-        target = self.op_overload
         returns = target._schema.returns  # type: ignore[union-attr]
         if len(returns) == 1:
             # NOTE: [special handling of all_reduce_coalesced_'s return value]
@@ -6648,7 +6652,6 @@ class FallbackKernel(ExternKernelAlloc):
             self.use_runtime_dispatch = True
 
         def do_runtime_dispatch() -> None:
-            exported_args = None
             args = None
             exported_args = self.export_extern_kernel_node()
 
@@ -7513,7 +7516,10 @@ class EffectfulKernel(FallbackKernel):
 
         from torch._higher_order_ops.effects import get_effect_key
 
-        effect_type = get_effect_key(kernel, (*nontensor_args, *tensor_args), kwargs)
+        uncovered_args = [
+            a.value if isinstance(a, TorchBindObject) else a for a in tensor_args
+        ]
+        effect_type = get_effect_key(kernel, (*nontensor_args, *uncovered_args), kwargs)
         assert effect_type is not None
         self.effect_type = effect_type
         self.prev_effect_buffer = V.graph.effectful_ops.get(effect_type, None)
@@ -7535,14 +7541,37 @@ class EffectfulKernel(FallbackKernel):
 
 @ir_dataclass
 class TorchBindObject(IRNode):
+    from torch._library.fake_class_registry import FakeScriptObject
+
     name: str
-    value: torch._C.ScriptObject
+    value: Union[FakeScriptObject, torch.ScriptObject]
 
     def get_name(self):  # type: ignore[no-untyped-def]
         return self.name
 
     def codegen_reference(self, writer: Optional[IndentedBuffer] = None) -> str:
         return self.name
+
+    def get_value(self) -> Union[FakeScriptObject, torch.ScriptObject]:
+        return self.value
+
+    def get_real_obj(self) -> torch.ScriptObject:
+        if isinstance(self.value, torch.ScriptObject):
+            return self.value
+        else:
+            return self.value.real_obj
+
+    def get_buf_bytes(self) -> int:
+        # Returns the sum of all tensors in the flattened object
+        real_script_obj = self.get_real_obj()
+        flat_dict = dict(real_script_obj.__obj_flatten__())  # type: ignore[attr-defined]
+        flat_elems = pytree.tree_flatten(flat_dict)[0]
+        flat_sizes = [
+            x.element_size() * x.numel()
+            for x in flat_elems
+            if isinstance(x, torch.Tensor)
+        ]
+        return functools.reduce(lambda x, y: x + y, flat_sizes, 0)
 
 
 class _CollectiveKernel(FallbackKernel):


### PR DESCRIPTION
As title.

Many changes adapted from https://github.com/pytorch/pytorch/pull/129537.

Also this diff is only for *static* method of torchbind *attributes*. Some case that's not supported/tested:
- dynamic torchbind objects
-  torchbind objects as an input to the module.

Note that in JIT Inductor, the attributes are lifted as inputs. So even if we just have torchbind objects as attributes, they will show up as inputs in the graph.

Example generated python code in torch.compile with inductor backend for the test case in `inductor/test_torchbind.py` (P1730554370):

```python
async_compile.wait(globals())
del async_compile

def call(args):
    arg1_1, arg2_1, arg3_1 = args
    args.clear()
    assert_size_stride(arg1_1, (2, 3), (3, 1))
    assert_size_stride(arg2_1, (2, 3), (3, 1))
    buf2 = empty_strided_cpu((2, 3), (3, 1), torch.float32)
    cpp_fused_add_0(arg1_1, arg2_1, buf2)
    del arg1_1
    del arg2_1
    # Topologically Sorted Source Nodes: [x, takes_foo_tuple_return], Original ATen: [aten.add]
    buf3 = torch.ops._TorchScriptTesting.takes_foo_tuple_return.default(arg3_1, buf2)
    buf4 = buf3[0]
    assert_size_stride(buf4, (2, 3), (3, 1))
    buf5 = buf3[1]
    assert_size_stride(buf5, (2, 3), (3, 1))
    buf6 = buf4; del buf4  # reuse
    cpp_fused_add_1(buf6, buf5)
    del buf5
    # Topologically Sorted Source Nodes: [y, b], Original ATen: [aten.add]
    buf7 = torch.ops._TorchScriptTesting.takes_foo.default(arg3_1, buf6)
    del buf3
    del buf6
    buf8 = buf7
    assert_size_stride(buf8, (2, 3), (3, 1))
    # Topologically Sorted Source Nodes: [c], Original ATen: []
    buf9 = torch.ops.higher_order.call_torchbind(arg3_1, 'add_tensor', buf2)
    del arg3_1
    del buf7
    buf10 = buf9
    assert_size_stride(buf10, (2, 3), (3, 1))
    del buf9
    buf11 = buf2; del buf2  # reuse
    cpp_fused_add_2(buf11, buf8, buf10)
    return (buf11, )


def benchmark_compiled_module(times=10, repeat=10):
    from torch._dynamo.testing import rand_strided
    from torch._inductor.utils import print_performance
    arg1_1 = rand_strided((2, 3), (3, 1), device='cpu', dtype=torch.float32)
    arg2_1 = rand_strided((2, 3), (3, 1), device='cpu', dtype=torch.float32)
    import pickle
    global arg3_1
    arg3_1 = pickle.loads(b'\x80\x04\x95[\x00\x00\x00\x00\x00\x00\x00\x8c\x05torch\x94\x8c\x0cScriptObject\x94\x93\x94)\x81\x94]\x94(K\nK\x14e\x8c0__torch__.torch.classes._TorchScriptTesting._Foo\x94\x86\x94b.')
    fn = lambda: call([arg1_1, arg2_1, arg3_1])
    return print_performance(fn, times=times, repeat=repeat)


if __name__ == "__main__":
    from torch._inductor.wrapper_benchmark import compiled_module_main
    compiled_module_main('None', benchmark_compiled_module)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov