### PR TITLE
Update expected results for pr_time_benchmarks

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -1,20 +1,20 @@
-add_loop_eager,compile_time_instruction_count,2806000000,0.015
+add_loop_eager,compile_time_instruction_count,2869000000,0.015
 
 
 
-add_loop_eager_dynamic,compile_time_instruction_count,5460000000,0.025
+add_loop_eager_dynamic,compile_time_instruction_count,5547000000,0.025
 
 
 
-add_loop_inductor,compile_time_instruction_count,27520000000,0.015
+add_loop_inductor,compile_time_instruction_count,28130000000,0.015
 
 
 
-add_loop_inductor_dynamic_gpu,compile_time_instruction_count,40410000000,0.025
+add_loop_inductor_dynamic_gpu,compile_time_instruction_count,41610000000,0.025
 
 
 
-add_loop_inductor_gpu,compile_time_instruction_count,23970000000,0.015
+add_loop_inductor_gpu,compile_time_instruction_count,24570000000,0.015
 
 
 
@@ -22,11 +22,11 @@ basic_modules_ListOfLinears_eager,compile_time_instruction_count,953800000,0.015
 
 
 
-basic_modules_ListOfLinears_inductor,compile_time_instruction_count,17070000000,0.015
+basic_modules_ListOfLinears_inductor,compile_time_instruction_count,17600000000,0.015
 
 
 
-basic_modules_ListOfLinears_inductor_gpu_force_shape_pad,compile_time_instruction_count,15320000000,0.015
+basic_modules_ListOfLinears_inductor_gpu_force_shape_pad,compile_time_instruction_count,15780000000,0.015
 
 
 
@@ -34,32 +34,32 @@ basic_modules_ListOfLinears_inductor_gpu,compile_time_instruction_count,97140000
 
 
 
-update_hint_regression,compile_time_instruction_count,1523000000,0.02
+update_hint_regression,compile_time_instruction_count,1576000000,0.02
 
 
 
-sum_floordiv_regression,compile_time_instruction_count,1026000000,0.015
+sum_floordiv_regression,compile_time_instruction_count,1044000000,0.015
 
 
 
-symint_sum,compile_time_instruction_count,3013000000,0.015
+symint_sum,compile_time_instruction_count,3101000000,0.015
 
 
 
-aotdispatcher_inference_nosubclass_cpu,compile_time_instruction_count,1964000000,0.015
+aotdispatcher_inference_nosubclass_cpu,compile_time_instruction_count,2005000000,0.015
 
 
 
-aotdispatcher_inference_subclass_cpu,compile_time_instruction_count,5672000000,0.015
+aotdispatcher_inference_subclass_cpu,compile_time_instruction_count,5784000000,0.015
 
 
 
-aotdispatcher_partitioner_cpu,compile_time_instruction_count,7752000000,0.015
+aotdispatcher_partitioner_cpu,compile_time_instruction_count,8300000000,0.015
 
 
 
-aotdispatcher_training_nosubclass_cpu,compile_time_instruction_count,3537000000,0.015
+aotdispatcher_training_nosubclass_cpu,compile_time_instruction_count,3678000000,0.015
 
 
 
-aotdispatcher_training_subclass_cpu,compile_time_instruction_count,9662000000,0.015
+aotdispatcher_training_subclass_cpu,compile_time_instruction_count,9982000000,0.015


### PR DESCRIPTION
Followup after revert : https://github.com/pytorch/pytorch/pull/150572 expected tests results need to be updated


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames