### PR TITLE
ci: Fix check_binary gcc abi check

### DIFF
--- a/.ci/pytorch/check_binary.sh
+++ b/.ci/pytorch/check_binary.sh
@@ -73,26 +73,14 @@ fi
 # Check GCC ABI
 ###############################################################################
 
-# NOTE [ Building libtorch with old vs. new gcc ABI ]
-#
-# Packages built with one version of ABI could not be linked against by client
-# C++ libraries that were compiled using the other version of ABI. Since both
-# gcc ABIs are still common in the wild, we need to support both ABIs. Currently:
-#
-# - All the nightlies built on CentOS 7 + devtoolset7 use the old gcc ABI.
-# - All the nightlies built on Ubuntu 16.04 + gcc 5.4 use the new gcc ABI.
+# NOTE: As of https://github.com/pytorch/pytorch/issues/126551 we only produce
+#       wheels wheels cxx11-abi
 
 echo "Checking that the gcc ABI is what we expect"
 if [[ "$(uname)" != 'Darwin' ]]; then
   function is_expected() {
-    if [[ "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* || "$DESIRED_CUDA" == *"rocm"* ]]; then
-      if [[ "$1" -gt 0 || "$1" == "ON " ]]; then
-        echo 1
-      fi
-    else
-      if [[ -z "$1" || "$1" == 0 || "$1" == "OFF" ]]; then
-        echo 1
-      fi
+    if [[ "$1" -gt 0 || "$1" == "ON " ]]; then
+      echo 1
     fi
   }
 

--- a/.ci/pytorch/check_binary.sh
+++ b/.ci/pytorch/check_binary.sh
@@ -74,7 +74,7 @@ fi
 ###############################################################################
 
 # NOTE: As of https://github.com/pytorch/pytorch/issues/126551 we only produce
-#       wheels wheels cxx11-abi
+#       wheels with cxx11-abi
 
 echo "Checking that the gcc ABI is what we expect"
 if [[ "$(uname)" != 'Darwin' ]]; then

--- a/.ci/pytorch/smoke_test/check_binary_symbols.py
+++ b/.ci/pytorch/smoke_test/check_binary_symbols.py
@@ -121,9 +121,9 @@ def main() -> None:
         else:
             install_root = Path(distutils.sysconfig.get_python_lib()) / "torch"
 
-    libtorch_cpu_path = install_root / "lib" / "libtorch_cpu.so"
-    pre_cxx11_abi = "cxx11-abi" not in os.getenv("DESIRED_DEVTOOLSET", "")
-    check_lib_symbols_for_abi_correctness(libtorch_cpu_path, pre_cxx11_abi)
+    libtorch_cpu_path = str(install_root / "lib" / "libtorch_cpu.so")
+    # NOTE: All binaries are built with cxx11abi now
+    check_lib_symbols_for_abi_correctness(libtorch_cpu_path, False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #149102
* __->__ #149104

All of our binaries should be built with the cxx11-abi now so lets fix
this check to reflect reality.

I also noticed that this particular script is not used widely since this
issue should've been caught in nightlies a long time ago.

Maybe worth an investigation to just remove this script if it's not
actually being used.

Signed-off-by: Eli Uriegas <github@terriblecode.com>