### PR TITLE
Enable TMA persistent GEMM Template by default

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1149,7 +1149,7 @@ class triton:
     # Whether persistent matmul kernels should be enabled this flag only has effect when on h100
     # with a verison of triton new enough to support TMA
     enable_persistent_tma_matmul = (
-        os.environ.get("ENABLE_PERSISTENT_TMA_MATMUL", "0") == "1"
+        os.environ.get("ENABLE_PERSISTENT_TMA_MATMUL", "1") == "1"
     )
     # Skip L1 cache for buffers that are used only once.  Disabled by default
     skip_l1_cache = os.environ.get("TORCHINDUCTOR_SKIP_L1", "0") == "1"


### PR DESCRIPTION
ghstack-source-id: d95f0938c09704b6658c6ed9f9c9d02cb474d636
Pull Request resolved: https://github.com/pytorch/pytorch/pull/149427

Another attempt to enable the TMA persistent GEMM templates in Inductor, given the availability of Hopper GPUs in the CI.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov