### PR TITLE
handle default in _NamedOptimizer

### DIFF
--- a/torch/distributed/optim/named_optimizer.py
+++ b/torch/distributed/optim/named_optimizer.py
@@ -83,6 +83,8 @@ class _NamedOptimizer(optim.Optimizer):
             **kwargs,
         )
         self.module = module
+        self.defaults = self._optimizer.defaults
+
         if param_groups is None:
             self.ordered_param_keys = list(self.named_parameters.keys())
         else:


### PR DESCRIPTION
This pr propagate the defaults field of the wrapper optimizer to the _NamedOptimizer.

This fixes a bug where torch.compile would fail when calling optimizer.zero_grad()

```bash
[rank1]: AttributeError: '_NamedOptimizer' object has no attribute 'defaults'
[rank0]: Traceback (most recent call last):
[rank0]:   File "/root/prime-rl/train.py", line 256, in <module>
[rank0]:     train(config)
[rank0]:   File "/root/prime-rl/train.py", line 199, in train
[rank0]:     optimizer.zero_grad()
[rank0]:   File "/root/prime-rl/.venv/lib/python3.10/site-packages/torch/_compile.py", line 32, in inner
[rank0]:     return disable_fn(*args, **kwargs)
[rank0]:   File "/root/prime-rl/.venv/lib/python3.10/site-packages/torch/_dynamo/eval_frame.py", line 745, in _fn
[rank0]:     return fn(*args, **kwargs)
[rank0]:   File "/root/prime-rl/.venv/lib/python3.10/site-packages/torch/optim/optimizer.py", line 955, in zero_grad
[rank0]:     foreach = self.defaults.get("foreach", False) or self.defaults.get(
[rank0]: AttributeError: '_NamedOptimizer' object has no attribute 'defaults'
```

PS: When can we get `_NamedOptimizer` as public API ?

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o