### PR TITLE
Add the memory and dispatch to the logging module.

### DIFF
--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -52,6 +52,8 @@ register_log(
         "torch._export.serde.serialize",
     ],
 )
+register_log("memory", "torch.memory")
+register_log("dispatch", "torch.dispatch")
 
 register_artifact(
     "guards",


### PR DESCRIPTION
We want to print logs for the memory and dispatch separately. Therefore, the memory and dispatch log modules are added to this PR.