### PR TITLE
[ROCm][TunableOp] More TF32 support.

### DIFF
--- a/aten/src/ATen/cuda/tunable/TunableGemm.h
+++ b/aten/src/ATen/cuda/tunable/TunableGemm.h
@@ -145,7 +145,11 @@ inline const char* TypeName(T v) {
 
 template <>
 inline const char* TypeName(float v) {
-  return "float";
+  if (!at::globalContext().allowTF32CuBLAS()) {
+    return "float";
+  } else {
+    return "tf32";
+  }
 }
 
 template <>

--- a/aten/src/ATen/cuda/tunable/TunableGemm.h
+++ b/aten/src/ATen/cuda/tunable/TunableGemm.h
@@ -145,10 +145,10 @@ inline const char* TypeName(T v) {
 
 template <>
 inline const char* TypeName(float v) {
-  if (!at::globalContext().allowTF32CuBLAS()) {
-    return "float";
-  } else {
+  if (at::globalContext().allowTF32CuBLAS()) {
     return "tf32";
+  } else {
+    return "float";
   }
 }
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -100,8 +100,7 @@ def get_tunableop_validators():
 def find_tunableop_result(results, OpSig, ParamSig):
     assert isinstance(results, tuple)
     for inner_tuple in results:
-        if OpSig in inner_tuple:
-            if ParamSig in inner_tuple:
+        if OpSig in inner_tuple and ParamSig in inner_tuple:
                 return inner_tuple
     return None
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5499,9 +5499,6 @@ class TestLinalg(TestCase):
         # for HIP/AMDGPU, tf32 is behind a flag because the TF32 support is new
         # and only for MI300+. Eventually this flag will go away.
         # This test is not 100% foolproof, a stricter test would be to enable
-        # HIPBLASLT logging and verify that the compute type is xf32_r.
-        # This test only checks that the solution found by TunableOp is
-        # not from ROCBLAS.
         tf32_ctx = self._hip_allow_tf32 if torch.version.hip else contextlib.nullcontext
 
         with tf32_ctx():

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5528,8 +5528,8 @@ class TestLinalg(TestCase):
                 # Additionally, the Op Signature must be tf32
                 last_result = torch.cuda.tunable.get_results()
                 found_result = find_tunableop_result(last_result,
-                                                    'GemmTunableOp_tf32_NN',
-                                                    'nn_37_37_37_ld_37_37_37')
+                                                     'GemmTunableOp_tf32_NN',
+                                                     'nn_37_37_37_ld_37_37_37')
                 self.assertTrue(found_result is not None)
                 self.assertTrue('Rocblas' not in found_result)
 
@@ -5552,8 +5552,8 @@ class TestLinalg(TestCase):
                 # The new tuning result must be of type float
                 last_result = torch.cuda.tunable.get_results()
                 found_result = find_tunableop_result(last_result,
-                                                    'GemmTunableOp_float_NN',
-                                                    'nn_37_37_37_ld_37_37_37')
+                                                     'GemmTunableOp_float_NN',
+                                                     'nn_37_37_37_ld_37_37_37')
                 self.assertTrue(found_result is not None)
 
         finally:

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5498,7 +5498,6 @@ class TestLinalg(TestCase):
         # Test TunableOp with TF32. Supported by hipblasLT on MI300+.
         # for HIP/AMDGPU, tf32 is behind a flag because the TF32 support is new
         # and only for MI300+. Eventually this flag will go away.
-        # This test is not 100% foolproof, a stricter test would be to enable
         tf32_ctx = self._hip_allow_tf32 if torch.version.hip else contextlib.nullcontext
 
         with tf32_ctx():
@@ -5527,8 +5526,8 @@ class TestLinalg(TestCase):
             # Additionally, the Op Signature must be tf32
             last_result = torch.cuda.tunable.get_results()
             found_result = find_tunableop_result(last_result,
-                                          'GemmTunableOp_tf32_NN',
-                                          'nn_37_37_37_ld_37_37_37')
+                                                 'GemmTunableOp_tf32_NN',
+                                                 'nn_37_37_37_ld_37_37_37')
             self.assertTrue(found_result is not None)
             self.assertTrue('Rocblas' not in found_result)
 
@@ -5540,9 +5539,6 @@ class TestLinalg(TestCase):
             ref_num_results = total_num_results
 
             # Tune the same GEMM again
-            N = M = K = 37
-            A = torch.randn(N, K, device=device, dtype=dtype)
-            B = torch.randn(K, M, device=device, dtype=dtype)
             C = torch.matmul(A, B)
 
             # This stores total number of cumulative results
@@ -5554,8 +5550,8 @@ class TestLinalg(TestCase):
             # The new tuning result must be of type float
             last_result = torch.cuda.tunable.get_results()
             found_result = find_tunableop_result(last_result,
-                                          'GemmTunableOp_float_NN',
-                                          'nn_37_37_37_ld_37_37_37')
+                                                 'GemmTunableOp_float_NN',
+                                                 'nn_37_37_37_ld_37_37_37')
             self.assertTrue(found_result is not None)
 
             # disable TunableOp

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5498,6 +5498,8 @@ class TestLinalg(TestCase):
         # Test TunableOp with TF32. Supported by hipblasLT on MI300+.
         # for HIP/AMDGPU, tf32 is behind a flag because the TF32 support is new
         # and only for MI300+. Eventually this flag will go away.
+        import os
+
         tf32_ctx = self._hip_allow_tf32 if torch.version.hip else contextlib.nullcontext
 
         with tf32_ctx():

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -101,7 +101,7 @@ def find_tunableop_result(results, OpSig, ParamSig):
     assert isinstance(results, tuple)
     for inner_tuple in results:
         if OpSig in inner_tuple and ParamSig in inner_tuple:
-                return inner_tuple
+            return inner_tuple
     return None
 
 class TestLinalg(TestCase):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5644,6 +5644,9 @@ class TestLinalg(TestCase):
                 self.assertTrue(found_result is not None)
 
         finally:
+            # Disable TF32
+            torch.backends.cuda.matmul.allow_tf32 = False
+
             # disable TunableOp
             torch.cuda.tunable.enable(False)
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -97,6 +97,14 @@ def get_tunableop_validators():
         validators[key] = value
     return validators
 
+def find_tunableop_result(results, OpSig, ParamSig):
+    assert isinstance(results, tuple)
+    for inner_tuple in results:
+        if OpSig in inner_tuple:
+            if ParamSig in inner_tuple:
+                return inner_tuple
+    return None
+
 class TestLinalg(TestCase):
     @contextlib.contextmanager
     def _hip_allow_tf32(self):

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -444,6 +444,7 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
 
     dtype_dict = {
         "float": torch.float32,
+        "tf32" : torch.float32,
         "double": torch.float64,
         "BFloat16": torch.bfloat16,
         "Half": torch.half,
@@ -470,6 +471,12 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
         transA = layout[0] == "T"
         transB = layout[1] == "T"
         dtype = dtype_dict.get(data_type)
+        if data_type == "tf32":
+            # User must still set HIPBLASLT_ALLOW_TF32=1
+            torch.backends.cuda.matmul.allow_tf32 = True
+        else:
+            torch.backends.cuda.matmul.allow_tf32 = False
+
     else:  # ScaledGEMM
         untuned_gemm_temp = untuned_gemm[0].split("_")
         # dtypeC = might not be FP8 type, keep track

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -444,7 +444,7 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
 
     dtype_dict = {
         "float": torch.float32,
-        "tf32" : torch.float32,
+        "tf32": torch.float32,
         "double": torch.float64,
         "BFloat16": torch.bfloat16,
         "Half": torch.half,


### PR DESCRIPTION
This PR includes additional enhancements to TF32 support in TunableOp.
- OpSignature now differentiates between float32 and tf32 data types.
- Offline tuning now supports TF32.
- Unit tests for online and offline tuning of TF32. 


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang