### PR TITLE
[Async TP] Support saving reduce-scatter for backward to fix no AC, per op SAC, and per layer SAC policies in torchtitan

### DIFF
--- a/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
+++ b/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
@@ -492,44 +492,6 @@ class MicroPipelineTPTest(TestCase):
                 gm.graph,
             )
 
-    @skipIfRocm
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
-    @fresh_inductor_cache()
-    def test_unsuccessful_fusion(self):
-        group = dist.group.WORLD
-        scatter_dim = 0
-
-        def no_matching_pattern(
-            A: torch.Tensor,
-            B: torch.Tensor,
-        ) -> torch.Tensor:
-            """
-            Performs 'reshape -> reciprocal -> mm -> reshape -> reduce scatter' pattern,
-            so the extra 'reciprocal' op in the middle should cause pattern matching to fail.
-            """
-            out_shape = [*A.shape[:-1], B.shape[-1]]
-            A = A.reshape(-1, A.shape[-1])
-
-            # insert extra op after reshape that will cause pattern matching to fail
-            A = torch.reciprocal(A)
-
-            C = A @ B
-            C = C.view(out_shape)
-            return reduce_scatter_tensor(C, "sum", scatter_dim, group)
-
-        A = torch.rand(2, 16, 32, device="cuda").to(torch.bfloat16)
-        B = torch.rand(16, 32, device="cuda").to(torch.bfloat16).T
-
-        gm = _make_post_grad_fx(no_matching_pattern, A, B)
-
-        with _test_mode():
-            self.assertRaisesRegex(
-                AssertionError,
-                "no successful fusions of matul-reduce-scatters",
-                micro_pipeline_tp_pass,
-                gm.graph,
-            )
-
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @parametrize("shard_dim", [0, 1])
     @fresh_inductor_cache()

--- a/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
+++ b/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
@@ -157,11 +157,11 @@ class MicroPipelineTPTest(TestCase):
                 "placeholder",
             )
             self.assertEqual(
-                reduce_scatter.rs_node.target,
+                reduce_scatter.reduce_scatter_node.target,
                 torch.ops._c10d_functional.reduce_scatter_tensor.default,
             )
             self.assertEqual(
-                reduce_scatter.res_node.target,
+                reduce_scatter.wait_tensor_node.target,
                 torch.ops._c10d_functional.wait_tensor.default,
             )
             self.assertEqual(reduce_scatter.group_name, group.group_name)

--- a/torch/_inductor/fx_passes/micro_pipeline_tp.py
+++ b/torch/_inductor/fx_passes/micro_pipeline_tp.py
@@ -232,7 +232,9 @@ class _ReduceScatterMatch:
 
             # Assert that now the reduce scatter node has only one user (the wait_tensor) and it's not
             # saved for backward anymore.
-            assert len(self.reduce_scatter_node.users) == 1, "Reduce scatter node has multiple users, this is not expected"
+            assert len(self.reduce_scatter_node.users) == 1, (
+                "Reduce scatter node has multiple users, this is not expected"
+            )
 
     def erase(self) -> None:
         for node in reversed(self.match.nodes):
@@ -1069,7 +1071,7 @@ def micro_pipeline_tp_pass(graph: torch.fx.Graph):
             "async TP found no matching all-gather/reduce-scatter patterns for fusion"
         )
 
-    # TODO: raise an exception if we're using async TP but failed to fuse any all-gather-matmuls
+    torch.distributed.breakpoint()
     for all_gather in all_gathers:
         fuse_all_gather_matmul(all_gather)
 

--- a/torch/_inductor/fx_passes/micro_pipeline_tp.py
+++ b/torch/_inductor/fx_passes/micro_pipeline_tp.py
@@ -844,8 +844,8 @@ def fuse_matmul_reduce_scatter(reduce_scatter: _ReduceScatterMatch) -> None:
 
     Returns boolean indicating if fusion was successful or not.
     """
-    assert torch.distributed.is_available() or torch.distributed.is_nccl_available(), (
-        "torch.distributed must be available to use async tensor parallelism"
+    assert torch.distributed.is_available() and torch.distributed.is_nccl_available(), (
+        "torch.distributed and NCCL must be available to use async tensor parallelism"
     )
 
     from torch.distributed._symmetric_memory import (

--- a/torch/_inductor/fx_passes/micro_pipeline_tp.py
+++ b/torch/_inductor/fx_passes/micro_pipeline_tp.py
@@ -870,7 +870,7 @@ def fuse_matmul_reduce_scatter(reduce_scatter: _ReduceScatterMatch) -> None:
     )
 
     assert is_symm_mem_enabled_for_group(group_name), (
-        f"symmetric memory is not enabled for process group {group_name}, skipping fuse_matmul_reduce_scatter fusion"
+        f"symmetric memory is not enabled for process group {group_name}, this is required for async TP"
     )
 
     # Currently fused_matmul_reduce_scatter doesn't return the matmul result,

--- a/torch/_inductor/fx_passes/micro_pipeline_tp.py
+++ b/torch/_inductor/fx_passes/micro_pipeline_tp.py
@@ -1071,7 +1071,6 @@ def micro_pipeline_tp_pass(graph: torch.fx.Graph):
             "async TP found no matching all-gather/reduce-scatter patterns for fusion"
         )
 
-    torch.distributed.breakpoint()
     for all_gather in all_gathers:
         fuse_all_gather_matmul(all_gather)
 

--- a/torch/_inductor/fx_passes/micro_pipeline_tp.py
+++ b/torch/_inductor/fx_passes/micro_pipeline_tp.py
@@ -211,7 +211,24 @@ class _ReduceScatterMatch:
     group_name: str
 
     def replace_with(self, new_node: torch.fx.Node) -> None:
+        # Replace all uses of the result node (wait_tensor) with the fused node.
         self.res_node.replace_all_uses_with(new_node)
+
+        # If the reduce-scatter result is saved for backward, save the fused node for backward instead.
+        self._update_save_for_backward(new_node)
+
+    def _update_save_for_backward(self, new_node: torch.fx.Node) -> None:
+        """
+        If the output node is a user of the reduce_scatter node (indicating the reduce_scatter
+        result is saved for backward), this method will update the output node to use the fused node instead.
+        """
+        output_node = None
+        for user in self.rs_node.users:
+            if user.target == "output":
+                output_node = user
+                break
+        if output_node is not None:
+            output_node.replace_input_with(self.rs_node, new_node)
 
     def erase(self) -> None:
         for node in reversed(self.match.nodes):
@@ -222,7 +239,7 @@ class _ReduceScatterMatch:
 def find_reduce_scatter_patterns(graph: torch.fx.Graph):
     c10d = torch.ops._c10d_functional
 
-    def reduce_scatter_template(inp: PatternExpr):
+    def reduce_scatter_template(inp: PatternExpr, users: int):
         return CallFunction(
             c10d.wait_tensor.default,
             CallFunction(
@@ -231,14 +248,22 @@ def find_reduce_scatter_patterns(graph: torch.fx.Graph):
                 KeywordArg("reduce_op"),
                 Ignored(),
                 KeywordArg("group_name"),
+                _users=users,
             ),
         )
 
     # Matches funcol.reduce_scatter_tensor with scatter_dim == 0
-    zero_dim_reduce_scatter_pattern = reduce_scatter_template(KeywordArg("input"))
+    zero_dim_reduce_scatter_pattern_single_user = reduce_scatter_template(
+        KeywordArg("input"), users=1
+    )
+
+    # Two users will occur when the reduce-scatter result is saved for backward
+    zero_dim_reduce_scatter_pattern_multi_user = reduce_scatter_template(
+        KeywordArg("input"), users=2
+    )
 
     # Matches funcol.reduce_scatter_tensor with scatter_dim > 0
-    non_zero_dim_reduce_scatter_pattern = reduce_scatter_template(
+    non_zero_dim_reduce_scatter_pattern_single_user = reduce_scatter_template(
         CallFunction(
             aten.cat.default,
             ListOf(
@@ -255,12 +280,34 @@ def find_reduce_scatter_patterns(graph: torch.fx.Graph):
                 )
             ),
         ),
+        users=1,
+    )
+
+    # Two users will occur when the reduce-scatter result is saved for backward
+    non_zero_dim_reduce_scatter_pattern_multi_user = reduce_scatter_template(
+        CallFunction(
+            aten.cat.default,
+            ListOf(
+                CallFunction(
+                    operator.getitem,
+                    CallFunction(
+                        aten.split.Tensor,
+                        KeywordArg("input"),
+                        Ignored(),
+                        KeywordArg("scatter_dim"),
+                        _users=MULTIPLE,
+                    ),
+                    Ignored(),
+                )
+            ),
+        ),
+        users=2,
     )
 
     reduce_scatters = []
     for node in reversed(graph.nodes):
         if node.target == c10d.wait_tensor.default:
-            if match := non_zero_dim_reduce_scatter_pattern.match(node):
+            if match := non_zero_dim_reduce_scatter_pattern_single_user.match(node):
                 assert isinstance(match, Match)
                 reduce_scatters.append(
                     _ReduceScatterMatch(
@@ -273,7 +320,33 @@ def find_reduce_scatter_patterns(graph: torch.fx.Graph):
                         group_name=match.kwargs["group_name"],
                     )
                 )
-            elif match := zero_dim_reduce_scatter_pattern.match(node):
+            elif match := zero_dim_reduce_scatter_pattern_single_user.match(node):
+                assert isinstance(match, Match)
+                reduce_scatters.append(
+                    _ReduceScatterMatch(
+                        match=match,
+                        input_node=match.kwargs["input"],
+                        rs_node=match.nodes[0],
+                        res_node=node,
+                        reduce_op=match.kwargs["reduce_op"],
+                        scatter_dim=0,
+                        group_name=match.kwargs["group_name"],
+                    )
+                )
+            elif match := non_zero_dim_reduce_scatter_pattern_multi_user.match(node):
+                assert isinstance(match, Match)
+                reduce_scatters.append(
+                    _ReduceScatterMatch(
+                        match=match,
+                        input_node=match.kwargs["input"],
+                        rs_node=match.nodes[-2],
+                        res_node=node,
+                        reduce_op=match.kwargs["reduce_op"],
+                        scatter_dim=match.kwargs["scatter_dim"],
+                        group_name=match.kwargs["group_name"],
+                    )
+                )
+            elif match := zero_dim_reduce_scatter_pattern_multi_user.match(node):
                 assert isinstance(match, Match)
                 reduce_scatters.append(
                     _ReduceScatterMatch(
@@ -757,7 +830,7 @@ def _insert_fused_matmul_reduce_scatter(
         raise AssertionError(f"Unexpected matmul match type: {type(matmul)}")
 
 
-def fuse_matmul_reduce_scatter(reduce_scatter: _ReduceScatterMatch) -> bool:
+def fuse_matmul_reduce_scatter(reduce_scatter: _ReduceScatterMatch) -> None:
     """
     Fused the pattern
 
@@ -771,14 +844,9 @@ def fuse_matmul_reduce_scatter(reduce_scatter: _ReduceScatterMatch) -> bool:
 
     Returns boolean indicating if fusion was successful or not.
     """
-    if (
-        not torch.distributed.is_available()
-        or not torch.distributed.is_nccl_available()
-    ):
-        log.debug(
-            "torch.distributed is not available, skipping fuse_matmul_reduce_scatter fusion"
-        )
-        return False
+    assert torch.distributed.is_available() or torch.distributed.is_nccl_available(), (
+        "torch.distributed must be available to use async tensor parallelism"
+    )
 
     from torch.distributed._symmetric_memory import (
         is_symm_mem_enabled_for_group,
@@ -794,35 +862,32 @@ def fuse_matmul_reduce_scatter(reduce_scatter: _ReduceScatterMatch) -> bool:
         reduce_scatter.group_name,
     )
 
-    if not is_symm_mem_enabled_for_group(group_name):
-        log.debug(
-            "symmetric memory is not enabled for process group %s, skipping fuse_matmul_reduce_scatter fusion",
-            group_name,
-        )
-        return False
+    assert is_symm_mem_enabled_for_group(group_name), (
+        f"symmetric memory is not enabled for process group {group_name}, skipping fuse_matmul_reduce_scatter fusion"
+    )
 
     # Currently fused_matmul_reduce_scatter doesn't return the matmul result,
     # so we can't apply the fusion if the matmul result is used by multiple
     # users. This is not a fundamental limitation of the fused op and can be
     # addressed if needed.
     if len(input_node.users) != 1:
-        log.debug(
+        log.warning(
             "matmul result has more than one user, skipping fused_matmul_reduce_scatter fusion."
         )
-        return False
+        return
 
     matmul = _find_producer_matmul(input_node)
     if matmul is None:
-        log.debug(
+        log.warning(
             "no producer matmul found for reduce scatter, skipping fuse_matmul_reduce_scatter fusion"
         )
-        return False
+        return
 
     if rs_res_node in matmul.arg_ancestor_nodes:
-        log.debug(
+        log.warning(
             "reduce-scatter result node is an ancestor of matmul, skipping fuse_matmul_reduce_scatter fusion"
         )
-        return False
+        return
 
     # We need to track 3 values for the fused scaled mm reduce scatter implementation:
     #   1. The scatter dim before the reshape, which was assigned using the original (a,b,c) @ (c,d) = (a,b,d) dims.
@@ -885,7 +950,6 @@ def fuse_matmul_reduce_scatter(reduce_scatter: _ReduceScatterMatch) -> bool:
             fused_node.prepend(node)
 
     log.debug("successfully fused matmul reduce scatter")
-    return True
 
 
 def _get_node_to_ancestors(
@@ -996,10 +1060,5 @@ def micro_pipeline_tp_pass(graph: torch.fx.Graph):
     for all_gather in all_gathers:
         fuse_all_gather_matmul(all_gather)
 
-    fused_reduce_scatters = False
     for reduce_scatter in reduce_scatters:
-        if fuse_matmul_reduce_scatter(reduce_scatter):
-            fused_reduce_scatters = True
-
-    if reduce_scatters and not fused_reduce_scatters:
-        raise AssertionError("no successful fusions of matul-reduce-scatters")
+        fuse_matmul_reduce_scatter(reduce_scatter)

--- a/torch/_inductor/fx_passes/micro_pipeline_tp.py
+++ b/torch/_inductor/fx_passes/micro_pipeline_tp.py
@@ -230,6 +230,10 @@ class _ReduceScatterMatch:
         if output_node is not None:
             output_node.replace_input_with(self.reduce_scatter_node, new_node)
 
+            # Assert that now the reduce scatter node has only one user (the wait_tensor) and it's not
+            # saved for backward anymore.
+            assert len(self.reduce_scatter_node.users) == 1, "Reduce scatter node has multiple users, this is not expected"
+
     def erase(self) -> None:
         for node in reversed(self.match.nodes):
             if len(node.users) == 0:


### PR DESCRIPTION
Fixes #149876

## Stack
- [previous PR in stack] https://github.com/pytorch/pytorch/pull/149247

## TL;DR
This PR implements support in async TP for saving the reduce-scatter result for backward, which previously would break the torchtitan AC policies: no AC, per op SAC, and per layer SAC.

## Context
In torchtitan's LLama3 per op SAC policy, we want to save the output of `reduce_scatter` ops for backward, which is useful for TP. The reduce_scatter op is also saved for No AC (since all activations are saved) and per layer SAC (since we save the activations for N full layers, which do contain reduce-scatters for TP.

However, doing this causes incompatibility with Async TP for the AC policies above, for 2 reasons:

1) The graph pattern matching specifically only matches on reduce scatter nodes with 1 user, but reduce_scatter nodes saved for backwards will have 2 users (the 2nd one being the return/output node, which saves it for backward).

2) The subgraph replacement logic which replaces the users of the `wait_tensor` after the reduce-scatter with the new fused node has no mechanism to save the fused_node for backward instead of the reduce-scatter node. This means we cannot directly replace the subgraph, since we can't delete nodes which still have users (in this case, the output node is still using the reduce-scatter node).

To fix this, we do 2 things:

1) Add additional pattern matching logic to also match reduce-scatter nodes with 2 users, so we also perform fusion when reduce-scatter is saved for backward.

2) When replacing the subgraph with the fused node, detect if the reduce-scatter was saved for backward, and if so, save the result of the fused node for backward instead. This enables us to properly erase the subgraph and prevent the memory leak which occurred in #149876

## Other changes 
- Continue to throw an error if we don't find any candidate all-gathers or reduce-scatters for fusion (since TP should have both) but DON'T throw an error if we don't fuse any matmul-reduce-scatters. This is because I've found there are actually valid graphs where we do fuse reduce scatters in the forward graph but not the backward graph (in the backward pass there are reduce-scatters but the producer op is an "add" not a mm/scaled_mm).

## Test plan

1. All unit tests are passing
2. Visualized the graphs and verified the fusion is occurring properly.
3. Verified via manual torchtitan runs there is no memory leak / OOM occurring anymore.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @xmfan