### PR TITLE
[ONNX] Annotate None inputs in symbolic ops

### DIFF
--- a/test/onnx/ops/test_ops.py
+++ b/test/onnx/ops/test_ops.py
@@ -145,7 +145,7 @@ class SymbolicOpsTest(common_utils.TestCase):
             def forward(self, x: torch.Tensor):
                 return torch.onnx.ops.symbolic(
                     "custom_domain::CustomOp",
-                    (x,),
+                    (x, None),
                     dict(
                         int_key=1,
                         float_key=1.0,
@@ -289,7 +289,7 @@ class SymbolicOpsTest(common_utils.TestCase):
             def forward(self, x: torch.Tensor):
                 return torch.onnx.ops.symbolic_multi_out(
                     "custom_domain::CustomOp",
-                    (x,),
+                    (x, None),
                     dict(
                         int_key=1,
                         float_key=1.0,

--- a/torch/onnx/ops/__init__.py
+++ b/torch/onnx/ops/__init__.py
@@ -55,7 +55,7 @@ def _parse_domain_op_type(domain_op: str) -> tuple[str, str]:
 def symbolic(
     domain_op: str,
     /,
-    inputs: Sequence[torch.Tensor],
+    inputs: Sequence[torch.Tensor | None],
     attrs: dict[
         str,
         int
@@ -153,7 +153,7 @@ def symbolic(
 def symbolic_multi_out(
     domain_op: str,
     /,
-    inputs: Sequence[torch.Tensor],
+    inputs: Sequence[torch.Tensor | None],
     attrs: dict[
         str,
         int


### PR DESCRIPTION
Add `None` to type annotations of `torch.onnx.ops.symbolic*` ops and improve tests to test support for optional inputs. Previously it was omitted mistakenly even though the implementation supports it.