### PR TITLE
[CI] Increase shards number for XPU ci UT tests

### DIFF
--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -34,10 +34,12 @@ jobs:
       runner: linux.12xlarge
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 4, runner: "linux.idc.xpu" },
-          { config: "default", shard: 2, num_shards: 4, runner: "linux.idc.xpu" },
-          { config: "default", shard: 3, num_shards: 4, runner: "linux.idc.xpu" },
-          { config: "default", shard: 4, num_shards: 4, runner: "linux.idc.xpu" },
+          { config: "default", shard: 1, num_shards: 6, runner: "linux.idc.xpu" },
+          { config: "default", shard: 2, num_shards: 6, runner: "linux.idc.xpu" },
+          { config: "default", shard: 3, num_shards: 6, runner: "linux.idc.xpu" },
+          { config: "default", shard: 4, num_shards: 6, runner: "linux.idc.xpu" },
+          { config: "default", shard: 5, num_shards: 6, runner: "linux.idc.xpu" },
+          { config: "default", shard: 6, num_shards: 6, runner: "linux.idc.xpu" },
         ]}
     secrets: inherit
 


### PR DESCRIPTION
The XPU CI test met timeout issue, refer https://github.com/pytorch/pytorch/actions/runs/14897047392/job/41842336828 and this PR will reduce the ci time cost