### PR TITLE
[inductor] Fix mm logging for `torch._scaled_.mm`

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -193,6 +193,43 @@ from user code:
     test_inductor_debug = within_range_record_test(3, 26, inductor=logging.DEBUG)
     test_inductor_info = within_range_record_test(2, 10, inductor=logging.INFO)
 
+    @make_logging_test(inductor=logging.INFO)
+    def test_inductor_mm_info(self, records):
+        a = torch.randn(128, 128)
+        b = torch.randn(128, 128)
+
+        def foo(a, b):
+            return a @ b
+
+        foo_c = torch.compile(foo)
+        foo_c(a, b)
+
+        for r in records:
+            assert "WON'T CONVERT" not in str(r)
+
+    @requires_cuda
+    @unittest.skipIf(not SM90OrLater, "requires H100+ GPU")
+    @make_logging_test(inductor=logging.INFO)
+    def test_inductor_scaled_mm_info(self, records):
+        a = torch.ones(128, 128, device="cuda", dtype=torch.float8_e4m3fn)
+        b = (
+            torch.ones(128, 128, device="cuda", dtype=torch.float8_e4m3fn)
+            .t()
+            .contiguous()
+            .t()
+        )
+        a_s = torch.tensor(1, device="cuda", dtype=torch.float32)
+        b_s = torch.tensor(1, device="cuda", dtype=torch.float32)
+
+        def foo(a, b, a_s, b_s):
+            return torch._scaled_mm(a, b, a_s, b_s, out_dtype=torch.bfloat16)
+
+        foo_c = torch.compile(foo)
+        foo_c(a, b, a_s, b_s)
+
+        for r in records:
+            assert "WON'T CONVERT" not in str(r)
+
     @make_logging_test()
     def test_inductor_error(self, records):
         exitstack = contextlib.ExitStack()

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -845,10 +845,19 @@ def _compile_fx_inner(
     log.debug("FX codegen and compilation took %.3fs", time.time() - start)
 
     # This message is for printing overview information of inductor mm counts, shapes,etc after lowering
-    if log.isEnabledFor(logging.INFO):
+    if log.isEnabledFor(logging.INFO) and counters["aten_mm_info"]:
         mm_table_data = []
         for key, value in counters["aten_mm_info"].items():
             name, m, n, k = key.split("_")
+            # example key 1: aten.mm_128_128_128
+            # example key 2: aten._scaled_mm.default_128_128_128
+            # below is a bit brittle, but should work
+            parts = key.split("_")
+            if len(parts) < 4:
+                log.info("Unable to parse key %s", key)
+                continue
+            name = "_".join(parts[:-3])
+            m, n, k = parts[-3:]
             mm_table_data.append([name, m, n, k, value])
         log.info("Overview info of inductor aten mms: ")
         log.info(


### PR DESCRIPTION
Summary:
This pr is just for recreation of the original pr: https://github.com/pytorch/pytorch/pull/149769

Fix for `torch._scaled_mm` op mm logging,  which breaks the original brittle underscore parsing 
assumptions.

Test Plan: CI

Differential Revision: D71828732




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov