### PR TITLE
ProcessGroupGloo: support ReduceOp::AVG

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -80,6 +80,11 @@ def simple_reduce_tests(rank, world_size):
             torch.tensor([rank + 1.0]),
             torch.tensor([float(world_size)]),
         ),
+        (
+            c10d.ReduceOp.AVG,
+            torch.tensor([rank + 1.0]),
+            torch.tensor([float((world_size + 1) / 2)]),
+        ),
     ]
 
     # Generate tests for BAND.

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -178,6 +178,7 @@ template <typename T, std::enable_if_t<!std::is_integral_v<T>, int> = 0>
 ReduceFunc toFunction(const ReduceOp& r) {
   switch (r) {
     case ReduceOp::SUM:
+    case ReduceOp::AVG:
       return ReduceFunc(&::gloo::sum<T>);
     case ReduceOp::PRODUCT:
       return ReduceFunc(&::gloo::product<T>);
@@ -193,9 +194,6 @@ ReduceFunc toFunction(const ReduceOp& r) {
       break;
     case ReduceOp::BXOR:
       TORCH_CHECK(false, "Cannot use ReduceOp.BXOR with non-integral dtype");
-      break;
-    case ReduceOp::AVG:
-      TORCH_CHECK(false, "Cannot use ReduceOp.AVG with Gloo");
       break;
     case ReduceOp::PREMUL_SUM:
       TORCH_CHECK(false, "Cannot use ReduceOp.PREMUL_SUM with Gloo");
@@ -245,6 +243,7 @@ template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
 ReduceFunc toFunction(const ReduceOp& r) {
   switch (r) {
     case ReduceOp::SUM:
+    case ReduceOp::AVG:
       return ReduceFunc(&::gloo::sum<T>);
     case ReduceOp::PRODUCT:
       return ReduceFunc(&::gloo::product<T>);
@@ -258,9 +257,6 @@ ReduceFunc toFunction(const ReduceOp& r) {
       return ReduceFunc(&bor<T>);
     case ReduceOp::BXOR:
       return ReduceFunc(&bxor<T>);
-    case ReduceOp::AVG:
-      TORCH_CHECK(false, "Cannot use ReduceOp.AVG with Gloo");
-      break;
     case ReduceOp::PREMUL_SUM:
       TORCH_CHECK(false, "Cannot use ReduceOp.PREMUL_SUM with Gloo");
       break;
@@ -1058,6 +1054,11 @@ class AsyncAllreduceWork : public ProcessGroupGloo::AsyncWork {
     opts.setTag(tag);
     GENERATE_ALL_TYPES(scalarType, setOutputs, opts, tensors);
     gloo::allreduce(opts);
+
+    // Gloo doesn't support AVG so we use SUM + division.
+    if (reduceOp == ReduceOp::AVG) {
+      tensors[0] /= context->size;
+    }
   }
 
   void run() override {
@@ -1666,6 +1667,11 @@ class AsyncReduceWork : public ProcessGroupGloo::AsyncWork {
     opts.setReduceFunction(getFunction(scalarType, reduceOp));
     GENERATE_ALL_TYPES(scalarType, setOutput, opts, tensors[0]);
     gloo::reduce(opts);
+
+    // Gloo doesn't support AVG so we use SUM + division.
+    if (reduceOp == ReduceOp::AVG) {
+      tensors[0] /= context->size;
+    }
   }
 
   void run() override {


### PR DESCRIPTION
This adds AVG support to ProcessGroupGloo to better support FSDP on CPU. I expect there will be more issues but this is easy enough to support in a naive fashion. 

This applies to both reduce and allreduce.

This is a simple SUM + division and may not be the most numerically stable but that's expected. FSDP for low precision data types implements pre/post divide and uses SUM instead.

Test plan:

```
pytest -v test/distributed/test_c10d_gloo.py
```

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @c-p-i-o