### PR TITLE
Add cache size to error message

### DIFF
--- a/torch/_dynamo/cache_size.py
+++ b/torch/_dynamo/cache_size.py
@@ -171,9 +171,9 @@ def exceeds_recompile_limit(
     Checks if we are exceeding the cache size limit.
     """
     if cache_size.will_compilation_exceed_accumulated_limit():
-        return True, "accumulated_recompile_limit"
+        return True, f"accumulated_recompile_limit ({config.accumulated_recompile_limit})"
     if cache_size.will_compilation_exceed_specific_limit(config.recompile_limit):
-        return True, "recompile_limit"
+        return True, f"recompile_limit ({config.recompile_limit})"
     # NOTE this check is needed in the case that the frame's cache doesn't grow
     # and we keep recompiling. This can happen if the guard guard_manager becomes invalidated,
     # e.g. due to guarded objects being freed. This technically makes the
@@ -181,5 +181,5 @@ def exceeds_recompile_limit(
     # check in case we have a better fix in the future.
     assert compile_id.frame_compile_id is not None
     if compile_id.frame_compile_id >= config.accumulated_recompile_limit:
-        return True, "accumulated_recompile_limit"
+        return True, f"accumulated_recompile_limit ({config.accumulated_recompile_limit})"
     return False, ""


### PR DESCRIPTION
Adds the configured limit size to the cache size limit error message.

When the limit is hit right now, it only tells you that the cache size limit has been reached, not what the limit is. That's not too helpful if you want to bump the limit.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames