### PR TITLE
adding logging to capture when a trainer process is sigkilled.

### DIFF
--- a/test/distributed/elastic/multiprocessing/errors/subprocess_handler_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/subprocess_handler_test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Owner(s): ["oncall: distributed"]
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from torch.distributed.elastic.events import EventMetadataValue, EventSource
+from torch.distributed.elastic.multiprocessing.api import _construct_event
+from torch.distributed.elastic.multiprocessing.subprocess_handler import (
+    SubprocessHandler,
+)
+
+
+class TestSubprocessHandler(unittest.TestCase):
+    @patch(
+        "torch.distributed.elastic.multiprocessing.subprocess_handler.SubprocessHandler._popen"
+    )
+    def test_subprocess_handler_init_with_rank(self, mock_popen):
+        # Mock the open function to return a mock file object
+
+        # Mock the Popen object
+        mock_proc = MagicMock()
+        mock_popen.return_value = mock_proc
+
+        # Initialize SubprocessHandler
+        handler = SubprocessHandler(
+            entrypoint="echo",
+            args=("Hello, World!",),
+            env={"RANK": "0"},
+            stdout=None,
+            stderr=None,
+            local_rank_id=0,
+        )
+
+        self.assertEqual(handler.local_rank_id, 0)
+        self.assertEqual(handler.global_rank, "0")
+
+    @patch(
+        "torch.distributed.elastic.multiprocessing.subprocess_handler.SubprocessHandler._popen"
+    )
+    def test_subprocess_handler_init_without_rank_env(self, mock_popen):
+        # Mock the open function to return a mock file object
+
+        # Mock the Popen object
+        mock_proc = MagicMock()
+        mock_popen.return_value = mock_proc
+
+        # Initialize SubprocessHandler
+        handler = SubprocessHandler(
+            entrypoint="echo",
+            args=("Hello, World!",),
+            env={"LOCAL_RANK": "0"},
+            stdout=None,
+            stderr=None,
+            local_rank_id=0,
+        )
+
+        self.assertEqual(handler.local_rank_id, 0)
+        self.assertEqual(handler.global_rank, None)
+
+    def test_construct_event(self):
+        source: EventSource = EventSource.WORKER
+        global_rank = 1
+        raw_error = "Error message"
+        local_rank = 0
+
+        expected_metadata: dict[str, EventMetadataValue] = {}
+        expected_metadata["global_rank"] = global_rank
+        expected_metadata["raw_error"] = raw_error
+        expected_metadata["local_rank"] = local_rank
+
+        event = _construct_event(source, global_rank, raw_error, local_rank)
+
+        self.assertEqual(event.name, "torchelastic.worker.closure")
+        self.assertEqual(event.source, source)
+        self.assertEqual(event.metadata, expected_metadata)

--- a/torch/distributed/elastic/multiprocessing/subprocess_handler/subprocess_handler.py
+++ b/torch/distributed/elastic/multiprocessing/subprocess_handler/subprocess_handler.py
@@ -9,7 +9,7 @@ import os
 import signal
 import subprocess
 import sys
-from typing import Any, Optional
+from typing import Any, cast, Optional
 
 
 __all__ = ["SubprocessHandler"]
@@ -49,6 +49,7 @@ class SubprocessHandler:
         args_str = (entrypoint, *[str(e) for e in args])
         self.local_rank_id = local_rank_id
         self.proc: subprocess.Popen = self._popen(args_str, env_vars)
+        self.global_rank = cast(Optional[int], env.get("RANK"))
 
     def _popen(self, args: tuple, env: dict[str, str]) -> subprocess.Popen:
         kwargs: dict[str, Any] = {}


### PR DESCRIPTION
Summary:
It will help us determine when a trainer process is not terminated gracefully due to SIGKILL by torch elastic.
In case of process is terminated with SIGKILL, there is no way to collect logs before termination which causes confusion due to missing logs. Logging when trainer was SIGKILLED when help understand failure for the trainer process.

Test Plan:
unit tests

buck tests test/distributed/elastic/multiprocessing/errors/subprocess_handler_test.py
 https://www.internalfb.com/intern/testinfra/testrun/12103424072581559


**ran an e2e job to confirm that training jobs using torch elastic will continue to run gracefully.**
https://www.internalfb.com/mlhub/pipelines/runs/mast/f710719113-TrainingApplication_OYJWR?job_attempt=0&version=0&tab=execution_details&env=PRODUCTION

Differential Revision: D71296393




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o