### PR TITLE
Add release branch push triggers to inductor-rocm-mi300.yml

### DIFF
--- a/.github/workflows/inductor-rocm-mi300.yml
+++ b/.github/workflows/inductor-rocm-mi300.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/*
     tags:
       - ciflow/inductor-rocm/*
   workflow_dispatch:


### PR DESCRIPTION
In similar vein as https://github.com/pytorch/pytorch/pull/149517

When we added the rocm-mi300.yml earlier this year, we had lower capacity and we were just pipecleaning the workflow, so we set the trigger to only respond to pushes to main branch. But now we have more stability as well as capacity, and we would really like to ensure that the release branch is being tested on MI300s as well.

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd