### PR TITLE
Add aot_eager_then_compile stance

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -1050,6 +1050,21 @@ This error is most likely due to a call to `nonstrict_trace`-ed function, where 
 
         self.assertEqual(fn(x, y), torch.compile(fn)(x, y))
 
+    def test_set_stance_aot_eager_then_compile(self):
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnts)
+        def fn(x, y, z):
+            return x * y * z[0]
+
+        with torch.compiler.set_stance("aot_eager_then_compile"):
+            fn(2, torch.randn(2), {0: torch.randn(2)})
+            fn(3, torch.randn(3), {0: torch.randn(3)})
+            fn(4, torch.randn(4), {0: torch.randn(4)})
+
+        # Would have been 4 without stance
+        self.assertEqual(cnts.op_count, 2)
+
     @torch._dynamo.config.patch("inline_inbuilt_nn_modules", True)
     def test_mark_static_nn_module(self):
         @torch._dynamo.mark_static

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -179,11 +179,11 @@ def _callback_from_stance(callback):
         return callback
     elif _stance.stance == "eager_then_compile":
         if callback not in (False, None):
-            return _create_eager_then_compile_callback(callback, _stance.stance)
+            return _create_delayed_compile_callback(callback, _stance.stance)
         return callback
     elif _stance.stance == "aot_eager_then_compile":
         if callback not in (False, None):
-            return _create_eager_then_compile_callback(callback, _stance.stance)
+            return _create_delayed_compile_callback(callback, _stance.stance)
         return callback
     elif _stance.stance == "force_eager":
         # disable
@@ -230,7 +230,7 @@ def _get_or_add_example_inputs(frame):
     return example_inputs
 
 
-def _create_eager_then_compile_callback(callback, stance):
+def _create_delayed_compile_callback(callback, stance):
     def callback_fn(*args, **kwargs):
         frame = args[0]
         example_inputs = _get_or_add_example_inputs(frame)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #148530
* __->__ #148509

Sometimes `eager_then_compile` stance isn't enough since some models are so close to the memory limit that going to eager will OOM since we don't get the memory reductions from activation checkpointing. This PR introduces `aot_eager_then_compile` which avoids the expensive inductor compile, but still does aot_eager to get the benefits of memory reduction in the first invocation.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames