### PR TITLE
[ci] disable cudagraph for tts_angular on dashboard

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1825,6 +1825,10 @@ class BenchmarkRunner:
         return set()
 
     @property
+    def disable_cudagraph_models(self):
+        return set()
+
+    @property
     def guard_on_nn_module_models(self):
         return set()
 
@@ -3833,6 +3837,9 @@ def run(runner, args, original_dir=None):
         )
         experiment = coverage_experiment
         output_filename = "coverage.csv"
+
+    if args.only in runner.disable_cudagraph_models:
+        args.disable_cudagraphs = True
 
     if args.inductor or args.backend == "inductor" or args.export_aot_inductor:
         inductor_config.triton.cudagraphs = not args.disable_cudagraphs

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -146,6 +146,10 @@ class TorchBenchmarkRunner(BenchmarkRunner):
         return self._skip["freezing"]["cuda"]
 
     @property
+    def disable_cudagraph_models(self):
+        return self._config["disable_cudagraph"]
+
+    @property
     def skip_models_for_freezing_cpu(self):
         return self._skip["freezing"]["cpu"]
 

--- a/benchmarks/dynamo/torchbench.yaml
+++ b/benchmarks/dynamo/torchbench.yaml
@@ -111,6 +111,12 @@ non_deterministic:
   - sam_fast
 
 
+disable_cudagraph:
+  # tts_angular is flaky with cudagraphs. Its speedup
+  # oscillates from .05 to 1.05
+  - tts_angular
+
+
 dtype:
   force_amp_for_fp16_bf16_models:
     - DALLE2_pytorch


### PR DESCRIPTION
tts_angular with cudagraph is flaky. Its speedup varies from .05 to 1.01. This PR disables cudagraph for tts_angular to avoid the noise. Since tts_angular shows ~1x speedup while other torchbench models show ~2x speedup, skipping tts_angular would wrongly bump the cudagraph speedup. So this PR only disables cudagraph for tts_angular instead of skipping tts_angular.

[Dashboard ](https://github.com/pytorch/pytorch/actions/runs/13597394087)
 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames