### PR TITLE
HSDP custom hook UTs are multi-threaded - can't set device rank

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_init.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_init.py
@@ -1025,7 +1025,6 @@ class TestHSDPWithCustomHook(FSDPTestMultiThread):
         super().perThreadSetUp()
         torch.set_default_device("cuda")
         rank = dist.get_rank()
-        torch.cuda.set_device(rank)
 
     @unittest.skipIf(not TEST_CUDA, "no cuda")
     def test_custom_hook_custom_stream(self):

--- a/test/distributed/_composable/fsdp/test_fully_shard_init.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_init.py
@@ -1024,7 +1024,6 @@ class TestHSDPWithCustomHook(FSDPTestMultiThread):
     def perThreadSetUp(self) -> None:
         super().perThreadSetUp()
         torch.set_default_device("cuda")
-        rank = dist.get_rank()
 
     @unittest.skipIf(not TEST_CUDA, "no cuda")
     def test_custom_hook_custom_stream(self):


### PR DESCRIPTION
HSDP custom hook UTs are multi-threaded and using single physical GPU. If we set rank in each thread, then we are referencing the same GPU with multiple ranks, which isn't right. Therefore, removing the rank setting from these UTs. Now, they are passing with 1, 2, 4 GPUs. 

Fixes #147767 and #147769


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o