### PR TITLE
[codemod] Fix clang-tidy command line doc comments

### DIFF
--- a/torch/csrc/jit/runtime/static/.clang-tidy
+++ b/torch/csrc/jit/runtime/static/.clang-tidy
@@ -1,7 +1,7 @@
 # NOTE there must be no spaces before the '-', so put the comma after.
 # When making changes, be sure to verify the output of the following command to ensure
 # the desired checks are enabled (run from the directory containing a .clang-tidy file):
-# ~/fbsource/tools/lint/clangtidy/clang-tidy-platform010 -list-checks
+# ~/fbsource/tools/lint/clangtidy/clang-tidy-platform010-clang-17 -list-checks
 # NOTE: Please don't disable inheritance from the parent to make sure that common checks get propagated.
 
 # Remove noisy checks which are not necessary.


### PR DESCRIPTION
Summary:
Fixes the comments to match the latest updates to the checked-in tools.

Search/replace applied in this order:
* `# /fbsource/tools/lint/clangtidy/clang-tidy-platform010 -list-checks` -> `# ~/fbsource/tools/lint/clangtidy/clang-tidy-platform010-clang-17 -list-checks`
* `# ~/fbsource/tools/lint/clangtidy/clang-tidy-platform010 -list-checks` -> `# ~/fbsource/tools/lint/clangtidy/clang-tidy-platform010-clang-17 -list-checks`
* `fbsource/tools/lint/clangtidy/clang-tidy-platform010 -list-checks` -> `fbsource/tools/lint/clangtidy/clang-tidy-platform010-clang-17 -list-checks`

Test Plan: CI

Reviewed By: johnkearney

Differential Revision: D71431516




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel