### PR TITLE
[fbcode]Removing `@NoIntBaseDeprecated` annotation in `caffe2.thrift` file

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -101,6 +101,8 @@ try:
 except ImportError:
     has_pytest = False
 
+from thrift.py3.types import Enum as ThriftEnum
+
 
 MI300_ARCH = ("gfx942",)
 
@@ -2792,6 +2794,11 @@ class RelaxedNumberPair(NumberPair):
                 or (isinstance(expected, self._supported_types) and isinstance(actual, other_supported_types))
         ):
             self._inputs_not_supported()
+
+        # Because Thrift Enums have changed to have a base class of int, check if actual or expected are of type thrift enum and call inputs_not_supported.
+        if isinstance(actual, ThriftEnum) or isinstance(expected, ThriftEnum):
+            self._inputs_not_supported()
+
 
         return [self._to_number(input, id=id) for input in (actual, expected)]
 


### PR DESCRIPTION
Summary:
To align with thrift-python, we are adding the int base class for `non-Flag` enums. In order to not break production code, the annotation `python.NoIntBaseClassDeprecated` is added to opt-out some enums

After the related customer code logic changes, we can now safely remove the annotations that were added earlier.

Our ultimate goal is to unconditionally add the `int` base to `thrift-py3` enums.

Test Plan:
```
buck test 'fbcode//mode/opt' fbcode//caffe2/torch/fb/training_toolkit/applications/bulk_eval/tests:evaluator_test -- --exact 'caffe2/torch/fb/training_toolkit/applications/bulk_eval/tests:evaluator_test - test_setup_evaluation_utils (caffe2.torch.fb.training_toolkit.applications.bulk_eval.tests.evaluator_test.EvaluatorTest)'
```

Reviewed By: ahilger

Differential Revision: D71446522


