### PR TITLE
[torch] Fix unsafe concurrent access to autocast_enabled

### DIFF
--- a/torch/csrc/jit/passes/autocast.cpp
+++ b/torch/csrc/jit/passes/autocast.cpp
@@ -7,6 +7,7 @@
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/quantization/helper.h>
+#include <atomic>
 #include <optional>
 
 #include <stack>
@@ -17,7 +18,7 @@ namespace torch::jit {
 
 namespace {
 
-bool autocast_enabled = true;
+std::atomic<bool> autocast_enabled = true;
 
 struct AutocastContext {
   bool gpu_enabled = false;
@@ -509,9 +510,7 @@ void handleBlock(Block* block, AutocastContext initial_state) {
 } // namespace
 
 bool setAutocastMode(bool value) {
-  auto old_value = autocast_enabled;
-  autocast_enabled = value;
-  return old_value;
+  return autocast_enabled.exchange(value);
 }
 
 bool autocastEnabled() {


### PR DESCRIPTION
Summary: Making autocast_enabled atomic, as it can be accessed from multiple threads

Differential Revision: D70456813




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @mcarilli @ptrblck @leslie-fang-intel