### PR TITLE
Use constants.onnx default opset for export compat

### DIFF
--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -10,6 +10,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any, Callable, TYPE_CHECKING
 
 import torch
+from torch.onnx import _constants
 from torch.onnx._internal._lazy_import import onnxscript_apis, onnxscript_ir as ir
 from torch.onnx._internal.exporter import (
     _constants,
@@ -160,7 +161,7 @@ def export_compat(
                 export_params=export_params,
                 input_names=input_names,
                 output_names=output_names,
-                opset_version=17,  # TODO(justinchuby): Hard coded to 17 for now
+                opset_version=_constants.ONNX_DEFAULT_OPSET,
                 dynamic_axes=dynamic_axes,
                 keep_initializers_as_inputs=keep_initializers_as_inputs,
             )

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -1393,10 +1393,10 @@ def _export(
     if opset_version is None:
         opset_version = _constants.ONNX_DEFAULT_OPSET
 
-    # torch.onnx.export does not support opset versions >=18
+    # torch.onnx.export does not support opset versions >ONNX_TORCHSCRIPT_EXPORTER_MAX_OPSET
     if opset_version > _constants.ONNX_TORCHSCRIPT_EXPORTER_MAX_OPSET:
         # We do not want to fail because we should still allow users to create
-        # custom symbolic functions for opset>17
+        # custom symbolic functions for opset>ONNX_TORCHSCRIPT_EXPORTER_MAX_OPSET
         warnings.warn(
             f"Exporting to ONNX opset version {opset_version} is not supported. "
             f"by 'torch.onnx.export()'. "

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -1393,7 +1393,7 @@ def _export(
     if opset_version is None:
         opset_version = _constants.ONNX_DEFAULT_OPSET
 
-    # torch.onnx.export does not support opset versions >ONNX_TORCHSCRIPT_EXPORTER_MAX_OPSET
+    # torch.onnx.export does not support opset versions >= 18
     if opset_version > _constants.ONNX_TORCHSCRIPT_EXPORTER_MAX_OPSET:
         # We do not want to fail because we should still allow users to create
         # custom symbolic functions for opset>ONNX_TORCHSCRIPT_EXPORTER_MAX_OPSET

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -1393,10 +1393,10 @@ def _export(
     if opset_version is None:
         opset_version = _constants.ONNX_DEFAULT_OPSET
 
-    # torch.onnx.export does not support opset versions >= 18
+    # torch.onnx.export does not support opset versions >=18
     if opset_version > _constants.ONNX_TORCHSCRIPT_EXPORTER_MAX_OPSET:
         # We do not want to fail because we should still allow users to create
-        # custom symbolic functions for opset>ONNX_TORCHSCRIPT_EXPORTER_MAX_OPSET
+        # custom symbolic functions for opset>17
         warnings.warn(
             f"Exporting to ONNX opset version {opset_version} is not supported. "
             f"by 'torch.onnx.export()'. "


### PR DESCRIPTION
The current rules for opsets are confusing, and the comments associated with them are outdated. This is particularly problematic for dynamo export, where the opset is hardcoded to version 18. To improve clarity and maintainability, it would be beneficial to use global constants wherever possible.