### PR TITLE
cd: Introduce new binary build workflows (cpu)

### DIFF
--- a/.cd/generate_build_matrix.py
+++ b/.cd/generate_build_matrix.py
@@ -30,7 +30,7 @@ from functools import cache
 from pathlib import Path
 
 
-ROOT_DIR = Path(__file__).parent.parent.parent
+ROOT_DIR = Path(__file__).parent.parent
 
 STABLE_CUDA_VERSION = "12.6"
 

--- a/.ci/manywheel/build_cuda.sh
+++ b/.ci/manywheel/build_cuda.sh
@@ -26,12 +26,20 @@ if [[ -z "$EXTRA_CAFFE2_CMAKE_FLAGS" ]]; then
     EXTRA_CAFFE2_CMAKE_FLAGS=()
 fi
 
+if [[ -n "${ACCELERATOR_VERSION:-}" ]]; then
+    CUDA_VERSION="${ACCELERATOR_VERSION}"
+    echo "Using CUDA $CUDA_VERSION as determined by ACCELERATOR_VERSION"
+fi
+
+# ===========================================================================
+# TODO: This is a legacy variable that we eventually want to get rid of in
+#       favor of ACCELERATOR_VERSION
 # Determine CUDA version and architectures to build for
 #
 # NOTE: We should first check `DESIRED_CUDA` when determining `CUDA_VERSION`,
 # because in some cases a single Docker image can have multiple CUDA versions
 # on it, and `nvcc --version` might not show the CUDA version we want.
-if [[ -n "$DESIRED_CUDA" ]]; then
+if [[ -n "$DESIRED_CUDA" && -z "${CUDA_VERSION:-}" ]]; then
     # If the DESIRED_CUDA already matches the format that we expect
     if [[ ${DESIRED_CUDA} =~ ^[0-9]+\.[0-9]+$ ]]; then
         CUDA_VERSION=${DESIRED_CUDA}
@@ -48,6 +56,7 @@ else
     CUDA_VERSION=$(nvcc --version|grep release|cut -f5 -d" "|cut -f1 -d",")
     echo "CUDA $CUDA_VERSION Detected"
 fi
+# ===========================================================================
 
 cuda_version_nodot=$(echo $CUDA_VERSION | tr -d '.')
 

--- a/.ci/pytorch/check_binary.sh
+++ b/.ci/pytorch/check_binary.sh
@@ -156,7 +156,7 @@ build_and_run_example_cpp () {
 ###############################################################################
 if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then
   # NS: Set LD_LIBRARY_PATH for CUDA builds, but perhaps it should be removed
-  if [[ "$DESIRED_CUDA" == "cu"* ]]; then
+  if [[ "$GPU_ARCH_TYPE" =~ "*cuda*" ]]; then
     export LD_LIBRARY_PATH=/usr/local/cuda/lib64
   fi
   build_and_run_example_cpp simple-torch-test
@@ -229,7 +229,7 @@ if [[ "$OSTYPE" == "msys" ]]; then
 fi
 
 # Test that CUDA builds are setup correctly
-if [[ "$DESIRED_CUDA" != 'cpu' && "$DESIRED_CUDA" != 'xpu' && "$DESIRED_CUDA" != 'cpu-cxx11-abi' && "$DESIRED_CUDA" != *"rocm"* && "$(uname -m)" != "s390x" ]]; then
+if [[ "$GPU_ARCH_TYPE" = "cuda" ]]; then
   if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then
     build_and_run_example_cpp check-torch-cuda
   else

--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -50,6 +50,8 @@ on:
         required: true
         type: string
         description: Desired Cuda version
+      # ===========================================================================
+      # TODO: Rename these to ACCELERATOR_VERSION and ACCELERATOR_TYPE
       GPU_ARCH_VERSION:
         required: false
         type: string
@@ -58,10 +60,16 @@ on:
         required: true
         type: string
         description: GPU Arch type
+      # ===========================================================================
+
+      # ===========================================================================
+      # TODO: Rename this to CONTAINER_IMAGE
       DOCKER_IMAGE:
         required: true
         type: string
         description: Docker image to use
+      # ===========================================================================
+
       LIBTORCH_CONFIG:
         required: false
         type: string
@@ -70,10 +78,13 @@ on:
         required: false
         type: string
         description: Desired libtorch variant (for libtorch builds only)
+      # ===========================================================================
+      # TODO: Rename this to PYTHON_VERSION
       DESIRED_PYTHON:
         required: false
         type: string
         description: Desired python version
+      # ===========================================================================
       PYTORCH_EXTRA_INSTALL_REQUIREMENTS:
         required: false
         type: string
@@ -152,7 +163,7 @@ jobs:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
         with:
-          no-sudo: ${{ inputs.build_environment == 'linux-aarch64-binary-manywheel' || inputs.build_environment == 'linux-s390x-binary-manywheel' }}
+          no-sudo: ${{ contains(inputs.build_environment, 'aarch64') || contains(inputs.build_environment, 's390x') }}
 
       - name: Setup Linux
         if: inputs.build_environment != 'linux-s390x-binary-manywheel'
@@ -172,7 +183,7 @@ jobs:
           rm -rf "${GITHUB_WORKSPACE}"
           mkdir "${GITHUB_WORKSPACE}"
 
-          if [[ ${{ inputs.build_environment }} == 'linux-aarch64-binary-manywheel' ]] || [[ ${{ inputs.build_environment }} == 'linux-s390x-binary-manywheel' ]] ; then
+          if [[ ${{ inputs.build_environment }} =~ 'aarch64' ]] || [[ ${{ inputs.build_environment }} =~ 's390x' ]] ; then
             rm -rf "${RUNNER_TEMP}/artifacts"
             mkdir "${RUNNER_TEMP}/artifacts"
           fi
@@ -259,17 +270,17 @@ jobs:
             ${{ runner.temp }}/artifacts/*
 
       - name: Teardown Linux
-        if: always() && inputs.build_environment != 'linux-s390x-binary-manywheel'
+        if: always() && !contains(inputs.build_environment, 's390x')
         uses: pytorch/test-infra/.github/actions/teardown-linux@main
 
       - name: Chown workspace
-        if: always() && inputs.build_environment != 'linux-s390x-binary-manywheel'
+        if: always() && !contains(inputs.build_environment, 's390x')
         uses: ./pytorch/.github/actions/chown-workspace
         with:
           ALPINE_IMAGE: ${{ inputs.ALPINE_IMAGE }}
 
       - name: Cleanup docker
-        if: always() && inputs.build_environment == 'linux-s390x-binary-manywheel'
+        if: always() && contains(inputs.build_environment, 's390x')
         shell: bash
         run: |
           # on s390x stop the container for clean worker stop

--- a/.github/workflows/_generate-binary-matrix.yml
+++ b/.github/workflows/_generate-binary-matrix.yml
@@ -43,6 +43,9 @@ on:
         description: The generated matrix for macos cpu builds
         value: ${{ jobs.generate-matrix.outputs.macos-cpu-matrix }}
 
+env:
+  PACKAGE_TYPE: ${{ inputs.package-type }}
+
 jobs:
   generate-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/_generate-binary-matrix.yml
+++ b/.github/workflows/_generate-binary-matrix.yml
@@ -53,7 +53,7 @@ jobs:
 
           set +x
 
-          python3 .ci/release/generate_build_matrix.py \
+          python3 .cd/release/generate_build_matrix.py \
             --package-type "${PACKAGE_TYPE}" \
             --os "${OS}" \
             --accelerator-type "${ACCELERATOR_TYPE}" \

--- a/.github/workflows/_generate-binary-matrix.yml
+++ b/.github/workflows/_generate-binary-matrix.yml
@@ -1,0 +1,60 @@
+name: generate-binary-matrix
+
+# Example workflow_call:
+#
+# generate-binary-matrix:
+#   uses: ./.github/workflows/_generate-binary-matrix.yml
+#   with:
+#     package-type: wheel
+#     os: linux
+#     accelerator-type: cpu
+
+on:
+  workflow_call:
+    inputs:
+      package-type:
+        required: true
+        type: string
+        description: Type of binary package to build (wheel libtorch)
+      os:
+        required: true
+        type: string
+        description: Operating system to build for
+      accelerator-type:
+        required: true
+        type: string
+        description: Accelerator type to build for
+    outputs:
+      matrix:
+        description: The generated matrix
+        value: ${{ jobs.generate-matrix.outputs.matrix }}
+
+jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Generate matrix
+        id: set-matrix
+        run: |
+          # Set default values
+          PACKAGE_TYPE="${{ inputs.package-type }}"
+          OS="${{ inputs.os }}"
+          ACCELERATOR_TYPE="${{ inputs.accelerator-type }}"
+
+          set +x
+
+          python3 .ci/release/generate_build_matrix.py \
+            --package-type "${PACKAGE_TYPE}" \
+            --os "${OS}" \
+            --accelerator-type "${ACCELERATOR_TYPE}" \
+            --to-github-output

--- a/.github/workflows/_generate-binary-matrix.yml
+++ b/.github/workflows/_generate-binary-matrix.yml
@@ -53,7 +53,7 @@ jobs:
 
           set +x
 
-          python3 .cd/release/generate_build_matrix.py \
+          python3 .cd/generate_build_matrix.py \
             --package-type "${PACKAGE_TYPE}" \
             --os "${OS}" \
             --accelerator-type "${ACCELERATOR_TYPE}" \

--- a/.github/workflows/_linux-binary.yml
+++ b/.github/workflows/_linux-binary.yml
@@ -19,10 +19,18 @@ on:
         required: true
         type: string
         description: Builds on
+      container_image:
+        required: true
+        type: string
+        description: Container image
       package_type:
         required: true
         type: string
         description: Package type
+      python_version:
+        required: true
+        type: string
+        description: Python version
       pytorch_extra_install_requirements:
         required: true
         type: string
@@ -43,13 +51,11 @@ on:
 
 jobs:
   build:
-    strategy:
-      fail-fast: true 
     uses: ./.github/workflows/_binary-build-linux.yml
     with:
       DESIRED_CUDA: ${{ inputs.accelerator_type }}
-      DESIRED_PYTHON: ${{ matrix.python_version }}
-      DOCKER_IMAGE: ${{ matrix.container_image }}
+      DESIRED_PYTHON: ${{ inputs.python_version }}
+      DOCKER_IMAGE: ${{ inputs.container_image }}
       GPU_ARCH_TYPE: ${{ inputs.accelerator_type }}
       GPU_ARCH_VERSION: ${{ inputs.accelerator_version }}
       PACKAGE_TYPE: ${{ inputs.package_type }}
@@ -64,7 +70,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   test:
-    needs: 
+    needs:
       - build
     uses: ./.github/workflows/_binary-test-linux.yml
     with:
@@ -75,7 +81,19 @@ jobs:
       DESIRED_CUDA: ${{ inputs.accelerator_type }}
       GPU_ARCH_TYPE: ${{ inputs.accelerator_type }}
       GPU_ARCH_VERSION: ${{ inputs.accelerator_version }}
-      DOCKER_IMAGE: ${{ matrix.container_image }}
+      DOCKER_IMAGE: ${{ inputs.container_image }}
       runs_on: ${{ inputs.test_on }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+  upload:
+    needs:
+      - test
+    uses: ./.github/workflows/_binary-upload.yml
+    with:
+      build_name: upload-${{ inputs.build_name }}
+      package_type: ${{ inputs.package_type }}
+      GPU_ARCH_TYPE: ${{ inputs.accelerator_type }}
+      # TODO: I know this isn't the correct DESIRED_CUDA, need to fix
+      DESIRED_CUDA: ${{ inputs.accelerator_type }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_linux-binary.yml
+++ b/.github/workflows/_linux-binary.yml
@@ -1,0 +1,74 @@
+name: linux-binary
+
+on:
+  workflow_call:
+    inputs:
+      runner_prefix: # aka label-type
+        required: false
+        default: ""
+        type: string
+        description: prefix for runner label
+      package_type:
+        required: true
+        type: string
+        description: Package type
+      accelerator_type:
+        required: true
+        type: string
+        description: GPU Arch type
+    secrets:
+      github-token:
+        required: true
+        description: Github Token
+
+jobs:
+  generate-matrix:
+    uses: ./.github/workflows/_generate-binary-matrix.yml
+    with:
+      os: linux 
+      package-type: ${{ inputs.package_type }}
+      accelerator-type: ${{ inputs.accelerator_type }}
+  build:
+    strategy:
+      fail-fast: true 
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+    needs: 
+      - generate-matrix
+    uses: ./.github/workflows/_binary-build-linux.yml
+    with:
+      DESIRED_CUDA: ${{ matrix.accelerator_type }}
+      DESIRED_PYTHON: ${{ matrix.python_version }}
+      DOCKER_IMAGE: ${{ matrix.container_image }}
+      GPU_ARCH_TYPE: ${{ matrix.accelerator_type }}
+      GPU_ARCH_VERSION: ${{ matrix.accelerator_version }}
+      PACKAGE_TYPE: ${{ inputs.package_type }}
+      PYTORCH_ROOT: /pytorch
+      build_environment: ${{ matrix.accelerator_type }}
+      build_name: build-${{ matrix.build_name }}
+      pytorch_extra_install_requirements: ${{ matrix.pytorch_extra_install_requirements }}
+      runner_prefix: ${{ inputs.runner_prefix }}
+      runs_on: ${{ matrix.builds_on }}
+      timeout-minutes: 240
+      use_split_build: False
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+  test:
+    needs: 
+      - build
+      - generate-matrix
+    strategy:
+      fail-fast: true 
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+    uses: ./.github/workflows/_binary-test-linux.yml
+    with:
+      build_name: test-${{ matrix.build_name }}
+      build_environment: ${{ matrix.accelerator_type }}
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: ${{ inputs.package_type }}
+      DESIRED_CUDA: ${{ matrix.accelerator_type }}
+      GPU_ARCH_TYPE: ${{ matrix.accelerator_type }}
+      GPU_ARCH_VERSION: ${{ matrix.accelerator_version }}
+      DOCKER_IMAGE: ${{ matrix.container_image }}
+      runs_on: ${{ matrix.test_on }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/binary-builds.yml
+++ b/.github/workflows/binary-builds.yml
@@ -24,12 +24,28 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
+  generate-matrix:
+    if: github.repository_owner == 'pytorch'
+    uses: ./.github/workflows/_generate-binary-matrix.yml
+    with:
+      package-type: wheel
   linux-cpu:
-    needs: get-label-type
+    needs:
+      - get-label-type
+      - generate-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.linux-cpu-matrix) }}
     uses: ./.github/workflows/_linux-binary.yml
     with:
+      accelerator_type: ${{ matrix.accelerator_type }}
+      accelerator_version: ${{ matrix.accelerator_version }}
+      build_name: ${{ matrix.build_name }}
+      builds_on: ${{ matrix.builds_on }}
+      container_image: ${{ matrix.container_image }}
       package_type: wheel
-      accelerator_type: cpu
+      python_version: ${{ matrix.python_version }}
+      pytorch_extra_install_requirements: ${{ matrix.pytorch_extra_install_requirements }}
       runner_prefix: ${{ needs.get-label-type.outputs.label-type }}
+      test_on: ${{ matrix.test_on }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/binary-builds.yml
+++ b/.github/workflows/binary-builds.yml
@@ -1,0 +1,35 @@
+name: Binary Builds
+
+on:
+  pull_request:
+  # TODO: Uncomment this when we finish developing the workflow
+  # push:
+  #   branches:
+  #     - main
+  #     - nightly
+  #     - release/*
+  #   tags:
+  #     - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+  #     - 'ciflow/binaries/*'
+  workflow_dispatch:
+
+# TODO: Could we autogenerate this?
+jobs:
+  get-label-type:
+    if: github.repository_owner == 'pytorch'
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+  linux-cpu:
+    needs: get-label-type
+    uses: ./.github/workflows/_linux-binary.yml
+    with:
+      package_type: wheel
+      accelerator_type: cpu
+      runner_prefix: ${{ needs.get-label-type.outputs.label-type }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #150713
* #149830

Introduces new binary build workflows and some supplementary changes to
downstream scripts in order to accommodate the new workflows.

Goal here is to get off the ground with the new syntax and ideally make
it easier to add on more workflows after this one is solidified.

I'm not entirely happy with the state of some of these workflows since
there are lot of unused variables but I do want to test this as a POC
ASAP so we can flesh out the UX / how we'd like to maintain it.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>