### PR TITLE
xpu: improve error handling and reporting in XPU cmake files

### DIFF
--- a/cmake/Caffe2Config.cmake.in
+++ b/cmake/Caffe2Config.cmake.in
@@ -100,6 +100,13 @@ if(@USE_XPU@)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
   include("${CMAKE_CURRENT_LIST_DIR}/public/xpu.cmake")
   set(CMAKE_MODULE_PATH "${old_CMAKE_MODULE_PATH}")
+
+  if(@USE_XPU@ AND NOT PYTORCH_FOUND_XPU)
+    message(FATAL_ERROR
+      "Your installed Caffe2 version uses XPU but I cannot find the XPU runtime"
+      "libraries. Please set the proper oneAPI paths and / or install "
+      "oneAPI.")
+  endif()
 endif()
 
 if(@CAFFE2_USE_MKL@)

--- a/cmake/Modules/FindSYCLToolkit.cmake
+++ b/cmake/Modules/FindSYCLToolkit.cmake
@@ -46,7 +46,9 @@ function(parse_sycl_compiler_version version_number)
   set(${version_number} "${VERSION_NUMBER_MATCH}" PARENT_SCOPE)
 endfunction()
 
-parse_sycl_compiler_version(SYCL_COMPILER_VERSION)
+if(SYCL_COMPILER)
+  parse_sycl_compiler_version(SYCL_COMPILER_VERSION)
+endif()
 
 if(NOT SYCL_COMPILER_VERSION)
   set(SYCL_FOUND False)


### PR DESCRIPTION
For #149075

* Add a graceful cmake error instead of cryptic one if SYCL runtime is not found:
```
The link interface of target "c10_xpu" contains:

    torch::xpurt

  but the target was not found.
```
* Suppress unclear cmake error if SYCL compiler is not available and further version query fails:
```
CMake Error at /home/dvrogozh/pytorch/torch/share/cmake/Caffe2/FindSYCLToolkit.cmake:37 (string):
  string sub-command REGEX, mode REPLACE needs at least 6 arguments total to
  command.
```

CC: @gujinghui @EikanWang @fengyuan14 @guangyey @jgong5