### PR TITLE
[ONNX] Remove inaccurate test comment

### DIFF
--- a/test/onnx/exporter/test_capture_strategies.py
+++ b/test/onnx/exporter/test_capture_strategies.py
@@ -59,9 +59,6 @@ class ExportStrategiesTest(common_utils.TestCase):
         self.assertIsInstance(batch_dim_val, torch.SymInt)
 
     def test_jit_trace_supports_dynamic_shapes_as_dict(self):
-        # Since we wrap the model into one that takes flat inputs for JIT tracing,
-        # there is no way to expose the original forward function signature for
-        # torch.export, which is required for dynamic shapes when provided as a dict.
         class Model(torch.nn.Module):
             def forward(self, a, b):
                 c = torch.relu(a)


### PR DESCRIPTION
Remove the comment that says jit trace strategy doesn't support dynamic shapes as dict because it does support it (which is what the test is testing)
