### PR TITLE
[Inductor][Tests] Use generic device or require CUDA for newly added tests

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4918,11 +4918,9 @@ class CommonTemplate:
 
         eager_version_counters_after = [
             # TODO: remove the + 1 after https://github.com/pytorch/pytorch/issues/120622 is fixed
-            (
-                buffer._version + 1
-                if k in ["m.running_mean", "m.running_var"]
-                else buffer._version
-            )
+            buffer._version + 1
+            if k in ["m.running_mean", "m.running_var"]
+            else buffer._version
             for k, buffer in model_for_eager.named_buffers()
         ]
 
@@ -13518,11 +13516,9 @@ if HAS_GPU and not TEST_WITH_ASAN:
                 ),
                 (
                     fn3,
-                    (
-                        "triton_poi_fused_layer_norm_relu"
-                        if torch._dynamo.config.inline_inbuilt_nn_modules
-                        else "triton_poi_fused_LayerNorm_ReLU"
-                    ),
+                    "triton_poi_fused_layer_norm_relu"
+                    if torch._dynamo.config.inline_inbuilt_nn_modules
+                    else "triton_poi_fused_LayerNorm_ReLU",
                     (torch.randn(4, 4, device=GPU_TYPE),),
                 ),
             ]

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4918,9 +4918,11 @@ class CommonTemplate:
 
         eager_version_counters_after = [
             # TODO: remove the + 1 after https://github.com/pytorch/pytorch/issues/120622 is fixed
-            buffer._version + 1
-            if k in ["m.running_mean", "m.running_var"]
-            else buffer._version
+            (
+                buffer._version + 1
+                if k in ["m.running_mean", "m.running_var"]
+                else buffer._version
+            )
             for k, buffer in model_for_eager.named_buffers()
         ]
 
@@ -13516,9 +13518,11 @@ if HAS_GPU and not TEST_WITH_ASAN:
                 ),
                 (
                     fn3,
-                    "triton_poi_fused_layer_norm_relu"
-                    if torch._dynamo.config.inline_inbuilt_nn_modules
-                    else "triton_poi_fused_LayerNorm_ReLU",
+                    (
+                        "triton_poi_fused_layer_norm_relu"
+                        if torch._dynamo.config.inline_inbuilt_nn_modules
+                        else "triton_poi_fused_LayerNorm_ReLU"
+                    ),
                     (torch.randn(4, 4, device=GPU_TYPE),),
                 ),
             ]
@@ -14021,7 +14025,7 @@ if HAS_GPU and not TEST_WITH_ASAN:
                 return x.sin()
 
             fn_c = torch.compile(fn)
-            x = torch.rand(16, device="cuda")
+            x = torch.rand(16, device=self.device)
 
             _, code = run_and_get_code(fn_c, x)
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -14033,6 +14033,7 @@ if HAS_GPU and not TEST_WITH_ASAN:
                 "'XBLOCK': 'constexpr'"
             ).run(code[0])
 
+        @requires_cuda
         @torch._inductor.config.patch("graph_partition", True)
         def test_graph_partition(self):
             def f(x, y):
@@ -14059,6 +14060,7 @@ if HAS_GPU and not TEST_WITH_ASAN:
                     code[0]
                 )
 
+        @requires_cuda
         @torch._inductor.config.patch("graph_partition", True)
         def test_graph_partition_multiple_functions(self):
             def f(x, y):
@@ -14081,6 +14083,7 @@ if HAS_GPU and not TEST_WITH_ASAN:
 
             self.assertEqual(eager_out, compiled_out)
 
+        @requires_cuda
         @torch._inductor.config.patch("graph_partition", True)
         def test_graph_partition_condition_op(self):
             def f(p, b):
@@ -14100,6 +14103,7 @@ if HAS_GPU and not TEST_WITH_ASAN:
             compiled_out = compiled_f(p, a)
             self.assertEqual(eager_out, compiled_out)
 
+        @requires_cuda
         @torch._inductor.config.patch("graph_partition", True)
         def test_graph_partition_symint(self):
             def f(x, y):
@@ -14122,6 +14126,7 @@ if HAS_GPU and not TEST_WITH_ASAN:
             compiled_out = f_compiled(x, y)
             self.assertEqual(compiled_out, f(x, y))
 
+        @requires_cuda
         @torch._inductor.config.patch("graph_partition", True)
         def test_graph_partition_unbacked_symint(self):
             def f(x, y):
@@ -14143,6 +14148,7 @@ if HAS_GPU and not TEST_WITH_ASAN:
             eager_out = f(x, y)
             self.assertEqual(compiled_out, eager_out)
 
+        @requires_cuda
         @torch._inductor.config.patch("graph_partition", True)
         def test_graph_partition_buffer_reuse(self):
             def f(x, y):


### PR DESCRIPTION
Some tests added to Inductor as part of #147038 and #145583 were cuda specific and failing on XPU. This PR changes the attrs dict replacement test to use the generic device variable. The first graph partitioning test (`test_graph_partition`) fails on XPU - the graph does not appear to be properly partitioned. Subsequent tests pass if I use the generic `.to(device=self.device)` call. But since I was not sure if graph partitioning was expected to work on XPU I opted to explicitly skip the tests on XPU for now and leave them as is.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov