### PR TITLE
[Easy] Add `output_size` in forward method of ConvTranspose2d

### DIFF
--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -1143,6 +1143,14 @@ class ConvTranspose2d(_ConvTransposeNd):
         )
 
     def forward(self, input: Tensor, output_size: Optional[list[int]] = None) -> Tensor:
+        """
+        Performs the forward pass.
+
+        Attributes:
+            input (Tensor): The input tensor.
+            output_size (list[int], optional): A list of integers representing
+                the dimensions of the output tensor. Default is None.
+        """
         if self.padding_mode != "zeros":
             raise ValueError(
                 "Only `zeros` padding mode is supported for ConvTranspose2d"

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -1149,7 +1149,7 @@ class ConvTranspose2d(_ConvTransposeNd):
         Attributes:
             input (Tensor): The input tensor.
             output_size (list[int], optional): A list of integers representing
-                the dimensions of the output tensor. Default is None.
+                the size of the output tensor. Default is None.
         """
         if self.padding_mode != "zeros":
             raise ValueError(


### PR DESCRIPTION
Fixes #74593

Add description for `forward` in [ConvTranspose2d](https://pytorch.org/docs/stable/generated/torch.nn.ConvTranspose2d.html) doc

## Test Result

![image](https://github.com/user-attachments/assets/eebad7a2-f782-4219-9756-344e0f34fada)
