### PR TITLE
Narrow scope of clangtidy lintrunner on CI to match lintrunner configs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
       submodules: true
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
-        export ADDITIONAL_LINTRUNNER_ARGS="--take CLANGTIDY,CLANGFORMAT --all-files"
+        export ADDITIONAL_LINTRUNNER_ARGS="--take CLANGTIDY,CLANGFORMAT --configs .lintrunner.toml --all-files"
         export CLANG=1
         .github/scripts/lintrunner.sh
 

--- a/aten/src/ATen/CPUGeneratorImpl.cpp
+++ b/aten/src/ATen/CPUGeneratorImpl.cpp
@@ -21,7 +21,6 @@ struct CPUGeneratorImplStateLegacy {
   int left;  /* = 1; */
   int seeded; /* = 0; */
   uint64_t next;
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   uint64_t state[at::MERSENNE_STATE_N]; /* the array for the state vector  */
 
   /********************************/


### PR DESCRIPTION
Summary: `--all-files` for the CLANGTIDY lint is too broad, leading it to produce errors on files that should not be linted like `.cuh` files (see [discussion in PR 148936](https://github.com/pytorch/pytorch/pull/148936)). This PR narrows the scope to respect the include and exclude patterns in the `.lintrunner.toml` config.

Test Plan:
1. Apply these changes to D70539649 and [export it to a PR](https://github.com/pytorch/pytorch/pull/148936)
2. Observe that the PR doesn't have any linter errors ([other errors on there are already being looked at](https://fb.workplace.com/groups/pytorch.edge.users/permalink/1721728545364098/) and are separate)

Differential Revision: D71335488


