### PR TITLE
[BE] simplify test_cpp_extensions_aot and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,9 +62,7 @@ test/forward_backward_compatibility/nightly_schemas.txt
 dropout_model.pt
 test/generated_type_hints_smoketest.py
 test/htmlcov
-test/cpp_extensions/install/
-test/cpp_extensions/open_registration_extension/install
-test/cpp_extensions/libtorch_agnostic_extension/install
+test/cpp_extensions/**/install
 test/kernel.errors.txt
 third_party/build/
 third_party/nccl/

--- a/test/test_cpp_extensions_aot.py
+++ b/test/test_cpp_extensions_aot.py
@@ -217,15 +217,6 @@ class TestCppExtensionAOT(common.TestCase):
         missing_symbols = subprocess.check_output(["nm", "-u", so_file]).decode("utf-8")
         self.assertFalse("Py" in missing_symbols)
 
-        # finally, clean up the folder
-        cmd = [sys.executable, "setup.py", "clean"]
-        return_code = shell(
-            cmd,
-            cwd=os.path.join("cpp_extensions", "python_agnostic_extension"),
-            env=os.environ.copy(),
-        )
-        if return_code != 0:
-            return return_code
 
     @unittest.skipIf(not TEST_CUDA, "some aspects of this test require CUDA")
     def test_libtorch_agnostic(self):

--- a/test/test_cpp_extensions_aot.py
+++ b/test/test_cpp_extensions_aot.py
@@ -3,7 +3,6 @@
 import os
 import re
 import subprocess
-import sys
 import unittest
 from itertools import repeat
 from pathlib import Path
@@ -16,7 +15,6 @@ import torch.utils.cpp_extension
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_utils import (
     IS_WINDOWS,
-    shell,
     skipIfTorchDynamo,
     TEST_XPU,
     xfailIfTorchDynamo,
@@ -216,7 +214,6 @@ class TestCppExtensionAOT(common.TestCase):
 
         missing_symbols = subprocess.check_output(["nm", "-u", so_file]).decode("utf-8")
         self.assertFalse("Py" in missing_symbols)
-
 
     @unittest.skipIf(not TEST_CUDA, "some aspects of this test require CUDA")
     def test_libtorch_agnostic(self):


### PR DESCRIPTION
It is shady to clean up an install mid-test. So don't do that anymore and use .gitignore instead.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149231

