### PR TITLE
[dynamo][not ready] Handle builtin methods as f_locals

### DIFF
--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -393,13 +393,15 @@ class BuiltinMethodVariable(BaseUserFunctionVariable):
     @functools.lru_cache(None)
     def is_supported_builtin_method(obj):
         method_self = obj.__self__
-        method_name = obj.__name__
 
-        # TODO(anijain2305) - Add support for more builtin methods
-        # Supports tuple.__new__ and frozenset({....}).__contains__
-        return (method_self is tuple and method_name == "__new__") or (
-            type(method_self) is frozenset and method_name == "__contains__"
-        )
+        if method_self is None:
+            # Its a function
+            return False
+
+        type_self = type(method_self)
+
+        if hasattr(type_self, "__module__") and type_self.__module__ == "builtins":
+            return True
 
     def call_function(
         self,

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -394,7 +394,7 @@ class BuiltinMethodVariable(BaseUserFunctionVariable):
     def is_supported_builtin_method(obj):
         method_self = obj.__self__
 
-        if method_self is None:
+        if method_self is None or inspect.ismodule(method_self):
             # Its a function
             return False
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147155


```
import torch


def gn(x):
    return torch.sin(x)

def fn(method, x, a):
    # method is a.append
    method(gn(x))
    return a


opt_fn = torch.compile(fn, backend="eager", fullgraph=True)

x = torch.randn(4)
a = []
print(opt_fn(a.append, x, a))
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames