### PR TITLE
[dynamo] Remove `traceable_tensor_subclasses`-related code

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -373,9 +373,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         inp = (torch.ones(2, 2) + 1).as_subclass(TestSubclass)
 
         fn_opt = torch.compile(fn, fullgraph=True)
-        with TestMode(), torch._dynamo.config.patch(
-            "traceable_tensor_subclasses", {TestSubclass}
-        ):
+        with TestMode():
             with torch._C.DisableTorchFunctionSubclass():
                 expected = fn(inp)
                 actual = fn_opt(inp)
@@ -404,9 +402,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         inp = (torch.ones(2, 2) + 1).as_subclass(TestSubclass)
 
         fn_opt = torch.compile(fn, fullgraph=True)
-        with TestMode(), torch._dynamo.config.patch(
-            "traceable_tensor_subclasses", {TestSubclass}
-        ):
+        with TestMode():
             expected = fn(inp)
             actual = fn_opt(inp)
 

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -36,10 +36,6 @@ from torch.testing._internal.two_tensor import TwoTensor
 from torch.utils._python_dispatch import return_and_correct_aliasing
 
 
-def traceable_subclass(c):
-    return torch._dynamo.config.patch("traceable_tensor_subclasses", {c})
-
-
 def nontraceable_subclass(c):
     return torch._dynamo.config.patch("nontraceable_tensor_subclasses", {c})
 
@@ -418,15 +414,6 @@ def _recompiles_for_inputs(fn, inputs1, inputs2, dynamic=True):
 
 class SubclassTests(torch._dynamo.test_case.TestCase):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls._exit_stack.enter_context(
-            torch._dynamo.config.patch(
-                "traceable_tensor_subclasses", GLOBAL_TEST_SUBCLASSES
-            )
-        )
-
-    @classmethod
     def tearDownClass(cls):
         cls._exit_stack.close()
 
@@ -444,18 +431,14 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
                     kwargs = {}
                 return super().__torch_function__(func, types, args, kwargs)
 
-        with torch._dynamo.config.patch(
-            "traceable_tensor_subclasses", {BadNewTorchFunction}
-        ):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            return torch.add(x, 1)
 
-            @torch.compile(backend="eager", fullgraph=True)
-            def fn(x):
-                return torch.add(x, 1)
+        input = torch.ones(2, 2).as_subclass(BadNewTorchFunction)
 
-            input = torch.ones(2, 2).as_subclass(BadNewTorchFunction)
-
-            res = fn(input)
-            self.assertIsInstance(res, BadNewTorchFunction)
+        res = fn(input)
+        self.assertIsInstance(res, BadNewTorchFunction)
 
     def test_no_torch_function_recompiles(self):
         class NJT:
@@ -629,16 +612,14 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
             def __torch_function__(cls, func, types, args=(), kwargs=None):
                 return super().__torch_function__(func, types, args, kwargs)
 
-        with torch._dynamo.config.patch("traceable_tensor_subclasses", {LocalSubclass}):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            return LocalSubclass(torch.add(x, 1.0)) * 2
 
-            @torch.compile(backend="eager", fullgraph=True)
-            def fn(x):
-                return LocalSubclass(torch.add(x, 1.0)) * 2
+        input = torch.ones(2, 2)
 
-            input = torch.ones(2, 2)
-
-            res = fn(input)
-            self.assertIsInstance(res, LocalSubclass)
+        res = fn(input)
+        self.assertIsInstance(res, LocalSubclass)
 
     def test_torch_function_list_args(self):
         HANDLED_FUNCTIONS = {}
@@ -693,18 +674,16 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
         ],
     )
     def test_type_check(self, comparison, input_type):
-        with torch._dynamo.config.patch("traceable_tensor_subclasses", {DummyNDim}):
+        def fn(x):
+            if comparison(x, DummyNDim):
+                return torch.ones(1, 1)
+            else:
+                return torch.zeros(2, 2)
 
-            def fn(x):
-                if comparison(x, DummyNDim):
-                    return torch.ones(1, 1)
-                else:
-                    return torch.zeros(2, 2)
-
-            input = torch.ones(2, 2).as_subclass(input_type)
-            exp_res = fn(input)
-            act_res = torch.compile(backend="eager", fullgraph=True)(fn)(input)
-            self.assertEqual(exp_res, act_res)
+        input = torch.ones(2, 2).as_subclass(input_type)
+        exp_res = fn(input)
+        act_res = torch.compile(backend="eager", fullgraph=True)(fn)(input)
+        self.assertEqual(exp_res, act_res)
 
     def test_torch_function_call_on_method(self):
         x = torch.ones(2, 2)
@@ -751,9 +730,8 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
 
         fn_opt = torch.compile(fn)
 
-        with torch._dynamo.config.patch("traceable_tensor_subclasses", {LocalSubclass}):
-            res_exp = fn(x, wrapped)
-            res_act = fn_opt(y, wrapped2)
+        res_exp = fn(x, wrapped)
+        res_act = fn_opt(y, wrapped2)
 
         self.assertEqual(res_exp, res_act)
 
@@ -772,9 +750,8 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
         x = torch.ones(2, 2).as_subclass(LocalSubclass)
         fn_opt = compile_full_eager(fn)
 
-        with torch._dynamo.config.patch("traceable_tensor_subclasses", {LocalSubclass}):
-            res_exp = fn(x)
-            res_act = fn_opt(x)
+        res_exp = fn(x)
+        res_act = fn_opt(x)
 
         self.assertEqual(res_exp, res_act)
 
@@ -793,9 +770,7 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
             return x.ndim
 
         msg = "Currently only support accessing overridden attributes that are functions or properties, but got <class 'int'>"
-        with torch._dynamo.config.patch(
-            "traceable_tensor_subclasses", {LocalSubclass}
-        ), self.assertRaisesRegex(torch._dynamo.exc.Unsupported, msg):
+        with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, msg):
             x = torch.ones(2, 2).as_subclass(LocalSubclass)
             fn(x)
 
@@ -822,9 +797,8 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
         x = LocalSubclass(torch.ones(2, 2))
         fn_opt = compile_full_eager(fn)
 
-        with torch._dynamo.config.patch("traceable_tensor_subclasses", {LocalSubclass}):
-            res_exp = fn(x)
-            res_act = fn_opt(x)
+        res_exp = fn(x)
+        res_act = fn_opt(x)
 
         self.assertEqual(res_exp, res_act)
 
@@ -840,21 +814,14 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
         def fn(x):
             return x.sigmoid()
 
-        with torch._dynamo.config.patch(
-            error_on_recompile=True, traceable_tensor_subclasses={LocalSubclass}
-        ):
+        with torch._dynamo.config.patch(error_on_recompile=True):
             x = torch.ones(2, 2).as_subclass(LocalSubclass)
             fn(x)
             fn(x)
             x = torch.ones(2, 2).as_subclass(LocalSubclass)
             fn(x)
 
-        with torch._dynamo.config.patch(
-            traceable_tensor_subclasses={LocalSubclass}
-        ), self.assertRaisesRegex(
-            TypeError,
-            "'bool' object is not callable",
-        ):
+        with self.assertRaisesRegex(TypeError, "'bool' object is not callable"):
             LocalSubclass.sigmoid = False
             fn(x)
 
@@ -903,13 +870,12 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
         def fn(x):
             return torch.clone(x)
 
-        with torch._dynamo.config.patch(traceable_tensor_subclasses={TestTensor}):
-            inp = torch.ones(4, 4)
-            x = inp.as_subclass(TestTensor)
-            torch._dynamo.mark_dynamic(x, 0)
-            compiled_fn = torch.compile(fn, fullgraph=True)
-            out = compiled_fn(x)
-            self.assertEqual(out, torch.ones(4, 4) * 2)
+        inp = torch.ones(4, 4)
+        x = inp.as_subclass(TestTensor)
+        torch._dynamo.mark_dynamic(x, 0)
+        compiled_fn = torch.compile(fn, fullgraph=True)
+        out = compiled_fn(x)
+        self.assertEqual(out, torch.ones(4, 4) * 2)
 
     def test_torch_function_wrapper_class_with_kwargs(self):
         x = torch.ones(2, 2)
@@ -954,13 +920,12 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
         def fn(x):
             return x.x + torch.ones(2, 2)
 
-        with traceable_subclass(AttrSubclass):
-            input = torch.ones(2, 2).as_subclass(AttrSubclass)
-            fn_opt = compile_full_eager(fn)
+        input = torch.ones(2, 2).as_subclass(AttrSubclass)
+        fn_opt = compile_full_eager(fn)
 
-            res_exp = fn(input)
-            res_act = fn_opt(input)
-            self.assertEqual(res_exp, res_act)
+        res_exp = fn(input)
+        res_act = fn_opt(input)
+        self.assertEqual(res_exp, res_act)
 
     def test_make_subclass(self):
         # Make sure `torch.Tensor._make_subclass` is traceable, and Dynamo
@@ -979,16 +944,15 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
             res = x * y + z
             return res
 
-        with traceable_subclass(MySubclass):
-            x0 = torch.randn(2, 2)
-            x1 = x0.clone()
+        x0 = torch.randn(2, 2)
+        x1 = x0.clone()
 
-            fn_opt = compile_full_eager(fn)
+        fn_opt = compile_full_eager(fn)
 
-            res_exp = fn(x0)
-            res_act = fn_opt(x1)
-            self.assertEqual(res_exp, res_act)
-            self.assertEqual(x0, x1)
+        res_exp = fn(x0)
+        res_act = fn_opt(x1)
+        self.assertEqual(res_exp, res_act)
+        self.assertEqual(x0, x1)
 
     def test_subclass_override_shape_and_to(self):
         # This is a slight variabtion of
@@ -1010,17 +974,16 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
             y = x.to("cpu")
             return x + 1, y + 2, x_shape, x.tensor_shape, y.tensor_shape
 
-        with traceable_subclass(MySubclass):
-            x0 = torch.nn.Parameter(torch.randn(2, 2).as_subclass(MySubclass))
-            x1 = torch.nn.Parameter(x0.clone().as_subclass(MySubclass))
+        x0 = torch.nn.Parameter(torch.randn(2, 2).as_subclass(MySubclass))
+        x1 = torch.nn.Parameter(x0.clone().as_subclass(MySubclass))
 
-            fn_opt = compile_full_eager(fn)
+        fn_opt = compile_full_eager(fn)
 
-            res_exp = fn(x0)
-            res_act = fn_opt(x1)
-            self.assertEqual(res_exp, res_act)
-            self.assertEqual(x0, x1)
-            self.assertEqual(x0.tensor_shape, x1.tensor_shape)
+        res_exp = fn(x0)
+        res_act = fn_opt(x1)
+        self.assertEqual(res_exp, res_act)
+        self.assertEqual(x0, x1)
+        self.assertEqual(x0.tensor_shape, x1.tensor_shape)
 
     def test_subclass_dont_invoke_torch_function_on_overriden_method(self):
         # We shouldn't fire `__torch_function__` for overriden tensor methods.
@@ -1037,14 +1000,13 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
         def fn(x):
             return x.to("cpu")
 
-        with traceable_subclass(MySubclass):
-            x = torch.nn.Parameter(torch.randn(2, 2).as_subclass(MySubclass))
+        x = torch.nn.Parameter(torch.randn(2, 2).as_subclass(MySubclass))
 
-            fn_opt = compile_full_eager(fn)
+        fn_opt = compile_full_eager(fn)
 
-            res_exp = fn(x)
-            res_act = fn_opt(x)
-            self.assertEqual(res_exp, res_act)
+        res_exp = fn(x)
+        res_act = fn_opt(x)
+        self.assertEqual(res_exp, res_act)
 
     def test_subclass_dont_invoke_torch_function_on_overriden_attr(self):
         from types import MethodWrapperType
@@ -1063,14 +1025,13 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
         def fn(x):
             return x + x.ndim()
 
-        with traceable_subclass(MySubclass):
-            x = torch.nn.Parameter(torch.randn(2, 2).as_subclass(MySubclass))
+        x = torch.nn.Parameter(torch.randn(2, 2).as_subclass(MySubclass))
 
-            fn_opt = compile_full_eager(fn)
+        fn_opt = compile_full_eager(fn)
 
-            res_exp = fn(x)
-            res_act = fn_opt(x)
-            self.assertEqual(res_exp, res_act)
+        res_exp = fn(x)
+        res_act = fn_opt(x)
+        self.assertEqual(res_exp, res_act)
 
     def test_parameter_subclass_with_old_torch_function(self):
         class MySubclass(torch.nn.Parameter):
@@ -1149,9 +1110,8 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
         opt_f = torch.compile(f, backend="eager", fullgraph=True)
 
         x = GGUFParameter(torch.ones(2), quant_type=42)
-        with traceable_subclass(GGUFParameter):
-            res = f(x)
-            ref = opt_f(x)
+        res = f(x)
+        ref = opt_f(x)
         self.assertEqual(res, ref)
 
     def test_newly_constructed_tensor_subclass_attr_mutation(self):
@@ -1168,9 +1128,8 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
 
         opt_f = compile_full_eager(f)
 
-        with traceable_subclass(MySubclass):
-            res = f()
-            ref = opt_f()
+        res = f()
+        ref = opt_f()
 
         self.assertEqual(res, ref)
         self.assertEqual(res[0].bar, ref[0].bar)
@@ -1189,9 +1148,8 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
 
         opt_f = compile_full_eager(f)
 
-        with traceable_subclass(MySubclass):
-            res = f()
-            ref = opt_f()
+        res = f()
+        ref = opt_f()
 
         self.assertEqual(res, ref)
         self.assertEqual(res[0].bar, ref[0].bar)
@@ -1213,9 +1171,8 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
         opt_f = compile_full_eager(f)
 
         t = MySubclass(torch.ones(2))
-        with traceable_subclass(MySubclass):
-            res = f(t)
-            ref = opt_f(t)
+        res = f(t)
+        ref = opt_f(t)
 
         self.assertEqual(res, ref)
         self.assertEqual(res.elem, ref.elem)

--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -9,10 +9,9 @@ import pprint
 import pickle
 import collections
 import unittest
-import contextlib
 import os
 
-from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_CROSSREF, TEST_WITH_TORCHDYNAMO
+from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_CROSSREF
 from torch.overrides import (
     handle_torch_function,
     has_torch_function,
@@ -382,27 +381,6 @@ class TensorLike:
         return HANDLED_FUNCTIONS_TENSOR_LIKE[func](*args, **kwargs)
 
 class TestTorchFunctionOverride(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls._stack = contextlib.ExitStack()
-        if TEST_WITH_TORCHDYNAMO:
-            # Add classes to the wrapped tensor subclasses
-            @contextlib.contextmanager
-            def setup_subclasses():
-                old = set(torch._dynamo.config.traceable_tensor_subclasses)
-                torch._dynamo.config.traceable_tensor_subclasses.add(DiagonalTensor)
-                try:
-                    yield
-                finally:
-                    torch._dynamo.config.traceable_tensor_subclasses.clear()
-                    torch._dynamo.config.traceable_tensor_subclasses.update(old)
-
-            cls._stack.enter_context(setup_subclasses())
-
-    @classmethod
-    def tearDownClass(cls):
-        cls._stack.close()
-
     def test_dtype_override(self):
         class MyDtype:
             def __torch_function__(self, *args, **kwargs):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #151062
* #151061
* #151060

Since #149792 deprecates `traceable_tensor_subclasses` and it's been
landed for over a week, we can safely remove all the old code that uses
`traceable_tensor_subclasses` (they were primarily for testing purposes
and are equivalent to no-ops now).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames