### PR TITLE
[dynamo] handle tensor subclass with non-classmethod `__torch_function__`

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -927,7 +927,10 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
     def test_tensor_subclass_with_non_classmethod_torch_function(self):
         class MySubclass(torch.Tensor):
             def __torch_function__(self, func, types, args, kwargs=None):
-                return super().__torch_function__(func, types, args, kwargs)
+                if kwargs is None:
+                    kwargs = {}
+                with torch._C.DisableTorchFunctionSubclass():
+                    return func(*args, **kwargs)
 
         def fn(x):
             return x + 1

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -924,6 +924,21 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
         res_act = fn_opt(wrapped)
         self.assertEqual(res_exp, res_act)
 
+    def test_tensor_subclass_with_non_classmethod_torch_function(self):
+        class MySubclass(torch.Tensor):
+            def __torch_function__(self, func, types, args, kwargs=None):
+                return super().__torch_function__(func, types, args, kwargs)
+
+        def fn(x):
+            return x + 1
+
+        fn_opt = compile_full_eager(fn)
+
+        x = torch.randn(2, 2).as_subclass(MySubclass)
+        res_exp = fn(x)
+        res_act = fn_opt(x)
+        self.assertEqual(res_exp, res_act)
+
     def test_tensor_subclass_custom_attr(self):
         class AttrSubclass(torch.Tensor):
             x: int = 10
@@ -1056,6 +1071,20 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
             res_exp = fn(x)
             res_act = fn_opt(x)
             self.assertEqual(res_exp, res_act)
+
+    def test_parameter_subclass_with_old_torch_function(self):
+        class MySubclass(torch.nn.Parameter):
+            pass
+
+        def fn(x):
+            return x + 1
+
+        fn_opt = compile_full_eager(fn)
+
+        x = torch.randn(2, 2).as_subclass(MySubclass)
+        res_exp = fn(x)
+        res_act = fn_opt(x)
+        self.assertEqual(res_exp, res_act)
 
     def test_parameter_subclass_custom_torch_func_and_dynamic_attr(self):
         # This is a slight variation of

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -4123,6 +4123,8 @@ def is_torch_function_object(value):
 
 
 def has_torch_function(vt: torch._dynamo.variables.base.VariableTracker) -> bool:
+    # This emulates
+    # https://github.com/pytorch/pytorch/blob/8d81806211bc3c0ee6c2ef235017bacf1d775a85/torch/csrc/utils/disable_torch_function.cpp#L315-L323
     from torch._dynamo.variables import UserDefinedObjectVariable
     from torch._dynamo.variables.torch_function import TensorWithTFOverrideVariable
 
@@ -4137,12 +4139,14 @@ def has_torch_function(vt: torch._dynamo.variables.base.VariableTracker) -> bool
     if vt.is_realized() or (
         hasattr(vt, "peek_value") and hasattr(vt.peek_value(), "__torch_function__")
     ):
+        func = None
         if isinstance(vt, TensorWithTFOverrideVariable):
-            return True
+            func = getattr(vt.class_type, "__torch_function__", None)
 
-        return isinstance(vt, UserDefinedObjectVariable) and hasattr(
-            vt.value, "__torch_function__"
-        )
+        elif isinstance(vt, UserDefinedObjectVariable):
+            func = getattr(vt.value, "__torch_function__", None)
+
+        return func not in (None, torch._C._disabled_torch_function_impl)
 
     return False
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -250,7 +250,6 @@ from .torch import (
     TorchInGraphFunctionVariable,
 )
 from .torch_function import (
-    build_torch_function_fn,
     TensorWithTFOverrideVariable,
     torch_function_mode_stack_state_mgr,
     TorchFunctionModeVariable,
@@ -1798,9 +1797,6 @@ class VariableBuilder:
             subclass_type = None
         else:
             subclass_type = type(value)
-            options["torch_function_fn"] = build_torch_function_fn(
-                self.tx, value, self.source
-            )
             self.install_guards(GuardBuilder.TYPE_MATCH)
 
         if get_static_address_type(value) == "guarded":

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -64,7 +64,7 @@ from ..utils import (
     istype,
     make_cell,
 )
-from .base import AttributeMutationNew, typestr, ValueMutationNew, VariableTracker
+from .base import AttributeMutationNew, ValueMutationNew, VariableTracker
 from .constant import ConstantVariable
 
 
@@ -232,7 +232,7 @@ class UserFunctionVariable(BaseUserFunctionVariable):
             unimplemented_v2(
                 gb_type="can't handle functions not implemented in python ",
                 context=f"{fn}",
-                explanation=f"Dynamo can only handle functions defined in python",
+                explanation="Dynamo can only handle functions defined in python",
                 hints=[
                     "Move usage of this function out of `torch.compile` region",
                     *graph_break_hints.INFERENCE_MODE,

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -808,9 +808,9 @@ class UserDefinedObjectVariable(UserDefinedVariable):
 
     def get_torch_fn(self, tx):
         self.torch_function_check()
-        from .torch_function import build_torch_function_fn
+        from .torch_function import get_torch_function_fn
 
-        return build_torch_function_fn(tx, self.value, self.source)
+        return get_torch_function_fn(tx, self)
 
     def call_torch_function(self, tx: "InstructionTranslator", fn, types, args, kwargs):
         self.torch_function_check()

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -815,11 +815,10 @@ class UserDefinedObjectVariable(UserDefinedVariable):
     def call_torch_function(self, tx: "InstructionTranslator", fn, types, args, kwargs):
         self.torch_function_check()
 
-        from .torch_function import _get_subclass_type_var, call_torch_function
+        from .torch_function import call_torch_function
 
         return call_torch_function(
             tx,
-            _get_subclass_type_var(tx, self),
             self.get_torch_fn(tx),
             fn,
             types,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #151062
* __->__ #151061
* #151060

As title, this patch fixes bugs in
1. emulating `has_torch_function`
2. emulating calling `__torch_function__`
3. building a callable VT for non-classmethod `__torch_function__`

Fixes #120799, #150265, #150848.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames