### PR TITLE
remove unnecessary xpu availability check when retrieving aot flags

### DIFF
--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -420,8 +420,6 @@ def synchronize(device: _device_t = None) -> None:
 
 def get_arch_list() -> list[str]:
     r"""Return list XPU architectures this library was compiled for."""
-    if not is_available():
-        return []
     arch_flags = torch._C._xpu_getArchFlags()
     if arch_flags is None:
         return []


### PR DESCRIPTION
As title

Retrieving xpu aot flags that the pytorch binary was compiled against is not the same as running the binary itself. Thus it doesn't seem to necessarily check if there is an xpu environment available.