### PR TITLE
Enable fast path for qlinear (static/dynamic) and qadd for AArch64 though ACL directly.

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/ACLUtils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/ACLUtils.cpp
@@ -3,7 +3,11 @@
 #if AT_MKLDNN_ACL_ENABLED()
 
 #include <ATen/Parallel.h>
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#else
 #include <ATen/ops/empty.h>
+#endif
 #include <arm_compute/core/Helpers.h>
 #include <arm_compute/core/Types.h>
 #include <arm_compute/core/Utils.h>

--- a/aten/src/ATen/native/quantized/cpu/ACLUtils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/ACLUtils.cpp
@@ -1,0 +1,310 @@
+#include <ATen/native/quantized/cpu/ACLUtils.h>
+
+#if AT_MKLDNN_ACL_ENABLED()
+
+#include <ATen/Parallel.h>
+#include <ATen/ops/empty.h>
+#include <arm_compute/core/Helpers.h>
+#include <arm_compute/core/Types.h>
+#include <arm_compute/core/Utils.h>
+#include <arm_compute/core/utils/quantization/AsymmHelpers.h>
+
+namespace at::native::acl_utils {
+
+QuantMatmul::QuantMatmul(
+    int64_t weight_dim_0,
+    int64_t weight_dim_1,
+    double weight_scale,
+    int64_t weight_offset,
+    int8_t* weight_ptr,
+    std::optional<float*> bias_ptr,
+    const QuantMatmulCacheKey& cache_key)
+    : key(cache_key) {
+  auto wei_q_tensor_info = arm_compute::TensorInfo(
+      arm_compute::TensorShape(weight_dim_1, weight_dim_0),
+      1,
+      arm_compute::DataType::QASYMM8_SIGNED,
+      arm_compute::QuantizationInfo(weight_scale, -weight_offset, false));
+  wei_q_tensor_info.set_are_values_constant(true);
+  wei_q_tensor_.allocator()->init(wei_q_tensor_info);
+  wei_q_tensor_.allocator()->import_memory(weight_ptr);
+
+  if (bias_ptr.has_value()) {
+    auto bia_tensor_info = arm_compute::TensorInfo(
+        arm_compute::TensorShape(1, weight_dim_1),
+        1,
+        arm_compute::DataType::F32);
+    bia_tensor_ = arm_compute::Tensor();
+
+    bia_tensor_->allocator()->init(bia_tensor_info);
+    bia_tensor_->allocator()->import_memory(bias_ptr.value());
+  }
+  const bool fuse_relu =
+      std::get<static_cast<int>(QuantMatmulCacheKeyIndex::FUSE_RELU)>(key);
+  if (fuse_relu) {
+    relu_info_ =
+        arm_compute::ActivationLayerInfo(arm_compute::ActivationFunction::RELU);
+  }
+}
+
+QuantMatmul::~QuantMatmul() {
+  // this will not free memory, it will just tell ACL that we're no longer
+  // using the pointer
+  wei_q_tensor_.allocator()->free();
+  if (bia_tensor_.has_value()) {
+    bia_tensor_->allocator()->free();
+  }
+}
+
+DynamicQuantMatmul::DynamicQuantMatmul(
+    int64_t weight_dim_0,
+    int64_t weight_dim_1,
+    double weight_scale,
+    int64_t weight_offset,
+    int8_t* weight_ptr,
+    std::optional<float*> bias_ptr,
+    const QuantMatmulCacheKey& cache_key)
+    : QuantMatmul(
+          weight_dim_0,
+          weight_dim_1,
+          weight_scale,
+          weight_offset,
+          weight_ptr,
+          bias_ptr,
+          cache_key) {
+  int64_t m = std::get<static_cast<int>(QuantMatmulCacheKeyIndex::M)>(key);
+
+  auto src_q_tensor_info = arm_compute::TensorInfo(
+      arm_compute::TensorShape(weight_dim_0, m),
+      1,
+      // ACL dyanamically quantized matmuls only support (signed) int8_t
+      arm_compute::DataType::QASYMM8_SIGNED,
+      // TODO: setting the initial offset value to int8_t max instead of zero,
+      // because ACL currently skips MatrixBReduction calculation if the
+      // source offset at configuration time is zero. This is fixed by this
+      // PR: https://review.mlplatform.org/c/ml/ComputeLibrary/+/12820/8 This
+      // will be set to the actual src offset value at runtime.
+      arm_compute::QuantizationInfo(
+          /*scale=*/1.0,
+          /*offset=*/std::numeric_limits<int8_t>::max(),
+          /*is_dynamic=*/true));
+  src_q_tensor_info.set_are_values_constant(false);
+
+  auto src_tensor_info = arm_compute::TensorInfo(
+      arm_compute::TensorShape(weight_dim_0, m), arm_compute::Format::F32);
+  src_tensor_info.set_are_values_constant(false);
+
+  auto dst_tensor_info = arm_compute::TensorInfo(
+      arm_compute::TensorShape(weight_dim_1, m), arm_compute::Format::F32);
+
+  src_q_tensor.allocator()->init(src_q_tensor_info);
+  src_tensor.allocator()->init(src_tensor_info);
+  dst_tensor.allocator()->init(dst_tensor_info);
+
+  src_q_tensor_orig_ =
+      at::empty({m, weight_dim_0}, at::device(c10::kCPU).dtype(c10::kQInt8));
+  // allocate/import memory
+  src_q_tensor.allocator()->import_memory(src_q_tensor_orig_.data_ptr());
+
+  if (relu_info_.has_value()) {
+    relu = arm_compute::NEActivationLayer();
+  }
+}
+
+DynamicQuantMatmul::~DynamicQuantMatmul() {
+  // this will not free memory, it will just tell ACL that we're no longer
+  // using the pointer
+  src_q_tensor.allocator()->free();
+}
+
+arm_compute::Status DynamicQuantMatmul::validate() {
+  if (relu_info_.has_value()) {
+    auto relu_status = arm_compute::NEActivationLayer::validate(
+        dst_tensor.info(), dst_tensor.info(), relu_info_.value());
+    if (relu_status.error_code() != arm_compute::ErrorCode::OK) {
+      return relu_status;
+    }
+  }
+  auto quant_status = arm_compute::NEQuantizationLayer::validate(
+      src_tensor.info(), src_q_tensor.info());
+  if (quant_status.error_code() != arm_compute::ErrorCode::OK) {
+    return quant_status;
+  }
+  return arm_compute::NEGEMMLowpMatrixMultiplyCore::validate(
+      src_q_tensor.info(),
+      wei_q_tensor_.info(),
+      bia_tensor_.has_value() ? bia_tensor_.value().info() : nullptr,
+      dst_tensor.info(),
+      gemm_info_);
+}
+
+void DynamicQuantMatmul::configure() {
+  quant.configure(&src_tensor, &src_q_tensor);
+  gemm.configure(
+      &src_q_tensor,
+      &wei_q_tensor_,
+      bia_tensor_.has_value() ? &bia_tensor_.value() : nullptr,
+      &dst_tensor,
+      gemm_info_);
+  if (relu.has_value()) {
+    relu->configure(&dst_tensor, &dst_tensor, relu_info_.value());
+  }
+}
+
+StaticQuantMatmul::StaticQuantMatmul(
+    int64_t weight_dim_0,
+    int64_t weight_dim_1,
+    double weight_scale,
+    int64_t weight_offset,
+    int8_t* weight_ptr,
+    std::optional<float*> bias_ptr,
+    const QuantMatmulCacheKey& cache_key)
+    : QuantMatmul(
+          weight_dim_0,
+          weight_dim_1,
+          weight_scale,
+          weight_offset,
+          weight_ptr,
+          bias_ptr,
+          cache_key) {
+  const int64_t m =
+      std::get<static_cast<int>(QuantMatmulCacheKeyIndex::M)>(key);
+  const int64_t input_zero_point =
+      std::get<static_cast<int>(QuantMatmulCacheKeyIndex::INPUT_OFFSET)>(key);
+  const double input_scale =
+      std::get<static_cast<int>(QuantMatmulCacheKeyIndex::INPUT_SCALE)>(key);
+  const int64_t output_zero_point =
+      std::get<static_cast<int>(QuantMatmulCacheKeyIndex::OUTPUT_OFFSET)>(key);
+  const double output_scale =
+      std::get<static_cast<int>(QuantMatmulCacheKeyIndex::OUTPUT_SCALE)>(key);
+  const bool signed_input =
+      std::get<static_cast<int>(QuantMatmulCacheKeyIndex::SIGNED_INPUT)>(key);
+
+  const auto input_acl_datatype = signed_input
+      ? arm_compute::DataType::QASYMM8_SIGNED
+      : arm_compute::DataType::QASYMM8;
+
+  auto src_q_tensor_info = arm_compute::TensorInfo(
+      arm_compute::TensorShape(weight_dim_0, m),
+      1,
+      input_acl_datatype,
+      arm_compute::QuantizationInfo(input_scale, -input_zero_point, false));
+  src_q_tensor_info.set_are_values_constant(false);
+  src_q_tensor.allocator()->init(src_q_tensor_info);
+
+  if (bias_ptr.has_value()) {
+    auto bia_q_tensor_info = arm_compute::TensorInfo(
+        arm_compute::TensorShape(1, weight_dim_1),
+        1,
+        arm_compute::DataType::S32,
+        arm_compute::QuantizationInfo(
+            1 / (input_scale * weight_scale), 0, false));
+    bia_q_tensor_ = arm_compute::Tensor();
+    bia_q_tensor_.value().allocator()->init(bia_q_tensor_info);
+
+    float* bias_fp32_buffer = (float*)bia_tensor_.value().buffer();
+    bia_q_tensor_orig_ =
+        at::empty({m, weight_dim_0}, at::device(c10::kCPU).dtype(c10::kQInt32));
+    int32_t* bias_s32_buffer = (int32_t*)bia_q_tensor_orig_.value().data_ptr();
+    const float bias_scale =
+        bia_q_tensor_info.quantization_info().uniform().scale;
+    // Quantize the bias to int32_t. It makes sense to do it here rather in the
+    // prepack phase because dynamically quantized ACL matmuls don't need the
+    // bias in int32_t.
+    at::parallel_for(0, weight_dim_1, 1, [&](int64_t start, int64_t end) {
+      for (int64_t i = start; i < end; ++i) {
+        bias_s32_buffer[i] =
+            int32_t(std::round(bias_fp32_buffer[i] * bias_scale));
+      }
+    });
+    bia_q_tensor_.value().allocator()->import_memory(bias_s32_buffer);
+  }
+  auto dst_q_tensor_info = arm_compute::TensorInfo(
+      arm_compute::TensorShape(weight_dim_1, m),
+      1,
+      input_acl_datatype,
+      arm_compute::QuantizationInfo(output_scale, output_zero_point, false));
+  dst_q_tensor.allocator()->init(dst_q_tensor_info);
+
+  // Setup lowp_gemm output stage
+  int output_multiplier;
+  int output_shift;
+  float multiplier = (input_scale * weight_scale) / output_scale;
+  arm_compute::quantization::calculate_quantized_multiplier_less_than_one(
+      multiplier, &output_multiplier, &output_shift);
+
+  arm_compute::GEMMLowpOutputStageInfo output_stage_info;
+  output_stage_info.type =
+      arm_compute::GEMMLowpOutputStageType::QUANTIZE_DOWN_FIXEDPOINT;
+  output_stage_info.gemmlowp_multiplier = output_multiplier;
+  output_stage_info.gemmlowp_shift = output_shift;
+  output_stage_info.gemmlowp_offset = output_zero_point;
+
+  int32_t min_activation = signed_input ? std::numeric_limits<int8_t>::min()
+                                        : std::numeric_limits<uint8_t>::min();
+  int32_t max_activation = signed_input ? std::numeric_limits<int8_t>::max()
+                                        : std::numeric_limits<uint8_t>::max();
+
+  if (relu_info_.has_value()) {
+    // figure out min, max values for ReLU
+    const arm_compute::UniformQuantizationInfo uqinfo =
+        dst_q_tensor_info.quantization_info().uniform();
+    std::tie(min_activation, max_activation) =
+        arm_compute::get_quantized_activation_min_max(
+            relu_info_.value(), src_q_tensor_info.data_type(), uqinfo);
+    // fuse ReLU with the GEMM
+    gemm_info_.set_activation_info(relu_info_.value());
+  }
+  output_stage_info.gemmlowp_min_bound = min_activation;
+  output_stage_info.gemmlowp_max_bound = max_activation;
+  output_stage_info.output_data_type = dst_q_tensor_info.data_type();
+
+  gemm_info_.set_gemmlowp_output_stage(output_stage_info);
+}
+
+StaticQuantMatmul::~StaticQuantMatmul() {
+  // this will not free memory, it will just tell ACL that we're no longer
+  // using the pointer
+  if (bia_q_tensor_.has_value()) {
+    bia_q_tensor_.value().allocator()->free();
+  }
+}
+
+arm_compute::Status StaticQuantMatmul::validate() {
+  return arm_compute::NEGEMMLowpMatrixMultiplyCore::validate(
+      src_q_tensor.info(),
+      wei_q_tensor_.info(),
+      bia_q_tensor_.has_value() ? bia_q_tensor_.value().info() : nullptr,
+      dst_q_tensor.info(),
+      gemm_info_);
+}
+
+void StaticQuantMatmul::configure() {
+  gemm.configure(
+      &src_q_tensor,
+      &wei_q_tensor_,
+      bia_q_tensor_.has_value() ? &bia_q_tensor_.value() : nullptr,
+      &dst_q_tensor,
+      gemm_info_);
+}
+
+} // namespace at::native::acl_utils
+
+PackedLinearWeightsACL::PackedLinearWeightsACL(
+    std::unique_ptr<ideep::tensor> weight,
+    std::optional<ideep::tensor> bias,
+    at::Tensor orig_weight,
+    std::optional<at::Tensor> orig_bias)
+    : PackedLinearWeightsOnednn(
+          std::move(weight),
+          std::move(bias),
+          std::move(orig_weight),
+          std::move(orig_bias)) {
+  auto w = *(weight_.get());
+  k_ = w.get_dim(0);
+  n_ = w.get_dim(1);
+  weight_zero_point_ = orig_weight_.q_zero_point();
+  weight_scale_ = orig_weight_.q_scale();
+}
+
+#endif // AT_MKLDNN_ACL_ENABLED()

--- a/aten/src/ATen/native/quantized/cpu/ACLUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/ACLUtils.h
@@ -1,0 +1,233 @@
+#pragma once
+
+#include <ATen/Config.h>
+#if AT_MKLDNN_ACL_ENABLED()
+
+#include <ATen/native/quantized/cpu/OnednnUtils.h>
+#include <arm_compute/core/Error.h>
+#include <arm_compute/core/TensorInfo.h>
+#include <arm_compute/function_info/ActivationLayerInfo.h>
+#include <arm_compute/runtime/NEON/functions/NEActivationLayer.h>
+#include <arm_compute/runtime/NEON/functions/NEGEMMLowpMatrixMultiplyCore.h>
+#include <arm_compute/runtime/NEON/functions/NEQuantizationLayer.h>
+#include <arm_compute/runtime/Tensor.h>
+#include <array>
+
+// Utilities for Arm Compute Library (ACL) quantized operations
+// Provides interfaces to leverage ACL's accelerated kernels for statically and
+// dynamically quantized matmuls (i.e. qlinear and qlinear_dynamic) These are
+// utalized through PackedLinearWeightsACL which extends
+// PackedLinearWeightsOnednn Note that PackedLinearWeightsACL extends rather
+// than replaces PackedLinearWeightsOnednn for AArch64 because ACL currently
+// only supports per_tensor weight quantization.
+namespace at::native::acl_utils {
+
+using QuantMatmulCacheKey = std::tuple<
+    int64_t, // M
+    bool, // FUSE_RELU
+    int64_t, // NUM_THREADS
+    double, // INPUT_SCALE
+    int64_t, // INPUT_OFFSET
+    double, // OUTPUT_SCALE
+    int64_t, // OUTPUT_OFFSET
+    bool // SIGNED_INPUT
+    >;
+
+enum class QuantMatmulCacheKeyIndex {
+  M,
+  FUSE_RELU,
+  NUM_THREADS,
+  INPUT_SCALE,
+  INPUT_OFFSET,
+  OUTPUT_SCALE,
+  OUTPUT_OFFSET,
+  SIGNED_INPUT
+};
+
+// Abstract interface to share common stuff between static/dynamic ACL matmuls.
+struct QuantMatmul {
+  arm_compute::NEGEMMLowpMatrixMultiplyCore gemm;
+  // key for use in the cache
+  QuantMatmulCacheKey key;
+
+  QuantMatmul(
+      int64_t weight_dim_0,
+      int64_t weight_dim_1,
+      double weight_scale,
+      int64_t weight_offset,
+      int8_t* weight_ptr,
+      std::optional<float*> bias_ptr,
+      const QuantMatmulCacheKey& cache_key);
+
+  virtual ~QuantMatmul();
+  virtual arm_compute::Status validate() = 0;
+  virtual void configure() = 0;
+
+ protected:
+  arm_compute::Tensor wei_q_tensor_;
+  std::optional<arm_compute::Tensor> bia_tensor_;
+  arm_compute::GEMMInfo gemm_info_;
+  std::optional<arm_compute::ActivationLayerInfo> relu_info_;
+};
+
+struct DynamicQuantMatmul : public QuantMatmul {
+  arm_compute::Tensor src_q_tensor;
+  arm_compute::Tensor src_tensor;
+  arm_compute::Tensor dst_tensor;
+  arm_compute::NEQuantizationLayer quant;
+  // We need a ReLU layer here (unlike static quantization) because the ReLU
+  // cannot be "truly" fused with the GEMM through gemm_info in ACL dynamically
+  // quantized matmuls.
+  std::optional<arm_compute::NEActivationLayer> relu;
+
+  DynamicQuantMatmul(
+      int64_t weight_dim_0,
+      int64_t weight_dim_1,
+      double weight_scale,
+      int64_t weight_offset,
+      int8_t* weight_ptr,
+      std::optional<float*> bias_ptr,
+      const QuantMatmulCacheKey& cache_key);
+
+  ~DynamicQuantMatmul() override;
+
+  arm_compute::Status validate() override;
+  void configure() override;
+
+ private:
+  at::Tensor src_q_tensor_orig_;
+};
+
+struct StaticQuantMatmul : public QuantMatmul {
+  arm_compute::Tensor src_q_tensor;
+  arm_compute::Tensor dst_q_tensor;
+
+  StaticQuantMatmul(
+      int64_t weight_dim_0,
+      int64_t weight_dim_1,
+      double weight_scale,
+      int64_t weight_offset,
+      int8_t* weight_ptr,
+      std::optional<float*> bias_ptr,
+      const QuantMatmulCacheKey& cache_key);
+
+  ~StaticQuantMatmul() override;
+
+  arm_compute::Status validate() override;
+  void configure() override;
+
+ private:
+  std::optional<arm_compute::Tensor> bia_q_tensor_;
+  std::optional<at::Tensor> bia_q_tensor_orig_;
+};
+
+} // namespace at::native::acl_utils
+struct PackedLinearWeightsACL : public PackedLinearWeightsOnednn {
+  using ACLQuantMatmul = at::native::acl_utils::QuantMatmul;
+  using ACLDynamicQuantMatmul = at::native::acl_utils::DynamicQuantMatmul;
+  using ACLStaticQuantMatmul = at::native::acl_utils::StaticQuantMatmul;
+  using ACLQuantMatmulCacheKey = at::native::acl_utils::QuantMatmulCacheKey;
+  using ACLQuantMatmulCacheKeyIndex =
+      at::native::acl_utils::QuantMatmulCacheKeyIndex;
+
+  PackedLinearWeightsACL(
+      std::unique_ptr<ideep::tensor> weight,
+      std::optional<ideep::tensor> bias,
+      at::Tensor orig_weight,
+      std::optional<at::Tensor> orig_bias);
+
+  at::Tensor apply_dynamic(at::Tensor input, bool reduce_range = false)
+      override;
+  at::Tensor apply_dynamic_relu(at::Tensor input, bool reduce_range = false)
+      override;
+
+  at::Tensor apply(
+      at::Tensor input,
+      double output_scale,
+      int64_t output_zero_point) override;
+  at::Tensor apply_relu(
+      at::Tensor input,
+      double output_scale,
+      int64_t output_zero_point) override;
+
+  template <typename ACLQuantMatmulT>
+  std::shared_ptr<ACLQuantMatmulT> get_acl_quant_matmul(
+      const ACLQuantMatmulCacheKey& key) {
+    return std::dynamic_pointer_cast<ACLQuantMatmulT>(
+        fetch_or_create_acl_quant_matmul<ACLQuantMatmulT>(key));
+  }
+
+ private:
+  int64_t k_;
+  int64_t n_;
+  int64_t weight_zero_point_;
+  double weight_scale_;
+
+  // A 2 element (per layer) cache. Given it's not intended to store more than 2
+  // elements, we do not need a fancy implementation. The idea behind it is to
+  // allow for a (configuration free) fast path for autoregressive
+  // transformer-like models which usually involve 2 input tensor shapes; one
+  // for the prefill phase and another for the autoregressive phase
+  std::array<std::shared_ptr<ACLQuantMatmul>, 2> cache_;
+
+  template <typename ACLQuantMatmulT>
+  std::shared_ptr<ACLQuantMatmul> fetch_or_create_acl_quant_matmul(
+      const ACLQuantMatmulCacheKey& key) {
+    // We're only maintaining a 2 element LRU cache
+    // hit first
+    if (cache_[0] != nullptr && cache_[0]->key == key) {
+      return cache_[0];
+    }
+    // hit second
+    if (cache_[1] != nullptr && cache_[1]->key == key) {
+      // Update LRU
+      std::swap(cache_[0], cache_[1]);
+      return cache_[0];
+    }
+    // miss -> replace Least Recently Used - i.e. element at index 1
+    cache_[1] = create_acl_quant_matmul<ACLQuantMatmulT>(key);
+    std::swap(cache_[0], cache_[1]);
+    return cache_[0];
+  }
+
+  template <typename ACLQuantMatmulT>
+  std::shared_ptr<ACLQuantMatmulT> create_acl_quant_matmul(
+      const ACLQuantMatmulCacheKey& key) {
+    std::optional<float*> bias_ptr;
+    if (bias_.has_value()) {
+      bias_ptr = (float*)bias_.value().get_data_handle();
+    }
+    auto acl_gemm = std::make_shared<ACLQuantMatmulT>(
+        k_,
+        n_,
+        weight_scale_,
+        weight_zero_point_,
+        (int8_t*)weight_.get()->get_data_handle(),
+        bias_ptr,
+        key);
+
+    // validate
+    auto status = acl_gemm->validate();
+    if (status.error_code() != arm_compute::ErrorCode::OK) {
+      TORCH_WARN(
+          "Arm Compute Library's Quantized Matmul Validation Failed: " +
+          status.error_description());
+      return nullptr;
+    }
+
+    // configure
+    acl_gemm->configure();
+    return acl_gemm;
+  }
+
+  template <bool ReluFused>
+  at::Tensor apply_dynamic_impl(at::Tensor input, bool reduce_range = false);
+
+  template <bool ReluFused>
+  at::Tensor apply_impl(
+      at::Tensor input,
+      double output_scale,
+      int64_t output_zero_point);
+};
+
+#endif // AT_MKLDNN_ACL_ENABLED()

--- a/aten/src/ATen/native/quantized/cpu/ACLUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/ACLUtils.h
@@ -8,6 +8,7 @@
 #include <arm_compute/core/TensorInfo.h>
 #include <arm_compute/function_info/ActivationLayerInfo.h>
 #include <arm_compute/runtime/NEON/functions/NEActivationLayer.h>
+#include <arm_compute/runtime/NEON/functions/NEArithmeticAddition.h>
 #include <arm_compute/runtime/NEON/functions/NEGEMMLowpMatrixMultiplyCore.h>
 #include <arm_compute/runtime/NEON/functions/NEQuantizationLayer.h>
 #include <arm_compute/runtime/Tensor.h>
@@ -119,6 +120,29 @@ struct StaticQuantMatmul : public QuantMatmul {
  private:
   std::optional<arm_compute::Tensor> bia_q_tensor_;
   std::optional<at::Tensor> bia_q_tensor_orig_;
+};
+
+struct QuantAdd {
+  arm_compute::Tensor qa_tensor;
+  arm_compute::Tensor qb_tensor;
+  arm_compute::Tensor qdst_tensor;
+  arm_compute::NEArithmeticAddition q_add;
+
+  QuantAdd(
+      arm_compute::DataType dtype,
+      const std::vector<int64_t>& input_dims,
+      double qa_scale,
+      int64_t qa_offset,
+      double qb_scale,
+      int64_t qb_offset,
+      double dst_scale,
+      int64_t dst_offset);
+
+  arm_compute::Status validate();
+  void configure();
+
+ private:
+  arm_compute::ConvertPolicy policy{arm_compute::ConvertPolicy::SATURATE};
 };
 
 } // namespace at::native::acl_utils

--- a/aten/src/ATen/native/quantized/cpu/BinaryOps.cpp
+++ b/aten/src/ATen/native/quantized/cpu/BinaryOps.cpp
@@ -5,6 +5,7 @@
 #include <ATen/ExpandUtils.h>
 #include <torch/library.h>
 #include <ATen/quantized/Quantizer.h>
+#include <ATen/native/quantized/cpu/ACLUtils.h>
 #include <ATen/native/quantized/cpu/BinaryOps.h>
 #include <ATen/native/quantized/cpu/QuantizedOps.h>
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
@@ -384,6 +385,67 @@ Tensor xnnp_add(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
 }
 #endif // USE_XNNPACK
 
+#if AT_MKLDNN_ACL_ENABLED()
+Tensor acl_qadd(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
+  TORCH_CHECK(
+      qa.qscheme() == kPerTensorAffine || qa.qscheme() == kPerTensorSymmetric,
+      "Only per tensor quantization is supported in ACL quantized add.");
+
+  Tensor qa_contig = qa.contiguous(qa.suggest_memory_format());
+  Tensor qb_contig = qb.contiguous(qa.suggest_memory_format());
+  auto qa_mem_format = qa_contig.suggest_memory_format();
+  Tensor dst = at::native::empty_affine_quantized(
+      at::infer_size_dimvector(qa_contig.sizes(), qb_contig.sizes()),
+      qa_contig.scalar_type(),
+      std::nullopt /* layout */,
+      kCPU,
+      std::nullopt /* pin_memory */,
+      scale,
+      zero_point,
+      qa_mem_format);
+
+  if (qb_contig.size(0) == 0) {
+    return dst;
+  }
+
+  auto input_dims = qa_contig.sizes().vec();
+  auto acl_dtype = dst.scalar_type() == kQInt8
+      ? arm_compute::DataType::QASYMM8_SIGNED
+      : arm_compute::DataType::QASYMM8;
+  auto acl_add = std::make_shared<acl_utils::QuantAdd>(
+      acl_dtype,
+      input_dims,
+      qa_contig.q_scale(),
+      qa_contig.q_zero_point(),
+      qb_contig.q_scale(),
+      qb_contig.q_zero_point(),
+      dst.q_scale(),
+      dst.q_zero_point());
+
+  auto status = acl_add->validate();
+  TORCH_CHECK(
+      status.error_code() == arm_compute::ErrorCode::OK,
+      "Arm Compute Library's Quantized Matmul Validation Failed: " +
+          status.error_description());
+
+  acl_add->configure();
+
+  acl_add->qa_tensor.allocator()->import_memory(qa_contig.data_ptr());
+  acl_add->qb_tensor.allocator()->import_memory(qb_contig.data_ptr());
+  acl_add->qdst_tensor.allocator()->import_memory(dst.data_ptr());
+
+  acl_add->q_add.run();
+
+  // this will not free memory, it will just tell ACL that we're no longer
+  // using the pointer
+  acl_add->qa_tensor.allocator()->free();
+  acl_add->qb_tensor.allocator()->free();
+  acl_add->qdst_tensor.allocator()->free();
+
+  return dst;
+}
+#endif // AT_MKLDNN_ACL_ENABLED()
+
 template <bool ReLUFused = false>
 Tensor qadd(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
   check_inputs(qa, qb);
@@ -406,6 +468,15 @@ Tensor qadd(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
     }
 #endif // USE_PYTORCH_QNNPACK
   }
+
+#if AT_MKLDNN_ACL_ENABLED()
+  if (!ReLUFused && qa.ndimension() > 0 && qa.sizes() == qb.sizes() &&
+      qa.scalar_type() == qb.scalar_type() &&
+      (qa.scalar_type() == kQInt8 || qa.scalar_type() == kQUInt8)) {
+    return acl_qadd(qa, qb, scale, zero_point);
+  }
+#endif // AT_MKLDNN_ACL_ENABLED()
+
   auto qc = at::_empty_affine_quantized(
       qa.sizes(),
       at::device(kCPU)

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -5,6 +5,7 @@
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/quantized/cpu/QnnpackUtils.h>
 #include <ATen/native/quantized/cpu/OnednnUtils.h>
+#include <ATen/native/quantized/cpu/ACLUtils.h>
 #include <ATen/native/quantized/cpu/QuantUtils.h>
 #include <ATen/native/quantized/library.h>
 #include <ATen/native/quantized/PackedParams.h>
@@ -697,6 +698,135 @@ static at::Tensor linear_dynamic_fp16_with_onednn_weight(
   primitive.execute(ideep::stream::default_stream(), args);
   return dim == 2 ? output : output.reshape(output_size);
 }
+
+#if AT_MKLDNN_ACL_ENABLED()
+
+template <bool ReluFused>
+at::Tensor PackedLinearWeightsACL::apply_dynamic_impl(
+    at::Tensor input,
+    bool reduce_range) {
+  // Dynamic: fp32 * int8 -> fp32
+  using at::Tensor;
+
+  TORCH_CHECK(
+      input.dim() >= 2,
+      "The dimension of input tensor should be larger than or equal to 2");
+  TORCH_CHECK(
+      input.scalar_type() == c10::ScalarType::Float,
+      "qlinear_dynamic (ACL): data type of input should be float.");
+
+  auto input_contig = input.contiguous();
+  const int64_t dim = input.dim();
+  auto input_reshaped =
+      dim == 2 ? input : input.reshape({-1, input.size(input.dim() - 1)});
+  auto input_dims = input_reshaped.sizes().vec();
+
+  int64_t m = input_dims[0];
+  auto key = std::make_tuple(
+      m, /* M */
+      ReluFused, /* FUSE_RELU */
+      static_cast<int64_t>(at::get_num_threads()), /* NUM_THREADS */
+      1, /* INPUT_SCALE */
+      0, /* INPUT_OFFSET */
+      1, /* OUTPUT_SCALE */
+      0, /* OUTPUT_OFFSET */
+      true /* SIGNED_INPUT */
+  );
+  auto acl_gemm =
+      get_acl_quant_matmul<at::native::acl_utils::DynamicQuantMatmul>(key);
+
+  if (acl_gemm) {
+    // Find quantization parameters
+    float x_max = 0, x_min = 0;
+
+#ifdef USE_FBGEMM
+    // Use FBGEMM's FindMinMax if available since it's faster
+    fbgemm::FindMinMax(
+        /*m=*/input_contig.data_ptr<float>(),
+        /*min=*/&x_min,
+        /*max=*/&x_max,
+        /*len=*/input.numel());
+#else
+    if (input_contig.numel() > 0) {
+      auto [t_min, t_max] = at::aminmax(input_contig);
+      x_max = t_max.item<float>();
+      x_min = t_min.item<float>();
+    }
+#endif
+
+    auto q_params = quant_utils::ChooseQuantizationParams(
+        /*min=*/x_min,
+        /*max=*/x_max,
+        /*qmin=*/std::numeric_limits<int8_t>::min(),
+        /*qmax=*/std::numeric_limits<int8_t>::max(),
+        /*preserve_sparsity=*/false,
+        /*force_scale_power_of_two=*/false,
+        /*reduce_range=*/reduce_range);
+
+    acl_gemm->src_tensor.allocator()->import_memory(
+        (float*)input_contig.data_ptr());
+
+    acl_gemm->src_q_tensor.info()->set_quantization_info(
+        arm_compute::QuantizationInfo(
+            q_params.scale, q_params.zero_point, true));
+
+    // quantize src tensor: fp32 -> s8
+    acl_gemm->quant.run();
+
+    // allocation for fp32 out tensor
+    auto output = at::empty({m, n_}, input.options().dtype(at::kFloat));
+    if (output.numel() == 0)
+      return output;
+
+    // We set the offset to "-zero_point" for the GEMM, but to "zero_point" for
+    // the quantization layer This is a known inconsistency in ACL.
+    acl_gemm->src_q_tensor.info()->set_quantization_info(
+        arm_compute::QuantizationInfo(
+            q_params.scale, -q_params.zero_point, true));
+
+    acl_gemm->dst_tensor.allocator()->import_memory((float*)output.data_ptr());
+
+    // s8 src, s8 wei -> f32 dst
+    acl_gemm->gemm.run();
+
+    if (acl_gemm->relu.has_value()) {
+      acl_gemm->relu->run();
+    }
+
+    // this will not free memory, it will just tell ACL that we're no longer
+    // using the pointer
+    acl_gemm->src_tensor.allocator()->free();
+    acl_gemm->dst_tensor.allocator()->free();
+
+    auto out_sizes = input.sizes().vec();
+    out_sizes.back() = n_;
+    if (output.sizes().vec() == out_sizes)
+      return output;
+    return output.reshape(out_sizes);
+  }
+
+  // fallback to oneDNN in the unlikely scinario that ACL's validation fails
+  if (ReluFused) {
+    return PackedLinearWeightsOnednn::apply_dynamic_relu(input, reduce_range);
+  } else {
+    return PackedLinearWeightsOnednn::apply_dynamic(input, reduce_range);
+  }
+}
+
+at::Tensor PackedLinearWeightsACL::apply_dynamic(
+    at::Tensor input,
+    bool reduce_range) {
+  return apply_dynamic_impl</*ReluFused=*/false>(
+      std::move(input), reduce_range);
+}
+
+at::Tensor PackedLinearWeightsACL::apply_dynamic_relu(
+    at::Tensor input,
+    bool reduce_range) {
+  return apply_dynamic_impl</*ReluFused=*/true>(std::move(input), reduce_range);
+}
+
+#endif // #if AT_MKLDNN_ACL_ENABLED()
 #endif // #if AT_MKLDNN_ENABLED()
 
 namespace at::native {

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -1,15 +1,16 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/Context.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/cpp_custom_type_hack.h>
-#include <ATen/Context.h>
+#include <ATen/native/mkldnn/MKLDNNCommon.h>
+#include <ATen/native/quantized/PackedParams.h>
+#include <ATen/native/quantized/cpu/ACLUtils.h>
+#include <ATen/native/quantized/cpu/OnednnUtils.h>
+#include <ATen/native/quantized/cpu/QnnpackUtils.h>
+#include <ATen/native/quantized/cpu/QuantUtils.h>
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
-#include <ATen/native/quantized/cpu/QnnpackUtils.h>
-#include <ATen/native/quantized/cpu/OnednnUtils.h>
-#include <ATen/native/quantized/cpu/QuantUtils.h>
 #include <ATen/native/quantized/library.h>
-#include <ATen/native/quantized/PackedParams.h>
-#include <ATen/native/mkldnn/MKLDNNCommon.h>
 #include <ATen/quantized/Quantizer.h>
 #include <torch/custom_class.h>
 #include <torch/library.h>
@@ -279,12 +280,15 @@ c10::intrusive_ptr<LinearPackedParamsBase> PackedLinearWeightsOnednn::prepack(
     packed_bias.init(bias_desc, b.data_ptr());
     onednn_bias = std::optional<ideep::tensor>(packed_bias);
   }
-  auto ret_ptr = c10::make_intrusive<PackedLinearWeightsOnednn>(
-      PackedLinearWeightsOnednn{
-        std::move(weight_ptr),
-        onednn_bias,
-        weight,
-        bias});
+#if AT_MKLDNN_ACL_ENABLED()
+  if (qtype == c10::kPerTensorAffine) {
+    return c10::make_intrusive<PackedLinearWeightsACL>(PackedLinearWeightsACL{
+        std::move(weight_ptr), onednn_bias, weight, bias});
+  }
+#endif // #if AT_MKLDNN_ACL_ENABLED()
+  auto ret_ptr =
+      c10::make_intrusive<PackedLinearWeightsOnednn>(PackedLinearWeightsOnednn{
+          std::move(weight_ptr), onednn_bias, weight, bias});
   return ret_ptr;
 }
 


### PR DESCRIPTION
This is a backport for the PRs enabling a fast path for eager mode static/dynamic quantized matmuls and quantized add for AArch64 through Arm Compute Library (ACL) directly - https://github.com/pytorch/pytorch/pull/148585, https://github.com/pytorch/pytorch/pull/148653.

PR https://github.com/pytorch/pytorch/pull/148584 is the base for all of the above and made its way to `release/2.7`, but we need the above two PRs to capitalize on it.

It would mean a lot for us to have these changes in v2.7. They directly enable business partners to adopt PyTorch on Arm as they accelerate MLPerf's recommender model by ~ **14x** 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @malfet @snadampal @milpuz01