### PR TITLE
Add torchcheck for replication_pad3d_backward

### DIFF
--- a/aten/src/ATen/native/ReplicationPadding.cpp
+++ b/aten/src/ATen/native/ReplicationPadding.cpp
@@ -229,17 +229,20 @@ void replication_pad3d_backward_out_cpu_template(
   int pbottom = paddingSize[3];
   int pfront = paddingSize[4];
   int pback = paddingSize[5];
+  int dimc = 0;
   int dimw = 3;
   int dimh = 2;
   int dimd = 1;
 
   if (input.dim() == 5) {
+    dimc++;
     dimw++;
     dimh++;
     dimd++;
   }
 
   /* sizes */
+  int64_t ichannel = input.size(dimc);
   int64_t idepth = input.size(dimd);
   int64_t iheight = input.size(dimh);
   int64_t iwidth = input.size(dimw);
@@ -249,6 +252,9 @@ void replication_pad3d_backward_out_cpu_template(
 
   at::native::padding::check_valid_input<3>(input, paddingSize);
 
+  TORCH_CHECK(ichannel == gradOutput.size(dimc),
+      "gradOutput width unexpected. Expected: ", ichannel, ", Got: ",
+      gradOutput.size(dimc));
   TORCH_CHECK(owidth == gradOutput.size(dimw),
       "gradOutput width unexpected. Expected: ", owidth, ", Got: ",
       gradOutput.size(dimw));


### PR DESCRIPTION
Fixes #142833

Add check on channel dimension, logic same to the CUDA implementation https://github.com/pytorch/pytorch/blob/78bbb468c66fe56e389bf73bf626302b8e2b4cf4/aten/src/ATen/native/cuda/ReplicationPadding.cu#L347

cc @mikaylagawarecki 