### PR TITLE
[PT][FSDP] support custom all reduce hook across FSDP units

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -267,6 +267,7 @@ class TestFullyShardCollectiveOps(FSDPTestMultiThread):
             reduce_scatter_reduce_op=None,
             all_reduce_group=None,
             all_reduce_stream=all_reduce_stream,
+            all_reduce_hook=None,
             all_reduce_grads=True,
             partial_reduce_output=None,
         )

--- a/test/distributed/_composable/fsdp/test_fully_shard_init.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_init.py
@@ -3,7 +3,7 @@
 import copy
 import itertools
 import unittest
-from typing import Optional
+from typing import cast, Optional
 
 import torch
 import torch.distributed as dist
@@ -26,6 +26,7 @@ from torch.distributed.fsdp._fully_shard._fsdp_param import ParamModuleInfo
 from torch.distributed.fsdp._fully_shard._fsdp_param_group import (
     _get_param_module_infos,
 )
+from torch.distributed.fsdp._fully_shard._fully_shard import FSDPModule
 from torch.distributed.fsdp._init_utils import (
     _init_inter_node_process_group,
     _init_intra_node_process_group,
@@ -1013,6 +1014,114 @@ class TestFullyShardHSDPBroadcast(FSDPTestMultiThread):
         # Check that we can run an iteration without erroring
         inp = torch.randint(0, model_args.vocab_size, (2, 16), device="cuda")
         model(inp).sum().backward()
+
+
+class TestHSDPWithCustomHook(FSDPTestMultiThread):
+    @property
+    def world_size(self) -> int:
+        return 4
+
+    def perThreadSetUp(self) -> None:
+        super().perThreadSetUp()
+        torch.set_default_device("cuda")
+        rank = dist.get_rank()
+        torch.cuda.set_device(rank)
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_custom_hook_custom_stream(self):
+        hsdp_mesh = init_device_mesh(
+            "cuda", (2, 2), mesh_dim_names=("replicate", "shard")
+        )
+        model = MLP(10, bias=False)
+        fully_shard(model, mesh=hsdp_mesh)
+        model = cast(FSDPModule, model)
+        custom_stream = torch.cuda.Stream()
+
+        # native HSDP should reject
+        with self.assertRaises(ValueError) as cm:
+            model.set_all_reduce_hook(lambda output: output, stream=custom_stream)
+
+        ex = cm.exception
+        self.assertEqual(str(ex), "stream cannot be set when using native HSDP")
+
+        # FSDP + hook in custom stream is ok
+        intra_pg = _init_intra_node_process_group(2)
+        fsdp_mesh = DeviceMesh.from_group(
+            intra_pg,
+            "cuda",
+            dist.get_process_group_ranks(intra_pg),
+            mesh_dim_names=("shard",),
+        )
+        hook_used_stream = None
+
+        def _hook(_output: torch.Tensor) -> None:
+            nonlocal hook_used_stream
+            hook_used_stream = torch.cuda.current_stream()
+
+        model = MLP(10, bias=False)
+        fully_shard(model, mesh=fsdp_mesh)
+        model = cast(FSDPModule, model)
+        model.set_all_reduce_hook(_hook, stream=custom_stream)
+
+        inp = torch.arange(10, dtype=torch.float32, requires_grad=True).view(1, 10)
+        out = model(inp)
+        out.sum().backward()
+        torch.cuda.synchronize()
+        self.assertEqual(hook_used_stream, custom_stream)
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_custom_hsdp_all_reduce_hook(self):
+        world_pg = dist.distributed_c10d._get_default_group()
+        intra_pg = _init_intra_node_process_group(2)
+        inter_pg = _init_inter_node_process_group(world_pg, 2)
+        mesh = DeviceMesh.from_group(
+            intra_pg,
+            "cuda",
+            dist.get_process_group_ranks(intra_pg),
+            mesh_dim_names=("shard",),
+        )
+        model = MLP(10, bias=False)
+        rank = dist.get_rank()
+        rank_group = rank // 2
+
+        # init the weights to be constant within each group
+        # this is just to simplify the test numeric check when we do bwd
+        torch.nn.init.constant_(model.in_proj.weight, 1.0 * rank_group)
+        torch.nn.init.constant_(model.out_proj.weight, 2.0 * rank_group)
+
+        fully_shard(model, mesh=mesh)
+        model = cast(FSDPModule, model)
+
+        hook_called: bool = False
+
+        def _custom_hook(output: torch.Tensor) -> None:
+            nonlocal hook_called
+            dist.all_reduce(output, group=inter_pg, op=dist.ReduceOp.AVG)
+            hook_called = True
+
+        model.set_all_reduce_hook(_custom_hook)
+
+        inp = torch.arange(10, dtype=torch.float32, requires_grad=True).view(1, 10)
+        out = model(inp)
+        out.sum().backward()
+        torch.cuda.synchronize()
+        # custom hook was fired
+        self.assertTrue(hook_called)
+        # within each replica, FSDP shards the weights at dim 0
+        # so half of MLP weights with 2x2 setup
+        out_proj_local_grad = model.out_proj.weight.grad.to_local().cpu()
+        in_proj_local_grad = model.in_proj.weight.grad.to_local().cpu()
+
+        # grad is halved in custom bwd all reduce hook during avg
+        # as replica 0 weights are 0
+        self.assertEqual(
+            out_proj_local_grad,
+            torch.full((5, 40), 22.5, dtype=torch.float32, device="cpu"),
+        )
+        self.assertEqual(
+            in_proj_local_grad,
+            torch.arange(0, 100, 10, dtype=torch.float32, device="cpu").repeat(20, 1),
+        )
 
 
 class TestFullyShardShardPlacementFn(FSDPTestMultiThread):

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -158,6 +158,11 @@ class FSDPParamGroup:
         # - Hook state
         self._module_to_pre_save_state_dict_hook_handle: _ModuleToHandleDict = {}
         self._module_to_pre_load_state_dict_hook_handle: _ModuleToHandleDict = {}
+        self._all_reduce_hook: Optional[Callable[[torch.Tensor], None]] = None
+        # Optional stream to run the user-defined all-reduce hook in
+        # Saved here and not in the comm. context because we allow the user to
+        # specify it, possibly at construction time before lazy init
+        self._all_reduce_hook_stream: Optional[torch.cuda.Stream] = None
 
         # - Communication and communication/computation overlap
         self.comm_ctx = FSDPCommContext()
@@ -414,6 +419,18 @@ class FSDPParamGroup:
                     self.comm_ctx.reduce_scatter_state.event
                 )
                 self.comm_ctx.reduce_scatter_state = None
+            all_reduce_pg = self._all_reduce_process_group if self._is_hsdp else None
+            all_reduce_stream: torch.cuda.Stream
+            if all_reduce_pg is None and self._all_reduce_hook_stream is not None:
+                # this means the native HSDP is not enabled,
+                # but user may want to have a custom HSDP setup
+                assert (
+                    self._all_reduce_hook is not None
+                ), "all reduce hook stream is specified but hook itself is missing."
+                all_reduce_stream = self._all_reduce_hook_stream
+            else:
+                all_reduce_stream = self.comm_ctx.all_reduce_stream
+
             self._wait_for_post_backward()
             (
                 reduce_scatter_input,
@@ -432,9 +449,10 @@ class FSDPParamGroup:
                 self.device,
                 self.reduce_scatter_reduce_op,
                 self._all_reduce_process_group if self._is_hsdp else None,
-                self.comm_ctx.all_reduce_stream,
+                all_reduce_stream,
                 self.all_reduce_grads,
                 self._partial_reduce_output,
+                self._all_reduce_hook,
             )
             self.comm_ctx.reduce_scatter_state = ReduceScatterState(
                 reduce_scatter_input, reduce_scatter_event


### PR DESCRIPTION
This change adds an API `set_all_reduce_hook` to the `FSDPModule` to
support customized all reduce either in native HSDP (2d mesh) setup or custom HSDP (1d FSDP + custom AR across replicas)
* For native HSDP, the original AR would still run as is and this hook allows for additional gradient modification post all reduce.
* For custom HSDP, the original AR will be skipped and all the logic is instead expected to be executed in the hook.

The custom hook is expected to perform operations in place (no return value).

Example basic usage:
```
model = ...
fully_shard(model, mesh=...)
model.set_all_reduce_hook(my_hook)
```

By default, the hook will run in the default all reduce stream post reduce scatter.
When native HSDP is NOT enabled, the custom hook can be specified to run in a custom stream. This custom stream will also be synchronized post reduce scatter similarly. See tests for examples.

Test Plan: CI

Differential Revision: D68255583




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o