### PR TITLE
[ROCm][TunableOp] Stricter unit tests for online and offline tuning

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4732,7 +4732,7 @@ class TestLinalg(TestCase):
 
         def has_any_dim_size_one(tensor: torch.Tensor):
             """Check if any dimension of a PyTorch tensor has size 1."""
-            return torch.any(torch.eq(torch.tensor(tensor.shape), 1)).item()
+            return any(dim == 1 for dim in tensor.shape)
 
         def is_mm_compatible(A, B):
             """Check if two matrices A and B are compatible for torch.mm."""

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -109,28 +109,29 @@ def find_tunableop_result(results, OpSig, ParamSig):
             return inner_tuple
     return None
 
-def compare_untuned_tuned_param_sig(untuned_filename, tuned_filename):
-    # Compare Param Signature of untuned and tuned Tunableop results
-    # file. Verify that for each Param Signature in the untuned file
+def compare_untuned_tuned_entries(untuned_filename, tuned_filename):
+    # Compare the entries of untuned and tuned Tunableop results
+    # file. Verify that for each Op+Param Signature in the untuned file
     # there is a matching one in the tuned results file.
     import csv
     ok = False
     with open(untuned_filename) as file1:
         with open(tuned_filename) as file2:
             untuned_reader = csv.reader(file1)
-            untuned_csv_entries = [row[1] for row in untuned_reader]
+            untuned_csv_entries = {(row[0], row[1]) for row in untuned_reader}
 
             tuned_reader = csv.reader(file2)
             for _ in range(5):  # Skip the first 5 lines for the validator
                 next(tuned_reader, None)
 
-            result_csv_entries = [row[1] for row in tuned_reader]
+            result_csv_entries = {(row[0], row[1]) for row in tuned_reader}
 
-            for value in untuned_csv_entries:
-                if value in result_csv_entries:
-                    ok = True
-                else:
-                    ok = False
+            missing = untuned_csv_entries - result_csv_entries
+
+            if missing:
+                ok = False
+            else:
+                ok = True
 
     return ok
 
@@ -4768,7 +4769,7 @@ class TestLinalg(TestCase):
             self.assertGreater(os.path.getsize(result_filename), 0)
 
             # Compare Param Signature of untuned and tuned results
-            ok = compare_untuned_tuned_param_sig(untuned_filename, result_filename)
+            ok = compare_untuned_tuned_entries(untuned_filename, result_filename)
             self.assertTrue(ok)
 
     @onlyCUDA
@@ -4866,7 +4867,7 @@ class TestLinalg(TestCase):
             self.assertGreater(os.path.getsize(result_filename), 0)
 
             # Compare Param Signature of untuned and tuned results
-            ok = compare_untuned_tuned_param_sig(untuned_filename, result_filename)
+            ok = compare_untuned_tuned_entries(untuned_filename, result_filename)
             self.assertTrue(ok)
 
     @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
@@ -5282,7 +5283,7 @@ class TestLinalg(TestCase):
             self.assertGreater(os.path.getsize(result_filename), 0)
 
             # Compare Param Signature of untuned and tuned results
-            ok = compare_untuned_tuned_param_sig(untuned_filename, result_filename)
+            ok = compare_untuned_tuned_entries(untuned_filename, result_filename)
             self.assertTrue(ok)
 
     @onlyCUDA
@@ -5498,7 +5499,7 @@ class TestLinalg(TestCase):
                 self.assertGreater(os.path.getsize(result_filename), 0)
 
                 # Compare Param Signature of untuned and tuned results
-                ok = compare_untuned_tuned_param_sig(untuned_filename, result_filename)
+                ok = compare_untuned_tuned_entries(untuned_filename, result_filename)
                 self.assertTrue(ok)
 
         finally:


### PR DESCRIPTION
Improvements to unit tests and warnings for unsupported cases in offline tuning. Here are more details:
- Previously we only compared the OpSig for the untuned vs. tuned entries. This was not strict enough so we now compare OpSig+ParamSig.
- The main offline and online UTs are now stricter to make sure we exercise the code paths for the four combinations of transA and transB.
- Offline tuning does not support some tensor shapes. Emit warning and skip tuning.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang