### PR TITLE
Add OIDC permissions to bazel workflow

### DIFF
--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -33,6 +33,10 @@ on:
         default: "linux.large"
         description: Runner type
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
@@ -79,6 +83,13 @@ jobs:
 
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
+          role-session-name: gha-bazel-build
+          aws-region: us-east-1
 
       - name: Calculate docker image
         id: calculate-docker-image
@@ -201,6 +212,13 @@ jobs:
       - name: Chown workspace
         uses: ./.github/actions/chown-workspace
         if: always()
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_pytorch_artifacts
+          role-session-name: gha-bazel-build-upload-artifacts
+          aws-region: us-east-1
 
       - name: Upload test artifacts
         uses: ./.github/actions/upload-test-artifacts

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -385,6 +385,9 @@ jobs:
     name: linux-focal-cpu-py3.10-gcc11-bazel-test
     uses: ./.github/workflows/_bazel-build-test.yml
     needs: get-label-type
+    permissions:
+      id-token: write
+      contents: read
     with:
       runner: "${{ needs.get-label-type.outputs.label-type }}linux.large"
       build-environment: linux-focal-cuda12.6-py3.10-gcc11-bazel-test


### PR DESCRIPTION
Update workflow to use OIDC authentication to access AWS resources rather than assuming the runner's default role. This is part of the multicloud effort to prepare jobs to support being run in non-AWS clouds.

The JWT ID token requires `id-token: write` in order to create the token for the job. See: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers#adding-permissions-settings

Ref: pytorch-fdn/multicloud-ci-infra#3
