### PR TITLE
Remove redundant moves in kernel.cpp

### DIFF
--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -483,7 +483,7 @@ ExprHandle TensorExprKernel::getVarForShape(const c10::ShapeSymbol& ss) {
   if (it == shapeSymbolToVar_.end()) {
     VarHandle var("ss" + std::to_string(-value), kLong);
     shapeSymbolToVar_.emplace(value, var);
-    return std::move(var);
+    return var;
   }
   return it->second;
 }
@@ -1020,7 +1020,7 @@ ExprHandle TensorExprKernel::getStrideArg(
         kLong);
     strideArgToVar_[std::pair<size_t, size_t>(
         tensor_input_index, stride_index)] = var;
-    return std::move(var);
+    return var;
   }
   return it->second;
 }


### PR DESCRIPTION
During compilation the gcc compiler suggests

> ```
> pytorch/torch/csrc/jit/tensorexpr/kernel.cpp: In member function ‘torch::jit::tensorexpr::ExprHandle torch::jit::tensorexpr::TensorExprKernel::getVarForShape(const c10::ShapeSymbol&)’:
> pytorch/torch/csrc/jit/tensorexpr/kernel.cpp:486:21: warning: redundant move in return statement [-Wredundant-move]
>   486 |     return std::move(var);
>       |            ~~~~~~~~~^~~~~
> pytorch/torch/csrc/jit/tensorexpr/kernel.cpp:486:21: note: remove ‘std::move’ call
> pytorch/torch/csrc/jit/tensorexpr/kernel.cpp: In member function ‘torch::jit::tensorexpr::ExprHandle torch::jit::tensorexpr::TensorExprKernel::getStrideArg(size_t, size_t)’:
> pytorch/torch/csrc/jit/tensorexpr/kernel.cpp:1023:21: warning: redundant move in return statement [-Wredundant-move]
>  1023 |     return std::move(var);
>       |            ~~~~~~~~~^~~~~
> pytorch/torch/csrc/jit/tensorexpr/kernel.cpp:1023:21: note: remove ‘std::move’ call
> ```

So making these changes.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel