### PR TITLE
Configure `cuda.cmake` to ensure consistent behavior downstream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1284,6 +1284,9 @@ if(USE_CUDA OR USE_ROCM)
 
 endif()
 
+configure_file(${PROJECT_SOURCE_DIR}/cmake/public/cuda.cmake.in
+               ${PROJECT_BINARY_DIR}/cmake/public/cuda.cmake @ONLY)
+
 # Note(jiayq): when building static libraries, all PRIVATE dependencies will
 # also become interface libraries, and as a result if there are any dependency
 # libraries that are not exported, the following install export script will
@@ -1298,7 +1301,7 @@ if(BUILD_SHARED_LIBS)
     DESTINATION share/cmake/Caffe2
     COMPONENT dev)
   install(
-    FILES ${PROJECT_SOURCE_DIR}/cmake/public/cuda.cmake
+    FILES ${PROJECT_BINARY_DIR}/cmake/public/cuda.cmake
           ${PROJECT_SOURCE_DIR}/cmake/public/xpu.cmake
           ${PROJECT_SOURCE_DIR}/cmake/public/glog.cmake
           ${PROJECT_SOURCE_DIR}/cmake/public/gflags.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -851,6 +851,9 @@ if(MSVC)
   append_cxx_flag_if_supported("/utf-8" CMAKE_CXX_FLAGS)
 endif()
 
+configure_file(${PROJECT_SOURCE_DIR}/cmake/public/cuda.cmake.in
+               ${PROJECT_BINARY_DIR}/cmake/public/cuda.cmake @ONLY)
+
 # Note for ROCM platform: 1. USE_ROCM is always ON until
 # include(cmake/Dependencies.cmake) 2. USE_CUDA will become OFF during
 # re-configuration Truth Table: CUDA 1st pass: USE_CUDA=True;USE_ROCM=True,
@@ -1283,9 +1286,6 @@ if(USE_CUDA OR USE_ROCM)
   # interface as well.
 
 endif()
-
-configure_file(${PROJECT_SOURCE_DIR}/cmake/public/cuda.cmake.in
-               ${PROJECT_BINARY_DIR}/cmake/public/cuda.cmake @ONLY)
 
 # Note(jiayq): when building static libraries, all PRIVATE dependencies will
 # also become interface libraries, and as a result if there are any dependency

--- a/c10/cuda/CMakeLists.txt
+++ b/c10/cuda/CMakeLists.txt
@@ -3,7 +3,7 @@
 # C10 CUDA is a minimal library, but it does depend on CUDA.
 
 include(../../cmake/public/utils.cmake)
-include(${PROJECT_BINARY_DIR}/cmake/public/cuda.cmake)
+include(${PROJECT_BINARY_DIR}/../cmake/public/cuda.cmake)
 
 # ---[ Configure macro file.
 set(C10_CUDA_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS}) # used in cmake_macros.h.in

--- a/c10/cuda/CMakeLists.txt
+++ b/c10/cuda/CMakeLists.txt
@@ -3,7 +3,7 @@
 # C10 CUDA is a minimal library, but it does depend on CUDA.
 
 include(../../cmake/public/utils.cmake)
-include(../../cmake/public/cuda.cmake)
+include(${PROJECT_BINARY_DIR}/cmake/public/cuda.cmake)
 
 # ---[ Configure macro file.
 set(C10_CUDA_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS}) # used in cmake_macros.h.in

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -41,7 +41,7 @@ if(USE_CUDA)
   set(CAFFE2_USE_CUSPARSELT ${USE_CUSPARSELT})
   set(CAFFE2_USE_CUFILE ${USE_CUFILE})
   set(CAFFE2_USE_NVRTC ${USE_NVRTC})
-  include(${CMAKE_CURRENT_LIST_DIR}/public/cuda.cmake)
+  include(${PROJECT_BINARY_DIR}/cmake/public/cuda.cmake)
   if(CAFFE2_USE_CUDA)
     # A helper variable recording the list of Caffe2 dependent libraries
     # torch::cudart is dealt with separately, due to CUDA_ADD_LIBRARY

--- a/cmake/public/cuda.cmake.in
+++ b/cmake/public/cuda.cmake.in
@@ -170,7 +170,7 @@ else()
 endif()
 
 # nvToolsExt
-if(USE_SYSTEM_NVTX)
+if(@USE_SYSTEM_NVTX@)
   find_path(nvtx3_dir NAMES nvtx3 PATHS ${CUDA_INCLUDE_DIRS})
 else()
   find_path(nvtx3_dir NAMES nvtx3 PATHS "${PROJECT_SOURCE_DIR}/third_party/NVTX/c/include" NO_DEFAULT_PATH)

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -126,7 +126,7 @@ if(USE_ITT)
 endif()
 
 if(USE_CUDA)
-    include(${TORCH_ROOT}/cmake/public/cuda.cmake)
+    include(${PROJECT_BINARY_DIR}/cmake/public/cuda.cmake)
     append_filelist("libtorch_python_cuda_core_sources" TORCH_PYTHON_SRCS)
     list(APPEND TORCH_PYTHON_SRCS ${GENERATED_THNN_CXX_CUDA})
 


### PR DESCRIPTION
The current implementation of `cuda.cmake` relies on the option variable `USE_SYSTEM_NVTX`:

https://github.com/pytorch/pytorch/blob/9bae904cb47b2d896f4653f751f0526379823606/cmake/public/cuda.cmake#L173-L177

which is only set during the PyTorch build process:

https://github.com/pytorch/pytorch/blob/9bae904cb47b2d896f4653f751f0526379823606/CMakeLists.txt#L466

This can cause issues when the file is installed as part of a package, as downstream users have no control over this variable:

https://github.com/pytorch/pytorch/blob/9bae904cb47b2d896f4653f751f0526379823606/CMakeLists.txt#L1300-L1311

When `find_package(Torch CONFIG)` is called downstream, `cuda.cmake` is transitively included, but the value of `USE_SYSTEM_NVTX` is not propagated. This can lead to inconsistent behavior, as reported in https://github.com/pytorch/pytorch/issues/139108 and https://github.com/pytorch/pytorch/issues/147220. In one case, a package manager had to apply a patch to hardcode `USE_SYSTEM_NVTX=TRUE` to make it work with system nvtx3: https://github.com/conda-forge/pytorch-cpu-feedstock/pull/377

To address this issue, I propose that we either decouple `cuda.cmake` from option variables defined during the PyTorch build or configure the file with the chosen option when building PyTorch. This PR presents a minimal solution by configuring `cuda.cmake` to ensure consistent behavior downstream.

Alternative solutions are welcome!