### PR TITLE
[DO NOT LAND] Use cudaGetDevice in OSSProxyExecutor

### DIFF
--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include <c10/util/Exception.h>
+#include <torch/csrc/inductor/aoti_runtime/device_utils.h>
 #include <torch/csrc/inductor/aoti_torch/oss_proxy_executor.h>
 #include <torch/csrc/jit/serialization/pickle.h>
 
@@ -585,6 +586,9 @@ OSSProxyExecutor::OSSProxyExecutor(
     device_ = std::make_unique<c10::Device>(c10::DeviceType::CPU);
   } else {
     int device_idx = -1;
+#ifdef USE_CUDA
+    AOTI_RUNTIME_DEVICE_CHECK(cudaGetDevice(&device_idx));
+#endif // USE_CUDA
     device_ = std::make_unique<c10::Device>(c10::DeviceType::CUDA, device_idx);
   }
 


### PR DESCRIPTION
Summary: I am trying to use `cudaGetDevice()` in `oss_proxy_executor.cpp` and guard it under the macro `USE_CUDA`. However, seems like the code under `USE_CUDA` was never invoked even if I built PyTorch on a GPU machine. The `device_idx` remains -1, ideally it should change to `0` after `cudaGetDevice()` is called. 

Test Plan: CI

Differential Revision: D73537817


