### PR TITLE
[ROCm] Incorporate ROCm triton specific tuning parameters

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -643,6 +643,8 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         num_stages: int,
         num_warps: int,
         matrix_instr_nonkdim: int = 0,  # only used for hip to choose the shape of mfma instruction.
+        waves_per_eu: int = 0,  # only used for hip to schedule waves per execution unit
+        kpack: int = 0,  # ROCm specific gemm paramete
         workspace_arg: Optional[WorkspaceArg] = None,
     ) -> None:
         super().__init__(kernel_name, input_tensor_meta, output_tensor_meta, extra_args)
@@ -652,6 +654,8 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         self.num_stages = num_stages
         self.num_warps = num_warps
         self.matrix_instr_nonkdim = matrix_instr_nonkdim
+        self.waves_per_eu = waves_per_eu
+        self.kpack = kpack
         self.workspace_arg = workspace_arg
 
     def make_run_fn(

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -1449,6 +1449,10 @@ def flex_attention(
     SPARSE_KV_BLOCK_SIZE = V.graph.sizevars.evaluate_static_shape(SPARSE_KV_BLOCK_SIZE)
     SPARSE_Q_BLOCK_SIZE = V.graph.sizevars.evaluate_static_shape(SPARSE_Q_BLOCK_SIZE)
 
+    # ROCm specific considerations
+    if torch.version.hip:
+        kernel_options["kpack"] = 2
+
     # Note, we don't need to pass in the captured buffers explicitly
     # because they're implicitly added by the score_mod function
     # We do need to explicitly pass it in for autotuning though.

--- a/torch/_inductor/kernel/flex_decoding.py
+++ b/torch/_inductor/kernel/flex_decoding.py
@@ -519,6 +519,10 @@ def create_flex_decoding_kernel(*args, **kwargs):
     # Mark SPARSE_KV_BLOCK_SIZE as static shapes and add guards.
     SPARSE_KV_BLOCK_SIZE = V.graph.sizevars.evaluate_static_shape(SPARSE_KV_BLOCK_SIZE)
 
+    # ROCm specific considerations
+    if torch.version.hip:
+        kernel_options["kpack"] = 2
+
     original_kernel_options = kernel_options.copy()
     # Note, we don't need to pass in the captured buffers explicitly
     # because they're implicitly added by the score_mod function

--- a/torch/_inductor/kernel/flex_decoding.py
+++ b/torch/_inductor/kernel/flex_decoding.py
@@ -519,10 +519,6 @@ def create_flex_decoding_kernel(*args, **kwargs):
     # Mark SPARSE_KV_BLOCK_SIZE as static shapes and add guards.
     SPARSE_KV_BLOCK_SIZE = V.graph.sizevars.evaluate_static_shape(SPARSE_KV_BLOCK_SIZE)
 
-    # ROCm specific considerations
-    if torch.version.hip:
-        kernel_options["kpack"] = 2
-
     original_kernel_options = kernel_options.copy()
     # Note, we don't need to pass in the captured buffers explicitly
     # because they're implicitly added by the score_mod function

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -111,10 +111,7 @@ def filtered_configs(
                     #  block_m and block_n must be a multiple of matrix_instr_nonkdim
                     kpack = 1
                     continue
-                
-                # Hit numerical issue when block_k = 16, kpack = 2
-                if block_k == 16:
-                    kpack = 1
+
                 if (
                     block_m,
                     block_n,

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -109,7 +109,6 @@ def filtered_configs(
                     or block_n % matrix_instr_nonkdim != 0
                 ):
                     #  block_m and block_n must be a multiple of matrix_instr_nonkdim
-                    kpack = 1
                     continue
 
                 if (

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -89,7 +89,7 @@ def filtered_configs(
         ),
         min_block_size_k,
     )
-    used = OrderedSet[tuple[int, int, int, int, int, int]]()
+    used = OrderedSet[tuple[int, ...]]()
     for block_m, block_n, block_k, num_stages, num_warps in configs:
         # shrink configs for small sizes
         block_m = max(min(int(block_m * scale), m), min_block_size)
@@ -119,6 +119,7 @@ def filtered_configs(
                     num_stages,
                     num_warps,
                     matrix_instr_nonkdim,
+                    kpack,
                 ) not in used and (
                     max_mm_configs is None or len(used) < max_mm_configs
                 ):

--- a/torch/_inductor/runtime/coordinate_descent_tuner.py
+++ b/torch/_inductor/runtime/coordinate_descent_tuner.py
@@ -20,6 +20,8 @@ def get_field(config, name):
         return config.num_warps
     elif name == "num_stages":
         return config.num_stages
+    elif name == "waves_per_eu":
+        return config.kwargs.get(name, int(8 // config.num_warps)
     else:
         return config.kwargs.get(name, None)
 
@@ -97,6 +99,8 @@ class CoordescTuner:
         ]
         if self.is_mm:
             out.append("num_stages")
+        if self.inductor_meta.get("is_hip") is True:
+            out.append("waves_per_eu")
 
         return out
 
@@ -107,7 +111,9 @@ class CoordescTuner:
             return val > self.get_config_max(prefix)
         if name == "num_warps":
             return val > self.get_warpsmax()
-
+        if name == "waves_per_eu":
+            return val > 8
+        
         return False
 
     def get_neighbour_values(self, name, orig_val, radius=1, include_self=False):

--- a/torch/_inductor/runtime/coordinate_descent_tuner.py
+++ b/torch/_inductor/runtime/coordinate_descent_tuner.py
@@ -21,7 +21,7 @@ def get_field(config, name):
     elif name == "num_stages":
         return config.num_stages
     elif name == "waves_per_eu":
-        return config.kwargs.get(name, int(8 // config.num_warps)
+        return config.kwargs.get(name, int(8 // config.num_warps))
     else:
         return config.kwargs.get(name, None)
 
@@ -113,7 +113,7 @@ class CoordescTuner:
             return val > self.get_warpsmax()
         if name == "waves_per_eu":
             return val > 8
-        
+
         return False
 
     def get_neighbour_values(self, name, orig_val, radius=1, include_self=False):

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1333,27 +1333,14 @@ class TritonTemplateCaller(ir.TritonTemplateCallerBase):
         if log_info is None:
             log_info = {}
         self.log_info: dict[str, Any] = log_info
-        if torch.version.hip is None:
-            self.log_info.update(
-                {
-                    "backend": "Triton",
-                    "grid": str(self.bmreq.grid),
-                    "num_stages": self.bmreq.num_stages,
-                    "num_warps": self.bmreq.num_warps,
-                }
-            )
-        else:
-            self.log_info.update(
-                {
-                    "backend": "Triton",
-                    "grid": str(self.bmreq.grid),
-                    "num_stages": self.bmreq.num_stages,
-                    "num_warps": self.bmreq.num_warps,
-                    "matrix_instr_nonkdim": self.bmreq.matrix_instr_nonkdim,
-                    "waves_per_eu": self.bmreq.waves_per_eu,
-                    "kpack": self.bmreq.kpack,
-                }
-            )
+        self.log_info.update(
+            {
+                "backend": "Triton",
+                "grid": str(self.bmreq.grid),
+                "num_stages": self.bmreq.num_stages,
+                "num_warps": self.bmreq.num_warps,
+            }
+        )
         self.mutated_inputs = mutated_inputs
         self.workspace_arg = workspace_arg
         self.allowed_prologue_inps = (


### PR DESCRIPTION
Splitting https://github.com/pytorch/pytorch/pull/147315 into two PRs. This PR adds general support for kpack and waves_per_eu triton kernel args for AMD backend. More detail in the PR above.

A follow up PR will update the configs used by ROCm but this requires https://github.com/pytorch/pytorch/pull/147452 to land first

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov