### PR TITLE
[TD] Enable TD on distributed cpu

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -30,7 +30,6 @@ from torch.testing._internal.common_utils import (
     get_report_path,
     IS_CI,
     IS_MACOS,
-    IS_WINDOWS,
     retry_shell,
     set_cwd,
     shell,

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1377,11 +1377,7 @@ def parse_args():
         default=IS_CI
         and (
             TEST_WITH_CROSSREF
-            or TEST_WITH_ASAN
-            or (TEST_CONFIG == "distributed" and TEST_CUDA)
-            or (IS_WINDOWS and not TEST_CUDA)
-            or TEST_CONFIG == "nogpu_AVX512"
-            or TEST_CONFIG == "nogpu_NO_AVX2"
+            or TEST_CONFIG == "distributed"
             or TEST_CONFIG == "default"
         )
         and get_pr_number() is not None


### PR DESCRIPTION
Enable TD on distributed cpu, I think the only reason it's not is because I forgot to enable it

Get rid of some of the statements that are no ops:
* asan uses default shard
* nogpu got moved to periodic
* no windows cuda testing anymore

Only thing on pull and trunk that doesn't use TD is dynamo_wrapped but I think it's fast enough to be ok for now, we can take another look after this