### PR TITLE
Skip unsupported types by MPS in `test_torchinductor.py`

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -188,6 +188,7 @@ for test_name in [
     "test_slice_scatter4",
     "test_softmax",
     "test_sort",
+    "test_split_cumsum",
     "test_sum_int",
     "test_sum_keepdims",
     "test_tanh",

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2019,7 +2019,11 @@ class CommonTemplate:
             if not self.is_dtype_supported(dtype):
                 continue
             # cumsum not implemented for integers on MacOS-13
-            if self.device == "mps" and not dtype.is_floating_point and MACOS_VERSION < 13.3:
+            if (
+                self.device == "mps"
+                and not dtype.is_floating_point
+                and MACOS_VERSION < 13.3
+            ):
                 continue
             # Use low=0 since when the mean value is 0, cumsum at all points
             # tends towards zero which makes the relative error term blow up
@@ -2088,7 +2092,11 @@ class CommonTemplate:
             if not self.is_dtype_supported(dtype):
                 continue
             # cumsum not implemented on MacOS-13
-            if self.device == "mps" and not dtype.is_floating_point and MACOS_VERSION < 13.3:
+            if (
+                self.device == "mps"
+                and not dtype.is_floating_point
+                and MACOS_VERSION < 13.3
+            ):
                 continue
             inp = _large_cumprod_input(
                 (10, 10000), dim=1, dtype=dtype, device=self.device

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2015,6 +2015,8 @@ class CommonTemplate:
             include_complex=False,
             include_half=False,
         ):
+            if not self.is_dtype_supported(dtype):
+                continue
             # Use low=0 since when the mean value is 0, cumsum at all points
             # tends towards zero which makes the relative error term blow up
             inp = make_tensor(10, 3, 352, 352, low=0, dtype=dtype, device=self.device)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #147266
* #147205
* __->__ #147211

- Skip unsupported dtypes in `test_split_cumsum` (and manually skip int64 for MacOS13)
- Adapt `test_cat` to use `torch.half` instead of `torch.double` on MPS
- Skip `test_adaptive_avg_pool1d_argmax` is avgpool is not implemented for all sizes
- 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov