### PR TITLE
fix sympy FloorToInt when compile

### DIFF
--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -543,7 +543,7 @@ class FloorToInt(sympy.Function):
         if isinstance(number, sympy.Integer):
             return number
         if isinstance(number, sympy.Number):
-            return sympy.Integer(math.floor(float(number)))
+            return sympy.Integer(sympy.floor(number))
 
 
 class CeilDiv(sympy.Function):


### PR DESCRIPTION
fix follow error
<img width="1903" alt="image" src="https://github.com/user-attachments/assets/2d967bc4-f884-4e5f-b1d4-d8cca2f281a7" />


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168