### PR TITLE
[ONNX] Assert capture strategy in tests

### DIFF
--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -157,7 +157,7 @@ class TestExportAPIDynamo(common_utils.TestCase):
             strict=True,
         )
 
-        self.assert_export(ep)
+        self.assert_export(ep, strategy=None)
 
     def test_dynamic_shapes_supports_input_names(self):
         self.assert_export(

--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -52,10 +52,10 @@ class NestedModelForDynamicShapes(torch.nn.Module):
 class TestExportAPIDynamo(common_utils.TestCase):
     """Tests for the ONNX exporter API when dynamo=True."""
 
-    def assert_export(self, *args, **kwargs):
+    def assert_export(self, *args, strategy="TorchExportNonStrictStrategy", **kwargs):
         onnx_program = torch.onnx.export(*args, **kwargs, dynamo=True)
         assert onnx_program is not None
-        onnx_testing.assert_onnx_program(onnx_program)
+        onnx_testing.assert_onnx_program(onnx_program, strategy=strategy)
 
     def test_args_normalization_with_no_kwargs(self):
         self.assert_export(
@@ -128,7 +128,11 @@ class TestExportAPIDynamo(common_utils.TestCase):
             def forward(self, x):
                 return x
 
-        self.assert_export(torch.jit.script(ScriptModule()), (torch.randn(1, 1, 2),))
+        self.assert_export(
+            torch.jit.script(ScriptModule()),
+            (torch.randn(1, 1, 2),),
+            strategy="JitTraceConvertStrategy",
+        )
 
     def test_dynamic_shapes_with_fully_specified_axes(self):
         exported_program = torch.export.export(

--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -159,29 +159,6 @@ class TestExportAPIDynamo(common_utils.TestCase):
 
         self.assert_export(ep, strategy=None)
 
-    def test_dynamic_shapes_supports_input_names(self):
-        self.assert_export(
-            SampleModelForDynamicShapes(),
-            (
-                torch.randn(2, 2, 3),
-                torch.randn(2, 2, 3),
-            ),
-            strategy=None,
-            dynamic_shapes={
-                "custom_x": {
-                    0: torch.export.Dim("customx_dim_0"),
-                    1: torch.export.Dim("customx_dim_1"),
-                    2: torch.export.Dim("customx_dim_2"),
-                },
-                "custom_b": {
-                    0: torch.export.Dim("customb_dim_0"),
-                    1: torch.export.Dim("customb_dim_1"),
-                    2: torch.export.Dim("customb_dim_2"),
-                },
-            },
-            input_names=["custom_x", "custom_b"],
-        )
-
     def test_partial_dynamic_shapes(self):
         self.assert_export(
             SampleModelForDynamicShapes(),

--- a/test/onnx/exporter/test_hf_models_e2e.py
+++ b/test/onnx/exporter/test_hf_models_e2e.py
@@ -26,25 +26,6 @@ class DynamoExporterHfModelsTest(common_utils.TestCase):
         assert onnx_program is not None
         return onnx_program
 
-    def assert_onnx_program(
-        self,
-        onnx_program,
-        *,
-        rtol: float | None = None,
-        atol: float | None = None,
-        args: tuple[Any, ...] | None = None,
-        kwargs: dict[str, Any] | None = None,
-        strategy: str | None = "TorchExportNonStrictStrategy",
-    ):
-        onnx_testing.assert_onnx_program(
-            onnx_program,
-            rtol=rtol,
-            atol=atol,
-            args=args,
-            kwargs=kwargs,
-            strategy=strategy,
-        )
-
     def test_onnx_export_huggingface_llm_models_with_kv_cache(self):
         model, kwargs, dynamic_axes, input_names, output_names = (
             _prepare_llm_model_gptj_to_test()
@@ -56,7 +37,7 @@ class DynamoExporterHfModelsTest(common_utils.TestCase):
             output_names=output_names,
             dynamic_axes=dynamic_axes,
         )
-        self.assert_onnx_program(onnx_program)
+        onnx_testing.assert_onnx_program(onnx_program)
 
     def test_onnx_export_with_custom_axis_names_in_dynamic_shapes(self):
         model, kwargs, _, input_names, output_names = _prepare_llm_model_gptj_to_test()
@@ -97,7 +78,7 @@ class DynamoExporterHfModelsTest(common_utils.TestCase):
             dynamic_shapes=dynamic_shapes,
             optimize=False,
         )
-        self.assert_onnx_program(onnx_program)
+        onnx_testing.assert_onnx_program(onnx_program)
 
         # Check that the dynamic axes are correctly set in the ONNX model
         for dim, custom_name in zip(

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import torchvision
 import transformers
 
 import torch
@@ -19,7 +18,13 @@ from torch.utils import _pytree as torch_pytree
 class DynamoExporterTest(common_utils.TestCase):
     def export(self, model, args=(), kwargs=None, **options) -> torch.onnx.ONNXProgram:
         onnx_program = torch.onnx.export(
-            model, args, kwargs=kwargs, dynamo=True, fallback=False, **options
+            model,
+            args,
+            kwargs=kwargs,
+            dynamo=True,
+            fallback=False,
+            verbose=False,
+            **options,
         )
         assert onnx_program is not None
         return onnx_program
@@ -172,23 +177,6 @@ class DynamoExporterTest(common_utils.TestCase):
         )
         self.assert_onnx_program(onnx_program)
         self.assert_onnx_program(onnx_program, args=(torch.tensor([-1, -2]),))
-
-    def test_onnx_export_torchvision_ops(self):
-        class VisionModel(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-
-            def forward(self, *x):
-                out = torchvision.ops.nms(x[0], x[1], x[2])
-                return out
-
-        args = (
-            torch.tensor([[0, 0, 1, 1], [0.5, 0.5, 1, 1]], dtype=torch.float),
-            torch.tensor([0.1, 0.2]),
-            0,
-        )
-        onnx_program = self.export(VisionModel(), args)
-        self.assert_onnx_program(onnx_program)
 
     def test_empty(self):
         def func(x):

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -246,7 +246,7 @@ class DynamoExporterTest(common_utils.TestCase):
 
         class LoggingLoggerModule(torch.nn.Module):
             def forward(self, x):
-                logger.log("abc")
+                logger.info("abc")
                 return x + 1
 
         onnx_program = self.export(LoggingLoggerModule(), (torch.tensor(1),))

--- a/torch/onnx/_internal/exporter/_capture_strategies.py
+++ b/torch/onnx/_internal/exporter/_capture_strategies.py
@@ -116,7 +116,7 @@ class CaptureStrategy(abc.ABC):
                 exception=e,
             )
         self._success(model)
-        return Result(exported_program, strategy=self.__call__.__name__)
+        return Result(exported_program, strategy=self.__class__.__name__)
 
     @abc.abstractmethod
     def _capture(

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -644,9 +644,9 @@ def _handle_output_node(
     # for example, a subgraph has multiple outputs. We flatten them all as ONNX graph outputs
     for output in node.args[0]:  # type: ignore[index,union-attr]
         output_value_name = output.name  # type: ignore[union-attr]
-        assert isinstance(output_value_name, str), (
-            f"Bug: Expected {output_value_name!r} to be a string"
-        )
+        assert isinstance(
+            output_value_name, str
+        ), f"Bug: Expected {output_value_name!r} to be a string"
         values = node_name_to_values[output_value_name]
         if isinstance(values, Sequence):
             graph_like.outputs.extend(values)
@@ -749,9 +749,9 @@ def _get_inputs_and_attributes(
         return inputs, {}, [], [node.name]  # type: ignore[return-value]
 
     # The target should be an ATen operator now
-    assert hasattr(node.target, "_schema"), (
-        f"The target should be an ATen operator now, but node target {node.target} has no schema"
-    )
+    assert hasattr(
+        node.target, "_schema"
+    ), f"The target should be an ATen operator now, but node target {node.target} has no schema"
     node_schema: torch.FunctionSchema = node.target._schema
 
     # This function assumes the order of arguments in FX op is the
@@ -1045,9 +1045,9 @@ def _exported_program_to_onnx_program(
         persistent = spec.persistent
         value = values[value_name]
 
-        assert not isinstance(value, Sequence), (
-            f"Input '{value_name}' should not be a sequence. This is unexpected."
-        )
+        assert not isinstance(
+            value, Sequence
+        ), f"Input '{value_name}' should not be a sequence. This is unexpected."
 
         value.metadata_props["pkg.torch.export.graph_signature.InputSpec.kind"] = (
             input_kind.name
@@ -1223,6 +1223,7 @@ def export(
     failed_results: list[_capture_strategies.Result] = []
 
     program: torch.export.ExportedProgram | None = None
+    capture_strategy: str | None = None
     # Step 1: Export the model with torch.export.export if the model is not already an ExportedProgram
     if isinstance(model, torch.export.ExportedProgram):
         # We know the model is already exported program, so the args, kwargs, and dynamic_shapes
@@ -1258,6 +1259,7 @@ def export(
                 failed_results.append(result)
 
         assert result is not None
+        capture_strategy = result.strategy
         if result.exported_program is None:
             # If all strategies fail, produce an error report and raise the first error
             profile_result = _maybe_stop_profiler_and_get_result(profiler)
@@ -1371,6 +1373,8 @@ def export(
         onnx_program = _exported_program_to_onnx_program(
             decomposed_program, registry=registry
         )
+        # Record the strategy used for getting the exported program for unit test assertions
+        onnx_program._capture_strategy = capture_strategy
 
         # Run the ONNX passes
         if input_names:

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -644,9 +644,9 @@ def _handle_output_node(
     # for example, a subgraph has multiple outputs. We flatten them all as ONNX graph outputs
     for output in node.args[0]:  # type: ignore[index,union-attr]
         output_value_name = output.name  # type: ignore[union-attr]
-        assert isinstance(
-            output_value_name, str
-        ), f"Bug: Expected {output_value_name!r} to be a string"
+        assert isinstance(output_value_name, str), (
+            f"Bug: Expected {output_value_name!r} to be a string"
+        )
         values = node_name_to_values[output_value_name]
         if isinstance(values, Sequence):
             graph_like.outputs.extend(values)
@@ -749,9 +749,9 @@ def _get_inputs_and_attributes(
         return inputs, {}, [], [node.name]  # type: ignore[return-value]
 
     # The target should be an ATen operator now
-    assert hasattr(
-        node.target, "_schema"
-    ), f"The target should be an ATen operator now, but node target {node.target} has no schema"
+    assert hasattr(node.target, "_schema"), (
+        f"The target should be an ATen operator now, but node target {node.target} has no schema"
+    )
     node_schema: torch.FunctionSchema = node.target._schema
 
     # This function assumes the order of arguments in FX op is the
@@ -1045,9 +1045,9 @@ def _exported_program_to_onnx_program(
         persistent = spec.persistent
         value = values[value_name]
 
-        assert not isinstance(
-            value, Sequence
-        ), f"Input '{value_name}' should not be a sequence. This is unexpected."
+        assert not isinstance(value, Sequence), (
+            f"Input '{value_name}' should not be a sequence. This is unexpected."
+        )
 
         value.metadata_props["pkg.torch.export.graph_signature.InputSpec.kind"] = (
             input_kind.name

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -76,6 +76,8 @@ class ONNXProgram:
         self.exported_program = exported_program
         self._inference_session: ort.InferenceSession | None = None
         self._tempdir: tempfile.TemporaryDirectory | None = None
+        # Strategy used to capture the exported program
+        self._capture_strategy: str | None = None
 
     def __repr__(self) -> str:
         return f"""\

--- a/torch/onnx/_internal/exporter/_testing.py
+++ b/torch/onnx/_internal/exporter/_testing.py
@@ -22,7 +22,7 @@ def assert_onnx_program(
     atol: float | None = None,
     args: tuple[Any, ...] | None = None,
     kwargs: dict[str, Any] | None = None,
-    strategy: str | None = None,
+    strategy: str | None = "TorchExportNonStrictStrategy",
 ) -> None:
     """Assert that the ONNX model produces the same output as the PyTorch ExportedProgram.
 

--- a/torch/onnx/_internal/exporter/_testing.py
+++ b/torch/onnx/_internal/exporter/_testing.py
@@ -25,6 +25,7 @@ def assert_onnx_program(
     strategy: str | None = None,
 ) -> None:
     """Assert that the ONNX model produces the same output as the PyTorch ExportedProgram.
+
     Args:
         program: The ``ONNXProgram`` to verify.
         rtol: Relative tolerance.
@@ -33,6 +34,9 @@ def assert_onnx_program(
             If None, the default example inputs in the ExportedProgram will be used.
         kwargs: The keyword arguments to pass to the program.
             If None, the default example inputs in the ExportedProgram will be used.
+        strategy: Assert the capture strategy used to export the program. Values can be
+            class names like "TorchExportStrategy" or "TorchExportNonStrictStrategy" etc.
+            If None, the strategy is not asserted.
     """
     if strategy is not None:
         if program._capture_strategy != strategy:

--- a/torch/onnx/_internal/exporter/_testing.py
+++ b/torch/onnx/_internal/exporter/_testing.py
@@ -22,6 +22,7 @@ def assert_onnx_program(
     atol: float | None = None,
     args: tuple[Any, ...] | None = None,
     kwargs: dict[str, Any] | None = None,
+    strategy: str | None = None,
 ) -> None:
     """Assert that the ONNX model produces the same output as the PyTorch ExportedProgram.
     Args:
@@ -33,6 +34,12 @@ def assert_onnx_program(
         kwargs: The keyword arguments to pass to the program.
             If None, the default example inputs in the ExportedProgram will be used.
     """
+    if strategy is not None:
+        if program._capture_strategy != strategy:
+            raise ValueError(
+                f"Expected strategy '{strategy}' is used to capture the exported program, "
+                f"but got '{program._capture_strategy}'."
+            )
     exported_program = program.exported_program
     if exported_program is None:
         raise ValueError(


### PR DESCRIPTION
Previously the strategy used for obtaining the exported program is not asserted. This leads to silent errors if torch.export breaks something and a fallback strategy is used. This change adds a _capture_strategy field to ONNXProgram and enables unit tests to assert the strategy used to prevent fallbacks from happening.

Fixes #147674 
