### PR TITLE
[ROCm][CI] Increase wheel build timeout from 210 to 240

### DIFF
--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -23,7 +23,7 @@ on:
         description: Hardware to run this "build" job on, linux.12xlarge or linux.arm64.2xlarge.
       timeout-minutes:
         required: false
-        default: 210
+        default: 240
         type: number
         description: timeout for the job
       use_split_build:


### PR DESCRIPTION
Fixes #150046.  Increasing the timeout from 210 to 240.
cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd