### PR TITLE
Add batch dim sharding rule to sdpa

### DIFF
--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -517,14 +517,15 @@ def scaled_dot_product_efficient_attention_strategy(op_schema: OpSchema) -> OpSt
         num_heads_dim_sharding.append(Shard(1))
     single_mesh_dim_strategies.append(num_heads_dim_sharding)
 
+    # batch sharding
     if compute_log_sumexp:
-        logsumexp_sharding: Placement = Shard(0)
+        logsumexp_sharding_dp: Placement = Shard(0)
     else:
         # empty logsumexp, replicated
-        logsumexp_sharding = Replicate()
+        logsumexp_sharding_dp = Replicate()
     batch_sharding = [
         Shard(0),  # output
-        logsumexp_sharding,  # logsumexp
+        logsumexp_sharding_dp,  # logsumexp
         None,  # philox_seed
         None,  # philox_offset
         Shard(0),  # q
@@ -880,7 +881,7 @@ def scaled_scaled_dot_product_cudnn_attention_backward_strategy(
     if has_scale:
         batch_dim_sharding_inp.append(None)
 
-    batch_sharding = batch_dim_sharding_out + batch_dim_sharding_inp
+    batch_dim_sharding = batch_dim_sharding_out + batch_dim_sharding_inp
     single_mesh_dim_strategies.append(batch_dim_sharding)
 
     return expand_to_full_mesh_op_strategy(

--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -731,12 +731,12 @@ def scaled_dot_product_cudnn_attention_strategy(op_schema: OpSchema) -> OpStrate
     batch_dim_sharding: PlacementList = [
         Shard(0),  # output
         logsumexp_sharding,
-        None,      # cum_seq_q
-        None,      # cum_seq_k
-        None,      # max_q
-        None,      # max_k
-        None,      # philox_seed
-        None,      # philox_offset
+        None,  # cum_seq_q
+        None,  # cum_seq_k
+        None,  # max_q
+        None,  # max_k
+        None,  # philox_seed
+        None,  # philox_offset
         debug_attn_mask_sharding,
         Shard(0),  # q
         Shard(0),  # k


### PR DESCRIPTION
This is a trivial rule that for most cases isn't needed, but if we want to consider that the input data is actually `Shard(0)` (instead of `Replicated()` as it is currently assumed), then we need this rule.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o