### PR TITLE
[BE] Do not allow PyTorch codebase to use `c10::optional`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -978,6 +978,11 @@ endif()
 include(cmake/public/utils.cmake)
 if(NOT MSVC)
   string(APPEND CMAKE_CXX_FLAGS " -O2 -fPIC")
+  # This prevents use of `c10::optional`, `c10::nullopt` etc within the codebase
+  string(APPEND CMAKE_CXX_FLAGS " -DC10_NODEPRECATED")
+  string(APPEND CMAKE_CUDA_FLAGS " -DC10_NODEPRECATED")
+  string(APPEND CMAKE_OBJCXX_FLAGS " -DC10_NODEPRECATED")
+
   # Eigen fails to build with some versions, so convert this to a warning
   # Details at http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1459
   string(APPEND CMAKE_CXX_FLAGS " -Wall")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -978,10 +978,12 @@ endif()
 include(cmake/public/utils.cmake)
 if(NOT MSVC)
   string(APPEND CMAKE_CXX_FLAGS " -O2 -fPIC")
-  # This prevents use of `c10::optional`, `c10::nullopt` etc within the codebase
-  string(APPEND CMAKE_CXX_FLAGS " -DC10_NODEPRECATED")
-  string(APPEND CMAKE_CUDA_FLAGS " -DC10_NODEPRECATED")
-  string(APPEND CMAKE_OBJCXX_FLAGS " -DC10_NODEPRECATED")
+  if(NOT USE_XPU)
+    # This prevents use of `c10::optional`, `c10::nullopt` etc within the codebase
+    string(APPEND CMAKE_CXX_FLAGS " -DC10_NODEPRECATED")
+    string(APPEND CMAKE_CUDA_FLAGS " -DC10_NODEPRECATED")
+    string(APPEND CMAKE_OBJCXX_FLAGS " -DC10_NODEPRECATED")
+  endif()
 
   # Eigen fails to build with some versions, so convert this to a warning
   # Details at http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1459


### PR DESCRIPTION
Extensions can still rely on it, and we should decorate it with deprecated, but it is a C++20 feature.
XPU still uses it, so exclude XPU builds  until https://github.com/intel/torch-xpu-ops/pull/1615 is merged

Test plan:
 - https://github.com/pytorch/pytorch/pull/150464/commits/0def9b4acc81f9bcb032f57f8c606a71234564c9 should fail MPS builds
 ```
/Users/ec2-user/runner/_work/pytorch/pytorch/aten/src/ATen/native/mps/OperationUtils.mm:975:44: error: no template named 'optional' in namespace 'c10'; did you mean 'std::optional'?
                                           c10::optional<int64_t> extra) {
                                           ^~~~~~~~~~~~~
                                           std::optional
```
 - https://github.com/pytorch/pytorch/pull/150464/commits/a769759dd42cb8b370d9cbfac5c161832ee033b8 should fail CUDA builds
 ```
/var/lib/jenkins/workspace/torch/csrc/distributed/c10d/CUDASymmetricMemoryOps.cu(530): error: namespace "c10" has no member "nullopt"
        input, c10::nullopt, reduce_op, group_name, out);
                    ^

1 error detected in the compilation of 
```

Fixes https://github.com/pytorch/pytorch/issues/150313


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k