### PR TITLE
Remove mention of magma-cuda in readme.md, refactor magma_conda install

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -87,7 +87,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # I.e. magma-cuda102 package corresponds to CUDA_VERSION=10.2 and CUDA_VERSION=10.2.89
   # Magma is installed from a tarball in the ossci-linux bucket into the conda env
   if [ -n "$CUDA_VERSION" ]; then
-    ${SCRIPT_FOLDER}/install_magma_conda.sh $(cut -f1-2 -d'.' <<< ${CUDA_VERSION}) ${ANACONDA_PYTHON_VERSION}
+    conda_run ${SCRIPT_FOLDER}/install_magma_conda.sh $(cut -f1-2 -d'.' <<< ${CUDA_VERSION})
   fi
 
   # Install some other packages, including those needed for Python test reporting

--- a/.ci/docker/common/install_magma_conda.sh
+++ b/.ci/docker/common/install_magma_conda.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Script that replaces the magma install from a conda package
+# Script that installs magma from tarball inside conda environment
+# it replaces anaconda magma-cuda package which is no longer published
+# please see: https://github.com/pytorch/pytorch/issues/138506
 
 set -eou pipefail
 

--- a/.ci/docker/common/install_magma_conda.sh
+++ b/.ci/docker/common/install_magma_conda.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Script that installs magma from tarball inside conda environment
-# it replaces anaconda magma-cuda package which is no longer published
-# please see: https://github.com/pytorch/pytorch/issues/138506
+# Script that installs magma from tarball inside conda environment.
+# It replaces anaconda magma-cuda package which is no longer published.
+# Execute it inside active conda environment.
+# See issue: https://github.com/pytorch/pytorch/issues/138506
 
 set -eou pipefail
 

--- a/.ci/docker/common/install_magma_conda.sh
+++ b/.ci/docker/common/install_magma_conda.sh
@@ -3,24 +3,22 @@
 
 set -eou pipefail
 
-function do_install() {
-    cuda_version_nodot=${1/./}
-    anaconda_python_version=$2
+cuda_version_nodot=${1/./}
+if [[ $# -ge 2 &&  -n "$2" ]]; then
+    anaconda_dir="/opt/conda/envs/py_$2"
+else
+    anaconda_dir="$CONDA_PREFIX"
+fi
 
-    MAGMA_VERSION="2.6.1"
-    magma_archive="magma-cuda${cuda_version_nodot}-${MAGMA_VERSION}-1.tar.bz2"
-
-    anaconda_dir="/opt/conda/envs/py_${anaconda_python_version}"
-    (
-        set -x
-        tmp_dir=$(mktemp -d)
-        pushd ${tmp_dir}
-        curl -OLs https://ossci-linux.s3.us-east-1.amazonaws.com/${magma_archive}
-        tar -xvf "${magma_archive}"
-        mv include/* "${anaconda_dir}/include/"
-        mv lib/* "${anaconda_dir}/lib"
-        popd
-    )
-}
-
-do_install $1 $2
+MAGMA_VERSION="2.6.1"
+magma_archive="magma-cuda${cuda_version_nodot}-${MAGMA_VERSION}-1.tar.bz2"
+(
+    set -x
+    tmp_dir=$(mktemp -d)
+    pushd ${tmp_dir}
+    curl -OLs https://ossci-linux.s3.us-east-1.amazonaws.com/${magma_archive}
+    tar -xvf "${magma_archive}"
+    mv include/* "${anaconda_dir}/include/"
+    mv lib/* "${anaconda_dir}/lib"
+    popd
+)

--- a/.ci/docker/common/install_magma_conda.sh
+++ b/.ci/docker/common/install_magma_conda.sh
@@ -7,7 +7,7 @@
 set -eou pipefail
 
 cuda_version_nodot=${1/./}
-anaconda_dir="$CONDA_PREFIX"
+anaconda_dir=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
 
 MAGMA_VERSION="2.6.1"
 magma_archive="magma-cuda${cuda_version_nodot}-${MAGMA_VERSION}-1.tar.bz2"

--- a/.ci/docker/common/install_magma_conda.sh
+++ b/.ci/docker/common/install_magma_conda.sh
@@ -4,11 +4,7 @@
 set -eou pipefail
 
 cuda_version_nodot=${1/./}
-if [[ $# -ge 2 &&  -n "$2" ]]; then
-    anaconda_dir="/opt/conda/envs/py_$2"
-else
-    anaconda_dir="$CONDA_PREFIX"
-fi
+anaconda_dir="$CONDA_PREFIX"
 
 MAGMA_VERSION="2.6.1"
 magma_archive="magma-cuda${cuda_version_nodot}-${MAGMA_VERSION}-1.tar.bz2"

--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ pip install -r requirements.txt
 ```bash
 pip install mkl-static mkl-include
 # CUDA only: Add LAPACK support for the GPU if needed
-conda install -c pytorch magma-cuda121  # or the magma-cuda* that matches your CUDA version from https://anaconda.org/pytorch/repo
+# magma installation: run with active conda environment. specify CUDA version to install
+.ci/docker/common/install_magma_conda.sh 12.4
 
 # (optional) If using torch.compile with inductor/triton, install the matching version of triton
 # Run from the pytorch directory after cloning


### PR DESCRIPTION
Related to: https://github.com/pytorch/pytorch/issues/138506 we migrated magma-cuda build from anaconda to aws
Last version of magma-cuda published was 12.6 https://anaconda.org/pytorch/magma-cuda126

Here is the PR that moved from anaconda to tarball: https://github.com/pytorch/pytorch/pull/140417 

cc @malfet @afrittoli @seemethere @albanD 
