### PR TITLE
add sbgemv dispatch in torch cpu flash attention

### DIFF
--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -27,6 +27,9 @@ extern "C" void sbgemm_(char *transa, char *transb, int *m, int *n, int *k,
                 const at::BFloat16 *b, int *ldb,
                 float *beta,
                 float *c, int *ldc);
+
+extern "C" void sbgemv_(const char* trans, const int* m, const int* n, const float* alpha, const at::BFloat16 * a, const int* lda, const at::BFloat16 * x, const int* incx, const float* beta, float* y, const int* incy);
+
 #endif  // BLAS_HAS_SBGEMM
 extern "C" void cswap_(int *n, const void *x, int *incx, void *y, int *incy);
 extern "C" void dcopy_(int *n, const double *x, int *incx, double *y, int *incy);
@@ -425,15 +428,24 @@ void gemm(
       int m_ = m, n_ = n, k_ = k, lda_ = lda, ldb_ = ldb, ldc_ = ldc;
       char transa_ = to_blas(transa), transb_ = to_blas(transb);
       float alpha_ = alpha, beta_ = beta;
-      sbgemm_(&transa_, &transb_,
-              &m_, &n_, &k_,
-              &alpha_,
-              a, &lda_,
-              b, &ldb_,
-              &beta_,
-              c, &ldc_);
+      if (m != 1 && n == 1 && k != 1 && transb == TransposeType::NoTranspose) { // dispatch to sbgemv kernel
+        int incr_x = 1, incr_y = 1;
+        if(transa == TransposeType::NoTranspose) {
+          sbgemv_(&transa_, &m_, &k_, &alpha_, a, &lda_, b, &incr_x, &beta_, c, &incr_y);
+        } else {
+          sbgemv_(&transa_, &k_, &m_, &alpha_, a, &lda_, b, &incr_x, &beta_, c, &incr_y);
+        }
+      } else {
+        sbgemm_(&transa_, &transb_,
+                &m_, &n_, &k_,
+                &alpha_,
+                a, &lda_,
+                b, &ldb_,
+                &beta_,
+                c, &ldc_);
+      }
       return;
-   }
+    }
 #endif
 #ifdef MKL_HAS_SBGEMM
   if (use_blas_gemm(transa, transb, m, n, k, lda, ldb, ldc)) {

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2009,7 +2009,7 @@ class TestSDPACpuOnly(NNTestCase):
     @parametrize("fused_kernel", [SDPBackend.FLASH_ATTENTION])
     @parametrize("dtype", [torch.float64, torch.float32, torch.bfloat16, torch.float16])
     @parametrize("batch_size", [2, 12])
-    @parametrize("q_seq_len", [11, 514, 1030])
+    @parametrize("q_seq_len", [1, 11, 514, 1030])
     @parametrize("kv_seq_len", [17, 514])
     @parametrize("n_head", [1, 3])
     @parametrize("head_dim", [8])


### PR DESCRIPTION
# Summary

This PR introduces a dispatch to the OpenBLAS sbgemv kernel in PyTorch CPU Flash Attention kernel when the query sequence length is 1.

# Motivation

During the decoding phase in transformer models (e.g., for autoregressive inference), the shape of the query tensor often has sequence length = 1. Currently, this leads to dispatching A(m, k) * B(k, n) into the general sbgemm kernel, even when the operation is effectively a matrix-vector multiplication. This PR optimizes such cases by dispatching to sbgemv, which is better suited and shows measurable performance improvements.

#  Heuristic Consideration

Our heuristic ensures that the matmul is dispatched to sbgemv only when matrix A is multiplied by a vector B, which is the intended use case for GEMV operations. Also we limit the dispatch to transb == NoTranspose because when transb == Transpose, the leading dimension (lda) might not be 1. This causes the sbgemv kernel to handle non-contiguous memory, which performs poorly.

# Benchmark result

Benchmarked using `torch.nn.functional.scaled_dot_product_attention` on **Neoverse™ V1**.

**Configuration:**
- `OMP_NUM_THREADS=16`
- Tensor shapes:
  - Query: `[1, 16, 1, 32]`
  - Key: `[1, 16, 1500, 32]`
  - Value: `[1, 16, 1500, 32]`

**Results:**

| Kernel   | Latency (µs) | Speedup |
|----------|--------------|---------|
| `sbgemm` | 121.700      | —       |
| `sbgemv` | 104.663      | ~16%    |


# Benchmark script
```python
import torch
import time
import numpy as np
import math
from torch.profiler import profile, record_function, ProfilerActivity

class SimpleAttentionModel(torch.nn.Module):
    def __init__(self, query, key, value):
        super(SimpleAttentionModel, self).__init__()
        self.query = query
        self.key = key
        self.value = value

    def forward(self, attn_mask=None):
        torch.nn.functional.scaled_dot_product_attention(
                    self.query,
                    self.key,
                    self.value,
                    attn_mask=attn_mask)


# implementation run for BertSdpaSelfAttention
def bench_sdpa(batch_size = 1, num_attention_heads = 16, sequence_length = 142, query_sequence_length = 142 , hidden_size=1024, precision=torch.float32):
    with torch.no_grad():
    
        attention_head_size = int(hidden_size / num_attention_heads)
    
        query = torch.rand(size=(batch_size, num_attention_heads, query_sequence_length, attention_head_size), dtype=precision)
        key = torch.rand(size=(batch_size, num_attention_heads, sequence_length, attention_head_size), dtype=precision)
        value = torch.rand(size=(batch_size, num_attention_heads, sequence_length, attention_head_size), dtype=precision)
         
        model = SimpleAttentionModel(query, key, value)
        model.eval()
        #model = torch.nn.utils.pack_linear.pack_linear_weights(model)
        
        for _ in range(100):
            model()

        times = []
        n_iters = 10000
        for _ in range(n_iters):
            s = time.time_ns()
            model()
            times.append((time.time_ns() - s) / 1e3)
        
        min_times = np.min(times)
        mean_times = np.mean(times)
        print(f"Min Times = {min_times} us")
        print(f"Mean Times = {mean_times} us")
        # print("Times = ", times)




if __name__ == "__main__":
    batch_size = 1
    num_attention_heads = 16
    sequence_length = 1500
    query_sequence_length = 1
    hidden_size=512

    print("BF16 mode:")
    with profile(activities=[ProfilerActivity.CPU], record_shapes=True) as prof:
        with record_function("model_inference"):
            bench_sdpa(batch_size = batch_size, num_attention_heads = num_attention_heads, sequence_length = sequence_length, query_sequence_length = query_sequence_length, hidden_size = hidden_size, precision=torch.bfloat16)
    profile_data = prof.key_averages(group_by_input_shape=True).table(sort_by="cpu_time_total")
    print(profile_data)

```

cc @malfet @snadampal @milpuz01 @aditew01 @nikhil-arm @fadara01