### PR TITLE
Not generate custom obj json when it's empty

### DIFF
--- a/test/inductor/test_torchbind.py
+++ b/test/inductor/test_torchbind.py
@@ -24,6 +24,24 @@ class TestTorchbind(TestCase):
         super().setUp()
         init_torchbind_implementations()
 
+    def get_dummy_exported_model(self):
+        """
+        Returns the ExportedProgram, example inputs, and result from calling the
+        eager model with those inputs
+        """
+
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        m = M()
+        inputs = (torch.ones(2, 3),)
+        orig_res = m(*inputs)
+
+        ep = torch.export.export(m, inputs, strict=False)
+
+        return ep, inputs, orig_res, m
+
     def get_exported_model(self):
         """
         Returns the ExportedProgram, example inputs, and result from calling the
@@ -95,6 +113,15 @@ class TestTorchbind(TestCase):
             str(schema),
             "call_torchbind(__torch__.torch.classes._TorchScriptTesting._Foo obj, str method, int _1) -> int _0",
         )
+
+    def test_torchbind_config_not_generated(self):
+        # custom_objs_config.json should not be generated when its empty
+        ep, inputs, _, _ = self.get_dummy_exported_model()
+        aoti_files = aot_compile(
+            ep.module(), inputs, options={"aot_inductor.package": True}
+        )
+        for file in aoti_files:
+            self.assertTrue(not file.endswith("/custom_objs_config.json"))
 
     def test_torchbind_aot_compile(self):
         ep, inputs, _, _ = self.get_exported_model()

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1765,12 +1765,13 @@ class AotCodeCompiler:
                 write_atomic(custom_obj_path, custom_obj_bytes, True)
                 generated_files.append(custom_obj_path)
 
-            constants_config_json = os.path.join(
-                wrapper_path_operator.parent, "custom_objs_config.json"
-            )
-            with open(constants_config_json, "w") as f:
-                f.write(json.dumps(qual_name_to_id))
-            generated_files.append(constants_config_json)
+            if qual_name_to_id:
+                constants_config_json = os.path.join(
+                    wrapper_path_operator.parent, "custom_objs_config.json"
+                )
+                with open(constants_config_json, "w") as f:
+                    f.write(json.dumps(qual_name_to_id))
+                generated_files.append(constants_config_json)
 
             gpu_codecache: Union[ROCmCodeCache, CUDACodeCache] = (
                 ROCmCodeCache() if torch.version.hip else CUDACodeCache()


### PR DESCRIPTION
Summary: as title.

See internal Diff summary for more context.


Test Plan: buck run @fbcode//mode/dev-nosan //caffe2/test/inductor:torchbind -- -r config_not_generated

Differential Revision: D71241676




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov