### PR TITLE
Implement util function compute_global_tensor_shape for 1D device mesh

### DIFF
--- a/test/distributed/tensor/test_utils.py
+++ b/test/distributed/tensor/test_utils.py
@@ -150,29 +150,42 @@ class UtilTest(DTensorTestBase):
             if isinstance(placements[0], Shard):
                 uneven_dim = list(range(self.world_size))
                 local_shape = (
-                    torch.Size([5, uneven_dim[device_mesh.get_rank()]])
+                    torch.Size([5, uneven_dim[self.rank]])
                     if placements[0].dim == 1
-                    else torch.Size([uneven_dim[device_mesh.get_rank()], 5])
+                    else torch.Size([uneven_dim[self.rank], 5])
                 )
                 expected_global_shape = (
                     torch.Size([5, sum(uneven_dim)])
                     if placements[0].dim == 1
                     else torch.Size([sum(uneven_dim), 5])
                 )
-                global_shape = compute_global_tensor_shape(
-                    local_shape,
-                    device_mesh,
-                    placements,
-                )
-                self.assertEqual(
-                    global_shape,
-                    expected_global_shape,
-                )
             else:
-                global_shape = compute_global_tensor_shape(
-                    torch.Size([5, 5]), device_mesh, placements
-                )
-                self.assertEqual(global_shape, torch.Size([5, 5]))
+                expected_global_shape = torch.Size([5, 5])
+                local_shape = torch.Size([5, 5])
+            global_shape = compute_global_tensor_shape(
+                local_shape, device_mesh, placements
+            )
+            self.assertEqual(global_shape, expected_global_shape)
+
+    @with_comms
+    def test_compute_global_tensor_shape_1D_invalid_shape(self):
+        one_d_placement = [Shard(1)]
+        device_mesh = init_device_mesh(self.device_type, (self.world_size,))
+        uneven_dim = list(range(self.world_size))
+        local_shape = (
+            torch.Size([5, uneven_dim[self.rank]])
+            if self.rank % 2 == 0
+            else torch.Size([6, uneven_dim[self.rank]])
+        )
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Non-sharded dimentions should have identical size across ranks.",
+        ):
+            _ = compute_global_tensor_shape(
+                local_shape,
+                device_mesh,
+                one_d_placement,
+            )
 
     @with_comms
     def test_compute_global_tensor_shape_failure_2D(self):
@@ -180,12 +193,22 @@ class UtilTest(DTensorTestBase):
         device_mesh_2D = init_device_mesh(self.device_type, (2, 2))
         with self.assertRaisesRegex(
             NotImplementedError,
-            "compute_global_tensor_shape only supports 1D mesh for now.",
+            "compute_global_tensor_shape only supports 1 placement for now.",
         ):
             _ = compute_global_tensor_shape(
                 torch.Size([2, 2]),
                 device_mesh_2D,
                 placement_2D,
+            )
+        placement_1D = [Shard(0)]
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Expected one placement per mesh dim",
+        ):
+            _ = compute_global_tensor_shape(
+                torch.Size([2, 2]),
+                device_mesh_2D,
+                placement_1D,
             )
 
     @with_comms

--- a/test/distributed/tensor/test_utils.py
+++ b/test/distributed/tensor/test_utils.py
@@ -1,8 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 
 import itertools
-import random
-from threading import local
 
 import torch
 from torch.distributed.device_mesh import init_device_mesh
@@ -150,7 +148,7 @@ class UtilTest(DTensorTestBase):
         device_mesh = init_device_mesh(self.device_type, (self.world_size,))
         for placements in one_d_placements:
             if isinstance(placements[0], Shard):
-                uneven_dim = [i for i in range(self.world_size)]
+                uneven_dim = list(range(self.world_size))
                 global_shape = compute_global_tensor_shape(
                     torch.Size([5, uneven_dim[device_mesh.get_rank()]]),
                     device_mesh,

--- a/torch/distributed/tensor/_utils.py
+++ b/torch/distributed/tensor/_utils.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from collections.abc import Sequence
-from threading import local
 from typing import cast, Optional
 
 import torch
@@ -136,9 +135,9 @@ def _compute_local_shape_and_global_offset(
             if isinstance(placement, Shard):
                 shard_dim = placement.dim
                 local_offset = [0] * len(global_shape)
-                assert shard_dim < len(
-                    local_shape
-                ), f"Sharding dim {shard_dim} greater than tensor ndim {len(local_shape)}"
+                assert shard_dim < len(local_shape), (
+                    f"Sharding dim {shard_dim} greater than tensor ndim {len(local_shape)}"
+                )
                 shard_size, shard_offset = placement._local_shard_size_and_offset(
                     local_shape[shard_dim],
                     mesh_dim_size,
@@ -229,9 +228,9 @@ def compute_global_tensor_info(
                 )
             shard_dim = shard_placement.dim
 
-            assert (
-                shard_dim < tensor.ndim
-            ), f"Sharding dim {shard_dim} greater than tensor ndim {tensor.ndim} for placement number {idx}."
+            assert shard_dim < tensor.ndim, (
+                f"Sharding dim {shard_dim} greater than tensor ndim {tensor.ndim} for placement number {idx}."
+            )
 
             local_dim_size = tensor_shape[shard_dim]
             tensor_shape[shard_dim] = local_dim_size * mesh_dim_size

--- a/torch/distributed/tensor/_utils.py
+++ b/torch/distributed/tensor/_utils.py
@@ -251,8 +251,8 @@ def compute_global_tensor_shape(
 ) -> torch.Size:
     """
     Compute the global size of a DTensor from the given local tensor shape,
-    the mesh and placements. Different from compute_global_tensor_info,
-    which assumed sharding is even, this util allgathers local shards' shapes
+    the mesh and placements. Different from `compute_global_tensor_info`,
+    which assumes sharding is even, this util allgathers local shards' shapes
     from all ranks and thus can support uneven sharding.
     NOTE: Currently this function only supports 1D mesh.
 

--- a/torch/distributed/tensor/_utils.py
+++ b/torch/distributed/tensor/_utils.py
@@ -252,6 +252,20 @@ def compute_global_tensor_shape(
     """
     Compute the global size of a DTensor from the given local tensor shape,
     the mesh and placements.
+    NOTE: Currently this function only supports 1D mesh.
+
+    Args:
+        shape (:class:`torch.Size`):
+            Shape of the Local tensor
+        mesh (:class:`DeviceMesh`):
+            Object which describes the mesh topology
+            of devices for the DTensor.
+        placements (Sequence[:class:`Placement`]]):
+            The attribute of the DTensor that describes its layout
+            on the mesh topology.
+
+    Return:
+        tensor_shape: Shape of the glocal DTensor.
     """
     if mesh.ndim > 1:
         raise NotImplementedError(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #152166
* __->__ #151990

### Summary

compute_global_tensor_shape util function takes in local tensor shape, device mesh
and placements. We all gather the shapes from the shards and according to the placement
type we construct the global shape.

Note: currenty only implemented for placement type Shard and Replicate, TODO for StridedShared

### Test

`pytest test/distributed/tensor/test_utils.py`

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k