### PR TITLE
Documentation: fix RNN example for multiple layers

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -494,13 +494,15 @@ class RNN(RNNBase):
             h_t = hx
             output = []
             for t in range(seq_len):
+                x_l = x[t]
                 for layer in range(num_layers):
                     h_t[layer] = torch.tanh(
-                        x[t] @ weight_ih[layer].T
+                        x_l @ weight_ih[layer].T
                         + bias_ih[layer]
                         + h_t_minus_1[layer] @ weight_hh[layer].T
                         + bias_hh[layer]
                     )
+                    x_l = h_t[layer]
                 output.append(h_t[-1])
                 h_t_minus_1 = h_t
             output = torch.stack(output)


### PR DESCRIPTION

Hi,

The documentation on RNN provides the following snippet of code that I think is incorrect.
```
# Efficient implementation equivalent to the following with bidirectional=False
def forward(x, hx=None):
    if batch_first:
        x = x.transpose(0, 1)
    seq_len, batch_size, _ = x.size()
    if hx is None:
        hx = torch.zeros(num_layers, batch_size, hidden_size)
    h_t_minus_1 = hx
    h_t = hx
    output = []
    for t in range(seq_len):
        for layer in range(num_layers):
            h_t[layer] = torch.tanh(
                x[t] @ weight_ih[layer].T
                + bias_ih[layer]
                + h_t_minus_1[layer] @ weight_hh[layer].T
                + bias_hh[layer]
            )
        output.append(h_t[-1])
        h_t_minus_1 = h_t
    output = torch.stack(output)
    if batch_first:
        output = output.transpose(0, 1)
    return output, h_t
```

Having a number of layers `num_layers > 1` makes a stacked RNN, where the input to layer `L>1` is the state `h_L-1` at layer `L-1`.
The doc supports that by mentioning the size of the weight matrix must be:

```
weight_ih_l[k]: the learnable input-hidden weights of the k-th layer,
            of shape `(hidden_size, input_size)` for `k = 0`. Otherwise, the shape is
            `(hidden_size, num_directions * hidden_size)`
```

However, in the snippet above, the line
https://github.com/pytorch/pytorch/blob/fb55bac3de7f0afb45969ad8adbc340de48747ac/torch/nn/modules/rnn.py#L499
multiplies the input `x[t]` with the weight matrix `weight_ih[layer]`, whose dimensions mismatch.

I don't think the snippet is functional, this PR fixes this.