### PR TITLE
[ONNX] Use torch export to get dynamic shapes for JIT convert strategy

### DIFF
--- a/test/onnx/exporter/test_capture_strategies.py
+++ b/test/onnx/exporter/test_capture_strategies.py
@@ -49,10 +49,8 @@ class ExportStrategiesTest(common_utils.TestCase):
         b = torch.tensor([[1.0]])
 
         strategy = _capture_strategies.JitTraceConvertStrategy()
-        dynamic_shapes = {
-            "a": {0: "dynamic"},
-            "b": {0: "dynamic"},
-        }
+        batch_dim = torch.export.Dim("batch_dim")
+        dynamic_shapes = (0: batch_dim }, {0: batch_dim})
         result = strategy(model, (a, b), kwargs=None, dynamic_shapes=dynamic_shapes)
         if result.exception:
             raise result.exception

--- a/test/onnx/exporter/test_capture_strategies.py
+++ b/test/onnx/exporter/test_capture_strategies.py
@@ -31,8 +31,6 @@ class ExportStrategiesTest(common_utils.TestCase):
         b = torch.tensor(1.0)
 
         result = strategy_cls()(model, (a, b), kwargs=None, dynamic_shapes=None)
-        if result.exception:
-            raise result.exception
         ep = result.exported_program
         assert ep is not None
         torch.testing.assert_close(ep.module()(a, b), model(a, b))

--- a/torch/onnx/_internal/exporter/_capture_strategies.py
+++ b/torch/onnx/_internal/exporter/_capture_strategies.py
@@ -291,10 +291,12 @@ class JitTraceConvertStrategy(CaptureStrategy):
                 self._verbose_print(
                     f"Torch Script model has been saved to '{program_path}'."
                 )
-        ep = _torchscript_converter.TS2EPConverter(
-            jit_model, flattened_args
-        ).convert()
+        ep = _torchscript_converter.TS2EPConverter(jit_model, flattened_args).convert()
         if dynamic_shapes is not None:
+            if isinstance(dynamic_shapes, dict):
+                raise RuntimeError(
+                    "JitTraceConvertStrategy does not support dynamic_shapes as dict. You may pass it in as a tuple"
+                )
             # Retrace with torch.export to get dynamic shapes
             ep = torch.export.export(
                 ep.module(), flattened_args, dynamic_shapes=dynamic_shapes, strict=False

--- a/torch/onnx/_internal/exporter/_capture_strategies.py
+++ b/torch/onnx/_internal/exporter/_capture_strategies.py
@@ -293,13 +293,12 @@ class JitTraceConvertStrategy(CaptureStrategy):
                 )
         ep = _torchscript_converter.TS2EPConverter(jit_model, flattened_args).convert()
         if dynamic_shapes is not None:
-            if isinstance(dynamic_shapes, dict):
-                raise RuntimeError(
-                    "JitTraceConvertStrategy does not support dynamic_shapes as dict. You may pass it in as a tuple"
-                )
             # Retrace with torch.export to get dynamic shapes
             ep = torch.export.export(
-                ep.module(), flattened_args, dynamic_shapes=dynamic_shapes, strict=False
+                ep.module(),
+                flattened_args,
+                dynamic_shapes=dynamic_shapes,
+                strict=False,
             )
         return ep
 

--- a/torch/onnx/_internal/exporter/_capture_strategies.py
+++ b/torch/onnx/_internal/exporter/_capture_strategies.py
@@ -230,8 +230,6 @@ class JitTraceConvertStrategy(CaptureStrategy):
         # Avoid circular import
         from torch._export import converter as _torchscript_converter
 
-        del dynamic_shapes  # Unused
-
         flattened_args, spec = _pytree.tree_flatten((args, kwargs))
         flattened_args = tuple(flattened_args)
 
@@ -293,9 +291,15 @@ class JitTraceConvertStrategy(CaptureStrategy):
                 self._verbose_print(
                     f"Torch Script model has been saved to '{program_path}'."
                 )
-        return _torchscript_converter.TS2EPConverter(
+        ep = _torchscript_converter.TS2EPConverter(
             jit_model, flattened_args
         ).convert()
+        if dynamic_shapes is not None:
+            # Retrace with torch.export to get dynamic shapes
+            ep = torch.export.export(
+                ep.module(), flattened_args, dynamic_shapes=dynamic_shapes, strict=False
+            )
+        return ep
 
     def _enter(self, model) -> None:
         model_repr = _take_first_line(repr(model))


### PR DESCRIPTION
Use torch export to get dynamic shapes for JIT converted graph. I just realized we can retrace a converted jit graph with `torch.export` and produce dynamic shapes using `torch.export`.

-	**Prior:** The exporter will produce a **static graph silently** even when dynamic_shapes are provided.
-	**Proposed:** When `dynamic_shapes` is provided and when the strategy is able to handle it, it will succeed

## Why are we still keeping the JIT strategy?

It is useful when users want to convert JIT modules or `.pt` files into ONNX via the new path. Sometimes also useful when there are JIT scripted modules in the nn module.