### PR TITLE
[XPU] skip a subprocess UT for Windows

### DIFF
--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
         )
         self.assertRegex(stderr, "Cannot re-initialize XPU in forked subprocess.")
 
-    @unittest.skipIf(IS_WINDOWS, "multiprocessing not applicable in a Windows subprocess")
+    @unittest.skipIf(IS_WINDOWS, "not applicable to Windows (only fails with fork)")
     def test_lazy_init(self):
         """Validate that no XPU calls are made during `import torch` call"""
 

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
         )
         self.assertRegex(stderr, "Cannot re-initialize XPU in forked subprocess.")
 
-    @unittest.skipIf(IS_WINDOWS, "not applicable to Windows (only fails with fork)")
+    @unittest.skipIf(IS_WINDOWS, "Only for lazy initialization on Linux, not applicable on Windows.")
     def test_lazy_init(self):
         """Validate that no XPU calls are made during `import torch` call"""
 

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -159,6 +159,7 @@ if __name__ == "__main__":
         )
         self.assertRegex(stderr, "Cannot re-initialize XPU in forked subprocess.")
 
+    @unittest.skipIf(IS_WINDOWS, "multiprocessing not applicable in a Windows subprocess")
     def test_lazy_init(self):
         """Validate that no XPU calls are made during `import torch` call"""
 

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -159,7 +159,9 @@ if __name__ == "__main__":
         )
         self.assertRegex(stderr, "Cannot re-initialize XPU in forked subprocess.")
 
-    @unittest.skipIf(IS_WINDOWS, "Only for lazy initialization on Linux, not applicable on Windows.")
+    @unittest.skipIf(
+        IS_WINDOWS, "Only for lazy initialization on Linux, not applicable on Windows."
+    )
     def test_lazy_init(self):
         """Validate that no XPU calls are made during `import torch` call"""
 


### PR DESCRIPTION
This case creates subprocess in a subprocess. In Windows it can't load function at this scenario hence I have to skip it
```
File "C:\ProgramData\miniforge3\envs\lfq\lib\multiprocessing\spawn.py", line 116, in spawn_main
    exitcode = _main(fd, parent_sentinel)
  File "C:\ProgramData\miniforge3\envs\lfq\lib\multiprocessing\spawn.py", line 126, in _main
    self = reduction.pickle.load(from_parent)
AttributeError: Can't get attribute 'run_model' on <module '__main__' (built-in)>
Traceback (most recent call last):
  File "<string>", line 25, in <module>
  File "<string>", line 16, in test_multi_process
AssertionError
```

cc @gujinghui @EikanWang @fengyuan14 @guangyey