### PR TITLE
faster gather implementation

### DIFF
--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -536,4 +536,133 @@ inline int can_vectorize_up_to(array_t pointers) {
   return result;
 }
 
+
+
+template <typename T>
+__inline__ size_t get_alignment(T ptr_or_size) {
+  auto val = reinterpret_cast<uintptr_t>(ptr_or_size);
+  if (val % 16 == 0) {
+    return 16;
+  } else if (val % 8 == 0) {
+    return 8;
+  } else if (val % 4 == 0) {
+    return 4;
+  } else if (val % 2 == 0) {
+    return 2;
+  } else {
+    return 1;
+  }
+}
+
+template <>
+__inline__ size_t get_alignment<size_t>(size_t size) {
+  return get_alignment(reinterpret_cast<void*>(size));
+}
+
+template <bool Value, class... Args>
+inline constexpr bool dependent_bool_value = Value;
+
+template <class... Args>
+inline constexpr bool dependent_false = dependent_bool_value<false, Args...>;
+
+template <int Size>
+union Vec;
+
+template <>
+union Vec<4> {
+  uint16_t u16[2];
+  uint32_t u32, as_scalar;
+  float f32;
+};
+
+template <>
+union Vec<8> {
+  uint16_t u16[4];
+  uint32_t u32[2];
+  uint64_t u64, as_scalar;
+  float f32[2];
+};
+
+template <>
+union alignas(16) Vec<16> {
+  uint16_t u16[8];
+  uint32_t u32[4];
+  uint64_t u64[2];
+  uint4 u128, as_scalar;
+  float f32[4];
+};
+
+template <int Alignment, typename T>
+__device__ __inline__ Vec<Alignment> ld_vec(const T* addr) {
+  Vec<Alignment> vec;
+#if defined(USE_ROCM)
+  Vec<Alignment> vec;
+  if constexpr (Alignment == 16) {
+    vec.u128 = *reinterpret_cast<const uint4*>(addr);
+  } else if constexpr (Alignment == 8) {
+    vec.u64 = *reinterpret_cast<const uint64_t*>(addr);
+  } else if constexpr (Alignment == 4) {
+    vec.u32 = *reinterpret_cast<const uint32_t*>(addr);
+  } else {
+    static_assert(dependent_false<T>);
+  }
+  return vec;
+#else
+  if constexpr (Alignment == 16) {
+    asm("ld.global.v4.u32 {%0,%1,%2,%3}, [%4];"
+        : "=r"(vec.u32[0]), "=r"(vec.u32[1]), "=r"(vec.u32[2]), "=r"(vec.u32[3])
+        : "l"(addr)
+        : "memory");
+  } else if constexpr (Alignment == 8) {
+    asm("ld.global.v2.u32 {%0,%1}, [%2];"
+        : "=r"(vec.u32[0]), "=r"(vec.u32[1])
+        : "l"(addr)
+        : "memory");
+  } else if constexpr (Alignment == 4) {
+    asm("ld.global.u32 %0, [%1];" : "=r"(vec.u32) : "l"(addr) : "memory");
+  } else {
+    static_assert(dependent_false<T>);
+  }
+  return vec;
+#endif
+}
+
+template <int Alignment, typename T>
+__device__ __inline__ void st_vec(T* addr, const Vec<Alignment>& vec) {
+#if defined(USE_ROCM)
+  if constexpr (Alignment == 16) {
+    reinterpret_cast<uint64_t*>(addr)[0] = vec.u64[0];
+    reinterpret_cast<uint64_t*>(addr)[1] = vec.u64[1];
+  } else if constexpr (Alignment == 8) {
+    *reinterpret_cast<uint64_t*>(addr) = vec.u64;
+  } else if constexpr (Alignment == 4) {
+    *reinterpret_cast<uint32_t*>(addr) = vec.u32;
+  } else {
+    static_assert(dependent_false<T>);
+  }
+#else
+  if constexpr (Alignment == 16) {
+    asm("st.global.v4.u32 [%0], {%1,%2,%3,%4};"
+        :
+        : "l"(addr),
+          "r"(vec.u32[0]),
+          "r"(vec.u32[1]),
+          "r"(vec.u32[2]),
+          "r"(vec.u32[3])
+        : "memory");
+  } else if constexpr (Alignment == 8) {
+    asm("st.global.v2.u32 [%0], {%1,%2};"
+        :
+        : "l"(addr), "r"(vec.u32[0]), "r"(vec.u32[1])
+        : "memory");
+  } else if constexpr (Alignment == 4) {
+    asm("st.global.u32 [%0], %1;" : : "l"(addr), "r"(vec.u32) : "memory");
+  } else {
+    static_assert(dependent_false<T>);
+  }
+#endif
+}
+
+
+
 } // namespace at::native::memory

--- a/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
+++ b/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
@@ -1,8 +1,8 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/TensorAdvancedIndexing.h>
-
 #include <ATen/core/Tensor.h>
 #include <ATen/Dispatch.h>
+#include <ATen/ceil_div.h>
 #include <ATen/MemoryOverlap.h>
 
 #include <ATen/native/ScatterGatherChecks.h>
@@ -11,6 +11,7 @@
 
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/cuda/KernelUtils.cuh>
+#include <ATen/native/cuda/MemoryAccess.cuh>
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/CUDAContext.h>
@@ -112,6 +113,33 @@ static void _launch_scatter_gather_kernel(int64_t N, const func_t& f) {
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
+template <int Alignment>
+__global__ void vectorized_gather_kernel(char * out, char * inp, int64_t * idx, int num_ind, int64_t slice_size, int64_t ind_dim_size, int64_t inp_stride, int64_t out_stride) {
+    int64_t ind = idx[blockIdx.x];
+    CUDA_KERNEL_ASSERT(ind >=0 && ind < ind_dim_size && "vectorized gather kernel index out of bounds");
+    int32_t off = (blockDim.x * blockIdx.y + threadIdx.x) * Alignment; // off is guaranteed to be within int32 limits
+    if (off >= slice_size) return;
+    auto vec = at::native::memory::ld_vec<Alignment>(inp + ind * inp_stride + off);
+    at::native::memory::st_vec<Alignment>(out + blockIdx.x * (int32_t)out_stride + off, vec);  // out offset is guaranteed to be within int32 limits
+}
+
+
+
+template <int64_t Alignment>
+void vectorized_gather_kernel_launch(char * out, char * inp, int64_t * idx, int num_ind,
+                                     int64_t slice_size_in_bytes, int64_t ind_dim_size, int64_t inp_stride_bytes, int64_t out_stride_bytes){
+
+  constexpr int64_t max_num_threads=256;
+  auto num_threads = at::round_up(
+      at::ceil_div(slice_size_in_bytes, Alignment),
+      static_cast<int64_t>(C10_WARP_SIZE));
+  dim3 grid = {static_cast<uint32_t>(num_ind), static_cast<uint32_t>(at::ceil_div(slice_size_in_bytes, max_num_threads * Alignment)), 1};
+  auto block = std::min(max_num_threads, num_threads);
+  vectorized_gather_kernel<Alignment><<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(out, inp, idx, num_ind, slice_size_in_bytes,
+  ind_dim_size, inp_stride_bytes, out_stride_bytes);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+}
 
 template <bool is_scatter_like, typename scalar_t>
 struct _cuda_scatter_gather_internal_kernel {
@@ -132,17 +160,41 @@ struct _cuda_scatter_gather_internal_kernel {
       return;
     }
 
+
     char* self_ptr = (char*)iter.data_ptr(0);
     char* src_ptr = (char*)iter.data_ptr(1);
     char* index_ptr = (char*)iter.data_ptr(2);
 
+    if constexpr (!is_scatter_like) {
+      // we can go to faster path if we are indexing on the first dim
+      // the dst and src are contiguous and all the dims and pts are multiple of 16
+      size_t element_size = sizeof(scalar_t);
+      constexpr int64_t alignment = 16;
+      //TensorIterator strides and sizes are ordered fastest moving to slowest moving,
+      //in consrast to regular sizes
+      using at::native::memory::get_alignment;
+      // we need contiguous source and dst slices and aligned pointers and strides and slice size to do vectorized loads
+      // also we need idx to be expanded in the last dimension so we can copy entire slices
+      if (iter.ndim() == 2 && iter.strides(2)[0]==0 && (size_t)iter.strides(0)[0]==element_size &&
+          (size_t)iter.strides(1)[0]==element_size && get_alignment(self_ptr) == 16 && get_alignment(src_ptr) == 16 &&
+          get_alignment((size_t)(iter.shape()[0] * element_size)) == 16 && get_alignment((size_t)(index_stride * element_size)) == 16 &&
+          iter.strides(0)[1] == 16) {
+        auto slice_size = iter.shape()[0] * element_size;
+        auto num_ind = iter.shape()[1];
+        auto ind_dim_size = index_size;
+        auto inp_stride_bytes = index_stride * element_size;
+        auto out_stride_bytes = iter.strides(0)[1];
+        vectorized_gather_kernel_launch<alignment>(self_ptr, src_ptr, (int64_t*)index_ptr, num_ind, slice_size, ind_dim_size, inp_stride_bytes, out_stride_bytes);
+        return;
+      }
+    }
     auto offset_calc = make_offset_calculator<3>(iter);
     auto loop = [=]C10_DEVICE(int i) {
       auto offsets = offset_calc.get(i);
 
       int64_t idx_dim = *(int64_t*)(index_ptr + offsets[2]);
       CUDA_KERNEL_ASSERT(idx_dim >= 0 && idx_dim < index_size
-        && "index out of bounds");
+        && "scatter gather kernel index out of bounds");
 
       f(
         (scalar_t*)(self_ptr + offsets[0]),
@@ -153,6 +205,7 @@ struct _cuda_scatter_gather_internal_kernel {
     };
 
     _launch_scatter_gather_kernel<num_threads(), thread_work_size()>(iter.numel(), loop);
+
   }
 }; // struct _cuda_scatter_fill_internal_kernel
 

--- a/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
+++ b/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
@@ -160,7 +160,6 @@ struct _cuda_scatter_gather_internal_kernel {
       return;
     }
 
-
     char* self_ptr = (char*)iter.data_ptr(0);
     char* src_ptr = (char*)iter.data_ptr(1);
     char* index_ptr = (char*)iter.data_ptr(2);
@@ -178,7 +177,7 @@ struct _cuda_scatter_gather_internal_kernel {
       if (iter.ndim() == 2 && iter.strides(2)[0]==0 && (size_t)iter.strides(0)[0]==element_size &&
           (size_t)iter.strides(1)[0]==element_size && get_alignment(self_ptr) == 16 && get_alignment(src_ptr) == 16 &&
           get_alignment((size_t)(iter.shape()[0] * element_size)) == 16 && get_alignment((size_t)(index_stride * element_size)) == 16 &&
-          iter.strides(0)[1] == 16) {
+          get_alignment((size_t)iter.strides(0)[1]) == 16) {
         auto slice_size = iter.shape()[0] * element_size;
         auto num_ind = iter.shape()[1];
         auto ind_dim_size = index_size;

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -63,6 +63,33 @@ class TestScatterGather(TestCase):
             actual = torch.gather(src, 2, idx)
             self.assertEqual(actual, expected, atol=0, rtol=0)
 
+    @dtypes(torch.int8, torch.bfloat16)
+    def test_gather_large(self, device, dtype):
+        # test larger shapes to check vectorized implementation
+        for (m, n, k) in ((4096, 3072, 4096), (4096, 3072, 4100)):
+            src = make_tensor((m, k), device=device, dtype=dtype)
+            alloc0 = torch.empty(src.nelement() * 2, device=device, dtype=dtype)
+            discontig = alloc0.view(m, 2 * k)[:, ::2].copy_(src)
+            alloc1 = torch.empty(src.nelement() + 1, device=device, dtype=dtype)
+            misaligned = alloc1[1:].view(m, k).copy_(src)
+            num_ind = n
+            for dim in (0, 1):
+                max_ind = src.shape[dim]
+                ind0 = torch.randint(max_ind, (num_ind,), device=device)
+                shape_ind = [1] * src.ndim
+                shape_ind[dim] = ind0.shape[0]
+                shape_out = list(src.shape)
+                shape_out[dim] = ind0.shape[0]
+                ind = ind0.view(shape_ind).expand(shape_out)
+                res = torch.gather(src, dim=dim, index=ind)
+                ref = src[ind0] if dim == 0 else src[:, ind0]
+                self.assertEqual(res, ref, atol=0, rtol=0)
+                res = torch.gather(discontig, dim=dim, index=ind)
+                self.assertEqual(res, ref, atol=0, rtol=0)
+                res = torch.gather(misaligned, dim=dim, index=ind)
+                self.assertEqual(res, ref, atol=0, rtol=0)
+
+
     @dtypes(torch.bool)
     def test_gather_bool(self, device, dtype):
         src = torch.tensor(((False, True), (True, True)), device=device, dtype=dtype)

--- a/torch/csrc/distributed/c10d/CUDASymmetricMemoryOps.cu
+++ b/torch/csrc/distributed/c10d/CUDASymmetricMemoryOps.cu
@@ -72,7 +72,7 @@ size_t get_and_verify_alignment(const at::Tensor& input, const char* op_name) {
   const size_t min_alignment = std::max(4l, input.element_size());
   // Only check the offset since the multicast address is always at least
   // 128-bit aligned
-  const size_t ptr_alignment = get_alignment(
+  const size_t ptr_alignment = at::native::memory::get_alignment(
       static_cast<size_t>(input.storage_offset() * input.element_size()));
   TORCH_CHECK(
       ptr_alignment >= min_alignment,
@@ -84,7 +84,7 @@ size_t get_and_verify_alignment(const at::Tensor& input, const char* op_name) {
       "-byte aligned.");
 
   const size_t size_alignment =
-      get_alignment(static_cast<size_t>(input.numel() * input.element_size()));
+      at::native::memory::get_alignment(static_cast<size_t>(input.numel() * input.element_size()));
   TORCH_CHECK(
       size_alignment >= min_alignment,
       op_name,
@@ -225,7 +225,7 @@ static __global__ void multimem_one_shot_all_reduce_kernel(
   auto stride = blockDim.x * gridDim.x * numel_per_thread;
   for (size_t i = offset; i < numel; i += stride) {
     auto vec = multimem_ld_reduce_add<alignment>(input_mc_ptr + i);
-    st_vec<alignment>(output_ptr + i, vec);
+    at::native::memory::st_vec<alignment>(output_ptr + i, vec);
   }
 
   __syncthreads();
@@ -318,7 +318,7 @@ static __global__ void multimem_all_gather_kernel(
   auto offset = (blockDim.x * blockIdx.x + threadIdx.x) * alignment;
   auto stride = blockDim.x * gridDim.x * alignment;
   for (size_t i = offset; i < bytes_per_rank; i += stride) {
-    auto vec = ld_vec<alignment>(input_ptr + i);
+    auto vec = at::native::memory::ld_vec<alignment>(input_ptr + i);
     multimem_st<alignment>(output_mc_ptr + start + i, vec);
   }
 
@@ -418,8 +418,8 @@ static __launch_bounds__(one_shot_all_reduce_max_num_threads) __global__
   auto stride = blockDim.x * gridDim.x * numel_per_thread;
   if (input_ptr) {
     for (size_t i = offset; i < numel; i += stride) {
-      Vec<alignment> vec_st = ld_vec<alignment>(input_ptr + i);
-      st_vec<alignment>(input_ptrs[rank] + input_offset + i, vec_st);
+      Vec<alignment> vec_st = at::native::memory::ld_vec<alignment>(input_ptr + i);
+      at::native::memory::st_vec<alignment>(input_ptrs[rank] + input_offset + i, vec_st);
     }
   }
   // TODO make it sync with one block for no-copy case
@@ -429,7 +429,7 @@ static __launch_bounds__(one_shot_all_reduce_max_num_threads) __global__
   for (size_t i = offset; i < numel; i += stride) {
     auto vec = load_and_reduce<T, alignment, k_world_size>(
         input_ptrs, rank, world_size, input_offset + i);
-    st_vec<alignment>(output_ptr + i, vec);
+    at::native::memory::st_vec<alignment>(output_ptr + i, vec);
   }
 
   __syncthreads();
@@ -606,9 +606,9 @@ static __launch_bounds__(two_shot_all_reduce_max_num_threads) __global__
         input_ptrs, rank, world_size, input_offset + start + idx);
     // store to local buffer or to output
     if constexpr (reduce_scatter) {
-      st_vec<alignment>(output_ptr + i, vec);
+      at::native::memory::st_vec<alignment>(output_ptr + i, vec);
     } else {
-      st_vec<alignment>(input_ptrs[rank] + input_offset + start + i, vec);
+      at::native::memory::st_vec<alignment>(input_ptrs[rank] + input_offset + start + i, vec);
     }
   }
 
@@ -627,7 +627,7 @@ static __launch_bounds__(two_shot_all_reduce_max_num_threads) __global__
       if (remote_start + i >= numel) {
         continue;
       }
-      tmp[step] = ld_vec<alignment>(
+      tmp[step] = at::native::memory::ld_vec<alignment>(
           input_ptrs[remote_rank] + input_offset + remote_start + i);
     }
 #pragma unroll k_world_size
@@ -637,7 +637,7 @@ static __launch_bounds__(two_shot_all_reduce_max_num_threads) __global__
       if (remote_start + i >= numel) {
         continue;
       }
-      st_vec<alignment>(output_ptr + remote_start + i, tmp[step]);
+      at::native::memory::st_vec<alignment>(output_ptr + remote_start + i, tmp[step]);
     }
   }
   // need to make sure all blocks exit simultaneously so that the data
@@ -675,7 +675,7 @@ static __launch_bounds__(two_shot_all_reduce_max_num_threads) __global__
         input_ptrs, rank, world_size, input_offset + start + i);
     for (size_t step = 0; step < world_size; ++step) {
       size_t remote_rank = (rank + step) % world_size;
-      st_vec<alignment>(
+      at::native::memory::st_vec<alignment>(
           input_ptrs[remote_rank] + input_offset + start + i, vec);
     }
   }


### PR DESCRIPTION
So far it's only for `gather`, but we'll move index_select and index to this implementation too. Torchtitan and fbgemm have noticed that gather/index_select perf is bad, this PR brings core implementation to be on par with those customized implementations. Added benefits: all dtypes are supported, a bit less strict on the tensor dimensions/contiguity because we pick the fast path after TensorIterator collapsed the dimensions. 

Biggest part of this PR is not even the kernel (it's dumb, just vectorized loads are enough), but moving utilities for vectorized loads and stores from SymmetricMemory to be generally accessible in MemoryAccess.cuh. 
Additional tests are coming to make sure this implementation doesn't break anything

`gather` is equivalent to x[indices] for 1d indices via
```
def fn_gather(x, indices):
    return torch.gather(x, dim=0, index=indices.unsqueeze(1).expand(-1, x.shape[1]))


def fn_index(x, indices):
    return x[indices]
```

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k