### PR TITLE
[DTensor] Fix`slice_backward` strategy, add `select_int`, `select_backward` strategies

### DIFF
--- a/torch/distributed/tensor/_ops/_experimental_ops.py
+++ b/torch/distributed/tensor/_ops/_experimental_ops.py
@@ -1,27 +1,45 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
-# implement matrix related ops for distributed tensor
+# implement experimental ops for distributed tensor
 
 import torch
+from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._op_schema import (
     OpSchema,
     OpStrategy,
     PlacementStrategy,
-    StrategyType,
+    RuntimeSchemaInfo,
 )
-from torch.distributed.tensor._ops.utils import register_op_strategy
-from torch.distributed.tensor.placement_types import Replicate
+from torch.distributed.tensor._ops.utils import generate_redistribute_costs, register_op_strategy
+from torch.distributed.tensor.placement_types import Replicate, Shard
 
 
 aten = torch.ops.aten
 
 
-@register_op_strategy(aten.slice_backward.default)
-def slice_backward_rules(op_schema: OpSchema) -> StrategyType:
-    """
-    slice_backward is a new_zeros + slice_scatter, we only allow replication
-    on the input/output for now since new_zeros would produce replication
-    """
-    mesh = op_schema.get_mesh_from_args(validate=False)
-    replicate_spec = DTensorSpec(mesh, tuple([Replicate()] * mesh.ndim))
-    return OpStrategy([PlacementStrategy(replicate_spec)])
+@register_op_strategy(
+    aten.slice_backward.default,
+    schema_info=RuntimeSchemaInfo(1),
+)
+def slice_backward_rules(mesh: DeviceMesh, op_schema: OpSchema) -> OpStrategy:
+    # func: slice_backward(Tensor grad_output, SymInt[] input_sizes, int dim, SymInt start, SymInt end, SymInt step) -> Tensor
+    args_schema = op_schema.args_schema
+    input_strategy, dim = args_schema[0], args_schema[2]
+    assert isinstance(input_strategy, OpStrategy), f"{input_strategy}"
+    output_strategies: list[PlacementStrategy] = []
+    for placement_strategy in input_strategy.strategies:
+        output_spec = placement_strategy.output_spec
+        new_placements = []
+        for placement in output_spec.placements:
+            # Redistribute to replicate only if the dim is sharded and matches
+            # the slice dim
+            if isinstance(placement, Shard) and placement.dim == dim:
+                new_placements.append(Replicate())
+            else:
+                new_placements.append(placement)
+        new_spec = DTensorSpec(mesh, tuple(new_placements))
+        redistribute_cost = [generate_redistribute_costs(input_strategy, new_spec)]
+        placement_strategy.redistribute_cost = redistribute_cost
+        new_strategy = PlacementStrategy(output_specs=new_spec, input_specs=(output_spec,))
+        output_strategies.append(new_strategy)
+    return OpStrategy(output_strategies)

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -77,6 +77,8 @@ class ShardingPropagator:
             aten.reshape.default: 1,
             aten.view.default: 1,
             aten._unsafe_view.default: 1,
+            aten.select_backward.default: 1,
+            aten.slice_backward.default: 1,
         }
 
     def register_sharding_prop_rule(


### PR DESCRIPTION
For `slice_backward`:
1. `slice_backward` was missing `schema_info` leading to a caching bug
2. We do not need to redistribute to replicate if a shard dim differs from the slice `dim`

For `select_int` and `select_backward`, we add strategies.

For `select_backward` and `slice_backward`, we need to specify that their concrete `input_sizes` arg (arg index 1) need to be modified by adding an entry in `self.op_to_shape_and_stride_idx`.

cc @H-Huang @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o