### PR TITLE
Removed ROCM ifdef that governs thread count + smem parallel reduction.

### DIFF
--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -146,11 +146,7 @@ Tensor& binary_cross_entropy_backward_out_cuda(const Tensor& grad, const Tensor&
 namespace {
 
 int nll_loss_threads(int64_t nframe){
-#if defined(USE_ROCM)
   return std::clamp(1 << static_cast<int64_t>(std::round(std::log2(nframe/16))), 32, 1024);
-#else
-  return 32;
-#endif
 }
 
 // NOTE(crcrpar): `Byte` support was added for https://github.com/pytorch/pytorch/issues/59765.


### PR DESCRIPTION
#149548 Fixed the arbitrarily missing parallelism for NLL, but they also added an arbritrary #ifdef ROCM guard around this fix to prevent its use on CUDA gpus. There is also a problem with the way the kernel does the reduction from the intermediate shared memory, using only thread 0 walking linearly. This has been changed to a simple parallel reduction algorithm.

Tested changes with `python3 test/test_nn.py` 

```
Ran 3551 tests in 200.554s

OK (skipped=998, expected failures=4)
```

Performance before and after with the script below with an RTX 3090, batch size x axis, time (sec) y axis. This GPU is also used for display graphics and such, so the measurements are pretty noisy, even with 100 samples.

## Before
![before_nll](https://github.com/user-attachments/assets/c19044aa-7bc2-4223-b560-9be7acedef35)

## After ifdef removal
![after_nll](https://github.com/user-attachments/assets/4672f5ca-93b0-4c34-a257-81b2ab364995)

## After Parallel SMEM reduction

![after_reduction](https://github.com/user-attachments/assets/9607b68c-7d9d-4ee0-9f99-8989d134e4fd)


```python
import torch
from matplotlib import pyplot as plt
from torch.nn import functional as F

timing = []
batches=  list(range(32, 4096, 32))

for batch in [32] + batches:
    samples = []
    for _ in range(100):
        probs = torch.rand(batch, 10).cuda()
        labels = torch.randint(0, 10, (batch,)).cuda()
        start = torch.cuda.Event(enable_timing=True)
        end = torch.cuda.Event(enable_timing=True)
        start.record()
        F.nll_loss(probs, labels)
        end.record()
        torch.cuda.synchronize()
        elapsed = start.elapsed_time(end)
        samples.append(elapsed)
    timing.append(sum(samples) / len(samples))
timing = timing[1:]

plt.plot(batches, timing)
plt.show()
```


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd