### PR TITLE
[MPS] unary kernels - avoid copying tensors if they have same stride

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8507,6 +8507,14 @@ class TestMPS(TestCaseMPS):
                 op(cpu_x, out=cpu_y)
                 op(mps_x, out=mps_y)
                 self.assertEqual(mps_y, cpu_y)
+                # test for non contiguous input/output with similar strides
+                cpu_x = torch.randn(shape, device='cpu', dtype=dtype).mT
+                mps_x = cpu_x.detach().clone().to('mps')
+                cpu_y = torch.zeros_like(cpu_x)
+                mps_y = cpu_y.detach().clone().to('mps')
+                op(cpu_x, out=cpu_y)
+                op(mps_x, out=mps_y)
+                self.assertEqual(mps_y, cpu_y)
 
 
         helper((5, 5), torch.exp, False)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8507,11 +8507,12 @@ class TestMPS(TestCaseMPS):
                 op(cpu_x, out=cpu_y)
                 op(mps_x, out=mps_y)
                 self.assertEqual(mps_y, cpu_y)
+
                 # test for non contiguous input/output with similar strides
                 cpu_x = torch.randn(shape, device='cpu', dtype=dtype).mT
-                mps_x = cpu_x.detach().clone().to('mps')
-                cpu_y = torch.zeros_like(cpu_x)
-                mps_y = cpu_y.detach().clone().to('mps')
+                mps_x = cpu_x.to('mps')
+                cpu_y = torch.empty_like(cpu_x)
+                mps_y = cpu_y.to('mps')
                 op(cpu_x, out=cpu_y)
                 op(mps_x, out=mps_y)
                 self.assertEqual(mps_y, cpu_y)


### PR DESCRIPTION
I was a bit concerned when I saw in #148272 that metal unary kernel was 0.02x of the performance of what we had with MPS Graphs for sqrt(for non contiguous) tensors. This change makes it so that copying is only done if we don't have same strided tensors(for input/output). So if out tensor is not provided then we don't do copy(don't call contiguous) at all and dispatch the kernel as is. After making this change the script that I listed at the end of the above PR has the same execution time as the non-transposed one.

Times for reference(on transposed tensor where matrix is NxN matrix):

| N     | time_old           | time_new           |
|-------|--------------------|--------------------|
| 100   | 0.0002241021       | 0.0001548659       |
| 1000  | 0.0005934822       | 0.0002150342       |
| 10000 | 0.3242016407       | 0.0045755033       |

cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen