### PR TITLE
fix pt2e block wise quantization unit test

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -2545,12 +2545,10 @@ class TestQuantizePT2EAffineQuantization(PT2EQuantizationTestCase):
                 return self.linear(x)
 
         node_occurrence = {
-            torch.ops.pt2e_quant.quantize_affine: 2,
+            torch.ops.pt2e_quant.quantize_affine: 1,
             torch.ops.pt2e_quant.dequantize_affine: 2,
         }
         node_list = [
-            torch.ops.pt2e_quant.quantize_affine,
-            torch.ops.pt2e_quant.dequantize_affine,
             torch.ops.pt2e_quant.quantize_affine,
             torch.ops.pt2e_quant.dequantize_affine,
         ]


### PR DESCRIPTION
Differential Revision: D69806596

https://github.com/pytorch/pytorch/pull/146946 breaks the unit test, because the quant nodes are folded by default now. 

