### PR TITLE
[ROCm] Enable mi300-specific workflows to be triggered on PRs

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -7,6 +7,7 @@ ciflow_push_tags:
 - ciflow/inductor
 - ciflow/inductor-periodic
 - ciflow/inductor-rocm
+- ciflow/inductor-rocm-mi300
 - ciflow/inductor-perf-compare
 - ciflow/inductor-micro-benchmark
 - ciflow/inductor-micro-benchmark-cpu-x86
@@ -16,6 +17,7 @@ ciflow_push_tags:
 - ciflow/nightly
 - ciflow/periodic
 - ciflow/rocm
+- ciflow/rocm-mi300
 - ciflow/s390
 - ciflow/slow
 - ciflow/trunk

--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -7,7 +7,6 @@ ciflow_push_tags:
 - ciflow/inductor
 - ciflow/inductor-periodic
 - ciflow/inductor-rocm
-- ciflow/inductor-rocm-mi300
 - ciflow/inductor-perf-compare
 - ciflow/inductor-micro-benchmark
 - ciflow/inductor-micro-benchmark-cpu-x86

--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -7,6 +7,7 @@ ciflow_push_tags:
 - ciflow/inductor
 - ciflow/inductor-periodic
 - ciflow/inductor-rocm
+- ciflow/inductor-perf-test-nightly-rocm
 - ciflow/inductor-perf-compare
 - ciflow/inductor-micro-benchmark
 - ciflow/inductor-micro-benchmark-cpu-x86

--- a/.github/workflows/inductor-perf-test-nightly-rocm.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm.yml
@@ -3,7 +3,7 @@ name: inductor-perf-nightly-rocm
 on:
   push:
     tags:
-      - ciflow/inductor-perf-nightly-rocm/*
+      - ciflow/inductor-perf-test-nightly-rocm/*
   schedule:
     - cron: 0 7 * * 0
   # NB: GitHub has an upper limit of 10 inputs here, so before we can sort it

--- a/.github/workflows/inductor-perf-test-nightly-rocm.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm.yml
@@ -1,6 +1,9 @@
 name: inductor-perf-nightly-rocm
 
 on:
+  push:
+    tags:
+      - ciflow/inductor-perf-nightly-rocm/*
   schedule:
     - cron: 0 7 * * 0
   # NB: GitHub has an upper limit of 10 inputs here, so before we can sort it

--- a/.github/workflows/inductor-rocm-mi300.yml
+++ b/.github/workflows/inductor-rocm-mi300.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - ciflow/inductor-rocm/*
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/rocm-mi300.yml
+++ b/.github/workflows/rocm-mi300.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - ciflow/rocm-mi300/*
   workflow_dispatch:
   schedule:
     - cron: 29 8 * * *  # about 1:29am PDT


### PR DESCRIPTION
This change will be needed to be able to trigger the MI300-specific CI workflows on PRs by using a PR label.

* inductor-rocm-mi300.yml uses the existing `ciflow/inductor-rocm` label so that any PR manually labeled as such will trigger `inductor` config runs on both MI200 and MI300.
* rocm-mi300.yml uses a separate `ciflow/rocm-mi300` label, since we don't want to over-trigger `default` config runs on MI300 runners due to limited capacity, and [`ciflow/rocm` label is automatically applied](https://github.com/pytorch/test-infra/blob/79438512a0632583899938d3b0277da78f5569e0/torchci/lib/bot/autoLabelBot.ts#L24) on many PRs.
* inductor-perf-test-nightly-rocm.yml uses a separate `ciflow/inductor-perf-test-nightly-rocm` label, so that we can manually trigger a round of perf testing on MI300 runners to test the perf impact of a major inductor-related change.


cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd