### PR TITLE
[dynamic shapes] oblivious rewrite for meta_select

### DIFF
--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -137,8 +137,8 @@ inline void checkSetStorage(Tensor& result, Storage storage, T storage_offset,
 #endif
 
   // storageOffset
-  TORCH_CHECK(
-      storage_offset >= 0, "Tensor: invalid storage offset ", storage_offset);
+  TORCH_SYM_CHECK(
+      c10::SymInt(storage_offset).sym_ge(0), "Tensor: invalid storage offset ", storage_offset);
 
   // set_storage_{device} (except set_storage_meta__symint)
   // will (unsafely) set the storage offset and then call resize_impl that

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -4418,7 +4418,7 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         class Foo(torch.nn.Module):
             def forward(self, x, ys):
                 u0, u1 = ys.tolist()
-                return x[u0] + x[(u0-u1+1)//2]
+                return x[u0] + x[(u0 - u1 + 1) // 2]
 
         ep = export(
             Foo(),

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -4429,9 +4429,20 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
             },
         )
         self.assertEqual(
-            ep.module()(torch.arange(20), torch.tensor([2, -3])),
-            5,
-        )
+            ep.module()(torch.arange(20), torch.tensor([-1, -2])),
+            19 + 1,
+        )  # negative indexing is ok
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r".* expression 0 <= s.* \+ u0 .*",
+        ):  # unless it's out of bounds
+            ep.module()(torch.randn(5), torch.tensor([-6, 0]))
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r".* expression u0 \+ 1 <= s.*",
+        ):  # out of bounds at end
+            ep.module()(torch.randn(5), torch.tensor([5, 0]))
+        
 
     def test_if_functional(self):
         class Module(torch.nn.Module):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5306,7 +5306,7 @@ def meta_zeros(
 
 @register_meta(aten.select.int)
 def meta_select(self, dim, index):
-    from torch.fx.experimental.symbolic_shapes import guard_size_oblivious
+    from torch.fx.experimental.symbolic_shapes import guard_or_true, sym_and
 
     ndim = self.dim()
     torch._check_index(
@@ -5318,14 +5318,15 @@ def meta_select(self, dim, index):
     size = self.size(dim)
 
     torch._check_index(
-        not (
-            guard_size_oblivious(-index > size) or guard_size_oblivious(index >= size)
+        sym_and(
+            -index <= size,
+            index <= size - 1,
         ),
         lambda: f"select(): index {index} out of range for tensor of size "
         f"{self.size()} at dimension {dim}",
     )
 
-    index = index if index >= 0 else index + size
+    index = index if guard_or_true(index >= 0) else index + size
 
     new_size = list(self.size())
     new_stride = list(self.stride())

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5306,7 +5306,7 @@ def meta_zeros(
 
 @register_meta(aten.select.int)
 def meta_select(self, dim, index):
-    from torch.fx.experimental.symbolic_shapes import guard_or_true, sym_and
+    from torch.fx.experimental.symbolic_shapes import guard_or_true
 
     ndim = self.dim()
     torch._check_index(
@@ -5318,10 +5318,12 @@ def meta_select(self, dim, index):
     size = self.size(dim)
 
     torch._check_index(
-        sym_and(
-            -index <= size,
-            index <= size - 1,
-        ),
+        -index <= size,
+        lambda: f"select(): index {index} out of range for tensor of size "
+        f"{self.size()} at dimension {dim}",
+    )
+    torch._check_index(
+        index <= size - 1,
         lambda: f"select(): index {index} out of range for tensor of size "
         f"{self.size()} at dimension {dim}",
     )

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -143,6 +143,7 @@ __all__ = [
     "CURRENT_NODE_KEY",
     "has_free_symbols",
     "has_free_unbacked_symbols",
+    "sym_and",
     "sym_eq",
     "SymbolicContext",
     "StatelessSymbolicContext",
@@ -1293,6 +1294,18 @@ def sym_eq(x: _T, y: _T) -> Union[bool, SymBool]:
         return x == y
     else:
         raise AssertionError(f"unexpected sym_eq between {type(x)} {type(y)}")
+
+
+def sym_and(
+    x: Union[bool, SymBool], *others: Union[bool, SymBool]
+) -> Union[bool, SymBool]:
+    if len(others) == 0:
+        return x
+    assert isinstance(x, (bool, SymBool))
+    for y in others:
+        assert isinstance(y, (bool, SymBool))
+        x = operator.and_(x, y)
+    return x
 
 
 def guard_scalar(

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -143,7 +143,6 @@ __all__ = [
     "CURRENT_NODE_KEY",
     "has_free_symbols",
     "has_free_unbacked_symbols",
-    "sym_and",
     "sym_eq",
     "SymbolicContext",
     "StatelessSymbolicContext",
@@ -1294,18 +1293,6 @@ def sym_eq(x: _T, y: _T) -> Union[bool, SymBool]:
         return x == y
     else:
         raise AssertionError(f"unexpected sym_eq between {type(x)} {type(y)}")
-
-
-def sym_and(
-    x: Union[bool, SymBool], *others: Union[bool, SymBool]
-) -> Union[bool, SymBool]:
-    if len(others) == 0:
-        return x
-    assert isinstance(x, (bool, SymBool))
-    for y in others:
-        assert isinstance(y, (bool, SymBool))
-        x = operator.and_(x, y)
-    return x
 
 
 def guard_scalar(


### PR DESCRIPTION
Uses guard_or_true in place of size-oblivious to assume if not already known, that the index is in-bounds.

Tests to check runtime asserts for out-of-bounds indexing

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv