### PR TITLE
[apf] Fix input adapter

### DIFF
--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -300,6 +300,7 @@ class UnflattenedModule(torch.nn.Module):
         self.flat_args_adapter = flat_args_adapter
 
         self.meta = export_module.graph_module.meta
+        self.meta["unflattened_module"] = self
 
         # Flag to indicate whether args have been adapted.
         self.adapted = False


### PR DESCRIPTION
Summary: Add support for inputs that no longer exist in `input_fields`, but is not actually used by the original program. In this case, we just give it a dummy input based on the node's metadata.

Test Plan: Verified for S488841

Differential Revision: D69328093


