### PR TITLE
Split up cub-RadixSortPairs.cu to parallelize compilation

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -271,6 +271,7 @@ exclude_patterns = [
     'torch/csrc/utils/generated_serialization_types.h',
     'torch/csrc/utils/pythoncapi_compat.h',
     'torch/csrc/inductor/aoti_runtime/sycl_runtime_wrappers.h',
+    'aten/src/ATen/ExpandBase.h',
 ]
 init_command = [
     'python3',

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-f16-8.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-f16-8.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS(c10::BFloat16, 8)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-int32-1.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-int32-1.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS(int32_t, 1)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-int32-2.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-int32-2.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS(int32_t, 2)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-int32-4.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-int32-4.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS(int32_t, 4)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-int64-1.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-int64-1.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS(int64_t, 1)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-int64-2.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-int64-2.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS(int64_t, 2)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-int64-4.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-int64-4.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS(int64_t, 4)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-scalars.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-scalars.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, AT_INSTANTIATE_SORT_PAIRS_8)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-uint16-8.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-uint16-8.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS(uint16_t, 8)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-uint32-8.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-uint32-8.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS(uint32_t, 8)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-uint64-8.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-uint64-8.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS(uint64_t, 8)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs.cuh
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs.cuh
@@ -1,3 +1,5 @@
+#pragma once
+
 #define TORCH_ASSERT_NO_OPERATORS
 #include <ATen/cuda/CUDAConfig.h>
 #include <ATen/cuda/cub.cuh>
@@ -66,20 +68,7 @@ void radix_sort_pairs_impl(
       int64_t begin_bit,                             \
       int64_t end_bit);
 
-AT_INSTANTIATE_SORT_PAIRS(int32_t, 1)
-AT_INSTANTIATE_SORT_PAIRS(int32_t, 2)
-AT_INSTANTIATE_SORT_PAIRS(int32_t, 4)
-AT_INSTANTIATE_SORT_PAIRS(int64_t, 1)
-AT_INSTANTIATE_SORT_PAIRS(int64_t, 2)
-AT_INSTANTIATE_SORT_PAIRS(int64_t, 4)
-
 #define AT_INSTANTIATE_SORT_PAIRS_8(scalar_t, ScalarType) \
   AT_INSTANTIATE_SORT_PAIRS(scalar_t, 8)
-
-AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, AT_INSTANTIATE_SORT_PAIRS_8)
-AT_INSTANTIATE_SORT_PAIRS(uint16_t, 8)
-AT_INSTANTIATE_SORT_PAIRS(uint32_t, 8)
-AT_INSTANTIATE_SORT_PAIRS(uint64_t, 8)
-AT_INSTANTIATE_SORT_PAIRS(c10::BFloat16, 8)
 
 } // namespace at::cuda::cub::detail


### PR DESCRIPTION
Summary: `cub-RadixSortPairs.cu` has slow compilation times, especially on Windows. These changes split up the file into smaller components to allow each component to compile in parallel. On Windows, I observed a compile time drop from about 20 minutes to 6 minutes.

Differential Revision: D70539649


