### PR TITLE
torch.utils.checkpoint preserves torch function mode stack during recompute

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7515,6 +7515,7 @@ for shape in [(1,), ()]:
         ):
             self.assertEqual(param.grad, checkpoint_param.grad)
 
+     @xfailIfTorchDynamo
     def test_checkpointing_preserves_torch_function_mode_stack(self):
         log = []
 
@@ -7539,16 +7540,20 @@ for shape in [(1,), ()]:
 
         with Mode1():
             with Mode2():
-                a = torch.tensor(1., requires_grad=True)
+                a = torch.tensor(1.0, requires_grad=True)
 
                 log = []
                 out = checkpoint(func, a, use_reentrant=False, context_fn=context_fn)
-                self.assertTrue(log[-3] == "mode3" and log[-2] == "mode2" and log[-1] == "mode1")
+                self.assertTrue(
+                    log[-3] == "mode3" and log[-2] == "mode2" and log[-1] == "mode1"
+                )
 
 
                 log = []
                 out.backward()
-                self.assertTrue(log[-3] == "mode3" and log[-2] == "mode2" and log[1] == "mode1")
+                self.assertTrue(
+                    log[-3] == "mode3" and log[-2] == "mode2" and log[1] == "mode1"
+                )
 
     def test_callback_adds_callback(self):
         called = [0]

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7515,7 +7515,7 @@ for shape in [(1,), ()]:
         ):
             self.assertEqual(param.grad, checkpoint_param.grad)
 
-     @xfailIfTorchDynamo
+    @xfailIfTorchDynamo
     def test_checkpointing_preserves_torch_function_mode_stack(self):
         log = []
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7517,13 +7517,13 @@ for shape in [(1,), ()]:
 
     @xfailIfTorchDynamo
     def test_checkpointing_preserves_torch_function_mode_stack(self):
-        log = []
+        log = [""]
 
         def get_mode_class(n):
             class Func(TorchFunctionMode):
                 def __torch_function__(self, func, types, args, kwargs=None):
                     kwargs = {} if kwargs is None else kwargs
-                    log.append(f"mode{n}")
+                    log[0] += f" mode{n} {func.__name__}"
                     return func(*args, **kwargs)
 
             return Func
@@ -7541,18 +7541,13 @@ for shape in [(1,), ()]:
         with Mode1():
             with Mode2():
                 a = torch.tensor(1.0, requires_grad=True)
-
-                log = []
+                log = [""]
                 out = checkpoint(func, a, use_reentrant=False, context_fn=context_fn)
-                self.assertTrue(
-                    log[-3] == "mode3" and log[-2] == "mode2" and log[-1] == "mode1"
-                )
-
-                log = []
+                self.assertTrue("mode3 cos mode2 cos mode1 cos" in log[0])
+                log = [""]
                 out.backward()
-                self.assertTrue(
-                    log[-3] == "mode3" and log[-2] == "mode2" and log[1] == "mode1"
-                )
+                self.assertTrue("mode3 cos mode2 cos mode1 cos" in log[0])
+
 
     def test_callback_adds_callback(self):
         called = [0]

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -47,6 +47,7 @@ from torch.autograd.profiler_util import (
     FunctionEvent,
     FunctionEventAvg,
 )
+from torch.overrides import TorchFunctionMode
 from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
@@ -80,7 +81,6 @@ from torch.testing._internal.common_utils import (
     TestCase,
     xfailIfTorchDynamo,
 )
-from torch.overrides import TorchFunctionMode
 from torch.utils._mode_utils import no_dispatch
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils.checkpoint import (
@@ -7547,7 +7547,6 @@ for shape in [(1,), ()]:
                 self.assertTrue(
                     log[-3] == "mode3" and log[-2] == "mode2" and log[-1] == "mode1"
                 )
-
 
                 log = []
                 out.backward()

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -491,6 +491,22 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
     }
   });
 
+  py::class_<at::ThreadLocalState>(_C_m, "ThreadLocalState");
+
+  // Then define your functions that use it
+  _C_m.def("stash_tls_state",
+        []() {
+            return at::ThreadLocalState();
+        },
+        "Captures and returns the current thread local state");
+
+  _C_m.def("restore_tls_state",
+        [](const at::ThreadLocalState& state) {
+            at::ThreadLocalState::setThreadLocalState(state);
+        },
+        "Restores a previously stashed thread local state",
+        py::arg("state"));
+
   _C_m.def("_activate_gpu_trace", []() { activateGPUTrace(); });
 
   py_context_manager_DEPRECATED<c10::InferenceMode, bool>(

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -2074,6 +2074,18 @@ def _pop_mode():
 
 
 @contextlib.contextmanager
+def _apply_torch_function_mode_stack(mode_stack):
+    stack_len = len(mode_stack)
+    try:
+        for mode in mode_stack:
+            _push_mode(mode)
+        yield
+    finally:
+        for _ in range(stack_len):
+            _pop_mode()
+
+
+@contextlib.contextmanager
 def _pop_mode_temporarily():
     old = _pop_mode()
     try:

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -2074,18 +2074,6 @@ def _pop_mode():
 
 
 @contextlib.contextmanager
-def _apply_torch_function_mode_stack(mode_stack):
-    stack_len = len(mode_stack)
-    try:
-        for mode in mode_stack:
-            _push_mode(mode)
-        yield
-    finally:
-        for _ in range(stack_len):
-            _pop_mode()
-
-
-@contextlib.contextmanager
 def _pop_mode_temporarily():
     old = _pop_mode()
     try:

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1521,8 +1521,8 @@ def _checkpoint_without_reentrant_generator(
             with (
                 device_autocast_ctx,   # type: ignore[attr-defined]
                 torch.amp.autocast("cpu", **cpu_autocast_kwargs),
+                _apply_torch_function_mode_stack(torch_function_mode_stack),
                 recompute_context,
-                _apply_torch_function_mode_stack(torch_function_mode_stack)
             ):
                 fn(*args, **kwargs)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148023
* #146633

Fixes https://github.com/pytorch/pytorch/issues/147995

TorchFunctionModeTLS is part of the autograd tls, but because .backward() itself is a leaf for TorchFunctionMode, the mode is disabled before we enter into the engine.  Conversely, since TorchDispatchMode traces through the .backward() python call, we don't actually need to manually stash/restore if the user keeps the same mode enabled.