### PR TITLE
[ONNX] Add draft_export as a strategy

### DIFF
--- a/test/onnx/exporter/test_capture_strategies.py
+++ b/test/onnx/exporter/test_capture_strategies.py
@@ -15,6 +15,7 @@ class ExportStrategiesTest(common_utils.TestCase):
         [
             _capture_strategies.TorchExportStrategy,
             _capture_strategies.TorchExportNonStrictStrategy,
+            _capture_strategies.TorchExportDraftExportStrategy,
             _capture_strategies.JitTraceConvertStrategy,
         ],
         name_fn=lambda strategy_cls: strategy_cls.__name__,

--- a/test/onnx/exporter/test_capture_strategies.py
+++ b/test/onnx/exporter/test_capture_strategies.py
@@ -36,11 +36,30 @@ class ExportStrategiesTest(common_utils.TestCase):
         assert ep is not None
         torch.testing.assert_close(ep.module()(a, b), model(a, b))
 
+    def test_jit_conversion_on_data_dependent_model(self):
+        class Model(torch.nn.Module):
+            def forward(self, a, b):
+                if a.sum() > 0:
+                    return a.cos()
+                # The branch is expected to be specialized
+                return b.sin()
+
+        model = Model()
+        a = torch.tensor(0.0)
+        b = torch.tensor(1.0)
+
+        strategy = _capture_strategies.JitTraceConvertStrategy()
+        result = strategy(model, (a, b), kwargs=None, dynamic_shapes=None)
+        ep = result.exported_program
+        assert ep is not None
+        torch.testing.assert_close(ep.module()(a, b), model(a, b))
+
     def test_draft_export_on_data_dependent_model(self):
         class Model(torch.nn.Module):
             def forward(self, a, b):
                 if a.sum() > 0:
                     return a.cos()
+                # The branch is expected to be specialized and a warning is logged
                 return b.sin()
 
         model = Model()

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -177,16 +177,17 @@ def export(
 
     When ``dynamo=True``:
 
-    The exporter tries the following strategies to get an ExportedProgram for conversion to ONNX:
-    1. If the model is already an ExportedProgram, it will be used as-is.
-    2. Use :func:`torch.export.export` and set ``strict=False``.
-    3. Use :func:`torch.export.export` and set ``strict=True``.
-    4. Use ``draft_export`` which removes some soundness guarantees in data-dependent
-        operations to allow export to proceed. You will get a warning if the exporter
-        encounters any unsound data-dependent operation.
-    5. Use :func:`torch.jit.trace` to trace the model then convert to ExportedProgram.
-        This is the most unsound strategy but may be useful for converting TorchScript
-        models to ONNX.
+    The exporter tries the following strategies to get an ExportedProgram for conversion to ONNX.
+
+    #. If the model is already an ExportedProgram, it will be used as-is.
+    #. Use :func:`torch.export.export` and set ``strict=False``.
+    #. Use :func:`torch.export.export` and set ``strict=True``.
+    #. Use ``draft_export`` which removes some soundness guarantees in data-dependent
+       operations to allow export to proceed. You will get a warning if the exporter
+       encounters any unsound data-dependent operation.
+    #. Use :func:`torch.jit.trace` to trace the model then convert to ExportedProgram.
+       This is the most unsound strategy but may be useful for converting TorchScript
+       models to ONNX.
 
     Args:
         model: The model to be exported.

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -170,6 +170,24 @@ def export(
 ) -> ONNXProgram | None:
     r"""Exports a model into ONNX format.
 
+    Setting :param:`dynamo` to ``True`` enables the new ONNX export logic
+    which is based on :class:`torch.export.ExportedProgram` and a more modern
+    set of translation logic. This is the recommended way to export models
+    to ONNX.
+
+    When ``dynamo=True``:
+
+    The exporter tries the following strategies to get an ExportedProgram for conversion to ONNX:
+    1. If the model is already an ExportedProgram, it will be used as-is.
+    2. Use :func:`torch.export.export` and set ``strict=False``.
+    3. Use :func:`torch.export.export` and set ``strict=True``.
+    4. Use ``draft_export`` which is removes some soundness guarantees in data-dependent
+        operations to allow export to proceed. You will get a warning if any of
+        the data-dependent operations are encountered.
+    5. Use :func:`torch.jit.trace` to trace the model then convert to ExportedProgram.
+        This is the most unsound strategy but may be useful for converting TorchScript
+        models to ONNX.
+
     Args:
         model: The model to be exported.
         args: Example positional inputs. Any non-Tensor arguments will be hard-coded into the

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -170,7 +170,7 @@ def export(
 ) -> ONNXProgram | None:
     r"""Exports a model into ONNX format.
 
-    Setting :param:`dynamo` to ``True`` enables the new ONNX export logic
+    Setting ``dynamo=True`` enables the new ONNX export logic
     which is based on :class:`torch.export.ExportedProgram` and a more modern
     set of translation logic. This is the recommended way to export models
     to ONNX.

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -181,9 +181,9 @@ def export(
     1. If the model is already an ExportedProgram, it will be used as-is.
     2. Use :func:`torch.export.export` and set ``strict=False``.
     3. Use :func:`torch.export.export` and set ``strict=True``.
-    4. Use ``draft_export`` which is removes some soundness guarantees in data-dependent
-        operations to allow export to proceed. You will get a warning if any of
-        the data-dependent operations are encountered.
+    4. Use ``draft_export`` which removes some soundness guarantees in data-dependent
+        operations to allow export to proceed. You will get a warning if the exporter
+        encounters any unsound data-dependent operation.
     5. Use :func:`torch.jit.trace` to trace the model then convert to ExportedProgram.
         This is the most unsound strategy but may be useful for converting TorchScript
         models to ONNX.

--- a/torch/onnx/_internal/exporter/_capture_strategies.py
+++ b/torch/onnx/_internal/exporter/_capture_strategies.py
@@ -246,7 +246,7 @@ class TorchExportDraftExportStrategy(CaptureStrategy):
         report = ep._report  # type: ignore[attr-defined]
         if not report.successful():
             self._exception = RuntimeError(str(report))
-        # The report is logged and displayed by draft_export already, so we don't need to print it again.
+            self._verbose_print(f"Draft Export report:\n{report}")
         return ep
 
     def _enter(self, model) -> None:

--- a/torch/onnx/_internal/exporter/_capture_strategies.py
+++ b/torch/onnx/_internal/exporter/_capture_strategies.py
@@ -126,7 +126,9 @@ class CaptureStrategy(abc.ABC):
             )
         self._success(model)
         return Result(
-            exported_program, strategy=self.__class__.__name__, exception=self._exception
+            exported_program,
+            strategy=self.__class__.__name__,
+            exception=self._exception,
         )
 
     @abc.abstractmethod

--- a/torch/onnx/_internal/exporter/_capture_strategies.py
+++ b/torch/onnx/_internal/exporter/_capture_strategies.py
@@ -12,6 +12,7 @@ import pathlib
 from typing import Any, Callable, TYPE_CHECKING
 
 import torch
+from torch.export import _draft_export
 from torch.utils import _pytree
 
 
@@ -62,6 +63,13 @@ class Result:
 
     @property
     def success(self) -> bool:
+        """Whether the capture was successful.
+
+        An exception can still be recorded even if the capture was successful. In
+        this case the exception is informational only. For example, draft_export
+        can record an exception if there are warnings during the export. The exceptions
+        will go into the onnx export report when report=True.
+        """
         return self.exported_program is not None
 
 
@@ -95,6 +103,7 @@ class CaptureStrategy(abc.ABC):
         self._timestamp = timestamp or datetime.datetime.now().strftime(
             "%Y-%m-%d_%H-%M-%S-%f"
         )
+        self._exception: Exception | None = None
 
     def __call__(
         self,
@@ -116,7 +125,9 @@ class CaptureStrategy(abc.ABC):
                 exception=e,
             )
         self._success(model)
-        return Result(exported_program, strategy=self.__class__.__name__)
+        return Result(
+            exported_program, strategy=self.__class__.__name__, exception=self._exception
+        )
 
     @abc.abstractmethod
     def _capture(
@@ -223,6 +234,39 @@ class TorchExportNonStrictStrategy(CaptureStrategy):
         )
 
 
+class TorchExportDraftExportStrategy(CaptureStrategy):
+    def _capture(
+        self, model, args, kwargs, dynamic_shapes
+    ) -> torch.export.ExportedProgram:
+        ep = _draft_export.draft_export(
+            model, args, kwargs=kwargs, dynamic_shapes=dynamic_shapes
+        )
+        report = ep._report  # type: ignore[attr-defined]
+        if not report.successful():
+            self._exception = RuntimeError(str(report))
+        # The report is logged and displayed by draft_export already, so we don't need to print it again.
+        return ep
+
+    def _enter(self, model) -> None:
+        model_repr = _take_first_line(repr(model))
+        self._verbose_print(
+            f"Obtain model graph for `{model_repr}` with `torch.export draft_export`..."
+        )
+
+    def _success(self, model) -> None:
+        model_repr = _take_first_line(repr(model))
+        self._verbose_print(
+            f"Obtain model graph for `{model_repr}` with `torch.export draft_export`... ✅"
+        )
+
+    def _failure(self, model, e) -> None:
+        del e  # Unused
+        model_repr = _take_first_line(repr(model))
+        self._verbose_print(
+            f"Obtain model graph for `{model_repr}` with `torch.export draft_export`... ❌"
+        )
+
+
 class JitTraceConvertStrategy(CaptureStrategy):
     def _capture(
         self, model, args, kwargs, dynamic_shapes
@@ -325,5 +369,6 @@ class JitTraceConvertStrategy(CaptureStrategy):
 CAPTURE_STRATEGIES = (
     TorchExportNonStrictStrategy,  # strict=False is preferred over strict=True because it does not have dynamo issues
     TorchExportStrategy,
+    TorchExportDraftExportStrategy,
     JitTraceConvertStrategy,
 )

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -1255,14 +1255,17 @@ def export(
                 export_status.torch_export_non_strict = result.success
             elif strategy_class is _capture_strategies.TorchExportStrategy:
                 export_status.torch_export = result.success
+            elif strategy_class is _capture_strategies.TorchExportDraftExportStrategy:
+                export_status.torch_export_draft_export = result.success
             elif strategy_class is _capture_strategies.JitTraceConvertStrategy:
                 export_status.torch_jit = result.success
 
-            if result.exported_program is not None:
+            if result.exception is not None:
+                failed_results.append(result)
+            if result.success:
+                assert result.exported_program is not None
                 program = result.exported_program
                 break
-            else:
-                failed_results.append(result)
 
         assert result is not None
         capture_strategy = result.strategy

--- a/torch/onnx/_internal/exporter/_reporting.py
+++ b/torch/onnx/_internal/exporter/_reporting.py
@@ -22,6 +22,8 @@ class ExportStatus:
     torch_export: bool | None = None
     # Whether torch.export.export.export(..., strict=False) succeeds
     torch_export_non_strict: bool | None = None
+    # Whether torch.export._draft_export.draft_export() succeeds
+    torch_export_draft_export: bool | None = None
     # Whether torch.jit.trace succeeds
     torch_jit: bool | None = None
     # Whether decomposition succeeds
@@ -47,6 +49,7 @@ def _format_export_status(status: ExportStatus) -> str:
         f"```\n"
         f"{_status_emoji(status.torch_export_non_strict)} Obtain model graph with `torch.export.export(..., strict=False)`\n"
         f"{_status_emoji(status.torch_export)} Obtain model graph with `torch.export.export(..., strict=True)`\n"
+        f"{_status_emoji(status.torch_export_draft_export)} Obtain model graph with `torch.export._draft_export.draft_export`\n"
         f"{_status_emoji(status.torch_jit)} Obtain model graph with `torch.jit.trace`\n"
         f"{_status_emoji(status.decomposition)} Decompose operators for ONNX compatibility\n"
         f"{_status_emoji(status.onnx_translation)} Translate the graph into ONNX\n"
@@ -77,7 +80,12 @@ def _format_exported_program(exported_program: torch.export.ExportedProgram) -> 
 
 def construct_report_file_name(timestamp: str, status: ExportStatus) -> str:
     # Status could be None. So we need to check for False explicitly.
-    if not (status.torch_export or status.torch_export_non_strict or status.torch_jit):
+    if not (
+        status.torch_export
+        or status.torch_export_non_strict
+        or status.torch_export_draft_export
+        or status.torch_jit
+    ):
         # All strategies failed
         postfix = "pt_export"
     elif status.decomposition is False:
@@ -90,7 +98,12 @@ def construct_report_file_name(timestamp: str, status: ExportStatus) -> str:
         postfix = "runtime"
     elif status.output_accuracy is False:
         postfix = "accuracy"
-    elif status.torch_export is False or status.torch_export_non_strict is False:
+    elif (
+        status.torch_export is False
+        or status.torch_export_non_strict is False
+        or status.torch_export_draft_export is False
+        or status.torch_jit is False
+    ):
         # Some strategies failed
         postfix = "strategies"
     else:


### PR DESCRIPTION
Create draft_export strategy.

The strategy is added before jit and after strict=True, as the third fallback. Since it is specializing tensors it should not be less robust than the jit trace strategy.
