### PR TITLE
Fix scaled_mm template migration missing endif block

### DIFF
--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -128,10 +128,11 @@ mm_template = TritonTemplate(
         idx_n = offs_b_n[None, :]
         {{load_input("B", "b", ("idx_m", "idx_n"), mask=None if EVEN_K else "b_mask", indent_width=8)}}
 
-        if USE_FAST_ACCUM:
+        {% if USE_FAST_ACCUM %}
             acc = tl.dot(a, b, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
-        else:
+        {% else %}
             acc += tl.dot(a, b, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+        {% endif %}
 
     # rematerialize rm and rn to save registers
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
@@ -204,6 +205,7 @@ mm_template = TritonTemplate(
             acc = tl.dot(a, b, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
         {% else %}
             acc += tl.dot(a, b, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+        {% endif %}
 
     # rematerialize rm and rn to save registers
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
@@ -306,7 +308,7 @@ persistent_tma_mm_template = TritonTemplate(
             allow_tf32=ALLOW_TF32,
         )
 
-        if ki == k_tiles - 1:
+        {% if ki == k_tiles - 1 %}
             # rematerialize rm and rn to save registers
             rcm = rm + tl.arange(0, BLOCK_M)
             rcn = rn + tl.arange(0, BLOCK_N)
@@ -317,6 +319,7 @@ persistent_tma_mm_template = TritonTemplate(
             # inductor generates a suffix
             {{store_output(("idx_m", "idx_n"), "acc", "mask", indent_width=12)}}
             acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
+        {% endif %}
 """,
 )
 
@@ -460,7 +463,7 @@ device_tma = r"""
         else:
             accumulator += tl.dot(a, b.T)
 
-        if ki == k_tiles - 1:
+        {% if ki == k_tiles - 1 %}
             # Apply inverse scaling
             offs_cm = offs_am + tl.arange(0, BLOCK_M)
             offs_cn = offs_bn + tl.arange(0, BLOCK_N)
@@ -484,6 +487,7 @@ device_tma = r"""
             # inductor generates a suffix
             {{store_output(("idx_m", "idx_n"), "accumulator", "mask", indent_width=12)}}
             accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        {% endif %}
 """
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #150438
* #150437



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov