### PR TITLE
[triton 3.3] Fix aoti cpp wrapper remaining 5 issue. (following #148051)

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -571,31 +571,31 @@ class CppWrapperGpu(CppWrapperCpu):
                 device_index, call_args
             )
             kernel_var_name = self.generate_load_kernel_once(kernel_name, V.graph)
-            if triton_version_uses_attrs_dict():
-                signature = triton_meta["signature"]
-                arg_signatures = [
-                    val for val in signature.values() if val != "constexpr"
-                ]
-                call_args = [
-                    call_arg
-                    for call_arg, arg_name in zip(call_args, signature)
-                    if signature[arg_name] != "constexpr"
-                ]
-                arg_types = [
-                    arg_type
-                    for arg_type, arg_name in zip(arg_types, signature)
-                    if signature[arg_name] != "constexpr"
-                ]
-            else:
-                # args with value 1 are added into equal_to_1 and constants
-                # in triton_meta (in the Python codegen) which makes them
-                # inlined in the PTX and compiled CUBIN
-                arg_signatures = []
-                if (
-                    triton_meta is not None
-                    and triton_meta.get("configs")
-                    and triton_meta.get("signature")
-                ):
+            arg_signatures = []
+            if (
+                triton_meta is not None
+                and triton_meta.get("configs")
+                and triton_meta.get("signature")
+            ):
+                if triton_version_uses_attrs_dict():
+                    signatures = triton_meta["signature"]
+                    arg_signatures = [
+                        val for val in signatures.values() if val != "constexpr"
+                    ]
+                    call_args = [
+                        call_arg
+                        for call_arg, arg_name in zip(call_args, signatures)
+                        if signatures[arg_name] != "constexpr"
+                    ]
+                    arg_types = [
+                        arg_type
+                        for arg_type, arg_name in zip(arg_types, signatures)
+                        if signatures[arg_name] != "constexpr"
+                    ]
+                else:
+                    # args with value 1 are added into equal_to_1 and constants
+                    # in triton_meta (in the Python codegen) which makes them
+                    # inlined in the PTX and compiled CUBIN
                     equal_to_1 = triton_meta["configs"][0].equal_to_1
                     call_args = [
                         arg for i, arg in enumerate(call_args) if i not in equal_to_1


### PR DESCRIPTION
Summary:
Fix the following 5 on a100:

- test_foreach_cpp_wrapper_cuda_gpu_wrapper

- test_enable_dynamic_shapes_cpp_wrapper_cuda_gpu_wrapper

- test_dynamic_shapes_persistent_reduction_mixed_x_dim_cuda_gpu_wrapper

- test_enable_dynamic_shapes_cpp_wrapper_cuda_dynamic_shapes_gpu_wrapper

- test_dynamic_shapes_persistent_reduction_mixed_x_dim_cuda_dynamic_shapes_gpu_wrapper

Test Plan:
oss :

```
TORCHINDUCTOR_COMPILE_THREADS=1 TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_BACKENDS=TRITON TORCH_LOGS="+inductor, output_code" TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 CPLUS_INCLUDE_PATH=/usr/local/cuda-12.6/include:$CPLUS_INCLUDE_PATH python test/inductor/test_gpu_cpp_wrapper.py -k test_foreach_cpp_wrapper_cuda_gpu_wrapper
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov