### PR TITLE
Parallelize sort using libstdc++ parallel mode

### DIFF
--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -418,11 +418,6 @@ if(INTERN_BUILD_ATEN_OPS)
         set(EXTRA_FLAGS "-DCPU_CAPABILITY=${CPU_CAPABILITY} -DCPU_CAPABILITY_${CPU_CAPABILITY}")
       endif(MSVC)
 
-      # Only parallelize the SortingKernel for now to avoid side effects
-      if(${NAME} STREQUAL "native/cpu/SortingKernel.cpp" AND NOT MSVC AND USE_OMP)
-        string(APPEND EXTRA_FLAGS " -D_GLIBCXX_PARALLEL")
-      endif()
-
       # Disable certain warnings for GCC-9.X
       if(CMAKE_COMPILER_IS_GNUCXX)
         if(("${NAME}" STREQUAL "native/cpu/GridSamplerKernel.cpp") AND ("${CPU_CAPABILITY}" STREQUAL "DEFAULT"))


### PR DESCRIPTION
Fixes #149977, #149979, #150094.

Previously, #149505 used libstdc++ parallel mode by enabling `-D_GLIBCXX_PARALLEL`. However, mixing source files compiled with and without parallel mode can lead to undefined behavior (See https://gcc.gnu.org/onlinedocs/libstdc++/manual/parallel_mode_using.html) We switch to using the specific paralell sort from `<parallel/algorithm>` when compiled with GCC compiler. Note that use of `std::execution` policy has dependency on libtbb and we thus decide to avoid that.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @malfet @snadampal @milpuz01 @aditew01 @nikhil-arm @fadara01