### PR TITLE
Enabling xpu in OffsetBasedRNGTracker .

### DIFF
--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -159,7 +159,7 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
     should be shared and synchronized among all ranks to respect the semantics of DTensor
     random operators.
 
-    note: _RNGStateTracker only supports cuda/cuda-like device. Xpu support is experimental.
+    note: _RNGStateTracker only supports cuda/cuda-like device.
     """
 
     def __init__(
@@ -170,7 +170,7 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         super().__init__(_resolve_device(device_mesh=device_mesh))
         assert self._device_handle is not None
         # DTensor RNG tracker so far only supports CUDA/CUDA-like devices
-        if self._device.type not in [ "cuda", "xpu"]:
+        if self._device.type not in ["cuda", "xpu"]:
             raise RuntimeError(
                 f"{self.__class__.__name__} instantiation requires the presence of "
                 f"CUDA/CUDA-like/XPU device. Got {self._device.type} instead."
@@ -198,7 +198,7 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         if self.distribute_region_enabled:
             old_offset = self.get_offset("parallel-rng")
             self._set_pre_op_offset(spec)
-            with torch.random.fork_rng(devices=[self._device]):
+            with torch.random.fork_rng(devices=[self._device], device_type=self._device.type):
                 assert self._device_handle is not None
                 self._device_handle.set_rng_state(self.rng_states["parallel-rng"])
                 try:

--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -170,7 +170,7 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         super().__init__(_resolve_device(device_mesh=device_mesh))
         assert self._device_handle is not None
         # DTensor RNG tracker so far only supports CUDA/CUDA-like devices
-        if self._device.type == 'cpu':
+        if self._device.type == "cpu":
             raise RuntimeError(
                 f"{self.__class__.__name__} instantiation requires the presence of "
                 f"CUDA/CUDA-like/XPU device. Got {self._device.type} instead."

--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -159,7 +159,7 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
     should be shared and synchronized among all ranks to respect the semantics of DTensor
     random operators.
 
-    note: _RNGStateTracker only supports cuda/cuda-like device
+    note: _RNGStateTracker only supports cuda/cuda-like device. Xpu support is experimental.
     """
 
     def __init__(
@@ -170,10 +170,10 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         super().__init__(_resolve_device(device_mesh=device_mesh))
         assert self._device_handle is not None
         # DTensor RNG tracker so far only supports CUDA/CUDA-like devices
-        if self._device.type != "cuda":
+        if self._device.type not in [ "cuda", "xpu"]:
             raise RuntimeError(
                 f"{self.__class__.__name__} instantiation requires the presence of "
-                f"CUDA/CUDA-like device. Got {self._device.type} instead."
+                f"CUDA/CUDA-like/XPU device. Got {self._device.type} instead."
             )
 
         rng_state = self._device_handle.get_rng_state().to(self._device)

--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -170,7 +170,7 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         super().__init__(_resolve_device(device_mesh=device_mesh))
         assert self._device_handle is not None
         # DTensor RNG tracker so far only supports CUDA/CUDA-like devices
-        if self._device.type not in ["cuda", "xpu"]:
+        if self._device.type == 'cpu':
             raise RuntimeError(
                 f"{self.__class__.__name__} instantiation requires the presence of "
                 f"CUDA/CUDA-like/XPU device. Got {self._device.type} instead."

--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -198,7 +198,9 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         if self.distribute_region_enabled:
             old_offset = self.get_offset("parallel-rng")
             self._set_pre_op_offset(spec)
-            with torch.random.fork_rng(devices=[self._device], device_type=self._device.type):
+            with torch.random.fork_rng(
+                devices=[self._device], device_type=self._device.type
+            ):
                 assert self._device_handle is not None
                 self._device_handle.set_rng_state(self.rng_states["parallel-rng"])
                 try:


### PR DESCRIPTION
Else torch.distributed breaks on xpu devices.

Fixes #ISSUE_NUMBER


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o