### PR TITLE
Use release notes label for module: distributed_checkpoint

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -98,7 +98,7 @@
 - test/distributed/**
 - torch/testing/_internal/distributed/**
 
-"module: distributed_checkpoint":
+"release notes: distributed (checkpoint)":
 - torch/distributed/checkpoint/**
 - test/distributed/checkpoint/**
 


### PR DESCRIPTION
module: distributed_checkpoint is redundant with oncall: distributed checkpointing.

@fduwjj let us know that module: distributed_checkpoint is just used for release notes, so let's use the release notes label for the release notes, which the bot will pick up better.