### PR TITLE
[Inductor] Add utility to rewrite sympy expressions with FloorDiv

### DIFF
--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -984,6 +984,7 @@ class TestFloorDiv(TestCase):
         self.assertEqual(expr.count(sympy.Pow), 1)
 
         rewritten = FloorDiv.rewrite(expr)
+        self._expand_and_check(expr, rewritten)
         self.assertTrue(isinstance(rewritten, FloorDiv))
         self.assertEqual(rewritten.args, (x, y))
 
@@ -1012,6 +1013,7 @@ class TestFloorDiv(TestCase):
         self.assertEqual(expr.count(FloorDiv), 0)
 
         rewritten = FloorDiv.rewrite(expr)
+        self._expand_and_check(expr, rewritten)
         self.assertEqual(rewritten.count(FloorDiv), 2)
 
     def test_rewrite_floor_div_rational_const(self):

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -957,6 +957,25 @@ class TestSingletonInt(TestCase):
         self.assertEqual(j1.free_symbols, set())
 
 class TestFloorDiv(TestCase):
+
+    def _expand_and_check(self, x: sympy.Expr, y: sympy.Expr):
+        """
+        Checks equality after expanding FloorDiv.
+        """
+        x, y = tuple(expr.expand(floordiv=True) for expr in (x, y))
+        self.assertEqual(x, y)
+
+    def test_expand(self):
+        x, y = sympy.symbols("x y")
+        orig = FloorDiv(x, y)
+        expanded = orig.expand(floordiv=True)
+
+        # Check the args of the expanded expression.
+        self.assertTrue(isinstance(expanded, sympy.floor))
+        num, denom = orig.args
+        (quotient,) = expanded.args
+        self.assertEqual(quotient, num / denom)
+
     def test_rewrite_floor_div_mul_pow(self):
         x, y = sympy.symbols("x y")
         expr = sympy.floor(x / y)

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -1026,6 +1026,17 @@ class TestFloorDiv(TestCase):
         rewritten = FloorDiv.rewrite(expr)
         self.assertEqual(rewritten, sympy.S.Zero)
 
+    def test_no_distribute_mul_floordiv(self):
+        """
+        Test that multiplication doesn't distribute with floor division.
+        """
+        x = sympy.Symbol("x")
+        expr = 2 * sympy.floor(x / 2)
+        rewritten = FloorDiv.rewrite(expr)
+        self._expand_and_check(expr, rewritten)
+        self.assertEqual(rewritten.count(sympy.Mul), 1)
+        self.assertEqual(rewritten.count(FloorDiv), 1)
+
 class TestIdentity(TestCase):
     def test_expand_identity(self):
         """

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -956,6 +956,43 @@ class TestSingletonInt(TestCase):
 
         self.assertEqual(j1.free_symbols, set())
 
+class TestFloorDiv(TestCase):
+    def test_rewrite_floor_div_mul(self):
+        x, y = sympy.symbols("x y")
+        expr = sympy.floor(x / y)
+        self.assertEqual(expr.count(FloorDiv), 0)
+        self.assertEqual(expr.count(sympy.core.mul.Mul), 1)
+
+        rewritten = FloorDiv.rewrite(expr)
+        self.assertTrue(isinstance(rewritten, FloorDiv))
+        self.assertEqual(rewritten.args, (x, y))
+
+    def test_rewrite_floor_div_rational(self):
+        x = sympy.Symbol("x")
+        expr = sympy.floor(x / 5)
+        self.assertEqual(expr.count(FloorDiv), 0)
+        self.assertEqual(expr.count(sympy.Rational), 1)
+
+        rewritten = FloorDiv.rewrite(expr)
+        self.assertTrue(isinstance(rewritten, FloorDiv))
+        self.assertEqual(rewritten.args, (x, 5))
+
+    def test_no_rewrite_div(self):
+        x, y = sympy.symbols("x y")
+        expr = x / y
+        self.assertEqual(expr.count(FloorDiv), 0)
+
+        rewritten = FloorDiv.rewrite(expr)
+        self.assertEqual(rewritten, expr)
+
+    def test_rewrite_floor_div_nested(self):
+        x, y = sympy.symbols("x y")
+        expr = sympy.floor((sympy.floor(x / 5) + 1) / y)
+        self.assertEqual(expr.count(FloorDiv), 0)
+
+        rewritten = FloorDiv.rewrite(expr)
+        self.assertEqual(rewritten.count(FloorDiv), 2)
+
 class TestIdentity(TestCase):
     def test_expand_identity(self):
         """

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -957,20 +957,22 @@ class TestSingletonInt(TestCase):
         self.assertEqual(j1.free_symbols, set())
 
 class TestFloorDiv(TestCase):
-    def test_rewrite_floor_div_mul(self):
+    def test_rewrite_floor_div_mul_pow(self):
         x, y = sympy.symbols("x y")
         expr = sympy.floor(x / y)
         self.assertEqual(expr.count(FloorDiv), 0)
         self.assertEqual(expr.count(sympy.core.mul.Mul), 1)
+        self.assertEqual(expr.count(sympy.Pow), 1)
 
         rewritten = FloorDiv.rewrite(expr)
         self.assertTrue(isinstance(rewritten, FloorDiv))
         self.assertEqual(rewritten.args, (x, y))
 
-    def test_rewrite_floor_div_rational(self):
+    def test_rewrite_floor_div_mul_rational(self):
         x = sympy.Symbol("x")
         expr = sympy.floor(x / 5)
         self.assertEqual(expr.count(FloorDiv), 0)
+        self.assertEqual(expr.count(sympy.core.mul.Mul), 1)
         self.assertEqual(expr.count(sympy.Rational), 1)
 
         rewritten = FloorDiv.rewrite(expr)
@@ -992,6 +994,16 @@ class TestFloorDiv(TestCase):
 
         rewritten = FloorDiv.rewrite(expr)
         self.assertEqual(rewritten.count(FloorDiv), 2)
+
+    def test_rewrite_floor_div_rational_const(self):
+        expr = sympy.floor(sympy.S.One / 5, evaluate=False)
+        self.assertEqual(expr.count(FloorDiv), 0)
+        self.assertEqual(expr.count(sympy.Mul), 0)
+        self.assertEqual(expr.count(sympy.Rational), 1)
+
+        # Expression evaluates to a compile time constant
+        rewritten = FloorDiv.rewrite(expr)
+        self.assertEqual(rewritten, sympy.S.Zero)
 
 class TestIdentity(TestCase):
     def test_expand_identity(self):

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -206,6 +206,13 @@ class FloorDiv(sympy.Function):
         divisor = printer.parenthesize(self.divisor, PRECEDENCE["Atom"] - 0.5)
         return f"({base}//{divisor})"
 
+    def _eval_expand_floordiv(self, **hints):
+        """
+        Expands FloorDiv(x, y) into floor(x / y).
+        """
+        num, denom = self.args
+        return sympy.floor(num / denom)
+
     # Automatic evaluation.
     # https://docs.sympy.org/latest/guides/custom-functions.html#best-practices-for-eval
     @classmethod

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -314,11 +314,11 @@ class FloorDiv(sympy.Function):
                 for arg_idx, frac in enumerate(arg.args):
                     other_arg = arg.args[1 - arg_idx]
                     if isinstance(frac, sympy.Rational):
-                        # Look for x * (y / z). This becomes FloorDiv(x * y, z).
+                        # Look for floor(x * (y / z)). This becomes FloorDiv(x * y, z).
                         numerator = other_arg * frac.numerator
                         return FloorDiv(numerator, frac.denominator)
                     elif isinstance(frac, sympy.Pow):
-                        # Look for x * (y ** -n). This becomes FloorDiv(x, y ** n).
+                        # Look for floor(x * (y ** -n)). This becomes FloorDiv(x, y ** n).
                         base, power = frac.args
                         if power.is_negative:
                             return FloorDiv(other_arg, base**-power)

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -311,7 +311,7 @@ class FloorDiv(sympy.Function):
                         numerator = other_arg * frac.numerator
                         return FloorDiv(numerator, frac.denominator)
                     elif isinstance(frac, sympy.Pow):
-                        # Look for x * (y ** -n). This becomes FloorDiv(x, y ^ n).
+                        # Look for x * (y ** -n). This becomes FloorDiv(x, y ** n).
                         base, power = frac.args
                         if power.is_negative:
                             return FloorDiv(other_arg, base**-power)


### PR DESCRIPTION
Feature used in https://github.com/pytorch/pytorch/pull/146942.

# Feature
This PR a two new routines:
  - Pattern match `floor(x/y)` and convert it to `x // y`. This is done by a new static method `FloorDiv.rewrite`, which is not part of sympy's general expression evaluation. The user has to specifically call this method to rewrite the expression.
  - The inverse: expand `x // y` back into `floor(x/y)`. This is triggered by `expr.expand(floordiv=True)`. 

The pattern match is useful in the parent PR because `FloorDiv` ops generate FX-friendly Python code, which we can directly embed into `SymInt`'s for things like the Triton launch grid. 

It would be possible to directly call `FloorDiv` when the grid expression is first constructed, as opposed to this approach of pattern matching it after the fact. However, since these grid expressions generate and evaluate Python code on the fly, that is not completely straightforward. It seems nice to have a utility for "fixing" a sympy expression which wasn't originally constructed with `FloorDiv`.

# Test plan
Added some unit tests covering these features. Expansion allows us to check that the pattern matcher is sound. The parent PR also uses pattern matching to compute launch grids in some dynamic shape tests.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10