### PR TITLE
[MPS] Add `bicubic2d_aa`

### DIFF
--- a/aten/src/ATen/native/mps/kernels/UpSample.metal
+++ b/aten/src/ATen/native/mps/kernels/UpSample.metal
@@ -273,7 +273,7 @@ struct BilinearFunctor {
     x = abs(x);
     return x < 1.0 ? 1.0 - x : x;
   }
-  float area_factor = 1.0;
+  static constant constexpr float area_factor = 1.0;
 };
 
 struct BicubicFunctor {
@@ -288,7 +288,7 @@ struct BicubicFunctor {
     }
     return 0;
   }
-  float area_factor = 2.0;
+  static constant constexpr float area_factor = 2.0;
 };
 
 template <typename T, typename F>
@@ -310,12 +310,12 @@ kernel void upsample_2d_aa(
       scales.x,
       output_x,
       /*align_corners=*/false,
-      /*cubic=*/f.area_factor == 2.0);
+      /*cubic=*/F::area_factor == 2.0);
   auto y_center = area_pixel_compute_source_index(
       scales.y,
       output_y,
       /*align_corners=*/false,
-      /*cubic=*/f.area_factor == 2.0);
+      /*cubic=*/F::area_factor == 2.0);
   auto clamped_scales = max(1.0, scales);
   auto x_min =
       max(0L, long(floor(x_center - f.area_factor * clamped_scales.x + 1)));

--- a/aten/src/ATen/native/mps/kernels/UpSample.metal
+++ b/aten/src/ATen/native/mps/kernels/UpSample.metal
@@ -268,12 +268,31 @@ kernel void upsample_bilinear2d(
   }
 }
 
-inline float bilinear_functor(float x) {
-  return abs(x) < 1.0 ? 1.0 - abs(x) : abs(x);
-}
+struct BilinearFunctor {
+  inline float operator()(float x) {
+    x = abs(x);
+    return x < 1.0 ? 1.0 - x : x;
+  }
+  float area_factor = 1.0;
+};
 
-template <typename T>
-kernel void upsample_bilinear2d_aa(
+struct BicubicFunctor {
+  inline float operator()(float x) {
+    // https://en.wikipedia.org/wiki/Bicubic_interpolation#Bicubic_convolution_algorithm
+    x = abs(x);
+    if (x < 1.0) {
+      return 1.0 + (1.5 * x - 2.5) * x * x;
+    }
+    if (x < 2.0) {
+      return 2.0 - 0.5 * ((x - 5.0) * x + 8.0) * x;
+    }
+    return 0;
+  }
+  float area_factor = 2.0;
+};
+
+template <typename T, typename F>
+kernel void upsample_2d_aa(
     constant T* inputData [[buffer(0)]],
     device T* outputData [[buffer(1)]],
     constant ulong4& input_strides [[buffer(2)]],
@@ -286,15 +305,26 @@ kernel void upsample_bilinear2d_aa(
   auto output_x = thread_index % static_cast<uint>(output_sizes.w);
   auto output_y = thread_index / static_cast<uint>(output_sizes.w);
   (void)align_corners; // Align corners is unused for AA algorithm
+  F f;
   auto x_center = area_pixel_compute_source_index(
-      scales.x, output_x, /*align_corners=*/false, /*cubic=*/false);
+      scales.x,
+      output_x,
+      /*align_corners=*/false,
+      /*cubic=*/f.area_factor == 2.0);
   auto y_center = area_pixel_compute_source_index(
-      scales.y, output_y, /*align_corners=*/false, /*cubic=*/false);
+      scales.y,
+      output_y,
+      /*align_corners=*/false,
+      /*cubic=*/f.area_factor == 2.0);
   auto clamped_scales = max(1.0, scales);
-  auto x_min = max(0L, long(floor(x_center - clamped_scales.x + 1)));
-  auto x_max = min(input_sizes.w, long(ceil(x_center + clamped_scales.x)));
-  auto y_min = max(0L, long(floor(y_center - clamped_scales.y + 1)));
-  auto y_max = min(input_sizes.z, long(ceil(y_center + clamped_scales.y)));
+  auto x_min =
+      max(0L, long(floor(x_center - f.area_factor * clamped_scales.x + 1)));
+  auto x_max = min(
+      input_sizes.w, long(ceil(x_center + f.area_factor * clamped_scales.x)));
+  auto y_min =
+      max(0L, long(floor(y_center - f.area_factor * clamped_scales.y + 1)));
+  auto y_max = min(
+      input_sizes.z, long(ceil(y_center + f.area_factor * clamped_scales.y)));
   for (int n = 0; n < output_sizes.x; n++) {
     for (int c = 0; c < output_sizes.y; c++) {
       float res = 0.0;
@@ -302,9 +332,9 @@ kernel void upsample_bilinear2d_aa(
       constant auto* input =
           inputData + n * input_strides.x + c * input_strides.y;
       for (auto y = y_min; y < y_max; ++y) {
-        auto dy = bilinear_functor((y - y_center) / clamped_scales.y);
+        auto dy = f((y - y_center) / clamped_scales.y);
         for (auto x = x_min; x < x_max; ++x) {
-          auto dx = bilinear_functor((x - x_center) / clamped_scales.x);
+          auto dx = f((x - x_center) / clamped_scales.x);
           auto val = input[x * input_strides.w + y * input_strides.z];
           res += val * dx * dy;
           ws += dx * dy;
@@ -456,6 +486,19 @@ kernel void upsample_bicubic2d_backward(
           constant bool& align_corners [[buffer(7)]],              \
           uint thread_index [[thread_position_in_grid]])
 
+#define INSTANTIATE_UPSAMPLE_2D_AA(NAME, FUNCTOR, DTYPE)           \
+  template [[host_name("upsample_" #NAME "_" #DTYPE)]] kernel void \
+  upsample_2d_aa<DTYPE, FUNCTOR>(                                  \
+      constant DTYPE * inputData [[buffer(0)]],                    \
+      device DTYPE * outputData [[buffer(1)]],                     \
+      constant ulong4 & input_strides [[buffer(2)]],               \
+      constant ulong4 & output_strides [[buffer(3)]],              \
+      constant long4 & input_sizes [[buffer(4)]],                  \
+      constant long4 & output_sizes [[buffer(5)]],                 \
+      constant float2 & scales [[buffer(6)]],                      \
+      constant bool& align_corners [[buffer(7)]],                  \
+      uint thread_index [[thread_position_in_grid]])
+
 #define INSTANTIATE_UPSAMPLE_2D_BACKWARD(NAME, DTYPE)                       \
   template [[host_name("upsample_" #NAME "_backward_" #DTYPE)]] kernel void \
       upsample_##NAME##_backward<DTYPE>(                                    \
@@ -482,11 +525,12 @@ kernel void upsample_bicubic2d_backward(
       constant bool& align_corners [[buffer(7)]],                 \
       uint thread_index [[thread_position_in_grid]])
 
-#define INSTANTIATE_UPSAMPLE_ALL(DTYPE)               \
-  INSTANTIATE_UPSAMPLE_2D(bicubic2d, DTYPE);          \
-  INSTANTIATE_UPSAMPLE_2D_BACKWARD(bicubic2d, DTYPE); \
-  INSTANTIATE_UPSAMPLE_2D(bilinear2d, DTYPE);         \
-  INSTANTIATE_UPSAMPLE_2D(bilinear2d_aa, DTYPE);      \
+#define INSTANTIATE_UPSAMPLE_ALL(DTYPE)                              \
+  INSTANTIATE_UPSAMPLE_2D(bicubic2d, DTYPE);                         \
+  INSTANTIATE_UPSAMPLE_2D_AA(bicubic2d_aa, BicubicFunctor, DTYPE);   \
+  INSTANTIATE_UPSAMPLE_2D_BACKWARD(bicubic2d, DTYPE);                \
+  INSTANTIATE_UPSAMPLE_2D(bilinear2d, DTYPE);                        \
+  INSTANTIATE_UPSAMPLE_2D_AA(bilinear2d_aa, BilinearFunctor, DTYPE); \
   INSTANTIATE_UPSAMPLE_LINEAR(DTYPE);
 
 INSTANTIATE_UPSAMPLE_2D(bilinear2d, uchar);

--- a/aten/src/ATen/native/mps/operations/UpSample.mm
+++ b/aten/src/ATen/native/mps/operations/UpSample.mm
@@ -9,6 +9,7 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/_upsample_bicubic2d_aa_native.h>
 #include <ATen/ops/_upsample_bilinear2d_aa_backward_native.h>
 #include <ATen/ops/_upsample_bilinear2d_aa_native.h>
 #include <ATen/ops/_upsample_nearest_exact1d.h>
@@ -465,6 +466,18 @@ TORCH_IMPL_FUNC(_upsample_bilinear2d_aa_out_mps)
   TORCH_CHECK(at::isFloatingType(input.scalar_type()),
               "_upsample_bilineard2d_aa_out_mps only supports floating-point dtypes");
   mps::upsample_kernel_out_template(input, output_size, align_corners, scales_h, scales_w, output, "bilinear2d_aa");
+}
+
+TORCH_IMPL_FUNC(_upsample_bicubic2d_aa_out_mps)
+(const Tensor& input,
+ IntArrayRef output_size,
+ bool align_corners,
+ std::optional<double> scales_h,
+ std::optional<double> scales_w,
+ const Tensor& output) {
+  TORCH_CHECK(at::isFloatingType(input.scalar_type()),
+              "_upsample_bicubic2d_aa_out_mps only supports floating-point dtypes");
+  mps::upsample_kernel_out_template(input, output_size, align_corners, scales_h, scales_w, output, "bicubic2d_aa");
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -12766,6 +12766,7 @@
   dispatch:
     CPU: _upsample_bicubic2d_aa_out_cpu
     CUDA: _upsample_bicubic2d_aa_out_cuda
+    MPS: _upsample_bicubic2d_aa_out_mps
 
 - func: _upsample_bicubic2d_aa(Tensor self, SymInt[2] output_size, bool align_corners, float? scales_h=None, float? scales_w=None) -> Tensor
   python_module: nn

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10027,7 +10027,6 @@ class TestNNDeviceType(NNTestCase):
         torch.set_printoptions(precision=5)
         self.assertEqual(out_t, expected_out_t, atol=1e-5, rtol=0)
 
-    @expectedFailureMPS  # NotImplementedError: aten::_upsample_bicubic2d_aa.out https://github.com/pytorch/pytorch/issues/77764
     @parametrize_test("memory_format", [torch.contiguous_format, torch.channels_last])
     def test_upsamplingBicubic2d_aa_correctness(self, device, memory_format):
         t_in = torch.arange(3 * 8 * 8, dtype=torch.float, device=device).reshape(1, 3, 8, 8)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149378

Which is currently the most frequently requested op in https://github.com/pytorch/pytorch/issues/141287

Mostly done by refactoring `upsample_bilinear2d_aa` to accept Functor as one of the template arguments, which closely ideas from https://github.com/python-pillow/Pillow/blob/eec43cfbc0c9962af2b728677d1d011b311584db/src/libImaging/Resample.c as well as 
https://github.com/pytorch/pytorch/blob/bb42e4d1374828ba417fa252d2bcac2f07d368e8/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu#L472-L478

Populate unit tests by copying upsample_bilinear_2d_aa and reusing it as upsample_bicubic2d_aa

At that point, only difference between upsample_bilinear2d_aa and upsample_bicubic2d_aa are convolution kernel function and size: for bilinear it's 3x3, for bicubic it's 5x5