### PR TITLE
[Easy/Profiler] Add last entry to truncated values

### DIFF
--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -384,13 +384,15 @@ static inline std::string format_list(
   if (truncate && list.size() > kTruncatLength) {
     if (with_escaped_quotes == true) {
       auto x = fmt::format(
-          "\"[{}, ...]\"",
-          fmt::join(list.begin(), list.begin() + kTruncatLength, ", "));
+          "\"[{}, ..., {}]\"",
+          fmt::join(list.begin(), list.begin() + kTruncatLength - 1, ", "),
+          *std::prev(list.end()));
       return x;
     } else {
       auto x = fmt::format(
-          "[{}, ...]",
-          fmt::join(list.begin(), list.begin() + kTruncatLength, ", "));
+          "[{}, ..., {}]",
+          fmt::join(list.begin(), list.begin() + kTruncatLength - 1, ", "),
+          *std::prev(list.end()));
       return x;
     }
   }


### PR DESCRIPTION
Summary: Since the ranks of a PG are usually in a consecutive range it is useful to print the last values when truncating metadata

Test Plan:
Manually changed truncate length to 2 and ran 4 gpu graph to get the following trace:
https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/traces/dynocli/devgpu003.rva5.facebook.com/rank-1.Mar_05_09_48_21.1280355.pt.trace.json.gz&bucket=gpu_traces

Differential Revision: D70637461


