### PR TITLE
Introduce TORCH_ABI_VERSION and a runtime aoti_torch_abi_version C shim ABI

### DIFF
--- a/torch/csrc/api/include/torch/version.h.in
+++ b/torch/csrc/api/include/torch/version.h.in
@@ -9,6 +9,18 @@
 /// Indicates the patch version of LibTorch.
 #define TORCH_VERSION_PATCH @TORCH_VERSION_PATCH@
 
-/// Indicates the version of LibTorch.
+/// Indicates the ABI version tag of LibTorch.
+#define TORCH_VERSION_ABI_TAG 0
+
+/// Indicates the version of LibTorch as a string literal.
 #define TORCH_VERSION \
   "@TORCH_VERSION_MAJOR@.@TORCH_VERSION_MINOR@.@TORCH_VERSION_PATCH@"
+
+/// Indicates the ABI version of LibTorch as a single uint64.
+/// [ byte ][ byte ][ byte ][ byte ][ byte ][ byte ][ byte ][ byte ]
+/// [ MAJ  ][ MIN  ][ PATCH][                              ABI TAG ]
+#define TORCH_ABI_VERSION \
+  (uint64_t)TORCH_VERSION_MAJOR << 56 | \
+  (uint64_t)TORCH_VERSION_MINOR << 48 | \
+  (uint64_t)TORCH_VERSION_PATCH << 40 | \
+  TORCH_VERSION_ABI_TAG << 0

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -143,6 +143,9 @@ AOTI_TORCH_EXPORT int32_t aoti_torch_memory_format_channels_last();
 AOTI_TORCH_EXPORT int32_t aoti_torch_memory_format_channels_last_3d();
 AOTI_TORCH_EXPORT int32_t aoti_torch_memory_format_preserve_format();
 
+// Get TORCH_ABI_VERSION of the built libtorch.so
+AOTI_TORCH_EXPORT uint64_t aoti_torch_abi_version();
+
 // Functions for converting a single-element tensor to a scalar value
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_item_float16(AtenTensorHandle tensor, c10::Half* ret_value);
@@ -655,8 +658,6 @@ AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_get_current_cuda_stream(int32_t device_index, void** ret_stream);
 
 #endif // USE_CUDA
-
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch_get_libtorch_version(const char* str);
 
 // See `ProxyExecutor Design Note` in ir.py for more details
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_proxy_executor_call_function(

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -656,6 +656,8 @@ aoti_torch_get_current_cuda_stream(int32_t device_index, void** ret_stream);
 
 #endif // USE_CUDA
 
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_get_libtorch_version(const char* str);
+
 // See `ProxyExecutor Design Note` in ir.py for more details
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_proxy_executor_call_function(
     AOTIProxyExecutorHandle proxy_executor,

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -1208,6 +1208,13 @@ void aoti_torch_print_tensor_handle(AtenTensorHandle self, const char* msg) {
   std::cout << '\n';
 }
 
+#include <torch/version.h>
+AOTITorchError aoti_torch_get_libtorch_version(const char* str) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    *str = TORCH_VERSION;
+  });
+}
+
 // ProxyExecutor
 AOTITorchError aoti_torch_proxy_executor_call_function(
     AOTIProxyExecutorHandle proxy_executor,

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -13,6 +13,7 @@
 #include <torch/csrc/inductor/aoti_torch/utils.h>
 #include <torch/csrc/inductor/inductor_ops.h>
 #include <torch/csrc/jit/serialization/pickle.h>
+#include <torch/version.h>
 #include <cstdint>
 #include <cstdio>
 #include <fstream>
@@ -230,6 +231,10 @@ AOTI_TORCH_SCALAR_TO_TENSOR_IMPL(
     c10::complex<double>,
     ComplexDouble)
 #undef AOTI_TORCH_SCALAR_TO_TENSOR_IMPL
+
+uint64_t aoti_torch_abi_version() {
+  return TORCH_ABI_VERSION;
+}
 
 bool aoti_torch_grad_mode_is_enabled() {
   return c10::GradMode::is_enabled();
@@ -1206,13 +1211,6 @@ void aoti_torch_print_tensor_handle(AtenTensorHandle self, const char* msg) {
   std::cout << "Requires grad: " << t->requires_grad() << '\n';
 
   std::cout << '\n';
-}
-
-#include <torch/version.h>
-AOTITorchError aoti_torch_get_libtorch_version(const char* str) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    *str = TORCH_VERSION;
-  });
 }
 
 // ProxyExecutor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148836


<details>
ghstack-source-id: 9619e98a56b47312c0ddea04b9d9500dd8e554b3
Pull Request resolved: https://github.com/pytorch/pytorch/pull/148836
<details>
