### PR TITLE
dynamo: Don't crash when encountering a object with no __name__

### DIFF
--- a/test/dynamo/test_compile.py
+++ b/test/dynamo/test_compile.py
@@ -203,6 +203,15 @@ class InPlaceCompilationTests(TestCase):
         with self.assertRaises(AttributeError):
             opt_mod(x)
 
+    def test_torch_script_compilation(self):
+        @torch.jit.script
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            return x
+
+        a = torch.randn(1, 1)
+        out = torch.compile(fn)(a)
+        self.assertEqual(out, a)
+
 
 # The private variants of the below functions are extensively tested
 # So as long as the signatures match we're good

--- a/test/dynamo/test_trace_rules.py
+++ b/test/dynamo/test_trace_rules.py
@@ -15,13 +15,18 @@ import torch._functorch.deprecated as deprecated_func
 from torch._dynamo.trace_rules import (
     LEGACY_MOD_INLINELIST,
     load_object,
+    lookup_inner,
     manual_torch_name_rule_map,
     MOD_INLINELIST,
     torch_c_binding_in_graph_functions,
     torch_non_c_binding_in_graph_functions,
 )
 from torch._dynamo.utils import hashable, is_safe_constant, istype
-from torch._dynamo.variables import TorchInGraphFunctionVariable, UserFunctionVariable
+from torch._dynamo.variables import (
+    SkipFunctionVariable,
+    TorchInGraphFunctionVariable,
+    UserFunctionVariable,
+)
 from torch.testing._internal.common_utils import skipIfWindows
 
 
@@ -473,6 +478,18 @@ class TraceRuleTests(torch._dynamo.test_case.TestCase):
                     "Otherwise, add it to `manual_torch_name_rule_map` instead."
                 ),
             )
+
+    def test_almost_impossible_missing_name(self):
+        class weird:  # noqa: UP004
+            def __getattribute__(self, name):
+                if name == "__name__":
+                    raise AttributeError("test")
+
+        w = weird()
+        o = set()
+        with self.assertRaises(AttributeError):
+            w.__name__
+        self.assertEqual(lookup_inner(w, name=None, reasons=o), SkipFunctionVariable)
 
 
 class TestModuleSurviveSkipFiles(torch._dynamo.test_case.TestCase):

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3763,7 +3763,7 @@ def lookup_inner(
                 reasons.add("func name is patched_init")
             return SkipFunctionVariable
         elif name == "__torch_function__" or (
-            obj and obj.__name__ == "__torch_function__"
+            obj and getattr(obj, "__name__", None) == "__torch_function__"
         ):
             if reasons is not None:
                 reasons.add("func name is __torch_function__")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147246

This was triggering on ScriptFunctions. Note that other than badly implemented c functiosn, this seems to be almost impossible to trigger, so I wrote a smaller unit test, rather than a full repro. Let me know if people feel strongly and want a full reproduction.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames