### PR TITLE
Migrate aten.split.Tensor from using Sharding Rule to Sharding Strategy

### DIFF
--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -789,8 +789,6 @@ def split_strategy(op_schema: OpSchema) -> TupleStrategy:
             if is_tensor_dim_sharded(spec, dim=dim):
                 # if the input is sharded on the split dim, we need to unshard it
                 placements = unshard_tensor_dim(spec.placements, dim=dim)
-            else:
-                placements = spec.placements
 
             spec = DTensorSpec(spec.mesh, placements)
 

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -755,8 +755,6 @@ def split_strategy(op_schema: OpSchema) -> TupleStrategy:
     )
     dim = normalize_dim(split_dim, input_ndim)
 
-    split_strategy = []
-
     # tensor to split cannot have Partial for now
     for arg_strategy in input_strategy.strategies:
         arg_spec = arg_strategy.output_spec
@@ -780,8 +778,10 @@ def split_strategy(op_schema: OpSchema) -> TupleStrategy:
     )
     assert isinstance(output_size_list, Sized)
 
+    split_strategies = []
+
     for _ in range(len(output_size_list)):
-        split_strategy.append(OpStrategy(strategies=[]))
+        op_strategy = OpStrategy([])
 
         for strategy in input_strategy.strategies:
             spec = strategy.output_spec
@@ -794,8 +794,9 @@ def split_strategy(op_schema: OpSchema) -> TupleStrategy:
 
             spec = DTensorSpec(spec.mesh, placements)
 
-            split_strategy[-1].strategies.append(
+            op_strategy.strategies.append(
                 PlacementStrategy(output_specs=spec, input_specs=([spec]))
             )
+        split_strategies.append(op_strategy)
 
-    return TupleStrategy(split_strategy)
+    return TupleStrategy(split_strategies)

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -33,7 +33,6 @@ from torch.distributed.tensor.placement_types import (
     Replicate,
     Shard,
 )
-from torch.functional import split
 
 
 aten = torch.ops.aten


### PR DESCRIPTION
Summary:
Use Sharding Strategy for aten.split.Tensor instead of sharding rule

Test Plan:
pytest test/distributed/tensor/test_dtensor_ops.py -s -k split

Reviewers:
xilunwu

Subscribers:

Tasks:

Tags:

Fixes #ISSUE_NUMBER


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @tianyu-l @XilunWu