### PR TITLE
Improve stable library apis per Scott's feedback

### DIFF
--- a/docs/source/notes/libtorch_stable_abi.md
+++ b/docs/source/notes/libtorch_stable_abi.md
@@ -9,6 +9,7 @@ This note will eventually contain more details on how to use the APIs in torch/c
 |  type in custom extension    |   StableIValue representation   |   type in libtorch  |   Schema Type  |
 | -------- | ------- | ------- | ------- |
 | std::optional\<S> | raw bitwise copy into leading bytes of uint64_t of pointer to a new StableIValue representing S | std::optional\<T> | Type? |
+| std::optional\<S>() | nullptr | std::optional\<T>() | Type? |
 | std::nullopt | nullptr | IValue() | None |
 | RAIIATH | raw bitwise copy of underlying AtenTensorHandle into leading bytes of uint64_t | at::Tensor |  Tensor |
 | int32_t | raw bitwise copy into leading bytes of uint64_t | at::ScalarType | ScalarType |

--- a/docs/source/notes/libtorch_stable_abi.md
+++ b/docs/source/notes/libtorch_stable_abi.md
@@ -8,9 +8,7 @@ This note will eventually contain more details on how to use the APIs in torch/c
 
 |  type in custom extension    |   StableIValue representation   |   type in libtorch  |   Schema Type  |
 | -------- | ------- | ------- | ------- |
-| std::optional\<S> | raw bitwise copy into leading bytes of uint64_t of pointer to a new StableIValue representing S | std::optional\<T> | Type? |
-| std::optional\<S>() | nullptr | std::optional\<T>() | Type? |
-| std::nullopt | nullptr | IValue() | None |
+| std::optional\<S> | if there is a value, raw bitwise copy into leading bytes of uint64_t of pointer to a new StableIValue representing S. if there is no value, nullptr. | std::optional\<T> | Type? |
 | RAIIATH | raw bitwise copy of underlying AtenTensorHandle into leading bytes of uint64_t | at::Tensor |  Tensor |
 | int32_t | raw bitwise copy into leading bytes of uint64_t | at::ScalarType | ScalarType |
 | int32_t | raw bitwise copy into leading bytes of uint64_t | at::Layout | Layout |

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -1432,12 +1432,12 @@ class StableIValueBoxedKernel : public c10::OperatorKernel {
     const auto num_returns = schema.returns().size();
     const auto num_arguments = schema.arguments().size();
 
-    std::unique_ptr<StableIValue[]> ministack(new StableIValue[std::max(num_arguments, num_returns)]);
+    auto ministack = std::make_unique<StableIValue[]>(std::max(num_arguments, num_returns));
 
     for (const auto idx : c10::irange(num_arguments)) {
       const auto ministack_idx = num_arguments - idx - 1;
       const c10::TypePtr& arg_type = schema.arguments()[ministack_idx].type();
-      ministack.get()[ministack_idx] = from_ivalue(arg_type, torch::jit::pop(stack));
+      ministack[ministack_idx] = from_ivalue(arg_type, torch::jit::pop(stack));
     }
 
     // boxed function is going to take a stack of StableIValues, cast them to
@@ -1448,7 +1448,7 @@ class StableIValueBoxedKernel : public c10::OperatorKernel {
     // IValue from StableIValue
     for (size_t idx = 0; idx < num_returns; idx++) {
       const c10::TypePtr& ret_type = schema.returns()[idx].type();
-      torch::jit::push(stack, to_ivalue(ret_type, ministack.get()[idx]));
+      torch::jit::push(stack, to_ivalue(ret_type, ministack[idx]));
     }
   }
 

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -1365,7 +1365,7 @@ static c10::IValue to_ivalue(
       auto ret_raiiath = torch::aot_inductor::RAIIAtenTensorHandle(
           to<AtenTensorHandle>(stable_ivalue));
       return (c10::IValue(*torch::aot_inductor::tensor_handle_to_tensor_pointer(
-        ret_raiiath.get())));
+          ret_raiiath.get())));
     }
     case c10::TypeKind::IntType: {
       return c10::IValue(to<int64_t>(stable_ivalue));
@@ -1432,7 +1432,8 @@ class StableIValueBoxedKernel : public c10::OperatorKernel {
     const auto num_returns = schema.returns().size();
     const auto num_arguments = schema.arguments().size();
 
-    auto ministack = std::make_unique<StableIValue[]>(std::max(num_arguments, num_returns));
+    auto ministack =
+        std::make_unique<StableIValue[]>(std::max(num_arguments, num_returns));
 
     for (const auto idx : c10::irange(num_arguments)) {
       const auto ministack_idx = num_arguments - idx - 1;


### PR DESCRIPTION
Following 3 suggestions:
1. inline at::Tensor arg
2. use uniq ptr of array vs std::vector
3. document the `std::optional<S>()` case

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152040

