### PR TITLE
Avoid circular imports in tracing_state_functions

### DIFF
--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -28,15 +28,13 @@ This is a core part of Dynamo's tracing system, translating torch operations int
 traceable graph nodes while preserving correct semantics and handling edge cases.
 """
 
-from __future__ import annotations
-
 import functools
 import inspect
 import logging
 import math
 import re
 from collections.abc import Sequence
-from typing import Any, Callable, TYPE_CHECKING
+from typing import Any, Callable, Optional, TYPE_CHECKING
 
 import torch._C
 import torch._refs
@@ -172,7 +170,7 @@ constant_fold_functions = dict.fromkeys(constant_fold_functions)
 
 
 @functools.lru_cache(None)
-def tracing_state_functions() -> dict[Callable[[], Any], bool | None]:
+def tracing_state_functions() -> dict[Callable[[], Any], Optional[bool]]:
     # Defined as a function to avoid circular import like torch.onnx
     return {
         torch.jit.is_scripting: False,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -34,7 +34,7 @@ import logging
 import math
 import re
 from collections.abc import Sequence
-from typing import Callable, TYPE_CHECKING
+from typing import Any, Callable, TYPE_CHECKING
 
 import torch._C
 import torch._refs
@@ -170,7 +170,7 @@ constant_fold_functions = dict.fromkeys(constant_fold_functions)
 
 
 @functools.lru_cache(None)
-def tracing_state_functions() -> dict[Callable, bool]:
+def tracing_state_functions() -> dict[Callable[[], Any], bool | None]:
     # Defined as a function to avoid circular import like torch.onnx
     return {
         torch.jit.is_scripting: False,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -34,7 +34,7 @@ import logging
 import math
 import re
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import Callable, TYPE_CHECKING
 
 import torch._C
 import torch._refs
@@ -169,8 +169,9 @@ constant_fold_functions_need_guards = dict.fromkeys(constant_fold_functions_need
 constant_fold_functions = dict.fromkeys(constant_fold_functions)
 
 
-def tracing_state_functions():
-    # Avoid circular import like torch.onnx
+@functools.lru_cache(None)
+def tracing_state_functions() -> dict[Callable, bool]:
+    # Defined as a function to avoid circular import like torch.onnx
     return {
         torch.jit.is_scripting: False,
         torch.jit.is_tracing: False,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -28,6 +28,8 @@ This is a core part of Dynamo's tracing system, translating torch operations int
 traceable graph nodes while preserving correct semantics and handling edge cases.
 """
 
+from __future__ import annotations
+
 import functools
 import inspect
 import logging


### PR DESCRIPTION
tracing_state_functions references some torch functions from submodules like `torch.onnx.is_in_onnx_export` that could trigger module initialization & circular imports. I turned the mapping into a function so that the dictionary is not initialized at torch import.

(discovered in https://github.com/pytorch/pytorch/pull/149646)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames