### PR TITLE
[PGNCCL] Stash tensors for reduce_scatter_v and all_gather_v

### DIFF
--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -735,6 +735,17 @@ class ProcessGroupNCCLOpTest(MultiProcContinousTest):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_reduce_scatter_v(self):
+        device = torch.device("cuda", self.rank_to_GPU[self.rank][0])
+        input_list = [torch.ones(i, device=device) for i in range(self.world_size)]
+        output = torch.zeros(self.rank, device=device)
+        work = c10d.reduce_scatter(output, input_list, group=self.pg, async_op=True)
+        expected = torch.ones(self.rank, device=device) * self.world_size
+        work.wait()
+        self.assertEqual(expected, output)
+
+    @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_reduce_scatter_ops(self):
         pg = self.pg
         local_device_ids = self.rank_to_GPU[self.rank]

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -3169,6 +3169,7 @@ void ProcessGroupNCCL::startCoalescing() {
   // 'start' and 'end' coalescing region without doing an operation inbetween.
 
   coalescingState_.reset();
+  coalescingState_.active = true;
   groupStart();
 }
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -248,12 +248,14 @@ struct CoalescingState {
   bool async = false;
   // Stores the list of tensors for all collectives run inside a coalescing
   // TODO (eqy)
+  std::vector<at::Tensor> tensors;
 
   void reset() {
     active = false;
     opType = 0;
     comm = nullptr;
     async = false;
+    tensors.clear();
   }
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #148994

https://github.com/pytorch/pytorch/pull/148590 removed `record_stream`. Since previous `AVOID_RECORD` flag does not cover `reduce_scatter_v` and `all_gather_v` which are in coalescing form, these two ops were missed. Causing TorchRec's Variable Length Embedding to fail.

This PR adds a vector to stash tensors when coalescing is in flight. And the end of coalescing, it will hand over the tensors to `Work`. 

Rest of the PR is mostly BE -- grouping various variables related to coalescing in one single struct and offer a `reset` method. So that it is easier to extend what we need to temporarily bookkeep.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o

Differential Revision: [D71589949](https://our.internmc.facebook.com/intern/diff/D71589949)