### PR TITLE
[inductor] Add the largest matmul tile size to default tuning set

### DIFF
--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -179,6 +179,7 @@ mm_kernel_configs = (
         {"config": (128, 128, 32, 3, 4), "cond": True},
         {"config": (128, 128, 64, 3, 4), "cond": True},
         {"config": (128, 128, 64, 5, 8), "cond": True},
+        {"config": (128, 256, 64, 3, 8), "cond": True},
     ]
     if inductor_config.max_autotune_gemm_search_space != "EXHAUSTIVE"
     else [


### PR DESCRIPTION
While we probably don't want to expand the set of default matmul tunings too much, this is the largest tile size usable by H100 and A100, and is usually the top performing tile size for large matmuls.  E.g. on H100 adding this tile size improves perf of multiplying 8192-square matrices from 600->700 tflops.  (cuBLAS 12.6 gets 780, so Triton still isn't SOTA, but closer)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov