### PR TITLE
[ONNX] Handle error in verification interpreter

### DIFF
--- a/torch/onnx/_internal/exporter/_verification.py
+++ b/torch/onnx/_internal/exporter/_verification.py
@@ -272,7 +272,15 @@ class _VerificationInterpreter(torch.fx.Interpreter):
         node_name = n.name
         if node_name not in self._onnx_values:
             return result
-        (onnx_result,) = self._onnx_program.compute_values([node_name], self._args)
+        try:
+            (onnx_result,) = self._onnx_program.compute_values([node_name], self._args)
+        except Exception as e:
+            logger.warning(
+                "Failed to compute value for node %s: %s",
+                node_name,
+                e,
+            )
+            return result
         info = VerificationInfo.from_tensors(
             name=node_name,
             expected=result,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #148707
* __->__ #148730

Use a simple try catch to handle onnx runtime errors in the verification interpreter when that happens. One example is ort will sometimes produce a list of None for some nodes. I am not sure how that happens yet.
