### PR TITLE
[dynamic shapes] stop writing Max(*, 1) for strides

### DIFF
--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -925,8 +925,10 @@ void TensorImpl::empty_tensor_restride_symint(MemoryFormat memory_format) {
         const auto last_idx = dim_ - 1;
         sym_shape_meta.strides_[last_idx] = c10::SymInt(1);
         for (auto i = last_idx - 1; i >= 0; --i) {
-          sym_shape_meta.strides_[i] = sym_shape_meta.strides_[i + 1] *
-              sym_shape_meta.sizes_[i + 1].max(1);
+          if (TORCH_GUARD_OR_TRUE(sym_shape_meta.sizes_[i + 1].sym_gt(1))) {
+            sym_shape_meta.strides_[i] = sym_shape_meta.strides_[i + 1] *
+              sym_shape_meta.sizes_[i + 1];
+          }
         }
       }
       break;

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -923,12 +923,13 @@ void TensorImpl::empty_tensor_restride_symint(MemoryFormat memory_format) {
       sym_shape_meta.strides_.resize(dim_);
       if (dim_ > 0) {
         const auto last_idx = dim_ - 1;
+        auto accum = c10::SymInt(1);
         sym_shape_meta.strides_[last_idx] = c10::SymInt(1);
         for (auto i = last_idx - 1; i >= 0; --i) {
           if (TORCH_GUARD_OR_TRUE(sym_shape_meta.sizes_[i + 1].sym_gt(1))) {
-            sym_shape_meta.strides_[i] = sym_shape_meta.strides_[i + 1] *
-              sym_shape_meta.sizes_[i + 1];
+            accum *= sym_shape_meta.sizes_[i + 1];
           }
+          sym_shape_meta.strides_[i] = accum;
         }
       }
       break;

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -4416,7 +4416,7 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         node = [node for node in ep.graph.nodes][-2]
         val = node.meta["val"]
         u0, u1, u2 = val.shape
-        self.assertEqual(val.stride(0), u1*u2)
+        self.assertEqual(val.stride(0), u1 * u2)
         self.assertEqual(val.stride(1), u2)
 
     def test_tolist(self):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -4406,6 +4406,19 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
                 strict=strict,
             )
 
+    def test_contiguous_unbacked_strides(self):
+        class Foo(torch.nn.Module):
+            def forward(self, xs):
+                u0, u1, u2 = xs.tolist()
+                return torch.empty(u0, u1, u2).contiguous()
+
+        ep = export(Foo(), (torch.tensor([2, 3, 4]),))
+        node = [node for node in ep.graph.nodes][-2]
+        val = node.meta["val"]
+        u0, u1, u2 = val.shape
+        self.assertEqual(val.stride(0), u1*u2)
+        self.assertEqual(val.stride(1), u2)
+
     def test_tolist(self):
         class M(torch.nn.Module):
             def forward(self, x):

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -885,7 +885,7 @@ def forward(self, x_1):
             cf(
                 torch.empty_strided(
                     (2, 3, 1, u0),
-                    (3 * Max(1, u0), Max(1, u0), Max(1, u0), 1),
+                    (3 * u0, u0, u0, 1),
                     device="meta",
                 )
             )

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -1644,7 +1644,7 @@ def make_contiguous_strides_for(
     strides = []
     for l in reversed(shape):
         strides.append(multiplier)
-        if is_nested_int(l) or guard_or_true(l <= 0):
+        if is_nested_int(l) or guard_or_true(l >= 1):
             multiplier *= l  # type:ignore[assignment]
 
     result = tuple(reversed(strides))

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -1638,15 +1638,14 @@ def make_contiguous_strides_for(
     if not shape:
         return ()
 
-    from torch.fx.experimental.symbolic_shapes import is_nested_int
+    from torch.fx.experimental.symbolic_shapes import guard_or_true, is_nested_int
 
     multiplier: Union[_IntLikeT, int] = 1
     strides = []
     for l in reversed(shape):
         strides.append(multiplier)
-        multiplier *= (
-            l if is_nested_int(l) else sym_max(l, 1)
-        )  # type:ignore[assignment]
+        if is_nested_int(l) or guard_or_true(l <= 0):
+            multiplier *= l  # type:ignore[assignment]
 
     result = tuple(reversed(strides))
 


### PR DESCRIPTION
When handling strides, avoiding generating Max(u0, 1) expressions if we can, since it'll be hard to deal with these once we move away from guard_size_oblivious.

Looking at what the code was before sym_max was introduced (https://github.com/pytorch/pytorch/pull/94400 in `_prims_common/__init__.py`), this change seems appropriate.