### PR TITLE
type `fully_shard` so that the return value can be chained with typing enabled

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_init.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_init.py
@@ -1089,8 +1089,7 @@ class TestHSDPWithCustomHook(FSDPTestMultiThread):
         torch.nn.init.constant_(model.in_proj.weight, 1.0 * rank_group)
         torch.nn.init.constant_(model.out_proj.weight, 2.0 * rank_group)
 
-        fully_shard(model, mesh=mesh)
-        model = cast(FSDPModule, model)
+        model = fully_shard(model, mesh=mesh)
 
         hook_called: bool = False
 

--- a/torch/distributed/_composable/contract.py
+++ b/torch/distributed/_composable/contract.py
@@ -1,10 +1,9 @@
 # mypy: allow-untyped-defs
 import uuid
 from collections import OrderedDict
-from collections.abc import Sequence
 from functools import wraps
-from typing import Callable, Generic, Optional, overload, Protocol, TypeVar, Union
-from typing_extensions import Concatenate, ParamSpec
+from typing import Callable, Generic, Optional, Protocol
+from typing_extensions import Concatenate, ParamSpec, TypeVar
 
 import torch
 import torch.nn as nn
@@ -33,6 +32,7 @@ class RegistryItem:
 
 
 _TState = TypeVar("_TState", bound="_State", covariant=True)
+_M = TypeVar("_M", nn.Module, list[nn.Module])
 
 
 class _ContractFn(Protocol, Generic[_P, _T, _TState]):
@@ -43,35 +43,11 @@ class _ContractFn(Protocol, Generic[_P, _T, _TState]):
         ...
 
 
-@overload
-def contract() -> (
-    Callable[
-        [Callable[Concatenate[nn.Module, _P], _T]],
-        _ContractFn[Concatenate[nn.Module, _P], _T, _State],
-    ]
-):
-    ...
-
-
-@overload
 def contract(
-    state_cls: type[_TState],
+    state_cls: type[_TState] = _State,  # type: ignore[assignment]
 ) -> Callable[
-    [Callable[Concatenate[nn.Module, _P], _T]],
-    _ContractFn[Concatenate[nn.Module, _P], _T, _TState],
-]:
-    ...
-
-
-def contract(
-    state_cls: type = _State,
-) -> Callable[
-    [
-        Callable[
-            Concatenate[Union[nn.Module, Sequence[nn.Module]], _P], Optional[nn.Module]
-        ]
-    ],
-    _ContractFn,
+    [Callable[Concatenate[_M, _P], _M]],
+    _ContractFn[Concatenate[_M, _P], _M, _TState],
 ]:
     r"""
     Decorate a function as a composable distributed API, where the first
@@ -116,19 +92,16 @@ def contract(
     # wraps will make functions decorated with contract() pickleable - needed for integration with torch.package
     @wraps(state_cls)  # type: ignore[arg-type]
     def inner(
-        func: Callable[
-            Concatenate[Union[nn.Module, Sequence[nn.Module]], _P], Optional[nn.Module]
-        ]
-    ) -> _ContractFn[
-        Concatenate[Union[nn.Module, Sequence[nn.Module]], _P], _T, _TState
-    ]:
+        func: Callable[Concatenate[_M, _P], _M]
+    ) -> _ContractFn[Concatenate[_M, _P], _M, _TState]:
         @wraps(func)
         def wrapper(
-            module: Union[nn.Module, Sequence[nn.Module]],
+            module: _M,
             *args: _P.args,
             **kwargs: _P.kwargs,
-        ) -> Optional[nn.Module]:
+        ) -> _M:
             inp_module = module
+            modules: list[nn.Module]
             if isinstance(module, nn.Module):
                 modules = [module]
             else:
@@ -179,10 +152,11 @@ def contract(
             updated = func(inp_module, *args, **kwargs)
             if updated is None:
                 updated = inp_module  # type: ignore[assignment]
+            updated_modules: list[nn.Module]
             if isinstance(updated, nn.Module):
                 updated_modules = [updated]
             else:
-                updated_modules = _get_root_modules(list(inp_module))  # type: ignore[arg-type]
+                updated_modules = _get_root_modules(list(inp_module))  # type: ignore[arg-type, call-overload]
 
             all_new_named_params: list[dict[str, nn.Parameter]] = []
             all_new_named_buffers: list[dict[str, torch.Tensor]] = []
@@ -266,7 +240,7 @@ def contract(
 
         return wrapper  # type: ignore[return-value]
 
-    return inner
+    return inner  # type: ignore[return-value]
 
 
 def _get_registry(module: nn.Module) -> Optional[dict[str, RegistryItem]]:

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -1,13 +1,23 @@
 # mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
+
+from __future__ import annotations
+
 import functools
-from collections.abc import Iterable
-from typing import Any, Callable, cast, NoReturn, Optional, Union
+from typing import (
+    Any,
+    Callable,
+    cast,
+    NoReturn,
+    Optional,
+    overload,
+    TYPE_CHECKING,
+    Union,
+)
 
 import torch
 import torch.nn as nn
 from torch.distributed._composable import contract
-from torch.distributed.tensor import DeviceMesh, Shard
 from torch.distributed.utils import _get_root_modules
 
 from ._fsdp_api import MixedPrecisionPolicy, OffloadPolicy
@@ -24,6 +34,11 @@ from ._fsdp_param_group import FSDPParamGroup
 from ._fsdp_state import _get_module_fsdp_state, FSDPState
 
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from torch.distributed.tensor import DeviceMesh, Shard
+
 __all__ = [
     "fully_shard",
     "FSDPModule",
@@ -35,11 +50,42 @@ __all__ = [
 cls_to_fsdp_cls: dict[type, type] = {}
 
 
+@overload
+def fully_shard(
+    module: nn.Module,
+    *,
+    mesh: Optional[DeviceMesh] = ...,
+    reshard_after_forward: Union[bool, int] = ...,
+    shard_placement_fn: Optional[Callable[[nn.Parameter], Optional[Shard]]] = ...,
+    mp_policy: MixedPrecisionPolicy = ...,
+    offload_policy: OffloadPolicy = ...,
+    ignored_params: Optional[set[nn.Parameter]] = ...,
+) -> FSDPModule:
+    ...
+
+
+@overload
+def fully_shard(
+    module: list[nn.Module],
+    *,
+    mesh: Optional[DeviceMesh] = ...,
+    reshard_after_forward: Union[bool, int] = ...,
+    shard_placement_fn: Optional[Callable[[nn.Parameter], Optional[Shard]]] = ...,
+    mp_policy: MixedPrecisionPolicy = ...,
+    offload_policy: OffloadPolicy = ...,
+    ignored_params: Optional[set[nn.Parameter]] = ...,
+) -> list[FSDPModule]:
+    ...
+
+
 # The decorator adds a state object to `module` that can be accessed via
 # `fully_shard.state(module)`. The state object and module are 1:1.
-@contract(state_cls=FSDPState)
+# [1] Python runtime decorator does not play well with static type checking
+# so suppressing some type checks to support type overloads
+# such that caller can still get correct return types based on input type
+@contract(state_cls=FSDPState)  # type: ignore[misc] # see [1]
 def fully_shard(
-    module: Union[nn.Module, list[nn.Module]],
+    module,
     *,
     mesh: Optional[DeviceMesh] = None,
     reshard_after_forward: Union[bool, int] = True,
@@ -134,6 +180,9 @@ def fully_shard(
             :class:`OffloadPolicy` and its subclasses for details.
         ignored_params: Optional(Set[nn.Parameter]): The set of parameters that we
             don't want to shard with FSDP.
+
+    Returns:
+        FSDPModule: The module with FSDP applied (in-place).
     """
     if isinstance(module, (nn.ModuleList, nn.ModuleDict)):
         raise ValueError(
@@ -159,7 +208,7 @@ def fully_shard(
     modules = (
         (module,) if isinstance(module, nn.Module) else tuple(_get_root_modules(module))
     )
-    state = fully_shard.state(modules[0])
+    state = fully_shard.state(modules[0])  # type: ignore[attr-defined] # see [1]
     state.init(modules, device, mp_policy)
 
     managed_modules = _get_managed_modules(modules, ignored_params)
@@ -224,7 +273,7 @@ class FSDPModule:
         if fsdp_param_group := state._fsdp_param_group:
             fsdp_param_group.reshard()
 
-    def unshard(self, async_op: bool = False) -> Optional["UnshardHandle"]:
+    def unshard(self, async_op: bool = False) -> Optional[UnshardHandle]:
         """
         Unshards the module's parameters by allocating memory and all-gathering
         the parameters. This method is *not* recursive. The unshard follows the
@@ -325,7 +374,7 @@ class FSDPModule:
                 if fsdp_param_group := state._fsdp_param_group:
                     fsdp_param_group.reshard_after_backward = reshard_after_backward
 
-    def set_modules_to_forward_prefetch(self, modules: list["FSDPModule"]) -> None:
+    def set_modules_to_forward_prefetch(self, modules: list[FSDPModule]) -> None:
         """
         Sets the FSDP modules for which this FSDP module should explicitly
         prefetch all-gathers in forward. The prefetching runs after this
@@ -345,7 +394,7 @@ class FSDPModule:
             module._get_fsdp_state() for module in modules
         ]
 
-    def set_modules_to_backward_prefetch(self, modules: list["FSDPModule"]) -> None:
+    def set_modules_to_backward_prefetch(self, modules: list[FSDPModule]) -> None:
         """
         Sets the FSDP modules for which this FSDP module should explicitly
         prefetch all-gathers in backward. This overrides the default backward

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -658,7 +658,7 @@ class _PipelineStageBase(ABC):
                     fsdp_module.set_is_last_backward(True)
                     fsdp_module.set_reshard_after_backward(True)
                     fsdp_module.set_requires_gradient_sync(True)
-                    fsdp_state = fully_shard.state(fsdp_module)  # type: ignore[arg-type]
+                    fsdp_state = fully_shard.state(fsdp_module)  # type: ignore[attr-defined]
                     for state in fsdp_state._state_ctx.all_states:
                         if state._fsdp_param_group:
                             state._fsdp_param_group.post_backward()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147489
* #147488

This allows for

```
fsdped = fully_shard(model)
fsdped.set_xyz()
```

same applies if `model` is actually a list of modules

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o

Differential Revision: [D69888119](https://our.internmc.facebook.com/intern/diff/D69888119)