### PR TITLE
Create and send `full_tensor` on `ProcessGroup`-supported device in `_broadcast_tensors`

### DIFF
--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -896,6 +896,30 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
+    def test_set_cpu_model_state_dict_broadcast_from_rank0(self) -> None:
+        torch.manual_seed(42)
+        model = nn.Linear(2, 2)
+        expected_state_dict = {
+            k: v.detach().clone() for k, v in model.state_dict().items()
+        }
+        state_dict = expected_state_dict if torch.distributed.get_rank() == 0 else {}
+        model._apply(lambda t: torch.zeros_like(t))
+
+        set_model_state_dict(
+            model,
+            state_dict,
+            options=StateDictOptions(full_state_dict=True, broadcast_from_rank0=True),
+        )
+
+        for (actual_name, tensor), (expected_name, expected_tensor) in zip(
+            model.state_dict().items(),
+            expected_state_dict.items(),
+        ):
+            assert actual_name == expected_name
+            torch.testing.assert_close(tensor, expected_tensor, msg=expected_name)
+
+    @with_comms
+    @skip_if_lt_x_gpu(2)
     def test_multi_device_load_model_state_dict(self) -> None:
         torch.manual_seed(0)
         with torch.device("meta"):

--- a/torch/distributed/_state_dict_utils.py
+++ b/torch/distributed/_state_dict_utils.py
@@ -557,7 +557,10 @@ def _broadcast_tensors(
             if (local_state := local_state_dict.get(key)) is not None:
                 local_state_dict[key] = (
                     (local_state[0], full_tensor.to(device))
-                    if isinstance(local_state, tuple) and isinstance(local_state[0], DTensor)
+                    if (
+                        isinstance(local_state, tuple)
+                        and isinstance(local_state[0], DTensor)
+                    )
                     else full_tensor.to(device)
                 )
 

--- a/torch/distributed/_state_dict_utils.py
+++ b/torch/distributed/_state_dict_utils.py
@@ -514,35 +514,54 @@ def _broadcast_tensors(
     device: torch.device,
     pg: Optional[dist.ProcessGroup] = None,
 ) -> None:
-    tensors = []
+    if pg is None:
+        pg = dist.distributed_c10d._get_default_group()
+    pg_device = (
+        device
+        if device.type in {pg_device.type for pg_device in pg._device_types}
+        else pg._device_types[0]
+    )
+
+    tensors: list[torch.Tensor] = []
     for key in keys:
         if dist.get_rank() == 0:
             full_state = full_state_dict[key]
             assert isinstance(full_state, torch.Tensor)
-            full_tensor = full_state.detach().to(device)
+            full_tensor = full_state.detach().to(pg_device)
         else:
             tensor_info = full_state_dict[key]
             full_tensor = torch.empty(
                 size=tensor_info.size,
-                device=device,
+                device=pg_device,
                 dtype=tensor_info.dtype,
             )
-        tensors.append(full_tensor)
-        local_state = local_state_dict.get(key, None)
-        if local_state is None:
-            continue
-        elif isinstance(local_state, DTensor):
-            local_state_dict[key] = (local_state, full_tensor)
-        else:
-            local_state_dict[key] = full_tensor
 
-    if pg is None:
-        pg = dist.distributed_c10d._get_default_group()
+        tensors.append(full_tensor)
+
+        if (local_state := local_state_dict.get(key)) is None:
+            continue
+
+        local_state_dict[key] = (
+            (local_state, full_tensor)
+            if isinstance(local_state, DTensor)
+            else full_tensor
+        )
 
     if len(tensors) > 1:
         dist._broadcast_coalesced(pg, tensors, 500, 0)
     else:
         dist.broadcast(tensors[0], src=0, group=pg)
+
+    if pg_device != device:
+        for key, full_tensor in zip(keys, tensors):
+            local_state_dict[key] = (
+                (local_state, full_tensor.to(device))
+                if (
+                    isinstance(local_state_dict[key], tuple)
+                    and isinstance(local_state := local_state_dict[key][0], DTensor)
+                )
+                else full_tensor.to(device)
+            )
 
     _distribute_tensors(local_state_dict, keys, device, pg)
 

--- a/torch/distributed/_state_dict_utils.py
+++ b/torch/distributed/_state_dict_utils.py
@@ -554,14 +554,12 @@ def _broadcast_tensors(
 
     if pg_device != device:
         for key, full_tensor in zip(keys, tensors):
-            local_state_dict[key] = (
-                (local_state, full_tensor.to(device))
-                if (
-                    isinstance(local_state_dict[key], tuple)
-                    and isinstance(local_state := local_state_dict[key][0], DTensor)
+            if (local_state := local_state_dict.get(key)) is not None:
+                local_state_dict[key] = (
+                    (local_state[0], full_tensor.to(device))
+                    if isinstance(local_state, tuple) and isinstance(local_state[0], DTensor)
+                    else full_tensor.to(device)
                 )
-                else full_tensor.to(device)
-            )
 
     _distribute_tensors(local_state_dict, keys, device, pg)
 


### PR DESCRIPTION
Fixes #138842

`device` is always the device of the `local_state_dict`, which may or may not be CPU, which is not supported by NCCL backend.

Instead, create broadcasted tensors on one of `pg._device_types` and then move the tensors back if `local_state_dict`'s `device` was not supported by the `ProcessGroup`.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o