### PR TITLE
[MPSInductor] Add `bessel_[jy][01]` ops

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -122,6 +122,15 @@ class MPSBasicTests(TestCase):
     def test_pointwise_bessel_j0(self):
         self.common(torch.special.bessel_j0, (torch.rand(128, 128),), check_lowp=True)
 
+    def test_pointwise_bessel_j1(self):
+        self.common(torch.special.bessel_j1, (torch.rand(128, 128),), check_lowp=True)
+
+    def test_pointwise_bessel_y0(self):
+        self.common(torch.special.bessel_y0, (torch.rand(128, 128),), check_lowp=False)
+
+    def test_pointwise_bessel_y1(self):
+        self.common(torch.special.bessel_y1, (torch.rand(128, 128),), check_lowp=True)
+
     def test_pointwise_xlog1py(self):
         self.common(
             torch.special.xlog1py,

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -119,6 +119,9 @@ class MPSBasicTests(TestCase):
             torch.special.spherical_bessel_j0, (torch.rand(128, 128),), check_lowp=False
         )
 
+    def test_pointwise_bessel_j0(self):
+        self.common(torch.special.bessel_j0, (torch.rand(128, 128),), check_lowp=True)
+
     def test_pointwise_xlog1py(self):
         self.common(
             torch.special.xlog1py,

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -374,6 +374,22 @@ class MetalOverrides(OpOverrides):
     def entr(x: CSEVariable) -> str:
         return f"c10::metal::entr({x})"
 
+    @staticmethod
+    def bessel_j0(x: CSEVariable) -> str:
+        return f"c10::metal::bessel_j0_forward({x})"
+
+    @staticmethod
+    def bessel_j1(x: CSEVariable) -> str:
+        return f"c10::metal::bessel_j1_forward({x})"
+
+    @staticmethod
+    def bessel_y0(x: CSEVariable) -> str:
+        return f"c10::metal::bessel_y0_forward({x})"
+
+    @staticmethod
+    def bessel_y1(x: CSEVariable) -> str:
+        return f"c10::metal::bessel_y1_forward({x})"
+
 
 MetalOverrides._initialize_pointwise_overrides("mps")
 
@@ -527,9 +543,9 @@ class MetalKernel(SIMDKernel):
                 dtype=dtype,
             )
         if reduction_type == "welford_reduce":
-            assert not self.multistage_reduction, (
-                f"Multistage reduction not yet supported for {reduction_type}"
-            )
+            assert (
+                not self.multistage_reduction
+            ), f"Multistage reduction not yet supported for {reduction_type}"
             acc_buf = self._new_accvar(src_dtype, acc_buf_size)
             self.compute.splice(f"{acc_buf}[{reduction_dim.name}] = {value};")
             wf_res = self.cse.generate(

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -543,9 +543,9 @@ class MetalKernel(SIMDKernel):
                 dtype=dtype,
             )
         if reduction_type == "welford_reduce":
-            assert (
-                not self.multistage_reduction
-            ), f"Multistage reduction not yet supported for {reduction_type}"
+            assert not self.multistage_reduction, (
+                f"Multistage reduction not yet supported for {reduction_type}"
+            )
             acc_buf = self._new_accvar(src_dtype, acc_buf_size)
             self.compute.splice(f"{acc_buf}[{reduction_dim.name}] = {value};")
             wf_res = self.cse.generate(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149179
* #149123

By simply calling corresponding special functions

Followup TODO: tweak bessel_y0 to match CPU implementation for `torch.half` dtype

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov