### PR TITLE
Relax njt x njt to dense matmul reduction checks

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -8675,6 +8675,15 @@ COMPILE_BACKWARD_SKIPS_AND_XFAILS = [
         op_match_fn=lambda device, op: (op.full_name in {"cdouble", "cfloat", "chalf"}),
         name="unimplemented_view_as_real",
     ),
+    # https://github.com/pytorch/pytorch/issues/152962
+    XFailRule(
+        error_type=torch._dynamo.exc.UserError,
+        # Eq(27, u0) (unhinted: Eq(s27, u0)).  (Size-like symbols: u0)
+        error_msg="Could not guard on data-dependent expression",
+        op_match_fn=lambda device, op: op.full_name == "matmul",
+        sample_match_fn=lambda device, sample: "3D_noncontig_transposed_with_seqlen_cache" in sample.name,
+        name="3D_noncontig_transposed_with_seqlen_cache_matmul_compile_backward_issue",
+    ),
     *COMPILE_FORWARD_SKIPS_AND_XFAILS,
     *BACKWARD_SKIPS_AND_XFAILS,
 ]

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -8286,8 +8286,13 @@ FORWARD_SKIPS_AND_XFAILS = [
         sample_match_fn=lambda device, sample: (
             "noncontig_holes" in sample.name
             # "other" is the name for the matmul arg and "mat2" is the name for the bmm arg
-            and sample.input.dim()
-            == sample.kwargs.get("other", sample.kwargs.get("mat2")).dim()
+            and sample.input.dim() == sample.kwargs.get("other", sample.kwargs.get("mat2")).dim()
+            and not (
+                # matmuls that reduce to dense are supported even for non-contig with holes
+                sample.input._ragged_idx == sample.input.dim() - 1
+                and sample.kwargs.get("other", None) is not None
+                and sample.kwargs.get("other")._ragged_idx == sample.input.dim() - 2
+            )
         ),
         name="mm_noncontig_holes",
     ),
@@ -8378,6 +8383,21 @@ BACKWARD_SKIPS_AND_XFAILS = [
         op_match_fn=lambda device, op: (op.full_name in {"unflatten"}),
         sample_match_fn=lambda device, sample: ("noncontig_holes" in sample.name),
         name="broken_unflatten_backward",
+    ),
+    # expected: matmul backwards uses a to_padded_tensor() for NJT x NJT --> dense 
+    # which isn't supported for non-contig NJTs with holes
+    XFailRule(
+        error_type=RuntimeError,
+        error_msg="not supported for nested tensors with holes",
+        op_match_fn=lambda device, op: (op.full_name in {"matmul"}),
+        sample_match_fn=lambda device, sample: (
+            "noncontig_holes" in sample.name
+            and (  # specify case for NJT x NJT --> dense
+                sample.input._ragged_idx == sample.input.dim() - 1
+                and sample.kwargs.get("other")._ragged_idx == sample.input.dim() - 2
+            )
+        ),
+        name="njt_mm_to_dense_noncontig_holes",
     ),
     # sum() backward is not implemented for non-full reductions
     XFailRule(
@@ -8558,6 +8578,21 @@ COMPILE_FORWARD_SKIPS_AND_XFAILS = [
             and sample.kwargs.get("memory_format", None) == torch.contiguous_format
         ),
         name="clone_unbind_data_dependency",
+    ),
+    # NJT x NJT --> dense matmuls use unbind() leading to data-dependent expression in some cases
+    XFailRule(
+        error_type=torch._dynamo.exc.UserError,
+        # Eq(36, u0) (unhinted: Eq(s41, u0)).  (Size-like symbols: u0)
+        error_msg="Could not guard on data-dependent expression",
+        op_match_fn=lambda device, op: (op.full_name == "matmul"),
+        sample_match_fn=lambda device, sample: (
+            ("_contig_transposed" in sample.name or "noncontig_holes" in sample.name)
+            and (  # specify case for NJT x NJT --> dense
+                sample.input._ragged_idx == sample.input.dim() - 1
+                and sample.kwargs.get("other")._ragged_idx == sample.input.dim() - 2
+            )
+        ),
+        name="njt_matmul_to_dense_unbind_data_dependency",
     ),
     # chunk(): broken in several ways on the batch dim; revisit after similar
     # data-dependency issues are handled for narrow()

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -1238,12 +1238,10 @@ def matmul_default(func, *args, **kwargs):
         if inp.dim() > 3 and other.dim() > 3 and raggedness_matches(inp, other._size):
             return NestedTensor(func(inp._values, other._values), **extract_kwargs(inp))
         # Support reducing over ragged with dense output:
-        # (B, D, j1) x (B, j1, E) => (B, D, E)
+        # (..., D, j1) x (..., j1, E) => (..., D, E)
         elif (
-            inp.dim() == 3
-            and other.dim() == 3
-            and inp._ragged_idx == 2
-            and other._ragged_idx == 1
+            inp._ragged_idx == inp.dim() - 1
+            and other._ragged_idx == inp.dim() - 2
             and inp.size(inp._ragged_idx) == other.size(other._ragged_idx)
         ):
             # do unbind for this; can't use padded conversion due to j1 in last dim


### PR DESCRIPTION
Attempts to address [this comment](https://github.com/pytorch/pytorch/issues/145158#issuecomment-2712038919) from @jbschlosser.

The new forward matmul tests I added are passing except for the 'noncontig_holes' examples which are failing because they are not raising the expected torch._dynamo.exc.BackendCompilerFailed.
```
...
FAIL: test_forward_matmul_cuda_float32 (__main__.TestNestedTensorOpInfoCUDA.test_forward_matmul_cuda_float32) (sample='6D_noncontig_holes_without_seqlen_cache: (..., E, j1) x (..., j1, F)', idx=18)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/HUGE/Code/pytorch/test/test_nestedtensor.py", line 8689, in test_forward
    with subtest_ctx(self), skip_xfail_ctx(self):
AssertionError: (<class 'RuntimeError'>, <class 'torch._dynamo.exc.BackendCompilerFailed'>) not raised
...
```

The backward matmul tests are passing, although I think these aren't being run on the new SampleInputs as there are only two tests passing. How can I add new tests for the backwards pass?

All of the forward and backward compiled tests seem to be failing on :
```
torch._dynamo.exc.UserError: Could not guard on data-dependent expression Eq(36, u0) (unhinted: Eq(s34, u0)).  (Size-like symbols: u0)

or

AssertionError: "not supported for nested tensors with holes" does not match "Could not guard on data-dependent expression Eq(36, u0) (unhinted: Eq(s34, u0)).  (Size-like symbols: u0)
```
The second of which seems like it should be caught by the earlier assertion on the non-compiled tests...

Here's a verbose log for:
```
TORCH_LOGS="+dynamo,+dynamic" TORCHDYNAMO_VERBOSE=1 python test/test_nestedtensor.py -k matmul -vvv
```


[relax_njt_x_njt_to_dense_matmul_reduction_checks.txt](https://github.com/user-attachments/files/19501949/relax_njt_x_njt_to_dense_matmul_reduction_checks.txt)

I would appreciate any feedback or pointers on how to get things sorted!

cc @cpuhrsch @jbschlosser @bhosmer @drisspg @soulitzer @davidberard98 @YuqingJ