### PR TITLE
[Dynamo][Typing] Enable `@override` for VTs [1/N]

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -3008,7 +3008,7 @@ class InstructionTranslatorBase(
             else:
                 self.block_stack.append(BlockStackEntry(inst, target, len(self.stack)))
 
-        self.push(ctx.enter(self))
+        self.push(ctx.enter(self))  # type: ignore[arg-type]
 
     def append_prefix_inst(self, inst):
         assert self.accept_prefix_inst

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -403,10 +403,14 @@ class VariableTracker(metaclass=VariableTrackerMeta):
     def reconstruct(self, codegen: "PyCodegen"):
         raise NotImplementedError
 
-    def unpack_var_sequence(self, tx) -> list["VariableTracker"]:
+    def unpack_var_sequence(
+        self, tx: "InstructionTranslator"
+    ) -> list["VariableTracker"]:
         raise NotImplementedError
 
-    def force_unpack_var_sequence(self, tx) -> list["VariableTracker"]:
+    def force_unpack_var_sequence(
+        self, tx: "InstructionTranslator"
+    ) -> list["VariableTracker"]:
         # like unpack_var_sequence, but should only be used when it is
         # safe to eagerly (vs. lazily) unpack this variable.
         # e.g. map(f, x) is normally evaluated lazily but sometimes
@@ -415,7 +419,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         # it should only be called once.
         return self.unpack_var_sequence(tx)
 
-    def has_unpack_var_sequence(self, tx) -> bool:
+    def has_unpack_var_sequence(self, tx: "InstructionTranslator") -> bool:
         try:
             self.unpack_var_sequence(tx)
             return True
@@ -423,7 +427,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             return False
 
     # NB: don't call force_unpack_var_sequence, especially if it mutates!
-    def has_force_unpack_var_sequence(self, tx) -> bool:
+    def has_force_unpack_var_sequence(self, tx: "InstructionTranslator") -> bool:
         return self.has_unpack_var_sequence(tx)
 
     # Forces unpacking the var sequence while also applying a function to each element.
@@ -473,7 +477,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def call_method(
         self,
-        tx,
+        tx: "InstructionTranslator",
         name,
         args: "list[VariableTracker]",
         kwargs: "dict[str, VariableTracker]",
@@ -562,7 +566,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         """Used by LazyVariableTracker to indicate an unrealized node"""
         return True
 
-    def next_variable(self, tx):
+    def next_variable(self, tx: "InstructionTranslator"):
         unimplemented_v2(
             gb_type="Unsupported next() call",
             context=f"next({self})",
@@ -570,7 +574,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             hints=[*graph_break_hints.USER_ERROR],
         )
 
-    def is_strict_mode(self, tx):
+    def is_strict_mode(self, tx: "InstructionTranslator"):
         return tx.strict_checks_fn and tx.strict_checks_fn(self)
 
     def is_mutable(self):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1,4 +1,4 @@
-# mypy: allow-untyped-defs
+# mypy: ignore-errors
 
 import contextlib
 import functools

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -14,6 +14,7 @@ import unittest
 from collections import defaultdict, OrderedDict
 from collections.abc import KeysView, Sequence
 from typing import Callable, TYPE_CHECKING, Union
+from typing_extensions import override
 
 import torch
 from torch import sym_float, sym_int
@@ -718,9 +719,11 @@ class BuiltinVariable(VariableTracker):
 
         return f"{self.__class__.__name__}({name})"
 
+    @override
     def as_python_constant(self):
         return self.fn
 
+    @override
     def as_proxy(self):
         DTYPE = {
             bool: torch.bool,
@@ -731,6 +734,7 @@ class BuiltinVariable(VariableTracker):
             return DTYPE[self.fn]
         return super().as_proxy()
 
+    @override
     def reconstruct(self, codegen: "PyCodegen"):
         name = self.fn.__name__
         assert self.fn.__module__ == "builtins"
@@ -1126,6 +1130,7 @@ class BuiltinVariable(VariableTracker):
         ],
     ] = {}
 
+    @override
     def call_function(
         self,
         tx: "InstructionTranslator",
@@ -1146,9 +1151,10 @@ class BuiltinVariable(VariableTracker):
             )
         return handler(tx, args, kwargs)
 
+    @override
     def call_method(
         self,
-        tx,
+        tx: "InstructionTranslator",
         name,
         args: "list[VariableTracker]",
         kwargs: "dict[str, VariableTracker]",

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -10,6 +10,7 @@ maintaining type safety through the compilation process.
 
 import operator
 from typing import TYPE_CHECKING
+from typing_extensions import override
 
 import torch
 from torch._dynamo.source import AttrSource, GetItemSource
@@ -82,15 +83,18 @@ its type to `common_constant_types`.
         else:
             self.value = value
 
+    @override
     def as_proxy(self):
         return self.value
 
     def __repr__(self) -> str:
         return f"ConstantVariable({type(self.value).__name__}: {repr(self.value)})"
 
+    @override
     def as_python_constant(self):
         return self.value
 
+    @override
     def is_python_constant(self):
         return True
 
@@ -117,12 +121,14 @@ its type to `common_constant_types`.
             return all(ConstantVariable.is_literal(x) for x in obj)
         return ConstantVariable.is_base_literal(obj)
 
+    @override
     def unpack_var_sequence(self, tx):
         try:
             return [ConstantVariable.create(x) for x in self.as_python_constant()]
         except TypeError as e:
             raise NotImplementedError from e
 
+    @override
     def const_getattr(self, tx: "InstructionTranslator", name):
         if not hasattr(self.value, name):
             raise NotImplementedError
@@ -131,6 +137,7 @@ its type to `common_constant_types`.
             raise NotImplementedError
         return member
 
+    @override
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -208,6 +215,7 @@ its type to `common_constant_types`.
             return ConstantVariable.create(result)
         return super().call_method(tx, name, args, kwargs)
 
+    @override
     def call_obj_hasattr(
         self, tx: "InstructionTranslator", name: str
     ) -> "VariableTracker":
@@ -241,6 +249,7 @@ class EnumVariable(VariableTracker):
             hints=[*graph_break_hints.USER_ERROR, *graph_break_hints.SUPPORTABLE],
         )
 
+    @override
     def as_proxy(self):
         if isinstance(self.value, int):
             return int(self.value)  # convert IntEnum to a normal int
@@ -249,9 +258,11 @@ class EnumVariable(VariableTracker):
     def __repr__(self) -> str:
         return f"EnumVariable({type(self.value)})"
 
+    @override
     def as_python_constant(self):
         return self.value
 
+    @override
     def var_getattr(self, tx: "InstructionTranslator", name):
         if not hasattr(self.value, name):
             raise NotImplementedError

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -174,7 +174,6 @@ class GenericContextWrappingVariable(UserDefinedObjectVariable):
     def fn_name(self):
         return type(self.cm_obj).__name__
 
-    @override
     def enter(self, tx: "InstructionTranslator"):
         source = None if self.source is None else AttrSource(self.source, "__enter__")
         return variables.UserMethodVariable(
@@ -183,7 +182,6 @@ class GenericContextWrappingVariable(UserDefinedObjectVariable):
             source=source,
         ).call_function(tx, [], {})
 
-    @override
     def exit(self, tx: "InstructionTranslator", *args):
         source = None if self.source is None else AttrSource(self.source, "__exit__")
         x = variables.UserMethodVariable(


### PR DESCRIPTION
As https://github.com/pytorch/pytorch/pull/150289#pullrequestreview-2729254192 said.

Enable `@override` for VTs:

- torch/_dynamo/variables/base.py
- torch/_dynamo/variables/builtin.py
- torch/_dynamo/variables/constant.py
- torch/_dynamo/variables/ctx_manager.py

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames