### PR TITLE
[BE] Do not copy arguments in variadic template

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -421,9 +421,9 @@ static inline void mtl_setArgs(id<MTLComputeCommandEncoder> encoder, const T& va
 }
 
 template <unsigned idx = 0, typename T, typename... Args>
-static inline void mtl_setArgs(id<MTLComputeCommandEncoder> encoder, const T& val, Args... args) {
+static inline void mtl_setArgs(id<MTLComputeCommandEncoder> encoder, const T& val, Args&&... args) {
   detail::mtl_setArg(encoder, val, idx);
-  mtl_setArgs<idx + 1>(encoder, args...);
+  mtl_setArgs<idx + 1>(encoder, std::forward<Args>(args)...);
 }
 
 static inline void mtl_dispatch1DJob(id<MTLComputeCommandEncoder> encoder,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #147369
* __->__ #147977

By adding missing  `std::forward<Args>(args)...` and declaring template as passing args by reference

Noticed while working on creating `mtl_setBytes` specification that takes `MPSScalar` as argument