### PR TITLE
Remove outdated comment in ATen/mkl/Sparse.h about lack of Windows support

### DIFF
--- a/aten/src/ATen/mkl/Sparse.h
+++ b/aten/src/ATen/mkl/Sparse.h
@@ -2,8 +2,6 @@
 
 #include <ATen/Config.h>
 
-// MKL Sparse is not currently supported on Windows
-// See https://github.com/pytorch/pytorch/issues/97352
 #if AT_MKL_ENABLED()
 #define AT_USE_MKL_SPARSE() 1
 #else


### PR DESCRIPTION
Fixes #147124.

* #102604 added support for Intel oneMKL Sparse BLAS APIs so there was an outdated comment left around in the codebase that can now be removed.