### PR TITLE
WIP enable aten convolution out in lowerings

### DIFF
--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -366,12 +366,18 @@ conv3d_template = TritonTemplate(
 """,
 )
 
-aten_convolution = ExternKernelChoice(
+aten_convolution_out = ExternKernelChoice(
     torch.convolution,
     "at::convolution",
     has_out_variant=False,
-    op_overload=aten.convolution.default,
+    op_overload=aten.convolution.out,
 )
+# aten_convolution = ExternKernelChoice(
+#     torch.convolution,
+#     "at::convolution",
+#     has_out_variant=False,
+#     op_overload=aten.convolution.default,
+# )
 
 
 def conv1x1_via_mm(x, w, *, out):
@@ -611,7 +617,7 @@ def convolution(
     choices = []
     if torch._inductor.utils._use_conv_autotune_backend("ATEN"):
         choices = [
-            aten_convolution.bind(
+            aten_convolution_out.bind(
                 args,
                 layout,
                 ordered_kwargs_for_cpp_kernel,


### PR DESCRIPTION
So that the convolution op can plan its output memory for fusion opportunities.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov