### PR TITLE
Add timm_efficientnet to flaky models after cuda 12.6 update in CI/CD

### DIFF
--- a/benchmarks/dynamo/check_accuracy.py
+++ b/benchmarks/dynamo/check_accuracy.py
@@ -12,6 +12,7 @@ flaky_models = {
     "yolov3",
     "gluon_inception_v3",
     "detectron2_maskrcnn_r_101_c4",
+    "timm_efficientnet", # see https://github.com/pytorch/pytorch/issues/148699
     "XGLMForCausalLM",  # discovered in https://github.com/pytorch/pytorch/pull/128148
 }
 

--- a/benchmarks/dynamo/check_accuracy.py
+++ b/benchmarks/dynamo/check_accuracy.py
@@ -12,7 +12,7 @@ flaky_models = {
     "yolov3",
     "gluon_inception_v3",
     "detectron2_maskrcnn_r_101_c4",
-    "timm_efficientnet", # see https://github.com/pytorch/pytorch/issues/148699
+    "timm_efficientnet",  # see https://github.com/pytorch/pytorch/issues/148699
     "XGLMForCausalLM",  # discovered in https://github.com/pytorch/pytorch/pull/128148
 }
 


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/pull/148612
This model have become flaky

Tracking this regression in an issue : https://github.com/pytorch/pytorch/issues/148699


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames