### PR TITLE
Expose bicubic mode for torch::nn::functional::grid_sample in LibTorch

### DIFF
--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -631,6 +631,17 @@ TEST_F(FunctionalTest, GridSample) {
 
   ASSERT_TRUE(output.allclose(expected));
 
+  // bicubic, zeros, true
+  options = F::GridSampleFuncOptions()
+                .mode(torch::kBicubic)
+                .padding_mode(torch::kZeros)
+                .align_corners(true);
+  output = F::grid_sample(input, grid, options);
+  expected = torch::tensor(
+      {{{{0., 0., 1.}, {3., 4., 5.}, {7., 8., 0.}}}}, torch::kFloat);
+
+  ASSERT_TRUE(output.allclose(expected));
+
   // bilinear, border, true
   options = F::GridSampleFuncOptions()
                 .mode(torch::kBilinear)

--- a/torch/csrc/api/include/torch/nn/options/vision.h
+++ b/torch/csrc/api/include/torch/nn/options/vision.h
@@ -16,7 +16,9 @@ namespace torch::nn::functional {
 /// F::GridSampleFuncOptions().mode(torch::kBilinear).padding_mode(torch::kZeros).align_corners(true));
 /// ```
 struct TORCH_API GridSampleFuncOptions {
-  typedef std::variant<enumtype::kBilinear, enumtype::kNearest, enumtype::kBicubic> mode_t;
+  typedef std::
+      variant<enumtype::kBilinear, enumtype::kNearest, enumtype::kBicubic>
+          mode_t;
   typedef std::
       variant<enumtype::kZeros, enumtype::kBorder, enumtype::kReflection>
           padding_mode_t;

--- a/torch/csrc/api/include/torch/nn/options/vision.h
+++ b/torch/csrc/api/include/torch/nn/options/vision.h
@@ -16,7 +16,7 @@ namespace torch::nn::functional {
 /// F::GridSampleFuncOptions().mode(torch::kBilinear).padding_mode(torch::kZeros).align_corners(true));
 /// ```
 struct TORCH_API GridSampleFuncOptions {
-  typedef std::variant<enumtype::kBilinear, enumtype::kNearest> mode_t;
+  typedef std::variant<enumtype::kBilinear, enumtype::kNearest, enumtype::kBicubic> mode_t;
   typedef std::
       variant<enumtype::kZeros, enumtype::kBorder, enumtype::kReflection>
           padding_mode_t;

--- a/torch/csrc/api/include/torch/nn/options/vision.h
+++ b/torch/csrc/api/include/torch/nn/options/vision.h
@@ -16,9 +16,7 @@ namespace torch::nn::functional {
 /// F::GridSampleFuncOptions().mode(torch::kBilinear).padding_mode(torch::kZeros).align_corners(true));
 /// ```
 struct TORCH_API GridSampleFuncOptions {
-  typedef std::
-      variant<enumtype::kBilinear, enumtype::kNearest, enumtype::kBicubic>
-          mode_t;
+  typedef std::variant<enumtype::kBilinear, enumtype::kNearest, enumtype::kBicubic> mode_t;
   typedef std::
       variant<enumtype::kZeros, enumtype::kBorder, enumtype::kReflection>
           padding_mode_t;


### PR DESCRIPTION
When bicubic interpolation was added to grid_sampler in #44780, `GridSampleFuncOptions` was not updated to allow a user to use bicubic mode in LibTorch, even though the function could handle it. This PR fixes the parity such that LibTorch's  `torch::nn::functional::grid_sample` behaves the same as PyTorch's `torch.nn.functional.grid_sample`.

Existing users can directly use `torch::grid_sampler` but must know what int to pass for the interpolation (2 for bicubic) and padding mode parameters, which is not ideal.

