### PR TITLE
[profiler] use inspect.getattr_static to avoid importing inductor

### DIFF
--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import gzip
+import inspect
 import json
 import os
 import shutil
@@ -221,7 +222,7 @@ class _KinetoProfile:
                     "distributedInfo", json.dumps(dist_info, cls=_NumpyEncoder)
                 )
 
-            if hasattr(torch, "_inductor"):
+            if inspect.getattr_static(torch, "_inductor", None) is not None:
                 import torch._inductor.config as inductor_config
 
                 cuda_version = None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #151946

`hasattr(torch, "_inductor")` causes inductor to be imported, which is part of the issue in #151829. We can use inspect.getattr_static to do this instead, to avoid actually importing inductor. `inspect.getattr_static` will actually return False until inductor gets imported, and it seems safe to assume that cudagraphs (the main reason we're checking for inductor) isn't going to be enabled unless we're actually using inductor (in which case, inductor would be imported)