### PR TITLE
[ONNX] Fix missed None type support in dyamic shapes string cases

### DIFF
--- a/test/onnx/exporter/test_dynamic_shapes.py
+++ b/test/onnx/exporter/test_dynamic_shapes.py
@@ -609,6 +609,25 @@ class TestDynamicShapes(common_utils.TestCase):
         self.assertEqual(dynamic_shapes_with_export_dim, expected_dynamic_shapes)
         self.assertTrue(need_axis_mapping)
 
+    def test__any_str_or_dim_in_dynamic_shapes_returns_true(self):
+        dynamic_shapes = {
+            "input_x": [
+                {
+                    0: torch.export.Dim.AUTO,
+                    1: torch.export.Dim("abc"),
+                },
+                {
+                    0: torch.export.Dim.AUTO,
+                    1: torch.export.Dim.STATIC,
+                },
+            ],
+            "input_b": {2: "customb_dim_0"},
+            "input_c": None,
+        }
+        self.assertTrue(
+            _dynamic_shapes._any_str_or_dim_in_dynamic_shapes(dynamic_shapes)
+        )
+
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/torch/onnx/_internal/exporter/_dynamic_shapes.py
+++ b/torch/onnx/_internal/exporter/_dynamic_shapes.py
@@ -160,7 +160,12 @@ def _any_str_or_dim_in_dynamic_shapes(
 ) -> bool:
     """Check if there is any string or _Dim in the dynamic_shapes."""
     flat_dynamic_shapes, _ = _flatten_dynamic_shapes_to_axes(dynamic_shapes)
-    if any(not isinstance(axes, (dict, list, tuple)) for axes in flat_dynamic_shapes):
+    # This indicates the dynamic_shapes includes something we don't support in axes, and it's flattened
+    # to itself, otherwisee, flat_dynamic_shapes should be a list of dict/list/tuple (or None).
+    if any(
+        not isinstance(axes, (dict, list, tuple)) and axes is not None
+        for axes in flat_dynamic_shapes
+    ):
         return False
     # both str and _Dim can provide custom names
     for axes in flat_dynamic_shapes:

--- a/torch/onnx/_internal/exporter/_dynamic_shapes.py
+++ b/torch/onnx/_internal/exporter/_dynamic_shapes.py
@@ -161,7 +161,7 @@ def _any_str_or_dim_in_dynamic_shapes(
     """Check if there is any string or _Dim in the dynamic_shapes."""
     flat_dynamic_shapes, _ = _flatten_dynamic_shapes_to_axes(dynamic_shapes)
     # This indicates the dynamic_shapes includes something we don't support in axes, and it's flattened
-    # to itself, otherwisee, flat_dynamic_shapes should be a list of dict/list/tuple (or None).
+    # to itself. Otherwise, flat_dynamic_shapes should be a list of dict/list/tuple (or None).
     if any(
         not isinstance(axes, (dict, list, tuple)) and axes is not None
         for axes in flat_dynamic_shapes


### PR DESCRIPTION
In `_any_str_or_dim_in_dynamic_shapes`, we strictly guard the `dynamic_shapes` to make sure the flattened shapes are valid. But the code missed to consider None could be in the shapes.

NOTE: Found in benchmarking with Olive.
