### PR TITLE
Remove effect token unbacked bindings when removing with_effect nodes

### DIFF
--- a/test/cpp/jit/test_custom_class_registrations.cpp
+++ b/test/cpp/jit/test_custom_class_registrations.cpp
@@ -518,6 +518,8 @@ TORCH_LIBRARY(_TorchScriptTesting, m) {
       "takes_foo_list_return(__torch__.torch.classes._TorchScriptTesting._Foo foo, Tensor x) -> Tensor[]");
   m.def(
       "takes_foo_tuple_return(__torch__.torch.classes._TorchScriptTesting._Foo foo, Tensor x) -> (Tensor, Tensor)");
+  m.def(
+      "takes_foo_tensor_return(__torch__.torch.classes._TorchScriptTesting._Foo foo, Tensor x) -> Tensor");
 
   m.class_<FooGetterSetter>("_FooGetterSetter")
       .def(torch::init<int64_t, int64_t>())
@@ -701,6 +703,10 @@ std::tuple<at::Tensor, at::Tensor> takes_foo_tuple_return(
   return std::make_tuple(a, b);
 }
 
+at::Tensor takes_foo_tensor_return(c10::intrusive_ptr<Foo> foo, at::Tensor x) {
+  return at::ones({foo->x, foo->y}, at::device(at::kCPU).dtype(at::kInt));
+}
+
 void queue_push(c10::intrusive_ptr<TensorQueue> tq, at::Tensor x) {
   tq->push(x);
 }
@@ -732,6 +738,7 @@ TORCH_LIBRARY_IMPL(_TorchScriptTesting, CPU, m) {
   m.impl("queue_push", queue_push);
   m.impl("queue_pop", queue_pop);
   m.impl("queue_size", queue_size);
+  m.impl("takes_foo_tensor_return", takes_foo_tensor_return);
 }
 
 TORCH_LIBRARY_IMPL(_TorchScriptTesting, Meta, m) {

--- a/torch/export/_remove_effect_tokens_pass.py
+++ b/torch/export/_remove_effect_tokens_pass.py
@@ -71,6 +71,13 @@ def _remove_effect_tokens_from_graph_helper(
             new_node = ep.graph.call_function(func, node.args[2:], node.kwargs)
         for k, v in node.meta.items():
             new_node.meta[k] = v
+            if k == "unbacked_bindings":
+                # Remove the extra layer for effect token
+                old_bindings = new_node.meta[k]
+                new_bindings = {
+                    k: path[1:] if path else path for k, path in old_bindings.items()
+                }
+                new_node.meta[k] = new_bindings
 
         node.replace_all_uses_with(new_node)
 

--- a/torch/testing/_internal/torchbind_impls.py
+++ b/torch/testing/_internal/torchbind_impls.py
@@ -61,6 +61,13 @@ def register_fake_operators():
         b = foo.add_tensor(a)
         return (a, b)
 
+    @torch.library.register_fake("_TorchScriptTesting::takes_foo_tensor_return")
+    def meta_takes_foo_tensor_return(foo, x):
+        # This implementation deliberately creates unbacked symint for testing
+        ctx = torch.library.get_ctx()
+        fake_shape = [ctx.new_dynamic_size() for _ in range(2)]
+        return torch.empty(fake_shape, dtype=torch.int, device="cpu")
+
     torch.ops._TorchScriptTesting.takes_foo_list_return.default.py_impl(
         torch._C.DispatchKey.Meta
     )(meta_takes_foo_list_return)


### PR DESCRIPTION
Summary:
**Export**

Fix `node.meta["unbacked_bindings"]`when removing `with_effect` wrapper in `ep.module()` call.

Test Plan:
```
buck run //caffe2/test:test_export -- -r test_custom_obj_unbacked_symint
```

Differential Revision: D71567148




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel