### PR TITLE
Revert "Add a warning when a tensor with requires_grad=True is converted to a scalar (#143261)"

### DIFF
--- a/aten/src/ATen/native/Scalar.cpp
+++ b/aten/src/ATen/native/Scalar.cpp
@@ -11,17 +11,11 @@
 #include <ATen/ops/item_native.h>
 #endif
 
-#include <torch/csrc/autograd/grad_mode.h>
-
 namespace at::native {
 
 Scalar item(const Tensor& self) {
   auto numel = self.sym_numel();
   TORCH_CHECK(numel == 1, "a Tensor with ", numel, " elements cannot be converted to Scalar");
-  if (torch::autograd::GradMode::is_enabled() && self.requires_grad()) {
-    TORCH_WARN_ONCE("Converting a tensor with requires_grad=True to a scalar may lead to unexpected behavior.\n"
-                    "Consider using tensor.detach() first.");
-  }
   if (self.is_sparse()) {
     if (self._nnz() == 0) return Scalar(0);
     if (self.is_coalesced()) return at::_local_scalar_dense(self._values());

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10829,23 +10829,6 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
     def test_bf16_supported_on_cpu(self):
         self.assertFalse(torch.cuda.is_bf16_supported())
 
-    def test_tensor_with_grad_to_scalar_warning(self) -> None:
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-
-            x = torch.tensor(2.0, requires_grad=True)
-            math.pow(x, 3)  # calling this results in a warning
-
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[0].category, UserWarning))
-            self.assertIn(
-                "Converting a tensor with requires_grad=True to a scalar may lead to unexpected behavior.",
-                str(w[0].message)
-            )
-
-            _ = math.pow(x, 3)  # calling it again does not result in a second warning
-            self.assertEqual(len(w), 1)
 
 # The following block extends TestTorch with negative dim wrapping tests
 # FIXME: replace these with OpInfo sample inputs or systemic OpInfo tests


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This reverts commit 515b45e5693dbf9dd58d8472806cbe5f49e43074.

Reverted https://github.com/pytorch/pytorch/pull/143261 on behalf of https://github.com/clee2000 due to failing internal tests D72135661 ([comment](https://github.com/pytorch/pytorch/pull/143261#issuecomment-2767531682))