### PR TITLE
[CI] Skip test_copy_large_tensor on M2-15 runners

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7476,6 +7476,7 @@ class TestMPS(TestCaseMPS):
 
     @unittest.skipIf(total_memory < 12_000_000_000, "Needs at least 12Gb RAM to run the test")
     @unittest.skipIf(MACOS_VERSION < 14.0, "Can't allocate 4Gb tensor on MacOS 13")
+    @unittest.skipIf(IS_CI, "May be fixes https://github.com/pytorch/pytorch/issues/149999")
     def test_copy_large(self):
         """ Test that copy of 4Gb+ tensors works """
         x = torch.ones((2**30 + 11,), dtype=torch.float32)


### PR DESCRIPTION
They have more than 12Gb memory, but may be running this test causes OOM in CI