### PR TITLE
[MPS] Fix metal ops with different dtypes

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -4,8 +4,9 @@
 
 #include <initializer_list>
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/Tensor.h>
+#include <ATen/TensorIterator.h>
 #include <ATen/Utils.h>
+#include <ATen/core/Tensor.h>
 #include <ATen/mps/MPSStream.h>
 #include <ATen/native/mps/MetalShaderLibrary.h>
 #include <ATen/native/mps/TensorFactory.h>
@@ -36,9 +37,6 @@
 @end
 
 // Fwd declarations
-namespace at {
-struct TensorIteratorBase;
-}
 using namespace at::mps;
 
 namespace at::native::mps {
@@ -82,6 +80,9 @@ static inline std::string getMPSTypeString(const TensorBase& t, bool short_name 
 std::string scalarToMetalTypeString(const c10::ScalarType& scalar_type);
 static inline std::string scalarToMetalTypeString(const TensorBase& t) {
   return scalarToMetalTypeString(t.scalar_type());
+}
+static inline std::string scalarToMetalTypeString(const TensorIteratorBase& i) {
+  return scalarToMetalTypeString(i.common_dtype());
 }
 NSArray<NSNumber*>* getTensorAxes(const TensorBase& t);
 NSArray<NSNumber*>* getTensorAxes(const IntArrayRef& sizes, at::OptionalIntArrayRef dim);

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1025,8 +1025,11 @@ void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter, const std:
   const uint32_t numThreads = iter.numel();
   const auto cast_needed = input.scalar_type() != other.scalar_type();
   const auto suffix = iter.is_contiguous() ? "dense" : "strided";
-  const auto kernel_name =
-      fmt::format("{}_{}{}_{}", name, suffix, cast_needed ? "_cast" : "", scalarToMetalTypeString(iter));
+  const auto kernel_name = fmt::format("{}_{}{}_{}",
+                                       name,
+                                       suffix,
+                                       cast_needed ? "_cast" : "",
+                                       cast_needed ? scalarToMetalTypeString(iter) : scalarToMetalTypeString(input));
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       auto computeEncoder = mpsStream->commandEncoder();

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1026,7 +1026,7 @@ void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter, const std:
   const auto cast_needed = input.scalar_type() != other.scalar_type();
   const auto suffix = iter.is_contiguous() ? "dense" : "strided";
   const auto kernel_name =
-      fmt::format("{}_{}{}_{}", name, suffix, cast_needed ? "_cast" : "", scalarToMetalTypeString(input));
+      fmt::format("{}_{}{}_{}", name, suffix, cast_needed ? "_cast" : "", scalarToMetalTypeString(iter));
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       auto computeEncoder = mpsStream->commandEncoder();

--- a/c10/metal/common.h
+++ b/c10/metal/common.h
@@ -10,5 +10,20 @@
 namespace c10 {
 namespace metal {
 C10_METAL_CONSTEXPR unsigned max_ndim = 16;
+
+enum class ScalarType {
+    Byte = 0,
+    Char = 1,
+    Short = 2,
+    Int = 3,
+    Long = 4,
+    Half = 5,
+    Float = 6,
+    Bool = 11,
+#if !defined(__METAL__) || __METAL_VERSION__ >= 310
+    BFloat16 = 15,
+#endif
+};
+
 } // namespace metal
 } // namespace c10

--- a/c10/metal/common.h
+++ b/c10/metal/common.h
@@ -12,16 +12,16 @@ namespace metal {
 C10_METAL_CONSTEXPR unsigned max_ndim = 16;
 
 enum class ScalarType {
-    Byte = 0,
-    Char = 1,
-    Short = 2,
-    Int = 3,
-    Long = 4,
-    Half = 5,
-    Float = 6,
-    Bool = 11,
+  Byte = 0,
+  Char = 1,
+  Short = 2,
+  Int = 3,
+  Long = 4,
+  Half = 5,
+  Float = 6,
+  Bool = 11,
 #if !defined(__METAL__) || __METAL_VERSION__ >= 310
-    BFloat16 = 15,
+  BFloat16 = 15,
 #endif
 };
 

--- a/c10/metal/common.h
+++ b/c10/metal/common.h
@@ -7,22 +7,37 @@
 #define C10_METAL_CONSTEXPR constexpr
 #endif
 
+#if !defined(__METAL__) || __METAL_VERSION__ >= 310
+#define C10_METAL_ALL_TYPES_FUNCTOR(_) \
+  _(Byte, 0)                           \
+  _(Char, 1)                           \
+  _(Short, 2)                          \
+  _(Int, 3)                            \
+  _(Long, 4)                           \
+  _(Half, 5)                           \
+  _(Float, 6)                          \
+  _(Bool, 11)                          \
+  _(BFloat16, 15)
+#else
+#define C10_METAL_ALL_TYPES_FUNCTOR(_) \
+  _(Byte, 0)                           \
+  _(Char, 1)                           \
+  _(Short, 2)                          \
+  _(Int, 3)                            \
+  _(Long, 4)                           \
+  _(Half, 5)                           \
+  _(Float, 6)                          \
+  _(Bool, 11)
+#endif
+
 namespace c10 {
 namespace metal {
 C10_METAL_CONSTEXPR unsigned max_ndim = 16;
 
 enum class ScalarType {
-  Byte = 0,
-  Char = 1,
-  Short = 2,
-  Int = 3,
-  Long = 4,
-  Half = 5,
-  Float = 6,
-  Bool = 11,
-#if !defined(__METAL__) || __METAL_VERSION__ >= 310
-  BFloat16 = 15,
-#endif
+#define _DEFINE_ENUM_VAL_(_v, _n) _v = _n,
+  C10_METAL_ALL_TYPES_FUNCTOR(_DEFINE_ENUM_VAL_)
+#undef _DEFINE_ENUM_VAL_
 };
 
 } // namespace metal

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -145,6 +145,36 @@ kernel void binary_dense(
   out[tid] = f(input[tid], other[tid]);
 }
 
+template <typename T>
+T cast_from(constant void* ptr, long offs, ScalarType type) {
+  switch (type) {
+    case ScalarType::Bool: return ref_at_offs<bool>(ptr, offs);
+    case ScalarType::Byte: return ref_at_offs<uchar>(ptr, offs);
+    case ScalarType::Char: return ref_at_offs<char>(ptr, offs);
+    case ScalarType::Short: return ref_at_offs<short>(ptr, offs);
+    case ScalarType::Int: return ref_at_offs<int>(ptr, offs);
+    case ScalarType::Long: return ref_at_offs<long>(ptr, offs);
+    // Floats
+    case ScalarType::Float: return static_cast<T>(ref_at_offs<float>(ptr, offs));
+    case ScalarType::Half: return static_cast<T>(ref_at_offs<half>(ptr, offs));
+#if __METAL_VERSION__ >= 310
+//    case ScalarType::BFloat16: return static_cast<T>(ref_at_offs<bfloat>(ptr, offs));
+#endif
+  }
+}
+template <typename T, typename F>
+kernel void binary_dense_cast(
+    device result_of<F, T, T>* out [[buffer(0)]],
+    constant void* input [[buffer(1)]],
+    constant void* other [[buffer(2)]],
+    constant uint4 &sizes_types [[buffer(3)]],
+    uint tid [[thread_position_in_grid]]) {
+  F f;
+  const auto a = cast_from<T>(input,tid*sizes_types.x, static_cast<ScalarType>(sizes_types.z));
+  const auto b = cast_from<T>(other,tid*sizes_types.y, static_cast<ScalarType>(sizes_types.w));
+  out[tid] = f(a, b);
+}
+
 #define REGISTER_BINARY_INDEXING_OP(NAME, DTYPE)                               \
   template [[host_name(#NAME "_strided_" #DTYPE)]] kernel void ::c10::metal::  \
       binary_strided<DTYPE, NAME##_functor>(                                   \
@@ -162,6 +192,13 @@ kernel void binary_dense(
           device ::c10::metal::result_of<NAME##_functor, DTYPE, DTYPE> * out_, \
           constant DTYPE * input_,                                             \
           constant DTYPE * other_,                                             \
+          uint tid); \
+  template [[host_name(#NAME "_dense_cast_" #DTYPE)]] kernel void ::c10::metal::    \
+      binary_dense_cast<DTYPE, NAME##_functor>(                                     \
+          device ::c10::metal::result_of<NAME##_functor, DTYPE, DTYPE> * out_, \
+          constant void * input,                                             \
+          constant void * other,                                             \
+          constant uint4 &sizes_types, \
           uint tid)
 } // namespace metal
 } // namespace c10

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -1,3 +1,4 @@
+// Metal indexing primitives
 #pragma once
 #include <c10/metal/common.h>
 #include <c10/metal/utils.h>
@@ -104,10 +105,39 @@ kernel void unary_strided(
   }
 
 template <typename T>
-inline constant T& ref_at_offs(constant void* ptr, long offs) {
+inline T val_at_offs(constant void* ptr, long offs) {
   return *reinterpret_cast<constant T*>(
       static_cast<constant char*>(ptr) + offs);
 }
+
+// Value at offset with dynamic cast from provided type
+template <typename T>
+inline T val_at_offs(constant void* ptr, long offs, ScalarType type) {
+  switch (type) {
+    case ScalarType::Bool:
+      return val_at_offs<bool>(ptr, offs);
+    case ScalarType::Byte:
+      return val_at_offs<uchar>(ptr, offs);
+    case ScalarType::Char:
+      return val_at_offs<char>(ptr, offs);
+    case ScalarType::Short:
+      return val_at_offs<short>(ptr, offs);
+    case ScalarType::Int:
+      return val_at_offs<int>(ptr, offs);
+    case ScalarType::Long:
+      return val_at_offs<long>(ptr, offs);
+    // Floats
+    case ScalarType::Float:
+      return static_cast<T>(val_at_offs<float>(ptr, offs));
+    case ScalarType::Half:
+      return static_cast<T>(val_at_offs<half>(ptr, offs));
+#if __METAL_VERSION__ >= 310
+    case ScalarType::BFloat16:
+      return cast_to<T>(val_at_offs<bfloat>(ptr, offs));
+#endif
+  }
+}
+
 template <typename T>
 inline device T& ref_at_offs(device void* ptr, long offs) {
   return *reinterpret_cast<device T*>(static_cast<device char*>(ptr) + offs);
@@ -122,16 +152,40 @@ kernel void binary_strided(
     constant long* output_strides [[buffer(4)]],
     constant long* input_strides [[buffer(5)]],
     constant long* other_strides [[buffer(6)]],
-    constant uint& ndim [[buffer(7)]],
+    constant uint3& ndim [[buffer(7)]],
     uint index [[thread_position_in_grid]]) {
   F f;
   int pos[max_ndim];
-  pos_from_thread_index(int(index), pos, sizes, ndim);
-  const auto input_offs = offset_from_coord(pos, input_strides, ndim);
-  const auto other_offs = offset_from_coord(pos, other_strides, ndim);
-  const auto output_offs = offset_from_coord(pos, output_strides, ndim);
-  const auto a = ref_at_offs<T>(input, input_offs);
-  const auto b = ref_at_offs<T>(other, other_offs);
+  pos_from_thread_index(int(index), pos, sizes, ndim.x);
+  const auto input_offs = offset_from_coord(pos, input_strides, ndim.x);
+  const auto other_offs = offset_from_coord(pos, other_strides, ndim.x);
+  const auto output_offs = offset_from_coord(pos, output_strides, ndim.x);
+  const auto a = val_at_offs<T>(input, input_offs);
+  const auto b = val_at_offs<T>(other, other_offs);
+  ref_at_offs<result_of<F, T, T>>(output, output_offs) = f(a, b);
+}
+
+template <typename T, typename F>
+kernel void binary_strided_cast(
+    device void* output [[buffer(0)]],
+    constant void* input [[buffer(1)]],
+    constant void* other [[buffer(2)]],
+    constant long* sizes [[buffer(3)]],
+    constant long* output_strides [[buffer(4)]],
+    constant long* input_strides [[buffer(5)]],
+    constant long* other_strides [[buffer(6)]],
+    constant uint3& ndim_types [[buffer(7)]],
+    uint index [[thread_position_in_grid]]) {
+  F f;
+  int pos[max_ndim];
+  pos_from_thread_index(int(index), pos, sizes, ndim_types.x);
+  const auto input_offs = offset_from_coord(pos, input_strides, ndim_types.x);
+  const auto other_offs = offset_from_coord(pos, other_strides, ndim_types.x);
+  const auto output_offs = offset_from_coord(pos, output_strides, ndim_types.x);
+  const auto a =
+      val_at_offs<T>(input, input_offs, static_cast<ScalarType>(ndim_types.y));
+  const auto b =
+      val_at_offs<T>(other, other_offs, static_cast<ScalarType>(ndim_types.z));
   ref_at_offs<result_of<F, T, T>>(output, output_offs) = f(a, b);
 }
 
@@ -145,48 +199,6 @@ kernel void binary_dense(
   out[tid] = f(input[tid], other[tid]);
 }
 
-template <typename T, typename U>
-inline ::metal::enable_if_t<::metal::is_same_v<U, T>, T> cast_to(const U from) {
-  return from;
-}
-
-template <typename T, typename U>
-inline ::metal::enable_if_t<is_complex_v<T>, T> cast_to(const U from) {
-  return T(float(from), 0.0);
-}
-
-template <typename T, typename U>
-inline ::metal::enable_if_t<!::metal::is_same_v<U, T> && !is_complex_v<T>, T>
-cast_to(const U from) {
-  return static_cast<T>(from);
-}
-
-template <typename T>
-T cast_from(constant void* ptr, long offs, ScalarType type) {
-  switch (type) {
-    case ScalarType::Bool:
-      return ref_at_offs<bool>(ptr, offs);
-    case ScalarType::Byte:
-      return ref_at_offs<uchar>(ptr, offs);
-    case ScalarType::Char:
-      return ref_at_offs<char>(ptr, offs);
-    case ScalarType::Short:
-      return ref_at_offs<short>(ptr, offs);
-    case ScalarType::Int:
-      return ref_at_offs<int>(ptr, offs);
-    case ScalarType::Long:
-      return ref_at_offs<long>(ptr, offs);
-    // Floats
-    case ScalarType::Float:
-      return static_cast<T>(ref_at_offs<float>(ptr, offs));
-    case ScalarType::Half:
-      return static_cast<T>(ref_at_offs<half>(ptr, offs));
-#if __METAL_VERSION__ >= 310
-    case ScalarType::BFloat16:
-      return cast_to<T>(ref_at_offs<bfloat>(ptr, offs));
-#endif
-  }
-}
 template <typename T, typename F>
 kernel void binary_dense_cast(
     device result_of<F, T, T>* out [[buffer(0)]],
@@ -195,9 +207,9 @@ kernel void binary_dense_cast(
     constant uint4& sizes_types [[buffer(3)]],
     uint tid [[thread_position_in_grid]]) {
   F f;
-  const auto a = cast_from<T>(
+  const auto a = val_at_offs<T>(
       input, tid * sizes_types.x, static_cast<ScalarType>(sizes_types.z));
-  const auto b = cast_from<T>(
+  const auto b = val_at_offs<T>(
       other, tid * sizes_types.y, static_cast<ScalarType>(sizes_types.w));
   out[tid] = f(a, b);
 }
@@ -212,7 +224,18 @@ kernel void binary_dense_cast(
           constant long* output_strides,                                       \
           constant long* input_strides,                                        \
           constant long* other_strides,                                        \
-          constant uint& ndim,                                                 \
+          constant uint3& ndim,                                                \
+          uint tid);                                                           \
+  template [[host_name(#NAME "_strided_cast_" #DTYPE)]] kernel void ::c10::    \
+      metal::binary_strided_cast<DTYPE, NAME##_functor>(                       \
+          device void* out,                                                    \
+          constant void* input,                                                \
+          constant void* other,                                                \
+          constant long* sizes,                                                \
+          constant long* output_strides,                                       \
+          constant long* input_strides,                                        \
+          constant long* other_strides,                                        \
+          constant uint3& ndim_types,                                          \
           uint tid);                                                           \
   template [[host_name(#NAME "_dense_" #DTYPE)]] kernel void ::c10::metal::    \
       binary_dense<DTYPE, NAME##_functor>(                                     \

--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -1,5 +1,6 @@
 // Metal helper functions
 #pragma once
+#include <c10/metal/common.h>
 #include <metal_stdlib>
 
 namespace c10 {
@@ -144,6 +145,22 @@ constexpr constant bool is_scalar_floating_point_v =
 template <typename T>
 constexpr constant bool is_scalar_integral_v =
     ::metal::is_integral_v<T> && ::metal::is_scalar_v<T>;
+
+template <typename T, typename U>
+inline ::metal::enable_if_t<::metal::is_same_v<U, T>, T> cast_to(const U from) {
+  return from;
+}
+
+template <typename T, typename U>
+inline ::metal::enable_if_t<is_complex_v<T>, T> cast_to(const U from) {
+  return T(float(from), 0.0);
+}
+
+template <typename T, typename U>
+inline ::metal::enable_if_t<!::metal::is_same_v<U, T> && !is_complex_v<T>, T>
+cast_to(const U from) {
+  return static_cast<T>(from);
+}
 
 } // namespace metal
 } // namespace c10


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149974


By implementing `_cast_` flavors of both dense and strided ops. Add regression tests that tests `fmax`/`fmin` for mixed dtypes.

Been dreaded to write this PR for a while, as it end up to be pretty bulky:
 - Adds 1C10_METAL_ALL_TYPES_FUNCTOR` and `c10::metal::ScalarType` to `c10/metal/common.h` and test that its values always match `c10::ScalarType`
 - Add `c10::metal::cast_to` to `c10/metal/utils.h` which could be used to cast any scalar metal dtype to any other one, including complex values
 - Implement `val_at_offs<T>(constant void *, long offs, ScalarType dtype)` that is used to dynamically cast types
 - Add `binary_strided_cast` and `binary_dense_cast` that are invoked for output dtype and cast both inputs to that output before performing the op

Benchmark collected on M2Pro that runs fmax for 1 mln element tensors (Times are in microseconds.)

|                                           |  dense-dense  |  transp-transp  |  dense-transp  |  transp-dense  |  dense-scalar  |  dense-bcast |
|-------------------------|---------------|----------------|----------------|----------------|---------------|--------------- |
|      fmax (torch.float16, torch.float16)  |     160.9     |      159.9      |     270.5      |     270.9      |     236.6      |     293.0   
|      fmax (torch.float32, torch.float32)  |     176.9     |      171.0      |     273.7      |     293.5      |     242.6      |     294.2   
|      fmax (torch.float32, torch.float16)  |     171.4     |      170.9      |     283.6      |     303.0      |     253.7      |     302.3   
|      add (torch.float16, torch.float16)   |     218.0     |      223.6      |     221.0      |     222.0      |     214.9      |     218.3   
|      add (torch.float32, torch.float32)   |     227.4     |      233.9      |     228.8      |     231.9      |     218.9      |     221.4   
|      add (torch.float32, torch.float16)   |     226.1     |      227.5      |     227.5      |     226.9      |     177.0      |     190.8   


TODOS:
 - Include input and output dtype in non-cast kernel name
 - Make TensorFactory.h use `C10_METAL_ALL_TYPES_FUNCTOR`
- Extend mixed_dytpes testing via OpInfo

Fixes https://github.com/pytorch/pytorch/issues/149951