### PR TITLE
[export][dynamic shapes] add Dim._OBLIVIOUS, _mark_oblivious()

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10877,6 +10877,20 @@ fn
         with self.assertRaisesRegex(RuntimeError, "RelaxedUnspecConstraint"):
             fn(x, y)
 
+    def test_mark_oblivious(self):
+        @torch.compile()
+        def fn(x, y):
+            y = torch.cat([y, y], dim=0)
+            return x * y
+
+        x = torch.randn(12)
+        y = torch.randn(6)
+        torch._dynamo.decorators._mark_oblivious(x, 0)
+        torch._dynamo.decorators._mark_oblivious(y, 0)
+        f(x, y)
+        f(torch.randn(2), torch.randn(1))
+        f(torch.randn(0), torch.randn(0))
+
     def test_sym_max_unbacked_sizelike_simplification(self):
         @torch.compile(fullgraph=True, backend="eager")
         def cf(x):

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -512,6 +512,26 @@ def mark_unbacked(t, index, strict=False):
 
 
 @forbid_in_graph
+def _mark_oblivious(t, index):
+    """
+    Mark a tensor as having a size-oblivious dim. This follows unbacked semantics for 0/1 specialization,
+    but allows guards on the symbol (the symbol has a hint, so is technically backed).
+    More specifically, a [0, inf] range is allocated, and size-oblivious semantics will apply.
+    """
+    assert not is_traceable_wrapper_subclass(t), "not implemented yet"
+
+    if isinstance(index, int):
+        if not hasattr(t, "_dynamo_oblivious_indices"):
+            t._dynamo_oblivious_indices = set()
+        t._dynamo_oblivious_indices.add(index)
+        return
+
+    assert isinstance(index, (list, tuple))
+    for i in index:
+        _mark_oblivious(t, i)
+
+
+@forbid_in_graph
 def mark_dynamic(t, index, *, min=None, max=None):
     """
     Mark a tensor as having a dynamic dim and set corresponding min and max range for the dim.

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2845,6 +2845,7 @@ def _automatic_dynamic(
             e, "_dynamo_strict_unbacked_indices", set()
         )
         marked_unbacked = i in getattr(e, "_dynamo_unbacked_indices", set())
+        marked_oblivious = i in getattr(e, "_dynamo_oblivious_indices", set())
         marked_dynamic = i in getattr(e, "_dynamo_dynamic_indices", set())
         marked_weak_dynamic = i in getattr(e, "_dynamo_weak_dynamic_indices", set())
         marked_static = i in getattr(e, "_dynamo_static_indices", set())
@@ -2926,6 +2927,8 @@ def _automatic_dynamic(
 
         if marked_unbacked:
             dynamic_size = DimDynamic.SIZE_LIKE_UNBACKED
+        elif marked_oblivious:
+            dynamic_size = DimDynamic.OBLIVIOUS_SIZE
         elif (
             constraint_size is not None
             or marked_dynamic

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -113,6 +113,8 @@ def fakify(
             # are raised when specializing.
             dynamic_sizes.append(DimDynamic.DYNAMIC)
             constraint_sizes[i] = RelaxedUnspecConstraint(warn_only=False)  # type: ignore[call-overload]
+        elif i in getattr(t, "_dynamo_oblivious_indices", {}):
+            dynamic_sizes.append(DimDynamic.OBLIVIOUS_SIZE)
         else:
             dynamic_sizes.append(DimDynamic.STATIC)
     symbolic_context = StatelessSymbolicContext(

--- a/torch/export/dynamic_shapes.py
+++ b/torch/export/dynamic_shapes.py
@@ -46,11 +46,13 @@ class _DimHint(Enum):
     - AUTO means automatic inference of shape (static or dynamic).
     - STATIC means static shape (always specialized).
     - DYNAMIC means dynamic, will error out if specialized.
+    - _OBLIVIOUS allocates an backed symbol with size-oblivious semantics.
     """
 
     AUTO = auto()
     STATIC = auto()
     DYNAMIC = auto()
+    _OBLIVIOUS = auto()
 
 
 class _Dim(type):
@@ -238,6 +240,7 @@ def Dim(name: str, *, min: Optional[int] = None, max: Optional[int] = None):
 Dim.AUTO = _DimHint.AUTO  # type: ignore[attr-defined]
 Dim.STATIC = _DimHint.STATIC  # type: ignore[attr-defined]
 Dim.DYNAMIC = _DimHint.DYNAMIC  # type: ignore[attr-defined]
+Dim._OBLIVIOUS = _DimHint._OBLIVIOUS  # type: ignore[attr-defined]
 
 
 def dims(
@@ -929,6 +932,8 @@ def _process_dynamic_shapes(
                         torch._dynamo.mark_static(tensor, i)
                     elif dim == _DimHint.DYNAMIC:
                         torch._dynamo.mark_dynamic(tensor, i)
+                    elif dim == _DimHint._OBLIVIOUS:
+                        torch._dynamo.decorators._mark_oblivious(tensor, i)
                     constraints.append(_RelaxedConstraint(id(tensor), i))
                 elif dim is None:
                     torch._dynamo.mark_static(tensor, i)
@@ -946,6 +951,8 @@ def _process_dynamic_shapes(
                         torch._dynamo.mark_static(tensor, i)
                     elif dim == _DimHint.DYNAMIC:
                         torch._dynamo.mark_dynamic(tensor, i)
+                    elif dim == _DimHint._OBLIVIOUS:
+                        torch._dynamo.decorators._mark_oblivious(tensor, i)
                     constraints.append(_RelaxedConstraint(id(tensor), i))
                 elif dim is None:
                     torch._dynamo.mark_static(tensor, i)


### PR DESCRIPTION
Summary: Adds `Dim._OBLIVIOUS` in export dynamic shapes, and `_mark_oblivious()` in dynamo decorators, to support the use of OBLIVIOUS_SIZE.

The semantics are that we allocate what looks like a unbacked symbol, but is technically backed; it contains a hint, the user-intention is just to opt into size-oblivious reasoning and avoid 0/1 specialization.

Decided to do this over mark_unbacked + hint because it's easier to write code in symbolic_shapes that distinguishes between valid reasoning for oblivious sizes and general unbacked (e.g. we can set replacements for oblivious sizes since they're graph inputs, and we don't face the "time traveling" problem): https://github.com/pytorch/pytorch/blob/3a69dee955f2c6c57f7c879ba82469fa0c1d0b74/torch/fx/experimental/symbolic_shapes.py#L6284-L6297

On the other hand if we just handled this with unbacked + hint, it's hard to tell if we're dealing with input sizes that should have hints, or if we've just been doing real-tensor prop.

Test Plan: test_export

Differential Revision: D70193972




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames