### PR TITLE
Enable a fast path for (static) qlinear for AArch64 through ACL directly.

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1,17 +1,18 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/core/Tensor.h>
 #include <ATen/Context.h>
 #include <ATen/Parallel.h>
 #include <ATen/TensorOperators.h>
-#include <ATen/native/quantized/cpu/fbgemm_utils.h>
-#include <ATen/native/quantized/cpu/QnnpackUtils.h>
-#include <ATen/native/quantized/cpu/XnnpackUtils.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/native/mkldnn/MKLDNNCommon.h>
+#include <ATen/native/quantized/PackedParams.h>
+#include <ATen/native/quantized/cpu/ACLUtils.h>
 #include <ATen/native/quantized/cpu/OnednnUtils.h>
+#include <ATen/native/quantized/cpu/QnnpackUtils.h>
 #include <ATen/native/quantized/cpu/QuantUtils.h>
+#include <ATen/native/quantized/cpu/XnnpackUtils.h>
+#include <ATen/native/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/quantized/cpu/qlinear.h>
 #include <ATen/native/quantized/library.h>
-#include <ATen/native/quantized/PackedParams.h>
-#include <ATen/native/mkldnn/MKLDNNCommon.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 #include <torch/library.h>
 
@@ -1107,6 +1108,97 @@ static at::Tensor linear_int8_with_onednn_weight(
   primitive.execute(ideep::stream::default_stream(), args);
   return dim == 2 ? output : output.reshape(output_size);
 }
+
+#if AT_MKLDNN_ACL_ENABLED()
+
+template <bool ReluFused>
+at::Tensor PackedLinearWeightsACL::apply_impl(
+    at::Tensor input,
+    double output_scale,
+    int64_t output_zero_point) {
+  const int64_t dim = input.dim();
+  TORCH_CHECK(
+      dim != 0, "qlinear (ONEDNN): input dim should be at least 1, but got 0");
+  TORCH_CHECK(
+      input.scalar_type() == c10::ScalarType::QUInt8 ||
+          input.scalar_type() == c10::ScalarType::QInt8,
+      "qlinear (ONEDNN): data type of input should be QUInt8 or QInt8.");
+
+  auto input_contig = input.expect_contiguous();
+
+  int64_t m = input.numel() / k_;
+  double input_scale = input.q_scale();
+  int64_t input_zero_point = input.q_zero_point();
+  auto is_input_qint8 = input.scalar_type() == c10::ScalarType::QInt8;
+  auto key = std::make_tuple(
+      m,
+      ReluFused,
+      static_cast<int64_t>(at::get_num_threads()),
+      input_scale,
+      input_zero_point,
+      output_scale,
+      output_zero_point,
+      is_input_qint8);
+
+  auto acl_gemm =
+      get_acl_quant_matmul<at::native::acl_utils::StaticQuantMatmul>(key);
+  if (acl_gemm) {
+    acl_gemm->src_q_tensor.allocator()->import_memory(input_contig->data_ptr());
+
+    auto dst_dims = {m, n_};
+    at::Tensor output = at::_empty_affine_quantized(
+        dst_dims,
+        at::device(c10::kCPU).dtype(
+            is_input_qint8 ? c10::kQInt8 : c10::kQUInt8),
+        output_scale,
+        output_zero_point);
+
+    if (output.numel() == 0) {
+      return output;
+    }
+
+    acl_gemm->dst_q_tensor.allocator()->import_memory(output.data_ptr());
+
+    acl_gemm->gemm.run();
+
+    acl_gemm->src_q_tensor.allocator()->free();
+    acl_gemm->dst_q_tensor.allocator()->free();
+
+    auto out_sizes = input.sizes().vec();
+    out_sizes.back() = n_;
+
+    if (output.sizes().vec() == out_sizes)
+      return output;
+    return output.reshape(out_sizes);
+  }
+
+  // fallback to oneDNN in the unlikely scinario that ACL's validation fails
+  if (ReluFused) {
+    return PackedLinearWeightsOnednn::apply_relu(
+        input, output_scale, output_zero_point);
+  } else {
+    return PackedLinearWeightsOnednn::apply(
+        input, output_scale, output_zero_point);
+  }
+}
+
+at::Tensor PackedLinearWeightsACL::apply(
+    at::Tensor input,
+    double output_scale,
+    int64_t output_zero_point) {
+  return apply_impl</*ReluFused=*/false>(
+      std::move(input), output_scale, output_zero_point);
+}
+
+at::Tensor PackedLinearWeightsACL::apply_relu(
+    at::Tensor input,
+    double output_scale,
+    int64_t output_zero_point) {
+  return apply_impl</*ReluFused=*/true>(
+      std::move(input), output_scale, output_zero_point);
+}
+
+#endif // AT_MKLDNN_ACL_ENABLED()
 #endif // #if AT_MKLDNN_ENABLED()
 
 namespace at::native {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148586
* #148585
* #148584

This enables a fast path for eager mode static quantization for AArch64 through Arm Compute Library (ACL) directly.

PR #145942 addressed the high overhead in qlinear_dynamic on AArch64 (due to redundant weight pretranspositions and reductions) by enabling a path that calls ACL directly.
This does the same thing but for (static) qlinear.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10