### PR TITLE
[Dynamo] Replace `unimplemented` with `unimplemented_v2` in `torch/_dynamo/variables/nn_module.py`

### DIFF
--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -796,7 +796,7 @@ class NNModuleVariable(VariableTracker):
                 key = args[0].as_python_constant()
             else:
                 unimplemented_v2(
-                    gb_type="Unsupported key type for __getitem__",
+                    gb_type="Unsupported key type for nn.Module.__getitem__",
                     context=f"call_method: {self} {name} {args} {kwargs}",
                     explanation="Dynamo does not support getitem on "
                     "`nn.Module` with non-constant key.",

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -253,7 +253,7 @@ class NNModuleVariable(VariableTracker):
                 "on `nn.Module` instances that have a custom "
                 "`__getattribute__` method defined.",
                 hints=[
-                    "Avoid defining `__getattribute__` in your module. ",
+                    "Avoid defining `__getattribute__` in your module.",
                     *graph_break_hints.SUPPORTABLE,
                 ],
             )
@@ -275,7 +275,7 @@ class NNModuleVariable(VariableTracker):
                 "on `nn.Module` instances that have a custom "
                 "`__getattribute__` method defined.",
                 hints=[
-                    "Avoid defining `__getattribute__` in your module. ",
+                    "Avoid defining `__getattribute__` in your module.",
                     *graph_break_hints.SUPPORTABLE,
                 ],
             )
@@ -1049,7 +1049,10 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
                     gb_type="UnspecializedNNModuleVariable missing method",
                     context=f"call_method: {self} {name} {args} {kwargs}",
                     explanation=f"Dynamo does not support tracing method {name} of nn.Module {self.value}",
-                    hints=[],
+                    hints=[
+                        "Dynamo does not really define unspecialized nn.Module very well.",
+                        *graph_break_hints.DIFFICULT,
+                    ],
                 )
 
             # "_parameters" in self.value.__dict__ checks that module is initialized

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -602,7 +602,7 @@ class NNModuleVariable(VariableTracker):
                     gb_type="non-const NNModule method",
                     context=f"call_method: {self} {name} {args} {kwargs}",
                     explanation="Dynamo does not support calling "
-                    f"method `{name}` with non-constant arguments.",
+                    f"method `{name}` of ``nn.Module`` {module} with non-constant arguments.",
                     hints=[],
                 )
 

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -599,7 +599,7 @@ class NNModuleVariable(VariableTracker):
                 x.is_python_constant() for x in itertools.chain(args, kwargs.values())
             ):
                 unimplemented_v2(
-                    gb_type="non-const NNModule method",
+                    gb_type="non-const argument in nn.Module method",
                     context=f"call_method: {self} {name} {args} {kwargs}",
                     explanation="Dynamo does not support calling "
                     f"method `{name}` of ``nn.Module`` {module} with non-constant arguments.",

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -287,11 +287,20 @@ class NNModuleVariable(VariableTracker):
         if not isinstance(getattr_fn, types.FunctionType):
             unimplemented_v2(
                 gb_type="torch.nn.Module with a non-function custom __getattr__",
-                context=f"var_getattr {self}",
-                explanation="Dynamo encountered a custom `__getattr__` method "
-                "on an `nn.Module` instance that is not a standard Python function. "
-                "Only function-based `__getattr__` methods can be traced.",
-                hints=[*graph_break_hints.USER_ERROR],
+                context=f"var_getattr {self} {name}",
+                explanation=(
+                    "Dynamo detected a nn.Module object with a custom "
+                    "`__getattr__` method, but this method is not a standard "
+                    "Python function (e.g., it might be implemented in C/C++). "
+                    "Dynamo cannot currently trace into such non-standard "
+                    "`__getattr__` methods."
+                ),
+                hints=[
+                    "Avoid using objects with non-standard __getattr__ methods "
+                    "within the compiled region. If possible, implement "
+                    "__getattr__ as a standard Python function.",
+                    *graph_break_hints.SUPPORTABLE,
+                ],
             )
 
         options = {"source": AttrSource(obj_source, "__getattr__")}

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -1039,7 +1039,7 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
                 unimplemented_v2(
                     gb_type="UnspecializedNNModuleVariable missing method",
                     context=f"call_method: {self} {name} {args} {kwargs}",
-                    explanation=f"Dynamo does not support tracing method {name}",
+                    explanation=f"Dynamo does not support tracing method {name} of nn.Module {self.value}",
                     hints=[],
                 )
 

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -311,7 +311,7 @@ class NNModuleVariable(VariableTracker):
 
         if not self.source:
             unimplemented_v2(
-                gb_type="GETATTR with no source",
+                gb_type="getattr with no source",
                 context=f"var_getattr {self} {name}",
                 explanation="Dynamo does not know how to access an attribute "
                 "on an `nn.Module` instance that lacks a source. This is "


### PR DESCRIPTION
Part of #147913

Replace `unimplemented` with`unimplemented_v2` in `torch/_dynamo/variables/nn_module.py`



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames