### PR TITLE
[dynamic shapes] rewrite slice_forward decomp with guard_or_false

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -775,8 +775,7 @@ def forward(self, x_1):
         self.assertEqual(y.size(0), 1)
         self.assertEqual(z.size(0), 1)
         with self.assertRaisesRegex(
-            RuntimeError,
-            r"Runtime assertion failed for expression u1 <= u0 .*"
+            RuntimeError, r"Runtime assertion failed for expression u1 <= u0 .*"
         ):
             fn(torch.tensor([5, 6, -2]))
 

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -760,6 +760,26 @@ def forward(self, x_1):
         self.assertTrue(expect_true(i0 == 10 - i1))
         self.assertExpectedInline(str(i0), """u0""")
 
+    def test_unbacked_slice(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(xs):
+            u0, u1, u2 = xs.tolist()
+            x = torch.empty(u0)
+            y = x[u1:u2]
+            z = x[(u2 - u1) : (u1 + 2 * u2)]
+            return y, z
+
+        with torch._dynamo.config.patch(capture_scalar_outputs=True):
+            fn(torch.tensor([32, 3, 6]))
+        y, z = fn(torch.tensor([5, 0, 1]))
+        self.assertEqual(y.size(0), 1)
+        self.assertEqual(z.size(0), 1)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Runtime assertion failed for expression u1 <= u0 .*"
+        ):
+            fn(torch.tensor([5, 6, -2]))
+
     def test_expect_true_double_digits(self):
         shape_env = ShapeEnv()
         ia = [shape_env.create_unbacked_symint() for _ in range(11)]  # allocate 10

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -711,7 +711,7 @@ def slice_forward(
     step: int = 1,
 ):
     from torch.fx.experimental.symbolic_shapes import (
-        guard_size_oblivious,
+        guard_or_false,
         statically_known_true,
     )
 
@@ -728,23 +728,37 @@ def slice_forward(
     start_val = start if start is not None else 0
     end_val = end if end is not None else sys.maxsize  # 2^63 - 1
 
-    if guard_size_oblivious(start_val < 0):
+    # negative indexing case
+    if guard_or_false(start_val < 0):
         start_val += sizes[dim]
-
-    if guard_size_oblivious(end_val < 0):
+    if guard_or_false(end_val < 0):
         end_val += sizes[dim]
 
-    if guard_size_oblivious(start_val < 0):
+    # negative out-of-bounds for start: treat as 0
+    if guard_or_false(start_val < 0):
         start_val = 0
-    elif guard_size_oblivious(start_val > sizes[dim]):
-        start_val = sizes[dim]
+    else:
+        torch._check(start_val >= 0)
 
-    if guard_size_oblivious(end_val < start_val):
+    # positive out-of-bounds for start: treat as ends-of-bound
+    if guard_or_false(start_val > sizes[dim]):
+        start_val = sizes[dim]
+    else:
+        torch._check(start_val <= sizes[dim])
+
+    # end < start: treat as empty slice
+    if guard_or_false(end_val < start_val):
         end_val = start_val
-    elif statically_known_true(end_val == sys.maxsize) or guard_size_oblivious(
+    else:
+        torch._check(end_val >= start_val)
+
+    # positive out-of-bounds for end
+    if statically_known_true(end_val == sys.maxsize) or guard_or_false(
         end_val > sizes[dim]
     ):
         end_val = sizes[dim]
+    else:
+        torch._check(end_val <= sizes[dim])
 
     storage_offset = self.storage_offset() + start_val * strides[dim]
     len = end_val - start_val


### PR DESCRIPTION
Uses guard_or_false in place of size-oblivious to assume if not already known that the start/end indices are in-bounds.

Adds torch._checks for this, checking `start_val >= 0, end_val <= sizes[dim], start_val >= end_val`, which helps guarantee that the output size at runtime matches the symbolic expression in `end_val - start_val`.

Without these checks the reported symbolic size might not match, e.g. if end_val < start_val, eager returns a size-0 tensor but the symbolic size is negative.