### PR TITLE
[ROCm][TunableOp] Support submatrices in offline tuning

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5752,7 +5752,7 @@ class TestLinalg(TestCase):
             # Cover GEMM+bias case. Also mostly a subset of the regular
             # GEMM case but with a implicit transpose which makes code
             #  path slightly different.
-            # 'TN' case
+            # 'TN'
             X = torch.rand(ldc, lda, dtype=dtype, device=device)
             matA = torch.rand(ldc, ldb, dtype=dtype, device=device)
 
@@ -5762,7 +5762,7 @@ class TestLinalg(TestCase):
 
             torch.nn.functional.linear(subX, subA, bias)
 
-            # 'NT' case
+            # 'NT'
             X = torch.rand(ldc, lda, dtype=dtype, device=device).t()
             matA = torch.rand(ldc, ldb, dtype=dtype, device=device).t()
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5723,8 +5723,8 @@ class TestLinalg(TestCase):
             # 'TN'
             matA = torch.rand(ldc, lda, dtype=dtype, device=device)
             matB = torch.rand(ldc, ldb, dtype=dtype, device=device).t()
-            subA = matA[:m,:k]
-            subB = matB[:k,:n]
+            subA = matA[:m, :k]
+            subB = matB[:k, :n]
             torch.mm(subA, subB)
 
             # 'NN'

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5772,6 +5772,36 @@ class TestLinalg(TestCase):
 
             torch.nn.functional.linear(subX, subA, bias)
 
+            # Strided batch GEMM.
+            # 'TN'
+            b = 3
+            matA = torch.rand(b, ldc, lda, dtype=dtype, device=device)
+            matB = torch.rand(b, ldc, ldb, dtype=dtype, device=device).transpose(1, 2)
+            subA = matA[:b, :m, :k]
+            subB = matB[:b, :k, :n]
+            torch.bmm(subA, subB)
+
+            # 'NN'
+            matA = torch.rand(b, lda, ldc, dtype=dtype, device=device)
+            matB = torch.rand(b, ldc, ldb, dtype=dtype, device=device)
+            subA = matA[:b, :m, :k]
+            subB = matB[:b, :k, :n]
+            torch.bmm(subA, subB)
+
+            # 'NT'
+            matA = torch.rand(b, ldc, lda, dtype=dtype, device=device).transpose(1, 2)
+            matB = torch.rand(b, ldc, ldb, dtype=dtype, device=device)
+            subA = matA[:b, :m, :k]
+            subB = matB[:b, :k, :n]
+            torch.bmm(subA, subB)
+
+            # 'TT'
+            matA = torch.rand(b, k, lda, dtype=dtype, device=device).transpose(1, 2)
+            matB = torch.rand(b, ldb, k, dtype=dtype, device=device).transpose(1, 2)
+            subA = matA[:b, :k, :m]
+            subB = matB[:b, :n, :k]
+            torch.bmm(subA, subB)
+
             self.assertTrue(torch.cuda.tunable.is_enabled())
             self.assertTrue(torch.cuda.tunable.tuning_is_enabled() is False)
 
@@ -5793,7 +5823,7 @@ class TestLinalg(TestCase):
             total_num_results = new_results - ref_results
 
             # There must be a new tuning results
-            self.assertEqual(total_num_results, 6)
+            self.assertEqual(total_num_results, 10)
 
             self.assertTrue(torch.cuda.tunable.write_file())
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5701,14 +5701,13 @@ class TestLinalg(TestCase):
             m = 4
             k = 2
 
+            # There might be less confusing ways create submatrices, but this works
+            # just fine and covers the four transA, transB combinations.
             # 'TN'
-            matA = torch.rand(lda, ldc, dtype=dtype, device=device)
-            matB = torch.rand(ldb, ldc, dtype=dtype, device=device).t()
-
+            matA = torch.rand(ldc, lda, dtype=dtype, device=device)
+            matB = torch.rand(ldc, ldb, dtype=dtype, device=device).t()
             subA = matA[:m,:k]
             subB = matB[:k,:n]
-
-            torch.mm(matA, matB)
             torch.mm(subA, subB)
 
             # 'NN'
@@ -5716,7 +5715,6 @@ class TestLinalg(TestCase):
             matB = torch.rand(ldc, ldb, dtype=dtype, device=device)
             subA = matA[:m, :k]
             subB = matB[:k, :n]
-            torch.mm(matA, matB)
             torch.mm(subA, subB)
 
             # 'NT'
@@ -5724,7 +5722,6 @@ class TestLinalg(TestCase):
             matB = torch.rand(ldc, ldb, dtype=dtype, device=device)
             subA = matA[:m, :k]
             subB = matB[:k, :n]
-            torch.mm(matA, matB)
             torch.mm(subA, subB)
 
             # 'TT'
@@ -5732,7 +5729,6 @@ class TestLinalg(TestCase):
             matB = torch.rand(ldb, k, dtype=dtype, device=device).t()
             subA = matA[:k, :m]
             subB = matB[:n, :k]
-            torch.mm(matA, matB)
             torch.mm(subA, subB)
 
             self.assertTrue(torch.cuda.tunable.is_enabled())
@@ -5756,7 +5752,7 @@ class TestLinalg(TestCase):
             total_num_results = new_results - ref_results
 
             # There must be a new tuning results
-            # self.assertEqual(total_num_results, 1)
+            self.assertEqual(total_num_results, 4)
 
             self.assertTrue(torch.cuda.tunable.write_file())
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5310,8 +5310,16 @@ class TestLinalg(TestCase):
             m = 3
             n = 5
             k = 7
+            # 'TN' case
             X = torch.rand(m, k, dtype=dtype, device=device)
             matA = torch.rand(n, k, dtype=dtype, device=device)
+            bias = torch.rand(n, dtype=dtype, device=device)
+
+            torch.nn.functional.linear(X, matA, bias)
+
+            # 'NT' case
+            X = torch.rand(k, m, dtype=dtype, device=device).t()
+            matA = torch.rand(k, n, dtype=dtype, device=device).t()
             bias = torch.rand(n, dtype=dtype, device=device)
 
             torch.nn.functional.linear(X, matA, bias)
@@ -5320,7 +5328,7 @@ class TestLinalg(TestCase):
             total_num_results = len(torch.cuda.tunable.get_results())
 
             # There must be a new tuning result
-            self.assertEqual((total_num_results - ref_num_results), 1)
+            self.assertEqual((total_num_results - ref_num_results), 2)
 
     @onlyCUDA
     @skipCUDAIfNotRocm
@@ -5340,12 +5348,19 @@ class TestLinalg(TestCase):
             m = 5
             n = 7
             k = 9
+            # 'TN' case
             X = torch.rand(m, k, dtype=dtype, device=device)
             matA = torch.rand(n, k, dtype=dtype, device=device)
             bias = torch.rand(n, dtype=dtype, device=device)
 
             torch.nn.functional.linear(X, matA, bias)
 
+            # 'NT' case
+            X = torch.rand(k, m, dtype=dtype, device=device).t()
+            matA = torch.rand(k, n, dtype=dtype, device=device).t()
+            bias = torch.rand(n, dtype=dtype, device=device)
+
+            torch.nn.functional.linear(X, matA, bias)
             self.assertTrue(torch.cuda.tunable.is_enabled())
             self.assertTrue(torch.cuda.tunable.tuning_is_enabled() is False)
 
@@ -5367,7 +5382,7 @@ class TestLinalg(TestCase):
             total_num_results = new_results - ref_results
 
             # There must be a new tuning results
-            self.assertEqual(total_num_results, 1)
+            self.assertEqual(total_num_results, 2)
 
             self.assertTrue(torch.cuda.tunable.write_file())
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5681,6 +5681,8 @@ class TestLinalg(TestCase):
     @dtypes(torch.float)
     def test_mm_submatrix_offline_tunableop(self, device, dtype):
         # Test offline tuning with submatrices
+        # Covers both GEMM and ScaledGEMM case, the later
+        # implicitly due to shared code path
         ordinal = torch.cuda.current_device()
 
         with self._tunableop_ctx():

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5685,51 +5685,55 @@ class TestLinalg(TestCase):
 
         with self._tunableop_ctx():
             torch.cuda.tunable.set_rotating_buffer_size(0)
+            # set these to single iterations to keep it short but still exercise the code
+            torch.cuda.tunable.set_max_tuning_duration(1)
+            torch.cuda.tunable.set_max_tuning_iterations(1)
 
             # record GEMM
             torch.cuda.tunable.tuning_enable(False)
             torch.cuda.tunable.record_untuned_enable(True)
             self.assertTrue(torch.cuda.tunable.record_untuned_is_enabled())
 
-            ldb = 10
             lda = 12
+            ldb = 10
             ldc = 14
-            k = 2
-            m = 4
             n = 8
-            # # 'TN'
-            # matA = torch.rand(lda, k, dtype=dtype, device=device)
-            # matB = torch.rand(ldb, k, dtype=dtype, device=device).t()
-            # # matC = torch.empty(ldc, m, device=device)
+            m = 4
+            k = 2
 
-            # subA = matA[:m,:k]
-            # subB = matB[:k,:n]
-            # torch.mm(matA, matB)
-            # torch.mm(subA, subB)
-            
-            # # 'NN'
-            # matA = torch.rand(lda, k, dtype=dtype, device=device)
-            # matB = torch.rand(k, ldb, dtype=dtype, device=device)
-            # subA = matA[:m, :k]
-            # subB = matB[:k, :n]
-            # torch.mm(matA, matB)
-            # torch.mm(subA, subB)
+            # 'TN'
+            matA = torch.rand(lda, ldc, dtype=dtype, device=device)
+            matB = torch.rand(ldb, ldc, dtype=dtype, device=device).t()
 
-            # # 'NT'
-            matA = torch.rand(k, lda, dtype=dtype, device=device).t()
-            matB = torch.rand(k, ldb, dtype=dtype, device=device)
-            subA = matA[:k, :m]
+            subA = matA[:m,:k]
+            subB = matB[:k,:n]
+
+            torch.mm(matA, matB)
+            torch.mm(subA, subB)
+
+            # 'NN'
+            matA = torch.rand(lda, ldc, dtype=dtype, device=device)
+            matB = torch.rand(ldc, ldb, dtype=dtype, device=device)
+            subA = matA[:m, :k]
             subB = matB[:k, :n]
             torch.mm(matA, matB)
             torch.mm(subA, subB)
 
-            # # 'TT'
-            # matA = torch.rand(k, lda, dtype=dtype, device=device).t()
-            # matB = torch.rand(ldb, k, dtype=dtype, device=device).t()
-            # subA = matA[:k, :m]
-            # subB = matB[:n, :k]
-            # torch.mm(matA, matB)
-            # torch.mm(subA, subB)
+            # 'NT'
+            matA = torch.rand(ldc, lda, dtype=dtype, device=device).t()
+            matB = torch.rand(ldc, ldb, dtype=dtype, device=device)
+            subA = matA[:m, :k]
+            subB = matB[:k, :n]
+            torch.mm(matA, matB)
+            torch.mm(subA, subB)
+
+            # 'TT'
+            matA = torch.rand(k, lda, dtype=dtype, device=device).t()
+            matB = torch.rand(ldb, k, dtype=dtype, device=device).t()
+            subA = matA[:k, :m]
+            subB = matB[:n, :k]
+            torch.mm(matA, matB)
+            torch.mm(subA, subB)
 
             self.assertTrue(torch.cuda.tunable.is_enabled())
             self.assertTrue(torch.cuda.tunable.tuning_is_enabled() is False)

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -465,9 +465,10 @@ def _create_matrices(
     if subMatrix:
         # User reference for understanding leading dimension:
         # https://github.com/Reference-LAPACK/lapack/blob/master/BLAS/SRC/dgemm.f
-        # TO DO: rowsA = rowsB = ldc may not be necessary, but it is
-        # simplest scenario to consider
-        rowsA = rowsB = ldc
+        # TO DO: According to lines 108 - 133, there is no lower bound on rowsA,
+        # but there is a restriction on rowsB. Using this formula for now as it
+        # seems to work for all UTs.
+        rowsA = rowsB = max(ldc, k)
 
         if randn:
             matA = torch.randn(rowsA, lda, dtype=dtypeA, device=deviceid)

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -665,6 +665,11 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
             return
 
         [b] = [int(g) for g in untuned_gemm_temp[5:6]]
+
+        # Resolve linter issue
+        if dtype is None or not isinstance(dtype, torch.dtype):
+            raise TypeError(f"dtype must be a torch.dtype, but got {dtype}")
+
         matA, matB = _create_batch_matrices(
             m,
             n,

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -583,10 +583,7 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
     dtypeB = None
     dtypeC = None
 
-    # TODO: Role of transA and transB is counterintuitive in the code
-    # below. In many places their role should be inverted. Additionaly
-    # there are implicit transposes elsewhere. Code could be
-    # simplified further.
+    # Extract BLAS parameters
     if underscore_count == 2:
         [op_sig, data_type, layout] = untuned_gemm[0].split("_")
         transB = layout[0] == "T"

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -613,8 +613,8 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
 
         if subMatrix:
             warnings.warn(
-            "Offline tuning is not supported on submatrices. Use online tuning instead. "
-            + f"Skipped tuning for: {untuned_gemm[1]}"
+                "Offline tuning is not supported on submatrices. Use online tuning instead. "
+                + f"Skipped tuning for: {untuned_gemm[1]}"
             )
             return
 

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -694,25 +694,12 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
         # y = x*A^T + b
         assert transA != transB
 
-        if subMatrix:
-            warnings.warn(
-            "Offline tuning is not supported on submatrices. Use online tuning instead. "
-            + f"Skipped tuning for: {untuned_gemm[1]}"
-            )
-            return
-
-        X = (
-            torch.rand(k, m, dtype=dtype, device=deviceid).t()
-            if transB
-            else torch.rand(m, k, dtype=dtype, device=deviceid)
-        )
-        matA = (
-            torch.rand(n, k, dtype=dtype, device=deviceid)
-            if transA
-            else torch.rand(k, n, dtype=dtype, device=deviceid).t()
-        )
         bias = torch.rand(n, dtype=dtype, device=deviceid)
 
+        X, matA = _create_matrices(
+            m, n, k, lda, ldb, ldc, transA, transB, dtype, deviceid, subMatrix=subMatrix
+        )
+        matA = matA.t()
         torch.nn.functional.linear(X, matA, bias)
     else:
         warnings.warn(f"error: unknown op {op_sig}")

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -438,20 +438,20 @@ def _gather_tunableop_results() -> None:
 
 
 def _create_matrices(
-    m,
-    n,
-    k,
-    lda,
-    ldb,
-    ldc,
-    transA,
-    transB,
-    dtypeA,
-    deviceid,
-    dtypeB=None,
-    randn=True,
-    subMatrix=False,
-):
+    m: int,
+    n: int,
+    k: int,
+    lda: int,
+    ldb: int,
+    ldc: int,
+    transA: bool,
+    transB: bool,
+    dtypeA: torch.dtype,
+    deviceid: str,
+    dtypeB: Optional[torch.dtype] = None,
+    randn: bool = True,
+    subMatrix: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
     r"""Helper function for _process_single_offline_gemm.
     Creates matrices that are then consumed by one of the Torch GEMM APIs.
     """
@@ -597,6 +597,10 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
                 )
                 return
 
+        # Resolve linter issue
+        if dtype is None or not isinstance(dtype, torch.dtype):
+            raise TypeError(f"dtype must be a torch.dtype, but got {dtype}")
+
         matA, matB = _create_matrices(
             m, n, k, lda, ldb, ldc, transA, transB, dtype, deviceid, subMatrix=subMatrix
         )
@@ -636,6 +640,10 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
         # Only combination supported by PyTorch
         assert transA is True
         assert transB is False
+
+        # Resolve linter issue
+        if dtypeA is None or not isinstance(dtypeA, torch.dtype):
+            raise TypeError(f"dtype must be a torch.dtype, but got {dtypeA}")
 
         matA, matB = _create_matrices(
             m,
@@ -693,6 +701,10 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
     elif op_sig == "GemmAndBiasTunableOp":
         # y = x*A^T + b
         assert transA != transB
+
+        # Resolve linter issue
+        if dtype is None or not isinstance(dtype, torch.dtype):
+            raise TypeError(f"dtype must be a torch.dtype, but got {dtype}")
 
         bias = torch.rand(n, dtype=dtype, device=deviceid)
 

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -707,11 +707,8 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
             if transA
             else torch.rand(k, n, dtype=dtype, device=deviceid).t()
         )
-        bias = (
-            torch.rand(n, dtype=dtype, device=deviceid)
-            if transA
-            else torch.rand(m, dtype=dtype, device=deviceid)
-        )
+        bias = torch.rand(n, dtype=dtype, device=deviceid)
+
         torch.nn.functional.linear(X, matA, bias)
     else:
         warnings.warn(f"error: unknown op {op_sig}")

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -534,6 +534,10 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
     dtypeB = None
     dtypeC = None
 
+    # TODO: Role of transA and transB is counterintuitive in the code
+    # below. In many places their role should be inverted. Additionaly
+    # there are implicit transposes elsewhere. Code could be
+    # simplified further.
     if underscore_count == 2:
         [op_sig, data_type, layout] = untuned_gemm[0].split("_")
         transA = layout[0] == "T"

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -573,16 +573,11 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
         assert untuned_gemm_temp[4] == "ld"
         [lda, ldb, ldc] = [int(g) for g in untuned_gemm_temp[5:8]]
 
-    # We cannot handle submatrices in offline tuning
+    # Detect subMatrix case
     if all(item in [n, m, k] for item in [lda, ldb, ldc]):
         subMatrix = False
     else:
         subMatrix = True
-        warnings.warn(
-            "Offline tuning is not supported on submatrices. Use online tuning instead. "
-            + f"Skipped tuning for: {untuned_gemm[1]}"
-        )
-    #     return
 
     if op_sig == "GemmTunableOp":
         # Warnings for unsupported cases:
@@ -609,6 +604,13 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
             warnings.warn(
                 "Offline tuning is not support for this GEMM. Use online tuning instead. "
                 + f"Skipped tuning for: {untuned_gemm[1]}"
+            )
+            return
+
+        if subMatrix:
+            warnings.warn(
+            "Offline tuning is not supported on submatrices. Use online tuning instead. "
+            + f"Skipped tuning for: {untuned_gemm[1]}"
             )
             return
 
@@ -687,6 +689,13 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
     elif op_sig == "GemmAndBiasTunableOp":
         # y = x*A^T + b
         assert transA != transB
+
+        if subMatrix:
+            warnings.warn(
+            "Offline tuning is not supported on submatrices. Use online tuning instead. "
+            + f"Skipped tuning for: {untuned_gemm[1]}"
+            )
+            return
 
         X = (
             torch.rand(k, m, dtype=dtype, device=deviceid).t()

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -470,11 +470,11 @@ def _create_matrices(
         rowsA = rowsB = ldc
 
         if randn:
-            matA = torch.randn(rowsA, ldb, dtype=dtypeA, device=deviceid)
-            matB = torch.randn(rowsB, lda, dtype=dtypeA, device=deviceid)
+            matA = torch.randn(rowsA, lda, dtype=dtypeA, device=deviceid)
+            matB = torch.randn(rowsB, ldb, dtype=dtypeA, device=deviceid)
         else:
-            matA = torch.full((rowsA, ldb), fillA, dtype=dtypeB, device=deviceid)
-            matB = torch.full((rowsB, lda), fillB, dtype=dtypeB, device=deviceid)
+            matA = torch.full((rowsA, lda), fillA, dtype=dtypeB, device=deviceid)
+            matB = torch.full((rowsB, ldb), fillB, dtype=dtypeB, device=deviceid)
 
         subA = matA[:k, :m].t() if transB else matA[:m, :k]
         subB = matB[:n, :k].t() if transA else matB[:k, :n]
@@ -568,10 +568,10 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
     [n, m, k] = [int(g) for g in untuned_gemm_temp[1:4]]
     if op_sig == "GemmStridedBatchedTunableOp":
         assert untuned_gemm_temp[6] == "ld"
-        [lda, ldb, ldc] = [int(g) for g in untuned_gemm_temp[7:10]]
+        [ldb, lda, ldc] = [int(g) for g in untuned_gemm_temp[7:10]]
     else:
         assert untuned_gemm_temp[4] == "ld"
-        [lda, ldb, ldc] = [int(g) for g in untuned_gemm_temp[5:8]]
+        [ldb, lda, ldc] = [int(g) for g in untuned_gemm_temp[5:8]]
 
     # Detect subMatrix case
     if all(item in [n, m, k] for item in [lda, ldb, ldc]):


### PR DESCRIPTION
This PR adds support for submatrices in offline tuning for:
- GEMM
- GEMM and bias
- ScaledGEMM
- Batch Strided GEMM

New UTs to cover submatrices. Submatrices for strided batch API is not part of this PR and will be done seperately.

There is also a bug fix for offline tuning for full matrix for GEMM and bias in the `NT` case. Offline and online UTs were updated to cover this corner case.

To improve code readability, swapped definition of transA and transB.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang