### PR TITLE
[MPS] Fix scalar to tensors bitshifts

### DIFF
--- a/aten/src/ATen/native/mps/operations/BitwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/BitwiseOps.mm
@@ -15,14 +15,14 @@ namespace at::native {
 namespace mps {
 static MetalShaderLibrary lib(R"METAL(
 
-kernel void bitwise_and_tensor(device {0}  *out [[buffer(0)]],
+kernel void bitwise_and_tensor_tensor(device {0}  *out [[buffer(0)]],
                          constant {1}  *a [[buffer(1)]],
                          constant {2}  *b [[buffer(2)]],
                          uint offset [[thread_position_in_grid]]) {{
   out[offset] = a[offset] & b [offset];
 }}
 
-kernel void bitwise_and_scalar(device {0}  *out [[buffer(0)]],
+kernel void bitwise_and_tensor_scalar(device {0}  *out [[buffer(0)]],
                          constant {1}  *a [[buffer(1)]],
                          constant {2}  &b [[buffer(2)]],
                          uint offset [[thread_position_in_grid]]) {{
@@ -30,60 +30,74 @@ kernel void bitwise_and_scalar(device {0}  *out [[buffer(0)]],
 }}
 
 
-kernel void bitwise_or_tensor(device {0}  *out [[buffer(0)]],
+kernel void bitwise_or_tensor_tensor(device {0}  *out [[buffer(0)]],
                          constant {1}  *a [[buffer(1)]],
                          constant {2}  *b [[buffer(2)]],
                          uint offset [[thread_position_in_grid]]) {{
   out[offset] = a[offset] | b [offset];
 }}
 
-kernel void bitwise_or_scalar(device {0}  *out [[buffer(0)]],
+kernel void bitwise_or_tensor_scalar(device {0}  *out [[buffer(0)]],
                          constant {1}  *a [[buffer(1)]],
                          constant {2}  &b [[buffer(2)]],
                          uint offset [[thread_position_in_grid]]) {{
   out[offset] = a[offset] | b;
 }}
 
-kernel void bitwise_xor_tensor(device {0}  *out [[buffer(0)]],
+kernel void bitwise_xor_tensor_tensor(device {0}  *out [[buffer(0)]],
                          constant {1}  *a [[buffer(1)]],
                          constant {2}  *b [[buffer(2)]],
                          uint offset [[thread_position_in_grid]]) {{
   out[offset] = a[offset] ^ b [offset];
 }}
 
-kernel void bitwise_xor_scalar(device {0}  *out [[buffer(0)]],
+kernel void bitwise_xor_tensor_scalar(device {0}  *out [[buffer(0)]],
                          constant {1}  *a [[buffer(1)]],
                          constant {2}  &b [[buffer(2)]],
                          uint offset [[thread_position_in_grid]]) {{
   out[offset] = a[offset] ^ b;
 }}
 
-kernel void bitwise_lshift_tensor(device {0}  *out [[buffer(0)]],
+kernel void bitwise_lshift_tensor_tensor(device {0}  *out [[buffer(0)]],
                          constant {1}  *a [[buffer(1)]],
                          constant {2}  *b [[buffer(2)]],
                          uint offset [[thread_position_in_grid]]) {{
   out[offset] = a[offset] << b [offset];
 }}
 
-kernel void bitwise_lshift_scalar(device {0}  *out [[buffer(0)]],
+kernel void bitwise_lshift_tensor_scalar(device {0}  *out [[buffer(0)]],
                          constant {1}  *a [[buffer(1)]],
                          constant {2}  &b [[buffer(2)]],
                          uint offset [[thread_position_in_grid]]) {{
   out[offset] = a[offset] << b;
 }}
 
-kernel void bitwise_rshift_tensor(device {0}  *out [[buffer(0)]],
+kernel void bitwise_lshift_scalar_tensor(device {0}  *out [[buffer(0)]],
+                         constant {1}  &a [[buffer(1)]],
+                         constant {2}  *b [[buffer(2)]],
+                         uint offset [[thread_position_in_grid]]) {{
+  out[offset] = a << b[offset];
+}}
+
+kernel void bitwise_rshift_tensor_tensor(device {0}  *out [[buffer(0)]],
                          constant {1}  *a [[buffer(1)]],
                          constant {2}  *b [[buffer(2)]],
                          uint offset [[thread_position_in_grid]]) {{
   out[offset] = a[offset] >> b [offset];
 }}
 
-kernel void bitwise_rshift_scalar(device {0}  *out [[buffer(0)]],
+kernel void bitwise_rshift_tensor_scalar(device {0}  *out [[buffer(0)]],
                          constant {1}  *a [[buffer(1)]],
                          constant {2}  &b [[buffer(2)]],
                          uint offset [[thread_position_in_grid]]) {{
   out[offset] = a[offset] >> b;
+}}
+
+kernel void bitwise_rshift_scalar_tensor(device {0}  *out [[buffer(0)]],
+                         constant {1}  &a [[buffer(1)]],
+                         constant {2}  *b [[buffer(2)]],
+                         uint offset [[thread_position_in_grid]]) {{
+  out[offset] = a >> b[offset];
 }}
 
 kernel void bitwise_not(device {0}  *out [[buffer(0)]],
@@ -142,7 +156,8 @@ static void handle_binary_op(const Tensor& self, const Tensor& other, Tensor& ou
 static void _bitwise_op_out_mps(const Tensor& self,
                                 const Tensor& other,
                                 const Tensor& output_,
-                                const std::string& op_name) {
+                                const std::string& op_name,
+                                bool is_commutative = true) {
   using namespace at::mps;
   const bool is_self_scalar = self.dim() == 0;
   const bool is_other_scalar = other.dim() == 0;
@@ -171,14 +186,18 @@ static void _bitwise_op_out_mps(const Tensor& self,
       TORCH_CHECK(false, "Unknown operation to be performed over scalars ", op_name);
     }
   } else if (is_other_scalar) {
-    handle_binary_op(self.contiguous(), other, output, fmt::format("bitwise_{}_scalar", op_name));
+    handle_binary_op(self.contiguous(), other, output, fmt::format("bitwise_{}_tensor_scalar", op_name));
   } else if (is_self_scalar) {
-    handle_binary_op(other.contiguous(), self, output, fmt::format("bitwise_{}_scalar", op_name));
+    if (!is_commutative) {
+      handle_binary_op(self, other.contiguous(), output, fmt::format("bitwise_{}_scalar_tensor", op_name));
+    } else {
+      handle_binary_op(other.contiguous(), self, output, fmt::format("bitwise_{}_tensor_scalar", op_name));
+    }
   } else {
     handle_binary_op(self.expand(output_size).contiguous(),
                      other.expand(output_size).contiguous(),
                      output,
-                     fmt::format("bitwise_{}_tensor", op_name));
+                     fmt::format("bitwise_{}_tensor_tensor", op_name));
   }
   if (needs_output_copy) {
     output_.copy_(output);
@@ -237,11 +256,11 @@ static void _bitwise_not_out_mps(const Tensor& self, const Tensor& output_) {
 } // namespace mps
 namespace {
 void lshift_kernel_mps(TensorIteratorBase& iter) {
-  mps::_bitwise_op_out_mps(iter.input(0), iter.input(1), iter.output(0), "lshift");
+  mps::_bitwise_op_out_mps(iter.input(0), iter.input(1), iter.output(0), "lshift", false);
 }
 
 void rshift_kernel_mps(TensorIteratorBase& iter) {
-  mps::_bitwise_op_out_mps(iter.input(0), iter.input(1), iter.output(0), "rshift");
+  mps::_bitwise_op_out_mps(iter.input(0), iter.input(1), iter.output(0), "rshift", false);
 }
 
 } // namespace

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8791,6 +8791,11 @@ class TestLogical(TestCaseMPS):
         x_cpu = x.cpu()
         self.assertEqual((x >> 3).cpu(), x_cpu >> 3)
         self.assertEqual((x << 1).cpu(), x_cpu << 1)
+        # Regression test for https://github.com/pytorch/pytorch/issues/147889
+        x = x.clamp(0, 32)
+        x_cpu = x.cpu()
+        self.assertEqual((65535 >> x).cpu(), 65535 >> x_cpu)
+        self.assertEqual((1 << x).cpu(), 1 << x_cpu)
 
 
 class TestSmoothL1Loss(TestCaseMPS):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #148719
* __->__ #148686
* #148685

By introducing a concept of non-commutative binary op and renaming all op templates from `bitwise_foo_tensor` and `bitwise_foo_scalar` to `bitwise_foo_tensor_tensor` and `bitwise_foo_tensor_scalar`

Add regression tests

Please note, that for some undefined values MPS and CPU behaviors are different, for example
```
>>> import torch
>>> 4095 >> torch.arange(12, device="mps", dtype=torch.uint8)
tensor([255, 255, 255, 255, 255, 127,  63,  31,  15,   7,   3,   1],
       device='mps:0', dtype=torch.uint8)
>>> 4095 >> torch.arange(12, device="cpu", dtype=torch.uint8)
tensor([255, 127,  63,  31,  15,   7,   3,   1,   0,   0,   0,   0],
       dtype=torch.uint8)
```
Because on CPU scalar is cast to output dtype before operation is performed, but on MPS this happens after the op is done

Fixes https://github.com/pytorch/pytorch/issues/147889