### PR TITLE
Refactoring Distributed test cases to be device agnostic [2/n]

### DIFF
--- a/test/distributed/_composable/test_checkpoint.py
+++ b/test/distributed/_composable/test_checkpoint.py
@@ -28,7 +28,7 @@ class MemoryDelta(ContextDecorator):
             torch.get_device_module(self.device).memory_stats()[
                 "active_bytes.all.current"
             ]
-            if self.device.type == torch.get_device_module(self.device)
+            if self.device.type == device_type.type
             else 0
         )
         return self
@@ -38,7 +38,7 @@ class MemoryDelta(ContextDecorator):
             torch.get_device_module(self.device).memory_stats()[
                 "active_bytes.all.current"
             ]
-            if self.device.type == torch.get_device_module(self.device)
+            if self.device.type == device_type.type
             else 0
         )
 
@@ -133,7 +133,7 @@ class TestCheckpoint(TestCase):
             loss2 = net2(x2).sum()
         loss2.backward()
 
-        if x.device.type == device_type:
+        if x.device.type == device_type.type:
             self.assertTrue(mem2.delta() < mem1.delta())
 
         for p1, p2 in zip(net1.parameters(), net2.parameters()):


### PR DESCRIPTION
Continuing the series from #145222

In this series of PR we intend to refactoring distributed test cases to enable to be completely device agnostic.

These changes will include the following approaches to do the same :

Allowing for multiple device types using instantiate_device_type_test

- Replacing calls to cuda stream with torch.get_device_module(device) wherever it applies
- Skipping set up steps required while using MultiProcessTestCase with DistributedTestBase (https://github.com/pytorch/pytorch/pull/138216) wherever applicable
- Replacing explicit calls to distributed backend (NCCL,HCCL,etc) with get_default_backend_for_device (https://github.com/pytorch/pytorch/pull/140536).

 
This should result in improvement in usability for all devices

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o