### PR TITLE
Fix torch.utils.checkpoint import error

### DIFF
--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -19,6 +19,11 @@ from torch.utils.backend_registration import (
 from torch.utils.cpp_backtrace import get_cpp_backtrace
 from torch.utils.throughput_benchmark import ThroughputBenchmark
 
+def __getattr__(name):
+    if name == 'checkpoint':
+        import torch.utils.checkpoint as checkpoint
+        return checkpoint
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 def set_module(obj, mod):
     """


### PR DESCRIPTION
# Problem
We were trying to use the torch.utils.checkpoint.checkpoint function directly with only the import of torch and without importing torch.utils.checkpoint in our script. However, we would encounter an import error "AttributeError: module 'torch.utils' has no attribute 'checkpoint'". We would like to propose a small fix to this.

# Test case
```
import torch
import torch.nn as nn


# Define a simple multi - layer perceptron
class SimpleMLP(nn.Module):
    def __init__(self, input_size, hidden_size, output_size):
        super(SimpleMLP, self).__init__()
        self.fc1 = nn.Linear(input_size, hidden_size)
        self.relu = nn.ReLU()
        self.fc2 = nn.Linear(hidden_size, output_size)

    def forward(self, x):
        # Apply checkpointing to the first fully - connected layer
        def custom_forward(*inputs):
            layer, input_tensor = inputs
            return layer(input_tensor)
        # error of module 'torch.utils' has no attribute 'checkpoint' here
        out = torch.utils.checkpoint.checkpoint(custom_forward, self.fc1, x)
        out = self.relu(out)
        out = self.fc2(out)
        return out


# Set the input parameters
input_size = 5
hidden_size = 10
output_size = 5
batch_size = 4

# Create an instance of the MLP
model = SimpleMLP(input_size, hidden_size, output_size)

# Generate some random input data
x = torch.randn(batch_size, input_size, requires_grad=True)

# Forward pass
output = model(x)

# Compute the loss (using a simple sum as an example)
loss = output.sum()

# Backward pass
loss.backward()

# Print the gradients of the input tensor
print("Gradients of the input tensor:", x.grad)
```
## Before fix
```
Traceback (most recent call last):
  File "C:\PATH\torch_checkpoint_importBug.py", line 38, in <module>
    output = model(x)
  File "C:\PATH\myenv\lib\site-packages\torch\nn\modules\module.py", line 1736, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "C:\PATH\myenv\lib\site-packages\torch\nn\modules\module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
  File "C:\PATH\torch_checkpoint_importBug.py", line 19, in forward
    out = torch.utils.checkpoint.checkpoint(custom_forward, self.fc1, x)
AttributeError: module 'torch.utils' has no attribute 'checkpoint'
```
## After fix
```
C:\PATH\myenv\lib\site-packages\torch\_dynamo\eval_frame.py:632: UserWarning: torch.utils.checkpoint: the use_reentrant parameter should be passed explicitly. In version 2.5 we will raise an exception if use_reentrant is not passed. use_reentrant=False is recommended, but if you need to preserve the current default behavior, you can pass use_reentrant=True. Refer to docs for more details on the differences between the two variants.
  return fn(*args, **kwargs)
Gradients of the input tensor: tensor([[ 0.2166,  0.3589,  0.0104,  0.0993,  0.0271],
        [-0.0243,  0.1251, -0.0784,  0.0148,  0.0960],
        [ 0.1056,  0.2088,  0.0594, -0.0161,  0.1761],
        [-0.1030,  0.2255, -0.2244,  0.1612,  0.1799]])
```
# Brief description of solution
We added a \_\_getattr__ function to return the "checkpoint" module import from "import torch.utils.checkpoint as checkpoint" when we are requesting "torch.utils.checkpoint". We cannot directly add a line "import torch.utils.checkpoint as checkpoint" directly in \_\_init__.py as this would lead to a long chain of circular import. But this function bypass this issue as we are not actually importing it to use and only want a reference to it.