### PR TITLE
[PT2] Port use_triton_dot_compress to PT2 pre_grad passes

### DIFF
--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -122,6 +122,10 @@ def fuse_split_getitem_squeeze_cat(graph):
     return None
 
 
+def use_triton_dot_compress(graph):
+    return None
+
+
 @init_once_fakemode
 def lazy_init():
     from . import efficient_conv_bn_eval, split_cat  # noqa: F401
@@ -172,6 +176,7 @@ def _run_pre_dispatch_passes(
 
     full_pass_list = default_pass_list + [
         fuse_split_getitem_squeeze_cat,
+        use_triton_dot_compress,
     ]
 
     log.info(


### PR DESCRIPTION
Summary: add use_triton_dot_compress in pre_grad

Test Plan:
```
scripts/aetk/aetk -L

%run ~/fbsource/fbcode/caffe2/test/inductor/fb/test_customized_triton_kernel_passes.py
```

Reviewed By: frank-wei

Differential Revision: D68909838




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov