### PR TITLE
Fix torchbind schema str generation

### DIFF
--- a/test/inductor/test_torchbind.py
+++ b/test/inductor/test_torchbind.py
@@ -123,6 +123,24 @@ class TestTorchbind(TestCase):
         for file in aoti_files:
             self.assertTrue(not file.endswith("/custom_objs_config.json"))
 
+    def test_torchbind_hop_schema_no_input(self):
+        q = _empty_tensor_queue()
+        q_ir = ir.TorchBindObject(name="q", value=q)
+        schema = CallTorchBind.schema(q_ir, "pop")
+        self.assertEqual(
+            str(schema),
+            "call_torchbind(__torch__.torch.classes._TorchScriptTesting._TensorQueue obj, str method) -> Tensor _0",
+        )
+
+    def test_torchbind_hop_schema_no_output(self):
+        q = _empty_tensor_queue()
+        q_ir = ir.TorchBindObject(name="q", value=q)
+        schema = CallTorchBind.schema(q_ir, "push")
+        self.assertEqual(
+            str(schema),
+            "call_torchbind(__torch__.torch.classes._TorchScriptTesting._TensorQueue obj, str method, Tensor _1) -> NoneType _0",
+        )
+
     def test_torchbind_aot_compile(self):
         ep, inputs, _, _ = self.get_exported_model()
         aoti_files = aot_compile(

--- a/torch/_higher_order_ops/torchbind.py
+++ b/torch/_higher_order_ops/torchbind.py
@@ -46,9 +46,10 @@ class CallTorchBind(HigherOrderOperator):
             "call_torchbind(" + str(schema.arguments[0].real_type) + " obj,"
         )
         first_comma_index = schema_str.find(",")
-        new_schema_str = (
-            new_schema_str + " str method," + schema_str[first_comma_index + 1 :]
-        )
+        if first_comma_index == -1:
+            # If no comma is found, find the last closing parenthesis
+            first_comma_index = schema_str.rfind(") ->")
+        new_schema_str = new_schema_str + " str method" + schema_str[first_comma_index:]
         new_schema = torch._C.parse_schema(new_schema_str)
         return new_schema
 


### PR DESCRIPTION
Summary: Fix Torchbind HOP schema generation when there's no input

Test Plan:
```
buck run fbcode//mode/dev-nosan //caffe2/test/inductor:torchbind -- -r schema
```

Differential Revision: D71231164




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov