### PR TITLE
Fix auto_functionalize x inference_mode

### DIFF
--- a/test/inductor/test_auto_functionalize.py
+++ b/test/inductor/test_auto_functionalize.py
@@ -1707,6 +1707,27 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
             output = compiled(torch.rand(2, 2))
             self.assertNotEqual(id(output), id(input))
 
+    def test_inference_mode_view(self):
+        @torch.library.custom_op("mylib::foo", mutates_args={"workspace"})
+        def foo(x: torch.Tensor, workspace: torch.Tensor) -> torch.Tensor:
+            return x.clone()
+
+        @foo.register_fake
+        def _(x, workspace):
+            return x.clone()
+
+        @torch.compile(fullgraph=True, backend="aot_eager")
+        def f(x, w):
+            y = foo(x, w)
+            z = y.view(-1)
+            return z.sin()
+
+        x = torch.randn(2)
+        w = torch.randn(2)
+        with torch.inference_mode():
+            y = f(x, w)
+        self.assertEqual(y, x.sin())
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_higher_order_ops/auto_functionalize.py
+++ b/torch/_higher_order_ops/auto_functionalize.py
@@ -423,6 +423,7 @@ def get_mutable_args(op: OpOverload) -> tuple[list[str], list[torch.Type]]:
 
 
 def do_auto_functionalize(
+    mode: "torch._subclasses.functional_tensor.FunctionalTensorMode",
     op: OpOverload,
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
@@ -436,7 +437,7 @@ def do_auto_functionalize(
     """
     from torch._subclasses.functional_tensor import PythonFunctionalizeAPI
 
-    ctx = PythonFunctionalizeAPI()
+    ctx = PythonFunctionalizeAPI(mode=mode)
 
     # All of the (args, kwargs), but all as kwargs. The names for the
     # args come from the schema. This makes it easier for us to work with them.
@@ -512,13 +513,14 @@ def do_auto_functionalize(
 
 
 def do_auto_functionalize_v2(
+    mode: "torch._subclasses.functional_tensor.FunctionalTensorMode",
     op: OpOverload,
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
 ) -> Any:
     from torch._subclasses.functional_tensor import PythonFunctionalizeAPI
 
-    ctx = PythonFunctionalizeAPI()
+    ctx = PythonFunctionalizeAPI(mode=mode)
 
     # All of the (args, kwargs), but all as kwargs. The names for the
     # args come from the schema. This makes it easier for us to work with them.

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -466,9 +466,9 @@ class FunctionalTensorMode(TorchDispatchMode):
             import torch._inductor.config as inductor_config
 
             if self.export or not inductor_config.enable_auto_functionalized_v2:
-                return do_auto_functionalize(func, args, kwargs)
+                return do_auto_functionalize(self, func, args, kwargs)
             else:
-                return do_auto_functionalize_v2(func, args, kwargs)
+                return do_auto_functionalize_v2(self, func, args, kwargs)
 
         from torch._higher_order_ops.effects import handle_effects, has_effects
 

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -460,9 +460,6 @@ class FunctionalTensorMode(TorchDispatchMode):
         ) and not torch._C._dispatch_has_kernel_for_dispatch_key(
             func.name(), torch._C.DispatchKey.Functionalize
         ):
-            # it doesn't matter what mode we use here because
-            # the implementation of do_auto_functionalize doesn't
-            # interact with FunctionalTensorMode at all
             import torch._inductor.config as inductor_config
 
             if self.export or not inductor_config.enable_auto_functionalized_v2:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147925

Fixes #147924

We were using the wrong FunctionalTensorMode to construct
FunctionalTensors. FunctionalTensors modify the FunctionalTensorMode on
construction, so that led to the wrong FunctionalTensorMode being
modified. This PR threads the FunctionalTensorMode through correctly.

Test Plan:
- new test

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov