### PR TITLE
docs: add torch.e and torch.pi to constants table (#134964)

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -319,8 +319,10 @@ Constants
 ~~~~~~~~~~~~~~~~~~~~~~
 
 ======================================= ===========================================
-``inf``                                     A floating-point positive infinity. Alias for :attr:`math.inf`.
-``nan``                                     A floating-point "not a number" value. This value is not a legal number. Alias for :attr:`math.nan`.
+``inf``                                 A floating-point positive infinity. Alias for :attr:`math.inf`.
+``nan``                                 A floating-point "not a number" value. Alias for :attr:`math.nan`.
+``e``                                   The base of the natural logarithm. Alias for :attr:`math.e`.
+``pi``                                  The constant π. Alias for :attr:`math.pi`.
 ======================================= ===========================================
 
 Pointwise Ops


### PR DESCRIPTION
Fixes #134964

Before

<img width="850" alt="Screenshot 2025-04-23 at 2 55 20 AM" src="https://github.com/user-attachments/assets/539f93c8-1e68-40b6-9eda-cd4d4646266c" />


After

<img width="864" alt="Screenshot 2025-04-23 at 2 55 34 AM" src="https://github.com/user-attachments/assets/16338c07-41b2-4de6-a576-bed8a326b421" />

cc @svekars @sekyondaMeta @AlannaBurke