### PR TITLE
Implement fast access to individual elements of jagged nested tensors

### DIFF
--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -1797,11 +1797,12 @@ def select_int(func, *args, **kwargs):
         index = new_kwargs["index"]
         begin, end = inp._offsets[[index, index+1]]
         if inp._lengths is not None:
-            # if the tensor has a hole, we must include the size of the jagged dim for this element
-            index_len = inp._lengths[index]
-            return inp._values[begin:end, :index_len]
+            length = inp._lengths[index]
+        else:
+            length = end - begin
         # if tensor has no holes, we can just select from the start and end pos
-        return inp._values[begin:end]
+        return inp._values.narrow(inp._ragged_idx - 1, begin, length)
+#        return inp._values[begin:end]
 
     if inp._lengths is not None:
         raise ValueError(

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -1795,12 +1795,34 @@ def select_int(func, *args, **kwargs):
 
     if operating_on_batch:
         index = new_kwargs["index"]
-        begin, end = inp._offsets[[index, index+1]]
+        begin, end = inp._offsets.narrow(0, index, 2)
+        size = inp._values.size(inp._ragged_idx - 1)
+        begin = begin.item()
+        end = end.item()
+#        torch._check_is_size(begin)
+#        torch._check_is_size(end)
+        torch._check(begin >= 0)
+        torch._check(begin < size)
         if inp._lengths is not None:
-            length = inp._lengths[index]
+            length = inp._lengths[index].item()
+            torch._check(length >= 0)
+            torch._check(begin + length < size)
+            torch._check(begin < size)
+#            torch._check_is_size(begin + length)
         else:
+            torch._check(begin >= 0)
+            torch._check(end >= 0)
+            torch._check(end >= begin)
+            torch._check(end < size)
             length = end - begin
+            torch._check(length >= 0)
+            torch._check(begin + length == end)
+            torch._check(begin + length < size)
+            torch._check(end - length == begin)
+            torch._check(end - length < size)
         # if tensor has no holes, we can just select from the start and end pos
+        torch._check_is_size(begin)
+        torch._check_is_size(length)
         return inp._values.narrow(inp._ragged_idx - 1, begin, length)
 #        return inp._values[begin:end]
 

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -1796,7 +1796,7 @@ def select_int(func, *args, **kwargs):
     if operating_on_batch:
         index = new_kwargs["index"]
         size = inp._values.size(inp._ragged_idx - 1)
-        if size <= 1:
+        if inp.size(new_kwargs["dim"]) == 1:
             # i think this shortcut is necessary:
             # when adding the guards below, test_compile_backward_select will
             # try to guard (or rather test?) on the following


### PR DESCRIPTION
I removed the dependency on `tensor.unbind()` discussed in #148379 and replaced it with basic indexing ops on the values tensor based on the inputs.

Feedback would greatly be appreciated, I am not sure i got the part with the lengths right - wasnt able to find a lot of documentation on jagged tensors, I hope I understood `NestedTensor._lengths` correctly

Fixes #148379
