### PR TITLE
[inductor] Reduce runtime of CPU OpInfo tests

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -1154,20 +1154,17 @@ class TestInductorOpInfo(TestCase):
                         # Triton
                         if has_triton():
                             adjusted_kwargs.update(
-                                {
-                                    "copy_to_gpu": False,
-                                    "reference_in_float": False,
-                                    "check_gradient": requires_grad,
-                                    "output_process_fn_grad": sample_input.output_process_fn_grad,
-                                }
+                                copy_to_gpu=False, reference_in_float=False
                             )
-                        # C++ CPU backend
-                        elif torch._inductor.config.cpu_backend == "cpp":
+
+                        # skip checking gradient on CPU for now
+                        if device_type == GPU_TYPE:
                             adjusted_kwargs.update(
-                                {
-                                    "check_gradient": False,  # Skip checking gradient on CPU for now
-                                }
+                                check_gradient=requires_grad,
+                                output_process_fn_grad=sample_input.output_process_fn_grad,
                             )
+                        else:
+                            adjusted_kwargs["check_gradient"] = False
 
                         # Update with overridden kwargs and context-specific overrides
                         adjusted_kwargs.update(overridden_kwargs)


### PR DESCRIPTION
`has_triton()` returns True if Triton is present on the system and supports _any_ backend we care about. In this case, that means we _always_ check gradients, even though the intended behavior is to skip gradients when testing on CPU.

Fixes a bug from #146911.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov