### PR TITLE
Remove runtime dependency on packaging

### DIFF
--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -3,8 +3,6 @@ import functools
 import logging
 import re
 from typing import Optional
-
-
 import torch
 from torch._dynamo.utils import counters
 from torch._inductor.autoheuristic.autoheuristic import AutoHeuristicSelectAlgorithm
@@ -55,6 +53,8 @@ from .mm_common import (
     triton_config,
 )
 
+
+
 def parse_version(version_string: str) -> Optional[tuple[int, ...]]:
     pattern = r"(\d+)\.(\d+)?"
     match = re.match(pattern, version_string)
@@ -64,10 +64,11 @@ def parse_version(version_string: str) -> Optional[tuple[int, ...]]:
     else:
         return None
 
+
 try:
     import triton
 
-    triton_version = parse_version(triton.__version__) 
+    triton_version = parse_version(triton.__version__)
     has_triton = True
     if triton_version is not None:
         triton_major, triton_minor = triton_version
@@ -77,6 +78,8 @@ try:
 except ImportError:
     triton_version = None
     has_triton = False
+    triton_major = 0
+    triton_minor = 0
 
 log = logging.getLogger(__name__)
 aten = torch.ops.aten

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -1,9 +1,9 @@
 # mypy: allow-untyped-defs
 import functools
 import logging
+import re
 from typing import Optional
 
-from packaging.version import Version
 
 import torch
 from torch._dynamo.utils import counters
@@ -55,12 +55,25 @@ from .mm_common import (
     triton_config,
 )
 
+def parse_version(version_string: str) -> Optional[tuple[int, ...]]:
+    pattern = r"(\d+)\.(\d+)?"
+    match = re.match(pattern, version_string)
+
+    if match:
+        return tuple(int(group) for group in match.groups())
+    else:
+        return None
 
 try:
     import triton
 
-    triton_version = triton.__version__
+    triton_version = parse_version(triton.__version__) 
     has_triton = True
+    if triton_version is not None:
+        triton_major, triton_minor = triton_version
+    else:
+        triton_major = 0
+        triton_minor = 0
 except ImportError:
     triton_version = None
     has_triton = False
@@ -138,7 +151,7 @@ mm_template = TritonTemplate(
     {{store_output(("idx_m", "idx_n"), "acc", "mask")}}
 """
         if (torch.version.hip is None)
-        or (has_triton and Version(triton_version) >= Version("3.3.0"))
+        or (has_triton and triton_major >= 3 and triton_minor >= 3)
         # FIXME: To get around rocm failures like https://github.com/pytorch/pytorch/actions/runs/13123783322/job/36617154943
         # The only difference between the two templates is M >= BLOCK_M and N >= BLOCK_N checking.
         # See more details in https://github.com/pytorch/pytorch/pull/146293

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -3,6 +3,7 @@ import functools
 import logging
 import re
 from typing import Optional
+
 import torch
 from torch._dynamo.utils import counters
 from torch._inductor.autoheuristic.autoheuristic import AutoHeuristicSelectAlgorithm
@@ -52,7 +53,6 @@ from .mm_common import (
     should_fallback_to_aten,
     triton_config,
 )
-
 
 
 def parse_version(version_string: str) -> Optional[tuple[int, ...]]:


### PR DESCRIPTION
Looks like after https://github.com/pytorch/pytorch/pull/148924
We are seeing this error in nightly test:
https://github.com/pytorch/pytorch/actions/runs/13806023728/job/38616861623

```
  File "/Users/runner/work/_temp/anaconda/envs/test_conda_env/lib/python3.13/site-packages/torch/_inductor/pattern_matcher.py", line 79, in <module>
    from .lowering import fallback_node_due_to_unsupported_type
  File "/Users/runner/work/_temp/anaconda/envs/test_conda_env/lib/python3.13/site-packages/torch/_inductor/lowering.py", line 7024, in <module>
    from . import kernel
  File "/Users/runner/work/_temp/anaconda/envs/test_conda_env/lib/python3.13/site-packages/torch/_inductor/kernel/__init__.py", line 1, in <module>
    from . import mm, mm_common, mm_plus_mm
  File "/Users/runner/work/_temp/anaconda/envs/test_conda_env/lib/python3.13/site-packages/torch/_inductor/kernel/mm.py", line 6, in <module>
    from packaging.version import Version
ModuleNotFoundError: No module named 'packaging'
```

Hence removing runtime dependency on packaging since it may not be installed by default

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov