### PR TITLE
Disable -Werror for s390x test module compilation

### DIFF
--- a/test/cpp_extensions/open_registration_extension/setup.py
+++ b/test/cpp_extensions/open_registration_extension/setup.py
@@ -1,5 +1,6 @@
 import distutils.command.clean
 import os
+import platform
 import shutil
 import sys
 from pathlib import Path
@@ -40,6 +41,9 @@ if __name__ == "__main__":
             CXX_FLAGS = ["/sdl"]
         else:
             CXX_FLAGS = ["/sdl", "/permissive-"]
+    elif platform.machine() == "s390x":
+        # no -Werror on s390x due to newer compiler
+        CXX_FLAGS = {"cxx": ["-g", "-Wall"]}
     else:
         CXX_FLAGS = {"cxx": ["-g", "-Wall", "-Werror"]}
 


### PR DESCRIPTION
This change should make nightly testsuite green again for s390x.