### PR TITLE
Move expanded dim require_exact_stride handling to api from sdpa lowering

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5276,6 +5276,7 @@ class ExternKernel(InputsKernel):
         # Without representation of the expand in inductor IR, in codegen we end up
         # launching a grid for the full size tensor and doing redundant computation
         # across expanded dims.
+        # TODO: could also be good to have a codegen fix to recognize overlapping elements
 
         expanded_dims: Optional[list[int]] = None
         orig_size = x.get_size()

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2554,14 +2554,7 @@ def sdpa_constraint(fx_node, *args, **kwargs):
 
                 out_strides[i] = stride
 
-            for dim in expanded_dims:
-                arg = slice_(arg, dim, 0, 1)
-
-            # TODO this is too subtle to get right in lowering, should be handled in match_exact_strides
-            out = ir.ExternKernel.require_exact_strides(arg, out_strides)
-            out = expand(TensorBox(out), out_size)
-            out = ir.try_match_insignificant_strides(out, out_strides)
-            return out
+            return ir.ExternKernel.require_exact_strides(arg, out_strides)
 
         if ir.is_aligned_realized_tensor(arg, ALIGNMENT):
             return ir.try_match_insignificant_strides(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148101

See issue: https://github.com/pytorch/pytorch/issues/147156#issue-2852362217. 

Original tests from https://github.com/pytorch/pytorch/pull/146054 should cover these changes, and I tested that the perf on https://github.com/pytorch/pytorch/issues/145760 remains fixed.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov