### PR TITLE
fix ValueError issue

### DIFF
--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -687,7 +687,7 @@ class Tracer(TracerBase):
                 args.append(proxy_placeholder("*" + next(names_iter)))
             if co.co_flags & inspect.CO_VARKEYWORDS:
                 args.append(proxy_placeholder("**" + next(names_iter)))
-            root_fn = _patch_function(root_fn, len(args))
+            root_fn = _patch_function(fn_for_analysis, len(args))
 
         flat_args, in_spec = pytree.tree_flatten(tuple(args))
         if not all(child.is_leaf() for child in in_spec.children_specs):


### PR DESCRIPTION
	fix following issue:
	ValueError: code: co_varnames is too small

Fixes #149497 

In `symbolic_trace`, It will crash with following stack.
```shell
Traceback (most recent call last):
  File "/home/hmsjwzb/work/models/QWEN/./qwen5.py", line 55, in <module>
    traced_model = torch.fx.symbolic_trace(model)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hmsjwzb/work/models/QWEN/qwen/lib/python3.11/site-packages/torch/fx/_symbolic_trace.py", line 1314, in symbolic_trace
    graph = tracer.trace(root, concrete_args)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hmsjwzb/work/models/QWEN/qwen/lib/python3.11/site-packages/torch/fx/_symbolic_trace.py", line 788, in trace
    fn, args = self.create_args_for_root(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hmsjwzb/work/models/QWEN/qwen/lib/python3.11/site-packages/torch/fx/_symbolic_trace.py", line 679, in create_args_for_root
    root_fn = _patch_function(root_fn, len(args))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hmsjwzb/work/models/QWEN/qwen/lib/python3.11/site-packages/torch/fx/_symbolic_trace.py", line 184, in _patch_function
    new_code = CodeType(*co_args)  # type: ignore[arg-type]
               ^^^^^^^^^^^^^^^^^^
ValueError: code: co_varnames is too small
```
Here is the python script caused this crash.
```python
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer
from torch_mlir import fx

model_name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
tokenizer = AutoTokenizer.from_pretrained(model_name)
model = AutoModelForCausalLM.from_pretrained(model_name)

prompt = "What are the benefits of using AI in healthcare?"
input_ids = tokenizer.encode(prompt, return_tensors="pt")

model.eval()
traced_model = torch.fx.symbolic_trace(model)
m = fx.export_and_import(traced_model, (input_ids,), enable_ir_printing=True,
                        enable_graph_printing=True)

with open("qwen1.5b_s.mlir", "w") as f:
    f.write(str(m))
```

I think it is a mistake.

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv