### PR TITLE
[cutlass backend] clear_on_fresh_inductor_cache when generatings cutlass ops

### DIFF
--- a/torch/_inductor/codegen/cuda/cutlass_utils.py
+++ b/torch/_inductor/codegen/cuda/cutlass_utils.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 import sympy
 
 import torch
+from torch._inductor.utils import clear_on_fresh_inductor_cache
 
 from ... import config
 from ...ir import Layout
@@ -170,6 +171,7 @@ class CUTLASSArgs:
         self.architectures = _normalize_cuda_arch(self.architectures)
 
 
+@clear_on_fresh_inductor_cache
 @functools.lru_cache(None)
 def _gen_ops_cached(arch, version) -> list[Any]:
     # Note: Cache needs to be specific for cuda architecture and version


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147586

Differential Revision: [D69966732](https://our.internmc.facebook.com/intern/diff/D69966732/)

This is needed if we want to generate cutlass ops with different instantiation level in one session.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov