### PR TITLE
[clang-tidy] Get rid-off dangerouse clang-tidy option

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -69,7 +69,6 @@ readability-string-compare,
 -readability-redundant-control-flow,
 '
 HeaderFilterRegex: '^(aten/|c10/|torch/).*$'
-WarningsAsErrors: '*'
 CheckOptions:
   cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor: true
   cppcoreguidelines-special-member-functions.AllowImplicitlyDeletedCopyOrMove: true


### PR DESCRIPTION
Summary: WarningsAsErrors is a special option that should be applied carefully. At our case clang-tidy checks have a lot of false positives and as result WarningsAsErrors will prevent the corresponding diffs from landing

Test Plan: No special test required here

Differential Revision: D72159625


