### PR TITLE
Automate stable CUDA update and linter using min Python verison

### DIFF
--- a/.ci/docker/ci_commit_pins/triton.txt
+++ b/.ci/docker/ci_commit_pins/triton.txt
@@ -1,1 +1,1 @@
-4b3bb1f8da0ded6ccd572dd1358ef45af5a1befe
+ab727c406a3805fe0acfb63a18ead299ff7cf05c

--- a/.ci/docker/ci_commit_pins/triton.txt
+++ b/.ci/docker/ci_commit_pins/triton.txt
@@ -1,1 +1,1 @@
-ab727c406a3805fe0acfb63a18ead299ff7cf05c
+4b3bb1f8da0ded6ccd572dd1358ef45af5a1befe

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -374,7 +374,7 @@ def generate_wheels_matrix(
                     }
                 )
                 # Special build building to use on Colab. Python 3.11 for 12.6 CUDA
-                if python_version == "3.11" and arch_version == "12.6":
+                if python_version == "3.11" and arch_version == CUDA_STABLE:
                     ret.append(
                         {
                             "python_version": python_version,
@@ -417,7 +417,7 @@ def generate_wheels_matrix(
                         "pytorch_extra_install_requirements": (
                             PYTORCH_EXTRA_INSTALL_REQUIREMENTS["xpu"]
                             if gpu_arch_type == "xpu"
-                            else PYTORCH_EXTRA_INSTALL_REQUIREMENTS["12.6"]
+                            else PYTORCH_EXTRA_INSTALL_REQUIREMENTS[CUDA_STABLE]
                             if os != "linux"
                             else ""
                         ),

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -17,6 +17,7 @@ from typing import Optional
 
 # NOTE: Also update the CUDA sources in tools/nightly.py when changing this list
 CUDA_ARCHES = ["11.8", "12.6", "12.8"]
+CUDA_STABLE = "12.6"
 CUDA_ARCHES_FULL_VERSION = {
     "11.8": "11.8.0",
     "12.6": "12.6.3",

--- a/.github/scripts/get_ci_variable.py
+++ b/.github/scripts/get_ci_variable.py
@@ -22,7 +22,9 @@ def main(args: list[str]) -> None:
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--cuda-stable-version", action="store_true", help="get cuda stable version"
+        "--cuda-stable-version",
+        action="store_true",
+        help="get cuda stable version",
     )
     parser.add_argument(
         "--min-python-version",

--- a/.github/scripts/get_ci_variable.py
+++ b/.github/scripts/get_ci_variable.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Return stable CUDA version for the current channel"""
+
+import argparse
+import re
+import sys
+from typing import Optional
+
+
+def parse_version(version_string: str) -> Optional[tuple[int, ...]]:
+    pattern = r"(\d+)\.(\d+)?"
+    match = re.match(pattern, version_string)
+
+    if match:
+        return tuple(int(group) for group in match.groups())
+    else:
+        return None
+
+
+def main(args: list[str]) -> None:
+    import generate_binary_build_matrix
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--cuda-stable-version", action="store_true", help="get cuda stable version"
+    )
+    parser.add_argument(
+        "--min-python-version",
+        action="store_true",
+        help="get min supported python version",
+    )
+    parser.add_argument(
+        "--old-python-version",
+        action="store_true",
+        help="get min supported python version - 0.1",
+    )
+    options = parser.parse_args(args)
+    if options.cuda_stable_version:
+        return print(generate_binary_build_matrix.CUDA_STABLE)
+    if options.min_python_version:
+        return print(generate_binary_build_matrix.FULL_PYTHON_VERSIONS[0])
+    if options.old_python_version:
+        version = parse_version(generate_binary_build_matrix.FULL_PYTHON_VERSIONS[0])
+        if version is not None:
+            major, minor = version
+            return print(f"{major}.{minor - 1}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/.github/scripts/get_ci_variable.py
+++ b/.github/scripts/get_ci_variable.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Return stable CUDA version for the current channel"""
+"""Helper script - Return CI variables such as stable cuda, min python version, etc."""
 
 import argparse
 import re

--- a/.github/scripts/get_ci_variable.py
+++ b/.github/scripts/get_ci_variable.py
@@ -2,19 +2,7 @@
 """Helper script - Return CI variables such as stable cuda, min python version, etc."""
 
 import argparse
-import re
 import sys
-from typing import Optional
-
-
-def parse_version(version_string: str) -> Optional[tuple[int, ...]]:
-    pattern = r"(\d+)\.(\d+)?"
-    match = re.match(pattern, version_string)
-
-    if match:
-        return tuple(int(group) for group in match.groups())
-    else:
-        return None
 
 
 def main(args: list[str]) -> None:
@@ -31,21 +19,11 @@ def main(args: list[str]) -> None:
         action="store_true",
         help="get min supported python version",
     )
-    parser.add_argument(
-        "--old-python-version",
-        action="store_true",
-        help="get min supported python version - 0.1",
-    )
     options = parser.parse_args(args)
     if options.cuda_stable_version:
         return print(generate_binary_build_matrix.CUDA_STABLE)
     if options.min_python_version:
         return print(generate_binary_build_matrix.FULL_PYTHON_VERSIONS[0])
-    if options.old_python_version:
-        version = parse_version(generate_binary_build_matrix.FULL_PYTHON_VERSIONS[0])
-        if version is not None:
-            major, minor = version
-            return print(f"{major}.{minor - 1}")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -117,8 +117,10 @@ jobs:
           # To get QEMU binaries in our PATH
           echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
           # Generate PyTorch version to use
-          echo "PYTORCH_VERSION=$(python3 .github/scripts/generate_pytorch_version.py --no-build-suffix)" >> "${GITHUB_ENV}"
-          echo "STABLE_CUDA_VERSION=$(python3 .github/scripts/get_ci_variable.py --stable-cuda-version)" >> "${GITHUB_ENV}"
+          {
+            echo "PYTORCH_VERSION=$(python3 .github/scripts/generate_pytorch_version.py --no-build-suffix)";
+            echo "STABLE_CUDA_VERSION=$(python3 .github/scripts/get_ci_variable.py --stable-cuda-version)"
+          } >> "${GITHUB_ENV}"
       - name: Setup test specific variables
         if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
         run: |
@@ -155,7 +157,7 @@ jobs:
           docker push ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_NIGHTLY_COMMIT}${CUDA_SUFFIX}"
 
           # Please note, here we ned to pin specific verison of CUDA as with latest label
-          if [[ ${CUDA_VERSION_SHORT} == ${STABLE_CUDA_VERSION} ]]; then
+          if [[ ${CUDA_VERSION_SHORT} == "${STABLE_CUDA_VERSION}" ]]; then
             docker tag ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_NIGHTLY_COMMIT}${CUDA_SUFFIX}" \
                     ghcr.io/pytorch/pytorch-nightly:latest
             docker push ghcr.io/pytorch/pytorch-nightly:latest

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -118,6 +118,7 @@ jobs:
           echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
           # Generate PyTorch version to use
           echo "PYTORCH_VERSION=$(python3 .github/scripts/generate_pytorch_version.py --no-build-suffix)" >> "${GITHUB_ENV}"
+          echo "STABLE_CUDA_VERSION=$(python3 .github/scripts/get_ci_variable.py --stable-cuda-version)" >> "${GITHUB_ENV}"
       - name: Setup test specific variables
         if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
         run: |
@@ -154,7 +155,7 @@ jobs:
           docker push ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_NIGHTLY_COMMIT}${CUDA_SUFFIX}"
 
           # Please note, here we ned to pin specific verison of CUDA as with latest label
-          if [[ ${CUDA_VERSION_SHORT} == "12.4" ]]; then
+          if [[ ${CUDA_VERSION_SHORT} == ${STABLE_CUDA_VERSION} ]]; then
             docker tag ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_NIGHTLY_COMMIT}${CUDA_SUFFIX}" \
                     ghcr.io/pytorch/pytorch-nightly:latest
             docker push ghcr.io/pytorch/pytorch-nightly:latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -253,7 +253,7 @@ jobs:
         with:
           submodules: false
           fetch-depth: 1
-      - name: Setup min python version
+      - name: Get min python version
         id: get-min-python-version
         if: matrix.test_type == 'older_python_version'
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -253,11 +253,25 @@ jobs:
         with:
           submodules: false
           fetch-depth: 1
-      - name: Setup Python 3.8
+      - name: Setup old python version
+        id: get-old-python-version
+        if: matrix.test_type == 'older_python_version'
+        run: |
+          set -eou pipefail
+          # Generate PyTorch version to use
+          echo "OLD_PYTHON_VERSION=$(python3 .github/scripts/get_ci_variable.py --old-python-version)" >> "${GITHUB_OUTPUT}"
+      - name: Setup min python version
+        id: get-min-python-version
+        if: matrix.test_type == 'older_python_version'
+        run: |
+          set -eou pipefail
+          # Generate PyTorch version to use
+          echo "MIN_PYTHON_VERSION=$(python3 .github/scripts/get_ci_variable.py --min-python-version)" >> "${GITHUB_OUTPUT}"
+      - name: Setup Min Python version
         if: matrix.test_type == 'older_python_version'
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: ${{ steps.get-old-python-version.outputs.OLD_PYTHON_VERSION }}
           architecture: x64
           check-latest: false
           cache: pip
@@ -267,7 +281,7 @@ jobs:
         if: matrix.test_type != 'older_python_version'
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: ${{ steps.get-min-python-version.outputs.OLD_PYTHON_VERSION }}
           architecture: x64
           check-latest: false
           cache: pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -253,13 +253,6 @@ jobs:
         with:
           submodules: false
           fetch-depth: 1
-      - name: Setup old python version
-        id: get-old-python-version
-        if: matrix.test_type == 'older_python_version'
-        run: |
-          set -eou pipefail
-          # Generate PyTorch version to use
-          echo "OLD_PYTHON_VERSION=$(python3 .github/scripts/get_ci_variable.py --old-python-version)" >> "${GITHUB_OUTPUT}"
       - name: Setup min python version
         id: get-min-python-version
         if: matrix.test_type == 'older_python_version'
@@ -271,7 +264,7 @@ jobs:
         if: matrix.test_type == 'older_python_version'
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ steps.get-old-python-version.outputs.OLD_PYTHON_VERSION }}
+          python-version: 3.6
           architecture: x64
           check-latest: false
           cache: pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -267,7 +267,7 @@ jobs:
           set -eou pipefail
           # Generate PyTorch version to use
           echo "MIN_PYTHON_VERSION=$(python3 .github/scripts/get_ci_variable.py --min-python-version)" >> "${GITHUB_OUTPUT}"
-      - name: Setup Min Python version
+      - name: Setup Old Python version
         if: matrix.test_type == 'older_python_version'
         uses: actions/setup-python@v4
         with:
@@ -277,11 +277,11 @@ jobs:
           cache: pip
           cache-dependency-path: |
             **/requirements.txt
-      - name: Setup Python 3.9
+      - name: Setup Min Python version
         if: matrix.test_type != 'older_python_version'
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ steps.get-min-python-version.outputs.OLD_PYTHON_VERSION }}
+          python-version: ${{ steps.get-min-python-version.outputs.MIN_PYTHON_VERSION }}
           architecture: x64
           check-latest: false
           cache: pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -253,11 +253,11 @@ jobs:
         with:
           submodules: false
           fetch-depth: 1
-      - name: Setup Python 3.6
+      - name: Setup Python 3.8
         if: matrix.test_type == 'older_python_version'
         uses: actions/setup-python@v4
         with:
-          python-version: '3.6'
+          python-version: '3.8'
           architecture: x64
           check-latest: false
           cache: pip


### PR DESCRIPTION
1. Fixes: https://github.com/pytorch/pytorch/issues/145571 . Cuda Stable is the same cuda version that is published to pypi, also used to set Metadata section in the rest of whl scripts and tag the docker releases with latest tag.
2. Updates min python version used in linter