### PR TITLE
[Inductor][Windows] add env_var switch to turn all Windows inductor UTs.

### DIFF
--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -11,6 +11,7 @@ It includes:
 import contextlib
 import importlib
 import logging
+import os
 from typing import Union
 
 import torch
@@ -29,13 +30,24 @@ from . import config, reset, utils
 log = logging.getLogger(__name__)
 
 
+def check_skip_windows_inductor_UTs_switch():
+    if not IS_WINDOWS:
+        return False
+
+    var = os.environ.get("RUN_ALL_WIN_INDUCTOR_UTS", "OFF")
+    if var in ["ON", "YES", "1", "Y"]:
+        return False
+
+    return True
+
+
 def run_tests(needs: Union[str, tuple[str, ...]] = ()) -> None:
     from torch.testing._internal.common_utils import run_tests
 
     if TEST_WITH_TORCHDYNAMO or TEST_WITH_CROSSREF:
         return  # skip testing
 
-    if not torch.xpu.is_available() and IS_WINDOWS:
+    if not torch.xpu.is_available() and check_skip_windows_inductor_UTs_switch():
         return
 
     if isinstance(needs, str):

--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -30,17 +30,6 @@ from . import config, reset, utils
 log = logging.getLogger(__name__)
 
 
-def check_skip_windows_inductor_UTs_switch() -> bool:
-    if not IS_WINDOWS:
-        return False
-
-    var = os.environ.get("RUN_ALL_WIN_INDUCTOR_UTS", "OFF")
-    if var in ["ON", "YES", "1", "Y"]:
-        return False
-
-    return True
-
-
 def run_tests(needs: Union[str, tuple[str, ...]] = ()) -> None:
     from torch.testing._internal.common_utils import run_tests
 

--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -36,7 +36,11 @@ def run_tests(needs: Union[str, tuple[str, ...]] = ()) -> None:
     if TEST_WITH_TORCHDYNAMO or TEST_WITH_CROSSREF:
         return  # skip testing
 
-    if not torch.xpu.is_available() and IS_WINDOWS and os.environ.get("TORCHINDUCTOR_WINDOWS_TESTS", "0") == "0":
+    if (
+        not torch.xpu.is_available()
+        and IS_WINDOWS
+        and os.environ.get("TORCHINDUCTOR_WINDOWS_TESTS", "0") == "0"
+    ):
         return
 
     if isinstance(needs, str):

--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -47,7 +47,7 @@ def run_tests(needs: Union[str, tuple[str, ...]] = ()) -> None:
     if TEST_WITH_TORCHDYNAMO or TEST_WITH_CROSSREF:
         return  # skip testing
 
-    if not torch.xpu.is_available() and check_skip_windows_inductor_UTs_switch():
+    if not torch.xpu.is_available() and IS_WINDOWS and os.environ.get("TORCHINDUCTOR_WINDOWS_TESTS", "0") == "0":
         return
 
     if isinstance(needs, str):

--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -30,7 +30,7 @@ from . import config, reset, utils
 log = logging.getLogger(__name__)
 
 
-def check_skip_windows_inductor_UTs_switch():
+def check_skip_windows_inductor_UTs_switch() -> bool:
     if not IS_WINDOWS:
         return False
 


### PR DESCRIPTION
For timeout reason, we can't turn on all Windows Inductor UTs in CI: https://github.com/pytorch/pytorch/issues/135927 
And without the UTs, we can't ensure Windows inductor quality.

Intel team will do some local test for Windows inductor, but we still need to add a switch to turn on the full Windows inductor UTs.

The switch is an environment variable:
```cmd
set TORCHINDUCTOR_WINDOWS_TESTS=1
```
After setup this environment variable, we can turn on all Windows inductor UTs, It will not affect to PyTorch CI.

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames