### PR TITLE
Support huggingface reading and writing for multi rank case

### DIFF
--- a/test/distributed/checkpoint/test_hf_storage.py
+++ b/test/distributed/checkpoint/test_hf_storage.py
@@ -8,15 +8,16 @@ import tempfile
 from unittest.mock import MagicMock
 
 import torch
+from torch.distributed.checkpoint._hf_planner import (
+    _FqnToFileMapping,
+    _HuggingFaceLoadPlanner,
+)
 from torch.distributed.checkpoint._hf_storage import (
     _HuggingFaceStorageReader,
     _HuggingFaceStorageWriter,
     _metadata_fn,
 )
-from torch.distributed.checkpoint.default_planner import (
-    DefaultLoadPlanner,
-    DefaultSavePlanner,
-)
+from torch.distributed.checkpoint.default_planner import DefaultSavePlanner
 from torch.distributed.checkpoint.filesystem import _StorageInfo, FileSystem
 from torch.distributed.checkpoint.metadata import (
     BytesStorageMetadata,
@@ -58,7 +59,7 @@ class TestHfStorage(TestCase):
 
             save_plan = SavePlan(
                 [write_item_1, write_item_2],
-                storage_data={"tensor_0": 1, "tensor_1": 1},
+                storage_data=_FqnToFileMapping({"tensor_0": 1, "tensor_1": 1}),
             )
             save_planner = DefaultSavePlanner()
             save_planner.set_up_planner(state_dict=state_dict)
@@ -126,7 +127,7 @@ class TestHfStorage(TestCase):
 
             read_items = _create_read_items(name, BytesStorageMetadata(), file_name)
             load_plan = LoadPlan(read_items)
-            load_planner = DefaultLoadPlanner()
+            load_planner = _HuggingFaceLoadPlanner()
             load_planner.set_up_planner(state_dict={name: torch.rand(4)})
 
             read_data = reader.read_data(load_plan, load_planner)
@@ -159,7 +160,7 @@ class TestHfStorage(TestCase):
 
             writer = _HuggingFaceStorageWriter(
                 path=path,
-                fqn_to_index_mapping={},
+                fqn_to_index_mapping=_FqnToFileMapping({}),
             )
             writer.fs = FileSystem()
             writer.finish(

--- a/torch/distributed/checkpoint/__init__.py
+++ b/torch/distributed/checkpoint/__init__.py
@@ -1,4 +1,5 @@
 from . import _extension
+from ._hf_planner import _HuggingFaceLoadPlanner, _HuggingFaceSavePlanner
 from ._hf_storage import _HuggingFaceStorageReader, _HuggingFaceStorageWriter
 from .api import CheckpointException
 from .default_planner import DefaultLoadPlanner, DefaultSavePlanner

--- a/torch/distributed/checkpoint/_dedup_save_plans.py
+++ b/torch/distributed/checkpoint/_dedup_save_plans.py
@@ -62,3 +62,25 @@ def dedup_save_plans(
         )
         for plan, item_indexes in zip(all_plans, plan_to_item_indices)
     ]
+
+
+def dedup_save_plans_with_fqn_to_index_mapping(
+    all_plans: list[SavePlan], fqn_to_index_mapping: dict[str, int]
+) -> list[SavePlan]:
+    num_plans = len(all_plans)
+
+    to_remove: list[set] = [set() for _ in range(len(all_plans))]
+    for plan_idx, plan in enumerate(all_plans):
+        for item_idx, item in enumerate(plan.items):
+            if (fqn_to_index_mapping[item.index.fqn] - 1) % num_plans != plan_idx:
+                to_remove[plan_idx].add(item_idx)
+
+    for plan_idx, remove_set in enumerate(to_remove):
+        new_items = [
+            write_item
+            for item_idx, write_item in enumerate(all_plans[plan_idx].items)
+            if item_idx not in remove_set
+        ]
+        all_plans[plan_idx] = dataclasses.replace(all_plans[plan_idx], items=new_items)
+
+    return all_plans

--- a/torch/distributed/checkpoint/_hf_planner.py
+++ b/torch/distributed/checkpoint/_hf_planner.py
@@ -1,0 +1,49 @@
+# mypy: allow-untyped-defs
+from dataclasses import dataclass
+
+from torch.distributed.checkpoint._dedup_save_plans import (
+    dedup_save_plans_with_fqn_to_index_mapping,
+)
+from torch.distributed.checkpoint.default_planner import (
+    DefaultLoadPlanner,
+    DefaultSavePlanner,
+)
+from torch.distributed.checkpoint.planner import ReadItem, SavePlan
+
+
+__all__ = ["_HuggingFaceSavePlanner", "_HuggingFaceLoadPlanner"]
+
+
+@dataclass
+class _FqnToFileMapping:
+    fqn_to_file_index_mapping: dict[str, int]
+
+
+class _HuggingFaceSavePlanner(DefaultSavePlanner):
+    """
+    A save planner that dedups the save plans based on the fqn to file index mapping.
+    """
+
+    def _dedup_save_plans(self, all_plans: list[SavePlan]) -> list[SavePlan]:
+        assert len(all_plans) > 0, "all_plans should not be empty"
+        assert all_plans[0].storage_data is not None, "storage_data should not be None"
+        assert isinstance(all_plans[0].storage_data, _FqnToFileMapping), (
+            "storage_data should be of type _FqnToFileMapping"
+        )
+
+        fqn_to_index_mapping: dict[str, int] = all_plans[
+            0
+        ].storage_data.fqn_to_file_index_mapping
+
+        return dedup_save_plans_with_fqn_to_index_mapping(
+            all_plans, fqn_to_index_mapping
+        )
+
+
+class _HuggingFaceLoadPlanner(DefaultLoadPlanner):
+    def __init__(self, allow_tensor_resize: bool = False):
+        super().__init__()
+        self.allow_tensor_resize = allow_tensor_resize
+
+    def resolve_tensor(self, read_item: ReadItem):
+        return self.lookup_tensor(read_item.dest_index)

--- a/torch/distributed/checkpoint/_hf_storage.py
+++ b/torch/distributed/checkpoint/_hf_storage.py
@@ -7,6 +7,10 @@ from typing import Optional
 import fsspec  # type: ignore[import-untyped]
 
 from torch.distributed.checkpoint._fsspec_filesystem import FsspecReader, FsspecWriter
+from torch.distributed.checkpoint._hf_planner import (
+    _FqnToFileMapping,
+    _HuggingFaceLoadPlanner,
+)
 from torch.distributed.checkpoint.metadata import (
     BytesStorageMetadata,
     Metadata,
@@ -64,11 +68,12 @@ class _HuggingFaceStorageWriter(FsspecWriter):
         self._fqn_to_index_mapping: dict[str, int] = fqn_to_index_mapping
 
     def prepare_local_plan(self, plan: SavePlan) -> SavePlan:
-        super().prepare_local_plan(plan)
-        return dataclasses.replace(plan, storage_data=self._fqn_to_index_mapping)
+        plan = super().prepare_local_plan(plan)
+        return dataclasses.replace(
+            plan, storage_data=_FqnToFileMapping(self._fqn_to_index_mapping)
+        )
 
     def prepare_global_plan(self, plans: list[SavePlan]) -> list[SavePlan]:
-        assert len(plans) == 1, "distributed checkpointing is not yet supported"
         return plans
 
     def write_data(
@@ -76,11 +81,16 @@ class _HuggingFaceStorageWriter(FsspecWriter):
         plan: SavePlan,
         planner: SavePlanner,
     ) -> Future[list[WriteResult]]:
+        if len(plan.items) == 0:
+            fut: Future = Future()
+            fut.set_result([])
+            return fut
+
         # storage_plan is a map from key to file index
-        storage_plan: dict[str, int] = plan.storage_data
+        storage_plan: dict[str, int] = plan.storage_data.fqn_to_file_index_mapping
 
         buckets = self._split_by_storage_plan(storage_plan, plan.items)
-        highest_index = max(buckets.keys())
+        highest_index = max(storage_plan.values())
 
         file_queue: queue.Queue = queue.Queue()
         for file_index, write_items in buckets.items():
@@ -172,8 +182,17 @@ class _HuggingFaceStorageReader(FsspecReader):
                 for req in reqs:
                     tensor = loaded_tensors[req.dest_index.fqn]
 
-                    target_tensor = planner.resolve_tensor(req).detach()
-                    target_tensor.resize_(tensor.size())
+                    target_tensor = planner.resolve_tensor(req)
+                    if (
+                        isinstance(planner, _HuggingFaceLoadPlanner)
+                        and planner.allow_tensor_resize
+                    ):
+                        target_tensor.resize_(tensor.size())
+                    else:
+                        assert target_tensor.size() == tensor.size(), (
+                            f"Tensor size mismatch for {req.dest_index.fqn}: {target_tensor.size()} != {tensor.size()}"
+                        )
+                    target_tensor = target_tensor.detach()
                     target_tensor.copy_(tensor)
                     planner.commit_tensor(req, target_tensor)
 

--- a/torch/distributed/checkpoint/default_planner.py
+++ b/torch/distributed/checkpoint/default_planner.py
@@ -126,10 +126,13 @@ class DefaultSavePlanner(SavePlanner):
 
         return self.plan
 
+    def _dedup_save_plans(self, all_plans: list[SavePlan]) -> list[SavePlan]:
+        return dedup_save_plans(all_plans, self.dedup_save_to_lowest_rank)
+
     def _create_global_plan(
         self, all_plans: list[SavePlan]
     ) -> tuple[list[SavePlan], Metadata]:
-        deduped_plans = dedup_save_plans(all_plans, self.dedup_save_to_lowest_rank)
+        deduped_plans = self._dedup_save_plans(all_plans)
 
         global_plan, metadata = create_default_global_save_plan(deduped_plans)
 


### PR DESCRIPTION
Summary: This diff adds the ability for HF reader/writer to read/write in a distributed way. We do this by sending all the tensors meant for the same file to the same rank.

Test Plan:
ensure existing tests pass
I also ran a full end to end test on my devserver to read/write from my HF repo

Differential Revision: D70096439




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn @ekr0