### PR TITLE
Expand allowed_getattr_types_for_subgm to torch.Tensor

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -7301,7 +7301,6 @@ def forward(self, b_a_buffer, x):
         self.assertEqual(ep.module()(init, xs), M()(init, xs))
 
     # map_fn references module outside the module hierarchy
-    @unittest.expectedFailure
     def test_map_buffers(self):
         class M1(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -149,7 +149,12 @@ class Verifier(metaclass=_VerifierMeta):
 
     def allowed_getattr_types_for_subgm(self) -> tuple[type[Any], ...]:
         # subgm in HOP's argument could has have getattr(weight) nodes, thus stateful
-        return (torch.fx.GraphModule, torch.nn.parameter.Parameter, torch.utils._pytree.TreeSpec)
+        return (
+            torch.fx.GraphModule,
+            torch.nn.parameter.Parameter,
+            torch.Tensor,  # for buffer and constant tensor
+            torch.utils._pytree.TreeSpec
+        )
 
     def check_valid_op(self, op):
         pass
@@ -276,7 +281,7 @@ class Verifier(metaclass=_VerifierMeta):
 
                     if not isinstance(attr, _allowed_getattr_types(is_toplevel_gm)):
                         raise SpecViolationError(
-                            f"Invalid get_attr type {type(attr)}. \n"
+                            f"Invalid get_attr type {type(attr)} on target {node.target}. \n"
                             f"Valid get_attr types: {_allowed_getattr_types(is_toplevel_gm)}"
                         )
 


### PR DESCRIPTION
Summary:
att

regular weight has the type of torch.nn.parameter.Parameter
buffer and tensor constant has the type of torch.Tensor

both types are valid.

Test Plan: CI

Differential Revision: D72657275


