### PR TITLE
[inductor][cpu] Fix error with FlexibleLayout weights in  BMM

### DIFF
--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -1043,7 +1043,8 @@ class CppGemmTemplate(CppTemplate):
             blocked_w = cls.block_weight(W, new_size, padding)
             new_inputs[1] = cls.pack_vnni_weight(blocked_w, micro_gemm, new_size)
         elif isinstance(W, ir.IRNode):
-            blocked_w = ir.ExternKernel.require_contiguous(W)
+            # Require W layout to be fixed & contiguous, happens inplace.
+            ir.ExternKernel.require_contiguous(W)
 
         def _is_int8_gemm(inputs):
             return (

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -1042,8 +1042,8 @@ class CppGemmTemplate(CppTemplate):
         if should_block_weight:
             blocked_w = cls.block_weight(W, new_size, padding)
             new_inputs[1] = cls.pack_vnni_weight(blocked_w, micro_gemm, new_size)
-        else:
-            blocked_w = W
+        elif isinstance(W, ir.IRNode):
+            blocked_w = ir.ExternKernel.require_contiguous(W)
 
         def _is_int8_gemm(inputs):
             return (


### PR DESCRIPTION
Fixes #148074 

When node A is reshaped (is a `ReinterpretView`) and node B has a `FlexibleLayout`, then the layout of node B *may* be changed during the `kernel.select(options["W"], 0, self.b_index)` call, which could cause the assertion in `kernel.select` to fail.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov