### PR TITLE
[CUDA][CPU] Bump system memory requirement for `test_cross_entropy_large_tensor`

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12152,7 +12152,7 @@ if __name__ == '__main__':
 
     # Ref: https://github.com/pytorch/pytorch/issues/85005
     @onlyCUDA
-    @largeTensorTest("45GB", "cpu")
+    @largeTensorTest("120GB", "cpu")
     @largeTensorTest("70GB", "cuda")
     @parametrize_test("reduction", ("none", "mean", "sum"))
     def test_cross_entropy_large_tensor(self, device, reduction):


### PR DESCRIPTION
`/usr/bin/time` seems to show max resident pages at 119GiB

cc @ptrblck @msaroufim @jerryzh168