### PR TITLE
[ROCm][Windows] Fix unrecognized constexpr std::memcpy for HIP-clang

### DIFF
--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -243,7 +243,12 @@ C10_HOST_DEVICE inline float fp16_ieee_to_fp32_value(uint16_t h) {
   // const float exp_scale = 0x1.0p-112f;
   constexpr uint32_t scale_bits = (uint32_t)15 << 23;
   float exp_scale_val = 0;
+#if defined(_MSC_VER) && defined(__clang__)
+  __builtin_memcpy(&exp_scale_val, &scale_bits, sizeof(exp_scale_val));
+#else
   std::memcpy(&exp_scale_val, &scale_bits, sizeof(exp_scale_val));
+#endif
+
   const float exp_scale = exp_scale_val;
   const float normalized_value =
       fp32_from_bits((two_w >> 4) + exp_offset) * exp_scale;


### PR DESCRIPTION
Since in MSVC's 2019/2022 implementation of STL memcpy is not defined as a constexpr function, HIP clang compiler on Windows cannot evaluate the following memcopy as one that could be resolved during the compile time. To resolve this, a `__builtin_memcpy` is used instead which doesn't have this limitation.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd