### PR TITLE
Use TorchVersion for triton version check

### DIFF
--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -55,16 +55,6 @@ from .mm_common import (
 )
 
 
-def parse_version(version_string: str) -> Optional[tuple[int, ...]]:
-    pattern = r"(\d+)\.(\d+)?"
-    match = re.match(pattern, version_string)
-
-    if match:
-        return tuple(int(group) for group in match.groups())
-    else:
-        return None
-
-
 try:
     import triton
 
@@ -146,8 +136,7 @@ mm_template = TritonTemplate(
     # inductor generates a suffix
     {{store_output(("idx_m", "idx_n"), "acc", "mask")}}
 """
-        if (torch.version.hip is None)
-        or (has_triton and triton_version >= "3.3.0")
+        if (torch.version.hip is None) or (has_triton and triton_version >= "3.3.0")
         # FIXME: To get around rocm failures like https://github.com/pytorch/pytorch/actions/runs/13123783322/job/36617154943
         # The only difference between the two templates is M >= BLOCK_M and N >= BLOCK_N checking.
         # See more details in https://github.com/pytorch/pytorch/pull/146293

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -71,7 +71,7 @@ try:
     triton_version = TorchVersion(triton.__version__)
     has_triton = True
 except ImportError:
-    triton_version = None
+    triton_version = TorchVersion("0.0.0")
     has_triton = False
 
 log = logging.getLogger(__name__)

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -136,7 +136,7 @@ mm_template = TritonTemplate(
     # inductor generates a suffix
     {{store_output(("idx_m", "idx_n"), "acc", "mask")}}
 """
-        if (torch.version.hip is None) or (has_triton and triton_version >= "3.3.0")
+        if (torch.version.hip is None) or triton_version >= "3.3.0"
         # FIXME: To get around rocm failures like https://github.com/pytorch/pytorch/actions/runs/13123783322/job/36617154943
         # The only difference between the two templates is M >= BLOCK_M and N >= BLOCK_N checking.
         # See more details in https://github.com/pytorch/pytorch/pull/146293


### PR DESCRIPTION
Followup after https://github.com/pytorch/pytorch/pull/149092#issuecomment-2721990321
To use TorchVersion for triton version parsing


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov