### PR TITLE
[ROCm][Windows] Disable Composable Kernels and Triton for Windows builds

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -357,6 +357,11 @@ endif()
     ${native_quantized_hip_hip}
     ${native_transformers_hip_hip} ${native_transformers_src_hip_hip}
   )
+  if(WIN32) # Windows doesn't support Composable Kernels
+    file(GLOB native_hip_bgemm "native/hip/bgemm_kernels/*.hip")
+    file(GLOB native_hip_ck "native/hip/ck*.hip")
+    exclude(ATen_HIP_SRCS "${ATen_HIP_SRCS}" ${native_hip_bgemm} ${native_hip_ck})
+  endif()
   # TODO: Codegen separate files for HIP and use those (s/cuda_generated_sources/hip_generated_sources)
   list(APPEND all_hip_cpp
     ${native_nested_hip_cpp}

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -357,10 +357,12 @@ endif()
     ${native_quantized_hip_hip}
     ${native_transformers_hip_hip} ${native_transformers_src_hip_hip}
   )
-  if(WIN32) # Windows doesn't support Composable Kernels
+  if(WIN32) # Windows doesn't support Composable Kernels and Triton
     file(GLOB native_hip_bgemm "native/hip/bgemm_kernels/*.hip")
     file(GLOB native_hip_ck "native/hip/ck*.hip")
-    exclude(ATen_HIP_SRCS "${ATen_HIP_SRCS}" ${native_hip_bgemm} ${native_hip_ck})
+    exclude(ATen_HIP_SRCS "${ATen_HIP_SRCS}"
+      ${native_hip_bgemm} ${native_hip_ck}
+      ${native_transformers_hip_hip} ${native_transformers_hip_cpp})
   endif()
   # TODO: Codegen separate files for HIP and use those (s/cuda_generated_sources/hip_generated_sources)
   list(APPEND all_hip_cpp
@@ -379,6 +381,9 @@ endif()
     ${miopen_cpp}
     ${all_hip_cpp}
   )
+  if(WIN32) # Windows doesn't support Triton
+    exclude(all_hip_cpp "${all_hip_cpp}" ${native_transformers_hip_cpp})
+  endif()
 endif()
 
 if(USE_XPU)


### PR DESCRIPTION
Currently, Composible Kernels and Triton aren't available on Windows. This PR ensures that the files relating to this dependency are not included during the build.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd