### PR TITLE
Use /var/tmp instead of /tmp for torch cache directory on fbcode

### DIFF
--- a/torch/_inductor/runtime/cache_dir_utils.py
+++ b/torch/_inductor/runtime/cache_dir_utils.py
@@ -5,6 +5,8 @@ import tempfile
 from collections.abc import Generator
 from contextlib import contextmanager
 
+from torch._environment import is_fbcode
+
 
 # Factoring out to file without torch dependencies
 
@@ -20,7 +22,7 @@ def cache_dir() -> str:
 def default_cache_dir() -> str:
     sanitized_username = re.sub(r'[\\/:*?"<>|]', "_", getpass.getuser())
     return os.path.join(
-        tempfile.gettempdir(),
+        tempfile.gettempdir() if not is_fbcode() else "/var/tmp",
         "torchinductor_" + sanitized_username,
     )
 


### PR DESCRIPTION
Summary:
We've been noticing that cache directory has been getting cleaned underneath us, lets use /var/tmp which is supposed to be cleaned less frequently.

https://fb.workplace.com/groups/257735836456307/posts/883428143887070

Test Plan: unit tests

Reviewed By: masnesral

Differential Revision: D73008663




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov