### PR TITLE
[assoc_scan/scan] Added testcase for complex tensors

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -2028,8 +2028,9 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1, arg5_1):
     @requires_cuda
     @parametrize("reverse", [False, True])
     @parametrize("device", [torch.device("cpu"), torch.device("cuda")])
-    def test_scan_binary_operator_complex(self, reverse, device):
-        A = torch.randn(10, 3, 10, dtype=torch.complex64, device=device)
+    @parametrize("dtype", [torch.complex64, torch.complex128])
+    def test_scan_binary_operator_complex(self, reverse, device, dtype):
+        A = torch.randn(10, 3, 10, dtype=dtype, device=device)
         projected_inputs = torch.ones_like(A) * 0.9 + torch.ones_like(A) * 0.08j
         elements = (A, projected_inputs)
         init = tuple(
@@ -3807,6 +3808,7 @@ class AssociativeScanTests(TestCase):
     @parametrize("combine_mode", ["pointwise", "generic"])
     @parametrize("reverse", [False, True])
     @parametrize("device", [torch.device("cpu"), torch.device("cuda")])
+    @parametrize("dtype", [torch.complex64, torch.complex128])
     # Skipping the combination of combine_mode=pointwise and device=cpu
     # as the current implementation of pointwise does only support CUDA device
     @decorateIf(
@@ -3817,9 +3819,9 @@ class AssociativeScanTests(TestCase):
         ),
     )
     def test_associative_scan_binary_operator_complex(
-        self, compile_mode, combine_mode, reverse, device
+        self, compile_mode, combine_mode, reverse, device, dtype
     ):
-        A = torch.randn(10, 3, 10, dtype=torch.complex64, device=device)
+        A = torch.randn(10, 3, 10, dtype=dtype, device=device)
         projected_inputs = torch.ones_like(A) * 0.9 + torch.ones_like(A) * 0.08j
         elements = (A, projected_inputs)
 

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -2030,7 +2030,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1, arg5_1):
     @parametrize("device", [torch.device("cpu"), torch.device("cuda")])
     def test_scan_binary_operator_complex(self, reverse, device):
         A = torch.randn(10, 3, 10, dtype=torch.complex64, device=device)
-        projected_inputs = torch.ones_like(A) * 0.98j + torch.ones_like(A) * 0.98j
+        projected_inputs = torch.ones_like(A) * 0.9 + torch.ones_like(A) * 0.08j
         elements = (A, projected_inputs)
         init = tuple(
             [
@@ -3820,7 +3820,7 @@ class AssociativeScanTests(TestCase):
         self, compile_mode, combine_mode, reverse, device
     ):
         A = torch.randn(10, 3, 10, dtype=torch.complex64, device=device)
-        projected_inputs = torch.ones_like(A) * 0.98j + torch.ones_like(A) * 0.98j
+        projected_inputs = torch.ones_like(A) * 0.9 + torch.ones_like(A) * 0.08j
         elements = (A, projected_inputs)
 
         kwargs = {


### PR DESCRIPTION
We have a user @largraf using associative_scan with complex tensors. Thus, I wanted to add a test case to ensure that a `combine_fn` working on complex tensors is working with `associative_scan` and `scan`.

The tests do fail though with `torch.complex32`, potentially due to numerical precision issues? Furthermore, some operations, such as the scatter gather function (`o.scatter_(0, ind * idx, x.unsqueeze(0))`), are not implemented for `ComplexHalf` yet. Do we need to support that at the moment?

cc @ydwu4 