### PR TITLE
[Inductor] Record Triton’s Base32 Cache Key in `.best_config` for Debugging

### DIFF
--- a/test/inductor/test_best_config.py
+++ b/test/inductor/test_best_config.py
@@ -1,0 +1,96 @@
+# Owner(s): ["module: inductor"]
+
+import glob
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+import torch
+from torch._inductor import config
+from torch.testing._internal.common_utils import IS_LINUX, skipIfXpu
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+
+
+try:
+    import triton  # noqa: F401
+except ImportError as e:
+    if __name__ == "__main__":
+        sys.exit(0)
+    raise unittest.SkipTest("requires triton") from e
+
+from torch._inductor.test_case import run_tests, TestCase
+
+
+def trivial_kernel(x):
+    return torch.sin(x) + torch.cos(x)
+
+
+class TestKernelBestConfig(TestCase):
+    device_type = GPU_TYPE
+
+    @classmethod
+    def setUpClass(cls):
+        # Save the original configuration and environment variables.
+        cls.original_compile_threads = config.compile_threads
+        cls.original_max_autotune = config.max_autotune
+        cls.original_inductor_env = os.environ.get("TORCHINDUCTOR_CACHE_DIR", "")
+        cls.original_triton_env = os.environ.get("TRITON_CACHE_DIR", "")
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        # Restore the original configuration and environment variables.
+        os.environ["TORCHINDUCTOR_CACHE_DIR"] = cls.original_inductor_env
+        os.environ["TRITON_CACHE_DIR"] = cls.original_triton_env
+        config.compile_threads = cls.original_compile_threads
+        config.max_autotune = cls.original_max_autotune
+        super().tearDownClass()
+
+    @skipIfXpu
+    def test_best_config_has_triton_cache_key(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.environ["TORCHINDUCTOR_CACHE_DIR"] = tmpdir
+            triton_cache_dir = os.path.join(tmpdir, "triton_cache")
+            os.environ["TRITON_CACHE_DIR"] = triton_cache_dir
+
+            config.compile_threads = 0
+            config.max_autotune = True
+
+            compiled_fn = torch.compile(trivial_kernel)
+
+            x = torch.randn(32, 10, device=GPU_TYPE)
+            compiled_fn(x)
+
+            # Search for .best_config files in the inductor cache directory.
+            best_config_files = glob.glob(
+                os.path.join(tmpdir, "**", "*.best_config"), recursive=True
+            )
+            self.assertGreater(
+                len(best_config_files),
+                0,
+                f"No best_config files found in {tmpdir}. Directory contents: {os.listdir(tmpdir)}",
+            )
+
+            # Validate that each best_config file contains a real triton_cache_hash,
+            # and that a corresponding Triton cache directory exists.
+            for file_path in best_config_files:
+                with open(file_path) as f:
+                    data = json.load(f)
+                self.assertIn(
+                    "triton_cache_hash",
+                    data,
+                    f"Missing triton_cache_hash in {os.path.basename(file_path)}",
+                )
+                cache_hash = data["triton_cache_hash"]
+                expected_path = os.path.join(triton_cache_dir, cache_hash)
+                self.assertTrue(
+                    os.path.exists(expected_path),
+                    f"Triton cache directory missing: {expected_path}",
+                )
+
+
+if __name__ == "__main__":
+    if IS_LINUX and HAS_GPU:
+        run_tests()

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -301,6 +301,7 @@ S390X_TESTLIST = [
     "inductor/test_autoheuristic",
     "inductor/test_b2b_gemm",
     "inductor/test_benchmarking",
+    "inductor/test_best_config",
     "inductor/test_ck_backend",
     "inductor/test_codecache",
     "inductor/test_codegen_triton",

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -12,6 +12,7 @@ from typing_extensions import override
 import torch
 from torch.compiler._cache import CacheArtifactManager, CacheArtifactType
 from torch.utils._triton import has_triton
+from torch._inductor.runtime.runtime_utils import triton_hash_to_path_key
 
 from ..remote_cache import (
     create_cache,
@@ -197,7 +198,11 @@ class AutotuneCache:
 
     # Save the config in the caches
     def save(
-        self, config: Config, time_taken_ns: int, found_by_coordesc: bool = False
+        self,
+        config: Config,
+        time_taken_ns: int,
+        found_by_coordesc: bool = False,
+        triton_binary_hash: Optional[str] = None, 
     ) -> None:
         data = {
             **config.kwargs,
@@ -206,6 +211,8 @@ class AutotuneCache:
             "configs_hash": self.configs_hash,
             "found_by_coordesc": found_by_coordesc,
             "time_taken_ms": time_taken_ns // 1000000,  # Convert from NS to MS
+            "triton_binary_hash": triton_hash_to_path_key(triton_binary_hash),
+
         }
 
         if local_cache := self.local_cache:

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -12,7 +12,6 @@ from typing_extensions import override
 import torch
 from torch.compiler._cache import CacheArtifactManager, CacheArtifactType
 from torch.utils._triton import has_triton
-from torch._inductor.runtime.runtime_utils import triton_hash_to_path_key
 
 from ..remote_cache import (
     create_cache,
@@ -211,7 +210,7 @@ class AutotuneCache:
             "configs_hash": self.configs_hash,
             "found_by_coordesc": found_by_coordesc,
             "time_taken_ms": time_taken_ns // 1000000,  # Convert from NS to MS
-            "triton_binary_hash": triton_hash_to_path_key(triton_binary_hash),
+            "triton_binary_hash": triton_binary_hash,
 
         }
 

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -201,7 +201,7 @@ class AutotuneCache:
         config: Config,
         time_taken_ns: int,
         found_by_coordesc: bool = False,
-        triton_cache_hash: Optional[str] = None, 
+        triton_cache_hash: Optional[str] = None,
     ) -> None:
         data = {
             **config.kwargs,

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -201,7 +201,7 @@ class AutotuneCache:
         config: Config,
         time_taken_ns: int,
         found_by_coordesc: bool = False,
-        triton_binary_hash: Optional[str] = None, 
+        triton_cache_hash: Optional[str] = None, 
     ) -> None:
         data = {
             **config.kwargs,
@@ -210,7 +210,7 @@ class AutotuneCache:
             "configs_hash": self.configs_hash,
             "found_by_coordesc": found_by_coordesc,
             "time_taken_ms": time_taken_ns // 1000000,  # Convert from NS to MS
-            "triton_binary_hash": triton_binary_hash,
+            "triton_cache_hash": triton_cache_hash,
         }
 
         if local_cache := self.local_cache:

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -211,7 +211,6 @@ class AutotuneCache:
             "found_by_coordesc": found_by_coordesc,
             "time_taken_ms": time_taken_ns // 1000000,  # Convert from NS to MS
             "triton_binary_hash": triton_binary_hash,
-
         }
 
         if local_cache := self.local_cache:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -774,10 +774,9 @@ class CachingAutotuner(KernelInterface):
             launcher.shared,
         )
 
-        triton_binary_hash = launcher.cache_hash
 
         if self.save_cache_hook:
-            self.save_cache_hook(launcher.config, self.autotune_time_taken_ns, triton_binary_hash=triton_binary_hash,)
+            self.save_cache_hook(launcher.config, self.autotune_time_taken_ns, triton_cache_hash=launcher.cache_hash,)
 
     def save_gpu_kernel(self, grid, stream, launcher):
         if callable(grid):

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -774,8 +774,10 @@ class CachingAutotuner(KernelInterface):
             launcher.shared,
         )
 
+        triton_binary_hash = launcher.cache_hash
+
         if self.save_cache_hook:
-            self.save_cache_hook(launcher.config, self.autotune_time_taken_ns)
+            self.save_cache_hook(launcher.config, self.autotune_time_taken_ns, triton_binary_hash=triton_binary_hash,)
 
     def save_gpu_kernel(self, grid, stream, launcher):
         if callable(grid):
@@ -1212,6 +1214,7 @@ class TritonCompileResult:
         launcher.n_regs = getattr(binary, "n_regs", None)
         launcher.n_spills = getattr(binary, "n_spills", None)
         launcher.shared = binary_shared
+        launcher.cache_hash = triton_hash_to_path_key(binary.hash)
         launcher.store_cubin = self.inductor_meta.get("store_cubin", False)
         # store this global variable to avoid the high overhead of reading it when calling run
         if launcher.store_cubin:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -774,7 +774,6 @@ class CachingAutotuner(KernelInterface):
             launcher.shared,
         )
 
-
         if self.save_cache_hook:
             self.save_cache_hook(launcher.config, self.autotune_time_taken_ns, triton_cache_hash=launcher.cache_hash,)
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -775,7 +775,11 @@ class CachingAutotuner(KernelInterface):
         )
 
         if self.save_cache_hook:
-            self.save_cache_hook(launcher.config, self.autotune_time_taken_ns, triton_cache_hash=launcher.cache_hash,)
+            self.save_cache_hook(
+                launcher.config,
+                self.autotune_time_taken_ns,
+                triton_cache_hash=launcher.cache_hash,
+            )
 
     def save_gpu_kernel(self, grid, stream, launcher):
         if callable(grid):


### PR DESCRIPTION
Modified  TorchInductor’s autotuning flow so that each `best_config` JSON file also includes the Triton “base32” (or base64) cache key. 

**Motivation**

Debugging & Analysis: With this change, we can quickly identify which compiled binary and IRs belongs to a given best config.
The impact is minimal since it is only an extra field in .best_config. It can help advanced performance tuning or kernel-level debugging.

Also, since Triton already stores cubin/hsaco in its cache, developers/researchers can avoid to set `store_cubin = True` since they can get the cubin/hsaco in the Triton cache and with the code provided in this PR, they can easily match the best_config with the right Triton cache directory for the "best" kernel. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @davidberard98 