### PR TITLE
[Intel GPU][PT2E] bugfix: use zero-point to decide conv src zp mask

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/QConv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QConv.cpp
@@ -135,7 +135,7 @@ at::Tensor quantized_convolution(
     mask_weight = (2 ^ 0) | (2 ^ 1); // 2^0 (group) | 2^1 (output channel)
   dnnl::primitive_attr pattr;
 
-  bool src_need_zp = (act_scale != 0);
+  bool src_need_zp = (act_zero_point != 0);
   bool dst_need_zp = (output_zero_point != 0);
 
   // create usr_md for tensors, and md for conv primitive


### PR DESCRIPTION
# Motivation
The PR fix a bug that wrongly decides the zero-point mask setting. Specifically, it deems zero-point is always not zeros due to scale is used for judgement. Fortunately, the bug only affects the performance. The accuracy is not affected.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149473



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10