### PR TITLE
Fix CPU bitwise shifts for out-of-limit values in VSX-vec

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int16_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int16_vsx.h
@@ -349,26 +349,6 @@ class Vectorized<int16_t> {
 };
 
 template <>
-Vectorized<int16_t> inline operator<<(
-    const Vectorized<int16_t>& a,
-    const Vectorized<int16_t>& b) {
-  vuint16 shift_vec0 = reinterpret_cast<vuint16>(b.vec0());
-  vuint16 shift_vec1 = reinterpret_cast<vuint16>(b.vec1());
-  return Vectorized<int16_t>{
-      vec_sl(a.vec0(), shift_vec0), vec_sl(a.vec1(), shift_vec1)};
-}
-
-template <>
-Vectorized<int16_t> inline operator>>(
-    const Vectorized<int16_t>& a,
-    const Vectorized<int16_t>& b) {
-  vuint16 shift_vec0 = reinterpret_cast<vuint16>(b.vec0());
-  vuint16 shift_vec1 = reinterpret_cast<vuint16>(b.vec1());
-  return Vectorized<int16_t>{
-      vec_sr(a.vec0(), shift_vec0), vec_sr(a.vec1(), shift_vec1)};
-}
-
-template <>
 Vectorized<int16_t> inline maximum(
     const Vectorized<int16_t>& a,
     const Vectorized<int16_t>& b) {
@@ -381,6 +361,8 @@ Vectorized<int16_t> inline minimum(
     const Vectorized<int16_t>& b) {
   return a.minimum(b);
 }
+
+DEFINE_SHIFT_FUNCS(int16_t)
 
 template <>
 Vectorized<int16_t> C10_ALWAYS_INLINE

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int32_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int32_vsx.h
@@ -279,26 +279,6 @@ class Vectorized<int32_t> {
 };
 
 template <>
-Vectorized<int32_t> inline operator<<(
-    const Vectorized<int32_t>& a,
-    const Vectorized<int32_t>& b) {
-  vuint32 shift_vec0 = reinterpret_cast<vuint32>(b.vec0());
-  vuint32 shift_vec1 = reinterpret_cast<vuint32>(b.vec1());
-  return Vectorized<int32_t>{
-      vec_sl(a.vec0(), shift_vec0), vec_sl(a.vec1(), shift_vec1)};
-}
-
-template <>
-Vectorized<int32_t> inline operator>>(
-    const Vectorized<int32_t>& a,
-    const Vectorized<int32_t>& b) {
-  vuint32 shift_vec0 = reinterpret_cast<vuint32>(b.vec0());
-  vuint32 shift_vec1 = reinterpret_cast<vuint32>(b.vec1());
-  return Vectorized<int32_t>{
-      vec_sr(a.vec0(), shift_vec0), vec_sr(a.vec1(), shift_vec1)};
-}
-
-template <>
 Vectorized<int32_t> inline maximum(
     const Vectorized<int32_t>& a,
     const Vectorized<int32_t>& b) {
@@ -311,6 +291,8 @@ Vectorized<int32_t> inline minimum(
     const Vectorized<int32_t>& b) {
   return a.minimum(b);
 }
+
+DEFINE_SHIFT_FUNCS(int32_t)
 
 template <>
 Vectorized<int32_t> C10_ALWAYS_INLINE

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int64_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int64_vsx.h
@@ -232,26 +232,6 @@ class Vectorized<int64_t> {
 };
 
 template <>
-Vectorized<int64_t> inline operator<<(
-    const Vectorized<int64_t>& a,
-    const Vectorized<int64_t>& b) {
-  vuint64 shift_vec0 = reinterpret_cast<vuint64>(b.vec0());
-  vuint64 shift_vec1 = reinterpret_cast<vuint64>(b.vec1());
-  return Vectorized<int64_t>{
-      vec_sl(a.vec0(), shift_vec0), vec_sl(a.vec1(), shift_vec1)};
-}
-
-template <>
-Vectorized<int64_t> inline operator>>(
-    const Vectorized<int64_t>& a,
-    const Vectorized<int64_t>& b) {
-  vuint64 shift_vec0 = reinterpret_cast<vuint64>(b.vec0());
-  vuint64 shift_vec1 = reinterpret_cast<vuint64>(b.vec1());
-  return Vectorized<int64_t>{
-      vec_sr(a.vec0(), shift_vec0), vec_sr(a.vec1(), shift_vec1)};
-}
-
-template <>
 Vectorized<int64_t> inline maximum(
     const Vectorized<int64_t>& a,
     const Vectorized<int64_t>& b) {
@@ -264,6 +244,8 @@ Vectorized<int64_t> inline minimum(
     const Vectorized<int64_t>& b) {
   return a.minimum(b);
 }
+
+DEFINE_SHIFT_FUNCS(int64_t)
 
 template <>
 Vectorized<int64_t> C10_ALWAYS_INLINE


### PR DESCRIPTION
Similar to #96659 this implements the conditionals handling the out-of-limit values in the shift amounts (rhs) for the vectorized VSX code using the same logic as the scalar code.

Fixes #109777



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168