### PR TITLE
Clean up grid in execution trace

### DIFF
--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -389,6 +389,9 @@ class TestExecutionTrace(TestCase):
         # Create a temp file to save execution trace data.
         fp = tempfile.NamedTemporaryFile("w+t", suffix="_et.json", delete=False)
         fp.close()
+        et = ExecutionTraceObserver()
+        et.register_callback(fp.name)
+        et.set_extra_resource_collection(True)
 
         with profile(
             activities=torch.profiler.supported_activities(),
@@ -396,9 +399,7 @@ class TestExecutionTrace(TestCase):
             schedule=torch.profiler.schedule(
                 skip_first=3, wait=1, warmup=1, active=2, repeat=1
             ),
-            execution_trace_observer=(
-                ExecutionTraceObserver().register_callback(fp.name)
-            ),
+            execution_trace_observer=et,
         ) as p:
             for idx in range(10):
                 with record_function(f"## LOOP {idx} ##"):

--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -606,15 +606,6 @@ static void handleKernelBackendInfo(
             fc.kernelFile.substr(fc.kernelFile.find_last_of('/') + 1);
       }
 
-      // get grid information
-      TORCH_INTERNAL_ASSERT(
-          kwinputs.find("grid") != kwinputs.end(),
-          "grid is missing in triton kernel");
-      fc.inputValues.emplace_back(
-          "\"" + kwinputs.at("grid").toStringRef() + "\"");
-      fc.inputTypes.emplace_back("\"String\"");
-      fc.inputShapes.emplace_back("[]");
-
       // get stream information
       TORCH_INTERNAL_ASSERT(
           kwinputs.find("stream") != kwinputs.end(),


### PR DESCRIPTION
Summary: This DIFF https://www.internalfb.com/diff/D70471332 removed input "grid" when calling triton kernel. PyTorch execution trace need to make the appropriate change. It includes capturing ET and replay ET.

Test Plan:
buck2 run mode/opt caffe2/test:test_profiler_cuda  -- profiler.test_execution_trace.TestExecutionTraceCUDA.test_execution_trace_with_pt2_cuda

buck2 run mode/opt param_bench/fb/integration_tests:test_et_replay

Differential Revision: D71152464


