### PR TITLE
[MPS][BE] Get rid of `supports_dense` flag

### DIFF
--- a/aten/src/ATen/native/mps/MetalShaderLibrary.h
+++ b/aten/src/ATen/native/mps/MetalShaderLibrary.h
@@ -133,10 +133,7 @@ class MetalShaderLibrary {
       TensorIteratorBase& iter,
       const std::string& name,
       std::optional<int64_t> extra = std::nullopt);
-  void exec_binary_kernel(
-      TensorIteratorBase& iter,
-      const std::string& name,
-      const bool supports_dense = true);
+  void exec_binary_kernel(TensorIteratorBase& iter, const std::string& name);
 
  protected:
   virtual MTLLibrary_t getLibrary();

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1010,9 +1010,7 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
   }
 }
 
-void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter,
-                                            const std::string& name,
-                                            const bool supports_dense) {
+void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter, const std::string& name) {
   TORCH_CHECK(iter.common_dtype() != at::kDouble, "float64 is not supported on MPS");
 
   Tensor input = iter.input(0);
@@ -1027,7 +1025,7 @@ void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter,
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       auto computeEncoder = mpsStream->commandEncoder();
-      if (supports_dense && iter.is_contiguous()) {
+      if (iter.is_contiguous()) {
         const auto kernel_name = fmt::format("{}_dense_{}", name, scalarToMetalTypeString(input));
         auto binaryPSO = getPipelineStateForFunc(kernel_name);
         [computeEncoder setComputePipelineState:binaryPSO];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #149730
* __->__ #149729
* #149728
* #149727

As now all binary ops supports dense