### PR TITLE
Fix crash in -[PTMCoreMLCompiler _compileModel:atPath:]

### DIFF
--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.mm
@@ -93,7 +93,14 @@ static NSString *gVersionExtension = @"version";
 + (BOOL)_compileModel:(NSString *)modelName atPath:(NSString *)modelPath {
   NSError *error;
   NSURL *modelURL = [NSURL fileURLWithPath:modelPath];
-  NSURL *temporaryURL = [MLModel compileModelAtURL:modelURL error:&error];
+
+  NSURL *temporaryURL;
+  try {
+    temporaryURL = [MLModel compileModelAtURL:modelURL error:&error];
+  } catch (std::runtime_error &e) {
+    // Could not compile.
+    return NO;
+  }
 
   // After the compiled model has been created, the original specs can be cleared to save cache space.
   [[NSFileManager defaultManager] removeItemAtPath:modelPath error:nil];


### PR DESCRIPTION
Summary:
We could hit one of those exceptions:
https://github.com/apple/coremltools/blob/main/modelpackage/src/ModelPackage.cpp#L205-L225

And it would make this code path crash.

Test Plan: build.

Differential Revision: D70122378




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel