### PR TITLE
[torch] Make amdsmi cdll hook private

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -79,7 +79,7 @@ try:
             # already loaded version of amdsmi, or any version in the processes
             # rpath/LD_LIBRARY_PATH first, so that we only load a single copy
             # of the .so.
-            class amdsmi_cdll_hook:
+            class _amdsmi_cdll_hook:
                 def __init__(self) -> None:
                     self.original_CDLL = ctypes.CDLL  # type: ignore[misc,assignment]
                     paths = ["libamd_smi.so"]
@@ -104,7 +104,7 @@ try:
                 def __exit__(self, type: Any, value: Any, traceback: Any) -> None:
                     ctypes.CDLL = self.original_CDLL  # type: ignore[misc]
 
-            with amdsmi_cdll_hook():
+            with _amdsmi_cdll_hook():
                 import amdsmi  # type: ignore[import]
 
         _HAS_PYNVML = True


### PR DESCRIPTION
Summary: https://github.com/pytorch/pytorch/actions/runs/13314282597/job/37186177974 yelled at me for landing a seemingly public API that's not exported. It's a private API, so lets prepend `_` to make that clear

Test Plan: CI

Differential Revision: D69665234




cc @ptrblck @msaroufim @eqy