### PR TITLE
[Triton 3.3] [ROCm] Enabled split_scan support for ROCm builds

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -108,6 +108,16 @@ else:
     CUDATemplate: TypeAlias = object
 
 
+try:
+    import triton
+    
+    triton_version = triton.__version__
+    has_triton = True
+except ImportError:
+    triton_version = None
+    has_triton = False
+
+
 _T = TypeVar("_T")
 _U = TypeVar("_U")
 _V = TypeVar("_V")
@@ -2186,8 +2196,10 @@ class Scan(Loops):
         scan_type = Scan
         if num_splits > 1:
             supports_split = (
-                torch.version.hip is None or triton_version < "3.3.0"
-            ) and len(dtypes) == 1
+                has_triton
+                and torch.version.hip is not None
+                and triton_version >= "3.3.0"
+            ) or (len(dtypes) == 1)
             if not supports_split:
                 if can_fallback_to_aten:
                     # Fallback to ATen

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2196,10 +2196,9 @@ class Scan(Loops):
         scan_type = Scan
         if num_splits > 1:
             supports_split = (
-                has_triton
-                and torch.version.hip is not None
-                and triton_version >= "3.3.0"
-            ) or (len(dtypes) == 1)
+                torch.version.hip is None
+                or (has_triton and triton_version >= "3.3.0")
+            ) and (len(dtypes) == 1)
             if not supports_split:
                 if can_fallback_to_aten:
                     # Fallback to ATen

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2185,7 +2185,9 @@ class Scan(Loops):
         )
         scan_type = Scan
         if num_splits > 1:
-            supports_split = len(dtypes) == 1
+            supports_split = (
+                torch.version.hip is None or triton_version < "3.3.0"
+            ) and len(dtypes) == 1
             if not supports_split:
                 if can_fallback_to_aten:
                     # Fallback to ATen

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -110,7 +110,7 @@ else:
 
 try:
     import triton
-    
+
     triton_version = triton.__version__
     has_triton = True
 except ImportError:

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2185,7 +2185,7 @@ class Scan(Loops):
         )
         scan_type = Scan
         if num_splits > 1:
-            supports_split = torch.version.hip is None and len(dtypes) == 1
+            supports_split = len(dtypes) == 1
             if not supports_split:
                 if can_fallback_to_aten:
                     # Fallback to ATen

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2196,8 +2196,7 @@ class Scan(Loops):
         scan_type = Scan
         if num_splits > 1:
             supports_split = (
-                torch.version.hip is None
-                or (has_triton and triton_version >= "3.3.0")
+                torch.version.hip is None or (has_triton and triton_version >= "3.3.0")
             ) and (len(dtypes) == 1)
             if not supports_split:
                 if can_fallback_to_aten:


### PR DESCRIPTION
Fixes issue https://github.com/pytorch/pytorch/issues/133228

Enabled split_scan support for ROCm builds.

Must be handled in a non BC breaking way so this functionality is enabled conditionalised on triton version.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov