### PR TITLE
[bugfix][ez]: jit bugfix 3.10 version checking

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -1541,7 +1541,7 @@ def _get_model_id(obj) -> Optional[str]:
 # In Python-3.11+ typed enums (i.e. IntEnum for example) retain number of base class methods in subclass
 # that were previously dropped. To preserve the behavior, explicitly drop them there
 
-if sys.version_info > (3, 10):
+if sys.version_info >= (3, 11):
     _drop(enum.Enum.__new__)
     _drop(enum.Enum.__format__)
     _drop(enum.Enum.__repr__)


### PR DESCRIPTION
Caught by a ruff static linter check. Will be flagged when we update the version. This was enabling on any minor version of 3.10 when it should have only enabled on 3.11

cc @albanD