### PR TITLE
[Inductor UT][XPU] Skip fft_c2c case since it's not implemented on XPU.

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -4526,7 +4526,7 @@ GPU_TEST_FAILURES = {
     # No scaled_dot_product_efficient_attention implementation for XPU yet.
     "test_scaled_dot_product_efficient_attention": fail_gpu(("xpu",)),
     # No fft implementation for XPU yet.
-    "test_fft_c2c": fail_gpu(("xpu",)),
+    "test_fft_c2c": fail_gpu(("xpu",), is_skip=True),
     "test_stft": fail_gpu(("xpu",)),
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147351



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov