### PR TITLE
Fix _del_library

### DIFF
--- a/torch/library.py
+++ b/torch/library.py
@@ -443,6 +443,21 @@ def _del_library(
     op_defs,
     registration_handles,
 ):
+    import torch.fx
+
+    for op_def in op_defs:
+        name = op_def
+        overload_name = ""
+        if "." in op_def:
+            name, overload_name = op_def.split(".")
+        if (
+            name,
+            overload_name,
+        ) in torch.fx.operator_schemas._SCHEMA_TO_SIGNATURE_CACHE:
+            del torch.fx.operator_schemas._SCHEMA_TO_SIGNATURE_CACHE[
+                (name, overload_name)
+            ]
+
     captured_impls -= op_impls
     captured_defs -= op_defs
     for handle in registration_handles:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #148104
* __->__ #148688
* #148092
* #148091
* #148063
* #148046

On library deletion, we need to clear fx's schema cache.

Test Plan:
- next PR up in the stack