### PR TITLE
[CI] Fix log artifact not containing test logs?

### DIFF
--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -53,7 +53,7 @@ runs:
         if [ -f 'usage_log.txt' ]; then
             zip "logs-${FILE_SUFFIX}.zip" 'usage_log.txt'
         fi
-        if find "test/test-reports" -name "*.log" 2>/dev/null | grep -q .; then
+        if find "test/test-reports" -name "*.log" 2>/dev/null | stdbuf -o0 grep -q .; then
             zip -r "logs-${FILE_SUFFIX}.zip" test/test-reports -i '*.log'
         fi
 


### PR DESCRIPTION
Sometimes I would find a log artifact that only has usage_logs.txt in it, even though there are other logs created by tests.  I think this is somehow caused by output buffering with find.  I don't understand how, but at the very least, I can see that all the jobs on this PR have the logs from the test runs
