### PR TITLE
Add adaptive_avg_pool2d input and output_size check

### DIFF
--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -35,6 +35,11 @@ namespace {
         "adaptive_avg_pool2d(): Expected input to have non-zero size for non-batch dimensions, "
         "but input has sizes ", input.sizes(), " with dimension ", i + ndim, " being "
         "empty");
+      if (input.size(i) != output_size[i + 2]) {
+        TORCH_WARN(
+          "Input dimensions ", input.sizes(), " different with output_size ", output_size
+          );
+      }
     }
 
     TORCH_CHECK(input.dtype() == output.dtype(),


### PR DESCRIPTION
Fixes #126673

## Test Result

```python
import torch
import torch.nn as nn

batch_size = 10
channels = 3
length = 32
input_tensor = torch.randn([batch_size, channels, length])
adaptive_avg_pool = nn.AdaptiveAvgPool2d(output_size=16)
output_tensor = adaptive_avg_pool(input_tensor)
print(output_tensor.shape)

UserWarning: Input dimensions [10, 3, 32] different with output_size [16, 16] (Triggered internally at /home/zong/code/pytorch/aten/src/ATen/native/AdaptiveAveragePooling.cpp:39.)
  return torch._C._nn.adaptive_avg_pool2d(input, _output_size)
torch.Size([10, 16, 16])


batch_size = 10
channels = 3
length = 32
input_tensor = torch.randn([batch_size, channels, length])
adaptive_avg_pool = nn.AdaptiveAvgPool2d(output_size=[3, 32]) # no warning
output_tensor = adaptive_avg_pool(input_tensor)
print(output_tensor.shape)

torch.Size([10, 3, 32])

```
