### PR TITLE
windows linker receives wrong non existent path

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -838,8 +838,7 @@ def _get_python_related_args() -> tuple[list[str], list[str]]:
         python_include_dirs.append(python_include_path)
 
     if _IS_WINDOWS:
-        python_path = os.path.dirname(sys.executable)
-        python_lib_path = [os.path.join(python_path, "libs")]
+        python_lib_path = [(Path(sysconfig.get_path("include", scheme="nt" )).parent / "libs").absolute()]
     else:
         python_lib_path = [sysconfig.get_config_var("LIBDIR")]
 


### PR DESCRIPTION
Fix to issue #149889  where the windows linker receives a wrong path.

cc @malfet @seemethere @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov