### PR TITLE
Add additional MacOS test runners for MPS

### DIFF
--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -31,6 +31,7 @@ jobs:
           { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m1-13" },
           { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m1-14" },
           { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m2-15" },
+          { config: "test_mps", shard: 1, num_shards: 1, runner: "m1-24-macos15" },
           { config: "test_mps", shard: 1, num_shards: 1, runner: "m1-pro-32-macos15" },
           { config: "test_mps", shard: 1, num_shards: 1, runner: "m2-max-96-macos15" },
         ]}

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -31,8 +31,8 @@ jobs:
           { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m1-13" },
           { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m1-14" },
           { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m2-15" },
-          { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m2-15" },
           { config: "test_mps", shard: 1, num_shards: 1, runner: "m1-pro-32-macos15" },
+          { config: "test_mps", shard: 1, num_shards: 1, runner: "m2-max-96-macos15" },
         ]}
     secrets: inherit
 

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -31,6 +31,8 @@ jobs:
           { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m1-13" },
           { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m1-14" },
           { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m2-15" },
+          { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m2-15" },
+          { config: "test_mps", shard: 1, num_shards: 1, runner: "m1-pro-32-macos15" },
         ]}
     secrets: inherit
 

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -31,7 +31,7 @@ jobs:
           { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m1-13" },
           { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m1-14" },
           { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m2-15" },
-          { config: "test_mps", shard: 1, num_shards: 1, runner: "m1-24-macos15" },
+          { config: "test_mps", shard: 1, num_shards: 1, runner: "m2-24-macos15" },
           { config: "test_mps", shard: 1, num_shards: 1, runner: "m1-pro-32-macos15" },
           { config: "test_mps", shard: 1, num_shards: 1, runner: "m2-max-96-macos15" },
         ]}


### PR DESCRIPTION
Add additional Mac MPS test runners, as part of an effort to eventually add all supported Mac configs

cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen