### PR TITLE
[MPS] grad scaler

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Amp.metal
+++ b/aten/src/ATen/native/mps/kernels/Amp.metal
@@ -1,0 +1,83 @@
+#include <metal_stdlib>
+using namespace metal;
+
+template <typename T>
+kernel void ampNonFiniteCheckAndUnscale(
+    device T* data [[buffer(0)]],
+    device T* foundInf [[buffer(1)]],
+    constant T& invScale [[buffer(2)]],
+    constant uint& numel [[buffer(3)]],
+    uint tid [[thread_position_in_grid]]) {
+  if (tid >= numel) {
+    return;
+  }
+  T val = data[tid];
+
+  if (!isfinite(val)) {
+    device atomic_float* flag = (device atomic_float*)foundInf;
+    atomic_store_explicit(flag, 1, memory_order_relaxed);
+  }
+
+  data[tid] = (invScale == 1.0f ? val : val * invScale);
+}
+
+template <typename T>
+kernel void ampUpdateScale(
+    device T* scale [[buffer(0)]],
+    device int* growth_tracker [[buffer(1)]],
+    device T* foundInf [[buffer(2)]],
+    constant T& scaleGrowthFactor [[buffer(3)]],
+    constant T& scaleBackoffFactor [[buffer(4)]],
+    constant uint& growthInterval [[buffer(5)]],
+    uint tid [[thread_position_in_grid]]) {
+  if (tid != 0) {
+    return;
+  }
+
+  int flag = (int)(foundInf[0]);
+
+  if (flag != 0) {
+    *scale = *scale * scaleBackoffFactor;
+    *growth_tracker = 0;
+  } else {
+    int g = *growth_tracker;
+    g += 1;
+    if (uint(g) >= growthInterval) {
+      *scale = *scale * scaleGrowthFactor;
+      g = 0;
+    }
+    *growth_tracker = g;
+  }
+}
+
+#define INSTANTIATE_AMP_NONFINITE_CHECK_AND_UNSCALE(DTYPE)                  \
+  template [[host_name("ampNonFiniteCheckAndUnscale_" #DTYPE)]] kernel void \
+  ampNonFiniteCheckAndUnscale<DTYPE>(                                       \
+      device DTYPE * data [[buffer(0)]],                                    \
+      device DTYPE * foundInf [[buffer(1)]],                                \
+      constant DTYPE & invScale [[buffer(2)]],                              \
+      constant uint & numel [[buffer(3)]],                                  \
+      uint tid [[thread_position_in_grid]])
+
+#define INSTANTIATE_AMP_UPDATE_SCALE(DTYPE)                    \
+  template [[host_name("ampUpdateScale_" #DTYPE)]] kernel void \
+  ampUpdateScale<DTYPE>(                                       \
+      device DTYPE * scale [[buffer(0)]],                      \
+      device int* growth_tracker [[buffer(1)]],                \
+      device DTYPE* foundInf [[buffer(2)]],                    \
+      constant DTYPE& scaleGrowthFactor [[buffer(3)]],         \
+      constant DTYPE& scaleBackoffFactor [[buffer(4)]],        \
+      constant uint& growthInterval [[buffer(5)]],             \
+      uint tid [[thread_position_in_grid]])
+
+INSTANTIATE_AMP_NONFINITE_CHECK_AND_UNSCALE(float);
+INSTANTIATE_AMP_NONFINITE_CHECK_AND_UNSCALE(half);
+#if __METAL_VERSION__ >= 310
+INSTANTIATE_AMP_NONFINITE_CHECK_AND_UNSCALE(bfloat);
+#endif
+
+INSTANTIATE_AMP_UPDATE_SCALE(float);
+INSTANTIATE_AMP_UPDATE_SCALE(half);
+#if __METAL_VERSION__ >= 310
+INSTANTIATE_AMP_UPDATE_SCALE(bfloat);
+#endif

--- a/aten/src/ATen/native/mps/kernels/Amp.metal
+++ b/aten/src/ATen/native/mps/kernels/Amp.metal
@@ -7,7 +7,7 @@ using namespace metal;
 
 template <typename T>
 struct AmpNonFiniteCheckAndUnscaleArgs {
-  metal::array<device T*, kmaxTensors> data;
+  metal::array<device T*, kmaxTensors> data [[id(0)]];
 };
 
 struct MetadataArguments {

--- a/aten/src/ATen/native/mps/kernels/Amp.metal
+++ b/aten/src/ATen/native/mps/kernels/Amp.metal
@@ -68,7 +68,6 @@ kernel void ampUpdateScale(
     constant T& scaleBackoffFactor [[buffer(4)]],
     constant int& growthInterval [[buffer(5)]],
     uint tid [[thread_position_in_grid]]) {
-
   if (foundInf != 0.0f) {
     scale *= scaleBackoffFactor;
     growth_tracker = 0;

--- a/aten/src/ATen/native/mps/kernels/Amp.metal
+++ b/aten/src/ATen/native/mps/kernels/Amp.metal
@@ -40,8 +40,7 @@ kernel void ampNonFiniteCheckAndUnscale(
     uint index = offset + i;
     T val = data[index];
     if (!isfinite(val)) {
-      device atomic_float* flag = (device atomic_float*)foundInf;
-      atomic_store_explicit(flag, 1.0f, memory_order_relaxed);
+      foundInf[0] = 1.0f;
     }
     data[index] = (invScale == static_cast<T>(1.0) ? val : val * invScale);
   }
@@ -55,8 +54,7 @@ kernel void ampNonFiniteCheckAndUnscaleSingle(
     uint tid [[thread_position_in_grid]]) {
   T val = data[tid];
   if (!isfinite(val)) {
-    device atomic_float* flag = (device atomic_float*)foundInf;
-    atomic_store_explicit(flag, 1.0f, memory_order_relaxed);
+    foundInf[0] = 1.0f;
   }
   data[tid] = (invScale == T(1.0) ? val : val * invScale);
 }

--- a/aten/src/ATen/native/mps/kernels/Amp.metal
+++ b/aten/src/ATen/native/mps/kernels/Amp.metal
@@ -61,8 +61,8 @@ kernel void ampNonFiniteCheckAndUnscaleSingle(
 
 template <typename T>
 kernel void ampUpdateScale(
-    device T* scale [[buffer(0)]],
-    device int* growth_tracker [[buffer(1)]],
+    device T& scale [[buffer(0)]],
+    device int& growth_tracker [[buffer(1)]],
     device float& foundInf [[buffer(2)]],
     constant T& scaleGrowthFactor [[buffer(3)]],
     constant T& scaleBackoffFactor [[buffer(4)]],
@@ -70,16 +70,15 @@ kernel void ampUpdateScale(
     uint tid [[thread_position_in_grid]]) {
 
   if (foundInf != 0.0f) {
-    *scale = *scale * scaleBackoffFactor;
-    *growth_tracker = 0;
+    scale *= scaleBackoffFactor;
+    growth_tracker = 0;
   } else {
-    int g = *growth_tracker;
-    g += 1;
+    int g = growth_tracker + 1;
     if (g >= growthInterval) {
-      *scale = *scale * scaleGrowthFactor;
+      scale *= scaleGrowthFactor;
       g = 0;
     }
-    *growth_tracker = g;
+    growth_tracker = g;
   }
 }
 
@@ -107,8 +106,8 @@ kernel void ampUpdateScale(
 #define INSTANTIATE_AMP_UPDATE_SCALE(DTYPE)                    \
   template [[host_name("ampUpdateScale_" #DTYPE)]] kernel void \
   ampUpdateScale<DTYPE>(                                       \
-      device DTYPE * scale [[buffer(0)]],                      \
-      device int* growth_tracker [[buffer(1)]],                \
+      device DTYPE & scale [[buffer(0)]],                      \
+      device int& growth_tracker [[buffer(1)]],                \
       device float& foundInf [[buffer(2)]],                    \
       constant DTYPE& scaleGrowthFactor [[buffer(3)]],         \
       constant DTYPE& scaleBackoffFactor [[buffer(4)]],        \

--- a/aten/src/ATen/native/mps/kernels/FusedOptimizerOps.metal
+++ b/aten/src/ATen/native/mps/kernels/FusedOptimizerOps.metal
@@ -57,9 +57,9 @@ struct SgdMomentumArguments {
 };
 
 struct MetadataArguments {
-  uint32_t numels[kmaxTensors];
-  uint32_t threadgroup_to_tensor[kmaxThreadGroups];
-  uint32_t threadgroup_to_chunk[kmaxThreadGroups];
+  ulong numels[kmaxTensors];
+  ulong threadgroup_to_tensor[kmaxThreadGroups];
+  ulong threadgroup_to_chunk[kmaxThreadGroups];
 };
 
 enum ADAM_MODE : uint8_t { ORIGINAL = 0, ADAMW = 1 };

--- a/aten/src/ATen/native/mps/operations/Amp.mm
+++ b/aten/src/ATen/native/mps/operations/Amp.mm
@@ -18,6 +18,7 @@
 
 namespace at::native {
 namespace mps {
+namespace {
 #ifndef PYTORCH_JIT_COMPILE_SHADERS
 static auto& lib = MetalShaderLibrary::getBundledLibrary();
 #else
@@ -89,6 +90,7 @@ static void _amp_update_scale_mps_impl(Tensor& self,
     [computeEncoder dispatchThreadgroups:gridSize threadsPerThreadgroup:threadGroupSize];
   });
 }
+} // namespace
 } // namespace mps
 
 void _amp_foreach_non_finite_check_and_unscale_mps_(at::TensorList self,
@@ -133,7 +135,8 @@ void _amp_foreach_non_finite_check_and_unscale_mps_(at::TensorList self,
     }
   }
 
-  std::string kernel_name = "ampNonFiniteCheckAndUnscale_" + mps::scalarToMetalTypeString(tensor_lists[0][0]);
+  std::string kernel_name =
+      "ampNonFiniteCheckAndUnscale_" + mps::scalarToMetalTypeString(tensor_lists[0][0].scalar_type());
   mps::multi_tensor_apply<1>(kernel_name, tensor_lists, found_inf, inv_scale);
 }
 

--- a/aten/src/ATen/native/mps/operations/Amp.mm
+++ b/aten/src/ATen/native/mps/operations/Amp.mm
@@ -19,11 +19,6 @@
 namespace at::native {
 namespace mps {
 namespace {
-#ifndef PYTORCH_JIT_COMPILE_SHADERS
-static auto& lib = MetalShaderLibrary::getBundledLibrary();
-#else
-#include <ATen/native/mps/Amp_metallib.h>
-#endif
 
 static void _amp_non_finite_check_and_unscale_mps_single_impl(const Tensor& scaled_grad,
                                                               at::Tensor& found_inf,

--- a/aten/src/ATen/native/mps/operations/Amp.mm
+++ b/aten/src/ATen/native/mps/operations/Amp.mm
@@ -1,0 +1,113 @@
+//  Copyright © 2022 Apple Inc.
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/mps/MPSProfiler.h>
+// For MTLLanguageVersion_3_1
+#include <ATen/native/mps/MPSGraphSequoiaOps.h>
+#include <ATen/native/mps/MPSGraphSonomaOps.h>
+#include <ATen/native/mps/OperationUtils.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/_amp_foreach_non_finite_check_and_unscale_native.h>
+#include <ATen/ops/_amp_update_scale_native.h>
+#endif
+
+namespace at::native {
+namespace mps {
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/Amp_metallib.h>
+#endif
+
+static void _amp_foreach_non_finite_check_and_unscale_mps_impl(TensorList self,
+                                                               at::Tensor& found_inf,
+                                                               const at::Tensor& inv_scale) {
+  found_inf.fill_(0);
+  float inv_scale_val = inv_scale.item<float>();
+
+  auto stream = getCurrentMPSStream();
+  auto device = MPSDevice::getInstance()->device();
+  auto ampPipelineState =
+      lib.getPipelineStateForFunc("ampNonFiniteCheckAndUnscale_" + mps::scalarToMetalTypeString(self[0]));
+
+  MTLSize threadGroupSize = MTLSizeMake(256, 1, 1);
+
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    auto computeEncoder = stream->commandEncoder();
+
+    for (auto& scaled_grad : self) {
+      TORCH_CHECK(scaled_grad.is_mps(), "Tensor is not on the MPS device.");
+      if (scaled_grad.numel() == 0) {
+        continue;
+      }
+
+      id<MTLBuffer> data_buffer = getMTLBufferStorage(scaled_grad);
+      id<MTLBuffer> found_inf_buffer = getMTLBufferStorage(found_inf);
+
+      uint32_t numel = static_cast<uint32_t>(scaled_grad.numel());
+
+      uint32_t numThreadgroups = (numel + threadGroupSize.width - 1) / threadGroupSize.width;
+      MTLSize gridSize = MTLSizeMake(numThreadgroups * threadGroupSize.width, 1, 1);
+      [computeEncoder setComputePipelineState:ampPipelineState];
+      mtl_setArgs(computeEncoder, data_buffer, found_inf_buffer, inv_scale_val, numel);
+      [computeEncoder dispatchThreadgroups:gridSize threadsPerThreadgroup:threadGroupSize];
+    }
+  });
+}
+
+static void _amp_update_scale_mps_impl(Tensor& self,
+                                       Tensor& growth_tracker,
+                                       const Tensor& found_inf,
+                                       double scale_growth_factor,
+                                       double scale_backoff_factor,
+                                       int64_t growth_interval) {
+  auto stream = getCurrentMPSStream();
+  auto device = MPSDevice::getInstance()->device();
+  auto ampUpdatePipelineState = lib.getPipelineStateForFunc("ampUpdateScale_" + mps::scalarToMetalTypeString(self));
+
+  MTLSize threadGroupSize = MTLSizeMake(1, 1, 1);
+  MTLSize gridSize = threadGroupSize;
+
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    auto computeEncoder = stream->commandEncoder();
+    [computeEncoder setComputePipelineState:ampUpdatePipelineState];
+
+    id<MTLBuffer> scaleBuffer = getMTLBufferStorage(self);
+    id<MTLBuffer> growthTrackerBuffer = getMTLBufferStorage(growth_tracker);
+    id<MTLBuffer> foundInfBuffer = getMTLBufferStorage(found_inf);
+    float scaleGrowthFactorVal = static_cast<float>(scale_growth_factor);
+    float scaleBackoffFactorVal = static_cast<float>(scale_backoff_factor);
+    uint32_t growthIntervalVal = static_cast<uint32_t>(growth_interval);
+
+    mtl_setArgs(computeEncoder,
+                scaleBuffer,
+                growthTrackerBuffer,
+                foundInfBuffer,
+                scaleGrowthFactorVal,
+                scaleBackoffFactorVal,
+                growthIntervalVal);
+    [computeEncoder dispatchThreadgroups:gridSize threadsPerThreadgroup:threadGroupSize];
+  });
+}
+} // namespace mps
+
+void _amp_foreach_non_finite_check_and_unscale_mps_(TensorList self,
+                                                    at::Tensor& found_inf,
+                                                    const at::Tensor& inv_scale) {
+  mps::_amp_foreach_non_finite_check_and_unscale_mps_impl(self, found_inf, inv_scale);
+}
+
+Tensor& _amp_update_scale_mps_(Tensor& self,
+                               Tensor& growth_tracker,
+                               const Tensor& found_inf,
+                               double scale_growth_factor,
+                               double scale_backoff_factor,
+                               int64_t growth_interval) {
+  mps::_amp_update_scale_mps_impl(
+      self, growth_tracker, found_inf, scale_growth_factor, scale_backoff_factor, growth_interval);
+  return self;
+}
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Amp.mm
+++ b/aten/src/ATen/native/mps/operations/Amp.mm
@@ -62,7 +62,7 @@ static void _amp_update_scale_mps_impl(Tensor& self,
     [computeEncoder setComputePipelineState:ampUpdatePipelineState];
 
     mtl_setArgs(
-                computeEncoder, self, growth_tracker, found_inf, scale_growth_factor, scale_backoff_factor, growth_interval);
+        computeEncoder, self, growth_tracker, found_inf, scale_growth_factor, scale_backoff_factor, growth_interval);
     mtl_dispatch1DJob(computeEncoder, ampUpdatePipelineState, 1);
   });
 }

--- a/aten/src/ATen/native/mps/operations/Amp.mm
+++ b/aten/src/ATen/native/mps/operations/Amp.mm
@@ -28,6 +28,7 @@ static void _amp_non_finite_check_and_unscale_mps_single_impl(const Tensor& scal
     return;
   }
   TORCH_CHECK(scaled_grad.is_mps(), "Tensor is not on the MPS device.");
+  TORCH_CHECK(scaled_grad.numel() <= std::numeric_limits<uint32_t>::max(), "scaled_grad is too large");
   float inv_scale_val = inv_scale.item<float>();
   auto stream = getCurrentMPSStream();
   auto device = MPSDevice::getInstance()->device();

--- a/aten/src/ATen/native/mps/operations/Amp.mm
+++ b/aten/src/ATen/native/mps/operations/Amp.mm
@@ -60,14 +60,9 @@ static void _amp_update_scale_mps_impl(Tensor& self,
     auto computeEncoder = stream->commandEncoder();
     [computeEncoder setComputePipelineState:ampUpdatePipelineState];
 
-    mtl_setArgs(computeEncoder,
-                self,
-                growth_tracker,
-                found_inf,
-                scale_growth_factor,
-                scale_backoff_factor,
-                growth_interval);
-    mtl_dispatch1DJob(computeEncoder,  ampUpdatePipelineState, 1);
+    mtl_setArgs(
+                computeEncoder, self, growth_tracker, found_inf, scale_growth_factor, scale_backoff_factor, growth_interval);
+    mtl_dispatch1DJob(computeEncoder, ampUpdatePipelineState, 1);
   });
 }
 

--- a/aten/src/ATen/native/mps/operations/FusedAdamKernelImpl.mm
+++ b/aten/src/ATen/native/mps/operations/FusedAdamKernelImpl.mm
@@ -68,4 +68,14 @@ void _fused_adam_mps_impl_(TensorList params,
                                                  maximize);
 }
 
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/FusedOptimizerOps_metallib.h>
+#endif
+
+std::pair<id<MTLComputePipelineState>, id<MTLFunction>> getFusedAdamCPLState(const std::string& fname) {
+  return {lib.getPipelineStateForFunc(fname), lib.getMTLFunction(fname)};
+}
+
 } // namespace at::native::mps

--- a/aten/src/ATen/native/mps/operations/FusedAdamKernelImpl.mm
+++ b/aten/src/ATen/native/mps/operations/FusedAdamKernelImpl.mm
@@ -68,14 +68,4 @@ void _fused_adam_mps_impl_(TensorList params,
                                                  maximize);
 }
 
-#ifndef PYTORCH_JIT_COMPILE_SHADERS
-static auto& lib = MetalShaderLibrary::getBundledLibrary();
-#else
-#include <ATen/native/mps/FusedOptimizerOps_metallib.h>
-#endif
-
-std::pair<id<MTLComputePipelineState>, id<MTLFunction>> getCPLState(const std::string& fname) {
-  return {lib.getPipelineStateForFunc(fname), lib.getMTLFunction(fname)};
-}
-
 } // namespace at::native::mps

--- a/aten/src/ATen/native/mps/operations/FusedAdamKernelImpl.mm
+++ b/aten/src/ATen/native/mps/operations/FusedAdamKernelImpl.mm
@@ -74,7 +74,7 @@ static auto& lib = MetalShaderLibrary::getBundledLibrary();
 #include <ATen/native/mps/FusedOptimizerOps_metallib.h>
 #endif
 
-std::pair<id<MTLComputePipelineState>, id<MTLFunction>> getFusedAdamCPLState(const std::string& fname) {
+std::pair<id<MTLComputePipelineState>, id<MTLFunction>> getCPLState(const std::string& fname) {
   return {lib.getPipelineStateForFunc(fname), lib.getMTLFunction(fname)};
 }
 

--- a/aten/src/ATen/native/mps/operations/FusedSgdKernel.mm
+++ b/aten/src/ATen/native/mps/operations/FusedSgdKernel.mm
@@ -114,8 +114,6 @@ void _fused_sgd_kernel_mps_(TensorList params,
                             const bool is_first_step,
                             const std::optional<Tensor>& grad_scale,
                             const std::optional<Tensor>& found_inf) {
-  TORCH_CHECK(!grad_scale.has_value() && !found_inf.has_value(), "grad_scale and found_inf are not supported on MPS");
-
   if (!momentum_buffer_list.empty()) {
     return _fused_sgd_with_momentum_kernel_mps_(params,
                                                 grads,
@@ -163,8 +161,6 @@ void _fused_sgd_kernel_mps_(TensorList params,
                             const bool is_first_step,
                             const std::optional<Tensor>& grad_scale,
                             const std::optional<Tensor>& found_inf) {
-  TORCH_CHECK(!grad_scale.has_value() && !found_inf.has_value(), "grad_scale and found_inf are not supported on MPS");
-
   if (!momentum_buffer_list.empty()) {
     return _fused_sgd_with_momentum_kernel_mps_(params,
                                                 grads,

--- a/aten/src/ATen/native/mps/operations/MultiTensorApply.h
+++ b/aten/src/ATen/native/mps/operations/MultiTensorApply.h
@@ -7,6 +7,17 @@ static_assert(sizeof(bool) == 1);
 
 namespace at::native::mps {
 
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/Amp_metallib.h>
+#include <ATen/native/mps/FusedOptimizerOps_metallib.h>
+#endif
+
+inline std::pair<id<MTLComputePipelineState>, id<MTLFunction>> getCPLState(const std::string& fname) {
+  return {lib.getPipelineStateForFunc(fname), lib.getMTLFunction(fname)};
+}
+
 static constexpr int64_t kChunkSize = 65536;
 static constexpr int64_t kmaxThreadGroups = 32;
 static constexpr int64_t kmaxTensors = 32;

--- a/aten/src/ATen/native/mps/operations/MultiTensorApply.h
+++ b/aten/src/ATen/native/mps/operations/MultiTensorApply.h
@@ -11,7 +11,10 @@ namespace at::native::mps {
 static auto& lib = MetalShaderLibrary::getBundledLibrary();
 #else
 #include <ATen/native/mps/Amp_metallib.h>
+// workaround to not include lib twice
+#define lib _ignored_lib_name_for_fused
 #include <ATen/native/mps/FusedOptimizerOps_metallib.h>
+#undef lib
 #endif
 
 inline std::pair<id<MTLComputePipelineState>, id<MTLFunction>> getCPLState(const std::string& fname) {

--- a/aten/src/ATen/native/mps/operations/MultiTensorApply.h
+++ b/aten/src/ATen/native/mps/operations/MultiTensorApply.h
@@ -259,8 +259,9 @@ void multi_tensor_apply(const std::string& kernel_name,
                         std::vector<std::vector<at::Tensor>>& tensor_lists,
                         ArgTypes... args) {
   const auto num_tensors = tensor_lists[0].size();
-  if (num_tensors == 0)
+  if (num_tensors == 0) {
     return;
+  }
 
   TORCH_CHECK(tensor_lists.size() == depth, "Number of tensor lists must match depth.");
 

--- a/aten/src/ATen/native/mps/operations/MultiTensorApply.h
+++ b/aten/src/ATen/native/mps/operations/MultiTensorApply.h
@@ -275,7 +275,7 @@ void multi_tensor_apply(const std::string& kernel_name,
       [computeEncoder setComputePipelineState:pipeline];
 
       id<MTLArgumentEncoder> argumentEncoder = [function newArgumentEncoderWithBufferIndex:0];
-      id<MTLBuffer> tensorArgumentBuffer = [device newBufferWithLength:argumentEncoder.encodedLength options:0];
+      auto tensorArgumentBuffer = [[device newBufferWithLength:argumentEncoder.encodedLength options:0] autorelease];
       [argumentEncoder setArgumentBuffer:tensorArgumentBuffer offset:0];
 
       int tensor_loc = 0;
@@ -326,7 +326,7 @@ void multi_tensor_apply(const std::string& kernel_name,
 
             // prepare for the next batch: reset threadgroup count and create a new buffer
             threadgroup_loc = 0;
-            tensorArgumentBuffer = [device newBufferWithLength:argumentEncoder.encodedLength options:0];
+            tensorArgumentBuffer = [ [device newBufferWithLength:argumentEncoder.encodedLength options:0] autorelease];
             [argumentEncoder setArgumentBuffer:tensorArgumentBuffer offset:0];
 
             if (partial) {

--- a/aten/src/ATen/native/mps/operations/MultiTensorApply.h
+++ b/aten/src/ATen/native/mps/operations/MultiTensorApply.h
@@ -326,7 +326,7 @@ void multi_tensor_apply(const std::string& kernel_name,
 
             // prepare for the next batch: reset threadgroup count and create a new buffer
             threadgroup_loc = 0;
-            tensorArgumentBuffer = [ [device newBufferWithLength:argumentEncoder.encodedLength options:0] autorelease];
+            tensorArgumentBuffer = [[device newBufferWithLength:argumentEncoder.encodedLength options:0] autorelease];
             [argumentEncoder setArgumentBuffer:tensorArgumentBuffer offset:0];
 
             if (partial) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -10389,6 +10389,7 @@
   dispatch:
     CUDA: _amp_foreach_non_finite_check_and_unscale_cuda_
     CPU: _amp_foreach_non_finite_check_and_unscale_cpu_
+    MPS: _amp_foreach_non_finite_check_and_unscale_mps_
   autogen: _amp_foreach_non_finite_check_and_unscale, _amp_foreach_non_finite_check_and_unscale.out
 
 - func: _amp_update_scale_(Tensor(a!) self, Tensor(b!) growth_tracker, Tensor found_inf, float scale_growth_factor, float scale_backoff_factor, int growth_interval) -> Tensor(a!)
@@ -10396,6 +10397,7 @@
   dispatch:
     CUDA: _amp_update_scale_cuda_
     CPU: _amp_update_scale_cpu_
+    MPS: _amp_update_scale_mps_
   autogen: _amp_update_scale, _amp_update_scale.out
 
     #- func: _cat(Tensor[] tensors, int dim=0) -> Tensor

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1119,8 +1119,7 @@ class TestAutocastMPS(TestCase):
             scaler_mps.update()
 
             for p_cpu, p_mps in zip(model_cpu.parameters(), model_mps.parameters()):
-                self.assertEqual(p_mps.cpu(), p_cpu, rtol=rtol, atol=atol,
-                                msg=f"Parameter {p_cpu} (CPU) != {p_mps.cpu()} (MPS)")
+                self.assertEqual(p_mps.cpu(), p_cpu, rtol=rtol, atol=atol, msg=f"Parameter {p_cpu} (CPU) != {p_mps.cpu()} (MPS)")
 
         # smol model
         model_cpu = nn.Linear(10, 5).to('cpu')

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1109,7 +1109,9 @@ class TestAutocastMPS(TestCase):
                 return self.fc5(x)
         torch.manual_seed(42)
 
-        def helper(model_cpu, model_mps, dtype, iterations, batch_size, atol=1e-4, rtol=1e-5):
+        def helper(model_cpu, model_mps, dtype, iterations, batch_size, atol=3e-4, rtol=1e-5):
+            if dtype == torch.bfloat16 and MACOS_VERSION < 14.0:
+                raise unittest.SkipTest("bfloat16 needs MacOS14+")
             optimizer_cpu = torch.optim.SGD(model_cpu.parameters(), lr=0.01)
             optimizer_mps = torch.optim.SGD(model_mps.parameters(), lr=0.01)
             loss_fn = nn.MSELoss()

--- a/torch/amp/grad_scaler.py
+++ b/torch/amp/grad_scaler.py
@@ -336,7 +336,11 @@ class GradScaler:
 
         # FP32 division can be imprecise for certain compile options, so we carry out the reciprocal in FP64.
         assert self._scale is not None
-        inv_scale = self._scale.double().reciprocal().float()
+        inv_scale = (
+            self._scale.double().reciprocal().float()
+            if self._scale.device != torch.device("mps:0")
+            else self._scale.reciprocal()
+        )
         found_inf = torch.full((), 0.0, dtype=torch.float32, device=self._scale.device)
 
         optimizer_state["found_inf_per_device"] = self._unscale_grads_(

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -832,9 +832,6 @@ def _fused_adam(
         device_exp_avg_sqs = cast(list[Tensor], device_exp_avg_sqs_)
         device_state_steps = cast(list[Tensor], device_state_steps_)
 
-        if device.type == "mps":  # type: ignore[union-attr]
-            assert found_inf is None and grad_scale is None
-
         device_grad_scale, device_found_inf = None, None
         if grad_scale is not None:
             device_grad_scale = grad_scale_dict.setdefault(


### PR DESCRIPTION
Fixes #142397

Basic implementation is done. What's left:
- [x] Different dtype/device tensors in the TensorList
- [x] fast path for grouping the foreach kernel
- [x] Tests

Regarding tests, I found some tests in `test/test_torch.py` for GradScaler but I couldn't figure out what is the best way to enable the test for MPS device. 

By removing `@onlyNativeDeviceTypes`, one enables the tests for MPS but also enables tests for all other devices which are not included in the native device types. If I put:
`instantiate_device_type_tests(TestTorchDeviceType, globals(), allow_mps=True)`

This enables lots of tests in that class for MPS which were not(?) being tested before? This part needs some clarification

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5 @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen