### PR TITLE
s390x: add cleanup for cancelled docker image builds

### DIFF
--- a/.github/workflows/build-manywheel-images-s390x.yml
+++ b/.github/workflows/build-manywheel-images-s390x.yml
@@ -57,3 +57,12 @@ jobs:
       - name: Build Docker Image
         run: |
           .ci/docker/manywheel/build.sh manylinuxs390x-builder:cpu-s390x
+
+      - name: Cleanup docker
+        if: cancelled()
+        shell: bash
+        run: |
+          # if podman build command is interrupted,
+          # it can leave a couple of processes still running.
+          # order them to stop for clean shutdown.
+          docker system prune --build -f || true


### PR DESCRIPTION
When podman image build is cancelled,
a couple of processes are left behind,
and their existence prevents
proper shutdown of runner container.

Add cleanup step at the end of workflow
using new option recently introduced in podman:
https://github.com/containers/podman/pull/25102

Example of job preventing s390x worker cleaning up and restarting properly:
https://github.com/pytorch/pytorch/actions/runs/13289159296/job/37105230728