### PR TITLE
[easy] Fix test_dynamo_timed

### DIFF
--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -174,6 +174,7 @@ class TestDynamoTimed(TestCase):
 
         add(torch.rand([10]), torch.rand([10]))
         utils.reset_frame_count()
+        torch._logging._internal.structured_logging_overhead.clear()
 
     @dynamo_config.patch(
         {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #151816

Summary: The structured logging counter is a global that might have been affected by earlier tests. Clear it explicitly.
Fixes #148093

Test Plan: `pytest test/dynamo/test_utils.py`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames