### PR TITLE
[triton 3.3] Fix inductor/test_profiler.py test

### DIFF
--- a/test/inductor/test_profiler.py
+++ b/test/inductor/test_profiler.py
@@ -102,7 +102,11 @@ class DynamoProfilerTests(torch._inductor.test_case.TestCase):
         for event in events:
             if event.name == "triton_poi_fused_add_cos_sin_0":
                 event_found = True
-                self.assertTrue(event.input_shapes == [[4, 4], [4, 4], [4, 4], []])
+                # Note: depending on the triton version, we might get 4 or 5 args
+                # (including / not including the constexpr args). The last two are
+                # both empty args, so we just truncate the event.input_shapes to the
+                # first 4.
+                self.assertEqual(event.input_shapes[:4], [[4, 4], [4, 4], [4, 4], []])
         self.assertTrue(event_found)
 
     @unittest.skipIf(not HAS_TRITON, "requires cuda & triton")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148230

test_inductor_profiling_kernel_names_pointwise is checking that the profiler correctly records the input shapes to the kernel. After triton 3.3, we get a different number of args (because the constexpr args are passed in, from the python perspective). This just patches the test to pass in either case.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov