### PR TITLE
[TEST][SPARSE] Simplify branching in test_cusparselt_backend

### DIFF
--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -1223,12 +1223,9 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         # CUDA 11.8 has cuSPARSELt v0.4.0 support
         if version == (11, 8):
             assert torch.backends.cusparselt.version() == 400
-        # PyTorch CUDA 12.4 using cuSPARSELt v0.6.2
+        # PyTorch CUDA 12.4+ using cuSPARSELt v0.6.2+
         elif version >= (12, 4):
-            assert torch.backends.cusparselt.version() == 602
-        # PyTorch CUDA 12.6+ using cuSPARSELt v0.6.3
-        elif version >= (12, 6):
-            assert torch.backends.cusparselt.version() == 603
+            assert torch.backends.cusparselt.version() >= 602
         else:
             assert torch.backends.cusparselt.version() is None
 


### PR DESCRIPTION
Due to introduction of CUDA versions, the branching becomes more complicated. This PR is proposed to simplify branching in `test_cusparselt_backend` in order to avoid checking each and every CUDA version.

cc @mruberry @ZainRizvi