### PR TITLE
[PT2] Allow tensor type in allowed_getattr_types_for_subgm when verifiying ep

### DIFF
--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -149,7 +149,7 @@ class Verifier(metaclass=_VerifierMeta):
 
     def allowed_getattr_types_for_subgm(self) -> tuple[type[Any], ...]:
         # subgm in HOP's argument could has have getattr(weight) nodes, thus stateful
-        return (torch.fx.GraphModule, torch.nn.parameter.Parameter)
+        return (torch.fx.GraphModule, torch.nn.parameter.Parameter, torch.Tensor)
 
     def check_valid_op(self, op):
         pass


### PR DESCRIPTION
Summary:
Noticed this when converting a graph with the following format

EP(
non_lowerable_part: (....)
AOTI_HOP(non_lowerable_inputs)
)


You will get the following error
```
raise SpecViolationError(
torch._export.verifier.SpecViolationError: Invalid get_attr type <class 'torch.Tensor'>.
Valid get_attr types: (<class 'torch.fx.graph_module.GraphModule'>, <class 'torch.nn.parameter.Parameter'>)
```

The non lowerable part has a tensor type in the sub gm for get_attr

Test Plan: Sandcastle

Differential Revision: D70206758


