### PR TITLE
[MPS][BE] Migrate `torch.complex` to binary_functor

### DIFF
--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -122,7 +122,7 @@ Tensor& complex_out_mps(const Tensor& real, const Tensor& imag, Tensor& output) 
   auto output_as_real = at::view_as_real(output).select(output.dim(), 0);
   auto iter = TensorIteratorConfig().add_output(output_as_real).add_input(real).add_input(imag).build();
 
-  lib.exec_binary_kernel(iter, "complex_kernel", /*supports_dense=*/false);
+  lib.exec_binary_kernel(iter, "make_complex");
   return output;
 }
 } // namespace at::native


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #149730
* #149729
* #149728
* __->__ #149727

As it's very similar in nature to `torch.polar`
Though rename kernel from `complex_kernel` to `make_complex`