### PR TITLE
[Intel GPU] skip a cuda api call in amp to save some host overhead on xpu

### DIFF
--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -260,8 +260,8 @@ class autocast:
         self._cache_enabled = torch.is_autocast_cache_enabled()
         if (
             enabled
-            and torch.cuda.amp.common.amp_definitely_not_available()
             and self.device == "cuda"
+            and torch.cuda.amp.common.amp_definitely_not_available()
         ):
             warnings.warn(
                 "User provided device_type of 'cuda', but CUDA is not available. Disabling"


### PR DESCRIPTION
This can save ~0.2ms on non cuda devices by skip calling `amp_definitely_not_available()`. It can improve small models in torchbench like lennard_jones on xpu 10% on both eager and inductor in dynamo benchmarks.

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5