### PR TITLE
[Export] Remove to() from module generated form exported program

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -7625,7 +7625,7 @@ def forward(self, b_a_buffer, x):
             self.assertIn("torch._check(u <= 5)", error_msg)
             self.assertNotIn("torch._check_is_size", error_msg)
 
-    def test_train_eval_on_exported_preautograd_module(self):
+    def test_train_eval_to_on_exported_preautograd_module(self):
         class Foo(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -7645,6 +7645,12 @@ def forward(self, b_a_buffer, x):
             NotImplementedError, r"Calling eval\(\) is not supported yet."
         ):
             graph_module.eval()
+
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            r"Calling to\(\) is not supported for moving a module from an exported graph. Use torch.export.passes.move_to_device_pass instead.",
+        ):
+            graph_module.to()
 
     def test_lifted_constants(self) -> None:
         class Module(torch.nn.Module):

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -1307,8 +1307,15 @@ class ExportedProgram:
         def _eval(self, mode: bool = True):
             raise NotImplementedError("Calling eval() is not supported yet.")
 
+        def _to(self, *args: object, **kwargs: object) -> torch.nn.Module:
+            raise NotImplementedError(
+                "Calling to() is not supported for moving a module from an exported graph. Use torch.export.passes.move_to_device_pass instead."
+            )
+
         module.train = types.MethodType(_train, module)  # type: ignore[method-assign]
         module.eval = types.MethodType(_eval, module)  # type: ignore[method-assign]
+        module.to = types.MethodType(_to, module)  # type: ignore[method-assign]
+
         return module
 
     def _num_lifted_params_buffers(self):


### PR DESCRIPTION
Prevent users from calling `to()` on module-generated form-exported programs, as this is not supported [[PyTorch issue #151010](https://github.com/pytorch/pytorch/issues/151010)]