### PR TITLE
export method

### DIFF
--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -1352,13 +1352,50 @@ def deregister_module_as_pytree_input_node(cls: type[torch.nn.Module]) -> None:
     _deregister_pytree_flatten_spec(cls)
 
 
+def _sync_state(src, dst):
+    assert isinstance(
+        src,
+        torch.nn.Module,
+    ), f"Expected {src} to be a nn.Module"
+    assert isinstance(
+        dst,
+        torch.nn.Module,
+    ), f"Expected {dst} to be a nn.Module"
+    # Share state (params, buffers) between modules.
+    # This ensures that state mutations are visible across them.
+    # Since tensor constants are not mutable, copying (without sharing) is OK.
+    # Also, primitive constants are specialized, so copying (without sharing) is OK.
+    self._params = method.__self__._params
+    self._buffers = method.__self__._buffers
+
+
+def sync_state(*wrapped_method_modules):
+    """
+    Sync state between exported modules corresponding to wrapped methods.
+    This might be necessary after serializing/deserializing due to copying.
+    """
+    if wrapped_method_modules:
+        m, *other_ms = wrapped_method_modules
+        for other_m in other_ms:
+            _sync_state(m, other_m)
+
+
 class _WrappedMethod(torch.nn.Module):
     def __init__(self, method):
         super().__init__()
-        self._buffers = method.__self__._buffers
+        # share state of method's self module
+        _sync_state(method.__self__, self)
+        # redirect forward to method
         self.forward = method
 
 
 def wrap_method(method):
-    assert ismethod(method)
+    """
+    Wrap a method as a module so that it can be exported.
+    The wrapped module's forward points to the method, and
+    the method's original module state is shared.
+    """
+    assert ismethod(
+        method,
+    ), f"Expected {method} to be a method"
     return _WrappedMethod(method)

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -10,7 +10,7 @@ import operator
 import re
 from collections.abc import Iterable
 from contextlib import contextmanager
-from inspect import Parameter
+from inspect import ismethod, Parameter
 from typing import Any, Callable, Optional, TYPE_CHECKING, Union
 
 import torch
@@ -1350,3 +1350,15 @@ def register_module_as_pytree_input_node(cls: type[torch.nn.Module]) -> None:
 def deregister_module_as_pytree_input_node(cls: type[torch.nn.Module]) -> None:
     _deregister_pytree_node(cls)
     _deregister_pytree_flatten_spec(cls)
+
+
+class _WrappedMethod(torch.nn.Module):
+    def __init__(self, method):
+        super().__init__()
+        self._buffers = method.__self__._buffers
+        self.forward = method
+
+
+def wrap_method(method):
+    assert ismethod(method)
+    return _WrappedMethod(method)

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -1365,8 +1365,8 @@ def _sync_state(src, dst):
     # This ensures that state mutations are visible across them.
     # Since tensor constants are not mutable, copying (without sharing) is OK.
     # Also, primitive constants are specialized, so copying (without sharing) is OK.
-    self._params = method.__self__._params
-    self._buffers = method.__self__._buffers
+    dst._parameters = src._parameters
+    dst._buffers = src._buffers
 
 
 def sync_state(*wrapped_method_modules):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147573

The `export` API takes a `nn.Module` and traces its `forward` method. However sometimes it is useful to export different methods of a `nn.Module`, either as a one-off for debugging or as a set of methods that are called in some sequence outside `export` (e.g., `encode` / `decode`). When multiple methods of the same module instance are exported, they should share the same of the common module instance. 

This PR adds a couple of utils in `torch._export.utils` for this workflow. 

The `wrap_method` util wraps a method as a `nn.Module` that can then be exported. See included test. We recommend using the same module instance to export multiple methods on that instance, in which case they are guaranteed to share  state. On serde, this state sharing is lost, so we provide another util, `sync_state`, to re-sync the state.

These utils are meant to be eventually replaced by API-level changes, but for now this can unblock users who need this workflow. In particular, in the future we can accept one or multiple method entrypoints, with their own args / kwargs / dynamic shape specifications, which can create a variant of `ExportedProgram` with multiple graphs that share state; then we can automatically ensure that the state sharing is preserved through serde.

Differential Revision: [D69960801](https://our.internmc.facebook.com/intern/diff/D69960801/)
@diff-train-skip-merge