### PR TITLE
Code Clean: Remove python3.8 specific code because PyTorch now need Python3.9 and later

### DIFF
--- a/test/torch_np/numpy_tests/core/test_dtype.py
+++ b/test/torch_np/numpy_tests/core/test_dtype.py
@@ -325,11 +325,6 @@ class TestMisc(TestCase):
         # test for https://github.com/numpy/numpy/pull/16574#issuecomment-642660971
         assert np.dtype(dtype=np.float64) == np.dtype(np.float64)
 
-    @skipif(sys.version_info >= (3, 9), reason="Requires python 3.9")
-    def test_class_getitem_38(self) -> None:
-        with pytest.raises(TypeError):
-            np.dtype[Any]
-
 
 class TestFromDTypeAttribute(TestCase):
     def test_simple(self):

--- a/test/torch_np/numpy_tests/core/test_dtype.py
+++ b/test/torch_np/numpy_tests/core/test_dtype.py
@@ -3,7 +3,6 @@
 import functools
 import operator
 import pickle
-import sys
 import types
 from itertools import permutations
 from typing import Any

--- a/test/torch_np/numpy_tests/core/test_scalar_methods.py
+++ b/test/torch_np/numpy_tests/core/test_scalar_methods.py
@@ -5,7 +5,6 @@ Test the scalar constructors, which also do type-coercion
 """
 import fractions
 import functools
-import sys
 import types
 from typing import Any
 from unittest import skipIf as skipif, SkipTest

--- a/test/torch_np/numpy_tests/core/test_scalar_methods.py
+++ b/test/torch_np/numpy_tests/core/test_scalar_methods.py
@@ -222,15 +222,6 @@ class TestClassGetItem(TestCase):
         assert np.number[Any]
 
 
-@instantiate_parametrized_tests
-class TestClassGetitemMisc(TestCase):
-    @skipif(sys.version_info >= (3, 9), reason="Requires python 3.8")
-    @parametrize("cls", [np.number, np.complexfloating, np.int64])
-    def test_class_getitem_38(self, cls: type[np.number]) -> None:
-        with pytest.raises(TypeError):
-            cls[Any]
-
-
 @skip(reason="scalartype(...).bit_count() not implemented")
 @instantiate_parametrized_tests
 class TestBitCount(TestCase):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #150839
* #150838
* __->__ #150834

As the title stated.