### PR TITLE
[c10d][fr] Fix a bug when first rank is not zero in the script

### DIFF
--- a/tools/flight_recorder/components/utils.py
+++ b/tools/flight_recorder/components/utils.py
@@ -220,7 +220,7 @@ def match_coalesced_groups_with_non_p2p(
         ]
         for rank in all_rank_events
     }
-    is_p2p = any(op.type in P2P for op in all_ops[0])
+    is_p2p = any(op.type in P2P for ops in all_ops.values() for op in ops)
     pg_name = pg_info[0]
 
     def visualize_ops(
@@ -602,7 +602,7 @@ def find_coalesced_group_with_non_p2p(
 
     if len(found) > 1:
         name = found[-1][1]["profiling_name"]
-        if name.startswith("nccl:") and name.endswith("_coalesced"):
+        if name.startswith("nccl:") and not name.endswith("_coalesced"):
             logger.error("Rank %s does not have a coalesced end.", rank)
         return found
     return []


### PR DESCRIPTION
Summary: Further testing the script, we found that we shouldn't always assume rank 0 is the first rank, so we need to check all entries and see if it P2P op for this coalesced group.

Test Plan: Directly test with corner case.

Differential Revision: D73266257


