### PR TITLE
Enable strobelight profiling  specific compile frame ids using COMPILE_STROBELIGHT_FRAME_FILTER

### DIFF
--- a/test/strobelight/examples/compile_time_profile_example.py
+++ b/test/strobelight/examples/compile_time_profile_example.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
     # You can pass TORCH_COMPILE_STROBELIGHT=True instead.
     StrobelightCompileTimeProfiler.enable()
 
-    # You use the the code below to filter what frames to be profiled.
+    # You can use the code below to filter what frames to be profiled.
     StrobelightCompileTimeProfiler.frame_id_filter = "1/.*"
     # StrobelightCompileTimeProfiler.frame_id_filter='0/.*'
     # StrobelightCompileTimeProfiler.frame_id_filter='.*'

--- a/test/strobelight/examples/compile_time_profile_example.py
+++ b/test/strobelight/examples/compile_time_profile_example.py
@@ -5,40 +5,33 @@ from torch._strobelight.compile_time_profiler import StrobelightCompileTimeProfi
 
 if __name__ == "__main__":
     # You can pass TORCH_COMPILE_STROBELIGHT=True instead.
-    # StrobelightCompileTimeProfiler.enable()
+    StrobelightCompileTimeProfiler.enable()
+
+    # You use the the code below to filter what frames to be profiled.
+    StrobelightCompileTimeProfiler.frame_id_filter = "1/.*"
+    # StrobelightCompileTimeProfiler.frame_id_filter='0/.*'
+    # StrobelightCompileTimeProfiler.frame_id_filter='.*'
+    # You can set env variable COMPILE_STROBELIGHT_FRAME_FILTER to set the filter also.
 
     def fn(x, y, z):
         return x * y + z
 
-    # @torch.compile(fullgraph=True)
-    # def e(n):
-    #     for _ in range(3):
-    #         for _ in range(5):
-    #             fn(torch.rand(n, n), torch.rand(n, n), torch.rand(n, n))
+    @torch.compile()
+    def work(n):
+        for _ in range(3):
+            for _ in range(5):
+                fn(torch.rand(n, n), torch.rand(n, n), torch.rand(n, n))
 
     # Strobelight will be called only 3 times because dynamo will be disabled after
     # 3rd iteration.
-    # Those will be 0/0
-    
-    # set COMPILE_STROBELIGHT_FRAME_FILTER="0" to only profile this. 
-    # for i in range(3):
-    #     # torch._dynamo.reset()
-    #     e(i)
-    
-    # print("finished compiling first frame")
-
-    @torch.compile(fullgraph=True)
-    def func2(x):
-        for i in range(0, 100):
-            x  = x*2
-        return x
-
-    # set COMPILE_STROBELIGHT_FRAME_FILTER="1" to only profile this. 
-    func2(torch.rand(10))
-
+    # Frame 0/0
+    for i in range(3):
+        torch._dynamo.reset()
+        work(i)
 
     @torch.compile(fullgraph=True)
     def func4(x):
-        return x*x
-    
+        return x * x
+
+    # Frame 1/0
     func4(torch.rand(10))

--- a/test/strobelight/examples/compile_time_profile_example.py
+++ b/test/strobelight/examples/compile_time_profile_example.py
@@ -5,19 +5,40 @@ from torch._strobelight.compile_time_profiler import StrobelightCompileTimeProfi
 
 if __name__ == "__main__":
     # You can pass TORCH_COMPILE_STROBELIGHT=True instead.
-    StrobelightCompileTimeProfiler.enable()
+    # StrobelightCompileTimeProfiler.enable()
 
     def fn(x, y, z):
         return x * y + z
 
-    @torch.compile()
-    def work(n):
-        for _ in range(3):
-            for _ in range(5):
-                fn(torch.rand(n, n), torch.rand(n, n), torch.rand(n, n))
+    # @torch.compile(fullgraph=True)
+    # def e(n):
+    #     for _ in range(3):
+    #         for _ in range(5):
+    #             fn(torch.rand(n, n), torch.rand(n, n), torch.rand(n, n))
 
     # Strobelight will be called only 3 times because dynamo will be disabled after
     # 3rd iteration.
-    for i in range(3):
-        torch._dynamo.reset()
-        work(i)
+    # Those will be 0/0
+    
+    # set COMPILE_STROBELIGHT_FRAME_FILTER="0" to only profile this. 
+    # for i in range(3):
+    #     # torch._dynamo.reset()
+    #     e(i)
+    
+    # print("finished compiling first frame")
+
+    @torch.compile(fullgraph=True)
+    def func2(x):
+        for i in range(0, 100):
+            x  = x*2
+        return x
+
+    # set COMPILE_STROBELIGHT_FRAME_FILTER="1" to only profile this. 
+    func2(torch.rand(10))
+
+
+    @torch.compile(fullgraph=True)
+    def func4(x):
+        return x*x
+    
+    func4(torch.rand(10))

--- a/torch/_strobelight/compile_time_profiler.py
+++ b/torch/_strobelight/compile_time_profiler.py
@@ -86,7 +86,7 @@ class StrobelightCompileTimeProfiler:
     inside_profile_compile_time: bool = False
     enabled: bool = False
 
-    # A list of comma seperated inegers. ex: 1,2,3 if not empty then we only profile the compile ids in the list.
+    # A regex that can be used to filter out what frames to profile. ex: "1/.*"
     frame_id_filter: Optional[str] = os.environ.get("COMPILE_STROBELIGHT_FRAME_FILTER")
 
     # A unique identifier that is used as the run_user_name in the strobelight profile to
@@ -192,7 +192,7 @@ class StrobelightCompileTimeProfiler:
             logger.info(
                 "profile_compile_time is requested for phase: %s, frame %s, while already in running phase: %s,"
                 "frame %s, recursive call ignored",
-                frame_id,
+                phase_name,
                 frame_id,
                 cls.current_phase,
                 frame_id,

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 from typing import Any, Callable, Optional, TypeVar
 from typing_extensions import ParamSpec
+import re
 
 import torch
 from torch._strobelight.compile_time_profiler import StrobelightCompileTimeProfiler
@@ -90,13 +91,14 @@ def compile_time_strobelight_meta(
         def wrapper_function(*args: _P.args, **kwargs: _P.kwargs) -> _T:
             if "skip" in kwargs and isinstance(skip := kwargs["skip"], int):
                 kwargs["skip"] = skip + 1
+            return function(*args, **kwargs)
 
-            if not StrobelightCompileTimeProfiler.enabled:
-                return function(*args, **kwargs)
+            # if not StrobelightCompileTimeProfiler.should_profile():
+            #     return function(*args, **kwargs)
 
-            return StrobelightCompileTimeProfiler.profile_compile_time(
-                function, phase_name, *args, **kwargs
-            )
+            # return StrobelightCompileTimeProfiler.profile_compile_time(
+            #     function, phase_name, *args, **kwargs
+            # )
 
         return wrapper_function
 

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -6,7 +6,6 @@ import sys
 import tempfile
 from typing import Any, Callable, Optional, TypeVar
 from typing_extensions import ParamSpec
-import re
 
 import torch
 from torch._strobelight.compile_time_profiler import StrobelightCompileTimeProfiler
@@ -91,14 +90,15 @@ def compile_time_strobelight_meta(
         def wrapper_function(*args: _P.args, **kwargs: _P.kwargs) -> _T:
             if "skip" in kwargs and isinstance(skip := kwargs["skip"], int):
                 kwargs["skip"] = skip + 1
-            return function(*args, **kwargs)
 
-            # if not StrobelightCompileTimeProfiler.should_profile():
-            #     return function(*args, **kwargs)
+            # This is not needed but we have it here to avoid having profile_compile_time
+            # in stack traces when profiling is not enabled.
+            if not StrobelightCompileTimeProfiler.enabled:
+                return function(*args, **kwargs)
 
-            # return StrobelightCompileTimeProfiler.profile_compile_time(
-            #     function, phase_name, *args, **kwargs
-            # )
+            return StrobelightCompileTimeProfiler.profile_compile_time(
+                function, phase_name, *args, **kwargs
+            )
 
         return wrapper_function
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147549
* #147547

running python test/strobelight/examples/compile_time_profile_example.py 
```
strobelight_compile_time_profiler, line 123, 2025-02-20 14:08:08,409, INFO: compile time strobelight profiling enabled
strobelight_compile_time_profiler, line 159, 2025-02-20 14:08:08,409, INFO: Unique sample tag for this run is: 2025-02-20-14:08:081656673devgpu005.nha1.facebook.com
strobelight_compile_time_profiler, line 160, 2025-02-20 14:08:09,124, INFO: URL to access the strobelight profile at the end of the run: https://fburl.com/scuba/pyperf_experimental/on_demand/9felqj0i

strobelight_compile_time_profiler, line 205, 2025-02-20 14:08:12,436, INFO: profiling frame 0/0 is skipped due to frame_id_filter 1/.*
strobelight_compile_time_profiler, line 205, 2025-02-20 14:08:15,553, INFO: profiling frame 0/0 is skipped due to frame_id_filter 1/.*
strobelight_compile_time_profiler, line 205, 2025-02-20 14:08:16,170, INFO: profiling frame 0/0 is skipped due to frame_id_filter 1/.*
strobelight_compile_time_profiler, line 214, 2025-02-20 14:08:16,877, INFO: profiling frame 1/0
strobelight_function_profiler, line 247, 2025-02-20 14:08:19,416, INFO: strobelight run id is: 4015948658689996
strobelight_function_profiler, line 249, 2025-02-20 14:08:21,546, INFO: strobelight profiling running
strobelight_function_profiler, line 289, 2025-02-20 14:08:25,964, INFO: work function took 4.417063233006047 seconds
strobelight_function_profiler, line 230, 2025-02-20 14:08:28,310, INFO: strobelight profiling stopped
strobelight_function_profiler, line 221, 2025-02-20 14:08:44,308, INFO: Total samples: 119
strobelight_function_profiler, line 221, 2025-02-20 14:08:44,308, INFO: GraphProfiler (python stack): https://fburl.com/scuba/pyperf_experimental/on_demand/73h2f7ur
strobelight_function_profiler, line 221, 2025-02-20 14:08:44,308, INFO: Icicle view (python stack): https://fburl.com/scuba/pyperf_experimental/on_demand/zs06fi9e
strobelight_compile_time_profiler, line 167, 2025-02-20 14:08:44,308, INFO: 1 strobelight success runs out of 1 non-recursive compilation events.

```
