### PR TITLE
[decomps] Add decomposition for linalg_vector_norm

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -310,8 +310,6 @@ aten::lgamma_
 aten::lift
 aten::lift.out
 aten::lift_fresh
-aten::linalg_vector_norm
-aten::linalg_vector_norm.out
 aten::log
 aten::log.out
 aten::log10

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -386,6 +386,7 @@ def _core_aten_decompositions_post_autograd() -> dict[
             aten.leaky_relu_backward,
             aten.lerp,
             aten.lerp_,
+            aten.linalg_vector_norm,
             aten.linspace,
             aten.logaddexp,
             aten.logaddexp2,


### PR DESCRIPTION

Summary:
## Context

`linalg_vector_norm` is required to run Vision Transformer models in ExecuTorch. Currently, model export + inference fails because ExecuTorch doesn't have a kernel for `linalg_vector_norm`.

However, there is a decomposition for the operator. Add the decomposition to the core decomp table to unblock ExecuTorch.
