### PR TITLE
[Docs] Clarify behavior when integer dtype is used with requires_grad=True in `tensor.to()`

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -5198,8 +5198,8 @@ inferred from the arguments of ``self.to(*args, **kwargs)``.
     :class:`torch.dtype` and :class:`torch.device`.
     If ``self`` requires gradients (``requires_grad=True``) but the target
     ``dtype`` specified is an integer type, the returned tensor will implicitly
-    set ``requires_grad=False``. This is because only Tensors of floating
-    point and complex dtype can require gradients.
+    set ``requires_grad=False``. This is because only tensors with
+    floating-point or complex dtype can require gradients.
 
 Here are the ways to call ``to``:
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -5199,7 +5199,7 @@ inferred from the arguments of ``self.to(*args, **kwargs)``.
     If ``self`` requires gradients (``requires_grad=True``) but the target
     ``dtype`` specified is an integer type, the returned tensor will implicitly
     set ``requires_grad=False``. This is because only tensors with
-    floating-point or complex dtype can require gradients.
+    floating-point or complex dtypes can require gradients.
 
 Here are the ways to call ``to``:
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -5196,6 +5196,10 @@ inferred from the arguments of ``self.to(*args, **kwargs)``.
     has the correct :class:`torch.dtype` and :class:`torch.device`, then ``self`` is returned.
     Otherwise, the returned tensor is a copy of ``self`` with the desired
     :class:`torch.dtype` and :class:`torch.device`.
+    If ``self`` requires gradients (``requires_grad=True``) but the target
+    `dtype` specified is an integer type, the returned tensor will implicitly
+    set ``requires_grad=False``. This is because only Tensors of floating
+    point and complex dtype can require gradients.
 
 Here are the ways to call ``to``:
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -5197,7 +5197,7 @@ inferred from the arguments of ``self.to(*args, **kwargs)``.
     Otherwise, the returned tensor is a copy of ``self`` with the desired
     :class:`torch.dtype` and :class:`torch.device`.
     If ``self`` requires gradients (``requires_grad=True``) but the target
-    `dtype` specified is an integer type, the returned tensor will implicitly
+    ``dtype`` specified is an integer type, the returned tensor will implicitly
     set ``requires_grad=False``. This is because only Tensors of floating
     point and complex dtype can require gradients.
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -5196,6 +5196,9 @@ inferred from the arguments of ``self.to(*args, **kwargs)``.
     has the correct :class:`torch.dtype` and :class:`torch.device`, then ``self`` is returned.
     Otherwise, the returned tensor is a copy of ``self`` with the desired
     :class:`torch.dtype` and :class:`torch.device`.
+
+.. note::
+
     If ``self`` requires gradients (``requires_grad=True``) but the target
     ``dtype`` specified is an integer type, the returned tensor will implicitly
     set ``requires_grad=False``. This is because only tensors with


### PR DESCRIPTION
Fixes #150618

Related comment: https://github.com/pytorch/pytorch/issues/3226#issuecomment-489362234
