### PR TITLE
[Profiler][HPU] Enable profiler.key_averages().table() for HPU devices

### DIFF
--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -609,6 +609,7 @@ class FunctionEvent(FormattedTimesMixin):
                 DeviceType.CUDA,
                 DeviceType.PrivateUse1,
                 DeviceType.MTIA,
+                DeviceType.HPU,
             ]
             return self.time_range.elapsed_us()
 
@@ -633,6 +634,7 @@ class FunctionEvent(FormattedTimesMixin):
                 DeviceType.CUDA,
                 DeviceType.PrivateUse1,
                 DeviceType.MTIA,
+                DeviceType.HPU,
             ]
             return self.device_time_total
 


### PR DESCRIPTION
Fixes #150769
