### PR TITLE
Parallelize bf16->f32 conversion for gemm(bf16:bf16->bf16)

### DIFF
--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -337,9 +337,11 @@ void gemm(
               b, &ldb_,
               &beta_,
               float_v.data(), &ldc_);
-      for (auto cv: float_v) {
-        *(c++) = c10::convert<at::BFloat16>(cv);
-      }
+      at::parallel_for(0, c_size, 1, [&](int64_t begin, int64_t end) {
+        for (const auto i : c10::irange(begin, end)) {
+          *(c++) = c10::convert<at::BFloat16>(float_v[i]);
+        }
+      });
       return;
    }
 #endif


### PR DESCRIPTION
Improves performance for at::addmm / linear kernels when executed in dtype=bfloat16 and when SBGEMM is available. 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @malfet @snadampal @milpuz01