### PR TITLE
[prototype] in memory checkpoint example

### DIFF
--- a/torch/distributed/checkpoint/_in_memory_checkpoint.py
+++ b/torch/distributed/checkpoint/_in_memory_checkpoint.py
@@ -1,0 +1,414 @@
+import logging
+import mmap
+import os
+import pickle
+import tempfile
+import socket
+from multiprocessing import shared_memory
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Callable, cast, Generator, Optional, TypeVar, Union
+
+import time
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed import ProcessGroup, Work
+from torch.distributed.tensor import _DTensorSpec, DTensor
+from torch.utils._pytree import (
+    KeyPath,
+    tree_flatten_with_path,
+    tree_unflatten,
+    TreeSpec,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+@dataclass
+class _TensorMeta:
+    """
+    This is the metadata for a tensor that is used to transfer checkpoints.
+    It contains the shape, the dtype, the storage offset and the stride of the
+    tensor.
+
+    This must be pickleable so that it can be sent over the wire.
+    """
+
+    shape: torch.Size
+    dtype: torch.dtype
+    storage_offset: int
+    stride: tuple[int, ...]
+    nbytes: int
+
+
+@dataclass
+class _DTensorMeta:
+    """
+    This is the metadata for a DTensor that is used to transfer checkpoints.
+    It contains the metadata for the local tensor and the spec of the DTensor.
+
+    This must be pickleable so that it can be sent over the wire.
+    """
+
+    local: _TensorMeta
+    spec: _DTensorSpec
+
+
+@dataclass
+class _StateDictMeta:
+    """
+    This is the metadata for a state dict that is used to transfer checkpoints.
+    It contains the step, the pytree spec of the state dict and the metadata for
+    each tensor in the state dict.
+
+    This must be pickleable so that it can be sent over the wire.
+
+    Args:
+        step: the step of the checkpoint to verify consistency
+        treespec: the pytree spec of the state dict
+        paths: the path of each leaf in the state dict
+        non_tensor_leaves: the metadata for each tensor in the state dict and any
+            non-tensor leaves in the state dict
+    """
+
+    step: int
+    treespec: TreeSpec
+    paths: list[KeyPath]
+    non_tensor_leaves: list[Union[object, _TensorMeta, _DTensorMeta]]
+
+
+@contextmanager
+def _timeit(name: str) -> Generator[None, None, None]:
+    start = time.perf_counter()
+    yield
+    dur = time.perf_counter() - start
+    logger.info(f"{name} took {dur}s")
+
+
+def _prepare_tensor(tensor: torch.Tensor) -> tuple[torch.Tensor, _TensorMeta]:
+    return (
+        _cast_tensor(tensor, torch.uint8),
+        _TensorMeta(
+            shape=tensor.shape,
+            dtype=tensor.dtype,
+            storage_offset=cast(int, tensor.storage_offset()),
+            stride=tensor.stride(),
+            nbytes=tensor.untyped_storage().nbytes(),
+        ),
+    )
+
+
+def _prepare_state_dict(
+    state_dict: object,
+    step: int,
+    device: torch.device,
+) -> tuple[_StateDictMeta, list[torch.Tensor]]:
+    leaves: list[tuple[KeyPath, object]]
+    leaves, treespec = tree_flatten_with_path(state_dict)
+
+    paths: list[KeyPath] = []
+    non_tensor_leaves: list[Union[object, _TensorMeta, _DTensorMeta]] = []
+    tensors: list[torch.Tensor] = []
+    for key_path, v in leaves:
+        paths.append(key_path)
+
+        if isinstance(v, DTensor):
+            tensor, tensor_meta = _prepare_tensor(v._local_tensor)
+
+            tensors.append(tensor)
+
+            non_tensor_leaves.append(
+                _DTensorMeta(
+                    local=tensor_meta,
+                    spec=v._spec,
+                )
+            )
+        elif isinstance(v, torch.Tensor):
+            tensor, tensor_meta = _prepare_tensor(v)
+            tensors.append(tensor)
+            non_tensor_leaves.append(tensor_meta)
+        else:
+            non_tensor_leaves.append(v)
+
+    return (
+        _StateDictMeta(
+            step=step,
+            treespec=treespec,
+            paths=paths,
+            non_tensor_leaves=non_tensor_leaves,
+        ),
+        tensors,
+    )
+
+
+def _cast_tensor(tensor: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    """
+    Casts the underlying storage to a tensor of the given dtype.
+
+    The returned tensor will be of size ``storage.nbytes``.
+
+    This works for all datatypes and supports strided/offset tensors with the
+    caveat that the cast tensor may be larger than the original tensor due to
+    the differences in striding.
+    """
+    assert (
+        type(tensor) is torch.Tensor
+    ), f"can only cast standard tensors not {type(tensor)}"
+    storage = tensor.untyped_storage()
+    ret = torch.tensor(storage, dtype=dtype, device=tensor.device)
+    assert ret.untyped_storage() is storage, "storage should be the same"
+    return ret
+
+
+class InMemoryStorage:
+    """
+    In memory storage for checkpointing. This is a simple in memory storage which 
+    uses shared memory to store the checkpoint. 1 process keeps this alive and other 
+    processes can access it. TODO: can also save the memory to temporary files and load it via mmap
+    """
+    def __init__(self):
+        self._storage = {}
+
+    def save(self, key: str, data: object) -> None:
+        serialized_data = pickle.dumps(data)
+        data_size = len(serialized_data)
+        shm = shared_memory.SharedMemory(create=True, size=data_size)
+        shm.buf[:data_size] = serialized_data
+        # Store the shared memory name and size
+        self._storage[key] = (shm.name, data_size)
+
+    def load(self, key: str) -> object:
+        if key not in self._storage:
+            raise KeyError(f"No data found for key: {key}")
+        # Retrieve shared memory name and size
+        shm_name, data_size = self._storage[key]
+        # Access the shared memory
+        existing_shm = shared_memory.SharedMemory(name=shm_name)
+        serialized_data = bytes(existing_shm.buf[:data_size])
+        data = pickle.loads(serialized_data)
+        # Close the shared memory
+        existing_shm.close()
+        return data
+
+    def clear(self) -> None:
+        # Unlink all shared memory objects
+        for shm_name, _ in self._storage.values():
+            existing_shm = shared_memory.SharedMemory(name=shm_name)
+            existing_shm.unlink()
+        self._storage.clear()
+
+
+class PGTransport:
+    """
+    This is a checkpoint transport that uses the process group to transfer checkpoints.
+    This allows for fast recovery of workers by fetching the current weights
+    from an existing worker.
+
+    Args:
+        pg: the process group to use for communication
+        timeout: the timeout for communication
+        device: the device to use for tensors
+        state_dict: if specified this function will be called to do an inplace
+            receive into the returned state_dict. This is much faster than
+            having to allocate new tensors and transferring them to the CPU.
+    """
+
+    def __init__(
+        self,
+        pg: ProcessGroup,
+        timeout: timedelta,
+        device: torch.device,
+        state_dict: Optional[Callable[[], object]] = None,
+    ) -> None:
+        self._work: list[Work] = []
+        self._pg = pg
+        self._timeout = timeout
+        self._device = device
+        self._state_dict = state_dict
+
+    def metadata(self) -> str:
+        return "<n/a>"
+
+    def disallow_checkpoint(self) -> None:
+        pass
+
+    def send_checkpoint(
+        self, dst_ranks: list[int], step: int, state_dict: T, timeout: timedelta
+    ) -> None:
+        with _timeit("preparing state_dict"):
+            meta, tensors = _prepare_state_dict(state_dict, step, device=self._device)
+
+        work = []
+
+        with _timeit("send pickle"):
+            buf = pickle.dumps(meta)
+            len_t = torch.tensor([len(buf)], dtype=torch.int64, device=self._device)
+            buf_t = torch.frombuffer(buf, dtype=torch.uint8).to(self._device)
+            for dst_rank in dst_ranks:
+                work.append(self._pg.send([len_t], dst_rank, tag=1))
+                work.append(self._pg.send([buf_t], dst_rank, tag=2))
+
+        with _timeit("send tensors"):
+            for i, t in enumerate(tensors):
+                original_device = t.device
+                t = t.to(self._device)
+                for dst_rank in dst_ranks:
+                    work.append(self._pg.send([t], dst_rank, tag=3 + i))
+
+                # if we did a copy we should wait for the work to complete so we
+                # can free the memory to avoid OOMs
+                if original_device == torch.device("cpu"):
+                    for w in work:
+                        w.wait(timeout)
+                    work = []
+
+            for w in work:
+                w.wait(timeout)
+
+    def recv_checkpoint(
+        self, src_rank: int, metadata: str, step: int, timeout: timedelta
+    ) -> T:
+        state_dict = self._state_dict() if self._state_dict else {}
+        state_dict_leaves, _ = tree_flatten_with_path(state_dict)
+
+        dst_tensors: dict[KeyPath, object] = dict(state_dict_leaves)
+
+        len_t = torch.zeros(1, dtype=torch.int64, device=self._device)
+        self._pg.recv([len_t], src_rank, tag=1).wait(timeout)
+        length = cast(int, len_t.item())
+
+        assert length > 0, f"invalid metadata length {length=}"
+
+        buf = torch.empty(length, dtype=torch.uint8, device=self._device)
+        self._pg.recv([buf], src_rank, tag=2).wait(timeout)
+
+        meta: _StateDictMeta = pickle.loads(buf.cpu().numpy().tobytes())
+        assert meta.step == step
+
+        i: int = 0
+        works: list[Work] = []
+
+        def recv(path: KeyPath, v: _TensorMeta) -> torch.Tensor:
+            nonlocal i
+
+            inplace = dst_tensors.get(path)
+            if (
+                isinstance(inplace, torch.Tensor)
+                and inplace.device.type == self._device.type
+            ):
+                if isinstance(inplace, DTensor):
+                    inplace = inplace._local_tensor
+                t = _cast_tensor(inplace, torch.uint8)
+                assert (
+                    t.nbytes == v.nbytes
+                ), "inplace tensor storage must be the same size"
+            else:
+                t = torch.empty(v.nbytes, dtype=torch.uint8, device=self._device)
+
+            work = self._pg.recv([t], src_rank, tag=3 + i)
+            i += 1
+
+            if inplace is None:
+                # if not inplace we need to copy it to CPU to avoid OOMing
+                work.wait(timeout)
+                t = t.cpu()
+            else:
+                works.append(work)
+
+            return torch.as_strided(
+                t.view(v.dtype),
+                size=v.shape,
+                stride=v.stride,
+                storage_offset=v.storage_offset,
+            )
+
+        values = []
+        for path, v in zip(meta.paths, meta.non_tensor_leaves):
+            if isinstance(v, _TensorMeta):
+                values.append(recv(path, v))
+            elif isinstance(v, _DTensorMeta):
+                tensor = recv(path, v.local)
+                # pyre-fixme[29]: DTensor is not a function
+                values.append(DTensor(tensor, v.spec, requires_grad=False))
+            else:
+                values.append(v)
+
+        for work in works:
+            work.wait(timeout)
+
+        return tree_unflatten(values, meta.treespec)
+
+
+class ToyModel(nn.Module):
+    def __init__(self):
+        super(ToyModel, self).__init__()
+        self.net1 = nn.Linear(16, 16)
+        self.relu = nn.ReLU()
+        self.net2 = nn.Linear(16, 8)
+
+    def forward(self, x):
+        return self.net2(self.relu(self.net1(x)))
+
+if __name__ == "__main__":
+    # Example usage: torchrun --nproc-per-node=3 torch/distributed/checkpoint/_in_memory_checkpoint.py
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+    pg = dist.new_group(backend="gloo")
+    transport = PGTransport(
+        pg, timeout=timedelta(seconds=30), device=torch.device("cpu")
+    )
+    if rank == 0:
+        # keep this process alive, the storage in memory
+        model = ToyModel()
+        storage = InMemoryStorage()
+        storage.save("sd", model.state_dict())
+        print(f"Rank 0: Saved state_dict. {model.state_dict().keys()=}")
+
+        # Set up a server socket
+        server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server_socket.bind(('localhost', 12345))
+        server_socket.listen(1)
+        print("Rank 0: Server listening for connections...")
+        conn, addr = server_socket.accept()
+        print(f"Rank 0: Connection from {addr}")
+        # Send shared memory name and size
+        shm_name, data_size = storage._storage["sd"]
+        conn.sendall(f"{shm_name},{data_size}".encode('utf-8'))
+        conn.close()
+        storage.clear()
+
+    if rank == 1:
+        # TODO: waiting for server to start up
+        time.sleep(3)
+        # Connect to the server
+        client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        client_socket.connect(('localhost', 12345))
+        # Receive shared memory name and size
+        data = client_socket.recv(1024).decode('utf-8')
+        shm_name, data_size = data.split(',')
+        data_size = int(data_size)
+        client_socket.close()
+
+        # Access the shared memory
+        storage = InMemoryStorage()
+        storage._storage["sd"] = (shm_name, data_size)
+        state_dict = storage.load("sd")
+
+        print(f"Rank 1: Checkpoint loaded. {state_dict.keys()=}")
+        transport.send_checkpoint(
+            dst_ranks=[2], step=1, state_dict=state_dict, timeout=timedelta(seconds=30)
+        )
+        print("Rank 1: Checkpoint sent and saved.")
+    elif rank == 2:
+        # Rank 1 receives the checkpoint
+        received_state_dict = transport.recv_checkpoint(
+            src_rank=1, metadata="", step=1, timeout=timedelta(seconds=30)
+        )
+        print("Rank 2: Checkpoint received")
+    dist.destroy_process_group()

--- a/torch/distributed/checkpoint/_in_memory_checkpoint_example.py
+++ b/torch/distributed/checkpoint/_in_memory_checkpoint_example.py
@@ -1,0 +1,80 @@
+import os
+import socket
+import time
+from datetime import timedelta
+
+from torch.distributed.checkpoint._in_memory_checkpoint import (PGTransport, InMemoryStorage)
+import time
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+class ToyModel(nn.Module):
+    def __init__(self):
+        super(ToyModel, self).__init__()
+        self.net1 = nn.Linear(16, 16)
+        self.relu = nn.ReLU()
+        self.net2 = nn.Linear(16, 8)
+
+    def forward(self, x):
+        return self.net2(self.relu(self.net1(x)))
+
+if __name__ == "__main__":
+    # Example usage:
+    # torchrun --nproc-per-node=3 torch/distributed/checkpoint/_in_memory_checkpoint_example.py
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+    pg = dist.new_group(backend="gloo")
+    transport = PGTransport(
+        pg, timeout=timedelta(seconds=30), device=torch.device("cpu")
+    )
+    if rank == 0:
+        # keep this process alive, the storage in memory
+        model = ToyModel()
+        storage = InMemoryStorage()
+        storage.save("sd", model.state_dict())
+        print(f"Rank 0: Saved state_dict. {model.state_dict().keys()=}")
+
+        # Set up a server socket
+        server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server_socket.bind(('localhost', 12345))
+        server_socket.listen(1)
+        print("Rank 0: Server listening for connections...")
+        conn, addr = server_socket.accept()
+        print(f"Rank 0: Connection from {addr}")
+        # Send shared memory name and size
+        shm_name, data_size = storage._storage["sd"]
+        conn.sendall(f"{shm_name},{data_size}".encode('utf-8'))
+        conn.close()
+        storage.clear()
+
+    if rank == 1:
+        # TODO: waiting for server to start up
+        time.sleep(3)
+        # Connect to the server
+        client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        client_socket.connect(('localhost', 12345))
+        # Receive shared memory name and size
+        data = client_socket.recv(1024).decode('utf-8')
+        shm_name, data_size = data.split(',')
+        data_size = int(data_size)
+        client_socket.close()
+
+        # Access the shared memory
+        storage = InMemoryStorage()
+        storage._storage["sd"] = (shm_name, data_size)
+        state_dict = storage.load("sd")
+
+        print(f"Rank 1: Checkpoint loaded. {state_dict.keys()=}")
+        transport.send_checkpoint(
+            dst_ranks=[2], step=1, state_dict=state_dict, timeout=timedelta(seconds=30)
+        )
+        print("Rank 1: Checkpoint sent and saved.")
+    elif rank == 2:
+        # Rank 1 receives the checkpoint
+        received_state_dict = transport.recv_checkpoint(
+            src_rank=1, metadata="", step=1, timeout=timedelta(seconds=30)
+        )
+        print("Rank 2: Checkpoint received")
+    dist.destroy_process_group()

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -1185,7 +1185,6 @@ def get_state_dict(
 
     :rtype: typing.Tuple[typing.Dict[str, ValueType], OptimizerStateType]
     """
-
     with _gc_context():
         optimizers = (
             (optimizers,)

--- a/torch/distributed/test.ipynb
+++ b/torch/distributed/test.ipynb
@@ -1,0 +1,351 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import torch"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from torch.distributed.checkpoint.state_dict import get_state_dict"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import torch.nn as nn\n",
+        "class ToyModel(nn.Module):\n",
+        "    def __init__(self):\n",
+        "        super(ToyModel, self).__init__()\n",
+        "        self.net1 = nn.Linear(16, 16)\n",
+        "        self.relu = nn.ReLU()\n",
+        "        self.net2 = nn.Linear(16, 8)\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "        return self.net2(self.relu(self.net1(x)))\n",
+        "model = ToyModel()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "optim = torch.optim.Adam(model.parameters(), lr=1e-3)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "model_sd, optim_sd = get_state_dict(model, optim)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "output": {
+          "id": 29333630369555530,
+          "loadingStatus": "loaded"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "Metadata(state_dict_metadata={'net1.weight': TensorStorageMetadata(properties=TensorProperties(dtype=torch.float32, layout=torch.strided, requires_grad=False, memory_format=torch.contiguous_format, pin_memory=False), size=torch.Size([16, 16]), chunks=[ChunkStorageMetadata(offsets=torch.Size([0, 0]), sizes=torch.Size([16, 16]))]), 'net1.bias': TensorStorageMetadata(properties=TensorProperties(dtype=torch.float32, layout=torch.strided, requires_grad=False, memory_format=torch.contiguous_format, pin_memory=False), size=torch.Size([16]), chunks=[ChunkStorageMetadata(offsets=torch.Size([0]), sizes=torch.Size([16]))]), 'net2.weight': TensorStorageMetadata(properties=TensorProperties(dtype=torch.float32, layout=torch.strided, requires_grad=False, memory_format=torch.contiguous_format, pin_memory=False), size=torch.Size([8, 16]), chunks=[ChunkStorageMetadata(offsets=torch.Size([0, 0]), sizes=torch.Size([8, 16]))]), 'net2.bias': TensorStorageMetadata(properties=TensorProperties(dtype=torch.float32, layout=torch.strided, requires_grad=False, memory_format=torch.contiguous_format, pin_memory=False), size=torch.Size([8]), chunks=[ChunkStorageMetadata(offsets=torch.Size([0]), sizes=torch.Size([8]))])}, planner_data={'net1.weight': ('net1.weight',), 'net1.bias': ('net1.bias',), 'net2.weight': ('net2.weight',), 'net2.bias': ('net2.bias',)}, storage_data={MetadataIndex(fqn='net2.bias', offset=torch.Size([0]), index=0): _StorageInfo(relative_path='__0_0.distcp', offset=0, length=1577, transform_descriptors=None), MetadataIndex(fqn='net1.bias', offset=torch.Size([0]), index=0): _StorageInfo(relative_path='__0_0.distcp', offset=1577, length=1641, transform_descriptors=None), MetadataIndex(fqn='net2.weight', offset=torch.Size([0, 0]), index=0): _StorageInfo(relative_path='__0_0.distcp', offset=3218, length=2089, transform_descriptors=None), MetadataIndex(fqn='net1.weight', offset=torch.Size([0, 0]), index=0): _StorageInfo(relative_path='__0_0.distcp', offset=5307, length=2601, transform_descriptors=None)}, storage_meta=StorageMeta(checkpoint_id='.', save_id='3edfe72b-8ac2-4446-b15d-f433627bb4e6', load_id=None, modules=[]))"
+            ]
+          },
+          "execution_count": 22,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "import torch.distributed.checkpoint as dcp\n",
+        "CHECKPOINT_DIR = \".\"\n",
+        "dcp.save(model_sd, checkpoint_id=CHECKPOINT_DIR)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {
+        "output": {
+          "id": 1713451102889440,
+          "loadingStatus": "loaded"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "4229.92s - pydevd: Sending message related to process being replaced timed-out after 5 seconds\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "/data/users/howardhuang\r\n"
+          ]
+        }
+      ],
+      "source": [
+        "!pwd"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {},
+      "outputs": [
+        {
+          "ename": "CheckpointException",
+          "evalue": "CheckpointException ranks:dict_keys([0])\nTraceback (most recent call last): (RANK 0)\n  File \"/home/howardhuang/local/pytorch/torch/distributed/checkpoint/utils.py\", line 192, in reduce_scatter\n    local_data = map_fun()\n  File \"/home/howardhuang/local/pytorch/torch/distributed/checkpoint/logger.py\", line 87, in wrapper\n    result = func(*args, **kwargs)\n  File \"/home/howardhuang/local/pytorch/torch/distributed/checkpoint/state_dict_loader.py\", line 223, in local_step\n    local_plan = planner.create_local_plan()\n  File \"/home/howardhuang/local/pytorch/torch/distributed/checkpoint/default_planner.py\", line 334, in create_local_plan\n    return create_default_local_load_plan(\n  File \"/home/howardhuang/local/pytorch/torch/distributed/checkpoint/default_planner.py\", line 455, in create_default_local_load_plan\n    raise RuntimeError(f\"Missing key in checkpoint state_dict: {fqn}.\")\nRuntimeError: Missing key in checkpoint state_dict: model.net1.weight.\n",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n",
+            "\u001b[0;31mCheckpointException\u001b[0m                       Traceback (most recent call last)\n",
+            "Cell \u001b[0;32mIn[26], line 2\u001b[0m\n",
+            "\u001b[1;32m      1\u001b[0m sd \u001b[38;5;241m=\u001b[39m {\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmodel\u001b[39m\u001b[38;5;124m\"\u001b[39m: model}\n",
+            "\u001b[0;32m----> 2\u001b[0m dcp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49mload\u001b[49m(\u001b[49msd\u001b[49m,\u001b[49m \u001b[49mcheckpoint_id\u001b[49m\u001b[38;5;241;43m=\u001b[39;49mCHECKPOINT_DIR\u001b[49m)\u001b[49m\n",
+            "\n",
+            "File \u001b[0;32m~/local/pytorch/torch/distributed/checkpoint/logger.py:87\u001b[0m, in \u001b[0;36m_dcp_method_logger.<locals>.decorator.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n",
+            "\u001b[1;32m     85\u001b[0m \u001b[38;5;66;03m# exceptions\u001b[39;00m\n",
+            "\u001b[1;32m     86\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n",
+            "\u001b[0;32m---> 87\u001b[0m     result \u001b[38;5;241m=\u001b[39m func\u001b[49m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49margs\u001b[49m,\u001b[49m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49mkwargs\u001b[49m)\u001b[49m\n",
+            "\u001b[1;32m     88\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mBaseException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m error:\n",
+            "\u001b[1;32m     89\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m log_exceptions:\n",
+            "\n",
+            "File \u001b[0;32m~/local/pytorch/torch/distributed/checkpoint/utils.py:465\u001b[0m, in \u001b[0;36m_api_bc_check.<locals>.inner_func\u001b[0;34m(*args, **kwargs)\u001b[0m\n",
+            "\u001b[1;32m    463\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m func(args[\u001b[38;5;241m0\u001b[39m], \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n",
+            "\u001b[1;32m    464\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n",
+            "\u001b[0;32m--> 465\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m func\u001b[49m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49margs\u001b[49m,\u001b[49m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49mkwargs\u001b[49m)\u001b[49m\n",
+            "\n",
+            "File \u001b[0;32m~/local/pytorch/torch/distributed/checkpoint/state_dict_loader.py:177\u001b[0m, in \u001b[0;36mload\u001b[0;34m(state_dict, checkpoint_id, storage_reader, planner, process_group, no_dist)\u001b[0m\n",
+            "\u001b[1;32m    172\u001b[0m     elem \u001b[38;5;241m=\u001b[39m state_dict[key]\n",
+            "\u001b[1;32m    173\u001b[0m     statetful_sd[key] \u001b[38;5;241m=\u001b[39m (\n",
+            "\u001b[1;32m    174\u001b[0m         elem\u001b[38;5;241m.\u001b[39mstate_dict() \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(elem, Stateful) \u001b[38;5;28;01melse\u001b[39;00m elem\n",
+            "\u001b[1;32m    175\u001b[0m     )\n",
+            "\u001b[0;32m--> 177\u001b[0m _load_state_dict\u001b[49m(\u001b[49m\n",
+            "\u001b[1;32m    178\u001b[0m     \u001b[49mstate_dict\u001b[49m\u001b[38;5;241;43m=\u001b[39;49mstatetful_sd\u001b[49m,\u001b[49m\n",
+            "\u001b[1;32m    179\u001b[0m     \u001b[49mstorage_reader\u001b[49m\u001b[38;5;241;43m=\u001b[39;49mstorage_reader\u001b[49m,\u001b[49m\n",
+            "\u001b[1;32m    180\u001b[0m     \u001b[49mprocess_group\u001b[49m\u001b[38;5;241;43m=\u001b[39;49mprocess_group\u001b[49m,\u001b[49m\n",
+            "\u001b[1;32m    181\u001b[0m     \u001b[49mno_dist\u001b[49m\u001b[38;5;241;43m=\u001b[39;49mno_dist\u001b[49m,\u001b[49m\n",
+            "\u001b[1;32m    182\u001b[0m     \u001b[49mplanner\u001b[49m\u001b[38;5;241;43m=\u001b[39;49mplanner\u001b[49m,\u001b[49m\n",
+            "\u001b[1;32m    183\u001b[0m \u001b[49m)\u001b[49m\n",
+            "\u001b[1;32m    184\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m key \u001b[38;5;129;01min\u001b[39;00m keys:\n",
+            "\u001b[1;32m    185\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m key \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m state_dict:\n",
+            "\n",
+            "File \u001b[0;32m~/local/pytorch/torch/distributed/checkpoint/state_dict_loader.py:234\u001b[0m, in \u001b[0;36m_load_state_dict\u001b[0;34m(state_dict, storage_reader, process_group, coordinator_rank, no_dist, planner)\u001b[0m\n",
+            "\u001b[1;32m    231\u001b[0m     all_local_plans \u001b[38;5;241m=\u001b[39m storage_reader\u001b[38;5;241m.\u001b[39mprepare_global_plan(all_local_plans)\n",
+            "\u001b[1;32m    232\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m all_local_plans\n",
+            "\u001b[0;32m--> 234\u001b[0m central_plan: LoadPlan \u001b[38;5;241m=\u001b[39m distW\u001b[49m\u001b[38;5;241;43m.\u001b[39;49mreduce_scatter\u001b[49m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mplan\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m,\u001b[49m \u001b[49mlocal_step\u001b[49m,\u001b[49m \u001b[49mglobal_step\u001b[49m)\u001b[49m\n",
+            "\u001b[1;32m    236\u001b[0m \u001b[38;5;129m@_dcp_method_logger\u001b[39m(\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mckpt_kwargs)\n",
+            "\u001b[1;32m    237\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mread_data\u001b[39m():\n",
+            "\u001b[1;32m    238\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m planner \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n",
+            "\n",
+            "File \u001b[0;32m~/local/pytorch/torch/distributed/checkpoint/utils.py:219\u001b[0m, in \u001b[0;36m_DistWrapper.reduce_scatter\u001b[0;34m(self, step, map_fun, reduce_fun)\u001b[0m\n",
+            "\u001b[1;32m    217\u001b[0m result \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mscatter_object(all_results)\n",
+            "\u001b[1;32m    218\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(result, CheckpointException):\n",
+            "\u001b[0;32m--> 219\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m result\n",
+            "\u001b[1;32m    220\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m result\n",
+            "\n",
+            "\u001b[0;31mCheckpointException\u001b[0m: CheckpointException ranks:dict_keys([0])\n",
+            "Traceback (most recent call last): (RANK 0)\n",
+            "  File \"/home/howardhuang/local/pytorch/torch/distributed/checkpoint/utils.py\", line 192, in reduce_scatter\n",
+            "    local_data = map_fun()\n",
+            "  File \"/home/howardhuang/local/pytorch/torch/distributed/checkpoint/logger.py\", line 87, in wrapper\n",
+            "    result = func(*args, **kwargs)\n",
+            "  File \"/home/howardhuang/local/pytorch/torch/distributed/checkpoint/state_dict_loader.py\", line 223, in local_step\n",
+            "    local_plan = planner.create_local_plan()\n",
+            "  File \"/home/howardhuang/local/pytorch/torch/distributed/checkpoint/default_planner.py\", line 334, in create_local_plan\n",
+            "    return create_default_local_load_plan(\n",
+            "  File \"/home/howardhuang/local/pytorch/torch/distributed/checkpoint/default_planner.py\", line 455, in create_default_local_load_plan\n",
+            "    raise RuntimeError(f\"Missing key in checkpoint state_dict: {fqn}.\")\n",
+            "RuntimeError: Missing key in checkpoint state_dict: model.net1.weight.\n"
+          ]
+        }
+      ],
+      "source": [
+        "sd = {\"model\": model}\n",
+        "dcp.load(sd, checkpoint_id=CHECKPOINT_DIR)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "output": {
+          "id": 517906501012837,
+          "loadingStatus": "loaded"
+        }
+      },
+      "outputs": [
+        {
+          "ename": "ImportError",
+          "evalue": "cannot import name 'my_function' from 'torch.distributed.checkpoint._in_memory_checkpoint' (/home/howardhuang/local/pytorch/torch/distributed/checkpoint/_in_memory_checkpoint.py)",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n",
+            "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)\n",
+            "Cell \u001b[0;32mIn[9], line 1\u001b[0m\n",
+            "\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mtorch\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mdistributed\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcheckpoint\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01m_in_memory_checkpoint\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m my_function\n",
+            "\u001b[1;32m      3\u001b[0m my_function()\n",
+            "\n",
+            "\u001b[0;31mImportError\u001b[0m: cannot import name 'my_function' from 'torch.distributed.checkpoint._in_memory_checkpoint' (/home/howardhuang/local/pytorch/torch/distributed/checkpoint/_in_memory_checkpoint.py)"
+          ]
+        }
+      ],
+      "source": [
+        "from torch.distributed.checkpoint._in_memory_checkpoint import my_function\n",
+        "\n",
+        "my_function()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "output": {
+          "id": 573156702414769,
+          "loadingStatus": "loaded"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "(1,)"
+            ]
+          },
+          "execution_count": 13,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "t = torch.Tensor([1, 2, 3])\n",
+        "t.stride()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "output": {
+          "id": 3222316397911376,
+          "loadingStatus": "loaded"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Hello Worlda\u0000\u0000\u0000\n",
+            "Hello World\n"
+          ]
+        }
+      ],
+      "source": [
+        "import mmap\n",
+        "import os\n",
+        "\n",
+        "# Define the file path and size\n",
+        "file_path = 'persistent_storage.dat'\n",
+        "file_size = 1024  # 1 KB for demonstration\n",
+        "\n",
+        "# Create a file and set its size\n",
+        "with open(file_path, 'wb') as f:\n",
+        "    f.write(b'\\x00' * file_size)\n",
+        "\n",
+        "# Open the file for reading and writing\n",
+        "with open(file_path, 'r+b') as f:\n",
+        "    # Memory-map the file\n",
+        "    mm = mmap.mmap(f.fileno(), file_size)\n",
+        "\n",
+        "    # Write data to the memory-mapped file\n",
+        "    mm[0:12] = b'Hello Worlda'\n",
+        "\n",
+        "    # Read data from the memory-mapped file\n",
+        "    print(mm[0:15].decode('utf-8'))  # Output: Hello World\n",
+        "\n",
+        "    # Close the memory-mapped file\n",
+        "    mm.close()\n",
+        "\n",
+        "# At this point, the data is saved to 'persistent_storage.dat' on disk\n",
+        "\n",
+        "# To demonstrate persistence, open the file again in a new process or later\n",
+        "with open(file_path, 'r+b') as f:\n",
+        "    mm = mmap.mmap(f.fileno(), file_size)\n",
+        "\n",
+        "    # Read the persisted data\n",
+        "    print(mm[0:11].decode('utf-8'))  # Output: Hello World\n",
+        "\n",
+        "    mm.close()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "output": {
+          "id": 978633167731894,
+          "loadingStatus": "loaded"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "__0_0.distcp  \u001b[0m\u001b[01;34mdotsync-home\u001b[0m/  persistent_storage.dat\r\n",
+            "\u001b[01;34mbento-cache\u001b[0m/  \u001b[01;34mnotebooks\u001b[0m/     \u001b[01;34mscratch\u001b[0m/\r\n"
+          ]
+        }
+      ],
+      "source": [
+        "ls"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": []
+    }
+  ],
+  "metadata": {
+    "fileHeader": "",
+    "fileUid": "991d1613-7ee6-45b4-96d6-d816a73630a2",
+    "isAdHoc": false,
+    "kernelspec": {
+      "display_name": "titan (conda)",
+      "language": "python",
+      "name": "conda_titan_local"
+    },
+    "language_info": {
+      "name": "plaintext"
+    },
+    "orig_nbformat": 4
+  }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149202

The problem:

Reading from disk / network file system is expensive. If we can read from memory then loading checkpoints is a lot faster and we can do it more frequently.

The idea:

1. Keep a process alive which has the checkpoint in memory 
2. On cases where the Trainer dies (the host does not die), restart training, reconfigure the process group, retrieve the checkpoint from memory.
3. Reshard / replicate as necessary using DCP. Update to use TorchFTs pg transport which uses P2P ops.

Look at the example script https://github.com/pytorch/pytorch/pull/149202/files#diff-a41fce34729130d2f85e2eebdf2180353d2faaf0213ec778934ed075cc382a56 for a rough idea.

----------

Brainstorming docs: https://fburl.com/gdoc/w6x32v9a, https://fburl.com/gdoc/se7kh86g
Potential impact and savings: https://fburl.com/gdoc/5pcd2lkm


cc @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o