### PR TITLE
[Inductor][Optimus] Fix a corner case in split cat aten pass

### DIFF
--- a/test/inductor/test_split_cat_fx_aten_passes.py
+++ b/test/inductor/test_split_cat_fx_aten_passes.py
@@ -21,7 +21,7 @@ class TestSplitCat(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()
 
-    def forward(self, x: torch.Tensor, y: torch.Tensor):
+    def forward(self, x: torch.Tensor, y: torch.Tensor, z: torch.Tensor):
         cat = torch.ops.aten.cat.default([x, y], 1)
         split = torch.ops.aten.split.Tensor(cat, 32, 1)
         getitem = split[0]
@@ -45,7 +45,8 @@ class TestSplitCat(torch.nn.Module):
             ],
             1,
         )
-        return cat_1
+        cat_2 = torch.ops.aten.cat.default([getitem, z], 1)
+        return torch.ops.aten.cat.default([cat_1, cat_2], 1)
 
 
 class TestSelectCat(torch.nn.Module):
@@ -118,13 +119,14 @@ class TestSplitCatAten(TestCase):
         inputs = [
             torch.randn(1024, 128, device=torch.device(device=GPU_TYPE)),
             torch.randn(1024, 128, device=torch.device(device=GPU_TYPE)),
+            torch.randn(1024, 32, device=torch.device(device=GPU_TYPE)),
         ]
         module = TestSplitCat()
         traced = torch.compile(module)
         ref = module(*inputs)
         res = traced(*inputs)
         self.compare_pred(module, traced, inputs)
-        self.assertEqual(counters["inductor"]["normalization_aten_pass"], 3)
+        self.assertEqual(counters["inductor"]["normalization_aten_pass"], 5)
         self.assertEqual(counters["inductor"]["split_cat_aten_pass"], 1)
         self.assertEqual(ref, res, rtol=1e-8, atol=1e-8)
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)


### PR DESCRIPTION
Summary: We need to further check the input of the cat to make sure all of them are from the same split node.

Test Plan:
# unit test

```
buck2 test 'fbcode//mode/dev-nosan' fbcode//caffe2/test/inductor:split_cat_fx_aten_passes -- test_split_cat_post_grad
```

Buck UI: https://www.internalfb.com/buck2/c875cbdd-5374-46cf-811c-45f91cf6ba3e
Test UI: https://www.internalfb.com/intern/testinfra/testrun/10977524161964655
Network: Up: 64KiB  Down: 27KiB  (reSessionID-2e5915cb-4894-48f6-ab1c-3981adb42dab)
Executing actions. Remaining     0/3                                                                         1.5s exec time total
Command: test.     Finished 2 local
Time elapsed: 2:52.1s
Tests finished: Pass 2. Fail 0. Fatal 0. Skip 0. Build failure 0

# E2E

before
aps-recgpt_ig_emb_pt2_comment_out-30c4d5127e

tlparse:
https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/aps-recgpt_ig_emb_pt2_comment_out-30c4d5127e/attempt_0/version_0/rank_0/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=100


after
aps-recgpt_ig_emb_pt2_comment_out-c03f74e353

Differential Revision: D70132209




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov