### PR TITLE
[MPSInductor] Specify `max_total_threads_per_threadgroup`

### DIFF
--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -93,7 +93,8 @@ template <typename T>
 }
 
 template <typename T, typename U>
-::metal::enable_if_t<::metal::is_integral_v<T> && ::metal::is_integral_v<U>, T> max(T a, U b) {
+::metal::enable_if_t<::metal::is_integral_v<T>&& ::metal::is_integral_v<U>, T>
+max(T a, U b) {
   return ::metal::max(a, static_cast<T>(b));
 }
 
@@ -102,9 +103,10 @@ template <typename T>
   return ::metal::isunordered(a, b) ? NAN : ::metal::min(a, b);
 }
 
-template <typename T>
-::metal::enable_if_t<::metal::is_integral_v<T>, T> min(T a, T b) {
-  return ::metal::min(a, b);
+template <typename T, typename U>
+::metal::enable_if_t<::metal::is_integral_v<T>&& ::metal::is_integral_v<U>, T>
+min(T a, U b) {
+  return ::metal::min(a, static_cast<T>(b));
 }
 
 #if __METAL_VERSION__ >= 310

--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -92,9 +92,9 @@ template <typename T>
   return ::metal::isunordered(a, b) ? NAN : ::metal::max(a, b);
 }
 
-template <typename T>
-::metal::enable_if_t<::metal::is_integral_v<T>, T> max(T a, T b) {
-  return ::metal::max(a, b);
+template <typename T, typename U>
+::metal::enable_if_t<::metal::is_integral_v<T> && ::metal::is_integral_v<U>, T> max(T a, U b) {
+  return ::metal::max(a, static_cast<T>(b));
 }
 
 template <typename T>

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -195,6 +195,7 @@ for test_name in [
     "test_inf",
     "test_isinf",
     "test_isinf2",
+    "test_large_broadcast_reduction",
     "test_layer_norm",
     "test_lgamma",
     "test_linear_float64",

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -680,7 +680,9 @@ class MetalKernel(SIMDKernel):
             if self.inside_reduction:
                 reduction_dim = next(t for t in self.range_trees if t.is_reduction)
                 threadgroup_size = min(reduction_dim.numel, self.max_threadgroup_size)
-                code.writeline(f"[[max_total_threads_per_threadgroup({threadgroup_size})]]")
+                code.writeline(
+                    f"[[max_total_threads_per_threadgroup({threadgroup_size})]]"
+                )
             code.writeline("kernel void generated_kernel(")
             with code.indent():
                 for outer, inner in self.args.output_buffers.items():

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import itertools
+import math
 from typing import Any, Optional, TYPE_CHECKING
 
 import sympy
@@ -678,8 +679,8 @@ class MetalKernel(SIMDKernel):
             if self.inside_reduction:
                 code.writeline("#include <c10/metal/reduction_utils.h>")
             if self.inside_reduction:
-                reduction_dim = next(t for t in self.range_trees if t.is_reduction)
-                threadgroup_size = min(reduction_dim.numel, self.max_threadgroup_size)
+                total_reduction_size = math.prod(t.numel for t in self.range_trees if t.is_reduction)
+                threadgroup_size = min(total_reduction_size, self.max_threadgroup_size)
                 code.writeline(
                     f"[[max_total_threads_per_threadgroup({threadgroup_size})]]"
                 )

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -679,7 +679,9 @@ class MetalKernel(SIMDKernel):
             if self.inside_reduction:
                 code.writeline("#include <c10/metal/reduction_utils.h>")
             if self.inside_reduction:
-                total_reduction_size = math.prod(t.numel for t in self.range_trees if t.is_reduction)
+                total_reduction_size = math.prod(
+                    t.numel for t in self.range_trees if t.is_reduction
+                )
                 threadgroup_size = min(total_reduction_size, self.max_threadgroup_size)
                 code.writeline(
                     f"[[max_total_threads_per_threadgroup({threadgroup_size})]]"

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -677,6 +677,10 @@ class MetalKernel(SIMDKernel):
             )
             if self.inside_reduction:
                 code.writeline("#include <c10/metal/reduction_utils.h>")
+            if self.inside_reduction:
+                reduction_dim = next(t for t in self.range_trees if t.is_reduction)
+                threadgroup_size = min(reduction_dim.numel, self.max_threadgroup_size)
+                code.writeline(f"[[max_total_threads_per_threadgroup({threadgroup_size})]]")
             code.writeline("kernel void generated_kernel(")
             with code.indent():
                 for outer, inner in self.args.output_buffers.items():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #150247

When generating reduction kernel, otherwise compiler can unroll loops too much that kernel could not be launched for the intended threadgroup size

Extend `c10::metal::max` to accept different dtypes

Together this fixes `test_large_broadcast_reduction`

TODO:
  - Explore different threadgroup_sizes for best perf

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov