### PR TITLE
Add `__all__` for `torch.utils.dlpack`

### DIFF
--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -6,6 +6,11 @@ import enum
 from torch._C import _from_dlpack
 from torch._C import _to_dlpack as to_dlpack
 
+__all__ = [
+    "from_dlpack",
+    "to_dlpack",
+]
+
 
 class DLDeviceType(enum.IntEnum):
     # Enums as in DLPack specification (aten/src/ATen/dlpack.h)

--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -7,6 +7,7 @@ from torch._C import _from_dlpack
 from torch._C import _to_dlpack as to_dlpack
 
 __all__ = [
+    "DLDeviceType",
     "from_dlpack",
     "to_dlpack",
 ]


### PR DESCRIPTION
Fixes the issue:

```python
torch.utils.dlpack.to_dlpack(tensor)  # "to_dlpack" is not exported from module "torch.utils.dlpack" Pylance[reportPrivateImportUsage](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportPrivateImportUsage)
```

the docs for `torch.utils.dlpack`: https://pytorch.org/docs/stable/dlpack.html