### PR TITLE
Expose functions used in custom backend in torch_python dll

### DIFF
--- a/torch/csrc/tensor/python_tensor.h
+++ b/torch/csrc/tensor/python_tensor.h
@@ -27,9 +27,9 @@ TORCH_PYTHON_API void py_set_default_dtype(PyObject* dtype_obj);
 // TODO: This is nuts!  There is no reason to let the default tensor type id
 // change.  Probably only store ScalarType, as that's the only flex point
 // we support.
-TORCH_API c10::DispatchKey get_default_dispatch_key();
+TORCH_PYTHON_API c10::DispatchKey get_default_dispatch_key();
 TORCH_PYTHON_API at::Device get_default_device();
 
 // Gets the ScalarType for the default tensor type.
-TORCH_API at::ScalarType get_default_scalar_type();
+TORCH_PYTHON_API at::ScalarType get_default_scalar_type();
 } // namespace torch::tensors

--- a/torch/csrc/tensor/python_tensor.h
+++ b/torch/csrc/tensor/python_tensor.h
@@ -31,5 +31,5 @@ TORCH_API c10::DispatchKey get_default_dispatch_key();
 TORCH_PYTHON_API at::Device get_default_device();
 
 // Gets the ScalarType for the default tensor type.
-at::ScalarType get_default_scalar_type();
+TORCH_API at::ScalarType get_default_scalar_type();
 } // namespace torch::tensors

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -209,7 +209,7 @@ struct FunctionSignature {
 
 // PythonArgs contains bound Python arguments for an actual invocation
 // along with references to the matched signature.
-struct PythonArgs {
+struct TORCH_PYTHON_API PythonArgs {
   PythonArgs(
       bool traceable,
       const FunctionSignature& signature,
@@ -302,12 +302,12 @@ struct PythonArgs {
   inline bool isNone(int i);
   inline std::optional<c10::DispatchKeySet> toDispatchKeySetOptional(int i);
 
-  // Functions used in performance-critical inline functions should
-  // be `public` so tagging them with `TORCH_PYTHON_API` looks
-  // more appropriate.
-  TORCH_PYTHON_API at::Tensor tensor_slow(int i);
-  TORCH_PYTHON_API at::Scalar scalar_slow(int i);
-  TORCH_PYTHON_API at::Scalar scalar_slow(PyObject* arg);
+ private:
+  // Non-inline functions' symbols are exposed to torch_python DLL
+  // via TORCH_PYTHON_API tag at struct level.
+  at::Tensor tensor_slow(int i);
+  at::Scalar scalar_slow(int i);
+  at::Scalar scalar_slow(PyObject* arg);
 };
 
 // FunctionParameter is a single formal parameter of a Python function.

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -302,7 +302,9 @@ struct PythonArgs {
   inline bool isNone(int i);
   inline std::optional<c10::DispatchKeySet> toDispatchKeySetOptional(int i);
 
- private:
+  // Functions used in performance-critical inline functions should
+  // be `public` so tagging them with `TORCH_PYTHON_API` looks
+  // more appropriate.
   TORCH_PYTHON_API at::Tensor tensor_slow(int i);
   TORCH_PYTHON_API at::Scalar scalar_slow(int i);
   TORCH_PYTHON_API at::Scalar scalar_slow(PyObject* arg);

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -303,9 +303,9 @@ struct PythonArgs {
   inline std::optional<c10::DispatchKeySet> toDispatchKeySetOptional(int i);
 
  private:
-  at::Tensor tensor_slow(int i);
-  at::Scalar scalar_slow(int i);
-  at::Scalar scalar_slow(PyObject* arg);
+  TORCH_PYTHON_API at::Tensor tensor_slow(int i);
+  TORCH_PYTHON_API at::Scalar scalar_slow(int i);
+  TORCH_PYTHON_API at::Scalar scalar_slow(PyObject* arg);
 };
 
 // FunctionParameter is a single formal parameter of a Python function.
@@ -320,7 +320,7 @@ struct FunctionParameter {
       int64_t* failed_idx = nullptr);
 
   void set_default_str(const std::string& str);
-  std::string type_name() const;
+  TORCH_PYTHON_API std::string type_name() const;
 
   ParameterType type_;
   bool optional;


### PR DESCRIPTION
Fixes #148208. There are solutions for exposing symbols implicitly from inline functions (i.e., inline function A calls non-inline function B in foo.h. Code includes foo.h has to see the symbol B in DLL).

Solution 1: tag the entire struct where the inline functions are defined as member functions with TORCH_PYTHON_API --- this PR does this for python_arg_parser.h. An alternative solution exists but will slow down dispatching a lot --- drop inline keyword and move implementation to .cc file.

Solution 2: tag individual functions with TORCH_PYTHON_API. This PR does this for python_tensor.h.

Related discussion about hiding torch_python symbols: https://github.com/pytorch/pytorch/pull/142214
