### PR TITLE
Fix format string in ck_gemm_template.h for int64_t variables

### DIFF
--- a/aten/src/ATen/native/hip/ck_gemm_template.h
+++ b/aten/src/ATen/native/hip/ck_gemm_template.h
@@ -382,7 +382,7 @@ void gemm_impl_wmma(CUDABLAS_GEMM_ARGTYPES(Dtype)) {
 
  if(!gemm.IsSupportedArgument(argument))
  {
-        printf("error shape = %d %d %d TRANSA=%d TRANSB=%d \n",
+        printf("error shape = %ld %ld %ld TRANSA=%d TRANSB=%d \n",
                         n, m, k,TRANSA, TRANSB);
 
         throw std::runtime_error(


### PR DESCRIPTION
Summary:
Change %d to %ld in printf format specifier to correctly handle int64_t variables n, m, k.
This fixes compilation errors in HIP builds where the format string didn't match the argument type.

forward fix for D71412006

```
In file included from fbcode/caffe2/aten/src/ATen/native/hip/ck_gemm_bfloat16.hip:4:
fbcode/caffe2/aten/src/ATen/native/hip/ck_gemm_template.h:386:28: error: format specifies type 'int' but the argument has type 'int64_t' (aka 'long') [-Werror,-Wformat]
  385 |         printf("error shape = %d %d %d TRANSA=%d TRANSB=%d \n",
      |                                  ~~
      |                                  %ld
  386 |                         n, m, k,TRANSA, TRANSB);
      |                            ^
fbcode/caffe2/aten/src/ATen/native/hip/ck_gemm_template.h:386:31: error: format specifies type 'int' but the argument has type 'int64_t' (aka 'long') [-Werror,-Wformat]
  385 |         printf("error shape = %d %d %d TRANSA=%d TRANSB=%d \n",
      |                                     ~~
      |                                     %ld
  386 |                         n, m, k,TRANSA, TRANSB);
      |                               ^
fbcode/caffe2/aten/src/ATen/native/hip/ck_gemm_template.h:386:25: error: format specifies type 'int' but the argument has type 'int64_t' (aka 'long') [-Werror,-Wformat]
  385 |         printf("error shape = %d %d %d TRANSA=%d TRANSB=%d \n",
      |                               ~~
      |                               %ld
  386 |                         n, m, k,TRANSA, TRANSB);
      |                         ^
```

Test Plan:
```
buck2 build --flagfile fbcode//mode/opt-amd-gpu fbcode//torchrec/sparse/tests:test_jagged_tensor_gpu
```

Differential Revision: D71418611
