### PR TITLE
Raise KeyError when class attr is overwritten by a Module

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -719,6 +719,20 @@ class TestNN(NNTestCase):
             with self.assertRaises(KeyError):
                 getattr(m, fn)('attribute_name', nn.Module())
 
+    def test_add_module_raises_error_if_attr_exists_in_cls(self):
+        methods_to_test = ['add_module', 'register_module']
+
+        class MyModule(nn.Module):
+            attribute_name = "some value"
+
+        for fn in methods_to_test:
+            m = MyModule()
+            with self.assertRaises(KeyError):
+                getattr(m, fn)('attribute_name', MyModule())
+
+        with self.assertRaises(KeyError):
+            m.attribute_name = MyModule()
+
     @unittest.expectedFailure
     def test_getattr_with_property(self):
         class Model(nn.Module):

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1983,6 +1983,10 @@ class Module:
                     self._buffers,
                     self._non_persistent_buffers_set,
                 )
+                if hasattr(type(self), name):
+                    raise KeyError(
+                        "Cannot assign a module instead of an existing class attribute."
+                    )
                 for hook in _global_module_registration_hooks.values():
                     output = hook(self, name, value)
                     if output is not None:


### PR DESCRIPTION
Currently, this code doesn't raise an exception though the result of the `setattr` is erroneous

```python
import torch
from torch.nn import Module
from torch.nn.parameter import Parameter


class MyModule(Module):
    class_attr = "some value"

c = MyModule()

print(c.class_attr) # prints "some value"
c.class_attr = MyModule()
print(c.class_attr) # prints "some value"
```

but this does
```python
import torch
from torch.nn import Module
from torch.nn.parameter import Parameter


class MyModule(Module):
    class_attr = "some value"

c = MyModule()

# c.class_attr = "another value"
# print(c.class_attr)

print(c.class_attr)
c.class_attr = Parameter(torch.randn(3)) # breaks
```

In this PR, I propose a KeyError when `setattr` is called for a `Module` instance and a class attribute already exists.

Since it's a silent error, it could be that some users see this error appear but it would then mean that they're wrongfully assuming that the `setattr` worked when it didn't.
