### PR TITLE
[tp] change test_layer_norm_bwd_req_grad test to avoid uneven TP sharding which causes timeout

### DIFF
--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -429,7 +429,7 @@ class DistMathOpsTest(DTensorTestBase):
     @with_comms
     def test_layer_norm_bwd_req_grad(self):
         device_mesh = self.build_device_mesh()
-        batch, seq_len, embedding_dim, vocab_size = 8, 8, 10, 32
+        batch, seq_len, embedding_dim, vocab_size = 8, 2 * self.world_size, 10, 32
 
         # build our subtest configurations and filter out invalid ones
         class SubTest(NamedTuple):


### PR DESCRIPTION
Fixes #148943 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149361



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o