### PR TITLE
Fix dependencies version error when building docs locally 

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,6 +9,6 @@ tensorboard==2.10.0
 # required to build torch.distributed.elastic.rendezvous.etcd* docs
 python-etcd==0.4.5
 sphinx-copybutton==0.5.0
-myst-parser==4.0.1
-sphinx-design==0.6.1
+myst-parser==0.18.1
+sphinx-design==0.4.0
 sphinxcontrib-mermaid==1.0.0


### PR DESCRIPTION
Fixes #151786

This PR downgrades version of 2 dependencies, which allow `pip install -r docs/requirements.txt`
