### PR TITLE
[Dynamo] Replace `unimplemented` with `unimplemented_v2` in `torch/_dynamo/variables/lists.py`

### DIFF
--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -26,7 +26,7 @@ import torch.fx
 
 from .. import graph_break_hints, polyfills, variables
 from ..bytecode_transformation import create_call_function, create_instruction
-from ..exc import raise_observed_exception, unimplemented, unimplemented_v2
+from ..exc import raise_observed_exception, unimplemented_v2
 from ..source import AttrSource
 from ..utils import (
     cmp_name_to_op_mapping,
@@ -137,7 +137,14 @@ class BaseListVariable(VariableTracker):
                 if value.constant is not None and value.constant.numel() == 1:
                     value = variables.ConstantVariable.create(value.constant.item())
                 else:
-                    unimplemented("__getitem__ with non-constant tensor")
+                    unimplemented_v2(
+                        gb_type="__getitem__ with non-constant tensor",
+                        context=f"call_method {self} {name} {args} {kwargs}",
+                        explanation=(
+                            "Cannot perform __getitem__ with non-constant tensor."
+                        ),
+                        hints=[*graph_break_hints.USER_ERROR],
+                    )
             else:
                 value = args[0]
             return self.getitem_const(tx, value)
@@ -341,7 +348,13 @@ class RangeVariable(BaseListVariable):
     def var_getattr(self, tx: "InstructionTranslator", name):
         fields = ["start", "stop", "step"]
         if name not in fields:
-            unimplemented(f"range.{name}")
+            unimplemented_v2(
+                gb_type="Unsupported attribute for range",
+                context=f"var_getattr {self} {name}",
+                explanation=f"Expected attribute to be one of {','.join(fields)} "
+                f"but got {name}",
+                hints=[*graph_break_hints.USER_ERROR],
+            )
         return self.items[fields.index(name)]
 
 
@@ -458,8 +471,11 @@ class ListVariable(CommonListMethodsVariable):
             tx.output.side_effects.mutation(self)
             if isinstance(key, SliceVariable):
                 if not value.has_force_unpack_var_sequence(tx):
-                    unimplemented(
-                        f"Missing dynamo support for expanding {value} into a list for slice assignment."
+                    unimplemented_v2(
+                        gb_type="Unsupported expanding for slice assignment",
+                        context=f"call_method {self} {name} {args}",
+                        explanation=f"Missing dynamo support for expanding {value} into a list for slice assignment.",
+                        hints=[*graph_break_hints.SUPPORTABLE],
                     )
                 self.items[key.as_python_constant()] = value.force_unpack_var_sequence(
                     tx
@@ -1041,7 +1057,13 @@ class SliceVariable(VariableTracker):
             return variables.GetAttrVariable(self, name)
         fields = ["start", "stop", "step"]
         if name not in fields:
-            unimplemented(f"slice.{name}")
+            unimplemented_v2(
+                gb_type="Unsupported attribute for slice",
+                context=f"var_getattr {self} {name}",
+                explanation=f"Expected attribute to be one of {','.join(fields)} "
+                f"but got {name}",
+                hints=[*graph_break_hints.USER_ERROR],
+            )
         return self.items[fields.index(name)]
 
 

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -138,7 +138,7 @@ class BaseListVariable(VariableTracker):
                     value = variables.ConstantVariable.create(value.constant.item())
                 else:
                     unimplemented_v2(
-                        gb_type="__getitem__ with non-constant tensor",
+                        gb_type="Indexing list with non-scalar tensor",
                         context=f"call_method {self} {name} {args} {kwargs}",
                         explanation=(
                             "Cannot perform __getitem__ with non-constant tensor."

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -349,7 +349,7 @@ class RangeVariable(BaseListVariable):
         fields = ["start", "stop", "step"]
         if name not in fields:
             unimplemented_v2(
-                gb_type="Unsupported attribute for range",
+                gb_type="Unsupported attribute for range() object",
                 context=f"var_getattr {self} {name}",
                 explanation=f"Expected attribute to be one of {','.join(fields)} "
                 f"but got {name}",

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -472,7 +472,7 @@ class ListVariable(CommonListMethodsVariable):
             if isinstance(key, SliceVariable):
                 if not value.has_force_unpack_var_sequence(tx):
                     unimplemented_v2(
-                        gb_type="Unsupported expanding for slice assignment",
+                        gb_type="Unsupported conversion for slice assignment",
                         context=f"call_method {self} {name} {args}",
                         explanation=f"Missing dynamo support for expanding {value} into a list for slice assignment.",
                         hints=[*graph_break_hints.SUPPORTABLE],

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1058,7 +1058,7 @@ class SliceVariable(VariableTracker):
         fields = ["start", "stop", "step"]
         if name not in fields:
             unimplemented_v2(
-                gb_type="Unsupported attribute for slice",
+                gb_type="Unsupported attribute for slice() object",
                 context=f"var_getattr {self} {name}",
                 explanation=f"Expected attribute to be one of {','.join(fields)} "
                 f"but got {name}",

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -474,7 +474,7 @@ class ListVariable(CommonListMethodsVariable):
                     unimplemented_v2(
                         gb_type="Unsupported conversion for slice assignment",
                         context=f"call_method {self} {name} {args}",
-                        explanation=f"Missing dynamo support for expanding {value} into a list for slice assignment.",
+                        explanation=f"Missing dynamo support for converting {value} into a list for slice assignment.",
                         hints=[*graph_break_hints.SUPPORTABLE],
                     )
                 self.items[key.as_python_constant()] = value.force_unpack_var_sequence(

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -141,7 +141,7 @@ class BaseListVariable(VariableTracker):
                         gb_type="Indexing list with non-scalar tensor",
                         context=f"call_method {self} {name} {args} {kwargs}",
                         explanation=(
-                            "Cannot perform __getitem__ with non-constant tensor."
+                            "Attempted to index list-like object with tensor with > 1 element."
                         ),
                         hints=[*graph_break_hints.USER_ERROR],
                     )


### PR DESCRIPTION
Part of #147913

Replace `unimplemented` with`unimplemented_v2` in `torch/_dynamo/variables/lists.py`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames