### PR TITLE
[Profiler] Give non-zero default values to start events

### DIFF
--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -1033,14 +1033,14 @@ class PostProcess {
       const auto python_tid =
           std::get<ExtraFields<E>>((*it)->extra_fields_).python_tid_;
       if ((*it)->start_tid_ == NoTID && SOFT_ASSERT(E == EventType::PyCall)) {
-      #ifdef USE_KINETO
-        kineto::DeviceAndResource info = {libkineto::processId(), libkineto::systemThreadId()};
-      #else
+#ifdef USE_KINETO
+        kineto::DeviceAndResource info = {
+            libkineto::processId(), libkineto::systemThreadId()};
+#else
         kineto::DeviceAndResource info = kineto::DeviceAndResource();
-      #endif // USE_KINETO
+#endif // USE_KINETO
         const auto& tid_info =
-            tid_map.insert({python_tid, {NoTID, info}})
-                .first->second;
+            tid_map.insert({python_tid, {NoTID, info}}).first->second;
         (*it)->start_tid_ = tid_info.first;
         (*it)->kineto_info_ = tid_info.second;
       }

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -13,6 +13,10 @@
 #include <Python.h>
 #include <frameobject.h>
 
+#ifdef USE_KINETO
+#include <libkineto.h>
+#endif
+
 #include <ATen/core/TensorBase.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/ApproximateClock.h>
@@ -1029,8 +1033,13 @@ class PostProcess {
       const auto python_tid =
           std::get<ExtraFields<E>>((*it)->extra_fields_).python_tid_;
       if ((*it)->start_tid_ == NoTID && SOFT_ASSERT(E == EventType::PyCall)) {
+      #ifdef USE_KINETO
+        kineto::DeviceAndResource info = {libkineto::processId(), libkineto::systemThreadId()};
+      #else
+        kineto::DeviceAndResource info = kineto::DeviceAndResource();
+      #endif // USE_KINETO
         const auto& tid_info =
-            tid_map.insert({python_tid, {NoTID, kineto::DeviceAndResource()}})
+            tid_map.insert({python_tid, {NoTID, info}})
                 .first->second;
         (*it)->start_tid_ = tid_info.first;
         (*it)->kineto_info_ = tid_info.second;


### PR DESCRIPTION
The intent of the existing code is to

> // Assign system TIDs to start events based on the system TID of the next
    // observed event with the same Python TID.

However, if there are start events that don't share the same Python TID as later observed events, then they are left with the default initialization of DeviceAndResource and assigned values of `0`. This is problematic because Kineto uses `device=0, resource=0` for the first GPU (or other backend) device.

This PR maintains the previous logic of using TIDs from later events if any are present, but defaults to the current process and system thread IDs if there aren't later events to reference.

This issue was discovered while working to implement a custom backend and some CPU start events were appearing on the same process and thread as the device in the trace.