### PR TITLE
[BE] Remove `onlyCPU` decorator from test_local_scalar_dense

### DIFF
--- a/aten/src/ATen/native/cuda/CUDAScalar.cu
+++ b/aten/src/ATen/native/cuda/CUDAScalar.cu
@@ -26,6 +26,7 @@ namespace at::native {
 
 Scalar _local_scalar_dense_cuda(const Tensor& self) {
   Scalar r;
+  TORCH_CHECK(self.numel() > 0, "_local_scalar_dense: Empty tensor not supported");
 #if defined(USE_ROCM)
   if (!use_sync_mode()){
 #endif

--- a/aten/src/ATen/native/mps/operations/Scalar.mm
+++ b/aten/src/ATen/native/mps/operations/Scalar.mm
@@ -15,6 +15,7 @@ namespace at::native {
 
 Scalar _local_scalar_dense_mps(const Tensor& self) {
   Scalar r;
+  TORCH_CHECK(self.numel() > 0, "_local_scalar_dense: Empty tensor not supported");
 
   auto output = at::empty_like(self, TensorOptions(kCPU));
   mps::mps_copy_(output, self, false);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6466,7 +6466,6 @@ else:
         t = torch.ones((), device=device, dtype=dtype)
         self.assertEqual(1, t.item())
 
-    @onlyCPU
     def test__local_scalar_dense_with_empty_tensor(self, device):
         input = torch.randn(0, device=device)
         with self.assertRaisesRegex(RuntimeError, "Empty tensor not supported"):


### PR DESCRIPTION
Followup from https://github.com/pytorch/pytorch/pull/145717, not sure why author thinks those tests should be limited to one architecture.
And fixed similar crashes for CUDA and MPS 
