### PR TITLE
[cutlass backend] try make cutlass backend benchmark more robust

### DIFF
--- a/benchmarks/inductor_backends/cutlass.py
+++ b/benchmarks/inductor_backends/cutlass.py
@@ -188,7 +188,18 @@ def run_single_experiment_group(
         compiled_op = torch.compile(op, fullgraph=True, options=config.to_options())
 
         start_time = time.perf_counter()
-        _ = compiled_op(A, B)
+        try:
+            _ = compiled_op(A, B)
+        except Exception as e:
+            print(f"Benchmark config {config.name()} failed: {e}")
+            results.append(
+            ExperimentResults(
+                    name=config.name(),
+                    forward_time=float('inf'),
+                    compilation_time=float('inf'),
+                )
+            )
+            continue
         compilation_time = time.perf_counter() - start_time
 
         forward_time = benchmark_torch_function_in_microseconds(
@@ -309,9 +320,10 @@ def main():
             CUTLASS_INSTANTIATION_LEVELS,
         )
     ):
+        group_results = run_single_experiment_group(group_config)
         results.append(
             ExperimentGroup(
-                config=group_config, results=run_single_experiment_group(group_config)
+                config=group_config, results=group_results
             ),
         )
 

--- a/benchmarks/inductor_backends/cutlass.py
+++ b/benchmarks/inductor_backends/cutlass.py
@@ -193,10 +193,10 @@ def run_single_experiment_group(
         except Exception as e:
             print(f"Benchmark config {config.name()} failed: {e}")
             results.append(
-            ExperimentResults(
+                ExperimentResults(
                     name=config.name(),
-                    forward_time=float('inf'),
-                    compilation_time=float('inf'),
+                    forward_time=float("inf"),
+                    compilation_time=float("inf"),
                 )
             )
             continue
@@ -322,9 +322,7 @@ def main():
     ):
         group_results = run_single_experiment_group(group_config)
         results.append(
-            ExperimentGroup(
-                config=group_config, results=group_results
-            ),
+            ExperimentGroup(config=group_config, results=group_results),
         )
 
     print_results(results)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149015

Differential Revision: [D71006269](https://our.internmc.facebook.com/intern/diff/D71006269/)

I want to make sure the benchmark even if failed on some experiment can still print most of the results. 

```
Experiment group: mm (3x3, 3x3) torch.bfloat16
+-----------------------+-------------------+----------------------+---------------------+
|         name          | forward_time (us) | compilation_time (s) | perf_over_aten (%)  |
+-----------------------+-------------------+----------------------+---------------------+
|         aten          | 6.175220478326082 |  0.5982149520423263  |         NA          |
|        triton         | 5.326753947883844 |  3.2067150759976357  | -13.739858089605114 |
| triton_persistent_tma | 5.340870004147291 |  3.279932268196717   | -13.51126615004617  |
|  cutlass_lvl_default  |        inf        |         inf          |         inf         |
|   cutlass_lvl_1111    |        inf        |         inf          |         inf         |
|   cutlass_lvl_2222    |        inf        |         inf          |         inf         |
|   cutlass_lvl_3333    |        inf        |         inf          |         inf         |
+-----------------------+-------------------+----------------------+---------------------+
```