### PR TITLE
Don't clear feedback_saver_fns after cache clear

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1649,7 +1649,6 @@ class AlgorithmSelectorCache(PersistentCache):
 
     def cache_clear(self) -> None:
         self.precompile_cache.clear()
-        self.feedback_saver_fns.clear()
 
     def __call__(
         self,


### PR DESCRIPTION
Summary:
Since feedback_saver_fns are used for logging, I don't think it makes sense to clear them, and this resulted in weird behavior in user code where disabling caches caused logging code to break. 



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov