### PR TITLE
add unbacked strict mode

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10845,6 +10845,19 @@ fn
 
         fn(torch.tensor([3, 3]))
 
+    def test_mark_unbacked_strict(self):
+        @torch.compile()
+        def fn(x, y):
+            return torch.mul(x, y)
+
+        x = torch.ones(5, 5)
+        torch._dynamo.decorators.mark_unbacked(x, 0, strict=True)
+        torch._dynamo.decorators.mark_unbacked(x, 1, strict=True)
+        y = torch.randn(5, 5)
+
+        with self.assertRaisesRegex(RuntimeError, "RelaxedUnspecConstraint"):
+            fn(x, y)
+
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_guard_size_oblivious(self):
         # This code, in fact, does NOT work in eager

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10845,6 +10845,7 @@ fn
 
         fn(torch.tensor([3, 3]))
 
+    @torch._dynamo.config.patch(assume_static_by_default=True)
     def test_mark_unbacked_strict(self):
         @torch.compile()
         def fn(x, y):

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -458,6 +458,7 @@ def mark_unbacked(t, index, strict=False):
             if not hasattr(t, "_dynamo_strict_unbacked_indices"):
                 t._dynamo_strict_unbacked_indices = set()
             t._dynamo_strict_unbacked_indices.add(index)
+            return
 
         if not hasattr(t, "_dynamo_unbacked_indices"):
             t._dynamo_unbacked_indices = set()

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -437,19 +437,28 @@ class _DimRange:
 
 
 @forbid_in_graph
-def mark_unbacked(t, index):
+def mark_unbacked(t, index, strict=False):
     """
     Mark a tensor as having an unbacked dim.  This changes the semantics of operations,
     we will always report the size does not equal zero/one, we will turn asserts
     on this index into runtime asserts, and if you try to get the real value we will
     raise an exception.  In other words, we will treat this dimension as if it was
     data dependent (we do not know anything about its value.)
+
+    For historical reasons, by default if an unbacked dim is specialized, we will
+    happily specialize it and continue. If you want to error in these cases, pass
+    strict=True.
     """
     # You could have copied the mark_dynamic behavior but I'm not convinced
     # it's what you want
     assert not is_traceable_wrapper_subclass(t), "not implemented yet"
 
     if isinstance(index, int):
+        if strict:
+            if not hasattr(t, "_dynamo_strict_unbacked_indices"):
+                t._dynamo_strict_unbacked_indices = set()
+            t._dynamo_strict_unbacked_indices.add(index)
+
         if not hasattr(t, "_dynamo_unbacked_indices"):
             t._dynamo_unbacked_indices = set()
         t._dynamo_unbacked_indices.add(index)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2809,8 +2809,6 @@ def _automatic_dynamic(
 
         if marked_unbacked:
             dynamic_size = DimDynamic.SIZE_LIKE_UNBACKED
-        elif marked_strict_unbacked:
-            dynamic_size = DimDynamic.STRICT_SIZE_LIKE_UNBACKED
         elif (
             constraint_size is not None
             or marked_dynamic

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2789,7 +2789,7 @@ def _automatic_dynamic(
                         )
                 else:
                     constraint_size = RelaxedUnspecConstraint(warn_only=False)
-            if marked_strict_unbacked:
+            elif marked_strict_unbacked:
                 constraint_size = RelaxedUnspecConstraint(warn_only=False)
             elif not marked_static and automatic_dynamic:
                 if automatic_dynamic_size:

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2729,6 +2729,9 @@ def _automatic_dynamic(
     constraint_strides = []
     for i in range(e.dim()):
         # NB: mark dynamic has precedence over static
+        marked_strict_unbacked = i in getattr(
+            e, "_dynamo_strict_unbacked_indices", set()
+        )
         marked_unbacked = i in getattr(e, "_dynamo_unbacked_indices", set())
         marked_dynamic = i in getattr(e, "_dynamo_dynamic_indices", set())
         marked_weak_dynamic = i in getattr(e, "_dynamo_weak_dynamic_indices", set())
@@ -2786,6 +2789,8 @@ def _automatic_dynamic(
                         )
                 else:
                     constraint_size = RelaxedUnspecConstraint(warn_only=False)
+            if marked_strict_unbacked:
+                constraint_size = RelaxedUnspecConstraint(warn_only=False)
             elif not marked_static and automatic_dynamic:
                 if automatic_dynamic_size:
                     constraint_size = RelaxedUnspecConstraint(warn_only=True)
@@ -2804,6 +2809,8 @@ def _automatic_dynamic(
 
         if marked_unbacked:
             dynamic_size = DimDynamic.SIZE_LIKE_UNBACKED
+        elif marked_strict_unbacked:
+            dynamic_size = DimDynamic.STRICT_SIZE_LIKE_UNBACKED
         elif (
             constraint_size is not None
             or marked_dynamic

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -4413,10 +4413,7 @@ class ShapeEnv:
                 source_name
             ]
 
-        if dynamic_dim in (
-            DimDynamic.SIZE_LIKE_UNBACKED,
-            DimDynamic.OBLIVIOUS_SIZE
-        ):
+        if dynamic_dim in (DimDynamic.SIZE_LIKE_UNBACKED, DimDynamic.OBLIVIOUS_SIZE):
             out = self.create_unbacked_symint(source).node.expr
             self._constrain_range_for_size(out)
             if isinstance(symbolic_context, StatefulSymbolicContext) and source_name:

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1505,8 +1505,6 @@ class DimDynamic(Enum):
     INFER_STRIDE = 4
     # Like SIZE_LIKE_UNBACKED, but there's a hint
     OBLIVIOUS_SIZE = 5
-    # Like SIZE_LIKE_UNBACKED, but we will error if specialoized
-    STRICT_SIZE_LIKE_UNBACKED = 6
 
 
 # NB: These constraints affect both clients and backends: given some
@@ -4417,8 +4415,7 @@ class ShapeEnv:
 
         if dynamic_dim in (
             DimDynamic.SIZE_LIKE_UNBACKED,
-            DimDynamic.OBLIVIOUS_SIZE,
-            DimDynamic.STRICT_SIZE_LIKE_UNBACKED,
+            DimDynamic.OBLIVIOUS_SIZE
         ):
             out = self.create_unbacked_symint(source).node.expr
             self._constrain_range_for_size(out)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1505,6 +1505,8 @@ class DimDynamic(Enum):
     INFER_STRIDE = 4
     # Like SIZE_LIKE_UNBACKED, but there's a hint
     OBLIVIOUS_SIZE = 5
+    # Like SIZE_LIKE_UNBACKED, but we will error if specialoized
+    STRICT_SIZE_LIKE_UNBACKED = 6
 
 
 # NB: These constraints affect both clients and backends: given some
@@ -4413,7 +4415,11 @@ class ShapeEnv:
                 source_name
             ]
 
-        if dynamic_dim in (DimDynamic.SIZE_LIKE_UNBACKED, DimDynamic.OBLIVIOUS_SIZE):
+        if dynamic_dim in (
+            DimDynamic.SIZE_LIKE_UNBACKED,
+            DimDynamic.OBLIVIOUS_SIZE,
+            DimDynamic.STRICT_SIZE_LIKE_UNBACKED,
+        ):
             out = self.create_unbacked_symint(source).node.expr
             self._constrain_range_for_size(out)
             if isinstance(symbolic_context, StatefulSymbolicContext) and source_name:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147333

fixes #145775

This is the first step in introducing a "strict" mode where we don't silent specialize and don't silent graph break. At a high level when we do mark_unbacked(... strict=True), anytime we specialize an unbacked symint we will explicitly error and tell the user their unbacked dimension was specialized to a single value.

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames