### PR TITLE
[cutlass] Define GELU_taylor<float> only if CUTLASS version is <= 380

### DIFF
--- a/aten/src/ATen/native/cuda/cutlass_extensions/epilogue/thread/ft_fused_activations.h
+++ b/aten/src/ATen/native/cuda/cutlass_extensions/epilogue/thread/ft_fused_activations.h
@@ -42,6 +42,7 @@
 #include <cutlass/half.h>
 #include <cutlass/numeric_conversion.h>
 #include <cutlass/numeric_types.h>
+#include <cutlass/version.h>
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -69,6 +70,7 @@ __forceinline__ __device__ float tanh_opt(float x)
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
+#if CUTLASS_VERSION <= 380
 template<>
 struct GELU_taylor<float> {
     static const bool kIsHeavy = true;
@@ -92,6 +94,7 @@ struct GELU_taylor<float> {
         return this->operator()(scalar);
     }
 };
+#endif
 
 }  // namespace thread
 }  // namespace epilogue


### PR DESCRIPTION
Summary:
#buildmore

https://github.com/NVIDIA/cutlass/blame/df8a550d3917b0e97f416b2ed8c2d786f7f686a3/include/cutlass/epilogue/thread/activation.h#L610
was added in v3.9 (not tagged yet)

Test Plan:
mostly ci.

Logic seems same.

Reviewed By: drisspg

Differential Revision: D72615240


