### PR TITLE
[MPSInductor] Fix `min`/`max` reductions over large dims

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -187,6 +187,7 @@ for test_name in [
     "test_low_memory_max_pool",
     "test_max_min",
     "test_max_pool2d2",
+    "test_multilayer_prime_size",
     "test_min_max_reduction_nan",
     "test_nan_to_num",
     "test_pow2",

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -487,9 +487,7 @@ class MetalKernel(SIMDKernel):
             acc_thread_var = f"{acc_buf}[{reduction_dim.name}]"
             src_metal_type = DTYPE_TO_METAL[src_dtype]
             if self.multistage_reduction:
-                lim_fn, reduction_op = (
-                    ("lowest", ">") if reduction_type == "max" else ("max", "<")
-                )
+                lim_fn = "lowest" if reduction_type == "max" else "max"
                 self.indexing_code.writeline(
                     f"{acc_thread_var} = ::metal::numeric_limits<{src_metal_type}>::{lim_fn}();"
                 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #149021
* #149020
* __->__ #149004

Simple followup after sum/prod

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov