### PR TITLE
Support having no metadata file for HuggingFaceStorageReader

### DIFF
--- a/torch/distributed/checkpoint/_fsspec_filesystem.py
+++ b/torch/distributed/checkpoint/_fsspec_filesystem.py
@@ -91,6 +91,9 @@ class FileSystem(FileSystemBase):
     def rm_file(self, path: Union[str, os.PathLike]) -> None:
         self.fs.rm(path)
 
+    def ls(self, path: Union[str, os.PathLike]) -> list[str]:
+        return self.fs.ls(path)
+
 
 # TODO: add the dcp.async_save mixin
 class FsspecWriter(FileSystemWriter):

--- a/torch/distributed/checkpoint/_hf_storage.py
+++ b/torch/distributed/checkpoint/_hf_storage.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import dataclasses
 import json
+import os
 import queue
 from typing import Optional
 
@@ -206,15 +207,40 @@ class _HuggingFaceStorageReader(FsspecReader):
         return fut
 
     def read_metadata(self) -> Metadata:
-        path = self.fs.concat_path(self.path, _metadata_fn)
-        with self.fs.create_stream(path, "r") as metadata_file:
-            metadata = json.load(metadata_file)
+        metadata_path = self.fs.concat_path(self.path, _metadata_fn)
 
         state_dict_metadata: dict[str, STORAGE_TYPES] = {}
-        for key in metadata["weight_map"].keys():
-            state_dict_metadata[key] = BytesStorageMetadata()
+        storage_data: dict[str, str] = {}
+
+        if not self.fs.exists(metadata_path):
+            # if metadata file doesn't exist, create it from the safetensors file
+            from safetensors.torch import safe_open  # type: ignore[import-not-found]
+
+            safetensors_files = []
+            for file in self.fs.ls(self.path):
+                if file.endswith(SUFFIX):
+                    safetensors_files.append(os.path.basename(file))
+
+            if len(safetensors_files) != 1:
+                raise ValueError(
+                    f"Need exactly one safetensors file to load without metadata, found {len(safetensors_files)} files"
+                )
+            storage_data = {}
+            with safe_open(safetensors_files[0], framework="pt") as f:
+                for k in f.keys():
+                    state_dict_metadata[k] = BytesStorageMetadata()
+                    storage_data[k] = safetensors_files[0]
+        else:
+            with self.fs.create_stream(metadata_path, "r") as metadata_file:
+                metadata = json.load(metadata_file)
+
+            for key in metadata["weight_map"].keys():
+                state_dict_metadata[key] = BytesStorageMetadata()
+            storage_data = metadata["weight_map"]
+
         metadata = Metadata(
-            state_dict_metadata=state_dict_metadata, storage_data=metadata["weight_map"]
+            state_dict_metadata=state_dict_metadata,
+            storage_data=storage_data,
         )
 
         if getattr(metadata, "storage_meta", None) is None:

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -479,6 +479,9 @@ class FileSystemBase(ABC):
     @abstractmethod
     def rm_file(self, path: Union[str, os.PathLike]) -> None: ...
 
+    @abstractmethod
+    def ls(self, path: Union[str, os.PathLike]) -> list[str]: ...
+
 
 class FileSystem(FileSystemBase):
     @contextmanager
@@ -538,6 +541,11 @@ class FileSystem(FileSystemBase):
         if not isinstance(path, Path):
             path = Path(path)
         path.unlink()
+
+    def ls(self, path: Union[str, os.PathLike]) -> list[str]:
+        if not isinstance(path, Path):
+            path = Path(path)
+        return [str(p) for p in path.iterdir()]
 
 
 class _FileSystemWriter(StorageWriter):


### PR DESCRIPTION
Summary: If there is only one safetensors file, we don't need users to have a metadata file and we can just construct it from the keys of that file. This is a use-case for some HuggingFace models, so adding support for it

Test Plan:
ensure existing tests pass
tested e2e in a notebook

Differential Revision: D72472490




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k