### PR TITLE
[cutlass backend] Add and fix logs, fix types, and make cutlass generator only generate GEMM

### DIFF
--- a/torch/_inductor/codegen/cuda/cutlass_utils.py
+++ b/torch/_inductor/codegen/cuda/cutlass_utils.py
@@ -192,7 +192,7 @@ def _gen_ops_cached(arch, version) -> dict[Any, Any]:
             arch,
             version,
         )
-        return []
+        return {}
     arch = _normalize_cuda_arch(arch)
     instantiation_level: str = config.cuda.cutlass_instantiation_level
     args = CUTLASSArgs(

--- a/torch/_inductor/codegen/cuda/cutlass_utils.py
+++ b/torch/_inductor/codegen/cuda/cutlass_utils.py
@@ -222,7 +222,7 @@ def _gen_ops_cached(arch, version) -> dict[Any, Any]:
             ) from e
 
     log.info(
-        "CUTLASS library generated %d operations in %.2f seconds",
+        "CUTLASS library generated a dict of %d operation kinds in %.2f seconds",
         len(manifest.operations),
         time.time() - start_time,
     )

--- a/torch/_inductor/codegen/cuda/cutlass_utils.py
+++ b/torch/_inductor/codegen/cuda/cutlass_utils.py
@@ -3,6 +3,7 @@ import functools
 import logging
 import os
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
@@ -20,6 +21,8 @@ from .cuda_env import get_cuda_arch, get_cuda_version
 
 
 log = logging.getLogger(__name__)
+
+CUTLASS_OPERATION_KIND: str = "gemm"
 
 
 def _rename_cutlass_import(content: str, cutlass_modules: list[str]) -> str:
@@ -148,8 +151,8 @@ class CUTLASSArgs:
     architectures: Optional[str] = None
     cuda_version: Optional[str] = None
     instantiation_level: Optional[str] = None
+    operations: Optional[str] = None
 
-    operations = "all"
     build_dir = ""
     curr_build_dir = ""
     generator_target = ""
@@ -173,7 +176,7 @@ class CUTLASSArgs:
 
 @clear_on_fresh_inductor_cache
 @functools.lru_cache(None)
-def _gen_ops_cached(arch, version) -> list[Any]:
+def _gen_ops_cached(arch, version) -> dict[Any, Any]:
     # Note: Cache needs to be specific for cuda architecture and version
 
     # Import cutlass python scripts.
@@ -196,9 +199,11 @@ def _gen_ops_cached(arch, version) -> list[Any]:
         architectures=arch,
         cuda_version=version,
         instantiation_level=instantiation_level,
+        operations=CUTLASS_OPERATION_KIND,
     )
     manifest = cutlass_manifest.Manifest(args)
 
+    start_time = time.time()
     if arch == "100":
         if hasattr(cutlass_generator, "GenerateSM100"):
             cutlass_generator.GenerateSM100(manifest, args.cuda_version)
@@ -215,10 +220,16 @@ def _gen_ops_cached(arch, version) -> list[Any]:
             raise NotImplementedError(
                 "Arch " + arch + " is not supported by current cutlass lib."
             ) from e
+
+    log.info(
+        "CUTLASS library generated %d operations in %.2f seconds",
+        len(manifest.operations),
+        time.time() - start_time,
+    )
     return manifest.operations
 
 
-def gen_ops() -> list[Any]:
+def gen_ops() -> dict[Any, Any]:
     """
     Generates all supported CUTLASS operations.
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #150973

Differential Revision: [D72760205](https://our.internmc.facebook.com/intern/diff/D72760205/)

We hardcoded to only use GEMM anyway. 

This also raises the problem with high instantiation level. As the instantiation level goes higher (here it is 3333), the time it takes to list the configs might be long already (here it is >3 minutes). 

If we know exactly what configs we care, we should have a way to generate them without calling generators. But let's see if we need that.

using this script
```
import os

os.environ["TORCH_LOGS"] = "inductor"

import torch

import torch._inductor.config

torch._inductor.config.max_autotune = True
torch._inductor.config.force_disable_caches = True
torch._inductor.config.max_autotune_gemm_backends = "Aten,CUTLASS"
# intentionally use no cutlass ops
torch._inductor.config.cuda.cutlass_max_profiling_configs = 0
torch._inductor.config.cuda.cutlass_instantiation_level = "3333"

def main():
    M = 128
    dtype = torch.float16
    A = torch.randn(M, M, device="cuda", dtype=dtype)
    B = torch.randn(M, M, device="cuda", dtype=dtype)

    compiled_model = torch.compile(torch.mm)

    _ = compiled_model(A, B)
    print("done")


if __name__ == "__main__":
    main()
```

before, with logs:
```
CUTLASS library generated 7 operations in 235.03 seconds
Got cutlass configs: total number of ops: 4753. Filtering took 10.51 seconds
```

after:
```
CUTLASS library generated 1 operations in 207.39 seconds
Got cutlass configs: total number of ops: 4753. Filtering took 9.53 seconds
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov