### PR TITLE
[Inductor][ROCm][CK] Unhardedcoded kernel shapes for ck_conv_template codegen

### DIFF
--- a/torch/_inductor/codegen/rocm/ck_conv_template.py
+++ b/torch/_inductor/codegen/rocm/ck_conv_template.py
@@ -11,6 +11,8 @@ try:
 except ImportError:
     ck4inductor = None
 
+
+
 if ck4inductor is not None:
     from ck4inductor.grouped_conv_fwd.gen_instances import (  # type: ignore[import]
         gen_conv_ops_library,
@@ -88,16 +90,13 @@ class CKGroupedConvFwdTemplate(CKTemplate):
 
         constexpr index_t NumDTensor = {{n_d_tensors}};
         constexpr index_t NDimSpatial = {{n_dim_spatial}};
-        constexpr index_t GroupCount = {{group_count}};
-        constexpr index_t NBatch = {{batch_size}};
-        constexpr index_t NOutChannels = {{n_output_channels}};
-        constexpr index_t NInChannels = {{n_input_channels}};
-        const std::vector<index_t> FilterSize = { {{filter_size}} };
-        const std::vector<index_t> InputSize = { {{input_size}} };
-        const std::vector<index_t> ConvolutionStrides = { {{convolution_strides}} };
-        const std::vector<index_t> Dilations = { {{dilations}} };
-        const std::vector<index_t> LeftPads = { {{left_pads}} };
-        const std::vector<index_t> RightPads = { {{right_pads}} };
+        const std::vector<index_t> FilterSize = { FilterSize_0, FilterSize_1 };
+        const std::vector<index_t> InputSize = { InputSize_0, InputSize_1 };
+        const std::vector<index_t> ConvolutionStrides = { ConvolutionStrides_0, ConvolutionStrides_1 };
+        const std::vector<index_t> Dilations = { Dilations_0, Dilations_1 };
+        const std::vector<index_t> LeftPads = { LeftPads_0, LeftPads_1 };
+        const std::vector<index_t> RightPads = { RightPads_0, RightPads_1 };
+
 
         auto conv_param = ck::utils::conv::ConvParam {
             NDimSpatial,
@@ -145,6 +144,8 @@ class CKGroupedConvFwdTemplate(CKTemplate):
         const auto cde_element_op = PassThrough {};
 
         auto copy = [](auto& x, auto& y) { ck::ranges::copy(x, y.begin()); };
+
+        // Ultimate Version
 
         copy(in_g_n_c_wis_desc.GetLengths(), a_g_n_c_wis_lengths);
         copy(in_g_n_c_wis_desc.GetStrides(), a_g_n_c_wis_strides);
@@ -531,6 +532,11 @@ class CKGroupedConvFwdTemplate(CKTemplate):
 
         instance_definition, instance_type = self.emit_ck_instance(op)
 
+        size_arg_strs = ["GroupCount", "NBatch", "NOutChannels", "NInChannels",
+                         "FilterSize_0", "FilterSize_1", "InputSize_0", "InputSize_1",
+                         "ConvolutionStrides_0", "ConvolutionStrides_1", "Dilations_0", "Dilations_1",
+                         "LeftPads_0", "LeftPads_1", "RightPads_0", "RightPads_1"]
+
         return self._template_from_string(self.conv_template).render(
             headers=self.header().getvalue(),
             globals=self.globals().getvalue(),
@@ -542,24 +548,33 @@ class CKGroupedConvFwdTemplate(CKTemplate):
                 names_str="input, weight, bias, output"
                 if Bias is not None
                 else "input, weight, output",
-                size_args=[],
+                size_args=[f"int32_t {arg}" for arg in size_arg_strs],
             ),
             n_d_tensors=1 if Bias is not None else 0,
             n_dim_spatial=self.n_spatial_dimensions,
-            group_count=self.groups,
-            batch_size=X.shape[0],  # type: ignore[index]
-            n_output_channels=Y.shape[1],  # type: ignore[index]
-            n_input_channels=X.shape[1],  # type: ignore[index]
-            filter_size=", ".join(map(str, W.shape[2:])),  # type: ignore[index]
-            input_size=", ".join(map(str, X.shape[2:])),  # type: ignore[index]
-            convolution_strides=", ".join(map(str, self.stride)),
-            dilations=", ".join(map(str, self.dilation)),
-            left_pads=", ".join(map(str, self.padding)),
-            right_pads=", ".join(map(str, self.padding)),
             input_layout=op.a_layout,
             weight_layout=op.b_layout,
             output_layout=op.e_layout,
         )
 
     def size_args(self):
-        return []
+
+        X, W = self.input_nodes[0], self.input_nodes[1]
+        Y = self.output_node
+
+        GroupCount = self.groups
+        NBatch = X.shape[0] 
+        NOutChannels = Y.shape[1]
+        NInChannels = X.shape[1]
+
+        FilterSize_0, FilterSize_1 = W.shape[2:4]
+        InputSize_0, InputSize_1 = X.shape[2:4]
+        ConvolutionStrides_0, ConvolutionStrides_1 = self.stride
+        Dilations_0, Dilations_1 = self.dilation
+        LeftPads_0, LeftPads_1 = self.padding
+        RightPads_0, RightPads_1 = self.padding
+
+        return GroupCount, NBatch, NOutChannels, NInChannels, \
+               FilterSize_0, FilterSize_1, InputSize_0, InputSize_1, \
+               ConvolutionStrides_0, ConvolutionStrides_1, Dilations_0, Dilations_1, \
+               LeftPads_0, LeftPads_1, RightPads_0, RightPads_1

--- a/torch/_inductor/codegen/rocm/ck_conv_template.py
+++ b/torch/_inductor/codegen/rocm/ck_conv_template.py
@@ -11,8 +11,6 @@ try:
 except ImportError:
     ck4inductor = None
 
-
-
 if ck4inductor is not None:
     from ck4inductor.grouped_conv_fwd.gen_instances import (  # type: ignore[import]
         gen_conv_ops_library,
@@ -144,8 +142,6 @@ class CKGroupedConvFwdTemplate(CKTemplate):
         const auto cde_element_op = PassThrough {};
 
         auto copy = [](auto& x, auto& y) { ck::ranges::copy(x, y.begin()); };
-
-        // Ultimate Version
 
         copy(in_g_n_c_wis_desc.GetLengths(), a_g_n_c_wis_lengths);
         copy(in_g_n_c_wis_desc.GetStrides(), a_g_n_c_wis_strides);


### PR DESCRIPTION
## [Inductor][ROCm][CK] Parameterize `ck_conv_template` Codegen  

### Description  
Previously, ROCm CK kernel codegen templates were hardcoded with fixed values for convolution parameters:  

- `index_t GroupCount`  
- `index_t NBatch`  
- `index_t NOutChannels`  
- `index_t NInChannels`  
- `vector<index_t> FilterSize`  
- `vector<index_t> InputSize`  
- `vector<index_t> ConvolutionStrides`  
- `vector<index_t> Dilations`  
- `vector<index_t> LeftPads`  
- `vector<index_t> RightPads`  

This PR updates `ck_conv_template` to accept these parameters dynamically from Inductor. By doing so, we reduce the number of generated templates, improving flexibility and maintainability.  

### Testing  
- Verified correctness by running relevant test cases, i.e test/inductor/test_ck_backend.py
- Ensured generated kernels reflect the updated parameterization, i.e generated templates in /tmp/torchinductor_root/


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov