### PR TITLE
[validations] Run nccl version check on Linux only

### DIFF
--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -271,8 +271,10 @@ def smoke_test_cuda(
         print(f"cuDNN enabled? {torch.backends.cudnn.enabled}")
         torch_cudnn_version = cudnn_to_version_str(torch.backends.cudnn.version())
         print(f"Torch cuDNN version: {torch_cudnn_version}")
-        torch_nccl_version = ".".join(str(v) for v in torch.cuda.nccl.version())
-        print(f"Torch nccl; version: {torch_nccl_version}")
+
+        if sys.platform in ["linux", "linux2"]:
+            torch_nccl_version = ".".join(str(v) for v in torch.cuda.nccl.version())
+            print(f"Torch nccl; version: {torch_nccl_version}")
 
         # Pypi dependencies are installed on linux ony and nccl is availbale only on Linux.
         if pypi_pkg_check == "enabled" and sys.platform in ["linux", "linux2"]:


### PR DESCRIPTION
Followup https://github.com/pytorch/pytorch/pull/150194 to disable nccl version print on OS's other then Linux