### PR TITLE
Only print dde partial fx graph for export

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1347,7 +1347,7 @@ class InstructionTranslatorBase(
                     ).print_readable(
                         print_output=False, include_stride=True, include_device=True
                     )
-                    e.partial_fx_graph = readable_graph
+                    e.partial_fx_graph = readable_graph  # type: ignore[attr-defined]
                     raise
 
                 raise

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1342,15 +1342,13 @@ class InstructionTranslatorBase(
                 raise
             except RuntimeError as e:
                 if hasattr(e, "msg") and "Data-dependent" in e.msg:
-                    print(
-                        "\n"
-                        + torch.fx.GraphModule(
-                            self.output.nn_modules, self.output.graph
-                        ).print_readable(
-                            print_output=False, include_stride=True, include_device=True
-                        ),
-                        file=sys.stderr,
+                    readable_graph = torch.fx.GraphModule(
+                        self.output.nn_modules, self.output.graph
+                    ).print_readable(
+                        print_output=False, include_stride=True, include_device=True
                     )
+                    e.partial_fx_graph = readable_graph
+                    raise
 
                 raise
             except Exception as e:

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 import dataclasses
+import sys
 import functools
 import inspect
 import logging
@@ -1096,6 +1097,13 @@ def _log_export_wrapper(fn):
                     message=str(e),
                     flags=_EXPORT_FLAGS,
                 )
+
+            if hasattr(e, 'partial_fx_graph'):
+                print(
+                    e.partial_fx_graph,
+                    file=sys.stderr,
+                )
+
             raise e
         finally:
             _EXPORT_FLAGS = None

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1,11 +1,11 @@
 # mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 import dataclasses
-import sys
 import functools
 import inspect
 import logging
 import re
+import sys
 import time
 import warnings
 from contextlib import contextmanager, nullcontext
@@ -1098,7 +1098,7 @@ def _log_export_wrapper(fn):
                     flags=_EXPORT_FLAGS,
                 )
 
-            if hasattr(e, 'partial_fx_graph'):
+            if hasattr(e, "partial_fx_graph"):
                 print(
                     e.partial_fx_graph,
                     file=sys.stderr,

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -7,7 +7,6 @@ import functools
 import inspect
 import math
 import os
-import sys
 import warnings
 from itertools import chain
 from types import CodeType, FunctionType, ModuleType
@@ -843,14 +842,12 @@ class Tracer(TracerBase):
             self.submodule_paths = None
         except RuntimeError as e:
             if isinstance(e.args[0], str) and "data-dependent" in e.args[0]:
-                print(
-                    "\n"
-                    + self.graph.python_code(
-                        root_module="self",
-                        verbose=True,
-                    ).src,
-                    file=sys.stderr,
-                )
+                partial_fx_graph = self.graph.python_code(
+                    root_module="self",
+                    verbose=True,
+                ).src
+                e.partial_fx_graph = partial_fx_graph
+                raise
 
             raise
         finally:

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -846,7 +846,7 @@ class Tracer(TracerBase):
                     root_module="self",
                     verbose=True,
                 ).src
-                e.partial_fx_graph = partial_fx_graph
+                e.partial_fx_graph = partial_fx_graph  # type: ignore[attr-defined]
                 raise
 
             raise


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149831

Lazos correctly pointed out this doesn't make sense for compile since
we graph break in compile. This results in tons of unwanted user log
spew. We do want this in export though since it's drastiaclly reduced
the support load for DDEs. This PR does the refactor to keep it in
export but remove it from compile

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames