### PR TITLE
[ONNX] Pick up missing types in dynamic shapes renaming

### DIFF
--- a/test/onnx/exporter/test_dynamic_shapes.py
+++ b/test/onnx/exporter/test_dynamic_shapes.py
@@ -331,7 +331,7 @@ class TestDynamicShapes(common_utils.TestCase):
         }
         self.assertEqual(unflatten_dynamic_shapes, expected_dynamic_shapes)
 
-    def test__flatten_dynamic_shapes_to_axes_with_leaves_that_are_supported_byexported_program(
+    def test__flatten_dynamic_shapes_to_axes_with_leaves_that_are_supported_by_exported_program(
         self,
     ):
         dim = torch.export.Dim("dim")

--- a/test/onnx/exporter/test_dynamic_shapes.py
+++ b/test/onnx/exporter/test_dynamic_shapes.py
@@ -514,7 +514,7 @@ class TestDynamicShapes(common_utils.TestCase):
             _dynamic_shapes.convert_str_to_export_dim(dynamic_shapes)
         )
         self.assertEqual(dynamic_shapes_with_export_dim, dynamic_shapes)
-        self.assertFalse(need_axis_mapping)
+        self.assertTrue(need_axis_mapping)
 
         # 2. Tuple
         dynamic_shapes = (

--- a/test/onnx/exporter/test_dynamic_shapes.py
+++ b/test/onnx/exporter/test_dynamic_shapes.py
@@ -331,6 +331,31 @@ class TestDynamicShapes(common_utils.TestCase):
         }
         self.assertEqual(unflatten_dynamic_shapes, expected_dynamic_shapes)
 
+    def test__flatten_dynamic_shapes_to_axes_with_leaves_that_are_supported_byexported_program(
+        self,
+    ):
+        dim = torch.export.Dim("dim")
+        dynamic_shapes = (
+            {
+                "input_a": {0: dim, 1: None},
+                "input_b": {1: torch.export.Dim.AUTO, 3: 512},
+            },
+            (
+                [torch.export.Dim.STATIC, torch.export.Dim.DYNAMIC, None],
+                [dim, 512],
+            ),
+        )
+        flatten_dynamic_shapes, _ = _dynamic_shapes._flatten_dynamic_shapes_to_axes(
+            dynamic_shapes
+        )
+        expected_flattened = [
+            {0: dim, 1: None},
+            {1: torch.export.Dim.AUTO, 3: 512},
+            [torch.export.Dim.STATIC, torch.export.Dim.DYNAMIC, None],
+            [dim, 512],
+        ]
+        self.assertEqual(flatten_dynamic_shapes, expected_flattened)
+
     @common_utils.parametrize(
         "model, args, kwargs, input_names, output_names, dynamic_axes, expected_dynamic_shapes",
         [

--- a/test/onnx/exporter/test_dynamic_shapes.py
+++ b/test/onnx/exporter/test_dynamic_shapes.py
@@ -493,42 +493,42 @@ class TestDynamicShapes(common_utils.TestCase):
         _, tree2 = _pytree.tree_flatten(expected_dynamic_shapes)
         self.assertEqual(tree1, tree2)
 
-    def test_convert_str_to_export_dim_returns_the_original_dynamic_shapes_when_there_is_no_str(
+    def test_convert_str_to_export_dim_returns_the_original_dynamic_shapes_when_there_is_no_str_and_dim(
         self,
     ):
         # 1. Dict
         dynamic_shapes = {
             "input_x": [
                 {
-                    0: torch.export.Dim("customx_dim_0"),
+                    0: torch.export.Dim.AUTO,
                     1: torch.export.Dim.AUTO,
                 },
                 {
                     0: torch.export.Dim.AUTO,
-                    1: torch.export.Dim("customx_dim_1"),
+                    1: torch.export.Dim.AUTO,
                 },
             ],
-            "input_b": {2: torch.export.Dim("customb_dim_0")},
+            "input_b": {2: torch.export.Dim.AUTO},
         }
         dynamic_shapes_with_export_dim, need_axis_mapping = (
             _dynamic_shapes.convert_str_to_export_dim(dynamic_shapes)
         )
         self.assertEqual(dynamic_shapes_with_export_dim, dynamic_shapes)
-        self.assertTrue(need_axis_mapping)
+        self.assertFalse(need_axis_mapping)
 
         # 2. Tuple
         dynamic_shapes = (
             [
                 {
-                    0: torch.export.Dim("customx_dim_0"),
+                    0: torch.export.Dim.AUTO,
                     1: torch.export.Dim.AUTO,
                 },
                 {
                     0: torch.export.Dim.AUTO,
-                    1: torch.export.Dim("customx_dim_1"),
+                    1: torch.export.Dim.AUTO,
                 },
             ],
-            {2: torch.export.Dim("customb_dim_0")},
+            {2: torch.export.Dim.AUTO},
         )
         dynamic_shapes_with_export_dim, need_axis_mapping = (
             _dynamic_shapes.convert_str_to_export_dim(dynamic_shapes)
@@ -536,7 +536,7 @@ class TestDynamicShapes(common_utils.TestCase):
         self.assertEqual(dynamic_shapes_with_export_dim, dynamic_shapes)
         self.assertFalse(need_axis_mapping)
 
-    def test_convert_str_to_export_dim_returns_the_converted_dynamic_shapes_when_there_is_str(
+    def test_convert_str_to_export_dim_returns_the_converted_dynamic_shapes_when_there_is_str_or_dim(
         self,
     ):
         dimx = torch.export.Dim("customx_dim_1")

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -508,6 +508,33 @@ class DynamoExporterTest(common_utils.TestCase):
         ):
             self.assertEqual(input.shape[0].value, expected_axis_name)
 
+    def test_export_of_static_dim_constraints(self):
+        # NOTE: This test is to ensure that the static dim constraints are respected.
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.l = torch.nn.Linear(6, 4)
+
+            def forward(self, x, y, z):
+                x0 = self.l(x) + y[1:]
+                return x0, z * 2.0
+
+        inputs = (torch.randn(4, 6), torch.randn(5, 4), torch.randn(3, 3))
+        dx = torch.export.Dim("dx", min=3, max=6)
+        dy = dx + 1
+        dz = torch.export.Dim("dz", min=3, max=6)
+
+        # all of these should be fine
+        dynamic_shapes = (
+            {0: dx, 1: torch.export.Dim.AUTO},
+            {0: dy, 1: None},
+            {0: dz, 1: 3},
+        )
+        onnx_program = self.export(Model(), inputs, dynamic_shapes=dynamic_shapes)
+        onnx_testing.assert_onnx_program(onnx_program, args=inputs)
+        # make sre the naming is working
+        self.assertEqual(onnx_program.model.graph.inputs[0].shape[0], "dx")
+
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/torch/onnx/_internal/exporter/_dynamic_shapes.py
+++ b/torch/onnx/_internal/exporter/_dynamic_shapes.py
@@ -246,7 +246,7 @@ def create_rename_mapping(
                 old_name = input.shape[dim].value
                 if old_name is None:
                     continue
-                # _DimHint and int and None exists in dynamic shapes, we skip renaming
+                # _DimHint, int and None exists in dynamic shapes, we skip renaming
                 if isinstance(axis, (_DimHint, int)) or axis is None:
                     continue
                 # NOTE: ExportedProgram could give the axes the same name if they share
@@ -266,7 +266,7 @@ def create_rename_mapping(
                 old_name = input.shape[dim].value
                 if old_name is None:
                     continue
-                # _DimHint and int and None exists in dynamic shapes, we skip renaming
+                # _DimHint, int and None exists in dynamic shapes, we skip renaming
                 if isinstance(axis, (_DimHint, int)) or axis is None:
                     continue
                 # NOTE: ExportedProgram could give the axes the same name if they share

--- a/torch/onnx/_internal/exporter/_dynamic_shapes.py
+++ b/torch/onnx/_internal/exporter/_dynamic_shapes.py
@@ -151,19 +151,22 @@ def from_dynamic_shapes_to_dynamic_axes(
     return dynamic_axes
 
 
-def _any_str_in_dynamic_shapes(
+def _any_str_or_dim_in_dynamic_shapes(
     dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any],
 ) -> bool:
-    """Check if there is any string in the dynamic_shapes."""
+    """Check if there is any string or _Dim in the dynamic_shapes."""
     flat_dynamic_shapes, _ = _flatten_dynamic_shapes_to_axes(dynamic_shapes)
+    if any(not isinstance(axes, (dict, list, tuple)) for axes in flat_dynamic_shapes):
+        return False
+    # both str and _Dim can provide custom names
     for axes in flat_dynamic_shapes:
         if isinstance(axes, dict):
             for dim in axes.values():
-                if isinstance(dim, str):
+                if isinstance(dim, (str, _Dim)):
                     return True
         elif isinstance(axes, (list, tuple)):
             for dim in axes:
-                if isinstance(dim, str):
+                if isinstance(dim, (str, _Dim)):
                     return True
     return False
 
@@ -172,9 +175,8 @@ def convert_str_to_export_dim(
     dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any] | None,
 ) -> tuple[dict[str, Any] | tuple[Any, ...] | list[Any] | None, bool]:
     # 1. If there is no string in dynamic_shapes, we do not touch dynamic_shapes
-    if dynamic_shapes is None or not _any_str_in_dynamic_shapes(dynamic_shapes):
+    if dynamic_shapes is None or not _any_str_or_dim_in_dynamic_shapes(dynamic_shapes):
         return dynamic_shapes, False
-
     # 2. Convert "name" to Dim.AUTO with flattening and identify if there is any string
     #    to be replaced with Dim.AUTO, and then unflatten it back to the original structure.
     #    for example: {"y": {0: "dim_0"}, "x": {1: "dim_1"}}
@@ -244,7 +246,8 @@ def create_rename_mapping(
                 old_name = input.shape[dim].value
                 if old_name is None:
                     continue
-                if isinstance(axis, _DimHint):
+                # _DimHint and int and None exists in dynamic shapes, we skip renaming
+                if isinstance(axis, (_DimHint, int)) or axis is None:
                     continue
                 # NOTE: ExportedProgram could give the axes the same name if they share
                 # the same shape constraints.
@@ -263,7 +266,8 @@ def create_rename_mapping(
                 old_name = input.shape[dim].value
                 if old_name is None:
                     continue
-                if isinstance(axis, _DimHint):
+                # _DimHint and int and None exists in dynamic shapes, we skip renaming
+                if isinstance(axis, (_DimHint, int)) or axis is None:
                     continue
                 # NOTE: ExportedProgram could give the axes the same name if they share
                 # the same shape constraints.
@@ -304,12 +308,12 @@ def _flatten_dynamic_shapes_to_axes(
             isinstance(x, dict)
             and all(
                 isinstance(k, int)
-                and (v is None or isinstance(v, (_Dim, _DimHint, str)))
+                and (v is None or isinstance(v, (_Dim, _DimHint, str, int)))
                 for k, v in x.items()
             )
         ) or (
             isinstance(x, (list, tuple))
-            and all(isinstance(v, (_Dim, _DimHint, str)) for v in x)
+            and all(v is None or isinstance(v, (_Dim, _DimHint, str, int)) for v in x)
         )
 
     return _pytree.tree_flatten(dynamic_shapes, is_leaf=is_axes)

--- a/torch/onnx/_internal/exporter/_ir_passes.py
+++ b/torch/onnx/_internal/exporter/_ir_passes.py
@@ -64,7 +64,6 @@ def rename_axis(model: ir.Model, rename_mapping: dict[str, str]) -> None:
     sorted_rename_mapping = dict(
         sorted(rename_mapping.items(), key=lambda item: len(item[0]), reverse=True)
     )
-
     for value in _all_values(model):
         if value.shape is None:
             continue


### PR DESCRIPTION
Found in `_check_dynamic_shapes` that int and None type are valid inputs of dynamic_shapes.
This PR adds the support on these two types and add the tests to guard the sync of ONNX flatten logic and the one in expor.t  