### PR TITLE
Improve docker build cleanup on s390x runners

### DIFF
--- a/.github/workflows/build-manywheel-images-s390x.yml
+++ b/.github/workflows/build-manywheel-images-s390x.yml
@@ -62,7 +62,12 @@ jobs:
         if: cancelled()
         shell: bash
         run: |
-          # if podman build command is interrupted,
+          # If podman build command is interrupted,
           # it can leave a couple of processes still running.
-          # order them to stop for clean shutdown.
+          # Order them to stop for clean shutdown.
+          # It looks like sometimes some processes remain
+          # after first cleanup.
+          # Wait a bit and do cleanup again. It looks like it helps.
+          docker system prune --build -f || true
+          sleep 60
           docker system prune --build -f || true


### PR DESCRIPTION
Currently it sometimes still leaves a couple of processess running.
