### PR TITLE
Fix dynamic shapes repordering bug

### DIFF
--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1218,7 +1218,7 @@ def _get_range_constraints(
 
     # This is because we trace based on the kewargs passed in from user
     # not based on the signature. I feel it would be better to just enforce
-    # one ordering at the start of tracing to avoid confusions, but that is 
+    # one ordering at the start of tracing to avoid confusions, but that is
     # bigger refactor, so do this to unblock for now.
     combined_args_traced_order = {}
     for arg in combined_args:

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1220,18 +1220,21 @@ def _get_range_constraints(
     # not based on the signature. I feel it would be better to just enforce
     # one ordering at the start of tracing to avoid confusions, but that is
     # bigger refactor, so do this to unblock for now.
-    combined_args_traced_order = {}
-    for arg in combined_args:
-        if arg not in kwargs:
-            combined_args_traced_order[arg] = combined_args[arg]
+    if not _is_torch_jit_trace:
+        combined_args_traced_order = {}
+        for arg in combined_args:
+            if arg not in kwargs:
+                combined_args_traced_order[arg] = combined_args[arg]
 
-    for key in kwargs:
-        combined_args_traced_order[key] = kwargs[key]
+        for key in kwargs:
+            combined_args_traced_order[key] = kwargs[key]
+
+        combined_args = combined_args_traced_order
 
     range_constraints = make_constraints(
         fake_mode,
         gm,
-        combined_args_traced_order,
+        combined_args,
         dynamic_shapes,
         num_lifted,
     )

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1194,7 +1194,12 @@ def _get_module_call_graph(
 
 
 def _get_range_constraints(
-    export_artifact: ExportArtifact, combined_args: dict[str, Any], dynamic_shapes
+    mod: torch.nn.Module,
+    export_artifact: ExportArtifact,
+    args,
+    kwargs,
+    dynamic_shapes,
+    _is_torch_jit_trace=False,
 ):
     gm: torch.fx.GraphModule = export_artifact.aten.gm
     export_graph_signature: ExportGraphSignature = export_artifact.aten.sig
@@ -1207,10 +1212,26 @@ def _get_range_constraints(
         ),
         len(export_graph_signature.input_specs),
     )
+    combined_args = _combine_args(
+        mod, args, kwargs, _is_torch_jit_trace=_is_torch_jit_trace
+    )
+
+    # This is because we trace based on the kewargs passed in from user
+    # not based on the signature. I feel it would be better to just enforce
+    # one ordering at the start of tracing to avoid confusions, but that is 
+    # bigger refactor, so do this to unblock for now.
+    combined_args_traced_order = {}
+    for arg in combined_args:
+        if arg not in kwargs:
+            combined_args_traced_order[arg] = combined_args[arg]
+
+    for key in kwargs:
+        combined_args_traced_order[key] = kwargs[key]
+
     range_constraints = make_constraints(
         fake_mode,
         gm,
-        combined_args,
+        combined_args_traced_order,
         dynamic_shapes,
         num_lifted,
     )
@@ -1994,8 +2015,10 @@ def _export_for_training(
     # Note: _get_range_constraints depends on "inline_constraints" to be set.
     export_artifact.aten.gm.meta["inline_constraints"] = inline_constraints
     range_constraints = _get_range_constraints(
+        mod,
         export_artifact,
-        _combine_args(mod, args, kwargs, _is_torch_jit_trace=False),
+        args,
+        kwargs,
         dynamic_shapes,
     )
     # The returned the gm is in-place modified
@@ -2155,9 +2178,12 @@ def _export(
     # Note: this step must be before _get_range_constraints.
     export_artifact.aten.gm.meta["inline_constraints"] = inline_constraints
     range_constraints = _get_range_constraints(
+        mod,
         export_artifact,
-        _combine_args(mod, args, kwargs, _is_torch_jit_trace=_is_torch_jit_trace),
+        args,
+        kwargs,
         dynamic_shapes,
+        _is_torch_jit_trace=_is_torch_jit_trace,
     )
     gm, module_call_graph = _get_module_call_graph(
         export_artifact,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149528


WHen we create constraints, we look at the ordering of kwargs according to model signature. But when we trace, we use the ordering that is created based on how user passes in their kwargs. As a result, constraints and dynamic shapes end up having a different order causing issues when they have different dynamic tensor specs. 

Differential Revision: [D71478578](https://our.internmc.facebook.com/intern/diff/D71478578)