### PR TITLE
Let pointwise sharding take arg with largest number of dims in case of ties

### DIFF
--- a/torch/distributed/tensor/_ops/_pointwise_ops.py
+++ b/torch/distributed/tensor/_ops/_pointwise_ops.py
@@ -441,7 +441,9 @@ def pointwise_strategy(op_schema: OpSchema, linearity: bool = False) -> OpStrate
 
             arg_max_shards = arg_strategy.max_num_shards()
             arg_max_ndim = arg_strategy.ndim
-            if (arg_max_shards > max_shards) or (arg_max_shards == max_shards and arg_max_ndim > max_ndim):
+            if (arg_max_shards > max_shards) or (
+                arg_max_shards == max_shards and arg_max_ndim > max_ndim
+            ):
                 max_shards_strategy_index = idx
                 max_shards = arg_max_shards
                 max_ndim = arg_max_ndim

--- a/torch/distributed/tensor/_ops/_pointwise_ops.py
+++ b/torch/distributed/tensor/_ops/_pointwise_ops.py
@@ -422,6 +422,7 @@ pointwise_ops = [
 def pointwise_strategy(op_schema: OpSchema, linearity: bool = False) -> OpStrategy:
     max_shards_strategy_index = -1
     max_shards = -1
+    max_ndim = -1
 
     if _is_inplace_op(op_schema.op):
         # inplace op should follow the first arg strategy
@@ -432,14 +433,18 @@ def pointwise_strategy(op_schema: OpSchema, linearity: bool = False) -> OpStrate
     else:
         # normal pointwise op, we choose to follow the arg with
         # the max shards in case operands needs reshard
+        # in case of multiple operands with max shard, we take
+        # the one with the max number of dimensions
         for idx, arg_strategy in enumerate(op_schema.args_schema):
             if not isinstance(arg_strategy, OpStrategy):
                 continue
 
             arg_max_shards = arg_strategy.max_num_shards()
-            if arg_max_shards > max_shards:
+            arg_max_ndim = arg_strategy.ndim
+            if (arg_max_shards > max_shards) or (arg_max_shards == max_shards and arg_max_ndim > max_ndim):
                 max_shards_strategy_index = idx
                 max_shards = arg_max_shards
+                max_ndim = arg_max_ndim
 
         followed_strategy = op_schema.args_schema[max_shards_strategy_index]
 


### PR DESCRIPTION
Before, we would take the first argument with the largest number of shards, regardless if it had fewer dims than another arg with the same number of shards but more dimensions. This would lead to potentially fewer sharding options

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o