### PR TITLE
[c10d][fr] Allow multiple writer registration with warnings

### DIFF
--- a/torch/csrc/distributed/c10d/FlightRecorder.cpp
+++ b/torch/csrc/distributed/c10d/FlightRecorder.cpp
@@ -205,9 +205,9 @@ DebugInfoWriter& DebugInfoWriter::getWriter(int rank) {
 void DebugInfoWriter::registerWriter(std::unique_ptr<DebugInfoWriter> writer) {
   if (hasWriterRegistered_.load()) {
     TORCH_WARN_ONCE(
-      "DebugInfoWriter is registered more than once, but since we need it to stay "
-      "outside ProcessGroup, user needs to ensure that this registration is indeed needed. "
-      "And we will only use the last registered writer.");
+        "DebugInfoWriter has already been registered, and since we need the writer to stay "
+        "outside ProcessGroup, user needs to ensure that this extra registration is indeed needed. "
+        "And we will only use the last registered writer.");
   }
   hasWriterRegistered_.store(true);
   writer_ = std::move(writer);

--- a/torch/csrc/distributed/c10d/FlightRecorder.cpp
+++ b/torch/csrc/distributed/c10d/FlightRecorder.cpp
@@ -203,10 +203,12 @@ DebugInfoWriter& DebugInfoWriter::getWriter(int rank) {
 }
 
 void DebugInfoWriter::registerWriter(std::unique_ptr<DebugInfoWriter> writer) {
-  TORCH_CHECK_WITH(
-      DistBackendError,
-      hasWriterRegistered_.load() == false,
-      "debugInfoWriter already registered");
+  if (hasWriterRegistered_.load()) {
+    TORCH_WARN_ONCE(
+      "DebugInfoWriter is registered more than once, but since we need it to stay "
+      "outside ProcessGroup, user needs to ensure that this registration is indeed needed. "
+      "And we will only use the last registered writer.");
+  }
   hasWriterRegistered_.store(true);
   writer_ = std::move(writer);
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #150232

The life span of writer is actually the whole program which is sub-optimal but it is a practical compromise so that the registration of writer can happen outside PG creation.

So we decide to allow multiple writer registrations with warnings.

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @wz337 @wconstab @d4l3k @c-p-i-o