### PR TITLE
Move broken job to unstable workflow: `trunk / libtorch-linux-focal-cuda12.4-py3.10-gcc9-debug / build`

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -45,22 +45,6 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
-  libtorch-linux-focal-cuda12_4-py3_10-gcc9-debug-build:
-    name: libtorch-linux-focal-cuda12.4-py3.10-gcc9-debug
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      build-environment: libtorch-linux-focal-cuda12.4-py3.10-gcc9
-      docker-image-name: pytorch-linux-focal-cuda12.4-cudnn9-py3-gcc9
-      build-generates-artifacts: false
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      runner: "linux.4xlarge"
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 1 },
-        ]}
-    secrets: inherit
-
   # no-ops builds test USE_PER_OPERATOR_HEADERS=0 where ATen/ops is not generated
   linux-focal-cuda12_4-py3_10-gcc9-no-ops-build:
     name: linux-focal-cuda12.4-py3.10-gcc9-no-ops

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -67,4 +67,3 @@ jobs:
           { config: "default", shard: 1, num_shards: 1 },
         ]}
     secrets: inherit
-

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -51,3 +51,20 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
+
+  libtorch-linux-focal-cuda12_4-py3_10-gcc9-debug-build:
+    name: libtorch-linux-focal-cuda12.4-py3.10-gcc9-debug
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      build-environment: libtorch-linux-focal-cuda12.4-py3.10-gcc9
+      docker-image-name: pytorch-linux-focal-cuda12.4-cudnn9-py3-gcc9
+      build-generates-artifacts: false
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runner: "linux.4xlarge"
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 1 },
+        ]}
+    secrets: inherit
+


### PR DESCRIPTION
The job `trunk / libtorch-linux-focal-cuda12.4-py3.10-gcc9-debug / build` is currently broken and marked as unstable: https://github.com/pytorch/pytorch/issues/148495

Why is this needed?
* Using Issues to mark jobs as unstable is only meant for short term use, and this job is taking longer to fix.  
* The tooling that upgrades the `viable/strict` commit does not respect issues that marks a job as unstable, so the `viable/strict` branch is lagging `main` by two days now

This change can be reverted once the job becomes healthy again