### PR TITLE
[DCP] Cache save plans in default planner

### DIFF
--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -22,6 +22,7 @@ from torch.distributed.checkpoint import (
     save_state_dict,
 )
 from torch.distributed.checkpoint._extension import ZStandard
+from torch.distributed.checkpoint.default_planner import DefaultSavePlanner
 from torch.testing._internal.common_distributed import requires_nccl, skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -40,6 +41,7 @@ from torch.testing._internal.distributed._shard.sharded_tensor._test_st_common i
 from torch.testing._internal.distributed.checkpoint_utils import (
     get_test_extension_registry,
     Rot13Example,
+    with_temp_dir,
 )
 
 
@@ -501,6 +503,92 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                         torch.allclose(save_dict["replicated"], load_dict_replicated),
                         f"save-spec {save_spec} load-spec {load_spec}",
                     )
+
+
+class TestDistributedStateDictSaveLoadWithCaching(ShardedTensorTestBase):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @with_comms(init_rpc=False)
+    @skip_if_lt_x_gpu(2)
+    @requires_nccl()
+    @with_temp_dir
+    def test_read_write_shard_tensor(self) -> None:
+        # pyre-fixme [28]: Unexpected keyword argument `dim` to call `dist._sharding_spec.api.ChunkShardingSpec.__init__`.
+        spec = ChunkShardingSpec(
+            dim=0,
+            placements=[
+                "rank:0/cuda:0",
+                "rank:1/cuda:1",
+            ],
+        )
+
+        model_to_save = MyShardedModel1(spec, init_rrefs=False)
+
+        # Test save
+        model_to_save._register_state_dict_hook(state_dict_hook)
+        state_dict_to_save = model_to_save.state_dict()
+
+        fs_writer = FileSystemWriter(path=self.temp_dir)
+        save_state_dict(
+            state_dict=state_dict_to_save,
+            storage_writer=fs_writer,
+            planner=DefaultSavePlanner(enable_plan_caching=True),
+        )
+
+        dist.barrier()
+
+        # Create a new model
+        model_to_load = MyShardedModel1(spec, init_rrefs=False)
+        # This is not the correct hook for loading the state dict
+        # model_to_load._register_load_state_dict_pre_hook(pre_load_state_dict_hook, True)
+        model_to_load._register_state_dict_hook(state_dict_hook)
+        state_dict_to_load_to = model_to_load.state_dict()
+
+        dist.barrier()
+
+        with self.assertRaises(AssertionError):
+            assert_state_dict_equal(self, state_dict_to_load_to, state_dict_to_save)
+
+        # Test load.
+        fs_reader = FileSystemReader(
+            path=self.temp_dir, _extension_registry=get_test_extension_registry()
+        )
+        load_state_dict(state_dict=state_dict_to_load_to, storage_reader=fs_reader)
+
+        assert_state_dict_equal(self, state_dict_to_load_to, state_dict_to_save)
+        dist.barrier()
+
+        # Save Attempt 2
+        save_state_dict(
+            state_dict=state_dict_to_save,
+            storage_writer=fs_writer,
+            planner=DefaultSavePlanner(enable_plan_caching=True),
+        )
+
+        dist.barrier()
+
+        # Create a new model
+        model_to_load = MyShardedModel1(spec, init_rrefs=False)
+        # This is not the correct hook for loading the state dict
+        # model_to_load._register_load_state_dict_pre_hook(pre_load_state_dict_hook, True)
+        model_to_load._register_state_dict_hook(state_dict_hook)
+        state_dict_to_load_to = model_to_load.state_dict()
+
+        dist.barrier()
+
+        with self.assertRaises(AssertionError):
+            assert_state_dict_equal(self, state_dict_to_load_to, state_dict_to_save)
+
+        # Test load.
+        fs_reader = FileSystemReader(
+            path=self.temp_dir, _extension_registry=get_test_extension_registry()
+        )
+        load_state_dict(state_dict=state_dict_to_load_to, storage_reader=fs_reader)
+
+        assert_state_dict_equal(self, state_dict_to_load_to, state_dict_to_save)
+        dist.barrier()
 
 
 instantiate_parametrized_tests(TestDistributedStateDictSaveLoadWithSharedTensor)

--- a/test/distributed/checkpoint/test_planner.py
+++ b/test/distributed/checkpoint/test_planner.py
@@ -22,6 +22,7 @@ from torch.distributed.checkpoint.default_planner import (
     create_default_local_load_plan,
     create_default_local_save_plan,
     DefaultLoadPlanner,
+    DefaultSavePlanner,
 )
 from torch.distributed.checkpoint.metadata import (
     BytesStorageMetadata,
@@ -30,7 +31,12 @@ from torch.distributed.checkpoint.metadata import (
     TensorProperties,
     TensorStorageMetadata,
 )
-from torch.distributed.checkpoint.planner import LoadItemType, SavePlan, WriteItemType
+from torch.distributed.checkpoint.planner import (
+    LoadItemType,
+    SavePlan,
+    SavePlanner,
+    WriteItemType,
+)
 from torch.distributed.checkpoint.planner_helpers import (
     _compare_save_plans,
     _merge_delta_local_plans,
@@ -135,6 +141,28 @@ class TestSavePlan(TestCase):
         self.assertEqual(bytes_wi.index, MetadataIndex("value"))
         self.assertIsNone(bytes_wi.tensor_data)
 
+    @with_fake_comms(rank=1, world_size=4)
+    def test_local_plan_with_caching(self):
+        tensor = torch.rand(10)
+        val = [1, 2, 3]
+        st = create_sharded_tensor(rank=1, world_size=4, shards_per_rank=1)
+        state_dict = {"tensor": tensor, "value": val, "st": st}
+        planner = DefaultSavePlanner(enable_plan_caching=True)
+        planner.set_up_planner(state_dict, is_coordinator=False)
+        # First iteration, should create a new plan
+        first_plan = planner.create_local_plan()
+
+        # Validate that the plan has been cached
+        cached_plan = SavePlanner._cached_save_plan[planner._cached_plans_key]
+        self.assertEqual(first_plan, cached_plan)
+
+        # second iteration, should create an empty unusable plan
+        second_plan = planner.create_local_plan()
+        self.assertFalse(second_plan.usable)
+        self.assertEqual(0, len(second_plan.items))
+        self.assertIsNone(second_plan.planner_data)
+        self.assertIsNone(second_plan.storage_data)
+
     def test_global_plan(self):
         def create_data(rank):
             with with_dist(rank=rank, world_size=4):
@@ -171,6 +199,96 @@ class TestSavePlan(TestCase):
                     self.assertEqual(
                         item_md.chunks[new_item.index.index], old_item.tensor_data.chunk
                     )
+
+    def test_global_plan_with_caching(self):
+        def create_data(rank):
+            with with_dist(rank=rank, world_size=4):
+                planner = DefaultSavePlanner(enable_plan_caching=True)
+                tensor = torch.rand(10)
+                val = [1, 2, 3]
+                st = create_sharded_tensor(rank=rank, world_size=4, shards_per_rank=1)
+                state_dict = {"tensor": tensor, "value": val, "st": st}
+                planner.set_up_planner(state_dict, is_coordinator=(rank == 0))
+                return planner.create_local_plan()
+
+        all_plans = [create_data(0), create_data(1), create_data(2), create_data(3)]
+        planner = DefaultSavePlanner(enable_plan_caching=True)
+        # First iteration, should create a new plan
+        first_global_plan, first_metadata = planner.create_global_plan(all_plans)
+
+        # Validate that the plan has been cached
+        cached_global_plan = SavePlanner._cached_global_plan[planner._cached_plans_key]
+        self.assertEqual(cached_global_plan, first_global_plan)
+
+        # Second iteration, should return empty plans
+        second_global_plan, second_metadata = planner.create_global_plan(all_plans)
+        # All the plans should be empty and usable
+        for plan in second_global_plan:
+            self.assertFalse(plan.usable)
+            self.assertEqual(0, len(plan.items))
+            self.assertIsNone(plan.planner_data)
+            self.assertIsNone(plan.storage_data)
+
+        self.assertEqual(first_metadata, second_metadata)
+
+        # Third iteration with changed plans
+        def create_data_v2(rank):
+            with with_dist(rank=rank, world_size=4):
+                planner = DefaultSavePlanner(enable_plan_caching=True)
+                tensor = torch.rand(20)
+                val = [1, 2, 3]
+                st = create_sharded_tensor(rank=rank, world_size=4, shards_per_rank=1)
+                state_dict = {"tensor": tensor, "value": val, "st": st}
+                planner.set_up_planner(state_dict, is_coordinator=(rank == 0))
+                return planner.create_local_plan()
+
+        all_plans = [
+            create_data_v2(0),
+            create_data_v2(1),
+            create_data_v2(2),
+            create_data_v2(3),
+        ]
+        third_global_plan, third_metadata = planner.create_global_plan(all_plans)
+        # Only the rank 0 plan should be non-empty. The rest should be empty
+        tensor_plan = third_global_plan[0]
+        self.assertNotEqual(0, len(tensor_plan.items))
+        self.assertTrue(tensor_plan.usable)
+
+        for plan in third_global_plan[1:]:
+            self.assertFalse(plan.usable)
+            self.assertEqual(0, len(plan.items))
+            self.assertIsNone(plan.planner_data)
+            self.assertIsNone(plan.storage_data)
+
+        # Global metadata should be different as one plan has changed
+        self.assertNotEqual(second_metadata, third_metadata)
+
+        # Validate that the new plan has been cached
+        cached_global_plan = SavePlanner._cached_global_plan[planner._cached_plans_key][
+            0
+        ]
+        self.assertEqual(cached_global_plan, tensor_plan)
+
+    def test_finish_plan_with_caching(self):
+        planner = DefaultSavePlanner(enable_plan_caching=True)
+        tensor = torch.rand(10)
+        val = [1, 2, 3]
+        state_dict = {"tensor": tensor, "value": val}
+        planner.set_up_planner(state_dict, is_coordinator=True)
+        plan = planner.create_local_plan()
+
+        # First iteration, should create a new plan
+        first_finished_plan = planner.finish_plan(plan)
+
+        # Validate that the plan has been cached
+        cached_finished_plan = SavePlanner._cached_final_save_plan[
+            planner._cached_plans_key
+        ]
+        self.assertEqual(first_finished_plan, cached_finished_plan)
+
+        # second iteration, should return the cached plan
+        second_finished_plan = planner.finish_plan(SavePlan([], usable=False))
+        self.assertEqual(second_finished_plan, first_finished_plan)
 
     def test_local_load_plan(self):
         def create_state_dict(rank):
@@ -366,20 +484,20 @@ class TestPlannerHelpers(TestCase):
 
         # Only the first plan changed.
         # Merge plan should have the first plan from the delta plans and the second plan from the cached plans
-        delta_plans = [create_data(2), SavePlan([])]
+        delta_plans = [create_data(2), SavePlan([], usable=False)]
         merged_plans = _merge_delta_local_plans(cached_plans, delta_plans)
         _validate_plans(delta_plans[0], merged_plans[0])
         _validate_plans(cached_plans[1], merged_plans[1])
 
         # Only the second plan changed.
         # Merge plan should have the first plan from the cached plans and the second plan from the delta plans
-        delta_plans = [SavePlan([]), create_data(3)]
+        delta_plans = [SavePlan([], usable=False), create_data(3)]
         merged_plans = _merge_delta_local_plans(cached_plans, delta_plans)
         _validate_plans(cached_plans[0], merged_plans[0])
         _validate_plans(delta_plans[1], merged_plans[1])
 
         # None of the plans changed. Cached plans should be returned
-        delta_plans = [SavePlan([]), SavePlan([])]
+        delta_plans = [SavePlan([], usable=False), SavePlan([], usable=False)]
         merged_plans = _merge_delta_local_plans(cached_plans, delta_plans)
         _validate_plans(cached_plans[0], merged_plans[0])
         _validate_plans(cached_plans[1], merged_plans[1])

--- a/torch/distributed/checkpoint/default_planner.py
+++ b/torch/distributed/checkpoint/default_planner.py
@@ -38,10 +38,12 @@ from torch.distributed.checkpoint.planner import (
     WriteItemType,
 )
 from torch.distributed.checkpoint.planner_helpers import (
+    _compare_save_plans,
     _create_default_metadata_only_plan,
     _create_read_items,
     _create_write_items,
     _init_state_dict,
+    _merge_delta_local_plans,
 )
 from torch.distributed.checkpoint.utils import find_state_dict_object
 from torch.distributed.tensor import DTensor
@@ -72,6 +74,7 @@ class DefaultSavePlanner(SavePlanner):
         flatten_sharded_tensors: bool = True,
         dedup_replicated_tensors: Optional[bool] = None,
         dedup_save_to_lowest_rank: bool = False,
+        enable_plan_caching: bool = False,
     ) -> None:
         self.flatten_state_dict = flatten_state_dict
         self.flatten_sharded_tensors = flatten_sharded_tensors
@@ -83,6 +86,8 @@ class DefaultSavePlanner(SavePlanner):
                 "deprecated, and no longer has any effect. Please remove this argument "
                 "from your call."
             )
+        self._cached_plans_key: str = self.__class__.__name__
+        self._enable_plan_caching = enable_plan_caching
 
     def set_up_planner(
         self,
@@ -103,9 +108,24 @@ class DefaultSavePlanner(SavePlanner):
             plan = dataclasses.replace(plan, planner_data=self.mappings)
         self.plan = plan
 
+        if self._enable_plan_caching:
+            # If plans are equal, we can skip sending the plan to the coordinator.
+            if (
+                self._cached_plans_key in SavePlanner._cached_save_plan
+                and _compare_save_plans(
+                    plan, SavePlanner._cached_save_plan[self._cached_plans_key]
+                )
+            ):
+                logger.info(
+                    "No change in the local plan. Skipping sending the plan to the coordinator"
+                )
+                return SavePlan([], usable=False)
+            else:
+                SavePlanner._cached_save_plan[self._cached_plans_key] = plan
+
         return self.plan
 
-    def create_global_plan(
+    def _create_global_plan(
         self, all_plans: list[SavePlan]
     ) -> tuple[list[SavePlan], Metadata]:
         all_plans = dedup_save_plans(all_plans, self.dedup_save_to_lowest_rank)
@@ -124,14 +144,86 @@ class DefaultSavePlanner(SavePlanner):
         if not _validate_global_plan(global_plan, metadata):
             raise ValueError("Failed to validate global plan")
 
+        return global_plan, metadata
+
+    def _create_global_plan_with_caching(
+        self, all_plans: list[SavePlan]
+    ) -> tuple[list[SavePlan], list[SavePlan], Metadata]:
+        """
+        Create global plan with caching.
+        Returns a tuple of global_plan_delta, global_plan, metadata.
+        """
+        global_plan_delta: list[SavePlan] = []
+
+        if self._cached_plans_key not in SavePlanner._cached_all_plans:
+            SavePlanner._cached_all_plans[self._cached_plans_key] = all_plans
+            global_plan, metadata = self._create_global_plan(all_plans)
+            SavePlanner._cached_global_plan[self._cached_plans_key] = global_plan
+            # If plans are not cached, global_plan delta will be the same as global plan.
+            return global_plan, global_plan, metadata
+
+        # We get global plan for the new delta plans.
+        # Ranks have already cached the plans which have not changed.
+        merged_plans = _merge_delta_local_plans(
+            SavePlanner._cached_all_plans[self._cached_plans_key], all_plans
+        )
+        global_plan, metadata = self._create_global_plan(merged_plans)
+
+        if self._cached_plans_key in self._cached_global_plan:
+            for cached_plan, new_plan in zip(
+                SavePlanner._cached_global_plan[self._cached_plans_key], global_plan
+            ):
+                if _compare_save_plans(cached_plan, new_plan):
+                    global_plan_delta.append(SavePlan([], usable=False))
+                else:
+                    global_plan_delta.append(new_plan)
+
+        SavePlanner._cached_global_plan[self._cached_plans_key] = global_plan
+
+        # If the plans are cached, global_plan delta will be the delta
+        # of new global plan and cached global plan.
+        return global_plan_delta, global_plan, metadata
+
+    def create_global_plan(
+        self, all_plans: list[SavePlan]
+    ) -> tuple[list[SavePlan], Metadata]:
+        global_plan_delta: list[SavePlan] = []
+        if self._enable_plan_caching:
+            # If the plans are cached, we only need to send the global plan delta to be scattered
+            # across ranks. Ranks will use the cached final plans instead.
+            (
+                global_plan_delta,
+                global_plan,
+                metadata,
+            ) = self._create_global_plan_with_caching(all_plans)
+        else:
+            global_plan, metadata = self._create_global_plan(all_plans)
+            # If the caching is not enabled, global delta plan will always be same as the new global plan.
+            global_plan_delta = global_plan
+
         self.global_plan = global_plan
         self.metadata = metadata
 
-        return self.global_plan, self.metadata
+        return global_plan_delta, self.metadata
+
+    def _finish_plan_with_caching(self, new_plan: SavePlan) -> SavePlan:
+        finished_plan: SavePlan = new_plan
+
+        if not new_plan.usable:
+            finished_plan = SavePlanner._cached_final_save_plan[self._cached_plans_key]
+        else:
+            finished_plan = new_plan
+            SavePlanner._cached_final_save_plan[self._cached_plans_key] = new_plan
+        return finished_plan
 
     def finish_plan(self, new_plan: SavePlan) -> SavePlan:
-        self.plan = new_plan
-        return new_plan
+        finished_plan: SavePlan = new_plan
+
+        if self._enable_plan_caching:
+            finished_plan = self._finish_plan_with_caching(new_plan)
+
+        self.plan = finished_plan
+        return self.plan
 
     def resolve_data(self, write_item: WriteItem) -> Union[torch.Tensor, io.BytesIO]:
         object = self.lookup_object(write_item.index)

--- a/torch/distributed/checkpoint/planner.py
+++ b/torch/distributed/checkpoint/planner.py
@@ -97,6 +97,9 @@ class SavePlan:
     items: list[WriteItem]
     storage_data: Any = None
     planner_data: Any = None
+    # This is used to indicate that the ranks should
+    # use the cached plans to write data instead.
+    usable: bool = True
 
 
 @dataclass

--- a/torch/distributed/checkpoint/planner_helpers.py
+++ b/torch/distributed/checkpoint/planner_helpers.py
@@ -47,6 +47,9 @@ def _compare_save_plans(plan: SavePlan, other_plan: SavePlan) -> bool:
     Returns:
        True if the two plans are equal, False otherwise.
     """
+    if plan.usable != other_plan.usable:
+        return False
+
     # Both the plans should have the same number of items
     if len(plan.items) != len(other_plan.items):
         return False
@@ -110,15 +113,15 @@ def _merge_delta_local_plans(
         delta_plans (List[SavePlan]): A list of delta plans to merge. It can contain empty plans
 
     Returns:
-        A single merged plan. If a delta plan is non empty, use that. Otherwise, use the cached plan.
+        A single merged plan. If a delta plan is not usable, use the cached plan. Otherwise, use the delta plan.
     """
     merged_plans = []
 
     for cached_plan, delta_plan in zip(cached_plans, delta_plans):
-        if delta_plan and len(delta_plan.items) > 0:
-            merged_plans.append(delta_plan)
-        else:
+        if delta_plan and not delta_plan.usable:
             merged_plans.append(cached_plan)
+        else:
+            merged_plans.append(delta_plan)
 
     return merged_plans
 


### PR DESCRIPTION
Summary:
This PR caches the save plans to significantly reduce the collective cost for successive checkpoint save attempts. Here is the high level approach:
-  Create the local plan and cache the same.
- In next iteration, compare the local plan with the cached plan metadata. If no change, do not send that local plan in the collective.
- Global plan step, will only create the global plan with the new delta plans and empty plans for the cached ones. 
- Finish plan step will check for the empty plans. If its empty, it will grab the cached plan. If not, it will use the new plan provided.

Test Plan: UTs

Differential Revision: D69224491

## How to enable the caching:
DefaultSavePlanner introduces the enable_plan_caching which is set to False by default for now. 
https://github.com/pytorch/pytorch/pull/147343/files#diff-579bbb7b82572753afa91085fbf954f7c7613ff8376da9b26153d5cc3a3c4ee8R77
Set this to True to enable the caching and we should see significant speed up in the subsequent checkpoint save attempts, specially for larger scale jobs. Reference issue: https://github.com/pytorch/pytorch/issues/123695

## Experiment results:
```
Model size: 1.6 TB post dedupe, Ranks: 256
First checkpoint save time: 280s.
Subsequent checkpoint save time: 155s. 
E2e latency improvement: ~45%
```


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn @ekr0