### PR TITLE
More fix for aot_export_module name collision during unlifting

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1295,6 +1295,11 @@ class AOTInductorTestsTemplate:
                     torch.ones(1, device=device, dtype=torch.float32),
                     persistent=True,
                 )
+                self.register_buffer(
+                    "_tensor_constant1",
+                    torch.ones(1, device=device, dtype=torch.float32),
+                    persistent=True,
+                )
                 self.sub_mod = SubModule(device)
 
             def forward(self, x):
@@ -1303,6 +1308,7 @@ class AOTInductorTestsTemplate:
                         x, 1, torch.tensor(self.user_float_feature_idx, device=x.device)
                     ),
                     self._tensor_constant0,
+                    self._tensor_constant1,
                     self.sub_mod._tensor_constant1,
                 )
 


### PR DESCRIPTION
Summary: Also check the module's named buffers and parameters when resolving name collision

Test Plan:
```
buck2 run mode/dev-nosan caffe2/test/inductor:test_aot_inductor -- -r aoti_constant_tensor_name_collision
```

Differential Revision: D73264885




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov