### PR TITLE
[BE] Unify kernel templates instantiation

### DIFF
--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -58,29 +58,13 @@ kernel void copysign_integral(
   *out = copysign(static_cast<float>(*input), static_cast<float>(*other));
 }
 
-#define REGISTER_FMAX_OP(DTYPE)                                   \
-  template [[host_name("fmax_" #DTYPE)]] kernel void fmax<DTYPE>( \
-      constant void* input_ [[buffer(0)]],                        \
-      constant void* other_ [[buffer(1)]],                        \
-      device void* out_ [[buffer(2)]],                            \
-      constant uint3* offsets [[buffer(3)]],                      \
-      uint tid [[thread_position_in_grid]]);
-
-#define REGISTER_FMIN_OP(DTYPE)                                   \
-  template [[host_name("fmin_" #DTYPE)]] kernel void fmin<DTYPE>( \
-      constant void* input_ [[buffer(0)]],                        \
-      constant void* other_ [[buffer(1)]],                        \
-      device void* out_ [[buffer(2)]],                            \
-      constant uint3* offsets [[buffer(3)]],                      \
-      uint tid [[thread_position_in_grid]]);
-
-#define REGISTER_COPYSIGN_OP(DTYPE)                                       \
-  template [[host_name("copysign_" #DTYPE)]] kernel void copysign<DTYPE>( \
-      constant void* input_ [[buffer(0)]],                                \
-      constant void* other_ [[buffer(1)]],                                \
-      device void* out_ [[buffer(2)]],                                    \
-      constant uint3* offsets [[buffer(3)]],                              \
-      uint tid [[thread_position_in_grid]]);
+#define REGISTER_BINARY_OP(NAME, DTYPE)                             \
+  template [[host_name(#NAME "_" #DTYPE)]] kernel void NAME<DTYPE>( \
+      constant void* input_,                                        \
+      constant void* other_,                                        \
+      device void* out_,                                            \
+      constant uint3* offsets,                                      \
+      uint tid)
 
 #define REGISTER_COPYSIGN_INTEGRAL_OP(DTYPE)             \
   template [[host_name("copysign_" #DTYPE)]] kernel void \
@@ -91,16 +75,16 @@ kernel void copysign_integral(
       constant uint3* offsets [[buffer(3)]],             \
       uint tid [[thread_position_in_grid]]);
 
-REGISTER_FMAX_OP(float);
-REGISTER_FMAX_OP(half);
-REGISTER_FMIN_OP(float);
-REGISTER_FMIN_OP(half);
-REGISTER_COPYSIGN_OP(float);
-REGISTER_COPYSIGN_OP(half);
+REGISTER_BINARY_OP(fmax, float);
+REGISTER_BINARY_OP(fmax, half);
+REGISTER_BINARY_OP(fmin, float);
+REGISTER_BINARY_OP(fmin, half);
+REGISTER_BINARY_OP(copysign, float);
+REGISTER_BINARY_OP(copysign, half);
 #if __METAL_VERSION__ >= 310
-REGISTER_FMAX_OP(bfloat);
-REGISTER_FMIN_OP(bfloat);
-REGISTER_COPYSIGN_OP(bfloat);
+REGISTER_BINARY_OP(fmax, bfloat);
+REGISTER_BINARY_OP(fmin, bfloat);
+REGISTER_BINARY_OP(copysign, bfloat);
 #endif
 REGISTER_COPYSIGN_INTEGRAL_OP(int);
 REGISTER_COPYSIGN_INTEGRAL_OP(long);
@@ -123,16 +107,8 @@ kernel void polar(
   out[1] = abs[0] * sin(angle[0]);
 }
 
-#define REGISTER_POLAR_OP(DTYPE)                                    \
-  template [[host_name("polar_" #DTYPE)]] kernel void polar<DTYPE>( \
-      constant void* abs,                                           \
-      constant void* angle,                                         \
-      device void* out,                                             \
-      constant uint3* offsets,                                      \
-      uint tid)
-
-REGISTER_POLAR_OP(float);
-REGISTER_POLAR_OP(half);
+REGISTER_BINARY_OP(polar, float);
+REGISTER_BINARY_OP(polar, half);
 
 template <typename T>
 kernel void complex_mul(
@@ -157,8 +133,8 @@ kernel void complex_mul(
       constant uint3* offsets,                              \
       uint tid)
 
-REGISTER_COMPLEX_MUL_OP(float);
-REGISTER_COMPLEX_MUL_OP(half);
+REGISTER_BINARY_OP(complex_mul, float);
+REGISTER_BINARY_OP(complex_mul, half);
 
 template <typename T, typename U>
 kernel void nextafter_kernel(
@@ -217,17 +193,8 @@ kernel void complex_kernel(
   out[1] = imag[0];
 }
 
-#define REGISTER_COMPLEX_OUT_OP(DTYPE)                         \
-  template [[host_name("complex_kernel_" #DTYPE)]] kernel void \
-  complex_kernel<DTYPE>(                                       \
-      constant void* real,                                     \
-      constant void* imag,                                     \
-      device void* out,                                        \
-      constant uint3* offsets,                                 \
-      uint tid)
-
-REGISTER_COMPLEX_OUT_OP(float);
-REGISTER_COMPLEX_OUT_OP(half);
+REGISTER_BINARY_OP(complex_kernel, float);
+REGISTER_BINARY_OP(complex_kernel, half);
 
 template <typename T>
 kernel void zeta(
@@ -243,13 +210,8 @@ kernel void zeta(
   *out = static_cast<T>(c10::metal::zeta(*input, *other));
 }
 
-#define REGISTER_ZETA_OP(DTYPE)                                   \
-  template [[host_name("zeta_" #DTYPE)]] kernel void zeta<DTYPE>( \
-      constant void* input_ [[buffer(0)]],                        \
-      constant void* other_ [[buffer(1)]],                        \
-      device void* out_ [[buffer(2)]],                            \
-      constant uint3* offsets [[buffer(3)]],                      \
-      uint tid [[thread_position_in_grid]]);
-
-REGISTER_ZETA_OP(float);
-REGISTER_ZETA_OP(half);
+REGISTER_BINARY_OP(zeta, float);
+REGISTER_BINARY_OP(zeta, half);
+#if __METAL_VERSION__ >= 310
+REGISTER_BINARY_OP(zeta, bfloat);
+#endif

--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -124,15 +124,6 @@ kernel void complex_mul(
   out[1] = input[0] * other[1] + input[1] * other[0];
 }
 
-#define REGISTER_COMPLEX_MUL_OP(DTYPE)                      \
-  template [[host_name("complex_mul_" #DTYPE)]] kernel void \
-  complex_mul<DTYPE>(                                       \
-      constant void* input,                                 \
-      constant void* other,                                 \
-      device void* out,                                     \
-      constant uint3* offsets,                              \
-      uint tid)
-
 REGISTER_BINARY_OP(complex_mul, float);
 REGISTER_BINARY_OP(complex_mul, half);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #146993
* __->__ #146965

By defining `REGISTER_BINARY_OP` template that could be used to register fmix, fmax, etc