### PR TITLE
xpu: torch.xpu.get_arch_list() to return [] if xpu not compiled

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -290,8 +290,6 @@ _COMMON_SYCL_FLAGS = [
 def _get_sycl_arch_list():
     if 'TORCH_XPU_ARCH_LIST' in os.environ:
         return os.environ.get('TORCH_XPU_ARCH_LIST')
-    if not torch.xpu.is_available():
-        return ""
     arch_list = torch.xpu.get_arch_list()
     # Dropping dg2-* archs since they lack hardware support for fp64 and require
     # special consideration from the user. If needed these platforms can

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -420,6 +420,8 @@ def synchronize(device: _device_t = None) -> None:
 
 def get_arch_list() -> list[str]:
     r"""Return list XPU architectures this library was compiled for."""
+    if not _is_compiled():
+        return []
     arch_flags = torch._C._xpu_getArchFlags()
     if arch_flags is None:
         return []


### PR DESCRIPTION
Initially discussed here: https://github.com/pytorch/pytorch/pull/132945#discussion_r1957366131

Previously `torch.xpu.get_arch_list()` got relaxed to work even if XPU device is not available. However, we overlooked the case when pytorch is not compiled with XPU support. In such a case function throws an exception. This commit adjusts this behavior and makes function return `[]` even if pytorch is not compiled with XPU support.

CC: @EikanWang @fengyuan14 @guangyey @malfet @albanD 
