### PR TITLE
Remove aoti_torch_cpu__weight_int4pack_mm_cpu_tensor

### DIFF
--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -708,13 +708,6 @@ AOTI_TORCH_EXPORT void aoti_torch_warn(
       __func__, __FILE__, static_cast<uint32_t>(__LINE__), #__VA_ARGS__);
 #endif
 
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__weight_int4pack_mm_cpu_tensor(
-    AtenTensorHandle X,
-    AtenTensorHandle w,
-    AtenTensorHandle qGroupSize,
-    AtenTensorHandle qScaleAndZeros,
-    AtenTensorHandle* ret0);
-
 #ifdef __cplusplus
 } // extern "C"
 

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -708,6 +708,13 @@ AOTI_TORCH_EXPORT void aoti_torch_warn(
       __func__, __FILE__, static_cast<uint32_t>(__LINE__), #__VA_ARGS__);
 #endif
 
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__weight_int4pack_mm_cpu_tensor(
+    AtenTensorHandle X,
+    AtenTensorHandle w,
+    AtenTensorHandle qGroupSize,
+    AtenTensorHandle qScaleAndZeros,
+    AtenTensorHandle* ret0);
+
 #ifdef __cplusplus
 } // extern "C"
 
@@ -738,12 +745,5 @@ DEFINE_DTYPE_SPECIALIZATION(int64_t, int64)
 DEFINE_DTYPE_SPECIALIZATION(bool, bool)
 
 #endif
-
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__weight_int4pack_mm_cpu_tensor(
-    AtenTensorHandle X,
-    AtenTensorHandle w,
-    AtenTensorHandle qGroupSize,
-    AtenTensorHandle qScaleAndZeros,
-    AtenTensorHandle* ret0);
 
 #endif // AOTI_TORCH_SHIM

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -1284,19 +1284,3 @@ AOTITorchError aoti_torch_zero_(AtenTensorHandle tensor) {
     t->zero_();
   });
 }
-
-AOTITorchError aoti_torch_cpu__weight_int4pack_mm_cpu_tensor(
-    AtenTensorHandle X,
-    AtenTensorHandle w,
-    AtenTensorHandle qGroupSize,
-    AtenTensorHandle qScaleAndZeros,
-    AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    auto tmp_result = at::native::_weight_int4pack_mm_cpu_tensor(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(w),
-        *tensor_handle_to_tensor_pointer(qGroupSize),
-        *tensor_handle_to_tensor_pointer(qScaleAndZeros));
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
-}

--- a/torchgen/aoti/fallback_ops.py
+++ b/torchgen/aoti/fallback_ops.py
@@ -155,5 +155,4 @@ inductor_fallback_ops = {
     "aten.view_as_real.default",
     "aten.view.dtype",
     "aten._weight_int8pack_mm.default",
-    "aten._weight_int4pack_mm.default",
 }

--- a/torchgen/aoti/fallback_ops.py
+++ b/torchgen/aoti/fallback_ops.py
@@ -155,4 +155,5 @@ inductor_fallback_ops = {
     "aten.view_as_real.default",
     "aten.view.dtype",
     "aten._weight_int8pack_mm.default",
+    "aten._weight_int4pack_mm.default",
 }


### PR DESCRIPTION
I noticed that this op was likely intended to be in the `extern "C"` portion of the file, but it was not added as such in https://github.com/pytorch/pytorch/pull/145250 which means this function is actually not stable/would get mangled by C++.

Following the thread there I am thinking there are two possible solutions:
(1) Since this op was never stable to begin with, and @Xia-Weiwen should add it to fallback_ops.py, I think this op is deletable + should get deleted before the 2.7 branch cut. 
(2) Or we could just move the op to the right portion of the code. ~While I like just deleting the op, I am hesitant to do in case there's something I haven't considered, so this PR does option 2.~

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148834

