### PR TITLE
[PP] RFC for fixing microbatch splitting for dim != 0

### DIFF
--- a/torch/distributed/pipelining/_utils.py
+++ b/torch/distributed/pipelining/_utils.py
@@ -67,10 +67,6 @@ def validate_tensor_metadata(desc, expected, given):
         raise PipeliningShapeError(
             f"{desc} has a dtype mismatch: expected {expected.dtype} actual {given.dtype}"
         )
-    if not expected.stride() == given.stride():
-        raise PipeliningShapeError(
-            f"{desc} has a stride mismatch: expected {expected.stride()} actual {given.stride()}"
-        )
 
 
 def validate_tensors_metadata(

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -504,7 +504,13 @@ or equal to the number of stages ({self._num_stages})."
 
         # Split target into microbatches
         if target is not None:
-            targets_split = list(torch.tensor_split(target, self._n_microbatches))
+            if self._args_chunk_spec is not None:
+                dim = self._args_chunk_spec[0].split_dim
+            else:
+                dim = 0
+            targets_split = list(
+                torch.tensor_split(target, self._n_microbatches, dim=dim)
+            )
         else:
             targets_split = None
 
@@ -1237,6 +1243,13 @@ class PipelineScheduleMulti(_PipelineSchedule):
         # Split target into microbatches
         if target is not None:
             targets_split = list(torch.tensor_split(target, self._n_microbatches))
+            if self._args_chunk_spec is not None:
+                dim = self._args_chunk_spec[0].split_dim
+            else:
+                dim = 0
+            targets_split = list(
+                torch.tensor_split(target, self._n_microbatches, dim=dim)
+            )
         else:
             targets_split = None
 


### PR DESCRIPTION
There are two issues when we perform the microbatch splitting in `PipelineSchedule.step()` only arise when we don't use the default (split on dim=0):

1) The check for valid tensor stride will fail. We use `tensor_split()` which creates a view of the original tensor and does not update the stride. We could make each of these microbatches `contiguous()` which would update its stride at the cost of copying the input tensor, but i opted to just remove the check.
2) We don't have a way of splitting the `target`, the splitting for it always defaults to dim=0.

I added two of the easiest solutions, but open to discussion. Not sure if it is worth it to add a new argument into `Schedule` to control how target should be split.

cc @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o

cc @lessw2020 