### PR TITLE
[Dynamo] Fix the unimplemented_v2 of EventVariable.call_method in ctx_manager.py

### DIFF
--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1341,13 +1341,14 @@ class EventVariable(VariableTracker):
                 ),
             )
         else:
+            method_name = (
+                f"{type(self.value).__module__}.{type(self.value).__qualname__}.{name}"
+            )
             unimplemented_v2(
-                gb_type="Unsupported torch.cuda.Event method",
+                gb_type=f"Unsupported {method_name} method",
                 context=str(name),
-                explanation=(
-                    f"Dynamo doesn't support tracing the torch.cuda.Event.{name} method. "
-                    f"We currently support wait, record, synchronize, and query.",
-                ),
+                explanation=f"Dynamo doesn't support tracing the {method_name} method. "
+                f"We currently support wait, record, synchronize, and query.",
                 hints=[
                     *graph_break_hints.SUPPORTABLE,
                 ],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #151217
* #151213
* __->__ #151208

Changes:
- Field of `explanations` shoule be `str` instead of `tuple`
- Not only `torch.cuda.Event`, but alse `torch.xpu.Event` can trigger this message.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames