### PR TITLE
[Async TP] Fuse matmul-reduce-scatters when reduce scatters have multiple users, and save fused node for backward instead of reduce_scatter node

### DIFF
--- a/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
+++ b/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
@@ -492,44 +492,6 @@ class MicroPipelineTPTest(TestCase):
                 gm.graph,
             )
 
-    @skipIfRocm
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
-    @fresh_inductor_cache()
-    def test_unsuccessful_fusion(self):
-        group = dist.group.WORLD
-        scatter_dim = 0
-
-        def no_matching_pattern(
-            A: torch.Tensor,
-            B: torch.Tensor,
-        ) -> torch.Tensor:
-            """
-            Performs 'reshape -> reciprocal -> mm -> reshape -> reduce scatter' pattern,
-            so the extra 'reciprocal' op in the middle should cause pattern matching to fail.
-            """
-            out_shape = [*A.shape[:-1], B.shape[-1]]
-            A = A.reshape(-1, A.shape[-1])
-
-            # insert extra op after reshape that will cause pattern matching to fail
-            A = torch.reciprocal(A)
-
-            C = A @ B
-            C = C.view(out_shape)
-            return reduce_scatter_tensor(C, "sum", scatter_dim, group)
-
-        A = torch.rand(2, 16, 32, device="cuda").to(torch.bfloat16)
-        B = torch.rand(16, 32, device="cuda").to(torch.bfloat16).T
-
-        gm = _make_post_grad_fx(no_matching_pattern, A, B)
-
-        with _test_mode():
-            self.assertRaisesRegex(
-                AssertionError,
-                "no successful fusions of matul-reduce-scatters",
-                micro_pipeline_tp_pass,
-                gm.graph,
-            )
-
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @parametrize("shard_dim", [0, 1])
     @fresh_inductor_cache()


### PR DESCRIPTION
Fixes #149876

## Stack
- [previous PR in stack] https://github.com/pytorch/pytorch/pull/149247

## TL;DR
This PR implements support in async TP for saving the reduce-scatter result for backward, which previously would break the torchtitan AC policies: no AC, per op SAC, and per layer SAC.

## Context
In torchtitan's LLama3 per op SAC policy, we want to save the output of `reduce_scatter` ops for backward, which is useful for TP. The reduce_scatter op is also saved for No AC (since all activations are saved) and per layer SAC (since we save the activations for N full layers, which do contain reduce-scatters for TP.

However, doing this causes incompatibility with Async TP for the AC policies above, for 2 reasons:

1) The graph pattern matching specifically only matches on reduce scatter nodes with 1 user, but reduce_scatter nodes saved for backwards will have 2 users (the 2nd one being the return/output node, which saves it for backward).

2) The subgraph replacement logic which replaces the users of the `wait_tensor` after the reduce-scatter with the new fused node has no mechanism to save the fused_node for backward instead of the reduce-scatter node. This means we cannot directly replace the subgraph, since we can't delete nodes which still have users (in this case, the output node is still using the reduce-scatter node).

To fix this, we do 2 things:

1) Add additional pattern matching logic to also match reduce-scatter nodes with 2 users, so we also perform fusion when reduce-scatter is saved for backward.

2) When replacing the subgraph with the fused node, detect if the reduce-scatter was saved for backward, and if so, save the result of the fused node for backward instead. This enables us to properly erase the subgraph and prevent the memory leak which occurred in #149876

## Other changes 
- Continue to throw an error if we don't find any candidate all-gathers or reduce-scatters for fusion (since TP should have both) but DON'T throw an error if we don't fuse any matmul-reduce-scatters. This is because I've found there are actually valid graphs where we do fuse reduce scatters in the forward graph but not the backward graph (in the backward pass there are reduce-scatters but the producer op is an "add" not a mm/scaled_mm).

## Test plan

1. All unit tests are passing
2. Visualized the graphs and verified the fusion is occurring properly.
3. Verified via manual torchtitan runs there is no memory leak / OOM occurring anymore.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov