### PR TITLE
Fix RuntimeError: value cannot be converted to type int64_t without overflow

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -974,6 +974,8 @@ def argsort_sym(
 
 @functools.lru_cache(8)
 def get_dtype_size(dtype: torch.dtype) -> int:
+    if dtype == torch.uint64:
+        return 8
     return torch.empty((), dtype=dtype).element_size()
 
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -974,6 +974,8 @@ def argsort_sym(
 
 @functools.lru_cache(8)
 def get_dtype_size(dtype: torch.dtype) -> int:
+    # TODO: Investigate why uint64 tensor creation causes overflow error:
+    # Workaround for RuntimeError in memory size calculation, but underlying cause unclear
     if dtype == torch.uint64:
         return 8
     return torch.empty((), dtype=dtype).element_size()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147492


The exact call is coming from here:

https://github.com/pytorch/pytorch/blob/78a94c911435bf9b1bb45888033a29081e406ec2/torch/_inductor/memory.py#L161

I have no idea why this error is being thrown and what mode/modes might be failing for this

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov