### PR TITLE
Move dump location to avoid dumping twice

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -847,6 +847,31 @@ def _compile_fx_inner(
 
     log.debug("FX codegen and compilation took %.3fs", time.time() - start)
 
+    # Dump provenance artifacts for debugging trace
+    provenance_info = V.debug.log_inductor_triton_kernel_to_post_grad_node_info()
+    # provenance_info might be None if config.trace.enabled is not set
+    if provenance_info:
+        (
+            debug_info,
+            node_mappings,
+        ) = provenance_info
+        trace_structured(
+            "artifact",
+            metadata_fn=lambda: {
+                "name": "inductor_triton_kernel_to_post_grad_nodes",
+                "encoding": "json",
+            },
+            payload_fn=lambda: json.dumps(debug_info),
+        )
+        trace_structured(
+            "artifact",
+            metadata_fn=lambda: {
+                "name": "inductor_provenance_tracking_node_mappings",
+                "encoding": "json",
+            },
+            payload_fn=lambda: json.dumps(node_mappings),
+        )
+
     # This message is for printing overview information of inductor mm counts, shapes,etc after lowering
     if log.isEnabledFor(logging.INFO):
         mm_table_data = []

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import functools
 import itertools
-import json
 import logging
 import operator
 import os
@@ -2121,32 +2120,6 @@ class GraphLowering(torch.fx.Interpreter):
                 "Finished codegen for all nodes. The list of kernel names available: %s",
                 V.graph.all_codegen_kernel_names,
             )
-            # Dump provenance artifacts for debugging trace
-            provenance_info = (
-                V.debug.log_inductor_triton_kernel_to_post_grad_node_info()
-            )
-            # provenance_info might be None if config.trace.enabled is not set
-            if provenance_info:
-                (
-                    debug_info,
-                    node_mappings,
-                ) = provenance_info
-                trace_structured(
-                    "artifact",
-                    metadata_fn=lambda: {
-                        "name": "inductor_triton_kernel_to_post_grad_nodes",
-                        "encoding": "json",
-                    },
-                    payload_fn=lambda: json.dumps(debug_info),
-                )
-                trace_structured(
-                    "artifact",
-                    metadata_fn=lambda: {
-                        "name": "inductor_provenance_tracking_node_mappings",
-                        "encoding": "json",
-                    },
-                    payload_fn=lambda: json.dumps(node_mappings),
-                )
 
             result = self.wrapper_code.generate(self.is_inference)
             self.wrapper_code.pop_codegened_graph()


### PR DESCRIPTION
Summary:
If we put the dumping code in codegen, we might get a separate node_mapping dump for the constant folded graph (https://github.com/pytorch/pytorch/blob/main/torch/_inductor/compile_fx.py#L1119).

We move it into compile_fx.py so there's only one node_mapping dump.

Test Plan: CI

Reviewed By: YUNQIUGUO

Differential Revision: D72068715




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov