### PR TITLE
[ez] include config as part of __all__ in torch.compiler

### DIFF
--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -2,9 +2,9 @@
 from typing import Any, Callable, Optional, TYPE_CHECKING, TypeVar
 from typing_extensions import ParamSpec
 
-from . import config
-
 import torch
+
+from . import config
 
 
 if TYPE_CHECKING:

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -2,6 +2,8 @@
 from typing import Any, Callable, Optional, TYPE_CHECKING, TypeVar
 from typing_extensions import ParamSpec
 
+from . import config
+
 import torch
 
 
@@ -11,6 +13,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "compile",
+    "config",
     "assume_constant_result",
     "reset",
     "allow_in_graph",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #148991
* __->__ #148978

Right now we are susceptive to a race condition where if the torch.compiler.config is not implicitly import via dynamo/builder.py, we will throw an error when trying to set compiler configs. This fixes it by including config in `__all__`.

Previous
```
>>> import torch
>>> torch.compiler.config.dynamic_sources = "L['kwargs']['float_features']"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'torch.compiler' has no attribute 'config'
>>> torch.compiler.config.dynamic_sources = 
"L['kwargs']['float_features']"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'torch.compiler' has no attribute 'config'
```

Now
```
>>> import torch
>>> torch.compiler.config.dynamic_sources = "L['kwargs']['float_features']"
```
