### PR TITLE
[MPS] Support ArgumentBuffer bindings from C++/Python

### DIFF
--- a/aten/src/ATen/native/mps/MetalShaderLibrary.h
+++ b/aten/src/ATen/native/mps/MetalShaderLibrary.h
@@ -24,6 +24,7 @@ typedef void* MTLComputeCommandEncoder_t;
 // Forward declaration of TensorBase and TensorIteratorBase
 namespace at {
 class TensorBase;
+class Tensor;
 struct TensorIteratorBase;
 } // namespace at
 
@@ -48,7 +49,7 @@ constexpr bool has_size_type_v = has_size_type<T>::value;
 
 class MetalKernelFunction {
  public:
-  MetalKernelFunction(MTLComputePipelineState_t cps_);
+  MetalKernelFunction(MTLComputePipelineState_t cps_, MTLFunction_t f_);
   ~MetalKernelFunction();
   MetalKernelFunction(MetalKernelFunction&) = delete;
   // Shader properties
@@ -56,10 +57,11 @@ class MetalKernelFunction {
   uint64_t getThreadExecutionWidth() const;
   uint64_t getStaticThreadGroupMemoryLength() const;
   void runCommandBlock(std::function<void(void)> f);
-  // Methods below should be called from runCommandBlock functionT
+  // Methods below should be called from runCommandBlock function
   void startEncoding();
   void setArg(unsigned idx, const at::TensorBase& t);
   void setArg(unsigned idx, const void* ptr, uint64_t size);
+  void setArgumentBuffer(unsigned idx, const std::vector<at::Tensor>& elemns);
   template <
       typename T,
       typename = std::enable_if_t<
@@ -88,6 +90,7 @@ class MetalKernelFunction {
 
  private:
   MTLComputePipelineState_t cps;
+  MTLFunction_t func;
   MTLComputeCommandEncoder_t encoder = nullptr;
 };
 

--- a/aten/src/ATen/native/mps/MetalShaderLibrary.h
+++ b/aten/src/ATen/native/mps/MetalShaderLibrary.h
@@ -24,7 +24,6 @@ typedef void* MTLComputeCommandEncoder_t;
 // Forward declaration of TensorBase and TensorIteratorBase
 namespace at {
 class TensorBase;
-class Tensor;
 struct TensorIteratorBase;
 } // namespace at
 
@@ -47,6 +46,9 @@ constexpr bool has_size_type_v = has_size_type<T>::value;
 
 } // namespace detail
 
+// Returns `gpuAddress` of respective `id<MTLBuffer>` plus storage offset
+void* get_tensor_gpu_address(const at::TensorBase&);
+
 class MetalKernelFunction {
  public:
   MetalKernelFunction(MTLComputePipelineState_t cps_, MTLFunction_t f_);
@@ -61,7 +63,6 @@ class MetalKernelFunction {
   void startEncoding();
   void setArg(unsigned idx, const at::TensorBase& t);
   void setArg(unsigned idx, const void* ptr, uint64_t size);
-  void setArgumentBuffer(unsigned idx, const std::vector<at::Tensor>& elemns);
   template <
       typename T,
       typename = std::enable_if_t<

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1155,12 +1155,8 @@ uint64_t MetalKernelFunction::getStaticThreadGroupMemoryLength() const {
   return [cps staticThreadgroupMemoryLength];
 }
 
-void MetalKernelFunction::setArgumentBuffer(unsigned idx, const std::vector<at::Tensor>& tv) {
-  auto arg_encoder = [func newArgumentEncoderWithBufferIndex:idx];
-  TORCH_CHECK(encoder, "Failed to create argument buffer encoder")
-  for (auto idx : c10::irange(tv.size())) {
-    mtl_setBuffer(arg_encoder, tv[idx], idx);
-  }
+void* get_tensor_gpu_address(const at::TensorBase& t) {
+  return reinterpret_cast<void*>(getMTLBufferStorage(t).gpuAddress + t.storage_offset() * t.element_size());
 }
 
 } // namespace at::native::mps

--- a/aten/src/ATen/test/mps_test_metal_library.cpp
+++ b/aten/src/ATen/test/mps_test_metal_library.cpp
@@ -54,6 +54,7 @@ TEST(MPSTestMetalLibrary, ArangeWithArgsShader) {
   });
   ASSERT_TRUE((x==y).all().item().toBool());
 }
+
 TEST(MPSTestMetalLibrary, Arange2DShader) {
   const auto size = 16;
   auto x = torch::empty({size, size}, at::device(at::kMPS));
@@ -70,4 +71,40 @@ TEST(MPSTestMetalLibrary, Arange2DShader) {
      func->dispatch({static_cast<uint64_t>(x.size(0)), static_cast<uint64_t>(x.size(1))});
   });
   ASSERT_EQ(x.sum().item().to<int>(), 65280);
+}
+
+TEST(MPSTestMetalLibrary, ArgumentBuffers) {
+  constexpr auto nbuffers = 64;
+  const auto size = 32;
+  std::vector<at::Tensor> ibuffers;
+  for([[maybe_unused]] auto idx: c10::irange(nbuffers)) {
+    ibuffers.push_back(torch::rand({size}, at::device(at::kMPS)));
+  }
+  auto output = torch::empty({size}, at::device(at::kMPS));
+  DynamicMetalShaderLibrary lib(R"MTL(
+  constant constexpr auto nbuffers = 64;
+  struct Inputs {
+    metal::array<device float *, nbuffers> args;
+  };
+
+  kernel void sum_all(device float* output, constant Inputs& inputs, uint idx [[thread_position_in_grid]]) {
+    output[idx] = 0;
+    for(auto i = 0; i < nbuffers; ++i) {
+      output[idx] += inputs.args[i][idx];
+    }
+  }
+  )MTL");
+  auto func = lib.getKernelFunction("sum_all");
+  func->runCommandBlock([&] {
+     func->startEncoding();
+     func->setArg(0, output);
+     func->setArgumentBuffer(1, ibuffers);
+     func->dispatch(size);
+  });
+  // Compute sum of all 64 input tensors
+  auto result = torch::zeros({size}, at::device(at::kMPS));
+  for(auto buf: ibuffers) {
+    result += buf;
+  }
+  ASSERT_EQ(result.sum().item().to<float>(), output.sum().item().to<float>());
 }

--- a/torch/csrc/mps/Module.cpp
+++ b/torch/csrc/mps/Module.cpp
@@ -372,6 +372,15 @@ struct OptionalArgCaster {
       } else if (py::isinstance<py::float_>(element)) {
         auto values = arg.cast<std::vector<float>>();
         setValue(f, idx, values);
+      } else if (THPVariable_Check(element.ptr())) {
+        /* List of tensors, most often to overcome the limits of 32-args per
+         * kernel */
+        auto tensorlist = py::cast<std::vector<at::Tensor>>(arg);
+        std::vector<void*> tl_ptrs;
+        for (auto& t : tensorlist) {
+          tl_ptrs.push_back(at::native::mps::get_tensor_gpu_address(t));
+        }
+        f.setArg(idx, tl_ptrs);
       } else {
         TORCH_CHECK(false, "Unexpected argument types");
       }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #150780

To workaround limitation of 32-arguments per kernel and being able to eventually compile something like
```python
import torch

def foo(*args):
  rc = torch.empty_like(args[0])
  for arg in args:
      rc += arg
  return rc


tensors = torch.rand(100, 32, device='mps').unbind(0)
print(torch.compile(foo)(*tensors))
```

For now, introduce `at::native::metal::get_tensor_gpu_address` and use it from both C++ test and compile_shader to convert list of tensors to list of pointers valid on GPU.

Initially this binding were done via `id< MTLArgumentEncoder>`, but according to [Improving CPU Performance by Using Argument Buffers](https://developer.apple.com/documentation/metal/improving-cpu-performance-by-using-argument-buffers?language=objc#Encode-Resources-into-Argument-Buffers) article, this is not necessary when targeting Tier2-only devices (which is true of all devices on MacOS-13 or newer):
> To directly encode the argument buffer resources on these Tier 2 devices, write the [MTLBuffer](https://developer.apple.com/documentation/metal/mtlbuffer?language=objc).[gpuAddress](https://developer.apple.com/documentation/metal/mtlbuffer/gpuaddress?language=objc) property — and for other resource types (samplers, textures, and acceleration structures), the [gpuResourceID](https://developer.apple.com/documentation/metal/mtlcomputepipelinestate/gpuresourceid?language=objc) property — into the corresponding structure member. To encode offsets, treat these property values as uint64 types and add the offset to them.

Add both C++ and PyThon unittests that validate that this works. 
Please note, that using either ArgumentEncoder or directly encoding the data does not guarantee buffer will not be freed until shader execution is complete. On the other hand, this should already be guaranteed by MPSCachingAllocator that would only free the memory after all streams completed its execution. 