### PR TITLE
Let `CUDAExtension` to find stub libs

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1468,6 +1468,8 @@ def library_paths(device_type: str = "cpu") -> list[str]:
                 # _find_cuda_home) - in that case we stay with 'lib64'.
                 lib_dir = 'lib'
 
+        if os.path.exists(_join_cuda_home(lib_dir, "stubs")):
+            paths.append(_join_cuda_home(lib_dir, "stubs"))
         paths.append(_join_cuda_home(lib_dir))
         if CUDNN_HOME is not None:
             paths.append(os.path.join(CUDNN_HOME, lib_dir))


### PR DESCRIPTION
Fixes: https://github.com/sgl-project/sglang/issues/4060

CUDA runtime sometimes provides stub libs rather than "real" libs (e.g. https://stackoverflow.com/questions/76988911/what-should-i-link-against-the-actual-cuda-driver-library-or-the-driver-library).

Currently `CUDAExtension` do not search for them so it may fail in some cases, e.g. https://github.com/sgl-project/sglang/issues/4060

This PR fixes it.