### PR TITLE
[standalone_compile] Some misc fixes

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1452,10 +1452,33 @@ class TestStandaloneCompile(TestCase):
 
             with fresh_inductor_cache():
                 loaded = torch._inductor.CompiledArtifact.load(path=path, format=format)
-                compiled_out = loaded(*args)
+                compiled_out = loaded(*args)[0]
                 self.assertEqual(eager_out, compiled_out)
 
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    @functorch_config.patch({"enable_autograd_cache": True})
+    @parametrize("dynamic", (False, True))
+    def test_call_in_backend(self, dynamic: bool) -> None:
+        mod = torch.nn.Linear(1, 3)
+        x = torch.randn(4, 1)
+        if dynamic:
+            torch._dynamo.mark_dynamic(x, 0)
+
+        def f(x):
+            with torch.no_grad():
+                return mod(x)
+
+        eager_out = f(x)
+
+        def backend(gm, args, **kwargs):
+            return torch._inductor.standalone_compile(gm, args)
+
+        with fresh_inductor_cache():
+            compiled_out = torch.compile(f, fullgraph=True, backend=backend)(x)
+            self.assertEqual(eager_out, compiled_out)
 
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
@@ -1467,7 +1490,7 @@ class TestStandaloneCompile(TestCase):
 
         def f(x):
             with torch.no_grad():
-                return mod(x)
+                return mod(x), x.sin()
 
         eager_out = f(x)
 
@@ -1518,7 +1541,7 @@ from torch._inductor.utils import fresh_inductor_cache
 arg = torch.ones(4, 1)
 with fresh_inductor_cache():
     loaded = torch._inductor.CompiledArtifact.load(path="{path}")
-    compiled_result = loaded(arg)
+    compiled_result = loaded(arg)[0]
 
 eager_result = arg.sin() * 2
 

--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -7,7 +7,7 @@ from contextlib import AbstractContextManager, nullcontext
 from typing import Any, Callable, Literal, Optional, TYPE_CHECKING
 
 import torch.fx
-from torch._dynamo.utils import dynamo_timed
+from torch._dynamo.utils import detect_fake_mode, dynamo_timed
 from torch._inductor.cudagraph_utils import BoxedDeviceIndex
 from torch._inductor.runtime.cache_dir_utils import temporary_cache_dir
 from torch._inductor.utils import BoxedBool, InputType
@@ -15,7 +15,6 @@ from torch._subclasses import FakeTensorMode
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
 from . import config
-from .utils import shape_env_from_inputs
 
 
 if TYPE_CHECKING:
@@ -58,7 +57,7 @@ class CompiledArtifact:
         self._artifacts = artifacts
 
     def __call__(self, *args: Any) -> Any:
-        return self._compiled_fn(*args)[0]
+        return self._compiled_fn(*args)
 
     def save(
         self, *, path: str, format: Literal["binary", "unpacked"] = "binary"
@@ -166,10 +165,11 @@ def standalone_compile(
 
     from .compile_fx import compile_fx
 
-    shape_env = shape_env_from_inputs(example_inputs, default=True)
-    assert shape_env is not None
+    fake_mode = detect_fake_mode(example_inputs)
+    if fake_mode is None:
+        fake_mode = FakeTensorMode(shape_env=ShapeEnv())
 
-    context = torch._guards.TracingContext(FakeTensorMode(shape_env=shape_env))
+    context = torch._guards.TracingContext(fake_mode)
     with torch._guards.tracing(context):
         with CacheArtifactManager.with_fresh_cache():
             compiled_fn = compile_fx(gm, example_inputs, **kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #151502
* #151551
* #151501

This PR fixes two things.

The first problem is that in the vLLM style standalone_compile is
called from within a custom torch.compile backend. If there already is a
FakeTensorMode (which there is), we shouldn't create a new
FakeTensorMode with the same shape_env, instead we should just reuse the
same FakeTensorMode.

The second thing is that compile_fx can mutate the passed in gm, so we
deepcopy (since standalone_compile should be standalone)

Test Plan:
- new test
- updated old tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov