### PR TITLE
[ROCm] Fixes and improvements to CUDA->HIP flag conversion for CPP extensions

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -625,6 +625,9 @@ class BuildExtension(build_ext):
 
             self._add_compile_flag(extension, '-DTORCH_API_INCLUDE_EXTENSION_H')
 
+            if IS_HIP_EXTENSION:
+                self._hipify_compile_flags(extension)
+
             if extension.py_limited_api:
                 # compile any extension that has passed in py_limited_api to the
                 # Extension constructor with the Py_LIMITED_API flag set to our
@@ -1044,6 +1047,12 @@ class BuildExtension(build_ext):
                 args.append(flag)
         else:
             extension.extra_compile_args.append(flag)
+
+    def _hipify_compile_flags(self, extension):
+        # Simple hipify, map CUDA->HIP
+        if isinstance(extension.extra_compile_args, dict):
+            extension.extra_compile_args['nvcc'] = [
+                flag.replace("CUDA", "HIP") for flag in extension.extra_compile_args['nvcc']]
 
     def _define_torch_extension_name(self, extension):
         # pybind11 doesn't support dots in the names


### PR DESCRIPTION
Fixes https://github.com/ROCm/hip/issues/3764.

Fixes and improvements to CUDA->HIP flag conversion for CPP extensions

- Log flag conversion for debugging purposes.
- Fix cases where it should not touch the -I flags or cases where CUDA appears more than once by replacing only the first instance.
- Fix case where nvcc key may not exist
- Fix case where hipify should ignore flag values and only touch the flag itself


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang