### PR TITLE
[BE][Ez]: Use itertools.chain.from_iterable when possible

### DIFF
--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -196,7 +196,7 @@ def get_overridable_functions():
 
     from torch.overrides import get_overridable_functions as get_overridable_functions_
 
-    funcs = set(chain(*get_overridable_functions_().values()))
+    funcs = set(chain.from_iterable(get_overridable_functions_().values()))
     more = {
         torch.ones,
         torch.ones_like,

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -4902,7 +4902,7 @@ class CppScheduling(BaseScheduling):
                 )
                 kernel_group.finalize_kernel(
                     outer_fusion_cpp_kernel_proxy,
-                    list(itertools.chain.from_iterable(nodes_list)),
+                    [*itertools.chain.from_iterable(nodes_list)],
                 )
 
             return True

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -4902,7 +4902,7 @@ class CppScheduling(BaseScheduling):
                 )
                 kernel_group.finalize_kernel(
                     outer_fusion_cpp_kernel_proxy,
-                    [_node for _nodes in nodes_list for _node in _nodes],
+                    list(itertools.chain.from_iterable(nodes_list)),
                 )
 
             return True

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -390,8 +390,8 @@ class MemoryEstimate:
 
     def __repr__(self) -> str:
         return f"""MemoryEstimate(
-            reads={[*itertools.chain(*self.reads.values())]!r},
-            writes={[*itertools.chain(*self.writes.values())]!r}
+            reads={[*itertools.chain.from_iterable(self.reads.values())]!r},
+            writes={[*itertools.chain.from_iterable(self.writes.values())]!r}
         )"""
 
 

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -241,7 +241,7 @@ class LoopBody:
         inverse_order = [inverse_order[i] for i in range(len(new_order))]
 
         def new_body(*indices: Sequence[sympy.Expr]) -> Any:
-            index = list(itertools.chain(*indices))
+            index = list(itertools.chain.from_iterable(indices))
             assert len(index) == len(iter_size) + len(reduce_size)
             iter_idx = index[: len(iter_size)]
             reduce_idx = index[len(iter_size) :]

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -241,7 +241,7 @@ class LoopBody:
         inverse_order = [inverse_order[i] for i in range(len(new_order))]
 
         def new_body(*indices: Sequence[sympy.Expr]) -> Any:
-            index = list(itertools.chain.from_iterable(indices))
+            index = [*itertools.chain.from_iterable(indices)]
             assert len(index) == len(iter_size) + len(reduce_size)
             iter_idx = index[: len(iter_size)]
             reduce_idx = index[len(iter_size) :]

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -129,11 +129,7 @@ class LogRegistry:
 
     # flattens all the qnames together (TODO: consider memoizing?)
     def get_log_qnames(self) -> set[str]:
-        return {
-            qname
-            for qnames in self.log_alias_to_log_qnames.values()
-            for qname in qnames
-        }
+        return set(itertools.chain.from_iterable(self.log_alias_to_log_qnames.values()))
 
     def get_artifact_log_qnames(self):
         return set(self.artifact_log_qnames)

--- a/torch/ao/quantization/_equalize.py
+++ b/torch/ao/quantization/_equalize.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import copy
+from itertools import chain
 from typing import Any
 
 import torch
@@ -233,7 +234,7 @@ def equalize(model, paired_modules_list, threshold=1e-4, inplace=True):
 
     name_to_module: dict[str, torch.nn.Module] = {}
     previous_name_to_module: dict[str, Any] = {}
-    name_set = {name for pair in paired_modules_list for name in pair}
+    name_set = set(chain.from_iterable(paired_modules_list))
 
     for name, module in model.named_modules():
         if name in name_set:

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -155,8 +155,8 @@ class MemoryTracker:
         import matplotlib.pyplot as plt
 
         def _plot_figure(x, y_values, labels):
-            min_val = min(list(chain(*y_values))) * 0.999
-            max_val = max(list(chain(*y_values))) * 1.001
+            min_val = min(chain.from_iterable(y_values)) * 0.999
+            max_val = max(chain.from_iterable(y_values)) * 1.001
             plt.figure()
             for y, label in zip(y_values, labels):
                 plt.plot(x, y, label=label)

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -9,6 +9,7 @@ import weakref
 from collections.abc import Generator, Iterable
 from enum import auto, Enum
 from functools import partial
+from itertools import chain
 from typing import Any, Callable, cast, no_type_check, Optional, TYPE_CHECKING
 
 import torch
@@ -370,9 +371,7 @@ def _get_handle_fqns_from_root(
         return None
     param_to_fqn = state._exec_order_data.param_to_fqn
     handle_params = handle.flat_param._params  # only populated for use_orig_params
-    param_fqns = [
-        fqn for fqn_list in [param_to_fqn[p] for p in handle_params] for fqn in fqn_list
-    ]
+    param_fqns = list(chain.from_iterable([param_to_fqn[p] for p in handle_params]))
     return param_fqns
 
 

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -371,7 +371,7 @@ def _get_handle_fqns_from_root(
         return None
     param_to_fqn = state._exec_order_data.param_to_fqn
     handle_params = handle.flat_param._params  # only populated for use_orig_params
-    param_fqns = list(chain.from_iterable([param_to_fqn[p] for p in handle_params]))
+    param_fqns = [*chain.from_iterable(param_to_fqn[p] for p in handle_params)]
     return param_fqns
 
 

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -153,7 +153,7 @@ def foreach_all_gather(
                 t.view(torch.uint8) for ts in param_all_gather_inputs for t in ts
             ]
         else:
-            all_gather_inputs = list(chain.from_iterable(param_all_gather_inputs))
+            all_gather_inputs = [*chain.from_iterable(param_all_gather_inputs)]
         inp_split_sizes = [t.numel() for t in all_gather_inputs]
         all_gather_input_numel = sum(inp_split_sizes)
         all_gather_input, all_gather_output = torch.ops.fsdp.all_gather_copy_in(

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -1,3 +1,4 @@
+from itertools import chain
 from typing import Callable, cast, NamedTuple, Optional, Union
 
 import torch
@@ -152,7 +153,7 @@ def foreach_all_gather(
                 t.view(torch.uint8) for ts in param_all_gather_inputs for t in ts
             ]
         else:
-            all_gather_inputs = [t for ts in param_all_gather_inputs for t in ts]
+            all_gather_inputs = list(chain.from_iterable(param_all_gather_inputs))
         inp_split_sizes = [t.numel() for t in all_gather_inputs]
         all_gather_input_numel = sum(inp_split_sizes)
         all_gather_input, all_gather_output = torch.ops.fsdp.all_gather_copy_in(

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1220,7 +1220,7 @@ def _map_param_key_to_optim_keys(
             [] for _ in range(dist.get_world_size(group))
         ]
         dist.all_gather_object(all_keys, all_optim_state_keys, group=group)
-        merge_all_optim_state_keys = list(chain.from_iterable(all_keys))
+        merge_all_optim_state_keys = [*chain.from_iterable(all_keys)]
         all_optim_state_keys = sorted(set(merge_all_optim_state_keys))
     else:
         key_obj_list: list[Optional[list[_OptimStateKey]]] = (
@@ -1254,9 +1254,9 @@ def _unflatten_param_groups(
         nested_unflat_param_names = [
             param_to_fqns[param] for param in param_group_params
         ]
-        unflat_param_group["params"] = list(
-            chain.from_iterable(nested_unflat_param_names)
-        )  # flatten the list of lists
+        unflat_param_group["params"] = [
+            *chain.from_iterable(nested_unflat_param_names)
+        ]  # flatten the list of lists
         param_groups.append(unflat_param_group)
     return param_groups
 

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -6,6 +6,7 @@ import warnings
 from collections.abc import Iterable, Iterator, Sequence
 from contextlib import ExitStack
 from dataclasses import dataclass, field
+from itertools import chain
 from typing import Any, cast, NamedTuple, no_type_check, Optional, TYPE_CHECKING, Union
 
 import torch
@@ -1219,9 +1220,7 @@ def _map_param_key_to_optim_keys(
             [] for _ in range(dist.get_world_size(group))
         ]
         dist.all_gather_object(all_keys, all_optim_state_keys, group=group)
-        merge_all_optim_state_keys = [
-            key for local_keys in all_keys for key in local_keys
-        ]
+        merge_all_optim_state_keys = list(chain.from_iterable(all_keys))
         all_optim_state_keys = sorted(set(merge_all_optim_state_keys))
     else:
         key_obj_list: list[Optional[list[_OptimStateKey]]] = (
@@ -1255,11 +1254,9 @@ def _unflatten_param_groups(
         nested_unflat_param_names = [
             param_to_fqns[param] for param in param_group_params
         ]
-        unflat_param_group["params"] = [
-            unflat_param_name
-            for unflat_param_names in nested_unflat_param_names
-            for unflat_param_name in unflat_param_names
-        ]  # flatten the list of lists
+        unflat_param_group["params"] = list(
+            chain.from_iterable(nested_unflat_param_names)
+        )  # flatten the list of lists
         param_groups.append(unflat_param_group)
     return param_groups
 

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -732,7 +732,9 @@ class ZeroRedundancyOptimizer(Optimizer, Joinable):
         if len(self._param_to_index_cache) == 0:
             self._param_to_index_cache = {
                 p: i
-                for i, p in enumerate(chain(*(g["params"] for g in self.param_groups)))
+                for i, p in enumerate(
+                    chain.from_iterable(g["params"] for g in self.param_groups)
+                )
             }
         return self._param_to_index_cache
 
@@ -741,7 +743,7 @@ class ZeroRedundancyOptimizer(Optimizer, Joinable):
         r"""List mapping parameter indices in the global optimizer scheme to the actual params."""
         if len(self._index_to_param_cache) == 0:
             self._index_to_param_cache = list(
-                chain(*(g["params"] for g in self.param_groups))
+                chain.from_iterable(g["params"] for g in self.param_groups)
             )
         return self._index_to_param_cache
 

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -414,7 +414,7 @@ def einsum(*args: Any) -> Tensor:
             equation, *operands, optimize=opt_einsum.strategy
         )[0]
         # flatten path for dispatching to C++
-        path = list(itertools.chain.from_iterable(tupled_path))
+        path = [*itertools.chain.from_iterable(tupled_path)]
     return _VF.einsum(equation, operands, path=path)  # type: ignore[attr-defined]
 
 

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -414,7 +414,7 @@ def einsum(*args: Any) -> Tensor:
             equation, *operands, optimize=opt_einsum.strategy
         )[0]
         # flatten path for dispatching to C++
-        path = [item for pair in tupled_path for item in pair]
+        path = list(itertools.chain.from_iterable(tupled_path))
     return _VF.einsum(equation, operands, path=path)  # type: ignore[attr-defined]
 
 

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -289,7 +289,7 @@ class Tracer(TracerBase):
         self._autowrap_function_ids: set[int] = {
             id(value)
             for name, value in chain.from_iterable(
-                [m.__dict__.items() for m in autowrap_modules]
+                m.__dict__.items() for m in autowrap_modules
             )
             if not name.startswith("_") and callable(value)
         }

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -288,7 +288,9 @@ class Tracer(TracerBase):
         # this captures both `math.sqrt()` and `from math import sqrt` automatically
         self._autowrap_function_ids: set[int] = {
             id(value)
-            for name, value in chain(*[m.__dict__.items() for m in autowrap_modules])
+            for name, value in chain.from_iterable(
+                [m.__dict__.items() for m in autowrap_modules]
+            )
             if not name.startswith("_") and callable(value)
         }
         self._autowrap_function_ids.update({id(f) for f in autowrap_functions})

--- a/torch/nn/parallel/_functions.py
+++ b/torch/nn/parallel/_functions.py
@@ -1,4 +1,5 @@
 import warnings
+from itertools import chain
 from typing import Optional
 
 import torch
@@ -25,7 +26,7 @@ class Broadcast(Function):
             if not input_requires_grad:
                 non_differentiables.extend(output[idx] for output in outputs)
         ctx.mark_non_differentiable(*non_differentiables)
-        return tuple([t for tensors in outputs for t in tensors])
+        return tuple(chain.from_iterable(outputs))
 
     @staticmethod
     def backward(ctx, *grad_outputs):

--- a/torch/profiler/_memory_profiler.py
+++ b/torch/profiler/_memory_profiler.py
@@ -957,7 +957,9 @@ class MemoryProfile:
         for event in self._op_tree.dfs():
             if event.typed[0] == _EventType.PyCall and event.typed[1].optimizer:
                 parameters = event.typed[1].optimizer.parameters
-                for _, t in it.chain(*[state for _, _, state in parameters]):
+                for _, t in it.chain.from_iterable(
+                    [state for _, _, state in parameters]
+                ):
                     key = TensorKey.from_tensor(t)
                     if key is not None:
                         self._categories.set_by_id(key, Category.OPTIMIZER_STATE)

--- a/torch/profiler/_memory_profiler.py
+++ b/torch/profiler/_memory_profiler.py
@@ -958,7 +958,7 @@ class MemoryProfile:
             if event.typed[0] == _EventType.PyCall and event.typed[1].optimizer:
                 parameters = event.typed[1].optimizer.parameters
                 for _, t in it.chain.from_iterable(
-                    [state for _, _, state in parameters]
+                    (state for _, _, state in parameters)
                 ):
                     key = TensorKey.from_tensor(t)
                     if key is not None:

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -49,7 +49,7 @@ MODULES_TO_SKIP: set[type] = {
 }
 
 # List of all module classes to test.
-MODULE_CLASSES: list[type] = list(chain(*[
+MODULE_CLASSES: list[type] = list(chain.from_iterable([
     [getattr(namespace, module_name) for module_name in namespace.__all__]  # type: ignore[attr-defined]
     for namespace in MODULE_NAMESPACES]))
 MODULE_CLASSES = [cls for cls in MODULE_CLASSES if cls not in MODULES_TO_SKIP]

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -49,9 +49,9 @@ MODULES_TO_SKIP: set[type] = {
 }
 
 # List of all module classes to test.
-MODULE_CLASSES: list[type] = list(chain.from_iterable([
+MODULE_CLASSES: list[type] = [*chain.from_iterable([
     [getattr(namespace, module_name) for module_name in namespace.__all__]  # type: ignore[attr-defined]
-    for namespace in MODULE_NAMESPACES]))
+    for namespace in MODULE_NAMESPACES])]
 MODULE_CLASSES = [cls for cls in MODULE_CLASSES if cls not in MODULES_TO_SKIP]
 
 # Dict of module class -> common name. Useful for making test names more intuitive.

--- a/torch/utils/benchmark/utils/compare.py
+++ b/torch/utils/benchmark/utils/compare.py
@@ -36,7 +36,7 @@ class _Column:
         highlight_warnings: bool,
     ):
         self._grouped_results = grouped_results
-        self._flat_results = list(it.chain.from_iterable(grouped_results))
+        self._flat_results = [*it.chain.from_iterable(grouped_results)]
         self._time_scale = time_scale
         self._time_unit = time_unit
         self._trim_significant_figures = trim_significant_figures

--- a/torch/utils/benchmark/utils/compare.py
+++ b/torch/utils/benchmark/utils/compare.py
@@ -36,7 +36,7 @@ class _Column:
         highlight_warnings: bool,
     ):
         self._grouped_results = grouped_results
-        self._flat_results = list(it.chain(*grouped_results))
+        self._flat_results = list(it.chain.from_iterable(grouped_results))
         self._time_scale = time_scale
         self._time_unit = time_unit
         self._trim_significant_figures = trim_significant_figures

--- a/torch/utils/benchmark/utils/fuzzer.py
+++ b/torch/utils/benchmark/utils/fuzzer.py
@@ -390,8 +390,8 @@ class Fuzzer:
 
     @staticmethod
     def _unpack(values, cls):
-        return tuple(it.chain(
-            *[[i] if isinstance(i, cls) else i for i in values]
+        return tuple(it.chain.from_iterable(
+            [[i] if isinstance(i, cls) else i for i in values]
         ))
 
     def take(self, n):


### PR DESCRIPTION
Often makes the code more readable, more efficient, and adds support for infinite iterables.


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov