### PR TITLE
Add AOTI shim for _weight_int4pack_mm_cpu_tensor (#149031)

### DIFF
--- a/test/inductor/test_cpu_cpp_wrapper.py
+++ b/test/inductor/test_cpu_cpp_wrapper.py
@@ -357,6 +357,9 @@ if RUN_CPU:
         ),  # multiple outputs, buffer clear
         BaseTest("test_view_as_complex"),
         BaseTest("test_view_as_real"),
+        BaseTest(
+            "test_woq_int4", "cpu", test_mkldnn_pattern_matcher.TestPatternMatcher()
+        ),
     ]:
         make_test_case(
             item.name,

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -3835,7 +3835,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
             include_ops = [
                 "aoti_torch_cpu__weight_int4pack_mm_cpu_tensor"
                 if torch._inductor.config.cpp_wrapper
-                else "extern_kernels.int4mm_packed_weight_cpu"
+                else "torch.ops.quantized.int4mm_packed_weight_cpu.default"
             ]
             self._test_code_common(
                 m,

--- a/torch/_inductor/mkldnn_ir.py
+++ b/torch/_inductor/mkldnn_ir.py
@@ -1227,3 +1227,58 @@ class MkldnnRnnLayer(ExternKernelAlloc):
     def codegen(self, wrapper):
         wrapper.include_extra_header("torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h")
         return super().codegen(wrapper)
+
+
+# Add this IR so that we can include shim_mkldnn.h for cpp_wrapper
+class WeightInt4PackMatmul(ExternKernelAlloc):
+    def __init__(
+        self,
+        layout,
+        inputs,
+        constant_args=(),
+    ) -> None:
+        """
+        inputs = [x, w, qGroupSize, qScalesAndZeros]
+        constant_args = ()
+        """
+        assert len(inputs) == 4
+        assert len(constant_args) == 0
+        super().__init__(
+            layout,
+            inputs,
+            constant_args,
+            None,
+            op_overload=(torch.ops.quantized.int4mm_packed_weight_cpu.default),
+            cpp_kernel_name=("aoti_torch_cpu__weight_int4pack_mm_cpu_tensor"),
+        )
+
+    def codegen(self, wrapper):
+        wrapper.include_extra_header("torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h")
+        super().codegen(wrapper)
+
+        if isinstance(self.layout, Layout):
+            self.codegen_size_asserts(wrapper)
+
+    @classmethod
+    def create(
+        cls,
+        x: "TensorBox",
+        w: "TensorBox",
+        qGroupSize: "TensorBox",
+        qScalesAndZeros: "TensorBox",
+    ):
+        inputs = [x, w, qGroupSize, qScalesAndZeros]
+        *m, _ = x.get_size()
+        n, _ = w.get_size()
+        output_size = list(m) + [n]
+        output_stride = FlexibleLayout.contiguous_strides(output_size)
+        kernel_layout = FixedLayout(
+            x.get_device(),  # type: ignore[arg-type]
+            x.get_dtype(),
+            output_size,
+            output_stride,
+        )
+        return WeightInt4PackMatmul(
+            layout=kernel_layout,
+            inputs=inputs,
+        )

--- a/torch/_inductor/quantized_lowerings.py
+++ b/torch/_inductor/quantized_lowerings.py
@@ -8,6 +8,7 @@ from . import config as inductor_config, lowering
 from .codegen.cpp_gemm_template import CppGemmTemplate, CppWoqInt4GemmTemplate
 from .codegen.cpp_utils import create_epilogue_with_attr
 from .lowering import expand, register_lowering
+from .mkldnn_ir import WeightInt4PackMatmul
 from .select_algorithm import (
     autotune_select_algorithm,
     ExternKernelChoice,
@@ -27,6 +28,7 @@ aten__weight_int4pack_mm_cpu = ExternKernelChoice(
     torch.ops.quantized.int4mm_packed_weight_cpu,
     "at::native::_weight_int4pack_mm_cpu_tensor",
     has_out_variant=False,
+    kernel_creator=WeightInt4PackMatmul.create,
 )
 
 quantized = torch.ops.quantized

--- a/torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h
@@ -4,10 +4,11 @@
 #include <ATen/Config.h>
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 
-#if AT_MKLDNN_ENABLED()
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#if AT_MKLDNN_ENABLED()
 
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_cpu_mkldnn__convolution_pointwise_binary(
@@ -235,8 +236,16 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__mkl_linear(
 
 #endif // AT_MKL_ENABLED
 
+#endif // AT_MKLDNN_ENABLED()
+
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__weight_int4pack_mm_cpu_tensor(
+    AtenTensorHandle X,
+    AtenTensorHandle w,
+    AtenTensorHandle qGroupSize,
+    AtenTensorHandle qScaleAndZeros,
+    AtenTensorHandle* ret0);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif
-#endif // AT_MKLDNN_ENABLED()
 #endif // AOTI_TORCH_SHIM_MKLDNN

--- a/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
@@ -523,3 +523,19 @@ AOTITorchError aoti_torch_cpu__mkl_linear(
 #endif // AT_MKL_ENABLED
 
 #endif // AT_MKLDNN_ENABLED()
+
+AOTITorchError aoti_torch_cpu__weight_int4pack_mm_cpu_tensor(
+    AtenTensorHandle X,
+    AtenTensorHandle w,
+    AtenTensorHandle qGroupSize,
+    AtenTensorHandle qScaleAndZeros,
+    AtenTensorHandle* ret0) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto tmp_result = at::native::_weight_int4pack_mm_cpu_tensor(
+        *tensor_handle_to_tensor_pointer(X),
+        *tensor_handle_to_tensor_pointer(w),
+        *tensor_handle_to_tensor_pointer(qGroupSize),
+        *tensor_handle_to_tensor_pointer(qScaleAndZeros));
+    *ret0 = new_tensor_handle(std::move(tmp_result));
+  });
+}


### PR DESCRIPTION
**Summary**
Previous implementation of shim did not align with the design and it was removed by https://github.com/pytorch/pytorch/pull/148907 This PR adds it back in the files of MKLDNN backend and re-enable the CPP wrapper UT.

**Test plan**
```
pytest -s test/inductor/test_cpu_cpp_wrapper.py -k test_woq_int4
```

Pull Request resolved: https://github.com/pytorch/pytorch/pull/149031
Approved by: https://github.com/leslie-fang-intel, https://github.com/EikanWang, https://github.com/desertfire



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov