### PR TITLE
capture the return value in the contract typing

### DIFF
--- a/torch/distributed/_composable/contract.py
+++ b/torch/distributed/_composable/contract.py
@@ -46,7 +46,7 @@ class _ContractFn(Protocol, Generic[_P, _T, _TState]):
 @overload
 def contract() -> (
     Callable[
-        [Callable[Concatenate[nn.Module, _P], Optional[nn.Module]]],
+        [Callable[Concatenate[nn.Module, _P], _T]],
         _ContractFn[Concatenate[nn.Module, _P], _T, _State],
     ]
 ):
@@ -57,7 +57,7 @@ def contract() -> (
 def contract(
     state_cls: type[_TState],
 ) -> Callable[
-    [Callable[Concatenate[nn.Module, _P], Optional[nn.Module]]],
+    [Callable[Concatenate[nn.Module, _P], _T]],
     _ContractFn[Concatenate[nn.Module, _P], _T, _TState],
 ]:
     ...


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #147489
* __->__ #147488

----

* the existing typing makes the return type `Optional[nn.Module]`
* this doesn't seem to be what the decorator actually does as it does
  not alter the original return type
* This PR aims to fix the typing

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o

Differential Revision: [D69888120](https://our.internmc.facebook.com/intern/diff/D69888120)