### PR TITLE
[Flex Attention] support num_heads > 1 in block_mask

### DIFF
--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -963,6 +963,34 @@ class TestFlexDecoding(InductorTestCase):
 
     @supported_platform
     @common_utils.parametrize("dtype", test_dtypes_fast)
+    @common_utils.parametrize("score_mod", test_score_mods)
+    @common_utils.parametrize("head_dims", test_Hq_Hkv)
+    def test_head_dependent_mask_mod(self, dtype: torch.dtype, score_mod, head_dims):
+        Hq, Hkv = head_dims
+        assert Hq % Hkv == 0
+
+        def head_attention_mod(kv_head_num):
+            head_type = torch.tensor(
+                [False if i % kv_head_num == 0 else True for i in range(kv_head_num)],
+                dtype=torch.bool,
+                device="cuda",
+            )
+
+            def mask_mod(b, h, q_idx, kv_idx):
+                bi_mask = head_type[h]
+                causal_mask = q_idx >= kv_idx
+
+                return bi_mask & causal_mask
+
+            return mask_mod
+
+        mask_mod = head_attention_mod(Hq)
+        mask = create_block_mask(mask_mod, 1, Hq, 1, S, device="cuda")
+        self.run_test(score_mod, dtype, Q_H=Hq, KV_H=Hkv, block_mask=mask)
+        self.run_test_with_paged_attention(score_mod, dtype, Q_H=Hq, KV_H=Hkv)
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes_fast)
     def test_subgraph_respect_decompostion(self, dtype):
         from torch._decomp import core_aten_decompositions
         from torch.fx.experimental.proxy_tensor import make_fx

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -698,7 +698,7 @@ flex_attention_template = TritonTemplate(
 )
 
 
-def _use_flex_decoding(query, kernel_options):
+def _use_flex_decoding(query, kv_indices, kernel_options, enable_gqa):
     """Decide which kernel to use, return true if use flex decoding kernel.
     Note:
        Since the number of splits is calculated based of the the number of batch and head dims
@@ -712,12 +712,28 @@ def _use_flex_decoding(query, kernel_options):
     non_zero_length = V.graph.sizevars.evaluate_expr(sympy.Gt(query.get_size()[-2], 0))
     static_batch = isinstance(query.get_size()[0], (int, sympy.Integer))
     static_num_heads = isinstance(query.get_size()[1], (int, sympy.Integer))
+    if enable_gqa:
+        # in the current flex decoding triton kernel, grouped query heads for the
+        # same kv head are handled by the same block. So it's hard to support different
+        # kv num blocks for grouped query heads. We just fall back to main flex_attention
+        # kernel where each query head is handled by a separate block.
+        valid_block_mask_num_heads = V.graph.sizevars.evaluate_expr(
+            sympy.Eq(kv_indices.get_size()[1], 1)
+        )
+    else:
+        valid_block_mask_num_heads = V.graph.sizevars.evaluate_expr(
+            sympy.Or(
+                sympy.Eq(kv_indices.get_size()[1], 1),
+                sympy.Eq(kv_indices.get_size()[1], query.get_size()[1]),
+            )
+        )
     return (
         not force_flex
         and short_query_length
         and static_batch
         and static_num_heads
         and non_zero_length
+        and valid_block_mask_num_heads
     )
 
 
@@ -1325,7 +1341,10 @@ def flex_attention(
         for k, v in kernel_options.items()
     }
     kernel_options.setdefault("FLOAT32_PRECISION", get_float32_precision())
-    if _use_flex_decoding(query, kernel_options):
+    enable_gqa = V.graph.sizevars.evaluate_expr(
+        sympy.Ne(query.get_size()[1], key.get_size()[1]),
+    )
+    if _use_flex_decoding(query, kv_indices, kernel_options, enable_gqa):
         return create_flex_decoding_kernel(
             query,
             key,

--- a/torch/_inductor/kernel/flex_decoding.py
+++ b/torch/_inductor/kernel/flex_decoding.py
@@ -114,9 +114,7 @@ flex_decoding_template = TritonTemplate(
     SPARSE_HQ = {{size("KV_NUM_BLKS", 1)}}
 
     sparse_idx_z = off_z % SPARSE_Z
-    # TODO: support masks not broadcasted along the head dimension.
-    tl.device_assert(SPARSE_HQ == 1)
-    sparse_idx_h = 0
+    sparse_idx_h = off_hkv % SPARSE_HQ
 
     SPARSE_KV_MULTIPLE: tl.constexpr = (SPARSE_KV_BLOCK_SIZE // BLOCK_N)
     SPARSE_KV_BLOCK_CNT = tl.cdiv(KV_LEN, SPARSE_KV_BLOCK_SIZE)


### PR DESCRIPTION
Previously flex decoding errors when block mask has num_heads > 1. So users have to use num_heads=1, or explicitly mark `kernel_options={"FORCE_USE_FLEX_ATTENTION": True}`.

This PR fixes this issue. When not using grouped query attention (GQA, i.e., Hq == Hkv), we support block mask with num_heads = 1 and num_heads = num_query_heads (i.e., Hq). This is the same setting as flex attention kernel.

When using GQA (i.e., Hq != Hkv), we support block mask with num_heads = 1. When num_heads = Hq, we fall back to flex attention kernel so user don't need to explicitly mark `kernel_options={"FORCE_USE_FLEX_ATTENTION": True}` anymore.

Why fallback? In the current flex decoding triton kernel, grouped query heads for the same kv head are handled by the same thread block. Supporting num_heads = Hq with GQA requires support different kv num blocks for different query heads in the same thread block, leading to lots of redundant workload. So we should better use the main flex_attention kernel where each query head is handled by a separate block.

Fixes #148527
Fixes #147267

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @Chillee @drisspg @yanboliang