### PR TITLE
[BE] Switch all structured funcs to stubs

### DIFF
--- a/aten/src/ATen/native/mps/operations/UnaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryKernel.mm
@@ -1,16 +1,8 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/TensorIterator.h>
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/UnaryOps.h>
 #include <ATen/native/mps/OperationUtils.h>
-#ifndef AT_PER_OPERATOR_HEADERS
-#include <ATen/Functions.h>
-#include <ATen/NativeFunctions.h>
-#else
-#include <ATen/ops/erfinv_native.h>
-#include <ATen/ops/exp_native.h>
-#include <ATen/ops/sinc_native.h>
-#include <ATen/ops/tanh_native.h>
-#endif
 
 #include <fmt/format.h>
 
@@ -69,26 +61,30 @@ static void exec_unary_kernel(const Tensor& self,
     output_.copy_(outputTensor);
   }
 }
-TORCH_IMPL_FUNC(erfinv_out_mps)(const Tensor& self, const Tensor& output_) {
-  TORCH_CHECK(self.scalar_type() != ScalarType::Double, "MPS does not support erfinv op with scalar type: Double");
-  exec_unary_kernel(self, output_, "erfinv");
+
+static void erfinv_kernel(TensorIteratorBase& iter) {
+  exec_unary_kernel(iter.input(0), iter.output(0), "erfinv");
 }
 
-TORCH_IMPL_FUNC(exp_out_mps)(const Tensor& self, const Tensor& output_) {
-  exec_unary_kernel(self, output_, "exp");
+static void exp_kernel(TensorIteratorBase& iter) {
+  exec_unary_kernel(iter.input(0), iter.output(0), "exp");
 }
 
-TORCH_IMPL_FUNC(sinc_out_mps)(const Tensor& self, const Tensor& output_) {
-  exec_unary_kernel(self, output_, "sinc");
+static void sinc_kernel(TensorIteratorBase& iter) {
+  exec_unary_kernel(iter.input(0), iter.output(0), "sinc");
 }
 
-TORCH_IMPL_FUNC(tanh_out_mps)(const Tensor& self, const Tensor& output_) {
-  exec_unary_kernel(self, output_, "tanh");
+static void tanh_kernel(TensorIteratorBase& iter) {
+  exec_unary_kernel(iter.input(0), iter.output(0), "tanh");
 }
 
 static void round_decimals_kernel(TensorIteratorBase& iter, int64_t decimals) {
   exec_unary_kernel(iter.input(0), iter.output(0), "round_decimals", decimals);
 }
 
+REGISTER_DISPATCH(exp_stub, exp_kernel);
+REGISTER_DISPATCH(erfinv_stub, erfinv_kernel);
+REGISTER_DISPATCH(sinc_stub, sinc_kernel);
+REGISTER_DISPATCH(tanh_stub, tanh_kernel);
 REGISTER_DISPATCH(round_decimals_stub, round_decimals_kernel);
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2577,8 +2577,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA: exp_out
-    MPS: exp_out_mps
+    CPU, CUDA, MPS: exp_out
   tags: pointwise
 
 - func: exp2(Tensor self) -> Tensor
@@ -5382,8 +5381,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA: sinc_out
-    MPS: sinc_out_mps
+    CPU, CUDA, MPS: sinc_out
   tags: pointwise
 
 - func: sinh(Tensor self) -> Tensor
@@ -6055,8 +6053,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA: tanh_out
-    MPS: tanh_out_mps
+    CPU, CUDA, MPS: tanh_out
     SparseCPU, SparseCUDA: tanh_sparse_out
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta: tanh_sparse_csr_out
   tags: pointwise
@@ -9611,8 +9608,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA: erfinv_out
-    MPS: erfinv_out_mps
+    CPU, CUDA, MPS: erfinv_out
     SparseCPU, SparseCUDA: erfinv_sparse_out
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta: erfinv_sparse_csr_out
   tags: pointwise


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #147299
* #147297
* __->__ #147296

No need to have separate foobar_out_mps when registering a dispatch to  foobar_stub will do

And this makes `exec_unary_kernel` defined in UnaryKernel.mm and
SpecialOps.mm look very similar