### PR TITLE
Update the heuristic for AArch64 bmm/baddbmm (F32 only)

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1360,43 +1360,6 @@ Tensor outer(const Tensor& self, const Tensor& vec2) {
 #endif
 #endif
 
-
-#if !defined(__aarch64__) || AT_MKLDNN_ACL_ENABLED()
-// Used by default on x86 platforms and on AArch64+ACL
-static inline int64_t get_mkldnn_matmul_min_dim() {
-  static auto value = [&] {
-    const int64_t default_min_dim = [&] {
-      // Minimum dimension requirement for MKLDNN; derived based on experiments.
-      //it's enabled on all Neoverse cpus.
-      return is_arm_neoverse() ? 8 : 0;
-    }();
-    const auto value = c10::utils::get_env("TORCH_MKLDNN_MATMUL_MIN_DIM");
-    return value.has_value() ? std::stoi(value.value()) : default_min_dim;
-  }();
-  return value;
-}
-
-
-static inline int64_t get_mkldnn_matmul_min_size() {
-  static auto value = [&] {
-    const int64_t default_min_size = [&] {
-      // Minimum size requirement for MKLDNN; derived based on experiments.
-      // it's enabled on all Neoverse cpus.
-      return is_arm_neoverse() ? 8 * 1024 : 0;
-    }();
-    const auto value = c10::utils::get_env("TORCH_MKLDNN_MATMUL_MIN_SIZE");
-    return value.has_value() ? std::stoi(value.value()) : default_min_size;
-  }();
-  return value;
-}
-
-
-static inline bool apply_mkldnn_matmul_heur(int64_t m, int64_t k, int64_t n) {
-  const int64_t min_dim = get_mkldnn_matmul_min_dim();
-  const int64_t min_size = get_mkldnn_matmul_min_size();
-  return at::globalContext().userEnabledMkldnn() && m > min_dim && k > min_dim && n > min_dim && m * k * n > min_size;
-}
-#endif
 static void addmm_impl_cpu_(
     Tensor &result, const Tensor &self, Tensor m1, Tensor m2, const Scalar& beta, const Scalar& alpha) {
   TORCH_INTERNAL_ASSERT(self.dim() == 2 && m1.dim() == 2 && m2.dim() == 2);
@@ -1516,9 +1479,7 @@ static void addmm_impl_cpu_(
   // that will call then into Arm® Compute Library (ACL) GEMM kernel and also
   // additionally have support for running kernel with BF16 instructions
   if (transpose_c) {
-    bool apply_heur =
-        apply_mkldnn_matmul_heur(b.sizes()[0], b.sizes()[1], a.sizes()[1]);
-    if (apply_heur && transpose_a && !transpose_b &&
+    if (use_mkldnn_matmul(b, a, c)  && transpose_a && !transpose_b &&
         (result.scalar_type() == at::ScalarType::Float ||
          result.scalar_type() == at::ScalarType::BFloat16 ||
          result.scalar_type() == at::ScalarType::Half)) {
@@ -1776,10 +1737,10 @@ static inline void bmm_out_or_baddbmm_(const Tensor& self_or_result_, const Tens
     return (strides[2] == 1 && (sizes[1] == 1 || strides[1] >= sizes[2])) ||
         (strides[1] == 1 && (sizes[2] == 1 || strides[2] >= sizes[1]));
   };
+
 #if !defined(__aarch64__) || AT_MKLDNN_ACL_ENABLED()
   // Always apply mkldnn heuristic on x86 platform, but on ARM only if compiled with ACL
-  bool apply_heur = apply_mkldnn_matmul_heur(batch1.sizes()[1], batch1.sizes()[2], batch2.sizes()[2]);
-  if (apply_heur && use_mkldnn_matmul(batch1, batch2, self_or_result)) {
+  if (use_mkldnn_matmul(batch1, batch2, self_or_result)) {
     try {
       mkldnn_matmul(batch1, batch2, self_or_result, beta.to<float>(), alpha.to<float>());
       return;

--- a/aten/src/ATen/native/mkldnn/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/Matmul.cpp
@@ -423,7 +423,7 @@ void mkldnn_matmul(
 
 }
 
-#if defined(__aarch64__)
+#if AT_MKLDNN_ACL_ENABLED()
 // Experimentally derived heuristics for MKLDNN+ACL on NEOVERSE cores
 static inline int64_t get_mkldnn_acl_addmm_min_dim() {
   static auto value = [&] {
@@ -473,7 +473,7 @@ inline bool checksize(const Tensor& mat1, const Tensor& mat2){
     return mat1.size(0) * mat1.size(1) > mkldnn_gemm_min_size;
   } else if (mat1.dim() == 2 && mat2.dim() == 2) {
     // aten::addmm
-#if defined(__aarch64__)
+#if AT_MKLDNN_ACL_ENABLED()
     const int64_t mkldnn_acl_addmm_min_dim = get_mkldnn_acl_addmm_min_dim();
     const int64_t mkldnn_acl_addmm_min_size = get_mkldnn_acl_addmm_min_size();
     // M > MIN_DIM and N > MIN_DIM and K > MIN_DIM and M*N*K > MIN_SIZE
@@ -486,7 +486,7 @@ inline bool checksize(const Tensor& mat1, const Tensor& mat2){
 #endif
   } else {
     // aten::bmm, aten::baddbmm
-#if defined(__aarch64__)
+#if AT_MKLDNN_ACL_ENABLED()
     const int64_t mkldnn_acl_bmm_baddbmm_threshold = get_mkldnn_acl_bmm_baddbmm_threshold();
     // BATCH_SIZE^2 * M * N * K >= THRESHOLD
     return mat1.size(0) * mat1.size(0) * mat1.size(1) * mat1.size(2) * mat2.size(2) >= mkldnn_acl_bmm_baddbmm_threshold;

--- a/aten/src/ATen/native/mkldnn/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/Matmul.cpp
@@ -423,7 +423,43 @@ void mkldnn_matmul(
 
 }
 
-static inline bool checksize(const Tensor& mat1, const Tensor& mat2){
+#if defined(__aarch64__)
+// Experimentally derived heuristics for MKLDNN+ACL on NEOVERSE cores
+static inline int64_t get_mkldnn_acl_addmm_min_dim() {
+  static auto value = [&] {
+    const int64_t default_min_dim = [&] {
+      return is_arm_neoverse() ? 8 : 0;
+    }();
+    const char* ptr = std::getenv("TORCH_MKLDNN_ADDMM_MIN_DIM");
+    return ptr != nullptr ? std::atoi(ptr) : default_min_dim;
+  }();
+  return value;
+}
+
+static inline int64_t get_mkldnn_acl_addmm_min_size() {
+  static auto value = [&] {
+    const int64_t default_min_size = [&] {
+      return is_arm_neoverse() ? 8 * 1024 : 0;
+    }();
+    const char* ptr = std::getenv("TORCH_MKLDNN_ADDMM_MIN_SIZE");
+    return ptr != nullptr ? std::atoi(ptr) : default_min_size;
+  }();
+  return value;
+}
+
+static inline int64_t get_mkldnn_acl_bmm_baddbmm_threshold() {
+  static auto value = [&] {
+    const int64_t default_threshold = [&] {
+      return is_arm_neoverse() ? 1L << 22 : 0;
+    }();
+    const char* ptr = std::getenv("TORCH_MKLDNN_BMM_BADDBMM_THRESHOLD");
+    return ptr != nullptr ? std::atoi(ptr) : default_threshold;
+  }();
+  return value;
+}
+#endif
+
+inline bool checksize(const Tensor& mat1, const Tensor& mat2){
   // if dim = 2, mat1's size = (m * n), mat2's size = (n * k)
   // else if dim = 3, mat1's size = (b * m * n), mat2's size = (b * n * k)
   // else called from aten::mv, mat1.size = (m * n), mat2.size = (n)
@@ -437,10 +473,26 @@ static inline bool checksize(const Tensor& mat1, const Tensor& mat2){
     return mat1.size(0) * mat1.size(1) > mkldnn_gemm_min_size;
   } else if (mat1.dim() == 2 && mat2.dim() == 2) {
     // aten::addmm
+#if defined(__aarch64__)
+    const int64_t mkldnn_acl_addmm_min_dim = get_mkldnn_acl_addmm_min_dim();
+    const int64_t mkldnn_acl_addmm_min_size = get_mkldnn_acl_addmm_min_size();
+    // M > MIN_DIM and N > MIN_DIM and K > MIN_DIM and M*N*K > MIN_SIZE
+    return mat1.size(0) > mkldnn_acl_addmm_min_dim
+        && mat1.size(1) > mkldnn_acl_addmm_min_dim
+        && mat2.size(1) > mkldnn_acl_addmm_min_dim
+        && mat1.size(0) * mat1.size(1) * mat2.size(1) > mkldnn_acl_addmm_min_size;
+#else
     return mat1.size(0) * mat1.size(1) * mat2.size(1) > mkldnn_gemm_min_size;
+#endif
   } else {
     // aten::bmm, aten::baddbmm
+#if defined(__aarch64__)
+    const int64_t mkldnn_acl_bmm_baddbmm_threshold = get_mkldnn_acl_bmm_baddbmm_threshold();
+    // BATCH_SIZE^2 * M * N * K >= THRESHOLD
+    return mat1.size(0) * mat1.size(0) * mat1.size(1) * mat1.size(2) * mat2.size(2) >= mkldnn_acl_bmm_baddbmm_threshold;
+#else
     return mat1.size(0) * mat1.size(1) * mat1.size(2) * mat2.size(2) > mkldnn_gemm_min_size;
+#endif
   }
 }
 

--- a/aten/src/ATen/native/mkldnn/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/Matmul.cpp
@@ -423,7 +423,7 @@ void mkldnn_matmul(
 
 }
 
-#if AT_MKLDNN_ACL_ENABLED()
+#if AT_MKLDNN_ACL_ENABLED() && !defined(FBCODE_CAFFE2)
 // Experimentally derived heuristics for MKLDNN+ACL on NEOVERSE cores
 static inline int64_t get_mkldnn_acl_addmm_min_dim() {
   static auto value = [&] {
@@ -473,7 +473,7 @@ inline bool checksize(const Tensor& mat1, const Tensor& mat2){
     return mat1.size(0) * mat1.size(1) > mkldnn_gemm_min_size;
   } else if (mat1.dim() == 2 && mat2.dim() == 2) {
     // aten::addmm
-#if AT_MKLDNN_ACL_ENABLED()
+#if AT_MKLDNN_ACL_ENABLED() && !defined(FBCODE_CAFFE2)
     const int64_t mkldnn_acl_addmm_min_dim = get_mkldnn_acl_addmm_min_dim();
     const int64_t mkldnn_acl_addmm_min_size = get_mkldnn_acl_addmm_min_size();
     // M > MIN_DIM and N > MIN_DIM and K > MIN_DIM and M*N*K > MIN_SIZE
@@ -486,7 +486,7 @@ inline bool checksize(const Tensor& mat1, const Tensor& mat2){
 #endif
   } else {
     // aten::bmm, aten::baddbmm
-#if AT_MKLDNN_ACL_ENABLED()
+#if AT_MKLDNN_ACL_ENABLED() && !defined(FBCODE_CAFFE2)
     const int64_t mkldnn_acl_bmm_baddbmm_threshold = get_mkldnn_acl_bmm_baddbmm_threshold();
     // BATCH_SIZE^2 * M * N * K >= THRESHOLD
     return mat1.size(0) * mat1.size(0) * mat1.size(1) * mat1.size(2) * mat2.size(2) >= mkldnn_acl_bmm_baddbmm_threshold;


### PR DESCRIPTION
Updates heuristic for bmm/baddbmm and consolidates all heuristic logic in a single location

 - The goal of the consolidation is to improve maintainability and readability of the heuristic logic. Instead of different parts scattered across two files, this patch centralizes everything inside `Matmul.cpp`, where there already exists heuristic-based selection for mkldnn.
 - The logic of the check itself doesn't change (existing code is reused where possible) but a separate heuristic threshold for bmm/baddbmm is introduced based on newer, benchmarking data. Use the script below to see the performance improvement for bmm from the new heuristic:
 ```
import torch
import time

# Set below to True to use cases selected by only one of the hueristics.
USE_ONLY_DIVERGENT_TEST_CASES = True   
BATCH_SIZES  = [ 1, 8, 32, 64, 128, 256 ]
M_DIMS       = [ 4, 8, 16, 32, 64, 256, 512 ]
N_DIMS       = [ 4, 8, 16, 32, 64, 256, 512 ]
K_DIMS       = [ 4, 8, 16, 32, 64, 256, 512 ]
ITERS = 50

def old_heuristic(m, n, k):
     is_above_min_dims = m > 8 and n > 8 and k > 8
     is_above_min_size = m*n*k > 8_192
     return is_above_min_dims and is_above_min_size

def new_heuristic(b, m, n, k):
     return b*b*m*n*k >= 4_194_304

def generate_test_cases():
    test_cases = []
    for b in BATCH_SIZES:
        for m in M_DIMS:
            for n in N_DIMS:
                    for k in K_DIMS:
                        if USE_ONLY_DIVERGENT_TEST_CASES:
                            if old_heuristic(m, n, k) != new_heuristic(b, m, n, k):
                                test_cases.append([b, m, n, k])
                        else:
                            test_cases.append([b, m, n, k])
    return test_cases

def test(x, y):
    for _ in range(5):
        torch.bmm(x, y)
    perf = 0.0
    for _ in range(ITERS):
        start = time.time()
        torch.bmm(x, y)
        end = time.time()
        perf += (end - start) / ITERS
    return perf

def main():
    print(f"{'b':<10}{'m':<10}{'n':<10}{'k':<10}{'time (s)':10}")
    cumulative_mean_time = 0.0
    for b, m, n, k in generate_test_cases():
        mean_time = test(torch.rand(b, m, n), torch.rand(b, n, k))
        cumulative_mean_time += mean_time
        print(f"{b:<10}{m:<10}{n:<10}{k:<10}{mean_time:10.3e}")
    print(f"Cumulative mean time = {cumulative_mean_time:.4f} s")


if __name__ == "__main__":
    main()
```

From the script we see that cumulative mean time from all test cases (at 16 threads) is:
 - 1.6195 s for the old heuristic
 - 0.7012 s for the new heuristic

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @snadampal @milpuz01 @nikhil-arm @fadara01 @robert-hardwick @nWEIdia @malfet