### PR TITLE
[Accelerator][Chore] Use existing `acc` when raising an error

### DIFF
--- a/torch/accelerator/_utils.py
+++ b/torch/accelerator/_utils.py
@@ -16,7 +16,7 @@ def _get_device_index(device: _device_t, optional: bool = False) -> int:
             raise RuntimeError("Accelerator expected")
         if acc.type != device.type:
             raise ValueError(
-                f"{device.type} doesn't match the current accelerator {torch.accelerator.current_accelerator()}."
+                f"{device.type} doesn't match the current accelerator {acc}."
             )
         device_index = device.index
     if device_index is None:


### PR DESCRIPTION
As the title said, `acc` already exists so we just use it instead of calling `current_accelerator()` again.

cc: @albanD @guangyey @FFFrog 