### PR TITLE
SubsetRandomSampler - changed iteration over tensor to iteration over list

### DIFF
--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -210,7 +210,7 @@ class SubsetRandomSampler(Sampler[int]):
         self.generator = generator
 
     def __iter__(self) -> Iterator[int]:
-        for i in torch.randperm(len(self.indices), generator=self.generator):
+        for i in torch.randperm(len(self.indices), generator=self.generator).tolist():
             yield self.indices[i]
 
     def __len__(self) -> int:


### PR DESCRIPTION
Digging further the problem at https://github.com/UKPLab/sentence-transformers/pull/3261, it boils down to this expensive loop over a torch tensor. Looping over a list, like in RandomSampler, solves the issue.

