### PR TITLE
Fix bug when Inductor include path contains spaces

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1559,7 +1559,7 @@ class CppBuilder:
             if _IS_WINDOWS:
                 self._include_dirs_args += f'/I "{inc_dir}" '
             else:
-                self._include_dirs_args += f"-I{inc_dir} "
+                self._include_dirs_args += f"-I{shlex.quote(inc_dir)} "
 
         for ldflag in BuildOption.get_ldflags():
             if _IS_WINDOWS:


### PR DESCRIPTION
This PR fixes a bug with how include directories with spaces are handled on Windows. I ran into an edge case with torch.compile() - it will error out with an exception on Windows. In particular, it will try to execute the following: `cl /I C:/Program Files/Python311/Include ...`, where `C:/Program` will be treated as separate from `Files/Python311/Include`.

I looked into using something like `shlex.quote` or `pathlib.Path`, but I didn't find those options to be suitable (shlex is POSIX shell only, pathlib.Path does not escape spaces).

There is another place in the function that also deals with escaping spaces. My fix follows the same style. https://github.com/pytorch/pytorch/blob/0ff2e6a85a3264438aaec8bfb9c69b679ea835da/torch/_inductor/cpp_builder.py#L1464

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov