### PR TITLE
Fix score_mod.py dynamic max autotune

### DIFF
--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -1533,7 +1533,13 @@ def flex_attention(
         autotune_select_algorithm(
             "flex_attention",
             choices,
-            inputs_for_autotuning,
+            # Need to filter out symbols since there is an invariant
+            # that all input_nodes are of type IRNode
+            [
+                x
+                for x in inputs_for_autotuning
+                if isinstance(x, torch._inductor.ir.IRNode)
+            ],
             layout,
             input_gen_fns=input_gen_fns,
         ),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148991

python benchmarks/transformer/score_mod.py --dynamic --max-autotune

previously would crash with

```
"/home/bobren/local/a/pytorch/torch/_inductor/select_algorithm.py", line 2306, in key_of
    node.get_device().type,

```

but with this change no longer does

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov