### PR TITLE
[MPS][BE] Turn `exec_unary_kernel` as MetalShaderLibrary method

### DIFF
--- a/aten/src/ATen/native/mps/MetalShaderLibrary.h
+++ b/aten/src/ATen/native/mps/MetalShaderLibrary.h
@@ -21,10 +21,11 @@ typedef void* MTLComputeCommandEncoder_t;
 #include <utility>
 #include <vector>
 
-// Forward declaration of TensorBase
+// Forward declaration of TensorBase and TensorIteratorBase
 namespace at {
 class TensorBase;
-}
+struct TensorIteratorBase;
+} // namespace at
 
 namespace at::native::mps {
 
@@ -128,6 +129,10 @@ class MetalShaderLibrary {
     return getLibraryPipelineState(getLibrary(params), fname).second;
   }
   static MetalShaderLibrary& getBundledLibrary();
+  void exec_unary_kernel(
+      TensorIteratorBase& iter,
+      const std::string& name,
+      std::optional<int64_t> extra = std::nullopt);
 
  protected:
   virtual MTLLibrary_t getLibrary();

--- a/aten/src/ATen/native/mps/kernels/SpecialOps.metal
+++ b/aten/src/ATen/native/mps/kernels/SpecialOps.metal
@@ -1,37 +1,37 @@
 #include <c10/metal/special_math.h>
 
-template <typename T, typename Tout = T>
+template <typename T0, typename T1>
 void kernel
-i0(constant T* input,
-   device Tout* output,
+i0(device T0* output,
+   constant T1* input,
    uint index [[thread_position_in_grid]]) {
-  output[index] = c10::metal::i0(static_cast<Tout>(input[index]));
+  output[index] = c10::metal::i0(static_cast<T0>(input[index]));
 }
 
-template <typename T, typename Tout = T>
+template <typename T0, typename T1>
 void kernel
-i1(constant T* input,
-   device Tout* output,
+i1(device T0* output,
+   constant T1* input,
    uint index [[thread_position_in_grid]]) {
-  output[index] = c10::metal::i1(static_cast<Tout>(input[index]));
+  output[index] = c10::metal::i1(static_cast<T0>(input[index]));
 }
 
-template <typename T, typename Tout = T>
+template <typename T0, typename T1>
 void kernel spherical_bessel_j0(
-    constant T* input,
-    device Tout* output,
+    device T0* output,
+    constant T1* input,
     uint index [[thread_position_in_grid]]) {
   output[index] =
-      c10::metal::spherical_bessel_j0(static_cast<Tout>(input[index]));
+      c10::metal::spherical_bessel_j0(static_cast<T0>(input[index]));
 }
 
 #define REGISTER_I0_I1(DTI, DTO)                                           \
-  template [[host_name("i0_" #DTI "_" #DTO)]] void kernel i0<DTI, DTO>(    \
-      constant DTI*, device DTO*, uint);                                   \
-  template [[host_name("i1_" #DTI "_" #DTO)]] void kernel i1<DTI, DTO>(    \
-      constant DTI*, device DTO*, uint);                                   \
-  template [[host_name("spherical_bessel_j0_" #DTI "_" #DTO)]] void kernel \
-  spherical_bessel_j0<DTI, DTO>(constant DTI*, device DTO*, uint);
+  template [[host_name("i0_" #DTO "_" #DTI)]] void kernel i0<DTO, DTI>(    \
+      device DTO*, constant DTI*, uint);                                   \
+  template [[host_name("i1_" #DTO "_" #DTI)]] void kernel i1<DTO, DTI>(    \
+      device DTO*, constant DTI*, uint);                                   \
+  template [[host_name("spherical_bessel_j0_" #DTO "_" #DTI)]] void kernel \
+  spherical_bessel_j0<DTO, DTI>(device DTO*, constant DTI*, uint);
 
 REGISTER_I0_I1(float, float);
 REGISTER_I0_I1(bool, float);

--- a/aten/src/ATen/native/mps/operations/UnaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryKernel.mm
@@ -14,71 +14,24 @@ static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
 #include <ATen/native/mps/UnaryKernel_metallib.h>
 #endif
 
-static void exec_unary_kernel(TensorIteratorBase& iter,
-                              const std::string& name,
-                              std::optional<int64_t> extra = std::nullopt) {
-  auto inputTensor = iter.input(0).contiguous();
-  auto outputTensor = iter.output(0);
-  bool needs_output_copy = false;
-  uint32_t length = outputTensor.numel();
-  if (length == 0) {
-    return;
-  }
-  using namespace mps;
-  @autoreleasepool {
-    id<MTLComputePipelineState> cplState = nil;
-    if (c10::isComplexType(inputTensor.scalar_type())) {
-      auto scalarStr = inputTensor.scalar_type() == kComplexFloat ? "float" : "half";
-      cplState = lib.getPipelineStateForFunc(fmt::format("{}_complex_{}_{}", name, scalarStr, scalarStr));
-    } else {
-      cplState = lib.getPipelineStateForFunc(
-          fmt::format("{}_{}_{}", name, scalarToMetalTypeString(outputTensor), scalarToMetalTypeString(inputTensor)));
-    }
-
-    if (!outputTensor.is_contiguous()) {
-      outputTensor = outputTensor.contiguous();
-      needs_output_copy = true;
-    }
-
-    MPSStream* mpsStream = getCurrentMPSStream();
-    dispatch_sync(mpsStream->queue(), ^() {
-      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-
-      getMPSProfiler().beginProfileKernel(cplState, name, {inputTensor});
-
-      [computeEncoder setComputePipelineState:cplState];
-      mtl_setArgs(computeEncoder, outputTensor, inputTensor);
-      if (extra) {
-        mtl_setBytes(computeEncoder, *extra, 2);
-      }
-      mtl_dispatch1DJob(computeEncoder, cplState, length);
-
-      getMPSProfiler().endProfileKernel(cplState);
-    });
-  }
-  if (needs_output_copy) {
-    iter.output(0).copy_(outputTensor);
-  }
-}
-
 static void erfinv_kernel(TensorIteratorBase& iter) {
-  exec_unary_kernel(iter, "erfinv");
+  lib.exec_unary_kernel(iter, "erfinv");
 }
 
 static void exp_kernel(TensorIteratorBase& iter) {
-  exec_unary_kernel(iter, "exp");
+  lib.exec_unary_kernel(iter, "exp");
 }
 
 static void sinc_kernel(TensorIteratorBase& iter) {
-  exec_unary_kernel(iter, "sinc");
+  lib.exec_unary_kernel(iter, "sinc");
 }
 
 static void tanh_kernel(TensorIteratorBase& iter) {
-  exec_unary_kernel(iter, "tanh");
+  lib.exec_unary_kernel(iter, "tanh");
 }
 
 static void round_decimals_kernel(TensorIteratorBase& iter, int64_t decimals) {
-  exec_unary_kernel(iter, "round_decimals", decimals);
+  lib.exec_unary_kernel(iter, "round_decimals", decimals);
 }
 
 REGISTER_DISPATCH(exp_stub, exp_kernel);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147299
* #147297
* #147296

And delete duplicate implementations from SpecialOps and UnaryKernel.
Change input and output arguments order for SpecialOps kernels to match those of UnaryOps

Fixes https://github.com/pytorch/pytorch/issues/146770