### PR TITLE
[ROCm] Add rocm-mi300 and inductor-rocm-mi300 to upload-test-stats.yml

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -2,7 +2,7 @@ name: Upload test stats
 
 on:
   workflow_run:
-    workflows: [pull, trunk, periodic, inductor, unstable, slow, unstable-periodic, inductor-periodic, rocm, inductor-micro-benchmark, inductor-micro-benchmark-x86, inductor-cu124, inductor-rocm, mac-mps]
+    workflows: [pull, trunk, periodic, inductor, unstable, slow, unstable-periodic, inductor-periodic, rocm, rocm-mi300, inductor-micro-benchmark, inductor-micro-benchmark-x86, inductor-cu124, inductor-rocm, inductor-rocm-mi300, mac-mps]
     types:
       - completed
 


### PR DESCRIPTION
We currently run MI300X machines on rocm-mi300 and inductor-rocm-mi300 but we don't have artifacts for the results:
e.g. 
https://hud.pytorch.org/pytorch/pytorch/commit/6e10471966e22cda8ac0cded8a179267880457e0#rocm-mi300
![image](https://github.com/user-attachments/assets/f5588072-b818-4f54-a348-0e6ac7e96829)



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd