### PR TITLE
[MPSInductor] Fix large prod and sum reductions

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -189,6 +189,7 @@ for test_name in [
     "test_min_max_reduction_nan",
     "test_nan_to_num",
     "test_pow2",
+    "test_prod",
     "test_randint_int64_mod",
     "test_randn_generator",
     "test_remainder",

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -159,6 +159,7 @@ for test_name in [
     "test_argmax_argmin2",
     "test_avg_pool2d5",
     "test_avg_pool2d8",
+    "test_bernoulli1",
     "test_builtins_round",
     "test_builtins_round_float_ndigits_neg",
     "test_cat_empty",

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -483,9 +483,9 @@ class MetalKernel(SIMDKernel):
                 dtype=DTYPE_TO_COMPUTATION_DTYPE[dtype],
             )
         if reduction_type in ["max", "min", "argmax", "argmin"]:
-            assert (
-                not self.multistage_reduction
-            ), f"Multistage reduction not yet supported for {reduction_type}"
+            assert not self.multistage_reduction, (
+                f"Multistage reduction not yet supported for {reduction_type}"
+            )
             acc_buf = self._new_accvar(src_dtype, acc_buf_size)
             self.compute.splice(
                 f"{acc_buf}[{reduction_dim.name}] = static_cast<{DTYPE_TO_METAL[src_dtype]}>({value});"
@@ -496,9 +496,9 @@ class MetalKernel(SIMDKernel):
                 dtype=dtype,
             )
         if reduction_type == "welford_reduce":
-            assert (
-                not self.multistage_reduction
-            ), f"Multistage reduction not yet supported for {reduction_type}"
+            assert not self.multistage_reduction, (
+                f"Multistage reduction not yet supported for {reduction_type}"
+            )
             acc_buf = self._new_accvar(src_dtype, acc_buf_size)
             self.compute.splice(f"{acc_buf}[{reduction_dim.name}] = {value};")
             wf_res = self.cse.generate(

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -1,4 +1,3 @@
-warning: Selection `RUF030` has no effect because preview is not enabled.
 # This is not a feature-complete compiler backend
 # Just an early prototype that shows that one can compile elementwise ops into a Metal shader
 from __future__ import annotations

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import itertools
+import sympy
 from typing import Any, Optional, TYPE_CHECKING
 
 from sympy.printing.precedence import PRECEDENCE
@@ -27,7 +28,6 @@ from .simd import IterationRangesEntry, SIMDKernel, SIMDScheduling
 if TYPE_CHECKING:
     from typing import Union
 
-    import sympy
 
     from ..ops_handler import ReductionType, StoreMode
     from ..scheduler import Scheduler, SchedulerNode
@@ -383,6 +383,7 @@ class MetalKernel(SIMDKernel):
     overrides = MetalOverrides  # type: ignore[assignment]
     suffix = ";"
     newvar_prefix = "auto "
+    max_threadgroup_size = 1024
     pexpr = PythonPrinter().doprint
     sexpr = MetalExprPrinter().doprint
     kexpr = sexpr
@@ -393,8 +394,8 @@ class MetalKernel(SIMDKernel):
         **kwargs: Any,
     ) -> None:
         super().__init__(tiling, **kwargs)
-        self.compute = self.body
         self.acc_var_ids = itertools.count()
+        self.multistage_reduction = False
 
     def dtype_to_str(self, dtype: torch.dtype) -> str:
         return DTYPE_TO_METAL[dtype]
@@ -442,6 +443,7 @@ class MetalKernel(SIMDKernel):
     ) -> Union[CSEVariable, tuple[CSEVariable, ...]]:
         """Codegen a reduction operation"""
         reduction_dim = next(t for t in self.range_trees if t.is_reduction)
+        acc_buf_size = min(reduction_dim.numel, self.max_threadgroup_size)
         if reduction_type == "any":
             acc = self._new_accvar(dtype)
             self.indexing_code.writeline(f"{acc} = false;")
@@ -460,29 +462,35 @@ class MetalKernel(SIMDKernel):
             )
             return acc
         if reduction_type in ["prod", "sum"]:
-            acc_buf = self._new_accvar(src_dtype, reduction_dim.numel)
-            self.compute.splice(f"{acc_buf}[{reduction_dim.name}] = {value};")
+            acc_buf = self._new_accvar(src_dtype, acc_buf_size)
+            if self.multistage_reduction:
+                self.indexing_code.writeline(f"{acc_buf}[{reduction_dim.name}] = 0;")
+                self.compute.splice(f"{acc_buf}[{reduction_dim.name}] += {value};")
+            else:
+                self.compute.splice(f"{acc_buf}[{reduction_dim.name}] = {value};")
             return self.cse.generate(
-                self.compute,
-                f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {reduction_dim.numel})",
+                self.stores,
+                f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {acc_buf_size})",
                 dtype=DTYPE_TO_COMPUTATION_DTYPE[dtype],
             )
         if reduction_type in ["max", "min", "argmax", "argmin"]:
-            acc_buf = self._new_accvar(src_dtype, reduction_dim.numel)
+            assert not self.multistage_reduction, f"Multistage reduction not yet supported for {reduction_type}"
+            acc_buf = self._new_accvar(src_dtype, acc_buf_size)
             self.compute.splice(
                 f"{acc_buf}[{reduction_dim.name}] = static_cast<{DTYPE_TO_METAL[src_dtype]}>({value});"
             )
             return self.cse.generate(
                 self.compute,
-                f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {reduction_dim.numel})",
+                f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {acc_buf_size})",
                 dtype=dtype,
             )
         if reduction_type == "welford_reduce":
-            acc_buf = self._new_accvar(src_dtype, reduction_dim.numel)
+            assert not self.multistage_reduction, f"Multistage reduction not yet supported for {reduction_type}"
+            acc_buf = self._new_accvar(src_dtype, acc_buf_size)
             self.compute.splice(f"{acc_buf}[{reduction_dim.name}] = {value};")
             wf_res = self.cse.generate(
                 self.compute,
-                f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {reduction_dim.numel})",
+                f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {acc_buf_size})",
             )
             return OpsWrapper._unwrap(
                 (f"{wf_res}.x", f"{wf_res}.y", self.features.reduction_numel)
@@ -490,15 +498,48 @@ class MetalKernel(SIMDKernel):
         raise NotImplementedError(reduction_type)
 
     def codegen_iteration_ranges_entry(self, entry: IterationRangesEntry) -> None:
+        self.multistage_reduction = entry.is_reduction and entry.root.numel > self.max_threadgroup_size
         index_expr = self.rename_indexing(entry.expr)
         index_str = self.sexpr(index_expr)  # type: ignore[misc]
-        self.loads.writeline(f"{self.index_dtype} {entry.name} = {index_str};")
+        if not self.multistage_reduction:
+            self.body.writeline(f"{self.index_dtype} {entry.name} = {index_str};")
+            return
+        loop_size = (entry.root.numel + self.max_threadgroup_size - 1) // self.max_threadgroup_size
+        self.body.splice(f"""
+        for(auto {entry.name}_cnt = 0; {entry.name}_cnt < {loop_size}; ++{entry.name}_cnt) {{
+            {self.index_dtype} {entry.name} = {loop_size} * {index_str} + {entry.name}_cnt;
+        """)
+
+    def codegen_body(self):
+        """
+        Concat output code from index_code, loads, compute, stores,
+        suffix into self.body.
+
+        For pointwise kernels, this is called just once at the end.
+
+        For reduction kernels, this generates a loop over the reduction
+        axis.
+        """
+        if self.multistage_reduction:
+            with self.body.indent():
+                self.body.splice(self.loads)
+                self.body.splice(self.compute)
+            self.body.writeline("}")
+            self.multistage_reduction = False
+        else:
+            self.body.splice(self.loads)
+            self.body.splice(self.compute)
+        self.body.splice(self.stores)
+        self.loads.clear()
+        self.compute.clear()
+        self.stores.clear()
 
     def codegen_kernel(self, name: Optional[str] = None) -> str:
         """Called at the end to generate a final kernel string"""
+        self.codegen_body()
         code = IndentedBuffer()
         code.writeline('compile_mps_shader("""')
-        idx_var_names = [v.name for v in self.active_range_trees()]
+        idx_vars = self.active_range_trees()
         with code.indent():
             code.splice(
                 """
@@ -522,12 +563,12 @@ class MetalKernel(SIMDKernel):
                     code.writeline(f"constant {dtype_str}* {inner},")
                 for outer, inner in self.args.sizevars.items():
                     code.writeline(f"constant long& {inner},")
-                assert len(idx_var_names) < 4, "Up to 3 index variables are supported"
+                assert len(idx_vars) < 4, "Up to 3 index variables are supported"
                 thread_pos_dtype = (
-                    f"uint{len(idx_var_names)}" if len(idx_var_names) > 1 else "uint"
+                    f"uint{len(idx_vars)}" if len(idx_vars) > 1 else "uint"
                 )
                 thread_pos_var_name = (
-                    idx_var_names[0] if len(idx_var_names) == 1 else "thread_pos"
+                    idx_vars[0].name if len(idx_vars) == 1 else "thread_pos"
                 )
                 thread_pos_suffix = "," if self.inside_reduction else ""
                 code.writeline(
@@ -539,13 +580,11 @@ class MetalKernel(SIMDKernel):
                     )
             code.writeline(") {")
             with code.indent():
-                if len(idx_var_names) > 1:
-                    for idx, name in enumerate(idx_var_names):
-                        code.writeline(f"auto {name} = thread_pos.{chr(120 + idx)};")
+                if len(idx_vars) > 1:
+                    for idx, var in enumerate(idx_vars):
+                        code.writeline(f"auto {var.name} = thread_pos.{chr(120 + idx)};")
                 code.splice(self.indexing_code)
-                code.splice(self.loads)
                 code.splice(self.body)
-                code.splice(self.stores)
             code.writeline("}")
         code.writeline('""")')
 
@@ -562,7 +601,7 @@ class MetalKernel(SIMDKernel):
             args += [f"threads=[{', '.join(threads)}]"]
         if self.inside_reduction:
             threads = [
-                self.pexpr(v.numel) if v.is_reduction else "1"  # type: ignore[misc]
+                self.pexpr(sympy.Min(v.numel, self.max_threadgroup_size)) if v.is_reduction else "1"  # type: ignore[misc]
                 for v in self.active_range_trees()
             ]
             args += [f"group_size=[{', '.join(threads)}]"]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #149004
* __->__ #148975

After this change, if reduction dimension is larger than `max_threadgroup_size`,  emit a `for` loop from `codegen_iteration_ranges_entry` and wrap it up in `codegen_body()`
I.e. after this changes following command
```
% TORCH_LOGS=output_code python -c "import torch;print(torch.compile(lambda x:(x[0::2].sin()+(x[1::2] + .4).cos()).sum(dim=0) - 3.14)(torch.rand(4096, device='mps')))" 2>&1|cut -c 86-
```
will emit following shader
```metal
#include <c10/metal/random.h>
#include <c10/metal/special_math.h>
#include <c10/metal/utils.h>
#include <c10/metal/reduction_utils.h>
kernel void generated_kernel(
    device float* out_ptr1,
    constant float* in_ptr0,
    uint2 thread_pos [[thread_position_in_grid]],
    uint2 group_pos [[thread_position_in_threadgroup]]
) {
    auto xindex = thread_pos.x;
    auto r0_index = thread_pos.y;
    threadgroup float tmp_acc_0[1024];
    tmp_acc_0[r0_index] = 0;
    for(auto r0_0_cnt = 0; r0_0_cnt < 2; ++r0_0_cnt) {
        int r0_0 = 2 * r0_index + r0_0_cnt;
        if (r0_0 >= 2047) break;
        auto tmp0 = in_ptr0[2*r0_0];
        auto tmp2 = in_ptr0[1 + 2*r0_0];
        auto tmp1 = metal::precise::sin(tmp0);
        auto tmp3 = 0.4;
        auto tmp4 = tmp2 + tmp3;
        auto tmp5 = metal::precise::cos(tmp4);
        auto tmp6 = tmp1 + tmp5;
        tmp_acc_0[r0_index] += tmp6;
    }
    auto tmp7 = c10::metal::threadgroup_sum(tmp_acc_0, 1024);
    auto tmp8 = 3.14;
    auto tmp9 = tmp7 - tmp8;
    out_ptr1[0] = static_cast<float>(tmp9);
}
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov