### PR TITLE
[inductor] [bug fix] Enable type promotions in slice_scatter in inductor

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2919,7 +2919,7 @@ def select_scatter(x, src, dim: int, index: int):
     )
 
 
-@register_lowering(aten.slice_scatter, type_promotion_kind=None)
+@register_lowering(aten.slice_scatter, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT)
 def slice_scatter(x, src, dim=0, start=None, end=None, step=1):
     assert x.get_dtype() == src.get_dtype()
     x_loader = x.make_loader()


### PR DESCRIPTION
Fixes #147842. Specifically, enables type promotions when calling `torch.slice_scatter` with tensors of different `dtype` thereby enforcing uniform behaviour in eager mode and inductor compilation mode. 

To test:
`pytest -s -v test/inductor/test_torchinductor.py -k test_slice_scatter_types_promotion`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov