### PR TITLE
[AOTInductor] Add function for users to extract constants in container

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -4315,6 +4315,70 @@ class AOTInductorTestsTemplate:
         output = runner_call(test_inputs)
         self.assertEqual(expected, output)
 
+    def test_extract_constants_map(self):
+        class Model(torch.nn.Module):
+            def __init__(self, n, k, device):
+                super().__init__()
+                self.weight = torch.randn(n, k, device=device)
+                self.bias = torch.randn(n, device=device)
+
+            def forward(self, a):
+                return torch.nn.functional.linear(a, self.weight, self.bias)
+
+        M, N, K = 8, 6, 16
+        model = Model(N, K, self.device)
+        a = torch.randn(M, K, device=self.device)
+        example_inputs = (a,)
+        with torch.no_grad(), config.patch({"always_keep_tensor_constants": True}):
+            so_path = AOTIRunnerUtil.legacy_compile(
+                model=model,
+                example_inputs=example_inputs,
+            )
+
+        runner = AOTIRunnerUtil.legacy_load_runner(self.device, so_path)
+
+        def runner_call(*args, **kwargs):
+            import torch.fx._pytree as fx_pytree
+
+            call_spec = runner.get_call_spec()
+            in_spec = pytree.treespec_loads(call_spec[0])
+            out_spec = pytree.treespec_loads(call_spec[1])
+            flat_inputs = fx_pytree.tree_flatten_spec((args, kwargs), in_spec)
+            flat_inputs = [x for x in flat_inputs if isinstance(x, torch.Tensor)]
+            flat_outputs = runner.run(flat_inputs)
+            return pytree.tree_unflatten(flat_outputs, out_spec)
+
+        test_inputs = torch.randn(M, K, device=self.device)
+        expected = model(test_inputs)
+        output = runner_call(test_inputs)
+        self.assertEqual(expected, output)
+
+        original_weights = {
+            "L__self___weight": model.weight,
+            "L__self___bias": model.bias,
+        }
+        new_weights = {
+            "L__self___weight": torch.randn(N, K, device=self.device),
+            "L__self___bias": torch.randn(N, device=self.device),
+        }
+
+        # Extract weights with use_inactive = False, this should be the current weight.
+        extracted_original_weights = runner.extract_constants_map(False)
+        self.assertEqual(original_weights, extracted_original_weights)
+
+        # update the inactive weights with new_weights, extract inactive weights.
+        runner.update_constant_buffer(new_weights, True, False)
+        extracted_new_weights = runner.extract_constants_map(True)
+        self.assertEqual(new_weights, extracted_new_weights)
+
+        # Swap constant buffer, this should give us the opposite weights.
+        runner.swap_constant_buffer()
+
+        extracted_inactive_weights = runner.extract_constants_map(True)
+        extracted_active_weights = runner.extract_constants_map(False)
+        self.assertEqual(original_weights, extracted_inactive_weights)
+        self.assertEqual(new_weights, extracted_active_weights)
+
     def test_update_constant_buffer(self):
         class Model(torch.nn.Module):
             def __init__(self, n, k, device):

--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -205,6 +205,22 @@ AOTIRuntimeError AOTInductorModelContainerGetConstantDtype(
     { *dtype = container->constant_dtype(idx); })
 }
 
+AOTIRuntimeError AOTInductorModelContainerExtractConstantsMap(
+    AOTInductorModelContainerHandle container_handle,
+    AOTInductorConstantMapHandle constant_map_handle,
+    bool use_inactive) {
+  auto* container =
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
+          container_handle);
+  auto constants_map = reinterpret_cast<std::unordered_map<std::string, AtenTensorHandle>*>(constant_map_handle);
+  CONVERT_EXCEPTION_TO_ERROR_CODE(
+    { const auto ret = container->extract_constants_map(use_inactive);
+      for (const auto& pair: ret) {
+        constants_map->emplace(pair.first, pair.second);
+      }
+    })
+}
+
 AOTIRuntimeError AOTInductorModelContainerUpdateConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle,

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
@@ -98,6 +98,9 @@ consider rebuild your model with the latest AOTInductor.");
   TRY_LOAD_SYMBOL(
       free_inactive_constant_buffer_func_,
       "AOTInductorModelContainerFreeInactiveConstantBuffer")
+  TRY_LOAD_SYMBOL(
+      extract_constants_map_func_,
+      "AOTInductorModelContainerExtractConstantsMap");
 #undef TRY_LOAD_SYMBOL
 
   // Hack to find the json file name from the model so file
@@ -198,6 +201,21 @@ std::unordered_map<std::string, int32_t> AOTIModelContainerRunner::
     AOTI_RUNTIME_ERROR_CODE_CHECK(
         get_constant_dtype_func_(container_handle_, i, &dtype));
     result.emplace(name, dtype);
+  }
+  return result;
+}
+
+const std::unordered_map<std::string, at::Tensor> AOTIModelContainerRunner::
+    extract_constants_map(bool use_inactive) const {
+  TensorConstantMap extracted_map;
+  AOTI_RUNTIME_ERROR_CODE_CHECK(extract_constants_map_func_(
+      container_handle_,
+      (AOTInductorConstantMapHandle)&extracted_map,
+      use_inactive));
+
+  std::unordered_map<std::string, at::Tensor> result;
+  for (const auto& pair : extracted_map) {
+    result.emplace(pair.first, *(pair.second));
   }
   return result;
 }

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.h
@@ -37,6 +37,8 @@ class TORCH_API AOTIModelContainerRunner {
       const;
   std::unordered_map<std::string, int32_t> getConstantNamesToDtypes() const;
 
+  const std::unordered_map<std::string, at::Tensor> extract_constants_map(
+      bool use_inactive) const;
   void update_inactive_constant_buffer(const TensorConstantMap& const_map);
   void update_constant_buffer(
       std::unordered_map<std::string, at::Tensor>& tensor_map,
@@ -80,6 +82,8 @@ class TORCH_API AOTIModelContainerRunner {
       get_constant_original_fqn_func_{nullptr};
   decltype(&AOTInductorModelContainerGetConstantDtype) get_constant_dtype_func_{
       nullptr};
+  decltype(&AOTInductorModelContainerExtractConstantsMap)
+      extract_constants_map_func_{nullptr};
   decltype(&AOTInductorModelContainerUpdateConstantBuffer)
       update_constant_buffer_func_{nullptr};
   decltype(&AOTInductorModelContainerUpdateInactiveConstantBuffer)

--- a/torch/csrc/inductor/aoti_runner/pybind.cpp
+++ b/torch/csrc/inductor/aoti_runner/pybind.cpp
@@ -31,6 +31,9 @@ void initAOTIRunnerBindings(PyObject* module) {
           "get_constant_names_to_dtypes",
           &AOTIModelContainerRunnerCpu::getConstantNamesToDtypes)
       .def(
+          "extract_constants_map",
+          &AOTIModelContainerRunnerCpu::extract_constants_map)
+      .def(
           "update_constant_buffer",
           static_cast<void (AOTIModelContainerRunnerCpu::*)(
               std::unordered_map<std::string, at::Tensor>&, bool, bool)>(
@@ -64,6 +67,9 @@ void initAOTIRunnerBindings(PyObject* module) {
           "get_constant_names_to_dtypes",
           &AOTIModelContainerRunnerCuda::getConstantNamesToDtypes)
       .def(
+          "extract_constants_map",
+          &AOTIModelContainerRunnerCuda::extract_constants_map)
+      .def(
           "update_constant_buffer",
           static_cast<void (AOTIModelContainerRunnerCuda::*)(
               std::unordered_map<std::string, at::Tensor>&, bool, bool)>(
@@ -96,6 +102,9 @@ void initAOTIRunnerBindings(PyObject* module) {
       .def(
           "get_constant_names_to_dtypes",
           &AOTIModelContainerRunnerXpu::getConstantNamesToDtypes)
+      .def(
+          "extract_constants_map",
+          &AOTIModelContainerRunnerXpu::extract_constants_map)
       .def(
           "update_constant_buffer",
           static_cast<void (AOTIModelContainerRunnerXpu::*)(

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -117,6 +117,12 @@ AOTIRuntimeError AOTInductorModelContainerGetConstantDtype(
     size_t idx,
     int32_t* dtype);
 
+// Extract the constants that is being used in the container.
+AOTIRuntimeError AOTInductorModelContainerExtractConstantsMap(
+    AOTInductorModelContainerHandle container_handle,
+    AOTInductorConstantMapHandle constant_map_handle,
+    bool use_inactive);
+
 // Setup the constant buffer in model container with provided ConstantMap
 // use_inactive should be set as true if the inactive buffer is to be updated.
 // validate_full_update checks if all constants are included in the ConstantMap


### PR DESCRIPTION
Summary: Add extract_constant_map that allows users to inspect the constants being used by AOTInductor

Test Plan:
`python test/inductor/test_aot_inductor.py -k extract_constants_map`

`LD_LIBRARY_PATH=/data/users/$USER/pytorch/build/lib /data/users/$USER/pytorch/build/bin/test_aoti_inference`

Differential Revision: D72020400




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @amjames @chauhang @aakhundov