### PR TITLE
Do not use username for inductor default_cache_dir

### DIFF
--- a/torch/_inductor/runtime/cache_dir_utils.py
+++ b/torch/_inductor/runtime/cache_dir_utils.py
@@ -16,10 +16,9 @@ def cache_dir() -> str:
 
 
 def default_cache_dir() -> str:
-    sanitized_username = re.sub(r'[\\/:*?"<>|]', "_", getpass.getuser())
     return os.path.join(
         tempfile.gettempdir(),
-        "torchinductor_" + sanitized_username,
+        "torchinductor_cache_dir"
     )
 
 


### PR DESCRIPTION
The existing approach of using the session username fails when:

1. There is no username for the current session
2. The username includes one or more spaces (compile fails)

Unless there's an important reason why this needs to be based on username, it seems much cleaner to just use "torchinductor_cache_dir", which fixes all of the above issues.

If there is an important reason for this, please let me know.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov