### PR TITLE
Add triton as dependency to CUDA aarch64 build

### DIFF
--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -75,7 +75,7 @@ TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_version.txt)
 # Here PYTORCH_EXTRA_INSTALL_REQUIREMENTS is already set for the all the wheel builds hence append TRITON_CONSTRAINT
 TRITON_CONSTRAINT="platform_system == 'Linux' and platform_machine == 'x86_64'"
 
-# CUDA 12.8 builds have triton for Linux and Linux aarch64 binaries. 
+# CUDA 12.8 builds have triton for Linux and Linux aarch64 binaries.
 if [[ "$DESIRED_CUDA" == cu128 ]]; then
   TRITON_CONSTRAINT="platform_system == 'Linux'"
 fi

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -75,7 +75,7 @@ TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_version.txt)
 # Here PYTORCH_EXTRA_INSTALL_REQUIREMENTS is already set for the all the wheel builds hence append TRITON_CONSTRAINT
 TRITON_CONSTRAINT="platform_system == 'Linux' and platform_machine == 'x86_64'"
 
-# This is Linux aarch64 CUDA build. We do have triton build for it. Hence add triton constrain
+# CUDA 12.8 builds have triton for Linux and Linux aarch64 binaries. 
 if [[ "$DESIRED_CUDA" == cu128 ]]; then
   TRITON_CONSTRAINT="platform_system == 'Linux'"
 fi

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -74,6 +74,12 @@ TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_version.txt)
 
 # Here PYTORCH_EXTRA_INSTALL_REQUIREMENTS is already set for the all the wheel builds hence append TRITON_CONSTRAINT
 TRITON_CONSTRAINT="platform_system == 'Linux' and platform_machine == 'x86_64'"
+
+# This is Linux aarch64 CUDA build. We do have triton build for it. Hence add triton constrain
+if [[ "$GPU_ARCH_TYPE" =~ .*aarch64.* && "$DESIRED_CUDA" != cpu ]]; then
+  TRITON_CONSTRAINT="platform_system == 'Linux'"
+fi
+
 if [[ "$PACKAGE_TYPE" =~ .*wheel.* &&  -n "${PYTORCH_EXTRA_INSTALL_REQUIREMENTS:-}" && ! "$PYTORCH_BUILD_VERSION" =~ .*xpu.* ]]; then
   TRITON_REQUIREMENT="triton==${TRITON_VERSION}; ${TRITON_CONSTRAINT}"
   if [[ -n "$PYTORCH_BUILD_VERSION" && "$PYTORCH_BUILD_VERSION" =~ .*dev.* ]]; then

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -76,7 +76,7 @@ TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_version.txt)
 TRITON_CONSTRAINT="platform_system == 'Linux' and platform_machine == 'x86_64'"
 
 # This is Linux aarch64 CUDA build. We do have triton build for it. Hence add triton constrain
-if [[ "$GPU_ARCH_TYPE" =~ .*aarch64.* && "$DESIRED_CUDA" != cpu ]]; then
+if [[ "$DESIRED_CUDA" == cu128 ]]; then
   TRITON_CONSTRAINT="platform_system == 'Linux'"
 fi
 


### PR DESCRIPTION
Aarch64 Triton build was added by: https://github.com/pytorch/pytorch/pull/148705
Hence add proper contrain to CUDA 12.8 Aarch64 build

Please note we want to still use:
```platform_system == 'Linux' and platform_machine == 'x86_64'```
For all other builds.

Since these are prototype binaries only used by cuda 12.8 linux aarch64 build. Which we would like to serve from download.pytorch.org
