### PR TITLE
Adding torch.ops.fbgemm to whitelist in GraphPickler

### DIFF
--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -407,7 +407,7 @@ class _OpPickleData:
             type["_OpOverloadPickleData"], type["_OpOverloadPacketPickleData"]
         ],
     ) -> "_OpPickleData":
-        if not name.startswith("torch.ops.aten"):  # TODO: What's the full list?
+        if not name.startswith(("torch.ops.aten", "torch.ops.fbgemm")):  # TODO: What's the full list?
             from torch._inductor.codecache import BypassFxGraphCache
 
             raise BypassFxGraphCache(f"Unable to pickle non-standard op: {name}")


### PR DESCRIPTION
As title, this is tested by running on the model see D73553912 as an example. The only difference is the module name.

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv