### PR TITLE
Custom ops support arbitrary input types by migrating to python dispatcher

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2467,6 +2467,7 @@ class TestCustomOpAPI(TestCase):
                     lambda info, in_dims, x, *, y: (x, 0),
                 )
 
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_dict_input(self):
         @torch.library.custom_op("mylib::foo", mutates_args=())
         def foo(d: dict, t: torch.Tensor) -> torch.Tensor:
@@ -2477,6 +2478,7 @@ class TestCustomOpAPI(TestCase):
         y = torch.ops.mylib.foo(d, t)
         self.assertEqual(y, torch.sin(d["x"] - d["y"] + t))
 
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_dataclass_input(self):
         torch.utils._pytree.register_dataclass(Point)
 

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3225,6 +3225,7 @@ def _module_dir(m: types.ModuleType):
 LEGACY_MOD_INLINELIST = {
     "torch._dynamo.external_utils",
     "torch._export.db.examples",
+    "torch._export.utils",
     "torch._export.wrappers",
     "torch._functorch.apis",
     "torch._functorch.deprecated",

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -40,6 +40,7 @@ import torch._C
 import torch._refs
 import torch.fx
 import torch.nn
+import torch.utils._pytree as pytree
 from torch._guards import TracingContext
 from torch._logging import warning_once
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass_type
@@ -1111,6 +1112,51 @@ This error is most likely due to a call to `nonstrict_trace`-ed function, where 
             result = special_handler(self, tx, *args, **kwargs)
             if result:
                 return result
+
+        # If the function is custom op, we need to wrap it as flat_apply call in the fx graph.
+        if isinstance(self.value, torch._ops.CustomOpOverload):
+            from torch._higher_order_ops.flat_apply import ConstantFunction, flat_apply
+
+            fn = self.value.py_kernels[torch._C.DispatchKey.CompositeExplicitAutograd]
+            packed_input_vt = TupleVariable.build(
+                tx,
+                (
+                    variables.TupleVariable.build(tx, args),
+                    variables.ConstDictVariable.build(tx, kwargs),
+                ),
+            )
+            flat_args_and_spec = variables.UserFunctionVariable(
+                pytree.tree_flatten
+            ).call_function(tx, [packed_input_vt], {})
+
+            flat_args_vt, in_spec_vt = flat_args_and_spec.items
+            _, func_spec = pytree.tree_flatten(ConstantFunction(fn))
+            in_spec = in_spec_vt.as_python_constant()
+            func_spec_proxy = tx.output.register_static_attr_and_return_proxy(
+                f"{fn.__name__}_spec", func_spec
+            )
+            in_spec_proxy = tx.output.register_static_attr_and_return_proxy(
+                fn.__name__ + "_input_spec", in_spec
+            )
+
+            proxified_flat_args = [
+                flat_arg_vt.as_proxy() for flat_arg_vt in flat_args_vt.items
+            ]
+
+            func_spec_proxy.node.type = type(func_spec)
+            in_spec_proxy.node.type = type(in_spec)
+            all_args = (func_spec_proxy, in_spec_proxy, *proxified_flat_args)
+
+            out_vt = wrap_fx_proxy(
+                tx=tx,
+                proxy=tx.output.create_proxy(
+                    "call_function",
+                    flat_apply,
+                    all_args,
+                    {},
+                ),
+            )
+            return out_vt
 
         any_symints_or_symfloats = any(isinstance(x, SymNodeVariable) for x in args)
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -213,8 +213,8 @@ def get_overridable_functions():
 def is_python_dispatcher_op_overload(op):
     return (
         isinstance(op, torch._ops.CustomOpOverload)
-        or isinstance(op, torch._ops.OpOverload)
-        and isinstance(op._op, torch._ops.CustomOpOverload)
+        or isinstance(op, torch._ops.OpOverloadPacket)
+        and op._has_pytree_arg_overload
     )
 
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -212,7 +212,7 @@ def get_overridable_functions():
 
 def is_python_dispatcher_op_overload(op):
     return (
-        isinstance(op, torch._ops.CustomOpOverload)
+        isinstance(op, torch._ops.PythonDispatcherOpOverload)
         or isinstance(op, torch._ops.OpOverloadPacket)
         and op._has_pytree_arg_overload
     )

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -347,7 +347,7 @@ class CustomOpDef:
                         return result
 
                     need_python_dispatch = hasattr(self, "_opoverload") and isinstance(
-                        self._opoverload, torch._ops.CustomOpOverload
+                        self._opoverload, torch._ops.PythonDispatcherOpOverload
                     )
 
                     if device_type is None:
@@ -623,7 +623,9 @@ class CustomOpDef:
         )
         self._opoverload = utils.lookup_op(self._qualname)
 
-        need_python_dispatch = isinstance(self._opoverload, torch._ops.CustomOpOverload)
+        need_python_dispatch = isinstance(
+            self._opoverload, torch._ops.PythonDispatcherOpOverload
+        )
 
         def fake_impl(*args, **kwargs):
             if self._abstract_fn is None:

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -636,7 +636,7 @@ class CustomOpDef:
                     f"fake impl."
                 )
             if need_python_dispatch:
-                args = args[1:]
+                args = args[1:]  # Remove the dispatch key under fake tensor mode.
             return self._abstract_fn(*args, **kwargs)
 
         autograd_impl = autograd.make_autograd_impl(self._opoverload, self)

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -346,7 +346,7 @@ class CustomOpDef:
                         )
                         return result
 
-                    need_python_dispatch = isinstance(
+                    need_python_dispatch = hasattr(self, "_opoverload") and isinstance(
                         self._opoverload, torch._ops.CustomOpOverload
                     )
 
@@ -361,9 +361,9 @@ class CustomOpDef:
                             )
                     else:
                         if need_python_dispatch:
-                            self._opoverload.py_impl(
-                                _C._dispatch_key_for_device(device_type)
-                            )(backend_impl)
+                            dispatch_key = _C._dispatch_key_for_device(device_type)
+                            dispatch_key = getattr(_C.DispatchKey, dispatch_key)
+                            self._opoverload.py_impl(dispatch_key)(backend_impl)
                         else:
                             self._lib.impl(
                                 self._name,

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -124,7 +124,9 @@ def infer_schema(
         annotation_type, _ = unstringify_type(param.annotation)
 
         if annotation_type not in SUPPORTED_PARAM_TYPES:
-            if annotation_type.__origin__ is tuple:
+            if annotation_type in torch.utils._pytree.SUPPORTED_NODES:
+                schema_type = "Any"
+            elif annotation_type.__origin__ is tuple:
                 list_type = tuple_to_list(annotation_type)
                 example_type_str = "\n\n"
                 # Only suggest the list type if this type is supported.
@@ -141,8 +143,8 @@ def infer_schema(
                     f"Parameter {name} has unsupported type {param.annotation}. "
                     f"The valid types are: {SUPPORTED_PARAM_TYPES.keys()}."
                 )
-
-        schema_type = SUPPORTED_PARAM_TYPES[annotation_type]
+        else:
+            schema_type = SUPPORTED_PARAM_TYPES[annotation_type]
         if type(mutates_args) == str:
             if mutates_args != UNKNOWN_MUTATES:
                 raise ValueError(

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -125,6 +125,7 @@ def infer_schema(
 
         if annotation_type not in SUPPORTED_PARAM_TYPES:
             if annotation_type in torch.utils._pytree.SUPPORTED_NODES:
+                # TODO: Move to a separate schema type for pytrees.
                 schema_type = "Any"
             elif annotation_type.__origin__ is tuple:
                 list_type = tuple_to_list(annotation_type)

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -151,17 +151,17 @@ def infer_schema(
                     "mutates_args must either be a sequence of the names of "
                     "the arguments that are mutated or the string 'unknown'. "
                 )
-            if schema_type.startswith("Tensor"):
-                schema_type = f"Tensor(a{idx}!){schema_type[len('Tensor'):]}"
+            if schema_type.startswith("Tensor"):  # type: ignore[possibly-undefined]
+                schema_type = f"Tensor(a{idx}!){schema_type[len('Tensor'):]}"  # type: ignore[possibly-undefined]
         elif name in mutates_args:
-            if not schema_type.startswith("Tensor"):
+            if not schema_type.startswith("Tensor"):  # type: ignore[possibly-undefined]
                 error_fn(
                     f"Parameter {name} is in mutable_args but only Tensors or collections of Tensors can be mutated"
                 )
-            schema_type = f"Tensor(a{idx}!){schema_type[len('Tensor'):]}"
+            schema_type = f"Tensor(a{idx}!){schema_type[len('Tensor'):]}"  # type: ignore[possibly-undefined]
         seen_args.add(name)
         if param.default is inspect.Parameter.empty:
-            params.append(f"{schema_type} {name}")
+            params.append(f"{schema_type} {name}")  # type: ignore[possibly-undefined]
         else:
             default_repr = None
             if param.default is None or isinstance(param.default, (int, float, bool)):
@@ -178,7 +178,7 @@ def infer_schema(
                     f"Parameter {name} has an unsupported default value type {type(param.default)}. "
                     f"Please file an issue on GitHub so we can prioritize this."
                 )
-            params.append(f"{schema_type} {name}={default_repr}")
+            params.append(f"{schema_type} {name}={default_repr}")  # type: ignore[possibly-undefined]
     if mutates_args != UNKNOWN_MUTATES:
         mutates_args_not_seen = set(mutates_args) - seen_args
         if len(mutates_args_not_seen) > 0:

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -320,6 +320,7 @@ class HigherOrderOperator(OperatorBase, abc.ABC):
             TransformType,
             DispatchKey,
         ],
+        with_keyset: bool = False,
     ) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
         if isinstance(k, DispatchKey) and not self.non_fallthrough_keys.has(k):
             self.non_fallthrough_keys = self.non_fallthrough_keys.add(k)
@@ -1236,11 +1237,11 @@ class OpOverloadPacket:
             op_, op_dk_, tags = op_dk_tags
             schema = torch._C._get_schema(self._qualified_op_name, use_key)
             if _has_pytree_object_arg(schema):
-                overload = CustomOpOverload(self, op_, op_dk_, schema, tags)
+                overload = CustomOpOverload(self, op_, op_dk_, schema, tags)  # type: ignore[assignment]
             elif _has_script_object_arg(schema):
-                overload = TorchBindOpOverload(self, op_, op_dk_, schema, tags)
+                overload = TorchBindOpOverload(self, op_, op_dk_, schema, tags)  # type: ignore[assignment]
             else:
-                overload = OpOverload(self, op_, op_dk_, schema, tags)
+                overload = OpOverload(self, op_, op_dk_, schema, tags)  # type: ignore[assignment]
             # cache the overload object
             setattr(self, key, overload)
             self._dir.append(key)

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -945,9 +945,9 @@ class OpOverload(OperatorBase):
     # TODO: add more methods to expose information about input and output arguments
 
 
-class CustomOpOverload(OpOverload):
+class PythonDispatcherOpOverload(OpOverload):
     def __repr__(self):
-        return "<CustomOpOverload(op='{}.{}', overload='{}')>".format(
+        return "<PythonDispatcherOpOverload(op='{}.{}', overload='{}')>".format(
             *self._schema.name.split("::"), self._overloadname
         )
 
@@ -1237,7 +1237,7 @@ class OpOverloadPacket:
             op_, op_dk_, tags = op_dk_tags
             schema = torch._C._get_schema(self._qualified_op_name, use_key)
             if _has_pytree_object_arg(schema):
-                overload = CustomOpOverload(self, op_, op_dk_, schema, tags)  # type: ignore[assignment]
+                overload = PythonDispatcherOpOverload(self, op_, op_dk_, schema, tags)  # type: ignore[assignment]
             elif _has_script_object_arg(schema):
                 overload = TorchBindOpOverload(self, op_, op_dk_, schema, tags)  # type: ignore[assignment]
             else:


### PR DESCRIPTION
Test case:
```
@torch.library.custom_op("mylib::foo", mutates_args=())
def foo(d: dict, t: torch.Tensor) -> torch.Tensor:
    return torch.sin(d["x"] - d["y"] + t)


@foo.register_fake
def _(d: dict, t: torch.Tensor) -> torch.Tensor:
    return torch.empty_like(d["x"])

d = {"x": torch.randn(2, 3, requires_grad=True), "y": torch.randn(2, 3, requires_grad=True)}
t = torch.randn(2, 3, requires_grad=True)

@torch.compile(backend="eager", fullgraph=True)
def fn(d, t):
    return torch.sin(torch.ops.mylib.foo.default(d, t) + 1.5)

y = fn(d, t)
print(y)
y.sum().backward()
print(d["x"].grad)
print(d["y"].grad)
print(t.grad)
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames