### PR TITLE
[Docs] Make `torch.Library`'s `kind` have no default value to be consistent with the code

### DIFF
--- a/torch/library.py
+++ b/torch/library.py
@@ -91,7 +91,7 @@ class Library:
         dispatch_key: PyTorch dispatch key (default: "")
     """
 
-    def __init__(self, ns, kind, dispatch_key=""):
+    def __init__(self, ns, kind="IMPL", dispatch_key=""):
         if kind not in ("IMPL", "DEF", "FRAGMENT"):
             raise ValueError("Unsupported kind: ", kind)
 

--- a/torch/library.py
+++ b/torch/library.py
@@ -87,11 +87,11 @@ class Library:
 
     Args:
         ns: library name
-        kind: "DEF", "IMPL" (default: "IMPL"), "FRAGMENT"
+        kind: "DEF", "IMPL", "FRAGMENT"
         dispatch_key: PyTorch dispatch key (default: "")
     """
 
-    def __init__(self, ns, kind="IMPL", dispatch_key=""):
+    def __init__(self, ns, kind, dispatch_key=""):
         if kind not in ("IMPL", "DEF", "FRAGMENT"):
             raise ValueError("Unsupported kind: ", kind)
 


### PR DESCRIPTION
Fixes #149389


