### PR TITLE
Pytorch. is_impure() does not take any argument. Removed it

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1817,7 +1817,7 @@ class Graph:
         def has_side_effect(node):
             if is_impure_node is not None:
                 return is_impure_node(node)
-            return node.is_impure(impure_random)
+            return node.is_impure()
 
         # Reverse iterate so that when we remove a node, any nodes used as an
         # input to that node have an updated user count that no longer reflects


### PR DESCRIPTION
Summary:
D72427768 introduced an argument when calling `is_impure` (defined here: https://www.internalfb.com/code/fbsource/[00b3734ebfa7]/arvr/libraries/art/python/third_party/_python3.7/_win64/torch/fx/node.py?lines=509)

This broke our conveyor:
 https://fb.workplace.com/groups/CTRLEngSupport/permalink/4045843202402092/

We removed the argument.

Test Plan:
`pte flow configs/pipelines/f4/releases/p1r/f4_pp_20250317_release enable_fast_run=True`


https://internalfb.com/intern/fblearner/details/718510504/

Differential Revision: D72605617




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv