### PR TITLE
[CI] Upgrade numpy?

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -277,9 +277,12 @@ else
     # or building non-XLA tests.
     if [[ "$BUILD_ENVIRONMENT" != *rocm*  &&
           "$BUILD_ENVIRONMENT" != *xla* ]]; then
-      if [[ "$BUILD_ENVIRONMENT" != *py3.8* ]]; then
-        # Install numpy-2.0.2 for builds which are backward compatible with 1.X
+      # Install numpy for builds which are backward compatible with 1.X
+      if [[ "$BUILD_ENVIRONMENT" = *py3.9* ]]; then
+        # 2.0.2 is the most recent version that supports Python 3.9
         python -mpip install numpy==2.0.2
+      else
+        python -mpip install numpy==2.2.3
       fi
 
       WERROR=1 python setup.py clean


### PR DESCRIPTION
Gets rid of mention of py3.8, which is no longer supported
Upgrades the numpy version used in build when possible (numpy2.0.2 is the most recent version that supports py3.9)
As of right now, numpy2.2.3 is the most recent numpy version.

py3.13 already has numpy2.1.2 installed and 2.0.2 doesn't have a release for py3.12 on pypi