### PR TITLE
[ONNX] Improve verify_onnx_program to use VerificationInterpreter

### DIFF
--- a/test/onnx/exporter/test_verification.py
+++ b/test/onnx/exporter/test_verification.py
@@ -69,5 +69,37 @@ class VerificationInterpreterTest(common_utils.TestCase):
             self.assertEqual(info.max_rel_diff, 0)
 
 
+class VerificationFunctionsTest(common_utils.TestCase):
+    def test_verify_onnx_program(self):
+        class Model(torch.nn.Module):
+            def forward(self, a, b):
+                c = a + b
+                return c - 1, c
+
+        model = Model()
+        args = (torch.tensor([1.0]), torch.tensor([2.0]))
+        onnx_program = torch.onnx.export(model, args, dynamo=True, verbose=False)
+        assert onnx_program is not None
+        verification_infos = _verification.verify_onnx_program(
+            onnx_program, args, compare_intermediates=False
+        )
+        self.assertEqual(len(verification_infos), 2)
+
+    def test_verify_onnx_program_with_compare_intermediates_true(self):
+        class Model(torch.nn.Module):
+            def forward(self, a, b):
+                c = a + b
+                return c - 1, c
+
+        model = Model()
+        args = (torch.tensor([1.0]), torch.tensor([2.0]))
+        onnx_program = torch.onnx.export(model, args, dynamo=True, verbose=False)
+        assert onnx_program is not None
+        verification_infos = _verification.verify_onnx_program(
+            onnx_program, args, compare_intermediates=True
+        )
+        self.assertEqual(len(verification_infos), 3)
+
+
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/test/onnx/exporter/test_verification.py
+++ b/test/onnx/exporter/test_verification.py
@@ -59,7 +59,7 @@ class VerificationInterpreterTest(common_utils.TestCase):
         args = (torch.tensor([1.0]), torch.tensor([2.0]))
         onnx_program = torch.onnx.export(model, args, dynamo=True, verbose=False)
         assert onnx_program is not None
-        interpreter = _verification.VerificationInterpreter(onnx_program)
+        interpreter = _verification._VerificationInterpreter(onnx_program)
         results = interpreter.run(args)
         torch.testing.assert_close(results, model(*args))
         verification_infos = interpreter.verification_infos

--- a/torch/onnx/_internal/exporter/_verification.py
+++ b/torch/onnx/_internal/exporter/_verification.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 __all__ = [
     "VerificationInfo",
-    "VerificationInterpreter",
     "verify_onnx_program",
 ]
 
@@ -108,7 +107,20 @@ def verify_onnx_program(
     onnx_program: _onnx_program.ONNXProgram,
     args: tuple[Any, ...] | None = None,
     kwargs: dict[str, Any] | None = None,
+    verify_intermediates: bool = False,
 ) -> list[VerificationInfo]:
+    """Verify the ONNX model by comparing the values with the expected values from ExportedProgram.
+
+    Args:
+        onnx_program: The ONNX program to verify.
+        args: The input arguments for the model.
+        kwargs: The keyword arguments for the model.
+        verify_intermediates: Whether to verify intermediate values. This is going
+            to take longer time, so it is disabled by default.
+
+    Returns:
+        VerificationInfo objects containing the verification information for each value.
+    """
     exported_program = onnx_program.exported_program
     if exported_program is None:
         raise ValueError(
@@ -127,21 +139,32 @@ def verify_onnx_program(
         args = ()
     if kwargs is None:
         kwargs = {}
-    torch_module = exported_program.module()
-    torch_outputs, _ = _pytree.tree_flatten(torch_module(*args, **kwargs))
-    onnx_outputs = onnx_program(*args, **kwargs)
+
+    # Flatten args for ONNX program and the VerificationInterpreter
+    flat_args, _ = exported_program._get_flat_args_with_check(args, kwargs)
+
+    # Get the output values first
+    torch_outputs, _ = _pytree.tree_flatten(exported_program.module()(*args, **kwargs))
+    onnx_outputs = onnx_program(*flat_args)
     results = []
     for torch_output, onnx_output, output_val in zip(
         torch_outputs, onnx_outputs, onnx_program.model.graph.outputs
     ):
-        name = output_val.name
         results.append(
             VerificationInfo.from_tensors(
-                name=str(name),
+                name=str(output_val.name),
                 expected=torch_output,
                 actual=onnx_output,
             )
         )
+    if not verify_intermediates:
+        return results
+
+    # Use the _VerificationInterpreter to get the intermediate values
+    interpreter = _VerificationInterpreter(onnx_program)
+    interpreter.run(*flat_args)
+    results.extend(interpreter.verification_infos)
+
     return results
 
 
@@ -171,7 +194,7 @@ def _create_value_mapping(graph: ir.Graph) -> dict[str, ir.Value]:
     return values
 
 
-class VerificationInterpreter(torch.fx.Interpreter):
+class _VerificationInterpreter(torch.fx.Interpreter):
     """Interpreter for verifying converted ONNX model accuracy by comparing intermediate values.
 
     To compare models, first initialize the interpreter with an ONNX program.
@@ -181,7 +204,7 @@ class VerificationInterpreter(torch.fx.Interpreter):
 
     ::
         onnx_program = torch.onnx.export(model, args, dynamo=True)
-        interpreter = VerificationInterpreter(onnx_program)
+        interpreter = _VerificationInterpreter(onnx_program)
         interpreter.run(*args)
         verification_infos = interpreter.verification_infos
         for info in verification_infos:
@@ -197,7 +220,7 @@ class VerificationInterpreter(torch.fx.Interpreter):
     """
 
     def __init__(self, onnx_program: torch.onnx.ONNXProgram) -> None:
-        """Initialize the VerificationInterpreter with an ONNX program.
+        """Initialize the _VerificationInterpreter with an ONNX program.
 
         Args:
             onnx_program: The ONNX program to verify.
@@ -210,7 +233,7 @@ class VerificationInterpreter(torch.fx.Interpreter):
         super().__init__(onnx_program.exported_program.module())
         self._onnx_program = onnx_program
         self._onnx_values = _create_value_mapping(onnx_program.model.graph)
-        self._args: list[Any] = []
+        self._args: tuple[Any, ...] = ()
         self.verification_infos: list[VerificationInfo] = []
 
     def run(
@@ -233,7 +256,7 @@ class VerificationInterpreter(torch.fx.Interpreter):
             Any: The result of executing the model.
         """
         self.verification_infos = []
-        self.args = args
+        self._args = args
         return super().run(
             *args,
             initial_env=initial_env,
@@ -247,7 +270,7 @@ class VerificationInterpreter(torch.fx.Interpreter):
         node_name = n.name
         if node_name not in self._onnx_values:
             return result
-        (onnx_result,) = self._onnx_program.compute_values([node_name], self.args)
+        (onnx_result,) = self._onnx_program.compute_values([node_name], self._args)
         info = VerificationInfo.from_tensors(
             name=node_name,
             expected=result,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #148707
* __->__ #148706

I realized we can just extend `verify_onnx_program` to return intermediate values. There is no need for us to expose the VerificationInterpreter to users.

I added a `compare_intermediates` option to `verify_onnx_program`.