### PR TITLE
[Hierarchical Compilation] Handle origin nodes without children

### DIFF
--- a/torch/_dynamo/graph_region_tracker.py
+++ b/torch/_dynamo/graph_region_tracker.py
@@ -179,6 +179,9 @@ class BackwardBfsArgIter:
         else:
             self._queue.append(arg)
 
+    def __str__(self) -> str:
+        return f"BackwardBfsArgIter(cur={self._cur}, queue={self._queue})"
+
 
 class GraphRegionTracker:
     """
@@ -315,7 +318,11 @@ def fully_expand_region_group(
         region_it.add_children(node)
 
     current_node = region_iters[0].next()
-    assert current_node is not None
+
+    # No children
+    if current_node is None:
+        return
+
     # Loop incrementally adding new nodes to each region
     # regions are only expanded if the node to add is valid
     # for ALL regions


### PR DESCRIPTION
Bug discovered running Hierarchical Compilation on HF. 

I don't have a smaller repro for this unfortunately.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #149686
* __->__ #149685



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames