### PR TITLE
[Inductor] Adjust boundary checking of dimensions using YBLOCK

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -12722,7 +12722,11 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.assertTrue(t.dtype is torch.float8_e4m3fn)
 
     @largeTensorTest("1GB", inductor=True)
-    def test_large_grid(self):
+    @parametrize(
+        "use_block_ptr",
+        [subtest(False), subtest(True, decorators=[skip_if_not_triton])],
+    )
+    def test_large_grid(self, use_block_ptr):
         # https://github.com/pytorch/pytorch/issues/123210
         def fn(primals_5):
             view = torch.ops.aten.reshape.default(primals_5, [-1, 2, 4])
@@ -12735,9 +12739,11 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
         s0 = 16777472
         s1 = 8
-        compiled_fn = torch.compile(fn)
-        actual = compiled_fn(torch.ones(s0, s1, device=self.device))
-        self.assertTrue((actual == 1).all())
+
+        with config.patch({"triton.use_block_ptr": use_block_ptr}):
+            compiled_fn = torch.compile(fn)
+            actual = compiled_fn(torch.ones(s0, s1, device=self.device))
+            self.assertTrue((actual == 1).all())
 
     @skip_if_gpu_halide
     def test_pattern_matcher_multi_user(self):

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1153,7 +1153,7 @@ class CommonTemplate:
         [
             # No boundary check in all dimensions
             [True, False, True],
-            # no xdim boundary check, ydim is checked since > max_ygrid
+            # No xdim boundary check, ydim is checked since > max_ygrid
             # z dim can be used since its not included
             [True, True, False],
             # Boundary check in all dimensions
@@ -1182,6 +1182,7 @@ class CommonTemplate:
         if ynumel_exceed_ygrid_size:
             shape.y = math.ceil(get_max_y_grid()) * shape.y + shape.y
 
+        # Use fixed block sizes to avoid having to generate very large input tensors
         class FixedBlockSizeChoices(InductorChoices):
             def triton_kernel_kwargs(self, kernel_cls, features, groups, kernel_kwargs):
                 block_sizes = {

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1189,12 +1189,12 @@ class CommonTemplate:
             if ynumel_exceed_ygrid_size:
                 # Only the y dimension should be boundary checked
                 # Loading a
-                self.assertTrue("boundary_check=[1]" in code)
+                self.assertIn("boundary_check=[1]", code)
                 # Loading b
                 self.assertTrue("boundary_check=[0]" in code)
             else:
                 # No boundary checking
-                self.assertTrue("boundary_check" not in code)
+                self.assertNotIn("boundary_check", code)
         else:
             # Loading a
             self.assertTrue("boundary_check=[0, 1]" in code)

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 # ruff: noqa: F841
 import contextlib
+import dataclasses
 import importlib
 import math
 import unittest
@@ -9,10 +10,13 @@ from typing import Any, Callable, Optional, Union
 import torch
 import torch.utils._pytree as pytree
 from torch._inductor import config
+from torch._inductor.choices import InductorChoices
+from torch._inductor.codegen.triton import FixedTritonConfig
 from torch._inductor.runtime.hints import TRITON_MAX_BLOCK
-from torch._inductor.runtime.runtime_utils import is_power_of_2
+from torch._inductor.runtime.runtime_utils import get_max_y_grid, is_power_of_2
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
+from torch._inductor.virtualized import V
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -1145,61 +1149,85 @@ class CommonTemplate:
     @config.patch("triton.prefer_nd_tiling", True)
     @config.patch("triton.max_tiles", 3)
     @parametrize(
-        "block_multiple, ynumel_exceed_ygrid_size",
+        "block_multiple, ynumel_exceed_ygrid_size, include_z",
         [
-            # no xdim boundary check, ydim is checked
-            [True, True],
-            # no boundary check in both dimensions
-            [True, False],
-            # if numel not a block multiple, must boundary check
+            # No boundary check in all dimensions
+            [True, False, True],
+            # no xdim boundary check, ydim is checked since > max_ygrid
+            # z dim can be used since its not included
+            [True, True, False],
+            # Boundary check in all dimensions
             # skip triton_cpu very slow test > 1000s
-            subtest([False, False], decorators=[test_torchinductor.skip_if_triton_cpu])
-            # TODO: test zdim too
+            subtest(
+                [False, False, True], decorators=[test_torchinductor.skip_if_triton_cpu]
+            ),
         ],
     )
-    def test_boundary_check(self, block_multiple, ynumel_exceed_ygrid_size):
-        from torch._inductor.runtime.hints import TRITON_MAX_BLOCK
-        from torch._inductor.runtime.runtime_utils import get_max_y_grid
+    def test_boundary_check(self, block_multiple, ynumel_exceed_ygrid_size, include_z):
+        @dataclasses.dataclass
+        class InputShape:
+            x: int
+            y: int
+            z: Optional[int] = None
 
-        shape = [TRITON_MAX_BLOCK["Y"], TRITON_MAX_BLOCK["X"]]
+            def to_list(self):
+                out = [self.y, self.x]
+                if self.z is not None:
+                    out.insert(0, self.z)
+                return out
 
-        if not block_multiple:
-            shape = [s + 1 for s in shape]
-
+        BLOCK_SIZE = 8
+        DIM_SIZE = BLOCK_SIZE if block_multiple else BLOCK_SIZE + 1
+        shape = InputShape(DIM_SIZE, DIM_SIZE, DIM_SIZE if include_z else None)
         if ynumel_exceed_ygrid_size:
-            shape[0] = shape[0] * (math.ceil(get_max_y_grid() / shape[0])) + shape[0]
+            shape.y = math.ceil(get_max_y_grid()) * shape.y + shape.y
 
-        a = torch.zeros(shape, device=self.device)
-        b = torch.zeros((shape[0], 1), device=self.device)
+        class FixedBlockSizeChoices(InductorChoices):
+            def triton_kernel_kwargs(self, kernel_cls, features, groups, kernel_kwargs):
+                block_sizes = {
+                    f"{prefix.upper()}BLOCK": BLOCK_SIZE
+                    for prefix, size in dataclasses.asdict(shape).items()
+                    if size is not None
+                }
+                kernel_kwargs["fixed_config"] = FixedTritonConfig(block_sizes)
+                return kernel_kwargs
+
+        a = self._discontiguous_tensor(shape.to_list(), device=self.device)
+        b_shape = shape.to_list()
+        b_shape[-1] = 1
+        b = self._discontiguous_tensor(b_shape, device=self.device)
 
         def func(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
             return a + b
 
-        result, code = run_and_compare(
-            self,
-            func,
-            a,
-            b,
-            expected_num_triton_kernels=1,
-            expected_num_block_pointers=3,
-        )
+        with V.set_choices_handler(FixedBlockSizeChoices()):
+            result, code = run_and_compare(
+                self,
+                func,
+                a,
+                b,
+                expected_num_triton_kernels=1,
+                expected_num_block_pointers=3,
+            )
 
-        code = code[0]
-        if block_multiple:
-            if ynumel_exceed_ygrid_size:
-                # Only the y dimension should be boundary checked
-                # Loading a
-                self.assertIn("boundary_check=[1]", code)
-                # Loading b
-                self.assertTrue("boundary_check=[0]" in code)
+            code = code[0]
+            if block_multiple:
+                if ynumel_exceed_ygrid_size:
+                    self.assertIn(
+                        "yoffset = (tl.program_id(1) + tl.program_id(2) * tl.num_programs(1)) * YBLOCK",
+                        code,
+                    )
+                    # Only the y dimension should be boundary checked
+                    # a, b, and output
+                    self.assertEqual(code.count("boundary_check=[0]"), 3)
+                else:
+                    # No boundary checking
+                    self.assertNotIn("boundary_check", code)
             else:
-                # No boundary checking
-                self.assertNotIn("boundary_check", code)
-        else:
-            # Loading a
-            self.assertTrue("boundary_check=[0, 1]" in code)
-            # Loading b
-            self.assertTrue("boundary_check=[0]" in code)
+                # Loading a
+                self.assertTrue("boundary_check=[0, 1, 2]" in code)
+                # Loading b
+                self.assertTrue("boundary_check=[0, 1]" in code)
 
 
 @unittest.skipIf(not TRITON_HAS_CPU, "requires triton CPU backend")

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -448,7 +448,7 @@ class BlockPtrOptions:
         # Also see Note: Constant mask optimisation
         # if ynumel / YBLOCK > max_ygrid, then the z dimension is used to handle
         # the remaining programs that cannot fit into the y dimension. This means
-        # its possible that more than the required number of programs are launched,
+        # it's possible that more than the required number of programs are launched,
         # possibly leading to out-of-bounds accesses. So even if ynumel divides YBLOCK,
         # boundary checking is required in the dimensions that are based on YBLOCK
         # e.g. for [YBLOCK // 16, YBLOCK, XBLOCK] dimensions 0 and 1 need boundary

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3960,6 +3960,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         if tree.is_reduction and self.cooperative_reduction:
             max_block = max_block * self.max_rsplit()
 
+        # [Note: Constant mask optimisation]
         # Optional optimization: if block divides numel exactly, we will
         # never need to do a masked load to handle stragglers at the end.
         # If this tree is for the y dimension, we should only use a constant


### PR DESCRIPTION
Apply the same logic introduced in https://github.com/pytorch/pytorch/pull/139751 to triton kernels using block ptrs. Here, if ynumel / YBLOCK > max_y_grids, dimensions dependent on YBLOCK need to be boundary checked, even if the block shape in such dimensions is a multiple of an expression in YBLOCK. This is because ynumel / YBLOCK % get_max_y_grids() may not be zero, so redundant programs will be launched that will attempt to read / write OOB.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov