### PR TITLE
Add OIDC permissions to docs workflow

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -37,12 +37,12 @@ on:
         description: role to assume for downloading artifacts
         required: false
         type: string
-        default: ""
+        default: "arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only"
       upload-aws-role-to-assume:
-        description: role to assume for downloading artifacts
+        description: role to assume for uploading artifacts
         required: false
         type: string
-        default: ""
+        default: "arn:aws:iam::308535385114:role/gha_workflow_pytorch_artifacts"
       runner_prefix:
         description: prefix for runner label
         type: string
@@ -51,6 +51,10 @@ on:
       GH_PYTORCHBOT_TOKEN:
         required: false
         description: Permissions for pushing to the docs site.
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   build-docs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,6 +43,9 @@ jobs:
     needs:
       - docs-build
       - get-label-type
+    permissions:
+      id-token: write
+      contents: read
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-py3.9-gcc11

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -85,6 +85,9 @@ jobs:
     name: linux-docs
     uses: ./.github/workflows/_docs.yml
     needs: linux-jammy-py3_9-gcc11-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-jammy-py3.9-gcc11
       docker-image: ${{ needs.linux-jammy-py3_9-gcc11-build.outputs.docker-image }}


### PR DESCRIPTION
Update workflow to use OIDC authentication to access AWS resources rather than assuming the runner's default role. This is part of the multicloud effort to prepare jobs to support being run in non-AWS clouds where assumption of EC2 instance role cannot be used.

The JWT ID token requires `id-token: write` in order to create the token for the job.
See: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers#adding-permissions-settings

Ref: pytorch-fdn/multicloud-ci-infra#3
