### PR TITLE
[Indcutor Remote Cache] Raise an exception if redis module is required but not available

### DIFF
--- a/torch/_inductor/remote_cache.py
+++ b/torch/_inductor/remote_cache.py
@@ -244,8 +244,7 @@ class RedisRemoteCacheBackend(RemoteCacheBackend[bytes]):
     def __init__(self, cache_id: str) -> None:
         super().__init__()
         if not redis:
-            # We had trouble importing redis - just skip init.
-            return
+            raise Exception("redis not available but required for remote cache")
 
         if "TORCHINDUCTOR_REDIS_URL" in os.environ:
             self._redis = redis.Redis.from_url(os.environ["TORCHINDUCTOR_REDIS_URL"])

--- a/torch/_inductor/remote_cache.py
+++ b/torch/_inductor/remote_cache.py
@@ -244,7 +244,7 @@ class RedisRemoteCacheBackend(RemoteCacheBackend[bytes]):
     def __init__(self, cache_id: str) -> None:
         super().__init__()
         if not redis:
-            raise Exception("redis not available but required for remote cache")
+            raise RuntimeError("redis not available but required for remote cache")
 
         if "TORCHINDUCTOR_REDIS_URL" in os.environ:
             self._redis = redis.Redis.from_url(os.environ["TORCHINDUCTOR_REDIS_URL"])


### PR DESCRIPTION
If we need redis but redis is not available, it is better to tell the user to install redis instead of continue silently.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov