### PR TITLE
[ROCm][Windows] Enable torchvision build with ROCm on Windows

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2794,7 +2794,7 @@ e.
     if IS_WINDOWS:
         compiler_name = "$cxx" if IS_HIP_EXTENSION else "cl"
         compile_rule.append(
-                f'  command = {compiler_name} /showIncludes $cflags -c $in /Fo$out $post_cflags')
+            f'  command = {compiler_name} /showIncludes $cflags -c $in /Fo$out $post_cflags')
         if not IS_HIP_EXTENSION:
             compile_rule.append('  deps = msvc')
     else:

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -842,7 +842,7 @@ class BuildExtension(build_ext):
         def win_cuda_flags(cflags):
             return (COMMON_NVCC_FLAGS +
                     cflags + _get_cuda_arch_flags(cflags))
-        
+
         def win_hip_flags(cflags):
             return (COMMON_HIPCC_FLAGS + COMMON_HIP_FLAGS + cflags + _get_rocm_arch_flags(cflags))
 
@@ -885,7 +885,7 @@ class BuildExtension(build_ext):
                         if IS_HIP_EXTENSION:
                             nvcc = _get_hipcc_path()
                         else:
-                            nvcc = _join_cuda_home('bin', 'nvcc')     
+                            nvcc = _join_cuda_home('bin', 'nvcc')
                         if isinstance(self.cflags, dict):
                             cflags = self.cflags['nvcc']
                         elif isinstance(self.cflags, list):
@@ -894,7 +894,7 @@ class BuildExtension(build_ext):
                             cflags = []
 
                         if IS_HIP_EXTENSION:
-                            cflags = win_hip_flags(cflags)   
+                            cflags = win_hip_flags(cflags)
                         else:
                             cflags = win_cuda_flags(cflags) + ['-std=c++17', '--use-local-env']
                             for ignore_warning in MSVC_IGNORE_CUDAFE_WARNINGS:
@@ -948,7 +948,7 @@ class BuildExtension(build_ext):
                                              depends, extra_postargs)
             # Replace space with \ when using hipcc (hipcc passes includes to clang without ""s so clang sees space in include paths as new argument)
             if IS_HIP_EXTENSION:
-                pp_opts = ["-I{}".format(s[2:].replace(" ", "\\")) if s.startswith('-I') else s for s in pp_opts]              
+                pp_opts = ["-I{}".format(s[2:].replace(" ", "\\")) if s.startswith('-I') else s for s in pp_opts]
             common_cflags = extra_preargs or []
             cflags = []
             if debug:
@@ -960,7 +960,7 @@ class BuildExtension(build_ext):
                 _set_hipcc_runtime_lib(is_standalone, debug)
                 common_cflags.extend(COMMON_HIP_FLAGS)
             else:
-                common_cflags.extend(COMMON_MSVC_FLAGS) 
+                common_cflags.extend(COMMON_MSVC_FLAGS)
             with_cuda = any(map(_is_cuda_file, sources))
 
             # extra_postargs can be either:
@@ -992,7 +992,7 @@ class BuildExtension(build_ext):
                 else:
                     cuda_post_cflags = list(extra_postargs)
                 if IS_HIP_EXTENSION:
-                    cuda_post_cflags = win_hip_flags(cuda_post_cflags)  
+                    cuda_post_cflags = win_hip_flags(cuda_post_cflags)
                 else:
                     cuda_post_cflags = win_cuda_flags(cuda_post_cflags)
             cflags = _nt_quote_args(cflags)
@@ -2113,7 +2113,7 @@ def _get_hipcc_path():
         return _join_rocm_home('bin', 'hipcc.bat')
     else:
         return _join_rocm_home('bin', 'hipcc')
-    
+
 def _write_ninja_file_and_compile_objects(
         sources: list[str],
         objects,

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -139,7 +139,6 @@ class GeneratedFileCleaner:
             for d in self.dirs_to_clean[::-1]:
                 os.rmdir(d)
 
-
 # Follow UNIX convention for paths to use '/' instead of '\\' on Windows
 def _to_unix_path(path: str) -> str:
     return path.replace(os.sep, '/')
@@ -830,6 +829,7 @@ def preprocessor(
         show_progress: bool) -> HipifyResult:
     """ Executes the CUDA -> HIP conversion on the specified file. """
     fin_path = os.path.abspath(os.path.join(output_directory, filepath))
+    filepath = _to_unix_path(filepath) 
     hipify_result = HIPIFY_FINAL_RESULT[fin_path]
     if filepath not in all_files:
         hipify_result.hipified_path = None
@@ -932,8 +932,8 @@ def preprocessor(
                         return templ.format(os.path.relpath(header_fout_path if header_fout_path is not None
                                                             else header_filepath, header_dir))
                 hipified_header_filepath = HIPIFY_FINAL_RESULT[header_filepath].hipified_path
-                return templ.format(os.path.relpath(hipified_header_filepath if hipified_header_filepath is not None
-                                                    else header_filepath, header_dir))
+                return templ.format(_to_unix_path(os.path.relpath(hipified_header_filepath if hipified_header_filepath is not None
+                                                    else header_filepath, header_dir)))
 
             return m.group(0)
         return repl

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -829,7 +829,7 @@ def preprocessor(
         show_progress: bool) -> HipifyResult:
     """ Executes the CUDA -> HIP conversion on the specified file. """
     fin_path = os.path.abspath(os.path.join(output_directory, filepath))
-    filepath = _to_unix_path(filepath) 
+    filepath = _to_unix_path(filepath)
     hipify_result = HIPIFY_FINAL_RESULT[fin_path]
     if filepath not in all_files:
         hipify_result.hipified_path = None
@@ -933,7 +933,7 @@ def preprocessor(
                                                             else header_filepath, header_dir))
                 hipified_header_filepath = HIPIFY_FINAL_RESULT[header_filepath].hipified_path
                 return templ.format(_to_unix_path(os.path.relpath(hipified_header_filepath if hipified_header_filepath is not None
-                                                    else header_filepath, header_dir)))
+                                                                  else header_filepath, header_dir)))
 
             return m.group(0)
         return repl


### PR DESCRIPTION
- Updated HIP flags for Windows (removed non Windows flags on Windows case, added runtime library)
- Set hipcc call for Windows case
- Removed CUDA flags (not used in ROCm) on Windows
- Updated Windows compiler (added case when using ROCm on Windows)
- Fixed path issue in hipify_python


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd