### PR TITLE
[sigmoid] Fix scalar resolution for Scalar_mode aten ops.

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -7828,6 +7828,16 @@ graph():
         )
         self.assertEqual(ep.module()(*inputs), m3(*inputs))
 
+    def test_operator_aten_tensor_mode_variant(self):
+        class Module(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.div.Tensor_mode(x, 2, rounding_mode="floor")
+
+        m = Module()
+        args = (torch.randn(4, 3),)
+        ep = export(m, args)
+        self.assertEqual(ep.module()(*args), m(*args))
+
     def test_export_then_compile_tensor_ctor(self):
         class M(torch.nn.Module):
             def forward(self, scores, mask):


### PR DESCRIPTION
Summary: For Scalar variant resolution, we didn't handle a corner case of "Tensor_mode" variant (from aten::div). Adding the missing case to the graph pass.

Test Plan: buck test mode/opt caffe2/test:test_export -- -r test_operator_aten_tensor_mode_variant_cpp_runtime

Differential Revision: D71638433


