### PR TITLE
Add super().setUp() to some test cases

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -693,6 +693,7 @@ class PyWorkTest(TestCase):
 
 class CompileTest(TestCase):
     def setUp(self):
+        super().setUp()
         # Allow testing aoti after torch.compile
         torch._inductor.config.triton.store_cubin = True
         torch._inductor.config.debug = True

--- a/test/export/test_draft_export.py
+++ b/test/export/test_draft_export.py
@@ -17,6 +17,7 @@ from torch.utils._pytree import tree_leaves
 
 class TestDraftExport(TestCase):
     def setUp(self):
+        super().setUp()
         init_torchbind_implementations()
 
         @torch._library.register_fake_class("_TorchScriptTesting::_TensorQueue")


### PR DESCRIPTION
I saw that their disabled issues were getting spammed with comments, meaning that they were still running in CI despite having a disable issue, so I added the super().setUp() call to check if there's a disable issue for them since they were missing it

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o