### PR TITLE
[CI INFRA TEST] Test experiment for ephemeral runners

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1498,6 +1498,9 @@ def main():
     if EMIT_BUILD_WARNING:
         print_box(build_update_message)
 
+'''
+A comment to test
+'''
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Just running the ci with the `ephemeral` experiment defined in https://github.com/pytorch/test-infra/issues/5132

This will run CI in meta's infra, with the ephemeral reuse changes. And force to only use ephemral runners from the autoscaler pool.

The goal of this experiment is evaluate queue time and if runners are stuck not picking up jobs. As well to evaluate if the experiment will suceed.