### PR TITLE
Use statically known true in should_decompose_mm

### DIFF
--- a/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
+++ b/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
@@ -4,6 +4,7 @@ import logging
 import torch
 from torch import Tensor
 from torch._dynamo.utils import counters
+from torch.fx.experimental.symbolic_shapes import statically_known_true
 
 from .. import config
 from ..pattern_matcher import Arg, CallFunction, Match, register_graph_pattern
@@ -71,9 +72,9 @@ def should_decompose_mm(mat1, mat2) -> bool:
         return False
     return (
         check_device(mat1, mat2, device="cuda")
-        and mat1.shape[0] >= min_first_dimension_decomposition
-        and mat2.shape[0] < max_other_dimention_decomposition
-        and mat2.shape[1] < max_other_dimention_decomposition
+        and statically_known_true(mat1.shape[0] >= min_first_dimension_decomposition)
+        and statically_known_true(mat2.shape[0] < max_other_dimention_decomposition)
+        and statically_known_true(mat2.shape[1] < max_other_dimention_decomposition)
     ) or (
         check_device(mat1, mat2, device="cpu")
         and mat1.shape[0] == 1

--- a/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
+++ b/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
@@ -77,9 +77,9 @@ def should_decompose_mm(mat1, mat2) -> bool:
         and statically_known_true(mat2.shape[1] < max_other_dimention_decomposition)
     ) or (
         check_device(mat1, mat2, device="cpu")
-        and mat1.shape[0] == 1
-        and mat2.shape[0] <= 64
-        and mat2.shape[1] <= 512
+        and statically_known_true(mat1.shape[0] == 1)
+        and statically_known_true(mat2.shape[0] <= 64)
+        and statically_known_true(mat2.shape[1] <= 512)
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149950

This meta function is causing recompiles for large ads runs due to overguarding: https://www.internalfb.com/ai_infra/job_inspector/guided/pt2_compile?jobName=aps-ig_fm_v4_pt2_on-6e0a734dcc&jobVersion=0&jobAttempt=0

If we look at the reasons, it's because of this function adding guards: https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/aps-ig_fm_v4_pt2_on-6e0a734dcc/attempt_0/version_0/rank_0/-_18_8_0/recompile_reasons_1971.json?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000

This PR moves to statically_known_true so we don't overly guard for dynamic shapes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov