### PR TITLE
Back out "Only call triton in worker process, ahead of time compile"

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1552,9 +1552,6 @@ class TestAutotuneCache(TestCase):
     @config.patch({"autotune_remote_cache": True})
     @config.patch({"bundled_autotune_remote_cache": False})
     @config.patch({"max_autotune": True})
-    @config.patch(
-        {"compile_threads": 1}
-    )  # Worker processes do not register PatchCaches() properly
     def test_autotune_cache(self):
         class Model(torch.nn.Module):
             def forward(self, x, y, a, b):
@@ -1592,7 +1589,6 @@ class TestAutotuneCache(TestCase):
     @config.patch({"autotune_local_cache": True})
     @config.patch({"autotune_remote_cache": False})
     @config.patch({"bundled_autotune_remote_cache": True})
-    @config.patch({"compile_threads": 1})
     @config.patch({"max_autotune": True})
     def test_bundled_autotune_remote_cache(self):
         class Model(torch.nn.Module):

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1032,7 +1032,7 @@ class TestMaxAutotuneRemoteCache(TestCase):
 
     @parametrize("dynamic", (False, True))
     @config.patch(
-        {"compile_threads": 1, "prologue_fusion": False}
+        {"prologue_fusion": False}
     )  # Worker processes do not register PatchCaches() properly
     def test_max_autotune_remote_caching(self, dynamic: bool):
         from unittest.mock import patch

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -18,8 +18,6 @@ from torch._dynamo.device_interface import get_registered_device_interfaces
 from torch._dynamo.utils import counters, dynamo_timed, set_feature_use
 from torch._inductor import config
 from torch._inductor.codecache import (
-    _load_triton_kernel_from_source,
-    code_hash,
     CodeCacheFuture,
     CppCodeCache,
     CppPythonBindingsCodeCache,
@@ -27,7 +25,8 @@ from torch._inductor.codecache import (
     HalideCodeCache,
     LambdaFuture,
     ROCmCodeCache,
-    torch_key,
+    TritonCodeCache,
+    TritonFuture,
 )
 from torch._inductor.compile_worker.subproc_pool import AnyPool, SubprocPool
 from torch._inductor.compile_worker.watchdog import _async_compile_initializer
@@ -43,7 +42,6 @@ from torch.utils._triton import has_triton_package
 
 if TYPE_CHECKING:
     from torch._inductor.runtime.hints import HalideMeta
-    from torch._inductor.runtime.triton_heuristics import CachingAutotuner
 
 # timing metrics for time spent in the compilation
 _cumulative_compile_time = 0.0
@@ -132,49 +130,9 @@ def get_compile_threads() -> int:
 
 
 @clear_on_fresh_inductor_cache
-class CompiledTritonKernels:
-    """
-    In memory cache for storing compiled triton kernels.
-
-    Each triton kernel is keyed by the hash of its source code. Each value stored
-    in the cache is a return value of AsyncCompile.triton().
-
-    Currently, the cache stores Future objects, but it should be generalizable for any kernels.
-    """
-
-    _cache: dict[str, LambdaFuture] = {}
-
-    @staticmethod
-    def key(kernel_src: str):
-        """
-        Generates a cache key given a triton kernel's full source code.
-        This source includes the inductor meta, compilation metadata, the kernel itself, etc.
-        `kernel_src` should be the exact string passed to async_compile.triton()'s first argument.
-        """
-        # Hashes the kernel source with torch_key into a single hash key
-        return code_hash(kernel_src, extra=torch_key())
-
-    @staticmethod
-    def save(kernel_src: str, future: LambdaFuture):
-        """
-        Saves a compiled triton kernel to the cache.
-        TODO: We store a LambdaFuture as that's the callable returned by async_compile.triton,
-        but the real type we want to return here is actually an abstract triton kernel.
-
-        TODO: Source code here is not just the kernel's source code, but also includes the inductor preamble, etc.
-        so it could be less strict.
-        """
-        key = CompiledTritonKernels.key(kernel_src)
-        CompiledTritonKernels._cache[key] = future
-
-    @staticmethod
-    def get(kernel_src: str, default: Any) -> LambdaFuture:
-        key = CompiledTritonKernels.key(kernel_src)
-        return CompiledTritonKernels._cache.get(key, default)
-
-    @staticmethod
-    def cache_clear():
-        CompiledTritonKernels._cache = {}
+@functools.lru_cache(None)
+def get_future_cache():
+    return {}
 
 
 class AsyncCompile:
@@ -250,84 +208,51 @@ class AsyncCompile:
         )
 
     def triton(self, kernel_name: str, source_code: str, device_str: str = "cuda"):
-        """
-        Async_compile.triton is more complicated than the other backends because
-        we're trying to optimize compile time as much as possible for this hot callsite.
-
-        First of all, the function is cached by CompiledTritonKernels; if there's a kernel
-        already compiled, we grab it directly from the cache and return.
-
-        Otherwise, if we have multiple compile threads, we kick off triton compilations on each
-        worker process by giving it a kernel and source code to compile. The worker initializes
-        a CachingAutotuner, runs triton compilation, and pickles the kernel back to us.
-        We use TritonCompileResult to represent the objects being pickled back to us by each
-        worker.
-
-        Some maybe not obvious things that are pickled back to us:
-        - Most of the time, we can avoid sending back CachingAutotuner.fn and other metadata
-          and do not have to pay the cost of loading the triton kernel on the parent. But certain
-          cases, like coordesc tuning and dynamic_scale_rblock, require us to reload the function
-          in the parent lazily when we require it.
-        - The AutotuneCache, if enabled, is constructed on each worker per triton config
-          and pickled by to us via `CachingAutotuner.save_cache_hook`.
-        """
-        if future := CompiledTritonKernels.get(source_code, None):
-            counters["inductor"]["async_compile_cache_hit"] += 1
-            return future
-
-        counters["inductor"]["async_compile_cache_miss"] += 1
-
         kernel_code_log.info("Triton Kernel:\n%s", source_code)
         _compile_start()
+        _set_triton_ptxas_path()
 
         if os.environ.get("TRITON_INTERPRET", "0") == "1":
             return getattr(
                 torch._inductor.codecache.PyCodeCache.load(source_code), kernel_name
             )
 
-        load_kernel = functools.partial(
-            _load_triton_kernel_from_source, kernel_name, source_code
-        )
-        is_parallel = self.use_process_pool()
-        set_feature_use("parallel_compile_post_warmup", is_parallel)
-        if is_parallel:
+        kernel = TritonCodeCache.load(kernel_name, source_code)
+        if self.use_process_pool():
+            set_feature_use("parallel_compile_post_warmup", True)
             # We want to support changing these env vars after (and while) the
             # process pool is running, so pass them to the subprocess to reset.
             env_vars = ["TORCHINDUCTOR_CACHE_DIR", "TRITON_CACHE_DIR"]
             extra_env = {v: os.environ[v] for v in env_vars if v in os.environ}
 
-            task = self.process_pool().submit(
-                _worker_compile_triton,
-                load_kernel,
-                extra_env,
+            future_cache = get_future_cache()
+
+            if future := future_cache.get(source_code, None):
+                counters["inductor"]["async_compile_cache_hit"] += 1
+                return future
+
+            counters["inductor"]["async_compile_cache_miss"] += 1
+            future = TritonFuture(
+                kernel,
+                self.process_pool().submit(
+                    _worker_compile_triton,
+                    kernel._reload_in_subproc,
+                    extra_env,
+                ),
             )
-
-            def reload_kernel_in_parent():
-                # Benchmark how often this happens
-                with dynamo_timed("reload_kernel_in_parent"):
-                    return load_kernel()
-
-            def get_result() -> CachingAutotuner:
-                kernel = task.result()
-                kernel.precompile(
-                    warm_cache_only=False, reload_kernel=reload_kernel_in_parent
-                )
-                return kernel
-
-            future = LambdaFuture(get_result, future=task)
-            CompiledTritonKernels.save(source_code, future)
+            future_cache[source_code] = future
             return future
+
         else:
+            set_feature_use("parallel_compile_post_warmup", False)
             with dynamo_timed(
                 "async_compile.precompile",
                 log_pt2_compile_event=True,
                 dynamo_compile_column_us="triton_compile_time_us",
                 log_waitcounter=True,
             ):
-                _set_triton_ptxas_path()
-                kernel = load_kernel()
-                kernel.precompile(warm_cache_only=False)
-                return kernel
+                kernel.precompile()
+            return kernel
 
     def multi_kernel(self, *args, **kwargs) -> Any:
         from torch._inductor.codegen.multi_kernel import MultiKernelCall

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -68,6 +68,7 @@ from torch._inductor.cpu_vec_isa import pick_vec_isa
 from torch._inductor.custom_graph_pass import CustomGraphPass, CustomGraphPassType
 from torch._inductor.freezing_utils import has_frozen_params, is_frozen_param
 from torch._inductor.runtime.compile_tasks import (
+    _module_to_triton_kernel,
     _reload_python_module,
     _reload_python_module_in_subproc,
 )
@@ -353,11 +354,10 @@ def sha256_hash(data: bytes) -> str:
     return base64.b32encode(hashlib.sha256(data).digest())[:51].decode("utf-8").lower()
 
 
-def code_hash(code: Union[str, bytes], extra: Union[str, bytes] = "") -> str:
+def code_hash(code: Union[str, bytes], extra: str = "") -> str:
     hashing_str = code if isinstance(code, bytes) else code.encode("utf-8")
-    if extra:
-        extra_b = extra if isinstance(extra, bytes) else extra.encode("utf-8")
-        hashing_str = hashing_str + b"||" + extra_b
+    if extra != "":
+        hashing_str = hashing_str + b"||" + extra.encode("utf-8")
     return "c" + sha256_hash(hashing_str)
 
 
@@ -2724,10 +2724,10 @@ class PyCodeCache:
         return parse_stack_trace(entry)
 
 
-def _load_triton_kernel_from_source(
-    kernel_name: str, source_code: str
-) -> CachingAutotuner:
-    return getattr(PyCodeCache.load(source_code), kernel_name)
+class TritonCodeCache:
+    @classmethod
+    def load(cls, kernel_name: str, source_code: str) -> ModuleType:
+        return _module_to_triton_kernel(PyCodeCache.load(source_code), kernel_name)
 
 
 def _cuda_compiler() -> Optional[str]:
@@ -3132,12 +3132,30 @@ class CodeCacheFuture:
         raise NotImplementedError
 
 
-class LambdaFuture(CodeCacheFuture):
+class TritonFuture(CodeCacheFuture):
+    kernel: CachingAutotuner
+
     def __init__(
-        self, result_fn: Callable[..., Any], future: Optional[Future[Any]] = None
+        self,
+        kernel: Any,
+        future: Optional[Future[Any]],
     ) -> None:
-        self.result_fn = result_fn
+        self.kernel = kernel
         self.future = future
+
+    def result(self) -> Callable[..., Any]:
+        if self.future is not None:
+            # If the worker failed this will throw an exception.
+            result = self.future.result()
+            assert result is None
+            self.future = None
+            self.kernel.precompile()
+        return self.kernel
+
+
+class LambdaFuture(CodeCacheFuture):
+    def __init__(self, result_fn: Callable[..., Any]) -> None:
+        self.result_fn = result_fn
 
     def result(self) -> Callable[..., Any]:  # type: ignore[override]
         return self.result_fn()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -30,7 +30,6 @@ from torch.utils._triton import has_triton_package
 from ...utils._sympy.symbol import free_symbol_is_type, prefix_str, symbol_is_type, SymT
 from ...utils._sympy.value_ranges import ValueRanges
 from .. import config, ir, metrics
-from ..async_compile import AsyncCompile
 from ..codecache import code_hash, get_path, PyCodeCache
 from ..ops_handler import DefaultHandler
 from ..runtime.benchmarking import benchmarker
@@ -114,7 +113,6 @@ log = logging.getLogger(__name__)
 perf_hint_log = torch._logging.getArtifactLogger(__name__, "perf_hints")
 schedule_log = torch._logging.getArtifactLogger(__name__, "schedule")
 fusion_log = torch._logging.getArtifactLogger(__name__, "fusion")
-async_compile = AsyncCompile()
 
 
 class OpDtypeSupport:
@@ -4001,16 +3999,9 @@ class TritonScheduling(SIMDScheduling):
             src_code = src_code.replace("#pragma CMT", "#")
 
             _basename, _, kernel_path = get_path(code_hash(src_code.strip()), "py")
+
             compile_wrapper = IndentedBuffer()
-
-            if async_compile.use_process_pool():
-                # The process pool is warm, we can shell out to workers right away. This
-                # allows us to save the result in async_compile.CompiledTritonKernels,
-                # so that the second time we call async_compile.triton, we do no work.
-                async_compile.triton(subs_name, src_code)
-
             compile_wrapper.writeline(f"async_compile.triton({subs_name!r}, '''")
-
             compile_wrapper.splice(src_code, strip=True)
             current_device = V.graph.get_current_device_or_throw()
             compile_wrapper.writeline(f"''', device_str='{current_device.type}')")

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -823,7 +823,7 @@ def _compile_fx_inner(
 
     # Clear Compiled Triton Kernels per inductor compile, as the future objects
     # may not be valid for use after they are run/autotuned
-    torch._inductor.async_compile.CompiledTritonKernels.cache_clear()
+    #torch._inductor.async_compile.CompiledTritonKernels.cache_clear()
 
     _step_logger()(
         logging.INFO,

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -6,7 +6,7 @@ import logging
 import os
 import os.path
 import re
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 from typing_extensions import override
 
 import torch
@@ -154,46 +154,7 @@ class AutotuneCache:
         if not remote_cache:
             return
 
-        # Save the args passed to create_cache
-        # in case AutotuneCache needs to be pickled
-        self.remote_cache_full_key = key
-        self.is_fbcode = is_fbcode
         self.remote_cache = (remote_cache, cache_key)
-
-    # The AutotuneCache may be serialized/deserialized if we're using
-    # AsyncCompile worker processes to run triton compilation.
-    # This is because AutotuneCache instances are created on the worker
-    # process, but we need to run AutotuneCache.save on the parent process
-    # when actually doing autotuning.
-    def __getstate__(self) -> dict[str, Any]:
-        # The remote cache handles themselves may not be serializable
-        # So clear it and reconstruct it on setstate
-        remote_cache = getattr(self, "remote_cache", None)
-        return {
-            **self.__dict__,
-            # Save the cache_key portion
-            "remote_cache": remote_cache and remote_cache[1],
-        }
-
-    def __setstate__(self, state: dict[str, Any]) -> None:
-        # Reconstruct the remote cache on the parent class
-        self.__dict__.update(state)
-        if self.remote_cache is not None:
-            assert isinstance(self.remote_cache, str)
-            assert hasattr(self, "remote_cache_full_key")
-            assert hasattr(self, "is_fbcode")
-            cache_key = self.remote_cache
-            remote_cache = create_cache(
-                self.remote_cache_full_key,
-                self.is_fbcode,
-                "FbRemoteAutotuneCache",
-                "RemoteAutotuneCache",
-            )
-            if remote_cache is not None:
-                self.remote_cache = (remote_cache, cache_key)
-            else:
-                log.warning("Warning, failed to recreate remote cache after pickling")
-                self.remote_cache = None
 
     # Save the config in the caches
     def save(

--- a/torch/_inductor/runtime/compile_tasks.py
+++ b/torch/_inductor/runtime/compile_tasks.py
@@ -68,10 +68,7 @@ def _set_triton_ptxas_path() -> None:
 
 def _worker_compile_triton(
     load_kernel: Callable[[], CachingAutotuner], extra_env: dict[str, str]
-) -> CachingAutotuner:
+) -> None:
     _set_triton_ptxas_path()
     os.environ.update(extra_env)
-    kernel = load_kernel()
-    kernel.precompile(warm_cache_only=True)
-    kernel.prepare_for_pickle()
-    return kernel
+    load_kernel().precompile(warm_cache_only=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148008

Original commit changeset: 5e70e713d95b

Original Phabricator Diff: D69123174

Differential Revision: [D70210584](https://our.internmc.facebook.com/intern/diff/D70210584/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov