### PR TITLE
[FSDP2] Add set_reshard_after_forward

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -195,8 +195,6 @@ class FSDPParamGroup:
         # the group's post-backward (e.g. reduce-scatter, all-reduce and div), which
         # should be waited on at the end of backward
         self._post_reduce_event: Optional[torch.Event] = None
-        # Whether to reshard parameters after forward
-        self.reshard_after_forward: bool = True
         # Holds the reshard-after-forward CUDA event when resharding to a
         # different world size, which should be waited on in the next unshard
         self._reshard_after_forward_event: Optional[torch.Event] = None
@@ -426,9 +424,9 @@ class FSDPParamGroup:
             if all_reduce_pg is None and self._all_reduce_hook_stream is not None:
                 # this means the native HSDP is not enabled,
                 # but user may want to have a custom HSDP setup
-                assert self._all_reduce_hook is not None, (
-                    "all reduce hook stream is specified but hook itself is missing."
-                )
+                assert (
+                    self._all_reduce_hook is not None
+                ), "all reduce hook stream is specified but hook itself is missing."
                 all_reduce_stream = self._all_reduce_hook_stream
             else:
                 all_reduce_stream = self.comm_ctx.all_reduce_stream
@@ -595,9 +593,9 @@ class FSDPParamGroup:
     def _register_state_dict_hooks(self) -> None:
         num_pre_save_hooks = len(self._module_to_pre_save_state_dict_hook_handle)
         num_pre_load_hooks = len(self._module_to_pre_load_state_dict_hook_handle)
-        assert num_pre_save_hooks == num_pre_load_hooks, (
-            f"Pre-save: {num_pre_save_hooks} pre-load: {num_pre_load_hooks}"
-        )
+        assert (
+            num_pre_save_hooks == num_pre_load_hooks
+        ), f"Pre-save: {num_pre_save_hooks} pre-load: {num_pre_load_hooks}"
         if num_pre_save_hooks > 0:
             return  # already registered
         modules_with_fsdp_params: set[nn.Module] = {
@@ -618,7 +616,7 @@ class FSDPParamGroup:
     # Properties #
     @property
     def _reshard_after_forward(self) -> bool:
-        return (self.post_forward_mesh_info is not None) and self.reshard_after_forward
+        return self.post_forward_mesh_info is not None
 
     @property
     def _use_post_forward_mesh(self) -> bool:

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -424,9 +424,9 @@ class FSDPParamGroup:
             if all_reduce_pg is None and self._all_reduce_hook_stream is not None:
                 # this means the native HSDP is not enabled,
                 # but user may want to have a custom HSDP setup
-                assert (
-                    self._all_reduce_hook is not None
-                ), "all reduce hook stream is specified but hook itself is missing."
+                assert self._all_reduce_hook is not None, (
+                    "all reduce hook stream is specified but hook itself is missing."
+                )
                 all_reduce_stream = self._all_reduce_hook_stream
             else:
                 all_reduce_stream = self.comm_ctx.all_reduce_stream
@@ -593,9 +593,9 @@ class FSDPParamGroup:
     def _register_state_dict_hooks(self) -> None:
         num_pre_save_hooks = len(self._module_to_pre_save_state_dict_hook_handle)
         num_pre_load_hooks = len(self._module_to_pre_load_state_dict_hook_handle)
-        assert (
-            num_pre_save_hooks == num_pre_load_hooks
-        ), f"Pre-save: {num_pre_save_hooks} pre-load: {num_pre_load_hooks}"
+        assert num_pre_save_hooks == num_pre_load_hooks, (
+            f"Pre-save: {num_pre_save_hooks} pre-load: {num_pre_load_hooks}"
+        )
         if num_pre_save_hooks > 0:
             return  # already registered
         modules_with_fsdp_params: set[nn.Module] = {

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -426,9 +426,9 @@ class FSDPParamGroup:
             if all_reduce_pg is None and self._all_reduce_hook_stream is not None:
                 # this means the native HSDP is not enabled,
                 # but user may want to have a custom HSDP setup
-                assert (
-                    self._all_reduce_hook is not None
-                ), "all reduce hook stream is specified but hook itself is missing."
+                assert self._all_reduce_hook is not None, (
+                    "all reduce hook stream is specified but hook itself is missing."
+                )
                 all_reduce_stream = self._all_reduce_hook_stream
             else:
                 all_reduce_stream = self.comm_ctx.all_reduce_stream
@@ -595,9 +595,9 @@ class FSDPParamGroup:
     def _register_state_dict_hooks(self) -> None:
         num_pre_save_hooks = len(self._module_to_pre_save_state_dict_hook_handle)
         num_pre_load_hooks = len(self._module_to_pre_load_state_dict_hook_handle)
-        assert (
-            num_pre_save_hooks == num_pre_load_hooks
-        ), f"Pre-save: {num_pre_save_hooks} pre-load: {num_pre_load_hooks}"
+        assert num_pre_save_hooks == num_pre_load_hooks, (
+            f"Pre-save: {num_pre_save_hooks} pre-load: {num_pre_load_hooks}"
+        )
         if num_pre_save_hooks > 0:
             return  # already registered
         modules_with_fsdp_params: set[nn.Module] = {

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -195,6 +195,8 @@ class FSDPParamGroup:
         # the group's post-backward (e.g. reduce-scatter, all-reduce and div), which
         # should be waited on at the end of backward
         self._post_reduce_event: Optional[torch.Event] = None
+        # Whether to reshard parameters after forward
+        self.reshard_after_forward: bool = True
         # Holds the reshard-after-forward CUDA event when resharding to a
         # different world size, which should be waited on in the next unshard
         self._reshard_after_forward_event: Optional[torch.Event] = None
@@ -424,9 +426,9 @@ class FSDPParamGroup:
             if all_reduce_pg is None and self._all_reduce_hook_stream is not None:
                 # this means the native HSDP is not enabled,
                 # but user may want to have a custom HSDP setup
-                assert self._all_reduce_hook is not None, (
-                    "all reduce hook stream is specified but hook itself is missing."
-                )
+                assert (
+                    self._all_reduce_hook is not None
+                ), "all reduce hook stream is specified but hook itself is missing."
                 all_reduce_stream = self._all_reduce_hook_stream
             else:
                 all_reduce_stream = self.comm_ctx.all_reduce_stream
@@ -593,9 +595,9 @@ class FSDPParamGroup:
     def _register_state_dict_hooks(self) -> None:
         num_pre_save_hooks = len(self._module_to_pre_save_state_dict_hook_handle)
         num_pre_load_hooks = len(self._module_to_pre_load_state_dict_hook_handle)
-        assert num_pre_save_hooks == num_pre_load_hooks, (
-            f"Pre-save: {num_pre_save_hooks} pre-load: {num_pre_load_hooks}"
-        )
+        assert (
+            num_pre_save_hooks == num_pre_load_hooks
+        ), f"Pre-save: {num_pre_save_hooks} pre-load: {num_pre_load_hooks}"
         if num_pre_save_hooks > 0:
             return  # already registered
         modules_with_fsdp_params: set[nn.Module] = {
@@ -616,7 +618,7 @@ class FSDPParamGroup:
     # Properties #
     @property
     def _reshard_after_forward(self) -> bool:
-        return self.post_forward_mesh_info is not None
+        return (self.post_forward_mesh_info is not None) and self.reshard_after_forward
 
     @property
     def _use_post_forward_mesh(self) -> bool:

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -355,10 +355,12 @@ class FSDPModule:
         self, reshard_after_forward: bool, recurse: bool = True
     ) -> None:
         """
-        Sets if the module should reshard parameters after forward. Setting
-        this to False can save computation time, as unsharded parameters do
-        not need to be re-all-gathered before setting it back to True during
-        training.
+        Sets if the module should reshard parameters after forward. This can be
+        used to change the ``_reshard_after_forward`` FSDP arg at runtime. For
+        example, this can be used to set the FSDP root module's value to
+        ``True`` (since it is otherwise specially set to ``False``), or it can
+        set an FSDP module's value to ``False`` for running evals and set back
+        to ``True`` for training.
 
         Args:
             reshard_after_forward (bool): Whether to reshard parameters after

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -361,7 +361,7 @@ class FSDPModule:
 
         Args:
             reshard_after_forward (bool): Whether to reshard parameters after
-                backward.
+                forward.
             recurse (bool): Whether to set for all FSDP submodules or just the
                 passed-in module.
         """

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -355,9 +355,10 @@ class FSDPModule:
         self, reshard_after_forward: bool, *, recurse: bool = True
     ) -> None:
         """
-        Sets if the module should reshard parameters after forward. This can
-        be used to save computation time for since the unsharded parameter fo not
-        need to be re-all-gathered before setting to True in training.
+        Sets if the module should reshard parameters after forward. Setting
+        this to False can save computation time, as unsharded parameters do
+        not need to be re-all-gathered before setting it back to True during
+        training.
 
         Args:
             reshard_after_forward (bool): Whether to reshard parameters after

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -394,7 +394,11 @@ class FSDPModule:
             if isinstance(module, FSDPModule):
                 state = module._get_fsdp_state()
                 if fsdp_param_group := state._fsdp_param_group:
-                    fsdp_param_group.reshard_after_backward = reshard_after_backward
+                    fsdp_param_group.post_forward_mesh_info = (
+                        fsdp_param_group.fsdp_params[0].post_forward_mesh_info
+                        if reshard_after_backward
+                        else None
+                    )
 
     def set_modules_to_forward_prefetch(self, modules: list[FSDPModule]) -> None:
         """

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -371,7 +371,11 @@ class FSDPModule:
             if isinstance(module, FSDPModule):
                 state = module._get_fsdp_state()
                 if fsdp_param_group := state._fsdp_param_group:
-                    fsdp_param_group.reshard_after_forward = reshard_after_forward
+                    fsdp_param_group.post_forward_mesh_info = (
+                        fsdp_param_group.fsdp_params[0].post_forward_mesh_info
+                        if reshard_after_forward
+                        else None
+                    )
 
     def set_reshard_after_backward(
         self, reshard_after_backward: bool, *, recurse: bool = True
@@ -394,11 +398,7 @@ class FSDPModule:
             if isinstance(module, FSDPModule):
                 state = module._get_fsdp_state()
                 if fsdp_param_group := state._fsdp_param_group:
-                    fsdp_param_group.post_forward_mesh_info = (
-                        fsdp_param_group.fsdp_params[0].post_forward_mesh_info
-                        if reshard_after_backward
-                        else None
-                    )
+                    fsdp_param_group.reshard_after_backward = reshard_after_backward
 
     def set_modules_to_forward_prefetch(self, modules: list[FSDPModule]) -> None:
         """

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -356,7 +356,7 @@ class FSDPModule:
     ) -> None:
         """
         Sets if the module should reshard parameters after forward. This can be
-        used to change the ``_reshard_after_forward`` FSDP arg at runtime. For
+        used to change the ``reshard_after_forward`` FSDP arg at runtime. For
         example, this can be used to set the FSDP root module's value to
         ``True`` (since it is otherwise specially set to ``False``), or it can
         set an FSDP module's value to ``False`` for running evals and set back

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -351,6 +351,28 @@ class FSDPModule:
                 if fsdp_param_group := state._fsdp_param_group:
                     fsdp_param_group.all_reduce_grads = requires_all_reduce
 
+    def set_reshard_after_forward(
+        self, reshard_after_forward: bool, *, recurse: bool = True
+    ) -> None:
+        """
+        Sets if the module should reshard parameters after forward. This can
+        be used to save computation time for since the unsharded parameter fo not
+        need to be re-all-gathered before setting to True in training.
+
+        Args:
+            reshard_after_forward (bool): Whether to reshard parameters after
+                backward.
+            recurse (bool): Whether to set for all FSDP submodules or just the
+                passed-in module.
+        """
+        self_module = cast(nn.Module, self)
+        modules = list(self_module.modules()) if recurse else [self_module]
+        for module in modules:
+            if isinstance(module, FSDPModule):
+                state = module._get_fsdp_state()
+                if fsdp_param_group := state._fsdp_param_group:
+                    fsdp_param_group.reshard_after_forward = reshard_after_forward
+
     def set_reshard_after_backward(
         self, reshard_after_backward: bool, *, recurse: bool = True
     ) -> None:

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -352,7 +352,7 @@ class FSDPModule:
                     fsdp_param_group.all_reduce_grads = requires_all_reduce
 
     def set_reshard_after_forward(
-        self, reshard_after_forward: bool, *, recurse: bool = True
+        self, reshard_after_forward: bool, recurse: bool = True
     ) -> None:
         """
         Sets if the module should reshard parameters after forward. Setting
@@ -373,9 +373,9 @@ class FSDPModule:
                 state = module._get_fsdp_state()
                 if fsdp_param_group := state._fsdp_param_group:
                     fsdp_param_group.post_forward_mesh_info = (
-                        fsdp_param_group.fsdp_params[0].post_forward_mesh_info
-                        if reshard_after_forward
-                        else None
+                        _get_post_forward_mesh_info(
+                            reshard_after_forward, fsdp_param_group.mesh_info
+                        )
                     )
 
     def set_reshard_after_backward(


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/149029

Add `set_reshard_after_forward` to set `post_forward_mesh_info` so as to decide `_reshard_after_forward`

Add unit test similar to `test_fully_shard_communication_count`, the FSDPModule would perform as `._reshard_after_forward=True` after `.set_reshard_after_forward=True`, as well as setting to False

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o