### PR TITLE
[PoC] Add RECORD_FUNCTION calls for aoti shim layer wrappers

### DIFF
--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -179,13 +179,13 @@ AOTI_TORCH_MEMORY_FORMAT_IMPL(channels_last_3d, ChannelsLast3d)
 AOTI_TORCH_MEMORY_FORMAT_IMPL(preserve_format, Preserve)
 #undef AOTI_TORCH_MEMORY_FORMAT_IMPL
 
-#define AOTI_TORCH_ITEM_IMPL(dtype, ctype)                     \
-  AOTITorchError aoti_torch_item_##dtype(                      \
-      AtenTensorHandle tensor, ctype* ret_value) {             \
-    AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({               \
-      at::Tensor* t = tensor_handle_to_tensor_pointer(tensor); \
-      *ret_value = t->item().to<ctype>();                      \
-    });                                                        \
+#define AOTI_TORCH_ITEM_IMPL(dtype, ctype)                          \
+  AOTITorchError aoti_torch_item_##dtype(                           \
+      AtenTensorHandle tensor, ctype* ret_value) {                  \
+    AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_item", { \
+      at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);      \
+      *ret_value = t->item().to<ctype>();                           \
+    });                                                             \
   }
 
 AOTI_TORCH_ITEM_IMPL(float16, c10::Half)
@@ -207,7 +207,7 @@ AOTI_TORCH_ITEM_IMPL(complex64, c10::complex<float>)
 #define AOTI_TORCH_SCALAR_TO_TENSOR_IMPL(dtype, ctype, ttype)                  \
   AOTITorchError aoti_torch_scalar_to_tensor_##dtype(                          \
       ctype value, AtenTensorHandle* ret_new_tensor) {                         \
-    AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({                               \
+    AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::scalar_tensor", {          \
       *ret_new_tensor =                                                        \
           new_tensor_handle(at::scalar_tensor(value, c10::ScalarType::ttype)); \
     });                                                                        \
@@ -240,16 +240,17 @@ void aoti_torch_grad_mode_set_enabled(bool enabled) {
 }
 
 AOTITorchError aoti_torch_delete_tensor_object(AtenTensorHandle tensor) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
-    delete t;
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_delete_tensor_object", {
+        at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
+        delete t;
+      });
 }
 
 AOTITorchError aoti_torch_get_data_ptr(
     AtenTensorHandle tensor,
     void** ret_data_ptr) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_data_ptr", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     if (t->is_mkldnn()) {
       *ret_data_ptr = data_ptr_from_mkldnn(t);
@@ -262,14 +263,14 @@ AOTITorchError aoti_torch_get_data_ptr(
 AOTITorchError aoti_torch_get_storage_size(
     AtenTensorHandle tensor,
     int64_t* ret_size) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_storage_size", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_size = t->storage().nbytes();
   });
 }
 
 AOTITorchError aoti_torch_get_dim(AtenTensorHandle tensor, int64_t* ret_dim) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_dim", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_dim = t->dim();
   });
@@ -278,7 +279,7 @@ AOTITorchError aoti_torch_get_dim(AtenTensorHandle tensor, int64_t* ret_dim) {
 AOTITorchError aoti_torch_get_numel(
     AtenTensorHandle tensor,
     int64_t* ret_numel) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_numel", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_numel = t->numel();
   });
@@ -287,7 +288,7 @@ AOTITorchError aoti_torch_get_numel(
 AOTITorchError aoti_torch_get_storage_numel(
     AtenTensorHandle tensor,
     int64_t* ret_numel) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_storage_numel", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     TORCH_INTERNAL_ASSERT(t->has_storage());
     auto dtype_size = t->dtype().itemsize();
@@ -301,7 +302,7 @@ AOTITorchError aoti_torch_get_storage_numel(
 AOTITorchError aoti_torch_get_sizes(
     AtenTensorHandle tensor,
     int64_t** ret_sizes) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_sizes", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     *ret_sizes = const_cast<int64_t*>(t->sizes().data());
@@ -312,7 +313,7 @@ AOTITorchError aoti_torch_get_size(
     AtenTensorHandle tensor,
     int64_t d,
     int64_t* ret_size) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_size", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_size = t->size(d);
   });
@@ -321,7 +322,7 @@ AOTITorchError aoti_torch_get_size(
 AOTITorchError aoti_torch_get_strides(
     AtenTensorHandle tensor,
     int64_t** ret_strides) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_strides", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     *ret_strides = const_cast<int64_t*>(t->strides().data());
@@ -332,7 +333,7 @@ AOTITorchError aoti_torch_get_stride(
     AtenTensorHandle tensor,
     int64_t d,
     int64_t* ret_stride) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_stride", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_stride = t->stride(d);
   });
@@ -341,7 +342,7 @@ AOTITorchError aoti_torch_get_stride(
 AOTITorchError aoti_torch_get_dtype(
     AtenTensorHandle tensor,
     int32_t* ret_dtype) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_dtype", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_dtype = static_cast<int32_t>(t->scalar_type());
   });
@@ -350,7 +351,7 @@ AOTITorchError aoti_torch_get_dtype(
 AOTITorchError aoti_torch_get_device_type(
     AtenTensorHandle tensor,
     int32_t* ret_device_type) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_device_type", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_device_type = static_cast<int32_t>(t->device().type());
   });
@@ -359,7 +360,7 @@ AOTITorchError aoti_torch_get_device_type(
 AOTITorchError aoti_torch_get_device_index(
     AtenTensorHandle tensor,
     int32_t* ret_device_index) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_device_index", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_device_index = static_cast<int16_t>(t->device().index());
   });
@@ -368,7 +369,7 @@ AOTITorchError aoti_torch_get_device_index(
 AOTITorchError aoti_torch_get_storage_offset(
     AtenTensorHandle tensor,
     int64_t* ret_storage_offset) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_storage_offset", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_storage_offset = t->storage_offset();
   });
@@ -381,7 +382,7 @@ AOTITorchError aoti_torch__reinterpret_tensor(
     const int64_t* strides_ptr,
     int64_t offset_increment,
     AtenTensorHandle* ret_new_tensor) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch__reinterpret_tensor", {
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     c10::IntArrayRef sizes(sizes_ptr, ndim);
     c10::IntArrayRef strides(strides_ptr, ndim);
@@ -399,7 +400,7 @@ AOTITorchError aoti_torch_empty_strided(
     int32_t device_type,
     int32_t device_index,
     AtenTensorHandle* ret_new_tensor) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_empty_strided", {
     c10::IntArrayRef sizes(sizes_ptr, ndim);
     c10::IntArrayRef strides(strides_ptr, ndim);
     if (c10::DeviceType(device_type) == c10::DeviceType::CPU) {
@@ -425,21 +426,22 @@ AOTITorchError aoti_torch_create_tensor_from_blob(
     int32_t device_type,
     int32_t device_index,
     AtenTensorHandle* ret_new_tensor) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    c10::IntArrayRef sizes(sizes_ptr, ndim);
-    c10::IntArrayRef strides(strides_ptr, ndim);
-    c10::Device device = c10_device(device_type, device_index);
-    c10::TensorOptions options = c10::TensorOptions().device(device).dtype(
-        static_cast<c10::ScalarType>(dtype));
-    *ret_new_tensor = new_tensor_handle(
-        // data == nullptr can happen for a 0-size tensor
-        (data != nullptr) ? at::for_blob(data, sizes)
-                                .strides(strides)
-                                .storage_offset(storage_offset)
-                                .options(options)
-                                .make_tensor()
-                          : at::empty_strided(sizes, strides, options));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_create_tensor_from_blob", {
+        c10::IntArrayRef sizes(sizes_ptr, ndim);
+        c10::IntArrayRef strides(strides_ptr, ndim);
+        c10::Device device = c10_device(device_type, device_index);
+        c10::TensorOptions options = c10::TensorOptions().device(device).dtype(
+            static_cast<c10::ScalarType>(dtype));
+        *ret_new_tensor = new_tensor_handle(
+            // data == nullptr can happen for a 0-size tensor
+            (data != nullptr) ? at::for_blob(data, sizes)
+                                    .strides(strides)
+                                    .storage_offset(storage_offset)
+                                    .options(options)
+                                    .make_tensor()
+                              : at::empty_strided(sizes, strides, options));
+      });
 }
 
 AOTITorchError aoti_torch_create_tensor_from_blob_v2(
@@ -455,33 +457,34 @@ AOTITorchError aoti_torch_create_tensor_from_blob_v2(
     int32_t layout,
     const uint8_t* opaque_metadata,
     int64_t opaque_metadata_size) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    if (layout == static_cast<int32_t>(at::kMkldnn)) {
-      c10::IntArrayRef sizes(sizes_ptr, ndim);
-      c10::IntArrayRef strides(strides_ptr, ndim);
-      c10::Device device = c10_device(device_type, device_index);
-      // get a mkldnn tensor wrapped by a torch Tensor(OpaqueTensorImpl),
-      // which used by later mkldnn op.
-      *ret_new_tensor = new_tensor_handle(mkldnn_tensor_from_data_ptr(
-          data,
-          sizes,
-          static_cast<c10::ScalarType>(dtype),
-          device,
-          opaque_metadata,
-          opaque_metadata_size));
-    } else {
-      aoti_torch_create_tensor_from_blob(
-          data,
-          ndim,
-          sizes_ptr,
-          strides_ptr,
-          storage_offset,
-          dtype,
-          device_type,
-          device_index,
-          ret_new_tensor);
-    }
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_create_tensor_from_blob_v2", {
+        if (layout == static_cast<int32_t>(at::kMkldnn)) {
+          c10::IntArrayRef sizes(sizes_ptr, ndim);
+          c10::IntArrayRef strides(strides_ptr, ndim);
+          c10::Device device = c10_device(device_type, device_index);
+          // get a mkldnn tensor wrapped by a torch Tensor(OpaqueTensorImpl),
+          // which used by later mkldnn op.
+          *ret_new_tensor = new_tensor_handle(mkldnn_tensor_from_data_ptr(
+              data,
+              sizes,
+              static_cast<c10::ScalarType>(dtype),
+              device,
+              opaque_metadata,
+              opaque_metadata_size));
+        } else {
+          aoti_torch_create_tensor_from_blob(
+              data,
+              ndim,
+              sizes_ptr,
+              strides_ptr,
+              storage_offset,
+              dtype,
+              device_type,
+              device_index,
+              ret_new_tensor);
+        }
+      });
 }
 
 AOTITorchError aoti_torch__embedding_bag(
@@ -499,7 +502,7 @@ AOTITorchError aoti_torch__embedding_bag(
     AtenTensorHandle* ret2, // returns new reference
     AtenTensorHandle* ret3 // returns new reference
 ) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch__embedding_bag", {
     auto [r0, r1, r2, r3] = at::_embedding_bag(
         *tensor_handle_to_tensor_pointer(weight),
         *tensor_handle_to_tensor_pointer(indices),
@@ -527,7 +530,7 @@ AOTITorchError aoti_torch__fft_c2c(
     int32_t forward,
     AtenTensorHandle* ret // returns new reference
 ) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch__fft_c2c", {
     auto dim = c10::IntArrayRef(dim_ptr, dim_size);
     *ret = new_tensor_handle(at::_fft_c2c(
         *tensor_handle_to_tensor_pointer(self), dim, normalization, forward));
@@ -552,36 +555,37 @@ AOTITorchError aoti_torch__scaled_dot_product_flash_attention_v2(
     AtenTensorHandle* ret7, // returns new reference
     AtenTensorHandle* ret8 // returns new reference
 ) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    at::Tensor* query_tensor = tensor_handle_to_tensor_pointer(query);
-    at::Tensor* key_tensor = tensor_handle_to_tensor_pointer(key);
-    at::Tensor* value_tensor = tensor_handle_to_tensor_pointer(value);
-    auto optional_scale = pointer_to_optional(scale);
-    auto [r0, r1, r2, r3, r4, r5, r6, r7, r8] =
-        at::_scaled_dot_product_flash_attention(
-            *query_tensor,
-            *key_tensor,
-            *value_tensor,
-            dropout_p,
-            is_causal,
-            return_debug_mask,
-            optional_scale);
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch__scaled_dot_product_flash_attention_v2", {
+        at::Tensor* query_tensor = tensor_handle_to_tensor_pointer(query);
+        at::Tensor* key_tensor = tensor_handle_to_tensor_pointer(key);
+        at::Tensor* value_tensor = tensor_handle_to_tensor_pointer(value);
+        auto optional_scale = pointer_to_optional(scale);
+        auto [r0, r1, r2, r3, r4, r5, r6, r7, r8] =
+            at::_scaled_dot_product_flash_attention(
+                *query_tensor,
+                *key_tensor,
+                *value_tensor,
+                dropout_p,
+                is_causal,
+                return_debug_mask,
+                optional_scale);
 
-    *ret0 = new_tensor_handle(std::move(r0));
-    *ret1 = new_tensor_handle(std::move(r1));
-    // ret2 and ret3 may be null
-    if (ret2) {
-      *ret2 = new_tensor_handle(std::move(r2));
-    }
-    if (ret3) {
-      *ret3 = new_tensor_handle(std::move(r3));
-    }
-    *ret4 = r4.expect_int();
-    *ret5 = r5.expect_int();
-    *ret6 = new_tensor_handle(std::move(r6));
-    *ret7 = new_tensor_handle(std::move(r7));
-    *ret8 = new_tensor_handle(std::move(r8));
-  });
+        *ret0 = new_tensor_handle(std::move(r0));
+        *ret1 = new_tensor_handle(std::move(r1));
+        // ret2 and ret3 may be null
+        if (ret2) {
+          *ret2 = new_tensor_handle(std::move(r2));
+        }
+        if (ret3) {
+          *ret3 = new_tensor_handle(std::move(r3));
+        }
+        *ret4 = r4.expect_int();
+        *ret5 = r5.expect_int();
+        *ret6 = new_tensor_handle(std::move(r6));
+        *ret7 = new_tensor_handle(std::move(r7));
+        *ret8 = new_tensor_handle(std::move(r8));
+      });
 }
 
 AOTITorchError aoti_torch__scaled_dot_product_flash_attention(
@@ -635,27 +639,28 @@ AOTITorchError aoti_torch__scaled_dot_product_efficient_attention(
     AtenTensorHandle* ret2, // returns new reference
     AtenTensorHandle* ret3 // returns new reference
 ) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    at::Tensor* query_tensor = tensor_handle_to_tensor_pointer(query);
-    at::Tensor* key_tensor = tensor_handle_to_tensor_pointer(key);
-    at::Tensor* value_tensor = tensor_handle_to_tensor_pointer(value);
-    auto optional_attn_bias =
-        pointer_to_optional(tensor_handle_to_tensor_pointer(attn_bias));
-    auto optional_scale = pointer_to_optional(scale);
-    auto [r0, r1, r2, r3] = at::_scaled_dot_product_efficient_attention(
-        *query_tensor,
-        *key_tensor,
-        *value_tensor,
-        optional_attn_bias,
-        compute_log_sumexp,
-        dropout_p,
-        is_causal,
-        optional_scale);
-    *ret0 = new_tensor_handle(std::move(r0));
-    *ret1 = new_tensor_handle(std::move(r1));
-    *ret2 = new_tensor_handle(std::move(r2));
-    *ret3 = new_tensor_handle(std::move(r3));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch__scaled_dot_product_efficient_attention", {
+        at::Tensor* query_tensor = tensor_handle_to_tensor_pointer(query);
+        at::Tensor* key_tensor = tensor_handle_to_tensor_pointer(key);
+        at::Tensor* value_tensor = tensor_handle_to_tensor_pointer(value);
+        auto optional_attn_bias =
+            pointer_to_optional(tensor_handle_to_tensor_pointer(attn_bias));
+        auto optional_scale = pointer_to_optional(scale);
+        auto [r0, r1, r2, r3] = at::_scaled_dot_product_efficient_attention(
+            *query_tensor,
+            *key_tensor,
+            *value_tensor,
+            optional_attn_bias,
+            compute_log_sumexp,
+            dropout_p,
+            is_causal,
+            optional_scale);
+        *ret0 = new_tensor_handle(std::move(r0));
+        *ret1 = new_tensor_handle(std::move(r1));
+        *ret2 = new_tensor_handle(std::move(r2));
+        *ret3 = new_tensor_handle(std::move(r3));
+      });
 }
 
 AOTITorchError aoti_torch_convolution(
@@ -674,7 +679,7 @@ AOTITorchError aoti_torch_convolution(
     int64_t groups,
     AtenTensorHandle* out // returns new reference
 ) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_convolution", {
     at::Tensor* input_tensor = tensor_handle_to_tensor_pointer(input);
     at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
     at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
@@ -698,10 +703,11 @@ AOTITorchError aoti_torch_convolution(
 }
 
 AOTITorchError aoti_torch_new_uninitialized_tensor(AtenTensorHandle* ret) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    at::Tensor* out_tensor = new at::Tensor();
-    *ret = tensor_pointer_to_tensor_handle(out_tensor);
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_new_uninitialized_tensor", {
+        at::Tensor* out_tensor = new at::Tensor();
+        *ret = tensor_pointer_to_tensor_handle(out_tensor);
+      });
 }
 
 AOTITorchError aoti_torch__scaled_mm(
@@ -715,7 +721,7 @@ AOTITorchError aoti_torch__scaled_mm(
     int8_t use_fast_accum,
     AtenTensorHandle* ret0,
     AtenTensorHandle* ret1) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch__scaled_mm", {
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     at::Tensor* mat2_tensor = tensor_handle_to_tensor_pointer(mat2);
     at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
@@ -746,7 +752,7 @@ AOTITorchError aoti_torch__scaled_mm_v2(
     int32_t* out_dtype,
     int8_t use_fast_accum,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch__scaled_mm_v2", {
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     at::Tensor* mat2_tensor = tensor_handle_to_tensor_pointer(mat2);
     at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
@@ -777,7 +783,7 @@ AOTITorchError aoti_torch_tensor_copy_(
 AOTITorchError aoti_torch_assign_tensors(
     AtenTensorHandle src,
     AtenTensorHandle dst) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_assign_tensors", {
     at::Tensor* src_tensor = tensor_handle_to_tensor_pointer(src);
     at::Tensor* dst_tensor = tensor_handle_to_tensor_pointer(dst);
     *dst_tensor = *src_tensor;
@@ -787,7 +793,7 @@ AOTITorchError aoti_torch_assign_tensors(
 AOTITorchError aoti_torch_assign_tensors_out(
     AtenTensorHandle src,
     AtenTensorHandle* ret_dst) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_assign_tensors_out", {
     at::Tensor* src_tensor_ptr = tensor_handle_to_tensor_pointer(src);
     at::Tensor dst_tensor = *src_tensor_ptr;
     *ret_dst = new_tensor_handle(std::move(dst_tensor));
@@ -795,7 +801,7 @@ AOTITorchError aoti_torch_assign_tensors_out(
 }
 
 AOTITorchError aoti_torch_clone(AtenTensorHandle self, AtenTensorHandle* ret) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_clone", {
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     *ret = new_tensor_handle(self_tensor->clone());
   });
@@ -806,7 +812,7 @@ AOTITorchError aoti_torch_as_strided(
     const int64_t* sizes_ptr,
     const int64_t* strides_ptr,
     AtenTensorHandle* ret) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_as_strided", {
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     int64_t ndim = self_tensor->dim();
     c10::IntArrayRef sizes(sizes_ptr, ndim);
@@ -819,23 +825,25 @@ AOTITorchError aoti_torch_as_strided(
 AOTITorchError aoti_torch_clone_preserve_strides(
     AtenTensorHandle self,
     AtenTensorHandle* ret) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    // To mimic clone_preserve_strides which is used in copy_misaligned_inputs
-    at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
-    int64_t needed_size = 1;
-    for (int i = 0; i < self_tensor->dim(); i++) {
-      if (self_tensor->size(i) == 0) {
-        needed_size = 0;
-        break;
-      }
-      needed_size += (self_tensor->size(i) - 1) * self_tensor->stride(i);
-    }
-    at::Tensor ret_tensor =
-        self_tensor->as_strided({needed_size}, {1})
-            .clone()
-            .as_strided(self_tensor->sizes(), self_tensor->strides());
-    *ret = new_tensor_handle(std::move(ret_tensor));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_clone_preserve_strides", {
+        // To mimic clone_preserve_strides which is used in
+        // copy_misaligned_inputs
+        at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
+        int64_t needed_size = 1;
+        for (int i = 0; i < self_tensor->dim(); i++) {
+          if (self_tensor->size(i) == 0) {
+            needed_size = 0;
+            break;
+          }
+          needed_size += (self_tensor->size(i) - 1) * self_tensor->stride(i);
+        }
+        at::Tensor ret_tensor =
+            self_tensor->as_strided({needed_size}, {1})
+                .clone()
+                .as_strided(self_tensor->sizes(), self_tensor->strides());
+        *ret = new_tensor_handle(std::move(ret_tensor));
+      });
 }
 
 // TODO: implement a more efficient version instead of calling into aten
@@ -846,7 +854,7 @@ AOTITorchError aoti_torch_addmm_out(
     AtenTensorHandle mat2,
     float beta,
     float alpha) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_addmm_out", {
     at::Tensor* out_tensor = tensor_handle_to_tensor_pointer(out);
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     at::Tensor* mat1_tensor = tensor_handle_to_tensor_pointer(mat1);
@@ -861,7 +869,7 @@ AOTITorchError aoti_torch_bmm_out(
     AtenTensorHandle out,
     AtenTensorHandle self,
     AtenTensorHandle mat2) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_bmm_out", {
     at::Tensor* out_tensor = tensor_handle_to_tensor_pointer(out);
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     at::Tensor* mat2_tensor = tensor_handle_to_tensor_pointer(mat2);
@@ -873,7 +881,7 @@ AOTITorchError aoti_torch_copy_(
     AtenTensorHandle self,
     AtenTensorHandle src,
     int32_t non_blocking) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_copy_", {
     tensor_handle_to_tensor_pointer(self)->copy_(
         *tensor_handle_to_tensor_pointer(src), non_blocking);
   });
@@ -884,7 +892,7 @@ AOTITorchError aoti_torch_mm_out(
     AtenTensorHandle out,
     AtenTensorHandle self,
     AtenTensorHandle mat2) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_mm_out", {
     at::Tensor* out_tensor = tensor_handle_to_tensor_pointer(out);
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     at::Tensor* mat2_tensor = tensor_handle_to_tensor_pointer(mat2);
@@ -898,7 +906,7 @@ AOTITorchError aoti_torch__mm_plus_mm_out(
     AtenTensorHandle b,
     AtenTensorHandle c,
     AtenTensorHandle d) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch__mm_plus_mm_out", {
     at::Tensor* out_tensor = tensor_handle_to_tensor_pointer(out);
     at::Tensor* a_tensor = tensor_handle_to_tensor_pointer(a);
     at::Tensor* b_tensor = tensor_handle_to_tensor_pointer(b);
@@ -912,11 +920,13 @@ AOTITorchError aoti_torch__mm_plus_mm_out(
 AOTITorchError aoti_torch_cpu_wrapped_fbgemm_pack_gemm_matrix_fp16(
     AtenTensorHandle weight,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_cpu_wrapped_fbgemm_pack_gemm_matrix_fp16", {
+        at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
 
-    *out = new_tensor_handle(at::fbgemm_pack_gemm_matrix_fp16(*weight_tensor));
-  });
+        *out =
+            new_tensor_handle(at::fbgemm_pack_gemm_matrix_fp16(*weight_tensor));
+      });
 }
 
 AOTITorchError aoti_torch_cpu__wrapped_linear_prepack(
@@ -925,20 +935,21 @@ AOTITorchError aoti_torch_cpu__wrapped_linear_prepack(
     AtenTensorHandle weight_zero_point,
     AtenTensorHandle bias,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
-    at::Tensor* weight_scale_tensor =
-        tensor_handle_to_tensor_pointer(weight_scale);
-    at::Tensor* weight_zero_point_tensor =
-        tensor_handle_to_tensor_pointer(weight_zero_point);
-    at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_cpu__wrapped_linear_prepack", {
+        at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
+        at::Tensor* weight_scale_tensor =
+            tensor_handle_to_tensor_pointer(weight_scale);
+        at::Tensor* weight_zero_point_tensor =
+            tensor_handle_to_tensor_pointer(weight_zero_point);
+        at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
 
-    *out = new_tensor_handle(at::_wrapped_linear_prepack(
-        *weight_tensor,
-        *weight_scale_tensor,
-        *weight_zero_point_tensor,
-        *bias_tensor));
-  });
+        *out = new_tensor_handle(at::_wrapped_linear_prepack(
+            *weight_tensor,
+            *weight_scale_tensor,
+            *weight_zero_point_tensor,
+            *bias_tensor));
+      });
 }
 
 AOTITorchError aoti_torch_cpu_wrapped_fbgemm_linear_fp16_weight(
@@ -947,14 +958,15 @@ AOTITorchError aoti_torch_cpu_wrapped_fbgemm_linear_fp16_weight(
     AtenTensorHandle bias,
     int64_t out_channel,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    at::Tensor* input_tensor = tensor_handle_to_tensor_pointer(input);
-    at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
-    at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_cpu_wrapped_fbgemm_linear_fp16_weight", {
+        at::Tensor* input_tensor = tensor_handle_to_tensor_pointer(input);
+        at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
+        at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
 
-    *out = new_tensor_handle(at::fbgemm_linear_fp16_weight_fp32_activation(
-        *input_tensor, *weight_tensor, *bias_tensor));
-  });
+        *out = new_tensor_handle(at::fbgemm_linear_fp16_weight_fp32_activation(
+            *input_tensor, *weight_tensor, *bias_tensor));
+      });
 }
 
 AOTITorchError aoti_torch_cpu__wrapped_quantized_linear_prepacked(
@@ -966,31 +978,33 @@ AOTITorchError aoti_torch_cpu__wrapped_quantized_linear_prepacked(
     AtenTensorHandle out_zeropoint,
     int64_t out_channel,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    at::Tensor* input_tensor = tensor_handle_to_tensor_pointer(input);
-    at::Tensor* input_scale_tensor =
-        tensor_handle_to_tensor_pointer(input_scale);
-    at::Tensor* input_zero_point_tensor =
-        tensor_handle_to_tensor_pointer(input_zero_point);
-    at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
-    at::Tensor* out_scale_tensor = tensor_handle_to_tensor_pointer(out_scale);
-    at::Tensor* out_zeropoint_tensor =
-        tensor_handle_to_tensor_pointer(out_zeropoint);
-    *out = new_tensor_handle(at::_wrapped_quantized_linear_prepacked(
-        *input_tensor,
-        *input_scale_tensor,
-        *input_zero_point_tensor,
-        *weight_tensor,
-        *out_scale_tensor,
-        *out_zeropoint_tensor,
-        out_channel));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_cpu__wrapped_quantized_linear_prepacked", {
+        at::Tensor* input_tensor = tensor_handle_to_tensor_pointer(input);
+        at::Tensor* input_scale_tensor =
+            tensor_handle_to_tensor_pointer(input_scale);
+        at::Tensor* input_zero_point_tensor =
+            tensor_handle_to_tensor_pointer(input_zero_point);
+        at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
+        at::Tensor* out_scale_tensor =
+            tensor_handle_to_tensor_pointer(out_scale);
+        at::Tensor* out_zeropoint_tensor =
+            tensor_handle_to_tensor_pointer(out_zeropoint);
+        *out = new_tensor_handle(at::_wrapped_quantized_linear_prepacked(
+            *input_tensor,
+            *input_scale_tensor,
+            *input_zero_point_tensor,
+            *weight_tensor,
+            *out_scale_tensor,
+            *out_zeropoint_tensor,
+            out_channel));
+      });
 }
 
 AOTITorchError aoti_torch_nonzero(
     AtenTensorHandle self,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_nonzero", {
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     *out = new_tensor_handle(at::nonzero(*self_tensor));
   });
@@ -1000,18 +1014,19 @@ AOTITorchError aoti_torch_repeat_interleave_Tensor(
     AtenTensorHandle repeats,
     int64_t* output_size,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    at::Tensor* repeats_tensor = tensor_handle_to_tensor_pointer(repeats);
-    *out = new_tensor_handle(at::_ops::repeat_interleave_Tensor::call(
-        *repeats_tensor, pointer_to_optional<c10::SymInt>(output_size)));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_repeat_interleave_Tensor", {
+        at::Tensor* repeats_tensor = tensor_handle_to_tensor_pointer(repeats);
+        *out = new_tensor_handle(at::_ops::repeat_interleave_Tensor::call(
+            *repeats_tensor, pointer_to_optional<c10::SymInt>(output_size)));
+      });
 }
 
 // Function to check existence of inf and NaN
 AOTITorchError aoti_torch_check_inf_and_nan(
     const char* tensor_name,
     AtenTensorHandle tensor) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_check_inf_and_nan", {
     at::Tensor* check_tensor = tensor_handle_to_tensor_pointer(tensor);
 
     assert_inf_and_nan(tensor_name, *check_tensor);
@@ -1024,7 +1039,7 @@ AOTITorchError aoti_torch_scatter_out(
     int64_t dim,
     AtenTensorHandle index,
     AtenTensorHandle src) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_scatter_out", {
     at::Tensor* out_tensor = tensor_handle_to_tensor_pointer(out);
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     at::Tensor* index_tensor = tensor_handle_to_tensor_pointer(index);
@@ -1041,7 +1056,7 @@ AOTITorchError aoti_torch_scatter_reduce_out(
     AtenTensorHandle src,
     const char* reduce,
     int32_t include_self) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_scatter_reduce_out", {
     at::Tensor* out_tensor = tensor_handle_to_tensor_pointer(out);
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     at::Tensor* index_tensor = tensor_handle_to_tensor_pointer(index);
@@ -1065,7 +1080,7 @@ AOTITorchError aoti_torch_index_put_out(
     // NOLINTNEXTLINE(misc-misplaced-const)
     const AtenTensorHandle values,
     bool accumulate) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_index_put_out", {
     c10::List<std::optional<at::Tensor>> indices_;
     indices_.reserve(num_indices);
     for (size_t i = 0; i < num_indices; i++) {
@@ -1084,7 +1099,7 @@ AOTITorchError aoti_torch_view_as_real(
     AtenTensorHandle self,
     AtenTensorHandle* ret // returns new reference
 ) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_view_as_real", {
     *ret = new_tensor_handle(
         at::_ops::view_as_real::call(*tensor_handle_to_tensor_pointer(self)));
   });
@@ -1095,7 +1110,7 @@ AOTITorchError aoti_torch_view_dtype(
     int32_t dtype,
     AtenTensorHandle* ret // returns new reference
 ) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_view_dtype", {
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     *ret = new_tensor_handle(at::_ops::view_dtype::call(
         *self_tensor, static_cast<c10::ScalarType>(dtype)));
@@ -1159,11 +1174,11 @@ void aoti_torch_print_tensor_handle(AtenTensorHandle self, const char* msg) {
   // Print dtypes and for float types, print exact precision
   auto scalarType = t->scalar_type();
   if (scalarType == at::ScalarType::Float) {
-    std::cout << "Dtype: float32" << std::endl;
+    std::cout << "Dtype: float32" << '\n';
   } else if (scalarType == at::ScalarType::Half) {
-    std::cout << "Dtype: float16" << std::endl;
+    std::cout << "Dtype: float16" << '\n';
   } else if (scalarType == at::ScalarType::BFloat16) {
-    std::cout << "Dtype: bfloat16" << std::endl;
+    std::cout << "Dtype: bfloat16" << '\n';
   } else {
     std::cout << "Dtype: " << t->dtype() << '\n';
   }
@@ -1207,22 +1222,25 @@ AOTITorchError aoti_torch_proxy_executor_call_function(
     int64_t* flatten_int_args,
     int num_tensors,
     AtenTensorHandle* flatten_tensor_args) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    if (!proxy_executor) {
-      throw std::runtime_error(
-          "Unable to find a proxy executor to run custom ops. Please check if "
-          "there is a json file generated in the same directory as the so, or use "
-          "torch._inductor.aoti_compile_and_package to package everything into a "
-          "PT2 artifact.");
-    }
-    ProxyExecutor* executor = reinterpret_cast<ProxyExecutor*>(proxy_executor);
-    executor->call_function(
-        extern_node_index,
-        num_ints,
-        flatten_int_args,
-        num_tensors,
-        flatten_tensor_args);
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_proxy_executor_call_function", {
+        if (!proxy_executor) {
+          throw std::runtime_error(
+              "Unable to find a proxy executor to run custom ops. Please check if "
+              "there is a json file generated in the same directory as the so, or use "
+              "torch._inductor.aoti_compile_and_package to package everything into a "
+              "PT2 artifact.");
+        }
+        ProxyExecutor* executor =
+            reinterpret_cast<ProxyExecutor*>(proxy_executor);
+
+        executor->call_function(
+            extern_node_index,
+            num_ints,
+            flatten_int_args,
+            num_tensors,
+            flatten_tensor_args);
+      });
 }
 
 void aoti_torch_check(
@@ -1256,7 +1274,7 @@ AOTITorchError aoti_torch__alloc_from_pool(
     const int64_t* sizes_ptr,
     const int64_t* strides_ptr,
     AtenTensorHandle* ret_new_tensor) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch__alloc_from_pool", {
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     c10::IntArrayRef sizes(sizes_ptr, ndim);
     c10::IntArrayRef strides(strides_ptr, ndim);
@@ -1270,7 +1288,7 @@ AOTITorchError aoti_torch__alloc_from_pool(
 }
 
 AOTITorchError aoti_torch_zero_(AtenTensorHandle tensor) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_zero_", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     t->zero_();
   });
@@ -1282,12 +1300,13 @@ AOTITorchError aoti_torch_cpu__weight_int4pack_mm_cpu_tensor(
     AtenTensorHandle qGroupSize,
     AtenTensorHandle qScaleAndZeros,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    auto tmp_result = at::native::_weight_int4pack_mm_cpu_tensor(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(w),
-        *tensor_handle_to_tensor_pointer(qGroupSize),
-        *tensor_handle_to_tensor_pointer(qScaleAndZeros));
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch__weight_int4pack_mm_cpu_tensor", {
+        auto tmp_result = at::native::_weight_int4pack_mm_cpu_tensor(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(w),
+            *tensor_handle_to_tensor_pointer(qGroupSize),
+            *tensor_handle_to_tensor_pointer(qScaleAndZeros));
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }

--- a/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
@@ -1,4 +1,5 @@
 
+#include <ATen/record_function.h>
 #include <torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h>
 #include <torch/csrc/inductor/aoti_torch/utils.h>
 
@@ -45,28 +46,30 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise_binary(
     int64_t unary_scalars_len_,
     const char** unary_algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    c10::List<std::optional<c10::Scalar>> unary_scalars_list;
-    unary_scalars_list.reserve(unary_scalars_len_);
-    for (int64_t i = 0; i < unary_scalars_len_; i++) {
-      unary_scalars_list.emplace_back(pointer_to_optional(unary_scalars[i]));
-    }
-    auto tmp_result = at::native::mkldnn_convolution_pointwise_binary(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(other),
-        *tensor_handle_to_tensor_pointer(W),
-        pointer_to_optional<at::Tensor>(B),
-        pointer_to_list<int64_t>(padding, padding_len_),
-        pointer_to_list<int64_t>(stride, stride_len_),
-        pointer_to_list<int64_t>(dilation, dilation_len_),
-        groups,
-        binary_attr,
-        pointer_to_optional<c10::Scalar>(alpha),
-        pointer_to_optional<std::string_view>(unary_attr),
-        unary_scalars_list,
-        pointer_to_optional<std::string_view>(unary_algorithm));
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::mkldnn_convolution_pointwise_binary", {
+        c10::List<std::optional<c10::Scalar>> unary_scalars_list;
+        unary_scalars_list.reserve(unary_scalars_len_);
+        for (int64_t i = 0; i < unary_scalars_len_; i++) {
+          unary_scalars_list.emplace_back(
+              pointer_to_optional(unary_scalars[i]));
+        }
+        auto tmp_result = at::native::mkldnn_convolution_pointwise_binary(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(other),
+            *tensor_handle_to_tensor_pointer(W),
+            pointer_to_optional<at::Tensor>(B),
+            pointer_to_list<int64_t>(padding, padding_len_),
+            pointer_to_list<int64_t>(stride, stride_len_),
+            pointer_to_list<int64_t>(dilation, dilation_len_),
+            groups,
+            binary_attr,
+            pointer_to_optional<c10::Scalar>(alpha),
+            pointer_to_optional<std::string_view>(unary_attr),
+            unary_scalars_list,
+            pointer_to_optional<std::string_view>(unary_algorithm));
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise_binary_(
@@ -88,28 +91,30 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise_binary_(
     int64_t unary_scalars_len_,
     const char** unary_algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    c10::List<std::optional<c10::Scalar>> unary_scalars_list;
-    unary_scalars_list.reserve(unary_scalars_len_);
-    for (int64_t i = 0; i < unary_scalars_len_; i++) {
-      unary_scalars_list.emplace_back(pointer_to_optional(unary_scalars[i]));
-    }
-    auto tmp_result = at::native::mkldnn_convolution_pointwise_binary_(
-        *tensor_handle_to_tensor_pointer(other),
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(W),
-        pointer_to_optional<at::Tensor>(B),
-        pointer_to_list<int64_t>(padding, padding_len_),
-        pointer_to_list<int64_t>(stride, stride_len_),
-        pointer_to_list<int64_t>(dilation, dilation_len_),
-        groups,
-        binary_attr,
-        pointer_to_optional<c10::Scalar>(alpha),
-        pointer_to_optional<std::string_view>(unary_attr),
-        unary_scalars_list,
-        pointer_to_optional<std::string_view>(unary_algorithm));
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::mkldnn_convolution_pointwise_binary_", {
+        c10::List<std::optional<c10::Scalar>> unary_scalars_list;
+        unary_scalars_list.reserve(unary_scalars_len_);
+        for (int64_t i = 0; i < unary_scalars_len_; i++) {
+          unary_scalars_list.emplace_back(
+              pointer_to_optional(unary_scalars[i]));
+        }
+        auto tmp_result = at::native::mkldnn_convolution_pointwise_binary_(
+            *tensor_handle_to_tensor_pointer(other),
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(W),
+            pointer_to_optional<at::Tensor>(B),
+            pointer_to_list<int64_t>(padding, padding_len_),
+            pointer_to_list<int64_t>(stride, stride_len_),
+            pointer_to_list<int64_t>(dilation, dilation_len_),
+            groups,
+            binary_attr,
+            pointer_to_optional<c10::Scalar>(alpha),
+            pointer_to_optional<std::string_view>(unary_attr),
+            unary_scalars_list,
+            pointer_to_optional<std::string_view>(unary_algorithm));
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise(
@@ -128,25 +133,26 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise(
     int64_t scalars_len_,
     const char** algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    c10::List<std::optional<c10::Scalar>> scalars_list;
-    scalars_list.reserve(scalars_len_);
-    for (int64_t i = 0; i < scalars_len_; i++) {
-      scalars_list.emplace_back(pointer_to_optional(scalars[i]));
-    }
-    auto tmp_result = at::native::mkldnn_convolution_pointwise(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(W),
-        pointer_to_optional<at::Tensor>(B),
-        pointer_to_list<int64_t>(padding, padding_len_),
-        pointer_to_list<int64_t>(stride, stride_len_),
-        pointer_to_list<int64_t>(dilation, dilation_len_),
-        groups,
-        attr,
-        scalars_list,
-        pointer_to_optional<std::string_view>(algorithm));
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::mkldnn_convolution_pointwise", {
+        c10::List<std::optional<c10::Scalar>> scalars_list;
+        scalars_list.reserve(scalars_len_);
+        for (int64_t i = 0; i < scalars_len_; i++) {
+          scalars_list.emplace_back(pointer_to_optional(scalars[i]));
+        }
+        auto tmp_result = at::native::mkldnn_convolution_pointwise(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(W),
+            pointer_to_optional<at::Tensor>(B),
+            pointer_to_list<int64_t>(padding, padding_len_),
+            pointer_to_list<int64_t>(stride, stride_len_),
+            pointer_to_list<int64_t>(dilation, dilation_len_),
+            groups,
+            attr,
+            scalars_list,
+            pointer_to_optional<std::string_view>(algorithm));
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu_mkldnn__convolution_transpose_pointwise(
@@ -167,26 +173,27 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_transpose_pointwise(
     int64_t scalars_len_,
     const char** algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    c10::List<std::optional<c10::Scalar>> scalars_list;
-    scalars_list.reserve(scalars_len_);
-    for (int64_t i = 0; i < scalars_len_; i++) {
-      scalars_list.emplace_back(pointer_to_optional(scalars[i]));
-    }
-    auto tmp_result = at::native::mkldnn_convolution_transpose_pointwise(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(W),
-        pointer_to_optional<at::Tensor>(B),
-        pointer_to_list<int64_t>(padding, padding_len_),
-        pointer_to_list<int64_t>(output_padding, output_padding_len_),
-        pointer_to_list<int64_t>(stride, stride_len_),
-        pointer_to_list<int64_t>(dilation, dilation_len_),
-        groups,
-        attr,
-        scalars_list,
-        pointer_to_optional<std::string_view>(algorithm));
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::mkldnn_convolution_transpose_pointwise", {
+        c10::List<std::optional<c10::Scalar>> scalars_list;
+        scalars_list.reserve(scalars_len_);
+        for (int64_t i = 0; i < scalars_len_; i++) {
+          scalars_list.emplace_back(pointer_to_optional(scalars[i]));
+        }
+        auto tmp_result = at::native::mkldnn_convolution_transpose_pointwise(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(W),
+            pointer_to_optional<at::Tensor>(B),
+            pointer_to_list<int64_t>(padding, padding_len_),
+            pointer_to_list<int64_t>(output_padding, output_padding_len_),
+            pointer_to_list<int64_t>(stride, stride_len_),
+            pointer_to_list<int64_t>(dilation, dilation_len_),
+            groups,
+            attr,
+            scalars_list,
+            pointer_to_optional<std::string_view>(algorithm));
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu_mkldnn_rnn_layer(
@@ -211,7 +218,7 @@ AOTITorchError aoti_torch_cpu_mkldnn_rnn_layer(
     AtenTensorHandle* ret1,
     AtenTensorHandle* ret2,
     AtenTensorHandle* ret3) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::cpu::mkldnn_rnn_layer", {
     auto tmp_result = at::cpu::mkldnn_rnn_layer(
         *tensor_handle_to_tensor_pointer(input),
         *tensor_handle_to_tensor_pointer(weight0),
@@ -245,21 +252,22 @@ AOTITorchError aoti_torch_cpu__linear_pointwise(
     int64_t scalars_len_,
     const char** algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    c10::List<std::optional<c10::Scalar>> scalars_list;
-    scalars_list.reserve(scalars_len_);
-    for (int64_t i = 0; i < scalars_len_; i++) {
-      scalars_list.emplace_back(pointer_to_optional(scalars[i]));
-    }
-    auto tmp_result = at::native::mkldnn_linear_pointwise(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(W),
-        pointer_to_optional<at::Tensor>(B),
-        attr,
-        scalars_list,
-        pointer_to_optional<std::string_view>(algorithm));
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::mkldnn_linear_pointwise", {
+        c10::List<std::optional<c10::Scalar>> scalars_list;
+        scalars_list.reserve(scalars_len_);
+        for (int64_t i = 0; i < scalars_len_; i++) {
+          scalars_list.emplace_back(pointer_to_optional(scalars[i]));
+        }
+        auto tmp_result = at::native::mkldnn_linear_pointwise(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(W),
+            pointer_to_optional<at::Tensor>(B),
+            attr,
+            scalars_list,
+            pointer_to_optional<std::string_view>(algorithm));
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu__linear_pointwise_binary(
@@ -269,15 +277,16 @@ AOTITorchError aoti_torch_cpu__linear_pointwise_binary(
     AtenTensorHandle* B,
     const char* attr,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    auto tmp_result = at::native::mkldnn_linear_pointwise_binary(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(other),
-        *tensor_handle_to_tensor_pointer(W),
-        pointer_to_optional<at::Tensor>(B),
-        attr);
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::mkldnn_linear_pointwise_binary", {
+        auto tmp_result = at::native::mkldnn_linear_pointwise_binary(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(other),
+            *tensor_handle_to_tensor_pointer(W),
+            pointer_to_optional<at::Tensor>(B),
+            attr);
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu__qlinear_pointwise_tensor(
@@ -296,29 +305,30 @@ AOTITorchError aoti_torch_cpu__qlinear_pointwise_tensor(
     int64_t post_op_args_len_,
     const char* post_op_algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    c10::List<std::optional<c10::Scalar>> scalars_list;
-    scalars_list.reserve(post_op_args_len_);
-    for (int64_t i = 0; i < post_op_args_len_; i++) {
-      scalars_list.emplace_back(pointer_to_optional(post_op_args[i]));
-    }
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::QLinearOnednn::run_pointwise_tensor", {
+        c10::List<std::optional<c10::Scalar>> scalars_list;
+        scalars_list.reserve(post_op_args_len_);
+        for (int64_t i = 0; i < post_op_args_len_; i++) {
+          scalars_list.emplace_back(pointer_to_optional(post_op_args[i]));
+        }
 
-    auto tmp_result = at::native::QLinearOnednn::run_pointwise_tensor(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(act_scale),
-        *tensor_handle_to_tensor_pointer(act_zero_point),
-        *tensor_handle_to_tensor_pointer(onednn_weight),
-        *tensor_handle_to_tensor_pointer(weight_scales),
-        *tensor_handle_to_tensor_pointer(weight_zero_points),
-        pointer_to_optional<at::Tensor>(B),
-        output_scale,
-        output_zero_point,
-        pointer_to_optional<at::ScalarType>(output_dtype),
-        post_op_name,
-        scalars_list,
-        post_op_algorithm);
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+        auto tmp_result = at::native::QLinearOnednn::run_pointwise_tensor(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(act_scale),
+            *tensor_handle_to_tensor_pointer(act_zero_point),
+            *tensor_handle_to_tensor_pointer(onednn_weight),
+            *tensor_handle_to_tensor_pointer(weight_scales),
+            *tensor_handle_to_tensor_pointer(weight_zero_points),
+            pointer_to_optional<at::Tensor>(B),
+            output_scale,
+            output_zero_point,
+            pointer_to_optional<at::ScalarType>(output_dtype),
+            post_op_name,
+            scalars_list,
+            post_op_algorithm);
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu__qlinear_pointwise_binary_tensor(
@@ -342,34 +352,36 @@ AOTITorchError aoti_torch_cpu__qlinear_pointwise_binary_tensor(
     int64_t unary_post_op_args_len_,
     const char* unary_post_op_algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    c10::List<std::optional<c10::Scalar>> scalars_list;
-    scalars_list.reserve(unary_post_op_args_len_);
-    for (int64_t i = 0; i < unary_post_op_args_len_; i++) {
-      scalars_list.emplace_back(pointer_to_optional(unary_post_op_args[i]));
-    }
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::QLinearOnednn::run_pointwise_binary_tensor", {
+        c10::List<std::optional<c10::Scalar>> scalars_list;
+        scalars_list.reserve(unary_post_op_args_len_);
+        for (int64_t i = 0; i < unary_post_op_args_len_; i++) {
+          scalars_list.emplace_back(pointer_to_optional(unary_post_op_args[i]));
+        }
 
-    auto tmp_result = at::native::QLinearOnednn::run_pointwise_binary_tensor(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(act_scale),
-        *tensor_handle_to_tensor_pointer(act_zero_point),
-        *tensor_handle_to_tensor_pointer(onednn_weight),
-        *tensor_handle_to_tensor_pointer(weight_scales),
-        *tensor_handle_to_tensor_pointer(weight_zero_points),
-        pointer_to_optional<at::Tensor>(other),
-        pointer_to_optional<at::Tensor>(B),
-        output_scale,
-        output_zero_point,
-        pointer_to_optional<at::ScalarType>(output_dtype),
-        other_scale,
-        other_zero_point,
-        binary_post_op,
-        binary_alpha,
-        unary_post_op,
-        scalars_list,
-        unary_post_op_algorithm);
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+        auto tmp_result =
+            at::native::QLinearOnednn::run_pointwise_binary_tensor(
+                *tensor_handle_to_tensor_pointer(X),
+                *tensor_handle_to_tensor_pointer(act_scale),
+                *tensor_handle_to_tensor_pointer(act_zero_point),
+                *tensor_handle_to_tensor_pointer(onednn_weight),
+                *tensor_handle_to_tensor_pointer(weight_scales),
+                *tensor_handle_to_tensor_pointer(weight_zero_points),
+                pointer_to_optional<at::Tensor>(other),
+                pointer_to_optional<at::Tensor>(B),
+                output_scale,
+                output_zero_point,
+                pointer_to_optional<at::ScalarType>(output_dtype),
+                other_scale,
+                other_zero_point,
+                binary_post_op,
+                binary_alpha,
+                unary_post_op,
+                scalars_list,
+                unary_post_op_algorithm);
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu__qconv2d_pointwise_tensor(
@@ -395,40 +407,41 @@ AOTITorchError aoti_torch_cpu__qconv2d_pointwise_tensor(
     int64_t post_op_args_len_,
     const char** algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    c10::List<std::optional<c10::Scalar>> scalars_list;
-    scalars_list.reserve(post_op_args_len_);
-    for (int64_t i = 0; i < post_op_args_len_; i++) {
-      scalars_list.emplace_back(pointer_to_optional(post_op_args[i]));
-    }
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::QConvoneDNN::run_pointwise_tensor", {
+        c10::List<std::optional<c10::Scalar>> scalars_list;
+        scalars_list.reserve(post_op_args_len_);
+        for (int64_t i = 0; i < post_op_args_len_; i++) {
+          scalars_list.emplace_back(pointer_to_optional(post_op_args[i]));
+        }
 
-    c10::List<int64_t> stride_list =
-        convert_to_c10_List<int64_t>(stride_args, stride_len_);
-    c10::List<int64_t> padding_list =
-        convert_to_c10_List<int64_t>(padding_args, padding_len_);
-    c10::List<int64_t> dilation_list =
-        convert_to_c10_List<int64_t>(dilation_args, dilation_len_);
+        c10::List<int64_t> stride_list =
+            convert_to_c10_List<int64_t>(stride_args, stride_len_);
+        c10::List<int64_t> padding_list =
+            convert_to_c10_List<int64_t>(padding_args, padding_len_);
+        c10::List<int64_t> dilation_list =
+            convert_to_c10_List<int64_t>(dilation_args, dilation_len_);
 
-    auto tmp_result = at::native::QConvoneDNN::run_pointwise_tensor(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(act_scale),
-        *tensor_handle_to_tensor_pointer(act_zero_point),
-        *tensor_handle_to_tensor_pointer(onednn_weight),
-        *tensor_handle_to_tensor_pointer(weight_scales),
-        *tensor_handle_to_tensor_pointer(weight_zero_points),
-        pointer_to_optional<at::Tensor>(B),
-        stride_list,
-        padding_list,
-        dilation_list,
-        groups,
-        output_scale,
-        output_zero_point,
-        pointer_to_optional<at::ScalarType>(output_dtype),
-        attr,
-        scalars_list,
-        pointer_to_optional<std::string_view>(algorithm));
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+        auto tmp_result = at::native::QConvoneDNN::run_pointwise_tensor(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(act_scale),
+            *tensor_handle_to_tensor_pointer(act_zero_point),
+            *tensor_handle_to_tensor_pointer(onednn_weight),
+            *tensor_handle_to_tensor_pointer(weight_scales),
+            *tensor_handle_to_tensor_pointer(weight_zero_points),
+            pointer_to_optional<at::Tensor>(B),
+            stride_list,
+            padding_list,
+            dilation_list,
+            groups,
+            output_scale,
+            output_zero_point,
+            pointer_to_optional<at::ScalarType>(output_dtype),
+            attr,
+            scalars_list,
+            pointer_to_optional<std::string_view>(algorithm));
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu__qconv2d_pointwise_binary_tensor(
@@ -459,45 +472,47 @@ AOTITorchError aoti_torch_cpu__qconv2d_pointwise_binary_tensor(
     int64_t unary_scalars_len_,
     const char** unary_algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    c10::List<std::optional<c10::Scalar>> unary_scalars_list;
-    unary_scalars_list.reserve(unary_scalars_len_);
-    for (int64_t i = 0; i < unary_scalars_len_; i++) {
-      unary_scalars_list.emplace_back(pointer_to_optional(unary_scalars[i]));
-    }
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::QConvoneDNN::run_pointwise_binary_tensor", {
+        c10::List<std::optional<c10::Scalar>> unary_scalars_list;
+        unary_scalars_list.reserve(unary_scalars_len_);
+        for (int64_t i = 0; i < unary_scalars_len_; i++) {
+          unary_scalars_list.emplace_back(
+              pointer_to_optional(unary_scalars[i]));
+        }
 
-    c10::List<int64_t> stride_list =
-        convert_to_c10_List<int64_t>(stride_args, stride_len_);
-    c10::List<int64_t> padding_list =
-        convert_to_c10_List<int64_t>(padding_args, padding_len_);
-    c10::List<int64_t> dilation_list =
-        convert_to_c10_List<int64_t>(dilation_args, dilation_len_);
+        c10::List<int64_t> stride_list =
+            convert_to_c10_List<int64_t>(stride_args, stride_len_);
+        c10::List<int64_t> padding_list =
+            convert_to_c10_List<int64_t>(padding_args, padding_len_);
+        c10::List<int64_t> dilation_list =
+            convert_to_c10_List<int64_t>(dilation_args, dilation_len_);
 
-    auto tmp_result = at::native::QConvoneDNN::run_pointwise_binary_tensor(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(act_scale),
-        *tensor_handle_to_tensor_pointer(act_zero_point),
-        *tensor_handle_to_tensor_pointer(onednn_weight),
-        *tensor_handle_to_tensor_pointer(weight_scales),
-        *tensor_handle_to_tensor_pointer(weight_zero_points),
-        *tensor_handle_to_tensor_pointer(accum),
-        pointer_to_optional<at::Tensor>(B),
-        stride_list,
-        padding_list,
-        dilation_list,
-        groups,
-        output_scale,
-        output_zero_point,
-        pointer_to_optional<at::ScalarType>(output_dtype),
-        accum_scale,
-        accum_zero_point,
-        binary_attr,
-        pointer_to_optional<c10::Scalar>(alpha),
-        pointer_to_optional<std::string_view>(unary_attr),
-        unary_scalars_list,
-        pointer_to_optional<std::string_view>(unary_algorithm));
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+        auto tmp_result = at::native::QConvoneDNN::run_pointwise_binary_tensor(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(act_scale),
+            *tensor_handle_to_tensor_pointer(act_zero_point),
+            *tensor_handle_to_tensor_pointer(onednn_weight),
+            *tensor_handle_to_tensor_pointer(weight_scales),
+            *tensor_handle_to_tensor_pointer(weight_zero_points),
+            *tensor_handle_to_tensor_pointer(accum),
+            pointer_to_optional<at::Tensor>(B),
+            stride_list,
+            padding_list,
+            dilation_list,
+            groups,
+            output_scale,
+            output_zero_point,
+            pointer_to_optional<at::ScalarType>(output_dtype),
+            accum_scale,
+            accum_zero_point,
+            binary_attr,
+            pointer_to_optional<c10::Scalar>(alpha),
+            pointer_to_optional<std::string_view>(unary_attr),
+            unary_scalars_list,
+            pointer_to_optional<std::string_view>(unary_algorithm));
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 #if AT_MKL_ENABLED()
@@ -509,7 +524,7 @@ AOTITorchError aoti_torch_cpu__mkl_linear(
     AtenTensorHandle* B,
     int64_t prepack_batch_size,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::mkl_linear", {
     auto tmp_result = at::native::mkl_linear(
         *tensor_handle_to_tensor_pointer(X),
         *tensor_handle_to_tensor_pointer(W),

--- a/torch/csrc/inductor/aoti_torch/utils.h
+++ b/torch/csrc/inductor/aoti_torch/utils.h
@@ -11,16 +11,17 @@
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 #include <optional>
 
-#define AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(...)    \
-  try {                                                    \
-    __VA_ARGS__                                            \
-  } catch (const std::exception& e) {                      \
-    LOG(ERROR) << "Exception in aoti_torch: " << e.what(); \
-    return AOTI_TORCH_FAILURE;                             \
-  } catch (...) {                                          \
-    LOG(ERROR) << "Exception in aoti_torch: UNKNOWN";      \
-    return AOTI_TORCH_FAILURE;                             \
-  }                                                        \
+#define AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(func_name, ...) \
+  try {                                                            \
+    RECORD_FUNCTION(func_name, c10::ArrayRef<c10::IValue>());      \
+    __VA_ARGS__                                                    \
+  } catch (const std::exception& e) {                              \
+    LOG(ERROR) << "Exception in aoti_torch: " << e.what();         \
+    return AOTI_TORCH_FAILURE;                                     \
+  } catch (...) {                                                  \
+    LOG(ERROR) << "Exception in aoti_torch: UNKNOWN";              \
+    return AOTI_TORCH_FAILURE;                                     \
+  }                                                                \
   return AOTI_TORCH_SUCCESS;
 
 namespace torch::aot_inductor {

--- a/torchgen/gen_aoti_c_shim.py
+++ b/torchgen/gen_aoti_c_shim.py
@@ -297,7 +297,7 @@ def gen_declaration_and_definition(
     ret_assignments_str = "\n" + "\n".join(ret_assignments) if ret_assignments else ""
     definition = f"""
 {declaration} {{
-    AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({{
+    AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_{device}_{func_name}", {{
         {tmp_result}{backend_call}(
 {textwrap.indent(", ".join(callsite_exprs), "            ")}
         );{textwrap.indent(ret_assignments_str, "        ")}
@@ -511,6 +511,7 @@ extern "C" {{
 
 #include <torch/csrc/inductor/aoti_torch/generated/{"extend/" if extend_aoti_c_shim else ""}c_shim_{device}.h>
 #include <torch/csrc/inductor/aoti_torch/utils.h>
+#include <ATen/record_function.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/{str(dispatch_key)}Functions.h>


### PR DESCRIPTION
Ports @chunyuan-w's [work](https://github.com/pytorch/pytorch/commit/734f940f527a53bde1334b8a8819062c78029f2f#diff-b60511be1e7fafc2c45e7c0cb3e769ad48b2a1060a69759f58979ffc33b38a79) to main branch to ensure some ops would appear in Inductor-CPU profiling results.

SDPA op doesn't appear in profiling results with this small example because it's being decomposed even for CPU (doesn't seem intentional, so it should probably be investigated orthogonally) -

<details>

```python
import torch
import torch.nn.functional as F
from torch.profiler import profile, record_function, ProfilerActivity
from torch._inductor import config as inductor_config
inductor_config.profiler_mark_wrapper_call = True
inductor_config.cpp.enable_kernel_profile = True

def attention_block(query, key, value, dropout_p=0.0):
    attn_output = F.scaled_dot_product_attention(
        query, key, value, 
        dropout_p=dropout_p
    )
    return attn_output

class SimpleAttentionModule(torch.nn.Module):
    def __init__(self, embed_dim):
        super().__init__()
        self.linear_q = torch.nn.Linear(embed_dim, embed_dim, dtype=torch.bfloat16)
        self.linear_k = torch.nn.Linear(embed_dim, embed_dim, dtype=torch.bfloat16)
        self.linear_v = torch.nn.Linear(embed_dim, embed_dim, dtype=torch.bfloat16)

    def forward(self, x):
        # Project x to query, key, and value
        query = self.linear_q(x)
        key   = self.linear_k(x)
        value = self.linear_v(x)
        return attention_block(query, key, value)

model = SimpleAttentionModule(embed_dim=4096)

x = torch.randn(64, 4096, dtype=torch.bfloat16)

with torch.no_grad():
    # Run a forward pass on the compiled model
    compiled_model = torch.compile(model)
    output = compiled_model(x)
    with profile(activities=[ProfilerActivity.CPU], record_shapes=True) as prof:
        compiled_model(x)
    print(prof.key_averages().table(sort_by="cpu_time_total", row_limit=100))

```

</details>

But if a group of ops are pattern-matched to the SDPA op in Inductor, then SDPA op should be visible in Inductor profiling results with this patch.