### PR TITLE
Update CPU tolerance for f16 triplet margin loss

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -374,6 +374,7 @@ inductor_override_kwargs["cpu"] = {
         "atol": 3e-4,
         "rtol": 0.002,
     },
+    ("nn.functional.triplet_margin_loss", f16): {"atol": 3e-4, "rtol": 0.003},
     ("nn.functional.triplet_margin_with_distance_loss", f16): {
         "atol": 3e-4,
         "rtol": 0.003,


### PR DESCRIPTION
Currently, the `test_torchinductor_opinfo` test for `nn.functional.triplet_margin_loss` fails on AArch64, this PR increases the acceptable ATOL and RTOL for this test when using F16. There is precedent for this as XPU and CUDA already increase the tolerance. Additionally, the CPU backend increases the tolerance for the `with_distance_loss` variant of `triplet_margin_loss`. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov