### PR TITLE
Add type hints to `_tensor_docs.add_docstr_all`

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -6,7 +6,7 @@ from torch._C import _add_docstr as add_docstr
 from torch._torch_docs import parse_kwargs, reproducibility_notes
 
 
-def add_docstr_all(method, docstr):
+def add_docstr_all(method: str, docstr: str) -> None:
     add_docstr(getattr(torch._C.TensorBase, method), docstr)
 
 


### PR DESCRIPTION
There is some sort of bug in `pytype` where if this function doesn't have type hints, `pytype` will spend 10 minutes inferring the types. Not that this matters much for a project not using `pytype`, but it led me to realize that this function could easily be type hinted and is not, so here is a PR adding some type hints.