### PR TITLE
Add RECORD_FUNCTION for aoti_xxx

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -472,6 +472,15 @@ def check_model(
 
     torch.manual_seed(0)
     actual = run(*example_inputs, **kwargs)
+
+    from torch._inductor import config as inductor_config
+
+    inductor_config.profiler_mark_wrapper_call = True
+    inductor_config.cpp.enable_kernel_profile = True
+
+    with torch.autograd.profiler.profile() as prof:
+        actual_2 = run(*example_inputs, **kwargs)
+    print(prof.key_averages().table(sort_by="self_cpu_time_total"))
     # if not called:
     #     exp = torch._dynamo.explain(run)(*example_inputs)
     #     print("Explain:", exp[0])

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -1439,14 +1439,16 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_library_impl(
 
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_library_def(TorchLibraryHandle self, const char* name) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
-      "TODO", { reinterpret_cast<torch::Library*>(self)->def(name); });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_library_def", {
+    reinterpret_cast<torch::Library*>(self)->def(name);
+  });
 }
 
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_delete_library_object(TorchLibraryHandle tlh) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
-      "TODO", { delete reinterpret_cast<torch::Library*>(tlh); });
+      "aoti_torch_delete_library_object",
+      { delete reinterpret_cast<torch::Library*>(tlh); });
 }
 
 static c10::IValue to_ivalue(

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -255,10 +255,10 @@ void aoti_torch_grad_mode_set_enabled(bool enabled) {
 
 AOTITorchError aoti_torch_delete_tensor_object(AtenTensorHandle tensor) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
-    "aoti_torch_delete_tensor_object", {
-      at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
-      delete t;
-    });
+      "aoti_torch_delete_tensor_object", {
+        at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
+        delete t;
+      });
 }
 
 AOTITorchError aoti_torch_get_data_ptr(
@@ -450,21 +450,21 @@ AOTITorchError aoti_torch_create_tensor_from_blob(
     int32_t device_index,
     AtenTensorHandle* ret_new_tensor) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
-    "aoti_torch_create_tensor_from_blob", {
-    c10::IntArrayRef sizes(sizes_ptr, ndim);
-    c10::IntArrayRef strides(strides_ptr, ndim);
-    c10::Device device = c10_device(device_type, device_index);
-    c10::TensorOptions options = c10::TensorOptions().device(device).dtype(
-        static_cast<c10::ScalarType>(dtype));
-    *ret_new_tensor = new_tensor_handle(
-        // data == nullptr can happen for a 0-size tensor
-        (data != nullptr) ? at::for_blob(data, sizes)
-                                .strides(strides)
-                                .storage_offset(storage_offset)
-                                .options(options)
-                                .make_tensor()
-                          : at::empty_strided(sizes, strides, options));
-  });
+      "aoti_torch_create_tensor_from_blob", {
+        c10::IntArrayRef sizes(sizes_ptr, ndim);
+        c10::IntArrayRef strides(strides_ptr, ndim);
+        c10::Device device = c10_device(device_type, device_index);
+        c10::TensorOptions options = c10::TensorOptions().device(device).dtype(
+            static_cast<c10::ScalarType>(dtype));
+        *ret_new_tensor = new_tensor_handle(
+            // data == nullptr can happen for a 0-size tensor
+            (data != nullptr) ? at::for_blob(data, sizes)
+                                    .strides(strides)
+                                    .storage_offset(storage_offset)
+                                    .options(options)
+                                    .make_tensor()
+                              : at::empty_strided(sizes, strides, options));
+      });
 }
 
 AOTITorchError aoti_torch_create_tensor_from_blob_v2(
@@ -481,33 +481,33 @@ AOTITorchError aoti_torch_create_tensor_from_blob_v2(
     const uint8_t* opaque_metadata,
     int64_t opaque_metadata_size) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
-    "aoti_torch_create_tensor_from_blob_v2", {
-    if (layout == static_cast<int32_t>(at::kMkldnn)) {
-      c10::IntArrayRef sizes(sizes_ptr, ndim);
-      c10::IntArrayRef strides(strides_ptr, ndim);
-      c10::Device device = c10_device(device_type, device_index);
-      // get a mkldnn tensor wrapped by a torch Tensor(OpaqueTensorImpl),
-      // which used by later mkldnn op.
-      *ret_new_tensor = new_tensor_handle(mkldnn_tensor_from_data_ptr(
-          data,
-          sizes,
-          static_cast<c10::ScalarType>(dtype),
-          device,
-          opaque_metadata,
-          opaque_metadata_size));
-    } else {
-      aoti_torch_create_tensor_from_blob(
-          data,
-          ndim,
-          sizes_ptr,
-          strides_ptr,
-          storage_offset,
-          dtype,
-          device_type,
-          device_index,
-          ret_new_tensor);
-    }
-  });
+      "aoti_torch_create_tensor_from_blob_v2", {
+        if (layout == static_cast<int32_t>(at::kMkldnn)) {
+          c10::IntArrayRef sizes(sizes_ptr, ndim);
+          c10::IntArrayRef strides(strides_ptr, ndim);
+          c10::Device device = c10_device(device_type, device_index);
+          // get a mkldnn tensor wrapped by a torch Tensor(OpaqueTensorImpl),
+          // which used by later mkldnn op.
+          *ret_new_tensor = new_tensor_handle(mkldnn_tensor_from_data_ptr(
+              data,
+              sizes,
+              static_cast<c10::ScalarType>(dtype),
+              device,
+              opaque_metadata,
+              opaque_metadata_size));
+        } else {
+          aoti_torch_create_tensor_from_blob(
+              data,
+              ndim,
+              sizes_ptr,
+              strides_ptr,
+              storage_offset,
+              dtype,
+              device_type,
+              device_index,
+              ret_new_tensor);
+        }
+      });
 }
 
 AOTITorchError aoti_torch__embedding_bag(
@@ -579,36 +579,36 @@ AOTITorchError aoti_torch__scaled_dot_product_flash_attention_v2(
     AtenTensorHandle* ret8 // returns new reference
 ) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
-    "aoti_torch__scaled_dot_product_flash_attention_v2", {
-    at::Tensor* query_tensor = tensor_handle_to_tensor_pointer(query);
-    at::Tensor* key_tensor = tensor_handle_to_tensor_pointer(key);
-    at::Tensor* value_tensor = tensor_handle_to_tensor_pointer(value);
-    auto optional_scale = pointer_to_optional(scale);
-    auto [r0, r1, r2, r3, r4, r5, r6, r7, r8] =
-        at::_scaled_dot_product_flash_attention(
-            *query_tensor,
-            *key_tensor,
-            *value_tensor,
-            dropout_p,
-            is_causal,
-            return_debug_mask,
-            optional_scale);
+      "aoti_torch__scaled_dot_product_flash_attention_v2", {
+        at::Tensor* query_tensor = tensor_handle_to_tensor_pointer(query);
+        at::Tensor* key_tensor = tensor_handle_to_tensor_pointer(key);
+        at::Tensor* value_tensor = tensor_handle_to_tensor_pointer(value);
+        auto optional_scale = pointer_to_optional(scale);
+        auto [r0, r1, r2, r3, r4, r5, r6, r7, r8] =
+            at::_scaled_dot_product_flash_attention(
+                *query_tensor,
+                *key_tensor,
+                *value_tensor,
+                dropout_p,
+                is_causal,
+                return_debug_mask,
+                optional_scale);
 
-    *ret0 = new_tensor_handle(std::move(r0));
-    *ret1 = new_tensor_handle(std::move(r1));
-    // ret2 and ret3 may be null
-    if (ret2) {
-      *ret2 = new_tensor_handle(std::move(r2));
-    }
-    if (ret3) {
-      *ret3 = new_tensor_handle(std::move(r3));
-    }
-    *ret4 = r4.expect_int();
-    *ret5 = r5.expect_int();
-    *ret6 = new_tensor_handle(std::move(r6));
-    *ret7 = new_tensor_handle(std::move(r7));
-    *ret8 = new_tensor_handle(std::move(r8));
-  });
+        *ret0 = new_tensor_handle(std::move(r0));
+        *ret1 = new_tensor_handle(std::move(r1));
+        // ret2 and ret3 may be null
+        if (ret2) {
+          *ret2 = new_tensor_handle(std::move(r2));
+        }
+        if (ret3) {
+          *ret3 = new_tensor_handle(std::move(r3));
+        }
+        *ret4 = r4.expect_int();
+        *ret5 = r5.expect_int();
+        *ret6 = new_tensor_handle(std::move(r6));
+        *ret7 = new_tensor_handle(std::move(r7));
+        *ret8 = new_tensor_handle(std::move(r8));
+      });
 }
 
 AOTITorchError aoti_torch__scaled_dot_product_flash_attention(
@@ -663,27 +663,27 @@ AOTITorchError aoti_torch__scaled_dot_product_efficient_attention(
     AtenTensorHandle* ret3 // returns new reference
 ) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
-    "aoti_torch__scaled_dot_product_efficient_attention", {
-    at::Tensor* query_tensor = tensor_handle_to_tensor_pointer(query);
-    at::Tensor* key_tensor = tensor_handle_to_tensor_pointer(key);
-    at::Tensor* value_tensor = tensor_handle_to_tensor_pointer(value);
-    auto optional_attn_bias =
-        pointer_to_optional(tensor_handle_to_tensor_pointer(attn_bias));
-    auto optional_scale = pointer_to_optional(scale);
-    auto [r0, r1, r2, r3] = at::_scaled_dot_product_efficient_attention(
-        *query_tensor,
-        *key_tensor,
-        *value_tensor,
-        optional_attn_bias,
-        compute_log_sumexp,
-        dropout_p,
-        is_causal,
-        optional_scale);
-    *ret0 = new_tensor_handle(std::move(r0));
-    *ret1 = new_tensor_handle(std::move(r1));
-    *ret2 = new_tensor_handle(std::move(r2));
-    *ret3 = new_tensor_handle(std::move(r3));
-  });
+      "aoti_torch__scaled_dot_product_efficient_attention", {
+        at::Tensor* query_tensor = tensor_handle_to_tensor_pointer(query);
+        at::Tensor* key_tensor = tensor_handle_to_tensor_pointer(key);
+        at::Tensor* value_tensor = tensor_handle_to_tensor_pointer(value);
+        auto optional_attn_bias =
+            pointer_to_optional(tensor_handle_to_tensor_pointer(attn_bias));
+        auto optional_scale = pointer_to_optional(scale);
+        auto [r0, r1, r2, r3] = at::_scaled_dot_product_efficient_attention(
+            *query_tensor,
+            *key_tensor,
+            *value_tensor,
+            optional_attn_bias,
+            compute_log_sumexp,
+            dropout_p,
+            is_causal,
+            optional_scale);
+        *ret0 = new_tensor_handle(std::move(r0));
+        *ret1 = new_tensor_handle(std::move(r1));
+        *ret2 = new_tensor_handle(std::move(r2));
+        *ret3 = new_tensor_handle(std::move(r3));
+      });
 }
 
 AOTITorchError aoti_torch_convolution(
@@ -726,10 +726,11 @@ AOTITorchError aoti_torch_convolution(
 }
 
 AOTITorchError aoti_torch_new_uninitialized_tensor(AtenTensorHandle* ret) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_new_uninitialized_tensor", {
-    at::Tensor* out_tensor = new at::Tensor();
-    *ret = tensor_pointer_to_tensor_handle(out_tensor);
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_new_uninitialized_tensor", {
+        at::Tensor* out_tensor = new at::Tensor();
+        *ret = tensor_pointer_to_tensor_handle(out_tensor);
+      });
 }
 
 AOTITorchError aoti_torch__scaled_mm(
@@ -847,23 +848,25 @@ AOTITorchError aoti_torch_as_strided(
 AOTITorchError aoti_torch_clone_preserve_strides(
     AtenTensorHandle self,
     AtenTensorHandle* ret) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_clone_preserve_strides", {
-    // To mimic clone_preserve_strides which is used in copy_misaligned_inputs
-    at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
-    int64_t needed_size = 1;
-    for (int i = 0; i < self_tensor->dim(); i++) {
-      if (self_tensor->size(i) == 0) {
-        needed_size = 0;
-        break;
-      }
-      needed_size += (self_tensor->size(i) - 1) * self_tensor->stride(i);
-    }
-    at::Tensor ret_tensor =
-        self_tensor->as_strided({needed_size}, {1})
-            .clone()
-            .as_strided(self_tensor->sizes(), self_tensor->strides());
-    *ret = new_tensor_handle(std::move(ret_tensor));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_clone_preserve_strides", {
+        // To mimic clone_preserve_strides which is used in
+        // copy_misaligned_inputs
+        at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
+        int64_t needed_size = 1;
+        for (int i = 0; i < self_tensor->dim(); i++) {
+          if (self_tensor->size(i) == 0) {
+            needed_size = 0;
+            break;
+          }
+          needed_size += (self_tensor->size(i) - 1) * self_tensor->stride(i);
+        }
+        at::Tensor ret_tensor =
+            self_tensor->as_strided({needed_size}, {1})
+                .clone()
+                .as_strided(self_tensor->sizes(), self_tensor->strides());
+        *ret = new_tensor_handle(std::move(ret_tensor));
+      });
 }
 
 // TODO: implement a more efficient version instead of calling into aten
@@ -940,11 +943,13 @@ AOTITorchError aoti_torch__mm_plus_mm_out(
 AOTITorchError aoti_torch_cpu_wrapped_fbgemm_pack_gemm_matrix_fp16(
     AtenTensorHandle weight,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_cpu_wrapped_fbgemm_pack_gemm_matrix_fp16", {
-    at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_cpu_wrapped_fbgemm_pack_gemm_matrix_fp16", {
+        at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
 
-    *out = new_tensor_handle(at::fbgemm_pack_gemm_matrix_fp16(*weight_tensor));
-  });
+        *out =
+            new_tensor_handle(at::fbgemm_pack_gemm_matrix_fp16(*weight_tensor));
+      });
 }
 
 AOTITorchError aoti_torch_cpu__wrapped_linear_prepack(
@@ -953,20 +958,21 @@ AOTITorchError aoti_torch_cpu__wrapped_linear_prepack(
     AtenTensorHandle weight_zero_point,
     AtenTensorHandle bias,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_cpu__wrapped_linear_prepack", {
-    at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
-    at::Tensor* weight_scale_tensor =
-        tensor_handle_to_tensor_pointer(weight_scale);
-    at::Tensor* weight_zero_point_tensor =
-        tensor_handle_to_tensor_pointer(weight_zero_point);
-    at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_cpu__wrapped_linear_prepack", {
+        at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
+        at::Tensor* weight_scale_tensor =
+            tensor_handle_to_tensor_pointer(weight_scale);
+        at::Tensor* weight_zero_point_tensor =
+            tensor_handle_to_tensor_pointer(weight_zero_point);
+        at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
 
-    *out = new_tensor_handle(at::_wrapped_linear_prepack(
-        *weight_tensor,
-        *weight_scale_tensor,
-        *weight_zero_point_tensor,
-        *bias_tensor));
-  });
+        *out = new_tensor_handle(at::_wrapped_linear_prepack(
+            *weight_tensor,
+            *weight_scale_tensor,
+            *weight_zero_point_tensor,
+            *bias_tensor));
+      });
 }
 
 AOTITorchError aoti_torch_cpu_wrapped_fbgemm_linear_fp16_weight(
@@ -975,14 +981,15 @@ AOTITorchError aoti_torch_cpu_wrapped_fbgemm_linear_fp16_weight(
     AtenTensorHandle bias,
     int64_t out_channel,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_cpu_wrapped_fbgemm_linear_fp16_weight", {
-    at::Tensor* input_tensor = tensor_handle_to_tensor_pointer(input);
-    at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
-    at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_cpu_wrapped_fbgemm_linear_fp16_weight", {
+        at::Tensor* input_tensor = tensor_handle_to_tensor_pointer(input);
+        at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
+        at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
 
-    *out = new_tensor_handle(at::fbgemm_linear_fp16_weight_fp32_activation(
-        *input_tensor, *weight_tensor, *bias_tensor));
-  });
+        *out = new_tensor_handle(at::fbgemm_linear_fp16_weight_fp32_activation(
+            *input_tensor, *weight_tensor, *bias_tensor));
+      });
 }
 
 AOTITorchError aoti_torch_cpu__wrapped_quantized_linear_prepacked(
@@ -994,25 +1001,27 @@ AOTITorchError aoti_torch_cpu__wrapped_quantized_linear_prepacked(
     AtenTensorHandle out_zeropoint,
     int64_t out_channel,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_cpu__wrapped_quantized_linear_prepacked", {
-    at::Tensor* input_tensor = tensor_handle_to_tensor_pointer(input);
-    at::Tensor* input_scale_tensor =
-        tensor_handle_to_tensor_pointer(input_scale);
-    at::Tensor* input_zero_point_tensor =
-        tensor_handle_to_tensor_pointer(input_zero_point);
-    at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
-    at::Tensor* out_scale_tensor = tensor_handle_to_tensor_pointer(out_scale);
-    at::Tensor* out_zeropoint_tensor =
-        tensor_handle_to_tensor_pointer(out_zeropoint);
-    *out = new_tensor_handle(at::_wrapped_quantized_linear_prepacked(
-        *input_tensor,
-        *input_scale_tensor,
-        *input_zero_point_tensor,
-        *weight_tensor,
-        *out_scale_tensor,
-        *out_zeropoint_tensor,
-        out_channel));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_cpu__wrapped_quantized_linear_prepacked", {
+        at::Tensor* input_tensor = tensor_handle_to_tensor_pointer(input);
+        at::Tensor* input_scale_tensor =
+            tensor_handle_to_tensor_pointer(input_scale);
+        at::Tensor* input_zero_point_tensor =
+            tensor_handle_to_tensor_pointer(input_zero_point);
+        at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
+        at::Tensor* out_scale_tensor =
+            tensor_handle_to_tensor_pointer(out_scale);
+        at::Tensor* out_zeropoint_tensor =
+            tensor_handle_to_tensor_pointer(out_zeropoint);
+        *out = new_tensor_handle(at::_wrapped_quantized_linear_prepacked(
+            *input_tensor,
+            *input_scale_tensor,
+            *input_zero_point_tensor,
+            *weight_tensor,
+            *out_scale_tensor,
+            *out_zeropoint_tensor,
+            out_channel));
+      });
 }
 
 AOTITorchError aoti_torch_nonzero(
@@ -1028,11 +1037,12 @@ AOTITorchError aoti_torch_repeat_interleave_Tensor(
     AtenTensorHandle repeats,
     int64_t* output_size,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_repeat_interleave_Tensor", {
-    at::Tensor* repeats_tensor = tensor_handle_to_tensor_pointer(repeats);
-    *out = new_tensor_handle(at::_ops::repeat_interleave_Tensor::call(
-        *repeats_tensor, pointer_to_optional<c10::SymInt>(output_size)));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_repeat_interleave_Tensor", {
+        at::Tensor* repeats_tensor = tensor_handle_to_tensor_pointer(repeats);
+        *out = new_tensor_handle(at::_ops::repeat_interleave_Tensor::call(
+            *repeats_tensor, pointer_to_optional<c10::SymInt>(output_size)));
+      });
 }
 
 // Function to check existence of inf and NaN
@@ -1235,22 +1245,24 @@ AOTITorchError aoti_torch_proxy_executor_call_function(
     int64_t* flatten_int_args,
     int num_tensors,
     AtenTensorHandle* flatten_tensor_args) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_proxy_executor_call_function", {
-    if (!proxy_executor) {
-      throw std::runtime_error(
-          "Unable to find a proxy executor to run custom ops. Please check if "
-          "there is a json file generated in the same directory as the so, or use "
-          "torch._inductor.aoti_compile_and_package to package everything into a "
-          "PT2 artifact.");
-    }
-    ProxyExecutor* executor = reinterpret_cast<ProxyExecutor*>(proxy_executor);
-    executor->call_function(
-        extern_node_index,
-        num_ints,
-        flatten_int_args,
-        num_tensors,
-        flatten_tensor_args);
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_proxy_executor_call_function", {
+        if (!proxy_executor) {
+          throw std::runtime_error(
+              "Unable to find a proxy executor to run custom ops. Please check if "
+              "there is a json file generated in the same directory as the so, or use "
+              "torch._inductor.aoti_compile_and_package to package everything into a "
+              "PT2 artifact.");
+        }
+        ProxyExecutor* executor =
+            reinterpret_cast<ProxyExecutor*>(proxy_executor);
+        executor->call_function(
+            extern_node_index,
+            num_ints,
+            flatten_int_args,
+            num_tensors,
+            flatten_tensor_args);
+      });
 }
 
 void aoti_torch_check(
@@ -1401,15 +1413,16 @@ AOTITorchError aoti_torch_library_init_fragment(
     const char* file,
     uint32_t line,
     TorchLibraryHandle* ret_new_torch_lib) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_library_init_fragment", {
-    *ret_new_torch_lib =
-        reinterpret_cast<TorchLibraryOpaque*>(new torch::Library(
-            torch::Library::Kind::FRAGMENT,
-            std::string(ns),
-            std::nullopt,
-            file,
-            line));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_library_init_fragment", {
+        *ret_new_torch_lib =
+            reinterpret_cast<TorchLibraryOpaque*>(new torch::Library(
+                torch::Library::Kind::FRAGMENT,
+                std::string(ns),
+                std::nullopt,
+                file,
+                line));
+      });
 }
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_library_impl(
@@ -1426,14 +1439,14 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_library_impl(
 
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_library_def(TorchLibraryHandle self, const char* name) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("TODO",
-      { reinterpret_cast<torch::Library*>(self)->def(name); });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "TODO", { reinterpret_cast<torch::Library*>(self)->def(name); });
 }
 
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_delete_library_object(TorchLibraryHandle tlh) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("TODO",
-      { delete reinterpret_cast<torch::Library*>(tlh); });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "TODO", { delete reinterpret_cast<torch::Library*>(tlh); });
 }
 
 static c10::IValue to_ivalue(

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -185,13 +185,14 @@ AOTI_TORCH_MEMORY_FORMAT_IMPL(channels_last_3d, ChannelsLast3d)
 AOTI_TORCH_MEMORY_FORMAT_IMPL(preserve_format, Preserve)
 #undef AOTI_TORCH_MEMORY_FORMAT_IMPL
 
-#define AOTI_TORCH_ITEM_IMPL(dtype, ctype)                     \
-  AOTITorchError aoti_torch_item_##dtype(                      \
-      AtenTensorHandle tensor, ctype* ret_value) {             \
-    AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({               \
-      at::Tensor* t = tensor_handle_to_tensor_pointer(tensor); \
-      *ret_value = t->item().to<ctype>();                      \
-    });                                                        \
+#define AOTI_TORCH_ITEM_IMPL(dtype, ctype)                         \
+  AOTITorchError aoti_torch_item_##dtype(                          \
+      AtenTensorHandle tensor, ctype* ret_value) {                 \
+    AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(                    \
+        "tensor_handle_to_tensor_pointer", {                       \
+          at::Tensor* t = tensor_handle_to_tensor_pointer(tensor); \
+          *ret_value = t->item().to<ctype>();                      \
+        });                                                        \
   }
 
 AOTI_TORCH_ITEM_IMPL(float16, c10::Half)
@@ -213,7 +214,7 @@ AOTI_TORCH_ITEM_IMPL(complex64, c10::complex<float>)
 #define AOTI_TORCH_SCALAR_TO_TENSOR_IMPL(dtype, ctype, ttype)                  \
   AOTITorchError aoti_torch_scalar_to_tensor_##dtype(                          \
       ctype value, AtenTensorHandle* ret_new_tensor) {                         \
-    AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({                               \
+    AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::scalar_tensor", {          \
       *ret_new_tensor =                                                        \
           new_tensor_handle(at::scalar_tensor(value, c10::ScalarType::ttype)); \
     });                                                                        \
@@ -253,16 +254,17 @@ void aoti_torch_grad_mode_set_enabled(bool enabled) {
 }
 
 AOTITorchError aoti_torch_delete_tensor_object(AtenTensorHandle tensor) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
-    delete t;
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+    "aoti_torch_delete_tensor_object", {
+      at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
+      delete t;
+    });
 }
 
 AOTITorchError aoti_torch_get_data_ptr(
     AtenTensorHandle tensor,
     void** ret_data_ptr) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_data_ptr", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     if (t->is_mkldnn()) {
       *ret_data_ptr = data_ptr_from_mkldnn(t);
@@ -275,14 +277,14 @@ AOTITorchError aoti_torch_get_data_ptr(
 AOTITorchError aoti_torch_get_storage_size(
     AtenTensorHandle tensor,
     int64_t* ret_size) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_storage_size", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_size = t->storage().nbytes();
   });
 }
 
 AOTITorchError aoti_torch_get_dim(AtenTensorHandle tensor, int64_t* ret_dim) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_dim", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_dim = t->dim();
   });
@@ -291,7 +293,7 @@ AOTITorchError aoti_torch_get_dim(AtenTensorHandle tensor, int64_t* ret_dim) {
 AOTITorchError aoti_torch_get_numel(
     AtenTensorHandle tensor,
     int64_t* ret_numel) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_numel", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_numel = t->numel();
   });
@@ -300,7 +302,7 @@ AOTITorchError aoti_torch_get_numel(
 AOTITorchError aoti_torch_get_storage_numel(
     AtenTensorHandle tensor,
     int64_t* ret_numel) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_storage_numel", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     TORCH_INTERNAL_ASSERT(t->has_storage());
     auto dtype_size = t->dtype().itemsize();
@@ -314,7 +316,7 @@ AOTITorchError aoti_torch_get_storage_numel(
 AOTITorchError aoti_torch_get_sizes(
     AtenTensorHandle tensor,
     int64_t** ret_sizes) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_sizes", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     *ret_sizes = const_cast<int64_t*>(t->sizes().data());
@@ -325,7 +327,7 @@ AOTITorchError aoti_torch_get_size(
     AtenTensorHandle tensor,
     int64_t d,
     int64_t* ret_size) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_size", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_size = t->size(d);
   });
@@ -334,7 +336,7 @@ AOTITorchError aoti_torch_get_size(
 AOTITorchError aoti_torch_get_strides(
     AtenTensorHandle tensor,
     int64_t** ret_strides) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_strides", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     *ret_strides = const_cast<int64_t*>(t->strides().data());
@@ -345,7 +347,7 @@ AOTITorchError aoti_torch_get_stride(
     AtenTensorHandle tensor,
     int64_t d,
     int64_t* ret_stride) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_stride", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_stride = t->stride(d);
   });
@@ -354,7 +356,7 @@ AOTITorchError aoti_torch_get_stride(
 AOTITorchError aoti_torch_get_dtype(
     AtenTensorHandle tensor,
     int32_t* ret_dtype) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_dtype", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_dtype = static_cast<int32_t>(t->scalar_type());
   });
@@ -363,7 +365,7 @@ AOTITorchError aoti_torch_get_dtype(
 AOTITorchError aoti_torch_get_device_type(
     AtenTensorHandle tensor,
     int32_t* ret_device_type) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_device_type", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_device_type = static_cast<int32_t>(t->device().type());
   });
@@ -372,7 +374,7 @@ AOTITorchError aoti_torch_get_device_type(
 AOTITorchError aoti_torch_get_device_index(
     AtenTensorHandle tensor,
     int32_t* ret_device_index) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_device_index", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_device_index = static_cast<int16_t>(t->device().index());
   });
@@ -381,7 +383,7 @@ AOTITorchError aoti_torch_get_device_index(
 AOTITorchError aoti_torch_get_storage_offset(
     AtenTensorHandle tensor,
     int64_t* ret_storage_offset) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_get_storage_offset", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     *ret_storage_offset = t->storage_offset();
   });
@@ -390,7 +392,7 @@ AOTITorchError aoti_torch_get_storage_offset(
 AOTITorchError aoti_torch_new_tensor_handle(
     AtenTensorHandle orig_handle,
     AtenTensorHandle* new_handle) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_new_tensor_handle", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(orig_handle);
     *new_handle = new_tensor_handle(at::Tensor(*t));
   });
@@ -403,7 +405,7 @@ AOTITorchError aoti_torch__reinterpret_tensor(
     const int64_t* strides_ptr,
     int64_t offset_increment,
     AtenTensorHandle* ret_new_tensor) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch__reinterpret_tensor", {
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     c10::IntArrayRef sizes(sizes_ptr, ndim);
     c10::IntArrayRef strides(strides_ptr, ndim);
@@ -421,7 +423,7 @@ AOTITorchError aoti_torch_empty_strided(
     int32_t device_type,
     int32_t device_index,
     AtenTensorHandle* ret_new_tensor) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_empty_strided", {
     c10::IntArrayRef sizes(sizes_ptr, ndim);
     c10::IntArrayRef strides(strides_ptr, ndim);
     if (c10::DeviceType(device_type) == c10::DeviceType::CPU) {
@@ -447,7 +449,8 @@ AOTITorchError aoti_torch_create_tensor_from_blob(
     int32_t device_type,
     int32_t device_index,
     AtenTensorHandle* ret_new_tensor) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+    "aoti_torch_create_tensor_from_blob", {
     c10::IntArrayRef sizes(sizes_ptr, ndim);
     c10::IntArrayRef strides(strides_ptr, ndim);
     c10::Device device = c10_device(device_type, device_index);
@@ -477,7 +480,8 @@ AOTITorchError aoti_torch_create_tensor_from_blob_v2(
     int32_t layout,
     const uint8_t* opaque_metadata,
     int64_t opaque_metadata_size) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+    "aoti_torch_create_tensor_from_blob_v2", {
     if (layout == static_cast<int32_t>(at::kMkldnn)) {
       c10::IntArrayRef sizes(sizes_ptr, ndim);
       c10::IntArrayRef strides(strides_ptr, ndim);
@@ -521,7 +525,7 @@ AOTITorchError aoti_torch__embedding_bag(
     AtenTensorHandle* ret2, // returns new reference
     AtenTensorHandle* ret3 // returns new reference
 ) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch__embedding_bag", {
     auto [r0, r1, r2, r3] = at::_embedding_bag(
         *tensor_handle_to_tensor_pointer(weight),
         *tensor_handle_to_tensor_pointer(indices),
@@ -549,7 +553,7 @@ AOTITorchError aoti_torch__fft_c2c(
     int32_t forward,
     AtenTensorHandle* ret // returns new reference
 ) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch__fft_c2c", {
     auto dim = c10::IntArrayRef(dim_ptr, dim_size);
     *ret = new_tensor_handle(at::_fft_c2c(
         *tensor_handle_to_tensor_pointer(self), dim, normalization, forward));
@@ -574,7 +578,8 @@ AOTITorchError aoti_torch__scaled_dot_product_flash_attention_v2(
     AtenTensorHandle* ret7, // returns new reference
     AtenTensorHandle* ret8 // returns new reference
 ) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+    "aoti_torch__scaled_dot_product_flash_attention_v2", {
     at::Tensor* query_tensor = tensor_handle_to_tensor_pointer(query);
     at::Tensor* key_tensor = tensor_handle_to_tensor_pointer(key);
     at::Tensor* value_tensor = tensor_handle_to_tensor_pointer(value);
@@ -657,7 +662,8 @@ AOTITorchError aoti_torch__scaled_dot_product_efficient_attention(
     AtenTensorHandle* ret2, // returns new reference
     AtenTensorHandle* ret3 // returns new reference
 ) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+    "aoti_torch__scaled_dot_product_efficient_attention", {
     at::Tensor* query_tensor = tensor_handle_to_tensor_pointer(query);
     at::Tensor* key_tensor = tensor_handle_to_tensor_pointer(key);
     at::Tensor* value_tensor = tensor_handle_to_tensor_pointer(value);
@@ -696,7 +702,7 @@ AOTITorchError aoti_torch_convolution(
     int64_t groups,
     AtenTensorHandle* out // returns new reference
 ) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_convolution", {
     at::Tensor* input_tensor = tensor_handle_to_tensor_pointer(input);
     at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
     at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
@@ -720,7 +726,7 @@ AOTITorchError aoti_torch_convolution(
 }
 
 AOTITorchError aoti_torch_new_uninitialized_tensor(AtenTensorHandle* ret) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_new_uninitialized_tensor", {
     at::Tensor* out_tensor = new at::Tensor();
     *ret = tensor_pointer_to_tensor_handle(out_tensor);
   });
@@ -737,7 +743,7 @@ AOTITorchError aoti_torch__scaled_mm(
     int8_t use_fast_accum,
     AtenTensorHandle* ret0,
     AtenTensorHandle* ret1) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch__scaled_mm", {
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     at::Tensor* mat2_tensor = tensor_handle_to_tensor_pointer(mat2);
     at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
@@ -768,7 +774,7 @@ AOTITorchError aoti_torch__scaled_mm_v2(
     int32_t* out_dtype,
     int8_t use_fast_accum,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch__scaled_mm_v2", {
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     at::Tensor* mat2_tensor = tensor_handle_to_tensor_pointer(mat2);
     at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
@@ -799,7 +805,7 @@ AOTITorchError aoti_torch_tensor_copy_(
 AOTITorchError aoti_torch_assign_tensors(
     AtenTensorHandle src,
     AtenTensorHandle dst) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_assign_tensors", {
     at::Tensor* src_tensor = tensor_handle_to_tensor_pointer(src);
     at::Tensor* dst_tensor = tensor_handle_to_tensor_pointer(dst);
     *dst_tensor = *src_tensor;
@@ -809,7 +815,7 @@ AOTITorchError aoti_torch_assign_tensors(
 AOTITorchError aoti_torch_assign_tensors_out(
     AtenTensorHandle src,
     AtenTensorHandle* ret_dst) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_assign_tensors_out", {
     at::Tensor* src_tensor_ptr = tensor_handle_to_tensor_pointer(src);
     at::Tensor dst_tensor = *src_tensor_ptr;
     *ret_dst = new_tensor_handle(std::move(dst_tensor));
@@ -817,7 +823,7 @@ AOTITorchError aoti_torch_assign_tensors_out(
 }
 
 AOTITorchError aoti_torch_clone(AtenTensorHandle self, AtenTensorHandle* ret) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_clone", {
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     *ret = new_tensor_handle(self_tensor->clone());
   });
@@ -828,7 +834,7 @@ AOTITorchError aoti_torch_as_strided(
     const int64_t* sizes_ptr,
     const int64_t* strides_ptr,
     AtenTensorHandle* ret) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_as_strided", {
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     int64_t ndim = self_tensor->dim();
     c10::IntArrayRef sizes(sizes_ptr, ndim);
@@ -841,7 +847,7 @@ AOTITorchError aoti_torch_as_strided(
 AOTITorchError aoti_torch_clone_preserve_strides(
     AtenTensorHandle self,
     AtenTensorHandle* ret) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_clone_preserve_strides", {
     // To mimic clone_preserve_strides which is used in copy_misaligned_inputs
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     int64_t needed_size = 1;
@@ -868,7 +874,7 @@ AOTITorchError aoti_torch_addmm_out(
     AtenTensorHandle mat2,
     float beta,
     float alpha) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_addmm_out", {
     at::Tensor* out_tensor = tensor_handle_to_tensor_pointer(out);
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     at::Tensor* mat1_tensor = tensor_handle_to_tensor_pointer(mat1);
@@ -883,7 +889,7 @@ AOTITorchError aoti_torch_bmm_out(
     AtenTensorHandle out,
     AtenTensorHandle self,
     AtenTensorHandle mat2) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_bmm_out", {
     at::Tensor* out_tensor = tensor_handle_to_tensor_pointer(out);
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     at::Tensor* mat2_tensor = tensor_handle_to_tensor_pointer(mat2);
@@ -895,7 +901,7 @@ AOTITorchError aoti_torch_copy_(
     AtenTensorHandle self,
     AtenTensorHandle src,
     int32_t non_blocking) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_copy_", {
     tensor_handle_to_tensor_pointer(self)->copy_(
         *tensor_handle_to_tensor_pointer(src), non_blocking);
   });
@@ -906,7 +912,7 @@ AOTITorchError aoti_torch_mm_out(
     AtenTensorHandle out,
     AtenTensorHandle self,
     AtenTensorHandle mat2) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_mm_out", {
     at::Tensor* out_tensor = tensor_handle_to_tensor_pointer(out);
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     at::Tensor* mat2_tensor = tensor_handle_to_tensor_pointer(mat2);
@@ -920,7 +926,7 @@ AOTITorchError aoti_torch__mm_plus_mm_out(
     AtenTensorHandle b,
     AtenTensorHandle c,
     AtenTensorHandle d) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch__mm_plus_mm_out", {
     at::Tensor* out_tensor = tensor_handle_to_tensor_pointer(out);
     at::Tensor* a_tensor = tensor_handle_to_tensor_pointer(a);
     at::Tensor* b_tensor = tensor_handle_to_tensor_pointer(b);
@@ -934,7 +940,7 @@ AOTITorchError aoti_torch__mm_plus_mm_out(
 AOTITorchError aoti_torch_cpu_wrapped_fbgemm_pack_gemm_matrix_fp16(
     AtenTensorHandle weight,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_cpu_wrapped_fbgemm_pack_gemm_matrix_fp16", {
     at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
 
     *out = new_tensor_handle(at::fbgemm_pack_gemm_matrix_fp16(*weight_tensor));
@@ -947,7 +953,7 @@ AOTITorchError aoti_torch_cpu__wrapped_linear_prepack(
     AtenTensorHandle weight_zero_point,
     AtenTensorHandle bias,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_cpu__wrapped_linear_prepack", {
     at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
     at::Tensor* weight_scale_tensor =
         tensor_handle_to_tensor_pointer(weight_scale);
@@ -969,7 +975,7 @@ AOTITorchError aoti_torch_cpu_wrapped_fbgemm_linear_fp16_weight(
     AtenTensorHandle bias,
     int64_t out_channel,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_cpu_wrapped_fbgemm_linear_fp16_weight", {
     at::Tensor* input_tensor = tensor_handle_to_tensor_pointer(input);
     at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
     at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
@@ -988,7 +994,7 @@ AOTITorchError aoti_torch_cpu__wrapped_quantized_linear_prepacked(
     AtenTensorHandle out_zeropoint,
     int64_t out_channel,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_cpu__wrapped_quantized_linear_prepacked", {
     at::Tensor* input_tensor = tensor_handle_to_tensor_pointer(input);
     at::Tensor* input_scale_tensor =
         tensor_handle_to_tensor_pointer(input_scale);
@@ -1012,7 +1018,7 @@ AOTITorchError aoti_torch_cpu__wrapped_quantized_linear_prepacked(
 AOTITorchError aoti_torch_nonzero(
     AtenTensorHandle self,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_nonzero", {
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     *out = new_tensor_handle(at::nonzero(*self_tensor));
   });
@@ -1022,7 +1028,7 @@ AOTITorchError aoti_torch_repeat_interleave_Tensor(
     AtenTensorHandle repeats,
     int64_t* output_size,
     AtenTensorHandle* out) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_repeat_interleave_Tensor", {
     at::Tensor* repeats_tensor = tensor_handle_to_tensor_pointer(repeats);
     *out = new_tensor_handle(at::_ops::repeat_interleave_Tensor::call(
         *repeats_tensor, pointer_to_optional<c10::SymInt>(output_size)));
@@ -1033,7 +1039,7 @@ AOTITorchError aoti_torch_repeat_interleave_Tensor(
 AOTITorchError aoti_torch_check_inf_and_nan(
     const char* tensor_name,
     AtenTensorHandle tensor) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_check_inf_and_nan", {
     at::Tensor* check_tensor = tensor_handle_to_tensor_pointer(tensor);
 
     assert_inf_and_nan(tensor_name, *check_tensor);
@@ -1046,7 +1052,7 @@ AOTITorchError aoti_torch_scatter_out(
     int64_t dim,
     AtenTensorHandle index,
     AtenTensorHandle src) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_scatter_out", {
     at::Tensor* out_tensor = tensor_handle_to_tensor_pointer(out);
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     at::Tensor* index_tensor = tensor_handle_to_tensor_pointer(index);
@@ -1063,7 +1069,7 @@ AOTITorchError aoti_torch_scatter_reduce_out(
     AtenTensorHandle src,
     const char* reduce,
     int32_t include_self) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_scatter_reduce_out", {
     at::Tensor* out_tensor = tensor_handle_to_tensor_pointer(out);
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     at::Tensor* index_tensor = tensor_handle_to_tensor_pointer(index);
@@ -1087,7 +1093,7 @@ AOTITorchError aoti_torch_index_put_out(
     // NOLINTNEXTLINE(misc-misplaced-const)
     const AtenTensorHandle values,
     bool accumulate) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_index_put_out", {
     c10::List<std::optional<at::Tensor>> indices_;
     indices_.reserve(num_indices);
     for (size_t i = 0; i < num_indices; i++) {
@@ -1106,7 +1112,7 @@ AOTITorchError aoti_torch_view_as_real(
     AtenTensorHandle self,
     AtenTensorHandle* ret // returns new reference
 ) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_view_as_real", {
     *ret = new_tensor_handle(
         at::_ops::view_as_real::call(*tensor_handle_to_tensor_pointer(self)));
   });
@@ -1117,7 +1123,7 @@ AOTITorchError aoti_torch_view_dtype(
     int32_t dtype,
     AtenTensorHandle* ret // returns new reference
 ) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_view_dtype", {
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     *ret = new_tensor_handle(at::_ops::view_dtype::call(
         *self_tensor, static_cast<c10::ScalarType>(dtype)));
@@ -1229,7 +1235,7 @@ AOTITorchError aoti_torch_proxy_executor_call_function(
     int64_t* flatten_int_args,
     int num_tensors,
     AtenTensorHandle* flatten_tensor_args) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_proxy_executor_call_function", {
     if (!proxy_executor) {
       throw std::runtime_error(
           "Unable to find a proxy executor to run custom ops. Please check if "
@@ -1278,7 +1284,7 @@ AOTITorchError aoti_torch__alloc_from_pool(
     const int64_t* sizes_ptr,
     const int64_t* strides_ptr,
     AtenTensorHandle* ret_new_tensor) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch__alloc_from_pool", {
     at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
     c10::IntArrayRef sizes(sizes_ptr, ndim);
     c10::IntArrayRef strides(strides_ptr, ndim);
@@ -1292,7 +1298,7 @@ AOTITorchError aoti_torch__alloc_from_pool(
 }
 
 AOTITorchError aoti_torch_zero_(AtenTensorHandle tensor) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_zero_", {
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
     t->zero_();
   });
@@ -1363,7 +1369,7 @@ AOTITorchError aoti_torch_library_init_impl(
     const char* file,
     uint32_t line,
     TorchLibraryHandle* ret_new_torch_lib) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_library_init_impl", {
     *ret_new_torch_lib =
         reinterpret_cast<TorchLibraryOpaque*>(new torch::Library(
             torch::Library::Kind::IMPL,
@@ -1379,7 +1385,7 @@ AOTITorchError aoti_torch_library_init_def(
     const char* file,
     uint32_t line,
     TorchLibraryHandle* ret_new_torch_lib) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_library_init_def", {
     *ret_new_torch_lib =
         reinterpret_cast<TorchLibraryOpaque*>(new torch::Library(
             torch::Library::Kind::DEF,
@@ -1395,7 +1401,7 @@ AOTITorchError aoti_torch_library_init_fragment(
     const char* file,
     uint32_t line,
     TorchLibraryHandle* ret_new_torch_lib) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_library_init_fragment", {
     *ret_new_torch_lib =
         reinterpret_cast<TorchLibraryOpaque*>(new torch::Library(
             torch::Library::Kind::FRAGMENT,
@@ -1410,7 +1416,7 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_library_impl(
     TorchLibraryHandle self,
     const char* name,
     void (*fn)(StableIValue*, uint64_t, uint64_t)) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_library_impl", {
     reinterpret_cast<torch::Library*>(self)->impl(
         name,
         torch::CppFunction::makeFromBoxedFunctor(
@@ -1420,13 +1426,13 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_library_impl(
 
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_library_def(TorchLibraryHandle self, const char* name) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("TODO",
       { reinterpret_cast<torch::Library*>(self)->def(name); });
 }
 
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_delete_library_object(TorchLibraryHandle tlh) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("TODO",
       { delete reinterpret_cast<torch::Library*>(tlh); });
 }
 
@@ -1470,7 +1476,7 @@ AOTITorchError aoti_torch_call_dispatcher(
     const char* opName,
     const char* overloadName,
     StableIValue* stack) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_call_dispatcher", {
     const auto op =
         c10::Dispatcher::singleton().findSchemaOrThrow(opName, overloadName);
     const auto& schema = op.schema();

--- a/torch/csrc/inductor/aoti_torch/shim_cuda.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_cuda.cpp
@@ -9,47 +9,53 @@ AOTITorchError aoti_torch_create_cuda_guard(
     int32_t device_index,
     CUDAGuardHandle* ret_guard // returns new reference
 ) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_create_cuda_guard", {
     at::cuda::CUDAGuard* guard = new at::cuda::CUDAGuard(device_index);
     *ret_guard = reinterpret_cast<CUDAGuardHandle>(guard);
   });
 }
 
 AOTITorchError aoti_torch_delete_cuda_guard(CUDAGuardHandle guard) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
-      { delete reinterpret_cast<at::cuda::CUDAGuard*>(guard); });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_delete_cuda_guard", {
+    delete reinterpret_cast<at::cuda::CUDAGuard*>(guard);
+  });
 }
 
 AOTITorchError aoti_torch_cuda_guard_set_index(
     CUDAGuardHandle guard,
     int32_t device_index) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    reinterpret_cast<at::cuda::CUDAGuard*>(guard)->set_index(device_index);
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_cuda_guard_set_index", {
+        reinterpret_cast<at::cuda::CUDAGuard*>(guard)->set_index(device_index);
+      });
 }
 
 AOTITorchError aoti_torch_create_cuda_stream_guard(
     void* stream,
     int32_t device_index,
     CUDAStreamGuardHandle* ret_guard) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    at::cuda::CUDAStreamGuard* guard =
-        new at::cuda::CUDAStreamGuard(at::cuda::getStreamFromExternal(
-            static_cast<cudaStream_t>(stream), device_index));
-    *ret_guard = reinterpret_cast<CUDAStreamGuardHandle>(guard);
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_create_cuda_stream_guard", {
+        at::cuda::CUDAStreamGuard* guard =
+            new at::cuda::CUDAStreamGuard(at::cuda::getStreamFromExternal(
+                static_cast<cudaStream_t>(stream), device_index));
+        *ret_guard = reinterpret_cast<CUDAStreamGuardHandle>(guard);
+      });
 }
 
 AOTITorchError aoti_torch_delete_cuda_stream_guard(
     CUDAStreamGuardHandle guard) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_delete_cuda_stream_guard",
       { delete reinterpret_cast<at::cuda::CUDAStreamGuard*>(guard); });
 }
 
 AOTITorchError aoti_torch_get_current_cuda_stream(
     int32_t device_index,
     void** ret_stream) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    *(cudaStream_t*)(ret_stream) = at::cuda::getCurrentCUDAStream(device_index);
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_get_current_cuda_stream", {
+        *(cudaStream_t*)(ret_stream) =
+            at::cuda::getCurrentCUDAStream(device_index);
+      });
 }

--- a/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
@@ -46,28 +46,30 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise_binary(
     int64_t unary_scalars_len_,
     const char** unary_algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::mkldnn_convolution_pointwise_binary", {
-    c10::List<std::optional<c10::Scalar>> unary_scalars_list;
-    unary_scalars_list.reserve(unary_scalars_len_);
-    for (int64_t i = 0; i < unary_scalars_len_; i++) {
-      unary_scalars_list.emplace_back(pointer_to_optional(unary_scalars[i]));
-    }
-    auto tmp_result = at::native::mkldnn_convolution_pointwise_binary(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(other),
-        *tensor_handle_to_tensor_pointer(W),
-        pointer_to_optional<at::Tensor>(B),
-        pointer_to_list<int64_t>(padding, padding_len_),
-        pointer_to_list<int64_t>(stride, stride_len_),
-        pointer_to_list<int64_t>(dilation, dilation_len_),
-        groups,
-        binary_attr,
-        pointer_to_optional<c10::Scalar>(alpha),
-        pointer_to_optional<std::string_view>(unary_attr),
-        unary_scalars_list,
-        pointer_to_optional<std::string_view>(unary_algorithm));
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::mkldnn_convolution_pointwise_binary", {
+        c10::List<std::optional<c10::Scalar>> unary_scalars_list;
+        unary_scalars_list.reserve(unary_scalars_len_);
+        for (int64_t i = 0; i < unary_scalars_len_; i++) {
+          unary_scalars_list.emplace_back(
+              pointer_to_optional(unary_scalars[i]));
+        }
+        auto tmp_result = at::native::mkldnn_convolution_pointwise_binary(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(other),
+            *tensor_handle_to_tensor_pointer(W),
+            pointer_to_optional<at::Tensor>(B),
+            pointer_to_list<int64_t>(padding, padding_len_),
+            pointer_to_list<int64_t>(stride, stride_len_),
+            pointer_to_list<int64_t>(dilation, dilation_len_),
+            groups,
+            binary_attr,
+            pointer_to_optional<c10::Scalar>(alpha),
+            pointer_to_optional<std::string_view>(unary_attr),
+            unary_scalars_list,
+            pointer_to_optional<std::string_view>(unary_algorithm));
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise_binary_(
@@ -89,28 +91,30 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise_binary_(
     int64_t unary_scalars_len_,
     const char** unary_algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::mkldnn_convolution_pointwise_binary_", {
-    c10::List<std::optional<c10::Scalar>> unary_scalars_list;
-    unary_scalars_list.reserve(unary_scalars_len_);
-    for (int64_t i = 0; i < unary_scalars_len_; i++) {
-      unary_scalars_list.emplace_back(pointer_to_optional(unary_scalars[i]));
-    }
-    auto tmp_result = at::native::mkldnn_convolution_pointwise_binary_(
-        *tensor_handle_to_tensor_pointer(other),
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(W),
-        pointer_to_optional<at::Tensor>(B),
-        pointer_to_list<int64_t>(padding, padding_len_),
-        pointer_to_list<int64_t>(stride, stride_len_),
-        pointer_to_list<int64_t>(dilation, dilation_len_),
-        groups,
-        binary_attr,
-        pointer_to_optional<c10::Scalar>(alpha),
-        pointer_to_optional<std::string_view>(unary_attr),
-        unary_scalars_list,
-        pointer_to_optional<std::string_view>(unary_algorithm));
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::mkldnn_convolution_pointwise_binary_", {
+        c10::List<std::optional<c10::Scalar>> unary_scalars_list;
+        unary_scalars_list.reserve(unary_scalars_len_);
+        for (int64_t i = 0; i < unary_scalars_len_; i++) {
+          unary_scalars_list.emplace_back(
+              pointer_to_optional(unary_scalars[i]));
+        }
+        auto tmp_result = at::native::mkldnn_convolution_pointwise_binary_(
+            *tensor_handle_to_tensor_pointer(other),
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(W),
+            pointer_to_optional<at::Tensor>(B),
+            pointer_to_list<int64_t>(padding, padding_len_),
+            pointer_to_list<int64_t>(stride, stride_len_),
+            pointer_to_list<int64_t>(dilation, dilation_len_),
+            groups,
+            binary_attr,
+            pointer_to_optional<c10::Scalar>(alpha),
+            pointer_to_optional<std::string_view>(unary_attr),
+            unary_scalars_list,
+            pointer_to_optional<std::string_view>(unary_algorithm));
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise(
@@ -129,25 +133,26 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise(
     int64_t scalars_len_,
     const char** algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::mkldnn_convolution_pointwise", {
-    c10::List<std::optional<c10::Scalar>> scalars_list;
-    scalars_list.reserve(scalars_len_);
-    for (int64_t i = 0; i < scalars_len_; i++) {
-      scalars_list.emplace_back(pointer_to_optional(scalars[i]));
-    }
-    auto tmp_result = at::native::mkldnn_convolution_pointwise(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(W),
-        pointer_to_optional<at::Tensor>(B),
-        pointer_to_list<int64_t>(padding, padding_len_),
-        pointer_to_list<int64_t>(stride, stride_len_),
-        pointer_to_list<int64_t>(dilation, dilation_len_),
-        groups,
-        attr,
-        scalars_list,
-        pointer_to_optional<std::string_view>(algorithm));
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::mkldnn_convolution_pointwise", {
+        c10::List<std::optional<c10::Scalar>> scalars_list;
+        scalars_list.reserve(scalars_len_);
+        for (int64_t i = 0; i < scalars_len_; i++) {
+          scalars_list.emplace_back(pointer_to_optional(scalars[i]));
+        }
+        auto tmp_result = at::native::mkldnn_convolution_pointwise(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(W),
+            pointer_to_optional<at::Tensor>(B),
+            pointer_to_list<int64_t>(padding, padding_len_),
+            pointer_to_list<int64_t>(stride, stride_len_),
+            pointer_to_list<int64_t>(dilation, dilation_len_),
+            groups,
+            attr,
+            scalars_list,
+            pointer_to_optional<std::string_view>(algorithm));
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu_mkldnn__convolution_transpose_pointwise(
@@ -168,26 +173,27 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_transpose_pointwise(
     int64_t scalars_len_,
     const char** algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::mkldnn_convolution_transpose_pointwise", {
-    c10::List<std::optional<c10::Scalar>> scalars_list;
-    scalars_list.reserve(scalars_len_);
-    for (int64_t i = 0; i < scalars_len_; i++) {
-      scalars_list.emplace_back(pointer_to_optional(scalars[i]));
-    }
-    auto tmp_result = at::native::mkldnn_convolution_transpose_pointwise(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(W),
-        pointer_to_optional<at::Tensor>(B),
-        pointer_to_list<int64_t>(padding, padding_len_),
-        pointer_to_list<int64_t>(output_padding, output_padding_len_),
-        pointer_to_list<int64_t>(stride, stride_len_),
-        pointer_to_list<int64_t>(dilation, dilation_len_),
-        groups,
-        attr,
-        scalars_list,
-        pointer_to_optional<std::string_view>(algorithm));
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::mkldnn_convolution_transpose_pointwise", {
+        c10::List<std::optional<c10::Scalar>> scalars_list;
+        scalars_list.reserve(scalars_len_);
+        for (int64_t i = 0; i < scalars_len_; i++) {
+          scalars_list.emplace_back(pointer_to_optional(scalars[i]));
+        }
+        auto tmp_result = at::native::mkldnn_convolution_transpose_pointwise(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(W),
+            pointer_to_optional<at::Tensor>(B),
+            pointer_to_list<int64_t>(padding, padding_len_),
+            pointer_to_list<int64_t>(output_padding, output_padding_len_),
+            pointer_to_list<int64_t>(stride, stride_len_),
+            pointer_to_list<int64_t>(dilation, dilation_len_),
+            groups,
+            attr,
+            scalars_list,
+            pointer_to_optional<std::string_view>(algorithm));
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu_mkldnn_rnn_layer(
@@ -246,21 +252,22 @@ AOTITorchError aoti_torch_cpu__linear_pointwise(
     int64_t scalars_len_,
     const char** algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::mkldnn_linear_pointwise_binary", {
-    c10::List<std::optional<c10::Scalar>> scalars_list;
-    scalars_list.reserve(scalars_len_);
-    for (int64_t i = 0; i < scalars_len_; i++) {
-      scalars_list.emplace_back(pointer_to_optional(scalars[i]));
-    }
-    auto tmp_result = at::native::mkldnn_linear_pointwise(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(W),
-        pointer_to_optional<at::Tensor>(B),
-        attr,
-        scalars_list,
-        pointer_to_optional<std::string_view>(algorithm));
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::mkldnn_linear_pointwise_binary", {
+        c10::List<std::optional<c10::Scalar>> scalars_list;
+        scalars_list.reserve(scalars_len_);
+        for (int64_t i = 0; i < scalars_len_; i++) {
+          scalars_list.emplace_back(pointer_to_optional(scalars[i]));
+        }
+        auto tmp_result = at::native::mkldnn_linear_pointwise(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(W),
+            pointer_to_optional<at::Tensor>(B),
+            attr,
+            scalars_list,
+            pointer_to_optional<std::string_view>(algorithm));
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu__linear_pointwise_binary(
@@ -270,15 +277,16 @@ AOTITorchError aoti_torch_cpu__linear_pointwise_binary(
     AtenTensorHandle* B,
     const char* attr,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::mkldnn_linear_pointwise", {
-    auto tmp_result = at::native::mkldnn_linear_pointwise_binary(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(other),
-        *tensor_handle_to_tensor_pointer(W),
-        pointer_to_optional<at::Tensor>(B),
-        attr);
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::mkldnn_linear_pointwise", {
+        auto tmp_result = at::native::mkldnn_linear_pointwise_binary(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(other),
+            *tensor_handle_to_tensor_pointer(W),
+            pointer_to_optional<at::Tensor>(B),
+            attr);
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu__qlinear_pointwise_tensor(
@@ -297,29 +305,30 @@ AOTITorchError aoti_torch_cpu__qlinear_pointwise_tensor(
     int64_t post_op_args_len_,
     const char* post_op_algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::QLinearOnednn::run_pointwise_tensor", {
-    c10::List<std::optional<c10::Scalar>> scalars_list;
-    scalars_list.reserve(post_op_args_len_);
-    for (int64_t i = 0; i < post_op_args_len_; i++) {
-      scalars_list.emplace_back(pointer_to_optional(post_op_args[i]));
-    }
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::QLinearOnednn::run_pointwise_tensor", {
+        c10::List<std::optional<c10::Scalar>> scalars_list;
+        scalars_list.reserve(post_op_args_len_);
+        for (int64_t i = 0; i < post_op_args_len_; i++) {
+          scalars_list.emplace_back(pointer_to_optional(post_op_args[i]));
+        }
 
-    auto tmp_result = at::native::QLinearOnednn::run_pointwise_tensor(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(act_scale),
-        *tensor_handle_to_tensor_pointer(act_zero_point),
-        *tensor_handle_to_tensor_pointer(onednn_weight),
-        *tensor_handle_to_tensor_pointer(weight_scales),
-        *tensor_handle_to_tensor_pointer(weight_zero_points),
-        pointer_to_optional<at::Tensor>(B),
-        output_scale,
-        output_zero_point,
-        pointer_to_optional<at::ScalarType>(output_dtype),
-        post_op_name,
-        scalars_list,
-        post_op_algorithm);
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+        auto tmp_result = at::native::QLinearOnednn::run_pointwise_tensor(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(act_scale),
+            *tensor_handle_to_tensor_pointer(act_zero_point),
+            *tensor_handle_to_tensor_pointer(onednn_weight),
+            *tensor_handle_to_tensor_pointer(weight_scales),
+            *tensor_handle_to_tensor_pointer(weight_zero_points),
+            pointer_to_optional<at::Tensor>(B),
+            output_scale,
+            output_zero_point,
+            pointer_to_optional<at::ScalarType>(output_dtype),
+            post_op_name,
+            scalars_list,
+            post_op_algorithm);
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu__qlinear_pointwise_binary_tensor(
@@ -343,34 +352,36 @@ AOTITorchError aoti_torch_cpu__qlinear_pointwise_binary_tensor(
     int64_t unary_post_op_args_len_,
     const char* unary_post_op_algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::QConvoneDNN::run_pointwise_tensor", {
-    c10::List<std::optional<c10::Scalar>> scalars_list;
-    scalars_list.reserve(unary_post_op_args_len_);
-    for (int64_t i = 0; i < unary_post_op_args_len_; i++) {
-      scalars_list.emplace_back(pointer_to_optional(unary_post_op_args[i]));
-    }
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::QConvoneDNN::run_pointwise_tensor", {
+        c10::List<std::optional<c10::Scalar>> scalars_list;
+        scalars_list.reserve(unary_post_op_args_len_);
+        for (int64_t i = 0; i < unary_post_op_args_len_; i++) {
+          scalars_list.emplace_back(pointer_to_optional(unary_post_op_args[i]));
+        }
 
-    auto tmp_result = at::native::QLinearOnednn::run_pointwise_binary_tensor(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(act_scale),
-        *tensor_handle_to_tensor_pointer(act_zero_point),
-        *tensor_handle_to_tensor_pointer(onednn_weight),
-        *tensor_handle_to_tensor_pointer(weight_scales),
-        *tensor_handle_to_tensor_pointer(weight_zero_points),
-        pointer_to_optional<at::Tensor>(other),
-        pointer_to_optional<at::Tensor>(B),
-        output_scale,
-        output_zero_point,
-        pointer_to_optional<at::ScalarType>(output_dtype),
-        other_scale,
-        other_zero_point,
-        binary_post_op,
-        binary_alpha,
-        unary_post_op,
-        scalars_list,
-        unary_post_op_algorithm);
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+        auto tmp_result =
+            at::native::QLinearOnednn::run_pointwise_binary_tensor(
+                *tensor_handle_to_tensor_pointer(X),
+                *tensor_handle_to_tensor_pointer(act_scale),
+                *tensor_handle_to_tensor_pointer(act_zero_point),
+                *tensor_handle_to_tensor_pointer(onednn_weight),
+                *tensor_handle_to_tensor_pointer(weight_scales),
+                *tensor_handle_to_tensor_pointer(weight_zero_points),
+                pointer_to_optional<at::Tensor>(other),
+                pointer_to_optional<at::Tensor>(B),
+                output_scale,
+                output_zero_point,
+                pointer_to_optional<at::ScalarType>(output_dtype),
+                other_scale,
+                other_zero_point,
+                binary_post_op,
+                binary_alpha,
+                unary_post_op,
+                scalars_list,
+                unary_post_op_algorithm);
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu__qconv2d_pointwise_tensor(
@@ -396,40 +407,41 @@ AOTITorchError aoti_torch_cpu__qconv2d_pointwise_tensor(
     int64_t post_op_args_len_,
     const char** algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::QConvoneDNN::run_pointwise_binary_tensor", {
-    c10::List<std::optional<c10::Scalar>> scalars_list;
-    scalars_list.reserve(post_op_args_len_);
-    for (int64_t i = 0; i < post_op_args_len_; i++) {
-      scalars_list.emplace_back(pointer_to_optional(post_op_args[i]));
-    }
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::QConvoneDNN::run_pointwise_binary_tensor", {
+        c10::List<std::optional<c10::Scalar>> scalars_list;
+        scalars_list.reserve(post_op_args_len_);
+        for (int64_t i = 0; i < post_op_args_len_; i++) {
+          scalars_list.emplace_back(pointer_to_optional(post_op_args[i]));
+        }
 
-    c10::List<int64_t> stride_list =
-        convert_to_c10_List<int64_t>(stride_args, stride_len_);
-    c10::List<int64_t> padding_list =
-        convert_to_c10_List<int64_t>(padding_args, padding_len_);
-    c10::List<int64_t> dilation_list =
-        convert_to_c10_List<int64_t>(dilation_args, dilation_len_);
+        c10::List<int64_t> stride_list =
+            convert_to_c10_List<int64_t>(stride_args, stride_len_);
+        c10::List<int64_t> padding_list =
+            convert_to_c10_List<int64_t>(padding_args, padding_len_);
+        c10::List<int64_t> dilation_list =
+            convert_to_c10_List<int64_t>(dilation_args, dilation_len_);
 
-    auto tmp_result = at::native::QConvoneDNN::run_pointwise_tensor(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(act_scale),
-        *tensor_handle_to_tensor_pointer(act_zero_point),
-        *tensor_handle_to_tensor_pointer(onednn_weight),
-        *tensor_handle_to_tensor_pointer(weight_scales),
-        *tensor_handle_to_tensor_pointer(weight_zero_points),
-        pointer_to_optional<at::Tensor>(B),
-        stride_list,
-        padding_list,
-        dilation_list,
-        groups,
-        output_scale,
-        output_zero_point,
-        pointer_to_optional<at::ScalarType>(output_dtype),
-        attr,
-        scalars_list,
-        pointer_to_optional<std::string_view>(algorithm));
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+        auto tmp_result = at::native::QConvoneDNN::run_pointwise_tensor(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(act_scale),
+            *tensor_handle_to_tensor_pointer(act_zero_point),
+            *tensor_handle_to_tensor_pointer(onednn_weight),
+            *tensor_handle_to_tensor_pointer(weight_scales),
+            *tensor_handle_to_tensor_pointer(weight_zero_points),
+            pointer_to_optional<at::Tensor>(B),
+            stride_list,
+            padding_list,
+            dilation_list,
+            groups,
+            output_scale,
+            output_zero_point,
+            pointer_to_optional<at::ScalarType>(output_dtype),
+            attr,
+            scalars_list,
+            pointer_to_optional<std::string_view>(algorithm));
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 AOTITorchError aoti_torch_cpu__qconv2d_pointwise_binary_tensor(
@@ -460,45 +472,47 @@ AOTITorchError aoti_torch_cpu__qconv2d_pointwise_binary_tensor(
     int64_t unary_scalars_len_,
     const char** unary_algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::QConvoneDNN::run_pointwise_binary_tensor", {
-    c10::List<std::optional<c10::Scalar>> unary_scalars_list;
-    unary_scalars_list.reserve(unary_scalars_len_);
-    for (int64_t i = 0; i < unary_scalars_len_; i++) {
-      unary_scalars_list.emplace_back(pointer_to_optional(unary_scalars[i]));
-    }
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "at::native::QConvoneDNN::run_pointwise_binary_tensor", {
+        c10::List<std::optional<c10::Scalar>> unary_scalars_list;
+        unary_scalars_list.reserve(unary_scalars_len_);
+        for (int64_t i = 0; i < unary_scalars_len_; i++) {
+          unary_scalars_list.emplace_back(
+              pointer_to_optional(unary_scalars[i]));
+        }
 
-    c10::List<int64_t> stride_list =
-        convert_to_c10_List<int64_t>(stride_args, stride_len_);
-    c10::List<int64_t> padding_list =
-        convert_to_c10_List<int64_t>(padding_args, padding_len_);
-    c10::List<int64_t> dilation_list =
-        convert_to_c10_List<int64_t>(dilation_args, dilation_len_);
+        c10::List<int64_t> stride_list =
+            convert_to_c10_List<int64_t>(stride_args, stride_len_);
+        c10::List<int64_t> padding_list =
+            convert_to_c10_List<int64_t>(padding_args, padding_len_);
+        c10::List<int64_t> dilation_list =
+            convert_to_c10_List<int64_t>(dilation_args, dilation_len_);
 
-    auto tmp_result = at::native::QConvoneDNN::run_pointwise_binary_tensor(
-        *tensor_handle_to_tensor_pointer(X),
-        *tensor_handle_to_tensor_pointer(act_scale),
-        *tensor_handle_to_tensor_pointer(act_zero_point),
-        *tensor_handle_to_tensor_pointer(onednn_weight),
-        *tensor_handle_to_tensor_pointer(weight_scales),
-        *tensor_handle_to_tensor_pointer(weight_zero_points),
-        *tensor_handle_to_tensor_pointer(accum),
-        pointer_to_optional<at::Tensor>(B),
-        stride_list,
-        padding_list,
-        dilation_list,
-        groups,
-        output_scale,
-        output_zero_point,
-        pointer_to_optional<at::ScalarType>(output_dtype),
-        accum_scale,
-        accum_zero_point,
-        binary_attr,
-        pointer_to_optional<c10::Scalar>(alpha),
-        pointer_to_optional<std::string_view>(unary_attr),
-        unary_scalars_list,
-        pointer_to_optional<std::string_view>(unary_algorithm));
-    *ret0 = new_tensor_handle(std::move(tmp_result));
-  });
+        auto tmp_result = at::native::QConvoneDNN::run_pointwise_binary_tensor(
+            *tensor_handle_to_tensor_pointer(X),
+            *tensor_handle_to_tensor_pointer(act_scale),
+            *tensor_handle_to_tensor_pointer(act_zero_point),
+            *tensor_handle_to_tensor_pointer(onednn_weight),
+            *tensor_handle_to_tensor_pointer(weight_scales),
+            *tensor_handle_to_tensor_pointer(weight_zero_points),
+            *tensor_handle_to_tensor_pointer(accum),
+            pointer_to_optional<at::Tensor>(B),
+            stride_list,
+            padding_list,
+            dilation_list,
+            groups,
+            output_scale,
+            output_zero_point,
+            pointer_to_optional<at::ScalarType>(output_dtype),
+            accum_scale,
+            accum_zero_point,
+            binary_attr,
+            pointer_to_optional<c10::Scalar>(alpha),
+            pointer_to_optional<std::string_view>(unary_attr),
+            unary_scalars_list,
+            pointer_to_optional<std::string_view>(unary_algorithm));
+        *ret0 = new_tensor_handle(std::move(tmp_result));
+      });
 }
 
 #if AT_MKL_ENABLED()

--- a/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
@@ -1,4 +1,5 @@
 
+#include <ATen/record_function.h>
 #include <torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h>
 #include <torch/csrc/inductor/aoti_torch/utils.h>
 
@@ -45,7 +46,7 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise_binary(
     int64_t unary_scalars_len_,
     const char** unary_algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::mkldnn_convolution_pointwise_binary", {
     c10::List<std::optional<c10::Scalar>> unary_scalars_list;
     unary_scalars_list.reserve(unary_scalars_len_);
     for (int64_t i = 0; i < unary_scalars_len_; i++) {
@@ -88,7 +89,7 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise_binary_(
     int64_t unary_scalars_len_,
     const char** unary_algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::mkldnn_convolution_pointwise_binary_", {
     c10::List<std::optional<c10::Scalar>> unary_scalars_list;
     unary_scalars_list.reserve(unary_scalars_len_);
     for (int64_t i = 0; i < unary_scalars_len_; i++) {
@@ -128,7 +129,7 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise(
     int64_t scalars_len_,
     const char** algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::mkldnn_convolution_pointwise", {
     c10::List<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(scalars_len_);
     for (int64_t i = 0; i < scalars_len_; i++) {
@@ -167,7 +168,7 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_transpose_pointwise(
     int64_t scalars_len_,
     const char** algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::mkldnn_convolution_transpose_pointwise", {
     c10::List<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(scalars_len_);
     for (int64_t i = 0; i < scalars_len_; i++) {
@@ -211,7 +212,7 @@ AOTITorchError aoti_torch_cpu_mkldnn_rnn_layer(
     AtenTensorHandle* ret1,
     AtenTensorHandle* ret2,
     AtenTensorHandle* ret3) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::cpu::mkldnn_rnn_layer", {
     auto tmp_result = at::cpu::mkldnn_rnn_layer(
         *tensor_handle_to_tensor_pointer(input),
         *tensor_handle_to_tensor_pointer(weight0),
@@ -245,7 +246,7 @@ AOTITorchError aoti_torch_cpu__linear_pointwise(
     int64_t scalars_len_,
     const char** algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::mkldnn_linear_pointwise_binary", {
     c10::List<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(scalars_len_);
     for (int64_t i = 0; i < scalars_len_; i++) {
@@ -269,7 +270,7 @@ AOTITorchError aoti_torch_cpu__linear_pointwise_binary(
     AtenTensorHandle* B,
     const char* attr,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::mkldnn_linear_pointwise", {
     auto tmp_result = at::native::mkldnn_linear_pointwise_binary(
         *tensor_handle_to_tensor_pointer(X),
         *tensor_handle_to_tensor_pointer(other),
@@ -296,7 +297,7 @@ AOTITorchError aoti_torch_cpu__qlinear_pointwise_tensor(
     int64_t post_op_args_len_,
     const char* post_op_algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::QLinearOnednn::run_pointwise_tensor", {
     c10::List<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(post_op_args_len_);
     for (int64_t i = 0; i < post_op_args_len_; i++) {
@@ -342,7 +343,7 @@ AOTITorchError aoti_torch_cpu__qlinear_pointwise_binary_tensor(
     int64_t unary_post_op_args_len_,
     const char* unary_post_op_algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::QConvoneDNN::run_pointwise_tensor", {
     c10::List<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(unary_post_op_args_len_);
     for (int64_t i = 0; i < unary_post_op_args_len_; i++) {
@@ -395,7 +396,7 @@ AOTITorchError aoti_torch_cpu__qconv2d_pointwise_tensor(
     int64_t post_op_args_len_,
     const char** algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::QConvoneDNN::run_pointwise_binary_tensor", {
     c10::List<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(post_op_args_len_);
     for (int64_t i = 0; i < post_op_args_len_; i++) {
@@ -459,7 +460,7 @@ AOTITorchError aoti_torch_cpu__qconv2d_pointwise_binary_tensor(
     int64_t unary_scalars_len_,
     const char** unary_algorithm,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::QConvoneDNN::run_pointwise_binary_tensor", {
     c10::List<std::optional<c10::Scalar>> unary_scalars_list;
     unary_scalars_list.reserve(unary_scalars_len_);
     for (int64_t i = 0; i < unary_scalars_len_; i++) {
@@ -509,7 +510,7 @@ AOTITorchError aoti_torch_cpu__mkl_linear(
     AtenTensorHandle* B,
     int64_t prepack_batch_size,
     AtenTensorHandle* ret0) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("at::native::mkl_linear", {
     auto tmp_result = at::native::mkl_linear(
         *tensor_handle_to_tensor_pointer(X),
         *tensor_handle_to_tensor_pointer(W),

--- a/torch/csrc/inductor/aoti_torch/shim_xpu.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_xpu.cpp
@@ -11,7 +11,7 @@ AOTITorchError aoti_torch_create_xpu_guard(
     int32_t device_index,
     XPUGuardHandle* ret_guard // returns new reference
 ) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_create_xpu_guard", {
     at::DeviceGuard* guard =
         new at::DeviceGuard(at::Device(at::DeviceType::XPU, device_index));
     *ret_guard = reinterpret_cast<XPUGuardHandle>(guard);
@@ -19,33 +19,37 @@ AOTITorchError aoti_torch_create_xpu_guard(
 }
 
 AOTITorchError aoti_torch_delete_xpu_guard(XPUGuardHandle guard) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
-      { delete reinterpret_cast<at::DeviceGuard*>(guard); });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_delete_xpu_guard" {
+    delete reinterpret_cast<at::DeviceGuard*>(guard);
+  });
 }
 
 AOTITorchError aoti_torch_xpu_guard_set_index(
     XPUGuardHandle guard,
     int32_t device_index) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
-      { reinterpret_cast<at::DeviceGuard*>(guard)->set_index(device_index); });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_xpu_guard_set_index", {
+    reinterpret_cast<at::DeviceGuard*>(guard)->set_index(device_index);
+  });
 }
 
 AOTITorchError aoti_torch_create_xpu_stream_guard(
     void* stream,
     int32_t device_index,
     XPUStreamGuardHandle* ret_guard) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    assert(stream);
-    at::StreamGuard* guard =
-        new at::StreamGuard(at::xpu::getStreamFromExternal(
-                                static_cast<sycl::queue*>(stream), device_index)
-                                .unwrap());
-    *ret_guard = reinterpret_cast<XPUStreamGuardHandle>(guard);
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_create_xpu_stream_guard", {
+        assert(stream);
+        at::StreamGuard* guard = new at::StreamGuard(
+            at::xpu::getStreamFromExternal(
+                static_cast<sycl::queue*>(stream), device_index)
+                .unwrap());
+        *ret_guard = reinterpret_cast<XPUStreamGuardHandle>(guard);
+      });
 }
 
 AOTITorchError aoti_torch_delete_xpu_stream_guard(XPUStreamGuardHandle guard) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_delete_xpu_stream_guard",
       { delete reinterpret_cast<at::StreamGuard*>(guard); });
 }
 
@@ -53,22 +57,26 @@ AOTITorchError aoti_torch_get_current_xpu_stream(
     int32_t device_index,
     void** ret_stream) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_get_current_xpu_stream",
       { *ret_stream = &(at::xpu::getCurrentXPUStream(device_index).queue()); });
 }
 
 AOTITorchError aoti_torch_get_current_xpu_device(int32_t* device_index) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_get_current_xpu_device",
       { *device_index = static_cast<int32_t>(c10::xpu::current_device()); });
 }
 
 AOTITorchError aoti_torch_set_current_xpu_device(const int32_t& device_index) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_set_current_xpu_device",
       { c10::xpu::set_device(static_cast<int8_t>(device_index)); });
 }
 
 AOTITorchError aoti_torch_get_current_sycl_queue(void** ret) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    int32_t device_index = static_cast<int32_t>(c10::xpu::current_device());
-    *ret = &(at::xpu::getCurrentXPUStream(device_index).queue());
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      "aoti_torch_get_current_sycl_queue", {
+        int32_t device_index = static_cast<int32_t>(c10::xpu::current_device());
+        *ret = &(at::xpu::getCurrentXPUStream(device_index).queue());
+      });
 }

--- a/torch/csrc/inductor/aoti_torch/utils.h
+++ b/torch/csrc/inductor/aoti_torch/utils.h
@@ -11,16 +11,17 @@
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 #include <optional>
 
-#define AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(...)    \
-  try {                                                    \
-    __VA_ARGS__                                            \
-  } catch (const std::exception& e) {                      \
-    LOG(ERROR) << "Exception in aoti_torch: " << e.what(); \
-    return AOTI_TORCH_FAILURE;                             \
-  } catch (...) {                                          \
-    LOG(ERROR) << "Exception in aoti_torch: UNKNOWN";      \
-    return AOTI_TORCH_FAILURE;                             \
-  }                                                        \
+#define AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(func_name, ...)    \
+  try {                                                               \
+    RECORD_FUNCTION(func_name, c10::ArrayRef<c10::IValue>());         \
+    __VA_ARGS__                                                       \
+  } catch (const std::exception& e) {                                 \
+    LOG(ERROR) << "Exception in aoti_torch: " << e.what();            \
+    return AOTI_TORCH_FAILURE;                                        \
+  } catch (...) {                                                     \
+    LOG(ERROR) << "Exception in aoti_torch: UNKNOWN";                 \
+    return AOTI_TORCH_FAILURE;                                        \
+  }                                                                   \
   return AOTI_TORCH_SUCCESS;
 
 namespace torch::aot_inductor {

--- a/torch/csrc/inductor/aoti_torch/utils.h
+++ b/torch/csrc/inductor/aoti_torch/utils.h
@@ -11,17 +11,17 @@
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 #include <optional>
 
-#define AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(func_name, ...)    \
-  try {                                                               \
-    RECORD_FUNCTION(func_name, c10::ArrayRef<c10::IValue>());         \
-    __VA_ARGS__                                                       \
-  } catch (const std::exception& e) {                                 \
-    LOG(ERROR) << "Exception in aoti_torch: " << e.what();            \
-    return AOTI_TORCH_FAILURE;                                        \
-  } catch (...) {                                                     \
-    LOG(ERROR) << "Exception in aoti_torch: UNKNOWN";                 \
-    return AOTI_TORCH_FAILURE;                                        \
-  }                                                                   \
+#define AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(func_name, ...) \
+  try {                                                            \
+    RECORD_FUNCTION(func_name, c10::ArrayRef<c10::IValue>());      \
+    __VA_ARGS__                                                    \
+  } catch (const std::exception& e) {                              \
+    LOG(ERROR) << "Exception in aoti_torch: " << e.what();         \
+    return AOTI_TORCH_FAILURE;                                     \
+  } catch (...) {                                                  \
+    LOG(ERROR) << "Exception in aoti_torch: UNKNOWN";              \
+    return AOTI_TORCH_FAILURE;                                     \
+  }                                                                \
   return AOTI_TORCH_SUCCESS;
 
 namespace torch::aot_inductor {

--- a/torchgen/gen_aoti_c_shim.py
+++ b/torchgen/gen_aoti_c_shim.py
@@ -298,7 +298,7 @@ def gen_declaration_and_definition(
     ret_assignments_str = "\n" + "\n".join(ret_assignments) if ret_assignments else ""
     definition = f"""
 {declaration} {{
-    AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({{
+    AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE("aoti_torch_{device}_{func_name}", {{
         {tmp_result}{backend_call}(
 {textwrap.indent(", ".join(callsite_exprs), "            ")}
         );{textwrap.indent(ret_assignments_str, "        ")}
@@ -512,6 +512,7 @@ extern "C" {{
 
 #include <torch/csrc/inductor/aoti_torch/generated/{"extend/" if extend_aoti_c_shim else ""}c_shim_{device}.h>
 #include <torch/csrc/inductor/aoti_torch/utils.h>
+#include <ATen/record_function.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/{str(dispatch_key)}Functions.h>


### PR DESCRIPTION
Fixes #148650

add RECORD_FUNCTION for aoti_xxx

Example:
```python
import torch
from torch.testing._internal.common_utils import run_tests, TemporaryFileName, TestCase
from torch.utils import ThroughputBenchmark

from contextlib import nullcontext

from torch._dynamo import config
from torch._inductor import config as inductor_config


class TwoLayerNet(torch.jit.ScriptModule):
    def __init__(self, D_in, H, D_out):
        super().__init__()
        self.linear1 = torch.nn.Linear(D_in, H)
        self.linear2 = torch.nn.Linear(2 * H, D_out)

    @torch.jit.script_method
    def forward(self, x1, x2):
        h1_relu = self.linear1(x1).clamp(min=0)
        h2_relu = self.linear1(x2).clamp(min=0)
        cat = torch.cat((h1_relu, h2_relu), 1)
        y_pred = self.linear2(cat)
        return y_pred


class TwoLayerNetModule(torch.nn.Module):
    def __init__(self, D_in, H, D_out):
        super().__init__()
        self.linear1 = torch.nn.Linear(D_in, H)
        self.linear2 = torch.nn.Linear(2 * H, D_out)

    def forward(self, x1, x2):
        h1_relu = self.linear1(x1).clamp(min=0)
        h2_relu = self.linear1(x2).clamp(min=0)
        cat = torch.cat((h1_relu, h2_relu), 1)
        y_pred = self.linear2(cat)
        return y_pred

Module = TwoLayerNetModule
dtype = torch.bfloat16
config.error_on_recompile = True
inductor_config.cpp_wrapper = True
inductor_config.freezing = True
D_in = 10
H = 5
D_out = 15
B = 8

autocast = dtype != torch.float32
module = Module(D_in, H, D_out)

input = (torch.randn(B, D_in), torch.randn(B, D_in))

with torch.no_grad(), torch.amp.autocast("cpu", enabled=autocast, dtype=dtype):
    torch._dynamo.reset()
    module(*input)
    module = torch.compile(module)
    module(*input)
    module(*input)

with torch.autograd.profiler.profile() as prof:
    with torch.no_grad(), torch.amp.autocast("cpu", enabled=autocast, dtype=dtype):
        module(*input)
print(prof.key_averages().table(sort_by="self_cpu_time_total"))

```

Without this patch, profiler not show aoti_xxx:
------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
    Torch-Compiled Region: 0/0        80.52%     376.467us        82.69%     386.590us     386.590us             1  
      TorchDynamo Cache Lookup        17.31%      80.955us        17.31%      80.955us      80.955us             1  
                   aten::empty         2.17%      10.123us         2.17%      10.123us       3.374us             3  
------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
With this patch:
----------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
    at::native::mkldnn_linear_pointwise_binary        48.54%     269.358us        50.61%     280.830us      93.610us             3  
                    Torch-Compiled Region: 0/0        30.83%     171.110us        85.10%     472.230us     472.230us             1  
                      TorchDynamo Cache Lookup        14.90%      82.692us        14.90%      82.692us      82.692us             1  
                                   aten::empty         2.07%      11.472us         2.07%      11.472us       3.824us             3  
                      aoti_torch_empty_strided         1.63%       9.047us         1.63%       9.047us       4.524us             2  
               aoti_torch_delete_tensor_object         1.00%       5.558us         1.00%       5.558us       0.428us            13  
                aoti_torch__reinterpret_tensor         0.75%       4.175us         0.75%       4.175us       2.087us             2  
                       aoti_torch_get_data_ptr         0.27%       1.510us         0.27%       1.510us       0.151us            10  
----------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov