### PR TITLE
Replace c10::is_pod with std::is_trivial

### DIFF
--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -212,7 +212,9 @@ struct RawAllocation {
 };
 
 // For performance.
-static_assert(c10::is_pod_v<RawAllocation>, "Non-POD member of RawAllocation.");
+static_assert(
+    std::is_trivial_v<RawAllocation>,
+    "Non-Trivial member of RawAllocation.");
 
 template <>
 struct ExtraFields<EventType::Allocation> : RawAllocation {
@@ -238,8 +240,8 @@ struct ExtraFields<EventType::OutOfMemory> {
 
 // For performance.
 static_assert(
-    c10::is_pod_v<ExtraFields<EventType::OutOfMemory>>,
-    "Non-POD member of ExtraFields<EventType::OutOfMemory>.");
+    std::is_trivial_v<ExtraFields<EventType::OutOfMemory>>,
+    "Non-Trivial member of ExtraFields<EventType::OutOfMemory>.");
 
 struct PyFrameState {
   int line_no_;

--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/profiler/collection.h>
 #include <torch/csrc/profiler/kineto_shim.h>
+#include <type_traits>
 
 #ifdef USE_KINETO
 #include <libkineto.h>
@@ -66,7 +67,7 @@ const std::set<libkineto::ActivityType> kPrivateUse1Types = {
 #endif // USE_KINETO
 
 static_assert(
-    c10::is_pod_v<DeviceAndResource>,
+    std::is_trivial_v<DeviceAndResource>,
     "Kineto specific details should be in `kineto_ids`.");
 
 const DeviceAndResource kineto_ids() {


### PR DESCRIPTION
These remaining c10::is_pod calls can be replaced without compromising the semantics.