### PR TITLE
Remove `reinterpret_cast`s with undefined behavior from stable/library.h

### DIFF
--- a/docs/source/notes/libtorch_stable_abi.md
+++ b/docs/source/notes/libtorch_stable_abi.md
@@ -8,15 +8,15 @@ This note will eventually contain more details on how to use the APIs in torch/c
 
 |  type in custom extension    |   StableIValue representation   |   type in libtorch  |   Schema Type  |
 | -------- | ------- | ------- | ------- |
-| std::optional\<S> | \*reinterpret_cast\<(StableIValue\*)\*>, pointer to a StableIValue recursively defined | std::optional\<T> | Type? |
-| std::nullopt | \*reinterpret_cast\<nullptr_t\*> | IValue() | None |
-| RAIIATH | \*reinterpret_cast\<uint64_t\*> of AtenTensorHandle | at::Tensor |  Tensor |
-| int32_t | \*reinterpret_cast\<uint64_t\*> | at::ScalarType | ScalarType |
-| int32_t | \*reinterpret_cast\<uint64_t\*> | at::Layout | Layout |
-| int32_t | \*reinterpret_cast\<uint64_t\*> | at::MemoryFormat | MemoryFormat |
-| bool | \*reinterpret_cast\<uint64_t\*> | bool | bool |
-| int64_t | \*reinterpret_cast\<uint64_t\*> | int64_t | int |
-| double | \*reinterpret_cast\<uint64_t\*> | double | float |
+| std::optional\<S> | raw bitwise copy into leading bytes of uint64_t of pointer to a new StableIValue representing S | std::optional\<T> | Type? |
+| std::nullopt | nullptr | IValue() | None |
+| RAIIATH | raw bitwise copy into leading bytes of uint64_t | at::Tensor |  Tensor |
+| int32_t | raw bitwise copy into leading bytes of uint64_t | at::ScalarType | ScalarType |
+| int32_t | raw bitwise copy into leading bytes of uint64_t | at::Layout | Layout |
+| int32_t | raw bitwise copy into leading bytes of uint64_t | at::MemoryFormat | MemoryFormat |
+| bool | raw bitwise copy into leading bytes of uint64_t | bool | bool |
+| int64_t | raw bitwise copy into leading bytes of uint64_t | int64_t | int |
+| double | raw bitwise copy into leading bytes of uint64_t | double | float |
 | ? | ? | c10::Device | Device |
 | ? | ? | c10::Stream | Stream |
 | ? | ? | c10::complex<double> | complex |


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #151593

There is a list of valid uses of `reinterpret_cast` (see https://en.cppreference.com/w/cpp/language/reinterpret_cast), and the use here was not on the list, hence undefined behavior. Implement what we meant using memcpy, which is well-defined.

Differential Revision: [D73200791](https://our.internmc.facebook.com/intern/diff/D73200791/)