### PR TITLE
Add default value for `serialization_format` in `_write_item` function for better compatibility

### DIFF
--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -310,7 +310,7 @@ def _write_item(
     data: Union[io.BytesIO, torch.Tensor],
     write_item: WriteItem,
     storage_key: str,
-    serialization_format: SerializationFormat,
+    serialization_format: SerializationFormat = SerializationFormat.TORCH_SAVE,
 ) -> WriteResult:
     offset = stream.tell()
 


### PR DESCRIPTION
The [861d2cc](https://github.com/pytorch/pytorch/commit/861d2cc02cce860d789cfda644a366abb95b53a5) commit by @ankitageorge introduced `serialization_format` argument to replace the original `safe_tensors` argument in `_write_item` function. It is fine to use this in pytorch. However, for many other projects, e.g., a widely-used LLM training framework [Megatron-LM](https://github.com/NVIDIA/Megatron-LM/tree/main), which directly uses the [_write_item](https://github.com/NVIDIA/Megatron-LM/blob/cd974f8d6bd3f528b0afc29355fce244a4addd3d/megatron/core/dist_checkpointing/strategies/filesystem_async.py#L320) function, this change will cause errors in its usage `_write_item(*transform_list, stream, data, write_item, storage_key)` there because before this commit, the previous argument `safe_tensors` has default value while the new argument does not.

Therefore, I think this PR is a better-to-have change and is more friendly for community projects which uses some torch functions. Thank you for your consideration.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k