### PR TITLE
[AOTI] Re-enable AOTI cpp unit test

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1619,6 +1619,7 @@ elif [[ "${TEST_CONFIG}" == *inductor_cpp_wrapper* ]]; then
   install_torchvision
   checkout_install_torchbench hf_T5 llama moco
   PYTHONPATH=$(pwd)/torchbench test_inductor_cpp_wrapper_shard "$SHARD_NUMBER"
+  test_inductor_aoti
 elif [[ "${TEST_CONFIG}" == *inductor* ]]; then
   install_torchvision
   test_inductor_shard "${SHARD_NUMBER}"

--- a/test/cpp/aoti_inference/test.cpp
+++ b/test/cpp/aoti_inference/test.cpp
@@ -1,3 +1,4 @@
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <filesystem>
 #include <string>
@@ -128,9 +129,13 @@ void test_aoti_constants_update(
   ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
 
   // Update with missing map which should throw.
-  EXPECT_THROW(
-      runner->update_constant_buffer(missing_map, false, true),
-      std::runtime_error);
+  // Somehow EXPECT_THROW doesn't work here when running tests in a row, but
+  // works when running AotInductorTest.RuntimeUpdateConstantsCuda individually.
+  try {
+    runner->update_constant_buffer(missing_map, false, true);
+  } catch (const std::runtime_error& e) {
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("API call failed at"));
+  }
 
   // Update random weight to buffer #1.
   runner->update_constant_buffer(missing_map, false, false);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149085

Summary: test_inductor_aoti was removed by accident previously. Add it back.