### PR TITLE
[ONNX] Support running bfloat16 models with ONNX Runtime

### DIFF
--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -102,7 +102,7 @@ logger = logging.getLogger(__name__)
 current_tracer: _building.OpRecorder | None = None
 
 
-def _torch_dtype_to_onnx_dtype(dtype: torch.dtype) -> ir.DataType:
+def torch_dtype_to_onnx_dtype(dtype: torch.dtype) -> ir.DataType:
     return _TORCH_DTYPE_TO_ONNX[dtype]
 
 
@@ -110,7 +110,7 @@ class TorchTensor(ir.Tensor):
     def __init__(self, tensor: torch.Tensor, name: str | None = None):
         # Pass the tensor as the raw data to ir.Tensor's constructor
         super().__init__(
-            tensor, dtype=_torch_dtype_to_onnx_dtype(tensor.dtype), name=name
+            tensor, dtype=torch_dtype_to_onnx_dtype(tensor.dtype), name=name
         )
 
     def numpy(self) -> npt.NDArray:
@@ -218,7 +218,7 @@ def _set_shape_type(
         # be the intention even though non of the ONNX ops deals with complex values.
         # In this case, we don't change the dtype or the shape of the tensor.
         if value.dtype is None:
-            value.dtype = _torch_dtype_to_onnx_dtype(meta_val.dtype)
+            value.dtype = torch_dtype_to_onnx_dtype(meta_val.dtype)
             if complex_to_float:
                 if meta_val.dtype == torch.complex64:
                     value.dtype = ir.DataType.FLOAT
@@ -439,7 +439,7 @@ def _convert_fx_arg_to_onnx_arg(
     if isinstance(arg, (torch.device, torch.memory_format, torch.layout)):
         return str(arg)
     if isinstance(arg, torch.dtype):
-        return _torch_dtype_to_onnx_dtype(arg)
+        return torch_dtype_to_onnx_dtype(arg)
     # Maybe a Python value
     return arg
 
@@ -782,7 +782,7 @@ def _get_inputs_and_attributes(
             elif isinstance(arg, torch.device):
                 attributes[schema_arg.name] = str(arg)
             elif isinstance(arg, torch.dtype):
-                attributes[schema_arg.name] = _torch_dtype_to_onnx_dtype(arg)
+                attributes[schema_arg.name] = torch_dtype_to_onnx_dtype(arg)
             else:
                 attributes[schema_arg.name] = arg
         for schema_arg in node_schema.arguments:
@@ -798,7 +798,7 @@ def _get_inputs_and_attributes(
             } or isinstance(kwarg, torch.device):
                 attr = str(kwarg)
             elif isinstance(kwarg, torch.dtype):
-                attr = _torch_dtype_to_onnx_dtype(kwarg)  # type: ignore[assignment]
+                attr = torch_dtype_to_onnx_dtype(kwarg)  # type: ignore[assignment]
             else:
                 attr = kwarg  # type: ignore[assignment]
 

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, TYPE_CHECKING
 
 import torch
 from torch.onnx._internal._lazy_import import onnx, onnxscript_apis, onnxscript_ir as ir
-from torch.onnx._internal.exporter import _core, _dynamic_shapes, _ir_passes
+from torch.onnx._internal.exporter import _dynamic_shapes, _ir_passes
 from torch.utils import _pytree
 
 
@@ -122,6 +122,8 @@ def _to_ort_value(tensor: torch.Tensor) -> ort.OrtValue:
     """Convert a PyTorch tensor to an ONNX Runtime OrtValue."""
     import onnxruntime as ort
 
+    from torch.onnx._internal.exporter import _core
+
     if hasattr(ort.OrtValue, "ortvalue_from_numpy_with_onnx_type"):
         # This requires ONNX Runtime 1.21 or newer
         if tensor.dtype in _NP_UNSUPPORTED_DTYPES:
@@ -129,7 +131,7 @@ def _to_ort_value(tensor: torch.Tensor) -> ort.OrtValue:
             return ort.OrtValue.ortvalue_from_numpy_with_onnx_type(
                 tensor.numpy(force=True), onnx_element_type=onnx_type
             )
-    # TODO(justinchuby): Use dlpack when ORT properly supports it
+    # TODO(#151064): Use dlpack when ORT properly supports it
     return ort.OrtValue.ortvalue_from_numpy(tensor.numpy(force=True))
 
 

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -135,6 +135,7 @@ def _to_ort_value(tensor: torch.Tensor) -> ort.OrtValue:
 
 def _from_ort_value(value: ort.OrtValue) -> torch.Tensor:
     if value.element_type() == ir.DataType.BFLOAT16:
+        # This requires ONNX Runtime 1.21 or newer
         return torch.from_dlpack(value._get_c_value())
     return torch.from_numpy(value.numpy())
 

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, TYPE_CHECKING
 
 import torch
 from torch.onnx._internal._lazy_import import onnx, onnxscript_apis, onnxscript_ir as ir
-from torch.onnx._internal.exporter import _dynamic_shapes, _ir_passes, _core
+from torch.onnx._internal.exporter import _core, _dynamic_shapes, _ir_passes
 from torch.utils import _pytree
 
 

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, TYPE_CHECKING
 
 import torch
 from torch.onnx._internal._lazy_import import onnx, onnxscript_apis, onnxscript_ir as ir
-from torch.onnx._internal.exporter import _dynamic_shapes, _ir_passes
+from torch.onnx._internal.exporter import _dynamic_shapes, _ir_passes, _core
 from torch.utils import _pytree
 
 
@@ -30,6 +30,15 @@ if TYPE_CHECKING:
     import onnxruntime as ort
 
 _LARGE_MODEL_THRESHOLD = 1536 * 1024 * 1024  # 1536MB
+_NP_UNSUPPORTED_DTYPES = frozenset(
+    {
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+        torch.float8_e4m3fnuz,
+        torch.float8_e5m2,
+        torch.float8_e5m2fnuz,
+    }
+)
 
 logger = logging.getLogger(__name__)
 
@@ -109,8 +118,34 @@ def _create_value_mapping(graph: ir.Graph) -> dict[str, ir.Value]:
     return values
 
 
+def _to_ort_value(tensor: torch.Tensor) -> ort.OrtValue:
+    """Convert a PyTorch tensor to an ONNX Runtime OrtValue."""
+    import onnxruntime as ort
+
+    if hasattr(ort.OrtValue, "ortvalue_from_numpy_with_onnx_type"):
+        # This requires ONNX Runtime 1.21 or newer
+        if tensor.dtype in _NP_UNSUPPORTED_DTYPES:
+            onnx_type = _core.torch_dtype_to_onnx_dtype(tensor.dtype)
+            return ort.OrtValue.ortvalue_from_numpy_with_onnx_type(
+                tensor.numpy(force=True), onnx_element_type=onnx_type
+            )
+    # TODO(justinchuby): Use dlpack when ORT properly supports it
+    return ort.OrtValue.ortvalue_from_numpy(tensor.numpy(force=True))
+
+
+def _from_ort_value(value: ort.OrtValue) -> torch.Tensor:
+    if value.element_type() == ir.DataType.BFLOAT16:
+        return torch.from_dlpack(value._get_c_value())
+    return torch.from_numpy(value.numpy())
+
+
 class ONNXProgram:
-    """A class to represent an ONNX program that is callable with torch tensors."""
+    """A class to represent an ONNX program that is callable with torch tensors.
+
+    Attributes:
+        model: The ONNX model as an ONNX IR model object.
+        exported_program: The exported program that produced the ONNX model.
+    """
 
     def __init__(
         self, model: ir.Model, exported_program: torch.export.ExportedProgram | None
@@ -151,16 +186,17 @@ ONNXProgram(
 
         # We don't expect non-tensor as inputs
         ort_input = {
-            k.name: v.numpy(force=True)
+            k.name: _to_ort_value(v)
             for k, v in zip(self.model.graph.inputs, flatten_args)
         }
         run_options = ort.RunOptions()
         run_options.log_severity_level = 3  # 3: Error
         logger.debug("Running the inference session with %s arguments.", len(ort_input))
-        outputs = self._inference_session.run(None, ort_input, run_options=run_options)
+        outputs = self._inference_session.run_with_ort_values(
+            None, ort_input, run_options=run_options
+        )
         logger.debug("Inference session run completed.")
-        # TODO(justinchuby): Maybe output complex tensors as needed
-        return tuple(torch.from_numpy(output) for output in outputs)
+        return tuple(_from_ort_value(output) for output in outputs)
 
     def compute_values(
         self, value_names: Sequence[str], args=(), kwargs=None


### PR DESCRIPTION
Use ORTValue objects to support bfloat16 and other dtypes as inputs. This only supports cuda as ort only implements bfloat16 on cuda.
