### PR TITLE
Deprecate host allocator legacy APIs

### DIFF
--- a/aten/src/ATen/cuda/CachingHostAllocator.h
+++ b/aten/src/ATen/cuda/CachingHostAllocator.h
@@ -32,38 +32,38 @@ inline TORCH_CUDA_CPP_API bool CachingHostAllocator_recordEvent(
     void* ptr,
     void* ctx,
     c10::cuda::CUDAStream stream) {
-  return getCachingHostAllocator()->record_event(ptr, ctx, stream.unwrap());
+  return getHostAllocator(at::kCUDA)->record_event(ptr, ctx, stream.unwrap());
 }
 
 // Releases cached pinned memory allocations via cudaHostFree
 C10_DEPRECATED_MESSAGE(
   "at::cuda::CachingHostAllocator_emptyCache() is deprecated. Please use at::getHostAllocator(at::kCUDA)->empty_cache() instead.")
 inline TORCH_CUDA_CPP_API void CachingHostAllocator_emptyCache() {
-  getCachingHostAllocator()->empty_cache();
+  getHostAllocator(at::kCUDA)->empty_cache();
 }
 
 C10_DEPRECATED_MESSAGE(
   "at::cuda::HostAlloc(...) is deprecated. Please use at::getHostAllocator(at::kCUDA)->allocate(...) instead.")
 inline TORCH_CUDA_CPP_API at::DataPtr HostAlloc(size_t size) {
-  return getCachingHostAllocator()->allocate(size);
+  return getHostAllocator(at::kCUDA)->allocate(size);
 }
 
 C10_DEPRECATED_MESSAGE(
   "at::cuda::CachingHostAllocator_getStats() is deprecated. Please use at::getHostAllocator(at::kCUDA)->get_stats() instead.")
 inline TORCH_CUDA_CPP_API at::HostStats CachingHostAllocator_getStats() {
-  return getCachingHostAllocator()->get_stats();
+  return getHostAllocator(at::kCUDA)->get_stats();
 }
 
 C10_DEPRECATED_MESSAGE(
   "at::cuda::CachingHostAllocator_resetAccumulatedStats() is deprecated. Please use at::getHostAllocator(at::kCUDA)->reset_accumulated_stats() instead.")
 inline TORCH_CUDA_CPP_API void CachingHostAllocator_resetAccumulatedStats() {
-  getCachingHostAllocator()->reset_accumulated_stats();
+  getHostAllocator(at::kCUDA)->reset_accumulated_stats();
 }
 
 C10_DEPRECATED_MESSAGE(
   "at::cuda::CachingHostAllocator_resetPeakStats() is deprecated. Please use at::getHostAllocator(at::kCUDA)->reset_peak_stats() instead.")
 inline TORCH_CUDA_CPP_API void CachingHostAllocator_resetPeakStats() {
-  getCachingHostAllocator()->reset_peak_stats();
+  getHostAllocator(at::kCUDA)->reset_peak_stats();
 }
 
 } // namespace at::cuda

--- a/aten/src/ATen/cuda/CachingHostAllocator.h
+++ b/aten/src/ATen/cuda/CachingHostAllocator.h
@@ -18,12 +18,16 @@ namespace at::cuda {
 // call between host and device, and passed the corresponding context from the
 // allocation. This is currently invoked by at::native::copy_kernel_cuda.
 //
+C10_DEPRECATED_MESSAGE(
+  "at::cuda::getCachingHostAllocator() is deprecated. Please use at::getHostAllocator(at::kCUDA) instead.")
 inline TORCH_CUDA_CPP_API at::HostAllocator* getCachingHostAllocator() {
   return at::getHostAllocator(at::kCUDA);
 }
 
 // Records an event in the specified stream. The allocation corresponding to the
 // input `ptr`/`ctx` will not be re-used until the event has occurred.
+C10_DEPRECATED_MESSAGE(
+  "at::cuda::CachingHostAllocator_recordEvent(...) is deprecated. Please use at::getHostAllocator(at::kCUDA)->record_event(...) instead.")
 inline TORCH_CUDA_CPP_API bool CachingHostAllocator_recordEvent(
     void* ptr,
     void* ctx,
@@ -32,22 +36,32 @@ inline TORCH_CUDA_CPP_API bool CachingHostAllocator_recordEvent(
 }
 
 // Releases cached pinned memory allocations via cudaHostFree
+C10_DEPRECATED_MESSAGE(
+  "at::cuda::CachingHostAllocator_emptyCache() is deprecated. Please use at::getHostAllocator(at::kCUDA)->empty_cache() instead.")
 inline TORCH_CUDA_CPP_API void CachingHostAllocator_emptyCache() {
   getCachingHostAllocator()->empty_cache();
 }
 
+C10_DEPRECATED_MESSAGE(
+  "at::cuda::HostAlloc(...) is deprecated. Please use at::getHostAllocator(at::kCUDA)->allocate(...) instead.")
 inline TORCH_CUDA_CPP_API at::DataPtr HostAlloc(size_t size) {
   return getCachingHostAllocator()->allocate(size);
 }
 
+C10_DEPRECATED_MESSAGE(
+  "at::cuda::CachingHostAllocator_getStats() is deprecated. Please use at::getHostAllocator(at::kCUDA)->get_stats() instead.")
 inline TORCH_CUDA_CPP_API at::HostStats CachingHostAllocator_getStats() {
   return getCachingHostAllocator()->get_stats();
 }
 
+C10_DEPRECATED_MESSAGE(
+  "at::cuda::CachingHostAllocator_resetAccumulatedStats() is deprecated. Please use at::getHostAllocator(at::kCUDA)->reset_accumulated_stats() instead.")
 inline TORCH_CUDA_CPP_API void CachingHostAllocator_resetAccumulatedStats() {
   getCachingHostAllocator()->reset_accumulated_stats();
 }
 
+C10_DEPRECATED_MESSAGE(
+  "at::cuda::CachingHostAllocator_resetPeakStats() is deprecated. Please use at::getHostAllocator(at::kCUDA)->reset_peak_stats() instead.")
 inline TORCH_CUDA_CPP_API void CachingHostAllocator_resetPeakStats() {
   getCachingHostAllocator()->reset_peak_stats();
 }

--- a/aten/src/ATen/cuda/PinnedMemoryAllocator.h
+++ b/aten/src/ATen/cuda/PinnedMemoryAllocator.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <c10/core/Allocator.h>
 #include <ATen/cuda/CachingHostAllocator.h>
 
 namespace at::cuda {
 
-inline TORCH_CUDA_CPP_API at::Allocator* getPinnedMemoryAllocator() {
-  return getCachingHostAllocator();
+inline TORCH_CUDA_CPP_API at::HostAllocator* getPinnedMemoryAllocator() {
+  return at::getHostAllocator(at::kCUDA);
 }
 } // namespace at::cuda

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -418,8 +418,7 @@ static void copy_kernel_cuda(TensorIterator& iter, bool non_blocking) {
     auto* ptr = (dst_device == kCPU ? dst : src);
     auto* ctx = host_tensor.storage().data_ptr().get_context();
     // TODO: warn on the return value.
-    CachingHostAllocator_recordEvent(ptr, ctx, stream);
-
+    at::getHostAllocator(at::kCUDA)->record_event(ptr, ctx, stream.unwrap());
   } else {
     at::cuda::memcpy_and_sync(dst, src, nbytes, kind, stream);
   }

--- a/aten/src/ATen/test/cuda_caching_host_allocator_test.cpp
+++ b/aten/src/ATen/test/cuda_caching_host_allocator_test.cpp
@@ -18,7 +18,7 @@ TEST(CachingHostAllocatorTest, check_stats) {
 
   // Clear the stats and ensure they are zero.
   size_t round_size = c10::llvm::PowerOf2Ceil(N);
-  auto stats = at::cuda::CachingHostAllocator_getStats();
+  auto stats = at::getHostAllocator(at::kCUDA)->get_stats();
   ASSERT_EQ(stats.allocation.current, 0);
   ASSERT_EQ(stats.allocation.peak, 0);
   ASSERT_EQ(stats.allocation.allocated, 0);
@@ -31,7 +31,7 @@ TEST(CachingHostAllocatorTest, check_stats) {
         {N}, at::TensorOptions().dtype(at::kByte).pinned_memory(true));
     ptr = pinned_tensor.data_ptr();
     ctx = pinned_tensor.storage().data_ptr().get_context();
-    auto stats = at::cuda::CachingHostAllocator_getStats();
+    auto stats = at::getHostAllocator(at::kCUDA)->get_stats();
     ASSERT_EQ(stats.allocation.current, 1);
     ASSERT_EQ(stats.allocation.peak, 1);
     ASSERT_EQ(stats.allocation.allocated, 1);
@@ -47,7 +47,7 @@ TEST(CachingHostAllocatorTest, check_stats) {
   {
     auto pinned_tensor = at::empty(
         {N}, at::TensorOptions().dtype(at::kByte).pinned_memory(true));
-    auto stats = at::cuda::CachingHostAllocator_getStats();
+    auto stats = at::getHostAllocator(at::kCUDA)->get_stats();
     ASSERT_EQ(ptr, pinned_tensor.data_ptr());
     ASSERT_EQ(ctx, pinned_tensor.storage().data_ptr().get_context());
     ASSERT_EQ(stats.allocation.current, 1);
@@ -65,7 +65,7 @@ TEST(CachingHostAllocatorTest, check_stats) {
     size_t new_round_size = c10::llvm::PowerOf2Ceil(new_size);
     auto pinned_tensor = at::empty(
         {new_size}, at::TensorOptions().dtype(at::kByte).pinned_memory(true));
-    auto stats = at::cuda::CachingHostAllocator_getStats();
+    auto stats = at::getHostAllocator(at::kCUDA)->get_stats();
     ASSERT_NE(ptr, pinned_tensor.data_ptr());
     ASSERT_NE(ctx, pinned_tensor.storage().data_ptr().get_context());
     ASSERT_EQ(stats.allocation.current, 1);
@@ -81,8 +81,8 @@ TEST(CachingHostAllocatorTest, check_stats) {
 
   // Test the empty cache.
   {
-    at::cuda::CachingHostAllocator_emptyCache();
-    auto stats = at::cuda::CachingHostAllocator_getStats();
+    at::getHostAllocator(at::kCUDA)->empty_cache();
+    auto stats = at::getHostAllocator(at::kCUDA)->get_stats();
     ASSERT_EQ(stats.allocation.current, 0);
     ASSERT_EQ(stats.allocated_bytes.current, 0);
     ASSERT_EQ(stats.allocation.peak, 2);
@@ -97,9 +97,9 @@ TEST(CachingHostAllocatorTest, check_stats) {
 
   // Test the reset stats.
   {
-    at::cuda::CachingHostAllocator_resetAccumulatedStats();
-    at::cuda::CachingHostAllocator_resetPeakStats();
-    auto stats = at::cuda::CachingHostAllocator_getStats();
+    at::getHostAllocator(at::kCUDA)->reset_accumulated_stats();
+    at::getHostAllocator(at::kCUDA)->reset_peak_stats();
+    auto stats = at::getHostAllocator(at::kCUDA)->get_stats();
     ASSERT_EQ(stats.allocation.peak, 0);
     ASSERT_EQ(stats.allocation.allocated, 0);
     ASSERT_EQ(stats.allocation.freed, 0);
@@ -242,7 +242,7 @@ TEST(CachingHostAllocatorTest, check_empty_cache) {
         ptr, ctx, at::cuda::getCurrentCUDAStream().unwrap()));
   }
 
-  at::cuda::CachingHostAllocator_emptyCache();
+  at::getHostAllocator(at::kCUDA)->empty_cache();
   ASSERT_FALSE(at::getHostAllocator(at::kCUDA)->record_event(
       ptr, ctx, at::cuda::getCurrentCUDAStream().unwrap()));
 }

--- a/aten/src/ATen/test/cuda_caching_host_allocator_test.cpp
+++ b/aten/src/ATen/test/cuda_caching_host_allocator_test.cpp
@@ -173,7 +173,7 @@ TEST(CachingHostAllocatorTest, check_raw_allocation) {
     return;
   }
 
-  auto data_ptr = at::cuda::getCachingHostAllocator()->allocate(N);
+  auto data_ptr = at::getHostAllocator(at::kCUDA)->allocate(N);
   class UserDataDeleter {
    public:
     explicit UserDataDeleter(std::unique_ptr<void, c10::DeleterFnPtr> ptr)

--- a/aten/src/ATen/test/xpu_caching_host_allocator_test.cpp
+++ b/aten/src/ATen/test/xpu_caching_host_allocator_test.cpp
@@ -72,7 +72,7 @@ TEST(CachingHostAllocatorTest, testRawAllocation) {
     return;
   }
 
-  auto data_ptr = at::xpu::getCachingHostAllocator()->allocate(N);
+  auto data_ptr = at::getHostAllocator(at::kXPU)->allocate(N);
   class UserDataDeleter {
    public:
     explicit UserDataDeleter(std::unique_ptr<void, c10::DeleterFnPtr> ptr)

--- a/aten/src/ATen/test/xpu_caching_host_allocator_test.cpp
+++ b/aten/src/ATen/test/xpu_caching_host_allocator_test.cpp
@@ -147,7 +147,7 @@ TEST(CachingHostAllocatorTest, testEmptyCache) {
     at::xpu::syncStreamsOnDevice();
   }
 
-  at::xpu::CachingHostAllocator_emptyCache();
+  at::getHostAllocator(at::kXPU)->empty_cache();
   ASSERT_FALSE(at::getHostAllocator(at::kXPU)->record_event(
       ptr, ctx, at::xpu::getCurrentXPUStream().unwrap()));
 }

--- a/aten/src/ATen/test/xpu_caching_host_allocator_test.cpp
+++ b/aten/src/ATen/test/xpu_caching_host_allocator_test.cpp
@@ -20,10 +20,10 @@ TEST(CachingHostAllocatorTest, testPinnedAliasSlice) {
       at::empty({N}, at::TensorOptions().dtype(at::kByte).pinned_memory(true));
   // TODO: Uncomment this line when op `pin_memory` is supported on XPU.
   // ASSERT_TRUE(pinned_tensor.is_pinned());
-  ASSERT_TRUE(at::xpu::CachingHostAllocator_recordEvent(
+  ASSERT_TRUE(at::getHostAllocator(at::kXPU)->record_event(
       pinned_tensor.data_ptr(),
       pinned_tensor.storage().data_ptr().get_context(),
-      at::xpu::getCurrentXPUStream()));
+      at::xpu::getCurrentXPUStream().unwrap()));
 
   // Check an tensor constructed with from_blob can be correctly recorded (via
   // the shared data_ptr)
@@ -35,10 +35,10 @@ TEST(CachingHostAllocatorTest, testPinnedAliasSlice) {
       alias_tensor.storage().data_ptr().get_context() ==
       pinned_tensor.storage().data_ptr().get_context());
   ASSERT_EQ(alias_tensor.data_ptr(), pinned_tensor.data_ptr());
-  ASSERT_TRUE(at::xpu::CachingHostAllocator_recordEvent(
+  ASSERT_TRUE(at::getHostAllocator(at::kXPU)->record_event(
       alias_tensor.data_ptr(),
       alias_tensor.storage().data_ptr().get_context(),
-      at::xpu::getCurrentXPUStream()));
+      at::xpu::getCurrentXPUStream().unwrap()));
 
   // Check an tensor constructed with slicing can be correctly recorded (via
   // the shared context)
@@ -48,20 +48,20 @@ TEST(CachingHostAllocatorTest, testPinnedAliasSlice) {
       slice_tensor.storage().data_ptr().get_context(),
       pinned_tensor.storage().data_ptr().get_context());
   ASSERT_NE(slice_tensor.data_ptr(), pinned_tensor.data_ptr());
-  ASSERT_TRUE(at::xpu::CachingHostAllocator_recordEvent(
+  ASSERT_TRUE(at::getHostAllocator(at::kXPU)->record_event(
       slice_tensor.data_ptr(),
       slice_tensor.storage().data_ptr().get_context(),
-      at::xpu::getCurrentXPUStream()));
+      at::xpu::getCurrentXPUStream().unwrap()));
 
   // Check a tensor that has neither a matching context nor data_ptr cannot be
   // recorded.
   auto alias_slice_tensor = at::from_blob(
       slice_tensor.data_ptr(), slice_tensor.sizes(), slice_tensor.options());
   // ASSERT_TRUE(alias_slice_tensor.is_pinned());
-  ASSERT_FALSE(at::xpu::CachingHostAllocator_recordEvent(
+  ASSERT_FALSE(at::getHostAllocator(at::kXPU)->record_event(
       alias_slice_tensor.data_ptr(),
       alias_slice_tensor.storage().data_ptr().get_context(),
-      at::xpu::getCurrentXPUStream()));
+      at::xpu::getCurrentXPUStream().unwrap()));
   ASSERT_NE(
       alias_slice_tensor.storage().data_ptr().get(),
       slice_tensor.storage().data_ptr().get());
@@ -105,10 +105,10 @@ TEST(CachingHostAllocatorTest, testRawAllocation) {
           .make_tensor();
 
   // ASSERT_TRUE(pinned_tensor.is_pinned());
-  ASSERT_TRUE(at::xpu::CachingHostAllocator_recordEvent(
+  ASSERT_TRUE(at::getHostAllocator(at::kXPU)->record_event(
       pinned_tensor.data_ptr(),
       pinned_tensor.storage().data_ptr().get_context(),
-      at::xpu::getCurrentXPUStream()));
+      at::xpu::getCurrentXPUStream().unwrap()));
 }
 
 TEST(CachingHostAllocatorTest, testUnknownTensor) {
@@ -119,10 +119,10 @@ TEST(CachingHostAllocatorTest, testUnknownTensor) {
   auto unpinned_tensor =
       at::empty({N}, at::TensorOptions().dtype(at::kByte).pinned_memory(false));
 
-  ASSERT_FALSE(at::xpu::CachingHostAllocator_recordEvent(
+  ASSERT_FALSE(at::getHostAllocator(at::kXPU)->record_event(
       unpinned_tensor.data_ptr(),
       unpinned_tensor.storage().data_ptr().get_context(),
-      at::xpu::getCurrentXPUStream()));
+      at::xpu::getCurrentXPUStream().unwrap()));
 }
 
 TEST(CachingHostAllocatorTest, testEmptyCache) {
@@ -137,8 +137,8 @@ TEST(CachingHostAllocatorTest, testEmptyCache) {
         {N}, at::TensorOptions().dtype(at::kByte).pinned_memory(true));
     ptr = pinned_tensor.data_ptr();
     ctx = pinned_tensor.storage().data_ptr().get_context();
-    ASSERT_TRUE(at::xpu::CachingHostAllocator_recordEvent(
-        ptr, ctx, at::xpu::getCurrentXPUStream()));
+    ASSERT_TRUE(at::getHostAllocator(at::kXPU)->record_event(
+        ptr, ctx, at::xpu::getCurrentXPUStream().unwrap()));
   }
 
   {
@@ -148,8 +148,8 @@ TEST(CachingHostAllocatorTest, testEmptyCache) {
   }
 
   at::xpu::CachingHostAllocator_emptyCache();
-  ASSERT_FALSE(at::xpu::CachingHostAllocator_recordEvent(
-      ptr, ctx, at::xpu::getCurrentXPUStream()));
+  ASSERT_FALSE(at::getHostAllocator(at::kXPU)->record_event(
+      ptr, ctx, at::xpu::getCurrentXPUStream().unwrap()));
 }
 
 TEST(CachingHostAllocatorTest, testReuse) {

--- a/aten/src/ATen/xpu/CachingHostAllocator.h
+++ b/aten/src/ATen/xpu/CachingHostAllocator.h
@@ -19,19 +19,19 @@ inline TORCH_XPU_API bool CachingHostAllocator_recordEvent(
     void* ptr,
     void* ctx,
     c10::xpu::XPUStream stream) {
-  return getCachingHostAllocator()->record_event(ptr, ctx, stream.unwrap());
+  return getHostAllocator(at::kXPU)->record_event(ptr, ctx, stream.unwrap());
 }
 
 C10_DEPRECATED_MESSAGE(
     "at::xpu::CachingHostAllocator_emptyCache() is deprecated. Please use at::getHostAllocator(at::kXPU)->empty_cache() instead.")
 inline TORCH_XPU_API void CachingHostAllocator_emptyCache() {
-  getCachingHostAllocator()->empty_cache();
+  getHostAllocator(at::kXPU)->empty_cache();
 }
 
 C10_DEPRECATED_MESSAGE(
     "at::xpu::HostAlloc(...) is deprecated. Please use at::getHostAllocator(at::kXPU)->allocate(...) instead.")
 inline TORCH_XPU_API at::DataPtr HostAlloc(size_t size) {
-  return getCachingHostAllocator()->allocate(size);
+  return getHostAllocator(at::kXPU)->allocate(size);
 }
 
 } // namespace at::xpu

--- a/aten/src/ATen/xpu/CachingHostAllocator.h
+++ b/aten/src/ATen/xpu/CachingHostAllocator.h
@@ -7,10 +7,14 @@
 
 namespace at::xpu {
 
+C10_DEPRECATED_MESSAGE(
+    "at::xpu::getCachingHostAllocator() is deprecated. Please use at::getHostAllocator(at::kXPU) instead.")
 inline TORCH_XPU_API at::HostAllocator* getCachingHostAllocator() {
   return at::getHostAllocator(at::kXPU);
 }
 
+C10_DEPRECATED_MESSAGE(
+  "at::xpu::CachingHostAllocator_recordEvent(...) is deprecated. Please use at::getHostAllocator(at::kXPU)->record_event(...) instead.")
 inline TORCH_XPU_API bool CachingHostAllocator_recordEvent(
     void* ptr,
     void* ctx,
@@ -18,10 +22,14 @@ inline TORCH_XPU_API bool CachingHostAllocator_recordEvent(
   return getCachingHostAllocator()->record_event(ptr, ctx, stream.unwrap());
 }
 
+C10_DEPRECATED_MESSAGE(
+  "at::xpu::CachingHostAllocator_emptyCache() is deprecated. Please use at::getHostAllocator(at::kXPU)->empty_cache() instead.")
 inline TORCH_XPU_API void CachingHostAllocator_emptyCache() {
   getCachingHostAllocator()->empty_cache();
 }
 
+C10_DEPRECATED_MESSAGE(
+  "at::xpu::HostAlloc(...) is deprecated. Please use at::getHostAllocator(at::kXPU)->allocate(...) instead.")
 inline TORCH_XPU_API at::DataPtr HostAlloc(size_t size) {
   return getCachingHostAllocator()->allocate(size);
 }

--- a/aten/src/ATen/xpu/CachingHostAllocator.h
+++ b/aten/src/ATen/xpu/CachingHostAllocator.h
@@ -14,7 +14,7 @@ inline TORCH_XPU_API at::HostAllocator* getCachingHostAllocator() {
 }
 
 C10_DEPRECATED_MESSAGE(
-  "at::xpu::CachingHostAllocator_recordEvent(...) is deprecated. Please use at::getHostAllocator(at::kXPU)->record_event(...) instead.")
+    "at::xpu::CachingHostAllocator_recordEvent(...) is deprecated. Please use at::getHostAllocator(at::kXPU)->record_event(...) instead.")
 inline TORCH_XPU_API bool CachingHostAllocator_recordEvent(
     void* ptr,
     void* ctx,
@@ -23,13 +23,13 @@ inline TORCH_XPU_API bool CachingHostAllocator_recordEvent(
 }
 
 C10_DEPRECATED_MESSAGE(
-  "at::xpu::CachingHostAllocator_emptyCache() is deprecated. Please use at::getHostAllocator(at::kXPU)->empty_cache() instead.")
+    "at::xpu::CachingHostAllocator_emptyCache() is deprecated. Please use at::getHostAllocator(at::kXPU)->empty_cache() instead.")
 inline TORCH_XPU_API void CachingHostAllocator_emptyCache() {
   getCachingHostAllocator()->empty_cache();
 }
 
 C10_DEPRECATED_MESSAGE(
-  "at::xpu::HostAlloc(...) is deprecated. Please use at::getHostAllocator(at::kXPU)->allocate(...) instead.")
+    "at::xpu::HostAlloc(...) is deprecated. Please use at::getHostAllocator(at::kXPU)->allocate(...) instead.")
 inline TORCH_XPU_API at::DataPtr HostAlloc(size_t size) {
   return getCachingHostAllocator()->allocate(size);
 }

--- a/aten/src/ATen/xpu/PinnedMemoryAllocator.h
+++ b/aten/src/ATen/xpu/PinnedMemoryAllocator.h
@@ -5,7 +5,7 @@
 
 namespace at::xpu {
 
-inline TORCH_XPU_API at::Allocator* getPinnedMemoryAllocator() {
-  return getCachingHostAllocator();
+inline TORCH_XPU_API at::HostAllocator* getPinnedMemoryAllocator() {
+  return at::getHostAllocator(at::kXPU);
 }
 } // namespace at::xpu

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -264,7 +264,7 @@ PyObject* THCPModule_getCompiledVersion(PyObject* self, PyObject* noargs) {
 
 PyObject* THCPModule_cudaHostAllocator(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  c10::Allocator* allocator = at::cuda::getCachingHostAllocator();
+  c10::Allocator* allocator = at::getHostAllocator(at::kCUDA);
   return PyLong_FromVoidPtr(allocator);
   END_HANDLE_TH_ERRORS
 }
@@ -553,7 +553,7 @@ PyObject* THCPModule_setMemoryFraction(PyObject* _unused, PyObject* args) {
 PyObject* THCPModule_hostEmptyCache(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS {
     pybind11::gil_scoped_release no_gil;
-    at::cuda::CachingHostAllocator_emptyCache();
+    at::getHostAllocator(at::kCUDA)->empty_cache();
   }
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
@@ -677,7 +677,7 @@ PyObject* THCPModule_hostMemoryStats(PyObject* _unused, PyObject* noargs) {
     return dict;
   };
 
-  const HostStats stats = at::cuda::CachingHostAllocator_getStats();
+  const HostStats stats = at::getHostAllocator(at::kCUDA)->get_stats();
 
   py::dict result;
   result["num_host_alloc"] = stats.num_host_alloc;
@@ -697,7 +697,7 @@ PyObject* THCPModule_resetAccumulatedHostMemoryStats(
     PyObject* _unused,
     PyObject* noargs) {
   HANDLE_TH_ERRORS
-  at::cuda::CachingHostAllocator_resetAccumulatedStats();
+  at::getHostAllocator(at::kCUDA)->reset_accumulated_stats();
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }
@@ -706,7 +706,7 @@ PyObject* THCPModule_resetPeakHostMemoryStats(
     PyObject* _unused,
     PyObject* noargs) {
   HANDLE_TH_ERRORS
-  at::cuda::CachingHostAllocator_resetPeakStats();
+  at::getHostAllocator(at::kCUDA)->reset_peak_stats();
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #151531
* #151439
* __->__ #151437
* #151431

# Motivation
This PR aims to deprecate the host allocator legacy API and recommend users to use the unified API `getHostAllocator(device_type)` APIs, such as:
```cpp
at::getHostAllocator(device_type)->allocate(...);
at::getHostAllocator(device_type)->empty_cache();
at::getHostAllocator(device_type)->record_event(...);
at::getHostAllocator(device_type)->get_stats();
at::getHostAllocator(device_type)->reset_accumulated_stats();
at::getHostAllocator(device_type)->reset_peak_stats();
```

# Additional Context
TODO:
- [ ] Move is_pinned from `AcceleratorHookInterface` to `HostAllocator`
- [ ] Deprecate `getPinnedMemoryAllocator` inside `AcceleratorHookInterface` and recommend using `getHostAllocator` instead.
