### PR TITLE
[MPSInductor] Fix `argmin`/`argmax` long reductions

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -156,6 +156,7 @@ for test_name in [
     "test_any",
     "test_arange5",
     "test_argmax_min_int32",
+    "test_argmax_argmin1",
     "test_argmax_argmin2",
     "test_avg_pool2d5",
     "test_avg_pool2d8",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149021
* #149020
* #149004

By adding an additional indexes array for aggregates and populating it when performing partial reductions.

And with that I can finally `torch.compile` TinyStories and get 600+ tokens/sec vs <200 on eager
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov