### PR TITLE
[c10d][fr] Refactor analysis script for modularization and reusing for coalesce collectives

### DIFF
--- a/tools/flight_recorder/components/builder.py
+++ b/tools/flight_recorder/components/builder.py
@@ -16,8 +16,6 @@ from tools.flight_recorder.components.types import (
     Database,
     EntryState,
     Group,
-    MatchInfo,
-    MatchState,
     MatchStateRecord,
     Membership,
     NCCLCall,
@@ -26,15 +24,14 @@ from tools.flight_recorder.components.types import (
 )
 from tools.flight_recorder.components.utils import (
     align_trace_from_beginning,
+    check_current_entry_match,
     check_no_missing_dump_files,
-    check_size_alltoall,
     check_version,
+    error_analysis,
     find_coalesced_group,
-    format_frames,
     get_version_detail,
     just_print_entries,
     match_coalesced_groups,
-    match_one_event,
 )
 
 
@@ -127,158 +124,6 @@ def build_groups_memberships(
     return groups, _groups, memberships, _memberships, _pg_guids
 
 
-def check_current_entry_match(
-    all_entries: dict[int, list[dict[str, Any]]],
-    _pg_guids: dict[tuple[str, int], str],
-    pg_info: tuple[str, str],
-    current_entry: dict[str, Any],
-    _memberships: dict[str, set[Any]],
-    mismatch: dict[str, int],
-    match_record: MatchStateRecord,
-) -> None:
-    pg_name, desc = pg_info[0], pg_info[1]
-    for o in match_record.expected_ranks.intersection(set(match_record.other_ranks)):
-        for i, e in enumerate(all_entries[o]):  # type: ignore[index]
-            # step over ops from other PGs
-            # only check match state when seq_id matches
-            if (
-                _pg_guids[(e["process_group"][0], o)] == pg_name
-                and e["process_group"][1] == desc
-                and e["collective_seq_id"] == match_record.entry_state.collective_seq_id
-            ):
-                match_info = match_one_event(current_entry, e, _memberships, pg_name)
-                if (
-                    match_info.state in [MatchState.FULLY_MATCHED, MatchState.UNDECIDED]
-                    and mismatch[pg_name] == 0
-                ):
-                    match_record.found_ranks.add(o)
-                    match_record.found_idx[o] = i
-                    match_record.has_undecided_case = (
-                        match_info.state == MatchState.UNDECIDED
-                    )
-                else:
-                    match_record.candidate_ranks.add(o)
-                    match_record.candidate_idx[o] = i
-                    if match_info.state not in [
-                        MatchState.FULLY_MATCHED,
-                        MatchState.UNDECIDED,
-                    ]:
-                        # Here we assume the current rank is not the source of the error.
-                        # But it's possible that the current rank is the culprit, then users will
-                        # see lots of normal ranks reported as culprit.
-                        # TODO: we need to figure out a better way to handle the case mentioned above.
-                        match_record.errors.add((o, match_info))
-                break
-
-
-def error_analysis(
-    all_entries: dict[int, list[dict[str, Any]]],
-    match_record: MatchStateRecord,
-    dumps_ranks: set[int],
-    first_rank: int,
-    current_entry: dict[str, Any],
-    mismatch: dict[str, int],
-    version: tuple[int, int],
-    pg_name: str,
-) -> None:
-    major_v, minor_v = version[0], version[1]
-    # case one: not every rank join the collective or in the flight recorder.
-    if (
-        match_record.candidate_ranks | match_record.found_ranks
-    ) != match_record.expected_ranks and match_record.expected_ranks - (
-        match_record.candidate_ranks | match_record.found_ranks
-    ) <= dumps_ranks:
-        mismatch[pg_name] += 1
-        logger_msg = "Not all ranks joining collective, sequence number: %s"
-        missing_ranks = match_record.expected_ranks - (
-            match_record.candidate_ranks | match_record.found_ranks
-        )
-        match_record.entry_state.log(
-            logger, logger_msg, format_frames, missing_ranks=missing_ranks
-        )
-        match_record.candidate_ranks.update(match_record.found_ranks)
-        match_record.candidate_idx.update(match_record.found_idx)
-        match_record.found_idx.clear()
-        match_record.found_ranks.clear()
-    elif (
-        len(match_record.candidate_ranks) == 1
-        and dumps_ranks == match_record.expected_ranks
-    ):
-        # case two: alltoall or alltoall_base case.
-        if match_record.has_undecided_case:
-            alltoall_cases = [current_entry] + [
-                all_entries[o][match_record.found_idx[o]]
-                for o in match_record.found_ranks
-            ]
-            fail_check, total_input_numel, total_output_numel = check_size_alltoall(
-                alltoall_cases
-            )
-            if major_v <= 2 and minor_v <= 3:
-                # We don't log the input/output sizes for alltoall before v2.4,
-                # so we don't consider the size mismatch as an error for now.
-                fail_check = False
-            if fail_check:
-                # When we see errors in all_to_all, it's hard to tell which rank is the source of the error.
-                mismatch[pg_name] += 1
-                logger_msg = (
-                    "Input/output mismatch in the collective sequence number: %s"
-                )
-                match_record.entry_state.log(
-                    logger,
-                    logger_msg,
-                    format_frames,
-                    total_numel=(total_input_numel, total_output_numel),
-                )
-                match_record.candidate_ranks.update(match_record.found_ranks)
-                match_record.candidate_idx.update(match_record.found_idx)
-                match_record.found_idx.clear()
-                match_record.found_ranks.clear()
-                match_record.errors.add(
-                    (first_rank, MatchInfo(MatchState.SIZE_OR_SYNTAX_MISMATCH))
-                )
-            else:
-                match_record.found_ranks.update(match_record.candidate_ranks)
-                match_record.found_idx.update(match_record.candidate_idx)
-                match_record.candidate_idx.clear()
-                match_record.candidate_ranks.clear()
-        # case three: all joined and everything matches on all ranks.
-        else:
-            match_record.found_ranks.update(match_record.candidate_ranks)
-            match_record.found_idx.update(match_record.candidate_idx)
-            match_record.candidate_idx.clear()
-            match_record.candidate_ranks.clear()
-    # case four: mismatch cases due to not same type, size mismatch or state mismatch.
-    elif len(match_record.errors) > 0:
-        mismatch[pg_name] += 1
-        logger_msg = "Collective sequence number: %s has errors"
-        match_record.entry_state.log(
-            logger, logger_msg, format_frames, errors=match_record.errors
-        )
-        match_record.candidate_ranks.update(match_record.found_ranks)
-        match_record.candidate_idx.update(match_record.found_idx)
-        match_record.found_idx.clear()
-        match_record.found_ranks.clear()
-    # partial analysis case when we cannot decide what's wrong with this collective entry.
-    else:
-        match_record.candidate_ranks.update(match_record.found_ranks)
-        match_record.candidate_idx.update(match_record.found_idx)
-        match_record.found_idx.clear()
-        match_record.found_ranks.clear()
-        if match_record.expected_ranks - dumps_ranks:
-            mismatch[pg_name] += 1
-            logger.info(
-                "We cannot decide what's wrong with this collective entry "
-                "because we missed FR dumps from ranks (%s) so we don't have enough "
-                "information. If you want to debug further use -j to dump all raw trace",
-                str(match_record.expected_ranks - dumps_ranks),
-            )
-        else:
-            logger.info(
-                "No errors found for this collective entry, There could be some "
-                "other reasons why we see collective timeout."
-            )
-
-
 def build_collectives(
     all_entries: dict[int, list[dict[str, Any]]],
     _groups: dict[str, Group],
@@ -346,12 +191,13 @@ def build_collectives(
         # lets match the first collective! we need to know which ranks are involved, and ensure that this same
         # collective is also the first one on those ranks within that group
         entries = all_entries[first_rank]
-        desc = entries[0]["process_group"][1]
+        current_entry = entries[0]
+        desc = current_entry["process_group"][1]
         # For db build and logs printing, we want to use the original pg_name, not the hash one.
-        original_pg_name = entries[0]["process_group"][0]
+        original_pg_name = current_entry["process_group"][0]
         pg_name = _pg_guids[(original_pg_name, first_rank)]
         expected_ranks = set(_memberships[pg_name])
-        entry_state = EntryState(entries[0], expected_ranks)
+        entry_state = EntryState(current_entry, expected_ranks)
         match_record = MatchStateRecord(
             expected_ranks=expected_ranks,
             other_ranks=other_ranks,
@@ -418,7 +264,7 @@ def build_collectives(
                 all_entries,
                 _pg_guids,
                 (pg_name, desc),
-                entries[0],
+                current_entry,
                 _memberships,
                 mismatch,
                 match_record,
@@ -430,7 +276,7 @@ def build_collectives(
                 match_record,
                 dumps_ranks,
                 first_rank,
-                entries[0],
+                current_entry,
                 mismatch,
                 get_version_detail(version),
                 pg_name,

--- a/tools/flight_recorder/components/types.py
+++ b/tools/flight_recorder/components/types.py
@@ -560,3 +560,26 @@ class Op:
                 else MatchInfo(MatchState.SIZE_OR_SYNTAX_MISMATCH)
             )
         return MatchInfo(MatchState.FULLY_MATCHED)
+
+
+class MatchStateRecord:
+    def __init__(
+        self,
+        expected_ranks: set[int],
+        other_ranks: list[int],
+        entry_state: EntryState,
+        candidate_ranks: set[int],
+        candidate_idx: dict[int, int],
+        found_ranks: set[int],
+        found_idx: dict[int, int],
+        errors: set[tuple[int, MatchInfo]],
+    ) -> None:
+        self.expected_ranks = expected_ranks
+        self.other_ranks = other_ranks
+        self.entry_state = entry_state
+        self.candidate_ranks = candidate_ranks
+        self.candidate_idx = candidate_idx
+        self.found_ranks = found_ranks
+        self.found_idx = found_idx
+        self.errors = errors
+        self.has_undecided_case = False

--- a/tools/flight_recorder/components/utils.py
+++ b/tools/flight_recorder/components/utils.py
@@ -13,6 +13,7 @@ from tools.flight_recorder.components.types import (
     Group,
     MatchInfo,
     MatchState,
+    MatchStateRecord,
     Membership,
     Op,
     P2P,
@@ -182,6 +183,158 @@ def check_size_alltoall(alltoall_cases: list[dict[str, Any]]) -> tuple[bool, int
         input_numel += math.prod(e["input_sizes"][0])
         output_numel += math.prod(e["output_sizes"][0])
     return input_numel != output_numel, input_numel, output_numel
+
+
+def check_current_entry_match(
+    all_entries: dict[int, list[dict[str, Any]]],
+    _pg_guids: dict[tuple[str, int], str],
+    pg_info: tuple[str, str],
+    current_entry: dict[str, Any],
+    _memberships: dict[str, set[Any]],
+    mismatch: dict[str, int],
+    match_record: MatchStateRecord,
+) -> None:
+    pg_name, desc = pg_info[0], pg_info[1]
+    for o in match_record.expected_ranks.intersection(set(match_record.other_ranks)):
+        for i, e in enumerate(all_entries[o]):  # type: ignore[index]
+            # step over ops from other PGs
+            # only check match state when seq_id matches
+            if (
+                _pg_guids[(e["process_group"][0], o)] == pg_name
+                and e["process_group"][1] == desc
+                and e["collective_seq_id"] == match_record.entry_state.collective_seq_id
+            ):
+                match_info = match_one_event(current_entry, e, _memberships, pg_name)
+                if (
+                    match_info.state in [MatchState.FULLY_MATCHED, MatchState.UNDECIDED]
+                    and mismatch[pg_name] == 0
+                ):
+                    match_record.found_ranks.add(o)
+                    match_record.found_idx[o] = i
+                    match_record.has_undecided_case = (
+                        match_info.state == MatchState.UNDECIDED
+                    )
+                else:
+                    match_record.candidate_ranks.add(o)
+                    match_record.candidate_idx[o] = i
+                    if match_info.state not in [
+                        MatchState.FULLY_MATCHED,
+                        MatchState.UNDECIDED,
+                    ]:
+                        # Here we assume the current rank is not the source of the error.
+                        # But it's possible that the current rank is the culprit, then users will
+                        # see lots of normal ranks reported as culprit.
+                        # TODO: we need to figure out a better way to handle the case mentioned above.
+                        match_record.errors.add((o, match_info))
+                break
+
+
+def error_analysis(
+    all_entries: dict[int, list[dict[str, Any]]],
+    match_record: MatchStateRecord,
+    dumps_ranks: set[int],
+    first_rank: int,
+    current_entry: dict[str, Any],
+    mismatch: dict[str, int],
+    version: tuple[int, int],
+    pg_name: str,
+) -> None:
+    major_v, minor_v = version[0], version[1]
+    # case one: not every rank join the collective or in the flight recorder.
+    if (
+        match_record.candidate_ranks | match_record.found_ranks
+    ) != match_record.expected_ranks and match_record.expected_ranks - (
+        match_record.candidate_ranks | match_record.found_ranks
+    ) <= dumps_ranks:
+        mismatch[pg_name] += 1
+        logger_msg = "Not all ranks joining collective, sequence number: %s"
+        missing_ranks = match_record.expected_ranks - (
+            match_record.candidate_ranks | match_record.found_ranks
+        )
+        match_record.entry_state.log(
+            logger, logger_msg, format_frames, missing_ranks=missing_ranks
+        )
+        match_record.candidate_ranks.update(match_record.found_ranks)
+        match_record.candidate_idx.update(match_record.found_idx)
+        match_record.found_idx.clear()
+        match_record.found_ranks.clear()
+    elif (
+        len(match_record.candidate_ranks) == 1
+        and dumps_ranks == match_record.expected_ranks
+    ):
+        # case two: alltoall or alltoall_base case.
+        if match_record.has_undecided_case:
+            alltoall_cases = [current_entry] + [
+                all_entries[o][match_record.found_idx[o]]
+                for o in match_record.found_ranks
+            ]
+            fail_check, total_input_numel, total_output_numel = check_size_alltoall(
+                alltoall_cases
+            )
+            if major_v <= 2 and minor_v <= 3:
+                # We don't log the input/output sizes for alltoall before v2.4,
+                # so we don't consider the size mismatch as an error for now.
+                fail_check = False
+            if fail_check:
+                # When we see errors in all_to_all, it's hard to tell which rank is the source of the error.
+                mismatch[pg_name] += 1
+                logger_msg = (
+                    "Input/output mismatch in the collective sequence number: %s"
+                )
+                match_record.entry_state.log(
+                    logger,
+                    logger_msg,
+                    format_frames,
+                    total_numel=(total_input_numel, total_output_numel),
+                )
+                match_record.candidate_ranks.update(match_record.found_ranks)
+                match_record.candidate_idx.update(match_record.found_idx)
+                match_record.found_idx.clear()
+                match_record.found_ranks.clear()
+                match_record.errors.add(
+                    (first_rank, MatchInfo(MatchState.SIZE_OR_SYNTAX_MISMATCH))
+                )
+            else:
+                match_record.found_ranks.update(match_record.candidate_ranks)
+                match_record.found_idx.update(match_record.candidate_idx)
+                match_record.candidate_idx.clear()
+                match_record.candidate_ranks.clear()
+        # case three: all joined and everything matches on all ranks.
+        else:
+            match_record.found_ranks.update(match_record.candidate_ranks)
+            match_record.found_idx.update(match_record.candidate_idx)
+            match_record.candidate_idx.clear()
+            match_record.candidate_ranks.clear()
+    # case four: mismatch cases due to not same type, size mismatch or state mismatch.
+    elif len(match_record.errors) > 0:
+        mismatch[pg_name] += 1
+        logger_msg = "Collective sequence number: %s has errors"
+        match_record.entry_state.log(
+            logger, logger_msg, format_frames, errors=match_record.errors
+        )
+        match_record.candidate_ranks.update(match_record.found_ranks)
+        match_record.candidate_idx.update(match_record.found_idx)
+        match_record.found_idx.clear()
+        match_record.found_ranks.clear()
+    # partial analysis case when we cannot decide what's wrong with this collective entry.
+    else:
+        match_record.candidate_ranks.update(match_record.found_ranks)
+        match_record.candidate_idx.update(match_record.found_idx)
+        match_record.found_idx.clear()
+        match_record.found_ranks.clear()
+        if match_record.expected_ranks - dumps_ranks:
+            mismatch[pg_name] += 1
+            logger.info(
+                "We cannot decide what's wrong with this collective entry "
+                "because we missed FR dumps from ranks (%s) so we don't have enough "
+                "information. If you want to debug further use -j to dump all raw trace",
+                str(match_record.expected_ranks - dumps_ranks),
+            )
+        else:
+            logger.info(
+                "No errors found for this collective entry, There could be some "
+                "other reasons why we see collective timeout."
+            )
 
 
 def find_coalesced_group(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #150882
* __->__ #150881

Trying to make the code of FR analysis more reusable and modularized. So we split core error analysis logic into separate functions.

This PR mostly is shuffle around the code a bit.

Differential Revision: [D72690120](https://our.internmc.facebook.com/intern/diff/D72690120)