### PR TITLE
[c10d][fr] Fix another bug when we should continue when the op list is empty

### DIFF
--- a/tools/flight_recorder/components/utils.py
+++ b/tools/flight_recorder/components/utils.py
@@ -265,6 +265,7 @@ def match_coalesced_groups_with_non_p2p(
     for rank, op_list in all_ops.items():
         if not op_list:
             logger.error("Rank %s has an empty op list.", rank)
+            continue
         if op_list[-1].type == "coalesced" and is_p2p:
             op_list.pop(-1)
 


### PR DESCRIPTION
Differential Revision: D73375318

We shouldn't check the op list when it is empty. And later, when it is empty we pops it out from the queue we will check for collective matching. Added a unit test for this case and also covered the case fixed https://github.com/pytorch/pytorch/pull/151683 in the unit test as well.


cc @H-Huang @awgu @wanchaol @fegin @wz337 @wconstab @d4l3k