### PR TITLE
[Easy][optim] Add LBFGS params optional desc

### DIFF
--- a/torch/optim/lbfgs.py
+++ b/torch/optim/lbfgs.py
@@ -201,17 +201,17 @@ class LBFGS(Optimizer):
 
     Args:
         params (iterable): iterable of parameters to optimize. Parameters must be real.
-        lr (float): learning rate (default: 1)
-        max_iter (int): maximal number of iterations per optimization step
+        lr (float, optional): learning rate (default: 1)
+        max_iter (int, optional): maximal number of iterations per optimization step
             (default: 20)
-        max_eval (int): maximal number of function evaluations per optimization
+        max_eval (int, optional): maximal number of function evaluations per optimization
             step (default: max_iter * 1.25).
-        tolerance_grad (float): termination tolerance on first order optimality
+        tolerance_grad (float, optional): termination tolerance on first order optimality
             (default: 1e-7).
-        tolerance_change (float): termination tolerance on function
+        tolerance_change (float, optional): termination tolerance on function
             value/parameter changes (default: 1e-9).
-        history_size (int): update history size (default: 100).
-        line_search_fn (str): either 'strong_wolfe' or None (default: None).
+        history_size (int, optional): update history size (default: 100).
+        line_search_fn (str, optional): either 'strong_wolfe' or None (default: None).
     """
 
     def __init__(


### PR DESCRIPTION
[LBFGS docs](https://pytorch.org/docs/stable/generated/torch.optim.LBFGS.html#torch.optim.LBFGS) missing `optional` description for params in compare with other optimizer docs, like [Adam](https://pytorch.org/docs/stable/generated/torch.optim.Adam.html)

## Test Result

### Before

![image](https://github.com/user-attachments/assets/34877490-16b4-4c68-bf6c-405bae563352)


### After

![image](https://github.com/user-attachments/assets/7fba94c8-7091-47b8-bdf1-ca7d779a027f)
