### PR TITLE
[c10d][fr] Enable FR analysis script for all fast-path coalesce op

### DIFF
--- a/test/distributed/flight_recorder/test_fr_analysis.py
+++ b/test/distributed/flight_recorder/test_fr_analysis.py
@@ -1,13 +1,17 @@
 # Owner(s): ["oncall: distributed"]
 
+import copy
 import math
 import pathlib
 import sys
+from typing import Any
 
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent.parent
 
 sys.path.insert(0, str(REPO_ROOT))
+from tools.flight_recorder.components.builder import build_db
+from tools.flight_recorder.components.config_manager import JobConfig
 from tools.flight_recorder.components.types import COLLECTIVES, MatchInfo, MatchState
 from tools.flight_recorder.components.utils import match_one_event
 
@@ -122,10 +126,19 @@ class FlightRecorderEventTest(TestCase):
             input_sizes = [[4, 4]]
             output_sizes = [[4, 4]]
             expectedState = MatchState.FULLY_MATCHED
-            if collective == "_reduce_scatter_base":
+            if collective in [
+                "_reduce_scatter_base",
+                "reduce_scatter_tensor_coalesced",
+                "REDUCESCATTER_coalesced",
+            ]:
                 input_sizes = [[4, 4]]
                 output_sizes = [[input_sizes[0][0] * 2]]
-            if collective == "all_gather":
+            if collective in [
+                "all_gather",
+                "_all_gather_base",
+                "all_gather_into_tensor_coalesced",
+                "ALLGATHER_coalesced",
+            ]:
                 output_sizes = [[math.prod(input_sizes[0]) * 2]]
             if collective == "all_to_all":
                 expectedState = MatchState.UNDECIDED
@@ -145,6 +158,84 @@ class FlightMatchInfoTest(TestCase):
         self.assertEqual(m1.state, m2.state)
         self.assertEqual(str(m1), "Error type: FULLY_MATCHED, rank 0")
         self.assertEqual(str(m2), "Error type: FULLY_MATCHED, rank 1")
+
+
+LOADED_FR_DETAIL_TEMPLATE: dict[str, dict[str, Any]] = {
+    "dump_file_rank_0": {
+        "entries": [],
+        "pg_config": {
+            "0": {"name": "0", "desc": "default_pg", "ranks": "[0, 1]"},
+        },
+        "rank": 0,
+    },
+    "dump_file_rank_1": {
+        "entries": [],
+        "pg_config": {
+            "0": {"name": "0", "desc": "default_pg", "ranks": "[0, 1]"},
+        },
+        "rank": 1,
+    },
+}
+
+
+def create_one_entry(
+    record_id,
+    collective_name,
+    input_sizes,
+    output_sizes,
+    state="completed",
+    collective_seq_id=0,
+    p2p_seq_id=0,
+    output_dtypes="float32",
+):
+    event = create_one_event(
+        collective_name,
+        ("0", "default"),
+        input_sizes,
+        output_sizes,
+        state,
+        collective_seq_id,
+        p2p_seq_id,
+        output_dtypes,
+    )
+    event.update({"record_id": record_id})
+    event.update({"is_p2p": False})
+    return event
+
+
+class FlightRecorderE2ETest(TestCase):
+    def testBuildDB(self):
+        config = JobConfig()
+        args = config.parse_args([])
+        version = "2.6"  # Same as the version in FlightRecorder.hpp
+        LOADED_FR_DETAIL_TEMPLATE["dump_file_rank_0"]["version"] = version
+        LOADED_FR_DETAIL_TEMPLATE["dump_file_rank_1"]["version"] = version
+        # Test case 1: matched all_reduce case.
+        details1 = copy.deepcopy(LOADED_FR_DETAIL_TEMPLATE)
+        details1["dump_file_rank_0"]["entries"].append(
+            create_one_entry(0, "all_reduce", [[4, 4]], [[4, 4]])
+        )
+        details1["dump_file_rank_1"]["entries"].append(
+            create_one_entry(0, "all_reduce", [[4, 4]], [[4, 4]])
+        )
+        db = build_db(details1, args, version)
+        self.assertEqual(len(db.collectives), 1)
+        self.assertEqual(db.collectives[0].record_id, 0)
+        self.assertEqual(db.collectives[0].collective_name, "nccl:all_reduce")
+        self.assertEqual(db.collectives[0].pass_check, True)
+        # Test case 2: matched allreduce_coalesced case.
+        details2 = copy.deepcopy(LOADED_FR_DETAIL_TEMPLATE)
+        details2["dump_file_rank_0"]["entries"].append(
+            create_one_entry(0, "allreduce_coalesced", [[4, 4]], [[4, 4]])
+        )
+        details2["dump_file_rank_1"]["entries"].append(
+            create_one_entry(0, "allreduce_coalesced", [[4, 4]], [[4, 4]])
+        )
+        db = build_db(details2, args, version)
+        self.assertEqual(len(db.collectives), 1)
+        self.assertEqual(db.collectives[0].record_id, 0)
+        self.assertEqual(db.collectives[0].collective_name, "nccl:allreduce_coalesced")
+        self.assertEqual(db.collectives[0].pass_check, True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #151238
* #151247
* __->__ #151243

This PR is to enable FR for all coalesce ops for fast path. (batch p2p is enabled in the current script, so we will mainly focus on non-P2P ops). To explain what is fast path, let's revisit how coalesced collective is working today:

For non-P2P coalesced ops, there are are several ways to call it (due to legendary reasons):

- Way one: Directly call python api like all_reduce_coalesced in python, this will be deprecated soon.
- Way two: Directly call api inside PGNCCL like allreduce_coalesced. The way case 1 will eventually call into this. This is not deprecated and will not be deprecated, IIUC.
- Way three: Using _coalescing_manager in python, like:
```
with _coalescing_manager():
    for i in range(num_colls):
           dist.all_reduce(tensors[i])
```
This way has two path:
   - Fast path: when users call all-reduce, all-gather-into-tensor or reduce-scatter, we will only launch one big collective by calling the api from case 1.
   - Slow path: we call startCoalescing() in the beginning and then a bunch of collectives (each one will generate a FR entry) and then endCoalescing(). Inside startCoalescing(), groupStart() is called and inside endCoalescing(), groupEnd() is then called. So although this is going to be one collective, we call into PGNCCL for each collective coalesced in the slow path case.
   - For uneven all-gather (allgather_v) and reduce-scatter, it follows the pattern mention in slow path. It directly call cpp api inside PGNCCL.
  
This PR addressed the fast path because this is just an easy case, we store the collectives info on the python side, and we will only call into PGNCCL once so there will only be one work and one FR entry. We can just treat them as regular coalesced collective.

We add some e2e unit test for build_db function so that the change to FR is more thoroughly tested.


cc @H-Huang @awgu @wanchaol @fegin @wz337 @wconstab @d4l3k