### PR TITLE
[sigmoid] Support _operator.neg/truediv

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -11632,6 +11632,16 @@ graph():
             "torch.testing._internal.two_tensor.TwoTensor", 2, exactly=True
         ).run(gm_torch_ir.code)
 
+    def test_sym_float_operators(self):
+        class Module(torch.nn.Module):
+            def forward(self, x):
+                return -(x.max().item() / 2) + x
+
+        m = Module()
+        args = (torch.ones(4),)
+        ep = export(m, args)
+        self.assertEqual(ep.module()(*args), m(*args))
+
     def test_cse_for_symint(self):
         class Foo(torch.nn.Module):
             # check sym ops only get computed once


### PR DESCRIPTION
Summary: adding operator.truediv and operator.neg support to the runtime

Test Plan: buck run mode/opt caffe2/test:test_export -- -r test_sym_float_operators_cpp_runtime_nonstrict

Differential Revision: D71637267


