### PR TITLE
Fix support of MixtureSameFamily [bugfix].

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2312,7 +2312,6 @@ coverage_ignore_classes = [
     "integer_interval",
     "interval",
     "less_than",
-    "mixture_same_family",
     "multinomial",
     "stack",
     # torch.distributions.transforms

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2313,6 +2313,7 @@ coverage_ignore_classes = [
     "interval",
     "less_than",
     "multinomial",
+    "removed_event_dim",
     "stack",
     # torch.distributions.transforms
     "AffineTransform",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2312,8 +2312,8 @@ coverage_ignore_classes = [
     "integer_interval",
     "interval",
     "less_than",
+    "mixture_same_family",
     "multinomial",
-    "removed_event_dim",
     "stack",
     # torch.distributions.transforms
     "AffineTransform",

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -2558,10 +2558,10 @@ class TestDistributions(DistributionsTestCase):
         )
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
-    def test_mixture_same_family_log_prob(self):
-        probs = torch.rand(5, 5).softmax(dim=-1)
-        loc = torch.randn(5, 5)
-        scale = torch.rand(5, 5)
+    def test_mixture_same_family_normal_log_prob(self):
+        probs = torch.rand(10, 5).softmax(dim=-1)
+        loc = torch.randn(10, 5)
+        scale = torch.rand(10, 5)
 
         def ref_log_prob(idx, x, log_prob):
             p = probs[idx].numpy()
@@ -2574,6 +2574,25 @@ class TestDistributions(DistributionsTestCase):
 
         self._check_log_prob(
             MixtureSameFamily(Categorical(probs=probs), Normal(loc, scale)),
+            ref_log_prob,
+        )
+
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    def test_mixture_same_family_binomial_log_prob(self):
+        max_count = 20
+        probs = torch.rand(10, 5).softmax(dim=-1)
+        binom_probs = torch.rand(10, 5)
+
+        def ref_log_prob(idx, x, log_prob):
+            p = probs[idx].numpy()
+            binom_p = binom_probs[idx].numpy()
+            mix = scipy.stats.multinomial(1, p)
+            comp = scipy.stats.binom(max_count, binom_p)
+            expected = scipy.special.logsumexp(comp.logpmf(x) + np.log(mix.p))
+            self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
+
+        self._check_log_prob(
+            MixtureSameFamily(Categorical(probs=probs), Binomial(max_count, binom_probs)),
             ref_log_prob,
         )
 

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -2592,7 +2592,9 @@ class TestDistributions(DistributionsTestCase):
             self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
 
         self._check_log_prob(
-            MixtureSameFamily(Categorical(probs=probs), Binomial(max_count, binom_probs)),
+            MixtureSameFamily(
+                Categorical(probs=probs), Binomial(max_count, binom_probs)
+            ),
             ref_log_prob,
         )
 

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -269,15 +269,15 @@ class _IndependentConstraint(Constraint):
 
 class mixture_same_family(Constraint):
     """
-    Constraint for the :class:`torch.distribution.MixtureSameFamily`
+    Constraint for the :class:`~torch.distribution.MixtureSameFamily`
     distribution that adds back the rightmost batch dimension before
     performing the validity check with the component distribution
     constraint.
 
     Args:
         base_constraint: The ``Constraint`` object of
-            the component distribution constraint of the
-            the :class:`torch.distribution.MixtureSameFamily`distribution.
+            the component distribution constraint of
+            the :class:`~torch.distribution.MixtureSameFamily` distribution.
     """
 
     def __init__(self, base_constraint):
@@ -296,7 +296,7 @@ class mixture_same_family(Constraint):
     def check(self, value):
         """
         Check validity of ``value`` as a possible outcome of sampling
-        the :class:`torch.distribution.MixtureSameFamily` distribution.
+        the :class:`~torch.distribution.MixtureSameFamily` distribution.
         """
         unsqueezed_value = value.unsqueeze(-1 - self.event_dim)
         result = self.base_constraint.check(unsqueezed_value)

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -267,7 +267,7 @@ class _IndependentConstraint(Constraint):
         return f"{self.__class__.__name__[1:]}({repr(self.base_constraint)}, {self.reinterpreted_batch_ndims})"
 
 
-class _MixtureSameFamilyConstraint(Constraint):
+class mixture_same_family(Constraint):
     """
     Constraint for the :class:`torch.distribution.MixtureSameFamily`
     distribution that adds back the rightmost batch dimension before
@@ -310,7 +310,7 @@ class _MixtureSameFamilyConstraint(Constraint):
         return result
 
     def __repr__(self):
-        return f"{self.__class__.__name__[1:]}({repr(self.base_constraint)})"
+        return f"{self.__class__.__name__}({repr(self.base_constraint)})"
 
 
 class _Boolean(Constraint):
@@ -709,7 +709,6 @@ class _Stack(Constraint):
 dependent = _Dependent()
 dependent_property = _DependentProperty
 independent = _IndependentConstraint
-mixture_same_family = _MixtureSameFamilyConstraint
 boolean = _Boolean()
 one_hot = _OneHot()
 nonnegative_integer = _IntegerGreaterThan(0)

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -18,7 +18,7 @@ The following constraints are implemented:
 - ``constraints.less_than(upper_bound)``
 - ``constraints.lower_cholesky``
 - ``constraints.lower_triangular``
-- ``constraints.mixture_same_family(constraint)``
+- ``constraints.MixtureSameFamilyConstraint(base_constraint)``
 - ``constraints.multinomial``
 - ``constraints.nonnegative``
 - ``constraints.nonnegative_integer``
@@ -57,7 +57,7 @@ __all__ = [
     "less_than",
     "lower_cholesky",
     "lower_triangular",
-    "mixture_same_family",
+    "MixtureSameFamilyConstraint",
     "multinomial",
     "nonnegative",
     "nonnegative_integer",
@@ -267,7 +267,7 @@ class _IndependentConstraint(Constraint):
         return f"{self.__class__.__name__[1:]}({repr(self.base_constraint)}, {self.reinterpreted_batch_ndims})"
 
 
-class mixture_same_family(Constraint):
+class MixtureSameFamilyConstraint(Constraint):
     """
     Constraint for the :class:`~torch.distribution.MixtureSameFamily`
     distribution that adds back the rightmost batch dimension before
@@ -276,7 +276,7 @@ class mixture_same_family(Constraint):
 
     Args:
         base_constraint: The ``Constraint`` object of
-            the component distribution constraint of
+            the component distribution of
             the :class:`~torch.distribution.MixtureSameFamily` distribution.
     """
 

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -288,7 +288,7 @@ class _RemovedEventDimConstraint(Constraint):
 
     @property
     def event_dim(self) -> int:  # type: ignore[override]
-        return self.base_event_dim - 1
+        return self.base_event_dim
 
     def check(self, value):
         unsqueezed_value = value.unsqueeze(-1 - self.base_event_dim)
@@ -299,7 +299,7 @@ class _RemovedEventDimConstraint(Constraint):
                 f"Expected value.dim() >= {expected} but got {value.dim()}"
             )
         result = result.reshape(
-            result.shape[: result.dim() - self.base_event_dim] + (-1,)
+            result.shape[: result.dim() - 1 - self.base_event_dim] + (-1,)
         )
         result = result.all(-1)
         return result

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -273,6 +273,11 @@ class _MixtureSameFamilyConstraint(Constraint):
     distribution that adds back the rightmost batch dimension before
     performing the validity check with the component distribution
     constraint.
+
+    Args:
+        base_constraint: The ``Constraint`` object of
+            the component distribution constraint of the
+            the :class:`torch.distribution.MixtureSameFamily`distribution.
     """
 
     def __init__(self, base_constraint):
@@ -289,6 +294,10 @@ class _MixtureSameFamilyConstraint(Constraint):
         return self.base_constraint.event_dim
 
     def check(self, value):
+        """
+        Check validity of ``value`` as a possible outcome of sampling
+        the :class:`torch.distribution.MixtureSameFamily` distribution.
+        """
         unsqueezed_value = value.unsqueeze(-1 - self.event_dim)
         result = self.base_constraint.check(unsqueezed_value)
         if value.dim() < self.event_dim:

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -293,14 +293,12 @@ class _RemovedEventDimConstraint(Constraint):
     def check(self, value):
         unsqueezed_value = value.unsqueeze(-1 - self.base_event_dim)
         result = self.base_constraint.check(unsqueezed_value)
-        if result.dim() < self.base_event_dim:
-            expected = self.event_dim
+        if value.dim() < self.event_dim:
             raise ValueError(
-                f"Expected value.dim() >= {expected} but got {value.dim()}"
+                f"Expected value.dim() >= {self.event_dim} but got {value.dim()}"
             )
-        result = result.reshape(
-            result.shape[: result.dim() - 1 - self.base_event_dim] + (-1,)
-        )
+        num_dim_to_keep = value.dim() - self.event_dim
+        result = result.reshape(result.shape[:num_dim_to_keep] + (-1,))
         result = result.all(-1)
         return result
 

--- a/torch/distributions/mixture_same_family.py
+++ b/torch/distributions/mixture_same_family.py
@@ -4,7 +4,7 @@ from typing import Optional
 import torch
 from torch import Tensor
 from torch.distributions import Categorical, constraints
-from torch.distributions.constraints import mixture_same_family
+from torch.distributions.constraints import MixtureSameFamilyConstraint
 from torch.distributions.distribution import Distribution
 
 
@@ -125,7 +125,7 @@ class MixtureSameFamily(Distribution):
 
     @constraints.dependent_property
     def support(self):
-        return mixture_same_family(self._component_distribution.support)
+        return MixtureSameFamilyConstraint(self._component_distribution.support)
 
     @property
     def mixture_distribution(self) -> Categorical:

--- a/torch/distributions/mixture_same_family.py
+++ b/torch/distributions/mixture_same_family.py
@@ -164,9 +164,9 @@ class MixtureSameFamily(Distribution):
         return torch.sum(cdf_x * mix_prob, dim=-1)
 
     def log_prob(self, x):
+        x = self._pad(x)
         if self._validate_args:
             self._validate_sample(x)
-        x = self._pad(x)
         log_prob_x = self.component_distribution.log_prob(x)  # [S, B, k]
         log_mix_prob = torch.log_softmax(
             self.mixture_distribution.logits, dim=-1

--- a/torch/distributions/mixture_same_family.py
+++ b/torch/distributions/mixture_same_family.py
@@ -4,7 +4,7 @@ from typing import Optional
 import torch
 from torch import Tensor
 from torch.distributions import Categorical, constraints
-from torch.distributions.constraints import removed_event_dim
+from torch.distributions.constraints import mixture_same_family
 from torch.distributions.distribution import Distribution
 
 
@@ -125,9 +125,7 @@ class MixtureSameFamily(Distribution):
 
     @constraints.dependent_property
     def support(self):
-        return removed_event_dim(
-            self._component_distribution.support, self._event_ndims
-        )
+        return mixture_same_family(self._component_distribution.support)
 
     @property
     def mixture_distribution(self) -> Categorical:


### PR DESCRIPTION
Fixes https://github.com/pyro-ppl/pyro/issues/3419 which is actually a `torch` bug that can be replicated by the below code:

```
from torch import rand
from torch.distributions import MixtureSameFamily, Categorical, Binomial

max_count = 20
probs = rand(10, 5)
binom_probs = rand(10, 5)

d = MixtureSameFamily(Categorical(probs=probs), Binomial(max_count, binom_probs))
d.log_prob(d.sample())
```

which results in:

```
Traceback (most recent call last):
  File "test.py", line 11, in <module>
    d.log_prob(d.sample())
  File "pytorch\torch\distributions\mixture_same_family.py", line 168, in log_prob   
    self._validate_sample(x)
  File "pytorch\torch\distributions\distribution.py", line 315, in _validate_sample  
    valid = support.check(value)
            ^^^^^^^^^^^^^^^^^^^^
  File "pytorch\torch\distributions\constraints.py", line 307, in check
    (value % 1 == 0) & (self.lower_bound <= value) & (value <= self.upper_bound)
                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: The size of tensor a (10) must match the size of tensor b (5) at non-singleton dimension 1
```

### Fix explanation (only for cases when the component distribution contains parameters with batch dimenisons)

- The failure is due to sample validation taking place before padding in `MixtureSameFamily.log_prob`, and hence the fix is to pad before doing sample validation.
- The fix itself does not alter the calculations at all. It only affects the sample validation process.
- The failure does not occur with the component distribution set to the `Normal` distribution, as its validation is not defined elementwise (the validation itself is elementwise).
- I've split the `test_mixture_same_family_log_prob` test into two tests based on the `Normal` and `Binomial` distributions.
- Initially, the `Binomial` version of the test did not fail, but this was due to the component distribution having equal batch dimensions of (5, 5) so I changed it to (10, 5).

### Updated fix explanation (for all cases)

- The previous fix caused a bug in sample shape validation (which is done correctly) due to the padding taking place before the sample validation.
- The updated fix corrects the support to reflect the fact that the support of `MixtureSameFamily` is equal to the support of its components distribution with the first event dimension removed.
- This issue was already anticipated in the [code](https://github.com/pytorch/pytorch/blob/331423e5c24170b218e743b3392acbad4480340d/torch/distributions/mixture_same_family.py#L127).

cc @albanD