### PR TITLE
[MTIA] Store original file path and line number that FX op derives from. Print the file path and line number for each op in IR printing.

### DIFF
--- a/torch/fx/config.py
+++ b/torch/fx/config.py
@@ -1,6 +1,14 @@
+import os
+
+
 # Whether to disable showing progress on compilation passes
 # Need to add a new config otherwise wil get a circular import if dynamo config is imported here
 disable_progress = True
 
 # If True this also shows the node names in each pass, for small models this is great but larger models it's quite noisy
 verbose_progress = False
+
+# Feature flag to control whether source location information (file_path, line_number) is captured.
+capture_source_locations: bool = (
+    os.getenv("TORCH_FX_CAPTURE_SOURCE_LOCATIONS", "0") == "1"
+)

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -683,6 +683,12 @@ class Node(_NodeBase):
             The list of Nodes on which this change was made.
         """
         if propagate_meta:
+            # We clear the file_path and line_number
+            # from the meta of the node being replaced.
+            if "file_path" in replace_with.meta:
+                del replace_with.meta["file_path"]
+            if "line_number" in replace_with.meta:
+                del replace_with.meta["line_number"]
             assert len(replace_with.meta) == 0, (
                 "Called node.replace_all_uses_with(replace_with, propagate_meta=True), "
                 "but replace_with already has .meta keys"


### PR DESCRIPTION
Summary:
When tracing with torch export to FX IR, we need to keep track of the original file path and line number that the FX op originates from in the user code. We then need to print this at the far right of the Node in IR printing.

Without a mapping of user PyTorch code to FX IR, it is very difficult to debug the IR, especially in cases where there are mysterious ops appearing.

I also add support for propagating the line number and file path even with decomposition. Side note: I find it interesting that decomposition actually produces a second traced ExportedProgram. Why do we not just run decomposition during the first tracing?

Jax/XLA currently offers this to users, and it is extremely useful for debug. 

**We default the printing to not print debug file source / line info by default.**

IR Example for Llama: **Scroll to the right**
```
    %div_tensor_12 : f16[1, 32, 2960, 2960][#users=1] = call_function[target=aten.div.Tensor](kwargs = {input: %reshape_default_906, other: 11.313708498984761}) file_path = transformers/models/llama/modeling_llama.py line_number = 419
    %slice_tensor_229 : f16[1, 1, 2960, 2960][#users=1] = call_function[target=aten.slice.Tensor](kwargs = {input: %clone_default_152, dim: 0, start: 0, end: 1, step: 1}) file_path = transformers/models/llama/modeling_llama.py line_number = 423
    %slice_tensor_230 : f16[1, 1, 2960, 2960][#users=1] = call_function[target=aten.slice.Tensor](kwargs = {input: %slice_tensor_229, dim: 1, start: 0, end: 1, step: 1}) file_path = transformers/models/llama/modeling_llama.py line_number = 423
    %slice_tensor_231 : f16[1, 1, 2960, 2960][#users=1] = call_function[target=aten.slice.Tensor](kwargs = {input: %slice_tensor_230, dim: 2, start: 0, end: 2960, step: 1}) file_path = transformers/models/llama/modeling_llama.py line_number = 423
    %slice_tensor_232 : f16[1, 1, 2960, 2960][#users=1] = call_function[target=aten.slice.Tensor](kwargs = {input: %slice_tensor_231, dim: 3, start: 0, end: 2960, step: 1}) file_path = transformers/models/llama/modeling_llama.py line_number = 423
    %add_tensor_135 : f16[1, 32, 2960, 2960][#users=1] = call_function[target=aten.add.Tensor](kwargs = {input: %div_tensor_12, other: %slice_tensor_232, alpha: 1}) file_path = transformers/models/llama/modeling_llama.py line_number = 423
    %_to_copy_default_194 : f32[1, 32, 2960, 2960][#users=1] = call_function[target=aten._to_copy.default](kwargs = {input: %add_tensor_135, dtype: torch.float32, layout: torch.strided, device: cpu, pin_memory: None, non_blocking: False, memory_format: None}) file_path = transformers/models/llama/modeling_llama.py line_number = 426
    %_softmax_default_12 : f32[1, 32, 2960, 2960][#users=1] = call_function[target=aten._softmax.default](kwargs = {input: %_to_copy_default_194, dim: -1, half_to_float: False}) file_path = transformers/models/llama/modeling_llama.py line_number = 426
    %_to_copy_default_195 : f16[1, 32, 2960, 2960][#users=1] = call_function[target=aten._to_copy.default](kwargs = {input: %_softmax_default_12, dtype: torch.float16, layout: None, device: None, pin_memory: None, non_blocking: False, memory_format: None}) file_path = transformers/models/llama/modeling_llama.py line_number = 426
    %clone_default_74 : f16[1, 32, 2960, 2960][#users=1] = call_function[target=aten.clone.default](kwargs = {input: %_to_copy_default_195, memory_format: None}) file_path = transformers/models/llama/modeling_llama.py line_number = 427
    %repeat_default_173 : f16[1, 32, 2960, 2960][#users=1] = call_function[target=aten.repeat.default](kwargs = {input: %clone_default_74, repeats: [1, 1, 1, 1]}) file_path = transformers/models/llama/modeling_llama.py line_number = 428
    %reshape_default_907 : f16[32, 2960, 2960][#users=1] = call_function[target=aten.reshape.default](kwargs = {input: %repeat_default_173, shape: [32, 2960, 2960]}) file_path = transformers/models/llama/modeling_llama.py line_number = 428
    %repeat_default_174 : f16[1, 32, 2960, 128][#users=1] = call_function[target=aten.repeat.default](kwargs = {input: %reshape_default_903, repeats: [1, 1, 1, 1]}) file_path = transformers/models/llama/modeling_llama.py line_number = 428
    %reshape_default_908 : f16[32, 2960, 128][#users=1] = call_function[target=aten.reshape.default](kwargs = {input: %repeat_default_174, shape: [32, 2960, 128]}) file_path = transformers/models/llama/modeling_llama.py line_number = 428
    %bmm_default_72 : f16[32, 2960, 128][#users=1] = call_function[target=aten.bmm.default](kwargs = {input: %reshape_default_907, mat2: %reshape_default_908}) file_path = transformers/models/llama/modeling_llama.py line_number = 428
    %reshape_default_909 : f16[1, 32, 2960, 128][#users=1] = call_function[target=aten.reshape.default](kwargs = {input: %bmm_default_72, shape: [1, 32, 2960, 128]}) file_path = transformers/models/llama/modeling_llama.py line_number = 428
    %permute_default_453 : f16[1, 2960, 32, 128][#users=1] = call_function[target=aten.permute.default](kwargs = {input: %reshape_default_909, dims: [0, 2, 1, 3]}) file_path = transformers/models/llama/modeling_llama.py line_number = 436
    %clone_default_75 : f16[1, 2960, 32, 128][#users=1] = call_function[target=aten.clone.default](kwargs = {input: %permute_default_453, memory_format: torch.contiguous_format}) file_path = transformers/models/llama/modeling_llama.py line_number = 436
    %reshape_default_910 : f16[1, 2960, 4096][#users=1] = call_function[target=aten.reshape.default](kwargs = {input: %clone_default_75, shape: [1, 2960, -1]}) file_path = transformers/models/llama/modeling_llama.py line_number = 438
    %permute_default_454 : f16[4096, 4096][#users=1] = call_function[target=aten.permute.default](kwargs = {input: %model_model_model_layers_12_self_attn_o_proj_weight, dims: [1, 0]}) file_path = transformers/models/llama/modeling_llama.py line_number = 445
    %reshape_default_911 : f16[2960, 4096][#users=1] = call_function[target=aten.reshape.default](kwargs = {input: %reshape_default_910, shape: [2960, 4096]}) file_path = transformers/models/llama/modeling_llama.py line_number = 445
    %mm_default_87 : f16[2960, 4096][#users=1] = call_function[target=aten.mm.default](kwargs = {input: %reshape_default_911, mat2: %permute_default_454}) file_path = transformers/models/llama/modeling_llama.py line_number = 445
    %reshape_default_912 : f16[1, 2960, 4096][#users=1] = call_function[target=aten.reshape.default](kwargs = {input: %mm_default_87, shape: [1, 2960, 4096]}) file_path = transformers/models/llama/modeling_llama.py line_number = 445
    %add_tensor_136 : f16[1, 2960, 4096][#users=2] = call_function[target=aten.add.Tensor](kwargs = {input: %add_tensor_131, other: %reshape_default_912, alpha: 1}) file_path = transformers/models/llama/modeling_llama.py line_number = 740
```

Test Plan: Added unit test

Differential Revision: D73346635




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv