### PR TITLE
Add assert_on_assumption on to guard_or_true, and guard_or_false

### DIFF
--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -902,23 +902,31 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 return expr
 
         @register(torch.fx.experimental.symbolic_shapes.guard_or_true)
-        def handle_guard_or_true(self, tx: "InstructionTranslator", expr):
+        def handle_guard_or_true(
+            self, tx: "InstructionTranslator", expr, assert_on_assumption=None
+        ):
             if isinstance(expr, SymNodeVariable):
                 # TODO: this probably should be folded somewhere else but I'm not sure where
                 # TODO: some of the other symbolic_shapes special tools can also get this treatment too
                 return variables.ConstantVariable.create(
-                    torch.fx.experimental.symbolic_shapes.guard_or_true(expr.sym_num)
+                    torch.fx.experimental.symbolic_shapes.guard_or_true(
+                        expr.sym_num, assert_on_assumption
+                    )
                 )
             elif isinstance(expr, ConstantVariable):
                 return expr
 
         @register(torch.fx.experimental.symbolic_shapes.guard_or_false)
-        def handle_guard_or_false(self, tx: "InstructionTranslator", expr):
+        def handle_guard_or_false(
+            self, tx: "InstructionTranslator", expr, assert_on_assumption=None
+        ):
             if isinstance(expr, SymNodeVariable):
                 # TODO: this probably should be folded somewhere else but I'm not sure where
                 # TODO: some of the other symbolic_shapes special tools can also get this treatment too
                 return variables.ConstantVariable.create(
-                    torch.fx.experimental.symbolic_shapes.guard_or_false(expr.sym_num)
+                    torch.fx.experimental.symbolic_shapes.guard_or_false(
+                        expr.sym_num, assert_on_assumption
+                    )
                 )
             elif isinstance(expr, ConstantVariable):
                 return expr

--- a/torch/fx/passes/runtime_assert.py
+++ b/torch/fx/passes/runtime_assert.py
@@ -258,17 +258,11 @@ def insert_deferred_runtime_asserts(
                 # nodes
                 with _set_node_metadata_hook(gm, _node_metadata_hook):
                     res = _sympy_interp(expr_to_proxy, ra.expr).node
-                    expr_msg = f"Runtime assertion failed for expression {ra.expr} on node '{res}'"
-                    assert_msg = (
-                        f"{expr_msg}\n\nThe original traceback points to the following location and error message:\n{ra.loc}\n{ra.msg}"
-                        if ra.msg
-                        else expr_msg
-                    )
                     graph.call_function(
                         torch.ops.aten._assert_scalar.default,
                         # TODO: use ra.msg here, but it's pretty
                         # useless right now
-                        (res, assert_msg),
+                        (res, ra.make_assert_message(res)),
                     )
                 added_asserts.add(ra.expr)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)


One thing that we will be doing often is asserting on the assumption made by 
guard_or_false, and guard_or_true. 

For example in expand if the input ==-1. we will assume its not -1 and want to add a runtime assertion that it is not -1
only when we do such assumptions. 

similarly this will be used for broadcast checks. and some other locations. where we do not want to silently deviate.

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov