### PR TITLE
Fix 32-bit indexing overflows in ReducedPrecisionGemV

### DIFF
--- a/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp
@@ -105,7 +105,7 @@ float fp16_dot_with_fp16_arith(const Half* x, const Half* a, int len) {
 // of matrix A at once as done in fp16_gemv_trans_fp16_arith, unroll
 // along an individual dot product.
 // NB: lda must be long, otherwise it can cause int32 overflow
-static void fp16_gemv_trans_fp16_arith_by_dot_products(const int m, const int n, const Half* a, const long lda, const Half *x, const float beta, Half* y, int incy) {
+static void fp16_gemv_trans_fp16_arith_by_dot_products(const int m, const int n, const Half* a, const int64_t lda, const Half *x, const float beta, Half* y, int incy) {
   if (beta == 0.0f) {
     parallel_for(0, n, 1, [&](int begin, int end) {
       for (int i = begin; i < end; ++i) {
@@ -396,7 +396,7 @@ float fp16_dot_with_fp32_arith(const Half* vec1, const Half* vec2, int64_t len) 
 }
 
 // NB: lda must be long, otherwise it can cause int32 overflow
-void fp16_gemv_trans_fp32_arith_by_dot_products(const int m, const int n, const Half* a, const long lda, const Half *x, const float beta, Half* y, int incy) {
+void fp16_gemv_trans_fp32_arith_by_dot_products(const int m, const int n, const Half* a, const int64_t lda, const Half *x, const float beta, Half* y, int incy) {
   if (beta == 0.0f) {
     parallel_for(0, n, 1, [&](int begin, int end) {
       for (int i = begin; i < end; ++i) {
@@ -451,7 +451,7 @@ float bf16_dot_with_fp32_arith(const at::BFloat16* vec1, const at::BFloat16* vec
 }
 
 // NB: lda must be long, otherwise it can cause int32 overflow
-void bf16_gemv_trans_fp32_arith_by_dot_products(const int m, const int n, const at::BFloat16* a, const long lda, const at::BFloat16 *x, at::BFloat16* y, int incy) {
+void bf16_gemv_trans_fp32_arith_by_dot_products(const int m, const int n, const at::BFloat16* a, const int64_t lda, const at::BFloat16 *x, at::BFloat16* y, int incy) {
   parallel_for(0, n, 1, [&](int begin, int end) {
     for (int i = begin; i < end; ++i) {
       y[i * incy] = bf16_dot_with_fp32_arith(x, a + lda * i, m);

--- a/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.cpp
@@ -104,7 +104,8 @@ float fp16_dot_with_fp16_arith(const Half* x, const Half* a, int len) {
 // Rather than unrolling to process multiple rows (transposed columns)
 // of matrix A at once as done in fp16_gemv_trans_fp16_arith, unroll
 // along an individual dot product.
-static void fp16_gemv_trans_fp16_arith_by_dot_products(const int m, const int n, const Half* a, const int lda, const Half *x, const float beta, Half* y, int incy) {
+// NB: lda must be long, otherwise it can cause int32 overflow
+static void fp16_gemv_trans_fp16_arith_by_dot_products(const int m, const int n, const Half* a, const long lda, const Half *x, const float beta, Half* y, int incy) {
   if (beta == 0.0f) {
     parallel_for(0, n, 1, [&](int begin, int end) {
       for (int i = begin; i < end; ++i) {
@@ -394,7 +395,8 @@ float fp16_dot_with_fp32_arith(const Half* vec1, const Half* vec2, int64_t len) 
   return dot_with_fp32_arith_no_bfdot(vec1, vec2, len);
 }
 
-void fp16_gemv_trans_fp32_arith_by_dot_products(const int m, const int n, const Half* a, const int lda, const Half *x, const float beta, Half* y, int incy) {
+// NB: lda must be long, otherwise it can cause int32 overflow
+void fp16_gemv_trans_fp32_arith_by_dot_products(const int m, const int n, const Half* a, const long lda, const Half *x, const float beta, Half* y, int incy) {
   if (beta == 0.0f) {
     parallel_for(0, n, 1, [&](int begin, int end) {
       for (int i = begin; i < end; ++i) {
@@ -448,7 +450,8 @@ float bf16_dot_with_fp32_arith(const at::BFloat16* vec1, const at::BFloat16* vec
   }
 }
 
-void bf16_gemv_trans_fp32_arith_by_dot_products(const int m, const int n, const at::BFloat16* a, const int lda, const at::BFloat16 *x, at::BFloat16* y, int incy) {
+// NB: lda must be long, otherwise it can cause int32 overflow
+void bf16_gemv_trans_fp32_arith_by_dot_products(const int m, const int n, const at::BFloat16* a, const long lda, const at::BFloat16 *x, at::BFloat16* y, int incy) {
   parallel_for(0, n, 1, [&](int begin, int end) {
     for (int i = begin; i < end; ++i) {
       y[i * incy] = bf16_dot_with_fp32_arith(x, a + lda * i, m);

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -9425,6 +9425,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         self.assertEqual(rc, ref)
 
     @dtypes(torch.float, torch.half, torch.bfloat16)
+    @largeTensorTest('16GB')
     def test_matmul_mv(self, device, dtype):
         # Regression test for https://github.com/pytorch/pytorch/issues/150637
         # Such matrix will take more than 4Gb in memory

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -9424,6 +9424,16 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         ref = alpha * A @ B + beta * C
         self.assertEqual(rc, ref)
 
+    @dtypes(torch.float, torch.half, torch.bfloat16)
+    def test_matmul_mv(self, device, dtype):
+        # Regression test for https://github.com/pytorch/pytorch/issues/150637
+        # Such matrix will take more than 4Gb in memory
+        n = 50_000
+        A = torch.ones(n, n, dtype=dtype, device=device)
+        B = torch.rand(n, dtype=dtype, device=device)
+        C = torch.matmul(A, B)
+        self.assertEqual(C, B.sum().expand(B.shape))
+
     @dtypes(torch.float, torch.double)
     @precisionOverride({torch.float32: 1e-4})
     def test_1_sized_with_0_strided(self, device, dtype):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #150949

By chaining `lda` type from `int` to  ~~`long`~~ `int64_t`

Add regression test (but probably restrict it to CPUs (or may be skip float32 testing on GPUs)

Fixes https://github.com/pytorch/pytorch/issues/150637

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10