### PR TITLE
TCPStoreLibUvBackend: support masterListenFd

### DIFF
--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -567,33 +567,6 @@ class LibUvTCPStoreTest(TCPStoreTest):
             addr, world_size, wait_for_workers=False, use_libuv=True
         )
 
-    def test_take_over_listen_socket(self):
-        """
-        override the take_over_listen_socket test in TCPStoreTest.
-        Reason: we have not thoroughly tested libuv TCPStore initialization using
-        open Socket so we decide to not support this use for now.
-        TODO (xilunwu): enable this use case
-        """
-        listen_sock: socket.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        listen_sock.bind(("localhost", 0))
-        addr, port, *_ = listen_sock.getsockname()
-        listen_fd = listen_sock.detach()
-
-        err_msg_reg = (
-            "^The libuv TCPStore backend does not support "
-            "initialization with an listen fd"
-        )
-
-        with self.assertRaisesRegex(NotImplementedError, err_msg_reg):
-            dist.TCPStore(
-                addr,
-                port,
-                1,
-                is_master=True,
-                master_listen_fd=listen_fd,
-                use_libuv=self._use_libuv,
-            )
-
 
 class PrefixTCPStoreTest(TestCase, StoreTestBase):
     def setUp(self):

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -250,17 +250,6 @@ TCPStore::TCPStore(std::string host, const TCPStoreOptions& opts)
         DistStoreError,
         ::c10d::detail::is_libuv_tcpstore_backend_available(),
         "use_libuv was requested but PyTorch was built without libuv support, run with USE_LIBUV=0 to disable it.");
-
-    if (opts.masterListenFd.has_value()) {
-      // TODO(xilunwu): support this init method after testing
-      constexpr auto* msg =
-          "The libuv TCPStore backend does not support initialization with an listen fd. "
-          "Please switch to the legacy TCPStore by setting environment variable USE_LIBUV "
-          "to \"0\".";
-      C10D_ERROR(msg);
-      C10_THROW_ERROR(NotImplementedError, msg);
-      return;
-    }
   }
 
   Socket::initialize();

--- a/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
@@ -219,8 +219,8 @@ class UvTcpServer : public UvTcpSocket {
     res->handleReady();
     try {
       int uv_res = uv_tcp_open((uv_tcp_t*)res->unsafeGetStream(), socket);
-      TORCH_CHECK_WITH(
-          DistStoreError,
+      C10D_CHECK_WITH(
+          SocketError,
           uv_res == 0,
           "Failed to open existing socket. ",
           "socket: ",
@@ -232,6 +232,18 @@ class UvTcpServer : public UvTcpSocket {
           ", message: ",
           uv_strerror(uv_res));
 
+      uv_res =
+          uv_listen(res->unsafeGetStream(), DEFAULT_BACKLOG, on_new_connection);
+      C10D_CHECK_WITH(
+          SocketError,
+          uv_res == 0,
+          fmt::format(
+              "The server socket has failed to listen on provided socket. "
+              "socket: {}, code: {}, name: {}, message: {}",
+              socket,
+              uv_res,
+              uv_err_name(uv_res),
+              uv_strerror(uv_res)));
       res->cacheSocketPort();
     } catch (std::exception& ex) {
       res->close();

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1609,7 +1609,7 @@ Arguments:
     timeout (timedelta, optional): Timeout used by the store during initialization and for methods such as :meth:`~torch.distributed.store.get` and :meth:`~torch.distributed.store.wait`. Default is timedelta(seconds=300)
     wait_for_workers (bool, optional): Whether to wait for all the workers to connect with the server store. This is only applicable when world_size is a fixed value. Default is True.
     multi_tenant (bool, optional): If True, all ``TCPStore`` instances in the current process with the same host/port will use the same underlying ``TCPServer``. Default is False.
-    master_listen_fd (int, optional): If specified, the underlying ``TCPServer`` will listen on this file descriptor, which must be a socket already bound to ``port``. Useful to avoid port assignment races in some scenarios. Default is None (meaning the server creates a new socket and attempts to bind it to ``port``).
+    master_listen_fd (int, optional): If specified, the underlying ``TCPServer`` will listen on this file descriptor, which must be a socket already bound to ``port``. To bind an ephemeral port we recommend setting the port to 0 and reading ``.port``. Default is None (meaning the server creates a new socket and attempts to bind it to ``port``).
     use_libuv (bool, optional): If True, use libuv for ``TCPServer`` backend. Default is True.
 Example::
     >>> import torch.distributed as dist


### PR DESCRIPTION
This supports `masterListenFd` which is required for full compatibility with the non-libuv TCPStore. The code was just missing a `uv_listen` call and now it works just fine.

This is required to migrate the last remaining uses of TCPStore off of the non-libuv backend.

Test plan:
```
pytest -v test/distributed/test_store.py -k test_take_over_listen_socket
```

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @c-p-i-o