### PR TITLE
[DTensor] Fix `local_map` with multi-threading

### DIFF
--- a/torch/distributed/tensor/experimental/_func_map.py
+++ b/torch/distributed/tensor/experimental/_func_map.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import functools
-
 from collections.abc import Sequence
 from typing import Callable, Optional, Union
 

--- a/torch/distributed/tensor/experimental/_func_map.py
+++ b/torch/distributed/tensor/experimental/_func_map.py
@@ -1,5 +1,7 @@
 # mypy: allow-untyped-defs
 # Copyright (c) Meta Platforms, Inc. and affiliates
+import functools
+
 from collections.abc import Sequence
 from typing import Callable, Optional, Union
 
@@ -126,7 +128,7 @@ def local_map(
     .. note:: This API is currently experimental and subject to change
     """
 
-    def wrapped(*args, **kwargs):
+    def wrapped(device_mesh: Optional[DeviceMesh], *args, **kwargs):
         # process input args
         flat_args, args_spec = pytree.tree_flatten(args)
         if in_placements is not None:
@@ -137,7 +139,6 @@ def local_map(
 
         # we assume every DTensor object is placed on the same device mesh
         flat_local_args = []
-        nonlocal device_mesh  # access var device_mesh from the outer scope
         seen_dtensor_arg = False
         for idx, arg in enumerate(flat_args):
             if isinstance(arg, DTensor):
@@ -232,4 +233,4 @@ def local_map(
         else:
             return out
 
-    return wrapped
+    return functools.partial(wrapped, device_mesh)


### PR DESCRIPTION
Using `nonlocal device_mesh` is not safe with multi-threading

cc @H-Huang @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o