### PR TITLE
Code Refactoring for getting start and stride from global ranks

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1009,39 +1009,10 @@ ProcessGroupNCCL::ProcessGroupNCCL(
             << ", TORCH_NCCL_LOG_CPP_STACK_ON_UNCLEAN_SHUTDOWN: "
             << logCppStackOnUncleanShutdown_;
 
-  if (options_->global_ranks_in_group.empty()) {
-    this->globalRankStart = 0;
-  } else {
-    this->globalRankStart =
-        static_cast<int>(options_->global_ranks_in_group[0]);
-  }
-
-  if (options_->global_ranks_in_group.empty()) {
-    this->globalRankStride = 1;
-  } else if (options_->global_ranks_in_group.size() == 1) {
-    this->globalRankStride = 0;
-  } else {
-    bool ranksAreStrided = true;
-    auto startRank = options_->global_ranks_in_group[0];
-    auto stride =
-        options_->global_ranks_in_group[1] - options_->global_ranks_in_group[0];
-    for (std::vector<uint64_t>::size_type i = 0;
-         i < options_->global_ranks_in_group.size();
-         i++) {
-      if (options_->global_ranks_in_group[i] != startRank + i * stride) {
-        ranksAreStrided = false;
-        break;
-      }
-    }
-
-    if (ranksAreStrided) {
-      this->globalRankStride = static_cast<int>(
-          options_->global_ranks_in_group[1] -
-          options_->global_ranks_in_group[0]);
-    } else {
-      this->globalRankStride = -1;
-    }
-  }
+  getGlobalRankStartAndStride(
+      options_->global_ranks_in_group,
+      this->globalRankStart,
+      this->globalRankStride);
 
   // Attach hooks to cache allocator to trigger the hooks whenever a traced
   // action is called. In the following hooks, we register a newly allocated

--- a/torch/csrc/distributed/c10d/Utils.cpp
+++ b/torch/csrc/distributed/c10d/Utils.cpp
@@ -26,4 +26,39 @@ size_t getTensorsNumel(const std::vector<at::Tensor>& tensors) {
   return numel;
 }
 
+void getGlobalRankStartAndStride(
+    const std::vector<uint64_t>& globalRanksInGroup,
+    int& globalRankStart,
+    int& globalRankStride) {
+  if (globalRanksInGroup.empty()) {
+    globalRankStart = 0;
+  } else {
+    globalRankStart = static_cast<int>(globalRanksInGroup[0]);
+  }
+
+  if (globalRanksInGroup.empty()) {
+    globalRankStride = 1;
+  } else if (globalRanksInGroup.size() == 1) {
+    globalRankStride = 0;
+  } else {
+    bool ranksAreStrided = true;
+    auto startRank = globalRanksInGroup[0];
+    auto stride = globalRanksInGroup[1] - globalRanksInGroup[0];
+    for (std::vector<uint64_t>::size_type i = 0; i < globalRanksInGroup.size();
+         i++) {
+      if (globalRanksInGroup[i] != startRank + i * stride) {
+        ranksAreStrided = false;
+        break;
+      }
+    }
+
+    if (ranksAreStrided) {
+      globalRankStride =
+          static_cast<int>(globalRanksInGroup[1] - globalRanksInGroup[0]);
+    } else {
+      globalRankStride = -1;
+    }
+  }
+}
+
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/Utils.hpp
+++ b/torch/csrc/distributed/c10d/Utils.hpp
@@ -558,6 +558,13 @@ size_t computeLengthsAndOffsets(
   return offset;
 }
 
+// Get the start and stride of the global rank from a list of global ranks
+// If the global ranks do not follow the consecutive rule, the stride will be -1
+void TORCH_API getGlobalRankStartAndStride(
+    const std::vector<uint64_t>& globalRanksInGroup,
+    int& globalRankStart,
+    int& globalRankStride);
+
 using RankType = uint32_t;
 using SizeType = uint64_t;
 


### PR DESCRIPTION
Summary: Code Refactoring for getting start and stride from global ranks, this function can be used in different collective backend.

Differential Revision: D69555405




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o