### PR TITLE
Use torch_compile_options for c10 libraries

### DIFF
--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
         )
 if(NOT BUILD_LIBTORCHLESS)
   add_library(c10 ${C10_SRCS} ${C10_HEADERS})
-  target_compile_options_if_supported(c10 "-Wdeprecated")
+  torch_compile_options(c10)
   if(HAVE_SOVERSION)
     set_target_properties(c10 PROPERTIES
         VERSION ${TORCH_VERSION} SOVERSION ${TORCH_SOVERSION})

--- a/c10/cuda/CMakeLists.txt
+++ b/c10/cuda/CMakeLists.txt
@@ -56,6 +56,7 @@ set(CUDA_LINK_LIBRARIES_KEYWORD PRIVATE)
 
 if(NOT BUILD_LIBTORCHLESS)
   torch_cuda_based_add_library(c10_cuda ${C10_CUDA_SRCS} ${C10_CUDA_HEADERS})
+  torch_compile_options(c10_cuda)
   set(CUDA_LINK_LIBRARIES_KEYWORD)
   # If building shared library, set dllimport/dllexport proper.
   target_compile_options(c10_cuda PRIVATE "-DC10_CUDA_BUILD_MAIN_LIB")

--- a/c10/hip/CMakeLists.txt
+++ b/c10/hip/CMakeLists.txt
@@ -33,6 +33,7 @@ file(GLOB_RECURSE C10_HIP_HEADERS *.h)
 
 if(NOT BUILD_LIBTORCHLESS)
   hip_add_library(c10_hip ${C10_HIP_SRCS} ${C10_HIP_HEADERS})
+  torch_compile_options(c10_hip)
 
   # Propagate HIP_CXX_FLAGS that were set from Dependencies.cmake
   target_compile_options(c10_hip PRIVATE ${HIP_CXX_FLAGS})

--- a/c10/xpu/CMakeLists.txt
+++ b/c10/xpu/CMakeLists.txt
@@ -31,6 +31,7 @@ set(C10_XPU_HEADERS
 )
 if(NOT BUILD_LIBTORCHLESS)
   add_library(c10_xpu ${C10_XPU_SRCS} ${C10_XPU_HEADERS})
+  torch_compile_options(c10_xpu)
   target_compile_options(c10_xpu PRIVATE "-DC10_XPU_BUILD_MAIN_LIB")
   # Enable hidden visibility if compiler supports it.
   if(${COMPILER_SUPPORTS_HIDDEN_VISIBILITY})


### PR DESCRIPTION
c10, c10_cuda, c10_hip and c10_xpu are given additional compile options by torch_compile_options, which are more restrictive and can help reveal potential bugs inside the code.