### PR TITLE
[async TP] Fix handling of case where scatter dim = 0 for 2D output tensor

### DIFF
--- a/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
+++ b/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
@@ -463,35 +463,6 @@ class MicroPipelineTPTest(TestCase):
         self.assertIn("fused_scaled_matmul_reduce_scatter", code)
         self.assertNotIn("reduce_scatter_tensor", code)
 
-    @skipIfRocm
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
-    @fresh_inductor_cache()
-    def test_no_all_gathers_or_reduce_scatters(self):
-        group = dist.group.WORLD
-
-        def no_matching_pattern(
-            A: torch.Tensor,
-            B: torch.Tensor,
-        ) -> torch.Tensor:
-            """
-            Performs some ops which will not have any all-gather-matmul or matmul-reduce-scatter patterns.
-            """
-            C = A * B
-            return all_reduce(C, "sum", group)
-
-        A = torch.rand(2, 16, 32, device="cuda").to(torch.bfloat16)
-        B = torch.rand(16, 32, device="cuda").to(torch.bfloat16)
-
-        gm = _make_post_grad_fx(no_matching_pattern, A, B)
-
-        with _test_mode():
-            self.assertRaisesRegex(
-                AssertionError,
-                "async TP found no matching all-gather/reduce-scatter patterns for fusion",
-                micro_pipeline_tp_pass,
-                gm.graph,
-            )
-
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @parametrize("shard_dim", [0, 1])
     @fresh_inductor_cache()

--- a/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
+++ b/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
@@ -16,7 +16,6 @@ from torch._inductor.fx_passes.post_grad import remove_noop_ops, view_to_reshape
 from torch._inductor.utils import fresh_inductor_cache, run_and_get_triton_code
 from torch.distributed._functional_collectives import (
     all_gather_tensor,
-    all_reduce,
     reduce_scatter_tensor,
 )
 from torch.distributed._symmetric_memory import _test_mode

--- a/torch/_inductor/fx_passes/micro_pipeline_tp.py
+++ b/torch/_inductor/fx_passes/micro_pipeline_tp.py
@@ -1067,7 +1067,7 @@ def micro_pipeline_tp_pass(graph: torch.fx.Graph):
         ]
 
     if not all_gathers and not reduce_scatters:
-        raise AssertionError(
+        log.warning(
             "async TP found no matching all-gather/reduce-scatter patterns for fusion"
         )
 

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -1252,7 +1252,7 @@ def _fused_scaled_matmul_reduce_scatter_impl(
     A_with_scatter_dim_0 = A.movedim(scatter_dim_after_maybe_reshape, 0)
 
     # To handle case where A is 3D+, reshape to 2D to prepare for mm which requires 2D inputs.
-    A_with_scatter_dim_0 = A.flatten(0, -2)
+    A_with_scatter_dim_0 = A_with_scatter_dim_0.flatten(0, -2)
 
     # Parition A along the first dim to prepare for sharding across TP process group.
     A_shards = A_with_scatter_dim_0.chunk(group.size())
@@ -1326,9 +1326,8 @@ def _fused_scaled_matmul_reduce_scatter_impl(
     )
 
     # Final 3D+ output shape must be scattered along original scatter dim as well.
-    final_out_shape = [*output_shape[:-1], B.shape[-1]]
-    final_out_shape[orig_scatter_dim] //= group.size()
-    out = reduced_out.view(*final_out_shape)
+    output_shape[orig_scatter_dim] //= group.size()
+    out = reduced_out.view(*output_shape)
     return out
 
 

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -1331,7 +1331,7 @@ def _fused_scaled_matmul_reduce_scatter_impl(
         dim=orig_scatter_dim,  # Reduce along the origal scatter dim (`group_size`)
     )
 
-    # Final 3D+ output shape must be scattered along original scatter dim as well.
+    # Output shape must be scattered along original scatter dim as well.
     output_shape[orig_scatter_dim] //= group.size()
     out = reduced_out.view(*output_shape)
     return out

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -1320,7 +1320,6 @@ def _fused_scaled_matmul_reduce_scatter_impl(
     # it is now dim 1 in this tensor, since this new `[group_size]` dim was prepended.
     stacked_partial_scatter_dim = orig_scatter_dim if orig_scatter_dim > 0 else 1
     stacked_partials_3D_leading_dims[stacked_partial_scatter_dim] //= group.size()
-    
 
     # Ensures that the transpose and reduction produce contiguous result
     # in a single reduction kernel.


### PR DESCRIPTION
## Summary of changes

1. Change assertion to a warning, when no all gather or reduce scatter patterns are found, and remove the corresponding unit test. It seems some valid TP graphs may not have any pattern matches, from what I can see. 
2. Fix wrong variable name being referenced (`A_with_scatter_dim_0` instead of just `A`)
3. Simplify reshaping to target output shape (don't need to recalculate output shape)
4. When "A" tensor is 2D, so we are doing doing a 2D x 2D scaled mm, we need to fix our handling of the case where the scatter dim is 0. When scatter dim is 0 for the 2D scaled mm output shape, this is actually dim 1 in the unreduced stacked partial scaled mm outputs, which has a (logical) shape of `(group_size, M//group_size, N)`. To summarize:
    - Unreduced stacked partials are of shape `(M, N)`
    - We view as `(group size, M//group_size, N)` and reduce along the scatter dim (`group_size` / dim 0).
    - Reduced output (`reduced_out`) has shape (M//group_size, N)


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov 