### PR TITLE
[Inductor-CPU] Avoid memory allocator lock contention in the GEMM template

### DIFF
--- a/torch/_inductor/codegen/cpp_template_kernel.py
+++ b/torch/_inductor/codegen/cpp_template_kernel.py
@@ -210,6 +210,19 @@ class CppTemplateKernel(CppKernel):
         numel = f"{cexpr_index(buf.get_numel())}"
         return f"auto _{name} = std::make_unique<{ctype}[]>({numel}); auto {name} = _{name}.get();"
 
+    def define_thread_local_buffer(
+        self, name, sizes: list[Any], dtype=torch.float
+    ) -> str:
+        """Define kernel local buffer on the current thread's stack"""
+        sizes = parse_expr_with_index_symbols(sizes)
+        buf = ir.Buffer(
+            name=name, layout=ir.FixedLayout(torch.device("cpu"), dtype, sizes)
+        )
+        self.local_buffers[name] = buf
+        ctype = f"{DTYPE_TO_CPP[dtype]}"
+        numel = f"{cexpr_index(buf.get_numel())}"
+        return f"alignas(64) {ctype} _{name}[{numel}]; {ctype}* {name} = _{name};"
+
     def reinit_buffer_if_null(self, name):
         """Reinit the previously defined local buffer if it is null"""
         assert name in self.local_buffers


### PR DESCRIPTION
## Summary

Use stack allocated buffer in GEMM template, whenever possible, to avoid memory allocator lock contention. It'd probably only save us a few cycles.

Based on a quick glance at the `get_cache_blocking` code, it looks like `Mc_blocks * Mr * Nc_blocks * Nr` wouldn't exceed the size of per-core L2 cache, so it's safe to assume that it'd be smaller than the default per-thread stack size on Linux.

Didn't observe a discernible difference in performance, but can we still land this change to remove some degree of non-determinism?

Thanks!

 




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov