### PR TITLE
[Distributed] Treat third-party devices with `set_rng_state()` and `get_rng_state` as CUDA-like devices when calling `manual_seed()`

### DIFF
--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -170,14 +170,14 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         super().__init__(_resolve_device(device_mesh=device_mesh))
         assert self._device_handle is not None
         # DTensor RNG tracker so far only supports CUDA/CUDA-like devices
-        if self._device.type != "cuda" and (
+        if (
             self._device.type == "cpu"
             or not hasattr(self._device_handle, "set_rng_state")
             or not hasattr(self._device_handle, "get_rng_state")
         ):
             raise RuntimeError(
                 f"{self.__class__.__name__} instantiation requires the presence of "
-                f"CUDA/CUDA-like device. Got {self._device.type} instead."
+                f"CUDA/CUDA-like device with RNG state support. Got {self._device.type} instead."
             )
 
         rng_state = self._device_handle.get_rng_state().to(self._device)

--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -170,7 +170,10 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         super().__init__(_resolve_device(device_mesh=device_mesh))
         assert self._device_handle is not None
         # DTensor RNG tracker so far only supports CUDA/CUDA-like devices
-        if self._device.type != "cuda":
+        if self._device.type != "cuda" and (
+            not hasattr(self._device_handle, "set_rng_state")
+            or not hasattr(self._device_handle, "get_rng_state")
+        ):
             raise RuntimeError(
                 f"{self.__class__.__name__} instantiation requires the presence of "
                 f"CUDA/CUDA-like device. Got {self._device.type} instead."

--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -201,7 +201,9 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         if self.distribute_region_enabled:
             old_offset = self.get_offset("parallel-rng")
             self._set_pre_op_offset(spec)
-            with torch.random.fork_rng(devices=[self._device], device_type=self._device.type):
+            with torch.random.fork_rng(
+                devices=[self._device], device_type=self._device.type
+            ):
                 assert self._device_handle is not None
                 self._device_handle.set_rng_state(self.rng_states["parallel-rng"])
                 try:

--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -171,7 +171,8 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         assert self._device_handle is not None
         # DTensor RNG tracker so far only supports CUDA/CUDA-like devices
         if self._device.type != "cuda" and (
-            not hasattr(self._device_handle, "set_rng_state")
+            self._device.type == "cpu"
+            or not hasattr(self._device_handle, "set_rng_state")
             or not hasattr(self._device_handle, "get_rng_state")
         ):
             raise RuntimeError(

--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -201,7 +201,7 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         if self.distribute_region_enabled:
             old_offset = self.get_offset("parallel-rng")
             self._set_pre_op_offset(spec)
-            with torch.random.fork_rng(devices=[self._device]):
+            with torch.random.fork_rng(devices=[self._device], device_type=self._device.type):
                 assert self._device_handle is not None
                 self._device_handle.set_rng_state(self.rng_states["parallel-rng"])
                 try:


### PR DESCRIPTION
Fixes #148858



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @tianyu-l @XilunWu @albanD @guangyey @EikanWang