### PR TITLE
Rendezvous on dead node

### DIFF
--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -320,9 +320,11 @@ def _remove_participant_epilogue(
     if state.complete:
         # If rendezvous was already complete and we still have participants left,
         # we need to start a new round if a participant leaves.
-        # We can only tigger a restart if there is a participant in the wait_list.
-        if not state.wait_list:
-            state.wait_list.add(next(iter(state.participants.keys())))
+        # A restart is only triggered if there is a participant in the wait_list.
+        # We move all participants to the wait_list so that all nodes have to rejoin
+        # the rendezvous.
+        state.wait_list.update(state.participants.keys())
+        state.participants.clear()
         state.complete = False
         state.round += 1
         logger.debug("Restarting rendezvous for round %s", state.round)

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -318,13 +318,14 @@ def _remove_participant_epilogue(
     state: _RendezvousState, settings: RendezvousSettings
 ) -> None:
     if state.complete:
-        # If we do not have any participants left, move to the next round.
-        if not state.participants:
-            msg = "No participants left in the rendezvous, marking rendezvous as incomplete"
-            logger.debug(msg)
-            state.complete = False
-
-            state.round += 1
+        # If rendezvous was already complete and we still have participants left,
+        # we need to start a new round if a participant leaves.
+        # We can only tigger a restart if there is a participant in the wait_list.
+        if not state.wait_list:
+            state.wait_list.add(next(iter(state.participants.keys())))
+        state.complete = False
+        state.round += 1
+        logger.debug("Restarting rendezvous for round %s", state.round)
     else:
         if len(state.participants) < settings.min_nodes:
             msg = (


### PR DESCRIPTION
This fixes #111646. If a participant in a completed(aka ongoing) rendezvous leaves, this will not trigger a rerendezvous even though [docs state as much](https://github.com/pytorch/pytorch/blob/d5a19e4525f49049f822930ed85fe32bb004589c/torch/distributed/elastic/rendezvous/__init__.py#L69).

We force the agent to restart by adding a participant to the wait_list already. This will kick off [all restarting and joining a new rendezvous.](https://github.com/pytorch/pytorch/blob/142f0f86ce054f401d9d5145e4291629cafba45f/torch/distributed/elastic/agent/server/api.py#L906)

A test was also added to verify this behaviour.


An alternative would be to instead change the [api ](https://github.com/pytorch/pytorch/blob/d5a19e4525f49049f822930ed85fe32bb004589c/torch/distributed/elastic/rendezvous/api.py#L144) to expose a cleaner way that a RendezvousBackend can provide a flag indicating the need for a restart.


Fixes #111646 


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta