### PR TITLE
Add `mse_loss_backward_out` type promotion

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -486,6 +486,9 @@ Tensor& mse_loss_backward_out(const Tensor& grad_output,
     .add_const_input(input)
     .add_const_input(target)
     .add_const_input(grad_output)
+    .promote_inputs_to_common_dtype(true)
+    .cast_common_dtype_to_outputs(true)
+    .enforce_safe_casting_to_output(true)
     .build();
   mse_backward_stub(iter.device_type(), iter, norm);
   return grad_input;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2605,6 +2605,15 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             self.assertEqual(len(w), 1)
             self.assertIn('Please ensure they have the same size.', str(w[0]))
 
+    def test_mse_loss_backward_promotion(self):
+        def func(x, y):
+            loss_32 = torch.nn.MSELoss()(x, y)
+            return loss_32
+        x = torch.randn(1, dtype=torch.float32)
+        y = torch.randn(1, dtype=torch.float64)
+        torch.autograd.functional.jacobian(func, (x, y), vectorize=True, strategy="forward-mode")
+        torch.autograd.functional.jacobian(func, (x, y), vectorize=True, strategy="reverse-mode")
+
     def test_weighted_mse_loss(self):
         inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)
         targets = torch.tensor([1.5, 2.5, 3.5, 4.5])


### PR DESCRIPTION
Fixes #94086, following #94621

## Test Result

```bash
pytest test/test_nn.py  -k test_mse_loss_backward_promotion
```
![image](https://github.com/user-attachments/assets/178c3652-f671-45d2-8bbc-1253c42254ad)

