### PR TITLE
Record the XPU and XCCL build settings in the compiled binary

### DIFF
--- a/caffe2/core/macros.h.in
+++ b/caffe2/core/macros.h.in
@@ -29,7 +29,7 @@
 #endif
 
 // Useful build settings that are recorded in the compiled binary
-// torch.__build__.show()
+// torch.__config__.show()
 #define CAFFE2_BUILD_STRINGS { \
   {"TORCH_VERSION", "${TORCH_VERSION}"}, \
   {"CXX_COMPILER", "${CMAKE_CXX_COMPILER}"}, \
@@ -65,4 +65,6 @@
   {"USE_ITT", "${CAFFE2_USE_ITT}"}, \
   {"USE_ROCM_KERNEL_ASSERT", "${USE_ROCM_KERNEL_ASSERT}"}, \
   {"USE_CUSPARSELT", "${USE_CUSPARSELT}"}, \
+  {"USE_XPU", "${USE_XPU}"}, \
+  {"USE_XCCL", "${USE_XCCL}"}, \
 }

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -36,7 +36,7 @@ class TestXpuConfig(TestCase):
 
     def test_xccl_record(self):
         config = torch.__config__.show()
-        assert 'USE_XCCL=0' in config or 'USE_XCCL=1' in config
+        assert f'USE_XCCL={int(torch.distributed.is_xccl_available())}' in config
 
 TEST_MULTIXPU = torch.xpu.device_count() > 1
 

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -29,6 +29,14 @@ from torch.testing._internal.common_utils import (
 )
 from torch.utils.checkpoint import checkpoint_sequential
 
+class TestXpuConfig(TestCase):
+    def test_xpu_record(self):
+        config = torch.__config__.show()
+        assert 'USE_XPU=0' in config or 'USE_XPU=1' in config
+
+    def test_xccl_record(self):
+        config = torch.__config__.show()
+        assert 'USE_XCCL=0' in config or 'USE_XCCL=1' in config
 
 TEST_MULTIXPU = torch.xpu.device_count() > 1
 
@@ -71,6 +79,9 @@ _xpu_computation_ops = [
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 class TestXpu(TestCase):
+    def test_config_xpu_record(self):
+        assert 'USE_XPU=1' in torch.__config__.show()
+
     def test_device_behavior(self):
         current_device = torch.xpu.current_device()
         torch.xpu.set_device(current_device)

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: intel"]
 
+import re
 import subprocess
 import sys
 import tempfile
@@ -734,8 +735,14 @@ class TestXPUAPISanity(TestCase):
 
     def test_torch_config(self):
         config = torch.__config__.show()
-        self.assertIn(f"USE_XPU={int(torch.xpu._is_compiled())}", config)
-        self.assertIn(f"USE_XCCL={int(torch.distributed.is_xccl_available())}", config)
+        value = re.search(r"USE_XPU=([^,]+)", config)
+        self.assertIsNotNone(value)
+        self.assertEqual(value.group(1) in ["ON", "1"], torch. xpu._is_compiled())
+        value = re.search(r"USE_XCCL=([^,]+)", config)
+        self.assertIsNotNone(value)
+        self.assertEqual(
+            value.group(1) in ["ON", "1"], torch.distributed.is_xccl_available()
+        )
 
 
 if __name__ == "__main__":

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -30,16 +30,6 @@ from torch.testing._internal.common_utils import (
 from torch.utils.checkpoint import checkpoint_sequential
 
 
-class TestXpuConfig(TestCase):
-    def test_xpu_record(self):
-        config = torch.__config__.show()
-        assert f"USE_XPU={int(torch.xpu._is_compiled())}" in config
-
-    def test_xccl_record(self):
-        config = torch.__config__.show()
-        assert f"USE_XCCL={int(torch.distributed.is_xccl_available())}" in config
-
-
 TEST_MULTIXPU = torch.xpu.device_count() > 1
 
 cpu_device = torch.device("cpu")
@@ -741,6 +731,11 @@ class TestXPUAPISanity(TestCase):
     def test_get_arch_list(self):
         if not torch.xpu._is_compiled():
             self.assertEqual(len(torch.xpu.get_arch_list()), 0)
+
+    def test_torch_config(self):
+        config = torch.__config__.show()
+        self.assertIn(f"USE_XPU={int(torch.xpu._is_compiled())}", config)
+        self.assertIn(f"USE_XCCL={int(torch.distributed.is_xccl_available())}", config)
 
 
 if __name__ == "__main__":

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -733,7 +733,7 @@ class TestXPUAPISanity(TestCase):
         if not torch.xpu._is_compiled():
             self.assertEqual(len(torch.xpu.get_arch_list()), 0)
 
-    def test_torch_config(self):
+    def test_torch_config_for_xpu(self):
         config = torch.__config__.show()
         value = re.search(r"USE_XPU=([^,]+)", config)
         self.assertIsNotNone(value)

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -737,7 +737,7 @@ class TestXPUAPISanity(TestCase):
         config = torch.__config__.show()
         value = re.search(r"USE_XPU=([^,]+)", config)
         self.assertIsNotNone(value)
-        self.assertEqual(value.group(1) in ["ON", "1"], torch. xpu._is_compiled())
+        self.assertEqual(value.group(1) in ["ON", "1"], torch.xpu._is_compiled())
         value = re.search(r"USE_XCCL=([^,]+)", config)
         self.assertIsNotNone(value)
         self.assertEqual(

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -29,14 +29,16 @@ from torch.testing._internal.common_utils import (
 )
 from torch.utils.checkpoint import checkpoint_sequential
 
+
 class TestXpuConfig(TestCase):
     def test_xpu_record(self):
         config = torch.__config__.show()
-        assert f'USE_XPU={int(torch.xpu._is_compiled())}` in config
+        assert f"USE_XPU={int(torch.xpu._is_compiled())}" in config
 
     def test_xccl_record(self):
         config = torch.__config__.show()
-        assert f'USE_XCCL={int(torch.distributed.is_xccl_available())}' in config
+        assert f"USE_XCCL={int(torch.distributed.is_xccl_available())}" in config
+
 
 TEST_MULTIXPU = torch.xpu.device_count() > 1
 

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -79,9 +79,6 @@ _xpu_computation_ops = [
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 class TestXpu(TestCase):
-    def test_config_xpu_record(self):
-        assert 'USE_XPU=1' in torch.__config__.show()
-
     def test_device_behavior(self):
         current_device = torch.xpu.current_device()
         torch.xpu.set_device(current_device)

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -32,7 +32,7 @@ from torch.utils.checkpoint import checkpoint_sequential
 class TestXpuConfig(TestCase):
     def test_xpu_record(self):
         config = torch.__config__.show()
-        assert 'USE_XPU=0' in config or 'USE_XPU=1' in config
+        assert f'USE_XPU={int(torch.xpu._is_compiled())}` in config
 
     def test_xccl_record(self):
         config = torch.__config__.show()


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

Currently the XPU and XCCL build settings are not recorded in the compiled binary and are not shown using the `torch.__config__.show()` which is a quick way to check if the binary has been built with such support.

Below is the output adding them (see end of last line):

```
Python 3.12.8 | packaged by conda-forge | (main, Dec  5 2024, 14:24:40) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
>>> print(torch.__config__.show())
PyTorch built with:
  - GCC 13.3
  - C++ Version: 201703
  - Intel(R) oneAPI Math Kernel Library Version 2025.1-Product Build 20250203 for Intel(R) 64 architecture applications
  - Intel(R) MKL-DNN v3.5.3 (Git Hash 66f0cb9eb66affd2da3bf5f8d897376f04aae6af)
  - OpenMP 201511 (a.k.a. OpenMP 4.5)
  - LAPACK is enabled (usually provided by MKL)
  - CPU capability usage: AVX512
XPU backend  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=RelWithDebInfo, COMMIT_SHA=43eb39d7c832b5560f7bfa8d29cc7919ac21c0ca, CXX_COMPILER=/home/pkourdis/compilers/gcc-13.3.0/bin/c++, CXX_FLAGS= -D_GLIBCXX_USE_CXX11_ABI=1 -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -DUSE_KINETO -DLIBKINETO_NOCUPTI -DLIBKINETO_NOROCTRACER -DLIBKINETO_NOXPUPTI=OFF -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Werror=range-loop-construct -Werror=bool-operation -Wnarrowing -Wno-missing-field-initializers -Wno-unknown-pragmas -Wno-unused-parameter -Wno-strict-overflow -Wno-strict-aliasing -Wno-stringop-overflow -Wsuggest-override -Wno-psabi -Wno-error=old-style-cast -fdiagnostics-color=always -faligned-new -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-dangling-reference -Wno-error=dangling-reference -Wno-error=redundant-move -DUSE_XPU -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, TORCH_VERSION=2.7.0, USE_CUDA=0, USE_CUDNN=OFF, USE_CUSPARSELT=OFF, USE_EXCEPTION_PTR=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_GLOO=ON, USE_MKL=ON, USE_MKLDNN=1, USE_MPI=0, USE_NCCL=OFF, USE_NNPACK=0, USE_OPENMP=ON, USE_ROCM=0, USE_ROCM_KERNEL_ASSERT=OFF, USE_XCCL=1, USE_XPU=1,
```