### PR TITLE
Fix only logging ir_post_fusion with torch_compile_debug enabled

### DIFF
--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -526,14 +526,15 @@ class DebugFormatter:
             fd.write(gm.print_readable(print_output=False))
 
     def ir_pre_fusion(self, nodes: SchedulerNodeList) -> None:
-        if ir_pre_fusion_log.isEnabledFor(logging.INFO):
-            ir_pre_fusion_log.info("BEFORE FUSION\n%s", self._write_ir(nodes))
+        with self.fopen("ir_pre_fusion.txt") as fd:
+            fd.write(self._write_ir(nodes))
 
     def ir_post_fusion(self, nodes: SchedulerNodeList) -> None:
-        if ir_post_fusion_log.isEnabledFor(logging.INFO):
-            ir_post_fusion_log.info("AFTER FUSION\n%s", self._write_ir(nodes))
+        with self.fopen("ir_post_fusion.txt") as fd:
+            fd.write(self._write_ir(nodes))
 
-    def _write_ir(self, nodes: SchedulerNodeList) -> str:
+    @staticmethod
+    def _write_ir(nodes: SchedulerNodeList) -> str:
         buf = io.StringIO()
         for node in nodes:
             buf.write(node.debug_str())
@@ -667,6 +668,20 @@ class DebugFormatter:
                 info_dict["benchmark_result"] = time
                 json.dump(info_dict, fd)
                 fd.write("\n")
+
+
+def log_ir_pre_fusion(nodes: SchedulerNodeList) -> None:
+    if ir_pre_fusion_log.isEnabledFor(logging.INFO):
+        ir_pre_fusion_log.info("BEFORE FUSION\n%s", DebugFormatter._write_ir(nodes))
+
+    V.debug.ir_pre_fusion(nodes)
+
+
+def log_ir_post_fusion(nodes: SchedulerNodeList) -> None:
+    if ir_post_fusion_log.isEnabledFor(logging.INFO):
+        ir_post_fusion_log.info("AFTER FUSION\n%s", DebugFormatter._write_ir(nodes))
+
+    V.debug.ir_post_fusion(nodes)
 
 
 @dataclasses.dataclass

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2018,7 +2018,9 @@ class Scheduler:
         self.compute_ancestors()
 
         metrics.ir_nodes_pre_fusion += len(self.nodes)
-        V.debug.ir_pre_fusion(self.nodes)
+        from torch._inductor.debug import log_ir_post_fusion, log_ir_pre_fusion
+
+        log_ir_pre_fusion(self.nodes)
         self.num_orig_nodes = len(self.nodes)
         self.create_foreach_nodes()
         self.nodes = self.topological_sort_schedule(self.nodes)
@@ -2047,7 +2049,7 @@ class Scheduler:
             self.nodes = comms.reorder_compute_and_comm_for_overlap(self.nodes)
         self.process_grouped_nodes()
         self.compute_last_usage()
-        V.debug.ir_post_fusion(self.nodes)
+        log_ir_post_fusion(self.nodes)
         V.debug.graph_diagram(self.nodes)
         self.debug_draw_graph()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148499

Because we were invoking the logs through `V.debug`, it was not running if TORCH_COMPILE_DEBUG was not set. this is because there is some magic the in debug [getattr](https://github.com/pytorch/pytorch/blob/d789c22712a1e7761fe77b19093f0a43caaaf0f3/torch/_inductor/debug.py#L468-L480). 

 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov