### PR TITLE
To enable NCCL communication to support uint64 tensors

### DIFF
--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -114,6 +114,8 @@ ncclDataType_t to_nccl_data_type(c10::ScalarType type) {
       return ncclDataType_t::ncclUint8;
     case at::kBool:
       return ncclDataType_t::ncclUint8;
+    case at::kUInt64:
+      return ncclDataType_t::ncclUint64;
 #if defined(USE_ROCM)
     case at::kFloat8_e4m3fnuz:
       return ncclDataType_t::ncclUint8;


### PR DESCRIPTION
In the field of cryptography and privacy computing,  is crucial. During our work with PyTorch, we discovered that NCCL communication does not support . Therefore, in this modification, we have enabled NCCL to support  tensor types.


