### PR TITLE
[ONNX] Migrate onnx ops decomp functions

### DIFF
--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import logging
 
-import torchvision
 import transformers
 
 import torch
@@ -152,23 +151,6 @@ class DynamoExporterTest(common_utils.TestCase):
         )
         onnx_testing.assert_onnx_program(onnx_program)
         onnx_testing.assert_onnx_program(onnx_program, args=(torch.tensor([-1, -2]),))
-
-    def test_onnx_export_torchvision_ops(self):
-        class VisionModel(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-
-            def forward(self, *x):
-                out = torchvision.ops.nms(x[0], x[1], x[2])
-                return out
-
-        args = (
-            torch.tensor([[0, 0, 1, 1], [0.5, 0.5, 1, 1]], dtype=torch.float),
-            torch.tensor([0.1, 0.2]),
-            0,
-        )
-        onnx_program = self.export(VisionModel(), args)
-        onnx_testing.assert_onnx_program(onnx_program)
 
     def test_empty(self):
         def func(x):

--- a/test/onnx/torchlib/extra_opinfo.py
+++ b/test/onnx/torchlib/extra_opinfo.py
@@ -1,0 +1,2716 @@
+# Owner(s): ["module: onnx"]
+"""
+Test data for aten operators which don't exist in PyTorch file:
+pytorch/torch/testing/_internal/common_methods_invocations.py.
+"""
+
+# flake8: noqa
+import functools
+import itertools
+from typing import Any, List
+
+import torch
+from torch import testing as torch_testing
+from torch.testing._internal import (
+    common_device_type,
+    common_dtype,
+    common_methods_invocations,
+)
+from torch.testing._internal.opinfo import core as opinfo_core
+
+
+S = 5
+M = 10
+
+
+def sample_inputs_scalar_tensor(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+    del device
+    del requires_grad
+    # Not including a scalar tensor in vals because meta tests start failing due to
+    # lack of meta support for _local_scalar_dense
+    # torch.tensor(2, device=device)
+    vals = (-5j, 0j, 1j)
+
+    for item in vals:
+        yield opinfo_core.SampleInput(item, dtype=dtype)
+
+
+def sample_inputs_bernoulli_p(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+
+    shapes = [
+        [3],
+        [],
+        [3, 2],
+        [2, 3, 2],
+    ]
+
+    for shape in shapes:
+        for p in (0, 0.5, 1):
+            t = torch_testing.make_tensor(
+                shape,
+                low=0,
+                high=1,
+                device=device,
+                dtype=dtype,
+                requires_grad=requires_grad,
+                **kwargs,
+            )
+            yield opinfo_core.SampleInput(t, args=(p,))
+            yield opinfo_core.SampleInput(t, kwargs={"p": p})
+
+
+def sample_inputs_bernoulli_p_deterministic(
+    op_info, device, dtype, requires_grad, **kwargs
+):
+    del op_info
+
+    shapes = [
+        [3],
+        [],
+        [3, 2],
+        [2, 3, 2],
+    ]
+
+    for shape in shapes:
+        for p in (0, 1):
+            t = torch_testing.make_tensor(
+                shape,
+                low=0,
+                high=1,
+                device=device,
+                dtype=dtype,
+                requires_grad=requires_grad,
+                **kwargs,
+            )
+            yield opinfo_core.SampleInput(t, args=(p,))
+            yield opinfo_core.SampleInput(t, kwargs={"p": p})
+
+
+def sample_inputs_col2im(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    # input_shape, output_size, kernal, dilation, padding, stride
+    cases = (
+        (
+            (1, 12, 12),
+            (4, 5),
+            (2, 2),
+            {"dilation": (1, 1), "padding": (0, 0), "stride": (1, 1)},
+        ),
+        (
+            (1, 8, 30),
+            (4, 5),
+            (2, 2),
+            {"dilation": (1, 1), "padding": (1, 1), "stride": (1, 1)},
+        ),
+        (
+            (1, 8, 9),
+            (4, 4),
+            (2, 2),
+            {"dilation": (1, 1), "padding": (0, 0), "stride": (1, 1)},
+        ),
+        (
+            (1, 8, 25),
+            (4, 4),
+            (2, 2),
+            {"dilation": (1, 1), "padding": (1, 1), "stride": (1, 1)},
+        ),
+        (
+            (1, 8, 9),
+            (4, 4),
+            (2, 2),
+            {"dilation": (1, 1), "padding": (1, 1), "stride": (2, 2)},
+        ),
+        (
+            (1, 9, 4),
+            (4, 4),
+            (3, 3),
+            {"dilation": (1, 1), "padding": (1, 1), "stride": (2, 2)},
+        ),
+        (
+            (1, 18, 16),
+            (2, 2),
+            (1, 1),
+            {"dilation": (2, 2), "padding": (3, 3), "stride": (2, 2)},
+        ),
+    )
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+    for shape, output_size, kernel_size, kwargs in cases:
+        tensor = make_arg(shape)
+        yield opinfo_core.SampleInput(
+            tensor, args=(output_size, kernel_size), kwargs=kwargs
+        )
+
+
+def sample_inputs_conv3d(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+
+    # Ordered as shapes for input, weight, bias,
+    # and a dict of values of (stride, padding, dilation, groups)
+    cases: tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...], dict[str, Any]] = (  # type: ignore[assignment]
+        (
+            (1, 3, 3, 224, 224),
+            (32, 3, 3, 3, 3),
+            None,
+            {
+                "stride": (2, 2, 2),
+                "padding": (1, 1, 1),
+                "dilation": (1, 1, 1),
+                "groups": 1,
+            },
+        ),
+        (
+            (2, 4, 3, 56, 56),
+            (32, 4, 3, 3, 3),
+            (32,),
+            {
+                "stride": (3, 3, 3),
+                "padding": (2, 2, 2),
+                "dilation": (1, 1, 1),
+                "groups": 1,
+            },
+        ),
+    )
+
+    for input_shape, weight, bias, kwargs in cases:  # type: ignore[assignment]
+        # Batched
+        yield opinfo_core.SampleInput(
+            make_arg(input_shape),
+            args=(make_arg(weight), make_arg(bias) if bias is not None else bias),
+            kwargs=kwargs,
+        )
+        # Unbatched
+        yield opinfo_core.SampleInput(
+            make_arg(input_shape[1:]),  # type: ignore[index]
+            args=(make_arg(weight), make_arg(bias) if bias is not None else bias),
+            kwargs=kwargs,
+        )
+
+
+def sample_inputs_convolution(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+
+    # Ordered as shapes for input, weight, bias,
+    # and a dict of values of (stride, padding, dilation, groups)
+    cases: tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...], dict[str, Any]] = (  # type: ignore[assignment]
+        (
+            (1, 3, 4),
+            (3, 3, 3),
+            (3,),
+            {
+                "stride": (2,),
+                "padding": (2,),
+                "dilation": (1,),
+                "transposed": False,
+                "output_padding": (0,),
+                "groups": 1,
+            },
+        ),
+        (
+            (1, 3, 4),
+            (3, 3, 3),
+            None,
+            {
+                "stride": (2,),
+                "padding": (2,),
+                "dilation": (1,),
+                "transposed": True,
+                "output_padding": (0,),
+                "groups": 1,
+            },
+        ),
+        (
+            (1, 3, 224, 224),
+            (32, 3, 3, 3),
+            None,
+            {
+                "stride": (2, 2),
+                "padding": (1, 1),
+                "dilation": (1, 1),
+                "transposed": False,
+                "output_padding": (0, 0),
+                "groups": 1,
+            },
+        ),
+        (
+            (1, 3, 3, 224, 224),
+            (32, 3, 3, 3, 3),
+            (32,),
+            {
+                "stride": (2, 2, 2),
+                "padding": (1, 1, 1),
+                "dilation": (1, 1, 1),
+                "transposed": False,
+                "output_padding": (0, 0, 0),
+                "groups": 1,
+            },
+        ),
+        # FIXME(jiz): Uncomment out these test data once
+        # torch 2.0 is released.
+        # (
+        #     (1, 3, 224, 224, 224),
+        #     (32, 3, 3, 3, 3),
+        #     (32,),
+        #     {
+        #         "stride": (2, 2, 2),
+        #         "padding": (1, 1, 1),
+        #         "dilation": (1, 1, 1),
+        #         "transposed": False,
+        #         "output_padding": (0, 0, 0),
+        #         "groups": 1,
+        #     },
+        # ),
+        (
+            (2, 4, 6, 6),
+            (4, 1, 3, 3),
+            (4,),
+            {
+                "stride": (3, 2),
+                "padding": (1, 1),
+                "dilation": (1, 1),
+                "transposed": True,
+                "output_padding": (0, 0),
+                "groups": 4,
+            },
+        ),
+    )
+
+    for input_shape, weight, bias, kwargs in cases:  # type: ignore[assignment]
+        yield opinfo_core.SampleInput(
+            make_arg(input_shape),
+            args=(make_arg(weight), make_arg(bias) if bias is not None else bias),
+            kwargs=kwargs,
+        )
+
+
+def sample_inputs_embedding_renorm(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+
+    def make_input(shape):
+        return common_methods_invocations.make_tensor(
+            shape, device=device, dtype=dtype, requires_grad=requires_grad
+        )
+
+    def make_long_input(shape, *, low, high, noncontiguous=False):
+        return common_methods_invocations.make_tensor(
+            shape,
+            device=device,
+            dtype=torch.long,
+            low=low,
+            high=high,
+            noncontiguous=noncontiguous,
+        )
+
+    for max_norm in (0.5, 1.0, 5.0):
+        for norm_type in (0.8, 1.0, 2.0, 2.5):
+            idx = make_long_input((6,), low=0, high=S)
+            weights = make_input((S, S)) * 2
+            yield common_methods_invocations.SampleInput(
+                weights,
+                args=(idx,),
+                kwargs={"max_norm": max_norm, "norm_type": norm_type},
+            )
+
+
+def sample_inputs_embedding_bag(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+
+    def make_input(shape):
+        return common_methods_invocations.make_tensor(
+            shape, device=device, dtype=dtype, requires_grad=requires_grad
+        )
+
+    def make_long_input(shape, *, low, high, noncontiguous=False):
+        return common_methods_invocations.make_tensor(
+            shape,
+            device=device,
+            dtype=torch.long,
+            low=low,
+            high=high,
+            noncontiguous=noncontiguous,
+        )
+
+    def make_per_sample_weight(flag, idx):
+        # a tensor of float / double weights, or None
+        # to indicate all weights should be taken to be 1
+        if flag:
+            return make_input(idx.reshape(-1).shape)
+        return None
+
+    offsets = [
+        torch.tensor([0, 2, 3], device=device, dtype=torch.long),
+        torch.tensor([0, 0, 2], device=device, dtype=torch.long),
+        torch.tensor([0, 2, 2, 4], device=device, dtype=torch.long),
+    ]
+    for offset in offsets:
+        for include_last_offset in (True, False):
+            for generate_per_sample_weight in (True, False):
+                for mode in (
+                    0,
+                    1,
+                    2,
+                ):  # ('sum', 'mean', 'max')
+                    # per_sample_weights only support mode='sum'
+                    if generate_per_sample_weight and mode in (
+                        1,
+                        2,
+                    ):  # ('mean', 'max'):
+                        continue
+
+                    # 1-D index tensor
+                    indices = make_long_input((S,), low=0, high=M)
+                    per_sample_weights = make_per_sample_weight(
+                        generate_per_sample_weight, indices
+                    )
+                    # 0
+                    yield common_methods_invocations.SampleInput(
+                        make_input((M, S)),
+                        args=(indices,),
+                        kwargs={
+                            "offsets": offset,
+                            "mode": mode,
+                            "per_sample_weights": per_sample_weights,
+                            "include_last_offset": include_last_offset,
+                        },
+                    )
+
+                    indices = make_long_input((S,), low=0, high=M, noncontiguous=True)
+                    per_sample_weights = make_per_sample_weight(
+                        generate_per_sample_weight, indices
+                    )
+                    # 1
+                    yield common_methods_invocations.SampleInput(
+                        make_input((M, S)),
+                        args=(indices,),
+                        kwargs={
+                            "offsets": offset,
+                            "mode": mode,
+                            "per_sample_weights": per_sample_weights,
+                            "include_last_offset": include_last_offset,
+                        },
+                    )
+
+                    if mode != 2:  # "max" mode in 2-D index tensor make aten func crash
+                        # 2-D index tensor
+                        indices = make_long_input((S, S), low=0, high=M)
+                        per_sample_weights = make_per_sample_weight(
+                            generate_per_sample_weight, indices
+                        )
+                        # 2
+                        yield common_methods_invocations.SampleInput(
+                            make_input((M, S)),
+                            args=(indices,),
+                            kwargs={
+                                "offsets": offset,
+                                "mode": mode,
+                                "per_sample_weights": per_sample_weights,
+                                "include_last_offset": include_last_offset,
+                            },
+                        )
+
+                        indices = make_long_input(
+                            (S, S), low=0, high=M, noncontiguous=True
+                        )
+                        per_sample_weights = make_per_sample_weight(
+                            generate_per_sample_weight, indices
+                        )
+                        # 3
+                        yield common_methods_invocations.SampleInput(
+                            make_input((M, S)),
+                            args=(indices,),
+                            kwargs={
+                                "offsets": offset,
+                                "mode": mode,
+                                "per_sample_weights": per_sample_weights,
+                                "include_last_offset": include_last_offset,
+                            },
+                        )
+
+
+def sample_inputs_embedding_bag_padding_idx(
+    op_info, device, dtype, requires_grad, **kwargs
+):
+    del op_info
+    del kwargs
+
+    def make_input(shape):
+        return common_methods_invocations.make_tensor(
+            shape, device=device, dtype=dtype, requires_grad=requires_grad
+        )
+
+    def make_long_input(shape, *, low, high, noncontiguous=False):
+        return common_methods_invocations.make_tensor(
+            shape,
+            device=device,
+            dtype=torch.long,
+            low=low,
+            high=high,
+            noncontiguous=noncontiguous,
+        )
+
+    def make_per_sample_weight(flag, idx):
+        # a tensor of float / double weights, or None
+        # to indicate all weights should be taken to be 1
+        if flag:
+            return make_input(idx.reshape(-1).shape)
+        return None
+
+    offsets = [
+        torch.tensor([0, 2, 3], device=device, dtype=torch.long),
+        # Below case not work for FullGraph mode, guess due to op.While() bug:
+        # when the initial condition is False, it still excute the loop body once.
+        # torch.tensor([0, 0, 2], device=device, dtype=torch.long),
+        # torch.tensor([0, 2, 2, 4], device=device, dtype=torch.long),
+    ]
+    for offset in offsets:
+        for include_last_offset in (True, False):
+            for generate_per_sample_weight in (True, False):
+                for mode in (
+                    0,
+                    1,
+                    2,
+                ):  # ('sum', 'mean', 'max')
+                    # per_sample_weights only support mode='sum'
+                    if generate_per_sample_weight and mode in (
+                        1,
+                        2,
+                    ):  # ('mean', 'max'):
+                        continue
+
+                    for padding_idx in (-1, 0, 1, 2, 3):
+                        # 1-D index tensor
+                        indices = make_long_input((S,), low=0, high=M)
+                        per_sample_weights = make_per_sample_weight(
+                            generate_per_sample_weight, indices
+                        )
+                        # 0
+                        yield common_methods_invocations.SampleInput(
+                            make_input((M, S)),
+                            args=(indices,),
+                            kwargs={
+                                "offsets": offset,
+                                "scale_grad_by_freq": False,
+                                "mode": mode,
+                                "sparse": False,
+                                "per_sample_weights": per_sample_weights,
+                                "include_last_offset": include_last_offset,
+                                "padding_idx": padding_idx,
+                            },
+                        )
+
+                        indices = make_long_input(
+                            (S,), low=0, high=M, noncontiguous=True
+                        )
+                        per_sample_weights = make_per_sample_weight(
+                            generate_per_sample_weight, indices
+                        )
+                        # 1
+                        yield common_methods_invocations.SampleInput(
+                            make_input((M, S)),
+                            args=(indices,),
+                            kwargs={
+                                "offsets": offset,
+                                "scale_grad_by_freq": False,
+                                "mode": mode,
+                                "sparse": False,
+                                "per_sample_weights": per_sample_weights,
+                                "include_last_offset": include_last_offset,
+                                "padding_idx": padding_idx,
+                            },
+                        )
+
+                        # if mode != 2:  # "max" mode in 2-D index tensor make aten func crash
+                        #     # 2-D index tensor
+                        #     indices = make_long_input((S, S), low=0, high=M)
+                        #     per_sample_weights = make_per_sample_weight(
+                        #         generate_per_sample_weight, indices
+                        #     )
+                        #     # 2
+                        #     yield common_methods_invocations.SampleInput(
+                        #         make_input((M, S)),
+                        #         args=(indices,),
+                        #         kwargs={
+                        #             "offsets": offset,
+                        #             "mode": mode,
+                        #             "per_sample_weights": per_sample_weights,
+                        #             "include_last_offset": include_last_offset,
+                        #             "padding_idx": padding_idx,
+                        #         },
+                        #     )
+
+                        #     indices = make_long_input((S, S), low=0, high=M, noncontiguous=True)
+                        #     per_sample_weights = make_per_sample_weight(
+                        #         generate_per_sample_weight, indices
+                        #     )
+                        #     # 3
+                        #     yield common_methods_invocations.SampleInput(
+                        #         make_input((M, S)),
+                        #         args=(indices,),
+                        #         kwargs={
+                        #             "offsets": offset,
+                        #             "mode": mode,
+                        #             "per_sample_weights": per_sample_weights,
+                        #             "include_last_offset": include_last_offset,
+                        #             "padding_idx": padding_idx,
+                        #         },
+                        #     )
+
+
+def sample_inputs__local_scalar_dense(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+
+    shapes = (
+        (),
+        (1,),
+        (3,),
+        (1, 1),
+        (1, 2),
+        (2, 1),
+        (1, 1, 1),
+        (2, 2, 2),
+    )
+
+    for shape in shapes:
+        t = torch_testing.make_tensor(
+            shape,
+            low=0,
+            high=1,
+            device=device,
+            dtype=dtype,
+            requires_grad=requires_grad,
+            **kwargs,
+        )
+        yield opinfo_core.SampleInput(t)
+
+
+def _prepare_data_for_fft_ops(device, dtype, requires_grad=False):
+    # Adapted from https://github.com/pytorch/pytorch/blob/01069ad4be449f376cf88a56d842b8eb50f6e9b6/torch/testing/_internal/opinfo/core.py#L2448C1-L2541C79
+    is_fp16_or_chalf = dtype in (torch.complex32, torch.half)
+    if not is_fp16_or_chalf:
+        oned_tensor = functools.partial(
+            opinfo_core.make_tensor,
+            (31,),
+            device=device,
+            dtype=dtype,
+            requires_grad=requires_grad,
+        )
+        nd_tensor = functools.partial(
+            opinfo_core.make_tensor,
+            (S, S + 1, S + 2),
+            device=device,
+            dtype=dtype,
+            requires_grad=requires_grad,
+        )
+    else:
+        low = None
+        high = None
+        shapes = ((2, 8, 9), (33,))
+
+        oned_tensor = functools.partial(
+            opinfo_core.make_tensor,
+            shapes[1],
+            device=device,
+            low=low,
+            high=high,
+            dtype=dtype,
+            requires_grad=requires_grad,
+        )
+        nd_tensor = functools.partial(
+            opinfo_core.make_tensor,
+            shapes[0],
+            device=device,
+            low=low,
+            high=high,
+            dtype=dtype,
+            requires_grad=requires_grad,
+        )
+
+    return oned_tensor, nd_tensor
+
+
+def sample_inputs__fft_c2c(self, device, dtype, requires_grad=False, **_):
+    del self  # Unused
+    oned_tensor, nd_tensor = _prepare_data_for_fft_ops(device, dtype, requires_grad)
+
+    for normalization, forward in itertools.product((0, 1, 2), (True, False)):
+        # 1-D
+        yield opinfo_core.SampleInput(
+            oned_tensor(), dim=(0,), normalization=normalization, forward=forward
+        )
+        # N-D
+        for dim in [
+            (0,),
+            (1,),
+            (2,),
+            (1, 2),
+            (0, 1),
+            (0, 1, 2),
+        ]:
+            yield opinfo_core.SampleInput(
+                nd_tensor(), dim=dim, normalization=normalization, forward=forward
+            )
+
+
+def sample_inputs__fft_r2c(self, device, dtype, requires_grad=False, **_):
+    del self  # Unused
+    oned_tensor, nd_tensor = _prepare_data_for_fft_ops(device, dtype, requires_grad)
+
+    for normalization, one_sided in itertools.product((0, 1, 2), (True, True)):
+        # 1-D
+        yield opinfo_core.SampleInput(
+            oned_tensor(), dim=(0,), normalization=normalization, onesided=one_sided
+        )
+        # N-D
+        for dim in [
+            (0,),
+            (1,),
+            (2,),
+            (1, 2),
+            (0, 1),
+            (0, 1, 2),
+        ]:
+            yield opinfo_core.SampleInput(
+                nd_tensor(), dim=dim, normalization=normalization, onesided=one_sided
+            )
+
+
+def sample_inputs__fft_c2r(self, device, dtype, requires_grad=False, **_):
+    del self  # Unused
+    oned_tensor, nd_tensor = _prepare_data_for_fft_ops(device, dtype, requires_grad)
+
+    for normalization in (0, 1, 2):
+        # 1-D
+        yield opinfo_core.SampleInput(
+            oned_tensor(), dim=(0,), normalization=normalization, last_dim_size=12
+        )
+        # N-D
+        for dim in [
+            (0,),
+            (1,),
+            (2,),
+            (1, 2),
+            (0, 1),
+            (0, 1, 2),
+        ]:
+            yield opinfo_core.SampleInput(
+                nd_tensor(), dim=dim, normalization=normalization, last_dim_size=6
+            )
+
+
+def _index_variable_bool(shape, max_indices, device):
+    if not isinstance(shape, tuple):
+        shape = (shape,)
+    index = (
+        torch.rand(*shape, dtype=torch.double, device=device)
+        .mul_(max_indices)
+        .floor_()
+        .bool()
+    )
+    return index
+
+
+def sample_inputs_index_bool(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info  # Unused
+    del kwargs  # Unused
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        dtype=dtype,
+        device=device,
+        requires_grad=requires_grad,
+    )
+    s = 5
+    index_bool = _index_variable_bool(s, s, device=device)
+    index_bool_2d = _index_variable_bool((s, s), s, device=device)
+    index_bool_3d = _index_variable_bool((s, s, s), s, device=device)
+    test_args = [
+        ([index_bool],),
+        ([None, index_bool],),
+        ([None, None, None, index_bool],),
+        ([index_bool, None],),
+        ([index_bool, None, None],),
+        # Extra index
+        ([None, index_bool, None, index_bool],),
+        ([index_bool, None, index_bool, None],),
+        ([None, index_bool, index_bool, None],),
+        ([index_bool_2d],),
+        ([index_bool_2d, None],),
+        ([index_bool_2d, None, None],),
+        ([None, index_bool_2d],),
+        ([None, None, index_bool_2d],),
+        ([index_bool_3d],),
+        ([index_bool_3d, None],),
+        ([None, index_bool_3d],),
+    ]
+
+    for args in test_args:
+        yield opinfo_core.SampleInput(make_arg((s, s, s, s)), args=args)
+
+
+def sample_inputs_index(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info  # Unused
+    del kwargs  # Unused
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        dtype=dtype,
+        device=device,
+        requires_grad=requires_grad,
+    )
+    s = 5
+    index_1d = common_methods_invocations.index_variable(2, s, device=device)
+    index_2d = common_methods_invocations.index_variable((s + 1, 2), s, device=device)
+    index_3d = common_methods_invocations.index_variable(
+        (s + 2, s + 1, 2), s, device=device
+    )
+    test_args = [
+        ([index_1d],),
+        ([None, index_1d],),
+        ([None, None, None, index_1d],),
+        ([index_1d, None],),
+        ([index_1d, None, None],),
+        # Extra index
+        ([None, index_1d, None, index_1d],),
+        ([index_1d, None, index_1d, None],),
+        ([None, index_1d, index_1d, None],),
+        ([index_2d],),
+        ([None, index_2d],),
+        ([None, None, None, index_2d],),
+        ([index_2d, None],),
+        ([index_2d, None, None],),
+        # Extra index
+        ([None, index_2d, None, index_2d],),
+        ([index_2d, None, index_2d, None],),
+        ([None, index_2d, index_2d, None],),
+        ([index_3d],),
+        ([None, index_3d],),
+        ([None, None, None, index_3d],),
+        ([index_3d, None],),
+        ([index_3d, None, None],),
+        # Extra index
+        ([None, index_3d, None, index_3d],),
+        ([index_3d, None, index_3d, None],),
+        ([None, index_3d, index_3d, None],),
+        # Mixed indices
+        ([None, index_3d, index_1d, index_2d],),
+        # All indices are not None
+        ([index_2d, index_3d, index_1d],),
+        ([index_2d, index_3d, index_1d, index_2d],),
+    ]
+
+    for args in test_args:
+        yield opinfo_core.SampleInput(make_arg((s, s, s, s)), args=args)
+
+
+def sample_inputs_index_put(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+
+    data = torch_testing.make_tensor(
+        (10, 3),
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+    indices = [torch.arange(8, dtype=torch.int64, device=device).reshape((-1, 4))]
+    values = torch_testing.make_tensor(
+        (2, 4, 3),
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+    yield opinfo_core.SampleInput(data, indices, values)
+
+
+def sample_inputs_layer_norm(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info  # unused
+    del kwargs
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+
+    # Ordered as input shape, normalized_shape, eps
+    cases: tuple[tuple[int], tuple[int], float] = (  # type: ignore[assignment]
+        ((1, 2, 3), (1, 2, 3), 0.5),
+        ((2, 2, 3), (2, 3), -0.5),
+        ((1,), (1,), 1e-5),
+        ((1, 2), (2,), 1e-5),
+        ((0, 1), (1,), 1e-5),
+    )
+
+    for input_shape, normalized_shape, eps in cases:  # type: ignore[misc]
+        # Shape of weight and bias should be the same as normalized_shape
+        weight = make_arg(normalized_shape)  # type: ignore[has-type]
+        bias = make_arg(normalized_shape)  # type: ignore[has-type]
+        yield opinfo_core.SampleInput(
+            make_arg(input_shape),  # type: ignore[has-type]
+            args=(normalized_shape, weight, bias, eps),  # type: ignore[has-type]
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(input_shape),  # type: ignore[has-type]
+            args=(normalized_shape, None, bias, eps),  # type: ignore[has-type]
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(input_shape),  # type: ignore[has-type]
+            args=(normalized_shape, weight, None, eps),  # type: ignore[has-type]
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(input_shape),  # type: ignore[has-type]
+            args=(normalized_shape, None, None, eps),  # type: ignore[has-type]
+        )
+
+
+def sample_inputs_like_fns(self, device, dtype, requires_grad, **kwargs):
+    del self  # Unused
+
+    inputs = [
+        ((), {}),
+        ((S, S), {}),
+        ((0, S, 0), {}),
+        ((S,), {}),
+        ((S,), {"dtype": dtype}),
+        # Hard-code some dtypes/devices. We want to test cases where the
+        # (dtype, device) is different from the input's (dtype, device)
+        ((S,), {"dtype": torch.double}),
+    ]
+    for shape, kwargs in inputs:
+        t = torch_testing.make_tensor(
+            shape,
+            dtype=dtype,
+            device=device,
+            low=None,
+            high=None,
+            requires_grad=requires_grad,
+        )
+        yield opinfo_core.SampleInput(t, **kwargs)
+
+
+def sample_inputs__log_softmax(
+    op_info,
+    device,
+    dtype,
+    requires_grad,
+    **kwargs,
+):
+    del op_info  # Unused
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+    cases = [
+        ((S,), (0,)),
+        ((S, S), (0,)),
+        ((S, S), (1,)),
+        ((S, S), (-1,)),
+        ((S, M, S), (2,)),
+        ((S, 0, 0), (-1,)),
+    ]
+
+    for (shape, dim), half_to_float in itertools.product(cases, (False,)):
+        # NOTE: softmax with half to float conversion is not supported on CPU
+        # So we don't test it here
+        kwargs = dict(half_to_float=half_to_float)
+        yield opinfo_core.SampleInput(make_arg(shape), args=dim, kwargs=kwargs)
+
+
+def sample_inputs_max_pool_empty_strides(
+    op_info, device, dtype, requires_grad, **kwargs
+):
+    make_arg = functools.partial(
+        torch_testing.make_tensor, device=device, dtype=dtype, requires_grad=False
+    )
+
+    # FIXME: (RuntimeError: non-empty 3D or 4D (batch mode) tensor expected for input)
+
+    params_generator_type_dict = {
+        "ops.aten.max_pool1d": _TestParamsMaxPool1dEmptyStride,
+        "ops.aten.max_pool2d": _TestParamsMaxPool2dEmptyStride,
+        "ops.aten.max_pool3d": _TestParamsMaxPool3dEmptyStride,
+    }
+
+    params_generator = params_generator_type_dict[op_info.name]()
+    for (shape, memory_format), kwargs in params_generator.gen_input_params():
+        arg = (
+            make_arg(shape)
+            .to(memory_format=memory_format)
+            .requires_grad_(requires_grad)
+        )
+        yield opinfo_core.SampleInput(arg, kwargs=kwargs)
+
+
+def sample_inputs_max_pool1d_with_indices(
+    op_info, device, dtype, requires_grad, **kwargs
+):
+    del op_info
+    make_arg = functools.partial(
+        torch_testing.make_tensor, device=device, dtype=dtype, requires_grad=False
+    )
+    params_generator = (
+        common_methods_invocations._TestParamsMaxPool1d()  # pylint: disable=protected-access
+    )
+    for (shape, memory_format), kwargs in params_generator.gen_input_params():
+        arg = (
+            make_arg(shape)
+            .to(memory_format=memory_format)
+            .requires_grad_(requires_grad)
+        )
+        yield opinfo_core.SampleInput(arg, kwargs=kwargs)
+
+
+def sample_inputs_max_pool2d_with_indices(
+    op_info, device, dtype, requires_grad, **kwargs
+):
+    del op_info
+    make_arg = functools.partial(
+        torch_testing.make_tensor, device=device, dtype=dtype, requires_grad=False
+    )
+    params_generator = (
+        common_methods_invocations._TestParamsMaxPool2d()  # pylint: disable=protected-access
+    )
+    for (shape, memory_format), kwargs in params_generator.gen_input_params():
+        arg = (
+            make_arg(shape)
+            .to(memory_format=memory_format)
+            .requires_grad_(requires_grad)
+        )
+        yield opinfo_core.SampleInput(arg, kwargs=kwargs)
+
+
+def sample_inputs_max_pool3d_with_indices(
+    op_info, device, dtype, requires_grad, **kwargs
+):
+    del op_info
+    make_arg = functools.partial(
+        torch_testing.make_tensor, device=device, dtype=dtype, requires_grad=False
+    )
+    params_generator = (
+        common_methods_invocations._TestParamsMaxPool3d()  # pylint: disable=protected-access
+    )
+    for (shape, memory_format), kwargs in params_generator.gen_input_params():
+        arg = (
+            make_arg(shape)
+            .to(memory_format=memory_format)
+            .requires_grad_(requires_grad)
+        )
+        yield opinfo_core.SampleInput(arg, kwargs=kwargs)
+
+
+def sample_inputs_native_group_norm(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+
+    # Ordered as input shape, C,N,HxW, and kwargs for group and eps
+    cases = (
+        ((1, 6, 3), (6,), (6,), 1, 6, 3, {"group": 2, "eps": 0.5}),
+        ((2, 6, 3), (6,), (6,), 2, 6, 3, {"group": 3, "eps": -0.5}),
+        ((5, 5, 5), (5,), (5,), 5, 5, 5, {"group": 1, "eps": 1e-5}),
+        ((5, 8, 10), (8,), (8,), 5, 8, 10, {"group": 4, "eps": 1e-5}),
+    )
+
+    for input_shape, weight, bias, N, C, HxW, kwargs in cases:
+        # args: running mean, running var, weight and bias should necessarily be of shape: (channels,)
+        channels = input_shape[1] if len(input_shape) > 1 else 0
+        weight = make_arg(channels) if channels > 0 else None
+        bias = make_arg(channels) if channels > 0 else None
+
+        yield opinfo_core.SampleInput(
+            make_arg(input_shape),
+            args=(
+                weight,
+                bias,
+                N,
+                C,
+                HxW,
+            ),
+            kwargs=kwargs,
+        )
+
+
+def sample_inputs_native_dropout(
+    op_info, device, dtype, requires_grad, *, valid_input_dim=None, **kwargs
+):
+    del op_info  # Unused
+    del kwargs  # Unused
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+
+    if valid_input_dim:
+        cases = ((S,) * i for i in valid_input_dim)
+    else:
+        cases = ((S, S), (S,), ())
+    # ONNX requires 0 <= p < 1
+    p_vals = [0.0]
+
+    training_vals = [True, False]
+
+    for case, p, training in itertools.product(cases, p_vals, training_vals):
+        yield opinfo_core.SampleInput(make_arg(case), p=p, train=training)
+
+
+# NOTE: In `_native_batch_norm_legit` tests, it generates two kinds of args:
+# 1. (input, weight, bias, running_mean, running_var, training, momentum, eps)
+# 2. (input, weight, bias, training, momentum, eps)
+# which requires two function signatures to take the inputs, that's why we have
+# two sample_inputs functions here instead.
+def sample_inputs__native_batch_norm_legit(
+    op_info, device, dtype, requires_grad, **kwargs
+):
+    samples = common_methods_invocations.sample_inputs_batch_norm(
+        op_info, device, dtype, requires_grad, **kwargs
+    )
+    for sample in samples:
+        # torch.native_batch_norm does not support 0 numel tensors
+        # IndexError: Dimension out of range (expected to be in range of [-1, 0], but got 1)
+        if sample.input.numel() == 0:
+            continue
+        args = sample.args
+        training = sample.kwargs.get("training", True)
+        momentum = sample.kwargs.get("momentum", 0.5)
+        eps = sample.kwargs.get("eps", 1e-5)
+        if args[0] is not None and args[1] is not None:
+            yield opinfo_core.SampleInput(
+                sample.input,
+                args=(args[2], args[3], args[0], args[1]),
+                kwargs={"training": training, "momentum": momentum, "eps": eps},
+            )
+
+
+def sample_inputs__native_batch_norm_legit_no_stats(
+    op_info, device, dtype, requires_grad, **kwargs
+):
+    samples = common_methods_invocations.sample_inputs_batch_norm(
+        op_info, device, dtype, requires_grad, **kwargs
+    )
+    for sample in samples:
+        # torch.native_batch_norm does not support 0 numel tensors
+        # IndexError: Dimension out of range (expected to be in range of [-1, 0], but got 1)
+        if sample.input.numel() == 0:
+            continue
+        args = sample.args
+        training = sample.kwargs.get("training", True)
+        momentum = sample.kwargs.get("momentum", 0.5)
+        eps = sample.kwargs.get("eps", 1e-5)
+        if args[0] is not None and args[1] is None:
+            yield opinfo_core.SampleInput(
+                sample.input,
+                args=(args[2], args[3]),
+                kwargs={"training": training, "momentum": momentum, "eps": eps},
+            )
+
+
+def sample_inputs_non_max_suppression(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+    boxes = torch.tensor(
+        [
+            [0.0, 0.0, 10.0, 10.0],
+            [10.0, 10.0, 20.0, 20.0],
+            [32.0, 32.0, 40.0, 52.0],
+        ],
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+    scores = torch.tensor(
+        [0.8, 0.4, 0.6], device=device, dtype=dtype, requires_grad=requires_grad
+    )
+
+    for iou_threshold in (0.3, 0.5, 0.7, 0.9):
+        yield opinfo_core.SampleInput(boxes, args=(scores, iou_threshold))
+
+
+def sample_inputs_normal_tensor_float(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del requires_grad
+    del kwargs
+    make_arg = functools.partial(
+        torch_testing.make_tensor, dtype=dtype, device=device, requires_grad=False
+    )
+    samples = (
+        ((S, S), 0.0),
+        ((S, S, S), 4.2),
+    )
+    for mean, std in samples:
+        yield opinfo_core.SampleInput(make_arg(mean), std)
+
+
+def sample_inputs_normal_float_tensor(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del requires_grad
+    del kwargs
+    make_arg = functools.partial(
+        torch_testing.make_tensor, dtype=dtype, device=device, requires_grad=False
+    )
+    samples = (
+        (4.2, (S, S)),
+        (-2.0, (S, S, S)),
+    )
+    for mean, std in samples:
+        yield opinfo_core.SampleInput(mean, make_arg(std, low=0.0))
+
+
+def sample_inputs_normal_tensor_tensor(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del requires_grad
+    del kwargs
+    make_arg = functools.partial(
+        torch_testing.make_tensor, dtype=dtype, device=device, requires_grad=False
+    )
+    samples = (
+        ((S, S), (S, S)),
+        ((S, S, S), (S, S, S)),
+    )
+    for mean, std in samples:
+        yield opinfo_core.SampleInput(make_arg(mean), make_arg(std, low=0.0))
+
+
+def sample_inputs_rand(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info  # Unused
+    del device  # Unused
+    del requires_grad  # Unused
+    del kwargs  # Unused
+
+    shapes = (
+        (M,),
+        (S, S),
+        (S, S, S),
+    )
+
+    for shape in shapes:
+        yield opinfo_core.SampleInput(shape, kwargs=dict(dtype=dtype))
+
+
+def sample_inputs_rand_like(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info  # Unused
+    del kwargs  # Unused
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+    shapes = (
+        (M,),
+        (S, S),
+        (S, S, S),
+    )
+
+    for shape in shapes:
+        yield opinfo_core.SampleInput(make_arg(shape))
+
+
+def sample_inputs_randint(self, device, dtype, requires_grad, **kwargs):
+    high = 10
+
+    for sample in sample_inputs_like_fns(self, device, dtype, requires_grad, **kwargs):
+        # With high
+        yield opinfo_core.SampleInput(
+            high, sample.input.shape, *sample.args, **sample.kwargs
+        )
+
+
+def sample_inputs_randint_low(self, device, dtype, requires_grad, **kwargs):
+    low = 2
+    high = 10
+
+    for sample in sample_inputs_like_fns(self, device, dtype, requires_grad, **kwargs):
+        # With low and high
+        yield opinfo_core.SampleInput(
+            low, high, sample.input.shape, *sample.args, **sample.kwargs
+        )
+
+
+def sample_inputs_randint_like(self, device, dtype, requires_grad, **kwargs):
+    high = 10
+
+    for sample in sample_inputs_like_fns(self, device, dtype, requires_grad, **kwargs):
+        # With high
+        yield opinfo_core.SampleInput(sample.input, high, *sample.args, **sample.kwargs)
+
+
+def sample_inputs_randint_like_low_dtype(self, device, dtype, requires_grad, **kwargs):
+    low = 2
+    high = 10
+
+    for sample in sample_inputs_like_fns(self, device, dtype, requires_grad, **kwargs):
+        # With low and high
+        yield opinfo_core.SampleInput(
+            sample.input, low, high, *sample.args, **sample.kwargs
+        )
+
+
+def sample_inputs_randn(op, device, dtype, requires_grad, **kwargs):
+    del op  # Unused
+    del device  # Unused
+    del requires_grad  # Unused
+    del kwargs  # Unused
+
+    shapes = ((M,), (S, S))
+
+    for shape in shapes:
+        yield opinfo_core.SampleInput(input=shape, kwargs=dict(dtype=dtype))
+
+
+def sample_inputs_reflection_pad1d(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+
+    cases: tuple = (  # ignore
+        ((2, 3), (1, 2)),
+        ((4, 5), (0, 1)),
+        ((6, 7), (1, 1)),
+        ((8, 9), (1, 0)),
+    )
+
+    make_inp = opinfo_core.partial(
+        torch.testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+
+    for shape, pad in cases:
+        yield opinfo_core.SampleInput(make_inp(shape), args=(pad,))
+
+
+def sample_inputs_replication_pad1d(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+
+    cases: tuple = (  # ignore
+        ((2, 3), (1, 2)),
+        ((4, 5), (0, 1)),
+        ((6, 7), (1, 1)),
+        ((8, 9), (1, 0)),
+    )
+
+    make_inp = opinfo_core.partial(
+        torch.testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+
+    for shape, pad in cases:
+        yield opinfo_core.SampleInput(make_inp(shape), args=(pad,))
+
+
+def sample_inputs_slice_scatter(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        dtype=dtype,
+        device=device,
+        requires_grad=requires_grad,
+    )
+
+    L = 20
+    cases = (
+        ((L, L, L), (L, L, L), (0, 0, L, 1)),
+        ((L, L, L), (L // 2, L, L), (0, L // 2, L, 1)),
+        ((L, L, L), (L // 4, L, L), (0, L // 2, L, 2)),
+        ((L, L, L), (L, L, L), (1, 0, L, 1)),
+        ((L, L, L), (L, L // 2, L), (1, L // 2, L, 1)),
+        ((L, L, L), (L, L // 4, L), (1, L // 2, L, 2)),
+        ((L, L, L), (L, L, L), (2, 0, L, 1)),
+        ((L, L, L), (L, L, L // 2), (2, L // 2, L, 1)),
+        ((L, L, L), (L, L, L // 4), (2, L // 2, L, 2)),
+        ((L, L, L), (L, L // 2, L), (1, L // 2, L * 2, 1)),  # end > L
+        ((L, L, L), (L, L, L), (-2, 0, L, 1)),  # negative dim
+        ((L, L, L), (L, L, L // 4), (-1, L // 2, L * 2, 2)),  # end > L and negative dim
+    )
+
+    for input_shape, src_shape, args in cases:
+        input_ = make_arg(input_shape)
+        src = make_arg(src_shape)
+        yield opinfo_core.SampleInput(input_, args=(src, *args))
+
+
+def sample_inputs__scaled_dot_product_flash_attention(
+    op_info, device, dtype, requires_grad, **kwargs
+):
+    del op_info
+    del kwargs
+
+    make = opinfo_core.partial(
+        opinfo_core.make_tensor, device=device, dtype=dtype, requires_grad=requires_grad
+    )
+    batch, seq_q, seq_kv, num_heads, head_dim = 4, 3, 6, 4, 8
+
+    dim_4_q_shape = (batch, num_heads, seq_q, head_dim)
+    dim_4_kv_shape = (batch, num_heads, seq_kv, head_dim)
+
+    qkv_shapes = [(dim_4_q_shape, dim_4_kv_shape)]
+    samples = []
+    for qkv_shape, is_causal, dropout_p in opinfo_core.product(
+        qkv_shapes, [True, False], [0.0]
+    ):
+        shape_q, shape_kv = qkv_shape
+        samples.append(
+            opinfo_core.SampleInput(
+                make(shape_q),
+                make(shape_kv),
+                make(shape_kv),
+                is_causal=is_causal,
+                dropout_p=dropout_p,
+            )
+        )
+
+    # Add an attn_mask
+    samples.append(
+        opinfo_core.SampleInput(
+            make((batch, num_heads, seq_q, head_dim)),
+            make((batch, num_heads, seq_kv, head_dim)),
+            make((batch, num_heads, seq_kv, head_dim)),
+            is_causal=False,
+            dropout_p=0.0,
+        )
+    )
+
+    yield from samples
+
+
+def sample_inputs__scaled_dot_product_efficient_attention(
+    op_info, device, dtype, requires_grad, **kwargs
+):
+    del op_info
+    del kwargs
+
+    make = opinfo_core.partial(
+        opinfo_core.make_tensor, device=device, dtype=dtype, requires_grad=requires_grad
+    )
+    batch, seq_q, seq_kv, num_heads, head_dim = 2, 3, 6, 4, 8
+
+    dim_4_q_shape = (batch, num_heads, seq_q, head_dim)
+    dim_4_kv_shape = (batch, num_heads, seq_kv, head_dim)
+
+    qkv_shapes = [(dim_4_q_shape, dim_4_kv_shape)]
+
+    samples = []
+    for qkv_shape, is_causal, dropout_p, compute_log_sumexp in opinfo_core.product(
+        qkv_shapes, [True, False], [0.0], [True, False]
+    ):
+        shape_q, shape_kv = qkv_shape
+        samples.append(
+            opinfo_core.SampleInput(
+                make(shape_q),
+                make(shape_kv),
+                make(shape_kv),
+                attn_bias=None,  # TODO: Add attn_bias
+                is_causal=is_causal,
+                dropout_p=dropout_p,
+                compute_log_sumexp=compute_log_sumexp,
+            )
+        )
+
+    yield from samples
+
+
+def sample_inputs__softmax(
+    op_info,
+    device,
+    dtype,
+    requires_grad,
+    **kwargs,
+):
+    del op_info  # Unused
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+    cases = [
+        ((S,), (0,)),
+        ((S, S), (0,)),
+        ((S, S), (1,)),
+        ((S, S), (-1,)),
+        ((S, M, S), (2,)),
+        ((S, 0, 0), (-1,)),
+    ]
+
+    for (shape, dim), half_to_float in itertools.product(cases, (False,)):
+        # NOTE: softmax with half to float conversion is not supported on CPU
+        # So we don't test it here
+        kwargs = dict(half_to_float=half_to_float)
+        yield opinfo_core.SampleInput(make_arg(shape), args=dim, kwargs=kwargs)
+
+
+def sample_inputs_prims_std_var(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info  # Unused
+    del kwargs  # Unused
+    tensor_nd = functools.partial(
+        opinfo_core.make_tensor,
+        (S, S, S),
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+    tensor_1d = functools.partial(
+        opinfo_core.make_tensor,
+        (S,),
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+
+    yield opinfo_core.SampleInput(tensor_nd(), dims=(1,), correction=0)
+    yield opinfo_core.SampleInput(tensor_1d(), dims=(0,), correction=0)
+    yield opinfo_core.SampleInput(tensor_1d(), dims=(0,), correction=1)
+
+    yield opinfo_core.SampleInput(tensor_nd(), dims=(1,), correction=1)
+    yield opinfo_core.SampleInput(tensor_nd(), dims=(1,), correction=S // 2)
+    yield opinfo_core.SampleInput(tensor_nd(), dims=(), correction=0)
+    # Negative indices are not supported
+
+
+def sample_inputs_stft(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+
+    def mt(shape, **kwargs):
+        return torch_testing.make_tensor(
+            shape, device=device, dtype=dtype, requires_grad=requires_grad, **kwargs
+        )
+
+    yield opinfo_core.SampleInput(mt(100), n_fft=10, return_complex=True)
+    yield opinfo_core.SampleInput(mt(100), n_fft=10, return_complex=False)
+    if dtype.is_complex:
+        yield opinfo_core.SampleInput(mt(100), n_fft=10)
+
+    yield opinfo_core.SampleInput(mt(10), n_fft=7, return_complex=True)
+    yield opinfo_core.SampleInput(
+        mt((10, 100)), n_fft=16, hop_length=4, return_complex=True
+    )
+
+    window = mt(16, low=0.5, high=2.0)
+    yield opinfo_core.SampleInput(
+        mt((2, 100)), kwargs=dict(n_fft=16, window=window, return_complex=True)
+    )
+    yield opinfo_core.SampleInput(
+        mt((3, 100)), kwargs=dict(n_fft=16, window=window, return_complex=True)
+    )
+    if not dtype.is_complex:
+        yield opinfo_core.SampleInput(
+            mt((10, 100)), n_fft=16, window=window, onesided=False, return_complex=True
+        )
+
+
+def sample_inputs_tensor_bool(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del device
+    del requires_grad
+    del kwargs
+    yield opinfo_core.SampleInput(True, dtype=dtype)
+    yield opinfo_core.SampleInput(False, dtype=dtype)
+
+
+def sample_inputs_tensor_float(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del device
+    del requires_grad
+    del kwargs
+    yield opinfo_core.SampleInput(3.0, dtype=dtype)
+    yield opinfo_core.SampleInput(-1.0, dtype=dtype)
+
+
+def sample_inputs_tensor_int(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del device
+    del requires_grad
+    del kwargs
+    yield opinfo_core.SampleInput(2, dtype=dtype)
+    yield opinfo_core.SampleInput(-5, dtype=dtype)
+
+
+def sample_inputs_unfold(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    # Case `target_end == 1`, where `target_end = (input.size(dimension) - size) // step + 1`.
+    t = torch_testing.make_tensor(
+        (2, 3, 4),
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+        **kwargs,
+    )
+    for dimension, size, step in [
+        (1, 2, 2),
+        (-1, 2, 2),
+        (-2, 2, 2),
+    ]:
+        yield opinfo_core.SampleInput(t, args=(dimension, size, step))
+
+
+def sample_inputs_upsample_2d(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+
+    N, C = 2, 3
+    D = 4
+    SS = 3
+    L = 5
+
+    align_corners_options = (True, False)
+    rank = 2
+
+    def shape(size, rank, with_batch_channel=True):
+        if with_batch_channel:
+            return tuple([N, C] + ([size] * rank))
+        return tuple([size] * rank)
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+        low=-1,
+        high=1,
+    )
+
+    yield opinfo_core.SampleInput(
+        make_arg(shape(D, rank)), shape(SS, rank, False), True
+    )
+
+    for align_corners in align_corners_options:
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)), shape(S, rank, False), align_corners
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)), shape(L, rank, False), align_corners
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)),
+            args=(shape(L, rank, False), align_corners),
+            kwargs=dict(scales_h=0.6, scales_w=4.2),
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)),
+            args=(shape(L, rank, False), align_corners),
+            kwargs=dict(scales_h=4.2, scales_w=0.6),
+        )
+
+
+def sample_inputs_upsample_2d_vec(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+
+    N, C = 2, 3
+    D = 4
+    SS = 3
+    L = 5
+
+    align_corners_options = (True, False)
+    rank = 2
+
+    def shape(size, rank, with_batch_channel=True):
+        if with_batch_channel:
+            return tuple([N, C] + ([size] * rank))
+        return tuple([size] * rank)
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+        low=-1,
+        high=1,
+    )
+
+    yield opinfo_core.SampleInput(
+        make_arg(shape(D, rank)), shape(SS, rank, False), True, None
+    )
+
+    for align_corners in align_corners_options:
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)), shape(S, rank, False), align_corners, None
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)), shape(L, rank, False), align_corners, None
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)),
+            args=(
+                None,  # output_size
+                align_corners,
+            ),
+            kwargs=dict(scale_factors=[1.7, 1.7]),
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)),
+            args=(
+                None,  # if this is None, the scalar must be list
+                align_corners,
+            ),
+            kwargs=dict(scale_factors=[0.6, 0.6]),
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)),
+            args=(
+                None,  # if this is None, the scalar must be list
+                align_corners,
+            ),
+            kwargs=dict(scale_factors=[0.6, 4.2]),
+        )
+
+
+def sample_inputs_upsample_linear1d(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+
+    N, C = 2, 3
+    D = 4
+    SS = 3
+    L = 5
+
+    align_corners_options = (True, False)
+    rank = 1
+
+    def shape(size, rank, with_batch_channel=True):
+        if with_batch_channel:
+            return tuple([N, C] + ([size] * rank))
+        return tuple([size] * rank)
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+        low=-1,
+        high=1,
+    )
+
+    yield opinfo_core.SampleInput(
+        make_arg(shape(D, rank)), shape(SS, rank, False), True
+    )
+
+    for align_corners in align_corners_options:
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)), shape(S, rank, False), align_corners
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)), shape(L, rank, False), align_corners
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)), shape(L, rank, False), align_corners, scales=4.2
+        )
+
+
+def sample_inputs_upsample_nearest1d(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+
+    N, C = 2, 3
+    D = 4
+    L = 5
+
+    rank = 1
+
+    def shape(size, rank, with_batch_channel=True):
+        if with_batch_channel:
+            return tuple([N, C] + ([size] * rank))
+        return tuple([size] * rank)
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+        low=-1,
+        high=1,
+    )
+
+    yield opinfo_core.SampleInput(
+        make_arg(shape(D, rank)),
+        shape(S, rank, False),
+    )
+    yield opinfo_core.SampleInput(
+        make_arg(shape(D, rank)),
+        shape(L, rank, False),
+    )
+    # yield opinfo_core.SampleInput(
+    #     make_arg(shape(D, rank)),
+    #     shape(S, rank, False),  # output_size
+    #     [1.7],  # scaler
+    # )
+    # yield opinfo_core.SampleInput(
+    #     make_arg(shape(D, rank)),
+    #     shape(S, rank, False),  # if this is None, the scalar must be list
+    #     [0.6],
+    # )
+
+
+def sample_inputs_upsample_nearest1d_vec(
+    op_info, device, dtype, requires_grad, **kwargs
+):
+    del op_info
+    del kwargs
+
+    N, C = 2, 3
+    D = 4
+    L = 5
+
+    rank = 1
+
+    def shape(size, rank, with_batch_channel=True):
+        if with_batch_channel:
+            return tuple([N, C] + ([size] * rank))
+        return tuple([size] * rank)
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+        low=-1,
+        high=1,
+    )
+
+    yield opinfo_core.SampleInput(make_arg(shape(D, rank)), shape(S, rank, False), None)
+    yield opinfo_core.SampleInput(make_arg(shape(D, rank)), shape(L, rank, False), None)
+    yield opinfo_core.SampleInput(
+        make_arg(shape(D, rank)),
+        None,  # output_size
+        scale_factors=(1.7,),
+    )
+    yield opinfo_core.SampleInput(
+        make_arg(shape(D, rank)),
+        None,
+        scale_factors=(0.6,),
+    )
+
+
+def sample_inputs_upsample_nearest2d(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+
+    N, C = 2, 3
+    D = 4
+    L = 5
+
+    rank = 2
+
+    def shape(size, rank, with_batch_channel=True):
+        if with_batch_channel:
+            return tuple([N, C] + ([size] * rank))
+        return tuple([size] * rank)
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+        low=-1,
+        high=1,
+    )
+
+    yield opinfo_core.SampleInput(
+        make_arg(shape(D, rank)),
+        shape(S, rank, False),
+    )
+    yield opinfo_core.SampleInput(
+        make_arg(shape(D, rank)),
+        shape(L, rank, False),
+    )
+    # yield opinfo_core.SampleInput(
+    #     make_arg(shape(D, rank)),
+    #     shape(L, rank, False),
+    #     1.7, 2.0,  # scaler
+    # )
+    # yield opinfo_core.SampleInput(
+    #     make_arg(shape(D, rank)),
+    #     shape(L, rank, False),
+    #     0.6, 0.4,
+    # )
+
+
+def sample_inputs_upsample_nearest2d_vec(
+    op_info, device, dtype, requires_grad, **kwargs
+):
+    del op_info
+    del kwargs
+
+    N, C = 2, 3
+    D = 4
+    L = 5
+
+    rank = 2
+
+    def shape(size, rank, with_batch_channel=True):
+        if with_batch_channel:
+            return tuple([N, C] + ([size] * rank))
+        return tuple([size] * rank)
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+        low=-1,
+        high=1,
+    )
+
+    yield opinfo_core.SampleInput(make_arg(shape(D, rank)), shape(S, rank, False), None)
+    yield opinfo_core.SampleInput(make_arg(shape(D, rank)), shape(L, rank, False), None)
+    yield opinfo_core.SampleInput(
+        make_arg(shape(D, rank)),
+        None,
+        scale_factors=(1.7, 2.0),
+    )
+    yield opinfo_core.SampleInput(
+        make_arg(shape(D, rank)),
+        None,
+        scale_factors=(0.6, 0.4),
+    )
+
+
+def sample_inputs_upsample_nearest3d(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+
+    N, C = 2, 3
+    D = 4
+    L = 5
+
+    rank = 3
+
+    def shape(size, rank, with_batch_channel=True):
+        if with_batch_channel:
+            return tuple([N, C] + ([size] * rank))
+        return tuple([size] * rank)
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+        low=-1,
+        high=1,
+    )
+
+    yield opinfo_core.SampleInput(
+        make_arg(shape(D, rank)),
+        shape(S, rank, False),
+    )
+    yield opinfo_core.SampleInput(
+        make_arg(shape(D, rank)),
+        shape(L, rank, False),
+    )
+    # yield opinfo_core.SampleInput(
+    #     make_arg(shape(D, rank)),
+    #     shape(L, rank, False),
+    #     1.7, 1.5, 2.0,  # scaler
+    # )
+    # yield opinfo_core.SampleInput(
+    #     make_arg(shape(D, rank)),
+    #     shape(L, rank, False),
+    #     0.6, 0.3, 0.5,
+    # )
+
+
+def sample_inputs_upsample_nearest3d_vec(
+    op_info, device, dtype, requires_grad, **kwargs
+):
+    del op_info
+    del kwargs
+
+    N, C = 2, 3
+    D = 4
+    L = 5
+
+    rank = 3
+
+    def shape(size, rank, with_batch_channel=True):
+        if with_batch_channel:
+            return tuple([N, C] + ([size] * rank))
+        return tuple([size] * rank)
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+        low=-1,
+        high=1,
+    )
+
+    yield opinfo_core.SampleInput(make_arg(shape(D, rank)), shape(S, rank, False), None)
+    yield opinfo_core.SampleInput(make_arg(shape(D, rank)), shape(L, rank, False), None)
+    yield opinfo_core.SampleInput(
+        make_arg(shape(D, rank)),
+        None,
+        scale_factors=(1.7, 1.5, 2.0),  # scaler
+    )
+    yield opinfo_core.SampleInput(
+        make_arg(shape(D, rank)),
+        None,
+        scale_factors=(0.6, 0.3, 0.5),
+    )
+
+
+def sample_inputs_upsample_trilinear3d(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+
+    N, C = 2, 3
+    D = 4
+    SS = 3
+    L = 5
+
+    align_corners_options = (True, False)
+    rank = 3
+
+    def shape(size, rank, with_batch_channel=True):
+        if with_batch_channel:
+            return tuple([N, C] + ([size] * rank))
+        return tuple([size] * rank)
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+        low=-1,
+        high=1,
+    )
+
+    for align_corners in align_corners_options:
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)), shape(SS, rank, False), align_corners
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)), shape(S, rank, False), align_corners
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)), shape(L, rank, False), align_corners
+        )
+
+
+def sample_inputs_upsample_trilinear3d_vec(
+    op_info, device, dtype, requires_grad, **kwargs
+):
+    del op_info
+    del kwargs
+
+    N, C = 2, 3
+    D = 4
+    SS = 3
+    L = 5
+
+    align_corners_options = (True, False)
+    rank = 3
+
+    def shape(size, rank, with_batch_channel=True):
+        if with_batch_channel:
+            return tuple([N, C] + ([size] * rank))
+        return tuple([size] * rank)
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+        low=-1,
+        high=1,
+    )
+
+    yield opinfo_core.SampleInput(
+        make_arg(shape(D, rank)), shape(SS, rank, False), True, None
+    )
+
+    for align_corners in align_corners_options:
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)), shape(S, rank, False), align_corners, None
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)), shape(L, rank, False), align_corners, None
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)),
+            args=(None, align_corners),
+            kwargs=dict(scale_factors=(1.7, 1.7, 1.7)),
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)),
+            args=(None, align_corners),
+            kwargs=dict(scale_factors=(0.6, 0.6, 0.6)),
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)),
+            args=(None, align_corners),
+            kwargs=dict(scale_factors=(0.6, 1.7, 4.2)),
+        )
+
+
+def sample_inputs_window_functions(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+    del device
+    del requires_grad
+
+    for window_length in [2, 3, 7, 10, 32]:
+        yield opinfo_core.SampleInput(window_length, kwargs=dict(dtype=dtype))
+
+
+class _TestParamsMaxPoolEmptyStrideBase:
+    # Adapted from https://github.com/pytorch/pytorch/blob/d6d55f8590eab05d2536756fb4efcfb2d07eb81a/torch/testing/_internal/common_methods_invocations.py#L3203
+    def __init__(self):
+        self.kwargs = {
+            "kernel_size": [3],
+            "stride": [()],
+            "ceil_mode": [True, False],
+            "padding": [0, 1],
+            "dilation": [1],
+        }
+
+        # fmt: off
+        self.shapes = [
+            [1, 2, None],  # batch
+            [2],  # channels
+            [3, 6]  # signal
+        ]
+        # fmt: on
+
+    def _gen_shape(self):
+        for shape in itertools.product(*self.shapes):
+            # shape[0] is None indicates missing batch dimension
+            if shape[0] is None:
+                shape = shape[1:]
+
+            yield shape, torch.contiguous_format
+            # only 2d (N, C, H, W) rank 4 tensors support channels_last memory format
+            if len(self.shapes) == 4 and len(shape) == 4:
+                yield shape, torch.channels_last
+
+    def _gen_kwargs(self):
+        keys = self.kwargs.keys()
+        for values in itertools.product(*self.kwargs.values()):
+            yield dict(zip(keys, values))
+
+    def gen_input_params(self):
+        yield from itertools.product(self._gen_shape(), self._gen_kwargs())
+
+
+class _TestParamsMaxPool1dEmptyStride(_TestParamsMaxPoolEmptyStrideBase):
+    def __init__(self):
+        super().__init__()
+        self.kwargs["kernel_size"] += [(3,)]
+        self.kwargs["stride"] += [(2,)]
+        self.kwargs["padding"] += [(1,)]
+        self.kwargs["dilation"] += [(1,)]
+
+
+class _TestParamsMaxPool2dEmptyStride(_TestParamsMaxPoolEmptyStrideBase):
+    def __init__(self):
+        super().__init__()
+        self.kwargs["kernel_size"] += [(3, 2)]
+        self.kwargs["stride"] += [(2, 1)]
+        self.kwargs["padding"] += [(1, 1)]
+        self.kwargs["dilation"] += [(1, 2)]
+
+        self.shapes.append([6])
+
+
+class _TestParamsMaxPool3dEmptyStride(_TestParamsMaxPoolEmptyStrideBase):
+    def __init__(self):
+        super().__init__()
+        self.kwargs["kernel_size"] += [(3, 2, 3)]
+        self.kwargs["stride"] += [(2, 1, 2)]
+        self.kwargs["dilation"] += [(1, 2, 1)]
+
+        self.shapes.append([6])
+        self.shapes.append([5])
+
+
+# NOTE: How to create an OpInfo:
+# 1. Create a function that generates sample inputs for the op.
+#    This function should yield SampleInputs.
+#    Use `sample_inputs_col2im` as an example.
+# 2. Specify dtypes that the op supports.
+# 3. Use how you would call the op in PyTorch as the name of the OpInfo.
+#    For example, `torch.ops.aten.col2im` should be named "ops.aten.col2im".
+#    This way OpInfo knows to use `torch.ops.aten.col2im` as the op.
+#    See the docstring of OpInfo for more details.
+#
+#    This name is used as the unique ID to connect `TorchLibOpInfo("unique_name", ...)``
+#    in ops_test_data.py and opinfo_core.OpInfo("unique_name", ...)
+#    To avoid name duplication, it is possible to rename the OpInfo and specify
+#    the `op` field explicitly.
+OP_DB: List[opinfo_core.OpInfo] = [
+    opinfo_core.OpInfo(
+        "ops.aten.bernoulli.p",
+        aten_name="bernoulli.p",
+        # dtypes can be a tuple of (torch.float, torch.double).
+        dtypes=common_dtype.all_types(),
+        sample_inputs_func=sample_inputs_bernoulli_p,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        # Deterministic bernoulli sampling where p is either 0 or 1
+        "ops.aten.bernoulli.p_deterministic",
+        op=torch.ops.aten.bernoulli.p,
+        aten_name="bernoulli.p",
+        dtypes=common_dtype.all_types(),
+        sample_inputs_func=sample_inputs_bernoulli_p_deterministic,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.blackman_window",
+        aten_name="blackman_window",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_window_functions,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.col2im",
+        aten_name="col2im",
+        dtypes=common_dtype.floating_and_complex_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=sample_inputs_col2im,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.conv3d",
+        aten_name="conv3d",
+        dtypes=common_dtype.floating_and_complex_types_and(torch.int64, torch.bfloat16),
+        sample_inputs_func=sample_inputs_conv3d,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.convolution",
+        aten_name="convolution",
+        dtypes=common_dtype.floating_and_complex_types_and(torch.int64, torch.bfloat16),
+        sample_inputs_func=sample_inputs_convolution,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.embedding_bag",
+        aten_name="embedding_bag",
+        dtypes=common_dtype.floating_types_and_half(),
+        sample_inputs_func=sample_inputs_embedding_bag,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.embedding_bag.padding_idx",
+        aten_name="embedding_bag.padding_idx",
+        dtypes=common_dtype.floating_types_and_half(),
+        sample_inputs_func=sample_inputs_embedding_bag_padding_idx,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.embedding_renorm",
+        aten_name="embedding_renorm",
+        dtypes=common_dtype.floating_types_and_half(),
+        sample_inputs_func=sample_inputs_embedding_renorm,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten._fft_c2c",
+        aten_name="_fft_c2c",
+        dtypes=common_dtype.complex_types(),
+        sample_inputs_func=sample_inputs__fft_c2c,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten._fft_c2r",
+        aten_name="_fft_c2r",
+        dtypes=common_dtype.complex_types(),
+        sample_inputs_func=sample_inputs__fft_c2r,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten._fft_r2c",
+        aten_name="_fft_r2c",
+        dtypes=common_dtype.floating_types(),
+        sample_inputs_func=sample_inputs__fft_r2c,
+        supports_out=False,
+    ),
+    opinfo_core.BinaryUfuncInfo(
+        "ops.aten.floor_divide",
+        aten_name="floor_divide",
+        dtypes=common_dtype.floating_types_and_half(),
+        rhs_make_tensor_kwargs=dict(exclude_zero=True),
+    ),
+    opinfo_core.BinaryUfuncInfo(
+        "ops.aten.floor_divide.int",
+        aten_name="floor_divide",
+        op=torch.ops.aten.floor_divide,
+        dtypes=common_dtype.integral_types(),
+        # Create only positive inputs
+        lhs_make_tensor_kwargs=dict(low=0),
+        rhs_make_tensor_kwargs=dict(exclude_zero=True, low=0),
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.hamming_window",
+        aten_name="hamming_window",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_window_functions,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.hann_window",
+        aten_name="hann_window",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_window_functions,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.index.Tensor",
+        aten_name="index.Tensor",
+        dtypes=common_dtype.all_types_and_complex_and(
+            torch.bool, torch.float16, torch.bfloat16, torch.chalf
+        ),
+        sample_inputs_func=sample_inputs_index,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.index.Tensor.bool",
+        aten_name="index.Tensor",
+        dtypes=common_dtype.all_types_and_complex_and(
+            torch.bool, torch.float16, torch.bfloat16, torch.chalf
+        ),
+        sample_inputs_func=sample_inputs_index_bool,
+        op=torch.ops.aten.index.Tensor,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.index_put",
+        aten_name="index_put",
+        dtypes=common_dtype.floating_types(),
+        sample_inputs_func=sample_inputs_index_put,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten._unsafe_index_put",
+        aten_name="_unsafe_index_put",
+        dtypes=common_dtype.floating_types(),
+        sample_inputs_func=sample_inputs_index_put,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.layer_norm",
+        aten_name="layer_norm",
+        dtypes=common_dtype.floating_and_complex_types_and(torch.int64, torch.bfloat16),
+        sample_inputs_func=sample_inputs_layer_norm,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten._local_scalar_dense",
+        aten_name="_local_scalar_dense",
+        dtypes=common_dtype.all_types(),
+        sample_inputs_func=sample_inputs__local_scalar_dense,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten._log_softmax",
+        op=torch.ops.aten._log_softmax,  # pylint: disable=protected-access
+        aten_name="_log_softmax",
+        dtypes=common_dtype.floating_types_and_half(),
+        sample_inputs_func=sample_inputs__log_softmax,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.max_pool1d",
+        variant_test_name="empty_strides",
+        aten_name="max_pool1d",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_max_pool_empty_strides,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.max_pool2d",
+        variant_test_name="empty_strides",
+        aten_name="max_pool2d",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_max_pool_empty_strides,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.max_pool3d",
+        variant_test_name="empty_strides",
+        aten_name="max_pool3d",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_max_pool_empty_strides,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.native_dropout",
+        aten_name="native_dropout",
+        dtypes=common_dtype.all_types_and_half(),
+        sample_inputs_func=sample_inputs_native_dropout,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.native_group_norm",
+        aten_name="native_group_norm",
+        dtypes=common_dtype.floating_and_complex_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=sample_inputs_native_group_norm,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten._native_batch_norm_legit",
+        aten_name="_native_batch_norm_legit",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        dtypesIfCUDA=common_dtype.floating_types_and(torch.float16, torch.bfloat16),
+        supports_forward_ad=True,
+        supports_fwgrad_bwgrad=True,
+        assert_jit_shape_analysis=True,
+        sample_inputs_func=sample_inputs__native_batch_norm_legit,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten._native_batch_norm_legit_functional",
+        aten_name="_native_batch_norm_legit_functional",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        dtypesIfCUDA=common_dtype.floating_types_and(torch.float16, torch.bfloat16),
+        supports_forward_ad=True,
+        supports_fwgrad_bwgrad=True,
+        assert_jit_shape_analysis=True,
+        sample_inputs_func=sample_inputs__native_batch_norm_legit,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten._native_batch_norm_legit.no_stats",
+        aten_name="_native_batch_norm_legit.no_stats",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        dtypesIfCUDA=common_dtype.floating_types_and(torch.float16, torch.bfloat16),
+        supports_forward_ad=True,
+        supports_fwgrad_bwgrad=True,
+        assert_jit_shape_analysis=True,
+        sample_inputs_func=sample_inputs__native_batch_norm_legit_no_stats,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.normal.float_Tensor",
+        aten_name="normal.Tensor_Tensor",
+        dtypes=common_dtype.floating_types_and_half(),
+        sample_inputs_func=sample_inputs_normal_float_tensor,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.normal.Tensor_float",
+        aten_name="normal.Tensor_Tensor",
+        dtypes=common_dtype.floating_types_and_half(),
+        sample_inputs_func=sample_inputs_normal_tensor_float,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.normal.Tensor_Tensor",
+        aten_name="normal.Tensor_Tensor",
+        dtypes=common_dtype.floating_types_and_half(),
+        sample_inputs_func=sample_inputs_normal_tensor_tensor,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.rand",
+        aten_name="rand",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_rand,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.rand_like",
+        aten_name="rand_like",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_rand_like,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.randint",
+        aten_name="randint",
+        dtypes=common_dtype.integral_types(),
+        sample_inputs_func=sample_inputs_randint,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.randint.low",
+        aten_name="randint.low",
+        dtypes=common_dtype.integral_types(),
+        sample_inputs_func=sample_inputs_randint_low,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.randint_like",
+        aten_name="randint_like",
+        dtypes=common_dtype.integral_types(),
+        sample_inputs_func=sample_inputs_randint_like,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.randint_like.low_dtype",
+        aten_name="randint_like.low_dtype",
+        dtypes=common_dtype.integral_types(),
+        sample_inputs_func=sample_inputs_randint_like_low_dtype,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.randn",
+        aten_name="randn",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_randn,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.randn_like",
+        aten_name="randn",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_like_fns,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.reflection_pad1d",
+        aten_name="ops.aten.reflection_pad1d",
+        dtypes=common_dtype.floating_and_complex_types_and(torch.int64, torch.bfloat16),
+        sample_inputs_func=sample_inputs_reflection_pad1d,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.replication_pad1d",
+        aten_name="ops.aten.replication_pad1d",
+        dtypes=common_dtype.floating_and_complex_types_and(torch.int64, torch.bfloat16),
+        sample_inputs_func=sample_inputs_replication_pad1d,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten._scaled_dot_product_flash_attention",
+        aten_name="_scaled_dot_product_flash_attention",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        # NOTE: Different from aten::scaled_dot_product_attention, this op doesn't support
+        #       dim<=3 input.
+        sample_inputs_func=sample_inputs__scaled_dot_product_flash_attention,
+        supports_out=False,
+        supports_forward_ad=False,
+        supports_fwgrad_bwgrad=True,
+        check_batched_forward_grad=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten._scaled_dot_product_efficient_attention",
+        aten_name="_scaled_dot_product_efficient_attention",
+        # only support CUDA
+        dtypes=common_dtype.empty_types(),
+        dtypesIfCUDA=common_dtype.floating_types_and(torch.bfloat16),
+        # NOTE: Different from aten::scaled_dot_product_attention, this op doesn't support
+        #       dim<=3 input.
+        sample_inputs_func=sample_inputs__scaled_dot_product_efficient_attention,
+        supports_out=False,
+        supports_forward_ad=False,
+        supports_fwgrad_bwgrad=True,
+        check_batched_forward_grad=False,
+        decorators=[common_device_type.onlyCUDA],
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.slice_scatter",
+        aten_name="slice_scatter",
+        dtypes=common_dtype.all_types_and(torch.bfloat16, torch.half, torch.bool),
+        sample_inputs_func=sample_inputs_slice_scatter,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten._softmax",
+        op=torch.ops.aten._softmax,  # pylint: disable=protected-access
+        aten_name="_softmax",
+        dtypes=common_dtype.floating_types_and_half(),
+        sample_inputs_func=sample_inputs__softmax,
+        supports_out=False,
+    ),
+    # NOTE: torch.STFT has pre-padding and it's not supported by aten::stft
+    # This custom OpInfo uses aten::stft directly.
+    opinfo_core.OpInfo(
+        "ops.aten.stft",
+        aten_name="stft",
+        dtypes=common_dtype.floating_and_complex_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=sample_inputs_stft,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.tensor.bool",
+        aten_name="tensor.bool",
+        dtypes=common_dtype.all_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=sample_inputs_tensor_bool,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.tensor.float",
+        aten_name="tensor.float",
+        dtypes=common_dtype.all_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=sample_inputs_tensor_float,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.tensor.int",
+        aten_name="tensor.int",
+        dtypes=common_dtype.all_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=sample_inputs_tensor_int,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.unfold",
+        aten_name="unfold",
+        dtypes=common_dtype.all_types(),
+        sample_inputs_func=sample_inputs_unfold,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.upsample_bicubic2d.default",
+        aten_name="upsample_bicubic2d",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_2d,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.upsample_bicubic2d.vec",
+        aten_name="upsample_bicubic2d.vec",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_2d_vec,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.upsample_bilinear2d.default",
+        aten_name="upsample_bilinear2d",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_2d,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.upsample_bilinear2d.vec",
+        aten_name="upsample_bilinear2d.vec",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_2d_vec,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.upsample_linear1d",
+        aten_name="upsample_linear1d",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_linear1d,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.upsample_nearest1d",
+        aten_name="upsample_nearest1d",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_nearest1d,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.upsample_nearest1d.vec",
+        aten_name="upsample_nearest1d.vec",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_nearest1d_vec,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.upsample_nearest2d",
+        aten_name="upsample_nearest2d",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_nearest2d,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.upsample_nearest2d.vec",
+        aten_name="upsample_nearest2d.vec",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_nearest2d_vec,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.upsample_nearest3d",
+        aten_name="upsample_nearest3d",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_nearest3d,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.upsample_nearest3d.vec",
+        aten_name="upsample_nearest3d.vec",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_nearest3d_vec,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.upsample_trilinear3d.default",
+        aten_name="upsample_trilinear3d",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_trilinear3d,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.upsample_trilinear3d.vec",
+        aten_name="upsample_trilinear3d.vec",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_trilinear3d_vec,
+        supports_out=False,
+    ),
+    opinfo_core.ReductionOpInfo(
+        "ops.prims.var.default",
+        nan_policy="propagate",
+        supports_out=True,
+        promotes_int_to_float=True,
+        complex_to_real=True,
+        supports_forward_ad=True,
+        supports_fwgrad_bwgrad=True,
+        check_batched_forward_grad=False,
+        dtypes=common_dtype.floating_and_complex_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=sample_inputs_prims_std_var,
+    ),
+    opinfo_core.OpInfo(
+        "nn.functional.max_pool1d_with_indices",
+        aten_name="max_pool1d_with_indices",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_max_pool1d_with_indices,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "nn.functional.max_pool2d_with_indices",
+        aten_name="max_pool2d_with_indices",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_max_pool2d_with_indices,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "nn.functional.max_pool3d_with_indices",
+        aten_name="max_pool3d_with_indices",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_max_pool3d_with_indices,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.scalar_tensor",
+        aten_name="scalar_tensor",
+        dtypes=common_dtype.complex_types(),
+        sample_inputs_func=sample_inputs_scalar_tensor,
+        supports_autograd=False,
+        supports_out=False,
+    ),
+]

--- a/test/onnx/torchlib/ops_test_data.py
+++ b/test/onnx/torchlib/ops_test_data.py
@@ -42,11 +42,19 @@ import functools
 from typing import Any, Callable, Collection, Optional
 from typing_extensions import Self
 
+import extra_opinfo
 import numpy as np
 import ops_test_common
 
 import torch
-from torch.onnx._internal.exporter._torchlib.ops import core as core_ops
+from torch.onnx._internal.exporter._torchlib.ops import (
+    core as core_ops,
+    fft as fft_ops,
+    linalg as linalg_ops,
+    nn as nn_ops,
+    prims as prims_ops,
+    special as special_ops,
+)
 from torch.testing._internal import common_methods_invocations
 from torch.testing._internal.opinfo import definitions as opinfo_definitions
 
@@ -56,6 +64,7 @@ OPS_DB = copy.deepcopy(common_methods_invocations.op_db)
 
 # Append extra op_db into the op database for testing
 OPS_DB.extend(opinfo_definitions.signal.op_db)
+OPS_DB.extend(extra_opinfo.OP_DB)
 
 
 @dataclasses.dataclass
@@ -443,10 +452,1596 @@ def _where_input_wrangler(
 # Ops to be tested for numerical consistency between onnx and pytorch
 # Find the names of the OpInfos in torch/testing/_internal/common_methods_invocations.py
 TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
+    TorchLibOpInfo(
+        "ops.aten._fft_c2c",  # Custom from extra_opinfo
+        fft_ops.aten__fft_c2c,
+        tolerance={torch.complex64: (3e-3, 1.8e-4)},
+        complex=True,
+    ),
+    TorchLibOpInfo(
+        "ops.aten._fft_c2r",  # Custom from extra_opinfo
+        fft_ops.aten__fft_c2r,
+        tolerance={torch.complex64: (3e-3, 1.8e-4)},
+        complex=True,
+    ).xfail(
+        dtypes=(torch.complex64,),
+        reason="fixme: the result is wrong: https://github.com/microsoft/onnxscript/pull/926",
+    ),
+    TorchLibOpInfo(
+        "ops.aten._fft_r2c",  # Custom from extra_opinfo
+        fft_ops.aten__fft_r2c,
+        tolerance={torch.float64: (2e-6, 2e-6), torch.float32: (3e-2, 3e-4)},
+    ),
+    TorchLibOpInfo(
+        "ops.aten._local_scalar_dense",
+        core_ops.aten__local_scalar_dense,
+    ),
+    TorchLibOpInfo("ops.aten._log_softmax", core_ops.aten__log_softmax),
+    TorchLibOpInfo(
+        "ops.aten._log_softmax_half",
+        core_ops.aten__log_softmax_half,
+        tolerance={torch.float16: (1e-3, 1e-3)},
+    ),
+    TorchLibOpInfo("ops.aten._softmax", core_ops.aten__softmax),
+    TorchLibOpInfo("ops.aten._softmax_half", core_ops.aten__softmax_half),
+    TorchLibOpInfo("all_dim", core_ops.aten_all_dim).skip(
+        matcher=lambda sample: not (len(sample.kwargs) > 0)
+        or isinstance(sample.kwargs.get("dim"), tuple),
+        reason="this Aten overload only support one tensor as input and {dim,keepdim} as kwargs by design. dim must be an integer",
+    ),
+    TorchLibOpInfo("all_dims", core_ops.aten_all_dims).skip(
+        matcher=lambda sample: not isinstance(sample.kwargs.get("dim"), tuple),
+        reason="this overload requires dim to be a tuple",
+    ),
+    TorchLibOpInfo("allclose", core_ops.aten_allclose),
+    TorchLibOpInfo(
+        "all",
+        core_ops.aten_all,
+    ).skip(
+        matcher=lambda sample: len(sample.kwargs) != 0,
+        reason="this Aten overload only support one tensor as input by design",
+    ),
     TorchLibOpInfo("abs", core_ops.aten_abs),
     TorchLibOpInfo("abs", core_ops.aten_abs_complex, complex=True),
+    TorchLibOpInfo("acos", core_ops.aten_acos),
+    TorchLibOpInfo("acosh", core_ops.aten_acosh),
     TorchLibOpInfo("add", core_ops.aten_add, tolerance={torch.float16: (1e-3, 1e-3)}),
     TorchLibOpInfo("add", core_ops.aten_add_complex, complex=True),
+    TorchLibOpInfo(
+        "addbmm",
+        core_ops.aten_addbmm,
+        tolerance={torch.float32: (2e-5, 2e-5), torch.float16: (2e-1, 2e-2)},
+    ),
+    TorchLibOpInfo(
+        "addcdiv", core_ops.aten_addcdiv, tolerance={torch.float16: (3e-2, 1e-3)}
+    ),
+    TorchLibOpInfo(
+        "addcmul", core_ops.aten_addcmul, tolerance={torch.float16: (4e-3, 3e-3)}
+    ),
+    TorchLibOpInfo("addmm", core_ops.aten_addmm)
+    .xfail(
+        dtypes=(torch.int16, torch.int32, torch.int64),
+        reason="ONNX Runtime does not support int inputs to Gemm",
+    )
+    .xfail(
+        "decomposed",
+        dtypes=(torch.int16, torch.int32, torch.int64),
+        reason="ONNX Runtime does not support int inputs to Gemm",
+    )
+    .skip(
+        "decomposed",
+        matcher=lambda sample: torch.numel(sample.input) == 0
+        or torch.numel(sample.args[0]) == 0
+        or torch.numel(sample.args[1]) == 0,
+        reason="zero sized inputs cannot be compared",
+    ),
+    TorchLibOpInfo(
+        "addmv", core_ops.aten_addmv, tolerance={torch.float16: (2e-3, 2e-2)}
+    ),
+    TorchLibOpInfo(
+        "addr",
+        core_ops.aten_addr,
+        tolerance={torch.float16: (3e-3, 4e-3)},
+    ),
+    TorchLibOpInfo(
+        "amax",
+        core_ops.aten_amax,
+        input_wrangler=_amin_amax_input_wrangler,
+    ),
+    TorchLibOpInfo(
+        "amin",
+        core_ops.aten_amin,
+        input_wrangler=_amin_amax_input_wrangler,
+    ),
+    TorchLibOpInfo(
+        "any",
+        core_ops.aten_any,
+    ).skip(
+        matcher=lambda sample: len(sample.kwargs) != 0,
+        reason="this Aten overload only support one tensor as input by design",
+    ),
+    TorchLibOpInfo(
+        "any_dim",
+        core_ops.aten_any_dim,
+    ).skip(
+        matcher=lambda sample: not (len(sample.kwargs) > 0)
+        or isinstance(sample.kwargs.get("dim"), tuple),
+        reason="this Aten overload only support one tensor as input and {dim,keepdim} as kwargs by design. dim must be an integer",
+    ),
+    TorchLibOpInfo("any_dims", core_ops.aten_any_dims).skip(
+        matcher=lambda sample: not isinstance(sample.kwargs.get("dim"), tuple),
+        reason="this overload requires dim to be a tuple",
+    ),
+    TorchLibOpInfo("asin", core_ops.aten_asin),
+    TorchLibOpInfo("asinh", core_ops.aten_asinh),
+    TorchLibOpInfo("atan", core_ops.aten_atan),
+    TorchLibOpInfo(
+        "atan2", core_ops.aten_atan2, tolerance={torch.float16: (1e-3, 1e-3)}
+    ),
+    TorchLibOpInfo("atanh", core_ops.aten_atanh),
+    TorchLibOpInfo("atleast_1d", core_ops.aten_atleast_1d).skip(
+        matcher=lambda sample: isinstance(sample.input, (list, tuple)),
+        reason="takes single tensor as input",
+    ),
+    TorchLibOpInfo(
+        "atleast_1d_Sequence",
+        core_ops.aten_atleast_1d_sequence,
+    )
+    .skip(
+        matcher=lambda sample: not isinstance(sample.input, (list, tuple)),
+        reason="takes tensor sequences only",
+    )
+    .xfail(
+        reason=(
+            "fixme: ORT shape inference failed."
+            "https://github.com/microsoft/onnxscript/issues/1007"
+        ),
+    ),
+    TorchLibOpInfo("atleast_2d", core_ops.aten_atleast_2d).skip(
+        matcher=lambda sample: isinstance(sample.input, (list, tuple)),
+        reason="takes single tensor as input",
+    ),
+    TorchLibOpInfo(
+        "atleast_2d_Sequence",
+        core_ops.aten_atleast_2d_sequence,
+    )
+    .skip(
+        matcher=lambda sample: not isinstance(sample.input, (list, tuple)),
+        reason="takes tensor sequences only",
+    )
+    .xfail(
+        reason=(
+            "fixme: ORT shape inference failed."
+            "https://github.com/microsoft/onnxscript/issues/1007"
+        ),
+    ),
+    TorchLibOpInfo("atleast_3d", core_ops.aten_atleast_3d).skip(
+        matcher=lambda sample: isinstance(sample.input, (list, tuple)),
+        reason="takes single tensor as input",
+    ),
+    TorchLibOpInfo(
+        "atleast_3d_Sequence",
+        core_ops.aten_atleast_3d_sequence,
+    )
+    .skip(
+        matcher=lambda sample: not isinstance(sample.input, (list, tuple)),
+        reason="takes tensor sequences only",
+    )
+    .xfail(
+        reason=(
+            "fixme: ORT shape inference failed."
+            "https://github.com/microsoft/onnxscript/issues/1007"
+        ),
+    ),
+    TorchLibOpInfo(
+        "baddbmm", core_ops.aten_baddbmm, tolerance={torch.float16: (1e-3, 1e-2)}
+    ),
+    TorchLibOpInfo("bernoulli", core_ops.aten_bernoulli, nondeterministic=True),
+    TorchLibOpInfo(
+        # This string is a unique ID. In extra_opinfo.py, we
+        # also define test data for this ID with
+        # `opinfo_core.OpInfo("aten.bernoulli.p", ...)`.
+        "ops.aten.bernoulli.p",
+        core_ops.aten_bernoulli_p,
+        # Skip comparison for the output of this op because it is a random tensor.
+        nondeterministic=True,
+    ),
+    TorchLibOpInfo("ops.aten.bernoulli.p_deterministic", core_ops.aten_bernoulli_p),
+    TorchLibOpInfo("bitwise_and", core_ops.aten_bitwise_and),
+    TorchLibOpInfo("bitwise_left_shift_int16", core_ops.aten_bitwise_left_shift_int16),
+    TorchLibOpInfo("bitwise_left_shift_int32", core_ops.aten_bitwise_left_shift_int32),
+    TorchLibOpInfo("bitwise_left_shift_int64", core_ops.aten_bitwise_left_shift_int64),
+    TorchLibOpInfo("bitwise_left_shift_int8", core_ops.aten_bitwise_left_shift_int8),
+    TorchLibOpInfo("bitwise_not", core_ops.aten_bitwise_not),
+    TorchLibOpInfo("bitwise_or", core_ops.aten_bitwise_or),
+    TorchLibOpInfo(
+        "bitwise_right_shift_int16", core_ops.aten_bitwise_right_shift_int16
+    ),
+    TorchLibOpInfo(
+        "bitwise_right_shift_int32", core_ops.aten_bitwise_right_shift_int32
+    ),
+    TorchLibOpInfo(
+        "bitwise_right_shift_int64", core_ops.aten_bitwise_right_shift_int64
+    ),
+    TorchLibOpInfo("bitwise_right_shift_int8", core_ops.aten_bitwise_right_shift_int8),
+    TorchLibOpInfo("bitwise_xor", core_ops.aten_bitwise_xor),
+    TorchLibOpInfo("ops.aten.blackman_window", core_ops.aten_blackman_window),
+    TorchLibOpInfo("bmm", core_ops.aten_bmm),
+    TorchLibOpInfo("broadcast_to", core_ops.aten_broadcast_to),
+    TorchLibOpInfo("cat", core_ops.aten_cat).skip(
+        matcher=lambda sample: sample.input[0].equal(
+            torch.tensor([]).to(sample.input[0].device)
+        ),
+        reason="fixme: ORT aborts with zero-dim tensors. https://github.com/microsoft/onnxruntime/issues/16619",
+    ),
+    TorchLibOpInfo("cat", core_ops.aten_cat_complex, complex=True).skip(
+        matcher=lambda sample: sample.input[0].equal(
+            torch.tensor([]).to(sample.input[0].device)
+        ),
+        reason="fixme: ORT aborts with zero-dim tensors. https://github.com/microsoft/onnxruntime/issues/16619",
+    ),
+    TorchLibOpInfo("ceil", core_ops.aten_ceil),
+    TorchLibOpInfo(
+        "chunk",
+        core_ops.aten_chunk,
+    ).xfail(
+        dtypes=(torch.bool,),
+        reason="fixme: ORT does not implement SplitToSequence for bool inputs: https://github.com/microsoft/onnxruntime/issues/16905",
+    ),
+    TorchLibOpInfo("clamp_max", core_ops.aten_clamp_max).skip(
+        reason="Size 0 inputs are not handled by design",
+        matcher=lambda sample: sample.input.numel() == 0,
+    ),
+    TorchLibOpInfo("clamp_min", core_ops.aten_clamp_min).skip(
+        reason="Size 0 inputs are not handled by design",
+        matcher=lambda sample: sample.input.numel() == 0,
+    ),
+    TorchLibOpInfo("clone", core_ops.aten_clone),
+    TorchLibOpInfo("complex", core_ops.aten_complex),
+    TorchLibOpInfo("concat", core_ops.aten_cat).skip(
+        matcher=lambda sample: sample.input[0].equal(
+            torch.tensor([]).to(sample.input[0].device)
+        ),
+        reason="fixme: ORT aborts with zero-dim tensors. https://github.com/microsoft/onnxruntime/issues/16619",
+    ),
+    TorchLibOpInfo("concatenate", core_ops.aten_cat).skip(
+        matcher=lambda sample: sample.input[0].equal(
+            torch.tensor([]).to(sample.input[0].device)
+        ),
+        reason="fixme: ORT aborts with zero-dim tensors. https://github.com/microsoft/onnxruntime/issues/16619",
+    ),
+    TorchLibOpInfo("conj", core_ops.aten_conj),
+    TorchLibOpInfo("conj", core_ops.aten_conj_complex, complex=True),
+    TorchLibOpInfo("constant_pad_nd", core_ops.aten_constant_pad_nd),
+    # TorchLibOpInfo("copy", core_ops.aten_copy),  # copy is not in OPS_DB
+    TorchLibOpInfo("cos", core_ops.aten_cos),
+    TorchLibOpInfo("cosh", core_ops.aten_cosh),
+    TorchLibOpInfo(
+        "cross", core_ops.aten_cross, tolerance={torch.float16: (1e-1, 2e-2)}
+    ),
+    TorchLibOpInfo("deg2rad", core_ops.aten_deg2rad),
+    # TorchLibOpInfo("detach", core_ops.aten_detach),  # detach is not in OP-TEST-DB
+    TorchLibOpInfo("diagonal", core_ops.aten_diagonal),
+    TorchLibOpInfo("diagonal_bool", core_ops.aten_diagonal_bool),
+    TorchLibOpInfo("div", core_ops.aten_div).skip(
+        matcher=lambda sample: sample.kwargs.get("rounding_mode") is not None,
+        reason="this variation does not take the rounding_mode argument",
+    ),
+    TorchLibOpInfo("true_divide", core_ops.aten_div),
+    TorchLibOpInfo("true_divide", core_ops.aten_div_complex, complex=True),
+    TorchLibOpInfo("div_mode", core_ops.aten_div_mode)
+    .skip(
+        variant_name="no_rounding_mode",
+        reason="this variation requires the rounding_mode argument",
+    )
+    .skip(
+        variant_name="trunc_rounding",
+        dtypes=(torch.float16,),
+        # Numbers match sometimes but not other times
+        reason="fixme: off-by-one. https://github.com/microsoft/onnxscript/issues/990",
+    ),
+    TorchLibOpInfo("div_mode_int", core_ops.aten_div_mode_int).skip(
+        variant_name="no_rounding_mode",
+        reason="this variation requires the rounding_mode argument",
+    ),
+    TorchLibOpInfo("dot", core_ops.aten_dot),
+    TorchLibOpInfo(
+        "empty",
+        core_ops.aten_empty,
+        input_wrangler=_empty_input_wrangler,
+        nondeterministic=True,
+    ),
+    TorchLibOpInfo(
+        "einsum", core_ops.aten_einsum, input_wrangler=_einsum_input_wrangler
+    )
+    .xfail(
+        reason="fixme: PyTorch produces int64 output with int32 input",
+        dtypes=(torch.int32,),
+    )
+    .xfail(
+        reason="fixme: ONNX shape inference fails: https://github.com/onnx/onnx/issues/5739",
+        matcher=lambda sample: sample.args[0] == "...ik, ...j -> ij",
+    ),
+    # TorchLibOpInfo("empty_strided", core_ops.aten_empty_strided),  # empty_strided is not in OPS_DB
+    TorchLibOpInfo("eq", core_ops.aten_eq),
+    TorchLibOpInfo("equal", core_ops.aten_equal),
+    TorchLibOpInfo("exp", core_ops.aten_exp),
+    TorchLibOpInfo("exp2", core_ops.aten_exp2),
+    TorchLibOpInfo("expand", core_ops.aten_expand),
+    TorchLibOpInfo("expand_as", core_ops.aten_expand_as),
+    TorchLibOpInfo("erf", special_ops.aten_special_erf),
+    TorchLibOpInfo(
+        "erfc", special_ops.aten_special_erfc, tolerance={torch.float16: (5e-1, 2e-4)}
+    ),
+    TorchLibOpInfo(
+        "expm1", special_ops.aten_special_expm1, tolerance={torch.float16: (1e-2, 2e-4)}
+    ),
+    TorchLibOpInfo("special.erfcx", special_ops.aten_special_erfcx).xfail(
+        reason="fixme: The implementation is numerically unstable: https://github.com/microsoft/onnxscript/issues/1223"
+    ),
+    TorchLibOpInfo("fill", core_ops.aten_fill),
+    TorchLibOpInfo("flip", core_ops.aten_flip).skip(
+        reason="fixme: size 0 inputs are not handled yet",
+        matcher=lambda sample: sample.input.numel() == 0,
+    ),
+    TorchLibOpInfo("floor", core_ops.aten_floor),
+    TorchLibOpInfo("ops.aten.floor_divide", core_ops.aten_floor_divide),
+    TorchLibOpInfo("fmod", core_ops.aten_fmod),
+    TorchLibOpInfo("frac", core_ops.aten_frac),
+    TorchLibOpInfo("full", core_ops.aten_full),
+    TorchLibOpInfo(
+        "full_like",
+        core_ops.aten_full_like,
+    ),
+    TorchLibOpInfo("gather", core_ops.aten_gather).skip(
+        matcher=lambda sample: sample.input.numel() == 0 or sample.args[1].numel() == 0,
+        reason="fixme: ORT does not support empty tensors as input",
+    ),
+    TorchLibOpInfo("ge", core_ops.aten_ge),
+    TorchLibOpInfo("ge_bool", core_ops.aten_ge_bool),
+    TorchLibOpInfo("gt", core_ops.aten_gt),
+    TorchLibOpInfo("gt_bool", core_ops.aten_gt_bool),
+    # TorchLibOpInfo("is_nonzero", core_ops.aten_is_nonzero),  # no test case in OPS_DB
+    TorchLibOpInfo("ops.aten.index.Tensor", core_ops.aten_index),
+    TorchLibOpInfo("ops.aten.index.Tensor.bool", core_ops.aten_index_bool),
+    TorchLibOpInfo(
+        "index_put_bool",
+        core_ops.aten_index_put_bool,
+        input_wrangler=_index_put_input_wrangler,
+    ).skip(
+        matcher=lambda sample: sample.args[0][0].dtype != torch.bool,
+        reason="this Aten overload only supports tensor(bool) as indices",
+    ),
+    TorchLibOpInfo(
+        "index_put",
+        core_ops.aten_index_put,
+        input_wrangler=_index_put_input_wrangler,
+    )
+    .skip(
+        matcher=lambda sample: sample.args[0][0].dtype != torch.int64,
+        reason="this Aten overload only supports tensor(int) as indices",
+    )
+    .xfail(
+        dtypes=(torch.float16,),
+        matcher=lambda sample: sample.kwargs.get("accumulate") is True,
+        reason="fixme: ORT only supports float32 when accumulate is True:  MLFloat16 data type is not supported with ScatterND when reduction is 'add'",
+    ),
+    TorchLibOpInfo("ops.aten.index_put", core_ops.aten_index_put),
+    TorchLibOpInfo("ops.aten._unsafe_index_put", core_ops.aten_index_put),
+    TorchLibOpInfo("index_select", core_ops.aten_index_select),
+    TorchLibOpInfo("isclose", core_ops.aten_isclose),
+    TorchLibOpInfo("isfinite", core_ops.aten_isfinite),
+    TorchLibOpInfo("isinf", core_ops.aten_isinf),
+    TorchLibOpInfo("isnan", core_ops.aten_isnan),
+    TorchLibOpInfo("isneginf", core_ops.aten_isneginf),
+    TorchLibOpInfo("isposinf", core_ops.aten_isposinf),
+    TorchLibOpInfo("lift_fresh_copy", core_ops.aten_lift_fresh_copy),
+    TorchLibOpInfo("linalg.det", linalg_ops.aten_linalg_det),
+    TorchLibOpInfo(
+        "linalg.vector_norm",
+        linalg_ops.aten_linalg_vector_norm,
+        tolerance={torch.float16: (2e-3, 2e-3)},
+    ).skip(
+        matcher=lambda sample: sample.kwargs.get("ord") == 6,
+        dtypes=(torch.float16,),
+        reason="ORT returns a more accurate value for float16 with ord=6 (expected=Inf, actual=9.48).",
+    ),
+    TorchLibOpInfo(
+        "linspace",
+        core_ops.aten_linspace,
+        tolerance={torch.float16: (2e-2, 2e-3)},
+    )
+    .xfail(
+        dtypes=(torch.int64, torch.int32),
+        reason="fixme: Results do not match with PyTorch. https://github.com/microsoft/onnxscript/issues/854",
+    )
+    .xfail(
+        variant_name="tensor_overload",
+        dtypes=(torch.int64, torch.int32),
+        reason="fixme: Results do not match with PyTorch. https://github.com/microsoft/onnxscript/issues/854",
+    ),
+    TorchLibOpInfo("log", core_ops.aten_log),
+    TorchLibOpInfo("le", core_ops.aten_le),
+    TorchLibOpInfo("le_bool", core_ops.aten_le_bool),
+    TorchLibOpInfo(
+        "lerp",
+        core_ops.aten_lerp,
+        tolerance={torch.float16: (2e-3, 2e-1)},
+    ),
+    TorchLibOpInfo("log10", core_ops.aten_log10),
+    TorchLibOpInfo("log1p", core_ops.aten_log1p),
+    TorchLibOpInfo(
+        "log_softmax",
+        special_ops.aten_special_log_softmax,
+        tolerance={torch.float32: (3.7e-5, 1.8e-4), torch.float16: (4e-4, 6e-3)},
+    )
+    .xfail(
+        dtypes=(torch.float16,),
+        reason="fixme: ORT failed. https://github.com/microsoft/onnxruntime/issues/16438",
+    )
+    .xfail(
+        variant_name="with_dtype",
+        dtypes=(torch.float16,),
+        reason="fixme: ORT failed. https://github.com/microsoft/onnxruntime/issues/16438",
+    )
+    .skip(
+        matcher=lambda sample: len(sample.input.shape) == 0,
+        reason="fixme: LogSoftMax does not support empty tensor as input",
+    )
+    .skip(
+        variant_name="with_dtype",
+        matcher=lambda sample: len(sample.input.shape) == 0,
+        reason="fixme: LogSoftMax does not support empty tensor as input",
+    ),
+    TorchLibOpInfo("log2", core_ops.aten_log2),
+    TorchLibOpInfo(
+        "logaddexp", core_ops.aten_logaddexp, tolerance={torch.float16: (1, 1e-4)}
+    ),
+    TorchLibOpInfo(
+        "logaddexp2", core_ops.aten_logaddexp2, tolerance={torch.float16: (2e-2, 6e-4)}
+    ),
+    TorchLibOpInfo(
+        "logcumsumexp",
+        core_ops.aten_logcumsumexp,
+        tolerance={torch.float16: (1e-2, 1e-1)},
+    ),
+    TorchLibOpInfo("logdet", core_ops.aten_logdet),
+    TorchLibOpInfo("logsumexp", core_ops.aten_logsumexp),
+    TorchLibOpInfo("lt", core_ops.aten_lt),
+    TorchLibOpInfo("lt_bool", core_ops.aten_lt_bool),
+    TorchLibOpInfo("masked_fill", core_ops.aten_masked_fill).xfail(
+        dtypes=(torch.bool,),
+        reason="fixme: ORT does not have an implementation for Where with bool inputs.",
+    ),
+    TorchLibOpInfo(
+        "matmul",
+        core_ops.aten_matmul,
+        # Windows requires a more relaxed tolerance
+        tolerance={torch.float32: (2e-5, 2e-5), torch.float16: (2e-3, 2e-2)},
+    ).skip(
+        matcher=lambda sample: torch.numel(sample.input) == 0,
+        reason="values of matmul of [m, 0] and [0, n] matrices are undefined",
+    ),
+    TorchLibOpInfo("maximum", core_ops.aten_maximum),
+    TorchLibOpInfo("maximum_bool", core_ops.aten_maximum_bool),
+    TorchLibOpInfo(
+        "mean",
+        core_ops.aten_mean,
+        input_wrangler=_mean_input_wrangler,
+    ).skip(
+        matcher=lambda sample: sample.kwargs.get("dim") is not None,
+        reason="this Aten overload only accept 1 inputs: self",
+    ),
+    TorchLibOpInfo(
+        "mean_dim",
+        core_ops.aten_mean_dim,
+        input_wrangler=_mean_input_wrangler,
+    ).skip(
+        matcher=lambda sample: sample.kwargs.get("dim") is None,
+        reason="this Aten overload can accept 2 inputs:(self, dim)",
+    ),
+    TorchLibOpInfo("mH", core_ops.aten_mH),
+    TorchLibOpInfo("mH", core_ops.aten_mH_complex, complex=True),
+    TorchLibOpInfo("min_dim", core_ops.aten_min_dim)
+    .xfail(
+        matcher=lambda sample: len(sample.args) == 0
+        or (len(sample.args) > 0 and not isinstance(sample.args[0], int)),
+        reason="this ATen overload only support one tensor as input and another int as args",
+    )
+    .xfail(
+        variant_name="reduction_with_dim",
+        dtypes=(torch.int64,),
+        reason="fixme: ORT 1.18 does not support int64",
+    ),
+    TorchLibOpInfo(
+        "min",
+        core_ops.aten_min,
+    ).skip(
+        matcher=lambda sample: len(sample.args) > 0,
+        reason="this ATen overload only supports one tensor as input by design",
+    ),
+    TorchLibOpInfo("minimum", core_ops.aten_minimum),
+    TorchLibOpInfo("minimum_bool", core_ops.aten_minimum_bool),
+    TorchLibOpInfo("mm", core_ops.aten_mm).skip(
+        matcher=lambda sample: torch.numel(sample.input) == 0,
+        reason="values of matmul of [m, 0] and [0, n] matrices are undefined",
+    ),
+    TorchLibOpInfo("mT", core_ops.aten_mT),
+    TorchLibOpInfo("mT", core_ops.aten_mT_complex, complex=True),
+    TorchLibOpInfo("mul", core_ops.aten_mul),
+    TorchLibOpInfo("mul", core_ops.aten_mul_complex, complex=True),
+    TorchLibOpInfo(
+        "mv",
+        core_ops.aten_mv,
+        tolerance={torch.float16: (3e-2, 1e-2)},
+    ),
+    TorchLibOpInfo("narrow", core_ops.aten_narrow),
+    TorchLibOpInfo("ops.aten.native_dropout", core_ops.aten_native_dropout),
+    TorchLibOpInfo("ne", core_ops.aten_ne),
+    TorchLibOpInfo("neg", core_ops.aten_neg),
+    TorchLibOpInfo(
+        "new_empty",
+        core_ops.aten_new_empty,
+        nondeterministic=True,
+    ),
+    TorchLibOpInfo(
+        "new_empty_strided",
+        core_ops.aten_new_empty_strided,
+        nondeterministic=True,
+    ),
+    TorchLibOpInfo(
+        "new_full",
+        core_ops.aten_new_full,
+    ),
+    TorchLibOpInfo(
+        "new_ones",
+        core_ops.aten_new_ones,
+    ),
+    TorchLibOpInfo(
+        "new_zeros",
+        core_ops.aten_new_zeros,
+    ),
+    TorchLibOpInfo("nn.functional.celu", nn_ops.aten_celu),
+    TorchLibOpInfo("nn.functional.celu_type_promoted", nn_ops.aten_celu_type_promoted),
+    TorchLibOpInfo(
+        "nn.functional.cross_entropy",
+        # use cross_entropy as test case instead of cross_entropy_loss (not in OPS_DB)
+        nn_ops.aten_cross_entropy_loss,
+        tolerance={torch.float16: (1e-2, 1e-2)},
+        input_wrangler=_cross_entropy_input_wrangler,
+    ).xfail(
+        matcher=lambda sample: len(sample.args) < 1
+        or (
+            isinstance(sample.args[0], torch.Tensor)
+            and sample.args[0].dtype != torch.int64
+        ),
+        reason="ONNX SoftmaxCrossEntropyLoss op only accept argument[target] as int type",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.dropout",
+        core_ops.aten_dropout,
+        input_wrangler=_dropout_input_wrangler,
+    ).skip(
+        matcher=lambda sample: len(sample.kwargs) == 0
+        or sample.kwargs.get("p", 0.0) > 0.0,
+        reason="dropout is random so the result not match",
+    ),
+    TorchLibOpInfo("nn.functional.elu", nn_ops.aten_elu),
+    TorchLibOpInfo(
+        "ops.aten.embedding_bag",
+        core_ops.aten_embedding_bag,
+        tolerance={torch.float16: (1e-2, 5e-2)},
+        compare_shape_only_for_output=(1, 2, 3),
+    ).skip(
+        reason="fixme: https://github.com/pytorch/pytorch/issues/146336",
+    ),
+    TorchLibOpInfo(
+        "ops.aten.embedding_bag.padding_idx",
+        core_ops.aten_embedding_bag_padding_idx,
+        tolerance={torch.float16: (1e-2, 1e-2)},
+        compare_shape_only_for_output=(1, 2, 3),
+    ),
+    TorchLibOpInfo(
+        "ops.aten.embedding_renorm",
+        core_ops.aten_embedding_renorm,
+        tolerance={torch.float16: (1e-2, 1e-2)},
+        compare_shape_only_for_output=(1, 2, 3),
+    ),
+    TorchLibOpInfo(
+        "nn.functional.embedding",
+        core_ops.aten_embedding,
+        input_wrangler=_embedding_input_wrangler,
+    ),
+    TorchLibOpInfo("nn.functional.hardsigmoid", nn_ops.aten_hardsigmoid),
+    TorchLibOpInfo("nn.functional.hardswish", nn_ops.aten_hardswish),
+    TorchLibOpInfo("nn.functional.hardtanh", nn_ops.aten_hardtanh),
+    TorchLibOpInfo("nn.functional.leaky_relu", nn_ops.aten_leaky_relu),
+    TorchLibOpInfo(
+        "nn.functional.logsigmoid",
+        nn_ops.aten_log_sigmoid,
+        tolerance={torch.float32: (3.7e-5, 1.8e-4), torch.float16: (8e-2, 4e-4)},
+    ),
+    TorchLibOpInfo("nn.functional.mish", nn_ops.aten_mish),
+    TorchLibOpInfo(
+        "nn.functional.nll_loss",
+        nn_ops.aten_nll_loss,
+        input_wrangler=_nll_loss_input_wrangler,
+        tolerance={torch.float16: (5e-2, 1e-2)},
+    ),
+    TorchLibOpInfo("nn.functional.pad", nn_ops.aten_pad)
+    .skip(
+        variant_name="circular",
+        reason="fixme: ORT does not support the circular mode",
+    )
+    .skip(
+        variant_name="replicate_negative",
+        reason="fixme: The implementation for negative paddings is not correct",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.pixel_shuffle",
+        core_ops.aten_pixel_shuffle,
+    )
+    .xfail(
+        dtypes=(torch.int32, torch.int64),
+        reason="fixme: ONNX Runtime does not support int32/64 inputs",
+    )
+    .xfail(
+        matcher=lambda sample: sample.input.numel() == 0,
+        reason="fixme: ORT does not support empty tensor as input",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.pixel_unshuffle",
+        core_ops.aten_pixel_unshuffle,
+    )
+    .xfail(
+        dtypes=(torch.int32, torch.int64),
+        reason="fixme: ONNX Runtime does not support int32/64 inputs",
+    )
+    .xfail(
+        matcher=lambda sample: sample.input.numel() == 0,
+        reason="fixme: ORT does not support empty tensor as input",
+    ),
+    TorchLibOpInfo(
+        "ops.aten.reflection_pad1d",
+        nn_ops.aten_reflection_pad1d,
+    ).xfail(
+        dtypes=(torch.int64,),
+        reason="Torch not implement reflection_pad1d for int64.",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.reflection_pad2d",
+        nn_ops.aten_reflection_pad2d,
+        input_wrangler=_reflection_pad2d_input_wrangler,
+    ).skip(
+        matcher=lambda sample: not (
+            len(sample.args) > 1 and sample.args[1] == "reflect"
+        ),
+        reason="this Aten overload need args[1] == 'reflect' for pad mode",
+    ),
+    TorchLibOpInfo("nn.functional.relu", nn_ops.aten_relu),
+    TorchLibOpInfo("nn.functional.relu6", nn_ops.aten_relu6),
+    TorchLibOpInfo(
+        "ops.aten.replication_pad1d",
+        nn_ops.aten_replication_pad1d,
+    ),
+    TorchLibOpInfo(
+        "nn.functional.replication_pad2d",
+        nn_ops.aten_replication_pad2d,
+        input_wrangler=_replication_pad2d_input_wrangler,
+    )
+    .skip(
+        matcher=lambda sample: not (
+            len(sample.args) > 1 and sample.args[1] == "replicate"
+        ),
+        reason="this Aten overload need args[1] == 'replicate' for pad mode",
+    )
+    .skip(
+        variant_name="replicate_negative",
+        reason="fixme: https://github.com/microsoft/onnxscript/pull/2037",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.replication_pad3d",
+        nn_ops.aten_replication_pad3d,
+        input_wrangler=_replication_pad3d_input_wrangler,
+    ).skip(
+        matcher=lambda sample: not (
+            len(sample.args) > 1
+            and sample.args[1] == "replicate"
+            and len(sample.input.shape) == 5
+        ),
+        reason="this Aten overload need args[1] == 'replicate' for pad mode, and 3D tensor",
+    ),
+    TorchLibOpInfo("nn.functional.selu", core_ops.aten_selu),
+    TorchLibOpInfo(
+        "nn.functional.mse_loss",
+        nn_ops.aten_mse_loss,
+        input_wrangler=_mse_loss_input_wrangler,
+    ),
+    TorchLibOpInfo(
+        "nonzero",
+        core_ops.aten_nonzero,
+        input_wrangler=_nonzero_input_wrangler,
+    )
+    .xfail(
+        matcher=lambda sample: sample.kwargs.get("as_tuple"),
+        reason="as_tuple=True is not supported",
+    )
+    .xfail(
+        matcher=lambda sample: len(sample.input.shape) == 0,
+        reason="fixme: output 'shape' do not match: torch.Size([0, 1]) != torch.Size([0, 0]).",
+    ),
+    TorchLibOpInfo("normal", core_ops.aten_normal, nondeterministic=True)
+    .skip(
+        matcher=lambda sample: len(sample.args) > 0
+        and not isinstance(sample.args[0], float),
+        reason="ORT only accept float type for args[0] 'mean'",
+    )
+    .xfail(
+        variant_name="number_mean",
+        reason="This variant does not support dtype as an argument",
+        matcher=lambda sample: sample.kwargs.get("dtype") is not None,
+    ),
+    TorchLibOpInfo(
+        "ops.aten.normal.float_Tensor",
+        core_ops.aten_normal_float_tensor,
+        nondeterministic=True,
+    ),
+    TorchLibOpInfo(
+        "ops.aten.normal.Tensor_float",
+        core_ops.aten_normal_tensor_float,
+        nondeterministic=True,
+    ),
+    TorchLibOpInfo(
+        "ops.aten.normal.Tensor_Tensor",
+        core_ops.aten_normal_tensor_tensor,
+        nondeterministic=True,
+    ),
+    TorchLibOpInfo("ones", core_ops.aten_ones),
+    TorchLibOpInfo("permute", core_ops.aten_permute),
+    TorchLibOpInfo("polar", core_ops.aten_polar),
+    TorchLibOpInfo("pow", core_ops.aten_pow),
+    TorchLibOpInfo("prod", core_ops.aten_prod).skip(
+        matcher=lambda sample: sample.kwargs.get("dim") is not None
+        or sample.kwargs.get("keepdim") is not None
+        or sample.kwargs.get("dtype") != -1,
+        reason="this Aten overload only accept 1 inputs: self",
+    ),
+    TorchLibOpInfo("prod_dim_int", core_ops.aten_prod_dim_int).skip(
+        matcher=lambda sample: (
+            sample.kwargs.get("dim") is None and sample.kwargs.get("keepdim") is None
+        )
+        or sample.kwargs.get("dtype") != -1,
+        reason="this Aten overload can accept 3 inputs:(self, dim, keepdim)",
+    ),
+    TorchLibOpInfo("nn.functional.prelu", core_ops.aten_prelu),
+    TorchLibOpInfo("ops.aten.rand", core_ops.aten_rand, nondeterministic=True),
+    TorchLibOpInfo(
+        "ops.aten.rand_like", core_ops.aten_rand_like, nondeterministic=True
+    ),
+    TorchLibOpInfo("ops.aten.randint", core_ops.aten_randint, nondeterministic=True),
+    TorchLibOpInfo(
+        "ops.aten.randint.low", core_ops.aten_randint_low, nondeterministic=True
+    ),
+    TorchLibOpInfo(
+        "ops.aten.randint_like", core_ops.aten_randint_like, nondeterministic=True
+    ),
+    TorchLibOpInfo(
+        "ops.aten.randint_like.low_dtype",
+        core_ops.aten_randint_like_low_dtype,
+        nondeterministic=True,
+    ),
+    TorchLibOpInfo("ops.aten.randn", core_ops.aten_randn, nondeterministic=True).xfail(
+        dtypes=(torch.float16,),
+        reason="fixme: Shape inference error",
+    ),
+    TorchLibOpInfo(
+        "ops.aten.randn_like", core_ops.aten_randn_like, nondeterministic=True
+    ),
+    TorchLibOpInfo("rad2deg", core_ops.aten_rad2deg),
+    TorchLibOpInfo("reciprocal", core_ops.aten_reciprocal),
+    TorchLibOpInfo(
+        "remainder",
+        core_ops.aten_remainder,
+    ),
+    TorchLibOpInfo("repeat", core_ops.aten_repeat),
+    TorchLibOpInfo("reshape", core_ops.aten_reshape),
+    TorchLibOpInfo("resolve_conj", core_ops.aten_resolve_conj),
+    TorchLibOpInfo("resolve_neg", core_ops.aten_resolve_neg),
+    TorchLibOpInfo("round", core_ops.aten_round).skip(
+        matcher=lambda sample: sample.kwargs.get("decimals") is not None,
+        reason="this Aten overload only support one tensor as input and one int as args by design",
+    ),
+    TorchLibOpInfo("round_decimals", core_ops.aten_round_decimals),
+    TorchLibOpInfo("rsqrt", core_ops.aten_rsqrt),
+    TorchLibOpInfo(
+        "scalar_tensor",
+        core_ops.aten_scalar_tensor,
+        input_wrangler=_scalar_tensor_input_wrangler,
+    ),
+    TorchLibOpInfo(
+        "scalar_tensor",
+        core_ops.aten_scalar_tensor,
+        input_wrangler=_scalar_tensor_input_wrangler,
+        complex=True,
+    ),
+    TorchLibOpInfo(
+        "ops.aten.scalar_tensor",
+        core_ops.aten_scalar_tensor_complex,
+        complex=True,
+    ),
+    TorchLibOpInfo(
+        "scatter_add",
+        core_ops.aten_scatter_add,
+    )
+    .xfail(
+        matcher=lambda sample: len(sample.input.shape) == 0,
+        reason="fixme: Rank(0) input will lead ORT failed due to different rank(result) in if-else branch. https://github.com/onnx/onnx/issues/4986",
+    )
+    .xfail(
+        dtypes=(torch.float16,),
+        reason="fixme: ORT error: MLFloat16 data type is not supported with ScatterElements opset 16 when reduction is 'add'",
+    ),
+    TorchLibOpInfo("select", core_ops.aten_select),
+    TorchLibOpInfo("select_scatter", core_ops.aten_select_scatter),
+    TorchLibOpInfo("sigmoid", core_ops.aten_sigmoid),
+    TorchLibOpInfo("sign", core_ops.aten_sign),
+    TorchLibOpInfo("nn.functional.silu", nn_ops.aten_silu),
+    TorchLibOpInfo("sin", core_ops.aten_sin),
+    TorchLibOpInfo(
+        "sinc", special_ops.aten_special_sinc, tolerance={torch.float16: (1e-2, 6e-4)}
+    ),
+    TorchLibOpInfo("sinh", core_ops.aten_sinh),
+    TorchLibOpInfo(
+        "softmax",
+        core_ops.aten_softmax,
+        tolerance={torch.float32: (3.7e-5, 1.8e-4), torch.float16: (3e-4, 4e-4)},
+    )
+    .xfail(
+        dtypes=(torch.float16,),
+        reason="fixme: ORT failed. https://github.com/microsoft/onnxruntime/issues/16438",
+    )
+    .xfail(
+        variant_name="with_dtype",
+        dtypes=(torch.float16,),
+        reason="fixme: ORT failed. https://github.com/microsoft/onnxruntime/issues/16438",
+    )
+    .skip(
+        matcher=lambda sample: len(sample.input.shape) == 0,
+        reason="fixme: SoftMax does not support empty tensor as input",
+    )
+    .skip(
+        variant_name="with_dtype",
+        matcher=lambda sample: len(sample.input.shape) == 0,
+        reason="fixme: SoftMax does not support empty tensor as input",
+    ),
+    TorchLibOpInfo("nn.functional.softplus", nn_ops.aten_softplus),
+    TorchLibOpInfo("sort", core_ops.aten_sort).xfail(
+        dtypes=(torch.float16,),
+        reason="fixme: Tensor-likes are not close. Tests pass for float32.",
+    ),
+    TorchLibOpInfo(
+        "split_with_sizes",
+        core_ops.aten_split_with_sizes,
+    ).xfail(
+        dtypes=(torch.bool,),
+        reason="fixme: ORT does not implement SplitToSequence for bool inputs: https://github.com/microsoft/onnxruntime/issues/16905",
+    ),
+    TorchLibOpInfo(
+        "split",
+        core_ops.aten_split,
+    )
+    .xfail(
+        dtypes=(torch.bool,),
+        reason="fixme: ORT does not implement SplitToSequence for bool inputs: https://github.com/microsoft/onnxruntime/issues/16905",
+    )
+    .xfail(
+        variant_name="list_args",
+        dtypes=(torch.bool,),
+        reason="fixme: ORT does not implement SplitToSequence for bool inputs: https://github.com/microsoft/onnxruntime/issues/16905",
+    ),
+    TorchLibOpInfo("sqrt", core_ops.aten_sqrt),
+    TorchLibOpInfo(
+        "squeeze_dim",
+        core_ops.aten_squeeze_dim,
+    )
+    .skip(
+        matcher=lambda sample: not (
+            len(sample.args) > 0 and isinstance(sample.args[0], int)
+        ),
+        reason="this Aten overload only support one tensor as input and one int as args by design",
+    )
+    .skip(
+        matcher=lambda sample: len(sample.input.shape) != 0
+        and sample.input.shape[sample.args[0]] != 1,
+        reason="this Aten overload only support squeeze dim with size 1",
+    ),
+    TorchLibOpInfo(
+        "squeeze_dim",
+        core_ops.aten_squeeze_dim_complex,
+        complex=True,
+    )
+    .skip(
+        matcher=lambda sample: not (
+            len(sample.args) > 0 and isinstance(sample.args[0], int)
+        ),
+        reason="this Aten overload only support one tensor as input and one int as args by design",
+    )
+    .skip(
+        matcher=lambda sample: len(sample.input.shape) != 0
+        and sample.input.shape[sample.args[0]] != 1,
+        reason="this Aten overload only support squeeze dim with size 1",
+    ),
+    TorchLibOpInfo(
+        "squeeze",
+        core_ops.aten_squeeze,
+    ).skip(
+        matcher=lambda sample: len(sample.args) != 0,
+        reason="this Aten overload only support one tensor as input by design",
+    ),
+    TorchLibOpInfo("stack", core_ops.aten_stack),
+    TorchLibOpInfo("stack", core_ops.aten_stack_complex, complex=True),
+    TorchLibOpInfo("sub", core_ops.aten_sub, tolerance={torch.float16: (2e-3, 1e-3)}),
+    TorchLibOpInfo("sub", core_ops.aten_sub_complex, complex=True),
+    # TorchLibOpInfo("sym_size", core_ops.aten_sym_size),  # no test case in OPS_DB
+    TorchLibOpInfo("t", core_ops.aten_t),
+    TorchLibOpInfo("tan", core_ops.aten_tan),
+    TorchLibOpInfo("tanh", core_ops.aten_tanh),
+    TorchLibOpInfo(
+        "tile",
+        core_ops.aten_tile,
+    ).skip(
+        matcher=lambda sample: any(dim == 0 for dim in sample.input.shape)
+        or not sample.input.shape,
+        reason="fixme: Logic not implemented for size 0 inputs in op.Reshape",
+    ),
+    TorchLibOpInfo("topk", core_ops.aten_topk)
+    .xfail(
+        dtypes=(torch.int64, torch.int32),
+        enabled_if=not ops_test_common.IS_WINDOWS,
+        reason="fixme: result mismatch. https://github.com/microsoft/onnxscript/issues/853",
+    )
+    .skip(
+        dtypes=(torch.float16,),
+        reason="fixme: result mismatch. https://github.com/microsoft/onnxscript/issues/853",
+    )
+    .skip(
+        matcher=lambda sample: len(sample.input.shape) == 0
+        or sample.input.numel() == 0,
+        reason="scalar inputs or empty inputs are not handled",
+    ),
+    TorchLibOpInfo("tril", core_ops.aten_tril).xfail(
+        dtypes=(torch.int32, torch.bool),
+        reason="fixme: ORT 1.18 does not have an implementation of Trilu for int32, bool.",
+    ),
+    TorchLibOpInfo("triu", core_ops.aten_triu).xfail(
+        dtypes=(torch.int32, torch.bool),
+        reason="fixme: ORT 1.18 does not have an implementation of Trilu for int32, bool.",
+    ),
+    TorchLibOpInfo("trunc", core_ops.aten_trunc),
+    TorchLibOpInfo(
+        "unbind",
+        core_ops.aten_unbind,
+    ).xfail(
+        dtypes=(torch.bool,),
+        reason="fixme: ORT does not implement SplitToSequence for bool inputs: https://github.com/microsoft/onnxruntime/issues/16905",
+    ),
+    TorchLibOpInfo(
+        "unflatten",
+        core_ops.aten_unflatten,
+        input_wrangler=_unflatten_input_wrangler,
+    )
+    .xfail(
+        matcher=lambda sample: any(dim == 0 for dim in sample.input.shape),
+        reason="fixme: Logic not implemented for size 0 inputs in op.Reshape",
+    )
+    .xfail(
+        reason="fixme: https://github.com/pytorch/pytorch/issues/146336",
+    ),
+    TorchLibOpInfo("unfold", core_ops.aten_unfold),
+    TorchLibOpInfo("ops.aten.unfold", core_ops.aten_unfold),
+    TorchLibOpInfo("unsqueeze", core_ops.aten_unsqueeze),
+    TorchLibOpInfo("view", core_ops.aten_view),
+    TorchLibOpInfo("view", core_ops.aten_view_complex, complex=True),
+    TorchLibOpInfo("view_as", core_ops.aten_view_as),
+    TorchLibOpInfo("view_as_complex", core_ops.aten_view_as_complex),
+    TorchLibOpInfo("view_as_complex_copy", core_ops.aten_view_as_complex_copy),
+    TorchLibOpInfo("view_as_real", core_ops.aten_view_as_real, complex=True),
+    TorchLibOpInfo("view_as_real_copy", core_ops.aten_view_as_real_copy, complex=True),
+    TorchLibOpInfo("view_copy", core_ops.aten_view_copy),
+    TorchLibOpInfo(
+        "where", core_ops.aten_where, input_wrangler=_where_input_wrangler
+    ).xfail(
+        dtypes=(torch.bool,),
+        reason="fixme: ORT does not have an implementation for Where with bool inputs.",
+    ),
+    TorchLibOpInfo("xlogy", special_ops.aten_special_xlogy),
+    TorchLibOpInfo("zeros", core_ops.aten_zeros),
+    TorchLibOpInfo(
+        "arange_start_step",
+        core_ops.aten_arange_start_step,
+    )
+    .skip(
+        matcher=lambda sample: len(sample.args) != 2,
+        reason="arange_start_step overload takes three arguments (input, start, step)",
+    )
+    .skip(
+        matcher=lambda sample: sample.kwargs.get("dtype") is None,
+        reason="dtype needs to be specified for non-float tensors",
+        dtypes=(torch.float16, torch.int64, torch.int32),
+    ),
+    TorchLibOpInfo(
+        "arange_start",
+        core_ops.aten_arange_start,
+    )
+    .skip(
+        matcher=lambda sample: len(sample.args) != 1,
+        reason="arange_start overload takes two arguments (input, start)",
+    )
+    .skip(
+        matcher=lambda sample: sample.kwargs.get("dtype") is None,
+        reason="dtype needs to be specified for non-float tensors",
+        dtypes=(torch.float16, torch.int64, torch.int32),
+    ),
+    TorchLibOpInfo(
+        "arange",
+        core_ops.aten_arange,
+    )
+    .xfail(
+        dtypes=(torch.int32,),
+        reason="fixme: output shape mismatch in edge cases. https://github.com/microsoft/onnxscript/issues/974",
+    )
+    .skip(
+        matcher=lambda sample: len(sample.args) != 0,
+        reason="arange overload takes single argument",
+    )
+    .xfail(
+        matcher=lambda sample: sample.kwargs.get("end") is not None,
+        reason="arange overload does not support positional 'end' argument",
+    )
+    .skip(
+        matcher=lambda sample: sample.kwargs.get("dtype") is None,
+        reason="dtype needs to be specified for non-float tensors",
+        dtypes=(torch.float16, torch.int64, torch.int32),
+    ),
+    TorchLibOpInfo("argmax", core_ops.aten_argmax).xfail(
+        reason="ORT did not implement argmax for int64",
+        dtypes=(torch.int64,),
+    ),
+    TorchLibOpInfo("argmin", core_ops.aten_argmin).xfail(
+        reason="ORT did not implement argmax for int64",
+        dtypes=(torch.int64,),
+    ),
+    TorchLibOpInfo(
+        "as_strided",
+        core_ops.aten_as_strided,
+    ).xfail(
+        variant_name="partial_views",
+        reason="ONNX doesn't have partial view for tensor",
+    ),
+    TorchLibOpInfo("clamp", core_ops.aten_clamp),
+    TorchLibOpInfo(
+        "ops.aten.col2im",
+        nn_ops.aten_col2im,
+    ).xfail(
+        dtypes=(torch.float16,),
+        reason="fixme: Tensor-likes are not close. https://github.com/microsoft/onnxruntime/issues/16007",
+    ),
+    TorchLibOpInfo("cumsum", core_ops.aten_cumsum).xfail(
+        dtypes=(torch.int32,),
+        reason="fixme: torch.cumsum with int32 inputs uses int64 as the output type",
+    ),
+    TorchLibOpInfo("contiguous", core_ops.aten_contiguous),
+    TorchLibOpInfo(
+        "ops.aten.convolution",
+        core_ops.aten_convolution,
+        tolerance={torch.float32: (3.7e-5, 1.8e-4)},
+    ),
+    TorchLibOpInfo("empty_like", core_ops.aten_empty_like, nondeterministic=True),
+    TorchLibOpInfo(
+        "grid_sampler_2d",
+        core_ops.aten_grid_sampler_2d,
+    )
+    .skip(
+        # Torch implemented this using the cubic convolution algorithm with alhpa=-0.75, might be different than ORT
+        matcher=lambda sample: sample.args[1] == 2,
+        reason="fixme: 'bicubic' mode in ORT implemented differently with Torch",
+    )
+    .skip(
+        dtypes=(torch.float16,),
+        reason="fixme: Accuracy is not high enough",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.group_norm",
+        nn_ops.aten_group_norm,
+        tolerance={torch.float16: (1e-2, 7e-3)},
+    ).xfail(
+        matcher=lambda sample: any(dim == 0 for dim in sample.input.shape),
+        reason="Using op.InstanceNormalization to simulate GroupNorm, which does not support 0-dim input",
+    ),
+    TorchLibOpInfo(
+        "ops.aten.hamming_window",
+        core_ops.aten_hamming_window,
+        tolerance={torch.float32: (8e-2, 6e-3)},
+    ),
+    TorchLibOpInfo("ops.aten.hann_window", core_ops.aten_hann_window),
+    TorchLibOpInfo("heaviside", core_ops.aten_heaviside),
+    TorchLibOpInfo(
+        "nn.functional.grid_sample",
+        core_ops.aten_grid_sampler,
+        input_wrangler=_grid_sample_input_wrangler,
+        tolerance={torch.float16: (8e-2, 2e-3)},
+    ).skip(
+        # Torch implemented this using the cubic convolution algorithm with alhpa=-0.75, might be different than ORT
+        matcher=lambda sample: sample.kwargs.get("mode") == "bicubic"
+        or len(sample.args[0].shape) != 4,
+        reason="fixme: 'bicubic' mode in ORT implemented differently with Torch and only support 4D-tensor",
+    ),
+    TorchLibOpInfo(
+        "ops.aten.layer_norm",
+        core_ops.aten_layer_norm,
+        tolerance={torch.float32: (3.7e-5, 1.8e-4)},
+    ).xfail(
+        dtypes=(torch.int64,),
+        reason="fixme: ORT `LayerNormKernelImpl` not implemented for int64",
+    ),
+    TorchLibOpInfo(
+        "logit", core_ops.aten_logit, tolerance={torch.float16: (1e-1, 7e-4)}
+    ),
+    TorchLibOpInfo("max_dim", core_ops.aten_max_dim)
+    .xfail(
+        matcher=lambda sample: len(sample.args) == 0
+        or (len(sample.args) > 0 and not isinstance(sample.args[0], int)),
+        reason="this ATen overload only support one tensor as input and another int as args",
+    )
+    .xfail(
+        variant_name="reduction_with_dim",
+        dtypes=(torch.int64,),
+        reason="fixme: ORT 1.18 does not support int64",
+    ),
+    TorchLibOpInfo(
+        "max",
+        core_ops.aten_max,
+    ).skip(
+        matcher=lambda sample: len(sample.args) > 0,
+        reason="this ATen overload only supports one tensor as input by design",
+    ),
+    TorchLibOpInfo("multinomial", core_ops.aten_multinomial, nondeterministic=True),
+    TorchLibOpInfo(
+        # Custom from extra_opinfo
+        "ops.aten.max_pool1d",
+        nn_ops.aten_max_pool1d,
+    ),
+    TorchLibOpInfo(
+        # Custom from extra_opinfo
+        "ops.aten.max_pool2d",
+        nn_ops.aten_max_pool2d,
+    ),
+    TorchLibOpInfo(
+        "ops.aten.max_pool3d",  # Custom from extra_opinfo
+        nn_ops.aten_max_pool3d,
+    ).xfail(
+        variant_name="empty_strides",
+        reason="fixme: 'shape' do not match: torch.Size([2, 3, 4, 3]) != torch.Size([2, 3, 4, 2]). https://github.com/microsoft/onnxscript/issues/975",
+    ),
+    TorchLibOpInfo(
+        "native_batch_norm",
+        core_ops.aten_native_batch_norm,
+        tolerance={torch.float16: (1e-2, 7e-3)},
+    )
+    .skip(
+        device_type="cpu",
+        matcher=lambda sample: sample.args[-3] is False,
+        reason="native_batch_norm outputs different shapes on CPU and CUDA when training is False. Our implematation is based on that for CUDA",
+    )
+    .skip(
+        device_type="cpu",
+        dtypes=(torch.float16,),
+        reason="native_batch_norm outputs different dtypes on CPU and CUDA. Our implematation is based on that for CUDA",
+    )
+    .skip(
+        matcher=lambda sample: sample.kwargs.get("training") is True
+        or sample.args[-3] is True,
+        reason="fixme: ORT only supports BatchNorm less than opset14",
+    ),
+    TorchLibOpInfo(
+        "ops.aten._native_batch_norm_legit",
+        core_ops.aten_native_batch_norm,
+        tolerance={torch.float16: (1e-2, 7e-3)},
+    )
+    .skip(
+        device_type="cpu",
+        matcher=lambda sample: sample.kwargs.get("training") is False,
+        reason="native_batch_norm outputs different shapes on CPU and CUDA when training is False. Our implematation is based on that for CUDA",
+    )
+    .skip(
+        matcher=lambda sample: sample.kwargs.get("training") is True
+        or sample.args[-3] is True,
+        reason="fixme: ORT only supports BatchNorm less than opset14",
+    ),
+    TorchLibOpInfo(
+        "ops.aten._native_batch_norm_legit.no_stats",
+        core_ops.aten__native_batch_norm_no_stats,
+    ),
+    TorchLibOpInfo(
+        "ops.aten._native_batch_norm_legit_functional",
+        core_ops.aten__native_batch_norm_legit_functional,
+        tolerance={torch.float16: (1e-2, 7e-3)},
+    )
+    .skip(
+        device_type="cpu",
+        matcher=lambda sample: sample.kwargs.get("training") is False,
+        reason="native_batch_norm outputs different results on CPU and CUDA when training is False. Our implematation is based on that for CUDA",
+    )
+    .skip(
+        matcher=lambda sample: sample.kwargs.get("training") is True
+        or sample.args[-3] is True,
+        reason="fixme: ORT only supports BatchNorm less than opset14",
+    ),
+    TorchLibOpInfo(
+        "ops.aten.native_group_norm",
+        core_ops.aten_native_group_norm,
+        tolerance={torch.float16: (1e-2, 7e-3)},
+    ),
+    TorchLibOpInfo(
+        "native_layer_norm",
+        core_ops.aten_native_layer_norm,
+        tolerance={torch.float32: (3.7e-5, 1.8e-4), torch.float16: (1e-1, 7e-4)},
+    )
+    .xfail(
+        dtypes=(torch.float32,),
+        matcher=lambda sample: len(sample.input.shape) == 1,
+        enabled_if=ops_test_common.IS_MACOS,
+        reason="fixme: result mismatch. https://github.com/microsoft/onnxruntime/issues/20676",
+    )
+    .skip(
+        dtypes=(torch.float16,),
+        device_type="cpu",
+        reason="native_layer_norm outputs different dtypes on CPU and CUDA. Our implematation is based on that for CUDA",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.avg_pool1d",
+        nn_ops.aten_avg_pool1d,
+        input_wrangler=_avg_pool_input_wrangler,
+    )
+    .xfail(
+        matcher=lambda sample: (len(sample.args) > 5 and sample.args[5] is not None)
+        or (sample.kwargs.get("divisor_override") is not None),
+        reason="ONNX doesn't support divisor_override argument",
+    )
+    .xfail(
+        matcher=lambda sample: (sample.kwargs.get("ceil_mode") is True)
+        and (
+            sample.kwargs.get("count_include_pad") is True
+            or sample.input.shape[2]
+            % (
+                sample.args[0][0]
+                if isinstance(sample.args[0], tuple)
+                else sample.args[0]
+            )
+            != 0
+        ),
+        reason="fixme: ORT doesn't match PyTorch when ceil_mode=True until opset 19",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.avg_pool2d",
+        nn_ops.aten_avg_pool2d,
+        input_wrangler=_avg_pool_input_wrangler,
+    ).xfail(
+        matcher=lambda sample: (len(sample.args) > 5 and sample.args[5] is not None)
+        or (sample.kwargs.get("divisor_override") is not None),
+        reason="ONNX doesn't support divisor_override argument",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.avg_pool3d",
+        nn_ops.aten_avg_pool3d,
+        input_wrangler=_avg_pool_input_wrangler,
+    )
+    .xfail(
+        matcher=lambda sample: (len(sample.args) > 5 and sample.args[5] is not None)
+        or (sample.kwargs.get("divisor_override") is not None),
+        reason="ONNX doesn't support divisor_override argument",
+    )
+    .xfail(
+        matcher=lambda sample: sample.kwargs.get("ceil_mode") is True,
+        reason="fixme(after opset19): ORT doesn't match PyTorch when ceil_mode=True until opset 19",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.conv1d",
+        core_ops.aten_conv1d,
+    ).xfail(
+        matcher=lambda sample: isinstance(sample.kwargs.get("padding"), str),
+        reason="String padding is not accepted by aten::conv1d",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.conv2d",
+        core_ops.aten_conv2d,
+        tolerance={torch.float32: (2e-5, 3e-5)},
+    ).xfail(
+        matcher=lambda sample: isinstance(sample.kwargs.get("padding"), str),
+        reason="String padding is not accepted by aten::conv2d",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.instance_norm",
+        core_ops.aten_instance_norm,
+        tolerance={torch.float16: (1e-2, 1e-3)},
+    ),
+    TorchLibOpInfo(
+        "ops.aten.conv3d",
+        core_ops.aten_conv3d,
+        tolerance={torch.float32: (3.7e-5, 1.8e-4)},
+    ),
+    TorchLibOpInfo(
+        "nn.functional.gelu",
+        nn_ops.aten_gelu,
+        tolerance={torch.float16: (8e-2, 1e-4)},
+    ),
+    TorchLibOpInfo("nn.functional.glu", nn_ops.aten_glu),
+    TorchLibOpInfo(
+        "nn.functional.linear",
+        nn_ops.aten_linear,
+        tolerance={torch.float16: (1e-2, 1e-3)},
+    ),
+    TorchLibOpInfo(
+        "nn.functional.unfold",
+        nn_ops.aten_im2col,
+        input_wrangler=_im2col_input_wrangler,
+    ).xfail(
+        matcher=lambda sample: any(dim == 0 for dim in sample.input.shape)
+        or not sample.input.shape,
+        reason="fixme: Logic not implemented for size 0 inputs in op.Reshape",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.max_pool1d",
+        nn_ops.aten_max_pool1d,
+        input_wrangler=_max_pool_input_wrangler,
+    ).skip(
+        matcher=lambda sample: sample.kwargs.get("return_indices") is True,
+        reason="this aten overload assume return_indices=False",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.max_pool1d_with_indices",
+        nn_ops.aten_max_pool1d_with_indices,
+        input_wrangler=_max_pool_input_wrangler,
+    ).skip(
+        matcher=lambda sample: sample.kwargs.get("return_indices") is False,
+        reason="this aten overload assume return_indices=True",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.max_pool2d",
+        nn_ops.aten_max_pool2d,
+        input_wrangler=_max_pool_input_wrangler,
+    ).skip(
+        matcher=lambda sample: sample.kwargs.get("return_indices") is True,
+        reason="this aten overload assume return_indices=False",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.max_pool2d_with_indices",
+        nn_ops.aten_max_pool2d_with_indices,
+        input_wrangler=_max_pool_input_wrangler,
+    ).skip(
+        matcher=lambda sample: sample.kwargs.get("return_indices") is False,
+        reason="this aten overload assume return_indices=True",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.max_pool3d",
+        nn_ops.aten_max_pool3d,
+        input_wrangler=_max_pool_input_wrangler,
+    )
+    .skip(
+        matcher=lambda sample: sample.kwargs.get("ceil_mode") is True
+        and sample.kwargs.get("padding") == 1,
+        reason="FIXME: After https://github.com/microsoft/onnxruntime/issues/15446 is fixed",
+    )
+    .skip(
+        matcher=lambda sample: sample.kwargs.get("return_indices") is True,
+        reason="this aten overload assume return_indices=False",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.max_pool3d_with_indices",
+        nn_ops.aten_max_pool3d_with_indices,
+        input_wrangler=_max_pool_input_wrangler,
+    )
+    .skip(
+        matcher=lambda sample: sample.kwargs.get("ceil_mode") is True
+        and sample.kwargs.get("padding") == 1,
+        reason="FIXME: After https://github.com/microsoft/onnxruntime/issues/15446 is fixed",
+    )
+    .skip(
+        matcher=lambda sample: sample.kwargs.get("return_indices") is False,
+        reason="this aten overload assume return_indices=True",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.scaled_dot_product_attention",
+        nn_ops.aten_scaled_dot_product_attention,
+        tolerance={torch.float32: (3e-4, 1.5e-5)},
+    )
+    .skip(
+        matcher=lambda sample: (attn_mask := sample.kwargs.get("attn_mask")) is not None
+        and attn_mask.dtype == torch.bool,
+        reason="this overload takes a non-boolean mask",
+    )
+    .skip(
+        matcher=lambda sample: sample.kwargs.get("dropout_p") != 0.0,
+        reason="dropout is random so the results do not match",
+    )
+    .xfail(
+        dtypes=(torch.float16,),
+        reason="fixme: ORT failed. https://github.com/microsoft/onnxruntime/issues/16438",
+    ),
+    TorchLibOpInfo(
+        "ops.aten._scaled_dot_product_flash_attention",
+        nn_ops.aten__scaled_dot_product_flash_attention,
+        tolerance={torch.float32: (3e-4, 1.5e-5)},
+        # Output[0] is OK, but other outputs just have the same shape with zero values
+        nondeterministic=True,
+        compare_shape_only_for_output=(1, 2, 3, 4, 5, 6, 7, 8),
+    ).skip(
+        device_type="cpu",
+        reason="_scaled_dot_product_flash_attention only supports CUDA",
+    ),
+    TorchLibOpInfo(
+        "ops.aten._scaled_dot_product_efficient_attention",
+        nn_ops.aten__scaled_dot_product_efficient_attention,
+        tolerance={torch.float32: (3e-4, 1.5e-5)},
+        # Output[0] is OK, but other outputs just have the same shape with zero values
+        nondeterministic=True,
+        compare_shape_only_for_output=(1, 2, 3),
+    ).skip(
+        enabled_if=not torch.cuda.is_available(),
+        reason="_scaled_dot_product_efficient_attention only supports CUDA",
+    ),
+    TorchLibOpInfo(
+        "nn.functional.scaled_dot_product_attention_bool_mask",
+        nn_ops.aten_scaled_dot_product_attention_bool_mask,
+        tolerance={torch.float32: (3e-4, 1.5e-5)},
+    )
+    .skip(
+        matcher=lambda sample: (attn_mask := sample.kwargs.get("attn_mask")) is not None
+        and attn_mask.dtype != torch.bool,
+        reason="this overload takes a boolean mask",
+    )
+    .skip(
+        matcher=lambda sample: sample.kwargs.get("dropout_p") != 0.0,
+        reason="dropout is random so the results do not match",
+    )
+    .xfail(
+        dtypes=(torch.float16,),
+        reason="fixme: ORT failed. https://github.com/microsoft/onnxruntime/issues/16438",
+    ),
+    TorchLibOpInfo(
+        "ops.aten.upsample_bilinear2d.default",
+        nn_ops.aten_upsample_bilinear2d,
+    ).xfail(
+        matcher=lambda sample: sample.args[1] is False
+        and sample.kwargs.get("scales_h") is not None,
+        reason="fixme: align_corners=False output mismatch when scales are provided",
+    ),
+    TorchLibOpInfo(
+        "ops.aten.upsample_bilinear2d.vec",
+        nn_ops.aten_upsample_bilinear2d_vec,
+    ),
+    TorchLibOpInfo(
+        "ops.aten.upsample_bicubic2d.default",
+        nn_ops.aten_upsample_bicubic2d,
+    ).xfail(
+        matcher=lambda sample: sample.args[1] is False
+        and sample.kwargs.get("scales_h") is not None,
+        reason="fixme: align_corners=False output mismatch when scales are provided",
+    ),
+    TorchLibOpInfo(
+        "ops.aten.upsample_bicubic2d.vec",
+        nn_ops.aten_upsample_bicubic2d_vec,
+    ),
+    TorchLibOpInfo(
+        "ops.aten.upsample_linear1d",
+        nn_ops.aten_upsample_linear1d,
+    ).xfail(
+        matcher=lambda sample: sample.args[1] is False
+        and sample.kwargs.get("scales") is not None,
+        reason="fixme: align_corners=False output mismatch when scales are provided",
+    ),
+    TorchLibOpInfo(
+        "ops.aten.upsample_nearest1d",
+        nn_ops.aten_upsample_nearest1d,
+    ),
+    TorchLibOpInfo(
+        "ops.aten.upsample_nearest1d.vec",
+        nn_ops.aten_upsample_nearestnd_vec,
+    ),
+    TorchLibOpInfo(
+        "ops.aten.upsample_nearest2d",
+        nn_ops.aten_upsample_nearest2d,
+    ),
+    TorchLibOpInfo(
+        "ops.aten.upsample_nearest2d.vec",
+        nn_ops.aten_upsample_nearestnd_vec,
+    ),
+    TorchLibOpInfo(
+        "ops.aten.upsample_nearest3d",
+        nn_ops.aten_upsample_nearest3d,
+    ),
+    TorchLibOpInfo(
+        "ops.aten.upsample_nearest3d.vec",
+        nn_ops.aten_upsample_nearestnd_vec,
+    ),
+    TorchLibOpInfo(
+        "ops.aten.upsample_trilinear3d.default",
+        nn_ops.aten_upsample_trilinear3d,
+    ),
+    TorchLibOpInfo(
+        "ops.aten.upsample_trilinear3d.vec",
+        nn_ops.aten_upsample_trilinear3d_vec,
+    ),
+    TorchLibOpInfo("ones_like", core_ops.aten_ones_like),
+    TorchLibOpInfo(
+        "roll",
+        core_ops.aten_roll,
+        input_wrangler=_roll_input_wrangler,
+    ),
+    TorchLibOpInfo(
+        "roll",
+        core_ops.aten_roll_complex,
+        input_wrangler=_roll_input_wrangler,
+        complex=True,
+    ),
+    TorchLibOpInfo(
+        "scatter_reduce",
+        core_ops.aten_scatter_reduce,
+        input_wrangler=_scatter_reduce_input_wrangler,
+    )
+    .xfail(
+        variant_name="mean",
+        reason="ONNX doesn't support reduce='mean' option",
+    )
+    .skip(
+        # ONNX has not include_self parameter and default is include_self=True mode
+        matcher=lambda sample: sample.kwargs.get("include_self") is False,
+        reason="ONNX does't support include_self=False option",
+    )
+    .xfail(
+        variant_name="amax",
+        reason="fixme: MLFloat16 data type is not supported with ScatterElements opset 18 when reduction is 'max'",
+    )
+    .xfail(
+        variant_name="amin",
+        reason="fixme: MLFloat16 data type is not supported with ScatterElements opset 18 when reduction is 'min'",
+    )
+    .xfail(
+        variant_name="prod",
+        reason="fixme: MLFloat16 data type is not supported with ScatterElements opset 18 when reduction is 'prod'",
+    )
+    .xfail(
+        variant_name="sum",
+        reason="fixme: MLFloat16 data type is not supported with ScatterElements opset 18 when reduction is 'add'",
+    ),
+    TorchLibOpInfo("ops.aten.slice_scatter", core_ops.aten_slice_scatter),
+    TorchLibOpInfo("slice", core_ops.aten_slice),
+    TorchLibOpInfo(
+        "sum",
+        core_ops.aten_sum_dim_IntList,
+        input_wrangler=_sum_input_wrangler,
+    ).xfail(
+        dtypes=(torch.int32,),
+        reason="fixme: torch.sum uses int64 as the accumulator for int32 inputs",
+    ),
+    TorchLibOpInfo(
+        "ops.aten.tensor.bool", core_ops.aten_tensor_bool
+    ),  # Custom from extra_opinfo
+    TorchLibOpInfo(
+        "ops.aten.tensor.float",
+        core_ops.aten_tensor_float,  # Custom from extra_opinfo
+    ),
+    TorchLibOpInfo(
+        "ops.aten.tensor.int", core_ops.aten_tensor_int
+    ),  # Custom from extra_opinfo
+    TorchLibOpInfo("transpose", core_ops.aten_transpose),
+    TorchLibOpInfo("transpose", core_ops.aten_transpose_complex, complex=True),
+    TorchLibOpInfo(
+        "ops.prims.var.default",
+        prims_ops.prims_var,
+        tolerance={torch.float16: (1e-3, 5e-2)},
+    ),
+    TorchLibOpInfo("zeros_like", core_ops.aten_zeros_like),
 )
 
 ops_test_common.duplicate_opinfo(OPS_DB, "all", ("all_dim", "all_dims"))

--- a/torch/onnx/_internal/exporter/_ir_passes.py
+++ b/torch/onnx/_internal/exporter/_ir_passes.py
@@ -65,6 +65,7 @@ def rename_axis(model: ir.Model, rename_mapping: dict[str, str]) -> None:
     sorted_rename_mapping = dict(
         sorted(rename_mapping.items(), key=lambda item: len(item[0]), reverse=True)
     )
+
     for value in _all_values(model):
         if value.shape is None:
             continue
@@ -92,20 +93,10 @@ def rename_axis(model: ir.Model, rename_mapping: dict[str, str]) -> None:
 
 def add_torchlib_common_imports(model: ir.Model) -> None:
     """Hack to add torchlib common imports to the model."""
+    from torch.onnx._internal.exporter._torchlib.ops import common as common_ops
 
-    try:
-        # TODO(justinchuby): Remove this hack and improved onnxscript
-        from onnxscript.function_libs.torch_lib.ops import common as common_ops
-
-        model.opset_imports["pkg.onnxscript.torch_lib.common"] = 1
-        rank_func = ir.serde.deserialize_function(common_ops.Rank.to_function_proto())
-        is_scalar_func = ir.serde.deserialize_function(
-            common_ops.IsScalar.to_function_proto()
-        )
-        model.functions[rank_func.identifier()] = rank_func
-        model.functions[is_scalar_func.identifier()] = is_scalar_func
-    except Exception:
-        logger.exception("Failed to add torchlib common imports to the model.")
+    rank_func = ir.serde.deserialize_function(common_ops.Rank.to_function_proto())
+    model.functions[rank_func.identifier()] = rank_func
 
 
 def _maybe_set_opset_version(

--- a/torch/onnx/_internal/exporter/_torchlib/ops/__init__.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/__init__.py
@@ -1,6 +1,24 @@
 from __future__ import annotations
 
 
-__all__ = ["core", "hop"]
+__all__ = [
+    "common",
+    "core",
+    "fft",
+    "hop",
+    "linalg",
+    "nn",
+    "prims",
+    "special",
+]
 
-from torch.onnx._internal.exporter._torchlib.ops import core, hop
+from torch.onnx._internal.exporter._torchlib.ops import (
+    common,
+    core,
+    fft,
+    hop,
+    linalg,
+    nn,
+    prims,
+    special,
+)

--- a/torch/onnx/_internal/exporter/_torchlib/ops/common.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/common.py
@@ -1,0 +1,72 @@
+"""Common operators shared in the torchlib library."""
+
+# mypy: disable-error-code="misc,arg-type,type-arg,valid-type,assignment,return-value,type-var,operator,no-untyped-def,index"
+# ruff: noqa: TCH001,TCH002
+# flake8: noqa
+from __future__ import annotations
+
+import numpy.typing as npt
+
+import onnx
+import onnxscript
+import onnxscript.values
+from onnxscript import INT64, ir, opset18 as op
+from onnxscript.onnx_types import COMPLEX128, COMPLEX64, DOUBLE, FLOAT, TensorType
+
+from torch.onnx._internal.exporter import _constants
+from torch.onnx._internal.exporter._torchlib._tensor_typing import RealType, TTensor
+
+
+COMPLEX64_TYPE = COMPLEX64.dtype
+COMPLEX128_TYPE = COMPLEX128.dtype
+
+torch_opset = onnxscript.values.Opset(domain=_constants.TORCHLIB_DOMAIN, version=1)
+
+
+@onnxscript.script(torch_opset)
+def Rank(input: TTensor) -> INT64:
+    """Take the rank of the input tensor."""
+
+    return op.Size(op.Shape(input))
+
+
+def cast_to(a: RealType, dtype: int) -> RealType:
+    """Cast input to dtype while handling complex types."""
+
+    # Traced function because different if branches return different dtypes
+    # which is not supported in an ONNX function
+    if dtype == COMPLEX128_TYPE:
+        # Cast to the real representation of the complex type
+        casted = op.Cast(a, to=DOUBLE.dtype)
+        # Create a complex number
+        real_part = op.Unsqueeze(casted, axes=[-1])
+        imag_part = op.Expand(op.Cast(0.0, to=DOUBLE.dtype), op.Shape(real_part))
+        result = op.Concat(real_part, imag_part, axis=-1)
+    elif dtype == COMPLEX64_TYPE:
+        # Cast to the real representation of the complex type
+        casted = op.Cast(a, to=FLOAT.dtype)
+        # Create a complex number
+        real_part = op.Unsqueeze(casted, axes=[-1])
+        imag_part = op.Expand(0.0, op.Shape(real_part))
+        result = op.Concat(real_part, imag_part, axis=-1)
+    else:
+        # Cast to real numbers
+        result = op.Cast(a, to=dtype)
+
+    return result
+
+
+def constant(
+    array: npt.ArrayLike | onnx.TensorProto | ir.DLPackCompatible | ir.ArrayCompatible,
+    dtype: int | onnx.TensorProto.DataType | ir.DataType,
+) -> TensorType:
+    """Utility for creating a constant tensor.
+
+    Args:
+        array: The array to convert to a constant tensor.
+        dtype: The data type of the tensor.
+
+    Returns:
+        A constant node.
+    """
+    return op.Constant(value=ir.tensor(array, dtype=ir.DataType(dtype)))

--- a/torch/onnx/_internal/exporter/_torchlib/ops/core.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/core.py
@@ -5,16 +5,131 @@
 
 from __future__ import annotations
 
+import math
 import operator
+from typing import Any, Optional, Sequence, Tuple, Union
 
+from onnxscript import (
+    BFLOAT16,
+    BOOL,
+    COMPLEX128,
+    COMPLEX64,
+    DOUBLE,
+    FLOAT,
+    FLOAT16,
+    graph,
+    INT16,
+    INT32,
+    INT64,
+    INT8,
+    UINT16,
+    UINT32,
+    UINT64,
+    UINT8,
+)
 from onnxscript.onnx_opset import opset18 as op
+from onnxscript.onnx_types import TensorType
 
 import torch
-from torch.onnx._internal.exporter._torchlib._tensor_typing import TReal, TRealOrUInt8
+from torch.onnx._internal.exporter._torchlib._tensor_typing import (
+    IntType,
+    RealType,
+    TFloat,
+    TFloatHighPrecision,
+    TInt,
+    TReal,
+    TRealOrUInt8,
+    TRealUnlessFloat16OrInt8,
+    TRealUnlessInt16OrInt8,
+    TTensor,
+    TTensor2,
+    TTensorOrString,
+)
 from torch.onnx._internal.exporter._torchlib._torchlib_registry import onnx_impl
+from torch.onnx._internal.exporter._torchlib.ops import common as common_ops
 
+
+_INT64_MAX = 9223372036854775807
+_INT64_MIN = -9223372036854775808
+_MATH_PI = math.pi
+Rank = common_ops.Rank
 
 aten = torch.ops.aten
+
+
+@onnx_impl(aten._local_scalar_dense.default)
+def aten__local_scalar_dense(self: Union[FLOAT16, FLOAT, DOUBLE, BFLOAT16]) -> FLOAT:
+    """_local_scalar_dense(Tensor self) -> Scalar"""
+
+    # Return the first element in tensor as a scalar.
+    return op.Cast(op.Gather(op.Reshape(self, [-1]), 0), to=FLOAT.dtype)
+
+
+@onnx_impl(aten._local_scalar_dense.default)
+def aten__local_scalar_dense_int(self: IntType) -> INT64:
+    """_local_scalar_dense(Tensor self) -> Scalar"""
+
+    # Return the first element in tensor as a scalar.
+    return op.Cast(op.Gather(op.Reshape(self, [-1]), 0), to=INT64.dtype)
+
+
+@onnx_impl(aten._log_softmax.default, trace_only=True)
+def aten__log_softmax_half(
+    self: Union[FLOAT16, BFLOAT16], dim: int, half_to_float: bool
+) -> FLOAT:
+    """_log_softmax(Tensor self, int dim, bool half_to_float) -> Tensor"""
+
+    self_is_scalar = len(self.shape) == 0
+    if half_to_float:
+        self = op.Cast(self, to=FLOAT.dtype)
+    if self_is_scalar:
+        self = op.Unsqueeze(self, op.Constant(value_ints=[0]))
+    result = op.LogSoftmax(self, axis=dim)
+    if self_is_scalar:
+        result = op.Squeeze(result, op.Constant(value_ints=[0]))
+    return result
+
+
+@onnx_impl(aten._log_softmax.default, trace_only=True)
+def aten__log_softmax(
+    self: TFloatHighPrecision,
+    dim: int,
+    half_to_float: bool,
+) -> TFloatHighPrecision:
+    """_log_softmax(Tensor self, int dim, bool half_to_float) -> Tensor"""
+
+    self_is_scalar = len(self.shape) == 0
+    if self_is_scalar:
+        self = op.Unsqueeze(self, op.Constant(value_ints=[0]))
+    result = op.LogSoftmax(self, axis=dim)
+    if self_is_scalar:
+        result = op.Squeeze(result)
+    return result
+
+
+@onnx_impl(aten._softmax.default, trace_only=True)
+def aten__softmax_half(
+    self: Union[FLOAT16, BFLOAT16], dim: int, half_to_float: bool
+) -> FLOAT:
+    """_softmax(Tensor self, int dim, bool half_to_float) -> Tensor"""
+
+    # trace_only because we need to cast conditionally based on half_to_float
+    if half_to_float:
+        self = op.Cast(self, to=FLOAT.dtype)
+
+    return aten_softmax_no_dtype(self, dim)
+
+
+@onnx_impl(aten._softmax.default, trace_only=True)
+def aten__softmax(
+    self: TFloatHighPrecision, dim: int, half_to_float: bool
+) -> TFloatHighPrecision:
+    """_softmax(Tensor self, int dim, bool half_to_float) -> Tensor"""
+
+    # trace_only to reuse aten_softmax_no_dtype
+
+    del half_to_float  # Unused
+    return aten_softmax_no_dtype(self, dim)
 
 
 @onnx_impl((aten.abs.default, operator.abs), trace_only=True)
@@ -31,9 +146,24 @@ def aten_abs_complex(self: TRealOrUInt8) -> TRealOrUInt8:
     return op.ReduceL2(self, [-1], keepdims=False)
 
 
+@onnx_impl(aten.acos.default, trace_only=True)
+def aten_acos(self: TFloat) -> TFloat:
+    """acos(Tensor self) -> Tensor"""
+
+    return op.Acos(self)
+
+
+@onnx_impl(aten.acosh.default, trace_only=True)
+def aten_acosh(self: TFloat) -> TFloat:
+    """acosh(Tensor self) -> Tensor"""
+
+    return op.Acosh(self)
+
+
 @onnx_impl((aten.add.Tensor, aten.add.Scalar, operator.add), trace_only=True)
 def aten_add(self: TReal, other: TReal, alpha: float = 1.0) -> TReal:
     """add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"""
+    # TODO(microsoft/onnxruntime#15977): Improve fp16 precision
     if alpha != 1.0:
         alpha = op.CastLike(alpha, other)
         other = op.Mul(other, alpha)
@@ -45,3 +175,8869 @@ def aten_add_complex(self: TReal, other: TReal, alpha: float = 1.0) -> TReal:
     """add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"""
 
     return aten_add(self, other, alpha=alpha)
+
+
+@onnx_impl(aten.addbmm.default)
+def aten_addbmm(
+    self: TReal,
+    batch1: TReal,
+    batch2: TReal,
+    beta: float = 1.0,
+    alpha: float = 1.0,
+) -> TReal:
+    """addbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+
+    Performs a batch matrix-matrix product of matrices stored in `batch1` and `batch2`,
+    with a reduced add step (all matrix multiplications get accumulated along the first
+    dimension). `self` is added to the final result.
+
+    `batch1` and `batch2` must be 3-D tensors each containing the same number of matrices.
+    """
+
+    scaled_self = op.Mul(self, beta)
+    axes = op.Constant(value_ints=[0])
+    reduced_batches = op.ReduceSum(op.MatMul(batch1, batch2), axes, keepdims=False)
+
+    return op.Add(scaled_self, op.Mul(reduced_batches, alpha))
+
+
+@onnx_impl(aten.addcdiv.default)
+def aten_addcdiv(
+    self: TFloat, tensor1: TFloat, tensor2: TFloat, value: float = 1.0
+) -> TFloat:
+    """addcdiv(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
+
+    Performs the element-wise division of tensor1 by tensor2, multiplies the result
+    by the scalar value and adds it to self.
+    """
+
+    return op.Add(self, op.Mul(op.Div(tensor1, tensor2), value))
+
+
+@onnx_impl(aten.addcmul.default)
+def aten_addcmul(
+    self: TReal,
+    tensor1: TReal,
+    tensor2: TReal,
+    value: float = 1.0,
+) -> TReal:
+    """addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
+
+    Performs the element-wise multiplication of tensor1 by tensor2, multiplies the
+    result by the scalar value and adds it to self.
+    """
+
+    # Follow the order in https://github.com/pytorch/pytorch/blob/29e3fddb082b5a14262a7246bc62381a55199d45/aten/src/ATen/native/cpu/PointwiseOpsKernel.cpp#L47
+    # TODO(#811): Understand fp16 accuracy issue
+    return op.Add(self, op.Mul(op.Mul(value, tensor1), tensor2))
+
+
+@onnx_impl(aten.addmm.default, trace_only=True)
+def aten_addmm(
+    self: TReal, mat1: TReal, mat2: TReal, beta: float = 1.0, alpha: float = 1.0
+) -> TReal:
+    """addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor"""
+
+    # NOTE: ONNX Runtime does not support int inputs to Gemm as of 1.16.
+    # To support int inputs, consider an overriding implementation that casts to float and back.
+
+    alpha = float(alpha)
+    beta = float(beta)
+
+    # addmm only accepts 2d tensors: https://pytorch.org/docs/stable/generated/torch.addmm.html
+    return op.Gemm(mat1, mat2, self, alpha=alpha, beta=beta)
+
+
+@onnx_impl(aten.addmv.default)
+def aten_addmv(
+    self: TReal, mat: TReal, vec: TReal, beta: float = 1.0, alpha: float = 1.0
+) -> TReal:
+    """addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor"""
+
+    return op.Add(op.Mul(self, beta), op.Mul(op.MatMul(mat, vec), alpha))
+
+
+@onnx_impl(aten.addr.default, trace_only=True)
+def aten_addr(
+    self: TReal, vec1: TReal, vec2: TReal, beta: float = 1.0, alpha: float = 1.0
+) -> TReal:
+    """addr(Tensor self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+
+    Performs the outer-product of vectors vec1 and vec2 and adds it to the matrix input.
+    """
+    vec1_shape = op.Constant(value_ints=[-1, 1])
+    vec2_shape = op.Constant(value_ints=[1, -1])
+    vec1_reshaped = op.Reshape(vec1, vec1_shape)
+    vec2_reshaped = op.Reshape(vec2, vec2_shape)
+
+    outer = op.MatMul(vec1_reshaped, vec2_reshaped)
+    # https://github.com/pytorch/pytorch/blob/51664489ba6f6b2343bbec9af9ca99185e2a5dbc/aten/src/ATen/native/cpu/LinearAlgebraKernel.cpp#L53-L54
+    # When beta == 0, values in self should be ignored,
+    # nans and infs in self should not propagate.
+    alpha = op.CastLike(alpha, outer)
+    if beta == 0.0:
+        result = op.Mul(alpha, outer)
+    else:
+        beta = op.CastLike(beta, outer)
+        result = op.Add(op.Mul(beta, self), op.Mul(alpha, outer))
+
+    return result
+
+
+def aten_adjoint(self: TensorType) -> TensorType:
+    """adjoint(Tensor(a) self) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def aten_affine_grid_generator(
+    theta: TensorType, size: Sequence[int], align_corners: bool
+) -> TensorType:
+    """affine_grid_generator(Tensor theta, int[] size, bool align_corners) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_affine_grid_generator_backward(
+    grad: TensorType, size: Sequence[int], align_corners: bool
+) -> TensorType:
+    """affine_grid_generator_backward(Tensor grad, int[] size, bool align_corners) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.alias.default, trace_only=True)
+def aten_alias(self: TTensor) -> TTensor:
+    """alias(Tensor(a) self) -> Tensor(a)"""
+
+    return op.Identity(self)
+
+
+def aten_alias_copy(self: TensorType) -> TensorType:
+    """alias_copy(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_align_as(self: TensorType, other: TensorType) -> TensorType:
+    """align_as(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_align_tensors(tensors: Sequence[TensorType]) -> TensorType:
+    """align_tensors(Tensor[] tensors) -> Tensor[]"""
+
+    raise NotImplementedError
+
+
+def aten_align_to(self: TensorType, names: Sequence[str]) -> TensorType:
+    """align_to(Tensor(a) self, Dimname[] names) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.all.default, trace_only=True)
+def aten_all(self: TTensor) -> BOOL:
+    """all(Tensor self) -> Tensor"""
+
+    if len(self.shape) == 0:
+        result = op.Cast(self, to=BOOL.dtype)
+    else:
+        self_bool = op.Cast(self, to=BOOL.dtype)
+        self_int = op.Cast(self_bool, to=INT64.dtype)
+        all_true = op.ReduceMin(self_int, keepdims=False)
+        result = op.Cast(all_true, to=BOOL.dtype)
+    return result
+
+
+@onnx_impl(aten.all.dim, trace_only=True)
+def aten_all_dim(self: TTensor, dim: int, keepdim: bool = False) -> BOOL:
+    """all.dim(Tensor self, int dim, bool keepdim=False) -> Tensor"""
+
+    self_bool = op.Cast(self, to=BOOL.dtype)
+    self_int = op.Cast(self_bool, to=INT64.dtype)
+    dims = op.Reshape(dim, op.Constant(value_ints=[-1]))
+    all_true = op.ReduceMin(self_int, dims, keepdims=keepdim)
+    return op.Cast(all_true, to=BOOL.dtype)
+
+
+@onnx_impl(aten.all.dims, trace_only=True)
+def aten_all_dims(
+    self: TTensor, dim: Sequence[int] = (), keepdim: bool = False
+) -> BOOL:
+    """all.dims(Tensor self, int[]? dim=None, bool keepdim=False) -> Tensor"""
+
+    if not dim:
+        return _aten_all_dims_no_dim(self, keepdim)
+    for d in dim:
+        self = aten_all_dim(self, d, keepdim=True)
+    if not keepdim:
+        self = op.Squeeze(self, list(dim))
+    return self
+
+
+def _aten_all_dims_no_dim(self: TTensor, keepdims: bool) -> BOOL:
+    if len(self.shape) == 0:
+        result = op.Cast(self, to=BOOL.dtype)
+    else:
+        self_bool = op.Cast(self, to=BOOL.dtype)
+        self_int = op.Cast(self_bool, to=INT64.dtype)
+        all_true = op.ReduceMin(self_int, keepdims=keepdims)
+        result = op.Cast(all_true, to=BOOL.dtype)
+    return result
+
+
+@onnx_impl(aten.allclose.default)
+def aten_allclose(
+    self: TReal,
+    other: TReal,
+    rtol: float = 1e-05,
+    atol: float = 1e-08,
+    equal_nan: bool = False,
+) -> BOOL:
+    """allclose(Tensor self, Tensor other, float rtol=1e-05, float atol=1e-08, bool equal_nan=False) -> bool"""
+
+    # FIXME: check equal_nan when self and other are all NaN
+    # |input - other| <= atol + rtol x |other|
+    left_part = op.Abs(op.Sub(self, other))
+    right_part = op.Add(atol, op.Mul(rtol, op.Abs(other)))
+    is_close = op.LessOrEqual(left_part, right_part)
+    is_close_int = op.Cast(is_close, to=INT8.dtype)
+
+    # If min is 0, some elements are not close -> allclose is False
+    # If min is 1, all elements are close -> allclose is True
+    return op.Cast(op.ReduceMin(is_close_int, keepdims=False), to=BOOL.dtype)
+
+
+def aten_alpha_dropout(input: TensorType, p: float, train: bool) -> TensorType:
+    """alpha_dropout(Tensor input, float p, bool train) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.amax.default)
+def aten_amax(self: TRealOrUInt8, dim: INT64, keepdim: bool = False) -> TRealOrUInt8:
+    """amax(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor"""
+
+    # ReduceMax reduces all dimensions when dim is empty
+    return op.ReduceMax(self, dim, keepdims=keepdim)
+
+
+@onnx_impl(aten.amin.default)
+def aten_amin(self: TRealOrUInt8, dim: INT64, keepdim: bool = False) -> TRealOrUInt8:
+    """amin(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor"""
+
+    # ReduceMin reduces all dimensions when dim is empty
+    return op.ReduceMin(self, dim, keepdims=keepdim)
+
+
+def aten_aminmax(
+    self: TensorType, dim: Optional[int] = None, keepdim: bool = False
+) -> tuple[TensorType, TensorType]:
+    """aminmax(Tensor self, *, int? dim=None, bool keepdim=False) -> (Tensor min, Tensor max)"""
+
+    raise NotImplementedError
+
+
+def aten_and(self: TensorType, other: TensorType) -> TensorType:
+    """__and__.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_angle(self: TensorType) -> TensorType:
+    """angle(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.any.default, trace_only=True)
+def aten_any(self: TTensor) -> BOOL:
+    """any(Tensor self) -> Tensor"""
+
+    if len(self.shape) == 0:
+        result = op.Cast(self, to=BOOL.dtype)
+    else:
+        self_bool = op.Cast(self, to=BOOL.dtype)
+        # op.ReduceMax() in the next step cannot process BOOL inputs, so convert to INT64
+        self_int = op.Cast(self_bool, to=INT64.dtype)
+        any_true = op.ReduceMax(self_int, keepdims=False)
+        result = op.Cast(any_true, to=BOOL.dtype)
+    return result
+
+
+@onnx_impl(aten.any.dim, trace_only=True)
+def aten_any_dim(self: TTensor, dim: int, keepdim: bool = False) -> BOOL:
+    """any.dim(Tensor self, int dim, bool keepdim=False) -> Tensor"""
+
+    self_bool = op.Cast(self, to=BOOL.dtype)
+    # op.ReduceMax() in the next step cannot process BOOL inputs, so convert to INT64
+    self_int = op.Cast(self_bool, to=INT64.dtype)
+    # Change dim from int to INT64[1]
+    dims = op.Reshape(dim, op.Constant(value_ints=[-1]))
+    any_true = op.ReduceMax(self_int, dims, keepdims=keepdim)
+    return op.Cast(any_true, to=BOOL.dtype)
+
+
+@onnx_impl(aten.any.dims, trace_only=True)
+def aten_any_dims(
+    self: TTensor, dim: Sequence[int] = (), keepdim: bool = False
+) -> BOOL:
+    """any.dims(Tensor self, int[1]? dim=None, bool keepdim=False) -> Tensor"""
+
+    if not dim:
+        return _aten_any_dims_no_dim(self, keepdim)
+    for d in dim:
+        self = aten_any_dim(self, d, keepdim=True)
+    if not keepdim:
+        self = op.Squeeze(self, list(dim))
+    return self
+
+
+def _aten_any_dims_no_dim(self: TTensor, keepdims: bool) -> BOOL:
+    if len(self.shape) == 0:
+        result = op.Cast(self, to=BOOL.dtype)
+    else:
+        self_bool = op.Cast(self, to=BOOL.dtype)
+        self_int = op.Cast(self_bool, to=INT64.dtype)
+        any_true = op.ReduceMax(self_int, keepdims=keepdims)
+        result = op.Cast(any_true, to=BOOL.dtype)
+    return result
+
+
+def _range_supported(dtype: int) -> bool:
+    """Returns true if the dtype is supported by the ONNX Range op."""
+    return dtype in {
+        DOUBLE.dtype,
+        FLOAT.dtype,
+        INT16.dtype,
+        INT32.dtype,
+        INT64.dtype,
+    }
+
+
+def _integral_to_be_adjusted(dtype: int) -> bool:
+    """Returns true if the dtype is special integral handled by torch."""
+    return dtype in {
+        INT8.dtype,
+        INT16.dtype,
+        INT32.dtype,
+    }
+
+
+@onnx_impl(aten.arange.default, trace_only=True)
+def aten_arange(
+    end: TRealUnlessFloat16OrInt8,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TensorType:
+    """arange(Scalar end, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    if dtype == -1 or dtype is None:
+        zero = op.CastLike(0.0, end)
+        one = op.CastLike(1.0, end)
+        result = op.Range(zero, end, one)
+    elif _range_supported(dtype):
+        end = op.Cast(end, to=dtype)
+        zero = op.Cast(0, to=dtype)
+        one = op.Cast(1, to=dtype)
+        result = op.Range(zero, end, one)
+    else:
+        # Cast input to float if dtype is not supported by Range,
+        # because the input dtype may be e.g. bfloat16 / int8 etc.
+        # which Range does not support. The output type is ensured because the output
+        # is casted to the specified dtype.
+        end = op.Cast(end, to=FLOAT.dtype)
+        zero = op.Constant(value_float=0.0)
+        one = op.Constant(value_float=1.0)
+        result = op.Cast(op.Range(zero, end, one), to=dtype)
+
+    return result
+
+
+@onnx_impl(aten.arange.start, trace_only=True)
+def aten_arange_start(
+    start: TRealUnlessFloat16OrInt8,
+    end: TRealUnlessFloat16OrInt8,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TensorType:
+    """arange.start(Scalar start, Scalar end, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    if dtype == -1 or dtype is None:
+        one = op.CastLike(1.0, end)
+        result = op.Range(start, end, one)
+    elif _range_supported(dtype):
+        end = op.Cast(end, to=dtype)
+        start = op.Cast(start, to=dtype)
+        one = op.Cast(1, to=dtype)
+        result = op.Range(start, end, one)
+    else:
+        # Cast input to float if dtype is not supported by Range,
+        # because the input dtype may be e.g. bfloat16 / int8 etc.
+        # which Range does not support. The output type is ensured because the output
+        # is casted to the specified dtype.
+        end = op.Cast(end, to=FLOAT.dtype)
+        start = op.Cast(start, to=FLOAT.dtype)
+        one = op.Constant(value_float=1.0)
+        result = op.Cast(op.Range(start, end, one), to=dtype)
+
+    return result
+
+
+def _adjust_args_for_arange_int_dtype(
+    start: TRealUnlessFloat16OrInt8,
+    end: TRealUnlessFloat16OrInt8,
+    step: TRealUnlessFloat16OrInt8,
+) -> Tuple[FLOAT, FLOAT, FLOAT]:
+    zero = op.Cast(0.0, to=FLOAT.dtype)
+    start = op.Cast(start, to=FLOAT.dtype)
+    end = op.Cast(end, to=FLOAT.dtype)
+    step = op.Cast(step, to=FLOAT.dtype)
+
+    start = op.Where(op.Less(start, zero), op.Ceil(start), start)
+    start = op.Where(op.Less(step, zero), op.Floor(start), start)
+
+    return (start, end, step)
+
+
+@onnx_impl(aten.arange.start_step, trace_only=True)
+def aten_arange_start_step(
+    start: TRealUnlessFloat16OrInt8,
+    end: TRealUnlessFloat16OrInt8,
+    step: TRealUnlessFloat16OrInt8 = 1.0,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TensorType:
+    """arange.start_step(Scalar start, Scalar end, Scalar step=1, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    if dtype == -1:
+        # TODO: Because this is a trace_only function, the inputs are not promoted to
+        # Tensor until it hits ONNX ops. However, if it's dynamic, it should be
+        # Tensor at this point.
+        # https://github.com/microsoft/onnxscript/issues/1914
+        if isinstance(start, (int, float)):
+            start_is_int = isinstance(start, int)
+        else:
+            start_is_int = start.dtype in {
+                INT16.dtype,
+                INT32.dtype,
+                INT64.dtype,
+            }
+        if isinstance(end, (int, float)):
+            end_is_int = isinstance(end, int)
+        else:
+            end_is_int = end.dtype in {
+                INT16.dtype,
+                INT32.dtype,
+                INT64.dtype,
+            }
+        if isinstance(step, (int, float)):
+            step_is_int = isinstance(step, int)
+        else:
+            step_is_int = step.dtype in {
+                INT16.dtype,
+                INT32.dtype,
+                INT64.dtype,
+            }
+        if start_is_int and end_is_int and step_is_int:
+            result = op.Range(start, end, step)
+        else:
+            # to float
+            start = op.Cast(start, to=FLOAT.dtype)
+            end = op.Cast(end, to=FLOAT.dtype)
+            step = op.Cast(step, to=FLOAT.dtype)
+            result = op.Range(start, end, step)
+    elif _integral_to_be_adjusted(dtype):
+        # PyTorch arange op handles these integral types differently from INT64,
+        # so we have to adjust these arguments accordingly.
+        # https://github.com/pytorch/pytorch/blob/121cfb60c0817816fcbe2190303b7f6d05c77cf3/torch/_refs/__init__.py#L4794
+        start, end, step = _adjust_args_for_arange_int_dtype(start, end, step)
+        result = op.Cast(op.Range(start, end, step), to=dtype)
+    elif dtype == INT64.dtype:
+        end = op.Cast(end, to=dtype)
+        start = op.Cast(start, to=dtype)
+        step = op.Cast(step, to=dtype)
+        result = op.Range(start, end, step)
+    else:
+        # Cast input to float if dtype is not supported by Range,
+        # because the input dtype may be e.g. bfloat16,
+        # which Range does not support. The output type is ensured because the output
+        # is casted to the specified dtype.
+        end = op.Cast(end, to=FLOAT.dtype)
+        start = op.Cast(start, to=FLOAT.dtype)
+        step = op.Cast(step, to=FLOAT.dtype)
+        result = op.Cast(op.Range(start, end, step), to=dtype)
+
+    return result
+
+
+def aten_arccos(self: TensorType) -> TensorType:
+    """arccos(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_arccosh(self: TensorType) -> TensorType:
+    """arccosh(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_arcsin(self: TensorType) -> TensorType:
+    """arcsin(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_arcsinh(self: TensorType) -> TensorType:
+    """arcsinh(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_arctan(self: TensorType) -> TensorType:
+    """arctan(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_arctan2(self: TensorType, other: TensorType) -> TensorType:
+    """arctan2(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_arctanh(self: TensorType) -> TensorType:
+    """arctanh(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.argmax.default, trace_only=True)
+def aten_argmax(
+    self: Union[RealType, UINT8], dim: Optional[int] = None, keepdim: bool = False
+) -> INT64:
+    """argmax(Tensor self, int? dim=None, bool keepdim=False) -> Tensor"""
+
+    if dim is None:
+        result = _aten_argmax(self, keepdim)
+    else:
+        result = _aten_argmax_dim(self, dim, keepdim)
+    return result
+
+
+@onnx_impl(aten.argmax.default, private=True, trace_only=True)
+def _aten_argmax(self: Union[RealType, UINT8], keepdim: bool = False) -> INT64:
+    """argmax(Tensor self, int? dim=None, bool keepdim=False) -> Tensor"""
+
+    self_is_scaler = len(self.shape) == 0
+    self = op.Reshape(self, op.Constant(value_ints=[-1]))
+    result = op.ArgMax(self, keepdims=keepdim)
+    if self_is_scaler:
+        result = op.Squeeze(result)
+
+    return result
+
+
+@onnx_impl(aten.argmax.default, private=True, trace_only=True)
+def _aten_argmax_dim(
+    self: Union[RealType, UINT8], dim: int, keepdim: bool = False
+) -> INT64:
+    """argmax(Tensor self, int? dim=None, bool keepdim=False) -> Tensor"""
+
+    self_is_scaler = len(self.shape) == 0
+    if self_is_scaler:
+        self = op.Reshape(self, op.Constant(value_ints=[-1]))
+
+    result = op.ArgMax(self, axis=dim, keepdims=keepdim)
+    if self_is_scaler:
+        result = op.Squeeze(result)
+
+    return result
+
+
+@onnx_impl(aten.argmin.default, trace_only=True)
+def aten_argmin(
+    self: Union[RealType, UINT8], dim: Optional[int] = None, keepdim: bool = False
+) -> INT64:
+    """argmax(Tensor self, int? dim=None, bool keepdim=False) -> Tensor"""
+
+    if dim is None:
+        result = _aten_argmin(self, keepdim)
+    else:
+        result = _aten_argmin_dim(self, dim, keepdim)
+    return result
+
+
+@onnx_impl(aten.argmin.default, private=True, trace_only=True)
+def _aten_argmin(self: Union[RealType, UINT8], keepdim: bool = False) -> INT64:
+    """argmin(Tensor self, int? dim=None, bool keepdim=False) -> Tensor"""
+
+    self_is_scaler = len(self.shape) == 0
+    self = op.Reshape(self, op.Constant(value_ints=[-1]))
+    result = op.ArgMin(self, keepdims=keepdim)
+    if self_is_scaler:
+        result = op.Squeeze(result)
+
+    return result
+
+
+@onnx_impl(aten.argmin.default, private=True, trace_only=True)
+def _aten_argmin_dim(
+    self: Union[RealType, UINT8], dim: int, keepdim: bool = False
+) -> INT64:
+    """argmin(Tensor self, int? dim=None, bool keepdim=False) -> Tensor"""
+
+    self_is_scaler = len(self.shape) == 0
+    if self_is_scaler:
+        self = op.Reshape(self, op.Constant(value_ints=[-1]))
+
+    result = op.ArgMin(self, axis=dim, keepdims=keepdim)
+    if self_is_scaler:
+        result = op.Squeeze(result)
+
+    return result
+
+
+def aten_argsort(
+    self: TensorType, dim: int = -1, descending: bool = False
+) -> TensorType:
+    """argsort(Tensor self, int dim=-1, bool descending=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_argwhere(self: TensorType) -> TensorType:
+    """argwhere(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.as_strided.default, trace_only=True)
+def aten_as_strided(
+    self: TTensor, size: INT64, stride: Sequence[int], storage_offset: int = 0
+) -> TTensor:
+    """as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)"""
+
+    rank = len(stride)
+    return _aten_as_strided_onnx(self, size, stride, storage_offset, rank)
+
+
+@onnx_impl(aten.as_strided.default, private=True)
+def _aten_as_strided_onnx(
+    self: TTensor, size: INT64, stride: INT64, storage_offset: int = 0, rank: int = 0
+) -> TTensor:
+    # e.g. when size=[2,3,4], stride=[2,1,3], indices=[0]
+    # i = 0
+    # indices=[0], add_value=[0,3,6,9]
+    # expand(shape=[4]) to [0,0,0,0]
+    # then + add_value = [0,3,6,9]
+    # i = 1
+    # indices=[0,3,6,9], add_value=[0,1,2]
+    # expand(shape=[3,4] to [[0,3,6,9],[0,3,6,9],[0,3,6,9]]
+    # indices + add_value = [[0,3,6,9],[1,3,7,10],[2,5,8,11]]
+    # i = 2
+    # indices = [[0,3,6,9],[1,3,7,10],[2,5,8,11]], add_value=[0,2]
+    # expand(shape=[2,3,4]) to [[[0,3,6,9],[1,3,7,10],[2,5,8,11]]],[[0,3,6,9],[1,3,7,10],[2,5,8,11]]]
+    # indices + add_value = [[[0,3,6,9],[1,3,7,10],[2,5,8,11]]],[[2,5,8,11],[3,5,9,12],[4,7,10,13]]]
+    neg_1 = op.Constant(value_ints=[-1])
+    rank_tensor = op.Reshape(rank, neg_1)  # should be 3
+    # The final indices for op.Gather(data, indices), will be continually changed during the loop
+    indices = op.Constant(value_int=0)
+    one_seq = op.SequenceEmpty()
+    for i in range(rank):
+        # Get the index from back to front, should be 2,1,0 when to i=0,1,2
+        j = rank - i - 1
+        j_tensor = op.Reshape(j, neg_1)
+        # Get size according to index_j, should be 4,3,2 when i=0,1,2
+        size_dim_j = op.Gather(size, j_tensor, axis=0)
+        # Get right size according to index_j, should be [4],[3,4],[2,3,4] when i=0,1,2
+        size_after_j = op.Slice(size, j_tensor, rank_tensor)
+        # Get stride according to index_j, should be 3,1,2 when i=0,1,2
+        stride_dim_j = op.Gather(stride, j_tensor, axis=0)
+        indices = op.Expand(indices, size_after_j)
+        # When size[j]=4, stride[j]=3, then add_value = [0,1,2,3] * 3 = [0,3,6,9]
+        # When size[j]=3, stride[j]=1, then add_value = [0,1,2] * 1 = [0,1,2]
+        # When size[j]=2, stride[j]=2, then add_value = [0,1] * 2 = [0,2]
+        add_value = op.Range(0, size_dim_j, 1) * stride_dim_j
+        # Compute the shape for add_value for correct broadcasting
+        if i == 0:
+            # shape = [dim_size]
+            shape = size_dim_j
+        else:
+            # shape = [dim_size, 1, 1, ...], the count of 1 euqal to i
+            ones = op.ConcatFromSequence(one_seq, axis=0)
+            shape = op.Concat(op.Cast(size_dim_j, to=FLOAT.dtype), ones, axis=0)
+            shape = op.Cast(shape, to=INT64.dtype)
+
+        add_value = op.Reshape(add_value, shape)
+        # Broadcasting add value to indices according to size and stride value
+        indices = indices + add_value
+        # Dims after dim_size to reshape(add_value), should be [1],[1,1],[1,1,1] when i=0,1,2
+        one_seq = op.SequenceInsert(one_seq, op.Constant(value_floats=[1.0]))
+
+    self_flatten = op.Reshape(self, op.Constant(value_ints=[-1]))
+    indices = op.Add(indices, storage_offset)
+    result = op.Gather(self_flatten, indices)
+
+    return result
+
+
+def aten_as_strided_copy(
+    self: TensorType, size: INT64, stride: INT64, storage_offset: Optional[INT64] = None
+) -> TensorType:
+    """as_strided_copy(Tensor self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_as_strided_scatter(
+    self: TensorType,
+    src: TensorType,
+    size: INT64,
+    stride: INT64,
+    storage_offset: Optional[INT64] = None,
+) -> TensorType:
+    """as_strided_scatter(Tensor self, Tensor src, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.asin.default, trace_only=True)
+def aten_asin(self: TFloat) -> TFloat:
+    """asin(Tensor self) -> Tensor"""
+
+    return op.Asin(self)
+
+
+@onnx_impl(aten.asinh.default, trace_only=True)
+def aten_asinh(self: TFloat) -> TFloat:
+    """asinh(Tensor self) -> Tensor"""
+
+    return op.Asinh(self)
+
+
+@onnx_impl(aten.atan.default, trace_only=True)
+def aten_atan(self: TFloat) -> TFloat:
+    """atan(Tensor self) -> Tensor"""
+
+    return op.Atan(self)
+
+
+@onnx_impl(aten.atan2.default)
+def aten_atan2(self: TFloat, other: TFloat) -> TFloat:
+    """atan2(Tensor self, Tensor other) -> Tensor"""
+
+    # self is y, and other is x on coordinate
+    slope = op.Div(self, other)
+    atan = op.Atan(slope)
+
+    second_third_quadrant = op.Where(self > 0.0, atan + _MATH_PI, atan - _MATH_PI)
+    result = op.Where(other < 0.0, second_third_quadrant, atan)
+
+    return result
+
+
+@onnx_impl(aten.atanh.default, trace_only=True)
+def aten_atanh(self: TFloat) -> TFloat:
+    """atanh(Tensor self) -> Tensor"""
+
+    return op.Atanh(self)
+
+
+@onnx_impl(aten.atleast_1d.default, trace_only=True)
+def aten_atleast_1d(self: TTensor) -> TTensor:
+    """atleast_1d(Tensor self) -> Tensor"""
+
+    if len(self.shape) == 0:
+        self = op.Reshape(self, op.Constant(value_ints=[1]))
+    return op.Identity(self)
+
+
+@onnx_impl(aten.atleast_1d.Sequence)
+def aten_atleast_1d_sequence(self: Sequence[TTensor]) -> TTensor:
+    """atleast_1d.Sequence(Tensor[] tensors) -> Tensor[]"""
+
+    @graph()
+    def reshape_to_1d(tensor):
+        shape = op.Shape(tensor)
+        rank = op.Size(shape)
+        if rank == 0:
+            tensor = op.Reshape(tensor, op.Constant(value_ints=[1]))
+        return tensor
+
+    return op.SequenceMap(self, body=reshape_to_1d)
+
+
+@onnx_impl(aten.atleast_2d.default)
+def aten_atleast_2d(self: TTensor) -> TTensor:
+    """atleast_2d(Tensor self) -> Tensor"""
+
+    if Rank(self) <= 1:
+        self = op.Reshape(self, op.Constant(value_ints=[1, -1]))
+    return op.Identity(self)
+
+
+@onnx_impl(aten.atleast_2d.Sequence)
+def aten_atleast_2d_sequence(self: Sequence[TTensor]) -> TTensor:
+    """atleast_2d.Sequence(Tensor[] tensors) -> Tensor[]"""
+
+    @graph()
+    def reshape_to_2d(tensor):
+        shape = op.Shape(tensor)
+        rank = op.Size(shape)
+        if rank <= 1:
+            tensor = op.Reshape(tensor, op.Constant(value_ints=[1, -1]))
+        return tensor
+
+    return op.SequenceMap(self, body=reshape_to_2d)
+
+
+@onnx_impl(aten.atleast_3d.default, trace_only=True)
+def aten_atleast_3d(self: TTensor) -> TTensor:
+    """atleast_3d(Tensor self) -> Tensor"""
+
+    rank = Rank(self)
+    if rank <= 1:
+        self = op.Reshape(self, op.Constant(value_ints=[1, -1, 1]))
+    elif rank == 2:
+        self = op.Unsqueeze(self, op.Constant(value_ints=[-1]))
+    return op.Identity(self)
+
+
+@onnx_impl(aten.atleast_3d.Sequence)
+def aten_atleast_3d_sequence(self: Sequence[TTensor]) -> TTensor:
+    """atleast_3d.Sequence(Tensor[] tensors) -> Tensor[]"""
+
+    @graph()
+    def reshape_to_3d(tensor):
+        shape = op.Shape(tensor)
+        rank = op.Size(shape)
+        if rank <= 1:
+            tensor = op.Reshape(tensor, op.Constant(value_ints=[1, -1, 1]))
+        elif rank == 2:
+            tensor = op.Unsqueeze(tensor, op.Constant(value_ints=[-1]))
+        return tensor
+
+    return op.SequenceMap(self, body=reshape_to_3d)
+
+
+@onnx_impl(aten.baddbmm.default, trace_only=True)
+def aten_baddbmm(
+    self: TRealOrUInt8,
+    batch1: TRealUnlessInt16OrInt8,
+    batch2: TRealUnlessInt16OrInt8,
+    beta: Optional[TFloat] = None,
+    alpha: Optional[TFloat] = None,
+) -> TRealUnlessInt16OrInt8:
+    """baddbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor"""
+    # beta and alpha can be SymFloat
+    batch_mul = op.MatMul(batch1, batch2)
+    if alpha is None or alpha == 1:
+        mul_a = batch_mul
+    else:
+        mul_a = op.Mul(batch_mul, op.CastLike(alpha, self))
+    if beta is None or beta == 1:
+        mul_b = self
+    else:
+        mul_b = op.Mul(self, op.CastLike(beta, self))
+    return op.Add(mul_a, mul_b)
+
+
+def aten_bartlett_window(window_length: int) -> TensorType:
+    """bartlett_window(int window_length, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_batch_norm(
+    input: TensorType,
+    weight: Optional[TensorType],
+    bias: Optional[TensorType],
+    running_mean: Optional[TensorType],
+    running_var: Optional[TensorType],
+    training: bool,
+    momentum: float,
+    eps: float,
+    cudnn_enabled: bool,
+) -> TensorType:
+    """batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_batch_norm_backward_elemt(
+    grad_out: TensorType,
+    input: TensorType,
+    mean: TensorType,
+    invstd: TensorType,
+    weight: Optional[TensorType],
+    mean_dy: TensorType,
+    mean_dy_xmu: TensorType,
+    count: TensorType,
+) -> TensorType:
+    """batch_norm_backward_elemt(Tensor grad_out, Tensor input, Tensor mean, Tensor invstd, Tensor? weight, Tensor mean_dy, Tensor mean_dy_xmu, Tensor count) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_batch_norm_backward_reduce(
+    grad_out: TensorType,
+    input: TensorType,
+    mean: TensorType,
+    invstd: TensorType,
+    weight: Optional[TensorType],
+    input_g: bool,
+    weight_g: bool,
+    bias_g: bool,
+) -> tuple[TensorType, TensorType, TensorType, TensorType]:
+    """batch_norm_backward_reduce(Tensor grad_out, Tensor input, Tensor mean, Tensor invstd, Tensor? weight, bool input_g, bool weight_g, bool bias_g) -> (Tensor, Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_batch_norm_elemt(
+    input: TensorType,
+    weight: Optional[TensorType],
+    bias: Optional[TensorType],
+    mean: TensorType,
+    invstd: TensorType,
+    eps: float,
+) -> TensorType:
+    """batch_norm_elemt(Tensor input, Tensor? weight, Tensor? bias, Tensor mean, Tensor invstd, float eps) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_batch_norm_gather_stats(
+    input: TensorType,
+    mean: TensorType,
+    invstd: TensorType,
+    running_mean: Optional[TensorType],
+    running_var: Optional[TensorType],
+    momentum: float,
+    eps: float,
+    count: int,
+) -> tuple[TensorType, TensorType]:
+    """batch_norm_gather_stats(Tensor input, Tensor mean, Tensor invstd, Tensor? running_mean, Tensor? running_var, float momentum, float eps, int count) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_batch_norm_gather_stats_with_counts(
+    input: TensorType,
+    mean: TensorType,
+    invstd: TensorType,
+    running_mean: Optional[TensorType],
+    running_var: Optional[TensorType],
+    momentum: float,
+    eps: float,
+    counts: TensorType,
+) -> tuple[TensorType, TensorType]:
+    """batch_norm_gather_stats_with_counts(Tensor input, Tensor mean, Tensor invstd, Tensor? running_mean, Tensor? running_var, float momentum, float eps, Tensor counts) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_batch_norm_stats(
+    input: TensorType, eps: float
+) -> tuple[TensorType, TensorType]:
+    """batch_norm_stats(Tensor input, float eps) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_batch_norm_update_stats(
+    input: TensorType,
+    running_mean: Optional[TensorType],
+    running_var: Optional[TensorType],
+    momentum: float,
+) -> tuple[TensorType, TensorType]:
+    """batch_norm_update_stats(Tensor input, Tensor? running_mean, Tensor? running_var, float momentum) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.bernoulli.default, trace_only=True)
+def aten_bernoulli(self: TFloat) -> TFloat:
+    """Proximal implementation of aten::bernoulli.default
+
+    Note that due to the limitation of ONNX, we ignore the `generator` argument in
+      aten::bernoulli.default(Tensor self, *, Generator? generator=None) -> Tensor
+    """
+    return op.Bernoulli(self)
+
+
+@onnx_impl(aten.bernoulli.p)
+def aten_bernoulli_p(self: TTensor, p: float) -> TTensor:
+    """Proximal implementation of aten::bernoulli.p(Tensor self, float p, *, Generator? generator=None)
+
+    Ignore `generator` due to the limit on ONNX expressiveness.
+    """
+    # NOTE: We will lose some precision when input is float64 but that's considered insignificant
+    self_float = op.Cast(self, to=FLOAT.dtype)
+    rands = op.RandomUniformLike(
+        self_float,
+        high=1.0,
+        low=0.0,
+    )
+    sampled = op.Less(rands, p)
+    return op.CastLike(sampled, self)
+
+
+def aten_bilinear(
+    input1: TensorType,
+    input2: TensorType,
+    weight: TensorType,
+    bias: Optional[TensorType] = None,
+) -> TensorType:
+    """bilinear(Tensor input1, Tensor input2, Tensor weight, Tensor? bias=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_binary_cross_entropy_with_logits(
+    self: TensorType,
+    target: TensorType,
+    weight: Optional[TensorType] = None,
+    pos_weight: Optional[TensorType] = None,
+    reduction: int = 1,
+) -> TensorType:
+    """binary_cross_entropy_with_logits(Tensor self, Tensor target, Tensor? weight=None, Tensor? pos_weight=None, int reduction=Mean) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_bincount(
+    self: TensorType, weights: Optional[TensorType] = None, minlength: int = 0
+) -> TensorType:
+    """bincount(Tensor self, Tensor? weights=None, int minlength=0) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_binomial(
+    count: TensorType, prob: TensorType, generator: Optional[str] = None
+) -> TensorType:
+    """binomial(Tensor count, Tensor prob, Generator? generator=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(
+    (
+        aten.bitwise_and.Tensor,
+        aten.bitwise_and.Scalar,
+        aten.bitwise_and.Scalar_Tensor,
+        operator.and_,
+    ),
+    trace_only=True,
+)
+def aten_bitwise_and(self: TInt, other: TInt) -> TInt:
+    """bitwise_and.Tensor(Tensor self, Tensor other) -> Tensor"""
+    # logical_and implements the BOOL variant
+
+    return op.BitwiseAnd(self, other)
+
+
+@onnx_impl(
+    (
+        aten.bitwise_left_shift.Tensor,
+        aten.bitwise_left_shift.Tensor_Scalar,
+        aten.bitwise_left_shift.Scalar_Tensor,
+        operator.__lshift__,
+    ),
+    trace_only=True,
+)
+def aten_bitwise_left_shift_int16(self: INT16, other: INT16) -> INT16:
+    """bitwise_left_shift.Tensor(Tensor self, Tensor other) -> Tensor"""
+    # assert other >= 0
+    self = op.Cast(self, to=UINT16.dtype)
+    other = op.Cast(other, to=UINT16.dtype)
+
+    result = op.BitShift(self, other, direction="LEFT")
+
+    return op.Cast(result, to=INT16.dtype)
+
+
+@onnx_impl(
+    (
+        aten.bitwise_left_shift.Tensor,
+        aten.bitwise_left_shift.Tensor_Scalar,
+        aten.bitwise_left_shift.Scalar_Tensor,
+        operator.__lshift__,
+    ),
+    trace_only=True,
+)
+def aten_bitwise_left_shift_int32(self: INT32, other: INT32) -> INT32:
+    """bitwise_left_shift.Tensor(Tensor self, Tensor other) -> Tensor"""
+    # assert other >= 0
+    self = op.Cast(self, to=UINT32.dtype)
+    other = op.Cast(other, to=UINT32.dtype)
+
+    result = op.BitShift(self, other, direction="LEFT")
+
+    return op.Cast(result, to=INT32.dtype)
+
+
+@onnx_impl(
+    (
+        aten.bitwise_left_shift.Tensor,
+        aten.bitwise_left_shift.Tensor_Scalar,
+        aten.bitwise_left_shift.Scalar_Tensor,
+        operator.__lshift__,
+    ),
+    trace_only=True,
+)
+def aten_bitwise_left_shift_int64(self: INT64, other: INT64) -> INT64:
+    """bitwise_left_shift.Tensor(Tensor self, Tensor other) -> Tensor"""
+    # assert other >= 0
+    self = op.Cast(self, to=UINT64.dtype)
+    other = op.Cast(other, to=UINT64.dtype)
+
+    result = op.BitShift(self, other, direction="LEFT")
+
+    return op.Cast(result, to=INT64.dtype)
+
+
+@onnx_impl(
+    (
+        aten.bitwise_left_shift.Tensor,
+        aten.bitwise_left_shift.Tensor_Scalar,
+        aten.bitwise_left_shift.Scalar_Tensor,
+        operator.__lshift__,
+    ),
+    trace_only=True,
+)
+def aten_bitwise_left_shift_int8(self: INT8, other: INT8) -> INT8:
+    """bitwise_left_shift.Tensor(Tensor self, Tensor other) -> Tensor"""
+    # assert other >= 0
+    self = op.Cast(self, to=UINT8.dtype)
+    other = op.Cast(other, to=UINT8.dtype)
+
+    result = op.BitShift(self, other, direction="LEFT")
+
+    return op.Cast(result, to=INT8.dtype)
+
+
+@onnx_impl(aten.bitwise_not.default, trace_only=True)
+def aten_bitwise_not(self: TInt) -> TInt:
+    """bitwise_not(Tensor self) -> Tensor"""
+    # logical_not implements the BOOL variant
+
+    return op.BitwiseNot(self)
+
+
+@onnx_impl(
+    (
+        aten.bitwise_or.Tensor,
+        aten.bitwise_or.Scalar,
+        aten.bitwise_or.Scalar_Tensor,
+        operator.or_,
+    ),
+    trace_only=True,
+)
+def aten_bitwise_or(self: TInt, other: TInt) -> TInt:
+    """bitwise_or.Tensor(Tensor self, Tensor other) -> Tensor"""
+    # logical_or implements the BOOL variant
+
+    return op.BitwiseOr(self, other)
+
+
+@onnx_impl(
+    (
+        aten.bitwise_right_shift.Tensor,
+        aten.bitwise_right_shift.Tensor_Scalar,
+        aten.bitwise_right_shift.Scalar_Tensor,
+        operator.__rshift__,
+    )
+)
+def aten_bitwise_right_shift_int16(self: INT16, other: INT16) -> INT16:
+    """bitwise_right_shift.Tensor(Tensor self, Tensor other) -> Tensor"""
+    negative = op.Less(self, 0)
+    self = op.Cast(self, to=UINT16.dtype)
+    other = op.Cast(other, to=UINT16.dtype)
+
+    # Simulate arithmetic shift using logical shift
+    # Clear the lower bits of an all one mask to create the mask to simulate the sign bit shifting
+    mask = op.BitShift(
+        op.Cast(op.Constant(value_int=0xFFFF), to=UINT16.dtype),
+        other,
+        direction="RIGHT",
+    )
+    mask = op.BitwiseNot(mask)
+    # Do logical shift
+    shifted = op.BitShift(self, other, direction="RIGHT")
+    # Compute the arithmetic shifted value assuming the sign bit was set
+    negative_shifted = op.BitwiseOr(shifted, mask)
+    # Choose the shifted value based on the sign bit
+    return op.Where(
+        negative,
+        op.Cast(negative_shifted, to=INT16.dtype),
+        op.Cast(shifted, to=INT16.dtype),
+    )
+
+
+@onnx_impl(
+    (
+        aten.bitwise_right_shift.Tensor,
+        aten.bitwise_right_shift.Tensor_Scalar,
+        aten.bitwise_right_shift.Scalar_Tensor,
+        operator.__rshift__,
+    )
+)
+def aten_bitwise_right_shift_int32(self: INT32, other: INT32) -> INT32:
+    """bitwise_right_shift.Tensor(Tensor self, Tensor other) -> Tensor"""
+    negative = op.Less(self, 0)
+    self = op.Cast(self, to=UINT32.dtype)
+    other = op.Cast(other, to=UINT32.dtype)
+
+    # Simulate arithmetic shift using logical shift
+    # Clear the lower bits of an all one mask to create the mask to simulate the sign bit shifting
+    mask = op.BitShift(
+        op.Cast(op.Constant(value_int=0xFFFFFFFF), to=UINT32.dtype),
+        other,
+        direction="RIGHT",
+    )
+    mask = op.BitwiseNot(mask)
+    # Do logical shift
+    shifted = op.BitShift(self, other, direction="RIGHT")
+    # Compute the arithmetic shifted value assuming the sign bit was set
+    negative_shifted = op.BitwiseOr(shifted, mask)
+    # Choose the shifted value based on the sign bit
+    return op.Where(
+        negative,
+        op.Cast(negative_shifted, to=INT32.dtype),
+        op.Cast(shifted, to=INT32.dtype),
+    )
+
+
+@onnx_impl(
+    (
+        aten.bitwise_right_shift.Tensor,
+        aten.bitwise_right_shift.Tensor_Scalar,
+        aten.bitwise_right_shift.Scalar_Tensor,
+        operator.__rshift__,
+    )
+)
+def aten_bitwise_right_shift_int64(self: INT64, other: INT64) -> INT64:
+    """bitwise_right_shift.Tensor(Tensor self, Tensor other) -> Tensor"""
+    negative = op.Less(self, 0)
+    self = op.Cast(self, to=UINT64.dtype)
+    other = op.Cast(other, to=UINT64.dtype)
+
+    # Simulate arithmetic shift using logical shift
+    # Clear the lower bits of an all one mask to create the mask to simulate the sign bit shifting
+    mask = op.BitShift(
+        # 0xFFFFFFFFFFFFFFFF
+        op.Cast(op.Constant(value_int=-1), to=UINT64.dtype),
+        other,
+        direction="RIGHT",
+    )
+    mask = op.BitwiseNot(mask)
+    # Do logical shift
+    shifted = op.BitShift(self, other, direction="RIGHT")
+    # Compute the arithmetic shifted value assuming the sign bit was set
+    negative_shifted = op.BitwiseOr(shifted, mask)
+    # Choose the shifted value based on the sign bit
+    return op.Where(
+        negative,
+        op.Cast(negative_shifted, to=INT64.dtype),
+        op.Cast(shifted, to=INT64.dtype),
+    )
+
+
+@onnx_impl(
+    (
+        aten.bitwise_right_shift.Tensor,
+        aten.bitwise_right_shift.Tensor_Scalar,
+        aten.bitwise_right_shift.Scalar_Tensor,
+        operator.__rshift__,
+    )
+)
+def aten_bitwise_right_shift_int8(self: INT8, other: INT8) -> INT8:
+    """bitwise_right_shift.Tensor(Tensor self, Tensor other) -> Tensor"""
+    negative = op.Less(self, 0)
+    self = op.Cast(self, to=UINT8.dtype)
+    other = op.Cast(other, to=UINT8.dtype)
+
+    # Simulate arithmetic shift using logical shift
+    # Clear the lower bits of an all one mask to create the mask to simulate the sign bit shifting
+    mask = op.BitShift(
+        op.Cast(op.Constant(value_int=0xFF), to=UINT8.dtype), other, direction="RIGHT"
+    )
+    mask = op.BitwiseNot(mask)
+    # Do logical shift
+    shifted = op.BitShift(self, other, direction="RIGHT")
+    # Compute the arithmetic shifted value assuming the sign bit was set
+    negative_shifted = op.BitwiseOr(shifted, mask)
+    # Choose the shifted value based on the sign bit
+    return op.Where(
+        negative,
+        op.Cast(negative_shifted, to=INT8.dtype),
+        op.Cast(shifted, to=INT8.dtype),
+    )
+
+
+@onnx_impl(
+    (
+        aten.bitwise_xor.Tensor,
+        aten.bitwise_xor.Scalar,
+        aten.bitwise_xor.Scalar_Tensor,
+    ),
+    trace_only=True,
+)
+def aten_bitwise_xor(self: TInt, other: TInt) -> TInt:
+    """bitwise_xor.Tensor(Tensor self, Tensor other) -> Tensor"""
+    # logical_xor implements the BOOL variant
+
+    return op.BitwiseXor(self, other)
+
+
+@onnx_impl(aten.blackman_window.default, trace_only=True)
+def aten_blackman_window(
+    window_length: int,
+    dtype: int = 1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TensorType:
+    """blackman_window(int window_length, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    if dtype is None or dtype == -1:
+        dtype = 1
+    return op.BlackmanWindow(window_length, output_datatype=dtype)
+
+
+def aten_block_diag(tensors: Sequence[TensorType]) -> TensorType:
+    """block_diag(Tensor[] tensors) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.bmm.default, trace_only=True)
+def aten_bmm(self: TFloat, mat2: TFloat) -> TFloat:
+    """bmm(Tensor self, Tensor mat2) -> Tensor"""
+
+    return op.MatMul(self, mat2)
+
+
+def aten_broadcast_tensors(tensors: Sequence[TensorType]) -> TensorType:
+    """broadcast_tensors(Tensor[] tensors) -> Tensor[]"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.broadcast_to.default)
+def aten_broadcast_to(self: TTensor, size: INT64) -> TTensor:
+    """broadcast_to(Tensor(a) self, SymInt[] size) -> Tensor(a)"""
+
+    return op.Expand(self, size)
+
+
+def aten_bucketize(
+    self: TensorType,
+    boundaries: TensorType,
+    out_int32: bool = False,
+    right: bool = False,
+) -> TensorType:
+    """bucketize.Tensor(Tensor self, Tensor boundaries, *, bool out_int32=False, bool right=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_can_cast(from_: int, to: int) -> bool:
+    """can_cast(ScalarType from, ScalarType to) -> bool"""
+
+    raise NotImplementedError
+
+
+def aten_cartesian_prod(tensors: Sequence[TensorType]) -> TensorType:
+    """cartesian_prod(Tensor[] tensors) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.cat.default, trace_only=True, complex=True)
+def aten_cat_complex(tensors: Sequence[TTensor], dim: int = 0) -> TTensor:
+    """cat(Tensor[] tensors, int dim=0) -> Tensor"""
+    # Real representation unsqueezes the last dimension
+    if dim < 0:
+        dim = dim - 1
+    return aten_cat(tensors, dim=dim)
+
+
+@onnx_impl(
+    (aten.cat.default, aten.concat.default, aten.concatenate.default), trace_only=True
+)
+def aten_cat(tensors: Sequence[TTensor], dim: int = 0) -> TTensor:
+    """cat(Tensor[] tensors, int dim=0) -> Tensor"""
+
+    # Remove None tensors
+    tensors = [tensor for tensor in tensors if tensor is not None]
+    return op.Concat(*tensors, axis=dim)
+
+
+def aten_ccol_indices(self: TensorType) -> TensorType:
+    """ccol_indices(Tensor(a) self) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def aten_ccol_indices_copy(self: TensorType) -> TensorType:
+    """ccol_indices_copy(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_cdist(
+    x1: TensorType, x2: TensorType, p: float = 2.0, compute_mode: Optional[int] = None
+) -> TensorType:
+    """cdist(Tensor x1, Tensor x2, float p=2, int? compute_mode=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.ceil.default, trace_only=True)
+def aten_ceil(self: TFloat) -> TFloat:
+    """ceil(Tensor self) -> Tensor"""
+
+    return op.Ceil(self)
+
+
+@onnx_impl("math::ceil", trace_only=True)
+def python_math_ceil(self: TFloat) -> TInt:
+    """ceil(Tensor self) -> Tensor"""
+    ceil = op.Ceil(self)
+    return op.Cast(ceil, to=INT64.dtype)
+
+
+def aten_chain_matmul(matrices: Sequence[TensorType]) -> TensorType:
+    """chain_matmul(Tensor[] matrices) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_chalf(self: TensorType, memory_format: Optional[str] = None) -> TensorType:
+    """chalf(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_channel_shuffle(self: TensorType, groups: int) -> TensorType:
+    """channel_shuffle(Tensor self, int groups) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_cholesky(self: TensorType, upper: bool = False) -> TensorType:
+    """cholesky(Tensor self, bool upper=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_cholesky_inverse(self: TensorType, upper: bool = False) -> TensorType:
+    """cholesky_inverse(Tensor self, bool upper=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_cholesky_solve(
+    self: TensorType, input2: TensorType, upper: bool = False
+) -> TensorType:
+    """cholesky_solve(Tensor self, Tensor input2, bool upper=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_choose_qparams_optimized(
+    input: TensorType, numel: int, n_bins: int, ratio: float, bit_width: int
+) -> tuple[TensorType, TensorType]:
+    """choose_qparams_optimized(Tensor input, int numel, int n_bins, float ratio, int bit_width) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.chunk.default)
+def aten_chunk(self: TTensor, chunks: int, dim: int = 0) -> Sequence[TTensor]:
+    """chunk(Tensor(a -> *) self, int chunks, int dim=0) -> Tensor(a)[]"""
+    # This will create a Sequence of tensors
+    neg_1 = op.Constant(value_ints=[-1])
+    # Get size of specified dim
+    self_shape = op.Shape(self)
+    dim_size = op.Gather(self_shape, dim, axis=0)
+    # Compute size/chunk to get the number of data in one chunk
+    num_per_chunk = op.Div(dim_size, chunks)
+    num_per_chunk = (
+        op.Cast(op.Mod(dim_size, chunks) > 0, to=INT64.dtype) + num_per_chunk
+    )  # type: ignore[operator]
+
+    # Compute real chunk number
+    num_chunk = op.Div(dim_size, num_per_chunk)
+    # Get something like [n, n, n, n, ...], total num_chunk
+    list_split = op.Expand(num_per_chunk, op.Reshape(num_chunk, neg_1))
+
+    remainder = op.Mod(dim_size, num_per_chunk)
+    if remainder > 0:  # type: ignore[operator]
+        # Append the remainder to the [n, n, n, n, ..., r]
+        list_split = op.Concat(list_split, op.Reshape(remainder, neg_1), axis=0)
+
+    return op.SplitToSequence(self, list_split, axis=dim)
+
+
+@onnx_impl((aten.clamp.default, aten.clamp.Tensor), trace_only=True)
+def aten_clamp(
+    self: TReal, min: Optional[TReal] = None, max: Optional[TReal] = None
+) -> TReal:
+    """clamp(Tensor self, Tensor? min=None, Tensor? max=None) -> Tensor"""
+    clamped = self
+
+    if min is None and max is None:
+        return clamped
+
+    # If min is greater than max torch.clamp(..., min, max)
+    # sets all elements in input to the value of max.
+    # So this order is important.
+    if min is not None:
+        min_clamp = op.CastLike(min, self)
+        clamped = op.Max(clamped, min_clamp)
+
+    if max is not None:
+        max_clamp = op.CastLike(max, self)
+        clamped = op.Min(clamped, max_clamp)
+
+    return clamped
+
+
+@onnx_impl((aten.clamp_max.default, aten.clamp_max.Tensor), trace_only=True)
+def aten_clamp_max(self: TReal, max_: TReal) -> TReal:
+    """clamp_max(Tensor self, Tensor max) -> Tensor"""
+
+    # This implementation does not intent to handle when self is an empty tensor
+    max_rank = len(max_.shape)
+    if max_rank == 0:
+        max_ = op.CastLike(max_, self)
+        result = op.Clip(self, None, max_)
+    else:
+        result = op.Min(self, max_)
+
+    return result
+
+
+@onnx_impl((aten.clamp_min.default, aten.clamp_min.Tensor), trace_only=True)
+def aten_clamp_min(self: TReal, min_: TReal) -> TReal:
+    """clamp_min(Tensor self, Tensor min) -> Tensor"""
+
+    # This implementation does not intent to handle when self is an empty tensor
+    min_rank = len(min_.shape)
+    if min_rank == 0:
+        min_ = op.CastLike(min_, self)
+        result = op.Clip(self, min_, None)
+    else:
+        result = op.Max(self, min_)
+
+    return result
+
+
+@onnx_impl(aten.clone.default, trace_only=True)
+def aten_clone(
+    self: TTensor,
+    memory_format: str = "",
+) -> TTensor:
+    """clone(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor"""
+
+    return op.Identity(self)
+
+
+def aten_coalesce(self: TensorType) -> TensorType:
+    """coalesce(Tensor(a) self) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def aten_col_indices(self: TensorType) -> TensorType:
+    """col_indices(Tensor(a) self) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def aten_col_indices_copy(self: TensorType) -> TensorType:
+    """col_indices_copy(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_column_stack(tensors: Sequence[TensorType]) -> TensorType:
+    """column_stack(Tensor[] tensors) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_combinations(
+    self: TensorType, r: int = 2, with_replacement: bool = False
+) -> TensorType:
+    """combinations(Tensor self, int r=2, bool with_replacement=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.complex.default, trace_only=True)
+def aten_complex(real: TFloat, imag: TFloat) -> TFloat:
+    """complex(Tensor real, Tensor imag) -> Tensor"""
+
+    # Broadcast the real and imaginary parts to the same shape
+    broadcasted_shape = _shape_of_broadcast_tensors(real, imag)
+    real = op.Expand(real, broadcasted_shape)
+    imag = op.Expand(imag, broadcasted_shape)
+
+    return op.Concat(
+        op.Unsqueeze(real, axes=[-1]), op.Unsqueeze(imag, axes=[-1]), axis=-1
+    )
+
+
+@onnx_impl(aten.conj.default, trace_only=True)
+def aten_conj(self: TTensor) -> TTensor:
+    """conj(Tensor(a) self) -> Tensor(a)"""
+
+    return op.Identity(self)
+
+
+def _complex_conjugate(self: TFloat) -> TFloat:
+    zero = op.Constant(value_ints=[0])
+    one = op.Constant(value_ints=[1])
+    two = op.Constant(value_ints=[2])
+    neg_1 = op.Constant(value_ints=[-1])
+    # The last dimension is the real and imaginary parts
+
+    real = op.Slice(self, zero, one, neg_1)
+    imag = op.Slice(self, one, two, neg_1)
+    conjugated = op.Concat(real, op.Neg(imag), axis=-1)
+
+    return conjugated
+
+
+@onnx_impl(aten.conj.default, complex=True, trace_only=True)
+def aten_conj_complex(self: TFloat) -> TFloat:
+    """conj(Tensor(a) self) -> Tensor(a)"""
+
+    return _complex_conjugate(self)
+
+
+def aten_conj_physical(self: TensorType) -> TensorType:
+    """conj_physical(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.constant_pad_nd.default)
+def aten_constant_pad_nd(self: TTensor, pad: INT64, value: float = 0.0) -> TTensor:
+    """constant_pad_nd(Tensor self, SymInt[] pad, Scalar value=0) -> Tensor"""
+
+    # The desired order of paddings is
+    # dim_0_begin, dim_1_begin, ... , dim_0_end, ..., dim_n_end.
+    # n is the dimension of input.
+    # assume zero-dimensions in the beginning
+    # rank = len(self.shape)  # rank must be scalar
+    # paddings = list(pad[:]) + [0] * (rank * 2 - len(pad))
+    # reverse order and collate first beginnings and then ends
+    # paddings = paddings[-2::-2] + paddings[-1::-2]
+
+    neg_1 = op.Constant(value_ints=[-1])
+
+    zero_count = op.Sub(op.Mul(Rank(self), 2), op.Size(pad))
+    zero_count = op.Reshape(zero_count, neg_1)
+    zero = op.Constant(value_ints=[0])
+    zeros = op.Expand(zero, zero_count)
+    torch_paddings = op.Concat(pad, zeros, axis=0)
+    size_d = op.Size(torch_paddings)
+    steps = op.Constant(value_ints=[-2])
+
+    starts = steps
+    ends = op.Sub(starts, size_d)
+    odd_elements = op.Slice(torch_paddings, starts, ends, zero, steps)
+
+    starts = neg_1
+    ends = op.Sub(starts, size_d)
+    even_elements = op.Slice(torch_paddings, starts, ends, zero, steps)
+
+    onnx_padding = op.Concat(odd_elements, even_elements, axis=0)
+    return op.Pad(self, onnx_padding, value)
+
+
+@onnx_impl(aten.contiguous.default, trace_only=True)
+def aten_contiguous(
+    self: TTensor,
+    memory_format: str = "contiguous_format",
+) -> TTensor:
+    """contiguous(Tensor(a) self, *, MemoryFormat memory_format=contiguous_format) -> Tensor(a)"""
+
+    # ONNX does not have the notion of memory_format. It is always treated as a no-op.
+    return op.Identity(self)
+
+
+@onnx_impl(aten.conv1d.default, trace_only=True)
+def aten_conv1d(
+    input: TFloat,
+    weight: TFloat,
+    bias: Optional[TFloat] = None,
+    stride: Sequence[int] = (1,),
+    padding: Sequence[int] = (0,),
+    dilation: Sequence[int] = (1,),
+    groups: int = 1,
+) -> TFloat:
+    """conv1d(Tensor input, Tensor weight, Tensor? bias=None, int[1] stride=1, int[1] padding=0, int[1] dilation=1, int groups=1) -> Tensor"""
+
+    # Attributes need to be manipulated in Python to match ONNX's conv1d
+    if not isinstance(padding, Sequence):
+        padding = (padding,)
+    pads = [*padding, *padding]
+
+    if not isinstance(dilation, Sequence):
+        dilation = (dilation,)
+    dilations = list(dilation)
+
+    if not isinstance(stride, Sequence):
+        stride = (stride,)
+    strides = list(stride)
+
+    if bias is None:
+        weight_dim_0 = op.Shape(weight, start=0, end=1)
+        bias_shape = op.Expand(weight_dim_0, op.Constant(value_ints=[1]))
+        zero = op.CastLike(0.0, input)
+        bias = op.Expand(zero, bias_shape)
+
+    result = _aten_convolution_onnx(
+        input,
+        weight,
+        bias,
+        transposed=False,
+        strides=strides,
+        pads=pads,
+        dilations=dilations,
+        groups=groups,
+    )
+
+    return result
+
+
+@onnx_impl(aten.conv2d.default, trace_only=True)
+def aten_conv2d(
+    input: TFloat,
+    weight: TFloat,
+    bias: Optional[TFloat] = None,
+    stride: Sequence[int] = (1, 1),
+    padding: Sequence[int] = (0, 0),
+    dilation: Sequence[int] = (1, 1),
+    groups: int = 1,
+) -> TFloat:
+    """conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor"""
+
+    # Attributes need to be manipulated in Python to match ONNX's conv2d
+    if not isinstance(padding, Sequence):
+        padding = (padding, padding)
+    pads = [*padding, *padding]
+
+    if not isinstance(dilation, Sequence):
+        dilation = (dilation, dilation)
+    dilations = list(dilation)
+
+    if not isinstance(stride, Sequence):
+        stride = (stride, stride)
+    strides = list(stride)
+
+    if bias is None:
+        weight_dim_0 = op.Shape(weight, start=0, end=1)
+        bias_shape = op.Expand(weight_dim_0, op.Constant(value_ints=[1]))
+        zero = op.CastLike(0.0, input)
+        bias = op.Expand(zero, bias_shape)
+
+    result = _aten_convolution_onnx(
+        input,
+        weight,
+        bias,
+        transposed=False,
+        strides=strides,
+        pads=pads,
+        dilations=dilations,
+        groups=groups,
+    )
+
+    return result
+
+
+@onnx_impl(aten.conv3d.default, trace_only=True)
+def aten_conv3d(
+    input: TFloat,
+    weight: TFloat,
+    bias: Optional[TFloat] = None,
+    stride: Sequence[int] = (1, 1, 1),
+    padding: Sequence[int] = (0, 0, 0),
+    dilation: Sequence[int] = (1, 1, 1),
+    groups: int = 1,
+) -> TFloat:
+    """conv3d(Tensor input, Tensor weight, Tensor? bias=None, int[3] stride=1, int[3] padding=0, int[3] dilation=1, int groups=1) -> Tensor"""
+
+    # Attributes need to be manipulated in Python to match ONNX's conv3d
+    if not isinstance(padding, Sequence):
+        padding = (padding, padding, padding)
+    pads = [*padding, *padding]
+
+    if not isinstance(dilation, Sequence):
+        dilation = (dilation, dilation, dilation)
+    dilations = list(dilation)
+
+    if not isinstance(stride, Sequence):
+        stride = (stride, stride, stride)
+    strides = list(stride)
+
+    if bias is None:
+        weight_dim_0 = op.Shape(weight, start=0, end=1)
+        bias_shape = op.Expand(weight_dim_0, op.Constant(value_ints=[1]))
+        zero = op.CastLike(0.0, input)
+        bias = op.Expand(zero, bias_shape)
+
+    result = _aten_convolution_onnx(
+        input,
+        weight,
+        bias,
+        transposed=False,
+        strides=strides,
+        pads=pads,
+        dilations=dilations,
+        groups=groups,
+    )
+
+    return result
+
+
+def aten_conv_tbc(
+    self: TensorType, weight: TensorType, bias: TensorType, pad: int = 0
+) -> TensorType:
+    """conv_tbc(Tensor self, Tensor weight, Tensor bias, int pad=0) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_conv_tbc_backward(
+    self: TensorType, input: TensorType, weight: TensorType, bias: TensorType, pad: int
+) -> tuple[TensorType, TensorType, TensorType]:
+    """conv_tbc_backward(Tensor self, Tensor input, Tensor weight, Tensor bias, int pad) -> (Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_conv_transpose1d(
+    input: TensorType,
+    weight: TensorType,
+    bias: Optional[TensorType] = None,
+    stride: Sequence[int] = (1,),
+    padding: Sequence[int] = (0,),
+    output_padding: Sequence[int] = (0,),
+    groups: int = 1,
+    dilation: Sequence[int] = (1,),
+) -> TensorType:
+    """conv_transpose1d(Tensor input, Tensor weight, Tensor? bias=None, int[1] stride=1, int[1] padding=0, int[1] output_padding=0, int groups=1, int[1] dilation=1) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.convolution.default, trace_only=True)
+def aten_convolution(
+    input: TFloat,
+    weight: TFloat,
+    bias: Optional[TFloat] = None,
+    stride: Sequence[int] = (1,),
+    padding: Sequence[int] = (0,),
+    dilation: Sequence[int] = (1,),
+    transposed: bool = False,
+    output_padding: Sequence[int] = (0,),
+    groups: int = 1,
+) -> TFloat:
+    """convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor"""
+
+    if not isinstance(padding, Sequence):
+        padding = (padding, padding)
+    pads = [*padding, *padding]
+
+    if not isinstance(dilation, Sequence):
+        dilation = (dilation, dilation)
+    dilations = list(dilation)
+
+    if not isinstance(stride, Sequence):
+        stride = (stride, stride)
+    strides = list(stride)
+
+    result = _aten_convolution_onnx(
+        input,
+        weight,
+        bias,
+        transposed,
+        strides=strides,
+        pads=pads,
+        dilations=dilations,
+        output_padding=output_padding,
+        groups=groups,
+    )
+
+    return result
+
+
+@onnx_impl(aten.convolution.default, private=True, trace_only=True)
+def _aten_convolution_onnx(
+    input: TFloat,
+    weight: TFloat,
+    bias: TFloat,
+    transposed: bool,
+    strides: Sequence[int],
+    pads: Sequence[int],
+    dilations: Sequence[int],
+    output_padding: Sequence[int] = (0,),
+    groups: int = 1,
+) -> TFloat:
+    """ConvXd with attributes pre-computed to fit the ONNX spec."""
+
+    # NOTE: transposed must be an input because when provided as an attribute,
+    # it will be an integer, not a boolean, which will fail the if condition.
+    # Alternatively we could cast transposed to BOOL.
+    # E.g. `if op.Cast(transposed, BOOL.dtype): ...`
+
+    no_batch = len(input.shape) != len(weight.shape)
+
+    if no_batch:
+        input = op.Unsqueeze(input, op.Constant(value_ints=[0]))
+
+    if transposed:
+        result = op.ConvTranspose(
+            input,
+            weight,
+            bias,
+            strides=strides,
+            pads=pads,
+            group=groups,
+            dilations=dilations,
+            output_padding=output_padding,
+        )
+    else:
+        result = op.Conv(
+            input,
+            weight,
+            bias,
+            strides=strides,
+            pads=pads,
+            group=groups,
+            dilations=dilations,
+        )
+
+    if no_batch:
+        result = op.Squeeze(result, op.Constant(value_ints=[0]))
+
+    return result
+
+
+def aten_convolution_backward(
+    grad_output: TensorType,
+    input: TensorType,
+    weight: TensorType,
+    bias_sizes: Optional[INT64],
+    stride: Sequence[int],
+    padding: INT64,
+    dilation: Sequence[int],
+    transposed: bool,
+    output_padding: INT64,
+    groups: int,
+    output_mask: Sequence[bool],
+) -> tuple[TensorType, TensorType, TensorType]:
+    """convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_convolution_backward_overrideable(
+    grad_output: TensorType,
+    input: TensorType,
+    weight: TensorType,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    transposed: bool,
+    output_padding: Sequence[int],
+    groups: int,
+    output_mask: Sequence[bool],
+) -> tuple[TensorType, TensorType, TensorType]:
+    """convolution_backward_overrideable(Tensor grad_output, Tensor input, Tensor weight, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups, bool[3] output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)"""
+
+    raise NotImplementedError
+
+
+def aten_convolution_overrideable(
+    input: TensorType,
+    weight: TensorType,
+    bias: Optional[TensorType],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    transposed: bool,
+    output_padding: Sequence[int],
+    groups: int,
+) -> TensorType:
+    """convolution_overrideable(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.copy.default)
+def aten_copy(
+    self: TTensor,
+    src: TTensor2,
+    non_blocking: bool = False,
+) -> TTensor:
+    """copy(Tensor self, Tensor src, bool non_blocking=False) -> Tensor"""
+
+    return op.CastLike(src, self)
+
+
+@onnx_impl(aten._to_copy.default, trace_only=True)
+def aten__to_copy(
+    self: TTensor,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+    non_blocking: bool = False,
+    memory_format: str = "",
+) -> TTensor:
+    """_to_copy(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool non_blocking=False, MemoryFormat? memory_format=None) -> Tensor"""
+
+    if dtype == -1:
+        return op.Identity(self)
+    else:
+        return common_ops.cast_to(self, dtype=dtype)
+
+
+def aten_copysign(self: TensorType, other: TensorType) -> TensorType:
+    """copysign.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_corrcoef(self: TensorType) -> TensorType:
+    """corrcoef(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.cos.default, trace_only=True)
+def aten_cos(self: TFloat) -> TFloat:
+    """cos(Tensor self) -> Tensor"""
+
+    return op.Cos(self)
+
+
+@onnx_impl(aten.cosh.default, trace_only=True)
+def aten_cosh(self: TFloat) -> TFloat:
+    """cosh(Tensor self) -> Tensor"""
+
+    return op.Cosh(self)
+
+
+def aten_cosine_embedding_loss(
+    input1: TensorType,
+    input2: TensorType,
+    target: TensorType,
+    margin: float = 0.0,
+    reduction: int = 1,
+) -> TensorType:
+    """cosine_embedding_loss(Tensor input1, Tensor input2, Tensor target, float margin=0.0, int reduction=Mean) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_cosine_similarity(
+    x1: TensorType, x2: TensorType, dim: int = 1, eps: float = 1e-08
+) -> TensorType:
+    """cosine_similarity(Tensor x1, Tensor x2, int dim=1, float eps=1e-08) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_count_nonzero(self: TensorType, dim: Optional[int] = None) -> TensorType:
+    """count_nonzero(Tensor self, int? dim=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_cov(
+    self: TensorType,
+    correction: int = 1,
+    fweights: Optional[TensorType] = None,
+    aweights: Optional[TensorType] = None,
+) -> TensorType:
+    """cov(Tensor self, *, int correction=1, Tensor? fweights=None, Tensor? aweights=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl((aten.cross.default, aten.linalg_cross.default))
+def aten_cross(self: TTensor, other: TTensor, dim: int = -1) -> TTensor:
+    """cross(Tensor self, Tensor other, int? dim=None) -> Tensor"""
+
+    # Reference https://en.wikipedia.org/w/index.php?title=Cross_product&oldid=1143125073
+    a1, a2, a3 = op.Split(self, axis=dim, num_outputs=3)
+    b1, b2, b3 = op.Split(other, axis=dim, num_outputs=3)
+    # Broadcasting is implicitly supported by Mul
+    c1 = op.Sub(op.Mul(a2, b3), op.Mul(a3, b2))
+    c2 = op.Sub(op.Mul(a3, b1), op.Mul(a1, b3))
+    c3 = op.Sub(op.Mul(a1, b2), op.Mul(a2, b1))
+
+    return op.Concat(c1, c2, c3, axis=dim)
+
+
+def aten_crow_indices(self: TensorType) -> TensorType:
+    """crow_indices(Tensor(a) self) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def aten_crow_indices_copy(self: TensorType) -> TensorType:
+    """crow_indices_copy(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_ctc_loss(
+    log_probs: TensorType,
+    targets: TensorType,
+    input_lengths: TensorType,
+    target_lengths: TensorType,
+    blank: int = 0,
+    reduction: int = 1,
+    zero_infinity: bool = False,
+) -> TensorType:
+    """ctc_loss.Tensor(Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths, int blank=0, int reduction=Mean, bool zero_infinity=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_cudnn_affine_grid_generator(
+    theta: TensorType, N: int, C: int, H: int, W: int
+) -> TensorType:
+    """cudnn_affine_grid_generator(Tensor theta, int N, int C, int H, int W) -> Tensor grid"""
+
+    raise NotImplementedError
+
+
+def aten_cudnn_affine_grid_generator_backward(
+    grad: TensorType, N: int, C: int, H: int, W: int
+) -> TensorType:
+    """cudnn_affine_grid_generator_backward(Tensor grad, int N, int C, int H, int W) -> Tensor grad_theta"""
+
+    raise NotImplementedError
+
+
+def aten_cudnn_batch_norm(
+    input: TensorType,
+    weight: TensorType,
+    bias: Optional[TensorType],
+    running_mean: Optional[TensorType],
+    running_var: Optional[TensorType],
+    training: bool,
+    exponential_average_factor: float,
+    epsilon: float,
+) -> tuple[TensorType, TensorType, TensorType, TensorType]:
+    """cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_cudnn_batch_norm_backward(
+    input: TensorType,
+    grad_output: TensorType,
+    weight: TensorType,
+    running_mean: Optional[TensorType],
+    running_var: Optional[TensorType],
+    save_mean: Optional[TensorType],
+    save_var: Optional[TensorType],
+    epsilon: float,
+    reserveSpace: TensorType,
+) -> tuple[TensorType, TensorType, TensorType]:
+    """cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_cudnn_convolution(
+    self: TensorType,
+    weight: TensorType,
+    padding: Sequence[int],
+    stride: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+    benchmark: bool,
+    deterministic: bool,
+    allow_tf32: bool,
+) -> TensorType:
+    """cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_cudnn_convolution_add_relu(
+    self: TensorType,
+    weight: TensorType,
+    z: TensorType,
+    alpha: Optional[float],
+    bias: Optional[TensorType],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+) -> TensorType:
+    """cudnn_convolution_add_relu(Tensor self, Tensor weight, Tensor z, Scalar? alpha, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_cudnn_convolution_relu(
+    self: TensorType,
+    weight: TensorType,
+    bias: Optional[TensorType],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+) -> TensorType:
+    """cudnn_convolution_relu(Tensor self, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_cudnn_convolution_transpose(
+    self: TensorType,
+    weight: TensorType,
+    padding: Sequence[int],
+    output_padding: Sequence[int],
+    stride: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+    benchmark: bool,
+    deterministic: bool,
+    allow_tf32: bool,
+) -> TensorType:
+    """cudnn_convolution_transpose(Tensor self, Tensor weight, int[] padding, int[] output_padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_cudnn_grid_sampler(self: TensorType, grid: TensorType) -> TensorType:
+    """cudnn_grid_sampler(Tensor self, Tensor grid) -> Tensor output"""
+
+    raise NotImplementedError
+
+
+def aten_cudnn_grid_sampler_backward(
+    self: TensorType, grid: TensorType, grad_output: TensorType
+) -> tuple[TensorType, TensorType]:
+    """cudnn_grid_sampler_backward(Tensor self, Tensor grid, Tensor grad_output) -> (Tensor grad_self, Tensor grad_grid)"""
+
+    raise NotImplementedError
+
+
+def aten_cudnn_is_acceptable(self: TensorType) -> bool:
+    """cudnn_is_acceptable(Tensor self) -> bool"""
+
+    raise NotImplementedError
+
+
+def aten_cummax(self: TensorType, dim: int) -> tuple[TensorType, TensorType]:
+    """cummax(Tensor self, int dim) -> (Tensor values, Tensor indices)"""
+
+    raise NotImplementedError
+
+
+def aten_cummaxmin_backward(
+    grad: TensorType, input: TensorType, indices: TensorType, dim: int
+) -> TensorType:
+    """cummaxmin_backward(Tensor grad, Tensor input, Tensor indices, int dim) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_cummin(self: TensorType, dim: int) -> tuple[TensorType, TensorType]:
+    """cummin(Tensor self, int dim) -> (Tensor values, Tensor indices)"""
+
+    raise NotImplementedError
+
+
+def aten_cumprod(self: TensorType, dim: int, dtype: Optional[int] = None) -> TensorType:
+    """cumprod(Tensor self, int dim, *, ScalarType? dtype=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_cumprod_backward(
+    grad: TensorType, input: TensorType, dim: int, output: TensorType
+) -> TensorType:
+    """cumprod_backward(Tensor grad, Tensor input, int dim, Tensor output) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.cumsum.default, trace_only=True)
+def aten_cumsum(
+    self: TRealUnlessInt16OrInt8, dim: Union[INT32, INT64], dtype: int = -1
+) -> TRealUnlessInt16OrInt8:
+    """cumsum(Tensor self, int dim, *, ScalarType? dtype=None) -> Tensor"""
+
+    # TODO(justinchuby): The accumulation type for int32 is int64. Consider excluding from inputs.
+    if dtype == -1:
+        cast = self
+    else:
+        cast = op.Cast(self, to=dtype)
+    if len(self.shape) == 0:
+        # A scalar
+        result = op.Identity(cast)
+    else:
+        result = op.CumSum(cast, dim)
+    return result
+
+
+def aten_data(self: TensorType) -> TensorType:
+    """data(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.deg2rad.default, trace_only=True)
+def aten_deg2rad(self: TFloat) -> TFloat:
+    """deg2rad(Tensor self) -> Tensor"""
+
+    return op.Mul(self, op.CastLike(_MATH_PI / 180.0, self))
+
+
+def aten_dense_dim(self: TensorType) -> int:
+    """dense_dim(Tensor self) -> int"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.detach.default, trace_only=True)
+def aten_detach(self: TensorType) -> TensorType:
+    """detach(Tensor(a) self) -> Tensor(a)"""
+
+    return op.Identity(self)
+
+
+def aten_detach_copy(self: TensorType) -> TensorType:
+    """detach_copy(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_diag(self: TensorType, diagonal: int = 0) -> TensorType:
+    """diag(Tensor self, int diagonal=0) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_diag_embed(
+    self: TensorType, offset: int = 0, dim1: int = -2, dim2: int = -1
+) -> TensorType:
+    """diag_embed(Tensor self, int offset=0, int dim1=-2, int dim2=-1) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_diagflat(self: TensorType, offset: int = 0) -> TensorType:
+    """diagflat(Tensor self, int offset=0) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl((aten.diagonal.default, aten.diagonal_copy.default), trace_only=True)
+def aten_diagonal(self: TReal, offset: int = 0, dim1: int = 0, dim2: int = 1) -> TReal:
+    """diagonal(Tensor(a) self, int offset=0, int dim1=0, int dim2=1) -> Tensor(a)"""
+
+    # perm is used to transpose the tensor to make dim1 and dim2 as the last 2 dims
+    # [0,1,2] -> [2,0,1] when dim1=0 and dim2=1
+    # [0,1,2] -> [1,0,2] when dim1=0 and dim2=2
+    # [0,1,2] -> [0,1,2] when dim1=1 and dim2=2
+    if dim1 < 0:
+        dim1 = dim1 + len(self.shape)
+    if dim2 < 0:
+        dim2 = dim2 + len(self.shape)
+
+    self_rank = len(self.shape)
+    perm = list(range(self_rank))
+    perm.remove(dim1)
+    perm.remove(dim2)
+    perm.append(dim1)
+    perm.append(dim2)
+
+    # If rank=2, then axes=[0]; if rank=3, then axes=[1]
+    # This is because computing diagonal sum is on dim2 after transpose by perm
+    axes = [self_rank - 2]
+
+    neg_1 = op.Constant(value_ints=[-1])
+    dim1_size = op.Reshape(op.Gather(op.Shape(self), dim1), neg_1)  # row
+    dim2_size = op.Reshape(op.Gather(op.Shape(self), dim2), neg_1)  # col
+    mask_shape = op.Concat(dim1_size, dim2_size, axis=0)
+    mask = op.EyeLike(op.ConstantOfShape(mask_shape), k=offset)
+    mask = op.CastLike(mask, self)
+    self_t = op.Transpose(self, perm=perm)
+    result = op.Mul(self_t, mask)
+    result = op.ReduceSum(result, keepdims=False, axes=axes)
+    # min(row, col)
+    min_dim_size = op.Min(dim1_size, dim2_size)
+    # take 2 tensors as example:
+    # one is 3x5 in size, min_dim_size = 3, dim1_size = 3
+    # the other is 5x3 in size, min_dim_size = 3, dim1_size = 5
+    # 3 rows x 5 cols     5 rows x 3 cols
+    # offset  diagonal    offset  diagonal
+    # ----------------    ----------------
+    # -4      0           -6      0
+    # -3      0           -5      0
+    # -2      1           -4      1
+    # -1      2           -3      2
+    # 0       3           -2      3
+    # 1       3           -1      3
+    # 2       3           0       3
+    # 3       2           1       2
+    # 4       1           2       1
+    # 5       0           3       0
+    # 6       0           4       0
+
+    # From above table, we can get the logic below
+    offset_val = op.Constant(value_ints=[offset])
+    if offset < 0:
+        # row + offset
+        length = op.Add(dim1_size, offset_val)
+        start = op.Constant(value_ints=[0])
+    else:  # offset >= 0
+        # col - offset
+        length = op.Sub(dim2_size, offset_val)
+        start = offset_val
+
+    # max(min(length, min(row, col)), 0)
+    length = op.Max(op.Min(length, min_dim_size), op.Constant(value_ints=[0]))
+    end = op.Add(start, length)
+    result = op.Slice(result, start, end, axes=axes)
+
+    return result
+
+
+@onnx_impl(aten.diagonal.default, trace_only=True)
+def aten_diagonal_bool(
+    self: BOOL, offset: int = 0, dim1: int = 0, dim2: int = 1
+) -> BOOL:
+    """diagonal(Tensor(a) self, int offset=0, int dim1=0, int dim2=1) -> Tensor(a)"""
+
+    # perm is used to transpose the tensor to make dim1 and dim2 as the last 2 dims
+    # [0,1,2] -> [2,0,1] when dim1=0 and dim2=1
+    # [0,1,2] -> [1,0,2] when dim1=0 and dim2=2
+    # [0,1,2] -> [0,1,2] when dim1=1 and dim2=2
+    if dim1 < 0:
+        dim1 = dim1 + len(self.shape)
+    if dim2 < 0:
+        dim2 = dim2 + len(self.shape)
+
+    self_rank = len(self.shape)
+    perm = list(range(self_rank))
+    perm.remove(dim1)
+    perm.remove(dim2)
+    perm.append(dim1)
+    perm.append(dim2)
+
+    # If rank=2, then axes=[0]; if rank=3, then axes=[1]
+    # This is because computing diagonal sum is on dim2 after transpose by perm
+    axes = [self_rank - 2]
+
+    neg_1 = op.Constant(value_ints=[-1])
+    dim1_size = op.Reshape(op.Gather(op.Shape(self), dim1), neg_1)  # row
+    dim2_size = op.Reshape(op.Gather(op.Shape(self), dim2), neg_1)  # col
+    mask_shape = op.Concat(dim1_size, dim2_size, axis=0)
+    mask = op.EyeLike(op.ConstantOfShape(mask_shape), k=offset)
+    self_int = op.Cast(self, to=INT64.dtype)
+    mask_int = op.Cast(mask, to=INT64.dtype)
+    self_int_t = op.Transpose(self_int, perm=perm)
+    result = op.Mul(self_int_t, mask_int)
+    result = op.ReduceSum(result, keepdims=False, axes=axes)
+    # min(row, col)
+    min_dim_size = op.Min(dim1_size, dim2_size)
+    # take 2 tensors as example:
+    # one is 3x5 in size, min_dim_size = 3, dim1_size = 3
+    # the other is 5x3 in size, min_dim_size = 3, dim1_size = 5
+    # 3 rows x 5 cols     5 rows x 3 cols
+    # offset  diagonal    offset  diagonal
+    # ----------------    ----------------
+    # -4      0           -6      0
+    # -3      0           -5      0
+    # -2      1           -4      1
+    # -1      2           -3      2
+    # 0       3           -2      3
+    # 1       3           -1      3
+    # 2       3           0       3
+    # 3       2           1       2
+    # 4       1           2       1
+    # 5       0           3       0
+    # 6       0           4       0
+
+    # From above table, we can get the logic below
+    offset_val = op.Constant(value_ints=[offset])
+    if offset < 0:
+        # row + offset
+        length = op.Add(dim1_size, offset_val)
+        start = op.Constant(value_ints=[0])
+    else:  # offset >= 0
+        # col - offset
+        length = op.Sub(dim2_size, offset_val)
+        start = offset_val
+
+    # max(min(length, min(row, col)), 0)
+    length = op.Max(op.Min(length, min_dim_size), op.Constant(value_ints=[0]))
+    end = op.Add(start, length)
+    result = op.Slice(result, start, end, axes=axes)
+    result = op.Cast(result, to=BOOL.dtype)
+
+    return result
+
+
+def aten_diagonal_backward(
+    grad_output: TensorType, input_sizes: INT64, offset: int, dim1: int, dim2: int
+) -> TensorType:
+    """diagonal_backward(Tensor grad_output, SymInt[] input_sizes, int offset, int dim1, int dim2) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_diagonal_copy(
+    self: TensorType, offset: int = 0, dim1: int = 0, dim2: int = 1
+) -> TensorType:
+    """diagonal_copy(Tensor self, int offset=0, int dim1=0, int dim2=1) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_diagonal_scatter(
+    self: TensorType, src: TensorType, offset: int = 0, dim1: int = 0, dim2: int = 1
+) -> TensorType:
+    """diagonal_scatter(Tensor self, Tensor src, int offset=0, int dim1=0, int dim2=1) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_diff(
+    self: TensorType,
+    n: int = 1,
+    dim: int = -1,
+    prepend: Optional[TensorType] = None,
+    append: Optional[TensorType] = None,
+) -> TensorType:
+    """diff(Tensor self, int n=1, int dim=-1, Tensor? prepend=None, Tensor? append=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_digamma(self: TensorType) -> TensorType:
+    """digamma(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_dist(self: TensorType, other: TensorType, p: float = 2.0) -> TensorType:
+    """dist(Tensor self, Tensor other, Scalar p=2) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(
+    (
+        aten.div.Tensor,
+        aten.div.Scalar,
+        # When rounding_mode is None, performs a true division
+        # https://pytorch.org/docs/stable/generated/torch.div.html
+        aten.div.Tensor_mode,
+        aten.div.Scalar_mode,
+        aten.divide.Tensor,
+        aten.divide.Scalar,
+        aten.true_divide.Tensor,
+        aten.true_divide.Scalar,
+    )
+)
+def aten_div(self: TFloat, other: TFloat) -> TFloat:
+    """div.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    # Int inputs will be promoted to float by PyTorch
+    return op.Div(self, other)
+
+
+@onnx_impl(operator.truediv, trace_only=True)
+def operator_truediv(self: TensorType, other: TensorType) -> FLOAT:
+    return op.Div(op.Cast(self, to=FLOAT.dtype), op.Cast(other, to=FLOAT.dtype))
+
+
+@onnx_impl(
+    (
+        aten.div.Tensor,
+        aten.div.Scalar,
+        aten.divide.Tensor,
+        aten.divide.Scalar,
+        aten.true_divide.Tensor,
+        aten.true_divide.Scalar,
+    ),
+    complex=True,
+)
+def aten_div_complex(self: TFloat, other: TFloat) -> TFloat:
+    """div.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    # Complex division. PyTorch type promotion ensures both arguments are complex numbers
+    self_real = op.Slice(self, [0], [1], axes=[-1])
+    self_imag = op.Slice(self, [1], [2], axes=[-1])
+    other_real = op.Slice(other, [0], [1], axes=[-1])
+    other_imag = op.Slice(other, [1], [2], axes=[-1])
+
+    # Complex division
+    # (a + bi) / (c + di) = (ac + bd) / (c^2 + d^2) + (bc - ad) / (c^2 + d^2)i
+    # https://mathworld.wolfram.com/ComplexDivision.html
+    ac = op.Mul(self_real, other_real)
+    bd = op.Mul(self_imag, other_imag)
+    bc = op.Mul(self_imag, other_real)
+    ad = op.Mul(self_real, other_imag)
+    denominator = op.Add(op.Mul(other_real, other_real), op.Mul(other_imag, other_imag))
+    real = op.Div(ac + bd, denominator)
+    imag = op.Div(bc - ad, denominator)
+
+    return op.Concat(real, imag, axis=-1)
+
+
+@onnx_impl((aten.div.Tensor_mode, aten.div.Scalar_mode), trace_only=True)
+def aten_div_mode(self: TFloat, other: TFloat, rounding_mode: str) -> TFloat:
+    """div.Tensor_mode(Tensor self, Tensor other, *, str? rounding_mode) -> Tensor"""
+
+    # TODO(justinchuby): trace_only=False when we use opset19 which supports string comparison
+    assert rounding_mode in {"trunc", "floor"}
+
+    if rounding_mode == "trunc":
+        # Rounds the results of the division towards zero.
+        # Equivalent to C-style integer division
+        result = aten_trunc(op.Div(self, other))
+    else:  # rounding_mode == "floor"
+        result = op.Floor(op.Div(self, other))
+
+    return result
+
+
+@onnx_impl((aten.div.Tensor_mode, aten.div.Scalar_mode), trace_only=True)
+def aten_div_mode_int(self: TInt, other: TInt, rounding_mode: str) -> TInt:
+    """div.Tensor_mode(Tensor self, Tensor other, *, str? rounding_mode) -> Tensor
+
+    Variant for integer inputs.
+    """
+    # TODO(justinchuby): trace_only=False when we use opset19 which supports string comparison
+    assert rounding_mode in {"trunc", "floor"}
+
+    quotient = op.Div(op.Cast(self, to=FLOAT.dtype), op.Cast(other, to=FLOAT.dtype))
+
+    if rounding_mode == "trunc":
+        # Rounds the results of the division towards zero.
+        # Equivalent to C-style integer division
+        result = aten_trunc(quotient)
+    else:  # rounding_mode == "floor"
+        result = op.Floor(quotient)
+
+    return op.CastLike(result, self)
+
+
+@onnx_impl(aten.dot.default, trace_only=True)
+def aten_dot(self: TFloat, tensor: TFloat) -> TFloat:
+    """dot(Tensor self, Tensor tensor) -> Tensor"""
+
+    return op.MatMul(self, tensor)
+
+
+@onnx_impl(aten.dropout.default, trace_only=True)
+def aten_dropout(input: TFloat, p: FLOAT, train: BOOL) -> TFloat:
+    """dropout(Tensor input, float p, bool train) -> Tensor"""
+
+    if len(input.shape) == 0:
+        input = op.Reshape(input, op.Constant(value_ints=[-1]))
+        result, _ = op.Dropout(input, p, train)
+        result = op.Squeeze(result)
+    else:
+        result, _ = op.Dropout(input, p, train)
+
+    return result
+
+
+def aten_dstack(tensors: Sequence[TensorType]) -> TensorType:
+    """dstack(Tensor[] tensors) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.einsum.default, trace_only=True)
+def aten_einsum(
+    equation: str,
+    tensors: Sequence[TReal],
+    path: Optional[int] = None,
+) -> TReal:
+    """einsum(str equation, Tensor[] tensors, *, int[]? path=None) -> Tensor"""
+
+    # Use trace_only to unpack the `tensors` sequence
+    return op.Einsum(*tensors, equation=equation)
+
+
+@onnx_impl(aten.embedding.default, trace_only=True)
+def aten_embedding(
+    weight: TTensor,
+    indices: TInt,
+    padding_idx: int = -1,
+    scale_grad_by_freq: bool = False,
+    sparse: bool = False,
+) -> TTensor:
+    # embedding(Tensor weight, Tensor indices, int padding_idx=-1, bool scale_grad_by_freq=False, bool sparse=False) -> Tensor
+
+    return op.Gather(weight, indices)
+
+
+def aten_embedding_backward(
+    grad: TensorType,
+    indices: TensorType,
+    num_weights: INT64,
+    padding_idx: int,
+    scale_grad_by_freq: bool,
+    sparse: bool,
+) -> TensorType:
+    """embedding_backward(Tensor grad, Tensor indices, SymInt num_weights, int padding_idx, bool scale_grad_by_freq, bool sparse) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.embedding_bag.default, trace_only=True)
+def aten_embedding_bag(
+    weight: TFloat,
+    indices: INT64,
+    offsets: INT64,
+    scale_grad_by_freq: bool = False,
+    mode: int = 0,  # [0,1,2] indicate ["sum", "mean", "max"]
+    sparse: bool = False,
+    per_sample_weights: Optional[TFloat] = None,
+    include_last_offset: bool = False,
+) -> Tuple[TFloat, TFloat, TFloat, TFloat]:
+    """embedding_bag(Tensor weight, Tensor indices, Tensor offsets, bool scale_grad_by_freq=False, int mode=0, bool sparse=False, Tensor? per_sample_weights=None, bool include_last_offset=False) -> (Tensor, Tensor, Tensor, Tensor)"""
+
+    # assert(rank(indices) in [1,2])
+    # assert(rank(offsets) == 1)
+    # assert(op.Size(per_sample_weights) == op.Size(indices))
+    if per_sample_weights is None:
+        # Set per_sample_weights to 1.0, because cannot check 'None' in ONNX-Script
+        # Size of persample_weights is the same as indices, and should be 1d tensor
+        indices_1d = op.Reshape(indices, [-1])
+        per_sample_weights = op.Expand(1, op.Shape(indices_1d))
+        # Dtype of per_sample_weights is the same as weight
+        per_sample_weights = op.CastLike(per_sample_weights, weight)
+
+    result, offset2bag, bag_size, max_indices = _aten_embedding_bag_onnx(
+        weight, indices, offsets, mode, per_sample_weights, include_last_offset
+    )
+    return result, offset2bag, bag_size, max_indices
+
+
+@onnx_impl(aten.embedding_bag.default, private=True)
+def _aten_embedding_bag_onnx(
+    weight: TFloat,
+    indices: INT64,
+    offsets: INT64,
+    mode: int,
+    per_sample_weights: TFloat,
+    include_last_offset: bool,
+) -> Tuple[TFloat, TFloat, TFloat, TFloat]:
+    neg_1 = op.Constant(value_ints=[-1])
+    # Assume indices is shape(5,2), indices_1d is shape(10,)
+    indices_1d = op.Reshape(indices, neg_1)
+    # Get weight out according to indices_1d,
+    new_weight = op.Gather(weight, indices_1d)
+    # This happends after first step of Gather. Because Shape(indices)==Shape(per_sample_weights)
+    new_weight = op.Mul(new_weight, op.Unsqueeze(per_sample_weights, axes=1))
+    weight_dim_1 = op.Reshape(op.Shape(weight, start=1), neg_1)
+    indices_size = op.Shape(indices_1d)
+
+    # Assume indices is shape(5,2) reshape to (10,), offsets=[0,2,3], include_last_offset = False
+    # [0,2,3] -> [0:2], [2:3], [3:10]
+    num_bag = op.Size(offsets)  # 3 bags, means 10 is the last index
+    if op.Equal(include_last_offset, True):
+        num_bag = num_bag - 1  # 2 bags, means 3 is the last index
+    else:
+        offsets = op.Concat(offsets, indices_size, axis=0)  # Replace end with number
+
+    # The element in sequence must be FLOAT32 dtype due to ORT bug
+    new_weight = op.Cast(new_weight, to=FLOAT.dtype)
+    # FIXME: https://github.com/microsoft/onnxruntime/issues/16846
+    result = op.SequenceEmpty()
+
+    index_tensor = op.Constant(value_int=0)  # Used for iterator
+    cond = index_tensor < num_bag
+    # Process each bag
+    while cond:
+        slice_index = op.Reshape(index_tensor, neg_1)
+        start = op.Slice(offsets, slice_index, slice_index + 1)
+        end = op.Slice(offsets, slice_index + 1, slice_index + 2)
+        # row_result should be 0, need to generate (1,N) shape tensor with 0 values
+        if start == end:
+            row_result = op.Expand(
+                op.Constant(value_floats=[0.0]),
+                op.Concat(op.Constant(value_ints=[1]), weight_dim_1, axis=0),
+            )
+        else:
+            if mode == 0:  # sum
+                weight_rows = op.Slice(new_weight, start, end)
+                row_result = op.ReduceSum(weight_rows, axes=[0])
+            elif mode == 1:  # mean
+                weight_rows = op.Slice(new_weight, start, end)
+                if op.Equal(index_tensor, num_bag - 1):  # The last bag
+                    row_result = op.ReduceSum(weight_rows, axes=[0])
+                    # When include_last_offset=False, offsets=[0,2,3] -> [0,2,3,10], denominator=10-3=7
+                    # When include_last_offset=True, offsets=[0,2,3], denominator=10-2=8
+                    denominator = op.Sub(op.Shape(indices, start=0, end=1), start)
+                    if op.Greater(denominator, 0):
+                        row_result = op.Div(
+                            row_result, op.CastLike(denominator, new_weight)
+                        )
+                else:
+                    row_result = op.ReduceMean(weight_rows, axes=[0])
+            else:  # max
+                if op.Equal(index_tensor, num_bag - 1):  # The last bag
+                    weight_rows = op.Slice(new_weight, start, indices_size)
+                else:
+                    weight_rows = op.Slice(new_weight, start, end)
+                row_result = op.ReduceMax(weight_rows, axes=[0])
+
+        result = op.SequenceInsert(result, row_result)
+        index_tensor = index_tensor + 1
+        cond = index_tensor < num_bag
+
+    result = op.ConcatFromSequence(result, axis=0)
+    result = op.CastLike(result, weight)
+
+    # Only compute the shape of other 3 outputs, we don't care the value
+    if mode == 0:  # sum
+        offset2bag = op.Shape(indices, start=0, end=0)  # Generate empty tensor
+        if op.Equal(include_last_offset, True):
+            bag_size = op.Expand(0, op.Shape(offsets))
+        else:
+            bag_size = op.Expand(0, op.Shape(offsets) - 1)
+        max_indices = op.Expand(0, op.Shape(bag_size))
+    elif mode == 1:  # mean
+        offset2bag = op.Expand(0, op.Shape(indices, start=0, end=1))
+        bag_size = op.Expand(0, op.Shape(offsets) - 1)
+        max_indices = op.Expand(0, op.Shape(bag_size))
+    else:  # max
+        offset2bag = op.Expand(0, op.Shape(indices, start=0, end=1))
+        bag_size = op.Expand(0, op.Shape(offsets) - 1)
+        # shape = (bag_size.dim[0], weight.dim[1])
+        dim_0 = op.Shape(bag_size, start=0, end=1)
+        dim_1 = op.Shape(weight, start=1, end=2)
+        max_indices = op.Expand(0, op.Concat(dim_0, dim_1, axis=0))
+
+    return result, offset2bag, bag_size, max_indices
+
+
+@onnx_impl(
+    (
+        aten.embedding_bag.padding_idx,
+        aten._embedding_bag.default,
+        aten._embedding_bag_forward_only.default,
+    ),
+    trace_only=True,
+)
+def aten_embedding_bag_padding_idx(
+    weight: TFloat,
+    indices: INT64,
+    offsets: INT64,
+    scale_grad_by_freq: bool = False,
+    mode: int = 0,  # [0,1,2] indicate ["sum", "mean", "max"]
+    sparse: bool = False,
+    per_sample_weights: Optional[TFloat] = None,
+    include_last_offset: bool = False,
+    padding_idx: int = -1,
+) -> Tuple[TFloat, TFloat, TFloat, TFloat]:
+    """embedding_bag.padding_idx(Tensor weight, Tensor indices, Tensor offsets, bool scale_grad_by_freq, int mode, bool sparse, Tensor? per_sample_weights, bool include_last_offset, int? padding_idx) -> (Tensor, Tensor, Tensor, Tensor)
+
+    We add default values for the attributes to accommodate _embedding_bag as well:
+    _embedding_bag(Tensor weight, Tensor indices, Tensor offsets, bool scale_grad_by_freq=False, int mode=0, bool sparse=False, Tensor? per_sample_weights=None, bool include_last_offset=False, int padding_idx=-1)
+    """
+    assert (
+        padding_idx is not None
+    ), "padding_idx must not be None. This is likely a dispatcher error"
+
+    if per_sample_weights is None:
+        per_sample_weights = op.Expand(
+            op.Constant(value_floats=[1.0]), op.Shape(indices)
+        )
+        per_sample_weights = op.CastLike(per_sample_weights, weight)
+
+    # Change padding_idx to positive value, -1 means the last index
+    if padding_idx < 0:
+        padding_idx = weight.shape[0] + padding_idx
+
+    result, offset2bag, bag_size, max_indices = _aten_embedding_bag_1d_padding_idx_onnx(
+        weight,
+        indices,
+        offsets,
+        mode,
+        per_sample_weights,
+        include_last_offset,
+        padding_idx,
+    )
+
+    return result, offset2bag, bag_size, max_indices
+
+
+@onnx_impl(aten.embedding_bag.padding_idx, private=True)
+def _aten_embedding_bag_1d_padding_idx_onnx(
+    weight: TFloat,
+    indices: INT64,
+    offsets: INT64,
+    mode: int,
+    per_sample_weights: TFloat,
+    include_last_offset: bool,
+    padding_idx: int,
+) -> Tuple[TFloat, TFloat, TFloat, TFloat]:
+    neg_1 = op.Constant(value_ints=[-1])
+    # Get weight out according to indices,
+    # e.g. indices=[3,1,4,5,3] means get weight[[3,1,4,5,3]]
+    indices_weight = op.Gather(weight, indices)
+    # This happends after first step of Gather. Because Shape(indices)==Shape(per_sample_weights)
+    indices_weight = op.Mul(indices_weight, op.Unsqueeze(per_sample_weights, axes=1))
+
+    # The element in sequence must be FLOAT32 dtype due to ORT bug
+    indices_weight = op.Cast(indices_weight, to=FLOAT.dtype)
+    # FIXME: https://github.com/microsoft/onnxruntime/issues/16846
+    result = op.SequenceEmpty()
+
+    num_bag = op.Size(offsets)
+    idx_size = op.Reshape(op.Size(indices), neg_1)
+
+    if op.Equal(include_last_offset, True):
+        num_bag = num_bag - 1
+        # Change(by ScatterElement setting) the last element to 'end'
+        # [0,2,3] -> [0,2,end]
+        offsets = op.ScatterElements(offsets, [-1], idx_size)
+    else:
+        # Change [0,2,3] -> [0,2,3,end], means [0:2],[2:3],[3:end]
+        offsets = op.Concat(offsets, idx_size, axis=0)
+
+    # Process each bag
+    i = op.Constant(value_int=0)  # Used for iterator
+    cond_1 = i < num_bag
+    while cond_1:
+        start_pos = op.Gather(offsets, i)
+        end_pos = op.Gather(offsets, i + 1)
+        # empty tensor
+        curr_offsets = op.Shape(indices, start=0, end=0)
+        j = start_pos
+        cond_2 = j < end_pos
+        while cond_2:
+            index = op.Gather(indices, j)
+            if not op.Equal(index, padding_idx):
+                # Something like the 'append' operation
+                curr_offsets = op.Concat(curr_offsets, op.Reshape(j, neg_1), axis=0)
+            j = j + 1
+            cond_2 = j < end_pos
+
+        # Empty input get zero value output, not empty output
+        if op.Size(curr_offsets) == 0:
+            dim_1 = op.Shape(weight, start=1, end=2)
+            expand_shape = op.Concat([1], dim_1, axis=0)
+            row_result = op.Expand([0.0], expand_shape)
+        else:
+            row_weight = op.Gather(indices_weight, curr_offsets)
+            if mode == 0:  # sum
+                row_result = op.ReduceSum(row_weight, axes=[0])
+            elif mode == 1:  # mean
+                row_result = op.ReduceMean(row_weight, axes=[0])
+            else:
+                row_result = op.ReduceMax(row_weight, axes=[0])
+
+        result = op.SequenceInsert(result, row_result)
+
+        i = i + 1
+        cond_1 = i < num_bag
+
+    result = op.ConcatFromSequence(result, axis=0)
+    result = op.CastLike(result, weight)
+
+    if mode == 0:  # sum
+        offset2bag = op.Expand(0, op.Shape(indices))
+        if op.Equal(include_last_offset, True):
+            bag_size = op.Expand(0, op.Shape(offsets))
+        else:
+            bag_size = op.Expand(0, op.Shape(offsets) - 1)
+        max_indices = op.Expand(0, op.Shape(bag_size))
+    elif mode == 1:  # mean
+        offset2bag = op.Expand(0, op.Shape(indices, start=0, end=1))
+        bag_size = op.Expand(0, op.Shape(offsets) - 1)
+        max_indices = op.Expand(0, op.Shape(bag_size))
+    else:  # mode == 2, max
+        offset2bag = op.Expand(0, op.Shape(indices, start=0, end=1))
+        bag_size = op.Expand(0, op.Shape(offsets) - 1)
+        # shape = (bag_size.dim[0], weight.dim[1])
+        dim_0 = op.Shape(bag_size, start=0, end=1)
+        dim_1 = op.Shape(weight, start=1, end=2)
+        max_indices = op.Expand(0, op.Concat(dim_0, dim_1, axis=0))
+
+    return result, offset2bag, bag_size, max_indices
+
+
+def aten_embedding_dense_backward(
+    grad_output: TensorType,
+    indices: TensorType,
+    num_weights: INT64,
+    padding_idx: int,
+    scale_grad_by_freq: bool,
+) -> TensorType:
+    """embedding_dense_backward(Tensor grad_output, Tensor indices, SymInt num_weights, int padding_idx, bool scale_grad_by_freq) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.embedding_renorm.default, trace_only=True)
+def aten_embedding_renorm(
+    weight: TFloat, indices: INT64, max_norm: float, norm_type: float = 2.0
+) -> TFloat:
+    """embedding_renorm(Tensor weight, Tensor indices, float max_norm, float norm_type) -> Tensor"""
+
+    unique_indices, _, _, _ = op.Unique(indices)
+    partial_weight = op.Gather(weight, unique_indices)
+    # partial_weight_norm = sum(|w|^p)^(1/p)
+    if norm_type == 1.0:
+        # This is not necessary, but op.ReduceL1 is faster than function list in 'else'
+        partial_weight_norm = op.ReduceL1(partial_weight, axes=[1], keepdims=True)
+    elif norm_type == 2.0:
+        # This is not necessary, but op.ReduceL2 is faster than function list in 'else'
+        partial_weight_norm = op.ReduceL2(partial_weight, axes=[1], keepdims=True)
+    else:
+        # Abs -> Pow -> ReduceSum -> Pow -> Pow
+        partial_weight_abs = op.Abs(partial_weight)
+        partial_weight_pow = op.Pow(
+            partial_weight_abs, op.Constant(value_float=norm_type)
+        )
+        partial_weight_norm = op.ReduceSum(partial_weight_pow, axes=[1], keepdims=True)
+        pow_value = op.CastLike(1.0 / norm_type, weight)
+        partial_weight_norm = op.Pow(partial_weight_norm, pow_value)
+
+    max_norm = op.CastLike(op.Constant(value_float=max_norm), weight)
+    # This is to avoid weight is zero
+    err = op.CastLike(op.Constant(value_float=1e-7), weight)
+    partial_weight_norm_ = op.Add(partial_weight_norm, err)
+    scales = op.Div(max_norm, partial_weight_norm_)
+    partial_weight_renorm = op.Mul(partial_weight, scales)
+    # Set values to renormed values where weight_norm > max_norm, but keep the original values where weight_norm <= max_norm
+    partial_weight_renorm = op.Where(
+        op.Greater(partial_weight_norm, max_norm), partial_weight_renorm, partial_weight
+    )
+    value = op.ScatterND(
+        weight, op.Unsqueeze(unique_indices, [1]), partial_weight_renorm
+    )
+    return value
+
+
+def aten_embedding_sparse_backward(
+    grad: TensorType,
+    indices: TensorType,
+    num_weights: int,
+    padding_idx: int,
+    scale_grad_by_freq: bool,
+) -> TensorType:
+    """embedding_sparse_backward(Tensor grad, Tensor indices, int num_weights, int padding_idx, bool scale_grad_by_freq) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.empty.memory_format, trace_only=True)
+def aten_empty(
+    size: IntType,
+    dtype: int = FLOAT.dtype,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+    memory_format: str = "",
+) -> TensorType:  # type: ignore[type-var]
+    # empty(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+    if dtype == -1:
+        dtype = FLOAT.dtype
+    # using Zeros to simulate np.empty()
+    size = op.Cast(size, to=INT64.dtype)
+    zero = op.Constant(value_float=0.0)
+    zero = op.Cast(zero, to=dtype)
+
+    return op.Expand(zero, size)
+
+
+@onnx_impl(aten.empty_like.default, trace_only=True)
+def aten_empty_like(
+    self: TTensor,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+    memory_format: str = "",
+) -> TTensor:
+    """empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor"""
+
+    if dtype == -1 or dtype is None:
+        zero = op.CastLike(0, self)
+    else:
+        zero = op.Cast(0, to=dtype)
+
+    shape = op.Shape(self)
+    return op.Expand(zero, shape)
+
+
+def aten_empty_quantized(
+    size: Sequence[int], qtensor: TensorType, memory_format: Optional[str] = None
+) -> TensorType:
+    """empty_quantized(int[] size, Tensor qtensor, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.empty_strided.default, trace_only=True)
+def aten_empty_strided(
+    size: INT64,
+    stride: INT64,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TTensor:  # type: ignore[type-var]
+    # empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+
+    # using Zeros to simulate empty()
+    size = op.Cast(size, to=INT64.dtype)
+    zero = op.Constant(value_float=0.0)
+
+    return op.Expand(zero, size)
+
+
+@onnx_impl(
+    (aten.eq.default, aten.eq.Tensor, aten.eq.Scalar, operator.eq), trace_only=True
+)
+def aten_eq(self: TTensor, other: TTensor) -> BOOL:
+    """eq.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Equal(self, other)
+
+
+@onnx_impl(aten.equal.default, trace_only=True)
+def aten_equal(self: TTensor, other: TTensor) -> BOOL:
+    """equal(Tensor self, Tensor other) -> bool"""
+
+    # NOTE: Torch aten::equal returns a single Boolean while ONNX Equal is elementwise.
+    # The equivalent Torch op with ONNX Equal is aten::eq.
+    elementwise_equal = op.Equal(self, other)
+    elementwise_equal_int = op.Cast(elementwise_equal, to=INT64.dtype)
+    # ReduceMin does not support bool. So we cast to int64
+    all_equal = op.ReduceMin(elementwise_equal_int, keepdims=False)
+    return op.Cast(all_equal, to=BOOL.dtype)
+
+
+def aten_erfinv(self: TensorType) -> TensorType:
+    """erfinv(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.exp.default)
+def aten_exp(self: TFloat) -> TFloat:
+    """exp(Tensor self) -> Tensor"""
+
+    return op.Exp(self)
+
+
+@onnx_impl(aten.exp2.default, trace_only=True)
+def aten_exp2(self: TFloat) -> TFloat:
+    """exp2(Tensor self) -> Tensor"""
+
+    two = op.Constant(value_int=2)
+    two = op.CastLike(two, self)
+    return op.Pow(two, self)
+
+
+@onnx_impl(aten.expand.default)
+def aten_expand(self: TTensor, size: TInt) -> TTensor:
+    """expand(Tensor(a) self, SymInt[] size, *, bool implicit=False) -> Tensor(a)"""
+    size = op.Cast(size, to=INT64.dtype)
+    # NOTE: PyTorch supports `not changing dim` by -1, but ONNX supports `not changing dim` by 1.
+    # To support -1 dim, we need to convert -1 to 1.
+    size = op.Abs(size)
+    return op.Expand(self, size)
+
+
+@onnx_impl(aten.expand_as.default, trace_only=True)
+def aten_expand_as(self: TTensor, other: TTensor) -> TTensor:
+    """expand_as(Tensor(a) self, Tensor other) -> Tensor(a)"""
+
+    shape = op.Shape(other)
+    result = op.Expand(self, shape)
+    return result
+
+
+def aten_expand_copy(
+    self: TensorType, size: INT64, implicit: bool = False
+) -> TensorType:
+    """expand_copy(Tensor self, SymInt[] size, *, bool implicit=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_eye(n: int) -> TensorType:
+    """eye(int n, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fake_quantize_per_channel_affine(
+    self: TensorType,
+    scale: TensorType,
+    zero_point: TensorType,
+    axis: int,
+    quant_min: int,
+    quant_max: int,
+) -> TensorType:
+    """fake_quantize_per_channel_affine(Tensor self, Tensor scale, Tensor zero_point, int axis, int quant_min, int quant_max) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fake_quantize_per_channel_affine_cachemask(
+    self: TensorType,
+    scale: TensorType,
+    zero_point: TensorType,
+    axis: int,
+    quant_min: int,
+    quant_max: int,
+) -> tuple[TensorType, TensorType]:
+    """fake_quantize_per_channel_affine_cachemask(Tensor self, Tensor scale, Tensor zero_point, int axis, int quant_min, int quant_max) -> (Tensor output, Tensor mask)"""
+
+    raise NotImplementedError
+
+
+def aten_fake_quantize_per_channel_affine_cachemask_backward(
+    grad: TensorType, mask: TensorType
+) -> TensorType:
+    """fake_quantize_per_channel_affine_cachemask_backward(Tensor grad, Tensor mask) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fake_quantize_per_tensor_affine(
+    self: TensorType, scale: float, zero_point: int, quant_min: int, quant_max: int
+) -> TensorType:
+    """fake_quantize_per_tensor_affine(Tensor self, float scale, int zero_point, int quant_min, int quant_max) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fake_quantize_per_tensor_affine_cachemask(
+    self: TensorType, scale: float, zero_point: int, quant_min: int, quant_max: int
+) -> tuple[TensorType, TensorType]:
+    """fake_quantize_per_tensor_affine_cachemask(Tensor self, float scale, int zero_point, int quant_min, int quant_max) -> (Tensor output, Tensor mask)"""
+
+    raise NotImplementedError
+
+
+def aten_fake_quantize_per_tensor_affine_cachemask_backward(
+    grad: TensorType, mask: TensorType
+) -> TensorType:
+    """fake_quantize_per_tensor_affine_cachemask_backward(Tensor grad, Tensor mask) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fbgemm_linear_fp16_weight(
+    input: TensorType, packed_weight: TensorType, bias: TensorType
+) -> TensorType:
+    """fbgemm_linear_fp16_weight(Tensor input, Tensor packed_weight, Tensor bias) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fbgemm_linear_fp16_weight_fp32_activation(
+    input: TensorType, packed_weight: TensorType, bias: TensorType
+) -> TensorType:
+    """fbgemm_linear_fp16_weight_fp32_activation(Tensor input, Tensor packed_weight, Tensor bias) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fbgemm_linear_int8_weight(
+    input: TensorType,
+    weight: TensorType,
+    packed: TensorType,
+    col_offsets: TensorType,
+    weight_scale: float,
+    weight_zero_point: float,
+    bias: TensorType,
+) -> TensorType:
+    """fbgemm_linear_int8_weight(Tensor input, Tensor weight, Tensor packed, Tensor col_offsets, Scalar weight_scale, Scalar weight_zero_point, Tensor bias) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fbgemm_linear_int8_weight_fp32_activation(
+    input: TensorType,
+    weight: TensorType,
+    packed: TensorType,
+    col_offsets: TensorType,
+    weight_scale: float,
+    weight_zero_point: float,
+    bias: TensorType,
+) -> TensorType:
+    """fbgemm_linear_int8_weight_fp32_activation(Tensor input, Tensor weight, Tensor packed, Tensor col_offsets, Scalar weight_scale, Scalar weight_zero_point, Tensor bias) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fbgemm_linear_quantize_weight(
+    input: TensorType,
+) -> tuple[TensorType, TensorType, float, int]:
+    """fbgemm_linear_quantize_weight(Tensor input) -> (Tensor, Tensor, float, int)"""
+
+    raise NotImplementedError
+
+
+def aten_fbgemm_pack_gemm_matrix_fp16(input: TensorType) -> TensorType:
+    """fbgemm_pack_gemm_matrix_fp16(Tensor input) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fbgemm_pack_quantized_matrix(input: TensorType) -> TensorType:
+    """fbgemm_pack_quantized_matrix(Tensor input) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_feature_alpha_dropout(input: TensorType, p: float, train: bool) -> TensorType:
+    """feature_alpha_dropout(Tensor input, float p, bool train) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_feature_dropout(input: TensorType, p: float, train: bool) -> TensorType:
+    """feature_dropout(Tensor input, float p, bool train) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl((aten.fill.Tensor, aten.fill.Scalar))
+def aten_fill(self: TTensor, value: TTensor2) -> TTensor:
+    """fill.Tensor(Tensor self, Tensor value) -> Tensor"""
+
+    # Cast the value before Expand so it can be constant folded
+    value = op.CastLike(value, self)
+    shape = op.Shape(self)
+    return op.Expand(value, shape)
+
+
+def aten_fix(self: TensorType) -> TensorType:
+    """fix(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+# aten_flatten is decomposed by PyTorch
+def aten_flatten(self: TTensor, start_dim: int = 0, end_dim: int = -1) -> TTensor:
+    """flatten.using_ints(Tensor(a) self, int start_dim=0, int end_dim=-1) -> Tensor(a)"""
+    raise NotImplementedError
+
+
+@onnx_impl(aten.flip.default, trace_only=True)
+def aten_flip(self: TTensor, dims: Sequence[int]) -> TTensor:
+    """flip(Tensor self, int[] dims) -> Tensor"""
+
+    if not dims:
+        # Nothing to flip
+        return op.Identity(self)
+
+    rank = len(dims)
+    starts = op.Constant(value_ints=[-1] * rank)  # something like [-1, -1, -1]
+    steps = starts  # something like [-1, -1, -1]
+    ends = op.Constant(
+        value_ints=[_INT64_MIN] * rank
+    )  # something like [-xxx, -xxx, -xxx]
+    dims = op.Constant(value_ints=dims)
+    return op.Slice(self, starts, ends, dims, steps)
+
+
+def aten_fliplr(self: TensorType) -> TensorType:
+    """fliplr(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_flipud(self: TensorType) -> TensorType:
+    """flipud(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.floor.default, trace_only=True)
+def aten_floor(self: TFloat) -> TFloat:
+    """floor(Tensor self) -> Tensor"""
+
+    return op.Floor(self)
+
+
+@onnx_impl("math::floor", trace_only=True)
+def python_math_floor(self: TFloat) -> TInt:
+    """floor(Tensor self) -> Tensor"""
+    floor = op.Floor(self)
+    return op.Cast(floor, to=INT64.dtype)
+
+
+@onnx_impl(aten.floor_divide.default, trace_only=True)
+def aten_floor_divide(self: TFloat, other: TFloat) -> TFloat:
+    """floor_divide(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Floor(op.Div(self, other))
+
+
+@onnx_impl(operator.floordiv, trace_only=True)
+def operator_floordiv(self: INT64, other: INT64) -> INT64:
+    # We implement floor_divide only for positive inputs (using integer division)
+    # because that is the usual intended case and is the most efficient.
+    return op.Div(self, other)
+
+
+def aten_fmax(self: TensorType, other: TensorType) -> TensorType:
+    """fmax(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fmin(self: TensorType, other: TensorType) -> TensorType:
+    """fmin(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl((aten.fmod.Tensor, aten.fmod.Scalar), trace_only=True)
+def aten_fmod(self: TRealOrUInt8, other: TRealOrUInt8) -> TRealOrUInt8:
+    """fmod.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Mod(self, other, fmod=1)
+
+
+@onnx_impl(aten.frac.default, trace_only=True)
+def aten_frac(self: TFloat) -> TFloat:
+    """frac(Tensor self) -> Tensor
+
+    Computes the fractional portion of each element in input.
+    """
+
+    # https://pytorch.org/docs/stable/generated/torch.frac.html
+    return op.Sub(self, op.Mul(op.Floor(op.Abs(self)), op.Sign(self)))
+
+
+def aten_frexp(self: TensorType) -> tuple[TensorType, TensorType]:
+    """frexp.Tensor(Tensor self) -> (Tensor mantissa, Tensor exponent)"""
+
+    raise NotImplementedError
+
+
+def aten_frobenius_norm(self: TensorType) -> TensorType:
+    """frobenius_norm(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_from_file(
+    filename: str, shared: Optional[bool] = None, size: Optional[int] = 0
+) -> TensorType:
+    """from_file(str filename, bool? shared=None, int? size=0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.full.default, trace_only=True)
+def aten_full(
+    size: Union[INT64, INT32],
+    fill_value: TensorType,
+    dtype: int = FLOAT.dtype,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TensorType:
+    """full(SymInt[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    if dtype != -1:
+        fill_value = op.Cast(fill_value, to=dtype)
+
+    size = op.Cast(size, to=INT64.dtype)
+    return op.Expand(fill_value, size)
+
+
+@onnx_impl(aten.full_like.default, trace_only=True)
+def aten_full_like(
+    self: TensorType,
+    fill_value: TensorType,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TensorType:
+    """full_like(Tensor self, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor"""
+
+    if dtype == -1:
+        fill_value = op.CastLike(fill_value, self)
+    else:
+        fill_value = op.Cast(fill_value, to=dtype)
+
+    self_shape = op.Shape(self)
+    return op.Expand(fill_value, self_shape)
+
+
+def aten_fused_moving_avg_obs_fake_quant(
+    self: TensorType,
+    observer_on: TensorType,
+    fake_quant_on: TensorType,
+    running_min: TensorType,
+    running_max: TensorType,
+    scale: TensorType,
+    zero_point: TensorType,
+    averaging_const: float,
+    quant_min: int,
+    quant_max: int,
+    ch_axis: int,
+    per_row_fake_quant: bool = False,
+    symmetric_quant: bool = False,
+) -> TensorType:
+    """fused_moving_avg_obs_fake_quant(Tensor self, Tensor observer_on, Tensor fake_quant_on, Tensor(a!) running_min, Tensor(b!) running_max, Tensor(c!) scale, Tensor(d!) zero_point, float averaging_const, int quant_min, int quant_max, int ch_axis, bool per_row_fake_quant=False, bool symmetric_quant=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.gather.default, trace_only=True)
+def aten_gather(
+    self: TReal,
+    dim: int,
+    index: TInt,
+    sparse_grad: bool = False,
+) -> TReal:
+    """gather(Tensor self, int dim, Tensor index, *, bool sparse_grad=False) -> Tensor"""
+
+    if len(self.shape) == 0:
+        if len(index.shape) == 0:
+            return op.Identity(self)
+        else:
+            return op.Expand(self, op.Shape(index))
+
+    if len(index.shape) == 0:
+        return op.Identity(self)
+
+    index = op.Cast(index, to=INT64.dtype)
+    result = op.GatherElements(self, index, axis=dim)
+    return result
+
+
+def aten_gather_backward(
+    grad: TensorType, self: TensorType, dim: int, index: TensorType, sparse_grad: bool
+) -> TensorType:
+    """gather_backward(Tensor grad, Tensor self, int dim, Tensor index, bool sparse_grad) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_gcd(self: TensorType, other: TensorType) -> TensorType:
+    """gcd(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(
+    (aten.ge.Tensor, aten.ge.Scalar, aten.greater_equal.Tensor, operator.ge),
+    trace_only=True,
+)
+def aten_ge(self: TReal, other: TReal) -> BOOL:
+    """ge.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    return op.GreaterOrEqual(self, other)
+
+
+@onnx_impl(
+    (aten.ge.Tensor, aten.ge.Scalar, aten.greater_equal.Tensor, operator.ge),
+    trace_only=True,
+)
+def aten_ge_bool(self: BOOL, other: BOOL) -> BOOL:
+    """ge.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    # self, other, self >= other
+    #    F,    F,    T
+    #    F,    T,    F
+    #    T,    F,    T
+    #    T,    T,    T
+
+    return op.Or(self, op.Not(other))
+
+
+def aten_geqrf(self: TensorType) -> tuple[TensorType, TensorType]:
+    """geqrf(Tensor self) -> (Tensor a, Tensor tau)"""
+
+    raise NotImplementedError
+
+
+def aten_ger(self: TensorType, vec2: TensorType) -> TensorType:
+    """ger(Tensor self, Tensor vec2) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(operator.getitem)
+def aten_getitem(self: Sequence[TTensor], i: INT64) -> TTensor:
+    return op.SequenceAt(self, i)
+
+
+@onnx_impl(aten.grid_sampler.default, trace_only=True)
+def aten_grid_sampler(
+    input: TTensor,
+    grid: TTensor,
+    interpolation_mode: int,
+    padding_mode: int,
+    align_corners: bool,
+) -> TTensor:
+    """grid_sampler(Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> Tensor"""
+
+    inter_mode_options = ("bilinear", "nearest", "bicubic")
+    inter_mode_str = inter_mode_options[interpolation_mode]
+
+    padding_mode_options = ("zeros", "border", "reflection")
+    padding_mode_str = padding_mode_options[padding_mode]
+
+    # Only one onnx Op so don't put into private function
+    return op.GridSample(
+        input,
+        grid,
+        align_corners=align_corners,
+        mode=inter_mode_str,
+        padding_mode=padding_mode_str,
+    )
+
+
+@onnx_impl(aten.grid_sampler_2d.default, trace_only=True)
+def aten_grid_sampler_2d(
+    input: TTensor,
+    grid: TTensor,
+    interpolation_mode: int,
+    padding_mode: int,
+    align_corners: bool,
+) -> TTensor:
+    """grid_sampler_2d(Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> Tensor"""
+
+    inter_mode_options = ("bilinear", "nearest", "bicubic")
+    inter_mode_str = inter_mode_options[interpolation_mode]
+
+    padding_mode_options = ("zeros", "border", "reflection")
+    padding_mode_str = padding_mode_options[padding_mode]
+
+    # Only one onnx Op so don't put into private function
+    return op.GridSample(
+        input,
+        grid,
+        align_corners=align_corners,
+        mode=inter_mode_str,
+        padding_mode=padding_mode_str,
+    )
+
+
+def aten_grid_sampler_2d_backward(
+    grad_output: TensorType,
+    input: TensorType,
+    grid: TensorType,
+    interpolation_mode: int,
+    padding_mode: int,
+    align_corners: bool,
+    output_mask: Sequence[bool],
+) -> tuple[TensorType, TensorType]:
+    """grid_sampler_2d_backward(Tensor grad_output, Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners, bool[2] output_mask) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_grid_sampler_3d(
+    input: TensorType,
+    grid: TensorType,
+    interpolation_mode: int,
+    padding_mode: int,
+    align_corners: bool,
+) -> TensorType:
+    """grid_sampler_3d(Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_grid_sampler_3d_backward(
+    grad_output: TensorType,
+    input: TensorType,
+    grid: TensorType,
+    interpolation_mode: int,
+    padding_mode: int,
+    align_corners: bool,
+    output_mask: Sequence[bool],
+) -> tuple[TensorType, TensorType]:
+    """grid_sampler_3d_backward(Tensor grad_output, Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners, bool[2] output_mask) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_gru_cell(
+    input: TensorType,
+    hx: TensorType,
+    w_ih: TensorType,
+    w_hh: TensorType,
+    b_ih: Optional[TensorType] = None,
+    b_hh: Optional[TensorType] = None,
+) -> TensorType:
+    """gru_cell(Tensor input, Tensor hx, Tensor w_ih, Tensor w_hh, Tensor? b_ih=None, Tensor? b_hh=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(
+    (aten.gt.Tensor, aten.gt.Scalar, aten.greater.Tensor, operator.gt),
+    trace_only=True,
+)
+def aten_gt(self: TReal, other: TReal) -> BOOL:
+    """gt.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Greater(self, other)
+
+
+@onnx_impl(
+    (aten.gt.Tensor, aten.gt.Scalar, aten.greater.Tensor, operator.gt),
+    trace_only=True,
+)
+def aten_gt_bool(self: BOOL, other: BOOL) -> BOOL:
+    """gt.Tensor(Tensor self, Tensor other) -> Tensor"""
+    # self, other, self > other
+    #    F,    F,    F
+    #    F,    T,    F
+    #    T,    F,    T
+    #    T,    T,    F
+
+    return op.And(self, op.Not(other))
+
+
+@onnx_impl(aten.hamming_window.default, trace_only=True)
+def aten_hamming_window(
+    window_length: int,
+    dtype: int = 1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TensorType:
+    """hamming_window(int window_length, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    if dtype is None or dtype == -1:
+        dtype = 1
+    # ONNX uses different alpha/beta values for the Hamming window
+    # Whereas PyTorch uses alpha=0.54, beta=0.46, ONNX uses
+    # alpha=0.543478, beta=0.456522. This causes a slight difference
+    # in the output values, but we still uses the HammingWindow op for performance.
+    return op.HammingWindow(window_length, output_datatype=dtype)
+
+
+@onnx_impl(aten.hann_window.default, trace_only=True)
+def aten_hann_window(
+    window_length: int,
+    dtype: int = 1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TensorType:
+    """hann_window(int window_length, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    if dtype is None or dtype == -1:
+        dtype = 1
+    return op.HannWindow(window_length, output_datatype=dtype)
+
+
+def aten_hardshrink(self: TensorType, lambd: float = 0.5) -> TensorType:
+    """hardshrink(Tensor self, Scalar lambd=0.5) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_hardshrink_backward(
+    grad_out: TensorType, self: TensorType, lambd: float
+) -> TensorType:
+    """hardshrink_backward(Tensor grad_out, Tensor self, Scalar lambd) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.heaviside.default, trace_only=True)
+def aten_heaviside(self: TReal, values: TReal) -> TReal:
+    """heaviside(Tensor self, Tensor values) -> Tensor"""
+
+    zero = op.CastLike(0, self)
+    one = op.CastLike(1, self)
+    intermediate = op.Where(op.Less(self, zero), zero, one)
+
+    return op.Where(op.Equal(self, zero), values, intermediate)
+
+
+def aten_hinge_embedding_loss(
+    self: TensorType, target: TensorType, margin: float = 1.0, reduction: int = 1
+) -> TensorType:
+    """hinge_embedding_loss(Tensor self, Tensor target, float margin=1.0, int reduction=Mean) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_histc(
+    self: TensorType, bins: int = 100, min: float = 0.0, max: float = 0.0
+) -> TensorType:
+    """histc(Tensor self, int bins=100, Scalar min=0, Scalar max=0) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_histogramdd(
+    self: TensorType,
+    bins: Sequence[int],
+    range: Optional[float] = None,
+    weight: Optional[TensorType] = None,
+    density: bool = False,
+) -> tuple[TensorType, TensorType]:
+    """histogramdd(Tensor self, int[] bins, float[]? range=None, Tensor? weight=None, bool density=False) -> (Tensor hist, Tensor[] bin_edges)"""
+
+    raise NotImplementedError
+
+
+def aten_hspmm(mat1: TensorType, mat2: TensorType) -> TensorType:
+    """hspmm(Tensor mat1, Tensor mat2) -> Tensor"""
+
+    raise NotImplementedError
+
+
+# Do not register hstack - decomposed by PyTorch: https://github.com/pytorch/pytorch/blob/bedf96d7ffe74b34bcfe52c7ae1ae05f40d6c8ee/torch/_refs/__init__.py#L3918
+def aten_hstack(tensors: Sequence[TTensor]) -> TTensor:
+    """hstack(Tensor[] tensors) -> Tensor"""
+
+    @graph()
+    def reshape_to_atleast_2d(tensor):
+        shape = op.Shape(tensor)
+        rank = op.Size(shape)
+        if rank <= 1:
+            tensor = op.Reshape(tensor, op.Constant(value_ints=[1, -1]))
+        return tensor
+
+    tensors_atleast_2d = op.SequenceMap(tensors, body=reshape_to_atleast_2d)
+
+    result = op.ConcatFromSequence(tensors_atleast_2d, axis=1, new_axis=0)
+
+    # hstack expects a non-empty sequence of tensors. So we don't need to check for length
+    rank_1d_or_less = op.Less(Rank(op.SequenceAt(tensors, 0)), 2)
+    if rank_1d_or_less:
+        result = op.Reshape(result, op.Constant(value_ints=[-1]))
+    return result
+
+
+def aten_hypot(self: TensorType, other: TensorType) -> TensorType:
+    """hypot(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_i0(self: TensorType) -> TensorType:
+    """i0(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_igamma(self: TensorType, other: TensorType) -> TensorType:
+    """igamma(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_igammac(self: TensorType, other: TensorType) -> TensorType:
+    """igammac(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_imag(self: TensorType) -> TensorType:
+    """imag(Tensor(a) self) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def _are_consecutive(sorted_list: Sequence[int]) -> bool:
+    """Returns True if a sorted list contains consecutive numbers."""
+    if not sorted_list:
+        return True
+
+    return sorted_list == list(range(min(sorted_list), max(sorted_list) + 1))
+
+
+def _has_none_in_middle(indices) -> bool:
+    """Returns True if there is a None in the middle of the list."""
+    not_none_indices = [i for i, idx in enumerate(indices) if idx is not None]
+    return not _are_consecutive(not_none_indices)
+
+
+def _shape_of_broadcast_tensors(*args: TensorType) -> INT64:
+    """Returns the broadcasted shape of the given tensors."""
+    broadcasted = op.Max(*args)
+    return op.Shape(broadcasted)
+
+
+@onnx_impl(aten.index.Tensor, private=True, trace_only=True)
+def _aten_index_onnx(
+    self: TensorType,
+    indices: Sequence[Optional[INT64]],
+    index_ranks: Sequence[int],
+) -> TensorType:
+    self_rank = len(self.shape)
+    advanced_indexing_rank = max(index_ranks)
+
+    # reordered_positions is the permutation of the index positions where
+    # positions with None are move to the end of the list
+    # For example, if indices = [None, 1, None, 2], then reordered_positions = [1, 3, 0, 2]
+    reordered_positions = sorted(
+        range(len(indices)), key=lambda i: (indices[i] is None, i)
+    )
+
+    # Fill the list with the remaining indices up to the rank of the tensor self.
+    # For example, if indices = [None, 1, None, 2], and the rank of self is 6,
+    # then reordered_positions = [1, 3, 0, 2, 4, 5]
+    reordered_positions = [
+        *reordered_positions,
+        *range(len(reordered_positions), self_rank),
+    ]
+    # Transpose self according to the reordered positions
+    self = op.Transpose(self, perm=reordered_positions)
+
+    # Broadcast the indices to the same shape then concatenate
+    not_none_indices = [idx for idx in indices if idx is not None]
+    broadcast_shape = _shape_of_broadcast_tensors(*not_none_indices)
+    final_index = op.Concat(
+        *(
+            op.Unsqueeze(op.Expand(idx, broadcast_shape), -1)
+            for idx in not_none_indices
+        ),
+        axis=-1,
+    )
+
+    self = op.GatherND(self, final_index, batch_dims=0)
+
+    if _has_none_in_middle(indices):
+        # If there is None in the middle, Advanced Indexing cannot decide where to put
+        # the new dimensions. So it places them in the front, like GatherND does.
+        return op.Identity(self)
+
+    # When the indices are consecutive, Advanced Indexing will place the new dimensions
+    # (aka. the broadcasted shape) in the middle, replacing the original [x1, ..., xk] axes.
+    #
+    # Input index axes (three parts):
+    #   [
+    #      x_None_front_1, ... x_None_front_m,
+    #      x1, ..., xk,
+    #      x_None_back_1, ..., x_None_back_m
+    #   ]
+    # GatherND result axes:
+    #   [
+    #      *broadcasted_shape(x1, x2, ..., xk),
+    #      x_None_front_1, ... x_None_front_m,
+    #      x_None_back_1, ..., x_None_back_m
+    #   ]
+    # (Transpose here)
+    # Advanced indexing result axes:
+    #   [
+    #      x_None_front_1, ... x_None_front_m,
+    #      *brocasted_shape(x1, x2, ..., xk),
+    #      x_None_back_1, ..., x_None_back_m
+    #   ]
+    #
+    # Need to transpose the result of GatherND to match this axes ordering.
+    first_not_none_position = reordered_positions[0]  # x_None_front_m + 1
+    starting_position_of_none_in_back = (
+        advanced_indexing_rank + first_not_none_position
+    )  # x_None_back_1
+    result_rank = self_rank - len(not_none_indices) + advanced_indexing_rank
+    perm = [
+        *range(
+            advanced_indexing_rank, starting_position_of_none_in_back
+        ),  # None_front_1...x_None_back_1
+        *range(advanced_indexing_rank),  # 0...len(broadcasted_shape)
+        *range(
+            starting_position_of_none_in_back,
+            result_rank,
+        ),  # None_back_1...None_back_m
+    ]
+
+    return op.Transpose(self, perm=perm)
+
+
+@onnx_impl((aten.index.Tensor, aten._unsafe_index.Tensor), trace_only=True)
+def aten_index(self: TensorType, indices: Sequence[Optional[INT64]]) -> TensorType:
+    """index.Tensor(Tensor self, Tensor?[] indices) -> Tensor
+
+    NOTE: Understanding `aten::index`
+    For `arg0` with shape `[7, 3, 4, 5, 6]`
+    The indexing operation `arg0[0, :, 1:2, tensor([[4,5]])]` will be translated to
+
+    ```
+    +>  select: i64[3, 4, 5, 6] = torch.ops.aten.select.int(arg0, 0, 0);
+    +>  slice_1: i64[3, 4, 5, 6] = torch.ops.aten.slice.Tensor(select, 0, 0, 9223372036854775807);
+    +>  slice_2: i64[3, 1, 5, 6] = torch.ops.aten.slice.Tensor(slice_1, 1, 1, 2);
+    +>  index: i64[3, 1, 1, 2, 6] = torch.ops.aten.index.Tensor(slice_2, [None, None, arg1]);
+    ```
+
+    Here,
+    - `indices = [None, None, arg1]` is equivalent to `indices = [None, None, arg1, None]`
+    - The operation `arg0[0, :, 1:2, tensor([[4,5]])]` is equivalent to `arg0[0, :, 1:2, tensor([[4,5]]), :]`
+
+    None in `indices` are like fillers for dimensions that cannot be removed in the process.
+    """
+
+    index_ranks = [len(index.shape) for index in indices if index is not None]
+
+    return _aten_index_onnx(self, indices, index_ranks)
+
+
+@onnx_impl((aten.index.Tensor, aten._unsafe_index.Tensor), trace_only=True)
+def aten_index_bool(self: TensorType, indices: Sequence[Optional[BOOL]]) -> TensorType:  # type: ignore[return]
+    index_ranks = [len(index.shape) for index in indices if index is not None]
+
+    if index_ranks[0] == 1:
+        # indices contains scalar only.
+        new_indices = [
+            op.Transpose(op.NonZero(index), perm=[1, 0]) if index is not None else None
+            for index in indices
+        ]
+        new_indices = [
+            op.Squeeze(index, axes=[1]) if index is not None else None
+            for index in new_indices
+        ]
+        return _aten_index_onnx(self, new_indices, index_ranks)
+    else:
+        input_rank = len(self.shape)
+        # Prepare perm for transposing self tensor.
+        # In indices, None meaning skip the corresponding dimension,
+        # so we need to move this dimension to the end of the list.
+        # After we gathered the final results, we transpose it back.
+        # For example,
+        # self's shape is [5, 5, 5, 5], indices is [None, (5, 5)]
+        # the final result's shape should be [5, 16, 5].
+        trans_perm = list(range(input_rank))
+        trans_perm.append(trans_perm.pop(0))
+        count_of_none = 0
+        for index in indices:
+            if index is None:
+                self = op.Transpose(self, perm=trans_perm)
+                count_of_none += 1
+            else:
+                new_indices = op.Transpose(op.NonZero(index), perm=[1, 0])
+                result = op.GatherND(self, new_indices, batch_dims=0)
+                finla_rank = input_rank - (len(index.shape) - 1)
+                trans_perm = list(range(finla_rank))
+                trans_perm = trans_perm[-1:] + trans_perm[:-1]
+                for _ in range(count_of_none):
+                    result = op.Transpose(result, perm=trans_perm)
+                return result
+
+
+def aten_index_add(
+    self: TensorType, dim: int, index: TensorType, source: TensorType, alpha: float = 1
+) -> TensorType:
+    """index_add(Tensor self, int dim, Tensor index, Tensor source, *, Scalar alpha=1) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_index_copy(
+    self: TensorType, dim: int, index: TensorType, source: TensorType
+) -> TensorType:
+    """index_copy(Tensor self, int dim, Tensor index, Tensor source) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl((aten.index_put.default, aten._unsafe_index_put.default), trace_only=True)
+def aten_index_put(
+    self: TReal,
+    indices: Sequence[INT64],
+    values: TReal,
+    accumulate: bool = False,
+) -> TReal:
+    """index_put(Tensor self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor
+
+    See implementation of `torch.onnx.symbolic_opset11.index_put
+    <https://github.com/pytorch/pytorch/blob/main/torch/onnx/symbolic_opset11.py#L212>`_.
+    """
+
+    # TODO(justinchuby): Handle when indicies has more than one element
+    index = indices[0]
+    new_index = op.Unsqueeze(index, [-1])
+
+    if accumulate:
+        result = op.ScatterND(self, new_index, values, reduction="add")
+    else:
+        result = op.ScatterND(self, new_index, values)
+
+    return result
+
+
+@onnx_impl(aten.index_put.default, trace_only=True)
+def aten_index_put_bool(
+    self: TReal,
+    indices: Sequence[BOOL],
+    values: TReal,
+    accumulate: bool = False,
+) -> TReal:
+    """index_put(Tensor self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor"""
+
+    # TODO: Support indices with more than 1 elements
+    index = indices[0]
+    # accumulate should be always False, True does not make sense but an assert would be great
+    # Reshape indices so it can be properly broadcasted
+    self_rank = len(self.shape)
+    index_rank = len(index.shape)
+    if self_rank > index_rank:
+        index_shape = op.Shape(index)
+        padding = op.Constant(value_ints=[1 for _ in range(self_rank - index_rank)])
+        padded_shape = op.Concat(index_shape, padding, axis=0)
+        index = op.Reshape(index, padded_shape)
+    return op.Where(index, values, self)
+
+
+def aten_index_reduce(
+    self: TensorType,
+    dim: int,
+    index: TensorType,
+    source: TensorType,
+    reduce: str,
+    include_self: bool = True,
+) -> TensorType:
+    """index_reduce(Tensor self, int dim, Tensor index, Tensor source, str reduce, *, bool include_self=True) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.index_select.default, trace_only=True)
+def aten_index_select(self: TTensor, dim: int, index: IntType) -> TTensor:
+    """index_select(Tensor self, int dim, Tensor index) -> Tensor"""
+
+    self_is_scalar = len(self.shape) == 0
+    if self_is_scalar:
+        self = op.Reshape(self, op.Constant(value_ints=[-1]))
+
+    # Index may be a scalar. Reshape it to a rank 1 tensor.
+    index = op.Reshape(index, op.Constant(value_ints=[-1]))
+    index = op.Cast(index, to=INT64.dtype)
+    result = op.Gather(self, index, axis=dim)
+
+    if self_is_scalar:
+        result = op.Squeeze(result)
+
+    return result
+
+
+def aten_index_select_backward(
+    grad: TensorType, self_sizes: INT64, dim: int, index: TensorType
+) -> TensorType:
+    """index_select_backward(Tensor grad, SymInt[] self_sizes, int dim, Tensor index) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_indices(self: TensorType) -> TensorType:
+    """indices(Tensor(a) self) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def aten_indices_copy(self: TensorType) -> TensorType:
+    """indices_copy(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_inner(self: TensorType, other: TensorType) -> TensorType:
+    """inner(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.instance_norm.default, trace_only=True)
+def aten_instance_norm(
+    input: TFloat,
+    weight: Optional[TFloat] = None,
+    bias: Optional[TFloat] = None,
+    running_mean: Optional[TFloat] = None,
+    running_var: Optional[TFloat] = None,
+    use_input_stats: bool = True,
+    momentum: float = 0.1,
+    eps: float = 1e-05,
+    cudnn_enabled: bool = False,
+) -> TFloat:
+    """instance_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool use_input_stats, float momentum, float eps, bool cudnn_enabled) -> Tensor"""
+    del cudnn_enabled  # unused
+    if weight is None:  # Set to 1.0 as default
+        weight = op.CastLike(
+            op.Expand(op.Constant(value_floats=[1.0]), op.Shape(input, start=1, end=2)),
+            input,
+        )
+
+    if bias is None:  # Set to 0.0 as default
+        bias = op.CastLike(
+            op.Expand(op.Constant(value_floats=[0.0]), op.Shape(input, start=1, end=2)),
+            input,
+        )
+
+    # If `use_input_stats` is set to True, ignore 'running_mean' and 'running_var' and
+    # compute using input statistics.
+    # Otherwise, compute using the running statistics.
+    if use_input_stats:
+        return op.InstanceNormalization(input, weight, bias, epsilon=eps)
+
+    assert (
+        running_mean is not None and running_var is not None
+    ), "running_mean and running_var must be provided when use_input_stats is False"
+
+    batch_size = op.Shape(input, start=0, end=1)
+    bn_input = op.Reshape(
+        input,
+        op.Concat(op.Constant(value_ints=[1, -1]), op.Shape(input, start=2), axis=0),
+    )
+    weight = op.Tile(weight, batch_size)
+    bias = op.Tile(bias, batch_size)
+    running_mean = op.Tile(running_mean, batch_size)
+    running_var = op.Tile(running_var, batch_size)
+
+    norm = op.BatchNormalization(
+        bn_input,
+        weight,
+        bias,
+        running_mean,
+        running_var,
+        epsilon=eps,
+        momentum=1.0 - momentum,
+        training_mode=False,
+    )
+    return op.Reshape(norm, op.Shape(input))
+
+
+def aten_int_repr(self: TensorType) -> TensorType:
+    """int_repr(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_inverse(self: TensorType) -> TensorType:
+    """inverse(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_is_coalesced(self: TensorType) -> bool:
+    """is_coalesced(Tensor self) -> bool"""
+
+    raise NotImplementedError
+
+
+def aten_is_complex(self: TensorType) -> bool:
+    """is_complex(Tensor self) -> bool"""
+
+    raise NotImplementedError
+
+
+def aten_is_conj(self: TensorType) -> bool:
+    """is_conj(Tensor self) -> bool"""
+
+    raise NotImplementedError
+
+
+def aten_is_distributed(self: TensorType) -> bool:
+    """is_distributed(Tensor self) -> bool"""
+
+    raise NotImplementedError
+
+
+def aten_is_floating_point(self: TensorType) -> bool:
+    """is_floating_point(Tensor self) -> bool"""
+
+    raise NotImplementedError
+
+
+def aten_is_inference(self: TensorType) -> bool:
+    """is_inference(Tensor self) -> bool"""
+
+    raise NotImplementedError
+
+
+def aten_is_leaf(self: TensorType) -> bool:
+    """is_leaf(Tensor self) -> bool"""
+
+    raise NotImplementedError
+
+
+def aten_is_neg(self: TensorType) -> bool:
+    """is_neg(Tensor self) -> bool"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.is_nonzero.default)
+def aten_is_nonzero(self: Union[RealType, BOOL]) -> BOOL:
+    """is_nonzero(Tensor self) -> bool"""
+
+    # if size != 1, return False
+    # else [0],[True],[0.0] return True, others return False
+    result = op.Not(op.Size(self) != 1)
+    if result:
+        result = op.Cast(self, to=BOOL.dtype)
+    return result
+
+
+def aten_is_pinned(self: TensorType, device: Optional[str] = None) -> bool:
+    """is_pinned(Tensor self, Device? device=None) -> bool"""
+
+    raise NotImplementedError
+
+
+# is_same_size is decomposed by PyTorch
+def aten_is_same_size(self: TTensor, other: TTensor) -> BOOL:
+    """is_same_size(Tensor self, Tensor other) -> bool"""
+
+    raise NotImplementedError
+
+
+def aten_is_set_to(self: TensorType, tensor: TensorType) -> bool:
+    """is_set_to(Tensor self, Tensor tensor) -> bool"""
+
+    raise NotImplementedError
+
+
+def aten_is_signed(self: TensorType) -> bool:
+    """is_signed(Tensor self) -> bool"""
+
+    raise NotImplementedError
+
+
+def aten_is_vulkan_available() -> bool:
+    """is_vulkan_available() -> bool"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.isclose.default)
+def aten_isclose(
+    self: TReal,
+    other: TReal,
+    rtol: float = 1e-05,
+    atol: float = 1e-08,
+    equal_nan: bool = False,
+) -> BOOL:
+    """isclose(Tensor self, Tensor other, float rtol=1e-05, float atol=1e-08, bool equal_nan=False) -> Tensor"""
+
+    # FIXME: check equal_nan when self and other are all NaN
+    # |input - other| <= atol + rtol x |other|
+    left_part = op.Abs(op.Sub(self, other))
+    right_part = op.Add(atol, op.Mul(rtol, op.Abs(other)))
+    result = op.LessOrEqual(left_part, right_part)
+    return result
+
+
+@onnx_impl(aten.isfinite.default)
+def aten_isfinite(self: TFloatHighPrecision) -> BOOL:
+    """isfinite(Tensor self) -> Tensor"""
+
+    # IsInf only supports FLOAT and DOUBLE
+    not_inf = op.Not(op.IsInf(self))
+    not_nan = op.Not(op.IsNaN(self))  # TODO: The test case doesnt cover this condition
+    return op.And(not_inf, not_nan)
+
+
+@onnx_impl(aten.isinf.default)
+def aten_isinf(self: TFloat) -> BOOL:
+    """isinf(Tensor self) -> Tensor"""
+
+    # Added Cast inside the function so it can support all real dtypes naturally
+    self = op.Cast(self, to=FLOAT.dtype)
+    return op.IsInf(self)
+
+
+@onnx_impl(aten.isnan.default)
+def aten_isnan(self: TFloat) -> BOOL:
+    """isnan(Tensor self) -> Tensor"""
+
+    return op.IsNaN(self)
+
+
+@onnx_impl(aten.isneginf.default)
+def aten_isneginf(self: TFloat) -> BOOL:
+    """isneginf(Tensor self) -> Tensor"""
+
+    # Added Cast inside the function so it can support all real dtypes naturally
+    self = op.Cast(self, to=FLOAT.dtype)
+    return op.And(op.Less(self, 0), op.IsInf(self))
+
+
+@onnx_impl(aten.isposinf.default)
+def aten_isposinf(self: TFloat) -> BOOL:
+    """isposinf(Tensor self) -> Tensor"""
+
+    # Added Cast inside the function so it can support all real dtypes naturally
+    self = op.Cast(self, to=FLOAT.dtype)
+    return op.And(op.Greater(self, 0), op.IsInf(self))
+
+
+def aten_isreal(self: TensorType) -> TensorType:
+    """isreal(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_istft(
+    self: TensorType,
+    n_fft: int,
+    hop_length: Optional[int] = None,
+    win_length: Optional[int] = None,
+    window: Optional[TensorType] = None,
+    center: bool = True,
+    normalized: bool = False,
+    onesided: Optional[bool] = None,
+    length: Optional[int] = None,
+    return_complex: bool = False,
+) -> TensorType:
+    """istft(Tensor self, int n_fft, int? hop_length=None, int? win_length=None, Tensor? window=None, bool center=True, bool normalized=False, bool? onesided=None, int? length=None, bool return_complex=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_item(self: TensorType) -> float:
+    """item(Tensor self) -> Scalar"""
+
+    raise NotImplementedError
+
+
+def aten_kaiser_window(window_length: int) -> TensorType:
+    """kaiser_window(int window_length, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_kl_div(
+    self: TensorType, target: TensorType, reduction: int = 1, log_target: bool = False
+) -> TensorType:
+    """kl_div(Tensor self, Tensor target, int reduction=Mean, *, bool log_target=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_kron(self: TensorType, other: TensorType) -> TensorType:
+    """kron(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_kthvalue(
+    self: TensorType, k: int, dim: int = -1, keepdim: bool = False
+) -> tuple[TensorType, TensorType]:
+    """kthvalue(Tensor self, int k, int dim=-1, bool keepdim=False) -> (Tensor values, Tensor indices)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.layer_norm.default, trace_only=True)
+def aten_layer_norm(
+    input: TReal,
+    normalized_shape: INT64,
+    weight: Optional[TReal] = None,
+    bias: Optional[TReal] = None,
+    eps: float = 1e-05,
+) -> TReal:
+    """layer_norm(Tensor input, int[] normalized_shape, Tensor? weight=None, Tensor? bias=None, float eps=1e-05, bool cudnn_enable=True) -> Tensor"""
+
+    # trace_only to use Python to obtain start_axis
+    start_axis = -len(normalized_shape)
+
+    if weight is None:
+        one = op.Constant(value_float=1.0)
+        weight = op.Expand(one, op.Shape(input, start=start_axis))
+
+    if bias is None:
+        zero = op.Constant(value_float=0.0)
+        bias = op.Expand(zero, op.Shape(input, start=start_axis))
+
+    return _aten_layer_norm_onnx(input, weight, bias, axis=start_axis, eps=eps)
+
+
+@onnx_impl(aten.layer_norm.default, private=True)
+def _aten_layer_norm_onnx(
+    input: TReal,
+    weight: TReal,
+    bias: TReal,
+    axis: int,
+    eps: float = 1e-05,
+) -> TReal:
+    """layer_norm(Tensor input, int[] normalized_shape, Tensor? weight=None, Tensor? bias=None, float eps=1e-05, bool cudnn_enable=True) -> Tensor"""
+
+    # TODO(justinchuby): Use OptionalHasElement after onnx/onnx#4982
+    result, _, _ = op.LayerNormalization(input, weight, bias, axis=axis, epsilon=eps)
+    return result
+
+
+def aten_lcm(self: TensorType, other: TensorType) -> TensorType:
+    """lcm(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_ldexp(self: TensorType, other: TensorType) -> TensorType:
+    """ldexp.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(
+    (aten.le.Tensor, aten.le.Scalar, aten.less_equal.Tensor, operator.le),
+    trace_only=True,
+)
+def aten_le(self: TReal, other: TReal) -> BOOL:
+    """le.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    return op.LessOrEqual(self, other)
+
+
+@onnx_impl(
+    (aten.le.Tensor, aten.le.Scalar, aten.less_equal.Tensor, operator.le),
+    trace_only=True,
+)
+def aten_le_bool(self: BOOL, other: BOOL) -> BOOL:
+    """le.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    # self, other, self <= other
+    #    F,    F,    T
+    #    F,    T,    T
+    #    T,    F,    F
+    #    T,    T,    T
+
+    return op.Or(other, op.Not(self))
+
+
+@onnx_impl((aten.lerp.Tensor, aten.lerp.Scalar))
+def aten_lerp(self: TTensor, end: TTensor, weight: TTensor) -> TTensor:
+    """lerp.Tensor(Tensor self, Tensor end, Tensor weight) -> Tensor"""
+
+    weight = op.CastLike(weight, self)
+    diff = op.Sub(end, self)
+    return op.Where(
+        op.Less(weight, 0.5),
+        op.Add(self, op.Mul(weight, diff)),
+        op.Sub(end, op.Mul(diff, op.Sub(1.0, weight))),
+    )
+
+
+def aten_lgamma(self: TensorType) -> TensorType:
+    """lgamma(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_lift(self: TensorType) -> TensorType:
+    """lift(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_lift_fresh(self: TensorType) -> TensorType:
+    """lift_fresh(Tensor(a) self) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.lift_fresh_copy.default, trace_only=True)
+def aten_lift_fresh_copy(self: TensorType) -> TensorType:
+    """lift_fresh_copy(Tensor self) -> Tensor"""
+
+    return op.Identity(self)
+
+
+def aten_linear_backward(
+    self: TensorType,
+    grad_output: TensorType,
+    weight: TensorType,
+    output_mask: Sequence[bool],
+) -> tuple[TensorType, TensorType, TensorType]:
+    """linear_backward(Tensor self, Tensor grad_output, Tensor weight, bool[3] output_mask) -> (Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.linspace.default, trace_only=True)
+def aten_linspace(
+    start: TFloat,
+    end: TFloat,
+    steps: int,
+    dtype: int = FLOAT.dtype,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TensorType:
+    """linspace(Scalar start, Scalar end, int steps, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    if dtype == -1 or dtype is None:
+        dtype = FLOAT.dtype
+
+    # Reference: https://github.com/pytorch/pytorch/blob/b35ca2cb941b5ba90858322810ca85c31e4541fd/torch/_refs/__init__.py#L4896
+    if steps == 0:
+        return aten_full(op.Constant(value_ints=[0]), 0.0, dtype=dtype)
+    if steps == 1:
+        return aten_full(op.Constant(value_ints=[steps]), start, dtype=dtype)
+
+    rg = aten_arange_start(0, steps, dtype=dtype)
+    start = op.Cast(start, to=dtype)
+    end = op.Cast(end, to=dtype)
+    steps_float = op.Cast(steps, to=dtype)
+    one = op.Cast(1.0, to=dtype)
+    two = op.Cast(2.0, to=dtype)
+    steps_minus_1 = op.Cast(steps - 1, to=dtype)
+    step = op.Div(op.Sub(end, start), steps_minus_1)
+    return op.Where(
+        rg < op.Div(steps_float, two),
+        start + step * rg,
+        end - step * (steps_float - one - rg),
+    )
+
+
+@onnx_impl(aten.log.default, trace_only=True)
+def aten_log(self: TFloat) -> TFloat:
+    """log(Tensor self) -> Tensor"""
+
+    return op.Log(self)
+
+
+@onnx_impl(aten.log10.default, trace_only=True)
+def aten_log10(self: TFloat) -> TFloat:
+    """log10(Tensor self) -> Tensor"""
+
+    return op.Div(op.Log(self), op.CastLike(op.Log(10.0), self))
+
+
+@onnx_impl(aten.log1p.default)
+def aten_log1p(self: TFloat) -> TFloat:
+    """log1p(Tensor self) -> Tensor"""
+
+    return op.Log(op.Add(self, 1.0))
+
+
+@onnx_impl(aten.log2.default, trace_only=True)
+def aten_log2(self: TFloat) -> TFloat:
+    """log2(Tensor self) -> Tensor"""
+
+    return op.Div(op.Log(self), op.CastLike(op.Log(2.0), self))
+
+
+@onnx_impl(aten.logaddexp.default, trace_only=True)
+def aten_logaddexp(self: TFloat, other: TFloat) -> TFloat:
+    """logaddexp(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Log(op.Add(op.Exp(self), op.Exp(other)))
+
+
+@onnx_impl(aten.logaddexp2.default, trace_only=True)
+def aten_logaddexp2(self: TFloat, other: TFloat) -> TFloat:
+    """logaddexp2(Tensor self, Tensor other) -> Tensor"""
+    two = op.CastLike(2.0, self)
+    summation = op.Add(op.Pow(two, self), op.Pow(two, other))
+
+    return op.Div(op.Log(summation), op.Log(two))
+
+
+@onnx_impl(aten.logcumsumexp.default, trace_only=True)
+def aten_logcumsumexp(self: TFloat, dim: int) -> TFloat:
+    """logcumsumexp(Tensor self, int dim) -> Tensor"""
+
+    if len(self.shape) == 0:
+        result = self
+    else:
+        # Make dim 1-d
+        dims = op.Unsqueeze(dim, axes=[0])
+        # This uses the max trick to avoid overflow:
+        # Assuming A = [a_1, a_2, ..., a_n] and the output
+        # out = [out_1, out_2, ..., out_n], then
+        # out_i = log(cumsum(exp(A)))_i
+        #       = log(exp(a_1) + ... + exp(a_i))
+        #       = log(exp(a_1) + ... + exp(a_i)) - max(A) + max(A)
+        #       = log((exp(a_1) + ... + exp(a_i)) / exp(max(A))) + max(A)
+        #       = log(exp(a_1-max(A)) + ... + exp(a_i-max(A))) + max(A)
+        #       = log(sum<j=1...i>(exp(a_j - max(A)))) + max(A)
+        # Vectorizing for all i, we get the expression below.
+        self_max = op.ReduceMax(self, dims)
+        result = op.Log(op.CumSum(op.Exp(self - self_max), dims)) + self_max
+    return result
+
+
+@onnx_impl(aten.logdet.default, trace_only=True)
+def aten_logdet(self: TFloat) -> TFloat:
+    """logdet(Tensor self) -> Tensor"""
+
+    return op.Log(op.Det(self))
+
+
+@onnx_impl(
+    (
+        aten.logical_and.default,
+        aten.bitwise_and.Tensor,
+        aten.bitwise_and.Scalar,
+        aten.bitwise_and.Scalar_Tensor,
+    ),
+    trace_only=True,
+)
+def aten_logical_and(self: BOOL, other: BOOL) -> BOOL:
+    """logical_and(Tensor self, Tensor other) -> Tensor"""
+
+    return op.And(self, other)
+
+
+@onnx_impl((aten.logical_not.default, aten.bitwise_not.default), trace_only=True)
+def aten_logical_not(self: BOOL) -> BOOL:
+    """logical_not(Tensor self) -> Tensor"""
+
+    return op.Not(self)
+
+
+@onnx_impl(
+    (
+        aten.logical_or.default,
+        aten.bitwise_or.Tensor,
+        aten.bitwise_or.Scalar,
+        aten.bitwise_or.Scalar_Tensor,
+        aten.add.Tensor,
+        aten.add.Scalar,
+    ),
+    trace_only=True,
+)
+def aten_logical_or(self: BOOL, other: BOOL) -> BOOL:
+    """logical_or(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Or(self, other)
+
+
+@onnx_impl(
+    (
+        aten.logical_xor.default,
+        aten.bitwise_xor.Tensor,
+        aten.bitwise_xor.Scalar,
+        aten.bitwise_xor.Scalar_Tensor,
+    ),
+    trace_only=True,
+)
+def aten_logical_xor(self: BOOL, other: BOOL) -> BOOL:
+    """logical_xor(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Xor(self, other)
+
+
+@onnx_impl(aten.logit.default, private=True)
+def _aten_logit_onnx(self: TFloat) -> TFloat:
+    return op.Log(op.Div(self, op.Sub(1.0, self)))
+
+
+@onnx_impl(aten.logit.default, private=True)
+def _aten_logit_clamp_onnx(self: TFloat, eps: float) -> TFloat:
+    eps = op.CastLike(eps, self)
+    one = op.CastLike(1.0, self)
+    temporary_self = op.Where(self <= one - eps, self, one - eps)
+    z = op.Where(temporary_self < eps, eps, temporary_self)
+
+    return op.Log(op.Div(z, op.Sub(one, z)))
+
+
+@onnx_impl(aten.logit.default, trace_only=True)
+def aten_logit(self: TFloat, eps: Optional[float] = None) -> TFloat:
+    """logit(Tensor self, float? eps=None) -> Tensor"""
+    if eps is None:
+        return _aten_logit_onnx(self)
+    return _aten_logit_clamp_onnx(self, eps)
+
+
+def aten_logspace(
+    start: float, end: float, steps: int, base: float = 10.0
+) -> TensorType:
+    """logspace(Scalar start, Scalar end, int steps, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.logsumexp.default, trace_only=True)
+def aten_logsumexp(self: TFloat, dim: INT64, keepdim: int = False) -> TFloat:
+    """logsumexp(Tensor self, int[1] dim, bool keepdim=False) -> Tensor"""
+
+    if len(self.shape) == 0:
+        # A scalar
+        result = self
+    else:
+        result = op.ReduceLogSumExp(self, dim, keepdims=keepdim)
+    return result
+
+
+def aten_lstm_cell(
+    input: TensorType,
+    hx: Sequence[TensorType],
+    w_ih: TensorType,
+    w_hh: TensorType,
+    b_ih: Optional[TensorType] = None,
+    b_hh: Optional[TensorType] = None,
+) -> tuple[TensorType, TensorType]:
+    """lstm_cell(Tensor input, Tensor[] hx, Tensor w_ih, Tensor w_hh, Tensor? b_ih=None, Tensor? b_hh=None) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_lstm_mps_backward(
+    grad_y: TensorType,
+    grad_hy: Optional[TensorType],
+    grad_cy: Optional[TensorType],
+    z_state: TensorType,
+    cell_state_fwd: TensorType,
+    input: TensorType,
+    hx: Sequence[TensorType],
+    params: Sequence[TensorType],
+    has_biases: bool,
+    num_layers: int,
+    dropout: float,
+    train: bool,
+    bidirectional: bool,
+    batch_first: bool,
+) -> tuple[TensorType, TensorType, TensorType]:
+    """lstm_mps_backward(Tensor grad_y, Tensor? grad_hy, Tensor? grad_cy, Tensor z_state, Tensor cell_state_fwd, Tensor input, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first) -> (Tensor, Tensor[], Tensor[])"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(
+    (aten.lt.Tensor, aten.lt.Scalar, aten.less.Tensor, operator.lt),
+    trace_only=True,
+)
+def aten_lt(self: TReal, other: TReal) -> BOOL:
+    """lt.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Less(self, other)
+
+
+@onnx_impl(
+    (aten.lt.Tensor, aten.lt.Scalar, aten.less.Tensor, operator.lt),
+    trace_only=True,
+)
+def aten_lt_bool(self: BOOL, other: BOOL) -> BOOL:
+    """lt.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    # self, other, self < other
+    #    F,    F,    F
+    #    F,    T,    T
+    #    T,    F,    F
+    #    T,    T,    F
+
+    return op.And(other, op.Not(self))
+
+
+def aten_lu_solve(
+    self: TensorType, LU_data: TensorType, LU_pivots: TensorType
+) -> TensorType:
+    """lu_solve(Tensor self, Tensor LU_data, Tensor LU_pivots) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_lu_unpack(
+    LU_data: TensorType,
+    LU_pivots: TensorType,
+    unpack_data: bool = True,
+    unpack_pivots: bool = True,
+) -> tuple[TensorType, TensorType, TensorType]:
+    """lu_unpack(Tensor LU_data, Tensor LU_pivots, bool unpack_data=True, bool unpack_pivots=True) -> (Tensor P, Tensor L, Tensor U)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.mH.default)
+def aten_mH(self: TRealOrUInt8) -> TRealOrUInt8:
+    """mH(Tensor(a) self) -> Tensor(a)"""
+
+    # Taking the conjugate transpose of a real matrix is the same as the transpose
+    return op.Einsum(self, equation="...ij->...ji")
+
+
+@onnx_impl(aten.mH.default, complex=True, trace_only=True)
+def aten_mH_complex(self: TFloat) -> TFloat:
+    """mH(Tensor(a) self) -> Tensor(a)"""
+
+    # c is the last dimension being the real and imaginary parts
+    trasposed = op.Einsum(self, equation="...ijc->...jic")
+    return _complex_conjugate(trasposed)
+
+
+@onnx_impl(aten.mT.default)
+def aten_mT(self: TRealOrUInt8) -> TRealOrUInt8:
+    """mT(Tensor(a) self) -> Tensor(a)"""
+
+    return op.Einsum(self, equation="...ij->...ji")
+
+
+@onnx_impl(aten.mT.default, complex=True)
+def aten_mT_complex(self: TFloat) -> TFloat:
+    """mT(Tensor(a) self) -> Tensor(a)"""
+
+    # c is the last dimension being the real and imaginary parts
+    return op.Einsum(self, equation="...ijc->...jic")
+
+
+def aten_margin_ranking_loss(
+    input1: TensorType,
+    input2: TensorType,
+    target: TensorType,
+    margin: float = 0.0,
+    reduction: int = 1,
+) -> TensorType:
+    """margin_ranking_loss(Tensor input1, Tensor input2, Tensor target, float margin=0.0, int reduction=Mean) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(
+    (aten.masked_fill.Scalar, aten.masked_fill.Tensor),
+    trace_only=True,
+)
+def aten_masked_fill(self: TTensor, mask: BOOL, value: TTensor) -> TTensor:
+    """masked_fill.Tensor(Tensor self, Tensor mask, Tensor value) -> Tensor"""
+    # NOTE: Do not attempt to cast `mask` to BOOL because mask should not take any other types.
+    # `mask` coming in as other types is often an error and should fail the model.
+    value_cast = op.CastLike(value, self)
+    return op.Where(mask, value_cast, self)
+
+
+def aten_masked_scatter(
+    self: TensorType, mask: TensorType, source: TensorType
+) -> TensorType:
+    """masked_scatter(Tensor self, Tensor mask, Tensor source) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_masked_select(self: TensorType, mask: TensorType) -> TensorType:
+    """masked_select(Tensor self, Tensor mask) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_masked_select_backward(
+    grad: TensorType, input: TensorType, mask: TensorType
+) -> TensorType:
+    """masked_select_backward(Tensor grad, Tensor input, Tensor mask) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.matmul.default, trace_only=True)
+def aten_matmul(
+    self: TRealUnlessInt16OrInt8, other: TRealUnlessInt16OrInt8
+) -> TRealUnlessInt16OrInt8:
+    """matmul(Tensor self, Tensor other) -> Tensor"""
+
+    return op.MatMul(self, other)
+
+
+def aten_matmul_backward(
+    grad: TensorType, self: TensorType, other: TensorType, mask: Sequence[bool]
+) -> tuple[TensorType, TensorType]:
+    """matmul_backward(Tensor grad, Tensor self, Tensor other, bool[2] mask) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_matrix_H(self: TensorType) -> TensorType:
+    """matrix_H(Tensor(a) self) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def aten_matrix_exp(self: TensorType) -> TensorType:
+    """matrix_exp(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_matrix_exp_backward(self: TensorType, grad: TensorType) -> TensorType:
+    """matrix_exp_backward(Tensor self, Tensor grad) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_matrix_power(self: TensorType, n: int) -> TensorType:
+    """matrix_power(Tensor self, int n) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.max.default, trace_only=True)
+def aten_max(self: TReal) -> TReal:
+    """max(Tensor self) -> Tensor"""
+
+    return op.ReduceMax(self, keepdims=False)
+
+
+@onnx_impl(aten.max.dim, trace_only=True)
+def aten_max_dim(self: TReal, dim: int, keepdim: bool = False) -> Tuple[TReal, INT64]:
+    """max.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)"""
+
+    if len(self.shape) == 0:
+        result = self
+        indices = op.Constant(value_int=0)
+    else:
+        dims = op.Reshape(dim, op.Constant(value_ints=[-1]))
+        result = op.ReduceMax(self, dims, keepdims=keepdim)
+        indices = op.ArgMax(self, axis=dim, keepdims=keepdim)
+    return result, indices
+
+
+@onnx_impl((aten.maximum.default, aten.max.other), trace_only=True)
+def aten_maximum(self: TReal, other: TReal) -> TReal:
+    """maximum(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Max(self, other)
+
+
+@onnx_impl((aten.maximum.default, aten.max.other), trace_only=True)
+def aten_maximum_bool(self: BOOL, other: BOOL) -> BOOL:
+    """maximum(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Or(self, other)
+
+
+@onnx_impl(aten.mean.default)
+def aten_mean(self: TReal) -> TReal:
+    """mean(Tensor self, *, ScalarType? dtype=None) -> Tensor"""
+
+    result = op.ReduceMean(self)
+    return op.Squeeze(result)
+
+
+@onnx_impl(aten.mean.dim, trace_only=True)
+def aten_mean_dim(self: TReal, dim: INT64, keepdim: bool = False) -> TReal:
+    """mean.dim(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor"""
+
+    if len(self.shape) == 0:
+        result = self
+    else:
+        dims = op.Reshape(dim, op.Constant(value_ints=[-1]))
+        result = op.ReduceMean(self, dims, keepdims=keepdim)
+    return result
+
+
+def aten_median(self: TensorType) -> TensorType:
+    """median(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_meshgrid(tensors: Sequence[TensorType]) -> TensorType:
+    """meshgrid(Tensor[] tensors) -> Tensor[]"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.min.default, trace_only=True)
+def aten_min(self: TReal) -> TReal:
+    """min(Tensor self) -> Tensor"""
+
+    return op.ReduceMin(self, keepdims=False)
+
+
+@onnx_impl(aten.min.dim, trace_only=True)
+def aten_min_dim(self: TReal, dim: int, keepdim: bool = False) -> Tuple[TReal, TInt]:
+    """min.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)"""
+    if len(self.shape) == 0:
+        result = self
+        indices = op.Constant(value_int=0)
+    else:
+        dims = op.Reshape(dim, op.Constant(value_ints=[-1]))
+        result = op.ReduceMin(self, dims, keepdims=keepdim)
+        indices = op.ArgMin(self, axis=dim, keepdims=keepdim)
+
+    return result, indices
+
+
+@onnx_impl((aten.minimum.default, aten.min.other), trace_only=True)
+def aten_minimum(self: TReal, other: TReal) -> TReal:
+    """minimum(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Min(self, other)
+
+
+@onnx_impl((aten.minimum.default, aten.min.other), trace_only=True)
+def aten_minimum_bool(self: BOOL, other: BOOL) -> BOOL:
+    """minimum(Tensor self, Tensor other) -> Tensor"""
+
+    return op.And(self, other)
+
+
+def aten_miopen_batch_norm(
+    input: TensorType,
+    weight: TensorType,
+    bias: Optional[TensorType],
+    running_mean: Optional[TensorType],
+    running_var: Optional[TensorType],
+    training: bool,
+    exponential_average_factor: float,
+    epsilon: float,
+) -> tuple[TensorType, TensorType, TensorType]:
+    """miopen_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_miopen_batch_norm_backward(
+    input: TensorType,
+    grad_output: TensorType,
+    weight: TensorType,
+    running_mean: Optional[TensorType],
+    running_var: Optional[TensorType],
+    save_mean: Optional[TensorType],
+    save_var: Optional[TensorType],
+    epsilon: float,
+) -> tuple[TensorType, TensorType, TensorType]:
+    """miopen_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon) -> (Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_miopen_convolution(
+    self: TensorType,
+    weight: TensorType,
+    bias: Optional[TensorType],
+    padding: INT64,
+    stride: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+    benchmark: bool,
+    deterministic: bool,
+) -> TensorType:
+    """miopen_convolution(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_miopen_convolution_add_relu(
+    self: TensorType,
+    weight: TensorType,
+    z: TensorType,
+    alpha: Optional[float],
+    bias: Optional[TensorType],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+) -> TensorType:
+    """miopen_convolution_add_relu(Tensor self, Tensor weight, Tensor z, Scalar? alpha, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_miopen_convolution_relu(
+    self: TensorType,
+    weight: TensorType,
+    bias: Optional[TensorType],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+) -> TensorType:
+    """miopen_convolution_relu(Tensor self, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_miopen_convolution_transpose(
+    self: TensorType,
+    weight: TensorType,
+    bias: Optional[TensorType],
+    padding: INT64,
+    output_padding: INT64,
+    stride: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+    benchmark: bool,
+    deterministic: bool,
+) -> TensorType:
+    """miopen_convolution_transpose(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, SymInt[] output_padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_miopen_depthwise_convolution(
+    self: TensorType,
+    weight: TensorType,
+    bias: Optional[TensorType],
+    padding: INT64,
+    stride: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+    benchmark: bool,
+    deterministic: bool,
+) -> TensorType:
+    """miopen_depthwise_convolution(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_miopen_rnn(
+    input: TensorType,
+    weight: Sequence[TensorType],
+    weight_stride0: int,
+    hx: TensorType,
+    cx: Optional[TensorType],
+    mode: int,
+    hidden_size: int,
+    num_layers: int,
+    batch_first: bool,
+    dropout: float,
+    train: bool,
+    bidirectional: bool,
+    batch_sizes: Sequence[int],
+    dropout_state: Optional[TensorType],
+) -> tuple[TensorType, TensorType, TensorType, TensorType, TensorType]:
+    """miopen_rnn(Tensor input, Tensor[] weight, int weight_stride0, Tensor hx, Tensor? cx, int mode, int hidden_size, int num_layers, bool batch_first, float dropout, bool train, bool bidirectional, int[] batch_sizes, Tensor? dropout_state) -> (Tensor, Tensor, Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_miopen_rnn_backward(
+    input: TensorType,
+    weight: Sequence[TensorType],
+    weight_stride0: int,
+    weight_buf: TensorType,
+    hx: TensorType,
+    cx: Optional[TensorType],
+    output: TensorType,
+    grad_output: Optional[TensorType],
+    grad_hy: Optional[TensorType],
+    grad_cy: Optional[TensorType],
+    mode: int,
+    hidden_size: int,
+    num_layers: int,
+    batch_first: bool,
+    dropout: float,
+    train: bool,
+    bidirectional: bool,
+    batch_sizes: Sequence[int],
+    dropout_state: Optional[TensorType],
+    reserve: TensorType,
+    output_mask: Sequence[bool],
+) -> tuple[TensorType, TensorType, TensorType, TensorType]:
+    """miopen_rnn_backward(Tensor input, Tensor[] weight, int weight_stride0, Tensor weight_buf, Tensor hx, Tensor? cx, Tensor output, Tensor? grad_output, Tensor? grad_hy, Tensor? grad_cy, int mode, int hidden_size, int num_layers, bool batch_first, float dropout, bool train, bool bidirectional, int[] batch_sizes, Tensor? dropout_state, Tensor reserve, bool[4] output_mask) -> (Tensor, Tensor, Tensor, Tensor[])"""
+
+    raise NotImplementedError
+
+
+def aten_mkldnn_adaptive_avg_pool2d(
+    self: TensorType, output_size: Sequence[int]
+) -> TensorType:
+    """mkldnn_adaptive_avg_pool2d(Tensor self, int[2] output_size) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_mkldnn_adaptive_avg_pool2d_backward(
+    grad_output: TensorType, self: TensorType
+) -> TensorType:
+    """mkldnn_adaptive_avg_pool2d_backward(Tensor grad_output, Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_mkldnn_convolution(
+    self: TensorType,
+    weight: TensorType,
+    bias: Optional[TensorType],
+    padding: INT64,
+    stride: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+) -> TensorType:
+    """mkldnn_convolution(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, int[] stride, int[] dilation, int groups) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_mkldnn_linear_backward(
+    self: TensorType,
+    grad_output: TensorType,
+    weight: TensorType,
+    output_mask: Sequence[bool],
+) -> tuple[TensorType, TensorType, TensorType]:
+    """mkldnn_linear_backward(Tensor self, Tensor grad_output, Tensor weight, bool[3] output_mask) -> (Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_mkldnn_linear_backward_input(
+    input_size: Sequence[int], grad_output: TensorType, weight: TensorType
+) -> TensorType:
+    """mkldnn_linear_backward_input(int[] input_size, Tensor grad_output, Tensor weight) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_mkldnn_linear_backward_weights(
+    grad_output: TensorType, input: TensorType, weight: TensorType, bias_defined: bool
+) -> tuple[TensorType, TensorType]:
+    """mkldnn_linear_backward_weights(Tensor grad_output, Tensor input, Tensor weight, bool bias_defined) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_mkldnn_max_pool2d(
+    self: TensorType,
+    kernel_size: Sequence[int],
+    stride: Optional[Sequence[int]] = None,
+    padding: Sequence[int] = (0, 0),
+    dilation: Sequence[int] = (1, 1),
+    ceil_mode: bool = False,
+) -> TensorType:
+    """mkldnn_max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_mkldnn_max_pool2d_backward(
+    grad_output: TensorType,
+    output: TensorType,
+    input: TensorType,
+    kernel_size: Sequence[int],
+    stride: Optional[Sequence[int]] = None,
+    padding: Sequence[int] = (0, 0),
+    dilation: Sequence[int] = (1, 1),
+    ceil_mode: bool = False,
+) -> TensorType:
+    """mkldnn_max_pool2d_backward(Tensor grad_output, Tensor output, Tensor input, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_mkldnn_max_pool3d(
+    self: TensorType,
+    kernel_size: Sequence[int],
+    stride: Optional[Sequence[int]] = None,
+    padding: Sequence[int] = (0, 0, 0),
+    dilation: Sequence[int] = (1, 1, 1),
+    ceil_mode: bool = False,
+) -> TensorType:
+    """mkldnn_max_pool3d(Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, int[3] dilation=1, bool ceil_mode=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_mkldnn_max_pool3d_backward(
+    grad_output: TensorType,
+    output: TensorType,
+    input: TensorType,
+    kernel_size: Sequence[int],
+    stride: Optional[Sequence[int]] = None,
+    padding: Sequence[int] = (0, 0, 0),
+    dilation: Sequence[int] = (1, 1, 1),
+    ceil_mode: bool = False,
+) -> TensorType:
+    """mkldnn_max_pool3d_backward(Tensor grad_output, Tensor output, Tensor input, int[3] kernel_size, int[3] stride=[], int[3] padding=0, int[3] dilation=1, bool ceil_mode=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.mm.default, trace_only=True)
+def aten_mm(
+    self: TRealUnlessInt16OrInt8, mat2: TRealUnlessInt16OrInt8
+) -> TRealUnlessInt16OrInt8:
+    """mm(Tensor self, Tensor mat2) -> Tensor"""
+
+    return op.MatMul(self, mat2)
+
+
+def aten_mode(
+    self: TensorType, dim: int = -1, keepdim: bool = False
+) -> tuple[TensorType, TensorType]:
+    """mode(Tensor self, int dim=-1, bool keepdim=False) -> (Tensor values, Tensor indices)"""
+
+    raise NotImplementedError
+
+
+def aten_mps_convolution_backward(
+    self: TensorType,
+    grad_output: TensorType,
+    weight: TensorType,
+    padding: Sequence[int],
+    stride: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+    output_mask: Sequence[bool],
+) -> tuple[TensorType, TensorType, TensorType]:
+    """mps_convolution_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_mps_convolution_transpose_backward(
+    self: TensorType,
+    grad_output: TensorType,
+    weight: TensorType,
+    padding: Sequence[int],
+    output_padding: Sequence[int],
+    stride: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+    output_mask: Sequence[bool],
+) -> tuple[TensorType, TensorType]:
+    """mps_convolution_transpose_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] output_padding, int[] stride, int[] dilation, int groups, bool[2] output_mask) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_mps_max_pool2d_backward(
+    grad_output: TensorType,
+    self: TensorType,
+    kernel_size: Sequence[int],
+    stride: Optional[Sequence[int]] = None,
+    padding: Sequence[int] = (0, 0),
+    dilation: Sequence[int] = (1, 1),
+    ceil_mode: bool = False,
+) -> TensorType:
+    """mps_max_pool2d_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_msort(self: TensorType) -> TensorType:
+    """msort(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(
+    (aten.mul.default, aten.mul.Tensor, operator.mul, aten.multiply.Tensor),
+    trace_only=True,
+)
+def aten_mul(self: TReal, other: TReal) -> TReal:
+    """mul.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Mul(self, other)
+
+
+@onnx_impl(
+    (aten.mul.default, aten.mul.Tensor, aten.multiply.Tensor),
+    trace_only=True,
+)
+def aten_mul_bool(self: BOOL, other: BOOL) -> BOOL:
+    """ONNX Mul doesn't support Boolean, so use And as an equivalent operator."""
+
+    # TODO(justinchuby): Handle cases where type reconcilation is not enough,
+    # since different ONNX operators are used based on different data types.
+
+    return op.And(self, other)
+
+
+@onnx_impl(
+    (aten.mul.default, aten.mul.Tensor, aten.multiply.Tensor),
+    trace_only=True,
+    complex=True,
+)
+def aten_mul_complex(self: TReal, other: TReal) -> TReal:
+    """mul.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    # TODO(justinchuby): Maybe use Split to simplify the logic
+    self_real = op.Slice(self, [0], [1], axes=[-1])
+    self_imag = op.Slice(self, [1], [2], axes=[-1])
+    other_real = op.Slice(other, [0], [1], axes=[-1])
+    other_imag = op.Slice(other, [1], [2], axes=[-1])
+
+    # Complex multiplication
+    # (a + bi) * (c + di) = (ac - bd) + (ad + bc)i
+
+    ac = op.Mul(self_real, other_real)
+    bd = op.Mul(self_imag, other_imag)
+    ad = op.Mul(self_real, other_imag)
+    bc = op.Mul(self_imag, other_real)
+
+    real = op.Sub(ac, bd)
+    imag = op.Add(ad, bc)
+
+    return op.Concat(real, imag, axis=-1)
+
+
+@onnx_impl(aten.multinomial.default, trace_only=True)
+def aten_multinomial(
+    self: TFloat,
+    num_samples: int,
+    replacement: bool = False,
+) -> TInt:
+    """multinomial(Tensor self, int num_samples, bool replacement=False, *, Generator? generator=None) -> Tensor"""
+    # ONNX Multinomial doesn't support 1D input
+    if len(self.shape) == 1:
+        unsqueezed_input = op.Unsqueeze(self, axes=0)
+    else:
+        unsqueezed_input = self
+    # ONNX multinomial expects log probability
+    log_input = op.Log(unsqueezed_input)
+    result = op.Multinomial(log_input, dtype=INT64.dtype, sample_size=num_samples)
+    if len(self.shape) == 1:
+        result = op.Squeeze(result)
+    return result
+
+
+def aten_multiply(self: TensorType, other: TensorType) -> TensorType:
+    """multiply.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.mv.default, trace_only=True)
+def aten_mv(self: TensorType, vec: TensorType) -> TensorType:
+    """mv(Tensor self, Tensor vec) -> Tensor"""
+
+    return op.MatMul(self, vec)
+
+
+def aten_mvlgamma(self: TensorType, p: int) -> TensorType:
+    """mvlgamma(Tensor self, int p) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_nan_to_num(
+    self: TensorType,
+    nan: Optional[float] = None,
+    posinf: Optional[float] = None,
+    neginf: Optional[float] = None,
+) -> TensorType:
+    """nan_to_num(Tensor self, float? nan=None, float? posinf=None, float? neginf=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_nanmean(
+    self: TensorType,
+    dim: Optional[int] = None,
+    keepdim: bool = False,
+    dtype: Optional[int] = None,
+) -> TensorType:
+    """nanmean(Tensor self, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_nanmedian(self: TensorType) -> TensorType:
+    """nanmedian(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_nanquantile(
+    self: TensorType,
+    q: TensorType,
+    dim: Optional[int] = None,
+    keepdim: bool = False,
+    interpolation: str = "linear",
+) -> TensorType:
+    """nanquantile(Tensor self, Tensor q, int? dim=None, bool keepdim=False, *, str interpolation='linear') -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_nansum(
+    self: TensorType,
+    dim: Optional[int] = None,
+    keepdim: bool = False,
+    dtype: Optional[int] = None,
+) -> TensorType:
+    """nansum(Tensor self, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.narrow.default, trace_only=True)
+def aten_narrow(self: TTensor, dim: INT64, start: INT64, length: INT64) -> TTensor:
+    """narrow(Tensor(a) self, int dim, SymInt start, SymInt length) -> Tensor(a)"""
+
+    dim = op.Reshape(dim, op.Constant(value_ints=[-1]))
+    start = op.Reshape(start, op.Constant(value_ints=[-1]))
+    length = op.Reshape(length, op.Constant(value_ints=[-1]))
+
+    end = op.Add(start, length)
+    return op.Slice(self, start, end, dim)
+
+
+def aten_narrow_copy(
+    self: TensorType, dim: int, start: INT64, length: INT64
+) -> TensorType:
+    """narrow_copy(Tensor self, int dim, SymInt start, SymInt length) -> Tensor"""
+
+    raise NotImplementedError
+
+
+# NOTE: https://github.com/pytorch/pytorch/blob/a44f8894fa6d973693aab44a3dda079a168b05c1/torch/_decomp/decompositions.py#L1501-L1510
+# _native_batch_norm_legit_no_training and _native_batch_norm_legit are meant to
+# replace native_batch_norm within unknown time period.
+# TODO: Refactor this after native_batch_norm is deprecated.
+@onnx_impl(aten._native_batch_norm_legit_no_training.default, trace_only=True)
+def aten__native_batch_norm_no_training(
+    input: TFloat,
+    weight: Optional[TFloat] = None,
+    bias: Optional[TFloat] = None,
+    running_mean: Optional[TFloat] = None,
+    running_var: Optional[TFloat] = None,
+    momentum: float = 0.9,
+    eps: float = 1e-05,
+) -> Tuple[TFloat, TFloat, TFloat]:
+    """_native_batch_norm_legit_no_training(Tensor input, Tensor? weight, Tensor? bias, Tensor running_mean, Tensor running_var, float momentum, float eps) -> (Tensor, Tensor, Tensor)"""
+
+    return aten_native_batch_norm(
+        input, weight, bias, running_mean, running_var, False, momentum, eps
+    )
+
+
+@onnx_impl(aten._native_batch_norm_legit.no_stats, trace_only=True)
+def aten__native_batch_norm_no_stats(
+    input: TFloat,
+    weight: Optional[TFloat] = None,
+    bias: Optional[TFloat] = None,
+    training: bool = False,
+    momentum: float = 0.9,
+    eps: float = 1e-05,
+) -> Tuple[TFloat, TFloat, TFloat]:
+    """_native_batch_norm_legit.no_stats(Tensor input, Tensor? weight, Tensor? bias, bool training, float momentum, float eps) -> (Tensor, Tensor, Tensor)"""
+
+    return aten_native_batch_norm(
+        input, weight, bias, None, None, training, momentum, eps
+    )
+
+
+@onnx_impl(
+    (aten.native_batch_norm.default, aten._native_batch_norm_legit.default),
+    trace_only=True,
+)
+def aten_native_batch_norm(
+    input: TFloat,
+    weight: Optional[TFloat] = None,
+    bias: Optional[TFloat] = None,
+    running_mean: Optional[TFloat] = None,
+    running_var: Optional[TFloat] = None,
+    training: bool = False,
+    momentum: float = 0.9,
+    eps: float = 1e-05,
+) -> Tuple[TFloat, TFloat, TFloat]:
+    """native_batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps) -> (Tensor, Tensor, Tensor)"""
+
+    if weight is None:  # Set to 1.0 as default
+        weight = op.Expand(
+            op.CastLike(op.Constant(value_floats=[1.0]), input),
+            op.Shape(input, start=1, end=2),
+        )
+
+    if bias is None:  # Set to 0.0 as default
+        bias = op.Expand(
+            op.CastLike(op.Constant(value_floats=[0.0]), input),
+            op.Shape(input, start=1, end=2),
+        )
+
+    axes = list(range(len(input.shape)))
+    axes.pop(1)
+    axes = op.Constant(value_ints=axes)
+    if running_mean is None:  # Using input mean
+        running_mean = op.ReduceMean(input, axes, keepdims=False)
+
+    if running_var is None:  # Using input var
+        mean = op.ReduceMean(input, axes)
+        input_sub_mean = op.Sub(input, mean)
+        sqr_input_sub_mean = op.Mul(input_sub_mean, input_sub_mean)
+        running_var = op.ReduceMean(sqr_input_sub_mean, axes, keepdims=False)
+
+    # TODO: This is a temporary fix for the issue that BatchNormalization
+    #       is forced to be in training mode in PyTorch, and ORT currently
+    #       only supports training mode with opset version lower than 14.
+    training = False
+    # We have to split to two private functions, because BatchNormalization returns
+    # three outputs when training_mode=True and one when it is False.
+    if training:
+        norm, input_mean, input_rstd, _, _ = _aten_native_batch_norm_training_onnx(
+            input,
+            weight,
+            bias,
+            running_mean,
+            running_var,
+            axes,
+            momentum=1.0 - momentum,
+            eps=eps,
+        )
+    else:
+        norm, input_mean, input_rstd, _, _ = _aten_native_batch_norm_inference_onnx(
+            input,
+            weight,
+            bias,
+            running_mean,
+            running_var,
+            momentum=1.0 - momentum,
+            eps=eps,
+        )
+
+    return norm, input_mean, input_rstd
+
+
+@onnx_impl(aten.native_batch_norm.default, private=True)
+def _aten_native_batch_norm_training_onnx(
+    input: TFloat,
+    weight: TFloat,
+    bias: TFloat,
+    running_mean: TFloat,
+    running_var: TFloat,
+    axes: INT64,
+    momentum: float,
+    eps: float,
+) -> Tuple[TFloat, TFloat, TFloat, TFloat, TFloat]:
+    """Batch normalization training mode.
+
+    NOTE: momentum in PyTorch is 1.0-momentum in ONNX.
+    When calling this function be sure to pass 1.0-momentum when momentum is obtained from PyTorch.
+    """
+    norm, running_mean, _ = op.BatchNormalization(
+        input,
+        weight,
+        bias,
+        running_mean,
+        running_var,
+        epsilon=eps,
+        momentum=momentum,
+        training_mode=True,
+    )
+    # Compute mean and rstd
+    # Mean, var, and rstd computation and results are expected to be
+    # in higher precision when inputs are float16.
+    upcast_input = op.Cast(input, to=FLOAT.dtype)
+    mean = op.ReduceMean(upcast_input, axes)
+    input_sub_mean = op.Sub(upcast_input, mean)
+    sqr = op.Mul(input_sub_mean, input_sub_mean)
+    var = op.ReduceMean(sqr, axes, keepdims=False)
+    rstd = op.Div(1.0, op.Sqrt(var + eps))
+    # Get mean again with size = [1, C]
+    mean = op.ReduceMean(upcast_input, axes, keepdims=False)
+
+    # Compute the running var the PyTorch way
+    # https://github.com/pytorch/pytorch/blob/5cc511f72fe073bbd8c10d796d72dce67f5cd5c4/torch/_decomp/decompositions.py#L1646
+
+    n = op.Cast(op.Size(input) / op.Shape(input)[1], to=FLOAT.dtype)
+    unbiased_var = var * (n / (n - 1.0))
+
+    # NOTE: momentum in ONNX is 1.0-momentum in PyTorch
+    new_running_var = (
+        op.CastLike((1.0 - momentum) * unbiased_var, running_var)
+        + momentum * running_var
+    )
+
+    return norm, mean, rstd, running_mean, new_running_var
+
+
+@onnx_impl(aten.native_batch_norm.default, private=True)
+def _aten_native_batch_norm_inference_onnx(
+    input: TFloat,
+    weight: TFloat,
+    bias: TFloat,
+    running_mean: TFloat,
+    running_var: TFloat,
+    momentum: float,
+    eps: float,
+) -> Tuple[TFloat, TFloat, TFloat, TFloat, TFloat]:
+    """Batch normalization inference mode.
+
+    NOTE: momentum in PyTorch is 1.0-momentum in ONNX.
+    When calling this function be sure to pass 1.0-momentum when momentum is obtained from PyTorch.
+    """
+    norm = op.BatchNormalization(
+        input,
+        weight,
+        bias,
+        running_mean,
+        running_var,
+        epsilon=eps,
+        momentum=momentum,
+        training_mode=False,
+    )
+    # CUDA and CPU gives different shapes:
+    # https://github.com/pytorch/pytorch/blob/a44f8894fa6d973693aab44a3dda079a168b05c1/torch/_decomp/decompositions.py#L1451-L1457
+    # We use CUDA's output here
+    invstd = op.Div(1.0, op.Sqrt(running_var + eps))
+    # https://github.com/pytorch/pytorch/blob/a44f8894fa6d973693aab44a3dda079a168b05c1/torch/_decomp/decompositions.py#L1475
+    running_mean_fp32 = op.Cast(running_mean, to=FLOAT.dtype)
+    invstd = op.Cast(invstd, to=FLOAT.dtype)
+    return norm, running_mean_fp32, invstd, running_mean, running_var
+
+
+# TODO: This op is using duplicated code from aten_native_batch_norm,
+#       need to refactor it later. https://github.com/microsoft/onnxscript/issues/1125
+# NOTE: This op is invoked by PyTorch Functionalization, and not in
+# native_functions.yaml, It can be found in torch/_decomp/decompositions.py
+@onnx_impl(aten._native_batch_norm_legit_functional.default, trace_only=True)
+def aten__native_batch_norm_legit_functional(
+    input: TFloat,
+    weight: Optional[TFloat] = None,
+    bias: Optional[TFloat] = None,
+    running_mean: Optional[TFloat] = None,
+    running_var: Optional[TFloat] = None,
+    training: bool = False,
+    momentum: float = 0.9,
+    eps: float = 1e-05,
+) -> Tuple[TFloat, TFloat, TFloat, TFloat, TFloat]:
+    if weight is None:  # Set to 1.0 as default
+        weight = op.Expand(
+            op.Constant(value_floats=[1.0]), op.Shape(input, start=1, end=2)
+        )
+
+    if bias is None:  # Set to 0.0 as default
+        bias = op.Expand(
+            op.Constant(value_floats=[0.0]), op.Shape(input, start=1, end=2)
+        )
+
+    axes = list(range(len(input.shape)))
+    axes.pop(1)
+    axes = op.Constant(value_ints=axes)
+    if running_mean is None:  # Using input mean
+        running_mean = op.ReduceMean(input, axes, keepdims=False)
+
+    if running_var is None:  # Using input var
+        mean = op.ReduceMean(input, axes)
+        input_sub_mean = op.Sub(input, mean)
+        sqr_input_sub_mean = op.Mul(input_sub_mean, input_sub_mean)
+        running_var = op.ReduceMean(sqr_input_sub_mean, axes, keepdims=False)
+
+    # TODO: This is a temporary fix for the issue that BatchNormalization
+    #       is forced to be in training mode in PyTorch, and ORT currently
+    #       only supports training mode with opset version lower than 14.
+    training = False
+    # We have to split to two private functions, because BatchNormalization returns
+    # three outputs when training_mode=True and one when it is False.
+    if training:
+        (
+            norm,
+            input_mean,
+            input_rstd,
+            running_mean,
+            running_var,
+        ) = _aten_native_batch_norm_training_onnx(
+            input,
+            weight,
+            bias,
+            running_mean,
+            running_var,
+            axes,
+            momentum=1.0 - momentum,
+            eps=eps,
+        )
+    else:
+        (
+            norm,
+            input_mean,
+            input_rstd,
+            running_mean,
+            running_var,
+        ) = _aten_native_batch_norm_inference_onnx(
+            input,
+            weight,
+            bias,
+            running_mean,
+            running_var,
+            momentum=1.0 - momentum,
+            eps=eps,
+        )
+
+    return norm, input_mean, input_rstd, running_mean, running_var
+
+
+def aten_native_batch_norm_backward(
+    grad_out: TensorType,
+    input: TensorType,
+    weight: Optional[TensorType],
+    running_mean: Optional[TensorType],
+    running_var: Optional[TensorType],
+    save_mean: Optional[TensorType],
+    save_invstd: Optional[TensorType],
+    train: bool,
+    eps: float,
+    output_mask: Sequence[bool],
+) -> tuple[TensorType, TensorType, TensorType]:
+    """native_batch_norm_backward(Tensor grad_out, Tensor input, Tensor? weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_invstd, bool train, float eps, bool[3] output_mask) -> (Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_native_channel_shuffle(self: TensorType, groups: int) -> TensorType:
+    """native_channel_shuffle(Tensor self, int groups) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.native_dropout.default, trace_only=True)
+def aten_native_dropout(
+    input: TFloat, p: float, train: bool = True
+) -> Tuple[TFloat, BOOL]:
+    """native_dropout(Tensor input, float p, bool? train) -> (Tensor, Tensor)"""
+
+    result, mask = op.Dropout(input, p, train)
+    return result, mask
+
+
+def aten_native_dropout_backward(
+    grad_output: TensorType, mask: TensorType, scale: float
+) -> TensorType:
+    """native_dropout_backward(Tensor grad_output, Tensor mask, float scale) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.native_group_norm.default, trace_only=True)
+def aten_native_group_norm(
+    input: TFloat,
+    weight: Optional[TFloat] = None,
+    bias: Optional[TFloat] = None,
+    N: Optional[INT64] = None,
+    C: Optional[INT64] = None,
+    HxW: Optional[INT64] = None,
+    group: int = 1,
+    eps: float = 1e-05,
+) -> Tuple[TFloat, TFloat, TFloat]:
+    """native_group_norm(Tensor input, Tensor? weight, Tensor? bias, SymInt N, SymInt C, SymInt HxW, int group, float eps) -> (Tensor, Tensor, Tensor)"""
+
+    # Actually we don't need N,C,HxW value because the input tensor has that information
+    if weight is None:  # Set to 1.0 as default, the shape is Channel size
+        weight = op.Expand(
+            op.Constant(value_floats=[1.0]), op.Shape(input, start=1, end=2)
+        )
+
+    if bias is None:  # Set to 0.0 as default, the shape is Channel size
+        bias = op.Expand(
+            op.Constant(value_floats=[0.0]), op.Shape(input, start=1, end=2)
+        )
+
+    # Accoding to Torch, return rstd instead of var
+    norm, mean, rstd = _aten_native_group_norm_onnx(input, weight, bias, group, eps)
+    return norm, mean, rstd
+
+
+@onnx_impl(aten.native_group_norm.default, private=True)
+def _aten_native_group_norm_onnx(
+    input: TFloat,
+    weight: TFloat,
+    bias: TFloat,
+    group: INT64,
+    eps: float,
+) -> Tuple[TFloat, TFloat, TFloat]:
+    # Because onnx.GroupNorm() need size=group for weight and bias
+    # But the torch's aten function's input need size=channel, the size mismatched
+    # So we have to use onnx.InstanceNorm() to simulate
+    neg_1 = op.Constant(value_ints=[-1])
+    # Create weight_instance_norm and bias_instance_norm, copied from Torch ONNX converter
+    group_tensor = op.Reshape(group, neg_1)
+    # 0 in the shape list keeps dimension value unchanged, for InstanceNorm need [0,group,-1]
+    shape_input = op.Concat(op.Constant(value_ints=[0]), group_tensor, neg_1, axis=0)
+    input_reshaped = op.Reshape(input, shape_input)
+    weight_inst_norm = op.Expand(op.CastLike(1.0, input), group_tensor)
+    bias_inst_norm = op.Expand(op.CastLike(0.0, input), group_tensor)
+    norm = op.InstanceNormalization(
+        input_reshaped, weight_inst_norm, bias_inst_norm, epsilon=eps
+    )
+    # Reshape back to input's shape
+    norm = op.Reshape(norm, op.Shape(input))
+    # Using the input weight and bias to do affine
+    # But need to unsqueeze to the target shape for broading cast easy
+    input_rank = Rank(input)
+    axes_unsqueeze = op.Range(1, input_rank - 1, 1)
+    weight_full_shape = op.Unsqueeze(weight, axes_unsqueeze)
+    bias_full_shape = op.Unsqueeze(bias, axes_unsqueeze)
+    weight_full_shape = op.CastLike(weight_full_shape, norm)
+    norm_mul_weight = op.Mul(norm, weight_full_shape)
+    bias_full_shape = op.CastLike(bias_full_shape, norm_mul_weight)
+    norm_result = op.Add(norm_mul_weight, bias_full_shape)
+    # Compute mean and rstd, but using Torch algorithm
+    # The returned shape for mean and vstd should be [N, group, -1]
+    N = op.Shape(input, start=0, end=1)
+    shape_N_group_neg1 = op.Concat(N, group_tensor, neg_1, axis=0)
+    input_N_group_neg1 = op.Reshape(input, shape_N_group_neg1)
+    # The output size is [N, group], so dims = [2]
+    axes = op.Constant(value_ints=[2])
+    # Get mean which size is [N, group, 1], for broadcasting
+    mean = op.ReduceMean(input_N_group_neg1, axes)
+    input_sub_mean = op.Sub(input_N_group_neg1, mean)
+    sqr_input_sub_mean = op.Mul(input_sub_mean, input_sub_mean)
+    # In Pytorch, vstd = 1/(sqrt(var + eps))
+    var = op.ReduceMean(sqr_input_sub_mean, axes, keepdims=False)
+    rstd = op.Div(1.0, op.Sqrt(var + eps))
+    # Get the correct shape [N, group] for mean again
+    mean = op.ReduceMean(input_N_group_neg1, axes, keepdims=False)
+    return norm_result, mean, rstd
+
+
+def aten_native_group_norm_backward(
+    grad_out: TensorType,
+    input: TensorType,
+    mean: TensorType,
+    rstd: TensorType,
+    weight: Optional[TensorType],
+    N: INT64,
+    C: INT64,
+    HxW: INT64,
+    group: int,
+    output_mask: Sequence[bool],
+) -> tuple[TensorType, TensorType, TensorType]:
+    """native_group_norm_backward(Tensor grad_out, Tensor input, Tensor mean, Tensor rstd, Tensor? weight, SymInt N, SymInt C, SymInt HxW, int group, bool[3] output_mask) -> (Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.native_layer_norm.default, trace_only=True)
+def aten_native_layer_norm(
+    input: TReal,
+    normalized_shape: Sequence[int],
+    weight: Optional[TReal] = None,
+    bias: Optional[TReal] = None,
+    eps: float = 1e-05,
+) -> Tuple[TReal, TReal, TReal]:
+    """native_layer_norm(Tensor input, SymInt[] normalized_shape, Tensor? weight, Tensor? bias, float eps) -> (Tensor, Tensor, Tensor)"""
+
+    # https://pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html#torch.nn.LayerNorm
+    # The mean and standard-deviation are calculated over the last D dimensions,
+    # where D is the dimension of normalized_shape. For example, if normalized_shape is
+    # (3, 5) (a 2-dimensional shape), the mean and standard-deviation are computed
+    # over the last 2 dimensions of the input (i.e. input.mean((-2, -1))).
+
+    start_axis = -len(normalized_shape)
+
+    if weight is None:
+        one = op.Constant(value_floats=[1.0])
+        weight = op.Expand(one, op.Shape(input, start=start_axis))
+        weight = op.CastLike(weight, input)
+
+    result, mean, rdenominator = op.LayerNormalization(
+        input, weight, bias, axis=start_axis, epsilon=eps
+    )
+
+    return result, mean, rdenominator
+
+
+def aten_native_layer_norm_backward(
+    grad_out: TensorType,
+    input: TensorType,
+    normalized_shape: INT64,
+    mean: TensorType,
+    rstd: TensorType,
+    weight: Optional[TensorType],
+    bias: Optional[TensorType],
+    output_mask: Sequence[bool],
+) -> tuple[TensorType, TensorType, TensorType]:
+    """native_layer_norm_backward(Tensor grad_out, Tensor input, SymInt[] normalized_shape, Tensor mean, Tensor rstd, Tensor? weight, Tensor? bias, bool[3] output_mask) -> (Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_native_norm(self: TensorType, p: float = 2.0) -> TensorType:
+    """native_norm(Tensor self, Scalar p=2) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(
+    (aten.ne.default, aten.ne.Scalar, aten.ne.Tensor, operator.ne), trace_only=True
+)
+def aten_ne(self: TReal, other: TReal) -> BOOL:
+    """ne.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Not(op.Equal(self, other))
+
+
+@onnx_impl((aten.neg.default, operator.neg), trace_only=True)
+def aten_neg(self: TReal) -> TReal:
+    """neg(Tensor self) -> Tensor"""
+
+    return op.Neg(self)
+
+
+def aten_negative(self: TensorType) -> TensorType:
+    """negative(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.new_empty.default, trace_only=True)
+def aten_new_empty(
+    self: TTensor,
+    size: INT64,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TTensor:
+    """new_empty(Tensor self, SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    # using zero to simulate empty array
+    result = op.ConstantOfShape(size)
+    if dtype == -1:
+        return op.CastLike(result, self)
+    return op.Cast(result, to=dtype)
+
+
+@onnx_impl(aten.new_empty_strided.default, trace_only=True)
+def aten_new_empty_strided(
+    self: TTensor,
+    size: INT64,
+    stride: INT64,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TTensor:
+    """new_empty_strided(Tensor self, SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    # using zero to simulate empty array
+    zero = op.ConstantOfShape(size)
+    if dtype == -1:
+        return op.CastLike(zero, self)
+    return op.Cast(zero, to=dtype)
+
+
+@onnx_impl(aten.new_full.default, trace_only=True)
+def aten_new_full(
+    self: TTensor,
+    size: INT64,
+    fill_value: TensorType,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TTensor:
+    # new_full(Tensor self, SymInt[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+
+    if dtype == -1:
+        fill_value = op.CastLike(fill_value, self)
+    else:
+        fill_value = op.Cast(fill_value, to=dtype)
+    return op.Expand(fill_value, size)
+
+
+@onnx_impl(aten.new_ones.default, trace_only=True)
+def aten_new_ones(
+    self: TReal,
+    size: INT64,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TReal:
+    """new_ones(Tensor self, SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    one = op.Constant(value_float=1.0)
+    result = op.Expand(one, size)
+    if dtype == -1:
+        return op.CastLike(result, self)
+    return op.Cast(result, to=dtype)
+
+
+@onnx_impl(aten.new_zeros.default, trace_only=True)
+def aten_new_zeros(
+    self: TReal,
+    size: INT64,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TReal:
+    """new_zeros(Tensor self, SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    result = op.ConstantOfShape(size)
+    if dtype == -1:
+        return op.CastLike(result, self)
+    return op.Cast(result, to=dtype)
+
+
+def aten_nextafter(self: TensorType, other: TensorType) -> TensorType:
+    """nextafter(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.nonzero.default)
+def aten_nonzero(self: TTensor) -> INT64:
+    """nonzero(Tensor self) -> Tensor"""
+    # NOTE: In torch the return shape is [n, d], while in onnx [d, n],
+    # where `d` is rank of input tensor, `n` is number of nonzero elements.
+    return op.Transpose(op.NonZero(self), perm=[1, 0])
+
+
+def aten_nonzero_numpy(self: TensorType) -> TensorType:
+    """nonzero_numpy(Tensor self) -> Tensor[]"""
+
+    raise NotImplementedError
+
+
+def aten_norm_except_dim(v: TensorType, pow: int = 2, dim: int = 0) -> TensorType:
+    """norm_except_dim(Tensor v, int pow=2, int dim=0) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(
+    (
+        aten.normal.Tensor_float,
+        aten.normal.Tensor_Tensor,
+        aten.normal.float_Tensor,
+        aten.normal.float_float,
+        aten.normal_functional.default,
+    ),
+    trace_only=True,
+)
+def aten_normal(
+    self: TTensor,
+    mean: float = 0.0,
+    std: float = 1.0,
+) -> TFloat:  # type: ignore[type-var]
+    """normal_functional(Tensor self, float mean=0, float std=1, *, Generator? generator=None) -> Tensor"""
+
+    if len(self.shape) == 0:
+        self = op.Reshape(self, op.Constant(value_ints=[-1]))
+
+    result = op.RandomNormalLike(self, mean=mean, scale=std)
+    return result
+
+
+@onnx_impl(aten.normal.float_float, trace_only=True)
+def aten_normal_float_float(
+    mean: float, std: float, size: INT64, dtype: int = FLOAT.dtype
+) -> TensorType:
+    """normal.float_float(float mean, float std, SymInt[] size, *, Generator? generator=None, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    if dtype == -1:
+        dtype = FLOAT.dtype
+    # Create a dummy tensor for RandomNormalLike to get the shape
+    dummy_tensor = op.ConstantOfShape(size)
+    result = op.RandomNormalLike(dummy_tensor, mean=mean, scale=std)
+    return op.Cast(result, to=dtype)
+
+
+@onnx_impl(aten.normal.float_Tensor)
+def aten_normal_float_tensor(mean: FLOAT, std: TFloat) -> TFloat:
+    """normal.float_Tensor(float mean, Tensor std, *, Generator? generator=None) -> Tensor"""
+
+    mean_casted = op.CastLike(mean, std)
+    sampled = op.RandomNormalLike(mean_casted, mean=0.0, scale=1.0)
+    # Transform the distribution to the mean and std
+    return op.Add(op.Mul(std, sampled), mean_casted)
+
+
+@onnx_impl(aten.normal.Tensor_float)
+def aten_normal_tensor_float(mean: TFloat, std: FLOAT) -> TFloat:
+    """normal.Tensor_float(Tensor mean, float std=1, *, Generator? generator=None) -> Tensor"""
+
+    sampled = op.RandomNormalLike(mean, mean=0.0, scale=1.0)
+    # Transform the distribution to the mean and std
+    return op.Add(op.Mul(op.CastLike(std, sampled), sampled), mean)
+
+
+@onnx_impl(aten.normal.Tensor_Tensor)
+def aten_normal_tensor_tensor(mean: TFloat, std: TFloat) -> TFloat:
+    """normal.Tensor_Tensor(Tensor mean, Tensor std, *, Generator? generator=None) -> Tensor"""
+
+    sampled = op.RandomNormalLike(mean, mean=0.0, scale=1.0)
+    # Transform the distribution to the mean and std
+    return op.Add(op.Mul(std, sampled), mean)
+
+
+def aten_not_equal(self: TensorType, other: TensorType) -> TensorType:
+    """not_equal.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_nuclear_norm(self: TensorType, keepdim: bool = False) -> TensorType:
+    """nuclear_norm(Tensor self, bool keepdim=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.ones.default, trace_only=True)
+def aten_ones(
+    size: IntType,
+    dtype: int = FLOAT.dtype,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+):
+    """ones(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+    if dtype == -1:
+        dtype = FLOAT.dtype
+    size = op.Cast(size, to=INT64.dtype)
+    one = op.Constant(value_float=1.0)
+    one = op.Cast(one, to=dtype)
+    return op.Expand(one, size)
+
+
+@onnx_impl(aten.ones_like.default, trace_only=True)
+def aten_ones_like(
+    self: TTensor,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+    memory_format: str = "",
+) -> TTensor:
+    """ones_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+
+    Note: dtype is an onnx enum. Users should convert torch dtype to onnx dtype
+    before calling this function.
+    """
+    if dtype is None:
+        dtype = -1
+
+    if dtype == -1:
+        one = op.CastLike(1, self)
+    else:
+        one = op.Cast(1, to=dtype)
+    shape = op.Shape(self)
+    return op.Expand(one, shape)
+
+
+def aten_or(self: TensorType, other: TensorType) -> TensorType:
+    """__or__.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_orgqr(self: TensorType, input2: TensorType) -> TensorType:
+    """orgqr(Tensor self, Tensor input2) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_ormqr(
+    self: TensorType,
+    input2: TensorType,
+    input3: TensorType,
+    left: bool = True,
+    transpose: bool = False,
+) -> TensorType:
+    """ormqr(Tensor self, Tensor input2, Tensor input3, bool left=True, bool transpose=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_outer(self: TensorType, vec2: TensorType) -> TensorType:
+    """outer(Tensor self, Tensor vec2) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_output_nr(self: TensorType) -> int:
+    """output_nr(Tensor self) -> int"""
+
+    raise NotImplementedError
+
+
+def aten_pairwise_distance(
+    x1: TensorType,
+    x2: TensorType,
+    p: float = 2.0,
+    eps: float = 1e-06,
+    keepdim: bool = False,
+) -> TensorType:
+    """pairwise_distance(Tensor x1, Tensor x2, float p=2, float eps=1e-06, bool keepdim=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_pdist(self: TensorType, p: float = 2.0) -> TensorType:
+    """pdist(Tensor self, float p=2) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.permute.default, trace_only=True)
+def aten_permute(self: TTensor, dims: Sequence[int]) -> TTensor:
+    """permute(Tensor(a) self, int[] dims) -> Tensor(a)"""
+
+    if not dims:
+        return op.Transpose(self)
+
+    # Handle negative axes
+    dims = [axis + len(dims) if axis < 0 else axis for axis in dims]
+
+    return op.Transpose(self, perm=dims)
+
+
+def aten_permute_copy(self: TensorType, dims: Sequence[int]) -> TensorType:
+    """permute_copy(Tensor self, int[] dims) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_pin_memory(self: TensorType, device: Optional[str] = None) -> TensorType:
+    """pin_memory(Tensor(a) self, Device? device=None) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def aten_pinverse(self: TensorType, rcond: float = 1e-15) -> TensorType:
+    """pinverse(Tensor self, float rcond=1e-15) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.pixel_shuffle.default)
+def aten_pixel_shuffle(self: TReal, upscale_factor: int) -> TReal:
+    """pixel_shuffle(Tensor self, int upscale_factor) -> Tensor"""
+    self_shape = op.Shape(self)
+    batch_dims = self_shape[:-3]
+    chw_in_dims = self_shape[-3:]
+    # Reshaping input by collapsing all leading dimensions to match ONNX op requirement (4D)
+    reshaped_self = op.Reshape(
+        self, op.Concat(op.Constant(value_ints=[-1]), chw_in_dims, axis=0)
+    )
+    depth_to_space = op.DepthToSpace(
+        reshaped_self, blocksize=upscale_factor, mode="CRD"
+    )
+    output_shape = op.Concat(batch_dims, op.Shape(depth_to_space)[1:], axis=0)
+    return op.Reshape(depth_to_space, output_shape)
+
+
+@onnx_impl(aten.pixel_unshuffle.default)
+def aten_pixel_unshuffle(self: TReal, downscale_factor: int) -> TReal:
+    """pixel_unshuffle(Tensor self, int downscale_factor) -> Tensor"""
+
+    self_shape = op.Shape(self)
+    batch_dims = self_shape[:-3]
+    chw_in_dims = self_shape[-3:]
+    # Reshaping input by collapsing all leading dimensions to match ONNX op requirement (4D)
+    reshaped_self = op.Reshape(
+        self, op.Concat(op.Constant(value_ints=[-1]), chw_in_dims, axis=0)
+    )
+    space_to_depth = op.SpaceToDepth(reshaped_self, blocksize=downscale_factor)
+    output_shape = op.Concat(batch_dims, op.Shape(space_to_depth)[1:], axis=0)
+    return op.Reshape(space_to_depth, output_shape)
+
+
+def aten_poisson(self: TensorType, generator: Optional[str] = None) -> TensorType:
+    """poisson(Tensor self, Generator? generator=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_poisson_nll_loss(
+    input: TensorType,
+    target: TensorType,
+    log_input: bool,
+    full: bool,
+    eps: float,
+    reduction: int,
+) -> TensorType:
+    """poisson_nll_loss(Tensor input, Tensor target, bool log_input, bool full, float eps, int reduction) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.polar.default)
+def aten_polar(abs: TFloat, angle: TFloat) -> TFloat:
+    """polar(Tensor abs, Tensor angle) -> Tensor"""
+
+    real = op.Unsqueeze(op.Mul(abs, op.Cos(angle)), axes=[-1])
+    imag = op.Unsqueeze(op.Mul(abs, op.Sin(angle)), axes=[-1])
+    return op.Concat(real, imag, axis=-1)
+
+
+def aten_polygamma(n: int, self: TensorType) -> TensorType:
+    """polygamma(int n, Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_positive(self: TensorType) -> TensorType:
+    """positive(Tensor(a) self) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(
+    (
+        aten.pow.Tensor_Tensor,
+        aten.pow.Tensor_Scalar,
+    ),
+    trace_only=True,
+)
+def aten_pow(self: TReal, exponent: TTensor) -> TReal:
+    """pow(Tensor self, Tensor exponent) -> Tensor"""
+    return op.Pow(self, exponent)
+
+
+@onnx_impl(
+    (
+        aten.pow.Scalar,
+        operator.pow,
+    ),
+    trace_only=True,
+)
+def aten_pow_scalar(self: float, exponent: TTensor) -> TTensor:
+    """pow.Scalar(Scalar self, Tensor exponent) -> Tensor"""
+
+    return op.Pow(op.Cast(self, to=exponent.dtype), exponent)
+
+
+@onnx_impl((aten.prelu.default, aten._prelu_kernel.default), trace_only=True)
+def aten_prelu(self: TReal, weight: TReal) -> TReal:
+    """prelu(Tensor self, Tensor weight) -> Tensor"""
+
+    rank = len(self.shape)
+    if rank == 0:
+        # e.g. self: [], weight: [1]
+        weight = op.Squeeze(weight)
+    elif rank >= 2:
+        # e.g. self: [5,10,5], weight: [10]
+        weight = op.Reshape(weight, [1, -1] + [1] * (rank - 2))
+    return op.PRelu(self, weight)
+
+
+def aten_prelu_backward(
+    grad_output: TensorType, self: TensorType, weight: TensorType
+) -> tuple[TensorType, TensorType]:
+    """prelu_backward(Tensor grad_output, Tensor self, Tensor weight) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.prod.default, trace_only=True)
+def aten_prod(self: TReal, dtype: int = -1) -> TReal:
+    """prod(Tensor self, *, ScalarType? dtype=None) -> Tensor"""
+
+    if dtype != -1 and dtype is not None:
+        self = op.Cast(self, to=dtype)
+    return op.ReduceProd(self)
+
+
+@onnx_impl(aten.prod.dim_int, trace_only=True)
+def aten_prod_dim_int(
+    self: TReal, dim: int, keepdim: bool = False, dtype: int = -1
+) -> TReal:
+    """prod.dim_int(Tensor self, int dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor"""
+
+    if dtype != -1 and dtype is not None:
+        self = op.Cast(self, to=dtype)
+    return op.ReduceProd(self, axes=[dim], keepdims=keepdim)
+
+
+def aten_promote_types(type1: int, type2: int) -> int:
+    """promote_types(ScalarType type1, ScalarType type2) -> ScalarType"""
+
+    raise NotImplementedError
+
+
+def aten_put(
+    self: TensorType, index: TensorType, source: TensorType, accumulate: bool = False
+) -> TensorType:
+    """put(Tensor self, Tensor index, Tensor source, bool accumulate=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_q_per_channel_axis(self: TensorType) -> int:
+    """q_per_channel_axis(Tensor self) -> int"""
+
+    raise NotImplementedError
+
+
+def aten_q_per_channel_scales(self: TensorType) -> TensorType:
+    """q_per_channel_scales(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_q_per_channel_zero_points(self: TensorType) -> TensorType:
+    """q_per_channel_zero_points(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_q_scale(self: TensorType) -> float:
+    """q_scale(Tensor self) -> float"""
+
+    raise NotImplementedError
+
+
+def aten_q_zero_point(self: TensorType) -> int:
+    """q_zero_point(Tensor self) -> int"""
+
+    raise NotImplementedError
+
+
+def aten_qr(self: TensorType, some: bool = True) -> tuple[TensorType, TensorType]:
+    """qr(Tensor self, bool some=True) -> (Tensor Q, Tensor R)"""
+
+    raise NotImplementedError
+
+
+def aten_qscheme(self: TensorType) -> str:
+    """qscheme(Tensor self) -> QScheme"""
+
+    raise NotImplementedError
+
+
+def aten_quantile(
+    self: TensorType,
+    q: TensorType,
+    dim: Optional[int] = None,
+    keepdim: bool = False,
+    interpolation: str = "linear",
+) -> TensorType:
+    """quantile(Tensor self, Tensor q, int? dim=None, bool keepdim=False, *, str interpolation='linear') -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_quantize_per_channel(
+    self: TensorType, scales: TensorType, zero_points: TensorType, axis: int, dtype: int
+) -> TensorType:
+    """quantize_per_channel(Tensor self, Tensor scales, Tensor zero_points, int axis, ScalarType dtype) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_quantize_per_tensor(
+    self: TensorType, scale: float, zero_point: int, dtype: int
+) -> TensorType:
+    """quantize_per_tensor(Tensor self, float scale, int zero_point, ScalarType dtype) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_quantize_per_tensor_dynamic(
+    self: TensorType, dtype: int, reduce_range: bool
+) -> TensorType:
+    """quantize_per_tensor_dynamic(Tensor self, ScalarType dtype, bool reduce_range) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_quantized_batch_norm(
+    input: TensorType,
+    weight: Optional[TensorType],
+    bias: Optional[TensorType],
+    mean: TensorType,
+    var: TensorType,
+    eps: float,
+    output_scale: float,
+    output_zero_point: int,
+) -> TensorType:
+    """quantized_batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_quantized_gru_cell(
+    input: TensorType,
+    hx: TensorType,
+    w_ih: TensorType,
+    w_hh: TensorType,
+    b_ih: TensorType,
+    b_hh: TensorType,
+    packed_ih: TensorType,
+    packed_hh: TensorType,
+    col_offsets_ih: TensorType,
+    col_offsets_hh: TensorType,
+    scale_ih: float,
+    scale_hh: float,
+    zero_point_ih: float,
+    zero_point_hh: float,
+) -> TensorType:
+    """quantized_gru_cell(Tensor input, Tensor hx, Tensor w_ih, Tensor w_hh, Tensor b_ih, Tensor b_hh, Tensor packed_ih, Tensor packed_hh, Tensor col_offsets_ih, Tensor col_offsets_hh, Scalar scale_ih, Scalar scale_hh, Scalar zero_point_ih, Scalar zero_point_hh) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_quantized_lstm_cell(
+    input: TensorType,
+    hx: Sequence[TensorType],
+    w_ih: TensorType,
+    w_hh: TensorType,
+    b_ih: TensorType,
+    b_hh: TensorType,
+    packed_ih: TensorType,
+    packed_hh: TensorType,
+    col_offsets_ih: TensorType,
+    col_offsets_hh: TensorType,
+    scale_ih: float,
+    scale_hh: float,
+    zero_point_ih: float,
+    zero_point_hh: float,
+) -> tuple[TensorType, TensorType]:
+    """quantized_lstm_cell(Tensor input, Tensor[] hx, Tensor w_ih, Tensor w_hh, Tensor b_ih, Tensor b_hh, Tensor packed_ih, Tensor packed_hh, Tensor col_offsets_ih, Tensor col_offsets_hh, Scalar scale_ih, Scalar scale_hh, Scalar zero_point_ih, Scalar zero_point_hh) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_quantized_max_pool1d(
+    self: TensorType,
+    kernel_size: Sequence[int],
+    stride: Optional[Sequence[int]] = None,
+    padding: Sequence[int] = (0,),
+    dilation: Sequence[int] = (1,),
+    ceil_mode: bool = False,
+) -> TensorType:
+    """quantized_max_pool1d(Tensor self, int[1] kernel_size, int[1] stride=[], int[1] padding=0, int[1] dilation=1, bool ceil_mode=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_quantized_max_pool2d(
+    self: TensorType,
+    kernel_size: Sequence[int],
+    stride: Optional[Sequence[int]] = None,
+    padding: Sequence[int] = (0, 0),
+    dilation: Sequence[int] = (1, 1),
+    ceil_mode: bool = False,
+) -> TensorType:
+    """quantized_max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_quantized_rnn_relu_cell(
+    input: TensorType,
+    hx: TensorType,
+    w_ih: TensorType,
+    w_hh: TensorType,
+    b_ih: TensorType,
+    b_hh: TensorType,
+    packed_ih: TensorType,
+    packed_hh: TensorType,
+    col_offsets_ih: TensorType,
+    col_offsets_hh: TensorType,
+    scale_ih: float,
+    scale_hh: float,
+    zero_point_ih: float,
+    zero_point_hh: float,
+) -> TensorType:
+    """quantized_rnn_relu_cell(Tensor input, Tensor hx, Tensor w_ih, Tensor w_hh, Tensor b_ih, Tensor b_hh, Tensor packed_ih, Tensor packed_hh, Tensor col_offsets_ih, Tensor col_offsets_hh, Scalar scale_ih, Scalar scale_hh, Scalar zero_point_ih, Scalar zero_point_hh) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_quantized_rnn_tanh_cell(
+    input: TensorType,
+    hx: TensorType,
+    w_ih: TensorType,
+    w_hh: TensorType,
+    b_ih: TensorType,
+    b_hh: TensorType,
+    packed_ih: TensorType,
+    packed_hh: TensorType,
+    col_offsets_ih: TensorType,
+    col_offsets_hh: TensorType,
+    scale_ih: float,
+    scale_hh: float,
+    zero_point_ih: float,
+    zero_point_hh: float,
+) -> TensorType:
+    """quantized_rnn_tanh_cell(Tensor input, Tensor hx, Tensor w_ih, Tensor w_hh, Tensor b_ih, Tensor b_hh, Tensor packed_ih, Tensor packed_hh, Tensor col_offsets_ih, Tensor col_offsets_hh, Scalar scale_ih, Scalar scale_hh, Scalar zero_point_ih, Scalar zero_point_hh) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.rad2deg.default, trace_only=True)
+def aten_rad2deg(self: TFloat) -> TFloat:
+    """rad2deg(Tensor self) -> Tensor"""
+
+    return op.Mul(self, op.CastLike(180.0 / _MATH_PI, self))
+
+
+@onnx_impl(aten.rand.default, trace_only=True)
+def aten_rand(
+    size: INT64,
+    dtype: int = FLOAT.dtype,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TReal:
+    """rand(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+    if dtype == -1:
+        dtype = FLOAT.dtype
+    shaper = op.ConstantOfShape(size)
+    return op.RandomUniformLike(shaper, dtype=dtype)
+
+
+@onnx_impl(aten.rand_like.default, trace_only=True)
+def aten_rand_like(
+    self: TFloat,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TFloat:
+    """rand_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor"""
+
+    if dtype == -1:
+        return op.RandomUniformLike(self)
+    return op.RandomUniformLike(self, dtype=dtype)
+
+
+@onnx_impl(aten.randint.default, trace_only=True)
+def aten_randint(
+    high: INT64,
+    size: INT64,
+    dtype: int = INT64.dtype,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TensorType:
+    """randint(SymInt high, SymInt[] size, *, ScalarType? dtype=long, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    shaper = op.ConstantOfShape(size)
+    rand = op.RandomUniformLike(shaper)
+    # Scale to [0, high] first
+    rand_scaled = op.Mul(rand, op.CastLike(high, rand))
+    # Round to ints
+    rand_int = op.Floor(rand_scaled)
+    return op.Cast(rand_int, to=dtype)
+
+
+@onnx_impl(aten.randint.low, trace_only=True)
+def aten_randint_low(
+    low: INT64,
+    high: INT64,
+    size: INT64,
+    dtype: int = INT64.dtype,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TensorType:
+    """randint.low(SymInt low, SymInt high, SymInt[] size, *, ScalarType? dtype=long, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    shaper = op.ConstantOfShape(size)
+    rand = op.RandomUniformLike(shaper)
+    # Translate to [low, high] first
+    high = op.Cast(high, to=FLOAT.dtype)
+    low = op.Cast(low, to=FLOAT.dtype)
+    rand_translated = op.Add(op.Mul(rand, op.Sub(high, low)), low)
+    # Round to ints
+    rand_int = op.Floor(rand_translated)
+    return op.Cast(rand_int, to=dtype)
+
+
+@onnx_impl(aten.randint_like.default, trace_only=True)
+def aten_randint_like(
+    self: TensorType,
+    high: INT64,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> IntType:
+    """randint_like(Tensor self, SymInt high, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor"""
+
+    self_float = op.Cast(self, to=FLOAT.dtype)
+    rand = op.RandomUniformLike(self_float)
+    # Scale to [0, high] first
+    rand_scaled = op.Mul(rand, op.CastLike(high, rand))
+    # Round to ints
+    rand_int = op.Floor(rand_scaled)
+    if dtype == -1:
+        return op.CastLike(rand_int, self)
+    return op.Cast(rand_int, to=dtype)
+
+
+@onnx_impl(aten.randint_like.low_dtype, trace_only=True)
+def aten_randint_like_low_dtype(
+    self: TensorType,
+    low: INT64,
+    high: INT64,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> IntType:
+    """randint_like.low_dtype(Tensor self, SymInt low, SymInt high, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+
+    This is the TorchLib overload for aten::randint_like.low_dtype when dtype is None.
+    """
+
+    self_float = op.Cast(self, to=FLOAT.dtype)
+    rand = op.RandomUniformLike(self_float)
+    # Translate to [low, high] first
+    high = op.Cast(high, to=FLOAT.dtype)
+    low = op.Cast(low, to=FLOAT.dtype)
+    rand_translated = op.Add(op.Mul(rand, op.Sub(high, low)), low)
+    # Round to ints
+    rand_int = op.Floor(rand_translated)
+    if dtype == -1:
+        return op.CastLike(rand_int, self)
+    return op.Cast(rand_int, to=dtype)
+
+
+@onnx_impl(aten.randn.default, trace_only=True)
+def aten_randn(
+    size: INT64,
+    dtype: int = FLOAT.dtype,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TReal:
+    """randn(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    shaper = op.ConstantOfShape(size)
+    return op.RandomNormalLike(shaper, dtype=dtype)
+
+
+@onnx_impl(aten.randn_like.default, trace_only=True)
+def aten_randn_like(
+    self: TFloat,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TFloat:
+    """randn_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor"""
+
+    if dtype == -1:
+        return op.RandomNormalLike(self)
+    return op.RandomNormalLike(self, dtype=dtype)
+
+
+def aten_randperm(
+    n: int, layout: str = "", device: str = "", pin_memory: bool = False
+) -> TensorType:
+    """randperm(int n, *, ScalarType? dtype=long, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_range(
+    start: float,
+    end: float,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TensorType:
+    """range(Scalar start, Scalar end, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_ravel(self: TensorType) -> TensorType:
+    """ravel(Tensor(a) self) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def aten_real(self: TensorType) -> TensorType:
+    """real(Tensor(a) self) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.reciprocal.default, trace_only=True)
+def aten_reciprocal(self: TFloat) -> TFloat:
+    """reciprocal(Tensor self) -> Tensor"""
+
+    return op.Reciprocal(self)
+
+
+def aten_record_stream(self: TensorType, s: str) -> Any:
+    """record_stream(Tensor(a!) self, Stream s) -> ()"""
+
+    raise NotImplementedError
+
+
+def aten_refine_names(self: TensorType, names: Sequence[str]) -> TensorType:
+    """refine_names(Tensor(a) self, Dimname[] names) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl((aten.remainder.Tensor, aten.remainder.Scalar), trace_only=True)
+def aten_remainder(self: TFloat, other: TFloat) -> TFloat:
+    """remainder.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    # TODO(justinchuby): Improve fp16 precision by following the logic in
+    # https://github.com/pytorch/pytorch/blob/3a823e46170778cc32783f27596c77d0103084a9/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp#L264-L277
+
+    # a - a.div(b, rounding_mode="floor") * b
+    rounded_quotient = op.Floor(op.Div(self, other))
+
+    return op.Sub(self, op.Mul(rounded_quotient, other))
+
+
+@onnx_impl(
+    (aten.remainder.Tensor, aten.remainder.Scalar, operator.mod), trace_only=True
+)
+def aten_remainder_int(self: TInt, other: TInt) -> TInt:
+    """remainder.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Mod(self, other)
+
+
+def aten_rename(self: TensorType, names: Optional[str]) -> TensorType:
+    """rename(Tensor(a) self, Dimname[]? names) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def aten_renorm(self: TensorType, p: float, dim: int, maxnorm: float) -> TensorType:
+    """renorm(Tensor self, Scalar p, int dim, Scalar maxnorm) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.repeat.default)
+def aten_repeat(self: TTensor, repeats: TInt) -> TTensor:
+    """repeat(Tensor self, SymInt[] repeats) -> Tensor"""
+
+    if op.Size(repeats) == 0:
+        result = self
+    else:
+        # TODO(justinchuby): Make ones_like a function when onnxscript supports it
+        repeats = op.Cast(repeats, to=INT64.dtype)
+        # shape = ones_like(repeats) := {
+        one = op.Constant(value_int=1)
+        repeats_shape = op.Shape(repeats)
+        shape = op.Expand(one, repeats_shape)
+        # }
+        self_expanded = op.Expand(self, shape)
+        result = op.Tile(self_expanded, repeats)
+    return result
+
+
+def aten_repeat_interleave(
+    repeats: TensorType, output_size: Optional[int] = None
+) -> TensorType:
+    """repeat_interleave.Tensor(Tensor repeats, *, int? output_size=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.reshape.default)
+def aten_reshape(self: TTensor, shape: IntType) -> TTensor:
+    """reshape(Tensor(a) self, SymInt[] shape) -> Tensor(a)"""
+
+    # Reshape only support INT64 as 'shape'
+    shape = op.Cast(shape, to=INT64.dtype)
+    return op.Reshape(self, shape)
+
+
+def aten_reshape_as(self: TensorType, other: TensorType) -> TensorType:
+    """reshape_as(Tensor(a) self, Tensor other) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.resolve_conj.default, trace_only=True)
+def aten_resolve_conj(self: TTensor) -> TTensor:
+    """resolve_conj(Tensor(a) self) -> Tensor(a)"""
+
+    return op.Identity(self)
+
+
+@onnx_impl(aten.resolve_neg.default, trace_only=True)
+def aten_resolve_neg(self: TTensor) -> TTensor:
+    """resolve_neg(Tensor(a) self) -> Tensor(a)"""
+
+    return op.Identity(self)
+
+
+def aten_result_type(tensor: TensorType, other: TensorType) -> int:
+    """result_type.Tensor(Tensor tensor, Tensor other) -> ScalarType"""
+
+    raise NotImplementedError
+
+
+def aten_retain_grad(self: TensorType) -> Any:
+    """retain_grad(Tensor(a!) self) -> ()"""
+
+    raise NotImplementedError
+
+
+def aten_retains_grad(self: TensorType) -> bool:
+    """retains_grad(Tensor self) -> bool"""
+
+    raise NotImplementedError
+
+
+def aten_rnn_relu_cell(
+    input: TensorType,
+    hx: TensorType,
+    w_ih: TensorType,
+    w_hh: TensorType,
+    b_ih: Optional[TensorType] = None,
+    b_hh: Optional[TensorType] = None,
+) -> TensorType:
+    """rnn_relu_cell(Tensor input, Tensor hx, Tensor w_ih, Tensor w_hh, Tensor? b_ih=None, Tensor? b_hh=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_rnn_tanh_cell(
+    input: TensorType,
+    hx: TensorType,
+    w_ih: TensorType,
+    w_hh: TensorType,
+    b_ih: Optional[TensorType] = None,
+    b_hh: Optional[TensorType] = None,
+) -> TensorType:
+    """rnn_tanh_cell(Tensor input, Tensor hx, Tensor w_ih, Tensor w_hh, Tensor? b_ih=None, Tensor? b_hh=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.roll.default, trace_only=True)
+def aten_roll(
+    self: TTensor, shifts: Sequence[int], dims: Sequence[int] = ()
+) -> TTensor:
+    """roll(Tensor self, int[1] shifts, int[1] dims=[]) -> Tensor"""
+
+    self_rank = len(self.shape)
+    if self_rank == 0:
+        return op.Identity(self)
+    elif self.shape[0] == 0:  # empty tensor
+        return op.Identity(self)
+    else:
+        # NOTE: In pytorch, default value of dims is an empty list.
+        if len(dims) == 0:  # Empty sequence
+            # assert isinstance(shifts, int)
+            return _aten_roll_shift_no_dim_onnx(self, shifts)
+        else:
+            # assert len(shifts) == len(dims), but shifts is a tensor, dims is a list
+            result = self
+            for i, shift in enumerate(shifts):
+                dim = dims[i]
+                result = _aten_roll_shift_and_dim_onnx(result, shift, dim)
+            return result
+
+
+@onnx_impl(aten.roll.default, trace_only=True, complex=True)
+def aten_roll_complex(
+    self: TTensor, shifts: Sequence[int], dims: Sequence[int] = ()
+) -> TTensor:
+    """roll(Tensor self, int[1] shifts, int[1] dims=[]) -> Tensor"""
+
+    self_rank = len(self.shape)
+    if self_rank == 1:
+        return op.Identity(self)
+
+    if self.shape[0] == 0:  # empty tensor
+        return op.Identity(self)
+
+    self_real = op.Slice(self, [0], [1], axes=[-1])
+    self_imag = op.Slice(self, [1], [2], axes=[-1])
+    if not dims:
+        # assert isinstance(shifts, int)
+        shift_real = _aten_roll_shift_no_dim_onnx(self_real, shifts)
+        shift_imag = _aten_roll_shift_no_dim_onnx(self_imag, shifts)
+
+        result = op.Concat(shift_real, shift_imag, axis=-1)
+
+    else:
+        # assert len(shifts) == len(dims), but shifts is a tensor, dims is a list
+        for i, dim in enumerate(dims):
+            shift = op.Gather(shifts, i, axis=0)
+            self_real = _aten_roll_shift_and_dim_onnx(self_real, shift, dim)
+            self_imag = _aten_roll_shift_and_dim_onnx(self_imag, shift, dim)
+
+        result = op.Concat(self_real, self_imag, axis=-1)
+    return result
+
+
+@onnx_impl(aten.roll.default, private=True)
+def _aten_roll_shift_no_dim_onnx(self: TTensor, shift: INT64) -> TTensor:
+    neg_1 = op.Constant(value_ints=[-1])
+    # flatten the self tensor: from [[A,B],[C,D]] to [A,B,C,D]
+    self_flatten = op.Reshape(self, neg_1)
+    # Compute slice length
+    shift_tensor = op.Reshape(shift, neg_1)
+    if shift_tensor < 0:
+        # For [A,B,C,D], if shift is -1, slice_length = -(-1) = 1, means move [A] to the end
+        slice_length = -shift_tensor
+    else:
+        # For [A,B,C,D], if shift is 1, slice_length = 4 - 1 = 3, means move [A,B,C] to the end
+        # The effect equals to move [D] to the beginning
+        slice_length = op.Size(self_flatten) - shift_tensor
+    # Get second part of the tensor, e.g. [A,B,C]
+    suffix = op.Slice(self_flatten, op.Constant(value_ints=[0]), slice_length)
+    # Get first part of the tensor, e.g. [D]
+    prefix = op.Slice(
+        self_flatten, slice_length, op.Reshape(op.Size(self_flatten), neg_1)
+    )
+    # Concat first+second together, e.g. [D,A,B,C]
+    result = op.Concat(prefix, suffix, axis=0)
+    return op.Reshape(result, op.Shape(self))
+
+
+@onnx_impl(aten.roll.default, private=True)
+def _aten_roll_shift_and_dim_onnx(self: TTensor, shift: INT64, dim: int) -> TTensor:
+    neg_1 = op.Constant(value_ints=[-1])
+    dim_tensor = op.Reshape(op.Constant(value_int=dim), neg_1)
+    shift_tensor = op.Reshape(shift, neg_1)
+    if shift_tensor < 0:
+        slice_length = -shift_tensor
+    else:
+        slice_length = op.Gather(op.Shape(self), dim_tensor, axis=0) - shift_tensor
+    # from [A,B,C,D] -> [D,A,B,C], [D] is prefix, [A,B,C] is suffix
+    suffix = op.Slice(self, op.Constant(value_ints=[0]), slice_length, axes=dim_tensor)
+    prefix = op.Slice(
+        self, slice_length, op.Reshape(op.Size(self), neg_1), axes=dim_tensor
+    )
+    result = op.Concat(prefix, suffix, axis=dim)
+    return result
+
+
+def aten_rot90(
+    self: TensorType, k: int = 1, dims: Sequence[int] = (0, 1)
+) -> TensorType:
+    """rot90(Tensor self, int k=1, int[] dims=[0,1]) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.round.default, trace_only=True)
+def aten_round(self: TFloat) -> TFloat:
+    """round(Tensor self) -> Tensor"""
+
+    return op.Round(self)
+
+
+@onnx_impl(aten.round.decimals)
+def aten_round_decimals(self: TFloat, decimals: int = 0) -> TFloat:
+    """round.decimals(Tensor self, *, int decimals) -> Tensor"""
+
+    # Scale the input by 10^decimals, round it, and scale it back.
+    ten = op.CastLike(10.0, self)
+    scale = op.Pow(ten, op.CastLike(decimals, self))
+    self_scaled = op.Mul(self, scale)
+    rounded = op.Round(self_scaled)
+    return op.Div(rounded, scale)
+
+
+def aten_row_indices(self: TensorType) -> TensorType:
+    """row_indices(Tensor(a) self) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def aten_row_indices_copy(self: TensorType) -> TensorType:
+    """row_indices_copy(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_row_stack(tensors: Sequence[TensorType]) -> TensorType:
+    """row_stack(Tensor[] tensors) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_rrelu(
+    self: TensorType,
+    lower: float = 0.125,
+    upper: float = 0.3333333333333333,
+    training: bool = False,
+    generator: Optional[str] = None,
+) -> TensorType:
+    """rrelu(Tensor self, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.rsqrt.default, trace_only=True)
+def aten_rsqrt(self: TFloat) -> TFloat:
+    """rsqrt(Tensor self) -> Tensor"""
+
+    return op.Reciprocal(op.Sqrt(self))
+
+
+# Do not register rsub. It will be decomposed and type promoted by torch
+def aten_rsub(self: TReal, other: TReal, alpha: float = 1.0) -> TReal:
+    """rsub.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.scalar_tensor.default, trace_only=True)
+def aten_scalar_tensor(
+    s: float,
+    dtype: int = FLOAT.dtype,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> RealType:
+    """scalar_tensor(Scalar s, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+    if dtype == -1:
+        dtype = FLOAT.dtype
+    # Set trace_only=True because different if branches return different dtypes
+    # which is not supported in an ONNX function
+    return common_ops.cast_to(s, dtype=dtype)
+
+
+@onnx_impl(aten.scalar_tensor.default, trace_only=True, complex=True)
+def aten_scalar_tensor_complex(
+    s: Union[FLOAT, DOUBLE],
+    dtype: int = COMPLEX64.dtype,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> RealType:
+    """scalar_tensor(Scalar s, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+    # NOTE: When the input is originally in complex, this function is invoked.
+    # On the other hand, when the input is originally in real, aten_scalar_tensor is used.
+    # is invoked.
+    if dtype == -1:
+        dtype = COMPLEX64.dtype
+    if dtype == COMPLEX128.dtype:
+        result = op.Cast(s, to=DOUBLE.dtype)
+    elif dtype == COMPLEX64.dtype:
+        result = op.Cast(s, to=FLOAT.dtype)
+    else:
+        # NOTE: No-op for non-complex dtype
+        # It's potentially a bug if it comes here with no-op.
+        result = s
+    return result
+
+
+@onnx_impl(aten.scalar_tensor.default, trace_only=True)
+def aten_scalar_tensor_sym_number(
+    s: TensorType,
+    dtype: int = FLOAT.dtype,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> RealType:
+    """scalar_tensor(Scalar s, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+    if dtype == -1:
+        dtype = FLOAT.dtype
+    return common_ops.cast_to(s, dtype=dtype)
+
+
+@onnx_impl(aten.scatter.value, trace_only=True)
+def aten_scatter(
+    self: TReal,
+    dim: int,  # we have to use int here because ScatterElements() will use this attribute
+    index: TInt,
+    src: TReal,
+) -> TReal:
+    """scatter_add(Tensor self, int dim, Tensor index, Tensor src) -> Tensor"""
+
+    update = op.Expand(src, op.Shape(index))
+    return op.ScatterElements(self, index, update, axis=dim)
+
+
+@onnx_impl(aten.scatter_add.default)
+def aten_scatter_add(
+    self: TReal,
+    dim: int,  # we have to use int here because ScatterElements() will use this attribute
+    index: TInt,
+    src: TReal,
+) -> TReal:
+    """scatter_add(Tensor self, int dim, Tensor index, Tensor src) -> Tensor"""
+
+    # if rank(self) == 0 will lead ORT failed, skipped
+    return op.ScatterElements(self, index, src, axis=dim, reduction="add")
+
+
+@onnx_impl(aten.scatter_reduce.two, trace_only=True)
+def aten_scatter_reduce(
+    self: TReal,
+    dim: int,  # we have to use int here because ScatterElements() will use this attribute
+    index: TInt,
+    src: TReal,
+    reduce: str,
+    include_self: bool = True,
+):
+    """scatter_reduce.two(Tensor self, int dim, Tensor index, Tensor src, str reduce, *, bool include_self=True) -> Tensor"""
+
+    reduce_mode = {  # convert torch string name to onnx string name
+        "mean": "none",  # 'mean' doesn't support in ONNX 1.14 definition
+        "sum": "add",
+        "prod": "mul",
+        "amin": "min",
+        "amax": "max",
+    }
+    onnx_reduce = reduce_mode[reduce]
+    self_is_scalar = len(self.shape) == 0
+    if self_is_scalar:  # assert (index_rank == 0 and rank_src == 0)
+        neg_1 = op.Constant(value_ints=[-1])
+        self = op.Reshape(self, neg_1)
+        index = op.Reshape(index, neg_1)
+        src = op.Reshape(src, neg_1)
+    result = op.ScatterElements(self, index, src, axis=dim, reduction=onnx_reduce)
+    if self_is_scalar:
+        result = op.Squeeze(result)
+    return result
+
+
+def aten_searchsorted(
+    sorted_sequence: TensorType,
+    self: TensorType,
+    out_int32: bool = False,
+    right: bool = False,
+    side: Optional[str] = None,
+    sorter: Optional[TensorType] = None,
+) -> TensorType:
+    """searchsorted.Tensor(Tensor sorted_sequence, Tensor self, *, bool out_int32=False, bool right=False, str? side=None, Tensor? sorter=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_segment_reduce(
+    data: TensorType,
+    reduce: str,
+    lengths: Optional[TensorType] = None,
+    indices: Optional[TensorType] = None,
+    offsets: Optional[TensorType] = None,
+    axis: int = 0,
+    unsafe: bool = False,
+    initial: Optional[float] = None,
+) -> TensorType:
+    """segment_reduce(Tensor data, str reduce, *, Tensor? lengths=None, Tensor? indices=None, Tensor? offsets=None, int axis=0, bool unsafe=False, Scalar? initial=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.select.int, trace_only=True)
+def aten_select(self: TTensor, dim: int, index: int) -> TTensor:
+    """select(Tensor self, int dim, int index) -> Tensor"""
+
+    return op.Gather(self, index, axis=dim)
+
+
+def aten_select_backward(
+    grad_output: TensorType, input_sizes: INT64, dim: int, index: int
+) -> TensorType:
+    """select_backward(Tensor grad_output, SymInt[] input_sizes, int dim, int index) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.select_scatter.default)
+def aten_select_scatter(
+    self: TensorType, src: TensorType, dim: int, index: int
+) -> TensorType:
+    """select_scatter(Tensor self, Tensor src, int dim, int index) -> Tensor"""
+
+    # Change src rank to self rank according to dim
+    # e.g. if self is [2,3,4], src is [2,4], dim=1, then update is [2,1,4]
+    update = op.Unsqueeze(src, axes=dim)
+    # Change index rank to the same as 'update' [2,1,4]
+    indices = op.Expand(index, op.Shape(update))
+    return op.ScatterElements(self, indices, update, axis=dim, reduction="none")
+
+
+@onnx_impl(aten.selu.default)
+def aten_selu(self: TFloat) -> TFloat:
+    """selu(Tensor self) -> Tensor"""
+
+    return op.Selu(self)
+
+
+def aten_set_data(self: TensorType, new_data: TensorType) -> Any:
+    """set_data(Tensor(a!) self, Tensor new_data) -> ()"""
+
+    raise NotImplementedError
+
+
+def aten_sgn(self: TensorType) -> TensorType:
+    """sgn(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.sigmoid.default, trace_only=True)
+def aten_sigmoid(self: TFloat) -> TFloat:
+    """sigmoid(Tensor self) -> Tensor"""
+
+    return op.Sigmoid(self)
+
+
+@onnx_impl(aten.sign.default)
+def aten_sign(self: TReal) -> TReal:
+    """sign(Tensor self) -> Tensor"""
+
+    return op.Sign(self)
+
+
+def aten_signbit(self: TensorType) -> TensorType:
+    """signbit(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.sin.default, trace_only=True)
+def aten_sin(self: TFloat) -> TFloat:
+    """sin(Tensor self) -> Tensor"""
+
+    return op.Sin(self)
+
+
+@onnx_impl(aten.sinh.default, trace_only=True)
+def aten_sinh(self: TFloat) -> TFloat:
+    """sinh(Tensor self) -> Tensor"""
+
+    return op.Sinh(self)
+
+
+@onnx_impl((aten.slice.Tensor), trace_only=True)
+def aten_slice(
+    self: TTensor,
+    dim: int = 0,
+    start: Optional[INT64] = None,
+    end: Optional[INT64] = None,
+    step: Optional[INT64] = None,
+) -> TTensor:
+    """slice.Tensor(Tensor(a) self, int dim=0, SymInt? start=None, SymInt? end=None, SymInt step=1) -> Tensor(a)"""
+
+    # TODO: using OptionalHasElement() to check start/end value
+    if start is not None:
+        start = op.Cast(start, to=INT64.dtype)
+        start = op.Reshape(start, op.Constant(value_ints=[-1]))
+    else:
+        start = op.Constant(value_ints=[0])
+
+    if end is not None:
+        end = op.Cast(end, to=INT64.dtype)
+        end = op.Reshape(end, op.Constant(value_ints=[-1]))
+    else:
+        end = op.Constant(value_ints=[_INT64_MAX])
+
+    dim = op.Cast(dim, to=INT64.dtype)
+    dim = op.Reshape(dim, op.Constant(value_ints=[-1]))
+
+    if step is not None:
+        step = op.Cast(step, to=INT64.dtype)
+        step = op.Reshape(step, op.Constant(value_ints=[-1]))
+    else:
+        step = op.Constant(value_ints=[1])
+
+    return op.Slice(self, start, end, dim, step)
+
+
+def aten_slice_backward(
+    grad_output: TensorType,
+    input_sizes: INT64,
+    dim: int,
+    start: INT64,
+    end: INT64,
+    step: INT64,
+) -> TensorType:
+    """slice_backward(Tensor grad_output, SymInt[] input_sizes, int dim, SymInt start, SymInt end, SymInt step) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_slice_copy(
+    self: TensorType,
+    dim: int = 0,
+    start: Optional[INT64] = None,
+    end: Optional[INT64] = None,
+    step: INT64 = 1,
+) -> TensorType:
+    """slice_copy.Tensor(Tensor self, int dim=0, SymInt? start=None, SymInt? end=None, SymInt step=1) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.slice_scatter.default, trace_only=True)
+def aten_slice_scatter(
+    self: TTensor,
+    src: TTensor,
+    dim: int = 0,
+    start: Optional[INT64] = None,
+    end: Optional[INT64] = None,
+    step: INT64 = 1,
+) -> TTensor:
+    """slice_scatter(Tensor self, Tensor src, int dim=0, SymInt? start=None, SymInt? end=None, SymInt step=1) -> Tensor"""
+
+    # Although 'start' and 'end' can be None in signature, but actually 'start' must be specified
+    # Assert(start is not None)
+    # And, 'end' also must be specified, and end-start must be equal to the size of 'src'
+    # Assert(end-start == shape(src) > 0)
+    # Try torch sample to get more information:
+    # https://pytorch.org/docs/master/generated/torch.slice_scatter.html?highlight=slice_scatter#torch.slice_scatter
+    # Take (torch.zeros(8, 8), torch.ones(2, 8), 0, 6, 64, 1) as example:
+    # Step 1: get 1D tensor from 0 to dim_size-1, then Slice it using start, end and step.
+    # We cannot use Range(start, end, step) directly as start or end may out of range.
+    # For the example, the output of this step is Slice([0, ..., 7], 6, 64, 1) = [6, 7]
+
+    # Scatter ND
+    zero = op.Constant(value_ints=[0])
+    self_shape = op.Shape(self)
+    dim_shape = op.Gather(self_shape, dim, axis=0)
+    index_base = op.Range(0, dim_shape, 1)
+    index_base = op.Slice(
+        index_base,
+        op.Unsqueeze(start, zero),
+        op.Unsqueeze(end, zero),
+        zero,
+        op.Unsqueeze(step, zero),
+    )
+    index_base = op.Unsqueeze(index_base, -1)
+
+    # Use trace only to construct the perm attribute in Transpose
+    dims = None
+    if dim != 0:
+        src_rank = len(src.shape)  # type: ignore[attr-defined]
+
+        if src_rank != 0:
+            # Python code, change when onnxscript supports this
+            dims = list(range(src_rank))
+            dims[0], dims[dim] = dims[dim], dims[0]
+            # Python code ends
+
+            src = op.Transpose(src, perm=dims)
+            self = op.Transpose(self, perm=dims)
+
+    output = op.ScatterND(self, index_base, src)
+    if dims is not None:
+        output = op.Transpose(output, perm=dims)
+    return output
+
+
+def aten_slogdet(self: TensorType) -> tuple[TensorType, TensorType]:
+    """slogdet(Tensor self) -> (Tensor sign, Tensor logabsdet)"""
+
+    raise NotImplementedError
+
+
+def aten_smm(self: TensorType, mat2: TensorType) -> TensorType:
+    """smm(Tensor self, Tensor mat2) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl((aten.softmax.int, aten.special_softmax.default), trace_only=True)
+def aten_softmax(self: TFloat, dim: int, dtype: int = -1) -> TFloat:
+    """softmax(Tensor self, int dim, ScalarType? dtype=None) -> Tensor"""
+
+    self_is_scalar = len(self.shape) == 0
+    if self_is_scalar:
+        self = op.Unsqueeze(self, op.Constant(value_ints=[0]))
+    result = op.Softmax(self, axis=dim)
+    if dtype != -1:
+        result = op.Cast(result, to=dtype)
+    if self_is_scalar:
+        # Convert to scalar when input is scalar
+        result = op.Squeeze(result)
+
+    return result
+
+
+@onnx_impl((aten.softmax.int, aten.special_softmax.default), trace_only=True)
+def aten_softmax_no_dtype(self: TFloat, dim: int) -> TFloat:
+    """softmax(Tensor self, int dim, ScalarType? dtype=None) -> Tensor"""
+
+    self_is_scalar = len(self.shape) == 0
+    if self_is_scalar:
+        self = op.Unsqueeze(self, op.Constant(value_ints=[0]))
+    result = op.Softmax(self, axis=dim)
+    if self_is_scalar:
+        # Convert to scalar when input is scalar
+        result = op.Squeeze(result)
+
+    return result
+
+
+@onnx_impl(aten.sort.default, trace_only=True)
+def aten_sort(
+    self: TReal, dim: int = -1, descending: bool = False, stable: bool = False
+) -> tuple[TReal, INT64]:
+    """sort(Tensor self, int dim=-1, bool descending=False, bool stable=False) -> (Tensor values, Tensor indices)"""
+
+    self_is_scalar = len(self.shape) == 0
+    if self_is_scalar:
+        return op.Identity(self), op.Constant(value_int=0)
+    shape = op.Shape(self)
+    dim_size = op.Gather(shape, dim, axis=0)
+    dim_size = op.Reshape(dim_size, op.Constant(value_ints=[1]))
+    values, indices = op.TopK(self, dim_size, axis=dim, largest=descending, sorted=True)
+    return values, indices
+
+
+def aten_sparse_dim(self: TensorType) -> int:
+    """sparse_dim(Tensor self) -> int"""
+
+    raise NotImplementedError
+
+
+def aten_sparse_mask(self: TensorType, mask: TensorType) -> TensorType:
+    """sparse_mask(Tensor self, Tensor mask) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl((aten.split.default, aten.split.Tensor))
+def aten_split(self: TTensor, split_size: INT64, dim: int = 0) -> TTensor:
+    """split.Tensor(Tensor(a -> *) self, SymInt split_size, int dim=0) -> Tensor(a)[]"""
+
+    return op.SplitToSequence(self, split_size, axis=dim)
+
+
+def aten_split_copy(self: TensorType, split_size: INT64, dim: int = 0) -> TensorType:
+    """split_copy.Tensor(Tensor self, SymInt split_size, int dim=0) -> Tensor[]"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.split_with_sizes.default)
+def aten_split_with_sizes(self: TTensor, split_sizes: INT64, dim: int = 0) -> TTensor:
+    """split_with_sizes(Tensor(a -> *) self, SymInt[] split_sizes, int dim=0) -> Tensor(a)[]"""
+
+    return op.SplitToSequence(self, split_sizes, axis=dim)
+
+
+def aten_split_with_sizes_copy(
+    self: TensorType, split_sizes: INT64, dim: int = 0
+) -> TensorType:
+    """split_with_sizes_copy(Tensor self, SymInt[] split_sizes, int dim=0) -> Tensor[]"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.sqrt.default, trace_only=True)
+def aten_sqrt(self: TFloat) -> TFloat:
+    """sqrt(Tensor self) -> Tensor"""
+
+    return op.Sqrt(self)
+
+
+def aten_square(self: TensorType) -> TensorType:
+    """square(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.squeeze.default)
+def aten_squeeze(self: TTensor) -> TTensor:
+    """squeeze(Tensor(a) self) -> Tensor(a)"""
+
+    return op.Squeeze(self)
+
+
+@onnx_impl(aten.squeeze.dim, trace_only=True)
+def aten_squeeze_dim(self: TTensor, dim: int) -> TTensor:
+    """squeeze.dim(Tensor(a) self, int dim) -> Tensor(a)"""
+    if len(self.shape) == 0:
+        return op.Identity(self)
+    return op.Squeeze(self, [dim])
+
+
+@onnx_impl(aten.squeeze.dim, complex=True, trace_only=True)
+def aten_squeeze_dim_complex(self: TTensor, dim: int) -> TTensor:
+    if len(self.shape) == 1:
+        # The single dimension is the complex dimension
+        return op.Identity(self)
+    if dim < 0:
+        # Account for the complex dimension in ONNX
+        dim = dim - 1
+
+    return aten_squeeze_dim(self, dim)
+
+
+@onnx_impl(aten.squeeze.dims, trace_only=True)
+def aten_squeeze_dims(self: TTensor, dim: Sequence[int]) -> TTensor:
+    """squeeze.dims(Tensor(a) self, int[] dim) -> Tensor(a)"""
+    if len(self.shape) == 0:
+        return op.Identity(self)
+    return op.Squeeze(self, dim)
+
+
+@onnx_impl(aten.squeeze.dims, complex=True, trace_only=True)
+def aten_squeeze_dims_complex(self: TTensor, dim: Sequence[int]) -> TTensor:
+    if len(self.shape) == 1:
+        # The single dimension is the complex dimension
+        return op.Identity(self)
+    dims = []
+    for d in dim:
+        if d < 0:
+            # Account for the complex dimension in ONNX
+            d = d - 1
+        dims.append(d)
+    return aten_squeeze_dims(self, dims)
+
+
+def aten_squeeze_copy(self: TensorType) -> TensorType:
+    """squeeze_copy(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_sspaddmm(
+    self: TensorType,
+    mat1: TensorType,
+    mat2: TensorType,
+    beta: float = 1.0,
+    alpha: float = 1.0,
+) -> TensorType:
+    """sspaddmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.stack.default, trace_only=True, complex=True)
+def aten_stack_complex(
+    tensors: Sequence[TTensorOrString], dim: int = 0
+) -> TTensorOrString:
+    """stack(Tensor[] tensors, int dim=0) -> Tensor"""
+    # Real representation unsqueezes the last dimension
+    if dim < 0:
+        dim = dim - 1
+    return aten_stack(tensors, dim)
+
+
+@onnx_impl(aten.stack.default, trace_only=True)
+def aten_stack(tensors: Sequence[TTensorOrString], dim: int = 0) -> TTensorOrString:
+    """stack(Tensor[] tensors, int dim=0) -> Tensor"""
+    if isinstance(tensors, Sequence):
+        unsqueezed = [op.Unsqueeze(t, op.Constant(value_ints=[dim])) for t in tensors]
+        return op.Concat(*unsqueezed, axis=dim)
+    return op.ConcatFromSequence(tensors, axis=dim, new_axis=1)
+
+
+# std is decomposed by PyTroch
+def aten_std(self: TReal, unbiased: bool = True) -> TReal:
+    """std(Tensor self, bool unbiased=True) -> Tensor"""
+    var = _aten_var_onnx(self, correction=float(unbiased), keepdim=False)
+    return op.Sqrt(var)
+
+
+# std_dim is decomposed by PyTroch
+def aten_std_dim(
+    self: TReal,
+    dim: Sequence[int],
+    unbiased: Optional[bool] = True,
+    keepdim: Optional[bool] = False,
+) -> TReal:
+    """std.dim(Tensor self, int[1]? dim, bool unbiased=True, bool keepdim=False) -> Tensor"""
+
+    var = _aten_var_dim_onnx(
+        self, dims=dim, correction=float(unbiased), keepdim=keepdim
+    )
+    return op.Sqrt(var)
+
+
+# std is decomposed by PyTroch
+def aten_std_correction(
+    self: TReal,
+    # FIXME(justinchuby): Make dim Optional[Sequence[int]]
+    dim: Optional[int] = None,
+    correction: Optional[float] = None,
+    keepdim: bool = False,
+) -> TReal:
+    """std.correction(Tensor self, int[1]? dim=None, *, Scalar? correction=None, bool keepdim=False) -> Tensor"""
+
+    if correction is None:
+        correction = 1.0
+
+    if dim is None:
+        var = _aten_var_onnx(self, correction=correction, keepdim=keepdim)
+    else:
+        var = _aten_var_dim_onnx(self, dims=dim, correction=correction, keepdim=keepdim)
+    return op.Sqrt(var)
+
+
+# std_mean is decomposed by PyTroch
+def aten_std_mean(self: TReal, unbiased: bool = True) -> Tuple[TReal, TReal]:
+    """std_mean(Tensor self, bool unbiased=True) -> (Tensor, Tensor)"""
+
+    # Assume bool(True) and int(1) are same in ONNX, so pass "unbiased" directly as "correction"
+    # If not this case, should be explicitly set correction value according to unbiased value
+    var, mean = _aten_var_mean_onnx(self, correction=float(unbiased), keepdim=False)
+    return op.Sqrt(var), mean
+
+
+# std_mean is decomposed by PyTroch
+def aten_std_mean_dim(
+    self: TReal, dim: Sequence[int], unbiased: bool = True, keepdim: bool = False
+) -> Tuple[TReal, TReal]:
+    """std_mean.dim(Tensor self, int[1]? dim, bool unbiased=True, bool keepdim=False) -> (Tensor, Tensor)"""
+
+    # Although dim is Optional in signature, but we assume it must have value for this overload
+    # Assert(dim is not None)
+    var, mean = _aten_var_mean_dim_onnx(
+        self, dims=dim, correction=float(unbiased), keepdim=keepdim
+    )
+    return op.Sqrt(var), mean
+
+
+# std_mean is decomposed by PyTroch
+def aten_std_mean_correction(
+    self: TReal,
+    # FIXME(justinchuby): Make dim Optional[Sequence[int]]
+    dim: Optional[int] = None,
+    correction: Optional[float] = None,
+    keepdim: bool = False,
+) -> Tuple[TReal, TReal]:
+    """std_mean.correction(Tensor self, int[1]? dim=None, *, Scalar? correction=None, bool keepdim=False) -> (Tensor, Tensor)"""
+
+    if correction is None:
+        correction = 1.0
+
+    if dim is None:
+        var, mean = _aten_var_mean_onnx(self, correction=correction, keepdim=keepdim)
+    else:
+        var, mean = _aten_var_mean_dim_onnx(
+            self, dims=dim, correction=correction, keepdim=keepdim
+        )
+    return op.Sqrt(var), mean
+
+
+@onnx_impl(
+    (
+        aten.sub.Tensor,
+        aten.sub.Scalar,
+        aten.subtract.Tensor,
+        aten.subtract.Scalar,
+        operator.sub,
+    ),
+    trace_only=True,
+)
+def aten_sub(self: TReal, other: TReal, alpha: float = 1.0) -> TReal:
+    """sub.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"""
+    if alpha != 1.0:
+        alpha = op.CastLike(alpha, other)
+        other = op.Mul(other, alpha)
+    return op.Sub(self, other)
+
+
+@onnx_impl(
+    (
+        aten.sub.Tensor,
+        aten.sub.Scalar,
+        aten.subtract.Tensor,
+        aten.subtract.Scalar,
+    ),
+    trace_only=True,
+    complex=True,
+)
+def aten_sub_complex(self: TReal, other: TReal, alpha: float = 1.0) -> TReal:
+    """sub.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"""
+
+    return aten_sub(self, other, alpha=alpha)
+
+
+@onnx_impl(aten.sum.default, trace_only=True)
+def aten_sum(self: TReal, dtype: int = -1) -> TReal:
+    """sum(Tensor self, *, ScalarType? dtype=None) -> Tensor"""
+    if len(self.shape) == 0:
+        result = op.Identity(self)
+    else:
+        result = op.ReduceSum(self, keepdims=False)
+    if dtype != -1 and dtype is not None:
+        result = op.Cast(result, to=dtype)
+    return result
+
+
+@onnx_impl(aten.sum.dim_IntList, trace_only=True)
+def aten_sum_dim_IntList(
+    self: TReal, dim: Optional[INT64] = None, keepdim: bool = False, dtype: int = -1
+) -> TReal:
+    """sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor"""
+    if len(self.shape) == 0:
+        result = op.Identity(self)
+    elif dim is None:
+        result = op.ReduceSum(self, keepdims=keepdim)
+    else:
+        dim = op.Reshape(dim, op.Constant(value_ints=[-1]))
+        dim = op.Cast(dim, to=INT64.dtype)
+        result = op.ReduceSum(self, dim, keepdims=keepdim)
+
+    if dtype != -1 and dtype is not None:
+        result = op.Cast(result, to=dtype)
+
+    return result
+
+
+def aten_sum_to_size(self: TensorType, size: Sequence[int]) -> TensorType:
+    """sum_to_size(Tensor self, int[] size) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_svd(
+    self: TensorType, some: bool = True, compute_uv: bool = True
+) -> tuple[TensorType, TensorType, TensorType]:
+    """svd(Tensor self, bool some=True, bool compute_uv=True) -> (Tensor U, Tensor S, Tensor V)"""
+
+    raise NotImplementedError
+
+
+def aten_swapaxes(self: TensorType, axis0: int, axis1: int) -> TensorType:
+    """swapaxes(Tensor(a) self, int axis0, int axis1) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def aten_swapdims(self: TensorType, dim0: int, dim1: int) -> TensorType:
+    """swapdims(Tensor(a) self, int dim0, int dim1) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.sym_size.int, trace_only=True)
+def aten_sym_size(self: TensorType, dim: int = 0) -> INT64:
+    """sym_size.int(Tensor self, int dim) -> SymInt"""
+    return op.Squeeze(op.Shape(self, end=dim + 1, start=dim))
+
+
+def aten_symeig(
+    self: TensorType, eigenvectors: bool = False, upper: bool = True
+) -> tuple[TensorType, TensorType]:
+    """symeig(Tensor self, bool eigenvectors=False, bool upper=True) -> (Tensor eigenvalues, Tensor eigenvectors)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.t.default, trace_only=True)
+def aten_t(self: TTensor) -> TTensor:
+    """t(Tensor(a) self) -> Tensor(a)"""
+
+    rank = Rank(self)
+    if rank == 2:
+        result = op.Transpose(self, perm=[1, 0])
+    else:
+        # rank < 2
+        result = self
+    return result
+
+
+def aten_t_copy(self: TensorType) -> TensorType:
+    """t_copy(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_take(self: TensorType, index: TensorType) -> TensorType:
+    """take(Tensor self, Tensor index) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_take_along_dim(
+    self: TensorType, indices: TensorType, dim: Optional[int] = None
+) -> TensorType:
+    """take_along_dim(Tensor self, Tensor indices, int? dim=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.tan.default, trace_only=True)
+def aten_tan(self: TFloat) -> TFloat:
+    """tan(Tensor self) -> Tensor"""
+
+    return op.Tan(self)
+
+
+@onnx_impl(aten.tanh.default, trace_only=True)
+def aten_tanh(self: TFloat) -> TFloat:
+    """tanh(Tensor self) -> Tensor"""
+
+    return op.Tanh(self)
+
+
+@onnx_impl(aten.tensor.bool, trace_only=True)
+def aten_tensor_bool(self: bool, dtype: int) -> TensorType:
+    tensor = op.Constant(value_int=self)
+    return op.Cast(tensor, to=dtype)
+
+
+@onnx_impl(aten.tensor.float, trace_only=True)
+def aten_tensor_float(self: float, dtype: int) -> TensorType:
+    tensor = op.Constant(value_float=self)
+    return op.Cast(tensor, to=dtype)
+
+
+@onnx_impl(aten.tensor.int, trace_only=True)
+def aten_tensor_int(self: int, dtype: int) -> TensorType:
+    tensor = op.Constant(value_int=self)
+    return op.Cast(tensor, to=dtype)
+
+
+def aten_tensordot(
+    self: TensorType,
+    other: TensorType,
+    dims_self: Sequence[int],
+    dims_other: Sequence[int],
+) -> TensorType:
+    """tensordot(Tensor self, Tensor other, int[] dims_self, int[] dims_other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_threshold(self: TensorType, threshold: float, value: float) -> TensorType:
+    """threshold(Tensor self, Scalar threshold, Scalar value) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_threshold_backward(
+    grad_output: TensorType, self: TensorType, threshold: float
+) -> TensorType:
+    """threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.tile.default)
+def aten_tile(self: TTensor, dims: INT64) -> TTensor:
+    """tile(Tensor self, int[] dims) -> Tensor"""
+
+    self_rank = Rank(self)
+    dims_rank = op.Size(dims)
+    diff = op.Sub(self_rank, dims_rank)
+
+    if diff > 0:
+        # dims is shorter than self.shape
+        # pad dims with 1
+        diff_1d = op.Reshape(diff, op.Constant(value_ints=[1]))
+        exapnd_ones = op.Expand(op.Constant(value_ints=[1]), diff_1d)
+        dims = op.Concat(exapnd_ones, dims, axis=0)
+
+    if diff < 0:
+        # dims is longer than self.shape
+        # pad self.shape with 1
+        diff_1d = op.Reshape(op.Abs(diff), op.Constant(value_ints=[1]))
+        exapnd_ones = op.Expand(op.Constant(value_ints=[1]), diff_1d)
+        self_shape = op.Shape(self)
+        self_final_shape = op.Concat(exapnd_ones, self_shape, axis=0)
+        self = op.Reshape(self, self_final_shape)
+
+    return op.Tile(self, dims)
+
+
+def aten_to_dense(self: TensorType, dtype: Optional[int] = None) -> TensorType:
+    """to_dense(Tensor self, ScalarType? dtype=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_to_dense_backward(grad: TensorType, input: TensorType) -> TensorType:
+    """to_dense_backward(Tensor grad, Tensor input) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_to_mkldnn(self: TensorType, dtype: Optional[int] = None) -> TensorType:
+    """to_mkldnn(Tensor self, ScalarType? dtype=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_to_mkldnn_backward(grad: TensorType, input: TensorType) -> TensorType:
+    """to_mkldnn_backward(Tensor grad, Tensor input) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_to_padded_tensor(
+    self: TensorType, padding: float, output_size: Optional[INT64] = None
+) -> TensorType:
+    """to_padded_tensor(Tensor self, float padding, SymInt[]? output_size=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_to_sparse(self: TensorType) -> TensorType:
+    """to_sparse(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_to_sparse_bsc(self: TensorType, blocksize: Sequence[int]) -> TensorType:
+    """to_sparse_bsc(Tensor self, int[2] blocksize) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_to_sparse_bsr(self: TensorType, blocksize: Sequence[int]) -> TensorType:
+    """to_sparse_bsr(Tensor self, int[2] blocksize) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_to_sparse_csc(self: TensorType) -> TensorType:
+    """to_sparse_csc(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_to_sparse_csr(self: TensorType) -> TensorType:
+    """to_sparse_csr(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.topk.default, trace_only=True)
+def aten_topk(
+    self: TReal, k: int, dim: int = -1, largest: bool = True, sorted: bool = True
+) -> Tuple[TReal, INT64]:
+    """topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True) -> (Tensor values, Tensor indices)"""
+
+    # We do not handle scalar inputs for topk
+    values, indices = op.TopK(self, [k], axis=dim, largest=largest, sorted=sorted)
+    return values, indices
+
+
+def aten_trace(self: TensorType) -> TensorType:
+    """trace(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_trace_backward(grad: TensorType, sizes: INT64) -> TensorType:
+    """trace_backward(Tensor grad, SymInt[] sizes) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.transpose.int, trace_only=True)
+def aten_transpose(self: TTensor, dim0: int, dim1: int) -> TTensor:
+    """transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)"""
+
+    # Use trace only to construct the prem attribute in Transpose
+    self_rank = len(self.shape)  # type: ignore[attr-defined]
+
+    if self_rank == 0:
+        result = self
+    else:
+        # Python code, change when onnxscript supports this
+        dims = list(range(self_rank))
+        dims[dim0], dims[dim1] = dims[dim1], dims[dim0]
+        # Python code ends
+
+        result = op.Transpose(self, perm=dims)
+
+    return result
+
+
+@onnx_impl(aten.transpose.int, trace_only=True, complex=True)
+def aten_transpose_complex(self: TTensor, dim0: int, dim1: int) -> TTensor:
+    """transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)"""
+
+    # Use trace only to construct the prem attribute in Transpose
+    self_rank = len(self.shape)  # type: ignore[attr-defined]
+
+    if self_rank == 0:
+        result = self
+    else:
+        # Python code, change when onnxscript supports this
+        # Handle when dim0 or dim1 is negative. ONNX uses the last axis to
+        # represent to complex axis so we need to move the dim one axis toward the start.
+        if dim0 < 0:
+            dim0 = dim0 - 1
+        if dim1 < 0:
+            dim1 = dim1 - 1
+        dims = list(range(self_rank))
+        dims[dim0], dims[dim1] = dims[dim1], dims[dim0]
+        # Python code ends
+
+        result = op.Transpose(self, perm=dims)
+
+    return result
+
+
+def aten_triangular_solve(
+    self: TensorType,
+    A: TensorType,
+    upper: bool = True,
+    transpose: bool = False,
+    unitriangular: bool = False,
+) -> tuple[TensorType, TensorType]:
+    """triangular_solve(Tensor self, Tensor A, bool upper=True, bool transpose=False, bool unitriangular=False) -> (Tensor solution, Tensor cloned_coefficient)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.tril.default)
+def aten_tril(self: TTensor, diagonal: int = 0) -> TTensor:
+    """tril(Tensor self, int diagonal=0) -> Tensor"""
+
+    return op.Trilu(self, diagonal, upper=0)
+
+
+def aten_tril_indices(row: int, col: int, offset: int = 0) -> TensorType:
+    """tril_indices(int row, int col, int offset=0, *, ScalarType? dtype=long, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_triplet_margin_loss(
+    anchor: TensorType,
+    positive: TensorType,
+    negative: TensorType,
+    margin: float = 1.0,
+    p: float = 2.0,
+    eps: float = 1e-06,
+    swap: bool = False,
+    reduction: int = 1,
+) -> TensorType:
+    """triplet_margin_loss(Tensor anchor, Tensor positive, Tensor negative, float margin=1.0, float p=2, float eps=1e-06, bool swap=False, int reduction=Mean) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.triu.default)
+def aten_triu(self: TTensor, diagonal: int = 0) -> TTensor:
+    """triu(Tensor self, int diagonal=0) -> Tensor"""
+
+    return op.Trilu(self, diagonal, upper=1)
+
+
+def aten_triu_indices(row: int, col: int, offset: int = 0) -> TensorType:
+    """triu_indices(int row, int col, int offset=0, *, ScalarType? dtype=long, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.trunc.default)
+def aten_trunc(self: TFloat) -> TFloat:
+    """trunc(Tensor self) -> Tensor"""
+    # Reference https://github.com/onnx/onnx/issues/4588#issuecomment-2658170591
+    return op.Floor(op.Abs(self)) * op.Sign(self)
+
+
+@onnx_impl(aten.type_as.default, trace_only=True)
+def aten_type_as(self: TTensor, other: TTensor2) -> TTensor2:
+    """type_as(Tensor self, Tensor other) -> Tensor"""
+
+    return op.CastLike(self, other)
+
+
+@onnx_impl(aten.unbind.int)
+def aten_unbind(self: TTensor, dim: int = 0) -> Sequence[TTensor]:
+    """unbind.int(Tensor(a -> *) self, int dim=0) -> Tensor(a)[]"""
+
+    split_sizes = op.Constant(value_int=1)
+    return op.SplitToSequence(self, split_sizes, axis=dim, keepdims=False)
+
+
+@onnx_impl(aten.unflatten.int)
+def aten_unflatten(self: TReal, dim: INT64, sizes: INT64):
+    """unflatten(Tensor(a) self, int dim, SymInt[] sizes) -> Tensor(a)"""
+
+    self_size = op.Shape(self)
+
+    # PyTorch accepts negative dim as reversed counting
+    self_rank = op.Size(self_size)
+    dim = self_rank + dim
+    dim = dim % self_rank
+
+    head_start_idx = op.Constant(value_ints=[0])
+    head_end_idx = op.Reshape(dim, op.Constant(value_ints=[1]))
+    head_part_rank = op.Slice(self_size, head_start_idx, head_end_idx)
+
+    tail_start_idx = op.Reshape(dim + 1, op.Constant(value_ints=[1]))
+    tail_end_idx = op.Constant(value_ints=[_INT64_MAX])
+    tail_part_rank = op.Slice(self_size, tail_start_idx, tail_end_idx)
+
+    final_shape = op.Concat(head_part_rank, sizes, tail_part_rank, axis=0)
+
+    return op.Reshape(self, final_shape)
+
+
+@onnx_impl(aten.unfold.default, trace_only=True)
+def aten_unfold(self: TTensor, dimension: int, size: int, step: int) -> TTensor:
+    """unfold(Tensor(a) self, int dimension, int size, int step) -> Tensor(a)"""
+
+    self_rank = len(self.shape)
+    if self_rank == 0:
+        result = op.Unsqueeze(self, 0)
+    else:
+        # Handle negative dimension
+        if dimension < 0:
+            dimension = dimension + self_rank
+        dim_size = self.shape[dimension]
+        target_end = (dim_size - size) // step + 1
+        if target_end >= 1:  # the rank of final reuslt will be self_rank + 1
+            self_rank = self_rank + 1
+        # perm need to be list[int], so have to be generated in trace_only mode
+        perm = list(range(self_rank))
+        # from [0,1,2,3,4] -> [0,1,3,4,2] when dimension=1
+        perm.append(perm.pop(dimension + 1))
+        result = _aten_unfold_onnx(self, dimension, size, step, target_end, perm)
+    return result
+
+
+@onnx_impl(aten.unfold.default, private=True)
+def _aten_unfold_onnx(
+    self: TTensor, dim: int, size: int, step: int, target_end: int, perm: Sequence[int]
+) -> TTensor:
+    dims = op.Reshape(op.Constant(value_int=dim), op.Constant(value_ints=[-1]))
+    # FIXME(justinchuby): obtain the dtype for SequenceEmpty, currently it assumes float
+    seq_result = op.SequenceEmpty()
+    i = op.Constant(value_int=0)
+    cond = i < target_end
+    while cond:  # because for loop cannot work here, so use while loop
+        starts = op.Reshape(i * step, [-1])  # starts is [0, step, step*2, step*3, ...]
+        ends = (
+            starts + size
+        )  # ends is [0+size, step+size, step*2+size, step*3+size, ...]
+        slice_result = op.Slice(self, starts, ends, dims)
+        # sequence only support float32
+        slice_result_float32 = op.Cast(slice_result, to=FLOAT.dtype)
+        seq_result = op.SequenceInsert(seq_result, slice_result_float32)
+        i = i + 1
+        cond = i < target_end
+    concat_result = op.ConcatFromSequence(seq_result, axis=dim, new_axis=1)
+    result = op.Transpose(concat_result, perm=perm)
+    return op.CastLike(result, self)
+
+
+def aten_unfold_backward(
+    grad_in: TensorType, input_sizes: INT64, dim: int, size: int, step: int
+) -> TensorType:
+    """unfold_backward(Tensor grad_in, SymInt[] input_sizes, int dim, int size, int step) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_unfold_copy(
+    self: TensorType, dimension: int, size: int, step: int
+) -> TensorType:
+    """unfold_copy(Tensor self, int dimension, int size, int step) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_unique_consecutive(
+    self: TensorType,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    dim: Optional[int] = None,
+) -> tuple[TensorType, TensorType, TensorType]:
+    """unique_consecutive(Tensor self, bool return_inverse=False, bool return_counts=False, int? dim=None) -> (Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_unique_dim(
+    self: TensorType,
+    dim: int,
+    sorted: bool = True,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+) -> tuple[TensorType, TensorType, TensorType]:
+    """unique_dim(Tensor self, int dim, bool sorted=True, bool return_inverse=False, bool return_counts=False) -> (Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_unique_dim_consecutive(
+    self: TensorType,
+    dim: int,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+) -> tuple[TensorType, TensorType, TensorType]:
+    """unique_dim_consecutive(Tensor self, int dim, bool return_inverse=False, bool return_counts=False) -> (Tensor, Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_unsafe_chunk(self: TensorType, chunks: int, dim: int = 0) -> TensorType:
+    """unsafe_chunk(Tensor self, int chunks, int dim=0) -> Tensor[]"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.unsafe_split.Tensor)
+def aten_unsafe_split(
+    self: TTensor, split_size: INT64, dim: int = 0
+) -> Sequence[TTensor]:
+    """unsafe_split.Tensor(Tensor self, SymInt split_size, int dim=0) -> Tensor[]"""
+
+    return op.SplitToSequence(self, split_size, axis=dim)
+
+
+def aten_unsafe_split_with_sizes(
+    self: TensorType, split_sizes: INT64, dim: int = 0
+) -> TensorType:
+    """unsafe_split_with_sizes(Tensor self, SymInt[] split_sizes, int dim=0) -> Tensor[]"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.unsqueeze.default)
+def aten_unsqueeze(self: TTensor, dim: int) -> TTensor:
+    """unsqueeze(Tensor(a) self, int dim) -> Tensor(a)"""
+
+    dim = op.Cast(dim, to=INT64.dtype)
+    return op.Unsqueeze(self, dim)
+
+
+def aten_unsqueeze_copy(self: TensorType, dim: int) -> TensorType:
+    """unsqueeze_copy(Tensor self, int dim) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_value_selecting_reduction_backward(
+    grad: TensorType, dim: int, indices: TensorType, sizes: INT64, keepdim: bool
+) -> TensorType:
+    """value_selecting_reduction_backward(Tensor grad, int dim, Tensor indices, SymInt[] sizes, bool keepdim) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_values(self: TensorType) -> TensorType:
+    """values(Tensor(a) self) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def aten_values_copy(self: TensorType) -> TensorType:
+    """values_copy(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_vander(
+    x: TensorType, N: Optional[int] = None, increasing: bool = False
+) -> TensorType:
+    """vander(Tensor x, int? N=None, bool increasing=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+# var is decomposed by PyTroch
+def aten_var(self: TReal, unbiased: Optional[bool] = True) -> TReal:
+    """var(Tensor self, bool unbiased=True) -> Tensor"""
+
+    # Assume bool(True) and int(1) are same in ONNX, so pass "unbiased" directly as "correction"
+    # If not this case, should be explicitly set correction value according to unbiased value
+    return _aten_var_onnx(self, correction=float(unbiased), keepdim=False)
+
+
+# var is decomposed by PyTroch
+def aten_var_dim(
+    self: TReal,
+    dim: Sequence[int],
+    unbiased: Optional[bool] = True,
+    keepdim: Optional[bool] = False,
+) -> TReal:
+    """var(Tensor self, int[1]? dim, bool unbiased=True, bool keepdim=False) -> Tensor"""
+
+    return _aten_var_dim_onnx(
+        self, dims=dim, correction=float(unbiased), keepdim=keepdim
+    )
+
+
+# var is decomposed by PyTroch
+def aten_var_correction(
+    self: TReal,
+    # FIXME(justinchuby): Make dim Optional[Sequence[int]]
+    dim: Optional[int] = None,
+    correction: Optional[float] = None,
+    keepdim: bool = False,
+) -> TReal:
+    """var.correction(Tensor self, int[1]? dim=None, *, Scalar? correction=None, bool keepdim=False) -> Tensor"""
+
+    if correction is None:
+        correction = 1.0
+
+    if dim is None:
+        var = _aten_var_onnx(self, correction=correction, keepdim=keepdim)
+    else:
+        var = _aten_var_dim_onnx(self, dims=dim, correction=correction, keepdim=keepdim)
+    return var
+
+
+# var is decomposed by PyTroch
+def _aten_var_onnx(self: TReal, correction: float, keepdim: bool = False) -> TReal:
+    mean = op.ReduceMean(self, keepdims=keepdim)
+    sub_mean = op.Sub(self, mean)
+    sqr_mean = op.Mul(sub_mean, sub_mean)
+    var = op.ReduceMean(sqr_mean, keepdims=keepdim)
+    # Adjust var according to correction value
+    if correction > 0.0:
+        self_shape = op.Shape(self)
+        numel_float = op.CastLike(op.ReduceProd(self_shape, keepdims=False), self)
+        mul = op.Mul(var, numel_float)
+        sub = op.Sub(numel_float, op.CastLike(correction, self))
+        var = op.Div(mul, sub)
+
+    return var
+
+
+# var is decomposed by PyTroch
+def _aten_var_dim_onnx(
+    self: TReal, dims: Sequence[int], correction: float, keepdim: bool = False
+) -> TReal:
+    dims = op.Reshape(dims, op.Constant(value_ints=[-1]))
+    # Computer mean and var
+    sub_mean = op.Sub(self, op.ReduceMean(self, dims, keepdims=True))
+    sqr_mean = op.Mul(sub_mean, sub_mean)
+    var = op.ReduceMean(sqr_mean, dims, keepdims=keepdim)
+    # Adjust var according to correction value
+    if correction > 0.0:
+        self_shape = op.Shape(self)
+        dim_size = op.Gather(self_shape, dims, axis=0)
+        numel_float = op.CastLike(op.ReduceProd(dim_size, keepdims=False), self)
+        mul = op.Mul(var, numel_float)
+        sub = op.Sub(numel_float, op.CastLike(correction, self))
+        var = op.Div(mul, sub)
+
+    return var
+
+
+# var_mean is decomposed by PyTroch
+def aten_var_mean(self: TReal, unbiased: bool = True) -> Tuple[TReal, TReal]:
+    """var_mean(Tensor self, bool unbiased=True) -> (Tensor, Tensor)"""
+
+    # Assume bool(True) and int(1) are same in ONNX, so pass "unbiased" directly as "correction"
+    # If not this case, should be explicitly set correction value according to unbiased value
+    return _aten_var_mean_onnx(self, correction=float(unbiased), keepdim=False)
+
+
+# var_mean is decomposed by PyTroch
+def aten_var_mean_dim(
+    self: TReal, dim: Sequence[int], unbiased: bool = True, keepdim: bool = False
+) -> Tuple[TReal, TReal]:
+    """var_mean.dim(Tensor self, int[1]? dim, bool unbiased=True, bool keepdim=False) -> (Tensor, Tensor)"""
+
+    # Although dim is Optional in signature, but we assume it must have value for this overload
+    # Assert(dim is not None)
+    return _aten_var_mean_dim_onnx(
+        self, dims=dim, correction=float(unbiased), keepdim=keepdim
+    )
+
+
+# var_mean is decomposed by PyTroch
+def aten_var_mean_correction(
+    self: TReal,
+    # FIXME(justinchuby): Make dim Optional[Sequence[int]]
+    dim: Optional[int] = None,
+    correction: Optional[float] = None,
+    keepdim: bool = False,
+) -> Tuple[TReal, TReal]:
+    """var_mean.correction(Tensor self, int[1]? dim=None, *, Scalar? correction=None, bool keepdim=False) -> (Tensor, Tensor)"""
+
+    if correction is None:
+        correction = 1.0
+
+    if dim is None:
+        var, mean = _aten_var_mean_onnx(self, correction=correction, keepdim=keepdim)
+    else:
+        var, mean = _aten_var_mean_dim_onnx(
+            self, dims=dim, correction=correction, keepdim=keepdim
+        )
+    return var, mean
+
+
+# var_mean is decomposed by PyTroch
+def _aten_var_mean_onnx(
+    self: TReal, correction: float = 1.0, keepdim: bool = False
+) -> Tuple[TReal, TReal]:
+    # Compute mean and var
+    mean = op.ReduceMean(self, keepdims=keepdim)
+    sub_mean = op.Sub(self, mean)
+    sqr_mean = op.Mul(sub_mean, sub_mean)
+    var = op.ReduceMean(sqr_mean, keepdims=keepdim)
+    # Adjust var according to correction value
+    if correction > 0.0:
+        self_shape = op.Shape(self)
+        numel_float = op.CastLike(op.ReduceProd(self_shape, keepdims=False), self)
+        mul = op.Mul(var, numel_float)
+        sub = op.Sub(numel_float, op.CastLike(correction, self))
+        var = op.Div(mul, sub)
+
+    return var, mean
+
+
+# var_mean is decomposed by PyTroch
+def _aten_var_mean_dim_onnx(
+    self: TReal, dims: Sequence[int], correction: float, keepdim: bool = False
+) -> Tuple[TReal, TReal]:
+    dims = op.Reshape(dims, op.Constant(value_ints=[-1]))
+    # Computer mean and var
+    mean = op.ReduceMean(self, dims, keepdims=keepdim)
+    sub_mean = op.Sub(self, op.ReduceMean(self, dims, keepdims=True))
+    sqr_mean = op.Mul(sub_mean, sub_mean)
+    var = op.ReduceMean(sqr_mean, dims, keepdims=keepdim)
+    # Adjust var according to correction value
+    if correction > 0.0:
+        self_shape = op.Shape(self)
+        dim_size = op.Gather(self_shape, dims, axis=0)
+        numel_float = op.CastLike(op.ReduceProd(dim_size, keepdims=False), self)
+        mul = op.Mul(var, numel_float)
+        sub = op.Sub(numel_float, op.CastLike(correction, self))
+        var = op.Div(mul, sub)
+
+    return var, mean
+
+
+def aten_vdot(self: TensorType, other: TensorType) -> TensorType:
+    """vdot(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl((aten.view.default, aten._unsafe_view.default), trace_only=True)
+def aten_view(self: TTensor, size: IntType) -> TTensor:
+    """view(Tensor(a) self, SymInt[] size) -> Tensor(a)"""
+
+    size = op.Cast(size, to=INT64.dtype)  # Reshape only support INT64 as second input
+    return op.Reshape(self, size)
+
+
+@onnx_impl((aten.view.default, aten._unsafe_view.default), complex=True)
+def aten_view_complex(self: TTensor, size: IntType) -> TTensor:
+    """view(Tensor(a) self, SymInt[] size) -> Tensor(a)"""
+
+    size = op.Cast(size, to=INT64.dtype)  # Reshape only support INT64 as second input
+    complex_size = op.Concat(size, op.Constant(value_ints=[2]), axis=0)
+    return op.Reshape(self, complex_size)
+
+
+@onnx_impl(aten.view_as.default)
+def aten_view_as(self: TTensor, other: TTensor2) -> TTensor:
+    """view_as(Tensor(a) self, Tensor other) -> Tensor(a)"""
+
+    size = op.Shape(other)
+    return op.Reshape(self, size)
+
+
+@onnx_impl(aten.view_as_complex.default, trace_only=True)
+def aten_view_as_complex(self: TTensor) -> TTensor:
+    """view_as_complex(Tensor(a) self) -> Tensor(a)"""
+
+    # We always operate on the real representation of a complex number in torchlib
+    # So this is a no-op
+    return op.Identity(self)
+
+
+@onnx_impl(aten.view_as_complex_copy.default, trace_only=True)
+def aten_view_as_complex_copy(self: TTensor) -> TTensor:
+    """view_as_complex_copy(Tensor self) -> Tensor"""
+
+    # We always operate on the real representation of a complex number in torchlib
+    # So this is a no-op
+    return op.Identity(self)
+
+
+@onnx_impl(aten.view_as_real.default, complex=True, trace_only=True)
+def aten_view_as_real(self: TTensor) -> TTensor:
+    """view_as_real(Tensor(a) self) -> Tensor(a)"""
+
+    # We always operate on the real representation of a complex number in torchlib
+    # So this is a no-op
+    return op.Identity(self)
+
+
+@onnx_impl(aten.view_as_real_copy.default, complex=True, trace_only=True)
+def aten_view_as_real_copy(self: TTensor) -> TTensor:
+    """view_as_real_copy(Tensor self) -> Tensor"""
+
+    # We always operate on the real representation of a complex number in torchlib
+    # So this is a no-op
+    return op.Identity(self)
+
+
+@onnx_impl(aten.view_copy.default)
+def aten_view_copy(self: TTensor, size: IntType) -> TTensor:
+    """view_copy(Tensor self, SymInt[] size) -> Tensor"""
+
+    size = op.Cast(size, to=INT64.dtype)  # Reshape only support INT64 as second input
+    return op.Reshape(self, size)
+
+
+# Do not register vstack - decomposed by PyTorch: https://github.com/pytorch/pytorch/blob/bedf96d7ffe74b34bcfe52c7ae1ae05f40d6c8ee/torch/_refs/__init__.py#L3918
+def aten_vstack(tensors: Sequence[TTensor]) -> TTensor:
+    """vstack(Tensor[] tensors) -> Tensor"""
+
+    # The same logic as atleast_2d duplicated here to keep
+    # the function self contained
+    @graph()
+    def reshape_to_2d(tensor):
+        shape = op.Shape(tensor)
+        rank = op.Size(shape)
+        if rank <= 1:
+            tensor = op.Reshape(tensor, op.Constant(value_ints=[1, -1]))
+        return tensor
+
+    tensors_2d = op.SequenceMap(tensors, body=reshape_to_2d)
+    return op.ConcatFromSequence(tensors_2d, axis=0)
+
+
+@onnx_impl(
+    (
+        aten.where.Scalar,
+        aten.where.ScalarSelf,
+        aten.where.ScalarOther,
+        aten.where.self,
+    )
+)
+def aten_where(condition: BOOL, self: TTensor, other: TTensor) -> TTensor:
+    """where.self(Tensor condition, Tensor self, Tensor other) -> Tensor"""
+
+    return op.Where(condition, self, other)
+
+
+def aten_xor(self: TensorType, other: TensorType) -> TensorType:
+    """__xor__.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.zeros.default, trace_only=True)
+def aten_zeros(
+    size: IntType,
+    dtype: int = FLOAT.dtype,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+) -> TensorType:
+    """zeros(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+    if dtype == -1:
+        dtype = FLOAT.dtype
+    size = op.Cast(size, to=INT64.dtype)
+    zero = op.Constant(value_float=0.0)
+    zero = op.Cast(zero, to=dtype)
+
+    return op.Expand(zero, size)
+
+
+@onnx_impl(aten.zeros_like.default, trace_only=True)
+def aten_zeros_like(
+    self: TTensor,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+    memory_format: str = "",
+) -> TTensor:
+    """zeros_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor"""
+
+    # NOTE: trace_only because both if branches need to be the same type, but we have
+    # a cast in the if branch.
+    if dtype is None:
+        dtype = -1
+
+    if dtype == -1:
+        zero = op.CastLike(0, self)
+    else:
+        zero = op.Cast(0, to=dtype)
+
+    shape = op.Shape(self)
+    return op.Expand(zero, shape)

--- a/torch/onnx/_internal/exporter/_torchlib/ops/fft.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/fft.py
@@ -1,0 +1,387 @@
+"""torch.ops.aten operators under the `fft` module."""
+
+# mypy: disable-error-code="misc,arg-type,type-arg,valid-type,assignment,return-value,type-var,operator,no-untyped-def,index"
+# ruff: noqa: TCH001,TCH002
+# flake8: noqa
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from onnxscript import INT64
+from onnxscript.onnx_opset import opset18 as op
+from onnxscript.onnx_types import TensorType
+
+import torch
+from torch.onnx._internal.exporter._torchlib._tensor_typing import TFloat
+from torch.onnx._internal.exporter._torchlib._torchlib_registry import onnx_impl
+
+
+aten = torch.ops.aten
+
+
+@onnx_impl(
+    (aten._fft_c2c.default, aten._fft_c2r.default, aten._fft_r2c.default),
+    private=True,
+    complex=True,
+    trace_only=True,
+)
+def _fftn_onnx_normalization(
+    self: TFloat,
+    transformed: TFloat,
+    normalization: int,
+    forward: bool,
+    dims: Sequence[int],
+) -> TFloat:
+    # Obtain the total_sample_count (n) for normalization
+    self_shape = op.Shape(self)
+    total_sample_count = op.ReduceProd(op.Gather(self_shape, dims), keepdims=0)
+    total_sample_count = op.CastLike(total_sample_count, transformed)
+
+    # Normalize the result
+    # Reference https://pytorch.org/docs/stable/generated/torch.fft.fftn.html#torch.fft.fftn
+    # Reference https://github.com/pytorch/pytorch/blob/d090c18fcaaba6e1b5cb474a89058cf6081c8275/torch/_refs/fft.py#L42
+    if normalization == 1:
+        # "forward" - normalize by 1/n
+        if forward:
+            result = op.Div(transformed, op.Sqrt(total_sample_count))
+        else:
+            result = op.Mul(transformed, op.Sqrt(total_sample_count))
+    elif normalization == 2:
+        # "ortho" - normalize by 1/sqrt(n)
+        if forward:
+            result = op.Div(transformed, total_sample_count)
+        else:
+            result = transformed
+    else:
+        # "backward" - no normalization
+        if forward:
+            result = transformed
+        else:
+            result = op.Mul(transformed, total_sample_count)
+
+    return result
+
+
+@onnx_impl(
+    (aten._fft_c2c.default, aten._fft_c2r.default, aten._fft_r2c.default),
+    trace_only=True,
+    private=True,
+    complex=True,
+)
+def _fftn_onnx(
+    self: TFloat, dims: Sequence[int], normalization: int, inverse: bool, onesided: bool
+) -> TFloat:
+    """Standard complex to complex or real to complex FFT (forward or backward).
+
+    This is a private shared function for implementing the various FFT functions.
+
+    Args:
+        self: The input tensor.
+        dims: The dimensions to apply FFT.
+        normalization: The normalization mode.
+        inverse: Whether to compute the inverse FFT.
+        onesided: Whether to compute the one-sided FFT, which retains only the
+            positive frequencies.
+
+    Returns:
+        The transformed tensor.
+    """
+
+    # NOTE: trace_only because we need to process each dimension in a loop
+    # NOTE: SymInt dim is not support because DFT-17 needs a static axis
+    # TODO(justinchuby): Make dim dynamic and remove trace_only when ONNX provides support
+
+    # The 0-th dimension in ONNX DFT-17 is the batch dimension. We need to add a new
+    # dimension at the beginning to represent the batch dimension.
+    transformed = op.Unsqueeze(self, axes=[0])
+
+    # Add 1 to account for the batch dimension when counting axes from the left
+    new_dims = [dim_ + 1 if dim_ >= 0 else dim_ for dim_ in dims]
+
+    for dim in new_dims[:-1]:
+        transformed = op.DFT(transformed, axis=dim, inverse=inverse, onesided=False)
+
+    # Torch computers one-sided FFT on the last dimension only.
+    if onesided:
+        transformed = op.DFT(
+            transformed, axis=new_dims[-1], inverse=inverse, onesided=True
+        )
+    else:
+        transformed = op.DFT(
+            transformed, axis=new_dims[-1], inverse=inverse, onesided=False
+        )
+
+    # Remove the batch dimension
+    transformed = op.Squeeze(transformed, axes=[0])
+
+    return _fftn_onnx_normalization(self, transformed, normalization, not inverse, dims)
+
+
+@onnx_impl(aten._fft_c2c.default, trace_only=True, complex=True)
+def aten__fft_c2c(
+    self: TFloat, dim: Sequence[int], normalization: int, forward: bool
+) -> TFloat:
+    """_fft_c2c(Tensor self, SymInt[] dim, int normalization, bool forward) -> Tensor
+
+    Standard complex to complex FFT (forward or backward).
+    """
+
+    # NOTE: trace_only because we need to negate forward
+    # NOTE: SymInt dim is not support because DFT-17 needs a static axis
+    # TODO(justinchuby): Make dim dynamic and remove trace_only when ONNX provides support
+
+    # ONNX DFT input assumes the last dimension is the complex dimension.
+    # Thus dim=-1 in PyTorch is dim=-2 in ONNX.
+    dim = [d - 1 if d < 0 else d for d in dim]
+    return _fftn_onnx(self, dim, normalization, inverse=not forward, onesided=False)
+
+
+@onnx_impl(aten._fft_c2r.default, trace_only=True, complex=True)
+def aten__fft_c2r(
+    self: TFloat,
+    dim: Sequence[int],
+    normalization: int,
+    last_dim_size: INT64,  # pylint: disable=unused-argument
+) -> TFloat:
+    """_fft_c2r(Tensor self, int[] dim, int normalization, SymInt last_dim_size) -> Tensor
+
+    Complex to real inverse FFT.
+    """
+
+    # TODO(justinchuby): Figure out what last_dim_size does
+
+    self_rank = len(self.shape)
+    # ONNX DFT input assumes the last dimension is the complex dimension.
+    # Thus dim=-1 in PyTorch is dim=-2 in ONNX.
+    dim = [(d - 1) + self_rank if d < 0 else d for d in dim]
+    transformed = _fftn_onnx(self, dim, normalization, inverse=True, onesided=False)
+    # Take only the real part
+    real_part = op.Slice(transformed, axes=[-1], starts=[0], ends=[1])
+
+    return op.Squeeze(real_part, axes=[-1])
+
+
+@onnx_impl(aten._fft_r2c.default, trace_only=True)
+def aten__fft_r2c(
+    self: TFloat, dim: Sequence[int], normalization: int, onesided: bool
+) -> TFloat:
+    """_fft_r2c(Tensor self, int[] dim, int normalization, bool onesided) -> Tensor
+
+    Real to complex forward FFT.
+    """
+
+    # Add a new dimension at the end
+    signal = op.Unsqueeze(self, axes=[-1])
+    # No need to fill the imaginary part because ONNX DFT accepts real inputs
+    # https://onnx.ai/onnx/operators/onnx__DFT.html#inputs
+
+    self_rank = len(self.shape)
+    # ONNX DFT input assumes the last dimension is the complex dimension.
+    # Thus dim=-1 in PyTorch is dim=-2 in ONNX.
+    dim = [(d - 1) + self_rank if d < 0 else d for d in dim]
+
+    return _fftn_onnx(signal, dim, normalization, inverse=False, onesided=onesided)
+
+
+def aten_fft_fft(
+    self: TensorType, n: Optional[int] = None, dim: int = -1, norm: Optional[str] = None
+) -> TensorType:
+    """fft_fft(Tensor self, int? n=None, int dim=-1, str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_fft2(
+    self: TensorType,
+    s: Optional[int] = None,
+    dim: Sequence[int] = (-2, -1),
+    norm: Optional[str] = None,
+) -> TensorType:
+    """fft_fft2(Tensor self, int[1]? s=None, int[1] dim=[-2,-1], str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_fftfreq(n: int, d: float = 1.0) -> TensorType:
+    """fft_fftfreq(int n, float d=1.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_fftn(
+    self: TensorType,
+    s: Optional[int] = None,
+    dim: Optional[int] = None,
+    norm: Optional[str] = None,
+) -> TensorType:
+    """fft_fftn(Tensor self, int[1]? s=None, int[1]? dim=None, str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_fftshift(self: TensorType, dim: Optional[int] = None) -> TensorType:
+    """fft_fftshift(Tensor self, int[1]? dim=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_hfft(
+    self: TensorType, n: Optional[int] = None, dim: int = -1, norm: Optional[str] = None
+) -> TensorType:
+    """fft_hfft(Tensor self, int? n=None, int dim=-1, str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_hfft2(
+    self: TensorType,
+    s: Optional[int] = None,
+    dim: Sequence[int] = (-2, -1),
+    norm: Optional[str] = None,
+) -> TensorType:
+    """fft_hfft2(Tensor self, int[1]? s=None, int[1] dim=[-2,-1], str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_hfftn(
+    self: TensorType,
+    s: Optional[int] = None,
+    dim: Optional[int] = None,
+    norm: Optional[str] = None,
+) -> TensorType:
+    """fft_hfftn(Tensor self, int[1]? s=None, int[1]? dim=None, str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_ifft(
+    self: TensorType, n: Optional[int] = None, dim: int = -1, norm: Optional[str] = None
+) -> TensorType:
+    """fft_ifft(Tensor self, int? n=None, int dim=-1, str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_ifft2(
+    self: TensorType,
+    s: Optional[int] = None,
+    dim: Sequence[int] = (-2, -1),
+    norm: Optional[str] = None,
+) -> TensorType:
+    """fft_ifft2(Tensor self, int[1]? s=None, int[1] dim=[-2,-1], str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_ifftn(
+    self: TensorType,
+    s: Optional[int] = None,
+    dim: Optional[int] = None,
+    norm: Optional[str] = None,
+) -> TensorType:
+    """fft_ifftn(Tensor self, int[1]? s=None, int[1]? dim=None, str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_ifftshift(self: TensorType, dim: Optional[int] = None) -> TensorType:
+    """fft_ifftshift(Tensor self, int[1]? dim=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_ihfft(
+    self: TensorType, n: Optional[int] = None, dim: int = -1, norm: Optional[str] = None
+) -> TensorType:
+    """fft_ihfft(Tensor self, int? n=None, int dim=-1, str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_ihfft2(
+    self: TensorType,
+    s: Optional[int] = None,
+    dim: Sequence[int] = (-2, -1),
+    norm: Optional[str] = None,
+) -> TensorType:
+    """fft_ihfft2(Tensor self, int[1]? s=None, int[1] dim=[-2,-1], str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_ihfftn(
+    self: TensorType,
+    s: Optional[int] = None,
+    dim: Optional[int] = None,
+    norm: Optional[str] = None,
+) -> TensorType:
+    """fft_ihfftn(Tensor self, int[1]? s=None, int[1]? dim=None, str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_irfft(
+    self: TensorType, n: Optional[int] = None, dim: int = -1, norm: Optional[str] = None
+) -> TensorType:
+    """fft_irfft(Tensor self, int? n=None, int dim=-1, str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_irfft2(
+    self: TensorType,
+    s: Optional[int] = None,
+    dim: Sequence[int] = (-2, -1),
+    norm: Optional[str] = None,
+) -> TensorType:
+    """fft_irfft2(Tensor self, int[1]? s=None, int[1] dim=[-2,-1], str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_irfftn(
+    self: TensorType,
+    s: Optional[int] = None,
+    dim: Optional[int] = None,
+    norm: Optional[str] = None,
+) -> TensorType:
+    """fft_irfftn(Tensor self, int[1]? s=None, int[1]? dim=None, str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_rfft(
+    self: TensorType, n: Optional[int] = None, dim: int = -1, norm: Optional[str] = None
+) -> TensorType:
+    """fft_rfft(Tensor self, int? n=None, int dim=-1, str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_rfft2(
+    self: TensorType,
+    s: Optional[int] = None,
+    dim: Sequence[int] = (-2, -1),
+    norm: Optional[str] = None,
+) -> TensorType:
+    """fft_rfft2(Tensor self, int[1]? s=None, int[1] dim=[-2,-1], str? norm=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_rfftfreq(n: int, d: float = 1.0) -> TensorType:
+    """fft_rfftfreq(int n, float d=1.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fft_rfftn(
+    self: TensorType,
+    s: Optional[int] = None,
+    dim: Optional[int] = None,
+    norm: Optional[str] = None,
+) -> TensorType:
+    """fft_rfftn(Tensor self, int[1]? s=None, int[1]? dim=None, str? norm=None) -> Tensor"""
+
+    raise NotImplementedError

--- a/torch/onnx/_internal/exporter/_torchlib/ops/linalg.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/linalg.py
@@ -1,0 +1,360 @@
+"""torch.ops.aten operators under the `linalg` module."""
+# mypy: disable-error-code="misc,arg-type,type-arg,valid-type,assignment,return-value,type-var,operator,no-untyped-def,index"
+# ruff: noqa: TCH001,TCH002
+# flake8: noqa
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Sequence
+
+from onnxscript import BOOL
+from onnxscript.onnx_opset import opset18 as op
+from onnxscript.onnx_types import TensorType
+
+import torch
+from torch.onnx._internal.exporter._torchlib._tensor_typing import TFloat, TTensor
+from torch.onnx._internal.exporter._torchlib._torchlib_registry import onnx_impl
+
+
+aten = torch.ops.aten
+
+
+def aten_linalg_cholesky(self: TensorType, upper: bool = False) -> TensorType:
+    """linalg_cholesky(Tensor self, *, bool upper=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_cholesky_ex(
+    self: TensorType, upper: bool = False, check_errors: bool = False
+) -> tuple[TensorType, TensorType]:
+    """linalg_cholesky_ex(Tensor self, *, bool upper=False, bool check_errors=False) -> (Tensor L, Tensor info)"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_cond(self: TensorType, p: Optional[float] = None) -> TensorType:
+    """linalg_cond(Tensor self, Scalar? p=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_cross(self: TTensor, other: TTensor, dim: int = -1) -> TTensor:
+    """linalg_cross(Tensor self, Tensor other, *, int dim=-1) -> Tensor"""
+
+    # Same implementation as aten_cross
+    raise NotImplementedError
+
+
+@onnx_impl((aten._linalg_det.default, aten.linalg_det.default, aten.det.default))
+def aten_linalg_det(A: TFloat) -> TFloat:
+    """linalg_det(Tensor A) -> Tensor"""
+
+    return op.Det(A)
+
+
+def aten_linalg_diagonal(
+    A: TensorType, offset: int = 0, dim1: int = -2, dim2: int = -1
+) -> TensorType:
+    """linalg_diagonal(Tensor(a) A, *, int offset=0, int dim1=-2, int dim2=-1) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_eig(self: TensorType) -> tuple[TensorType, TensorType]:
+    """linalg_eig(Tensor self) -> (Tensor eigenvalues, Tensor eigenvectors)"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_eigh(
+    self: TensorType, UPLO: str = "L"
+) -> tuple[TensorType, TensorType]:
+    """linalg_eigh(Tensor self, str UPLO="L") -> (Tensor eigenvalues, Tensor eigenvectors)"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_eigvals(self: TensorType) -> TensorType:
+    """linalg_eigvals(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_eigvalsh(self: TensorType, UPLO: str = "L") -> TensorType:
+    """linalg_eigvalsh(Tensor self, str UPLO="L") -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_householder_product(input: TensorType, tau: TensorType) -> TensorType:
+    """linalg_householder_product(Tensor input, Tensor tau) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_inv(A: TensorType) -> TensorType:
+    """linalg_inv(Tensor A) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_inv_ex(
+    A: TensorType, check_errors: bool = False
+) -> tuple[TensorType, TensorType]:
+    """linalg_inv_ex(Tensor A, *, bool check_errors=False) -> (Tensor inverse, Tensor info)"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_ldl_factor(
+    self: TensorType, hermitian: bool = False
+) -> tuple[TensorType, TensorType]:
+    """linalg_ldl_factor(Tensor self, *, bool hermitian=False) -> (Tensor LD, Tensor pivots)"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_ldl_factor_ex(
+    self: TensorType, hermitian: bool = False, check_errors: bool = False
+) -> tuple[TensorType, TensorType, TensorType]:
+    """linalg_ldl_factor_ex(Tensor self, *, bool hermitian=False, bool check_errors=False) -> (Tensor LD, Tensor pivots, Tensor info)"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_ldl_solve(
+    LD: TensorType, pivots: TensorType, B: TensorType, hermitian: bool = False
+) -> TensorType:
+    """linalg_ldl_solve(Tensor LD, Tensor pivots, Tensor B, *, bool hermitian=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_lstsq(
+    self: TensorType,
+    b: TensorType,
+    rcond: Optional[float] = None,
+    driver: Optional[str] = None,
+) -> tuple[TensorType, TensorType, TensorType, TensorType]:
+    """linalg_lstsq(Tensor self, Tensor b, float? rcond=None, *, str? driver=None) -> (Tensor solution, Tensor residuals, Tensor rank, Tensor singular_values)"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_lu(
+    A: TensorType, pivot: bool = True
+) -> tuple[TensorType, TensorType, TensorType]:
+    """linalg_lu(Tensor A, *, bool pivot=True) -> (Tensor P, Tensor L, Tensor U)"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_lu_factor(
+    A: TensorType, pivot: bool = True
+) -> tuple[TensorType, TensorType]:
+    """linalg_lu_factor(Tensor A, *, bool pivot=True) -> (Tensor LU, Tensor pivots)"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_lu_factor_ex(
+    A: TensorType, pivot: bool = True, check_errors: bool = False
+) -> tuple[TensorType, TensorType, TensorType]:
+    """linalg_lu_factor_ex(Tensor A, *, bool pivot=True, bool check_errors=False) -> (Tensor LU, Tensor pivots, Tensor info)"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_lu_solve(
+    LU: TensorType,
+    pivots: TensorType,
+    B: TensorType,
+    left: bool = True,
+    adjoint: bool = False,
+) -> TensorType:
+    """linalg_lu_solve(Tensor LU, Tensor pivots, Tensor B, *, bool left=True, bool adjoint=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_matmul(self: TensorType, other: TensorType) -> TensorType:
+    """linalg_matmul(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_matrix_exp(self: TensorType) -> TensorType:
+    """linalg_matrix_exp(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_matrix_norm(
+    self: TensorType,
+    ord: float,
+    dim: Sequence[int] = (-2, -1),
+    keepdim: bool = False,
+    dtype: Optional[int] = None,
+) -> TensorType:
+    """linalg_matrix_norm(Tensor self, Scalar ord, int[] dim=[-2,-1], bool keepdim=False, *, ScalarType? dtype=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_matrix_power(self: TensorType, n: int) -> TensorType:
+    """linalg_matrix_power(Tensor self, int n) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_matrix_rank(
+    self: TensorType, tol: float, hermitian: bool = False
+) -> TensorType:
+    """linalg_matrix_rank(Tensor self, float tol, bool hermitian=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_multi_dot(tensors: Sequence[TensorType]) -> TensorType:
+    """linalg_multi_dot(Tensor[] tensors) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_norm(
+    self: TensorType,
+    ord: Optional[float] = None,
+    dim: Optional[int] = None,
+    keepdim: bool = False,
+    dtype: Optional[int] = None,
+) -> TensorType:
+    """linalg_norm(Tensor self, Scalar? ord=None, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_pinv(
+    self: TensorType, rcond: float, hermitian: bool = False
+) -> TensorType:
+    """linalg_pinv(Tensor self, float rcond, bool hermitian=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_qr(
+    A: TensorType, mode: str = "reduced"
+) -> tuple[TensorType, TensorType]:
+    """linalg_qr(Tensor A, str mode='reduced') -> (Tensor Q, Tensor R)"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_slogdet(A: TensorType) -> tuple[TensorType, TensorType]:
+    """linalg_slogdet(Tensor A) -> (Tensor sign, Tensor logabsdet)"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_solve(A: TensorType, B: TensorType, left: bool = True) -> TensorType:
+    """linalg_solve(Tensor A, Tensor B, *, bool left=True) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_solve_ex(
+    A: TensorType, B: TensorType, left: bool = True, check_errors: bool = False
+) -> tuple[TensorType, TensorType]:
+    """linalg_solve_ex(Tensor A, Tensor B, *, bool left=True, bool check_errors=False) -> (Tensor result, Tensor info)"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_solve_triangular(
+    self: TensorType,
+    B: TensorType,
+    upper: bool,
+    left: bool = True,
+    unitriangular: bool = False,
+) -> TensorType:
+    """linalg_solve_triangular(Tensor self, Tensor B, *, bool upper, bool left=True, bool unitriangular=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_svd(
+    A: TensorType, full_matrices: bool = True, driver: Optional[str] = None
+) -> tuple[TensorType, TensorType, TensorType]:
+    """linalg_svd(Tensor A, bool full_matrices=True, *, str? driver=None) -> (Tensor U, Tensor S, Tensor Vh)"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_svdvals(A: TensorType, driver: Optional[str] = None) -> TensorType:
+    """linalg_svdvals(Tensor A, *, str? driver=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_tensorinv(self: TensorType, ind: int = 2) -> TensorType:
+    """linalg_tensorinv(Tensor self, int ind=2) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_tensorsolve(
+    self: TensorType, other: TensorType, dims: Optional[int] = None
+) -> TensorType:
+    """linalg_tensorsolve(Tensor self, Tensor other, int[]? dims=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_vander(x: TensorType, N: Optional[int] = None) -> TensorType:
+    """linalg_vander(Tensor x, *, int? N=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_linalg_vecdot(x: TensorType, y: TensorType, dim: int = -1) -> TensorType:
+    """linalg_vecdot(Tensor x, Tensor y, *, int dim=-1) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.linalg_vector_norm.default, trace_only=True)
+def aten_linalg_vector_norm(
+    self: TFloat,
+    ord: float = 2.0,
+    dim: Optional[int] = None,
+    keepdim: bool = False,
+    dtype: int = -1,
+) -> TFloat:
+    """linalg_vector_norm(Tensor self, Scalar ord=2, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor"""
+
+    if dtype != -1:
+        self = op.Cast(self, to=dtype)
+    if dim is None:
+        self = op.Reshape(self, op.Constant(value_ints=[-1]))
+        keepdim = False
+    else:
+        dim = op.Reshape(dim, op.Constant(value_ints=[-1]))
+    self = op.Abs(self)
+    if math.isinf(ord):
+        if ord > 0:
+            return op.ReduceMax(self, dim, keepdims=keepdim)
+        else:
+            return op.ReduceMin(self, dim, keepdims=keepdim)
+    elif ord == 0.0:  # sum(x!=0) means count non-zero elements
+        self_bool = op.Cast(self, to=BOOL.dtype)
+        self_0_1 = op.CastLike(self_bool, self)
+        return op.ReduceSum(self_0_1, dim, keepdims=keepdim)
+    elif ord == 1.0:
+        return op.ReduceL1(self, dim, keepdims=keepdim)
+    elif ord == 2.0:
+        return op.ReduceL2(self, dim, keepdims=keepdim)
+    else:
+        self_pow = op.Pow(self, ord)
+        exp = op.CastLike(1 / ord, self)
+        return op.Pow(op.ReduceSum(self_pow, dim, keepdims=keepdim), exp)

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -1,6 +1,6 @@
 """torch.ops.aten operators under the `nn` module."""
 
-# mypy: disable-error-code="misc,arg-type,type-arg,valid-type,assignment,return-value,type-var,operator,no-untyped-def,index"
+# mypy: disable-error-code="misc,arg-type,type-arg,valid-type,assignment,return-value,type-var,operator,no-untyped-def,index,list-item"
 # ruff: noqa: TCH001,TCH002
 # flake8: noqa
 

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -1667,7 +1667,7 @@ def aten_replication_pad2d_backward(
     raise NotImplementedError
 
 
-@onnx_impl(aten.replication_pad3d.default)
+@onnx_impl(aten.replication_pad3d.default, trace_only=True)
 def aten_replication_pad3d(self: TTensor, padding: Sequence[INT64]) -> TTensor:
     """replication_pad3d(Tensor self, SymInt[6] padding) -> Tensor"""
 

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -1,0 +1,2728 @@
+"""torch.ops.aten operators under the `nn` module."""
+
+# mypy: disable-error-code="misc,arg-type,type-arg,valid-type,assignment,return-value,type-var,operator,no-untyped-def,index"
+# ruff: noqa: TCH001,TCH002
+# flake8: noqa
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Sequence, Tuple, TypeVar, Union
+
+import onnx
+
+from onnxscript import BFLOAT16, BOOL, DOUBLE, FLOAT, FLOAT16, INT64
+from onnxscript.onnx_opset import opset18 as op
+from onnxscript.onnx_types import TensorType
+
+import torch
+from torch.onnx._internal.exporter._torchlib._tensor_typing import (
+    IntType,
+    TFloat,
+    TFloatOrUInt8,
+    TInt,
+    TReal,
+    TTensor,
+)
+from torch.onnx._internal.exporter._torchlib._torchlib_registry import onnx_impl
+from torch.onnx._internal.exporter._torchlib.ops import common as common_ops
+
+
+aten = torch.ops.aten
+
+
+_MATH_PI = math.pi
+Rank = common_ops.Rank
+
+_INT64_MAX = 9223372036854775807
+_INT64_MIN = -9223372036854775808
+
+# All float types but float32
+TFloatUnlessFloat32 = TypeVar(
+    "TFloatUnlessFloat32", bound=Union[BFLOAT16, FLOAT16, DOUBLE]
+)
+
+
+aten = torch.ops.aten
+
+
+# NOTE: Implementations of adaptive_average_pool are handled by torch decomp
+def aten_adaptive_max_pool1d(
+    self: TensorType, output_size: Sequence[int]
+) -> tuple[TensorType, TensorType]:
+    """adaptive_max_pool1d(Tensor self, int[1] output_size) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_adaptive_max_pool2d(
+    self: TensorType, output_size: Sequence[int]
+) -> tuple[TensorType, TensorType]:
+    """adaptive_max_pool2d(Tensor self, int[2] output_size) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_adaptive_max_pool2d_backward(
+    grad_output: TensorType, self: TensorType, indices: TensorType
+) -> TensorType:
+    """adaptive_max_pool2d_backward(Tensor grad_output, Tensor self, Tensor indices) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_adaptive_max_pool3d(
+    self: TensorType, output_size: Sequence[int]
+) -> tuple[TensorType, TensorType]:
+    """adaptive_max_pool3d(Tensor self, int[3] output_size) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_adaptive_max_pool3d_backward(
+    grad_output: TensorType, self: TensorType, indices: TensorType
+) -> TensorType:
+    """adaptive_max_pool3d_backward(Tensor grad_output, Tensor self, Tensor indices) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def _adjust_attributes_of_avg_pool(
+    expand_size: int,
+    kernel_size: Sequence[int],
+    stride: Sequence[int],
+    padding: Sequence[int],
+) -> Tuple[Sequence[int], Sequence[int], Sequence[int]]:
+    """Adjust attributes of avg_pool to match ONNX specification."""
+
+    if isinstance(kernel_size, int):
+        kernel_shape = [kernel_size] * expand_size
+    else:
+        kernel_shape = kernel_size
+
+    if isinstance(padding, int):
+        pads = [padding] * expand_size * 2
+    elif len(padding) == 1:
+        pads = padding * expand_size * 2
+    elif len(padding) == 2:
+        pads = padding * expand_size
+    else:
+        pads = padding * 2
+
+    if isinstance(stride, int):
+        strides = [stride] * expand_size
+    elif not stride:
+        strides = kernel_shape
+    else:
+        strides = stride
+
+    return (kernel_shape, strides, pads)
+
+
+@onnx_impl(aten.avg_pool1d.default, trace_only=True)
+def aten_avg_pool1d(
+    self: TFloat,
+    kernel_size: Sequence[int],
+    stride: Sequence[int] = (),
+    padding: Sequence[int] = (0,),
+    ceil_mode: bool = False,
+    count_include_pad: bool = True,
+) -> TFloat:
+    """avg_pool1d(Tensor self, int[1] kernel_size, int[1] stride=[], int[1] padding=0, bool ceil_mode=False, bool count_include_pad=True) -> Tensor"""
+
+    # Torch prefer to use single number x for kerne,stride,pad,dilation on both side implicitly
+    # But ONNX needs pair number [x,y] to specify on each side explicitly
+    # For pool3d, this number should be 3
+    expand_size = 1
+
+    kernel_shape, strides, pads = _adjust_attributes_of_avg_pool(
+        expand_size, kernel_size, stride, padding
+    )
+
+    result = op.AveragePool(
+        self,
+        ceil_mode=ceil_mode,
+        count_include_pad=count_include_pad,
+        kernel_shape=kernel_shape,
+        pads=pads,
+        strides=strides,
+    )
+
+    return result
+
+
+@onnx_impl(aten.avg_pool2d.default, trace_only=True)
+def aten_avg_pool2d(
+    self: TFloat,
+    kernel_size: Sequence[int],
+    stride: Sequence[int] = (),
+    padding: Sequence[int] = (0, 0),
+    ceil_mode: bool = False,
+    count_include_pad: bool = True,
+    divisor_override: Optional[int] = None,
+) -> TFloat:
+    """avg_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, bool ceil_mode=False, bool count_include_pad=True, int? divisor_override=None) -> Tensor"""
+
+    # Torch prefer to use single number x for kerne,stride,pad,dilation on both side implicitly
+    # But ONNX needs pair number [x,y] to specify on each side explicitly
+    # For pool3d, this number should be 3
+    expand_size = 2
+
+    kernel_shape, strides, pads = _adjust_attributes_of_avg_pool(
+        expand_size, kernel_size, stride, padding
+    )
+
+    result = op.AveragePool(
+        self,
+        ceil_mode=ceil_mode,
+        count_include_pad=count_include_pad,
+        kernel_shape=kernel_shape,
+        pads=pads,
+        strides=strides,
+    )
+
+    # TODO: if want to support divisor_override argument, need to op.Mul(result, mask)
+    # mask = [
+    #    1, 2, 3, S,..3, 2, 1
+    #    2, 4, 6, 2S, 6, 4, 2
+    #    3, 6, 9, 3S, 9, 6, 3
+    #    S, 2S,3S,SS,3S,2S, S
+    #    3, 6, 9, 3S, 9, 6, 3
+    #    2, 4, 6, 2S, 6, 4, 2
+    #    1, 2, 3, S,..3, 2, 1
+    # ]
+    # S is stride size, in this case S=4,
+    # S may dup lot of times according to the image size
+
+    return result
+
+
+def aten_avg_pool2d_backward(
+    grad_output: TensorType,
+    self: TensorType,
+    kernel_size: Sequence[int],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    ceil_mode: bool,
+    count_include_pad: bool,
+    divisor_override: Optional[int],
+) -> TensorType:
+    """avg_pool2d_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, bool ceil_mode, bool count_include_pad, int? divisor_override) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.avg_pool3d.default, trace_only=True)
+def aten_avg_pool3d(
+    self: TFloat,
+    kernel_size: Sequence[int],
+    stride: Sequence[int] = (),
+    padding: Sequence[int] = (0, 0, 0),
+    ceil_mode: bool = False,
+    count_include_pad: bool = True,
+    divisor_override: Optional[int] = None,
+) -> TFloat:
+    """avg_pool3d(Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, bool ceil_mode=False, bool count_include_pad=True, int? divisor_override=None) -> Tensor"""
+
+    # Torch prefer to use single number x for kerne,stride,pad,dilation on both side implicitly
+    # But ONNX needs pair number [x,y] to specify on each side explicitly
+    # For pool3d, this number should be 3
+    expand_size = 3
+
+    kernel_shape, strides, pads = _adjust_attributes_of_avg_pool(
+        expand_size, kernel_size, stride, padding
+    )
+
+    result = op.AveragePool(
+        self,
+        kernel_shape=kernel_shape,
+        strides=strides,
+        pads=pads,
+        count_include_pad=count_include_pad,
+        ceil_mode=ceil_mode,
+    )
+
+    # TODO: if want to support divisor_override argument, need to op.Mul(result, mask)
+    # mask = [
+    #    1, 2, 3, S,..3, 2, 1
+    #    2, 4, 6, 2S, 6, 4, 2
+    #    3, 6, 9, 3S, 9, 6, 3
+    #    S, 2S,3S,SS,3S,2S, S
+    #    3, 6, 9, 3S, 9, 6, 3
+    #    2, 4, 6, 2S, 6, 4, 2
+    #    1, 2, 3, S,..3, 2, 1
+    # ]
+    # S is stride size, in this case S=4,
+    # S may dup lot of times according to the image size
+
+    return result
+
+
+def aten_avg_pool3d_backward(
+    grad_output: TensorType,
+    self: TensorType,
+    kernel_size: Sequence[int],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    ceil_mode: bool,
+    count_include_pad: bool,
+    divisor_override: Optional[int],
+) -> TensorType:
+    """avg_pool3d_backward(Tensor grad_output, Tensor self, int[3] kernel_size, int[3] stride, int[3] padding, bool ceil_mode, bool count_include_pad, int? divisor_override) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_binary_cross_entropy(
+    self: TensorType,
+    target: TensorType,
+    weight: Optional[TensorType] = None,
+    reduction: int = 1,
+) -> TensorType:
+    """binary_cross_entropy(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_binary_cross_entropy_backward(
+    grad_output: TensorType,
+    self: TensorType,
+    target: TensorType,
+    weight: Optional[TensorType] = None,
+    reduction: int = 1,
+) -> TensorType:
+    """binary_cross_entropy_backward(Tensor grad_output, Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.celu.default, trace_only=True)
+def aten_celu(self: FLOAT, alpha: float = 1.0) -> FLOAT:
+    """celu(Tensor self, Scalar alpha=1.0) -> Tensor"""
+
+    return op.Celu(self, alpha=alpha)  # op.Celu only support float32
+
+
+@onnx_impl(aten.celu.default, trace_only=True)
+def aten_celu_type_promoted(
+    self: TFloatUnlessFloat32, alpha: float = 1.0
+) -> TFloatUnlessFloat32:
+    """celu(Tensor self, Scalar alpha=1.0) -> Tensor"""
+
+    self_upcasted = op.Cast(self, to=FLOAT.dtype)
+    return op.CastLike(op.Celu(self_upcasted, alpha=alpha), self)
+
+
+@onnx_impl(aten.col2im.default, trace_only=True)
+def aten_col2im(
+    self: TReal,
+    output_size: INT64,
+    kernel_size: INT64,
+    dilation: Sequence[int] = (1, 1),
+    padding: Sequence[int] = (0, 0),
+    stride: Sequence[int] = (1, 1),
+) -> TReal:
+    """col2im(Tensor self, SymInt[2] output_size, int[2] kernel_size, int[2] dilation, int[2] padding, int[2] stride) -> Tensor"""
+
+    # assert(len(output_size)==2) for ONNX
+    # assert(len(kernel_size)==2) for ONNX
+    # assert(len(dilation)==2) for ONNX
+    # assert(len(stride)==2) for ONNX
+
+    # The pads should be [w, x, y, z] for ONNX
+    if len(padding) == 1:  # [w] -> [w, w, w, w]
+        pads = padding * 4
+    elif len(padding) == 2:  # [w, x] -> [w, x, w, x]
+        pads = padding * 2
+    else:  # assert len(padding) == 4, already [w, x, y, z]
+        pads = padding
+
+    # Only one ONNX op here so didn't write a private function
+    return op.Col2Im(
+        self,
+        output_size,
+        kernel_size,
+        dilations=dilation,
+        pads=pads,
+        strides=stride,
+    )
+
+
+def aten_conv_depthwise3d(
+    self: TensorType,
+    weight: TensorType,
+    kernel_size: Sequence[int],
+    bias: Optional[TensorType],
+    stride: Sequence[int],
+    padding: INT64,
+    dilation: Sequence[int],
+) -> TensorType:
+    """conv_depthwise3d(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias, int[3] stride, SymInt[3] padding, int[3] dilation) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.cross_entropy_loss.default, trace_only=True)
+def aten_cross_entropy_loss(
+    self: TFloat,
+    target: IntType,
+    weight: Optional[TFloat] = None,
+    reduction: int = 1,  # default is 'mean'
+    ignore_index: int = -100,
+    label_smoothing: float = 0.0,  # this was ignored due to ONNX not support
+) -> TFloat:
+    """cross_entropy_loss(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, SymInt ignore_index=-100, float label_smoothing=0.0) -> Tensor"""
+
+    if reduction == 0:  # "none"
+        result, _ = op.SoftmaxCrossEntropyLoss(
+            self, target, weight, reduction="none", ignore_index=ignore_index
+        )
+    elif reduction == 2:  # "sum"
+        result, _ = op.SoftmaxCrossEntropyLoss(
+            self, target, weight, reduction="sum", ignore_index=ignore_index
+        )
+    else:  # "mean", default
+        result, _ = op.SoftmaxCrossEntropyLoss(
+            self, target, weight, reduction="mean", ignore_index=ignore_index
+        )
+
+    return result
+
+
+@onnx_impl(aten.elu.default, trace_only=True)
+def aten_elu(
+    self: TFloat,
+    alpha: float = 1.0,
+    scale: float = 1.0,
+    input_scale: float = 1.0,
+) -> TFloat:
+    """elu(Tensor self, Scalar alpha=1, Scalar scale=1, Scalar input_scale=1) -> Tensor"""
+
+    input_scale = op.CastLike(input_scale, self)
+    scale = op.CastLike(scale, self)
+    self = op.Mul(self, input_scale)
+    return op.Mul(op.Elu(self, alpha=alpha), scale)
+
+
+def aten_elu_backward(
+    grad_output: TensorType,
+    alpha: float,
+    scale: float,
+    input_scale: float,
+    is_result: bool,
+    self_or_result: TensorType,
+) -> TensorType:
+    """elu_backward(Tensor grad_output, Scalar alpha, Scalar scale, Scalar input_scale, bool is_result, Tensor self_or_result) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_flatten_dense_tensors(tensors: Sequence[TensorType]) -> TensorType:
+    """flatten_dense_tensors(Tensor[] tensors) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fractional_max_pool2d(
+    self: TensorType,
+    kernel_size: Sequence[int],
+    output_size: Sequence[int],
+    random_samples: TensorType,
+) -> tuple[TensorType, TensorType]:
+    """fractional_max_pool2d(Tensor self, int[2] kernel_size, int[2] output_size, Tensor random_samples) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_fractional_max_pool2d_backward(
+    grad_output: TensorType,
+    self: TensorType,
+    kernel_size: Sequence[int],
+    output_size: Sequence[int],
+    indices: TensorType,
+) -> TensorType:
+    """fractional_max_pool2d_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] output_size, Tensor indices) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_fractional_max_pool3d(
+    self: TensorType,
+    kernel_size: Sequence[int],
+    output_size: Sequence[int],
+    random_samples: TensorType,
+) -> tuple[TensorType, TensorType]:
+    """fractional_max_pool3d(Tensor self, int[3] kernel_size, int[3] output_size, Tensor random_samples) -> (Tensor, Tensor)"""
+
+    raise NotImplementedError
+
+
+def aten_fractional_max_pool3d_backward(
+    grad_output: TensorType,
+    self: TensorType,
+    kernel_size: Sequence[int],
+    output_size: Sequence[int],
+    indices: TensorType,
+) -> TensorType:
+    """fractional_max_pool3d_backward(Tensor grad_output, Tensor self, int[3] kernel_size, int[3] output_size, Tensor indices) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.gelu.default, trace_only=True)
+def aten_gelu(self: TReal, approximate: str = "none") -> TReal:
+    """gelu(Tensor self, *, str approximate='none') -> Tensor"""
+
+    if approximate == "tanh":
+        result = _aten_gelu_approximate_tanh(self)
+    else:
+        result = _aten_gelu_approximate_none(self)
+    return result
+
+
+@onnx_impl(aten.gelu.default, private=True)
+def _aten_gelu_approximate_none(self: TReal) -> TReal:
+    """gelu(Tensor self, *, str approximate='none') -> Tensor"""
+
+    # GELU(x) = 0.5 * x * [1 + ERF(x/sqrt(2)]
+    inner = op.Div(self, 1.4142135623730951)
+    erf = op.Erf(inner)
+    inner = op.Add(erf, 1)
+    inner = op.Mul(self, inner)
+    result = op.Mul(0.5, inner)
+    return result
+
+
+@onnx_impl(aten.gelu.default, private=True)
+def _aten_gelu_approximate_tanh(self: TReal) -> TReal:
+    """gelu(Tensor self, *, str approximate='none') -> Tensor"""
+
+    # GELU(x) = 0.5 * x * {1 + Tanh[\sqrt(2/pi) * (x + 0.044715 * x^3)]}
+    cubed = op.Pow(self, 3)
+    inner = op.Mul(0.044715, cubed)
+    inner = op.Add(self, inner)
+    # Prefer explicit graph construction over precomputed constants for clarity.
+    two_over_pi = op.CastLike(op.Div(2.0, _MATH_PI), self)
+    inner = op.Mul(op.Sqrt(two_over_pi), inner)
+    inner = op.Tanh(inner)
+    inner = op.Add(inner, 1)
+    inner = op.Mul(self, inner)
+    result = op.Mul(0.5, inner)
+    return result
+
+
+def aten_gelu_backward(
+    grad_output: TensorType, self: TensorType, approximate: str = "none"
+) -> TensorType:
+    """gelu_backward(Tensor grad_output, Tensor self, *, str approximate='none') -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.glu.default, trace_only=True)
+def aten_glu(self: TFloat, dim: int = -1) -> TFloat:
+    """glu(Tensor self, int dim=-1) -> Tensor"""
+
+    first, second = op.Split(self, axis=dim, num_outputs=2)
+    result = op.Mul(first, op.Sigmoid(second))
+    return result
+
+
+def aten_glu_backward(
+    grad_output: TensorType, self: TensorType, dim: int
+) -> TensorType:
+    """glu_backward(Tensor grad_output, Tensor self, int dim) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_glu_backward_jvp(
+    grad_x: TensorType,
+    grad_glu: TensorType,
+    x: TensorType,
+    dgrad_glu: TensorType,
+    dx: TensorType,
+    dim: int,
+) -> TensorType:
+    """glu_backward_jvp(Tensor grad_x, Tensor grad_glu, Tensor x, Tensor dgrad_glu, Tensor dx, int dim) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.group_norm.default, trace_only=True)
+def aten_group_norm(
+    input: TFloat,
+    num_groups: int,
+    weight: Optional[TFloat] = None,
+    bias: Optional[TFloat] = None,
+    eps: float = 1e-05,
+    cudnn_enabled: bool = True,
+) -> TensorType:
+    """group_norm(Tensor input, int num_groups, Tensor? weight=None, Tensor? bias=None, float eps=1e-05, bool cudnn_enabled=True) -> Tensor"""
+
+    # Actually we don't need N,C,HxW value because the input tensor has that information
+    if weight is None:  # Set to 1.0 as default, the shape is Channel size
+        weight = op.Expand(
+            op.Constant(value_floats=[1.0]), op.Shape(input, start=1, end=2)
+        )
+
+    if bias is None:  # Set to 0.0 as default, the shape is Channel size
+        bias = op.Expand(
+            op.Constant(value_floats=[0.0]), op.Shape(input, start=1, end=2)
+        )
+
+    # Because onnx.GroupNorm() need size=group for weight and bias
+    # But the torch's aten function's input need size=channel, the size mismatched
+    # So we have to use onnx.InstanceNorm() to simulate
+    neg_1 = op.Constant(value_ints=[-1])
+    # Create weight_instance_norm and bias_instance_norm, copied from Torch ONNX converter
+    group_tensor = op.Reshape(num_groups, neg_1)
+    # 0 in the shape list keeps dimension value unchanged, for InstanceNorm need [0,group,-1]
+    shape_input = op.Concat(op.Constant(value_ints=[0]), group_tensor, neg_1, axis=0)
+    input_reshaped = op.Reshape(input, shape_input)
+    weight_inst_norm = op.Expand(
+        op.CastLike(op.Constant(value_float=1.0), input), group_tensor
+    )
+    bias_inst_norm = op.Expand(
+        op.CastLike(op.Constant(value_float=0.0), input), group_tensor
+    )
+    norm = op.InstanceNormalization(
+        input_reshaped, weight_inst_norm, bias_inst_norm, epsilon=eps
+    )
+    # Reshape back to input's shape
+    norm = op.Reshape(norm, op.Shape(input))
+    # Using the input weight and bias to do affine
+    # But need to unsqueeze to the target shape for broading cast easy
+    input_rank = Rank(input)
+    one = op.Constant(value_int=1)
+    axes_unsqueeze = op.Range(one, op.Sub(input_rank, one), one)
+    weight_full_shape = op.Unsqueeze(weight, axes_unsqueeze)
+    bias_full_shape = op.Unsqueeze(bias, axes_unsqueeze)
+    weight_full_shape = op.CastLike(weight_full_shape, norm)
+    norm_mul_weight = op.Mul(norm, weight_full_shape)
+    bias_full_shape = op.CastLike(bias_full_shape, norm_mul_weight)
+    norm_result = op.Add(norm_mul_weight, bias_full_shape)
+    return norm_result
+
+
+def aten_glu_jvp(
+    glu: TensorType, x: TensorType, dx: TensorType, dim: int
+) -> TensorType:
+    """glu_jvp(Tensor glu, Tensor x, Tensor dx, int dim) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.hardsigmoid.default, trace_only=True)
+def aten_hardsigmoid(self: TFloat) -> TFloat:
+    """hardsigmoid(Tensor self) -> Tensor"""
+
+    return op.HardSigmoid(self, alpha=1 / 6, beta=1 / 2)
+
+
+def aten_hardsigmoid_backward(grad_output: TensorType, self: TensorType) -> TensorType:
+    """hardsigmoid_backward(Tensor grad_output, Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.hardswish.default)
+def aten_hardswish(self: TFloat) -> TFloat:
+    """hardswish(Tensor self) -> Tensor"""
+
+    return op.HardSwish(self)
+
+
+def aten_hardswish_backward(grad_output: TensorType, self: TensorType) -> TensorType:
+    """hardswish_backward(Tensor grad_output, Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.hardtanh.default)
+def aten_hardtanh(self: TReal, min_val: float = -1.0, max_val: float = 1.0) -> TReal:
+    """hardtanh(Tensor self, Scalar min_val=-1, Scalar max_val=1) -> Tensor"""
+
+    return op.Clip(self, min_val, max_val)
+
+
+@onnx_impl(aten.hardtanh_backward.default, trace_only=True)
+def aten_hardtanh_backward(
+    grad_output: TensorType, self: TensorType, min_val: float, max_val: float
+) -> TensorType:
+    """hardtanh_backward(Tensor grad_output, Tensor self, Scalar min_val, Scalar max_val) -> Tensor"""
+
+    max_mask = op.Where(op.Greater(self, max_val), 0.0, 1.0)
+    min_mask = op.Where(op.Less(self, min_val), 0.0, 1.0)
+    return op.Mul(op.Mul(grad_output, max_mask), min_mask)
+
+
+def aten_huber_loss(
+    self: TensorType, target: TensorType, reduction: int = 1, delta: float = 1.0
+) -> TensorType:
+    """huber_loss(Tensor self, Tensor target, int reduction=Mean, float delta=1.0) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_huber_loss_backward(
+    grad_output: TensorType,
+    self: TensorType,
+    target: TensorType,
+    reduction: int,
+    delta: float,
+) -> TensorType:
+    """huber_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction, float delta) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def _get_im2col_indices_along_dim(
+    input_d: TInt,
+    kernel_size_d: int,
+    dilation_d: int,
+    padding_d: int,
+    stride_d: int,
+):
+    # Input is always 4-D (N, C, H, W)
+    # Calculate indices of sliding blocks along spatial dimension
+    # Slide kernel over input each dim d:
+    # each dimension d ranges from 0 to input[d]+2xpadding[d]-dilation[d]x(kernel_size[d]-1)
+    # with steps = stride
+
+    blocks_d = input_d + ((padding_d * 2) - (dilation_d * (kernel_size_d - 1)))
+
+    # Stride kernel over input and find starting indices along dim d
+    blocks_d_indices = op.Range(0, blocks_d, stride_d)
+    blocks_d_indices = op.Unsqueeze(blocks_d_indices, [0])
+
+    # Apply dilation on kernel and find its indices along dim d
+    kernel_grid = op.Range(0, kernel_size_d * dilation_d, dilation_d)
+    kernel_mask = op.Unsqueeze(kernel_grid, [1])
+
+    # Broadcast and add kernel staring positions (indices) with
+    # kernel_grid along dim d, to get block indices along dim d
+    block_mask = op.Add(blocks_d_indices, kernel_mask)
+
+    return block_mask
+
+
+def _get_im2col_padded_input(input, padding_h, padding_w):
+    # Input is always 4-D tensor (N, C, H, W)
+    # Padding tensor has the following format: (padding_h, padding_w)
+    # Reshape the padding to follow ONNX format: (dim1_begin, dim2_begin,...,dim1_end, dim2_end,...)
+    pad = op.Concat(
+        op.Constant(value_ints=[0, 0]),
+        op.Unsqueeze(padding_h, [0]),
+        op.Unsqueeze(padding_w, [0]),
+        op.Constant(value_ints=[0, 0]),
+        op.Unsqueeze(padding_h, [0]),
+        op.Unsqueeze(padding_w, [0]),
+        axis=0,
+    )
+    return op.Pad(input, pad)
+
+
+def _get_im2col_output_shape(input, kernel_h, kernel_w):
+    input_shape = op.Shape(input)
+    batch_dim = op.Gather(input_shape, 0, axis=0)
+    channel_dim = op.Gather(input_shape, 1, axis=0)
+    channel_unfolded = op.Mul(channel_dim, kernel_h * kernel_w)
+
+    return op.Concat(
+        op.Unsqueeze(batch_dim, [0]),
+        op.Unsqueeze(channel_unfolded, [0]),
+        op.Constant(value_ints=[-1]),
+        axis=0,
+    )
+
+
+@onnx_impl(aten.im2col.default, trace_only=True)
+def aten_im2col(
+    self: TReal,
+    kernel_size: Sequence[int],
+    dilation: Sequence[int] = (1, 1),
+    padding: Sequence[int] = (0, 0),
+    stride: Sequence[int] = (1, 1),
+) -> TensorType:
+    """im2col(Tensor self, int[2] kernel_size, int[2] dilation=1, int[2] padding=0, int[2] stride=1) -> Tensor"""
+
+    input_shape = op.Shape(self)
+    input_h = op.Gather(input_shape, 2, axis=0)
+    input_w = op.Gather(input_shape, 3, axis=0)
+
+    if not isinstance(kernel_size, Sequence):
+        kernel_size = (kernel_size, kernel_size)
+    kernel_sizes = list(kernel_size)
+
+    if not isinstance(dilation, Sequence):
+        dilation = (dilation, dilation)
+    dilations = list(dilation)
+
+    if not isinstance(padding, Sequence):
+        padding = (padding, padding)
+    pads = list(padding)
+
+    if isinstance(stride, int):
+        stride = (stride, stride)
+    strides = list(stride)
+
+    stride_h, stride_w = strides[0], strides[1]
+    padding_h, padding_w = pads[0], pads[1]
+    dilation_h, dilation_w = dilations[0], dilations[1]
+    kernel_h, kernel_w = kernel_sizes[0], kernel_sizes[1]
+
+    blocks_row_indices = _get_im2col_indices_along_dim(
+        input_h, kernel_h, dilation_h, padding_h, stride_h
+    )
+    blocks_col_indices = _get_im2col_indices_along_dim(
+        input_w, kernel_w, dilation_w, padding_w, stride_w
+    )
+
+    output_shape = _get_im2col_output_shape(self, kernel_h, kernel_w)
+    padded_input = _get_im2col_padded_input(self, padding_h, padding_w)
+
+    # For a 4D matrix of size (1, 1, 3, 3) as below with kernel_size=2, stride=1, and dilation=1
+    # [[[[1., 2., 3.,],
+    #    [4., 5., 6.,],
+    #    [7., 8., 9.,]]]]
+    # First gather indices along rows (dim=2) with blocks_row_indices = [[0,1], [1,2]] to get:
+    # [[[[[1., 2., 3.],
+    #     [4., 5., 6.]],
+    #    [[4., 5., 6.],
+    #     [7., 8., 9.]]]]]
+    # And then gather along cols (dim=4) with blocks_row_indices = [[0,1], [1,2]] to get:
+    # [[[[[[1., 2.],
+    #      [4., 5.]],
+    #     [[2., 3.],
+    #      [5., 6]]],
+    #    [[[4., 5.],
+    #      [7., 8.]],
+    #     [[5., 6.],
+    #      [8., 9.]]]]]]
+    # Transpose dims 3 (depth) and 4 (rows), and then reshape to output shape (1, 1, 4, 4) to get:
+    #  [[[1., 2., 4., 5.],
+    #    [2., 3., 5., 6.],
+    #    [4., 5., 7., 8.],
+    #    [5., 6., 8., 9.]]]
+    output = op.Gather(padded_input, blocks_row_indices, axis=2)
+    output = op.Gather(output, blocks_col_indices, axis=4)
+    output = op.Transpose(output, perm=[0, 1, 2, 4, 3, 5])
+    return op.Reshape(output, output_shape)
+
+
+def aten_infinitely_differentiable_gelu_backward(
+    grad: TensorType, self: TensorType
+) -> TensorType:
+    """infinitely_differentiable_gelu_backward(Tensor grad, Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_l1_loss(
+    self: TensorType, target: TensorType, reduction: int = 1
+) -> TensorType:
+    """l1_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.leaky_relu.default)
+def aten_leaky_relu(self: TFloat, negative_slope: float = 0.01) -> TFloat:
+    """leaky_relu(Tensor self, Scalar negative_slope=0.01) -> Tensor"""
+
+    return op.LeakyRelu(self, alpha=negative_slope)
+
+
+def aten_leaky_relu_backward(
+    grad_output: TensorType,
+    self: TensorType,
+    negative_slope: float,
+    self_is_result: bool,
+) -> TensorType:
+    """leaky_relu_backward(Tensor grad_output, Tensor self, Scalar negative_slope, bool self_is_result) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.linear.default, trace_only=True)
+def aten_linear(input: TFloat, weight: TFloat, bias: Optional[TFloat] = None) -> TFloat:
+    """linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor"""
+
+    if len(input.shape) == 2:
+        # Use Gemm for the rank 2 input
+        return op.Gemm(input, weight, bias, transB=True)
+    weight_transposed = op.Transpose(weight, perm=[1, 0])
+    mul = op.MatMul(input, weight_transposed)
+    if bias is None:
+        return mul
+    return op.Add(mul, bias)
+
+
+@onnx_impl(aten.log_sigmoid.default)
+def aten_log_sigmoid(self: TFloat) -> TFloat:
+    """log_sigmoid(Tensor self) -> Tensor"""
+
+    return op.Log(op.Sigmoid(self))
+
+
+def aten_log_sigmoid_backward(
+    grad_output: TensorType, self: TensorType, buffer: TensorType
+) -> TensorType:
+    """log_sigmoid_backward(Tensor grad_output, Tensor self, Tensor buffer) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_log_sigmoid_forward(self: TensorType) -> tuple[TensorType, TensorType]:
+    """log_sigmoid_forward(Tensor self) -> (Tensor output, Tensor buffer)"""
+
+    raise NotImplementedError
+
+
+def aten_logit_backward(
+    grad_output: TensorType, self: TensorType, eps: Optional[float] = None
+) -> TensorType:
+    """logit_backward(Tensor grad_output, Tensor self, float? eps=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.max_pool1d.default, trace_only=True)
+def aten_max_pool1d(
+    self: TFloatOrUInt8,
+    kernel_size: Sequence[int],
+    stride: Sequence[int] = (),
+    padding: Sequence[int] = (0,),
+    dilation: Sequence[int] = (1,),
+    ceil_mode: bool = False,
+) -> TFloatOrUInt8:
+    """max_pool1d(Tensor self, int[1] kernel_size, int[1] stride=[], int[1] padding=0, int[1] dilation=1, bool ceil_mode=False) -> Tensor"""
+
+    # Torch prefers to use single number x for kernel, stride, pad and dilation on both sides implicitly.
+    # But ONNX needs to specify a tuple of three ints for all sides explicitly.
+    expand_size = 1
+
+    kernel_shape, strides, pads, dilations = _adjust_attributes_of_max_pool(
+        expand_size, kernel_size, stride, padding, dilation
+    )
+
+    return _aten_max_pool_onnx(
+        self, kernel_shape, strides, pads, dilations, ceil_mode, 2
+    )
+
+
+@onnx_impl(aten.max_pool1d_with_indices.default, trace_only=True)
+def aten_max_pool1d_with_indices(
+    self: TFloatOrUInt8,
+    kernel_size: Sequence[int],
+    stride: Sequence[int] = (),
+    padding: Sequence[int] = (0,),
+    dilation: Sequence[int] = (1,),
+    ceil_mode: bool = False,
+) -> Tuple[TFloatOrUInt8, INT64]:
+    """max_pool1d_with_indices(Tensor self, int[1] kernel_size, int[1] stride=[], int[1] padding=0, int[1] dilation=1, bool ceil_mode=False) -> (Tensor, Tensor)"""
+
+    # Torch prefers to use single number x for kernel, stride, pad and dilation on both sides implicitly.
+    # But ONNX needs to specify a tuple of three ints for all sides explicitly.
+    expand_size = 1
+
+    kernel_shape, strides, pads, dilations = _adjust_attributes_of_max_pool(
+        expand_size, kernel_size, stride, padding, dilation
+    )
+
+    return _aten_max_pool_with_indices_onnx(
+        self,
+        kernel_shape,
+        strides,
+        pads,
+        dilations,
+        ceil_mode,
+        2,
+        ([1] * expand_size),
+        ([0] * expand_size),
+        ([2 + i for i in range(expand_size)]),
+    )
+
+
+def _adjust_attributes_of_max_pool(
+    expand_size: int,
+    kernel_size: Sequence[int],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+) -> Tuple[Sequence[int], Sequence[int], Sequence[int], Sequence[int]]:
+    if isinstance(dilation, int):
+        dilations = [dilation] * expand_size
+    else:
+        dilations = dilation
+
+    if isinstance(kernel_size, int):
+        kernel_shape = [kernel_size] * expand_size
+    else:
+        kernel_shape = kernel_size
+
+    # NOTE: expand_size is the dimension of pooling kernel,
+    # ONNX needs begin and end padding so we need to double the padding
+
+    # NOTE: expand size prevents padding from being a single int in
+    # multiple dimension cases
+    if isinstance(padding, int):
+        pads = [padding] * expand_size * 2
+    elif len(padding) == 1:
+        pads = padding * expand_size * 2
+    elif len(padding) == 2:
+        # 2D padding
+        pads = padding * 2
+    elif len(padding) == 3:
+        # 3D padding
+        pads = padding * 2
+    else:
+        # When padding is already done for all dimensions,
+        # we don't need to double it
+        # eg: (1, 1, 1, 1, 1, 1)
+        pads = padding
+
+    if isinstance(stride, int):
+        strides = [stride] * expand_size
+    elif not stride:
+        strides = kernel_shape
+    else:
+        strides = stride
+
+    return (kernel_shape, strides, pads, dilations)
+
+
+@onnx_impl(aten.max_pool2d.default, trace_only=True)
+def aten_max_pool2d(
+    self: TFloatOrUInt8,
+    kernel_size: Sequence[int],
+    stride: Sequence[int] = (),
+    padding: Sequence[int] = (0, 0),
+    dilation: Sequence[int] = (1, 1),
+    ceil_mode: bool = False,
+) -> TFloatOrUInt8:
+    """max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor"""
+
+    # Torch prefers to use single number x for kernel, stride, pad and dilation on both sides implicitly.
+    # But ONNX needs to specify a pair of number [x,y] on each side explicitly.
+    expand_size = 2
+
+    kernel_shape, strides, pads, dilations = _adjust_attributes_of_max_pool(
+        expand_size, kernel_size, stride, padding, dilation
+    )
+
+    return _aten_max_pool_onnx(
+        self, kernel_shape, strides, pads, dilations, ceil_mode, 3
+    )
+
+
+def _aten_max_pool_onnx(
+    self: TFloatOrUInt8,
+    kernel_shape: Sequence[int],
+    strides: Sequence[int],
+    pads: Sequence[int],
+    dilations: Sequence[int],
+    ceil_mode: bool,
+    unbatched_rank: int,
+) -> TFloatOrUInt8:
+    self_rank_is_unbatched_rank = Rank(self) == unbatched_rank
+    if self_rank_is_unbatched_rank:  # C,H,W -> N,C,H,W and N=1
+        self = op.Unsqueeze(self, op.Constant(value_ints=[0]))
+
+    pool_result, _ = op.MaxPool(
+        self,
+        ceil_mode=ceil_mode,
+        dilations=dilations,
+        kernel_shape=kernel_shape,
+        pads=pads,
+        strides=strides,
+    )
+
+    if self_rank_is_unbatched_rank:
+        pool_result = op.Squeeze(pool_result, op.Constant(value_ints=[0]))
+
+    return pool_result
+
+
+@onnx_impl(aten.max_pool3d.default, trace_only=True)
+def aten_max_pool3d(
+    self: TFloatOrUInt8,
+    kernel_size: Sequence[int],
+    stride: Sequence[int] = (),
+    padding: Sequence[int] = (0, 0, 0),
+    dilation: Sequence[int] = (1, 1, 1),
+    ceil_mode: bool = False,
+) -> TFloatOrUInt8:
+    """max_pool3d(Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, int[3] dilation=1, bool ceil_mode=False) -> Tensor"""
+
+    # Torch prefers to use single number x for kernel, stride, pad and dilation on both sides implicitly.
+    # But ONNX needs to specify a tuple of three ints for all sides explicitly.
+    expand_size = 3
+
+    kernel_shape, strides, pads, dilations = _adjust_attributes_of_max_pool(
+        expand_size, kernel_size, stride, padding, dilation
+    )
+
+    return _aten_max_pool_onnx(
+        self, kernel_shape, strides, pads, dilations, ceil_mode, 4
+    )
+
+
+@onnx_impl(aten.max_pool2d_with_indices.default, trace_only=True)
+def aten_max_pool2d_with_indices(
+    self: TFloatOrUInt8,
+    kernel_size: Sequence[int],
+    stride: Sequence[int] = (),
+    padding: Sequence[int] = (0, 0),
+    dilation: Sequence[int] = (1, 1),
+    ceil_mode: bool = False,
+) -> Tuple[TFloatOrUInt8, INT64]:
+    """max_pool2d_with_indices(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> (Tensor, Tensor)"""
+
+    # Torch prefers to use single number x for kernel, stride, pad and dilation on both sides implicitly.
+    # But ONNX needs to specify a pair of number [x,y] on each side explicitly.
+    expand_size = 2
+
+    kernel_shape, strides, pads, dilations = _adjust_attributes_of_max_pool(
+        expand_size, kernel_size, stride, padding, dilation
+    )
+
+    return _aten_max_pool_with_indices_onnx(
+        self,
+        kernel_shape,
+        strides,
+        pads,
+        dilations,
+        ceil_mode,
+        3,
+        ([1] * expand_size),
+        ([0] * expand_size),
+        ([2 + i for i in range(expand_size)]),
+    )
+
+
+def aten_max_pool2d_with_indices_backward(
+    grad_output: TensorType,
+    self: TensorType,
+    kernel_size: Sequence[int],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    ceil_mode: bool,
+    indices: TensorType,
+) -> TensorType:
+    """max_pool2d_with_indices_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool ceil_mode, Tensor indices) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.max_pool3d_with_indices.default, trace_only=True)
+def aten_max_pool3d_with_indices(
+    self: TFloatOrUInt8,
+    kernel_size: Sequence[int],
+    stride: Sequence[int] = (),
+    padding: Sequence[int] = (0, 0, 0),
+    dilation: Sequence[int] = (1, 1, 1),
+    ceil_mode: bool = False,
+) -> Tuple[TFloatOrUInt8, INT64]:
+    """max_pool3d_with_indices(Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, int[3] dilation=1, bool ceil_mode=False) -> (Tensor, Tensor)"""
+
+    # Torch prefers to use single number x for kernel, stride, pad and dilation on both sides implicitly.
+    # But ONNX needs to specify a tuple of three ints for all sides explicitly.
+    expand_size = 3
+
+    kernel_shape, strides, pads, dilations = _adjust_attributes_of_max_pool(
+        expand_size, kernel_size, stride, padding, dilation
+    )
+
+    return _aten_max_pool_with_indices_onnx(
+        self,
+        kernel_shape,
+        strides,
+        pads,
+        dilations,
+        ceil_mode,
+        4,
+        ([1] * expand_size),
+        ([0] * expand_size),
+        ([2 + i for i in range(expand_size)]),
+    )
+
+
+def _aten_max_pool_with_indices_onnx(
+    self: TFloatOrUInt8,
+    kernel_size: Sequence[int],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    ceil_mode: bool,
+    unbatched_rank: int,
+    n_dims_one: Sequence[int],
+    n_dims_zero: Sequence[int],
+    n_dims_axes: Sequence[int],
+) -> Tuple[TFloatOrUInt8, INT64]:
+    self_rank_is_unbatched_rank = Rank(self) == unbatched_rank
+    if self_rank_is_unbatched_rank:
+        self = op.Unsqueeze(self, axes=0)
+
+    pool_result, indices = op.MaxPool(
+        self,
+        ceil_mode=ceil_mode,
+        dilations=dilation,
+        kernel_shape=kernel_size,
+        pads=padding,
+        strides=stride,
+    )
+
+    # Simple but hacky way to get flattened indices values
+    # to be used to convert the indices values to non-flattened.
+    # In ONNX the indices are computed as a flatten 1-D tensor,
+    # so the values in indices are in [0, N x C x D1 x ... x Dn).
+    # To convert the indices to the same format used by PyTorch,
+    # we first execute a maxpool with a kernel and stride of 1 on the same input.
+    # This will result in a tensor of indices in which each index will have it's own value.
+    # Using this tensor as a reference, we extract the first index of each axis and subtract
+    # it from each index of this axis in the indices to convert.
+    # This step will result in a tensor where each dimension has values of indices within
+    # the dimension it is in.
+    # For Maxpool1d(kernel=1,stride=1,return_indices=True), with the input torch.ones(1,2,2).
+    # The computed indices are the following:
+    # output indices pytorch :
+    #     [[0,1],
+    #      [0,1]]
+    # output indices onnx:
+    #     [[0,1],
+    #      [2,3]]
+    # The purpose was to convert the indices from one format to the other to be able to match the results.
+    # So flattened_indices will have the value of each index and will be equal to :
+    #     [[0,1],
+    #     [2,3]]
+    # Then call Slice to get the first value of each line (so 0 and 2).
+    # And the subtraction executes :
+    #     [[0-0,1-0],
+    #     [2-2,3-2]]
+    # So indices results to the expected output which is :
+    #     [[0,1],
+    #     [0,1]]
+    # For more information :
+    # https://github.com/pytorch/pytorch/pull/16455#issuecomment-460776407
+    _, flatten_indices = op.MaxPool(
+        self, dilations=dilation, kernel_shape=n_dims_one, strides=n_dims_one
+    )
+
+    ends = op.Constant(value_ints=n_dims_one)
+    starts = op.Constant(value_ints=n_dims_zero)
+    axes = op.Constant(value_ints=n_dims_axes)
+
+    delta = op.Slice(flatten_indices, axes=axes, starts=starts, ends=ends)
+    indices = op.Sub(indices, delta)
+
+    if self_rank_is_unbatched_rank:
+        pool_result = op.Squeeze(pool_result, op.Constant(value_ints=[0]))
+        indices = op.Squeeze(indices, op.Constant(value_ints=[0]))
+
+    return (pool_result, indices)
+
+
+def aten_max_pool3d_with_indices_backward(
+    grad_output: TensorType,
+    self: TensorType,
+    kernel_size: Sequence[int],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    ceil_mode: bool,
+    indices: TensorType,
+) -> TensorType:
+    """max_pool3d_with_indices_backward(Tensor grad_output, Tensor self, int[3] kernel_size, int[3] stride, int[3] padding, int[3] dilation, bool ceil_mode, Tensor indices) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_max_unpool2d(
+    self: TensorType, indices: TensorType, output_size: Sequence[int]
+) -> TensorType:
+    """max_unpool2d(Tensor self, Tensor indices, int[2] output_size) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_max_unpool3d(
+    self: TensorType,
+    indices: TensorType,
+    output_size: Sequence[int],
+    stride: Sequence[int],
+    padding: Sequence[int],
+) -> TensorType:
+    """max_unpool3d(Tensor self, Tensor indices, int[3] output_size, int[3] stride, int[3] padding) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.mish.default)
+def aten_mish(self: TFloat) -> TFloat:
+    """mish(Tensor self) -> Tensor"""
+
+    return op.Mish(self)
+
+
+def aten_mish_backward(grad_output: TensorType, self: TensorType) -> TensorType:
+    """mish_backward(Tensor grad_output, Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_mkldnn_linear(
+    self: TensorType, weight: TensorType, bias: Optional[TensorType] = None
+) -> TensorType:
+    """mkldnn_linear(Tensor self, Tensor weight, Tensor? bias=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_mkldnn_reorder_conv2d_weight(
+    self: TensorType,
+    padding: Sequence[int] = (0, 0),
+    stride: Sequence[int] = (1, 1),
+    dilation: Sequence[int] = (1, 1),
+    groups: int = 1,
+) -> TensorType:
+    """mkldnn_reorder_conv2d_weight(Tensor self, int[2] padding=0, int[2] stride=1, int[2] dilation=1, int groups=1) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_mkldnn_reorder_conv3d_weight(
+    self: TensorType,
+    padding: Sequence[int] = (0, 0, 0),
+    stride: Sequence[int] = (1, 1, 1),
+    dilation: Sequence[int] = (1, 1, 1),
+    groups: int = 1,
+) -> TensorType:
+    """mkldnn_reorder_conv3d_weight(Tensor self, int[3] padding=0, int[3] stride=1, int[3] dilation=1, int groups=1) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.mse_loss.default, trace_only=True)
+def aten_mse_loss(self: TReal, target: TReal, reduction: int = 1) -> TReal:
+    """mse_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor"""
+    # FIXME: When reduction=0, the shape(result) will be different than other case
+    result = op.Mul(self - target, self - target)
+    if reduction == 1:  # mean
+        result = op.ReduceMean(result, keepdims=False)
+    if reduction == 2:  # sum
+        result = op.ReduceSum(result, keepdims=False)
+
+    return result
+
+
+def aten_mse_loss_backward(
+    grad_output: TensorType, self: TensorType, target: TensorType, reduction: int
+) -> TensorType:
+    """mse_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_multi_margin_loss(
+    self: TensorType,
+    target: TensorType,
+    p: float = 1.0,
+    margin: float = 1.0,
+    weight: Optional[TensorType] = None,
+    reduction: int = 1,
+) -> TensorType:
+    """multi_margin_loss(Tensor self, Tensor target, Scalar p=1, Scalar margin=1, Tensor? weight=None, int reduction=Mean) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_multi_margin_loss_backward(
+    grad_output: TensorType,
+    self: TensorType,
+    target: TensorType,
+    p: float,
+    margin: float,
+    weight: Optional[TensorType] = None,
+    reduction: int = 1,
+) -> TensorType:
+    """multi_margin_loss_backward(Tensor grad_output, Tensor self, Tensor target, Scalar p, Scalar margin, Tensor? weight=None, int reduction=Mean) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_multilabel_margin_loss(
+    self: TensorType, target: TensorType, reduction: int = 1
+) -> TensorType:
+    """multilabel_margin_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_multilabel_margin_loss_backward(
+    grad_output: TensorType,
+    self: TensorType,
+    target: TensorType,
+    reduction: int,
+    is_target: TensorType,
+) -> TensorType:
+    """multilabel_margin_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction, Tensor is_target) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_multilabel_margin_loss_forward(
+    self: TensorType, target: TensorType, reduction: int
+) -> tuple[TensorType, TensorType]:
+    """multilabel_margin_loss_forward(Tensor self, Tensor target, int reduction) -> (Tensor output, Tensor is_target)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.nll_loss.default, trace_only=True)
+def aten_nll_loss(
+    self: TFloat,
+    target: INT64,
+    weight: Optional[TFloat] = None,
+    reduction: int = 1,
+    ignore_index: int = -100,
+) -> TFloat:
+    """nll_loss(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, SymInt ignore_index=-100) -> Tensor"""
+
+    self_rank_is_1 = Rank(self) == 1
+    if self_rank_is_1:  # self rank should be at least 2
+        self = op.Unsqueeze(self, op.Constant(value_ints=[0]))
+
+    rank_target = Rank(target)
+    if rank_target == 0:  # target rank should be at least 1
+        target = op.Unsqueeze(target, op.Constant(value_ints=[0]))
+
+    if reduction == 0:
+        reduction_str = "none"
+    elif reduction == 1:
+        reduction_str = "mean"
+    else:  # assert reduction == 2
+        reduction_str = "sum"
+
+    result = op.NegativeLogLikelihoodLoss(
+        self, target, weight, ignore_index=ignore_index, reduction=reduction_str
+    )
+
+    if self_rank_is_1:
+        result = op.Squeeze(result)
+
+    return result
+
+
+def aten_nll_loss2d(
+    self: TensorType,
+    target: TensorType,
+    weight: Optional[TensorType] = None,
+    reduction: int = 1,
+    ignore_index: INT64 = -100,
+) -> TensorType:
+    """nll_loss2d(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, SymInt ignore_index=-100) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_nll_loss2d_backward(
+    grad_output: TensorType,
+    self: TensorType,
+    target: TensorType,
+    weight: Optional[TensorType],
+    reduction: int,
+    ignore_index: INT64,
+    total_weight: TensorType,
+) -> TensorType:
+    """nll_loss2d_backward(Tensor grad_output, Tensor self, Tensor target, Tensor? weight, int reduction, SymInt ignore_index, Tensor total_weight) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_nll_loss2d_forward(
+    self: TensorType,
+    target: TensorType,
+    weight: Optional[TensorType],
+    reduction: int,
+    ignore_index: INT64,
+) -> tuple[TensorType, TensorType]:
+    """nll_loss2d_forward(Tensor self, Tensor target, Tensor? weight, int reduction, SymInt ignore_index) -> (Tensor output, Tensor total_weight)"""
+
+    raise NotImplementedError
+
+
+def aten_nll_loss_backward(
+    grad_output: TensorType,
+    self: TensorType,
+    target: TensorType,
+    weight: Optional[TensorType],
+    reduction: int,
+    ignore_index: INT64,
+    total_weight: TensorType,
+) -> TensorType:
+    """nll_loss_backward(Tensor grad_output, Tensor self, Tensor target, Tensor? weight, int reduction, SymInt ignore_index, Tensor total_weight) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.nll_loss_forward.default, trace_only=True)
+def aten_nll_loss_forward(
+    self: TensorType,
+    target: TensorType,
+    weight: Optional[TensorType],
+    reduction: int,
+    ignore_index: int,
+) -> tuple[TensorType, TensorType]:
+    """nll_loss_forward(Tensor self, Tensor target, Tensor? weight, int reduction, SymInt ignore_index) -> (Tensor output, Tensor total_weight)"""
+
+    output = aten_nll_loss(self, target, weight, reduction, ignore_index)
+    # FIXME: Fake a total_weight tensor for now. It should be different based on weight, reduction and ignore_index
+    if weight is None:
+        total_weight = op.CastLike(op.Size(output), self)
+    else:
+        total_weight = op.CastLike(op.Size(output), weight)
+    return output, total_weight
+
+
+def aten_nll_loss_nd(
+    self: TensorType,
+    target: TensorType,
+    weight: Optional[TensorType] = None,
+    reduction: int = 1,
+    ignore_index: INT64 = -100,
+) -> TensorType:
+    """nll_loss_nd(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, SymInt ignore_index=-100) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_one_hot(self: TensorType, num_classes: int = -1) -> TensorType:
+    """one_hot(Tensor self, int num_classes=-1) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.pad.default, trace_only=True)
+def aten_pad(
+    self: TensorType,
+    pad: Sequence[INT64],
+    mode: str = "constant",
+    value: Optional[float] = None,
+) -> TensorType:
+    """pad(Tensor self, SymInt[] pad, str mode="constant", float? value=None) -> Tensor"""
+
+    rank = len(self.shape)
+    paddings = _process_padding(pad, rank)
+    const_value = (
+        op.Constant(value=ir.tensor(value, dtype=ir.DataType(self.dtype)))
+        if value is not None
+        else None
+    )
+    onnx_mode = {
+        "constant": "constant",
+        "reflect": "reflect",
+        "replicate": "edge",
+        "circular": "wrap",
+    }[mode]
+
+    return op.Pad(self, paddings, constant_value=const_value, mode=onnx_mode)
+
+
+def aten_pad_sequence(
+    sequences: Sequence[TensorType],
+    batch_first: bool = False,
+    padding_value: float = 0.0,
+) -> TensorType:
+    """pad_sequence(Tensor[] sequences, bool batch_first=False, float padding_value=0.0) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.reflection_pad1d.default, trace_only=True)
+def aten_reflection_pad1d(self: TFloat, padding: Sequence[INT64]) -> TFloat:
+    """reflection_pad1d(Tensor self, SymInt[2] padding) -> Tensor"""
+
+    # assert len(padding) == 2
+    # Input of padding argument should be [x,y], need change to onnx format [0, x, 0, y]
+    rank = len(self.shape)
+    paddings = _process_padding(padding, rank)
+    return op.Pad(self, paddings, mode="reflect")
+
+
+def aten_reflection_pad1d_backward(
+    grad_output: TensorType, self: TensorType, padding: INT64
+) -> TensorType:
+    """reflection_pad1d_backward(Tensor grad_output, Tensor self, SymInt[2] padding) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.reflection_pad2d.default, trace_only=True)
+def aten_reflection_pad2d(self: TTensor, padding: Sequence[INT64]) -> TTensor:
+    """reflection_pad2d(Tensor self, SymInt[4] padding) -> Tensor"""
+    rank = len(self.shape)
+    paddings = _process_padding(padding, rank)
+    return op.Pad(self, paddings, mode="reflect")
+
+
+def aten_reflection_pad2d_backward(
+    grad_output: TensorType, self: TensorType, padding: INT64
+) -> TensorType:
+    """reflection_pad2d_backward(Tensor grad_output, Tensor self, SymInt[4] padding) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@torch_op(aten.reflection_pad3d.default, trace_only=True)
+def aten_reflection_pad3d(self: TensorType, padding: Sequence[INT64]) -> TensorType:
+    """reflection_pad3d(Tensor self, SymInt[6] padding) -> Tensor"""
+    rank = len(self.shape)
+    paddings = _process_padding(padding, rank)
+    return op.Pad(self, paddings, mode="reflect")
+
+
+def aten_reflection_pad3d_backward(
+    grad_output: TensorType, self: TensorType, padding: INT64
+) -> TensorType:
+    """reflection_pad3d_backward(Tensor grad_output, Tensor self, SymInt[6] padding) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.relu.default, trace_only=True)
+def aten_relu(self: TReal) -> TReal:
+    """relu(Tensor self) -> Tensor"""
+
+    return op.Relu(self)
+
+
+@onnx_impl(aten.relu6.default, trace_only=True)
+def aten_relu6(self: TReal) -> TReal:
+    """relu6(Tensor self) -> Tensor"""
+
+    six = op.CastLike(op.Constant(value_int=6), self)
+    return op.Min(op.Relu(self), six)
+
+
+@onnx_impl(aten.replication_pad1d.default, trace_only=True)
+def aten_replication_pad1d(self: TensorType, padding: Sequence[INT64]) -> TensorType:
+    """replication_pad1d(Tensor self, SymInt[2] padding) -> Tensor"""
+
+    rank = len(self.shape)
+    paddings = _process_padding(padding, rank)
+    return op.Pad(self, paddings, mode="edge")
+
+
+def aten_replication_pad1d_backward(
+    grad_output: TensorType, self: TensorType, padding: INT64
+) -> TensorType:
+    """replication_pad1d_backward(Tensor grad_output, Tensor self, SymInt[2] padding) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.replication_pad2d.default, trace_only=True)
+def aten_replication_pad2d(self: TTensor, padding: Sequence[INT64]) -> TTensor:
+    """replication_pad2d(Tensor self, SymInt[4] padding) -> Tensor"""
+
+    rank = len(self.shape)
+    paddings = _process_padding(padding, rank)
+    return op.Pad(self, paddings, mode="edge")
+
+
+def aten_replication_pad2d_backward(
+    grad_output: TensorType, self: TensorType, padding: INT64
+) -> TensorType:
+    """replication_pad2d_backward(Tensor grad_output, Tensor self, SymInt[4] padding) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.replication_pad3d.default)
+def aten_replication_pad3d(self: TTensor, padding: Sequence[INT64]) -> TTensor:
+    """replication_pad3d(Tensor self, SymInt[6] padding) -> Tensor"""
+
+    rank = len(self.shape)
+    paddings = _process_padding(padding, rank)
+    return op.Pad(self, paddings, mode="edge")
+
+
+def aten_replication_pad3d_backward(
+    grad_output: TensorType, self: TensorType, padding: INT64
+) -> TensorType:
+    """replication_pad3d_backward(Tensor grad_output, Tensor self, SymInt[6] padding) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_rrelu_with_noise(
+    self: TensorType,
+    noise: TensorType,
+    lower: float = 0.125,
+    upper: float = 0.3333333333333333,
+    training: bool = False,
+    generator: Optional[str] = None,
+) -> TensorType:
+    """rrelu_with_noise(Tensor self, Tensor noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_rrelu_with_noise_backward(
+    grad_output: TensorType,
+    self: TensorType,
+    noise: TensorType,
+    lower: float,
+    upper: float,
+    training: bool,
+    self_is_result: bool,
+) -> TensorType:
+    """rrelu_with_noise_backward(Tensor grad_output, Tensor self, Tensor noise, Scalar lower, Scalar upper, bool training, bool self_is_result) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def _causal_attention_mask(query: TFloat, key: TFloat) -> TFloat:
+    """Create a causal mask for the given query and key tensors.
+
+    Equivalent to::
+        mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)
+        attn_mask = torch.zeros(L, S, dtype=torch.float)
+        attn_mask = attn_mask.masked_fill(not mask, -float("inf"))
+
+    Args:
+        query: Tensor of shape [..., L, E]
+        key: Tensor of shape [..., S, E]
+
+    Returns:
+        Tensor of shape [L, S]
+    """
+    q_shape = op.Shape(query)
+    k_shape = op.Shape(key)
+
+    target_length = op.Slice(
+        q_shape, op.Constant(value_ints=[-2]), op.Constant(value_ints=[-1])
+    )
+    source_length = op.Slice(
+        k_shape, op.Constant(value_ints=[-2]), op.Constant(value_ints=[-1])
+    )
+    # attn_mask = torch.ones(L, S) := {
+    size = op.Concat(target_length, source_length, axis=0)
+    attn_mask = op.Expand(op.Constant(value_float=1.0), size)
+    # }
+    attn_mask = op.Trilu(attn_mask, upper=0)
+    # The causal mask has 0s in the lower triangle and -inf in the upper triangle.
+    attn_mask = op.Where(
+        op.Equal(attn_mask, op.Constant(value_float=0.0)),
+        op.Constant(value_float=-float("inf")),
+        op.Constant(value_float=0.0),
+    )
+    attn_mask = op.CastLike(attn_mask, query)
+    return attn_mask
+
+
+def _attention_scale(query: TFloat) -> TFloat:
+    """Calculate the scale factor for the attention result.
+
+    Args:
+        query: Tensor of shape [..., L, E]
+
+    Returns:
+        Scalar scale factor := 1 / math.sqrt(query.size(-1))
+    """
+    q_shape = op.Shape(query)
+    q_last_dim = op.Gather(q_shape, op.Constant(value_ints=[-1]))
+    embedding_size = op.CastLike(q_last_dim, query)
+    one = op.Constant(value_float=1.0)
+    cast_one = op.CastLike(one, query)
+    scale = op.Div(cast_one, op.Sqrt(embedding_size))
+    return scale
+
+
+@onnx_impl(aten.scaled_dot_product_attention.default, trace_only=True)
+def aten_scaled_dot_product_attention(
+    query: TFloat,
+    key: TFloat,
+    value: TFloat,
+    attn_mask: Optional[TFloat] = None,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    scale: Optional[float] = None,
+    enable_gqa: bool = False,
+) -> TFloat:
+    """scaled_dot_product_attention(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool is_causal=False, *, float? scale=None, bool enable_gqa=False) -> Tensor
+
+    Reference: https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html
+
+    Equivalent to the PyTorch code::
+        scale_factor = 1 / math.sqrt(Q.size(-1)) if scale is None else scale
+        attn_mask = (
+            torch.ones(L, S, dtype=torch.bool).tril(diagonal=0) if is_causal else attn_mask
+        )
+        attn_mask = (
+            attn_mask.masked_fill(not attn_mask, -float("inf"))
+            if attn_mask.dtype == torch.bool
+            else attn_mask
+        )
+        attn_weight = torch.softmax(
+            (Q @ K.transpose(-2, -1) * scale_factor) + attn_mask, dim=-1
+        )
+        attn_weight = torch.dropout(attn_weight, dropout_p)
+        return attn_weight @ V
+
+    where Q, K, V are the query, key, and value tensors, respectively.
+    L is the target sequence length, S is the source sequence length, and E is the embedding size.
+    """
+    # Use trace_only to handle optional inputs
+    assert (not is_causal) or (
+        is_causal and attn_mask is None
+    ), "is_causal and attn_mask cannot be set at the same time"
+
+    assert not enable_gqa, "conversion of scaled_dot_product_attention not implemented if enable_gqa is True"
+
+    # Reference: https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html
+    if scale is None:
+        scale = _attention_scale(query)
+    scale = op.CastLike(scale, query)
+
+    if is_causal:
+        attn_mask = _causal_attention_mask(query, key)
+
+    if attn_mask is None:
+        return _aten_scaled_dot_product_attention_no_mask_onnx(
+            query, key, value, scale, dropout_p
+        )
+
+    return _aten_scaled_dot_product_attention_float_mask_onnx(
+        query, key, value, attn_mask, scale, dropout_p
+    )
+
+
+def _aten__scaled_dot_product_flash_attention_fillin_empty_outputs(
+    query: TFloat,
+) -> Tuple[FLOAT, INT64, INT64, FLOAT]:
+    query_first_three_dims = op.Slice(
+        op.Shape(query), op.Constant(value_ints=[0]), op.Constant(value_ints=[3])
+    )
+    logsumexp = op.Expand(0.0, query_first_three_dims)
+    # TODO: Eliminate `make_tensor` usage when ORT supports empty tensor.
+    empty_tensor_int = op.Cast(
+        op.ConstantOfShape(
+            op.Constant(
+                value=onnx.helper.make_tensor("Empty_INTS", INT64.dtype, [0], [])
+            )
+        ),
+        to=INT64.dtype,
+    )
+    empty_tensor_float = op.ConstantOfShape(
+        op.Constant(value=onnx.helper.make_tensor("Empty_FLOATS", INT64.dtype, [0], []))
+    )
+    empty_int = op.Constant(value_int=0)
+
+    return logsumexp, empty_tensor_int, empty_int, empty_tensor_float
+
+
+@onnx_impl(aten._scaled_dot_product_flash_attention.default, trace_only=True)
+def aten__scaled_dot_product_flash_attention(
+    query: TFloat,
+    key: TFloat,
+    value: TFloat,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    return_debug_mask: bool = False,
+    scale: Optional[float] = None,
+) -> Tuple[TFloat, FLOAT, INT64, INT64, INT64, INT64, INT64, INT64, FLOAT]:
+    """_scaled_dot_product_flash_attention(Tensor query, Tensor key, Tensor value, float dropout_p=0.0, bool is_causal=False, bool return_debug_mask=False, *, float? scale=None) -> (Tensor output, Tensor logsumexp, Tensor cum_seq_q, Tensor cum_seq_k, int max_q, int max_k, Tensor philox_seed, Tensor philox_offset, Tensor debug_attn_mask)
+
+    One of the implementations of scaled_dot_product_attention.
+    Reference: https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html
+
+    NOTE: Currently, there are three implementations of nn.scaled_dot_product_attention in PyTorch due to optimization.
+    However, it's the same implementation from ONNX perspective.
+
+    """
+    result = aten_scaled_dot_product_attention(
+        query, key, value, dropout_p=dropout_p, is_causal=is_causal, scale=scale
+    )
+
+    # The followings are not comsumed by the graph.
+    (
+        logsumexp,
+        empty_tensor_int,
+        empty_int,
+        empty_tensor_float,
+    ) = _aten__scaled_dot_product_flash_attention_fillin_empty_outputs(query)
+
+    return (
+        result,
+        logsumexp,
+        empty_tensor_int,
+        empty_tensor_int,
+        empty_int,
+        empty_int,
+        empty_tensor_int,
+        empty_tensor_int,
+        empty_tensor_float,
+    )
+
+
+@onnx_impl(aten._scaled_dot_product_efficient_attention.default, private=True)
+def _aten_scaled_dot_product_efficient_attention_fillin_empty_outputs(
+    query: TFloat,
+    compute_log_sumexp: bool,
+) -> Tuple[FLOAT, INT64]:
+    """_scaled_dot_product_efficient_attention(Tensor query, Tensor key, Tensor value, Tensor? attn_bias, bool compute_log_sumexp, float dropout_p=0.0, bool is_causal=False, *, float? scale=None) -> (Tensor output, Tensor log_sumexp, Tensor philox_seed, Tensor philox_offset)"""
+
+    query = op.Transpose(query, perm=[0, 2, 1, 3])
+    query_shape = op.Shape(query)
+    query_first_dims = op.Slice(query_shape, op.Constant(value_ints=[_INT64_MIN]), [1])
+    query_second_dims = op.Slice(query_shape, [1], [2])
+    num_heads = op.Slice(query_shape, [-2], [-1])
+
+    if compute_log_sumexp:
+        logsumexp_dim = op.Cast(
+            op.Ceil(op.Cast(query_second_dims, to=FLOAT.dtype) / 32.0) * 32.0,
+            to=INT64.dtype,
+        )
+        logsum_exp = op.Expand(
+            0.0, op.Concat(query_first_dims, num_heads, logsumexp_dim, axis=0)
+        )
+    else:
+        logsum_exp = op.Expand(0.0, op.Concat(query_first_dims, num_heads, [0], axis=0))
+
+    # See Note [Seed and Offset]:
+    empty_tensor_int = op.Cast(
+        op.ConstantOfShape(
+            op.Constant(
+                value=onnx.helper.make_tensor("Empty_INTS", INT64.dtype, [0], [])
+            )
+        ),
+        to=INT64.dtype,
+    )
+
+    return logsum_exp, empty_tensor_int
+
+
+@onnx_impl(aten._scaled_dot_product_flash_attention_for_cpu.default, trace_only=True)
+def aten__scaled_dot_product_flash_attention_for_cpu(
+    query: TFloat,
+    key: TFloat,
+    value: TFloat,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    attn_mask: Optional[TFloat] = None,
+    scale: Optional[float] = None,
+) -> Tuple[TFloat, FLOAT]:
+    """_scaled_dot_product_flash_attention_for_cpu(Tensor query, Tensor key, Tensor value, float dropout_p=0.0, bool is_causal=False, *, Tensor? attn_mask=None, float? scale=None) -> (Tensor output, Tensor logsumexp)"""
+    result = aten_scaled_dot_product_attention(
+        query,
+        key,
+        value,
+        attn_mask=attn_mask,
+        dropout_p=dropout_p,
+        is_causal=is_causal,
+        scale=scale,
+    )
+    query_shape = op.Shape(query)
+    query_first_dims = op.Slice(query_shape, [0], [1])
+    query_second_dims = op.Slice(query_shape, [1], [2])
+    num_heads = op.Slice(query_shape, [-2], [-1])
+    logsumexp_dim = op.Cast(
+        op.Ceil(op.Cast(query_second_dims, to=FLOAT.dtype) / 32.0) * 32.0,
+        to=INT64.dtype,
+    )
+    logsum_exp = op.Expand(
+        0.0, op.Concat(query_first_dims, num_heads, logsumexp_dim, axis=0)
+    )
+    return result, logsum_exp
+
+
+@onnx_impl(aten._scaled_dot_product_efficient_attention.default, trace_only=True)
+def aten__scaled_dot_product_efficient_attention(
+    query: TFloat,
+    key: TFloat,
+    value: TFloat,
+    attn_bias: Optional[TFloat],
+    compute_log_sumexp: bool,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    scale: Optional[float] = None,
+) -> Tuple[TFloat, FLOAT, INT64, INT64]:
+    """_scaled_dot_product_efficient_attention(Tensor query, Tensor key, Tensor value, Tensor? attn_bias, bool compute_log_sumexp, float dropout_p=0.0, bool is_causal=False, *, float? scale=None) -> (Tensor output, Tensor log_sumexp, Tensor philox_seed, Tensor philox_offset)"""
+
+    result = aten_scaled_dot_product_attention(
+        query,
+        key,
+        value,
+        attn_bias,
+        dropout_p=dropout_p,
+        is_causal=is_causal,
+        scale=scale,
+    )
+
+    # The followings are not comsumed by the graph.
+    (
+        logsumexp,
+        empty_tensor_int,
+    ) = _aten_scaled_dot_product_efficient_attention_fillin_empty_outputs(
+        query, compute_log_sumexp
+    )
+
+    return (
+        result,
+        logsumexp,
+        empty_tensor_int,
+        empty_tensor_int,
+    )
+
+
+@onnx_impl(aten.scaled_dot_product_attention.default, trace_only=True)
+def aten_scaled_dot_product_attention_bool_mask(
+    query: TFloat,
+    key: TFloat,
+    value: TFloat,
+    attn_mask: Optional[BOOL] = None,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    scale: Optional[float] = None,
+    enable_gqa: bool = False,
+) -> TFloat:
+    """scaled_dot_product_attention(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool is_causal=False, *, float? scale=None, bool enable_gqa=False) -> Tensor
+
+    Reference: https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html
+
+    Equivalent to the PyTorch code::
+        scale_factor = 1 / math.sqrt(Q.size(-1)) if scale is None else scale
+        attn_mask = (
+            torch.ones(L, S, dtype=torch.bool).tril(diagonal=0) if is_causal else attn_mask
+        )
+        attn_mask = (
+            attn_mask.masked_fill(not attn_mask, -float("inf"))
+            if attn_mask.dtype == torch.bool
+            else attn_mask
+        )
+        attn_weight = torch.softmax(
+            (Q @ K.transpose(-2, -1) * scale_factor) + attn_mask, dim=-1
+        )
+        attn_weight = torch.dropout(attn_weight, dropout_p)
+        return attn_weight @ V
+
+    where Q, K, V are the query, key, and value tensors, respectively.
+    L is the target sequence length, S is the source sequence length, and E is the embedding size.
+    """
+    # Use trace_only to handle optional inputs
+    assert (not is_causal) or (
+        is_causal and attn_mask is None
+    ), "is_causal and attn_mask cannot be set at the same time"
+
+    assert not enable_gqa, "conversion of scaled_dot_product_attention not implemented if enable_gqa is True"
+
+    if scale is None:
+        scale = _attention_scale(query)
+    scale = op.CastLike(scale, query)
+
+    if is_causal:
+        attn_mask = _causal_attention_mask(query, key)
+        # The causal mask is always float
+        return _aten_scaled_dot_product_attention_float_mask_onnx(
+            query, key, value, attn_mask, scale, dropout_p
+        )
+
+    if attn_mask is None:
+        return _aten_scaled_dot_product_attention_no_mask_onnx(
+            query, key, value, scale, dropout_p
+        )
+
+    return _aten_scaled_dot_product_attention_bool_mask_onnx(
+        query, key, value, attn_mask, scale, dropout_p
+    )
+
+
+def _aten_scaled_dot_product_attention_no_mask_onnx(
+    query: TFloat,
+    key: TFloat,
+    value: TFloat,
+    scale: TFloat,
+    dropout_p: float,
+) -> TFloat:
+    # Swap the last two axes of key
+    key_shape = op.Shape(key)
+    key_last_dim = op.Slice(key_shape, [-1], op.Constant(value_ints=[_INT64_MAX]))
+    key_second_last_dim = op.Slice(key_shape, [-2], [-1])
+    key_first_dims = op.Slice(key_shape, op.Constant(value_ints=[_INT64_MIN]), [-2])
+    # Contract the dimensions that are not the last two so we can transpose
+    # with a static permutation.
+    key_squeezed_shape = op.Concat(
+        op.Constant(value_ints=[-1]), key_second_last_dim, key_last_dim, axis=0
+    )
+    key_squeezed = op.Reshape(key, key_squeezed_shape)
+    key_squeezed_transposed = op.Transpose(key_squeezed, perm=[0, 2, 1])
+    key_transposed_shape = op.Concat(
+        key_first_dims, key_last_dim, key_second_last_dim, axis=0
+    )
+    key_transposed = op.Reshape(key_squeezed_transposed, key_transposed_shape)
+
+    # https://github.com/pytorch/pytorch/blob/12da0c70378b5be9135c6fda62a9863bce4a4818/aten/src/ATen/native/transformers/attention.cpp#L653
+    # Scale q, k before matmul for stability see https://tinyurl.com/sudb9s96 for math
+    query_scaled = op.Mul(query, op.Sqrt(scale))
+    key_transposed_scaled = op.Mul(
+        key_transposed, op.CastLike(op.Sqrt(scale), key_transposed)
+    )
+    attn_weight = op.Softmax(
+        op.MatMul(query_scaled, key_transposed_scaled),
+        axis=-1,
+    )
+    attn_weight, _ = op.Dropout(attn_weight, dropout_p)
+    return op.MatMul(attn_weight, value)
+
+
+def _aten_scaled_dot_product_attention_bool_mask_onnx(
+    query: TFloat,
+    key: TFloat,
+    value: TFloat,
+    attn_mask: BOOL,
+    scale: TFloat,
+    dropout_p: float,
+) -> TFloat:
+    # Swap the last two axes of key
+    key_shape = op.Shape(key)
+    key_last_dim = op.Slice(key_shape, [-1], op.Constant(value_ints=[_INT64_MAX]))
+    key_second_last_dim = op.Slice(key_shape, [-2], [-1])
+    key_first_dims = op.Slice(key_shape, op.Constant(value_ints=[_INT64_MIN]), [-2])
+    # Contract the dimensions that are not the last two so we can transpose
+    # with a static permutation.
+    key_squeezed_shape = op.Concat(
+        op.Constant(value_ints=[-1]), key_second_last_dim, key_last_dim, axis=0
+    )
+    key_squeezed = op.Reshape(key, key_squeezed_shape)
+    key_squeezed_transposed = op.Transpose(key_squeezed, perm=[0, 2, 1])
+    key_transposed_shape = op.Concat(
+        key_first_dims, key_last_dim, key_second_last_dim, axis=0
+    )
+    key_transposed = op.Reshape(key_squeezed_transposed, key_transposed_shape)
+
+    # https://github.com/pytorch/pytorch/blob/12da0c70378b5be9135c6fda62a9863bce4a4818/aten/src/ATen/native/transformers/attention.cpp#L653
+    # Scale q, k before matmul for stability see https://tinyurl.com/sudb9s96 for math
+    query_scaled = op.Mul(query, op.Sqrt(scale))
+    key_transposed_scaled = op.Mul(key_transposed, op.Sqrt(scale))
+    # Turn the Boolean mask to float: attn_mask.masked_fill(not attn_mask, -float('inf'))
+    attn_mask = op.Where(
+        attn_mask, op.Constant(value_float=0.0), op.Constant(value_float=-float("inf"))
+    )
+    attn_weight = op.Softmax(
+        op.Add(op.MatMul(query_scaled, key_transposed_scaled), attn_mask),
+        axis=-1,
+    )
+    attn_weight, _ = op.Dropout(attn_weight, dropout_p)
+    return op.MatMul(attn_weight, value)
+
+
+def _aten_scaled_dot_product_attention_float_mask_onnx(
+    query: TFloat,
+    key: TFloat,
+    value: TFloat,
+    attn_mask: TFloat,
+    scale: TFloat,
+    dropout_p: float,
+) -> TFloat:
+    # Swap the last two axes of key
+    key_shape = op.Shape(key)
+    key_last_dim = op.Slice(key_shape, [-1], op.Constant(value_ints=[_INT64_MAX]))
+    key_second_last_dim = op.Slice(key_shape, [-2], [-1])
+    key_first_dims = op.Slice(key_shape, op.Constant(value_ints=[_INT64_MIN]), [-2])
+    # Contract the dimensions that are not the last two so we can transpose
+    # with a static permutation.
+    key_squeezed_shape = op.Concat(
+        op.Constant(value_ints=[-1]), key_second_last_dim, key_last_dim, axis=0
+    )
+    key_squeezed = op.Reshape(key, key_squeezed_shape)
+    key_squeezed_transposed = op.Transpose(key_squeezed, perm=[0, 2, 1])
+    key_transposed_shape = op.Concat(
+        key_first_dims, key_last_dim, key_second_last_dim, axis=0
+    )
+    key_transposed = op.Reshape(key_squeezed_transposed, key_transposed_shape)
+
+    # https://github.com/pytorch/pytorch/blob/12da0c70378b5be9135c6fda62a9863bce4a4818/aten/src/ATen/native/transformers/attention.cpp#L653
+    # Scale q, k before matmul for stability see https://tinyurl.com/sudb9s96 for math
+    query_scaled = op.Mul(query, op.Sqrt(scale))
+    key_transposed_scaled = op.Mul(key_transposed, op.Sqrt(scale))
+    attn_weight = op.Softmax(
+        op.Add(op.MatMul(query_scaled, key_transposed_scaled), attn_mask),
+        axis=-1,
+    )
+    attn_weight, _ = op.Dropout(attn_weight, dropout_p)
+    return op.MatMul(attn_weight, value)
+
+
+def aten_sigmoid_backward(grad_output: TensorType, output: TensorType) -> TensorType:
+    """sigmoid_backward(Tensor grad_output, Tensor output) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.silu.default, trace_only=True)
+def aten_silu(self: TFloat) -> TFloat:
+    """silu(Tensor self) -> Tensor"""
+
+    return op.Mul(self, op.Sigmoid(self))
+
+
+def aten_silu_backward(grad_output: TensorType, self: TensorType) -> TensorType:
+    """silu_backward(Tensor grad_output, Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_slow_conv3d(
+    self: TensorType,
+    weight: TensorType,
+    kernel_size: Sequence[int],
+    bias: Optional[TensorType] = None,
+    stride: Sequence[int] = (1, 1, 1),
+    padding: INT64 = (0, 0, 0),
+) -> TensorType:
+    """slow_conv3d(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, SymInt[3] padding=0) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_slow_conv3d_forward(
+    self: TensorType,
+    weight: TensorType,
+    kernel_size: Sequence[int],
+    bias: Optional[TensorType],
+    stride: Sequence[int],
+    padding: INT64,
+) -> TensorType:
+    """slow_conv3d_forward(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias, int[3] stride, SymInt[3] padding) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_slow_conv_dilated2d(
+    self: TensorType,
+    weight: TensorType,
+    kernel_size: Sequence[int],
+    bias: Optional[TensorType] = None,
+    stride: Sequence[int] = (1, 1),
+    padding: INT64 = (0, 0),
+    dilation: Sequence[int] = (1, 1),
+) -> TensorType:
+    """slow_conv_dilated2d(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, SymInt[2] padding=0, int[2] dilation=1) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_slow_conv_dilated3d(
+    self: TensorType,
+    weight: TensorType,
+    kernel_size: Sequence[int],
+    bias: Optional[TensorType] = None,
+    stride: Sequence[int] = (1, 1, 1),
+    padding: INT64 = (0, 0, 0),
+    dilation: Sequence[int] = (1, 1, 1),
+) -> TensorType:
+    """slow_conv_dilated3d(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, SymInt[3] padding=0, int[3] dilation=1) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_slow_conv_transpose2d(
+    self: TensorType,
+    weight: TensorType,
+    kernel_size: Sequence[int],
+    bias: Optional[TensorType] = None,
+    stride: Sequence[int] = (1, 1),
+    padding: INT64 = (0, 0),
+    output_padding: INT64 = (0, 0),
+    dilation: Sequence[int] = (1, 1),
+) -> TensorType:
+    """slow_conv_transpose2d(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, SymInt[2] padding=0, SymInt[2] output_padding=0, int[2] dilation=1) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_slow_conv_transpose3d(
+    self: TensorType,
+    weight: TensorType,
+    kernel_size: Sequence[int],
+    bias: Optional[TensorType] = None,
+    stride: Sequence[int] = (1, 1, 1),
+    padding: INT64 = (0, 0, 0),
+    output_padding: INT64 = (0, 0, 0),
+    dilation: Sequence[int] = (1, 1, 1),
+) -> TensorType:
+    """slow_conv_transpose3d(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, SymInt[3] padding=0, SymInt[3] output_padding=0, int[3] dilation=1) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_smooth_l1_loss(
+    self: TensorType, target: TensorType, reduction: int = 1, beta: float = 1.0
+) -> TensorType:
+    """smooth_l1_loss(Tensor self, Tensor target, int reduction=Mean, float beta=1.0) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_smooth_l1_loss_backward(
+    grad_output: TensorType,
+    self: TensorType,
+    target: TensorType,
+    reduction: int,
+    beta: float,
+) -> TensorType:
+    """smooth_l1_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction, float beta) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_soft_margin_loss(
+    self: TensorType, target: TensorType, reduction: int = 1
+) -> TensorType:
+    """soft_margin_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_soft_margin_loss_backward(
+    grad_output: TensorType, self: TensorType, target: TensorType, reduction: int
+) -> TensorType:
+    """soft_margin_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.softplus.default)
+def aten_softplus(self: TFloat, beta: float = 1.0, threshold: float = 20.0) -> TFloat:
+    """softplus(Tensor self, Scalar beta=1, Scalar threshold=20) -> Tensor"""
+
+    self_scaled = self * beta
+    softplus = op.Softplus(self_scaled) / beta
+    return op.Where(self_scaled > threshold, self, softplus)
+
+
+def aten_softplus_backward(
+    grad_output: TensorType, self: TensorType, beta: float, threshold: float
+) -> TensorType:
+    """softplus_backward(Tensor grad_output, Tensor self, Scalar beta, Scalar threshold) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_softshrink(self: TensorType, lambd: float = 0.5) -> TensorType:
+    """softshrink(Tensor self, Scalar lambd=0.5) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_softshrink_backward(
+    grad_output: TensorType, self: TensorType, lambd: float
+) -> TensorType:
+    """softshrink_backward(Tensor grad_output, Tensor self, Scalar lambd) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_tanh_backward(grad_output: TensorType, output: TensorType) -> TensorType:
+    """tanh_backward(Tensor grad_output, Tensor output) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_thnn_conv2d(
+    self: TensorType,
+    weight: TensorType,
+    kernel_size: Sequence[int],
+    bias: Optional[TensorType] = None,
+    stride: Sequence[int] = (1, 1),
+    padding: Sequence[int] = (0, 0),
+) -> TensorType:
+    """thnn_conv2d(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_unflatten_dense_tensors(
+    flat: TensorType, tensors: Sequence[TensorType]
+) -> TensorType:
+    """unflatten_dense_tensors(Tensor flat, Tensor[] tensors) -> Tensor[]"""
+
+    raise NotImplementedError
+
+
+def _get_upsample_align_corners_mode(align_corners: bool) -> str:
+    return "align_corners" if align_corners else "pytorch_half_pixel"
+
+
+def _aten_upsample_output_size(
+    self: TReal,
+    output_size: INT64,
+    mode: str,
+    coordinate_transformation_mode: str,
+) -> TReal:
+    batch_and_channel = op.Shape(self, end=2, start=0)
+    # When output_size is passed in as a list of integers, the torch.onnx
+    # graph builder when handling op.Concat may fail
+    # to determine the output type. We cast it to INT64 to ensure the output
+    output_size = op.Cast(output_size, to=INT64.dtype)
+    # Append the batch and channel dimensions to the requested output size
+    output_size = op.Concat(batch_and_channel, output_size, axis=0)
+    return op.Resize(
+        self,
+        None,
+        None,
+        output_size,
+        mode=mode,
+        coordinate_transformation_mode=coordinate_transformation_mode,
+        nearest_mode="floor",
+    )
+
+
+def _aten_upsample_scales(
+    self: TReal,
+    scale_factors: Sequence[float],
+    mode: str,
+    coordinate_transformation_mode: str,
+) -> TReal:
+    return op.Resize(
+        self,
+        None,
+        op.Constant(
+            value_floats=[1.0, 1.0, *scale_factors]
+        ),  # format should be: [1.0, 1.0, scale_h, scale_w]
+        None,
+        mode=mode,
+        coordinate_transformation_mode=coordinate_transformation_mode,
+        nearest_mode="floor",
+    )
+
+
+@onnx_impl(aten.upsample_bicubic2d.default, trace_only=True)
+def aten_upsample_bicubic2d(
+    self: TReal,
+    output_size: INT64,
+    align_corners: bool,
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> TReal:
+    """upsample_bicubic2d(Tensor self, SymInt[2] output_size, bool align_corners, float? scales_h=None, float? scales_w=None) -> Tensor"""
+
+    # NOTE: Based on experimentation, scales_h and scales_w are always ignored in PyTorch,
+    # unless when align_corners is True, in which case we do not know what is going on.
+    coordinate_transformation_mode = _get_upsample_align_corners_mode(align_corners)
+    return _aten_upsample_output_size(
+        self,
+        output_size,
+        mode="cubic",
+        coordinate_transformation_mode=coordinate_transformation_mode,
+    )
+
+
+@onnx_impl(aten.upsample_bicubic2d.vec, trace_only=True)
+def aten_upsample_bicubic2d_vec(
+    self: TReal,
+    output_size: INT64,
+    align_corners: bool,
+    scale_factors: Optional[Sequence[float]],
+) -> TReal:
+    """upsample_bicubic2d.vec(Tensor input, SymInt[]? output_size, bool align_corners, float[]? scale_factors) -> Tensor"""
+
+    coordinate_transformation_mode = _get_upsample_align_corners_mode(align_corners)
+    if scale_factors is not None:
+        result = _aten_upsample_scales(
+            self,
+            scale_factors,
+            mode="cubic",
+            coordinate_transformation_mode=coordinate_transformation_mode,
+        )
+    else:
+        result = _aten_upsample_output_size(
+            self,
+            output_size,
+            mode="cubic",
+            coordinate_transformation_mode=coordinate_transformation_mode,
+        )
+
+    return result
+
+
+def aten_upsample_bicubic2d_backward(
+    grad_output: TensorType,
+    output_size: INT64,
+    input_size: INT64,
+    align_corners: bool,
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> TensorType:
+    """upsample_bicubic2d_backward(Tensor grad_output, SymInt[2] output_size, SymInt[4] input_size, bool align_corners, float? scales_h=None, float? scales_w=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.upsample_bilinear2d.default, trace_only=True)
+def aten_upsample_bilinear2d(
+    self: TReal,
+    output_size: INT64,
+    align_corners: bool,
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> TReal:
+    """upsample_bilinear2d(Tensor self, SymInt[2] output_size, bool align_corners, float? scales_h=None, float? scales_w=None) -> Tensor"""
+
+    # NOTE: Based on experimentation, scales_h and scales_w are always ignored in PyTorch,
+    # unless when align_corners is True, in which case we do not know what is going on.
+    coordinate_transformation_mode = _get_upsample_align_corners_mode(align_corners)
+    return _aten_upsample_output_size(
+        self,
+        output_size,
+        coordinate_transformation_mode=coordinate_transformation_mode,
+        mode="linear",
+    )
+
+
+@onnx_impl(aten.upsample_bilinear2d.vec, trace_only=True)
+def aten_upsample_bilinear2d_vec(
+    self: TReal,
+    output_size: Optional[INT64],
+    align_corners: bool,
+    scale_factors: Optional[Sequence[float]],
+) -> TReal:
+    """upsample_bilinear2d.vec(Tensor input, SymInt[]? output_size, bool align_corners, float[]? scale_factors) -> Tensor"""
+
+    coordinate_transformation_mode = _get_upsample_align_corners_mode(align_corners)
+    if scale_factors is not None:
+        result = _aten_upsample_scales(
+            self,
+            scale_factors,
+            mode="linear",
+            coordinate_transformation_mode=coordinate_transformation_mode,
+        )
+    else:
+        assert output_size is not None
+        result = _aten_upsample_output_size(
+            self,
+            output_size,
+            mode="linear",
+            coordinate_transformation_mode=coordinate_transformation_mode,
+        )
+
+    return result
+
+
+def aten_upsample_bilinear2d_backward(
+    grad_output: TensorType,
+    output_size: INT64,
+    input_size: INT64,
+    align_corners: bool,
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> TensorType:
+    """upsample_bilinear2d_backward(Tensor grad_output, SymInt[2] output_size, SymInt[4] input_size, bool align_corners, float? scales_h=None, float? scales_w=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.upsample_linear1d.default, trace_only=True)
+def aten_upsample_linear1d(
+    self: TReal, output_size: INT64, align_corners: bool, scales: Optional[float] = None
+) -> TReal:
+    """upsample_linear1d(Tensor self, SymInt[1] output_size, bool align_corners, float? scales=None) -> Tensor"""
+    coordinate_transformation_mode = _get_upsample_align_corners_mode(align_corners)
+    # scales is ignored in PyTorch
+    return _aten_upsample_output_size(
+        self,
+        output_size,
+        mode="linear",
+        coordinate_transformation_mode=coordinate_transformation_mode,
+    )
+
+
+def aten_upsample_linear1d_backward(
+    grad_output: TensorType,
+    output_size: INT64,
+    input_size: INT64,
+    align_corners: bool,
+    scales: Optional[float] = None,
+) -> TensorType:
+    """upsample_linear1d_backward(Tensor grad_output, SymInt[1] output_size, SymInt[3] input_size, bool align_corners, float? scales=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.upsample_nearest1d.default, trace_only=True)
+def aten_upsample_nearest1d(
+    self: TReal, output_size: INT64, scales: Optional[float] = None
+) -> TReal:
+    """upsample_nearest1d(Tensor self, SymInt[1] output_size, float? scales=None) -> Tensor"""
+    if scales is not None:
+        return _aten_upsample_scales(self, [scales], "nearest", "asymmetric")
+    else:
+        return _aten_upsample_output_size(self, output_size, "nearest", "asymmetric")
+
+
+@onnx_impl(
+    (
+        aten.upsample_nearest1d.vec,
+        aten.upsample_nearest2d.vec,
+        aten.upsample_nearest3d.vec,
+    ),
+    trace_only=True,
+)
+def aten_upsample_nearestnd_vec(
+    input: TReal,
+    output_size: Optional[INT64] = None,
+    scale_factors: Optional[Sequence[float]] = None,
+) -> TReal:
+    """upsample_nearest3d.vec(Tensor input, SymInt[]? output_size, float[]? scale_factors) -> Tensor"""
+
+    if scale_factors is not None:
+        return _aten_upsample_scales(input, scale_factors, "nearest", "asymmetric")
+    else:
+        assert output_size is not None
+        return _aten_upsample_output_size(input, output_size, "nearest", "asymmetric")
+
+
+def aten_upsample_nearest1d_backward(
+    grad_output: TensorType,
+    output_size: INT64,
+    input_size: INT64,
+    scales: Optional[float] = None,
+) -> TensorType:
+    """upsample_nearest1d_backward(Tensor grad_output, SymInt[1] output_size, SymInt[3] input_size, float? scales=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.upsample_nearest2d.default, trace_only=True)
+def aten_upsample_nearest2d(
+    self: TReal,
+    output_size: INT64,
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> TReal:
+    """upsample_nearest2d(Tensor self, SymInt[2] output_size, float? scales_h=None, float? scales_w=None) -> Tensor"""
+
+    if scales_h is not None and scales_w is not None:
+        return _aten_upsample_scales(
+            self,
+            [scales_h, scales_w],
+            "nearest",
+            "asymmetric",
+        )
+    else:
+        return _aten_upsample_output_size(self, output_size, "nearest", "asymmetric")
+
+
+def aten_upsample_nearest2d_backward(
+    grad_output: TensorType,
+    output_size: INT64,
+    input_size: INT64,
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> TensorType:
+    """upsample_nearest2d_backward(Tensor grad_output, SymInt[2] output_size, SymInt[4] input_size, float? scales_h=None, float? scales_w=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.upsample_nearest3d.default, trace_only=True)
+def aten_upsample_nearest3d(
+    self: TReal,
+    output_size: INT64,
+    scales_d: Optional[float] = None,
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> TReal:
+    """upsample_nearest3d(Tensor self, SymInt[3] output_size, float? scales_d=None, float? scales_h=None, float? scales_w=None) -> Tensor"""
+
+    if scales_d is not None and scales_h is not None and scales_w is not None:
+        return _aten_upsample_scales(
+            self,
+            [scales_d, scales_h, scales_w],
+            "nearest",
+            "asymmetric",
+        )
+    else:
+        return _aten_upsample_output_size(self, output_size, "nearest", "asymmetric")
+
+
+def aten_upsample_nearest3d_backward(
+    grad_output: TensorType,
+    output_size: INT64,
+    input_size: INT64,
+    scales_d: Optional[float] = None,
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> TensorType:
+    """upsample_nearest3d_backward(Tensor grad_output, SymInt[3] output_size, SymInt[5] input_size, float? scales_d=None, float? scales_h=None, float? scales_w=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(aten.upsample_trilinear3d.default, trace_only=True)
+def aten_upsample_trilinear3d(
+    self: TReal,
+    output_size: INT64,
+    align_corners: bool,
+    scales_d: Optional[float] = None,
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> TReal:
+    """upsample_trilinear3d(Tensor self, SymInt[3] output_size, bool align_corners, float? scales_d=None, float? scales_h=None, float? scales_w=None) -> Tensor"""
+
+    del scales_d
+    del scales_h
+    del scales_w
+
+    coordinate_transformation_mode = _get_upsample_align_corners_mode(align_corners)
+    return _aten_upsample_output_size(
+        self,
+        output_size,
+        mode="linear",
+        coordinate_transformation_mode=coordinate_transformation_mode,
+    )
+
+
+@onnx_impl(aten.upsample_trilinear3d.vec, trace_only=True)
+def aten_upsample_trilinear3d_vec(
+    self: TReal,
+    output_size: INT64,
+    align_corners: bool,
+    scale_factors: Optional[Sequence[float]],
+) -> TReal:
+    """upsample_trilinear3d.vec(Tensor input, SymInt[]? output_size, bool align_corners, float[]? scale_factors) -> Tensor"""
+
+    coordinate_transformation_mode = _get_upsample_align_corners_mode(align_corners)
+    if scale_factors is not None:
+        result = _aten_upsample_scales(
+            self,
+            scale_factors,
+            mode="linear",
+            coordinate_transformation_mode=coordinate_transformation_mode,
+        )
+    else:
+        result = _aten_upsample_output_size(
+            self,
+            output_size,
+            mode="linear",
+            coordinate_transformation_mode=coordinate_transformation_mode,
+        )
+    return result
+
+
+def aten_upsample_trilinear3d_backward(
+    grad_output: TensorType,
+    output_size: INT64,
+    input_size: INT64,
+    align_corners: bool,
+    scales_d: Optional[float] = None,
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> TensorType:
+    """upsample_trilinear3d_backward(Tensor grad_output, SymInt[3] output_size, SymInt[5] input_size, bool align_corners, float? scales_d=None, float? scales_h=None, float? scales_w=None) -> Tensor"""
+
+    raise NotImplementedError

--- a/torch/onnx/_internal/exporter/_torchlib/ops/prims.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/prims.py
@@ -1,0 +1,867 @@
+"""torch.ops.aten operators under the `prims` module."""
+
+# mypy: disable-error-code="misc,arg-type,type-arg,valid-type,assignment,return-value,type-var,operator,no-untyped-def,index"
+# ruff: noqa: TCH001,TCH002
+# flake8: noqa
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from onnxscript import INT64
+from onnxscript.onnx_opset import opset18 as op
+from onnxscript.onnx_types import BOOL, TensorType
+
+import torch
+from torch.onnx._internal.exporter._torchlib._tensor_typing import RealType, TTensor
+from torch.onnx._internal.exporter._torchlib._torchlib_registry import onnx_impl
+from torch.onnx._internal.exporter._torchlib.ops import common as common_ops
+
+
+prims = torch.ops.prims
+
+
+@onnx_impl(prims.abs.default, trace_only=True)
+def prims_abs(self: TTensor) -> TTensor:
+    """abs(Tensor self) -> Tensor"""
+
+    return op.Abs(self)
+
+
+@onnx_impl(prims.acos.default, trace_only=True)
+def prims_acos(self: TensorType) -> TensorType:
+    """acos(Tensor self) -> Tensor"""
+
+    return op.Acos(self)
+
+
+@onnx_impl(prims.acosh.default, trace_only=True)
+def prims_acosh(self: TensorType) -> TensorType:
+    """acosh(Tensor self) -> Tensor"""
+
+    return op.Acosh(self)
+
+
+@onnx_impl(prims.add.default, trace_only=True)
+def prims_add(self: TTensor, other: TTensor) -> TTensor:
+    """add(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Add(self, other)
+
+
+def prims_amax(
+    inp: TensorType, dims: Optional[Sequence[int]], output_dtype: Optional[int] = None
+) -> TensorType:
+    """amax(Tensor inp, int[]? dims, *, ScalarType? output_dtype=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_amin(
+    inp: TensorType, dims: Optional[Sequence[int]], output_dtype: Optional[int] = None
+) -> TensorType:
+    """amin(Tensor inp, int[]? dims, *, ScalarType? output_dtype=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_as_strided(
+    a: TensorType, size: INT64, stride: INT64, storage_offset: INT64
+) -> TensorType:
+    """as_strided(Tensor a, SymInt[] size, SymInt[] stride, SymInt storage_offset) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_as_strided_scatter(
+    self: TensorType, src: TensorType, size: INT64, stride: INT64, storage_offset: INT64
+) -> TensorType:
+    """as_strided_scatter(Tensor self, Tensor src, SymInt[] size, SymInt[] stride, SymInt storage_offset) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.asin.default, trace_only=True)
+def prims_asin(self: TTensor) -> TTensor:
+    """asin(Tensor self) -> Tensor"""
+
+    return op.Asin(self)
+
+
+@onnx_impl(prims.asinh.default, trace_only=True)
+def prims_asinh(self: TTensor) -> TTensor:
+    """asinh(Tensor self) -> Tensor"""
+
+    return op.Asinh(self)
+
+
+@onnx_impl(prims.atan.default, trace_only=True)
+def prims_atan(self: TTensor) -> TTensor:
+    """atan(Tensor self) -> Tensor"""
+
+    return op.Atan(self)
+
+
+def prims_atan2(self: TensorType, other: TensorType) -> TensorType:
+    """atan2(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.atanh.default, trace_only=True)
+def prims_atanh(self: TTensor) -> TTensor:
+    """atanh(Tensor self) -> Tensor"""
+
+    return op.Atanh(self)
+
+
+def prims_bessel_i0(self: TensorType) -> TensorType:
+    """bessel_i0(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_bessel_i0e(self: TensorType) -> TensorType:
+    """bessel_i0e(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_bessel_i1(self: TensorType) -> TensorType:
+    """bessel_i1(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_bessel_i1e(self: TensorType) -> TensorType:
+    """bessel_i1e(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_bessel_j0(self: TensorType) -> TensorType:
+    """bessel_j0(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_bessel_j1(self: TensorType) -> TensorType:
+    """bessel_j1(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_bitwise_and(self: TensorType, other: TensorType) -> TensorType:
+    """bitwise_and(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_bitwise_not(self: TensorType) -> TensorType:
+    """bitwise_not(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_bitwise_or(self: TensorType, other: TensorType) -> TensorType:
+    """bitwise_or(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_bitwise_xor(self: TensorType, other: TensorType) -> TensorType:
+    """bitwise_xor(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_broadcast_in_dim(
+    a: TensorType, shape: INT64, broadcast_dimensions: Sequence[int]
+) -> TensorType:
+    """broadcast_in_dim(Tensor(a) a, SymInt[] shape, int[] broadcast_dimensions) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def prims_cat(tensors: Sequence[TensorType], dim: int) -> TensorType:
+    """cat(Tensor[] tensors, int dim) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_cbrt(self: TensorType) -> TensorType:
+    """cbrt(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.ceil.default, trace_only=True)
+def prims_ceil(self: TTensor) -> TTensor:
+    """ceil(Tensor self) -> Tensor"""
+
+    return op.Ceil(self)
+
+
+def prims_clone(self: TensorType, memory_format: Optional[str] = None) -> TensorType:
+    """clone(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_collapse_view(a: TensorType, start: int, end: int) -> TensorType:
+    """collapse_view(Tensor(a) a, int start, int end) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def prims_conj(a: TensorType) -> TensorType:
+    """conj(Tensor(a) a) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def prims_conj_physical(self: TensorType) -> TensorType:
+    """conj_physical(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.convert_element_type.default, trace_only=True)
+def prims_convert_element_type(a: RealType, dtype: int) -> RealType:
+    """convert_element_type(Tensor a, ScalarType dtype) -> Tensor"""
+
+    # Set trace_only=True because different if branches return different dtypes
+    # which is not supported in an ONNX function
+    return common_ops.cast_to(a, dtype)
+
+
+def prims_copy_strided(a: TensorType, stride: INT64) -> TensorType:
+    """copy_strided(Tensor a, SymInt[] stride) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_copy_to(a: TensorType, b: TensorType) -> TensorType:
+    """copy_to(Tensor a, Tensor b) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.cos.default, trace_only=True)
+def prims_cos(self: TTensor) -> TTensor:
+    """cos(Tensor self) -> Tensor"""
+
+    return op.Cos(self)
+
+
+@onnx_impl(prims.cosh.default, trace_only=True)
+def prims_cosh(self: TTensor) -> TTensor:
+    """cosh(Tensor self) -> Tensor"""
+
+    return op.Cosh(self)
+
+
+@onnx_impl(prims.device_put.default)
+def prims_device_put(
+    a: TTensor,
+    device: str = "unspecified",  # pylint: disable=unused-argument
+) -> TTensor:
+    """device_put(Tensor a, Device device) -> Tensor"""
+
+    # ONNX does not have the notion of a "device". So we just return the input
+    return op.Identity(a)
+
+
+def prims_digamma(self: TensorType) -> TensorType:
+    """digamma(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.div.default, trace_only=True)
+def prims_div(self: TTensor, other: TTensor) -> TTensor:
+    """div(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Div(self, other)
+
+
+def prims_empty(
+    shape: INT64, dtype: int, device: str, requires_grad: bool
+) -> TensorType:
+    """empty(SymInt[] shape, *, ScalarType dtype, Device device, bool requires_grad) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_empty_strided(
+    shape: INT64, strides: INT64, dtype: int, device: str, requires_grad: bool
+) -> TensorType:
+    """empty_strided(SymInt[] shape, SymInt[] strides, *, ScalarType dtype, Device device, bool requires_grad) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.eq.default, trace_only=True)
+def prims_eq(self: TTensor, other: TTensor) -> TTensor:
+    """eq(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Equal(self, other)
+
+
+@onnx_impl(prims.erf.default, trace_only=True)
+def prims_erf(self: TTensor) -> TTensor:
+    """erf(Tensor self) -> Tensor"""
+
+    return op.Erf(self)
+
+
+def prims_erf_inv(self: TensorType) -> TensorType:
+    """erf_inv(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_erfc(self: TensorType) -> TensorType:
+    """erfc(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_erfcx(self: TensorType) -> TensorType:
+    """erfcx(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.exp.default, trace_only=True)
+def prims_exp(self: TTensor) -> TTensor:
+    """exp(Tensor self) -> Tensor"""
+
+    return op.Exp(self)
+
+
+def prims_exp2(self: TensorType) -> TensorType:
+    """exp2(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_expm1(self: TensorType) -> TensorType:
+    """expm1(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_fft_c2c(self: TensorType, dim: Sequence[int], forward: bool) -> TensorType:
+    """fft_c2c(Tensor self, *, int[] dim, bool forward) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_fft_c2r(
+    self: TensorType, dim: Sequence[int], last_dim_size: INT64
+) -> TensorType:
+    """fft_c2r(Tensor self, *, int[] dim, SymInt last_dim_size) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_fft_r2c(self: TensorType, dim: Sequence[int], onesided: bool) -> TensorType:
+    """fft_r2c(Tensor self, *, int[] dim, bool onesided) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_fill(self: TensorType, value: float) -> TensorType:
+    """fill(Tensor self, Scalar value) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.floor.default, trace_only=True)
+def prims_floor(self: TTensor) -> TTensor:
+    """floor(Tensor self) -> Tensor"""
+
+    return op.Floor(self)
+
+
+def prims_fmax(self: TensorType, other: TensorType) -> TensorType:
+    """fmax(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_fmin(self: TensorType, other: TensorType) -> TensorType:
+    """fmin(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_fmod(self: TensorType, other: TensorType) -> TensorType:
+    """fmod(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_full(
+    shape: INT64, fill_value: float, dtype: int, device: str, requires_grad: bool
+) -> TensorType:
+    """full(SymInt[] shape, Scalar fill_value, *, ScalarType dtype, Device device, bool requires_grad) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_full_like(
+    a: TensorType, fill_value: float, dtype: int, device: str, requires_grad: bool
+) -> TensorType:
+    """full_like(Tensor a, Scalar fill_value, *, ScalarType dtype, Device device, bool requires_grad) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_gcd(self: TensorType, other: TensorType) -> TensorType:
+    """gcd(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.ge.default, trace_only=True)
+def prims_ge(self: TTensor, other: TTensor) -> TTensor:
+    """ge(Tensor self, Tensor other) -> Tensor"""
+
+    return op.GreaterOrEqual(self, other)
+
+
+@onnx_impl(prims.gt.default, trace_only=True)
+def prims_gt(self: TTensor, other: TTensor) -> TTensor:
+    """gt(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Greater(self, other)
+
+
+def prims_hypot(self: TensorType, other: TensorType) -> TensorType:
+    """hypot(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_igamma(self: TensorType, other: TensorType) -> TensorType:
+    """igamma(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_igammac(self: TensorType, other: TensorType) -> TensorType:
+    """igammac(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_imag(self: TensorType) -> TensorType:
+    """imag(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_iota(
+    length: INT64,
+    start: INT64,
+    step: INT64,
+    dtype: int,
+    device: str,
+    requires_grad: bool,
+) -> TensorType:
+    """iota(SymInt length, *, SymInt start, SymInt step, ScalarType dtype, Device device, bool requires_grad) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_isfinite(self: TensorType) -> TensorType:
+    """isfinite(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_item(a: TensorType) -> float:
+    """item(Tensor a) -> Scalar"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.le.default, trace_only=True)
+def prims_le(self: TensorType, other: TensorType) -> TensorType:
+    """le(Tensor self, Tensor other) -> Tensor"""
+
+    return op.LessOrEqual(self, other)
+
+
+def prims_lgamma(self: TensorType) -> TensorType:
+    """lgamma(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.log.default, trace_only=True)
+def prims_log(self: TensorType) -> TensorType:
+    """log(Tensor self) -> Tensor"""
+
+    return op.Log(self)
+
+
+def prims_log10(self: TensorType) -> TensorType:
+    """log10(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_log1p(self: TensorType) -> TensorType:
+    """log1p(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_log2(self: TensorType) -> TensorType:
+    """log2(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.lt.default, trace_only=True)
+def prims_lt(self: TensorType, other: TensorType) -> TensorType:
+    """lt(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Less(self, other)
+
+
+def prims_maximum(self: TensorType, other: TensorType) -> TensorType:
+    """maximum(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_maximum_value(dtype: int) -> float:
+    """maximum_value(ScalarType dtype) -> Scalar"""
+
+    raise NotImplementedError
+
+
+def prims_minimum(self: TensorType, other: TensorType) -> TensorType:
+    """minimum(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_minium_value(dtype: int) -> float:
+    """minium_value(ScalarType dtype) -> Scalar"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.mul.default, trace_only=True)
+def prims_mul(self: TTensor, other: TTensor) -> TTensor:
+    """mul(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Mul(self, other)
+
+
+def prims_ndtri(self: TensorType) -> TensorType:
+    """ndtri(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.ne.default, trace_only=True)
+def prims_ne(self: TTensor, other: TTensor) -> TTensor:
+    """ne(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Not(op.Equal(self, other))
+
+
+@onnx_impl(prims.neg.default, trace_only=True)
+def prims_neg(self: TTensor) -> TTensor:
+    """neg(Tensor self) -> Tensor"""
+
+    return op.Neg(self)
+
+
+def prims_nextafter(self: TensorType, other: TensorType) -> TensorType:
+    """nextafter(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_normal(
+    shape: INT64, mean: float, std: float, dtype: int, device: str, requires_grad: bool
+) -> TensorType:
+    """normal(SymInt[] shape, *, Scalar mean, Scalar std, ScalarType dtype, Device device, bool requires_grad) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.pow.default, trace_only=True)
+def prims_pow(self: TTensor, other: TTensor) -> TTensor:
+    """pow(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Pow(self, other)
+
+
+def prims_prod(
+    inp: TensorType, dims: Optional[Sequence[int]], output_dtype: Optional[int] = None
+) -> TensorType:
+    """prod(Tensor inp, int[]? dims, *, ScalarType? output_dtype=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_real(self: TensorType) -> TensorType:
+    """real(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_reciprocal(self: TensorType) -> TensorType:
+    """reciprocal(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_remainder(self: TensorType, other: TensorType) -> TensorType:
+    """remainder(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.reshape.default, trace_only=True)
+def prims_reshape(a: TTensor, shape: INT64) -> TTensor:
+    """reshape(Tensor a, SymInt[] shape) -> Tensor"""
+
+    return op.Reshape(a, shape)
+
+
+@onnx_impl(prims.resize.default, trace_only=True)
+def prims_resize(a: TensorType, shape: INT64) -> TensorType:
+    """resize(Tensor a, SymInt[] shape) -> Tensor"""
+
+    return op.Expand(a, shape)
+
+
+def prims_rev(a: TensorType, dims: Sequence[int]) -> TensorType:
+    """rev(Tensor a, int[] dims) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.round.default, trace_only=True)
+def prims_round(self: TensorType) -> TensorType:
+    """round(Tensor self) -> Tensor"""
+
+    return op.Round(self)
+
+
+def prims_rsqrt(self: TensorType) -> TensorType:
+    """rsqrt(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_scalar_tensor(
+    s: float, dtype: Optional[int] = None, device: Optional[str] = None
+) -> TensorType:
+    """scalar_tensor(Scalar s, *, ScalarType? dtype=None, Device? device=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_shift_left(self: TensorType, other: TensorType) -> TensorType:
+    """shift_left(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_shift_right_arithmetic(self: TensorType, other: TensorType) -> TensorType:
+    """shift_right_arithmetic(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_sign(self: TensorType) -> TensorType:
+    """sign(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_signbit(self: TensorType) -> TensorType:
+    """signbit(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.sin.default, trace_only=True)
+def prims_sin(self: TTensor) -> TTensor:
+    """sin(Tensor self) -> Tensor"""
+
+    return op.Sin(self)
+
+
+@onnx_impl(prims.sinh.default, trace_only=True)
+def prims_sinh(self: TTensor) -> TTensor:
+    """sinh(Tensor self) -> Tensor"""
+
+    return op.Sinh(self)
+
+
+def prims_slice(
+    a: TensorType,
+    start_indices: INT64,
+    limit_indices: INT64,
+    strides: Optional[INT64] = None,
+) -> TensorType:
+    """slice(Tensor(a) a, SymInt[] start_indices, SymInt[] limit_indices, SymInt[]? strides=None) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def prims_slice_in_dim(
+    a: TensorType,
+    start_index: INT64,
+    limit_index: INT64,
+    stride: int = 1,
+    axis: int = 0,
+) -> TensorType:
+    """slice_in_dim(Tensor(a) a, SymInt start_index, SymInt limit_index, int stride=1, int axis=0) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+def prims_spherical_bessel_j0(self: TensorType) -> TensorType:
+    """spherical_bessel_j0(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_split_dim(a: TensorType, dim: int, outer_length: INT64) -> TensorType:
+    """split_dim(Tensor(a) a, int dim, SymInt outer_length) -> Tensor(a)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.sqrt.default, trace_only=True)
+def prims_sqrt(self: TTensor) -> TTensor:
+    """sqrt(Tensor self) -> Tensor"""
+
+    return op.Sqrt(self)
+
+
+@onnx_impl(prims.squeeze.default, trace_only=True)
+def prims_squeeze(a: TTensor, dimensions: Sequence[int]) -> TTensor:
+    """squeeze(Tensor(a) a, int[] dimensions) -> Tensor(a)"""
+
+    return op.Squeeze(a, axes=dimensions)
+
+
+@onnx_impl(prims.sub.default, trace_only=True)
+def prims_sub(self: TTensor, other: TTensor) -> TTensor:
+    """sub(Tensor self, Tensor other) -> Tensor"""
+
+    return op.Sub(self, other)
+
+
+def prims_sum(
+    inp: TensorType, dims: Optional[Sequence[int]], output_dtype: Optional[int] = None
+) -> TensorType:
+    """sum(Tensor inp, int[]? dims, *, ScalarType? output_dtype=None) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_svd(
+    A: TensorType, full_matrices: bool
+) -> tuple[TensorType, TensorType, TensorType]:
+    """svd(Tensor A, *, bool full_matrices) -> (Tensor U, Tensor S, Tensor Vh)"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.tan.default, trace_only=True)
+def prims_tan(self: TTensor) -> TTensor:
+    """tan(Tensor self) -> Tensor"""
+
+    return op.Tan(self)
+
+
+@onnx_impl(prims.tanh.default, trace_only=True)
+def prims_tanh(self: TTensor) -> TTensor:
+    """tanh(Tensor self) -> Tensor"""
+
+    return op.Tanh(self)
+
+
+@onnx_impl(prims.transpose.default, trace_only=True)
+def prims_transpose(a: TensorType, permutation: Sequence[int]) -> TensorType:
+    """transpose(Tensor(a) a, int[] permutation) -> Tensor(a)"""
+
+    return op.Transpose(a, perm=permutation)
+
+
+def prims_trunc(self: TensorType) -> TensorType:
+    """trunc(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def prims_uniform(
+    shape: INT64, low: float, high: float, dtype: int, device: str
+) -> TensorType:
+    """uniform(SymInt[] shape, *, Scalar low, Scalar high, ScalarType dtype, Device device) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.var.default, trace_only=True)
+def prims_var(
+    inp: TensorType,
+    dims: Optional[Sequence[int]],
+    correction: int,
+    output_dtype: Optional[int] = None,
+) -> TensorType:
+    """var(Tensor inp, int[]? dims, *, int correction, ScalarType? output_dtype=None) -> Tensor"""
+
+    if not dims:
+        # dims can be empty in practice. We just use a None so it is not added in the ONNX graph
+        dims = None
+    sub_mean = op.Sub(inp, op.ReduceMean(inp, dims, keepdims=True))
+    sqr_mean = op.Mul(sub_mean, sub_mean)
+    var = op.ReduceMean(sqr_mean, dims, keepdims=False)
+    # Adjust var according to correction value
+    if correction != 0:
+        inp_shape = op.Shape(inp)
+        dim_size = op.Gather(inp_shape, dims, axis=0)
+        numel_float = op.CastLike(op.ReduceProd(dim_size, keepdims=False), inp)
+        mul = op.Mul(var, numel_float)
+        # Subtract the correction value
+        sub = op.Sub(numel_float, op.CastLike(correction, inp))
+        var = op.Div(mul, sub)
+
+    if output_dtype is not None and output_dtype != -1:
+        var = op.Cast(var, to=output_dtype)
+
+    return var
+
+
+def prims_view_of(a: TensorType) -> TensorType:
+    """view_of(Tensor(a) a) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl(prims.where.default, trace_only=True)
+def prims_where(pred: BOOL, a: TTensor, b: TTensor) -> TTensor:
+    """where(Tensor pred, Tensor a, Tensor b) -> Tensor"""
+
+    return op.Where(pred, a, b)
+
+
+def prims_zeta(self: TensorType, other: TensorType) -> TensorType:
+    """zeta(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError

--- a/torch/onnx/_internal/exporter/_torchlib/ops/special.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/special.py
@@ -1,0 +1,393 @@
+"""torch.ops.aten operators under the `special` module."""
+
+# mypy: disable-error-code="misc,arg-type,type-arg,valid-type,assignment,return-value,type-var,operator,no-untyped-def,index"
+# ruff: noqa: TCH001,TCH002
+# flake8: noqa
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Sequence
+
+from onnxscript.onnx_opset import opset18 as op
+from onnxscript.onnx_types import TensorType
+
+import torch
+from torch.onnx._internal.exporter._torchlib._tensor_typing import TFloat
+from torch.onnx._internal.exporter._torchlib._torchlib_registry import onnx_impl
+from torch.onnx._internal.exporter._torchlib.ops import common as common_ops
+
+
+_MATH_PI = math.pi
+
+aten = torch.ops.aten
+
+
+def aten_special_airy_ai(x: TensorType) -> TensorType:
+    """special_airy_ai(Tensor x) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_bessel_j0(self: TensorType) -> TensorType:
+    """special_bessel_j0(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_bessel_j1(self: TensorType) -> TensorType:
+    """special_bessel_j1(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_bessel_y0(self: TensorType) -> TensorType:
+    """special_bessel_y0(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_bessel_y1(self: TensorType) -> TensorType:
+    """special_bessel_y1(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_chebyshev_polynomial_t(x: TensorType, n: TensorType) -> TensorType:
+    """special_chebyshev_polynomial_t(Tensor x, Tensor n) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_chebyshev_polynomial_u(x: TensorType, n: TensorType) -> TensorType:
+    """special_chebyshev_polynomial_u(Tensor x, Tensor n) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_chebyshev_polynomial_v(x: TensorType, n: TensorType) -> TensorType:
+    """special_chebyshev_polynomial_v(Tensor x, Tensor n) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_chebyshev_polynomial_w(x: TensorType, n: TensorType) -> TensorType:
+    """special_chebyshev_polynomial_w(Tensor x, Tensor n) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_digamma(self: TensorType) -> TensorType:
+    """special_digamma(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_entr(self: TensorType) -> TensorType:
+    """special_entr(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl((aten.erf.default, aten.special_erf.default))
+def aten_special_erf(self: TFloat) -> TFloat:
+    """erf(Tensor self) -> Tensor"""
+
+    return op.Erf(self)
+
+
+@onnx_impl((aten.erfc.default, aten.special_erfc.default))
+def aten_special_erfc(self: TFloat) -> TFloat:
+    """erfc(Tensor self) -> Tensor"""
+
+    return op.Sub(1, op.Erf(self))
+
+
+@onnx_impl(aten.special_erfcx.default)
+def aten_special_erfcx(self: TFloat) -> TFloat:
+    """special_erfcx(Tensor self) -> Tensor"""
+
+    return op.Mul(op.Exp(op.Pow(self, 2)), op.Sub(1, op.Erf(self)))
+
+
+def aten_special_erfinv(self: TensorType) -> TensorType:
+    """special_erfinv(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_exp2(self: TensorType) -> TensorType:
+    """special_exp2(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_expit(self: TensorType) -> TensorType:
+    """special_expit(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl((aten.expm1.default, aten.special_expm1.default))
+def aten_special_expm1(self: TFloat) -> TFloat:
+    """special_expm1(Tensor self) -> Tensor"""
+
+    return op.Sub(op.Exp(self), 1)
+
+
+def aten_special_gammainc(self: TensorType, other: TensorType) -> TensorType:
+    """special_gammainc(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_gammaincc(self: TensorType, other: TensorType) -> TensorType:
+    """special_gammaincc(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_gammaln(self: TensorType) -> TensorType:
+    """special_gammaln(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_hermite_polynomial_h(x: TensorType, n: TensorType) -> TensorType:
+    """special_hermite_polynomial_h(Tensor x, Tensor n) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_hermite_polynomial_he(x: TensorType, n: TensorType) -> TensorType:
+    """special_hermite_polynomial_he(Tensor x, Tensor n) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_i0(self: TensorType) -> TensorType:
+    """special_i0(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_i0e(self: TensorType) -> TensorType:
+    """special_i0e(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_i1(self: TensorType) -> TensorType:
+    """special_i1(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_i1e(self: TensorType) -> TensorType:
+    """special_i1e(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_laguerre_polynomial_l(x: TensorType, n: TensorType) -> TensorType:
+    """special_laguerre_polynomial_l(Tensor x, Tensor n) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_legendre_polynomial_p(x: TensorType, n: TensorType) -> TensorType:
+    """special_legendre_polynomial_p(Tensor x, Tensor n) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_log1p(self: TensorType) -> TensorType:
+    """special_log1p(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_log_ndtr(self: TensorType) -> TensorType:
+    """special_log_ndtr(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl((aten.log_softmax.int, aten.special_log_softmax.default), trace_only=True)
+def aten_special_log_softmax(self: TFloat, dim: int, dtype: int = -1) -> TFloat:
+    """special_log_softmax(Tensor self, int dim, *, ScalarType? dtype=None) -> Tensor"""
+
+    self_is_scalar = len(self.shape) == 0
+    if self_is_scalar:
+        self = op.Unsqueeze(self, op.Constant(value_ints=[0]))
+    result = op.LogSoftmax(self, axis=dim)
+    if dtype != -1:
+        result = op.Cast(result, to=dtype)
+    if self_is_scalar:  # squeeze to scalar due to input is scalar
+        result = op.Squeeze(result)
+    return result
+
+
+def aten_special_logit(self: TensorType, eps: Optional[float] = None) -> TensorType:
+    """special_logit(Tensor self, float? eps=None) -> Tensor"""
+    # TODO: alias of core.aten_logit
+    raise NotImplementedError
+
+
+def aten_special_logsumexp(
+    self: TensorType, dim: Sequence[int], keepdim: bool = False
+) -> TensorType:
+    """special_logsumexp(Tensor self, int[1] dim, bool keepdim=False) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_modified_bessel_i0(self: TensorType) -> TensorType:
+    """special_modified_bessel_i0(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_modified_bessel_i1(self: TensorType) -> TensorType:
+    """special_modified_bessel_i1(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_modified_bessel_k0(self: TensorType) -> TensorType:
+    """special_modified_bessel_k0(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_modified_bessel_k1(self: TensorType) -> TensorType:
+    """special_modified_bessel_k1(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_multigammaln(self: TensorType, p: int) -> TensorType:
+    """special_multigammaln(Tensor self, int p) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_ndtr(self: TensorType) -> TensorType:
+    """special_ndtr(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_ndtri(self: TensorType) -> TensorType:
+    """special_ndtri(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_polygamma(n: int, self: TensorType) -> TensorType:
+    """special_polygamma(int n, Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_psi(self: TensorType) -> TensorType:
+    """special_psi(Tensor self) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_round(self: TensorType, decimals: int = 0) -> TensorType:
+    """special_round(Tensor self, *, int decimals=0) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_scaled_modified_bessel_k0(x: TensorType) -> TensorType:
+    """special_scaled_modified_bessel_k0(Tensor x) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_scaled_modified_bessel_k1(x: TensorType) -> TensorType:
+    """special_scaled_modified_bessel_k1(Tensor x) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_shifted_chebyshev_polynomial_t(
+    x: TensorType, n: TensorType
+) -> TensorType:
+    """special_shifted_chebyshev_polynomial_t(Tensor x, Tensor n) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_shifted_chebyshev_polynomial_u(
+    x: TensorType, n: TensorType
+) -> TensorType:
+    """special_shifted_chebyshev_polynomial_u(Tensor x, Tensor n) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_shifted_chebyshev_polynomial_v(
+    x: TensorType, n: TensorType
+) -> TensorType:
+    """special_shifted_chebyshev_polynomial_v(Tensor x, Tensor n) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_shifted_chebyshev_polynomial_w(
+    x: TensorType, n: TensorType
+) -> TensorType:
+    """special_shifted_chebyshev_polynomial_w(Tensor x, Tensor n) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl((aten.special_sinc.default, aten.sinc.default))
+def aten_special_sinc(self: TFloat) -> TFloat:
+    """special_sinc(Tensor self) -> Tensor"""
+
+    # This computes the normalized sinc, where the input is multiplied by pi.
+    # https://pytorch.org/docs/stable/special.html#torch.special.sinc
+    pi_self = self * _MATH_PI
+
+    return op.Where(self == 0.0, op.CastLike(1, self), op.Sin(pi_self) / pi_self)
+
+
+def aten_special_spherical_bessel_j0(x: TensorType) -> TensorType:
+    """special_spherical_bessel_j0(Tensor x) -> Tensor"""
+
+    raise NotImplementedError
+
+
+def aten_special_xlog1py(self: TensorType, other: TensorType) -> TensorType:
+    """special_xlog1py(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError
+
+
+@onnx_impl((aten.xlogy.Tensor, aten.xlogy.Scalar_Self, aten.xlogy.Scalar_Other))
+def aten_special_xlogy(self: TFloat, other: TFloat) -> TFloat:
+    """special_xlogy(Tensor self, Tensor other) -> Tensor"""
+
+    # https://pytorch.org/docs/stable/special.html#torch.special.xlogy
+    # out := {
+    #     NaN if other == NaN
+    #     0 if self == 0
+    #     self * log(other) otherwise
+    # }
+
+    nans = op.IsNaN(other)
+    zeros = op.Equal(self, 0)
+    xlogy = op.Mul(self, op.Log(other))
+    xlogy_with_nans = op.Where(nans, other, xlogy)
+    return op.Where(zeros, self, xlogy_with_nans)
+
+
+def aten_special_zeta(self: TensorType, other: TensorType) -> TensorType:
+    """special_zeta(Tensor self, Tensor other) -> Tensor"""
+
+    raise NotImplementedError


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #147472
* __->__ #147469

This is the main PR that adds the onnx decomp functions from onnxscript to pytorch to decouple torch.onnx from implementations in onnxscript. Details of this migration, including how the logic is tested are described in https://github.com/pytorch/pytorch/issues/139301#issuecomment-2661017047.

## Guide for reviewers

The PR include three parts:

- Addition of the decomp logic. These are self contained onnxscript implementations under `_torchlib/ops`. They are individually tested by `test/onnx/torchlib/test_ops.py` using the added metadata in `test/onnx/torchlib/ops_test_data.py` and `test/onnx/torchlib/extra_opinfo.py`.
    - Match and replacement was done on the `onnxscript` torchlib code to replace `"aten::xxx"` keys to `aten.xxx` torch op overload objects for accurate registration in core.
- Removal of redundant bridging logic: `torch/onnx/_internal/exporter/_registration.py` and `torch/onnx/_internal/exporter/_ir_passes.py` has logic to handle the decomp when they were out of core. These logic were removed.
- Removal of a test: `test/onnx/exporter/test_small_models_e2e.py` has a single test for torchvision, which we do not migrate into core. So we remove it until we have a better plan to support torchvision. It is deemed acceptible because torchvision supoport was only a demo in the new exporter previously, and there are way to register torchvision functions using the `torch.onnx.export(..., dynamo=True, custom_translation_table=...)` api for users.

### Test runtime

Added tests finish within 40 seconds on a 10-core local machine.

### Previous work done

Necessary refactoring are done in #147396 and scafolding of tests and logic are added in #147392.

### Migration source

Synced with ONNX Script at https://github.com/microsoft/onnxscript/commit/6f9533e480b618a4c606e678b7754a1bd9cad183

### Issue fixed 
Fix https://github.com/pytorch/pytorch/issues/139301

Signed-off-by: Justin Chu <justinchuby@users.noreply.github.com>