### PR TITLE
Consistently use `testing.assert_close` in tests

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_ignore_params.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_ignore_params.py
@@ -213,7 +213,7 @@ class TestFullyShardIgnoreParams(FSDPTest):
     def compare_params(self, name, ref_param, test_param):
         ref_full_tensor = _get_full_tensor(name, ref_param)
         test_full_tensor = _get_full_tensor(name, test_param)
-        self.assertTrue(torch.allclose(ref_full_tensor, test_full_tensor))
+        torch.testing.assert_close(ref_full_tensor, test_full_tensor)
 
     def compare_ref_test_params(self, ref_name_to_param_map, test_name_to_param_map):
         for name in ref_name_to_param_map:
@@ -296,7 +296,7 @@ class TestFullyShardIgnoreParams(FSDPTest):
             test_loss = test_model(test_inp)
 
             # Compare ref and test loss at each step
-            self.assertTrue(torch.allclose(ref_loss, test_loss))
+            torch.testing.assert_close(ref_loss, test_loss)
             ref_loss.backward()
             test_loss.backward()
 

--- a/test/distributed/_composable/test_composability/test_2d_composability.py
+++ b/test/distributed/_composable/test_composability/test_2d_composability.py
@@ -567,7 +567,7 @@ class TestNew2dParallelTraining(DTensorTestBase):
                         continue
                     if type(p2) is DTensor:
                         p2 = p2.redistribute(p2.device_mesh, [Replicate()]).to_local()
-                    self.assertTrue(torch.allclose(p1, p2), f"{p1} vs {p2}")
+                    torch.testing.assert_close(p1, p2)
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -877,7 +877,7 @@ class TestNew2dParallelStateDict(DTensorTestBase):
                         .to_local()
                     )
                 self.assertTrue(isinstance(dist_state, torch.Tensor))
-                self.assertTrue(torch.allclose(state, dist_state))
+                torch.testing.assert_close(state, dist_state)
 
         # Update the parameters 2d optim states will be different from ref_optim_state_dict.
         model_2d(model_2d.get_input().cuda(self.rank)).sum().backward()

--- a/test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py
@@ -148,14 +148,14 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
         spec, _ = self.get_gpu_specs()
 
         st1, st2 = self.get_random_tensors(spec, spec, 10, 10)
-        self.assertTrue(torch.allclose(st1, st2))
-        self.assertTrue(torch.allclose(st1, st2, atol=0))
+        torch.testing.assert_close(st1, st2)
+        torch.testing.assert_close(st1, st2, atol=0)
 
         # compare different arrays
         st1, st2 = self.get_random_tensors(spec, spec, 10, 10, seed_offset=1)
         self.assertFalse(torch.allclose(st1, st2))
         # sharded_tensor.rand produces uniform values in the [0,1] range.
-        self.assertTrue(torch.allclose(st1, st2, atol=1))
+        torch.testing.assert_close(st1, st2, atol=1)
 
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -458,7 +458,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         sd = {"random": torch.zeros(10)}
         DCP.load(sd, checkpoint_id=self.temp_dir)
 
-        self.assertTrue(torch.allclose(sd["random"], t2))
+        torch.testing.assert_close(sd["random"], t2)
 
         with self.assertRaisesRegex(
             CheckpointException, ".*Checkpoint already exists.*"

--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -397,7 +397,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         load_tensor = self.load_tensor(model_to_load.sharded_tensor)
 
         if dist.get_rank() == 0:
-            self.assertTrue(torch.allclose(store_tensor, load_tensor))
+            torch.testing.assert_close(store_tensor, load_tensor)
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)

--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -448,7 +448,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         load_tensor = self.load_tensor(model_to_load.sharded_tensor)
 
         if dist.get_rank() == 0:
-            self.assertTrue(torch.allclose(store_tensor, load_tensor))
+            torch.testing.assert_close(store_tensor, load_tensor)
 
     @with_comms(init_rpc=False, backend="gloo")
     @parametrize("thread_count", _THREAD_COUNTS)

--- a/test/distributed/checkpoint/test_fsdp_optim_state.py
+++ b/test/distributed/checkpoint/test_fsdp_optim_state.py
@@ -125,7 +125,7 @@ class FsdpOptimStateCheckpoint(DTensorTestBase):
                 state2 = after_optim_state.get(fqn).get(state_name)
                 if isinstance(state, ShardedTensor):
                     self.assertTrue(isinstance(state2, ShardedTensor))
-                    self.assertTrue(torch.allclose(state, state2))
+                    torch.testing.assert_close(state, state2)
                 else:
                     self.assertEqual(state, state2)
 

--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -165,7 +165,7 @@ class TestFSSpec(ShardedTensorTestBase):
 
         sd = {"random": torch.zeros(10)}
         dcp.load(sd, checkpoint_id=self.temp_dir)
-        self.assertTrue(torch.allclose(sd["random"], t2))
+        torch.testing.assert_close(sd["random"], t2)
 
         with self.assertRaisesRegex(
             CheckpointException, ".*Checkpoint already exists.*"

--- a/test/distributed/fsdp/test_checkpoint_wrapper.py
+++ b/test/distributed/fsdp/test_checkpoint_wrapper.py
@@ -43,7 +43,7 @@ class CheckpointWrapperTest(TestCase):
         lin_new.load_state_dict(state_dict)
         for p1, p2 in zip(lin.parameters(), lin_new.parameters()):
             self.assertEqual(p1, p2)
-            self.assertTrue(torch.allclose(p1, p2))
+            torch.testing.assert_close(p1, p2)
 
         # Load non-checkpoint wrapped module into checkpoint wrapped one
         # Make params different

--- a/test/distributed/optim/test_named_optimizer.py
+++ b/test/distributed/optim/test_named_optimizer.py
@@ -70,7 +70,7 @@ class NamedOptimizerTest(unittest.TestCase):
                 self.assertEqual(val, group_2[key])
             else:
                 for tensors in zip(val, group_2[key]):
-                    self.assertTrue(torch.allclose(tensors[0], tensors[1]))
+                    torch.testing.assert_close(tensors[0], tensors[1])
 
     def test_state_dict(self):
         """Check that NamedOptimizer exposes the expected state dict

--- a/test/distributed/tensor/test_attention.py
+++ b/test/distributed/tensor/test_attention.py
@@ -195,7 +195,7 @@ class RingAttentionTest(DTensorTestBase):
                 if backend == SDPBackend.EFFICIENT_ATTENTION
                 else 1e-3 * self.world_size
             )
-            self.assertTrue(torch.allclose(out, cp_out, atol=atol))
+            torch.testing.assert_close(out, cp_out, atol=atol)
 
             if not test_forward_only:
                 cp_dq, cp_dk, cp_dv = context_parallel_unshard(
@@ -208,9 +208,9 @@ class RingAttentionTest(DTensorTestBase):
                     if backend == SDPBackend.EFFICIENT_ATTENTION
                     else 8e-3 * self.world_size
                 )
-                self.assertTrue(torch.allclose(q.grad, cp_dq, atol=atol))
-                self.assertTrue(torch.allclose(k.grad, cp_dk, atol=atol))
-                self.assertTrue(torch.allclose(v.grad, cp_dv, atol=atol))
+                torch.testing.assert_close(q.grad, cp_dq, atol=atol)
+                torch.testing.assert_close(k.grad, cp_dk, atol=atol)
+                torch.testing.assert_close(v.grad, cp_dv, atol=atol)
 
                 cp_q.grad = None
                 cp_k.grad = None

--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -536,7 +536,7 @@ class TestWithNCCL(MultiProcessTestCase):
             in_, w, out_grad
         )
 
-        self.assertTrue(torch.allclose(compile_w_grad, eager_w_grad))
+        torch.testing.assert_close(compile_w_grad, eager_w_grad)
 
 
 def dummy_init_pg() -> None:

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -698,7 +698,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
 
         for output, input in zip(outputs, inputs):
             expect = torch.cat([input] * self.world_size)
-            self.assertTrue(torch.allclose(output, expect))
+            torch.testing.assert_close(output, expect)
 
     @requires_gloo()
     def test_reduce_scatter_tensor(self):
@@ -722,7 +722,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             input.view(self.world_size, *out_shape).chunk(self.world_size)[self.rank]
             * self.world_size
         )
-        self.assertTrue(torch.allclose(output, expect))
+        torch.testing.assert_close(output, expect)
 
     @requires_gloo()
     def test_reduce_scatter_tensor_coalesced(self):
@@ -749,7 +749,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
                 ]
                 * self.world_size
             )
-            self.assertTrue(torch.allclose(output, expect))
+            torch.testing.assert_close(output, expect)
 
     @requires_gloo()
     def test_scatter_checks(self):

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -634,11 +634,11 @@ class SymmetricMemoryTest(MultiProcessTestCase):
 
         x = restride_A_shard_for_fused_all_gather_matmul(t, dim)
         self.assertTrue(x.movedim(dim, 0).is_contiguous())
-        self.assertTrue(torch.allclose(x, t))
+        torch.testing.assert_close(x, t)
 
         x = restride_A_for_fused_matmul_reduce_scatter(t, dim)
         self.assertTrue(x.movedim(dim, 0).is_contiguous())
-        self.assertTrue(torch.allclose(x, t))
+        torch.testing.assert_close(x, t)
 
     @skipIfRocm
     @skip_if_lt_x_gpu(2)

--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -247,7 +247,7 @@ class AutogradFunctionTests(torch._dynamo.test_case.TestCase):
                 for _ in range(3):
                     ref = model(x)
                     res = opt_model(x)
-                    self.assertTrue(torch.allclose(ref, res))
+                    torch.testing.assert_close(ref, res)
                 self.assertEqual(cnts.frame_count, 2)
 
     def test_linear_setup_context(self):

--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -220,7 +220,7 @@ class TestExplainWithBackend(torch._dynamo.test_case.TestCase):
         result = optimized_fn(input_tensor)
 
         # Check that fn still produces the same output when wrapped by ExplainWithBackend
-        self.assertTrue(torch.allclose(result, fn(input_tensor)))
+        torch.testing.assert_close(result, fn(input_tensor))
 
         # Verify ExplainOutput object contents, output might change but make sure these fields are present
         explain_output = eb.output()

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -767,7 +767,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         res = fn(x)
         opt_fn = torch.compile(fn, backend="eager")
         opt_res = opt_fn(x)
-        self.assertTrue(torch.allclose(res, opt_res))
+        torch.testing.assert_close(res, opt_res)
         self.assertEqual(res.dtype, torch.bfloat16)
         self.assertEqual(opt_res.dtype, torch.bfloat16)
 

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -3925,8 +3925,8 @@ def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
 
         inp_test = (torch.randn(20, 16, 50, 100), torch.randn(20, 16, 50, 100))
 
-        self.assertTrue(torch.allclose(gm(inp_test)[0], gm2(inp_test)[0]))
-        self.assertTrue(torch.allclose(gm(inp_test)[1], gm2(inp_test)[1]))
+        torch.testing.assert_close(gm(inp_test)[0], gm2(inp_test)[0])
+        torch.testing.assert_close(gm(inp_test)[1], gm2(inp_test)[1])
 
     def test_retracibility_dict_container_inp_out(self):
         class MyLinear(torch.nn.Module):
@@ -3974,9 +3974,9 @@ def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
             "b": torch.randn(20, 16, 50, 100),
         }
 
-        self.assertTrue(torch.allclose(gm(inp_test)["a"][0], gm2(inp_test)["a"][0]))
-        self.assertTrue(torch.allclose(gm(inp_test)["a"][1], gm2(inp_test)["a"][1]))
-        self.assertTrue(torch.allclose(gm(inp_test)["b"], gm2(inp_test)["b"]))
+        torch.testing.assert_close(gm(inp_test)["a"][0], gm2(inp_test)["a"][0])
+        torch.testing.assert_close(gm(inp_test)["a"][1], gm2(inp_test)["a"][1])
+        torch.testing.assert_close(gm(inp_test)["b"], gm2(inp_test)["b"])
 
     def test_retracibility_nested_list_out(self):
         class MyLinear(torch.nn.Module):
@@ -4027,10 +4027,10 @@ def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
             "b": torch.randn(20, 16, 50, 100),
         }
 
-        self.assertTrue(torch.allclose(gm(inp_test)[0][0], gm2(inp_test)[0][0]))
-        self.assertTrue(torch.allclose(gm(inp_test)[0][1], gm2(inp_test)[0][1]))
-        self.assertTrue(torch.allclose(gm(inp_test)[1][0], gm2(inp_test)[1][0]))
-        self.assertTrue(torch.allclose(gm(inp_test)[1][1], gm2(inp_test)[1][1]))
+        torch.testing.assert_close(gm(inp_test)[0][0], gm2(inp_test)[0][0])
+        torch.testing.assert_close(gm(inp_test)[0][1], gm2(inp_test)[0][1])
+        torch.testing.assert_close(gm(inp_test)[1][0], gm2(inp_test)[1][0])
+        torch.testing.assert_close(gm(inp_test)[1][1], gm2(inp_test)[1][1])
 
     def test_fx_pytree(self):
         def foo(args):
@@ -4042,7 +4042,7 @@ def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
 
         gm, _ = torch._dynamo.export(foo, inp_container, aten_graph=True)
 
-        self.assertTrue(torch.allclose(foo(inp_container), gm(inp_container)))
+        torch.testing.assert_close(foo(inp_container), gm(inp_container))
 
     @config.patch(suppress_errors=True)
     @config.patch(verbose=True)
@@ -4080,7 +4080,7 @@ def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
         name, buffer = buffers[0]
         self.assertEqual(name, "L__self___buffer1")
 
-        self.assertTrue(torch.allclose(buffer, torch.zeros(5)))
+        torch.testing.assert_close(buffer, torch.zeros(5))
 
     def test_param_buffer_safe_from_mutation_recurse(self):
         class Child(torch.nn.Module):
@@ -4104,7 +4104,7 @@ def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
 
         gm, _ = torch._dynamo.export(Module(), torch.ones(5), aten_graph=False)
         for _, buffer in gm.named_buffers():
-            self.assertTrue(torch.allclose(buffer, torch.zeros(5)))
+            torch.testing.assert_close(buffer, torch.zeros(5))
 
     def test_predispatch_with_higher_order(self):
         def f(x):
@@ -4115,8 +4115,8 @@ def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
         )
         inp1 = torch.randn(4, 4)
         inp2 = torch.randn(6, 4)
-        self.assertTrue(torch.allclose(f(inp1), gm(inp1)))
-        self.assertTrue(torch.allclose(f(inp2), gm(inp2)))
+        torch.testing.assert_close(f(inp1), gm(inp1))
+        torch.testing.assert_close(f(inp2), gm(inp2))
 
     def test_predispatch_with_higher_order_nested(self):
         def f(x):
@@ -4131,9 +4131,9 @@ def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
         inp1 = torch.randn(4, 4)
         inp2 = torch.randn(6, 4)
         inp3 = torch.randn(8, 4)
-        self.assertTrue(torch.allclose(f(inp1), gm(inp1)))
-        self.assertTrue(torch.allclose(f(inp2), gm(inp2)))
-        self.assertTrue(torch.allclose(f(inp3), gm(inp3)))
+        torch.testing.assert_close(f(inp1), gm(inp1))
+        torch.testing.assert_close(f(inp2), gm(inp2))
+        torch.testing.assert_close(f(inp3), gm(inp3))
 
     def test_predispatch_with_for_out_dtype(self):
         class M(torch.nn.Module):
@@ -4149,7 +4149,7 @@ def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
         x = torch.randint(-128, 127, (5, 5), dtype=torch.int8)
         gm, _ = torch._dynamo.export(m, x, aten_graph=True, pre_dispatch=True)
 
-        self.assertTrue(torch.allclose(m(x), gm(x)))
+        torch.testing.assert_close(m(x), gm(x))
 
     def test_predispatch_with_for_out_dtype_nested(self):
         class M(torch.nn.Module):
@@ -4175,9 +4175,9 @@ def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
         x = torch.ones((5, 5), dtype=torch.int8)
         gm, _ = torch._dynamo.export(m, x, aten_graph=True, pre_dispatch=True)
 
-        self.assertTrue(torch.allclose(m(x), gm(x)))
+        torch.testing.assert_close(m(x), gm(x))
         y = torch.zeros((5, 5), dtype=torch.int8)
-        self.assertTrue(torch.allclose(m(y), gm(y)))
+        torch.testing.assert_close(m(y), gm(y))
 
         self.assertExpectedInline(
             gm.true_graph_0.code.strip(),
@@ -4218,7 +4218,7 @@ def forward(self, arg0_1, arg1_1):
         x, y = torch.rand(3), torch.rand(3)
         gm, _ = torch._dynamo.export(t, x, y)
 
-        self.assertTrue(torch.allclose(forward(None, x, y), gm(x, y)))
+        torch.testing.assert_close(forward(None, x, y), gm(x, y))
         for node in gm.graph.nodes:
             if node.op == "call_function":
                 self.assertIn("nn_module_stack", node.meta)

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -2257,8 +2257,8 @@ def forward(self):
 
         opt_test = torch.compile(test, backend="eager")
         inp = torch.ones(3, 3)
-        self.assertTrue(torch.allclose(test(True, inp), opt_test(True, inp)))
-        self.assertTrue(torch.allclose(test(False, inp), opt_test(False, inp)))
+        torch.testing.assert_close(test(True, inp), opt_test(True, inp))
+        torch.testing.assert_close(test(False, inp), opt_test(False, inp))
 
     def test_map_graph_break(self):
         backend = EagerAndRecordGraphs()
@@ -6907,7 +6907,7 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
         inp = torch.ones(3, 3)
         true_pred = torch.Tensor([True])
         false_pred = torch.Tensor([False])
-        self.assertTrue(torch.allclose(test(true_pred, inp), opt_test(true_pred, inp)))
+        torch.testing.assert_close(test(true_pred, inp), opt_test(true_pred, inp))
         self.assertEqual(cnt.frame_count, 1)
         self.assertTrue(
             torch.allclose(test(false_pred, inp), opt_test(false_pred, inp))

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -3617,7 +3617,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         opt_fn = torch.compile(indirect, backend=cnts)
         result1, result2 = opt_fn()
         self.assertAlmostEqual(cell1 + 1, result1)
-        self.assertTrue(torch.allclose(cell2 + 3, result2))
+        torch.testing.assert_close(cell2 + 3, result2)
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 1)
 
@@ -3647,7 +3647,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         for i in range(1, 4):
             result1, result2, _ = opt_fn()
             self.assertAlmostEqual(orig1 + 1 * i, result1)
-            self.assertTrue(torch.allclose(orig2 + 10 * i, result2))
+            torch.testing.assert_close(orig2 + 10 * i, result2)
             if i == 1:
                 # No automatic dynamic
                 self.assertEqual(cnts.frame_count, 1)
@@ -3727,8 +3727,8 @@ utils_device.CURRENT_DEVICE == None""".split(
         actual1 = opt_mod(torch.tensor(False), inp)
         exp2 = mod(torch.tensor(True), inp)
         actual2 = opt_mod(torch.tensor(True), inp)
-        self.assertTrue(torch.allclose(exp1, actual1))
-        self.assertTrue(torch.allclose(exp2, actual2))
+        torch.testing.assert_close(exp1, actual1)
+        torch.testing.assert_close(exp2, actual2)
 
     def test_closure_write_across_functions(self):
         z = 1
@@ -3774,7 +3774,7 @@ utils_device.CURRENT_DEVICE == None""".split(
             return t + 1, x, res
 
         res = root(torch.ones(1))
-        self.assertTrue(torch.allclose(torch.ones(1) + 1, res[0]))
+        torch.testing.assert_close(torch.ones(1) + 1, res[0])
         self.assertEqual(0, res[1])
         self.assertEqual(10, res[2])
 
@@ -3793,8 +3793,8 @@ utils_device.CURRENT_DEVICE == None""".split(
             return get_inner()
 
         res, inner = root()
-        self.assertTrue(torch.allclose(x + x, res))
-        self.assertTrue(torch.allclose(inner(), res))
+        torch.testing.assert_close(x + x, res)
+        torch.testing.assert_close(inner(), res)
 
     def test_writes_to_cells_across_frames1(self):
         # This regression test was added when Dynamo accidentally had both
@@ -3818,7 +3818,7 @@ utils_device.CURRENT_DEVICE == None""".split(
             return t + 1, res
 
         res = root(torch.zeros(1))
-        self.assertTrue(torch.allclose(res[0], torch.ones(1)))
+        torch.testing.assert_close(res[0], torch.ones(1))
         self.assertEqual(res[1], 1)
         self.assertEqual(x, 1)
 
@@ -3846,7 +3846,7 @@ utils_device.CURRENT_DEVICE == None""".split(
             return t + 1, res
 
         res = root(torch.zeros(1))
-        self.assertTrue(torch.allclose(res[0], torch.ones(1)))
+        torch.testing.assert_close(res[0], torch.ones(1))
         self.assertEqual(res[1], 1)
         self.assertEqual(x, 1)
 
@@ -3877,7 +3877,7 @@ utils_device.CURRENT_DEVICE == None""".split(
 
         result = fn(torch.ones(1))
         inner_x = get_x()
-        self.assertTrue(torch.allclose(result, torch.ones(1)))
+        torch.testing.assert_close(result, torch.ones(1))
         self.assertEqual(inner_x, 42)
 
     def test_existing_func_that_creates_capturing_nested_func(self):
@@ -3896,7 +3896,7 @@ utils_device.CURRENT_DEVICE == None""".split(
             return res, get_x
 
         res, get_x = root(torch.ones(1))
-        self.assertTrue(torch.allclose(res, torch.ones(1)))
+        torch.testing.assert_close(res, torch.ones(1))
         self.assertEqual(0, get_x())
         x += 1
         self.assertEqual(1, get_x())
@@ -5193,7 +5193,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         input = rand_3_5
         output = loss(input, target)
 
-        self.assertTrue(torch.allclose(dynamo_output, output))
+        torch.testing.assert_close(dynamo_output, output)
 
     def test_cross_entropy_loss_fancy_ctor2(self):
         rand_3_5 = torch.randn(3, 5)
@@ -5208,7 +5208,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         input = rand_3_5
         output = loss(input, target)
 
-        self.assertTrue(torch.allclose(dynamo_output, output))
+        torch.testing.assert_close(dynamo_output, output)
 
     def test_cross_entropy_loss_simple_ctor(self):
         output = None
@@ -5224,7 +5224,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         input = rand_3_5
         output = loss(input, target)
 
-        self.assertTrue(torch.allclose(dynamo_output, output))
+        torch.testing.assert_close(dynamo_output, output)
 
     def test_nn_functional_reduction(self):
         def fn(loss, reduction):
@@ -5241,7 +5241,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         ref = fn(x, y)
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         res = opt_fn(x, y)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
 
     def test_large_reduction_list(self):
         dtype = torch.float32
@@ -5309,7 +5309,7 @@ utils_device.CURRENT_DEVICE == None""".split(
             k_a, v_a = actual_params[idx]
             k, v = params[idx]
             self.assertEqual(k_a, k)
-            self.assertTrue(torch.allclose(v_a, v))
+            torch.testing.assert_close(v_a, v)
 
         # Prefix
         params = []
@@ -5327,7 +5327,7 @@ utils_device.CURRENT_DEVICE == None""".split(
             k_a, v_a = actual_params[idx]
             k, v = params[idx]
             self.assertEqual(k_a, k)
-            self.assertTrue(torch.allclose(v_a, v))
+            torch.testing.assert_close(v_a, v)
 
     @torch._dynamo.config.patch(guard_nn_modules=True)
     def test_module_complex_iter(self):
@@ -6002,7 +6002,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         def f():
             return C().fn(torch.ones(2, 3))
 
-        self.assertTrue(torch.allclose(f(), torch.tensor([2.0])))
+        torch.testing.assert_close(f(), torch.tensor([2.0]))
 
     def test_object_staticmethod(self):
         class C:
@@ -6014,7 +6014,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         def f():
             return C().fn(torch.ones(2, 3))
 
-        self.assertTrue(torch.allclose(f(), torch.tensor([2.0])))
+        torch.testing.assert_close(f(), torch.tensor([2.0]))
 
     def test_user_function_variable_supports_enum_argument(self):
         class Foo(enum.Enum):
@@ -6034,7 +6034,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         ref = fn(x)
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         res = opt_fn(x)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
 
     def test_user_function_variable_supports_type_abcmeta_argument(self):
         class Foo(metaclass=abc.ABCMeta):
@@ -6062,7 +6062,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         ref = fn(x)
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         res = opt_fn(x)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
 
     def test_user_function_variable_supports_function_argument(self):
         # Test user defined function default arguments can be:
@@ -6082,7 +6082,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         ref = fn(x)
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         res = opt_fn(x)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
 
     def test_typing_variable_isinstance(self):
         def fn(x, m):
@@ -6096,7 +6096,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         ref = fn(x, m)
         opt_fn = torch.compile(fn, backend="eager")
         res = opt_fn(x, m)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
 
     @torch._dynamo.config.patch(guard_nn_modules=True)
     def test_repro_graph_breaks_in__get_item_by_idx(self):

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1285,7 +1285,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         ref = m(x)
         opt_m = torch.compile(m, backend="eager")
         res = opt_m(x)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
 
     def test_unsupportedmethod(self):
         m = UnsupportedMethodCall()
@@ -1586,7 +1586,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         # would be initialized when running eager mode.
         res = opt_m(x)
         ref = m(x)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
 
     # RuntimeError: SymIntArrayRef expected to contain only concrete integers
     @expectedFailureDynamic
@@ -1598,7 +1598,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         # first iteration
         res = opt_m(x)
         ref = m(x)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
         # input shape changed and second iteration
         x = torch.rand([20, 20])
         try:
@@ -1615,7 +1615,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         opt_m = torch.compile(m, backend="eager", fullgraph=True)
         res = opt_m(x)
         ref = m(x)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
 
     # RuntimeError: SymIntArrayRef expected to contain only concrete integers
     @expectedFailureDynamic
@@ -1626,7 +1626,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         opt_m = torch.compile(m, backend="eager", fullgraph=True)
         res = opt_m(x)
         ref = m(x)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
 
     # RuntimeError: SymIntArrayRef expected to contain only concrete integers
     @expectedFailureDynamic
@@ -1640,7 +1640,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         opt_m = torch.compile(backend="eager", fullgraph=True)(m)
         res = opt_m(x)
         ref = m(x)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
 
     def test_lazy_module_no_cls_to_become(self):
         # make sure super() works in the case where cls_to_become is None
@@ -1649,7 +1649,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         opt_m = torch.compile(m, backend="eager", fullgraph=True)
         res = opt_m(x)
         ref = m(x)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
 
     def test_lazy_module_kwargs(self):
         m = LazyModuleKwArgs()
@@ -1657,7 +1657,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         y = [torch.rand([5, 5])] * 2
         opt_m = torch.compile(backend="eager", fullgraph=True)(m)
         exp_res = m(x, y)
-        self.assertTrue(torch.allclose(exp_res, opt_m(x, y)))
+        torch.testing.assert_close(exp_res, opt_m(x, y))
 
     # RuntimeError: SymIntArrayRef expected to contain only concrete integers
     @expectedFailureDynamic
@@ -1692,10 +1692,10 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         # Make sure we don't get recompilation across multiple runs
         actual_res = test(mod, x)
         expect_res = mod(x)
-        self.assertTrue(torch.allclose(expect_res, actual_res))
+        torch.testing.assert_close(expect_res, actual_res)
         actual_res = test(mod, x)
         expect_res = mod(x)
-        self.assertTrue(torch.allclose(expect_res, actual_res))
+        torch.testing.assert_close(expect_res, actual_res)
         self.assertEqual(cnt.frame_count, 1)
 
     def test_call_fn_with_non_const_inputs_safe(self):
@@ -1724,7 +1724,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         ref = m(x)
         opt_m = torch.compile(backend="eager", fullgraph=True)(m)
         res = opt_m(x)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
 
     def test_conv_transpose_call_forward_directly(self):
         m = ConvTransposeCallForwardDirectly()
@@ -1732,7 +1732,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         ref = m(x)
         opt_m = torch.compile(backend="eager", fullgraph=True)(m)
         res = opt_m(x)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
 
     def test_conv_call_super_forward_directly(self):
         x = torch.randn(4, 4)
@@ -1740,7 +1740,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         ref = m(x)
         opt_m = torch.compile(backend="eager", fullgraph=True)(m)
         res = opt_m(x)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
 
     def test_conv_transpose_call_super_forward_directly(self):
         x = torch.randn(4, 4, 4)
@@ -1748,7 +1748,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         ref = m(x)
         opt_m = torch.compile(backend="eager", fullgraph=True)(m)
         res = opt_m(x)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
 
     @torch._dynamo.config.patch("allow_unspec_int_on_nn_module", True)
     def test_nn_module_unspec_int_attr(self):
@@ -1761,7 +1761,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
             # Compiling `self.step` as static
             ref1 = mod(x)
             res1 = opt_mod(x)
-            self.assertTrue(torch.allclose(ref1, res1))
+            torch.testing.assert_close(ref1, res1)
             self.assertEqual(cnt.frame_count, 1)
 
             mod.step += 1
@@ -1770,7 +1770,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
             # Second time: compiling `self.step` as dynamic
             ref2 = mod(x)
             res2 = opt_mod(x)
-            self.assertTrue(torch.allclose(ref2, res2))
+            torch.testing.assert_close(ref2, res2)
             self.assertEqual(cnt.frame_count, ifdynstaticdefault(2, 1))
 
             mod.step += 1
@@ -1779,7 +1779,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
             # Third time: no re-compilation!
             ref3 = mod(x)
             res3 = opt_mod(x)
-            self.assertTrue(torch.allclose(ref3, res3))
+            torch.testing.assert_close(ref3, res3)
             self.assertEqual(cnt.frame_count, ifdynstaticdefault(2, 1))
 
 
@@ -1794,13 +1794,13 @@ class NNModuleTestsDevice(torch._dynamo.test_case.TestCase):
         # first iteration
         res = opt_m(x)
         ref = m(x)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
         # move to device and second iteration
         m = m.to(device)
         x = x.to(device)
         res = opt_m(x)
         ref = m(x)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
         self.assertEqual(cnt.frame_count, 2)
 
 

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -3089,9 +3089,9 @@ class GraphModule(torch.nn.Module):
         out_buffer_ref = out_ref.values()
         ga_ref, gb_ref, gc_ref = torch.autograd.grad(out_buffer_ref.sum(), (a, b, c))
 
-        self.assertTrue(torch.allclose(ga, ga_ref))
-        self.assertTrue(torch.allclose(gb, gb_ref))
-        self.assertTrue(torch.allclose(gc, gc_ref))
+        torch.testing.assert_close(ga, ga_ref)
+        torch.testing.assert_close(gb, gb_ref)
+        torch.testing.assert_close(gc, gc_ref)
 
     def test_basic_autograd(self):
         self._test_autograd("aot_eager")
@@ -3153,7 +3153,7 @@ class GraphModule(torch.nn.Module):
         # correctness
         self.assertEqual(len(out), len(out_ref))
         for x, x_ref in zip(out, out_ref):
-            self.assertTrue(torch.allclose(x, x_ref))
+            torch.testing.assert_close(x, x_ref)
 
         # We specialize on the length of offsets, e.g. (1) we recompile if the
         # length of the offsets is different. (2) we don't recompile if the
@@ -3206,9 +3206,9 @@ class GraphModule(torch.nn.Module):
         self.assertTrue(out.size() == out_ref.size())
         self.assertTrue(out.stride() == out_ref.stride())
         if out.is_nested:
-            self.assertTrue(torch.allclose(out.values(), out_ref.values()))
+            torch.testing.assert_close(out.values(), out_ref.values())
         else:
-            self.assertTrue(torch.allclose(out, out_ref))
+            torch.testing.assert_close(out, out_ref)
 
         # Check that no upper/lower bound guards are incurred
         def backend(gm, args):

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -135,7 +135,7 @@ class TestConverter(TestCase):
         for x, y in zip(xs, ys):
             if isinstance(x, torch.Tensor) and isinstance(y, torch.Tensor):
                 self.assertEqual(x.shape, y.shape)
-                self.assertTrue(torch.allclose(x, y))
+                torch.testing.assert_close(x, y)
             else:
                 self.assertEqual(type(x), type(y))
                 self.assertEqual(x, y)

--- a/test/export/test_draft_export.py
+++ b/test/export/test_draft_export.py
@@ -459,7 +459,7 @@ class TestDraftExport(TestCase):
         ep = draft_export(mod, inputs)
         report = ep._report
         for ep_out, eager_out in zip(ep.module()(*inputs), mod(*inputs)):
-            self.assertTrue(torch.allclose(ep_out, eager_out))
+            torch.testing.assert_close(ep_out, eager_out)
             self.assertEqual(ep_out.dtype, eager_out.dtype)
 
         self.assertEqual(len(report.failures), 2)
@@ -504,7 +504,7 @@ class TestDraftExport(TestCase):
         for ep_out, eager_out in zip(
             tree_leaves(ep.module()(*inputs)), tree_leaves(mod(*inputs))
         ):
-            self.assertTrue(torch.allclose(ep_out, eager_out))
+            torch.testing.assert_close(ep_out, eager_out)
             self.assertEqual(ep_out.dtype, eager_out.dtype)
 
         self.assertEqual(len(report.failures), 1)
@@ -537,7 +537,7 @@ class TestDraftExport(TestCase):
         ep = draft_export(mod, inputs)
         report = ep._report
         for ep_out, eager_out in zip(ep.module()(*inputs), mod(*inputs)):
-            self.assertTrue(torch.allclose(ep_out, eager_out))
+            torch.testing.assert_close(ep_out, eager_out)
             self.assertEqual(ep_out.dtype, eager_out.dtype)
 
         self.assertEqual(len(report.failures), 1)

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -29,7 +29,7 @@ class TestExperiment(TestCase):
             traced_module_by_torchscript, inps
         )
 
-        self.assertTrue(torch.allclose(exported_module(*inps), model_to_trace(*inps)))
+        torch.testing.assert_close(exported_module(*inps), model_to_trace(*inps))
 
     def test_torchscript_module_export_single_input(self):
         class M(torch.nn.Module):
@@ -44,7 +44,7 @@ class TestExperiment(TestCase):
             traced_module_by_torchscript, inps
         )
 
-        self.assertTrue(torch.allclose(exported_module(inps), model_to_trace(inps)))
+        torch.testing.assert_close(exported_module(inps), model_to_trace(inps))
 
     def test_torchscript_module_export_various_inputs_with_annotated_input_names(self):
         def _check_equality_and_annotations(m_func, inps):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -537,7 +537,7 @@ class TestExport(TestCase):
         ep = export(model, (torch.randint(0, 8, (5,), dtype=torch.int64),))
         print(ep)
         inp = torch.randint(0, 8, (5,), dtype=torch.int64)
-        self.assertTrue(torch.allclose(ep.module()(inp), M()(inp)))
+        torch.testing.assert_close(ep.module()(inp), M()(inp))
 
     def test_symint_output(self):
         class Foo(torch.nn.Module):
@@ -990,14 +990,14 @@ graph():
             },
         )
         ep_output = ep.module()(seq_embeddings, mask, exp)
-        self.assertTrue(torch.allclose(output, ep_output))
+        torch.testing.assert_close(output, ep_output)
 
         seq_embeddings = torch.randn(6, 5)
         mask = torch.ones(6, 5, dtype=torch.bool)
         exp = torch.randn(30)
         output = m(seq_embeddings, mask, exp)
         ep_output = ep.module()(seq_embeddings, mask, exp)
-        self.assertTrue(torch.allclose(output, ep_output))
+        torch.testing.assert_close(output, ep_output)
 
     def test_setgrad_lifted_tensor(self):
         class M(torch.nn.Module):
@@ -1469,7 +1469,7 @@ graph():
         model = TestModule()
         x = torch.randn(20, 10)
         ep_model = export(model, (x,), strict=False).module()
-        self.assertTrue(torch.allclose(model(x), ep_model(x)))
+        torch.testing.assert_close(model(x), ep_model(x))
 
     def test_output_node_name(self):
         class TestModule(torch.nn.Module):
@@ -1484,7 +1484,7 @@ graph():
         x = torch.randn(20, 10)
         ep_model = export(model, (x,), strict=False).module()
         self.assertEqual(list(ep_model.graph.nodes)[-1].name, "output")
-        self.assertTrue(torch.allclose(model(x), ep_model(x)))
+        torch.testing.assert_close(model(x), ep_model(x))
 
     def test_real_tensor_size_mismatch(self):
         from torch._subclasses.fake_tensor import MetadataMismatchError
@@ -1975,7 +1975,7 @@ graph():
         ref_x = torch.randn(3, 4)
         ref_out = m(ref_x)
         ep_training = torch.export.export_for_training(m, (ref_x,), strict=False)
-        self.assertTrue(torch.allclose(ep_training.module()(ref_x), ref_out))
+        torch.testing.assert_close(ep_training.module()(ref_x), ref_out)
         self.assertExpectedInline(
             str(ep_training.graph).strip(),
             """\
@@ -1994,7 +1994,7 @@ graph():
     return (add_2,)""",
         )
         ep = export(m, (ref_x,))
-        self.assertTrue(torch.allclose(ep.module()(ref_x), ref_out))
+        torch.testing.assert_close(ep.module()(ref_x), ref_out)
 
     @testing.expectedFailureLegacyExportNonStrict  # Old export doesn't work with subclasses
     @testing.expectedFailureLegacyExportStrict  # Old export doesn't work with subclasses
@@ -2050,7 +2050,7 @@ graph():
     return (add_2,)""",
         )
         ep = export(m, (ref_x,))
-        self.assertTrue(torch.allclose(ep.module()(ref_x), ref_out))
+        torch.testing.assert_close(ep.module()(ref_x), ref_out)
 
     @testing.expectedFailureLegacyExportNonStrict  # Old export doesn't work with subclasses
     @testing.expectedFailureLegacyExportStrict  # Old export doesn't work with subclasses
@@ -2090,7 +2090,7 @@ graph():
     return (add_2,)""",
         )
         ep = export(m, (ref_x,))
-        self.assertTrue(torch.allclose(ep.module()(ref_x), ref_out))
+        torch.testing.assert_close(ep.module()(ref_x), ref_out)
 
     @testing.expectedFailureLegacyExportNonStrict  # Old export doesn't work with subclasses
     @testing.expectedFailureLegacyExportStrict  # Old export doesn't work with subclasses
@@ -2130,7 +2130,7 @@ graph():
     return (add_2,)""",
         )
         ep = export(m, (ref_x,))
-        self.assertTrue(torch.allclose(ep.module()(ref_x), ref_out))
+        torch.testing.assert_close(ep.module()(ref_x), ref_out)
 
     @testing.expectedFailureLegacyExportNonStrict  # Old export doesn't work with subclasses
     @testing.expectedFailureLegacyExportStrict  # Old export doesn't work with subclasses
@@ -2174,7 +2174,7 @@ graph():
     return (add_3,)""",
         )
         ep = export(m, (ref_x,))
-        self.assertTrue(torch.allclose(ep.module()(ref_x), ref_out))
+        torch.testing.assert_close(ep.module()(ref_x), ref_out)
 
     @testing.expectedFailureLegacyExportNonStrict  # Old export doesn't work with subclasses
     @testing.expectedFailureLegacyExportStrict  # Old export doesn't work with subclasses
@@ -2213,7 +2213,7 @@ graph():
     return (add_2,)""",
         )
         ep = export(m, (ref_x,))
-        self.assertTrue(torch.allclose(ep.module()(ref_x), ref_out))
+        torch.testing.assert_close(ep.module()(ref_x), ref_out)
 
     def test_real_tensor_errors_on_aliasing_custom_op(self):
         @torch.library.custom_op("export::foo_alias", mutates_args={})
@@ -2628,7 +2628,7 @@ def forward(self, p_linear_weight, p_linear_bias, x):
         mod = ModWith2Bars()
         inputs = (torch.randn(4),)
         ep = export(mod, inputs)
-        self.assertTrue(torch.allclose(ep.module()(*inputs), mod(*inputs)))
+        torch.testing.assert_close(ep.module()(*inputs), mod(*inputs))
 
     def test_derived_dim_basic(self):
         class Foo(torch.nn.Module):
@@ -3275,7 +3275,7 @@ def forward(self, x):
 
         ep = export(M(), (torch.ones(3, 3),))
         inp = torch.randn(3, 3)
-        self.assertTrue(torch.allclose(ep.module()(inp)[0], inp + 1))
+        torch.testing.assert_close(ep.module()(inp)[0], inp + 1)
 
     def test_derived_dim_out_of_order_simplified(self):
         _dimz = torch.export.Dim("_dimz", min=6, max=8)
@@ -4562,9 +4562,9 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         ep = export(M(), inputs)
         orig_res = M()(*inputs)
         ep_res = ep.module()(*inputs)
-        self.assertTrue(torch.allclose(orig_res[0], ep_res[0]))
-        self.assertTrue(torch.allclose(orig_res[1], ep_res[1]))
-        self.assertTrue(torch.allclose(orig_res[2], ep_res[2]))
+        torch.testing.assert_close(orig_res[0], ep_res[0])
+        torch.testing.assert_close(orig_res[1], ep_res[1])
+        torch.testing.assert_close(orig_res[2], ep_res[2])
 
     def test_sequential_slicing(self):
         # See https://github.com/pytorch/pytorch/issues/137455
@@ -4600,7 +4600,7 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         inp = (torch.randn(4, 4),)
         for mod in [TestModule1(), TestModule2()]:
             epm = export(mod, inp).module()
-            self.assertTrue(torch.allclose(epm(*inp), mod(*inp)))
+            torch.testing.assert_close(epm(*inp), mod(*inp))
 
     def test_unflatten_isinstance(self):
         class N(torch.nn.Module):
@@ -4626,7 +4626,7 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
             preserve_module_call_signature=tuple(types.keys()),
         )
         ufm = torch.export.unflatten(ep)
-        self.assertTrue(torch.allclose(ufm(x), x + 5))
+        torch.testing.assert_close(ufm(x), x + 5)
         for fqn, mod in ufm.named_modules(remove_duplicate=False):
             if cls := types.get(fqn):
                 ty = f"{cls.__module__}.{cls.__qualname__}"
@@ -4666,15 +4666,15 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         )
         orig_res = M2()(*inputs)
         ep_res = ep.module()(*inputs)
-        self.assertTrue(torch.allclose(orig_res[0], ep_res[0]))
-        self.assertTrue(torch.allclose(orig_res[1], ep_res[1]))
-        self.assertTrue(torch.allclose(orig_res[2], ep_res[2]))
+        torch.testing.assert_close(orig_res[0], ep_res[0])
+        torch.testing.assert_close(orig_res[1], ep_res[1])
+        torch.testing.assert_close(orig_res[2], ep_res[2])
 
         unflattened = torch.export.unflatten(ep)
         ep_res = unflattened(*inputs)
-        self.assertTrue(torch.allclose(orig_res[0], ep_res[0]))
-        self.assertTrue(torch.allclose(orig_res[1], ep_res[1]))
-        self.assertTrue(torch.allclose(orig_res[2], ep_res[2]))
+        torch.testing.assert_close(orig_res[0], ep_res[0])
+        torch.testing.assert_close(orig_res[1], ep_res[1])
+        torch.testing.assert_close(orig_res[2], ep_res[2])
 
     def test_export_func_with_var_keyword_pytree_args(self):
         class Module(torch.nn.Module):
@@ -4807,18 +4807,18 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         m = M()
         rx = torch.randn(5)
 
-        self.assertTrue(torch.allclose(m.t, epm_foo.t))
-        self.assertTrue(torch.allclose(m.t, epm_bar.t))
+        torch.testing.assert_close(m.t, epm_foo.t)
+        torch.testing.assert_close(m.t, epm_bar.t)
 
         # ...foo
-        self.assertTrue(torch.allclose(epm_foo(rx), m.foo(rx)))
-        self.assertTrue(torch.allclose(m.t, epm_foo.t))
-        self.assertTrue(torch.allclose(m.t, epm_bar.t))
+        torch.testing.assert_close(epm_foo(rx), m.foo(rx))
+        torch.testing.assert_close(m.t, epm_foo.t)
+        torch.testing.assert_close(m.t, epm_bar.t)
 
         # ...bar
-        self.assertTrue(torch.allclose(epm_bar(rx), m.bar(rx)))
-        self.assertTrue(torch.allclose(m.t, epm_foo.t))
-        self.assertTrue(torch.allclose(m.t, epm_bar.t))
+        torch.testing.assert_close(epm_bar(rx), m.bar(rx))
+        torch.testing.assert_close(m.t, epm_foo.t)
+        torch.testing.assert_close(m.t, epm_bar.t)
 
     def test_export_api_with_dynamic_shapes(self):
         from torch.export import Dim, dims
@@ -5804,7 +5804,7 @@ def forward(self, x):
             (torch.randint(1, 2, (2, 2)), torch.randint(3, 5, (2, 3))),
         )
         test_inp = (torch.randint(1, 2, (2, 2)), torch.randint(3, 5, (2, 3)))
-        self.assertTrue(torch.allclose(ep.module()(*test_inp), fn(*test_inp)))
+        torch.testing.assert_close(ep.module()(*test_inp), fn(*test_inp))
 
     def test_constrain_size_with_constrain_value(self):
         class Module(torch.nn.Module):
@@ -6088,7 +6088,7 @@ def forward(self, x):
             m_result = m(*inp)
             ep_result = export(m, inp).module()(*inp)
             for m_t, ep_t in zip(m_result, ep_result):
-                self.assertTrue(torch.allclose(m_t, ep_t))
+                torch.testing.assert_close(m_t, ep_t)
 
         test(M())
         test(Wrapper(M().forward))
@@ -6159,10 +6159,10 @@ def forward(self, x):
         export_return_val = stateful_gm(torch.ones(5, 5))
         eager = Foo()
         eager_return_val = eager(torch.ones(5, 5))
-        self.assertTrue(torch.allclose(eager_return_val, export_return_val))
+        torch.testing.assert_close(eager_return_val, export_return_val)
 
         for name, buffer in stateful_gm.named_buffers():
-            self.assertTrue(torch.allclose(torch.ones(1), buffer))
+            torch.testing.assert_close(torch.ones(1), buffer)
 
         changed = stateful_gm.graph.eliminate_dead_code()
         self.assertFalse(changed)
@@ -6171,7 +6171,7 @@ def forward(self, x):
         )
 
         for name, buffer in stateful_gm.named_buffers():
-            self.assertTrue(torch.allclose(torch.tensor(2, dtype=torch.float), buffer))
+            torch.testing.assert_close(torch.tensor(2, dtype=torch.float), buffer)
 
     def test_to_module_with_mutated_buffer_multiple(self):
         class Bar(torch.nn.Module):
@@ -6200,11 +6200,11 @@ def forward(self, x):
         export_return_val = stateful_gm(torch.ones(5, 5))
         eager = Foo()
         eager_return_val = eager(torch.ones(5, 5))
-        self.assertTrue(torch.allclose(eager_return_val, export_return_val))
+        torch.testing.assert_close(eager_return_val, export_return_val)
 
         for name, buffer in stateful_gm.named_buffers():
             if name == "L__self___buf":
-                self.assertTrue(torch.allclose(torch.ones(1), buffer))
+                torch.testing.assert_close(torch.ones(1), buffer)
             if name == "L__self___bar_buf":
                 self.assertTrue(
                     torch.allclose(torch.tensor(4, dtype=torch.float), buffer)
@@ -6296,7 +6296,7 @@ def forward(self, x):
             RuntimeError, "to be equal to trunc, but got floor"
         ):
             _ = exported.module()(torch.randn(4, 4), torch.randn(4), "floor")
-        self.assertTrue(torch.allclose(exported.module()(*inps), foo(*inps)))
+        torch.testing.assert_close(exported.module()(*inps), foo(*inps))
 
     def test_redundant_assert_max_upper_bound(self):
         class M(torch.nn.Module):
@@ -6340,11 +6340,11 @@ def forward(self, x):
         export_return_val = stateful_gm(torch.ones(5, 5))
         eager = Foo()
         eager_return_val = eager(torch.ones(5, 5))
-        self.assertTrue(torch.allclose(eager_return_val, export_return_val))
+        torch.testing.assert_close(eager_return_val, export_return_val)
 
         for name, buffer in stateful_gm.named_buffers():
             if name == "L__self___buf":
-                self.assertTrue(torch.allclose(torch.ones(1), buffer))
+                torch.testing.assert_close(torch.ones(1), buffer)
             if name == "L__self___bar_buf":
                 self.assertTrue(
                     torch.allclose(torch.tensor(4, dtype=torch.float), buffer)
@@ -6392,7 +6392,7 @@ def forward(self, x):
         exported = torch.export.export(Foo(), (inp,))
         reexported = torch.export.export(exported.module(), (inp,))
 
-        self.assertTrue(torch.allclose(Foo()(inp), reexported.module()(inp)))
+        torch.testing.assert_close(Foo()(inp), reexported.module()(inp))
 
         dim0_x = torch.export.Dim("dim0_x")
         exported = torch.export.export(Foo(), (inp,), dynamic_shapes=({0: dim0_x},))
@@ -6502,7 +6502,7 @@ def forward(self, b_a_buffer, x):
         ep = torch.export.export(M(), (inp,))
         inp = torch.randn(2, 3)
         epm = ep.module()
-        self.assertTrue(torch.allclose(epm(inp), M()(inp)))
+        torch.testing.assert_close(epm(inp), M()(inp))
 
         for gm in epm.named_modules():
             if not isinstance(gm, torch.fx.GraphModule):
@@ -6528,7 +6528,7 @@ def forward(self, b_a_buffer, x):
                 return associative_scan(self.combine_fn, x, 2)
 
         ep = export(Foo(), (xs,), dynamic_shapes={"x": {1: dim1}})
-        self.assertTrue(torch.allclose(ep.module()(xs), Foo()(xs)))
+        torch.testing.assert_close(ep.module()(xs), Foo()(xs))
 
     @requires_cuda
     @testing.expectedFailureCppRuntime
@@ -6547,7 +6547,7 @@ def forward(self, b_a_buffer, x):
                 return associative_scan(self.combine_fn, x, 1)
 
         ep = export(Foo(), (xs,), dynamic_shapes={"x": {1: dim1}})
-        self.assertTrue(torch.allclose(ep.module()(xs), Foo()(xs)))
+        torch.testing.assert_close(ep.module()(xs), Foo()(xs))
 
     # TODO: need combine_mode='pointwise' here in order to avoid,
     # but 'pointwise does not support lifted arguments yet supported in inductor
@@ -6570,7 +6570,7 @@ def forward(self, b_a_buffer, x):
         inp = torch.ones(3, 10, 2, device=torch.device("cuda"))
         ep = export(M(), (inp,))
         epm = ep.module()
-        self.assertTrue(torch.allclose(epm(inp), M()(inp)))
+        torch.testing.assert_close(epm(inp), M()(inp))
 
         for gm in epm.named_modules():
             if not isinstance(gm, torch.fx.GraphModule):
@@ -6605,7 +6605,7 @@ def forward(self, b_a_buffer, x):
         ep = torch.export.export(M(), example_inputs)
         example_inputs = (torch.randn(3, 2), torch.tensor(3))
         epm = ep.module()
-        self.assertTrue(torch.allclose(epm(*example_inputs), M()(*example_inputs)))
+        torch.testing.assert_close(epm(*example_inputs), M()(*example_inputs))
 
         for gm in epm.named_modules():
             if not isinstance(gm, torch.fx.GraphModule):
@@ -6679,11 +6679,11 @@ def forward(self, b_a_buffer, x):
         self.assertEqual(len(ep.constants), 3)
 
         inp = (torch.tensor(5),)
-        self.assertTrue(torch.allclose(ep.module()(*inp), Foo()(*inp)))
+        torch.testing.assert_close(ep.module()(*inp), Foo()(*inp))
 
         transform = ep.run_decompositions()
         self.assertEqual(len(ep.graph_signature.input_specs), 4)
-        self.assertTrue(torch.allclose(ep.module()(*inp), transform.module()(*inp)))
+        torch.testing.assert_close(ep.module()(*inp), transform.module()(*inp))
 
         class Boo(torch.nn.Module):
             def __init__(self) -> None:
@@ -6701,11 +6701,11 @@ def forward(self, b_a_buffer, x):
         self.assertEqual(len(ep.constants), 3)
 
         inp = (torch.tensor(True),)
-        self.assertTrue(torch.allclose(ep.module()(*inp), Boo()(*inp)))
+        torch.testing.assert_close(ep.module()(*inp), Boo()(*inp))
 
         transform = ep.run_decompositions()
         self.assertEqual(len(ep.graph_signature.input_specs), 4)
-        self.assertTrue(torch.allclose(ep.module()(*inp), transform.module()(*inp)))
+        torch.testing.assert_close(ep.module()(*inp), transform.module()(*inp))
 
     def test_tensor_attribute_zero_args(self):
         class Foo(torch.nn.Module):
@@ -6791,7 +6791,7 @@ def forward(self, b_a_buffer, x):
         ep = export(m, inp)
         state_dict = ep.state_dict
 
-        self.assertTrue(torch.allclose(ep.module()(*inp), m(*inp)))
+        torch.testing.assert_close(ep.module()(*inp), m(*inp))
 
         core_aten_ep = ep.run_decompositions()
         FileCheck().check_count("torch.ops.aten.permute.default", 1, exactly=True).run(
@@ -6800,7 +6800,7 @@ def forward(self, b_a_buffer, x):
         FileCheck().check_count("torch.ops.aten.t.default", 0, exactly=True).run(
             core_aten_ep.graph_module.code
         )
-        self.assertTrue(torch.allclose(core_aten_ep.module()(*inp), m(*inp)))
+        torch.testing.assert_close(core_aten_ep.module()(*inp), m(*inp))
         self.assertEqual(id(state_dict), id(ep.state_dict))
 
     @unittest.skipIf(IS_FBCODE, "We can't customize decomp in fbcode")
@@ -6957,7 +6957,7 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, c_
         FileCheck().check_count("torch.ops.aten.t.default", 0, exactly=True).run(
             core_aten_ep.graph_module.code
         )
-        self.assertTrue(torch.allclose(core_aten_ep.module()(*inp), m(*inp)))
+        torch.testing.assert_close(core_aten_ep.module()(*inp), m(*inp))
 
     def test_nonzero_2(self):
         class Module(torch.nn.Module):
@@ -6967,7 +6967,7 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, c_
         f = Module()
         ep = export(f, (torch.ones(2),))
         inp = torch.randn(2)
-        self.assertTrue(torch.allclose(ep.module()(inp), torch.nonzero(inp)))
+        torch.testing.assert_close(ep.module()(inp), torch.nonzero(inp))
 
     def test_redundant_asserts(self):
         class Foo(torch.nn.Module):
@@ -7114,7 +7114,7 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, c_
 
         inps = (torch.randn(3, 3),)
         ep = export(M2(), inps)
-        self.assertTrue(torch.allclose(ep.module()(*inps), M2()(*inps)))
+        torch.testing.assert_close(ep.module()(*inps), M2()(*inps))
 
         add_nodes = [
             node
@@ -7137,7 +7137,7 @@ graph():
         )
 
         unflattened = unflatten(ep)
-        self.assertTrue(torch.allclose(unflattened(*inps), M2()(*inps)))
+        torch.testing.assert_close(unflattened(*inps), M2()(*inps))
 
     def test_nested_module_with_init_buffer(self):
         class M1(torch.nn.Module):
@@ -7155,7 +7155,7 @@ graph():
 
         inps = (torch.randn(3, 3),)
         ep = export(M2(), inps)
-        self.assertTrue(torch.allclose(ep.module()(*inps), M2()(*inps)))
+        torch.testing.assert_close(ep.module()(*inps), M2()(*inps))
 
         self.assertEqual(len(ep.state_dict), 0)
         self.assertEqual(len(ep.constants), 0)
@@ -7172,7 +7172,7 @@ graph():
         )
 
         unflattened = unflatten(ep)
-        self.assertTrue(torch.allclose(unflattened(*inps), M2()(*inps)))
+        torch.testing.assert_close(unflattened(*inps), M2()(*inps))
 
     def test_nested_module_with_constant_buffer(self):
         class M1(torch.nn.Module):
@@ -7190,7 +7190,7 @@ graph():
 
         inps = (torch.randn(3, 3),)
         ep = export_for_training(M2(), inps).run_decompositions({})
-        self.assertTrue(torch.allclose(ep.module()(*inps), M2()(*inps)))
+        torch.testing.assert_close(ep.module()(*inps), M2()(*inps))
 
         self.assertEqual(len(ep.state_dict), 0)
         self.assertEqual(len(ep.constants), 1)
@@ -7207,7 +7207,7 @@ graph():
         )
 
         unflattened = unflatten(ep)
-        self.assertTrue(torch.allclose(unflattened(*inps), M2()(*inps)))
+        torch.testing.assert_close(unflattened(*inps), M2()(*inps))
 
     def test_nested_module_with_parameter(self):
         class M1(torch.nn.Module):
@@ -7227,7 +7227,7 @@ graph():
         inps = (torch.randn(3, 3),)
         # Strict export segfaults (Issue #128109)
         ep = export_for_training(M2(), inps, strict=False).run_decompositions({})
-        self.assertTrue(torch.allclose(ep.module()(*inps), M2()(*inps)))
+        torch.testing.assert_close(ep.module()(*inps), M2()(*inps))
 
         self.assertEqual(len(ep.state_dict), 0)
         self.assertEqual(len(ep.constants), 1)
@@ -7253,7 +7253,7 @@ graph():
         )
 
         unflattened = unflatten(ep)
-        self.assertTrue(torch.allclose(unflattened(*inps), M2()(*inps)))
+        torch.testing.assert_close(unflattened(*inps), M2()(*inps))
 
     def test_module_dict_key(self):
         class Module(torch.nn.Module):
@@ -7317,7 +7317,7 @@ graph():
         )
 
         test_inp = torch.ones(8, 4)
-        self.assertTrue(torch.allclose(ep.module()(test_inp), Foo().forward(test_inp)))
+        torch.testing.assert_close(ep.module()(test_inp), Foo().forward(test_inp))
 
     def test_runtime_assert_with_size(self):
         class M(torch.nn.Module):
@@ -7333,7 +7333,7 @@ graph():
             dynamic_shapes={"x": None, "y": {0: torch.export.Dim("t")}},
         )
         inp = (torch.tensor(6), torch.randn(13))
-        self.assertTrue(torch.allclose(ep.module()(*inp), M()(*inp)))
+        torch.testing.assert_close(ep.module()(*inp), M()(*inp))
 
     @unittest.skip("Test is only supposed to work with non-strict mode")
     def test_issue_113041(self):
@@ -7781,7 +7781,7 @@ graph():
             normalized_k = k.replace(".", "_")
             self.assertIn(normalized_k, torch_gm.state_dict())
             self.assertEqual(v, torch_gm.state_dict()[normalized_k])
-        self.assertTrue(torch.allclose(torch_gm(test_inp), orig_eager(test_inp)))
+        torch.testing.assert_close(torch_gm(test_inp), orig_eager(test_inp))
 
         pre_autograd_gm = torch.export._trace._export(
             orig_eager, (torch.rand(2, 3),), {}, pre_dispatch=True
@@ -7790,7 +7790,7 @@ graph():
             normalized_k = k.replace(".", "_")
             self.assertIn(k, pre_autograd_gm.state_dict())
             self.assertEqual(v, pre_autograd_gm.state_dict()[k])
-        self.assertTrue(torch.allclose(pre_autograd_gm(test_inp), orig_eager(test_inp)))
+        torch.testing.assert_close(pre_autograd_gm(test_inp), orig_eager(test_inp))
 
         ep = export(orig_eager, (torch.rand(2, 3),), {})
         for k, v in orig_eager.state_dict().items():
@@ -7798,7 +7798,7 @@ graph():
             # program's state dict is able to contain the module information.
             self.assertIn(k, ep.state_dict)
             self.assertEqual(v, ep.state_dict[k])
-        self.assertTrue(torch.allclose(ep.module()(test_inp), orig_eager(test_inp)))
+        torch.testing.assert_close(ep.module()(test_inp), orig_eager(test_inp))
 
     def test_nn_module_stack(self):
         class Leaf(torch.nn.Module):
@@ -7992,8 +7992,8 @@ graph():
         ep = export(n0, inp)
         epm = ep.module()
         ufm = torch.export.unflatten(ep)
-        self.assertTrue(torch.allclose(epm(*inp), eager))
-        self.assertTrue(torch.allclose(ufm(*inp), eager))
+        torch.testing.assert_close(epm(*inp), eager)
+        torch.testing.assert_close(ufm(*inp), eager)
 
     def test_unflatten_random_dag_6(self):
         # dag: {0: [1, 2, 4, 5], 1: [3, 5], 2: [4, 5], 3: [], 4: [5], 5: []}
@@ -8060,8 +8060,8 @@ graph():
         ep = export(n0, inp)
         epm = ep.module()
         ufm = torch.export.unflatten(ep)
-        self.assertTrue(torch.allclose(epm(*inp), eager))
-        self.assertTrue(torch.allclose(ufm(*inp), eager))
+        torch.testing.assert_close(epm(*inp), eager)
+        torch.testing.assert_close(ufm(*inp), eager)
 
     def test_unflatten_random_dag_buf_8(self):
         class N7(torch.nn.Module):
@@ -9195,15 +9195,15 @@ graph():
                 ufm = torch.export.unflatten(ep)
 
                 exported_result = epm(*inp)
-                self.assertTrue(torch.allclose(exported_result, eager_result))
+                torch.testing.assert_close(exported_result, eager_result)
 
                 unflattened_result = ufm(*inp)
-                self.assertTrue(torch.allclose(unflattened_result, eager_result))
+                torch.testing.assert_close(unflattened_result, eager_result)
 
                 for fqn, mod in swap.items():
                     ufm.set_submodule(fqn, mod)
                 unflattened_result = ufm(*inp)
-                self.assertTrue(torch.allclose(unflattened_result, eager_result))
+                torch.testing.assert_close(unflattened_result, eager_result)
 
             if not is_retracebility_test(self._testMethodName):
                 # swapping will not work with retrace
@@ -9246,14 +9246,14 @@ graph():
             ufm = torch.export.unflatten(ep)
 
             exported_result = epm(*inp)
-            self.assertTrue(torch.allclose(exported_result, eager_result))
+            torch.testing.assert_close(exported_result, eager_result)
 
             unflattened_result = ufm(*inp)
-            self.assertTrue(torch.allclose(unflattened_result, eager_result))
+            torch.testing.assert_close(unflattened_result, eager_result)
 
             ufm.set_submodule("n", N())
             unflattened_result = ufm(*inp)
-            self.assertTrue(torch.allclose(unflattened_result, eager_result))
+            torch.testing.assert_close(unflattened_result, eager_result)
 
     def test_unflatten_multiple_graphs_dispatch(self):
         class N(torch.nn.Module):
@@ -9287,10 +9287,10 @@ graph():
             ufm = torch.export.unflatten(ep)
 
             exported_result = epm(*inp)
-            self.assertTrue(torch.allclose(exported_result, eager_result))
+            torch.testing.assert_close(exported_result, eager_result)
 
             unflattened_result = ufm(*inp)
-            self.assertTrue(torch.allclose(unflattened_result, eager_result))
+            torch.testing.assert_close(unflattened_result, eager_result)
 
         if is_training_ir_test(self._testMethodName):
             test(
@@ -9334,16 +9334,16 @@ graph():
             ufm = torch.export.unflatten(ep)
 
             exported_result = epm(*inp)
-            self.assertTrue(torch.allclose(exported_result, eager_result))
+            torch.testing.assert_close(exported_result, eager_result)
 
             unflattened_result = ufm(*inp)
-            self.assertTrue(torch.allclose(unflattened_result, eager_result))
+            torch.testing.assert_close(unflattened_result, eager_result)
 
             if swap:
                 for fqn, mod in swap.items():
                     ufm.set_submodule(fqn, mod)
                 unflattened_result = ufm(*inp)
-                self.assertTrue(torch.allclose(unflattened_result, eager_result))
+                torch.testing.assert_close(unflattened_result, eager_result)
 
         if not is_retracebility_test(self._testMethodName):
             # swapping will not work with retrace
@@ -9391,16 +9391,16 @@ graph():
             ufm = torch.export.unflatten(ep)
 
             exported_result = epm(*inp)
-            self.assertTrue(torch.allclose(exported_result, eager_result))
+            torch.testing.assert_close(exported_result, eager_result)
 
             unflattened_result = ufm(*inp)
-            self.assertTrue(torch.allclose(unflattened_result, eager_result))
+            torch.testing.assert_close(unflattened_result, eager_result)
 
             if swap:
                 for fqn, mod in swap.items():
                     ufm.set_submodule(fqn, mod)
                 unflattened_result = ufm(*inp)
-                self.assertTrue(torch.allclose(unflattened_result, eager_result))
+                torch.testing.assert_close(unflattened_result, eager_result)
 
         if not is_retracebility_test(self._testMethodName):
             # swapping will not work with retrace
@@ -9441,7 +9441,7 @@ graph():
         ep = export(M(), inp)
         epm = ep.module()
         ufm = torch.export.unflatten(ep)
-        self.assertTrue(torch.allclose(ufm(*inp), epm(*inp)))
+        torch.testing.assert_close(ufm(*inp), epm(*inp))
 
     def test_placeholder_update_preserving(self):
         class Child(torch.nn.Module):
@@ -9469,10 +9469,10 @@ graph():
 
         inp = torch.ones(2, 3, dtype=torch.float32)
         ep1_result = ep1.module()(inp)
-        self.assertTrue(torch.allclose(ep1_result, orig_result))
+        torch.testing.assert_close(ep1_result, orig_result)
         inp = torch.ones(2, 3, dtype=torch.float32)
         ep2_result = ep2.module()(inp)
-        self.assertTrue(torch.allclose(ep2_result, orig_result))
+        torch.testing.assert_close(ep2_result, orig_result)
 
     @testing.expectedFailureLegacyExportNonStrict
     @testing.expectedFailureLegacyExportStrict
@@ -9581,7 +9581,7 @@ def forward(self, c_submod_params, x):
         ep = export(M(), inp)
         epm = ep.module()
         ufm = torch.export.unflatten(ep)
-        self.assertTrue(torch.allclose(ufm(*inp), epm(*inp)))
+        torch.testing.assert_close(ufm(*inp), epm(*inp))
 
     def test_unflatten_multiple_graphs_shared_submodule(self):
         class N(torch.nn.Module):
@@ -9624,13 +9624,13 @@ def forward(self, c_submod_params, x):
             ep = export(m, inp)
             exported_result = ep.module()(*inp)
             # exported and eager results should match (baseline)
-            self.assertTrue(torch.allclose(exported_result, eager_result))
+            torch.testing.assert_close(exported_result, eager_result)
 
             unflattened = torch.export.unflatten(ep)
             unflattened_result = unflattened(*inp)
             # unflattened and eager results should match
             # (needs multiple specialized graphs for shared submodule instance)
-            self.assertTrue(torch.allclose(unflattened_result, eager_result))
+            torch.testing.assert_close(unflattened_result, eager_result)
 
             # expected graph should call minimal number of specialized submodules
             self.assertExpectedInline(
@@ -9665,11 +9665,11 @@ def forward(self, c_submod_params, x):
 
             ep = export(m, inp, preserve_module_call_signature=("n", "p"))
             exported_result = ep.module()(*inp)
-            self.assertTrue(torch.allclose(exported_result, eager_result))
+            torch.testing.assert_close(exported_result, eager_result)
 
             unflattened = torch.export.unflatten(ep)
             unflattened_result = unflattened(*inp)
-            self.assertTrue(torch.allclose(unflattened_result, eager_result))
+            torch.testing.assert_close(unflattened_result, eager_result)
 
         test(
             gen_m(n=True, n_1=False, p=False, p_1=False),
@@ -9953,7 +9953,7 @@ def forward(self, p_bar_linear_weight, p_bar_linear_bias, x):
             "t": (Dim.STATIC,),
         }
         ep = export(Model(), inp, dynamic_shapes=spec)
-        self.assertTrue(torch.allclose(Model()(*inp), ep.module()(*inp)))
+        torch.testing.assert_close(Model()(*inp), ep.module()(*inp))
 
     def test_predispatch_cond(self):
         class Model(torch.nn.Module):
@@ -10112,7 +10112,7 @@ def forward(self, x, b_t, y):
         mod = ModuleListTruncated()
 
         epm = export(mod, (x,)).module()
-        self.assertTrue(torch.allclose(mod(x), epm(x)))
+        torch.testing.assert_close(mod(x), epm(x))
 
     def test_non_persistent_buffer(self):
         class MyModule(torch.nn.Module):
@@ -10225,7 +10225,7 @@ def forward(self, x, b_t, y):
 
         inp = (torch.randn(3, 3), torch.randn(3, 3))
         new_res = torch.compile(f, backend=my_custom_backend)(*inp)
-        self.assertTrue(torch.allclose(f(*inp), new_res))
+        torch.testing.assert_close(f(*inp), new_res)
 
     def test_nonstrict_retrace_preserves_metadata(self):
         class MyModule(torch.nn.Module):
@@ -10295,7 +10295,7 @@ def forward(self, x, b_t, y):
         m = EmptyM()
         ep = torch.export.export(m, ())
         for out, real_out in zip(ep.module()(), m()):
-            self.assertTrue(torch.allclose(out, real_out))
+            torch.testing.assert_close(out, real_out)
 
     def test_trace_under_fake(self):
         class MyModule(torch.nn.Module):
@@ -10365,9 +10365,9 @@ def forward(self, x, b_t, y):
             ep_strict = export(m, (input,), strict=True)
             ep_non_strict = export(m, (input,), strict=False)
 
-            self.assertTrue(torch.allclose(input * 3, m(input)))
-            self.assertTrue(torch.allclose(input * 2, ep_strict.module()(input)))
-            self.assertTrue(torch.allclose(input * 2, ep_non_strict.module()(input)))
+            torch.testing.assert_close(input * 3, m(input))
+            torch.testing.assert_close(input * 2, ep_strict.module()(input))
+            torch.testing.assert_close(input * 2, ep_non_strict.module()(input))
 
     def test_user_input_and_buffer_mutation(self):
         class MyModule(torch.nn.Module):
@@ -10410,17 +10410,17 @@ def forward(self, x, b_t, y):
         ep = torch.export.export(M(), inps_for_export)
         x_new_eager, z_new_eager, legit_eager = M()(*inps)
         x_new_export, z_new_export, legit_export = ep.module()(*inps_for_export)
-        self.assertTrue(torch.allclose(x_new_eager, x_new_export))
-        self.assertTrue(torch.allclose(z_new_eager, z_new_export))
-        self.assertTrue(torch.allclose(legit_eager, legit_export))
+        torch.testing.assert_close(x_new_eager, x_new_export)
+        torch.testing.assert_close(z_new_eager, z_new_export)
+        torch.testing.assert_close(legit_eager, legit_export)
 
         ep = ep.run_decompositions()
         x_new_export, z_new_export, legit_export = ep.module()(
             *inps_for_export_with_decomp
         )
-        self.assertTrue(torch.allclose(x_new_eager, x_new_export))
-        self.assertTrue(torch.allclose(z_new_eager, z_new_export))
-        self.assertTrue(torch.allclose(legit_eager, legit_export))
+        torch.testing.assert_close(x_new_eager, x_new_export)
+        torch.testing.assert_close(z_new_eager, z_new_export)
+        torch.testing.assert_close(legit_eager, legit_export)
 
     def test_custom_op_auto_functionalize_pre_dispatch(self):
         class M(torch.nn.Module):
@@ -11015,8 +11015,8 @@ def forward(self, x, y):
         ep = export(M(), (torch.ones(4, 4),)).run_decompositions()
         mod = ep.module()
         a, b = mod(torch.zeros(4, 4))
-        self.assertTrue(torch.allclose(a, torch.ones(4, 4)))
-        self.assertTrue(torch.allclose(b, torch.ones(4, 4)))
+        torch.testing.assert_close(a, torch.ones(4, 4))
+        torch.testing.assert_close(b, torch.ones(4, 4))
 
     @testing.expectedFailureLegacyExportNonStrict
     @testing.expectedFailureLegacyExportStrict
@@ -11103,7 +11103,7 @@ graph():
         self.assertEqual(num_constant_inputs, 1)
         # unflatten
         unflattened = unflatten(ep)
-        self.assertTrue(torch.allclose(m1(*inps), unflattened(*inps)))
+        torch.testing.assert_close(m1(*inps), unflattened(*inps))
 
     @testing.expectedFailureRetraceability
     def test_unused_aliases(self):
@@ -11456,8 +11456,8 @@ def forward(self, x):
         comp_mod = ep.module()
         inp1 = torch.randn(3, 4)
         inp2 = torch.randn(7, 4)
-        self.assertTrue(torch.allclose(comp_mod(inp1), mod(inp1)))
-        self.assertTrue(torch.allclose(comp_mod(inp2), mod(inp2)))
+        torch.testing.assert_close(comp_mod(inp1), mod(inp1))
+        torch.testing.assert_close(comp_mod(inp2), mod(inp2))
 
     def test_automatic_dynamic_shapes_simple_equality(self):
         # The next 3 test cases tests for automatic dynamic shapes specs, verifying that automatic dynamism
@@ -12217,7 +12217,7 @@ class GraphModule(torch.nn.Module):
             m = Foo()
             ep = export(m, (torch.randn(4, 4),))
             inp = (torch.randn(4, 4),)
-            self.assertTrue(torch.allclose(ep.module()(*inp), m(*inp)))
+            torch.testing.assert_close(ep.module()(*inp), m(*inp))
 
     @unittest.skipIf(IS_MACOS, "Distributed not packaged in macos")
     def test_distributed_all_gather(self):
@@ -12247,7 +12247,7 @@ class GraphModule(torch.nn.Module):
             m = Foo()
             ep = export(m, (torch.randn(2),))
             inp = (torch.randn(2),)
-            self.assertTrue(torch.allclose(ep.module()(*inp), m(*inp)))
+            torch.testing.assert_close(ep.module()(*inp), m(*inp))
 
     @unittest.skipIf(IS_MACOS, "Distributed not packaged in macos")
     @testing.expectedFailureCppRuntime

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -604,8 +604,8 @@ class TestPasses(TestCase):
         without_token_ep.verifier().check(without_token_ep)
         without_token_res = without_token_ep.module()(inp)
 
-        self.assertTrue(torch.allclose(orig_res, ep_res))
-        self.assertTrue(torch.allclose(orig_res, without_token_res))
+        torch.testing.assert_close(orig_res, ep_res)
+        torch.testing.assert_close(orig_res, without_token_res)
 
     def test_remove_effect_token_kwargs(self):
         class MyModule(torch.nn.Module):

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -750,7 +750,7 @@ class TestDeserialize(TestCase):
                     if orig.is_meta:
                         self.assertEqual(orig, loaded)
                     else:
-                        self.assertTrue(torch.allclose(orig, loaded))
+                        torch.testing.assert_close(orig, loaded)
                 else:
                     self.assertEqual(orig, loaded)
             self._check_graph_nodes(
@@ -1249,8 +1249,8 @@ class TestDeserialize(TestCase):
         inp = (torch.randn(3),)
         orig_res = ep.module()(*inp)
         res = deserialized_ep.module()(*inp)
-        self.assertTrue(torch.allclose(orig_res[0], res[0]))
-        self.assertTrue(torch.allclose(orig_res[1], res[1]))
+        torch.testing.assert_close(orig_res[0], res[0])
+        torch.testing.assert_close(orig_res[1], res[1])
 
         # The deserialized graph should have deduped getitem calls
         self.assertExpectedInline(
@@ -1379,7 +1379,7 @@ def forward(self, x):
         ep = torch.export.export_for_training(M(), ())
         ep._example_inputs = None
         roundtrip_ep = deserialize(serialize(ep))
-        self.assertTrue(torch.allclose(ep.module()(), roundtrip_ep.module()()))
+        torch.testing.assert_close(ep.module()(), roundtrip_ep.module()())
 
     def test_serialize_float8(self):
         for dtype in [torch.float8_e5m2, torch.float8_e4m3fn]:
@@ -1447,7 +1447,7 @@ class TestSaveLoad(TestCase):
         buffer.seek(0)
         loaded_ep = load(buffer)
 
-        self.assertTrue(torch.allclose(ep.module()(*inp), loaded_ep.module()(*inp)))
+        torch.testing.assert_close(ep.module()(*inp), loaded_ep.module()(*inp))
 
     def test_save_file(self):
         class Foo(torch.nn.Module):
@@ -1464,7 +1464,7 @@ class TestSaveLoad(TestCase):
             f.seek(0)
             loaded_ep = load(f)
 
-        self.assertTrue(torch.allclose(ep.module()(*inp), loaded_ep.module()(*inp)))
+        torch.testing.assert_close(ep.module()(*inp), loaded_ep.module()(*inp))
 
     def test_save_path(self):
         class Foo(torch.nn.Module):
@@ -1481,7 +1481,7 @@ class TestSaveLoad(TestCase):
             save(ep, path)
             loaded_ep = load(path)
 
-        self.assertTrue(torch.allclose(ep.module()(*inp), loaded_ep.module()(*inp)))
+        torch.testing.assert_close(ep.module()(*inp), loaded_ep.module()(*inp))
 
     def test_save_extra(self):
         inp = (torch.tensor([0.1, 0.1]),)
@@ -1500,7 +1500,7 @@ class TestSaveLoad(TestCase):
         extra_files = {"extra.txt": ""}
         loaded_ep = load(buffer, extra_files=extra_files)
 
-        self.assertTrue(torch.allclose(ep.module()(*inp), loaded_ep.module()(*inp)))
+        torch.testing.assert_close(ep.module()(*inp), loaded_ep.module()(*inp))
         self.assertEqual(extra_files["extra.txt"], "moo")
 
     def test_version_error(self):
@@ -1543,7 +1543,7 @@ class TestSaveLoad(TestCase):
         loaded_ep = load(buffer)
 
         inp = (torch.tensor(1),)
-        self.assertTrue(torch.allclose(ep.module()(*inp), loaded_ep.module()(*inp)))
+        torch.testing.assert_close(ep.module()(*inp), loaded_ep.module()(*inp))
 
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")

--- a/test/export/test_swap.py
+++ b/test/export/test_swap.py
@@ -74,7 +74,7 @@ class TestSwap(TestCase):
             {"foo.nested": NestedChild(), "bar": Child2()},
         )
 
-        self.assertTrue(torch.allclose(ep.module()(*inps), swapped_gm(*inps)))
+        torch.testing.assert_close(ep.module()(*inps), swapped_gm(*inps))
 
     def test_unflatten_preserve_with_unused_input(self):
         class M1(torch.nn.Module):
@@ -103,7 +103,7 @@ class TestSwap(TestCase):
         )
 
         inps = (torch.randn(2), torch.randn(5))
-        self.assertTrue(torch.allclose(ep.module()(*inps), swapped_gm(*inps)))
+        torch.testing.assert_close(ep.module()(*inps), swapped_gm(*inps))
 
     def test_nested_leaf(self):
         class Leaf(torch.nn.Module):
@@ -139,7 +139,7 @@ class TestSwap(TestCase):
         )
 
         inps = (torch.randn(3),)
-        self.assertTrue(torch.allclose(ep.module()(*inps), swapped_gm(*inps)))
+        torch.testing.assert_close(ep.module()(*inps), swapped_gm(*inps))
 
     def test_dedup_sym_size(self):
         # Here, sym_size & floor div are used in 3 subgraphs (top-level, m1, m2),
@@ -186,10 +186,10 @@ class TestSwap(TestCase):
         )
 
         inps = (torch.randn(10), torch.randn(10))
-        self.assertTrue(torch.allclose(ep.module()(*inps), swapped_gm(*inps)))
+        torch.testing.assert_close(ep.module()(*inps), swapped_gm(*inps))
 
         inps = (torch.randn(20), torch.randn(20))
-        self.assertTrue(torch.allclose(ep.module()(*inps), swapped_gm(*inps)))
+        torch.testing.assert_close(ep.module()(*inps), swapped_gm(*inps))
 
     def test_remove_duplicate_pytree_simple(self):
         class Child1(torch.nn.Module):
@@ -236,7 +236,7 @@ class TestSwap(TestCase):
             {"foo": Child1(), "bar": Child2()},
         )
 
-        self.assertTrue(torch.allclose(ep.module()(*inps), swapped_gm(*inps)))
+        torch.testing.assert_close(ep.module()(*inps), swapped_gm(*inps))
         self.assertExpectedInline(
             swapped_gm.code.strip(),
             """\
@@ -313,7 +313,7 @@ def forward(self, x, y):
             {"foo": Child1(), "bar": Child2()},
         )
 
-        self.assertTrue(torch.allclose(ep.module()(*inps), swapped_gm(*inps)))
+        torch.testing.assert_close(ep.module()(*inps), swapped_gm(*inps))
         self.assertExpectedInline(
             swapped_gm.code.strip(),
             """\
@@ -358,7 +358,7 @@ def forward(self, x, y):
         inp = (CustomInput(torch.randn(2, 3), torch.randn(3, 2)),)
         res1 = torch.fx.Interpreter(swapped).run(*inp)
         res2 = swapped(*inp)
-        self.assertTrue(torch.allclose(res1, res2))
+        torch.testing.assert_close(res1, res2)
 
     def test_custom_input_kwargs(self):
         @dataclass
@@ -386,7 +386,7 @@ def forward(self, x, y):
         inp_kwargs = {"inputs": CustomInput(torch.randn(2, 3), torch.randn(3, 2))}
         res1 = torch.fx.Interpreter(swapped).run(*(*inp_args, *inp_kwargs.values()))
         res2 = swapped(*inp_args, **inp_kwargs)
-        self.assertTrue(torch.allclose(res1, res2))
+        torch.testing.assert_close(res1, res2)
 
     def test_custom_output(self):
         @dataclass
@@ -408,10 +408,10 @@ def forward(self, x, y):
         inp = (torch.randn(2, 3), torch.randn(3, 2))
         res1 = torch.fx.Interpreter(swapped).run(*inp)
         res2 = swapped(*inp)
-        self.assertTrue(torch.allclose(res1[0].a, res2[0].a))
-        self.assertTrue(torch.allclose(res1[0].b, res2[0].b))
-        self.assertTrue(torch.allclose(res1[1].a, res2[1].a))
-        self.assertTrue(torch.allclose(res1[1].b, res2[1].b))
+        torch.testing.assert_close(res1[0].a, res2[0].a)
+        torch.testing.assert_close(res1[0].b, res2[0].b)
+        torch.testing.assert_close(res1[1].a, res2[1].a)
+        torch.testing.assert_close(res1[1].b, res2[1].b)
 
 
 if __name__ == "__main__":

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -858,7 +858,7 @@ metadata incorrectly.
         compiled_f = torch.compile(f, backend="aot_eager")
         out = compiled_f(custom_aa_compile)
 
-        self.assertTrue(torch.allclose(out_eager, out))
+        torch.testing.assert_close(out_eager, out)
 
         out.sum().backward()
 
@@ -891,7 +891,7 @@ metadata incorrectly.
         out_eager = f(x_nested, y_nested, z)
         compiled_f = torch.compile(f, backend="aot_eager")
         out = compiled_f(x_nested_compile, y_nested_compile, z_compile)
-        self.assertTrue(torch.allclose(out_eager, out))
+        torch.testing.assert_close(out_eager, out)
 
         self.assertTrue(isinstance(out, TwoTensor))
         self.assertTrue(isinstance(out.a, TwoTensor))
@@ -912,10 +912,10 @@ metadata incorrectly.
         self.assertTrue(isinstance(y_nested_compile.grad.a, TwoTensor))
         self.assertTrue(isinstance(y_nested_compile.grad.b, TwoTensor))
 
-        self.assertTrue(torch.allclose(x_nested_compile.grad.a.a, x_nested.grad.a.a))
-        self.assertTrue(torch.allclose(x_nested_compile.grad.a.b, x_nested.grad.a.b))
-        self.assertTrue(torch.allclose(y_nested_compile.grad.a.a, y_nested.grad.a.a))
-        self.assertTrue(torch.allclose(y_nested_compile.grad.a.b, y_nested.grad.a.b))
+        torch.testing.assert_close(x_nested_compile.grad.a.a, x_nested.grad.a.a)
+        torch.testing.assert_close(x_nested_compile.grad.a.b, x_nested.grad.a.b)
+        torch.testing.assert_close(y_nested_compile.grad.a.a, y_nested.grad.a.a)
+        torch.testing.assert_close(y_nested_compile.grad.a.b, y_nested.grad.a.b)
 
     @unittest.skipIf(IS_WINDOWS, "Windows isn't supported for this case")
     def test_nested_subclasses_complicated_inps_mixed(self):
@@ -946,13 +946,13 @@ metadata incorrectly.
         compiled_f = torch.compile(f, backend="aot_eager")
         out_eager = f(x_nested, custom_aa)
         out = compiled_f(x_nested_compile, custom_aa_compile)
-        self.assertTrue(torch.allclose(out_eager, out))
+        torch.testing.assert_close(out_eager, out)
 
         out.sum().backward()
         out_eager.sum().backward()
 
-        self.assertTrue(torch.allclose(x_nested_compile.grad, x_nested.grad))
-        self.assertTrue(torch.allclose(custom_aa_compile.grad, custom_aa.grad))
+        torch.testing.assert_close(x_nested_compile.grad, x_nested.grad)
+        torch.testing.assert_close(custom_aa_compile.grad, custom_aa.grad)
 
     def test_composite_impl_compile(self):
         class Foo(torch.nn.Module):
@@ -4235,11 +4235,11 @@ def forward(self, arg0_1, arg1_1):
         eager_mod = Foo()
         output_1, output_2 = gm(torch.zeros(2, 2), inp)
         eager_output = eager_mod(inp)
-        self.assertTrue(torch.allclose(output_2, eager_output[0]))
+        torch.testing.assert_close(output_2, eager_output[0])
 
         _, output_2 = gm(output_1, inp)
         eager_output = eager_mod(inp)
-        self.assertTrue(torch.allclose(output_2, eager_output[0]))
+        torch.testing.assert_close(output_2, eager_output[0])
         self.assertTrue("foo" in graph_sig.buffers)
         self.assertTrue(graph_sig.inputs_to_buffers["arg0_1"] == "foo")
 

--- a/test/functorch/test_dims.py
+++ b/test/functorch/test_dims.py
@@ -317,8 +317,8 @@ class TestMin(TestCase):
         A = torch.rand(4, 5)
         _r = stack([A[i, j]], d, j)
         # a, b = r.unbind(d)
-        # self.assertTrue(torch.allclose(a.order(i, j), i.expand(j).order(i, j)))
-        # self.assertTrue(torch.allclose(b.order(i, j), j.expand(i).order(i, j)))
+        # torch.testing.assert_close(a.order(i, j), i.expand(j).order(i, j))
+        # torch.testing.assert_close(b.order(i, j), j.expand(i).order(i, j))
 
     def test_max(self):
         ap = torch.rand(2, 3, 2)

--- a/test/fx/test_lazy_graph_module.py
+++ b/test/fx/test_lazy_graph_module.py
@@ -48,7 +48,7 @@ class TestLazyGraphModule(TestCase):
         expected = x.cos()
         actual = gm(x)
 
-        self.assertTrue(torch.allclose(expected, actual))
+        torch.testing.assert_close(expected, actual)
         code = gm.print_readable(False)
         self.assertTrue("cos()" in code)
         self.assertTrue(isinstance(gm, _LazyGraphModule))
@@ -65,7 +65,7 @@ class TestLazyGraphModule(TestCase):
         expected = x.cos()
         actual = gm.forward(x)
 
-        self.assertTrue(torch.allclose(expected, actual))
+        torch.testing.assert_close(expected, actual)
 
     def test_needs_recompile(self):
         """
@@ -94,7 +94,7 @@ class TestLazyGraphModule(TestCase):
         self.assertTrue(gm._needs_recompile())
         x = torch.randn(2, 3)
         # trigger the first recompilation
-        self.assertTrue(torch.allclose(x.sin(), gm(x)))
+        torch.testing.assert_close(x.sin(), gm(x))
         self.assertFalse(gm._needs_recompile())
 
         self.replace_sin_with_cos(gm)
@@ -102,7 +102,7 @@ class TestLazyGraphModule(TestCase):
         gm.recompile()
         self.assertTrue(gm._needs_recompile())
         # trigger the second recompilation
-        self.assertTrue(torch.allclose(x.cos(), gm(x)))
+        torch.testing.assert_close(x.cos(), gm(x))
         self.assertFalse(gm._needs_recompile())
 
     def test_accessing_code_cause_recompiling(self):

--- a/test/higher_order_ops/test_with_effects.py
+++ b/test/higher_order_ops/test_with_effects.py
@@ -240,7 +240,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         inputs = (torch.randn(2, 3),)
 
         res = torch.compile(f, backend="aot_eager")(*inputs)
-        self.assertTrue(torch.allclose(res, f(*inputs)))
+        torch.testing.assert_close(res, f(*inputs))
 
     @unittest.skipIf(IS_WINDOWS, "triton")
     @unittest.skipIf(not SM70OrLater, "triton")
@@ -254,7 +254,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         inputs = (torch.randn(2, 3),)
 
         res = torch.compile(f, backend="inductor")(*inputs)
-        self.assertTrue(torch.allclose(res, f(*inputs)))
+        torch.testing.assert_close(res, f(*inputs))
 
     @unittest.skipIf(IS_WINDOWS, "Skipped on Windows!")
     @skipIfNoDynamoSupport
@@ -281,7 +281,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
             inputs = (torch.randn(3),)
 
             res = torch.compile(f, backend="inductor")(*inputs)
-            self.assertTrue(torch.allclose(res, f(*inputs)))
+            torch.testing.assert_close(res, f(*inputs))
 
     def test_compile_aot_eager_requires_grad(self):
         def f(x):
@@ -293,7 +293,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         inputs = (torch.randn(2, 3, requires_grad=True),)
 
         res = torch.compile(f, backend="aot_eager")(*inputs)
-        self.assertTrue(torch.allclose(res, f(*inputs)))
+        torch.testing.assert_close(res, f(*inputs))
 
         res.sum().backward()
 
@@ -417,7 +417,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
             opt_mod = torch.compile(backend="inductor")(mod)
             y = opt_mod(x)
 
-            self.assertTrue(torch.allclose(y, mod(x)))
+            torch.testing.assert_close(y, mod(x))
             # Ensure it works well with backward
             y.sum().backward()
             # Ensure the grad is existing

--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -242,7 +242,7 @@ class TestAOTInductorPackage(TestCase):
                 self.assertTrue(so_path.exists())
                 optimized = torch._export.aot_load(str(so_path), self.device)
                 actual = optimized(*example_inputs)
-                self.assertTrue(torch.allclose(actual, expected))
+                torch.testing.assert_close(actual, expected)
 
     def test_metadata(self):
         class Model(torch.nn.Module):

--- a/test/inductor/test_b2b_gemm.py
+++ b/test/inductor/test_b2b_gemm.py
@@ -45,7 +45,7 @@ class B2BGEMMTest(TestCase):
         B = torch.randn((32, 256), device=GPU_TYPE, dtype=torch.float16)
         C = torch.randn((256, 32), device=GPU_TYPE, dtype=torch.float16)
         res, (code,) = run_and_get_code(f_opt, A, B, C)
-        self.assertTrue(torch.allclose(f_32(A, B, C), res, atol=0.1, rtol=0.01))
+        torch.testing.assert_close(f_32(A, B, C), res, atol=0.1, rtol=0.01)
         self.assertTrue("B2B_GEMM_LEFT_TRITON_ENTRANCE" in code)
 
     @torch._dynamo.config.patch(recompile_limit=32)
@@ -71,7 +71,7 @@ class B2BGEMMTest(TestCase):
         B = torch.randn((256, 32), device=GPU_TYPE, dtype=torch.float16)
         C = torch.randn((32, 256), device=GPU_TYPE, dtype=torch.float16)
         res, (code,) = run_and_get_code(f_opt, A, B, C)
-        self.assertTrue(torch.allclose(f_32(A, B, C), res, atol=0.1, rtol=0.01))
+        torch.testing.assert_close(f_32(A, B, C), res, atol=0.1, rtol=0.01)
         self.assertTrue("B2B_GEMM_RIGHT_TRITON_ENTRANCE" in code)
 
     @torch._dynamo.config.patch(recompile_limit=32)
@@ -96,7 +96,7 @@ class B2BGEMMTest(TestCase):
         B = torch.randn((32, 256), device=GPU_TYPE, dtype=torch.float16)
         C = torch.randn((256, 32), device=GPU_TYPE, dtype=torch.float16)
         res, (code,) = run_and_get_code(f_opt, A, B, C)
-        self.assertTrue(torch.allclose(f_32(A, B, C), res, atol=0.1, rtol=0.01))
+        torch.testing.assert_close(f_32(A, B, C), res, atol=0.1, rtol=0.01)
         self.assertTrue("B2B_GEMM_LEFT_TRITON_ENTRANCE" in code)
 
     @torch._dynamo.config.patch(recompile_limit=32)
@@ -121,7 +121,7 @@ class B2BGEMMTest(TestCase):
         B = torch.randn((256, 32), device=GPU_TYPE, dtype=torch.float16)
         C = torch.randn((32, 256), device=GPU_TYPE, dtype=torch.float16)
         res, (code,) = run_and_get_code(f_opt, A, B, C)
-        self.assertTrue(torch.allclose(f_32(A, B, C), res, atol=0.1, rtol=0.01))
+        torch.testing.assert_close(f_32(A, B, C), res, atol=0.1, rtol=0.01)
         self.assertTrue("B2B_GEMM_RIGHT_TRITON_ENTRANCE" in code)
 
     @torch._dynamo.config.patch(recompile_limit=32)
@@ -141,7 +141,7 @@ class B2BGEMMTest(TestCase):
         B = torch.randn((32, 256), device=GPU_TYPE, dtype=torch.float16)
         C = torch.randn((256, 32), device=GPU_TYPE, dtype=torch.float16)
         res, (code,) = run_and_get_code(f_opt, A, B, C)
-        self.assertTrue(torch.allclose(f(A, B, C), res, atol=0.1, rtol=0.01))
+        torch.testing.assert_close(f(A, B, C), res, atol=0.1, rtol=0.01)
         self.assertTrue("B2B_GEMM_LEFT_TRITON_ENTRANCE" not in code)
         self.assertTrue("B2B_GEMM_RIGHT_TRITON_ENTRANCE" not in code)
 
@@ -160,7 +160,7 @@ class B2BGEMMTest(TestCase):
         B = torch.randn((100, 100), device=GPU_TYPE, dtype=torch.float16)
         C = torch.randn((100, 100), device=GPU_TYPE, dtype=torch.float16)
         res, (code,) = run_and_get_code(f_opt, A, B, C)
-        self.assertTrue(torch.allclose(f(A, B, C), res, atol=0.1, rtol=0.01))
+        torch.testing.assert_close(f(A, B, C), res, atol=0.1, rtol=0.01)
         self.assertTrue("B2B_GEMM_LEFT_TRITON_ENTRANCE" not in code)
         self.assertTrue("B2B_GEMM_RIGHT_TRITON_ENTRANCE" not in code)
 

--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -320,11 +320,11 @@ class CondTests(TestCase):
         opt_model = torch.compile(main_model)
         out1 = main_model(x1, 1)
         opt_out1 = opt_model(x1, 1)
-        self.assertTrue(torch.allclose(out1, opt_out1, atol=1e-5))
+        torch.testing.assert_close(out1, opt_out1, atol=1e-5)
 
         out2 = main_model(x2, 30)
         opt_out2 = opt_model(x2, 30)
-        self.assertTrue(torch.allclose(out2, opt_out2, atol=1e-5))
+        torch.testing.assert_close(out2, opt_out2, atol=1e-5)
 
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -5209,7 +5209,7 @@ class CPUReproTests(TestCase):
             output = model(x)
             c_model = torch.compile(model)
             c_output = c_model(x)
-            self.assertTrue(torch.allclose(output, c_output))
+            torch.testing.assert_close(output, c_output)
 
     @requires_vectorization
     def test_bool_max(self):

--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -564,7 +564,7 @@ class TestGroupBatchFusion(TestCase):
         self.assertEqual(counters["inductor"]["batch_nan_to_num"], 1)
         self.assertEqual(counters["inductor"]["unbind_stack_to_slices_pass"], 2)
         self.assertEqual(counters["inductor"]["unbind_stack_pass"], 2)
-        self.assertTrue(torch.allclose(ref, res))
+        torch.testing.assert_close(ref, res)
         counters.clear()
 
 
@@ -598,7 +598,7 @@ class TestPostGradBatchLinearFusion(TestCase):
         eager_output = pt1_module(inputs)
         pt2_module = torch.compile(pt1_module)
         pt2_output = pt2_module(inputs)
-        self.assertTrue(torch.allclose(eager_output, pt2_output))
+        torch.testing.assert_close(eager_output, pt2_output)
         self.assertEqual(
             counters["inductor"]["batch_linear_post_grad"],
             2,

--- a/test/inductor/test_inplace_padding.py
+++ b/test/inductor/test_inplace_padding.py
@@ -107,7 +107,7 @@ class InplacePaddingTest(TestCase):
             r"as_strided\(\(2048, 2047\), \(2048, 1\)\)"
         ).run(code)
 
-        self.assertTrue(torch.allclose(ref, act, atol=1e-2, rtol=1e-2))
+        torch.testing.assert_close(ref, act, atol=1e-2, rtol=1e-2)
         self.assertEqual(num_inplace_padding(), 1)
 
     @inductor_config.patch(cpp_wrapper=True)
@@ -151,7 +151,7 @@ class InplacePaddingTest(TestCase):
             r"aoti_torch_as_strided\(buf0_handle, .*, &buf0_handle_restrided\)"
         ).run(code)
 
-        self.assertTrue(torch.allclose(ref, act, atol=1e-2, rtol=1e-2))
+        torch.testing.assert_close(ref, act, atol=1e-2, rtol=1e-2)
 
         self.assertEqual(num_inplace_padding(), 1)
         self.assertTrue(compile_time_autotune_called)

--- a/test/inductor/test_layout_optim.py
+++ b/test/inductor/test_layout_optim.py
@@ -288,7 +288,7 @@ class TestLayoutOptim(TestCase):
             a = torch.randn(2, size, requires_grad=True).to(GPU_TYPE)
             b = torch.randn(2, size).to(GPU_TYPE)
             actual = torch.compile(f, dynamic=True)(a, b)
-            self.assertTrue(torch.allclose(f(a, b), actual))
+            torch.testing.assert_close(f(a, b), actual)
 
             # Trigger the compiling of the backward graph
             actual.sum().backward()
@@ -338,7 +338,7 @@ class TestLayoutOptim(TestCase):
         loss.backward()
 
         ref = model(x, targets)
-        self.assertTrue(torch.allclose(ref, loss))
+        torch.testing.assert_close(ref, loss)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -696,7 +696,7 @@ class TestMaxAutotune(TestCase):
         with fresh_inductor_cache():
             act = torch.compile(f)(x, y)
         ref = f(x, y)
-        self.assertTrue(torch.allclose(act, ref, atol=4 * 1e-3, rtol=4 * 1e-3))
+        torch.testing.assert_close(act, ref, atol=4 * 1e-3, rtol=4 * 1e-3)
 
     @config.patch(max_autotune=True)
     def test_empty_conv_input(self, kernel_size=3):
@@ -719,7 +719,7 @@ class TestMaxAutotune(TestCase):
         opt_f = torch.compile(f)
         ref = f(x, weight)
         act = opt_f(x, weight)
-        self.assertTrue(torch.allclose(ref, act, atol=4 * 1e-3, rtol=4 * 1e-3))
+        torch.testing.assert_close(ref, act, atol=4 * 1e-3, rtol=4 * 1e-3)
 
     @config.patch(max_autotune=True)
     def test_empty_conv_input_with_1x1_kernel(self):

--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -126,7 +126,7 @@ class TestOnlineSoftmax(TestCase):
         opt_f = torch.compile(f)
         ref = f(q, k, v)
         act, (code,) = run_and_get_code(opt_f, q, k, v)
-        self.assertTrue(torch.allclose(ref, act, atol=1e-2, rtol=1e-2))
+        torch.testing.assert_close(ref, act, atol=1e-2, rtol=1e-2)
         self.assertTrue("aten._scaled_dot_product_" in code)
 
     @parametrize("nrow", [2, 2048])
@@ -163,7 +163,7 @@ class TestOnlineSoftmax(TestCase):
         x = torch.randn(1, 2**20, dtype=torch.bfloat16, device=GPU_TYPE)
         ref = torch.softmax(x, dim=-1)
         act, (code,) = run_and_get_code(torch.compile(torch.softmax), x, dim=-1)
-        self.assertTrue(torch.allclose(ref, act, atol=1e-3, rtol=1e-3))
+        torch.testing.assert_close(ref, act, atol=1e-3, rtol=1e-3)
         self.assertTrue(code.count("def triton") >= 2)
         self.assertTrue("online_softmax_reduce" not in code)
 
@@ -247,7 +247,7 @@ class TestOnlineSoftmax(TestCase):
         x = torch.randn(1, device=GPU_TYPE)
         ref = f(x)
         act, (code,) = run_and_get_code(torch.compile(f), x)
-        self.assertTrue(torch.allclose(ref, act))
+        torch.testing.assert_close(ref, act)
         self.assertTrue("online_softmax_reduce" not in code)
 
     def test_causal_mask(self):
@@ -262,7 +262,7 @@ class TestOnlineSoftmax(TestCase):
         act = torch.compile(f)(x)
         self.assertTrue(not ref.isnan().any())
         self.assertTrue(not act.isnan().any())
-        self.assertTrue(torch.allclose(ref, act))
+        torch.testing.assert_close(ref, act)
 
     def test_tb_speech_transformer_attn(self):
         """
@@ -291,7 +291,7 @@ class TestOnlineSoftmax(TestCase):
         act = torch.compile(f)(x, mask)
         self.assertTrue(not ref.isnan().any())
         self.assertTrue(not act.isnan().any())
-        self.assertTrue(torch.allclose(ref, act))
+        torch.testing.assert_close(ref, act)
 
 
 instantiate_parametrized_tests(TestOnlineSoftmax)

--- a/test/inductor/test_op_dtype_prop.py
+++ b/test/inductor/test_op_dtype_prop.py
@@ -232,7 +232,7 @@ class TestCase(InductorTestCase):
 
         # Check accuracy.
         ref = func(*inputs)
-        self.assertTrue(torch.allclose(ref, result))
+        torch.testing.assert_close(ref, result)
 
         # Check for exactly one upcast.
         num_upcasts = code.count(".to(tl.float32)")

--- a/test/inductor/test_torchbind.py
+++ b/test/inductor/test_torchbind.py
@@ -53,12 +53,12 @@ class TestTorchbind(TestCase):
         compiled = torch._inductor.compile(ep.module(), inputs)
 
         new_res = compiled(*inputs)
-        self.assertTrue(torch.allclose(orig_res, new_res))
+        torch.testing.assert_close(orig_res, new_res)
 
     def test_torchbind_compile(self):
         _, inputs, orig_res, mod = self.get_exported_model()
         new_res = torch.compile(mod, backend="inductor")(*inputs)
-        self.assertTrue(torch.allclose(orig_res, new_res))
+        torch.testing.assert_close(orig_res, new_res)
 
     def test_torchbind_get_buf_bytes(self):
         a = torch.classes._TorchScriptTesting._Foo(10, 20)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4821,7 +4821,7 @@ class CommonTemplate:
             opt_mod = torch.compile(mod)
             res = opt_mod(x)
             expected = mod(x)
-            self.assertTrue(torch.allclose(res, expected))
+            torch.testing.assert_close(res, expected)
 
     def test_buffer_copied_in_graph(self):
         class MyModel(torch.nn.Module):
@@ -8486,9 +8486,9 @@ class CommonTemplate:
                 b2 = fn(x).clone()
 
                 # same seed, same values
-                self.assertTrue(torch.allclose(a0, b0))
-                self.assertTrue(torch.allclose(a1, b1))
-                self.assertTrue(torch.allclose(a2, b2))
+                torch.testing.assert_close(a0, b0)
+                torch.testing.assert_close(a1, b1)
+                torch.testing.assert_close(a2, b2)
 
                 # different calls, different values
                 self.assertFalse(torch.allclose(a0, a1))
@@ -8512,9 +8512,9 @@ class CommonTemplate:
         b2 = fn(x)[0].clone()
 
         # same seed, same values
-        self.assertTrue(torch.allclose(a0, b0))
-        self.assertTrue(torch.allclose(a1, b1))
-        self.assertTrue(torch.allclose(a2, b2))
+        torch.testing.assert_close(a0, b0)
+        torch.testing.assert_close(a1, b1)
+        torch.testing.assert_close(a2, b2)
 
         # different calls, different values
         self.assertFalse(torch.allclose(a0, a1))
@@ -8787,7 +8787,7 @@ class CommonTemplate:
             c = fn(x)
 
             # same seed, same values
-            self.assertTrue(torch.allclose(a, c))
+            torch.testing.assert_close(a, c)
 
             # different calls, different values
             self.assertFalse(torch.allclose(a, b))
@@ -9910,7 +9910,7 @@ class CommonTemplate:
                 expected = po(*inps0)
                 actual = compiled(*inps0)
 
-            self.assertTrue(torch.allclose(actual, expected, atol=1e-3, rtol=1e-3))
+            torch.testing.assert_close(actual, expected, atol=1e-3, rtol=1e-3)
 
     def test_unfold_zero_dimension_tensor(self):
         def forward(x):
@@ -11702,7 +11702,7 @@ class CommonTemplate:
             compiled_inductor_f = torch.compile(f, backend="inductor", fullgraph=True)
             compiled_inductor_out = compiled_inductor_f(x)
 
-        self.assertTrue(torch.allclose(compiled_inductor_out, eager_out))
+        torch.testing.assert_close(compiled_inductor_out, eager_out)
 
     @skip_if_gpu_halide  # cuda error
     def test_buffer_use_after_remove(self):
@@ -14262,7 +14262,7 @@ if HAS_GPU:
             x = torch.randn(2, 1024, device=GPU_TYPE)
             ref = f(x)
             actual, code = run_and_get_code(torch.compile(f), x)
-            self.assertTrue(torch.allclose(ref, actual))
+            torch.testing.assert_close(ref, actual)
 
             code = code[0]
             if config.cpp_wrapper:

--- a/test/inductor/test_torchinductor_codegen_config_overrides.py
+++ b/test/inductor/test_torchinductor_codegen_config_overrides.py
@@ -52,7 +52,7 @@ class CodegenInductorTest(InductorTestCase):
         ref_tensors = flatten_tensors(func(*args))
         actual_tensors = flatten_tensors(result)
         for ref, actual in zip(ref_tensors, actual_tensors):
-            self.assertTrue(torch.allclose(ref, actual))
+            torch.testing.assert_close(ref, actual)
 
         return result, code
 

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -79,7 +79,7 @@ def run_and_compare(
     for ref, actual in zip(ref_tensors, actual_tensors):
         # Don't clobber the default tolerance values
         tol = {t: v for t, v in {"rtol": rtol, "atol": atol}.items() if v is not None}
-        self.assertTrue(torch.allclose(ref, actual, **tol))
+        torch.testing.assert_close(ref, actual, **tol)
 
     def count_code(substr: str, expected: Optional[int]):
         count = sum(prog.count(substr) for prog in code)

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -235,7 +235,7 @@ class TestArgumentCloneAndRestore(TestCase):
         # Record peak memory before that.
         peak_mem_after = torch.cuda.max_memory_allocated()
 
-        self.assertTrue(torch.allclose(gpu_tensor, gpu_tensor_clone))
+        torch.testing.assert_close(gpu_tensor, gpu_tensor_clone)
         self.assertTrue(
             peak_mem_after <= peak_mem_before + self.MEM_TOLERANCE,
             f"{peak_mem_before=} v.s. {peak_mem_after=}",

--- a/test/jit/test_await.py
+++ b/test/jit/test_await.py
@@ -42,8 +42,8 @@ class TestAwait(JitTestCase):
         sm = torch.jit.script(fn)
         out = fn(inp)
         script_out = sm(inp)
-        self.assertTrue(torch.allclose(torch.eye(2) + 102, script_out))
-        self.assertTrue(torch.allclose(script_out, out))
+        torch.testing.assert_close(torch.eye(2) + 102, script_out)
+        torch.testing.assert_close(script_out, out)
 
     def test_nowait(self):
         def fn(x: Tensor):
@@ -57,8 +57,8 @@ class TestAwait(JitTestCase):
         sm = torch.jit.script(fn)
         out = fn(inp)
         script_out = sm(inp)
-        self.assertTrue(torch.allclose(torch.eye(2) + 13, script_out))
-        self.assertTrue(torch.allclose(script_out, out))
+        torch.testing.assert_close(torch.eye(2) + 13, script_out)
+        torch.testing.assert_close(script_out, out)
 
     def test_nowait_class(self):
         class C:
@@ -81,8 +81,8 @@ class TestAwait(JitTestCase):
         sm = torch.jit.script(fn)
         out = fn(inp)
         script_out = sm(inp)
-        self.assertTrue(torch.allclose(torch.eye(2), script_out))
-        self.assertTrue(torch.allclose(script_out, out))
+        torch.testing.assert_close(torch.eye(2), script_out)
+        torch.testing.assert_close(script_out, out)
 
     def test_await_class_arg(self):
         class C:
@@ -110,8 +110,8 @@ class TestAwait(JitTestCase):
         sm = torch.jit.script(fn)
         out = fn(inp)
         script_out = sm(inp)
-        self.assertTrue(torch.allclose(torch.eye(2), script_out))
-        self.assertTrue(torch.allclose(script_out, out))
+        torch.testing.assert_close(torch.eye(2), script_out)
+        torch.testing.assert_close(script_out, out)
 
     def test_awaitable_to_await(self):
         class C:
@@ -139,8 +139,8 @@ class TestAwait(JitTestCase):
         sm = torch.jit.script(fn)
         out = fn(inp)
         script_out = sm(inp)
-        self.assertTrue(torch.allclose(torch.eye(2) + 2 * torch.ones(2), script_out))
-        self.assertTrue(torch.allclose(script_out, out))
+        torch.testing.assert_close(torch.eye(2) + 2 * torch.ones(2), script_out)
+        torch.testing.assert_close(script_out, out)
 
     def test_await_class_return(self):
         class C:
@@ -171,8 +171,8 @@ class TestAwait(JitTestCase):
         sm = torch.jit.script(fn)
         out = fn(inp)
         script_out = sm(inp)
-        self.assertTrue(torch.allclose(torch.eye(2) + 6 * torch.ones(2), script_out))
-        self.assertTrue(torch.allclose(script_out, out))
+        torch.testing.assert_close(torch.eye(2) + 6 * torch.ones(2), script_out)
+        torch.testing.assert_close(script_out, out)
         self.assertGraphContainsExactly(
             sm.graph, kind="prim::awaitable_wait", num_kind_nodes=1
         )
@@ -209,8 +209,8 @@ class TestAwait(JitTestCase):
         sm = torch.jit.script(fn)
         out = fn(inp)
         script_out = sm(inp)
-        self.assertTrue(torch.allclose(torch.eye(2) + 7 * torch.ones(2), script_out))
-        self.assertTrue(torch.allclose(script_out, out))
+        torch.testing.assert_close(torch.eye(2) + 7 * torch.ones(2), script_out)
+        torch.testing.assert_close(script_out, out)
         self.assertGraphContainsExactly(
             sm.graph, kind="prim::awaitable_wait", num_kind_nodes=2
         )
@@ -241,8 +241,8 @@ class TestAwait(JitTestCase):
         sm = torch.jit.script(main)
         out = main(inp)
         script_out = sm(inp)
-        self.assertTrue(torch.allclose(6 * torch.eye(2), script_out))
-        self.assertTrue(torch.allclose(script_out, out))
+        torch.testing.assert_close(6 * torch.eye(2), script_out)
+        torch.testing.assert_close(script_out, out)
 
     def test_eager_await_non_scriptable(self):
         # Tree type can not be compiled (Recursive type)
@@ -279,7 +279,7 @@ class TestAwait(JitTestCase):
         self.assertTrue(
             torch.allclose(2 * torch.eye(2) + 2 * torch.ones(2), script_out)
         )
-        self.assertTrue(torch.allclose(script_out, out))
+        torch.testing.assert_close(script_out, out)
 
     def test_await_eager_lazy(self):
         def delayed(x: Tensor) -> Tensor:
@@ -309,7 +309,7 @@ class TestAwait(JitTestCase):
         self.assertTrue(
             torch.allclose(2 * torch.eye(2) + 2 * torch.ones(2), script_out)
         )
-        self.assertTrue(torch.allclose(script_out, out))
+        torch.testing.assert_close(script_out, out)
 
     def test_jit_trace(self):
         def gap(x: Tensor):
@@ -349,15 +349,15 @@ class TestAwait(JitTestCase):
         out = main(inp)
         script_out = sm(inp)
         expected = 4.8415 * torch.eye(2)
-        self.assertTrue(torch.allclose(expected, script_out))
-        self.assertTrue(torch.allclose(script_out, out))
+        torch.testing.assert_close(expected, script_out)
+        torch.testing.assert_close(script_out, out)
 
         iofile = io.BytesIO()
         torch.jit.save(sm, iofile)
         iofile.seek(0)
         sm = torch.jit.load(iofile)
         script_out_load = sm(inp)
-        self.assertTrue(torch.allclose(expected, script_out_load))
+        torch.testing.assert_close(expected, script_out_load)
 
     def test_await_func_arg(self):
         def gap(x: Tensor):
@@ -381,12 +381,12 @@ class TestAwait(JitTestCase):
         out = main(inp)
         script_out = sm(inp)
         expected = -2 * torch.eye(2)
-        self.assertTrue(torch.allclose(expected, script_out))
-        self.assertTrue(torch.allclose(script_out, out))
+        torch.testing.assert_close(expected, script_out)
+        torch.testing.assert_close(script_out, out)
 
         iofile = io.BytesIO()
         torch.jit.save(sm, iofile)
         iofile.seek(0)
         sm = torch.jit.load(iofile)
         script_out_load = sm(inp)
-        self.assertTrue(torch.allclose(expected, script_out_load))
+        torch.testing.assert_close(expected, script_out_load)

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -430,8 +430,8 @@ class TestPoolingNN(NNTestCase):
 
         self.assertTrue(upout.is_contiguous(memory_format=torch.channels_last))
         self.assertTrue(ref_upout.is_contiguous())
-        self.assertTrue(torch.allclose(upout, ref_upout))
-        self.assertTrue(torch.allclose(out.grad, ref_out.grad))
+        torch.testing.assert_close(upout, ref_upout)
+        torch.testing.assert_close(out.grad, ref_out.grad)
 
     def test_max_unpool(self):
         with set_default_dtype(torch.double):

--- a/test/onnx/dynamo/test_dynamo_with_onnxruntime_backend.py
+++ b/test/onnx/dynamo/test_dynamo_with_onnxruntime_backend.py
@@ -753,7 +753,7 @@ class TestDynamoWithONNXRuntime(onnx_test_common._TestONNXRuntime):
 
         result = compiled_model(data, ref_data)
 
-        self.assertTrue(torch.allclose(result, data.view(ref_data.shape)))
+        torch.testing.assert_close(result, data.view(ref_data.shape))
 
     def test_no_input(self):
         def reshape_wrapper():

--- a/test/quantization/bc/test_backward_compatibility.py
+++ b/test/quantization/bc/test_backward_compatibility.py
@@ -277,7 +277,7 @@ class TestSerialization(TestCase):
             f"get_attrs: expected {expected_get_attrs}, got {get_attrs}",
         )
         output_tensor = mq(input_tensor)
-        self.assertTrue(torch.allclose(output_tensor, expected_output_tensor))
+        torch.testing.assert_close(output_tensor, expected_output_tensor)
 
     @override_qengines
     def test_linear(self):

--- a/test/quantization/core/experimental/test_bits.py
+++ b/test/quantization/core/experimental/test_bits.py
@@ -84,7 +84,7 @@ class TestBits(TestCase):
         t = torch.zeros(20, dtype=torch.int16).view(torch.bits16)
         s = Int16Tensor(t)
         s = s + 1 - 1
-        self.assertTrue(torch.allclose(s, torch.zeros(20, dtype=torch.bits16)))
+        torch.testing.assert_close(s, torch.zeros(20, dtype=torch.bits16))
 
 instantiate_device_type_tests(TestBits, globals())
 

--- a/test/quantization/core/test_quantized_module.py
+++ b/test/quantization/core/test_quantized_module.py
@@ -952,7 +952,7 @@ class TestStaticQuantizedModule(QuantizationTestCase):
         mq2.load_state_dict(mq1.state_dict())
         ref2 = mq2(data2)
 
-        self.assertTrue(torch.allclose(ref1, ref2))
+        torch.testing.assert_close(ref1, ref2)
 
     def test_dropout_serialization(self):
         data1 = torch.randn(2, 4, 6, 8)
@@ -1021,7 +1021,7 @@ class TestStaticQuantizedModule(QuantizationTestCase):
         mq2.load_state_dict(mq1.state_dict())
         ref2 = mq2(data2)
 
-        self.assertTrue(torch.allclose(ref1, ref2))
+        torch.testing.assert_close(ref1, ref2)
 
     def test_batch_norm2d_serialization(self):
         data1 = torch.randn(2, 4, 6, 8)

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -1311,8 +1311,8 @@ class TestQuantizedOps(TestCase):
         qC_hat_1 = torch.ops.quantized.add(qA, qB, output_scale, output_zp)
         qC_hat_2 = torch.ops.quantized.add(qB, qA, output_scale, output_zp)
 
-        self.assertTrue(torch.allclose(qC.dequantize(), qC_hat_1.dequantize()))
-        self.assertTrue(torch.allclose(qC.dequantize(), qC_hat_2.dequantize()))
+        torch.testing.assert_close(qC.dequantize(), qC_hat_1.dequantize())
+        torch.testing.assert_close(qC.dequantize(), qC_hat_2.dequantize())
 
     """Tests channel shuffle operation on quantized tensors."""
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=4, max_dims=4,
@@ -7818,8 +7818,8 @@ class TestQNNPackOps(TestCase):
             qC_hat_1 = torch.ops.quantized.add(qA, qB, output_scale, output_zp)
             qC_hat_2 = torch.ops.quantized.add(qB, qA, output_scale, output_zp)
 
-            self.assertTrue(torch.allclose(qC.dequantize(), qC_hat_1.dequantize()))
-            self.assertTrue(torch.allclose(qC.dequantize(), qC_hat_2.dequantize()))
+            torch.testing.assert_close(qC.dequantize(), qC_hat_1.dequantize())
+            torch.testing.assert_close(qC.dequantize(), qC_hat_2.dequantize())
 
         with override_quantized_engine("qnnpack"):
             for dtype in (torch.qint8, torch.quint8):

--- a/test/quantization/core/test_quantized_tensor.py
+++ b/test/quantization/core/test_quantized_tensor.py
@@ -429,7 +429,7 @@ class TestQuantizedTensor(TestCase):
         data_fp16_dequant = data_fp16.dequantize()
         data_fp16_fp32 = data_fp16.to(torch.float)
         self.assertTrue(data_fp16_dequant.dtype == torch.float)
-        self.assertTrue(torch.allclose(data_fp16_fp32, data_fp16_dequant))
+        torch.testing.assert_close(data_fp16_fp32, data_fp16_dequant)
 
     def test_dequantize_fp16_cpu(self):
         self._test_dequantize_fp16(torch.device('cpu'))

--- a/test/quantization/eager/test_quantize_eager_qat.py
+++ b/test/quantization/eager/test_quantize_eager_qat.py
@@ -1058,7 +1058,7 @@ class TestQuantizeEagerQATNumerics(QuantizationTestCase):
         data = torch.randn(4, 4)
         r1 = m_ref(data)
         r2 = m(data)
-        self.assertTrue(torch.allclose(r1, r2))
+        torch.testing.assert_close(r1, r2)
 
     @skipIfNoXNNPACK
     @override_qengines
@@ -1081,7 +1081,7 @@ class TestQuantizeEagerQATNumerics(QuantizationTestCase):
         data = torch.randn(4, 4)
         r1 = m_ref(data)
         r2 = m(data)
-        self.assertTrue(torch.allclose(r1, r2))
+        torch.testing.assert_close(r1, r2)
 
     @override_qengines
     def test_linear_bn_workflow(self):

--- a/test/quantization/jit/test_ondevice_quantization.py
+++ b/test/quantization/jit/test_ondevice_quantization.py
@@ -373,7 +373,7 @@ class TestOnDeviceDynamicPTQFinalize(TestCase):
         m.observe_forward(*inputs)
         m.quantize_forward(*inputs)
         output = m.quantized_forward(*inputs)
-        self.assertTrue(torch.allclose(ref_output, output))
+        torch.testing.assert_close(ref_output, output)
         thrown = False
         try:
             m(*inputs)
@@ -393,7 +393,7 @@ class TestOnDeviceDynamicPTQFinalize(TestCase):
         m.observe_forward(*inputs)
         m.quantize_forward(*inputs)
         output = m.quantized_forward(*inputs)
-        self.assertTrue(torch.allclose(ref_output, output))
+        torch.testing.assert_close(ref_output, output)
         thrown = False
         try:
             m(*inputs)
@@ -427,7 +427,7 @@ class TestOnDeviceDynamicPTQFinalize(TestCase):
             m.observe_forward(*inputs)
             m.quantize_forward(*inputs)
             output = m.quantized_forward(*inputs)
-            self.assertTrue(torch.allclose(ref_output, output))
+            torch.testing.assert_close(ref_output, output)
         else:
             # check for lite interpreter
             m = OnDevicePTQUtils.ptq_dynamic_quantize(model, qconfig_dict)
@@ -445,14 +445,14 @@ class TestOnDeviceDynamicPTQFinalize(TestCase):
             self.assertFalse(m.find_method("observe_forward"))
             self.assertFalse(m.find_method("reset_observers_forward"))
             output = m(*inputs)
-            self.assertTrue(torch.allclose(ref_output, output))
+            torch.testing.assert_close(ref_output, output)
 
             # Now serialize to flabuffer and load from fb and check
             dict_: dict[str, str] = {}
             bytes = torch._C._save_mobile_module_to_bytes(m._c, dict_)
             m = LiteScriptModule(torch._C._load_mobile_module_from_bytes(bytes))
             fb_output = m(*inputs)
-            self.assertTrue(torch.allclose(ref_output, fb_output))
+            torch.testing.assert_close(ref_output, fb_output)
 
         model.eval()
         inputs = model.get_example_inputs()
@@ -477,7 +477,7 @@ class TestOnDeviceDynamicPTQFinalize(TestCase):
             m.observe_forward(*inputs)
             m.quantize_forward(*inputs)
             output = m.quantized_forward(*inputs)
-            self.assertTrue(torch.allclose(ref_output, output))
+            torch.testing.assert_close(ref_output, output)
         else:
             # check for lite interpreter
             m = OnDevicePTQUtils.ptq_dynamic_quantize(model, qconfig_dict)
@@ -495,7 +495,7 @@ class TestOnDeviceDynamicPTQFinalize(TestCase):
             self.assertFalse(m.find_method("observe_forward"))
             self.assertFalse(m.find_method("reset_observers_forward"))
             output = m(*inputs)
-            self.assertTrue(torch.allclose(ref_output, output))
+            torch.testing.assert_close(ref_output, output)
 
     def _check_serialization_deserialization(self, model):
         self._check_serdes_and_device_side_api_helper(model, False)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1541,11 +1541,11 @@ class TestAutograd(TestCase):
             return g * 2
 
         def posthook(gO, gI):
-            self.assertTrue(torch.allclose(gI[0], a * 2))
+            torch.testing.assert_close(gI[0], a * 2)
             self.assertEqual(len(gO), 0)
 
         def prehook(gI):
-            self.assertTrue(torch.allclose(gI[0], a * 2))
+            torch.testing.assert_close(gI[0], a * 2)
             self.assertEqual(len(gI), 1)
 
         b = a.clone()
@@ -1849,8 +1849,8 @@ class TestAutograd(TestCase):
 
             def posthook(grad_input, grad_output):
                 self.assertEqual(pre_counter[0], 3)
-                self.assertTrue(torch.allclose(grad_output[0], torch.ones(1) * 8))
-                self.assertTrue(torch.allclose(grad_input[0], torch.ones(1) * 16))
+                torch.testing.assert_close(grad_output[0], torch.ones(1) * 8)
+                torch.testing.assert_close(grad_input[0], torch.ones(1) * 16)
                 post_counter[0] += 1
                 return grad_input
 
@@ -1885,7 +1885,7 @@ class TestAutograd(TestCase):
             b.grad_fn.register_prehook(prehook)
             b.sum().backward()
             self.assertEqual(pre_counter[0], 4)
-            self.assertTrue(torch.allclose(a.grad, torch.ones(3, 3) * 2))
+            torch.testing.assert_close(a.grad, torch.ones(3, 3) * 2)
 
     def test_grad_fn_prehooks_multiple_outputs(self):
         # Compute gradients without hooks
@@ -1908,7 +1908,7 @@ class TestAutograd(TestCase):
 
         self.assertEqual(counter[0], 1)
         # Compare
-        self.assertTrue(torch.allclose(a.grad, b.grad * 2))
+        torch.testing.assert_close(a.grad, b.grad * 2)
 
         # Test with custom Function
         class DoubleMul2(Function):
@@ -1937,8 +1937,8 @@ class TestAutograd(TestCase):
         (c + d).sum().backward()
 
         self.assertEqual(counter[0], 1)
-        self.assertTrue(torch.allclose(a.grad, torch.ones(1) * 4 * k))
-        self.assertTrue(torch.allclose(b.grad, torch.ones(1) * 4 * k))
+        torch.testing.assert_close(a.grad, torch.ones(1) * 4 * k)
+        torch.testing.assert_close(b.grad, torch.ones(1) * 4 * k)
 
     def test_grad_fn_prehooks_remove_hooks(self):
         for use_custom_function in (True, False):
@@ -1958,7 +1958,7 @@ class TestAutograd(TestCase):
             b.grad_fn.register_prehook(prehook)
             handle.remove()
             b.sum().backward()
-            self.assertTrue(torch.allclose(a.grad, torch.ones(3, 3) * 2))
+            torch.testing.assert_close(a.grad, torch.ones(3, 3) * 2)
             self.assertEqual(counter[0], 1)
 
             # Remove hooks during backward
@@ -1982,7 +1982,7 @@ class TestAutograd(TestCase):
             handle3 = b.grad_fn.register_prehook(prehook2)
             handle3.remove()
             b.sum().backward()
-            self.assertTrue(torch.allclose(a.grad, torch.ones(3, 3) * 2))
+            torch.testing.assert_close(a.grad, torch.ones(3, 3) * 2)
             self.assertEqual(counter[0], 1)
 
     def test_node_post_hook_registered_during_unpack_hook(self):
@@ -2166,8 +2166,8 @@ class TestAutograd(TestCase):
             var.mul_(2)
             out = (var + mean).sum()
             gvar_expected, gmean_expected = torch.autograd.grad(out, inputs=(var, mean))
-            self.assertTrue(torch.allclose(gvar, gvar_expected))
-            self.assertTrue(torch.allclose(gmean, gmean_expected))
+            torch.testing.assert_close(gvar, gvar_expected)
+            torch.testing.assert_close(gmean, gmean_expected)
 
     def test_retain_grad_inplace_over_view(self):
         base = torch.tensor([1.0], requires_grad=True).clone()
@@ -10685,7 +10685,7 @@ class TestAutogradForwardMode(TestCase):
             # # Verify that mutating unpacked tangent does not affect the original tangent
             tangent_clone = tangent.clone()
             unpacked_tangent *= 2
-            self.assertTrue(torch.allclose(tangent_clone, tangent))
+            torch.testing.assert_close(tangent_clone, tangent)
 
             # as_strided runs without error
             dual.as_strided((5,), (1,), 0)
@@ -11178,8 +11178,8 @@ class TestAutogradForwardMode(TestCase):
                 view *= 2
                 p, t = fwAD.unpack_dual(base)
 
-                self.assertTrue(torch.allclose(p_clone * 2, p))
-                self.assertTrue(torch.allclose(t_clone * 2, t))
+                torch.testing.assert_close(p_clone * 2, p)
+                torch.testing.assert_close(t_clone * 2, t)
 
     def test_grad_cleanup(self):
         foo = torch.rand(2)
@@ -12339,7 +12339,7 @@ class TestAllowMutationOnSaved(TestCase):
         with torch.autograd.graph.allow_mutation_on_saved_tensors() as ctx:
             da = fn(a)
 
-        self.assertTrue(torch.allclose(a * 2, da))
+        torch.testing.assert_close(a * 2, da)
         self.assertClonedLenEqual(ctx, 0)
 
     def test_views(self):
@@ -12363,7 +12363,7 @@ class TestAllowMutationOnSaved(TestCase):
             da = fn(a)
 
         self.assertClonedLenEqual(ctx, 0)
-        self.assertTrue(torch.allclose(a * 2, da))
+        torch.testing.assert_close(a * 2, da)
 
     def test_save_base_and_modify_view(self):
         with torch.autograd.graph.allow_mutation_on_saved_tensors() as ctx:
@@ -12378,7 +12378,7 @@ class TestAllowMutationOnSaved(TestCase):
             self.assertClonedLenEqual(ctx, 0)
 
         self.assertClonedLenEqual(ctx, 0)
-        self.assertTrue(torch.allclose(a * 2, a.grad))
+        torch.testing.assert_close(a * 2, a.grad)
 
     def test_save_view_modify_base(self):
         with torch.autograd.graph.allow_mutation_on_saved_tensors() as ctx:
@@ -12388,7 +12388,7 @@ class TestAllowMutationOnSaved(TestCase):
             out = (c**2).sum()
             b *= 2
             out.backward()
-            self.assertTrue(torch.allclose(a * 2, a.grad))
+            torch.testing.assert_close(a * 2, a.grad)
 
     def test_double_backward(self):
         with torch.autograd.graph.allow_mutation_on_saved_tensors() as ctx:
@@ -12400,7 +12400,7 @@ class TestAllowMutationOnSaved(TestCase):
             (da,) = torch.autograd.grad(out, a, create_graph=True)
             (d2a,) = torch.autograd.grad(da.sum(), a)
 
-        self.assertTrue(torch.allclose(torch.ones_like(a) * 2, d2a))
+        torch.testing.assert_close(torch.ones_like(a) * 2, d2a)
         self.assertClonedLenEqual(ctx, 0)
 
     def test_saved_but_not_anymore(self):
@@ -13441,7 +13441,7 @@ class TestNestedCheckpoint(TestCase):
 
                     for actual_fn in actual_fns:
                         actual = actual_fn(x)
-                        self.assertTrue(torch.allclose(expected, actual))
+                        torch.testing.assert_close(expected, actual)
                         self.check_graph_dies(actual_fn)
 
     @parametrize("early_stop", [True, False])
@@ -13464,10 +13464,10 @@ class TestNestedCheckpoint(TestCase):
             a = torch.randn(3, 3, requires_grad=True)
             expected = grad(sum(grad(sum(h))))(a)
             actual = grad(sum(grad(sum(c(hc)))))(a)
-            self.assertTrue(torch.allclose(expected, actual))
+            torch.testing.assert_close(expected, actual)
 
             actual = grad(sum(c(grad(sum(c(hc))))))(a)
-            self.assertTrue(torch.allclose(expected, actual))
+            torch.testing.assert_close(expected, actual)
 
             self.check_graph_dies(grad(c(hc)))
             self.check_graph_dies(grad(sum(grad(sum(c(hc))))))
@@ -13492,7 +13492,7 @@ class TestNestedCheckpoint(TestCase):
         out, _unused1, _unused2 = fn(k, a, b, f)
         expected_grads = torch.autograd.grad(out, (a, b))
         for actual, expected in zip(actual_grads, expected_grads):
-            self.assertTrue(torch.allclose(actual, expected))
+            torch.testing.assert_close(actual, expected)
 
     @parametrize("early_stop", [True, False])
     def test_nested_checkpoint_kwargs(self, early_stop):
@@ -13512,7 +13512,7 @@ class TestNestedCheckpoint(TestCase):
             out = fn(a, blah=b)
             expected_grads = torch.autograd.grad(out, (a, b))
             for actual, expected in zip(actual_grads, expected_grads):
-                self.assertTrue(torch.allclose(actual, expected))
+                torch.testing.assert_close(actual, expected)
 
     @parametrize("early_stop", [True, False])
     def test_nested_checkpoint_same_graph(self, early_stop):

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -1143,8 +1143,8 @@ class DecompOneOffTests(TestCase):
 
         ref = torch.ops.aten._weight_norm_interface(g, v, 2)
         res = torch._decomp.decompositions._weight_norm_interface(g, v, 2)
-        self.assertTrue(torch.allclose(ref[0], res[0]))
-        self.assertTrue(torch.allclose(ref[1], res[1]))
+        torch.testing.assert_close(ref[0], res[0])
+        torch.testing.assert_close(ref[1], res[1])
 
         inp = torch.rand([30, 10], device=device)
         inp2 = torch.rand([30, 1], device=device)
@@ -1199,7 +1199,7 @@ class DecompOneOffTests(TestCase):
                 is_causal=is_causal,
             )
 
-            self.assertTrue(torch.allclose(actual_res, eager_res, atol=atol, rtol=rtol))
+            torch.testing.assert_close(actual_res, eager_res, atol=atol, rtol=rtol)
 
     @onlyCPU
     def test_native_layer_norm_cpu_decomp(self, device):

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -4432,7 +4432,7 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
                     out_expected = func(
                         nt.values(), dim=reduce_dim_expected, keepdim=keepdim
                     )
-                    self.assertTrue(torch.allclose(out_actual, out_expected))
+                    torch.testing.assert_close(out_actual, out_expected)
                 else:  # raggedness preserved
                     out_expected = func(nt.values(), dim=reduce_dim_expected)
                     self.assertTrue(
@@ -4596,7 +4596,7 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
                 out_actual.is_nested,
                 "softmax(): the result of reducing a nested tensor along the ragged dimension is a nested tensor",
             )  # output is a nested tensor
-            self.assertTrue(torch.allclose(out_actual.values(), out_expected))
+            torch.testing.assert_close(out_actual.values(), out_expected)
 
     @dtypes(torch.float32)
     @parametrize("requires_grad", [False, True])
@@ -4680,7 +4680,7 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
                     "layer_norm(): the result of reducing a nested tensor along the ragged dimension is a nested tensor",
                 )  # output is a nested tensor
                 self.assertEqual(out_actual._values.shape, out_expected.shape)
-                self.assertTrue(torch.allclose(out_actual.values(), out_expected))
+                torch.testing.assert_close(out_actual.values(), out_expected)
 
     @dtypes(torch.float32)
     @parametrize("requires_grad", [False, True])
@@ -4936,7 +4936,7 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
                     out_expected = func(
                         nt.values(), dim=reduce_dim_expected, keepdim=keepdim
                     )
-                    self.assertTrue(torch.allclose(out_actual, out_expected))
+                    torch.testing.assert_close(out_actual, out_expected)
                 else:  # raggedness preserved
                     out_expected = func(nt.values(), dim=reduce_dim_expected)
                     self.assertTrue(
@@ -7214,8 +7214,8 @@ torch.cuda.synchronize()
         value.grad = None
         attn_output_eager, _, _ = m_eager(query, value, offsets)
         attn_output_eager.sum().backward()
-        self.assertTrue(torch.allclose(attn_output_eager, attn_output))
-        self.assertTrue(torch.allclose(value_grad, value.grad))
+        torch.testing.assert_close(attn_output_eager, attn_output)
+        torch.testing.assert_close(value_grad, value.grad)
 
     # Helper function to generate random query, key, value NJTs in (B, n_heads, *, D) format.
     # If noncontig_with_holes is True, the results will be non-contiguous with holes (i.e. have

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8195,7 +8195,7 @@ class TestNNDeviceType(NNTestCase):
         o_cpu = m(a_cpu)
         o_cpu.sum().backward()
         # workaround for memory usage overhead of assertEqual
-        self.assertTrue(torch.allclose(a.grad.cpu(), a_cpu.grad.half()))
+        torch.testing.assert_close(a.grad.cpu(), a_cpu.grad.half())
 
     @onlyCUDA
     @largeTensorTest("48GB", "cpu")
@@ -10087,7 +10087,7 @@ class TestNNDeviceType(NNTestCase):
         out = torch.nn.functional.interpolate(x.to(memory_format=torch.channels_last), scale_factor=2, mode='nearest')
         out_ref = torch.nn.functional.interpolate(x, scale_factor=2, mode='nearest')
         del x
-        self.assertTrue(torch.allclose(out, out_ref))
+        torch.testing.assert_close(out, out_ref)
 
         x = torch.ones((17, 256, 512, 512), dtype=dtype).cuda().to(memory_format=torch.channels_last)
         out = torch.nn.functional.interpolate(x, scale_factor=2, mode='nearest')
@@ -10441,10 +10441,10 @@ class TestNNDeviceType(NNTestCase):
             yy.backward(yy)
             # workaround to reduce memory usage vs. self.assertEqual, see #84944
             rtol, atol = torch.testing._comparison.get_tolerances(dtype, rtol=None, atol=None)
-            self.assertTrue(torch.allclose(y.cpu(), yy, rtol=rtol, atol=atol))
+            torch.testing.assert_close(y.cpu(), yy, rtol=rtol, atol=atol)
             # x is half
             rtol, _ = torch.testing._comparison.get_tolerances(torch.half, rtol=None, atol=None)
-            self.assertTrue(torch.allclose(x.grad.cpu(), xx.grad, rtol=rtol, atol=1e-3))
+            torch.testing.assert_close(x.grad.cpu(), xx.grad, rtol=rtol, atol=1e-3)
 
         run_test(1100000000, 2)  # Illegal memory access https://github.com/pytorch/pytorch/issues/52715
         run_test(2200000000, 1)  # invalid configuration argument https://github.com/pytorch/pytorch/issues/52716
@@ -11742,7 +11742,7 @@ class TestNNDeviceType(NNTestCase):
             orig_rtol, orig_atol = rtol, atol
             rtol, atol = 7 * rtol, 3 * atol
         with torch.no_grad():
-            self.assertTrue(torch.allclose(out.cpu(), out_cpu, rtol=rtol, atol=atol))
+            torch.testing.assert_close(out.cpu(), out_cpu, rtol=rtol, atol=atol)
         if reduction == "sum":
             rtol, atol = orig_rtol, orig_atol
 
@@ -11750,7 +11750,7 @@ class TestNNDeviceType(NNTestCase):
             out.backward()
             out_cpu.backward()
             with torch.no_grad():
-                self.assertTrue(torch.allclose(input.grad.cpu(), input_cpu.grad, rtol=rtol, atol=atol))
+                torch.testing.assert_close(input.grad.cpu(), input_cpu.grad, rtol=rtol, atol=atol)
 
     # Ref: https://github.com/pytorch/pytorch/issue/108345
     @onlyCUDA
@@ -11763,7 +11763,7 @@ class TestNNDeviceType(NNTestCase):
         loss = torch.nn.functional.cross_entropy(logits, labels)
         loss_cpu = torch.nn.functional.cross_entropy(logits.cpu(), labels.cpu())
         print(logits.numel(), labels.numel(), loss.numel())
-        self.assertTrue(torch.allclose(loss_cpu, loss.cpu(), rtol=1e-4, atol=1e-4))
+        torch.testing.assert_close(loss_cpu, loss.cpu(), rtol=1e-4, atol=1e-4)
 
     def _nll_loss_helper(self, input_size, reduction, expected, device, dtype):
         input = torch.rand(input_size, requires_grad=True, device=device, dtype=dtype)
@@ -12138,9 +12138,9 @@ if __name__ == '__main__':
 
         # workaround to reduce memory usage vs. self.assertEqual, see #84944
         rtol, atol = torch.testing._comparison.get_tolerances(torch.float32, rtol=None, atol=None)
-        self.assertTrue(torch.allclose(loss.cpu(), loss_cpu, rtol=rtol, atol=atol))
+        torch.testing.assert_close(loss.cpu(), loss_cpu, rtol=rtol, atol=atol)
         if reduction != "none":
-            self.assertTrue(torch.allclose(logits.grad.cpu(), logits_cpu.grad, rtol=rtol, atol=atol))
+            torch.testing.assert_close(logits.grad.cpu(), logits_cpu.grad, rtol=rtol, atol=atol)
 
     def test_smoothl1loss_backward_zero_beta(self, device):
         input = torch.randn(300, 256, requires_grad=True, device=device)

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -895,7 +895,7 @@ class TestReductions(TestCase):
         return_out = torch.mean(a, dim=0, keepdim=True, out=out)
         target = torch.tensor([[[2.0, 2.0, 2.0, 2.0]]], dtype=dtype, device=device)
         self.assertTrue(torch._C._is_alias_of(out, return_out))
-        self.assertTrue(torch.allclose(out, target))
+        torch.testing.assert_close(out, target)
 
     # TODO: update this and tests that use it to handle device properly
     def _test_reduce_integer_upcast(self, fn, has_out=True, test_complex=True):


### PR DESCRIPTION
The error message for failing tests are much better.


The replacement was done using Search&Replace with a Regexp so should all be fine.

Edit: Looking around I'd say even `self.assertEqual` would work. Not sure when to use which

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @ezyang @SherlockNoMad @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov