### PR TITLE
[xpu] set aot device flags in cpp_extension

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -295,7 +295,7 @@ def _get_sycl_arch_list():
         return []
     else:
         return ['-fsycl-targets=spir64_gen,spir64',
-                f'-Xs "-device {\',\'.join(arch_list)}"']
+                f'-Xs "-device {",".join(arch_list)}"']
 
 _SYCL_DLINK_FLAGS = [
     *_COMMON_SYCL_FLAGS,

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -291,6 +291,9 @@ def _get_sycl_arch_list():
     arch_list = [x for x in arch_list if not x.startswith('dg2')]
     return ','.join(arch_list)
 
+# If arch list returned by _get_sycl_arch_list() is empty, then sycl kernels will be compiled
+# for default spir64 target and avoid device specific compilations entirely. Further, kernels
+# will be JIT compiled at runtime.
 _COMMON_SYCL_FLAGS = [
     '-fsycl',
     '-fsycl-targets=spir64_gen,spir64' if _get_sycl_arch_list() != '' else '',

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -285,7 +285,7 @@ _COMMON_SYCL_FLAGS = [
     '-fsycl',
 ]
 
-def _get_sycl_arch_flag():
+def _get_sycl_arch_flags():
     arch_list = torch.xpu.get_arch_list()
     # Dropping dg2* archs since they lack hardware support for fp64 and require
     # special consideration from the user. If needed these platforms can
@@ -295,6 +295,7 @@ def _get_sycl_arch_flag():
         return []
     else:
         return ['-fsycl-targets=spir64_gen,spir64',
+                '-flink-huge-device-code',
                 f'-Xs "-device {",".join(arch_list)}"']
 
 _SYCL_DLINK_FLAGS = [
@@ -302,7 +303,7 @@ _SYCL_DLINK_FLAGS = [
     '-fsycl-link',
     '--offload-compress',
 ]
-_SYCL_DLINK_FLAGS += _get_sycl_arch_flag()
+_SYCL_DLINK_FLAGS += _get_sycl_arch_flags()
 
 JIT_EXTENSION_VERSIONER = ExtensionVersioner()
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -285,7 +285,7 @@ _COMMON_SYCL_FLAGS = [
     '-fsycl',
 ]
 
-def _get_sycl_arch_list():
+def _get_sycl_arch_flag():
     arch_list = torch.xpu.get_arch_list()
     # Dropping dg2* archs since they lack hardware support for fp64 and require
     # special consideration from the user. If needed these platforms can
@@ -302,7 +302,7 @@ _SYCL_DLINK_FLAGS = [
     '-fsycl-link',
     '--offload-compress',
 ]
-_SYCL_DLINK_FLAGS += _get_sycl_arch_list()
+_SYCL_DLINK_FLAGS += _get_sycl_arch_flag()
 
 JIT_EXTENSION_VERSIONER = ExtensionVersioner()
 


### PR DESCRIPTION
If PyTorch is compiled with only AOT text strings starting with "dg2", the `_get_sycl_arch_list()` function will pass an empty string to `-device` argument of `ocloc` and then cause a compilation crash.