### PR TITLE
[export] don't use unbacked_renamings in export

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -786,6 +786,46 @@ class TestDeserialize(TestCase):
 
             self.check_graph(M(), (torch.randn(3), torch.randn(3), torch.randn(3)))
 
+    def test_unbacked_bindings_serialize(self):
+        from torch._export.utils import _get_shape_env_from_gm
+        from torch.utils._sympy.symbol import prefix_str, symbol_is_type, SymT
+
+        class M(torch.nn.Module):
+            def forward(self, x, y):
+                x += 2
+                n = x.item()
+                n = n * 2 + y.item()
+                return n + 2
+
+        inps = (
+            torch.tensor(4),
+            torch.tensor(5),
+        )
+        for _strict in [True, False]:
+            ep = torch.export.export(M(), inps, strict=_strict).run_decompositions()
+
+            # check bindings after deserialization
+            buffer = io.BytesIO()
+            save(ep, buffer)
+            buffer.seek(0)
+            loaded_ep = load(buffer)
+            bound = set()
+            for old_node, new_node in zip(ep.graph.nodes, loaded_ep.graph.nodes):
+                self.assertEqual(
+                    "unbacked_bindings" in old_node.meta,
+                    "unbacked_bindings" in new_node.meta,
+                )
+                bound.update(new_node.meta.get("unbacked_bindings", {}))
+
+            # check ShapeEnv counters
+            shape_env = _get_shape_env_from_gm(loaded_ep.graph_module)
+            next_index = next(shape_env.unbacked_symint_counter)
+            for symbol in bound:
+                self.assertTrue(symbol_is_type(symbol, SymT.UNBACKED_INT))
+                self.assertTrue(
+                    int(str(symbol)[len(prefix_str[SymT.UNBACKED_INT]) :]) < next_index
+                )
+
     def test_sym_bool_dynamic_shapes(self) -> None:
         class MyModule(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -434,6 +434,46 @@ def _remap_constants(
                 constants[target] = constant
 
 
+def _replace_unbacked_bindings(gm: torch.fx.GraphModule) -> None:
+    """
+    When we run an interpreter-based pass over a GraphModule, execution of data-dependent operators
+    will produce example values with new unbacked symbols. To track that the new/old symbols are equivalent,
+    we used to rely on the unbacked_renamings mapping. This led to problematic metadata where the unbacked_bindings
+    keys mapped new symbols (u2) to paths containing old symbols (u0) in the example values, or worse, backed symbols
+    or constants (e.g. if the original unbacked was replaced/specialized). Additionally this created problems with
+    de/serialized programs, since we didn't comprehensively serialize ShapeEnv/unbacked renamings/node bindings.
+
+    This pass attempts a simpler way of handling these for export, by throwing away the previously computed bindings, and re-running
+    the pattern match used in compute_unbacked_bindings. This ensures we keep the original symbols contained in the example values,
+    or delete bindings if they've been replaced/specialized.
+    """
+    from torch._export.utils import _get_shape_env_from_gm
+    from torch.fx.experimental.symbolic_shapes import _free_unbacked_symbols_with_path
+    from torch.utils._sympy.symbol import symbol_is_type, SymT
+
+    if (shape_env := _get_shape_env_from_gm(gm)) is None:
+        return
+
+    base_unbacked_symbols = {
+        symbol
+        for symbol in shape_env.var_to_range
+        if symbol_is_type(symbol, (SymT.UNBACKED_INT, SymT.UNBACKED_FLOAT))
+        and symbol not in shape_env.unbacked_renamings
+    }
+    for node in gm.graph.nodes:
+        node.meta.pop("unbacked_bindings", None)
+        if (val := node.meta.get("val")) is not None and (
+            unbacked_bindings := _free_unbacked_symbols_with_path(
+                val,
+                (),
+                shape_env=shape_env,
+                pending=base_unbacked_symbols,
+                simplify=True,
+            )
+        ):
+            node.meta["unbacked_bindings"] = unbacked_bindings
+
+
 def _produce_aten_artifact(
     *,
     gm: torch.fx.GraphModule,
@@ -462,6 +502,11 @@ def _produce_aten_artifact(
     # Overwrite output specs afterwards.
     flat_fake_args = pytree.tree_leaves((fake_args, fake_kwargs))
     gm, graph_signature = apply_runtime_assertion_pass(gm, graph_signature)
+
+    # Simplify unbacked_bindings by recomputing them.
+    # Useful for any pass that's interpreter-based and might call rebind_unbacked(),
+    # e.g. AOTAutograd in this case.
+    _replace_unbacked_bindings(gm)
 
     total_non_user_inputs = (
         len(graph_signature.parameters)
@@ -1397,22 +1442,6 @@ def _strict_export_lower_to_aten_ir(
     gm = aten_export_artifact.gm
     export_graph_signature = aten_export_artifact.sig
     constants = aten_export_artifact.constants
-
-    # update unbacked bindings that might have gone out of sync
-    # between Dynamo and AOTAutograd
-    for node in gm.graph.nodes:
-        if "unbacked_bindings" in node.meta:
-            old_unbacked_bindings = node.meta["unbacked_bindings"]
-            val = node.meta["val"]
-            new_unbacked_bindings = {}
-            for key in old_unbacked_bindings.values():
-                expr = pytree.key_get(val, key).node.expr
-                if expr.is_symbol:
-                    new_unbacked_bindings[expr] = key
-            if new_unbacked_bindings:
-                node.meta["unbacked_bindings"] = new_unbacked_bindings
-            else:
-                del node.meta["unbacked_bindings"]
 
     _populate_param_buffer_metadata_to_new_gm(
         params_buffers_to_node_meta, gm, export_graph_signature

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -943,6 +943,162 @@ class DivideByKey:
         return o // self.divisor
 
 
+def _free_unbacked_symbols_with_path(
+    a: object,
+    path: pytree.KeyPath,
+    real: Optional[object] = None,
+    shape_env: Optional[ShapeEnv] = None,
+    pending: Optional[set[sympy.Symbol]] = None,
+    simplify: bool = False,
+) -> dict[sympy.Symbol, pytree.KeyPath]:
+    go = functools.partial(
+        _free_unbacked_symbols_with_path,
+        shape_env=shape_env,
+        pending=pending,
+        simplify=simplify,
+    )
+
+    def expr(s: Union[SymInt, SymFloat, SymBool]) -> sympy.Expr:
+        if simplify:
+            return s.node.expr
+        # (When called from compute_unbacked_bindings)
+        # NB: Intentionally access _expr, not expr, do not want
+        # simplification!
+        return s.node._expr
+
+    if pending is None:
+        pending = set()
+    r = {}
+    if isinstance(a, (tuple, list)):
+        # NB: real is apparently not always a tuple/list here
+        # python test/inductor/test_torchinductor.py CpuTests.test_index_propagation_nested_indirect_indexing_cpu
+        for i in range(len(a)):
+            r.update(
+                go(
+                    a[i],
+                    path + (pytree.SequenceKey(i),),
+                    real=real[i] if real is not None else None,  # type: ignore[index]
+                )
+            )
+    elif is_traceable_wrapper_subclass(a):
+        # TODO: Determine if this is correct
+        attrs, _ = a.__tensor_flatten__()
+        for attr in attrs:
+            sub = getattr(a, attr)
+            r.update(go(sub, path + (InnerTensorKey(attr),)))
+    elif isinstance(a, torch.Tensor):
+        from torch._subclasses.fake_tensor import FakeTensor
+
+        assert isinstance(a, FakeTensor)
+        r.update(
+            go(
+                a.size(),
+                path + (CallMethodKey("size"),),
+                real=a.real_tensor.size() if a.real_tensor is not None else None,
+            )
+        )
+        if a.layout not in [
+            torch.sparse_csr,
+            torch.sparse_csc,
+            torch.sparse_bsr,
+            torch.sparse_bsc,
+        ]:
+            r.update(
+                go(
+                    a.stride(),
+                    path + (CallMethodKey("stride"),),
+                    real=a.real_tensor.stride() if a.real_tensor is not None else None,
+                )
+            )
+        r.update(
+            go(
+                a.storage_offset(),
+                path + (CallMethodKey("storage_offset"),),
+                real=(
+                    a.real_tensor.storage_offset()
+                    if a.real_tensor is not None
+                    else None
+                ),
+            )
+        )
+
+    elif (
+        isinstance(a, (torch.SymInt, torch.SymFloat))
+        and isinstance(s := expr(a), sympy.Symbol)
+        and s in pending
+    ):
+        r[s] = path
+        if shape_env and real is not None:
+            assert isinstance(real, (int, float))
+            shape_env.set_unbacked_var_to_val(s, real)
+        pending.remove(s)
+    # When an unbacked SymInt is perfectly divisible by an integer
+    # constant, we replace it with the integer constant to improve
+    # reasoning capabilities.  However, in synthetic examples, it is
+    # then possible that the factor never is explicitly allocated.
+    # Fortunately, we can compute it by division.
+    elif (
+        isinstance(a, torch.SymInt)
+        and isinstance(s := expr(a), sympy.Mul)
+        and len(s.args) == 2
+        and isinstance(lhs := s.args[0], (sympy.Integer, sympy.Symbol))
+        and isinstance(rhs := s.args[1], sympy.Symbol)
+        # support exactly one unbacked for now
+        and ((rhs in pending) ^ (lhs in pending))
+        # support constant coefficient or backed symbolic coefficient
+        and (
+            isinstance(coeff := lhs if lhs not in pending else rhs, sympy.Integer)
+            or shape_env
+            and coeff in shape_env.var_to_val
+        )
+    ):
+
+        def _symint_wrap(s: sympy.Symbol) -> SymInt:
+            return shape_env.create_symintnode(  # type: ignore[union-attr]
+                s,
+                hint=int(shape_env.var_to_val[s]),  # type: ignore[union-attr]
+                source=shape_env.var_to_sources.get(s, [None])[0],  # type: ignore[union-attr]
+            )
+
+        unbacked = lhs if lhs in pending else rhs
+        divisor: Union[int, SymInt] = (
+            int(coeff)
+            if shape_env and isinstance(coeff, sympy.Integer)
+            else _symint_wrap(coeff)
+        )
+        # TODO: DivideByKey needs to test divisibility at runtime!
+        r[unbacked] = path + (DivideByKey(divisor),)
+        if real is not None:
+            assert isinstance(real, int)
+            val = (
+                real // int(coeff)
+                if isinstance(coeff, sympy.Integer)
+                else CleanDiv(real, coeff)
+            )
+            if shape_env:
+                shape_env.set_unbacked_var_to_val(unbacked, val)
+        pending.remove(unbacked)
+    # The annoyance here arises from the fact that SymBool is
+    # allocated by allocating a SymInt and then testing if it's equal
+    # to one.  So you have a complicated binding site logic for this.
+    elif (
+        isinstance(a, torch.SymBool)
+        and isinstance(s := expr(a), sympy.Eq)
+        # This must match create_unbacked_symbool EXACTLY
+        and isinstance(s.lhs, sympy.Symbol)
+        and s.rhs == 1
+        and s.lhs in pending
+    ):
+        r[s.lhs] = path + (ConvertIntKey(),)
+        if real is not None:
+            assert type(real) is bool
+            if shape_env:
+                shape_env.set_unbacked_var_to_val(s, int(real))
+        pending.remove(s.lhs)
+
+    return r
+
+
 def compute_unbacked_bindings(
     shape_env: Optional[ShapeEnv],
     example_value: object,
@@ -974,134 +1130,9 @@ def compute_unbacked_bindings(
         log.info("compute_unbacked_bindings %s", fs)
         fs.clear()
 
-    def free_unbacked_symbols_with_path(
-        a: object, path: pytree.KeyPath, real: Optional[object] = None
-    ) -> dict[sympy.Symbol, pytree.KeyPath]:
-        assert shape_env is not None
-        r = {}
-        if isinstance(a, (tuple, list)):
-            # NB: real is apparently not always a tuple/list here
-            # python test/inductor/test_torchinductor.py CpuTests.test_index_propagation_nested_indirect_indexing_cpu
-            for i in range(len(a)):
-                r.update(
-                    free_unbacked_symbols_with_path(
-                        a[i],
-                        path + (pytree.SequenceKey(i),),
-                        real=real[i] if real is not None else None,  # type: ignore[index]
-                    )
-                )
-        elif is_traceable_wrapper_subclass(a):
-            # TODO: Determine if this is correct
-            attrs, _ = a.__tensor_flatten__()
-            for attr in attrs:
-                sub = getattr(a, attr)
-                r.update(
-                    free_unbacked_symbols_with_path(sub, path + (InnerTensorKey(attr),))
-                )
-        elif isinstance(a, torch.Tensor):
-            from torch._subclasses.fake_tensor import FakeTensor
-
-            assert isinstance(a, FakeTensor)
-            r.update(
-                free_unbacked_symbols_with_path(
-                    a.size(),
-                    path + (CallMethodKey("size"),),
-                    real=a.real_tensor.size() if a.real_tensor is not None else None,
-                )
-            )
-            r.update(
-                free_unbacked_symbols_with_path(
-                    a.stride(),
-                    path + (CallMethodKey("stride"),),
-                    real=a.real_tensor.stride() if a.real_tensor is not None else None,
-                )
-            )
-            r.update(
-                free_unbacked_symbols_with_path(
-                    a.storage_offset(),
-                    path + (CallMethodKey("storage_offset"),),
-                    real=(
-                        a.real_tensor.storage_offset()
-                        if a.real_tensor is not None
-                        else None
-                    ),
-                )
-            )
-
-        # NB: Intentionally access _expr, not expr, do not want
-        # simplification!
-        elif (
-            isinstance(a, (torch.SymInt, torch.SymFloat))
-            and isinstance(s := a.node._expr, sympy.Symbol)
-            and s in pending
-        ):
-            r[s] = path
-            if real is not None:
-                assert isinstance(real, (int, float))
-                shape_env.set_unbacked_var_to_val(s, real)
-            pending.remove(s)
-        # When an unbacked SymInt is perfectly divisible by an integer
-        # constant, we replace it with the integer constant to improve
-        # reasoning capabilities.  However, in synthetic examples, it is
-        # then possible that the factor never is explicitly allocated.
-        # Fortunately, we can compute it by division.
-        elif (
-            isinstance(a, torch.SymInt)
-            and isinstance(s := a.node._expr, sympy.Mul)
-            and len(s.args) == 2
-            and isinstance(lhs := s.args[0], (sympy.Integer, sympy.Symbol))
-            and isinstance(rhs := s.args[1], sympy.Symbol)
-            # support exactly one unbacked for now
-            and ((rhs in pending) ^ (lhs in pending))
-            # support constant coefficient or backed symbolic coefficient
-            and (
-                isinstance(coeff := lhs if lhs not in pending else rhs, sympy.Integer)
-                or coeff in a.node.shape_env.var_to_val
-            )
-        ):
-
-            def _symint_wrap(s: sympy.Symbol) -> SymInt:
-                return a.node.shape_env.create_symintnode(
-                    s,
-                    hint=int(a.node.shape_env.var_to_val[s]),
-                    source=a.node.shape_env.var_to_sources.get(s, [None])[0],
-                )
-
-            unbacked = lhs if lhs in pending else rhs
-            divisor: Union[int, SymInt] = (
-                int(coeff) if isinstance(coeff, sympy.Integer) else _symint_wrap(coeff)
-            )
-            # TODO: DivideByKey needs to test divisibility at runtime!
-            r[unbacked] = path + (DivideByKey(divisor),)
-            if real is not None:
-                assert isinstance(real, int)
-                val = (
-                    real // int(coeff)
-                    if isinstance(coeff, sympy.Integer)
-                    else CleanDiv(real, coeff)
-                )
-                shape_env.set_unbacked_var_to_val(unbacked, val)
-            pending.remove(unbacked)
-        # The annoyance here arises from the fact that SymBool is
-        # allocated by allocating a SymInt and then testing if it's equal
-        # to one.  So you have a complicated binding site logic for this.
-        elif (
-            isinstance(a, torch.SymBool)
-            and isinstance(s := a.node._expr, sympy.Eq)
-            # This must match create_unbacked_symbool EXACTLY
-            and isinstance(s.lhs, sympy.Symbol)
-            and s.rhs == 1
-            and s.lhs in pending
-        ):
-            r[s.lhs] = path + (ConvertIntKey(),)
-            if real is not None:
-                assert type(real) is bool
-                shape_env.set_unbacked_var_to_val(s, int(real))
-            pending.remove(s.lhs)
-
-        return r
-
-    symbol_to_path = free_unbacked_symbols_with_path(example_value, ())
+    symbol_to_path = _free_unbacked_symbols_with_path(
+        example_value, (), shape_env=shape_env, pending=pending, simplify=False
+    )
     if not peek and pending:
         extra = (
             repr((example_value.stride(), example_value.storage_offset()))


### PR DESCRIPTION
Plan: avoid the use of unbacked renamings, and introduce a pass run in `_produce_aten_artifact` that recomputes unbacked bindings. Decided to do this because in we don't serialize unbacked renamings (or any ShapeEnv state), so this used to compose poorly with de/serialization. This hopefully establishes the invariant that the unbacked binding keys are always in sync with the example values (i.e. same indices, and removed if the symbol is replaced / specialized).

For de/serialization, we don't stored unbacked bindings, and just rerun the pass.

Involved a refactor of compute_unbacked_bindings.

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv