### PR TITLE
[MPS][BE] Fix `c10::metal::sinc` implementation

### DIFF
--- a/aten/src/ATen/native/mps/kernels/UnaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/UnaryKernel.metal
@@ -58,16 +58,12 @@ struct tanh_functor {
 
 struct sinc_functor {
   template <typename T>
-  inline enable_if_t<is_scalar_floating_point_v<T>, T> operator()(const T x) {
-    return T(sinc(static_cast<float>(x)));
+  inline enable_if_t<is_floating_point_v<T>, T> operator()(const T x) {
+    return sinc(x);
   }
   template <typename T>
   inline enable_if_t<is_scalar_integral_v<T>, float> operator()(const T x) {
     return sinc(static_cast<float>(x));
-  }
-  template <typename T>
-  inline enable_if_t<is_complex_v<T>, T> operator()(const T x) {
-    return T(sinc(static_cast<float2>(x)));
   }
 };
 

--- a/c10/metal/special_math.h
+++ b/c10/metal/special_math.h
@@ -1,5 +1,6 @@
 // Implementation of specal math functions for Metal
 #pragma once
+#include <c10/metal/utils.h>
 #include <metal_stdlib>
 
 namespace c10 {
@@ -452,18 +453,18 @@ inline float digamma(T0 x) {
 }
 
 template <typename T>
-inline T sinc(T a) {
+inline ::metal::enable_if_t<is_scalar_floating_point_v<T>, T> sinc(T a) {
   if (a == static_cast<T>(0)) {
     return static_cast<T>(1);
   }
-  constexpr T pi = static_cast<T>(M_PI_F);
-  T product = pi * a;
-  return static_cast<T>(::metal::sin(product) / product);
+  auto product = M_PI_F * float(a);
+  return static_cast<T>(::metal::precise::sin(product) / product);
 }
 
 // Complex sinc2 implementation
-inline float2 sinc(float2 inp) {
-  float2 a = inp * M_PI_F;
+template <typename T>
+inline ::metal::enable_if_t<is_complex_v<T>, T> sinc(T inp) {
+  auto a = float2(inp) * M_PI_F;
   const float a2 = a.x * a.x + a.y * a.y;
   if (a2 == 0) {
     return 0;
@@ -474,7 +475,7 @@ inline float2 sinc(float2 inp) {
   float coshy = ::metal::cosh(a.y);
   auto re = sinx * coshy * a.x + cosx * sinhy * a.y;
   auto im = cosx * sinhy * a.x - sinx * coshy * a.y;
-  return float2(re, im) / a2;
+  return T(re, im) / a2;
 }
 
 template <typename T>

--- a/c10/metal/special_math.h
+++ b/c10/metal/special_math.h
@@ -457,14 +457,14 @@ inline ::metal::enable_if_t<is_scalar_floating_point_v<T>, T> sinc(T a) {
   if (a == static_cast<T>(0)) {
     return static_cast<T>(1);
   }
-  auto product = M_PI_F * float(a);
+  auto product = M_PI_F * static_cast<float>(a);
   return static_cast<T>(::metal::precise::sin(product) / product);
 }
 
 // Complex sinc2 implementation
 template <typename T>
 inline ::metal::enable_if_t<is_complex_v<T>, T> sinc(T inp) {
-  auto a = float2(inp) * M_PI_F;
+  auto a = static_cast<float2>(inp) * M_PI_F;
   const float a2 = a.x * a.x + a.y * a.y;
   if (a2 == 0) {
     return 0;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #148468
* __->__ #148471

Restrict scalar implementation to `is_scalar_floating_point_v` types, but perform all internal computations in full 32-bit floats. Make complex implementation a template for `is_complex_v` types
This makes its eager kernel implementation for both real and complex type a trivial call to the template