### PR TITLE
[Inductor] Modify TritonTemplate store_output function to support TMA stores

### DIFF
--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -301,15 +301,11 @@ persistent_tma_mm_template = TritonTemplate(
         )
 
         if ki == k_tiles - 1:
-            # rematerialize rm and rn to save registers
-            rcm = rm + tl.arange(0, BLOCK_M)
-            rcn = rn + tl.arange(0, BLOCK_N)
-            idx_m = rcm[:, None]
-            idx_n = rcn[None, :]
-            mask = (idx_m < M) & (idx_n < N)
+            # cast acc to output type for TMA store
+            out = acc.cast(A.dtype.element_ty)
 
             # inductor generates a suffix
-            {{store_output(("idx_m", "idx_n"), "acc", "mask", indent_width=12)}}
+            {{store_output(["rm", "rn"], "out", indent_width=12, mode = "TMA")}}
             acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
 
 """,

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -19,7 +19,7 @@ from .utils import IndentedBuffer, reduction_num_outputs, sympy_index_symbol, sy
 
 
 T = TypeVar("T")
-StoreMode = Optional[Literal["atomic_add"]]
+StoreMode = Optional[Literal["atomic_add", "TMA"]]
 ReductionType = Literal[
     "argmax",
     "argmin",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #151775
* #151774

Summary:
The `store_output` macro -- used in Triton templates to generate triton kernel code for storing output using `tl.store` -- has been modified to support TMA based stores.

This now allows functions using TMA stores to benefit from inductor epilogue fusion. Additionally, it is now a lot easier to add TMA stores to existing kernels.

The persistent + TMA template mm template was updated to use this logic.

Test Plan:
contbuild and OSS CI

Reviewers: paulzhan

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov