### PR TITLE
Fix torchscript issues with reference quantized modules

### DIFF
--- a/torch/ao/nn/quantized/reference/modules/utils.py
+++ b/torch/ao/nn/quantized/reference/modules/utils.py
@@ -193,11 +193,12 @@ def _quantize_weight_decomposed(
     weight_quant_min: typing.Optional[int],
     weight_quant_max: typing.Optional[int],
 ) -> torch.Tensor:
-    _DTYPE_TO_QVALUE_BOUNDS = {
+    _DTYPE_TO_QVALUE_BOUNDS: dict[torch.dtype, tuple[int, int]] = {
         torch.uint8: (0, 255),
         torch.int8: (-128, 127),
-        torch.int32: (-(2**31), 2**31 - 1),
+        torch.int32: (int(-(2**31)), int(2**31 - 1)),
     }
+
     # TODO: add an util function for converting qdtype to dtype
     _QDTYPE_TO_UNDERLYING_INT_REPR_DTYPE = {
         torch.quint8: torch.uint8,
@@ -255,10 +256,10 @@ def _dequantize_weight_decomposed(
     weight_quant_max: typing.Optional[int],
 ) -> torch.Tensor:
     # TODO: get the quant_min and quant_max from activation_post_process
-    _DTYPE_TO_QVALUE_BOUNDS = {
+    _DTYPE_TO_QVALUE_BOUNDS: dict[torch.dtype, tuple[int, int]] = {
         torch.uint8: (0, 255),
         torch.int8: (-128, 127),
-        torch.int32: (-(2**31), 2**31 - 1),
+        torch.int32: (int(-(2**31)), int(2**31 - 1)),
     }
     # TODO: add an util function for converting qdtype to dtype
     _QDTYPE_TO_UNDERLYING_INT_REPR_DTYPE = {

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -129,6 +129,7 @@ _constant_types = (
     torch.device,
     torch.layout,
     torch.dtype,
+    torch.qscheme,
 )
 
 

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -486,6 +486,9 @@ def try_ann_to_type(ann, loc, rcb=None):
         return StreamObjType.get()
     if ann is torch.dtype:
         return IntType.get()  # dtype not yet bound in as its own type
+    if ann is torch.qscheme:
+        return IntType.get()  # qscheme not yet bound in as its own type
+
     if inspect.isclass(ann) and issubclass(ann, enum.Enum):
         if _get_script_class(ann) is None:
             scripted_class = torch.jit._script._recursive_compile_class(ann, loc)


### PR DESCRIPTION
Summary:
The reference quantized modules for linear / conv / etc fail to torchscript due to two issues

(1) The type of torch.qscheme doesn't script 
(2) The "_DTYPE_TO_QVALUE_BOUNDS" values were resolving to union[float, int] instead of just int. We fix that with a hard cast.

See: <internal post> + comments for more context

Test Plan: unit tests + fixing this NB N6923590

Differential Revision: D72652616




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel