### PR TITLE
[MPS] layernorm forward kernel

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LayerNorm.metal
+++ b/aten/src/ATen/native/mps/kernels/LayerNorm.metal
@@ -1,0 +1,294 @@
+#include <metal_simdgroup>
+#include <metal_stdlib>
+using namespace metal;
+
+template <typename T>
+kernel void layer_norm_single_row(
+    device T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    device T* meanOut [[buffer(2)]],
+    device T* rstdTensor [[buffer(3)]],
+    constant uint& axis_size [[buffer(4)]],
+    constant float& epsilon [[buffer(5)]],
+    constant int& use_weight [[buffer(6)]],
+    constant int& use_bias [[buffer(7)]],
+    device T* weight [[buffer(8)]],
+    device T* bias [[buffer(9)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int SIMD_SIZE = 32;
+  constexpr int N_READS = 4;
+
+  // each threadgroup handles one full “row” of length axis_size
+  uint row_offset = tg_id * axis_size;
+  device T* x = input + row_offset + tid * N_READS;
+  device T* out = output + row_offset + tid * N_READS;
+
+  // partial sums for calculating mean & variance
+  float partial_sum = 0.0f;
+  float partial_sum_sq = 0.0f;
+  uint base_lane = tid * N_READS;
+  if (base_lane + N_READS <= axis_size) {
+    float4 v4 = float4(x[0], x[1], x[2], x[3]);
+    partial_sum = v4.x + v4.y + v4.z + v4.w;
+    partial_sum_sq = dot(v4, v4);
+  } else {
+    int remaining = axis_size - base_lane;
+    if (remaining >= 3) {
+      float3 v3 = float3(x[0], x[1], x[2]);
+      partial_sum = v3.x + v3.y + v3.z;
+      partial_sum_sq = dot(v3, v3);
+    } else if (remaining >= 2) {
+      float2 v2 = float2(x[0], x[1]);
+      partial_sum = v2.x + v2.y;
+      partial_sum_sq = dot(v2, v2);
+    } else if (remaining >= 1) {
+      float v = x[0];
+      partial_sum = v;
+      partial_sum_sq = fma(v, v, partial_sum_sq);
+    }
+  }
+
+  // threadgroup‐wide reduction
+  threadgroup float local_sums[SIMD_SIZE];
+  threadgroup float local_sums_sq[SIMD_SIZE];
+  threadgroup float tg_mean[1];
+  threadgroup float tg_inv_std[1];
+
+  if (simdgroup_id == 0) {
+    local_sums[simd_lane_id] = 0.0f;
+    local_sums_sq[simd_lane_id] = 0.0f;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // each simdgroup writes its partial
+  float group_partial_sum = simd_sum(partial_sum);
+  float group_partial_sum_sq = simd_sum(partial_sum_sq);
+  if (simd_lane_id == 0) {
+    local_sums[simdgroup_id] = group_partial_sum;
+    local_sums_sq[simdgroup_id] = group_partial_sum_sq;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // warp 0 reduces those 32 values
+  if (simdgroup_id == 0) {
+    float sum = simd_sum(local_sums[simd_lane_id]);
+    float sum_sq = simd_sum(local_sums_sq[simd_lane_id]);
+    if (simd_lane_id == 0) {
+      float mean = sum / float(axis_size);
+      float var = sum_sq / float(axis_size) - mean * mean;
+      var = var < 1e-6 ? 0.0f : var; // for rsqrt precision
+      float inv_std = metal::precise::rsqrt(var + epsilon);
+      tg_mean[0] = mean;
+      tg_inv_std[0] = inv_std;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  float mean = tg_mean[0];
+  float inv_std = tg_inv_std[0];
+
+  // normalize and optional scale & shift
+  if (base_lane + N_READS <= axis_size) {
+#pragma unroll
+    for (int i = 0; i < N_READS; i++) {
+      float v = float(x[i]);
+      float norm = (v - mean) * inv_std;
+      uint lane_idx = base_lane + i;
+      if (use_weight)
+        norm *= float(weight[lane_idx]);
+      if (use_bias)
+        norm += float(bias[lane_idx]);
+      out[i] = static_cast<T>(norm);
+    }
+  } else {
+#pragma unroll
+    for (int i = 0; i < N_READS; i++) {
+      uint lane_idx = base_lane + i;
+      if (lane_idx < axis_size) {
+        float v = float(x[i]);
+        float norm = (v - mean) * inv_std;
+        if (use_weight)
+          norm *= float(weight[lane_idx]);
+        if (use_bias)
+          norm += float(bias[lane_idx]);
+        out[i] = static_cast<T>(norm);
+      }
+    }
+  }
+
+  if (tid == 0 && simd_lane_id == 0) {
+    meanOut[tg_id] = static_cast<T>(mean);
+    rstdTensor[tg_id] = static_cast<T>(inv_std);
+  }
+}
+
+template <typename T>
+kernel void layer_norm_looped(
+    device T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    device T* meanOut [[buffer(2)]],
+    device T* rstdTensor [[buffer(3)]],
+    constant uint& axis_size [[buffer(4)]],
+    constant float& epsilon [[buffer(5)]],
+    constant int& use_weight [[buffer(6)]],
+    constant int& use_bias [[buffer(7)]],
+    device T* weight [[buffer(8)]],
+    device T* bias [[buffer(9)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int SIMD_SIZE = 32;
+  constexpr int N_READS = 4;
+
+  uint row_offset = tg_id * axis_size;
+  device T* x = input + row_offset;
+  device T* out = output + row_offset;
+
+  float partial_sum = 0.0f;
+  float partial_sum_sq = 0.0f;
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      float4 xi4 = float4(x[base], x[base + 1], x[base + 2], x[base + 3]);
+      partial_sum += xi4.x + xi4.y + xi4.z + xi4.w;
+      partial_sum_sq += dot(xi4, xi4);
+    } else {
+      int remaining = axis_size - base;
+      if (remaining >= 3) {
+        float3 v3 = float3(x[base], x[base + 1], x[base + 2]);
+        partial_sum += v3.x + v3.y + v3.z;
+        partial_sum_sq += dot(v3, v3);
+      } else if (remaining >= 2) {
+        float2 v2 = float2(x[base], x[base + 1]);
+        partial_sum += v2.x + v2.y;
+        partial_sum_sq += dot(v2, v2);
+      } else if (remaining >= 1) {
+        float v = x[base];
+        partial_sum += v;
+        partial_sum_sq = fma(v, v, partial_sum_sq);
+      }
+    }
+  }
+
+  partial_sum = simd_sum(partial_sum);
+  partial_sum_sq = simd_sum(partial_sum_sq);
+
+  threadgroup float local_sums[SIMD_SIZE];
+  threadgroup float local_sums_sq[SIMD_SIZE];
+  threadgroup float tg_mean[1];
+  threadgroup float tg_inv_std[1];
+
+  if (simd_lane_id == 0) {
+    local_sums[simdgroup_id] = 0.0f;
+    local_sums_sq[simdgroup_id] = 0.0f;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (simd_lane_id == 0) {
+    local_sums[simdgroup_id] = partial_sum;
+    local_sums_sq[simdgroup_id] = partial_sum_sq;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (simdgroup_id == 0) {
+    float s = simd_sum(local_sums[simd_lane_id]);
+    float ss = simd_sum(local_sums_sq[simd_lane_id]);
+    if (simd_lane_id == 0) {
+      float mean = s / float(axis_size);
+      float var = ss / float(axis_size) - mean * mean;
+      var = var < 1e-6 ? 0.0f : var; // for rsqrt precision
+      float inv_std = metal::precise::rsqrt(var + epsilon);
+      tg_mean[0] = mean;
+      tg_inv_std[0] = inv_std;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  float mean = tg_mean[0];
+  float inv_std = tg_inv_std[0];
+
+  // write back normalized + scale/shift if needed
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+#pragma unroll
+      for (int i = 0; i < N_READS; i++) {
+        float xi = float(x[base + i]);
+        float norm = (xi - mean) * inv_std;
+        if (use_weight)
+          norm *= float(weight[base + i]);
+        if (use_bias)
+          norm += float(bias[base + i]);
+        out[base + i] = T(norm);
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < N_READS; i++) {
+        if (base + i < axis_size) {
+          float xi = float(x[base + i]);
+          float norm = (xi - mean) * inv_std;
+          if (use_weight)
+            norm *= float(weight[base + i]);
+          if (use_bias)
+            norm += float(bias[base + i]);
+          out[base + i] = T(norm);
+        }
+      }
+    }
+  }
+
+  if (tid == 0 && simd_lane_id == 0) {
+    meanOut[tg_id] = T(mean);
+    rstdTensor[tg_id] = T(inv_std);
+  }
+}
+
+#define instantiate_layer_norm_single_row(DTYPE)                          \
+  template [[host_name("layer_norm_single_row_" #DTYPE)]] [[kernel]] void \
+  layer_norm_single_row<DTYPE>(                                           \
+      device DTYPE * input [[buffer(0)]],                                 \
+      device DTYPE * output [[buffer(1)]],                                \
+      device DTYPE * meanOut [[buffer(2)]],                               \
+      device DTYPE * rstdTensor [[buffer(3)]],                            \
+      constant uint & axis_size [[buffer(4)]],                            \
+      constant float& epsilon [[buffer(5)]],                              \
+      constant int& use_weight [[buffer(6)]],                             \
+      constant int& use_bias [[buffer(7)]],                               \
+      device DTYPE* weight [[buffer(8)]],                                 \
+      device DTYPE* bias [[buffer(9)]],                                   \
+      uint tg_id [[threadgroup_position_in_grid]],                        \
+      uint tid [[thread_position_in_threadgroup]],                        \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                    \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_layer_norm_looped(DTYPE)                          \
+  template [[host_name("layer_norm_looped_" #DTYPE)]] [[kernel]] void \
+  layer_norm_looped<DTYPE>(                                           \
+      device DTYPE * input [[buffer(0)]],                             \
+      device DTYPE * output [[buffer(1)]],                            \
+      device DTYPE * meanOut [[buffer(2)]],                           \
+      device DTYPE * rstdTensor [[buffer(3)]],                        \
+      constant uint & axis_size [[buffer(4)]],                        \
+      constant float& epsilon [[buffer(5)]],                          \
+      constant int& use_weight [[buffer(6)]],                         \
+      constant int& use_bias [[buffer(7)]],                           \
+      device DTYPE* weight [[buffer(8)]],                             \
+      device DTYPE* bias [[buffer(9)]],                               \
+      uint tg_id [[threadgroup_position_in_grid]],                    \
+      uint tid [[thread_position_in_threadgroup]],                    \
+      uint lsize [[threads_per_threadgroup]],                         \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_layer_norm(DTYPE) \
+  instantiate_layer_norm_single_row(DTYPE) instantiate_layer_norm_looped(DTYPE)
+
+instantiate_layer_norm(float) instantiate_layer_norm(half)
+#if __METAL_VERSION__ >= 310
+    instantiate_layer_norm(bfloat)
+#endif

--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -885,8 +885,7 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_mps(const Tensor& input,
                                                   const std::optional<Tensor>& weight_opt,
                                                   const std::optional<Tensor>& bias_opt,
                                                   double eps) {
-  auto N = std::accumulate(
-      normalized_shape.begin(), normalized_shape.end(), static_cast<int64_t>(1), std::multiplies<int64_t>());
+  auto N = c10::multiply_integers(normalized_shape);
   auto out = at::empty_like(input, MemoryFormat::Contiguous);
   auto batch_dim = input.dim() - normalized_shape.size();
   IntArrayRef batch_shape = input.sizes().slice(0, batch_dim);

--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -916,7 +916,7 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_mps(const Tensor& input,
     mps::dispatch_sync_with_rethrow(stream->queue(), ^() {
       // which kernel variant to use based on the normalized axis N size
       const int N_READS = 4;
-      std::string metalType = mps::scalarToMetalTypeString(input);
+      auto metalType = mps::scalarToMetalTypeString(input);
       id<MTLComputePipelineState> layerNormKernel = nil;
       if (axis_size <= 1024 * N_READS) {
         layerNormKernel = mps::lib.getPipelineStateForFunc("layer_norm_single_row_" + metalType);

--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -22,6 +22,13 @@
 
 namespace at::native {
 namespace mps {
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/LayerNorm_metallib.h>
+#endif
+
 static void get_shapes(MPSShape* input_shape_readonly,
                        NSMutableArray<NSNumber*>*& input_shape,
                        NSMutableArray<NSNumber*>*& new_mean_shape,
@@ -878,6 +885,11 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_mps(const Tensor& input,
                                                   const std::optional<Tensor>& weight_opt,
                                                   const std::optional<Tensor>& bias_opt,
                                                   double eps) {
+  int64_t N = std::accumulate(
+      normalized_shape.begin(), normalized_shape.end(), static_cast<int64_t>(1), std::multiplies<int64_t>());
+  Tensor out = at::empty_like(input, MemoryFormat::Contiguous);
+  auto batch_dim = input.dim() - normalized_shape.size();
+  IntArrayRef batch_shape = input.sizes().slice(0, batch_dim);
   c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
   const Tensor& weight = *weight_maybe_owned;
   c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
@@ -887,37 +899,58 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_mps(const Tensor& input,
   auto M = M_N.first;
   auto X = input.expect_contiguous();
   auto gamma = weight.expect_contiguous();
+  Tensor mean = at::empty(batch_shape, input.options(), MemoryFormat::Contiguous);
+  Tensor rstd = at::empty(batch_shape, input.options(), MemoryFormat::Contiguous);
 
   auto input_shape = input.sizes();
+  int axis_size = static_cast<int>(N);
+  float epsilon_buf = static_cast<float>(eps);
+  int use_weight_buf = weight.defined() ? 1 : 0;
+  int use_bias_buf = bias.defined() ? 1 : 0;
   const auto input_ndim = input.dim();
   const int normalized_ndim = normalized_shape.size();
   // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
   const int axis = input_ndim - normalized_ndim;
-  at::Tensor input_reshaped = input.numel() == 0 ? input.reshape({1, M, 0}) : input.reshape({1, M, -1});
-  // Unlike Batch Normalization, which applies scalar scale and bias for each
-  // entire channel/plane with the affine option, Layer Normalization applies
-  // per-element scale and bias. E.g. For input {N, C, H, W}, weight for
-  // batchnorm has shape {C} while weight for layernorm has shape {H, W} or {W}.
-  auto outputs = at::native_batch_norm(input_reshaped,
-                                       /*weight=*/{},
-                                       /*bias=*/{},
-                                       /*running_mean=*/{},
-                                       /*running_var=*/{},
-                                       /*training=*/true,
-                                       /*momentum=*/0,
-                                       eps);
-  at::Tensor out = std::get<0>(outputs);
-  out = out.view(input_shape);
-  if (weight.defined() && bias.defined()) {
-    out = bias.addcmul(out, weight, 1);
-  } else if (weight.defined()) {
-    out = out.mul(weight);
-  } else if (bias.defined()) {
-    out = out.add(bias);
-  }
-  at::Tensor mean = std::get<1>(outputs);
-  at::Tensor variance = std::get<2>(outputs);
+  MPSStream* stream = getCurrentMPSStream();
+  @autoreleasepool {
+    mps::dispatch_sync_with_rethrow(stream->queue(), ^() {
+      // which kernel variant to use based on the normalized axis N size
+      const int N_READS = 4;
+      std::string metalType = mps::scalarToMetalTypeString(input);
+      id<MTLComputePipelineState> layerNormKernel = nil;
+      if (axis_size <= 1024 * N_READS) {
+        layerNormKernel = mps::lib.getPipelineStateForFunc("layer_norm_single_row_" + metalType);
+      } else {
+        layerNormKernel = mps::lib.getPipelineStateForFunc("layer_norm_looped_" + metalType);
+      }
+      id<MTLComputeCommandEncoder> computeEncoder = stream->commandEncoder();
+      [computeEncoder setComputePipelineState:layerNormKernel];
 
+      [computeEncoder setBuffer:mps::getMTLBufferStorage(*X) offset:0 atIndex:0];
+      [computeEncoder setBuffer:mps::getMTLBufferStorage(out) offset:0 atIndex:1];
+      [computeEncoder setBuffer:mps::getMTLBufferStorage(mean) offset:0 atIndex:2];
+      [computeEncoder setBuffer:mps::getMTLBufferStorage(rstd) offset:0 atIndex:3];
+      uint32_t axis_size_u = static_cast<uint32_t>(axis_size);
+      [computeEncoder setBytes:&axis_size_u length:sizeof(axis_size_u) atIndex:4];
+      [computeEncoder setBytes:&epsilon_buf length:sizeof(epsilon_buf) atIndex:5];
+      [computeEncoder setBytes:&use_weight_buf length:sizeof(use_weight_buf) atIndex:6];
+      [computeEncoder setBytes:&use_bias_buf length:sizeof(use_bias_buf) atIndex:7];
+      if (use_weight_buf) {
+        [computeEncoder setBuffer:mps::getMTLBufferStorage(*gamma) offset:0 atIndex:8];
+      } else {
+        [computeEncoder setBuffer:nil offset:0 atIndex:8];
+      }
+      if (use_bias_buf) {
+        [computeEncoder setBuffer:mps::getMTLBufferStorage(bias) offset:0 atIndex:9];
+      } else {
+        [computeEncoder setBuffer:nil offset:0 atIndex:9];
+      }
+      MTLSize numThreads = MTLSizeMake(std::min((axis_size + N_READS - 1) / N_READS, 1024), 1, 1);
+      MTLSize numThreadgroups = MTLSizeMake(M, 1, 1);
+      [computeEncoder dispatchThreadgroups:numThreadgroups threadsPerThreadgroup:numThreads];
+    });
+  }
+  out = out.view(input_shape);
   std::vector<int64_t> stat_shape;
   for (const auto idx : c10::irange(axis)) {
     stat_shape.push_back(input_shape[idx]);
@@ -926,8 +959,8 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_mps(const Tensor& input,
     stat_shape.push_back(1);
   }
   mean = mean.view(stat_shape);
-  variance = variance.view(stat_shape);
-  return std::make_tuple(out, mean, variance);
+  rstd = rstd.view(stat_shape);
+  return std::make_tuple(out, mean, rstd);
 }
 
 std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_mps(const Tensor& grad_out,


### PR DESCRIPTION
Implements layernorm forward pass as a metal kernel instead of MPSGraph ops. Speed ups are indicated on the chart below:
![Figure_1](https://github.com/user-attachments/assets/27a4d2ef-b3e4-4650-9ce3-b939c080321e)

Script for generating times, need to build torch with old/new codebase and then run this with different file name indicated at the end of the script
```python
import csv
import time

import numpy as np

import torch
import torch.nn.functional as F


matrix_sizes = [32, 64, 128, 256, 512, 1024, 2048, 4096, 8192]
batch_sizes = [1]
elementwise_affine = [False, True]
num_runs = 50
warmup_runs = 3


def create_input_tensor(n, batch_size):
    torch.manual_seed(42)
    return torch.randn(batch_size, n, dtype=torch.float32)


def run_layer_norm(A, normalized_shape, elementwise_affine):
    torch.mps.synchronize()
    start = time.perf_counter()
    out = F.layer_norm(A, normalized_shape)
    torch.mps.synchronize()
    end = time.perf_counter()
    return out, end - start


results = {"N": [], "elementwise_affine": [], "batch_size": [], "mean_time": [], "std_time": []}

for el_aff in elementwise_affine:
    for n in matrix_sizes:
        for batch_size in batch_sizes:
            print(f"\nBenchmarking LayerNorm for input size N={n}, batch_size={batch_size}, elementwise_affine={el_aff}")

            try:
                A_cpu = create_input_tensor(n, batch_size)
                A_mps = A_cpu.to("mps")

                normalized_shape = (n,)

                for _ in range(warmup_runs):
                    _, _ = run_layer_norm(A_mps, normalized_shape, el_aff)

                times = []
                for _ in range(num_runs):
                    _, t = run_layer_norm(A_mps, normalized_shape, el_aff)
                    times.append(t)

                mean_time = np.mean(times)
                std_time = np.std(times)

                results["N"].append(n)
                results["elementwise_affine"].append(el_aff)
                results["batch_size"].append(batch_size)
                results["mean_time"].append(mean_time)
                results["std_time"].append(std_time)

                print(f"Mean time: {mean_time:.4f}s ± {std_time:.4f}s")

            except RuntimeError as e:
                print(f"Error for N={n}, batch_size={batch_size}: {e}")
                continue

with open("layernorm_benchmark_times_new.csv", "w", newline="") as f:
    writer = csv.writer(f)
    writer.writerow(["N", "elementwise_affine", "batch_size", "mean_time", "std_time"])
    for i in range(len(results["N"])):
        writer.writerow(
            [
                results["N"][i],
                results["elementwise_affine"][i],
                results["batch_size"][i],
                results["mean_time"][i],
                results["std_time"][i],
            ]
        )

```

cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen