### PR TITLE
[util] fetch logical count cpu

### DIFF
--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -413,7 +413,7 @@ class UsageLogger:
                 self._gpu_lib_detected = "amdsmi"
                 self._gpu_handles = amdsmi.amdsmi_get_processor_handles()
 
-            self._num_of_cpus = psutil.cpu_count(logical=False)
+            self._num_of_cpus = psutil.cpu_count(logical=True)
             # update summary info
             self._metadata.gpu_type = self._gpu_lib_detected
             self._metadata.gpu_count = len(self._gpu_handles)


### PR DESCRIPTION
To match with Vcpu count with aws:

after (96), before (48)
Instance Ref: https://instances.vantage.sh/aws/ec2/g4dn.metal
before: https://hud.pytorch.org/utilization/13377376406/37360984234/1
after: https://hud.pytorch.org/utilization/13401543806/37435031356/1