### PR TITLE
[re_build] Get output from stdout and sterr in local and remote execution and better error msg for too big to optimize

### DIFF
--- a/torch/_inductor/exc.py
+++ b/torch/_inductor/exc.py
@@ -91,6 +91,8 @@ class CppCompileError(RuntimeError):
     def __init__(self, cmd: list[str], output: str) -> None:
         if isinstance(output, bytes):
             output = output.decode("utf-8")
+        self.cmd = cmd
+        self.output = output
 
         super().__init__(
             textwrap.dedent(


### PR DESCRIPTION
Summary:

In aoti, we make a better error message for the `too big to optimize` error by suggesting the `aot_inductor.compile_wrapper_opt_level = 'O0'` flag.

Test Plan:
 result example:
```
error: Function _ZN5torch12aot_inductorL22__check_inputs_outputsEPP16AtenTensorOpaqueS3_ is too big to optimize [-Werror,-Wignored-optimization-argument]
2 warnings and 1 error generated.

The runtime check __check_inputs_outputs() is too big to optimize. Please use torch._inductor.config.aot_inductor.compile_wrapper_opt_level = 'O0' flag.
```

Differential Revision: D72208338




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov