### PR TITLE
[AOTI][dashboard] Skip torchbench models not supported by export

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1825,6 +1825,10 @@ class BenchmarkRunner:
         return set()
 
     @property
+    def skip_models_due_to_export_not_supported(self):
+        return set()
+
+    @property
     def disable_cudagraph_models(self):
         return set()
 
@@ -3786,6 +3790,7 @@ def run(runner, args, original_dir=None):
 
             # AOTInductor doesn't support control flow yet
             runner.skip_models.update(runner.skip_models_due_to_control_flow)
+            runner.skip_models.update(runner.skip_models_due_to_export_not_supported)
         elif args.backend == "torchao":
             assert "cuda" in args.devices, "Quantization requires CUDA device."
             assert args.bfloat16, "Quantization requires dtype bfloat16."

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -206,6 +206,10 @@ class TorchBenchmarkRunner(BenchmarkRunner):
         return self._skip["control_flow"]
 
     @property
+    def skip_models_due_to_export_not_supported(self):
+        return self._skip["export_not_supported"]
+
+    @property
     def guard_on_nn_module_models(self):
         return {
             "vision_maskrcnn",

--- a/benchmarks/dynamo/torchbench.yaml
+++ b/benchmarks/dynamo/torchbench.yaml
@@ -242,6 +242,16 @@ skip:
     - opacus_cifar10
     - speech_transformer
 
+  export_not_supported:
+    - doctr_reco_predictor
+    - doctr_det_predictor
+    - drq
+    - llama
+    - sam_fast
+    - soft_actor_critic
+    - timm_efficientdet
+    - vision_maskrcnn
+
   # Models that should only run in --multiprocess mode
   multiprocess:
     - simple_gpt


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148359

Summary: Certain models fail in export because of data-dependent ops. Skip them so that oncall can better track the AOTInductor dashboard.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames