### PR TITLE
Allow rebuild of triton on workflow_dispatch

### DIFF
--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -14,6 +14,7 @@ on:
       - .github/ci_commit_pins/triton.txt
       - .ci/docker/ci_commit_pins/triton.txt
       - .ci/docker/ci_commit_pins/triton-xpu.txt
+  workflow_dispatch:
   pull_request:
     paths:
       - .github/workflows/build-triton-wheel.yml


### PR DESCRIPTION
Allows to rebuild triton from main.
latest triton build failed : https://github.com/pytorch/pytorch/actions/runs/13984299781/job/39298288914
The cause PR was reverted: https://github.com/pytorch/pytorch/pull/148419
We need to rebuild the triton now
