### PR TITLE
Add OIDC permissions to linux-test workflow

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -46,7 +46,7 @@ on:
         description: role to assume for downloading artifacts
         required: false
         type: string
-        default: ""
+        default: "arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only"
       disable-monitor:
         description: |
           [Experimental] Disable utilization monitoring for tests.
@@ -64,6 +64,10 @@ on:
         required: false
         description: |
           FB app token to write to scribe endpoint
+
+permissions:
+  id-token: write
+  contents: read
 
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -370,6 +374,14 @@ jobs:
           test_config: ${{ matrix.config }}
           job_identifier: ${{ github.workflow }}_${{ inputs.build-environment }}
 
+      - name: Configure AWS Credentials - Upload Benchmark Results
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: "arn:aws:iam::308535385114:role/gha_workflow_upload-benchmark-results"
+          role-session-name: gha-linux-test-upload-benchmark-results
+          aws-region: us-east-1
+          unset-current-credentials: true
+
       - name: Upload the benchmark results
         uses: pytorch/test-infra/.github/actions/upload-benchmark-results@main
         with:
@@ -392,6 +404,15 @@ jobs:
           MONITOR_SCRIPT_PID: ${{ steps.monitor-script.outputs.monitor-script-pid }}
         run: |
           kill "$MONITOR_SCRIPT_PID"
+
+      - name: Configure AWS Credentials - Upload Test Artifacts
+        uses: aws-actions/configure-aws-credentials@v4
+        if: always() && steps.test.conclusion && steps.test.conclusion != 'skipped'
+        with:
+          role-to-assume: "arn:aws:iam::308535385114:role/gha_workflow_pytorch_artifacts"
+          role-session-name: gha-linux-test-upload-test-artifacts
+          aws-region: us-east-1
+          unset-current-credentials: true
 
       - name: Upload test artifacts
         uses: ./.github/actions/upload-test-artifacts

--- a/.github/workflows/inductor-micro-benchmark-x86.yml
+++ b/.github/workflows/inductor-micro-benchmark-x86.yml
@@ -34,6 +34,9 @@ jobs:
     name: linux-jammy-cpu-py3.9-gcc11-inductor
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-jammy-cpu-py3_9-gcc11-inductor-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-jammy-py3.9-gcc11
       docker-image: ${{ needs.linux-jammy-cpu-py3_9-gcc11-inductor-build.outputs.docker-image }}

--- a/.github/workflows/inductor-micro-benchmark.yml
+++ b/.github/workflows/inductor-micro-benchmark.yml
@@ -46,6 +46,9 @@ jobs:
     name: cuda12.6-py3.10-gcc9-sm80
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-cuda12_6-py3_10-gcc9-inductor-micro-benchmark-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-cuda12.6-py3.10-gcc9-sm80
       docker-image: ${{ needs.linux-focal-cuda12_6-py3_10-gcc9-inductor-micro-benchmark-build.outputs.docker-image }}

--- a/.github/workflows/inductor-nightly.yml
+++ b/.github/workflows/inductor-nightly.yml
@@ -51,6 +51,9 @@ jobs:
     name: linux-jammy-cpu-py3.9-gcc11-nightly-dynamo-benchmarks
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-jammy-cpu-py3_9-gcc11-nightly-dynamo-benchmarks-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-jammy-py3.9-gcc11-build
       docker-image: ${{ needs.linux-jammy-cpu-py3_9-gcc11-nightly-dynamo-benchmarks-build.outputs.docker-image }}

--- a/.github/workflows/inductor-perf-compare.yml
+++ b/.github/workflows/inductor-perf-compare.yml
@@ -46,6 +46,9 @@ jobs:
     name: cuda12.6-py3.10-gcc9-sm80
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-cuda12_6-py3_10-gcc9-inductor-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-cuda12.6-py3.10-gcc9-sm80
       docker-image: ${{ needs.linux-focal-cuda12_6-py3_10-gcc9-inductor-build.outputs.docker-image }}

--- a/.github/workflows/inductor-perf-test-nightly-aarch64.yml
+++ b/.github/workflows/inductor-perf-test-nightly-aarch64.yml
@@ -117,6 +117,9 @@ jobs:
     name: linux-jammy-aarch64-py3.10-inductor
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-jammy-aarch64-py3_10-inductor-build
+    permissions:
+      id-token: write
+      contents: read
     if: github.event.schedule == '0 7 * * *'
     with:
       build-environment: linux-jammy-aarch64-py3.10
@@ -133,6 +136,9 @@ jobs:
     name: linux-jammy-aarch64-py3.10-inductor
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-jammy-aarch64-py3_10-inductor-build
+    permissions:
+      id-token: write
+      contents: read
     if: github.event_name == 'workflow_dispatch'
     with:
       build-environment: linux-jammy-aarch64-py3.10

--- a/.github/workflows/inductor-perf-test-nightly-h100.yml
+++ b/.github/workflows/inductor-perf-test-nightly-h100.yml
@@ -113,6 +113,9 @@ jobs:
     name: cuda12.6-py3.10-gcc9-sm90
     uses: ./.github/workflows/_linux-test.yml
     needs: build
+    permissions:
+      id-token: write
+      contents: read
     if: github.event.schedule == '0 7 * * 1-6'
     with:
       build-environment: linux-focal-cuda12.6-py3.10-gcc9-sm90
@@ -128,6 +131,9 @@ jobs:
     name: cuda12.6-py3.10-gcc9-sm90
     uses: ./.github/workflows/_linux-test.yml
     needs: build
+    permissions:
+      id-token: write
+      contents: read
     if: github.event.schedule == '0 7 * * 0'
     with:
       build-environment: linux-focal-cuda12.6-py3.10-gcc9-sm90
@@ -143,6 +149,9 @@ jobs:
     name: cuda12.6-py3.10-gcc9-sm90
     uses: ./.github/workflows/_linux-test.yml
     needs: build
+    permissions:
+      id-token: write
+      contents: read
     if: github.event_name == 'workflow_dispatch'
     with:
       build-environment: linux-focal-cuda12.6-py3.10-gcc9-sm90

--- a/.github/workflows/inductor-perf-test-nightly-x86.yml
+++ b/.github/workflows/inductor-perf-test-nightly-x86.yml
@@ -94,6 +94,9 @@ jobs:
     name: linux-jammy-cpu-py3.9-gcc11-inductor
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-jammy-cpu-py3_9-gcc11-inductor-build
+    permissions:
+      id-token: write
+      contents: read
     if: github.event.schedule == '0 7 * * *'
     with:
       build-environment: linux-jammy-py3.9-gcc11-build
@@ -110,6 +113,9 @@ jobs:
     name: linux-jammy-cpu-py3.9-gcc11-inductor
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-jammy-cpu-py3_9-gcc11-inductor-build
+    permissions:
+      id-token: write
+      contents: read
     if: github.event_name == 'workflow_dispatch'
     with:
       build-environment: linux-jammy-py3.9-gcc11-build

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -115,6 +115,9 @@ jobs:
     name: cuda12.6-py3.10-gcc9-sm80
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-cuda12_6-py3_10-gcc9-inductor-build
+    permissions:
+      id-token: write
+      contents: read
     if: github.event.schedule == '0 7 * * 1-6'
     with:
       build-environment: linux-focal-cuda12.6-py3.10-gcc9-sm80
@@ -130,6 +133,9 @@ jobs:
     name: cuda12.6-py3.10-gcc9-sm80
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-cuda12_6-py3_10-gcc9-inductor-build
+    permissions:
+      id-token: write
+      contents: read
     if: github.event.schedule == '0 7 * * 0'
     with:
       build-environment: linux-focal-cuda12.6-py3.10-gcc9-sm80
@@ -145,6 +151,9 @@ jobs:
     name: cuda12.6-py3.10-gcc9-sm80
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-cuda12_6-py3_10-gcc9-inductor-build
+    permissions:
+      id-token: write
+      contents: read
     if: github.event_name == 'workflow_dispatch'
     with:
       build-environment: linux-focal-cuda12.6-py3.10-gcc9-sm80

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -48,6 +48,9 @@ jobs:
     name: cuda12.6-py3.10-gcc9-sm86
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-cuda12_6-py3_10-gcc9-inductor-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-cuda12.6-py3.10-gcc9-sm86
       docker-image: ${{ needs.linux-focal-cuda12_6-py3_10-gcc9-inductor-build.outputs.docker-image }}
@@ -74,6 +77,9 @@ jobs:
     name: cuda12.6-py3.12-gcc9-sm86
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-cuda12_6-py3_12-gcc9-inductor-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-cuda12.6-py3.12-gcc9-sm86
       docker-image: ${{ needs.linux-focal-cuda12_6-py3_12-gcc9-inductor-build.outputs.docker-image }}
@@ -98,6 +104,9 @@ jobs:
     name: linux-jammy-cpu-py3.12-gcc11-inductor-halide
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-jammy-cpu-py3_12-inductor-halide-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-jammy-py3.12-gcc11
       docker-image: ${{ needs.linux-jammy-cpu-py3_12-inductor-halide-build.outputs.docker-image }}
@@ -122,6 +131,9 @@ jobs:
     name: linux-jammy-cpu-py3.12-gcc11-inductor-triton-cpu
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-jammy-cpu-py3_12-inductor-triton-cpu-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-jammy-py3.12-gcc11
       docker-image: ${{ needs.linux-jammy-cpu-py3_12-inductor-triton-cpu-build.outputs.docker-image }}
@@ -149,6 +161,9 @@ jobs:
     name: linux-jammy-cpu-py3.9-gcc11-inductor
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-jammy-cpu-py3_9-gcc11-inductor-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-jammy-py3.9-gcc11-build
       docker-image: ${{ needs.linux-jammy-cpu-py3_9-gcc11-inductor-build.outputs.docker-image }}
@@ -174,6 +189,9 @@ jobs:
     name: cuda12.6-py3.13-gcc9-sm86
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-cuda12_6-py3_13-gcc9-inductor-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-cuda12.6-py3.13-gcc9-sm86
       docker-image: ${{ needs.linux-focal-cuda12_6-py3_13-gcc9-inductor-build.outputs.docker-image }}

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -65,6 +65,9 @@ jobs:
     name: cuda12.6-py3.10-gcc9-sm86
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-cuda12_6-py3_10-gcc9-inductor-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-cuda12.6-py3.10-gcc9-sm86
       docker-image: ${{ needs.linux-focal-cuda12_6-py3_10-gcc9-inductor-build.outputs.docker-image }}
@@ -97,6 +100,9 @@ jobs:
     name: linux-jammy-cpu-py3.9-gcc11-inductor
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-jammy-cpu-py3_9-gcc11-inductor-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-jammy-py3.9-gcc11-build
       docker-image: ${{ needs.linux-jammy-cpu-py3_9-gcc11-inductor-build.outputs.docker-image }}

--- a/.github/workflows/operator_benchmark.yml
+++ b/.github/workflows/operator_benchmark.yml
@@ -52,6 +52,9 @@ jobs:
     name: linux-jammy-cpu-py3.9-gcc11-opbenchmark
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-jammy-cpu-py3_9-gcc11-opbenchmark-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-jammy-py3.9-gcc11-build
       docker-image: ${{ needs.linux-jammy-cpu-py3_9-gcc11-opbenchmark-build.outputs.docker-image }}

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -74,6 +74,9 @@ jobs:
     needs:
       - linux-focal-cuda12_6-py3_10-gcc11-build
       - target-determination
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-cuda12.6-py3.10-gcc11
       docker-image: ${{ needs.linux-focal-cuda12_6-py3_10-gcc11-build.outputs.docker-image }}
@@ -101,6 +104,9 @@ jobs:
     name: linux-focal-cuda11.8-py3.9-gcc9
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-cuda11_8-py3_9-gcc9-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-cuda11.8-py3.9-gcc9
       docker-image: ${{ needs.linux-focal-cuda11_8-py3_9-gcc9-build.outputs.docker-image }}
@@ -134,6 +140,9 @@ jobs:
     needs:
       - linux-focal-cuda11_8-py3_10-gcc9-debug-build
       - target-determination
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-cuda11.8-py3.10-gcc9-debug
       docker-image: ${{ needs.linux-focal-cuda11_8-py3_10-gcc9-debug-build.outputs.docker-image }}
@@ -199,6 +208,9 @@ jobs:
     needs:
       - linux-focal-cuda12_6-py3-gcc11-slow-gradcheck-build
       - target-determination
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-cuda12.6-py3-gcc11-slow-gradcheck
       docker-image: ${{ needs.linux-focal-cuda12_6-py3-gcc11-slow-gradcheck-build.outputs.docker-image }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -75,6 +75,9 @@ jobs:
     needs:
       - linux-jammy-py3_9-gcc11-build
       - target-determination
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-jammy-py3.9-gcc11
       docker-image: ${{ needs.linux-jammy-py3_9-gcc11-build.outputs.docker-image }}
@@ -145,6 +148,9 @@ jobs:
     needs:
       - linux-jammy-py3_10-clang15-asan-build
       - target-determination
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-jammy-py3.10-clang15-asan
       docker-image: ${{ needs.linux-jammy-py3_10-clang15-asan-build.outputs.docker-image }}
@@ -173,6 +179,9 @@ jobs:
     needs:
       - linux-focal-py3_9-clang10-onnx-build
       - target-determination
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-py3.9-clang10-onnx
       docker-image: ${{ needs.linux-focal-py3_9-clang10-onnx-build.outputs.docker-image }}
@@ -208,6 +217,9 @@ jobs:
     needs:
       - linux-focal-py3_9-clang10-build
       - target-determination
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-py3.9-clang10
       docker-image: ${{ needs.linux-focal-py3_9-clang10-build.outputs.docker-image }}
@@ -241,6 +253,9 @@ jobs:
     name: linux-focal-py3.13-clang10
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-py3_13-clang10-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-py3.13-clang10
       docker-image: ${{ needs.linux-focal-py3_13-clang10-build.outputs.docker-image }}
@@ -271,6 +286,9 @@ jobs:
     needs:
       - linux-focal-cuda11_8-py3_10-gcc9-build
       - target-determination
+    permissions:
+      id-token: write
+      contents: read
     with:
       timeout-minutes: 360
       build-environment: linux-focal-cuda11.8-py3.10-gcc9
@@ -302,6 +320,9 @@ jobs:
     needs:
       - linux-focal-cuda12_6-py3_10-gcc11-build
       - target-determination
+    permissions:
+      id-token: write
+      contents: read
     with:
       timeout-minutes: 360
       build-environment: linux-focal-cuda12.6-py3.10-gcc11
@@ -356,6 +377,9 @@ jobs:
     name: linux-focal-py3_9-clang9-xla
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-py3_9-clang9-xla-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-py3.9-clang9-xla
       docker-image: ${{ needs.linux-focal-py3_9-clang9-xla-build.outputs.docker-image }}
@@ -478,6 +502,9 @@ jobs:
     needs:
       - linux-focal-cuda12_6-py3_10-gcc11-sm89-build
       - target-determination
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-cuda12.6-py3.10-gcc11-sm89
       docker-image: ${{ needs.linux-focal-cuda12_6-py3_10-gcc11-sm89-build.outputs.docker-image }}
@@ -502,6 +529,9 @@ jobs:
     name: linux-jammy-py3-clang12-executorch
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-jammy-py3-clang12-executorch-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-jammy-py3-clang12-executorch
       docker-image: ${{ needs.linux-jammy-py3-clang12-executorch-build.outputs.docker-image }}
@@ -527,6 +557,9 @@ jobs:
     name: cuda12.4-py3.10-gcc9-sm75
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-cuda12_4-py3_10-gcc9-inductor-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-cuda12.4-py3.10-gcc9-sm75
       docker-image: ${{ needs.linux-focal-cuda12_4-py3_10-gcc9-inductor-build.outputs.docker-image }}

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -70,6 +70,9 @@ jobs:
     needs:
       - linux-focal-cuda12_6-py3_10-gcc11-sm86-build
       - target-determination
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-cuda12.6-py3.10-gcc11-sm86
       docker-image: ${{ needs.linux-focal-cuda12_6-py3_10-gcc11-sm86-build.outputs.docker-image }}
@@ -97,6 +100,9 @@ jobs:
     needs:
       - linux-focal-py3_9-clang10-build
       - target-determination
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-py3.9-clang10
       docker-image: ${{ needs.linux-focal-py3_9-clang10-build.outputs.docker-image }}
@@ -156,6 +162,9 @@ jobs:
     needs:
       - linux-jammy-py3_10-clang15-asan-build
       - target-determination
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-jammy-py3.10-clang15-asan
       docker-image: ${{ needs.linux-jammy-py3_10-clang15-asan-build.outputs.docker-image }}

--- a/.github/workflows/torchbench.yml
+++ b/.github/workflows/torchbench.yml
@@ -41,6 +41,9 @@ jobs:
     name: cuda12.4-py3.10-gcc9-sm80
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-cuda12_4-py3_10-gcc9-torchbench-build-gcp
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-focal-cuda12.4-py3.10-gcc9-sm80
       docker-image: ${{ needs.linux-focal-cuda12_4-py3_10-gcc9-torchbench-build-gcp.outputs.docker-image }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -228,6 +228,9 @@ jobs:
   verify-cachebench-cpu-test:
     name: verify-cachebench-cpu-test
     uses: ./.github/workflows/_linux-test.yml
+    permissions:
+      id-token: write
+      contents: read
     needs:
       - verify-cachebench-cpu-build
       - target-determination


### PR DESCRIPTION
Update workflow to use OIDC authentication to access AWS resources rather than assuming the runner's default role. This is part of the multicloud effort to prepare jobs to support being run in non-AWS clouds where assumption of EC2 instance role cannot be used.

The JWT ID token requires id-token: write in order to create the token for the job.
See: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers#adding-permissions-settings

Ref: pytorch-fdn/multicloud-ci-infra#3
