### PR TITLE
[invoke_subgraph] Do not cache fake tensors for AOTDispatcher first pass

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -956,6 +956,7 @@ class GraphModule(torch.nn.Module):
         res = opt_fn(x)
         self.assertEqual(ref, res)
 
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_unbacked(self):
         @mark_compile_region
         def gn(x, y):
@@ -970,7 +971,6 @@ class GraphModule(torch.nn.Module):
         x = torch.tensor(4)
         y = torch.randn(8)
         ref = fn(x, y)
-        torch._dynamo.config.capture_scalar_outputs = True
         opt_fn = torch.compile(
             fn, backend="eager", fullgraph=True
         )  # Inductor fails with assertion error when lowering aten.sym_constrain_range_for_size.default

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1515,16 +1515,15 @@ class FakeTensorMode(TorchDispatchMode):
                 for node in subgraph_mod.graph.nodes:
                     if node.op == "call_function":
                         op = node.target
-                        # Dynamo graphs can have operator.add type of operations. For these operations, it is safe to cache.
-                        if (
-                            callable(op)
-                            and getattr(op, "__module__", None)
-                            in {"_operator", "operator"}
-                            and not op.__name__.startswith("i")
-                        ):
-                            continue
-                        if op in (torch._check, torch._check_is_size):
-                            continue
+
+                        # AOTDispatcher first pass does not run make_fx on
+                        # dynamo graphs. As a result, it can have non OpOverload
+                        # ops.
+                        if not isinstance(op, torch._ops.OpOverload):
+                            raise _BypassDispatchCache(
+                                f"{func.name()} hop with a non OpOverload input"
+                            )
+
                         try:
                             self._validate_cache_key(op, [], {})
                         except _BypassDispatchCache as e:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #150486
* __->__ #150450
* #150082

