### PR TITLE
Update onnxscript pin

### DIFF
--- a/.ci/docker/common/install_onnx.sh
+++ b/.ci/docker/common/install_onnx.sh
@@ -32,7 +32,7 @@ pip_install coloredlogs packaging
 
 pip_install onnxruntime==1.18.1
 pip_install onnx==1.17.0
-pip_install onnxscript==0.1.0 --no-deps
+pip_install onnxscript==0.2.2 --no-deps
 # required by onnxscript
 pip_install ml_dtypes
 

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -339,7 +339,7 @@ onnx==1.17.0
 #Pinned versions:
 #test that import:
 
-onnxscript==0.1.0
+onnxscript==0.2.2
 #Description: Required by mypy and test_public_bindings.py when checking torch.onnx._internal
 #Pinned versions:
 #test that import:


### PR DESCRIPTION
Summary:

Update pin to include https://github.com/microsoft/onnxscript/pull/2085

required to land https://github.com/pytorch/pytorch/pull/148140 

Test Plan: CI

Differential Revision: D70526777


