### PR TITLE
[export] Remove report from draft-export output

### DIFF
--- a/torch/export/_draft_export.py
+++ b/torch/export/_draft_export.py
@@ -344,7 +344,7 @@ def draft_export(
     preserve_module_call_signature: tuple[str, ...] = (),
     strict: bool = False,
     pre_dispatch: bool = False,
-) -> tuple[ExportedProgram, DraftExportReport]:
+) -> ExportedProgram:
     kwargs = kwargs or {}
     dynamic_shapes = dynamic_shapes or {}
 
@@ -473,4 +473,4 @@ You can now change back to torch.export.export()
     """
         )
 
-    return ep, report
+    return ep


### PR DESCRIPTION
Summary: This matches the export API. To print the report, people can just do `print(ep._report)`. This information is also displayed in the terminal after the draft_export call.

Test Plan: CI

Reviewed By: SherlockNoMad

Differential Revision: D69689154


