### PR TITLE
[BE] Move all lint runner to 24.04

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,9 +3,6 @@ self-hosted-runner:
     # GitHub hosted runner that actionlint doesn't recognize because actionlint version (1.6.21) is too old
     - ubuntu-24.04
     # GitHub hosted x86 Linux runners
-    # TODO: Cleanup mentions of linux.20_04 when upgrade to linux.24_04 is complete
-    - linux.20_04.4x
-    - linux.20_04.16x
     - linux.24_04.4x
     - linux.24_04.16x
     # Organization-wide AWS Linux Runners

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -233,8 +233,6 @@ jobs:
             runner: linux.24_04.4x
           - test_type: without_torch
             runner: linux.24_04.4x
-          # NOTE: The oldest supported version of python for 24.04 is 3.8
-          #       so this cannot be updated if we want to keep this test at 3.6
           - test_type: older_python_version
             runner: linux.24_04.4x
     steps:
@@ -256,7 +254,7 @@ jobs:
         if: matrix.test_type == 'older_python_version'
         uses: actions/setup-python@v5
         with:
-          python-version: 3.6
+          python-version: 3.8
           architecture: x64
           check-latest: false
           cache: pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -236,7 +236,7 @@ jobs:
           # NOTE: The oldest supported version of python for 24.04 is 3.8
           #       so this cannot be updated if we want to keep this test at 3.6
           - test_type: older_python_version
-            runner: linux.20_04.4x
+            runner: linux.24_04.4x
     steps:
       # [see note: pytorch repo ref]
       # deep clone (fetch-depth 0) required, to allow us to use git log


### PR DESCRIPTION
As Ubuntu-20 reached EOL on Apr 1st, see https://github.com/actions/runner-images/issues/11101
This forces older python version to be 3.8
Delete all linux-20.04 runners from the lintrunner.yml