### PR TITLE
[dynamo] Remove dead code path around `functools.partial` objects

### DIFF
--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -27,7 +27,6 @@ import dataclasses
 import enum
 import functools
 import inspect
-import itertools
 import random
 import sys
 import threading
@@ -62,14 +61,12 @@ from ..source import (
 )
 from ..utils import (
     build_checkpoint_variable,
-    build_invoke_subgraph_variable,
     check_constant_args,
     cmp_name_to_op_mapping,
     dict_methods,
     get_custom_getattr,
     has_torch_function,
     is_frozen_dataclass,
-    is_invoke_subgraph,
     is_namedtuple_cls,
     is_utils_checkpoint,
     is_wrapper_or_member_descriptor,
@@ -928,8 +925,6 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         args: "list[VariableTracker]",
         kwargs: "dict[str, VariableTracker]",
     ) -> "VariableTracker":
-        from .. import trace_rules
-
         if (
             self.is_supported_random()
             and all(k.is_python_constant() for k in args)
@@ -969,48 +964,6 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             obj_src = AttrSource(self.source, "__self__")
             obj_var = VariableTracker.build(tx, obj, obj_src)
             return func_var.call_function(tx, [obj_var] + args, kwargs)
-        elif (
-            istype(self.value, functools.partial)
-            and trace_rules.lookup(self.value.func)
-            == variables.TorchInGraphFunctionVariable
-            and all(
-                variables.ConstantVariable.is_literal(v)
-                for v in itertools.chain(self.value.args, self.value.keywords.values())
-            )
-        ):
-            if self.source:
-                install_guard(
-                    AttrSource(self.source, "func").make_guard(GuardBuilder.ID_MATCH),
-                    AttrSource(self.source, "args").make_guard(
-                        GuardBuilder.CONSTANT_MATCH
-                    ),
-                    AttrSource(self.source, "keywords").make_guard(
-                        GuardBuilder.CONSTANT_MATCH
-                    ),
-                )
-
-            partial_args = [
-                variables.ConstantVariable.create(v) for v in self.value.args
-            ]
-            partial_args.extend(args)
-            partial_kwargs = {
-                k: variables.ConstantVariable.create(v)
-                for k, v in self.value.keywords.items()
-            }
-            partial_kwargs.update(kwargs)
-
-            # TODO(dynamo-team) - Consider calling VariableBuilder directly here
-            if is_utils_checkpoint(self.value.func):
-                return build_checkpoint_variable().call_function(
-                    tx, partial_args, partial_kwargs
-                )
-            elif is_invoke_subgraph(self.value.func):
-                return build_invoke_subgraph_variable().call_function(
-                    tx, partial_args, partial_kwargs
-                )
-            return variables.TorchInGraphFunctionVariable(
-                self.value.func
-            ).call_function(tx, partial_args, partial_kwargs)
         elif callable(self.value):
             if self.source:
                 install_guard(self.source.make_guard(GuardBuilder.FUNCTION_MATCH))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148683

This removes the code paths added in #98120, which has then been
superceded by #108846.

More importantly, it makes `EQUALS_MATCH`'s `ok_mutable_types` (added in #134016)
easier to reason about, i.e., no need to worry about `dict` types, which
was only needed for #98120.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames