### PR TITLE
c10d/Store: add queues

### DIFF
--- a/torch/csrc/distributed/c10d/HashStore.cpp
+++ b/torch/csrc/distributed/c10d/HashStore.cpp
@@ -61,19 +61,17 @@ std::vector<uint8_t> HashStore::get(const std::string& key) {
 void HashStore::wait(
     const std::vector<std::string>& keys,
     const std::chrono::milliseconds& timeout) {
-  const auto end = std::chrono::steady_clock::now() + timeout;
-  auto pred = [&]() {
-    auto done = true;
-    for (const auto& key : keys) {
-      if (map_.find(key) == map_.end()) {
-        done = false;
-        break;
-      }
-    }
-    return done;
-  };
-
   std::unique_lock<std::mutex> lock(m_);
+  waitLocked(lock, keys, timeout);
+}
+
+void HashStore::waitLocked(
+    std::unique_lock<std::mutex>& lock,
+    const std::vector<std::string>& keys,
+    const std::chrono::milliseconds& timeout) {
+  const auto end = std::chrono::steady_clock::now() + timeout;
+  auto pred = [&]() { return checkLocked(lock, keys); };
+
   if (timeout == kNoTimeout) {
     cv_.wait(lock, pred);
   } else {
@@ -112,8 +110,18 @@ bool HashStore::deleteKey(const std::string& key) {
 
 bool HashStore::check(const std::vector<std::string>& keys) {
   std::unique_lock<std::mutex> lock(m_);
+
+  return checkLocked(lock, keys);
+}
+
+bool HashStore::checkLocked(
+    const std::unique_lock<std::mutex>& lock,
+    const std::vector<std::string>& keys) {
   for (const auto& key : keys) {
-    if (map_.find(key) == map_.end()) {
+    auto foundKV = map_.find(key) != map_.end();
+    auto foundQueue =
+        queues_.find(key) != queues_.end() && !queues_[key].empty();
+    if (!foundKV && !foundQueue) {
       return false;
     }
   }
@@ -172,6 +180,37 @@ void HashStore::multiSet(
 
 bool HashStore::hasExtendedApi() const {
   return true;
+}
+
+void HashStore::queuePush(
+    const std::string& key,
+    const std::vector<uint8_t>& value) {
+  std::unique_lock<std::mutex> lock(m_);
+
+  queues_[key].push_back(value);
+
+  cv_.notify_one();
+}
+
+std::vector<uint8_t> HashStore::queuePop(const std::string& key) {
+  std::unique_lock<std::mutex> lock(m_);
+
+  waitLocked(lock, {key}, timeout_);
+
+  auto& queue = queues_[key];
+  auto val = queue.front();
+  queue.pop_front();
+  return val;
+}
+
+int64_t HashStore::queueLen(const std::string& key) {
+  std::unique_lock<std::mutex> lock(m_);
+
+  auto it = queues_.find(key);
+  if (it == queues_.end()) {
+    return 0;
+  }
+  return static_cast<int64_t>(it->second.size());
 }
 
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/HashStore.hpp
+++ b/torch/csrc/distributed/c10d/HashStore.hpp
@@ -52,8 +52,26 @@ class TORCH_API HashStore : public Store {
   // Returns true if this store support append, multiGet and multiSet
   bool hasExtendedApi() const override;
 
+  void queuePush(const std::string& key, const std::vector<uint8_t>& value)
+      override;
+
+  std::vector<uint8_t> queuePop(const std::string& key) override;
+
+  int64_t queueLen(const std::string& key) override;
+
+ protected:
+  bool checkLocked(
+      const std::unique_lock<std::mutex>& lock,
+      const std::vector<std::string>& keys);
+
+  void waitLocked(
+      std::unique_lock<std::mutex>& lock,
+      const std::vector<std::string>& keys,
+      const std::chrono::milliseconds& timeout);
+
  protected:
   std::unordered_map<std::string, std::vector<uint8_t>> map_;
+  std::unordered_map<std::string, std::deque<std::vector<uint8_t>>> queues_;
   std::mutex m_;
   std::condition_variable cv_;
 };

--- a/torch/csrc/distributed/c10d/PrefixStore.cpp
+++ b/torch/csrc/distributed/c10d/PrefixStore.cpp
@@ -110,6 +110,20 @@ bool PrefixStore::hasExtendedApi() const {
   return store_->hasExtendedApi();
 }
 
+void PrefixStore::queuePush(
+    const std::string& key,
+    const std::vector<uint8_t>& value) {
+  store_->queuePush(joinKey(key), value);
+}
+
+std::vector<uint8_t> PrefixStore::queuePop(const std::string& key) {
+  return store_->queuePop(joinKey(key));
+}
+
+int64_t PrefixStore::queueLen(const std::string& key) {
+  return store_->queueLen(joinKey(key));
+}
+
 c10::intrusive_ptr<Store> PrefixStore::getUnderlyingStore() {
   return store_;
 }

--- a/torch/csrc/distributed/c10d/PrefixStore.hpp
+++ b/torch/csrc/distributed/c10d/PrefixStore.hpp
@@ -52,6 +52,13 @@ class TORCH_API PrefixStore : public Store {
   // Returns true if this store support append, multiGet and multiSet
   bool hasExtendedApi() const override;
 
+  void queuePush(const std::string& key, const std::vector<uint8_t>& value)
+      override;
+
+  std::vector<uint8_t> queuePop(const std::string& key) override;
+
+  int64_t queueLen(const std::string& key) override;
+
   c10::intrusive_ptr<Store> getUnderlyingStore();
 
   // Recursively to fetch the store before layers of wrapping with PrefixStore.

--- a/torch/csrc/distributed/c10d/Store.hpp
+++ b/torch/csrc/distributed/c10d/Store.hpp
@@ -51,7 +51,7 @@ class TORCH_API Store : public torch::CustomClassHolder {
       const std::string& key,
       const std::vector<uint8_t>& currentValue,
       const std::vector<uint8_t>& newValue) {
-    TORCH_INTERNAL_ASSERT(false, "Not implemented.");
+    C10_THROW_ERROR(NotImplementedError, "Not implemented.");
   }
 
   std::string get_to_str(const std::string& key);
@@ -81,7 +81,9 @@ class TORCH_API Store : public torch::CustomClassHolder {
       const std::string& /* unused */,
       // NOLINTNEXTLINE(performance-unnecessary-value-param)
       WatchKeyCallback /* unused */) {
-    TORCH_CHECK(false, "watchKey is deprecated, no implementation support it.");
+    C10_THROW_ERROR(
+        NotImplementedError,
+        "watchKey is deprecated, no implementation support it.");
   }
 
   virtual void append(
@@ -97,6 +99,20 @@ class TORCH_API Store : public torch::CustomClassHolder {
 
   // Returns true if this store support append, multiGet and multiSet
   virtual bool hasExtendedApi() const;
+
+  virtual void queuePush(
+      const std::string& key,
+      const std::vector<uint8_t>& value) {
+    C10_THROW_ERROR(NotImplementedError, "queue support is not implemented.");
+  }
+
+  virtual std::vector<uint8_t> queuePop(const std::string& key) {
+    C10_THROW_ERROR(NotImplementedError, "queue support is not implemented.");
+  }
+
+  virtual int64_t queueLen(const std::string& key) {
+    C10_THROW_ERROR(NotImplementedError, "queue support is not implemented.");
+  }
 
  protected:
   std::chrono::milliseconds timeout_;

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -650,6 +650,63 @@ void TCPStore::multiSet(
   buffer.flush();
 }
 
+void TCPStore::queuePush(
+    const std::string& key,
+    const std::vector<uint8_t>& data) {
+  TORCH_CHECK_WITH(
+      NotImplementedError,
+      usingLibUv_,
+      "queues not implemented on legacy TCPStore backend");
+
+  STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__queuePush);
+
+  const std::lock_guard<std::mutex> lock(activeOpLock_);
+
+  detail::SendBuffer buffer(*client_, detail::QueryType::QUEUE_PUSH);
+  buffer.appendString(keyPrefix_ + key);
+  buffer.appendBytes(data);
+  buffer.flush();
+}
+
+std::vector<uint8_t> TCPStore::queuePop(const std::string& key) {
+  TORCH_CHECK_WITH(
+      NotImplementedError,
+      usingLibUv_,
+      "queues not implemented on legacy TCPStore backend");
+
+  STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__queuePop);
+
+  const std::lock_guard<std::mutex> lock(activeOpLock_);
+
+  doWait(keyPrefix_ + key, timeout_);
+  detail::SendBuffer buffer(*client_, detail::QueryType::QUEUE_POP);
+  buffer.appendString(keyPrefix_ + key);
+  buffer.flush();
+
+  auto keys = client_->receiveValue<int64_t>();
+  C10D_CHECK_WITH(
+      QueueEmptyError, keys > 0, "expected one key to be ready in queuePop");
+
+  return client_->receiveBits();
+}
+
+int64_t TCPStore::queueLen(const std::string& key) {
+  TORCH_CHECK_WITH(
+      NotImplementedError,
+      usingLibUv_,
+      "queues not implemented on legacy TCPStore backend");
+
+  STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__queueLen);
+
+  const std::lock_guard<std::mutex> lock(activeOpLock_);
+
+  detail::SendBuffer buffer(*client_, detail::QueryType::QUEUE_LEN);
+  buffer.appendString(keyPrefix_ + key);
+  buffer.flush();
+
+  return client_->receiveValue<int64_t>();
+}
+
 bool TCPStore::hasExtendedApi() const {
   return true;
 }

--- a/torch/csrc/distributed/c10d/TCPStore.hpp
+++ b/torch/csrc/distributed/c10d/TCPStore.hpp
@@ -114,6 +114,13 @@ class TORCH_API TCPStore : public Store {
 
   bool hasExtendedApi() const override;
 
+  void queuePush(const std::string& key, const std::vector<uint8_t>& value)
+      override;
+
+  std::vector<uint8_t> queuePop(const std::string& key) override;
+
+  int64_t queueLen(const std::string& key) override;
+
   // Waits for all workers to join.
   void waitForWorkers();
 

--- a/torch/csrc/distributed/c10d/TCPStoreBackend.hpp
+++ b/torch/csrc/distributed/c10d/TCPStoreBackend.hpp
@@ -33,6 +33,9 @@ enum class QueryType : uint8_t {
   MULTI_SET,
   CANCEL_WAIT,
   PING,
+  QUEUE_PUSH,
+  QUEUE_POP,
+  QUEUE_LEN,
 };
 
 enum class CheckResponseType : uint8_t { READY, NOT_READY };

--- a/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
@@ -666,6 +666,12 @@ class LibUVStoreDaemon : public BackgroundThread {
   int64_t deleteKey(const std::string& key);
   void append(const std::string& key, const std::vector<uint8_t>& value);
 
+  void queuePush(const std::string& queueName, const std::vector<uint8_t>& val);
+  void queuePop(
+      const std::string& queueName,
+      const c10::intrusive_ptr<UvHandle>& client);
+  int64_t queueLen(const std::string& queueName);
+
   void registerClient(const c10::intrusive_ptr<UvHandle>& client);
   void unregisterClient(const c10::intrusive_ptr<UvHandle>& client);
   void clearClientWaitState(const c10::intrusive_ptr<UvHandle>& client);
@@ -691,6 +697,10 @@ class LibUVStoreDaemon : public BackgroundThread {
   std::unordered_map<c10::intrusive_ptr<UvHandle>, size_t> keysAwaited_;
   std::unordered_set<c10::intrusive_ptr<UvHandle>> clients_;
   std::unordered_set<c10::intrusive_ptr<UvHandle>> miscellaneousClients_;
+
+  // Queues
+  std::unordered_map<std::string, std::deque<std::vector<uint8_t>>> queues_;
+
   int port_;
 
   static LibUVStoreDaemon& from_uv(uv_handle_t* stream) {
@@ -708,6 +718,7 @@ class LibUVStoreDaemon : public BackgroundThread {
   void onConnect(int status);
   void onExitRequest();
   void wakeupWaitingClients(const std::string& key);
+  void wakeupOneWaitingClient(const std::string& key);
   // bool tryListen(bool use_ipv6);
 
   static void print_active_handles(uv_handle_t* handle, void* arg);
@@ -785,6 +796,18 @@ class UvClient : public UvTcpSocket {
             break;
           case QueryType::CANCEL_WAIT:
             if (!parse_cancel_wait_command())
+              return;
+            break;
+          case QueryType::QUEUE_PUSH:
+            if (!parse_queue_push_command())
+              return;
+            break;
+          case QueryType::QUEUE_POP:
+            if (!parse_queue_pop_command())
+              return;
+            break;
+          case QueryType::QUEUE_LEN:
+            if (!parse_queue_len_command())
               return;
             break;
           default:
@@ -916,7 +939,11 @@ class UvClient : public UvTcpSocket {
         return false;
     }
 
-    C10D_TRACE("check key_count:{} address:{}", key_count, this->address());
+    C10D_TRACE(
+        "check key_count:{} keys[0]:{} address:{}",
+        key_count,
+        keys[0],
+        this->address());
 
     // Now we have received all the keys
     StreamWriter sw(iptr());
@@ -949,7 +976,11 @@ class UvClient : public UvTcpSocket {
         return false;
     }
 
-    C10D_TRACE("wait key_count:{} address:{}", key_count, this->address());
+    C10D_TRACE(
+        "wait key_count:{} keys[0]:{} address:{}",
+        key_count,
+        keys[0],
+        this->address());
 
     if (store->waitKeys(keys, iptr())) {
       StreamWriter sw(iptr());
@@ -1069,12 +1100,55 @@ class UvClient : public UvTcpSocket {
   bool parse_cancel_wait_command() {
     store->clearClientWaitState(iptr());
 
-    C10D_TRACE("cancel_wait key_count:{} address:{}", this->address());
+    C10D_TRACE("cancel_wait address:{}", this->address());
 
     StreamWriter sw(iptr());
     sw.write1((uint8_t)WaitResponseType::WAIT_CANCELED);
     sw.send();
 
+    return true;
+  }
+
+  bool parse_queue_push_command() {
+    std::string key;
+    if (!stream.read_key(key)) {
+      return false;
+    }
+
+    std::vector<uint8_t> data;
+    if (!stream.read_payload(data)) {
+      return false;
+    }
+
+    C10D_TRACE("queue_push key:{} address:{}", key, this->address());
+
+    store->queuePush(key, data);
+    return true;
+  }
+
+  bool parse_queue_pop_command() {
+    std::string key;
+    if (!stream.read_key(key)) {
+      return false;
+    }
+
+    C10D_TRACE("queue_pop key:{} address:{}", key, this->address());
+
+    store->queuePop(key, iptr());
+    return true;
+  }
+
+  bool parse_queue_len_command() {
+    std::string key;
+    if (!stream.read_key(key)) {
+      return false;
+    }
+
+    C10D_TRACE("queue_len key:{} address:{}", key, this->address());
+
+    StreamWriter sw(iptr());
+    sw.write_value<int64_t>(store->queueLen(key));
+    sw.send();
     return true;
   }
 
@@ -1347,7 +1421,13 @@ int64_t LibUVStoreDaemon::add(const std::string& key, int64_t addVal) {
 
 bool LibUVStoreDaemon::checkKeys(const std::vector<std::string>& keys) {
   return std::all_of(keys.begin(), keys.end(), [&](const std::string& s) {
-    return tcpStore_.count(s) > 0;
+    if (tcpStore_.count(s) > 0) {
+      return true;
+    }
+    if (auto it = queues_.find(s); it != queues_.end() && !it->second.empty()) {
+      return true;
+    }
+    return false;
   });
 }
 
@@ -1406,6 +1486,50 @@ void LibUVStoreDaemon::wakeupWaitingClients(const std::string& key) {
   }
 }
 
+void LibUVStoreDaemon::wakeupOneWaitingClient(const std::string& key) {
+  auto socketsToWait = waitingSockets_.find(key);
+  if (socketsToWait != waitingSockets_.end()) {
+    for (const auto& client : socketsToWait->second) {
+      if (--keysAwaited_[client] == 0) {
+        StreamWriter sw(client->iptr());
+        sw.write1((uint8_t)WaitResponseType::STOP_WAITING);
+        sw.send();
+        return;
+      }
+    }
+  }
+}
+
+void LibUVStoreDaemon::queuePush(
+    const std::string& key,
+    const std::vector<uint8_t>& value) {
+  queues_[key].push_back(value);
+  wakeupOneWaitingClient(key);
+}
+
+void LibUVStoreDaemon::queuePop(
+    const std::string& key,
+    const c10::intrusive_ptr<UvHandle>& client) {
+  auto& queue = queues_[key];
+
+  StreamWriter sw(client->iptr());
+  sw.write_value<int64_t>(queue.size());
+
+  if (queue.size() > 0) {
+    auto value = queue.front();
+    queue.pop_front();
+    sw.write_vector(value);
+  }
+
+  sw.send();
+}
+int64_t LibUVStoreDaemon::queueLen(const std::string& key) {
+  auto it = queues_.find(key);
+  if (it == queues_.end()) {
+    return 0;
+  }
+  return static_cast<int64_t>(it->second.size());
+}
 #endif
 
 std::unique_ptr<BackgroundThread> create_libuv_tcpstore_backend(

--- a/torch/csrc/distributed/c10d/exception.h
+++ b/torch/csrc/distributed/c10d/exception.h
@@ -36,4 +36,8 @@ class TORCH_API TimeoutError : public DistNetworkError {
   using DistNetworkError::DistNetworkError;
 };
 
+class TORCH_API QueueEmptyError : public DistStoreError {
+  using DistStoreError::DistStoreError;
+};
+
 } // namespace c10d


### PR DESCRIPTION
This adds queue operations as described in https://github.com/pytorch/pytorch/issues/150943.

This works by adding two new operations `queue_push` and `queue_pop`. The semantics are designed to be blocking with a timeout. Pushing will always succeed as the queue is infinite size. Popping will first call `wait` until the key is ready and then pop the value from the queue.

This implements queues for only: HashStore, TCPStore w/ libuv. FileStore and the legacy backends are not supported.

`wait` and `check` work for queue operations though queue_push will only wake up the first waiter rather than all of them.

This also has a few cleanups to error types/documentation in related code.

Example trace:

```
[I409 16:51:43.963833529 TCPStoreLibUvBackend.cpp:829] [c10d - trace] validate magic:1015412686 address:[localhost]:55816
[I409 16:51:43.963845838 TCPStoreLibUvBackend.cpp:842] [c10d - trace] ping nonce:2840795 address:[localhost]:55816
[I409 16:51:43.963902914 TCPStoreLibUvBackend.cpp:911] [c10d - trace] add key:init/ val:1 address:[localhost]:55816
[I409 16:51:43.963939389 TCPStoreLibUvBackend.cpp:977] [c10d - trace] wait key_count:1 keys[0]:init/ address:[localhost]:55816
[I409 16:51:43.963974842 TCPStoreLibUvBackend.cpp:893] [c10d - trace] get key:init/ address:[localhost]:55816
[I409 16:51:43.964071909 TCPStoreLibUvBackend.cpp:1121] [c10d - trace] queue_push key:/test_prefix/test_queue_support address:[localhost]:55816
[I409 16:51:43.964080221 TCPStoreLibUvBackend.cpp:940] [c10d - trace] check key_count:1 keys[0]:/test_prefix/foo address:[localhost]:55816
[I409 16:51:43.964108584 TCPStoreLibUvBackend.cpp:1121] [c10d - trace] queue_push key:/test_prefix/foo address:[localhost]:55816
[I409 16:51:43.964123207 TCPStoreLibUvBackend.cpp:1121] [c10d - trace] queue_push key:/test_prefix/foo address:[localhost]:55816
[I409 16:51:43.964128194 TCPStoreLibUvBackend.cpp:940] [c10d - trace] check key_count:1 keys[0]:/test_prefix/foo address:[localhost]:55816
[I409 16:51:43.964156347 TCPStoreLibUvBackend.cpp:977] [c10d - trace] wait key_count:1 keys[0]:/test_prefix/foo address:[localhost]:55816
[I409 16:51:43.964187493 TCPStoreLibUvBackend.cpp:977] [c10d - trace] wait key_count:1 keys[0]:/test_prefix/foo address:[localhost]:55816
[I409 16:51:43.964217709 TCPStoreLibUvBackend.cpp:1133] [c10d - trace] queue_pop key:/test_prefix/foo address:[localhost]:55816
[I409 16:51:43.964324300 TCPStoreLibUvBackend.cpp:977] [c10d - trace] wait key_count:1 keys[0]:/test_prefix/foo address:[localhost]:55816
[I409 16:51:43.964354495 TCPStoreLibUvBackend.cpp:1133] [c10d - trace] queue_pop key:/test_prefix/foo address:[localhost]:55816
[I409 16:51:43.964416299 TCPStoreLibUvBackend.cpp:940] [c10d - trace] check key_count:1 keys[0]:/test_prefix/foo address:[localhost]:55816
[I409 16:51:43.964458733 TCPStoreLibUvBackend.cpp:977] [c10d - trace] wait key_count:1 keys[0]:/test_prefix/non_existant address:[localhost]:55816
[W409 16:51:43.974516585 socket.cpp:460] [c10d] waitForInput: poll for socket SocketImpl(fd=75, addr=[localhost]:55816, remote=[localhost]:46641) returned 0, likely a timeout
[W409 16:51:43.974559169 socket.cpp:485] [c10d] waitForInput: socket SocketImpl(fd=75, addr=[localhost]:55816, remote=[localhost]:46641) timed out after 10ms
[I409 16:51:43.974600451 TCPStoreLibUvBackend.cpp:1101] [c10d - trace] cancel_wait address:[localhost]:55816
```

Test plan:

```
$ pytest test/distributed/test_store.py -k queue -v -s                       
                                                                                                                                                                                                        
test/distributed/test_store.py::FileStoreTest::test_queues SKIPPED [0.4351s] (Store does not support queues)
test/distributed/test_store.py::HashStoreTest::test_queues PASSED [0.0009s]
test/distributed/test_store.py::PrefixFileStoreTest::test_queues SKIPPED [0.0006s] (Store does not support queues)
test/distributed/test_store.py::TCPStoreTest::test_queues SKIPPED [0.0012s] (Store does not support queues)
test/distributed/test_store.py::LibUvTCPStoreTest::test_queues PASSED [0.0014s]
test/distributed/test_store.py::PrefixTCPStoreTest::test_queues PASSED [0.0014s]
```

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab