### PR TITLE
[Profiler/Easy] Pass Overload Names To Kineto

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -2931,6 +2931,17 @@ aten::mm""",
     def test_profiler_overload_names(self):
         from torch.library import _scoped_library, fallthrough_kernel
 
+        def validate_json(prof):
+            print()
+            with TemporaryFileName(mode="w+") as fname:
+                prof.export_chrome_trace(fname)
+                with open(fname) as f:
+                    events = json.load(f)["traceEvents"]
+                    self.assertTrue(
+                        any("aten::add.Tensor" in e["name"] for e in events)
+                    )
+                    self.assertTrue(any("aten::add.out" in e["name"] for e in events))
+
         with _scoped_library("aten", "IMPL") as my_lib:
             my_lib.impl("add.Tensor", fallthrough_kernel, "CPU")
             experimental_config = torch._C._profiler._ExperimentalConfig(
@@ -2981,6 +2992,7 @@ aten::mm""",
             key_averages = prof.key_averages(group_by_overload_name=True)
             assert len(key_averages) == 3
             assert "Overload Name" in key_averages.table()
+            validate_json(prof)
 
 
 if __name__ == "__main__":

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -880,8 +880,12 @@ void passEventsToKineto(
     // duration will overflow and become a very large positive number. For a
     // long term solution, add guards in kineto for each activity type
     int64_t act_end_time = std::max(e->endTimeNS(), e->start_time_ns_);
+    std::string name = e->name();
+    if (!e->overload_name().empty()) {
+      name = fmt::format("{}.{}", e->name(), e->overload_name());
+    }
     auto* activity = cpu_trace.addCPUActivity(
-        e->name(),
+        name,
         e->kinetoType(),
         e->kineto_info_,
         e->correlationID(),


### PR DESCRIPTION
Summary: Right now we get Overload names and forward them to the Event List frontend for profiler but we do not forward anything to kineto. This diff checks if there is an overload name for each cpu op and appends it to the name if necessary

Test Plan: Added test in CI

Differential Revision: D71326670


