### PR TITLE
[inductor][profiler] move `standalone_compile` import to TYPE_CHECKING

### DIFF
--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -9,13 +9,13 @@ from typing import Any, IO, Optional, TYPE_CHECKING, Union
 import torch._inductor.config
 import torch.fx
 
-from .standalone_compile import CompiledArtifact  # noqa: TC001
-
 
 if TYPE_CHECKING:
     from torch._inductor.utils import InputType
     from torch.export import ExportedProgram
     from torch.types import FileLike
+
+    from .standalone_compile import CompiledArtifact  # noqa: TC001
 
 __all__ = [
     "compile",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #151949

Fixes #151829

Allows .standalone_compile imports to be lazy, which prevents unecessary execution when importing torch._inductor.

This matters for profiler, because the profiler imports torch._inductor just to check the config (to see if cuda graphs is used)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov