### PR TITLE
Split up cub-RadixSortPairs-scalars.cu to parallelize compilation

### DIFF
--- a/aten/src/ATen/cuda/cub-RadixSortPairs-bool-Bool.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-bool-Bool.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS_8(decltype(::c10::impl::ScalarTypeToCPPType<at::ScalarType::Bool>::t), at::ScalarType::Bool)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-double-Double.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-double-Double.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS_8(double, Double)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-float-Float.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-float-Float.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS_8(float, at::ScalarType::Float)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-half-Half.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-half-Half.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS_8(decltype(::c10::impl::ScalarTypeToCPPType<at::ScalarType::Half>::t), at::ScalarType::Half)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-int-Int.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-int-Int.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS_8(int, Int)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-int16_t-Short.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-int16_t-Short.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS_8(int16_t, Short)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-int64_t-Long.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-int64_t-Long.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS_8(int64_t, at::ScalarType::Long)
+
+} // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-int8_t-Char.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-int8_t-Char.cu
@@ -2,6 +2,6 @@
 
 namespace at::cuda::cub::detail {
 
-AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, AT_INSTANTIATE_SORT_PAIRS_8)
+AT_INSTANTIATE_SORT_PAIRS_8(int8_t, Char)
 
 } // namespace at::cuda::cub::detail

--- a/aten/src/ATen/cuda/cub-RadixSortPairs-uint8_t-Byte.cu
+++ b/aten/src/ATen/cuda/cub-RadixSortPairs-uint8_t-Byte.cu
@@ -1,0 +1,7 @@
+#include <ATen/cuda/cub-RadixSortPairs.cuh>
+
+namespace at::cuda::cub::detail {
+
+AT_INSTANTIATE_SORT_PAIRS_8(uint8_t, Byte)
+
+} // namespace at::cuda::cub::detail


### PR DESCRIPTION
Summary: `cub-RadixSortPairs-scalars.cu` has slow compilation times, especially on Windows. These changes split up the file into smaller components to allow each component to compile in parallel. On Windows, I observed a compile time drop from about 6 minutes to 4 minutes. This is a similar follow up to [PR 148936](https://github.com/pytorch/pytorch/pull/148936).

Differential Revision: D70539650


