### PR TITLE
[codemod] Remove unused-variable in caffe2/torch/csrc/distributed/c10d/cuda/AsyncMM.cu

### DIFF
--- a/torch/csrc/distributed/c10d/cuda/AsyncMM.cu
+++ b/torch/csrc/distributed/c10d/cuda/AsyncMM.cu
@@ -224,7 +224,6 @@ at::Tensor async_input_mm_out(
       a.is_contiguous() && out.is_contiguous(),
       "async_input_mm: `a` and `out` must be in row-major layout");
 
-  bool is_b_row_major = b.is_contiguous();
   if (!b.is_contiguous()) {
     TORCH_CHECK(b.stride(1) == b.size(0));
     TORCH_CHECK(b.stride(0) == 1);
@@ -241,6 +240,7 @@ at::Tensor async_input_mm_out(
   TORCH_CHECK_EQ(out.sizes()[1], N);
 
 #if defined(BUILD_ASYNC_MM_KERNEL)
+  const bool is_b_row_major = b.is_contiguous();
   DISPATCH_LAYOUT_B(is_b_row_major, [&]() {
     // TODO(yifu): tuning
     async_input_mm_impl<LayoutB, Shape<_128, _256, _64>, Shape<_2, _1, _1>>(


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Test Plan: Sandcastle

Reviewed By: dtolnay






cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o