### PR TITLE
[ROCm][TunableOp] resolve the rocBLAS version dynamically

### DIFF
--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -227,15 +227,10 @@ TuningResultsValidator::TuningResultsValidator() {
   }
   // rocblas
   {
-#define STRINGIFY(s) #s
-#define XSTRINGIFY(s) STRINGIFY(s)
-    std::string rocblas_version = c10::str(
-        XSTRINGIFY(ROCBLAS_VERSION_MAJOR), ".",
-        XSTRINGIFY(ROCBLAS_VERSION_MINOR), ".",
-        XSTRINGIFY(ROCBLAS_VERSION_PATCH), "-",
-        XSTRINGIFY(ROCBLAS_VERSION_TWEAK));
-#undef XSTRINGIFY
-#undef STRINGIFY
+    size_t rocblas_version_size;
+    rocblas_get_version_string_size(&rocblas_version_size);
+    std::string rocblas_version(rocblas_version_size - 1, '\0');
+    rocblas_get_version_string(rocblas_version.data(), rocblas_version_size);
     RegisterValidator(
         "ROCBLAS_VERSION",
         [rocblas_version]() { return rocblas_version; },

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4953,9 +4953,8 @@ class TestLinalg(TestCase):
         self.assertEqual(len(torch.cuda.tunable.get_validators()), validator_num_lines)
 
         validators = get_tunableop_validators()
-        if torch.version.hip:
-            assert "ROCBLAS_VERSION" in validators
-            assert re.match(r'^\d+.\d+.\d+.\d+.[a-z0-9]+$', validators["ROCBLAS_VERSION"]) # format: [major].[minor].[patch].[tweak].[commit id] according to https://github.com/ROCm/rocBLAS/blob/160c08b458e06fb2dc223736948695c2212a455c/library/include/internal/rocblas-version.h.in#L29-L33
+        assert "ROCBLAS_VERSION" in validators
+        assert re.match(r'^\d+.\d+.\d+.\d+.[a-z0-9]+$', validators["ROCBLAS_VERSION"]) # format: [major].[minor].[patch].[tweak].[commit id] according to https://github.com/ROCm/rocBLAS/blob/160c08b458e06fb2dc223736948695c2212a455c/library/include/internal/rocblas-version.h.in#L29-L33
 
         # disable TunableOp
         torch.cuda.tunable.enable(False)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4953,8 +4953,8 @@ class TestLinalg(TestCase):
         self.assertEqual(len(torch.cuda.tunable.get_validators()), validator_num_lines)
 
         validators = get_tunableop_validators()
-        assert "ROCBLAS_VERSION" in validators
-        assert re.match(r'^\d+.\d+.\d+.\d+.[a-z0-9]+$', validators["ROCBLAS_VERSION"]) # format: [major].[minor].[patch].[tweak].[commit id] according to https://github.com/ROCm/rocBLAS/blob/160c08b458e06fb2dc223736948695c2212a455c/library/include/internal/rocblas-version.h.in#L29-L33
+        self.assertTrue("ROCBLAS_VERSION" in validators)
+        self.assertTrue(re.match(r'^\d+.\d+.\d+.\d+.[a-z0-9]+$', validators["ROCBLAS_VERSION"])) # format: [major].[minor].[patch].[tweak].[commit id] according to https://github.com/ROCm/rocBLAS/blob/160c08b458e06fb2dc223736948695c2212a455c/library/include/internal/rocblas-version.h.in#L29-L33
 
         # disable TunableOp
         torch.cuda.tunable.enable(False)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4954,7 +4954,8 @@ class TestLinalg(TestCase):
 
         validators = get_tunableop_validators()
         self.assertTrue("ROCBLAS_VERSION" in validators)
-        self.assertTrue(re.match(r'^\d+.\d+.\d+.\d+.[a-z0-9]+$', validators["ROCBLAS_VERSION"])) # format: [major].[minor].[patch].[tweak].[commit id] according to https://github.com/ROCm/rocBLAS/blob/160c08b458e06fb2dc223736948695c2212a455c/library/include/internal/rocblas-version.h.in#L29-L33
+        # format: [major].[minor].[patch].[tweak].[commit id]
+        self.assertTrue(re.match(r'^\d+.\d+.\d+.\d+.[a-z0-9]+$', validators["ROCBLAS_VERSION"]))
 
         # disable TunableOp
         torch.cuda.tunable.enable(False)


### PR DESCRIPTION
Dynamically gets rocBLAS version instead of relying on some preprocessing-time definitions which may be stale.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd