### PR TITLE
Cleanup ctx manager state management

### DIFF
--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -20,11 +20,10 @@ consistency between eager execution and compiled graph behavior by capturing and
 restoring state changes.
 """
 
-import dataclasses
 import inspect
 import sys
 import warnings
-from typing import Callable, Optional, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Union
 
 import torch._C
 from torch._guards import Guard
@@ -52,27 +51,6 @@ from .user_defined import UserDefinedObjectVariable
 
 if TYPE_CHECKING:
     from torch._dynamo.symbolic_convert import InstructionTranslator
-
-
-@dataclasses.dataclass
-class ContextManagerState:
-    """
-    Mutating `self` in VariableTracker is not allowed because we copy
-    them.  This is a mutable container pointed to by context managers
-    that won't get copied, so it is safe to mutate.
-    """
-
-    cleanup_fn: Optional[Callable] = None
-    proxy: Optional[torch.fx.Proxy] = None
-
-    def cleanup(self):
-        if self.cleanup_fn is not None:
-            self.cleanup_fn()
-            self.cleanup_fn = None
-
-    def cleanup_assert(self):
-        assert self.cleanup_fn, "multiple exits?"
-        self.cleanup()
 
 
 class ContextWrappingVariable(VariableTracker):


### PR DESCRIPTION
Fixes #149572

## Changes

- Move logic in `ContextManagerState` to `ContextWrappingVariable`
- Remove `ContextManagerState`


## Test Result

```bash
pytest test/dynamo/test_ctx_manager.py
```

![image](https://github.com/user-attachments/assets/f1c2987f-b5eb-4a3f-9191-7369202ebb0a)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames