### PR TITLE
[torchrun] Fix: Use Correctly Reachable Host Address in c10d Rendezvous

### DIFF
--- a/torch/distributed/elastic/rendezvous/api.py
+++ b/torch/distributed/elastic/rendezvous/api.py
@@ -5,13 +5,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import socket
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, ClassVar, Optional
 
 from torch.distributed import Store
-from torch.distributed.elastic.utils.distributed import get_free_port
+from torch.distributed.elastic.utils.distributed import get_free_port, get_routable_ip
 
 
 __all__ = [
@@ -86,7 +85,7 @@ class RendezvousStoreInfo:
         """
         # TODO swap to collectives comms API
         if rank == 0:
-            addr = local_addr or socket.gethostbyname(socket.getfqdn())
+            addr = local_addr or get_routable_ip()
             # When TCPStore is not shared, we fallback to get_free_port.
             port = server_port or get_free_port()
             store.set(

--- a/torch/distributed/elastic/rendezvous/api.py
+++ b/torch/distributed/elastic/rendezvous/api.py
@@ -86,7 +86,7 @@ class RendezvousStoreInfo:
         """
         # TODO swap to collectives comms API
         if rank == 0:
-            addr = local_addr or socket.getfqdn()
+            addr = local_addr or socket.gethostbyname(socket.getfqdn())
             # When TCPStore is not shared, we fallback to get_free_port.
             port = server_port or get_free_port()
             store.set(

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -265,7 +265,8 @@ class _NodeDescGenerator:
 
             self._local_id += 1
 
-        return _NodeDesc(local_addr or socket.getfqdn(), os.getpid(), local_id)
+        addr = local_addr or socket.gethostbyname(socket.getfqdn())
+        return _NodeDesc(addr, os.getpid(), local_id)
 
 
 class _RendezvousState:

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -9,7 +9,6 @@ import inspect
 import logging
 import os
 import pickle
-import socket
 import threading
 import time
 import weakref
@@ -22,6 +21,7 @@ from typing import Any, Callable, Optional
 import torch.distributed as dist
 from torch.distributed import Store
 from torch.distributed.elastic.events import construct_and_record_rdzv_event, NodeState
+from torch.distributed.elastic.utils.distributed import get_routable_ip
 
 from .api import (
     RendezvousClosedError,
@@ -265,7 +265,7 @@ class _NodeDescGenerator:
 
             self._local_id += 1
 
-        addr = local_addr or socket.gethostbyname(socket.getfqdn())
+        addr = local_addr or get_routable_ip()
         return _NodeDesc(addr, os.getpid(), local_id)
 
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/150532

In this PR, we replace `socket.getfqdn()` with `socket.gethostbyname(socket.getfqdn())`, ensuring that an IP address is used instead of a potentially unresolvable hostname.

Anyway, using an IP is more reliable than a hostname in this case.


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o