### PR TITLE
[inductor][ck] kBatch parametrized

### DIFF
--- a/torch/_inductor/codegen/rocm/ck_template.py
+++ b/torch/_inductor/codegen/rocm/ck_template.py
@@ -1,7 +1,12 @@
+from typing import Any
+from typing_extensions import override
+
 import torch
 from torch._inductor.codegen.rocm.rocm_template import ROCmTemplate
 from torch._inductor.ir import IRNode
 from torch._inductor.utils import IndentedBuffer
+
+from .rocm_template import ArgInfo
 
 
 class CKTemplate(ROCmTemplate):
@@ -90,3 +95,14 @@ class CKTemplate(ROCmTemplate):
             return ptr
         else:
             return f"({self._TORCH_DTYPE_TO_CK.get(node.get_dtype())}*)({ptr})"
+
+    @override
+    def get_runtime_arg_info(self) -> list[ArgInfo]:
+        return [ArgInfo("kBatch", "int32_t")]
+
+    @override
+    def get_runtime_arg_values(self, **kwargs: Any) -> list[Any]:
+        """
+        Helper method to retrieve runtime args from generate kwargs
+        """
+        return [kwargs[arg.name] for arg in self.get_runtime_arg_info()]

--- a/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
@@ -81,7 +81,7 @@ class CKGemmTemplate(CKTemplate):
             LDB,
             std::array<ck::index_t, {{ds_size}}>{ {{ds_strides}} },
             LDC,
-            1, // kBatch
+            kBatch, // kBatch
             {{a_elementwise_op}},
             {{b_elementwise_op}},
             {{epilogue}} // c_elementwise_op
@@ -141,6 +141,7 @@ class CKGemmTemplate(CKTemplate):
         const int32_t LDB = {{LDB}};
         const int32_t LDC = {{LDC}};
         const int32_t LDD = {{LDD}};
+        const int32_t kBatch = {{kBatch}};
 
         using AElementType = {{a_ck_dtype}};
         using BElementType = {{b_ck_dtype}};
@@ -683,10 +684,7 @@ class CKGemmTemplate(CKTemplate):
 
         if config.rocm.generate_test_runner:
             is_static_problem = all(is_static_int(arg) for arg in self.size_args())
-            if self.is_batched:
-                size_arg_strs = ["B", "M", "N", "K", "LDA", "LDB", "LDC", "LDD"]
-            else:
-                size_arg_strs = ["M", "N", "K", "LDA", "LDB", "LDC", "LDD"]
+            # NOTE: size_arg_strs is defined above
             size_arg_vals = (
                 self.size_args()
                 if is_static_problem
@@ -695,6 +693,12 @@ class CKGemmTemplate(CKTemplate):
                 )
             )
             size_args = dict(zip(size_arg_strs, size_arg_vals, strict=True))
+            runtime_args = dict(
+                zip(
+                    [a.name for a in self.get_runtime_arg_info()],
+                    self.get_runtime_arg_values(),
+                )
+            )
             runner_code = self._template_from_string(
                 self.standalone_runner_template
             ).render(
@@ -735,6 +739,7 @@ class CKGemmTemplate(CKTemplate):
                     ["<source_file_name>"], "<executable_name>", "exe"
                 ),
                 **size_args,
+                **runtime_args,
             )
             res += runner_code
 
@@ -832,6 +837,7 @@ class CKGemmTemplate(CKTemplate):
             template.maybe_append_choice(
                 choices,
                 op=op,
+                kBatch=1,
             )
 
     def size_args(self):

--- a/torch/_inductor/codegen/rocm/rocm_kernel.py
+++ b/torch/_inductor/codegen/rocm/rocm_kernel.py
@@ -14,7 +14,7 @@ from .rocm_template_buffer import ROCmTemplateBuffer
 
 
 if TYPE_CHECKING:
-    from torch._inductor.codegen.rocm.rocm_template import ROCmTemplate
+    from torch._inductor.codegen.rocm.rocm_template import ArgInfo, ROCmTemplate
 
 log = logging.getLogger(__name__)
 
@@ -40,7 +40,12 @@ class ROCmTemplateKernel(ROCmKernel):
 
     _EXTRA_CPP_ARGS = "size_t* workspace_size, uint8_t* workspace, hipStream_t stream"
 
-    def __init__(self, kernel_name) -> None:
+    def __init__(
+        self,
+        kernel_name: str,
+        runtime_arg_info: list["ArgInfo"],
+        runtime_arg_values: list[Any],
+    ) -> None:
         """
         Initializes a new instance of the ROCmTemplateKernel class.
 
@@ -51,6 +56,8 @@ class ROCmTemplateKernel(ROCmKernel):
         self.kernel_name = kernel_name
         # Mapping from arg name to IRNode.
         self.named_nodes: dict[str, IRNode] = {}
+        self.runtime_arg_info = runtime_arg_info
+        self.runtime_arg_values = runtime_arg_values
 
     def get_signature(self):
         return self.signature
@@ -104,7 +111,9 @@ class ROCmTemplateKernel(ROCmKernel):
 
         arg_defs, *_ = self.args.cpp_argdefs()
 
-        signature = f"int {self.kernel_name}({', '.join(arg_defs + size_args)}, {self._EXTRA_CPP_ARGS})"
+        runtime_arg_defs = [f"{arg.ty} {arg.name}" for arg in self.runtime_arg_info]
+
+        signature = f"int {self.kernel_name}({', '.join(arg_defs + size_args + runtime_arg_defs)},{self._EXTRA_CPP_ARGS})"
         self.signature = signature
         return signature
 
@@ -135,6 +144,7 @@ class ROCmTemplateKernel(ROCmKernel):
             _, call_args, arg_types = self.args.cpp_argdefs()
         else:
             _, call_args, _, arg_types = self.args.python_argdefs()
+
         kernel_args = []
         for arg in call_args:
             # dynamo wraps unspec variable as 0d CPU tensor, need convert to scalar
@@ -149,6 +159,7 @@ class ROCmTemplateKernel(ROCmKernel):
         size_args = [
             f"{V.graph.sizevars.simplify(sarg)}" for sarg in node.template.size_args()
         ]
+
         if V.graph.cpp_wrapper:
             kernel_args.extend(size_args)
         else:
@@ -156,6 +167,11 @@ class ROCmTemplateKernel(ROCmKernel):
 
         if V.graph.cpp_wrapper:
             arg_types.extend(["int"] * len(node.template.size_args()))
+
+        # the runtime args come right after the size args
+        kernel_args.extend(self.runtime_arg_values)
+        for arg in self.runtime_arg_info:
+            arg_types.append(arg.ty)
 
         # workspace_size ptr is NULL to mark this call is not intended for retrieving workspace_size.
         # workspace_size should have already been retrieved prior to this call.
@@ -180,7 +196,6 @@ class ROCmTemplateKernel(ROCmKernel):
             kernel_args.append("nullptr" if V.graph.cpp_wrapper else "None")
         if V.graph.cpp_wrapper:
             arg_types.append("uint8_t*")
-
         current_device = V.graph.get_current_device_or_throw()
         wrapper.generate_kernel_call(
             name,


### PR DESCRIPTION
Summary:
# Why

Enable us to set the kBatch parameter, rather than bake it in

Especially for larger splitK scenarios, this can yield very good performance (up to 1.5x vs hipblaslt from initial tests)

## Why like this

The obvious question should be: why not add this to the op itself, and maybe even into the template/kernel. That would simplify the code.

The choice to have it as a "runtime" param that we fix is be able to reuse the compiled CK `.so` libraries, as now multiple choices of kBatch can be used with the exact same `.so` (as the shared library does not depend on kBatch, but takes it as a parameter)

# What

- copy cutlass approach for swizzle to have a "runtime" arg that we pass in but is really choice dependent
- pipe through everything from template and kernel
- hard-code it to be kBatch=1 for now (same as before, just now settable)

This is part of a series of Diffs, where next we need to figure out
1. how to filter out ops + kBatch that don't work
2. set this better for splitK scenarios (hand written heuristic)

Test Plan:
(with minor modifications)

```
# show it working with AOTI
buck2 run mode/opt-amd-gpu //scripts/henrylhtsang/repros:aot
```

```
# show it working with inductor only
buck2 run -c fbcode.re_gpu_tests=False mode/opt-amd-gpu  fbcode//deeplearning/aot_inductor/benchmark/sampling:test_gemm_autotune_benchmark_AMD_block_0
```

Differential Revision: D70200008




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov