### PR TITLE
Fix outdated docstring of torch.export.export regarding strict flag

### DIFF
--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -322,15 +322,15 @@ def export(
          are denoted by None. Arguments that are dicts or tuples / lists of tensors are
          recursively specified by using mappings or sequences of contained specifications.
 
-        strict: When enabled (default), the export function will trace the program through
-         TorchDynamo which will ensure the soundness of the resulting graph. Otherwise, the
-         exported program will not validate the implicit assumptions baked into the graph and
-         may cause behavior divergence between the original model and the exported one. This is
-         useful when users need to workaround bugs in the tracer, or simply want incrementally
-         enable safety in their models. Note that this does not affect the resulting IR spec
-         to be different and the model will be serialized in the same way regardless of what value
+        strict: When disabled (default), the export function will trace the program through
+         Python runtime, which by itself will not validate some of the implicit assumptions
+         baked into the graph. It will still validate most critical assumptions like shape
+         safety. When enabled (by setting ``strict=True``), the export function will trace
+         the program through TorchDynamo which will ensure the soundness of the resulting
+         graph. TorchDynamo has limited Python feature coverage, thus you may experience more
+         errors. Note that toggling this argument does not affect the resulting IR spec to be
+         different and the model will be serialized in the same way regardless of what value
          is passed here.
-         WARNING: This option is experimental and use this at your own risk.
 
     Returns:
         An :class:`ExportedProgram` containing the traced callable.


### PR DESCRIPTION
Summary: Fix outdated docstring of torch.export.export regarding strict flag

Test Plan: None, doc only change

Differential Revision: D71068215


