### PR TITLE
use identity op for alpha=inf in torch.celu and quantized_celu

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -539,6 +539,10 @@ Tensor celu(const Tensor & self, const Scalar& alpha) {
   TORCH_CHECK(alpha.to<double>() != 0,
       "ZeroDivisionError: alpha cannot be 0 for CELU");
   double inv_alpha = 1. / alpha.to<double>();
+  // Limit of CELU(x, alpha) as alpha -> inf = x
+  if (inv_alpha == 0) {
+    return self;
+  }
   return at::elu(self, alpha, Scalar(1.0), Scalar(inv_alpha));
 }
 
@@ -546,6 +550,10 @@ Tensor & celu_(Tensor & self, const Scalar& alpha) {
   TORCH_CHECK(alpha.to<double>() != 0,
       "ZeroDivisionError: alpha cannot be 0 for CELU");
   double inv_alpha = 1. / alpha.to<double>();
+  // Limit of CELU(x, alpha) as alpha -> inf = x
+  if (inv_alpha == 0) {
+    return self;
+  }
   return at::elu_(self, alpha, Scalar(1.0), Scalar(inv_alpha));
 }
 

--- a/aten/src/ATen/native/quantized/cpu/qelu.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qelu.cpp
@@ -25,6 +25,10 @@ static Tensor quantized_celu(const Tensor& qx, double output_scale, int64_t outp
   TORCH_CHECK(alpha.to<double>() != 0,
       "ZeroDivisionError: alpha cannot be 0 for CELU");
   double inv_alpha = 1. / alpha.to<double>();
+  // Limit of CELU(x, alpha) as alpha -> inf = x
+  if (inv_alpha == 0) {
+    return qx;
+  }
   return quantized_elu(qx, output_scale, output_zero_point, alpha, Scalar(1.0), Scalar(inv_alpha));
 }
 


### PR DESCRIPTION
Fixes #148065

This MR short-circuits the celu and quantized_celu ops to just return the input in the case alpha=inf, so the implementation of celu(x, inf) is defined on all x.

```
import torch

# (same for torch.ao.nn.quantized.functional.celu)


# Before
# -----------
x = torch.tensor(2.)
print(torch.celu(x, torch.inf))
# tensor(2.)
print(torch.celu(-x, torch.inf))
# tensor(nan)

x = torch.tensor(0.)
print(torch.celu(x, torch.inf))
# tensor(nan)



# After
# --------
x = torch.tensor(2.)
print(torch.celu(x, torch.inf))
# tensor(2.)
print(torch.celu(-x, torch.inf))
# tensor(-2.)

x = torch.tensor(0.)
print(torch.celu(x, torch.inf))
# tensor(0.)

```


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168