### PR TITLE
Increase reference count of state tensor in `THPGenerator_reduce` to avoid premature garbage collection in `multiprocessing` start method `"forkserver"` and `"spawn"`

### DIFF
--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -259,6 +259,7 @@ static PyObject* THPGenerator_reduce(PyObject* _self, PyObject* noargs) {
   PyTuple_SET_ITEM(state.get(), 2, THPGenerator_getState(_self, nullptr));
   PyTuple_SET_ITEM(ret.get(), 2, state.release());
 
+  Py_INCREF(ret);
   return ret.release();
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -256,10 +256,11 @@ static PyObject* THPGenerator_reduce(PyObject* _self, PyObject* noargs) {
       1,
       device_type != at::kCPU ? THPGenerator_getOffset(_self, nullptr)
                               : Py_None);
-  PyTuple_SET_ITEM(state.get(), 2, THPGenerator_getState(_self, nullptr));
+  PyObject* state_tensor = THPGenerator_getState(_self, nullptr);
+  Py_INCREF(state_tensor);
+  PyTuple_SET_ITEM(state.get(), 2, state_tensor);
   PyTuple_SET_ITEM(ret.get(), 2, state.release());
 
-  Py_INCREF(ret);
   return ret.release();
   END_HANDLE_TH_ERRORS
 }


### PR DESCRIPTION
Fixes #146828

For this script:

```python
from __future__ import annotations

import time

import torch

def worker(generator: torch.Generator):
    print(generator.get_state())

if __name__ == '__main__':
    torch.multiprocessing.set_start_method("forkserver")  # or "spawn"

    generator = torch.Generator("cpu")
    process = torch.multiprocessing.Process(target=worker, args=(generator,))
    process.start()  # process.run() does not cause a crash

    for i in range(10):
        print("Main", i)
        time.sleep(1)

    process.join()
    process.close()

```

When I add ~~`Py_INCREF(ret)`~~ `Py_INCREF(state_tensor)`, I stop getting:

```console
$ python a.py
Main 0
Main 1
Traceback (most recent call last):
  File "/home/matthew/.conda/envs/torch39/lib/python3.9/multiprocessing/forkserver.py", line 274, in main
    code = _serve_one(child_r, fds,
  File "/home/matthew/.conda/envs/torch39/lib/python3.9/multiprocessing/forkserver.py", line 313, in _serve_one
    code = spawn._main(child_r, parent_sentinel)
  File "/home/matthew/.conda/envs/torch39/lib/python3.9/multiprocessing/spawn.py", line 126, in _main
    self = reduction.pickle.load(from_parent)
  File "/home/matthew/pytorch/torch/multiprocessing/reductions.py", line 546, in rebuild_storage_fd
    storage = cls._new_shared_fd_cpu(fd, size)
RuntimeError: unable to resize file <filename not specified> to the right size: Invalid argument (22)
Main 2
Main 3
Main 4
Main 5
Main 6
Main 7
Main 8
Main 9
```

And I start getting:

```console
$ python a.py
Main 0
Main 1
tensor([  1, 209, 156,  ...,   0,   0,   0], dtype=torch.uint8)
Main 2
Main 3
Main 4
Main 5
Main 6
Main 7
Main 8
Main 9
```

cc @pbelevich