### PR TITLE
Make `aten.embedding` do not wrap negative index

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1248,12 +1248,14 @@ def embedding_dense_backward(
         grad_weights_scale = counts[indices]
         grad_output = grad_output / grad_weights_scale.unsqueeze(-1)
 
-    mask = _unsqueeze_to_dim(indices == padding_idx, grad_output.ndim)
-    grad = grad_output.masked_fill(mask, 0)
+    if padding_idx >= 0:
+        mask = _unsqueeze_to_dim(indices == padding_idx, grad_output.ndim)
+        grad_output = grad_output.masked_fill(mask, 0)
+
     grad_weight = grad_output.new_zeros(
         (num_weights,) + grad_output.shape[indices.ndim :]
     )
-    return aten._unsafe_index_put(grad_weight, [indices], grad, accumulate=True).to(
+    return aten._unsafe_index_put(grad_weight, [indices], grad_output, accumulate=True).to(
         result_dtype
     )
 

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1255,9 +1255,9 @@ def embedding_dense_backward(
     grad_weight = grad_output.new_zeros(
         (num_weights,) + grad_output.shape[indices.ndim :]
     )
-    return aten._unsafe_index_put(grad_weight, [indices], grad_output, accumulate=True).to(
-        result_dtype
-    )
+    return aten._unsafe_index_put(
+        grad_weight, [indices], grad_output, accumulate=True
+    ).to(result_dtype)
 
 
 def prod(x: list[int]):

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -119,6 +119,7 @@ decomps_to_exclude = [
     aten.sum,  # inductor lowers this directly
     aten.unbind,  # inductor lowers this directly
     aten.baddbmm,  # upcasts to fp32, perf issue
+    aten.embedding_dense_backward, # wrap_neg=False
 ]
 
 remove_decompositions(decompositions, decomps_to_exclude)
@@ -199,6 +200,42 @@ def index_add(
         return NotImplemented
     else:
         return _index_add(x, dim, index, tensor, inplace=False, alpha=alpha)
+
+
+@register_decomposition(aten.embedding_dense_backward)
+def embedding_dense_backward(
+    grad_output: torch.Tensor,
+    indices: torch.Tensor,
+    num_weights: int,
+    padding_idx: int,
+    scale_grad_by_freq: bool,
+):
+    computation_dtype, result_dtype = utils.elementwise_dtypes(
+        grad_output, type_promotion_kind=utils.ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT
+    )
+    grad_output = grad_output.to(computation_dtype)
+    indices = indices.to(torch.long)
+    if scale_grad_by_freq:
+        counts = indices.new_zeros((num_weights,))
+        ones = torch.ones_like(indices)
+        counts = aten._unsafe_index_put(counts, [indices], ones, accumulate=True)
+        grad_weights_scale = counts[indices]
+        grad_output = grad_output / grad_weights_scale.unsqueeze(-1)
+
+    if padding_idx >= 0:
+        def _unsqueeze_to_dim(x: torch.Tensor, dim: int) -> torch.Tensor:
+            for _ in range(dim - x.dim()):
+                x = x.unsqueeze(-1)
+            return x
+        mask = _unsqueeze_to_dim(indices == padding_idx, grad_output.ndim)
+        grad_output = grad_output.masked_fill(mask, 0)
+
+    grad_weight = grad_output.new_zeros(
+        (num_weights,) + grad_output.shape[indices.ndim :]
+    )
+    return inductor_prims._unsafe_nowrap_index_put(grad_weight, [indices], grad_output, accumulate=True).to(
+        result_dtype
+    )
 
 
 # Not really sure how to put this into the main library.  PrimTorch wants

--- a/torch/_inductor/inductor_prims.py
+++ b/torch/_inductor/inductor_prims.py
@@ -108,6 +108,13 @@ _unsafe_index_put_ = make_prim(
     ),
     doc="Unsafe index_put_ (doesn't issue device asserts)",
 )
+_unsafe_nowrap_index_put = make_prim(
+    "_unsafe_nowrap_index_put(Tensor self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor",
+    lambda self, indices, values, accumulate=False: torch.ops.aten.index_put(
+        self, indices, values, accumulate
+    ),
+    doc="Unsafe & wrap_neg=False index_put",
+)
 fma = make_prim(
     "fma(Tensor a, Tensor b, Tensor c) -> Tensor",
     lambda a, b, c: (a * b) + c,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3582,6 +3582,13 @@ def _unsafe_index_put(x, indices, values, accumulate=False):
     )
 
 
+@register_lowering(inductor_prims._unsafe_nowrap_index_put)
+def _unsafe_nowrap_index_put(x, indices, values, accumulate=False):
+    return index_put_impl_(
+        clone(x), indices, values, accumulate, check=False, may_realize=False, wrap_neg=False
+    )
+
+
 def index_put_as_masked_fill(self, indices, value, accumulate):
     if value.get_device() != self.get_device():
         value = to_device(value, self.get_device())
@@ -3620,7 +3627,7 @@ def _unsafe_index_put_(self, indices, values, accumulate=False):
     )
 
 
-def index_put_impl_(self, indices, values, accumulate, check, may_realize=False):
+def index_put_impl_(self, indices, values, accumulate, check, may_realize=False, wrap_neg=True):
     if may_realize:
 
         def try_get_name(x):
@@ -3720,6 +3727,7 @@ def index_put_impl_(self, indices, values, accumulate, check, may_realize=False)
         indexed_size,
         None,
         check=check,
+        wrap_neg=wrap_neg,
     )
 
     values = expand(values, expected_vals_size)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3383,7 +3383,7 @@ def embedding(weight, indices, padding_idx=-1, scale_grad_by_freq=False, sparse=
     def fn(idx):
         assert len(idx) == len(new_size), f"{idx} != {new_size}"
         var_index = indices_loader(idx[:indices_ndim])
-        weight_idx = [ops.indirect_indexing(var_index, weight_size[0])] + [
+        weight_idx = [ops.indirect_indexing(var_index, weight_size[0], wrap_neg=False)] + [
             *idx[indices_ndim:]
         ]
         return weight_loader(weight_idx)


### PR DESCRIPTION
Fixes #151918


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben