### PR TITLE
[mm_logs] follow up to add count info based on shape for inductor `aten.mm`s

### DIFF
--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -2,6 +2,7 @@
 import logging
 
 import torch
+from torch._dynamo.utils import counters
 from torch._inductor.codegen.rocm.ck_universal_gemm_template import CKGemmTemplate
 
 from .. import ir, lowering as L
@@ -168,6 +169,8 @@ def tuned_bmm(mat1, mat2, *, layout=None):
 
     m, n, k, layout, mat1, mat2 = mm_args(mat1, mat2, layout=layout)
 
+    # below is for getting an overview logging info of inductor mms
+    counters["inductor"][f"aten.bmm_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten.bmm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,
@@ -215,6 +218,19 @@ def tuned_bmm(mat1, mat2, *, layout=None):
 @L.register_lowering(aten.baddbmm)
 def tuned_baddbmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     m, n, k, layout, mat1, mat2, inp = mm_args(mat1, mat2, inp, layout=layout)
+
+    # below is for getting an overview logging info of inductor mms
+    counters["inductor"][f"aten.baddbmm_{m}_{n}_{k}"] += 1
+    log.info(
+        "Tuned aten.baddbmm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, inp=%s, output_layout=%s",
+        m,
+        n,
+        k,
+        mat1.get_dtype(),
+        mat2.get_dtype(),
+        inp.get_dtype(),
+        layout,
+    )
 
     # options to tune from
     choices = (

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -4,6 +4,7 @@ import logging
 from typing import Optional
 
 import torch
+from torch._dynamo.utils import counters
 from torch._inductor.autoheuristic.autoheuristic import AutoHeuristicSelectAlgorithm
 from torch._inductor.autoheuristic.autoheuristic_utils import (
     AHContext,
@@ -358,6 +359,8 @@ def tuned_mm(mat1, mat2, *, layout=None):
     m, n, k, layout, mat1, mat2 = mm_args(mat1, mat2, layout=layout)
     name = "mm"
 
+    # below is for getting an overview logging info of inductor mms
+    counters["inductor"][f"aten.mm_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten.mm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,
@@ -478,6 +481,8 @@ def tuned_int_mm(mat1, mat2, *, layout=None):
         mat1, mat2, layout=layout, out_dtype=torch.int32
     )
 
+    # below is for getting an overview logging info of inductor mms
+    counters["inductor"][f"aten._int_mm_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten._int_mm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,
@@ -522,6 +527,8 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     m, n, k, layout, mat1, mat2, inp_expanded = mm_args(mat1, mat2, inp, layout=layout)
     static_shape, is_nonzero = _is_static_problem(layout)
 
+    # below is for getting an overview logging info of inductor mms
+    counters["inductor"][f"aten.addmm_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten.addmm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,

--- a/torch/_inductor/kernel/mm_scaled.py
+++ b/torch/_inductor/kernel/mm_scaled.py
@@ -6,6 +6,7 @@ from typing import Any, Optional
 import sympy
 
 import torch
+from torch._dynamo.utils import counters
 from torch._inductor.codegen.rocm.ck_universal_gemm_template import CKGemmTemplate
 from torch.utils._triton import has_triton_tma_device
 
@@ -507,7 +508,8 @@ def tuned_scaled_mm(
     m, n, k, layout, mat_a, mat_b = mm_args(
         mat_a, mat_b, layout=layout, out_dtype=out_dtype
     )
-
+    # below is for getting an overview logging info of inductor mms
+    counters["inductor"][f"aten._scaled_mm.default_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten._scaled_mm.default: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,


### PR DESCRIPTION
Summary:
as title.

when enable `TORCH_LOGS="+inductor"`, you can get logs at the end such as

stats [('calls_captured', 1), ('unique_graphs', 1)]
inductor [('pattern_matcher_count', 2), ('pattern_matcher_nodes', 2), ('benchmarking.TritonBenchmarker.benchmark_gpu', 2), **(('aten_addmm', (16, 6, 16)), 1)**, ('extern_calls', 1), ('async_compile_cache_miss', 1)]
graph_break []

Test Plan: follow up to add proper logging test.

Differential Revision: D70665104


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov