### PR TITLE
[dynamo] Use sentinel value for guard filter.

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -2493,10 +2493,13 @@ class CheckFunctionManager:
         if guard_filter_fn:
 
             def make_guard_filter_entry(guard):
+                MISSING = object()
                 name = strip_local_scope(guard.name)
                 if name == "":
-                    value = None
+                    has_value = False
+                    value = MISSING
                 else:
+                    has_value = True
                     value = builder.get(guard.name)
                 is_global = is_from_global_source(guard.originating_source)
                 guard_fn = guard.create_fn
@@ -2504,6 +2507,7 @@ class CheckFunctionManager:
                     guard_fn = guard.create_fn.func
                 return GuardFilterEntry(
                     name=name,
+                    has_value=has_value,
                     value=value,
                     guard_type=guard_fn.__name__,
                     derived_guard_types=tuple(guard.guard_types)

--- a/torch/_dynamo/types.py
+++ b/torch/_dynamo/types.py
@@ -40,6 +40,7 @@ class GuardFail(NamedTuple):
 @dataclasses.dataclass(frozen=True)
 class GuardFilterEntry:
     name: str
+    has_value: bool
     value: object
     guard_type: str
     derived_guard_types: tuple[str, ...]


### PR DESCRIPTION
Summary: `None` can collide with the real values in the scope, so we should use a separate value. Also added "has_value" to the struct so that it's more clear whether the value is absent or not.

Test Plan: CI

Differential Revision: D72881300




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames