### PR TITLE
[cutlass backend][ez] Incorporate AOTI dynamic shape test into main test of MM

### DIFF
--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -232,53 +232,6 @@ class TestCutlassBackend(TestCase):
             torch.testing.assert_close(Y_compiled, Y)
 
     @unittest.skipIf(not SM90OrLater, "need sm_90")
-    @mock.patch.dict(os.environ, {"PATH": _get_path_without_sccache()})
-    def test_aoti_rerun_with_different_shapes(self):
-        """
-        Compile with one shape, then re-run with different input shapes
-        """
-        max_autotune_gemm_backends = "CUTLASS"
-
-        class MyModel(torch.nn.Module):
-            def forward(self, a, b):
-                return a @ b
-
-        model = MyModel()
-        a = torch.randn(128, 16).cuda().half()
-        b = torch.randn(16, 512).cuda().half()
-        x = torch.randn(256, 32).cuda().half()
-        y = torch.randn(32, 256).cuda().half()
-
-        with config.patch(
-            {
-                "max_autotune": True,
-                "autotune_in_subproc": True,
-                "max_autotune_gemm_backends": max_autotune_gemm_backends,
-                "cuda.cutlass_max_profiling_configs": 3,
-                "autotune_fallback_to_aten": False,
-            }
-        ):
-            from torch.export import Dim
-
-            M = Dim("M", min=1, max=1024)
-            N = Dim("N", min=1, max=1024)
-            K = Dim("K", min=1, max=1024)
-            dynamic_shapes = {
-                "a": {0: M, 1: K},
-                "b": {0: K, 1: N},
-            }
-
-            actual = AOTIRunnerUtil.run_multiple(
-                "cuda",
-                model,
-                [(a, b), (x, y)],
-                dynamic_shapes=dynamic_shapes,
-            )
-            expected = [model(a, b), model(x, y)]
-            torch.testing.assert_close(actual[0], expected[0])
-            torch.testing.assert_close(actual[1], expected[1])
-
-    @unittest.skipIf(not SM90OrLater, "need sm_90")
     @parametrize("dynamic", (False, True))
     @mock.patch.dict(os.environ, {"PATH": _get_path_without_sccache()})
     def test_diff_matmul_share_same_kernel(self, dynamic):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148786



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov