### PR TITLE
[TD] test_cpp_extensions_aot_ninja corresponds to things in test/cpp_extensions 

### DIFF
--- a/tools/testing/target_determination/heuristics/edited_by_pr.py
+++ b/tools/testing/target_determination/heuristics/edited_by_pr.py
@@ -20,8 +20,8 @@ from tools.testing.test_run import TestRun
 # contains the test. Test file with path test/a/b.py should of the form a/b.
 # Regexes should be based on repo root.
 ADDITIONAL_MAPPINGS = {
-    # Not actual test files but rather functions defined in run_test.py that run
-    # tests in test/cpp_extensions.
+    # Not files that are tracked by git but rather functions defined in
+    # run_test.py that generate test files which run tests in test/cpp_extensions.
     "test_cpp_extensions_aot_ninja": [r"test\/cpp_extensions.*"],
     "test_cpp_extensions_aot_no_ninja": [r"test\/cpp_extensions.*"],
 }

--- a/tools/testing/target_determination/heuristics/edited_by_pr.py
+++ b/tools/testing/target_determination/heuristics/edited_by_pr.py
@@ -22,8 +22,8 @@ from tools.testing.test_run import TestRun
 ADDITIONAL_MAPPINGS = {
     # Not actual test files but rather functions defined in run_test.py that run
     # tests in test/cpp_extensions.
-    "test_cpp_extensions_aot_ninja": [r"test\/cpp_extensions.*\/test.*\.py"],
-    "test_cpp_extensions_aot_no_ninja": [r"test\/cpp_extensions.*\/test.*\.py"],
+    "test_cpp_extensions_aot_ninja": [r"test\/cpp_extensions.*"],
+    "test_cpp_extensions_aot_no_ninja": [r"test\/cpp_extensions.*"],
 }
 
 

--- a/tools/testing/target_determination/heuristics/edited_by_pr.py
+++ b/tools/testing/target_determination/heuristics/edited_by_pr.py
@@ -14,6 +14,7 @@ from tools.testing.target_determination.heuristics.utils import (
 )
 from tools.testing.test_run import TestRun
 
+
 # Some files run tests in other test files, so we map them to each other here.
 # This is a map from file that runs the test to regex that matches the file that
 # contains the test. Test file with path test/a/b.py should of the form a/b.
@@ -22,7 +23,7 @@ ADDITIONAL_MAPPINGS = {
     # Not actual test files but rather functions defined in run_test.py that run
     # tests in test/cpp_extensions.
     "test_cpp_extensions_aot_ninja": [r"test\/cpp_extensions.*\/test.*\.py"],
-    "test_cpp_extensions_aot_no_ninja": [r"test\/cpp_extensions.*\/test.*\.py"]
+    "test_cpp_extensions_aot_no_ninja": [r"test\/cpp_extensions.*\/test.*\.py"],
 }
 
 
@@ -42,7 +43,11 @@ def _get_modified_tests() -> set[str]:
         changed_files = query_changed_files()
         should_run = python_test_file_to_test_name(set(changed_files))
         for test_file, regexes in ADDITIONAL_MAPPINGS.items():
-            if any(re.search(regex, changed_file) is not None for regex in regexes for changed_file in changed_files):
+            if any(
+                re.search(regex, changed_file) is not None
+                for regex in regexes
+                for changed_file in changed_files
+            ):
                 should_run.add(test_file)
         return should_run
     except Exception as e:

--- a/tools/testing/target_determination/heuristics/edited_by_pr.py
+++ b/tools/testing/target_determination/heuristics/edited_by_pr.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 from warnings import warn
 
@@ -12,6 +13,17 @@ from tools.testing.target_determination.heuristics.utils import (
     query_changed_files,
 )
 from tools.testing.test_run import TestRun
+
+# Some files run tests in other test files, so we map them to each other here.
+# This is a map from file that runs the test to regex that matches the file that
+# contains the test. Test file with path test/a/b.py should of the form a/b.
+# Regexes should be based on repo root.
+ADDITIONAL_MAPPINGS = {
+    # Not actual test files but rather functions defined in run_test.py that run
+    # tests in test/cpp_extensions.
+    "test_cpp_extensions_aot_ninja": [r"test\/cpp_extensions.*\/test.*\.py"],
+    "test_cpp_extensions_aot_no_ninja": [r"test\/cpp_extensions.*\/test.*\.py"]
+}
 
 
 class EditedByPR(HeuristicInterface):
@@ -28,9 +40,12 @@ class EditedByPR(HeuristicInterface):
 def _get_modified_tests() -> set[str]:
     try:
         changed_files = query_changed_files()
+        should_run = python_test_file_to_test_name(set(changed_files))
+        for test_file, regexes in ADDITIONAL_MAPPINGS.items():
+            if any(re.search(regex, changed_file) is not None for regex in regexes for changed_file in changed_files):
+                should_run.add(test_file)
+        return should_run
     except Exception as e:
         warn(f"Can't query changed test files due to {e}")
         # If unable to get changed files from git, quit without doing any sorting
-        return set()
-
-    return python_test_file_to_test_name(set(changed_files))
+    return set()


### PR DESCRIPTION
Manually map test_cpp_extensions_aot_ninja to files in test/cpp_extensions since test_cpp_extensions_aot_ninja isn't an actual file you can edit, but a wrapper for files in test/cpp_extensions.

Idk if this is a good idea, feels very manual.  Maybe it would be better to classify this the same as any other TD failure where TD simply can't figure out the tests it needs to run