### PR TITLE
Fix `lr_scheduler` unexpectedly calls `step()` when init argument last_epoch is larger than -1

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2578,7 +2578,7 @@ class TestLRScheduler(TestCase):
     @parametrize(
         "LRClass",
         [
-            partial(ExponentialLR, gamma=0.9),
+            partial(ExponentialLR, gamma=0.999),
         ],
     )
     def test_lr_scheduler_checkpoint(self, LRClass):
@@ -2589,8 +2589,8 @@ class TestLRScheduler(TestCase):
         sch.step()
         optim2 = torch.optim.AdamW(model.parameters())
         optim2.load_state_dict(optim.state_dict())
-        sch2 = LRClass(optim2, last_epoch=1)
-        self.assertEqual(optim.param_groups[0]["lr"], optim2.param_groups[0]["lr"])
+        sch2 = LRClass(optim2, last_epoch=0)
+        self.assertEqual(sch2._get_closed_form_lr()[0], optim.param_groups[0]["lr"])
 
 
 instantiate_parametrized_tests(TestLRScheduler)

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2579,6 +2579,18 @@ class TestLRScheduler(TestCase):
         "LRClass",
         [
             partial(ExponentialLR, gamma=0.999),
+            partial(LambdaLR, lr_lambda=lambda epoch: epoch // 30),
+            partial(MultiplicativeLR, lr_lambda=lambda epoch: 0.95),
+            partial(StepLR, step_size=30),
+            partial(MultiStepLR, milestones=[30, 80]),
+            ConstantLR,
+            LinearLR,
+            PolynomialLR,
+            partial(CosineAnnealingLR, T_max=10),
+            partial(CosineAnnealingWarmRestarts, T_0=20),
+            partial(CyclicLR, base_lr=0.01, max_lr=0.1),
+            partial(OneCycleLR, max_lr=0.01, total_steps=10),
+            partial(SWALR, swa_lr=0.01),
         ],
     )
     def test_lr_scheduler_checkpoint(self, LRClass):
@@ -2590,7 +2602,18 @@ class TestLRScheduler(TestCase):
         optim2 = torch.optim.AdamW(model.parameters())
         optim2.load_state_dict(optim.state_dict())
         sch2 = LRClass(optim2, last_epoch=0)
-        self.assertEqual(sch2._get_closed_form_lr()[0], optim.param_groups[0]["lr"])
+        self.assertEqual(sch2.get_last_lr()[0], optim.param_groups[0]["lr"])
+
+    def test_lr_scheduler_checkpoint_on_plateau(self):
+        model = torch.nn.Linear(3, 3)
+        optim = torch.optim.AdamW(model.parameters())
+        sch = ReduceLROnPlateau(optim, mode="min")
+        optim.step()
+        sch.step(1)
+        optim2 = torch.optim.AdamW(model.parameters())
+        optim2.load_state_dict(optim.state_dict())
+        sch2 = ReduceLROnPlateau(optim2, mode="min")
+        self.assertEqual(sch2.get_last_lr()[0], optim.param_groups[0]["lr"])
 
 
 instantiate_parametrized_tests(TestLRScheduler)

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2602,7 +2602,12 @@ class TestLRScheduler(TestCase):
         optim2 = torch.optim.AdamW(model.parameters())
         optim2.load_state_dict(optim.state_dict())
         sch2 = LRClass(optim2, last_epoch=0)
-        self.assertEqual(sch2.get_last_lr()[0], optim.param_groups[0]["lr"])
+        self.assertEqual(
+            sch2._get_closed_form_lr()[0]
+            if hasattr(self, "_get_closed_form_lr")
+            else sch2.get_last_lr()[0],
+            optim.param_groups[0]["lr"],
+        )
 
     def test_lr_scheduler_checkpoint_on_plateau(self):
         model = torch.nn.Linear(3, 3)
@@ -2613,7 +2618,12 @@ class TestLRScheduler(TestCase):
         optim2 = torch.optim.AdamW(model.parameters())
         optim2.load_state_dict(optim.state_dict())
         sch2 = ReduceLROnPlateau(optim2, mode="min")
-        self.assertEqual(sch2.get_last_lr()[0], optim.param_groups[0]["lr"])
+        self.assertEqual(
+            sch2._get_closed_form_lr()[0]
+            if hasattr(self, "_get_closed_form_lr")
+            else sch2.get_last_lr()[0],
+            optim.param_groups[0]["lr"],
+        )
 
 
 instantiate_parametrized_tests(TestLRScheduler)

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2578,36 +2578,18 @@ class TestLRScheduler(TestCase):
     @parametrize(
         "LRClass",
         [
-            partial(LambdaLR, lr_lambda=lambda e: e // 10),
-            partial(MultiplicativeLR, lr_lambda=lambda: 0.95),
-            partial(StepLR, step_size=30),
-            partial(MultiStepLR, milestones=[30, 80]),
-            ConstantLR,
-            LinearLR,
             partial(ExponentialLR, gamma=0.9),
-            PolynomialLR,
-            partial(CosineAnnealingLR, T_max=10),
-            lambda opt, **kwargs: SequentialLR(
-                opt,
-                schedulers=[ConstantLR(opt), ConstantLR(opt)],
-                milestones=[2],
-                **kwargs,
-            ),
-            partial(CyclicLR, base_lr=0.01, max_lr=0.1),
-            partial(OneCycleLR, max_lr=0.01, total_steps=10, anneal_strategy="linear"),
-            partial(CosineAnnealingWarmRestarts, T_0=20),
         ],
     )
-    def test_lr_after_load_state_dict(self, LRClass):
+    def test_lr_scheduler_checkpoint(self, LRClass):
         model = torch.nn.Linear(3, 3)
         optim = torch.optim.AdamW(model.parameters())
         sch = LRClass(optim)
         optim.step()
         sch.step()
-
         optim2 = torch.optim.AdamW(model.parameters())
         optim2.load_state_dict(optim.state_dict())
-        sch2 = LRClass(optim2, last_epoch=0)
+        sch2 = LRClass(optim2, last_epoch=1)
         self.assertEqual(optim.param_groups[0]["lr"], optim2.param_groups[0]["lr"])
 
 

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -793,6 +793,8 @@ class ExponentialLR(LRScheduler):
         """Compute the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
+        // when loading from a checkpoint, we don't want _initial_step (called from the constructor) to update the lr
+        // one more step ahead of itself.
         if self._is_initial:
             return [group["lr"] for group in self.optimizer.param_groups]
         return [group["lr"] * self.gamma for group in self.optimizer.param_groups]

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -793,8 +793,8 @@ class ExponentialLR(LRScheduler):
         """Compute the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
-        // when loading from a checkpoint, we don't want _initial_step (called from the constructor) to update the lr
-        // one more step ahead of itself.
+        # when loading from a checkpoint, we don't want _initial_step (called from the constructor)
+        # to update the lr one more step ahead of itself.
         if self._is_initial:
             return [group["lr"] for group in self.optimizer.param_groups]
         return [group["lr"] * self.gamma for group in self.optimizer.param_groups]

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -464,7 +464,7 @@ class MultiplicativeLR(LRScheduler):
         """Compute the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
-        if self.last_epoch > 0:
+        if not self._is_initial:
             return [
                 group["lr"] * lmbda(self.last_epoch)
                 for lmbda, group in zip(self.lr_lambdas, self.optimizer.param_groups)
@@ -729,7 +729,7 @@ class LinearLR(LRScheduler):
                 group["lr"] * self.start_factor for group in self.optimizer.param_groups
             ]
 
-        if self.last_epoch > self.total_iters:
+        if self._is_initial or self.last_epoch > self.total_iters:
             return [group["lr"] for group in self.optimizer.param_groups]
 
         return [
@@ -995,7 +995,7 @@ class PolynomialLR(LRScheduler):
         """Compute the learning rate."""
         _warn_get_lr_called_within_step(self)
 
-        if self.last_epoch == 0 or self.last_epoch > self.total_iters:
+        if self._is_initial or self.last_epoch > self.total_iters:
             return [group["lr"] for group in self.optimizer.param_groups]
 
         decay_factor = (
@@ -1081,7 +1081,7 @@ class CosineAnnealingLR(LRScheduler):
         """Retrieve the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
-        if self.last_epoch == 0:
+        if self._is_initial:
             return [group["lr"] for group in self.optimizer.param_groups]
         elif self._step_count == 1 and self.last_epoch > 0:
             return [

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -141,7 +141,7 @@ class LRScheduler:
     def _initial_step(self) -> None:
         """Initialize step counts and perform a step."""
         self._step_count = 0
-        self.step()
+        self._update_lr(self.last_epoch)
 
     def state_dict(self) -> dict[str, Any]:
         """Return the state of the scheduler as a :class:`dict`.
@@ -195,6 +195,9 @@ class LRScheduler:
                     "https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate",
                     UserWarning,
                 )
+        self._update_lr(epoch)
+
+    def _update_lr(self, epoch: Optional[int] = None):
         self._step_count += 1
 
         with _enable_get_lr_call(self):
@@ -204,7 +207,7 @@ class LRScheduler:
             else:
                 warnings.warn(EPOCH_DEPRECATION_WARNING, UserWarning)
                 self.last_epoch = epoch
-                if hasattr(self, "_get_closed_form_lr"):
+                if self.last_epoch != -1 and hasattr(self, "_get_closed_form_lr"):
                     values = cast(list[float], self._get_closed_form_lr())
                 else:
                     values = self.get_lr()


### PR DESCRIPTION
Fixes #102261

## Changes

- Use flag `_is_initial` to replace `self.last_epoch == 0` condition to judge whether `lr` should be initial value
- Add test for `ExponentialLR` checkpoint usecase

## Test Result

```python
pytest -s test/optim/test_lrscheduler.py  -vv
```

![image](https://github.com/user-attachments/assets/6fd32bcc-b4fb-4421-b891-620bd4900dc1)
