### PR TITLE
fix test_einsum: use initialized values

### DIFF
--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -456,9 +456,13 @@ class TestUnbackedSymints(InductorTestCase):
             return qk, qk2, qvec
 
         example_inputs = (
-            torch.empty_strided((12, 1, 512, 64), (64, 196608, 768, 1), device=device),
-            torch.empty_strided((12, 1, 512, 64), (64, 196608, 768, 1), device=device),
-            torch.empty((12,), device=device),
+            torch.empty_strided(
+                (12, 1, 512, 64), (64, 196608, 768, 1), device=device
+            ).uniform_(0, 1),
+            torch.empty_strided(
+                (12, 1, 512, 64), (64, 196608, 768, 1), device=device
+            ).uniform_(0, 1),
+            torch.randn((12,), device=device),
             torch.scalar_tensor(10, device=device, dtype=torch.int8),
         )
         actual = torch.compile(fn, fullgraph=True)(*example_inputs)


### PR DESCRIPTION
Summary: `empty` uses uninitialized values so that could be NaNs, thus, the assert_close kept failing in FBCode.

Differential Revision: D73067722


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov