### PR TITLE
[ONNX] Update types in VerificationInfo

### DIFF
--- a/torch/onnx/_internal/exporter/_verification.py
+++ b/torch/onnx/_internal/exporter/_verification.py
@@ -61,8 +61,8 @@ class VerificationInfo:
     def from_tensors(
         cls,
         name: str,
-        expected: torch.Tensor | torch.types.Number,
-        actual: torch.Tensor | torch.types.Number,
+        expected: torch.Tensor | float | int | bool,
+        actual: torch.Tensor | float | int | bool,
     ) -> VerificationInfo:
         """Create a VerificationInfo object from two tensors.
 


### PR DESCRIPTION
torch.types.Number was rendered as is in the documentation and can be confusing. We write the original types instead to reduce confusion for users.
