### PR TITLE
[standalone_compile] support multiple returns

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1431,7 +1431,7 @@ class TestStandaloneCompile(TestCase):
 
         def f(x):
             with torch.no_grad():
-                return mod(x)
+                return mod(x), x.sin()
 
         eager_out = f(x)
 
@@ -1486,7 +1486,7 @@ class TestStandaloneCompile(TestCase):
                 loaded = torch._inductor.CompiledArtifact.load(
                     path=path, format="unpacked"
                 )
-                compiled_out = loaded(*args)
+                compiled_out = loaded(*args)[0]
                 self.assertEqual(eager_out, compiled_out)
 
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
@@ -1518,7 +1518,7 @@ from torch._inductor.utils import fresh_inductor_cache
 arg = torch.ones(4, 1)
 with fresh_inductor_cache():
     loaded = torch._inductor.CompiledArtifact.load(path="{path}")
-    compiled_result = loaded(arg)
+    compiled_result = loaded(arg)[0]
 
 eager_result = arg.sin() * 2
 

--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -58,7 +58,7 @@ class CompiledArtifact:
         self._artifacts = artifacts
 
     def __call__(self, *args: Any) -> Any:
-        return self._compiled_fn(*args)[0]
+        return self._compiled_fn(*args)
 
     def save(
         self, *, path: str, format: Literal["binary", "unpacked"] = "binary"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #151502
* __->__ #151551
* #151501

We were only returning the first one. There's an edge case on what to do
if the original function returns a single Tensor. capture(f) returns a
function that returns a tuple of one Tensor in this case and we were
originally converting this back to one single Tensor. I think it's fine
to return a tuple of one Tensor (that is what the graph passed to
standalone_compile asked for!) but we can revisit.
fine

Test Plan:
- modified one test to used multiple outputs

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov