### PR TITLE
[BE][1/2] Move original_weights_lookup attribute to constant

### DIFF
--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -411,6 +411,8 @@ QBIN_RELU_OP_MAPPING: dict[Union[Callable, str], Callable] = {
     torch.mul: torch.ops.quantized.mul_relu,
 }
 
+ORIGINAL_WEIGHTS_LOOKUP = "original_weights_lookup"
+
 
 def _save_packed_weight(self, destination, prefix, keep_vars):
     for attr_name in dir(self):
@@ -530,7 +532,7 @@ def fold_weight(
 
     if keep_original_weights:
         setattr(  # noqa: B010
-            quantized_model, "original_weights_lookup", original_weights_lookup
+            quantized_model, ORIGINAL_WEIGHTS_LOOKUP, original_weights_lookup
         )
 
     return quantized_model


### PR DESCRIPTION
Summary: As title. Cleaning usages by using global constant.

Test Plan: `buck test 'fbcode//mode/opt' fbcode//caffe2/test:quantization_fx -- --exact 'caffe2/test:quantization_fx - test_keep_original_weights (quantization.fx.test_quantize_fx.TestQuantizeFx)'`

Differential Revision: D72892815




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv