### PR TITLE
cleanup JK for duplicate pt2 compile callbacks prevention

### DIFF
--- a/test/dynamo/test_callback.py
+++ b/test/dynamo/test_callback.py
@@ -18,25 +18,12 @@ class CallbackTests(TestCase):
         return super().tearDown()
         callback_handler.clear()
 
-    def test_callbacks_without_duplicate_prevention(self) -> None:
-        callback_handler._CompilationCallbackHandler__prevent_duplicate_callbacks = (
-            False
-        )
-
-        with callback_handler.install_callbacks(), callback_handler.install_callbacks():
-            self.assertEqual(self._on_compile_start.call_count, 2)
-        self.assertEqual(self._on_compile_end.call_count, 2)
-
     def test_callbacks_with_duplicate_prevention(self) -> None:
-        callback_handler._CompilationCallbackHandler__prevent_duplicate_callbacks = True
-
         with callback_handler.install_callbacks(), callback_handler.install_callbacks():
             self._on_compile_start.assert_called_once()
         self._on_compile_end.assert_called_once()
 
     def test_counter(self) -> None:
-        callback_handler._CompilationCallbackHandler__prevent_duplicate_callbacks = True
-
         with callback_handler.install_callbacks():
             self.assertEqual(
                 callback_handler._CompilationCallbackHandler__pending_callbacks_counter,
@@ -47,7 +34,6 @@ class CallbackTests(TestCase):
         )
 
     def test_counter_assertion(self) -> None:
-        callback_handler._CompilationCallbackHandler__prevent_duplicate_callbacks = True
         callback_handler._CompilationCallbackHandler__pending_callbacks_counter -= 1
 
         with self.assertRaises(

--- a/torch/_dynamo/callback.py
+++ b/torch/_dynamo/callback.py
@@ -29,9 +29,7 @@ import threading
 from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass, field  # noqa: F811
-from typing import Any, Callable, Optional
-
-from torch._utils_internal import justknobs_check
+from typing import Any, Callable
 
 
 @dataclass
@@ -39,9 +37,6 @@ class CompilationCallbackHandler:
     start_callbacks: list[Callable[[], None]] = field(default_factory=list)
     end_callbacks: list[Callable[[], None]] = field(default_factory=list)
 
-    __prevent_duplicate_callbacks: Optional[bool] = field(
-        default=None, init=False, repr=False
-    )
     __pending_callbacks_counter: int = field(default=0, init=False, repr=False)
     __pending_callbacks_counter_lock: threading.Lock = field(
         default_factory=threading.Lock, init=False, repr=False
@@ -101,40 +96,25 @@ class CompilationCallbackHandler:
         for callback in self.end_callbacks:
             callback()
 
-    @property
-    def prevent_duplicate_callbacks(self) -> bool:
-        if self.__prevent_duplicate_callbacks is None:
-            self.__prevent_duplicate_callbacks = justknobs_check(
-                "pytorch/dynamo:prevent_duplicate_callbacks"
-            )
-        return self.__prevent_duplicate_callbacks
-
     @contextmanager
     def install_callbacks(self) -> Generator[None, Any, Any]:
         """
         Context manager to install the callbacks and run them when the context is exited.
         """
-        if self.prevent_duplicate_callbacks:
-            try:
-                with self.__pending_callbacks_counter_lock:
-                    if self.__pending_callbacks_counter == 0:
-                        self.run_start_callbacks()
-                    self.__pending_callbacks_counter += 1
-                yield
-            finally:
-                with self.__pending_callbacks_counter_lock:
-                    assert self.__pending_callbacks_counter > 0, (
-                        "Pending callbacks counter cannot become negative."
-                    )
-                    if self.__pending_callbacks_counter == 1:
-                        self.run_end_callbacks()
-                    self.__pending_callbacks_counter -= 1
-        else:
-            try:
-                self.run_start_callbacks()
-                yield
-            finally:
-                self.run_end_callbacks()
+        try:
+            with self.__pending_callbacks_counter_lock:
+                if self.__pending_callbacks_counter == 0:
+                    self.run_start_callbacks()
+                self.__pending_callbacks_counter += 1
+            yield
+        finally:
+            with self.__pending_callbacks_counter_lock:
+                assert self.__pending_callbacks_counter > 0, (
+                    "Pending callbacks counter cannot become negative."
+                )
+                if self.__pending_callbacks_counter == 1:
+                    self.run_end_callbacks()
+                self.__pending_callbacks_counter -= 1
 
     def clear(self) -> None:
         """

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -620,10 +620,7 @@ def compile_fx_inner(
                 dynamo_compile_column_us="inductor_cumulative_compile_time_us",
             )
         )
-
-        if torch._dynamo.callback_handler.prevent_duplicate_callbacks:
-            stack.enter_context(torch._dynamo.callback_handler.install_callbacks())
-
+        stack.enter_context(torch._dynamo.callback_handler.install_callbacks())
         stack.enter_context(with_fresh_cache_if_config())
         stack.enter_context(DebugContext())
         CompileEventLogger.pt2_compile(


### PR DESCRIPTION
Summary: This diff cleans up the JK we used for enabling `add pt2 callbacks for backward pass and prevent duplicate callbacks` feature.

Differential Revision: D70643543




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov