### PR TITLE
[triton 3.3] cpp wrapper aoti remaining test failure following #148051

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -578,20 +578,19 @@ class CppWrapperGpu(CppWrapperCpu):
                     and triton_meta.get("configs")
                     and triton_meta.get("signature")
                 ):
+                    signatures = triton_meta["signature"]
                     arg_signatures = [
-                        val
-                        for val in triton_meta.get("signature").values()
-                        if val != "constexpr"
+                        val for val in signatures.values() if val != "constexpr"
                     ]
                     call_args = [
                         call_arg
-                        for call_arg, arg_name in zip(call_args, arg_signatures)
-                        if arg_signatures[arg_name] != "constexpr"
+                        for call_arg, arg_name in zip(call_args, signatures)
+                        if signatures[arg_name] != "constexpr"
                     ]
                     arg_types = [
                         arg_type
-                        for arg_type, arg_name in zip(arg_types, arg_signatures)
-                        if arg_signatures[arg_name] != "constexpr"
+                        for arg_type, arg_name in zip(arg_types, signatures)
+                        if signatures[arg_name] != "constexpr"
                     ]
             else:
                 # args with value 1 are added into equal_to_1 and constants

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -577,8 +577,12 @@ class CppWrapperGpu(CppWrapperCpu):
                     triton_meta is not None
                     and triton_meta.get("configs")
                     and triton_meta.get("signature")
-                ):  
-                    arg_signatures = [val for val in triton_meta.get("signature").values() if val != "constexpr"]
+                ):
+                    arg_signatures = [
+                        val
+                        for val in triton_meta.get("signature").values()
+                        if val != "constexpr"
+                    ]
                     call_args = [
                         call_arg
                         for call_arg, arg_name in zip(call_args, arg_signatures)


### PR DESCRIPTION
This should hopefully fix the remaining cpp_wrapper aoti tests failure in this paste: [P1741802912](https://www.internalfb.com/phabricator/paste/view/P1741802912)

following https://github.com/pytorch/pytorch/pull/148051

Related issue: #147734 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov