### PR TITLE
remove MTIA from the check of duplicate flow events

### DIFF
--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -1115,7 +1115,9 @@ class TransferEvents {
                     "ROCTracer produced duplicate flow start: ", i.flow.id);
               }
 #else // USE_ROCM
+              if (!at::hasMTIA()) {
               TORCH_INTERNAL_ASSERT(inserted.second);
+              }
 #endif // USE_ROCM
             }
             TORCH_INTERNAL_ASSERT(e->parent_.expired());


### PR DESCRIPTION
Summary: For MTIA, there can be more than one event with same correlation id. Need to omit this check

Test Plan: CIs

Differential Revision: D72815463


