### PR TITLE
Docker release - pin buildkit to v0.19.0

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -103,13 +103,11 @@ jobs:
           password: ${{ secrets.GHCR_PAT }}
       # Setup multi-arch image builds
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         env:
           QEMU_BINARY_PATH: ${{ runner.temp }}/bin
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: v0.10.0
+        uses: docker/setup-buildx-action@v3
       - name: Setup job specific variables
         run: |
           set -eou pipefail

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -108,6 +108,8 @@ jobs:
           QEMU_BINARY_PATH: ${{ runner.temp }}/bin
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: image=moby/buildkit:v0.19.0
       - name: Setup job specific variables
         run: |
           set -eou pipefail

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -104,6 +104,8 @@ jobs:
       # Setup multi-arch image builds
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+        with:
+          image: 'docker.io/tonistiigi/binfmt:qemu-v9.2.0'
         env:
           QEMU_BINARY_PATH: ${{ runner.temp }}/bin
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -109,6 +109,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
+          version: latest
           driver-opts: image=moby/buildkit:v0.19.0
       - name: Setup job specific variables
         run: |

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -104,8 +104,6 @@ jobs:
       # Setup multi-arch image builds
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-        with:
-          image: 'docker.io/tonistiigi/binfmt:qemu-v9.2.0'
         env:
           QEMU_BINARY_PATH: ${{ runner.temp }}/bin
       - name: Set up Docker Buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ ARG BASE_IMAGE=ubuntu:22.04
 ARG PYTHON_VERSION=3.11
 
 FROM ${BASE_IMAGE} as dev-base
-RUN apt-get update &&  DEBIAN_FRONTEND=noninteractive apt-get --reinstall install -y libc-bin
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
         ccache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ARG BASE_IMAGE=ubuntu:22.04
 ARG PYTHON_VERSION=3.11
 
 FROM ${BASE_IMAGE} as dev-base
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+RUN apt-get update &&  DEBIAN_FRONTEND=noninteractive apt-get --reinstall install -y libc-bin
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
         ccache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
         cmake \
         curl \
         git \
+        libc-bin \
         libjpeg-dev \
         libpng-dev && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
         cmake \
         curl \
         git \
-        libc-bin \
         libjpeg-dev \
         libpng-dev && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fix nightly build failure during arm64 docker build (since 02.21.2025): https://github.com/pytorch/pytorch/actions/runs/13452177170/job/37588508155#step:12:851

Error:
```
#10 73.62 Segmentation fault (core dumped)
#10 73.67 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#10 73.85 Segmentation fault (core dumped)
#10 73.85 dpkg: error processing package libc-bin (--configure):
#10 73.85  installed libc-bin package post-installation script subprocess returned error exit status 139
```
Looks like we are hitting: https://github.com/moby/buildkit/issues/5783

Update setup-qemu and buildkit actions to v3 and buildkit to v0.19.0

Please note: CUDA 12.8 error is not related to this failure in nightly cpu arm64. Looks like we are trying to install release torch when running on PR. Cuda 12.8 build is not released yet, hence a failure. Will send followup to make sure we are using nightly torch when running on PR.
