### PR TITLE
Inductor Tiling Rewrite

### DIFF
--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2063,10 +2063,8 @@ class SIMDScheduling(BaseScheduling):
             # Some kernels have no reduction ranges, and a reduction numel of 1
             if not ranges:
                 if target_numel:
-                    breakpoint()
                     return ([target_numel], [])
                 else:
-                    breakpoint()
                     return ([], [])
 
             key = (repr(vars_to_use), use_split_var, is_pointwise)
@@ -2132,8 +2130,6 @@ class SIMDScheduling(BaseScheduling):
                     process_node_vars(is_pointwise=False),
                 )
             )
-
-        # breakpoint()
 
         # TODO, add tests, reduction splits if config.triton.tile_reductions
         overlapping_iter_vars = (

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2023,7 +2023,7 @@ class SIMDScheduling(BaseScheduling):
             lambda: f"{pw_ranges}, {pointwise_numel}, {node_schedule}"
         )
         torch._check(
-            sympy_product(reduction_numel) == red_ranges,
+            sympy_product(red_ranges) == reduction_numel,
             lambda: f"{red_ranges}, {reduction_numel}, {node_schedule}"
         )
 

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2018,8 +2018,14 @@ class SIMDScheduling(BaseScheduling):
         pw_ranges = [ranges[v] for v in all_iter_vars]
         red_ranges = [ranges[v] for v in all_red_vars]
 
-        assert sympy_product(pw_ranges) == pointwise_numel
-        assert sympy_product(red_ranges) == reduction_numel
+        torch._check(
+            sympy_product(pw_ranges) == pointwise_numel,
+            lambda: f"{pw_ranges}, {pointwise_numel}, {node_schedule}"
+        )
+        torch._check(
+            sympy_product(reduction_numel) == red_ranges,
+            lambda: f"{red_ranges}, {reduction_numel}, {node_schedule}"
+        )
 
         # score of a pointwise or reduction split
         scored_sub_split: dict[Any, tuple[list[int], list[int]]] = {}

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -24,6 +24,8 @@ from ..virtualized import V
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
+    from torch._inductor.tiling_utils import CoalesceVarAnalysis
+
 
 class NodeScheduleMarker:
     @staticmethod
@@ -80,12 +82,14 @@ class SIMDKernelFeatures:
         node_schedule: list[NodeScheduleEntry],
         numel: sympy.Expr,
         reduction_numel: sympy.Expr = sympy.S.One,
+        coalesce_analysis: Optional[CoalesceVarAnalysis] = None,
     ):
         self.node_schedule = node_schedule
         # numel excludes reduction_numel
         self.numel: sympy.Expr = V.graph.sizevars.simplify(numel)
         self.reduction_numel: sympy.Expr = V.graph.sizevars.simplify(reduction_numel)
         self._stats_cache: dict[tuple[sympy.Expr, ...], MemoryStats] = {}
+        self.coalesce_analysis = coalesce_analysis
 
     @cache_on_self
     def is_reduction(self) -> bool:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1600,6 +1600,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         min_elem_per_thread=0,
         optimize_mask=True,
         fixed_config: Optional[FixedTritonConfig] = None,
+        tiling_scores: Optional[dict[str, sympy.Expr]] = None,
         **kwargs,
     ) -> None:
         self.optimize_mask: bool = optimize_mask
@@ -1616,6 +1617,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.pointer_advancements: dict[SymT, dict[str, list[sympy.Expr]]] = (
             collections.defaultdict(dict)
         )
+        self.tiling_scores = tiling_scores
         self._load_counts: collections.Counter[str] = collections.Counter()
 
         # A set of autotuning hints to pass as part of triton_meta
@@ -3641,6 +3643,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             "num_reduction": self.num_reduction,
             **self.inductor_meta_common(),
         }
+        if self.tiling_scores:
+            inductor_meta["tiling_scores"] = self.tiling_scores
+
         if self.cooperative_reduction:
             inductor_meta["persistent_reduction"] = self.persistent_reduction
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1073,7 +1073,7 @@ class triton:
     #   - max_tiles=2 is the default
     #   - max_tiles=3 is experimental and may have bugs
     # higher values are unsupported
-    max_tiles = 2
+    max_tiles = 3
 
     # Prefer higher dimensional tilings. This simplifies indexing expressions, making
     # it easier to identify block pointers.
@@ -1589,6 +1589,9 @@ class test_configs:
     autotune_choice_desc_regex: Optional[str] = None
 
     graphsafe_rng_func_ignores_fallback_random = False
+
+    # TODO - temporary config before enabled by default
+    global_tiling_analysis: bool = True
 
 
 if TYPE_CHECKING:

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -312,6 +312,14 @@ class LoopBody:
             for entry in self.memory_usage[MemoryUsageType.LOAD]
         ]
 
+    def get_all_read_expr(self, buffer_name):
+        # reversed to match old behavior
+        out = []
+        for entry in reversed(self.memory_usage[MemoryUsageType.LOAD]):
+            if entry.buffer_name == buffer_name:
+                out.append(self.indexing_exprs[entry.index_name])
+        return out
+
     def get_write_exprs(self):
         return [
             self.indexing_exprs[entry.index_name]
@@ -320,6 +328,16 @@ class LoopBody:
                 self.memory_usage[MemoryUsageType.STORE_REDUCTION],
             )
         ]
+
+    def get_all_write_expr(self, buffer_name):
+        out = []
+        for entry in itertools.chain(
+            self.memory_usage[MemoryUsageType.STORE],
+            self.memory_usage[MemoryUsageType.STORE_REDUCTION],
+        ):
+            if entry.buffer_name == buffer_name:
+                out.append(self.indexing_exprs[entry.index_name])
+        return out
 
     def debug_str(self):
         lines = [f"var_ranges = {dict(self.var_ranges)}"]

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2037,7 +2037,9 @@ def _get_config(numels: dict[str, int]) -> dict[str, int]:
     return {prefix.upper() + "BLOCK": numel for prefix, numel in numels.items()}
 
 
-def triton_config_tiled_reduction(size_hints, x, y, r, num_stages=1):
+def triton_config_tiled_reduction(
+    size_hints, x, y, r, num_stages=1, register_intensive=False
+):
     """
     Construct a tile reduction triton config with some adjustment
     heuristics based on size_hints. Size_hints is a tuple of numels in
@@ -2063,12 +2065,15 @@ def triton_config_tiled_reduction(size_hints, x, y, r, num_stages=1):
     for prefix in sorted(rnumels):
         while rnumels[prefix] < size_hints[prefix] and total_numel() < target:
             rnumels[prefix] *= 2
-    while y < size_hints[1] and total_numel() < target:
+    while y < size_hints["y"] and total_numel() < target:
         y *= 2
 
     cfg = _get_config({"x": x, "y": y, **rnumels})
     num_warps = _num_warps(total_numel() // 256, min_num_warps=1)
-    check_config(cfg, xnumel=size_hints[0], ynumel=size_hints[1])
+    num_warps = _num_warps(
+        num_warps, max_num_warps=16, register_intensive=register_intensive
+    )
+    check_config(cfg, xnumel=size_hints["x"], ynumel=size_hints["y"])
     check_max_block(cfg)
     return Config(cfg, num_warps=num_warps, num_stages=num_stages)
 
@@ -2191,22 +2196,47 @@ def _reduction_configs(
         MAX_R0_BLOCK = 1024
         register_intensive = True
 
-    contiguous_config = triton_config_reduction(
-        size_hints,
+    def make_config(x, r, num_warps=None, num_stages=1, register_intensive=False):
+        # For 3D case with tiling scores, create an adapted version
+        if "y" in size_hints:
+            assert "tiling_scores" in inductor_meta
+            return adapt_config_for_tiling(
+                size_hints,
+                inductor_meta["tiling_scores"],
+                x,
+                r,
+                num_warps=num_warps,
+                num_stages=num_stages,
+                register_intensive=register_intensive,
+            )
+        else:
+            # For other cases, use the original function
+            return triton_config_reduction(
+                size_hints,
+                x,
+                r,
+                num_warps=num_warps,
+                num_stages=num_stages,
+                register_intensive=register_intensive,
+            )
+
+    contiguous_config = make_config(
         1,
-        rnumel if 256 <= rnumel < MAX_R0_BLOCK else MAX_R0_BLOCK,
+        min(rnumel, MAX_R0_BLOCK),
         register_intensive=register_intensive,
     )
-    outer_config = triton_config_reduction(
-        size_hints, 64, 8, register_intensive=register_intensive
-    )
-    tiny_config = triton_config_reduction(
-        size_hints,
+    outer_config = make_config(64, 8, register_intensive=register_intensive)
+    tiny_config = make_config(
         2 * (256 // rnumel) if rnumel <= 256 else 1,
         min(rnumel, MAX_R0_BLOCK),
         register_intensive=register_intensive,
     )
-    if inductor_meta.get("max_autotune") or inductor_meta.get("max_autotune_pointwise"):
+    # For 3d tiling, default to more autotuning initially
+    if "y" in size_hints:
+        pass
+    elif inductor_meta.get("max_autotune") or inductor_meta.get(
+        "max_autotune_pointwise"
+    ):
         pass  # skip all these cases
     elif reduction_hint == ReductionHint.INNER:
         return [contiguous_config]
@@ -2215,18 +2245,94 @@ def _reduction_configs(
     elif reduction_hint == ReductionHint.OUTER_TINY:
         return [tiny_config]
     if disable_pointwise_autotuning(inductor_meta):
-        return [triton_config_reduction(size_hints, 32, 128)]
+        return [make_config(32, 128)]
     return [
         contiguous_config,
         outer_config,
         tiny_config,
-        triton_config_reduction(size_hints, 64, 64),
-        triton_config_reduction(size_hints, 8, 512),
+        make_config(64, 64),
+        make_config(8, 512),
         # halve the XBLOCK/Rn_BLOCK compared to outer_config
         # TODO: this may only be beneficial when each iteration of the reduction
         # is quite heavy. E.g. https://gist.github.com/shunting314/189a8ef69f90db9d614a823385147a72
-        triton_config_reduction(size_hints, 64, 4, num_warps=8),
+        make_config(64, 4, num_warps=8),
     ]
+
+
+def match_target_block_product(
+    size_hints, tiling_scores, target_block_product, min_block_size=4
+):
+    """
+    Distribute block sizes across dimensions according to tiling scores,
+    aiming to match a target product of block sizes.
+    """
+    total_score = sum(tiling_scores.values())
+    if total_score == 0:
+        # just assume even score with no minimum block size
+        min_block_size = 1
+        tiling_scores = {k: target_block_product for k in tiling_scores.keys()}
+
+    # First, give each coalescing dimension at least min_block_size
+    block_sizes = {}
+    relative_scores = {}
+    curr_block_product = 1
+
+    for dim, score in tiling_scores.items():
+        if score == 0:
+            block_sizes[dim] = 1
+            continue
+
+        block_sizes[dim] = min_block_size
+        curr_block_product *= min_block_size
+        relative_scores[dim] = score / total_score
+
+    # Scale up dimensions by their relative scores until we reach the target
+    while curr_block_product < target_block_product and len(relative_scores):
+        dim, score = max(relative_scores.items(), key=lambda item: item[1])
+
+        # Check if we've hit the max for this dimension
+        if (
+            block_sizes[dim] >= TRITON_MAX_BLOCK[dim.capitalize()]
+            or block_sizes[dim] >= size_hints[dim]
+        ):
+            del relative_scores[dim]
+            continue
+
+        block_sizes[dim] *= 2
+        relative_scores[dim] /= 2
+        curr_block_product *= 2
+
+    return block_sizes
+
+
+def adapt_config_for_tiling(
+    size_hints,
+    tiling_scores,
+    original_x,
+    original_r,
+    num_warps=None,
+    num_stages=1,
+    register_intensive=False,
+    persistent_reduction=False,
+) -> Config:
+    """
+    Create an adapted configuration based on tiling scores,
+    redistributing the same total block size (x * r) according to tiling scores.
+    """
+    assert all(s in tiling_scores for s in size_hints)
+    target_block_product = original_x * original_r
+    block_sizes = match_target_block_product(
+        size_hints, tiling_scores, target_block_product
+    )
+
+    return triton_config_tiled_reduction(
+        size_hints,
+        block_sizes["x"],
+        block_sizes["y"],
+        block_sizes["r0_"],
+        num_stages=num_stages,
+        register_intensive=register_intensive,
+    )
 
 
 def reduction(
@@ -2309,14 +2415,37 @@ def _persistent_reduction_configs(
     xnumel = size_hints["x"]
     rnumel = get_total_reduction_numel(size_hints)
 
-    configs = [
-        triton_config_reduction(size_hints, xblock, rnumel, register_intensive=True)
-        for xblock in (1, 8, 32, 128)
-        if xblock == 1 or (rnumel * xblock <= 4096 and xblock <= xnumel)
-    ]
+    MAX_PERSISTENT_BLOCK_NUMEL = 4096
 
+    if "y" not in size_hints:
+        configs = [
+            triton_config_reduction(size_hints, xblock, rnumel, register_intensive=True)
+            for xblock in (1, 8, 32, 128)
+            if xblock == 1
+            or (rnumel * xblock <= MAX_PERSISTENT_BLOCK_NUMEL and xblock <= xnumel)
+        ]
+    else:
+        configs = []
+        assert "tiling_scores" in inductor_meta
+        x_y_scores = {dim: inductor_meta["tiling_scores"][dim] for dim in ("x", "y")}
+        for target_block_size in (1, 8, 32, 64, 128):
+            if target_block_size * rnumel > MAX_PERSISTENT_BLOCK_NUMEL:
+                continue
+
+            block_sizes = match_target_block_product(
+                size_hints, x_y_scores, target_block_size
+            )
+            configs.append(
+                triton_config_tiled_reduction(
+                    size_hints, block_sizes["x"], block_sizes["y"], rnumel
+                )
+            )
+
+    # defer to more autotuning, initially
+    if "y" in size_hints:
+        pass
     # TODO(jansel): we should be able to improve these heuristics
-    if reduction_hint == ReductionHint.INNER and rnumel >= 256:
+    elif reduction_hint == ReductionHint.INNER and rnumel >= 256:
         configs = configs[:1]
     elif reduction_hint == ReductionHint.OUTER:
         configs = configs[-1:]

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2260,7 +2260,7 @@ def _reduction_configs(
 
 
 def match_target_block_product(
-    size_hints, tiling_scores, target_block_product, min_block_size=4
+    size_hints, tiling_scores, target_block_product, min_block_size=1
 ):
     """
     Distribute block sizes across dimensions according to tiling scores,

--- a/torch/_inductor/tiling_utils.py
+++ b/torch/_inductor/tiling_utils.py
@@ -1,0 +1,281 @@
+import dataclasses
+import itertools
+from collections import Counter, defaultdict
+from typing import Optional, TYPE_CHECKING, Union
+
+import sympy
+
+from torch._inductor.utils import sympy_product, sympy_subs
+from torch.utils._ordered_set import OrderedSet
+from torch.utils._sympy.functions import FloorDiv, ModularIndexing
+from torch.utils._sympy.solve import try_solve
+from torch.utils._sympy.symbol import symbol_is_type, SymT
+
+
+if TYPE_CHECKING:
+    from torch._inductor.scheduler import FusedSchedulerNode, SchedulerNode
+
+
+def solve_for_zero(expr: sympy.Expr) -> Optional[tuple[sympy.Rel, sympy.Expr]]:
+    """
+    Given an expr with a single free symbol, solve for a constant relation that would make
+    this expression 0.
+    """
+    if expr.is_constant() and not expr == 0:
+        return None
+    elif isinstance(expr, FloorDiv):
+        return None
+
+    assert len(expr.free_symbols) <= 1
+    free_symbol = next(iter(expr.free_symbols))
+    if isinstance(expr, ModularIndexing):
+        out = try_solve(sympy.Eq(expr.args[0], expr.args[2]), free_symbol)
+    else:
+        out = try_solve(sympy.Eq(expr, 0), free_symbol)
+    if not out or not out[1].is_constant():
+        return None
+    return out
+
+
+def solve_for_tiling(expr: sympy.Expr) -> Optional[int]:
+    """
+    Giving an expr with a single free symbol, try to find a tiling that would
+    make the expression coalesced with respect to that symbol.
+    """
+    assert len(expr.free_symbols) == 1
+    free_symbol = next(iter(expr.free_symbols))
+
+    # Sympy solving is very limited with ModularIndexing and FloorDiv,
+    # but good otherwise.
+    if not expr.has(ModularIndexing) and not expr.has(FloorDiv):
+        expr_plus_one = sympy_subs(expr, {free_symbol: free_symbol + 1})
+        out = try_solve(sympy.Eq(expr_plus_one - expr, 1), free_symbol)
+        if not out or not out[1].is_constant():
+            return None
+        return out[1]
+
+    required_values = []
+    eq_1_expressions = []
+
+    # very piecemeal solution if ModularIndexing or FloorDiv involved.
+    # Expand as needed.
+    for arg in sympy.Add.make_args(expr):
+        # Try to make mul terms 0
+        if isinstance(arg, sympy.Mul):
+            seen = False
+            # TODO - only need one of these to be solvable to zero
+            for mul_arg in arg.args:
+                out = solve_for_zero(mul_arg)
+                if out is None or not out[1].is_constant():
+                    continue
+
+                seen = True
+                required_values.append(out[1])
+
+            if not seen:
+                return None
+        else:
+            eq_1_expressions.append(arg)
+
+    if not eq_1_expressions:
+        return None
+
+    eq_1_expr = sum(eq_1_expressions)
+
+    def indexing_div_rep(x, y, z=None):
+        return x / y
+
+    is_non_differentiable = eq_1_expr.has(ModularIndexing) or eq_1_expr.has(
+        ModularIndexing
+    )
+    # For the purposes of tiling/coalesced access, we can treat ModularIndexing and FloorDiv equivalently
+    eq_1_expr = eq_1_expr.replace(ModularIndexing, indexing_div_rep).replace(
+        FloorDiv, indexing_div_rep
+    )
+    out = try_solve(sympy.Eq(eq_1_expr, 1), free_symbol)
+    if out is None or not out[1].is_constant():
+        return None
+
+    # since we approximated FloorDiv/ModularIndexing, double check here
+    if (
+        is_non_differentiable
+        and not (sympy_subs(eq_1_expr, {free_symbol: out[1]})) == 1
+    ):
+        return None
+
+    required_values.append(out[1])
+
+    if len(OrderedSet(required_values)) == 1:
+        return required_values[0]
+
+    return None
+
+
+def find_coalesced_var(
+    index: sympy.Expr, var_ranges: dict[sympy.Expr, int]
+) -> Optional[sympy.Expr]:
+    """
+    Try to find the symbol which coalesces this index
+    """
+    # TODO - not sure what to do with indirect variable
+    top_level_terms = sympy.Add.make_args(index)
+    for v in var_ranges:
+        if v in top_level_terms:
+            return v
+
+    # Approximate analysis by evaluating at 1 and 0
+    variables = dict.fromkeys(index.free_symbols, 0)
+    zero_index = sympy_subs(index, variables)
+    for v in var_ranges.keys():
+        variables[v] = 1
+        new_val = sympy_subs(index, variables)
+        if new_val - zero_index == 1:
+            return v
+        variables[v] = 0
+
+    return None
+
+
+def _extract_fused_node_meta(
+    node: Union["FusedSchedulerNode", "SchedulerNode"],
+) -> tuple[
+    OrderedSet[sympy.Symbol],
+    OrderedSet[sympy.Symbol],
+    OrderedSet[sympy.Expr],
+    OrderedSet[sympy.Expr],
+    dict[sympy.Symbol, int],
+]:
+    """Extracts index variables, reduce variables, read/write expressions, and variable ranges from a fused node."""
+    reads: OrderedSet[sympy.Expr] = OrderedSet()
+    writes: OrderedSet[sympy.Expr] = OrderedSet()
+    all_index_vars: OrderedSet[sympy.Symbol] = OrderedSet()
+    all_reduce_vars: OrderedSet[sympy.Symbol] = OrderedSet()
+    var_ranges: dict[sympy.Symbol, int] = {}
+
+    outputs = node.get_buffer_names()
+    inputs = OrderedSet(dep.name for dep in node.read_writes.reads)
+
+    for n in node.get_nodes():
+        body = n._body
+        all_index_vars |= body.iter_vars
+        all_reduce_vars |= body.reduce_vars
+        var_ranges.update(body.var_ranges)
+
+        for inp in inputs:
+            reads |= body.get_all_read_expr(inp)
+        for out in outputs:
+            writes |= body.get_all_write_expr(out)
+
+    return all_index_vars, all_reduce_vars, reads, writes, var_ranges
+
+
+def get_score(addr: sympy.Expr, var_ranges: dict[sympy.Symbol, int]) -> int:
+    """
+    Score addr according to its approximate size
+    """
+
+    # TODO - deduplicate with candidate_tilings
+    var_sizes = []
+    for v in addr.free_symbols:
+        v_size = var_ranges.get(v, None)
+        if not symbol_is_type(v, SymT.INDIRECT) and v_size is not None:
+            var_sizes.append(v_size)
+    from .virtualized import V
+
+    return V.graph.sizevars.size_hint(sympy_product(var_sizes))
+
+
+@dataclasses.dataclass(frozen=True)
+class VarTiling:
+    """
+    Tiling of a var by `tiling_factor` that yields additional coalesced mem accesses by `benefit_score`
+    """
+
+    var: sympy.Symbol
+    tiling_factor: int
+    score: int
+
+
+@dataclasses.dataclass(frozen=True)
+class CoalesceVarAnalysis:
+    coalesced_by_var: dict[sympy.Expr, int]
+
+    # Expression, split, score
+    suggested_split: Optional[VarTiling] = None
+
+
+def analyze_memory_coalescing(
+    fused_node: Union["FusedSchedulerNode", "SchedulerNode"],
+) -> Optional[CoalesceVarAnalysis]:
+    """
+    Find variables that coalesce the reads and writes and score the total size.
+
+    If uncoalesced memory expressions are found, look for additionally tiling of variables
+    which will coalesce memory accesses.
+
+    For instance - for the following expression:
+
+    (32*p0) // 2048
+
+    Tiling p0 by 64 will make this expression coalesced.
+    """
+
+    _, _, reads, writes, var_ranges = _extract_fused_node_meta(fused_node)
+
+    coalesced_by_var = Counter()
+    uncoalesced_addrs: dict[sympy.Expr, int] = {}
+
+    for memory_expr in itertools.chain(reads, writes):
+        size = get_score(memory_expr, var_ranges)
+        maybe_coalesced_var = find_coalesced_var(memory_expr, var_ranges)
+        if maybe_coalesced_var:
+            coalesced_by_var[maybe_coalesced_var] += size
+        else:
+            uncoalesced_addrs[memory_expr] = size
+
+    if not uncoalesced_addrs:
+        return CoalesceVarAnalysis(coalesced_by_var=coalesced_by_var)
+
+    # map from var -> tiling -> total_score
+    potential_tiling_scores: dict[sympy.Expr, dict[int, int]] = defaultdict(Counter)
+
+    for uncoalesced_expr, addr_score in uncoalesced_addrs.items():
+        expr_subs = {v: 0 for v in uncoalesced_expr.free_symbols}
+        for v in uncoalesced_expr.free_symbols:
+            del expr_subs[v]
+            single_var_expr = sympy_subs(uncoalesced_expr, expr_subs)
+            expr_subs[v] = 0
+            tiling_factor = solve_for_tiling(single_var_expr)
+            if tiling_factor is None or not tiling_factor.is_constant():
+                continue
+
+            MIN_TILING_BLOCK = 4
+            if any(
+                (b < MIN_TILING_BLOCK)
+                for b in (tiling_factor, var_ranges[v] // tiling_factor)
+            ):
+                continue
+
+            potential_tiling_scores[v][tiling_factor] += addr_score
+
+    best_tiling: Optional[tuple[sympy.Expr, int]] = None
+    best_tiling_score = 0
+
+    for var, tiling_counter in potential_tiling_scores.items():
+        for tile, tile_score in tiling_counter.items():
+            score = tile_score - coalesced_by_var[var]
+            if score > best_tiling_score:
+                best_tiling = (var, tile)
+                best_tiling_score = score
+
+    if best_tiling is None:
+        return CoalesceVarAnalysis(coalesced_by_var=coalesced_by_var)
+
+    # TODO - for strictly pointwise fusions,
+    # we can consider just swizzling the var if the var we are going to tile
+    # does not coalesce a significant portion of global reads
+    # TODO - could also prefer index var splits to reduction, better tested
+    return CoalesceVarAnalysis(
+        coalesced_by_var=coalesced_by_var,
+        suggested_split=VarTiling(best_tiling[0], best_tiling[1], score),
+    )

--- a/torch/_inductor/tiling_utils.py
+++ b/torch/_inductor/tiling_utils.py
@@ -1,11 +1,16 @@
 import dataclasses
 import itertools
 from collections import Counter, defaultdict
-from typing import Optional, TYPE_CHECKING, Union
+from operator import is_
+from re import A
+from typing import Optional, TYPE_CHECKING, Union, Sequence
 
 import sympy
 
 import torch
+import heapq
+
+
 from torch._inductor import config
 from torch._inductor.dependencies import index_vars_no_squeeze
 from torch._inductor.utils import sympy_product, sympy_subs
@@ -15,6 +20,7 @@ from torch.utils._sympy.solve import try_solve
 from torch.utils._sympy.symbol import symbol_is_type, SymT
 
 from .virtualized import V
+Split = tuple[sympy.Expr]
 
 
 if TYPE_CHECKING:
@@ -57,7 +63,14 @@ def solve_for_tiling(expr: sympy.Expr) -> Optional[sympy.Expr]:
     # but good otherwise.
     if not expr.has(ModularIndexing) and not expr.has(FloorDiv):
         expr_plus_one = sympy_subs(expr, {free_symbol: free_symbol + 1})
+
+        diff = expr_plus_one - expr
+        if diff.is_constant() and diff >= 0:
+            # breakpoint()
+            return diff
+
         out = try_solve(sympy.Eq(expr_plus_one - expr, 1), free_symbol)
+
         if not out or not out[1].is_constant():
             return None
         return out[1]
@@ -170,9 +183,469 @@ class FusedNormalizedReadsWrites:
     var_ranges: dict[sympy.Symbol, int]
 
 
+
+def get_pw_red_splits(
+    n: "SchedulerNode", pointwise_numel: sympy.Expr, red_numel: sympy.Expr
+) -> tuple[
+    tuple[list[sympy.Symbol], list[int]], tuple[list[sympy.Symbol], list[int]]
+]:
+    if n.is_reduction() or sympy_product(n._body.sizes[0]) == pointwise_numel:
+        return (
+            (n._body.iter_vars, n._body.sizes[0]),
+            (n._body.reduce_vars, n._body.sizes[1]),
+        )  # type: ignore[return-value]
+
+    assert sympy_product(n._body.sizes[0]) == pointwise_numel * red_numel  # type: ignore[operator]
+    i = len(n._body.sizes[0]) - 1
+    prod = 1
+    while i >= 0:
+        prod *= n._body.sizes[0][i]
+        if prod == red_numel:
+            break
+
+    if i >= 0:
+        pw_splits = n._body.sizes[0][0:i]
+        iter_vars = n._body.iter_vars[0:i]
+
+        red_splits = n._body.sizes[0][i:]
+        red_vars = n._body.iter_vars[i:]
+        return (iter_vars, pw_splits), (red_vars, red_splits)  # type: ignore[return-value]
+
+    # TODO - handle
+    raise RuntimeError(
+        f"Unhandled node: size: {n._body.sizes}, pw: {pointwise_numel}, red: {red_numel}"
+    )
+
+
+class NodeSplitGetter():
+
+    def __init__(self, node: Union["FusedSchedulerNode", "SchedulerNode"],):
+        from torch._inductor.codegen.simd import SIMDKernel, CantSplit
+        self.node = node
+        self.pointwise_numel: sympy.Expr = node.group[1][0]
+        self.red_numel: sympy.Expr = node.group[1][1]
+
+        self.pw_split_options: dict[int, OrderedSet[Split]] = defaultdict(OrderedSet)
+
+        self.reduction_split: Split = ()
+
+        if self.pointwise_numel == 1:
+            self.pw_split_options[0].add(())
+
+        self.all_node_sizes: OrderedSet[tuple[Split, Split]] = OrderedSet()
+        
+        fused_group = node.group[1]
+        for n in reversed(node.get_nodes()):
+            if not isinstance(n, torch._inductor.scheduler.SchedulerNode):
+                continue
+
+            (_, n_pw_splits), (_, n_red_splits) = get_pw_red_splits(n, self.pointwise_numel, self.red_numel)
+                        
+            # fill in reduction size
+            n_pw_splits, n_red_splits = torch._inductor.codegen.simd.SIMDKernel.prepare_split_iteration_lengths(fused_group, (n_pw_splits, n_red_splits), self.red_numel)
+            
+            self.pw_split_options[len(n_pw_splits)].add(tuple(n_pw_splits))
+
+            # initially, we are just going to do a single reduction split since
+            # reduction tiling is off by default. even if we miss a reduction split, 
+            # we can recover it in the split var analysis.
+            # TODO: an earlier version fo this code tried to iteratively try the maximum number 
+            # of split vars, by iterating over both pointwise and reduction. but not worth
+            # the complexity yet.  
+
+            if n_red_splits != ():
+                self.reduction_split = (sympy_product(n_red_splits),)
+
+            n_size = (tuple(n_pw_splits), tuple(n_red_splits))
+            self.all_node_sizes.add(n_size)
+
+        self.seen_pw_splits: OrderedSet[Split] = OrderedSet()
+        
+    def get_node_splits(self):
+        max_pw_split = max(self.pw_split_options.keys())
+        for pw_split_len in range(max_pw_split, 0, -1):
+            for pw_split in self.pw_split_options[pw_split_len]:
+                if out := self.try_split(pw_split, self.reduction_split):
+                    return out
+
+            # combine dims for next round
+            for pw_split in self.pw_split_options[pw_split_len]:
+                for i in range(len(pw_split) - 1):
+                    new_split = tuple(
+                        pw_split[0:i] + tuple([sympy_product(pw_split[i:i+2])]) + pw_split[i+2:]
+                    )
+                    self.pw_split_options[len(new_split)].add(new_split)
+
+        # if for whatever reason we couldnt split above, return default split
+        return ((self.pointwise_numel,), (self.red_numel,))
+
+
+    def try_split(self, pw: Split, red: Split) -> Optional[tuple[Split, Split]]:
+        from torch._inductor.codegen.simd import SIMDKernel, CantSplit
+
+        if pw in self.seen_pw_splits:
+            return None
+        self.seen_pw_splits.add(pw)
+
+        for n_pw, n_red in self.all_node_sizes:
+            try:
+                groups = pw + red
+                lengths = (n_pw, n_red)
+                splits, getters = SIMDKernel._split_iteration_ranges(groups, lengths)
+            except CantSplit:
+                return None
+
+            assert len(getters) == 2
+            pw_group_splits = splits[:len(pw)]
+            # breakpoint()
+            # if len(pw) == 3:
+            #     breakpoint()
+            # pw_split_sums = tuple(sympy_product(s) for s in pw_group_splits)
+            # if len(flattened_pw_splits) == 4:
+            #     breakpoint()
+            # if we had to divide a variable in two to do this split, try to split on it
+            flattened_pw_splits = tuple(itertools.chain.from_iterable(pw_group_splits))
+            breakpoint()
+            if flattened_pw_splits != pw:
+                # if len(flattened_pw_splits) != 4:
+                # breakpoint()
+                out = self.try_split(flattened_pw_splits, red)
+                if out:
+                    breakpoint
+                    return out
+        
+        # if len(pw) == 3:
+        #     return None
+        print("Returning", pw, red)
+        return pw, red
+
+def apply_var_mapping_old(old_vars, new_vars, new_ranges, return_getters_groups):
+    var_map = {}    
+    num_vars = sum(len(s) for s in new_ranges)
+    new_var_map = {}
+
+    split_vars = sympy.symbols(f"v_0:{num_vars}")
+    var_count = len(split_vars) - 1
+
+    # ([p0, p1, p2], [[128, 6], [64], [196]])
+    
+    curr_count = 0
+    new_var_map = {}
+    for group, old_var in zip(new_ranges, old_vars):
+        
+        divis = None
+        assert len(group) <= 2
+        if len(group) == 2:
+            new_var1 = split_vars[curr_count]
+            new_var2 = split_vars[curr_count + 1]
+            curr_count += 2
+            # TODO _ think about
+            new_var_map[new_var1] = (old_var * group[1])
+            new_var_map[new_var2] = (old_var)
+        else:
+            new_var = split_vars[curr_count]
+            curr_count += 1
+            new_var_map[new_var] = old_var 
+
+    out_exprs = [sympy_subs(g(split_vars), new_var_map) for g in return_getters_groups]
+
+    var_map = {}
+
+    var_map = defaultdict(list)
+
+    for expr, new_var in zip(out_exprs, new_vars):
+        repl_map = dict.fromkeys(expr.free_symbols, 0)
+        for v in expr.free_symbols:
+            repl_map[v] = new_var
+            var_map[v].append(sympy_subs(expr, repl_map))
+            repl_map[v] = 0
+
+    var_map = {k: sum(v) for k, v in var_map.items()}
+    return var_map
+
+
+def apply_var_mapping(iter_vars, red_vars, norm_pw_vars, norm_red_vars, new_ranges, return_getters_groups):
+    var_map = {}    
+    
+    all_old_vars = list(iter_vars) + list(red_vars)
+    all_new_vars = list(norm_pw_vars) + list(norm_red_vars)
+    
+    # Create symbolic variables for all splits
+    num_vars = sum(len(s) for s in new_ranges)
+    split_vars = sympy.symbols(f"v_0:{num_vars}")
+    breakpoint()
+
+    # out = [g(split_vars) for g in return_getters_groups]
+
+    # ([p0, p1, p2], [[128, 6], [64], [196]])
+    curr_count = 0
+    new_var_map = {}
+
+    # new_ranges[:len(n_pw_splits)], return_getters_groups[0])
+    g1 = (
+        new_ranges[0:len(norm_pw_vars)],
+        iter_vars,
+        return_getters_groups[0]
+    )
+    g2 = (
+        new_ranges[len(norm_pw_vars):],
+        red_vars,
+        return_getters_groups[1],
+    )
+    var_map = defaultdict(list)
+
+    for i, (ranges, old_vars, return_getter_group) in enumerate((g1, g2)):
+
+        init_range = curr_count
+        breakpoint()
+        for group, old_var in zip(ranges, old_vars):
+            assert len(group) <= 2
+            if len(group) == 2:
+                new_var1 = split_vars[curr_count]
+                new_var2 = split_vars[curr_count + 1]
+                curr_count += 2
+                # TODO _ think about
+                new_var_map[new_var1] = (old_var * group[1])
+                new_var_map[new_var2] = (old_var)
+            else:
+                new_var = split_vars[curr_count]
+                curr_count += 1
+                new_var_map[new_var] = old_var 
+
+        out_exprs = [sympy_subs(g(split_vars), new_var_map) for g in return_getter_group]
+
+        new_vars = norm_pw_vars if i == 0 else norm_red_vars
+        # if i == 0:
+        #     breakpoint()
+        for expr, new_var in zip(out_exprs, new_vars):
+            repl_map = dict.fromkeys(expr.free_symbols, 0)
+            for v in expr.free_symbols:
+                repl_map[v] = new_var
+                var_map[v].append(sympy_subs(expr, repl_map))
+                repl_map[v] = 0
+    
+    breakpoint()
+    var_map = {k: sum(v) for k, v in var_map.items()}
+    return var_map
+
+def apply_var_mapping(iter_vars, red_vars, norm_pw_vars, norm_red_vars, new_ranges, return_getters_groups):
+    """Maps original variables to expressions using normalized variables."""
+    # Create flattened iteration variables
+    num_vars = sum(len(s) for s in new_ranges)
+    flat_vars = sympy.symbols(f"v_0:{num_vars}")
+    
+    # Apply getters to get expressions with flat variables
+    flat_exprs = []
+    for getter_group in return_getters_groups:
+        flat_exprs.append([g(flat_vars) for g in getter_group])
+    
+    # Map flat variables to normalized variables where possible
+    flat_to_norm = {}
+    norm_idx = 0
+    for norm_var in list(norm_pw_vars) + list(norm_red_vars):
+        if norm_idx < len(flat_vars):
+            flat_to_norm[flat_vars[norm_idx]] = norm_var
+            norm_idx += 1
+    
+    # Create mapping from original variables to expressions with normalized variables
+    var_map = {}
+    
+    # Map pointwise variables
+    for i, (orig_var, flat_expr) in enumerate(zip(iter_vars, flat_exprs[0])):
+        # Replace flat variables with normalized ones where possible
+        norm_expr = flat_expr
+        for flat_var, norm_var in flat_to_norm.items():
+            norm_expr = norm_expr.subs(flat_var, norm_var)
+        var_map[orig_var] = norm_expr
+    
+    # Map reduction variables
+    for i, (orig_var, flat_expr) in enumerate(zip(red_vars, flat_exprs[1])):
+        norm_expr = flat_expr
+        for flat_var, norm_var in flat_to_norm.items():
+            norm_expr = norm_expr.subs(flat_var, norm_var)
+        var_map[orig_var] = norm_expr
+    
+    return var_map
+
+def zip_equal(it1, it2):
+    if len(it1) != len(it2):
+        raise ValueError("Lengths of iterables are different")
+    return zip(it1, it2)
+
+
+def apply_var_mapping(iter_vars, red_vars, norm_pw_vars, norm_red_vars, new_ranges, return_getters_groups, var_mappings):
+    """Maps original variables to expressions using normalized variables."""
+    # Create flattened iteration variables
+    num_vars = sum(len(s) for s in new_ranges)
+    flat_vars = sympy.symbols(f"v_0:{num_vars}")
+    
+    # First map flat variables to normalized variables
+    flat_to_norm = {}
+    norm_vars = list(norm_pw_vars) + list(norm_red_vars)
+
+    flat_var_mappings = []
+    for var_mapping in var_mappings:
+        for g in var_mapping:
+            flat_var_mappings.append(g((iter_vars, red_vars)))
+
+    new_var_mappings = {}
+    count = 0
+    tot = []
+
+    old_vars_to_new_vars = defaultdict(list)
+
+    assert len(new_ranges) == len(norm_pw_vars + norm_red_vars)
+    # breakpoint()
+    all_flat_vars = []
+    all_var_mapping = {}
+
+    apply_groups = []
+    for group in return_getters_groups:
+        apply_groups.append([g(flat_vars) for g in group])
+
+    iter_vars_to_flat_vars = {}
+    
+    for group, var_group in zip_equal(apply_groups, ((iter_vars, red_vars))):
+        for g, v in zip_equal(group, var_group):
+            iter_vars_to_flat_vars[v] = g
+
+    count = 0
+    flat_vars_to_new_vars = {}
+    for new_range, new_var in zip_equal(new_ranges, norm_pw_vars + norm_red_vars):
+
+        range_vars = []
+        for i in range(len(new_range)):
+            range_vars.append(flat_vars[count])
+            count += 1
+
+        prod = 1
+        for i in range(len(new_range) -1, -1, -1):
+            flat_vars_to_new_vars[range_vars[i]] = new_var * prod
+            prod = new_range[i] * prod
+
+    final_dict = {k: sympy_subs(v, flat_vars_to_new_vars) for k, v in iter_vars_to_flat_vars.items()}
+    # breakpoint()
+    
+    return final_dict
+    pass
+
+        
+
+
+    # Assign normalized variables to flat variables based on position
+    flat_idx = 0
+    for range_idx, range_group in enumerate(new_ranges):
+        for _ in range(len(range_group)):
+            if flat_idx < len(norm_vars):
+                flat_to_norm[flat_vars[flat_idx]] = norm_vars[flat_idx]
+            flat_idx += 1
+    
+    # Initialize var_map with defaultdict to collect contributions
+    var_map = defaultdict(list)
+    
+    # Process pointwise getters
+    for i, getter in enumerate(return_getters_groups[0]):
+        if i < len(iter_vars):
+            orig_var = iter_vars[i]
+            flat_expr = getter(flat_vars)
+            
+            # Substitute normalized variables into the expression
+            norm_expr = sympy_subs(flat_expr, flat_to_norm)
+            
+            # Add this contribution to the variable
+            var_map[orig_var].append(norm_expr)
+    
+    # Process reduction gettersx
+    for i, getter in enumerate(return_getters_groups[1]):
+        if i < len(red_vars):
+            orig_var = red_vars[i]
+            flat_expr = getter(flat_vars)
+            norm_expr = sympy_subs(flat_expr, flat_to_norm)
+            var_map[orig_var].append(norm_expr)
+    
+    breakpoint()
+    # Sum up all contributions for each original variable
+    return {k: sum(v) for k, v in var_map.items()}
+
+
+
+def apply_unified_var_mapping(iter_vars, red_vars, norm_pw_vars, norm_red_vars, new_ranges, return_getters_groups):
+    """
+    Apply variable mapping for both pointwise and reduction variables using a unified approach.
+    
+    Args:
+        iter_vars: Iteration variables for pointwise operations
+        red_vars: Reduction variables
+        norm_pw_vars: Normalized pointwise variables
+        norm_red_vars: Normalized reduction variables
+        new_ranges: Ranges for all variables (pointwise + reduction)
+        return_getters_groups: List of lists of getter functions [pw_getters, red_getters]
+        
+    Returns:
+        Combined variable mapping
+    """
+    # Create a flat list of all variables
+    all_old_vars = list(iter_vars) + list(red_vars)
+    all_new_vars = list(norm_pw_vars) + list(norm_red_vars)
+    
+    # Create symbolic variables for all splits
+    num_vars = sum(len(s) for s in new_ranges)
+    split_vars = sympy.symbols(f"v_0:{num_vars}")
+    
+    # Create mapping from split variables to original variable expressions
+    var_idx = 0
+    new_var_map = {}
+    breakpoint()
+    
+    for group, old_var in zip(new_ranges, all_old_vars):
+        if len(group) == 2:
+            # Handle case where a variable is split into two dimensions
+            new_var1 = split_vars[var_idx]
+            new_var2 = split_vars[var_idx + 1]
+            var_idx += 2
+            
+            new_var_map[new_var1] = (old_var * group[1])
+            new_var_map[new_var2] = old_var
+        else:
+            # Handle case where variable is not split
+            new_var = split_vars[var_idx]
+            var_idx += 1
+            new_var_map[new_var] = old_var
+    
+    # Create a unified list of getters with their corresponding output variables
+    unified_getters = []
+    try:
+        for group_idx, (getters, output_vars) in enumerate(zip(return_getters_groups, [norm_pw_vars, norm_red_vars])):
+            for getter_idx, getter in enumerate(getters):
+                unified_getters.append((getter, output_vars[getter_idx], group_idx))
+    except Exception as e:
+        breakpoint()
+        raise
+        
+    # Process all getters in a single loop
+    var_map = defaultdict(int)
+    
+    for getter, output_var, group_idx in unified_getters:
+        # Apply substitution to get expression in terms of original variables
+        expr = sympy_subs(getter(split_vars), new_var_map)
+        
+        # Map split variables to their contribution in the final expression
+        for v in expr.free_symbols:
+            # Create temporary replacement map to isolate this variable's contribution
+            repl_map = {sym: 0 for sym in expr.free_symbols}
+            repl_map[v] = output_var
+            
+            # Add this contribution to the variable mapping
+            term = sympy_subs(expr, repl_map)
+            var_map[v] += term
+    
+    return var_map
+
+
 def _extract_fused_node_meta(
     node: Union["FusedSchedulerNode", "SchedulerNode"],
 ) -> FusedNormalizedReadsWrites:
+
     """Extracts index variables, reduce variables, read/write expressions, and variable ranges from a fused node."""
     reads: OrderedSet[sympy.Expr] = OrderedSet()
     writes: OrderedSet[sympy.Expr] = OrderedSet()
@@ -180,99 +653,18 @@ def _extract_fused_node_meta(
     outputs = node.get_buffer_names()
     inputs = OrderedSet(dep.name for dep in node.read_writes.reads)
 
-    pointwise_numel = node.group[1][0]
-    red_numel = node.group[1][1]
-
-    # If there are fused nodes with one node having:
-    # sizes = ([2048], [])
-    # ranges: {p0: 2048}
-    # and another node with
-    # sizes: ([32, 64], [])
-    # ranges: {p0: 32, p1: 64}
-    # The p0 in the first node actually corresponds to
-    # 64 * p0 + p1
-    # So we find the node with the most number of splits, and
-    # normalize the other nodes to use the same iter vars.
-
-    def get_pw_red_splits(
-        n: "SchedulerNode",
-    ) -> tuple[
-        tuple[list[sympy.Symbol], list[int]], tuple[list[sympy.Symbol], list[int]]
-    ]:
-        if n.is_reduction() or sympy_product(n._body.sizes[0]) == pointwise_numel:
-            return (
-                (n._body.iter_vars, n._body.sizes[0]),
-                (n._body.reduce_vars, n._body.sizes[1]),
-            )  # type: ignore[return-value]
-
-        torch._check(
-            get_hint(sympy_product(n._body.sizes[0])) == get_hint(pointwise_numel * red_numel),
-            lambda: f"Unexpected sizes: {n._body.sizes[0], pointwise_numel, red_numel}"
-        )
-
-        i = len(n._body.sizes[0]) - 1
-        prod = 1
-        while i >= 0:
-            prod *= n._body.sizes[0][i]
-            if prod == red_numel:
-                break
-
-        if i >= 0:
-            pw_splits = n._body.sizes[0][0:i]
-            iter_vars = n._body.iter_vars[0:i]
-
-            red_splits = n._body.sizes[0][i:]
-            red_vars = n._body.iter_vars[i:]
-            return (iter_vars, pw_splits), (red_vars, red_splits)  # type: ignore[return-value]
-
-        # TODO - handle
-        raise RuntimeError(
-            f"Unhandled node: size: {n._body.sizes}, pw: {pointwise_numel}, red: {red_numel}"
-        )
-
-    pw_splits: list[int] = []
-    red_splits: list[int] = []
-
-    for n in node.get_nodes():
-        if not isinstance(n, torch._inductor.scheduler.SchedulerNode):
-            continue
-
-        (_, n_pw_splits), (_, n_red_splits) = get_pw_red_splits(n)
-        if len(n_pw_splits) > len(pw_splits):
-            pw_splits = n_pw_splits
-        if len(n_red_splits) > len(red_splits):
-            red_splits = n_red_splits
+    pw_splits, red_splits = NodeSplitGetter(node).get_node_splits()
 
     # lets use different prefix (`n`) to distinguish
     (norm_pw_vars, norm_red_vars), ranges = index_vars_no_squeeze(
         pw_splits, red_splits, prefix="n"
     )
-
-    def norm_to_split(
-        norm_ranges: dict[sympy.Symbol, int],
-        norm_vars: list[sympy.Symbol],
-        curr_sizes: list[int],
-        curr_vars: list[sympy.Symbol],
-    ) -> dict[sympy.Symbol, sympy.Expr]:
-        norm_index = len(norm_vars) - 1
-        var_map: dict[sympy.Symbol, sympy.Expr] = {}
-        for var, size in zip(reversed(curr_vars), reversed(curr_sizes)):
-            var_replacement = []
-            prod = 1
-            while size != 1:
-                norm_var = norm_vars[norm_index]
-                # NYI : non compatible splits - could try again with different splits
-                assert size % norm_ranges[norm_var] == 0
-                size = size // norm_ranges[norm_var]
-                norm_index -= 1
-                var_replacement.append(norm_var * prod)
-                prod *= norm_ranges[norm_var]
-
-            var_map[var] = sum(reversed(var_replacement))
-
-        return var_map
-
-    for n in node.get_nodes():
+    node = node
+    pointwise_numel: sympy.Expr = node.group[1][0]
+    red_numel: sympy.Expr = node.group[1][1]
+    # breakpoint()
+    
+    for n in (list(node.get_nodes())):
         if not isinstance(n, torch._inductor.scheduler.SchedulerNode):
             continue
 
@@ -284,15 +676,39 @@ def _extract_fused_node_meta(
         for out in outputs:
             n_writes |= body.get_all_write_expr(out)
 
-        (iter_vars, pw_splits), (red_vars, red_splits) = get_pw_red_splits(n)
-        var_map = norm_to_split(ranges, norm_pw_vars, pw_splits, iter_vars)
-        var_map.update(norm_to_split(ranges, norm_red_vars, red_splits, red_vars))
+        (iter_vars, n_pw_splits), (red_vars, n_red_splits) = get_pw_red_splits(n, pointwise_numel, red_numel)
+       
+        groups = pw_splits + red_splits
+        lengths = (n_pw_splits, (n_red_splits))
+        lengths = torch._inductor.codegen.simd.SIMDKernel.prepare_split_iteration_lengths(groups, lengths, red_numel)
+        # breakpoint()
+        new_ranges, return_getters_groups, var_mappings = torch._inductor.codegen.simd.SIMDKernel._split_iteration_ranges(groups, lengths, True)
+        
+        len_vars = [iter_vars, red_vars]
 
-        n_reads = [sympy_subs(read, var_map) for read in n_reads]
-        n_writes = [sympy_subs(read, var_map) for read in n_writes]
+        # out = var_mappings
+        # Apply unified mapping
+        # breakpoint()
+        print(iter_vars, red_vars, norm_pw_vars, norm_red_vars, new_ranges, return_getters_groups)
+        # var_map2 = apply_var_mapping_old(iter_vars, norm_pw_vars, new_ranges[:len(n_pw_splits)], return_getters_groups[0])
+        # breakpoint()
+        var_map = apply_var_mapping(
+            iter_vars, red_vars, 
+            norm_pw_vars, norm_red_vars, 
+            new_ranges, return_getters_groups, var_mappings
+        )
+        breakpoint()
+        
+        # for k, v in var_map2.items():
+        #     assert var_map[k] == v
+        # breakpoint()
+        # var_map.update(apply_var_mapping(red_vars, norm_red_vars, new_ranges[len(n_pw_splits):], return_getters_groups[1]))
 
-        reads |= n_reads
-        writes |= n_writes
+        n_reads_new = [sympy_subs(read, var_map) for read in n_reads]
+        n_writes_new = [sympy_subs(read, var_map) for read in n_writes]
+
+        reads |= n_reads_new
+        writes |= n_writes_new
 
     return FusedNormalizedReadsWrites(
         norm_pw_vars,  # type: ignore[arg-type]
@@ -382,6 +798,7 @@ def analyze_memory_coalescing(
         else:
             uncoalesced_addrs[memory_expr] = size
 
+    # breakpoint()
     if not uncoalesced_addrs:
         return CoalesceVarAnalysis(
             coalesced_by_var=coalesced_by_var, norm_read_writes=norm_read_writes
@@ -399,7 +816,10 @@ def analyze_memory_coalescing(
             del expr_subs[v]
             single_var_expr = sympy_subs(uncoalesced_expr, expr_subs)
             expr_subs[v] = 0
+            # if repr(single_var_expr) == "64*n1":
+            #     breakpoint()
             tiling_factor = solve_for_tiling(single_var_expr)
+            # breakpoint()
             if (
                 tiling_factor is None
                 or not tiling_factor.is_constant()

--- a/torch/_inductor/tiling_utils.py
+++ b/torch/_inductor/tiling_utils.py
@@ -47,6 +47,9 @@ def solve_for_tiling(expr: sympy.Expr) -> Optional[sympy.Expr]:
     Giving an expr with a single free symbol, try to find a tiling that would
     make the expression coalesced with respect to that symbol.
     """
+    if len(expr.free_symbols) == 0:
+        return None
+
     assert len(expr.free_symbols) == 1
     free_symbol = next(iter(expr.free_symbols))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #151958

Fix for https://github.com/pytorch/pytorch/issues/149982. 

Summary:

This PR does two main things:
1. Rewrites the tiling heuristics. The previous tiling heuristic would have each dependency generate a tiling. Then, we sum up the score for each generated tiling, preferring any 2d tiling over the default. The new tiling heuristics scores each tiling by its global coalesced memory. This gives both a potentially better tiling (especially for more complicated, 3d patterns) as well as information we can use in generating block sizes.  

2. Analyses memory dependencies for accesses that would be coalesced with additional tiling. The motivating kernel is in https://github.com/pytorch/pytorch/issues/149982 which is a 32 element reduction. A smaller version of it is [here](https://gist.github.com/eellison/0fa9396f5479eb4dba09756e3bf6ff2a). We need to run this kernel once in the forward per linear layer on a contiguous tensor, and once in the backward on a transposed tensor. 

While the contiguous kernel has coalesced accesses, and is performant on master, the transposed version accesses uncoalesced memory on main and is ~2.8x slower. See, this [full log](https://gist.github.com/eellison/fa644bfd9d0ae11dadb62e17a5d48a83) from the above repro. Now, with this PR, it is only ~1.15x slower. See the [updated log](https://gist.github.com/eellison/0b2b653309494d28cf7b48929a022075). 

We analyse memory addresses that are not coalesced by any iteration variable. For this following dependency:

`(((32*n0 + n1)//2048)) + 4096*(ModularIndexing(32*n0 + n1, 1, 2048))` we infer that tiling `n0` by 64 makes the first term coalesced. 

I'm sure there are still some CI failures to debug..

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @vkuzo 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov 