### PR TITLE
Remove custom kwargs before calling BuildExtension.__init__(...)

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -575,10 +575,12 @@ class BuildExtension(build_ext):
         return cls_with_options
 
     def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
         self.no_python_abi_suffix = kwargs.get("no_python_abi_suffix", False)
-
         self.use_ninja = kwargs.get('use_ninja', True)
+
+        filtered_kwargs = [kw for kw in kwargs if kw not in ["no_python_abi_suffix", "use_ninja"]]
+        super().__init__(*args, **filtered_kwargs)
+
         if self.use_ninja:
             # Test if we can use ninja. Fallback otherwise.
             msg = ('Attempted to use ninja as the BuildExtension backend but '

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -578,7 +578,7 @@ class BuildExtension(build_ext):
         self.no_python_abi_suffix = kwargs.get("no_python_abi_suffix", False)
         self.use_ninja = kwargs.get('use_ninja', True)
 
-        filtered_kwargs = [kw for kw in kwargs if kw not in ["no_python_abi_suffix", "use_ninja"]]
+        filtered_kwargs = {kw: val for kw, val in kwargs.items() if kw not in ["no_python_abi_suffix", "use_ninja"]}
         super().__init__(*args, **filtered_kwargs)
 
         if self.use_ninja:


### PR DESCRIPTION
Remove custom kwargs before calling `BuildExtension.__init__(...)`

This should fix what is going on in https://fb.workplace.com/chat/t/100068823519463#:~:text=https%3A//github.com/pytorch/rl/actions/runs/13974012630/job/39123001095

cc @vmoens
