### PR TITLE
[Break XPU][Inductor UT] Avoid custom op registration conflicts in test_auto_functionalize.py.

### DIFF
--- a/test/inductor/test_auto_functionalize.py
+++ b/test/inductor/test_auto_functionalize.py
@@ -1708,7 +1708,9 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
             self.assertNotEqual(id(output), id(input))
 
     def test_inference_mode_view(self):
-        @torch.library.custom_op("mylib::foo", mutates_args={"workspace"})
+        @torch.library.custom_op(
+            "test_inference_mode_view::foo", mutates_args={"workspace"}
+        )
         def foo(x: torch.Tensor, workspace: torch.Tensor) -> torch.Tensor:
             return x.clone()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #147727
* #148178
* __->__ #148155


Fix #148148

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov