### PR TITLE
[Inductor] Refactor accuracy check to `allclose_many` function

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -6,7 +6,6 @@ import unittest
 from typing import Any, Callable, Optional, Union
 
 import torch
-import torch.utils._pytree as pytree
 from torch._inductor import config
 from torch._inductor.runtime.hints import TRITON_MAX_BLOCK
 from torch._inductor.runtime.runtime_utils import is_power_of_2
@@ -18,6 +17,7 @@ from torch.testing._internal.common_utils import (
     subtest,
 )
 from torch.testing._internal.inductor_utils import (
+    allclose_many,
     GPU_TYPE,
     HAS_GPU,
     requires_gpu,
@@ -65,21 +65,15 @@ def run_and_compare(
     if config_patches is None:
         config_patches = {}
 
-    def flatten_tensors(tensors):
-        flat, spec = pytree.tree_flatten(tensors)
-        return flat
-
     with config.patch(config_patches):
         compiled = torch.compile(func, backend="inductor", **compile_kwargs)
         result, code = run_and_get_code(compiled, *args)
 
     # Check numerical accuracy
-    ref_tensors = flatten_tensors(func(*args))
-    actual_tensors = flatten_tensors(result)
-    for ref, actual in zip(ref_tensors, actual_tensors):
-        # Don't clobber the default tolerance values
-        tol = {t: v for t, v in {"rtol": rtol, "atol": atol}.items() if v is not None}
-        self.assertTrue(torch.allclose(ref, actual, **tol))
+    # Don't clobber the default tolerance values
+    tol = {t: v for t, v in {"rtol": rtol, "atol": atol}.items() if v is not None}
+    ref = func(*args)
+    allclose_many(self, ref, result, **tol)
 
     def count_code(substr: str, expected: Optional[int]):
         count = sum(prog.count(substr) for prog in code)

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -1,12 +1,20 @@
 # Owner(s): ["module: inductor"]
 
+import contextlib
+
 from sympy import Symbol
 
 import torch
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import sympy_subs
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
+from torch.testing._internal.inductor_utils import allclose_many
 
 
+@instantiate_parametrized_tests
 class TestUtils(TestCase):
     def test_zip_schema(self):
         def foo(x: torch.Tensor) -> None:
@@ -71,6 +79,20 @@ class TestUtils(TestCase):
         self.assertEqual(result.name, "y")
         self.assertEqual(result.is_integer, None)
         self.assertEqual(result.is_nonnegative, None)
+
+    @parametrize(
+        "ref,actual,raises",
+        [
+            (1, 1, False),
+            ([2, 3], [2, 4], True),
+        ],
+    )
+    def test_allclose_many(self, ref, actual, raises):
+        """
+        Checks that allclose_many raises an exception when the operands are not close.
+        """
+        with self.assertRaises(AssertionError) if raises else contextlib.nullcontext():
+            allclose_many(self, torch.tensor(ref), torch.tensor(actual))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Note: This seems like a duplicate of `torch._dynamo.utils.same`. I will likely close this PR in favor of that.**

Preparatory refactor for https://github.com/pytorch/pytorch/pull/146942.

# Feature

This is a small change to refactor an existing test utility into a common library, so it can be reused across test modules. The feature is a function called `allclose_many`, which checks accuracy across a pytree of tensors. Most end-to-end tests perform this type of check. I'm not sure if there's an existing utility for this, but this one seems simple enough.

As a bonus, `allclose_many` calls into its own helper `call_many`, which can be used for other types of checks. This is essentially a variadic form of `pytree.tree_map`.

# Test plan

This feature is used by existing block pointer tests. Also, this PR adds a new unit test checking that `allclose_many` correctly spots an accuracy bug.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov