### PR TITLE
Fix redistribution cost for all-reduce

### DIFF
--- a/torch/distributed/tensor/_collective_utils.py
+++ b/torch/distributed/tensor/_collective_utils.py
@@ -297,7 +297,7 @@ def allreduce_cost(bytes_gb: float, mesh_topo: MeshTopoInfo, mesh_dim: int) -> f
     num_devices_on_mesh_dim = mesh_topo.mesh_dim_devices[mesh_dim]
     mesh_dim_bandwidth = mesh_topo.mesh_dim_bandwidth[mesh_dim]
     # allreduce have almost 2x comm bytes compare to allgather/reduce_scatter
-    num_hops = 2 * num_devices_on_mesh_dim - 1
+    num_hops = 2 * (num_devices_on_mesh_dim - 1)
 
     latency = 6.6 + num_hops * mesh_topo.mesh_dim_latency[mesh_dim]
     bw = (bytes_gb * num_hops / num_devices_on_mesh_dim) / mesh_dim_bandwidth


### PR DESCRIPTION
This issue seems to have been introduced in https://github.com/pytorch/pytorch/pull/119897. With the current implementation, it might be more favorable to perform a reduce_scatter followed by an all-gather than simply an all-reduce.

Thanks @lw for the helpful discussions on getting this PR out!

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o