### PR TITLE
Remove deprecate method and attirbute in `LRScheduler`

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2359,47 +2359,6 @@ class TestLRScheduler(TestCase):
             ConstantLR,
             LinearLR,
             partial(ExponentialLR, gamma=0.9),
-            lambda opt, **kwargs: SequentialLR(
-                opt,
-                schedulers=[ConstantLR(opt), ConstantLR(opt)],
-                milestones=[2],
-                **kwargs,
-            ),
-            PolynomialLR,
-            partial(CosineAnnealingLR, T_max=10),
-            ReduceLROnPlateau,
-            partial(CyclicLR, base_lr=0.01, max_lr=0.1),
-            partial(CosineAnnealingWarmRestarts, T_0=20),
-            partial(OneCycleLR, max_lr=0.01, total_steps=10),
-        ],
-    )
-    def test_lr_scheduler_verbose_deprecation_warning(self, LRClass):
-        """Check that a deprecating warning with verbose parameter."""
-        with self.assertWarnsOnceRegex(
-            UserWarning, "The verbose parameter is deprecated"
-        ):
-            LRClass(self.opt, verbose=True)
-
-        with self.assertWarnsOnceRegex(
-            UserWarning, "The verbose parameter is deprecated"
-        ):
-            LRClass(self.opt, verbose=False)
-
-        # No warning is raised when verbose is the default value.
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
-            LRClass(self.opt)
-
-    @parametrize(
-        "LRClass",
-        [
-            partial(LambdaLR, lr_lambda=lambda e: e // 10),
-            partial(MultiplicativeLR, lr_lambda=lambda: 0.95),
-            partial(StepLR, step_size=30),
-            partial(MultiStepLR, milestones=[30, 80]),
-            ConstantLR,
-            LinearLR,
-            partial(ExponentialLR, gamma=0.9),
             PolynomialLR,
             partial(CosineAnnealingLR, T_max=10),
             lambda opt, **kwargs: ChainedScheduler(

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -53,18 +53,6 @@ EPOCH_DEPRECATION_WARNING = (
 )
 
 
-def _check_verbose_deprecated_warning(verbose):
-    """Raise a warning when verbose is not the default value."""
-    if verbose != "deprecated":
-        warnings.warn(
-            "The verbose parameter is deprecated. Please use get_last_lr() "
-            "to access the learning rate.",
-            UserWarning,
-        )
-        return verbose
-    return False
-
-
 def _format_param(name: str, optimizer: Optimizer, param):
     """Return correctly formatted lr/momentum for each param group."""
 
@@ -92,7 +80,6 @@ class LRScheduler:
         self,
         optimizer: Optimizer,
         last_epoch: int = -1,
-        verbose="deprecated",
     ):  # noqa: D107
         # Attach optimizer
         if not isinstance(optimizer, Optimizer):
@@ -142,7 +129,6 @@ class LRScheduler:
             opt.step = wrap_step(opt.step)  # type: ignore[method-assign]
 
         patch_track_step_called(self.optimizer)
-        self.verbose = _check_verbose_deprecated_warning(verbose)
         self._initial_step()
 
     def _initial_step(self):
@@ -267,12 +253,6 @@ class LambdaLR(LRScheduler):
             factor given an integer parameter epoch, or a list of such
             functions, one for each group in optimizer.param_groups.
         last_epoch (int): The index of last epoch. Default: -1.
-        verbose (bool | str): If ``True``, prints a message to stdout for
-            each update. Default: ``False``.
-
-            .. deprecated:: 2.2
-                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
-                learning rate.
 
     Example:
         >>> # xdoctest: +SKIP
@@ -291,7 +271,6 @@ class LambdaLR(LRScheduler):
         optimizer: Optimizer,
         lr_lambda: Union[Callable[[int], float], list[Callable[[int], float]]],
         last_epoch: int = -1,
-        verbose="deprecated",
     ):  # noqa: D107
         self.optimizer = optimizer
 
@@ -304,7 +283,7 @@ class LambdaLR(LRScheduler):
                     f"Expected {len(optimizer.param_groups)} lr_lambdas, but got {len(lr_lambda)}"
                 )
             self.lr_lambdas = list(lr_lambda)
-        super().__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch)
 
     def state_dict(self):
         """Return the state of the scheduler as a :class:`dict`.
@@ -369,12 +348,6 @@ class MultiplicativeLR(LRScheduler):
             factor given an integer parameter epoch, or a list of such
             functions, one for each group in optimizer.param_groups.
         last_epoch (int): The index of last epoch. Default: -1.
-        verbose (bool | str): If ``True``, prints a message to stdout for
-            each update. Default: ``False``.
-
-            .. deprecated:: 2.2
-                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
-                learning rate.
 
     Example:
         >>> # xdoctest: +SKIP
@@ -391,7 +364,6 @@ class MultiplicativeLR(LRScheduler):
         optimizer: Optimizer,
         lr_lambda: Union[Callable[[int], float], list[Callable[[int], float]]],
         last_epoch: int = -1,
-        verbose="deprecated",
     ):  # noqa: D107
         self.optimizer = optimizer
 
@@ -404,7 +376,7 @@ class MultiplicativeLR(LRScheduler):
                     f"Expected {len(optimizer.param_groups)} lr_lambdas, but got {len(lr_lambda)}"
                 )
             self.lr_lambdas = list(lr_lambda)
-        super().__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch)
 
     def state_dict(self):
         """Return the state of the scheduler as a :class:`dict`.
@@ -469,12 +441,6 @@ class StepLR(LRScheduler):
         gamma (float): Multiplicative factor of learning rate decay.
             Default: 0.1.
         last_epoch (int): The index of last epoch. Default: -1.
-        verbose (bool | str): If ``True``, prints a message to stdout for
-            each update. Default: ``False``.
-
-            .. deprecated:: 2.2
-                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
-                learning rate.
 
     Example:
         >>> # xdoctest: +SKIP
@@ -496,11 +462,10 @@ class StepLR(LRScheduler):
         step_size: int,
         gamma: float = 0.1,
         last_epoch: int = -1,
-        verbose="deprecated",
     ):  # noqa: D107
         self.step_size = step_size
         self.gamma = gamma
-        super().__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch)
 
     def get_lr(self):
         """Compute the learning rate of each parameter group."""
@@ -529,12 +494,6 @@ class MultiStepLR(LRScheduler):
         gamma (float): Multiplicative factor of learning rate decay.
             Default: 0.1.
         last_epoch (int): The index of last epoch. Default: -1.
-        verbose (bool | str): If ``True``, prints a message to stdout for
-            each update. Default: ``False``.
-
-            .. deprecated:: 2.2
-                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
-                learning rate.
 
     Example:
         >>> # xdoctest: +SKIP
@@ -555,11 +514,10 @@ class MultiStepLR(LRScheduler):
         milestones: Iterable[int],
         gamma: float = 0.1,
         last_epoch: int = -1,
-        verbose="deprecated",
     ):  # noqa: D107
         self.milestones = Counter(milestones)
         self.gamma = gamma
-        super().__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch)
 
     def get_lr(self):
         """Compute the learning rate of each parameter group."""
@@ -594,12 +552,6 @@ class ConstantLR(LRScheduler):
         total_iters (int): The number of steps that the scheduler multiplies the learning rate by the factor.
             Default: 5.
         last_epoch (int): The index of the last epoch. Default: -1.
-        verbose (bool | str): If ``True``, prints a message to stdout for
-            each update. Default: ``False``.
-
-            .. deprecated:: 2.2
-                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
-                learning rate.
 
     Example:
         >>> # xdoctest: +SKIP
@@ -622,7 +574,6 @@ class ConstantLR(LRScheduler):
         factor: float = 1.0 / 3,
         total_iters: int = 5,
         last_epoch: int = -1,
-        verbose="deprecated",
     ):  # noqa: D107
         if factor > 1.0 or factor < 0:
             raise ValueError(
@@ -631,7 +582,7 @@ class ConstantLR(LRScheduler):
 
         self.factor = factor
         self.total_iters = total_iters
-        super().__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch)
 
     def get_lr(self):
         """Compute the learning rate of each parameter group."""
@@ -672,12 +623,6 @@ class LinearLR(LRScheduler):
         total_iters (int): The number of iterations that multiplicative factor reaches to 1.
             Default: 5.
         last_epoch (int): The index of the last epoch. Default: -1.
-        verbose (bool | str): If ``True``, prints a message to stdout for
-            each update. Default: ``False``.
-
-            .. deprecated:: 2.2
-                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
-                learning rate.
 
     Example:
         >>> # xdoctest: +SKIP
@@ -701,7 +646,6 @@ class LinearLR(LRScheduler):
         end_factor: float = 1.0,
         total_iters: int = 5,
         last_epoch: int = -1,
-        verbose="deprecated",
     ):  # noqa: D107
         if start_factor > 1.0 or start_factor <= 0:
             raise ValueError(
@@ -716,7 +660,7 @@ class LinearLR(LRScheduler):
         self.start_factor = start_factor
         self.end_factor = end_factor
         self.total_iters = total_iters
-        super().__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch)
 
     def get_lr(self):
         """Compute the learning rate."""
@@ -765,12 +709,6 @@ class ExponentialLR(LRScheduler):
         optimizer (Optimizer): Wrapped optimizer.
         gamma (float): Multiplicative factor of learning rate decay.
         last_epoch (int): The index of last epoch. Default: -1.
-        verbose (bool | str): If ``True``, prints a message to stdout for
-            each update. Default: ``False``.
-
-            .. deprecated:: 2.2
-                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
-                learning rate.
     """
 
     def __init__(
@@ -778,10 +716,9 @@ class ExponentialLR(LRScheduler):
         optimizer: Optimizer,
         gamma: float,
         last_epoch: int = -1,
-        verbose="deprecated",
     ):  # noqa: D107
         self.gamma = gamma
-        super().__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch)
 
     def get_lr(self):
         """Compute the learning rate of each parameter group."""
@@ -806,11 +743,6 @@ class SequentialLR(LRScheduler):
         schedulers (list): List of chained schedulers.
         milestones (list): List of integers that reflects milestone points.
         last_epoch (int): The index of last epoch. Default: -1.
-        verbose (bool | str): Does nothing.
-
-            .. deprecated:: 2.2
-                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
-                learning rate.
 
     Example:
         >>> # xdoctest: +SKIP
@@ -835,7 +767,6 @@ class SequentialLR(LRScheduler):
         schedulers: list[LRScheduler],
         milestones: list[int],
         last_epoch: int = -1,
-        verbose="deprecated",
     ):  # noqa: D107
         if len(schedulers) < 1:
             raise ValueError(
@@ -866,7 +797,6 @@ class SequentialLR(LRScheduler):
                 f"than the number of milestone points, but got number of schedulers {len(schedulers)} and the "
                 f"number of milestones to be equal to {len(milestones)}"
             )
-        _check_verbose_deprecated_warning(verbose)
         self._schedulers = schedulers
         self._milestones = milestones
         self.last_epoch = last_epoch + 1
@@ -954,12 +884,6 @@ class PolynomialLR(LRScheduler):
         optimizer (Optimizer): Wrapped optimizer.
         total_iters (int): The number of steps that the scheduler decays the learning rate. Default: 5.
         power (float): The power of the polynomial. Default: 1.0.
-        verbose (bool | str): If ``True``, prints a message to stdout for
-            each update. Default: ``False``.
-
-            .. deprecated:: 2.2
-                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
-                learning rate.
 
     Example:
         >>> # xdoctest: +SKIP("undefined vars")
@@ -982,11 +906,10 @@ class PolynomialLR(LRScheduler):
         total_iters: int = 5,
         power: float = 1.0,
         last_epoch: int = -1,
-        verbose="deprecated",
     ):  # noqa: D107
         self.total_iters = total_iters
         self.power = power
-        super().__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch)
 
     def get_lr(self):
         """Compute the learning rate."""
@@ -1046,12 +969,6 @@ class CosineAnnealingLR(LRScheduler):
         T_max (int): Maximum number of iterations.
         eta_min (float): Minimum learning rate. Default: 0.
         last_epoch (int): The index of last epoch. Default: -1.
-        verbose (bool | str): If ``True``, prints a message to stdout for
-            each update. Default: ``False``.
-
-            .. deprecated:: 2.2
-                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
-                learning rate.
 
     .. _SGDR\: Stochastic Gradient Descent with Warm Restarts:
         https://arxiv.org/abs/1608.03983
@@ -1063,11 +980,10 @@ class CosineAnnealingLR(LRScheduler):
         T_max: int,
         eta_min: float = 0.0,
         last_epoch: int = -1,
-        verbose="deprecated",
     ):  # noqa: D107
         self.T_max = T_max
         self.eta_min = eta_min
-        super().__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch)
 
     def get_lr(self):
         """Retrieve the learning rate of each parameter group."""
@@ -1253,12 +1169,6 @@ class ReduceLROnPlateau(LRScheduler):
         eps (float): Minimal decay applied to lr. If the difference
             between new and old lr is smaller than eps, the update is
             ignored. Default: 1e-8.
-        verbose (bool | str): If ``True``, prints a message to stdout for
-            each update. Default: ``False``.
-
-            .. deprecated:: 2.2
-                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
-                learning rate.
 
     Example:
         >>> # xdoctest: +SKIP
@@ -1282,7 +1192,6 @@ class ReduceLROnPlateau(LRScheduler):
         cooldown: int = 0,
         min_lr: Union[list[float], float] = 0,
         eps: float = 1e-8,
-        verbose="deprecated",
     ):  # noqa: D107
         if factor >= 1.0:
             raise ValueError("Factor should be < 1.0.")
@@ -1306,7 +1215,6 @@ class ReduceLROnPlateau(LRScheduler):
 
         self.patience = patience
 
-        self.verbose = _check_verbose_deprecated_warning(verbose)
         self.cooldown = cooldown
         self.cooldown_counter = 0
         self.mode = mode
@@ -1501,12 +1409,6 @@ class CyclicLR(LRScheduler):
             number of *batches* computed, not the total number of epochs computed.
             When last_epoch=-1, the schedule is started from the beginning.
             Default: -1
-        verbose (bool | str): If ``True``, prints a message to stdout for
-            each update. Default: ``False``.
-
-            .. deprecated:: 2.2
-                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
-                learning rate.
 
     Example:
         >>> # xdoctest: +SKIP
@@ -1538,7 +1440,6 @@ class CyclicLR(LRScheduler):
         base_momentum: float = 0.8,
         max_momentum: float = 0.9,
         last_epoch: int = -1,
-        verbose="deprecated",
     ):  # noqa: D107
         # Attach optimizer
         if not isinstance(optimizer, Optimizer):
@@ -1600,7 +1501,7 @@ class CyclicLR(LRScheduler):
                     group["max_momentum"] = m_momentum
                     group["base_momentum"] = b_momentum
 
-        super().__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch)
         self.base_lrs = base_lrs
 
     def _init_scale_fn(self):
@@ -1728,12 +1629,6 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         T_mult (int, optional): A factor by which :math:`T_{i}` increases after a restart. Default: 1.
         eta_min (float, optional): Minimum learning rate. Default: 0.
         last_epoch (int, optional): The index of the last epoch. Default: -1.
-        verbose (bool | str): If ``True``, prints a message to stdout for
-            each update. Default: ``False``.
-
-            .. deprecated:: 2.2
-                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
-                learning rate.
 
     .. _SGDR\: Stochastic Gradient Descent with Warm Restarts:
         https://arxiv.org/abs/1608.03983
@@ -1746,7 +1641,6 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         T_mult: int = 1,
         eta_min: float = 0.0,
         last_epoch: int = -1,
-        verbose="deprecated",
     ):  # noqa: D107
         if T_0 <= 0 or not isinstance(T_0, int):
             raise ValueError(f"Expected positive integer T_0, but got {T_0}")
@@ -1761,7 +1655,7 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         self.T_mult = T_mult
         self.eta_min = eta_min
         self.T_cur = last_epoch
-        super().__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch)
 
     def get_lr(self):
         """Compute the initial learning rate."""
@@ -1931,12 +1825,6 @@ class OneCycleLR(LRScheduler):
             number of *batches* computed, not the total number of epochs computed.
             When last_epoch=-1, the schedule is started from the beginning.
             Default: -1
-        verbose (bool | str): If ``True``, prints a message to stdout for
-            each update. Default: ``False``.
-
-            .. deprecated:: 2.2
-                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
-                learning rate.
 
     Example:
         >>> # xdoctest: +SKIP
@@ -1970,7 +1858,6 @@ class OneCycleLR(LRScheduler):
         final_div_factor: float = 1e4,
         three_phase: bool = False,
         last_epoch: int = -1,
-        verbose="deprecated",
     ):  # noqa: D107
         # Validate optimizer
         if not isinstance(optimizer, Optimizer):
@@ -2086,7 +1973,7 @@ class OneCycleLR(LRScheduler):
                     group["max_momentum"] = m_momentum
                     group["base_momentum"] = b_momentum
 
-        super().__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch)
 
     def _anneal_func(self, *args, **kwargs):
         if hasattr(self, "_anneal_func_type"):

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -177,34 +177,6 @@ class LRScheduler:
         """Compute learning rate using chainable form of the scheduler."""
         raise NotImplementedError
 
-    def print_lr(
-        self,
-        is_verbose: bool,
-        group: dict[str, Any],
-        lr: float,
-        epoch: Optional[int] = None,
-    ):
-        """Display the current learning rate.
-
-        .. deprecated:: 2.4
-            ``print_lr()`` is deprecated. Please use ``get_last_lr()`` to access the
-            learning rate.
-        """
-        warnings.warn(
-            "`LRScheduler.print_lr()` is being deprecated. To fetch the learning rate, "
-            "please use `get_last_lr()` instead. For more details, "
-            "see https://github.com/pytorch/pytorch/issues/99270.",
-            UserWarning,
-        )
-        if is_verbose:
-            if epoch is None:
-                print(f"Adjusting learning rate of group {group} to {lr:.4e}.")
-            else:
-                epoch_str = ("%.2f" if isinstance(epoch, float) else "%.5d") % epoch
-                print(
-                    f"Epoch {epoch_str}: adjusting learning rate of group {group} to {lr:.4e}."
-                )
-
     def step(self, epoch: Optional[int] = None):
         """Perform a step."""
         # Raise a warning if old pattern is detected


### PR DESCRIPTION
Following [#99270 suggestion](https://github.com/pytorch/pytorch/issues/99270#issuecomment-1511656408), remove deprecate method `LRScheduler.print_lr`

_____
# BC-breaking note

**`LRScheduler.print_lr()` along with the `verbose` kwarg to the LRScheduler constructor has been deprecated since release 2.2. Please use `LRScheduler.get_last_lr()` to access the learning rate instead.**

`print_lr` and `verbose` were confusing, not properly documented and were little used, as described in #99270, so we deprecated them in 2.2. Now, we complete the deprecation by removing them completely. To access and print the learning rate of a LRScheduler:

In 2.6.0
```
optim = ...
lrsched = torch.optim.lr_scheduler.ReduceLROnPlateau(optim, verbose=True)
// lrsched will internally call print_lr
```

In 2.7.0
```
optim = ...
lrsched = torch.optim.lr_scheduler.ReduceLROnPlateau(optim)
print(lrsched.get_last_lr())
```

