### PR TITLE
[BE] Use `C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED`

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_16bit_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_16bit_float.h
@@ -15,9 +15,6 @@
 #include <sleef.h>
 #endif
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wignored-qualifiers"
-
 namespace at::vec {
 // See Note [CPU_CAPABILITY namespace]
 inline namespace CPU_CAPABILITY {
@@ -315,6 +312,9 @@ public:
     return b;
   }
 
+// 'const' type qualifier on return type has no effect, but sleef defines this this way
+// For example `Sleef_exp2f8_u10` signature is `const __m256 (__m256)`
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wignored-qualifiers")
   Vectorized<T> map(SLEEF_CONST __m256 (*SLEEF_CONST_OLD vop)(__m256)) const {
     __m256 lo, hi;
     cvt_to_fp32<T>(values, lo, hi);
@@ -322,6 +322,7 @@ public:
     const auto o2 = vop(hi);
     return cvt_from_fp32<T>(o1, o2);
   }
+C10_DIAGNOSTIC_POP()
   Vectorized<T> isnan() const {
     __m256 lo, hi;
     cvt_to_fp32<T>(values, lo, hi);

--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -228,5 +228,3 @@ CONVERT_NON_VECTORIZED_INIT(BFloat16, bfloat16);
 LOAD_FP32_NON_VECTORIZED_INIT(BFloat16, bf16)
 #endif // defined(CPU_CAPABILITY_AVX2)
 }} // namsepace at::vec::CPU_CAPABILITY
-
-#pragma GCC diagnostic pop

--- a/aten/src/ATen/cpu/vec/vec256/vec256_half.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_half.h
@@ -228,5 +228,3 @@ CONVERT_NON_VECTORIZED_INIT(Half, half)
 LOAD_FP32_NON_VECTORIZED_INIT(Half, fp16)
 #endif // defined(CPU_CAPABILITY_AVX2)
 }} // namsepace at::vec::CPU_CAPABILITY
-
-#pragma GCC diagnostic pop


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #148362
* __->__ #148354

Instead of `#pragma GCC diagnostic ignored "-Wignored-qualifiers"`
Also limit the scope to just `Vectorized::map` that has to be declared that way due to sleef function signature definitions that return `const __m256` for AVX2 methods

Also delete `#pragma GCC diagnostic pop` from vec256_half and vec256_bfloat16 as it results in an unbalanced pop warning, for push that is defined in vec256_16bit_float, which will be included only once
```
In file included from /Users/malfet/git/pytorch/pytorch/aten/src/ATen/cpu/vec/vec.h:7:
In file included from /Users/malfet/git/pytorch/pytorch/aten/src/ATen/cpu/vec/vec256/vec256.h:15:
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/cpu/vec/vec256/vec256_half.h:232:27: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
  232 | #pragma GCC diagnostic pop
      |                           ^
1 warning generated.

```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10