### PR TITLE
Fix `MaskedTensor` to device ignored mask

### DIFF
--- a/test/test_maskedtensor.py
+++ b/test/test_maskedtensor.py
@@ -236,6 +236,32 @@ class TestBasics(TestCase):
             _compare_mt_t(sparse_mt, data)
             _compare_mt_t(mt.grad, data.grad)
 
+    def test_to_device(self, device):
+        for sample in _generate_sample_data(device=device):
+            data = sample.input
+            mask = sample.kwargs["mask"]
+            mt = masked_tensor(data, mask, requires_grad=True)
+
+            new_device = torch.device("cpu") if device != "cpu" else torch.device("cuda")
+            mt_device = mt.to(new_device)
+
+            self.assertEqual(mt_device.device.type, new_device.type)
+            self.assertEqual(mt_device.get_mask().device.type, new_device.type)
+            self.assertEqual(mt_device.get_data().device.type, new_device.type)
+
+    def test_to_dtype(self, device):
+        for sample in _generate_sample_data(device=device):
+            data = sample.input
+            mask = sample.kwargs["mask"]
+            mt = masked_tensor(data, mask, requires_grad=True)
+
+            new_dtype = torch.float64 if data.dtype == torch.float32 else torch.float32
+            mt_dtype = mt.to(new_dtype)
+
+            self.assertEqual(mt_dtype.dtype, new_dtype)
+            self.assertEqual(mt_dtype.get_mask().dtype, torch.bool)
+            self.assertEqual(mt_dtype.get_data().dtype, new_dtype)
+
     def test_to_dense(self, device):
         samples = _generate_sample_data(
             device=device,

--- a/test/test_maskedtensor.py
+++ b/test/test_maskedtensor.py
@@ -242,7 +242,7 @@ class TestBasics(TestCase):
             mask = sample.kwargs["mask"]
             mt = masked_tensor(data, mask, requires_grad=True)
 
-            new_device = torch.device("cpu") if device != "cpu" else torch.device("cuda")
+            new_device = torch.device("cuda") if device != "cuda" and torch.cuda.is_available() else torch.device("cpu")
             mt_device = mt.to(new_device)
 
             self.assertEqual(mt_device.device.type, new_device.type)

--- a/torch/masked/maskedtensor/_ops_refs.py
+++ b/torch/masked/maskedtensor/_ops_refs.py
@@ -351,7 +351,10 @@ def _apply_fn_on_data(func, *args, **kwargs):
 @register_dispatch_func([torch.ops.aten._to_copy])
 def _to_copy(func, *args, **kwargs):
     new_data = func(_get_data(args[0]), *args[1:], **kwargs)
-    return MaskedTensor(new_data, _maybe_get_mask(args[0]))
+    cloned_kwargs = kwargs.copy()
+    cloned_kwargs["dtype"] = torch.bool
+    new_mask = func(_maybe_get_mask(args[0]), *args[1:], **cloned_kwargs)
+    return MaskedTensor(new_data, new_mask)
 
 
 @register_dispatch_func([torch.ops.aten._softmax])

--- a/torch/masked/maskedtensor/core.py
+++ b/torch/masked/maskedtensor/core.py
@@ -6,6 +6,7 @@ from typing import Any
 from typing_extensions import TypeIs
 
 import torch
+from torch._prims_common import canonicalize_device, DeviceLikeType
 from torch.overrides import get_default_nowrap_functions
 
 
@@ -363,8 +364,8 @@ class MaskedTensor(torch.Tensor):
         device_to = current_device
         if len(args) == 1:
             arg = args[0]
-            if isinstance(arg, (torch.device, str, int)):
-                device_to = torch.device(arg)
+            if isinstance(arg, DeviceLikeType):
+                device_to = canonicalize_device(arg)
             elif isinstance(arg, torch.Tensor):
                 device_to = arg.device
         else:

--- a/torch/masked/maskedtensor/core.py
+++ b/torch/masked/maskedtensor/core.py
@@ -2,11 +2,11 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 
 import warnings
-from typing import Any, get_args
+from typing import Any
 from typing_extensions import TypeIs
 
 import torch
-from torch._prims_common import canonicalize_device, DeviceLikeType
+from torch._prims_common import canonicalize_device
 from torch.overrides import get_default_nowrap_functions
 
 
@@ -364,7 +364,7 @@ class MaskedTensor(torch.Tensor):
         device_to = current_device
         if len(args) == 1:
             arg = args[0]
-            if isinstance(arg, get_args(DeviceLikeType)):
+            if isinstance(arg, (torch.device, str, int)):
                 device_to = canonicalize_device(arg)
             elif isinstance(arg, torch.Tensor):
                 device_to = arg.device

--- a/torch/masked/maskedtensor/core.py
+++ b/torch/masked/maskedtensor/core.py
@@ -2,7 +2,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 
 import warnings
-from typing import Any
+from typing import Any, get_args
 from typing_extensions import TypeIs
 
 import torch
@@ -364,7 +364,7 @@ class MaskedTensor(torch.Tensor):
         device_to = current_device
         if len(args) == 1:
             arg = args[0]
-            if isinstance(arg, DeviceLikeType):
+            if isinstance(arg, get_args(DeviceLikeType)):
                 device_to = canonicalize_device(arg)
             elif isinstance(arg, torch.Tensor):
                 device_to = arg.device

--- a/torch/masked/maskedtensor/core.py
+++ b/torch/masked/maskedtensor/core.py
@@ -2,7 +2,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 
 import warnings
-from typing import Any
+from typing import Any, cast
 from typing_extensions import TypeIs
 
 import torch
@@ -370,5 +370,6 @@ class MaskedTensor(torch.Tensor):
                 device_to = arg.device
         else:
             device_to = kwargs.get("device", current_device)
-        self._masked_mask = self._masked_mask.to(device=device_to)
-        return super().to(*args, **kwargs)
+        masked_tensor = cast(MaskedTensor, super().to(*args, **kwargs))
+        masked_tensor._masked_mask = self._masked_mask.to(device=device_to)
+        return masked_tensor

--- a/torch/masked/maskedtensor/core.py
+++ b/torch/masked/maskedtensor/core.py
@@ -357,3 +357,17 @@ class MaskedTensor(torch.Tensor):
     @property
     def is_sparse(self):  # type: ignore[override]
         return self.is_sparse_coo() or self.is_sparse_csr()
+
+    def to(self, *args, **kwargs):
+        current_device = self._masked_data.device
+        device_to = current_device
+        if len(args) == 1:
+            arg = args[0]
+            if isinstance(arg, (torch.device, str, int)):
+                device_to = torch.device(arg)
+            elif isinstance(arg, torch.Tensor):
+                device_to = arg.device
+        else:
+            device_to = kwargs.get("device", current_device)
+        self._masked_mask = self._masked_mask.to(device=device_to)
+        return super().to(*args, **kwargs)

--- a/torch/masked/maskedtensor/core.py
+++ b/torch/masked/maskedtensor/core.py
@@ -2,11 +2,10 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 
 import warnings
-from typing import Any, cast
+from typing import Any
 from typing_extensions import TypeIs
 
 import torch
-from torch._prims_common import canonicalize_device
 from torch.overrides import get_default_nowrap_functions
 
 
@@ -358,18 +357,3 @@ class MaskedTensor(torch.Tensor):
     @property
     def is_sparse(self):  # type: ignore[override]
         return self.is_sparse_coo() or self.is_sparse_csr()
-
-    def to(self, *args, **kwargs):
-        current_device = self._masked_data.device
-        device_to = current_device
-        if len(args) == 1:
-            arg = args[0]
-            if isinstance(arg, (torch.device, str, int)):
-                device_to = canonicalize_device(arg)
-            elif isinstance(arg, torch.Tensor):
-                device_to = arg.device
-        else:
-            device_to = kwargs.get("device", current_device)
-        masked_tensor = cast(MaskedTensor, super().to(*args, **kwargs))
-        masked_tensor._masked_mask = self._masked_mask.to(device=device_to)
-        return masked_tensor


### PR DESCRIPTION
Fixes #147140

## Changes

- Add `to` implementation in `MaskedTensor` to support move `mask` to target device

## Test Result

```python
In [1]: import torch
   ...: from torch.masked import as_masked_tensor
   ...: data = torch.tensor([1,2,3])
   ...: mask = torch.tensor([True,False,True])
   ...: mt = as_masked_tensor(data, mask).to('cuda')
   ...: mt.get_data().device, mt.get_mask().device
/home/zong/code/pytorch/torch/masked/maskedtensor/core.py:247: UserWarning: The PyTorch API of MaskedTensors is in prototype stage and will change in the near future. Please open a Github issue for features requests and see our documentation on the torch.masked module for further information about the project.
  return MaskedTensor(data, mask)
/home/zong/code/pytorch/torch/masked/maskedtensor/_ops_refs.py:354: UserWarning: The PyTorch API of MaskedTensors is in prototype stage and will change in the near future. Please open a Github issue for features requests and see our documentation on the torch.masked module for further information about the project.
  return MaskedTensor(new_data, _maybe_get_mask(args[0]))
Out[1]: (device(type='cuda', index=0), device(type='cuda', index=0))

In [2]: mt.sum(dim=0)
/home/zong/code/pytorch/torch/masked/maskedtensor/core.py:247: UserWarning: The PyTorch API of MaskedTensors is in prototype stage and will change in the near future. Please open a Github issue for features requests and see our documentation on the torch.masked module for further information about the project.
  return MaskedTensor(data, mask)
Out[2]: MaskedTensor(4, True)

```


```bash
pytest test/test_maskedtensor.py -vv
```

![image](https://github.com/user-attachments/assets/640b809c-b4f0-4aca-a09e-04049017a745)
