### PR TITLE
Added A Error Handling Block Around Recovering DynamicLayerStack 

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -637,6 +637,7 @@ class _TorchDynamoContext:
                         "Detected that you are using FX to torch.jit.trace "
                         "a dynamo-optimized function. This is not supported at the moment."
                     )
+
                 cleanups = [enter() for enter in self.enter_exit_hooks]
                 prior_skip_guard_eval_unsafe = set_skip_guard_eval_unsafe(
                     _is_skip_guard_eval_unsafe_stance()


### PR DESCRIPTION
Fixes #149801

Added an error handling for DynamicLayerStack to ensure if it's recovered as desired, if not , raise that exception.

In the finally part, https://github.com/pytorch/pytorch/blob/6470b373c16017f5cb8f1aa4060bb60632b18160/torch/_dynamo/eval_frame.py#L675, pop-up method is called to recover the DynamicLayerStack, but if some error is thrown in the middle of DynamicLayerStack's pop and push pair, that recovery logic will cause another exception.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames