### PR TITLE
Make `nn.MultiLabelMarginLoss` error message user friendly

### DIFF
--- a/aten/src/ATen/native/LossMulti.h
+++ b/aten/src/ATen/native/LossMulti.h
@@ -13,7 +13,7 @@ namespace at::native {
     const Tensor& target) {
     TORCH_CHECK(
         (ndims == 2 && input.size(1) != 0) || (ndims == 1 && input.size(0) != 0) || ndims == 0,
-        "Expected non-empty vector or matrix with optional 0-dim batch size, but got: ",
+        "Expected input tensor to have 0, 1 or 2 dimension, but got: ", ndims, ", with shape: ",
         input.sizes());
 
     if (ndims <= 1) {
@@ -21,16 +21,16 @@ namespace at::native {
       dim = ndims == 0 ? 1 : input.size(0);
       TORCH_CHECK(
           target.dim() <= 1 && target.numel() == dim,
-          "inconsistent target size: ", target.sizes(), " for input of size: ",
-          input.sizes());
+          "Expected target tensor to have 0 or 1 dimension, and ", dim, " elements, but got: dim = ", target.dim(),
+          ", numel = ", target.numel());
     } else {
       nframe = input.size(0);
       dim = input.size(1);
       TORCH_CHECK(
           target.dim() == 2 && target.size(0) == nframe &&
           target.size(1) == dim,
-          "inconsistent target size: ", target.sizes(), " for input of size: ",
-          input.sizes());
+          "Expected target tensor to have 2 dimension and shape [", nframe, ", ", dim,
+          "], but got: dim = ", target.dim(), ", shape = ", target.sizes());
     }
   }
 

--- a/aten/src/ATen/native/cuda/MultiLabelMarginCriterion.cu
+++ b/aten/src/ATen/native/cuda/MultiLabelMarginCriterion.cu
@@ -31,7 +31,7 @@ void multilabel_margin_loss_shape_check(
     const Tensor& target) {
     TORCH_CHECK(
         (ndims == 2 && input.size(1) != 0) || (ndims == 1 && input.size(0) != 0) || ndims == 0,
-        "Expected non-empty vector or matrix with optional 0-dim batch size, but got: ",
+        "Expected input tensor to have 0, 1 or 2 dimension, but got: ", ndims, ", with shape: ",
         input.sizes());
 
     if (ndims <= 1) {
@@ -39,16 +39,16 @@ void multilabel_margin_loss_shape_check(
       dim = ndims == 0 ? 1 : input.size(0);
       TORCH_CHECK(
           target.dim() <= 1 && target.numel() == dim,
-          "inconsistent target size: ", target.sizes(), " for input of size: ",
-          input.sizes());
+          "Expected target tensor to have 0 or 1 dimension, and ", dim, " elements, but got: dim = ", target.dim(),
+          ", numel = ", target.numel());
     } else {
       nframe = input.size(0);
       dim = input.size(1);
       TORCH_CHECK(
           target.dim() == 2 && target.size(0) == nframe &&
           target.size(1) == dim,
-          "inconsistent target size: ", target.sizes(), " for input of size: ",
-          input.sizes());
+          "Expected target tensor to have 2 dimension and shape [", nframe, ", ", dim,
+          "], but got: dim = ", target.dim(), ", shape = ", target.sizes());
     }
 }
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9084,6 +9084,15 @@ class TestNNDeviceType(NNTestCase):
             l.backward()
         self.assertTrue(len(f.getvalue()) == 0)
 
+    def test_MarginLoss_errors(self, device):
+        loss = nn.MultiLabelMarginLoss()
+        with self.assertRaisesRegex(RuntimeError, 'Expected input tensor to have 0, 1 or 2 dimension'):
+            loss(torch.rand([20, 9, 20], device=device), torch.rand([2, 2, 2, 2], device=device))
+        with self.assertRaisesRegex(RuntimeError, 'Expected target tensor to have 2 dimension'):
+            loss(torch.rand([1, 3], device=device), torch.rand([2, 2], device=device))
+        with self.assertRaisesRegex(RuntimeError, 'Expected target tensor to have 0 or 1 dimension'):
+            loss(torch.rand(3, device=device), torch.rand([2, 2], device=device))
+
     @onlyNativeDeviceTypes
     def test_Unfold_empty(self, device):
         inp = torch.randn(0, 3, 3, 4, device=device)


### PR DESCRIPTION
Fixes #106011


## Test Result

```python

import torch
import torch.nn as nn

input_tensor = torch.rand([20, 9, 20])
target_tensor = torch.rand([2, 2, 2, 2, 2, 2, 2]) 

loss_function = nn.MultiLabelMarginLoss()
loss = loss_function(input_tensor, target_tensor)

RuntimeError: Expected input tensor to have 0, 1 or 2 dimension, but got: 3, with shape: [20, 9, 20]


input_tensor = torch.rand([1, 3])
target_tensor = torch.rand([2, 2]) 

loss_function = nn.MultiLabelMarginLoss()
loss = loss_function(input_tensor, target_tensor)

RuntimeError: Expected target tensor to have 2 dimension and shape [1, 3], but got: dim = 2, shape = [2, 2]


input_tensor = torch.rand(3)
target_tensor = torch.rand([2, 2])

loss_function = nn.MultiLabelMarginLoss()
loss = loss_function(input_tensor, target_tensor)

RuntimeError: Expected target tensor to have 0 or 1 dimension, and 3 elements, but got: dim = 2, numel = 4
```