### PR TITLE
[dynamo] Account for function id reuse in relevant Dynamo decorators

### DIFF
--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -8,6 +8,7 @@ This module provides decorators and utilities for controlling TorchDynamo's beha
 import functools
 import inspect
 import sys
+import weakref
 from dataclasses import dataclass
 from typing import Any, Callable, TYPE_CHECKING, TypeVar
 from typing_extensions import ParamSpec
@@ -155,8 +156,16 @@ def allow_in_graph(fn):
         return [allow_in_graph(x) for x in fn]
     assert callable(fn), "allow_in_graph expects a callable"
     if trace_rules.lookup_callable(fn) != variables.TorchInGraphFunctionVariable:
-        trace_rules._disallowed_callable_ids.remove(id(fn))
-        trace_rules._allowed_callable_ids.add(id(fn))
+        fn_id = id(fn)
+        trace_rules._disallowed_callable_ids.remove(fn_id)
+        trace_rules._allowed_callable_ids.add(fn_id)
+
+        # Avoid id reuse which creates subtle bugs.
+        def deregister():
+            trace_rules._allowed_callable_ids.remove(fn_id)
+            trace_rules._nonstrict_trace_callable_ids.remove(fn_id)
+
+        weakref.finalize(fn, deregister)
     return fn
 
 
@@ -184,11 +193,20 @@ def nonstrict_trace(traceable_fn):
     def wrapped(*args, **kwargs):
         return traceable_fn(*args, **kwargs)
 
+    wrapped_id = id(wrapped)
+
     # This line allows us to reuse much of the `allow_in_graph` impl.
-    trace_rules._allowed_callable_ids.add(id(wrapped))
+    trace_rules._allowed_callable_ids.add(wrapped_id)
 
     # This line allows us to diverge the impl from `allow_in_graph`.
-    trace_rules._nonstrict_trace_callable_ids.add(id(wrapped))
+    trace_rules._nonstrict_trace_callable_ids.add(wrapped_id)
+
+    # Avoid id reuse which creates subtle bugs.
+    def deregister():
+        trace_rules._allowed_callable_ids.remove(wrapped_id)
+        trace_rules._nonstrict_trace_callable_ids.remove(wrapped_id)
+
+    weakref.finalize(wrapped, deregister)
 
     return wrapped
 

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -163,7 +163,6 @@ def allow_in_graph(fn):
         # Avoid id reuse which creates subtle bugs.
         def deregister():
             trace_rules._allowed_callable_ids.remove(fn_id)
-            trace_rules._nonstrict_trace_callable_ids.remove(fn_id)
 
         weakref.finalize(fn, deregister)
     return fn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #148386
* #148007
* __->__ #148385

This fixes a recent series of flaky failure from `nonstrict_trace` unit
tests: #148166, #148056, #148055, #148054, #148034, #148033, #148032, #148031.

For now we don't need to worry about the other decorators because they
are either meant for builtin/numpy functions (which should never
deallocate in practice), or used for polyfills which keeps the function
object in `get_torch_obj_rule_map()`.

Fixes #147777.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames