### PR TITLE
ci: Consolidate commit hash updates into a matrix

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,7 +72,7 @@ jobs:
             pin-folder: .ci/docker/ci_commit_pins
     if: ${{ github.event_name == 'schedule' && github.repository_owner == 'pytorch' }}
     steps:
-      - name: update-vision-commit-hash
+      - name: "${{ matrix.repo-owner }}/${{ matrix.repo-name }} update-commit-hash"
         uses: pytorch/test-infra/.github/actions/update-commit-hash@main
         with:
           repo-owner: ${{ matrix.repo-owner }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,47 +52,32 @@ jobs:
     secrets:
       GH_PYTORCHBOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
 
-  update-vision-commit-hash:
+  update-commit-hashes:
     runs-on: ubuntu-latest
     environment: update-commit-hash
+    strategy:
+      matrix:
+        include:
+          - repo-name: vision
+            repo-owner: pytorch
+            branch: main
+            pin-folder: .github/ci_commit_pins
+          - repo-name: audio
+            repo-owner: pytorch
+            branch: main
+            pin-folder: .github/ci_commit_pins
+          - repo-name: executorch
+            repo-owner: pytorch
+            branch: main
+            pin-folder: .ci/docker/ci_commit_pins
     if: ${{ github.event_name == 'schedule' && github.repository_owner == 'pytorch' }}
     steps:
       - name: update-vision-commit-hash
         uses: pytorch/test-infra/.github/actions/update-commit-hash@main
         with:
-          repo-name: vision
-          branch: main
-          pin-folder: .github/ci_commit_pins
-          test-infra-ref: main
-          updatebot-token: ${{ secrets.UPDATEBOT_TOKEN }}
-          pytorchbot-token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-
-  update-audio-commit-hash:
-    runs-on: ubuntu-latest
-    environment: update-commit-hash
-    if: ${{ github.event_name == 'schedule' && github.repository_owner == 'pytorch' }}
-    steps:
-      - name: update-audio-commit-hash
-        uses: pytorch/test-infra/.github/actions/update-commit-hash@main
-        with:
-          repo-name: audio
-          branch: main
-          pin-folder: .github/ci_commit_pins
-          test-infra-ref: main
-          updatebot-token: ${{ secrets.UPDATEBOT_TOKEN }}
-          pytorchbot-token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-
-  update-executorch-commit-hash:
-    runs-on: ubuntu-latest
-    environment: update-commit-hash
-    if: ${{ github.event_name == 'schedule' && github.repository_owner == 'pytorch' }}
-    steps:
-      - name: update-executorch-commit-hash
-        uses: pytorch/test-infra/.github/actions/update-commit-hash@main
-        with:
-          repo-name: executorch
-          branch: main
-          pin-folder: .ci/docker/ci_commit_pins
-          test-infra-ref: main
+          repo-owner: {{ matrix.repo-owner }}
+          repo-name: {{ matrix.repo-name }}
+          branch: {{ matrix.branch }}
+          pin-folder: {{ matrix.pin-folder}}
           updatebot-token: ${{ secrets.UPDATEBOT_TOKEN }}
           pytorchbot-token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,9 +75,9 @@ jobs:
       - name: update-vision-commit-hash
         uses: pytorch/test-infra/.github/actions/update-commit-hash@main
         with:
-          repo-owner: {{ matrix.repo-owner }}
-          repo-name: {{ matrix.repo-name }}
-          branch: {{ matrix.branch }}
-          pin-folder: {{ matrix.pin-folder}}
+          repo-owner: ${{ matrix.repo-owner }}
+          repo-name: ${{ matrix.repo-name }}
+          branch: ${{ matrix.branch }}
+          pin-folder: ${{ matrix.pin-folder}}
           updatebot-token: ${{ secrets.UPDATEBOT_TOKEN }}
           pytorchbot-token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,7 +72,7 @@ jobs:
             pin-folder: .ci/docker/ci_commit_pins
     if: ${{ github.event_name == 'schedule' && github.repository_owner == 'pytorch' }}
     steps:
-      - name: "${{ matrix.repo-owner }}/${{ matrix.repo-name }} update-commit-hash"
+      - name: update-vision-commit-hash
         uses: pytorch/test-infra/.github/actions/update-commit-hash@main
         with:
           repo-owner: ${{ matrix.repo-owner }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #148486
* #148472
* __->__ #148466

Consolidates all of our commit hash update jobs into a single matrix to
make it easier to add more jobs later on.

Side note: How do I even test if this works?

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>