### PR TITLE
[oncall] Change error message to be more readable

### DIFF
--- a/torch/fx/passes/split_utils.py
+++ b/torch/fx/passes/split_utils.py
@@ -201,8 +201,7 @@ def split_by_tags(
         # Expect the component for `node` has higher order then its upstream components.
         assert (
             comp.order >= mx
-        ), f"Expected order: {comp.order} for the component: {comp.name} to be >= {mx}, the max order for all its "
-        "upstream components."
+        ), f"Component {comp.name} order must be >= max of its upstream components, order={comp.order} and max={mx}"
 
         # Map a input of `node` to nodes in the component's graph.
         def remap_func(x):


### PR DESCRIPTION
Summary:
During oncall, got a debug, where the error message is a bit ambiguous, due to multiple colons, and full line cutoff
```
AssertionError: Expected order: 1 for the component: remote_request_only to be >= 2, the max order for all its
```

Update the error message to something like
```
AssertionError: Component remote_request_only order must be >= max order of its upstream components, got component order=1 and max=2
```

Test Plan: CI

Differential Revision: D69482789




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv