### PR TITLE
[autodeps2] Replace third-party/pyyaml with third-party/pypi/pyyaml

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -178,7 +178,7 @@ THIRD_PARTY_LIBS = {
     "psimd": ["//xplat/third-party/psimd:psimd", "//third_party:psimd"],
     "pthreadpool": ["//xplat/third-party/pthreadpool:pthreadpool", "//third_party:pthreadpool"],
     "pthreadpool_header": ["//xplat/third-party/pthreadpool:pthreadpool_header", "//third_party:pthreadpool_header"],
-    "pyyaml": ["//third-party/pyyaml:pyyaml", "//third_party:pyyaml"],
+    "pyyaml": ["//third-party/pypi/pyyaml:pyyaml", "//third_party:pyyaml"],
     "rt": ["//xplat/third-party/linker_lib:rt", "//third_party:rt"],
     "ruy": ["//third-party/ruy:ruy_xplat_lib", "//third_party:ruy_lib"],
     "sleef_arm": ["//third-party/sleef:sleef_arm", "//third_party:sleef_arm"],


### PR DESCRIPTION
Summary: We should use the pypi version.

Test Plan: CI

Differential Revision: D73211869


