### PR TITLE
[BE] Use `c10::multiply_integers` in cholesky_impl

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1075,10 +1075,7 @@ static void linalg_cholesky_mps_impl(const Tensor& input,
 
   int64_t ndim = out.dim();
   int64_t N = out.size(-1);
-  int64_t B = 1;
-  for (int64_t i = 0; i < ndim - 2; i++) {
-    B *= out.size(i);
-  }
+  int64_t B = c10::multiply_integers(input_sizes.begin(), input_sizes.end() - 2);
 
   auto stream = getCurrentMPSStream();
   auto device = MPSDevice::getInstance()->device();


### PR DESCRIPTION
That replaces explicit for loop
