### PR TITLE
Fix issue in optimized_add issue: make_optimized should be called on non args only 

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1008,7 +1008,6 @@ def forward(self, x_1):
         assert_not_optimized(b + a)
         assert_not_optimized(b + a + b)
 
-
     def test_max_of_unique_summation_opt(self):
         shape_env = ShapeEnv()
         s0 = shape_env.create_unbacked_symint()

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1004,17 +1004,10 @@ def forward(self, x_1):
         b = s3 + s4 + s5
         assert_optimized(a)
         assert_optimized(b)
-        assert_optimized(a + b)
-        assert_optimized(b + a)
-
-        # same as above but b does not have ordered_summation_of_unique_symbols.
-        s6 = create_symint(shape_env, 11)
-        s7 = create_symint(shape_env, 21)
-        s8 = create_symint(shape_env, 31)
-        b = torch.sym_sum([s6, s7, s8])
-        assert_optimized(a)
-        assert_not_optimized(b)
         assert_not_optimized(a + b)
+        assert_not_optimized(b + a)
+        assert_not_optimized(b + a + b)
+
 
     def test_max_of_unique_summation_opt(self):
         shape_env = ShapeEnv()

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -885,7 +885,8 @@ def _optimized_add(
         new_args = list(lhs._args)
         for a in rhs._args:
             new_args = _binary_search_insert_arg(new_args, a)
-        return make_optimized(new_args)
+        if new_args is not None:
+            return make_optimized(new_args)
 
     # (a0+a2) + a1 => (a0+a1+a2)
     if lhs_is_optimized_summation and rhs.is_symbol:

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -885,18 +885,21 @@ def _optimized_add(
         new_args = list(lhs._args)
         for a in rhs._args:
             new_args = _binary_search_insert_arg(new_args, a)
+        # None means an element already exists.
         if new_args is not None:
             return make_optimized(new_args)
 
     # (a0+a2) + a1 => (a0+a1+a2)
     if lhs_is_optimized_summation and rhs.is_symbol:
         new_args = _binary_search_insert_arg(list(lhs._args), rhs)
+        # None means an element already exists.
         if new_args is not None:
             return make_optimized(new_args)
 
     # a1 + (a0+a2)=> (a0+a1+a2)
     if rhs_is_optimized_summation and lhs.is_symbol:
         new_args = _binary_search_insert_arg(list(rhs._args), lhs)
+        # None means an element already exists.
         if new_args is not None:
             return make_optimized(new_args)
 

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -865,6 +865,7 @@ def _optimized_add(
     from sympy.core.basic import _args_sortkey as sortkey
 
     def make_optimized(ordered_args):
+        assert ordered_args is not None
         result = sympy.Add(*ordered_args, evaluate=False)
         return (True, result)
 
@@ -882,24 +883,27 @@ def _optimized_add(
             return make_optimized(rhs._args + lhs._args)
 
         #  (a1+a3) + (a0+a2) => (a0+a1+a2+a3)
-        new_args = list(lhs._args)
-        for a in rhs._args:
-            new_args = _binary_search_insert_arg(new_args, a)
-        # None means an element already exists.
-        if new_args is not None:
-            return make_optimized(new_args)
+        if len(lhs._args) <=2 and len(rhs._args)<=2:
+            new_args = list(lhs._args)
+            for a in rhs._args:
+                new_args = _binary_search_insert_arg(new_args, a)
+                if new_args is None:
+                    break 
+            # None means an element already exists. 
+            if new_args is not None:
+                return make_optimized(new_args)
 
     # (a0+a2) + a1 => (a0+a1+a2)
     if lhs_is_optimized_summation and rhs.is_symbol:
         new_args = _binary_search_insert_arg(list(lhs._args), rhs)
-        # None means an element already exists.
+        # None means an element already exists. 
         if new_args is not None:
             return make_optimized(new_args)
 
     # a1 + (a0+a2)=> (a0+a1+a2)
     if rhs_is_optimized_summation and lhs.is_symbol:
         new_args = _binary_search_insert_arg(list(rhs._args), lhs)
-        # None means an element already exists.
+        # None means an element already exists. 
         if new_args is not None:
             return make_optimized(new_args)
 

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -883,27 +883,27 @@ def _optimized_add(
             return make_optimized(rhs._args + lhs._args)
 
         #  (a1+a3) + (a0+a2) => (a0+a1+a2+a3)
-        if len(lhs._args) <=2 and len(rhs._args)<=2:
+        if len(lhs._args) <= 2 and len(rhs._args) <= 2:
             new_args = list(lhs._args)
             for a in rhs._args:
                 new_args = _binary_search_insert_arg(new_args, a)
                 if new_args is None:
-                    break 
-            # None means an element already exists. 
+                    break
+            # None means an element already exists.
             if new_args is not None:
                 return make_optimized(new_args)
 
     # (a0+a2) + a1 => (a0+a1+a2)
     if lhs_is_optimized_summation and rhs.is_symbol:
         new_args = _binary_search_insert_arg(list(lhs._args), rhs)
-        # None means an element already exists. 
+        # None means an element already exists.
         if new_args is not None:
             return make_optimized(new_args)
 
     # a1 + (a0+a2)=> (a0+a1+a2)
     if rhs_is_optimized_summation and lhs.is_symbol:
         new_args = _binary_search_insert_arg(list(rhs._args), lhs)
-        # None means an element already exists. 
+        # None means an element already exists.
         if new_args is not None:
             return make_optimized(new_args)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #150955

PR https://github.com/pytorch/pytorch/pull/149665 did a change to the optimized_add that is causing an issue internally. 
In general make_optimized should be only be called with valid new_args,  new_args can become None
when elements already exists also, we should break out of the loop in that case.

Note that I also only maintained the optimized summation when both lhs and rhs lengths are <=2.
This is ok because the optimization is based on the inductive property of adding one symbol at a time.
the [2]+[2] here is serving as base case ( i feel we can also remove it ) .

Note that keeping it for all sizes while correct, I am not sure if tis as efficient (we will do N log(n) insertions).
there is no current justification for that. 

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv