### PR TITLE
[CI][Inductor] Add missing unittest import

### DIFF
--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -2,6 +2,7 @@
 import functools
 import itertools
 import math
+import unittest
 
 import torch
 import torch._inductor.config


### PR DESCRIPTION
Fixes unit test failures: 
test/inductor/test_fused_attention.py", line 567, in TestSDPAPatternRewriterTemplate  
   @unittest.skip("disabled in upstream")                                                                                     ^^^^^^^^                                                                                                             
NameError: name 'unittest' is not defined. Did you forget to import 'unittest' 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov
@ptrblck @eqy @tinglvv @malfet @atalman 