### PR TITLE
[codemod][lowrisk] Remove unused exception parameter from caffe2/aten/src/ATen/cuda/CUDABlas.cpp

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -199,12 +199,18 @@ static size_t _parseChosenWorkspaceSize() {
   if (val.has_value()) {
     try {
       workspace_size = std::stoi(val.value());
-    } catch(std::invalid_argument const& e) {
-      TORCH_WARN("invalid CUBLASLT_WORKSPACE_SIZE,",
-                 " using default workspace size of ", workspace_size, " KiB.");
-    } catch(std::out_of_range const& e) {
-      TORCH_WARN("CUBLASLT_WORKSPACE_SIZE out of range,",
-                 " using default workspace size of ", workspace_size, " KiB.");
+    } catch (std::invalid_argument const&) {
+      TORCH_WARN(
+          "invalid CUBLASLT_WORKSPACE_SIZE,",
+          " using default workspace size of ",
+          workspace_size,
+          " KiB.");
+    } catch (std::out_of_range const&) {
+      TORCH_WARN(
+          "CUBLASLT_WORKSPACE_SIZE out of range,",
+          " using default workspace size of ",
+          workspace_size,
+          " KiB.");
     }
   }
   return workspace_size * 1024;

--- a/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
@@ -385,9 +385,11 @@ namespace {
     // next broadcast all index tensors together
     try {
       indices = at::expand_outplace(indices);
-    } catch (std::exception &e) {
-      TORCH_CHECK_INDEX(false, "shape mismatch: indexing tensors could not be broadcast together"
-                               " with shapes ");
+    } catch (std::exception&) {
+      TORCH_CHECK_INDEX(
+          false,
+          "shape mismatch: indexing tensors could not be broadcast together"
+          " with shapes ");
     }
     // add missing null Tensors so that it matches self.dim()
     while (indices.size() < static_cast<size_t>(self.dim())) {

--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -551,8 +551,8 @@ class AlgoIterator {
       try {
         f(algoPerf);
         return;
-      } catch (c10::OutOfMemoryError& e) {
-        cudaGetLastError(); // clear CUDA error
+      } catch (c10::OutOfMemoryError&) {
+        std::ignore = cudaGetLastError(); // clear CUDA error
       }
     }
 
@@ -564,10 +564,10 @@ class AlgoIterator {
         f(algoPerf);
         cache.insert(args.params, algoPerf);
         return;
-      } catch (c10::OutOfMemoryError& e) {
-        cudaGetLastError(); // clear CUDA error
-      } catch (c10::CuDNNError& e) {
-        cudaGetLastError(); // clear CUDA error
+      } catch (c10::OutOfMemoryError&) {
+        std::ignore = cudaGetLastError(); // clear CUDA error
+      } catch (c10::CuDNNError&) {
+        std::ignore = cudaGetLastError(); // clear CUDA error
       }
     }
     TORCH_CHECK(

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -264,13 +264,13 @@ static int getLRUCacheLimit() {
     }
     try {
       return std::stoi(val);
-    } catch (std::invalid_argument const& e) {
+    } catch (std::invalid_argument const&) {
       TORCH_WARN(
           "invalid TORCH_CUDNN_V8_API_LRU_CACHE_LIMIT,",
           " using default LRU cache limit of ",
           DEFAULT_LIMIT,
           " entries.");
-    } catch (std::out_of_range const& e) {
+    } catch (std::out_of_range const&) {
       TORCH_WARN(
           "invalid TORCH_CUDNN_V8_API_LRU_CACHE_LIMIT,",
           " using default LRU cache limit of ",
@@ -676,9 +676,9 @@ void generate_and_filter_plans(
       workspace_ptr =
           c10::cuda::CUDACachingAllocator::get()->allocate(max_workspace_size);
       break;
-    } catch (c10::OutOfMemoryError& e) {
+    } catch (c10::OutOfMemoryError&) {
       max_workspace_size /= 2;
-      (void)cudaGetLastError(); // clear CUDA error
+      std::ignore = cudaGetLastError(); // clear CUDA error
       remove_invalid = true;
     }
   }
@@ -876,10 +876,10 @@ void try_plans(
       run_conv_plan(handle, x, y, w, plan, operation);
       benchmark_cache.update(key, plan);
       return;
-    } catch (cudnn_frontend::cudnnException& e) {
-    } catch (CuDNNError& e) {
-    } catch (c10::OutOfMemoryError& e) {
-      (void)cudaGetLastError(); // clear CUDA error
+    } catch (cudnn_frontend::cudnnException&) {
+    } catch (CuDNNError&) {
+    } catch (c10::OutOfMemoryError&) {
+      std::ignore = cudaGetLastError(); // clear CUDA error
     }
   }
   TORCH_CHECK(
@@ -900,10 +900,10 @@ void try_plans_fused(
       run_conv_plan_fused(handle, x, y, w, z, b, plan);
       benchmark_cache_fused.update(key, plan);
       return;
-    } catch (cudnn_frontend::cudnnException& e) {
-    } catch (CuDNNError& e) {
-    } catch (c10::OutOfMemoryError& e) {
-      (void)cudaGetLastError(); // clear CUDA error
+    } catch (cudnn_frontend::cudnnException&) {
+    } catch (CuDNNError&) {
+    } catch (c10::OutOfMemoryError&) {
+      std::ignore = cudaGetLastError(); // clear CUDA error
     }
   }
   TORCH_CHECK(
@@ -931,10 +931,10 @@ bool try_configs(
       run_conv_plan(handle, x, y, w, plan, operation);
       benchmark_cache.update(key, plan);
       return true;
-    } catch (cudnn_frontend::cudnnException& e) {
-    } catch (CuDNNError& e) {
-    } catch (c10::OutOfMemoryError& e) {
-      (void)cudaGetLastError(); // clear CUDA error
+    } catch (cudnn_frontend::cudnnException&) {
+    } catch (CuDNNError&) {
+    } catch (c10::OutOfMemoryError&) {
+      std::ignore = cudaGetLastError(); // clear CUDA error
     }
   }
   return false;
@@ -962,10 +962,10 @@ bool try_configs_fused(
       run_conv_plan_fused(handle, x, y, w, z, b, plan);
       benchmark_cache_fused.update(key, plan);
       return true;
-    } catch (cudnn_frontend::cudnnException& e) {
-    } catch (CuDNNError& e) {
-    } catch (c10::OutOfMemoryError& e) {
-      (void)cudaGetLastError(); // clear CUDA error
+    } catch (cudnn_frontend::cudnnException&) {
+    } catch (CuDNNError&) {
+    } catch (c10::OutOfMemoryError&) {
+      std::ignore = cudaGetLastError(); // clear CUDA error
     }
   }
   return false;
@@ -1001,8 +1001,8 @@ void run_single_conv(
     try {
       run_conv_plan(handle, x, y, w, *search, operation);
       return;
-    } catch (c10::OutOfMemoryError& e) {
-      (void)cudaGetLastError(); // clear CUDA error
+    } catch (c10::OutOfMemoryError&) {
+      std::ignore = cudaGetLastError(); // clear CUDA error
     }
   }
   if (!benchmark) {
@@ -1101,8 +1101,8 @@ void run_fused_conv(
     try {
       run_conv_plan_fused(handle, x, y, w, z, b, *search);
       return;
-    } catch (c10::OutOfMemoryError& e) {
-      (void)cudaGetLastError(); // clear CUDA error
+    } catch (c10::OutOfMemoryError&) {
+      std::ignore = cudaGetLastError(); // clear CUDA error
     }
   }
   if (!benchmark) {

--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -208,7 +208,7 @@ void PyTorchStreamReader::init() {
       static_cast<const char*>(version_ptr.get()), version_size);
   try {
     version_ = std::stoull(version);
-  } catch (const std::invalid_argument& e) {
+  } catch (const std::invalid_argument&) {
     CAFFE_THROW("Couldn't parse the version ", version, " as Long Long.");
   }
   if (version_ <

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -108,16 +108,16 @@ inline void PyErr_SetString(PyObject* type, const std::string& message) {
     throw;                                                          \
   }                                                                 \
   }                                                                 \
-  catch (py::error_already_set & e) {                               \
+  catch (py::error_already_set&) {                                  \
     throw;                                                          \
   }                                                                 \
-  catch (py::builtin_exception & e) {                               \
+  catch (py::builtin_exception&) {                                  \
     throw;                                                          \
   }                                                                 \
-  catch (torch::jit::JITException & e) {                            \
+  catch (torch::jit::JITException&) {                               \
     throw;                                                          \
   }                                                                 \
-  catch (const std::exception& e) {                                 \
+  catch (const std::exception&) {                                   \
     torch::translate_exception_to_python(std::current_exception()); \
     throw py::error_already_set();                                  \
   }

--- a/torch/csrc/jit/frontend/schema_type_parser.cpp
+++ b/torch/csrc/jit/frontend/schema_type_parser.cpp
@@ -194,11 +194,11 @@ std::optional<c10::Device> SchemaTypeParser::tryToParseDeviceType() {
       const std::string& num = L.expect(TK_NUMBER).text();
       try {
         device_idx = static_cast<c10::DeviceIndex>(std::stoi(num));
-      } catch (const std::invalid_argument& e) {
+      } catch (const std::invalid_argument&) {
         throw(
             ErrorReport(L.cur())
             << "Device index cannot be converted to integer");
-      } catch (const std::out_of_range& e) {
+      } catch (const std::out_of_range&) {
         throw(ErrorReport(L.cur()) << "Device index is too long");
       }
     }
@@ -217,11 +217,11 @@ std::optional<bool> SchemaTypeParser::tryToParseRequiresGrad() {
   const std::string& num = L.expect(TK_NUMBER).text();
   try {
     return (bool)std::stoi(num);
-  } catch (const std::invalid_argument& e) {
+  } catch (const std::invalid_argument&) {
     throw(
         ErrorReport(L.cur())
         << "Field requires_grad cannot be converted to integer");
-  } catch (const std::out_of_range& e) {
+  } catch (const std::out_of_range&) {
     throw(ErrorReport(L.cur()) << "Field requires_grad is too long");
   }
 }
@@ -277,11 +277,11 @@ TypePtr SchemaTypeParser::parseRefinedTensor() {
           try {
             auto stride = std::stoll(num);
             strides.push_back(stride);
-          } catch (const std::invalid_argument& e) {
+          } catch (const std::invalid_argument&) {
             throw(
                 ErrorReport(L.cur())
                 << "The stride value cannot be converted to int");
-          } catch (const std::out_of_range& e) {
+          } catch (const std::out_of_range&) {
             throw(ErrorReport(L.cur()) << "The stride is too big");
           }
         });
@@ -317,9 +317,9 @@ TypePtr SchemaTypeParser::parseRefinedTensor() {
     int64_t dim = 0;
     try {
       dim = std::stoll(num);
-    } catch (const std::invalid_argument& e) {
+    } catch (const std::invalid_argument&) {
       throw(ErrorReport(L.cur()) << "The number can't be converted to int");
-    } catch (const std::out_of_range& e) {
+    } catch (const std::out_of_range&) {
       throw(ErrorReport(L.cur()) << "Number is too big");
     }
     if (shape_symbol) {


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Test Plan: Sandcastle

Reviewed By: dtolnay





cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel