### PR TITLE
[ONNX] remove_assertion_nodes before decomp

### DIFF
--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -894,14 +894,17 @@ def _prepare_exported_program_for_export(
 ) -> torch.export.ExportedProgram:
     """Decompose and apply pre-export transformations to the exported program."""
 
+    graph_module = exported_program.graph_module
+    graph_module = _fx_passes.remove_assertion_nodes(graph_module)
+    # Reassign the graph module to save some runtime.
+    exported_program._graph_module = graph_module
+
     # Decompose the graph given the implemented torch ops in ONNX
     exported_program = _fx_passes.decompose_with_registry(exported_program, registry)
 
     graph_module = exported_program.graph_module
     # Include explicit type promotion nodes
     _fx_passes.insert_type_promotion_nodes(graph_module)
-    graph_module = _fx_passes.remove_assertion_nodes(graph_module)
-    # Reassign the graph module to save some runtime.
     exported_program._graph_module = graph_module
     return exported_program
 


### PR DESCRIPTION
Call remove_assertion_nodes before decomp because we see errors like `<class 'TypeError'>: cannot determine truth value of RelationalWhile executing %_assert_scalar_default : [num_users=0] = call_function[target=torch.ops.aten._assert_scalar.default](args = (%ge_2 Runtime assertion failed for expression u4 >= 0 on node 'ge_2') kwargs = {})`
