### PR TITLE
[Intel GPU] Add synchronize() in torch.utils.benchmark

### DIFF
--- a/torch/utils/benchmark/utils/timer.py
+++ b/torch/utils/benchmark/utils/timer.py
@@ -17,6 +17,10 @@ if torch.backends.cuda.is_built() and torch.cuda.is_available():  # type: ignore
     def timer() -> float:
         torch.cuda.synchronize()
         return timeit.default_timer()
+elif torch.xpu.is_available():
+    def timer() -> float:
+        torch.xpu.synchronize()
+        return timeit.default_timer()
 elif torch._C._get_privateuse1_backend_name() != "privateuseone":
     privateuse1_device_handler = getattr(torch, torch._C._get_privateuse1_backend_name(), None) \
         if torch._C._get_privateuse1_backend_name() != "cpu" else None


### PR DESCRIPTION
When following https://pytorch.org/tutorials/recipes/recipes/benchmark.html on XPU, I notice that the device it is not synchronized in the benchmark. This PR tries to fix this and align the behavior with CUDA. 