### PR TITLE
[c10d] Make getDefaultBackend more fault tolerant

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -875,7 +875,17 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   }
 
   bool hasHooks() const {
-    return getDefaultBackend()->hasHooks();
+    // `getDefaultBackend` will throw today if the backend is set to `undefined`
+    // (in case of `init_process_group(nothing)`)
+    try {
+      return getDefaultBackend()->hasHooks();
+    } catch (const std::exception& e) {
+      TORCH_WARN(
+          "Failed to check if ProcessGroup has hooks: ",
+          e.what(),
+          ". Assuming no hooks are registered.");
+      return false;
+    }
   }
 
   virtual const std::string& getGroupName() const;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148596

This is a forward fix for #135338.
It hits error like this:
```
"distributed_c10d.py", line 2156, in destroy_process_group
    if type(pg) == ProcessGroup and pg._has_hooks():
RuntimeError: Could not find the default backend type 0 for Process Group with name undefined.
```

When users call `init_process_group(nothing)`, default backend is not set, or set to `undefined`. Thus the above signature. Triggered by the `_has_hooks()` call.

The fix wraps `getDefaultBackend` with a try-catch.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o