### PR TITLE
[CI] Fix docker builds failing due to cmake update by setting CMAKE_POLICY_VERSION_MINIMUM

### DIFF
--- a/.ci/docker/common/install_executorch.sh
+++ b/.ci/docker/common/install_executorch.sh
@@ -37,7 +37,7 @@ install_conda_dependencies() {
 
 install_pip_dependencies() {
   pushd executorch
-  as_jenkins bash install_executorch.sh
+  as_jenkins CMAKE_POLICY_VERSION_MINIMUM=3.5 bash install_executorch.sh
 
   # A workaround, ExecuTorch has moved to numpy 2.0 which is not compatible with the current
   # numba and scipy version used in PyTorch CI

--- a/.ci/docker/common/install_executorch.sh
+++ b/.ci/docker/common/install_executorch.sh
@@ -37,6 +37,7 @@ install_conda_dependencies() {
 
 install_pip_dependencies() {
   pushd executorch
+  # Remove CMAKE_POLICY_VERSION_MINIMUM when cmake 4.0.0 is more supported
   as_jenkins CMAKE_POLICY_VERSION_MINIMUM=3.5 bash install_executorch.sh
 
   # A workaround, ExecuTorch has moved to numpy 2.0 which is not compatible with the current

--- a/.ci/docker/common/install_halide.sh
+++ b/.ci/docker/common/install_halide.sh
@@ -19,6 +19,7 @@ fi
 
 conda_install numpy scipy imageio cmake ninja
 
+# Remove this when cmake 4.0.0 is more supported
 export CMAKE_POLICY_VERSION_MINIMUM=3.5
 
 git clone --depth 1 --branch release/16.x --recursive https://github.com/llvm/llvm-project.git

--- a/.ci/docker/common/install_halide.sh
+++ b/.ci/docker/common/install_halide.sh
@@ -19,6 +19,8 @@ fi
 
 conda_install numpy scipy imageio cmake ninja
 
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+
 git clone --depth 1 --branch release/16.x --recursive https://github.com/llvm/llvm-project.git
 cmake -DCMAKE_BUILD_TYPE=Release \
         -DLLVM_ENABLE_PROJECTS="clang" \

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1482,7 +1482,7 @@ test_executorch() {
   bash examples/models/llama3_2_vision/install_requirements.sh
   # NB: We need to rebuild ExecuTorch runner here because it depends on PyTorch
   # from the PR
-  bash .ci/scripts/setup-linux.sh --build-tool cmake
+  CMAKE_POLICY_VERSION_MINIMUM=3.5 bash .ci/scripts/setup-linux.sh --build-tool cmake
 
   echo "Run ExecuTorch unit tests"
   pytest -v -n auto

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1482,6 +1482,7 @@ test_executorch() {
   bash examples/models/llama3_2_vision/install_requirements.sh
   # NB: We need to rebuild ExecuTorch runner here because it depends on PyTorch
   # from the PR
+  # Remove CMAKE_POLICY_VERSION_MINIMUM=3.5 when 4.0.0 is supported
   CMAKE_POLICY_VERSION_MINIMUM=3.5 bash .ci/scripts/setup-linux.sh --build-tool cmake
 
   echo "Run ExecuTorch unit tests"


### PR DESCRIPTION
Set the CMAKE_POLICY_VERSION_MINIMUM env var to make executorch and halide docker builds pass (they install from those repos which don't have cmake pinned)

This can be removed if executorch and halide update their builds and we update the hash?