### PR TITLE
Add no_data_dependent_graph_break mode

### DIFF
--- a/torch/fx/experimental/_config.py
+++ b/torch/fx/experimental/_config.py
@@ -3,6 +3,10 @@ import sys
 from typing import Optional
 
 
+# [@compile_ignored: debug] Fails hard instead of graph breaking on guard on data dependent errors.
+unbacked_strict = (
+    os.environ.get("TORCHDYNAMO_UNBACKED_STRICT", "0") == "1"
+)
 # [@compile_ignored: debug] Uses z3 for validating the guard optimizations transformations.
 translation_validation = (
     os.environ.get("TORCHDYNAMO_TRANSLATION_VALIDATION", "0") == "1"

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -112,6 +112,12 @@ class GuardOnDataDependentSymNode(RuntimeError):
         super().__init__(*args)
         self.cond = cond
 
+class GuardOnDataDependentSymNodeStrict(RuntimeError):
+    cond: sympy.Basic
+
+    def __init__(self, cond: sympy.Basic, *args: Any) -> None:
+        super().__init__(*args)
+        self.cond = cond
 
 class PendingUnbackedSymbolNotFound(RuntimeError):
     pass
@@ -5947,6 +5953,8 @@ class ShapeEnv:
             # TODO: Help text about how to use our runtime tests to fix this
             # problem
         )
+        if config.unbacked_strict:
+            return GuardOnDataDependentSymNodeStrict(expr, msg)
         return GuardOnDataDependentSymNode(expr, msg)
 
     def _update_var_to_range(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147342

This adds a strict mode `TORCHDYNAMO_UNBACKED_STRICT` to prevent graph breaking when we guard on data dependent. This is a better UX for those who are actively trying to make their model more dynamic, but aren't close enough to full graph to use that flag directly.

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames