### PR TITLE
Fix static functions when using module in MSVC

### DIFF
--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -45,7 +45,7 @@ namespace torch::autograd {
 /// If you change this, update the doc at the top of the
 /// torch/autograd/__init__.py file and
 /// "test_set_requires_grad_only_for_continuous_types" in test/test_autograd.py
-static inline bool isDifferentiableType(at::ScalarType t) {
+inline bool isDifferentiableType(at::ScalarType t) {
   return isFloatingType(t) || isComplexType(t);
 }
 


### PR DESCRIPTION
If you try to use torch in c++ using modules then it will not compile due to static function not being supported in MSVC when using modules https://developercommunity.visualstudio.com/t/10323558.

It's also aligned with [C++20 standard](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/n4849.pdf) (ISO/IEC 14882:2020) 10.2.7 Export declaration [module.interface]: "Exported names have either external linkage or no linkage".

Fixes https://github.com/pytorch/pytorch/issues/71309
Tested using the following code.

```c++
export module testModule;

import <torch/torch.h>;
import <memory>;
import <string>;
import <tuple>;
import <iostream>;

export namespace testModule 
{

    export void test()
    {
        torch::Tensor tensor1 = torch::rand({ 2, 3 });
        torch::Tensor tensor2 = torch::rand({ 3, 2 });
        // Perform tensor multiplication
        torch::Tensor result = torch::matmul(tensor1, tensor2);

        // Print the tensors
        std::cout << "Tensor 1: " << tensor1 << std::endl;
        std::cout << "Tensor 2: " << tensor2 << std::endl;
        std::cout << "Result of multiplication: " << result << std::endl;
    }
}
```

```c++
import testModule;

int main()
{
	testModule::test();
	return 0;
}
```