### PR TITLE
[MPSInductor][EZ] Fix argmin/max signatures

### DIFF
--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -64,11 +64,11 @@ T threadgroup_min(threadgroup T* data, unsigned size) {
 }
 
 template <typename T>
-long threadgroup_argmax(threadgroup T* data, unsigned size) {
+int threadgroup_argmax(threadgroup T* data, unsigned size) {
   // TODO: This should be moved to the callee
   ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
-  long rc = 0;
-  for (unsigned idx = 1; idx < size; ++idx) {
+  int rc = 0;
+  for (int idx = 1; idx < size; ++idx) {
     if (data[idx] > data[rc]) {
       rc = idx;
     }
@@ -77,11 +77,11 @@ long threadgroup_argmax(threadgroup T* data, unsigned size) {
 }
 
 template <typename T>
-T threadgroup_argmin(threadgroup T* data, unsigned size) {
+int threadgroup_argmin(threadgroup T* data, unsigned size) {
   // TODO: This should be moved to the callee
   ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
-  long rc = 0;
-  for (unsigned idx = 1; idx < size; ++idx) {
+  int rc = 0;
+  for (int idx = 1; idx < size; ++idx) {
     if (data[idx] < data[rc]) {
       rc = idx;
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #149021
* __->__ #149020
* #149004

threadgroup_argmin used to return input type, which is wrong, it should have returned `int` or `long`

Change signatures of both thredgroup_argmin and threadgroup_argmax to return int, as group size is small, no need to carry over large integeres