### PR TITLE
Fix preload for cusparseLT

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -279,13 +279,12 @@ def _preload_cuda_deps(lib_folder: str, lib_name: str) -> None:
     lib_path = None
     for path in sys.path:
         nvidia_path = os.path.join(path, "nvidia")
-        if not os.path.exists(nvidia_path):
-            continue
-        candidate_lib_paths = glob.glob(
-            os.path.join(nvidia_path, lib_folder, "lib", lib_name)
-        )
-        # if path/nvidia/lib_folder/ is not found look in path/lib_folder/
-        if not candidate_lib_paths:
+        if os.path.exists(nvidia_path):
+            candidate_lib_paths = glob.glob(
+                os.path.join(nvidia_path, lib_folder, "lib", lib_name)
+            )
+        else:
+            # if path/nvidia/lib_folder/ is not found look in path/lib_folder/
             candidate_lib_paths = glob.glob(
                 os.path.join(path, lib_folder, "lib", lib_name)
             )


### PR DESCRIPTION
This was added in #144477 but the preload logic was wrong since the missing `nvidia` path would trigger the `continue` in the loop and never search in the alternate location.
This is easily reproduced when trying to use torch 2.6.0 in a hermetic bazel build.

After this patch, torch manages to find and load cusparseLt properly.
Signed-off-by: Vihang Mehta <vihang@gimletlabs.ai>
