### PR TITLE
[MPSInductor] Move threadfence at the right location

### DIFF
--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -9,7 +9,7 @@ namespace metal {
 template <typename T>
 opmath_t<T> threadgroup_sum(threadgroup T* data, unsigned size) {
   // TODO: This should be moved to the callee
-  ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);  
+  ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
   opmath_t<T> rc = data[0];
   // TODO: Use `simd_shuffle_down`
   for (unsigned idx = 1; idx < size; ++idx) {

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -8,9 +8,9 @@ namespace metal {
 
 template <typename T>
 opmath_t<T> threadgroup_sum(threadgroup T* data, unsigned size) {
-  opmath_t<T> rc = data[0];
   // TODO: This should be moved to the callee
-  ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
+  ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);  
+  opmath_t<T> rc = data[0];
   // TODO: Use `simd_shuffle_down`
   for (unsigned idx = 1; idx < size; ++idx) {
     rc += data[idx];
@@ -20,9 +20,9 @@ opmath_t<T> threadgroup_sum(threadgroup T* data, unsigned size) {
 
 template <typename T>
 opmath_t<T> threadgroup_prod(threadgroup T* data, unsigned size) {
-  opmath_t<T> rc = data[0];
   // TODO: This should be moved to the callee
   ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
+  opmath_t<T> rc = data[0];
   for (unsigned idx = 1; idx < size; ++idx) {
     rc *= data[idx];
   }


### PR DESCRIPTION
Not sure how it worked in the past, but fence should be before first read from the shared memory, not after it.
This bug was exposed by https://github.com/pytorch/pytorch/pull/148969 which removed unnecessary barrier before calling `threadgroup_reduce` functions
Test plan:
```
% python3 generate.py --checkpoint_path checkpoints/stories15M/model.pth --prompt "Once upon a time" --device mps --compile
```
Before that it produced gibberish, now it works fine