### PR TITLE
Make Subset dataset a true wrapper

### DIFF
--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -10,7 +10,7 @@ from collections.abc import Sequence
 # targets fail to typecheck with:
 #     TypeError: Cannot create a consistent method resolution order (MRO) for
 #     bases Iterable, Generic
-from typing import cast, Generic, Iterable, Optional, TypeVar, Union  # noqa: UP035
+from typing import cast, Any, Generic, Iterable, Optional, TypeVar, Union  # noqa: UP035
 from typing_extensions import deprecated
 
 # No 'default_generator' in torch/__init__.pyi
@@ -417,6 +417,9 @@ class Subset(Dataset[_T_co]):
 
     def __len__(self):
         return len(self.indices)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.dataset, name)
 
 
 def random_split(


### PR DESCRIPTION
Imagine you have a custom `FooDataset` class like so:
```python
from torch.utils.data import Dataset, random_split

class FooDataset(Dataset):
    url = '...'

    def plot(self, x):
        ...
```
You want to make train/val/test splits of this dataset like so:
```python
dataset = FooDataset(...)
train_dataset, val_dataset, test_dataset = random_split(dataset, [0.6, 0.2, 0.2])
```
One would _expect_ that `train_dataset` has all of the same attributes and methods as `dataset`. However, it doesn't, you have to use the unintuitive `train_dataset.dataset` to access these attributes.

This PR turns `Subset` into a true wrapper class, such that all undefined attributes/methods automatically redirect to the `dataset` attribute. One can now access `train_dataset.url` or `train_dataset.plot(x)` as they would with the `dataset` object.

### References

* Inspired by: https://stackoverflow.com/questions/68926132/creation-of-a-class-wrapper-in-python