### PR TITLE
Support whitelist of dynamic sources

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7859,7 +7859,7 @@ utils_device.CURRENT_DEVICE == None""".split(
             torch.compile(my_dyn_fn, backend="eager")(y, y)
 
     @torch.compiler.config.patch(dynamic_sources="L['x']")
-    def test_dynamic_int_sources(self):
+    def test_dynamic_sources_int(self):
         counter = CompileCounter()
 
         @torch.compile(backend=counter)
@@ -7873,7 +7873,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         self.assertEqual(counter.frame_count, 1)
 
     @torch.compiler.config.patch(dynamic_sources="L['x']")
-    def test_dynamic_tensor_sources(self):
+    def test_dynamic_sources_tensor(self):
         counter = CompileCounter()
 
         @torch.compile(backend=counter)

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -51,6 +51,7 @@ from torch._dynamo.testing import (
     unsupported,
 )
 from torch._dynamo.utils import counters, ifdynstaticdefault
+from torch._dynamo.variables import builder
 from torch._inductor.utils import run_and_get_code
 from torch.ao.quantization import MinMaxObserver
 from torch.ao.quantization.fake_quantize import FakeQuantize
@@ -7858,6 +7859,42 @@ utils_device.CURRENT_DEVICE == None""".split(
         with self.assertRaises(ConstraintViolationError):
             torch.compile(my_dyn_fn, backend="eager")(y, y)
 
+    @torch._dynamo.config.patch(force_parameter_static_shapes=True)
+    @torch._dynamo.config.patch(force_nn_module_property_static_shapes=True)
+    @torch.compiler.config.patch(dynamic_sources="L['x'],L['y'],L['self']._modules['y'].x,L['self']._modules['y']._modules['c']._parameters['weight'],L['self']._modules['y']._modules['c']._parameters['bias']")
+    def test_dynamic_sources_force_parameter_static_shapes_and_property_static_shapes_override(self):
+        builder._DYNAMIC_SOURCES = None
+
+        counter = CompileCounter()
+        class Y(torch.nn.Module):
+            def __init__(self, n_input, n_output):
+                super().__init__()
+                self.c = torch.nn.Linear(n_input, n_output)
+                self.x = n_input
+
+            def forward(self, x):
+                return self.c(x) * self.x
+
+        class M(torch.nn.Module):
+            def __init__(self, n_input, n_output):
+                self.n_input = n_input
+                self.n_output = n_output
+                super().__init__()
+                self.y = Y(n_input, n_output)
+
+            @torch.compile(backend=counter)
+            def forward(self, x, y):
+                return self.y(x) * y
+
+        model = M(3210, 30)
+        model(torch.randn(1, 3210), 2)
+        model = M(3211, 30)
+        model(torch.randn(1, 3211), 3)
+        model = M(3212, 30)
+        model(torch.randn(1, 3212), 4)
+
+        self.assertEqual(counter.frame_count, 1)
+
     @torch.compiler.config.patch(dynamic_sources="L['x']")
     def test_dynamic_sources_int(self):
         counter = CompileCounter()
@@ -7905,6 +7942,22 @@ utils_device.CURRENT_DEVICE == None""".split(
 
         # 2 since graph break produces 2 graphs. NB: there are no recompiles
         self.assertEqual(counter.frame_count, 2)
+
+
+    @torch.compiler.config.patch(dynamic_sources="L['x'], L['y']")
+    def test_dynamic_sources_dynamic_override(self):
+        counter = CompileCounter()
+
+        @torch.compile(dynamic=False, backend=counter)
+        def fn(x, y):
+            return x * y
+
+        fn(2, torch.randn(2))
+        fn(3, torch.randn(3))
+        fn(4, torch.randn(4))
+
+        self.assertEqual(counter.frame_count, 1)
+
 
     def test_cannot_trace_mark_dynamic(self):
         y = torch.randn([3, 3, 3])

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7861,11 +7861,16 @@ utils_device.CURRENT_DEVICE == None""".split(
 
     @torch._dynamo.config.patch(force_parameter_static_shapes=True)
     @torch._dynamo.config.patch(force_nn_module_property_static_shapes=True)
-    @torch.compiler.config.patch(dynamic_sources="L['x'],L['y'],L['self']._modules['y'].x,L['self']._modules['y']._modules['c']._parameters['weight'],L['self']._modules['y']._modules['c']._parameters['bias']")
-    def test_dynamic_sources_force_parameter_static_shapes_and_property_static_shapes_override(self):
+    @torch.compiler.config.patch(
+        dynamic_sources="L['x'],L['y'],L['self']._modules['y'].x,L['self']._modules['y']._modules['c']._parameters['weight'],L['self']._modules['y']._modules['c']._parameters['bias']"
+    )
+    def test_dynamic_sources_force_parameter_static_shapes_and_property_static_shapes_override(
+        self,
+    ):
         builder._DYNAMIC_SOURCES = None
 
         counter = CompileCounter()
+
         class Y(torch.nn.Module):
             def __init__(self, n_input, n_output):
                 super().__init__()
@@ -7943,7 +7948,6 @@ utils_device.CURRENT_DEVICE == None""".split(
         # 2 since graph break produces 2 graphs. NB: there are no recompiles
         self.assertEqual(counter.frame_count, 2)
 
-
     @torch.compiler.config.patch(dynamic_sources="L['x'], L['y']")
     def test_dynamic_sources_dynamic_override(self):
         counter = CompileCounter()
@@ -7957,7 +7961,6 @@ utils_device.CURRENT_DEVICE == None""".split(
         fn(4, torch.randn(4))
 
         self.assertEqual(counter.frame_count, 1)
-
 
     def test_cannot_trace_mark_dynamic(self):
         y = torch.randn([3, 3, 3])

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2644,12 +2644,15 @@ def get_automatic_dynamic_shapes_mark_as():
 
 _DYNAMIC_SOURCES: Optional[set[str]] = None
 
+
 def get_dynamic_sources() -> set[str]:
     global _DYNAMIC_SOURCES
     if _DYNAMIC_SOURCES is not None:
         return _DYNAMIC_SOURCES
 
-    _DYNAMIC_SOURCES = set(torch.compiler.config.dynamic_sources.replace(" ", "").split(","))
+    _DYNAMIC_SOURCES = set(
+        torch.compiler.config.dynamic_sources.replace(" ", "").split(",")
+    )
 
     return _DYNAMIC_SOURCES
 

--- a/torch/compiler/config.py
+++ b/torch/compiler/config.py
@@ -69,6 +69,9 @@ dynamic_sources: str = Config(
 """
 Comma delimited list of sources that should be marked as dynamic. Primarily useful for large
 models with graph breaks where you need intermediate tensors and ints to be marked dynamic.
+
+This whitelist is dominant over all other flags dynamic=False, force_nn_module_property_static_shapes
+and force_parameter_static_shapes.
 """
 
 

--- a/torch/compiler/config.py
+++ b/torch/compiler/config.py
@@ -63,5 +63,13 @@ Tag to be included in the cache key generation for all torch compile caching.
 A common use case for such a tag is to break caches.
 """
 
+dynamic_sources: str = Config(
+    env_name_default="TORCH_COMPILE_DYNAMIC_SOURCES", default=""
+)
+"""
+Comma delimited list of sources that should be marked as dynamic. Primarily useful for large
+models with graph breaks where you need intermediate tensors and ints to be marked dynamic.
+"""
+
 
 install_config_module(sys.modules[__name__])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #147979

This PR introduces the ability to whitelist sources as dynamic. This is particularly useful for large models with graph breaks, as you can keep the dynamism across graph breaks since source names stay consistent. Additionally you can use this to mark ints as dynamic.

NB: I intentionally didn't complicate the interface by supporting specification of per dimension dynamism. There is virtue in keeping true to the standard way of representing sources (eg. L['x']). If we find in practice that we need more more fine grained control, we can explore further affordances at that time.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames