### PR TITLE
ci: Add workflow dispatch for commit hash update

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,9 +74,10 @@ jobs:
             repo-owner: triton-lang
             branch: main
             pin-folder: .ci/docker/ci_commit_pins
-    if: ${{ github.event_name == 'schedule' && github.repository_owner == 'pytorch' }}
+    # Allow this to be triggered on either a schedule or on workflow_dispatch to allow for easier testing
+    if: github.repository_owner == 'pytorch' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     steps:
-      - name: update-vision-commit-hash
+      - name: "${{ matrix.repo-owner }}/${{ matrix.repo-name }} update-commit-hash"
         uses: pytorch/test-infra/.github/actions/update-commit-hash@main
         with:
           repo-owner: ${{ matrix.repo-owner }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148486
* #148472
* #148466

Maybe this should also be split into its own workflow instead of piggy
backing off of nightly?

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>