### PR TITLE
[canary] force_nn_module_property_static_shapes=False

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -121,7 +121,7 @@ force_parameter_static_shapes = False
 # This flag ensures that the shapes of a nn module are always assumed to be static
 # If the flag is set to True, then the shapes of a nn.module are assumed to be static
 # If the flag is set to False, then the shapes of a nn.module can be dynamic
-force_nn_module_property_static_shapes = True
+force_nn_module_property_static_shapes = False
 
 # Typically, if you mark_dynamic a dimension, we will error if the dimension
 # actually ended up getting specialized.  This knob changes the behavior so


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148139

As part of the dynamic shapes roadmap this half, we want to reduce the number of unrolled out flags. This is one that limits dynamism and doesn't seem to affect compile time or correctness. Let's flip it to False by default.