### PR TITLE
Checks kv pair indexing in OrderedPreservingDictTest.test_range_insert

### DIFF
--- a/c10/test/util/ordered_preserving_dict_test.cpp
+++ b/c10/test/util/ordered_preserving_dict_test.cpp
@@ -183,8 +183,15 @@ TEST(OrderedPreservingDictTest, test_range_insert) {
 
   ASSERT_EQUAL_PRIM(map.at(-2), 0);
 
-  for (int i = 10, j = 2; i < nb_values - 5; i++, j++) {
+  auto begin = map.begin();
+  begin++;
+  begin++;
+  for (int i = 10; i < nb_values - 5; i++, begin++) {
+    // Check range inserted kv pairs: map(i) = i + 1 for i = 10,....995
     ASSERT_EQUAL_PRIM(map.at(i), i + 1);
+    // Check range inserted kv pairs are correctly indexed/ordered
+    TORCH_INTERNAL_ASSERT(begin->first == i);
+    TORCH_INTERNAL_ASSERT(begin->second == i + 1);
   }
 }
 


### PR DESCRIPTION
`OrderedPreservingDictTest.test_range_insert` has an [unused loop variable `j`](https://github.com/pytorch/pytorch/blob/main/c10/test/util/ordered_preserving_dict_test.cpp#L186), I think taken from the [inspired project](https://github.com/pytorch/pytorch/blob/main/c10/test/util/ordered_preserving_dict_test.cpp#L165) testcase for range inserts, where it [checks kv pair indexing/order](https://github.com/Tessil/ordered-map/blob/master/tests/ordered_map_tests.cpp#L136) for the ordered dict.

This just adds in that functionality to the test case.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov