### PR TITLE
Add device agnostic support for distributed tests

### DIFF
--- a/test/distributed/_composable/test_replicate.py
+++ b/test/distributed/_composable/test_replicate.py
@@ -1,6 +1,5 @@
 # Owner(s): ["oncall: distributed"]
 
-import os
 from copy import deepcopy
 
 import torch
@@ -89,7 +88,7 @@ class ReplicateTest(DistributedTestBase):
             store=dist.FileStore(self.file_name, self.world_size),
         )
 
-    def device_with_rank(self, device) ->torch.device:
+    def device_with_rank(self, device) -> torch.device:
         device_type = torch.device(device).type
         return torch.device(f"{device_type}:{torch.get_device_module(device).current_device()}")
 
@@ -254,7 +253,7 @@ class ReplicateFullyShardInit(DistributedTestBase):
     def world_size(self) -> int:
         return 2
 
-    def device_with_rank(self, device) ->torch.device:
+    def device_with_rank(self, device) -> torch.device:
         device_type = torch.device(device).type
         return torch.device(f"{device_type}:{torch.get_device_module(device).current_device()}")
 
@@ -294,7 +293,8 @@ class ReplicateFullyShardInit(DistributedTestBase):
         for linear in model.linears:
             self.assertTrue(isinstance(linear.weight, DTensor))
 
-devices = ("cuda", "hpu", "xpu")
+
+devices = ("cuda", "hpu")
 
 instantiate_device_type_tests(ReplicateTest, globals(), only_for=devices)
 instantiate_device_type_tests(ReplicateFullyShardInit, globals(), only_for=devices)

--- a/test/distributed/algorithms/ddp_comm_hooks/test_ddp_hooks.py
+++ b/test/distributed/algorithms/ddp_comm_hooks/test_ddp_hooks.py
@@ -18,21 +18,20 @@ from torch.distributed.algorithms.ddp_comm_hooks import (
 )
 from torch.nn.parallel import DistributedDataParallel
 from torch.testing._internal.common_distributed import (
-    MultiProcessTestCase,
+    DistributedTestBase,
     requires_nccl,
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
-
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 
 if TEST_WITH_DEV_DBG_ASAN:
     print("Multiprocessing spawn is not compatible with dev/dbg asan", file=sys.stderr)
     sys.exit(0)
 
-
-def gpus_for_rank(world_size):
-    visible_devices = list(range(torch.cuda.device_count()))
-    gpus_per_process = torch.cuda.device_count() // world_size
+def gpus_for_rank(world_size, device):
+    visible_devices = list(range(torch.get_device_module(device).device_count()))
+    gpus_per_process = torch.get_device_module(device).device_count() // world_size
     gpus_for_rank = []
     for rank in range(world_size):
         gpus_for_rank.append(
@@ -60,27 +59,7 @@ class TestDdpCommHook(nn.Module):
         return self.t0(x ** (1 + rank))
 
 
-class DistributedDataParallelCommHookTest(MultiProcessTestCase):
-    def setUp(self):
-        super().setUp()
-        self._spawn_processes()
-
-    def tearDown(self):
-        try:
-            os.remove(self.file_name)
-        except OSError:
-            pass
-
-    def _get_process_group_nccl(self):
-        store = dist.FileStore(self.file_name, self.world_size)
-        dist.init_process_group(
-            backend="nccl",
-            world_size=self.world_size,
-            rank=self.rank,
-            store=store,
-        )
-        return dist.distributed_c10d._get_default_group()
-
+class DistributedDataParallelCommHookTest(DistributedTestBase):
     @property
     def world_size(self):
         return 2
@@ -90,14 +69,14 @@ class DistributedDataParallelCommHookTest(MultiProcessTestCase):
 
         return local_model
 
-    def _get_grads(self, process_group, hook_type=None):
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+    def _get_grads(self, process_group, device, hook_type=None):
+        device_id = gpus_for_rank(self.world_size, device)[self.rank][0]
         gpu_model = DistributedDataParallel(
             TestDdpCommHook().to(device_id),
             device_ids=[device_id],
             process_group=process_group,
         )
-
+        # Set the model to the same device as the process group
         # Register DDP Communication Hook if defined
         if hook_type is not None:
             register_ddp_comm_hook(
@@ -119,95 +98,88 @@ class DistributedDataParallelCommHookTest(MultiProcessTestCase):
         param = next(model.parameters())
         return param.grad
 
-    @requires_nccl()
     @skip_if_lt_x_gpu(2)
-    def test_ddp_comm_hook_allreduce_hook(self):
+    def test_ddp_comm_hook_allreduce_hook(self, device):
         """
         This unit test verifies the ``allreduce`` hook registered case gives same result
         with no hook registered case.
         """
-        process_group = self._get_process_group_nccl()
-
+        process_group = self.create_pg(device)
         # No hook registered case, get the reference grads.
-        reference_grads = self._get_grads(process_group, None)
+        reference_grads = self._get_grads(process_group, device, None)
         # Register hook case, get the hook grads.
-        hook_grads = self._get_grads(process_group, DDPCommHookType.ALLREDUCE)
+        hook_grads = self._get_grads(process_group, device, DDPCommHookType.ALLREDUCE)
 
         torch.testing.assert_close(hook_grads, reference_grads, rtol=1e-5, atol=0)
 
-    @requires_nccl()
     @skip_if_lt_x_gpu(2)
-    def test_ddp_comm_hook_fp16compress_hook(self):
+    def test_ddp_comm_hook_fp16compress_hook(self, device):
         """
         This unit test verifies the ``fp16 compress`` hook registered case
         gives close result with no hook registered case.
         """
-        process_group = self._get_process_group_nccl()
+        process_group = self.create_pg(device)
 
         # No hook registered case, get the reference grads.
-        reference_grads = self._get_grads(process_group, None)
+        reference_grads = self._get_grads(process_group, device, None)
         # Register hook case, get the hook grads.
-        hook_grads = self._get_grads(process_group, DDPCommHookType.FP16_COMPRESS)
+        hook_grads = self._get_grads(process_group, device, DDPCommHookType.FP16_COMPRESS)
 
         torch.testing.assert_close(hook_grads, reference_grads, rtol=1e-5, atol=1e-4)
 
-    @requires_nccl()
     @skip_if_lt_x_gpu(2)
-    def test_ddp_comm_hook_quantize_per_tensor_hook(self):
+    def test_ddp_comm_hook_quantize_per_tensor_hook(self, device):
         """
         This unit test verifies the ``quantize per tensor`` hook registered case
         gives close result with no hook registered case.
         """
-        process_group = self._get_process_group_nccl()
+        process_group = self.create_pg(device)
 
         # No hook registered case, get the reference grads.
-        reference_grads = self._get_grads(process_group, None)
+        reference_grads = self._get_grads(process_group, device, None)
         # Register hook case, get the hook grads.
-        hook_grads = self._get_grads(process_group, DDPCommHookType.QUANTIZE_PER_TENSOR)
+        hook_grads = self._get_grads(process_group, device, DDPCommHookType.QUANTIZE_PER_TENSOR)
 
         torch.testing.assert_close(hook_grads, reference_grads, rtol=1e-5, atol=1e-4)
 
-    @requires_nccl()
     @skip_if_lt_x_gpu(2)
-    def test_ddp_comm_hook_quantize_per_channel_hook(self):
+    def test_ddp_comm_hook_quantize_per_channel_hook(self, device):
         """
         This unit test verifies the ``quantize per channel`` hook registered case
         gives close result with no hook registered case.
         """
-        process_group = self._get_process_group_nccl()
+        process_group = self.create_pg(device)
 
         # No hook registered case, get the reference grads.
-        reference_grads = self._get_grads(process_group, None)
+        reference_grads = self._get_grads(process_group, device, None)
         # Register hook case, get the hook grads.
         hook_grads = self._get_grads(
-            process_group, DDPCommHookType.QUANTIZE_PER_CHANNEL
+            process_group, device, DDPCommHookType.QUANTIZE_PER_CHANNEL
         )
 
         torch.testing.assert_close(hook_grads, reference_grads, rtol=1e-5, atol=1e-4)
 
-    @requires_nccl()
     @skip_if_lt_x_gpu(2)
-    def test_ddp_comm_hook_noop_hook(self):
+    def test_ddp_comm_hook_noop_hook(self, device):
         """
         This unit test verifies the ``noop`` hook registered case and a subsequent allreduce
         gives same result with no hook registered case.
         """
-        process_group = self._get_process_group_nccl()
+        process_group = self.create_pg(device)
 
         # No hook registered case, get the reference grads.
-        reference_grads = self._get_grads(process_group, None)
+        reference_grads = self._get_grads(process_group, device, None)
         # Register hook case, get the hook grads.
-        hook_grads = self._get_grads(process_group, DDPCommHookType.NOOP)
+        hook_grads = self._get_grads(process_group, device, DDPCommHookType.NOOP)
         # Apply a subsequent allreduce to average grads.
         hook_grads.div_(self.world_size)
         dist.all_reduce(hook_grads, group=process_group)
 
         torch.testing.assert_close(hook_grads, reference_grads, rtol=1e-5, atol=0)
 
-    @requires_nccl()
     @skip_if_lt_x_gpu(2)
-    def test_is_last_hook(self):
-        process_group = self._get_process_group_nccl()
+    def test_is_last_hook(self, device):
+        process_group = self.create_pg(device)
 
         def hook(flags, bucket):
             flags.append(bucket.is_last())
@@ -216,11 +188,12 @@ class DistributedDataParallelCommHookTest(MultiProcessTestCase):
             return fut
 
         flags = []
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        device_id = gpus_for_rank(self.world_size, device)[self.rank][0]
         model = nn.Sequential(
             nn.Linear(2, 4000, bias=False),
             *[nn.Linear(4000, 4000, bias=False) for _ in range(10)],
         )
+
         gpu_model = DistributedDataParallel(
             model.to(device_id),
             device_ids=[device_id],
@@ -232,7 +205,9 @@ class DistributedDataParallelCommHookTest(MultiProcessTestCase):
         self.assertTrue(flags[-1])
         self.assertFalse(any(flags[:-1]))
 
+devices = ("cuda", "hpu", "xpu")
 
+instantiate_device_type_tests(DistributedDataParallelCommHookTest, globals(), only_for=devices)
 if __name__ == "__main__":
     assert (
         not torch.cuda._initialized


### PR DESCRIPTION
/_composable/test_replicate.py and /algorithm/ddp_comm_hooks are modified for generic device
1. create_pg() method from DistributedTestBase is used for process group creation wherever accelarator/cuda is used
2. instantiate_device_type_tests is imported and device is brought in respective tests


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k