### PR TITLE
fix 142457 , fixes double free corruption by adding TORCH_CHECK to ensure weights have the proper size

### DIFF
--- a/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp
+++ b/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp
@@ -126,8 +126,7 @@ static inline void slow_conv_transpose3d_shape_check(
   if (weight.defined()) {
     const int64_t n_input_plane = weight.size(0);
     check_dim_size(input, ndim, dimf, n_input_plane);
-    // add check to ensure that weight has the dimensions we expect, i.e n_input_plane x n_output_plane x kernel_depth x kernel_height x kernel_width
-    // weight shall have 5 dims, which wree already checked, so we can safely call check_dim_size with 5 as dim
+    // add check to ensure that weight has the sizes we expect, i.e n_input_plane x n_output_plane x kernel_depth x kernel_height x kernel_width
     // check_dim_size will throw a generic error, to be more informative, we will do TORCH_CHECK manually
     TORCH_CHECK(
       weight.size(2) == kernel_depth,

--- a/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp
+++ b/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp
@@ -126,6 +126,33 @@ static inline void slow_conv_transpose3d_shape_check(
   if (weight.defined()) {
     const int64_t n_input_plane = weight.size(0);
     check_dim_size(input, ndim, dimf, n_input_plane);
+    // add check to ensure that weight has the dimensions we expect, i.e n_input_plane x n_output_plane x kernel_depth x kernel_height x kernel_width
+    // weight shall have 5 dims, which wree already checked, so we can safely call check_dim_size with 5 as dim
+    // check_dim_size will throw a generic error, to be more informative, we will do TORCH_CHECK manually
+    TORCH_CHECK(
+      weight.size(2) == kernel_depth,
+      "Expected weight to have size ",
+      kernel_depth,
+      " at dimension ",
+      3,
+      " but got ",
+      weight.size(2));
+    TORCH_CHECK(
+      weight.size(3) == kernel_height,
+      "Expected weight to have size ",
+      kernel_height,
+      " at dimension ",
+      4,
+      " but got ",
+      weight.size(3));
+    TORCH_CHECK(
+      weight.size(4) == kernel_width,
+      "Expected weight to have size ",
+      kernel_width,
+      " at dimension ",
+      5,
+      " but got ",
+      weight.size(4));
   }
 
   const int64_t input_width = input.size(dimw);


### PR DESCRIPTION
Fixes #142457

# Problem
```slow_conv_transpose3d_shape_check``` currently does not enforce the constraint that the size of the ```weight =  n_input_plane x n_output_plane x kernel_depth x kernel_height x kernel_width```. This causes the undefined behavior seen in issue 142457.  This can be fixed by enforcing that the sizes of weight at dims ```3```, ```4```, and  ```5``` equals the sizes of kernel at dims ```1```, ```2```, and ```3```.

# Fix

Added 3 ```TORCH_CHECKs``` to meet the above constraint.

# Test
## Reproduction code
```python
import torch

self = torch.full((1, 2, 4, 5, 4,), 0.5, dtype=torch.double)
weight = torch.full((2, 3, 2, 3, 2,), 0.5, dtype=torch.double)
kernel_size = [1, 1, 1]
bias = torch.full((3,), 0.5, dtype=torch.double)
stride = [1, 1, 1]
padding = [2, 2, 2]
output_padding = [2, 2, 2]
dilation = [1879048192, 1879048192, 1879048192]
torch.ops.aten.slow_conv_transpose3d(self, weight, kernel_size, bias, stride, padding, output_padding, dilation)
```
## Before fix
```bash
double free or corruption (!prev)
Aborted (core dumped)
```
## After fix
```bash
Traceback (most recent call last):
  File "/home/system/Desktop/pytorch_contrib/pytorch/../test.py", line 11, in <module>
    torch.ops.aten.slow_conv_transpose3d(self, weight, kernel_size, bias, stride, padding, output_padding, dilation)
  File "/home/system/Desktop/pytorch_contrib/pytorch/torch/_ops.py", line 1158, in __call__
    return self._op(*args, **(kwargs or {}))
RuntimeError: Expected weight to have size 1 at dimension 3 but got 2
```
# More verification tests
```python
import torch

self = torch.full((1, 2, 4, 5, 4,), 0.5, dtype=torch.double)
weight = torch.full((2, 3, 2, 3, 2,), 0.5, dtype=torch.double)
kernel_size = [2, 3, 2,]
bias = torch.full((3,), 0.5, dtype=torch.double)
stride = [1, 1, 1]
padding = [2, 2, 2]
output_padding = [0, 0, 0]
dilation = [1, 1, 1]
res1  = torch.ops.aten.slow_conv_transpose3d(self, weight, kernel_size, bias, stride, padding, output_padding, dilation)
module = torch.nn.ConvTranspose3d(2, 3, kernel_size=kernel_size, stride=stride, padding=padding, output_padding=output_padding, dilation=dilation, bias=True)
module.weight = torch.nn.Parameter(weight)
module.bias = torch.nn.Parameter(bias)
res2 = module(self)
assert torch.allclose(res1, res2)
print("Success")
```
