### PR TITLE
[Dynamo] Replace `unimplemented` with `unimplemented_v2` in `torch/_dynamo/variables/iter.py`

### DIFF
--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -131,11 +131,11 @@ class ItertoolsVariable(VariableTracker):
                         acc = func(tx, [acc, item], {})
                     except Exception as e:
                         unimplemented_v2(
-                            gb_type="Unexpected failure",
+                            gb_type="Unexpected failure during itertools.accumulate() iteration",
                             context=f"call_function {self} {args} {kwargs}",
                             explanation="Unexpected failure in invoking function during accumulate. "
                             f"Failed running func {func}({item}{acc})",
-                            hints=[*graph_break_hints.SUPPORTABLE],
+                            hints=[*graph_break_hints.DIFFICULT],
                             from_exc=e,
                         )
                 items.append(acc)
@@ -230,7 +230,7 @@ class ItertoolsVariable(VariableTracker):
                     )
             except Exception as e:
                 unimplemented_v2(
-                    gb_type="Unexpected failure",
+                    gb_type="Unexpected failure during itertools.groupby() iteration",
                     context=f"call_function {self} {args} {kwargs}",
                     explanation="Unexpected failure in invoking function during groupby",
                     hints=[*graph_break_hints.SUPPORTABLE],
@@ -375,7 +375,7 @@ class CycleIteratorVariable(IteratorVariable):
                     unimplemented_v2(
                         gb_type="input iterator to itertools.cycle has too many items",
                         context=f"next({self})",
-                        explanation=f"Has reached max iterator limit: {MAX_ITERATOR_LIMIT}",
+                        explanation=f"Has reached internal Dynamo max iterator limit: {MAX_ITERATOR_LIMIT}",
                         hints=[],
                     )
                 tx.output.side_effects.mutation(self)

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -98,8 +98,10 @@ class ItertoolsVariable(VariableTracker):
                     unimplemented_v2(
                         gb_type="Unsupported `func` in itertools.accumulate",
                         context=f"call_function {self} {args} {kwargs}",
-                        explanation="itertools.accumulate can only accept "
-                        "one of: `func` kwarg, pos 2 arg",
+                        explanation="Dynamo does not know how to get the "
+                        "function to use for itertools.accumulate. "
+                        "itertools.accumulate expects the `func` as the second "
+                        "argument or as a keyword argument.",
                         hints=[*graph_break_hints.USER_ERROR],
                     )
             else:

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -179,7 +179,8 @@ class ItertoolsVariable(VariableTracker):
                         gb_type="Unsupported key type for itertools.groupby",
                         context=f"call_function {self} {args} {kwargs}",
                         explanation="Dynamo does not know how to trace "
-                        f"itertools.groupby with key type: {str(type(key))}",
+                        f"itertools.groupby with key type: {str(type(key))}. "
+                        "We only support grouping keys that are constants (int, float, str, etc.)",
                         hints=[*graph_break_hints.SUPPORTABLE],
                     )
 

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -107,8 +107,14 @@ class ItertoolsVariable(VariableTracker):
                     gb_type="Unsupported arguments for itertools.accumulate",
                     context=f"call_function {self} {args} {kwargs}",
                     explanation="Dynamo does not know how to trace "
-                    f"itertools.accumulate with args: {args}",
-                    hints=[*graph_break_hints.USER_ERROR],
+                    f"itertools.accumulate with args: {args} and kwargs: {kwargs}. "
+                    "itertools.accumulate expects an iterable, an optional "
+                    "binary function for accumulation, and an optional initial "
+                    "value to set the starting state.",
+                    hints=[
+                        "Make sure the arguments to itertools.accumulate are correct.",
+                        *graph_break_hints.SUPPORTABLE,
+                    ],
                 )
 
             items = []

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -191,8 +191,13 @@ class ItertoolsVariable(VariableTracker):
                     gb_type="Unsupported arguments for itertools.groupby",
                     context=f"call_function {self} {args} {kwargs}",
                     explanation="Dynamo does not know how to trace "
-                    f"itertools.groupby with args: {args}",
-                    hints=[*graph_break_hints.USER_ERROR],
+                    f"itertools.groupby with args: {args} and kwargs: {kwargs}. "
+                    "itertools.groupby expects an iterable to group and an "
+                    "optional key function to determine groupings.",
+                    hints=[
+                        "Make sure the arguments to itertools.groupby are correct.",
+                        *graph_break_hints.SUPPORTABLE,
+                    ],
                 )
 
             if "key" in kwargs:


### PR DESCRIPTION
Part of #147913

Replace `unimplemented` with`unimplemented_v2` in `torch/_dynamo/variables/iter.py`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames