### PR TITLE
[MPS][Testing] Benchmark reduction ops

### DIFF
--- a/test/bench_mps_ops.py
+++ b/test/bench_mps_ops.py
@@ -3,6 +3,7 @@
 # Useful as reference tool when migrating ops from MPS to Metal
 import itertools
 import timeit
+import warnings
 from typing import Optional
 
 import torch
@@ -70,14 +71,48 @@ def bench_binary(
     return rc
 
 
+def bench_reduction(
+    reduction_func, device: str = "mps", dtype: torch.dtype = torch.float32
+) -> list[Measurement]:
+    rc = []
+
+    # Bench 2D with reduction over dim=0
+    def f(t):
+        return reduction_func(t, dim=0)
+
+    f.__name__ = reduction_func.__name__
+    f_c = torch.compile(f, dynamic=False)
+
+    for size in (512, 1024, 2048, 4096):
+        x = torch.testing.make_tensor(size, size, device=device, dtype=dtype)
+        rc_c, rc_e = f(x), f_c(x)
+        rc_c, rc_e = (rc_c[0], rc_e[0]) if isinstance(rc_c, tuple) else (rc_c, rc_e)
+        if not torch.allclose(rc_c, rc_e):
+            mdiff = (rc_c - rc_e).abs().max()
+            warnings.warn(
+                f"Eager and compile reduction do not match for {reduction_func.__name__} and {dtype} max_diff={mdiff}",
+                stacklevel=2,
+            )
+        rc.append(bench_unary_op(f, x, f"eager-{size}x{size}"))
+        rc.append(bench_unary_op(f_c, x, f"compile-{size}x{size}"))
+    return rc
+
+
 def main() -> None:
     dtypes = [torch.float16, torch.float32]
     if torch.backends.mps.is_macos_or_newer(14, 0):
         dtypes.append(torch.bfloat16)
+
     # Profile unary ops
     rc = []
     for op, dtype in itertools.product([torch.sqrt, torch.sin], dtypes):
         rc.extend(bench_unary(op, dtype=dtype))
+    Compare(rc).print()
+
+    # Profile reduction ops
+    rc = []
+    for op in [torch.sum, torch.max]:
+        rc.extend(bench_reduction(op))
     Compare(rc).print()
 
     # Profile binary ops


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #150457
* __->__ #150452

That compares eager vs compile
On my M4Pro mini I'm getting the following now
```
[---------------------------------------------------------------------------------------------  --------------------------------------------------------------------------------------------]
                           |  eager-512x512  |  compile-512x512  |  eager-1024x1024  |  compile-1024x1024  |  eager-2048x2048  |  compile-2048x2048  |  eager-4096x4096  |  compile-4096x4096
1 threads: ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      sum (torch.float32)  |      121.0      |       201.5       |       130.3       |        772.3        |       179.4       |        1470.5       |        476.1      |        2980.0
      max (torch.float32)  |      154.1      |       165.9       |       198.7       |        211.6        |       344.2       |         386.9       |       1326.6      |        1345.6
```