### PR TITLE
[CI] Add MacOS-M2-15 as MPS test target on trunk

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -109,6 +109,7 @@ jobs:
         { include: [
           { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-13" },
           { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-14" },
+          { config: "mps", shard: 1, num_shards: 1, runner: "macos-m2-15" },
         ]}
     secrets: inherit
 


### PR DESCRIPTION
Now that we have runners allocated by AWS
