### PR TITLE
[export] Fix logging so that it doesn't result in max recursion error

### DIFF
--- a/torch/export/_draft_export.py
+++ b/torch/export/_draft_export.py
@@ -322,11 +322,11 @@ class CaptureStructuredTrace(torch._logging._internal.LazyTraceHandler):
                                 # Don't log the expression if we have already
                                 # printed it beforehand
                                 if not res.visited:
+                                    res.visited = True
                                     for arg in res.argument_ids:
                                         _log_expression_created(emit_func, arg)
 
                                 emit_func(res.record)
-                                res.visited = True
 
                         _log_expression_created(
                             super().emit, metadata[key].get("expr_node_id")

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -1265,7 +1265,17 @@ def _make_node_magic(method, func):
 
                 def get_id(sym_node) -> Optional[int]:
                     # We don't want to return an ID if the input is a constant
-                    return None if sym_node.constant is not None else id(sym_node)
+                    import sympy
+
+                    if sym_node.constant is not None:
+                        return None
+                    elif id(sym_node) == id(result):
+                        return None
+                    elif isinstance(sym_node.expr, (sympy.Integer, sympy.Float)):
+                        return None
+                    elif sym_node.expr in (sympy.true, sympy.false):
+                        return None
+                    return id(sym_node)
 
                 dtrace_structured(
                     "expression_created",


### PR DESCRIPTION
Test Plan:
buck2 run mode/dev-nosan sigmoid/inference/ts_migration:pt2i_readiness_main -- --model_id=487493491 --test_suite ads_all --mode test_full_model

Produces https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmp2wsjQH/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=100

Differential Revision: D70416613




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv