### PR TITLE
[export] Refine draft-export CVE with Dim.AUTO

### DIFF
--- a/test/export/test_draft_export.py
+++ b/test/export/test_draft_export.py
@@ -303,9 +303,7 @@ class TestDraftExport(TestCase):
         report = ep._report
 
         self.assertEqual(len(report.failures), 1)
-        self.assertEqual(
-            report.failures[0].failure_type, FailureType.CONSTRAINT_VIOLATION_ERROR
-        )
+        self.assertEqual(report.failures[0].failure_type, FailureType.GUARD_ADDED)
 
         inp = (torch.randn(3, 3),)
         self.assertEqual(ep.module()(*inp), M()(*inp))


### PR DESCRIPTION
Instead of using refine_dynamic_shapes_from_suggested_fixes to fix ConstraintViolationErrors in draft-export, we can just convert the dims to Dim.AUTO, which is less error prone