### PR TITLE
[triton 3.3] cpp_wrapper: add a global_scratch arg

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -3999,9 +3999,9 @@ class AOTInductorTestsTemplate:
         # it gets explicitly declared using its data types in the cpp wrapper codegen code.
         expected_scalar_args = [
             "int64_t var_1 = u0;",
-            "int64_t var_3 = u0;",
-            "int64_t var_5 = u0;",
-            "int64_t var_9 = u0;",
+            "int64_t var_4 = u0;",
+            "int64_t var_7 = u0;",
+            "int64_t var_12 = u0;",
         ]
         # check the new behavior of codegen is expected
         result, code = run_and_get_cpp_code(

--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -206,6 +206,7 @@ hipify_python.hipify(
     includes=includes,
     ignores=ignores,
     extra_files=[
+        "torch/_inductor/codegen/cuda/device_op_overrides.py",
         "torch/_inductor/codegen/cpp_wrapper_cpu.py",
         "torch/_inductor/codegen/cpp_wrapper_gpu.py",
         "torch/_inductor/codegen/wrapper.py",

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -287,7 +287,7 @@ class DeviceOpOverrides:
     def tma_descriptor_helpers(self) -> str:
         raise NotImplementedError
 
-    def cpp_global_scratch(self) -> Optional[tuple[str, str]]:
+    def cpp_global_scratch(self, idx: int) -> Optional[tuple[str, str]]:
         # optionally return (scratch definition, arg name)
         raise NotImplementedError
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -287,6 +287,10 @@ class DeviceOpOverrides:
     def tma_descriptor_helpers(self) -> str:
         raise NotImplementedError
 
+    def cpp_global_scratch(self) -> Optional[tuple[str, str]]:
+        # optionally return (scratch definition, arg name)
+        raise NotImplementedError
+
 
 device_op_overrides_dict: dict[str, DeviceOpOverrides] = {}
 

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -465,7 +465,11 @@ class CppWrapperGpu(CppWrapperCpu):
         ):
             process_args(arg, arg_type, arg_signature)
 
-        if (global_scratch := self.device_codegen.cpp_global_scratch()) is not None:
+        if (
+            global_scratch := self.device_codegen.cpp_global_scratch(
+                next(self.arg_var_id)
+            )
+        ) is not None:
             global_scratch_def, global_scratch_var = global_scratch
             self.writeline(global_scratch_def)
             new_args.append(f"&{global_scratch_var}")

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -465,6 +465,11 @@ class CppWrapperGpu(CppWrapperCpu):
         ):
             process_args(arg, arg_type, arg_signature)
 
+        if (global_scratch := self.device_codegen.cpp_global_scratch()) is not None:
+            global_scratch_def, global_scratch_var = global_scratch
+            self.writeline(global_scratch_def)
+            new_args.append(f"&{global_scratch_var}")
+
         return ", ".join(new_args)
 
     def generate_default_grid(

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from typing import Optional
+
 import torch
 
+from ...utils import triton_version_uses_attrs_dict
 from ..common import DeviceOpOverrides, register_device_op_overrides
 
 
@@ -237,6 +240,11 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
 
     def cpp_device_ptr(self) -> str:
         return "CUdeviceptr"
+
+    def cpp_global_scratch(self) -> Optional[tuple[str, str]]:
+        if triton_version_uses_attrs_dict():
+            return "CUdeviceptr global_scratch = 0;", "global_scratch"
+        return None
 
 
 register_device_op_overrides("cuda", CUDADeviceOpOverrides())

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -241,9 +241,9 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
     def cpp_device_ptr(self) -> str:
         return "CUdeviceptr"
 
-    def cpp_global_scratch(self) -> Optional[tuple[str, str]]:
+    def cpp_global_scratch(self, idx: int) -> Optional[tuple[str, str]]:
         if triton_version_uses_attrs_dict():
-            return "CUdeviceptr global_scratch = 0;", "global_scratch"
+            return f"CUdeviceptr global_scratch_{idx} = 0;", f"global_scratch_{idx}"
         return None
 
 

--- a/torch/_inductor/codegen/xpu/device_op_overrides.py
+++ b/torch/_inductor/codegen/xpu/device_op_overrides.py
@@ -72,7 +72,7 @@ class XPUDeviceOpOverrides(DeviceOpOverrides):
     def cpp_device_ptr(self) -> str:
         return "void *"
 
-    def cpp_global_scratch(self) -> Optional[tuple[str, str]]:
+    def cpp_global_scratch(self, idx: int) -> Optional[tuple[str, str]]:
         return None
 
 

--- a/torch/_inductor/codegen/xpu/device_op_overrides.py
+++ b/torch/_inductor/codegen/xpu/device_op_overrides.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 from ..common import DeviceOpOverrides, register_device_op_overrides
 
 
@@ -69,6 +71,9 @@ class XPUDeviceOpOverrides(DeviceOpOverrides):
 
     def cpp_device_ptr(self) -> str:
         return "void *"
+
+    def cpp_global_scratch(self) -> Optional[tuple[str, str]]:
+        return None
 
 
 register_device_op_overrides("xpu", XPUDeviceOpOverrides())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148051

Following triton # 4916, the generated cubin expects a global_scratch argument to support on-device TMA. We believe this is the source of many of the "invalid argument" failures on AOTI/cpp_wrapper tests. AFAIK, we don't use on-device TMA in Inductor as of now, so it should be safe to use a nullptr for the scratch space.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov