### PR TITLE
Revert "Parallelize sort"

### DIFF
--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -414,11 +414,8 @@ if(INTERN_BUILD_ATEN_OPS)
       endif(MSVC)
 
       # Only parallelize the SortingKernel for now to avoid side effects
-      if(${NAME} STREQUAL "native/cpu/SortingKernel.cpp" AND NOT MSVC AND USE_OPENMP)
-        set(EXTRA_FLAGS "${EXTRA_FLAGS} -D_GLIBCXX_PARALLEL")
-        if(USE_PRECOMPILED_HEADERS)
-          set_source_files_properties(${NEW_IMPL} PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
-        endif()
+      if(${NAME} STREQUAL "native/cpu/SortingKernel.cpp" AND NOT MSVC AND USE_OMP)
+        string(APPEND EXTRA_FLAGS " -D_GLIBCXX_PARALLEL")
       endif()
 
       # Disable certain warnings for GCC-9.X


### PR DESCRIPTION
Reverts pytorch/pytorch#149765

Reverting because it breaks inductor tests.  Details in https://github.com/pytorch/pytorch/pull/149505#issuecomment-2759082390