### PR TITLE
Replace `unimplemented` with `unimplemented_v2' in `codegen.py`

### DIFF
--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -36,7 +36,7 @@ from .bytecode_transformation import (
     create_rot_n,
     Instruction,
 )
-from .exc import IncorrectUsage, unimplemented, unimplemented_v2
+from .exc import IncorrectUsage, unimplemented_v2
 from .source import AttrSource, ChainedSource, DictGetItemSource, Source
 from .utils import is_safe_constant, rot_n_helper
 from .variables.base import ValueMutationExisting, VariableTracker
@@ -197,7 +197,15 @@ class PyCodegen:
             try:
                 self.call_reconstruct(source)
             except NotImplementedError:
-                unimplemented(f"reconstruct: {source}")
+                unimplemented_v2(
+                    gb_type="Reconstruction failure",
+                    context=str(source),
+                    explanation=f"Dynamo has no bytecode reconstruction implemented for {type(source)} variable {source}.",
+                    hints=[
+                        "Report an issue to PyTorch if you need reconstrtuction support. Note that objects that don't have"
+                        "reconstruction rules may be fundamentally unreconstructable.",
+                    ],
+                )
 
             self._output.append(create_dup_top())
             self.add_cache(source)

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -198,7 +198,7 @@ class PyCodegen:
                 self.call_reconstruct(source)
             except NotImplementedError:
                 unimplemented_v2(
-                    gb_type="Reconstruction failure",
+                    gb_type="Reconstruction failure: source.reconstruct not implemented",
                     context=str(source),
                     explanation=f"Dynamo has no bytecode reconstruction implemented for {type(source)} variable {source}.",
                     hints=[

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -201,10 +201,7 @@ class PyCodegen:
                     gb_type="Reconstruction failure: source.reconstruct not implemented",
                     context=str(source),
                     explanation=f"Dynamo has no bytecode reconstruction implemented for {type(source)} variable {source}.",
-                    hints=[
-                        "Report an issue to PyTorch if you need reconstrtuction support. Note that objects that don't have"
-                        "reconstruction rules may be fundamentally unreconstructable.",
-                    ],
+                    hints=[*graph_break_hints.DYNAMO_BUG],
                 )
 
             self._output.append(create_dup_top())


### PR DESCRIPTION
Fixes #147913

- replace `unimplemented` in `codegen.py`
- remove unused import `unimplemented`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @williamwen42