### PR TITLE
[c10d][fr] Improve FR dump robustness with all watchdog broadcast wait and more frequent store check

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2144,13 +2144,6 @@ void ProcessGroupNCCL::broadcastDumpSignal() {
     // signal the monitor thread on PG0 to start dumping
     shouldDump_.store(true);
   }
-  // Give time for dumping before throwing exception for all ranks.
-  // It is hard to presume or control what the pattern of watchdog might look
-  // like, so it is better to let all ranks universally sleep for a short period
-  // of time, in this case, 60 seconds, which is also the maximum time we leave
-  // for FR dump.
-  std::this_thread::sleep_for(
-      std::chrono::milliseconds(waitTimeoutDumpInMilSec_));
 }
 
 void ProcessGroupNCCL::checkAndSetRemoteError() {
@@ -2324,6 +2317,13 @@ void ProcessGroupNCCL::watchdogHandler() {
         // recorder behavior is independent of desync Debug.
         if (dumpOnTimeoutOrEx_) {
           broadcastDumpSignal();
+          // Give time for dumping before throwing exception for all ranks.
+          // It is hard to presume or control what the pattern of watchdog might
+          // look like, so it is better to let all ranks universally sleep for a
+          // short period of time, in this case, 60 seconds, which is also the
+          // maximum time we leave for FR dump.
+          std::this_thread::sleep_for(
+              std::chrono::milliseconds(waitTimeoutDumpInMilSec_));
         }
 
         if (SHOULD_CLEAN_UP(asyncErrorHandling_)) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -1169,9 +1169,6 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // timeout for the dump to finish.
   int waitTimeoutDumpInMilSec_;
 
-  // promise to coordinate flight recorder dump.
-  std::promise<void> promiseFlightRecorderDump_;
-
   // Interval of check coordinated signals in ProcessGroupNCCL from other ranks
   // e.g., trigger the dump of the debugging info for timeout when notified.
   int coordCheckIntervalMilSec_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #150652

When debugging FR missing dump and missing dump logs, I have couple initial findings:
1. On the same rank, if a second watchdog timeout triggers on a different PG(or subPG), that watchdog thread will immediately throw exception instead of sleeping. We want to fix that by still making the watchdog thread to wait for 1 min.
2. The FR dump takes about 900ms to 1200ms so, we are not checking the store frequently enough. But instead of changing the frequency from 1sec to 300ms, we finally decided to just let all ranks just sleep for 1 min universally rather than using a promise.


cc @H-Huang @awgu @wanchaol @fegin @wz337 @wconstab @d4l3k