### PR TITLE
Add OIDC perms to windows-[build|test] workflows

### DIFF
--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -56,6 +56,10 @@ on:
         value: ${{ jobs.build.outputs.test-matrix }}
         description: An optional JSON description of what test configs to run later on.
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
@@ -170,6 +174,13 @@ jobs:
         run: |
           .ci/pytorch/win-build.sh
 
+      - name: Configure AWS Credentials - Upload Build Artifacts
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_pytorch_artifacts
+          role-session-name: gha-windows-build-upload-build-artifacts
+          aws-region: us-east-1
+
       # Upload to github so that people can click and download artifacts
       - name: Upload artifacts to s3
         if: steps.build.outcome != 'skipped'
@@ -179,6 +190,14 @@ jobs:
           if-no-files-found: error
           name: ${{ inputs.build-environment }}
           path: C:\${{ github.run_id }}\build-results
+
+      - name: Configure AWS Credentials - Upload sccache
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_upload-benchmark-results
+          role-session-name: gha-windows-build-sccache
+          aws-region: us-east-1
+          unset-current-credentials: true
 
       - name: Upload sccache stats
         if: steps.build.outcome != 'skipped'

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -37,6 +37,10 @@ on:
         type: boolean
         default: true
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
@@ -115,6 +119,13 @@ jobs:
           # Windows conda doesn't have python3 binary, only python, but it's python3
           ${CONDA_RUN} python -m tools.stats.monitor > usage_log.txt 2>&1 &
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
+          role-session-name: gha-windows-test
+          aws-region: us-east-1
 
       - name: Download PyTorch Build Artifacts
         uses: seemethere/download-artifact-s3@v4
@@ -229,6 +240,13 @@ jobs:
           MONITOR_SCRIPT_PID: ${{ steps.monitor-script.outputs.monitor-script-pid }}
         run: |
           kill "$MONITOR_SCRIPT_PID"
+
+      - name: Configure AWS Credentials - Upload Test Artifacts
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_pytorch_artifacts
+          role-session-name: gha-windows-test-upload-test-artifacts
+          aws-region: us-east-1
 
       - name: Upload test artifacts
         uses: ./.github/actions/upload-test-artifacts

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -368,6 +368,9 @@ jobs:
     name: win-vs2022-cpu-py3
     uses: ./.github/workflows/_win-build.yml
     needs: get-label-type
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: win-vs2022-cpu-py3
       cuda-version: cpu

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -130,6 +130,9 @@ jobs:
     name: win-vs2022-cpu-py3
     uses: ./.github/workflows/_win-build.yml
     needs: get-label-type
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: win-vs2022-cpu-py3
       cuda-version: cpu
@@ -149,6 +152,9 @@ jobs:
     needs:
       - win-vs2022-cpu-py3-build
       - target-determination
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: win-vs2022-cpu-py3
       cuda-version: cpu
@@ -159,6 +165,9 @@ jobs:
     name: win-vs2022-cuda12.6-py3
     uses: ./.github/workflows/_win-build.yml
     needs: get-label-type
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: win-vs2022-cuda12.6-py3
       cuda-version: "12.6"

--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -58,6 +58,9 @@ jobs:
     if: github.repository_owner == 'pytorch'
     name: win-vs2022-xpu-2025_0-py3
     uses: ./.github/workflows/_win-build.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: win-vs2022-xpu-py3
       cuda-version: cpu


### PR DESCRIPTION
Update workflow to use OIDC authentication to access AWS resources rather than assuming the runner's default role. This is part of the multicloud effort to prepare jobs to support being run in non-AWS clouds where assumption of EC2 instance role cannot be used.

The JWT ID token requires id-token: write in order to create the token for the job.
See: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers#adding-permissions-settings

Ref: pytorch-fdn/multicloud-ci-infra#3
