### PR TITLE
Add option to define OpenBLAS version for manylinux Dockerfile_2_28_aarch64

### DIFF
--- a/.ci/docker/common/install_openblas.sh
+++ b/.ci/docker/common/install_openblas.sh
@@ -4,8 +4,11 @@
 set -ex
 
 cd /
-git clone https://github.com/OpenMathLib/OpenBLAS.git -b v0.3.29 --depth 1 --shallow-submodules
-
+if [ -n "$OPENBLAS_VERSION" ]; then
+    git clone https://github.com/OpenMathLib/OpenBLAS.git -b $OPENBLAS_VERSION --depth 1 --shallow-submodules
+else
+    git clone https://github.com/OpenMathLib/OpenBLAS.git -b v0.3.29 --depth 1 --shallow-submodules
+fi
 
 OPENBLAS_BUILD_FLAGS="
 NUM_THREADS=128

--- a/.ci/docker/common/install_openblas.sh
+++ b/.ci/docker/common/install_openblas.sh
@@ -4,11 +4,7 @@
 set -ex
 
 cd /
-if [ -n "$OPENBLAS_VERSION" ]; then
-    git clone https://github.com/OpenMathLib/OpenBLAS.git -b $OPENBLAS_VERSION --depth 1 --shallow-submodules
-else
-    git clone https://github.com/OpenMathLib/OpenBLAS.git -b v0.3.29 --depth 1 --shallow-submodules
-fi
+git clone https://github.com/OpenMathLib/OpenBLAS.git -b "${OPENBLAS_VERSION:-v0.3.29}" --depth 1 --shallow-submodules
 
 OPENBLAS_BUILD_FLAGS="
 NUM_THREADS=128

--- a/.ci/docker/manywheel/Dockerfile_2_28_aarch64
+++ b/.ci/docker/manywheel/Dockerfile_2_28_aarch64
@@ -58,6 +58,7 @@ RUN git config --global --add safe.directory "*"
 
 FROM base as openblas
 # Install openblas
+ARG OPENBLAS_VERSION
 ADD ./common/install_openblas.sh install_openblas.sh
 RUN bash ./install_openblas.sh && rm install_openblas.sh
 

--- a/.ci/docker/manywheel/build.sh
+++ b/.ci/docker/manywheel/build.sh
@@ -27,6 +27,7 @@ fi
 
 MANY_LINUX_VERSION=${MANY_LINUX_VERSION:-}
 DOCKERFILE_SUFFIX=${DOCKERFILE_SUFFIX:-}
+OPENBLAS_VERSION=${OPENBLAS_VERSION:-}
 
 case ${image} in
     manylinux2_28-builder:cpu)
@@ -40,6 +41,7 @@ case ${image} in
         GPU_IMAGE=arm64v8/almalinux:8
         DOCKER_GPU_BUILD_ARG=" --build-arg DEVTOOLSET_VERSION=13 --build-arg NINJA_VERSION=1.12.1"
         MANY_LINUX_VERSION="2_28_aarch64"
+        OPENBLAS_VERSION="v0.3.29"
         ;;
     manylinuxcxx11-abi-builder:cpu-cxx11-abi)
         TARGET=final
@@ -109,6 +111,7 @@ tmp_tag=$(basename "$(mktemp -u)" | tr '[:upper:]' '[:lower:]')
 DOCKER_BUILDKIT=1 docker build  \
     ${DOCKER_GPU_BUILD_ARG} \
     --build-arg "GPU_IMAGE=${GPU_IMAGE}" \
+    --build-arg "OPENBLAS_VERSION=${OPENBLAS_VERSION}" \
     --target "${TARGET}" \
     -t "${tmp_tag}" \
     $@ \


### PR DESCRIPTION
Adds optional variable OPENBLAS_VERSION to `.ci/docker/common/install_openblas.sh` used to define which version of OpenBLAS to install. Adds argument to `Dockerfile_2_28_aarch64` image.


cc @malfet @snadampal @milpuz01 @aditew01 @nikhil-arm @fadara01