### PR TITLE
Remove numeric_limits::has_norm and numeric_limits::has_norm_loss

### DIFF
--- a/aten/src/ATen/test/half_test.cpp
+++ b/aten/src/ATen/test/half_test.cpp
@@ -100,8 +100,6 @@ ASSERT_SAME_TYPE(is_exact);
 ASSERT_SAME_TYPE(has_infinity);
 ASSERT_SAME_TYPE(has_quiet_NaN);
 ASSERT_SAME_TYPE(has_signaling_NaN);
-ASSERT_SAME_TYPE(has_denorm);
-ASSERT_SAME_TYPE(has_denorm_loss);
 ASSERT_SAME_TYPE(round_style);
 ASSERT_SAME_TYPE(is_iec559);
 ASSERT_SAME_TYPE(is_bounded);

--- a/c10/util/BFloat16-inl.h
+++ b/c10/util/BFloat16-inl.h
@@ -290,9 +290,6 @@ class numeric_limits<c10::BFloat16> {
   static constexpr bool has_infinity = true;
   static constexpr bool has_quiet_NaN = true;
   static constexpr bool has_signaling_NaN = true;
-  static constexpr auto has_denorm = numeric_limits<float>::has_denorm;
-  static constexpr auto has_denorm_loss =
-      numeric_limits<float>::has_denorm_loss;
   static constexpr auto round_style = numeric_limits<float>::round_style;
   static constexpr bool is_iec559 = false;
   static constexpr bool is_bounded = true;

--- a/c10/util/Float8_e4m3fn-inl.h
+++ b/c10/util/Float8_e4m3fn-inl.h
@@ -229,8 +229,6 @@ class numeric_limits<c10::Float8_e4m3fn> {
   static constexpr bool has_infinity = false;
   static constexpr bool has_quiet_NaN = true;
   static constexpr bool has_signaling_NaN = false;
-  static constexpr auto has_denorm = true;
-  static constexpr auto has_denorm_loss = true;
   static constexpr auto round_style = numeric_limits<float>::round_style;
   static constexpr bool is_iec559 = false;
   static constexpr bool is_bounded = true;

--- a/c10/util/Float8_e4m3fnuz-inl.h
+++ b/c10/util/Float8_e4m3fnuz-inl.h
@@ -230,8 +230,6 @@ class numeric_limits<c10::Float8_e4m3fnuz> {
   static constexpr bool has_infinity = false;
   static constexpr bool has_quiet_NaN = true;
   static constexpr bool has_signaling_NaN = false;
-  static constexpr auto has_denorm = true;
-  static constexpr auto has_denorm_loss = true;
   static constexpr auto round_style = numeric_limits<float>::round_style;
   static constexpr bool is_iec559 = false;
   static constexpr bool is_bounded = true;

--- a/c10/util/Float8_e5m2-inl.h
+++ b/c10/util/Float8_e5m2-inl.h
@@ -237,8 +237,6 @@ class numeric_limits<c10::Float8_e5m2> {
   static constexpr bool has_infinity = true;
   static constexpr bool has_quiet_NaN = true;
   static constexpr bool has_signaling_NaN = false;
-  static constexpr auto has_denorm = true;
-  static constexpr auto has_denorm_loss = true;
   static constexpr auto round_style = numeric_limits<float>::round_style;
   static constexpr bool is_iec559 = false;
   static constexpr bool is_bounded = true;

--- a/c10/util/Float8_e5m2fnuz-inl.h
+++ b/c10/util/Float8_e5m2fnuz-inl.h
@@ -234,8 +234,6 @@ class numeric_limits<c10::Float8_e5m2fnuz> {
   static constexpr bool has_infinity = false;
   static constexpr bool has_quiet_NaN = true;
   static constexpr bool has_signaling_NaN = false;
-  static constexpr auto has_denorm = true;
-  static constexpr auto has_denorm_loss = true;
   static constexpr auto round_style = numeric_limits<float>::round_style;
   static constexpr bool is_iec559 = false;
   static constexpr bool is_bounded = true;

--- a/c10/util/Float8_e8m0fnu-inl.h
+++ b/c10/util/Float8_e8m0fnu-inl.h
@@ -62,8 +62,6 @@ class numeric_limits<c10::Float8_e8m0fnu> {
   static constexpr bool has_infinity = false;
   static constexpr bool has_quiet_NaN = true;
   static constexpr bool has_signaling_NaN = false;
-  static constexpr auto has_denorm = false;
-  static constexpr auto has_denorm_loss = false;
   static constexpr auto round_style = numeric_limits<float>::round_style;
   static constexpr bool is_iec559 = false;
   static constexpr bool is_bounded = true;

--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -298,9 +298,6 @@ class numeric_limits<c10::Half> {
   static constexpr bool has_infinity = true;
   static constexpr bool has_quiet_NaN = true;
   static constexpr bool has_signaling_NaN = true;
-  static constexpr auto has_denorm = numeric_limits<float>::has_denorm;
-  static constexpr auto has_denorm_loss =
-      numeric_limits<float>::has_denorm_loss;
   static constexpr auto round_style = numeric_limits<float>::round_style;
   static constexpr bool is_iec559 = true;
   static constexpr bool is_bounded = true;


### PR DESCRIPTION
They are deprecated in C++23 and aren't used in computation.
See
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2614r2.pdf

cc @ezyang @gchanan