### PR TITLE
[BE][CI] Update actionlint to 1.7.7

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -445,8 +445,6 @@ jobs:
       - name: Check NVIDIA driver installation step
         if: failure() && steps.install-nvidia-driver.outcome && steps.install-nvidia-driver.outcome != 'skipped'
         shell: bash
-        env:
-          RUNNER_WORKSPACE: ${{ runner.workspace }}
         run: |
           set +e
           set -x

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -80,7 +80,7 @@ jobs:
           path: ${{ env.PT_RELEASE_FILE }}
       - name: Set output
         id: release_name
-        run: echo "::set-output name=pt_release_name::${{ env.PT_RELEASE_NAME }}.tar.gz"
+        run: echo "name=pt_release_name::${{ env.PT_RELEASE_NAME }}.tar.gz" >> "${GITHUB_OUTPUT}"
 
   upload_source_code_to_s3:
     if: ${{ github.repository == 'pytorch/pytorch' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && contains(github.ref, 'rc') }}

--- a/.github/workflows/target-determination-indexer.yml
+++ b/.github/workflows/target-determination-indexer.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           # detached container should get cleaned up by teardown_ec2_linux
           container_name=$(docker run \
-            ${GPU_FLAG:-} \
+            "${GPU_FLAG:-}" \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e AWS_DEFAULT_REGION \
             --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \

--- a/tools/linter/adapters/s3_init_config.json
+++ b/tools/linter/adapters/s3_init_config.json
@@ -36,16 +36,16 @@
     },
     "actionlint": {
         "Darwin-i386": {
-            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/actionlint/1.6.21/Darwin_amd64/actionlint",
-            "hash": "b354db83815384d3c3a07f68f44b30cb0a70899757a0d185d7322de9952e8813"
+            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/actionlint/1.7.7/Darwin_amd64/actionlint",
+            "hash": "996affd492c57441c5ecfe00dedaef1fde056872d242c0cf7cc15de058d59d03"
         },
         "Darwin-arm": {
-            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/actionlint/1.6.21/Darwin_arm64/actionlint",
-            "hash": "019f2a4a72cdadd7a67bec067399902e026a24e630cbf9ca46d5fb4dc20ef8b2"
+            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/actionlint/1.7.7/Darwin_arm64/actionlint",
+            "hash": "00aba386d026da33be6e85dd5a46d7af4dd9e4d6cbdb02335f4b267162fd2d9e"
         },
         "Linux": {
-            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/actionlint/1.6.21/Linux_arm64/actionlint",
-            "hash": "025ac157db121b33971ef24af72d73d71cda3cb1e3a94795bb2708ef4032ca76"
+            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/actionlint/1.7.7/Linux_x86_64/actionlint",
+            "hash": "9f7dedb4e23f89f2922073d1a6720405b7b520d4f5832ebb96f0d55a2958886c"
         }
     },
     "bazel": {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149919
* #149922
* #149918
* #149917

- fix anti-pattern started by https://github.com/pytorch/pytorch/pull/81922 when x86 actionlint binaries were placed in Linux-arm64 folder
- Fix renaming lint violations, namely
```
>>> Lint for .github/workflows/_linux-test.yml:

  Error (ACTIONLINT) [expression]
    property "workspace" is not defined in object type {arch: string; debug:
    string; environment: string; name: string; os: string; temp: string;
    tool_cache: string}

        446  |        if: failure() && steps.install-nvidia-driver.outcome && steps.install-nvidia-driver.outcome != 'skipped'
        447  |        shell: bash
        448  |        env:
    >>> 449  |          RUNNER_WORKSPACE: ${{ runner.workspace }}
        450  |        run: |
        451  |          set +e
        452  |          set -x



>>> Lint for .github/workflows/create_release.yml:

  Error (ACTIONLINT) [deprecated-commands]
    workflow command "set-output" was deprecated. use `echo "{name}={value}"
    >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-
    workflows/workflow-commands-for-github-actions

         80  |          path: ${{ env.PT_RELEASE_FILE }}
         81  |      - name: Set output
         82  |        id: release_name
    >>>  83  |        run: echo "::set-output name=pt_release_name::${{ env.PT_RELEASE_NAME }}.tar.gz"
         84  |
         85  |  upload_source_code_to_s3:
         86  |    if: ${{ github.repository == 'pytorch/pytorch' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && contains(github.ref, 'rc') }}



>>> Lint for .github/workflows/target-determination-indexer.yml:

  Error (ACTIONLINT) [shellcheck]
    shellcheck reported issue in this script: SC2086:info:3:3: Double quote to
    prevent globbing and word splitting

         98  |          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
         99  |          GITHUB_RUN_ID: ${{ github.run_id }}
        100  |          AWS_DEFAULT_REGION: us-east-1
    >>> 101  |        run: |
        102  |          # detached container should get cleaned up by teardown_ec2_linux
        103  |          container_name=$(docker run \
        104  |            ${GPU_FLAG:-} \
```