### PR TITLE
update release 2.7 xla pin

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1176,6 +1176,7 @@ build_xla() {
   retry install_pre_deps_pytorch_xla $XLA_DIR $USE_CACHE
   CMAKE_PREFIX_PATH="${SITE_PACKAGES}/torch:${CMAKE_PREFIX_PATH}" XLA_SANDBOX_BUILD=1 build_torch_xla $XLA_DIR
   retry install_post_deps_pytorch_xla
+  assert_git_not_dirty
 }
 
 test_xla() {

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1173,9 +1173,9 @@ build_xla() {
   apply_patches
   SITE_PACKAGES="$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')"
   # These functions are defined in .circleci/common.sh in pytorch/xla repo
-  retry install_deps_pytorch_xla $XLA_DIR $USE_CACHE
+  retry install_pre_deps_pytorch_xla $XLA_DIR $USE_CACHE
   CMAKE_PREFIX_PATH="${SITE_PACKAGES}/torch:${CMAKE_PREFIX_PATH}" XLA_SANDBOX_BUILD=1 build_torch_xla $XLA_DIR
-  assert_git_not_dirty
+  retry install_post_deps_pytorch_xla
 }
 
 test_xla() {

--- a/.github/ci_commit_pins/xla.txt
+++ b/.github/ci_commit_pins/xla.txt
@@ -1,1 +1,1 @@
-a14bd3b983b14887daea53ddc99e1f6551ea8d2c
+r2.7

--- a/.github/ci_commit_pins/xla.txt
+++ b/.github/ci_commit_pins/xla.txt
@@ -1,1 +1,1 @@
-r2.7
+a14bd3b983b14887daea53ddc99e1f6551ea8d2c


### PR DESCRIPTION
Fix the CI failure with outdated XLA pin. This mirrors the fix in https://github.com/pytorch/pytorch/pull/149381.
