### PR TITLE
[xnnpack] Expose subgraph symbols

### DIFF
--- a/third_party/xnnpack.buck.bzl
+++ b/third_party/xnnpack.buck.bzl
@@ -2236,7 +2236,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         apple_sdks = (IOS, MACOSX, APPLETVOS),
         labels = labels,
         deps = [
-            ":subgraph",
             ":tables",
             ":prod_ukernels",
             third_party("cpuinfo"),
@@ -2247,6 +2246,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         },
         header_namespace = "",
         headers = get_xnnpack_headers(),
+        exported_deps = [
+            ":subgraph",
+        ],
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS + [
             "-DXNN_NO_Q8_OPERATORS",


### PR DESCRIPTION
Summary: Main XNNPack target code uses symbols from subgraph so they need to be exported - this gets uncovered on macos where symbols were not visible after linking

Test Plan: CI / used for a macOS build on top of the stack.

Differential Revision: D71315023


