### PR TITLE
[provenance_tracking][reland] Fix UT error and re-land `ExternKernel` support

### DIFF
--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -45,6 +45,16 @@ class Model2(torch.nn.Module):
         return a1, b1, c1
 
 
+class Model3(torch.nn.Module):
+    def __init__(self, n, k):
+        super().__init__()
+        self.weight = torch.randn(n, k, device="cuda")
+        self.bias = torch.randn(n, device="cuda")
+
+    def forward(self, a):
+        return torch.nn.functional.linear(a, self.weight, self.bias)
+
+
 @config.patch("trace.enabled", True)
 class TestProvenanceTracingArtifact(TestCase):
     """
@@ -167,16 +177,32 @@ class TestProvenanceTracingArtifact(TestCase):
                     else:
                         assert device == "cpu"
                         # check the inductor kernel to post grad nodes mapping is expected for cpu
-                        expected_data = {
-                            "cpp_fused_mul_0": ["mul"],
-                            "cpp_fused_gelu_1": [
-                                "mul_3",
-                                "mul_1",
-                                "add",
-                                "erf",
-                                "mul_2",
-                            ],
-                        }
+                        if backend == "aot_inductor":
+                            expected_data = {
+                                "cpp_fused_mul_0": ["mul"],
+                                "aoti_torch_cpu_addmm_out": ["addmm", "mul"],
+                                "cpp_fused_gelu_1": [
+                                    "mul_3",
+                                    "mul_1",
+                                    "add",
+                                    "erf",
+                                    "mul_2",
+                                ],
+                            }
+                        else:
+                            # backend == "inductor"
+                            expected_data = {
+                                "cpp_fused_mul_0": ["mul"],
+                                "aoti_torch_cpu_addmm_out": ["addmm", "mul"],
+                                "cpp_fused_gelu_1": [
+                                    "mul_3",
+                                    "mul_1",
+                                    "add",
+                                    "erf",
+                                    "mul_2",
+                                ],
+                                "extern_kernels.addmm": ["addmm", "mul"],
+                            }
                         self._check_provenance_tracing_artifact(filepath, expected_data)
 
             finally:
@@ -190,6 +216,56 @@ class TestProvenanceTracingArtifact(TestCase):
     @unittest.skipIf(HAS_GPU, "the test is only for cpu")
     def test_triton_kernel_to_post_grad_tracing_cpu(self):
         self._test_triton_kernel_to_post_grad_tracing(device="cpu")
+
+    @requires_cuda
+    def test_triton_kernel_to_post_grad_tracing_extern_kernel(self):
+        M = 8
+        N = 6
+        K = 16
+        model = Model3(N, K)
+        batch = 2
+        a = torch.randn(batch, M, K, device="cuda")
+        example_inputs = (a,)
+        filepath = None
+
+        for backend in ["aot_inductor", "inductor"]:
+            try:
+                with config.patch(
+                    {
+                        "trace.debug_dir": tempfile.mkdtemp(),
+                        "force_disable_caches": True,
+                    }
+                ):
+                    with self.assertLogs(
+                        logging.getLogger("torch._inductor.debug"),
+                        level=logging.WARNING,
+                    ) as cm:
+                        if backend == "aot_inductor":
+                            AOTIRunnerUtil.run(model, example_inputs)
+                        else:
+                            ep = torch.export._trace._export(model, example_inputs)
+                            compiled = torch.compile(ep.module(), backend=backend)
+                            compiled(*example_inputs)
+                    self.assertEqual(len(cm.output), 1)
+                    m = re.match(r"WARNING.* debug trace: (.*)", cm.output[0])
+                    self.assertTrue(m)
+                    filepath = Path(m.group(1))
+                    if backend == "inductor":
+                        expected_data = {
+                            "aoti_torch_cuda_addmm_out": ["addmm", "_tensor_constant1"],
+                            "triton_poi_fused_0": ["_tensor_constant1"],
+                            "extern_kernels.addmm": ["addmm"],
+                        }
+                    else:
+                        # backend = aot_inductor
+                        expected_data = {
+                            "aoti_torch_cuda_addmm_out": ["addmm", "_tensor_constant1"],
+                            "triton_poi_fused_0": ["_tensor_constant1"],
+                        }
+                    self._check_provenance_tracing_artifact(filepath, expected_data)
+            finally:
+                if filepath:
+                    shutil.rmtree(filepath)
 
     @requires_cuda
     def _test_pt_tracing_combo_kernel(self, backend):

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -49,6 +49,7 @@ from ..utils import (
     get_benchmark_name,
     IndentedBuffer,
     LineContext,
+    set_kernel_post_grad_provenance_tracing,
     sympy_product,
     sympy_str,
     sympy_subs,
@@ -454,6 +455,9 @@ class ExternKernelOutLine(WrapperLine):
         else:
             kernel_name = node.get_kernel_name()
         device = d.type if (d := node.get_device()) else V.graph.device_type
+        # set provenance tracing kernel mapping for ExternKernel types
+        if config.trace.enabled:
+            set_kernel_post_grad_provenance_tracing(node, kernel_name, is_extern=True)
         self.wrapper._generate_extern_kernel_out_helper(
             kernel_name,
             node.codegen_reference(),

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -67,7 +67,15 @@ if TYPE_CHECKING:
     from .codegen.common import WorkspaceArg
     from .codegen.wrapper import PythonWrapperCodegen
     from .graph import GraphLowering
-    from .ir import Buffer, ExternKernel, IRNode, Layout, Operation, ReinterpretView
+    from .ir import (
+        Buffer,
+        ExternKernel,
+        ExternKernelOut,
+        IRNode,
+        Layout,
+        Operation,
+        ReinterpretView,
+    )
     from .output_code import CompiledFxGraph
     from .scheduler import BaseSchedulerNode, SchedulerBuffer
 
@@ -2830,24 +2838,39 @@ def get_donated_idxs() -> Optional[list[int]]:
 
 
 def set_kernel_post_grad_provenance_tracing(
-    node_schedule: Sequence[BaseSchedulerNode], kernel_name: str
+    node_schedule: Union[Sequence[BaseSchedulerNode], ExternKernelOut],
+    kernel_name: str,
+    is_extern: bool = False,
 ) -> None:
     from .codegen.simd_kernel_features import DisableReduction, EnableReduction
+    from .ir import ExternKernelOut
     from .virtualized import V
 
-    for snode in node_schedule:
-        if snode not in (EnableReduction, DisableReduction):
-            if snode.node is not None:
-                curr_node_info = (
-                    V.debug._inductor_triton_kernel_to_post_grad_node_info.setdefault(
+    if is_extern:
+        assert isinstance(node_schedule, ExternKernelOut)
+        curr_node_info = (
+            V.debug._inductor_triton_kernel_to_post_grad_node_info.setdefault(
+                kernel_name, []
+            )
+        )
+        curr_node_info.extend(
+            origin.name
+            for origin in node_schedule.origins
+            if origin.name not in curr_node_info
+        )
+    else:
+        assert isinstance(node_schedule, list)
+        for snode in node_schedule:
+            if snode not in (EnableReduction, DisableReduction):
+                if snode.node is not None:
+                    curr_node_info = V.debug._inductor_triton_kernel_to_post_grad_node_info.setdefault(
                         kernel_name, []
                     )
-                )
-                curr_node_info.extend(
-                    origin.name
-                    for origin in snode.node.origins  # type: ignore[attr-defined]
-                    if origin.name not in curr_node_info
-                )
+                    curr_node_info.extend(
+                        origin.name
+                        for origin in snode.node.origins
+                        if origin.name not in curr_node_info
+                    )
 
 
 class TritonAttrsDescriptorVersion(enum.Enum):


### PR DESCRIPTION
Summary:
ATT.


reverted previous diff :  D72572050

Test Plan:
```
 TORCH_LOGS="+inductor, output_code" buck2 run -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=h100 @//mode/opt fbcode//caffe2/test/inductor:provenance_tracing -- -r test_triton_kernel_to_post_grad_tracing_extern_kernel
```

Differential Revision: D73281217




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov