### PR TITLE
Make torch.cuda.gds APIs public

### DIFF
--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -174,7 +174,7 @@ def test_cuda_gds_errors_captured() -> None:
     try:
         print("Testing test_cuda_gds_errors_captured")
         with NamedTemporaryFile() as f:
-            torch.cuda.gds._GdsFile(f.name, os.O_CREAT | os.O_RDWR)
+            torch.cuda.gds.GdsFile(f.name, os.O_CREAT | os.O_RDWR)
     except RuntimeError as e:
         expected_error = "cuFileHandleRegister failed"
         if re.search(expected_error, f"{e}"):

--- a/docs/source/cuda.rst
+++ b/docs/source/cuda.rst
@@ -209,3 +209,17 @@ See the :doc:`documentation <cuda._sanitizer>` for information on how to use it.
 .. py:module:: torch.cuda.random
 .. py:module:: torch.cuda.sparse
 .. py:module:: torch.cuda.streams
+
+
+GPUDirect Storage (prototype)
+----------------------------
+
+.. currentmodule:: torch.cuda.gds
+
+    .. autosummary::
+        :toctree: generated
+        :nosignatures:
+
+    gds_register_buffer
+    gds_deregister_buffer
+    GdsFile

--- a/docs/source/cuda.rst
+++ b/docs/source/cuda.rst
@@ -198,7 +198,7 @@ See the :doc:`documentation <cuda._sanitizer>` for information on how to use it.
 GPUDirect Storage (prototype)
 -----------------------------
 
-The APIs in `torch.cuda.gds` provide thin wrappers around certain cuFile APIs which allow
+The APIs in ``torch.cuda.gds`` provide thin wrappers around certain cuFile APIs that allow
 direct memory access transfers between GPU memory and storage, avoiding a bounce buffer in the CPU. See the
 `cufile api documentation <https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html#cufile-io-api>`_
 for more details.

--- a/docs/source/cuda.rst
+++ b/docs/source/cuda.rst
@@ -196,7 +196,7 @@ See the :doc:`documentation <cuda._sanitizer>` for information on how to use it.
 
 
 GPUDirect Storage (prototype)
-----------------------------
+-----------------------------
 
 The APIs in `torch.cuda.gds` provide thin wrappers around certain cuFile APIs which allow
 direct memory access transfers between GPU memory and storage, avoiding a bounce buffer in the CPU. See the
@@ -208,10 +208,9 @@ ensure that their system is appropriately configured to use GPUDirect Storage pe
 `GPUDirect Storage documentation <https://docs.nvidia.com/gpudirect-storage/troubleshooting-guide/contents.html>`_.
 
 .. currentmodule:: torch.cuda.gds
-
-    .. autosummary::
-        :toctree: generated
-        :nosignatures:
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
 
     gds_register_buffer
     gds_deregister_buffer

--- a/docs/source/cuda.rst
+++ b/docs/source/cuda.rst
@@ -195,6 +195,29 @@ See the :doc:`documentation <cuda._sanitizer>` for information on how to use it.
     cuda._sanitizer
 
 
+GPUDirect Storage (prototype)
+----------------------------
+
+The APIs in `torch.cuda.gds` provide thin wrappers around certain cuFile APIs which allow
+direct memory access transfers between GPU memory and storage, avoiding a bounce buffer in the CPU. See the
+`cufile api documentation <https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html#cufile-io-api>`_
+for more details.
+
+These APIs can be used in versions greater than or equal to CUDA 12.6. In order to use these APIs, one must
+ensure that their system is appropriately configured to use GPUDirect Storage per the
+`GPUDirect Storage documentation <https://docs.nvidia.com/gpudirect-storage/troubleshooting-guide/contents.html>`_.
+
+.. currentmodule:: torch.cuda.gds
+
+    .. autosummary::
+        :toctree: generated
+        :nosignatures:
+
+    gds_register_buffer
+    gds_deregister_buffer
+    GdsFile
+
+
 .. This module needs to be documented. Adding here in the meantime
 .. for tracking purposes
 .. py:module:: torch.cuda.comm
@@ -209,17 +232,3 @@ See the :doc:`documentation <cuda._sanitizer>` for information on how to use it.
 .. py:module:: torch.cuda.random
 .. py:module:: torch.cuda.sparse
 .. py:module:: torch.cuda.streams
-
-
-GPUDirect Storage (prototype)
-----------------------------
-
-.. currentmodule:: torch.cuda.gds
-
-    .. autosummary::
-        :toctree: generated
-        :nosignatures:
-
-    gds_register_buffer
-    gds_deregister_buffer
-    GdsFile

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3525,7 +3525,7 @@ print(f"{{r1}}, {{r2}}")
             error_msg = "cuFileHandleRegister failed"
         with TemporaryFileName() as f:
             with self.assertRaisesRegex(RuntimeError, error_msg):
-                torch.cuda.gds._GdsFile(f, os.O_CREAT | os.O_RDWR)
+                torch.cuda.gds.GdsFile(f, os.O_CREAT | os.O_RDWR)
 
     def test_is_pinned_no_context(self):
         test_script = """\
@@ -5285,20 +5285,20 @@ class TestGDS(TestCase):
             self.skipTest("GPUDirect Storage requires ext4/xfs for local filesystem")
         src1 = torch.randn(1024, device="cuda")
         src2 = torch.randn(2, 1024, device="cuda")
-        torch.cuda.gds._gds_register_buffer(src1.untyped_storage())
-        torch.cuda.gds._gds_register_buffer(src2.untyped_storage())
+        torch.cuda.gds.gds_register_buffer(src1.untyped_storage())
+        torch.cuda.gds.gds_register_buffer(src2.untyped_storage())
         dest1 = torch.empty(1024, device="cuda")
         dest2 = torch.empty(2, 1024, device="cuda")
         with TemporaryFileName() as f:
-            file = torch.cuda.gds._GdsFile(f, os.O_CREAT | os.O_RDWR)
+            file = torch.cuda.gds.GdsFile(f, os.O_CREAT | os.O_RDWR)
             file.save_storage(src1.untyped_storage(), offset=0)
             file.save_storage(src2.untyped_storage(), offset=src1.nbytes)
             file.load_storage(dest1.untyped_storage(), offset=0)
             file.load_storage(dest2.untyped_storage(), offset=src1.nbytes)
         self.assertEqual(src1, dest1)
         self.assertEqual(src2, dest2)
-        torch.cuda.gds._gds_deregister_buffer(src1.untyped_storage())
-        torch.cuda.gds._gds_deregister_buffer(src2.untyped_storage())
+        torch.cuda.gds.gds_deregister_buffer(src1.untyped_storage())
+        torch.cuda.gds.gds_deregister_buffer(src2.untyped_storage())
 
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")

--- a/torch/cuda/gds.py
+++ b/torch/cuda/gds.py
@@ -58,13 +58,31 @@ class GdsFile:
 
     cuFile is a file-like interface to the GPUDirect Storage (GDS) API.
 
+    See the `cufile docs <https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html#cufile-io-api>`_
+    for more details.
+
     Args:
         filename (str): Name of the file to open.
         flags (int): Flags to pass to ``os.open`` when opening the file. ``os.O_DIRECT`` will
             be added automatically.
 
-    .. _CUDA GPUDirect Storage Documentation:
-        https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html#cufile-io-api
+    Example::
+
+        >>> # xdoctest: +SKIP("gds filesystem requirements")
+        >>> src1 = torch.randn(1024, device="cuda")
+        >>> src2 = torch.randn(2, 1024, device="cuda")
+        >>> file = torch.cuda.gds.GdsFile(f, os.O_CREAT | os.O_RDWR)
+        >>> file.save_storage(src1.untyped_storage(), offset=0)
+        >>> file.save_storage(src2.untyped_storage(), offset=src1.nbytes)
+        >>> dest1 = torch.empty(1024, device="cuda")
+        >>> dest2 = torch.empty(2, 1024, device="cuda")
+        >>> file.load_storage(dest1.untyped_storage(), offset=0)
+        >>> file.load_storage(dest2.untyped_storage(), offset=src1.nbytes)
+        >>> torch.equal(src1, dest1)
+        True
+        >>> torch.equal(src2, dest2)
+        True
+
     """
 
     def __init__(self, filename: str, flags: int):

--- a/torch/cuda/gds.py
+++ b/torch/cuda/gds.py
@@ -6,7 +6,11 @@ import torch
 from torch.types import Storage
 
 
-__all__: list[str] = []
+__all__: list[str] = [
+    "gds_register_buffer",
+    "gds_deregister_buffer",
+    "GdsFile",
+]
 
 
 def _dummy_fn(name: str) -> Callable:
@@ -31,7 +35,7 @@ if not hasattr(torch._C, "_gds_register_buffer"):
     torch._C.__dict__["_gds_save_storage"] = _dummy_fn("_gds_save_storage")
 
 
-def _gds_register_buffer(s: Storage) -> None:
+def gds_register_buffer(s: Storage) -> None:
     """Registers a buffer.
 
     Args:
@@ -40,7 +44,7 @@ def _gds_register_buffer(s: Storage) -> None:
     torch._C._gds_register_buffer(s)
 
 
-def _gds_deregister_buffer(s: Storage) -> None:
+def gds_deregister_buffer(s: Storage) -> None:
     """Registers a buffer.
 
     Args:
@@ -49,7 +53,7 @@ def _gds_deregister_buffer(s: Storage) -> None:
     torch._C._gds_deregister_buffer(s)
 
 
-class _GdsFile:
+class GdsFile:
     r"""Wrapper around cuFile.
 
     cuFile is a file-like interface to the GPUDirect Storage (GDS) API.


### PR DESCRIPTION
Follow up to https://github.com/pytorch/pytorch/pull/145748 that turned USE_CUFILE on for CUDA 12.6 and 12.8 binaries

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147120

