### PR TITLE
[BE] Toward Metal Iterator (step 2)

### DIFF
--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -78,13 +78,29 @@ kernel void binary_indexing(
   *out = f(*input, *other);
 }
 
-#define REGISTER_BINARY_INDEXING_OP(NAME, DTYPE)       \
-  template [[host_name(#NAME "_" #DTYPE)]] kernel void \
-  binary_indexing<DTYPE, NAME##_functor>(              \
-      constant void* input_,                           \
-      constant void* other_,                           \
-      device void* out_,                               \
-      constant uint3* offsets,                         \
+template <typename T, typename F>
+kernel void binary_dense(
+    constant T* input [[buffer(0)]],
+    constant T* other [[buffer(1)]],
+    device T* out [[buffer(2)]],
+    uint tid [[thread_position_in_grid]]) {
+  F f;
+  out[tid] = f(input[tid], other[tid]);
+}
+
+#define REGISTER_BINARY_INDEXING_OP(NAME, DTYPE)             \
+  template [[host_name(#NAME "_" #DTYPE)]] kernel void       \
+  binary_indexing<DTYPE, NAME##_functor>(                    \
+      constant void* input_,                                 \
+      constant void* other_,                                 \
+      device void* out_,                                     \
+      constant uint3* offsets,                               \
+      uint tid);                                             \
+  template [[host_name(#NAME "_dense_" #DTYPE)]] kernel void \
+  binary_dense<DTYPE, NAME##_functor>(                       \
+      constant DTYPE * input_,                               \
+      constant DTYPE * other_,                               \
+      device DTYPE * out_,                                   \
       uint tid)
 
 template <typename T>

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -8,6 +8,7 @@
 #include <ATen/native/mps/operations/BinaryKernel.h>
 // For MTLLanguageVersion_3_1
 #include <ATen/native/mps/MPSGraphSonomaOps.h>
+#include <fmt/format.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -30,7 +31,7 @@ static auto& lib = MetalShaderLibrary::getBundledLibrary();
 #include <ATen/native/mps/BinaryKernel_metallib.h>
 #endif
 
-static void binary_mps_impl(TensorIteratorBase& iter, const std::string func_name) {
+static void binary_mps_impl(TensorIteratorBase& iter, const std::string func_name, bool supports_dense = true) {
   TORCH_CHECK(iter.common_dtype() != at::kDouble, "float64 is not supported on MPS");
 
   Tensor input = iter.input(0);
@@ -44,7 +45,15 @@ static void binary_mps_impl(TensorIteratorBase& iter, const std::string func_nam
   const uint32_t numThreads = iter.numel();
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
-      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
+      auto computeEncoder = mpsStream->commandEncoder();
+      if (supports_dense && iter.is_contiguous()) {
+        const auto kernel_name = fmt::format("{}_dense_{}", func_name, scalarToMetalTypeString(input));
+        auto  binaryPSO = lib.getPipelineStateForFunc(kernel_name);
+        [computeEncoder setComputePipelineState:binaryPSO];
+        mtl_setArgs(computeEncoder, input, other, out);
+        mtl_dispatch1DJob(computeEncoder, binaryPSO, numThreads);
+        return;
+      }
       const std::string kernel = func_name + "_" + scalarToMetalTypeString(input);
       auto kernelDataOffsets = generateKernelDataOffsets(computeEncoder, iter);
 
@@ -80,7 +89,7 @@ void complex_mul_out(const Tensor& input, const Tensor& other, const Tensor& out
   auto iter =
       TensorIteratorConfig().add_output(output_as_real).add_input(input_as_real).add_input(other_as_real).build();
 
-  mps::binary_mps_impl(iter, "complex_mul");
+  mps::binary_mps_impl(iter, "complex_mul", false);
 }
 
 } // namespace mps
@@ -132,7 +141,7 @@ Tensor& polar_out_mps(const Tensor& abs, const Tensor& angle, Tensor& output) {
   auto output_as_real = at::view_as_real(output).select(output.dim(), 0);
   auto iter = TensorIteratorConfig().add_output(output_as_real).add_input(abs).add_input(angle).build();
 
-  mps::binary_mps_impl(iter, "polar");
+  mps::binary_mps_impl(iter, "polar", false);
   return output;
 }
 
@@ -148,7 +157,7 @@ Tensor& complex_out_mps(const Tensor& real, const Tensor& imag, Tensor& output) 
   auto output_as_real = at::view_as_real(output).select(output.dim(), 0);
   auto iter = TensorIteratorConfig().add_output(output_as_real).add_input(real).add_input(imag).build();
 
-  mps::binary_mps_impl(iter, "complex_kernel");
+  mps::binary_mps_impl(iter, "complex_kernel", false);
   return output;
 }
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -48,7 +48,7 @@ static void binary_mps_impl(TensorIteratorBase& iter, const std::string func_nam
       auto computeEncoder = mpsStream->commandEncoder();
       if (supports_dense && iter.is_contiguous()) {
         const auto kernel_name = fmt::format("{}_dense_{}", func_name, scalarToMetalTypeString(input));
-        auto  binaryPSO = lib.getPipelineStateForFunc(kernel_name);
+        auto binaryPSO = lib.getPipelineStateForFunc(kernel_name);
         [computeEncoder setComputePipelineState:binaryPSO];
         mtl_setArgs(computeEncoder, input, other, out);
         mtl_dispatch1DJob(computeEncoder, binaryPSO, numThreads);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #147018
* __->__ #147023

Add dense flavor of the binary ops, i.e. if iterator is contiguous, do not build indices but rather run different flavor, using the same functor, which results in almost 100% perf gain for binary operation with 1mln elements of `torch.fmax` as one can see from the table below collected on M4Pro Mini using following benchmarking script
```python
import torch

from timeit import default_timer
from itertools import product
from torch.utils.benchmark import Measurement, Timer

def bench_binary(
    n,
    binary_func,
    dtype=torch.float32,
) -> Measurement:
    t = Timer(
        stmt=f"f(x, y);f(x, y); f(x, y); torch.mps.synchronize()",
        setup=f"x, y=torch.rand((2, {n}), dtype={dtype}, device='mps').unbind(0)",
        globals = {'f': binary_func},
        language="python", timer=default_timer
    )
    return t.blocked_autorange()

if __name__ == "__main__":
    n = 1024**2
    for dtype in [torch.float32, torch.float16, torch.bfloat16]:
        eager_t = bench_binary(n, torch.fmax, dtype)
        use_msec = eager_t.mean > 1e-4
        multiplier = 1e3 if use_msec else 1e6
        uname = "msec" if use_msec else "usec"
        print(f"torch.fmax()x3 {str(dtype):>14} {eager_t.mean*multiplier:>7.2f} {uname}")
```

 Dtype  | Time before | Time After |
| ------|------------ | ---------- |
| float32  | 0.84 msec  | 0.66 msec |
| float16  |  0.49 msec |  0.23 msec |
| bfloat16  | 0.48 msec  | 0.22 msec |
