### PR TITLE
[MPSInductor] Fix noop codegen

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -242,6 +242,7 @@ for test_name in [
     "test_views6",
     "test_views7",
     "test_zero_dim_reductions",
+    "test_zero_element_mutation",
 ]:
     setattr(MPSBasicTests, test_name, getattr(CommonTemplate, test_name))
 

--- a/torch/_inductor/codegen/mps_device_op_overrides.py
+++ b/torch/_inductor/codegen/mps_device_op_overrides.py
@@ -10,7 +10,7 @@ class MPSDeviceOpOverrides(DeviceOpOverrides):
 
     def set_device(self, device_idx: int) -> str:
         assert device_idx == 0
-        return "# MPS set device"
+        return "pass  # MPS set device"
 
 
 register_device_op_overrides("mps", MPSDeviceOpOverrides())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #151224

By adding `pass` in front of the comment for fake set_device call
Which fixes `TestGPU.test_zero_element_mutation_mps`, which previously
failed with
```
torch._inductor.exc.InductorError: RuntimeError: Failed to import /var/folders/sc/2thx6_x95h7_h9qs8s48yh140000gn/T/tmp2emka_sx/7k/c7kmnwhb363ysalhewglr3cwtej6tiz3t4ppqa4bvhubaokmlprw.py
IndentationError: expected an indented block after 'with' statement on line 38 (c7kmnwhb363ysalhewglr3cwtej6tiz3t4ppqa4bvhubaokmlprw.py, line 40)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov