### PR TITLE
[mm_logs] enhance the printing for overview info

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -836,6 +836,14 @@ def _compile_fx_inner(
 
     log.debug("FX codegen and compilation took %.3fs", time.time() - start)
 
+    # This message is for printing overview information of inductor mm counts, shapes,etc after lowering
+    log.info(
+        "Overview info of inductor aten mms: %s",
+        ", ".join(
+            f"({key}: {value})" for key, value in counters["aten_mm_info"].items()
+        ),
+    )
+
     # Clear Compiled Triton Kernels per inductor compile, as the future objects
     # may not be valid for use after they are run/autotuned
     torch._inductor.async_compile.CompiledTritonKernels.cache_clear()

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -170,7 +170,7 @@ def tuned_bmm(mat1, mat2, *, layout=None):
     m, n, k, layout, mat1, mat2 = mm_args(mat1, mat2, layout=layout)
 
     # below is for getting an overview logging info of inductor mms
-    counters["inductor"][f"aten.bmm_{m}_{n}_{k}"] += 1
+    counters["aten_mm_info"][f"aten.bmm_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten.bmm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,
@@ -220,7 +220,7 @@ def tuned_baddbmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     m, n, k, layout, mat1, mat2, inp = mm_args(mat1, mat2, inp, layout=layout)
 
     # below is for getting an overview logging info of inductor mms
-    counters["inductor"][f"aten.baddbmm_{m}_{n}_{k}"] += 1
+    counters["aten_mm_info"][f"aten.baddbmm_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten.baddbmm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, inp=%s, output_layout=%s",
         m,

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -360,7 +360,7 @@ def tuned_mm(mat1, mat2, *, layout=None):
     name = "mm"
 
     # below is for getting an overview logging info of inductor mms
-    counters["inductor"][f"aten.mm_{m}_{n}_{k}"] += 1
+    counters["aten_mm_info"][f"aten.mm_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten.mm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,
@@ -482,7 +482,7 @@ def tuned_int_mm(mat1, mat2, *, layout=None):
     )
 
     # below is for getting an overview logging info of inductor mms
-    counters["inductor"][f"aten._int_mm_{m}_{n}_{k}"] += 1
+    counters["aten_mm_info"][f"aten._int_mm_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten._int_mm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,
@@ -528,7 +528,7 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     static_shape, is_nonzero = _is_static_problem(layout)
 
     # below is for getting an overview logging info of inductor mms
-    counters["inductor"][f"aten.addmm_{m}_{n}_{k}"] += 1
+    counters["aten_mm_info"][f"aten.addmm_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten.addmm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,

--- a/torch/_inductor/kernel/mm_scaled.py
+++ b/torch/_inductor/kernel/mm_scaled.py
@@ -509,7 +509,7 @@ def tuned_scaled_mm(
         mat_a, mat_b, layout=layout, out_dtype=out_dtype
     )
     # below is for getting an overview logging info of inductor mms
-    counters["inductor"][f"aten._scaled_mm.default_{m}_{n}_{k}"] += 1
+    counters["aten_mm_info"][f"aten._scaled_mm.default_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten._scaled_mm.default: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,


### PR DESCRIPTION
Summary:
previously the dynamo counters does not print the counts information automatically.


explicitly added a log msg to print after lowering for overview info for inductor aten mms

it will look like:

the name is in `{aten_op_name}_{m}_{n}_{k}`
```
torch/_inductor/compile_fx.py:832] [0/0] Overview info of inductor aten mms: (aten.addmm_16_6_16: 1), (name: count), xxx
```

 {F1975874802}

Test Plan:
```
TORCH_LOGS="+inductor" buck2 run -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=h100 @//mode/opt fbcode//caffe2/test/inductor:test_aot_inductor -- -r test_addmm_cuda
```

Differential Revision: D70739912




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov