### PR TITLE
ci: Remove manylinux builds for triton, except for XPU

### DIFF
--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -46,12 +46,8 @@ jobs:
       matrix:
         py_vers: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t" ]
         device: ["cuda", "rocm", "xpu"]
-        docker-image: ["pytorch/manylinux-builder:cpu", "pytorch/manylinux2_28-builder:cpu"]
+        docker-image: ["pytorch/manylinux2_28-builder:cpu"]
         exclude:
-          - device: "rocm"
-            docker-image: "pytorch/manylinux-builder:cpu"
-          - device: "xpu"
-            docker-image: "pytorch/manylinux2_28-builder:cpu"
         include:
           - device: "rocm"
             rocm_version: "6.3"
@@ -62,8 +58,7 @@ jobs:
       DOCKER_IMAGE: ${{ matrix.device == 'rocm' && format('pytorch/manylinux2_28-builder:rocm{0}', matrix.rocm_version) || matrix.docker-image }}
       PY_VERS: ${{ matrix.py_vers }}
       BUILD_DEVICE: ${{ matrix.device }}
-      # TODO: We need to get rid of this when we remove builds that rely on the base manylinux-builder image
-      PLATFORM: ${{ contains(matrix.docker-image, '2_28') && 'manylinux_2_28_x86_64' || 'manylinux2014_x86_64' }}
+      PLATFORM: 'manylinux_2_28_x86_64'
     steps:
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
@@ -132,7 +127,7 @@ jobs:
 
           docker exec -t "${container_name}" yum install -y zlib-devel zip
           docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}"  -m pip install -U setuptools==67.4.0 pybind11==2.13.1 auditwheel
-          if [[ ("${{ matrix.device }}" == "cuda" || "${{ matrix.device }}" == "rocm") && "${PLATFORM}" == "manylinux_2_28_x86_64" ]]; then
+          if [[ ("${{ matrix.device }}" == "cuda" || "${{ matrix.device }}" == "rocm") ]]; then
             # With this install, it gets clang 16.0.6.
             docker exec -t "${container_name}" dnf install clang lld -y
             WITH_CLANG_LDD="--with-clang-ldd"

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -131,12 +131,7 @@ jobs:
             docker exec -t "${container_name}" dnf install clang lld -y
             WITH_CLANG_LDD="--with-clang-ldd"
           fi
-          if [[ "${BUILD_DEVICE}" == xpu ]]; then
-            docker exec -t "${container_name}" yum install -y devtoolset-11-gcc-c++
-            docker exec -t "${container_name}" bash -c "source /opt/rh/devtoolset-11/enable && ${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE $RELEASE"
-          else
-            docker exec -t "${container_name}" bash -c "${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE $RELEASE $WITH_CLANG_LDD"
-          fi
+          docker exec -t "${container_name}" bash -c "${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE $RELEASE $WITH_CLANG_LDD"
           if [[ "${{ matrix.device }}" == "cuda" ]]; then
             docker exec -t "${container_name}"  bash -c "auditwheel repair --plat ${PLATFORM} //artifacts/*.whl"
           else

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -47,7 +47,6 @@ jobs:
         py_vers: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t" ]
         device: ["cuda", "rocm", "xpu"]
         docker-image: ["pytorch/manylinux2_28-builder:cpu"]
-        exclude:
         include:
           - device: "rocm"
             rocm_version: "6.3"

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -46,8 +46,14 @@ jobs:
       matrix:
         py_vers: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t" ]
         device: ["cuda", "rocm", "xpu"]
-        docker-image: ["pytorch/manylinux2_28-builder:cpu"]
+        docker-image: ["pytorch/manylinux-builder:cpu", "pytorch/manylinux2_28-builder:cpu"]
         exclude:
+          # TODO: Remove this for rocm when manylinux2_28 migration for xpu is done
+          - device: "rocm"
+            docker-image: "pytorch/manylinux-builder:cpu"
+          # TODO: Remove this for cuda when manylinux2_28 migration for xpu is done
+          - device: "cuda"
+            docker-image: "pytorch/manylinux-builder:cpu"
           - device: "xpu"
             docker-image: "pytorch/manylinux2_28-builder:cpu"
         include:

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         py_vers: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t" ]
-        device: ["cuda", "rocm"]
+        device: ["cuda", "rocm", "xpu"]
         docker-image: ["pytorch/manylinux2_28-builder:cpu"]
         exclude:
           - device: "xpu"
@@ -55,7 +55,7 @@ jobs:
             rocm_version: "6.3"
           - device: "cuda"
             rocm_version: ""
-          # TODO: Move xpu back into the regular matrix when manylinux2_28 migration for xpu is done
+          # TODO: Remove this for xpu when manylinux2_28 migration for xpu is done
           - device: "xpu"
             docker-image: "pytorch/manylinux-builder:cpu"
     timeout-minutes: 40

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -45,13 +45,19 @@ jobs:
       fail-fast: false
       matrix:
         py_vers: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t" ]
-        device: ["cuda", "rocm", "xpu"]
+        device: ["cuda", "rocm"]
         docker-image: ["pytorch/manylinux2_28-builder:cpu"]
+        exclude:
+          - device: "xpu"
+            docker-image: "pytorch/manylinux2_28-builder:cpu"
         include:
           - device: "rocm"
             rocm_version: "6.3"
           - device: "cuda"
             rocm_version: ""
+          # TODO: Move xpu back into the regular matrix when manylinux2_28 migration for xpu is done
+          - device: "xpu"
+            docker-image: "pytorch/manylinux-builder:cpu"
     timeout-minutes: 40
     env:
       DOCKER_IMAGE: ${{ matrix.device == 'rocm' && format('pytorch/manylinux2_28-builder:rocm{0}', matrix.rocm_version) || matrix.docker-image }}
@@ -131,7 +137,13 @@ jobs:
             docker exec -t "${container_name}" dnf install clang lld -y
             WITH_CLANG_LDD="--with-clang-ldd"
           fi
-          docker exec -t "${container_name}" bash -c "${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE $RELEASE $WITH_CLANG_LDD"
+          # TODO: Remove this conditional block when manylinux2_28 migration for xpu is done
+          if [[ "${BUILD_DEVICE}" == xpu ]]; then
+            docker exec -t "${container_name}" yum install -y devtoolset-11-gcc-c++
+            docker exec -t "${container_name}" bash -c "source /opt/rh/devtoolset-11/enable && ${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE $RELEASE"
+          else
+            docker exec -t "${container_name}" bash -c "${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE $RELEASE $WITH_CLANG_LDD"
+          fi
           if [[ "${{ matrix.device }}" == "cuda" ]]; then
             docker exec -t "${container_name}"  bash -c "auditwheel repair --plat ${PLATFORM} //artifacts/*.whl"
           else


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148129

We're dropping regular old manylinux so let's drop it here too

Relates to #123649 

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>