### PR TITLE
Add overflow check for large storage_offsets

### DIFF
--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -89,7 +89,7 @@ inline void checkInBoundsForStorage(
   T storage_size_bytes =
       at::detail::computeStorageNbytes(size, stride, data_type.itemsize());
   int64_t storage_offset_bytes;
-  bool storage_offset_bytes_overflow = c10::mul_overflows(maybe_convert_symint<int64_t>(storage_offset), data_type.itemsize(), &storage_offset_bytes);
+  const auto storage_offset_bytes_overflow = c10::mul_overflows(maybe_convert_symint<int64_t>(storage_offset), data_type.itemsize(), &storage_offset_bytes);
 
   TORCH_CHECK(!storage_offset_bytes_overflow,
               "Storage offset byte calculation overflowed with offset=", storage_offset);

--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -88,20 +88,20 @@ inline void checkInBoundsForStorage(
     const Storage& new_storage) {
   T storage_size_bytes =
       at::detail::computeStorageNbytes(size, stride, data_type.itemsize());
-  T storage_offset_bytes;
-  T storage_offset_bytes = c10::mul_overflows(storage_offset, data_type.itemsize(), &storage_offset_bytes);
+  int64_t storage_offset_bytes;
+  bool storage_offset_bytes_overflow = c10::mul_overflows(maybe_convert_symint<int64_t>(storage_offset), data_type.itemsize(), &storage_offset_bytes);
 
-  TORCH_CHECK(!storage_offset_bytes,
+  TORCH_CHECK(!storage_offset_bytes_overflow,
               "Storage offset byte calculation overflowed with offset=", storage_offset);
 
   if (storage_size_bytes == 0) {
     // NB: (a tensor with arbitrary 0 dims)'s storage can have any numel.
     return;
   }
-  T new_storage_size_bytes = maybe_convert_symint<T>(new_storage.sym_nbytes());
+  int64_t new_storage_size_bytes = maybe_convert_symint<int64_t>(new_storage.sym_nbytes());
 
-  T sum_size;
-  bool overflowed = c10::add_overflows(storage_size_bytes, storage_offset_bytes, &sum_size);
+  int64_t sum_size;
+  bool overflowed = c10::add_overflows(maybe_convert_symint<int64_t>(storage_size_bytes), maybe_convert_symint<int64_t>(storage_offset_bytes), &sum_size);
 
   TORCH_CHECK(!overflowed,
               "Total storage size calculation overflowed with offset=", storage_offset);
@@ -173,8 +173,6 @@ inline void setStrided(
                 "as_strided: Negative strides are not supported at the moment, "
                 "got strides: ", stride);
   }
-
-  
 
   auto* self_ = self.unsafeGetTensorImpl();
   checkInBoundsForStorage(

--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -6,6 +6,7 @@
 #include <ATen/TensorUtils.h>
 
 #include <c10/core/CPUAllocator.h>
+#include <c10/util/safe_numerics.h>
 
 #include <utility>
 
@@ -87,14 +88,26 @@ inline void checkInBoundsForStorage(
     const Storage& new_storage) {
   T storage_size_bytes =
       at::detail::computeStorageNbytes(size, stride, data_type.itemsize());
-  T storage_offset_bytes = storage_offset * data_type.itemsize();
+  T storage_offset_bytes;
+  T storage_offset_bytes = c10::mul_overflows(storage_offset, data_type.itemsize(), &storage_offset_bytes);
+
+  TORCH_CHECK(!storage_offset_bytes,
+              "Storage offset byte calculation overflowed with offset=", storage_offset);
+
   if (storage_size_bytes == 0) {
     // NB: (a tensor with arbitrary 0 dims)'s storage can have any numel.
     return;
   }
   T new_storage_size_bytes = maybe_convert_symint<T>(new_storage.sym_nbytes());
+
+  T sum_size;
+  bool overflowed = c10::add_overflows(storage_size_bytes, storage_offset_bytes, &sum_size);
+
+  TORCH_CHECK(!overflowed,
+              "Total storage size calculation overflowed with offset=", storage_offset);
+
   TORCH_CHECK(
-      storage_size_bytes + storage_offset_bytes <= new_storage_size_bytes,
+      sum_size <= new_storage_size_bytes,
       "setStorage: sizes ",
       size,
       ", strides ",
@@ -160,6 +173,8 @@ inline void setStrided(
                 "as_strided: Negative strides are not supported at the moment, "
                 "got strides: ", stride);
   }
+
+  
 
   auto* self_ = self.unsafeGetTensorImpl();
   checkInBoundsForStorage(

--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -36,7 +36,7 @@ C10_ALWAYS_INLINE bool add_overflows(int64_t a, int64_t b, int64_t* out) {
   return __builtin_add_overflow(a, b, out);
 #else
   *out = a + b;
-  return *out < a;
+  return b >= 0 ? *out < a : *out > a;
 #endif
 }
 

--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -31,6 +31,15 @@ C10_ALWAYS_INLINE bool add_overflows(uint64_t a, uint64_t b, uint64_t* out) {
 #endif
 }
 
+C10_ALWAYS_INLINE bool add_overflows(int64_t a, int64_t b, int64_t* out) {
+#if C10_HAS_BUILTIN_OVERFLOW()
+  return __builtin_add_overflow(a, b, out);
+#else
+  *out = a + b;
+  return *out < a;
+#endif
+}
+
 C10_ALWAYS_INLINE bool mul_overflows(uint64_t a, uint64_t b, uint64_t* out) {
 #if C10_HAS_BUILTIN_OVERFLOW()
   return __builtin_mul_overflow(a, b, out);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9169,6 +9169,18 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         self.assertIsNotNone(torch.tensor([]).clone().storage())
         self.assertIsNotNone(torch.tensor([0, 0, 0]).nonzero().storage())
         self.assertIsNotNone(torch.tensor([]).new().storage())
+        
+    def test_large_storage_offset_not_allowed(self):
+        """Test that large storage offsets that would cause overflow are caught and raise exceptions."""
+        t = torch.arange(10)
+        
+        # Test very large positive storage_offset that would overflow
+        with self.assertRaisesRegex(RuntimeError, "Storage offset byte calculation overflowed"):
+            torch.as_strided(t, size=(5,), stride=(2,), storage_offset=8170450533120000000)
+        
+        # Test very large negative storage_offset that would lead to wrong tensor
+        with self.assertRaisesRegex(RuntimeError, "Storage offset byte calculation overflowed"):
+            torch.as_strided(t, size=(5,), stride=(2,), storage_offset=2**63-10000)
 
     # FIXME: Extend this test and put in a TensorProperties test class
     def test_numel(self):


### PR DESCRIPTION
Fixes #145259

This adds two overflow checks to the storage offset calculation @ `aten/src/ATen/native/Resize.h`, avoiding this to crash:

```
python3 -c "import torch; print(torch.as_strided(torch.arange(10), size=(5,), stride=(2,), storage_offset=8170450533120000000))"
```

and avoiding this to return a wrong Tensor:
```
python3 -c "import torch; print(torch.as_strided(torch.arange(10), size=(5,), stride=(2,), storage_offset=2**63-10000))"

```

