### PR TITLE
[ROCm] Update libamd_comgr.so file in triton wheel build

### DIFF
--- a/.github/scripts/amd/package_triton_wheel.sh
+++ b/.github/scripts/amd/package_triton_wheel.sh
@@ -61,10 +61,14 @@ fi
 ROCM_SO=(
     "${libamdhip}"
     "libhsa-runtime64.so.1"
-    "libamd_comgr.so.2"
     "libdrm.so.2"
     "libdrm_amdgpu.so.1"
 )
+if [[ $ROCM_INT -ge 60400 ]]; then
+    ROCM_SO+=("libamd_comgr.so.3")
+else
+    ROCM_SO+=("libamd_comgr.so.2")
+fi
 
 if [[ $ROCM_INT -ge 60100 ]]; then
     ROCM_SO+=("librocprofiler-register.so.0")


### PR DESCRIPTION
In ROCm 6.4 and newer, when building Triton in the Triton-ROCm wheel build flow, newer releases of ROCm no longer have **libamd_comgr.so.2** as the .so file has been updated to **libamd_comgr.so.3** in ROCm 6.4 and newer. We conditionalize on which ROCm the wheel build is for, and choose the .so accordingly.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd