### PR TITLE
Fix `torch.nn.functional.hardswish` gradients corner case

### DIFF
--- a/aten/src/ATen/native/cpu/Activation.cpp
+++ b/aten/src/ATen/native/cpu/Activation.cpp
@@ -832,9 +832,9 @@ void hardswish_backward_kernel(TensorIterator& iter) {
     cpu_kernel_vec(
       iter,
       [&](scalar_t grad_val, scalar_t self_val) -> scalar_t {
-        if (float(self_val) < neg_three) {
+        if (float(self_val) <= neg_three) {
           return zero;
-        } else if (float(self_val) <= three) {
+        } else if (float(self_val) < three) {
           return float(grad_val) * ((float(self_val) / three) + one_half);
         } else {
           return grad_val;
@@ -847,19 +847,19 @@ void hardswish_backward_kernel(TensorIterator& iter) {
           Vec::blendv(
             grad_val0 * ((self_val0 / kThreeVec) + kOneHalfVec),
             grad_val0,
-            self_val0 > kThreeVec
+            self_val0 >= kThreeVec
           ),
           kZeroVec,
-          self_val0 < kNegThreeVec
+          self_val0 <= kNegThreeVec
         );
         self_val1 = Vec::blendv(
           Vec::blendv(
             grad_val1 * ((self_val1 / kThreeVec) + kOneHalfVec),
             grad_val1,
-            self_val1 > kThreeVec
+            self_val1 >= kThreeVec
           ),
           kZeroVec,
-          self_val1 < kNegThreeVec
+          self_val1 <= kNegThreeVec
         );
         return convert_from_float<scalar_t>(self_val0, self_val1);
       });
@@ -878,9 +878,9 @@ void hardswish_backward_kernel(TensorIterator& iter) {
     cpu_kernel_vec(
       iter,
       [&](scalar_t grad_val, scalar_t self_val) {
-        if (self_val < neg_three) {
+        if (self_val <= neg_three) {
           return zero;
-        } else if (self_val <= three) {
+        } else if (self_val < three) {
           return grad_val * ((self_val / three) + one_half);
         } else {
           return grad_val;
@@ -891,10 +891,10 @@ void hardswish_backward_kernel(TensorIterator& iter) {
           Vec::blendv(
             grad_val * ((self_val / kThreeVec) + kOneHalfVec),
             grad_val,
-            self_val > kThreeVec
+            self_val >= kThreeVec
           ),
           kZeroVec,
-          self_val < kNegThreeVec
+          self_val <= kNegThreeVec
         );
       }
     );

--- a/aten/src/ATen/native/cuda/ActivationHardswishKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationHardswishKernel.cu
@@ -45,9 +45,9 @@ void hardswish_backward_kernel(TensorIterator& iter) {
       [zero, three, neg_three, one_half]GPU_LAMBDA(scalar_t grad_val_, scalar_t self_val_) -> scalar_t {
         opmath_t grad_val = static_cast<opmath_t>(grad_val_);
         opmath_t self_val = static_cast<opmath_t>(self_val_);
-        if (self_val < neg_three) {
+        if (self_val <= neg_three) {
           return zero;
-        } else if (self_val <= three) {
+        } else if (self_val < three) {
           return grad_val * ((self_val / three) + one_half);
         } else {
           return grad_val;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11176,25 +11176,28 @@ class TestNNDeviceType(NNTestCase):
         inputs.requires_grad = True
         self.assertTrue(gradcheck(F.hardswish, (inputs,)))
 
-    @dtypes(torch.half, torch.bfloat16, torch.float)
-    def test_hardswish_grad_corner(self, device, dtype):
+    def _test_hardswish_grad_corner(self, device, dtype, scalar, ref_fn):
         m = nn.Hardswish()
         shape = (1, 9, 9, 1)
-        cpu_input = torch.ones(shape, device=device, dtype=dtype)
-        cpu_input = cpu_input * 3
-        cpu_input.requires_grad = True
-        fwd_result = m(cpu_input)
+        inputs = torch.ones(shape, device=device, dtype=dtype)
+        inputs = inputs * scalar
+        inputs.requires_grad = True
+        fwd_result = m(inputs)
         fwd_result.backward(torch.ones_like(fwd_result))
-        ref = torch.ones(shape, device=device, dtype=dtype)
-        self.assertEqual(cpu_input.grad, ref)
+        ref = ref_fn(shape, device=device, dtype=dtype)
+        self.assertEqual(inputs.grad, ref)
 
-        cpu_input = torch.ones(shape, device=device, dtype=dtype)
-        cpu_input = cpu_input * -3
-        cpu_input.requires_grad = True
-        fwd_result = m(cpu_input)
-        fwd_result.backward(torch.ones_like(fwd_result))
-        ref = torch.zeros(shape, device=device, dtype=dtype)
-        self.assertEqual(cpu_input.grad, ref)
+    @onlyCUDA
+    @dtypes(torch.half, torch.bfloat16, torch.float)
+    def test_hardswish_grad_corner_cuda(self, device, dtype):
+        self._test_hardswish_grad_corner(device, dtype, 3, torch.ones)
+        self._test_hardswish_grad_corner(device, dtype, -3, torch.zeros)
+
+    @onlyCPU
+    @dtypes(torch.half, torch.bfloat16, torch.float)
+    def test_hardswish_grad_corner_cpu(self, device, dtype):
+        self._test_hardswish_grad_corner(device, dtype, 3, torch.ones)
+        self._test_hardswish_grad_corner(device, dtype, -3, torch.zeros)
 
     def _test_batchnorm_eval(self, ndim, device, dtype, module_dtype=None):
         module_dtype = module_dtype or dtype

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11187,15 +11187,9 @@ class TestNNDeviceType(NNTestCase):
         ref = ref_fn(shape, device=device, dtype=dtype)
         self.assertEqual(inputs.grad, ref)
 
-    @onlyCUDA
+    @onlyNativeDeviceTypes
     @dtypes(torch.half, torch.bfloat16, torch.float)
-    def test_hardswish_grad_corner_cuda(self, device, dtype):
-        self._test_hardswish_grad_corner(device, dtype, 3, torch.ones)
-        self._test_hardswish_grad_corner(device, dtype, -3, torch.zeros)
-
-    @onlyCPU
-    @dtypes(torch.half, torch.bfloat16, torch.float)
-    def test_hardswish_grad_corner_cpu(self, device, dtype):
+    def test_hardswish_grad_corner(self, device, dtype):
         self._test_hardswish_grad_corner(device, dtype, 3, torch.ones)
         self._test_hardswish_grad_corner(device, dtype, -3, torch.zeros)
 

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -212,9 +212,9 @@ def hardswish(self: Tensor) -> Tensor:
 @pw_cast_for_opmath
 def hardswish_backward(grad_output: Tensor, self: Tensor) -> Tensor:
     return torch.where(
-        self < -3,
+        self <= -3,
         0.0,
-        torch.where(self <= 3, grad_output * ((self / 3) + 0.5), grad_output),
+        torch.where(self < 3, grad_output * ((self / 3) + 0.5), grad_output),
     )
 
 

--- a/torch/csrc/jit/runtime/symbolic_script.cpp
+++ b/torch/csrc/jit/runtime/symbolic_script.cpp
@@ -936,7 +936,7 @@ const std::vector<std::string> functions = {
         def hardswish(self):
             result = torch.hardswish(self)
             def backward(grad_output):
-                m = (self > 3.).type_as(result)
+                m = (self >= 3.).type_as(result)
                 m = torch.where((self > -3.) & (self < 3.),  self / 3. + .5, m)
                 return grad_output * m
             return result, backward

--- a/torch/csrc/jit/runtime/symbolic_script.cpp
+++ b/torch/csrc/jit/runtime/symbolic_script.cpp
@@ -937,7 +937,7 @@ const std::vector<std::string> functions = {
             result = torch.hardswish(self)
             def backward(grad_output):
                 m = (self > 3.).type_as(result)
-                m = torch.where((self >= -3.) & (self <= 3.),  self / 3. + .5, m)
+                m = torch.where((self > -3.) & (self < 3.),  self / 3. + .5, m)
                 return grad_output * m
             return result, backward
 


### PR DESCRIPTION
Fixes #147801

## Changes

- Change hardswish gradient compute condition as [torch.nn.functional.hardswish](https://pytorch.org/docs/stable/generated/torch.nn.functional.hardswish.html)
- Enable cuda for test `test_hardswish_grad_corner`
- Add test case for value=-3

## Test Result

```bash
pytest test/test_nn.py -k test_hardswish
pytest test/test_unary_ufuncs.py -k test_hardswish
pytest test/inductor/test_torchinductor.py -k test_hardswish
```

![image](https://github.com/user-attachments/assets/000cb5c4-15f5-4bfd-ab45-f52bf810ff3d)
![image](https://github.com/user-attachments/assets/38b08cf8-ea84-47a2-8e37-0a213da3e0c8)
![image](https://github.com/user-attachments/assets/54bc57be-2c57-46cc-ab90-94ea6cbe1c34)


cc @ezyang @albanD @gqchen @pearu @nikitaved @soulitzer @Varal7 @xmfan @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10