### PR TITLE
reroute index to fast implementation for indexing on 0th dimension

### DIFF
--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -14,6 +14,8 @@
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/cuda/KernelUtils.cuh>
 #include <ATen/native/quantized/IndexKernel.h>
+#include <ATen/native/cuda/MemoryAccess.cuh>
+#include <ATen/native/cuda/IndexKernelUtils.h>
 
 #include <c10/core/Scalar.h>
 
@@ -52,7 +54,7 @@ static void launch_kernel(const int64_t N, const func_t& f) {
 }
 
 template <typename func_t>
-void gpu_index_kernel(TensorIteratorBase& iter, const IntArrayRef index_size, const IntArrayRef index_stride, const func_t& f) {
+void gpu_index_kernel(TensorIteratorBase& iter, const IntArrayRef index_size, const IntArrayRef index_stride, const func_t& f, const bool is_gather_like) {
   const auto num_indices = index_size.size();
   AT_ASSERT(num_indices == index_stride.size());
   AT_ASSERT(static_cast<int64_t>(num_indices) == iter.ntensors() - 2);
@@ -63,9 +65,39 @@ void gpu_index_kernel(TensorIteratorBase& iter, const IntArrayRef index_size, co
 
   if (!iter.can_use_32bit_indexing()) {
     for (auto& sub_iter : iter.with_32bit_indexing()) {
-      gpu_index_kernel(sub_iter, index_size, index_stride, f);
+      gpu_index_kernel(sub_iter, index_size, index_stride, f, is_gather_like);
     }
     return;
+  }
+
+
+  char* const out_ptr = static_cast<char*>(iter.data_ptr(0));
+  char* const in_ptr = static_cast<char*>(iter.data_ptr(1));
+
+  if (is_gather_like && num_indices==1) {
+      constexpr int64_t alignment = 16;
+      //TensorIterator strides and sizes are ordered fastest moving to slowest moving,
+      //in consrast to regular sizes
+      using at::native::memory::get_alignment;
+      const size_t element_size = iter.element_size(0);
+      const auto index_element_size = iter.element_size(2);
+      // we need contiguous source and dst slices and aligned pointers and strides and slice size to do vectorized loads
+      // also we need idx to be expanded in the last dimension so we can copy entire slices
+      if (iter.ndim() == 2 && iter.strides(2)[0]==0 && iter.strides(2)[1]==index_element_size && static_cast<size_t>(iter.strides(0)[0])==element_size &&
+          static_cast<size_t>(iter.strides(1)[0])==element_size && get_alignment(out_ptr) == 16 && get_alignment(in_ptr) == 16 &&
+          get_alignment(static_cast<size_t>(iter.shape()[0] * element_size)) == 16 &&
+          get_alignment(static_cast<size_t>(index_stride[0] * element_size)) == 16 &&
+          get_alignment(static_cast<size_t>(iter.strides(0)[1])) == 16) {
+        auto slice_size = iter.shape()[0] * element_size;
+        auto num_ind = iter.shape()[1];
+        auto ind_dim_size = index_size[0];
+        auto inp_stride_bytes = index_stride[0];
+        auto out_stride_bytes = iter.strides(0)[1];
+        if (iter.numel() == 0) return;
+        at::native::vectorized_gather_kernel_launch<alignment>(out_ptr, in_ptr, (int64_t*)iter.data_ptr(2), num_ind,
+        slice_size, ind_dim_size, inp_stride_bytes, out_stride_bytes, /*allow_neg_indices*/true);
+        return;
+      }
   }
 
   auto sizes = std::array<int64_t, MAX_DIMS>{};
@@ -77,8 +109,6 @@ void gpu_index_kernel(TensorIteratorBase& iter, const IntArrayRef index_size, co
     index_ptrs[i] = (char*)iter.data_ptr(i + 2);
   }
 
-  char* const out_ptr = static_cast<char*>(iter.data_ptr(0));
-  char* const in_ptr = static_cast<char*>(iter.data_ptr(1));
 
   auto offset_calc = make_offset_calculator<3>(iter);
   launch_kernel<launch_size_nd, launch_bound2>(iter.numel(), [=]__device__(int idx) {
@@ -183,14 +213,14 @@ template <typename scalar_t>
 void index_kernel_impl(TensorIteratorBase& iter, const IntArrayRef index_size, const IntArrayRef index_stride) {
   gpu_index_kernel(iter, index_size, index_stride, []C10_DEVICE(char* const out_data, const char* const in_data, const int64_t offset) {
     *reinterpret_cast<scalar_t*>(out_data) = *reinterpret_cast<const scalar_t*>(in_data + offset);
-  });
+  }, true);
 }
 
 template <typename scalar_t>
 void index_put_kernel_impl(TensorIterator& iter, const IntArrayRef index_size, const IntArrayRef index_stride) {
   gpu_index_kernel(iter, index_size, index_stride, []C10_DEVICE(char* const out_data, const char* const in_data, const int64_t offset) {
     *reinterpret_cast<scalar_t*>(out_data + offset) = *reinterpret_cast<const scalar_t*>(in_data);
-  });
+  }, false);
 }
 
 static void index_kernel(
@@ -280,7 +310,7 @@ void index_put_kernel_quantized_cuda(TensorIterator& iter, const IntArrayRef ind
       // The replacement should generate the same PTX as std::clamp. See https://godbolt.org/z/Wde9KW3v4
       qvalue = (qvalue < qmin) ? qmin : (qmax < qvalue) ? qmax : qvalue;
       *(scalar_t*)(out_data + offset) = static_cast<scalar_t>(qvalue);
-    });
+    }, false);
   });
 }
 

--- a/aten/src/ATen/native/cuda/IndexKernelUtils.cu
+++ b/aten/src/ATen/native/cuda/IndexKernelUtils.cu
@@ -1,0 +1,44 @@
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/native/cuda/MemoryAccess.cuh>
+
+#include <c10/macros/Macros.h>
+#include <c10/util/Exception.h>
+#include <ATen/native/cuda/Loops.cuh>
+#include <ATen/ceil_div.h>
+
+namespace at::native {
+template <int Alignment>
+__global__ void vectorized_gather_kernel(char * out, char * inp, int64_t * idx, int num_ind, int64_t slice_size, int64_t ind_dim_size, int64_t inp_stride, int64_t out_stride, bool allow_neg_indices) {
+    int64_t ind = idx[blockIdx.x];
+    if (allow_neg_indices) {
+        ind = (ind < 0) ? ind + ind_dim_size : ind;
+    }
+    CUDA_KERNEL_ASSERT(ind >=0 && ind < ind_dim_size && "vectorized gather kernel index out of bounds");
+    int32_t off = (blockDim.x * blockIdx.y + threadIdx.x) * Alignment; // off is guaranteed to be within int32 limits
+    if (off >= slice_size) return;
+    auto vec = at::native::memory::ld_vec<Alignment>(inp + ind * inp_stride + off);
+    at::native::memory::st_vec<Alignment>(out + blockIdx.x * (int32_t)out_stride + off, vec);  // out offset is guaranteed to be within int32 limits
+}
+
+
+
+template <int64_t Alignment>
+void vectorized_gather_kernel_launch(char * out, char * inp, int64_t * idx, int num_ind,
+                                     int64_t slice_size_in_bytes, int64_t ind_dim_size, int64_t inp_stride_bytes, int64_t out_stride_bytes, bool allow_neg_indices){
+
+  constexpr int64_t max_num_threads=256;
+  auto num_threads = at::round_up(
+      at::ceil_div(slice_size_in_bytes, Alignment),
+      static_cast<int64_t>(C10_WARP_SIZE));
+  dim3 grid = {static_cast<uint32_t>(num_ind), static_cast<uint32_t>(at::ceil_div(slice_size_in_bytes, max_num_threads * Alignment)), 1};
+  auto block = std::min(max_num_threads, num_threads);
+  vectorized_gather_kernel<Alignment><<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(out, inp, idx, num_ind, slice_size_in_bytes,
+  ind_dim_size, inp_stride_bytes, out_stride_bytes, allow_neg_indices);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+// explicit template instantiation
+template void vectorized_gather_kernel_launch<16>(char * out, char * inp, int64_t * idx, int num_ind, int64_t slice_size_in_bytes,
+int64_t ind_dim_size, int64_t inp_stride_bytes, int64_t out_stride_bytes, bool allow_neg_indices);
+
+}

--- a/aten/src/ATen/native/cuda/IndexKernelUtils.h
+++ b/aten/src/ATen/native/cuda/IndexKernelUtils.h
@@ -1,0 +1,12 @@
+
+#include <cstdint>
+
+namespace at::native {
+
+template <int64_t Alignment>
+void vectorized_gather_kernel_launch(char * out, char * inp, int64_t * idx, int num_ind,
+                                     int64_t slice_size_in_bytes, int64_t ind_dim_size, int64_t inp_stride_bytes, int64_t out_stride_bytes,
+                                     bool allow_neg_indices=false);
+
+
+}

--- a/aten/src/ATen/native/cuda/IndexKernelUtils.h
+++ b/aten/src/ATen/native/cuda/IndexKernelUtils.h
@@ -1,7 +1,25 @@
 
 #include <cstdint>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/cuda/MemoryAccess.cuh>
 
 namespace at::native {
+
+template<int alignment>
+inline bool fast_gather_kernel_eligible(const TensorIterator& iter, char * const out_ptr, char * const in_ptr, const size_t index_stride, const size_t element_size) {
+  using at::native::memory::get_alignment;
+  const auto index_element_size = iter.element_size(2);
+  //TensorIterator strides and sizes are ordered fastest moving to slowest moving,
+  //in contrast to regular sizes
+  // we need contiguous source and dst slices and aligned pointers and strides and slice size to do vectorized loads
+  // also we need idx to be expanded in the last dimension so we can copy entire slices
+
+  return iter.ndim() == 2 && iter.strides(2)[0]==0 && iter.strides(2)[1]==index_element_size && static_cast<size_t>(iter.strides(0)[0])==element_size &&
+          static_cast<size_t>(iter.strides(1)[0])==element_size && get_alignment(out_ptr) == alignment && get_alignment(in_ptr) == alignment &&
+          get_alignment(static_cast<size_t>(iter.shape()[0] * element_size)) == alignment &&
+          get_alignment(static_cast<size_t>(index_stride * element_size)) == alignment &&
+          get_alignment(static_cast<size_t>(iter.strides(0)[1])) == alignment;
+}
 
 template <int64_t Alignment>
 void vectorized_gather_kernel_launch(char * out, char * inp, int64_t * idx, int num_ind,

--- a/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
+++ b/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
@@ -8,7 +8,7 @@
 #include <ATen/native/ScatterGatherChecks.h>
 #include <ATen/native/ReduceOpsUtils.h>
 #include <ATen/native/TensorIterator.h>
-
+#include <ATen/native/cuda/IndexKernelUtils.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/cuda/KernelUtils.cuh>
 #include <ATen/native/cuda/MemoryAccess.cuh>
@@ -113,34 +113,6 @@ static void _launch_scatter_gather_kernel(int64_t N, const func_t& f) {
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
-template <int Alignment>
-__global__ void vectorized_gather_kernel(char * out, char * inp, int64_t * idx, int num_ind, int64_t slice_size, int64_t ind_dim_size, int64_t inp_stride, int64_t out_stride) {
-    int64_t ind = idx[blockIdx.x];
-    CUDA_KERNEL_ASSERT(ind >=0 && ind < ind_dim_size && "vectorized gather kernel index out of bounds");
-    int32_t off = (blockDim.x * blockIdx.y + threadIdx.x) * Alignment; // off is guaranteed to be within int32 limits
-    if (off >= slice_size) return;
-    auto vec = at::native::memory::ld_vec<Alignment>(inp + ind * inp_stride + off);
-    at::native::memory::st_vec<Alignment>(out + blockIdx.x * (int32_t)out_stride + off, vec);  // out offset is guaranteed to be within int32 limits
-}
-
-
-
-template <int64_t Alignment>
-void vectorized_gather_kernel_launch(char * out, char * inp, int64_t * idx, int num_ind,
-                                     int64_t slice_size_in_bytes, int64_t ind_dim_size, int64_t inp_stride_bytes, int64_t out_stride_bytes){
-
-  constexpr int64_t max_num_threads=256;
-  auto num_threads = at::round_up(
-      at::ceil_div(slice_size_in_bytes, Alignment),
-      static_cast<int64_t>(C10_WARP_SIZE));
-  dim3 grid = {static_cast<uint32_t>(num_ind), static_cast<uint32_t>(at::ceil_div(slice_size_in_bytes, max_num_threads * Alignment)), 1};
-  auto block = std::min(max_num_threads, num_threads);
-  vectorized_gather_kernel<Alignment><<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(out, inp, idx, num_ind, slice_size_in_bytes,
-  ind_dim_size, inp_stride_bytes, out_stride_bytes);
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
-
-}
-
 template <bool is_scatter_like, typename scalar_t>
 struct _cuda_scatter_gather_internal_kernel {
   template <typename func_t>
@@ -168,13 +140,14 @@ struct _cuda_scatter_gather_internal_kernel {
       // we can go to faster path if we are indexing on the first dim
       // the dst and src are contiguous and all the dims and pts are multiple of 16
       constexpr size_t element_size = sizeof(scalar_t);
+      const auto index_element_size = iter.element_size(2);
       constexpr int64_t alignment = 16;
       //TensorIterator strides and sizes are ordered fastest moving to slowest moving,
       //in consrast to regular sizes
       using at::native::memory::get_alignment;
       // we need contiguous source and dst slices and aligned pointers and strides and slice size to do vectorized loads
       // also we need idx to be expanded in the last dimension so we can copy entire slices
-      if (iter.ndim() == 2 && iter.strides(2)[0]==0 && static_cast<size_t>(iter.strides(0)[0])==element_size &&
+      if (iter.ndim() == 2 && iter.strides(2)[0]==0 && iter.strides(2)[1]==index_element_size && static_cast<size_t>(iter.strides(0)[0])==element_size &&
           static_cast<size_t>(iter.strides(1)[0])==element_size && get_alignment(self_ptr) == 16 && get_alignment(src_ptr) == 16 &&
           get_alignment(static_cast<size_t>(iter.shape()[0] * element_size)) == 16 &&
           get_alignment(static_cast<size_t>(index_stride * element_size)) == 16 &&
@@ -185,7 +158,7 @@ struct _cuda_scatter_gather_internal_kernel {
         auto inp_stride_bytes = index_stride * element_size;
         auto out_stride_bytes = iter.strides(0)[1];
         if (iter.numel() == 0) return;
-        vectorized_gather_kernel_launch<alignment>(self_ptr, src_ptr, (int64_t*)index_ptr, num_ind, slice_size, ind_dim_size, inp_stride_bytes, out_stride_bytes);
+        at::native::vectorized_gather_kernel_launch<alignment>(self_ptr, src_ptr, (int64_t*)index_ptr, num_ind, slice_size, ind_dim_size, inp_stride_bytes, out_stride_bytes);
         return;
       }
     }

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -84,10 +84,19 @@ class TestScatterGather(TestCase):
                 res = torch.gather(src, dim=dim, index=ind)
                 ref = src[ind0] if dim == 0 else src[:, ind0]
                 self.assertEqual(res, ref, atol=0, rtol=0)
+                if res.device.type == "cuda":
+                    ref_cpu = src.cpu()[ind0.cpu()] if dim == 0 else src.cpu()[:, ind0.cpu()]
+                    self.assertEqual(res.cpu(), ref_cpu, atol=0, rtol=0)
+                res_ind_neg = src[ind0 - src.shape[dim]] if dim == 0 else src[:, ind0 - src.shape[1]]
+                self.assertEqual(res_ind_neg, ref, atol=0, rtol=0)
                 res = torch.gather(discontig, dim=dim, index=ind)
                 self.assertEqual(res, ref, atol=0, rtol=0)
+                res_ind = discontig[ind0] if dim == 0 else discontig[:, ind0]
+                self.assertEqual(res_ind, ref, atol=0, rtol=0)
                 res = torch.gather(misaligned, dim=dim, index=ind)
                 self.assertEqual(res, ref, atol=0, rtol=0)
+                res_ind = misaligned[ind0] if dim == 0 else misaligned[:, ind0]
+                self.assertEqual(res_ind, ref, atol=0, rtol=0)
 
 
     @dtypes(torch.bool)


### PR DESCRIPTION
Per title, improve x[index] cuda perf for the common case of indexing along the first dim, using vectorized gather kernel
