### PR TITLE
remove TORCH_NCCL_AVOID_RECORD_STREAMS,use stashed_for_allocator_safety_ to save the input ref

### DIFF
--- a/docs/source/cuda_environment_variables.rst
+++ b/docs/source/cuda_environment_variables.rst
@@ -25,8 +25,6 @@ For more information on CUDA runtime environment variables, see `CUDA Environmen
     - If set to ``1``, forces TF32 enablement, overrides ``set_float32_matmul_precision`` setting.
   * - ``TORCH_NCCL_USE_COMM_NONBLOCKING``
     - If set to ``1``, enables non-blocking error handling in NCCL.
-  * - ``TORCH_NCCL_AVOID_RECORD_STREAMS``
-    - If set to ``0``, enables fallback to record streams-based synchronization behavior in NCCL.
   * - ``TORCH_CUDNN_V8_API_DEBUG``
     - If set to ``1``, sanity check whether cuDNN V8 is being used.
 


### PR DESCRIPTION
Thoroughly solve the following problems: [https://discuss.pytorch.org/t/cuda-allocation-lifetime-for-inputs-to-distributed-all-reduce/191573](https://discuss.pytorch.org/t/cuda-allocation-lifetime-for-inputs-to-distributed-all-reduce/191573)
`recordStream`  can cause additional performance loss and result in memory not being released in a timely manner,  save  input tensors ref  to `stashed_for_allocator_safety_ ` can make sure input tensors are not freed before their usages on ncclStreams finish.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o