### PR TITLE
[invoke_subgraph] Force grad_outs to be contiguous at tracing time

### DIFF
--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -228,6 +228,12 @@ def create_fw_bw_graph(subgraph, operands, grad_outputs=None):
                 grad_outputs = [grad for grad in grad_outputs if grad is not None]
                 grad_outputs = [grad for grad in grad_outputs if grad.requires_grad]
 
+                # Force grad_out to be contiguous. This is because at runtime,
+                # grad_out could have different strides than fw_outs. So, we
+                # force the grad_outs to be contiguous for both tracing and
+                # runtime.
+                grad_outputs = [grad.contiguous() for grad in grad_outputs]
+
             if any(
                 not isinstance(out, torch.Tensor)
                 for out in grad_outputs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #150561
* #150556
* #150486
* #150450
* #150082

I am unable to come up with a testcase. It passes many end-to-end tests that fail with ReshapeError at https://ossci-raw-job-status.s3.amazonaws.com/log/39717218372

![image](https://github.com/user-attachments/assets/8509b485-3897-4538-968b-bbe05af63a59)
