### PR TITLE
Remove ls from filesystem base

### DIFF
--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -479,9 +479,6 @@ class FileSystemBase(ABC):
     @abstractmethod
     def rm_file(self, path: Union[str, os.PathLike]) -> None: ...
 
-    @abstractmethod
-    def ls(self, path: Union[str, os.PathLike]) -> list[str]: ...
-
 
 class FileSystem(FileSystemBase):
     @contextmanager


### PR DESCRIPTION
Summary: User reported issue where they are inheriting from filesystembase but don't have the ls method which was added in the PR https://github.com/pytorch/pytorch/pull/150701#discussion_r2039840129. Removing the method from the base class but keeping it in derived class

Test Plan: buck test 'fbcode//mode/opt' fbcode//caffe2/test/distributed/checkpoint:test_hf_storage

Differential Revision: D72867722




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k