### PR TITLE
[dynamic] use maybe_mark_dynamic instead of mark_dynamic for batch size in benchmarks

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3700,6 +3700,7 @@ def run(runner, args, original_dir=None):
         (dev,) = args.devices
         os.environ["PJRT_DEVICE"] = {"cuda": "GPU", "cpu": "CPU"}[dev]
         torch._dynamo.mark_dynamic = MagicMock()
+        torch._dynamo.maybe_mark_dynamic = MagicMock()
         experiment = xla
         output_filename = "xla.csv"
     elif args.speedup_dynamo_ts:
@@ -4008,7 +4009,7 @@ def run(runner, args, original_dir=None):
                 nonlocal marked
                 for i, s in enumerate(t.size()):
                     if s == batch_size:
-                        torch._dynamo.mark_dynamic(t, i)
+                        torch._dynamo.maybe_mark_dynamic(t, i)
                         marked = True
                         break
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #148516
* __->__ #149420
* #149367
* #148694
* #149229
* #149336

in CA, when we capture the backward, the tensor containing the batch dim sometimes is coerced by some mul/matmul etc. with a static shaped tensor, resulting in a guard validation error


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames