### PR TITLE
[torchgen] Add support for schema with namespace

### DIFF
--- a/tools/test/test_codegen_model.py
+++ b/tools/test/test_codegen_model.py
@@ -5,10 +5,10 @@ import unittest
 from typing import cast
 
 import expecttest
+import yaml
 
 import torchgen.dest as dest
 import torchgen.gen as gen
-import yaml
 from torchgen.gen import LineLoader, parse_native_yaml_struct
 from torchgen.model import (
     Annotation,

--- a/tools/test/test_codegen_model.py
+++ b/tools/test/test_codegen_model.py
@@ -204,7 +204,6 @@ class TestAnnotation(expecttest.TestCase):
 
 
 class TestBaseOperatorName(expecttest.TestCase):
-
     def test_base_operator_name_with_ns_has_same_attributes_as_the_one_without_ns(
         self,
     ) -> None:

--- a/tools/test/test_codegen_model.py
+++ b/tools/test/test_codegen_model.py
@@ -5,13 +5,14 @@ import unittest
 from typing import cast
 
 import expecttest
-import yaml
 
 import torchgen.dest as dest
 import torchgen.gen as gen
+import yaml
 from torchgen.gen import LineLoader, parse_native_yaml_struct
 from torchgen.model import (
     Annotation,
+    BaseOperatorName,
     CustomClassType,
     DispatchKey,
     NativeFunctionsGroup,
@@ -200,6 +201,22 @@ class TestAnnotation(expecttest.TestCase):
             r"before alias set and after alias set cannot be larger than 1 at the same time",
         ):
             Annotation.parse("a|b -> c|d")
+
+
+class TestBaseOperatorName(expecttest.TestCase):
+
+    def test_base_operator_name_with_ns_has_same_attributes_as_the_one_without_ns(
+        self,
+    ) -> None:
+        op = "aten::__lshift__"
+        op_without_ns = "__lshift__"
+
+        op_name = BaseOperatorName.parse(op)
+        op_name_without_ns = BaseOperatorName.parse(op_without_ns)
+
+        self.assertEqual(op_name.base, op_name_without_ns.base)
+        self.assertEqual(op_name.inplace, op_name_without_ns.inplace)
+        self.assertEqual(op_name.dunder_method, op_name_without_ns.dunder_method)
 
 
 if __name__ == "__main__":

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -1707,9 +1707,11 @@ class FunctionSchema:
             for a in itertools.chain(
                 # Order is important here (otherwise e.g. inplace with mutable args
                 # and out= with mutable args won't have the same signature)
-                [self.arguments.self_arg.argument]
-                if self.arguments.self_arg is not None
-                else [],
+                (
+                    [self.arguments.self_arg.argument]
+                    if self.arguments.self_arg is not None
+                    else []
+                ),
                 self.arguments.out,
                 self.arguments.post_self_positional,
             )
@@ -2301,9 +2303,11 @@ class Arguments:
             pre_self_positional=tuple(
                 map(strip_arg_annotation, self.pre_self_positional)
             ),
-            self_arg=SelfArgument(strip_arg_annotation(self.self_arg.argument))
-            if self.self_arg is not None
-            else None,
+            self_arg=(
+                SelfArgument(strip_arg_annotation(self.self_arg.argument))
+                if self.self_arg is not None
+                else None
+            ),
             post_self_positional=tuple(
                 map(strip_arg_annotation, self.post_self_positional)
             ),
@@ -2538,7 +2542,6 @@ class BaseOperatorName:
     # we have a usecase in ExecuTorch where we want to support BaseOperatorName with namespace.
     namespace: str = ""
 
-
     @staticmethod
     def parse(op: str) -> BaseOperatorName:
         assert op != ""
@@ -2547,7 +2550,7 @@ class BaseOperatorName:
             "did you mean to specify an out overload name instead?"
         )
         # Extract namespace out. Base operator name may or may not contain namespace.
-        # E.g., aten::__lshift__ is a valid base operator name, __lshift__ is also valid. 
+        # E.g., aten::__lshift__ is a valid base operator name, __lshift__ is also valid.
         # We want to split the namespace out from the base operator name.
         match = re.match(r"^(.*::|)(.*)$", op)
         namespace = match.group(1) if match else ""


### PR DESCRIPTION
Fixes https://github.com/pytorch/executorch/issues/8711

In ExecuTorch when we try to parse the following schema:

```
aten::__lshift__.Scalar(Tensor self, Scalar other) -> Tensor
```
Repro:

```python
from torchgen.model import FunctionSchema
native_schema = FunctionSchema.parse("aten::__lshift__.Scalar(Tensor self, Scalar other) -> Tensor")
```
It's failing because `BaseOperatorName` categorizes it to be a
inplace operator.

I understand we are not supposed to pass in namespace "aten::" into
`FunctionSchema.parse()` but unfortunately ExecuTorch requires this
feature to work.

This PR adds a new `namespace` attribute to `BaseOperatorName` and makes
sure the rest of the stack works as before, if a schema without
namespace  is passed in