### PR TITLE
Allow TritonTemplate subclasses to override kernel type

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1051,6 +1051,8 @@ def _jinja2_env():
 
 
 class TritonTemplate(KernelTemplate):
+    # Allow subclasses to override the kernel type
+    kernel_type: type[Any] = TritonTemplateKernel
     index_counter = itertools.count()
     all_templates: dict[str, "TritonTemplate"] = {}
 
@@ -1137,7 +1139,7 @@ class TritonTemplate(KernelTemplate):
         with (
             patch.object(V.graph, "get_dtype", self._fake_get_dtype(fake_out)),
             V.graph.set_current_device(layout.device),
-            TritonTemplateKernel(
+            self.kernel_type(
                 kernel_name=kernel_name,
                 output_node=fake_out,
                 workspace_arg=workspace_arg,
@@ -1187,7 +1189,7 @@ class TritonTemplate(KernelTemplate):
         kernel_hash_name = f"triton_{self.name}_{next(self.index_counter)}"
 
         def make_kernel_render(out_node):
-            kernel = TritonTemplateKernel(
+            kernel = self.kernel_type(
                 kernel_name=str(Placeholder.KERNEL_NAME),
                 output_node=out_node,
                 workspace_arg=workspace_arg,


### PR DESCRIPTION
Allows subclasses of `TritonTemplate` to override the kernel type, e.g.
```
class MyTritonTemplate(TritonTemplate):
    kernel_type = MyTritonTemplateKernel
```

This means that all of the logic in `TritonTemplate` class doesn't need to be duplicated in subclasses if the only required change is the kernel type.

Note that there is precedent for doing this - see `SIMDScheduling` in `torch/_inductor/codegen/simd.py`:

```
class SIMDScheduling(BaseScheduling):
    kernel_type: type[Any] = SIMDKernel  # override in subclass
...
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov