### PR TITLE
[PT2]: allow empty dict to pass type check

### DIFF
--- a/aten/src/ATen/core/function_schema_inl.h
+++ b/aten/src/ATen/core/function_schema_inl.h
@@ -13,6 +13,9 @@ inline void FunctionSchema::checkArg(
     // Fast-path for the common case
     return;
   }
+  if (value.isGenericDict() && value.toGenericDict().empty()) {
+    return;
+  }
   if (!value.type<T>()->isSubtypeOf(*argument.type())) {
     TORCH_CHECK(
         false,

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -979,6 +979,9 @@ void check_type(const Argument& schema_arg, const IValue& arg) {
       schema_arg.type()->kind() == c10::TypeKind::TensorType) {
     return;
   }
+  if (arg.isGenericDict() && arg.toGenericDict().empty()) {
+    return;
+  }
   TORCH_CHECK(
       arg.type()->isSubtypeOf(schema_arg.type()),
       arg.type()->annotation_str(),


### PR DESCRIPTION
Summary:
Seeing errors like when testing sigmoid for some models.
```
terminate called after throwing an instance of 'c10::Error'
  what():  forward() Expected a value of type 'Dict[int, Tuple[Tensor, Tensor, Tensor]]' for argument 'event_based_features' but instead found type 'Dict[Any, Any]'.
```
Let empty dict pass type check.


Reviewed By: henryoier

Differential Revision: D69482349




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel