### PR TITLE
C++ support to print symbolic tensors as `Symbolic tensor: size=(...)`

### DIFF
--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -269,6 +269,14 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
     stream << "values:\n" << tensor_._values() << "\n";
     stream << "size:\n" << tensor_.sizes() << "\n";
     stream << "]";
+  } else if (tensor_.sym_numel().is_symbolic()) {
+    stream << "[ FakeTensor size=(";
+    bool first = true;
+    for (auto const &sz : tensor_.sym_sizes()) {
+      stream << (first ? "" : ", ") << sz;
+      first = false;
+    }
+    stream << ")]";
   } else {
     Tensor tensor;
     if (tensor_.is_quantized()) {

--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -270,7 +270,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
     stream << "size:\n" << tensor_.sizes() << "\n";
     stream << "]";
   } else if (tensor_.sym_numel().is_symbolic()) {
-    stream << "[ FakeTensor size=(";
+    stream << "[ Symbolic tensor: size=(";
     bool first = true;
     for (auto const &sz : tensor_.sym_sizes()) {
       stream << (first ? "" : ", ") << sz;

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -2158,6 +2158,42 @@ class FakeTensorDispatchCache(TestCase):
                     extract_tensor_metadata(b),
                 )
 
+    def test_cpp_symbolic_tensor_print(self):
+        shape_env = ShapeEnv()
+        mode1 = FakeTensorMode(shape_env=shape_env)
+        t1 = mode1.from_tensor(
+            torch.randn(10),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[DimDynamic.DYNAMIC], constraint_sizes=[None]
+            ),
+        )
+        t2 = mode1.from_tensor(
+            torch.randn(10, 10),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[DimDynamic.DYNAMIC, DimDynamic.DYNAMIC], constraint_sizes=[None, None]
+            ),
+        )
+
+        printcpp = '''
+        std::string dur_print(const at::Tensor &t) {
+            std::ostringstream oss;
+            oss << t << std::endl;
+            return oss.str();
+        }
+        '''
+        bohb = torch.utils.cpp_extension.load_inline(
+            name="dur_extension",
+            cpp_sources=printcpp,
+            functions=["dur_print"],
+        )
+        s1 = bohb.dur_print(t1)
+        s2 = bohb.dur_print(t2)
+        self.assertTrue('FakeTensor' in s1)
+        self.assertTrue('(s0)' in s1)
+
+        self.assertTrue('FakeTensor' in s2)
+        self.assertTrue('s1' in s2)
+        self.assertTrue('s2' in s2)
 
     def test_cache_aten_index(self):
         with FakeTensorMode():

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -2177,7 +2177,7 @@ class FakeTensorDispatchCache(TestCase):
         printcpp = '''
         std::string dur_print(const at::Tensor &t) {
             std::ostringstream oss;
-            oss << t << std::endl;
+            oss << t;
             return oss.str();
         }
         '''
@@ -2188,12 +2188,8 @@ class FakeTensorDispatchCache(TestCase):
         )
         s1 = bohb.dur_print(t1)
         s2 = bohb.dur_print(t2)
-        self.assertTrue('FakeTensor' in s1)
-        self.assertTrue('(s0)' in s1)
-
-        self.assertTrue('FakeTensor' in s2)
-        self.assertTrue('s1' in s2)
-        self.assertTrue('s2' in s2)
+        self.assertEqual(s1, '[ Symbolic tensor: size=(s0)]')
+        self.assertEqual(s2, '[ Symbolic tensor: size=(s1, s2)]')
 
     def test_cache_aten_index(self):
         with FakeTensorMode():


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/145491
