### PR TITLE
Add HPU support to test_structured_sparsifier.py

### DIFF
--- a/test/ao/sparsity/test_structured_sparsifier.py
+++ b/test/ao/sparsity/test_structured_sparsifier.py
@@ -29,7 +29,12 @@ from torch.testing._internal.common_pruning import (
     SimpleConv2d,
     SimpleLinear,
 )
-from torch.testing._internal.common_utils import skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import (
+    skipIfTorchDynamo,
+    TEST_CUDA,
+    TEST_HPU,
+    TestCase,
+)
 
 
 logging.basicConfig(
@@ -38,8 +43,9 @@ logging.basicConfig(
 
 DEVICES = {
     torch.device("cpu"),
-    torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu"),
-}
+    torch.device("cuda") if TEST_CUDA else None,
+    torch.device("hpu") if TEST_HPU else None,
+} - {None}
 
 
 class SimplePruner(BaseStructuredSparsifier):


### PR DESCRIPTION
# MOTIVATION

We recently integrated support for Intel Gaudi devices (identified as 'hpu') into the common_device_type framework via the pull request at https://github.com/pytorch/pytorch/pull/126970. This integration allows tests to be automatically instantiated for Gaudi devices upon loading the relevant library. Building on this development, the current pull request extends the utility of these hooks by adapting tests from test_structured_sparsifier.py to operate on Gaudi devices. Additionally, we have confirmed that these modifications do not interfere with the existing tests on CUDA devices.

Other accelerators can also extend the functionality by adding the device in the devices set. ( For eg: xpu )

Please note that the previous PR (https://github.com/pytorch/pytorch/pull/147370) was deleted due to CLA issues. 

# CHANGES
Use TEST_CUDA and TEST_HPU flags to set the device available in the test environment
@ankurneog 
