### PR TITLE
added six and pyyaml to requirements.txt to fix missing module error …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ setuptools>=62.3.0,<75.9
 sympy>=1.13.3
 types-dataclasses
 typing-extensions>=4.10.0
+six
+pyyaml


### PR DESCRIPTION

This PR adds the six and pyyaml module to the project’s dependencies to resolve a ModuleNotFoundError during the build process. The six module is required for compatibility between Python 2 and 3, and this change ensures the build process runs smoothly by including it in the environment setup.