### PR TITLE
Add OIDC permissions to xpu workflow

### DIFF
--- a/.github/workflows/_xpu-test.yml
+++ b/.github/workflows/_xpu-test.yml
@@ -47,6 +47,10 @@ on:
         type: boolean
         default: true
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 


### PR DESCRIPTION
The reusable workflow requires OIDC authentication to work and is configured via it's only caller xpu.yml however setting it here too to clarify that it is required. This setting also flags jobs that call this workflow without the required permissions set to remind them it need to be set.

JWT ID token requires `id-token: write` permissions as documented here https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers#adding-permissions-settings

Ref: pytorch-fdn/multicloud-ci-infra#3
