### PR TITLE
ci: Add triton to update hash workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,6 +70,10 @@ jobs:
             repo-owner: pytorch
             branch: main
             pin-folder: .ci/docker/ci_commit_pins
+          - repo-name: triton
+            repo-owner: openai
+            branch: main
+            pin-folder: .ci/docker/ci_commit_pins
     if: ${{ github.event_name == 'schedule' && github.repository_owner == 'pytorch' }}
     steps:
       - name: update-vision-commit-hash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -71,7 +71,7 @@ jobs:
             branch: main
             pin-folder: .ci/docker/ci_commit_pins
           - repo-name: triton
-            repo-owner: openai
+            repo-owner: triton-lang
             branch: main
             pin-folder: .ci/docker/ci_commit_pins
     if: ${{ github.event_name == 'schedule' && github.repository_owner == 'pytorch' }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #148486
* __->__ #148472
* #148466

Adds triton to our auto-update workflows so that PRs can be
automatically made and the triton team can follow up to fix any issues
that may arise.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>