### PR TITLE
[BE][EZ] Delete MacOS-12.3 xfail list

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -151,14 +151,6 @@ def mps_ops_grad_modifier(ops):
         '_unsafe_masked_index_put_accumulate': [torch.float16],
     }
 
-    MACOS_12_3_XFAILLIST_GRAD = {
-        # Unsupported Border padding mode, forward pass success as fallback to cpu
-        'grid_sampler_2d': [torch.float32, torch.float16, torch.bfloat16],
-        # Unimplemented
-        'logaddexp2': [torch.float32],
-
-    }
-
     MACOS_BEFORE_13_3_XFAILLIST_GRAD = {
         # Failures due to precision issues (due to fast-math). These has been fixed in MacOS 13.3+
         'masked.softmin': [torch.float32, torch.float16],
@@ -225,11 +217,6 @@ def mps_ops_grad_modifier(ops):
             addDecorator(op, DecorateInfo(
                          unittest.expectedFailure,
                          dtypes=ON_MPS_XFAILLIST[key]))
-
-        if key in MACOS_12_3_XFAILLIST_GRAD and (not torch.backends.mps.is_macos13_or_newer()):
-            addDecorator(op, DecorateInfo(
-                         unittest.expectedFailure,
-                         dtypes=MACOS_12_3_XFAILLIST_GRAD[key]))
 
         if key in MACOS_BEFORE_13_3_XFAILLIST_GRAD and (torch.backends.mps.is_macos13_or_newer() and MACOS_VERSION < 13.3):
             addDecorator(op, DecorateInfo(
@@ -503,116 +490,6 @@ def mps_ops_modifier(ops):
         'byte',
     }
     # Those ops worked on MacOS12, but broken on MacOS13, see https://github.com/pytorch/pytorch/issues/85758
-    MACOS_12_3_XFAILLIST = {
-        # Top 60
-        # expected failures
-        # The result of pow(9 , 8) is showing 43046716, whereas it should've been 43046721.
-        # fixed in macOS 13.3. Currently error is not raised.
-        'pow': [torch.int16, torch.int64, torch.uint8, torch.int8],
-        # expected failures
-        '__rpow__': [torch.uint8, torch.int8],
-
-        # Failures due to precision issues (due to fast-math). These has been fixed in MacOS 13.3+
-        'cdist': [torch.float32],
-        'tan': [torch.uint8, torch.float32],
-
-        # Data type support starts from macOS 13
-        'nn.functional.avg_pool1d': [torch.int64],
-        'nn.functional.avg_pool2d': [torch.int64],
-        'nn.functional.local_response_norm': [torch.int64],
-        '__radd__': [torch.uint8],
-        '__rdiv__': [torch.uint8],
-        '__rmul__': [torch.uint8],
-        'abs': [torch.uint8],
-        'acos': [torch.uint8],
-        'acosh': [torch.uint8],
-        'add': [torch.uint8],
-        'asin': [torch.uint8],
-        'asinh': [torch.uint8],
-        'atan': [torch.uint8],
-        'atanh': [torch.uint8],
-        'ceil': [torch.uint8],
-        'corrcoef': [torch.uint8],
-        'cos': [torch.uint8],
-        'cosh': [torch.uint8],
-        'cov': [torch.uint8],
-        'cumulative_trapezoid': [torch.uint8],
-        'deg2rad': [torch.uint8],
-        'diff': [torch.uint8],
-        'eq': [torch.uint8],
-        'equal': [torch.uint8],
-        'erf': [torch.uint8],
-        'exp2': [torch.uint8],
-        'exp': [torch.uint8],
-        'expm1': [torch.uint8],
-        'floor': [torch.uint8],
-        'fmax': [torch.uint8],
-        'fmin': [torch.uint8],
-        'fmod': [torch.uint8],
-        'ge': [torch.uint8],
-        'gt': [torch.uint8],
-        'isclose': [torch.uint8],
-        'isnan': [torch.uint8],
-        'kron': [torch.uint8],
-        'le': [torch.uint8],
-        'log10': [torch.uint8],
-        'log1p': [torch.uint8],
-        'log2': [torch.uint8],
-        'log': [torch.uint8],
-        'logical_and': [torch.uint8],
-        'logical_or': [torch.uint8],
-        'logical_xor': [torch.uint8],
-        'logit': [torch.uint8],
-        'lt': [torch.uint8],
-        'masked.mean': [torch.uint8],
-        'masked.std': [torch.uint8],
-        'masked.var': [torch.uint8],
-        'maximum': [torch.uint8],
-        'minimum': [torch.uint8],
-        'mul': [torch.uint8],
-        'ne': [torch.uint8],
-        'neg': [torch.uint8],
-        'nn.functional.cosine_embedding_loss': [torch.uint8],
-        'nn.functional.margin_ranking_loss': [torch.uint8],
-        'nn.functional.poisson_nll_loss': [torch.uint8],
-        'nn.functional.softsign': [torch.uint8],
-        'nn.functional.tanhshrink': [torch.uint8],
-        'nn.functional.triplet_margin_loss': [torch.uint8],
-        'nn.functional.triplet_margin_with_distance_loss': [torch.uint8],
-        'nn.functional.pairwise_distance': [torch.uint8],
-        'outer': [torch.uint8],
-        'rad2deg': [torch.uint8],
-        'reciprocal': [torch.uint8],
-        'remainder': [torch.uint8],
-        'round': [torch.uint8],
-        'rsqrt': [torch.uint8],
-        'sigmoid': [torch.uint8],
-        'sign': [torch.uint8],
-        'signbit': [torch.uint8],
-        'sin': [torch.uint8],
-        'sinh': [torch.uint8],
-        'special.ndtr': [torch.uint8],
-        'sqrt': [torch.uint8],
-        'sub': [torch.uint8],
-        'trapezoid': [torch.uint8],
-        'trapz': [torch.uint8],
-        'true_divide': [torch.uint8],
-        'trunc': [torch.uint8],
-        'xlogy': [torch.uint8],
-        'minbinary': [torch.uint8],
-        'maxbinary': [torch.uint8],
-        'divtrunc_rounding': [torch.uint8],
-        'divfloor_rounding': [torch.uint8],
-        'divno_rounding_mode': [torch.uint8],
-        'floor_divide': [torch.uint8],
-        'ldexp': [torch.uint8],
-        # square internally calls into power, and will type cast to int64, which supports starting from macOS 13
-        'square': [torch.bool, torch.int16, torch.int32, torch.int64, torch.uint8, torch.int8],
-
-        # cpu not giving nan for x/0.0
-        'atan2': [torch.bool, torch.int16, torch.int32, torch.int64, torch.uint8, torch.int8],
-    }
-
     MACOS_BEFORE_13_3_XFAILLIST = {
         # Failures due to precision issues (due to fast-math). These has been fixed in MacOS 13.3+
         'tan': [torch.float32],
@@ -1027,11 +904,6 @@ def mps_ops_modifier(ops):
             addDecorator(op, DecorateInfo(
                          unittest.expectedFailure,
                          dtypes=MACOS_13_3_XFAILLIST[key]))
-
-        if key in MACOS_12_3_XFAILLIST and (not torch.backends.mps.is_macos13_or_newer()):
-            addDecorator(op, DecorateInfo(
-                         unittest.expectedFailure,
-                         dtypes=MACOS_12_3_XFAILLIST[key]))
 
         # If ops is not supported for complex types, expect it to fail
         if key not in SUPPORTED_COMPLEX_OPS and (key not in AFTER_MACOS_14_0_SUPPORTED_COMPLEX_OPS or MACOS_VERSION < 14.0):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #147893
* __->__ #147905
* #147892

As PyTorch requires at least MacOS-13 (and Metal-3) to work, delete any pre-MacoS13 checks from test script