### PR TITLE
Dont exclude constant_pad_nd in prologue fusion

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1651,16 +1651,16 @@ class TestPrologueFusion(TestCase):
         M, K, N = sizes
 
         def foo(x, y):
-            return x @ y
+            return x @ y.T
 
         x = torch.rand([250, 245], device=GPU_TYPE)
-        y = torch.rand([245, 128], device=GPU_TYPE)
+        y = torch.rand([245, 128], device=GPU_TYPE).T.contiguous()
 
         # we should not attempt prologue fusion if it turns an aligned load
         # into an unaligned load
         out, code = run_and_get_code(torch.compile(foo), x, y)
         self.assertEqual(out, foo(x, y), atol=0.05, rtol=0.05)
-        self.check_code(code[0], num_kernels=3, num_allocs=3, num_deallocs=4)
+        self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/analyze_preserves_zero_mask.py
+++ b/torch/_inductor/analyze_preserves_zero_mask.py
@@ -1,6 +1,6 @@
 import dataclasses
 import itertools
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Callable, Optional, TYPE_CHECKING
 
 import sympy
 
@@ -89,7 +89,6 @@ class RecordLowPrecisionOps(DefaultHandler):
             "to_dtype",
             "constant",
             "where",
-            "masked",
         )
 
     def load(self, name: str, index: sympy.Expr) -> DTypeContainer:
@@ -109,6 +108,14 @@ class RecordLowPrecisionOps(DefaultHandler):
     @staticmethod
     def indirect_indexing(*args: Any, **kwargs: Any) -> sympy.Expr:
         return sympy.S.Zero
+
+    def masked(
+        self,
+        mask: DTypeContainer,
+        body: Callable[[], DTypeContainer],
+        other: DTypeContainer,
+    ) -> DTypeContainer:
+        return self.where(mask, other, body())
 
     def _default(self, name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
         out_dtype = getattr(self.dtype_prop, name)(*args, **kwargs)

--- a/torch/_inductor/analyze_preserves_zero_mask.py
+++ b/torch/_inductor/analyze_preserves_zero_mask.py
@@ -89,6 +89,7 @@ class RecordLowPrecisionOps(DefaultHandler):
             "to_dtype",
             "constant",
             "where",
+            "masked",
         )
 
     def load(self, name: str, index: sympy.Expr) -> DTypeContainer:

--- a/torch/_inductor/analyze_preserves_zero_mask.py
+++ b/torch/_inductor/analyze_preserves_zero_mask.py
@@ -131,7 +131,10 @@ class RecordLowPrecisionOps(DefaultHandler):
         }
 
         out_dtype = getattr(self.dtype_prop, name)(*args, **kwargs)
-        is_scalar = all(not isinstance(v, DTypeContainer) or v.is_scalar for v in itertools.chain(args, kwargs.values()))
+        is_scalar = all(
+            not isinstance(v, DTypeContainer) or v.is_scalar
+            for v in itertools.chain(args, kwargs.values())
+        )
         out = DTypeContainer(out_dtype, is_scalar=is_scalar)
 
         uses_low_prec = any(

--- a/torch/_inductor/analyze_preserves_zero_mask.py
+++ b/torch/_inductor/analyze_preserves_zero_mask.py
@@ -131,7 +131,7 @@ class RecordLowPrecisionOps(DefaultHandler):
         }
 
         out_dtype = getattr(self.dtype_prop, name)(*args, **kwargs)
-        is_scalar = all(v.is_scalar for v in itertools.chain(args, kwargs.values()))
+        is_scalar = all(not isinstance(v, DTypeContainer) or v.is_scalar for v in itertools.chain(args, kwargs.values()))
         out = DTypeContainer(out_dtype, is_scalar=is_scalar)
 
         uses_low_prec = any(

--- a/torch/_inductor/analyze_preserves_zero_mask.py
+++ b/torch/_inductor/analyze_preserves_zero_mask.py
@@ -1,6 +1,6 @@
 import dataclasses
 import itertools
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from typing import Any, Callable, Optional, TYPE_CHECKING, Union
 
 import sympy
 
@@ -8,6 +8,7 @@ import torch
 from torch._inductor import config
 from torch._inductor.dtype_propagation import DtypePropagationOpsHandler
 from torch._inductor.index_propagation import SymPyOps, TypedExpr
+from torch._prims_common import type_to_dtype
 
 from .ops_handler import DefaultHandler
 from .virtualized import StoreMode, V
@@ -118,10 +119,20 @@ class RecordLowPrecisionOps(DefaultHandler):
         return self.where(mask, other, body())
 
     def _default(self, name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+        def to_constant(c: Union[int, float]) -> DTypeContainer:
+            return DTypeContainer(type_to_dtype(type(c)), is_scalar=True)
+
+        args = tuple(
+            a if not isinstance(a, (int, float)) else to_constant(a) for a in args
+        )
+        kwargs = {
+            k: v if not isinstance(v, (int, float)) else to_constant(v)
+            for k, v in kwargs.items()
+        }
+
         out_dtype = getattr(self.dtype_prop, name)(*args, **kwargs)
-        out = DTypeContainer(out_dtype, is_scalar=(name == "constant"))
-        if name == "constant":
-            return DTypeContainer(torch.float, is_scalar=True)
+        is_scalar = all(v.is_scalar for v in itertools.chain(args, kwargs.values()))
+        out = DTypeContainer(out_dtype, is_scalar=is_scalar)
 
         uses_low_prec = any(
             isinstance(dtype_cont, DTypeContainer)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4440,7 +4440,19 @@ class TemplateBuffer(OperationBuffer):
         )
 
         for inp in self.inputs:
-            indexer = inp.layout.make_indexer()
+            layout = inp.layout
+
+            # we dont know what the iteration order is of the template,
+            # so we just want to make a single, contiguous dependency
+            if not layout.is_contiguous():
+                layout = FixedLayout(
+                    device=layout.device,
+                    dtype=layout.dtype,
+                    size=layout.size,
+                    stride=FlexibleLayout.contiguous_strides(layout.size),
+                    offset=layout.offset,
+                )
+            indexer = layout.make_indexer()
 
             def dummy(index, rindex):  # type: ignore[no-untyped-def]
                 assert len(rindex) == 0

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2739,24 +2739,18 @@ class Scheduler:
         device = node_list_fused[0].get_device()
         assert device is not None
 
-        epilogue_fusion = node1.get_template_node() is not None
-
         def log_fusion(ms_fused: float, ms1: float, ms2: float) -> None:
             if fusion_log.isEnabledFor(logging.DEBUG):
                 if ms_fused < ms1 + ms2:
-                    if not epilogue_fusion:
-                        breakpoint()
                     fusion_log.debug(
                         "can fuse %s (benchmark): fusing %s with %s cause %sx speedup",
-                        "epilogue" if epilogue_fusion else "prologue",
                         node1.get_buffer_names(),
                         node2.get_buffer_names(),
                         green_text(f"{(ms1 + ms2) / ms_fused:.3f}"),
                     )
                 else:
                     fusion_log.debug(
-                        "cannot fuse  %s benchmark): fusing %s with %s cause %sx slowdown",
-                        "epilogue" if epilogue_fusion else "prologue",
+                        "cannot fuse (benchmark): fusing %s with %s cause %sx speedup",
                         node1.get_buffer_names(),
                         node2.get_buffer_names(),
                         red_text(f"{ms_fused / (ms1 + ms2):.3f}"),

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2743,14 +2743,14 @@ class Scheduler:
             if fusion_log.isEnabledFor(logging.DEBUG):
                 if ms_fused < ms1 + ms2:
                     fusion_log.debug(
-                        "can fuse %s (benchmark): fusing %s with %s cause %sx speedup",
+                        "can fuse (benchmark): fusing %s with %s cause %sx speedup",
                         node1.get_buffer_names(),
                         node2.get_buffer_names(),
                         green_text(f"{(ms1 + ms2) / ms_fused:.3f}"),
                     )
                 else:
                     fusion_log.debug(
-                        "cannot fuse (benchmark): fusing %s with %s cause %sx speedup",
+                        "cannot fuse (benchmark): fusing %s with %s cause %sx slowdown",
                         node1.get_buffer_names(),
                         node2.get_buffer_names(),
                         red_text(f"{ms_fused / (ms1 + ms2):.3f}"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149947

Originally, I excluded constant_pad_nd from fusing to be conservative on compilation time. But, on benchmarking, you do occasionally get speedups by fusing it. Also includes a fix for making single, contiguous dep for prologues.

For instance, the following benchmark gets a 7% speedup by fusing in the constant_pad_nd.

```
import torch
import torch.nn.functional as F
torch._inductor.config.force_disable_caches = True

padded_N = 2048
n_pad_rows = 100

K, N = 2048, 4096

tensor1 = torch.randn(padded_N - n_pad_rows, 4096, device="cuda").to(torch.bfloat16)
tensor2 = torch.randn(4096, 4096, device="cuda").to(torch.bfloat16)

@torch.compile(mode='max-autotune-no-cudagraphs')
def masked_linear(input, weight, n_pad_input_rows):
    """
    Linear layer with input padded by `n_pad_input_rows` rows
    """
    # Use constant_pad_nd to pad with zeros for the invalid rows
    padded_input = F.pad(tensor1, (0, 0, 0, n_pad_input_rows), "constant", 0)
    return F.linear(padded_input, weight)

# Invoke the function
masked_linear(tensor1, tensor2, n_pad_rows)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov