### PR TITLE
Move emulate_precision_casts to be controlled by a JK.

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -601,8 +601,10 @@ debug_index_asserts = False
 # Inductor's behavior should be closer to fp64 ref numerics.  However, with
 # this knob you can ensure the downcast-upcast are preserved so that you can
 # emulate the eager numerics.
-emulate_precision_casts = (
-    os.environ.get("TORCHINDUCTOR_EMULATE_PRECISION_CASTS", "0") == "1"
+emulate_precision_casts: bool = Config(
+    justknob="pytorch/compiler:emulate_precision_casts",
+    env_name_force="TORCHINDUCTOR_EMULATE_PRECISION_CASTS",
+    default=False,
 )
 
 # warnings intended for PyTorch developers, disable for point releases


### PR DESCRIPTION
Summary: This allows us to selectively turn this on for internal use cases.

Test Plan: Relying primarily on existing models not breaking at test time.

Reviewed By: Yuzhen11

Differential Revision: D71647650




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov