### PR TITLE
[torch/elastic][upstream] Fix the wrong order when start_index is not 0

### DIFF
--- a/torch/distributed/elastic/utils/data/elastic_distributed_sampler.py
+++ b/torch/distributed/elastic/utils/data/elastic_distributed_sampler.py
@@ -52,10 +52,10 @@ class ElasticDistributedSampler(DistributedSampler):
         g = torch.Generator()
         g.manual_seed(self.epoch)
         indices = (
-            torch.randperm(len(self.dataset) - self.start_index, generator=g)  # type: ignore[arg-type]
-            .add(self.start_index)
+            torch.randperm(len(self.dataset), generator=g)  # type: ignore[arg-type]
             .tolist()
         )
+        indices = indices[self.start_index:]
 
         # add extra samples to make it evenly divisible
         indices += indices[: (self.total_size - len(indices))]


### PR DESCRIPTION
For ElasticDistributedSampler. If job is restarted, we will train from start_index. It means that indices should keep order. But it doesn't actually keep the order.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @dzhulgakov