### PR TITLE
Fix torch.compile Fallback for Meta Device Tensors

### DIFF
--- a/test/inductor/test_meta_compile_fallback.py
+++ b/test/inductor/test_meta_compile_fallback.py
@@ -1,0 +1,41 @@
+"""
+Test for meta tensor fallback in torch.compile.
+
+This test verifies that when a function compiled with torch.compile
+receives an input tensor on the "meta" device, it falls back to eager execution,
+thus avoiding the lowering exception described in issue #144607.
+"""
+
+import torch
+import pytest
+
+# Define a simple function that doubles its input.
+@torch.compile
+def foobar(x):
+    return x * 2
+
+def run_test(device: str):
+    # Call the compiled function twice with different input shapes.
+    out1 = foobar(torch.empty((1, 16, 128, 128), device=device))
+    out2 = foobar(torch.empty((1, 32, 64, 64), device=device))
+    return out1, out2
+
+def test_cuda():
+    # Skip this test if CUDA is not available.
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    out1, out2 = run_test("cuda")
+    # Check that the outputs are on CUDA and have the expected shapes.
+    assert out1.device.type == "cuda"
+    assert out1.shape == (1, 16, 128, 128)
+    assert out2.device.type == "cuda"
+    assert out2.shape == (1, 32, 64, 64)
+
+def test_meta():
+    # When a meta tensor is passed, the fallback should trigger.
+    out1, out2 = run_test("meta")
+    # We expect that the returned outputs are still meta tensors with the correct shapes.
+    assert out1.device.type == "meta"
+    assert out1.shape == (1, 16, 128, 128)
+    assert out2.device.type == "meta"
+    assert out2.shape == (1, 32, 64, 64)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2561,24 +2561,35 @@ def compile(
     else:
         backend = _TorchCompileWrapper(backend, mode, options, dynamic)
 
-    compiled_fn = torch._dynamo.optimize(
-        backend=backend,
-        nopython=fullgraph,
-        dynamic=dynamic,
-        disable=disable,
-    )(model)  # type: ignore[return-value]
+    try:
+        compiled_fn = torch._dynamo.optimize(
+            backend=backend,
+            nopython=fullgraph,
+            dynamic=dynamic,
+            disable=disable,
+        )(model)  # type: ignore[return-value]
+    except torch._dynamo.exc.BackendCompilerFailed as e:
+        # If the error message indicates a meta-related issue, fall back to eager mode.
+        if "meta" in str(e):
+            return model
+        else:
+            raise
 
     def wrapped_fn(*args, **kwargs):
-        # Check positional arguments for meta tensors.
+        # Pre-check: if any input tensor is on the "meta" device, immediately fallback.
         for arg in args:
             if isinstance(arg, torch.Tensor) and arg.device.type == "meta":
                 return model(*args, **kwargs)
-        # Check keyword arguments for meta tensors.
         for arg in kwargs.values():
             if isinstance(arg, torch.Tensor) and arg.device.type == "meta":
                 return model(*args, **kwargs)
-        # Otherwise, use the compiled version.
-        return compiled_fn(*args, **kwargs)
+        # Try calling the compiled function; if a lowering error occurs, fallback to eager.
+        try:
+            return compiled_fn(*args, **kwargs)
+        except torch._dynamo.exc.BackendCompilerFailed as e:
+            if "meta" in str(e):
+                return model(*args, **kwargs)
+            raise
 
     return wrapped_fn
 


### PR DESCRIPTION
Fixes #144607 by updating the fallback behavior in torch/__init__.py for cases when a function compiled with torch.compile is called with a tensor on the "meta" device. Instead of raising a lowering exception, the change transparently falls back to eager execution.

Additionally, this PR adds a new test (test/inductor/test_meta_compile_fallback.py) that:
	•	Verifies normal behavior when using CUDA tensors.
	•	Ensures that when a meta tensor is provided, the function correctly falls back to eager execution and returns a tensor with the expected shape and “meta” device.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov