### PR TITLE
add pt2 testing for torch.float8_e8m0fnu

### DIFF
--- a/test/quantization/core/experimental/test_float8.py
+++ b/test/quantization/core/experimental/test_float8.py
@@ -432,7 +432,7 @@ class TestFloat8Dtype(TestCase):
             torch.float8_e8m0fnu,
         ):
             # error message: https://gist.github.com/vkuzo/f533f9b4db82119f90a88c39ffdbdd56
-            # TODO(TODO issue): implement for e8m0 dtype
+            # TODO(#147873): implement for e8m0 dtype
             # TODO(later): implement for fnuz dtypes
             return unittest.skip(f"not yet implemented for {dtype}")
 
@@ -461,7 +461,7 @@ class TestFloat8Dtype(TestCase):
             torch.float8_e8m0fnu,
         ):
             # error message: https://gist.github.com/vkuzo/cabe066c5be5e0659638f925b04b94f4
-            # TODO(TODO issue): implement for e8m0 dtype
+            # TODO(#147875): implement for e8m0 dtype
             # TODO(later): implement for fnuz dtypes
             return unittest.skip(f"not yet implemented for {dtype}")
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -224,6 +224,7 @@ dtype_abbrs = {
     torch.float8_e5m2: "f8e5m2",
     torch.float8_e4m3fnuz: "f8e4m3fnuz",
     torch.float8_e5m2fnuz: "f8e5m2fnuz",
+    torch.float8_e8m0fnu: "f8e8m0fnu",
     torch.complex32: "c32",
     torch.complex64: "c64",
     torch.complex128: "c128",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147770

Summary:

Adds PT2 enablement tests for `torch.float8_e8m0fnu`, skipping tests as needed for the functionality which does not work yet:
* displaying e8m0 in TORCH_LOGS output: fixed in this PR
* uint8 -> view as e8m0 -> view as uint8 in torchinductor: already works, added a test
* uint8 -> view as e8m0 -> return in torchinductor: filed https://github.com/pytorch/pytorch/issues/147873
* float32|bfloat16 -> cast to e8m0 -> cast to float32|bfloat16: https://github.com/pytorch/pytorch/issues/147875

Test Plan: CI

TODO

Reviewers:

Subscribers:

Tasks:

Tags:

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv