### PR TITLE
[CUDA] include nvtx3 header in wheel so downstream torch extension can find it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1381,13 +1381,25 @@ if(DEFINED USE_CUSTOM_DEBINFO)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -g")
 endif()
 
-# Bundle PTXAS if needed
-if(BUILD_BUNDLE_PTXAS AND USE_CUDA)
-  if(NOT EXISTS "${PROJECT_SOURCE_DIR}/build/bin/ptxas")
-    message(STATUS "Copying PTXAS into the bin folder")
-    file(COPY "${CUDAToolkit_BIN_DIR}/ptxas"
-         DESTINATION "${PROJECT_BINARY_DIR}")
+if(USE_CUDA)
+  # Bundle PTXAS if needed
+  if(BUILD_BUNDLE_PTXAS)
+    if(NOT EXISTS "${PROJECT_SOURCE_DIR}/build/bin/ptxas")
+      message(STATUS "Copying PTXAS into the bin folder")
+      file(COPY "${CUDAToolkit_BIN_DIR}/ptxas"
+          DESTINATION "${PROJECT_BINARY_DIR}")
+    endif()
+    install(PROGRAMS "${PROJECT_BINARY_DIR}/ptxas"
+            DESTINATION "${CMAKE_INSTALL_BINDIR}")
   endif()
-  install(PROGRAMS "${PROJECT_BINARY_DIR}/ptxas"
-          DESTINATION "${CMAKE_INSTALL_BINDIR}")
+  # Include NVTX headers
+  if(NOT USE_SYSTEM_NVTX)
+    install(
+      DIRECTORY "${PROJECT_SOURCE_DIR}/third_party/NVTX/c/include/nvtx3"
+      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+      FILES_MATCHING
+        PATTERN "*.h"
+        PATTERN "*.hpp"
+    )
+  endif()
 endif()

--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -173,7 +173,13 @@ endif()
 if(USE_SYSTEM_NVTX)
   find_path(nvtx3_dir NAMES nvtx3 PATHS ${CUDA_INCLUDE_DIRS})
 else()
+  # Try to find nvtx3 from the source tree
   find_path(nvtx3_dir NAMES nvtx3 PATHS "${PROJECT_SOURCE_DIR}/third_party/NVTX/c/include" NO_DEFAULT_PATH)
+  # If not found in source tree, try to find nvtx3 from the torch wheel install path
+  if(NOT nvtx3_dir)
+    get_filename_component(TORCH_INSTALL_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../../.." ABSOLUTE)
+    find_path(nvtx3_dir NAMES nvtx3 PATHS "${TORCH_INSTALL_PREFIX}/include")
+  endif()
 endif()
 find_package_handle_standard_args(nvtx3 DEFAULT_MSG nvtx3_dir)
 if(nvtx3_FOUND)


### PR DESCRIPTION
When building pytorch with USE_SYSTEM_NVTX=0 or undefined then there's no information to downstream torch extension to figure out which nvtx3 headers was used with pytorch. This PR packages the nvtx3 header (340kb) into the torch wheel install so torch extension can reference it. This will help with keeping nvtx3 version alignment between pytorch and its extension.

Fixes: https://github.com/pytorch/pytorch/issues/147220

cc  @malfet @atalman @ptrblck @eqy @nWEIdia @tinglvv 

