### PR TITLE
[caffe2/c10/util/TypeIndex] Add '__CUDA_ARCH_LIST__' check

### DIFF
--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -56,7 +56,7 @@ inline constexpr c10::c10_string_view fully_qualified_type_name_impl() {
   constexpr c10::string_view suffix =
       "; c10::c10_string_view = c10::basic_string_view<char>]";
 #endif
-#if !defined(__CUDA_ARCH__)
+#if !defined(__CUDA_ARCH__) && !defined(__CUDA_ARCH_LIST__)
   static_assert(c10::starts_with(
       static_cast<std::string_view>(fun_sig),
       static_cast<std::string_view>(prefix)));
@@ -68,7 +68,7 @@ inline constexpr c10::c10_string_view fully_qualified_type_name_impl() {
       prefix.size(), fun_sig.size() - prefix.size() - suffix.size());
 }
 
-#if !defined(__CUDA_ARCH__)
+#if !defined(__CUDA_ARCH__) && !defined(__CUDA_ARCH_LIST__)
 template <typename T>
 inline constexpr uint64_t type_index_impl() {
 // Idea: __PRETTY_FUNCTION__ (or __FUNCSIG__ on msvc) contains a qualified name
@@ -89,7 +89,7 @@ inline constexpr uint64_t type_index_impl() {
 
 template <typename T>
 inline constexpr type_index get_type_index() {
-#if !defined(__CUDA_ARCH__)
+#if !defined(__CUDA_ARCH__) && !defined(__CUDA_ARCH_LIST__)
   // To enforce that this is really computed at compile time, we pass the
   // type index through std::integral_constant.
   return type_index{std::integral_constant<


### PR DESCRIPTION
Summary:
We suspect that switching the NVCC host compiler from GCC to Clang, while targeting multiple architectures, is causing issues because only _CUDA_ARCH_LIST_ is being passed, without _CUDA_ARCH_. 

To resolve this c10 compilation error, we should first fix the problem and then switch the NVCC host compiler from GCC to Clang. Once this is done, the errors no longer occur.

Test Plan: CI

Reviewed By: zhuhan0

Differential Revision: D73383236


