### PR TITLE
ci: Update linux.20_04 --> linux.24_04

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,7 +7,7 @@ self-hosted-runner:
     - linux.20_04.4x
     - linux.20_04.16x
     - linux.24_04.4x
-    - linux.20_04.16x
+    - linux.24_04.16x
     # Organization-wide AWS Linux Runners
     - linux.large
     - linux.2xlarge

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,7 +3,10 @@ self-hosted-runner:
     # GitHub hosted runner that actionlint doesn't recognize because actionlint version (1.6.21) is too old
     - ubuntu-24.04
     # GitHub hosted x86 Linux runners
+    # TODO: Cleanup mentions of linux.20_04 when upgrade to linux.24_04 is complete
     - linux.20_04.4x
+    - linux.20_04.16x
+    - linux.24_04.4x
     - linux.20_04.16x
     # Organization-wide AWS Linux Runners
     - linux.large

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -35,7 +35,7 @@ jobs:
       pull-requests: write
     name: Check labels
     if: github.repository_owner == 'pytorch'
-    runs-on: linux.20_04.4x
+    runs-on: linux.24_04.4x
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -243,8 +243,15 @@ jobs:
     name: Test collect_env
     runs-on: linux.24_04.4x
     strategy:
-      matrix:
-        test_type: [with_torch, without_torch, older_python_version]
+      include:
+        - test_type: with_torch
+          runner: linux.24_04.4x
+        - test_type: without_torch
+          runner: linux.24_04.4x
+        # NOTE: The oldest supported version of python for 24.04 is 3.8
+        #       so this cannot be updated if we want to keep this test at 3.6
+        - test_type: older_python_version
+          runner: linux.20_04.4x
     steps:
       # [see note: pytorch repo ref]
       # deep clone (fetch-depth 0) required, to allow us to use git log
@@ -264,7 +271,7 @@ jobs:
         if: matrix.test_type == 'older_python_version'
         uses: actions/setup-python@v4
         with:
-          python-version: 3.6.15
+          python-version: 3.6
           architecture: x64
           check-latest: false
           cache: pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -243,15 +243,16 @@ jobs:
     name: Test collect_env
     runs-on: ${{ matrix.runner }}
     strategy:
-      include:
-        - test_type: with_torch
-          runner: linux.24_04.4x
-        - test_type: without_torch
-          runner: linux.24_04.4x
-        # NOTE: The oldest supported version of python for 24.04 is 3.8
-        #       so this cannot be updated if we want to keep this test at 3.6
-        - test_type: older_python_version
-          runner: linux.20_04.4x
+      matrix:
+        include:
+          - test_type: with_torch
+            runner: linux.24_04.4x
+          - test_type: without_torch
+            runner: linux.24_04.4x
+          # NOTE: The oldest supported version of python for 24.04 is 3.8
+          #       so this cannot be updated if we want to keep this test at 3.6
+          - test_type: older_python_version
+            runner: linux.20_04.4x
     steps:
       # [see note: pytorch repo ref]
       # deep clone (fetch-depth 0) required, to allow us to use git log

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -215,7 +215,7 @@ jobs:
   test_run_test:
     name: Test `run_test.py` is usable without boto3
     if: ${{ github.repository == 'pytorch/pytorch' }}
-    runs-on: linux.20_04.4x
+    runs-on: linux.24_04.4x
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
@@ -241,7 +241,7 @@ jobs:
   test_collect_env:
     if: ${{ github.repository == 'pytorch/pytorch' }}
     name: Test collect_env
-    runs-on: linux.20_04.4x
+    runs-on: linux.24_04.4x
     strategy:
       matrix:
         test_type: [with_torch, without_torch, older_python_version]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -264,7 +264,7 @@ jobs:
         if: matrix.test_type == 'older_python_version'
         uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: 3.6.15
           architecture: x64
           check-latest: false
           cache: pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -241,7 +241,7 @@ jobs:
   test_collect_env:
     if: ${{ github.repository == 'pytorch/pytorch' }}
     name: Test collect_env
-    runs-on: linux.24_04.4x
+    runs-on: ${{ matrix.runner }}
     strategy:
       include:
         - test_type: with_torch

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   do_revert:
     name: try_revert_pr_${{ github.event.client_payload.pr_num }}
-    runs-on: linux.20_04.4x
+    runs-on: linux.24_04.4x
     environment: mergebot
     env:
         GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   do_merge:
     name: try_merge_pr_${{ github.event.client_payload.pr_num }}
-    runs-on: linux.20_04.4x
+    runs-on: linux.24_04.4x
     environment: mergebot
     permissions:
       id-token: write


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149142

Ubuntu 20.04 is getting deprecated soon so we might as well proactively
move to the latest LTS which is 24.04

> [!NOTE]
> The oldest supported version of python on 24.04 is Python 3.8. Since we test for Python 3.6 compat in our collect_env test we need to have this particular job stick with 20.04 for now until we decide to upgrade it to a newer python version.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>