### PR TITLE
[CI][CUDA][Distributed]Update test_composability.py

### DIFF
--- a/test/distributed/test_composability.py
+++ b/test/distributed/test_composability.py
@@ -385,7 +385,7 @@ if __name__ == "__main__":
     if not (
         dist.is_available()
         and dist.is_nccl_available()
-        and torch.cuda.device_count() > 1
+        and torch.cuda.device_count() > 3
     ):
         print(
             "c10d NCCL not available or not enough GPUs, skipping tests",


### PR DESCRIPTION
world_size = int(os.getenv("WORLD_SIZE", 4)) in subsequent lines indicate the tests in this file do not only require > 1 GPU, but at least 4 GPUs.  skip_if_lt_x_gpu(4) does not properly skip this on a platform with 2 GPUs.

skip_if_lt_x_gpu being broken, potentially related to a similar issue: https://github.com/pytorch/pytorch/issues/146094

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @tinglvv @eqy @ptrblck @atalman @malfet 
