### PR TITLE
Do not depend on numpy during the import

### DIFF
--- a/torch/_functorch/_activation_checkpointing/knapsack_evaluator.py
+++ b/torch/_functorch/_activation_checkpointing/knapsack_evaluator.py
@@ -2,7 +2,6 @@ from collections import deque
 from typing import Callable
 
 import networkx as nx
-import numpy as np
 
 from torch._functorch._activation_checkpointing.graph_info_provider import (
     GraphInfoProvider,
@@ -237,6 +236,7 @@ class KnapsackEvaluator:
         Returns:
             float: Memory budget at the knee point.
         """
+        import numpy as np
         results = self.evaluate_distribution_of_results_for_knapsack_algo(
             knapsack_algo=knapsack_algo,
             memory_budget_values=np.linspace(  # type: ignore[arg-type]

--- a/torch/_functorch/_activation_checkpointing/knapsack_evaluator.py
+++ b/torch/_functorch/_activation_checkpointing/knapsack_evaluator.py
@@ -237,6 +237,7 @@ class KnapsackEvaluator:
             float: Memory budget at the knee point.
         """
         import numpy as np
+
         results = self.evaluate_distribution_of_results_for_knapsack_algo(
             knapsack_algo=knapsack_algo,
             memory_budget_values=np.linspace(  # type: ignore[arg-type]


### PR DESCRIPTION
But a good followup would be to use torch primitives instead of numpy here
Fixes https://github.com/pytorch/pytorch/issues/149681

Test plan: Monkey-patch 2.7.0-rc and run `python -c "import torch;print(torch.compile(lambda x:x.sin() + x.cos())(torch.rand(32)))"`

cc @zou3519 @Chillee @samdow @kshitij12345