### PR TITLE
[CI] Fix `GPUTests.test_scheduler_vertical_fusion1`

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -223,6 +223,7 @@ for test_name in [
     "test_rsqrt",
     "test_scalar_cpu_tensor_arg",
     "test_scalar_output",
+    "test_scheduler_vertical_fusion1",
     "test_setitem_with_int_parameter",
     "test_signbit",
     "test_silu",

--- a/torch/_inductor/test_operators.py
+++ b/torch/_inductor/test_operators.py
@@ -12,7 +12,7 @@ if not torch._running_with_deploy():
     )
 
     _test_lib_impl = torch.library.Library("_inductor_test", "IMPL")
-    for dispatch_key in ("CPU", "CUDA", "Meta"):
+    for dispatch_key in ("CPU", "CUDA", "MPS", "Meta"):
         _test_lib_impl.impl("realize", lambda x: x.clone(), dispatch_key)
 
     class Realize(Function):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

By enabling the test_operators on MPS device

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov