### PR TITLE
Add regression tests for 3 missing PR-time benchmarks

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -38,11 +38,19 @@ update_hint_regression,compile_time_instruction_count,1523000000,0.02
 
 
 
+float_args,compile_time_instruction_count,413700000,0.015
+
+
+
 sum_floordiv_regression,compile_time_instruction_count,1026000000,0.015
 
 
 
 symint_sum,compile_time_instruction_count,3030000000,0.015
+
+
+
+symint_sum_loop,compile_time_instruction_count,3988000000,0.015
 
 
 
@@ -55,6 +63,10 @@ aotdispatcher_inference_subclass_cpu,compile_time_instruction_count,5759000000,0
 
 
 aotdispatcher_partitioner_cpu,compile_time_instruction_count,7873000000,0.015
+
+
+
+aotdispatcher_partitioner_cpu2,compile_time_instruction_count,1716000000,0.015
 
 
 


### PR DESCRIPTION
Uses values from the latest PR-time benchmark run on viable/strict. See https://github.com/pytorch/pytorch/actions/runs/13898520615/job/38900894469 for a job showing why this is needed.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames