### PR TITLE
[Intel GPU] Enable GQA and different head_dim of value for SDPA

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Attention.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Attention.cpp
@@ -21,9 +21,9 @@ bool check_head_dim_size_xpu(sdp::sdp_params const& params, bool debug) {
     }
     return false;
   }
+
   constexpr int MAX_HEAD_DIM = 576;
-  const auto max_size_last =
-      query_size_last > value_size_last ? query_size_last : value_size_last;
+  const auto max_size_last = query_size_last.max(value_size_last);
   if (max_size_last > MAX_HEAD_DIM) {
     if (debug) {
       TORCH_WARN(

--- a/aten/src/ATen/native/mkldnn/xpu/Attention.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Attention.cpp
@@ -9,29 +9,28 @@ bool check_head_dim_size_xpu(sdp::sdp_params const& params, bool debug) {
   const auto query_size_last = params.query.sym_size(-1);
   const auto key_size_last = params.key.sym_size(-1);
   const auto value_size_last = params.value.sym_size(-1);
-  if ((query_size_last != key_size_last) ||
-      (query_size_last != value_size_last)) {
+  if (query_size_last != key_size_last) {
     if (debug) {
       TORCH_WARN(
-          "OneDNN attention requires q,k,v to have the same last dimension.",
+          "OneDNN attention requires q,k to have the same last dimension.",
           " Got Query.size(-1): ",
           query_size_last,
           ", Key.size(-1): ",
           key_size_last,
-          ", Value.size(-1): ",
-          value_size_last,
           " instead.");
     }
     return false;
   }
   constexpr int MAX_HEAD_DIM = 576;
-  if (query_size_last > MAX_HEAD_DIM) {
+  const auto max_size_last =
+      query_size_last > value_size_last ? query_size_last : value_size_last;
+  if (max_size_last > MAX_HEAD_DIM) {
     if (debug) {
       TORCH_WARN(
           "OneDNN attention requires q,k,v to have head dimension less than ",
           MAX_HEAD_DIM,
           ". Got ",
-          query_size_last,
+          max_size_last,
           " instead.");
     }
     return false;
@@ -176,6 +175,9 @@ _scaled_dot_product_fused_attention_overrideable_xpu(
       query.size(3) == key.size(3),
       "scaled_dot_product_fused_attention_overrideable_xpu: Q/K should have the same head_dim");
   TORCH_INTERNAL_ASSERT(
+      query.size(1) % key.size(1) == 0,
+      "scaled_dot_product_fused_attention_overrideable_xpu: number of heads in K/V must divide number of heads in Q");
+  TORCH_INTERNAL_ASSERT(
       dropout_p == 0.0,
       "scaled_dot_product_fused_attention_overrideable_xpu: Currently do not support dropout > 0");
   TORCH_INTERNAL_ASSERT(
@@ -183,31 +185,32 @@ _scaled_dot_product_fused_attention_overrideable_xpu(
       "scaled_dot_product_fused_attention_overrideable_xpu: attn_bias cannot present with is_causal");
 
   const int64_t batch_size = query.size(0);
-  const int64_t num_head = query.size(1);
+  const int64_t num_head_q = query.size(1);
   const int64_t num_head_kv = key.size(1);
-  const int64_t head_dim = query.size(3);
+  const int64_t head_dim_qk = query.size(3);
   const int64_t head_dim_v = value.size(3);
   const int64_t seq_len_q = query.size(2);
   const int64_t seq_len_kv = key.size(2);
 
   auto opts = query.options();
-  auto output = at::empty({batch_size, num_head, seq_len_q, head_dim}, opts);
+  auto output =
+      at::empty({batch_size, num_head_q, seq_len_q, head_dim_v}, opts);
   at::Tensor logsumexp, debug_attn_mask; // not supported
 
   at::native::onednn::gpu_float_sdpa(
       batch_size,
       seq_len_q,
       seq_len_kv,
-      num_head,
+      num_head_q,
       num_head_kv,
-      head_dim,
+      head_dim_qk,
       head_dim_v,
       query,
       key,
       value,
       attn_bias,
       is_causal,
-      scale.has_value() ? scale.value() : (1.0 / std::sqrt(head_dim)),
+      scale.has_value() ? scale.value() : (1.0 / std::sqrt(head_dim_qk)),
       output);
 
   // rng not used

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attention.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attention.cpp
@@ -85,9 +85,6 @@ struct SDPALogicalParams {
 
     if (num_head_q != num_head_kv) { // Check whether the attention is a
                                      // Grouped-Query Attention (GQA)
-      TORCH_INTERNAL_ASSERT(
-          num_head_q % num_head_kv == 0,
-          "Number of heads in key and value must divide the number of heads in query.");
       int group_num = num_head_kv;
       int group_size = num_head_q / num_head_kv;
       // oneDNN requires the shape of the query tensor to be represented as

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attention.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attention.cpp
@@ -46,6 +46,13 @@ struct SDPALogicalParams {
       const at::Tensor& value_,
       const std::optional<at::Tensor>& attn_mask_,
       const at::Tensor& output_,
+      int batch_size,
+      int seq_len_q,
+      int seq_len_kv,
+      int num_head_q,
+      int num_head_kv,
+      int head_dim_qk,
+      int head_dim_v,
       bool is_causal) {
     const data_type dtype = to_logical_tensor_data_type(query_.scalar_type());
     TORCH_INTERNAL_ASSERT(
@@ -74,6 +81,24 @@ struct SDPALogicalParams {
     if (attn_mask_.has_value() &&
         at::native::onednn::is_broadcast(reshaped_attn_mask)) {
       at::native::onednn::undo_broadcast(reshaped_attn_mask);
+    }
+
+    if (num_head_q != num_head_kv) { // process GQA because oneDNN GQA requires
+                                     // Q/K/V to be 5D tensor.
+      TORCH_INTERNAL_ASSERT(
+          num_head_q % num_head_kv == 0,
+          "Number of heads in key and value must divide the number of heads in query.");
+      int group_num = num_head_kv;
+      int group_size = num_head_q / num_head_kv;
+      reshaped_query = query_.view(
+          {batch_size, group_num, group_size, seq_len_q, head_dim_qk});
+      reshaped_key = key_.unsqueeze(2);
+      reshaped_value = value_.unsqueeze(2);
+      reshaped_output = output_.view(
+          {batch_size, group_num, group_size, seq_len_q, head_dim_v});
+      if (attn_mask_.has_value() && attn_mask_.value().dim() == 4) {
+        reshaped_attn_mask = attn_mask_.value().unsqueeze(2);
+      }
     }
 
     query = {
@@ -140,19 +165,12 @@ struct SDPALogicalParams {
 };
 
 partition create_sdpa_graph_partition(
-    int batch_size,
-    int seq_len_q,
-    int seq_len_k,
-    int num_head,
-    int head_dim,
     bool is_causal,
     data_type dtype,
     const SDPALogicalParams& params) {
   // graph building and partitioning
   // currently, we assume that Q and K have same sequence length
 
-  dims qk_output_shape = {batch_size, num_head, seq_len_q, seq_len_k};
-  dims scale_shape = {1};
   size_t lt_id = static_cast<size_t>(SDPALogicalParams::TensorID::end);
   size_t op_id = 0;
 
@@ -284,11 +302,6 @@ partition create_sdpa_graph_partition(
 }
 
 partition& find_or_create_graph_partition(
-    int batch_size,
-    int seq_len_q,
-    int seq_len_k,
-    int num_head,
-    int head_dim,
     bool is_causal,
     const SDPALogicalParams& params) {
   thread_local static PartitionCache cache;
@@ -318,15 +331,8 @@ partition& find_or_create_graph_partition(
   if (!partition_.has_value()) {
     // partition cache no hit
     // graph building and partitioning
-    partition sdp_partition = create_sdpa_graph_partition(
-        batch_size,
-        seq_len_q,
-        seq_len_k,
-        num_head,
-        head_dim,
-        is_causal,
-        dtype,
-        params);
+    partition sdp_partition =
+        create_sdpa_graph_partition(is_causal, dtype, params);
     partition_ = cache.insert_partition_cache(patternID, sdp_partition);
   }
   return *partition_;
@@ -337,10 +343,10 @@ namespace at::native::onednn {
 void gpu_float_sdpa(
     int batch_size,
     int seq_len_q,
-    int seq_len_k,
-    int num_head,
+    int seq_len_kv,
+    int num_head_q,
     int num_head_kv,
-    int head_dim,
+    int head_dim_qk,
     int head_dim_v,
     const Tensor& query,
     const Tensor& key,
@@ -355,9 +361,7 @@ void gpu_float_sdpa(
   const auto get_tril_mask = [&]() {
     auto opts = query.options();
     auto bool_tril =
-        at::ones_symint(
-            {query.sym_size(-2), key.sym_size(-2)}, opts.dtype(at::kBool))
-            .tril();
+        at::ones_symint({seq_len_q, seq_len_kv}, opts.dtype(at::kBool)).tril();
     return at::where(
         bool_tril,
         0.f,
@@ -378,15 +382,21 @@ void gpu_float_sdpa(
 
   auto get_compiled_partition = [&]() {
     const SDPALogicalParams logical_params(
-        query, key, value, attn_mask, output, is_causal);
-    auto& partition_ = find_or_create_graph_partition(
+        query,
+        key,
+        value,
+        attn_mask,
+        output,
         batch_size,
         seq_len_q,
-        seq_len_k,
-        num_head,
-        head_dim,
-        is_causal,
-        logical_params);
+        seq_len_kv,
+        num_head_q,
+        num_head_kv,
+        head_dim_qk,
+        head_dim_v,
+        is_causal);
+    auto& partition_ =
+        find_or_create_graph_partition(is_causal, logical_params);
     auto i = logical_params.get_input();
     auto o = logical_params.get_output();
     auto compiled_partition = partition_.compile(i, o, eng);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/oneDNN.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/oneDNN.h
@@ -167,10 +167,10 @@ void quantized_matmul(
 void gpu_float_sdpa(
     int batch_size,
     int seq_len_q,
-    int seq_len_k,
-    int num_head,
+    int seq_len_kv,
+    int num_head_q,
     int num_head_kv,
-    int head_dim,
+    int head_dim_qk,
     int head_dim_v,
     const Tensor& query,
     const Tensor& key,

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -4007,7 +4007,7 @@ class TestSDPAXpuOnly(NNTestCase):
 
     def test_fused_attention_different_dk_dv(self, device):
         dtype = torch.bfloat16
-        make_tensor = partial(torch.rand, device=device, dtype=dtype, requires_grad=True)
+        make_tensor = partial(torch.rand, device=device, dtype=dtype, requires_grad=False)
         batch, num_heads, head_dim_k, head_dim_v = 32, 16, 128, 64
         q_shape = SdpaShape(batch, num_heads, 1, head_dim_k)
         k_shape = SdpaShape(batch, num_heads, 2, head_dim_k)
@@ -4022,6 +4022,44 @@ class TestSDPAXpuOnly(NNTestCase):
             query.float(), key.float(), value.float(), attn_mask=None, dropout_p=0.0, is_causal=False)[0]
 
         self.assertEqual(actual.contiguous(), math_ref.contiguous().to(dtype), atol=1e-3, rtol=1e-2)
+
+    @parametrize("dtype", [torch.half, torch.bfloat16])
+    @parametrize("batch_size,n_head,n_head_kv,q_size,kv_size,head_dim", [
+        (2, 64, 16, 9216, 77, 64),
+        (2, 32, 4, 2304, 2304, 64),
+        (2, 32, 2, 2304, 77, 64),
+        (2, 20, 2, 576, 576, 64),
+        (2, 20, 2, 576, 77, 64),
+        (2, 20, 2, 144, 144, 64),
+        (2, 20, 2, 144, 77, 64),
+        (1, 32, 2, 1, 32, 128),
+        (4, 32, 4, 1, 32, 128),
+        (1, 32, 2, 32, 32, 128),
+        (4, 32, 4, 32, 32, 128),
+        (1, 32, 2, 2016, 2016, 128),
+        (4, 32, 4, 2016, 2016, 128),
+    ])
+    @parametrize("is_causal", [True, False])
+    def test_fused_attention_gqa(self, device, dtype, batch_size, n_head, n_head_kv, q_size, kv_size, head_dim, is_causal):
+        tol = Tolerances(1e-5, 5e-6)
+        if dtype is torch.bfloat16:
+            tol = Tolerances(5e-2, 5e-2)
+        if dtype is torch.float16:
+            tol = Tolerances(1e-2, 1e-2)
+        make_tensor = partial(torch.rand, device=device, dtype=dtype, requires_grad=False)
+        q_shape = SdpaShape(batch_size, n_head, q_size, head_dim)
+        k_shape = SdpaShape(batch_size, n_head_kv, kv_size, head_dim)
+        v_shape = SdpaShape(batch_size, n_head_kv, kv_size, head_dim)
+        query, key, value = make_tensor(q_shape), make_tensor(k_shape), make_tensor(v_shape)
+
+        # test that we do not dispatch to onednn for an unsupported case
+        actual = F.scaled_dot_product_attention(
+            query, key, value, attn_mask=None, dropout_p=0.0, is_causal=is_causal, enable_gqa=True)
+
+        math_ref = torch.ops.aten._scaled_dot_product_attention_math(
+            query.float(), key.float(), value.float(), attn_mask=None, dropout_p=0.0, is_causal=is_causal, enable_gqa=True)[0]
+
+        self.assertEqual(actual.contiguous(), math_ref.contiguous().to(dtype), atol=tol.atol, rtol=tol.rtol)
 
     def test_onednn_attention_fail_d576(self, device):
         # Test that onednn graph attention dispatching correctly bails out on d > 576


### PR DESCRIPTION
In OneDNN v3.7, SDPA doesn't support num_head_q != num_head_kv (aka GQA) and head_dim_qk != head_dim_v.
In OneDNN v3.8, SDPA supports these two scenarios. Enable them in this PR.   SDPA UTs pass in local test.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168