### PR TITLE
Fix mtia_extension.cpp setDevice() to correctly set current_device

### DIFF
--- a/test/cpp_extensions/mtia_extension.cpp
+++ b/test/cpp_extensions/mtia_extension.cpp
@@ -38,9 +38,8 @@ struct MTIAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   }
 
   void setDevice(c10::Device d) const override {
-    c10::Device current_device = getDevice();
-    if (current_device.index() != d.index()) {
-      current_device = d;
+    if (getDevice().index() != d.index()) {
+      current_device = d.index();
     }
   }
   void uncheckedSetDevice(c10::Device d) const noexcept override {


### PR DESCRIPTION
We referred to this code and found that there was a minor bug. Fix for future reference for others. 