### PR TITLE
[CI] Don't clean workspace when fetching repo

### DIFF
--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -37,18 +37,36 @@ runs:
         # Clean workspace. The default checkout action should also do this, but
         # do it here as well just in case
         if [[ -d .git ]]; then
-          if [ -z "${NO_SUDO}" ]; then
-            sudo git clean -ffdx
-          else
+          # if [ -z "${NO_SUDO}" ]; then
+          #   sudo git clean -ffdx
+          # else
             git clean -ffdx
-          fi
+          # fi
         fi
+
+    - name: Checkout PyTorch
+      id: first-checkout-attempt
+      continue-on-error: true
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        # --depth=1 for speed, manually fetch history and other refs as necessary
+        fetch-depth: ${{ inputs.fetch-depth }}
+        submodules: ${{ inputs.submodules }}
+        show-progress: false
+
+    - name: Remove entire workspace if checkout failed
+      if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' && first-checkout-attempt.outcome != 'success' }}
+      shell: bash
+      env:
+        NO_SUDO: ${{ inputs.no-sudo }}
+      run: |
+        rm -rf "${GITHUB_WORKSPACE}"
 
     - name: Checkout PyTorch
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        # --depth=1 for speed, manually fetch history and other refs as necessary
         fetch-depth: ${{ inputs.fetch-depth }}
         submodules: ${{ inputs.submodules }}
         show-progress: false

--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -57,7 +57,7 @@ runs:
         submodules: ${{ inputs.submodules }}
         show-progress: false
 
-    - name: Remove entire workspace if checkout failed
+    - name: Clean workspace (try again)
       if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' &&
         (steps.first-clean != 'success' || steps.first-checkout-attempt.outcome != 'success') }}
       shell: bash
@@ -75,7 +75,7 @@ runs:
         fi
         mkdir "${GITHUB_WORKSPACE}"
 
-    - name: Checkout PyTorch
+    - name: Checkout PyTorch (try again)
       uses: actions/checkout@v4
       if: ${{ steps.first-clean != 'success' || steps.first-checkout-attempt.outcome != 'success' }}
       with:

--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -26,6 +26,8 @@ runs:
     - name: Set up parallel fetch and clean workspace
       shell: bash
       if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' }}
+      env:
+        NO_SUDO: ${{ inputs.no-sudo }}
       run: |
         # Use all available CPUs for fetching
         cd "${GITHUB_WORKSPACE}"
@@ -35,7 +37,11 @@ runs:
         # Clean workspace. The default checkout action should also do this, but
         # do it here as well just in case
         if [[ -d .git ]]; then
-          git clean -ffdx
+          if [ -z "${NO_SUDO}" ]; then
+            sudo git clean -ffdx
+          else
+            git clean -ffdx
+          fi
         fi
 
     - name: Checkout PyTorch

--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -23,7 +23,7 @@ runs:
       id: check_container_runner
       run: echo "IN_CONTAINER_RUNNER=$(if [ -f /.inarc ] || [ -f /.incontainer ]; then echo true ; else echo false; fi)" >> "$GITHUB_OUTPUT"
 
-    - name: Set up parallel fetch
+    - name: Set up parallel fetch and clean workspace
       shell: bash
       if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' }}
       run: |
@@ -31,6 +31,12 @@ runs:
         cd "${GITHUB_WORKSPACE}"
         git config --global fetch.parallel 0
         git config --global submodule.fetchJobs 0
+
+        # Clean workspace. The default checkout action should also do this, but
+        # do it here as well just in case
+        if [[ -d .git ]]; then
+          git clean -ffdx
+        fi
 
     - name: Checkout PyTorch
       uses: actions/checkout@v4

--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -56,7 +56,7 @@ runs:
         show-progress: false
 
     - name: Remove entire workspace if checkout failed
-      if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' && first-checkout-attempt.outcome != 'success' }}
+      if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' && steps.first-checkout-attempt.outcome != 'success' }}
       shell: bash
       env:
         NO_SUDO: ${{ inputs.no-sudo }}

--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -65,6 +65,7 @@ runs:
 
     - name: Checkout PyTorch
       uses: actions/checkout@v4
+      if: ${{ steps.first-checkout-attempt.outcome != 'success' }}
       with:
         ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         fetch-depth: ${{ inputs.fetch-depth }}

--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -24,6 +24,8 @@ runs:
       run: echo "IN_CONTAINER_RUNNER=$(if [ -f /.inarc ] || [ -f /.incontainer ]; then echo true ; else echo false; fi)" >> "$GITHUB_OUTPUT"
 
     - name: Set up parallel fetch and clean workspace
+      id: first-clean
+      continue-on-error: true
       shell: bash
       if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' }}
       env:
@@ -56,7 +58,8 @@ runs:
         show-progress: false
 
     - name: Remove entire workspace if checkout failed
-      if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' && steps.first-checkout-attempt.outcome != 'success' }}
+      if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' &&
+        (steps.first-clean != 'success' || steps.first-checkout-attempt.outcome != 'success') }}
       shell: bash
       env:
         NO_SUDO: ${{ inputs.no-sudo }}
@@ -65,7 +68,7 @@ runs:
 
     - name: Checkout PyTorch
       uses: actions/checkout@v4
-      if: ${{ steps.first-checkout-attempt.outcome != 'success' }}
+      if: ${{ steps.first-clean != 'success' || steps.first-checkout-attempt.outcome != 'success' }}
       with:
         ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         fetch-depth: ${{ inputs.fetch-depth }}

--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -64,7 +64,16 @@ runs:
       env:
         NO_SUDO: ${{ inputs.no-sudo }}
       run: |
-        rm -rf "${GITHUB_WORKSPACE}"
+        retry () {
+          $* || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
+        }
+        echo "${GITHUB_WORKSPACE}"
+        if [ -z "${NO_SUDO}" ]; then
+          retry sudo rm -rf "${GITHUB_WORKSPACE}"
+        else
+          retry rm -rf "${GITHUB_WORKSPACE}"
+        fi
+        mkdir "${GITHUB_WORKSPACE}"
 
     - name: Checkout PyTorch
       uses: actions/checkout@v4

--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -59,7 +59,7 @@ runs:
 
     - name: Clean workspace (try again)
       if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' &&
-        (steps.first-clean != 'success' || steps.first-checkout-attempt.outcome != 'success') }}
+        (steps.first-clean.outcome != 'success' || steps.first-checkout-attempt.outcome != 'success') }}
       shell: bash
       env:
         NO_SUDO: ${{ inputs.no-sudo }}
@@ -77,7 +77,7 @@ runs:
 
     - name: Checkout PyTorch (try again)
       uses: actions/checkout@v4
-      if: ${{ steps.first-clean != 'success' || steps.first-checkout-attempt.outcome != 'success' }}
+      if: ${{ steps.first-clean.outcome != 'success' || steps.first-checkout-attempt.outcome != 'success' }}
       with:
         ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         fetch-depth: ${{ inputs.fetch-depth }}

--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -39,11 +39,11 @@ runs:
         # Clean workspace. The default checkout action should also do this, but
         # do it here as well just in case
         if [[ -d .git ]]; then
-          # if [ -z "${NO_SUDO}" ]; then
-          #   sudo git clean -ffdx
-          # else
+          if [ -z "${NO_SUDO}" ]; then
+            sudo git clean -ffdx
+          else
             git clean -ffdx
-          # fi
+          fi
         fi
 
     - name: Checkout PyTorch

--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -23,23 +23,10 @@ runs:
       id: check_container_runner
       run: echo "IN_CONTAINER_RUNNER=$(if [ -f /.inarc ] || [ -f /.incontainer ]; then echo true ; else echo false; fi)" >> "$GITHUB_OUTPUT"
 
-    - name: Clean workspace
+    - name: Set up parallel fetch
       shell: bash
       if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' }}
-      env:
-        NO_SUDO: ${{ inputs.no-sudo }}
       run: |
-        retry () {
-          $* || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
-        }
-        echo "${GITHUB_WORKSPACE}"
-        if [ -z "${NO_SUDO}" ]; then
-          retry sudo rm -rf "${GITHUB_WORKSPACE}"
-        else
-          retry rm -rf "${GITHUB_WORKSPACE}"
-        fi
-        mkdir "${GITHUB_WORKSPACE}"
-
         # Use all available CPUs for fetching
         cd "${GITHUB_WORKSPACE}"
         git config --global fetch.parallel 0


### PR DESCRIPTION
Tested on https://github.com/pytorch/pytorch/pull/148995
Do two checkouts: first one attempts to use an existing checkout if possible.  The second one removes the workspace and re pulls everything if the first one fails

This is probably not going to be useful if we switch entirely to ephemeral runners but w/e


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd