### PR TITLE
Add side_effect to avoid dce custom op in CA graph

### DIFF
--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -737,6 +737,10 @@ class AutogradCompilerInstance:
                 or node.op == "placeholder"
                 or node.op == "output"
                 or (node.op == "call_function" and node.target in _impure_targets)
+                or (
+                    node.op == "call_function"
+                    and node.target in torch.fx.node._side_effectful_functions
+                )
             )
 
         before = len(self.fx_tracer.graph.nodes)


### PR DESCRIPTION
We found that in compiled_autograd, when defining custom op, the custom op will be dce in the backward graph. We added a side effect condition in the dce function to prevent eliminating custom op with side effect in CA graph.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @xmfan