### PR TITLE
[draft][FSDP2] Reorder FSDP2 pre_forward

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
@@ -599,10 +599,9 @@ class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
         fully_shard(model, mp_policy=mp_policy)
         x = torch.randn(256, 2048).cuda()
         x.requires_grad = True
-        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
-            out = checkpoint(model, x, use_reentrant=False)
-            loss = out.sum()
-            loss.backward()
+        out = checkpoint(model, x, use_reentrant=False)
+        loss = out.sum()
+        loss.backward()
 
 
 if __name__ == "__main__":

--- a/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
@@ -582,6 +582,7 @@ class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
             loss = model(inp).sum()
             loss.backward()
 
+    @skip_if_lt_x_gpu(1)
     def test_autocast_with_checkpoint(self):
         class ForwardModel(nn.Module):
             def __init__(self):

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -22,6 +22,7 @@ from torch.distributed.fsdp import (
     CPUOffloadPolicy,
     FSDPModule,
     fully_shard,
+    MixedPrecisionPolicy,
     OffloadPolicy,
     register_fsdp_forward_method,
 )
@@ -746,8 +747,98 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
                     self, ref_model, model, prefixes_to_ignore=prefixes_to_ignore
                 )
 
+    @skip_if_lt_x_gpu(2)
+    def test_train_parity_with_mp_policy(self):
+        """
+        Tests train parity against DDP when composing with activation
+        checkpointing, mp_policy and float input.
+        """
+        self.run_subtests(
+            {
+                "reshard_after_forward": [True, False],
+                "checkpoint_impl": ["utils"],  # "composable" could pass the test
+            },
+            self._test_train_parity_with_mp_policy,
+        )
 
-class TestFullyShardShardPlacementFnMultiProcess(FSDPTest):
+    def _test_train_parity_with_mp_policy(
+        self,
+        reshard_after_forward: Union[bool, int],
+        checkpoint_impl: str,
+    ):
+        assert checkpoint_impl in ("composable", "utils")
+        torch.manual_seed(42)
+        with torch.device(torch.device("cuda")):
+            model = MLP(8)
+        ref_model = replicate(copy.deepcopy(model), device_ids=[self.rank])
+        ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
+
+        if checkpoint_impl == "composable":
+            checkpoint(model)
+
+        # Apply FSDP with mp_policy
+        param_dtype = torch.bfloat16
+        reduce_dtype = torch.bfloat16
+        mp_policy = MixedPrecisionPolicy(
+            param_dtype=param_dtype, reduce_dtype=reduce_dtype
+        )
+        fsdp_kwargs = {
+            "reshard_after_forward": reshard_after_forward,
+            "mp_policy": mp_policy,
+        }
+        ref_model_compute = replicate(copy.deepcopy(model), device_ids=[self.rank]).to(
+            param_dtype
+        )
+        fully_shard(model, **fsdp_kwargs)
+        optim = torch.optim.Adam(model.parameters(), lr=1e-2)
+
+        torch.manual_seed(42 + self.rank)
+        # Use float input here
+        inp = torch.randn((2, 8), device="cuda")
+
+        for iter_idx in range(10):
+            torch.manual_seed(iter_idx + 1)
+            # under utils, with float input and mp_policy set, there's failure.
+            if checkpoint_impl == "utils":
+                out = torch.utils.checkpoint.checkpoint(model, inp, use_reentrant=False)
+            else:
+                out = model(inp)
+            loss = out.sum()
+            loss.backward()
+
+            ref_optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+            ref_loss = ref_model_compute(inp.to(param_dtype)).sum()
+            ref_loss.backward()
+
+            self.assertEqual(ref_loss, loss)
+
+            for ref_param, ref_param_compute in zip(
+                ref_model.parameters(), ref_model_compute.parameters()
+            ):
+                self.assertTrue(ref_param_compute.grad is not None)
+                self.assertEqual(ref_param.dtype, torch.float32)
+                if ref_param.grad is not None:
+                    ref_param.grad += ref_param_compute.grad
+                else:
+                    ref_param.grad = ref_param_compute.grad.to(ref_param.dtype)
+                ref_param_compute.grad = None
+            for ref_param in ref_model.parameters():
+                self.assertTrue(ref_param.grad is not None)
+                dist.all_reduce(ref_param.grad)
+                ref_param.grad /= self.world_size
+
+            check_sharded_parity(self, ref_model_compute, model)
+            optim.step()
+            ref_optim.step()
+            ref_optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+            optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+            for ref_param, ref_param_compute in zip(
+                ref_model.parameters(), ref_model_compute.parameters()
+            ):
+                ref_param_compute.detach().copy_(ref_param)
+
+
+class TestFullyShardShardPlacementFnMultiProcess(FSDPTestMultiThread):
     @property
     def world_size(self) -> int:
         return min(8, torch.cuda.device_count())

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -22,7 +22,6 @@ from torch.distributed.fsdp import (
     CPUOffloadPolicy,
     FSDPModule,
     fully_shard,
-    MixedPrecisionPolicy,
     OffloadPolicy,
     register_fsdp_forward_method,
 )
@@ -746,96 +745,6 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
                 check_sharded_parity(
                     self, ref_model, model, prefixes_to_ignore=prefixes_to_ignore
                 )
-
-    @skip_if_lt_x_gpu(2)
-    def test_train_parity_with_mp_policy(self):
-        """
-        Tests train parity against DDP when composing with activation
-        checkpointing, mp_policy and float input.
-        """
-        self.run_subtests(
-            {
-                "reshard_after_forward": [True, False],
-                "checkpoint_impl": ["utils"],  # "composable" could pass the test
-            },
-            self._test_train_parity_with_mp_policy,
-        )
-
-    def _test_train_parity_with_mp_policy(
-        self,
-        reshard_after_forward: Union[bool, int],
-        checkpoint_impl: str,
-    ):
-        assert checkpoint_impl in ("composable", "utils")
-        torch.manual_seed(42)
-        with torch.device(torch.device("cuda")):
-            model = MLP(8)
-        ref_model = replicate(copy.deepcopy(model), device_ids=[self.rank])
-        ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
-
-        if checkpoint_impl == "composable":
-            checkpoint(model)
-
-        # Apply FSDP with mp_policy
-        param_dtype = torch.bfloat16
-        reduce_dtype = torch.bfloat16
-        mp_policy = MixedPrecisionPolicy(
-            param_dtype=param_dtype, reduce_dtype=reduce_dtype
-        )
-        fsdp_kwargs = {
-            "reshard_after_forward": reshard_after_forward,
-            "mp_policy": mp_policy,
-        }
-        ref_model_compute = replicate(copy.deepcopy(model), device_ids=[self.rank]).to(
-            param_dtype
-        )
-        fully_shard(model, **fsdp_kwargs)
-        optim = torch.optim.Adam(model.parameters(), lr=1e-2)
-
-        torch.manual_seed(42 + self.rank)
-        # Use float input here
-        inp = torch.randn((2, 8), device="cuda")
-
-        for iter_idx in range(10):
-            torch.manual_seed(iter_idx + 1)
-            # under utils, with float input and mp_policy set, there's failure.
-            if checkpoint_impl == "utils":
-                out = torch.utils.checkpoint.checkpoint(model, inp, use_reentrant=False)
-            else:
-                out = model(inp)
-            loss = out.sum()
-            loss.backward()
-
-            ref_optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
-            ref_loss = ref_model_compute(inp.to(param_dtype)).sum()
-            ref_loss.backward()
-
-            self.assertEqual(ref_loss, loss)
-
-            for ref_param, ref_param_compute in zip(
-                ref_model.parameters(), ref_model_compute.parameters()
-            ):
-                self.assertTrue(ref_param_compute.grad is not None)
-                self.assertEqual(ref_param.dtype, torch.float32)
-                if ref_param.grad is not None:
-                    ref_param.grad += ref_param_compute.grad
-                else:
-                    ref_param.grad = ref_param_compute.grad.to(ref_param.dtype)
-                ref_param_compute.grad = None
-            for ref_param in ref_model.parameters():
-                self.assertTrue(ref_param.grad is not None)
-                dist.all_reduce(ref_param.grad)
-                ref_param.grad /= self.world_size
-
-            check_sharded_parity(self, ref_model_compute, model)
-            optim.step()
-            ref_optim.step()
-            ref_optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
-            optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
-            for ref_param, ref_param_compute in zip(
-                ref_model.parameters(), ref_model_compute.parameters()
-            ):
-                ref_param_compute.detach().copy_(ref_param)
 
 
 class TestFullyShardShardPlacementFnMultiProcess(FSDPTestMultiThread):

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -747,7 +747,7 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
                 )
 
 
-class TestFullyShardShardPlacementFnMultiProcess(FSDPTestMultiThread):
+class TestFullyShardShardPlacementFnMultiProcess(FSDPTest):
     @property
     def world_size(self) -> int:
         return min(8, torch.cuda.device_count())

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -216,7 +216,6 @@ class FSDPState(_State):
     ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         # When composing with module-hook-based activation checkpointing, the
         # the pre-backward hook is responsible for the unshard
-        # torch.distributed.breakpoint()
         args, kwargs = self._root_pre_forward(module, args, kwargs)
         if self._mp_policy.cast_forward_inputs and self._mp_policy.param_dtype:
             with torch.profiler.record_function("FSDP::cast_forward_inputs"):

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -216,15 +216,7 @@ class FSDPState(_State):
     ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         # When composing with module-hook-based activation checkpointing, the
         # the pre-backward hook is responsible for the unshard
-        if self._training_state == TrainingState.PRE_BACKWARD:
-            if self._mp_policy.cast_forward_inputs and self._mp_policy.param_dtype:
-                with torch.profiler.record_function("FSDP::cast_forward_inputs"):
-                    cast_fn = functools.partial(
-                        _cast_fp_tensor, self._mp_policy.param_dtype
-                    )
-                    args, kwargs = tree_map(cast_fn, args), tree_map(cast_fn, kwargs)
-            return args, kwargs
-        self._training_state = TrainingState.FORWARD
+        # torch.distributed.breakpoint()
         args, kwargs = self._root_pre_forward(module, args, kwargs)
         if self._mp_policy.cast_forward_inputs and self._mp_policy.param_dtype:
             with torch.profiler.record_function("FSDP::cast_forward_inputs"):
@@ -232,6 +224,9 @@ class FSDPState(_State):
                     _cast_fp_tensor, self._mp_policy.param_dtype
                 )
                 args, kwargs = tree_map(cast_fn, args), tree_map(cast_fn, kwargs)
+        if self._training_state == TrainingState.PRE_BACKWARD:
+            return args, kwargs
+        self._training_state = TrainingState.FORWARD
         if self._fsdp_param_group:
             args, kwargs = self._fsdp_param_group.pre_forward(module, args, kwargs)
         for fsdp_state in self._states_to_forward_prefetch:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/148831
When using checkpoint() of FSDP2, pre_forward will be called twice
Then second time to be call will have the training state as pre_backward, 
If mp_policy is set, args would not be casted in the seconds time, raise error `torch.utils.checkpoint: Recomputed values for the following tensors have different metadata than during the forward pass.`

This issue does not happen at FSDP1, because they have the different pre_forward:
FSDP1: 
- _root_pre_forward
    - _cast_forward_inputs(state.mixed_precision.param_dtype)
- _pre_forward
    - return if training state is `HandleTrainingState.BACKWARD_PRE`

FSDP2:
- _pre_forward
    - return if training state is `TrainingState.PRE_BACKWARD`
    - _root_pre_forward
    - cast_fn(self._mp_policy.param_dtype)



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o