### PR TITLE
Ignore missing-field-initializers warnings of  Gemm::Arguments constructors

### DIFF
--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -253,7 +253,7 @@ void f8f8bf16_rowwise_impl(
        reinterpret_cast<DtypeOutput*>(out.data_ptr()),
        stride_output,
        reinterpret_cast<DtypeOutput*>(out.data_ptr()),
-       stride_output}};
+       stride_output},{}};
 
   Gemm gemm;
 
@@ -434,7 +434,7 @@ void f8f8bf16_rowwise_impl_sm100(
        reinterpret_cast<DtypeOutput*>(out.data_ptr()),
        stride_output,
        reinterpret_cast<DtypeOutput*>(out.data_ptr()),
-       stride_output}};
+       stride_output},{}};
 
   Gemm gemm;
 
@@ -661,7 +661,8 @@ void f8f8bf16_rowwise_impl_sm89(
     problem_size.k(),             // stride A
     problem_size.k(),             // stride B
     0,                            // stride C (unused)
-    0);                           // stride D (unused)
+    0,                            // stride D (unused)
+    {});
 
   Gemm gemm;
 

--- a/aten/src/ATen/native/cuda/ScaledGroupMM.cu
+++ b/aten/src/ATen/native/cuda/ScaledGroupMM.cu
@@ -482,7 +482,8 @@ void f8f8bf16_grouped_gemm_impl_sm90(
        (const DtypeOutput**)output_ptrs,
        stride_output,
        output_ptrs,
-       stride_output}};
+       stride_output,{},{}},
+      };
 
   int sm_count = at::cuda::getDeviceProperties(out.device().index())->multiProcessorCount;
   if (at::globalContext()._SMCarveout_EXPERIMENTAL().has_value()) {


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
