### PR TITLE
[dynamo][fx] Don't emit `call_function` node to construct dataclass instances for Dynamo and `make_fx` tracing

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1914,6 +1914,7 @@ class SubgraphTracer(fx.Tracer):
     def __init__(self, output_graph, parent=None, is_export=False, source_target=None):
         super().__init__()
         self._proxy_named_tuple = False
+        self._proxy_dataclass = False
         self.output_graph = weakref.proxy(output_graph)
         self.graph = torch.fx.Graph()
 

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1920,6 +1920,7 @@ class _MakefxTracer:
             else:
                 self.fx_tracer = PythonKeyTracer()
             self.fx_tracer._proxy_named_tuple = False
+            self.fx_tracer._proxy_dataclass = False
 
             if self.tracing_mode == "fake":
                 import torch._dynamo
@@ -2008,6 +2009,7 @@ class _MakefxTracer:
             assert parent_tracer.fx_tracer is not None
             self.fx_tracer = _create_sub_fx_tracer(parent_tracer.fx_tracer)
             self.fx_tracer._proxy_named_tuple = False
+            self.fx_tracer._proxy_dataclass = False
             self._construct_modes_with_fx_tracer(self.fx_tracer)
             yield
         finally:

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -2,6 +2,7 @@
 import builtins
 import contextlib
 import copy
+import dataclasses
 import enum
 import functools
 import inspect
@@ -519,6 +520,14 @@ class CodeGen:
                 qualified_name = _get_qualified_name(type(arg))
                 global_name = add_global(qualified_name, type(arg))
                 return f"{global_name}{_get_repr(tuple(arg))}"
+            elif dataclasses.is_dataclass(arg):
+                qualified_name = _get_qualified_name(type(arg))
+                global_name = add_global(qualified_name, type(arg))
+                kwargs = ", ".join(
+                    f"{field.name}={_get_repr(getattr(arg, field.name))}"
+                    for field in dataclasses.fields(arg)
+                )
+                return f"{global_name}({kwargs})"
             elif isinstance(
                 arg, (torch._ops.OpOverload, torch._ops.HigherOrderOperator)
             ):

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -1,5 +1,6 @@
 # Nodes represent a definition of a value in our graph of operators.
 import builtins
+import dataclasses
 import inspect
 import operator
 import types
@@ -922,5 +923,11 @@ def map_aggregate(a: Argument, fn: Callable[[Argument], Argument]) -> Argument:
             map_aggregate(a.stop, fn),
             map_aggregate(a.step, fn),
         )
+    elif dataclasses.is_dataclass(a):
+        kwargs = {
+            field.name: map_aggregate(getattr(a, field.name), fn)
+            for field in dataclasses.fields(a)
+        }
+        return a.__class__(**kwargs)
     else:
         return fn(a)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #146950
* #146367
* #146714
* #146713
* __->__ #147152
* #147145

As title. The behavior change is limited to Dynamo and `make_fx` tracing
for backward compatibility reasons with `symbolic_trace`.

It heps enforce the invariant that Dynamo and `make_fx` graphs would
always contain tensor ops -- so rather than having these `call_function`
nodes to construct `NamedTuple`, we inline them directly as instance
arguments to the user nodes.

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames