### PR TITLE
[bazel] Fix aten generator directory path

### DIFF
--- a/aten.bzl
+++ b/aten.bzl
@@ -68,7 +68,7 @@ def generate_aten_impl(ctx):
         executable = ctx.executable.generator,
         arguments = [
             "--source-path",
-            "aten/src/ATen",
+            ctx.file._sigil.dirname,
             "--per-operator-headers",
             "--install_dir",
             install_dir,
@@ -89,5 +89,6 @@ generate_aten = rule(
         ),
         "outs": attr.output_list(),
         "srcs": attr.label_list(allow_files = True),
+        "_sigil": attr.label(allow_single_file = True, default = "@pytorch//:aten/src/ATen/CMakeLists.txt"),
     },
 )


### PR DESCRIPTION
The path we are passing to the aten directory is only correct in certain situations. If pytorch is an external repository, the path will need to be prefixed with external/pytorch. To make handling this as simple as possible, I used a sigil file from the directory to compute the path instead of hard coding it. For the sigil file I used a CMakeLists.txt as I figured thats one of the least likely files to go away.

An alternative approach might have been to find the path based on sources, but that seems more complex to implement since some of the sources might be in subdirectories.

This fixes one of the errors in the comments on [1] (by smallsunsun1) and makes progress on addressing [2].

[1] https://github.com/pytorch/pytorch/issues/35316
[2] https://github.com/pytorch/pytorch/issues/112903
