### PR TITLE
[Inductor][CPP] Fix expr issue in loop split

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3590,6 +3590,24 @@ class CPUReproTests(TestCase):
         x = torch.randn(1, 384, 20, 20).to(memory_format=torch.channels_last)
         self.common(fn, (x,))
 
+    def test_issue_148058(self):
+        # Fix issue https://github.com/pytorch/pytorch/issues/148058
+        def fn(x):
+            x = F.gumbel_softmax(x, tau=1.0, hard=True)
+            x = torch.where(x > 0.5, x, torch.zeros_like(x))
+            x = torch.scatter(
+                x,
+                dim=1,
+                index=torch.ones(1, 2, dtype=torch.long),
+                src=torch.ones_like(x),
+            )
+            return x
+
+        metrics.reset()
+        x = torch.randn(1, 2)
+        # Only test for functionality since the output of gumbel_softmax has randomness
+        torch.compile(fn, backend="inductor")(x)
+
     def test_non_contiguous_index_with_constant_stride(self):
         def fn(x):
             x1 = x[:, :, :, ::2]

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -4704,6 +4704,8 @@ class CppScheduling(BaseScheduling):
             assert isinstance(node.node, ir.ComputedBuffer)
             _, original_body, _ = node.node.get_default_sizes_body()
             for name, expr in original_body.indexing_exprs.items():
+                if not isinstance(expr, sympy.Expr):
+                    continue
                 for div_expr in expr.find(FloorDiv):
                     if (
                         any(div_expr.has(var) for var in original_body.iter_vars)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148882

**Summary**
Fix issue: https://github.com/pytorch/pytorch/issues/148058. In this case, there is an `indexing_expr` as an integer which doesn't have the method of `find`.

**Test Plan**
```
python -u -m pytest -s -v test/inductor/test_cpu_repro.py -k test_issue_148058
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov