### PR TITLE
[Accelerator] Add `torch.acc.set_default_device()` and `torch.acc.device_module()`

### DIFF
--- a/docs/source/accelerator.rst
+++ b/docs/source/accelerator.rst
@@ -10,6 +10,7 @@ torch.accelerator
     device_count
     is_available
     current_accelerator
+    set_default_device
     set_device_index
     set_device_idx
     current_device_index
@@ -18,3 +19,4 @@ torch.accelerator
     current_stream
     synchronize
     device_index
+    device_module

--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -156,6 +156,25 @@ class TestAccelerator(TestCase):
         ):
             event1.elapsed_time(event2)
 
+    def test_default_device(self):
+        cur_acc = torch.accelerator.current_accelerator(check_available=True)
+        self.assertIsNotNone(cur_acc)
+
+        # Tensors allocated on CPU by default
+        t = torch.randn(10)
+        self.assertEqual(t.device.type, "cpu")
+
+        # Tensors allocated on the current accelerator
+        torch.accelerator.set_default_device()
+        t = torch.randn(20)
+        self.assertEqual(t.device.type, cur_acc.type)
+        self.assertEqual(t.device.type, torch.get_default_device().type)
+
+        # Tensors allocated in a context manager
+        with torch.device("cpu"):
+            t = torch.randn(30)
+            self.assertEqual(t.device.type, "cpu")
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -45,11 +45,6 @@ def set_default_device() -> None:
 def device_module() -> Optional[ModuleType]:
     r"""
     Return the module associated with the current :ref:`accelerator<accelerators>`.
-
-    Example:
-        >>> acc_mod = torch.accelerator.device_module()
-        >>> acc_mod.device_count() if acc_mod else 0
-        0
     """
 
     acc = current_accelerator()

--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -48,7 +48,7 @@ def device_module() -> Optional[ModuleType]:
 
     Example:
         >>> acc_mod = torch.accelerator.device_module()
-        >>> acc_mod.device_count()
+        >>> acc_mod.device_count() if acc_mod else -1
         1
     """
 

--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -48,8 +48,8 @@ def device_module() -> Optional[ModuleType]:
 
     Example:
         >>> acc_mod = torch.accelerator.device_module()
-        >>> acc_mod.device_count() if acc_mod else -1
-        1
+        >>> acc_mod.device_count() if acc_mod else 0
+        0
     """
 
     acc = current_accelerator()


### PR DESCRIPTION
### Changes

Users may want to allocate tensors to the current accelerator, but `torch.set_default_device(torch.accelerator.current_accelerator())` is too long, so `torch.accelerator.set_default_device` (or `enable_default_device`?) may be a good choice.

### Test

```python
python test/test_accelerator.py
```

If you have any ideas, please let me know. Thanks! cc: @albanD @guangyey @FFFrog 