### PR TITLE
[MPSInductor][BE] Implement reduction caching

### DIFF
--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -538,6 +538,12 @@ class MetalKernel(SIMDKernel):
         value: Union[CSEVariable, tuple[CSEVariable, ...]],
     ) -> Union[CSEVariable, tuple[CSEVariable, ...]]:
         """Codegen a reduction operation"""
+        # Return cached reduction
+        assert self.inside_reduction
+        assert not self._load_mask
+        cache_key = (src_dtype, reduction_type, value)
+        if cache_key in self.cse.reduction_cache:
+            return self.cse.reduction_cache[cache_key]
         # Establish reduction buffer size and index expression
         reduction_idx = ""
         acc_buf_size = 1
@@ -641,9 +647,11 @@ class MetalKernel(SIMDKernel):
                 self.compute,
                 f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {acc_buf_size})",
             )
-            return OpsWrapper._unwrap(
+            self.cse.reduction_cache[cache_key] = result_tuple = OpsWrapper._unwrap(
                 (f"{wf_res}.x", f"{wf_res}.y", self.features.reduction_numel)
             )
+            return result_tuple
+
         if reduction_type == "welford_combine":
             assert not self.multistage_reduction, (
                 f"Multistage reduction not yet supported for {reduction_type}"
@@ -657,7 +665,10 @@ class MetalKernel(SIMDKernel):
                 self.compute,
                 f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {acc_buf_size})",
             )
-            return OpsWrapper._unwrap((f"{wf_res}.x", f"{wf_res}.y", f"{wf_res}.z"))
+            self.cse.reduction_cache[cache_key] = result_tuple = OpsWrapper._unwrap(
+                (f"{wf_res}.x", f"{wf_res}.y", f"{wf_res}.z")
+            )
+            return result_tuple
         raise NotImplementedError(reduction_type)
 
     def codegen_iteration_ranges_entry(self, entry: IterationRangesEntry) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #151155
* #151152
* __->__ #151151
* #150824
* #151042

That avoids double/triple invocation of welford reductions when both
mean and deviation must be returned

Code has been copy-n-pasted for Halide implementation
https://github.com/pytorch/pytorch/blob/575f348965abe8ea428eba7098f67ec9764a7f9a/torch/_inductor/codegen/halide.py#L1189-L1191

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov