### PR TITLE
[ONNX] Support complex comparison when verify=True

### DIFF
--- a/torch/onnx/_internal/exporter/_verification.py
+++ b/torch/onnx/_internal/exporter/_verification.py
@@ -44,6 +44,8 @@ def _compare_tensors(
     if expected.dtype == torch.bool:
         expected = expected.to(torch.float32)
         actual = actual.to(torch.float32)
+    if torch.is_complex(expected):
+        expected = torch.view_as_real(expected)
     abs_diff = torch.abs(expected - actual)
     eps = 1e-7
     normalizer = torch.abs(expected) + eps


### PR DESCRIPTION
Previously, the comparison of complex numbers was not supported when `verify=True`.

NOTE: This PR can be extended to support more complex comparison cases if there are other places in onnx codebase needed to be changed.
