### PR TITLE
[pt2_provenance_tracing] add combo kernel nodes post_grad nodes origin info

### DIFF
--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1653,6 +1653,11 @@ class SIMDScheduling(BaseScheduling):
 
         for src_code, kernel, _ in kernel_code_list:
             kernel_name = self.define_kernel(src_code, [combo_kernel_node], kernel)
+            # dump provenance node info for ComboKernelNode/ForeachKernel type
+            if config.trace.enabled:
+                set_kernel_post_grad_provenance_tracing(
+                    combo_kernel_node.snodes, kernel_name
+                )
             self.codegen_comment([combo_kernel_node])
             log.debug("ComboKernels: generated kernel %s.", kernel_name)
             kernel.call_kernel(V.graph.wrapper_code, kernel_name)

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2727,13 +2727,19 @@ def set_kernel_post_grad_provenance_tracing(
     from .codegen.simd_kernel_features import DisableReduction, EnableReduction
     from .virtualized import V
 
-    for node in node_schedule:
-        if node not in (EnableReduction, DisableReduction):
-            if node.node is not None:
-                V.debug._inductor_triton_kernel_to_post_grad_node_info[kernel_name] = [
+    for snode in node_schedule:
+        if snode not in (EnableReduction, DisableReduction):
+            if snode.node is not None:
+                curr_node_info = (
+                    V.debug._inductor_triton_kernel_to_post_grad_node_info.setdefault(
+                        kernel_name, []
+                    )
+                )
+                curr_node_info.extend(
                     origin.name
-                    for origin in node.node.origins  # type: ignore[attr-defined]
-                ]
+                    for origin in snode.node.origins  # type: ignore[attr-defined]
+                    if origin.name not in curr_node_info
+                )
 
 
 class TritonAttrsDescriptorVersion(enum.Enum):


### PR DESCRIPTION
Summary: found it helpful when running prod model with combo_kernel feature enabled

Test Plan: CI

Differential Revision: D71513304




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov