### PR TITLE
test 0-dim squeeze in basic.TestSqueeze

### DIFF
--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -166,8 +166,10 @@ void TestSqueeze(DeprecatedTypeProperties& type) {
   ASSERT_EQ_RESOLVED(b.dim(), 1);
   a = rand({1}, type);
   b = squeeze(a);
-  // TODO 0-dim squeeze
   ASSERT_TRUE(a[0].equal(b));
+  Tensor c = at::scalar_tensor(1, type.options());
+  Tensor d = squeeze(c);
+  ASSERT_TRUE(c.equal(d));
 }
 
 void TestCopy(DeprecatedTypeProperties& type) {


### PR DESCRIPTION
Replace TODO with 0-dim squeeze, checks scalar is unchanged in `basic.TestSqueeze`
