### PR TITLE
[CUDA Graphs][NCCL] Set event queries to happen under thread-local mode in `ProcessGroupNCCL.cpp`

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -5,14 +5,11 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAFunctions.h>
 
-#include <chrono>
 #include <cstddef>
-#include <thread>
 
 namespace at::cuda {
 
 static bool _cuda_graphs_debug = false;
-constexpr int kSynchronizeBusyWaitMillis = 10;
 
 MempoolId_t graph_pool_handle() {
   // Sets just the second value, to distinguish it from MempoolId_ts created from
@@ -40,25 +37,6 @@ MempoolId_t graph_pool_handle() {
  * Note [Interaction with CUDA graph capture] in CUDACachingAllocator.cpp
  * describes memory management for captures.
  */
-
-std::atomic<int> CUDAGraph::pending_event_queries = 0;
-
-// Track any outstanding event queries that could happen e.g., in a NCCL watchdog so that they
-// can be resolved before the capture begins. Note that event queries are not allowed during a
-// graph capture in the default capture mode.
-void CUDAGraph::inc_pending_event_queries() {
-  pending_event_queries++;
-}
-
-void CUDAGraph::dec_pending_event_queries() {
-  TORCH_INTERNAL_ASSERT(pending_event_queries > 0,
-    "Attempted to decrement the number of outstanding events to be queried, but it was <= 0.");
-  pending_event_queries--;
-}
-
-int CUDAGraph::num_pending_event_queries() {
-  return pending_event_queries;
-}
 
 CUDAGraph::CUDAGraph()
   // CUDAStreams may not be default-constructed.
@@ -125,15 +103,6 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*=0*/, cudaStreamCaptureMode capt
       AT_CUDA_CHECK(cudaStreamGetCaptureInfo(stream, &status, &stream_capture_id));
       return status == cudaStreamCaptureStatus::cudaStreamCaptureStatusActive && stream_capture_id == capture_id_;
   });
-
-  // At this point, any NCCL watchdogs should be aware that we are in capture mode
-  // and therefore should not enqueue any additional work that could be event-queried.
-  // We still must wait on any existing work that has not been cleaned up.
-  while (num_pending_event_queries()) {
-    TORCH_WARN_ONCE("Waiting for pending NCCL work to finish before starting graph capture.");
-    std::this_thread::sleep_for(
-      std::chrono::milliseconds(kSynchronizeBusyWaitMillis));
-  }
 
   // cudaStreamCaptureModeGlobal is the most conservative option to
   // prevent potentially unsafe CUDA API calls during capture.  See

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -22,9 +22,6 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
   CUDAGraph();
   ~CUDAGraph();
 
-  static void inc_pending_event_queries();
-  static void dec_pending_event_queries();
-  static int num_pending_event_queries();
   // See Note [Explicit Registration of Generators to the CUDA Graph]
   void register_generator_state(c10::intrusive_ptr<at::CUDAGeneratorState> state);
   void register_generator_state(const at::Generator& generator);
@@ -41,8 +38,6 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
  protected:
   cudaGraph_t graph_ = nullptr;
   cudaGraphExec_t graph_exec_ = nullptr;
-
-  static std::atomic<int> pending_event_queries;
 
   // internal states so reset() can do its best cleaning up
   // Set to true in capture_end if cudaStreamEndCapture succeeded

--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -302,10 +302,10 @@ class ProcessGroupNCCLOpTest(MultiProcContinousTest):
         pg = self.pg
         rank = self.rank_to_GPU[self.rank][0]
         with torch.cuda.device(rank):
-            for _ in range(10):
+            for _ in range(100):
                 xs = [torch.FloatTensor([1]).cuda(rank)]
-                for _ in range(30):
-                    pg.allreduce(xs[0]).wait()
+                for _ in range(50):
+                    pg.allreduce(xs[0])
 
                 graph = torch.cuda.CUDAGraph()
                 with torch.cuda.graph(graph):
@@ -315,7 +315,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinousTest):
                     pg.allreduce(xs[0]).wait()
                     xs[0] += 0.0
 
-                for _ in range(100):
+                for _ in range(1400):
                     graph.replay()
 
     @requires_nccl()

--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -302,10 +302,10 @@ class ProcessGroupNCCLOpTest(MultiProcContinousTest):
         pg = self.pg
         rank = self.rank_to_GPU[self.rank][0]
         with torch.cuda.device(rank):
-            for _ in range(100):
+            for _ in range(10):
                 xs = [torch.FloatTensor([1]).cuda(rank)]
-                for _ in range(50):
-                    pg.allreduce(xs[0])
+                for _ in range(30):
+                    pg.allreduce(xs[0]).wait()
 
                 graph = torch.cuda.CUDAGraph()
                 with torch.cuda.graph(graph):
@@ -315,7 +315,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinousTest):
                     pg.allreduce(xs[0]).wait()
                     xs[0] += 0.0
 
-                for _ in range(1400):
+                for _ in range(100):
                     graph.replay()
 
     @requires_nccl()

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -600,7 +600,6 @@ bool ProcessGroupNCCL::WorkNCCL::finishedGPUExecutionInternal() const {
   // hang if another thread is holding the CUDA global context lock. For
   // example, when doing a `cudaDeviceSynchronize` or even
   // `cudaStreamSynchronize`.
-  auto mode = cudaStreamCaptureModeThreadLocal;
   if (!ncclEndEvent_->query()) {
     return false;
   }
@@ -2318,8 +2317,8 @@ void ProcessGroupNCCL::watchdogHandler() {
         pgStatus_->lastStartedNumelOut = work.numelOut_;
       }
 
-
-      at::cuda::CUDAGuard guard(work.ncclEndEvent_->device_index());
+      // allow watchdog to do an event query on a side thread
+      at::cuda::CUDAGuard device_guard(work.ncclEndEvent_->device_index());
       at::cuda::CUDAStreamCaptureModeGuard g{cudaStreamCaptureModeThreadLocal};
 
       // Clean up completed work

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -3591,6 +3591,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collectiveCoalesced(
   Note that previously recorded events (e.g., before the capture) can be queried
   as the watchdog capture mode has been changed to thread-local, but user-side
   event queries (from the main thread) via .is_completed() are still disallowed.
+  TODO(eqy): Is there a path to allowing workEnqueue during graph capture for
+  watchdog-thread usage only?
 
   TODO:
    - Is our design for flight recorder safe in this context?  are we recording

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2318,7 +2318,7 @@ void ProcessGroupNCCL::watchdogHandler() {
         pgStatus_->lastStartedNumelOut = work.numelOut_;
       }
 
-      // allow watchdog event queries from a side thread
+
       at::cuda::CUDAGuard guard(work.ncclEndEvent_->device_index());
       at::cuda::CUDAStreamCaptureModeGuard g{cudaStreamCaptureModeThreadLocal};
 
@@ -3590,9 +3590,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collectiveCoalesced(
   We disable this event query behavior as they are disallowed during capture
   under the strictest capture mode setting.
   Note that previously recorded events (e.g., before the capture) can be queried
-  as the watchdog capture mode has been changed to thread-local.
-  TODO(eqy): can we re-enable queries during capture entirely given the above?
-  Will they function as expected?
+  as the watchdog capture mode has been changed to thread-local, but user-side
+  event queries (from the main thread) via .is_completed() are still disallowed.
 
   TODO:
    - Is our design for flight recorder safe in this context?  are we recording

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -10,7 +10,6 @@
 #include <utility>
 
 #include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/CUDAGraph.h>
 #include <c10/core/DeviceType.h>
 #include <c10/cuda/CUDAAllocatorConfig.h>
 #include <c10/cuda/CUDAGraphsC10Utils.h>
@@ -587,10 +586,17 @@ bool ProcessGroupNCCL::WorkNCCL::startedGPUExecutionInternal() const {
   if (!timingEnabled_) {
     return false;
   }
+  auto mode = cudaStreamCaptureModeThreadLocal;
+  // push
+  cudaThreadExchangeStreamCaptureMode(&mode);
   // Checking the work's corresponding CUDA event's status
   if (!ncclStartEvent_->query()) {
+    // pop
+    cudaThreadExchangeStreamCaptureMode(&mode);
     return false;
   }
+  // pop
+  cudaThreadExchangeStreamCaptureMode(&mode);
   return true;
 }
 
@@ -601,9 +607,16 @@ bool ProcessGroupNCCL::WorkNCCL::finishedGPUExecutionInternal() const {
   // hang if another thread is holding the CUDA global context lock. For
   // example, when doing a `cudaDeviceSynchronize` or even
   // `cudaStreamSynchronize`.
+  auto mode = cudaStreamCaptureModeThreadLocal;
+  // push
+  cudaThreadExchangeStreamCaptureMode(&mode);
   if (!ncclEndEvent_->query()) {
+    // pop
+    cudaThreadExchangeStreamCaptureMode(&mode);
     return false;
   }
+  // pop
+  cudaThreadExchangeStreamCaptureMode(&mode);
   return true;
 }
 
@@ -2354,7 +2367,6 @@ void ProcessGroupNCCL::watchdogHandler() {
           it = workMetaList_.erase(it);
           lastWorkListUpdateTime_ = std::chrono::steady_clock::now();
         }
-        at::cuda::CUDAGraph::dec_pending_event_queries();
       } else {
         // Increment the iterator if the current WorkNCCL object is not
         // completed.
@@ -3209,13 +3221,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::endCoalescing(OpType optype) {
         std::make_shared<std::vector<at::Tensor>>();
   }
 
-  // Notify graphs before we check the capture status preemptively
-  at::cuda::CUDAGraph::inc_pending_event_queries();
-
   if (enqueue) {
     workEnqueue(work);
-  } else {
-    at::cuda::CUDAGraph::dec_pending_event_queries();
   }
 
   coalescing_state_ = 0;
@@ -3405,12 +3412,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collective(
     work->numelOut_ += output.numel();
   }
 
-  // Notify graphs before we check the capture status preemptively
-  at::cuda::CUDAGraph::inc_pending_event_queries();
   if (enqueue) {
     workEnqueue(work);
-  } else {
-    at::cuda::CUDAGraph::dec_pending_event_queries();
   }
 
   return work;
@@ -3592,34 +3595,21 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collectiveCoalesced(
 
   /* Note [cuda graph capture and workEnqueue]
 
-  Normal behavior of the C10D watchdog is to query cuda events on work objects
-  periodically, but when cuda graph recording is active these event queries
-  would crash or mess up the recording.
-
-  To ensure we do not enqueue a work object to the watchdog when cuda graph
-  capture is active, we use a one-way sync. We increment a flag pre-emptively,
-  indicating our intent to enqueue a work object. Then we check capture_status
-  to see if (a) capturing is already in progress (we cannot enqueue in this
-  case), (b) capturing hasn't started yet, so we can trust that no capture will
-  start (since a pre-condition of starting a capture is to check the event query
-  count is 0).
-
-  If we are not able to enqueue the work due to capture-in-progress, we finally
-  decrement the counter.
-
-  For this reason we cannot easily move the increment inside workEnqueue unless
-  we also change the semantic of workEnqueue to 'maybeWorkEnqueue'.
+  Normal behavior of the C10D watchdog is to query cuda events on work objects.
+  We disable this event query behavior as they are disallowed during capture
+  under the strictest capture mode setting.
+  Note that previously recorded events (e.g., before the capture) can be queried
+  as the watchdog capture mode has been changed to thread-local.
+  TODO(eqy): can we re-enable queries during capture entirely given the above?
+  Will they function as expected?
 
   TODO:
    - Is our design for flight recorder safe in this context?  are we recording
   any FR events during cudagraph capture? if so, they won't be safe to poll for
   completion status.
   */
-  at::cuda::CUDAGraph::inc_pending_event_queries();
   if (capture_status == c10::cuda::CaptureStatus::None) {
     workEnqueue(work);
-  } else {
-    at::cuda::CUDAGraph::dec_pending_event_queries();
   }
   // TODO(whc) if the work isn't enqueued, I don't feel great about returning
   // it, since interactions with it by usercode won't behave normally - they
@@ -3861,13 +3851,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
   c10::cuda::CaptureStatus capture_status =
       c10::cuda::currentStreamCaptureStatusMayInitCtx();
 
-  // Notify graphs before we check the capture status preemptively
-  at::cuda::CUDAGraph::inc_pending_event_queries();
-
   if (!coalescing_state_ && capture_status == c10::cuda::CaptureStatus::None) {
     workEnqueue(work);
-  } else {
-    at::cuda::CUDAGraph::dec_pending_event_queries();
   }
   return work;
 }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -3586,8 +3586,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collectiveCoalesced(
   /* Note [cuda graph capture and workEnqueue]
 
   Normal behavior of the C10D watchdog is to query cuda events on work objects.
-  We disable this event query behavior as they are disallowed during capture
-  under the strictest capture mode setting.
+  We disable this event query behavior during graph capture as it is disallowed
+  during capture under the strictest capture mode setting.
   Note that previously recorded events (e.g., before the capture) can be queried
   as the watchdog capture mode has been changed to thread-local, but user-side
   event queries (from the main thread) via .is_completed() are still disallowed.


### PR DESCRIPTION
Should mean we don't need to coordinate the watchdog with CUDAGraph captures anymore

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @ptrblck @msaroufim @mcarilli @ezyang @eellison @penguinwu @BoyuanFeng