### PR TITLE
Fix AttributeError for `_get_vc_env` with setuptools>=75.9.0

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2523,7 +2523,10 @@ def _get_vc_env(vc_arch: str) -> dict[str, str]:
         return distutils._msvccompiler._get_vc_env(vc_arch)
     except AttributeError:
         from setuptools._distutils import _msvccompiler
-        return _msvccompiler._get_vc_env(vc_arch)
+        try:
+            return _msvccompiler._get_vc_env(vc_arch)
+        except AttributeError:
+            return _msvccompiler.msvc._get_vc_env(vc_arch)
 
 
 def _run_ninja_build(build_directory: str, verbose: bool, error_prefix: str) -> None:

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2522,11 +2522,12 @@ def _get_vc_env(vc_arch: str) -> dict[str, str]:
         from setuptools import distutils
         return distutils._msvccompiler._get_vc_env(vc_arch)
     except AttributeError:
-        from setuptools._distutils import _msvccompiler
         try:
+            from setuptools._distutils import _msvccompiler
             return _msvccompiler._get_vc_env(vc_arch)
         except AttributeError:
-            return _msvccompiler.msvc._get_vc_env(vc_arch)
+            from setuptools._distutils.compilers.C import msvc
+            return msvc._get_vc_env(vc_arch)
 
 
 def _run_ninja_build(build_directory: str, verbose: bool, error_prefix: str) -> None:


### PR DESCRIPTION
```
File "E:\AI\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\utils\cpp_extension.py", line 2172, in _get_vc_env
          return _msvccompiler._get_vc_env(vc_arch)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
      AttributeError: module 'distutils._msvccompiler' has no attribute '_get_vc_env'
```
see https://github.com/pypa/setuptools/blob/v75.9.0/setuptools/_distutils/_msvccompiler.py
