### PR TITLE
[MPS] Fix unary_kernel_strided logic

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -965,8 +965,8 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
                                            std::optional<int64_t> extra) {
   auto inputTensor = iter.input(0);
   auto outputTensor = iter.output(0);
-  bool same_strides =
-      inputTensor.strides().equals(outputTensor.strides()) && inputTensor.sizes().equals(outputTensor.sizes());
+  bool is_dense_strided = is_dense_in_storage(inputTensor) && inputTensor.strides().equals(outputTensor.strides());
+  bool needs_output_copy = false;
   uint32_t length = outputTensor.numel();
   if (length == 0) {
     return;
@@ -977,9 +977,12 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
     cplState = getPipelineStateForFunc(fmt::format(
         "{}_dense_{}_{}", name, scalarToMetalTypeString(outputTensor), scalarToMetalTypeString(inputTensor)));
 
-    if (!same_strides) {
+    if (!is_dense_strided) {
       inputTensor = inputTensor.contiguous();
-      outputTensor = outputTensor.contiguous();
+      if (!outputTensor.is_contiguous()) {
+          outputTensor = outputTensor.contiguous();
+          needs_output_copy = true;
+      }
     }
 
     MPSStream* mpsStream = getCurrentMPSStream();
@@ -998,7 +1001,7 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
       getMPSProfiler().endProfileKernel(cplState);
     });
   }
-  if (!same_strides) {
+  if (needs_output_copy) {
     iter.output(0).copy_(outputTensor);
   }
 }

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -980,8 +980,8 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
     if (!is_dense_strided) {
       inputTensor = inputTensor.contiguous();
       if (!outputTensor.is_contiguous()) {
-          outputTensor = outputTensor.contiguous();
-          needs_output_copy = true;
+        outputTensor = outputTensor.contiguous();
+        needs_output_copy = true;
       }
     }
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8523,7 +8523,7 @@ class TestMPS(TestCaseMPS):
                 op(mps_x, out=mps_y)
                 self.assertEqual(mps_y, cpu_y)
                 # test for sliced inputs and outputs with similar strides
-                mps_x, mps_y = torch.randn((2, shape[0]*2, shape[1]*2), device='mps', dtype=dtype).unbind(0)
+                mps_x, mps_y = torch.randn((2, shape[0] * 2, shape[1] * 2), device='mps', dtype=dtype).unbind(0)
                 op(mps_x[::2, ::2], out=mps_y[::2, ::2])
                 self.assertEqual(mps_y[::2, ::2], op(mps_x[::2, ::2].contiguous()))
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8514,7 +8514,7 @@ class TestMPS(TestCaseMPS):
                 op(mps_x, out=mps_y)
                 self.assertEqual(mps_y, cpu_y)
 
-                # test for non contiguous input/output with similar strides
+                # test for non contiguous but dense input/output with similar strides
                 cpu_x = torch.randn(shape, device='cpu', dtype=dtype).mT
                 mps_x = cpu_x.to('mps')
                 cpu_y = torch.empty_like(cpu_x)
@@ -8522,6 +8522,10 @@ class TestMPS(TestCaseMPS):
                 op(cpu_x, out=cpu_y)
                 op(mps_x, out=mps_y)
                 self.assertEqual(mps_y, cpu_y)
+                # test for sliced inputs and outputs with similar strides
+                mps_x, mps_y = torch.randn((2, shape[0]*2, shape[1]*2), device='mps', dtype=dtype).unbind(0)
+                op(mps_x[::2, ::2], out=mps_y[::2, ::2])
+                self.assertEqual(mps_y[::2, ::2], op(mps_x[::2, ::2].contiguous()))
 
 
         helper((5, 5), torch.exp, False)


### PR DESCRIPTION
Fixes bug introduced by https://github.com/pytorch/pytorch/pull/148350
Before this change
```
% python3 -c "import torch; x, y = torch.arange(128.0, device='mps').reshape(2, 8, 8).unbind(0); print(torch.sqrt(x[::2, ::2], out=y[::2, ::2]))"
tensor([[  0.0000,   1.4142,   2.0000,   2.4495],
        [ 80.0000,  82.0000,  84.0000,  86.0000],
        [ 96.0000,  98.0000, 100.0000, 102.0000],
        [112.0000, 114.0000, 116.0000, 118.0000]], device='mps:0')
```
After this change
```
% python3 -c "import torch; x, y = torch.arange(128.0, device='mps').reshape(2, 8, 8).unbind(0); print(torch.sqrt(x[::2, ::2], out=y[::2, ::2]))"
tensor([[0.0000, 1.4142, 2.0000, 2.4495],
        [4.0000, 4.2426, 4.4721, 4.6904],
        [5.6569, 5.8310, 6.0000, 6.1644],
        [6.9282, 7.0711, 7.2111, 7.3485]], device='mps:0')
```
One can not avoid copies if both input and output tensors have the same strides, one needs to make sure that they are dense-in-storage (transposed tensor would be dense, but say selecting every odd and even column wouldn't)

Add regression test to prevent those from happening again

Also, no need to check that sizes match, luckily it is checked by the structured op (and `out` for unary ops does not support broadcasting, I just checked)

Revived needs_copy_logic, though it  will become irrelevant after https://github.com/pytorch/pytorch/pull/148468 is landed
