### PR TITLE
[ONNX] Produce correct dtypes for bf16/f8 in IR TorchTensor

### DIFF
--- a/test/onnx/exporter/test_core.py
+++ b/test/onnx/exporter/test_core.py
@@ -35,14 +35,10 @@ class TorchTensorTest(common_utils.TestCase):
             (torch.uint32, np.uint32),
             (torch.uint64, np.uint64),
             (torch.uint8, np.uint8),
-            (torch.float4_e2m1fn_x2, ml_dtypes.float4_e2m1fn),
         ],
     )
     def test_numpy_returns_correct_dtype(self, dtype: torch.dtype, np_dtype):
-        if dtype == torch.float4_e2m1fn_x2:
-            tensor = _core.TorchTensor(torch.tensor([1], dtype=torch.uint8).view(dtype))
-        else:
-            tensor = _core.TorchTensor(torch.tensor([1], dtype=dtype))
+        tensor = _core.TorchTensor(torch.tensor([1], dtype=dtype))
         self.assertEqual(tensor.numpy().dtype, np_dtype)
         self.assertEqual(tensor.__array__().dtype, np_dtype)
         self.assertEqual(np.array(tensor).dtype, np_dtype)

--- a/test/onnx/exporter/test_core.py
+++ b/test/onnx/exporter/test_core.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ml_dtypes
 import numpy as np
 
 import torch
@@ -15,17 +16,17 @@ class TorchTensorTest(common_utils.TestCase):
     @common_utils.parametrize(
         "dtype, np_dtype",
         [
-            (torch.bfloat16, np.uint16),
+            (torch.bfloat16, ml_dtypes.bfloat16),
             (torch.bool, np.bool_),
             (torch.complex128, np.complex128),
             (torch.complex64, np.complex64),
             (torch.float16, np.float16),
             (torch.float32, np.float32),
             (torch.float64, np.float64),
-            (torch.float8_e4m3fn, np.uint8),
-            (torch.float8_e4m3fnuz, np.uint8),
-            (torch.float8_e5m2, np.uint8),
-            (torch.float8_e5m2fnuz, np.uint8),
+            (torch.float8_e4m3fn, ml_dtypes.float8_e4m3fn),
+            (torch.float8_e4m3fnuz, ml_dtypes.float8_e4m3fnuz),
+            (torch.float8_e5m2, ml_dtypes.float8_e5m2),
+            (torch.float8_e5m2fnuz, ml_dtypes.float8_e5m2fnuz),
             (torch.int16, np.int16),
             (torch.int32, np.int32),
             (torch.int64, np.int64),
@@ -34,10 +35,14 @@ class TorchTensorTest(common_utils.TestCase):
             (torch.uint32, np.uint32),
             (torch.uint64, np.uint64),
             (torch.uint8, np.uint8),
+            (torch.float4_e2m1fn_x2, ml_dtypes.float4_e2m1fn),
         ],
     )
     def test_numpy_returns_correct_dtype(self, dtype: torch.dtype, np_dtype):
-        tensor = _core.TorchTensor(torch.tensor([1], dtype=dtype))
+        if dtype == torch.float4_e2m1fn_x2:
+            tensor = _core.TorchTensor(torch.tensor([1], dtype=torch.uint8).view(dtype))
+        else:
+            tensor = _core.TorchTensor(torch.tensor([1], dtype=dtype))
         self.assertEqual(tensor.numpy().dtype, np_dtype)
         self.assertEqual(tensor.__array__().dtype, np_dtype)
         self.assertEqual(np.array(tensor).dtype, np_dtype)
@@ -45,25 +50,25 @@ class TorchTensorTest(common_utils.TestCase):
     @common_utils.parametrize(
         "dtype",
         [
-            (torch.bfloat16),
-            (torch.bool),
-            (torch.complex128),
-            (torch.complex64),
-            (torch.float16),
-            (torch.float32),
-            (torch.float64),
-            (torch.float8_e4m3fn),
-            (torch.float8_e4m3fnuz),
-            (torch.float8_e5m2),
-            (torch.float8_e5m2fnuz),
-            (torch.int16),
-            (torch.int32),
-            (torch.int64),
-            (torch.int8),
-            (torch.uint16),
-            (torch.uint32),
-            (torch.uint64),
-            (torch.uint8),
+            torch.bfloat16,
+            torch.bool,
+            torch.complex128,
+            torch.complex64,
+            torch.float16,
+            torch.float32,
+            torch.float64,
+            torch.float8_e4m3fn,
+            torch.float8_e4m3fnuz,
+            torch.float8_e5m2,
+            torch.float8_e5m2fnuz,
+            torch.int16,
+            torch.int32,
+            torch.int64,
+            torch.int8,
+            torch.uint16,
+            torch.uint32,
+            torch.uint64,
+            torch.uint8,
         ],
     )
     def test_tobytes(self, dtype: torch.dtype):

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -150,12 +150,7 @@ class DynamoExporterTest(common_utils.TestCase):
                 x = torch.cond(x.sum() > 0, true_fn, false_fn, (x, z))
                 return x, z
 
-        onnx_program = torch.onnx.export(
-            CondModel(),
-            (torch.tensor([1, 2]),),
-            dynamo=True,
-            fallback=False,
-        )
+        onnx_program = self.export(CondModel(), (torch.tensor([1, 2]),))
         onnx_testing.assert_onnx_program(onnx_program)
         onnx_testing.assert_onnx_program(onnx_program, args=(torch.tensor([-1, -2]),))
 
@@ -194,56 +189,34 @@ class DynamoExporterTest(common_utils.TestCase):
             _ = self.export(exported_program)
 
     @common_utils.parametrize(
-        "float8_type",
+        "float8_type, onnx_type",
         [
             common_utils.subtest(
-                torch.float8_e5m2,
+                (torch.float8_e5m2, ir.DataType.FLOAT8E5M2),
                 name="torch_float8_e5m2",
             ),
             common_utils.subtest(
-                torch.float8_e5m2fnuz,
+                (torch.float8_e5m2fnuz, ir.DataType.FLOAT8E5M2FNUZ),
                 name="torch_float8_e5m2fnuz",
             ),
             common_utils.subtest(
-                torch.float8_e4m3fn,
+                (torch.float8_e4m3fn, ir.DataType.FLOAT8E4M3FN),
                 name="torch_float8_e4m3fn",
             ),
             common_utils.subtest(
-                torch.float8_e4m3fnuz,
+                (torch.float8_e4m3fnuz, ir.DataType.FLOAT8E4M3FNUZ),
                 name="torch_float8_e4m3fnuz",
             ),
         ],
     )
-    def test_float8_support(self, float8_type):
+    def test_float8_support(self, float8_type: torch.dtype, onnx_type: ir.DataType):
         class Float8Module(torch.nn.Module):
             def forward(self, input: torch.Tensor):
                 input = input.to(float8_type)
                 return input
 
-        _ = self.export(Float8Module(), (torch.randn(1, 2),))
-
-    def test_bfloat16_support(self):
-        class BfloatModel(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                # Test parameters
-                self.param = torch.nn.Parameter(torch.tensor(2.0, dtype=torch.bfloat16))
-
-            def forward(self, x):
-                # Test constant tensors are stored as bfloat16
-                const = torch.tensor(1.0, dtype=torch.bfloat16)
-                return x * const * self.param
-
-        input = torch.tensor([1.0, 2.0], dtype=torch.bfloat16)
-        onnx_program = self.export(BfloatModel(), (input,), optimize=False)
-        initializers = onnx_program.model.graph.initializers.values()
-        self.assertEqual(len(initializers), 2)
-        for initializer in initializers:
-            self.assertEqual(initializer.dtype, ir.DataType.BFLOAT16)
-        self.assertEqual(onnx_program.model.graph.inputs[0].dtype, ir.DataType.BFLOAT16)
-        self.assertEqual(
-            onnx_program.model.graph.outputs[0].dtype, ir.DataType.BFLOAT16
-        )
+        onnx_program = self.export(Float8Module(), (torch.randn(1, 2),))
+        self.assertEqual(onnx_program.model.graph.outputs[0].dtype, onnx_type)
 
     def test_export_with_logging_logger(self):
         logger = logging.getLogger(__name__)

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -215,8 +215,30 @@ class DynamoExporterTest(common_utils.TestCase):
                 input = input.to(float8_type)
                 return input
 
-        onnx_program = self.export(Float8Module(), (torch.randn(1, 2),))
-        self.assertEqual(onnx_program.model.graph.outputs[0].dtype, onnx_type)
+        _ = self.export(Float8Module(), (torch.randn(1, 2),))
+
+    def test_bfloat16_support(self):
+        class BfloatModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                # Test parameters
+                self.param = torch.nn.Parameter(torch.tensor(2.0, dtype=torch.bfloat16))
+
+            def forward(self, x):
+                # Test constant tensors are stored as bfloat16
+                const = torch.tensor(1.0, dtype=torch.bfloat16)
+                return x * const * self.param
+
+        input = torch.tensor([1.0, 2.0], dtype=torch.bfloat16)
+        onnx_program = self.export(BfloatModel(), (input,), optimize=False)
+        initializers = onnx_program.model.graph.initializers.values()
+        self.assertEqual(len(initializers), 2)
+        for initializer in initializers:
+            self.assertEqual(initializer.dtype, ir.DataType.BFLOAT16)
+        self.assertEqual(onnx_program.model.graph.inputs[0].dtype, ir.DataType.BFLOAT16)
+        self.assertEqual(
+            onnx_program.model.graph.outputs[0].dtype, ir.DataType.BFLOAT16
+        )
 
     def test_export_with_logging_logger(self):
         logger = logging.getLogger(__name__)

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -116,15 +116,17 @@ class TorchTensor(ir.Tensor):
     def numpy(self) -> npt.NDArray:
         self.raw: torch.Tensor
         if self.dtype == ir.DataType.BFLOAT16:
-            return self.raw.view(torch.uint16).numpy(force=True)
+            return (
+                self.raw.view(torch.uint16).numpy(force=True).view(self.dtype.numpy())
+            )
         if self.dtype in {
             ir.DataType.FLOAT8E4M3FN,
             ir.DataType.FLOAT8E4M3FNUZ,
             ir.DataType.FLOAT8E5M2,
             ir.DataType.FLOAT8E5M2FNUZ,
         }:
-            # TODO: Use ml_dtypes
-            return self.raw.view(torch.uint8).numpy(force=True)
+            return self.raw.view(torch.uint8).numpy(force=True).view(self.dtype.numpy())
+
         return self.raw.numpy(force=True)
 
     def __array__(self, dtype: Any = None, copy: bool | None = None) -> npt.NDArray:

--- a/torch/onnx/_internal/exporter/_dispatching.py
+++ b/torch/onnx/_internal/exporter/_dispatching.py
@@ -32,6 +32,9 @@ _TORCH_DTYPE_TO_ONNX_COMPATIBLE: dict[torch.dtype, ir.DataType] = {
     torch.int64: ir.DataType.INT64,
     torch.int8: ir.DataType.INT8,
     torch.uint8: ir.DataType.UINT8,
+    torch.uint16: ir.DataType.UINT16,
+    torch.uint32: ir.DataType.UINT32,
+    torch.uint64: ir.DataType.UINT64,
 }
 
 


### PR DESCRIPTION
Split the changes from https://github.com/pytorch/pytorch/pull/151069 to address https://github.com/microsoft/onnxscript/issues/2187, where the output np arrays do not have the correct ml_dtypes types as expected.