### PR TITLE
[Event] add weakref for torch.Event

### DIFF
--- a/torch/csrc/Event.cpp
+++ b/torch/csrc/Event.cpp
@@ -82,6 +82,8 @@ static void THPEvent_dealloc(THPEvent* self) {
     pybind11::gil_scoped_release no_gil{};
     self->event.~Event();
   }
+  if (self->weakreflist != nullptr)
+    PyObject_ClearWeakRefs((PyObject*)self);
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
@@ -275,6 +277,8 @@ static PyMethodDef THPEvent_methods[] = {
     {(char*)"ipc_handle", THPEvent_ipc_handle, METH_NOARGS, nullptr},
     {nullptr}};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
 PyTypeObject THPEventType = {
     PyVarObject_HEAD_INIT(nullptr, 0)
     "torch.Event", /* tp_name */
@@ -300,7 +304,7 @@ PyTypeObject THPEventType = {
     nullptr, /* tp_traverse */
     nullptr, /* tp_clear */
     nullptr, /* tp_richcompare */
-    0, /* tp_weaklistoffset */
+    offsetof(THPEvent, weakreflist), /* tp_weaklistoffset */
     nullptr, /* tp_iter */
     nullptr, /* tp_iternext */
     THPEvent_methods, /* tp_methods */
@@ -315,6 +319,7 @@ PyTypeObject THPEventType = {
     nullptr, /* tp_alloc */
     THPEvent_pynew, /* tp_new */
 };
+#pragma GCC diagnostic pop
 
 void THPEvent_init(PyObject* module) {
   THPEventClass = &THPEventType;

--- a/torch/csrc/Event.h
+++ b/torch/csrc/Event.h
@@ -7,6 +7,7 @@
 struct TORCH_API THPEvent {
   PyObject_HEAD
   c10::Event event;
+  PyObject* weakreflist;
 };
 TORCH_API extern PyTypeObject* THPEventClass;
 TORCH_API extern PyTypeObject THPEventType;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #151217
* __->__ #151213
* #151208

**Backgroup:**
`torch._dynamo.utils.store_user_object_weakref(value)` was introduted by this [PR](https://github.com/pytorch/pytorch/pull/133635/files#diff-9f0663783bcd93e948e0491ef61b48123bdc9977bcc632fd707da578df13bfa1R802) for `torch.xxx.Event`, but `torch.Event` don`t support weakref.

So, the code shown below will fail:

```Python
@torch.compile(backend="eager"):
    event = torch.cuda.Event() //Success
    event = torch.Event() //Fail
```

**Optional sulotions:**
- Use Python class to wrap the current `torch.Event` class (Python class not created by C API supports weakref by default)
- add weakref capability by Python C API(Just like this pr did)

**Question:**
For testcase: Where can I put the tests?(If necessary)