### PR TITLE
Fix function name in doc string

### DIFF
--- a/torch/distributed/elastic/multiprocessing/errors/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/errors/__init__.py
@@ -54,7 +54,6 @@ import os
 import signal
 import socket
 import time
-import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
 from functools import wraps

--- a/torch/distributed/elastic/multiprocessing/errors/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/errors/__init__.py
@@ -325,7 +325,7 @@ def record(
         error_handler.dump_error_file(failure.error_file, failure.exitcode)
         raise
      except Exception as e:
-        error_handler.record(e)
+        error_handler.record_exception(e)
         raise
 
     .. important:: use this decorator once per process at the top level method,


### PR DESCRIPTION
The correct function is `record_exception`, not `record`

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o