### PR TITLE
[caffe2/torch] Fixup upstream LLVM (major version 21) API changes

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -535,7 +535,13 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
 
   module_ = std::make_unique<llvm::Module>("pytorch", getContext());
   module_->setDataLayout(jit_->getDataLayout());
-  module_->setTargetTriple(jit_->getTargetMachine().getTargetTriple().str());
+  module_->setTargetTriple(
+#if LLVM_VERSION_MAJOR >= 21
+      llvm::Triple(jit_->getTargetMachine().getTargetTriple())
+#else
+      jit_->getTargetMachine().getTargetTriple().str()
+#endif
+  );
 
   // We support float16 ops by casting expr inputs to float32
   // and then casting the result back to float16

--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -174,8 +174,12 @@ class TORCH_API PytorchLLVMJITImpl {
                 .setJITTargetMachineBuilder(
                     makeTargetMachineBuilder(triple, cpu, attrs))
 #if LLVM_VERSION_MAJOR >= 17
-                .setObjectLinkingLayerCreator([&](ExecutionSession& ES,
-                                                  const Triple& TT) {
+                .setObjectLinkingLayerCreator([&](ExecutionSession& ES
+#if LLVM_VERSION_MAJOR < 21
+                                                  ,
+                                                  const Triple& TT
+#endif
+                                              ) {
                   return std::make_unique<ObjectLinkingLayer>(
                       ES,
                       assertSuccess(jitlink::InProcessMemoryManager::Create()));


### PR DESCRIPTION
Latest LLVM introduced two changes related to the `Triple` usage that causes build failures when building pytorch.

## Failure in llvm_codegen.cpp:
Triple is stored in Modules instead of the string: https://github.com/llvm/llvm-project/commit/979c275097a642e9b96c6b0a12f013c831af3a6e

## Failure in llvm_jit.cpp:
Triple argument is removed from LLJITBuilder::... : https://github.com/llvm/llvm-project/commit/b18e5b6a36399f11ba1152875b6892900c5afdaf





cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel