### PR TITLE
Define `__all__` for `torch.utils.tensorboard`

### DIFF
--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -2440,7 +2440,6 @@
     "tqdm"
   ],
   "torch.utils.tensorboard": [
-    "FileWriter",
     "RecordWriter",
     "SummaryWriter"
   ],

--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -2440,7 +2440,9 @@
     "tqdm"
   ],
   "torch.utils.tensorboard": [
-    "RecordWriter"
+    "FileWriter",
+    "RecordWriter",
+    "SummaryWriter"
   ],
   "torch.ao.quantization.experimental.APoT_tensor": [
     "APoTQuantizer"

--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -2439,6 +2439,9 @@
     "load_url",
     "tqdm"
   ],
+  "torch.utils.tensorboard": [
+    "RecordWriter"
+  ],
   "torch.ao.quantization.experimental.APoT_tensor": [
     "APoTQuantizer"
   ],

--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -2439,10 +2439,6 @@
     "load_url",
     "tqdm"
   ],
-  "torch.utils.tensorboard": [
-    "RecordWriter",
-    "SummaryWriter"
-  ],
   "torch.ao.quantization.experimental.APoT_tensor": [
     "APoTQuantizer"
   ],

--- a/torch/utils/tensorboard/__init__.py
+++ b/torch/utils/tensorboard/__init__.py
@@ -9,5 +9,11 @@ if not hasattr(tensorboard, "__version__") or Version(
 del Version
 del tensorboard
 
-from .writer import FileWriter, SummaryWriter  # noqa: F401
-from tensorboard.summary.writer.record_writer import RecordWriter  # noqa: F401
+from .writer import FileWriter, SummaryWriter
+from tensorboard.summary.writer.record_writer import RecordWriter
+
+__all__ = [
+    "FileWriter",
+    "RecordWriter",
+    "SummaryWriter",
+]


### PR DESCRIPTION
Fixes the issue:

```python
import torch.utils.tensorboard
torch.utils.tensorboard.FileWriter  # pyright: "FileWriter" is not exported from module "torch.utils.tensorboard"
torch.utils.tensorboard.RecordWriter  # pyright: "RecordWriter" is not exported from module "torch.utils.tensorboard"
torch.utils.tensorboard.SummaryWriter  # pyright: "SummaryWriter" is not exported from module "torch.utils.tensorboard"
```

The [docs page for `torch.utils.tensorboard`](https://pytorch.org/docs/stable/tensorboard.html)