### PR TITLE
[ROCm] Skip gfx12 Row-Wise F8 Tests

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -855,7 +855,7 @@ class TestFP8Matmul(TestCase):
         ctx = self.assertRaises(RuntimeError) if torch.version.hip is None and device != "cpu" else contextlib.nullcontext()
         if IS_GFX12:
             self.skipTest("Gfx12 enablement in progress")
-        
+
         ctx = self.assertRaises(RuntimeError) if torch.version.hip is None else contextlib.nullcontext()
         with ctx:
             self._test_tautological_mm(device, e5m2_type, e5m2_type)

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -55,7 +55,10 @@ def CDNA3OrLater():
 def CDNA2OrLater():
     return evaluate_gfx_arch_within(["gfx90a", "gfx942"])
 
-IS_GFX12 = LazyVal(lambda: torch.cuda.is_available() and torch.version.hip and 'gfx12' in torch.cuda.get_device_properties(0).gcnArchName)
+IS_GFX12 = LazyVal(lambda: (
+    torch.cuda.is_available() and
+    torch.version.hip and
+    'gfx12' in torch.cuda.get_device_properties(0).gcnArchName))
 
 def evaluate_platform_supports_flash_attention():
     if TEST_WITH_ROCM:

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -55,6 +55,8 @@ def CDNA3OrLater():
 def CDNA2OrLater():
     return evaluate_gfx_arch_within(["gfx90a", "gfx942"])
 
+IS_GFX12 = LazyVal(lambda: torch.cuda.is_available() and torch.version.hip and 'gfx12' in torch.cuda.get_device_properties(0).gcnArchName)
+
 def evaluate_platform_supports_flash_attention():
     if TEST_WITH_ROCM:
         arch_list = ["gfx90a", "gfx942", "gfx1100"]


### PR DESCRIPTION
TLDR: Skip Gfx12 row-wise fp8 tests (under development)

This pull request introduces changes to the `test/test_matmul_cuda.py` and `torch/testing/_internal/common_cuda.py` files to add support for the GFX12 architecture. The changes include adding a new platform support check for GFX12 and updating several test cases to skip execution if the GFX12 architecture is detected.

Changes related to GFX12 support:

* [`torch/testing/_internal/common_cuda.py`](diffhunk://#diff-fe348e24069d43bc7c6913174b038fcc5880a3281bdc0e8e217cf210bd0935e5R58-R59): Added a new lazy evaluation `IS_GFX12` to check if the current CUDA device supports the GFX12 architecture.
* [`test/test_matmul_cuda.py`](diffhunk://#diff-3f31c52b48cfddf8f4617d809f7695b2e4a1c78656f8c4b5143a4b45d01fcf23L27-R28): Imported the new `IS_GFX12` variable.

Updates to test cases:

* [`test/test_matmul_cuda.py`](diffhunk://#diff-3f31c52b48cfddf8f4617d809f7695b2e4a1c78656f8c4b5143a4b45d01fcf23L470-R473): Modified `_test_tautological_mm` to skip the test if `IS_GFX12` is true.
* [`test/test_matmul_cuda.py`](diffhunk://#diff-3f31c52b48cfddf8f4617d809f7695b2e4a1c78656f8c4b5143a4b45d01fcf23R688): Added a skip condition for `IS_GFX12` in `test_float8_rowwise_scaling_sanity`.
* [`test/test_matmul_cuda.py`](diffhunk://#diff-3f31c52b48cfddf8f4617d809f7695b2e4a1c78656f8c4b5143a4b45d01fcf23R794): Added a skip condition for `IS_GFX12` in `test_scaled_mm_vs_emulated_row_wise`.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd