### PR TITLE
[BE/metal] Rename REGISTER_I0_I1 to REGISTER_SPECIAL.

### DIFF
--- a/aten/src/ATen/native/mps/kernels/SpecialOps.metal
+++ b/aten/src/ATen/native/mps/kernels/SpecialOps.metal
@@ -33,7 +33,7 @@ void kernel entr(
   output[index] = c10::metal::entr(static_cast<T0>(input[index]));
 }
 
-#define REGISTER_SPECIAL(DTI, DTO)                                            \
+#define REGISTER_SPECIAL(DTI, DTO)                                          \
   template [[host_name("i0_" #DTO "_" #DTI)]] void kernel i0<DTO, DTI>(     \
       device DTO*, constant DTI*, uint);                                    \
   template [[host_name("i1_" #DTO "_" #DTI)]] void kernel i1<DTO, DTI>(     \

--- a/aten/src/ATen/native/mps/kernels/SpecialOps.metal
+++ b/aten/src/ATen/native/mps/kernels/SpecialOps.metal
@@ -33,7 +33,7 @@ void kernel entr(
   output[index] = c10::metal::entr(static_cast<T0>(input[index]));
 }
 
-#define REGISTER_I0_I1(DTI, DTO)                                            \
+#define REGISTER_SPECIAL(DTI, DTO)                                            \
   template [[host_name("i0_" #DTO "_" #DTI)]] void kernel i0<DTO, DTI>(     \
       device DTO*, constant DTI*, uint);                                    \
   template [[host_name("i1_" #DTO "_" #DTI)]] void kernel i1<DTO, DTI>(     \
@@ -43,15 +43,15 @@ void kernel entr(
   template [[host_name("entr_" #DTO "_" #DTI)]] void kernel entr<DTO, DTI>( \
       device DTO*, constant DTI*, uint);
 
-REGISTER_I0_I1(float, float);
-REGISTER_I0_I1(bool, float);
-REGISTER_I0_I1(uchar, float);
-REGISTER_I0_I1(char, float);
-REGISTER_I0_I1(short, float);
-REGISTER_I0_I1(int, float);
-REGISTER_I0_I1(long, float);
+REGISTER_SPECIAL(float, float);
+REGISTER_SPECIAL(bool, float);
+REGISTER_SPECIAL(uchar, float);
+REGISTER_SPECIAL(char, float);
+REGISTER_SPECIAL(short, float);
+REGISTER_SPECIAL(int, float);
+REGISTER_SPECIAL(long, float);
 
-REGISTER_I0_I1(half, half);
+REGISTER_SPECIAL(half, half);
 #if __METAL_VERSION__ >= 310
-REGISTER_I0_I1(bfloat, bfloat);
+REGISTER_SPECIAL(bfloat, bfloat);
 #endif


### PR DESCRIPTION
Now that it's used for other ops as well.

cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen