### PR TITLE
Guard additional use of DriverAPI

### DIFF
--- a/torch/csrc/distributed/c10d/cuda/utils.cpp
+++ b/torch/csrc/distributed/c10d/cuda/utils.cpp
@@ -13,7 +13,8 @@
 namespace c10d::cuda {
 
 bool deviceSupportsMulticast(int device_idx) {
-#if defined(CUDART_SUPPORTS_MULTICAST)
+#if defined(PYTORCH_C10_DRIVER_API_SUPPORTED) && \
+defined(CUDART_SUPPORTS_MULTICAST)
   // Multicast support requirements:
   // - CUDA Runtime version >= 12030: Checked at compile time using
   // CUDART_VERSION.


### PR DESCRIPTION
Most uses of DriverAPI are guarded by `PYTORCH_C10_DRIVER_API_SUPPORTED`, but this use is not, which causes compilation errors when building without C10 DriverAPI support.


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k