### PR TITLE
Add stride + dtype to autotune results

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2207,9 +2207,7 @@ class AlgorithmSelectorCache(PersistentCache):
         )
 
         strides = ", ".join([str(n.get_stride()) for n in input_nodes])
-        dtypes = ", ".join(
-            [str(n.get_dtype()) for n in input_nodes]
-        )
+        dtypes = ", ".join([str(n.get_dtype()) for n in input_nodes])
         if config.autotune_num_choices_displayed == 0:
             return
         # when autotune_num_choices_displayed is None, [:None] means all
@@ -2279,7 +2277,6 @@ class AlgorithmSelectorCache(PersistentCache):
             f"{autotune_type_str} AUTOTUNE benchmarking takes {elapse:.4f} seconds and {precompile_elapse:.4f}"
             f" seconds precompiling for {len(timings)} choices\n"
         )
-
 
     @staticmethod
     def benchmark_example_value(node):

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2205,6 +2205,11 @@ class AlgorithmSelectorCache(PersistentCache):
                 for n in input_nodes
             ]
         )
+
+        strides = ", ".join([str(n.get_stride()) for n in input_nodes])
+        dtypes = ", ".join(
+            [str(n.get_dtype()) for n in input_nodes]
+        )
         if config.autotune_num_choices_displayed == 0:
             return
         # when autotune_num_choices_displayed is None, [:None] means all
@@ -2252,6 +2257,9 @@ class AlgorithmSelectorCache(PersistentCache):
 
         best_time = timings[best]
         sys.stderr.write(f"AUTOTUNE {name}({sizes})\n")
+        sys.stderr.write(f"strides: {strides}\n")
+        sys.stderr.write(f"dtypes: {dtypes}\n")
+
         for choice in top_k:
             result = timings[choice]
             if result:
@@ -2271,6 +2279,7 @@ class AlgorithmSelectorCache(PersistentCache):
             f"{autotune_type_str} AUTOTUNE benchmarking takes {elapse:.4f} seconds and {precompile_elapse:.4f}"
             f" seconds precompiling for {len(timings)} choices\n"
         )
+
 
     @staticmethod
     def benchmark_example_value(node):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #150419


Add stride/dtype info to autotune gemm results. New output header:

`AUTOTUNE mm(1024x1024, 1024x7680)`
`strides: [1, 1024], [7680, 1]`
`dtypes: torch.bfloat16, torch.bfloat16`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov

Differential Revision: [D72253313](https://our.internmc.facebook.com/intern/diff/D72253313)