### PR TITLE
BC fix for AOTIModelPackageLoader() constructor defaults

### DIFF
--- a/test/cpp/aoti_inference/test.cpp
+++ b/test/cpp/aoti_inference/test.cpp
@@ -76,7 +76,9 @@ void test_aoti_script(const std::string& device) {
   }
 }
 
-void test_aoti_package_loader(const std::string& device, bool use_runtime_constant_folding) {
+void test_aoti_package_loader(
+    const std::string& device,
+    bool use_runtime_constant_folding) {
   torch::NoGradGuard no_grad;
 
   std::string data_path =

--- a/test/cpp/aoti_inference/test.cpp
+++ b/test/cpp/aoti_inference/test.cpp
@@ -76,6 +76,29 @@ void test_aoti_script(const std::string& device) {
   }
 }
 
+void test_aoti_package_loader(const std::string& device, bool use_runtime_constant_folding) {
+  torch::NoGradGuard no_grad;
+
+  std::string data_path =
+      (std::filesystem::path(STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) / "data.pt")
+           .string();
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+  std::string suffix = use_runtime_constant_folding
+      ? device + "_use_runtime_constant_folding"
+      : device;
+  std::string path_attr = "model_so_path_" + suffix;
+  std::string inputs_attr = "inputs_" + suffix;
+  std::string outputs_attr = "outputs_" + suffix;
+  const auto& model_so_path = data_loader.attr(path_attr.c_str()).toStringRef();
+  const auto& ref_output_tensors =
+      data_loader.attr(outputs_attr.c_str()).toTensorList().vec();
+
+  torch::inductor::AOTIModelPackageLoader runner(model_so_path);
+  auto actual_output_tensors =
+      runner.run(data_loader.attr(inputs_attr.c_str()).toTensorList().vec());
+  ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
+}
+
 void test_aoti_constants_update(
     const std::string& device,
     bool use_runtime_constant_folding) {
@@ -300,6 +323,10 @@ TEST(AotInductorTest, BasicScriptTestCpu) {
   test_aoti_script("cpu");
 }
 
+TEST(AotInductorTest, BasicPackageLoaderTestCpu) {
+  test_aoti_package_loader("cpu", false);
+}
+
 #ifdef USE_CUDA
 TEST(AotInductorTest, BasicTestCuda) {
   test_aoti("cuda", true);
@@ -308,6 +335,11 @@ TEST(AotInductorTest, BasicTestCuda) {
 
 TEST(AotInductorTest, BasicScriptTestCuda) {
   test_aoti_script("cuda");
+}
+
+TEST(AotInductorTest, BasicPackageLoaderTestCuda) {
+  test_aoti_package_loader("cuda", true);
+  test_aoti_package_loader("cuda", false);
 }
 
 TEST(AotInductorTest, RuntimeUpdateConstantsCuda) {

--- a/test/cpp/aoti_inference/test.cpp
+++ b/test/cpp/aoti_inference/test.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include <torch/csrc/inductor/aoti_package/model_package_loader.h>
 #include <torch/csrc/inductor/aoti_runner/model_container_runner_cpu.h>
 #if defined(USE_CUDA) || defined(USE_ROCM)
 #include <torch/csrc/inductor/aoti_runner/model_container_runner_cuda.h>
@@ -88,14 +89,15 @@ void test_aoti_package_loader(
   std::string suffix = use_runtime_constant_folding
       ? device + "_use_runtime_constant_folding"
       : device;
-  std::string path_attr = "model_so_path_" + suffix;
+  std::string path_attr = "pt2_package_path_" + suffix;
   std::string inputs_attr = "inputs_" + suffix;
   std::string outputs_attr = "outputs_" + suffix;
-  const auto& model_so_path = data_loader.attr(path_attr.c_str()).toStringRef();
+  const auto& pt2_package_path =
+      data_loader.attr(path_attr.c_str()).toStringRef();
   const auto& ref_output_tensors =
       data_loader.attr(outputs_attr.c_str()).toTensorList().vec();
 
-  torch::inductor::AOTIModelPackageLoader runner(model_so_path);
+  torch::inductor::AOTIModelPackageLoader runner(pt2_package_path);
   auto actual_output_tensors =
       runner.run(data_loader.attr(inputs_attr.c_str()).toTensorList().vec());
   ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
@@ -340,7 +342,6 @@ TEST(AotInductorTest, BasicScriptTestCuda) {
 }
 
 TEST(AotInductorTest, BasicPackageLoaderTestCuda) {
-  test_aoti_package_loader("cuda", true);
   test_aoti_package_loader("cuda", false);
 }
 

--- a/test/cpp/aoti_inference/test.py
+++ b/test/cpp/aoti_inference/test.py
@@ -57,6 +57,17 @@ def generate_basic_tests():
                         "aot_inductor.use_runtime_constant_folding": use_runtime_constant_folding
                     },
                 )
+                # Also store a .pt2 file using the aoti_compile_and_package API
+                pt2_package_path = torch._inductor.aoti_compile_and_package(
+                    torch.export.export(
+                        model,
+                        (x,),
+                        dynamic_shapes=dynamic_shapes,
+                    ),
+                    inductor_configs={
+                        "aot_inductor.use_runtime_constant_folding": use_runtime_constant_folding
+                    },
+                )
 
             suffix = f"{device}"
             if use_runtime_constant_folding:
@@ -64,6 +75,7 @@ def generate_basic_tests():
             data.update(
                 {
                     f"model_so_path_{suffix}": model_so_path,
+                    f"pt2_package_path_{suffix}": pt2_package_path,
                     f"inputs_{suffix}": [x],
                     f"outputs_{suffix}": [ref_output],
                     f"w_pre_{suffix}": model.w_pre,
@@ -86,10 +98,15 @@ def generate_test_with_additional_tensors():
     torch._dynamo.reset()
     with torch.no_grad():
         model_so_path = aot_compile(model, (x, y))
+        # Also store a .pt2 file using the aoti_compile_and_package API
+        pt2_package_path = torch._inductor.aoti_compile_and_package(
+            torch.export.export(model, (x, y))
+        )
 
     data_with_tensor_constants.update(
         {
             "model_so_path": model_so_path,
+            "pt2_package_path": pt2_package_path,
             "inputs": [x, y],
             "outputs": [ref_output],
             "w": model.w,

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -340,14 +340,14 @@ void AOTIModelPackageLoader::load_metadata(const std::string& cpp_filename) {
 
 AOTIModelPackageLoader::AOTIModelPackageLoader(
     const std::string& model_package_path,
-    const bool run_single_threaded = false)
+    const bool run_single_threaded)
     : AOTIModelPackageLoader(model_package_path, "model", run_single_threaded) {
 }
 
 AOTIModelPackageLoader::AOTIModelPackageLoader(
     const std::string& model_package_path,
-    const std::string& model_name = "model",
-    const bool run_single_threaded = false) {
+    const std::string& model_name,
+    const bool run_single_threaded) {
   // Extract all files within the zipfile to a temporary directory
   mz_zip_archive zip_archive;
   memset(&zip_archive, 0, sizeof(zip_archive));

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -340,12 +340,6 @@ void AOTIModelPackageLoader::load_metadata(const std::string& cpp_filename) {
 
 AOTIModelPackageLoader::AOTIModelPackageLoader(
     const std::string& model_package_path,
-    const bool run_single_threaded)
-    : AOTIModelPackageLoader(model_package_path, "model", run_single_threaded) {
-}
-
-AOTIModelPackageLoader::AOTIModelPackageLoader(
-    const std::string& model_package_path,
     const std::string& model_name,
     const bool run_single_threaded) {
   // Extract all files within the zipfile to a temporary directory

--- a/torch/csrc/inductor/aoti_package/model_package_loader.h
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.h
@@ -9,11 +9,11 @@ class TORCH_API AOTIModelPackageLoader {
  public:
   AOTIModelPackageLoader(
       const std::string& model_package_path,
-      const bool run_single_threaded);
+      const bool run_single_threaded = false);
   AOTIModelPackageLoader(
       const std::string& model_package_path,
       const std::string& model_name,
-      const bool run_single_threaded);
+      const bool run_single_threaded = false);
   ~AOTIModelPackageLoader();
 
   AOTIModelContainerRunner* get_runner();

--- a/torch/csrc/inductor/aoti_package/model_package_loader.h
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.h
@@ -9,10 +9,7 @@ class TORCH_API AOTIModelPackageLoader {
  public:
   AOTIModelPackageLoader(
       const std::string& model_package_path,
-      const bool run_single_threaded = false);
-  AOTIModelPackageLoader(
-      const std::string& model_package_path,
-      const std::string& model_name,
+      const std::string& model_name = "model",
       const bool run_single_threaded = false);
   ~AOTIModelPackageLoader();
 

--- a/torch/csrc/inductor/aoti_package/pybind.cpp
+++ b/torch/csrc/inductor/aoti_package/pybind.cpp
@@ -15,11 +15,6 @@ class AOTIModelPackageLoaderPybind : public AOTIModelPackageLoader {
  public:
   AOTIModelPackageLoaderPybind(
       const std::string& model_package_path,
-      const bool run_single_threaded)
-      : AOTIModelPackageLoader(model_package_path, run_single_threaded) {}
-
-  AOTIModelPackageLoaderPybind(
-      const std::string& model_package_path,
       const std::string& model_name,
       const bool run_single_threaded)
       : AOTIModelPackageLoader(
@@ -54,7 +49,6 @@ void initAOTIPackageBindings(PyObject* module) {
 
   py::class_<AOTIModelPackageLoaderPybind>(m, "AOTIModelPackageLoader")
       .def(py::init<const std::string&, const std::string&, const bool>())
-      .def(py::init<const std::string&, const bool>())
       .def("get_metadata", &AOTIModelPackageLoaderPybind::get_metadata)
       .def(
           "run",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149082

The default value for `run_single_threaded` was wrongly specified in the .cpp file instead of the header, breaking C++-side instantiation of `AOTIModelPackageLoader` with no arguments. This PR fixes this and adds a test for the use case of running with `AOTIModelPackageLoader` instead of `AOTIModelContainerRunner` on the C++ side.

cc @desertfire @chenyang78 @penguinwu @yushangdi @benjaminglass1