### PR TITLE
[pytree][easy] lock global registry containers properly for thread-safety

### DIFF
--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -146,7 +146,7 @@ class NodeDef(NamedTuple):
     flatten_with_keys_fn: Optional[FlattenWithKeysFunc]
 
 
-_NODE_REGISTRY_LOCK = threading.Lock()
+_NODE_REGISTRY_LOCK = threading.RLock()
 SUPPORTED_NODES: dict[type[Any], NodeDef] = {}
 
 
@@ -371,13 +371,14 @@ def register_constant(cls: type[Any]) -> None:
     def _flatten_with_keys(x):  # type: ignore[no-untyped-def]
         return [], ConstantNode(x)
 
-    _private_register_pytree_node(
-        cls,
-        _flatten,
-        _unflatten,
-        flatten_with_keys_fn=_flatten_with_keys,
-    )
-    CONSTANT_NODES.add(cls)
+    with _NODE_REGISTRY_LOCK:
+        _private_register_pytree_node(
+            cls,
+            _flatten,
+            _unflatten,
+            flatten_with_keys_fn=_flatten_with_keys,
+        )
+        CONSTANT_NODES.add(cls)
 
 
 def is_constant_class(cls: type[Any]) -> bool:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148750



cc @zou3519