### PR TITLE
Update link to NVIDIA cuDNN Support Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ If you want to compile with CUDA support, [select a supported version of CUDA fr
 - [NVIDIA cuDNN](https://developer.nvidia.com/cudnn) v8.5 or above
 - [Compiler](https://gist.github.com/ax3l/9489132) compatible with CUDA
 
-Note: You could refer to the [cuDNN Support Matrix](https://docs.nvidia.com/deeplearning/cudnn/reference/support-matrix.html) for cuDNN versions with the various supported CUDA, CUDA driver and NVIDIA hardware
+Note: You could refer to the [cuDNN Support Matrix](https://docs.nvidia.com/deeplearning/cudnn/frontend/latest/reference/support-matrix.html) to check compatibility of your local cuDNN version with the various supported CUDA, CUDA drivers and NVIDIA hardware.
 
 If you want to disable CUDA support, export the environment variable `USE_CUDA=0`.
 Other potentially useful environment variables may be found in `setup.py`.


### PR DESCRIPTION
Fortunately or unfortunately the generic cuDNN version agnostic link doesn't wotk and now NVIDIA publishes supported hardware per cuDNN version.

