### PR TITLE
[Inductor][CPP] Add the legalize low fp support for index expr

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1001,10 +1001,11 @@ class CPUReproTests(TestCase):
 
     def test_low_fp_index_expr_issue_147279(self):
         # https://github.com/pytorch/pytorch/issues/147279
-        def fn(*args):
-            sym_0, sym_1, sym_2, sym_3 = args
-            var_228 = torch.arange(start=sym_0, end=sym_1, dtype=sym_2)
-            return torch.sum(var_228, dim=sym_3)
+        def fn(start, end, dtype, dim):
+            return torch.sum(
+                torch.arange(start=start, end=end, dtype=dtype),
+                dim=dim,
+            )
 
         self.common(
             fn,

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -999,6 +999,18 @@ class CPUReproTests(TestCase):
             (torch.randn(8),),
         )
 
+    def test_low_fp_index_expr_issue_147279(self):
+        # https://github.com/pytorch/pytorch/issues/147279
+        def fn(*args):
+            sym_0, sym_1, sym_2, sym_3 = args
+            var_228 = torch.arange(start=sym_0, end=sym_1, dtype=sym_2)
+            return torch.sum(var_228, dim=sym_3)
+
+        self.common(
+            fn,
+            (300, 400, torch.float16, (0,)),
+        )
+
     def test_index_put(self):
         # https://github.com/pytorch/pytorch/issues/138908
         def fn(x, y):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -3721,9 +3721,7 @@ class CppKernelProxy(CppKernel):
                 if node.target == "load":
                     assert len(node.args) == 3
                     return V.graph.get_dtype(node.args[1])  # type: ignore[arg-type]
-                elif node.target == "constant":
-                    return node.args[-1]  # type: ignore[return-value]
-                elif node.target == "to_dtype":
+                elif node.target in ["to_dtype", "constant", "index_expr"]:
                     return node.args[-1]  # type: ignore[return-value]
                 elif node.target == "to_dtype_bitcast":
                     return node.args[2]  # type: ignore[return-value]
@@ -3758,7 +3756,7 @@ class CppKernelProxy(CppKernel):
             to_lowp_fp_legalized_nodes = []
             for _node in sub_graph_nodes:
                 if (
-                    _node.target == "load"
+                    _node.target in ["load", "index_expr"]
                     and (dt := get_output_dtype(_node)) in DTYPE_LOWP_FP
                 ):
                     # No need to promote to float if all users are ops that accepts lowp fp input


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147298

**Summary**
Fix issue: https://github.com/pytorch/pytorch/issues/147279. The test case produced a low-precision floating-point value using `ops.index_expr`, but the CPP backend did not handle its legalization. This PR adds support for it.

**Test Plan**
```
python -u -m pytest -s -v test/inductor/test_cpu_repro.py -k test_low_fp_index_expr_issue_147279
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov