### PR TITLE
Remove warnings on non-buffer tensor constants (#148483)

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1748,8 +1748,6 @@ class Graph:
 
         # Check targets are legit
         if self.owning_module:
-            num_warnings = 0
-            MAX_WARNINGS = 5
             for node in self.nodes:
                 if node.op == "call_function":
                     if not callable(node.target):
@@ -1781,29 +1779,8 @@ class Graph:
                                 f"Node {node} target {node.target} {atom} of {seen_qualname} does "
                                 "not reference an nn.Module"
                             )
-                        elif (
-                            node.op == "get_attr"
-                            and not isinstance(new_m_itr, torch.nn.Module)
-                            and not isinstance(new_m_itr, torch.nn.Parameter)
-                            and atom not in m_itr._buffers
-                        ):
-                            if num_warnings < MAX_WARNINGS:
-                                # Don't emit this warning too frequently,
-                                # for very large graphs this can become very expensive
-                                # from a performance perspective.
-                                warnings.warn(
-                                    f"Node {node} target {node.target} {atom} of {seen_qualname} does "
-                                    "not reference an nn.Module, nn.Parameter, or buffer, which is "
-                                    "what 'get_attr' Nodes typically target"
-                                )
-                            num_warnings += 1
-                        else:
-                            m_itr = new_m_itr
-            if num_warnings > MAX_WARNINGS:
-                warnings.warn(
-                    f"Additional {num_warnings - MAX_WARNINGS} warnings "
-                    "suppressed about get_attr references"
-                )
+
+                        m_itr = new_m_itr
 
     @compatibility(is_backward_compatible=True)
     def eliminate_dead_code(


### PR DESCRIPTION
Summary:


Export already registers tensor constants directly in the graph and this is also true for Torchbind objects. This removes warning that pollutes the output.


cc ezyang SherlockNoMad EikanWang jgong5 wenzhe-nrv

imported-using-ghimport

Test Plan: Imported from OSS

Reviewed By: zou3519

Differential Revision: D70577856

Pulled By: tugsbayasgalan




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv