### PR TITLE
[MPS] Fix cholesky_ex for empty inputs

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1063,14 +1063,14 @@ static void linalg_cholesky_mps_impl(const Tensor& input,
   TORCH_CHECK(input.scalar_type() == at::ScalarType::Float, "linalg.cholesky: Input tensor must be float32");
   TORCH_CHECK(input.dim() >= 2, "linalg.cholesky: Input tensor must be at least 2D");
   TORCH_CHECK(input.size(-2) == input.size(-1), "linalg.cholesky: Input tensor must be square");
-
-  if (input.numel() == 0 || out.numel() == 0) {
-    out.zero_();
-    return;
-  }
+  
   auto input_sizes = input.sizes();
   resize_output(out, input_sizes);
   resize_output(info, {input_sizes.begin(), input_sizes.end() - 2});
+  if (input.numel() == 0) {
+    info.zero_();
+    return;
+  }
   out.copy_(input);
 
   int64_t ndim = out.dim();

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1063,7 +1063,6 @@ static void linalg_cholesky_mps_impl(const Tensor& input,
   TORCH_CHECK(input.scalar_type() == at::ScalarType::Float, "linalg.cholesky: Input tensor must be float32");
   TORCH_CHECK(input.dim() >= 2, "linalg.cholesky: Input tensor must be at least 2D");
   TORCH_CHECK(input.size(-2) == input.size(-1), "linalg.cholesky: Input tensor must be square");
-  
   auto input_sizes = input.sizes();
   resize_output(out, input_sizes);
   resize_output(info, {input_sizes.begin(), input_sizes.end() - 2});


### PR DESCRIPTION
By making sure that `info` is actually initialized  if input is empty(but no need to do anything about `out`, is it's guaranteed to be an empty tensor)

Also move output resizing logic before `input.numel()` check

Fixes https://github.com/pytorch/pytorch/issues/147128
