### PR TITLE
[MPS][BE] Align bitshift behavior with CPU

### DIFF
--- a/aten/src/ATen/native/mps/operations/BitwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/BitwiseOps.mm
@@ -62,42 +62,42 @@ kernel void bitwise_lshift_tensor_tensor(device {0}  *out [[buffer(0)]],
                          constant {1}  *a [[buffer(1)]],
                          constant {2}  *b [[buffer(2)]],
                          uint offset [[thread_position_in_grid]]) {{
-  out[offset] = a[offset] << b [offset];
+  out[offset] = static_cast<{0}>(a[offset]) << b [offset];
 }}
 
 kernel void bitwise_lshift_tensor_scalar(device {0}  *out [[buffer(0)]],
                          constant {1}  *a [[buffer(1)]],
                          constant {2}  &b [[buffer(2)]],
                          uint offset [[thread_position_in_grid]]) {{
-  out[offset] = a[offset] << b;
+  out[offset] = static_cast<{0}>(a[offset]) << b;
 }}
 
 kernel void bitwise_lshift_scalar_tensor(device {0}  *out [[buffer(0)]],
                          constant {1}  &a [[buffer(1)]],
                          constant {2}  *b [[buffer(2)]],
                          uint offset [[thread_position_in_grid]]) {{
-  out[offset] = a << b[offset];
+  out[offset] = static_cast<{0}>(a) << b[offset];
 }}
 
 kernel void bitwise_rshift_tensor_tensor(device {0}  *out [[buffer(0)]],
                          constant {1}  *a [[buffer(1)]],
                          constant {2}  *b [[buffer(2)]],
                          uint offset [[thread_position_in_grid]]) {{
-  out[offset] = a[offset] >> b [offset];
+  out[offset] = static_cast<{0}>(a[offset]) >> b [offset];
 }}
 
 kernel void bitwise_rshift_tensor_scalar(device {0}  *out [[buffer(0)]],
                          constant {1}  *a [[buffer(1)]],
                          constant {2}  &b [[buffer(2)]],
                          uint offset [[thread_position_in_grid]]) {{
-  out[offset] = a[offset] >> b;
+  out[offset] = static_cast<{0}>(a[offset]) >> b;
 }}
 
 kernel void bitwise_rshift_scalar_tensor(device {0}  *out [[buffer(0)]],
                          constant {1}  &a [[buffer(1)]],
                          constant {2}  *b [[buffer(2)]],
                          uint offset [[thread_position_in_grid]]) {{
-  out[offset] = a >> b[offset];
+  out[offset] = static_cast<{0}>(a) >> b[offset];
 }}
 
 kernel void bitwise_not(device {0}  *out [[buffer(0)]],

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8785,9 +8785,8 @@ class TestLogical(TestCaseMPS):
     @parametrize("dtype", [torch.int32, torch.int64, torch.int16, torch.int8, torch.uint8, torch.bool])
     def test_shifts(self, dtype):
         x = make_tensor(256, device="mps", dtype=dtype)
-        max_val = torch.iinfo(dtype).max if dtype != torch.bool else 1
         if dtype is not torch.bool:
-            x[3] = max_val
+            x[3] = torch.iinfo(dtype).max
             x[5] = torch.iinfo(dtype).min
         x_cpu = x.cpu()
         self.assertEqual((x >> 3).cpu(), x_cpu >> 3)
@@ -8795,8 +8794,8 @@ class TestLogical(TestCaseMPS):
         # Regression test for https://github.com/pytorch/pytorch/issues/147889
         x = x.clamp(0, 8)
         x_cpu = x.cpu()
-        self.assertEqual((max_val >> x).cpu(), max_val >> x_cpu)
-        self.assertEqual((1 << x).cpu(), 1 << x_cpu)
+        self.assertEqual((4095 >> x).cpu(), 4095 >> x_cpu)
+        self.assertEqual((257 << x).cpu(), 257 << x_cpu)
 
 
 class TestSmoothL1Loss(TestCaseMPS):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148719
* #148686
* #148685

By casting the argument to output type