### PR TITLE
[ROCm] change is_hip_clang() to always return True

### DIFF
--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -143,6 +143,7 @@ ignores = [
 
 ignores = [os.path.join(proj_dir, ignore) for ignore in ignores]
 
+
 # Check if the compiler is hip-clang.
 #
 # This used to be a useful function but now we can safely always assume hip-clang.

--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -143,15 +143,12 @@ ignores = [
 
 ignores = [os.path.join(proj_dir, ignore) for ignore in ignores]
 
-
 # Check if the compiler is hip-clang.
+#
+# This used to be a useful function but now we can safely always assume hip-clang.
+# Leaving the function here avoids bc-linter errors.
 def is_hip_clang() -> bool:
-    try:
-        hip_path = os.getenv("HIP_PATH", "/opt/rocm/hip")
-        with open(hip_path + "/lib/.hipInfo") as f:
-            return "HIP_COMPILER=clang" in f.read()
-    except OSError:
-        return False
+    return True
 
 
 # TODO Remove once the following submodules are updated


### PR DESCRIPTION
hipify is replacing kernel launchs <<< >>> with hipLaunchKernelGGL() macro and this is a regression caused by /opt/rocm/hip/.hipinfo no longer existing.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd