### PR TITLE
[Window] Fix invalid file path on windows.

### DIFF
--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -18,6 +18,7 @@ import enum
 import logging
 import os
 import pickle
+import re
 from collections import defaultdict
 from typing import Optional, TYPE_CHECKING, TypeVar, Union
 from typing_extensions import Self
@@ -500,7 +501,8 @@ def code_state_path(cache_key: str) -> Optional[str]:
 
     from torch._inductor.runtime.runtime_utils import cache_dir
 
-    return os.path.join(cache_dir(), "dynamo", f"code_state_{cache_key}.pkl")
+    code_state_key = re.sub(r'[<>:"/\\|?*]', "_", f"code_state_{cache_key}.pkl")
+    return os.path.join(cache_dir(), "dynamo", code_state_key)
 
 
 def should_use_remote_dynamo_pgo_cache() -> bool:
@@ -683,7 +685,7 @@ def write_local_impl(cache_key: str, pickled_code: bytes) -> Optional[tuple[str,
         with open(tmp_path, "wb") as f:
             f.write(pickled_code)
             size = f.tell()
-        os.rename(tmp_path, path)
+        os.replace(tmp_path, path)
     return path, size
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147708

This PR aims to fix the invalid path for windows: `C:\\Users\\sdp\\AppData\\Local\\Temp\\tmp0wugz2qm\\dynamo\\code_state___main__.TestFxGraphCache.test_cache_hot_load_pgo:None:.pkl.lock`
Windows does not allow chars `\ / : * ? " < > |` in a path.

And this PR also replace `os.rename` to `os.replace` in torch/_dynamo/pgo.py because `os.replace` allows target file exists on Windows, but not `os.rename` .
| Function                      | `os.rename()`              | `os.replace()`             |
|--------------------------------|----------------------------|----------------------------|
| Rename a file                 | ✅                          | ✅                          |
| Move a file                   | ✅                          | ✅                          |
| Overwrite an existing file     | ❌ (Error on Windows)       | ✅ (Will overwrite)         |
| Overwrite an existing directory | ❌ (Error on Windows)                         | ❌  (Error on Windows)                        |
| Move across disks             | ❌                          | ❌                          |




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames