### PR TITLE
[MPSInductor] Speedup `sum`/`prod` reductions

### DIFF
--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -6,27 +6,52 @@
 namespace c10 {
 namespace metal {
 
+constant constexpr unsigned simdgroup_size = 32;
+
 template <typename T>
-opmath_t<T> threadgroup_sum(threadgroup T* data, unsigned size) {
-  // TODO: This should be moved to the callee
-  ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
-  opmath_t<T> rc = data[0];
-  // TODO: Use `simd_shuffle_down`
-  for (unsigned idx = 1; idx < size; ++idx) {
-    rc += data[idx];
+opmath_t<T> threadgroup_sum(
+    threadgroup T* data,
+    T val,
+    unsigned idx,
+    unsigned size) {
+  auto rc = ::metal::simd_sum(val);
+  if (idx % simdgroup_size == 0) {
+    data[idx / simdgroup_size] = rc;
   }
-  return rc;
+  if (size > simdgroup_size) {
+    ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
+    if (idx < ((size + simdgroup_size - 1) / simdgroup_size)) {
+      auto rc1 = ::metal::simd_sum(data[idx]);
+      if (idx == 0) {
+        data[0] = rc1;
+      }
+    }
+  }
+  ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
+  return data[0];
 }
 
 template <typename T>
-opmath_t<T> threadgroup_prod(threadgroup T* data, unsigned size) {
-  // TODO: This should be moved to the callee
-  ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
-  opmath_t<T> rc = data[0];
-  for (unsigned idx = 1; idx < size; ++idx) {
-    rc *= data[idx];
+opmath_t<T> threadgroup_prod(
+    threadgroup T* data,
+    T val,
+    unsigned idx,
+    unsigned size) {
+  auto rc = ::metal::simd_product(val);
+  if (idx % simdgroup_size == 0) {
+    data[idx / simdgroup_size] = rc;
   }
-  return rc;
+  if (size > simdgroup_size) {
+    ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
+    if (idx < ((size + simdgroup_size - 1) / simdgroup_size)) {
+      auto rc1 = ::metal::simd_product(data[idx]);
+      if (idx == 0) {
+        data[0] = rc1;
+      }
+    }
+  }
+  ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
+  return data[0];
 }
 
 template <typename T>

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -19,21 +19,23 @@ inline ::metal::enable_if_t<!::metal::is_same_v<T, long>, T> simd_prod(T val) {
 }
 
 // Metal does not support SIMD reductions over 64-bit types
-// Simulate it using simd_shuffle_down over uint2 type
+// Simulate it accumulating over shuffled down int2 values
 template <typename T>
 inline ::metal::enable_if_t<::metal::is_same_v<T, long>, T> simd_sum(T val) {
   for (ushort i = simdgroup_size / 2; i > 0; i /= 2) {
-    val += as_type<long>(::metal::simd_shuffle_down(as_type<uint2>(val), i));
+    val += as_type<T>(
+        ::metal::simd_shuffle_and_fill_down(as_type<int2>(val), int2(0), i));
   }
-  return val;
+  return as_type<T>(::metal::simd_broadcast(as_type<int2>(val), 0));
 }
 
 template <typename T>
 inline ::metal::enable_if_t<::metal::is_same_v<T, long>, T> simd_prod(T val) {
   for (ushort i = simdgroup_size / 2; i > 0; i /= 2) {
-    val *= as_type<long>(::metal::simd_shuffle_down(as_type<uint2>(val), i));
+    val *= as_type<T>(
+        ::metal::simd_shuffle_and_fill_down(as_type<int2>(val), int2(0), i));
   }
-  return val;
+  return as_type<T>(::metal::simd_broadcast(as_type<int2>(val), 0));
 }
 
 // Below algorithms are  written with hardcoded assumption that simdgroup is 32

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1996,6 +1996,8 @@ class CommonTemplate:
             return torch.max(a), torch.sum(a)
 
         # Requires masked loading for the intermediate reduction
+        if self.device == "mps" and MACOS_VERSION < 13.3:
+            raise unittest.SkipTest("Fails with internal compiler error on MacOS-13")
         sample = torch.full((3999971,), 0, dtype=torch.int64)
         sample[-1] = 1
         self.common(fn, (sample,))
@@ -2492,6 +2494,8 @@ class CommonTemplate:
 
         dtypes = torch.bool, torch.uint8, torch.int
         inps = [torch.randint(2, (64,), dtype=dtype) for dtype in dtypes]
+        if self.device == "mps" and MACOS_VERSION < 13.3:
+            raise unittest.SkipTest("Fails with internal compiler error on MacOS-13")
         for i in inps:
             self.common(fn, (i,), check_lowp=False)
 

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -534,7 +534,8 @@ class MetalKernel(SIMDKernel):
         reduction_dim = next(t for t in self.range_trees if t.is_reduction)
         acc_buf_size = min(reduction_dim.numel, self.max_threadgroup_size)
         if reduction_type == "any":
-            acc = self._new_idxvar(dtype, default_value="false")
+            acc = self._new_idxvar(dtype)
+            self.indexing_code.writeline(f"{acc} = false;")
             self.indexing_code.writeline(
                 "threadgroup_barrier(metal::mem_flags::mem_threadgroup);"
             )

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -13,7 +13,7 @@ import torch
 from torch.utils._sympy.printers import ExprPrinter as ExprPrinter_
 from torch.utils._sympy.value_ranges import ValueRanges
 
-from ..utils import get_bounds_index_expr, get_kernel_metadata, ceildiv
+from ..utils import ceildiv, get_bounds_index_expr, get_kernel_metadata
 from ..virtualized import ops, OpsWrapper, V
 from .common import (
     CSEVariable,
@@ -504,22 +504,23 @@ class MetalKernel(SIMDKernel):
         line = f"if ({reduction_dim.name} == 0) {line}"
         self.stores.writeline(DeferredLine(name, line))
 
-    def _new_accvar(
+    def _new_idxvar(
         self,
         dtype: torch.dtype,
         elem_count: Optional[int] = None,
+        default_value: Optional[Any] = None,
+        is_threadgroup: bool = True,
         bounds: ValueRanges[Any] = ValueRanges.unknown(),
     ) -> CSEVariable:
         var_name = f"tmp_acc_{next(self.acc_var_ids)}"
         var = V.kernel.create_cse_var(var_name, bounds, dtype)
+        var_def = "threadgroup " if is_threadgroup else ""
+        var_def += f"{self.dtype_to_str(dtype)} {var_name}"
         if elem_count:
-            self.indexing_code.writeline(
-                f"threadgroup {self.dtype_to_str(dtype)} {var_name}[{elem_count}];"
-            )
-        else:
-            self.indexing_code.writeline(
-                f"threadgroup {self.dtype_to_str(dtype)} {var_name};"
-            )
+            var_def += f"[{elem_count}]"
+        if default_value is not None:
+            var_def += f" = {default_value}"
+        self.indexing_code.writeline(var_def + self.suffix)
         return var
 
     def reduction(
@@ -533,8 +534,7 @@ class MetalKernel(SIMDKernel):
         reduction_dim = next(t for t in self.range_trees if t.is_reduction)
         acc_buf_size = min(reduction_dim.numel, self.max_threadgroup_size)
         if reduction_type == "any":
-            acc = self._new_accvar(dtype)
-            self.indexing_code.writeline(f"{acc} = false;")
+            acc = self._new_idxvar(dtype, default_value="false")
             self.indexing_code.writeline(
                 "threadgroup_barrier(metal::mem_flags::mem_threadgroup);"
             )
@@ -550,23 +550,27 @@ class MetalKernel(SIMDKernel):
             )
             return acc
         if reduction_type in ["prod", "sum"]:
-            acc_buf = self._new_accvar(src_dtype, ceildiv(acc_buf_size, self.simd_group_size))
-            if self.multistage_reduction:
-                val = self._new_accvar(dtype)
+            acc_dtype = DTYPE_TO_COMPUTATION_DTYPE[src_dtype]
+            acc_buf = self._new_idxvar(
+                acc_dtype, ceildiv(acc_buf_size, self.simd_group_size)
+            )
+            if not self.multistage_reduction:
+                val = value
+            else:
                 default_val, reduction_op = (
                     (0, "+") if reduction_type == "sum" else (1, "*")
                 )
-                self.indexing_code.writeline(f"{val} = {default_val};")
+                val = self._new_idxvar(
+                    acc_dtype, default_value=default_val, is_threadgroup=False
+                )
                 self.compute.splice(f"{val} {reduction_op}= {value};")
-            else:
-                val = value
             return self.cse.generate(
                 self.stores,
                 f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {val}, {reduction_dim.name}, {acc_buf_size})",
                 dtype=DTYPE_TO_COMPUTATION_DTYPE[dtype],
             )
         if reduction_type in ["max", "min", "argmin", "argmax"]:
-            acc_buf = self._new_accvar(src_dtype, acc_buf_size)
+            acc_buf = self._new_idxvar(src_dtype, acc_buf_size)
             acc_thread_var = f"{acc_buf}[{reduction_dim.name}]"
             src_metal_type = DTYPE_TO_METAL[src_dtype]
             if not self.multistage_reduction:
@@ -586,7 +590,7 @@ class MetalKernel(SIMDKernel):
                 idx_var = next(
                     t for t in self.range_tree_nodes.values() if t.is_reduction
                 )
-                idx_acc_buf = self._new_accvar(torch.long, acc_buf_size)
+                idx_acc_buf = self._new_idxvar(torch.long, acc_buf_size)
                 cmp_op = ">" if reduction_type == "argmax" else "<"
                 idx_thread_var = f"{idx_acc_buf}[{reduction_dim.name}]"
                 self.indexing_code.splice(f"{idx_thread_var} = -1;")
@@ -613,7 +617,7 @@ class MetalKernel(SIMDKernel):
             assert not self.multistage_reduction, (
                 f"Multistage reduction not yet supported for {reduction_type}"
             )
-            acc_buf = self._new_accvar(src_dtype, acc_buf_size)
+            acc_buf = self._new_idxvar(src_dtype, acc_buf_size)
             self.compute.splice(f"{acc_buf}[{reduction_dim.name}] = {value};")
             wf_res = self.cse.generate(
                 self.compute,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #150566

By using cooperative `simd_sum`/`simd_product` instead of a C-style for loop for threadgroup reductions. This also allows significantly reduce amount of shared memory needed to perform those reductions

Using such reduction increases the `torch.compile` performance for gpt-fast using `stories110M` from 29 tokens/sec to 630 tokens/sec on M4 and changes perf of torch.rand as follows:
|size| before | after |
|------------------------|------------|-------------|
| 512x512         | 202.1       | 131.8       |
| 1024x1024   |   780.6    | 176.9       |
| 2048x2048    |   1423.4       | 339.9      |
| 4096x4097    |    2982.2 | 1047.2      |


Unfortunately, none of the SIMDgroup operations are available for 64-bit integers, but one can simulate the behavior using using `simd_shuffle_down` of 64-bit values represented as `int2` types, that yields reduction in $log_2(threadgroup\\_size)$ steps. [`mlx/kernels/reduction/ops.h](https://github.com/ml-explore/mlx/blob/86389bf9707f46101af45d90510e8e97c8a90b93/mlx/backend/metal/kernels/reduction/ops.h#L15-L18) contains an implementation of such algorithm, but alas it yields wrong results on M1/M2(and may be M3 machines) if not all threads in the simdgroup are active which could be observed by running
```python
import torch
lib=torch.mps.compile_shader("""
kernel void do_sum(device int* out, constant int* in, uint idx [[thread_position_in_grid]]) {
  out[idx] = metal::simd_shuffle_down(in[idx], 8);
}
""")
x=torch.arange(22, device='mps', dtype=torch.int32)
y=torch.empty_like(x)
lib.do_sum(y, x)
print(y)
```
that returns following on M4
```
tensor([ 8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,  0,  0,  0,  0, 0,  0,  0,  0], device='mps:0', dtype=torch.int32)
```
but same kernel running on M1 returns
```
tensor([ 8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 14, 15, 16, 17, 18, 19, 20, 21], device='mps:0', dtype=torch.int32)
```
This discrepancy in behavior can be addressed by using `simd_shuffle_and_fill_down`, but any kernels using simd_shuffle_and_fill_down cause an internal compiler error on MacOS-13.2. Considering that OS is to be EOL soon, skip the offending tests.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov