### PR TITLE
logging: close handler after removing it

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -932,6 +932,7 @@ def _clear_handlers(log):
     to_remove = [handler for handler in log.handlers if _is_torch_handler(handler)]
     for handler in to_remove:
         log.removeHandler(handler)
+        handler.close()
 
 
 def _reset_logs():


### PR DESCRIPTION
Fixes

```python
import unittest
import os
import tempfile
import torch
import tracemalloc

tracemalloc.start(10)

class Test(unittest.TestCase):
    def test(self):   
        with tempfile.TemporaryDirectory() as temp_dir:
            os.environ["TORCH_LOGS_OUT"] = f"{temp_dir}/test.log"
            torch._logging._init_logs()
            del os.environ["TORCH_LOGS_OUT"]

        torch._logging._init_logs()

if __name__ == "__main__":
    unittest.main()
```

which currently prints

```
/home/user/venv/lib/python3.12/site-packages/torch/_logging/_internal.py:907: ResourceWarning: unclosed file <_io.TextIOWrapper name='/var/folders/nw/7yk3mnls5tvcvnyvn9x4q5480000gp/T/tmpvhd39_5f/test.log' mode='a' encoding='UTF-8'>
  _clear_handlers(log)
Object allocated at (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/unittest/suite.py", lineno 122
    test(result)
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/unittest/case.py", lineno 690
    return self.run(*args, **kwds)
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/unittest/case.py", lineno 634
    self._callTestMethod(testMethod)
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/unittest/case.py", lineno 589
    if method() is not None:
  File "/home/user/tmp.py", lineno 13
    torch._logging._init_logs()
  File "/home/user/venv/lib/python3.12/site-packages/torch/_logging/_internal.py", lineno 963
    _setup_handlers(
  File "/home/user/venv/lib/python3.12/site-packages/torch/_logging/_internal.py", lineno 874
    debug_handler = _track_handler(create_handler_fn())
  File "/home/user/venv/lib/python3.12/site-packages/torch/_logging/_internal.py", lineno 964
    lambda: logging.FileHandler(log_file_name),
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", lineno 1231
    StreamHandler.__init__(self, self._open())
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", lineno 1263
    return open_func(self.baseFilename, self.mode,
```