### PR TITLE
[bazel] Fix unusual reference to cpuinfo workspace

### DIFF
--- a/c10/core/build.bzl
+++ b/c10/core/build.bzl
@@ -79,7 +79,7 @@ def define_targets(rules):
         visibility = ["//visibility:public"],
         deps = [
             ":ScalarType",
-            "//third_party/cpuinfo",
+            "@org_pytorch_cpuinfo//:cpuinfo",
             "//c10/macros",
             "//c10/util:TypeCast",
             "//c10/util:base",


### PR DESCRIPTION
It seems like this reference to cpuinfo is assuming that cpuinfo is a submodule of the project, which is not necessarily going to work when pytorch is pulled in as an external workspace.

Fix it to be a more traditional label using the @org_pytorch_cpuinfo external workspace.

Makes progress on https://github.com/pytorch/pytorch/issues/112903.
