### PR TITLE
Clear triton kernels after parent make_launcher

### DIFF
--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -187,6 +187,7 @@ class CompiledTritonKernels:
         if key in CompiledTritonKernels._cache:
             del CompiledTritonKernels._cache[key]
 
+
 class AsyncCompile:
     def __init__(self) -> None:
         pass

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -181,6 +181,11 @@ class CompiledTritonKernels:
     def cache_clear():
         CompiledTritonKernels._cache = {}
 
+    @staticmethod
+    def remove_future(kernel_src: str) -> None:
+        key = CompiledTritonKernels.key(kernel_src)
+        if key in CompiledTritonKernels._cache:
+            del CompiledTritonKernels._cache[key]
 
 class AsyncCompile:
     def __init__(self) -> None:
@@ -313,6 +318,9 @@ class AsyncCompile:
 
             def get_result() -> tuple[CachingAutotuner, int]:
                 kernel, elapsed_us = task.result()
+                # Now that we've compiled, we should clear the future
+                # so it can't be used again
+                CompiledTritonKernels.remove_future(source_code)
                 kernel.precompile(
                     warm_cache_only=False, reload_kernel=reload_kernel_in_parent
                 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148597

Before, we were clearing the cache only after inductor compile. But inductor may not **always** compile, i.e. on AOTAutogradCache hit.

So instead, we should clear it when the future is consumed. This is a more robust fix for the issue in D69476856

Differential Revision: [D70646281](https://our.internmc.facebook.com/intern/diff/D70646281/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov