### PR TITLE
test_store: fix timeout for test_queues

### DIFF
--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -149,13 +149,18 @@ class StoreTestBase:
     def test_append(self):
         self._test_append(self._create_store())
 
-    def test_queues(self):
+    def _create_store_or_skip_if_no_queues(self) -> dist.Store:
         store = self._create_store()
 
         try:
             store.queue_push("test_queue_support", "1")
         except NotImplementedError:
             self.skipTest("Store does not support queues")
+
+        return store
+
+    def test_queues(self):
+        store = self._create_store_or_skip_if_no_queues()
 
         self.assertFalse(store.check(["foo"]))
         self.assertEqual(store.queue_len("foo"), 0)
@@ -173,9 +178,8 @@ class StoreTestBase:
         self.assertFalse(store.check(["foo"]))
         self.assertEqual(store.queue_len("foo"), 0)
 
-        store.set_timeout(timedelta(seconds=0.01))
-        with self.assertRaisesRegex(DistStoreError, "timeout"):
-            store.queue_pop("non_existant")
+    def test_queues_bidirectional(self) -> None:
+        store = self._create_store_or_skip_if_no_queues()
 
         def worker_a():
             local_store = store.clone()
@@ -197,6 +201,13 @@ class StoreTestBase:
             ]
             for fut in futures:
                 fut.result()
+
+    def test_queues_timeout(self):
+        store = self._create_store_or_skip_if_no_queues()
+
+        store.set_timeout(timedelta(seconds=0.01))
+        with self.assertRaisesRegex(DistStoreError, "timeout"):
+            store.queue_pop("non_existant")
 
     def _test_multi_set(self, store):
         if not store.has_extended_api():


### PR DESCRIPTION
Fixes #151216, #151215

Previously I forgot to revert the timeout after setting it for the timeout test. 

To prevent this in the future I split the test into 3 different tests so timeout testing is isolated.

Test plan:

Stress tested

```
pytest test/distributed/test_store.py -k queue -v -s --minutes 10
```

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab