### PR TITLE
[elastic][test] fix race condition in test_barrier_timeout_rank_tracing

### DIFF
--- a/test/distributed/elastic/utils/util_test.py
+++ b/test/distributed/elastic/utils/util_test.py
@@ -158,7 +158,7 @@ class StoreUtilTest(TestCase):
         with ThreadPool(N - 1) as pool:
             outputs: list[str] = pool.map(run_barrier_for_rank, range(N - 1))
 
-        self.assertTrue(any("missing_ranks=[Rank 2 host]" in msg for msg in outputs))
+        self.assertTrue(any("missing_ranks=[Rank " in msg for msg in outputs))
 
         self.assertTrue(
             any(


### PR DESCRIPTION
# Root cause
The barrier timeout set to 0.1 is too short, some threads may not have enough time to reach the barrier.

# How to reproduce
Adding some sleep will be easy to reproduce.
```python
    def test_barrier_timeout_rank_tracing(self):
        N = 3 

        store = dist.HashStore()

        def run_barrier_for_rank(i: int):
            if i != 0:
                import time;time.sleep(1)  # Let some thread sleep for a while
            try:
                store_util.barrier(
                    store,
                    N,
                    key_prefix="test/store",
                    barrier_timeout=0.1,
                    rank=i,
                    rank_tracing_decoder=lambda x: f"Rank {x} host",
                    trace_timeout=0.01,
                )
            except Exception as e:
                return str(e)
            return ""

```





cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k