### PR TITLE
[Pyper] Enable GQA in PMA module

### DIFF
--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -265,7 +265,8 @@ def sdpa_flop_count(query_shape, key_shape, value_shape):
     b, h, s_q, d_q = query_shape
     _b2, _h2, s_k, _d2 = key_shape
     _b3, _h3, _s3, d_v = value_shape
-    assert b == _b2 == _b3 and h == _h2 == _h3 and d_q == _d2 and s_k == _s3 and d_q == _d2
+    # under gqa, h is not necessarily equal to h2 and h3
+    assert b == _b2 == _b3 and _h2 == _h3 and d_q == _d2 and s_k == _s3
     total_flops = 0
     # q: [b, h, s_q, d_q] @ k: [b, h, d_q, s_k] -> scores: [b, h, s_q, s_k]
     total_flops += bmm_flop((b * h, s_q, d_q), (b * h, d_q, s_k))
@@ -459,7 +460,8 @@ def sdpa_backward_flop_count(grad_out_shape, query_shape, key_shape, value_shape
     _b2, _h2, s_k, _d2 = key_shape
     _b3, _h3, _s3, d_v = value_shape
     _b4, _h4, _s4, _d4 = grad_out_shape
-    assert b == _b2 == _b3 == _b4 and h == _h2 == _h3 == _h4 and d_q == _d2
+    # under gqa, h is not necessarily equal to h2 and h3
+    assert b == _b2 == _b3 == _b4 and _h2 == _h3 and h == _h4 and d_q == _d2
     assert d_v == _d4 and s_k == _s3 and s_q == _s4
     total_flops = 0
     # Step 1: We recompute the scores matrix.


### PR DESCRIPTION
Summary: Add an option to use gqa instead of pma

Test Plan:
# how to set gqa

```
def enable_gqa(job):
    job = job.set_arg_path("arch.mtml_model.shared_arch.pytorch_interformer.interformer.interformer_config.megaformer_config.use_gqa", True)
    return job
```

# local reproduce
```
CUDA_VISIBLE_DEVICES=5 buck2 run mode/opt //aps_models/ads/ecosystem/tooling/tools/efficient_module_suite/pyper_models:pyper_model_perf_benchmark -- --flow_id 688722956 --shrink_model --mfu_profile_module "impl.shared_arch.pytorch_dhen.interformer" --use_synthetic_data
```

| Metric             | Value      |
|:-------------------|:-----------|
| Batch size         | 10         |
| GPU type           | H100       |
| Latency            | 124.48 ms  |
| Model size         | 2035.85 MB |
| Flops              | 35.04 G    |
| Flops/example      | 3.50 G     |
| TFLOPS/sec         | 0.28       |
| MFU                | 0.04%      |
| Activation/example | 201.19 MB  |

Trace link: https://our.intern.facebook.com/intern/perfdoctor/trace_view?filepath=tree/traces/efficient_module_suite/mtml_link_click_model.Feb_14_14_35_39_trace.json.gz&bucket=pyper_traces
snapshot link: https://www.internalfb.com/manifold/explorer/ai_efficiency/tree/gpu_snapshot/mtml_link_click_model.Feb_14_14_35_39.snapshot.pickle


# E2E

Differential Revision: D69557675


