### PR TITLE
Fix normalize mypy warning with tuple dim

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3,7 +3,6 @@
 import importlib
 import math
 import warnings
-from collections.abc import Sequence
 from typing import Callable, Optional, TYPE_CHECKING, Union
 
 import torch
@@ -16,6 +15,7 @@ from torch._jit_internal import (
     BroadcastingList2,
     BroadcastingList3,
 )
+from torch._prims_common import DimsType
 from torch._torch_docs import reproducibility_notes, sparse_support_notes, tf32_notes
 from torch.nn import _reduction as _Reduction, grad  # noqa: F401
 from torch.nn.modules.utils import _list_with_default, _pair, _single, _triple
@@ -5543,7 +5543,7 @@ def triplet_margin_with_distance_loss(
 def normalize(
     input: Tensor,
     p: float = 2.0,
-    dim: Union[int, Sequence[int]] = 1,
+    dim: DimsType = 1,
     eps: float = 1e-12,
     out: Optional[Tensor] = None,
 ) -> Tensor:

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3,6 +3,7 @@
 import importlib
 import math
 import warnings
+from collections.abc import Sequence
 from typing import Callable, Optional, TYPE_CHECKING, Union
 
 import torch
@@ -5542,7 +5543,7 @@ def triplet_margin_with_distance_loss(
 def normalize(
     input: Tensor,
     p: float = 2.0,
-    dim: int = 1,
+    dim: Union[int, Sequence[int]] = 1,
     eps: float = 1e-12,
     out: Optional[Tensor] = None,
 ) -> Tensor:
@@ -5559,8 +5560,8 @@ def normalize(
     Args:
         input: input tensor of any shape
         p (float): the exponent value in the norm formulation. Default: 2
-        dim (int or tuple of ints): the dimension to reduce. Default: 1
-        eps (float): small value to avoid division by zero. Default: 1e-12
+        dim (int or Sequence of ints, optional): the dimension to reduce. Default: 1
+        eps (float, optional): small value to avoid division by zero. Default: 1e-12
         out (Tensor, optional): the output tensor. If :attr:`out` is used, this
                                 operation won't be differentiable.
     """

--- a/torch/nn/functional.pyi.in
+++ b/torch/nn/functional.pyi.in
@@ -539,7 +539,7 @@ def triplet_margin_with_distance_loss(
 def normalize(
     input: Tensor,
     p: float = ...,
-    dim: int = ...,
+    dim: Union[int, Sequence[int]] = ...,
     eps: float = ...,
     out: Optional[Tensor] = ...,
 ) -> Tensor: ...

--- a/torch/nn/functional.pyi.in
+++ b/torch/nn/functional.pyi.in
@@ -13,6 +13,7 @@ from typing import (
 
 from torch import Tensor
 from torch.types import _dtype, _int, _size
+from torch._prims_common import DimsType
 
 from .common_types import (
     _ratio_any_t,
@@ -539,7 +540,7 @@ def triplet_margin_with_distance_loss(
 def normalize(
     input: Tensor,
     p: float = ...,
-    dim: Union[int, Sequence[int]] = ...,
+    dim: DimsType = ...,
     eps: float = ...,
     out: Optional[Tensor] = ...,
 ) -> Tensor: ...


### PR DESCRIPTION
Fixes #70100

## Test Result

```python
# cat ../normal.py
import torch
import torch.nn.functional as F

F.normalize(torch.rand(2,3,4), dim=(0,1))
```

### Before

```bash
mypy ../normal.py 
../normal.py:4:36: error: Argument "dim" to "normalize" has incompatible type "tuple[int, int]"; expected "int"  [arg-type]
Found 1 error in 1 file (checked 1 source file)
```

### After

```bash
mypy ../normal.py 
Success: no issues found in 1 source file
```
