### PR TITLE
Use more efficient mask to index computation

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -1013,13 +1013,11 @@ static Tensor _batch_tile_tensor(
 
 static Tensor _mask_to_indices(const Tensor& mask) {
   // This function returns a vector of the indices at which given
-  // boolean mask is True. at::nonzero can achieve the same, but
-  // we yet have to compare the performance difference.
+  // boolean mask is True. Here at::nonzero performs test (time/mem).
   TORCH_CHECK(
       mask.dim() == 1, "Currently _mask_to_indices only supports 1-d masks.");
   TORCH_CHECK(mask.dtype() == at::kBool, "Expected mask to be of dtype bool.");
-  return at::native::arange(mask.numel(), at::kLong, kStrided, mask.device())
-      .masked_select(mask);
+  return at::native::flatten( at::nonzero(mask) );
 }
 
 static std::pair<Tensor, Tensor> _not_zero_mask_to_col_row_indices(

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -1017,7 +1017,7 @@ static Tensor _mask_to_indices(const Tensor& mask) {
   TORCH_CHECK(
       mask.dim() == 1, "Currently _mask_to_indices only supports 1-d masks.");
   TORCH_CHECK(mask.dtype() == at::kBool, "Expected mask to be of dtype bool.");
-  return at::native::flatten( at::nonzero(mask) );
+  return at::native::flatten(at::nonzero(mask));
 }
 
 static std::pair<Tensor, Tensor> _not_zero_mask_to_col_row_indices(


### PR DESCRIPTION
This change addresses the third time/mem "spike" observed in

https://github.com/pytorch/pytorch/issues/151351

The change sees to perform better (time/mem) for both very sparse and very dense cases. It runs faster, and claims less memory both observed on CPU/GPU. It even avoids OOM for larger cases.

