### PR TITLE
Fix `torch.cuda.MemPool()` internal assertion failure when changing devices

### DIFF
--- a/torch/csrc/cuda/MemPool.cpp
+++ b/torch/csrc/cuda/MemPool.cpp
@@ -21,7 +21,8 @@ void THCPMemPool_init(PyObject* module) {
           }))
       .def_property_readonly("id", &::c10::cuda::MemPool::id)
       .def_property_readonly("allocator", &::c10::cuda::MemPool::allocator)
-      .def("use_count", &::c10::cuda::MemPool::use_count);
+      .def("use_count", &::c10::cuda::MemPool::use_count)
+      .def("device", &::c10::cuda::MemPool::device);
   shared_ptr_class_<::c10::cuda::MemPoolContext>(torch_C_m, "_MemPoolContext")
       .def(py::init<c10::cuda::MemPool*>())
       .def_static(

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -1134,6 +1134,7 @@ class MemPool(_MemPool):
 
     def __init__(self, allocator: Optional[_cuda_CUDAAllocator] = None):
         super().__init__(allocator, True)
+        self._device = torch.cuda.current_device()
 
     @property
     def id(self) -> tuple[int, int]:
@@ -1184,6 +1185,7 @@ def use_mem_pool(pool: MemPool, device: Union[Device, int] = None):
     device_index = (
         torch.cuda.current_device() if device is None else _get_device_index(device)
     )
+    assert device_index == pool._device, "MemPool can only be used in the same device as the one it was allocated"
     _cuda_beginAllocateToPool(device_index, pool.id)
     try:
         yield

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -1134,7 +1134,6 @@ class MemPool(_MemPool):
 
     def __init__(self, allocator: Optional[_cuda_CUDAAllocator] = None):
         super().__init__(allocator, True)
-        self._device = torch.cuda.current_device()
 
     @property
     def id(self) -> tuple[int, int]:
@@ -1185,7 +1184,7 @@ def use_mem_pool(pool: MemPool, device: Union[Device, int] = None):
     device_index = (
         torch.cuda.current_device() if device is None else _get_device_index(device)
     )
-    assert device_index == pool._device, "MemPool can only be used in the same device as the one it was allocated"
+    assert device_index == pool.device, "MemPool can only be used in the same device as the one it was allocated"
     _cuda_beginAllocateToPool(device_index, pool.id)
     try:
         yield


### PR DESCRIPTION
Fix https://github.com/pytorch/pytorch/issues/149802

This is just a prototype, and I would like to hear feedbacks, e.g. is this direction OK? or shall we let MemPool to support multi devices?

After feedbacks I will refine the PR, by e.g. making code better, adding tests, etc.
