### PR TITLE
OpenReg: Fix releasing tensor issue when using pin_memory

### DIFF
--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/csrc/OpenRegHooks.cpp
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/csrc/OpenRegHooks.cpp
@@ -31,13 +31,26 @@ struct HostAllocator final : at::Allocator {
   }
 
   static void ReportAndDelete(void* ptr) {
-    if (!ptr) {
+    if (!ptr || !Py_IsInitialized()) {
       return;
     }
     py::gil_scoped_acquire acquire;
+
+    PyObject *type = nullptr, *value = nullptr, *traceback = nullptr;
+    // Always stash, this will be a no-op if there is no error
+    PyErr_Fetch(&type, &value, &traceback);
+
     TORCH_CHECK(
-        get_method("hostFree")(reinterpret_cast<host_ptr_t>(ptr)).cast<bool>(),
-        "Failed to free memory pointer at ", ptr);
+      get_method("hostFree")(reinterpret_cast<host_ptr_t>(ptr)).cast<bool>(),
+      "Failed to free memory pointer at ", ptr);
+
+    // If that user code raised an error, just print it without raising it
+    if (PyErr_Occurred()) {
+      PyErr_Print();
+    }
+
+    // Restore the original error
+    PyErr_Restore(type, value, traceback);
   }
 
   at::DeleterFnPtr raw_deleter() const override {


### PR DESCRIPTION
# Fail when exiting process
When executing the following code:
```
import pytorch_openreg

import torch

if __name__ == "__main__":
    a = torch.tensor(1).pin_memory()
```
The process will exit with error. This is the same issue as https://github.com/pytorch/pytorch/pull/140936
# Fail when exiting python generator
When executing the following code, error will happen on python 3.9:
```
import pytorch_openreg
import torch

def generator():
    t = torch.tensor(1).pin_memory()
    yield

if __name__ == "__main__":
    iter = generator()
    next(iter)
    try:
        next(iter)  # Error happens here on python 3.9
    except StopIteration:
        print("success") # python 3.10+
```
This is the same issue as https://github.com/pytorch/pytorch/pull/141815#issuecomment-2547303381

cc @albanD 