### PR TITLE
Fix corner case in `torch.arange()` where int64_t truncation leads to size 0

### DIFF
--- a/aten/src/ATen/native/RangeUtils.h
+++ b/aten/src/ATen/native/RangeUtils.h
@@ -31,14 +31,14 @@ int64_t compute_arange_size(const Scalar& start, const Scalar& end, const Scalar
   if constexpr (std::is_same_v<scalar_t, int64_t>) {
     // Workaround for corner case where casting start/end/step to int64_t
     // may introduce precision loss. If all values are within the range
-    // that double can represent exactly (i.e., [-2^53, 2^53]), we prefer 
-    // using double arithmetic for consistency across devices. Otherwise, 
+    // that double can represent exactly (i.e., [-2^53, 2^53]), we prefer
+    // using double arithmetic for consistency across devices. Otherwise,
     // fallback to int64_t computation.
     auto xmax = static_cast<accscalar_t>(1L << std::numeric_limits<double>::digits);
     auto xmin = -xmax;
-    bool in_double_precision = xmin < xstart && xstart < xmax &&
-        xmin < xend && xend < xmax &&
-        xmin < xstep && xstep < xmax;
+    bool in_double_precision = xmin <= xstart && xstart <= xmax &&
+        xmin <= xend && xend <= xmax &&
+        xmin <= xstep && xstep <= xmax;
     if (C10_LIKELY(in_double_precision)) {
       size_d = std::ceil(
           static_cast<double>(end.to<double>() - start.to<double>()) /

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -915,6 +915,12 @@ TEST(TensorTest, Arange) {
     auto x = torch::arange(0, 5);
     ASSERT_EQ(x.dtype(), torch::kLong);
   }
+  {
+    auto x = torch::arange(0, 0.5, 1, torch::kLong);
+    ASSERT_EQ(x.dtype(), torch::kLong);
+    ASSERT_EQ(x.sizes(), std::vector<int64_t>({1}));
+    ASSERT_EQ(x.numel(), 1);
+  }
   test_Arange_expected_dtype(torch::kFloat);
   test_Arange_expected_dtype(torch::kDouble);
 }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10850,7 +10850,7 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
     def test_arange_with_int64(self):
         self.assertEqual(torch.arange(0, 0.5, 1, dtype=torch.int64).numel(), 1)
         self.assertEqual(torch.arange(0, 1.5, 1, dtype=torch.int64).numel(), 2)
-        self.assertEqual(torch.arange(1.1, 5, 1, dtype=torch.int64).numel(), 4)
+        self.assertEqual(torch.arange(1 << 53, (1 << 53) + 0.5, 1, dtype=torch.int64).numel(), 0)
 
 # The following block extends TestTorch with negative dim wrapping tests
 # FIXME: replace these with OpInfo sample inputs or systemic OpInfo tests

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10847,6 +10847,11 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
             _ = math.pow(x, 3)  # calling it again does not result in a second warning
             self.assertEqual(len(w), 1)
 
+    def test_arange_with_int64(self):
+        self.assertEqual(torch.arange(0, 0.5, 1, dtype=torch.int64).numel(), 1)
+        self.assertEqual(torch.arange(0, 1.5, 1, dtype=torch.int64).numel(), 2)
+        self.assertEqual(torch.arange(1.1, 5, 1, dtype=torch.int64).numel(), 4)
+
 # The following block extends TestTorch with negative dim wrapping tests
 # FIXME: replace these with OpInfo sample inputs or systemic OpInfo tests
 # Functions to test negative dimension wrapping


### PR DESCRIPTION
Fixes #149097

### Changes

This PR introduces a workaround for corner case where casting start/end/step to int64_t may introduce precision loss. If all values are within the range that double can represent exactly (i.e., [-2^53, 2^53]), we prefer using double arithmetic for consistency across devices. Otherwise, fallback to int64_t computation.

### Tests

All results are same as np

```
python test/test_torch.py -k test_arange
```

cc: @albanD 