### PR TITLE
[BE][Easy]: Simplify ModuleList reversed method

### DIFF
--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -804,7 +804,7 @@ class ParameterDict(Module):
         return iter(self._keys)
 
     def __reversed__(self) -> Iterator[str]:
-        return reversed(list(self._keys))
+        return reversed(self._keys)
 
     def copy(self) -> "ParameterDict":
         """Return a copy of this :class:`~torch.nn.ParameterDict` instance."""


### PR DESCRIPTION
Removes unnecessary list calls now that we are in Python 3.9 and KeyViews implement reversed directly.