### PR TITLE
Set specialized representation string for meta/fake tensor with empty construction

### DIFF
--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -598,13 +598,12 @@ def _str_intern(inp, *, tensor_contents=None):
         from torch._subclasses.fake_tensor import FakeTensor
 
         if self.is_meta or isinstance(self, FakeTensor):
-            suffixes.append("size=" + str(tuple(self.shape)))
             if self.dtype != torch.get_default_dtype():
                 suffixes.append("dtype=" + str(self.dtype))
-            # TODO: This implies that ellipses is valid syntax for allocating
-            # a meta tensor or FakeTensor, which it could be, but it isn't right now
+            # Redirect construction to `torch.empty` and use size as the positional argument.
             if not custom_contents_provided:
-                tensor_str = "..."
+                prefix = "torch.empty("
+                tensor_str = str(tuple(self.shape))
         else:
             if self.numel() == 0 and not self.is_sparse:
                 # Explicitly print the shape if it is not (0,), to match NumPy behavior


### PR DESCRIPTION
This is done so that the output of the representation is a valid pytorch code.

Now we can do:

```python
>>> import torch
>>> torch.empty((3,4), device='meta', dtype=torch.float64)
torch.empty((3, 4), device='meta', dtype=torch.float64)
```

Which allows to roundtrip repl with `eval`

Alternative is to allow the elliptical construction of tensor. However, this is a far bigger change to make, and we will have to alter accepted signature of tensor() to retrofit the usecase.

Fixes #147643
