### PR TITLE
[ROCm][TunableOp] Fix UT race condition and reduce UT duration.

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5383,6 +5383,7 @@ class TestLinalg(TestCase):
         # tested by PyTorch
         with self._tunableop_ctx():
             # set these to single iterations to keep it short but still exercise the code
+            torch.cuda.tunable.set_rotating_buffer_size(0)
             torch.cuda.tunable.set_max_tuning_iterations(1)
 
             # Reference number of results

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5087,21 +5087,21 @@ class TestLinalg(TestCase):
 
     @onlyCUDA
     @skipCUDAIfNotRocm
-    @dtypes(torch.float)
+    @dtypes(torch.bfloat16)
     def test_numeric_check_leak_tunableop_rocm(self, device, dtype):
         import os
         from torch.testing._internal.common_utils import CudaMemoryLeakCheck
         # run operator first without tuning to ensure all rocm libs are loaded,
         # otherwise false positive mem leak
-        B = 16
-        N = M = K = 256
-        dtype = torch.bfloat16
+        B = 5
+        N = M = K = 29
         device = torch.device("cuda:0")
         i1 = torch.randn((B, N, M), device=device, dtype=dtype)
         i2 = torch.randn((B, M, K), device=device, dtype=dtype)
         out = torch.bmm(i1, i2)
 
         with self._tunableop_ctx():
+            torch.cuda.tunable.set_rotating_buffer_size(0)
             # enable tunableop numeric check via env variable.
             os.environ["PYTORCH_TUNABLEOP_NUMERICAL_CHECK"] = "1"
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5007,19 +5007,14 @@ class TestLinalg(TestCase):
             torch.cuda.tunable.mgpu_tune_gemm_in_file(untuned_filename, total_gpus)
 
             # check the results files where written, one per gpu
-            # get the size of the first result and make sure it
-            # greater than 100. Since the validator text should
-            # be at least that much.
-            # The other results file will have
-            # at least the size of the first results file - 80
+            # Check that the results file is not empty and store
+            # that in a local variable for the next loop.
             for i in range(total_gpus):
                 result_filename = f"tunableop_results{i}.csv"
                 self.assertTrue(os.path.exists(result_filename))
+                self.assertGreater(os.path.getsize(result_filename), 0)
                 if i == 0:  # Store for next loop
                     result_size = os.path.getsize(result_filename)
-                    self.assertGreater(os.path.getsize(result_filename), 0)
-                self.assertGreater(os.path.getsize(result_filename), result_size - 80)
-
 
             # Check the full results files was written, one per gpu
             # check that the size of the full results file for

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -6873,7 +6873,8 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
     @bf32_on_and_off(0.05)
     def test_addmm_relu_tunableop_rocm(self, device, dtype):
         with self._tunableop_ctx():
-            torch.cuda.tunable.set_max_tuning_iterations(10)
+            torch.cuda.tunable.set_rotating_buffer_size(0)
+            torch.cuda.tunable.set_max_tuning_iterations(1)
             self._test_addmm_impl(torch._addmm_activation, "relu", device, dtype)
 
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -65,7 +65,7 @@ def blaslt_supported_device():
             return True
     return False
 
-def tunableop_matmul(device, dtype, offline=False):
+def tunableop_matmul(device, dtype, result_filename=None, offline=False):
     # Helper function to test TunableOp in a subprocess
     # requires helper function since lambda function
     # not supported by multiprocessing module
@@ -75,6 +75,9 @@ def tunableop_matmul(device, dtype, offline=False):
     if offline:
         torch.cuda.tunable.tuning_enable(False)
         torch.cuda.tunable.record_untuned_enable(True)
+    else:
+        if result_filename is not None:
+            torch.cuda.tunable.set_filename(result_filename)
 
     torch.cuda.tunable.set_max_tuning_duration(1)
     A = torch.randn((17, 17), device=device, dtype=dtype)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5215,9 +5215,9 @@ class TestLinalg(TestCase):
             ref_num_results = len(torch.cuda.tunable.get_results())
 
             # Tune one GEMMs to make sure TunableOp is enabled
-            M = 3
-            N = 3
-            K = 3
+            M = 11
+            N = 13
+            K = 17
             A = torch.randn(N, K, device=device, dtype=dtype)
             B = torch.randn(K, M, device=device, dtype=dtype)
             C = torch.matmul(A, B)
@@ -5236,9 +5236,9 @@ class TestLinalg(TestCase):
             torch.cuda.tunable.tuning_enable(False)
 
             # Try to tune one more GEMM
-            M = 3
-            N = 3
-            K = 4
+            M = 11
+            N = 13
+            K = 18
             A = torch.randn(N, K, device=device, dtype=dtype)
             B = torch.randn(K, M, device=device, dtype=dtype)
             C = torch.matmul(A, B)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5283,8 +5283,7 @@ class TestLinalg(TestCase):
         import multiprocessing as mp
 
         with self._tunableop_ctx():
-            ordinal = torch.cuda.current_device()
-            filename = f"tunableop_results{ordinal}.csv"
+            filename = torch.cuda.tunable.get_filename()
 
             # force=True needed according to:
             # https://docs.python.org/3/library/multiprocessing.html#multiprocessing.set_start_method
@@ -5292,7 +5291,7 @@ class TestLinalg(TestCase):
             # already set the start method
             mp.set_start_method("spawn", force=True)
 
-            p = mp.Process(target=tunableop_matmul, args=(device, dtype))
+            p = mp.Process(target=tunableop_matmul, args=(device, dtype, filename, False))
             p.start()
             p.join()
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -97,6 +97,14 @@ def find_tunableop_result(results, OpSig, ParamSig):
             return inner_tuple
     return None
 
+def get_tunableop_untuned_filename():
+    import os
+    ordinal = torch.cuda.current_device()
+    untuned_filename_env = os.getenv("PYTORCH_TUNABLEOP_UNTUNED_FILENAME")
+    untuned_filename_base, _, _ = untuned_filename_env.rpartition('.')
+    untuned_filename = f"{untuned_filename_base}{ordinal}.csv"
+    return untuned_filename
+
 class TestLinalg(TestCase):
     @contextlib.contextmanager
     def _hip_allow_tf32(self):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5019,6 +5019,7 @@ class TestLinalg(TestCase):
     def test_rotating_buffer_tunableop(self, device, dtype):
         # Test the TunableOp rotating buffer API
         # Test the default value, will return the l2_cache_size
+        set_tunableop_defaults()
         l2_cache_size = torch.cuda.tunable.get_rotating_buffer_size()
         self.assertGreater(l2_cache_size, 0)
         # Test zero

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -213,7 +213,6 @@ class TestLinalg(TestCase):
 
                 if missing:
                     ok = False
-                    print(missing)
                 else:
                     ok = True
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5391,9 +5391,9 @@ class TestLinalg(TestCase):
             # Scaled GEMM parameters
             fillA = 0.25
             fillB = 0.75
-            n = 32
-            m = 64
-            k = 128
+            n = 64
+            m = 16
+            k = 32
             scaleA = torch.tensor(0.8, device=device)
             scaleB = torch.tensor(0.9, device=device)
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -124,7 +124,7 @@ class TestLinalg(TestCase):
         # Inialize and then tear down TunableOp
         import glob
         import os
-        set_tunableop_defaults()
+        self._set_tunableop_defaults()
         torch.cuda.tunable.enable(True)
 
         try:
@@ -134,7 +134,11 @@ class TestLinalg(TestCase):
             torch.cuda.tunable.enable(False)
 
             # clean up, remove any files that were generated
-            for file in glob.glob("tunableop*.csv"):
+            unique_id = self.id().split(".")[-1]
+            patterns = [f"tunableop_results_{unique_id}_?.csv", f"tunableop_untuned_{unique_id}_?.csv",
+                        "tunableop_results?.csv", "tunableop_results_full?.csv", "tunableop_untuned?.csv"]
+            files = [f for pattern in patterns for f in glob.glob(pattern)]
+            for file in files:
                 try:
                     os.remove(file)
                 # NB: The file is locked on Windows

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -189,7 +189,7 @@ class TestLinalg(TestCase):
         if untuned_filename is None:
             untuned_filename = f"tunableop_untuned_{unique_id}_{ordinal}.csv"
         if tuned_filename is None:
-            tuned_filename =  f"tunableop_results_{unique_id}_{ordinal}.csv"
+            tuned_filename = f"tunableop_results_{unique_id}_{ordinal}.csv"
 
         with open(untuned_filename) as file1:
             with open(tuned_filename) as file2:

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4693,7 +4693,8 @@ class TestLinalg(TestCase):
             make_arg = partial(make_tensor, device=device, dtype=dtype)
             # Using gen_sizes_matmul(2) to ensure we cover
             # 'NN', 'TN', 'TT', and 'NN' cases.
-            for (size_x, size_y), nctg_x, nctg_y in product(self.gen_sizes_matmul(2), (True, False), (True, False)):
+            for (size_x, size_y), nctg_x, nctg_y in product(self.gen_sizes_matmul(2, y_dim=3),
+                                                            (True, False), (True, False)):
                 x = make_arg(size_x, noncontiguous=nctg_x)
                 y = make_arg(size_y, noncontiguous=nctg_y)
                 self.check_single_matmul(x, y)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -137,9 +137,13 @@ class TestLinalg(TestCase):
             torch.cuda.tunable.enable(False)
 
             # clean up, remove any files that were generated
-            unique_id = self.id().split(".")[-1]
-            patterns = [f"tunableop_results_{unique_id}_?.csv", f"tunableop_untuned_{unique_id}_?.csv",
-                        "tunableop_results?.csv", "tunableop_results_full?.csv", "tunableop_untuned?.csv"]
+            results_filename = torch.cuda.tunable.get_filename()
+            dot_index = results_filename.rfind(".")
+            results_filename_pattern = results_filename[:dot_index-1]
+            untuned_filename = os.getenv("PYTORCH_TUNABLEOP_UNTUNED_FILENAME")
+            dot_index = untuned_filename.rfind(".")
+            untuned_filename_pattern = untuned_filename[:dot_index]
+            patterns = [f"{results_filename_pattern}*.csv", f"{untuned_filename_pattern}*.csv"]
             files = [f for pattern in patterns for f in glob.glob(pattern)]
             for file in files:
                 try:

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5040,6 +5040,9 @@ class TestLinalg(TestCase):
         # buffer rotation (on by default) with strided batched gemm tunableop was causing a mem fault
         with self._tunableop_ctx():
             torch.cuda.tunable.set_max_tuning_iterations(10)
+            # Make sure the rotating buffer is not zero, otherwise this test does nothing useful.
+            rotating_buffer = torch.cuda.tunable.get_rotating_buffer_size()
+            self.assertGreater(rotating_buffer, 0)
             # the following 3 cases cover all previous failure cases and are here to catch regressions
             B = 16
             N = M = K = 256


### PR DESCRIPTION
This PR fixes two race conditions that occur when UT tests are run:
- In a particular order within a single shard. 
- Concurrently in multiple shards. Each test now gets a unique filename that depends on the test name.

There were two other minor improvements to the UTs: 
- matmul_offline_mgpu could occasionally fail if run on 8 GPUs. Criteria was relaxed.
- bmm_tunableop_rocm checks that the rotating buffer is not zero. Otherwise, the test is not useful.

Additionally, several UTs took over 1 minute to run. Their duration was reduced by a combination of setting max tuning iterations to one, setting the rotating buffer size to zero, and/or reducing the matrix dimensions.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang