### PR TITLE
[ROCm][TunableOp] Fix offline tuning for ScaledGEMM.

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4780,12 +4780,14 @@ class TestLinalg(TestCase):
             # Scaled GEMM parameters
             fillA = 0.25
             fillB = 0.75
-            m = n = k = 16
+            n = 16
+            m = 32
+            k = 64
             scaleA = torch.tensor(0.8, device=device)
             scaleB = torch.tensor(0.9, device=device)
 
             dtypeA = dtypeB = dtype
-            matA = torch.full((k, m), fillA, dtype=dtypeA, device=device)
+            matA = torch.full((m, k), fillA, dtype=dtypeA, device=device)
             matB = torch.full((n, k), fillB, dtype=dtypeB, device=device).t()
 
             # Summary of bias types that are supported:
@@ -4813,7 +4815,7 @@ class TestLinalg(TestCase):
             # rowwise scaling, only supported for this dtype combination
             if dtype is torch.torch.float8_e4m3fnuz:
                 scaleA = torch.ones((matA.shape[0], 1), device=device)
-                scaleB = torch.ones((1, matB.shape[0]), device=device)
+                scaleB = torch.ones((1, matB.shape[1]), device=device)
                 torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=torch.bfloat16)
 
             self.assertTrue(torch.cuda.tunable.is_enabled())
@@ -4850,6 +4852,8 @@ class TestLinalg(TestCase):
             self.assertTrue(os.path.exists(result_filename))
             self.assertGreater(os.path.getsize(result_filename), 0)
 
+            
+
         finally:
             # disable TunableOp
             torch.cuda.tunable.enable(False)
@@ -4861,12 +4865,12 @@ class TestLinalg(TestCase):
                 pass
 
             # clean up, remove any files that were generated
-            for filename in [untuned_filename, result_filename]:
-                try:
-                    os.remove(filename)
-                # NB: The file is locked on Windows
-                except (FileNotFoundError, PermissionError):
-                    pass
+            # for filename in [untuned_filename, result_filename]:
+            #     try:
+            #         os.remove(filename)
+            #     # NB: The file is locked on Windows
+            #     except (FileNotFoundError, PermissionError):
+            #         pass
 
     @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
     @onlyCUDA

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4705,6 +4705,7 @@ class TestLinalg(TestCase):
                 pass
 
     @onlyCUDA
+    @skipCUDAIfNotRocm
     @dtypes(torch.half)
     def test_matmul_offline_tunableop(self, device, dtype):
         import os
@@ -5363,6 +5364,7 @@ class TestLinalg(TestCase):
             pass
 
     @onlyCUDA
+    @skipCUDAIfNotRocm
     @dtypes(torch.bfloat16)
     def test_gemm_bias_offline_tunableop(self, device, dtype):
         # This test is the offline version of test_gemm_bias_tunableop

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5474,12 +5474,14 @@ class TestLinalg(TestCase):
         # Scaled GEMM parameters
         fillA = 0.25
         fillB = 0.75
-        m = n = k = 32
+        n = 16
+        m = 32
+        k = 64
         scaleA = torch.tensor(0.8, device=device)
         scaleB = torch.tensor(0.9, device=device)
 
         dtypeA = dtypeB = dtype
-        matA = torch.full((k, m), fillA, dtype=dtypeA, device=device)
+        matA = torch.full((m, k), fillA, dtype=dtypeA, device=device)
         matB = torch.full((n, k), fillB, dtype=dtypeB, device=device).t()
 
         # Summary of bias types that are supported:
@@ -5507,7 +5509,7 @@ class TestLinalg(TestCase):
         # rowwise scaling, only supported for this dtype combination
         if dtype is torch.torch.float8_e4m3fnuz:
             scaleA = torch.ones((matA.shape[0], 1), device=device)
-            scaleB = torch.ones((1, matB.shape[0]), device=device)
+            scaleB = torch.ones((1, matB.shape[1]), device=device)
             torch._scaled_mm(matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=torch.bfloat16)
 
         # This stores total number of cummulative results

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4758,6 +4758,10 @@ class TestLinalg(TestCase):
             self.assertTrue(os.path.exists(result_filename))
             self.assertGreater(os.path.getsize(result_filename), 0)
 
+            # Compare Param Signature of untuned and tuned results
+            ok = compare_untuned_tuned_param_sig(untuned_filename, result_filename)
+            self.assertTrue(ok)
+
         finally:
             # disable TunableOp
             torch.cuda.tunable.enable(False)
@@ -5419,6 +5423,10 @@ class TestLinalg(TestCase):
             self.assertTrue(os.path.exists(result_filename))
             self.assertGreater(os.path.getsize(result_filename), 0)
 
+            # Compare Param Signature of untuned and tuned results
+            ok = compare_untuned_tuned_param_sig(untuned_filename, result_filename)
+            self.assertTrue(ok)
+
         finally:
             # disable TunableOp
             torch.cuda.tunable.enable(False)
@@ -5673,6 +5681,16 @@ class TestLinalg(TestCase):
                                                      'GemmTunableOp_float_NN',
                                                      'nn_41_41_41_ld_41_41_41')
                 self.assertTrue(found_result is not None)
+
+                self.assertTrue(torch.cuda.tunable.write_file())
+
+                # Make sure the results file exists and that it is not zero
+                self.assertTrue(os.path.exists(result_filename))
+                self.assertGreater(os.path.getsize(result_filename), 0)
+
+                # Compare Param Signature of untuned and tuned results
+                ok = compare_untuned_tuned_param_sig(untuned_filename, result_filename)
+                self.assertTrue(ok)
 
         finally:
             # Disable TF32

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5474,9 +5474,9 @@ class TestLinalg(TestCase):
         # Scaled GEMM parameters
         fillA = 0.25
         fillB = 0.75
-        n = 16
-        m = 32
-        k = 64
+        n = 32
+        m = 64
+        k = 128
         scaleA = torch.tensor(0.8, device=device)
         scaleB = torch.tensor(0.9, device=device)
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -107,6 +107,31 @@ def find_tunableop_result(results, OpSig, ParamSig):
             return inner_tuple
     return None
 
+def compare_untuned_tuned_param_sig(untuned_filename, tuned_filename):
+    # Compare Param Signature of untuned and tuned Tunableop results
+    # file. Verify that for each Param Signature in the untuned file
+    # there is a matching one in the tuned results file.
+    import csv
+    ok = False
+    with open(untuned_filename) as file1:
+        with open(tuned_filename) as file2:
+            untuned_reader = csv.reader(file1)
+            untuned_csv_entries = [row[1] for row in untuned_reader]
+
+            tuned_reader = csv.reader(file2)
+            for _ in range(5):  # Skip the first 5 lines for the validator
+                next(tuned_reader, None)
+
+            result_csv_entries = [row[1] for row in tuned_reader]
+
+            for value in untuned_csv_entries:
+                if value in result_csv_entries:
+                    ok = True
+                else:
+                    ok = False
+
+    return ok
+
 class TestLinalg(TestCase):
     @contextlib.contextmanager
     def _hip_allow_tf32(self):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4881,7 +4881,9 @@ class TestLinalg(TestCase):
             self.assertTrue(os.path.exists(result_filename))
             self.assertGreater(os.path.getsize(result_filename), 0)
 
-            
+            # Compare Param Signature of untuned and tuned results
+            ok = compare_untuned_tuned_param_sig(untuned_filename, result_filename)
+            self.assertTrue(ok)
 
         finally:
             # disable TunableOp
@@ -4894,12 +4896,12 @@ class TestLinalg(TestCase):
                 pass
 
             # clean up, remove any files that were generated
-            # for filename in [untuned_filename, result_filename]:
-            #     try:
-            #         os.remove(filename)
-            #     # NB: The file is locked on Windows
-            #     except (FileNotFoundError, PermissionError):
-            #         pass
+            for filename in [untuned_filename, result_filename]:
+                try:
+                    os.remove(filename)
+                # NB: The file is locked on Windows
+                except (FileNotFoundError, PermissionError):
+                    pass
 
     @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
     @onlyCUDA

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -478,8 +478,8 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
             torch.backends.cuda.matmul.allow_tf32 = False
 
     else:  # ScaledGEMM
-        count = untuned_gemm[0].count('_')
-        assert (count in [6, 7])
+        count = untuned_gemm[0].count("_")
+        assert count in [6, 7]
         untuned_gemm_temp = untuned_gemm[0].split("_")
         # dtypeC = might not be FP8 type, keep track
         # of the the number of underscores
@@ -499,17 +499,19 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
     untuned_gemm_temp = untuned_gemm[1].split("_")
     [n, m, k] = [int(g) for g in untuned_gemm_temp[1:4]]
     if op_sig == "GemmStridedBatchedTunableOp":
-        assert (untuned_gemm_temp[6] == "ld")
+        assert untuned_gemm_temp[6] == "ld"
         [ldb, lda, ldc] = [int(g) for g in untuned_gemm_temp[7:10]]
     else:
-        assert (untuned_gemm_temp[4] == "ld")
+        assert untuned_gemm_temp[4] == "ld"
         [ldb, lda, ldc] = [int(g) for g in untuned_gemm_temp[5:8]]
 
     # We cannot handle submatrices in offline tuning
     if all(item in [n, m, k] for item in [lda, ldb, ldc]):
         pass
     else:
-        raise NotImplementedError(f"Submatrices are not supported in offline tuning: {untuned_gemm[1]} ")
+        raise NotImplementedError(
+            f"Submatrices are not supported in offline tuning: {untuned_gemm[1]} "
+        )
 
     if op_sig == "GemmTunableOp":
         matA = (

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -478,10 +478,11 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
             torch.backends.cuda.matmul.allow_tf32 = False
 
     else:  # ScaledGEMM
+        count = untuned_gemm[0].count('_')
+        assert (count in [6, 7])
         untuned_gemm_temp = untuned_gemm[0].split("_")
         # dtypeC = might not be FP8 type, keep track
         # of the the number of underscores
-        count = untuned_gemm_temp.count("_")
         op_sig = untuned_gemm_temp[0]
         data_typeA = untuned_gemm_temp[1] + "_" + untuned_gemm_temp[2]
         data_typeB = untuned_gemm_temp[3] + "_" + untuned_gemm_temp[4]

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -498,6 +498,19 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
 
     untuned_gemm_temp = untuned_gemm[1].split("_")
     [n, m, k] = [int(g) for g in untuned_gemm_temp[1:4]]
+    if op_sig == "GemmStridedBatchedTunableOp":
+        assert (untuned_gemm_temp[6] == "ld")
+        [ldb, lda, ldc] = [int(g) for g in untuned_gemm_temp[7:10]]
+    else:
+        assert (untuned_gemm_temp[4] == "ld")
+        [ldb, lda, ldc] = [int(g) for g in untuned_gemm_temp[5:8]]
+
+    # We cannot handle submatrices in offline tuning
+    if all(item in [n, m, k] for item in [lda, ldb, ldc]):
+        pass
+    else:
+        raise NotImplementedError(f"Submatrices are not supported in offline tuning: {untuned_gemm[1]} ")
+
     if op_sig == "GemmTunableOp":
         matA = (
             torch.rand(k, m, dtype=dtype, device=deviceid).t()

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -534,9 +534,9 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
             else torch.full((m, k), fillA, dtype=dtypeA, device=deviceid)
         )
         matB = (
-            torch.full((n, k), fillB, dtype=dtypeB, device=deviceid)
+            torch.full((n, k), fillB, dtype=dtypeB, device=deviceid).t()
             if transA
-            else torch.full((k, n), fillB, dtype=dtypeB, device=deviceid).t()
+            else torch.full((k, n), fillB, dtype=dtypeB, device=deviceid)
         )
 
         assert untuned_gemm_temp[8] == "rw"

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -509,9 +509,11 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
     if all(item in [n, m, k] for item in [lda, ldb, ldc]):
         pass
     else:
-        raise NotImplementedError(
-            f"Submatrices are not supported in offline tuning: {untuned_gemm[1]} "
+        warnings.warn(
+            "Offline tuning is not supported on submatrices. Use online tuning instead. "
+            + f"Skipped tuning for: {untuned_gemm[1]}"
         )
+        return
 
     if op_sig == "GemmTunableOp":
         matA = (


### PR DESCRIPTION
The main purpose of this PR is to fix offline tuning for ScaledGEMM. The previous UT passed because it was not strict enough. Additionally:
- All the offline tuning tests now do a comparison with the online results to ensure that ParamSignature match.
- We raise an error if submatrices are encountered as this is only supported in online tuning mode.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang