### PR TITLE
[Inductor UT][Windows][XPU] Enable Inductor UT on XPU Windows.

### DIFF
--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -32,8 +32,11 @@ log = logging.getLogger(__name__)
 def run_tests(needs: Union[str, tuple[str, ...]] = ()) -> None:
     from torch.testing._internal.common_utils import run_tests
 
-    if TEST_WITH_TORCHDYNAMO or IS_WINDOWS or TEST_WITH_CROSSREF:
+    if TEST_WITH_TORCHDYNAMO or TEST_WITH_CROSSREF:
         return  # skip testing
+
+    if not torch.xpu.is_available() and IS_WINDOWS:
+        return
 
     if isinstance(needs, str):
         needs = (needs,)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #146481
* __->__ #147347

This PR removes the restrictions on general cases for XPU on Windows, allowing us to run Inductor UT on Windows.
Additionally, this series of PRs has also fixed all XPU Inductor UT issues on Windows. However, due to resource constraints, we have not yet set up a Windows CI pipeline online.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames