### PR TITLE
[xpu] Adds XPU support in OffsetBasedRNGTracker

### DIFF
--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -159,7 +159,7 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
     should be shared and synchronized among all ranks to respect the semantics of DTensor
     random operators.
 
-    note: _RNGStateTracker only supports cuda/cuda-like device
+    note: _RNGStateTracker only supports CUDA/CUDA-like and XPU device
     """
 
     def __init__(
@@ -169,11 +169,11 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
     ):
         super().__init__(_resolve_device(device_mesh=device_mesh))
         assert self._device_handle is not None
-        # DTensor RNG tracker so far only supports CUDA/CUDA-like devices
-        if self._device.type != "cuda":
+        # DTensor RNG tracker so far only supports CUDA/CUDA-like and XPU devices
+        if self._device.type != "cuda" and self._device.type != "xpu":
             raise RuntimeError(
                 f"{self.__class__.__name__} instantiation requires the presence of "
-                f"CUDA/CUDA-like device. Got {self._device.type} instead."
+                f"CUDA/CUDA-like or XPU device. Got {self._device.type} instead."
             )
 
         rng_state = self._device_handle.get_rng_state().to(self._device)
@@ -198,7 +198,7 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         if self.distribute_region_enabled:
             old_offset = self.get_offset("parallel-rng")
             self._set_pre_op_offset(spec)
-            with torch.random.fork_rng(devices=[self._device]):
+            with torch.random.fork_rng(devices=[self._device], device_type=self._device.type):
                 assert self._device_handle is not None
                 self._device_handle.set_rng_state(self.rng_states["parallel-rng"])
                 try:


### PR DESCRIPTION
Met this error during training with torchtitan:
```
x4008c6s6b0n0.hostmgmt2008.cm.aurora.alcf.anl.gov 6: [rank6]:   File "/lus/flare/projects/Aurora_deployment/pkourdis/conda/envs/pytorch/lib/python3.12/site-packages/torch/distributed/tensor/_random.py", line 82, in manual_seed
x4008c6s6b0n0.hostmgmt2008.cm.aurora.alcf.anl.gov 6: [rank6]:     _rng_tracker = OffsetBasedRNGTracker(device_mesh, run_state_sync=False)
x4008c6s6b0n0.hostmgmt2008.cm.aurora.alcf.anl.gov 6: [rank6]:                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
x4008c6s6b0n0.hostmgmt2008.cm.aurora.alcf.anl.gov 6: [rank6]:   File "/lus/flare/projects/Aurora_deployment/pkourdis/conda/envs/pytorch/lib/python3.12/site-packages/torch/distributed/tensor/_random.py", line 174, in __init__
x4008c6s6b0n0.hostmgmt2008.cm.aurora.alcf.anl.gov 6: [rank6]:     raise RuntimeError(
x4008c6s6b0n0.hostmgmt2008.cm.aurora.alcf.anl.gov 6: [rank6]: RuntimeError: OffsetBasedRNGTracker instantiation requires the presence of CUDA/CUDA-like device. Got xpu instead
```
I was able to successfully run training with `XPU/XCCL` backends with this fix.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o