### PR TITLE
Use variadic length tuple for `torch.masked.DimOrDims`

### DIFF
--- a/torch/masked/_ops.py
+++ b/torch/masked/_ops.py
@@ -14,11 +14,11 @@ from torch.masked.maskedtensor.creation import as_masked_tensor
 if TYPE_CHECKING:
     from torch.types import _dtype as DType
 
-    DimOrDims = Optional[Union[int, tuple[int], list[int]]]
+    DimOrDims = Optional[Union[int, tuple[int, ...], list[int]]]
 else:
     # The JIT doesn't understand Union, nor torch.dtype here
     DType = int
-    DimOrDims = Optional[tuple[int]]
+    DimOrDims = Optional[tuple[int, ...]]
 
 
 __all__: list[str] = []


### PR DESCRIPTION
`tuple[int]` means only a tuple of length 1, which is not what was intended.

```python
loss = torch.masked.mean(loss, mask=mask, dim=(-1, -2))  # Argument of type "tuple[Literal[-1], Literal[-2]]" cannot be assigned to parameter "dim" of type "DimOrDims"
```