### PR TITLE
Fix `L1Loss`, `MSELoss`, `HuberLoss` missing `weight` param

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2613,6 +2613,9 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         expected_loss = torch.tensor(0.25)
         self.assertTrue(torch.isclose(loss, expected_loss), f"Expected {expected_loss}, but got {loss}")
 
+        loss = nn.MSELoss(weight=weight, reduction='mean')
+        self.assertTrue(torch.isclose(loss(inputs, targets), expected_loss), f"Expected {expected_loss}, but got {loss}")
+
     def test_weighted_l1_loss_with_weights(self):
         inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)
         targets = torch.tensor([1.5, 2.5, 3.5, 4.5])
@@ -2632,6 +2635,9 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         loss = F.huber_loss(input=inputs, target=targets, weight=weight, reduction='mean', delta=1.0)
         expected_loss = torch.tensor(0.25)
         print(torch.isclose(loss, expected_loss, atol=1e-6), f"Expected {expected_loss}, but got {loss}")
+
+        loss = nn.HuberLoss(weight=weight, reduction='mean', delta=1.0)
+        print(torch.isclose(loss(inputs, targets), expected_loss, atol=1e-6), f"Expected {expected_loss}, but got {loss}")
 
     def test_gaussian_nll_loss_broadcasting(self):
         input = torch.tensor([[0.5, 1.5, 2.5], [2., 4., 6.]])

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2619,7 +2619,11 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         weight = torch.tensor([1.0, 2.0, 3.0, 4.0])
         loss = F.l1_loss(inputs, targets, weight=weight, reduction='mean')
         expected_loss = torch.tensor(0.5)
-        self.assertTrue(torch.isclose(loss, expected_loss), f"Expected {expected_loss}, but got {loss}")
+        self.assertTrue(torch.isclose(loss, expected_loss), f"l1_loss Expected {expected_loss}, but got {loss}")
+
+        loss = nn.L1Loss(weight=weight, reduction='mean')
+        self.assertTrue(torch.isclose(loss(inputs, targets), expected_loss), f"L1Loss Expected {expected_loss}, but got {loss}")
+
 
     def test_weighted_huber_loss(self):
         inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3702,26 +3702,9 @@ def huber_loss(
 ) -> Tensor:
     r"""huber_loss(input, target, reduction='mean', delta=1.0, weight=None) -> Tensor
 
-    Computes the Huber loss, with optional weighting.
+    Computes the Huber loss.
 
-    Function uses a squared term if the absolute
-    element-wise error falls below delta and a delta-scaled L1 term otherwise.
-
-    When delta equals 1, this loss is equivalent to SmoothL1Loss.
-    In general, Huber loss differs from SmoothL1Loss by a factor of delta (AKA beta in Smooth L1).
-
-    Args:
-        input (Tensor): Predicted values.
-        target (Tensor): Ground truth values.
-        reduction (str, optional): Specifies the reduction to apply to the output:
-                                   'none' | 'mean' | 'sum'. 'mean': the mean of the output is taken.
-                                   'sum': the output will be summed. 'none': no reduction will be applied.
-                                   Default: 'mean'.
-        delta (float, optional): The threshold at which to change between delta-scaled L1 and L2 loss. Default: 1.0.
-        weight (Tensor, optional): Weights for each sample. Default: None.
-
-    Returns:
-        Tensor: Huber loss (optionally weighted).
+    See :class:`~torch.nn.HuberLoss` for details.
     """
     if has_torch_function_variadic(input, target, weight):
         return handle_torch_function(
@@ -3844,19 +3827,7 @@ def mse_loss(
 
     Measures the element-wise mean squared error, with optional weighting.
 
-    Args:
-        input (Tensor): Predicted values.
-        target (Tensor): Ground truth values.
-        size_average (bool, optional): Deprecated (use reduction).
-        reduce (bool, optional): Deprecated (use reduction).
-        reduction (str, optional): Specifies the reduction to apply to the output:
-                                   'none' | 'mean' | 'sum'. 'mean': the mean of the output is taken.
-                                   'sum': the output will be summed. 'none': no reduction will be applied.
-                                   Default: 'mean'.
-        weight (Tensor, optional): Weights for each sample. Default: None.
-
-    Returns:
-        Tensor: Mean Squared Error loss (optionally weighted).
+    See :class:`~torch.nn.MSELoss` for details.
     """
     if has_torch_function_variadic(input, target, weight):
         return handle_torch_function(

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3781,7 +3781,7 @@ def l1_loss(
     reduction: str = "mean",
     weight: Optional[Tensor] = None,
 ) -> Tensor:  # noqa: D400,D402
-    r"""l1_loss(input, target, size_average=None, reduce=None, reduction='mean') -> Tensor
+    r"""l1_loss(input, target, size_average=None, reduce=None, reduction='mean, weight=None) -> Tensor
 
     Function that takes the mean element-wise absolute value difference.
 

--- a/torch/nn/functional.pyi.in
+++ b/torch/nn/functional.pyi.in
@@ -403,6 +403,7 @@ def huber_loss(
     target: Tensor,
     reduction: str = ...,
     delta: float = ...,
+    weight: Optional[Tensor] = ...,
 ) -> Tensor: ...
 def l1_loss(
     input: Tensor,
@@ -418,6 +419,7 @@ def mse_loss(
     size_average: Optional[bool] = ...,
     reduce: Optional[bool] = ...,
     reduction: str = ...,
+    weight: Optional[Tensor] = ...,
 ) -> Tensor: ...
 def margin_ranking_loss(
     input1: Tensor,

--- a/torch/nn/functional.pyi.in
+++ b/torch/nn/functional.pyi.in
@@ -410,6 +410,7 @@ def l1_loss(
     size_average: Optional[bool] = ...,
     reduce: Optional[bool] = ...,
     reduction: str = ...,
+    weight: Optional[Tensor] = ...,
 ) -> Tensor: ...
 def mse_loss(
     input: Tensor,

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -104,6 +104,7 @@ class L1Loss(_Loss):
             elements in the output, ``'sum'``: the output will be summed. Note: :attr:`size_average`
             and :attr:`reduce` are in the process of being deprecated, and in the meantime,
             specifying either of those two args will override :attr:`reduction`. Default: ``'mean'``
+        weight (Tensor, optional): Weights for each sample. Default: None.
 
     Shape:
         - Input: :math:`(*)`, where :math:`*` means any number of dimensions.
@@ -121,11 +122,18 @@ class L1Loss(_Loss):
     """
     __constants__ = ["reduction"]
 
-    def __init__(self, size_average=None, reduce=None, reduction: str = "mean") -> None:
+    def __init__(
+        self,
+        size_average=None,
+        reduce=None,
+        reduction: str = "mean",
+        weight: Optional[Tensor] = None,
+    ) -> None:
         super().__init__(size_average, reduce, reduction)
+        self.weight = weight
 
     def forward(self, input: Tensor, target: Tensor) -> Tensor:
-        return F.l1_loss(input, target, reduction=self.reduction)
+        return F.l1_loss(input, target, reduction=self.reduction, weight=self.weight)
 
 
 class NLLLoss(_WeightedLoss):

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -596,6 +596,7 @@ class MSELoss(_Loss):
             elements in the output, ``'sum'``: the output will be summed. Note: :attr:`size_average`
             and :attr:`reduce` are in the process of being deprecated, and in the meantime,
             specifying either of those two args will override :attr:`reduction`. Default: ``'mean'``
+        weight (Tensor, optional): Weights for each sample. Default: None.
 
     Shape:
         - Input: :math:`(*)`, where :math:`*` means any number of dimensions.
@@ -611,11 +612,18 @@ class MSELoss(_Loss):
     """
     __constants__ = ["reduction"]
 
-    def __init__(self, size_average=None, reduce=None, reduction: str = "mean") -> None:
+    def __init__(
+        self,
+        size_average=None,
+        reduce=None,
+        reduction: str = "mean",
+        weight: Optional[Tensor] = None,
+    ) -> None:
         super().__init__(size_average, reduce, reduction)
+        self.weight = weight
 
     def forward(self, input: Tensor, target: Tensor) -> Tensor:
-        return F.mse_loss(input, target, reduction=self.reduction)
+        return F.mse_loss(input, target, reduction=self.reduction, weight=self.weight)
 
 
 class BCELoss(_WeightedLoss):
@@ -1094,6 +1102,7 @@ class HuberLoss(_Loss):
             elements in the output, ``'sum'``: the output will be summed. Default: ``'mean'``
         delta (float, optional): Specifies the threshold at which to change between delta-scaled L1 and L2 loss.
             The value must be positive.  Default: 1.0
+        weight (Tensor, optional): Weights for each sample. Default: None.
 
     Shape:
         - Input: :math:`(*)` where :math:`*` means any number of dimensions.
@@ -1102,12 +1111,24 @@ class HuberLoss(_Loss):
     """
     __constants__ = ["reduction", "delta"]
 
-    def __init__(self, reduction: str = "mean", delta: float = 1.0) -> None:
+    def __init__(
+        self,
+        reduction: str = "mean",
+        delta: float = 1.0,
+        weight: Optional[Tensor] = None,
+    ) -> None:
         super().__init__(reduction=reduction)
         self.delta = delta
+        self.weight = weight
 
     def forward(self, input: Tensor, target: Tensor) -> Tensor:
-        return F.huber_loss(input, target, reduction=self.reduction, delta=self.delta)
+        return F.huber_loss(
+            input,
+            target,
+            reduction=self.reduction,
+            delta=self.delta,
+            weight=self.weight,
+        )
 
 
 class SoftMarginLoss(_Loss):


### PR DESCRIPTION
Fixes #149841

## Changes

- Add missing `weight` param for `L1Loss`, `MSELoss`, `HuberLoss`
- Add doc description
- Add weight test case


## Test Result

![image](https://github.com/user-attachments/assets/12b1a52f-f0ee-4a6b-995b-efa6ae8b649c)

![image](https://github.com/user-attachments/assets/4b4b375e-4263-42cf-81f1-75fa532cde3a)

![image](https://github.com/user-attachments/assets/8c8efc42-00f7-4aee-bb48-16a6f97d29d5)

![image](https://github.com/user-attachments/assets/06643bbf-bd9c-4c79-918f-60c37faa5342)

![image](https://github.com/user-attachments/assets/e4b2da82-16cb-450e-b751-c49010c9ec1e)

![image](https://github.com/user-attachments/assets/94a74133-3e82-4370-99bf-54277424dabc)

