### PR TITLE
Enable weekly test for operator benchmark 

### DIFF
--- a/.github/workflows/operator_benchmark.yml
+++ b/.github/workflows/operator_benchmark.yml
@@ -11,6 +11,9 @@ on:
         type: string
         default: 'short'
         description: tag filter for operator benchmarks, options from long, short, all
+  schedule:
+    # Run at 07:00 UTC every Sunday
+    - cron: 0 7 * * 0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
To regularly track the performance of the operator benchmark, enable the weekly test.

Hi, @huydhn, as you mentioned in https://github.com/pytorch/pytorch/pull/143733#issuecomment-2578317520, we could integrate the performance data from the weekly test into the OSS benchmark database for the dashboard.