### PR TITLE
[c10d] Add `_allgather_base` , `reduce_scatter` , and `_reduce_scatter_base` into ProcessGroupMPI to enable FSDP with MPI backend

### DIFF
--- a/test/cpp/c10d/ProcessGroupMPITest.cpp
+++ b/test/cpp/c10d/ProcessGroupMPITest.cpp
@@ -239,7 +239,8 @@ void testReduceScatter(int iter = 10000) {
     auto outputs = std::vector<at::Tensor>({output});
 
     // Queue the work.
-    c10::intrusive_ptr<::c10d::Work> work = pg->reduce_scatter(outputs, tensors);
+    c10::intrusive_ptr<::c10d::Work> work =
+        pg->reduce_scatter(outputs, tensors);
     works.push_back(std::move(work));
   }
 
@@ -272,7 +273,8 @@ void testReduceScatterBase(int iter = 10000) {
     auto outputs = std::vector<at::Tensor>({output});
 
     // Queue the work.
-    c10::intrusive_ptr<::c10d::Work> work = pg->_reduce_scatter_base(output, tensor);
+    c10::intrusive_ptr<::c10d::Work> work =
+        pg->_reduce_scatter_base(output, tensor);
     works.push_back(std::move(work));
   }
 

--- a/test/cpp/c10d/ProcessGroupMPITest.cpp
+++ b/test/cpp/c10d/ProcessGroupMPITest.cpp
@@ -185,6 +185,111 @@ void testAllgather(int iter = 10000) {
   }
 }
 
+void testAllgatherBase(int iter = 10000) {
+  auto pg = c10d::ProcessGroupMPI::createProcessGroupMPI();
+  std::vector<c10::intrusive_ptr<::c10d::Work>> works;
+
+  // Get the world size
+  auto worldSize = pg->getSize();
+  auto rank = pg->getRank();
+
+  // Generate inputs
+  for (const auto i : c10::irange(iter)) {
+    auto tensor = at::ones({16, 16}) * i * rank;
+    auto output = at::zeros({worldSize, 16, 16});
+
+    // Queue the work.
+    c10::intrusive_ptr<::c10d::Work> work = pg->_allgather_base(output, tensor);
+    works.push_back(std::move(work));
+  }
+
+  auto outputTensors = waitFuture(pg, works);
+
+  // Verify outputs
+  for (const auto i : c10::irange(iter)) {
+    for (const auto j : c10::irange(worldSize)) {
+      const auto expected = i * j;
+      auto data = outputTensors[i][0][j].data_ptr<float>();
+      for (auto k = 0; k < outputTensors[i][0][j].numel(); ++k) {
+        if (data[k] != static_cast<float>(expected)) {
+          TORCH_CHECK(false, "BOOM!");
+        }
+      }
+    }
+  }
+}
+
+void testReduceScatter(int iter = 10000) {
+  auto pg = c10d::ProcessGroupMPI::createProcessGroupMPI();
+  std::vector<c10::intrusive_ptr<::c10d::Work>> works;
+
+  // Get the world size
+  auto worldSize = pg->getSize();
+  auto rank = pg->getRank();
+
+  // Generate inputs
+  int count = 2;
+  for (const auto i : c10::irange(iter)) {
+    auto tensors = std::vector<std::vector<at::Tensor>>(1);
+    tensors[0].resize(worldSize);
+    for (const auto j : c10::irange(worldSize)) {
+      tensors[0][j] = at::ones({count, count}) * i * rank;
+    }
+    auto output = at::zeros({count, count});
+    auto outputs = std::vector<at::Tensor>({output});
+
+    // Queue the work.
+    c10::intrusive_ptr<::c10d::Work> work = pg->reduce_scatter(outputs, tensors);
+    works.push_back(std::move(work));
+  }
+
+  auto outputTensors = waitFuture(pg, works);
+
+  // Verify outputs
+  for (const auto i : c10::irange(iter)) {
+    const auto expected = i * (worldSize * (worldSize - 1)) / 2.0;
+    auto data = outputTensors[i][0].data_ptr<float>();
+    for (auto j = 0; j < outputTensors[i][0].numel(); ++j) {
+      if (data[j] != static_cast<float>(expected)) {
+        TORCH_CHECK(false, "BOOM!");
+      }
+    }
+  }
+}
+
+void testReduceScatterBase(int iter = 10000) {
+  auto pg = c10d::ProcessGroupMPI::createProcessGroupMPI();
+  std::vector<c10::intrusive_ptr<::c10d::Work>> works;
+
+  // Get the world size
+  auto worldSize = pg->getSize();
+  auto rank = pg->getRank();
+
+  // Generate inputs
+  for (const auto i : c10::irange(iter)) {
+    auto tensor = at::ones({worldSize, 16, 16}) * i * rank;
+    auto output = at::zeros({16, 16});
+    auto outputs = std::vector<at::Tensor>({output});
+
+    // Queue the work.
+    c10::intrusive_ptr<::c10d::Work> work = pg->_reduce_scatter_base(output, tensor);
+    works.push_back(std::move(work));
+  }
+
+  auto outputTensors = waitFuture(pg, works);
+
+  // Verify outputs
+  for (const auto i : c10::irange(iter)) {
+    const auto expected = i * (worldSize * (worldSize - 1)) / 2.0;
+    auto data = outputTensors[i][0].data_ptr<float>();
+    for (auto j = 0; j < outputTensors[i][0].numel(); ++j) {
+      if (data[j] != static_cast<float>(expected)) {
+        TORCH_CHECK(false, "BOOM!");
+      }
+    }
+  }
+}
+
 void testGather(int iter = 10000) {
   auto pg = c10d::ProcessGroupMPI::createProcessGroupMPI();
   std::vector<c10::intrusive_ptr<::c10d::Work>> works;
@@ -355,6 +460,9 @@ int main(int argc, char** argv) {
   testBroadcast();
   testReduce();
   testAllgather();
+  testAllgatherBase();
+  testReduceScatter();
+  testReduceScatterBase();
   testGather();
   testScatter();
   testSendRecv(false);

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.hpp
@@ -197,6 +197,11 @@ class TORCH_API ProcessGroupMPI : public Backend {
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
+  c10::intrusive_ptr<Work> _reduce_scatter_base(
+      at::Tensor& outputTensor,
+      at::Tensor& inputTensor,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
+
   c10::intrusive_ptr<Work> alltoall_base(
       at::Tensor& outputTensor,
       at::Tensor& inputTensor,


### PR DESCRIPTION
This PR implements _allgather_base, reduce_scatter, and _reduce_scatter_base in the MPI backend (ProcessGroupMPI), enabling support for Fully Sharded Data Parallel (FSDP) in environments that use MPI for distributed communication.

### Context

As noted in https://github.com/pytorch/pytorch/issues/85628, FSDP currently supports only the NCCL backend. Due to this limitation, FSDP cannot run on legacy HPC environments or clusters that rely on MPI.

By implementing just these three collective operations, we can enable FSDP to work with the MPI backend. These collectives are implemented in a similar manner to existing operations such as allgather.

### Testing

We validated this PR using pytorch/build/bin/ProcessGroupMPITest with OpenMPI, and all tests passed successfully.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o