### PR TITLE
Update ir.cpp: if it's not ROCm then it may be Vulkan

### DIFF
--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1179,7 +1179,7 @@ bool Node::hasSideEffects() const {
     case prim::rpc_sync: // It represents RPC message sent.
     case prim::rpc_remote: // It represents RPC message sent.
     case aten::wait: // It can represent RPC message received.
-#if !defined(USE_ROCM)
+#if !defined(USE_ROCM) && !defined(USE_VULKAN)
     case cuda::set_stream:
     case cuda::_set_device:
     case cuda::_current_device:


### PR DESCRIPTION
Fix build for USE_ROCM=OFF USE_VULKAN=ON


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd