### PR TITLE
[Easy] Add Delimeter To Show Where Allocation Addr Begins

### DIFF
--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -113,7 +113,7 @@ function formatSize(num) {
   return `${num.toFixed(1)}YiB`;
 }
 function formatAddr(event) {
-  const prefix = event.action.startsWith('segment') ? 's' : 'b';
+  const prefix = event.action.startsWith('segment') ? 's\'' : 'b\'';
   return `${prefix}${event.addr.toString(16)}_${event.version}`;
 }
 function formatEvent(event) {


### PR DESCRIPTION
Summary: When we print the addr we append an "s" or a "b" to the beginning of an addr. Since the addr is in hex, a user might be confused and think the "b" is part of the address. Added an approstrophe to clear this up

Test Plan: CI

Differential Revision: D69828538


