### PR TITLE
[Inductor] fix `AOTInductorTestABICompatibleGpu.test_triton_kernel_weird_param_order` with new Triton

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -593,9 +593,9 @@ class CppWrapperGpu(CppWrapperCpu):
                         for arg_type, arg_name in zip(arg_types, signatures)
                         if signatures[arg_name] != "constexpr"
                     ]
-                    assert len(call_args) == len(
-                        arg_signatures
-                    ), f"len of the following lists do not match: {call_args=} {arg_signatures=}"
+                    assert len(call_args) == len(arg_signatures), (
+                        f"len of the following lists do not match: {call_args=} {arg_signatures=}"
+                    )
                 else:
                     # args with value 1 are added into equal_to_1 and constants
                     # in triton_meta (in the Python codegen) which makes them

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -582,16 +582,21 @@ class CppWrapperGpu(CppWrapperCpu):
                     arg_signatures = [
                         val for val in signatures.values() if val != "constexpr"
                     ]
-                    call_args = [
-                        call_arg
-                        for call_arg, arg_name in zip(call_args, signatures)
-                        if signatures[arg_name] != "constexpr"
-                    ]
-                    arg_types = [
-                        arg_type
-                        for arg_type, arg_name in zip(arg_types, signatures)
-                        if signatures[arg_name] != "constexpr"
-                    ]
+                    # may already be filtered
+                    if len(arg_signatures) != len(call_args):
+                        call_args = [
+                            call_arg
+                            for call_arg, arg_name in zip(call_args, signatures)
+                            if signatures[arg_name] != "constexpr"
+                        ]
+                        arg_types = [
+                            arg_type
+                            for arg_type, arg_name in zip(arg_types, signatures)
+                            if signatures[arg_name] != "constexpr"
+                        ]
+                    assert len(call_args) == len(
+                        arg_signatures
+                    ), f"len of the following lists do not match: {call_args=} {arg_signatures=}"
                 else:
                     # args with value 1 are added into equal_to_1 and constants
                     # in triton_meta (in the Python codegen) which makes them

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -333,12 +333,13 @@ class CppWrapperGpu(CppWrapperCpu):
                 constexprs,
             )
 
-        # in C++ wrapper, we don't pass constexpr args, as they don't
-        # get added as parameters to the PTX code compiled from the
-        # user-defined Triton kernel (only non-constexpr args do)
-        raw_args = [
-            raw_arg for i, raw_arg in enumerate(raw_args) if i not in constexprs
-        ]
+        if not triton_version_uses_attrs_dict():
+            # in C++ wrapper, we don't pass constexpr args, as they don't
+            # get added as parameters to the PTX code compiled from the
+            # user-defined Triton kernel (only non-constexpr args do)
+            raw_args = [
+                raw_arg for i, raw_arg in enumerate(raw_args) if i not in constexprs
+            ]
         args = [self.val_to_arg_str(v) for v in raw_args]
         arg_types = [
             arg.get_dtype() if isinstance(arg, IRNode) else type(arg)
@@ -582,18 +583,16 @@ class CppWrapperGpu(CppWrapperCpu):
                     arg_signatures = [
                         val for val in signatures.values() if val != "constexpr"
                     ]
-                    # may already be filtered
-                    if len(arg_signatures) != len(call_args):
-                        call_args = [
-                            call_arg
-                            for call_arg, arg_name in zip(call_args, signatures)
-                            if signatures[arg_name] != "constexpr"
-                        ]
-                        arg_types = [
-                            arg_type
-                            for arg_type, arg_name in zip(arg_types, signatures)
-                            if signatures[arg_name] != "constexpr"
-                        ]
+                    call_args = [
+                        call_arg
+                        for call_arg, arg_name in zip(call_args, signatures)
+                        if signatures[arg_name] != "constexpr"
+                    ]
+                    arg_types = [
+                        arg_type
+                        for arg_type, arg_name in zip(arg_types, signatures)
+                        if signatures[arg_name] != "constexpr"
+                    ]
                     assert len(call_args) == len(
                         arg_signatures
                     ), f"len of the following lists do not match: {call_args=} {arg_signatures=}"


### PR DESCRIPTION
In this case, the parameters have already been filtered [here](https://github.com/pytorch/pytorch/blob/201666d77dd980d71e392f705d7fac6256ee28f9/torch/_inductor/codegen/cpp_wrapper_gpu.py#L335) and subsequent filtering is not only unnecessary, it breaks the code, since the positions of the parameters change after filtering. For this test, for example, the second filtering discarded `buf0`.

For example:
```python
(Pdb) triton_meta["signature"]
{'in_ptr0': '*fp32', 'in_ptr1': '*fp32', 'n_elements': 'i32', 'BLOCK_SIZE': 'constexpr', 'out_ptr': '*fp32'}
(Pdb) call_args
['arg0_1', 'arg0_1', '256L', 'buf0']
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @davidberard98 @YUNQIUGUO