### PR TITLE
[AOTInductor] Codegen fix

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -133,7 +133,7 @@ PYTHON_TO_CPP = {
 }
 
 CONTAINER_PYTHON_TO_CPP = {
-    "List": "std::vector",
+    "List": "c10::ArrayRef",
     "Optional": "std::optional",
 }
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -135,6 +135,9 @@ def convert_arg_type(arg: torch.Argument) -> str:
         else:
             return f"at::{python_type} const&"
 
+    if python_type == "List[Optional[Tensor]]":
+        return "c10::List<std::optional<at::Tensor>> "
+
     if python_type in PYTHON_TO_CPP:
         cpp_type = PYTHON_TO_CPP[python_type]
         return cpp_type


### PR DESCRIPTION
-- Added CPP Codegen support for the List[Optional[Tensor]] data type during function argument conversion from Python, as the existing codegen did not support it. 
-- Modified std::vector to c10::ArrayRef to solve below runtime issues due to signature mismatch.

**Error Message:**
correct signature: std::vector<at::Tensor, std::allocatorat::Tensor > (c10::ArrayRefat::Tensor, c10::ArrayRefat::Tensor, c10::ArrayRef<double>, c10::ArrayRef<double>, c10::ArrayRef<long>, c10::ArrayRef<long>, std::string) accessed/called as: std::vector<at::Tensor, std::allocatorat::Tensor > (std::vector<at::Tensor, std::allocatorat::Tensor >, std::vector<at::Tensor, std::allocatorat::Tensor >, std::vector<double, std::allocator<double> >, std::vector<double, std::allocator<double> >, std::vector<long, std::allocator<long> >, std::vector<long, std::allocator<long> >, std::string)

**Function signature:**
std::vector<at::Tensor> zentorch_function(at::TensorList self, at::TensorList inputs,
                         at::TensorList weights, at::ArrayRef<double> betas,
                         at::ArrayRef<double> alphas, at::IntArrayRef fuse,
                         at::IntArrayRef name)
                         std::string zentorch_op_name



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov