### PR TITLE
[ca] support for dynamic shapes CopySlices

### DIFF
--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -502,15 +502,24 @@ class AutogradCompilerInstance:
             self.bind_objects_to_proxies(grad_ins, proxies)
         return tuple(grad_ins)
 
-    def call_copy_slices_prologue(self, inputs, base, view):
+    def call_copy_slices_prologue(
+        self,
+        inputs,
+        base_sizes,
+        base_strides,
+        base_storage_offset,
+        view_sizes,
+        view_strides,
+        view_storage_offset,
+    ):
         args = (
             inputs,
-            base.sizes(),
-            base.strides(),
-            base.storage_offset(),
-            view.sizes(),
-            view.strides(),
-            view.storage_offset(),
+            self.to_proxy(base_sizes),
+            self.to_proxy(base_strides),
+            self.to_proxy(base_storage_offset),
+            self.to_proxy(view_sizes),
+            self.to_proxy(view_strides),
+            self.to_proxy(view_storage_offset),
         )
         return self.proxy_call(copy_slices_prologue, args, [None] * 3)
 
@@ -1252,7 +1261,7 @@ in_compiled_autograd_region = False
 
 
 @contextlib.contextmanager
-def _enable(compiler_fn, dynamic=False):
+def _enable(compiler_fn, dynamic=True):
     if dynamic:
         assert type(dynamic) is bool
 

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -1261,7 +1261,7 @@ in_compiled_autograd_region = False
 
 
 @contextlib.contextmanager
-def _enable(compiler_fn, dynamic=True):
+def _enable(compiler_fn, dynamic=False):
     if dynamic:
         assert type(dynamic) is bool
 

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -270,9 +270,9 @@ variable_list CopySlices::apply_with_saved(
     TORCH_INTERNAL_ASSERT(stuff.size() == 3);
     // These variables are named the same as in CopySlices::apply_impl.
     // Follow along there.
-    auto result = stuff[0];
-    auto grad_slice = stuff[1];
-    auto grad_slice_clone = stuff[2];
+    const auto& result = stuff[0];
+    const auto& grad_slice = stuff[1];
+    const auto& grad_slice_clone = stuff[2];
     auto res = fn->apply_with_saved({grad_slice_clone}, saved);
     results = interface->call_copy_slices_epilogue(
         saved.get_py_compiler(), needs_input_grad, result, res, grad_slice);

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -39,7 +39,7 @@ struct TORCH_API PyCompilerInterface {
       // NOLINTNEXTLINE(performance-unnecessary-value-param)
       std::vector<at::TypePtr> packed_args_schema,
       bool is_custom_function = false,
-      bool is_traceable = true) {
+      bool is_traceable = true) const {
     TORCH_INTERNAL_ASSERT(false, "Needs to be overridden");
   }
 
@@ -51,14 +51,14 @@ struct TORCH_API PyCompilerInterface {
       const std::string& fn_name,
       const variable_list& inputs,
       const ivalue_list& packed_args,
-      const c10::IValue& output_metadata) {
+      const c10::IValue& output_metadata) const {
     TORCH_INTERNAL_ASSERT(false, "Needs to be overridden");
   }
   virtual variable_list call_copy_slices_prologue(
       PyObject* py_compiler,
       const variable_list& inputs,
       const at::TensorGeometry& base,
-      const at::TensorGeometry& view) {
+      const at::TensorGeometry& view) const {
     TORCH_INTERNAL_ASSERT(false, "Needs to be overridden");
   }
   virtual variable_list call_copy_slices_epilogue(
@@ -66,13 +66,13 @@ struct TORCH_API PyCompilerInterface {
       const std::vector<bool>& needs_input_grad,
       const at::Tensor& result,
       const variable_list& res,
-      const at::Tensor& grad_slice) {
+      const at::Tensor& grad_slice) const {
     TORCH_INTERNAL_ASSERT(false, "Needs to be overridden");
   }
   virtual at::Tensor call_unpack(
       PyObject* py_compiler,
       std::optional<size_t> hook_id,
-      size_t hook_input_id) {
+      size_t hook_input_id) const {
     TORCH_INTERNAL_ASSERT(false, "Needs to be overridden");
   }
 };

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -201,7 +201,7 @@ struct PyCompilerInterfaceImpl : PyCompilerInterface {
         view.sym_sizes(),
         view.sym_strides(),
         view.sym_storage_offset());
-    return py::cast<std::vector<at::Tensor>>(stuff);
+    return py::cast<std::vector<at::Tensor>>(std::move(stuff));
   }
   variable_list call_copy_slices_epilogue(
       PyObject* py_compiler,
@@ -212,7 +212,8 @@ struct PyCompilerInterfaceImpl : PyCompilerInterface {
     py::handle handle(py_compiler);
     py::object stuff = handle.attr("call_copy_slices_epilogue")(
         needs_input_grad, result, res, grad_slice);
-    auto output = py::cast<std::vector<std::optional<at::Tensor>>>(stuff);
+    auto output =
+        py::cast<std::vector<std::optional<at::Tensor>>>(std::move(stuff));
     return toTensorList(output);
   }
   at::Tensor call_unpack(
@@ -713,7 +714,7 @@ static at::Tensor call_accumulate(
   }
   py::handle handle(py_compiler);
   py::object stuff = handle.attr("accumulate")(old_var, new_var);
-  return py::cast<at::Tensor>(stuff);
+  return py::cast<at::Tensor>(std::move(stuff));
 }
 
 static TraceState call_begin_capture(

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -152,7 +152,7 @@ static variable_list call_function(
       jit::toPyObject(output_metadata));
 
   // Convert the output from PyObject* to vector<Tensor>
-  auto tmp = py::cast<std::vector<std::optional<at::Tensor>>>(stuff);
+  auto tmp = py::cast<std::vector<std::optional<at::Tensor>>>(std::move(stuff));
   return toTensorList(tmp);
 }
 

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -163,7 +163,7 @@ struct PyCompilerInterfaceImpl : PyCompilerInterface {
       functional_apply_t fn,
       std::vector<at::TypePtr> packed_args_schema,
       bool is_custom_function = false,
-      bool is_traceable = true) override {
+      bool is_traceable = true) const override {
     return torch::dynamo::autograd::bind_function(
         py_compiler,
         fn_name,
@@ -178,7 +178,7 @@ struct PyCompilerInterfaceImpl : PyCompilerInterface {
       const std::string& fn_name,
       const variable_list& inputs,
       const ivalue_list& packed_args,
-      const c10::IValue& output_metadata) override {
+      const c10::IValue& output_metadata) const override {
     return torch::dynamo::autograd::call_function(
         py_compiler,
         method_name,
@@ -191,10 +191,16 @@ struct PyCompilerInterfaceImpl : PyCompilerInterface {
       PyObject* py_compiler,
       const variable_list& inputs,
       const at::TensorGeometry& base,
-      const at::TensorGeometry& view) override {
+      const at::TensorGeometry& view) const override {
     py::handle handle(py_compiler);
-    py::object stuff =
-        handle.attr("call_copy_slices_prologue")(inputs, base, view);
+    py::object stuff = handle.attr("call_copy_slices_prologue")(
+        inputs,
+        base.sym_sizes(),
+        base.sym_strides(),
+        base.sym_storage_offset(),
+        view.sym_sizes(),
+        view.sym_strides(),
+        view.sym_storage_offset());
     return py::cast<std::vector<at::Tensor>>(stuff);
   }
   variable_list call_copy_slices_epilogue(
@@ -202,7 +208,7 @@ struct PyCompilerInterfaceImpl : PyCompilerInterface {
       const std::vector<bool>& needs_input_grad,
       const at::Tensor& result,
       const variable_list& res,
-      const at::Tensor& grad_slice) override {
+      const at::Tensor& grad_slice) const override {
     py::handle handle(py_compiler);
     py::object stuff = handle.attr("call_copy_slices_epilogue")(
         needs_input_grad, result, res, grad_slice);
@@ -212,7 +218,7 @@ struct PyCompilerInterfaceImpl : PyCompilerInterface {
   at::Tensor call_unpack(
       PyObject* py_compiler,
       std::optional<size_t> hook_id,
-      size_t hook_input_id) override {
+      size_t hook_input_id) const override {
     py::handle handle(py_compiler);
     py::object proxy = handle.attr("unpack_hook")(hook_id, hook_input_id);
     auto tmp = py::cast<std::optional<at::Tensor>>(proxy);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #149014
* #149064
* #148801
* #149030
* __->__ #148799

i'm changing CA initial trace to always trace as dynamic, fixes these errors:
```python
This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
FAILED [0.2139s] test/inductor/test_compiled_autograd.py::TestAutogradWithCompiledAutograd::test_autograd_python_custom_function_inplace - RuntimeError: !has_symbolic_sizes_strides_ INTERNAL ASSERT FAILED at "/home/xmfan/core/a/pytorch/aten/src/ATen/TensorGeometry.h":63, please report a bug to PyTorch. 
To execute this test, run the following from the base repo dir:
    python test/test_autograd.py TestAutogradWithCompiledAutograd.test_autograd_python_custom_function_inplace
This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
FAILED [0.0057s] test/inductor/test_compiled_autograd.py::TestAutogradWithCompiledAutograd::test_copy_slices_graph_task_updates - RuntimeError: !has_symbolic_sizes_strides_ INTERNAL ASSERT FAILED at "/home/xmfan/core/a/pytorch/aten/src/ATen/TensorGeometry.h":63, please report a bug to PyTorch. 
To execute this test, run the following from the base repo dir:
    python test/test_autograd.py TestAutogradWithCompiledAutograd.test_copy_slices_graph_task_updates
This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
FAILED [0.9662s] test/inductor/test_compiled_autograd.py::TestAutogradWithCompiledAutograd::test_inplace_on_view_weak_grad_fn - RuntimeError: !has_symbolic_sizes_strides_ INTERNAL ASSERT FAILED at "/home/xmfan/core/a/pytorch/aten/src/ATen/TensorGeometry.h":63, please report a bug to PyTorch. 
To execute this test, run the following from the base repo dir:
    python test/test_autograd.py TestAutogradWithCompiledAutograd.test_inplace_on_view_weak_grad_fn
This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
FAILED [0.0077s] test/inductor/test_compiled_autograd.py::TestAutogradWithCompiledAutograd::test_leaf_assignment - RuntimeError: !has_symbolic_sizes_strides_ INTERNAL ASSERT FAILED at "/home/xmfan/core/a/pytorch/aten/src/ATen/TensorGeometry.h":63, please report a bug to PyTorch. 
To execute this test, run the following from the base repo dir:
    python test/test_autograd.py TestAutogradWithCompiledAutograd.test_leaf_assignment
This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
FAILED [5.0485s] test/inductor/test_compiled_autograd.py::TestAutogradWithCompiledAutograd::test_setitem_mask - RuntimeError: !has_symbolic_sizes_strides_ INTERNAL ASSERT FAILED at "/home/xmfan/core/a/pytorch/aten/src/ATen/TensorGeometry.h":63, please report a bug to PyTorch. 
To execute this test, run the following from the base repo dir:
    python test/test_autograd.py TestAutogradWithCompiledAutograd.test_setitem_mask
This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
FAILED [0.0102s] test/inductor/test_compiled_autograd.py::TestAutogradWithCompiledAutograd::test_tensor_hooks_inplace_over_view - RuntimeError: !has_symbolic_sizes_strides_ INTERNAL ASSERT FAILED at "/home/xmfan/core/a/pytorch/aten/src/ATen/TensorGeometry.h":63, please report a bug to PyTorch. 
To execute this test, run the following from the base repo dir:
    python test/test_autograd.py TestAutogradWithCompiledAutograd.test_tensor_hooks_inplace_over_view
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames