### PR TITLE
ci: Use cache / progress when local docker build

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -460,10 +460,18 @@ if [[ "$image" == *cuda*  && ${OS} == "ubuntu" ]]; then
   fi
 fi
 
+no_cache_flag=""
+progress_flag=""
+# Do not use cache and progress=plain when in CI
+if [[ "${CI:-}" = "true" ]]; then
+  no_cache_flag="--no-cache"
+  progress_flag="--progress=plain"
+fi
+
 # Build image
 docker build \
-       --no-cache \
-       --progress=plain \
+       ${no_cache_flag} \
+       ${progress_flag} \
        --build-arg "BUILD_ENVIRONMENT=${image}" \
        --build-arg "PROTOBUF=${PROTOBUF:-}" \
        --build-arg "LLVMDEV=${LLVMDEV:-}" \

--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -463,7 +463,7 @@ fi
 no_cache_flag=""
 progress_flag=""
 # Do not use cache and progress=plain when in CI
-if [[ "${CI:-}" = "true" ]]; then
+if [[ -n "${CI:-}"]]; then
   no_cache_flag="--no-cache"
   progress_flag="--progress=plain"
 fi

--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -463,7 +463,7 @@ fi
 no_cache_flag=""
 progress_flag=""
 # Do not use cache and progress=plain when in CI
-if [[ -n "${CI:-}"]]; then
+if [[ -n "${CI:-}" ]]; then
   no_cache_flag="--no-cache"
   progress_flag="--progress=plain"
 fi


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #150418

It's a bit annoying to try and work on these locally when the cache /
progress isn't being used so let's just set it so that those flags are
only valid when in CI directly.

`${CI}` is a default environment variable that's defined by actions
itself.

See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>