### PR TITLE
Add an additional check to trigger graph break for sparse tensor

### DIFF
--- a/test/dynamo/test_compile.py
+++ b/test/dynamo/test_compile.py
@@ -211,7 +211,19 @@ class InPlaceCompilationTests(TestCase):
         a = torch.randn(1, 1)
         out = torch.compile(fn)(a)
         self.assertEqual(out, a)
+    
+    def test_to_sparse_to_dense_with_graph_break(self):
+        def fn(x):
+            x = x.to_sparse()
+            x = x.to_dense()
+            return x
 
+        x = torch.tensor([[1.0]])
+        c_fn = torch.compile(fn)
+
+        output = fn(x)
+        c_output = c_fn(x)
+        self.assertEqual(output, c_output)
 
 # The private variants of the below functions are extensively tested
 # So as long as the signatures match we're good

--- a/test/dynamo/test_compile.py
+++ b/test/dynamo/test_compile.py
@@ -211,7 +211,7 @@ class InPlaceCompilationTests(TestCase):
         a = torch.randn(1, 1)
         out = torch.compile(fn)(a)
         self.assertEqual(out, a)
-    
+
     def test_to_sparse_to_dense_with_graph_break(self):
         def fn(x):
             x = x.to_sparse()

--- a/test/dynamo/test_compile.py
+++ b/test/dynamo/test_compile.py
@@ -225,6 +225,7 @@ class InPlaceCompilationTests(TestCase):
         c_output = c_fn(x)
         self.assertEqual(output, c_output)
 
+
 # The private variants of the below functions are extensively tested
 # So as long as the signatures match we're good
 class PublicTorchCompilerTests(TestCase):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -18,6 +18,7 @@ from typing import Callable, TYPE_CHECKING, Union
 import torch
 from torch import sym_float, sym_int
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+from torch._subclasses.meta_utils import is_sparse_any
 
 from .. import config, graph_break_hints, polyfills, variables
 from ..exc import (
@@ -1996,6 +1997,19 @@ class BuiltinVariable(VariableTracker):
                         "Please report an issue to PyTorch.",
                     ],
                 )
+            if isinstance(obj, TensorVariable):
+                fake_val = obj.proxy.node.meta["example_value"]
+                if (
+                    isinstance(fake_val, torch.Tensor)
+                    and is_sparse_any(fake_val)
+                    and (not tx.export or not config.capture_sparse_compute)
+                ):
+                    unimplemented_v2(
+                        gb_type="Attempted to wrap sparse Tensor",
+                        context="",
+                        explanation="torch.compile does not support sparse Tensors",
+                        hints=[*graph_break_hints.SUPPORTABLE],
+                    )
 
             try:
                 return obj.var_getattr(tx, name)

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -17,8 +17,8 @@ from typing import Callable, TYPE_CHECKING, Union
 
 import torch
 from torch import sym_float, sym_int
-from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 from torch._subclasses.meta_utils import is_sparse_any
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
 from .. import config, graph_break_hints, polyfills, variables
 from ..exc import (


### PR DESCRIPTION
Fixes #151522 

This PR fixes the issue that Dynamo fails to trigger a graph break for sparse tensors in certain code paths. I added an additional check to handle this case, and it resolves the original problem.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames