### PR TITLE
[MPS] Make `torch.mps.compile_shader` public

### DIFF
--- a/docs/source/mps.rst
+++ b/docs/source/mps.rst
@@ -18,6 +18,7 @@ torch.mps
     current_allocated_memory
     driver_allocated_memory
     recommended_max_memory
+    compile_shader
 
 MPS Profiler
 ------------

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12795,7 +12795,7 @@ class TestCommon(TestCase):
 class TestMetalLibrary(TestCaseMPS):
     def test_metal_arange(self):
         x = torch.zeros(12, device="mps", dtype=torch.half)
-        lib = torch.mps._compile_shader("""
+        lib = torch.mps.compile_shader("""
             kernel void arange(device half* x, uint idx [[thread_position_in_grid]]) {
               x[idx] = idx;
             }
@@ -12807,7 +12807,7 @@ class TestMetalLibrary(TestCaseMPS):
         x = torch.empty(12, device="mps")
         y = torch.empty_like(x)
         z = torch.empty_like(x)
-        lib = torch.mps._compile_shader("""
+        lib = torch.mps.compile_shader("""
             kernel void arange_x(device float* x, uint3 idx [[thread_position_in_grid]]) {
               x[idx.x + idx.y + idx.z] = idx.x;
             }
@@ -12834,7 +12834,7 @@ class TestMetalLibrary(TestCaseMPS):
 
     def test_metal_arange_with_arg(self, start=3.14, step=.5):
         x = torch.zeros(12, device="mps")
-        lib = torch.mps._compile_shader("""
+        lib = torch.mps.compile_shader("""
             kernel void arange(device float* x, constant float& start, constant float& step,
                                uint idx [[thread_position_in_grid]]) {
               x[idx] = start + idx * step;
@@ -12849,7 +12849,7 @@ class TestMetalLibrary(TestCaseMPS):
     def test_metal_arange_with_arg_and_cast(self):
         x = torch.zeros(12, device="mps", dtype=torch.half)
         y = torch.zeros(12, device="mps", dtype=torch.half)
-        lib = torch.mps._compile_shader("""
+        lib = torch.mps.compile_shader("""
             kernel void arange_all_half(device half* x, constant half2& start_step,
                                uint idx [[thread_position_in_grid]]) {
               x[idx] = start_step.x + idx * start_step.y;
@@ -12867,10 +12867,10 @@ class TestMetalLibrary(TestCaseMPS):
 
     def test_metal_error_checking(self):
         # Syntax error asserts
-        self.assertRaises(SyntaxError, lambda: torch.mps._compile_shader("Syntax error"))
+        self.assertRaises(SyntaxError, lambda: torch.mps.compile_shader("Syntax error"))
         cpu_tensor = torch.rand(3)
         mps_tensor = torch.rand(3, device="mps")
-        lib = torch.mps._compile_shader("kernel void full(device half* x) { x[0] = 1.0; }")
+        lib = torch.mps.compile_shader("kernel void full(device half* x) { x[0] = 1.0; }")
         # Passing CPU tensor asserts
         self.assertRaises(RuntimeError, lambda: lib.full(cpu_tensor))
         # Passing invalid shader name asserts
@@ -12885,12 +12885,12 @@ class TestMetalLibrary(TestCaseMPS):
 
     def test_metal_include(self):
         # Checks that includes embedding works
-        lib = torch.mps._compile_shader("#include <c10/metal/special_math.h>")
+        lib = torch.mps.compile_shader("#include <c10/metal/special_math.h>")
         self.assertIsNotNone(lib)
 
     @unittest.skipIf(not torch.mps.profiler.is_metal_capture_enabled(), "Set MTL_CAPTURE_ENABLED and try again")
     def test_metal_capture(self):
-        lib = torch.mps._compile_shader("kernel void full(device float* x, uint idx [[thread_position_in_grid]]) { x[idx] = 1.0; }")
+        lib = torch.mps.compile_shader("kernel void full(device float* x, uint idx [[thread_position_in_grid]]) { x[idx] = 1.0; }")
         mps_tensor = torch.rand(32, device="mps")
         capture_name = f"lib_full{''.join(random.choice('0123456789') for i in range(5))}"
         capture_dirname = f"0000-{capture_name}.gputrace"

--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -176,6 +176,6 @@ def compile_mps_shader(source: str) -> Any:
     Compiles shader source but raise more actionable error message when needed
     """
     try:
-        return torch.mps._compile_shader(source)
+        return torch.mps.compile_shader(source)
     except SyntaxError as err:
         raise SyntaxError(f"failed to compile {source} with {err.msg}") from err

--- a/torch/mps/__init__.py
+++ b/torch/mps/__init__.py
@@ -140,13 +140,13 @@ def recommended_max_memory() -> int:
     return torch._C._mps_recommendedMaxMemory()
 
 
-def _compile_shader(source: str):
+def compile_shader(source: str):
     r"""Compiles compute shader from source and allows one to invoke kernels
     defined there from the comfort of Python runtime
     Example::
 
         >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_MPS)
-        >>> lib = torch.mps._compile_shader(
+        >>> lib = torch.mps.compile_shader(
         ... "kernel void full(device float* out, constant float& val, uint idx [[thread_position_in_grid]]) { out[idx] = val; }"
         ...  )
         >>> x = torch.zeros(16, device="mps")

--- a/torch/mps/__init__.py
+++ b/torch/mps/__init__.py
@@ -175,6 +175,7 @@ from .event import Event
 
 
 __all__ = [
+    "compile_shader",
     "device_count",
     "get_rng_state",
     "manual_seed",


### PR DESCRIPTION
It was a private method in 2.6, but nothing changes in its APIs for 2.7
and it will likely remain the same in 2.8, so time to remove underscore from its name

This allows one to author/invoke shaders directly from PyTorch, for example code below implements an increment by thread index:
```python
    ```python
    import torch
    x = torch.ones(10, device="mps")
    m = torch.mps.compile_shader("""
       kernel void foo(device float* x, uint idx [[thread_position_in_grid]]) {
         x[idx] += idx;
       }
    ")
    m.foo(x)
```