### PR TITLE
Update octokit/request-action to 2.4.0

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -16,7 +16,8 @@ jobs:
       conclusion: ${{ fromJson(steps.get_conclusion.outputs.data).conclusion }}
     steps:
       - name: Get workflow run conclusion
-        uses: octokit/request-action@v2.4.0
+        # TODO (huydhn): Pin this once https://github.com/octokit/request-action/issues/315 is resolved
+        uses: octokit/request-action@main
         id: get_conclusion
         with:
           route: GET /repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/attempts/${{ github.event.workflow_run.run_attempt }}

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -16,7 +16,7 @@ jobs:
       conclusion: ${{ fromJson(steps.get_conclusion.outputs.data).conclusion }}
     steps:
       - name: Get workflow run conclusion
-        uses: octokit/request-action@v2.1.0
+        uses: octokit/request-action@v2.4.0
         id: get_conclusion
         with:
           route: GET /repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/attempts/${{ github.event.workflow_run.run_attempt }}

--- a/.github/workflows/upload-torch-dynamo-perf-stats.yml
+++ b/.github/workflows/upload-torch-dynamo-perf-stats.yml
@@ -13,7 +13,7 @@ jobs:
       conclusion: ${{ fromJson(steps.get-conclusion.outputs.data).conclusion }}
     steps:
       - name: Get workflow run conclusion
-        uses: octokit/request-action@v2.1.0
+        uses: octokit/request-action@v2.4.0
         id: get-conclusion
         with:
           route: GET /repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/attempts/${{ github.event.workflow_run.run_attempt }}

--- a/.github/workflows/upload-torch-dynamo-perf-stats.yml
+++ b/.github/workflows/upload-torch-dynamo-perf-stats.yml
@@ -13,7 +13,8 @@ jobs:
       conclusion: ${{ fromJson(steps.get-conclusion.outputs.data).conclusion }}
     steps:
       - name: Get workflow run conclusion
-        uses: octokit/request-action@v2.4.0
+        # TODO (huydhn): Pin this once https://github.com/octokit/request-action/issues/315 is resolved
+        uses: octokit/request-action@main
         id: get-conclusion
         with:
           route: GET /repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/attempts/${{ github.event.workflow_run.run_attempt }}


### PR DESCRIPTION
The current version 2.1.0 has disappeared since yesterday:

* https://github.com/pytorch/pytorch/actions/workflows/upload-torch-dynamo-perf-stats.yml
* https://github.com/pytorch/pytorch/actions/workflows/upload-test-stats.yml

The latest version is 2.4.0 https://github.com/octokit/request-action