### PR TITLE
handle jk for emulation runs

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -41,6 +41,8 @@ def bundle_triton_into_fx_graph_cache_default() -> Optional[bool]:
 
 def prologue_fusion_enabled() -> bool:
     ENABLE_PROLOGUE_FUSION_VERSION = 0
+    if os.environ.get("PYTORCH_DISABLE_JUSTKNOBS", 0) == 1:
+        return True
 
     if "TORCHINDUCTOR_PROLOGUE_FUSION" in os.environ:
         return os.environ.get("TORCHINDUCTOR_PROLOGUE_FUSION") == "1"


### PR DESCRIPTION
Summary:
seeing jk error for a platform which has no service network,  https://www.internalfb.com/sandcastle/workflow/2260807012946333388/artifact/actionlog.2260807013059769273.stdout.1?selectedLines=1979-1980-1-1

so just fallback if JK is disabled

Test Plan: ez

Reviewed By: openrichardfb

Differential Revision: D70433783




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov