### PR TITLE
[MPS] Introduce a shader for `entr()`.

### DIFF
--- a/c10/metal/special_math.h
+++ b/c10/metal/special_math.h
@@ -530,5 +530,22 @@ inline float xlog1py(T x, T y) {
   return x * log1p(y);
 }
 
+template <typename T>
+inline float entr(T a) {
+  if (a != a) {
+    return a;
+  }
+
+  if (a > 0) {
+    return -a * ::metal::log(a);
+  }
+
+  if (a == 0) {
+    return 0;
+  }
+
+  return -INFINITY;
+}
+
 } // namespace metal
 } // namespace c10


### PR DESCRIPTION
To be used in eager/inductor in order to implement the missing operation.

cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov