### PR TITLE
Validate sparse tensors constructed via legacy constructor

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -165,6 +165,20 @@ class TestSparseLegacyAndDeprecation(TestCase):
             # Check warn-once:
             self.assertEqual(len(cm.warnings), 1)
 
+    @skipIfTorchDynamo("TorchDynamo fails with unknown reason")
+    def test_legacy_ctor_validates(self):
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "size is inconsistent with indices: for dim 0, size is 1 but found index 4702111234474983745"
+        ):
+            x = torch.sparse.FloatTensor(
+                torch.tensor([[4702111234474983745], [0]]),
+                torch.tensor([4774451407313060418], dtype=torch.float32),
+                (1, 1)
+            )
+
+
 
 class TestSparseBase(TestCase):
     def run(self, result=None):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -165,7 +165,7 @@ class TestSparseLegacyAndDeprecation(TestCase):
             # Check warn-once:
             self.assertEqual(len(cm.warnings), 1)
 
-    @skipIfTorchDynamo("TorchDynamo fails with unknown reason")
+
     def test_legacy_ctor_validates(self):
 
         with self.assertRaisesRegex(

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -638,7 +638,7 @@ Tensor legacy_sparse_tensor_generic_ctor_new(
     }
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     auto cdata = reinterpret_cast<void*>(r.toInt64(0));
-    auto result = at::unsafeTensorFromTH(cdata, true);
+    result = at::unsafeTensorFromTH(cdata, true);
   } else if (r.idx == 2) {
     if (ctor_or_new == CtorOrNew::CTOR) {
       TORCH_WARN_ONCE(
@@ -650,7 +650,7 @@ Tensor legacy_sparse_tensor_generic_ctor_new(
     auto deviceOptional = r.deviceOptional(2);
     check_legacy_ctor_device(dispatch_key, deviceOptional);
     at::OptionalDeviceGuard device_guard(deviceOptional);
-    auto result = at::sparse_coo_tensor(r.tensor(0), r.tensor(1));
+    result = at::sparse_coo_tensor(r.tensor(0), r.tensor(1));
   } else if (r.idx == 3) {
     if (ctor_or_new == CtorOrNew::CTOR) {
       TORCH_WARN_ONCE(
@@ -689,6 +689,7 @@ Tensor legacy_sparse_tensor_generic_ctor_new(
     result =
         new_with_sizes(options, scalar_type, deviceOptional, r.symintlist(0));
   }
+
   if (result.defined()) {
     at::_validate_sparse_coo_tensor_args(
         result._indices(),


### PR DESCRIPTION
EDIT: this is not an encompassing fix because of legacy_load, will redo

provided exploit now errors with 

RuntimeError: size is inconsistent with indices: for dim 0, size is 1 but found index 4702111234474983745
during torch.load


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147408

