### PR TITLE
Yguo/repro segfault triton aoti cpp wrapper

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -91,6 +91,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         triton_meta=None,
         autotune_configs=None,
         grid_extra_kwargs="",
+        signature=None,
     ):
         """
         Generates kernel call code.

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -534,7 +534,6 @@ class CppWrapperGpu(CppWrapperCpu):
                 triton_meta,
                 autotune_configs,
                 grid_extra_kwargs,
-                signature,
             )
 
         if device_index is None:

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -20,6 +20,7 @@ from .aoti_hipify_utils import maybe_hipify_code_wrapper
 from .common import get_device_op_overrides
 from .cpp_utils import cexpr
 from .cpp_wrapper_cpu import CppWrapperCpu
+from .triton_utils import equal_1_arg_indices
 from .multi_kernel import MultiKernelCall
 from .wrapper import PythonWrapperCodegen, SymbolicCallArg
 
@@ -488,6 +489,7 @@ class CppWrapperGpu(CppWrapperCpu):
         triton_meta=None,
         autotune_configs=None,
         grid_extra_kwargs="",
+        signature=None,
     ):
         """
         Override the default value of argument 'gpu' to True here.
@@ -532,6 +534,7 @@ class CppWrapperGpu(CppWrapperCpu):
                 triton_meta,
                 autotune_configs,
                 grid_extra_kwargs,
+                signature,
             )
 
         if device_index is None:
@@ -558,8 +561,10 @@ class CppWrapperGpu(CppWrapperCpu):
                 triton_meta is not None
                 and triton_meta.get("configs")
                 and triton_meta.get("signature")
-            ):
-                equal_to_1 = triton_meta["configs"][0].equal_to_1
+            ):  
+                # breakpoint()
+                # equal_to_1 = triton_meta["configs"][0].equal_to_1
+                equal_to_1 = equal_1_arg_indices(signature)
                 call_args = [
                     arg for i, arg in enumerate(call_args) if i not in equal_to_1
                 ]

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3556,6 +3556,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         if config.benchmark_kernel:
             code.splice(self.codegen_kernel_benchmark(num_gb))
+        
+        self.signature = signature
 
         return code.getvalue()
 
@@ -3665,6 +3667,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             arg_types=arg_types,
             grid_fn=self._get_grid_fn_str(),
             triton_meta=self.triton_meta,
+            signature=self.signature,
         )
 
         for ws in reversed(self.args.workspace_args):

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -161,9 +161,9 @@ def equal_1_arg_indices(
     indices: Optional[list[int]] = None,
 ) -> tuple[int, ...]:
     if indices is None:
-        indices = list(range(len(args)))
+        indices = list(range(len(args) if args is not None else 0))
 
-    equal_to_1 = tuple(i for i, arg in zip(indices, args) if _arg_equals_1(arg))
+    equal_to_1 = tuple(i for i, arg in zip(indices, args or []) if _arg_equals_1(arg))
 
     return equal_to_1
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2048,6 +2048,7 @@ class PythonWrapperCodegen(CodeGen):
         triton_meta=None,
         autotune_configs=None,
         grid_extra_kwargs="",
+        signature=None,
     ):
         """
         Generates kernel call code.

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2048,7 +2048,6 @@ class PythonWrapperCodegen(CodeGen):
         triton_meta=None,
         autotune_configs=None,
         grid_extra_kwargs="",
-        signature=None,
     ):
         """
         Generates kernel call code.


### PR DESCRIPTION
TEST PLAN:

```
TORCH_LOGS="output_code" CPLUS_INCLUDE_PATH=/usr/local/cuda-12.0/include:$CPLUS_INCLUDE_PATH python test/inductor/test_aot_inductor.py -k test_addmm_cuda
```
output paste: [P1730560592](https://www.internalfb.com/phabricator/paste/view/P1730560592)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov