### PR TITLE
Eagerly guard when dealing with float32 scalar tensor item calls

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1225,6 +1225,20 @@ utils_device.CURRENT_DEVICE == None""".split(
         )
 
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    def test_float_32_scalar_tensor_item(self):
+        def f(y):
+            y = y * y
+            y_scalar = y.item()
+            return y_scalar
+
+        f_opt = torch.compile(f)
+
+        self.assertEqual(
+            f(torch.tensor(3.0, device='cuda')),
+            f_opt(torch.tensor(3.0, device='cuda'))
+        )
+
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_arange_length_with_float32_dtype(self):
         @torch.compile(fullgraph=True)
         def f(x):

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -416,7 +416,11 @@ def local_scalar_dense(fake_mode, func, arg):
     ):
         # Without symints/symfloats, cannot handle this
         raise DataDependentOutputException(func)
-    if is_float_dtype(arg.dtype):
+    # SymFloats don't have a notion of dtype and implicitly
+    # only support float64. Thus if we call item() on a float32
+    # scalar tensor, we necessarily have to graph break otherwise
+    # we will have incorrect numerics.
+    if arg.dtype == torch.float64:
         r = fake_mode.shape_env.create_unbacked_symfloat()
     elif is_integer_dtype(arg.dtype):
         r = fake_mode.shape_env.create_unbacked_symint()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #151763
* #151766

Fixes #151470

SymFloats implicitly only supports float64 as we can see in code like
this:
https://github.com/pytorch/pytorch/blob/main/torch/_subclasses/fake_tensor.py#L479.
This PR fixes the above issue by eagerly guarding when dealing with float32 scalar tensor item calls

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames