### PR TITLE
[dynamo] keep C++ symbolic shape guards disabled for benchmarks

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/basic_modules_benchmarks.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/basic_modules_benchmarks.py
@@ -54,12 +54,9 @@ class Benchmark(BenchmarkBase):
         torch._dynamo.reset()
 
     def _work(self):
-        # enable_cpp_symbolic_shape_guards has impact on this benchmark
-        # Keep using False value for consistency.
         with (
             fresh_inductor_cache(),
             torch._inductor.config.patch(force_shape_pad=self._force_shape_pad),
-            torch._dynamo.config.patch("enable_cpp_symbolic_shape_guards", False),
         ):
             opt_m = torch.compile(backend=self.backend(), dynamic=self.is_dynamic())(
                 self.m.cuda() if self._is_gpu else self.m

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/benchmark_base.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/benchmark_base.py
@@ -247,7 +247,10 @@ class BenchmarkBase(ABC):
                     instruction_count=r,
                 )
         if self._enable_compile_time_instruction_count:
-            r = self._count_compile_time_instructions()
+            # enable_cpp_symbolic_shape_guards has impact on these benchmarks
+            # Keep using False value for consistency.
+            with config.patch("enable_cpp_symbolic_shape_guards", False):
+                r = self._count_compile_time_instructions()
 
             self.results.append(
                 (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #140756
* __->__ #151225



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames