### PR TITLE
inductor.config.descriptive_names = False is not actually supported (#145523) (#146051)

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -943,7 +943,7 @@ class cpp:
 
     # similar to config.triton.descriptive_names
     descriptive_names: Union[
-        bool, Literal["torch", "original_aten", "inductor_node"]
+        Literal["torch", "original_aten", "inductor_node"]
     ] = "original_aten"
 
     # how many nodes to allow into a single horizontal fusion
@@ -1114,12 +1114,11 @@ class triton:
     )
 
     # should we put op names in kernel names
-    # False: No special names (just triton__1, triton__2, etc.)
     # "torch": Maps to the fx op in the Dynamo graph (module name, method name, etc.)
     # "original_aten": Maps to the highest-level aten op (i.e. pre-decompositions)
     # "inductor_node": Maps to the node name in the FX graph passed to Inductor
     descriptive_names: Union[
-        bool, Literal["torch", "original_aten", "inductor_node"]
+        Literal["torch", "original_aten", "inductor_node"]
     ] = "original_aten"
 
     # use alternate codegen for smaller reductions


### PR DESCRIPTION
Summary:

This config is not supported (it throws an error when set), and doesn't really make sense imo.

Approved by: https://github.com/eellison

Test Plan: contbuild & OSS CI, see https://hud.pytorch.org/commit/pytorch/pytorch/edf266e9bbbf6063f7c4a336ffb50234e11a0a82

Reviewed By: masnesral

Differential Revision: D68846308




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov