### PR TITLE
fix lost input mutations with export_tracepoint

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -9443,6 +9443,37 @@ graph():
         ufm = torch.export.unflatten(ep)
         self.assertTrue(torch.allclose(ufm(*inp), epm(*inp)))
 
+    def test_placeholder_update_preserving(self):
+        class Child(torch.nn.Module):
+            def forward(self, x):
+                a = x.add_(3)
+                return a - 2
+
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.child = Child()
+
+            def forward(self, x):
+                f1 = self.child(x)  # x <- 1 + 3 = 4, x - 2 = 2
+                f2 = x * 4  # x * 4 = 16
+                return f1 + f2
+
+        inp = torch.ones(2, 3, dtype=torch.float32)
+        ep1 = export(Foo(), (inp,))
+        inp = torch.ones(2, 3, dtype=torch.float32)
+        ep2 = export(Foo(), (inp,), preserve_module_call_signature=("child",))
+
+        inp = torch.ones(2, 3, dtype=torch.float32)
+        orig_result = Foo()(inp)
+
+        inp = torch.ones(2, 3, dtype=torch.float32)
+        ep1_result = ep1.module()(inp)
+        self.assertTrue(torch.allclose(ep1_result, orig_result))
+        inp = torch.ones(2, 3, dtype=torch.float32)
+        ep2_result = ep2.module()(inp)
+        self.assertTrue(torch.allclose(ep2_result, orig_result))
+
     @testing.expectedFailureLegacyExportNonStrict
     @testing.expectedFailureLegacyExportStrict
     def test_constant_tensor_with_non_functional(self):

--- a/torch/_export/wrappers.py
+++ b/torch/_export/wrappers.py
@@ -44,8 +44,8 @@ def export_tracepoint_functional(ctx, *args, **kwargs):
     unwrapped_kwargs = ctx.unwrap_tensors(kwargs)
 
     with ctx.redispatch_to_next():
-        out = _export_tracepoint(*unwrapped_args, **unwrapped_kwargs)
-        return ctx.wrap_tensors(out)
+        _export_tracepoint(*unwrapped_args, **unwrapped_kwargs)
+        return args
 
 
 _export_tracepoint.py_impl(DispatchKey.Autograd)(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148709

Preserving module call signatures in the presence of input mutation cause incorrect results. The root cause turned out to be that export tracepoints would unwrap / wrap functional args that would lose mutation info on those args.

Differential Revision: [D70734821](https://our.internmc.facebook.com/intern/diff/D70734821/)