### PR TITLE
Add min/max support in export

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -7,6 +7,7 @@
 #include <c10/core/SymInt.h>
 #include <c10/util/irange.h>
 #include <optional>
+#include <iostream>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -222,8 +223,8 @@ inline Tensor applySlice(
         ? (*self_sizes)[dim]
         : self.sym_size(dim);
     if (!disable_slice_optimization &&
-        TORCH_GUARD_SIZE_OBLIVIOUS(start.sym_eq(0)) &&
-        TORCH_GUARD_SIZE_OBLIVIOUS(length.sym_eq(stop)) && step == 1) {
+        TORCH_STATICALLY_KNOWN_TRUE(start.sym_eq(0)) &&
+        TORCH_STATICALLY_KNOWN_TRUE(length.sym_eq(stop)) && step == 1) {
       return self;
     }
   }

--- a/c10/core/SymBool.cpp
+++ b/c10/core/SymBool.cpp
@@ -80,6 +80,14 @@ bool SymBool::guard_or_false(const char* file, int64_t line) const {
   return a->guard_or_false(file, line);
 }
 
+bool SymBool::statically_known_true(const char* file, int64_t line) const {
+  if (auto ma = maybe_as_bool()) {
+    return *ma;
+  }
+  SymNode a = toSymNodeImpl();
+  return a->statically_known_true(file, line);
+}
+
 bool SymBool::guard_or_true(const char* file, int64_t line) const {
   if (auto ma = maybe_as_bool()) {
     return *ma;

--- a/c10/core/SymBool.h
+++ b/c10/core/SymBool.h
@@ -62,6 +62,7 @@ class C10_API SymBool {
   bool guard_bool(const char* file, int64_t line) const;
   bool expect_true(const char* file, int64_t line) const;
   bool guard_size_oblivious(const char* file, int64_t line) const;
+  bool statically_known_true(const char* file, int64_t line) const;
   bool guard_or_false(const char* file, int64_t line) const;
   bool guard_or_true(const char* file, int64_t line) const;
 
@@ -129,6 +130,20 @@ inline bool guard_or_false(
   return b.guard_or_false(file, line);
 }
 
+inline bool statically_known_true(
+  bool b,
+  const char* file [[maybe_unused]],
+  int64_t line [[maybe_unused]]) {
+return b;
+}
+
+inline bool statically_known_true(
+  const c10::SymBool& b,
+  const char* file,
+  int64_t line) {
+return b.statically_known_true(file, line);
+}
+
 inline bool guard_or_true(
     bool b,
     const char* file [[maybe_unused]],
@@ -145,6 +160,9 @@ inline bool guard_or_true(
 
 #define TORCH_GUARD_SIZE_OBLIVIOUS(cond) \
   c10::guard_size_oblivious((cond), __FILE__, __LINE__)
+
+#define TORCH_STATICALLY_KNOWN_TRUE(cond) \
+  c10::statically_known_true((cond), __FILE__, __LINE__)
 
 #define TORCH_GUARD_OR_FALSE(cond) \
   c10::guard_or_false((cond), __FILE__, __LINE__)

--- a/c10/core/SymNodeImpl.h
+++ b/c10/core/SymNodeImpl.h
@@ -191,6 +191,11 @@ class C10_API SymNodeImpl : public c10::intrusive_ptr_target {
     // with a better implementation!
     return guard_bool(file, line);
   }
+  virtual bool statically_known_true(const char* file, int64_t line) {
+    // No improvement for unbacked SymBools by default, replace this
+    // with a better implementation!
+    return guard_bool(file, line);
+  }
   virtual bool guard_or_true(const char* file, int64_t line) {
     // No improvement for unbacked SymBools by default, replace this
     // with a better implementation!

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1214,14 +1214,14 @@ utils_device.CURRENT_DEVICE == None""".split(
             get_test_fn(func=min),
             2,
             expected_ops=1,
-            expected_ops_dynamic=ifdynstaticdefault(1, 10),
+            expected_ops_dynamic=ifdynstaticdefault(1, 7),
         )
         torch._dynamo.testing.standard_test(
             self,
             get_test_fn(func=max),
             2,
             expected_ops=1,
-            expected_ops_dynamic=ifdynstaticdefault(1, 5),
+            expected_ops_dynamic=ifdynstaticdefault(1, 7),
         )
 
     @torch._dynamo.config.patch(capture_scalar_outputs=True)

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -1668,7 +1668,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(opt_fn(cfg), 64)
         # With unspec int, maximum computation is preserved
         self.assertExpectedInline(cnt.frame_count, """1""")
-        self.assertExpectedInline(cnt.op_count, """3""")
+        self.assertExpectedInline(cnt.op_count, """4""")
 
     def test_reformer_sorting(self):
         x = torch.zeros([1, 12, 4096], dtype=torch.int64)

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1434,8 +1434,7 @@ class TestSymNumberMagicMethods(TestCase):
                 out = lambda_apply(sym_inp1)
             else:
                 out = lambda_apply(sym_inp1, inp2)
-            if fn not in sym_node.alternate_impl_if_hinted_methods:
-                self.assertTrue(isinstance(out, (SymInt, SymFloat, SymBool)))
+            self.assertTrue(isinstance(out, (SymInt, SymFloat, SymBool)))
             out = guard_fn(out)
             self.assertEqual(out, ref_out)
 
@@ -1446,16 +1445,14 @@ class TestSymNumberMagicMethods(TestCase):
         sym_inp2 = get_sym_inp(inp2)
         with maybe_xfail(inp1, sym_inp2):
             out = lambda_apply(inp1, sym_inp2)
-            if fn not in sym_node.alternate_impl_if_hinted_methods:
-                self.assertTrue(isinstance(out, (SymInt, SymFloat, SymBool)))
+            self.assertTrue(isinstance(out, (SymInt, SymFloat, SymBool)))
             out = guard_fn(out)
             self.assertEqual(out, ref_out)
 
         # Symified both args
         with maybe_xfail(sym_inp1, sym_inp2):
             out = lambda_apply(sym_inp1, sym_inp2)
-            if fn not in sym_node.alternate_impl_if_hinted_methods:
-                self.assertTrue(isinstance(out, (SymInt, SymFloat, SymBool)))
+            self.assertTrue(isinstance(out, (SymInt, SymFloat, SymBool)))
             out = guard_fn(out)
             self.assertEqual(out, ref_out)
 

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -232,6 +232,7 @@ class CompileCounter:
     def __call__(
         self, gm: torch.fx.GraphModule, example_inputs: list[torch.Tensor]
     ) -> Callable[..., Any]:
+        print("GRAPH", gm.graph)
         self.frame_count += 1
         for node in gm.graph.nodes:
             if "call" in node.op:

--- a/torch/csrc/utils/python_symnode.h
+++ b/torch/csrc/utils/python_symnode.h
@@ -135,6 +135,11 @@ class PythonSymNodeImpl : public c10::SymNodeImpl {
     return getPyObj().attr("guard_size_oblivious")(file, line).cast<bool>();
   }
 
+  bool statically_known_true(const char* file, int64_t line) override {
+    py::gil_scoped_acquire acquire;
+    return getPyObj().attr("statically_known_true")(file, line).cast<bool>();
+  }
+
   bool guard_or_false(const char* file, int64_t line) override {
     py::gil_scoped_acquire acquire;
     return getPyObj().attr("guard_or_false")(file, line).cast<bool>();

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1347,7 +1347,7 @@ class PreDispatchTorchFunctionMode(TorchFunctionMode):
         args: tuple[object, ...] = (),
         kwargs: Optional[dict[str, object]] = None,
     ) -> object:
-        kwargs = kwargs or {}
+        kwargs = kwargs or {} 
         if func in _side_effectful_need_to_be_preserved_pre_dispatch:
             # It's for passing the export verifier which needs to verify the meta['val']
             # TODO(tmanlaibaatar): we should systematically couple it with expoert verifier,

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -572,6 +572,12 @@ class SymNode:
             _advise_is_size(SymInt(self))
         return r
 
+    def statically_known_true(self, file, line):
+        from torch.fx.experimental.symbolic_shapes import statically_known_true
+
+        assert self.is_bool()
+        return statically_known_true(SymBool(self))
+
     def guard_size_oblivious(self, file, line):
         """
         Like guard_bool, but if we encounter unbacked symbols, if those symbols
@@ -1219,12 +1225,6 @@ sizes_strides_methods = {
     "is_non_overlapping_and_dense_indicator": _sympy_is_non_overlapping_and_dense_indicator,
 }
 
-alternate_impl_if_hinted_methods = {
-    "sym_min": builtins.min,
-    "sym_max": builtins.max,
-}
-
-
 def to_node(self, num):
     if isinstance(num, SymTypes):
         return num.node
@@ -1341,10 +1341,6 @@ def _make_node_magic(method, func):
         out_hint = None
         if self.hint is not None and other.hint is not None:
             out_hint = op(self.hint, other.hint)
-
-        alternate_impl = alternate_impl_if_hinted_methods.get(method)
-        if alternate_impl and out_hint is not None:
-            return to_node(self, alternate_impl(wrap_node(self), wrap_node(other)))
 
         if get_proxy_mode():
             return to_node(

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5916,6 +5916,8 @@ class ShapeEnv:
         if size_oblivious and expr.has(Max):
             max_replacements = {}
             for atom in expr.atoms(Max):
+                if len(atom.args) > 2:
+                    continue
                 a, b = atom.args
                 if b == 1 or b == 0:
                     a, b = b, a


### PR DESCRIPTION
Summary: Title

Test Plan: CI

I tried my best to replicate what dynamo does for min/max but had to omit some dynamo variables being handled because they are not applicable to non-strict export. I think this is ok because:
1. The original dynamo logic for handling min/max hasn't changed past 2 years so it is relatively stable so there probably won't be new code added there. 
2. Compared to dynamo, non-strict can still fall into original builtin min/max. 

This shows up as error in Optimum benchmarking:
pytest tests/exporters/onnx/test_onnx_export.py -k test_pytorch_export_on_cpu_plain_export_227_ibert_feature_extraction

Differential Revision: D71869601




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames