### PR TITLE
only print GraphModule during fx.Interpreter errors if valid

### DIFF
--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -173,7 +173,11 @@ class Interpreter:
                 if self.extra_traceback:
                     msg = f"While executing {node.format_node()}"
                     msg = f"{e.args[0]}\n\n{msg}" if e.args else str(msg)
-                    if isinstance(self.module, GraphModule):
+                    if (
+                        isinstance(self.module, GraphModule)
+                        and self.module.graph is not None
+                        and isinstance(self.module.graph, torch.fx.Graph)
+                    ):
                         msg += f"\nGraphModule: {self.module.print_readable(print_output=False, include_stride=True)}\n"
                     msg += f"\nOriginal traceback:\n{node.stack_trace}"
                     e.args = (msg,) + e.args[1:]


### PR DESCRIPTION
Came up in https://www.internalfb.com/diff/D69057074?dst_version_fbid=970771615000938&transaction_fbid=1723357345264461 - we need to make sure the GraphModule is valid before calling `print_readable` on it

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #133044
* #147561
* __->__ #148090
* #147749



cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv