### PR TITLE
distributed: add distributed P2P TensorQueue and TensorStore

### DIFF
--- a/test/distributed/test_queues.py
+++ b/test/distributed/test_queues.py
@@ -1,0 +1,94 @@
+import torch
+import torch.distributed as dist
+
+from torch.distributed._queue import TensorQueue, TensorStore
+from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestQueues(MultiProcessTestCase):
+    @property
+    def world_size(self):
+        return 2
+
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    def create_tcp_store(self):
+        store = dist.FileStore(self.file_name, self.world_size)
+
+        KEY = f"{self.id()}/port"
+
+        if self.rank == 0:
+            tcp_store = dist.TCPStore(
+                "127.0.0.1", 0, self.world_size, is_master=True, wait_for_workers=False
+            )
+            store.set(KEY, str(tcp_store.port))
+            return tcp_store
+        else:
+            port = int(store.get(KEY))
+            return dist.TCPStore(
+                "127.0.0.1",
+                port,
+                self.world_size,
+                is_master=False,
+                wait_for_workers=False,
+            )
+
+    def test_queues(self):
+        store = self.create_tcp_store()
+        dist.init_process_group(
+            backend="gloo", rank=self.rank, world_size=self.world_size, store=store
+        )
+
+        queue = TensorQueue("foo")
+
+        for i in range(10):
+            expected = torch.tensor([1, 2, 3, i])
+            out = torch.tensor([0, 0, 0, 0])
+
+            if self.rank == 0:
+                queue.push(expected)
+            else:
+                queue.pop(out)
+                self.assertEqual(out, expected)
+
+    def test_tensor_store(self):
+        store = self.create_tcp_store()
+        dist.init_process_group(
+            backend="gloo", rank=self.rank, world_size=self.world_size, store=store
+        )
+
+        tensor_store = TensorStore("foo")
+
+        tensors = []
+
+        for i in range(10):
+            print(f"iter {i=} {self.rank=}")
+            key = f"key_{i}"
+            if self.rank == 0:
+                t = torch.tensor([0])
+                tensors.append(t)
+                tensor_store.register(key, t)
+            else:
+                t = torch.tensor([i])
+                tensor_store.write(key, t)
+
+                out = torch.tensor([0])
+                tensor_store.read(key, out)
+                self.assertEqual(out, t)
+
+        # exit barrier
+        dist.barrier()
+
+        for i, t in enumerate(tensors):
+            self.assertEqual(t, torch.tensor([i]))
+
+
+if __name__ == "__main__":
+    assert (
+        not torch.cuda._initialized
+    ), "test_distributed must not have initialized CUDA context on main process"
+
+    run_tests()

--- a/torch/distributed/_queue.py
+++ b/torch/distributed/_queue.py
@@ -1,0 +1,106 @@
+import pickle
+import threading
+from dataclasses import dataclass
+
+import torch
+import torch.distributed as dist
+
+
+class TensorQueue:
+    """
+    TensorQueue implements a fully distributed queue on top of a specified
+    ProcessGroup using the default global TCPStore for metadata exchange.
+    """
+
+    def __init__(self, key: str, group=None) -> None:
+        self.group = group
+        self.store = dist.distributed_c10d._get_default_store().clone()
+
+        self.rank = dist.get_rank(group)
+        self.global_key = f"{key}/global"
+        self.local_key = f"{key}/{self.rank}"
+
+    def set_timeout(self, timeout: float) -> None:
+        self.store.set_timeout(timeout)
+
+    def push(self, tensor: torch.Tensor) -> None:
+        self.store.queue_push(self.global_key, self.local_key)
+
+        remote_rank = int(self.store.queue_pop(self.local_key))
+        dist.send(tensor, dst=remote_rank, group=self.group)
+
+    def pop(self, tensor: torch.Tensor) -> None:
+        remote_key = self.store.queue_pop(self.global_key)
+        remote_rank = int(remote_key.rpartition(b"/")[2])
+        self.store.queue_push(remote_key, str(self.rank))
+
+        dist.recv(tensor, src=remote_rank, group=self.group)
+
+
+@dataclass
+class _StoreRequest:
+    key: str
+    write: bool
+    response_key: str
+    rank: int
+
+
+class TensorStore:
+    """
+    TensorStore implements a fully distributed store on top of a specified
+    ProcessGroup using the default global TCPStore for metadata exchange.
+    """
+
+    def __init__(self, key: str, group=None) -> None:
+        self.group = group
+        self.store = dist.PrefixStore(
+            key,
+            dist.distributed_c10d._get_default_store().clone(),
+        )
+
+        self.rank = dist.get_rank(group)
+        self.request_key = f"req/{self.rank}"
+        self.response_key = f"resp/{self.rank}"
+
+        self.tensors = {}
+
+        self.thread = threading.Thread(target=self._worker, daemon=True)
+        self.thread.start()
+
+    def _worker(self) -> None:
+        store = self.store.clone()
+        while True:
+            req = pickle.loads(store.queue_pop(self.request_key))
+            store.queue_push(req.response_key, str(self.rank))
+            tensor = self.tensors[req.key]
+            if req.write:
+                dist.recv(tensor, src=req.rank, group=self.group)
+            else:
+                dist.send(tensor, dst=req.rank, group=self.group)
+
+    def set_timeout(self, timeout: float) -> None:
+        self.store.set_timeout(timeout)
+
+    def register(self, key: str, tensor: torch.Tensor) -> None:
+        self.tensors[key] = tensor
+        self.store.set(key, self.request_key)
+
+    def write(self, key: str, tensor: torch.Tensor) -> None:
+        request_key = self.store.get(key)
+        req = _StoreRequest(
+            write=True, response_key=self.response_key, key=key, rank=self.rank
+        )
+        self.store.queue_push(request_key, pickle.dumps(req))
+
+        remote_rank = int(self.store.queue_pop(self.response_key))
+        dist.send(tensor, dst=remote_rank, group=self.group)
+
+    def read(self, key: str, tensor: torch.Tensor) -> None:
+        request_key = self.store.get(key)
+        req = _StoreRequest(
+            write=False, response_key=self.response_key, key=key, rank=self.rank
+        )
+        self.store.queue_push(request_key, pickle.dumps(req))
+
+        remote_rank = int(self.store.queue_pop(self.response_key))
+        dist.recv(tensor, src=remote_rank, group=self.group)


### PR DESCRIPTION
This is an implementation of a distributed tensor queue and store system.

This uses `TCPStore`'s queue implementation to do a fully multi-reader multi-writer queue implementation. This uses the store for metadata exchange but all tensors are transferred via the global ProcessGroup (i.e. NCCL/gloo).

As such this should be highly performant for most use cases (~30k tensors/s across the job).

This implements two structures:

* TensorQueue which allows users to send/recv on arbitrary global queue keys. This supports multi-reader and multi-writer.
* TensorStore which allows trainers to globally register a tensor that allows remote machines to read/write to that tensor emulating RDMA.

Use cases:

* distributed dataloaders
* RL generator/trainer communication
* checkpoint transfers in a P2P fashion

This is mostly a POC and won't land in its current form.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab