### PR TITLE
[Inductor] Update should_decompose_mm condition for CPU

### DIFF
--- a/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
+++ b/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
@@ -78,7 +78,7 @@ def should_decompose_mm(mat1, mat2) -> bool:
     ) or (
         check_device(mat1, mat2, device="cpu")
         and statically_known_true(mat1.shape[0] == 1)
-        and statically_known_true(mat2.shape[0] <= 64)
+        and statically_known_true(mat2.shape[0] <= 128)
         and statically_known_true(mat2.shape[1] <= 512)
     )
 


### PR DESCRIPTION
Summary:
Similar to what we did previously in D70033166

Previously, for cpu we decompose addmm if
```
check_device(mat1, mat2, device="cpu")
        and statically_known_true(mat1.shape[0] == 1)
        and statically_known_true(mat2.shape[0] <= 64)
        and statically_known_true(mat2.shape[1] <= 512)
```
We have a new case where `mat1.shape[0] = 80`, and benchmark shows that it will beneficial if we decompose, so update the condition to
```
check_device(mat1, mat2, device="cpu")
        and statically_known_true(mat1.shape[0] == 1)
        and statically_known_true(mat2.shape[0] <= 128)
        and statically_known_true(mat2.shape[1] <= 512)
```

Differential Revision: D73292985




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov