### PR TITLE
Print hostname for ROCm CI runners in GHA logs

### DIFF
--- a/.github/actions/setup-rocm/action.yml
+++ b/.github/actions/setup-rocm/action.yml
@@ -5,6 +5,11 @@ description: Set up ROCm host for CI
 runs:
   using: composite
   steps:
+    - name: Print hostname
+      if: always()
+      shell: bash
+      run: |
+        hostname
     - name: Stop all running docker containers
       if: always()
       shell: bash

--- a/.github/actions/setup-rocm/action.yml
+++ b/.github/actions/setup-rocm/action.yml
@@ -9,7 +9,7 @@ runs:
       if: always()
       shell: bash
       run: |
-        hostname
+        echo "Hostname: ${NODE_NAME:-$(hostname)}"
     - name: Stop all running docker containers
       if: always()
       shell: bash


### PR DESCRIPTION
Will help provide debug info for MI300 nodes when something goes wrong in the GHA run, since currently it only prints the ephemeral pod ID, which cannot be easily traced back to the node after-the-fact.

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd