### PR TITLE
Fix the invalid link for FX

### DIFF
--- a/docs/source/fx.rst
+++ b/docs/source/fx.rst
@@ -854,7 +854,7 @@ Non-\ ``torch`` Functions
 
 FX uses ``__torch_function__`` as the mechanism by which it intercepts
 calls (see the `technical
-overview <https://github.com/pytorch/pytorch/blob/master/torch/fx/OVERVIEW.md#technical-details>`__
+overview <https://github.com/pytorch/pytorch/blob/main/torch/fx/README.md#technical-details>`__
 for more information about this). Some functions, such as builtin Python
 functions or those in the ``math`` module, are not covered by
 ``__torch_function__``, but we would still like to capture them in


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149289

As the title stated.