### PR TITLE
replace usages of upload_graph in inductor with tlparse

### DIFF
--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1,5 +1,4 @@
-# mypy: allow-untyped-decorators
-# mypy: allow-untyped-defs
+# mypy: allow-untyped-decorators# mypy: allow-untyped-defs
 import functools
 import itertools
 import logging
@@ -7,17 +6,17 @@ import operator
 from collections import Counter, defaultdict
 from typing import Any, Callable, Optional, TypeVar, Union
 from typing_extensions import ParamSpec
+from torch._logging import trace_structured
 
 import torch
 import torch._inductor as inductor
 import torch.utils._pytree as pytree
 from torch import fx
 from torch._decomp import register_decomposition
-from torch._dynamo.utils import counters, optimus_scuba_log
+from torch._dynamo.utils import counters
 from torch._inductor import comms
 from torch._inductor.virtualized import ops
 from torch._prims_common import is_boolean_dtype, is_expandable_to, is_integer_dtype
-from torch._utils_internal import upload_graph
 from torch.fx.experimental.symbolic_shapes import statically_known_true, sym_eq
 from torch.utils._ordered_set import OrderedSet
 
@@ -115,7 +114,14 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
 
     if config.pattern_matcher:
         lazy_init()
-        optimus_scuba_log["before_recompile_post_grad"] = upload_graph(gm.graph)
+        trace_structured(
+            "artifact",
+            metadata_fn=lambda: {
+                "name": "before_recompile_post_grad",
+                "encoding": "string",
+            },
+            payload_fn=lambda: gm.print_readable(print_output=False, include_stride=True, include_device=True)
+        )
         GraphTransformObserver(gm, "post_grad_custom_pre_pass").apply_graph_pass(
             functools.partial(group_batch_fusion_passes, pre_grad=False)
         )
@@ -139,8 +145,13 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
                 pattern_matcher_pass.apply
             )
             if not is_same_dict(counters["inductor"], inductor_before_change):
-                optimus_scuba_log[f"{pattern_matcher_pass.pass_name}_post_grad"] = (
-                    upload_graph(gm.graph)
+                trace_structured(
+                    "artifact",
+                    metadata_fn=lambda: {
+                        "name": f"{pattern_matcher_pass.pass_name}_post_grad",
+                        "encoding": "string",
+                    },
+                    payload_fn=lambda: gm.print_readable(print_output=False, include_stride=True, include_device=True)
                 )
         if config.b2b_gemm_pass:
             B2B_GEMM_PASS.apply(gm.graph)  # type: ignore[arg-type]
@@ -186,7 +197,14 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
     )
 
     gm.recompile()
-    optimus_scuba_log["after_recompile_post_grad"] = upload_graph(gm.graph)
+    trace_structured(
+        "artifact",
+        metadata_fn=lambda: {
+            "name": "after_recompile_post_grad",
+            "encoding": "string",
+        },
+        payload_fn=lambda: gm.print_readable(print_output=False, include_stride=True, include_device=True)
+    )
     gm.graph.lint()
 
 

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -8,8 +8,8 @@ from typing import Optional
 
 import torch
 import torch.nn as nn
-from torch._dynamo.utils import counters, detect_fake_mode, optimus_scuba_log
-from torch._utils_internal import upload_graph
+from torch._dynamo.utils import counters, detect_fake_mode
+from torch._logging import trace_structured
 from torch.fx.experimental.optimization import (
     matches_module_pattern,
     replace_node_module,
@@ -258,7 +258,14 @@ def pre_grad_passes(
             if example_inputs is not None:
                 gm = fuse_fx(gm, example_inputs)
             numpy_compat_normalization(gm.graph)
-            optimus_scuba_log["before_recompile_pre_grad"] = upload_graph(gm.graph)
+            trace_structured(
+                "artifact",
+                metadata_fn=lambda: {
+                    "name": "before_recompile_pre_grad",
+                    "encoding": "string",
+                },
+                payload_fn=lambda: gm.print_readable(print_output=False, include_stride=True, include_device=True)
+            )
             # We should always do the normalization_pass first
             if "normalization_pass" in config.pre_grad_fusion_options:
                 pattern_matcher_pass = PRE_GRAD_PATTERNS["normalization_pass"]
@@ -277,8 +284,13 @@ def pre_grad_passes(
                 for _ in range(counter):
                     pattern_matcher_pass.apply(gm.graph)  # type: ignore[arg-type]
                 if not is_same_dict(counters["inductor"], inductor_before_change):
-                    optimus_scuba_log[f"{pattern_matcher_pass.pass_name}_pre_grad"] = (
-                        upload_graph(gm.graph)
+                    trace_structured(
+                        "artifact",
+                        metadata_fn=lambda: {
+                            "name": f"{pattern_matcher_pass.pass_name}_pre_grad",
+                            "encoding": "string",
+                        },
+                        payload_fn=lambda: gm.print_readable(print_output=False, include_stride=True, include_device=True)
                     )
             # TODO: move efficient_conv_bn_eval_pass to the fusions dict too.
             efficient_conv_bn_eval_pass.apply(gm.graph)  # type: ignore[arg-type]
@@ -294,7 +306,14 @@ def pre_grad_passes(
 
     gm.graph.lint()
     gm.recompile()
-    optimus_scuba_log["after_recompile_pre_grad"] = upload_graph(gm.graph)
+    trace_structured(
+        "artifact",
+        metadata_fn=lambda: {
+            "name": "after_recompile_pre_grad",
+            "encoding": "string",
+        },
+        payload_fn=lambda: gm.print_readable(print_output=False, include_stride=True, include_device=True)
+    )
 
     if (
         config.pattern_matcher


### PR DESCRIPTION
Summary:
context here: https://fb.workplace.com/groups/1286739428954016/posts/1447200899574534/?comment_id=1447204456240845

we shouldn't be uploading graphs during compilation, which can be slow. Instead, we should be relying on tlparse everywhere we need to to dump intermediate artifacts to disk during compilation, so they can be pulled from disk offlinel ater.

Test Plan: CI

Differential Revision: D70731871




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov