### PR TITLE
[Inductor][CPP] Eliminate the overhead of BRGEMM fetching for Half micro gemm on CPU Inductor

### DIFF
--- a/aten/src/ATen/native/CPUBlas.h
+++ b/aten/src/ATen/native/CPUBlas.h
@@ -276,4 +276,24 @@ TORCH_API void pack(
 // Whether pack is supported in the platform.
 TORCH_API bool could_pack(ScalarType dt_in);
 
+struct GemmHelper;
+
+TORCH_API GemmHelper* brgemm_create(
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t ld_a,
+    int64_t ld_b,
+    int64_t ld_c,
+    const bool add_C,
+    ScalarType dt_a,
+    ScalarType dt_b,
+    ScalarType dt_c);
+
+TORCH_API void brgemm_execute(
+  GemmHelper* ghelper,
+  const at::Half* A,
+  const at::Half* B,
+  float* C);
+
 } // namespace at::native::cpublas


### PR DESCRIPTION
Split `brgemm` method into `brgemm_create` and `brgemm_execute` to avoid the overhead of key hashing and fetching for oneDNN BRGEMM object. Such overhead is not negligible when the gemm is very fast, e.g.,  on small shapes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov