### PR TITLE
[Inductor] Modify persistent+TMA template for Triton mm and admm to use new TMA API

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -987,6 +987,11 @@ class CachingAutotuner(KernelInterface):
         benchmark_run=False,
         **kwargs,
     ):  # type:ignore[override]
+        def alloc_fn(size: int, align: int, stream: Optional[int]):
+            return torch.empty(size, dtype=torch.int8, device=self.device_props.type)
+
+        triton.set_allocator(alloc_fn)
+
         if self.triton_interpret:
             args, grid = self._interpret_args_grid(args, self.configs[0])
             return self.fn[grid](


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #151772

Summary:
This PR modifies the Triton template for persisten+TMA mm and admm to use the new functional API for TMA introduced here: https://github.com/triton-lang/triton/pull/6248/

This also involves setting a global Triton allocator function to be called at kernel launch for any kernels that require additional global memory workspace. This is done in triton_heuristics.py directly before kernels are launched.

Test Plan:
contbuild & OSS CI

Reviewers: paulzhan

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov