### PR TITLE
[cudagraph] add log for skip reasons

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1231,6 +1231,7 @@ class CompilationMetrics:
     num_graph_breaks: Optional[int] = None
     triton_kernel_compile_times_us: Optional[str] = None
     ir_count: Optional[int] = None
+    cudagraph_skip_reason: Optional[str] = None
 
     @classmethod
     def create(cls, metrics: dict[str, Any]):

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Any, Callable, Optional, TYPE_CHECKING, Union
 
 import torch
-from torch._dynamo.utils import counters
+from torch._dynamo.utils import counters, get_metrics_context
 from torch._inductor.utils import InputType
 from torch.utils._ordered_set import OrderedSet
 
@@ -193,6 +193,9 @@ def check_lowering_disable_cudagraph(
 def log_cudagraph_skip_and_bump_counter(msg: str) -> None:
     perf_hint_log.warning(msg)
     counters["inductor"]["cudagraph_skips"] += 1
+    metrics_context = get_metrics_context()
+    if metrics_context.in_progress():
+        metrics_context.set("cudagraph_skip_reason", msg, overwrite=True)
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Summary: Add skip reasons to dynamo_compile so we can know popular skip reasons for cudagraph

Test Plan: {F1975906635}

Differential Revision: D70820791




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov