### PR TITLE
Fix `keepdim` param optional description

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -50,6 +50,11 @@ reduceops_common_args = merge_dicts(
     keepdim (bool): whether the output tensor has :attr:`dim` retained or not.
 """
     ),
+    {
+        "opt_keepdim": """
+    keepdim (bool, optional): whether the output tensor has :attr:`dim` retained or not. Default: ``False``.
+"""
+    },
 )
 
 multi_dim_common = merge_dicts(
@@ -78,11 +83,6 @@ output tensor having 1 (or ``len(dim)``) fewer dimension(s).
         If ``None``, all dimensions are reduced.
 """
     },
-    {
-        "opt_keepdim": """
-    keepdim (bool, optional): whether the output tensor has :attr:`dim` retained or not. Default: ``False``.
-"""
-    },
 )
 
 single_dim_common = merge_dicts(
@@ -92,6 +92,17 @@ single_dim_common = merge_dicts(
     dim (int): the dimension to reduce.
 """
     ),
+    {
+        "opt_dim": """
+    dim (int, optional): the dimension to reduce.
+"""
+    },
+    {
+        "opt_dim_all_reduce": """
+    dim (int, optional): the dimension to reduce.
+        If ``None``, all dimensions are reduced.
+"""
+    },
     {
         "keepdim_details": """If :attr:`keepdim` is ``True``, the output tensor is of the same size
 as :attr:`input` except in the dimension :attr:`dim` where it is of size 1.
@@ -5661,7 +5672,7 @@ Example::
             [ 4.,  5.,  6.]])
     >>> torch.kthvalue(x, 2, 0, True)
     torch.return_types.kthvalue(values=tensor([[4., 5., 6.]]), indices=tensor([[1, 1, 1]]))
-""".format(**multi_dim_common),
+""".format(**single_dim_common),
 )
 
 add_docstr(
@@ -6682,7 +6693,7 @@ Example::
             [-1.6092,  0.5419, -0.2993,  0.3195]])
     >>> torch.argmax(a, dim=1)
     tensor([ 0,  2,  0,  1])
-""".format(**multi_dim_common),
+""".format(**single_dim_common),
 )
 
 add_docstr(
@@ -6908,7 +6919,7 @@ Example::
             [ 1.0778, -1.9510,  0.7048,  0.4742, -0.7125]])
     >>> torch.median(a, 1)
     torch.return_types.median(values=tensor([-0.3982,  0.2270,  0.2488,  0.4742]), indices=tensor([1, 4, 4, 3]))
-""".format(**multi_dim_common),
+""".format(**single_dim_common),
 )
 
 add_docstr(
@@ -6965,7 +6976,7 @@ Example::
     torch.return_types.median(values=tensor([nan, 1., nan]), indices=tensor([1, 1, 1]))
     >>> a.nanmedian(0)
     torch.return_types.nanmedian(values=tensor([2., 1., 1.]), indices=tensor([0, 1, 0]))
-""".format(**multi_dim_common),
+""".format(**single_dim_common),
 )
 
 add_docstr(
@@ -7037,7 +7048,7 @@ Example::
     tensor(2.)
     >>> torch.quantile(a, 0.4, interpolation='nearest')
     tensor(1.)
-""".format(**multi_dim_common),
+""".format(**single_dim_common),
 )
 
 add_docstr(
@@ -7077,7 +7088,7 @@ Example::
     tensor([1., 2.])
     >>> t.nanquantile(0.5, dim=1)
     tensor([   nan, 1.5000])
-""".format(**multi_dim_common),
+""".format(**single_dim_common),
 )
 
 add_docstr(
@@ -7137,7 +7148,7 @@ Example::
    :noindex:
 
 See :func:`torch.minimum`.
-""".format(**multi_dim_common),
+""".format(**single_dim_common),
 )
 
 add_docstr(
@@ -7336,7 +7347,7 @@ Example::
             [1],
             [3],
             [1]])
-""".format(**multi_dim_common),
+""".format(**single_dim_common),
 )
 
 add_docstr(
@@ -7523,7 +7534,7 @@ Example::
     torch.return_types.mode(
     values=tensor([0, 2, 0, 0, 0, 0, 2]),
     indices=tensor([1, 3, 4, 4, 2, 4, 4]))
-""".format(**multi_dim_common),
+""".format(**single_dim_common),
 )
 
 add_docstr(
@@ -8609,7 +8620,7 @@ Example::
             [ 1.1131, -1.0629]])
     >>> torch.prod(a, 1)
     tensor([-0.2018, -0.2962, -0.0821, -1.1831])
-""".format(**multi_dim_common),
+""".format(**single_dim_common),
 )
 
 add_docstr(

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -804,7 +804,7 @@ returns `True` if all elements in the row evaluate to `True` and `False` otherwi
 
 Args:
     {input}
-    {dim}
+    {opt_dim}
     {opt_keepdim}
 
 Keyword args:
@@ -859,7 +859,7 @@ returns `True` if any element in the row evaluate to `True` and `False` otherwis
 
 Args:
     {input}
-    {dim}
+    {opt_dim}
     {opt_keepdim}
 
 Keyword args:
@@ -6609,7 +6609,7 @@ dimension(s) :attr:`dim`.
 
 Args:
     {input}
-    {dim}
+    {opt_dim}
     {opt_keepdim}
 
 Keyword args:
@@ -6664,7 +6664,7 @@ documentation for the exact semantics of this method.
 
 Args:
     {input}
-    {dim} If ``None``, the argmax of the flattened input is returned.
+    {opt_dim} If ``None``, the argmax of the flattened input is returned.
     {opt_keepdim}
 
 Example::
@@ -6756,7 +6756,7 @@ reduce over all of them.
 
 Args:
     {input}
-    {dim}
+    {opt_dim}
     {opt_keepdim}
 
 Keyword args:
@@ -6885,7 +6885,7 @@ the outputs tensor having 1 fewer dimension than :attr:`input`.
 
 Args:
     {input}
-    {dim}
+    {opt_dim}
     {opt_keepdim}
 
 Keyword args:
@@ -6942,7 +6942,7 @@ median of the non-``NaN`` elements. If all the elements in a reduced row are ``N
 
 Args:
     {input}
-    {dim}
+    {opt_dim}
     {opt_keepdim}
 
 Keyword args:
@@ -6990,7 +6990,7 @@ equal to the size of :attr:`q`, the remaining dimensions are what remains from t
 Args:
     {input}
     q (float or Tensor): a scalar or 1D tensor of values in the range [0, 1].
-    {dim}
+    {opt_dim}
     {opt_keepdim}
 
 Keyword arguments:
@@ -7048,7 +7048,7 @@ that reduction will be ``NaN``. See the documentation for :func:`torch.quantile`
 Args:
     {input}
     q (float or Tensor): a scalar or 1D tensor of quantile values in the range [0, 1]
-    {dim}
+    {opt_dim}
     {opt_keepdim}
 
 Keyword arguments:
@@ -7111,7 +7111,7 @@ the output tensors having 1 fewer dimension than :attr:`input`.
 
 Args:
     {input}
-    {dim}
+    {opt_dim}
     {opt_keepdim}
 
 Keyword args:
@@ -7214,7 +7214,7 @@ dimension(s) :attr:`dim`.
 
 Args:
     {input}
-    {dim}
+    {opt_dim}
     {opt_keepdim}
 
 Keyword args:
@@ -7311,7 +7311,7 @@ documentation for the exact semantics of this method.
 
 Args:
     {input}
-    {dim} If ``None``, the argmin of the flattened input is returned.
+    {opt_dim} If ``None``, the argmin of the flattened input is returned.
     {opt_keepdim}
 
 Example::
@@ -7501,7 +7501,7 @@ in the output tensors having 1 fewer dimension than :attr:`input`.
 
 Args:
     {input}
-    {dim}
+    {opt_dim}
     {opt_keepdim}
 
 Keyword args:
@@ -8588,7 +8588,7 @@ dimension :attr:`dim`.
 
 Args:
     {input}
-    {dim}
+    {opt_dim}
     {opt_keepdim}
 
 Keyword args:
@@ -10485,7 +10485,7 @@ the :attr:`correction`.
 
 Args:
     {input}
-    {dim}
+    {opt_dim}
 
 Keyword args:
     correction (int): difference between the sample size and sample degrees of freedom.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -805,7 +805,7 @@ returns `True` if all elements in the row evaluate to `True` and `False` otherwi
 Args:
     {input}
     {dim}
-    {keepdim}
+    {opt_keepdim}
 
 Keyword args:
     {out}
@@ -860,7 +860,7 @@ returns `True` if any element in the row evaluate to `True` and `False` otherwis
 Args:
     {input}
     {dim}
-    {keepdim}
+    {opt_keepdim}
 
 Keyword args:
     {out}
@@ -5636,7 +5636,7 @@ Args:
     {input}
     k (int): k for the k-th smallest element
     dim (int, optional): the dimension to find the kth value along
-    {keepdim}
+    {opt_keepdim}
 
 Keyword args:
     out (tuple, optional): the output tuple of (Tensor, LongTensor)
@@ -5656,7 +5656,7 @@ Example::
             [ 4.,  5.,  6.]])
     >>> torch.kthvalue(x, 2, 0, True)
     torch.return_types.kthvalue(values=tensor([[4., 5., 6.]]), indices=tensor([[1, 1, 1]]))
-""".format(**single_dim_common),
+""".format(**multi_dim_common),
 )
 
 add_docstr(
@@ -6256,7 +6256,7 @@ For summation index :math:`j` given by `dim` and other indices :math:`i`, the re
 Args:
     {input}
     {opt_dim}
-    {keepdim}
+    {opt_keepdim}
 
 Keyword args:
     {out}
@@ -6610,7 +6610,7 @@ dimension(s) :attr:`dim`.
 Args:
     {input}
     {dim}
-    {keepdim}
+    {opt_keepdim}
 
 Keyword args:
   {out}
@@ -6665,7 +6665,7 @@ documentation for the exact semantics of this method.
 Args:
     {input}
     {dim} If ``None``, the argmax of the flattened input is returned.
-    {keepdim}
+    {opt_keepdim}
 
 Example::
 
@@ -6677,7 +6677,7 @@ Example::
             [-1.6092,  0.5419, -0.2993,  0.3195]])
     >>> torch.argmax(a, dim=1)
     tensor([ 0,  2,  0,  1])
-""".format(**single_dim_common),
+""".format(**multi_dim_common),
 )
 
 add_docstr(
@@ -6757,7 +6757,7 @@ reduce over all of them.
 Args:
     {input}
     {dim}
-    {keepdim}
+    {opt_keepdim}
 
 Keyword args:
     {dtype}
@@ -6803,7 +6803,7 @@ propagate the `NaN` to the output whereas :func:`torch.nanmean` will ignore the
 Args:
     input (Tensor): the input tensor, either of floating point or complex dtype
     {opt_dim}
-    {keepdim}
+    {opt_keepdim}
 
 Keyword args:
     {dtype}
@@ -6886,7 +6886,7 @@ the outputs tensor having 1 fewer dimension than :attr:`input`.
 Args:
     {input}
     {dim}
-    {keepdim}
+    {opt_keepdim}
 
 Keyword args:
     out ((Tensor, Tensor), optional): The first tensor will be populated with the median values and the second
@@ -6903,7 +6903,7 @@ Example::
             [ 1.0778, -1.9510,  0.7048,  0.4742, -0.7125]])
     >>> torch.median(a, 1)
     torch.return_types.median(values=tensor([-0.3982,  0.2270,  0.2488,  0.4742]), indices=tensor([1, 4, 4, 3]))
-""".format(**single_dim_common),
+""".format(**multi_dim_common),
 )
 
 add_docstr(
@@ -6943,7 +6943,7 @@ median of the non-``NaN`` elements. If all the elements in a reduced row are ``N
 Args:
     {input}
     {dim}
-    {keepdim}
+    {opt_keepdim}
 
 Keyword args:
     out ((Tensor, Tensor), optional): The first tensor will be populated with the median values and the second
@@ -6960,7 +6960,7 @@ Example::
     torch.return_types.median(values=tensor([nan, 1., nan]), indices=tensor([1, 1, 1]))
     >>> a.nanmedian(0)
     torch.return_types.nanmedian(values=tensor([2., 1., 1.]), indices=tensor([0, 1, 0]))
-""".format(**single_dim_common),
+""".format(**multi_dim_common),
 )
 
 add_docstr(
@@ -6991,7 +6991,7 @@ Args:
     {input}
     q (float or Tensor): a scalar or 1D tensor of values in the range [0, 1].
     {dim}
-    {keepdim}
+    {opt_keepdim}
 
 Keyword arguments:
     interpolation (str): interpolation method to use when the desired quantile lies between two data points.
@@ -7032,7 +7032,7 @@ Example::
     tensor(2.)
     >>> torch.quantile(a, 0.4, interpolation='nearest')
     tensor(1.)
-""".format(**single_dim_common),
+""".format(**multi_dim_common),
 )
 
 add_docstr(
@@ -7049,7 +7049,7 @@ Args:
     {input}
     q (float or Tensor): a scalar or 1D tensor of quantile values in the range [0, 1]
     {dim}
-    {keepdim}
+    {opt_keepdim}
 
 Keyword arguments:
     interpolation (str): interpolation method to use when the desired quantile lies between two data points.
@@ -7072,7 +7072,7 @@ Example::
     tensor([1., 2.])
     >>> t.nanquantile(0.5, dim=1)
     tensor([   nan, 1.5000])
-""".format(**single_dim_common),
+""".format(**multi_dim_common),
 )
 
 add_docstr(
@@ -7112,7 +7112,7 @@ the output tensors having 1 fewer dimension than :attr:`input`.
 Args:
     {input}
     {dim}
-    {keepdim}
+    {opt_keepdim}
 
 Keyword args:
     out (tuple, optional): the tuple of two output tensors (min, min_indices)
@@ -7132,7 +7132,7 @@ Example::
    :noindex:
 
 See :func:`torch.minimum`.
-""".format(**single_dim_common),
+""".format(**multi_dim_common),
 )
 
 add_docstr(
@@ -7215,7 +7215,7 @@ dimension(s) :attr:`dim`.
 Args:
     {input}
     {dim}
-    {keepdim}
+    {opt_keepdim}
 
 Keyword args:
   {out}
@@ -7312,7 +7312,7 @@ documentation for the exact semantics of this method.
 Args:
     {input}
     {dim} If ``None``, the argmin of the flattened input is returned.
-    {keepdim}
+    {opt_keepdim}
 
 Example::
 
@@ -7331,7 +7331,7 @@ Example::
             [1],
             [3],
             [1]])
-""".format(**single_dim_common),
+""".format(**multi_dim_common),
 )
 
 add_docstr(
@@ -7502,7 +7502,7 @@ in the output tensors having 1 fewer dimension than :attr:`input`.
 Args:
     {input}
     {dim}
-    {keepdim}
+    {opt_keepdim}
 
 Keyword args:
     out (tuple, optional): the result tuple of two output tensors (values, indices)
@@ -7518,7 +7518,7 @@ Example::
     torch.return_types.mode(
     values=tensor([0, 2, 0, 0, 0, 0, 2]),
     indices=tensor([1, 3, 4, 4, 2, 4, 4]))
-""".format(**single_dim_common),
+""".format(**multi_dim_common),
 )
 
 add_docstr(
@@ -8589,7 +8589,7 @@ dimension :attr:`dim`.
 Args:
     {input}
     {dim}
-    {keepdim}
+    {opt_keepdim}
 
 Keyword args:
     {dtype}
@@ -8604,7 +8604,7 @@ Example::
             [ 1.1131, -1.0629]])
     >>> torch.prod(a, 1)
     tensor([-0.2018, -0.2962, -0.0821, -1.1831])
-""".format(**single_dim_common),
+""".format(**multi_dim_common),
 )
 
 add_docstr(
@@ -10495,7 +10495,7 @@ Keyword args:
             Previously this argument was called ``unbiased`` and was a boolean
             with ``True`` corresponding to ``correction=1`` and ``False`` being
             ``correction=0``.
-    {keepdim}
+    {opt_keepdim}
     {out}
 
 Example:
@@ -10550,7 +10550,7 @@ Keyword args:
             Previously this argument was called ``unbiased`` and was a boolean
             with ``True`` corresponding to ``correction=1`` and ``False`` being
             ``correction=0``.
-    {keepdim}
+    {opt_keepdim}
     {out}
 
 Returns:
@@ -10649,7 +10649,7 @@ reduce over all of them.
 Args:
     {input}
     {opt_dim}
-    {keepdim}
+    {opt_keepdim}
 
 Keyword args:
     {dtype}
@@ -10701,7 +10701,7 @@ If :attr:`dim` is a list of dimensions, reduce over all of them.
 Args:
     {input}
     {opt_dim}
-    {keepdim}
+    {opt_keepdim}
 
 Keyword args:
     {dtype}
@@ -11841,7 +11841,7 @@ Keyword args:
             Previously this argument was called ``unbiased`` and was a boolean
             with ``True`` corresponding to ``correction=1`` and ``False`` being
             ``correction=0``.
-    {keepdim}
+    {opt_keepdim}
     {out}
 
 Example:
@@ -11895,7 +11895,7 @@ Keyword args:
             Previously this argument was called ``unbiased`` and was a boolean
             with ``True`` corresponding to ``correction=1`` and ``False`` being
             ``correction=0``.
-    {keepdim}
+    {opt_keepdim}
     {out}
 
 Returns:

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -70,6 +70,11 @@ output tensor having 1 (or ``len(dim)``) fewer dimension(s).
     {
         "opt_dim": """
     dim (int or tuple of ints, optional): the dimension or dimensions to reduce.
+"""
+    },
+    {
+        "opt_dim_all_reduce": """
+    dim (int or tuple of ints, optional): the dimension or dimensions to reduce.
         If ``None``, all dimensions are reduced.
 """
     },
@@ -804,7 +809,7 @@ returns `True` if all elements in the row evaluate to `True` and `False` otherwi
 
 Args:
     {input}
-    {opt_dim}
+    {opt_dim_all_reduce}
     {opt_keepdim}
 
 Keyword args:
@@ -859,7 +864,7 @@ returns `True` if any element in the row evaluate to `True` and `False` otherwis
 
 Args:
     {input}
-    {opt_dim}
+    {opt_dim_all_reduce}
     {opt_keepdim}
 
 Keyword args:
@@ -6255,7 +6260,7 @@ For summation index :math:`j` given by `dim` and other indices :math:`i`, the re
 
 Args:
     {input}
-    {opt_dim}
+    {dim}
     {opt_keepdim}
 
 Keyword args:
@@ -6496,7 +6501,7 @@ in the output tensors having 1 fewer dimension than ``input``.
 
 Args:
     {input}
-    {opt_dim}
+    {opt_dim_all_reduce}
     {opt_keepdim}
 
 Keyword args:
@@ -6609,7 +6614,7 @@ dimension(s) :attr:`dim`.
 
 Args:
     {input}
-    {opt_dim}
+    {opt_dim_all_reduce}
     {opt_keepdim}
 
 Keyword args:
@@ -6756,7 +6761,7 @@ reduce over all of them.
 
 Args:
     {input}
-    {opt_dim}
+    {opt_dim_all_reduce}
     {opt_keepdim}
 
 Keyword args:
@@ -6802,7 +6807,7 @@ propagate the `NaN` to the output whereas :func:`torch.nanmean` will ignore the
 
 Args:
     input (Tensor): the input tensor, either of floating point or complex dtype
-    {opt_dim}
+    {opt_dim_all_reduce}
     {opt_keepdim}
 
 Keyword args:
@@ -6885,7 +6890,7 @@ the outputs tensor having 1 fewer dimension than :attr:`input`.
 
 Args:
     {input}
-    {opt_dim}
+    {opt_dim_all_reduce}
     {opt_keepdim}
 
 Keyword args:
@@ -6942,7 +6947,7 @@ median of the non-``NaN`` elements. If all the elements in a reduced row are ``N
 
 Args:
     {input}
-    {opt_dim}
+    {opt_dim_all_reduce}
     {opt_keepdim}
 
 Keyword args:
@@ -7048,7 +7053,7 @@ that reduction will be ``NaN``. See the documentation for :func:`torch.quantile`
 Args:
     {input}
     q (float or Tensor): a scalar or 1D tensor of quantile values in the range [0, 1]
-    {opt_dim}
+    {opt_dim_all_reduce}
     {opt_keepdim}
 
 Keyword arguments:
@@ -7111,7 +7116,7 @@ the output tensors having 1 fewer dimension than :attr:`input`.
 
 Args:
     {input}
-    {opt_dim}
+    {opt_dim_all_reduce}
     {opt_keepdim}
 
 Keyword args:
@@ -7214,7 +7219,7 @@ dimension(s) :attr:`dim`.
 
 Args:
     {input}
-    {opt_dim}
+    {opt_dim_all_reduce}
     {opt_keepdim}
 
 Keyword args:
@@ -8588,7 +8593,7 @@ dimension :attr:`dim`.
 
 Args:
     {input}
-    {opt_dim}
+    {opt_dim_all_reduce}
     {opt_keepdim}
 
 Keyword args:
@@ -10485,7 +10490,7 @@ the :attr:`correction`.
 
 Args:
     {input}
-    {opt_dim}
+    {opt_dim_all_reduce}
 
 Keyword args:
     correction (int): difference between the sample size and sample degrees of freedom.
@@ -10540,7 +10545,7 @@ the :attr:`correction`.
 
 Args:
     {input}
-    {opt_dim}
+    {opt_dim_all_reduce}
 
 Keyword args:
     correction (int): difference between the sample size and sample degrees of freedom.
@@ -10648,7 +10653,7 @@ reduce over all of them.
 
 Args:
     {input}
-    {opt_dim}
+    {opt_dim_all_reduce}
     {opt_keepdim}
 
 Keyword args:
@@ -10700,7 +10705,7 @@ If :attr:`dim` is a list of dimensions, reduce over all of them.
 
 Args:
     {input}
-    {opt_dim}
+    {opt_dim_all_reduce}
     {opt_keepdim}
 
 Keyword args:
@@ -11831,7 +11836,7 @@ the :attr:`correction`.
 
 Args:
     {input}
-    {opt_dim}
+    {opt_dim_all_reduce}
 
 Keyword args:
     correction (int): difference between the sample size and sample degrees of freedom.
@@ -11885,7 +11890,7 @@ the :attr:`correction`.
 
 Args:
     {input}
-    {opt_dim}
+    {opt_dim_all_reduce}
 
 Keyword args:
     correction (int): difference between the sample size and sample degrees of freedom.


### PR DESCRIPTION
Fixes #151104

Fix optional description of `dim`  and `keepdim`, except `torch.quantile` which already fixed in #146485

## Test Result

### Before

![image](https://github.com/user-attachments/assets/69f1824d-3d15-407e-8c92-f25a22e16914)


### After

![image](https://github.com/user-attachments/assets/e5aac674-ab8f-4988-a5f1-7400c36bdc99)

cc @soulitzer 

