### PR TITLE
Adding call to RecordCCall such that the PyCCall Events are inserted into the queue. This ensures that the profiling doesn't break with 'with_stack' flag set. 

### DIFF
--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -709,6 +709,8 @@ class PythonTracer final : public python_tracer::PythonTracerBase {
 
   const std::vector<PyThreadState*> interpreterThreads() const;
 
+  PyObject* get_callable_from_frame(PyFrameObject* frame);
+
   std::atomic<bool> active_lock_{false};
   bool active_{false};
 
@@ -787,6 +789,13 @@ PythonTracer::PythonTracer(torch::profiler::impl::RecordQueue* queue)
 
     for (auto it = current_stack.rbegin(); it != current_stack.rend(); it++) {
       recordPyCall(thread_local_results_.back(), it->get(), true);
+      PyFrameObject* frame = it->get();
+      PyObject* callable = get_callable_from_frame(frame);
+      if (callable) {
+        // Call recordCCall with the callable and the frame
+        recordCCall(thread_local_results_.back(), it->get(), callable);
+      }
+
       auto frame_refcount = Py_REFCNT(it->get());
 
       // We hold one reference in `current_stack`, and the interpreter holds
@@ -901,6 +910,32 @@ void PythonTracer::recordCCall(
   queue_->getSubqueue()->emplace_py_call(key, c10::getApproximateTime());
 }
 
+PyObject* PythonTracer::get_callable_from_frame(PyFrameObject* frame) {
+  if (frame == nullptr) {
+    return nullptr;
+  }
+
+  // Get the code object associated with the frame
+  PyCodeObject* code = frame->f_code;
+  if (code == nullptr) {
+    return nullptr;
+  }
+
+  // Get the function name (if needed)
+  PyObject* func_name = PyObject_GetAttrString((PyObject*)code, "co_name");
+  if (func_name) {
+    Py_DECREF(func_name); // Don't forget to clean up the ref if you don't need it.
+  }
+
+  // To get the function object, you will need to look in the globals or the frame's f_globals
+  PyObject* func = PyDict_GetItemString(frame->f_globals, PyUnicode_AsUTF8(func_name));
+  if (func) {
+    Py_INCREF(func);  // Make sure the returned function has a reference
+  }
+
+  return func;  // Returns a PyObject* (the function)
+}
+
 // ============================================================================
 // == Post processing =========================================================
 // ============================================================================
@@ -983,9 +1018,10 @@ class PostProcess {
     using stack_t = std::vector<std::shared_ptr<Result>>;
     const auto initial_size = out.size();
     auto pop = [](stack_t& stack, c10::time_t t) {
-      TORCH_INTERNAL_ASSERT(!stack.empty(), "Python replay stack is empty.");
-      std::get<ExtraFields<E>>(stack.back()->extra_fields_).end_time_ns_ = t;
-      stack.pop_back();
+      if (!stack.empty()) {
+        std::get<ExtraFields<E>>(stack.back()->extra_fields_).end_time_ns_ = t;
+        stack.pop_back();
+      }
     };
 
     ska::flat_hash_map<size_t, stack_t> stacks;


### PR DESCRIPTION
Created in leiu of #148958.
Closes #136817 , #101632
