### PR TITLE
[Intel GPU][PT2E] Register qconv impls to general qconv_pointwise schema

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/qconv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/qconv.cpp
@@ -262,7 +262,7 @@ TORCH_LIBRARY_IMPL(onednn, XPU, m) {
       TORCH_SELECTIVE_NAME("onednn::qconv2d_pointwise.binary"),
       QConvoneDNNXPU::run_pointwise_binary);
   m.impl(
-      TORCH_SELECTIVE_NAME("onednn::qconv_pointwise.binary"),
+      TORCH_SELECTIVE_NAME("onednn::qconv_pointwise"),
       QConvoneDNNXPU::run_pointwise);
   m.impl(
       TORCH_SELECTIVE_NAME("onednn::qconv_pointwise.tensor"),

--- a/aten/src/ATen/native/mkldnn/xpu/qconv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/qconv.cpp
@@ -223,6 +223,12 @@ TORCH_LIBRARY_IMPL(onednn, XPU, m) {
   m.impl(
       TORCH_SELECTIVE_NAME("onednn::qconv2d_pointwise.binary"),
       QConvoneDNNXPU::run_pointwise_binary);
+  m.impl(
+    TORCH_SELECTIVE_NAME("onednn::qconv_pointwise"),
+    QConvoneDNNXPU::run_pointwise);
+    m.impl(
+        TORCH_SELECTIVE_NAME("onednn::qconv2d_pointwise.binary"),
+        QConvoneDNNXPU::run_pointwise_binary);
 }
 
 } // namespace at::native::xpu

--- a/aten/src/ATen/native/mkldnn/xpu/qconv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/qconv.cpp
@@ -117,6 +117,44 @@ class QConvoneDNNXPU final {
         /*unary_algorithm*/ algorithm);
   }
 
+  static at::Tensor run_pointwise_tensor(
+      at::Tensor act,
+      at::Tensor act_scale,
+      at::Tensor act_zero_point,
+      at::Tensor weight,
+      at::Tensor weight_scales,
+      at::Tensor weight_zero_points,
+      std::optional<at::Tensor> bias,
+      torch::List<int64_t> stride,
+      torch::List<int64_t> padding,
+      torch::List<int64_t> dilation,
+      int64_t groups,
+      double output_scale,
+      int64_t output_zero_point,
+      std::optional<c10::ScalarType> output_dtype,
+      std::string_view attr,
+      torch::List<std::optional<at::Scalar>> scalars,
+      std::optional<std::string_view> algorithm) {
+    return run_pointwise(
+        act,
+        act_scale.item().toDouble(),
+        act_zero_point.item().toLong(),
+        weight,
+        weight_scales,
+        weight_zero_points,
+        bias,
+        stride,
+        padding,
+        dilation,
+        groups,
+        output_scale,
+        output_zero_point,
+        output_dtype,
+        /*unary_attr*/ attr,
+        /*unary_scalars*/ scalars,
+        /*unary_algorithm*/ algorithm);
+  }
+
   static at::Tensor run_pointwise_binary(
       at::Tensor act,
       double act_scale,
@@ -224,11 +262,11 @@ TORCH_LIBRARY_IMPL(onednn, XPU, m) {
       TORCH_SELECTIVE_NAME("onednn::qconv2d_pointwise.binary"),
       QConvoneDNNXPU::run_pointwise_binary);
   m.impl(
-      TORCH_SELECTIVE_NAME("onednn::qconv_pointwise"),
+      TORCH_SELECTIVE_NAME("onednn::qconv_pointwise.binary"),
       QConvoneDNNXPU::run_pointwise);
   m.impl(
-      TORCH_SELECTIVE_NAME("onednn::qconv_pointwise.binary"),
-      QConvoneDNNXPU::run_pointwise_binary);
+      TORCH_SELECTIVE_NAME("onednn::qconv_pointwise.tensor"),
+      QConvoneDNNXPU::run_pointwise_tensor);
 }
 
 } // namespace at::native::xpu

--- a/aten/src/ATen/native/mkldnn/xpu/qconv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/qconv.cpp
@@ -227,7 +227,7 @@ TORCH_LIBRARY_IMPL(onednn, XPU, m) {
       TORCH_SELECTIVE_NAME("onednn::qconv_pointwise"),
       QConvoneDNNXPU::run_pointwise);
   m.impl(
-      TORCH_SELECTIVE_NAME("onednn::qconv2d_pointwise.binary"),
+      TORCH_SELECTIVE_NAME("onednn::qconv_pointwise.binary"),
       QConvoneDNNXPU::run_pointwise_binary);
 }
 


### PR DESCRIPTION
# Motivation
Refer to https://github.com/pytorch/pytorch/pull/150751, general scheme for `qconv_pointwise` is added and `qconv2d_pointwise` is removed in callers. This PR registers the XPU backend implementations to this operator.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #151092



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10