### PR TITLE
Add sparse tensors constructed via legacy constructor to _sparse_tensors_to_validate

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -443,6 +443,33 @@ class SerializationMixin:
                         "size is inconsistent with indices"):
                     y = torch.load(f, weights_only=weights_only)
 
+    def test_serialization_sparse_invalid_legacy_ctor(self):
+        x = torch.zeros(3, 3)
+        x[1][1] = 1
+        x = x.to_sparse()
+        x_legacy_ctor = torch.sparse.FloatTensor(x.indices(), x.values())
+
+        # technically legacy ctor will still always be rebuilt with _rebuild_sparse_tensor
+        # this is to test that legacy ctor in data.pkl will be validated by weights_only unpickler
+        class LegacyCtorSerializationSpoofer:
+            def __init__(self, tensor):
+                self.tensor = tensor
+
+            def __reduce_ex__(self, proto):
+                indices = self.tensor._indices()
+                indices[0][0] = 3
+                return (torch.sparse.FloatTensor, (indices, self.tensor._values(), x.size()))
+
+        with tempfile.NamedTemporaryFile() as f:
+            sd = {"spoofed_legacy_ctor": LegacyCtorSerializationSpoofer(x_legacy_ctor)}
+            torch.save(sd, f)
+            for weights_only in (True,):
+                f.seek(0)
+                with self.assertRaisesRegex(
+                        RuntimeError,
+                        "size is inconsistent with indices"):
+                    y = torch.load(f, weights_only=weights_only)
+
     def _test_serialization_sparse_compressed_invalid(self,
                                                       conversion,
                                                       get_compressed_indices,


### PR DESCRIPTION
This is a redo of https://github.com/pytorch/pytorch/pull/147408 which added validation at the end of the legacy constructor calls.

The reason why I didn't land that was because in `legacy_load`, constructor would be called before storages of indices/values are set. So the tensor would not actually be validated.

Technically, torch.sparse.{Foo}Tensor should not even be called by our rebuild process since afaict this was the first PR that added support for sparse tensor serialization https://github.com/pytorch/pytorch/pull/27062 and it already uses `_rebuild_sparse_tensor` (which would add the rebuilt tensor to the list to validate), but torch.sparse.FooTensor is allowlisted

This PR adds tensors constructed as such to the list to validate at the end of torch.load.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147759

