### PR TITLE
[export] add runtime assert messages to python torch checks

### DIFF
--- a/c10/core/SymNodeImpl.h
+++ b/c10/core/SymNodeImpl.h
@@ -202,7 +202,10 @@ class C10_API SymNodeImpl : public c10::intrusive_ptr_target {
     // with a better implementation!
     return guard_bool(file, line);
   }
-  virtual bool expect_true(const char* file, int64_t line) {
+  virtual bool expect_true(
+    const char* file,
+    int64_t line,
+    const char* error_message = "") {
     // No improvement for unbacked SymBools by default, replace this
     // with a better implementation!
     return guard_bool(file, line);

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1629,7 +1629,7 @@ def _check_with(
 
     from torch.fx.experimental.symbolic_shapes import expect_true
 
-    if expect_true(cond):
+    if expect_true(cond, message=message):
         return
 
     # error_type must be a subclass of Exception and not subclass of Warning

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1246,7 +1246,7 @@ void initJITBindings(PyObject* module) {
           })
       .def(
           "expect_true",
-          [](const c10::SymNode& a, const char* file, int64_t line) {
+          [](const c10::SymNode& a, const char* file, int64_t line, const char* error_message="") {
             return a->expect_true(file, line);
           })
       .def(

--- a/torch/csrc/utils/python_symnode.h
+++ b/torch/csrc/utils/python_symnode.h
@@ -120,7 +120,10 @@ class PythonSymNodeImpl : public c10::SymNodeImpl {
     return getPyObj().attr("guard_bool")(file, line).cast<bool>();
   }
 
-  bool expect_true(const char* file, int64_t line) override {
+  bool expect_true(
+    const char* file,
+    int64_t line,
+    const char* error_message = "") override {
     py::gil_scoped_acquire acquire;
     return getPyObj().attr("expect_true")(file, line).cast<bool>();
   }

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -540,7 +540,7 @@ class SymNode:
             log.warning("Failed to convert to bool: %s", r)
             raise
 
-    def expect_true(self, file, line):
+    def expect_true(self, file, line, message=None):
         from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
 
         if (
@@ -555,7 +555,10 @@ class SymNode:
         # TODO: file/line here is very important, because the assert has been
         # deferred so you can't backtrace easily
         return self.shape_env.defer_runtime_assert(
-            self.expr, f"{file}:{line}", fx_node=self.fx_node
+            self.expr,
+            msg=f"{file}:{line}",
+            info=message,
+            fx_node=self.fx_node,
         )
 
     def expect_size(self, file, line):


### PR DESCRIPTION
~fixes #150063 (for python at least)

Before:
```
Runtime assertion failed for expression Eq(Mod(s16*s35, s35 - 1), 0) on node 'eq'
```

Now:
```
RuntimeError: Runtime assertion failed for expression Eq(Mod(s16*s35, s35 - 1), 0) on node 'eq'

The original traceback points to the following location and error message:
/data/users/pianpwk/pytorch/torch/_prims_common/__init__.py:954
shape '[s35 - 1, ((s16*s35)//(s35 - 1))]' is invalid for input of size s16*s35
```

Differential Revision: D72483950

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv