### PR TITLE
debug ival swap

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -4737,6 +4737,139 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         self.assertTrue(torch.allclose(orig_res[1], ep_res[1]))
         self.assertTrue(torch.allclose(orig_res[2], ep_res[2]))
 
+    def test_unflatten_placeholder_update_child2parent_swap(self):
+        class Child(torch.nn.Module):
+            def forward(self, x):
+                torch.ops.aten.dropout_(x, 0.5, False)  # Applying dropout inplace
+                return x - 2
+
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.child = Child()
+
+            def forward(self, x):
+                f1 = self.child(x)
+                f2 = x * 4
+                return f1 + f2
+
+        m = Foo()
+        inp = torch.ones(3, 10, dtype=torch.float32)
+        orig_result = m(inp)
+
+        if not is_retracebility_test(self._testMethodName):
+            inp = torch.ones(3, 10, dtype=torch.float32)
+            ep = export(m, (inp,), preserve_module_call_signature=("child",))
+            unf = unflatten(ep)
+            unf.print_readable()
+
+            inp = torch.ones(3, 10, dtype=torch.float32)
+            ep_result = ep.module()(inp)
+            self.assertTrue(torch.allclose(ep_result, orig_result))
+
+            unf.set_submodule("child", m.child)
+            inp = torch.ones(3, 10, dtype=torch.float32)
+            unf_result = unf(inp)
+            self.assertTrue(torch.allclose(unf_result, orig_result))
+
+    def test_unflatten_placeholder_update_grandchild2cousin_swap(self):
+        class Grandchild(torch.nn.Module):
+            def forward(self, x):
+                a = x.to(torch.float32)  # .to is considered a mutation
+                return x + 4, a
+
+        class Child(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.grandchild = Grandchild()
+
+            def forward(self, x):
+                y, a = self.grandchild(x)
+                return y + a
+
+        class OtherGrandchild(torch.nn.Module):
+            def forward(self, x):
+                return x * 2
+
+        class OtherChild(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.other_grandchild = OtherGrandchild()
+
+            def forward(self, x):
+                return x + self.other_grandchild(x)
+
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.child = Child()
+                self.other_child = OtherChild()
+
+            def forward(self, x):
+                f1 = self.child(x)
+                f2 = self.other_child(x)
+                return f1 + f2
+
+        inp = torch.ones(2, 3, dtype=torch.float32)
+        orig_result = Foo()(inp)
+        self.assertTrue(torch.allclose(orig_result, torch.ones(2, 3) * 9))
+
+        if not is_retracebility_test(self._testMethodName):
+            inp = torch.ones(2, 3, dtype=torch.float32)
+            ep = export(Foo(), (inp,), preserve_module_call_signature=("child",))
+            unf = unflatten(ep)
+
+            inp = torch.ones(2, 3, dtype=torch.float32)
+            ep_result = ep.module()(inp)
+            self.assertTrue(torch.allclose(ep_result, orig_result))
+
+            unf.set_submodule("child", Child())
+            inp = torch.ones(2, 3, dtype=torch.float32)
+            unf_result = unf(inp)
+            self.assertTrue(torch.allclose(unf_result, orig_result))
+
+    def test_unflatten_buffer_update_child2parent_swap(self):
+        class Child(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.buf = torch.nn.Buffer(torch.tensor(10))
+
+            def forward(self, x):
+                self.buf.add_(1)
+                return x + 2
+
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.child = Child()
+
+            def forward(self, x):
+                y = self.child(x)  # child.buf <- 10 + 1 = 11, x + 2 = 3
+                x = y + self.child.buf  # 14
+                y = self.child(x)  # child.buf <- 11 + 1 = 12, x + 2 = 16
+                x = y + self.child.buf  # 28
+                y = self.child(x)  # child.buf <- 12 + 1 = 13, x + 2 = 30
+                x = y + self.child.buf  # 43
+                return x
+
+        inp = torch.ones(2, 3, dtype=torch.float32)
+        orig_result = Foo()(inp)
+        self.assertTrue(torch.allclose(orig_result, torch.ones(2, 3) * 43))
+
+        if not is_retracebility_test(self._testMethodName):
+            inp = torch.ones(2, 3, dtype=torch.float32)
+            ep = export(Foo(), (inp,), preserve_module_call_signature=("child",))
+            unf = unflatten(ep)
+
+            inp = torch.ones(2, 3, dtype=torch.float32)
+            ep_result = ep.module()(inp)
+            self.assertTrue(torch.allclose(ep_result, orig_result))
+
+            unf.set_submodule("child", Child())
+            inp = torch.ones(2, 3, dtype=torch.float32)
+            unf_result = unf(inp)
+            self.assertTrue(torch.allclose(unf_result, orig_result))
+
     def test_export_func_with_var_keyword_pytree_args(self):
         class Module(torch.nn.Module):
             def forward(self, arg1, arg2, *args, kw1, kw2, **kwargs):

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -306,16 +306,14 @@ class UnflattenedModule(torch.nn.Module):
         self.adapted = False
         self._run_with_interpreter = RUN_WITH_INTERPRETER
 
-        _inplace_buffer_mutations(export_graph, self.graph_signature)
+        _inplace_buffer_and_input_mutations(export_graph, self.graph_signature)
 
         self.ivals = _IVals()
-        # record any intermediate value x that is used, with the modules that used it,
-        # and generate instructions to read the corresponding attribute
+        # for any intermediate value of a mutation that is read, track the mutation
         seen_modules, seen_attrs = _outline_submodules(export_graph, self)
-        # for each read intermediate value x, find the module that created it,
-        # and generate instructions to update the corresponding attribute;
-        # finally, initialize all these attributes
-        self.ivals.create(seen_modules.values(), self)
+        # for each read intermediate value of a mutation, find where it was created,
+        # and perform the mutation
+        self.ivals.update(seen_modules.values())
         # move attributes that correspond to graph arguments for HOPs
         # from exported program to unflattened submodules
         _copy_graph_attrs(export_module._graph_module, self, seen_attrs)
@@ -711,62 +709,75 @@ def unflatten(
     return UnflattenedModule(module, flat_args_adapter)
 
 
-def _inplace_buffer_mutations(
+def _inplace_buffer_and_input_mutations(
     graph: torch.fx.Graph,
     graph_signature: ExportGraphSignature,
 ) -> None:
-    """Transform buffer mutations from their functionalized form into a copy_
-    node in the graph.
+    """Transform buffer and input mutations from their functionalized form
+    into copy_ nodes in the graph.
 
-    Functionalization represents buffer mutation by passing the buffer as an input and output. So for example, the eager code:
+    Functionalization represents a buffer mutation by passing the buffer as
+    an input and output. For example, consider the eager code:
         def forward(self, x):
             self.buffer += x
             return x * x
 
-    Will become a graph that looks like:
+    This corresponds to a graph that looks like:
         def forward(self, buffer, x):
             mutated_buffer = aten.add(buffer, x)
             mul = aten.mul(x, x)
             return (mutated_buffer, mul)
 
-    We want to inplace this into something that looks like the original eager code:
+    We want to inplace this into something that looks like the original
+    eager code:
         def forward(self, buffer, x):
             mutated_buffer = aten.add(buffer, x)
             buffer.copy_(mutated_buffer)
             mul = aten.mul(x, x)
             return (mul,)
+
+    Input mutations are handled similarly.
     """
     output_node = next(iter(reversed(graph.nodes)))
     assert output_node.op == "output" and len(output_node.args) == 1
     return_args = output_node.args[0]
 
-    mutation_node_to_buffer = graph_signature.buffers_to_mutate
-    mutations = return_args[: len(mutation_node_to_buffer)]
-    buffers_to_inputs = {v: k for k, v in graph_signature.inputs_to_buffers.items()}
     input_name_to_node = {
         node.name: node for node in graph.nodes if node.op == "placeholder"
     }
+    mutation_name_to_input_name = {}
 
-    for mutation in mutations:
-        buffer_name = mutation_node_to_buffer[mutation.name]
-        input_name = buffers_to_inputs[buffer_name]
+    # Collect mutated buffers.
+    buffer_fqn_to_input_name = {
+        buffer_fqn: k for k, buffer_fqn in graph_signature.inputs_to_buffers.items()
+    }
+    mutation_name_to_input_name = {
+        k: buffer_fqn_to_input_name[buffer_fqn]
+        for k, buffer_fqn in graph_signature.buffers_to_mutate.items()
+    }
+    # Collect mutated user inputs.
+    mutation_name_to_input_name.update(graph_signature.user_inputs_to_mutate)
+
+    num_mutations = len(mutation_name_to_input_name)
+
+    for mutation in return_args[:num_mutations]:
+        input_name = mutation_name_to_input_name[mutation.name]
         input_node = input_name_to_node[input_name]
 
         with graph.inserting_after(mutation):
+            # Create a copy_ node that inplaces the mutation.
             new_node = graph.create_node(
-                "call_function", torch.ops.aten.copy_, (input_node, mutation)
+                "call_function", torch.ops.aten.copy_.default, (input_node, mutation)
             )
             for k, v in mutation.meta.items():
                 new_node.meta[k] = v
-        # Replace all uses of the previously functional mutation with our copy_ output.
+        # Replace all uses of the previously functional mutation with
+        # our copy_ node.
         mutation.replace_all_uses_with(new_node, lambda x: x is not new_node)
 
-    # Remove the mutated buffer from the graph outputs, since we don't need to
-    # thread it through anymore. We don't need to handle the inputs, which will
-    # be handled by _sink_params.
-    user_outputs = tuple(
-        return_args[len(mutation_node_to_buffer) :],
-    )
+    # Remove the mutated buffer / input from the graph outputs, since we don't
+    # need to thread it through anymore.
+    user_outputs = tuple(return_args[num_mutations:])
     output_node.args = ((user_outputs),)
 
 
@@ -1130,9 +1141,9 @@ class _ModuleFrame:
             self.copy_sym_call_function(x)
             return self.node_map[x]
         elif self.module_call_graph.get(self.fqn) is not None:
-            # x is an ival that is not in placeholders, so create a
-            # get_attr node corresponding to attribute __ival__x
-            return self.ivals.read(self.fqn, self.graph, x)  # type: ignore[operator, union-attr]
+            # x is reading the intermediate value of a mutation, so record it;
+            # later we will find where it was created and perform the update
+            return self.ivals.read(self, x)  # type: ignore[operator, union-attr]
         else:
             raise RuntimeError(
                 f"Could not run remap_input() on op type: {x.op} for node {x}"
@@ -1403,10 +1414,7 @@ def _reorder_submodules(
 
 class _IVals:
     """
-    Collect the intermediate values of buffer mutations in a graph,
-    along with the module call fqns that create and use them. Later,
-    in each fqn associated with an intermediate value we will install
-    a corresponding attribute, so that it can be updated and read.
+    Collect the intermediate values of mutations in a graph.
 
     Example: in the following graph, suppose that buf_in and buf_out
     are the input and output values of a buffer.
@@ -1423,78 +1431,51 @@ class _IVals:
     Here ival1 and ival2 are intermediate values created inside
     calls to n0 and n1 respectively, and used inside calls to
     n1 and n2 respectively.
-
-    Thus our analysis will produce {ival1: {n0, n1}, ival2: {n1, n2}}.
     """
 
     def __init__(self):
-        # ival node name -> set of fqns that create and use it
-        self.fqns = defaultdict(set)
-        # ival node name -> tensor storage for corresponding attribute
-        self.storage = {}
+        # for each fqn, set of node names corresponding to intermediate values
+        self.node_names_by_fqn = defaultdict(set)
 
-    def read(self, fqn, graph, node):
+    def _is_mutable(self, target):
+        if isinstance(target, torch._ops.OpOverload):
+            return target._schema.is_mutable
+        return False
+
+    def read(self, mf, node):
         """
-        Read attribute corresponding to a given intermediate value.
+        Read state corresponding to a given intermediate value.
         """
-        # to read ival x, get attribute __ival__x
-        with graph.inserting_before(None):
-            ival_node = graph.get_attr("__ival__" + node.name, type_expr=node.type)
-            ival_node.meta = copy.copy(node.meta)
+        # we can assume that the node must be from a mutation
+        assert node.op == "call_function"
+        b = self._is_mutable(node.target)
+        print("Checking mutability", node.target, b)
+        if not b:
+            # so the mutation was functionalized;
+            # we will apply the original mutation later (see below)
+            fqn, _ = next(reversed(node.meta["nn_module_stack"].values()))
+            self.node_names_by_fqn[fqn].add(node.name)
+        return mf.remap_input(node.args[0])
 
-        if node.name not in self.storage:
-            # create empty tensor matching fake, using a cache
-            # to ensure the same tensor is returned per ival_name
-            fake = node.meta["val"]
-            self.storage[node.name] = torch.empty(fake.shape, dtype=fake.dtype)
-        self.fqns[node.name].add(fqn)
-
-        return ival_node
-
-    def update(self, fqn, graph, node):
+    def update(self, partitions):
         """
-        Update attribute corresponding to a given intermediate value.
+        Update states corresponding to intermediate values that were read.
         """
-        self.fqns[node.name].add(fqn)
-
-        # to update ival x, get attribute __ival__x and copy x to __ival__x
-        with graph.inserting_after(node):
-            ival_node = graph.get_attr("__ival__" + node.name, type_expr=node.type)
-            ival_node.meta = copy.copy(node.meta)
-        with graph.inserting_after(ival_node):
-            new_ival_node = graph.create_node(
-                "call_function", torch.ops.aten.copy_, (ival_node, node)
-            )
-            new_ival_node.meta = copy.copy(node.meta)
-
-    def create(self, partitions, root_module):
-        """
-        Update attributes corresponding to intermediate values that were read.
-        Finally, initialize attributes in all modules that read or update
-        corresponding intermediate values.
-        """
-
-        entries = [("", root_module)]
         for shared_submodules in partitions:
             for entry in shared_submodules:
-                entries.append((entry.fqn, entry.module))
                 graph = entry.module.graph
-                for node in graph.nodes:
-                    if node.name in self.storage:
-                        self.update(entry.fqn, graph, node)
-
-        # fqn -> list of ival node names read or updated through it
-        ivals = defaultdict(list)
-        for name, fqns in self.fqns.items():
-            for fqn in fqns:
-                ivals[fqn].append(name)
-
-        for fqn, mod in entries:
-            for name in ivals[fqn]:
-                ival_name = f"__ival__{name}"
-                # for a ival named x created in module call m,
-                # create attribute m.__ival__x, initially empty
-                setattr(mod, ival_name, self.storage[name])
+                node_names = self.node_names_by_fqn[entry.fqn]
+                nodes = [n for n in graph.nodes if n.name in node_names]
+                for node in nodes:
+                    # so node must be from a functionalized mutation;
+                    # we perform the original mutation now
+                    with graph.inserting_after(node):
+                        new_node = graph.create_node(
+                            "call_function",
+                            torch.ops.aten.copy_.default,
+                            (node.args[0], node),
+                        )
+                        new_node.meta = copy.copy(node.meta)
 
 
 def _copy_graph_attrs(


### PR DESCRIPTION
Summary:
Recall that we use "ivals" to track intermediate values of mutations during unflattening. Previously, for each such intermediate value, we would create a hidden shared attribute that would be updated / read by respective submodules.

Unfortunately this scheme doesn't work when some but not all of those submodules are swapped out. This is because the swapped in submodules have no knowledge of these hidden attributes. Thus the submodules that are not swapped out end up reading / updating dangling state.

This PR does away with these hidden attributes. Instead, we directly read the underlying buffer or placeholder that was updated, and update those underlying buffers and placeholders in place. This makes the graphs look much closer to their eager origins.

Test Plan: added some tests, ensured existing tests pass

Differential Revision: D71203469
