### PR TITLE
[Bugfix] Skip non-tensor user inputs when calling create_graph_signature with trace_joint=True

### DIFF
--- a/torch/_functorch/_aot_autograd/input_output_analysis.py
+++ b/torch/_functorch/_aot_autograd/input_output_analysis.py
@@ -384,7 +384,7 @@ def create_graph_signature(
                 i + len(params_and_buffers_flat)
             ]
             for i, user_input in enumerate(user_args_flat)
-            if user_input.requires_grad
+            if isinstance(user_input, torch.Tensor) and user_input.requires_grad
         }
 
         assert len(gradients_to_parameters) + len(gradients_to_user_inputs) == len(


### PR DESCRIPTION
Summary:
# Context
Encountered a bug while trying to export the joint graph for a module.

# Reproducer

```py
    class mod(torch.nn.Module):
        def forward(self, ph: object, t: torch.Tensor):
            return (t.sum(),)

    m = mod()
    t = torch.rand(100, requires_grad=True)
    g, sig = aot_export_module(
        m,
        args=(
            None,
            t,
        ),
        trace_joint=True,
        output_loss_index=0,
    )
```

Before this change, crashes with
```
AttributeError: 'NoneType' object has no attribute 'requires_grad'
```
After this diff, the reproducer runs to completion

Differential Revision: D71203331


