### PR TITLE
Add smoke test to validate pypi env version vs torch complied and installed versions of nccl and cudnn

### DIFF
--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import Optional
 from tempfile import NamedTemporaryFile
 
 import torch
@@ -194,6 +195,29 @@ def test_cuda_gds_errors_captured() -> None:
             "Expected cuFileHandleRegister failed RuntimeError but have not received!"
         )
 
+def find_pypi_package_version(package : str) -> Optional[str]:
+    from importlib import metadata
+    dists = metadata.distributions()
+    for dist in dists:
+        if dist.metadata["Name"].startswith(package):
+            return dist.version
+    return None
+
+def cudnn_to_version_str(cudnn_version: int) -> str:
+    patch = int(cudnn_version % 10)
+    minor = int((cudnn_version / 100) % 100)
+    major = int((cudnn_version / 10000) % 10000)
+    return F"{major}.{minor}.{patch}"
+
+def compare_pypi_to_torch_versions(package: str, pypi_version: str, torch_version: str) -> None:
+    if pypi_version is None:
+        raise RuntimeError(f"Can't find {package} in PyPI for Torch: {torch_version}")
+    if pypi_version.startswith(torch_version):
+        print(f"Found matching {package}. Torch: {torch_version} PyPI {pypi_version}")
+    else:
+        raise RuntimeError(
+            f"Wrong {package} version. Torch: {torch_version} PyPI: {pypi_version}"
+        )
 
 def smoke_test_cuda(
     package: str, runtime_error_check: str, torch_compile_check: str
@@ -226,10 +250,11 @@ def smoke_test_cuda(
             raise RuntimeError(
                 f"Wrong CUDA version. Loaded: {torch.version.cuda} Expected: {gpu_arch_ver}"
             )
+
         print(f"torch cuda: {torch.version.cuda}")
-        # todo add cudnn version validation
-        print(f"torch cudnn: {torch.backends.cudnn.version()}")
         print(f"cuDNN enabled? {torch.backends.cudnn.enabled}")
+        torch_cudnn_version = cudnn_to_version_str(torch.backends.cudnn.version())
+        compare_pypi_to_torch_versions("cudnn", find_pypi_package_version("nvidia-cudnn"), torch_cudnn_version)
 
         torch.cuda.init()
         print("CUDA initialized successfully")
@@ -239,7 +264,8 @@ def smoke_test_cuda(
 
         # nccl is availbale only on Linux
         if sys.platform in ["linux", "linux2"]:
-            print(f"torch nccl version: {torch.cuda.nccl.version()}")
+            torch_nccl_version = '.'.join(str(v) for v in torch.cuda.nccl.version())
+            compare_pypi_to_torch_versions("nccl", find_pypi_package_version("nvidia-nccl"), torch_nccl_version)
 
         if runtime_error_check == "enabled":
             test_cuda_runtime_errors_captured()

--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -6,8 +6,8 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
 from tempfile import NamedTemporaryFile
+from typing import Optional
 
 import torch
 import torch._dynamo
@@ -195,21 +195,27 @@ def test_cuda_gds_errors_captured() -> None:
             "Expected cuFileHandleRegister failed RuntimeError but have not received!"
         )
 
-def find_pypi_package_version(package : str) -> Optional[str]:
+
+def find_pypi_package_version(package: str) -> Optional[str]:
     from importlib import metadata
+
     dists = metadata.distributions()
     for dist in dists:
         if dist.metadata["Name"].startswith(package):
             return dist.version
     return None
 
+
 def cudnn_to_version_str(cudnn_version: int) -> str:
     patch = int(cudnn_version % 10)
     minor = int((cudnn_version / 100) % 100)
     major = int((cudnn_version / 10000) % 10000)
-    return F"{major}.{minor}.{patch}"
+    return f"{major}.{minor}.{patch}"
 
-def compare_pypi_to_torch_versions(package: str, pypi_version: str, torch_version: str) -> None:
+
+def compare_pypi_to_torch_versions(
+    package: str, pypi_version: str, torch_version: str
+) -> None:
     if pypi_version is None:
         raise RuntimeError(f"Can't find {package} in PyPI for Torch: {torch_version}")
     if pypi_version.startswith(torch_version):
@@ -218,6 +224,7 @@ def compare_pypi_to_torch_versions(package: str, pypi_version: str, torch_versio
         raise RuntimeError(
             f"Wrong {package} version. Torch: {torch_version} PyPI: {pypi_version}"
         )
+
 
 def smoke_test_cuda(
     package: str, runtime_error_check: str, torch_compile_check: str
@@ -254,7 +261,9 @@ def smoke_test_cuda(
         print(f"torch cuda: {torch.version.cuda}")
         print(f"cuDNN enabled? {torch.backends.cudnn.enabled}")
         torch_cudnn_version = cudnn_to_version_str(torch.backends.cudnn.version())
-        compare_pypi_to_torch_versions("cudnn", find_pypi_package_version("nvidia-cudnn"), torch_cudnn_version)
+        compare_pypi_to_torch_versions(
+            "cudnn", find_pypi_package_version("nvidia-cudnn"), torch_cudnn_version
+        )
 
         torch.cuda.init()
         print("CUDA initialized successfully")
@@ -264,8 +273,10 @@ def smoke_test_cuda(
 
         # nccl is availbale only on Linux
         if sys.platform in ["linux", "linux2"]:
-            torch_nccl_version = '.'.join(str(v) for v in torch.cuda.nccl.version())
-            compare_pypi_to_torch_versions("nccl", find_pypi_package_version("nvidia-nccl"), torch_nccl_version)
+            torch_nccl_version = ".".join(str(v) for v in torch.cuda.nccl.version())
+            compare_pypi_to_torch_versions(
+                "nccl", find_pypi_package_version("nvidia-nccl"), torch_nccl_version
+            )
 
         if runtime_error_check == "enabled":
             test_cuda_runtime_errors_captured()


### PR DESCRIPTION
Followup after nccl update to validate both cudnn and nccl versions in nightly and release pipelines.

Tested on local dev machine, output.
Success:
```
Found matching cudnn. Torch: 9.5.1 PyPI 9.5.1.17
Found matching nccl. Torch: 2.25.1 PyPI 2.25.1
```

Failure:
```
Traceback (most recent call last):
  File "test1.py", line 29, in <module>
    compare_pypi_to_torch_versions("nccl", find_pypi_package_version("nvidia-nccl"), torch_nccl_version)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/test1.py", line 24, in compare_pypi_to_torch_versions
    raise RuntimeError(
        f"Wrong {package} version. Torch: {torch_version} PyPI: {pypi_version}"
    )
RuntimeError: Wrong nccl version. Torch: 2.25.1 PyPI: 2.26.2
```