### PR TITLE
Use 2022 as default VC_YEAR for windows tests

### DIFF
--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -173,7 +173,7 @@ jobs:
           VC_PRODUCT: "BuildTools"
           VC_VERSION: ""
           VS_VERSION: "16.8.6"
-          VC_YEAR: "2019"
+          VC_YEAR: "2022"
           AWS_DEFAULT_REGION: us-east-1
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
Same as: https://github.com/pytorch/pytorch/pull/147053 
New Windows AMI does not have Visual Studio 2019. Hence use 2022 as default. 
See: pytorch/test-infra#6226

