### PR TITLE
[c10d][fr] Fix the false positive in the dtype check in fr analysis script

### DIFF
--- a/test/distributed/flight_recorder/test_fr_analysis.py
+++ b/test/distributed/flight_recorder/test_fr_analysis.py
@@ -117,6 +117,29 @@ class FlightRecorderEventTest(TestCase):
             MatchState.COLLECTIVE_DTYPE_MISMATCH,
         )
 
+        e11 = create_one_event(
+            "gather",
+            ("0", "default"),
+            [[4, 4]],
+            [[4, 4], [4, 4]],
+            "completed",
+            1,
+            output_dtypes="float32",
+        )
+        e12 = create_one_event(
+            "gather",
+            ("0", "default"),
+            [[4, 4]],
+            [[]],
+            "completed",
+            1,
+            output_dtypes="",
+        )
+        self.assertEqual(
+            match_one_event(e11, e12, membership, "0").state,
+            MatchState.FULLY_MATCHED,
+        )
+
     def test_all_events(self):
         for collective in sorted(COLLECTIVES):
             input_sizes = [[4, 4]]

--- a/tools/flight_recorder/components/types.py
+++ b/tools/flight_recorder/components/types.py
@@ -498,9 +498,21 @@ class Op:
                     f"Expected state: '{self.state}' does not match found state: '{other.state}'",
                 )
             if (
-                set(self.input_dtypes) != set(self.output_dtypes)
-                or set(self.input_dtypes) != set(other.input_dtypes)
-                or set(self.input_dtypes) != set(other.output_dtypes)
+                (
+                    set(self.input_dtypes) != set(self.output_dtypes)
+                    and self.input_sizes[0]
+                    and self.output_sizes[0]
+                )
+                or (
+                    set(self.input_dtypes) != set(other.input_dtypes)
+                    and self.input_sizes[0]
+                    and other.input_sizes[0]
+                )
+                or (
+                    set(self.input_dtypes) != set(other.output_dtypes)
+                    and self.input_sizes[0]
+                    and other.output_sizes[0]
+                )
             ):
                 return MatchInfo(
                     MatchState.COLLECTIVE_DTYPE_MISMATCH,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #151063

When checking dtype in fr analysis script, we should only check it when the input of output numbel is larger than zero. For the case when it is gather or scatter, the output/input size will be an empty list for non-src or non-dst ranks which we should just skip the check.

cc @H-Huang @awgu @wanchaol @fegin @wz337 @wconstab @d4l3k

Differential Revision: [D72826823](https://our.internmc.facebook.com/intern/diff/D72826823)