### PR TITLE
Fix the shape check inside gnll loss

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3263,12 +3263,13 @@ def gaussian_nll_loss(
         if input.size()[:-1] == var.size():
             var = torch.unsqueeze(var, -1)
 
-        # This checks if the sizes match up to the final dimension, and the final dimension of var is of size 1.
-        # This is also a homoscedastic case.
+        # This checks if the var is broadcastable to the input.
         # e.g. input.size = (10, 2, 3), var.size = (10, 2, 1)
+        # or  input.size = (4, 3, 32, 32), var.size = (4, 1, 32, 32)
         elif (
-            input.size()[:-1] == var.size()[:-1] and var.size(-1) == 1
-        ):  # Heteroscedastic case
+            input.ndim == var.ndim
+            and all(x == y or y == 1 for x, y in zip(input.size(), var.size()))
+        ):
             pass
 
         # If none of the above pass, then the size of var is incorrect.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3263,13 +3263,13 @@ def gaussian_nll_loss(
         if input.size()[:-1] == var.size():
             var = torch.unsqueeze(var, -1)
 
-        # This checks if the var is broadcastable to the input.
+        # This checks if the var is broadcastable to the input and there is only one mismatched dimension.
         # This is also a homoscedastic case.
         # e.g. input.size = (10, 2, 3), var.size = (10, 2, 1)
         # or  input.size = (4, 3, 32, 32), var.size = (4, 1, 32, 32)
         elif (
             input.ndim == var.ndim
-            and all(x == y or y == 1 for x, y in zip(input.size(), var.size()))
+            and sum(y for x, y in zip(input.size(), var.size()) if x != y) == 1
         ):  # Heteroscedastic case
             pass
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3264,12 +3264,13 @@ def gaussian_nll_loss(
             var = torch.unsqueeze(var, -1)
 
         # This checks if the var is broadcastable to the input.
+        # This is also a homoscedastic case.
         # e.g. input.size = (10, 2, 3), var.size = (10, 2, 1)
         # or  input.size = (4, 3, 32, 32), var.size = (4, 1, 32, 32)
         elif (
             input.ndim == var.ndim
             and all(x == y or y == 1 for x, y in zip(input.size(), var.size()))
-        ):
+        ): # Heteroscedastic case
             pass
 
         # If none of the above pass, then the size of var is incorrect.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3270,7 +3270,7 @@ def gaussian_nll_loss(
         elif (
             input.ndim == var.ndim
             and all(x == y or y == 1 for x, y in zip(input.size(), var.size()))
-        ): # Heteroscedastic case
+        ):  # Heteroscedastic case
             pass
 
         # If none of the above pass, then the size of var is incorrect.

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -432,15 +432,18 @@ def module_inputs_torch_nn_GaussianNLLLoss(module_info, device, dtype, requires_
         ('reduction_sum', {'reduction': 'sum'}),
         ('reduction_mean', {'reduction': 'mean'}),
         ('reduction_none', {'reduction': 'none'}),
+        ('homoscedastic', {'homoscedastic': True}),
     ]
 
     module_inputs = []
     for desc, constructor_kwargs in cases:
+        homoscedastic = constructor_kwargs.pop('homoscedastic', False)
+        var_input = make_input(1, 3).abs() if homoscedastic else make_input(4, 1).abs()
         module_inputs.append(
             ModuleInput(constructor_input=FunctionInput(**constructor_kwargs),
-                        forward_input=FunctionInput(make_input(3),
-                                                    make_target(3),
-                                                    make_input(1).abs()),
+                        forward_input=FunctionInput(make_input(4, 3),
+                                                    make_target(4, 3),
+                                                    var_input),
                         desc=desc,
                         reference_fn=no_batch_dim_reference_fn)
         )


### PR DESCRIPTION
Fixes #147521
This modification allow user to put any size of var in GaussianNLLLoss if the var is broadcastable (to input/target's size)

Therefore, the demo code in #147521 will result in expected behaviour and correct output.

This allow all input size that match:
`input.size = (..., n, ...), var.size = (..., 1, ...)`


cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki