### PR TITLE
[c10d] Move unstashing from watchdog to main thread

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2355,12 +2355,10 @@ void ProcessGroupNCCL::watchdogHandler() {
         // to be destructed, so we transfer the work's shelf to a shelves
         // structure owned by the PG.
         if (!work.stashed_for_allocator_safety_->empty()) {
-          {
-            std::lock_guard<std::mutex> lock(shelvesMutex_);
-            // We are just pushing back a shared_ptr here, so the cost should be
-            // minimal
-            shelvesToUnstash_.push_back(work.stashed_for_allocator_safety_);
-          }
+          std::lock_guard<std::mutex> lock(shelvesMutex_);
+          // We are just pushing back a shared_ptr here, so the cost should be
+          // minimal
+          shelvesToUnstash_.push_back(work.stashed_for_allocator_safety_);
         }
 
         // Work status logging for desync debug

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -39,7 +39,7 @@
 
 namespace c10d {
 
-// A type for stashing tensors between op call and `work.wait()`
+// A shelf type for stashing tensors between op call and `work.wait()`
 typedef std::vector<at::Tensor> TensorShelf;
 
 // Control broadcasting of NCCL uniqueId


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #150130
* __->__ #150079
* #148590

This is a fix to the PR below.

### Context
If a work has completed but user didn't call `work.wait()`, we have responsibility to unstash the tensors (to allow memory recycle).  Previously we perform the unstashing in watchdog thread, after it detects that the work has completed while the "tensor shelf" is still full. But this caused some rare issues. (Note that this situation can also happen if the user "deliberately" defer the work.wait() call to very late, or the GPU kernel runs super fast.)

### Solution
This PR moves the unstashing from watchdog thread to main thread, and the "rare issue" seems to go away. To do that, we created a "shelf pool" in PG, and when watchdog is about to erase a work, it transfers the work's shelf to that pool (this is just a shared_ptr copy, thus low in cost). To clean the shelf pool in main thread, we piggyback user calls. For example, every collective call would trigger the function `workEnqueue()`, so we put the cleaning there.

### Side topic: 
(cc @ngimel )
The fact that unstashing tensors from watchdog thread causes an error / data corruption is weird. 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o

Differential Revision: [D71995632](https://our.internmc.facebook.com/intern/diff/D71995632)