### PR TITLE
Add check for 2-dim mask to COO mask computation

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -1014,14 +1014,18 @@ static Tensor _batch_tile_tensor(
 static Tensor _mask_to_indices(const Tensor& mask) {
   // This function returns a vector of the indices at which given
   // boolean mask is True. Here at::nonzero performs test (time/mem).
-  TORCH_CHECK(
-      mask.dim() == 1, "Currently _mask_to_indices only supports 1-d masks.");
+  TORCH_CHECK(mask.dim() == 1, "_mask_to_indices only supports 1-d masks.");
   TORCH_CHECK(mask.dtype() == at::kBool, "Expected mask to be of dtype bool.");
   return at::native::flatten(at::nonzero(mask));
 }
 
 static std::pair<Tensor, Tensor> _not_zero_mask_to_col_row_indices(
     Tensor not_zero_mask) {
+  TORCH_CHECK(
+      not_zero_mask.dim() == 2,
+      "_not_zero_mask_to_col_row_indices only supports 2-d masks.");
+  TORCH_CHECK(
+      not_zero_mask.dtype() == at::kBool, "Expected mask to be of dtype bool.");
   auto nz = not_zero_mask.nonzero();
   return {nz.select(1, 1), nz.select(1, 0)};
 }

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -1014,17 +1014,19 @@ static Tensor _batch_tile_tensor(
 static Tensor _mask_to_indices(const Tensor& mask) {
   // This function returns a vector of the indices at which given
   // boolean mask is True. Here at::nonzero performs test (time/mem).
-  TORCH_CHECK(mask.dim() == 1, "_mask_to_indices only supports 1-d masks.");
-  TORCH_CHECK(mask.dtype() == at::kBool, "Expected mask to be of dtype bool.");
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      mask.dim() == 1, "_mask_to_indices only supports 1-d masks.");
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      mask.dtype() == at::kBool, "Expected mask to be of dtype bool.");
   return at::native::flatten(at::nonzero(mask));
 }
 
 static std::pair<Tensor, Tensor> _not_zero_mask_to_col_row_indices(
     Tensor not_zero_mask) {
-  TORCH_CHECK(
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
       not_zero_mask.dim() == 2,
       "_not_zero_mask_to_col_row_indices only supports 2-d masks.");
-  TORCH_CHECK(
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
       not_zero_mask.dtype() == at::kBool, "Expected mask to be of dtype bool.");
   auto nz = not_zero_mask.nonzero();
   return {nz.select(1, 1), nz.select(1, 0)};


### PR DESCRIPTION
Follow up on discussion on https://github.com/pytorch/pytorch/pull/151794 Related to all fixes for https://github.com/pytorch/pytorch/issues/151351

