### PR TITLE
[Intel GPU][Inductor] Fallback embedding_dense_backward on XPU

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1236,8 +1236,6 @@ def embedding_dense_backward(
     padding_idx: int,
     scale_grad_by_freq: bool,
 ):
-    if grad_output.is_xpu:
-        return NotImplemented
     computation_dtype, result_dtype = utils.elementwise_dtypes(
         grad_output, type_promotion_kind=utils.ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT
     )

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1474,7 +1474,7 @@ def _addmm_activation(
 ):
     out = addmm(self, mat1, mat2, beta, alpha)
     if use_gelu:
-        if self.is_cuda or self.is_xpu:
+        if self.is_cuda:
             return aten.gelu(out, approximate="tanh")
         else:
             return aten.gelu(out)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1236,6 +1236,8 @@ def embedding_dense_backward(
     padding_idx: int,
     scale_grad_by_freq: bool,
 ):
+    if grad_output.is_xpu:
+        return NotImplemented
     computation_dtype, result_dtype = utils.elementwise_dtypes(
         grad_output, type_promotion_kind=utils.ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT
     )
@@ -1474,7 +1476,7 @@ def _addmm_activation(
 ):
     out = addmm(self, mat1, mat2, beta, alpha)
     if use_gelu:
-        if self.is_cuda:
+        if self.is_cuda or self.is_xpu:
             return aten.gelu(out, approximate="tanh")
         else:
             return aten.gelu(out)

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -147,9 +147,10 @@ def _embedding_dense_backward(
     padding_idx: int,
     scale_grad_by_freq: bool,
 ) -> torch.Tensor:
+    # TODO: check if XE4 still need this fallback
+    # check torch.xpu.get_device_properties(grad_output.device).architecture
     if grad_output.is_xpu:
         return NotImplemented
-    # decomp_func = decompositions.pop(op.overloads()[0], None)
     # We can write a util function to update decomp table if we have more ops to fallback.
     return decomp_embedding_dense_backward(
         grad_output, indices, num_weights, padding_idx, scale_grad_by_freq

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -146,7 +146,7 @@ def _embedding_dense_backward(
     num_weights: int,
     padding_idx: int,
     scale_grad_by_freq: bool,
-):
+) -> torch.Tensor:
     if grad_output.is_xpu:
         return NotImplemented
     # decomp_func = decompositions.pop(op.overloads()[0], None)

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -20,6 +20,7 @@ from torch._decomp import (
 from torch._decomp.decompositions import (
     _grid_sampler_2d as decomp_grid_sampler_2d,
     _index_add,
+    embedding_dense_backward as decomp_embedding_dense_backward,
     pw_cast_for_opmath,
 )
 from torch._decomp.decompositions_for_rng import extra_random_decomps
@@ -114,6 +115,7 @@ decomps_to_exclude = [
     aten._softmax_backward_data,
     aten.clamp_max,
     aten.clamp_min,
+    aten.embedding_dense_backward,  # we fall back on xpu
     aten.index_add,  # we conditionally call this decomp
     aten.glu,  # inductor lowers this directly
     aten.select_scatter,  # need to be in the ATen graph in order for it to work with the re-inplacing pass
@@ -135,6 +137,23 @@ def register_decomposition(
         if op in decompositions:
             log.warning("duplicate decomp: %s", ops)
     return decomp.register_decomposition(ops, decompositions)
+
+
+@register_decomposition([aten.embedding_dense_backward])
+def _embedding_dense_backward(
+    grad_output: torch.Tensor,
+    indices: torch.Tensor,
+    num_weights: int,
+    padding_idx: int,
+    scale_grad_by_freq: bool,
+):
+    if grad_output.is_xpu:
+        return NotImplemented
+    # decomp_func = decompositions.pop(op.overloads()[0], None)
+    # We can write a util function to update decomp table if we have more ops to fallback.
+    return decomp_embedding_dense_backward(
+        grad_output, indices, num_weights, padding_idx, scale_grad_by_freq
+    )
 
 
 # TODO: for now, inductor doesn't handle asserts

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2621,6 +2621,7 @@ make_fallback(aten.exponential.default, warn=False)  # (fails accuracy on test_t
 make_fallback(aten._pdist_forward)  # Has decomp. Needs benchmarks
 make_fallback(aten.soft_margin_loss_backward, warn=False)  # py_impl?
 make_fallback(aten._fused_rms_norm, warn=False)  # (MPS-only and faster than decomp)
+make_fallback(aten.embedding_dense_backward, warn=False) # (XPU-only and faster than decomp)
 
 
 # 1.5) Easy or Impossible
@@ -2811,7 +2812,6 @@ make_fallback(aten._efficient_attention_backward.default, sdpa_constraint)
 
 # index_reduce requires fallback when use_scatter_fallback(...) returns True
 make_fallback(aten.index_reduce)
-make_fallback(aten.embedding_dense_backward)
 
 
 # Register with type_promotion_kind None.

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2811,6 +2811,7 @@ make_fallback(aten._efficient_attention_backward.default, sdpa_constraint)
 
 # index_reduce requires fallback when use_scatter_fallback(...) returns True
 make_fallback(aten.index_reduce)
+make_fallback(aten.embedding_dense_backward)
 
 
 # Register with type_promotion_kind None.

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2621,7 +2621,9 @@ make_fallback(aten.exponential.default, warn=False)  # (fails accuracy on test_t
 make_fallback(aten._pdist_forward)  # Has decomp. Needs benchmarks
 make_fallback(aten.soft_margin_loss_backward, warn=False)  # py_impl?
 make_fallback(aten._fused_rms_norm, warn=False)  # (MPS-only and faster than decomp)
-make_fallback(aten.embedding_dense_backward, warn=False) # (XPU-only and faster than decomp)
+make_fallback(
+    aten.embedding_dense_backward, warn=False
+)  # (XPU-only and faster than decomp)
 
 
 # 1.5) Easy or Impossible

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2621,9 +2621,10 @@ make_fallback(aten.exponential.default, warn=False)  # (fails accuracy on test_t
 make_fallback(aten._pdist_forward)  # Has decomp. Needs benchmarks
 make_fallback(aten.soft_margin_loss_backward, warn=False)  # py_impl?
 make_fallback(aten._fused_rms_norm, warn=False)  # (MPS-only and faster than decomp)
-make_fallback(
-    aten.embedding_dense_backward, warn=False
-)  # (XPU-only and faster than decomp)
+if torch.xpu.is_available():
+    make_fallback(
+        aten.embedding_dense_backward, warn=False
+    )  # (XPU-only and faster than decomp)
 
 
 # 1.5) Easy or Impossible

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7133,6 +7133,18 @@ def _check_for_unsupported_isin_dtype(dtype):
     )
 
 
+@register_meta(aten.embedding_dense_backward)
+def meta_embedding_dense_backward(
+    grad_output,
+    indices,
+    num_weights,
+    padding_idx,
+    scale_grad_by_freq,
+):
+    grad_weight = grad_output.new_empty((num_weights, grad_output.size(-1)))
+    return grad_weight
+
+
 @register_meta(aten._embedding_bag_backward)
 def meta_embedding_bag_backward(
     grad,

--- a/torch/_prims_common/wrappers.py
+++ b/torch/_prims_common/wrappers.py
@@ -307,6 +307,8 @@ def out_wrapper(
                 result = fn(*args, is_out=(out is not None), **kwargs)  # type: ignore[arg-type]
             else:
                 result = fn(*args, **kwargs)
+            if result is NotImplemented:
+                return NotImplemented
             assert (
                 (isinstance(result, TensorLike) and is_tensor)
                 or (


### PR DESCRIPTION
Reopen #146888, now the modification only affects xpu device. We do not  want to decompose embedding_dense_backward for torch.compile. Current XPU devices have hardware limitations on atomic ops. Fallback to eager and we can use sort to implement this op. hf_T5 amp bf16 training in torchbench can get 2x improvement on Max 1550. ~~I also align with cuda on gelu decomposition in _addmm_activation~~


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @gujinghui @fengyuan14 @guangyey