### PR TITLE
Throw an error in get_pip_packages if pip list returns an error code.

### DIFF
--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -445,6 +445,8 @@ def get_pip_packages(run_lambda, patterns=None):
     # People generally have pip as `pip` or `pip3`
     # But here it is invoked as `python -mpip`
     out = run_and_read_all(run_lambda, [sys.executable, '-mpip', 'list', '--format=freeze'])
+    if out is None:
+        raise RuntimeError("`pip list` returned an error code. Run `pip list` at the command line to diagnose the error.")
     filtered_out = '\n'.join(
         line
         for line in out.splitlines()


### PR DESCRIPTION
Fixes #147669

Error handling for pip_get_packages when pip list returns an error code.
