### PR TITLE
[fix] pin cmake to 3.31.6 in build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     "numpy",
     "ninja",
     "pyyaml",
-    "cmake",
+    "cmake==3.31.6",
     "typing-extensions>=4.10.0",
     "requests",
 ]


### PR DESCRIPTION
As per PR #150158 , I believe that the build requirements should be updated. 