### PR TITLE
fix simple-spec crash

### DIFF
--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_1.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_1.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_10.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_10.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_11.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_11.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_12.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_12.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_13.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_13.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_14.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_14.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_15.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_15.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_16.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_16.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_17.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_17.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_18.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_18.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_19.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_19.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_2.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_2.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_3.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_3.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_4.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_4.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_5.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_5.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_6.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_6.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_7.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_7.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_8.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_8.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_9.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_9.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/addmm_pattern.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/addmm_pattern.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/bmm_pattern.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/bmm_pattern.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/fx_passes/serialized_patterns/mm_pattern.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/mm_pattern.py
@@ -7,6 +7,7 @@
 
 import torch
 import torch._inductor
+import operator
 
 aten = torch.ops.aten
 prims = torch.ops.prims

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1513,7 +1513,11 @@ def _serialize_pattern(
         pattern_matcher_imports = []
         for name in dir(torch._inductor.pattern_matcher):
             attr = getattr(torch._inductor.pattern_matcher, name)
-            if name == "_SimpleSpec" or isinstance(attr, type) and issubclass(attr, (PatternExpr, _TargetExpr)):
+            try:
+                if issubclass(attr, (PatternExpr, _TargetExpr)):
+                    pattern_matcher_imports.append(name)
+            except TypeError:
+                pass
                 pattern_matcher_imports.append(name)
 
         formatted_imports = ",\n   ".join(pattern_matcher_imports)

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1513,7 +1513,7 @@ def _serialize_pattern(
         pattern_matcher_imports = []
         for name in dir(torch._inductor.pattern_matcher):
             attr = getattr(torch._inductor.pattern_matcher, name)
-            if isinstance(attr, type) and issubclass(attr, (PatternExpr, _TargetExpr)):
+            if name == "_SimpleSpec" or isinstance(attr, type) and issubclass(attr, (PatternExpr, _TargetExpr)):
                 pattern_matcher_imports.append(name)
 
         formatted_imports = ",\n   ".join(pattern_matcher_imports)

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1518,7 +1518,6 @@ def _serialize_pattern(
                     pattern_matcher_imports.append(name)
             except TypeError:
                 pass
-                pattern_matcher_imports.append(name)
 
         formatted_imports = ",\n   ".join(pattern_matcher_imports)
         formatted_imports = f"from torch._inductor.pattern_matcher import (\n   {formatted_imports},\n)\n"

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1514,7 +1514,9 @@ def _serialize_pattern(
         for name in dir(torch._inductor.pattern_matcher):
             attr = getattr(torch._inductor.pattern_matcher, name)
             try:
-                if isinstance(attr, type) and issubclass(attr, (PatternExpr, _TargetExpr)):
+                if isinstance(attr, type) and issubclass(
+                    attr, (PatternExpr, _TargetExpr)
+                ):
                     pattern_matcher_imports.append(name)
             except TypeError:
                 pass

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1514,7 +1514,7 @@ def _serialize_pattern(
         for name in dir(torch._inductor.pattern_matcher):
             attr = getattr(torch._inductor.pattern_matcher, name)
             try:
-                if issubclass(attr, (PatternExpr, _TargetExpr)):
+                if isinstance(attr, type) and issubclass(attr, (PatternExpr, _TargetExpr)):
                     pattern_matcher_imports.append(name)
             except TypeError:
                 pass


### PR DESCRIPTION
found an issue while running `python torchgen/fuse/gen_patterns.py`

exact error:
```shell
Traceback (most recent call last):
  File "/Users/mayankmishra/Desktop/non-IBM/pytorch/torchgen/fuse/gen_patterns.py", line 19, in <module>
    joint_graph.lazy_init()
  File "/Users/mayankmishra/miniconda3/envs/ai/lib/python3.10/site-packages/torch/_inductor/pattern_matcher.py", line 2096, in lazy_init
    result = fn()
  File "/Users/mayankmishra/miniconda3/envs/ai/lib/python3.10/site-packages/torch/_inductor/fx_passes/joint_graph.py", line 53, in lazy_init
    _pad_mm_init()
  File "/Users/mayankmishra/miniconda3/envs/ai/lib/python3.10/site-packages/torch/_inductor/fx_passes/pad_mm.py", line 905, in _pad_mm_init
    gen_register_replacement(
  File "/Users/mayankmishra/miniconda3/envs/ai/lib/python3.10/site-packages/torch/_inductor/pattern_matcher.py", line 1584, in gen_register_replacement
    pat = _serialize_pattern(
  File "/Users/mayankmishra/miniconda3/envs/ai/lib/python3.10/site-packages/torch/_inductor/pattern_matcher.py", line 1539, in _serialize_pattern
    file_template = get_file_template()
  File "/Users/mayankmishra/miniconda3/envs/ai/lib/python3.10/site-packages/torch/_inductor/pattern_matcher.py", line 1513, in get_file_template
    if isinstance(attr, type) and issubclass(attr, (PatternExpr, _TargetExpr)):
  File "/Users/mayankmishra/miniconda3/envs/ai/lib/python3.10/abc.py", line 123, in __subclasscheck__
    return _abc_subclasscheck(cls, subclass)
TypeError: issubclass() arg 1 must be a class
```

This PR fixes this issue.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov