### PR TITLE
[torchbind] fix error message when attr is a real tensor.

### DIFF
--- a/torch/_library/fake_class_registry.py
+++ b/torch/_library/fake_class_registry.py
@@ -155,7 +155,7 @@ def maybe_to_fake_obj(
 
     for name in x._method_names():  # type: ignore[attr-defined]
         attr = getattr(fake_x, name, None)
-        if attr:
+        if attr is not None:
             if not callable(attr):
                 raise RuntimeError(f"Expect {name} to be a callable but got {attr}.")
 


### PR DESCRIPTION
Summary: Previously, when attr is defined, "if attr" will try to evaluate the data of attr, which is not intendended and we get a ugly error stack if the attr is not evaluable (like a fake tensor) before the callable(attr) check.

Test Plan: Existing tests.

Reviewed By: yushangdi, henryoier

Differential Revision: D73460905


