### PR TITLE
Fix PEP585 update

### DIFF
--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -3,8 +3,14 @@ import bisect
 import itertools
 import math
 import warnings
-from collections.abc import Iterable, Sequence
-from typing import cast, Generic, Optional, TypeVar, Union
+from collections.abc import Sequence
+
+# UP006 wants 'Iterable' to be imported from collections.abc but it needs to
+# stay from typing for now due to BC concerns. In particular several internal
+# targets fail to typecheck with:
+#     TypeError: Cannot create a consistent method resolution order (MRO) for
+#     bases Iterable, Generic
+from typing import cast, Generic, Iterable, Optional, TypeVar, Union  # noqa: UP006
 from typing_extensions import deprecated
 
 # No 'default_generator' in torch/__init__.pyi


### PR DESCRIPTION
Summary: D69920347 causes a pyre failure due to changing a base object from typing.Iterable to abc.Iterable.  For now revert that change until it can be dealt with on its own.

Test Plan:
failures from D69920347 pass locally
unit tests pass

Reviewed By: oulgen

Differential Revision: D69936518
