### PR TITLE
[ONNX] Create VerificationInterpreter

### DIFF
--- a/test/onnx/exporter/test_verification.py
+++ b/test/onnx/exporter/test_verification.py
@@ -1,0 +1,71 @@
+# Owner(s): ["module: onnx"]
+"""Test the verification module."""
+
+from __future__ import annotations
+
+import torch
+from torch.onnx._internal.exporter import _verification
+from torch.testing._internal import common_utils
+
+
+class VerificationInfoTest(common_utils.TestCase):
+    def test_from_tensors(self):
+        # Test with tensors
+        expected = torch.tensor([1.0, 2.0, 3.0])
+        actual = torch.tensor([1.0, 2.0, 3.0])
+        verification_info = _verification.VerificationInfo.from_tensors(
+            "test_tensor", expected, actual
+        )
+        self.assertEqual(verification_info.name, "test_tensor")
+        self.assertEqual(verification_info.max_abs_diff, 0)
+        self.assertEqual(verification_info.max_rel_diff, 0)
+        torch.testing.assert_close(
+            verification_info.abs_diff_hist[0], torch.tensor([3.0] + [0.0] * 8)
+        )
+        torch.testing.assert_close(
+            verification_info.rel_diff_hist[0], torch.tensor([3.0] + [0.0] * 8)
+        )
+        self.assertEqual(verification_info.expected_dtype, torch.float32)
+        self.assertEqual(verification_info.actual_dtype, torch.float32)
+
+    def test_from_tensors_int(self):
+        # Test with int tensors
+        expected = torch.tensor([1])
+        actual = 1
+        verification_info = _verification.VerificationInfo.from_tensors(
+            "test_tensor_int", expected, actual
+        )
+        self.assertEqual(verification_info.name, "test_tensor_int")
+        self.assertEqual(verification_info.max_abs_diff, 0)
+        self.assertEqual(verification_info.max_rel_diff, 0)
+        torch.testing.assert_close(
+            verification_info.abs_diff_hist[0], torch.tensor([1.0] + [0.0] * 8)
+        )
+        torch.testing.assert_close(
+            verification_info.rel_diff_hist[0], torch.tensor([1.0] + [0.0] * 8)
+        )
+        self.assertEqual(verification_info.expected_dtype, torch.int64)
+        self.assertEqual(verification_info.actual_dtype, torch.int64)
+
+
+class VerificationInterpreterTest(common_utils.TestCase):
+    def test_interpreter_stores_correct_info(self):
+        class Model(torch.nn.Module):
+            def forward(self, a, b):
+                c = a + b
+                return c - 1
+
+        args = (torch.tensor([1.0]), torch.tensor([2.0]))
+        onnx_program = torch.onnx.export(Model(), args, dynamo=True)
+        assert onnx_program is not None
+        interpreter = _verification.VerificationInterpreter(onnx_program)
+        interpreter.run(args)
+        verification_infos = interpreter.verification_infos
+        self.assertEqual(len(verification_infos), 3)
+        for info in verification_infos:
+            self.assertEqual(info.max_abs_diff, 0)
+            self.assertEqual(info.max_rel_diff, 0)
+
+
+if __name__ == "__main__":
+    common_utils.run_tests()

--- a/test/onnx/exporter/test_verification.py
+++ b/test/onnx/exporter/test_verification.py
@@ -55,11 +55,13 @@ class VerificationInterpreterTest(common_utils.TestCase):
                 c = a + b
                 return c - 1
 
+        model = Model()
         args = (torch.tensor([1.0]), torch.tensor([2.0]))
-        onnx_program = torch.onnx.export(Model(), args, dynamo=True)
+        onnx_program = torch.onnx.export(model, args, dynamo=True, verbose=False)
         assert onnx_program is not None
         interpreter = _verification.VerificationInterpreter(onnx_program)
-        interpreter.run(args)
+        results = interpreter.run(args)
+        torch.testing.assert_close(results, model(*args))
         verification_infos = interpreter.verification_infos
         self.assertEqual(len(verification_infos), 3)
         for info in verification_infos:

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -186,8 +186,10 @@ ONNXProgram(
                 )
         temporary_outputs = [values[name] for name in value_names]
         with _set_graph_outputs(self.model.graph, temporary_outputs):
-            result = self(*args, **kwargs)
-        self.release()
+            try:
+                result = self(*args, **kwargs)
+            finally:
+                self.release()
         return result
 
     @property

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -186,7 +186,9 @@ ONNXProgram(
                 )
         temporary_outputs = [values[name] for name in value_names]
         with _set_graph_outputs(self.model.graph, temporary_outputs):
-            return self(*args, **kwargs)
+            result = self(*args, **kwargs)
+        self.release()
+        return result
 
     @property
     def model_proto(self) -> onnx.ModelProto:

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -140,8 +140,6 @@ ONNXProgram(
         """Run the ONNX model with the same arguments you would provide to the GraphModule."""
         import onnxruntime as ort
 
-        if kwargs is None:
-            kwargs = {}
         flatten_args = _process_args(args, kwargs)
 
         if self._inference_session is None:

--- a/torch/onnx/_internal/exporter/_verification.py
+++ b/torch/onnx/_internal/exporter/_verification.py
@@ -62,8 +62,8 @@ class VerificationInfo:
             [0.0, 1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1, 1.0, 10, 1000000],
             dtype=torch.float,
         )
-        abs_diff_hist = (torch.histogram(abs_diff.float(), bins=bins),)
-        rel_diff_hist = (torch.histogram(rel_diff.float(), bins=bins),)
+        abs_diff_hist = torch.histogram(abs_diff.float(), bins=bins)
+        rel_diff_hist = torch.histogram(rel_diff.float(), bins=bins)
         return cls(
             name=name,
             max_abs_diff=max_abs_diff,

--- a/torch/onnx/_internal/exporter/_verification.py
+++ b/torch/onnx/_internal/exporter/_verification.py
@@ -186,7 +186,10 @@ class VerificationInterpreter(torch.fx.Interpreter):
         if node_name not in self._onnx_values:
             return result
         (onnx_result,) = self._onnx_program.compute_values([node_name], self.args)
-        result_ = torch.tensor(result)
+        if not isinstance(result, torch.Tensor):
+            result_ = torch.tensor(result)
+        else:
+            result_ = result
         max_absolute_difference, max_relative_difference, abs_diff, rel_diff = (
             _compare_tensors(
                 result_,

--- a/torch/onnx/_internal/exporter/_verification.py
+++ b/torch/onnx/_internal/exporter/_verification.py
@@ -146,7 +146,7 @@ class VerificationInterpreter(torch.fx.Interpreter):
                 "The ONNX program does not contain an exported_program. "
                 "Please provide an exported_program to verify the ONNX program."
             )
-        super().__init__(onnx_program.exported_program.graph_module)
+        super().__init__(onnx_program.exported_program.module())
         self._onnx_program = onnx_program
         self._onnx_values = _create_value_mapping(onnx_program.model.graph)
         self.verification_info: list[VerificationInfo] = []
@@ -186,9 +186,10 @@ class VerificationInterpreter(torch.fx.Interpreter):
         if node_name not in self._onnx_values:
             return result
         (onnx_result,) = self._onnx_program.compute_values([node_name], self.args)
+        result_ = torch.tensor(result)
         max_absolute_difference, max_relative_difference, abs_diff, rel_diff = (
             _compare_tensors(
-                result,
+                result_,
                 onnx_result,
             )
         )
@@ -203,7 +204,7 @@ class VerificationInterpreter(torch.fx.Interpreter):
                 max_rel_diff=max_relative_difference,
                 abs_diff_hist=torch.histogram(abs_diff.float(), bins=bins),
                 rel_diff_hist=torch.histogram(rel_diff.float(), bins=bins),
-                expected_dtype=result.dtype,
+                expected_dtype=result_.dtype,
                 actual_dtype=onnx_result.dtype,
             )
         )

--- a/torch/onnx/_internal/exporter/_verification.py
+++ b/torch/onnx/_internal/exporter/_verification.py
@@ -252,10 +252,18 @@ class VerificationInterpreter(torch.fx.Interpreter):
             actual=onnx_result,
         )
         self.verification_infos.append(info)
-        logger.info(
-            "Verification info for node %s: max_abs_diff: %s, max_rel_diff: %s",
-            node_name,
-            info.max_abs_diff,
-            info.max_rel_diff,
-        )
+        if info.max_abs_diff > 0.01 or info.max_rel_diff > 0.1:
+            logger.warning(
+                "Verification info for node %s: max_abs_diff: %s, max_rel_diff: %s",
+                node_name,
+                info.max_abs_diff,
+                info.max_rel_diff,
+            )
+        else:
+            logger.info(
+                "Verification info for node %s: max_abs_diff: %s, max_rel_diff: %s",
+                node_name,
+                info.max_abs_diff,
+                info.max_rel_diff,
+            )
         return result


### PR DESCRIPTION
An fx interpreter for comparing ONNX values with pytorch ones.

```py
import torch
from torch.onnx._internal.exporter._verification import VerificationInterpreter


class Model(torch.nn.Module):
    def forward(self, query, key, value):
        res = torch.nn.functional.scaled_dot_product_attention(
            query, key, value
        )
        rest = res.transpose(0, 1)
        return rest.view(8, 32, 128 * 64)

model = Model()

query = torch.rand(32, 8, 128, 64, dtype=torch.float16)
key = torch.rand(32, 8, 128, 64, dtype=torch.float16)
value = torch.rand(32, 8, 128, 64, dtype=torch.float16)

onnx_program = torch.onnx.export(model, (query, key, value), dynamo=True)
interpreter = VerificationInterpreter(onnx_program)
interpreter.run(query, key, value)
for info in interpreter.verification_infos:
    print(info)
```