### PR TITLE
autograd: Add VJP and JVP rules for aten::aminmax

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11403,26 +11403,14 @@ class TestAutogradDeviceType(TestCase):
                 self.assertEqual(x.grad.sum(), 1.0)
                 self.assertEqual((x.grad == 1 / 3).sum(), 3)
         
-        # 2) Test torch.amin and torch.amax only on the non NaN input:
-        for f in [torch.amin, torch.amax]:
+        amax2 = lambda x: torch.aminmax(x)[1]
+        for f in [torch.amin, torch.amax, amax2]:
             x1 = torch.tensor(
                 [1.0, 0.0, 1.0, 0.0, 1.0, 0.0],
                 device=device,
                 requires_grad=True,
             )
-            y = f(x1)   # scalar Tensor
-            y.backward()
-            self.assertEqual(x1.grad.sum(), 1.0)
-            self.assertEqual((x1.grad == 1.0 / 3.0).sum(), 3)
-
-        # 3) Test torch.aminmax (component 0 = min, component 1 = max) on non NaN:
-        for component in (0, 1):
-            x1 = torch.tensor(
-                [1.0, 0.0, 1.0, 0.0, 1.0, 0.0],
-                device=device,
-                requires_grad=True,
-            )
-            y = torch.aminmax(x1)[component]  # grab either the "min" or the "max" output
+            y = f(x1)
             y.backward()
             self.assertEqual(x1.grad.sum(), 1.0)
             self.assertEqual((x1.grad == 1.0 / 3.0).sum(), 3)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1201,6 +1201,17 @@
   self: scale_grad_by_count(restore_reduced_dims(grad, dim, keepdim), restore_reduced_dims(result, dim, keepdim) == self, dim)
   result: amaxamin_jvp(self_p, self_t, result, dim, keepdim)
 
+- name: aminmax(Tensor self, *, int? dim=None, bool keepdim=False) -> (Tensor min, Tensor max)
+  self:  |
+    scale_grad_by_count(restore_reduced_dims(grad_min, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim),
+      restore_reduced_dims(min, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim) == self,
+      dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}) +
+    scale_grad_by_count(restore_reduced_dims(grad_max, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim),
+      restore_reduced_dims(max, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim) == self,
+      dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}) 
+  min: 'amaxamin_jvp(self_p, self_t, min, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim)'
+  max: 'amaxamin_jvp(self_p, self_t, max, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim)'
+
 - name: mm(Tensor self, Tensor mat2) -> Tensor
   self: mm_mat1_backward(grad, mat2, self.sym_sizes(), self.sym_strides(), self.layout(), 1)
   mat2: mm_mat2_backward(grad, self, mat2.sym_sizes(), mat2.sym_strides(), mat2.layout(), 1)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1202,13 +1202,7 @@
   result: amaxamin_jvp(self_p, self_t, result, dim, keepdim)
 
 - name: aminmax(Tensor self, *, int? dim=None, bool keepdim=False) -> (Tensor min, Tensor max)
-  self:  |
-    scale_grad_by_count(restore_reduced_dims(grad_min, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim),
-      restore_reduced_dims(min, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim) == self,
-      dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}) +
-    scale_grad_by_count(restore_reduced_dims(grad_max, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim),
-      restore_reduced_dims(max, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim) == self,
-      dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}) 
+  self: aminmax_backward(self, dim, keepdim, grad_min, grad_max, min, max)
   min: 'amaxamin_jvp(self_p, self_t, min, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim)'
   max: 'amaxamin_jvp(self_p, self_t, max, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim)'
 

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -231,10 +231,8 @@ Tensor aminmax_backward(
   auto min_reduced = restore_reduced_dims(min, dims, keepdim);
   auto max_reduced = restore_reduced_dims(max, dims, keepdim);
 
-  auto min_mask =
-      at::isnan(min).all().item<bool>() ? self.isnan() : self == min_reduced;
-  auto max_mask =
-      at::isnan(max).all().item<bool>() ? self.isnan() : self == max_reduced;
+  auto min_mask = self == min_reduced;
+  auto max_mask = self == max_reduced;
 
   Tensor result;
   if (grad_min.defined()) {

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -220,13 +220,12 @@ Tensor amaxamin_jvp(
 
 Tensor aminmax_backward(
     const Tensor& self,
-    c10::optional<int64_t> dim,
+    std::optional<int64_t> dim,
     bool keepdim,
     const Tensor& grad_min,
     const Tensor& grad_max,
     const Tensor& min,
     const Tensor& max) {
-
   auto dims = dim.has_value() ? IntArrayRef{*dim} : IntArrayRef{};
   Tensor result;
   Tensor max_mask;

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -816,6 +816,14 @@ Tensor amaxamin_jvp(
     const Tensor& result,
     IntArrayRef dim,
     bool keepdim);
+Tensor aminmax_backward(
+    const at::Tensor& self,
+    c10::optional<int64_t> dim,
+    bool keepdim,
+    const at::Tensor& grad_min,
+    const at::Tensor& grad_max,
+    const at::Tensor& min,
+    const at::Tensor& max);
 std::tuple<Tensor, Tensor, Tensor> layer_norm_double_backward(
     const Tensor& input,
     const std::optional<Tensor>& gamma,

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -818,7 +818,7 @@ Tensor amaxamin_jvp(
     bool keepdim);
 Tensor aminmax_backward(
     const at::Tensor& self,
-    c10::optional<int64_t> dim,
+    std::optional<int64_t> dim,
     bool keepdim,
     const at::Tensor& grad_min,
     const at::Tensor& grad_max,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14694,7 +14694,7 @@ op_db: list[OpInfo] = [
            dtypes=all_types_and(torch.bool, torch.float16, torch.bfloat16),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16, torch.int32, torch.int8),
            decorators=(onlyNativeDeviceTypes,),
-           supports_autograd=False,
+           supports_autograd=True,
            sample_inputs_func=sample_inputs_aminmax,
            error_inputs_func=error_inputs_aminmax_amax_amin),
     OpInfo('as_strided',


### PR DESCRIPTION
Adds functionally correct backward (VJP) and forward (JVP) autograd rules for the aten::aminmax operator to derivatives.yaml using existing helper functions. This ensures correct eager mode differentiation.

Fixes #148808






cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @voznesenskym @penguinwu @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @xmfan