### PR TITLE
Ignore unused structured arguments in member functions

### DIFF
--- a/torchgen/dest/register_dispatch_key.py
+++ b/torchgen/dest/register_dispatch_key.py
@@ -583,6 +583,10 @@ class StructuredRegisterDispatchKey(RegisterDispatchKey):
     ) -> str:
         if generate_super:
             set_output_super = f"{parent_class}::set_output_raw_strided(output_idx, sizes, strides, options, names);"
+        elif k.inplace:
+            # Inplace variants without a super call don't use the strides argument.
+            # This silences -Werror=unused-parameter
+            set_output_super = "(void)strides;"
         else:
             set_output_super = ""
 


### PR DESCRIPTION
inplace structured overloads today do not use the `strides` in the `set_output_raw_strided` member function. For example addmv does not inherit from `TensorIterator`, so there is no `super` call in the `set_output_raw_strided` function, which can trigger a warning / error by the compiler:
```c++
}
struct structured_addmv_out_cpu_inplace final : public at::native::structured_addmv_out_cpu {
    structured_addmv_out_cpu_inplace(Tensor& self) : outputs_{std::ref(self)} {}
    void set_output_strided(
        int64_t output_idx, IntArrayRef sizes, IntArrayRef strides,
        TensorOptions options, DimnameList names
    ) override {
        const auto& out = outputs_[output_idx].get();
        check_inplace(out, sizes, options);
        auto maybe_proxy = maybe_create_proxy(out, sizes, strides, options);
        if (C10_UNLIKELY(maybe_proxy.has_value())) {
            proxy_outputs_[output_idx] = std::move(maybe_proxy).value();
        }
        if (!names.empty()) {
          namedinference::propagate_names(outputs_[output_idx], names);
        }
        // super must happen after, so that downstream can use maybe_get_output
        // to retrieve the output
    }
    void set_output_raw_strided(
        int64_t output_idx, IntArrayRef sizes, IntArrayRef strides,
        TensorOptions options, DimnameList names
    ) override {
        const auto& out = outputs_[output_idx].get();
        check_inplace(out, sizes, options);
        if (!names.empty()) {
          namedinference::propagate_names(outputs_[output_idx], names);
        }
        // super must happen after, so that downstream can use maybe_get_output
        // to retrieve the output
    }
    const Tensor& maybe_get_output(int64_t output_idx) override {
      return proxy_outputs_[output_idx].has_value() ? *proxy_outputs_[output_idx] : outputs_[output_idx].get();
    }
    std::array<std::reference_wrapper<Tensor>, 1> outputs_;
    std::array<::std::optional<Tensor>, 1> proxy_outputs_;
};

```

This PR marks the `strides` argument as unused for inplace structured overloads that do not subclass from `TensorIterator`.