### PR TITLE
Make `Adam`, `AdamW` work with nonzero-dim Tensor betas

### DIFF
--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -84,6 +84,7 @@ class Adam(Optimizer):
                 )
             if betas[1].numel() != 1:
                 raise ValueError("Tensor betas[1] must be 1-element")
+        betas = tuple(map(_to_scalar, betas))
 
         defaults = {
             "lr": lr,

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -102,8 +102,9 @@ AdamW.__doc__ = (
         lr (float, Tensor, optional): learning rate (default: 1e-3). A tensor LR
             is not yet supported for all our implementations. Please use a float
             LR if you are not also specifying fused=True or capturable=True.
-        betas (Tuple[float, float], optional): coefficients used for computing
-            running averages of gradient and its square (default: (0.9, 0.999))
+        betas (tuple[Union[float, Tensor], Union[float, Tensor]], optional):
+            coefficients used for computing running averages of gradient and
+            its square. If a tensor is provided, must be 1-element. (default: (0.9, 0.999))
         eps (float, optional): term added to the denominator to improve
             numerical stability (default: 1e-8)
         weight_decay (float, optional): weight decay coefficient (default: 1e-2)
@@ -145,8 +146,8 @@ def adamw(
     has_complex: bool = False,
     *,
     amsgrad: bool,
-    beta1: float,
-    beta2: float,
+    beta1: Union[float, Tensor],
+    beta2: Union[float, Tensor],
     lr: Union[float, Tensor],
     weight_decay: float,
     eps: float,

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -227,7 +227,7 @@ def _get_capturable_supported_devices(supports_xla: bool = True) -> list[str]:
     return capturable_supported_devices
 
 
-def _to_scalar(x):
+def _to_scalar(x: Union[float, torch.Tensor]):
     r"""This function converts a hyperparameter to a 0-dimension (scalar) tensor
     if it is a nonzero-dimensions 1-element tensor. If it is not a tensor, it is
     kept as is.

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -544,16 +544,6 @@ def optim_inputs_func_adam(device, dtype=None):
             },
             desc="Tensor lr, Tensor betas, with capturable",
         ),
-        OptimizerInput(
-            params=None,
-            kwargs={
-                "lr": torch.tensor(0.001),
-                "betas": (torch.tensor([[[0.9]]]), torch.tensor([[0.99]])),
-                "amsgrad": False,
-                "capturable": True,
-            },
-            desc="non-scalar betas",
-        ),
     ]
     mps_supported_configs = [
         OptimizerInput(

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -554,17 +554,6 @@ def optim_inputs_func_adam(device, dtype=None):
             },
             desc="non-scalar betas",
         ),
-        OptimizerInput(
-            params=None,
-            kwargs={
-                "lr": torch.tensor(0.001),
-                "betas": (torch.tensor([[[0.9]]]), torch.tensor([[0.99]])),
-                "amsgrad": False,
-                "capturable": True,
-                "fused": True,
-            },
-            desc="non-scalar betas with fused",
-        ),
     ]
     mps_supported_configs = [
         OptimizerInput(

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -553,7 +553,7 @@ def optim_inputs_func_adam(device, dtype=None):
                 "capturable": True,
                 "fused": True,
             },
-            desc="Tensor lr, Tensor betas, with fused",
+            desc="non-scalar betas with fused",
         ),
     ]
     mps_supported_configs = [

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -548,7 +548,7 @@ def optim_inputs_func_adam(device, dtype=None):
             params=None,
             kwargs={
                 "lr": torch.tensor(0.001),
-                "betas": (torch.tensor(0.9), torch.tensor(0.99)),
+                "betas": (torch.tensor([[[0.9]]]), torch.tensor([[0.99]])),
                 "amsgrad": False,
                 "capturable": True,
                 "fused": True,

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -544,6 +544,17 @@ def optim_inputs_func_adam(device, dtype=None):
             },
             desc="Tensor lr, Tensor betas, with capturable",
         ),
+        OptimizerInput(
+            params=None,
+            kwargs={
+                "lr": torch.tensor(0.001),
+                "betas": (torch.tensor(0.9), torch.tensor(0.99)),
+                "amsgrad": False,
+                "capturable": True,
+                "fused": True,
+            },
+            desc="Tensor lr, Tensor betas, with fused",
+        ),
     ]
     mps_supported_configs = [
         OptimizerInput(

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -528,7 +528,7 @@ def optim_inputs_func_adam(device, dtype=None):
             params=None,
             kwargs={
                 "lr": torch.tensor(0.001),
-                "betas": (torch.tensor(0.9), torch.tensor(0.99)),
+                "betas": (torch.tensor([[[0.9]]]), torch.tensor([[0.99]])),
                 "amsgrad": True,
                 "capturable": True,
             },
@@ -543,6 +543,16 @@ def optim_inputs_func_adam(device, dtype=None):
                 "capturable": True,
             },
             desc="Tensor lr, Tensor betas, with capturable",
+        ),
+        OptimizerInput(
+            params=None,
+            kwargs={
+                "lr": torch.tensor(0.001),
+                "betas": (torch.tensor([[[0.9]]]), torch.tensor([[0.99]])),
+                "amsgrad": False,
+                "capturable": True,
+            },
+            desc="non-scalar betas",
         ),
         OptimizerInput(
             params=None,


### PR DESCRIPTION
Fixes #147921

## Changes

- Convert tensor `betas` using `_to_scalar`
- Change annotation of `betas` param
- Change param type in docs 

## Test Result

```bash
pytest -s test/test_optim.py -k test_tensor_lr -vv
```

![image](https://github.com/user-attachments/assets/312ee045-1e8b-4789-aa6e-ba63e6df7e81)

![image](https://github.com/user-attachments/assets/7e6ec274-645b-46b9-b1a6-2b340a685203)


