### PR TITLE
[dynamo] Avoid unnecessary `.detach()` call in `_make_subclass` polyfill

### DIFF
--- a/torch/_dynamo/polyfills/tensor.py
+++ b/torch/_dynamo/polyfills/tensor.py
@@ -15,7 +15,10 @@ def make_subclass(
     # suffice for most of Dynamo tracing purposes.
     # https://github.com/pytorch/pytorch/blob/ccfde4dadfa3c342076a1ee387017f84dd4ad2f7/torch/csrc/autograd/python_variable.cpp#L597-L650
     assert len(kwargs) == 0, "_make_subclass only supports requires_grad as keyword arg"
-    data = data.detach()
+
+    # Avoid unnecessary `detach` node in the graph.
+    if data.requires_grad:
+        data = data.detach()
 
     # Avoid unnecessary `requires_grad` mutation, which isn't supported in Dynamo.
     if data.requires_grad != requires_grad:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #151265

This brings down compilation time quite a bit for certain tensor
subclass + `torch.compile` use cases, see #150706.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames