### PR TITLE
[MTIA] Add _mtia_maybeExchangeDevice to MTIA module

### DIFF
--- a/torch/csrc/mtia/Module.cpp
+++ b/torch/csrc/mtia/Module.cpp
@@ -67,6 +67,13 @@ void initModule(PyObject* module) {
     return at::detail::getMTIAHooks().exchangeDevice(device_index);
   });
 
+  m.def("_mtia_maybeExchangeDevice", [](c10::DeviceIndex device_index) {
+    if (device_index < 0) {
+      return static_cast<c10::DeviceIndex>(-1);
+    }
+    return at::detail::getMTIAHooks().maybeExchangeDevice(device_index);
+  });
+
   m.def("_mtia_getDefaultStream", [](c10::DeviceIndex device_index) {
     torch::utils::device_lazy_init(at::kMTIA);
     return at::detail::getMTIAHooks().getDefaultStream(device_index);

--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -40,6 +40,16 @@ else:
         raise RuntimeError("PyTorch was compiled without MTIA support")
 
 
+if hasattr(torch._C, "_mtia_maybeExchangeDevice"):
+    _maybe_exchange_device = torch._C._mtia_maybeExchangeDevice
+else:
+
+    def _maybe_exchange_device(device: int) -> int:
+        if device < 0:
+            return -1
+        raise RuntimeError("PyTorch was compiled without MTIA support")
+
+
 def init():
     _lazy_init()
 


### PR DESCRIPTION
Summary: The FlexAttention path uses `_maybe_exchange_device`, so it will be needed eventually for MTIA as well.

Test Plan: `buck2 test fbcode//mtia/host_runtime/torch_mtia/tests:test_torch_mtia_api -- test_maybe_exchange_device`

Reviewed By: chaos5958

Differential Revision: D70072063


