### PR TITLE
[CUDA][cuBLAS][cuBLASLt] Opt-in unified cuBLAS + cuBLASLt workspaces

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -233,7 +233,7 @@ void* _getWorkspaceWithoutHandle() {
 }
 
 void* _getWorkspace(size_t& workspaceSize) {
-  #ifdef USE_ROCM
+  #ifdef (USE_ROCM || IS_FBCODE)
     // See https://github.com/pytorch/pytorch/issues/73328 for reasoning behind
     // setting this to 1M.
     workspaceSize = _getWorkspaceSize();

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -241,7 +241,7 @@ void* _getWorkspace(size_t& workspaceSize) {
     workspaceSize = at::cuda::getChosenWorkspaceSize();
   #endif
 
-  #ifdef USE_ROCM || defined(IS_FBCODE)
+  #ifdef (USE_ROCM || IS_FBCODE)
     auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
     auto workspace = allocator.allocate(workspaceSize);
     auto workspace_ptr = workspace.mutable_get();

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -241,7 +241,7 @@ void* _getWorkspace(size_t& workspaceSize) {
     workspaceSize = at::cuda::getChosenWorkspaceSize();
   #endif
 
-  #ifdef USE_ROCM || IS_FBCODE
+  #ifdef USE_ROCM || defined(IS_FBCODE)
     auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
     auto workspace = allocator.allocate(workspaceSize);
     auto workspace_ptr = workspace.mutable_get();

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -233,16 +233,16 @@ void* _getWorkspaceWithoutHandle() {
 }
 
 void* _getWorkspace(size_t& workspaceSize) {
-  #ifdef (USE_ROCM || IS_FBCODE)
-    workspaceSize = _getWorkspaceSize();
-    auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
-    auto workspace = allocator.allocate(workspaceSize);
-    auto workspace_ptr = workspace.mutable_get();
-    TORCH_CHECK(workspace_ptr != nullptr, "OOM trying to allocate workspace for cublaslt");
-  #else
-    workspaceSize = at::cuda::getChosenWorkspaceSize();
-    auto workspace_ptr = _getWorkspaceWithoutHandle();
-  #endif
+#ifdef (USE_ROCM || IS_FBCODE)
+  workspaceSize = _getWorkspaceSize();
+  auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
+  auto workspace = allocator.allocate(workspaceSize);
+  auto workspace_ptr = workspace.mutable_get();
+  TORCH_CHECK(workspace_ptr != nullptr, "OOM trying to allocate workspace for cublaslt");
+#else
+  workspaceSize = at::cuda::getChosenWorkspaceSize();
+  auto workspace_ptr = _getWorkspaceWithoutHandle();
+#endif
   return workspace_ptr;
 }
 

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -233,7 +233,7 @@ void* _getWorkspaceWithoutHandle() {
 }
 
 void* _getWorkspace(size_t& workspaceSize) {
-#ifdef (USE_ROCM || IS_FBCODE)
+#ifdef (defined(USE_ROCM) || defined(IS_FBCODE))
   workspaceSize = _getWorkspaceSize();
   auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
   auto workspace = allocator.allocate(workspaceSize);

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -234,19 +234,13 @@ void* _getWorkspaceWithoutHandle() {
 
 void* _getWorkspace(size_t& workspaceSize) {
   #ifdef (USE_ROCM || IS_FBCODE)
-    // See https://github.com/pytorch/pytorch/issues/73328 for reasoning behind
-    // setting this to 1M.
     workspaceSize = _getWorkspaceSize();
-  #else
-    workspaceSize = at::cuda::getChosenWorkspaceSize();
-  #endif
-
-  #ifdef (USE_ROCM || IS_FBCODE)
     auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
     auto workspace = allocator.allocate(workspaceSize);
     auto workspace_ptr = workspace.mutable_get();
     TORCH_CHECK(workspace_ptr != nullptr, "OOM trying to allocate workspace for cublaslt");
   #else
+    workspaceSize = at::cuda::getChosenWorkspaceSize();
     auto workspace_ptr = _getWorkspaceWithoutHandle();
   #endif
   return workspace_ptr;

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -228,7 +228,7 @@ void* _getWorkspaceWithoutHandle() {
   cudaStream_t _stream = stream;
   auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
   auto workspace_it = at::cuda::cublas_handle_stream_to_workspace().find(key);
-  TORCH_CHECK(workspace_it != at::cuda::cublas_handle_stream_to_workspace().end());
+  TORCH_INTERNAL_ASSERT(workspace_it != at::cuda::cublas_handle_stream_to_workspace().end());
   return workspace_it->second.mutable_get();
 }
 
@@ -238,11 +238,11 @@ void* _getWorkspace(size_t& workspaceSize) {
   auto cublasWorkspaceSize = at::cuda::getChosenWorkspaceSize();
   if (cublasWorkspaceSize < workspaceSize) {
     TORCH_WARN_ONCE("Requested CUBLASLT workspace size of ", workspaceSize,
-		    " bytes exceeds CUBLAS workspace size of ", cublasWorkspaceSize,
-		    " bytes. Please increase CUBLAS workspace size",
-		    " via CUBLAS_WORKSPACE_CONFIG or decrease requested"
+                    " bytes exceeds CUBLAS workspace size of ", cublasWorkspaceSize,
+                    " bytes. Please increase CUBLAS workspace size",
+                    " via CUBLAS_WORKSPACE_CONFIG or decrease requested"
                     " CUBLASLT_WORKSPACE_SIZE. Otherwise CUBLASLT workspace"
-		    " size will be limited to the CUBLAS workspace size.");
+                    " size will be limited to the CUBLAS workspace size.");
     workspaceSize = cublasWorkspaceSize;
   }
 // #else

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -233,7 +233,7 @@ void* _getWorkspaceWithoutHandle() {
 }
 
 void* _getWorkspace(size_t& workspaceSize) {
-#ifdef (defined(USE_ROCM) || defined(IS_FBCODE))
+#ifdef (defined(USE_ROCM) || defined(FBCODE_CAFFE2))
   workspaceSize = _getWorkspaceSize();
   auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
   auto workspace = allocator.allocate(workspaceSize);

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1711,7 +1711,7 @@ void scaled_gemm(
                 all_algos[i].algo,
                 ret_workspace_size);
         if (is_valid_status == HIPBLAS_STATUS_SUCCESS) {
-            if (ret_workspace_size <= workspaceSize) {
+            if (ret_workspace_size <= ltworkspace.size) {
                 heuristicResult = all_algos[i];
                 found = true;
                 break;

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -235,7 +235,7 @@ void* _getUnifiedWorkspaceWithoutHandle() {
 struct CublasLtWorkspace {
   CublasLtWorkspace() {
     size = _getWorkspaceSize();
-#ifdef USE_ROCM
+#ifndef USE_ROCM
     static bool unified = c10::utils::check_env("TORCH_CUBLASLT_UNIFIED_WORKSPACE") == true;
     if (unified) {
       auto cublasWorkspaceSize = at::cuda::getChosenWorkspaceSize();

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -3,6 +3,7 @@
  */
 
 #include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContextLight.h>
 #include <ATen/cuda/CUDABlas.h>
 #include <ATen/cuda/Exceptions.h>
 #include <ATen/cuda/CUDADataType.h>
@@ -410,9 +411,13 @@ static inline bool bgemm_internal_cublaslt(CUDABLAS_BGEMM_ARGTYPES(Dtype)) {
   }
 
   CuBlasLtMatmulPreference preference;
+#ifdef USE_ROCM
   // See https://github.com/pytorch/pytorch/issues/73328 for reasoning behind
   // setting this to 1M.
   size_t workspaceSize = _getWorkspaceSize();
+#else
+  size_t workspaceSize = getChosenWorkspaceSize();
+#endif
   preference.setAttribute(CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, workspaceSize);
 
 #ifndef USE_ROCM
@@ -424,7 +429,20 @@ static inline bool bgemm_internal_cublaslt(CUDABLAS_BGEMM_ARGTYPES(Dtype)) {
   preference.setAttribute(CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_C_BYTES, c_alignment);
 #endif
 
-  auto workspace = at::empty(static_cast<int64_t>(workspaceSize), at::TensorOptions().dtype(at::kByte).device(at::kCUDA));
+#ifdef USE_ROCM
+  auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
+  auto workspace = allocator.allocate(workspaceSize);
+  auto workspace_ptr = workspace.mutable_get();
+  TORCH_CHECK(workspace_ptr != nullptr, "OOM trying to allocate workspace for cublaslt");
+#else
+  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto stream = c10::cuda::getCurrentCUDAStream();
+  cudaStream_t _stream = stream;
+  auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
+  auto workspace_it = cublas_handle_stream_to_workspace().find(key);
+  TORCH_CHECK(workspace_it != cublas_handle_stream_to_workspace().end());
+  auto workspace_ptr = workspace_it->second.mutable_get();
+#endif
 
   cublasStatus_t cublasStatus = CUBLAS_STATUS_SUCCESS;
   cublasLtMatmulHeuristicResult_t heuristicResult = {};
@@ -458,7 +476,7 @@ static inline bool bgemm_internal_cublaslt(CUDABLAS_BGEMM_ARGTYPES(Dtype)) {
       c,
       Cdesc.descriptor(),
       &heuristicResult.algo,
-      workspace.mutable_data_ptr(),
+      workspace_ptr,
       workspaceSize,
       at::cuda::getCurrentCUDAStream());
   }
@@ -1374,9 +1392,14 @@ bool gemm_and_bias(
   CuBlasLtMatrixLayout Cdesc(abcType, m, n, result_ld);
 
   CuBlasLtMatmulPreference preference;
+#ifdef USE_ROCM
   // See https://github.com/pytorch/pytorch/issues/73328 for reasoning behind
   // setting this to 1M.
   size_t workspaceSize = _getWorkspaceSize();
+#else
+  size_t workspaceSize = getChosenWorkspaceSize();
+#endif
+
   preference.setAttribute(CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, workspaceSize);
 
 #ifndef USE_ROCM
@@ -1390,7 +1413,21 @@ bool gemm_and_bias(
   preference.setAttribute(CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_D_BYTES, d_alignment);
 #endif
 
-  auto workspace = at::empty(static_cast<int64_t>(workspaceSize), at::TensorOptions().dtype(at::kByte).device(at::kCUDA));
+  auto stream = c10::cuda::getCurrentCUDAStream();
+
+#ifdef USE_ROCM
+  auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
+  auto workspace = allocator.allocate(workspaceSize);
+  auto workspace_ptr = workspace.mutable_get();
+  TORCH_CHECK(workspace_ptr != nullptr, "OOM trying to allocate workspace for cublaslt");
+#else
+  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  cudaStream_t _stream = stream;
+  auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
+  auto workspace_it = cublas_handle_stream_to_workspace().find(key);
+  TORCH_CHECK(workspace_it != cublas_handle_stream_to_workspace().end());
+  auto workspace_ptr = workspace_it->second.mutable_get();
+#endif
 
   cublasLtMatmulHeuristicResult_t heuristicResult = {};
   int returnedResult = 0;
@@ -1425,7 +1462,7 @@ bool gemm_and_bias(
       result_ptr,
       Cdesc.descriptor(),
       &heuristicResult.algo,
-      workspace.mutable_data_ptr(),
+      workspace_ptr,
       workspaceSize,
       at::cuda::getCurrentCUDAStream());
   }
@@ -1618,8 +1655,23 @@ void scaled_gemm(
 #endif // if CUDA_VERSION >= 12080
   }
 
+  auto stream = c10::cuda::getCurrentCUDAStream();
+
+#ifdef USE_ROCM
   size_t workspaceSize = _getWorkspaceSize();
-  auto workspace = at::empty(static_cast<int64_t>(workspaceSize), at::TensorOptions().dtype(at::kByte).device(at::kCUDA));
+  auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
+  auto workspace = allocator.allocate(workspaceSize);
+  auto workspace_ptr = workspace.mutable_get();
+  TORCH_CHECK(workspace_ptr != nullptr, "OOM trying to allocate workspace for cublaslt");
+#else
+  size_t workspaceSize = getChosenWorkspaceSize();
+  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  cudaStream_t _stream = stream;
+  auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
+  auto workspace_it = cublas_handle_stream_to_workspace().find(key);
+  TORCH_CHECK(workspace_it != cublas_handle_stream_to_workspace().end());
+  auto workspace_ptr = workspace_it->second.mutable_get();
+#endif
 
   CuBlasLtMatmulPreference preference;
   preference.setAttribute(CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, workspaceSize);
@@ -1703,9 +1755,9 @@ void scaled_gemm(
       result_ptr,
       Ddesc.descriptor(),
       &heuristicResult.algo,
-      workspace.mutable_data_ptr(),
+      workspace_ptr,
       workspaceSize,
-      at::cuda::getCurrentCUDAStream());
+      stream);
   TORCH_CHECK(
       cublasStatus == CUBLAS_STATUS_SUCCESS,
       "CUDA error: ",
@@ -1781,8 +1833,8 @@ void int8_gemm(
   CuBlasLtMatmulPreference preference;
   size_t workspaceSize = _getWorkspaceSize();
   preference.setAttribute(CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, workspaceSize);
-  auto workspace = at::empty(workspaceSize, at::TensorOptions().dtype(at::kByte).device(at::kCUDA));
-
+  auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
+  auto workspace = allocator.allocate(workspaceSize);
   cublasLtMatmulHeuristicResult_t heuristicResult = {};
   int returnedResult = 0;
   TORCH_CUDABLAS_CHECK(cublasLtMatmulAlgoGetHeuristic(
@@ -1820,7 +1872,7 @@ void int8_gemm(
       nullptr, // Heuristics don't seem to work for int8
 #endif
 #ifdef USE_ROCM
-      workspace.mutable_data_ptr(),
+      workspace.mutable_get(),
 #else
       nullptr, // Non-zero workspace doesn't seem to work.
 #endif

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -222,6 +222,16 @@ static size_t _getWorkspaceSize() {
   return workspace_size;
 }
 
+void* _getWorkspaceWithoutHandle() {
+  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto stream = c10::cuda::getCurrentCUDAStream();
+  cudaStream_t _stream = stream;
+  auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
+  auto workspace_it = at::cuda::cublas_handle_stream_to_workspace().find(key);
+  TORCH_CHECK(workspace_it != at::cuda::cublas_handle_stream_to_workspace().end());
+  return workspace_it->second.mutable_get();
+}
+
 } // anonymous namespace
 
 namespace at::cuda::blas {
@@ -435,13 +445,7 @@ static inline bool bgemm_internal_cublaslt(CUDABLAS_BGEMM_ARGTYPES(Dtype)) {
   auto workspace_ptr = workspace.mutable_get();
   TORCH_CHECK(workspace_ptr != nullptr, "OOM trying to allocate workspace for cublaslt");
 #else
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-  auto stream = c10::cuda::getCurrentCUDAStream();
-  cudaStream_t _stream = stream;
-  auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
-  auto workspace_it = cublas_handle_stream_to_workspace().find(key);
-  TORCH_CHECK(workspace_it != cublas_handle_stream_to_workspace().end());
-  auto workspace_ptr = workspace_it->second.mutable_get();
+  auto workspace_ptr = _getWorkspaceWithoutHandle();
 #endif
 
   cublasStatus_t cublasStatus = CUBLAS_STATUS_SUCCESS;
@@ -1421,12 +1425,7 @@ bool gemm_and_bias(
   auto workspace_ptr = workspace.mutable_get();
   TORCH_CHECK(workspace_ptr != nullptr, "OOM trying to allocate workspace for cublaslt");
 #else
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-  cudaStream_t _stream = stream;
-  auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
-  auto workspace_it = cublas_handle_stream_to_workspace().find(key);
-  TORCH_CHECK(workspace_it != cublas_handle_stream_to_workspace().end());
-  auto workspace_ptr = workspace_it->second.mutable_get();
+  auto workspace_ptr = _getWorkspaceWithoutHandle();
 #endif
 
   cublasLtMatmulHeuristicResult_t heuristicResult = {};
@@ -1656,21 +1655,14 @@ void scaled_gemm(
   }
 
   auto stream = c10::cuda::getCurrentCUDAStream();
-
-#ifdef USE_ROCM
   size_t workspaceSize = _getWorkspaceSize();
+#ifdef USE_ROCM
   auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
   auto workspace = allocator.allocate(workspaceSize);
   auto workspace_ptr = workspace.mutable_get();
   TORCH_CHECK(workspace_ptr != nullptr, "OOM trying to allocate workspace for cublaslt");
 #else
-  size_t workspaceSize = getChosenWorkspaceSize();
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-  cudaStream_t _stream = stream;
-  auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
-  auto workspace_it = cublas_handle_stream_to_workspace().find(key);
-  TORCH_CHECK(workspace_it != cublas_handle_stream_to_workspace().end());
-  auto workspace_ptr = workspace_it->second.mutable_get();
+  auto workspace_ptr = _getWorkspaceWithoutHandle();
 #endif
 
   CuBlasLtMatmulPreference preference;

--- a/aten/src/ATen/cuda/CUDAContextLight.h
+++ b/aten/src/ATen/cuda/CUDAContextLight.h
@@ -2,6 +2,7 @@
 // Light-weight version of CUDAContext.h with fewer transitive includes
 
 #include <cstdint>
+#include <map>
 
 #include <cuda_runtime_api.h>
 #include <cusparse.h>
@@ -87,6 +88,8 @@ TORCH_CUDA_CPP_API cublasHandle_t getCurrentCUDABlasHandle();
 TORCH_CUDA_CPP_API cublasLtHandle_t getCurrentCUDABlasLtHandle();
 
 TORCH_CUDA_CPP_API void clearCublasWorkspaces();
+TORCH_CUDA_CPP_API std::map<std::tuple<void *, void *>, at::DataPtr>& cublas_handle_stream_to_workspace();
+TORCH_CUDA_CPP_API size_t getChosenWorkspaceSize();
 
 #if defined(CUDART_VERSION) || defined(USE_ROCM)
 TORCH_CUDA_CPP_API cusolverDnHandle_t getCurrentCUDASolverDnHandle();

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -83,11 +83,6 @@ static hipblasStatus_t hipblasSetWorkspace_replacement(hipblasHandle_t handle, v
 
 #endif
 
-std::map<std::tuple<void *, void *>, at::DataPtr>& cublas_handle_stream_to_workspace() {
-  static auto& instance = *new std::map<std::tuple<void *, void *>, at::DataPtr>;
-  return instance;
-}
-
 void createCublasHandle(cublasHandle_t *handle) {
   TORCH_CUDABLAS_CHECK(cublasCreate(handle));
 }
@@ -108,6 +103,11 @@ void destroyCublasHandle(cublasHandle_t handle) {
 using CuBlasPoolType = DeviceThreadHandlePool<cublasHandle_t, createCublasHandle, destroyCublasHandle>;
 
 } // namespace
+
+std::map<std::tuple<void *, void *>, at::DataPtr>& cublas_handle_stream_to_workspace() {
+  static auto& instance = *new std::map<std::tuple<void *, void *>, at::DataPtr>;
+  return instance;
+}
 
 void clearCublasWorkspaces() {
   cublas_handle_stream_to_workspace().clear();

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3555,6 +3555,13 @@ def run(runner, args, original_dir=None):
         if args.devices == ["xpu"]:
             torch.use_deterministic_algorithms(True, warn_only=True)
         os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+        if args.only is not None and args.only in {
+            "DebertaForQuestionAnswering",
+            "nvidia_deeprecommender",
+        }:
+            # These seem unhappy with numerics of larger cuBLASLt workspace
+            # sizes following #145130 (due to enabling split-k?)
+            torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.allow_tf32 = False
         torch.backends.cudnn.benchmark = False

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3555,15 +3555,16 @@ def run(runner, args, original_dir=None):
         if args.devices == ["xpu"]:
             torch.use_deterministic_algorithms(True, warn_only=True)
         os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
-        if args.only is not None and args.only in {
-            "DebertaForQuestionAnswering",
-            "RobertaForQuestionAnswering",
-            "nvidia_deeprecommender",
-            "volo_d1_224",
-        }:
-            # These seem unhappy with numerics of larger cuBLASLt workspace
-            # sizes following #145130 (due to enabling split-k?)
-            torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+        # TODO(eqy): revisit when cuBLASLt workspace size is bumped
+        # if args.only is not None and args.only in {
+        #     "DebertaForQuestionAnswering",
+        #     "RobertaForQuestionAnswering",
+        #     "nvidia_deeprecommender",
+        #     "volo_d1_224",
+        # }:
+        #     # These seem unhappy with numerics of larger cuBLASLt workspace
+        #     # sizes following #145130 (due to enabling split-k?)
+        #     torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.allow_tf32 = False
         torch.backends.cudnn.benchmark = False

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3557,6 +3557,7 @@ def run(runner, args, original_dir=None):
         os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
         if args.only is not None and args.only in {
             "DebertaForQuestionAnswering",
+            "RobertaForQuestionAnswering",
             "nvidia_deeprecommender",
             "volo_d1_224",
         }:

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3558,6 +3558,7 @@ def run(runner, args, original_dir=None):
         if args.only is not None and args.only in {
             "DebertaForQuestionAnswering",
             "nvidia_deeprecommender",
+            "volo_d1_224",
         }:
             # These seem unhappy with numerics of larger cuBLASLt workspace
             # sizes following #145130 (due to enabling split-k?)


### PR DESCRIPTION
opt-in version of https://github.com/pytorch/pytorch/pull/145130 as there was a lack of repro for the 70% forward issue
`TORCH_CUBLASLT_UNIFIED_WORKSPACE=1`

@izaitsevfb could you comment if it was repeatable per every forward pass, on startup, or something else?

cc @ptrblck @msaroufim @jerryzh168 @csarofeen @xwang233 @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames