### PR TITLE
[BE] TCPStore: use typed errors for assertions

### DIFF
--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -246,7 +246,8 @@ TCPStore::TCPStore(std::string host, const TCPStoreOptions& opts)
   STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__init);
 
   if (opts.useLibUV) {
-    TORCH_CHECK(
+    TORCH_CHECK_WITH(
+        DistStoreError,
         ::c10d::detail::is_libuv_tcpstore_backend_available(),
         "use_libuv was requested but PyTorch was build without libuv support");
 
@@ -521,7 +522,8 @@ bool TCPStore::check(const std::vector<std::string>& keys) {
   if (response == detail::CheckResponseType::NOT_READY) {
     return false;
   }
-  TORCH_CHECK(false, "ready or not_ready response expected");
+  TORCH_CHECK_WITH(
+      DistStoreError, false, "ready or not_ready response expected");
 }
 
 void TCPStore::wait(const std::vector<std::string>& keys) {
@@ -558,7 +560,8 @@ void TCPStore::doWait(
       client_->receiveValueWithTimeout<detail::WaitResponseType>(timeout);
   if (response_opt.has_value()) {
     if (response_opt != detail::WaitResponseType::STOP_WAITING) {
-      TORCH_CHECK(false, "Stop_waiting response is expected");
+      TORCH_CHECK_WITH(
+          DistStoreError, false, "Stop_waiting response is expected");
     }
     return;
   }
@@ -573,12 +576,14 @@ void TCPStore::doWait(
   // this can happen if the server responds before we cancel, just ignore it
   if (response != detail::WaitResponseType::WAIT_CANCELED) {
     if (response != detail::WaitResponseType::STOP_WAITING) {
-      TORCH_CHECK(false, "Stop_waiting response is expected");
+      TORCH_CHECK_WITH(
+          DistStoreError, false, "Stop_waiting response is expected");
     }
 
     response = client_->receiveValue<detail::WaitResponseType>(); // ignore
     if (response != detail::WaitResponseType::WAIT_CANCELED) {
-      TORCH_CHECK(false, "wait_canceled response is expected");
+      TORCH_CHECK_WITH(
+          DistStoreError, false, "wait_canceled response is expected");
     }
   }
   C10_THROW_ERROR(
@@ -630,7 +635,8 @@ void TCPStore::multiSet(
     const std::vector<std::string>& keys,
     const std::vector<std::vector<uint8_t>>& values) {
   STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__multiSet);
-  TORCH_CHECK(
+  TORCH_CHECK_WITH(
+      DistStoreError,
       keys.size() == values.size(),
       "multiSet keys and values vectors must be of same size");
   const std::lock_guard<std::mutex> lock(activeOpLock_);

--- a/torch/csrc/distributed/c10d/exception.h
+++ b/torch/csrc/distributed/c10d/exception.h
@@ -12,13 +12,21 @@
 // Utility macro similar to C10_THROW_ERROR, the major difference is that this
 // macro handles exception types defined in the c10d namespace, whereas
 // C10_THROW_ERROR requires an exception to be defined in the c10 namespace.
-#define C10D_THROW_ERROR(err_type, msg) \
-  throw ::c10d::err_type(               \
-      {__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, msg)
+#define C10D_THROW_ERROR(err_type, ...)                      \
+  throw ::c10d::err_type(                                    \
+      {__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, \
+      c10::str(__VA_ARGS__))
+
+#define C10D_CHECK_WITH(error_t, cond, ...)                         \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {                             \
+    C10D_THROW_ERROR(                                               \
+        error_t, TORCH_CHECK_MSG(cond, "", c10::str(__VA_ARGS__))); \
+  }
 
 namespace c10d {
 
 using c10::DistNetworkError;
+using c10::DistStoreError;
 
 class TORCH_API SocketError : public DistNetworkError {
   using DistNetworkError::DistNetworkError;


### PR DESCRIPTION
This is a follow up to #147465 that changes most TORCH_CHECK calls in TCPStore and TCPStoreLibUvBackend  to use typed exceptions instead of generic `TORCH_CHECK` calls which end up as RuntimeErrors in Python.

Test plan:

```
pytest test/distributed/test_store.py
```

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @c-p-i-o