### PR TITLE
[ONNX][demo] Rotary embedding

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -22,7 +22,7 @@ class Model(torch.nn.Module):
         # It is also possible to specify the overload:
         # torch.ops.onnx.RotaryEmbedding.opset23
         return torch.ops.onnx.RotaryEmbedding(
-            input_data, cos_cache_data, sin_cache_data, position_ids_data
+            input_data, cos_cache_data, sin_cache_data, position_ids_data, interleaved=True
         )
 
 

--- a/demo.py
+++ b/demo.py
@@ -1,6 +1,7 @@
 import torch
 import torch.onnx._internal.ops._impl
 
+
 input_data = torch.rand(2, 3, 4, 8)
 position_ids_data = torch.randint(0, 50, (2, 3)).long()
 sin_cache_data = torch.rand(50, 4)

--- a/demo.py
+++ b/demo.py
@@ -28,9 +28,19 @@ class Model(torch.nn.Module):
 
 model = Model()
 
+# Dynamic shapes are supported
+dynamic_shapes = {
+    "input_data": {0: torch.export.Dim.DYNAMIC},
+    "cos_cache_data": None,
+    "sin_cache_data": None,
+    "position_ids_data": {0: torch.export.Dim.DYNAMIC},
+}
+
 # The program can be exported with the onnx op preserved
 ep = torch.export.export(
-    model, (input_data, cos_cache_data, sin_cache_data, position_ids_data)
+    model,
+    (input_data, cos_cache_data, sin_cache_data, position_ids_data),
+    dynamic_shapes=dynamic_shapes,
 )
 print("ep", ep)
 
@@ -40,6 +50,104 @@ print("aten_decomped", aten_decomped)
 
 # It can be exported to ONNX without any additional registration
 onnx_program = torch.onnx.export(
-    model, (input_data, cos_cache_data, sin_cache_data, position_ids_data), dynamo=True
+    model,
+    (input_data, cos_cache_data, sin_cache_data, position_ids_data),
+    dynamo=True,
+    dynamic_shapes=dynamic_shapes,
 )
 print("onnx", onnx_program.model)
+
+"""
+output:
+
+torch.Size([2, 3, 4, 8])
+/home/justinchu/dev/pytorch/torch/backends/mkldnn/__init__.py:78: UserWarning: TF32 acceleration on top of oneDNN is available for Intel GPUs. The current Torch version does not have Intel GPU Support. (Triggered internally at /home/justinchu/dev/pytorch/aten/src/ATen/Context.cpp:148.)
+  torch._C._set_onednn_allow_tf32(_allow_tf32)
+/home/justinchu/dev/pytorch/torch/backends/mkldnn/__init__.py:78: UserWarning: TF32 acceleration on top of oneDNN is available for Intel GPUs. The current Torch version does not have Intel GPU Support. (Triggered internally at /home/justinchu/dev/pytorch/aten/src/ATen/Context.cpp:148.)
+  torch._C._set_onednn_allow_tf32(_allow_tf32)
+ep ExportedProgram:
+    class GraphModule(torch.nn.Module):
+        def forward(self, input_data: "f32[s0, 3, 4, 8]", cos_cache_data: "f32[50, 4]", sin_cache_data: "f32[50, 4]", position_ids_data: "i64[s0, 3]"):
+             # File: /home/justinchu/dev/pytorch/demo.py:24 in forward, code: return torch.ops.onnx.RotaryEmbedding(
+            rotary_embedding: "f32[s0, 3, 4, 8]" = torch.ops.onnx.RotaryEmbedding.opset23(input_data, cos_cache_data, sin_cache_data, position_ids_data);  input_data = cos_cache_data = sin_cache_data = position_ids_data = None
+            return (rotary_embedding,)
+
+Graph signature: ExportGraphSignature(input_specs=[InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='input_data'), target=None, persistent=None), InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='cos_cache_data'), target=None, persistent=None), InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='sin_cache_data'), target=None, persistent=None), InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='position_ids_data'), target=None, persistent=None)], output_specs=[OutputSpec(kind=<OutputKind.USER_OUTPUT: 1>, arg=TensorArgument(name='rotary_embedding'), target=None)])
+Range constraints: {s0: VR[2, int_oo]}
+
+/home/justinchu/dev/pytorch/torch/backends/mkldnn/__init__.py:78: UserWarning: TF32 acceleration on top of oneDNN is available for Intel GPUs. The current Torch version does not have Intel GPU Support. (Triggered internally at /home/justinchu/dev/pytorch/aten/src/ATen/Context.cpp:148.)
+  torch._C._set_onednn_allow_tf32(_allow_tf32)
+aten_decomped ExportedProgram:
+    class GraphModule(torch.nn.Module):
+        def forward(self, input_data: "f32[s0, 3, 4, 8]", cos_cache_data: "f32[50, 4]", sin_cache_data: "f32[50, 4]", position_ids_data: "i64[s0, 3]"):
+             # File: /home/justinchu/dev/pytorch/demo.py:24 in forward, code: return torch.ops.onnx.RotaryEmbedding(
+            slice_1: "f32[s0, 3, 4, 8]" = torch.ops.aten.slice.Tensor(input_data, 0, 0, 9223372036854775807)
+            slice_2: "f32[s0, 3, 4, 8]" = torch.ops.aten.slice.Tensor(slice_1, 1, 0, 9223372036854775807);  slice_1 = None
+            slice_3: "f32[s0, 3, 4, 8]" = torch.ops.aten.slice.Tensor(slice_2, 2, 0, 9223372036854775807);  slice_2 = None
+            slice_4: "f32[s0, 3, 4, 8]" = torch.ops.aten.slice.Tensor(input_data, 0, 0, 9223372036854775807);  input_data = None
+            slice_5: "f32[s0, 3, 4, 8]" = torch.ops.aten.slice.Tensor(slice_4, 1, 0, 9223372036854775807);  slice_4 = None
+            slice_6: "f32[s0, 3, 4, 8]" = torch.ops.aten.slice.Tensor(slice_5, 2, 0, 9223372036854775807);  slice_5 = None
+            slice_7: "f32[s0, 3, 4, 0]" = torch.ops.aten.slice.Tensor(slice_6, 3, 8, 9223372036854775807);  slice_6 = None
+            index: "f32[s0, 3, 4]" = torch.ops.aten.index.Tensor(cos_cache_data, [position_ids_data]);  cos_cache_data = None
+            index_1: "f32[s0, 3, 4]" = torch.ops.aten.index.Tensor(sin_cache_data, [position_ids_data]);  sin_cache_data = position_ids_data = None
+            slice_8: "f32[s0, 3, 4]" = torch.ops.aten.slice.Tensor(index, 0, 0, 9223372036854775807);  index = None
+            slice_9: "f32[s0, 3, 4]" = torch.ops.aten.slice.Tensor(slice_8, 1, 0, 9223372036854775807);  slice_8 = None
+            slice_10: "f32[s0, 3, 4]" = torch.ops.aten.slice.Tensor(index_1, 0, 0, 9223372036854775807);  index_1 = None
+            slice_11: "f32[s0, 3, 4]" = torch.ops.aten.slice.Tensor(slice_10, 1, 0, 9223372036854775807);  slice_10 = None
+            unsqueeze: "f32[s0, 3, 1, 4]" = torch.ops.aten.unsqueeze.default(slice_9, 2);  slice_9 = None
+            unsqueeze_1: "f32[s0, 3, 1, 4]" = torch.ops.aten.unsqueeze.default(slice_11, 2);  slice_11 = None
+            split = torch.ops.aten.split.Tensor(slice_3, 4, -1);  slice_3 = None
+            getitem: "f32[s0, 3, 4, 4]" = split[0]
+            getitem_1: "f32[s0, 3, 4, 4]" = split[1];  split = None
+            mul: "f32[s0, 3, 4, 4]" = torch.ops.aten.mul.Tensor(unsqueeze, getitem)
+            mul_1: "f32[s0, 3, 4, 4]" = torch.ops.aten.mul.Tensor(unsqueeze_1, getitem_1)
+            sub: "f32[s0, 3, 4, 4]" = torch.ops.aten.sub.Tensor(mul, mul_1);  mul = mul_1 = None
+            mul_2: "f32[s0, 3, 4, 4]" = torch.ops.aten.mul.Tensor(unsqueeze_1, getitem);  unsqueeze_1 = getitem = None
+            mul_3: "f32[s0, 3, 4, 4]" = torch.ops.aten.mul.Tensor(unsqueeze, getitem_1);  unsqueeze = getitem_1 = None
+            add: "f32[s0, 3, 4, 4]" = torch.ops.aten.add.Tensor(mul_2, mul_3);  mul_2 = mul_3 = None
+            cat: "f32[s0, 3, 4, 8]" = torch.ops.aten.cat.default([sub, add], -1);  sub = add = None
+            cat_1: "f32[s0, 3, 4, 8]" = torch.ops.aten.cat.default([cat, slice_7], -1);  cat = slice_7 = None
+            return (cat_1,)
+
+Graph signature: ExportGraphSignature(input_specs=[InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='input_data'), target=None, persistent=None), InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='cos_cache_data'), target=None, persistent=None), InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='sin_cache_data'), target=None, persistent=None), InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='position_ids_data'), target=None, persistent=None)], output_specs=[OutputSpec(kind=<OutputKind.USER_OUTPUT: 1>, arg=TensorArgument(name='cat_1'), target=None)])
+Range constraints: {s0: VR[2, int_oo]}
+
+/home/justinchu/anaconda3/envs/pytorch/lib/python3.12/site-packages/onnxscript/converter.py:820: FutureWarning: 'onnxscript.values.Op.param_schemas' is deprecated in version 0.1 and will be removed in the future. Please use '.op_signature' instead.
+  param_schemas = callee.param_schemas()
+/home/justinchu/anaconda3/envs/pytorch/lib/python3.12/site-packages/onnxscript/converter.py:820: FutureWarning: 'onnxscript.values.OnnxFunction.param_schemas' is deprecated in version 0.1 and will be removed in the future. Please use '.op_signature' instead.
+  param_schemas = callee.param_schemas()
+[torch.onnx] Obtain model graph for `Model()` with `torch.export.export(..., strict=False)`...
+/home/justinchu/dev/pytorch/torch/backends/mkldnn/__init__.py:78: UserWarning: TF32 acceleration on top of oneDNN is available for Intel GPUs. The current Torch version does not have Intel GPU Support. (Triggered internally at /home/justinchu/dev/pytorch/aten/src/ATen/Context.cpp:148.)
+  torch._C._set_onednn_allow_tf32(_allow_tf32)
+[torch.onnx] Obtain model graph for `Model()` with `torch.export.export(..., strict=False)`... ✅
+[torch.onnx] Run decomposition...
+/home/justinchu/dev/pytorch/torch/backends/mkldnn/__init__.py:78: UserWarning: TF32 acceleration on top of oneDNN is available for Intel GPUs. The current Torch version does not have Intel GPU Support. (Triggered internally at /home/justinchu/dev/pytorch/aten/src/ATen/Context.cpp:148.)
+  torch._C._set_onednn_allow_tf32(_allow_tf32)
+[torch.onnx] Run decomposition... ✅
+[torch.onnx] Translate the graph into ONNX...
+[torch.onnx] Translate the graph into ONNX... ✅
+onnx <
+    ir_version=10,
+    opset_imports={'pkg.onnxscript.torch_lib.common': 1, '': 18},
+    producer_name='pytorch',
+    producer_version='2.7.0a0+git5da00d7',
+    domain=None,
+    model_version=None,
+>
+graph(
+    name=main_graph,
+    inputs=(
+        %"input_data"<FLOAT,[s0,3,4,8]>,
+        %"cos_cache_data"<FLOAT,[50,4]>,
+        %"sin_cache_data"<FLOAT,[50,4]>,
+        %"position_ids_data"<INT64,[s0,3]>
+    ),
+    outputs=(
+        %"rotary_embedding"<FLOAT,[s0,3,4,8]>
+    ),
+) {
+    0 |  # rotary_embedding
+         %"rotary_embedding"<FLOAT,[s0,3,4,8]> ⬅️ ::RotaryEmbedding(%"input_data", %"cos_cache_data", %"sin_cache_data", %"position_ids_data")
+    return %"rotary_embedding"<FLOAT,[s0,3,4,8]>
+}
+"""

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,34 @@
+import torch
+import torch.onnx._internal.ops._impl
+
+input_data = torch.rand(2, 3, 4, 8)
+position_ids_data = torch.randint(0, 50, (2, 3)).long()
+sin_cache_data = torch.rand(50, 4)
+cos_cache_data = torch.rand(50, 4)
+
+result = torch.ops.onnx.RotaryEmbedding(
+    input_data, cos_cache_data, sin_cache_data, position_ids_data
+)
+print(result.shape)
+
+
+class Model(torch.nn.Module):
+    def forward(self, input_data, cos_cache_data, sin_cache_data, position_ids_data):
+        return torch.ops.onnx.RotaryEmbedding(
+            input_data, cos_cache_data, sin_cache_data, position_ids_data
+        )
+
+
+model = Model()
+ep = torch.export.export(
+    model, (input_data, cos_cache_data, sin_cache_data, position_ids_data)
+)
+print("ep", ep)
+
+aten_decomped = ep.run_decompositions(torch.onnx._internal.ops._impl._ONNX_DECOMP_TABLE)
+print("aten_decomped", aten_decomped)
+
+onnx_program = torch.onnx.export(
+    model, (input_data, cos_cache_data, sin_cache_data, position_ids_data), dynamo=True
+)
+print("onnx", onnx_program.model)

--- a/demo.py
+++ b/demo.py
@@ -7,6 +7,8 @@ position_ids_data = torch.randint(0, 50, (2, 3)).long()
 sin_cache_data = torch.rand(50, 4)
 cos_cache_data = torch.rand(50, 4)
 
+# Eager mode is supported. Autograd is also supported so users can choose to use the op
+# in development and production
 result = torch.ops.onnx.RotaryEmbedding(
     input_data, cos_cache_data, sin_cache_data, position_ids_data
 )
@@ -15,20 +17,28 @@ print(result.shape)
 
 class Model(torch.nn.Module):
     def forward(self, input_data, cos_cache_data, sin_cache_data, position_ids_data):
+        # Users can choose to use the ONNX op directly
+        # Opset version is automatically selected by the PyTorch dispatcher
+        # It is also possible to specify the overload:
+        # torch.ops.onnx.RotaryEmbedding.opset23
         return torch.ops.onnx.RotaryEmbedding(
             input_data, cos_cache_data, sin_cache_data, position_ids_data
         )
 
 
 model = Model()
+
+# The program can be exported with the onnx op preserved
 ep = torch.export.export(
     model, (input_data, cos_cache_data, sin_cache_data, position_ids_data)
 )
 print("ep", ep)
 
+# The program can be decomposed into aten ops so it is fully compatible with the PyTorch ecosystem
 aten_decomped = ep.run_decompositions(torch.onnx._internal.ops._impl._ONNX_DECOMP_TABLE)
 print("aten_decomped", aten_decomped)
 
+# It can be exported to ONNX without any additional registration
 onnx_program = torch.onnx.export(
     model, (input_data, cos_cache_data, sin_cache_data, position_ids_data), dynamo=True
 )

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -443,6 +443,8 @@ def _get_onnxscript_opset(opset_version: int) -> onnxscript.values.Opset:
 
 def _is_onnx_op(op: torch._ops.OpOverload) -> bool:
     """Whether the op overload is an ONNX custom op implemented with PyTorch."""
+    if not isinstance(op, torch._ops.OpOverload):
+        return False
     return op.name().startswith("onnx::")
 
 

--- a/torch/onnx/_internal/ops/_impl.py
+++ b/torch/onnx/_internal/ops/_impl.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Optional
 import torch
 import torch.fx
 
+
 _T = typing.TypeVar("_T", bound=Callable)
 
 _ONNX_DECOMP_TABLE = {}

--- a/torch/onnx/_internal/ops/_impl.py
+++ b/torch/onnx/_internal/ops/_impl.py
@@ -33,8 +33,8 @@ def _onnx_op(op_type: str, opset_version: int) -> Callable[[_T], _T]:
     return decorator
 
 
-@_onnx_op("RotaryEmbedding", 18)
-def rotary_embedding_18(
+@_onnx_op("RotaryEmbedding", 23)
+def rotary_embedding(
     input: torch.Tensor,
     cos_cache: torch.Tensor,
     sin_cache: torch.Tensor,

--- a/torch/onnx/_internal/ops/_impl.py
+++ b/torch/onnx/_internal/ops/_impl.py
@@ -1,0 +1,93 @@
+import typing
+from typing import Any, Callable, Optional
+
+import torch
+import torch.fx
+
+_T = typing.TypeVar("_T", bound=Callable)
+
+_ONNX_DECOMP_TABLE = {}
+
+
+def onnx_aten_decomp_table() -> dict[Any, Callable]:
+    """Return the ONNX to ATen decomp table."""
+    return _ONNX_DECOMP_TABLE
+
+
+def _register_op(func: _T) -> _T:
+    func_name = func.__name__
+    torch_op = torch.library.custom_op(f"onnx::{func_name}", mutates_args=())(func)
+    _ONNX_DECOMP_TABLE[getattr(torch.ops.onnx, func_name).default] = func
+    # Use the same implementation for the fake implementation
+    # This is possible because we use pure aten ops to implement ONNX ops
+    torch_op.register_fake(func)
+    return torch_op
+
+
+@_register_op
+def rotary_embedding(
+    input: torch.Tensor,
+    cos_cache: torch.Tensor,
+    sin_cache: torch.Tensor,
+    position_ids: Optional[torch.Tensor] = None,
+    interleaved: bool = False,
+    num_heads: int = 0,
+    rotary_embedding_dim: int = 0,
+) -> torch.Tensor:
+    # First ensure input has shape [batch_size, num_heads, seq_len, head_size]
+    batch_size = input.shape[0]
+    sequence_length = input.shape[1]
+    if len(input.shape) == 3:
+        hidden_size = input.shape[2]
+        assert num_heads != 0
+        head_size = int(hidden_size / num_heads)
+        new_shape = [batch_size, sequence_length, num_heads, head_size]
+        input = torch.reshape(input, new_shape)
+    assert len(input.shape) == 4
+    head_size = input.shape[3]
+
+    # Fully or partially perform rotation on input based on rotary_embedding_dim attribute
+    if rotary_embedding_dim == 0:
+        # If rotary_embedding_dim not provided, perform full rotation by using head_size
+        rotary_embedding_dim = head_size
+    x_rotate = input[:, :, :, :rotary_embedding_dim]
+    x_not_rotate = input[:, :, :, rotary_embedding_dim:]
+    rotary_embedding_dim_half = int(rotary_embedding_dim / 2)
+
+    # Retrieve sin and cos caches using position ids
+    if position_ids is not None:
+        cos = cos_cache[position_ids]  # Shape: [batch_size, sequence_length, head_size/2]
+        sin = sin_cache[position_ids]  # Shape: [batch_size, sequence_length, head_size/2]
+    else:
+        cos = cos_cache
+        sin = sin_cache
+    cos = cos[:, :, :rotary_embedding_dim_half]  # Shape: [batch_size, sequence_length, rotary_embedding_dim/2]
+    sin = sin[:, :, :rotary_embedding_dim_half]  # Shape: [batch_size, sequence_length, rotary_embedding_dim/2]
+    cos = torch.unsqueeze(cos, 2)  # Shape: [batch_size, sequence_length, 1, rotary_embedding_dim/2]
+    sin = torch.unsqueeze(sin, 2)  # Shape: [batch_size, sequence_length, 1, rotary_embedding_dim/2]
+
+    # Either divide the input in halves or interleave (based on interleaved attribute)
+    if interleaved:
+        x1 = x_rotate[:, :, :, 0::2]
+        x2 = x_rotate[:, :, :, 1::2]
+    else:
+        x1, x2 = torch.split(x_rotate, 2, dim=-1)
+
+    # Calculate real and imaginary values
+    real = cos * x1 - sin * x2
+    imag = sin * x1 + cos * x2
+
+    # Inserted rotated embeddings back to the original input
+    if interleaved:
+        # x_rotate[:, :, :, 0::2] = real
+        # x_rotate[:, :, :, 1::2] = imag
+        real = torch.unsqueeze(real,-1)
+        imag = torch.unsqueeze(imag,-1)
+        x_rotate_concat = torch.cat((real, imag), dim=-1)
+        x_rotate = torch.reshape(x_rotate_concat, x_rotate.shape)
+    else:
+        x_rotate = torch.cat((real, imag), dim=-1)
+    output = torch.cat((x_rotate, x_not_rotate), dim=-1)
+    if len(input.shape) == 3:
+        output = torch.reshape(output, input.shape)
+    return output

--- a/torch/onnx/_internal/ops/_impl.py
+++ b/torch/onnx/_internal/ops/_impl.py
@@ -39,6 +39,7 @@ def rotary_embedding(
     cos_cache: torch.Tensor,
     sin_cache: torch.Tensor,
     position_ids: Optional[torch.Tensor] = None,
+    *,
     interleaved: bool = False,
     num_heads: int = 0,
     rotary_embedding_dim: int = 0,


### PR DESCRIPTION
This change gives users the ability to use onnx ops directly with `torch.ops.onnx.*` and showcases an implementation for RotaryEmbedding. The operators are native pytorch which play well with the ecosystem.