### PR TITLE
Skip test if torchvision is not available

### DIFF
--- a/test/inductor/test_benchmark_fusion.py
+++ b/test/inductor/test_benchmark_fusion.py
@@ -58,7 +58,10 @@ class BenchmarkFusionTestTemplate:
 
     @slowTest
     def test_resnet18(self):
-        import torchvision
+        try:
+            import torchvision
+        except ImportError:
+            self.skipTest("TorchVision not available")
 
         model = torchvision.models.resnet18()
         model.eval()


### PR DESCRIPTION
The test unconditionally imports torchvision and fails if the isn't installed.
Skip it in this case.




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov