### PR TITLE
[Graph Partition] fix extra reference in runner.partitions to cudagraphify functions

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -877,6 +877,21 @@ if HAS_CUDA:
         def test_unaligned_static_input_no_cudagraphs(self):
             self._test_unaligned_static_input_impl(expected_clones=0)
 
+        @torch._inductor.config.patch("graph_partition", True)
+        @torch._inductor.config.patch("triton.cudagraph_trees", False)
+        def test_graph_partition_gc(self):
+            def _test_dummy():
+                def foo(x):
+                    return x + 1
+
+                foo = torch.compile(foo)
+                for _ in range(3):
+                    foo(torch.randn(2, 3, device="cuda"))
+
+            _test_dummy()
+            gc.collect()
+            self.assertIsNone(self.get_manager())
+
         def test_sparsity(self):
             def foo(view_6, buf31):
                 return aten._sparse_coo_tensor_with_dims_and_tensors(

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1285,7 +1285,7 @@ class _InProcessFxCompile(FxCompile):
                     # not going to touch it for now
 
                     compiled_fn: Any
-                    recursively_apply_fns = None
+                    compiled_fn_runner = None
                     with dynamo_timed(
                         "GraphLowering.compile_to_fn", log_pt2_compile_event=True
                     ):
@@ -1339,8 +1339,8 @@ class _InProcessFxCompile(FxCompile):
                         else:
                             compiled_module = graph.compile_to_module()
                             compiled_fn = compiled_module.call
-                            recursively_apply_fns = getattr(
-                                compiled_module, "recursively_apply_fns", None
+                            compiled_fn_runner = getattr(
+                                compiled_module, "runner", None
                             )
 
                     num_bytes, nodes_num_elem, node_runtimes = graph.count_bytes()
@@ -1416,7 +1416,7 @@ class _InProcessFxCompile(FxCompile):
                         inputs_to_check,
                         runnable_graph_str,
                         inductor_post_grad_graph_str,
-                        recursively_apply_fns,
+                        compiled_fn_runner,
                     )
 
 


### PR DESCRIPTION
When CompiledFxGraph is deallocated, its cudagraphifed fn (i.e., `current_callable`) is expected to also be deallocated.
Without graph partition, this is true since the cudagraphified fn is only refered by compiled_fx_graph.current_callable.

However, with graph partition, runner.partitions hold cudagraphified fns while compiled_fx_graph.current_callable holds the runner.call. Thus the cudagraphied fn may not be deallocated when CompiledFxGraph is deallocated. This leads to errors in several unit tests (e.g., test_unaligned_static_input_no_cudagraphs and test_unaligned_static_input_non_trees).

In this PR, we also clean up runner.partitions when CompiledFxGraph is deallocated. This fixes the issue.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov