### PR TITLE
Fix bug in async TP handling of "reshape -> scaled mm -> reshape" pattern for float8 row-wise scaling

### DIFF
--- a/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
+++ b/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
@@ -403,37 +403,50 @@ class MicroPipelineTPTest(TestCase):
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @parametrize("scatter_dim", [0, 1, 2])
     @fresh_inductor_cache()
-    def test_fuse_scaled_matmul_reduce_scatter_rowwise_scales(self, scatter_dim):
-
+    def test_fuse_scaled_matmul_reduce_scatter_rowwise_scales_reshape_mm_reshape(
+        self, scatter_dim
+    ):
         group = dist.group.WORLD
 
-        def func(
+        def reshape_mm_reshape(
             A: torch.Tensor,
             B: torch.Tensor,
             A_scale: torch.Tensor,
             B_scale: torch.Tensor,
             out_dtype: torch.dtype,
         ) -> torch.Tensor:
+            """
+            Performs a scaled_mm followed by a reduce scatter,
+            following the reshape -> scaled_mm -> reshape pattern.
+            """
             orig_shape = A.shape
-            A = A.reshape(-1, orig_shape[-1])
-            C = torch._scaled_mm(
-                A, B, A_scale, B_scale, out_dtype=out_dtype
-            )
-            C = C.view(*orig_shape[:-1], C.shape[-1])
-            return reduce_scatter_tensor(C, "avg", scatter_dim, group)
 
-        A = torch.rand(16, 32, device="cuda").to(torch.float8_e4m3fn)
+            # reshape tensor and scale together
+            A = A.reshape(-1, orig_shape[-1])
+            A_scale = A_scale.reshape(-1, A_scale.shape[-1])
+
+            C = torch._scaled_mm(A, B, A_scale, B_scale, out_dtype=out_dtype)
+
+            # reshape output to have same leading dims as original `A` tensor
+            C = C.view(*orig_shape[:-1], C.shape[-1])
+            return reduce_scatter_tensor(C, "sum", scatter_dim, group)
+
+        A = torch.rand(1, 16, 32, device="cuda").to(torch.float8_e4m3fn)
         B = torch.rand(64, 32, device="cuda").to(torch.float8_e4m3fn).T
 
         # A_scale = rowwise scales
-        A_scale = torch.full((A.shape[0], 1), 0.1, device="cuda")
+        A_scale = torch.full((1, 16, 1), 0.1, device="cuda")
 
         # B_scale = rowwise scales transposed for A @ B^T
-        B_scale = torch.full((1, B.shape[1]), 0.1, device="cuda")
+        B_scale = torch.full((1, 64), 0.1, device="cuda")
 
-        gm = _make_post_grad_fx(func, A, B, A_scale, B_scale, torch.bfloat16)
+        gm = _make_post_grad_fx(
+            reshape_mm_reshape, A, B, A_scale, B_scale, torch.bfloat16
+        )
+
         with _test_mode():
             micro_pipeline_tp_pass(gm.graph)
+
         self.assertIn("fused_scaled_matmul_reduce_scatter", str(gm.graph))
         self.assertNotIn("reduce_scatter_tensor", str(gm.graph))
 
@@ -441,13 +454,12 @@ class MicroPipelineTPTest(TestCase):
             return
 
         with _test_mode():
-            compiled = torch.compile(func)
+            compiled = torch.compile(reshape_mm_reshape)
             code = run_and_get_triton_code(
                 compiled, A, B, A_scale, B_scale, torch.bfloat16
             )
         self.assertIn("fused_scaled_matmul_reduce_scatter", code)
         self.assertNotIn("reduce_scatter_tensor", code)
-    
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @parametrize("shard_dim", [0, 1])

--- a/torch/_inductor/fx_passes/micro_pipeline_tp.py
+++ b/torch/_inductor/fx_passes/micro_pipeline_tp.py
@@ -386,6 +386,7 @@ class _ScaledMatmul(_Matmul):
             aten._scaled_mm.default,
             aten.reshape.default,
         )
+
         def get_arg(node: torch.fx.Node, idx: int, default: Any) -> Any:
             if idx >= len(node.args):
                 return default
@@ -419,6 +420,7 @@ class _ScaledMatmul(_Matmul):
             out_dtype=get_arg(mm_node, 6, None),
             use_fast_accum=get_arg(mm_node, 7, False),
         )
+
 
 def _find_reshape_mm_reshape(node: torch.fx.Node) -> list[_Matmul]:
     if node.target != aten.reshape.default:

--- a/torch/_inductor/fx_passes/micro_pipeline_tp.py
+++ b/torch/_inductor/fx_passes/micro_pipeline_tp.py
@@ -388,7 +388,7 @@ class _ScaledMatmul(_Matmul):
 
         return _ScaledMatmul(
             nodes=match,
-            A_node=cast(torch.fx.Node, match[0].args[0]),
+            A_node=cast(torch.fx.Node, mm_node.args[0]),
             B_node=cast(torch.fx.Node, mm_node.args[1]),
             A_scale_node=cast(torch.fx.Node, mm_node.args[2]),
             B_scale_node=cast(torch.fx.Node, mm_node.args[3]),
@@ -720,10 +720,10 @@ def fuse_matmul_reduce_scatter(reduce_scatter: _ReduceScatterMatch) -> None:
     matmul = _find_producer_matmul(input_node)
     if matmul is None:
         return
-
+    
     if rs_res_node in matmul.arg_ancestor_nodes:
         return
-
+    
     graph = rs_res_node.graph
     with graph.inserting_before(rs_res_node):
         if "val" in matmul.A_node.meta:
@@ -735,7 +735,6 @@ def fuse_matmul_reduce_scatter(reduce_scatter: _ReduceScatterMatch) -> None:
                 inductor_prims.force_stride_order,
                 args=(matmul.A_node, restrided.stride()),
             )
-
         fused_node = _insert_fused_matmul_reduce_scatter(
             graph,
             matmul,

--- a/torch/_inductor/fx_passes/micro_pipeline_tp.py
+++ b/torch/_inductor/fx_passes/micro_pipeline_tp.py
@@ -405,7 +405,7 @@ class _ScaledMatmul(_Matmul):
         if is_reshape_mm_reshape_pattern:
             # scaled_mm's A_scale arg -> parent is reshape op
             A_scale_reshape_node = A_scale_node.all_input_nodes[0]
-            # reshape node's parent is the original exp2 output, before the reshape.
+            # reshape node's parent is the original scale, before the reshape.
             A_scale_node = A_scale_reshape_node.all_input_nodes[0]
 
         return _ScaledMatmul(

--- a/torch/_inductor/fx_passes/micro_pipeline_tp.py
+++ b/torch/_inductor/fx_passes/micro_pipeline_tp.py
@@ -720,10 +720,10 @@ def fuse_matmul_reduce_scatter(reduce_scatter: _ReduceScatterMatch) -> None:
     matmul = _find_producer_matmul(input_node)
     if matmul is None:
         return
-    
+
     if rs_res_node in matmul.arg_ancestor_nodes:
         return
-    
+
     graph = rs_res_node.graph
     with graph.inserting_before(rs_res_node):
         if "val" in matmul.A_node.meta:
@@ -735,6 +735,7 @@ def fuse_matmul_reduce_scatter(reduce_scatter: _ReduceScatterMatch) -> None:
                 inductor_prims.force_stride_order,
                 args=(matmul.A_node, restrided.stride()),
             )
+
         fused_node = _insert_fused_matmul_reduce_scatter(
             graph,
             matmul,


### PR DESCRIPTION
Part of https://github.com/pytorch/torchtitan/issues/864

## Summary 
While testing torchtitan with float8 training with rowwise scaling + async TP, a [bug](https://github.com/pytorch/torchtitan/issues/864) was discovered. The symptom was the scaling factor dims did not match the dims of the tensor the scales were to be applied to.

My [root cause analysis](https://github.com/pytorch/torchtitan/issues/864#issuecomment-2672465060) determined the reason is that when async TP graph manipulation constructs the `fused_scaled_matmul_reduce_scatter` op, it does not yet handle the "reshape -> scaled mm -> reshape" pattern used in torchao [here](https://github.com/pytorch/ao/blob/ed361ff5c7dd33aba9b4a0da2bd744de5a5debfb/torchao/float8/float8_linear.py#L122-L124) - specifically when row-wise scales are being used.

## TL;DR of root cause
- When a Float8Tensor is reshaped, the scale is reshaped along with it so the dimensions are aligned.
- In the graph manipulation logic of the micropipeline TP post grad pass, the scaled_mm `A tensor` node is referencing the tensor _before_ to the reshape op, but referencing the `A_scale` node _after_ the reshape op.
- To solve this, if a reshape -> scaled mm -> reshape pattern is detected, we can ensure both the tensor and scale used are from _before_ the reshape.


**Note:** the reason we don't use the tensor and scale from _after_  the reshape is because then the `scatter_dim`, which corresponds to the original tensor shape, would now be outdated, and keeping the scatter dim in sync with arbitrary reshapes would be complicated/not feasible. Furthermore, using the tensor / scale from before the reshape ensures the `fused_scaled_matmul_reduce_scatter` keeps the intended `(a,b,c) @ (c,d) = (a,b,d)` shape sequence

## Test plan
- Added new unit tests ensuring "reshape -> scaled mm -> reshape" pattern with row-wise scales is supported.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov