### PR TITLE
Support QNX SDP 8.0 in Pytorch Mobile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -714,7 +714,7 @@ endif()
 # Build libtorch mobile library, which contains ATen/TH ops and native support
 # for TorchScript model, but doesn't contain not-yet-unified caffe2 ops;
 if(INTERN_BUILD_MOBILE)
-    if(NOT BUILD_SHARED_LIBS AND NOT "${SELECTED_OP_LIST}" STREQUAL "")
+  if(NOT BUILD_SHARED_LIBS AND NOT "${SELECTED_OP_LIST}" STREQUAL "")
     string(APPEND CMAKE_CXX_FLAGS " -DNO_EXPORT")
   endif()
   if(BUILD_MOBILE_AUTOGRAD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -714,7 +714,7 @@ endif()
 # Build libtorch mobile library, which contains ATen/TH ops and native support
 # for TorchScript model, but doesn't contain not-yet-unified caffe2 ops;
 if(INTERN_BUILD_MOBILE)
-  if(NOT BUILD_SHARED_LIBS AND NOT "${SELECTED_OP_LIST}" STREQUAL "")
+    if(NOT BUILD_SHARED_LIBS AND NOT "${SELECTED_OP_LIST}" STREQUAL "")
     string(APPEND CMAKE_CXX_FLAGS " -DNO_EXPORT")
   endif()
   if(BUILD_MOBILE_AUTOGRAD)
@@ -1224,7 +1224,7 @@ if(ANDROID AND (NOT ANDROID_DEBUG_SYMBOLS))
   endif()
 endif()
 
-if(NOT APPLE AND UNIX)
+if(NOT APPLE AND NOT QNX AND UNIX)
   list(APPEND Caffe2_DEPENDENCY_LIBS dl)
 endif()
 

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -462,7 +462,7 @@ if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(s390x|ppc64le)$")
   list(APPEND ATen_CPU_DEPENDENCY_LIBS cpuinfo)
 endif()
 
-if(NOT EMSCRIPTEN AND NOT INTERN_BUILD_MOBILE)
+if(NOT EMSCRIPTEN)
   if(NOT MSVC)
     # Bump up optimization level for sleef to -O1, since at -O0 the compiler
     # excessively spills intermediate vector registers to the stack

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/CMakeLists.txt
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/CMakeLists.txt
@@ -26,7 +26,7 @@ IF(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_OSX_ARCHITECTURES MATCHES "^(x8
   SET(PYTORCH_QNNPACK_TARGET_PROCESSOR "${CMAKE_OSX_ARCHITECTURES}")
 ENDIF()
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "QCC")
   # TODO: See https://github.com/pytorch/pytorch/issues/56285
   set_source_files_properties(src/operator-run.c PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
   set_source_files_properties(src/conv-run.cc PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
@@ -60,7 +60,7 @@ endif()
 
 if(NOT CMAKE_SYSTEM_NAME)
   message(FATAL_ERROR "CMAKE_SYSTEM_NAME not defined")
-elseif(NOT CMAKE_SYSTEM_NAME MATCHES "^(Darwin|Linux|Android)$")
+elseif(NOT CMAKE_SYSTEM_NAME MATCHES "^(Darwin|Linux|Android|QNX)$")
   message(FATAL_ERROR "Unrecognized CMAKE_SYSTEM_NAME = ${CMAKE_SYSTEM_NAME}")
 endif()
 

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/math.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/math.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <stddef.h>
-#ifdef _MSC_VER
+#if defined _MSC_VER || defined __QNX__
 #undef min
 #undef max
 #endif

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -76,7 +76,7 @@ class C10_API Scalar {
       "int64_t is the same as long long on Windows");
   Scalar(long vv) : Scalar(vv, true) {}
 #endif
-#if defined(__linux__) && !defined(__ANDROID__)
+#if defined(__linux__) && !defined(__ANDROID__) || defined(__QNX__)
   static_assert(
       sizeof(void*) != 8 || std::is_same_v<long, int64_t>,
       "int64_t is the same as long on 64 bit Linux");

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -409,6 +409,18 @@ __host__ __device__
 #define CUDA_KERNEL_ASSERT_MSG(cond, msg)
 #define SYCL_KERNEL_ASSERT(cond)
 #else
+#if defined(__QNX__)
+#define CUDA_KERNEL_ASSERT(cond)                                         \
+  if (C10_UNLIKELY(!(cond))) {                                           \
+    __assert(                                                            \
+        #cond, __FILE__, static_cast<unsigned int>(__LINE__), __func__); \
+  }
+#define SYCL_KERNEL_ASSERT(cond)                                         \
+  if (C10_UNLIKELY(!(cond))) {                                           \
+    __assert(                                                            \
+        #cond, __FILE__, static_cast<unsigned int>(__LINE__), __func__); \
+  }
+#else
 #define CUDA_KERNEL_ASSERT(cond)                                         \
   if (C10_UNLIKELY(!(cond))) {                                           \
     __assert_fail(                                                       \
@@ -424,6 +436,7 @@ __host__ __device__
     __assert_fail(                                                       \
         #cond, __FILE__, static_cast<unsigned int>(__LINE__), __func__); \
   }
+#endif // __QNX__
 #endif //  C10_USE_ROCM_KERNEL_ASSERT and USE_ROCM
 #endif // __APPLE__
 

--- a/c10/test/util/exception_test.cpp
+++ b/c10/test/util/exception_test.cpp
@@ -36,8 +36,14 @@ TEST(ExceptionTest, TORCH_INTERNAL_ASSERT_DEBUG_ONLY) {
 // On these platforms there's no assert
 #if !defined(__ANDROID__) && !defined(__APPLE__)
 TEST(ExceptionTest, CUDA_KERNEL_ASSERT) {
+  // On this platform there is no __assert_fail
+#if defined(__QNX__)
+  // This function always throws even in NDEBUG mode
+  ASSERT_DEATH_IF_SUPPORTED({ CUDA_KERNEL_ASSERT(false); }, "");
+#else
   // This function always throws even in NDEBUG mode
   ASSERT_DEATH_IF_SUPPORTED({ CUDA_KERNEL_ASSERT(false); }, "Assert");
+#endif
 }
 #endif
 

--- a/c10/util/BFloat16-inl.h
+++ b/c10/util/BFloat16-inl.h
@@ -337,6 +337,13 @@ class numeric_limits<c10::BFloat16> {
     return c10::BFloat16(0x0001, c10::BFloat16::from_bits());
   }
 };
+ 
+#if defined(__QNX__)
+  inline bool isnan(c10::BFloat16& val)
+  {
+    return std::isnan(static_cast<float>(val));
+  }
+#endif
 
 } // namespace std
 

--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -344,6 +344,13 @@ class numeric_limits<c10::Half> {
     return c10::Half(0x0001, c10::Half::from_bits());
   }
 };
+ 
+#if defined(__QNX__)
+  inline bool isnan(c10::Half& val)
+  {
+    return std::isnan(static_cast<float>(val));
+  }
+#endif
 
 } // namespace std
 

--- a/c10/util/complex.h
+++ b/c10/util/complex.h
@@ -252,7 +252,7 @@ struct alignas(sizeof(T) * 2) complex {
     U c = rhs.real();
     U d = rhs.imag();
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__QNX__)
     // std::abs is already constexpr by gcc
     auto abs_c = std::abs(c);
     auto abs_d = std::abs(d);

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1503,6 +1503,10 @@ if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_options(torch_cpu PRIVATE "-DONNX_BUILD_MAIN_LIB")
 endif()
 
+if(QNX)
+  target_compile_options(torch_cpu PRIVATE "-Wno-error=nonnull")
+endif()
+
 caffe2_interface_library(torch_cpu torch_cpu_library)
 
 if(USE_CUDA)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -317,10 +317,10 @@ if(USE_NNPACK OR USE_PYTORCH_QNNPACK OR USE_XNNPACK)
       set(DISABLE_NNPACK_AND_FAMILY ON)
     endif()
   else()
-    if(NOT IOS AND NOT (CMAKE_SYSTEM_NAME MATCHES "^(Android|Linux|Darwin|Windows)$"))
+    if(NOT IOS AND NOT (CMAKE_SYSTEM_NAME MATCHES "^(Android|Linux|Darwin|Windows|QNX)$"))
       message(WARNING
         "Target platform \"${CMAKE_SYSTEM_NAME}\" is not supported in {Q/X}NNPACK. "
-        "Supported platforms are Android, iOS, Linux, and macOS. "
+        "Supported platforms are Android, iOS, Linux, macOS, and QNX. "
         "Turn this warning off by USE_{Q/X}NNPACK=OFF.")
       set(DISABLE_NNPACK_AND_FAMILY ON)
     endif()

--- a/cmake/External/nnpack.cmake
+++ b/cmake/External/nnpack.cmake
@@ -40,7 +40,7 @@ endif()
 # (3) Android, iOS, Linux, macOS - supported
 ##############################################################################
 
-if(ANDROID OR IOS OR ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+if(ANDROID OR IOS OR ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" OR QNX)
   message(STATUS "Brace yourself, we are building NNPACK")
   set(CAFFE2_THIRD_PARTY_ROOT ${PROJECT_SOURCE_DIR}/third_party)
 

--- a/scripts/build_mobile_qnx_arm.sh
+++ b/scripts/build_mobile_qnx_arm.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+##############################################################################
+# Example command to build the mobile target.
+##############################################################################
+#
+# This script shows how one can build a libtorch library optimized for mobile
+# devices using host toolchain.
+
+set -e
+
+export BUILD_PYTORCH_MOBILE_WITH_HOST_TOOLCHAIN=1
+CAFFE2_ROOT="$( cd "$(dirname "$0")"/.. ; pwd -P)"
+
+if [ -z ${QNX_DIR+x} ]; then
+  QNX_DIR=$CAFFE2_ROOT
+fi
+
+if [ -z ${TEST+x} ]; then
+  TEST="OFF"
+fi
+
+echo "Bash: $(/bin/bash --version | head -1)"
+echo "Caffe2 path: $CAFFE2_ROOT"
+echo "Toolchain path: $QNX_DIR"
+
+CMAKE_ARGS=()
+CMAKE_ARGS+=("-DCMAKE_PREFIX_PATH=$(python -c 'import sysconfig; print(sysconfig.get_path("purelib"))')")
+CMAKE_ARGS+=("-DPYTHON_EXECUTABLE=$(python -c 'import sys; print(sys.executable)')")
+CMAKE_ARGS+=("-DBUILD_CUSTOM_PROTOBUF=OFF")
+#CMAKE_ARGS+=("-DBUILD_SHARED_LIBS=OFF")
+CMAKE_ARGS+=("-DBUILD_SHARED_LIBS=ON")
+
+# custom build with selected ops
+if [ -n "${SELECTED_OP_LIST}" ]; then
+  SELECTED_OP_LIST="$(cd $(dirname $SELECTED_OP_LIST); pwd -P)/$(basename $SELECTED_OP_LIST)"
+  echo "Choose SELECTED_OP_LIST file: $SELECTED_OP_LIST"
+  if [ ! -r ${SELECTED_OP_LIST} ]; then
+    echo "Error: SELECTED_OP_LIST file ${SELECTED_OP_LIST} not found."
+    exit 1
+  fi
+  CMAKE_ARGS+=("-DSELECTED_OP_LIST=${SELECTED_OP_LIST}")
+fi
+
+# If Ninja is installed, prefer it to Make
+if [ -x "$(command -v ninja)" ]; then
+  CMAKE_ARGS+=("-GNinja")
+fi
+
+# Don't build artifacts we don't need
+CMAKE_ARGS+=("-DBUILD_TEST=${TEST}")
+CMAKE_ARGS+=("-DINSTALL_TEST=OFF")
+CMAKE_ARGS+=("-DBUILD_BINARY=OFF")
+
+# If there exists env variable and it equals to 1, build lite interpreter.
+# Default behavior is to build full jit interpreter.
+# cmd:  BUILD_LITE_INTERPRETER=1 ./scripts/build_mobile.sh
+if [ "x${BUILD_LITE_INTERPRETER}" == "x1" ]; then
+  CMAKE_ARGS+=("-DBUILD_LITE_INTERPRETER=ON")
+else
+  CMAKE_ARGS+=("-DBUILD_LITE_INTERPRETER=OFF")
+fi
+if [ "x${TRACING_BASED}" == "x1" ]; then
+  CMAKE_ARGS+=("-DTRACING_BASED=ON")
+else
+  CMAKE_ARGS+=("-DTRACING_BASED=OFF")
+fi
+
+# Lightweight dispatch bypasses the PyTorch Dispatcher.
+if [ "${USE_LIGHTWEIGHT_DISPATCH}" == 1 ]; then
+  CMAKE_ARGS+=("-DUSE_LIGHTWEIGHT_DISPATCH=ON")
+  CMAKE_ARGS+=("-DSTATIC_DISPATCH_BACKEND=CPU")
+else
+  CMAKE_ARGS+=("-DUSE_LIGHTWEIGHT_DISPATCH=OFF")
+fi
+
+# Disable unused dependencies
+CMAKE_ARGS+=("-DUSE_ROCM=OFF")
+CMAKE_ARGS+=("-DUSE_CUDA=OFF")
+CMAKE_ARGS+=("-DUSE_ITT=OFF")
+CMAKE_ARGS+=("-DUSE_GFLAGS=OFF")
+CMAKE_ARGS+=("-DUSE_OPENCV=OFF")
+CMAKE_ARGS+=("-DUSE_LMDB=OFF")
+CMAKE_ARGS+=("-DUSE_LEVELDB=OFF")
+CMAKE_ARGS+=("-DUSE_MPI=OFF")
+CMAKE_ARGS+=("-DUSE_OPENMP=OFF")
+CMAKE_ARGS+=("-DUSE_MKLDNN=OFF")
+CMAKE_ARGS+=("-DUSE_NNPACK=OFF")
+CMAKE_ARGS+=("-DUSE_NUMPY=OFF")
+CMAKE_ARGS+=("-DUSE_BLAS=OFF")
+
+# Only toggle if VERBOSE=1
+if [ "${VERBOSE:-}" == '1' ]; then
+  CMAKE_ARGS+=("-DCMAKE_VERBOSE_MAKEFILE=1")
+fi
+
+# QNX config
+CMAKE_ARGS+=("-DXNNPACK_ENABLE_ASSEMBLY=OFF")
+
+CMAKE_ARGS+=("-DBUILD_QNX_ASM_FLAGS=-D_QNX_SOURCE -D__QNXNTO__")
+CMAKE_ARGS+=("-DBUILD_QNX_C_FLAGS=-D_QNX_SOURCE -D__QNXNTO__")
+CMAKE_ARGS+=("-DBUILD_QNX_CXX_FLAGS=-D_QNX_SOURCE -D__QNXNTO__")
+CMAKE_ARGS+=("-DBUILD_QNX_LINKER_FLAGS=-Wl,--build-id=md5")
+CMAKE_ARGS+=("-DCMAKE_TOOLCHAIN_FILE=$QNX_DIR/qnx.nto.toolchain.cmake")
+CMAKE_ARGS+=("-DCMAKE_SYSTEM_PROCESSOR=aarch64")
+CMAKE_ARGS+=("-DCMAKE_ASM_COMPILER_TARGET=gcc_ntoaarch64le")
+CMAKE_ARGS+=("-DCMAKE_C_COMPILER_TARGET=gcc_ntoaarch64le")
+CMAKE_ARGS+=("-DCMAKE_CXX_COMPILER_TARGET=gcc_ntoaarch64le")
+CMAKE_ARGS+=("-DCAFFE2_CUSTOM_PROTOC_EXECUTABLE=$QNX_DIR/host/protobuf/install/bin/protoc")
+CMAKE_ARGS+=("-DNATIVE_BUILD_DIR=$QNX_DIR/host/sleef")
+
+# User-specified CMake arguments go last to allow overridding defaults
+CMAKE_ARGS+=("$@")
+
+# Now, actually build the Android target.
+BUILD_ROOT=${BUILD_ROOT:-"$CAFFE2_ROOT/build_mobile"}
+INSTALL_PREFIX=${BUILD_ROOT}/install
+mkdir -p $BUILD_ROOT
+
+echo "${CMAKE_ARGS[@]}"
+
+cd $BUILD_ROOT
+cmake "$CAFFE2_ROOT" \
+    -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX \
+    -DCMAKE_BUILD_TYPE=Release \
+    "${CMAKE_ARGS[@]}" \
+
+# Cross-platform parallel build
+if [ -z "$MAX_JOBS" ]; then
+  if [ "$(uname)" == 'Darwin' ]; then
+    MAX_JOBS=$(sysctl -n hw.ncpu)
+  else
+    MAX_JOBS=$(nproc)
+  fi
+fi
+
+echo "Will install headers and libs to $INSTALL_PREFIX for further project usage."
+cmake --build . --target install "-j${MAX_JOBS}" 2>> log.txt
+echo "Installation completed, now you can copy the headers/libs from $INSTALL_PREFIX to your project directory."

--- a/test/cpp/lite_interpreter_runtime/CMakeLists.txt
+++ b/test/cpp/lite_interpreter_runtime/CMakeLists.txt
@@ -7,10 +7,16 @@ set(LITE_INTERPRETER_RUNTIME_TEST_DIR
   ${TORCH_ROOT}/test/cpp/lite_interpreter_runtime/test_mobile_profiler.cpp
 )
 
+if(QNX)
+add_library(backend_with_compiler_runtime SHARED
+        ${TORCH_ROOT}/test/cpp/jit/test_backend_compiler_lib.cpp
+        )
+else()
 add_library(backend_with_compiler_runtime SHARED
         ${TORCH_ROOT}/test/cpp/jit/test_backend_compiler_lib.cpp
         ${TORCH_ROOT}/torch/csrc/jit/backends/backend_interface.cpp
         )
+endif()
 target_link_libraries(backend_with_compiler_runtime PRIVATE torch)
 
 add_executable(

--- a/test/cpp/lite_interpreter_runtime/test_lite_interpreter_runtime.cpp
+++ b/test/cpp/lite_interpreter_runtime/test_lite_interpreter_runtime.cpp
@@ -16,9 +16,14 @@ namespace mobile {
 
 TEST(RunTimeTest, LoadAndForward) {
   // Load check in model: sequence.ptl
+#if defined(__QNX__)
+  // Don't compile an absolute path when building for a target.
+  auto testModelFile = "sequence.ptl";
+#else
   std::string filePath(__FILE__);
   auto testModelFile = filePath.substr(0, filePath.find_last_of("/\\") + 1);
   testModelFile.append("sequence.ptl");
+#endif
 
   //  sequence.ptl source code:
   //  class A(torch.nn.Module):
@@ -53,6 +58,10 @@ TEST(RunTimeTest, LoadAndForward) {
 }
 
 TEST(RunTimeTest, Delegate) {
+#if defined(__QNX__)
+  // Don't compile an absolute path when building for a target.
+  auto testModelFile = "delegate_test.ptl";
+#else
   std::string filePath(__FILE__);
   auto testModelFile = filePath.substr(0, filePath.find_last_of("/\\") + 1);
   // "delegate_test.ptl" is generated from test/cpp/jit/test_backend.cpp,
@@ -66,6 +75,7 @@ TEST(RunTimeTest, Delegate) {
   //        return x + h
   //  )");
   testModelFile.append("delegate_test.ptl");
+#endif
   auto mlm = _load_for_mobile(testModelFile);
   std::vector<IValue> inputs;
   inputs.emplace_back(2.0 * at::ones({}));
@@ -76,6 +86,10 @@ TEST(RunTimeTest, Delegate) {
 }
 
 TEST(RunTimeTest, DelegateException) {
+#if defined(__QNX__)
+  // Don't compile an absolute path when building for a target.
+  auto testModelFile = "delegated_submodule_with_debug_info.ptl";
+#else
   std::string filePath(__FILE__);
   auto testModelFile = filePath.substr(0, filePath.find_last_of("/\\") + 1);
   /*
@@ -138,6 +152,7 @@ TEST(RunTimeTest, DelegateException) {
    *
    */
   testModelFile.append("delegated_submodule_with_debug_info.ptl");
+#endif
   auto mlm = _load_for_mobile(testModelFile);
   std::vector<IValue> inputs;
   inputs.emplace_back(torch::rand({2, 4}));

--- a/test/cpp/lite_interpreter_runtime/test_mobile_profiler.cpp
+++ b/test/cpp/lite_interpreter_runtime/test_mobile_profiler.cpp
@@ -45,15 +45,24 @@ bool checkMetaData(
 } // namespace
 
 TEST(MobileProfiler, ModuleHierarchy) {
+#if defined(__QNX__)
+  // Don't compile an absolute path when building for a target.
+  auto testModelFile = "to_be_profiled_module.ptl";
+#else
   auto testModelFile = torch::testing::getResourcePath(
       "test/cpp/lite_interpreter_runtime/to_be_profiled_module.ptl");
+#endif
 
   std::vector<IValue> inputs;
   inputs.emplace_back(at::rand({64, 64}));
   inputs.emplace_back(at::rand({64, 64}));
   std::string trace_file_name("/tmp/test_trace.trace");
 
+#if defined(__QNX__)
+  mobile::Module bc = _load_for_mobile(testModelFile);
+#else
   mobile::Module bc = _load_for_mobile(testModelFile.string());
+#endif
   {
     KinetoEdgeCPUProfiler profiler(
         bc,
@@ -99,15 +108,24 @@ TEST(MobileProfiler, ModuleHierarchy) {
 }
 
 TEST(MobileProfiler, Backend) {
+#if defined(__QNX__)
+  // Don't compile an absolute path when building for a target.
+  auto testModelFile = "test_backend_for_profiling.ptl";
+#else
   auto testModelFile = torch::testing::getResourcePath(
       "test/cpp/lite_interpreter_runtime/test_backend_for_profiling.ptl");
+#endif
 
   std::vector<IValue> inputs;
   inputs.emplace_back(at::rand({64, 64}));
   inputs.emplace_back(at::rand({64, 64}));
   std::string trace_file_name("/tmp/test_trace_backend.trace");
 
+#if defined(__QNX__)
+  mobile::Module bc = _load_for_mobile(testModelFile);
+#else
   mobile::Module bc = _load_for_mobile(testModelFile.string());
+#endif
   {
     KinetoEdgeCPUProfiler profiler(
         bc,
@@ -133,15 +151,24 @@ TEST(MobileProfiler, Backend) {
 }
 
 TEST(MobileProfiler, BackendMemoryEvents) {
+#if defined(__QNX__)
+  // Don't compile an absolute path when building for a target.
+  auto testModelFile = "test_backend_for_profiling.ptl";
+#else
   auto testModelFile = torch::testing::getResourcePath(
       "test/cpp/lite_interpreter_runtime/test_backend_for_profiling.ptl");
+#endif
 
   std::vector<IValue> inputs;
   inputs.emplace_back(at::rand({64, 64}));
   inputs.emplace_back(at::rand({64, 64}));
   std::string trace_file_name("/tmp/test_trace_backend_memory.trace");
 
+#if defined(__QNX__)
+  mobile::Module bc = _load_for_mobile(testModelFile);
+#else
   mobile::Module bc = _load_for_mobile(testModelFile.string());
+#endif
   {
     mobile::KinetoEdgeCPUProfiler profiler(
         bc,
@@ -165,8 +192,13 @@ TEST(MobileProfiler, BackendMemoryEvents) {
 }
 
 TEST(MobileProfiler, ProfilerEvent) {
+#if defined(__QNX__)
+  // Don't compile an absolute path when building for a target.
+  auto testModelFile = "test_backend_for_profiling.ptl";
+#else
   auto testModelFile = torch::testing::getResourcePath(
       "test/cpp/lite_interpreter_runtime/test_backend_for_profiling.ptl");
+#endif
 
   std::vector<IValue> inputs;
   inputs.emplace_back(at::rand({64, 64}));
@@ -177,7 +209,11 @@ TEST(MobileProfiler, ProfilerEvent) {
       torch::profiler::ProfilerPerfEvents.begin(),
       torch::profiler::ProfilerPerfEvents.end());
 
+#if defined(__QNX__)
+  mobile::Module bc = _load_for_mobile(testModelFile);
+#else
   mobile::Module bc = _load_for_mobile(testModelFile.string());
+#endif
   {
     // Bail if something goes wrong here
     try {

--- a/test/edge/CMakeLists.txt
+++ b/test/edge/CMakeLists.txt
@@ -67,7 +67,7 @@ if((CMAKE_CXX_COMPILER_ID MATCHES "AppleClang") OR (APPLE AND CMAKE_CXX_COMPILER
   target_link_options(test_edge_op_registration PRIVATE
           "-Wl,-force_load,$<TARGET_FILE:unbox_lib>"
           )
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU|QCC")
   target_link_options(test_edge_op_registration PRIVATE
           "-Wl,--whole-archive,$<TARGET_FILE:unbox_lib>,--no-whole-archive"
           )

--- a/test/mobile/lightweight_dispatch/CMakeLists.txt
+++ b/test/mobile/lightweight_dispatch/CMakeLists.txt
@@ -8,7 +8,11 @@ add_executable(test_codegen_unboxing
   ${TEST_ROOT}/test_codegen_unboxing.cpp
 )
 
-target_include_directories(test_codegen_unboxing PRIVATE ${ATen_CPU_INCLUDE})
+if(QNX)
+  target_include_directories(test_codegen_unboxing PRIVATE ${ATen_CPU_INCLUDE} ${TORCH_ROOT}/torch/csrc/api/include)
+else()
+  target_include_directories(test_codegen_unboxing PRIVATE ${ATen_CPU_INCLUDE})
+endif()
 
 target_compile_definitions(test_codegen_unboxing PRIVATE USE_GTEST)
 

--- a/tools/setup_helpers/env.py
+++ b/tools/setup_helpers/env.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 IS_WINDOWS = platform.system() == "Windows"
 IS_DARWIN = platform.system() == "Darwin"
 IS_LINUX = platform.system() == "Linux"
+IS_QNX_TARGET = "QNX_TARGET" in os.environ
 
 IS_CONDA = (
     "conda" in sys.version

--- a/torch/csrc/utils/byte_order.h
+++ b/torch/csrc/utils/byte_order.h
@@ -21,6 +21,10 @@
 #define thp_bswap16(x) OSSwapInt16(x)
 #define thp_bswap32(x) OSSwapInt32(x)
 #define thp_bswap64(x) OSSwapInt64(x)
+#elif defined (__QNX__)
+#define thp_bswap16(x) ENDIAN_SWAP16(x)
+#define thp_bswap32(x) ENDIAN_SWAP32(x)
+#define thp_bswap64(x) ENDIAN_SWAP64(x)
 #elif defined(__GNUC__) && !defined(__MINGW32__)
 #include <byteswap.h>
 #define thp_bswap16(x) bswap_16(x)


### PR DESCRIPTION
See https://github.com/qnx-ports/build-files/tree/pytorch_qnx_main for build instructions.
Changes to third_party subprojects are administered by patches in the build repo while we work on getting them upstreamed. Once they are I'll submit another PR to update the refs so that this can go in without extra complications.
Currently XNNPACK requires a one-line change to get it to build (cmake/Dependencies.cmake does not list it as supported with QNX, which is true at the moment, but we still need to allow it for the build to pass).

Test results:
[pyt_results.txt](https://github.com/user-attachments/files/18757964/pyt_results.txt)
One abort in TypeMetaTest.CtorDtorAndCopy

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168