### PR TITLE
[dynamic shapes] user-code friendly statically_known_true, has_static_value

### DIFF
--- a/docs/source/fx.experimental.rst
+++ b/docs/source/fx.experimental.rst
@@ -50,6 +50,7 @@ torch.fx.experimental.symbolic_shapes
     constrain_unify
     canonicalize_bool_expr
     statically_known_true
+    has_static_value
     lru_cache
     check_consistent
     compute_unbacked_bindings

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1511,6 +1511,11 @@ utils_device.CURRENT_DEVICE == None""".split(
                 x -= 1
             else:
                 x += 1
+            torch._check(x.shape[0] >= 10)
+            if statically_known_true(x.shape[0] > 9):
+                x += 1
+            else:
+                x -= 1
             if has_static_value(x.shape[0]):
                 x -= 1
             else:
@@ -1519,7 +1524,7 @@ utils_device.CURRENT_DEVICE == None""".split(
 
         x = torch.zeros(10)
         torch._dynamo.mark_dynamic(x, 0)
-        self.assertEqual(f(x).sum(), 20)
+        self.assertEqual(f(x).sum(), 30)
 
         @torch.compile(fullgraph=True, dynamic=True)
         def g(x, y):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1507,11 +1507,13 @@ utils_device.CURRENT_DEVICE == None""".split(
 
         @torch.compile(fullgraph=True)
         def f(x):
+            # At this point, this isn't statically known, only the hint says so.
             if statically_known_true(x.shape[0] > 9):
                 x -= 1
             else:
                 x += 1
             torch._check(x.shape[0] >= 10)
+            # But now it is.
             if statically_known_true(x.shape[0] > 9):
                 x += 1
             else:

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1498,6 +1498,21 @@ utils_device.CURRENT_DEVICE == None""".split(
         self.assertEqual(cnts.frame_count, 3)
         self.assertEqual(cnts.op_count, 9)
 
+    def test_user_code_statically_known_true(self):
+        from torch.fx.experimental.symbolic_shapes import statically_known_true
+
+        @torch.compile(fullgraph=True)
+        def f(x):
+            if statically_known_true(x.shape[0] > 50):
+                x += 1
+            else:
+                x -= 1
+            return x
+
+        x = torch.ones(51)
+        torch._dynamo.mark_dynamic(x, 0)
+        self.assertEqual(f(x).sum(), 0)
+
     def test_dictcomp(self):
         def fn1(inputs):
             return {k: v + 1 for k, v in inputs.items()}

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1500,7 +1500,10 @@ utils_device.CURRENT_DEVICE == None""".split(
 
     @patch.object(torch._dynamo.config, "capture_scalar_outputs", True)
     def test_user_code_statically_known(self):
-        from torch.fx.experimental.symbolic_shapes import has_static_value, statically_known_true
+        from torch.fx.experimental.symbolic_shapes import (
+            has_static_value,
+            statically_known_true,
+        )
 
         @torch.compile(fullgraph=True)
         def f(x):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1516,7 +1516,7 @@ utils_device.CURRENT_DEVICE == None""".split(
 
         x = torch.zeros(10)
         torch._dynamo.mark_dynamic(x, 0)
-        self.assertEqual(f(x), (True, True))
+        self.assertEqual(f(x), (True, False))
 
         @torch.compile(fullgraph=True, dynamic=True, backend="eager")
         def g(x, y):

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -312,6 +312,7 @@ manual_torch_name_rule_map: dict[str, Any] = {
     "torch.fx.experimental.symbolic_shapes.guard_or_true": TorchInGraphFunctionVariable,
     "torch.fx.experimental.symbolic_shapes.guard_or_false": TorchInGraphFunctionVariable,
     "torch.fx.experimental.symbolic_shapes.statically_known_true": TorchInGraphFunctionVariable,
+    "torch.fx.experimental.symbolic_shapes.has_static_value": TorchInGraphFunctionVariable,
     "torch.cuda._get_device_properties": TorchInGraphFunctionVariable,
     "torch.utils.hooks.BackwardHook": TorchInGraphFunctionVariable,
     "torch.set_default_device": UserFunctionVariable,

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -311,6 +311,7 @@ manual_torch_name_rule_map: dict[str, Any] = {
     "torch.fx.experimental.symbolic_shapes.guard_size_oblivious": TorchInGraphFunctionVariable,
     "torch.fx.experimental.symbolic_shapes.guard_or_true": TorchInGraphFunctionVariable,
     "torch.fx.experimental.symbolic_shapes.guard_or_false": TorchInGraphFunctionVariable,
+    "torch.fx.experimental.symbolic_shapes.statically_known_true": TorchInGraphFunctionVariable,
     "torch.cuda._get_device_properties": TorchInGraphFunctionVariable,
     "torch.utils.hooks.BackwardHook": TorchInGraphFunctionVariable,
     "torch.set_default_device": UserFunctionVariable,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -923,6 +923,15 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             elif isinstance(expr, ConstantVariable):
                 return expr
 
+        @register(torch.fx.experimental.symbolic_shapes.statically_known_true)
+        def handle_statically_known_true(self, tx: "InstructionTranslator", expr):
+            if isinstance(expr, SymNodeVariable):
+                return variables.ConstantVariable.create(
+                    torch.fx.experimental.symbolic_shapes.statically_known_true(expr.sym_num)
+                )
+            elif isinstance(expr, ConstantVariable):
+                return expr
+
         @register(torch._C._autograd._unsafe_set_version_counter)
         def handle_unsafe_set_version_counter(
             self, tx: "InstructionTranslator", *args, **kwargs

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -927,10 +927,25 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
         def handle_statically_known_true(self, tx: "InstructionTranslator", expr):
             if isinstance(expr, SymNodeVariable):
                 return variables.ConstantVariable.create(
-                    torch.fx.experimental.symbolic_shapes.statically_known_true(expr.sym_num)
+                    torch.fx.experimental.symbolic_shapes.statically_known_true(
+                        expr.sym_num
+                    )
                 )
             elif isinstance(expr, ConstantVariable):
                 return expr
+
+        @register(torch.fx.experimental.symbolic_shapes.has_static_value)
+        def handle_has_static_value(self, tx: "InstructionTranslator", expr):
+            if isinstance(expr, SymNodeVariable):
+                val = expr.sym_num
+            elif isinstance(expr, ConstantVariable):
+                val = expr.value
+            else:
+                return
+
+            return variables.ConstantVariable.create(
+                torch.fx.experimental.symbolic_shapes.has_static_value(val)
+            )
 
         @register(torch._C._autograd._unsafe_set_version_counter)
         def handle_unsafe_set_version_counter(

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import sympy
 from sympy import Add, S
-from torch._prims_common import IntLike
+
+from torch._prims_common import BoolLike, FloatLike, IntLike
 
 
 """
@@ -67,7 +68,7 @@ from torch.fx.experimental.recording import (
     ShapeEnvEvent,
 )
 from torch.fx.experimental.sym_node import SymNode, SymTypes
-from torch.types import BoolLikeType, FloatLikeType, IntLikeType, py_sym_types
+from torch.types import py_sym_types
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 from torch.utils._sympy.functions import (
@@ -434,13 +435,13 @@ def has_static_value(a: Union[SymBool, SymFloat, SymInt, bool, float, int]) -> b
     Args:
         a (Union[SymBool, SymFloat, SymInt, bool, float, int]): Object to test
     """
-    assert isinstance(a, py_sym_types + (bool, float, int))
+    assert isinstance(a, BoolLike + FloatLike + IntLike)
     if (
-        isinstance(a, BoolLikeType)
+        isinstance(a, BoolLike)
         and is_concrete_bool(a)  # type: ignore[arg-type]
-        or isinstance(a, FloatLikeType)
+        or isinstance(a, FloatLike)
         and is_concrete_float(a)  # type: ignore[arg-type]
-        or isinstance(a, IntLikeType)
+        or isinstance(a, IntLike)
         and is_concrete_int(a)  # type: ignore[arg-type]
     ):
         return True

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -425,6 +425,13 @@ def is_concrete_bool(a: Union[bool, SymBool]) -> bool:
 
 
 def has_static_value(a: Union[SymBool, SymFloat, SymInt, bool, float, int]):
+    """
+    User-code friendly utility to check if a value is static or dynamic.
+    Returns true if given a constant, or a symbolic expression with a fixed value.
+
+    Args:
+        a (Union[SymBool, SymFloat, SymInt, bool, float, int]): Object to test
+    """
     assert isinstance(a, (SymBool, SymFloat, SymInt, bool, float, int))
     if (
         isinstance(a, (SymBool, bool)) and is_concrete_bool(a)
@@ -438,6 +445,8 @@ def has_static_value(a: Union[SymBool, SymFloat, SymInt, bool, float, int]):
         and (shape_env := fake_mode.shape_env)
     ):
         return shape_env.bound_sympy(a.node.expr).is_singleton()
+    else:
+        log.debug("Could not detect ShapeEnv in has_static_value(%s) call", a)
 
     return False
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -424,7 +424,7 @@ def is_concrete_bool(a: Union[bool, SymBool]) -> bool:
     return False
 
 
-def has_static_value(a: Union[SymBool, SymFloat, SymInt, bool, float, int]):
+def has_static_value(a: Union[SymBool, SymFloat, SymInt, bool, float, int]) -> bool:
     """
     User-code friendly utility to check if a value is static or dynamic.
     Returns true if given a constant, or a symbolic expression with a fixed value.
@@ -434,17 +434,21 @@ def has_static_value(a: Union[SymBool, SymFloat, SymInt, bool, float, int]):
     """
     assert isinstance(a, (SymBool, SymFloat, SymInt, bool, float, int))
     if (
-        isinstance(a, (SymBool, bool)) and is_concrete_bool(a)
-        or isinstance(a, (SymBool, float)) and is_concrete_float(a)
-        or isinstance(a, (SymBool, int)) and is_concrete_int(a)
+        isinstance(a, (SymBool, bool))
+        and is_concrete_bool(a)  # type: ignore[arg-type]
+        or isinstance(a, (SymBool, float))
+        and is_concrete_float(a)  # type: ignore[arg-type]
+        or isinstance(a, (SymBool, int))
+        and is_concrete_int(a)  # type: ignore[arg-type]
     ):
         return True
 
     if (
-        (fake_mode := torch._guards.detect_fake_mode())
-        and (shape_env := fake_mode.shape_env)
+        (fake_mode := torch._guards.detect_fake_mode()) and (
+            shape_env := fake_mode.shape_env
+        )
     ):
-        return shape_env.bound_sympy(a.node.expr).is_singleton()
+        return shape_env.bound_sympy(a.node.expr).is_singleton()  # type: ignore[union-attr]
     else:
         log.debug("Could not detect ShapeEnv in has_static_value(%s) call", a)
 


### PR DESCRIPTION
Fixes #151480

Allows `statically_known_true` in user code, as well as introducing `has_static_value`, returning True if the input has a static bool/float/int value

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames