### PR TITLE
[export] Generate meta kernel

### DIFF
--- a/aten/src/ATen/native/ComparisonUtils.cpp
+++ b/aten/src/ATen/native/ComparisonUtils.cpp
@@ -18,10 +18,8 @@ void _assert_match(const O& original, const C& compared, const std::string& name
     bool equal = (original == compared.value());
     if (!equal) {
       std::stringstream msg;
-      msg << "Tensor " << name << " mismatch!";
-      if (!equal) {
-        throw std::runtime_error(msg.str());
-      }
+      msg << "Tensor " << name << " mismatch! Expected: " << compared.value() << ", Got: " << original;
+      throw std::runtime_error(msg.str());
     }
   }
 }

--- a/test/export/test_draft_export.py
+++ b/test/export/test_draft_export.py
@@ -4,8 +4,11 @@ import tempfile
 import unittest
 
 import torch
+from torch._library.fake_profile import MissingOpProfile, OpProfile, TensorMetadata
+from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.export import Dim, export
 from torch.export._draft_export import draft_export, FailureType
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
 from torch.testing._internal.torchbind_impls import (
@@ -29,7 +32,7 @@ class TestDraftExport(TestCase):
     def tearDown(self):
         return
 
-    def test_missing_meta_kernel_custom_op(self):
+    def test_missing_meta_kernel_custom_op_basic(self):
         with torch.library._scoped_library("mylib", "FRAGMENT"):
 
             @torch.library.custom_op("mylib::foo2", mutates_args={})
@@ -54,6 +57,9 @@ class TestDraftExport(TestCase):
             inp = (torch.randn(3, 3), torch.randn(3, 3))
             self.assertEqual(ep.module()(*inp), M()(*inp))
 
+            with torch._library.fake_profile.register_fake_profile(report.op_profiles):
+                ep.run_decompositions()
+
     def test_missing_meta_kernel_impl(self):
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
             torch.library.define(
@@ -64,7 +70,7 @@ class TestDraftExport(TestCase):
             )
 
             @torch.library.impl("mylib::foo", "cpu", lib=lib)
-            def foo_impl(a, b):
+            def foo_impl(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
                 return a + b
 
             class M(torch.nn.Module):
@@ -85,6 +91,100 @@ class TestDraftExport(TestCase):
 
             inp = (torch.randn(3, 3), torch.randn(3, 3))
             self.assertEqual(ep.module()(*inp), M()(*inp))
+
+            self.assertEqual(len(report.op_profiles), 1)
+            self.assertEqual(len(report.op_profiles["mylib.foo.default"]), 1)
+            print(report.op_profiles)
+
+            with torch._library.fake_profile.register_fake_profile(report.op_profiles):
+                ep = ep.run_decompositions()
+            self.assertEqual(ep.module()(*inp), M()(*inp))
+
+    def test_missing_meta_kernel_custom_op_multiple_profiles(self):
+        with torch.library._scoped_library("mylib", "FRAGMENT"):
+
+            @torch.library.custom_op("mylib::foo3", mutates_args={})
+            def foo3_impl(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+                return a + b
+
+            class M(torch.nn.Module):
+                def forward(self, a, b, c, d):
+                    res1 = torch.ops.mylib.foo3(a, b)
+                    res2 = torch.ops.mylib.foo3(c, d)
+                    return res1, res2
+
+            inp = (
+                torch.ones(3, 4),
+                torch.ones(3, 4),
+                torch.ones(2, 3, 4),
+                torch.ones(2, 3, 4),
+            )
+
+            ep = draft_export(M(), inp)
+            report = ep._report
+
+            self.assertEqual(len(report.failures), 1)
+            self.assertEqual(
+                report.failures[0].failure_type, FailureType.MISSING_FAKE_KERNEL
+            )
+            self.assertEqual(len(report.op_profiles), 1)
+            self.assertEqual(len(report.op_profiles["mylib.foo3.default"]), 2)
+
+            with torch._library.fake_profile.register_fake_profile(report.op_profiles):
+                ep.run_decompositions()
+
+    def test_missing_meta_kernel_custom_op_update_profile(self):
+        with torch.library._scoped_library("mylib", "FRAGMENT"):
+
+            @torch.library.custom_op("mylib::foo8", mutates_args={})
+            def foo8_impl(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+                return a + b
+
+            class M(torch.nn.Module):
+                def forward(self, a, b):
+                    res = torch.ops.mylib.foo8(a, b)
+                    return res
+
+            inp = (
+                torch.ones(3, 4),
+                torch.ones(3, 4),
+            )
+
+            ep = draft_export(M(), inp)
+            report = ep._report
+            self.assertEqual(len(report.op_profiles), 1)
+            self.assertEqual(len(report.op_profiles["mylib.foo8.default"]), 1)
+
+            new_inp = (
+                torch.ones(2, 3, 4),
+                torch.ones(2, 3, 4),
+            )
+
+            with torch._library.fake_profile.register_fake_profile(report.op_profiles):
+                with FakeTensorMode(allow_non_fake_inputs=True, shape_env=ShapeEnv()):
+                    torch.ops.mylib.foo8(*inp)
+                    with self.assertRaisesRegex(
+                        RuntimeError, "no profiles match the given inputs"
+                    ):
+                        torch.ops.mylib.foo8(*new_inp)
+
+                ep = draft_export(M(), new_inp)
+
+            report = ep._report
+            self.assertEqual(len(report.op_profiles), 1)
+            self.assertEqual(len(report.op_profiles["mylib.foo8.default"]), 1)
+
+            with torch._library.fake_profile.register_fake_profile(
+                report.op_profiles
+            ), FakeTensorMode(allow_non_fake_inputs=True, shape_env=ShapeEnv()):
+                torch.ops.mylib.foo8(*new_inp)
+
+                # Existing registration has been updated to match the new
+                # profile traced with draft-export
+                with self.assertRaisesRegex(
+                    RuntimeError, "no profiles match the given inputs"
+                ):
+                    torch.ops.mylib.foo8(*inp)
 
     @unittest.skipIf(not torch.cuda.is_available(), "Requires cuda")
     def test_missing_meta_kernel_guard(self):
@@ -405,122 +505,138 @@ class TestDraftExport(TestCase):
         self.assertEqual(tq.size(), 2)
 
     def test_override_size_and_dtype_mismatched_fake_kernels(self):
-        class M(torch.nn.Module):
-            def forward(self, a):
-                return torch.ops.mylib.foo(a)
+        with torch.library._scoped_library("mylib", "FRAGMENT"):
 
-        @torch.library.custom_op("mylib::foo", mutates_args={})
-        def foo(a: torch.Tensor) -> list[torch.Tensor]:
-            x = a * 2
-            y = a.repeat(2, 2)
-            z = a.to(torch.bfloat16)
-            return [x, y, z]
+            class M(torch.nn.Module):
+                def forward(self, a):
+                    return torch.ops.mylib.foo9(a)
 
-        @foo.register_fake
-        def foo_fake_impl(a):
-            x = torch.empty_like(a)  # good
-            y = torch.empty_like(a)  # size mismatch
-            z = torch.empty_like(a)  # dtype mismatch
-            return [x, y, z]
+            @torch.library.custom_op("mylib::foo9", mutates_args={})
+            def foo(a: torch.Tensor) -> list[torch.Tensor]:
+                x = a * 2
+                y = a.repeat(2, 2)
+                z = a.to(torch.bfloat16)
+                return [x, y, z]
 
-        mod = M()
-        inputs = (torch.randn(3, 3),)
-        with self.assertRaises(RuntimeError):
-            with torch._functorch.config.patch(fake_tensor_propagate_real_tensors=True):
-                export(mod, inputs, strict=True)
+            @torch.library.register_fake("mylib::foo9")
+            def foo_fake_impl(a):
+                x = torch.empty_like(a)  # good
+                y = torch.empty_like(a)  # size mismatch
+                z = torch.empty_like(a)  # dtype mismatch
+                return [x, y, z]
 
-        ep = draft_export(mod, inputs)
-        report = ep._report
-        for ep_out, eager_out in zip(ep.module()(*inputs), mod(*inputs)):
-            self.assertTrue(torch.allclose(ep_out, eager_out))
-            self.assertEqual(ep_out.dtype, eager_out.dtype)
+            mod = M()
+            inputs = (torch.randn(3, 3),)
+            with self.assertRaises(RuntimeError):
+                with torch._functorch.config.patch(
+                    fake_tensor_propagate_real_tensors=True
+                ):
+                    export(mod, inputs, strict=True)
 
-        self.assertEqual(len(report.failures), 2)
-        self.assertEqual(
-            report.failures[0].failure_type, FailureType.MISMATCHED_FAKE_KERNEL
-        )
-        self.assertEqual(
-            report.failures[1].failure_type, FailureType.MISMATCHED_FAKE_KERNEL
-        )
-        self.assertEqual(
-            sorted([f.data["reason"] for f in report.failures]),
-            [
-                "Dtypes torch.bfloat16 and torch.float32 are not equal!",
-                "mismatch between fake value 3 and real value 6 ",
-            ],
-        )
+            ep = draft_export(mod, inputs)
+            report = ep._report
+            for ep_out, eager_out in zip(ep.module()(*inputs), mod(*inputs)):
+                self.assertTrue(torch.allclose(ep_out, eager_out))
+                self.assertEqual(ep_out.dtype, eager_out.dtype)
+
+            self.assertEqual(len(report.failures), 2)
+            self.assertEqual(
+                report.failures[0].failure_type, FailureType.MISMATCHED_FAKE_KERNEL
+            )
+            self.assertEqual(
+                report.failures[1].failure_type, FailureType.MISMATCHED_FAKE_KERNEL
+            )
+            self.assertEqual(
+                sorted([f.data["reason"] for f in report.failures]),
+                [
+                    "Dtypes torch.bfloat16 and torch.float32 are not equal!",
+                    "mismatch between fake value 3 and real value 6 ",
+                ],
+            )
+
+            with torch._library.fake_profile.register_fake_profile(report.op_profiles):
+                ep.run_decompositions()
 
     def test_override_incorrectly_aliasing_kernel(self):
-        class M(torch.nn.Module):
-            def forward(self, a):
-                return torch.ops.mylib.foo(a)
+        with torch.library._scoped_library("mylib", "FRAGMENT"):
 
-        @torch.library.custom_op("mylib::foo", mutates_args={})
-        def foo(a: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-            return a * 2, a + 2
+            @torch.library.custom_op("mylib::foo10", mutates_args={})
+            def foo(a: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+                return a * 2, a + 2
 
-        @foo.register_fake
-        def foo_fake_impl(a):
-            return a, torch.empty_like(a)  # incorrectly aliasing
+            @torch.library.register_fake("mylib::foo10")
+            def foo_fake_impl(a):
+                return a, torch.empty_like(a)  # incorrectly aliasing
 
-        mod = M()
-        inputs = (torch.randn(3, 3),)
-        with self.assertRaisesRegex(
-            RuntimeError,
-            "Real tensor propagation found an aliasing mismatch",
-        ):
-            with torch._functorch.config.patch(fake_tensor_propagate_real_tensors=True):
-                export(mod, inputs, strict=True)
+            class M(torch.nn.Module):
+                def forward(self, a):
+                    return torch.ops.mylib.foo10(a)
 
-        ep = draft_export(mod, inputs)
-        report = ep._report
-        for ep_out, eager_out in zip(
-            tree_leaves(ep.module()(*inputs)), tree_leaves(mod(*inputs))
-        ):
-            self.assertTrue(torch.allclose(ep_out, eager_out))
-            self.assertEqual(ep_out.dtype, eager_out.dtype)
+            mod = M()
+            inputs = (torch.randn(3, 3),)
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Real tensor propagation found an aliasing mismatch",
+            ):
+                with torch._functorch.config.patch(
+                    fake_tensor_propagate_real_tensors=True
+                ):
+                    export(mod, inputs, strict=True)
 
-        self.assertEqual(len(report.failures), 1)
-        self.assertEqual(
-            report.failures[0].failure_type, FailureType.MISMATCHED_FAKE_KERNEL
-        )
-        self.assertTrue(
-            "Mismatched aliasing spec between fake kernel and real kernel"
-            in report.failures[0].data["reason"]
-        )
+            ep = draft_export(mod, inputs)
+            report = ep._report
+            for ep_out, eager_out in zip(
+                tree_leaves(ep.module()(*inputs)), tree_leaves(mod(*inputs))
+            ):
+                self.assertTrue(torch.allclose(ep_out, eager_out))
+                self.assertEqual(ep_out.dtype, eager_out.dtype)
+
+            self.assertEqual(len(report.failures), 1)
+            self.assertEqual(
+                report.failures[0].failure_type, FailureType.MISMATCHED_FAKE_KERNEL
+            )
+            self.assertTrue(
+                "Mismatched aliasing spec between fake kernel and real kernel"
+                in report.failures[0].data["reason"]
+            )
 
     def test_override_mismatched_fake_kernel_with_unbacked_symbols(self):
-        class M(torch.nn.Module):
-            def forward(self, a, b):
-                return torch.ops.mylib.foo(a, b)
+        with torch.library._scoped_library("mylib", "FRAGMENT"):
 
-        @torch.library.custom_op("mylib::foo", mutates_args={})
-        def foo(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-            return a[b.item()].to(torch.bfloat16)
+            @torch.library.custom_op("mylib::foo11", mutates_args={})
+            def foo11(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+                return a[b.item()].to(torch.bfloat16)
 
-        @foo.register_fake
-        def foo_fake_impl(a, b):
-            ctx = torch.library.get_ctx()
-            u = ctx.new_dynamic_size()
-            return torch.empty(u, a.shape[1], dtype=a.dtype)
+            @torch.library.register_fake("mylib::foo11")
+            def foo_fake_impl(a, b):
+                ctx = torch.library.get_ctx()
+                u = ctx.new_dynamic_size()
+                return torch.empty(u, a.shape[1], dtype=a.dtype)
 
-        mod = M()
-        inputs = (torch.randn(100, 4), torch.tensor(10))
+            class M(torch.nn.Module):
+                def forward(self, a, b):
+                    return torch.ops.mylib.foo11(a, b)
 
-        ep = draft_export(mod, inputs)
-        report = ep._report
-        for ep_out, eager_out in zip(ep.module()(*inputs), mod(*inputs)):
-            self.assertTrue(torch.allclose(ep_out, eager_out))
-            self.assertEqual(ep_out.dtype, eager_out.dtype)
+            mod = M()
+            inputs = (torch.randn(100, 4), torch.tensor(10))
 
-        self.assertEqual(len(report.failures), 1)
-        self.assertEqual(
-            report.failures[0].failure_type, FailureType.MISMATCHED_FAKE_KERNEL
-        )
-        self.assertEqual(
-            report.failures[0].data["reason"],
-            "Dtypes torch.bfloat16 and torch.float32 are not equal!",
-        )
+            ep = draft_export(mod, inputs)
+
+            report = ep._report
+            for ep_out, eager_out in zip(ep.module()(*inputs), mod(*inputs)):
+                self.assertTrue(torch.allclose(ep_out, eager_out))
+                self.assertEqual(ep_out.dtype, eager_out.dtype)
+
+            self.assertEqual(len(report.failures), 1)
+            self.assertEqual(
+                report.failures[0].failure_type, FailureType.MISMATCHED_FAKE_KERNEL
+            )
+            self.assertEqual(
+                report.failures[0].data["reason"],
+                "Dtypes torch.bfloat16 and torch.float32 are not equal!",
+            )
+            with torch._library.fake_profile.register_fake_profile(report.op_profiles):
+                ep.run_decompositions()
 
     # https://github.com/pytorch/pytorch/issues/140625
     @unittest.skipIf(IS_WINDOWS, "aoti_compile_and_package not supported on Windows")

--- a/torch/_export/passes/insert_custom_op_guards.py
+++ b/torch/_export/passes/insert_custom_op_guards.py
@@ -1,13 +1,15 @@
 import functools
+from collections import defaultdict
 
 import torch
 from torch._export.passes._node_metadata_hook import (
     _node_metadata_hook,
     _set_node_metadata_hook,
 )
+from torch._library.fake_profile import OpProfile, TensorMetadata
 
 
-def insert_custom_op_guards(gm: torch.fx.GraphModule, ops_to_guard: list[str]) -> None:
+def insert_custom_op_guards(gm: torch.fx.GraphModule, ops_to_guard: set[str]) -> None:
     """
     This is used by draft_export to insert guards in front of calls to custom
     operators which have a generated fake kernel.
@@ -36,3 +38,41 @@ def insert_custom_op_guards(gm: torch.fx.GraphModule, ops_to_guard: list[str]) -
                         )
 
     gm.recompile()
+
+
+def get_op_profiles(
+    gm: torch.fx.GraphModule, ops_to_guard: set[str]
+) -> dict[str, set[OpProfile]]:
+    """
+    This is used by draft_export to get a list of custom operator profiles so
+    that we can generate fake kernels.
+    """
+
+    def _get_op_profile(node: torch.fx.Node) -> OpProfile:
+        args_profile = tuple(
+            [
+                TensorMetadata.maybe_from_tensor(arg.meta.get("val"))
+                if isinstance(arg, torch.fx.Node)
+                else None
+                for arg in (*node.args, *node.kwargs.values())
+            ]
+        )
+
+        out_profile = None
+        meta = node.meta.get("val")
+        assert meta is not None
+        if isinstance(meta, torch.Tensor):
+            out_profile = TensorMetadata.maybe_from_tensor(meta)
+        elif isinstance(meta, (list, tuple)):
+            out_profile = tuple([TensorMetadata.maybe_from_tensor(m) for m in meta])  # type: ignore[assignment]
+        assert out_profile is not None
+
+        return OpProfile(args_profile, out_profile)  # type: ignore[arg-type]
+
+    op_profiles: dict[str, set[OpProfile]] = defaultdict(set)
+
+    for node in gm.graph.nodes:
+        if node.op == "call_function" and str(node.target) in ops_to_guard:
+            op_profiles[str(node.target)].add(_get_op_profile(node))
+
+    return op_profiles

--- a/torch/_library/fake_impl.py
+++ b/torch/_library/fake_impl.py
@@ -5,7 +5,7 @@ from typing import Callable, Optional
 from typing_extensions import deprecated
 
 import torch
-from torch._library.utils import Kernel, RegistrationHandle
+from torch._library.utils import config, Kernel, RegistrationHandle
 
 
 class FakeImplHolder:
@@ -16,41 +16,43 @@ class FakeImplHolder:
         self.kernel: Optional[Kernel] = None
         self.lib: Optional[torch.library.Library] = None
 
-    def register(self, func: Callable, source: str) -> RegistrationHandle:
+    def register(self, func: Callable, source: str, *, allow_override=False) -> RegistrationHandle:
         """Register an fake impl.
 
         Returns a RegistrationHandle that one can use to de-register this
         fake impl.
         """
-        if self.kernel is not None:
-            raise RuntimeError(
-                f"register_fake(...): the operator {self.qualname} "
-                f"already has an fake impl registered at "
-                f"{self.kernel.source}."
-            )
-        if torch._C._dispatch_has_kernel_for_dispatch_key(self.qualname, "Meta"):
-            raise RuntimeError(
-                f"register_fake(...): the operator {self.qualname} "
-                f"already has an DispatchKey::Meta implementation via a "
-                f"pre-existing torch.library or TORCH_LIBRARY registration. "
-                f"Please either remove that registration or don't call "
-                f"register_fake."
-            )
 
-        if torch._C._dispatch_has_kernel_for_dispatch_key(
-            self.qualname, "CompositeImplicitAutograd"
-        ):
-            raise RuntimeError(
-                f"register_fake(...): the operator {self.qualname} "
-                f"already has an implementation for this device type via a "
-                f"pre-existing registration to "
-                f"DispatchKey::CompositeImplicitAutograd."
-                f"CompositeImplicitAutograd operators do not need an fake "
-                f"impl; "
-                f"instead, the operator will decompose into its constituents "
-                f"and those "
-                f"can have fake impls defined on them."
-            )
+        if not allow_override:
+            if self.kernel is not None:
+                raise RuntimeError(
+                    f"register_fake(...): the operator {self.qualname} "
+                    f"already has an fake impl registered at "
+                    f"{self.kernel.source}."
+                )
+            if torch._C._dispatch_has_kernel_for_dispatch_key(self.qualname, "Meta"):
+                raise RuntimeError(
+                    f"register_fake(...): the operator {self.qualname} "
+                    f"already has an DispatchKey::Meta implementation via a "
+                    f"pre-existing torch.library or TORCH_LIBRARY registration. "
+                    f"Please either remove that registration or don't call "
+                    f"register_fake."
+                )
+
+            if torch._C._dispatch_has_kernel_for_dispatch_key(
+                self.qualname, "CompositeImplicitAutograd"
+            ):
+                raise RuntimeError(
+                    f"register_fake(...): the operator {self.qualname} "
+                    f"already has an implementation for this device type via a "
+                    f"pre-existing registration to "
+                    f"DispatchKey::CompositeImplicitAutograd."
+                    f"CompositeImplicitAutograd operators do not need an fake "
+                    f"impl; "
+                    f"instead, the operator will decompose into its constituents "
+                    f"and those "
+                    f"can have fake impls defined on them."
+                )
 
         # Store the kernel in this holder
         self.kernel = Kernel(func, source)
@@ -60,7 +62,7 @@ class FakeImplHolder:
             ns = self.qualname.split("::")[0]
             self.lib = torch.library.Library(ns, "FRAGMENT")  # noqa: TOR901
         meta_kernel = construct_meta_kernel(self.qualname, self)
-        self.lib.impl(self.qualname, meta_kernel, "Meta")
+        self.lib.impl(self.qualname, meta_kernel, "Meta", allow_override=allow_override)
 
         def deregister_fake_class():
             if self.lib:

--- a/torch/_library/fake_profile.py
+++ b/torch/_library/fake_profile.py
@@ -1,0 +1,155 @@
+import contextlib
+import logging
+from collections.abc import Generator
+from dataclasses import dataclass
+from typing import Any, Callable, Optional, Union
+
+import torch
+from torch._library.custom_ops import _maybe_get_opdef
+from torch._library.utils import config, Kernel
+
+
+log = logging.getLogger(__name__)
+
+
+class MissingOpProfile(RuntimeError):
+    """
+    This is raised when we don't have an operator profile available for the
+    given inputs.
+    """
+
+
+@dataclass(frozen=True)
+class TensorMetadata:
+    rank: int
+    dtype: torch.dtype
+    device: torch.device
+    layout: torch.layout
+
+    @staticmethod
+    def maybe_from_tensor(t: Any) -> Optional["TensorMetadata"]:
+        if not isinstance(t, torch.Tensor):
+            return None
+        return TensorMetadata(t.dim(), t.dtype, t.device, t.layout)
+
+
+@dataclass(frozen=True)
+class OpProfile:
+    args_profile: tuple[Optional[TensorMetadata]]
+    out_profile: Union[TensorMetadata, tuple[TensorMetadata]]
+
+
+def _generate_fake_kernel(op_name: str, op_profile: set[OpProfile]) -> Callable:
+    def _match_args(args_profile: tuple[Optional[TensorMetadata]], args: Any) -> bool:
+        return all(
+            TensorMetadata.maybe_from_tensor(arg) == args_profile[i]
+            for i, arg in enumerate(args)
+        )
+
+    def _generate_res(
+        out_profile: Union[TensorMetadata, tuple[TensorMetadata]],
+    ) -> Union[torch.Tensor, list[torch.Tensor]]:
+        ctx = torch.library.get_ctx()
+
+        def _generate_tensor_out(t: TensorMetadata) -> torch.Tensor:
+            fake_shape = [ctx.new_dynamic_size() for _ in range(t.rank)]
+            fake_strides = [-1] * t.rank
+            expected = 1
+            fake_stride = expected
+            for i in range(t.rank):
+                fake_strides[i] = fake_stride  # type: ignore[assignment]
+                fake_stride = fake_stride * fake_shape[i]  # type: ignore[assignment]
+
+            return torch.empty_strided(
+                fake_shape,
+                fake_strides,
+                device=t.device,
+                dtype=t.dtype,
+                layout=t.layout,
+            )
+
+        if isinstance(out_profile, TensorMetadata):
+            return _generate_tensor_out(out_profile)
+        else:
+            return [_generate_tensor_out(t) for t in out_profile]
+
+    def _fake_kernel(*args, **kwargs):  # type: ignore[no-untyped-def]
+        for profile in op_profile:
+            if _match_args(profile.args_profile, (*args, *kwargs.values())):
+                return _generate_res(profile.out_profile)
+
+        raise MissingOpProfile(
+            f"No fake kernel was found for {op_name}, and although we have "
+            "previously registered some profiles to generate a fake kernel, "
+            f"no profiles match the given inputs: {args, kwargs}."
+        )
+
+    return _fake_kernel
+
+
+@contextlib.contextmanager
+def register_fake_profile(op_profiles: dict[str, set[OpProfile]]) -> Generator:
+    """
+    Registers a fake kernel based on the given operator profiles. This fake
+    kernel registration will override any existing fake kernel registrations.
+
+    The input is a dictionary mapping operator names to a set of operator
+    profiles, which we will use to generate fake kernels. The operator profiles
+    are a record of the input and output tensor metadata. Based on this
+    information we will match a given input to the recorded profile, and return
+    an output with the same metadata as in the recorded profile. If a profile
+    doesn't exist then an exception will be thrown.
+
+    Args:
+        op_profiles (dict[str, set[OpProfile]]): A dictionary mapping operator
+            name to a set of operator profiles from which we will generate fake
+            kernels.
+    """
+
+    libs: list[torch.library.Library] = []
+    old_fake_impls: dict[str, Union[Callable, Kernel]] = {}
+    for op_name, profiles in op_profiles.items():
+        log.warning(
+            "Registering fake profile for %s. This will override any existing "
+            "fake kernel registration.",
+            op_name,
+        )
+
+        op_name_split = op_name.split(".")
+        namespace, op_name_str = op_name_split[0], op_name_split[1]
+        op_str = f"{namespace}::{op_name_str}"
+
+        newlib = torch.library.Library(namespace, "FRAGMENT")  # noqa: TOR901
+        fake_kernel = _generate_fake_kernel(op_str, profiles)
+
+        # Check if there are any fake kernels already registered
+        if opdef := _maybe_get_opdef(op_str):
+            if opdef._abstract_fn is not None:
+                old_fake_impls[op_str] = opdef._abstract_fn
+        elif fake_impl_holder := torch._library.simple_registry.singleton.find(
+            op_str
+        ).fake_impl:
+            if fake_impl_holder.kernel is not None:
+                old_fake_impls[op_str] = fake_impl_holder.kernel
+
+        torch.library.register_fake(op_str, fake_kernel, lib=newlib, allow_override=True)
+        libs.append(newlib)
+
+    try:
+        yield libs
+    finally:
+        for lib in libs:
+            lib._destroy()
+
+        for op_str, old_fake in old_fake_impls.items():
+            if isinstance(old_fake, Kernel):
+                torch.library.register_fake(op_str, old_fake.func, allow_override=True)
+                fake_impl_holder = torch._library.simple_registry.singleton.find(
+                    op_str
+                ).fake_impl
+                assert fake_impl_holder.kernel is not None
+                fake_impl_holder.kernel.source = (
+                    old_fake.source
+                )  # Update the source information to be the original one
+            else:
+                torch.library.register_fake(op_str, old_fake, allow_override=True)

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -559,6 +559,40 @@ def masked_select(fake_mode, func, self, mask):
     return self.new_empty((nnz,))
 
 
+@register_op_impl(torch.ops.aten._assert_tensor_metadata.default)
+def assert_tensor_metadata(
+    fake_mode,
+    func,
+    t,
+    sizes=None,
+    strides=None,
+    dtype=None,
+    *,
+    device=None,
+    layout=None,
+) -> None:
+    if sizes is not None:
+        assert (
+            t.size() == sizes
+        ), f"Tensor sizes mismatch! Expected: {sizes}, Got: {t.size()}"
+    if strides is not None:
+        assert (
+            t.stride() == strides
+        ), f"Tensor strides mismatch! Expected: {strides}, Got: {t.stride()}"
+    if dtype is not None:
+        assert (
+            t.dtype == dtype
+        ), f"Tensor dtype mismatch! Expected: {dtype}, Got: {t.dtype}"
+    if layout is not None:
+        assert (
+            t.layout == layout
+        ), f"Tensor layout mismatch! Expected: {layout}, Got: {t.layout()}"
+    if device is not None:
+        assert (
+            t.device == device
+        ), f"Tensor device mismatch! Expected: {device}, Got: {t.device}"
+
+
 # NB: this must be ordered after local_scalar_dense
 @register_op_impl(lambda func: torch.Tag.data_dependent_output in func.tags)
 def data_dep(fake_mode, func, *args, **kwargs):

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -24,6 +24,7 @@ import torch._library.utils as library_utils
 from torch import SymBool, SymFloat, SymInt, Tensor
 from torch._C._functorch import is_functorch_wrapped_tensor, is_legacy_batchedtensor
 from torch._library.fake_class_registry import FakeScriptObject
+from torch._library.fake_profile import MissingOpProfile
 from torch._logging import dtrace_structured
 from torch._prims_common import suggest_memory_format
 from torch._subclasses.meta_utils import (
@@ -2019,6 +2020,21 @@ class FakeTensorMode(TorchDispatchMode):
                         f"fake shape {s_fake} and real shape {s_real}, "
                         f"at output{keystr(path)}.size({j}), for func: {func}"
                     ) from exc
+        elif fake is None and real is not None:
+            if torch._functorch.config.generate_fake_kernels_from_real_mismatches:
+                dtrace_structured(
+                    "mismatched_fake_kernel",
+                    metadata_fn=lambda: {
+                        "op": str(func),
+                        "reason": f"mismatch between fake value {fake} and real value {real}",  # noqa: F821
+                    },
+                )
+                return _infer_fake_from_real_tensor(self, func, real), True  # type: ignore[arg-type]
+            raise MetadataMismatchError(
+                f"Real tensor propagation found a metadata mismatch between "
+                f"fake tensor {fake} and real tensor {real}, "
+                f" at output{keystr(path)}, for func: {func}"
+            )
         else:
             try:
                 _check_fake_real_vals(fake, real)
@@ -2511,10 +2527,32 @@ class FakeTensorMode(TorchDispatchMode):
             func.name()
         ).fake_impl.kernel
         if maybe_fake_impl:
-            ctx = torch._library.fake_impl.FakeImplCtx(self, func)
-            with torch._library.fake_impl.set_ctx_getter(lambda: ctx), self:
-                result = maybe_fake_impl(*args, **kwargs)
-                return maybe_propagate_real_tensors(result)
+            try:
+                ctx = torch._library.fake_impl.FakeImplCtx(self, func)
+                with torch._library.fake_impl.set_ctx_getter(lambda: ctx), self:
+                    result = maybe_fake_impl(*args, **kwargs)
+                    return maybe_propagate_real_tensors(result)
+
+            except MissingOpProfile as e:
+                # If we have a fake kernel registered generated from OpProfiles
+                # but there doesn't exist a profile for the existing inputs, and we are in
+                if (
+                    self.propagate_real_tensors
+                    and real_out is not nil
+                    and not library_utils.is_builtin(func)
+                    and self.shape_env is not None
+                ):
+                    result = inferred_fake_kernel_from_real_out(self, func, real_out)
+
+                    dtrace_structured(
+                        "missing_fake_kernel",
+                        metadata_fn=lambda: {
+                            "op": str(func),
+                        },
+                    )
+                    return maybe_propagate_real_tensors(result)
+                else:
+                    raise e
 
         # special handling for funcs registered through `register_op_impl`,
         # e.g., manipulating args on constructor calls to construct meta tensors

--- a/torch/export/_draft_export.py
+++ b/torch/export/_draft_export.py
@@ -11,7 +11,11 @@ from typing import Any, Callable, Optional, Union
 import torch
 import torch._logging._internal
 import torch._logging.structured
-from torch._export.passes.insert_custom_op_guards import insert_custom_op_guards
+from torch._export.passes.insert_custom_op_guards import (
+    get_op_profiles,
+    insert_custom_op_guards,
+    OpProfile,
+)
 from torch.export import ExportedProgram
 from torch.export._trace import _export
 from torch.export.dynamic_shapes import refine_dynamic_shapes_from_suggested_fixes
@@ -151,10 +155,12 @@ class DraftExportReport:
         failures: list[FailureReport],
         str_to_filename: dict[int, str],
         expressions_created: dict[int, dict[str, Any]],
+        op_profiles: dict[str, set[OpProfile]],
     ):
         self.failures: list[FailureReport] = failures
         self.str_to_filename = str_to_filename
         self.expressions_created: dict[int, dict[str, Any]] = expressions_created
+        self.op_profiles = op_profiles
 
     def successful(self) -> bool:
         return len(self.failures) == 0 or all(
@@ -395,9 +401,7 @@ def draft_export(
 
         str_to_filename: dict[int, str] = {}
         failures: list[FailureReport] = []
-        custom_ops_logs: dict[
-            Any, tuple[dict[str, Any], FailureType]
-        ] = {}  # For adding in assertions before custom ops
+        incorrect_custom_ops: set[str] = set()
         expressions_created: dict[int, dict[str, Any]] = {}
 
         for log_name, log_contents in capture_structured_log.log_record.logs:
@@ -424,14 +428,11 @@ def draft_export(
                 log_contents["new_dynamic_shapes"] = new_shapes
             elif log_name == "missing_fake_kernel":
                 failure_type = FailureType.MISSING_FAKE_KERNEL
-                custom_ops_logs[log_contents["op"]] = (log_contents, failure_type)
+                incorrect_custom_ops.add(log_contents["op"])
 
             elif log_name == "mismatched_fake_kernel":
                 failure_type = FailureType.MISMATCHED_FAKE_KERNEL
-                custom_ops_logs[(log_contents["op"], log_contents["reason"])] = (
-                    log_contents,
-                    failure_type,
-                )
+                incorrect_custom_ops.add(log_contents["op"])
 
             else:
                 continue
@@ -448,27 +449,41 @@ def draft_export(
             if v.visited:
                 expressions_created[k] = v.record
 
-        report = DraftExportReport(failures, str_to_filename, expressions_created)
+        op_profiles = get_op_profiles(ep.graph_module, incorrect_custom_ops)
+        report = DraftExportReport(
+            failures, str_to_filename, expressions_created, op_profiles
+        )
 
         # Add asserts around custom ops
-        insert_custom_op_guards(ep.graph_module, list(custom_ops_logs.keys()))
+        insert_custom_op_guards(ep.graph_module, incorrect_custom_ops)
 
     ep._report = report
     if not report.successful():
         log_filename = capture_structured_log.stream.name
 
-        log.warning(
-            """
+        warning_msg = f"""
 ###################################################################################################
-WARNING: %s issue(s) found during export, and it was not able to soundly produce a graph.
+WARNING: {len(report.failures)} issue(s) found during export, and it was not able to soundly produce a graph.
 To view the report of failures in an html page, please run the command:
-    `tlparse %s --export`
+    `tlparse {log_filename} --export`
 Or, you can view the errors in python by inspecting `print(ep._report)`.
-###################################################################################################
-        """,
-            len(report.failures),
-            log_filename,
-        )
+"""
+
+        if len(report.op_profiles) > 0:
+            warning_msg += f"""
+While tracing we found {len(report.op_profiles)} operator(s) which do not have a fake kernel registered.
+If you intend to retrace the exported graph or run it with fake tensors, please run it under the
+following context manager, which will register a fake kernel for those operators.
+```
+with torch._library.fake_profile.register_fake_profile(ep._report.op_profiles):
+    # run with fake tensors
+```
+"""
+
+        warning_msg += """#################################################################################################"""
+
+        log.warning(warning_msg)
+
     else:
         log.info(
             """

--- a/torch/library.py
+++ b/torch/library.py
@@ -184,7 +184,7 @@ class Library:
         _defs.add(qualname)
         return result
 
-    def _register_fake(self, op_name, fn, _stacklevel=1):
+    def _register_fake(self, op_name, fn, _stacklevel=1, *, allow_override=False):
         r"""Registers the fake impl for an operator defined in the library."""
         if torch._running_with_deploy():
             _library.utils.warn_deploy()
@@ -211,7 +211,7 @@ class Library:
         else:
             func_to_register = fn
 
-        handle = entry.fake_impl.register(func_to_register, source)
+        handle = entry.fake_impl.register(func_to_register, source, allow_override=allow_override)
         self._registration_handles.append(handle)
 
     def _register_torch_dispatch_rule(self, op_name, torch_dispatch_class, fn):
@@ -290,7 +290,7 @@ class Library:
         _impls.add(key)
         self._op_impls.add(key)
 
-    def impl(self, op_name, fn, dispatch_key="", *, with_keyset=False):
+    def impl(self, op_name, fn, dispatch_key="", *, with_keyset=False, allow_override=False):
         r"""Registers the function implementation for an operator defined in the library.
 
         Args:
@@ -332,7 +332,7 @@ class Library:
             )
 
         key = self.ns + "/" + name.split("::")[-1] + "/" + dispatch_key
-        if key in _impls:
+        if (not allow_override) and key in _impls:
             # TODO: in future, add more info about where the existing function is registered (this info is
             # today already returned by the C++ warning when impl is called but we error out before that)
             raise RuntimeError(


### PR DESCRIPTION
After draft-export tracing, we accumulate an "operator profile" of all the calls to this operator. The operator profile includes a list of the input tensor metadata and output tensor metadata, where the tensor metadata contains the rank, dtype, device, and layout. We can then use this to generate and register a meta kernel, where if we receive inputs that have the same profile, we will return an output that matches what we previously profiled.

caveat is that if we re-draft-export with new shapes, this will override the existing registration.