### PR TITLE
Fix `torch.max` optional args `dim`, `keepdim` description

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6504,15 +6504,15 @@ Example::
             [-0.6172,  1.0036, -0.6060, -0.2432]])
     >>> torch.max(a, 1)
     torch.return_types.max(values=tensor([0.8475, 1.1949, 1.5717, 1.0036]), indices=tensor([3, 0, 0, 1]))
-    >>> a = torch.randn(3,1,3,)
-    >>> a.max(dim=0, keepdim=True)
+    >>> a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    >>> a.max(dim=1, keepdim=True)
     torch.return_types.max(
-    values=tensor([[[1.2928, 1.4774, 0.8201]]]),
-    indices=tensor([[[2, 2, 1]]]))
-    >>> a.max(dim=0, keepdim=False)
+    values=tensor([[2.], [4.]]),
+    indices=tensor([[1], [1]]))
+    >>> a.max(dim=1, keepdim=False)
     torch.return_types.max(
-    values=tensor([[1.2928, 1.4774, 0.8201]]),
-    indices=tensor([[2, 2, 1]]))
+    values=tensor([2., 4.]),
+    indices=tensor([1, 1]))
 
 .. function:: max(input, other, *, out=None) -> Tensor
    :noindex:

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -73,6 +73,11 @@ output tensor having 1 (or ``len(dim)``) fewer dimension(s).
         If ``None``, all dimensions are reduced.
 """
     },
+    {
+        "opt_keepdim": """
+    keepdim (bool, optional): whether the output tensor has :attr:`dim` retained or not. Default: ``False``.
+"""
+    },
 )
 
 single_dim_common = merge_dicts(
@@ -6483,8 +6488,8 @@ in the output tensors having 1 fewer dimension than ``input``.
 
 Args:
     {input}
-    {dim}
-    {keepdim} Default: ``False``.
+    {opt_dim}
+    {opt_keepdim}
 
 Keyword args:
     out (tuple, optional): the result tuple of two output tensors (max, max_indices)
@@ -6499,13 +6504,22 @@ Example::
             [-0.6172,  1.0036, -0.6060, -0.2432]])
     >>> torch.max(a, 1)
     torch.return_types.max(values=tensor([0.8475, 1.1949, 1.5717, 1.0036]), indices=tensor([3, 0, 0, 1]))
+    >>> a = torch.randn(3,1,3,)
+    >>> a.max(dim=0, keepdim=True)
+    torch.return_types.max(
+    values=tensor([[[1.2928, 1.4774, 0.8201]]]),
+    indices=tensor([[[2, 2, 1]]]))
+    >>> a.max(dim=0, keepdim=False)
+    torch.return_types.max(
+    values=tensor([[1.2928, 1.4774, 0.8201]]),
+    indices=tensor([[2, 2, 1]]))
 
 .. function:: max(input, other, *, out=None) -> Tensor
    :noindex:
 
 See :func:`torch.maximum`.
 
-""".format(**single_dim_common),
+""".format(**multi_dim_common),
 )
 
 add_docstr(


### PR DESCRIPTION
[`torch.max`](https://pytorch.org/docs/stable/generated/torch.max.html#torch.max) optional args `dim`, `keepdim` not described in document, but users can ignore them.

```python
>>> import torch
>>> a = torch.randn(3,1,3)
>>> a.max()
tensor(1.9145)
>>> a.max(dim=1)
torch.return_types.max(
values=tensor([[ 1.1436, -0.0728,  1.3312],
        [-0.4049,  0.1792, -1.2247],
        [ 0.8767, -0.7888,  1.9145]]),
indices=tensor([[0, 0, 0],
        [0, 0, 0],
        [0, 0, 0]]))

```

## Changes

- Add `optional` description for `dim`, `keepdim`
- Add example of using `dim`, `keepdim`

## Test Result

### Before

![image](https://github.com/user-attachments/assets/3391bc45-b636-4e64-9406-04d80af0c087)

### After

![image](https://github.com/user-attachments/assets/1d70e282-409c-4573-b276-b8219fd6ef0a)
