### PR TITLE
[cutlass backend][BE] Fix two small things in cutlass backend standalone debugger

### DIFF
--- a/torch/_inductor/codegen/cuda/gemm_template.py
+++ b/torch/_inductor/codegen/cuda/gemm_template.py
@@ -304,7 +304,7 @@ bool initialize_block(
   if (block.size()<=0) return false;
   Element scope_max(static_cast<Element>(max)), scope_min(static_cast<Element>(min));
   cutlass::reference::device::BlockFillRandomUniform(
-    (Element*)block.get(), block.size(), seed, scope_max, scope_min, 0);
+    (Element*)block.get(), block.size(), seed, scope_max, scope_min);
 
   return true;
 }
@@ -1310,6 +1310,9 @@ class CUTLASS3xGemmTemplate(CUTLASSGemmTemplate):
     ) -> list[str]:
         if input_nodes[2] is None:
             del arg_names[2]
+        else:
+            # Reorder them as Bias, A, B
+            arg_names[0:3] = [arg_names[2], arg_names[0], arg_names[1]]
         return arg_names
 
     def render_gemm_arguments(

--- a/torch/_inductor/codegen/cuda/gemm_template.py
+++ b/torch/_inductor/codegen/cuda/gemm_template.py
@@ -1313,7 +1313,7 @@ class CUTLASS3xGemmTemplate(CUTLASSGemmTemplate):
         else:
             # Reorder them as Bias, A, B
             if self.input_reorder is not None:
-                arg_names[0:len(self.input_reorder)] = [
+                arg_names[0 : len(self.input_reorder)] = [
                     arg_names[i] for i in self.input_reorder
                 ]
         return arg_names

--- a/torch/_inductor/codegen/cuda/gemm_template.py
+++ b/torch/_inductor/codegen/cuda/gemm_template.py
@@ -1312,7 +1312,10 @@ class CUTLASS3xGemmTemplate(CUTLASSGemmTemplate):
             del arg_names[2]
         else:
             # Reorder them as Bias, A, B
-            arg_names[0:3] = [arg_names[2], arg_names[0], arg_names[1]]
+            if self.input_reorder is not None:
+                arg_names[0:len(self.input_reorder)] = [
+                    arg_names[i] for i in self.input_reorder
+                ]
         return arg_names
 
     def render_gemm_arguments(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148493

Differential Revision: [D70583777](https://our.internmc.facebook.com/intern/diff/D70583777/)

Two really small things: 
* The bits in BlockFillRandomUniform would round float to ints
* when bias exists, the order of args are C, A, B, D

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov