### PR TITLE
[export] Add min & max as attribute hints to Dim

### DIFF
--- a/torch/export/dynamic_shapes.py
+++ b/torch/export/dynamic_shapes.py
@@ -243,6 +243,9 @@ class Dim(type):
     DYNAMIC = _DimHint.DYNAMIC()
     STATIC = _DimHint.STATIC()
 
+    min: int
+    max: int
+
     def __new__(
         metacls, name: str, *, min: Optional[int] = None, max: Optional[int] = None
     ):


### PR DESCRIPTION
Summary:
I see this pyre error.

```
Undefined attribute [16]: `torch.export.dynamic_shapes.Dim` has no attribute `max`.
```

Differential Revision: D71575304


