### PR TITLE
Only create new tensors in `nn.Module.to_empty` if source tensor is not already on target device

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -962,29 +962,32 @@ class TestModule(TestCase):
 
     @modules([module for module in module_db if not module.is_lazy], allowed_dtypes=[torch.float32])
     @parametrize('swap', [True, False])
+    @parametrize('source_and_target_equal', [True, False])
     @wrapSwapTensorsTest()
-    def test_to_empty(self, device, dtype, module_info, swap, training):
+    def test_to_empty(self, device, dtype, module_info, swap, source_and_target_equal, training):
         module_cls = module_info.module_cls
 
-        with torch.device("meta"):
+        target_device = torch.device(device)
+        source_device = target_device if source_and_target_equal else torch.device("meta")
+
+        with source_device:
             module_inputs = module_info.module_inputs_func(module_info, device=None, dtype=dtype,
                                                            requires_grad=False, training=training)
 
         torch.__future__.set_swap_module_params_on_conversion(swap)
-        device_ = torch.device(device)
 
         for module_input in module_inputs:
             c_args, c_kwargs = module_input.constructor_input.args, module_input.constructor_input.kwargs
 
-            with torch.device("meta"):
+            with source_device:
                 m = module_cls(*c_args, **c_kwargs)
 
             p_ids_before = [id(p) for p in m.parameters()]
             p_cdatas_before = [p._cdata for p in m.parameters()]
-            m.to_empty(device=device_)
+            m.to_empty(device=target_device)
 
             self.assertTrue(all(isinstance(p, torch.nn.Parameter) for p in m.parameters()))
-            self.assertTrue(all(p.device == device_ for p in m.parameters()))
+            self.assertTrue(all(p.device == target_device for p in m.parameters()))
             self.assertTrue(all(p.dtype == dtype for p in m.parameters()))
             p_ids_after = [id(p) for p in m.parameters()]
             p_cdatas_after = [p._cdata for p in m.parameters()]
@@ -993,6 +996,10 @@ class TestModule(TestCase):
                 # id same, ._cdata differs --> swapped cdata of THPVariable
                 self.assertTrue(all(a == b for a, b in zip(p_ids_before, p_ids_after)))
                 self.assertTrue(all(a != b for a, b in zip(p_cdatas_before, p_cdatas_after)))
+            elif source_and_target_equal:
+                # id same, ._cdata same --> no-op
+                self.assertTrue(all(a == b for a, b in zip(p_ids_before, p_ids_after)))
+                self.assertTrue(all(a == b for a, b in zip(p_cdatas_before, p_cdatas_after)))
             else:
                 # id and ._cdata differ
                 # meta and device have different shallow copy types, so this will create a new

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1191,8 +1191,8 @@ class Module:
         return self._apply(lambda t: t.bfloat16() if t.is_floating_point() else t)
 
     def to_empty(
-        self: T, *, device: Optional[DeviceLikeType], recurse: bool = True
-    ) -> T:
+        self, *, device: Optional[DeviceLikeType], recurse: bool = True
+    ) -> Self:
         r"""Move the parameters and buffers to the specified device without copying storage.
 
         Args:
@@ -1204,8 +1204,10 @@ class Module:
         Returns:
             Module: self
         """
+        device = torch.empty((), device=device).device
         return self._apply(
-            lambda t: torch.empty_like(t, device=device), recurse=recurse
+            lambda t: torch.empty_like(t, device=device) if t.device != device else t,
+            recurse=recurse,
         )
 
     @overload


### PR DESCRIPTION
Fixes #148843

Some `Module`s are only partially initialized on the meta-device, like with [`accelerate.init_empty_weights()`](https://huggingface.co/docs/accelerate/v0.11.0/en/big_modeling#accelerate.init_empty_weights)

to avoid needing to re-initialize non-persistent buffers that are destroyed by `nn.Module.to_empty`, it can instead skip creating empty tensors when the source is already on the target device

cc: @awgu 