### PR TITLE
all_reduce autograd

### DIFF
--- a/test/distributed/test_functional_api.py
+++ b/test/distributed/test_functional_api.py
@@ -789,6 +789,31 @@ class TestFunctionalAutograd(MultiThreadedTestCase):
             rs_tensor.sum().backward()
             self.assertEqual(input_tensor.grad, torch.full(output_size, fill_value=1.0))
 
+    @parametrize("compile", [True, False])
+    def test_all_reduce_autograd(self, compile: bool = True) -> None:
+        group = dist.group.WORLD.group_name
+
+        t = torch.ones([4], requires_grad=True)
+
+        def my_func(t: torch.Tensor) -> torch.Tensor:
+            assert t.requires_grad
+            out = ft_c.all_reduce_autograd(t * 1.0, "sum", group)
+            out = out + 0
+            return out
+
+        if compile:
+            compiled = torch.compile(my_func, fullgraph=True, backend="aot_eager")
+        else:
+            compiled = my_func
+
+        out = compiled(t)
+        self.assertEqual(out, torch.ones([4]) * self.world_size)
+        self.assertIsNotNone(out.grad_fn)
+        self.assertTrue(out.requires_grad)
+        loss = out.sum()
+        loss.backward()
+        self.assertEqual(t.grad, torch.ones([4]) * self.world_size)
+
 
 class TestFunctionalAutogradWithDistributedBackend(DistributedTestBase):
     @with_comms()

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -54,6 +54,60 @@ at::Tensor all_reduce(
   return all_reduce_(output, std::move(reduce_op), std::move(group_name));
 }
 
+class AllReduce
+    : public torch::autograd::Function<AllReduce> {
+ public:
+  static torch::autograd::Variable forward(
+      torch::autograd::AutogradContext* ctx,
+      const at::Tensor& input,
+      const std::string& reduce_op,
+      const std::string& group_name) {
+    ctx->saved_data["reduce_op"] = reduce_op;
+    ctx->saved_data["group_name"] = group_name;
+
+    return c10::Dispatcher::singleton()
+        .findSchemaOrThrow("_c10d_functional::all_reduce", "")
+        .typed<decltype(all_reduce)>()
+        .call(input, reduce_op, group_name);
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      const torch::autograd::variable_list& grad_out_list) {
+    const std::string& reduce_op = ctx->saved_data["reduce_op"].toStringRef();
+    const std::string& group_name = ctx->saved_data["group_name"].toStringRef();
+
+    DCHECK(grad_out_list.size() == 1);
+    const auto& grad_out = grad_out_list[0];
+
+    auto out =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("_c10d_functional::all_reduce", "")
+            .typed<decltype(all_gather_into_tensor)>()
+            .call(grad_out, reduce_op, group_name);
+
+    // do an explicit wait to avoid cuda stream issues
+    // TODO: track active cuda stream in wait
+    out = c10::Dispatcher::singleton()
+              .findSchemaOrThrow("_c10d_functional::wait_tensor", "")
+              .typed<decltype(c10d::wait_tensor)>()
+              .call(out);
+
+    return {
+        out,
+        at::Tensor(),
+        at::Tensor(),
+    };
+  }
+};
+
+at::Tensor all_reduce_autograd(
+    const at::Tensor& input,
+    const std::string reduce_op,
+    const std::string group_name) {
+  return AllReduce::apply(input, reduce_op, group_name);
+}
+
 std::vector<at::Tensor> all_reduce_coalesced_(
     std::vector<at::Tensor> inputs,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
@@ -524,6 +578,14 @@ TORCH_LIBRARY(_c10d_functional_autograd, m) {
       "str group_name) -> Tensor",
       torch::dispatch(
           c10::DispatchKey::Autograd, ::all_gather_into_tensor_autograd),
+      {at::Tag::pt2_compliant_tag});
+  m.def(
+      "all_reduce("
+      "Tensor input, "
+      "str reduce_op, "
+      "str group_name) -> Tensor",
+      torch::dispatch(
+          c10::DispatchKey::Autograd, ::all_reduce_autograd),
       {at::Tag::pt2_compliant_tag});
 }
 

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -177,6 +177,15 @@ def all_reduce(self: torch.Tensor, reduceOp: str, group: RANK_TYPES, tag: str = 
     return _maybe_wrap_tensor(tensor)
 
 
+def all_reduce_autograd(self: torch.Tensor, reduceOp: str, group: RANK_TYPES, tag: str = ""):
+    """
+    Same as all_reduce but supports autograd.
+    """
+    group_name = _resolve_group_name(group, tag)
+    tensor = torch.ops._c10d_functional.all_reduce(self, reduceOp.lower(), group_name)
+    return _FromTorchTensor.apply(tensor)
+
+
 def all_gather_tensor(
     self: torch.Tensor,
     gather_dim: int,


### PR DESCRIPTION
This adds `all_reduce_autograd` to the functional_collectives library and follows #123599 & #123989, which is motivated by https://github.com/pytorch/pytorch/issues/58005#issuecomment-2670227180.
Test plan:
```
pytest test/distributed/test_functional_api.py -k Autograd
```



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci