### PR TITLE
Fix macro for bit_cast in c10/util/bit_cast.h - one line change

### DIFF
--- a/c10/util/bit_cast.h
+++ b/c10/util/bit_cast.h
@@ -3,7 +3,7 @@
 #include <cstring>
 #include <type_traits>
 
-#if __has_include(<bit>) && (__cplusplus >= 202002L || (defined(__cpp_lib_bit_cast) && __cpp_lib_bit_cast >= 201806L))
+#if __has_include(<bit>) && (defined(__cpp_lib_bit_cast) && __cpp_lib_bit_cast >= 201806L)
 #include <bit>
 #define C10_HAVE_STD_BIT_CAST 1
 #else


### PR DESCRIPTION
Fixes #148263.
