### PR TITLE
[Don't Merge] Check Regression

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -949,6 +949,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
             )
 
     def generate_return(self, output_refs: list[str]):
+        # only test
         cst_names = V.graph.constants.keys()
         output2idx: dict[str, int] = {}
 


### PR DESCRIPTION
There are regressions running ci for https://github.com/pytorch/pytorch/pull/150150
But this patch not related to the regressions.
This pr only used to check if there are regressions on master branch


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov