### PR TITLE
Add new GHA workflow to cache ROCm CI docker images on MI300 CI runners periodically

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -49,6 +49,7 @@ self-hosted-runner:
     - linux.rocm.gpu
     - linux.rocm.gpu.2
     - linux.rocm.gpu.4
+    - rocm-docker
     # Repo-specific Apple hosted  runners
     - macos-m1-ultra
     - macos-m2-14

--- a/.github/workflows/docker-cache-mi300.yml
+++ b/.github/workflows/docker-cache-mi300.yml
@@ -18,6 +18,11 @@ jobs:
   docker-cache:
     runs-on: linux.rocm.gpu.mi300.2
     steps:
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+        with:
+          no-sudo: true
+
       - name: Calculate docker image
         id: calculate-docker-image
         uses: pytorch/test-infra/.github/actions/calculate-docker-image@main

--- a/.github/workflows/docker-cache-mi300.yml
+++ b/.github/workflows/docker-cache-mi300.yml
@@ -9,6 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/docker-cache-mi300.yml
+++ b/.github/workflows/docker-cache-mi300.yml
@@ -1,8 +1,6 @@
 name: docker-cache-mi300
 
 on:
-  # TEMPORARY TO TRIGGER WORKFLOW ON PR
-  pull_request:
   # run every 6 hours
   schedule:
     - cron: 0 0,6,12,18 * * *

--- a/.github/workflows/docker-cache-mi300.yml
+++ b/.github/workflows/docker-cache-mi300.yml
@@ -52,5 +52,5 @@ jobs:
 
       - name: Tar and upload to S3 bucket
         run: |
-          sudo docker save -o docker-data/pytorch/pytorch_docker_image.tar ${{ steps.calculate-docker-image.outputs.docker-image }}
-          sudo rclone copy -P --s3-upload-concurrency 64 --s3-chunk-size 200M --s3-upload-cutoff 300M docker-data/pytorch/pytorch_docker_image.tar oci:pytorchbucket0002 --progress
+          sudo docker save -o ~/docker-data/pytorch/pytorch_docker_image.tar ${{ steps.calculate-docker-image.outputs.docker-image }}
+          sudo rclone copy -P --s3-upload-concurrency 64 --s3-chunk-size 200M --s3-upload-cutoff 300M ~/docker-data/pytorch/pytorch_docker_image.tar oci:pytorchbucket0002 --progress

--- a/.github/workflows/docker-cache-mi300.yml
+++ b/.github/workflows/docker-cache-mi300.yml
@@ -1,6 +1,8 @@
 name: docker-cache-mi300
 
 on:
+  # TEMPORARY TO TRIGGER WORKFLOW ON PR
+  pull_request:
   # run every 6 hours
   schedule:
     - cron: 0 0,6,12,18 * * *

--- a/.github/workflows/docker-cache-mi300.yml
+++ b/.github/workflows/docker-cache-mi300.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/docker-cache-mi300.yml
+++ b/.github/workflows/docker-cache-mi300.yml
@@ -23,6 +23,19 @@ jobs:
         with:
           no-sudo: true
 
+      - name: configure aws credentials
+        id: aws_creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
+          aws-region: us-east-1
+          role-duration-seconds: 18000
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        continue-on-error: false
+        uses: aws-actions/amazon-ecr-login@v2
+
       - name: Calculate docker image
         id: calculate-docker-image
         uses: pytorch/test-infra/.github/actions/calculate-docker-image@main

--- a/.github/workflows/docker-cache-mi300.yml
+++ b/.github/workflows/docker-cache-mi300.yml
@@ -12,7 +12,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   docker-cache:

--- a/.github/workflows/docker-cache-mi300.yml
+++ b/.github/workflows/docker-cache-mi300.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   docker-cache:
-    runs-on: amd-docker
+    runs-on: rocm-docker
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main

--- a/.github/workflows/docker-cache-mi300.yml
+++ b/.github/workflows/docker-cache-mi300.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   docker-cache:
-    runs-on: linux.rocm.gpu.mi300.2
+    runs-on: amd-docker
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
@@ -50,4 +50,7 @@ jobs:
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
 
-      # Steps to save the docker cache as a snapshot
+      - name: Tar and upload to S3 bucket
+        run: |
+          sudo docker save -o docker-data/pytorch/pytorch_docker_image.tar ${{ steps.calculate-docker-image.outputs.docker-image }}
+          sudo rclone copy -P --s3-upload-concurrency 64 --s3-chunk-size 200M --s3-upload-cutoff 300M docker-data/pytorch/pytorch_docker_image.tar oci:pytorchbucket0002 --progress

--- a/.github/workflows/docker-cache-mi300.yml
+++ b/.github/workflows/docker-cache-mi300.yml
@@ -1,0 +1,30 @@
+name: docker-cache-mi300
+
+on:
+  # run every 6 hours
+  schedule:
+    - cron: 0 0,6,12,18 * * *
+  workflow_dispatch:
+
+concurrency:
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  docker-cache:
+    runs-on: linux.rocm.gpu.mi300.2
+    steps:
+      - name: Calculate docker image
+        id: calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
+        with:
+          docker-image-name: pytorch-linux-focal-rocm-n-py3
+          push: false
+
+      - name: Pull docker image
+        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
+        with:
+          docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
+
+      # Steps to save the docker cache as a snapshot

--- a/.github/workflows/docker-cache-mi300.yml
+++ b/.github/workflows/docker-cache-mi300.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   docker-cache:
+    if: github.repository_owner == 'pytorch'
     runs-on: rocm-docker
     steps:
       - name: Checkout PyTorch

--- a/.github/workflows/docker-cache-mi300.yml
+++ b/.github/workflows/docker-cache-mi300.yml
@@ -53,4 +53,4 @@ jobs:
       - name: Tar and upload to S3 bucket
         run: |
           sudo docker save -o ~/docker-data/pytorch/pytorch_docker_image.tar ${{ steps.calculate-docker-image.outputs.docker-image }}
-          sudo rclone copy -P --s3-upload-concurrency 64 --s3-chunk-size 200M --s3-upload-cutoff 300M ~/docker-data/pytorch/pytorch_docker_image.tar oci:pytorchbucket0002 --progress
+          sudo rclone copy -P --s3-upload-concurrency 64 --s3-chunk-size 200M --s3-upload-cutoff 300M ~/docker-data/pytorch/pytorch_docker_image.tar oci:pytorchbucket0002/pytorch_docker_image --progress


### PR DESCRIPTION
Refiling https://github.com/pytorch/pytorch/pull/148387 from pytorch repo branch to get AWS login via OIDC working

Successful docker caching run: https://github.com/pytorch/pytorch/actions/runs/13843689908/job/38737095535
Run without cached docker image: https://github.com/pytorch/pytorch/actions/runs/13843692637/job/38746033460
![image](https://github.com/user-attachments/assets/c410ff35-a150-4885-b904-3a5e1888c032)
Run with cached docker image: 
![image](https://github.com/user-attachments/assets/41e417b5-a795-4ed2-a9cd-00151db8f813)
~6 min vs 3 s :) 

Thanks @saienduri for the help on the MI300 infra side

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd