### PR TITLE
Pin all root requirements to major versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,23 +1,23 @@
 # Python dependencies required for development
-astunparse
+astunparse~=1.6
 build[uv]  # for building sdist and wheel
 cmake>=3.27
-expecttest>=0.3.0
-filelock
-fsspec
-hypothesis
-jinja2
-lintrunner ; platform_machine != "s390x"
-networkx
-ninja
-numpy
-optree>=0.13.0
-packaging
-psutil
-pyyaml
-requests
+expecttest~=0.3.0
+filelock~=3.18
+fsspec==2025.3.2
+hypothesis~=6.130
+jinja2~=3.1
+lintrunner~=0.12.7 ; platform_machine != "s390x"
+networkx~=3.4
+ninja~=1.11
+numpy~=2.0
+optree~=0.15.0
+packaging~=24.2
+psutil~=7.0
+PyYAML~=6.0
+requests~=2.32
 # setuptools develop deprecated on 80.0
 setuptools>=62.3.0,<80.0
-sympy>=1.13.3
-types-dataclasses
-typing-extensions>=4.10.0
+sympy>=1.13.3,<2
+types-dataclasses~=0.6.6
+typing-extensions~=4.13


### PR DESCRIPTION
Builds regularly fail due to major changes in build packages (most recently #150149), should we pin all the root [`requirements.txt`](https://github.com/pytorch/pytorch/blob/a106842ea8be6eb17b368de16d9c107c12b809bc/requirements.txt) to at least major version?

I made this a draft because I didn't really know the right solution, but
- [pyproject.toml](https://github.com/pytorch/pytorch/blob/a106842ea8be6eb17b368de16d9c107c12b809bc/pyproject.toml#L2) has different build-requirements to requirements.txt? Which one is canonical? And should we have 2?
- The manylinux CI builds seems to `pip install -r requirements.txt` but the Ubuntu unit testing CI uses `pip install -r requirements-ci.txt`. @malfet [suggested here](https://github.com/pytorch/pytorch/pull/138338#pullrequestreview-2379132987) that we should pin build requirements in CI but not for local development, should we have another set of requirements for just manylinux?
- Should the requirements be baked into the builder Docker images? At least then we can build with known good build dependencies by choosing a specific commit of the builder image (e.g. [cpu-aarch64-af5c1b96e251422ad5fb05f98c1f0095f9c9d1cf](https://hub.docker.com/layers/pytorch/manylinuxaarch64-builder/cpu-aarch64-af5c1b96e251422ad5fb05f98c1f0095f9c9d1cf/images/sha256-f41083e96d23c3d2a1e6777f23fcf371979845eab129c25997f552a6d8023ad4)). At the moment, the CI build scripts do `pip install`, but this could be done in the `Dockerfile`, it would have the added benefit of speeding up the CI and making the builds more reproducible.