### PR TITLE
[fbcode]Removing `@NoIntBaseDeprecated` annotation in `caffe2.thrift` file (#149742)

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2810,8 +2810,11 @@ class RelaxedNumberPair(NumberPair):
                 number = int(number)
 
             return number
-        elif isinstance(number_like, Enum):
-            return int(number_like)  # type: ignore[call-overload]
+
+
+        # handling enum.Enum and Enum-like classes
+        elif hasattr(number_like, "value") and isinstance(number_like.value, int):
+            return number_like.value  # type: ignore[call-overload]
         else:
             return super()._to_number(number_like, id=id)
 


### PR DESCRIPTION
Summary:

To align with thrift-python, we are adding the int base class for `non-Flag` enums. In order to not break production code, the annotation `python.NoIntBaseClassDeprecated` is added to opt-out some enums

After the related customer code logic changes, we can now safely remove the annotations that were added earlier.

Our ultimate goal is to unconditionally add the `int` base to `thrift-py3` enums.

Test Plan:
```
buck test 'fbcode//mode/opt' fbcode//caffe2/torch/fb/training_toolkit/applications/bulk_eval/tests:evaluator_test -- --exact 'caffe2/torch/fb/training_toolkit/applications/bulk_eval/tests:evaluator_test - test_setup_evaluation_utils (caffe2.torch.fb.training_toolkit.applications.bulk_eval.tests.evaluator_test.EvaluatorTest)'
```

Reviewed By: ahilger

Differential Revision: D71446522


