### PR TITLE
Move MacOS inductor tests to M2-15 runner

### DIFF
--- a/.github/workflows/inductor-perf-test-nightly-macos.yml
+++ b/.github/workflows/inductor-perf-test-nightly-macos.yml
@@ -26,8 +26,7 @@ on:
       - .github/workflows/inductor-perf-test-nightly-macos.yml
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_d|        type: boolean
-ispatch' }}-${{ github.event_name == 'schedule' }}  
+  group:  ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-perf-test-nightly-macos.yml
+++ b/.github/workflows/inductor-perf-test-nightly-macos.yml
@@ -26,7 +26,8 @@ on:
       - .github/workflows/inductor-perf-test-nightly-macos.yml
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_d|        type: boolean
+ispatch' }}-${{ github.event_name == 'schedule' }}  
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/inductor-perf-test-nightly-macos.yml
+++ b/.github/workflows/inductor-perf-test-nightly-macos.yml
@@ -21,6 +21,9 @@ on:
         required: false
         type: string
         default: torchbench_perf_mps
+  pull_request:
+    paths:
+      - .github/workflows/inductor-perf-test-nightly-macos.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/inductor-perf-test-nightly-macos.yml
+++ b/.github/workflows/inductor-perf-test-nightly-macos.yml
@@ -42,7 +42,7 @@ jobs:
       python-version: 3.9.12
       test-matrix: |
         { include: [
-          { config: "perf_smoketest", shard: 1, num_shards: 1, runner: "macos-m1-14" },
+          { config: "perf_smoketest", shard: 1, num_shards: 1, runner: "macos-m2-15" },
         ]}
     secrets: inherit
 


### PR DESCRIPTION
To get more representative results (and be able to run more tests eventually)
Also get pull_request for workflow dispatch if yml file is modified