### PR TITLE
Add a test for checking that the CUDA stubs directory is not in libcaffe2_nvrts.so's RPATH or RUNPATH

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -22,6 +22,7 @@ import warnings
 import types
 import pickle
 import textwrap
+import shutil
 import subprocess
 import weakref
 import sys
@@ -10978,8 +10979,8 @@ def add_neg_dim_tests():
         setattr(TestTorch, test_name, make_neg_dim_test(name, tensor_arg, arg_constr, types, extra_dim))
 
 class TestRPATH(TestCase):
-    @unittest.skipIf(not sys.platform.startswith('linux'), "linux-only test")
-    def test_rpath(self):
+    @unittest.skipIf(not shutil.which('objdump'), "Required tool 'objdump' not available")
+    def test_cuda_stubs_not_in_rpath(self):
         """
         Make sure RPATH (or RUNPATH) in nvrtc does not contain a cuda stubs directory
         issue gh-35418

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10977,6 +10977,25 @@ def add_neg_dim_tests():
         assert not hasattr(TestTorch, test_name), "Duplicated test name: " + test_name
         setattr(TestTorch, test_name, make_neg_dim_test(name, tensor_arg, arg_constr, types, extra_dim))
 
+class TestRPATH(TestCase):
+    @unittest.skipIf(not sys.platform.startswith('linux'), "linux-only test")
+    def test_rpath(self):
+        """
+        Make sure RPATH (or RUNPATH) in nvrtc does not contain a cuda stubs directory
+        issue gh-35418
+        """
+        libdir = os.path.join(os.path.dirname(torch._C.__file__), 'lib')
+        caffe2_nvrtc = os.path.join(libdir, 'libcaffe2_nvrtc.so')
+        if os.path.exists(caffe2_nvrtc):
+            output = subprocess.check_output(['objdump', '-x', caffe2_nvrtc])
+            for line in output.split(b'\n'):
+                if b'RPATH' in line or b'RUNPATH' in line:
+                    # Catch paths like:
+                    # $ORIGIN:/usr/local/cuda-10.2/lib64/stubs:/usr/local/cuda-10.2/lib64
+                    self.assertFalse(b'/stubs:' in line)
+                    # $ORIGIN:/usr/local/cuda-10.2/lib64:/usr/local/cuda-10.2/lib64/stubs
+                    self.assertFalse(line.endswith(b'/stubs'))
+
 # TODO: these empy classes are temporarily instantiated for XLA compatibility
 #   once XLA updates their test suite it should be removed
 class TestViewOps(TestCase):


### PR DESCRIPTION
The CUDA stub directory must not appear in the rpath or RUNPATH of any library as that would make it unusable at runtime. This should no longer happen (it did before, see the previous PR) but we better check that it stays like that. See the referenced issue https://github.com/pytorch/pytorch/issues/35418

The test verifies this.

Closes https://github.com/pytorch/pytorch/issues/35418

See also https://github.com/pytorch/pytorch/pull/134669