### PR TITLE
[BC-breaking] Set NonStrict as default for export_for_training

### DIFF
--- a/test/export/test_export_training_ir_to_run_decomp.py
+++ b/test/export/test_export_training_ir_to_run_decomp.py
@@ -14,15 +14,15 @@ test_classes = {}
 
 
 def mocked_training_ir_to_run_decomp_export_strict(*args, **kwargs):
-    ep = torch.export.export_for_training(*args, **kwargs)
+    if "strict" in kwargs:
+        ep = torch.export.export_for_training(*args, **kwargs)
+    else:
+        ep = torch.export.export_for_training(*args, **kwargs, strict=True)
     return ep.run_decompositions({})
 
 
 def mocked_training_ir_to_run_decomp_export_non_strict(*args, **kwargs):
-    if "strict" in kwargs:
-        ep = torch.export.export_for_training(*args, **kwargs)
-    else:
-        ep = torch.export.export_for_training(*args, **kwargs, strict=False)
+    ep = torch.export.export_for_training(*args, **kwargs)
 
     return ep.run_decompositions({})
 

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -551,10 +551,10 @@ def forward(self, x):
 
         serialized = ExportedProgramSerializer().serialize(ep)
         self.assertEqual(
-            serialized.exported_program.range_constraints["s77"].min_val, 2
+            serialized.exported_program.range_constraints[symint.name].min_val, 2
         )
         self.assertEqual(
-            serialized.exported_program.range_constraints["s77"].max_val, 3
+            serialized.exported_program.range_constraints[symint.name].max_val, 3
         )
 
     def test_kwargs_default(self) -> None:

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -78,7 +78,7 @@ def export_for_training(
     kwargs: Optional[dict[str, Any]] = None,
     *,
     dynamic_shapes: Optional[Union[dict[str, Any], tuple[Any], list[Any]]] = None,
-    strict: bool = True,
+    strict: bool = False,
     preserve_module_call_signature: tuple[str, ...] = (),
 ) -> ExportedProgram:
     """


### PR DESCRIPTION
Summary:
- Flip default value of `strict` argument from True to False on torch.export.export_for_training API
- All callsites have been updated to provide this argument explicitly to avoid behavior change.
- If you see any breakages, that means you may have a new callsite that is missed, please set `strict=True` explicitly to the callsite to mitigage.

Test Plan: CI

Differential Revision: D72724975




cc @ezyang @gchanan