### PR TITLE
[MTIA] [Triton] Set codename of MTIA device in triton heuristics

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -534,9 +534,18 @@ class CachingAutotuner(KernelInterface):
             ),
         )
 
+        if self.device_props.type == "mtia":
+            from mtia.host_runtime.torch_mtia.acc_flags import (  # type: ignore[import-not-found]
+                build_codename,
+            )
+
+            arch = build_codename()
+        else:
+            arch = compile_meta["cc"]
+
         target = GPUTarget(
             compile_meta["device_type"],
-            compile_meta["cc"],
+            arch,
             cc_warp_size(compile_meta["cc"]),
         )
 


### PR DESCRIPTION
Summary: Triton-MTIA expects the codename of the device as the arch when querying the module map, not the compute capability. This diff gets rid of the following error: `No libdevice is provided for arch (0, 0)`

Test Plan: CI

Reviewed By: Myrthan

Differential Revision: D70072095




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov