### PR TITLE
Support fp8 dtypes in assert_close

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -943,6 +943,28 @@ class TestAssertCloseErrorMessage(TestCase):
             with self.assertRaisesRegex(AssertionError, re.escape("Greatest absolute difference: 2 at index (1, 0)")):
                 fn()
 
+    def test_small_float_dtype(self):
+        for dtype in [
+            torch.float8_e4m3fn,
+            torch.float8_e4m3fnuz,
+            torch.float8_e5m2,
+            torch.float8_e5m2fnuz,
+            torch.float8_e8m0fnu,
+        ]:
+            w = torch.tensor([3.14, 1.0], dtype=dtype)
+            x = torch.tensor([1.0, 3.14], dtype=dtype)
+            y = torch.tensor([3.14, 3.14], dtype=dtype)
+            z = torch.tensor([1.0, 3.14], dtype=dtype)
+            for fn in assert_close_with_inputs(x, y):
+                with self.assertRaisesRegex(AssertionError, re.escape("The first mismatched element is at index 0")):
+                    fn()
+            
+            for fn in assert_close_with_inputs(w, y):
+                with self.assertRaisesRegex(AssertionError, re.escape("The first mismatched element is at index 1")):
+                    fn()
+            for fn in assert_close_with_inputs(x, z):
+                fn()
+
     def test_abs_diff_scalar(self):
         actual = 3
         expected = 5

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -958,7 +958,7 @@ class TestAssertCloseErrorMessage(TestCase):
             for fn in assert_close_with_inputs(x, y):
                 with self.assertRaisesRegex(AssertionError, re.escape("The first mismatched element is at index 0")):
                     fn()
-            
+
             for fn in assert_close_with_inputs(w, y):
                 with self.assertRaisesRegex(AssertionError, re.escape("The first mismatched element is at index 1")):
                     fn()

--- a/test/test_type_info.py
+++ b/test/test_type_info.py
@@ -141,20 +141,6 @@ class TestDTypeInfo(TestCase):
         self.assertEqual(torch.complex64.to_real(), torch.float32)
         self.assertEqual(torch.complex32.to_real(), torch.float16)
 
-    def test_assert_close(self):
-        for dtype in [
-            torch.float8_e4m3fn,
-            torch.float8_e4m3fnuz,
-            torch.float8_e5m2,
-            torch.float8_e5m2fnuz,
-            torch.float8_e8m0fnu,
-        ]:
-            x = torch.tensor([1.0, 3.14], dtype=dtype)
-            y = torch.tensor([3.14, 3.14], dtype=dtype)
-            z = torch.tensor([1.0, 3.14], dtype=dtype)
-            with self.assertRaises(AssertionError):
-                torch.testing.assert_close(x, y)
-            torch.testing.assert_close(x, z)
 
 
 if __name__ == "__main__":

--- a/test/test_type_info.py
+++ b/test/test_type_info.py
@@ -142,7 +142,6 @@ class TestDTypeInfo(TestCase):
         self.assertEqual(torch.complex32.to_real(), torch.float16)
 
 
-
 if __name__ == "__main__":
     TestCase._default_dtype_check_enabled = True
     run_tests()

--- a/test/test_type_info.py
+++ b/test/test_type_info.py
@@ -141,6 +141,18 @@ class TestDTypeInfo(TestCase):
         self.assertEqual(torch.complex64.to_real(), torch.float32)
         self.assertEqual(torch.complex32.to_real(), torch.float16)
 
+    def test_assert_close(self):
+        for dtype in [
+            torch.float8_e4m3fn,
+            torch.float8_e4m3fnuz,
+            torch.float8_e5m2,
+            torch.float8_e5m2fnuz,
+            torch.float8_e8m0fnu,
+        ]:
+            x = torch.tensor([3.14, 3.14], dtype=dtype)
+            y = torch.tensor([3.14, 3.14], dtype=dtype)
+            torch.testing.assert_close(x, y)
+
 
 if __name__ == "__main__":
     TestCase._default_dtype_check_enabled = True

--- a/test/test_type_info.py
+++ b/test/test_type_info.py
@@ -149,9 +149,12 @@ class TestDTypeInfo(TestCase):
             torch.float8_e5m2fnuz,
             torch.float8_e8m0fnu,
         ]:
-            x = torch.tensor([3.14, 3.14], dtype=dtype)
+            x = torch.tensor([1.0, 3.14], dtype=dtype)
             y = torch.tensor([3.14, 3.14], dtype=dtype)
-            torch.testing.assert_close(x, y)
+            z = torch.tensor([1.0, 3.14], dtype=dtype)
+            with self.assertRaises(AssertionError):
+                torch.testing.assert_close(x, y)
+            torch.testing.assert_close(x, z)
 
 
 if __name__ == "__main__":

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -127,12 +127,13 @@ def get_tolerances(
     else:
         return default_tolerances(*inputs)
 
+
 def _make_bitwise_mismatch_msg(
     *,
     default_identifier: str,
     identifier: Optional[Union[str, Callable[[str], str]]] = None,
     extra: Optional[str] = None,
-    first_mismatch_idx: Optional[int] = None
+    first_mismatch_idx: Optional[int] = None,
 ):
     """makes a mismatch error message for bitwise values.
 
@@ -156,6 +157,7 @@ def _make_bitwise_mismatch_msg(
     if first_mismatch_idx is not None:
         msg += f"The first mismatched element is at index {first_mismatch_idx}.\n"
     return msg.strip()
+
 
 def _make_mismatch_msg(
     *,
@@ -311,7 +313,6 @@ def make_tensor_mismatch_msg(
         #  overflow
         actual_flat = actual_flat.to(torch.int64)
         expected_flat = expected_flat.to(torch.int64)
-
 
     abs_diff = torch.abs(actual_flat - expected_flat)
     # Ensure that only mismatches are used for the max_abs_diff computation
@@ -866,7 +867,10 @@ class TensorLikePair(Pair):
         elif actual.dtype.is_floating_point and actual.dtype.itemsize == 1:
             # intercept rtol and atol for bitwise comparison in low dimensional floats
             def bitwise_comp(actual, expected, rtol=0.0, atol=0.0, equal_nan=False):
-                return self._compare_regular_values_close(actual, expected, rtol = 0.0, atol = 0.0, equal_nan = equal_nan)
+                return self._compare_regular_values_close(
+                    actual, expected, rtol=0.0, atol=0.0, equal_nan=equal_nan
+                )
+
             compare_fn = bitwise_comp
         else:
             compare_fn = self._compare_regular_values_close
@@ -1333,7 +1337,7 @@ def assert_close(
     :meth:`~torch.Tensor.qscheme` and the result of :meth:`~torch.Tensor.dequantize` is close according to the
     definition above.
 
-    If ``actual`` and ``expected`` are small floating point dtypes, they are compared bitwise. In other words, 
+    If ``actual`` and ``expected`` are small floating point dtypes, they are compared bitwise. In other words,
     ``rtol`` and ``atol`` are set to zero.
 
     ``actual`` and ``expected`` can be :class:`~torch.Tensor`'s or any tensor-or-scalar-likes from which

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -274,7 +274,7 @@ def make_tensor_mismatch_msg(
         actual_flat = actual_flat.to(torch.int64)
         expected_flat = expected_flat.to(torch.int64)
 
-    if actual.dtype.is_floating_point() and actual.dtype.element_size() == 1:
+    if actual.dtype.is_floating_point and actual.element_size() == 1:
         actual_flat = actual_flat.to(torch.float32)
         expected_flat = expected_flat.to(torch.float32)
     abs_diff = torch.abs(actual_flat - expected_flat)

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -865,7 +865,6 @@ class TensorLikePair(Pair):
             actual, expected = actual.values(), expected.values()
             compare_fn = self._compare_regular_values_close
         elif actual.dtype.is_floating_point and actual.dtype.itemsize == 1:
-            # intercept rtol and atol for bitwise comparison in low dimensional floats
             def bitwise_comp(
                 actual: torch.Tensor,
                 expected: torch.Tensor,

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -865,6 +865,7 @@ class TensorLikePair(Pair):
             actual, expected = actual.values(), expected.values()
             compare_fn = self._compare_regular_values_close
         elif actual.dtype.is_floating_point and actual.dtype.itemsize == 1:
+
             def bitwise_comp(
                 actual: torch.Tensor,
                 expected: torch.Tensor,

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -274,6 +274,9 @@ def make_tensor_mismatch_msg(
         actual_flat = actual_flat.to(torch.int64)
         expected_flat = expected_flat.to(torch.int64)
 
+    if actual.dtype.is_floating_point() and actual.dtype.element_size() == 1:
+        actual_flat = actual_flat.to(torch.float32)
+        expected_flat = expected_flat.to(torch.float32)
     abs_diff = torch.abs(actual_flat - expected_flat)
     # Ensure that only mismatches are used for the max_abs_diff computation
     abs_diff[matches_flat] = 0

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -135,15 +135,15 @@ def _make_bitwise_mismatch_msg(
     extra: Optional[str] = None,
     first_mismatch_idx: Optional[int] = None,
 ):
-    """makes a mismatch error message for bitwise values.
+    """Makes a mismatch error message for bitwise values.
 
-    args:
-        default_identifier (str): default description of the compared values, e.g. "tensor-likes".
-        identifier (optional[union[str, callable[[str], str]]]): optional identifier that overrides
-            ``default_identifier``. can be passed as callable in which case it will be called with
+    Args:
+        default_identifier (str): Default description of the compared values, e.g. "Tensor-likes".
+        identifier (Optional[Union[str, Callable[[str], str]]]): Optional identifier that overrides
+            ``default_identifier``. Can be passed as callable in which case it will be called with
             ``default_identifier`` to create the description at runtime.
-        extra (optional[str]): extra information to be placed after the message header and the mismatch statistics.
-        first_mismatch_idx (optional[int]): the index of the first mismatch.
+        extra (Optional[str]): Extra information to be placed after the message header and the mismatch statistics.
+        first_mismatch_idx (Optional[int]): the index of the first mismatch.
     """
     if identifier is None:
         identifier = default_identifier


### PR DESCRIPTION
Fixes #135998

Adds support for fp8. These are compared bitwise, without atol and rtol. The implementation uses the same comparison functions, just with atol and rtol forced to zero. The error message is different from the default case; it only tells the user the first mismatch. This is to avoid triggering the error from #135998.

Test Plan:
New unit test covers new code paths.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov