### PR TITLE
Delete linux-focal-cuda12_6-py3_10-gcc11-bazel-test

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -204,18 +204,3 @@ jobs:
       test-matrix: ${{ needs.linux-focal-cuda12_6-py3-gcc11-slow-gradcheck-build.outputs.test-matrix }}
       timeout-minutes: 300
     secrets: inherit
-
-  linux-focal-cuda12_6-py3_10-gcc11-bazel-test:
-    name: linux-focal-cuda12.6-py3.10-gcc11-bazel-test
-    uses: ./.github/workflows/_bazel-build-test.yml
-    needs: get-label-type
-    with:
-      runner: "${{ needs.get-label-type.outputs.label-type }}linux.large"
-      build-environment: linux-focal-cuda12.6-py3.10-gcc11-bazel-test
-      docker-image-name: pytorch-linux-focal-cuda12.6-cudnn9-py3-gcc11
-      cuda-version: "12.6"
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
-        ]}
-    secrets: inherit


### PR DESCRIPTION
It's been broken for a while even when this jobs were still called ` linux-focal-cuda12.4-py3.10-gcc9-bazel-test`
Last time it run successfully on Feb 21st
