### PR TITLE
Disable some SVE autovec 

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -206,6 +206,9 @@ public:
     Vectorized vector;
     int_same_size_t<T> buffer[size()];
     mask.store(buffer);
+#if defined(__clang__) && __ARM_FEATURE_SVE
+    #pragma clang loop vectorize(disable)
+#endif
     for (const auto i : c10::irange(size())) {
       if (buffer[i] & 0x01)
        {


### PR DESCRIPTION
Summary: autovec miscompiles on patterns of the type: 
```cpp
for (const auto i : c10::irange())
```
Same issue as described in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117001 and addressed by https://github.com/pytorch/pytorch/pull/137795 for gcc, but not clang

Test Plan:
buck2 build //caffe2/caffe2/fb/transforms:sigrid_interface

Differential Revision: D70422723




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @malfet @snadampal @milpuz01