### PR TITLE
[inductor][user triton] Handle scf.yield more accurately

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -2347,6 +2347,7 @@ class MutationTests(torch._inductor.test_case.TestCase):
             in_ptr0,
             in_ptr1,
             out_ptr,
+            conditional_ptr,
             n_elements,
             BLOCK_SIZE: "tl.constexpr",
         ):
@@ -2354,7 +2355,7 @@ class MutationTests(torch._inductor.test_case.TestCase):
             block_start = pid * BLOCK_SIZE
             offsets = block_start + tl.arange(0, BLOCK_SIZE)
             mask = offsets < n_elements
-            conditional = (n_elements % 2) == 0
+            conditional = tl.load(conditional_ptr)
             if conditional:
                 in0 = in_ptr0 + 1
                 in1 = in_ptr1 + 1
@@ -2370,12 +2371,14 @@ class MutationTests(torch._inductor.test_case.TestCase):
         x = torch.randn(15)
         y = torch.randn(15)
         out = torch.zeros(15)
+        conditional = torch.tensor(True)
         return (
             branch_with_multiple_yield_args,
             {
                 "in_ptr0": x,
                 "in_ptr1": y,
                 "out_ptr": out,
+                "conditional_ptr": conditional,
                 "n_elements": 14,
                 "BLOCK_SIZE": 16,
             },

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -2341,51 +2341,6 @@ class MutationTests(torch._inductor.test_case.TestCase):
     # Tests injected below
 
     @make_mutation_test
-    def test_branch_with_multiple_yield_args():
-        @triton.jit
-        def branch_with_multiple_yield_args(
-            in_ptr0,
-            in_ptr1,
-            out_ptr,
-            conditional_ptr,
-            n_elements,
-            BLOCK_SIZE: "tl.constexpr",
-        ):
-            pid = tl.program_id(axis=0)
-            block_start = pid * BLOCK_SIZE
-            offsets = block_start + tl.arange(0, BLOCK_SIZE)
-            mask = offsets < n_elements
-            conditional = tl.load(conditional_ptr)
-            if conditional:
-                in0 = in_ptr0 + 1
-                in1 = in_ptr1 + 1
-                out = out_ptr + 1
-            else:
-                in0 = in_ptr0
-                in1 = in_ptr1
-                out = out_ptr
-            x = tl.load(in0 + offsets, mask=mask)
-            y = tl.load(in1 + offsets, mask=mask)
-            tl.store(out + offsets, x + y, mask=mask)
-
-        x = torch.randn(15)
-        y = torch.randn(15)
-        out = torch.zeros(15)
-        conditional = torch.tensor(True)
-        return (
-            branch_with_multiple_yield_args,
-            {
-                "in_ptr0": x,
-                "in_ptr1": y,
-                "out_ptr": out,
-                "conditional_ptr": conditional,
-                "n_elements": 14,
-                "BLOCK_SIZE": 16,
-            },
-            ["out_ptr"],
-        )
-
-    @make_mutation_test
     def test_out_of_order_kernel():
         @triton.jit
         def add_kernel_out_of_order(
@@ -3039,6 +2994,51 @@ class MutationTests(torch._inductor.test_case.TestCase):
                 "BLOCK_N": N,
             },
             ["o_ptr"],
+        )
+
+    @make_mutation_test
+    def test_branch_with_multiple_yield_args():
+        @triton.jit
+        def branch_with_multiple_yield_args(
+            in_ptr0,
+            in_ptr1,
+            out_ptr,
+            conditional_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+        ):
+            pid = tl.program_id(axis=0)
+            block_start = pid * BLOCK_SIZE
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            conditional = tl.load(conditional_ptr)
+            if conditional:
+                in0 = in_ptr0 + 1
+                in1 = in_ptr1 + 1
+                out = out_ptr + 1
+            else:
+                in0 = in_ptr0
+                in1 = in_ptr1
+                out = out_ptr
+            x = tl.load(in0 + offsets, mask=mask)
+            y = tl.load(in1 + offsets, mask=mask)
+            tl.store(out + offsets, x + y, mask=mask)
+
+        x = torch.randn(15)
+        y = torch.randn(15)
+        out = torch.zeros(15)
+        conditional = torch.tensor(True)
+        return (
+            branch_with_multiple_yield_args,
+            {
+                "in_ptr0": x,
+                "in_ptr1": y,
+                "out_ptr": out,
+                "conditional_ptr": conditional,
+                "n_elements": 14,
+                "BLOCK_SIZE": 16,
+            },
+            ["out_ptr"],
         )
 
 

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -156,6 +156,8 @@ class Op:
     fn_call_name: Optional[str]
     args: list[Union[Param, Intermediate]]
     ret: Intermediate = dataclasses.field(repr=False)
+    # used for scf.yield: see [Note: scf.yield fix-up]
+    sub_idx: Optional[int] = None
 
     def __post_init__(self) -> None:
         if self.name == "tt.call":
@@ -505,9 +507,59 @@ def ttir_to_functions(
                             op_stack[parent_block_id][op_result].extend(child_ops)
 
                 scf_results = [Intermediate(idx) for idx in result_ids]
-                for scf_result in scf_results:
+
+                if return_ops and all(
+                    (op.name == "scf.yield" and len(result_ids) == len(op.args))
+                    for op in return_ops
+                ):
+                    # [Note: scf.yield fix-up]
+                    #
+                    # TL;DR: if our scf.yield takes N args, then we'll create N scf.yield ops to handle each of the
+                    # args.
+                    #
+                    #      **Context**:
+                    # During mutation analysis, the analysis pass will identify mutating ops (e.g. tt.store)
+                    # and then DFS upwards towards the parameters of the function. Specifically, the analysis pass
+                    # looks at the mutated arg in tt.store; then looks for its source ops; and then recurses on the
+                    # arguments to each of the source ops.
+                    #
+                    # In the case of scf.if/scf.for, we may have multiple return ops, each passed as an arg
+                    # to scf.yield:
+                    #
+                    # %18:2 = scf.if %... -> (!tt.ptr<f32>, !tt.ptr<f32>) {
+                    #   ...
+                    #   scf.yield %1, %2
+                    # } else {
+                    #   scf.yield %3, %4
+                    # }
+                    #
+                    # And for each of the returns of the scf.if, we'd naively assign the source op of each of the
+                    # return values to be the scf.yields. But the scf.yields take _all_ the returns as arguments.
+                    # Therefore, if _any_ of the return values of the scf.if are mutated, then the analysis pass
+                    # would mark _all_ of the yield args as mutated.
+                    #
+                    #      **Solution**:
+                    # For the purposes of this analysis pass, we create N yield ops - one for each
+                    # return-val/yield-arg. In the example above, we'll have two scf.yield's for each branch of the
+                    # scf.if.
+
                     for return_op in return_ops:
-                        op_stack[parent_block_id][scf_result].append(return_op)
+                        for i, (scf_result, yield_arg) in enumerate(
+                            zip(scf_results, return_op.args)
+                        ):
+                            sub_yield_op = Op(
+                                return_op.name,
+                                return_op.fn_call_name,
+                                [yield_arg],
+                                return_op.ret,
+                                sub_idx=i,
+                            )
+                            op_stack[parent_block_id][scf_result].append(sub_yield_op)
+
+                else:
+                    for scf_result in scf_results:
+                        for return_op in return_ops:
+                            op_stack[parent_block_id][scf_result].append(return_op)
             else:
                 raise RuntimeError(
                     f"Unknown blocked function: {name}. Can't capture the TTIR."


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147762

**TL;DR**: Previously, the mutation analysis for scf.if/scf.for would bundle all the scf.yield arguments into a single op (the scf.yield), such that a mutation on any returned value from the scf.if/scf.for would register as a mutation to _all_ of the scf.yield args. To fix this, this PR artificially introduces a new scf.yield op for each of the scf.yield args.

**Context**: The relevant kernel is something like this one (added as a test in test_triton_kernels.py)

```python
        @triton.jit
        def branch_with_multiple_yield_args(
            in_ptr0,
            in_ptr1,
            out_ptr,
            conditional_ptr,
            n_elements,
            BLOCK_SIZE: "tl.constexpr",
        ):
            pid = tl.program_id(axis=0)
            block_start = pid * BLOCK_SIZE
            offsets = block_start + tl.arange(0, BLOCK_SIZE)
            mask = offsets < n_elements
            conditional = tl.load(conditional_ptr)
            if conditional:
                in0 = in_ptr0 + 1
                in1 = in_ptr1 + 1
                out = out_ptr + 1
            else:
                in0 = in_ptr0
                in1 = in_ptr1
                out = out_ptr
            x = tl.load(in0 + offsets, mask=mask)
            y = tl.load(in1 + offsets, mask=mask)
            tl.store(out + offsets, x + y, mask=mask)
```

The mutation analysis starts with the `tl.store` - and then does a DFS backwards towards the parameters.  When a new op is encountered in the DFS, the analysis pass recurses on the op's arguments.

The if branch gets converted to TTIR like this:

```mlir
    %21:3 = scf.if %20 -> (!tt.ptr<f32>, !tt.ptr<f32>, !tt.ptr<f32>) {
      ...
      scf.yield %31, %32, %33 : !tt.ptr<f32>, !tt.ptr<f32>, !tt.ptr<f32> loc(#loc10)
    } else {
      scf.yield %arg0, %arg1, %arg2 : !tt.ptr<f32>, !tt.ptr<f32>, !tt.ptr<f32> loc(#loc11)
    } loc(#loc7)
```

and so the "source" op of the `out` variable is marked as the `scf.yield` op - and then all of the arguments to `scf.yield` are marked as mutable (including arg0, arg1, and arg2 - only one of which is actually mutated).

**This PR** we duplicate the `scf.yield` to add one `scf.yield` per return value. That way we avoid marking all the returns from the scf.if/scf.for as mutated when only some are.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @oulgen

Differential Revision: [D70118202](https://our.internmc.facebook.com/intern/diff/D70118202)