### PR TITLE
[inductor] Don't leak pointers to cpp_wrapper with lru_cache

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -66,6 +66,10 @@ class CppWrapperCpu(PythonWrapperCodegen):
         # For GEMM kernels that must be initialized and are resolved at linking.
         self.initialized_kernels: dict[str, Kernel] = {}
         self.device_codegen = get_device_op_overrides(self.device)
+        # only need to include each header once
+        self.include_extra_header = functools.lru_cache(None)(  # type: ignore[method-assign]
+            self._include_extra_header
+        )
 
     @staticmethod
     def create(
@@ -177,8 +181,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
             # does not provide any ABI compatibility promise.
             self.header.splice("#include <ATen/record_function.h>")
 
-    @functools.lru_cache(None)  # noqa: B019
-    def include_extra_header(self, header: str):
+    def _include_extra_header(self, header: str):
         # This is needed for cpp to python dtype conversion
         self.header.splice(f"#include <{header}>")
 

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -1,8 +1,7 @@
 # mypy: allow-untyped-defs
-import functools
 import os
 from itertools import chain, count, zip_longest
-from typing import Any, Callable, Optional, TYPE_CHECKING, Union
+from typing import Any, Callable, Hashable, Optional, TYPE_CHECKING, Union
 
 import sympy
 
@@ -14,7 +13,7 @@ from torch._inductor.runtime.triton_heuristics import grid as default_grid_fn
 from .. import config
 from ..codecache import CudaKernelParamCache
 from ..ir import IRNode, TensorBox
-from ..utils import DeferredLineBase, get_gpu_type, GPU_ALIGN_BYTES
+from ..utils import cache_on_self, DeferredLineBase, get_gpu_type, GPU_ALIGN_BYTES
 from ..virtualized import V
 from .aoti_hipify_utils import maybe_hipify_code_wrapper
 from .common import get_device_op_overrides
@@ -188,6 +187,7 @@ class CppWrapperGpu(CppWrapperCpu):
         self.device_codegen = get_device_op_overrides(self.device)
         super().__init__()
         self.grid_id = count()
+        self._load_kernel_cache: dict[Hashable, str] = {}
 
     @staticmethod
     def create(
@@ -209,7 +209,7 @@ class CppWrapperGpu(CppWrapperCpu):
             maybe_hipify_code_wrapper(self.device_codegen.kernel_driver())
         )
 
-    @functools.lru_cache(None)  # noqa: B019
+    @cache_on_self
     def write_tma_descriptor_helpers_once(self):
         self.header.splice(self.device_codegen.tma_descriptor_helpers())
 
@@ -374,14 +374,18 @@ class CppWrapperGpu(CppWrapperCpu):
         args = f"&{desc_name}, {ptr}, {dims}, {block_dims}, {element_size}"
         self.writeline(f"{fn}({args});")
 
-    @functools.lru_cache(None)  # noqa: B019
     def generate_load_kernel_once(
         self,
         kernel_name: str,
         graph: "GraphLowering",  # for per-graph caching
     ):
-        keys = (get_cpp_wrapper_cubin_path_name(), "mangled_name", "shared_mem")
+        cache_key = (kernel_name, graph)
+        if cache_key in self._load_kernel_cache:
+            return self._load_kernel_cache[cache_key]
         kernel_var_name = f"kernels.{kernel_name}" if V.graph.aot_mode else kernel_name
+        self._load_kernel_cache[cache_key] = kernel_var_name
+
+        keys = (get_cpp_wrapper_cubin_path_name(), "mangled_name", "shared_mem")
         self.writeline(f"if ({kernel_var_name} == nullptr) {{")
         deferred_gpu_kernel_line = DeferredGpuKernelLine(
             kernel_name,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #147251
* __->__ #147233

Putting lru_cache on methods will keep pointers to the `self` objects
alive forever and leak memory.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov