### PR TITLE
fix #145064 , added error checking for empty tensor in _pdist_forward

### DIFF
--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -242,6 +242,7 @@ Tensor _cdist_backward(const Tensor& _grad, const Tensor& _x1, const Tensor& _x2
 }
 
 Tensor _pdist_forward(const Tensor& self, const double p) {
+  TORCH_CHECK(self.numel()>0, "Input tensor is empty");
   TORCH_CHECK(self.is_contiguous(), "_pdist_forward requires contiguous input");
   auto device = self.device().type();
   TORCH_CHECK(device == kCPU || device == kCUDA || device == kXPU, "_pdist_forward only supports CPU, XPU and CUDA devices, got: ", device);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5194,7 +5194,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
     def test_pdist_empty_col(self):
         for device in device_():
             inp = torch.randn(4, 0, dtype=torch.double, device=device, requires_grad=True)
-            self.assertTrue(gradcheck(F.pdist, (inp,)))
+            self.assertRaises(RuntimeError, gradcheck, F.pdist, (inp,))
 
     @unittest.expectedFailure
     def test_pdist_cpu_gradgrad_unimplemented(self):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2416,15 +2416,15 @@ else:
     def test_pdist_empty(self, device):
         shape = (0, 2)
         x = torch.randn(shape, device=device)
-        self.assertEqual(torch.empty(0, device=device), torch.pdist(x))
+        self.assertRaises(RuntimeError, torch.pdist, x)
 
-        shape = (1, 2)
+        shape = (0, 0)
         x = torch.randn(shape, device=device)
-        self.assertEqual(torch.empty(0, device=device), torch.pdist(x))
+        self.assertRaises(RuntimeError, torch.pdist, x)
 
         shape = (3, 0)
         x = torch.randn(shape, device=device)
-        self.assertEqual(torch.zeros(3, device=device), torch.pdist(x))
+        self.assertRaises(RuntimeError, torch.pdist, x)
 
     def test_cdist_empty(self, device):
         x = torch.randn((0, 5), device=device)


### PR DESCRIPTION
Fixes #145064

Added TORCH_CHECK to prevent iterating over nullptr and causing segfault.
We can verify this by running the following simple test:
```python import torch

print(torch.__version__)
input = torch.rand((11, 15,3))
print("Running test with non empty tensor")
print("="*50)
print(torch.ops.aten._pdist_forward(input, p=2.0))
print("="*50)
print("Running test with empty tensor")
print("="*50)
input = torch.rand((11, 15, 0))
print(torch.ops.aten._pdist_forward(input, p=2.0))
```

# Before fix:
```2.7.0a0+git464e572
Running test with non empty tensor
==================================================
tensor([1.2083, 1.4906, 1.2710, 1.4653, 1.6329, 1.5641, 1.6864, 1.3509, 1.3771,
        1.8574, 0.9800, 1.5987, 1.4999, 1.4619, 1.6616, 1.7614, 1.3761, 1.3119,
        1.3935, 1.4656, 1.6993, 1.3452, 1.4604, 1.0390, 1.2662, 1.6565, 1.5740,
        1.3851, 1.8369, 1.6037, 1.5965, 1.3896, 1.1114, 1.4699, 1.6736, 1.5287,
        1.2168, 1.5095, 1.6844, 1.4027, 1.7431, 1.2226, 1.4504, 1.1963, 1.5279,
        1.2033, 1.1480, 1.2056, 1.0587, 1.3939, 1.3022, 1.5384, 1.3645, 1.6349,
        1.2800])
==================================================
Running test with empty tensor
==================================================
Segmentation fault (core dumped)
```

# After fix
```
2.7.0a0+git464e572
Running test with non empty tensor
==================================================
tensor([1.5208, 1.5068, 1.2832, 1.4650, 1.9227, 1.9052, 1.9649, 1.9571, 1.8125,
        1.7174, 1.8387, 1.6939, 1.6634, 1.8099, 1.3245, 1.7073, 1.4311, 1.8628,
        1.6667, 1.6101, 1.8348, 1.4548, 1.3954, 1.5973, 1.7277, 1.8505, 1.3647,
        1.6524, 1.6583, 0.9928, 1.2633, 1.5329, 1.7163, 1.2425, 1.3743, 2.0104,
        1.8953, 1.4519, 1.8834, 1.5887, 2.0280, 1.1968, 1.2921, 1.4689, 1.5236,
        1.7794, 1.4897, 1.5896, 1.6168, 1.6176, 1.6705, 1.8576, 1.5708, 1.2780,
        1.3247])
==================================================
Running test with empty tensor
==================================================
Traceback (most recent call last):
  File "/home/harid/test.py", line 12, in <module>
    print(torch.ops.aten._pdist_forward(input, p=2.0))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/harid/pytorch/torch/_ops.py", line 1156, in __call__
    return self._op(*args, **(kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Input tensor is empty
```
@albanD  , I had to close the previous PR because of accidentally merging main with my branch. Furthermore, I also updated test cases to reflect the changes, which were causing failures in the previous PR.