### PR TITLE
Smoke Test - disable pypi package validation for binaries that package cuda libs

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -97,7 +97,7 @@ if [[ "\$GPU_ARCH_TYPE" != *s390x* && "\$GPU_ARCH_TYPE" != *xpu* && "\$GPU_ARCH_
   # this package contains all libraries packaged in torch libs folder
   # example of such package is https://download.pytorch.org/whl/cu126_full/torch
   if [[ "\$torch_pkg_size" -gt  1500000000 ]]; then
-    python /pytorch/.ci/pytorch/smoke_test/smoke_test.py --package=torchonly --torch-compile-check disabled --pypi-pckg-check disabled
+    python /pytorch/.ci/pytorch/smoke_test/smoke_test.py --package=torchonly --torch-compile-check disabled --pypi-pkg-check disabled
   else
     python /pytorch/.ci/pytorch/smoke_test/smoke_test.py --package=torchonly --torch-compile-check disabled $extra_parameters
   fi

--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -95,13 +95,12 @@ if [[ "\$GPU_ARCH_TYPE" != *s390x* && "\$GPU_ARCH_TYPE" != *xpu* && "\$GPU_ARCH_
   # todo: implement check for large binaries
   # if the package is larger than 1.5GB, we disable the pypi check.
   # this package contains all libraries packaged in torch libs folder
-  # example of such package is https://download.pytorch.org/whl/cu124_full/torch
-  extra_parameters=""
+  # example of such package is https://download.pytorch.org/whl/cu126_full/torch
   if [[ "\$torch_pkg_size" -gt  1500000000 ]]; then
-    extra_parameters="--pypi-pckg-check disabled"
+    python /pytorch/.ci/pytorch/smoke_test/smoke_test.py --package=torchonly --torch-compile-check disabled --pypi-pckg-check disabled
+  else
+    python /pytorch/.ci/pytorch/smoke_test/smoke_test.py --package=torchonly --torch-compile-check disabled $extra_parameters
   fi
-
-  python /pytorch/.ci/pytorch/smoke_test/smoke_test.py --package=torchonly --torch-compile-check disabled $extra_parameters
 fi
 
 # Clean temp files

--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -90,8 +90,17 @@ fi
 /pytorch/.ci/pytorch/check_binary.sh
 
 if [[ "\$GPU_ARCH_TYPE" != *s390x* && "\$GPU_ARCH_TYPE" != *xpu* && "\$GPU_ARCH_TYPE" != *rocm*  && "$PACKAGE_TYPE" != libtorch ]]; then
-  # Exclude s390, xpu, rocm and libtorch builds from smoke testing
-  python /pytorch/.ci/pytorch/smoke_test/smoke_test.py --package=torchonly --torch-compile-check disabled
+
+  torch_pkg_size=$(wc -c < "\$pkg")
+  # todo: implement check for large binaries
+  # if the package is larger than 1.5GB, we disable the pypi check.
+  # this package contains all libraries packaged in torch libs folder
+  extra_parameters=""
+  if [[ "\$torch_pkg_size" -gt  1500000000 ]]; then
+    extra_parameters="--pypi-pckg-check disabled"
+  fi
+
+  python /pytorch/.ci/pytorch/smoke_test/smoke_test.py --package=torchonly --torch-compile-check disabled "$extra_parameters"
 fi
 
 # Clean temp files

--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -92,7 +92,7 @@ fi
 if [[ "\$GPU_ARCH_TYPE" != *s390x* && "\$GPU_ARCH_TYPE" != *xpu* && "\$GPU_ARCH_TYPE" != *rocm*  && "$PACKAGE_TYPE" != libtorch ]]; then
 
   pkg_torch="$(ls -1 /final_pkgs/torch-* | sort |tail -1)"
-  torch_pkg_size="$(wc -c < \$pkg_torch)"
+  torch_pkg_size="\$(wc -c < $pkg_torch)"
   # todo: implement check for large binaries
   # if the package is larger than 1.5GB, we disable the pypi check.
   # this package contains all libraries packaged in torch libs folder

--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -91,7 +91,8 @@ fi
 
 if [[ "\$GPU_ARCH_TYPE" != *s390x* && "\$GPU_ARCH_TYPE" != *xpu* && "\$GPU_ARCH_TYPE" != *rocm*  && "$PACKAGE_TYPE" != libtorch ]]; then
 
-  torch_pkg_size=$(wc -c < \$pkg)
+  pkg_torch="$(ls -1 /final_pkgs/torch-* | sort |tail -1)"
+  torch_pkg_size="$(wc -c < \$pkg_torch)"
   # todo: implement check for large binaries
   # if the package is larger than 1.5GB, we disable the pypi check.
   # this package contains all libraries packaged in torch libs folder

--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -91,7 +91,7 @@ fi
 
 if [[ "\$GPU_ARCH_TYPE" != *s390x* && "\$GPU_ARCH_TYPE" != *xpu* && "\$GPU_ARCH_TYPE" != *rocm*  && "$PACKAGE_TYPE" != libtorch ]]; then
 
-  torch_pkg_size=$(wc -c < "\$pkg")
+  torch_pkg_size=$(wc -c < \$pkg)
   # todo: implement check for large binaries
   # if the package is larger than 1.5GB, we disable the pypi check.
   # this package contains all libraries packaged in torch libs folder
@@ -101,7 +101,7 @@ if [[ "\$GPU_ARCH_TYPE" != *s390x* && "\$GPU_ARCH_TYPE" != *xpu* && "\$GPU_ARCH_
     extra_parameters="--pypi-pckg-check disabled"
   fi
 
-  python /pytorch/.ci/pytorch/smoke_test/smoke_test.py --package=torchonly --torch-compile-check disabled "$extra_parameters"
+  python /pytorch/.ci/pytorch/smoke_test/smoke_test.py --package=torchonly --torch-compile-check disabled $extra_parameters
 fi
 
 # Clean temp files

--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -91,8 +91,7 @@ fi
 
 if [[ "\$GPU_ARCH_TYPE" != *s390x* && "\$GPU_ARCH_TYPE" != *xpu* && "\$GPU_ARCH_TYPE" != *rocm*  && "$PACKAGE_TYPE" != libtorch ]]; then
 
-  pkg_torch="$(ls -1 /final_pkgs/torch-* | sort |tail -1)"
-  torch_pkg_size="$(wc -c < $pkg_torch)"
+  torch_pkg_size="$(ls -1 /final_pkgs/torch-* | sort |tail -1 |xargs wc -c |cut -d ' ' -f1)"
   # todo: implement check for large binaries
   # if the package is larger than 1.5GB, we disable the pypi check.
   # this package contains all libraries packaged in torch libs folder

--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -92,7 +92,7 @@ fi
 if [[ "\$GPU_ARCH_TYPE" != *s390x* && "\$GPU_ARCH_TYPE" != *xpu* && "\$GPU_ARCH_TYPE" != *rocm*  && "$PACKAGE_TYPE" != libtorch ]]; then
 
   pkg_torch="$(ls -1 /final_pkgs/torch-* | sort |tail -1)"
-  torch_pkg_size="\$(wc -c < $pkg_torch)"
+  torch_pkg_size="$(wc -c < $pkg_torch)"
   # todo: implement check for large binaries
   # if the package is larger than 1.5GB, we disable the pypi check.
   # this package contains all libraries packaged in torch libs folder

--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -95,6 +95,7 @@ if [[ "\$GPU_ARCH_TYPE" != *s390x* && "\$GPU_ARCH_TYPE" != *xpu* && "\$GPU_ARCH_
   # todo: implement check for large binaries
   # if the package is larger than 1.5GB, we disable the pypi check.
   # this package contains all libraries packaged in torch libs folder
+  # example of such package is https://download.pytorch.org/whl/cu124_full/torch
   extra_parameters=""
   if [[ "\$torch_pkg_size" -gt  1500000000 ]]; then
     extra_parameters="--pypi-pckg-check disabled"


### PR DESCRIPTION
Smoke Test - disable pypi package validation for binaries that package cuda libs. These binaries do not install packages via pypi.
Should Resolve this from `linux-binary-manywheel / manywheel-py3_11-cuda12_6-full-test / test`: 
```
Traceback (most recent call last):
  File "/pytorch/.ci/pytorch/smoke_test/smoke_test.py", line 468, in <module>
    main()
  File "/pytorch/.ci/pytorch/smoke_test/smoke_test.py", line 462, in main
    smoke_test_cuda(
  File "/pytorch/.ci/pytorch/smoke_test/smoke_test.py", line 274, in smoke_test_cuda
    compare_pypi_to_torch_versions(
  File "/pytorch/.ci/pytorch/smoke_test/smoke_test.py", line 220, in compare_pypi_to_torch_versions
    raise RuntimeError(f"Can't find {package} in PyPI for Torch: {torch_version}")
RuntimeError: Can't find cudnn in PyPI for Torch: 9.5.1
```
Link: https://github.com/pytorch/pytorch/actions/runs/14101221665/job/39505479587#step:15:982