### PR TITLE
[Doc] Update CMAKE_PREFIX_PATH for XPU windows README

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Then PyTorch can be built with the command:
 if defined CMAKE_PREFIX_PATH (
     set "CMAKE_PREFIX_PATH=%CONDA_PREFIX%\Library;%CMAKE_PREFIX_PATH%"
 ) else (
-    set CMAKE_PREFIX_PATH=%CONDA_PREFIX%\Library
+    set "CMAKE_PREFIX_PATH=%CONDA_PREFIX%\Library"
 )
 
 python setup.py develop

--- a/README.md
+++ b/README.md
@@ -355,9 +355,9 @@ Please make sure [the common prerequisites](#prerequisites) as well as [the prer
 Then PyTorch can be built with the command:
 
 ```cmd
+:: CMD Commands:
 :: Set the CMAKE_PREFIX_PATH to help find corresponding packages
 :: %CONDA_PREFIX% only works after `conda activate custom_env`
-:: Use `$env:CMAKE_PREFIX_PATH = "${env:CONDA_PREFIX};${env:CMAKE_PREFIX_PATH}"` for powershell
 
 if defined CMAKE_PREFIX_PATH (
     set "CMAKE_PREFIX_PATH=%CONDA_PREFIX%\Library;%CMAKE_PREFIX_PATH%"

--- a/README.md
+++ b/README.md
@@ -358,7 +358,12 @@ Then PyTorch can be built with the command:
 :: Set the CMAKE_PREFIX_PATH to help find corresponding packages
 :: %CONDA_PREFIX% only works after `conda activate custom_env`
 :: Use `$env:CMAKE_PREFIX_PATH = "${env:CONDA_PREFIX};${env:CMAKE_PREFIX_PATH}"` for powershell
-set CMAKE_PREFIX_PATH=%CONDA_PREFIX%;%CMAKE_PREFIX_PATH%
+
+if defined CMAKE_PREFIX_PATH (
+    set "CMAKE_PREFIX_PATH=%CONDA_PREFIX%\Library;%CMAKE_PREFIX_PATH%"
+) else (
+    set CMAKE_PREFIX_PATH=%CONDA_PREFIX%\Library
+)
 
 python setup.py develop
 ```

--- a/README.md
+++ b/README.md
@@ -355,6 +355,11 @@ Please make sure [the common prerequisites](#prerequisites) as well as [the prer
 Then PyTorch can be built with the command:
 
 ```cmd
+:: Set the CMAKE_PREFIX_PATH to help find corresponding packages
+:: %CONDA_PREFIX% only works after `conda activate custom_env`
+:: Use `$env:CMAKE_PREFIX_PATH = "${env:CONDA_PREFIX};${env:CMAKE_PREFIX_PATH}"` for powershell
+set CMAKE_PREFIX_PATH=%CONDA_PREFIX%;%CMAKE_PREFIX_PATH%
+
 python setup.py develop
 ```
 


### PR DESCRIPTION
We found that the `pip install cmake` and `conda install cmake` has different behavior. 
The reason is that the pip installed one doesn't find the corresponding libs under conda env. So we need to set the `CMAKE_PREFIX_PATH` for alignment.

cc @svekars @sekyondaMeta @AlannaBurke @gujinghui @EikanWang @fengyuan14 @guangyey