### PR TITLE
Pin cmake==3.31.6

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -80,7 +80,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # following builds that we know should use conda. Specifically, Ubuntu bionic
   # and focal cannot find conda mkl with stock cmake, so we need a cmake from conda
   if [ -n "${CONDA_CMAKE}" ]; then
-    conda_install cmake
+    conda_install cmake==3.31.2
   fi
 
   # Magma package names are concatenation of CUDA major and minor ignoring revision

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Python dependencies required for development
 astunparse
-cmake
+cmake==3.31.6  # Temp pin until we support 4.0.0?
 expecttest>=0.3.0
 filelock
 fsspec


### PR DESCRIPTION
I'm not sure if this is the right think to do, but cmake 4.0.0 got released on pypi and our builds are failing with it

Example:
https://hud.pytorch.org/pytorch/pytorch/commit/aa70d62041c28fe35c416aa932b32ef0e4d5bc33#39555975425-box

I guess we have to go change all the cmake_minimum_required to >=3.5?

backwards compat still failing because its building with the base commit which this pr can't really change until it gets merged, but at least manywheel binary builds got past where they were originally failing

Also pin the conda installation, but the most recent version on conda is 3.31.2