### PR TITLE
Enable ruff check for `torch/utils/data/*.ipynb`

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1518,7 +1518,7 @@ command = [
 
 [[linter]]
 code = 'RUFF'
-include_patterns = ['**/*.py', '**/*.pyi']
+include_patterns = ['**/*.py', '**/*.pyi', 'torch/utils/data/typing.ipynb']
 exclude_patterns = [
     'caffe2/**',
     'functorch/docs/**',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1518,7 +1518,7 @@ command = [
 
 [[linter]]
 code = 'RUFF'
-include_patterns = ['**/*.py', '**/*.pyi', 'torch/utils/data/typing.ipynb']
+include_patterns = ['**/*.py', '**/*.pyi', 'torch/utils/data/*.ipynb']
 exclude_patterns = [
     'caffe2/**',
     'functorch/docs/**',

--- a/torch/utils/data/dataframes_pipes.ipynb
+++ b/torch/utils/data/dataframes_pipes.ipynb
@@ -1,32 +1,11 @@
 {
- "metadata": {
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.10"
-  },
-  "orig_nbformat": 2,
-  "kernelspec": {
-   "name": "python3610jvsc74a57bd0eb5e09632d6ea1cbf3eb9da7e37b7cf581db5ed13074b21cc44e159dc62acdab",
-   "display_name": "Python 3.6.10 64-bit ('dataloader': conda)"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2,
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## \\[RFC\\] How DataFrames (DF) and DataPipes (DP) work together"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -51,8 +30,7 @@
     "    def __init__(self, range = 20):\n",
     "        self.range = range\n",
     "    def __iter__(self):\n",
-    "        for i in range(self.range):\n",
-    "            yield i\n",
+    "        yield from self.range\n",
     "\n",
     "def get_dataframes_pipe(range = 10, dataframe_size = 7):\n",
     "    return ExampleIterPipe(range = range).map(lambda i: (i, i % 3))._to_dataframes_pipe(columns = ['i','j'], dataframe_size = dataframe_size)\n",
@@ -62,11 +40,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Doesn't matter how DF composed internally, iterator over DF Pipe gives single rows to user. This is similar to regular DataPipe."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -74,10 +52,31 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "DataFrames Pipe\n(0, 0)\n(1, 1)\n(2, 2)\n(3, 0)\n(4, 1)\n(5, 2)\n(6, 0)\n(7, 1)\n(8, 2)\n(9, 0)\nRegular DataPipe\n(0, 0)\n(1, 1)\n(2, 2)\n(3, 0)\n(4, 1)\n(5, 2)\n(6, 0)\n(7, 1)\n(8, 2)\n(9, 0)\n"
+      "DataFrames Pipe\n",
+      "(0, 0)\n",
+      "(1, 1)\n",
+      "(2, 2)\n",
+      "(3, 0)\n",
+      "(4, 1)\n",
+      "(5, 2)\n",
+      "(6, 0)\n",
+      "(7, 1)\n",
+      "(8, 2)\n",
+      "(9, 0)\n",
+      "Regular DataPipe\n",
+      "(0, 0)\n",
+      "(1, 1)\n",
+      "(2, 2)\n",
+      "(3, 0)\n",
+      "(4, 1)\n",
+      "(5, 2)\n",
+      "(6, 0)\n",
+      "(7, 1)\n",
+      "(8, 2)\n",
+      "(9, 0)\n"
      ]
     }
    ],
@@ -94,11 +93,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "You can iterate over raw DF using `raw_iterator`"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -106,10 +105,21 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "   i  j\n0  0  0\n1  1  1\n2  2  2\n3  3  0\n4  4  1\n5  5  2\n6  6  0\n   i  j\n0  7  1\n1  8  2\n2  9  0\n"
+      "   i  j\n",
+      "0  0  0\n",
+      "1  1  1\n",
+      "2  2  2\n",
+      "3  3  0\n",
+      "4  4  1\n",
+      "5  5  2\n",
+      "6  6  0\n",
+      "   i  j\n",
+      "0  7  1\n",
+      "1  8  2\n",
+      "2  9  0\n"
      ]
     }
    ],
@@ -120,11 +130,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Operations over DF Pipe is captured"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -134,10 +144,13 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "var_3 = input_var_2.i * 100\nvar_4 = var_3 + input_var_2.j\nvar_5 = var_4 - 2.7\ninput_var_2[\"y\"] = var_5\n"
+      "var_3 = input_var_2.i * 100\n",
+      "var_4 = var_3 + input_var_2.j\n",
+      "var_5 = var_4 - 2.7\n",
+      "input_var_2[\"y\"] = var_5\n"
      ]
     }
    ],
@@ -148,11 +161,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Captured operations executed on `__next__` calls of constructed DataPipe"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -160,10 +173,23 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "   i  j      y\n0  0  0   -2.7\n1  1  1   98.3\n2  2  2  199.3\n   i  j      y\n0  3  0  297.3\n1  4  1  398.3\n2  5  2  499.3\n   i  j      y\n0  6  0  597.3\n1  7  1  698.3\n2  8  2  799.3\n   i  j      y\n0  9  0  897.3\n"
+      "   i  j      y\n",
+      "0  0  0   -2.7\n",
+      "1  1  1   98.3\n",
+      "2  2  2  199.3\n",
+      "   i  j      y\n",
+      "0  3  0  297.3\n",
+      "1  4  1  398.3\n",
+      "2  5  2  499.3\n",
+      "   i  j      y\n",
+      "0  6  0  597.3\n",
+      "1  7  1  698.3\n",
+      "2  8  2  799.3\n",
+      "   i  j      y\n",
+      "0  9  0  897.3\n"
      ]
     }
    ],
@@ -175,11 +201,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "`shuffle` of DataFramePipe effects rows in individual manner"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -187,10 +213,46 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Raw DataFrames iterator\n   i  j\n2  8  2\n2  2  2\n2  5  2\n   i  j\n1  4  1\n1  1  1\n0  3  0\n   i  j\n1  7  1\n0  9  0\n0  6  0\n   i  j\n0  0  0\nRegular DataFrames iterator\n(1, 1)\n(5, 2)\n(8, 2)\n(9, 0)\n(7, 1)\n(6, 0)\n(3, 0)\n(4, 1)\n(0, 0)\n(2, 2)\nRegular iterator\n(5, 2)\n(6, 0)\n(0, 0)\n(9, 0)\n(3, 0)\n(1, 1)\n(2, 2)\n(8, 2)\n(4, 1)\n(7, 1)\n"
+      "Raw DataFrames iterator\n",
+      "   i  j\n",
+      "2  8  2\n",
+      "2  2  2\n",
+      "2  5  2\n",
+      "   i  j\n",
+      "1  4  1\n",
+      "1  1  1\n",
+      "0  3  0\n",
+      "   i  j\n",
+      "1  7  1\n",
+      "0  9  0\n",
+      "0  6  0\n",
+      "   i  j\n",
+      "0  0  0\n",
+      "Regular DataFrames iterator\n",
+      "(1, 1)\n",
+      "(5, 2)\n",
+      "(8, 2)\n",
+      "(9, 0)\n",
+      "(7, 1)\n",
+      "(6, 0)\n",
+      "(3, 0)\n",
+      "(4, 1)\n",
+      "(0, 0)\n",
+      "(2, 2)\n",
+      "Regular iterator\n",
+      "(5, 2)\n",
+      "(6, 0)\n",
+      "(0, 0)\n",
+      "(9, 0)\n",
+      "(3, 0)\n",
+      "(1, 1)\n",
+      "(2, 2)\n",
+      "(8, 2)\n",
+      "(4, 1)\n",
+      "(7, 1)\n"
      ]
     }
    ],
@@ -215,11 +277,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "You can continue mixing DF and DP operations"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -227,10 +289,23 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "    i   j          y\n0 -17 -17  -197000.0\n1 -13 -16  3813000.0\n0 -11 -17  5803000.0\n    i   j          y\n2 -12 -15  4823000.0\n1 -10 -16  6813000.0\n1 -16 -16   813000.0\n    i   j          y\n0  -8 -17  8803000.0\n2  -9 -15  7823000.0\n0 -14 -17  2803000.0\n    i   j          y\n2 -15 -15  1823000.0\n"
+      "    i   j          y\n",
+      "0 -17 -17  -197000.0\n",
+      "1 -13 -16  3813000.0\n",
+      "0 -11 -17  5803000.0\n",
+      "    i   j          y\n",
+      "2 -12 -15  4823000.0\n",
+      "1 -10 -16  6813000.0\n",
+      "1 -16 -16   813000.0\n",
+      "    i   j          y\n",
+      "0  -8 -17  8803000.0\n",
+      "2  -9 -15  7823000.0\n",
+      "0 -14 -17  2803000.0\n",
+      "    i   j          y\n",
+      "2 -15 -15  1823000.0\n"
      ]
     }
    ],
@@ -245,11 +320,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Batching combines everything into `list` it is possible to nest `list`s. List may have any number of DataFrames as soon as total number of rows equal to batch size."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -257,10 +332,21 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Iterate over DataFrame batches\n[(6, 0),(0, 0)]\n[(4, 1),(1, 1)]\n[(2, 2),(9, 0)]\n[(3, 0),(5, 2)]\n[(7, 1),(8, 2)]\nIterate over regular batches\n[(1, 1),(4, 1)]\n[(2, 2),(3, 0)]\n[(6, 0),(7, 1)]\n[(8, 2),(0, 0)]\n[(5, 2),(9, 0)]\n"
+      "Iterate over DataFrame batches\n",
+      "[(6, 0),(0, 0)]\n",
+      "[(4, 1),(1, 1)]\n",
+      "[(2, 2),(9, 0)]\n",
+      "[(3, 0),(5, 2)]\n",
+      "[(7, 1),(8, 2)]\n",
+      "Iterate over regular batches\n",
+      "[(1, 1),(4, 1)]\n",
+      "[(2, 2),(3, 0)]\n",
+      "[(6, 0),(7, 1)]\n",
+      "[(8, 2),(0, 0)]\n",
+      "[(5, 2),(9, 0)]\n"
      ]
     }
    ],
@@ -282,11 +368,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Some details about internal storage of batched DataFrames and how they are iterated"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -294,8 +380,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Type:  <class 'torch.utils.data.datapipes.iter.dataframes.DataChunkDF'>\n",
       "As string:  [(0, 0),(3, 0)]\n",
@@ -381,15 +467,15 @@
     "    print('-- df batch start --')\n",
     "    for item in i.raw_iterator():\n",
     "        print(item)\n",
-    "    print('-- df batch end --')   "
+    "    print('-- df batch end --')"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "`concat` should work only of DF with same schema, this code should produce an error "
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -407,12 +493,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "`unbatch` of `list` with DataFrame works similarly to regular unbatch.\n",
     "Note: DataFrame sizes might change"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -420,9 +506,9 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "error",
      "ename": "AttributeError",
      "evalue": "",
+     "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
@@ -445,11 +531,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "`map` applied to individual rows, `nesting_level` argument used to penetrate batching"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -457,10 +543,15 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Iterate over DataFrame batches\n[(1111000, 1111000),(1112000, 1112000),(1113000, 1113000),(1114000, 1111000),(1115000, 1112000)]\n[(1116000, 1113000),(1117000, 1111000),(1118000, 1112000),(1119000, 1113000),(1120000, 1111000)]\nIterate over regular batches\n[(1111000, 0),(1112000, 1),(1113000, 2),(1114000, 0),(1115000, 1)]\n[(1116000, 2),(1117000, 0),(1118000, 1),(1119000, 2),(1120000, 0)]\n"
+      "Iterate over DataFrame batches\n",
+      "[(1111000, 1111000),(1112000, 1112000),(1113000, 1113000),(1114000, 1111000),(1115000, 1112000)]\n",
+      "[(1116000, 1113000),(1117000, 1111000),(1118000, 1112000),(1119000, 1113000),(1120000, 1111000)]\n",
+      "Iterate over regular batches\n",
+      "[(1111000, 0),(1112000, 1),(1113000, 2),(1114000, 0),(1115000, 1)]\n",
+      "[(1116000, 2),(1117000, 0),(1118000, 1),(1119000, 2),(1120000, 0)]\n"
      ]
     }
    ],
@@ -483,11 +574,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "`filter` applied to individual rows, `nesting_level` argument used to penetrate batching"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -495,10 +586,15 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Iterate over DataFrame batches\n[(6, 0),(7, 1),(8, 2),(9, 0),(10, 1)]\n[(11, 2),(12, 0)]\nIterate over regular batches\n[(6, 0),(7, 1),(8, 2),(9, 0),(10, 1)]\n[(11, 2),(12, 0)]\n"
+      "Iterate over DataFrame batches\n",
+      "[(6, 0),(7, 1),(8, 2),(9, 0),(10, 1)]\n",
+      "[(11, 2),(12, 0)]\n",
+      "Iterate over regular batches\n",
+      "[(6, 0),(7, 1),(8, 2),(9, 0),(10, 1)]\n",
+      "[(11, 2),(12, 0)]\n"
      ]
     }
    ],
@@ -519,5 +615,26 @@
     "    print(i)"
    ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.6.10 64-bit ('dataloader': conda)",
+   "name": "python3610jvsc74a57bd0eb5e09632d6ea1cbf3eb9da7e37b7cf581db5ed13074b21cc44e159dc62acdab"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.10"
+  },
+  "orig_nbformat": 2
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/torch/utils/data/standard_pipes.ipynb
+++ b/torch/utils/data/standard_pipes.ipynb
@@ -1,32 +1,11 @@
 {
- "metadata": {
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.10"
-  },
-  "orig_nbformat": 2,
-  "kernelspec": {
-   "name": "python3610jvsc74a57bd0eb5e09632d6ea1cbf3eb9da7e37b7cf581db5ed13074b21cc44e159dc62acdab",
-   "display_name": "Python 3.6.10 64-bit ('dataloader': conda)"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2,
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Standard flow control and data processing DataPipes"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -48,11 +27,12 @@
     "    def __init__(self, range = 20):\n",
     "        self.range = range\n",
     "    def __iter__(self):\n",
-    "        for i in range(self.range):\n",
-    "            yield i"
+    "        yield from self.range"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Batch\n",
     "\n",
@@ -70,9 +50,7 @@
     "Example:\n",
     "\n",
     "Classic batching produce partial batches by default\n"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -80,10 +58,13 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 1, 2]\n[3, 4, 5]\n[6, 7, 8]\n[9]\n"
+      "[0, 1, 2]\n",
+      "[3, 4, 5]\n",
+      "[6, 7, 8]\n",
+      "[9]\n"
      ]
     }
    ],
@@ -94,11 +75,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "To drop incomplete batches add `drop_last` argument"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -106,10 +87,12 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 1, 2]\n[3, 4, 5]\n[6, 7, 8]\n"
+      "[0, 1, 2]\n",
+      "[3, 4, 5]\n",
+      "[6, 7, 8]\n"
      ]
     }
    ],
@@ -120,11 +103,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Sequential calling of `batch` produce nested batches"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -132,10 +115,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[[0, 1, 2], [3, 4, 5]]\n[[6, 7, 8], [9, 10, 11]]\n[[12, 13, 14], [15, 16, 17]]\n[[18, 19, 20], [21, 22, 23]]\n[[24, 25, 26], [27, 28, 29]]\n"
+      "[[0, 1, 2], [3, 4, 5]]\n",
+      "[[6, 7, 8], [9, 10, 11]]\n",
+      "[[12, 13, 14], [15, 16, 17]]\n",
+      "[[18, 19, 20], [21, 22, 23]]\n",
+      "[[24, 25, 26], [27, 28, 29]]\n"
      ]
     }
    ],
@@ -146,11 +133,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "It is possible to unbatch source data before applying the new batching rule using `unbatch_level` argument"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -158,10 +145,12 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]\n[20, 21, 22, 23, 24, 25, 26, 27, 28, 29]\n"
+      "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
+      "[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]\n",
+      "[20, 21, 22, 23, 24, 25, 26, 27, 28, 29]\n"
      ]
     }
    ],
@@ -172,6 +161,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Unbatch\n",
     "\n",
@@ -185,9 +176,7 @@
     "    `unbatch_level:int = 1`\n",
     " \n",
     "Example:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -195,10 +184,19 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "9\n0\n1\n2\n6\n7\n8\n3\n4\n5\n"
+      "9\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "6\n",
+      "7\n",
+      "8\n",
+      "3\n",
+      "4\n",
+      "5\n"
      ]
     }
    ],
@@ -209,11 +207,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "By default unbatching is applied only on the first layer, to unbatch deeper use `unbatch_level` argument"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -221,10 +219,29 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 1]\n[2, 3]\n[4, 5]\n[6, 7]\n[8, 9]\n[10, 11]\n[12, 13]\n[14, 15]\n[16, 17]\n[18, 19]\n[20, 21]\n[22, 23]\n[24, 25]\n[26, 27]\n[28, 29]\n[30, 31]\n[32, 33]\n[34, 35]\n[36, 37]\n[38, 39]\n"
+      "[0, 1]\n",
+      "[2, 3]\n",
+      "[4, 5]\n",
+      "[6, 7]\n",
+      "[8, 9]\n",
+      "[10, 11]\n",
+      "[12, 13]\n",
+      "[14, 15]\n",
+      "[16, 17]\n",
+      "[18, 19]\n",
+      "[20, 21]\n",
+      "[22, 23]\n",
+      "[24, 25]\n",
+      "[26, 27]\n",
+      "[28, 29]\n",
+      "[30, 31]\n",
+      "[32, 33]\n",
+      "[34, 35]\n",
+      "[36, 37]\n",
+      "[38, 39]\n"
      ]
     }
    ],
@@ -235,11 +252,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Setting `unbatch_level` to `-1` will unbatch to the lowest level"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -247,10 +264,49 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n31\n32\n33\n34\n35\n36\n37\n38\n39\n"
+      "0\n",
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n",
+      "5\n",
+      "6\n",
+      "7\n",
+      "8\n",
+      "9\n",
+      "10\n",
+      "11\n",
+      "12\n",
+      "13\n",
+      "14\n",
+      "15\n",
+      "16\n",
+      "17\n",
+      "18\n",
+      "19\n",
+      "20\n",
+      "21\n",
+      "22\n",
+      "23\n",
+      "24\n",
+      "25\n",
+      "26\n",
+      "27\n",
+      "28\n",
+      "29\n",
+      "30\n",
+      "31\n",
+      "32\n",
+      "33\n",
+      "34\n",
+      "35\n",
+      "36\n",
+      "37\n",
+      "38\n",
+      "39\n"
      ]
     }
    ],
@@ -261,6 +317,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Map\n",
     "\n",
@@ -274,9 +332,7 @@
     "  - `nesting_level: int = 0`\n",
     " \n",
     "Example:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -284,10 +340,19 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "0\n2\n4\n6\n8\n10\n12\n14\n16\n18\n"
+      "0\n",
+      "2\n",
+      "4\n",
+      "6\n",
+      "8\n",
+      "10\n",
+      "12\n",
+      "14\n",
+      "16\n",
+      "18\n"
      ]
     }
    ],
@@ -298,11 +363,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "`map` by default applies function to every mini-batch as a whole\n"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -310,10 +375,13 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 1, 2, 0, 1, 2]\n[3, 4, 5, 3, 4, 5]\n[6, 7, 8, 6, 7, 8]\n[9, 9]\n"
+      "[0, 1, 2, 0, 1, 2]\n",
+      "[3, 4, 5, 3, 4, 5]\n",
+      "[6, 7, 8, 6, 7, 8]\n",
+      "[9, 9]\n"
      ]
     }
    ],
@@ -324,11 +392,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "To apply function on individual items of the mini-batch use `nesting_level` argument"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -336,10 +404,11 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[[0, 2, 4], [6, 8, 10]]\n[[12, 14, 16], [18]]\n"
+      "[[0, 2, 4], [6, 8, 10]]\n",
+      "[[12, 14, 16], [18]]\n"
      ]
     }
    ],
@@ -350,11 +419,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Setting `nesting_level` to `-1` will apply `map` function to the lowest level possible"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -362,8 +431,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[[[0, 2, 4], [6, 8, 10]], [[12, 14, 16], [18]]]\n"
      ]
@@ -376,6 +445,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Filter\n",
     "\n",
@@ -390,9 +461,7 @@
     "  - `drop_empty_batches = True` whether empty many batches dropped or not.\n",
     " \n",
     "Example:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -400,10 +469,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "0\n2\n4\n6\n8\n"
+      "0\n",
+      "2\n",
+      "4\n",
+      "6\n",
+      "8\n"
      ]
     }
    ],
@@ -414,11 +487,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Classic `filter` by default applies filter function to every mini-batches as a whole \n"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -426,10 +499,12 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 1, 2]\n[3, 4, 5]\n[6, 7, 8]\n"
+      "[0, 1, 2]\n",
+      "[3, 4, 5]\n",
+      "[6, 7, 8]\n"
      ]
     }
    ],
@@ -441,11 +516,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "You can apply filter function on individual elements by setting `nesting_level` argument"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -453,10 +528,12 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[5]\n[6, 7, 8]\n[9]\n"
+      "[5]\n",
+      "[6, 7, 8]\n",
+      "[9]\n"
      ]
     }
    ],
@@ -468,11 +545,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "If mini-batch ends with zero elements after filtering default behaviour would be to drop them from the response. You can override this behaviour using `drop_empty_batches` argument.\n"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -480,10 +557,13 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[]\n[5]\n[6, 7, 8]\n[9]\n"
+      "[]\n",
+      "[5]\n",
+      "[6, 7, 8]\n",
+      "[9]\n"
      ]
     }
    ],
@@ -500,10 +580,11 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[[[0, 1, 2], [3]], [[], [10, 11]]]\n[[[12, 13, 14], [15, 16, 17]], [[18, 19]]]\n"
+      "[[[0, 1, 2], [3]], [[], [10, 11]]]\n",
+      "[[[12, 13, 14], [15, 16, 17]], [[18, 19]]]\n"
      ]
     }
    ],
@@ -515,6 +596,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Shuffle\n",
     "\n",
@@ -529,9 +612,7 @@
     "  - `buffer_size: int = 10000`\n",
     " \n",
     "Example:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -539,10 +620,19 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "2\n9\n4\n0\n3\n7\n8\n5\n6\n1\n"
+      "2\n",
+      "9\n",
+      "4\n",
+      "0\n",
+      "3\n",
+      "7\n",
+      "8\n",
+      "5\n",
+      "6\n",
+      "1\n"
      ]
     }
    ],
@@ -553,11 +643,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "`shuffle` operates on input mini-batches similar as on individual items"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -565,10 +655,13 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 1, 2]\n[3, 4, 5]\n[9]\n[6, 7, 8]\n"
+      "[0, 1, 2]\n",
+      "[3, 4, 5]\n",
+      "[9]\n",
+      "[6, 7, 8]\n"
      ]
     }
    ],
@@ -579,11 +672,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "To shuffle elements across batches use `shuffle(unbatch_level)` followed by `batch` pattern "
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -591,10 +684,13 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[2, 1, 0]\n[7, 9, 6]\n[3, 5, 4]\n[8]\n"
+      "[2, 1, 0]\n",
+      "[7, 9, 6]\n",
+      "[3, 5, 4]\n",
+      "[8]\n"
      ]
     }
    ],
@@ -605,6 +701,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Collate\n",
     "\n",
@@ -617,9 +715,7 @@
     "Arguments:\n",
     " \n",
     "Example:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -627,10 +723,13 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "tensor([0, 1, 2])\ntensor([3, 4, 5])\ntensor([6, 7, 8])\ntensor([9])\n"
+      "tensor([0, 1, 2])\n",
+      "tensor([3, 4, 5])\n",
+      "tensor([6, 7, 8])\n",
+      "tensor([9])\n"
      ]
     }
    ],
@@ -641,6 +740,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## GroupBy\n",
     "\n",
@@ -658,9 +759,7 @@
     "\n",
     "#### Attention\n",
     "As datasteam can be arbitrary large, grouping is done on best effort basis and there is no guarantee that same key will never present in the different groups. You can call it local groupby where locallity is the one DataPipe process/thread."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -668,10 +767,12 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 3, 6, 9]\n[1, 4, 7]\n[5, 2, 8]\n"
+      "[0, 3, 6, 9]\n",
+      "[1, 4, 7]\n",
+      "[5, 2, 8]\n"
      ]
     }
    ],
@@ -682,11 +783,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "By default group key function is applied to entire input (mini-batch)"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -694,10 +795,11 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[[0, 1, 2], [3, 4, 5], [6, 7, 8]]\n[[9]]\n"
+      "[[0, 1, 2], [3, 4, 5], [6, 7, 8]]\n",
+      "[[9]]\n"
      ]
     }
    ],
@@ -708,11 +810,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "It is possible to unnest items from the mini-batches using `unbatch_level` argument"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -720,10 +822,12 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 3, 6, 9]\n[1, 4, 7]\n[2, 5, 8]\n"
+      "[0, 3, 6, 9]\n",
+      "[1, 4, 7]\n",
+      "[2, 5, 8]\n"
      ]
     }
    ],
@@ -734,11 +838,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "When internal buffer (defined by `buffer_size`) is overfilled, groupby will yield biggest group available"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -746,10 +850,15 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[9, 3]\n[13, 4, 7]\n[2, 11, 14, 5]\n[0, 6, 12]\n[1, 10]\n[8]\n"
+      "[9, 3]\n",
+      "[13, 4, 7]\n",
+      "[2, 11, 14, 5]\n",
+      "[0, 6, 12]\n",
+      "[1, 10]\n",
+      "[8]\n"
      ]
     }
    ],
@@ -760,11 +869,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "`groupby` will produce `group_size` sized batches on as fast as possible basis"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -772,10 +881,15 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[6, 3, 12]\n[1, 16, 7]\n[2, 5, 8]\n[14, 11, 17]\n[15, 9, 0]\n[10, 4, 13]\n"
+      "[6, 3, 12]\n",
+      "[1, 16, 7]\n",
+      "[2, 5, 8]\n",
+      "[14, 11, 17]\n",
+      "[15, 9, 0]\n",
+      "[10, 4, 13]\n"
      ]
     }
    ],
@@ -786,11 +900,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Remaining groups must be at least `guaranteed_group_size` big. "
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -798,10 +912,15 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[11, 2, 5]\n[1, 4, 10]\n[0, 9, 6]\n[14, 8]\n[13, 7]\n[12, 3]\n"
+      "[11, 2, 5]\n",
+      "[1, 4, 10]\n",
+      "[0, 9, 6]\n",
+      "[14, 8]\n",
+      "[13, 7]\n",
+      "[12, 3]\n"
      ]
     }
    ],
@@ -812,11 +931,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Without defined `group_size` function will try to accumulate at least `guaranteed_group_size` elements before yielding resulted group"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -824,10 +943,12 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[3, 6, 9, 12, 0]\n[14, 2, 8, 11, 5]\n[7, 4, 1, 13, 10]\n"
+      "[3, 6, 9, 12, 0]\n",
+      "[14, 2, 8, 11, 5]\n",
+      "[7, 4, 1, 13, 10]\n"
      ]
     }
    ],
@@ -838,11 +959,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "This behaviour becomes noticable when data is bigger than buffer and some groups getting evicted before gathering all potential items"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -850,10 +971,15 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 3]\n[1, 4, 7]\n[2, 5, 8]\n[6, 9, 12]\n[10, 13]\n[11, 14]\n"
+      "[0, 3]\n",
+      "[1, 4, 7]\n",
+      "[2, 5, 8]\n",
+      "[6, 9, 12]\n",
+      "[10, 13]\n",
+      "[11, 14]\n"
      ]
     }
    ],
@@ -864,11 +990,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "With randomness involved you might end up with incomplete groups (so next example expected to fail in most cases)"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -876,16 +1002,20 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[14, 5, 11]\n[1, 7, 4, 10]\n[0, 12, 6]\n[8, 2]\n[9, 3]\n"
+      "[14, 5, 11]\n",
+      "[1, 7, 4, 10]\n",
+      "[0, 12, 6]\n",
+      "[8, 2]\n",
+      "[9, 3]\n"
      ]
     },
     {
-     "output_type": "error",
      "ename": "Exception",
      "evalue": "('Failed to group items', '[13]')",
+     "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
@@ -902,11 +1032,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "To avoid this error and drop incomplete groups, use `drop_remaining` argument"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -914,10 +1044,13 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[5, 2, 14]\n[4, 7, 13, 1, 10]\n[12, 6, 3, 9]\n[8, 11]\n"
+      "[5, 2, 14]\n",
+      "[4, 7, 13, 1, 10]\n",
+      "[12, 6, 3, 9]\n",
+      "[8, 11]\n"
      ]
     }
    ],
@@ -928,6 +1061,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Zip\n",
     "\n",
@@ -940,9 +1075,7 @@
     "Arguments:\n",
     " \n",
     "Example:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -950,10 +1083,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "(0, 3)\n(1, 0)\n(2, 4)\n(3, 2)\n(4, 1)\n"
+      "(0, 3)\n",
+      "(1, 0)\n",
+      "(2, 4)\n",
+      "(3, 2)\n",
+      "(4, 1)\n"
      ]
     }
    ],
@@ -965,6 +1102,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Fork\n",
     "\n",
@@ -977,9 +1116,7 @@
     "Arguments:\n",
     " \n",
     "Example:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -987,10 +1124,15 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "0\n1\n0\n1\n0\n1\n"
+      "0\n",
+      "1\n",
+      "0\n",
+      "1\n",
+      "0\n",
+      "1\n"
      ]
     }
    ],
@@ -1089,6 +1231,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Concat\n",
     "\n",
@@ -1102,9 +1246,7 @@
     "    `dp = dp.concat(*datapipes_list)`\n",
     "\n",
     "Example:\n"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -1112,10 +1254,16 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "0\n1\n2\n3\n0\n1\n2\n"
+      "0\n",
+      "1\n",
+      "2\n",
+      "3\n",
+      "0\n",
+      "1\n",
+      "2\n"
      ]
     }
    ],
@@ -1127,5 +1275,26 @@
     "    print(i)"
    ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.6.10 64-bit ('dataloader': conda)",
+   "name": "python3610jvsc74a57bd0eb5e09632d6ea1cbf3eb9da7e37b7cf581db5ed13074b21cc44e159dc62acdab"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.10"
+  },
+  "orig_nbformat": 2
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/torch/utils/data/typing.ipynb
+++ b/torch/utils/data/typing.ipynb
@@ -16,7 +16,9 @@
    "outputs": [],
    "source": [
     "from torch.utils.data import IterDataPipe\n",
-    "from typing import Any, Iterator, List, Tuple, TypeVar, Set, Union\n",
+    "from typing import Any, TypeVar, Union\n",
+    "from collections.abc import Iterator\n",
+    "import sys\n",
     "\n",
     "T_co = TypeVar('T_co', covariant=True)"
    ]
@@ -122,9 +124,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class DP(IterDataPipe[Tuple]):\n",
-    "    def __iter__(self) -> Iterator[Tuple[int, str]]:\n",
-    "        pass"
+    "class DP(IterDataPipe[tuple]):\n",
+    "    def __iter__(self) -> Iterator[tuple[int, str]]:\n",
+    "        pass\n",
+    "print(DP.type)"
    ]
   },
   {
@@ -135,7 +138,8 @@
    "source": [
     "class DP(IterDataPipe):\n",
     "    def __iter__(self) -> Iterator[int]:\n",
-    "        pass"
+    "        pass\n",
+    "print(DP.type)"
    ]
   },
   {
@@ -197,14 +201,14 @@
     }
    ],
    "source": [
-    "class DP(IterDataPipe[Tuple[T_co, str]]):\n",
-    "    def __iter__(self) -> Iterator[Tuple[T_co, str]]:\n",
+    "class DP(IterDataPipe[tuple[T_co, str]]):\n",
+    "    def __iter__(self) -> Iterator[tuple[T_co, str]]:\n",
     "        pass\n",
     "print(DP.type)\n",
     "\n",
     "T = TypeVar('T', int, str)  # equals to Union[int, str]\n",
-    "class DP(IterDataPipe[Tuple[T, str]]):\n",
-    "    def __iter__(self) -> Iterator[Tuple[Union[int, str], str]]:\n",
+    "class DP(IterDataPipe[tuple[T, str]]):\n",
+    "    def __iter__(self) -> Iterator[tuple[Union[int, str], str]]:\n",
     "        pass\n",
     "print(DP.type)"
    ]
@@ -242,8 +246,8 @@
     }
    ],
    "source": [
-    "class DP(IterDataPipe[List[int]]):\n",
-    "    def __iter__(self) -> Iterator[List[int]]:\n",
+    "class DP(IterDataPipe[list[int]]):\n",
+    "    def __iter__(self) -> Iterator[list[int]]:\n",
     "        pass\n",
     "print_helper(DP, DP())"
    ]
@@ -313,8 +317,7 @@
     "        self.dp = dp\n",
     "\n",
     "    def __iter__(self):\n",
-    "        for d in self.dp:\n",
-    "            yield d"
+    "        yield from self.dp"
    ]
   },
   {
@@ -378,7 +381,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class Temp(IterDataPipe[Tuple[int, T_co]]):\n",
+    "class Temp(IterDataPipe[tuple[int, T_co]]):\n",
     "    def __iter__(self):\n",
     "        pass\n",
     "dp = DP(Temp())"
@@ -407,14 +410,13 @@
    "source": [
     "from torch.utils.data import runtime_validation, runtime_validation_disabled\n",
     "\n",
-    "class DP(IterDataPipe[Tuple[int, T_co]]):\n",
+    "class DP(IterDataPipe[tuple[int, T_co]]):\n",
     "    def __init__(self, datasource):\n",
     "        self.ds = datasource\n",
     "\n",
     "    @runtime_validation\n",
     "    def __iter__(self):\n",
-    "        for d in self.ds:\n",
-    "            yield d"
+    "        yield from self.ds"
    ]
   },
   {
@@ -608,8 +610,7 @@
     "        self.ds = ds\n",
     "\n",
     "    def __iter__(self):\n",
-    "        for d in self.ds:\n",
-    "            yield d\n",
+    "        yield from self.ds\n",
     "dp = DP(ds).reinforce_type(int)"
    ]
   },
@@ -625,8 +626,7 @@
     "\n",
     "    @runtime_validation\n",
     "    def __iter__(self):\n",
-    "        for d in self.ds:\n",
-    "            yield d"
+    "        yield from self.ds"
    ]
   },
   {


### PR DESCRIPTION
Fixes part of #146411

Enable ruff check for `torch/utils/data/*.ipynb` files

## Test Result

```bash
lintrunner -a --take RUFF torch/utils/data/*.ipynb
```

![image](https://github.com/user-attachments/assets/88fddc91-3f19-4704-9aef-2cabd2cdc96e)


cc @Skylion007