### PR TITLE
Fix cusparseLt.so preload without nvidia directory

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -287,8 +287,6 @@ def _preload_cuda_deps(lib_folder: str, lib_name: str) -> None:
     lib_path = None
     for path in sys.path:
         nvidia_path = os.path.join(path, "nvidia")
-        if not os.path.exists(nvidia_path):
-            continue
         candidate_lib_paths = glob.glob(
             os.path.join(nvidia_path, lib_folder, "lib", lib_name)
         )


### PR DESCRIPTION
Since 2b241a8206843f43f0568b7b65473ebb593c4740, the `nvidia`
subdirectory existing is not enough to skip the rest of this logic since
other paths are now considered below.
