### PR TITLE
Disable flake8 advice C416

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -29,7 +29,9 @@ ignore =
     TOR102,
     # TODO(kit1980): resolve all TOR003 issues
     # pass `use_reentrant` explicitly to `checkpoint`.
-    TOR003
+    TOR003,
+    # tuple(generator) is a performance regression
+    C416
 per-file-ignores =
     __init__.py: F401
     test/**: F821

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ ignore = [
     "SIM117",
     "SIM118",
     "UP007", # keep-runtime-typing
+    "C416", # tuple(generator) is a performance regression
 ]
 select = [
     "B",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #148417
* #148416
* #148415
* #148414
* #148413
* #148422
* __->__ #148412

This is not a good suggestion, since it is almost 2x slower:
```
>>> timeit.timeit("tuple(x for x in range(10))")
0.39464114885777235
>>> timeit.timeit("tuple([x for x in range(10)])")
0.21258362499065697
>>>
```