### PR TITLE
Use enum to select floating point format in FbgemmEmbedding APIs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -69,7 +69,7 @@
 [submodule "third_party/fbgemm"]
     ignore = dirty
     path = third_party/fbgemm
-    url = https://github.com/pytorch/fbgemm
+    url = https://github.com/MatzeB/fbgemm
 [submodule "android/libs/fbjni"]
     ignore = dirty
     path = android/libs/fbjni

--- a/.gitmodules
+++ b/.gitmodules
@@ -69,7 +69,7 @@
 [submodule "third_party/fbgemm"]
     ignore = dirty
     path = third_party/fbgemm
-    url = https://github.com/MatzeB/fbgemm
+    url = https://github.com/pytorch/fbgemm
 [submodule "android/libs/fbjni"]
     ignore = dirty
     path = android/libs/fbjni

--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -223,7 +223,10 @@ index_select_add(
       offsets_data = offsets_include_last.data();
     }
 #if defined(USE_FBGEMM)
-    constexpr bool isbf16 = std::is_same_v<data_t, at::Half> ? false : true;
+    constexpr fbgemm::FloatFormat float_format =
+      std::is_same_v<data_t, at::Half> ? fbgemm::FloatFormat::FLOAT16 :
+      (std::is_same_v<data_t, at::BFloat16> ? fbgemm::FloatFormat::BFLOAT16 :
+       fbgemm::FloatFormat::DEFAULT);
     auto kernel_16bit_index_t = fbgemm_kernel_cache
         ? fbgemm_kernel_cache
               ->getCallback</* has_weight */ false, index_t, uint16_t>(ddim)
@@ -234,8 +237,8 @@ index_select_add(
               /* prefetch */ 16,
               /* is_weight_positional */ false,
               /* use_offsets */ true,
-              /* is_bf16_out */ isbf16,
-              /* is_bf16_in */ isbf16);
+              /* out_format */ float_format,
+              /* in_format */ float_format);
     at::parallel_for(
         0, output_size, 1, [&](index_t start_idx, index_t end_idx) {
           bool success = kernel_16bit_index_t(
@@ -590,8 +593,11 @@ index_select_scale_add(
     auto* scale_data_fp32 = scale_fp32.mutable_data_ptr<float>();
 
 #if defined(USE_FBGEMM)
-    constexpr bool isbf16 = std::is_same_v<data_t, at::Half> ? false : true;
-    if constexpr (isbf16) {
+    constexpr fbgemm::FloatFormat float_format =
+      std::is_same_v<data_t, at::Half> ? fbgemm::FloatFormat::FLOAT16 :
+      (std::is_same_v<data_t, at::BFloat16> ? fbgemm::FloatFormat::BFLOAT16 :
+       fbgemm::FloatFormat::DEFAULT);
+    if constexpr (float_format == fbgemm::FloatFormat::BFLOAT16) {
       fbgemm::Bfloat16ToFloat_simd(
           reinterpret_cast<const fbgemm::bfloat16*>(scale_data),
           scale_data_fp32,
@@ -612,8 +618,8 @@ index_select_scale_add(
               /* prefetch */ 16,
               /* is_weight_positional */ false,
               /* use_offsets */ true,
-              /* is_bf16_out */ isbf16,
-              /* is_bf16_in */ isbf16);
+              /* out_format */ float_format,
+              /* in_format */ float_format);
     at::parallel_for(
         0, output_size, 1, [&](index_t start_idx, index_t end_idx) {
           bool success = kernel_16bit_index_t(


### PR DESCRIPTION
Summary:
Most FBGemmEmbedding APIs currently feature a `bool is_bf16_out` parameter to differentiate between the float16 and bfloat16 format when the output array has type `uint16_t`.

I am in the process of adding E5M2 and E4M3FN formats for output arrays with type `uint8_t`. Instead of adding another parameter, I would like to change the `bool is_bf16_out` parameter to `enum FloatFormat` to make it easier to add new formats:

```
enum class FloatFormat {
  DEFAULT,
  FLOAT16,
  BFLOAT16,
  FP8_E5M2,
  FP8_E4M3FN,
};
```

Test Plan: sandcastle

Reviewed By: excelle08

Differential Revision: D68046358


