### PR TITLE
Remove as_tensor epilogue from float outputs

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1225,6 +1225,19 @@ utils_device.CURRENT_DEVICE == None""".split(
         )
 
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    def test_float_32_scalar_tensor_item(self):
+        def f(y):
+            y_scalar = y.item()
+            return y_scalar
+
+        f_opt = torch.compile(f)
+
+        self.assertEqual(
+            f(torch.tensor(3.0, device="cuda")), f_opt(torch.tensor(3.0, device="cuda"))
+        )
+
+
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_arange_length_with_float32_dtype(self):
         @torch.compile(fullgraph=True)
         def f(x):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1232,10 +1232,7 @@ utils_device.CURRENT_DEVICE == None""".split(
 
         f_opt = torch.compile(f)
 
-        self.assertEqual(
-            f(torch.tensor(3.0, device="cuda")), f_opt(torch.tensor(3.0, device="cuda"))
-        )
-
+        self.assertEqual(f(torch.tensor(3.0)), f_opt(torch.tensor(3.0)))
 
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_arange_length_with_float32_dtype(self):
@@ -1620,7 +1617,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         opt_fn = torch.compile(fn, backend=cnts)
         self.assertEqual(opt_fn(v1, v2), correct)
         self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(cnts.op_count, 4)
+        self.assertEqual(cnts.op_count, 3)
 
     @patch.object(torch._dynamo.config, "capture_scalar_outputs", False)
     def test_tensor_item_no_capture(self):

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -753,7 +753,7 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
         fn(x)
 
         self.assertExpectedInline(cnts.frame_count, """2""")
-        self.assertExpectedInline(cnts.op_count, """4""")
+        self.assertExpectedInline(cnts.op_count, """3""")
 
     def test_prune_torch_check(self):
         log_stream, ctx = logs_to_string("torch._dynamo.output_graph", "graph_code")

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -280,28 +280,6 @@ class PyCodegen:
                 )
             )
             output.extend(create_call_function(2, False))
-        elif (
-            isinstance(value, SymNodeVariable)
-            and value.python_type() == float
-            and not self.tx.export
-        ):
-            # This is a little unusual; force the output convention to be a
-            # Tensor here.  Don't do this for export because this is
-            # apparently load bearing for export tests (but I am a bit
-            # doubtful it actually works in the real world)
-            # NB: It works to add_graph_output on a computed expression
-            # as_tensor here, because we memoize as_tensor calls on
-            # SymNodeVariable!
-            graph_outputs_key = self.add_graph_output(
-                value.as_tensor(self.tx, torch.float64)
-            )
-
-            def gen_fn():
-                self.load_graph_output(graph_outputs[graph_outputs_key].index)
-                output.append(self.create_load_attr("item"))
-
-            self.add_push_null(gen_fn)
-            output.extend(create_call_function(0, False))
         elif isinstance(
             value,
             (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #151885
* #151766

Fixes #151470

This was originally added as a nicety - ensuring all graphs maintain
the invariant that ouputs are tensors. This, however, breaks simple
graphs such as

```
        def f(y):
            y_scalar = y.item()
            return y_scalar
```

since inductor only knows how to codegen tensors and sizevars (aka
ints), it ends up barfing when doing the codegen of this epilogue.
Notice in particular for the following example, it doesn't correctly
codegen the float kernel argument.

```
cpp_fused_scalar_tensor_0 = async_compile.cpp_pybinding(['double*'], '''
extern "C"  void kernel(double* out_ptr0)
{
    {
        {
            {
                auto tmp0 = zuf0;
                auto tmp1 = c10::convert<double>(tmp0);
                out_ptr0[static_cast<int64_t>(0L)] = tmp1;
            }
        }
    }
}
''')
```

Since this is just a nicety, let's get rid of it for now until we
officially support floats in inductor. By doing this we stay in
python when doing item() calls, resulting in same behavior for eager vs
compile

```
def call(args):
    arg0_1, = args
    args.clear()
    assert_size_stride(arg0_1, (), ())
    zuf0 = arg0_1.item()
    buf0 = None
    del arg0_1
    return (zuf0, )
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames