### PR TITLE
Significantly speed up save_cache_artifacts

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -89,7 +89,6 @@ class TestFxGraphCache(TestCase):
         PyCodeCache.cache_clear(purge=True)
         torch._dynamo.reset()
         clear_inductor_caches()
-        CacheArtifactManager.clear()
 
     @requires_triton()
     @config.patch({"fx_graph_cache": True})
@@ -363,6 +362,61 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
+
+    @config.patch(
+        {
+            "fx_graph_cache": True,
+            "fx_graph_remote_cache": False,
+        }
+    )
+    def test_cache_hot_load_repeat(self):
+        def fn(x, y):
+            return x @ y.sin()
+
+        compiled_fn = torch.compile(fn, dynamic=False)
+
+        a = torch.randn(4, 4)
+        b = torch.randn(4, 4)
+
+        a2 = torch.randn(4, 8)
+        b2 = torch.randn(8, 4)
+
+        with fresh_inductor_cache():
+            eager_result = fn(a, b)
+            compiled_result = compiled_fn(a, b)
+            self.assertEqual(eager_result, compiled_result)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+        artifacts = torch.compiler.save_cache_artifacts()
+
+        self.assertFalse(torch.compiler._cache.CacheArtifactManager.need_serialize())
+        self.assertIsNotNone(artifacts)
+
+        artifact_bytes, cache_info = artifacts
+
+        self.reset()
+
+        with fresh_inductor_cache():
+            torch.compiler.load_cache_artifacts(artifact_bytes)
+            eager_result = fn(a, b)
+            compiled_result = compiled_fn(a, b)
+            self.assertEqual(eager_result, compiled_result)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+        self.assertFalse(torch.compiler._cache.CacheArtifactManager.need_serialize())
+
+        self.reset()
+
+        with fresh_inductor_cache():
+            eager_result = fn(a2, b2)
+            compiled_result = compiled_fn(a2, b2)
+            self.assertEqual(eager_result, compiled_result)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+        self.assertTrue(torch.compiler._cache.CacheArtifactManager.need_serialize())
 
     @torch._dynamo.config.patch(automatic_dynamic_local_pgo=True)
     @torch._functorch.config.patch({"enable_autograd_cache": False})

--- a/torch/compiler/_cache.py
+++ b/torch/compiler/_cache.py
@@ -1,12 +1,18 @@
+import copy
 import dataclasses
 import logging
 import os
-import pickle
 from enum import Enum
 from typing import Optional, Union
 
 from torch._inductor.remote_cache import JsonDataTy, RemoteCacheJsonSerde
 from torch._inductor.runtime.runtime_utils import cache_dir
+from torch.utils._appending_byte_serializer import (
+    AppendingByteSerializer,
+    BytesReader,
+    BytesWriter,
+)
+from torch.utils._ordered_set import OrderedSet
 
 
 log = logging.getLogger(__name__)
@@ -33,6 +39,24 @@ class CacheArtifact:
     key: str
     content: bytes = dataclasses.field(repr=False)  # Do not display potential binary
 
+    @staticmethod
+    def serialize(cls: "CacheArtifact") -> bytes:
+        writer = BytesWriter()
+        writer.write_int(cls.type.value)
+        writer.write_str(cls.key)
+        writer.write_int(len(cls.content))
+        writer.write_bytes(cls.content)
+        return writer.get()
+
+    @staticmethod
+    def deserialize(data: bytes) -> "CacheArtifact":
+        reader = BytesReader(data)
+        type = reader.read_int()
+        key = reader.read_str()
+        bytes_len = reader.read_int()
+        content = reader.read_bytes(bytes_len)
+        return CacheArtifact(CacheArtifactType(type), key, content)
+
 
 @dataclasses.dataclass
 class CacheInfo:
@@ -58,6 +82,12 @@ class CacheInfo:
         else:
             log.warning(f"Unsupported artifact type {artifact.type}")  # noqa: G004
 
+    def clear(self) -> None:
+        self.inductor_artifacts.clear()
+        self.autotune_artifacts.clear()
+        self.aot_autograd_artifacts.clear()
+        self.pgo_artifacts.clear()
+
 
 class CacheArtifactManager:
     """
@@ -77,11 +107,24 @@ class CacheArtifactManager:
     """
 
     # Protected by the compile_lock
-    _cache_artifacts: list[CacheArtifact] = []
+    _new_cache_artifacts: list[CacheArtifact] = []
+    # Keep a seperate seen artifacts list to make avoid unnecessary duplicates
+    # This list will not be cleared between serialize() calls
+    _seen_artifacts: OrderedSet[CacheArtifact] = OrderedSet()
+    # When serialize() is called, artifacts are transferred from _cache_artifacts to
+    # internal data structure of the _serializer
+    # This allows us to only pay the cost of serialization if serialize() is called
+    _serializer: AppendingByteSerializer[CacheArtifact] = AppendingByteSerializer(
+        serialize_fn=CacheArtifact.serialize
+    )
+    _cache_info: CacheInfo = CacheInfo()
 
     @classmethod
     def clear(cls) -> None:
-        cls._cache_artifacts.clear()
+        cls._new_cache_artifacts.clear()
+        cls._seen_artifacts.clear()
+        cls._serializer.clear()
+        cls._cache_info.clear()
 
     @classmethod
     def record_artifact(
@@ -99,19 +142,35 @@ class CacheArtifactManager:
             serde = RemoteCacheJsonSerde()
             content = serde.encode(content)
         assert isinstance(content, bytes)
-        cls._cache_artifacts.append(CacheArtifact(artifact_type, key, content))
+        artifact = CacheArtifact(artifact_type, key, content)
+        if artifact in cls._seen_artifacts:
+            return
+        log.debug("Recording %s", str(artifact))
+        cls._new_cache_artifacts.append(artifact)
+        cls._seen_artifacts.add(artifact)
+
+    @classmethod
+    def need_serialize(cls) -> bool:
+        """
+        Have we seen new artifacts since last serialize call?
+        """
+        return len(cls._new_cache_artifacts) != 0
 
     @classmethod
     def serialize(cls) -> Optional[tuple[bytes, CacheInfo]]:
         """
         Converts the "mega" list into portable format
         """
-        info = CacheInfo()
-        for artifact in cls._cache_artifacts:
+        for artifact in cls._new_cache_artifacts:
             log.debug("saving: %s", artifact)
-            info.add(artifact)
+            cls._cache_info.add(artifact)
         try:
-            return (pickle.dumps(cls._cache_artifacts), info)
+            # We deep copy cls._cache_info since later compilations
+            # can keep adding to cache_info
+            info = copy.deepcopy(cls._cache_info)
+            artifact_bytes = cls._serializer.appendListAndGet(cls._new_cache_artifacts)
+            cls._new_cache_artifacts.clear()
+            return artifact_bytes, info
         except Exception:
             log.warning("Failed to pickle cache artifacts", exc_info=True)
         return None
@@ -119,10 +178,12 @@ class CacheArtifactManager:
     @staticmethod
     def deserialize(serialized_artifacts: bytes) -> Optional[CacheInfo]:
         """
-        Converst the portable format back into various filesystem caches
+        Converts the portable format back into various filesystem caches
         """
         try:
-            artifacts = pickle.loads(serialized_artifacts)
+            artifacts = AppendingByteSerializer.to_list(
+                serialized_artifacts, deserialize_fn=CacheArtifact.deserialize
+            )
         except Exception:
             log.warning("Failed to un-pickle cache artifacts", exc_info=True)
             return None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148227
* #148226

While using save_cache_artifacts on internal workloads, we have noticed that repeatedly calling this function after every batch is incredibly expensive. This PR significantly speeds up this function call by opting out of pickle and redesigning serialization algorithm.

Essentially what we want is to be able to call serialize many times without incurring costs from scratch. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov