### PR TITLE
[Inductor][CPP] Add float16 support for CppMicroGemmAMX

### DIFF
--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -829,7 +829,10 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
         vec_amx = VecAMX()
         # Currently brgemm config is only added for half
         if dtype == torch.half:
-            self._check_brgemm_counter(vec_amx)
+            if vec_amx.is_amx_fp16_supported():
+                self._check_amx_counter(vec_amx)
+            else:
+                self._check_brgemm_counter(vec_amx)
         else:
             self._check_amx_counter(vec_amx)
 

--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -828,11 +828,8 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
         self.assertEqual(counters["inductor"]["cpp_templated_kernel_counter"], 1)
         vec_amx = VecAMX()
         # Currently brgemm config is only added for half
-        if dtype == torch.half:
-            if vec_amx.is_amx_fp16_supported():
-                self._check_amx_counter(vec_amx)
-            else:
-                self._check_brgemm_counter(vec_amx)
+        if dtype == torch.half and not vec_amx.is_amx_fp16_supported():
+            self._check_brgemm_counter(vec_amx)
         else:
             self._check_amx_counter(vec_amx)
 

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -210,6 +210,9 @@ class VecAVX512(VecISA):
 @dataclasses.dataclass
 class VecAMX(VecAVX512):
     _arch_flags = VecAVX512._arch_flags + " -mamx-tile -mamx-bf16 -mamx-int8"
+    # check amx_fp16 separately since it is not always supported when amx is supported
+    # amx_fp16 intrinsic compilation need gcc >=13 on platforms which support amx_fp16
+    _is_amx_fp16_supported = False
 
     def __str__(self) -> str:
         return super().__str__() + " amx_tile"
@@ -237,31 +240,37 @@ extern "C" void __amx_chk_kernel() {
 }
 """
 
+    _amx_fp16_code = _amx_code.replace("_tile_dpbf16ps", "_tile_dpfp16ps")
+
     @functools.cache  # noqa: B019
     def __bool__(self) -> bool:
         if super().__bool__():
             if config.is_fbcode():
                 return False
             if self.check_build(VecAMX._amx_code) and torch.cpu._init_amx():
+                # check amx-fp16 as well when check amx
+                if torch.cpu._is_amx_fp16_supported():
+                    # save _arch_flags
+                    base_flags = self._arch_flags
+                    # temporarily change _arch_flags for amx-fp16 check_build
+                    self._arch_flags += " -mamx-fp16"
+                    if self.check_build(VecAMX._amx_fp16_code):
+                        self._is_amx_fp16_supported = True
+                    # restore _arch_flags
+                    self._arch_flags = base_flags
+
                 return True
         return False
 
-    # check amx_fp16 separately since it is not always supported when amx is supported
-    # amx_fp16 instrinsic compilation need gcc >=13 on platforms which support amx_fp16
     @functools.lru_cache(None)  # noqa: B019
     def is_amx_fp16_supported(self) -> bool:
-        if super().__bool__():
-            if config.is_fbcode():
-                return False
-            if torch.cpu._init_amx() and torch.cpu._is_amx_fp16_supported():
-                self._arch_flags += " -mamx-fp16"
-                if self.check_build(VecAMX._amx_fp16_code):
-                    return True
-                else:
-                    self._arch_flags = (
-                        VecAVX512._arch_flags + " -mamx-tile -mamx-bf16 -mamx-int8"
-                    )
-        return False
+        return self._is_amx_fp16_supported
+
+    def build_arch_flags(self) -> str:
+        if self._is_amx_fp16_supported:
+            return self._arch_flags + " -mamx-fp16"
+        else:
+            return self._arch_flags
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Add float16 support for CppMicroGemmAMX for float16 gemm template. Float16 CppMicroGemmAMX needs a higher version of compiler, e.g., GCC 13.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @yf225