### PR TITLE
Fix bug in _load_state_dict_from_keys method

### DIFF
--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -322,7 +322,7 @@ def _load_state_dict_from_keys(
         storage_reader=storage_reader,
         process_group=process_group,
         no_dist=no_dist,
-        planner=_EmptyStateDictLoadPlanner(keys=keys or set()),
+        planner=_EmptyStateDictLoadPlanner(keys=keys),
     )
 
     return sd


### PR DESCRIPTION
Summary:
The _load_state_dict_from_keys method specifies that `Loads any key specified in this set. If no keys are specified, the entire checkpoint is loaded.`
But this isn't happening right now, because an empty keys arg is passed in as a set() to `_load_state_dict` and keys is expected to be None for it to actually be included in the state_dict https://fburl.com/code/l8yzojyx. So with the set() argument, the state_dict is always going to be empty

Test Plan: ensure existing tests pass

Differential Revision: D71930712




cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o