### PR TITLE
[Bugfix] Add handling for buffer overrides

### DIFF
--- a/test/dynamo/test_buffers_override.py
+++ b/test/dynamo/test_buffers_override.py
@@ -1,21 +1,21 @@
 # Owner(s): ["module: dynamo"]
 
-from typing import Dict
 import torch
-import torch.nn as nn
 import torch._dynamo.test_case
+import torch.nn as nn
 
-class TestSimpleRepro(torch._dynamo.test_case.TestCase):
+
+class TestBuffersOverride(torch._dynamo.test_case.TestCase):
     def test_buffers_override(self):
         class SomeModel(nn.Module):
             def __init__(self):
-                super(SomeModel, self).__init__()
+                super().__init__()
                 # Override buffers; should not cause breakage
-                # this is because we use `named_buffers` for 
+                # this is because we use `named_buffers` for
                 # static marking
-                self.register_buffer("A", torch.ones(3,3))
+                self.register_buffer("A", torch.ones(3, 3))
                 self.buffers = []
-            
+
             def forward(self):
                 return self.A * torch.zeros(1, 1)
 
@@ -27,13 +27,13 @@ class TestSimpleRepro(torch._dynamo.test_case.TestCase):
     def test_named_buffers_override(self):
         class SomeModel(nn.Module):
             def __init__(self):
-                super(SomeModel, self).__init__()
+                super().__init__()
                 # Override buffers; should not cause breakage
-                # but skip the marking static here since 
+                # but skip the marking static here since
                 # named_buffers is overriden
-                self.register_buffer("B", torch.ones(3,3))
+                self.register_buffer("B", torch.ones(3, 3))
                 self.named_buffers = []
-            
+
             def forward(self):
                 return self.B * torch.zeros(1, 1)
 

--- a/test/dynamo/test_buffers_override.py
+++ b/test/dynamo/test_buffers_override.py
@@ -1,0 +1,49 @@
+# Owner(s): ["module: dynamo"]
+
+from typing import Dict
+import torch
+import torch.nn as nn
+import torch._dynamo.test_case
+
+class TestSimpleRepro(torch._dynamo.test_case.TestCase):
+    def test_buffers_override(self):
+        class SomeModel(nn.Module):
+            def __init__(self):
+                super(SomeModel, self).__init__()
+                # Override buffers; should not cause breakage
+                # this is because we use `named_buffers` for 
+                # static marking
+                self.register_buffer("A", torch.ones(3,3))
+                self.buffers = []
+            
+            def forward(self):
+                return self.A * torch.zeros(1, 1)
+
+        model = SomeModel().to(torch.device("cpu"))
+        compiled_model = torch.compile(model)
+        self.assertEqual(compiled_model.A, torch.ones(3, 3))
+        compiled_model()
+
+    def test_named_buffers_override(self):
+        class SomeModel(nn.Module):
+            def __init__(self):
+                super(SomeModel, self).__init__()
+                # Override buffers; should not cause breakage
+                # but skip the marking static here since 
+                # named_buffers is overriden
+                self.register_buffer("B", torch.ones(3,3))
+                self.named_buffers = []
+            
+            def forward(self):
+                return self.B * torch.zeros(1, 1)
+
+        model = SomeModel().to(torch.device("cpu"))
+        compiled_model = torch.compile(model)
+        self.assertEqual(compiled_model.B, torch.ones(3, 3))
+        compiled_model()
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1592,11 +1592,18 @@ class VariableBuilder:
                 # / named buffers
                 # NOTE: This is not likely to happen but worth guarding to avoid
                 # exception
-                if value.named_parameters == og_module_named_parameters_fn_ptr:
+                if (
+                    callable(value.named_parameters)
+                    and value.named_parameters.__func__
+                    == og_module_named_parameters_fn_ptr
+                ):
                     for _, p in value.named_parameters():
                         self.mark_static_input(p, guard=freezing)
 
-                if value.named_buffers == og_module_named_buffers_fn_ptr:
+                if (
+                    callable(value.named_buffers)
+                    and value.named_buffers.__func__ == og_module_named_buffers_fn_ptr
+                ):
                     for _, b in value.named_buffers():
                         self.mark_static_input(b, guard=freezing)
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1595,14 +1595,14 @@ class VariableBuilder:
                 if (
                     callable(value.named_parameters)
                     and value.named_parameters.__func__
-                    == og_module_named_parameters_fn_ptr
+                    is og_module_named_parameters_fn_ptr
                 ):
                     for _, p in value.named_parameters():
                         self.mark_static_input(p, guard=freezing)
 
                 if (
                     callable(value.named_buffers)
-                    and value.named_buffers.__func__ == og_module_named_buffers_fn_ptr
+                    and value.named_buffers.__func__ is og_module_named_buffers_fn_ptr
                 ):
                     for _, b in value.named_buffers():
                         self.mark_static_input(b, guard=freezing)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -385,6 +385,8 @@ ITERTOOLS_TYPE_IDS: frozenset[int] = frozenset(
 ITERTOOLS_POLYFILLED_TYPE_IDS: set[int] = set()
 
 # Capture fn pointer at import time
+# This is to guard against trying to mark the iterated tensors
+# as static in case user overrides fn ptr
 og_module_named_buffers_fn_ptr = torch.nn.Module.named_buffers
 og_module_named_parameters_fn_ptr = torch.nn.Module.named_parameters
 


### PR DESCRIPTION
Fixes #139167 

This PR:
* uses `named_buffers` to mark static 
* Checks that `named_buffers` is of expected type (callable, iterator) before trying to iterate over; if not, we skip this pass

These changes fix the previous errors in dynamo causing to crash (as shown in issue above)

### Unit Test
```
python test/dynamo/test_buffers_override.py
```

Results in:
```
.
----------------------------------------------------------------------
Ran 2 tests in 5.344s

OK
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames