### PR TITLE
Fix B018 Useless Expressions in Multiple Files (#106571)

### DIFF
--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -779,10 +779,8 @@ class DeterministicAlgorithmsVariable(ContextWrappingVariable):
     def _call_func(self, tx: "InstructionTranslator", values):
         assert len(values) == 1
         value = values[0]
-        (
-            tx.output.create_node(
-                "call_function", torch._C._set_deterministic_algorithms, (value,), {}
-            ),
+        tx.output.create_node(
+            "call_function", torch._C._set_deterministic_algorithms, (value,), {}
         )
         torch._C._set_deterministic_algorithms(value)
 

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1296,13 +1296,11 @@ class CUDAGraphNode:
                 self.output_storage_alias.append(UnaliasedStorage)
                 continue
 
-            (
-                torch._check(
-                    o.is_cuda or o.untyped_storage().data_ptr() == 0,
-                    lambda: (
-                        "Expected all cuda outputs in cuda graph recording. Non cuda output "
-                        f"from {self.stack_traces[i] if self.stack_traces else '(unknown)'}"
-                    ),
+            torch._check(
+                o.is_cuda or o.untyped_storage().data_ptr() == 0,
+                lambda: (
+                    "Expected all cuda outputs in cuda graph recording. Non cuda output "
+                    f"from {self.stack_traces[i] if self.stack_traces else '(unknown)'}"
                 ),
             )
 

--- a/torch/distributed/checkpoint/default_planner.py
+++ b/torch/distributed/checkpoint/default_planner.py
@@ -408,7 +408,7 @@ class _EmptyStateDictLoadPlanner(DefaultLoadPlanner):
             return True
 
         if key in self.keys:
-            True
+            return True
 
         unflattened_keys: list[str] = []
         planner_data = metadata.planner_data.get(key)


### PR DESCRIPTION
### Description
This PR addresses `flake8-bugbear` `B018` warnings ("Found useless expression") by removing unused tuple and constant expressions in three files. These fixes clean up the codebase, reducing potential confusion and aligning with the linting goals of #106571. As a first-time contributor (coming from Node.js and learning Python), I’m excited to help improve PyTorch’s code quality!

### Changes
- **`torch/_dynamo/variables/ctx_manager.py`**  
  - **Issue**: `Found useless Tuple expression. Consider either assigning it to a variable or removing it.`  
  - **Fix**: Removed unnecessary tuple wrapper `(...,)` around a statement, keeping the side-effecting call intact.  
- **`torch/_inductor/cudagraph_trees.py`**  
  - **Issue**: `Found useless Tuple expression. Consider either assigning it to a variable or removing it.`  
  - **Fix**: Removed unnecessary tuple wrapper `(...,)` around a statement, keeping the side-effecting call intact.  
- **`torch/distributed/checkpoint/default_planner.py`**  
  - **Issue**: `Found useless Constant expression. Consider either assigning it to a variable or removing it.`  
  - **Fix**: Added a `return` statement before the standalone `True` expression, making it a meaningful return value.

### Details
- **Related Issue**: Fixes #106571  
- **Linting Tool**: Verified with `flake8` and `flake8-bugbear`.  
- **Testing**: Ran `pytest` locally to ensure no functional changes—only cleanup.  

### Notes
Thanks to @spzala, @Skylion007, and @zou3519 for maintaining this awesome project! Any feedback on my fixes or PR process is welcome—I’m here to learn and contribute.  

#### FYI
@albanD I am creating a new PR because EasyCLA was failing on the first one.

---

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov