### PR TITLE
[ROCm][Windows] Fix clang-cl error related to -Wmissing prototypes enabled

### DIFF
--- a/torch/csrc/jit/codegen/fuser/cpu/fused_kernel.cpp
+++ b/torch/csrc/jit/codegen/fuser/cpu/fused_kernel.cpp
@@ -56,7 +56,7 @@ static bool programExists(const std::string& program) {
 }
 
 #ifdef _MSC_VER
-std::optional<std::wstring> exec(const std::wstring& cmd) {
+static std::optional<std::wstring> exec(const std::wstring& cmd) {
   std::array<wchar_t, 128> buffer;
   std::wstring result;
   std::unique_ptr<FILE, decltype(&_pclose)> pipe(
@@ -76,7 +76,7 @@ inline std::wstring& rtrim(std::wstring& s, const wchar_t* t = L" \t\n\r\f\v") {
   return s;
 }
 
-void activate() {
+static void activate() {
   wchar_t* root = nullptr;
   std::wstring cmd;
   std::optional<std::wstring> exec_out;

--- a/torch/csrc/jit/codegen/fuser/cpu/temp_file.h
+++ b/torch/csrc/jit/codegen/fuser/cpu/temp_file.h
@@ -25,7 +25,7 @@
 namespace torch::jit::fuser::cpu {
 
 #ifdef _MSC_VER
-static int wmkstemps(wchar_t* tmpl, int suffix_len) {
+inline int wmkstemps(wchar_t* tmpl, int suffix_len) {
   int len;
   wchar_t* name;
   int fd = -1;

--- a/torch/csrc/jit/codegen/fuser/cpu/temp_file.h
+++ b/torch/csrc/jit/codegen/fuser/cpu/temp_file.h
@@ -25,7 +25,7 @@
 namespace torch::jit::fuser::cpu {
 
 #ifdef _MSC_VER
-int wmkstemps(wchar_t* tmpl, int suffix_len) {
+static int wmkstemps(wchar_t* tmpl, int suffix_len) {
   int len;
   wchar_t* name;
   int fd = -1;


### PR DESCRIPTION
Some of the windows files (fused_kernels.cpp or temp_file.h) contain code that fail to compile when this flag is enabled when built with clang-cl.

This PR resolves the issue by ensuring that even if we build with clang-cl, it doesn't include those flags on windows.

Alternatively if needed, I can fix the files mentioned to pass under this flag.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd