### PR TITLE
[caffe2] disable warning for unused arguments

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/buckbuild.bzl
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/buckbuild.bzl
@@ -464,6 +464,7 @@ def define_qnnpack(third_party, labels = []):
         apple_sdks = (IOS, MACOSX, APPLETVOS),
         compiler_flags = [
             "-DPYTORCH_QNNPACK_RUNTIME_QUANTIZATION",
+            "-Wno-unused-command-line-argument",
         ],
         fbobjc_preprocessor_flags = [
             "-DQNNP_PRIVATE=",


### PR DESCRIPTION
Summary: Disable warnings on unused command line arguments for ukernels_asm.

Test Plan:
On top of D69602077:
```
$ buck2 build --flagfile fbsource//xplat/mode/arstudio/auto.py fbsource//xplat/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack:ukernels_asmAppleMac
```

Differential Revision: D69807977




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10