### PR TITLE
Generalize compile collective to avoid cuda-bias

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1351,7 +1351,7 @@ class OutputGraph:
                 "Expect only one device type but got {}".format("+".join(device_types))
             )
             with (
-                get_interface_for_device(device_types.pop()).device(
+                get_interface_for_device(device_types.pop()).device(  # type: ignore[attr-defined]
                     compile_pg.rank() % torch.accelerator.device_count()
                 ),
                 dynamo_timed("compiler_collective", log_pt2_compile_event=True),

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1348,7 +1348,7 @@ class OutputGraph:
             )
             device_type = compile_pg._device_types
             with (
-                get_interface_for_device(*device_type).device(
+                get_interface_for_device(device_types.pop()).device(
                     compile_pg.rank() % torch.accelerator.device_count()
                 ),
                 dynamo_timed("compiler_collective", log_pt2_compile_event=True),

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -79,6 +79,7 @@ from .bytecode_transformation import (
 from .code_context import code_context
 from .codegen import PyCodegen
 from .current_scope_id import enter_new_scope
+from .device_interface import get_interface_for_device
 from .exc import (
     BackendCompilerFailed,
     exceptions_allowed_to_be_fallback,
@@ -1345,8 +1346,9 @@ class OutputGraph:
                 },
                 payload_fn=lambda: ds.local_state.render(),
             )
+            device_type = torch.accelerator.current_accelerator()
             with (
-                torch.accelerator.set_device_index(
+                get_interface_for_device(device_type).device(
                     compile_pg.rank() % torch.accelerator.device_count()
                 ),
                 dynamo_timed("compiler_collective", log_pt2_compile_event=True),

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1346,7 +1346,10 @@ class OutputGraph:
                 },
                 payload_fn=lambda: ds.local_state.render(),
             )
-            device_type = compile_pg._device_types
+            device_types = compile_pg._device_types
+            assert len(device_types) == 1 "Expect only one device type but got {}".format(
+                "+".join(device_types)
+            )
             with (
                 get_interface_for_device(device_types.pop()).device(
                     compile_pg.rank() % torch.accelerator.device_count()

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1346,9 +1346,9 @@ class OutputGraph:
                 },
                 payload_fn=lambda: ds.local_state.render(),
             )
-            device_type = torch.accelerator.current_accelerator()
+            device_type = compile_pg._device_types
             with (
-                get_interface_for_device(device_type).device(
+                get_interface_for_device(*device_type).device(
                     compile_pg.rank() % torch.accelerator.device_count()
                 ),
                 dynamo_timed("compiler_collective", log_pt2_compile_event=True),

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1346,7 +1346,9 @@ class OutputGraph:
                 payload_fn=lambda: ds.local_state.render(),
             )
             with (
-                torch.cuda.device(compile_pg.rank() % torch.cuda.device_count()),
+                torch.accelerator.set_device_index(
+                    compile_pg.rank() % torch.accelerator.device_count()
+                ),
                 dynamo_timed("compiler_collective", log_pt2_compile_event=True),
             ):
                 all_states = [None] * compile_pg.size()

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1347,9 +1347,9 @@ class OutputGraph:
                 payload_fn=lambda: ds.local_state.render(),
             )
             device_types = compile_pg._device_types
-            assert (
-                len(device_types) == 1
-            ), "Expect only one device type but got {}".format("+".join(device_types))
+            assert len(device_types) == 1, (
+                "Expect only one device type but got {}".format("+".join(device_types))
+            )
             with (
                 get_interface_for_device(device_types.pop()).device(
                     compile_pg.rank() % torch.accelerator.device_count()

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1347,9 +1347,9 @@ class OutputGraph:
                 payload_fn=lambda: ds.local_state.render(),
             )
             device_types = compile_pg._device_types
-            assert len(device_types) == 1 "Expect only one device type but got {}".format(
-                "+".join(device_types)
-            )
+            assert (
+                len(device_types) == 1
+            ), "Expect only one device type but got {}".format("+".join(device_types))
             with (
                 get_interface_for_device(device_types.pop()).device(
                     compile_pg.rank() % torch.accelerator.device_count()


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/1527
Let the combination of `compile` and `collective` to support more devices.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @zhangxiaoli73 @kwen2501 @guangyey 