### PR TITLE
[MPS] Fix incorrect size for uint3 arg

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -55,9 +55,10 @@ Tensor& do_metal_mm(const Tensor& self, const Tensor& other, Tensor& output) {
       getMPSProfiler().beginProfileKernel(matmulPSO, "matmul", {self, other});
       auto computeEncoder = stream->commandEncoder();
       [computeEncoder setComputePipelineState:matmulPSO];
-      std::array<uint32_t, 3> sizes = {static_cast<uint32_t>(self.size(0)),
+      std::array<uint32_t, 4> sizes = {static_cast<uint32_t>(self.size(0)),
                                        static_cast<uint32_t>(self.size(1)),
-                                       static_cast<uint32_t>(output.size(1))};
+                                       static_cast<uint32_t>(output.size(1)),
+                                       0};
       std::array<int64_t, 6> strides = {
           self.stride(0), self.stride(1), other.stride(0), other.stride(1), output.stride(0), output.stride(1)};
       constexpr uint32_t TILE_DIM = 16; // fastest performance from tests on multiple macs


### PR DESCRIPTION
With the metal validation layer enabled I get the following error:

>  validateComputeFunctionArguments:844: failed assertion `Compute
>  Function(naive_matmul_half): argument sizes[0] from buffer(4) with
>  offset(0) and length(12) has space for 12 bytes, but argument has a
>  length(16).'

The spec (https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf) states that a `uint3` is 16 bytes in size but we only provide a buffer of size 12 here (3 x uint32_t). The other uses of `uint3` (Quantized.mm and Indexing.mm) pad this to 16 bytes correctly, so do the same here.

I did a quick spot check and couldn't find any other places where we use the wrong size.