### PR TITLE
Add error check for out variant of tensordot function with requries_grad tensor

### DIFF
--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -828,9 +828,9 @@ Tensor tensordot(const Tensor& input1, const Tensor& input2, IntArrayRef dims1, 
 Tensor &tensordot_out(const Tensor& input1, const Tensor& input2, IntArrayRef dims1, IntArrayRef dims2, Tensor& result) {
   if(result.defined()) {
     TORCH_CHECK(
-      !(input1.requires_grad() || input2.requires_grad() || result.requires_grad()) || !at::GradMode::is_enabled(),
-      "tensordot(): functions with out=... arguments don't support automatic differentiation, "
-      "but one of the arguments requires grad."
+      !(result.requires_grad() && at::GradMode::is_enabled()),
+      "tensordot(): the 'out' tensor was specified and requires gradients, but functions with 'out=...' arguments do not support automatic differentiation. "
+      "Either remove the 'out' argument or ensure the 'out' tensor does not require gradients."
     );
   }
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5782,6 +5782,18 @@ class TestLinalg(TestCase):
         with torch.no_grad():
             torch.matmul(a, b, out=c)
 
+    @dtypes(torch.float, torch.complex64)
+    def test_tensordot_out_kernel_errors_with_autograd(self, device, dtype):
+        a = torch.empty((2, 3), device=device, dtype=dtype, requires_grad=True)
+        b = torch.empty((3, 4), device=device, dtype=dtype, requires_grad=True)
+        c = torch.empty((2, 4), device=device, dtype=dtype)
+
+        with self.assertRaisesRegex(RuntimeError, "functions with out=... arguments don't support automatic differentiation"):
+            torch.tensordot(a, b, dims=([1], [0]), out=c)
+
+        with torch.no_grad():
+            torch.tensordot(a, b, dims=([1], [0]), out=c)
+
     # 4GB should do, but we run tests in parallel in CI, so let's be generous
     @largeTensorTest('16GB', device='cuda')
     def test_large_bmm_mm_backward(self, device):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5784,11 +5784,12 @@ class TestLinalg(TestCase):
 
     @dtypes(torch.float, torch.complex64)
     def test_tensordot_out_kernel_errors_with_autograd(self, device, dtype):
-        a = torch.empty((2, 3), device=device, dtype=dtype, requires_grad=True)
-        b = torch.empty((3, 4), device=device, dtype=dtype, requires_grad=True)
-        c = torch.empty((2, 4), device=device, dtype=dtype, requires_grad=True)
-        d = torch.empty((2, 4), device=device, dtype=dtype, requires_grad=False)
+        a = torch.empty((4, 2), device=device, dtype=dtype, requires_grad=True)
+        b = torch.empty((2, 4), device=device, dtype=dtype, requires_grad=True)
+        c = torch.empty((2, 2), device=device, dtype=dtype, requires_grad=True)
+        d = torch.empty((4, 4), device=device, dtype=dtype, requires_grad=False)
         err_msg = "the 'out' tensor was specified and requires gradients"
+
         with torch.set_grad_enabled(True), self.assertRaisesRegex(RuntimeError, err_msg):
             torch.tensordot(a, b, dims=([1], [0]), out=c)
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5797,6 +5797,7 @@ class TestLinalg(TestCase):
             torch.tensordot(a, b, dims=([1], [0]), out=d)
 
         with torch.set_grad_enabled(False), warnings.catch_warnings(record=True) as w:
+            # Hack to avoid resize error for CUDA tensors as resize_cuda_ is different to resize_.
             c.requires_grad = False
             torch.tensordot(a, b, dims=([1], [0]), out=c)
             self.assertEqual(len(w), 1)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5797,6 +5797,7 @@ class TestLinalg(TestCase):
             torch.tensordot(a, b, dims=([1], [0]), out=d)
 
         with torch.set_grad_enabled(False), warnings.catch_warnings(record=True) as w:
+            c.requires_grad = False
             torch.tensordot(a, b, dims=([1], [0]), out=c)
             self.assertEqual(len(w), 1)
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5786,12 +5786,16 @@ class TestLinalg(TestCase):
     def test_tensordot_out_kernel_errors_with_autograd(self, device, dtype):
         a = torch.empty((2, 3), device=device, dtype=dtype, requires_grad=True)
         b = torch.empty((3, 4), device=device, dtype=dtype, requires_grad=True)
-        c = torch.empty((2, 4), device=device, dtype=dtype)
-
-        with self.assertRaisesRegex(RuntimeError, "functions with out=... arguments don't support automatic differentiation"):
+        c = torch.empty((2, 4), device=device, dtype=dtype, requires_grad=True)
+        d = torch.empty((2, 4), device=device, dtype=dtype, requires_grad=False)
+        err_msg = "the 'out' tensor was specified and requires gradients"
+        with torch.set_grad_enabled(True), self.assertRaisesRegex(RuntimeError, err_msg):
             torch.tensordot(a, b, dims=([1], [0]), out=c)
 
-        with torch.no_grad():
+        with torch.set_grad_enabled(True):
+            torch.tensordot(a, b, dims=([1], [0]), out=d)
+
+        with torch.set_grad_enabled(False):
             torch.tensordot(a, b, dims=([1], [0]), out=c)
 
     # 4GB should do, but we run tests in parallel in CI, so let's be generous

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5796,8 +5796,9 @@ class TestLinalg(TestCase):
         with torch.set_grad_enabled(True):
             torch.tensordot(a, b, dims=([1], [0]), out=d)
 
-        with torch.set_grad_enabled(False):
+        with torch.set_grad_enabled(False), warnings.catch_warnings(record=True) as w:
             torch.tensordot(a, b, dims=([1], [0]), out=c)
+            self.assertEqual(len(w), 1)
 
     # 4GB should do, but we run tests in parallel in CI, so let's be generous
     @largeTensorTest('16GB', device='cuda')


### PR DESCRIPTION
Fixes #147846. Previously there is no error out under out variant of`tensordot` while `requires_grad=True`. This can cause potential issue when out tensor is part of a computation graph.

Enforces the out variant of tensordot to run without setting `requries_grad=True`. Change same to #117067

cc @ezyang @gchanan