### PR TITLE
[ONNX] Use onnxscript apis for 2.7

### DIFF
--- a/torch/onnx/_internal/_exporter_legacy.py
+++ b/torch/onnx/_internal/_exporter_legacy.py
@@ -30,7 +30,7 @@ from torch.onnx import errors
 from torch.onnx._internal import io_adapter
 from torch.onnx._internal._lazy_import import onnxscript_apis, onnxscript_ir as ir
 from torch.onnx._internal.diagnostics import infra
-from torch.onnx._internal.exporter import _onnx_program
+from torch.onnx._internal.exporter import _constants, _onnx_program
 from torch.onnx._internal.fx import (
     decomposition_table,
     patcher as patcher,
@@ -105,7 +105,7 @@ class OnnxRegistry:
             defaultdict(list)
         )
 
-        self._opset_version = onnxscript_apis.torchlib_opset_version()
+        self._opset_version = _constants.TORCHLIB_OPSET
         warnings.warn(
             f"torch.onnx.dynamo_export only implements opset version {self._opset_version} for now. If you need to use a "
             "different opset version, please register them with register_custom_op."

--- a/torch/onnx/_internal/_lazy_import.py
+++ b/torch/onnx/_internal/_lazy_import.py
@@ -29,7 +29,7 @@ class _LazyModule:
 if TYPE_CHECKING:
     import onnx
     import onnxscript
-    import onnxscript._framework_apis.torch_2_6 as onnxscript_apis
+    import onnxscript._framework_apis.torch_2_7 as onnxscript_apis
 
     onnxscript_ir = onnxscript.ir
 
@@ -37,4 +37,4 @@ else:
     onnx = _LazyModule("onnx")
     onnxscript = _LazyModule("onnxscript")
     onnxscript_ir = _LazyModule("onnxscript.ir")
-    onnxscript_apis = _LazyModule("onnxscript._framework_apis.torch_2_6")
+    onnxscript_apis = _LazyModule("onnxscript._framework_apis.torch_2_7")

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, TYPE_CHECKING
 import torch
 from torch.onnx._internal._lazy_import import onnxscript_apis, onnxscript_ir as ir
 from torch.onnx._internal.exporter import (
+    _constants,
     _core,
     _dynamic_shapes,
     _onnx_program,
@@ -67,7 +68,7 @@ def export_compat(
     fallback: bool = False,
 ) -> _onnx_program.ONNXProgram:
     if opset_version is None:
-        opset_version = onnxscript_apis.torchlib_opset_version()
+        opset_version = _constants.TORCHLIB_OPSET
 
     if isinstance(model, torch.export.ExportedProgram):
         # We know the model is already exported program, so the args, kwargs, and dynamic_shapes

--- a/torch/onnx/_internal/exporter/_registration.py
+++ b/torch/onnx/_internal/exporter/_registration.py
@@ -24,7 +24,7 @@ from typing_extensions import TypeAlias
 import torch
 import torch._ops
 from torch.onnx._internal._lazy_import import onnxscript, onnxscript_apis
-from torch.onnx._internal.exporter import _schemas
+from torch.onnx._internal.exporter import _constants, _schemas
 from torch.onnx._internal.exporter._torchlib import _torchlib_registry
 
 
@@ -141,7 +141,7 @@ class ONNXRegistry:
 
     def __init__(self) -> None:
         """Initializes the registry"""
-        self._opset_version = onnxscript_apis.torchlib_opset_version()
+        self._opset_version = _constants.TORCHLIB_OPSET
         self.functions: dict[TorchOp | str, list[OnnxDecompMeta]] = {}
 
     @property


### PR DESCRIPTION
Use onnxscript apis for 2.7.

Remove reference to `torchlib_opset()` and `torchlib_opset_version()` which were removed in the onnxscript 2.7 apis. These apis were removed because torchlib in onnxscript will always stay on opset 18. Future opset version bumps will happen in pytorch core after the migration of torchlib.
