### PR TITLE
[logging] Fix duration logging for dynamo_compile

### DIFF
--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -313,7 +313,7 @@ class TestDynamoTimed(TestCase):
  'cuda_version': None,
  'cudagraph_skip_reason': None,
  'distributed_ephemeral_timeout_us': None,
- 'duration_us': 0,
+ 'duration_us': None,
  'dynamo_compile_time_before_restart_us': 0,
  'dynamo_config': None,
  'dynamo_cumulative_compile_time_us': 0,

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -313,7 +313,7 @@ class TestDynamoTimed(TestCase):
  'cuda_version': None,
  'cudagraph_skip_reason': None,
  'distributed_ephemeral_timeout_us': None,
- 'duration_us': None,
+ 'duration_us': 0,
  'dynamo_compile_time_before_restart_us': 0,
  'dynamo_config': None,
  'dynamo_cumulative_compile_time_us': 0,

--- a/torch/_dynamo/metrics_context.py
+++ b/torch/_dynamo/metrics_context.py
@@ -14,10 +14,14 @@ execution performance.
 """
 
 import heapq
+import logging
 import time
 from collections.abc import Iterator
 from typing import Any, Callable, Optional
 from typing_extensions import TypeAlias
+
+
+log = logging.getLogger(__name__)
 
 
 class TopN:
@@ -84,10 +88,13 @@ class MetricsContext:
         self._level -= 1
         assert self._level >= 0
         if self._level == 0:
-            end_time_ns = time.time_ns()
-            self._on_exit(
-                self._start_time_ns, end_time_ns, self._metrics, exc_type, exc_value
-            )
+            try:
+                end_time_ns = time.time_ns()
+                self._on_exit(
+                    self._start_time_ns, end_time_ns, self._metrics, exc_type, exc_value
+                )
+            except Exception:
+                log.exception("Unexpected exception logging compilation metrics")
 
     def in_progress(self) -> bool:
         """
@@ -189,7 +196,7 @@ class RuntimeMetricsContext:
         self._start_time_ns: int = 0
 
     def increment(
-        self, metric: str, value: int, extra: Optional[dict[str, Any]]
+        self, metric: str, value: int, extra: Optional[dict[str, Any]] = None
     ) -> None:
         """
         Increment a metric by a given amount.
@@ -211,6 +218,12 @@ class RuntimeMetricsContext:
         Call the on_exit function with the metrics gathered so far and reset.
         """
         if self._metrics:
-            end_time_ns = time.time_ns()
-            self._on_exit(self._start_time_ns, end_time_ns, self._metrics, None, None)
-            self._metrics = {}
+            try:
+                end_time_ns = time.time_ns()
+                self._on_exit(
+                    self._start_time_ns, end_time_ns, self._metrics, None, None
+                )
+            except Exception:
+                log.exception("Unexpected exception logging runtime metrics")
+            finally:
+                self._metrics = {}

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -411,7 +411,7 @@ def dynamo_timed_cudagraph(
         log_pt2_compile_event=True,
         compile_id=compile_id,
         is_backward=mode == CompilationMode.BACKWARD,
-        dynamo_compile_runtime_column_us="runtime_cudagraphify_time_us"
+        dynamo_compile_column_us="runtime_cudagraphify_time_us"
         if dynamo_compile
         else None,
     ):

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -821,7 +821,7 @@ class CachingAutotuner(KernelInterface):
                 "CachingAutotuner.benchmark_all_configs",
                 log_pt2_compile_event=True,
                 metadata={"kernel_name": self.inductor_meta.get("kernel_name")},
-                dynamo_compile_runtime_column_us="runtime_triton_autotune_time_us",
+                dynamo_compile_column_us="runtime_triton_autotune_time_us",
                 compile_id=self.compile_id,
                 is_backward=self.is_backward,
                 log_waitcounter=True,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #151757
* __->__ #151749

Summary: There are a few issues I'm solving:.
1. It's too hard to measure total pt2 overhead using the dynamo_compile table because users need to know the columns representing all the top-level events (dynamo_cumulative_compile_time_us, etc.). Instead, let's populate the existing duration_us field for all top-level events. The complication is that runtime events in particular (Triton autotuning, cudagraphify) can be collapsed into a single row, with gaps in between, so we can't simply use `end_time - start_time` in all cases. Instead, we'll sum durations for all outer events when updating the compile-time or runtime metrics context. Introduce a 'depth' counter in TLS to track the nesting of CompilationMetrics events.
2. The existing implementation relies on callers of dynamo_timed to specify whether the event is a runtime or compile-time event. That doesn't work because some methods can be called in both situations, e.g., `CachingAutotuner.benchmark_all_configs`. For example `TORCHINDUCTOR_BENCHMARK_FUSION=1` enables benchmarking during compile-time. Instead, we can figure out automatically whether we're measuring a compile-time or runtime event and log accordingling.
3. If `log_compilation_events` were to throw an exception, we'd fail to clear the aggregated counters for runtime logs and they could be attributed to the wrong compile ID. I didn't actually find evidence of this in practice, but I added exception handling for extra safety.

Test Plan:
Ran internal models and compared dynamo_compile to pt2_compile_events:
`TORCHINDUCTOR_BENCHMARK_FUSION=0`
* tlparse: https://fburl.com/itciwnxc
* dynamo_compile: https://fburl.com/scuba/dynamo_compile/yvkif5vb
* pt2_compile_events: https://fburl.com/scuba/pt2_compile_events/segijet7

`TORCHINDUCTOR_BENCHMARK_FUSION=1`
* tlparse: https://fburl.com/jgurcvkw
* dynamo_compile: https://fburl.com/scuba/dynamo_compile/uum91ceb
* pt2_compile_events: https://fburl.com/scuba/pt2_compile_events/x4xnisez

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov