### PR TITLE
[ROCm] Add TF32 option for Flex Attention for gfx90a

### DIFF
--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -13,6 +13,7 @@ import sympy
 
 import torch
 from torch._inductor.virtualized import V
+from torch._inductor.utils import is_tf32_supported
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._pytree import tree_map
 from torch.utils._sympy.numbers import int_oo

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -144,7 +144,7 @@ def get_float32_precision():
 
     # On ROCm benchmark TF32 and FP32 as TF32 (after triton 3.3) as perf is inconsistent
     if torch.version.hip:
-        if is_tf32_supported:
+        if is_tf32_supported():
             return ["'ieee'", "'tf32'"]
         else:
             return ["'ieee'"]
@@ -1475,7 +1475,7 @@ def flex_attention(
                 )
             continue
 
-        for precision in fp32_precision():
+        for precision in fp32_precision:
             cur_kernel_options = original_kernel_options.copy()
             # Performance tuning
             # Triton parameters

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -1334,6 +1334,7 @@ def flex_attention(
         for k, v in kernel_options.items()
     }
 
+    kernel_options.setdefault("FLOAT32_PRECISION", get_float32_precision()[0])
     if _use_flex_decoding(query, kernel_options):
         return create_flex_decoding_kernel(
             query,
@@ -2428,6 +2429,8 @@ def flex_attention_backward(*args, **kwargs):
         else v
         for k, v in kernel_options.items()
     }
+
+    kernel_options.setdefault("FLOAT32_PRECISION", get_float32_precision()[0])
 
     if seq_len_q % 128 != 0 or seq_len_kv % 128 != 0:
         kernel_options.setdefault("IS_DIVISIBLE", False)

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -134,10 +134,22 @@ def maybe_realize(args: list[Optional[IRNode]]):
 
 
 def get_float32_precision():
-    if torch.get_float32_matmul_precision() == "highest" or torch.version.hip:
-        return "'ieee'"
-    else:
-        return "'tf32'"
+    # Return ieee if no GPU is avaiable, or highest precision specified.
+    if (
+        torch.get_float32_matmul_precision() == "highest"
+        or not torch.cuda.is_available()
+    ):
+        return ["'ieee'"]
+
+    # On ROCm benchmark TF32 and FP32 as TF32 (after triton 3.3) as perf is inconsistent
+    if torch.version.hip:
+        if is_tf32_supported:
+            return ["'ieee'", "'tf32'"]
+        else:
+            return ["'ieee'"]
+
+    # Default for NVIDIA environment
+    return ["'tf32'"]
 
 
 def zeros_and_scatter_lowering(shape: list[int], indices, values):
@@ -1320,7 +1332,7 @@ def flex_attention(
         else v
         for k, v in kernel_options.items()
     }
-    kernel_options.setdefault("FLOAT32_PRECISION", get_float32_precision())
+
     if _use_flex_decoding(query, kernel_options):
         return create_flex_decoding_kernel(
             query,
@@ -1441,6 +1453,10 @@ def flex_attention(
         if torch.version.hip:
             configs = [(c[0], c[1], c[2], 1) for c in configs]
 
+    # Get available fp32 precision options. ROCm will return TF32 and FP32 to ensure
+    # that the fastest implementation is chosen.
+    fp32_precision = get_float32_precision()
+
     # Mark SPARSE_KV_BLOCK_SIZE & SPARSE_Q_BLOCK_SIZE as static shapes and add guards.
     SPARSE_KV_BLOCK_SIZE = V.graph.sizevars.evaluate_static_shape(SPARSE_KV_BLOCK_SIZE)
     SPARSE_Q_BLOCK_SIZE = V.graph.sizevars.evaluate_static_shape(SPARSE_Q_BLOCK_SIZE)
@@ -1458,49 +1474,52 @@ def flex_attention(
                 )
             continue
 
-        cur_kernel_options = original_kernel_options.copy()
-        # Performance tuning
-        # Triton parameters
-        # Remove prefix for forward kernels options and delete backward kernel options.
-        for k in list(cur_kernel_options.keys()):
-            if k.startswith("fwd_"):
-                v = cur_kernel_options.pop(k)
-                cur_kernel_options[k[4:]] = v
-            if k.startswith("bwd_"):
-                cur_kernel_options.pop(k)
-        cur_kernel_options.setdefault("num_stages", num_stages)
-        cur_kernel_options.setdefault("num_warps", num_warps)
-        cur_kernel_options.setdefault("BLOCK_M", BLOCK_M)
-        cur_kernel_options.setdefault("BLOCK_N", BLOCK_N)
-        # Blocksparse options
-        cur_kernel_options.setdefault("SPARSE_Q_BLOCK_SIZE", SPARSE_Q_BLOCK_SIZE)
-        cur_kernel_options.setdefault("SPARSE_KV_BLOCK_SIZE", SPARSE_KV_BLOCK_SIZE)
+        for precision in fp32_precision():
+            cur_kernel_options = original_kernel_options.copy()
+            # Performance tuning
+            # Triton parameters
+            # Remove prefix for forward kernels options and delete backward kernel options.
+            for k in list(cur_kernel_options.keys()):
+                if k.startswith("fwd_"):
+                    v = cur_kernel_options.pop(k)
+                    cur_kernel_options[k[4:]] = v
+                if k.startswith("bwd_"):
+                    cur_kernel_options.pop(k)
+            cur_kernel_options.setdefault("num_stages", num_stages)
+            cur_kernel_options.setdefault("num_warps", num_warps)
+            cur_kernel_options.setdefault("BLOCK_M", BLOCK_M)
+            cur_kernel_options.setdefault("BLOCK_N", BLOCK_N)
+            # Blocksparse options
+            cur_kernel_options.setdefault("SPARSE_Q_BLOCK_SIZE", SPARSE_Q_BLOCK_SIZE)
+            cur_kernel_options.setdefault("SPARSE_KV_BLOCK_SIZE", SPARSE_KV_BLOCK_SIZE)
+            # FP32 precision
+            cur_kernel_options["FLOAT32_PRECISION"] = precision
+            error = flex_attention_template.maybe_append_choice(
+                choices=choices,
+                input_nodes=[
+                    query,
+                    key,
+                    value,
+                    logsumexp,
+                    kv_num_blocks,
+                    kv_indices,
+                    full_kv_num_blocks,
+                    full_kv_indices,
+                ],
+                layout=layout,
+                subgraphs=[
+                    subgraph_buffer,
+                    mask_graph_buffer,
+                ],
+                mutated_inputs=[
+                    logsumexp,
+                ],
+                call_sizes=query.get_size(),
+                **cur_kernel_options,
+            )
+            if error is not None and len(configs) == 1:
+                raise error
 
-        error = flex_attention_template.maybe_append_choice(
-            choices=choices,
-            input_nodes=[
-                query,
-                key,
-                value,
-                logsumexp,
-                kv_num_blocks,
-                kv_indices,
-                full_kv_num_blocks,
-                full_kv_indices,
-            ],
-            layout=layout,
-            subgraphs=[
-                subgraph_buffer,
-                mask_graph_buffer,
-            ],
-            mutated_inputs=[
-                logsumexp,
-            ],
-            call_sizes=query.get_size(),
-            **cur_kernel_options,
-        )
-        if error is not None and len(configs) == 1:
-            raise error
     inputs_for_autotuning = (
         [
             query,
@@ -2408,7 +2427,7 @@ def flex_attention_backward(*args, **kwargs):
         else v
         for k, v in kernel_options.items()
     }
-    kernel_options.setdefault("FLOAT32_PRECISION", get_float32_precision())
+
     if seq_len_q % 128 != 0 or seq_len_kv % 128 != 0:
         kernel_options.setdefault("IS_DIVISIBLE", False)
     else:
@@ -2513,6 +2532,10 @@ def flex_attention_backward(*args, **kwargs):
 
     set_head_dim_values(kernel_options, qk_head_dim, v_head_dim, V.graph.sizevars)
 
+    # Get available fp32 precision options. ROCm will return TF32 and FP32 to ensure
+    # that the fastest implementation is chosen.
+    fp32_precision = get_float32_precision()
+
     SPARSE_Q_BLOCK_SIZE = V.graph.sizevars.evaluate_static_shape(SPARSE_Q_BLOCK_SIZE)
     SPARSE_KV_BLOCK_SIZE = V.graph.sizevars.evaluate_static_shape(SPARSE_KV_BLOCK_SIZE)
 
@@ -2541,62 +2564,64 @@ def flex_attention_backward(*args, **kwargs):
         ):
             continue
 
-        # Performance tuning
-        # Triton heuristics
-        cur_kernel_options = original_kernel_options.copy()
-        # Remove prefix for backward kernels options and delete forward kernel options.
-        for k in list(cur_kernel_options.keys()):
-            if k.startswith("bwd_"):
-                v = cur_kernel_options.pop(k)
-                cur_kernel_options[k[4:]] = v
-            if k.startswith("fwd_"):
-                cur_kernel_options.pop(k)
-        cur_kernel_options.setdefault("num_warps", num_warps)
-        cur_kernel_options.setdefault("num_stages", num_stages)
+        for precision in fp32_precision:
+            # Performance tuning
+            # Triton heuristics
+            cur_kernel_options = original_kernel_options.copy()
+            # Remove prefix for backward kernels options and delete forward kernel options.
+            for k in list(cur_kernel_options.keys()):
+                if k.startswith("bwd_"):
+                    v = cur_kernel_options.pop(k)
+                    cur_kernel_options[k[4:]] = v
+                if k.startswith("fwd_"):
+                    cur_kernel_options.pop(k)
+            cur_kernel_options.setdefault("num_warps", num_warps)
+            cur_kernel_options.setdefault("num_stages", num_stages)
 
-        cur_kernel_options.setdefault("BLOCK_M1", BLOCK1)
-        cur_kernel_options.setdefault("BLOCK_N1", BLOCK2)
-        cur_kernel_options.setdefault("BLOCK_M2", BLOCK2)
-        cur_kernel_options.setdefault("BLOCK_N2", BLOCK1)
-        # Blocksparse options
-        cur_kernel_options.setdefault("SPARSE_Q_BLOCK_SIZE", SPARSE_Q_BLOCK_SIZE)
-        cur_kernel_options.setdefault("SPARSE_KV_BLOCK_SIZE", SPARSE_KV_BLOCK_SIZE)
-
-        flex_attention_backward_template.maybe_append_choice(
-            choices=choices,
-            input_nodes=[
-                query,
-                key,
-                value,
-                logsumexp,
-                delta,
-                grad_out,
-                grad_query,
-                broadcasted_grad_value,
-                kv_num_blocks,
-                kv_indices,
-                q_num_blocks,
-                q_indices,
-                full_kv_num_blocks,
-                full_kv_indices,
-                full_q_num_blocks,
-                full_q_indices,
-            ],
-            layout=layout_broadcasted_k,  # We use store_output only for grad_key
-            subgraphs=[
-                fw_subgraph_buffer,
-                joint_outputs.grad_input,
-                mask_graph_buffer,
-                joint_outputs.captured_grads_compute,
-            ],
-            mutated_inputs=[
-                grad_query,
-                broadcasted_grad_value,
-                *joint_outputs.mutated_grads,
-            ],
-            call_sizes=query.get_size() + key.get_size()[1:3],
-            **cur_kernel_options,
-        )
+            cur_kernel_options.setdefault("BLOCK_M1", BLOCK1)
+            cur_kernel_options.setdefault("BLOCK_N1", BLOCK2)
+            cur_kernel_options.setdefault("BLOCK_M2", BLOCK2)
+            cur_kernel_options.setdefault("BLOCK_N2", BLOCK1)
+            # Blocksparse options
+            cur_kernel_options.setdefault("SPARSE_Q_BLOCK_SIZE", SPARSE_Q_BLOCK_SIZE)
+            cur_kernel_options.setdefault("SPARSE_KV_BLOCK_SIZE", SPARSE_KV_BLOCK_SIZE)
+            # FP32 Precision
+            cur_kernel_options["FLOAT32_PRECISION"] = precision
+            flex_attention_backward_template.maybe_append_choice(
+                choices=choices,
+                input_nodes=[
+                    query,
+                    key,
+                    value,
+                    logsumexp,
+                    delta,
+                    grad_out,
+                    grad_query,
+                    broadcasted_grad_value,
+                    kv_num_blocks,
+                    kv_indices,
+                    q_num_blocks,
+                    q_indices,
+                    full_kv_num_blocks,
+                    full_kv_indices,
+                    full_q_num_blocks,
+                    full_q_indices,
+                ],
+                layout=layout_broadcasted_k,  # We use store_output only for grad_key
+                subgraphs=[
+                    fw_subgraph_buffer,
+                    joint_outputs.grad_input,
+                    mask_graph_buffer,
+                    joint_outputs.captured_grads_compute,
+                ],
+                mutated_inputs=[
+                    grad_query,
+                    broadcasted_grad_value,
+                    *joint_outputs.mutated_grads,
+                ],
+                call_sizes=query.get_size() + key.get_size()[1:3],
+                **cur_kernel_options,
+            )
     inputs_for_autotuning = (
         [
             query,

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1844,6 +1844,23 @@ def is_welford_reduction(reduction_type: str) -> bool:
     return reduction_type.startswith("welford")
 
 
+@functools.lru_cache(None)
+def is_tf32_supported() -> bool:
+    import triton
+
+    if not torch.version.hip:
+        return True
+    else:
+        gcn_arch = str(torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0])
+        if "gfx90a" not in gcn_arch:
+            return False
+        triton_version = tuple(int(v) for v in triton.__version__.split("."))
+        if triton_version < (3, 3, 0):
+            return False
+        else:
+            return True
+
+
 def reduction_num_outputs(reduction_type: str) -> int:
     return 3 if is_welford_reduction(reduction_type) else 1
 


### PR DESCRIPTION
Add TF32 option for flex attention kernels, performance doesn't seem to always be better so we will add this as an autotuning option.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov