### PR TITLE
Improve error message for CUDAGuardImpl, MPSGuardImpl, XPUGuardImpl

### DIFF
--- a/aten/src/ATen/mps/MPSGuardImpl.h
+++ b/aten/src/ATen/mps/MPSGuardImpl.h
@@ -36,7 +36,10 @@ struct TORCH_API MPSGuardImpl final
   // constructor
   MPSGuardImpl() {}
   explicit MPSGuardImpl(c10::DeviceType t) {
-    TORCH_INTERNAL_ASSERT(t == c10::DeviceType::MPS);
+    TORCH_CHECK(
+        t == DeviceType::MPS,
+        "MPSGuardImpl initialized with non-MPS DeviceType: ",
+        t);
   }
 
   // returns the type
@@ -57,7 +60,7 @@ struct TORCH_API MPSGuardImpl final
   }
 
   void setDevice(Device d) const override {
-    TORCH_INTERNAL_ASSERT(d.is_mps());
+    TORCH_CHECK(d.is_mps(), "Expected a MPS device, but got ", d);
   }
 
   void uncheckedSetDevice(Device d) const noexcept override {

--- a/c10/cuda/impl/CUDAGuardImpl.h
+++ b/c10/cuda/impl/CUDAGuardImpl.h
@@ -25,13 +25,16 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
 
   CUDAGuardImpl() = default;
   explicit CUDAGuardImpl(DeviceType t) {
-    TORCH_INTERNAL_ASSERT(t == DeviceType::CUDA);
+    TORCH_INTERNAL_ASSERT(
+        t == DeviceType::CUDA,
+        "CUDAGuardImpl initialized with non-CUDA DeviceType: ",
+        t);
   }
   DeviceType type() const override {
     return DeviceType::CUDA;
   }
   Device exchangeDevice(Device d) const override {
-    TORCH_INTERNAL_ASSERT(d.is_cuda());
+    TORCH_INTERNAL_ASSERT(d.is_cuda(), "Expected a CUDA device, but got ", d);
     auto old_device_index = c10::cuda::ExchangeDevice(d.index());
     return Device(DeviceType::CUDA, old_device_index);
   }
@@ -50,7 +53,7 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     return Device(DeviceType::CUDA, device);
   }
   void setDevice(Device d) const override {
-    TORCH_INTERNAL_ASSERT(d.is_cuda());
+    TORCH_INTERNAL_ASSERT(d.is_cuda(), "Expected a CUDA device, but got ", d);
     C10_CUDA_CHECK(c10::cuda::SetDevice(d.index()));
   }
   void uncheckedSetDevice(Device d) const noexcept override {

--- a/c10/cuda/impl/CUDAGuardImpl.h
+++ b/c10/cuda/impl/CUDAGuardImpl.h
@@ -25,7 +25,7 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
 
   CUDAGuardImpl() = default;
   explicit CUDAGuardImpl(DeviceType t) {
-    TORCH_INTERNAL_ASSERT(
+    TORCH_CHECK(
         t == DeviceType::CUDA,
         "CUDAGuardImpl initialized with non-CUDA DeviceType: ",
         t);
@@ -34,7 +34,7 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     return DeviceType::CUDA;
   }
   Device exchangeDevice(Device d) const override {
-    TORCH_INTERNAL_ASSERT(d.is_cuda(), "Expected a CUDA device, but got ", d);
+    TORCH_CHECK(d.is_cuda(), "Expected a CUDA device, but got ", d);
     auto old_device_index = c10::cuda::ExchangeDevice(d.index());
     return Device(DeviceType::CUDA, old_device_index);
   }
@@ -53,7 +53,7 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     return Device(DeviceType::CUDA, device);
   }
   void setDevice(Device d) const override {
-    TORCH_INTERNAL_ASSERT(d.is_cuda(), "Expected a CUDA device, but got ", d);
+    TORCH_CHECK(d.is_cuda(), "Expected a CUDA device, but got ", d);
     C10_CUDA_CHECK(c10::cuda::SetDevice(d.index()));
   }
   void uncheckedSetDevice(Device d) const noexcept override {

--- a/c10/xpu/impl/XPUGuardImpl.h
+++ b/c10/xpu/impl/XPUGuardImpl.h
@@ -17,7 +17,8 @@ struct XPUGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   XPUGuardImpl() = default;
 
   explicit XPUGuardImpl(DeviceType t) {
-    TORCH_INTERNAL_ASSERT(t == kXPU);
+    TORCH_CHECK(
+        t == kXPU, "XPUGuardImpl initialized with non-XPU DeviceType: ", t);
   }
 
   DeviceType type() const override {
@@ -25,7 +26,7 @@ struct XPUGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   }
 
   Device exchangeDevice(Device d) const override {
-    TORCH_INTERNAL_ASSERT(d.is_xpu());
+    TORCH_CHECK(d.is_xpu(), "Expected a XPU device, but got ", d);
     const auto old_device_index = c10::xpu::exchange_device(d.index());
     return Device(kXPU, old_device_index);
   }
@@ -36,7 +37,7 @@ struct XPUGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   }
 
   void setDevice(Device d) const override {
-    TORCH_INTERNAL_ASSERT(d.is_xpu());
+    TORCH_CHECK(d.is_xpu(), "Expected a XPU device, but got ", d);
     c10::xpu::set_device(d.index());
   }
 


### PR DESCRIPTION
Fixes #149822

Will get:

```
RuntimeError: t == DeviceType::CUDA INTERNAL ASSERT FAILED at "/home/jyh/workspace/pytorch/c10/cuda/impl/CUDAGuardImpl.h":28, please report a bug to PyTorch. CUDAGuardImpl initialized with non-CUDA DeviceType: cpu
```