### PR TITLE
[cuda] Add new gamma beta backwards kernel

### DIFF
--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -1126,7 +1126,7 @@ void dispatch_host_softmax_backward(int64_t dim_size, dim3 grid, Tensor &grad, T
   auto max_elements_per_smem = (at::cuda::getCurrentDeviceProperties()->sharedMemPerBlock -
     smem_reduction_sz) / sizeof(output_t);
   bool can_use_smem = static_cast<size_t>(dim_size) < max_elements_per_smem;
-  can_use_smem &= (!(reinterpret_cast<const uintptr_t>(gI.const_data_ptr<input_t>()) % ALIGN_BYTES));
+  can_use_smem &= (!(reinterpret_cast<uintptr_t>(gI.const_data_ptr<input_t>()) % ALIGN_BYTES));
   can_use_smem &= (!(reinterpret_cast<uintptr_t>(output.const_data_ptr<output_t>()) % ALIGN_BYTES));
   can_use_smem &= !(reinterpret_cast<uintptr_t>(grad.const_data_ptr<output_t>()) % ALIGN_BYTES);
   can_use_smem &= !(dim_size % ILP);

--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -1126,7 +1126,7 @@ void dispatch_host_softmax_backward(int64_t dim_size, dim3 grid, Tensor &grad, T
   auto max_elements_per_smem = (at::cuda::getCurrentDeviceProperties()->sharedMemPerBlock -
     smem_reduction_sz) / sizeof(output_t);
   bool can_use_smem = static_cast<size_t>(dim_size) < max_elements_per_smem;
-  can_use_smem &= (!(reinterpret_cast<uintptr_t>(gI.const_data_ptr<input_t>()) % ALIGN_BYTES));
+  can_use_smem &= (!(reinterpret_cast<const uintptr_t>(gI.const_data_ptr<input_t>()) % ALIGN_BYTES));
   can_use_smem &= (!(reinterpret_cast<uintptr_t>(output.const_data_ptr<output_t>()) % ALIGN_BYTES));
   can_use_smem &= !(reinterpret_cast<uintptr_t>(grad.const_data_ptr<output_t>()) % ALIGN_BYTES);
   can_use_smem &= !(dim_size % ILP);

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -1175,7 +1175,7 @@ void LaunchLayerNormBackwardKernel(
     // This is the short (and potentially wide) case.
     // Here we totally avoid a local reduction and only use 1 warp per block.
     ConfigureAndLaunchLayerNormBackwardKernel<T, T_ACC, 32, 1, 32>(dY_data, X_data, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
-  } else if (M > 64 * 1024 && N / 32 < 64) {
+  } else if (M > 64 * 1024 && N / kWarpSize < 64) {
     // Two kernels are better if we have large M and small N.
     constexpr int block_dim_x = 32;
     constexpr int block_dim_y = 1;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7189,6 +7189,25 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         ln = torch.nn.LayerNorm(2, eps=1e-6, elementwise_affine=False)
         self.assertEqual(ln.forward(x), torch.zeros_like(x))
 
+    def test_layer_norm_backwards_eps(self):
+        dtype = torch.float
+        m_x_n_list = [(32, 32), (1024, 32), (1024, 1024),
+                    (33, 33), (1025, 33), (1025, 1025)]
+        for m, n in m_x_n_list:
+            x = torch.randn((m, n), dtype=dtype, requires_grad=True)
+            grad_output = torch.rand_like(x)
+            x_cuda = x.clone().detach().to("cuda").requires_grad_()
+            grad_output_cuda = grad_output.clone().detach().to("cuda")
+            ln = nn.LayerNorm(n, device="cpu", dtype=dtype)
+            ln_cuda = nn.LayerNorm(n, device="cuda", dtype=dtype)
+            ln_out = ln(x)
+            ln_out_cuda = ln_cuda(x_cuda)
+            ln_out.backward(grad_output)
+            ln_out_cuda.backward(grad_output_cuda)
+            self.assertEqual(ln.weight.grad, ln_cuda.weight.grad, f"weight grad failed: {m=} {n=}", rtol=1e-5, atol=1e-4)
+            self.assertEqual(ln.bias.grad, ln_cuda.bias.grad, f"bias grad failed: {m=} {n=}", rtol=1e-5, atol=1e-4)
+            
+
     @largeTensorTest("40GB", device="cuda")
     def test_layer_norm_large_tensor(self):
         # test for https://github.com/pytorch/pytorch/issues/136291

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7189,6 +7189,25 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         ln = torch.nn.LayerNorm(2, eps=1e-6, elementwise_affine=False)
         self.assertEqual(ln.forward(x), torch.zeros_like(x))
 
+    @onlyCUDA
+    def test_layer_norm_backwards_eps(self):
+        dtype = torch.float
+        m_x_n_list = [(32, 32), (1024, 32), (1024, 1024),
+                    (33, 33), (1025, 33), (1025, 1025)]
+        for m, n in m_x_n_list:
+            x = torch.randn((m, n), dtype=dtype, requires_grad=True)
+            grad_output = torch.rand_like(x)
+            x_cuda = x.clone().detach().to("cuda").requires_grad_()
+            grad_output_cuda = grad_output.clone().detach().to("cuda")
+            ln = nn.LayerNorm(n, device="cpu", dtype=dtype)
+            ln_cuda = nn.LayerNorm(n, device="cuda", dtype=dtype)
+            ln_out = ln(x)
+            ln_out_cuda = ln_cuda(x_cuda)
+            ln_out.backward(grad_output)
+            ln_out_cuda.backward(grad_output_cuda)
+            self.assertEqual(ln.weight.grad, ln_cuda.weight.grad, f"weight grad failed: {m=} {n=}", rtol=1e-5, atol=1e-4)
+            self.assertEqual(ln.bias.grad, ln_cuda.bias.grad, f"bias grad failed: {m=} {n=}", rtol=1e-5, atol=1e-4)
+
     @largeTensorTest("40GB", device="cuda")
     def test_layer_norm_large_tensor(self):
         # test for https://github.com/pytorch/pytorch/issues/136291

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7189,7 +7189,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         ln = torch.nn.LayerNorm(2, eps=1e-6, elementwise_affine=False)
         self.assertEqual(ln.forward(x), torch.zeros_like(x))
 
-    @onlyCUDA
     def test_layer_norm_backwards_eps(self):
         dtype = torch.float
         m_x_n_list = [(32, 32), (1024, 32), (1024, 1024),
@@ -7199,7 +7198,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             grad_output = torch.rand_like(x)
             x_cuda = x.clone().detach().to("cuda").requires_grad_()
             grad_output_cuda = grad_output.clone().detach().to("cuda")
-            ln = nn.LayerNorm(n, device="cpu", dtype=dtype)
+            ln = nn.LayerNorm(n, dtype=dtype)
             ln_cuda = nn.LayerNorm(n, device="cuda", dtype=dtype)
             ln_out = ln(x)
             ln_out_cuda = ln_cuda(x_cuda)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7189,25 +7189,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         ln = torch.nn.LayerNorm(2, eps=1e-6, elementwise_affine=False)
         self.assertEqual(ln.forward(x), torch.zeros_like(x))
 
-    def test_layer_norm_backwards_eps(self):
-        dtype = torch.float
-        m_x_n_list = [(32, 32), (1024, 32), (1024, 1024),
-                    (33, 33), (1025, 33), (1025, 1025)]
-        for m, n in m_x_n_list:
-            x = torch.randn((m, n), dtype=dtype, requires_grad=True)
-            grad_output = torch.rand_like(x)
-            x_cuda = x.clone().detach().to("cuda").requires_grad_()
-            grad_output_cuda = grad_output.clone().detach().to("cuda")
-            ln = nn.LayerNorm(n, device="cpu", dtype=dtype)
-            ln_cuda = nn.LayerNorm(n, device="cuda", dtype=dtype)
-            ln_out = ln(x)
-            ln_out_cuda = ln_cuda(x_cuda)
-            ln_out.backward(grad_output)
-            ln_out_cuda.backward(grad_output_cuda)
-            self.assertEqual(ln.weight.grad, ln_cuda.weight.grad, f"weight grad failed: {m=} {n=}", rtol=1e-5, atol=1e-4)
-            self.assertEqual(ln.bias.grad, ln_cuda.bias.grad, f"bias grad failed: {m=} {n=}", rtol=1e-5, atol=1e-4)
-            
-
     @largeTensorTest("40GB", device="cuda")
     def test_layer_norm_large_tensor(self):
         # test for https://github.com/pytorch/pytorch/issues/136291


### PR DESCRIPTION
Context:
Prior to this PR we had 3 non-ROCM CUDA kernels to handle GammaBeta backwards pass:
1. For small M
2. 32x32 faster kernel for shapes that were divisible by 32 for both M and N
3. All other cases

This approach had several weaknesses:
1. For non-32x32 case, the performance was slow because we were not using warp shuffles there
2. For small M we were not doing coalesced loads so performance was poor in that case (though the total runtime is quite small in those cases so perhaps it doesn't matter much)
3. For large M and small N, we were only using few SMs in the GPU because we were only exploiting parallelism in the `N` dimension, not in the `M` dimension
4. We had to maintain 3 different kernels.

This PR:

1. Adds a single templatized kernel that can technically replace all 3 kernels and get equal or faster performance. The only reason I left out the simple kernel is because `USE_ROCM` case was using that and I couldn't test my kernel with `USE_ROCM`
2. Depending on template parameters, this kernel can either fully reduce the grad values or partially reduce them. In the partial reduction case, a second kernel is needed to fully reduce them.
3. For the large M and small N case, we can launch the partial reduction kernel followed by a `.sum()` to do the full reduction. The advantage is the partial reduction can fully utilize all SMs on the GPU as we parallelize across the `M` dimension. This can lead to pretty dramatic performance gains -- for instance, I saw 10x+ performance improvement for M=7e6 and N=32 (which was from a real model).

Full performance results are shown below on my H100:

![image](https://github.com/user-attachments/assets/741d1d85-a5d3-4a03-b57d-0eebdfe238fc)
