### PR TITLE
refresh benchmark results

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -6,11 +6,11 @@ add_loop_eager_dynamic,compile_time_instruction_count,5633000000,0.025
 
 
 
-add_loop_inductor,compile_time_instruction_count,28810000000,0.015
+add_loop_inductor,compile_time_instruction_count,29160000000,0.015
 
 
 
-add_loop_inductor_dynamic_gpu,compile_time_instruction_count,42490000000,0.025
+add_loop_inductor_dynamic_gpu,compile_time_instruction_count,42960000000,0.025
 
 
 
@@ -18,7 +18,7 @@ add_loop_inductor_gpu,compile_time_instruction_count,25505620920,0.015
 
 
 
-basic_modules_ListOfLinears_eager,compile_time_instruction_count,963100000,0.015
+basic_modules_ListOfLinears_eager,compile_time_instruction_count,970500000,0.015
 
 
 
@@ -38,7 +38,7 @@ update_hint_regression,compile_time_instruction_count,1608000000,0.02
 
 
 
-float_args,compile_time_instruction_count,436306379,0.015
+float_args,compile_time_instruction_count,441500000,0.015
 
 
 
@@ -70,7 +70,7 @@ aotdispatcher_partitioner_cpu2,compile_time_instruction_count,1856000000,0.015
 
 
 
-aotdispatcher_training_nosubclass_cpu,compile_time_instruction_count,3751000000,0.015
+aotdispatcher_training_nosubclass_cpu,compile_time_instruction_count,3770000000,0.015
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #151622

updating due to <1.5% increases in https://github.com/pytorch/pytorch/pull/151469
not all benchmarks were updated

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames