### PR TITLE
[training] Adding NUMA support for pytorch

### DIFF
--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -274,3 +274,8 @@ def record_chromium_event_internal(
     event: dict[str, Any],
 ):
     return None
+
+def maybe_enable_numa_binding(
+    device_type: Optional[str] = None, device_id: Optional[int] = None
+):
+    return None


### PR DESCRIPTION
Test Plan:
build and run tests for modified libraries locally

buck2 build arvr/mode/platform010/opt //xplat/caffe2:pytorch_ovrsource
buck run arvr/mode/win/debug-md -c python.package_style=inplace  //xplat/caffe2:pytorch_test_ovrsource
buck test arvr/mode/linux/opt -c python.package_style=inplace  //xplat/caffe2:pytorch_test_ovrsource
buck test mode/opt //caffe2/fb/test:_utils_internal_test

Differential Revision: D72321369




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k