### PR TITLE
[ROCm] fix CK compile for gfx1200

### DIFF
--- a/aten/src/ATen/native/hip/ck_types.h
+++ b/aten/src/ATen/native/hip/ck_types.h
@@ -6,6 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// work around CK assuming only a single FP8 interpretation at a time
+#if(defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)) && __HIP_DEVICE_COMPILE__
+#define CK_USE_FNUZ_FP8 1
+#undef CK_USE_OCP_FP8
+#elif __HIP_DEVICE_COMPILE__
+#undef CK_USE_FNUZ_FP8
+#define CK_USE_OCP_FP8 1
+#endif
+
 #include <ATen/ATen.h>
 #include <ck/ck.hpp>
 #include <ck/tensor_operation/gpu/device/tensor_layout.hpp>


### PR DESCRIPTION
gfx1200 causes the CK-based GEMM to fail to compile because CK is choosing an incorrect FP8 interpretation.  CK assumes FP8 interpretation is static and chosen prior to compilation.  This PR is a work-around that makes the selection dynamic during hipclang compilation passes.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd