### PR TITLE
[ROCm] Improve behavior of get_torch_rocm_version helper function on non-ROCm systems.

### DIFF
--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -260,7 +260,7 @@ def _get_torch_cuda_version():
     return tuple(int(x) for x in cuda_version.split("."))
 
 def _get_torch_rocm_version():
-    if not TEST_WITH_ROCM:
+    if not TEST_WITH_ROCM or torch.version.hip is None:
         return (0, 0)
     rocm_version = str(torch.version.hip)
     rocm_version = rocm_version.split("-")[0]    # ignore git sha


### PR DESCRIPTION
Fixes #150041 

Return a zero tuple when ROCm is _not_ supported, similar to what is done for the CUDA version of this function.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang