### PR TITLE
Remove libdevice ops in inductor

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -921,7 +921,6 @@ class CudaReproTests(TestCase):
         )
 
     def test_libdevice_routing(self):
-
         def foo(x):
             return x.exp()
 

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -920,6 +920,22 @@ class CudaReproTests(TestCase):
             out, torch.scatter_reduce(input_orig.clone(), 0, index, src, "sum")
         )
 
+    def test_libdevice_routing(self):
+
+        def foo(x):
+            return x.exp()
+
+        inp = torch.ones(64, device="cuda").to(torch.float64)
+
+        out, code = run_and_get_code(torch.compile(foo), inp)
+        FileCheck().check("libdevice.exp").run(code[0])
+        self.assertEqual(foo(inp), out)
+
+        inp = inp.to(torch.float)
+        out, code = run_and_get_code(torch.compile(foo), inp)
+        FileCheck().check_not("libdevice.exp").check("tl_math.exp").run(code[0])
+        self.assertEqual(foo(inp), out)
+
     def test_embedding_var_mean(self):
         def forward(arg0_1):
             full = torch.ops.aten.full.default(

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -935,6 +935,14 @@ class CudaReproTests(TestCase):
         FileCheck().check_not("libdevice.exp").check("tl_math.exp").run(code[0])
         self.assertEqual(foo(inp), out)
 
+        def foo(x):
+            return x.sigmoid()
+
+        inp = torch.ones(64, device="cuda").to(torch.float64)
+        out, code = run_and_get_code(torch.compile(foo), inp)
+        FileCheck().check("libdevice.exp").run(code[0])
+        self.assertEqual(foo(inp), out)
+
     def test_embedding_var_mean(self):
         def forward(arg0_1):
             full = torch.ops.aten.full.default(

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -808,35 +808,6 @@ class OpOverrides(BasicMathOpsMixin, OpDecompositions, OpsHandler[Any]):
         return repr(value)
 
     @staticmethod
-    def libdevice_sigmoid(x: OpVarT) -> OpVarT:
-        one = ops.constant(1, torch.int32)
-        return ops.truediv(one, ops.add(one, ops.libdevice_exp(ops.neg(x))))
-
-    @staticmethod
-    def libdevice_abs(x: OpVarT) -> OpVarT:
-        return ops.abs(x)
-
-    @staticmethod
-    def libdevice_sqrt(x: OpVarT) -> OpVarT:
-        return ops.sqrt(x)
-
-    @staticmethod
-    def libdevice_cos(x: OpVarT) -> OpVarT:
-        return ops.cos(x)
-
-    @staticmethod
-    def libdevice_sin(x: OpVarT) -> OpVarT:
-        return ops.sin(x)
-
-    @staticmethod
-    def libdevice_log(x: OpVarT) -> OpVarT:
-        return ops.log(x)
-
-    @staticmethod
-    def libdevice_exp(x: OpVarT) -> OpVarT:
-        return ops.exp(x)
-
-    @staticmethod
     def bitwise_not(x: OpVarT) -> OpVarT:
         return f"~{OpOverrides.paren(x)}"
 

--- a/torch/_inductor/codegen/halide.py
+++ b/torch/_inductor/codegen/halide.py
@@ -275,10 +275,6 @@ class HalideOverrides(OpOverrides):
         return f"hl.fast_exp(hl.cast(hl.Float(32), {x})) if {x.name}.type().bits() <= 32 else hl.exp({x})"
 
     @staticmethod
-    def libdevice_exp(x):
-        return f"hl.exp({x})"  # higher precision that ops.exp
-
-    @staticmethod
     def sqrt(x):
         return f"hl.sqrt({x})"
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1333,7 +1333,6 @@ class TritonKernelOverrides(TritonOverrides):
             assert hasattr(cls, fn_name)
             original_impl = getattr(cls, fn_name)
 
-            @staticmethod
             def dtype_router(x, _original_impl=original_impl, _fn_name=fn_name):
                 if x.dtype == torch.float64:
                     return f"libdevice.{_fn_name}({x})"
@@ -1341,7 +1340,7 @@ class TritonKernelOverrides(TritonOverrides):
                     return _original_impl(x)
 
             dtype_router.__name__ = fn_name
-            setattr(cls, fn_name, dtype_router)
+            setattr(cls, fn_name, staticmethod(dtype_router))
 
     @classmethod
     def constant(cls, value, dtype):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1330,6 +1330,7 @@ class TritonKernelOverrides(TritonOverrides):
         """Set up routing to libdevice implementations for fp64 inputs."""
 
         from torch._inductor.codegen.common import OpDecompositions
+
         for fn_name in torch._inductor.utils.op_requires_libdevice_fp64:
             assert hasattr(cls, fn_name)
             original_impl = getattr(cls, fn_name)
@@ -1342,7 +1343,9 @@ class TritonKernelOverrides(TritonOverrides):
 
             if fn_name == "sigmoid":
                 assert hasattr(OpDecompositions, "sigmoid")
-                fn = functools.partial(decomposition_router, _original_impl=original_impl, _fn_name=fn_name)
+                fn = functools.partial(
+                    decomposition_router, _original_impl=original_impl, _fn_name=fn_name
+                )
                 fn.__name__ = fn_name  # type: ignore[attr-defined]
                 setattr(cls, fn_name, staticmethod(fn))
                 continue
@@ -1353,7 +1356,9 @@ class TritonKernelOverrides(TritonOverrides):
                 else:
                     return _original_impl(x)
 
-            fn = functools.partial(dtype_router, _original_impl=original_impl, _fn_name=fn_name)
+            fn = functools.partial(
+                dtype_router, _original_impl=original_impl, _fn_name=fn_name
+            )
             fn.__name__ = fn_name  # type: ignore[attr-defined]
             setattr(cls, fn_name, staticmethod(fn))
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -970,11 +970,6 @@ class TritonOverrides(OpOverrides):
 
     @staticmethod
     @maybe_upcast_float32()
-    def libdevice_abs(x):
-        return f"libdevice.abs({x})"
-
-    @staticmethod
-    @maybe_upcast_float32()
     def exp(x):
         """
         When use_fast_math, use the ftz (flushing to zero) variant
@@ -990,11 +985,6 @@ class TritonOverrides(OpOverrides):
 
     @staticmethod
     @maybe_upcast_float32()
-    def libdevice_exp(x):
-        return f"libdevice.exp({x})"
-
-    @staticmethod
-    @maybe_upcast_float32()
     def exp2(x):
         return f"libdevice.exp2({x})"
 
@@ -1006,11 +996,6 @@ class TritonOverrides(OpOverrides):
     @staticmethod
     @maybe_upcast_float32()
     def sqrt(x):
-        return f"libdevice.sqrt({x})"
-
-    @staticmethod
-    @maybe_upcast_float32()
-    def libdevice_sqrt(x):
         return f"libdevice.sqrt({x})"
 
     @staticmethod
@@ -1060,18 +1045,8 @@ class TritonOverrides(OpOverrides):
 
     @staticmethod
     @maybe_upcast_float32()
-    def libdevice_cos(x):
-        return f"libdevice.cos({x})"
-
-    @staticmethod
-    @maybe_upcast_float32()
     def sin(x):
         return f"tl_math.sin({x})"
-
-    @staticmethod
-    @maybe_upcast_float32()
-    def libdevice_sin(x):
-        return f"libdevice.sin({x})"
 
     @classmethod
     def index_expr(cls, expr, dtype):
@@ -1278,11 +1253,6 @@ class TritonOverrides(OpOverrides):
         return f"tl_math.log({x})"
 
     @staticmethod
-    @maybe_upcast_float32()
-    def libdevice_log(x):
-        return f"libdevice.log({x})"
-
-    @staticmethod
     @maybe_upcast_float32(convert_output=False)
     def isinf(x):
         return f"libdevice.isinf({x}).to(tl.int1)"
@@ -1346,6 +1316,32 @@ class TritonKernelOverrides(TritonOverrides):
     the body of the main triton kernel and so it may use indexing and mask
     variables which are assumed to already be defined in the current scope.
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # happens in __init__ unlike _initialize_pointwise_overrides
+        # because the libdevice registrations are populated during lowerings
+        self._setup_libdevice_routing()
+
+    @classmethod
+    @functools.lru_cache(None)
+    def _setup_libdevice_routing(cls):
+        """Set up routing to libdevice implementations for fp64 inputs."""
+
+        for fn_name in torch._inductor.utils.op_requires_libdevice_fp64:
+            assert hasattr(cls, fn_name)
+            original_impl = getattr(cls, fn_name)
+
+            @staticmethod
+            def dtype_router(x, _original_impl=original_impl, _fn_name=fn_name):
+                if x.dtype == torch.float64:
+                    return f"libdevice.{_fn_name}({x})"
+                else:
+                    return _original_impl(x)
+
+            dtype_router.__name__ = fn_name
+            setattr(cls, fn_name, dtype_router)
 
     @classmethod
     def constant(cls, value, dtype):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1343,7 +1343,7 @@ class TritonKernelOverrides(TritonOverrides):
             if fn_name == "sigmoid":
                 assert hasattr(OpDecompositions, "sigmoid")
                 fn = functools.partial(decomposition_router, _original_impl=original_impl, _fn_name=fn_name)
-                fn.__name__ = fn_name
+                fn.__name__ = fn_name  # type: ignore[attr-defined]
                 setattr(cls, fn_name, staticmethod(fn))
                 continue
 
@@ -1354,7 +1354,7 @@ class TritonKernelOverrides(TritonOverrides):
                     return _original_impl(x)
 
             fn = functools.partial(dtype_router, _original_impl=original_impl, _fn_name=fn_name)
-            fn.__name__ = fn_name
+            fn.__name__ = fn_name  # type: ignore[attr-defined]
             setattr(cls, fn_name, staticmethod(fn))
 
     @classmethod

--- a/torch/_inductor/dtype_propagation.py
+++ b/torch/_inductor/dtype_propagation.py
@@ -358,10 +358,6 @@ class DtypePropagationOpsHandler:
         return promote_types([x])
 
     @staticmethod
-    def libdevice_abs(x: DTypeArg) -> torch.dtype:
-        return promote_types([x])
-
-    @staticmethod
     def check_bounds(
         expr: sympy.Expr, size: sympy.Expr, lower: bool, upper: bool
     ) -> None:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6481,7 +6481,6 @@ register_pointwise_numeric(aten.log1p)
 register_pointwise_numeric(aten.tan)
 register_pointwise_numeric(aten.tanh)
 register_pointwise_numeric_ldf64(aten.log)
-
 logical_and = register_pointwise(
     aten.logical_and,
     type_promotion_kind=None,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -593,7 +593,6 @@ def make_pointwise(
         loaders = [x.make_loader() for x in inputs]
         ranges = inputs[0].get_size()
         dtype = override_return_dtype or inputs[0].get_dtype()
-        is_gpu_device = is_gpu(decode_device(inputs[0].get_device()).type)
 
         for other in inputs[1:]:
             assert isinstance(other, ir.BaseConstant) or len(ranges) == len(

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -681,40 +681,6 @@ class OpsHandler(Generic[T]):
     ) -> None:
         raise NotImplementedError
 
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # In CUDA, optimized implementations of other mathematical operations are
-    # offered separately via libdevice for double precision computation (in
-    # Triton, these go to tl.math rather than tl).  We lower to these
-    # operators when doing FP64 on CUDA.  Note that some operators
-    # unconditional go to tl.math.
-    #
-    # TODO(ezyang): Is this really the best way to do this?  What if we have
-    # abs internally route to tl.math automatically when given a double
-    # precision input?  One reason is that when doing codegen, we often don't
-    # know what the dtype of the inputs are!  (In principle we do know, but
-    # for many analyses it's not conveniently available.)
-
-    def libdevice_abs(self, x0: T) -> T:
-        raise NotImplementedError
-
-    def libdevice_exp(self, x0: T) -> T:
-        raise NotImplementedError
-
-    def libdevice_sqrt(self, x0: T) -> T:
-        raise NotImplementedError
-
-    def libdevice_cos(self, x0: T) -> T:
-        raise NotImplementedError
-
-    def libdevice_sin(self, x0: T) -> T:
-        raise NotImplementedError
-
-    def libdevice_sigmoid(self, x0: T) -> T:
-        raise NotImplementedError
-
-    def libdevice_log(self, x0: T) -> T:
-        raise NotImplementedError
-
     # halide-only
     def halide_clamp(self, value: T, size: sympy.Expr, check: bool) -> T:
         raise NotImplementedError

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -301,9 +301,9 @@ def ceildiv(
     # TODO: There is a bug in a call to this function, to repro:
     # python benchmarks/dynamo/huggingface.py --inductor -d cuda --accuracy
     # --amp --only YituTechConvBert --dynamic-shapes
-    assert isinstance(numer, int) and isinstance(
-        denom, int
-    ), f"{numer}: {type(numer)}, {denom}: {type(denom)}"
+    assert isinstance(numer, int) and isinstance(denom, int), (
+        f"{numer}: {type(numer)}, {denom}: {type(denom)}"
+    )
     return runtime_ceildiv(numer, denom)
 
 
@@ -1448,9 +1448,9 @@ def _rocm_native_device_arch_name(device: str) -> str:
 
 
 @functools.lru_cache(None)
-def try_import_ck_lib() -> (
-    tuple[Optional[str], Callable[[], list[Any]], Callable[[], list[Any]], type[Any]]
-):
+def try_import_ck_lib() -> tuple[
+    Optional[str], Callable[[], list[Any]], Callable[[], list[Any]], type[Any]
+]:
     try:
         import ck4inductor  # type: ignore[import]
         from ck4inductor.universal_gemm.gen_instances import (  # type: ignore[import]
@@ -1722,9 +1722,9 @@ def get_code(fn: Callable[P, _T], *args: P.args, **kwargs: P.kwargs) -> list[str
 def get_triton_code(fn: Callable[P, _T], *args: P.args, **kwargs: P.kwargs) -> str:
     source_codes = get_code(fn, *args, **kwargs)
     # Can have two outputs if backwards was eagerly compiled
-    assert (
-        1 <= len(source_codes) <= 2
-    ), f"expected one or two code outputs got {len(source_codes)}"
+    assert 1 <= len(source_codes) <= 2, (
+        f"expected one or two code outputs got {len(source_codes)}"
+    )
     return source_codes[0]
 
 
@@ -1733,9 +1733,9 @@ def run_and_get_triton_code(
 ) -> str:
     _, source_codes = run_and_get_code(fn, *args, **kwargs)
     # Can have two outputs if backwards was eagerly compiled
-    assert (
-        1 <= len(source_codes) <= 2
-    ), f"expected one or two code outputs got {len(source_codes)}"
+    assert 1 <= len(source_codes) <= 2, (
+        f"expected one or two code outputs got {len(source_codes)}"
+    )
     return source_codes[0]
 
 
@@ -1861,9 +1861,9 @@ def is_cpu_device(inputs: Sequence[torch.Tensor]) -> bool:
 
 
 def get_sympy_Expr_dtype(val: sympy.Expr) -> torch.dtype:
-    assert isinstance(
-        val, sympy.Expr
-    ), "only support sympy.Expr as input to get_sympy_Expr_dtype"
+    assert isinstance(val, sympy.Expr), (
+        "only support sympy.Expr as input to get_sympy_Expr_dtype"
+    )
     if val.is_integer:  # type: ignore[attr-defined]
         return torch.int64
     else:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -301,9 +301,9 @@ def ceildiv(
     # TODO: There is a bug in a call to this function, to repro:
     # python benchmarks/dynamo/huggingface.py --inductor -d cuda --accuracy
     # --amp --only YituTechConvBert --dynamic-shapes
-    assert isinstance(numer, int) and isinstance(denom, int), (
-        f"{numer}: {type(numer)}, {denom}: {type(denom)}"
-    )
+    assert isinstance(numer, int) and isinstance(
+        denom, int
+    ), f"{numer}: {type(numer)}, {denom}: {type(denom)}"
     return runtime_ceildiv(numer, denom)
 
 
@@ -1448,9 +1448,9 @@ def _rocm_native_device_arch_name(device: str) -> str:
 
 
 @functools.lru_cache(None)
-def try_import_ck_lib() -> tuple[
-    Optional[str], Callable[[], list[Any]], Callable[[], list[Any]], type[Any]
-]:
+def try_import_ck_lib() -> (
+    tuple[Optional[str], Callable[[], list[Any]], Callable[[], list[Any]], type[Any]]
+):
     try:
         import ck4inductor  # type: ignore[import]
         from ck4inductor.universal_gemm.gen_instances import (  # type: ignore[import]
@@ -1722,9 +1722,9 @@ def get_code(fn: Callable[P, _T], *args: P.args, **kwargs: P.kwargs) -> list[str
 def get_triton_code(fn: Callable[P, _T], *args: P.args, **kwargs: P.kwargs) -> str:
     source_codes = get_code(fn, *args, **kwargs)
     # Can have two outputs if backwards was eagerly compiled
-    assert 1 <= len(source_codes) <= 2, (
-        f"expected one or two code outputs got {len(source_codes)}"
-    )
+    assert (
+        1 <= len(source_codes) <= 2
+    ), f"expected one or two code outputs got {len(source_codes)}"
     return source_codes[0]
 
 
@@ -1733,9 +1733,9 @@ def run_and_get_triton_code(
 ) -> str:
     _, source_codes = run_and_get_code(fn, *args, **kwargs)
     # Can have two outputs if backwards was eagerly compiled
-    assert 1 <= len(source_codes) <= 2, (
-        f"expected one or two code outputs got {len(source_codes)}"
-    )
+    assert (
+        1 <= len(source_codes) <= 2
+    ), f"expected one or two code outputs got {len(source_codes)}"
     return source_codes[0]
 
 
@@ -1861,9 +1861,9 @@ def is_cpu_device(inputs: Sequence[torch.Tensor]) -> bool:
 
 
 def get_sympy_Expr_dtype(val: sympy.Expr) -> torch.dtype:
-    assert isinstance(val, sympy.Expr), (
-        "only support sympy.Expr as input to get_sympy_Expr_dtype"
-    )
+    assert isinstance(
+        val, sympy.Expr
+    ), "only support sympy.Expr as input to get_sympy_Expr_dtype"
     if val.is_integer:  # type: ignore[attr-defined]
         return torch.int64
     else:
@@ -2656,6 +2656,13 @@ def register_op_dtype_propagation_rules(
     op_dtype_propagation_rules[name] = OpDtypeRule(
         type_promotion_kind, override_return_dtype
     )
+
+
+op_requires_libdevice_fp64: OrderedSet[str] = OrderedSet()
+
+
+def register_op_requires_libdevice_fp64(name: str) -> None:
+    op_requires_libdevice_fp64.add(name)
 
 
 def get_current_backend() -> str:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #151598
* __->__ #151562

Now that we track dtypes during codegen, we can delete all these extra ops that worked around the problem by doing dispatch at lowering time.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov