### PR TITLE
NCCL: Fix cmake file when cross compiling.

### DIFF
--- a/cmake/Modules/FindNCCL.cmake
+++ b/cmake/Modules/FindNCCL.cmake
@@ -57,7 +57,9 @@ if(NCCL_FOUND)  # obtaining NCCL version and some sanity checks
   include(CheckCXXSymbolExists)
   check_cxx_symbol_exists(NCCL_VERSION_CODE nccl.h NCCL_VERSION_DEFINED)
 
-  if (NCCL_VERSION_DEFINED)
+  if (CMAKE_CROSSCOMPILING)
+    message(STATUS "NCCL version not checked - cross compiling")
+  elseif (NCCL_VERSION_DEFINED)
     set(file "${PROJECT_BINARY_DIR}/detect_nccl_version.cc")
     file(WRITE ${file} "
       #include <iostream>


### PR DESCRIPTION
When cross compiling pytorch, we cannot execute compiled code.
FindNCCL uses try_run to check if the header version matches the binary version.

This fixes cross compilation scenarios by checking for CMAKE_CROSSCOMPILING prior to try_execute.

