### PR TITLE
[export] allow partially specifying keys for dynamic shapes dict spec

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -4117,7 +4117,9 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
 
         inputs = (torch.randn(4), torch.randn(6), torch.randn(6))
         dynamic_shapes = {"x": (Dim.AUTO,)}
-        if not is_retracebility_test(self._testMethodName):  # retraceability test forces dict -> tuple conversion
+        if not is_retracebility_test(
+            self._testMethodName
+        ):  # retraceability test forces dict -> tuple conversion
             export(P(), inputs, dynamic_shapes=dynamic_shapes)
 
     def test_unbacked_bindings_for_divisible_u_symint(self):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -4117,7 +4117,8 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
 
         inputs = (torch.randn(4), torch.randn(6), torch.randn(6))
         dynamic_shapes = {"x": (Dim.AUTO,)}
-        export(P(), inputs, dynamic_shapes=dynamic_shapes)
+        if not is_retracebility_test(self._testMethodName):  # retraceability test forces dict -> tuple conversion
+            export(P(), inputs, dynamic_shapes=dynamic_shapes)
 
     def test_unbacked_bindings_for_divisible_u_symint(self):
         from torch._export.utils import _get_shape_env_from_gm

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
+import copy
 import dataclasses
 import functools
 import inspect
@@ -1165,6 +1166,7 @@ def _process_export_inputs(mod, args, kwargs, dynamic_shapes):
         if isinstance(dynamic_shapes, torch.export.ShapesCollection):
             dynamic_shapes = dynamic_shapes.dynamic_shapes(mod, args, kwargs)
 
+    dynamic_shapes = copy.deepcopy(dynamic_shapes)
     return args, kwargs, original_in_spec, dynamic_shapes, verify_additional_inputs
 
 


### PR DESCRIPTION
Fixes #148564

Should help with exporting HF-style models, so users don't have to specify 100 Nones
