### PR TITLE
[SDPA] Respect `sdpa_kernel`'s `priority_order` setting in `torch.compile` 

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2982,7 +2982,14 @@ class TestSDPACudaOnly(NNTestCase):
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cuDNN Attention is not supported on this system")
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Platform does not support fused SDPA")
-    def test_fused_sdp_priority_order(self, device):
+    @parametrize("use_compile", [True, False])
+    def test_fused_sdp_priority_order(self, device, use_compile):
+        @torch.compile
+        def compiled_func(order):
+            with sdpa_kernel(order, set_priority=True):
+                out = scaled_dot_product_attention(q, q, q)
+            return out
+
         q = torch.randn(64, 8, 1024, 64, dtype=torch.half, device='cuda')
         default_order = torch._C._get_sdp_priority_order()
         orders = [[SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH, SDPBackend.EFFICIENT_ATTENTION],
@@ -2992,18 +2999,25 @@ class TestSDPACudaOnly(NNTestCase):
         import time
         times = list()
         for order in orders:
-            with sdpa_kernel(order, set_priority=True):
-                scaled_dot_product_attention(q, q, q)
+            if use_compile:
+                out = compiled_func(order)
+            else:
+                with sdpa_kernel(order, set_priority=True):
+                    out = scaled_dot_product_attention(q, q, q)
             torch.cuda.synchronize()
             t0 = time.perf_counter()
-            with sdpa_kernel(order, set_priority=True):
-                scaled_dot_product_attention(q, q, q)
+            if use_compile:
+                out = compiled_func(order)
+            else:
+                with sdpa_kernel(order, set_priority=True):
+                    out = scaled_dot_product_attention(q, q, q)
             torch.cuda.synchronize()
             t1 = time.perf_counter()
             times.append(t1 - t0)
         self.assertTrue(times[0] < times[1], "expected cuDNN SDPA to be faster than Math backend.")
         self.assertTrue(times[1] > times[2], "expected Eff Attn backend to faster than Math backend.")
         self.assertTrue(times[3] < times[2], "expected Flash Attn backend to faster than Math backend.")
+        self.assertTrue(times[0] < times[2], "expected cuDNN Attn backend to faster than Eff Attn backend.")
         reset_order = torch._C._get_sdp_priority_order()
         self.assertEqual(default_order, reset_order, "expected SDPA context manager to reset priority order.")
 

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3000,10 +3000,10 @@ class TestSDPACudaOnly(NNTestCase):
         times = list()
         for order in orders:
             if use_compile:
-                out = compiled_func(order)
+                compiled_func(order)
             else:
                 with sdpa_kernel(order, set_priority=True):
-                    out = scaled_dot_product_attention(q, q, q)
+                    scaled_dot_product_attention(q, q, q)
             torch.cuda.synchronize()
             t0 = time.perf_counter()
             if use_compile:

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3007,10 +3007,10 @@ class TestSDPACudaOnly(NNTestCase):
             torch.cuda.synchronize()
             t0 = time.perf_counter()
             if use_compile:
-                out = compiled_func(order)
+                compiled_func(order)
             else:
                 with sdpa_kernel(order, set_priority=True):
-                    out = scaled_dot_product_attention(q, q, q)
+                    scaled_dot_product_attention(q, q, q)
             torch.cuda.synchronize()
             t1 = time.perf_counter()
             times.append(t1 - t0)

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1141,7 +1141,7 @@ class SDPAKernelVariable(ContextWrappingVariable):
 
     def enter(self, tx):
         self.prev_backends = torch.nn.attention._cur_sdpa_kernel_backends(
-                with_priority=self.set_priority
+            with_priority=self.set_priority
         )
         self.set_cleanup_hook(
             tx,

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1102,12 +1102,13 @@ class SDPAKernelVariable(ContextWrappingVariable):
     """represents torch.nn.attention.sdpa_kernel"""
 
     @staticmethod
-    def create(tx: "InstructionTranslator", backends, **kwargs):
+    def create(tx: "InstructionTranslator", backends, set_priority=False, **kwargs):
         if isinstance(backends, torch.nn.attention.SDPBackend):
             backends = [backends]
         var = SDPAKernelVariable(
             target_values=backends,
             initial_values=None,
+            set_priority=set_priority,
             **kwargs,
         )
         return var
@@ -1116,11 +1117,13 @@ class SDPAKernelVariable(ContextWrappingVariable):
         self,
         target_values: list[torch.nn.attention.SDPBackend],
         initial_values=None,
+        set_priority: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(
             target_values=target_values, initial_values=initial_values, **kwargs
         )
+        self.set_priority = set_priority
 
     @staticmethod
     def _backends_to_nodes(tx, backends):
@@ -1137,16 +1140,16 @@ class SDPAKernelVariable(ContextWrappingVariable):
         return nodes
 
     def enter(self, tx):
-        self.prev_backends = torch.nn.attention._cur_sdpa_kernel_backends()
+        self.prev_backends = torch.nn.attention._cur_sdpa_kernel_backends(with_priority=self.set_priority)
         self.set_cleanup_hook(
-            tx, lambda: torch.nn.attention._sdpa_kernel(self.prev_backends)
+            tx, lambda: torch.nn.attention._sdpa_kernel(self.prev_backends, set_priority=self.set_priority)
         )
-        torch.nn.attention._sdpa_kernel(self.target_values)
+        torch.nn.attention._sdpa_kernel(self.target_values, set_priority=self.set_priority)
         arg = self._backends_to_nodes(tx, self.target_values)
         tx.output.create_node(
             "call_function",
             torch.nn.attention._sdpa_kernel,
-            (arg,),
+            (arg, bool(self.set_priority)),
             {},
         )
         return variables.ConstantVariable.create(None)
@@ -1157,7 +1160,7 @@ class SDPAKernelVariable(ContextWrappingVariable):
         tx.output.create_node(
             "call_function",
             torch.nn.attention._sdpa_kernel,
-            (arg,),
+            (arg, bool(self.set_priority)),
             {},
         )
         return variables.ConstantVariable.create(None)

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -390,7 +390,8 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
         elif self.value is torch.nn.attention.sdpa_kernel:
             assert len(args) == 1 or (len(kwargs) == 1 and "backends" in kwargs)
             backends = args[0] if len(args) == 1 else kwargs["backends"]
-            return SDPAKernelVariable.create(tx, backends.as_python_constant())
+            set_priority = kwargs["set_priority"] if "set_priority" in kwargs else False
+            return SDPAKernelVariable.create(tx, backends.as_python_constant(), set_priority)
         elif self.value is torch.nn.attention._sdpa_kernel_variadic:
             return SDPAKernelVariable.create(
                 tx, [arg.as_python_constant() for arg in args]

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -391,7 +391,9 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             assert len(args) == 1 or (len(kwargs) == 1 and "backends" in kwargs)
             backends = args[0] if len(args) == 1 else kwargs["backends"]
             set_priority = kwargs["set_priority"] if "set_priority" in kwargs else False
-            return SDPAKernelVariable.create(tx, backends.as_python_constant(), set_priority)
+            return SDPAKernelVariable.create(
+                    tx, backends.as_python_constant(), set_priority
+            )
         elif self.value is torch.nn.attention._sdpa_kernel_variadic:
             return SDPAKernelVariable.create(
                 tx, [arg.as_python_constant() for arg in args]

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -392,7 +392,7 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             backends = args[0] if len(args) == 1 else kwargs["backends"]
             set_priority = kwargs["set_priority"] if "set_priority" in kwargs else False
             return SDPAKernelVariable.create(
-                    tx, backends.as_python_constant(), set_priority
+                tx, backends.as_python_constant(), set_priority
             )
         elif self.value is torch.nn.attention._sdpa_kernel_variadic:
             return SDPAKernelVariable.create(

--- a/torch/nn/attention/__init__.py
+++ b/torch/nn/attention/__init__.py
@@ -74,17 +74,19 @@ def _backend_from_string(name: str):
 
 
 def _cur_sdpa_kernel_backends(with_priority: bool = False):
-    backends: list[SDPBackend] = []
+    backends = []
     for name, val in _backend_names.items():
         if getattr(torch.backends.cuda, f"{name}_sdp_enabled")():
             backends.append(getattr(SDPBackend, val))
     if with_priority:
         curr_priority = torch._C._get_sdp_priority_order()
-        backends = sorted(backends, key=lambda backend: curr_priority.index(int(backend)))
+        backends = sorted(
+            backends, key=lambda backend: curr_priority.index(int(backend))
+        )
     return backends
 
 
-def _sdpa_kernel(backends: Iterable[SDPBackend], set_priority: bool = False):
+def _sdpa_kernel(backends: Iterable, set_priority: bool = False):
     for name, val in _backend_names.items():
         enabled = getattr(SDPBackend, val) in backends
         getattr(torch.backends.cuda, f"enable_{name}_sdp")(enabled)

--- a/torch/nn/attention/__init__.py
+++ b/torch/nn/attention/__init__.py
@@ -73,18 +73,29 @@ def _backend_from_string(name: str):
     return getattr(SDPBackend, name)
 
 
-def _cur_sdpa_kernel_backends():
+def _cur_sdpa_kernel_backends(with_priority: bool = False):
     backends: list[SDPBackend] = []
     for name, val in _backend_names.items():
         if getattr(torch.backends.cuda, f"{name}_sdp_enabled")():
             backends.append(getattr(SDPBackend, val))
+    if with_priority:
+        curr_priority = torch._C._get_sdp_priority_order()
+        backends = sorted(backends, key=lambda backend: curr_priority.index(int(backend)))
     return backends
 
 
-def _sdpa_kernel(backends: Iterable[SDPBackend]):
+def _sdpa_kernel(backends: Iterable[SDPBackend], set_priority: bool = False):
     for name, val in _backend_names.items():
         enabled = getattr(SDPBackend, val) in backends
         getattr(torch.backends.cuda, f"enable_{name}_sdp")(enabled)
+    if set_priority:
+        # backends should be a unique list
+        user_priority = [int(backend) for backend in backends]
+        previous_priority = torch._C._get_sdp_priority_order()
+        for backend in previous_priority:
+            if backend not in user_priority:
+                user_priority.append(int(backend))
+        torch._C._set_sdp_priority_order(user_priority)
 
 
 @contextlib.contextmanager
@@ -124,28 +135,14 @@ def sdpa_kernel(
     if isinstance(backends, SDPBackend):
         backends = [backends]
 
-    backends_set = set(backends)
-    user_priority = None
-    previous_priority = None
+    backends = list(dict.fromkeys(backends))
 
-    if set_priority:
-        user_priority = [
-            int(x) for idx, x in enumerate(backends) if backends.index(x) == idx  # type: ignore[call-overload]
-        ]
-        previous_priority = torch._C._get_sdp_priority_order()
-        for backend in previous_priority:
-            if backend not in user_priority:
-                user_priority.append(int(backend))
-    previous_backends = _cur_sdpa_kernel_backends()
+    previous_backends = _cur_sdpa_kernel_backends(with_priority=set_priority)
     try:
-        if set_priority:
-            torch._C._set_sdp_priority_order(user_priority)  # type: ignore[arg-type]
-        _sdpa_kernel(backends_set)
+        _sdpa_kernel(backends, set_priority)
         yield {}
     finally:
-        _sdpa_kernel(previous_backends)
-        if set_priority:
-            torch._C._set_sdp_priority_order(previous_priority)  # type: ignore[arg-type]
+        _sdpa_kernel(previous_backends, set_priority)
 
 
 # variadic version of sdpa_kernel for dynamo to use while reconstructing


### PR DESCRIPTION
[https://github.com/pytorch/pytorch/pull/140467](https://github.com/pytorch/pytorch/pull/140467) added the option to specify a priority order for SDPA but the `torch.compile` path silently ignored this setting as I wasn't aware of the separate context manager handling on `torch.compile`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames