### PR TITLE
Optimize shard_dim_alltoall to use alltoall_single

### DIFF
--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -537,33 +537,39 @@ at::Tensor shard_dim_alltoall(
     const std::string& group_name) {
   auto group = c10d::resolve_process_group(group_name);
   auto group_size = group->getSize();
+  std::vector<int64_t> input_sizes = input.sizes().vec();
   std::vector<int64_t> output_sizes = input.sizes().vec();
-  if (output_sizes[shard_dim] % group_size != 0) {
-    LOG(WARNING) << "The first dimension of the shard_dim_alltoall input ("
-                 << output_sizes[shard_dim]
+  if (input_sizes[shard_dim] % group_size != 0) {
+    LOG(WARNING) << "The shard dimension of the shard_dim_alltoall input ("
+                 << input_sizes[shard_dim]
                  << ") is not divisible by the group size (" << group_size
                  << ").";
   }
-  output_sizes[shard_dim] = output_sizes[shard_dim] / group_size;
-  std::vector<at::Tensor> inputs;
-  inputs.reserve(group_size);
-  auto length = output_sizes[shard_dim];
-  for (int i = 0; i < group_size; i++) {
-    inputs.push_back(input.narrow(shard_dim, i * length, length).contiguous());
-  }
-  // allocate outputs
-  std::vector<at::Tensor> outputs;
-  outputs.reserve(group_size);
-  for (int i = 0; i < group_size; i++) {
-    outputs.push_back(input.new_empty(output_sizes).contiguous());
-  }
-  auto work = group->alltoall(outputs, inputs);
+  input_sizes[shard_dim] /= group_size;
+  input_sizes.insert(input_sizes.begin() + shard_dim, group_size);
 
+  auto tensor_reshaped = input.view(input_sizes);
+  auto tensor_for_comm = tensor_reshaped.movedim(shard_dim, 0).contiguous();
+
+  auto recv_tensor = at::empty_like(tensor_for_comm);
+  std::vector<int64_t> out_split_sizes;
+  std::vector<int64_t> in_split_sizes;
+  c10d::AllToAllOptions opts;
+
+  auto work = group->alltoall_base(recv_tensor, tensor_for_comm, out_split_sizes, in_split_sizes, opts);
+
+  // TODO: it's tricky to get the current async behavior work for shard dim alltoall
+  // so for now we just keep this comm op to be synchronous. We might need to
+  // have sth similar to future callback to do the permute, contiguous and view calls.
+  // We can revisit later how to support the async case with the Work registry.
   work->wait();
-  // TODO: it's very tricky to get the current async behavior work for shard dim
-  // alltoall so for now we just keep this comm op to be synchronous. We can
-  // revisit later how to support the async case with the Work registry.
-  return at::cat(outputs, gather_dim);
+
+  auto output = recv_tensor.movedim(0, gather_dim).contiguous();
+
+  // view/reshape it back to the expected output shape
+  output_sizes[shard_dim] /= group_size;
+  output_sizes[gather_dim] *= group_size;
+  return output.view(output_sizes);
 }
 } // namespace
 

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -556,12 +556,14 @@ at::Tensor shard_dim_alltoall(
   std::vector<int64_t> in_split_sizes;
   c10d::AllToAllOptions opts;
 
-  auto work = group->alltoall_base(recv_tensor, tensor_for_comm, out_split_sizes, in_split_sizes, opts);
+  auto work = group->alltoall_base(
+      recv_tensor, tensor_for_comm, out_split_sizes, in_split_sizes, opts);
 
-  // TODO: it's tricky to get the current async behavior work for shard dim alltoall
-  // so for now we just keep this comm op to be synchronous. We might need to
-  // have sth similar to future callback to do the permute, contiguous and view calls.
-  // We can revisit later how to support the async case with the Work registry.
+  // TODO: it's tricky to get the current async behavior work for shard dim
+  // alltoall so for now we just keep this comm op to be synchronous. We might
+  // need to have sth similar to future callback to do the permute, contiguous
+  // and view calls. We can revisit later how to support the async case with the
+  // Work registry.
   work->wait();
 
   auto output = recv_tensor.movedim(0, gather_dim).contiguous();


### PR DESCRIPTION
as titled, previously the shard_dim_alltoall uses `all_to_all`, which essentially could incur lots of copies if the tensor become non-contiguous during splits, and alltoall itself also incur copies

This PR uses alltoall_single instead, so that we could minimize tensor copies.

tested on all the shard dim change tests and it works properly:
```
pytest test/distributed/tensor/test_redistribute.py -s -k shard_dim_alltoall
```

Fixes #ISSUE_NUMBER


cc @H-Huang @awgu @kwen2501 @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o