### PR TITLE
Adding fbgemm to allowlist

### DIFF
--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -4,6 +4,7 @@ import io
 import pickle
 from abc import abstractmethod
 from typing import Any, Callable, NewType, Optional, TypeVar, Union
+from typing_extensions import override, Self
 
 import torch
 import torch.utils._pytree as pytree
@@ -17,7 +18,6 @@ from torch._subclasses.meta_utils import (
 from torch.fx.experimental.sym_node import SymNode
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.utils._mode_utils import no_dispatch
-from typing_extensions import override, Self
 
 
 _SymNodeT = TypeVar("_SymNodeT", torch.SymInt, torch.SymFloat)

--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -4,7 +4,6 @@ import io
 import pickle
 from abc import abstractmethod
 from typing import Any, Callable, NewType, Optional, TypeVar, Union
-from typing_extensions import override, Self
 
 import torch
 import torch.utils._pytree as pytree
@@ -18,6 +17,7 @@ from torch._subclasses.meta_utils import (
 from torch.fx.experimental.sym_node import SymNode
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.utils._mode_utils import no_dispatch
+from typing_extensions import override, Self
 
 
 _SymNodeT = TypeVar("_SymNodeT", torch.SymInt, torch.SymFloat)
@@ -307,9 +307,7 @@ class _TorchNumpyPickleData:
 
 class _GraphModulePickleData:
     @classmethod
-    def reduce_helper(
-        cls, pickler: GraphPickler, obj: torch.fx.GraphModule
-    ) -> tuple[
+    def reduce_helper(cls, pickler: GraphPickler, obj: torch.fx.GraphModule) -> tuple[
         Callable[[Self, _UnpickleState], torch.fx.GraphModule],
         tuple[Self, _UnpickleStateToken],
     ]:
@@ -407,7 +405,9 @@ class _OpPickleData:
             type["_OpOverloadPickleData"], type["_OpOverloadPacketPickleData"]
         ],
     ) -> "_OpPickleData":
-        if not name.startswith(("torch.ops.aten", "torch.ops.fbgemm")):  # TODO: What's the full list?
+        if not name.startswith(
+            ("torch.ops.aten", "torch.ops.fbgemm")
+        ):  # TODO: What's the full list?
             from torch._inductor.codecache import BypassFxGraphCache
 
             raise BypassFxGraphCache(f"Unable to pickle non-standard op: {name}")

--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -307,7 +307,9 @@ class _TorchNumpyPickleData:
 
 class _GraphModulePickleData:
     @classmethod
-    def reduce_helper(cls, pickler: GraphPickler, obj: torch.fx.GraphModule) -> tuple[
+    def reduce_helper(
+        cls, pickler: GraphPickler, obj: torch.fx.GraphModule
+    ) -> tuple[
         Callable[[Self, _UnpickleState], torch.fx.GraphModule],
         tuple[Self, _UnpickleStateToken],
     ]:

--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -407,7 +407,7 @@ class _OpPickleData:
             type["_OpOverloadPickleData"], type["_OpOverloadPacketPickleData"]
         ],
     ) -> "_OpPickleData":
-        if not name.startswith("torch.ops.aten"):  # TODO: What's the full list?
+        if not name.startswith(("torch.ops.aten", "torch.ops.fbgemm")):  # TODO: What's the full list?
             from torch._inductor.codecache import BypassFxGraphCache
 
             raise BypassFxGraphCache(f"Unable to pickle non-standard op: {name}")


### PR DESCRIPTION
Adding `torch.ops.fbgemm` to GraphPickler's allowlist. Otherwise, the fx graph module containing `fbgemm` node will return "Unable to pickle non-standard op" error.

The validation is done on the model and the difference appears only on the graph name not the node.

cc @aorenste @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv