### PR TITLE
[regression] Fix pin_memory() when it is called before device lazy initialization.

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -110,6 +110,11 @@ class TORCH_API Context {
 
   Allocator* getPinnedMemoryAllocator(
       std::optional<c10::DeviceType> device_type = std::nullopt) {
+    auto opt_device_type =
+        device_type.has_value() ? device_type : at::getAccelerator();
+    if (opt_device_type) {
+      lazyInitDevice(opt_device_type.value());
+    }
     return getAcceleratorHooksInterface(device_type).getPinnedMemoryAllocator();
   }
 

--- a/aten/src/ATen/EmptyTensor.cpp
+++ b/aten/src/ATen/EmptyTensor.cpp
@@ -28,10 +28,8 @@ c10::Allocator* GetCPUAllocatorMaybePinned(bool pin_memory) {
       opt_device_type = at::getAccelerator(false);
     }
     if (opt_device_type.has_value()) {
-      at::globalContext().lazyInitDevice(opt_device_type.value());
-      return at::globalContext()
-          .getAcceleratorHooksInterface(opt_device_type)
-          .getPinnedMemoryAllocator();
+      return at::globalContext().getPinnedMemoryAllocator(
+          opt_device_type.value());
     } else {
       TORCH_CHECK(
           false, "Need to provide pin_memory allocator to use pin memory.")


### PR DESCRIPTION
PR #145752 has added a check in the isPinnedPtr to check if a device is initialized before checking if the tensor is pinned. Also that PR has added a lazy initialization trigger when an at::empty is called with a pinned param set to true. However, when the tensor is firstly created and it is pinned in a separate call by calling pin_memory() function, lazy device init is not called so is_pinned returns always false.

With this PR, the lazy initialization is moved to getPinnedMemoryAllocator function, thus it is assured that device is initialized before we pin a tensor.

Fixes #149032

@ngimel @albanD