### PR TITLE
Clean temporary directory at exit

### DIFF
--- a/torch/distributed/nn/jit/instantiator.py
+++ b/torch/distributed/nn/jit/instantiator.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 import tempfile
+import atexit
 from typing import Optional
 
 import torch
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 _FILE_PREFIX = "_remote_module_"
 _TEMP_DIR = tempfile.TemporaryDirectory()
 INSTANTIATED_TEMPLATE_DIR_PATH = _TEMP_DIR.name
+atexit.register(_TEMP_DIR.cleanup)
 logger.info("Created a temporary directory at %s", INSTANTIATED_TEMPLATE_DIR_PATH)
 sys.path.append(INSTANTIATED_TEMPLATE_DIR_PATH)
 

--- a/torch/distributed/nn/jit/instantiator.py
+++ b/torch/distributed/nn/jit/instantiator.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python3
 # mypy: allow-untyped-defs
+import atexit
 import importlib
 import logging
 import os
 import sys
 import tempfile
-import atexit
 from typing import Optional
 
 import torch


### PR DESCRIPTION
Issue: A temporary directory is created in [pytorch/torch/distributed/nn/jit/instantiator.py](https://github.com/arthurlw/pytorch/blob/clean-temp-directory-at-exit/torch/distributed/nn/jit/instantiator.py) but is never cleaned up, leading to a ResourceWarning on program exit.

Solution: Registered an `atexit` handler to properly clean up the temporary directory when the program exits.

Fixes #147744  

**Line 23 in [0a49f8f](https://github.com/arthurlw/pytorch/commit/0a49f8fd3d34ee31f39bf7029ebb0b564433ac48)**  
```python
23  atexit.register(_TEMP_DIR.cleanup)
```

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @EikanWang @jgong5 @wenzhe-nrv @sanchitintel