### PR TITLE
[Inductor] Remove triton dtype patch which has landed

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1619,8 +1619,6 @@ class PythonWrapperCodegen(CodeGen):
         reset_to_zero_args,
         grids: list[list[Union[int, sympy.Expr]]],
     ):
-        from torch.utils._triton import patch_triton_dtype_repr
-
         from ..runtime.triton_heuristics import (
             config_to_dict,
             FixedGrid,
@@ -1635,7 +1633,6 @@ class PythonWrapperCodegen(CodeGen):
         )
         from .triton import gen_common_triton_imports, TritonKernel
 
-        patch_triton_dtype_repr()
         original_name = kernel.__name__
         signature: list[KernelArgType] = []
         constants: dict[str, Any] = {}
@@ -2223,7 +2220,7 @@ class PythonWrapperCodegen(CodeGen):
         self.lines.append(LineContext(ctx))
 
     def val_to_arg_str(self, s, type_=None):
-        from torch.utils._triton import dtype_to_string, has_triton_package
+        from torch.utils._triton import has_triton_package
 
         if has_triton_package():
             import triton
@@ -2250,7 +2247,7 @@ class PythonWrapperCodegen(CodeGen):
         elif isinstance(s, (ir.Buffer, ir.MutableBox, ReinterpretView)):
             return s.codegen_reference()
         elif has_triton_package() and isinstance(s, triton.language.dtype):  # type: ignore[possibly-undefined]
-            return dtype_to_string(s)
+            return repr(s)
         elif isinstance(s, ir.GeneratorState):
             return s.codegen_reference()
         else:

--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -113,23 +113,3 @@ def triton_hash_with_backend():
 
     # Hash is upper case so that it can't contain any Python keywords.
     return hashlib.sha256(key.encode("utf-8")).hexdigest().upper()
-
-
-def dtype_to_string(dtype):
-    if dtype.name.startswith("fp"):
-        suffix = "float" + dtype.name[2:]
-    elif dtype.name.startswith("bf"):
-        suffix = "bfloat" + dtype.name[2:]
-    else:
-        suffix = dtype.name
-    return "triton.language." + suffix
-
-
-def patch_triton_dtype_repr():
-    import triton
-
-    # Hack to get triton dtype repr to produce an evaluatable expression
-    # triton.language.float32 emits triton.language.fp32 which does not
-    # exist
-    # REMOVE when https://github.com/openai/triton/pull/3342 lands
-    triton.language.dtype.__repr__ = lambda self: dtype_to_string(self)


### PR DESCRIPTION
As this [pr][0] has already landed, we should remove its patch.

Having [mentioned][1] this before, I am making this change now to avoid omissions.

[0]: https://github.com/triton-lang/triton/pull/3342
[1]: https://github.com/pytorch/pytorch/pull/147583/files#r1970440062


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov