### PR TITLE
TCPStore: soft fail bind when agent store active

### DIFF
--- a/test/distributed/elastic/utils/distributed_test.py
+++ b/test/distributed/elastic/utils/distributed_test.py
@@ -170,7 +170,7 @@ class DistributedUtilTest(TestCase):
             server_port=pick_free_port,
             timeout=1,
         )
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(DistNetworkError):
             create_c10d_store(
                 is_server=True, server_addr=server_addr, server_port=store1.port
             )

--- a/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
@@ -288,20 +288,18 @@ class UvTcpServer : public UvTcpSocket {
 
       uv_res =
           uv_listen(res->unsafeGetStream(), DEFAULT_BACKLOG, on_new_connection);
-      TORCH_CHECK(
-          uv_res == 0,
-          "The server socket has failed to listen on any local network address. ",
-          "port: ",
-          port,
-          ", useIpv6: ",
-          useIpv6,
-          ", code: ",
-          uv_res,
-          ", name: ",
-          uv_err_name(uv_res),
-          ", message: ",
-          uv_strerror(uv_res));
-
+      if (uv_res != 0) {
+        C10D_THROW_ERROR(
+            SocketError,
+            fmt::format(
+                "The server socket has failed to listen on any local network address. "
+                "port: {}, useIpv6: {}, code: {}, name: {}, message: {}",
+                port,
+                useIpv6,
+                uv_res,
+                uv_err_name(uv_res),
+                uv_strerror(uv_res)));
+      }
       res->cacheSocketPort();
     } catch (std::exception& ex) {
       res->close();


### PR DESCRIPTION
This makes it easier to roll out `TORCHELASTIC_USE_AGENT_STORE` by opportunistically swallowing bind errors when the agent store is enabled and the port matches `MASTER_PORT`.

This should be very safe as if the store is somehow not up and the envs are set, the TCPStore client connections will fail to connect so we end up with a slightly different error message but success/failure behavior is identical.

This also pybinds `c10d::SocketError` into Python so we can assert on the error type in tests.

https://docs.google.com/document/d/1CzOn_N53AiFxWGgbyMWSnd2elCJd4lZ-ajPg2lzcxoM/edit?tab=t.0#heading=h.2j2f5dimrdau

Test plan:

```
pytest test/distributed/test_store.py
```

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @c-p-i-o