### PR TITLE
[ROCm] skip test_RNN_dropout_state

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4374,6 +4374,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                 # Check that backward does not cause a hard error
                 outs[0].sum().backward()
 
+    @skipIfRocm("fails because ROCm doesn't support 'dropout' in RNN (WIP to enable dropout https://github.com/pytorch/pytorch/pull/144572)")
     @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
     def test_RNN_dropout_state(self):
         for p in (0, 0.1234):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4374,8 +4374,9 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                 # Check that backward does not cause a hard error
                 outs[0].sum().backward()
 
-    @skipIfRocm("fails because ROCm doesn't support 'dropout' in RNN (WIP to enable dropout https://github.com/pytorch/pytorch/pull/144572)")
     @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
+    @skipIfRocm(msg="ROCm doesn't support 'dropout' for RNN "
+                "(WIP to enable dropout https://github.com/pytorch/pytorch/pull/144572)")
     def test_RNN_dropout_state(self):
         for p in (0, 0.1234):
             for train in (True, False):


### PR DESCRIPTION
PR to skip test_nn.py::TestNN::test_RNN_dropout_state
Currently ROCm doesn't support dropout value for RNN 

PR to enable RNN dropout on ROCm still in review and blocked pytorch/pytorch#144572

Fixes: https://github.com/pytorch/pytorch/issues/68849

cc: @jithunnair-amd  @pruthvistony 



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd