### PR TITLE
[ROCm][TunableOp] Add support for rowwise scaling on scaled GEMM.

### DIFF
--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -351,7 +351,7 @@ struct ScaledGemmParams : OpParams {
   ScaledGemmParams() = default;
 
   std::string Signature() const override {
-    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld", transa, transb, m, n, k, lda, ldb, ldc);
+    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld_rw_%d", transa, transb, m, n, k, lda, ldb, ldc, use_rowwise);
   }
 
   size_t GetSizeA() const {

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4655,12 +4655,7 @@ class TestLinalg(TestCase):
     @onlyCUDA
     @dtypes(torch.half)
     def test_matmul_offline_tunableop(self, device, dtype):
-        import tempfile
         import os
-
-        # Pointing to temp files. The test cannot remove them on Windows because
-        # they are in use and locked
-        tmp_dir = tempfile.mkdtemp()
 
         ordinal = torch.cuda.current_device()
 
@@ -4670,8 +4665,8 @@ class TestLinalg(TestCase):
             set_tunableop_defaults()
             torch.cuda.tunable.set_rotating_buffer_size(0)
 
-            result_filename = os.path.join(tmp_dir, f"tunableop_results{ordinal}.csv")
-            os.putenv("PYTORCH_TUNABLEOP_UNTUNED_FILENAME", os.path.join(tmp_dir, "tunableop_untuned.csv"))
+            result_filename = f"tunableop_results{ordinal}.csv"
+            os.putenv("PYTORCH_TUNABLEOP_UNTUNED_FILENAME", "tunableop_untuned.csv")
             torch.cuda.tunable.set_filename(result_filename)
 
             torch.cuda.tunable.enable()
@@ -4689,7 +4684,7 @@ class TestLinalg(TestCase):
             self.assertTrue(torch.cuda.tunable.is_enabled())
             self.assertTrue(torch.cuda.tunable.tuning_is_enabled() is False)
 
-            untuned_filename = os.path.join(tmp_dir, f"tunableop_untuned{ordinal}.csv")
+            untuned_filename = f"tunableop_untuned{ordinal}.csv"
             self.assertTrue(os.path.exists(untuned_filename))
 
             # tuning the untuned GEMMs in file

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5315,7 +5315,7 @@ class TestLinalg(TestCase):
         # Scaled GEMM parameters
         fillA = 0.25
         fillB = 0.75
-        m = n = k = 16
+        m = n = k = 32
         scaleA = torch.tensor(0.8, device=device)
         scaleB = torch.tensor(0.9, device=device)
 

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -405,17 +405,24 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
         dtype = dtype_dict.get(data_type)
     else:  # ScaledGEMM
         untuned_gemm_temp = untuned_gemm[0].split("_")
+        # dtypeC = might not be FP8 type, keep track
+        # of the the number of underscores
+        count = untuned_gemm_temp.count("_")
         op_sig = untuned_gemm_temp[0]
         data_typeA = untuned_gemm_temp[1] + "_" + untuned_gemm_temp[2]
         data_typeB = untuned_gemm_temp[3] + "_" + untuned_gemm_temp[4]
-        data_typeC = untuned_gemm_temp[5] + "_" + untuned_gemm_temp[6]
-        transA = untuned_gemm_temp[7][0] == "T"
-        transB = untuned_gemm_temp[7][1] == "T"
+        if count == 7:
+            data_typeC = untuned_gemm_temp[5] + "_" + untuned_gemm_temp[6]
+        else:
+            data_typeC = untuned_gemm_temp[5]
+        transA = untuned_gemm_temp[count][0] == "T"
+        transB = untuned_gemm_temp[count][1] == "T"
         dtypeA = dtype_dict.get(data_typeA)
         dtypeB = dtype_dict.get(data_typeB)
         dtypeC = dtype_dict.get(data_typeC)
 
-    [n, m, k] = [int(g) for g in untuned_gemm[1].split("_")[1:4]]
+    untuned_gemm_temp = untuned_gemm[1].split("_")
+    [n, m, k] = [int(g) for g in untuned_gemm_temp[1:4]]
     if op_sig == "GemmTunableOp":
         matA = (
             torch.rand(k, m, dtype=dtype, device=deviceid).t()
@@ -429,7 +436,7 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
         )
         torch.mm(matA, matB)
     elif op_sig == "GemmStridedBatchedTunableOp":
-        [b] = [int(g) for g in untuned_gemm[1].split("_")[5:6]]
+        [b] = [int(g) for g in untuned_gemm_temp[5:6]]
         matA = (
             torch.rand(b, k, m, dtype=dtype, device=deviceid)
             if transB
@@ -446,18 +453,28 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
     elif op_sig == "ScaledGemmTunableOp":
         fillA = 0.25
         fillB = 0.75
-        scaleA = torch.tensor(0.8, device=deviceid)
-        scaleB = torch.tensor(0.9, device=deviceid)
         matA = (
             torch.full((k, m), fillA, dtype=dtypeA, device=deviceid).t()
             if transB
             else torch.full((m, k), fillA, dtype=dtypeA, device=deviceid)
         )
         matB = (
-            torch.full((n, k), fillB, dtype=dtypeB, device=deviceid).t()
+            torch.full((n, k), fillB, dtype=dtypeB, device=deviceid)
             if transA
-            else torch.full((k, n), fillB, dtype=dtypeB, device=deviceid)
+            else torch.full((k, n), fillB, dtype=dtypeB, device=deviceid).t()
         )
+        assert untuned_gemm_temp[8] == "rw"
+        if untuned_gemm_temp[9] == "1":
+            rowwise = True
+        else:
+            rowwise = False
+        if rowwise:
+            scaleA = torch.ones((matA.shape[0], 1), device=deviceid)
+            scaleB = torch.ones((1, matB.shape[0]), device=deviceid)
+        else:
+            scaleA = torch.tensor(0.8, device=deviceid)
+            scaleB = torch.tensor(0.9, device=deviceid)
+
         torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=dtypeC)
     elif op_sig == "GemmAndBiasTunableOp":
         # y = x*A^T + b


### PR DESCRIPTION
This PR adds support for rowwise scaling versus tensorwise scaling on scaled GEMM.

There are few other items included in this PR as well:
- Fixes for offline tuning of scaled GEMM
- Simplification of existing offline UT
- Update existing online UT to also test rowwise versus tensorwise scaled GEMM
- New UT for offline scaled GEMM


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang