### PR TITLE
[easy] Do not logspam if static cuda launcher is disabled

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1137,10 +1137,10 @@ class StaticTritonCompileResult(CompileResult[StaticallyLaunchedCudaKernel]):
         triton_meta: dict[str, Any],
         heuristic_type: HeuristicType,
     ) -> Optional[StaticallyLaunchedCudaKernel]:
-        def check_can_launch() -> StaticallyLaunchedCudaKernel:
-            if not torch._inductor.config.use_static_cuda_launcher:
-                raise CannotStaticallyLaunchKernel("Static launcher disabled")
+        if not torch._inductor.config.use_static_cuda_launcher:
+            return None
 
+        def check_can_launch() -> StaticallyLaunchedCudaKernel:
             if triton_meta.get("device_type", None) != "cuda":
                 # Only cuda kernels
                 raise CannotStaticallyLaunchKernel("Non-cuda device")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #149629
* #149657
* #149442
* #149054
* __->__ #149669

No need to log.info every time someone runs with StaticCudaLauncher disabled.

Test plan: Run any benchmark and see that we don't spam the bypass message in logs. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov