### PR TITLE
remove guard _size_oblivious from expand and make it more resilient to data dependent errors. 

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -12173,6 +12173,20 @@ class TestCustomFunction(torch.testing._internal.common_utils.TestCase):
         opt_fn(x, y).sum().backward()
         self.assertTrue(y.grad is not None)
 
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    def test_expand_unbacked(self):
+        def fn(x, repeats):
+            u0 = repeats.item()
+            torch._check_is_size(u0)
+            x_unbacked = x.expand(u0, u0)
+            return x_unbacked
+
+        example_inputs = (
+            torch.rand(3, 3),
+            torch.tensor(3),
+        )
+        torch.compile(fn, fullgraph=True)(*example_inputs)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -2989,7 +2989,7 @@ def dstack(tensors: TensorSequenceType) -> TensorLikeType:
 
 @register_decomposition(aten.expand)
 def expand(a: Tensor, *shape) -> Tensor:
-    from torch.fx.experimental.symbolic_shapes import guard_size_oblivious
+    from torch.fx.experimental.symbolic_shapes import sym_or
 
     # NOTE: cannot use utils.extract_shape_from_varargs here
     # because that also validates the shape, but the shape
@@ -3007,10 +3007,9 @@ def expand(a: Tensor, *shape) -> Tensor:
     for idx, x in enumerate(a.shape):
         offset_idx = idx + offset
         requested_length = shape[offset_idx]
+
         torch._check(
-            guard_size_oblivious(requested_length == x)
-            or guard_size_oblivious(x == 1)
-            or requested_length == -1,
+            sym_or(requested_length == x, sym_or(x == 1, requested_length == -1)),
             lambda: f"expand: attempting to expand a dimension of length {x}!",
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #150238
* #148809

When we do not know that requested_length == x, we do not have to fail we can make it runtime assert with sym_or.
address #150235 https://github.com/pytorch/pytorch/issues/128645
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames