### PR TITLE
[vec128] Fix fmsub NEON defintion

### DIFF
--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -87,6 +87,10 @@ test_libtorch() {
   fi
 }
 
+run_cpp_tests() {
+  ./bin/vec_test_all_types_DEFAULT
+}
+
 test_custom_backend() {
   print_cmake_info
 
@@ -308,6 +312,7 @@ elif [[ $TEST_CONFIG == *"perf_smoketest"* ]]; then
 elif [[ $NUM_TEST_SHARDS -gt 1 ]]; then
   test_python_shard "${SHARD_NUMBER}"
   if [[ "${SHARD_NUMBER}" == 1 ]]; then
+    run_cpp_tests
     test_libtorch
     test_custom_script_ops
   elif [[ "${SHARD_NUMBER}" == 2 ]]; then

--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -87,10 +87,6 @@ test_libtorch() {
   fi
 }
 
-run_cpp_tests() {
-  ./bin/vec_test_all_types_DEFAULT
-}
-
 test_custom_backend() {
   print_cmake_info
 
@@ -312,7 +308,6 @@ elif [[ $TEST_CONFIG == *"perf_smoketest"* ]]; then
 elif [[ $NUM_TEST_SHARDS -gt 1 ]]; then
   test_python_shard "${SHARD_NUMBER}"
   if [[ "${SHARD_NUMBER}" == 1 ]]; then
-    run_cpp_tests
     test_libtorch
     test_custom_script_ops
   elif [[ "${SHARD_NUMBER}" == 2 ]]; then

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -540,7 +540,7 @@ Vectorized<float> inline fmadd(const Vectorized<float>& a, const Vectorized<floa
 
 template <>
 Vectorized<float> inline fmsub(const Vectorized<float>& a, const Vectorized<float>& b, const Vectorized<float>& c) {
-  return Vectorized<float>(vfmsq_f32(c, a, b));
+  return Vectorized<float>(vnegq_f32(vfmsq_f32(c, a, b)));
 }
 
 inline Vectorized<float> Vectorized<float>::erf() const{

--- a/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h
@@ -582,7 +582,7 @@ Vectorized<c10::Half> inline fmsub(
     const Vectorized<c10::Half>& b,
     const Vectorized<c10::Half>& c) {
 #ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
-  return Vectorized<c10::Half>(vfmsq_f16(c, a, b));
+  return Vectorized<c10::Half>(vnegq_f16(vfmsq_f16(c, a, b)));
 #else
   return a * b - c;
 #endif


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152075

As reported in https://github.com/pytorch/pytorch/issues/149292, according to manual, `vfmsq_f32` implements `c - a * b` rather than `a * b - c`, so it's call must be prefixed with `vnegq_f32`

Also, adjust the tests to use OpMath for FMA computation to avoid accuracy error accumulation due to non-fused multiply-and-add over lower precision dtypes

Note that `Vectorized::fmsub` is not currently instantiated anywhere, so it could safely remain broken

TODO:
 - Enable C++ testing on MacOS and/or aarch64 platforms (right now Mac tests are build without C++ tests)

Fixes https://github.com/pytorch/pytorch/issues/149292


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168