### PR TITLE
[Inductor][CPP] Optimize the epilogue for int8 GEMM Template

### DIFF
--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -1083,9 +1083,10 @@ class CppGemmTemplate(CppTemplate):
             BCompensate = None
             x_w_scale = None
             if use_int8_fast_epilogue_path:
-                x_scale = new_inputs[2]
-                x_zp = new_inputs[3]
-                w_scale = new_inputs[4]
+                # new_inputs has been reordered: [x, w, optional[bias], x_scale, x_zp, w_scale, w_zp]
+                x_scale = new_inputs[-4]
+                x_zp = new_inputs[-3]
+                w_scale = new_inputs[-2]
                 if isinstance(W, ir.IRNode):
                     BCompensate = V.graph.add_tensor_constant(
                         V.graph.constants[W.get_name() + "_BMatrixCompens"],

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -727,7 +727,6 @@ class CppGemmTemplate(CppTemplate):
             dtype_B = self.input_nodes[1].get_dtype()
             num_byte_A = get_num_byte(dtype_A)
             num_byte_B = get_num_byte(dtype_B)
-
             if dtype_A is torch.bfloat16 and dtype_B is torch.int8 and Kr != 1:
                 # We will cache dequantized weights (BF16) in L1D for AMX micro-kernel.
                 # In this case, the choice of the micro-kernel being used can't be decoupled from

--- a/torch/_inductor/mkldnn_lowerings.py
+++ b/torch/_inductor/mkldnn_lowerings.py
@@ -26,7 +26,7 @@ from .select_algorithm import (
     ExternKernelChoice,
 )
 from .utils import use_aten_gemm_kernels, use_cpp_gemm_template, use_max_autotune
-from .virtualized import ops, V
+from .virtualized import ops, OpsValue, V
 
 
 def create_int8_compensation(
@@ -73,14 +73,14 @@ def create_int8_compensation(
 
 
 def codegen_int8_gemm_template_compensation(
-    use_int8_fast_compensation_path,
-    input,
-    _x_w_scale,
-    _x_scale,
-    _w_scale,
-    _weight_compo,
-    _x_zp,
-):
+    use_int8_fast_compensation_path: bool,
+    input: OpsValue,
+    _weight_compo: OpsValue,
+    _x_scale: Optional[OpsValue],
+    _x_zp: Optional[OpsValue],
+    _w_scale: Optional[OpsValue],
+    _x_w_scale: Optional[OpsValue],
+) -> OpsValue:
     if use_int8_fast_compensation_path:
         temp = ops.sub(
             ops.mul(
@@ -807,11 +807,11 @@ def register_onednn_fusion_ops():
                             temp = codegen_int8_gemm_template_compensation(
                                 use_int8_fast_compensation_path,
                                 input,
-                                _x_w_scale,
-                                _x_scale,
-                                _w_scale,
                                 _weight_compo,
+                                _x_scale,
                                 _x_zp,
+                                _w_scale,
+                                _x_w_scale,
                             )
                             # Step 2: add Bias if applicable
                             if bias is not None:
@@ -1131,11 +1131,11 @@ def register_onednn_fusion_ops():
                             temp = codegen_int8_gemm_template_compensation(
                                 use_int8_fast_compensation_path,
                                 input,
-                                _x_w_scale,
-                                _x_scale,
-                                _w_scale,
                                 _weight_compo,
+                                _x_scale,
                                 _x_zp,
+                                _w_scale,
+                                _x_w_scale,
                             )
                             # Step 2: add Bias if applicable
                             if bias is not None:

--- a/torch/_inductor/mkldnn_lowerings.py
+++ b/torch/_inductor/mkldnn_lowerings.py
@@ -29,6 +29,98 @@ from .utils import use_aten_gemm_kernels, use_cpp_gemm_template, use_max_autotun
 from .virtualized import ops, V
 
 
+def create_int8_compensation(
+    x_scale,
+    x_zp,
+    w_scale,
+    packed_weight,
+    W_tensor,
+):
+    use_int8_fast_epilogue_path = False
+    weight_compens = None
+    x_w_scale = None
+    if all(
+        isinstance(item, ir.TensorBox) and item.get_name() in V.graph.constants
+        for item in [x_scale, x_zp, w_scale]
+    ):
+        use_int8_fast_epilogue_path = True
+        x_w_scale_tensor = (
+            V.graph.constants[x_scale.get_name()]
+            * V.graph.constants[w_scale.get_name()]
+        )
+        x_w_scale = V.graph.add_tensor_constant(
+            x_w_scale_tensor,
+            name=packed_weight.get_name() + "_x_w_compens",
+        )
+        weight_compens_tensor = torch.sum(W_tensor.to(torch.float), dim=0)
+        x_zp_tensor = V.graph.constants[x_zp.get_name()]
+        weight_compens_tensor = weight_compens_tensor * x_w_scale_tensor * x_zp_tensor
+        weight_compens = V.graph.add_tensor_constant(
+            weight_compens_tensor,
+            name=packed_weight.get_name() + "_BMatrixCompens",
+        )
+    else:
+        weight_compens_tensor = torch.sum(W_tensor.to(torch.float), dim=0)
+        weight_compens = V.graph.add_tensor_constant(
+            weight_compens_tensor,
+            name=packed_weight.get_name() + "_BMatrixCompens",
+        )
+    return (
+        use_int8_fast_epilogue_path,
+        weight_compens,
+        x_w_scale,
+    )
+
+
+def codegen_int8_gemm_template_compensation(
+    use_int8_fast_epilogue_path,
+    input,
+    _x_w_scale,
+    _x_scale,
+    _w_scale,
+    _weight_compo,
+    _x_zp,
+):
+    if use_int8_fast_epilogue_path:
+        temp = ops.sub(
+            ops.mul(
+                input,
+                _x_w_scale,
+            ),
+            _weight_compo,
+        )
+    else:
+        temp = ops.mul(
+            ops.mul(
+                input,
+                _x_scale,
+            ),
+            _w_scale,
+        )
+        # NOTE: We will apply compensation even if the x_zp is 0 for int8 quantization.
+        # That's because when torch.compile is invoked for dynamic quantization,
+        # x might coincidentally have such values that x_zp might be zero despite
+        # asymmetric quantization.
+        # Besides, if x_zp is dummy for int8 x, or if x is statically quantized,
+        # we'd still perform that redundant compute to avoid making the code messy
+        # because we discovered that redundant computation of compensation did not
+        # lead to performance degradation with the input shapes tested.
+        temp = ops.sub(
+            temp,
+            ops.mul(
+                ops.mul(
+                    ops.mul(
+                        _x_scale,
+                        _w_scale,
+                    ),
+                    _x_zp,
+                ),
+                _weight_compo,
+            ),
+        )
+    return temp
+
+
 def grouped_gemm_lowering(
     x: TensorBox,
     w: list[TensorBox],
@@ -657,41 +749,17 @@ def register_onednn_fusion_ops():
                 ) and use_cpp_gemm_template(layout, x, packed_weight):
                     W_tensor = V.graph.constants[packed_weight.get_name()].to_dense()
 
-                    use_fast_path = False
-                    if (
-                        isinstance(x_scale, ir.TensorBox)
-                        and x_scale.get_name() in V.graph.constants
-                        and isinstance(w_scale, ir.TensorBox)
-                        and w_scale.get_name() in V.graph.constants
-                    ):
-                        use_fast_path = True
-                        x_w_scale_tensor = (
-                            V.graph.constants[x_scale.get_name()]
-                            * V.graph.constants[w_scale.get_name()]
-                        )
-                        x_w_scale = V.graph.add_tensor_constant(
-                            x_w_scale_tensor,
-                            name=packed_weight.get_name() + "_x_w_compens",
-                        )
-                        weight_compens_tensor = torch.sum(
-                            W_tensor.to(torch.float), dim=0
-                        )
-                        x_zp_tensor = V.graph.constants[x_zp.get_name()]
-                        weight_compens_tensor = (
-                            weight_compens_tensor * x_w_scale_tensor * x_zp_tensor
-                        )
-                        weight_compens = V.graph.add_tensor_constant(
-                            weight_compens_tensor,
-                            name=packed_weight.get_name() + "_BMatrixCompens",
-                        )
-                    else:
-                        weight_compens_tensor = torch.sum(
-                            W_tensor.to(torch.float), dim=0
-                        )
-                        weight_compens = V.graph.add_tensor_constant(
-                            weight_compens_tensor,
-                            name=packed_weight.get_name() + "_BMatrixCompens",
-                        )
+                    (
+                        use_int8_fast_epilogue_path,
+                        weight_compens,
+                        x_w_scale,
+                    ) = create_int8_compensation(
+                        x_scale,
+                        x_zp,
+                        w_scale,
+                        packed_weight,
+                        W_tensor,
+                    )
 
                     def epilogue_creator(input_buffer):
                         # Epilogue to convert from s32 to f32 for u8s8f32
@@ -704,7 +772,9 @@ def register_onednn_fusion_ops():
                         input_loader = input_buffer.make_loader()
                         weight_compens_loader = weight_compens.make_loader()
                         x_w_scale_loader = (
-                            None if not use_fast_path else x_w_scale.make_loader()
+                            None
+                            if not use_int8_fast_epilogue_path
+                            else x_w_scale.make_loader()
                         )
                         x_scale_loader = x_scale.make_loader()
                         w_scale_loader = w_scale.make_loader()
@@ -721,60 +791,34 @@ def register_onednn_fusion_ops():
                             # cvt to FP32 before doing compensation
                             input = ops.to_dtype(input, torch.float32)
                             weight_compens_index = (index[-1],)
-                            _x_scale = None if use_fast_path else x_scale_loader(())
-                            _x_zp = None if use_fast_path else x_zp_loader(())
+                            _x_scale = (
+                                None
+                                if use_int8_fast_epilogue_path
+                                else x_scale_loader(())
+                            )
+                            _x_zp = (
+                                None if use_int8_fast_epilogue_path else x_zp_loader(())
+                            )
                             _w_scale = (
                                 None
-                                if use_fast_path
+                                if use_int8_fast_epilogue_path
                                 else w_scale_loader(weight_compens_index)
                             )
                             _weight_compo = weight_compens_loader(weight_compens_index)
-
                             # Step 1: Compute s8s8->s32 or u8s8->s32 GEMM & then apply compensation
-                            if use_fast_path:
-                                assert x_w_scale_loader is not None, (
-                                    "x_w_scale_loader is None"
-                                )
+                            _x_w_scale = None
+                            if use_int8_fast_epilogue_path:
+                                assert x_w_scale_loader is not None
                                 _x_w_scale = x_w_scale_loader(weight_compens_index)
-                                temp = ops.mul(
-                                    input,
-                                    _x_w_scale,
-                                )
-                            else:
-                                temp = ops.mul(
-                                    ops.mul(
-                                        input,
-                                        _x_scale,
-                                    ),
-                                    _w_scale,
-                                )
-                            # NOTE: We will apply compensation even if the x_zp is 0 for int8 quantization.
-                            # That's because when torch.compile is invoked for dynamic quantization,
-                            # x might coincidentally have such values that x_zp might be zero despite
-                            # asymmetric quantization.
-                            # Besides, if x_zp is dummy for int8 x, or if x is statically quantized,
-                            # we'd still perform that redundant compute to avoid making the code messy
-                            # because we discovered that redundant computation of compensation did not
-                            # lead to performance degradation with the input shapes tested.
-                            if use_fast_path:
-                                temp = ops.sub(
-                                    temp,
-                                    _weight_compo,
-                                )
-                            else:
-                                temp = ops.sub(
-                                    temp,
-                                    ops.mul(
-                                        ops.mul(
-                                            ops.mul(
-                                                _x_scale,
-                                                _w_scale,
-                                            ),
-                                            _x_zp,
-                                        ),
-                                        _weight_compo,
-                                    ),
-                                )
+                            temp = codegen_int8_gemm_template_compensation(
+                                use_int8_fast_epilogue_path,
+                                input,
+                                _x_w_scale,
+                                _x_scale,
+                                _w_scale,
+                                _weight_compo,
+                                _x_zp,
+                            )
                             # Step 2: add Bias if applicable
                             if bias is not None:
                                 _bias = bias_loader(weight_compens_index)
@@ -1034,41 +1078,17 @@ def register_onednn_fusion_ops():
                 ):
                     W_tensor = V.graph.constants[packed_weight.get_name()]
                     W_tensor = W_tensor.to_dense()
-                    use_fast_path = False
-                    if (
-                        isinstance(x_scale, ir.TensorBox)
-                        and x_scale.get_name() in V.graph.constants
-                        and isinstance(w_scale, ir.TensorBox)
-                        and w_scale.get_name() in V.graph.constants
-                    ):
-                        use_fast_path = True
-                        x_w_scale_tensor = (
-                            V.graph.constants[x_scale.get_name()]
-                            * V.graph.constants[w_scale.get_name()]
-                        )
-                        x_w_scale = V.graph.add_tensor_constant(
-                            x_w_scale_tensor,
-                            name=packed_weight.get_name() + "_x_w_compens",
-                        )
-                        weight_compens_tensor = torch.sum(
-                            W_tensor.to(torch.float), dim=0
-                        )
-                        x_zp_tensor = V.graph.constants[x_zp.get_name()]
-                        weight_compens_tensor = (
-                            weight_compens_tensor * x_w_scale_tensor * x_zp_tensor
-                        )
-                        weight_compens = V.graph.add_tensor_constant(
-                            weight_compens_tensor,
-                            name=packed_weight.get_name() + "_BMatrixCompens",
-                        )
-                    else:
-                        weight_compens_tensor = torch.sum(
-                            W_tensor.to(torch.float), dim=0
-                        )
-                        weight_compens = V.graph.add_tensor_constant(
-                            weight_compens_tensor,
-                            name=packed_weight.get_name() + "_BMatrixCompens",
-                        )
+                    (
+                        use_int8_fast_epilogue_path,
+                        weight_compens,
+                        x_w_scale,
+                    ) = create_int8_compensation(
+                        x_scale,
+                        x_zp,
+                        w_scale,
+                        packed_weight,
+                        W_tensor,
+                    )
 
                     def epilogue_creator(input_buffer):
                         # Epilogue to convert from s32 to f32 for u8s8f32
@@ -1083,7 +1103,9 @@ def register_onednn_fusion_ops():
                         x2_loader = x2.make_loader()
                         weight_compens_loader = weight_compens.make_loader()
                         x_w_scale_loader = (
-                            None if not use_fast_path else x_w_scale.make_loader()
+                            None
+                            if not use_int8_fast_epilogue_path
+                            else x_w_scale.make_loader()
                         )
                         x_scale_loader = x_scale.make_loader()
                         w_scale_loader = w_scale.make_loader()
@@ -1097,8 +1119,14 @@ def register_onednn_fusion_ops():
                             nonlocal bias
                             input = input_loader(index)
                             _x2 = x2_loader(index)
-                            _x_scale = None if use_fast_path else x_scale_loader(())
-                            _x_zp = None if use_fast_path else x_zp_loader(())
+                            _x_scale = (
+                                None
+                                if use_int8_fast_epilogue_path
+                                else x_scale_loader(())
+                            )
+                            _x_zp = (
+                                None if use_int8_fast_epilogue_path else x_zp_loader(())
+                            )
 
                             # MicroKernel Output is with int32
                             # cvt to FP32 before doing compensation
@@ -1106,48 +1134,24 @@ def register_onednn_fusion_ops():
                             weight_compens_index = (index[-1],)
                             _w_scale = (
                                 None
-                                if use_fast_path
+                                if use_int8_fast_epilogue_path
                                 else w_scale_loader(weight_compens_index)
                             )
                             _weight_compo = weight_compens_loader(weight_compens_index)
                             # Step 1: Doing compensation to cvt fp32
-                            if use_fast_path:
-                                assert x_w_scale_loader is not None, (
-                                    "x_w_scale_loader is None"
-                                )
+                            _x_w_scale = None
+                            if use_int8_fast_epilogue_path:
+                                assert x_w_scale_loader is not None
                                 _x_w_scale = x_w_scale_loader(weight_compens_index)
-                                temp = ops.mul(
-                                    input,
-                                    _x_w_scale,
-                                )
-                            else:
-                                temp = ops.mul(
-                                    ops.mul(
-                                        input,
-                                        _x_scale,
-                                    ),
-                                    _w_scale,
-                                )
-                            if use_fast_path:
-                                temp = ops.sub(
-                                    temp,
-                                    _weight_compo,
-                                )
-                            else:
-                                temp = ops.sub(
-                                    temp,
-                                    ops.mul(
-                                        ops.mul(
-                                            ops.mul(
-                                                _x_scale,
-                                                _w_scale,
-                                            ),
-                                            _x_zp,
-                                        ),
-                                        _weight_compo,
-                                    ),
-                                )
-
+                            temp = codegen_int8_gemm_template_compensation(
+                                use_int8_fast_epilogue_path,
+                                input,
+                                _x_w_scale,
+                                _x_scale,
+                                _w_scale,
+                                _weight_compo,
+                                _x_zp,
+                            )
                             # Step 2: add Bias if applicable
                             if bias is not None:
                                 _bias = bias_loader(weight_compens_index)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152000


**Summary**
For int8 GEMM Template, the micro GEMM will calculate in u8s8s32 and we will do the scale/zp compensation in the epilogue. In general,  it will be calculated as:
```
temp = micro_gemm_output * x_scale * w_scale
temp = temp - (x_scale * w_scale * x_zp) * sum(w, 0)
```
For case when `x_scale, w_scale, x_zp` are constant, we can pre-calculate the compensation to save runtime calculation.

**Performance**
Test with 4 cores of XEON-5 and shapes from VIT model
Before
```
GEMM(M=197,N=768,K=768) compile: 0.0939 ms (2.48 TOPS, 18.13 GB/s)
GEMM(M=197,N=3072,K=768) compile: 0.4275 ms (2.17 TOPS, 13.90 GB/s)
GEMM(M=197,N=768,K=3072) compile: 0.2677 ms (3.47 TOPS, 22.20 GB/s)
GEMM(M=1,N=1000,K=768) compile: 0.0148 ms (0.10 TOPS, 99.10 GB/s)
```

After
```
GEMM(M=197,N=768,K=768) compile: 0.0597 ms (3.90 TOPS, 28.53 GB/s)
GEMM(M=197,N=3072,K=768) compile: 0.2126 ms (4.37 TOPS, 27.95 GB/s)
GEMM(M=197,N=768,K=3072) compile: 0.2282 ms (4.07 TOPS, 26.04 GB/s)
GEMM(M=1,N=1000,K=768) compile: 0.0149 ms (0.10 TOPS, 98.71 GB/s)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov