### PR TITLE
Make `torch._check` support bool tensor as `cond` param

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6892,8 +6892,12 @@ class TestTorch(TestCase):
             with self.assertRaisesRegex(TypeError, 'cond must be a bool'):
                 check_fn('wrong type')
 
-            with self.assertRaisesRegex(TypeError, 'cond must be a bool'):
-                check_fn(torch.tensor(True))
+        torch._check(torch.tensor(True))
+        with self.assertRaisesRegex(RuntimeError, 'Expected cond to be True'):
+            torch._check(torch.tensor([True, False]))
+
+        with self.assertRaisesRegex(TypeError, 'cond tensor must have dtype torch.bool'):
+            torch._check(torch.tensor([1, 2]))
 
     # FIXME: move to indexing test suite
     def test_index_add(self):

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1650,16 +1650,19 @@ def _check(cond, message=None):  # noqa: F811
 
     Error type: ``RuntimeError``
 
-    C++ equivalent: ``TORCH_CHECK``
+    C++ equivalent: ``TORCH_CHECK`` for bool, ``TORCH_CHECK_TENSOR_ALL`` for BoolTensor
 
     Args:
-        cond (:class:`bool`): If False, throw error
+        cond (bool or Tensor): If False, throw error
 
         message (Callable, optional): Callable that returns either a string or
             an object that has a ``__str__()`` method to be used as the error
             message. Default: ``None``
     """
-    _check_with(RuntimeError, cond, message)
+    if is_tensor(cond):
+        _check_tensor_all_with(RuntimeError, cond, message)
+    else:
+        _check_with(RuntimeError, cond, message)
 
 
 def _check_is_size(i, message=None, *, max=None):


### PR DESCRIPTION
Fixes #148349

## Test Result

```python
pytest test/test_torch.py -k test_check -vv
```

![image](https://github.com/user-attachments/assets/b9cb97b9-28bd-4443-b9c6-0d8afe15068b)
