### PR TITLE
[fx] demote node prepend to self log from warning to debug

### DIFF
--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -1,9 +1,9 @@
 # Nodes represent a definition of a value in our graph of operators.
 import builtins
 import inspect
+import logging
 import operator
 import types
-import warnings
 from collections.abc import Mapping, Sequence
 from typing import Any, Callable, cast, Optional, TYPE_CHECKING, TypeVar, Union
 
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
     from .graph import Graph
 
 __all__ = ["Node", "map_arg", "map_aggregate", "has_side_effect"]
+
+log = logging.getLogger(__name__)
 
 BaseArgumentTypes = Union[
     str,
@@ -390,7 +392,7 @@ class Node(_NodeBase):
         """
         assert self.graph == x.graph, "Attempting to move a Node into a different Graph"
         if self == x:
-            warnings.warn(
+            log.debug(
                 "Trying to prepend a node to itself. This behavior has no effect on the graph."
             )
             return


### PR DESCRIPTION
FIXES https://github.com/pytorch/pytorch/issues/147175

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147538

This is harmless, not sure why this is a user warning. Writing reordering graph passes is more concise when we ignore this warning.


cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv