### PR TITLE
[AOTI][reland] Update test runner to use the new APIs

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -747,7 +747,7 @@ class CompileTest(TestCase):
         assert "= torch.ops._c10d_functional.wait_tensor.default" not in code
 
         # Test aoti
-        AOTIRunnerUtil.run("cuda", func, (arg,))
+        AOTIRunnerUtil.run(func, (arg,))
         torch.cuda.synchronize()
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
@@ -793,7 +793,7 @@ class CompileTest(TestCase):
         assert "= torch.ops._c10d_functional.wait_tensor.default" not in code
 
         # Test aoti
-        out = AOTIRunnerUtil.run("cuda", func, (args,))  # noqa: F841
+        out = AOTIRunnerUtil.run(func, (args,))  # noqa: F841
         torch.cuda.synchronize()
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
@@ -905,7 +905,7 @@ class CompileTest(TestCase):
         assert "= torch.ops._c10d_functional.wait_tensor.default" not in code
 
         # Test aoti
-        AOTIRunnerUtil.run("cuda", func, (arg,))
+        AOTIRunnerUtil.run(func, (arg,))
         torch.cuda.synchronize()
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
@@ -939,7 +939,7 @@ class CompileTest(TestCase):
         )
 
         # Test aoti
-        out = AOTIRunnerUtil.run("cuda", func, (args,))  # noqa: F841
+        out = AOTIRunnerUtil.run(func, (args,))  # noqa: F841
         torch.cuda.synchronize()
 
     @unittest.skipIf(not HAS_GPU, "This is a GPU test!")
@@ -961,7 +961,7 @@ class CompileTest(TestCase):
         )
 
         # Test aoti
-        AOTIRunnerUtil.run("cuda", func, (arg,))
+        AOTIRunnerUtil.run(func, (arg,))
         torch.cuda.synchronize()
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
@@ -987,7 +987,7 @@ class CompileTest(TestCase):
         )
 
         # Test aoti
-        AOTIRunnerUtil.run("cuda", func, (arg,))
+        AOTIRunnerUtil.run(func, (arg,))
         torch.cuda.synchronize()
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
@@ -1023,7 +1023,7 @@ class CompileTest(TestCase):
         )
 
         # Test aoti
-        AOTIRunnerUtil.run("cuda", func, (args,))
+        AOTIRunnerUtil.run(func, (args,))
         torch.cuda.synchronize()
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
@@ -1108,7 +1108,7 @@ class CompileTest(TestCase):
         )
 
         # Test aoti
-        AOTIRunnerUtil.run("cuda", func, (arg,))
+        AOTIRunnerUtil.run(func, (arg,))
         torch.cuda.synchronize()
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -183,7 +183,7 @@ class AOTInductorTestsTemplate:
             torch.randn(10, 10, device=self.device),
         )
         expected_path = os.path.join(tempfile.mkdtemp(dir=cache_dir()), "model.so")
-        actual_path = AOTIRunnerUtil.compile(
+        actual_path = AOTIRunnerUtil.legacy_compile(
             model, example_inputs, options={"aot_inductor.output_path": expected_path}
         )
         self.assertTrue(actual_path == expected_path)
@@ -203,7 +203,9 @@ class AOTInductorTestsTemplate:
 
         example_inputs = (torch.randn(4, 4, device=self.device),)
         with config.patch({"aot_inductor.use_runtime_constant_folding": True}):
-            self.check_model(Model(self.device), example_inputs)
+            model = Model(device=self.device)
+            actual = AOTIRunnerUtil.legacy_run(self.device, model, example_inputs)
+            self.assertTrue(same(model(*example_inputs), actual))
 
     @requires_gpu
     def test_duplicate_constant_folding(self):
@@ -221,7 +223,9 @@ class AOTInductorTestsTemplate:
 
         example_inputs = (torch.randn(4, 4, device=self.device),)
         with config.patch({"aot_inductor.use_runtime_constant_folding": True}):
-            self.check_model(Model(self.device), example_inputs)
+            model = Model(device=self.device)
+            actual = AOTIRunnerUtil.legacy_run(self.device, model, example_inputs)
+            self.assertTrue(same(model(*example_inputs), actual))
 
     @requires_gpu
     def test_multi_device(self):
@@ -285,7 +289,6 @@ class AOTInductorTestsTemplate:
 
         with torch.no_grad():
             result = AOTIRunnerUtil.run(
-                self.device,
                 m,
                 (ref_x,),
             )
@@ -426,7 +429,8 @@ class AOTInductorTestsTemplate:
             example_inputs = (torch.randn(10, 10, device=self.device).to(dtype),)
 
             with config.patch({"freezing": True}):
-                self.check_model(LinearModel(self.device), example_inputs)
+                model = LinearModel(device=self.device)
+                self.check_model(model, example_inputs)
 
     def test_linear_dynamic_maxautotune(self):
         class Model(torch.nn.Module):
@@ -483,7 +487,9 @@ class AOTInductorTestsTemplate:
 
         example_inputs = (torch.randn(2, 8, device=self.device),)
         counters.clear()
-        self.check_model(Model(), example_inputs)
+        model = Model().to(device=self.device)
+        actual = AOTIRunnerUtil.legacy_run(self.device, model, example_inputs)
+        self.assertTrue(same(model(*example_inputs), actual))
         self.assertEqual(counters["inductor"]["scmerge_split_removed"], 1)
         self.assertEqual(counters["inductor"]["scmerge_cat_removed"], 1)
         self.assertEqual(counters["inductor"]["scmerge_split_sections_removed"], 1)
@@ -535,7 +541,11 @@ class AOTInductorTestsTemplate:
             torch.randn(10, 10, device=self.device),
             torch.randn(10, 10, device=self.device),
         )
-        self.check_model(Model(), example_inputs)
+        # Had to use legacy_run. Bug to be fixed
+        with config.patch({"aot_inductor.use_runtime_constant_folding": True}):
+            model = Model()
+            actual = AOTIRunnerUtil.legacy_run(self.device, model, example_inputs)
+            self.assertTrue(same(model(*example_inputs), actual))
 
     @skip("Test was marked as expected failure, but does not fail always anymore.")
     def test_dynamic_smem_above_default_limit(self):
@@ -589,6 +599,8 @@ class AOTInductorTestsTemplate:
         model = Model(N, K, self.device)
         batch = 2
         a = torch.randn(batch, M, K, device=self.device)
+        # We should be able to call self.check_model here, but torch.export.export
+        # constants (non-parameter, non-buffer) doesn't work today.
         example_inputs = (a,)
         self.check_model(model, example_inputs)
 
@@ -1634,12 +1646,12 @@ class AOTInductorTestsTemplate:
         }
 
         # Compile & run model where dynamic dim size > 0.
-        so_path: str = AOTIRunnerUtil.compile(
+        package_path: str = AOTIRunnerUtil.compile(
             Repro(),
             example_inputs,
             dynamic_shapes=dynamic_shapes,
         )
-        aot_inductor_module = AOTIRunnerUtil.load(self.device, so_path)
+        aot_inductor_module = torch._inductor.aoti_load_package(package_path)
         aot_inductor_module(*example_inputs)
 
         # Re-run where dynamic dim size is 0.
@@ -1706,7 +1718,7 @@ class AOTInductorTestsTemplate:
                     args=(a, b),
                     kwargs={"alpha": 2.0},
                 )
-                kernel_runner = AOTIRunnerUtil.load_runner(self.device, so_path)
+                kernel_runner = AOTIRunnerUtil.legacy_load_runner(self.device, so_path)
                 res = kernel_runner.run([a, b])
                 self.assertTrue(isinstance(res, list))
                 self.assertTrue(len(res) == 1)
@@ -1846,7 +1858,7 @@ class AOTInductorTestsTemplate:
         # Compile model with AOTInductor
         device_interface = get_interface_for_device(GPU_TYPE)
         with device_interface.device(0):
-            so_path = AOTIRunnerUtil.compile(
+            package_path = AOTIRunnerUtil.compile(
                 model=Model(
                     w1.to(torch.device(GPU_TYPE, 0)), w2.to(torch.device(GPU_TYPE, 0))
                 ),
@@ -1857,7 +1869,7 @@ class AOTInductorTestsTemplate:
         for i in range(device_interface.device_count()):
             with device_interface.device(i):
                 example_inputs = tuple(t.to(torch.device(GPU_TYPE, i)) for t in inputs)
-                optimized = AOTIRunnerUtil.load(GPU_TYPE, so_path)
+                optimized = torch._inductor.aoti_load_package(package_path)
                 result_gpu = optimized(*example_inputs)
             self.assertTrue(same(result_cpu, result_gpu.cpu()))
 
@@ -1892,8 +1904,8 @@ class AOTInductorTestsTemplate:
         example_inputs = (torch.randn(8, 10, device=device),)
         expected = model(*example_inputs)
 
-        so_path = AOTIRunnerUtil.compile(model, example_inputs)
-        optimized = AOTIRunnerUtil.load(device, so_path)
+        so_path = AOTIRunnerUtil.legacy_compile(model, example_inputs)
+        optimized = AOTIRunnerUtil.legacy_load(device, so_path)
         actual = optimized(*example_inputs)
         torch.testing.assert_close(actual, expected)
 
@@ -1942,14 +1954,12 @@ class AOTInductorTestsTemplate:
         device_interface = get_interface_for_device(GPU_TYPE)
         with device_interface.device(0), torch.no_grad():
             result_gpu_0 = AOTIRunnerUtil.run(
-                GPU_TYPE,
                 Model(weight.to(torch.device(GPU_TYPE, 0))),
                 tuple(t.to(torch.device(GPU_TYPE, 0)) for t in inputs),
             )
 
         with device_interface.device(1), torch.no_grad():
             result_gpu_1 = AOTIRunnerUtil.run(
-                GPU_TYPE,
                 Model(weight.to(torch.device(GPU_TYPE, 1))),
                 tuple(t.to(torch.device(GPU_TYPE, 1)) for t in inputs),
             )
@@ -2044,8 +2054,8 @@ class AOTInductorTestsTemplate:
         }
 
         example_inputs = (x, y, z)
-        m = Model(self.device).to(dtype=torch.float)
-        self.check_model(m, example_inputs, dynamic_shapes=dynamic_shapes)
+        model = Model(self.device).to(dtype=torch.float)
+        self.check_model(model, example_inputs, dynamic_shapes=dynamic_shapes)
 
     def test_fake_tensor_device_validation(self):
         if self.device != GPU_TYPE:
@@ -2187,12 +2197,12 @@ class AOTInductorTestsTemplate:
 
         # compiler under no_grad
         with torch.no_grad():
-            so_path = AOTIRunnerUtil.compile(m, example_inputs)
+            package_path = AOTIRunnerUtil.compile(m, example_inputs)
 
         # run under grad enabled
         self.assertTrue(torch.is_grad_enabled())
 
-        optimized = AOTIRunnerUtil.load(self.device, so_path)
+        optimized = torch._inductor.aoti_load_package(package_path)
         actual = optimized(*example_inputs)
         actual = pytree.tree_leaves(actual)
 
@@ -3078,12 +3088,11 @@ class AOTInductorTestsTemplate:
                 return (self.foo_bar(x) + self.test_param) * self.test_buf
 
         with torch.no_grad():
-            so_path = AOTIRunnerUtil.compile(
+            so_path = AOTIRunnerUtil.legacy_compile(
                 model=TestModule().to(device=self.device),
                 example_inputs=(torch.rand(3, 4, device=self.device),),
             )
-
-        runner = AOTIRunnerUtil.load_runner(self.device, so_path)
+        runner = AOTIRunnerUtil.legacy_load_runner(self.device, so_path)
 
         expected_original_fqns = {
             "L__self___test_param": "test_param",
@@ -3187,6 +3196,7 @@ class AOTInductorTestsTemplate:
         example_inputs = (torch.randn(2, M, K, device=self.device),)
         model = Model(N, K, self.device)
         self.check_model(model, example_inputs)
+
         # Update model weights, after this AOTInductor should re-generate model.so
         # if weights are stored in the model.so
         model.weight += 1
@@ -3250,12 +3260,11 @@ class AOTInductorTestsTemplate:
             torch.randn(1, 16, device=GPU_TYPE),
         )
 
-        so_path: str = AOTIRunnerUtil.compile(
+        package_path: str = AOTIRunnerUtil.compile(
             Model(),
             example_inputs,
         )
-        aot_inductor_module = AOTIRunnerUtil.load(GPU_TYPE, so_path)
-
+        aot_inductor_module = torch._inductor.aoti_load_package(package_path)
         # Don't assign outputs to a variable b/c it will allocate GPU memory.
         device_interface = get_interface_for_device(GPU_TYPE)
         device: int = device_interface.current_device()
@@ -3416,7 +3425,9 @@ class AOTInductorTestsTemplate:
         m = Model()
         inputs = tuple(inputs)
         with torch.no_grad():
-            so_path = AOTIRunnerUtil.compile(m, inputs, dynamic_shapes=dynamic_shapes)
+            so_path = AOTIRunnerUtil.legacy_compile(
+                m, inputs, dynamic_shapes=dynamic_shapes
+            )
         with open(os.path.splitext(so_path)[0] + ".cpp") as cpp:
             src_code = cpp.read()
             FileCheck().check_count(
@@ -3445,10 +3456,8 @@ class AOTInductorTestsTemplate:
                 else 19,  # we have 9 symbolic strides for which we don't generate checks
                 exactly=True,
             ).run(src_code)
-        optimized = AOTIRunnerUtil.load(self.device, so_path)
-        actual = optimized(*inputs)
-        expected = m(*inputs)
-        torch.testing.assert_close(actual, expected)
+
+        self.check_model(m, inputs)
 
     @unittest.skipIf(TEST_WITH_ROCM, "FP8 is not supported on ROCM")
     @unittest.skipIf(
@@ -3537,11 +3546,11 @@ class AOTInductorTestsTemplate:
         x = torch.randn(1, 4, dtype=torch.float16, device=self.device)
         model = Model()
         with torch.no_grad():
-            so_path: str = AOTIRunnerUtil.compile(
+            package_path: str = AOTIRunnerUtil.compile(
                 model,
                 (x,),
             )
-        aot_inductor_module = AOTIRunnerUtil.load(self.device, so_path)
+        aot_inductor_module = torch._inductor.aoti_load_package(package_path)
         x_casted = x.float()
         with self.assertRaisesRegex(Exception, ""):
             aot_inductor_module(x_casted)
@@ -3559,7 +3568,6 @@ class AOTInductorTestsTemplate:
         model = Model()
         with torch.no_grad():
             result = AOTIRunnerUtil.run(
-                self.device,
                 model,
                 (x,),
             )
@@ -3584,7 +3592,6 @@ class AOTInductorTestsTemplate:
 
         with torch.no_grad():
             result = AOTIRunnerUtil.run(
-                self.device,
                 model,
                 (x,),
             )
@@ -3621,10 +3628,10 @@ class AOTInductorTestsTemplate:
         }
         model = Model()
         with torch.no_grad():
-            so_path: str = AOTIRunnerUtil.compile(
+            package_path: str = AOTIRunnerUtil.compile(
                 model, (x,), dynamic_shapes=dynamic_shapes
             )
-        aot_inductor_module = AOTIRunnerUtil.load(self.device, so_path)
+        aot_inductor_module = torch._inductor.aoti_load_package(package_path)
         # dynamic dim works fine
         _ = aot_inductor_module(y0)
         with self.assertRaisesRegex(Exception, ""):
@@ -3736,10 +3743,14 @@ class AOTInductorTestsTemplate:
             example_inputs_3,
             example_inputs_4,
         ]
-
-        self.check_model_with_multiple_inputs(
-            model, example_inputs_list, dynamic_shapes=dynamic_shapes
-        )
+        for example_input in example_inputs_list:
+            actual = AOTIRunnerUtil.legacy_run(
+                self.device,
+                model,
+                example_input,
+                dynamic_shapes=dynamic_shapes,
+            )
+            self.assertTrue(same(model(*example_input), actual))
 
     @common_utils.parametrize("max_autotune", [True, False])
     def test_misc_1(self, max_autotune):
@@ -3837,7 +3848,7 @@ class AOTInductorTestsTemplate:
         # test default debug printing all tensor values codegen
         with config.patch({"aot_inductor.debug_intermediate_value_printer": "2"}):
             result, code = run_and_get_cpp_code(
-                AOTIRunnerUtil.compile, model, example_inputs
+                AOTIRunnerUtil.legacy_compile, model, example_inputs
             )
 
             # check the c shim print_tensor_handle call is triggered by the config and injected the cpp output code as expected
@@ -3864,7 +3875,7 @@ class AOTInductorTestsTemplate:
             }
         ):
             result, code = run_and_get_cpp_code(
-                AOTIRunnerUtil.compile, model, example_inputs
+                AOTIRunnerUtil.legacy_compile, model, example_inputs
             )
             filtered_kernel_calls = [
                 (filtered_kernel_name, 2),
@@ -4126,12 +4137,12 @@ class AOTInductorTestsTemplate:
 
         # Check the runtime assertion is codegen'ed.
         so_path, code = run_and_get_cpp_code(
-            AOTIRunnerUtil.compile, model, example_inputs
+            AOTIRunnerUtil.legacy_compile, model, example_inputs
         )
         lowerbound_check = "u1 >= 1" if mark_unbacked else "u0 >= 2"
         FileCheck().check_count(lowerbound_check, 1).run(code)
 
-        compiled = AOTIRunnerUtil.load(self.device, so_path)
+        compiled = AOTIRunnerUtil.legacy_load(self.device, so_path)
         compiled(*example_inputs)
 
         # Check the runtime assertion.
@@ -4141,9 +4152,7 @@ class AOTInductorTestsTemplate:
 
         # Try it again without runtime assertions.
         with config.patch({"scalar_asserts": False}):
-            AOTIRunnerUtil.run_multiple(
-                self.device, model, [example_inputs, unexpected_inputs]
-            )
+            AOTIRunnerUtil.run_multiple(model, [example_inputs, unexpected_inputs])
 
     def test_none_args_aot_codegen(self):
         if self.device != GPU_TYPE:
@@ -4255,7 +4264,7 @@ class AOTInductorTestsTemplate:
                 "aot_inductor.package_constants_in_so": True,
             }
         ):
-            so_path = AOTIRunnerUtil.compile(
+            so_path = AOTIRunnerUtil.legacy_compile(
                 model=model,
                 example_inputs=example_inputs,
             )
@@ -4266,14 +4275,14 @@ class AOTInductorTestsTemplate:
                 "aot_inductor.package_constants_in_so": False,
             }
         ):
-            so_path_weightless = AOTIRunnerUtil.compile(
+            so_path_weightless = AOTIRunnerUtil.legacy_compile(
                 model=model,
                 example_inputs=example_inputs,
             )
         self.assertTrue(os.path.getsize(so_path) > 10_000_000)
         self.assertTrue(os.path.getsize(so_path_weightless) < 10_000_000)
 
-        runner = AOTIRunnerUtil.load_runner(self.device, so_path_weightless)
+        runner = AOTIRunnerUtil.legacy_load_runner(self.device, so_path_weightless)
 
         # Let's check whether the model has correct constant name mapping.
         expected_original_fqns = {
@@ -4319,13 +4328,14 @@ class AOTInductorTestsTemplate:
         model = Model(N, K, self.device)
         a = torch.randn(M, K, device=self.device)
         example_inputs = (a,)
+        # Attribute naming has changed in the new export API, so still use the legacy API here.
         with torch.no_grad(), config.patch({"always_keep_tensor_constants": True}):
-            so_path = AOTIRunnerUtil.compile(
+            so_path = AOTIRunnerUtil.legacy_compile(
                 model=model,
                 example_inputs=example_inputs,
             )
 
-        runner = AOTIRunnerUtil.load_runner(self.device, so_path)
+        runner = AOTIRunnerUtil.legacy_load_runner(self.device, so_path)
 
         # Let's check whether the model has correct constant name mapping.
         expected_original_fqns = {
@@ -4378,12 +4388,12 @@ class AOTInductorTestsTemplate:
         a = torch.randn(M, K, device=self.device)
         example_inputs = (a,)
         with torch.no_grad(), config.patch({"always_keep_tensor_constants": True}):
-            so_path = AOTIRunnerUtil.compile(
+            so_path = AOTIRunnerUtil.legacy_compile(
                 model=model,
                 example_inputs=example_inputs,
             )
 
-        runner = AOTIRunnerUtil.load_runner(self.device, so_path)
+        runner = AOTIRunnerUtil.legacy_load_runner(self.device, so_path)
 
         def runner_call(*args, **kwargs):
             import torch.fx._pytree as fx_pytree
@@ -4435,12 +4445,12 @@ class AOTInductorTestsTemplate:
         a = torch.randn(M, K, device=self.device)
         example_inputs = (a,)
         with torch.no_grad(), config.patch({"always_keep_tensor_constants": True}):
-            so_path = AOTIRunnerUtil.compile(
+            so_path = AOTIRunnerUtil.legacy_compile(
                 model=model,
                 example_inputs=example_inputs,
             )
 
-        runner = AOTIRunnerUtil.load_runner(self.device, so_path)
+        runner = AOTIRunnerUtil.legacy_load_runner(self.device, so_path)
 
         def runner_call(*args, **kwargs):
             import torch.fx._pytree as fx_pytree
@@ -4530,8 +4540,8 @@ class AOTInductorTestsTemplate:
         example_inputs = (arg,)
         model = Model()
         expected = model(*example_inputs)
-        so_path = AOTIRunnerUtil.compile(model, example_inputs)
-        optimized = AOTIRunnerUtil.load(self.device, so_path)
+        package_path = AOTIRunnerUtil.compile(model, example_inputs)
+        optimized = torch._inductor.aoti_load_package(package_path)
         # If the model is compiled with aligned inputs, the generated
         # code will check inputs alignment at runtime
         self.code_check_count(

--- a/test/inductor/test_aot_inductor_custom_ops.py
+++ b/test/inductor/test_aot_inductor_custom_ops.py
@@ -131,7 +131,7 @@ class AOTInductorTestsTemplate:
             torch.randn(3, 3, device=self.device),
             torch.randn(3, 3, device=self.device),
         )
-        with config.patch("aot_inductor.output_path", "model.so"):
+        with config.patch("aot_inductor.output_path", "model.pt2"):
             with self.assertRaises(Exception):
                 self.check_model(m, args)
 

--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -94,7 +94,6 @@ class TestAOTInductorPackage(TestCase):
         example_inputs,
         inductor_configs=None,
         dynamic_shapes=None,
-        disable_constraint_solver=False,
         atol=None,
         rtol=None,
     ) -> AOTICompiledModel:

--- a/test/inductor/test_aot_inductor_utils.py
+++ b/test/inductor/test_aot_inductor_utils.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tempfile
 import types
+from typing import Any, Optional, Union
 
 import torch
 import torch._export
@@ -31,7 +32,7 @@ class WrapperModule(torch.nn.Module):
 
 class AOTIRunnerUtil:
     @staticmethod
-    def compile(
+    def legacy_compile(
         model,
         example_inputs,
         options=None,
@@ -72,7 +73,7 @@ class AOTIRunnerUtil:
         return so_path
 
     @staticmethod
-    def load_runner(device, so_path):
+    def legacy_load_runner(device, so_path):
         if IS_FBCODE:
             from .fb import test_aot_inductor_model_runner_pybind  # @manual
 
@@ -101,10 +102,10 @@ class AOTIRunnerUtil:
                 return torch._C._aoti.AOTIModelContainerRunnerCuda(so_path, 1, device)
 
     @staticmethod
-    def load(device, so_path):
+    def legacy_load(device, so_path):
         # TODO: unify fbcode and oss behavior to only use torch._export.aot_load
         if IS_FBCODE:
-            runner = AOTIRunnerUtil.load_runner(device, so_path)
+            runner = AOTIRunnerUtil.legacy_load_runner(device, so_path)
 
             def optimized(*args, **kwargs):
                 call_spec = runner.get_call_spec()
@@ -120,39 +121,75 @@ class AOTIRunnerUtil:
             return torch._export.aot_load(so_path, device)
 
     @staticmethod
-    def run(
-        device,
+    def legacy_run(
+        device: str,
         model,
         example_inputs,
         options=None,
         dynamic_shapes=None,
         disable_constraint_solver=False,
     ):
-        so_path = AOTIRunnerUtil.compile(
+        so_path = AOTIRunnerUtil.legacy_compile(
             model,
             example_inputs,
             options=options,
             dynamic_shapes=dynamic_shapes,
             disable_constraint_solver=disable_constraint_solver,
         )
-        optimized = AOTIRunnerUtil.load(device, so_path)
+        optimized = AOTIRunnerUtil.legacy_load(device, so_path)
+        return optimized(*example_inputs)
+
+    @staticmethod
+    def compile(
+        model: Union[torch.nn.Module, types.FunctionType],
+        example_inputs: list[torch.Tensor],
+        inductor_configs: Optional[dict[str, Any]] = None,
+        dynamic_shapes: Optional[Union[dict[str, Any], tuple[Any], list[Any]]] = None,
+    ):
+        if not isinstance(model, torch.nn.Module):
+            # This should really be the default behavior of torch.export.export
+            model = WrapperModule(model)
+
+        with torch.no_grad():
+            # strict=False needs extra migration work
+            ep = torch.export.export(
+                model, example_inputs, dynamic_shapes=dynamic_shapes, strict=True
+            )
+            package_path = torch._inductor.aoti_compile_and_package(
+                ep, inductor_configs=inductor_configs
+            )
+        return package_path
+
+    @staticmethod
+    def run(
+        model: Union[torch.nn.Module, types.FunctionType],
+        example_inputs: list[torch.Tensor],
+        inductor_configs: Optional[dict[str, Any]] = None,
+        dynamic_shapes: Optional[Union[dict[str, Any], tuple[Any], list[Any]]] = None,
+    ):
+        package_path = AOTIRunnerUtil.compile(
+            model,
+            example_inputs,
+            inductor_configs=inductor_configs,
+            dynamic_shapes=dynamic_shapes,
+        )
+        optimized = torch._inductor.aoti_load_package(package_path)
         return optimized(*example_inputs)
 
     @staticmethod
     def run_multiple(
-        device,
-        model,
-        list_example_inputs,
-        options=None,
-        dynamic_shapes=None,
+        model: Union[torch.nn.Module, types.FunctionType],
+        list_example_inputs: list[list[torch.Tensor]],
+        inductor_configs: Optional[dict[str, Any]] = None,
+        dynamic_shapes: Optional[Union[dict[str, Any], tuple[Any], list[Any]]] = None,
     ):
-        so_path = AOTIRunnerUtil.compile(
+        package_path = AOTIRunnerUtil.compile(
             model,
             list_example_inputs[0],
-            options=options,
+            inductor_configs=inductor_configs,
             dynamic_shapes=dynamic_shapes,
         )
-        optimized = AOTIRunnerUtil.load(device, so_path)
+        optimized = torch._inductor.aoti_load_package(package_path)
         list_output_tensors = []
         for example_inputs in list_example_inputs:
             list_output_tensors.append(optimized(*example_inputs))
@@ -165,7 +202,6 @@ def check_model(
     example_inputs,
     options=None,
     dynamic_shapes=None,
-    disable_constraint_solver=False,
     atol=None,
     rtol=None,
 ):
@@ -196,12 +232,10 @@ def check_model(
 
         torch.manual_seed(0)
         actual = AOTIRunnerUtil.run(
-            self.device,
             model,
             example_inputs,
             options,
             dynamic_shapes,
-            disable_constraint_solver,
         )
 
     self.assertEqual(actual, expected, atol=atol, rtol=rtol)
@@ -228,7 +262,7 @@ def check_model_with_multiple_inputs(
 
         torch.manual_seed(0)
         list_actual = AOTIRunnerUtil.run_multiple(
-            self.device, model, list_example_inputs, options, dynamic_shapes
+            model, list_example_inputs, options, dynamic_shapes
         )
 
     self.assertTrue(same(list_actual, list_expected))
@@ -247,9 +281,9 @@ def code_check_count(
             "aot_inductor.use_minimal_arrayref_interface": self.use_minimal_arrayref_interface,
         }
     ):
-        so_path = torch._export.aot_compile(model, example_inputs)
+        package_path = torch._export.aot_compile(model, example_inputs)
 
-    with open(os.path.splitext(so_path)[0] + ".cpp") as cpp:
+    with open(os.path.splitext(package_path)[0] + ".cpp") as cpp:
         src_code = cpp.read()
         FileCheck().check_count(
             target_str,

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -106,7 +106,6 @@ class TestCKBackend(TestCase):
         ):
             if use_aoti:
                 Y_compiled = AOTIRunnerUtil.run(
-                    device="cuda",
                     model=mm,
                     example_inputs=(a, b),
                 )

--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -1809,7 +1809,6 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
         with verify(dtype) as (atol, rtol), torch.no_grad():
             expected = mod(v)
             actual = test_aot_inductor_utils.AOTIRunnerUtil.run(
-                "cpu",
                 mod,
                 (v,),
             )
@@ -2045,7 +2044,6 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
         with verify(dtype) as (atol, rtol), torch.no_grad():
             expected = mod(v)
             actual = test_aot_inductor_utils.AOTIRunnerUtil.run(
-                "cpu",
                 mod,
                 (v,),
             )
@@ -2420,7 +2418,6 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
         with verify(dtype) as (atol, rtol), torch.no_grad():
             expected = mod(x, w)
             actual = test_aot_inductor_utils.AOTIRunnerUtil.run(
-                "cpu",
                 mod,
                 (x, w),
             )
@@ -2477,7 +2474,6 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
                 x,
             )
             actual = test_aot_inductor_utils.AOTIRunnerUtil.run(
-                "cpu",
                 mod,
                 (x,),
             )

--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -375,7 +375,7 @@ class TestCutlassBackend(TestCase):
             expected = [model(*input) for input in inputs]
             if use_aoti:
                 actual = AOTIRunnerUtil.run_multiple(
-                    "cuda", model, inputs, dynamic_shapes=dynamic_shapes
+                    model, inputs, dynamic_shapes=dynamic_shapes
                 )
             else:
                 compiled_model = torch.compile(model, dynamic=dynamic)
@@ -437,7 +437,7 @@ class TestCutlassBackend(TestCase):
                 expected = [model(*input) for input in inputs]
                 if use_aoti:
                     actual = AOTIRunnerUtil.run_multiple(
-                        "cuda", model, inputs, dynamic_shapes=None
+                        model, inputs, dynamic_shapes=None
                     )
                 else:
                     compiled_model = torch.compile(model, dynamic=dynamic)
@@ -488,9 +488,7 @@ class TestCutlassBackend(TestCase):
         ):
             expected = [model(*input) for input in inputs]
             if use_aoti:
-                actual = AOTIRunnerUtil.run_multiple(
-                    "cuda", model, inputs, dynamic_shapes=None
-                )
+                actual = AOTIRunnerUtil.run_multiple(model, inputs, dynamic_shapes=None)
             else:
                 compiled_model = torch.compile(model, dynamic=dynamic)
                 actual = [compiled_model(*input) for input in inputs]
@@ -707,7 +705,6 @@ class TestCutlassBackend(TestCase):
             w = torch.randn(K, N).cuda().half()
 
             actual = AOTIRunnerUtil.run(
-                "cuda",
                 model,
                 (x, w),
                 dynamic_shapes=dynamic_shapes,
@@ -747,7 +744,6 @@ class TestCutlassBackend(TestCase):
             w = torch.randn(K, N).cuda().half()
 
             actual = AOTIRunnerUtil.run(
-                "cuda",
                 model,
                 (x, w),
                 dynamic_shapes=dynamic_shapes,
@@ -779,7 +775,6 @@ class TestCutlassBackend(TestCase):
             w = torch.randn(K, N).cuda().half()
 
             actual = AOTIRunnerUtil.run(
-                "cuda",
                 model,
                 (x, w),
             )

--- a/test/inductor/test_memory_planning.py
+++ b/test/inductor/test_memory_planning.py
@@ -91,7 +91,7 @@ class TestMemoryPlanning(TestCase):
         dim0_x = Dim("dim0_x", min=1, max=2048)
         dynamic_shapes = ({0: dim0_x}, None, None)
         result, code = run_and_get_cpp_code(
-            lambda: AOTIRunnerUtil.run(GPU_TYPE, f, args, dynamic_shapes=dynamic_shapes)
+            lambda: AOTIRunnerUtil.run(f, args, dynamic_shapes=dynamic_shapes)
         )
 
         FileCheck().check(

--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -123,9 +123,6 @@ class TestProvenanceTracingArtifact(TestCase):
         example_inputs = (a, b, c)
 
         model = Model()
-        ep = torch.export._trace._export(model, example_inputs)
-        gm = ep.module()
-
         for backend in ["aot_inductor", "inductor"]:
             try:
                 with config.patch(
@@ -139,11 +136,10 @@ class TestProvenanceTracingArtifact(TestCase):
                         level=logging.WARNING,
                     ) as cm:
                         if backend == "aot_inductor":
-                            so_path = torch._inductor.aot_compile(gm, example_inputs)
-                            optimized = AOTIRunnerUtil.load("cuda", so_path)
-                            optimized(*example_inputs)
+                            AOTIRunnerUtil.run(model, example_inputs)
                         else:
-                            compiled = torch.compile(gm, backend=backend)
+                            ep = torch.export._trace._export(model, example_inputs)
+                            compiled = torch.compile(ep.module(), backend=backend)
                             compiled(*example_inputs)
                     self.assertEqual(len(cm.output), 1)
                     m = re.match(r"WARNING.* debug trace: (.*)", cm.output[0])
@@ -178,9 +174,7 @@ class TestProvenanceTracingArtifact(TestCase):
                         level=logging.WARNING,
                     ) as cm:
                         if backend == "aot_inductor":
-                            so_path = torch._inductor.aot_compile(gm, example_inputs)
-                            optimized = AOTIRunnerUtil.load("cpu", so_path)
-                            optimized(*example_inputs)
+                            AOTIRunnerUtil.run(model, example_inputs)
                         else:
                             compiled = torch.compile(gm, backend=backend)
                             compiled(*example_inputs)

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -525,5 +525,12 @@ std::vector<std::string> AOTIModelPackageLoader::get_constant_fqns() {
   return constant_fqns;
 }
 
+void AOTIModelPackageLoader::update_constant_buffer(
+    std::unordered_map<std::string, at::Tensor>& tensor_map,
+    bool use_inactive,
+    bool validate_full_updates) {
+  runner_->update_constant_buffer(
+      tensor_map, use_inactive, validate_full_updates);
+}
 } // namespace torch::inductor
 #endif

--- a/torch/csrc/inductor/aoti_package/model_package_loader.h
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.h
@@ -32,6 +32,11 @@ class TORCH_API AOTIModelPackageLoader {
       bool check_full_update);
   std::vector<std::string> get_constant_fqns();
 
+  void update_constant_buffer(
+      std::unordered_map<std::string, at::Tensor>& tensor_map,
+      bool use_inactive,
+      bool validate_full_updates);
+
  private:
   std::string temp_dir_;
   std::unique_ptr<AOTIModelContainerRunner> runner_;

--- a/torch/csrc/inductor/aoti_package/pybind.cpp
+++ b/torch/csrc/inductor/aoti_package/pybind.cpp
@@ -43,6 +43,7 @@ class AOTIModelPackageLoaderPybind : public AOTIModelPackageLoader {
   }
 };
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 void initAOTIPackageBindings(PyObject* module) {
   auto rootModule = py::handle(module).cast<py::module>();
   auto m = rootModule.def_submodule("_aoti");
@@ -61,9 +62,11 @@ void initAOTIPackageBindings(PyObject* module) {
           py::arg("inputs"),
           py::arg("stream_handle") = nullptr)
       .def("get_call_spec", &AOTIModelPackageLoaderPybind::get_call_spec)
+      .def(
+          "get_constant_fqns", &AOTIModelPackageLoaderPybind::get_constant_fqns)
       .def("load_constants", &AOTIModelPackageLoaderPybind::load_constants)
       .def(
-          "get_constant_fqns",
-          &AOTIModelPackageLoaderPybind::get_constant_fqns);
+          "update_constant_buffer",
+          &AOTIModelPackageLoaderPybind::update_constant_buffer);
 }
 } // namespace torch::inductor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149412

Summary: Reland https://github.com/pytorch/pytorch/pull/147105. Switch to the newer aoti_compile_and_package APIs. Some tests still kept using legacy APIs, and will follow up with internal test refactoring.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov

Differential Revision: [D71470265](https://our.internmc.facebook.com/intern/diff/D71470265)