### PR TITLE
 [Export][AO] Include another batch_norm op in supported batch_norms

### DIFF
--- a/torch/ao/quantization/pt2e/utils.py
+++ b/torch/ao/quantization/pt2e/utils.py
@@ -151,6 +151,7 @@ def _is_supported_batch_norm_for_training(node: Node):
     supported_ops = [
         torch.ops.aten.batch_norm.default,
         torch.ops.aten._native_batch_norm_legit.default,
+        torch.ops.aten._native_batch_norm_legit_functional.default
         # Note: we won't need this op anymore after batch norm consolidation
         # For now, we need to continue to support it because it gives better
         # training numerics than `_native_batch_norm_legit`
@@ -307,6 +308,7 @@ def _fuse_conv_bn_(m: GraphModule) -> None:
         if n.op != "call_function" or n.target not in (
             torch.ops.aten._native_batch_norm_legit_no_training.default,
             torch.ops.aten.batch_norm.default,
+            torch.ops.aten._native_batch_norm_legit_functional.default
         ):
             continue
         bn_node = n


### PR DESCRIPTION
Running export with decomposition in PT export produces a graph with `aten._native_batch_norm_legit_functional.default` instead of other identified batch_norm ops in torch ao. This PR aims to include this op into torch AO utils.

```
class SimpleModel(torch.nn.Module):
    def __init__(self, input_dim=10, hidden_dim=20, output_dim=5):
        super().__init__()
        self.fc1 = torch.nn.Linear(input_dim, output_dim)
        self.bn1 = torch.nn.BatchNorm1d(output_dim)

    def forward(self, x):
        x = self.fc1(x)
        x = self.bn1(x)
        return x
def get_args(model, node_name):
    for node in model.graph.nodes:
        print(node.target)
        if(node.name == node_name):
            return node.args

ex_input = torch.randn((16,10))
ep_decomp = torch.export.export(SimpleModel(), args=(ex_input,)).run_decompositions().module()
print(ep_decomp.code)
```
Produces the following model:
```
def forward(self, x):
    x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
    fc1_weight = self.fc1.weight
    fc1_bias = self.fc1.bias
    bn1_weight = self.bn1.weight
    bn1_bias = self.bn1.bias
    bn1_running_mean = self.bn1.running_mean
    bn1_running_var = self.bn1.running_var
    bn1_num_batches_tracked = self.bn1.num_batches_tracked
    permute = torch.ops.aten.permute.default(fc1_weight, [1, 0]);  fc1_weight = None
    addmm = torch.ops.aten.addmm.default(fc1_bias, x, permute);  fc1_bias = x = permute = None
    add = torch.ops.aten.add.Tensor(bn1_num_batches_tracked, 1)
    _native_batch_norm_legit_functional = torch.ops.aten._native_batch_norm_legit_functional.default(addmm, bn1_weight, bn1_bias, bn1_running_mean, bn1_running_var, True, 0.1, 1e-05);  addmm = bn1_weight = bn1_bias = None
    getitem = _native_batch_norm_legit_functional[0]
    getitem_3 = _native_batch_norm_legit_functional[3]
    getitem_4 = _native_batch_norm_legit_functional[4];  _native_batch_norm_legit_functional = None
    copy__default = torch.ops.aten.copy_.default(bn1_running_mean, getitem_3);  bn1_running_mean = getitem_3 = copy__default = None
    copy__default_1 = torch.ops.aten.copy_.default(bn1_running_var, getitem_4);  bn1_running_var = getitem_4 = copy__default_1 = None
    copy__default_2 = torch.ops.aten.copy_.default(bn1_num_batches_tracked, add);  bn1_num_batches_tracked = add = copy__default_2 = None
    return pytree.tree_unflatten((getitem,), self._out_spec)
```

