### PR TITLE
Relax tolerance on test_aot_autograd_exhaustive_matmul_cpu_float32 without MKL

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -74,6 +74,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     skipIfRocm,
     TestCase,
+    TEST_MKL,
     xfail_inherited_tests,
     xfailIfTorchDynamo,
 )
@@ -6655,6 +6656,12 @@ aot_autograd_failures = {
     # conv2d sometimes nondeterministic in this config?
     decorate("nn.functional.conv2d", decorator=unittest.skipIf(IS_ARM64, "flaky")),
 }
+
+if not TEST_MKL:
+    aot_autograd_failures.update({
+        decorate("matmul", decorator=toleranceOverride({torch.float32: tol(atol=6e-05, rtol=4e-06)})),
+        decorate("__rmatmul__", decorator=toleranceOverride({torch.float32: tol(atol=6e-05, rtol=4e-06)})),
+    })
 
 symbolic_aot_autograd_failures = {
     xfail("combinations", ""),  # aten.masked_select.default

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -73,8 +73,8 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     skipIfRocm,
-    TestCase,
     TEST_MKL,
+    TestCase,
     xfail_inherited_tests,
     xfailIfTorchDynamo,
 )
@@ -6658,10 +6658,22 @@ aot_autograd_failures = {
 }
 
 if not TEST_MKL:
-    aot_autograd_failures.update({
-        decorate("matmul", decorator=toleranceOverride({torch.float32: tol(atol=6e-05, rtol=4e-06)})),
-        decorate("__rmatmul__", decorator=toleranceOverride({torch.float32: tol(atol=6e-05, rtol=4e-06)})),
-    })
+    aot_autograd_failures.update(
+        {
+            decorate(
+                "matmul",
+                decorator=toleranceOverride(
+                    {torch.float32: tol(atol=6e-05, rtol=4e-06)}
+                ),
+            ),
+            decorate(
+                "__rmatmul__",
+                decorator=toleranceOverride(
+                    {torch.float32: tol(atol=6e-05, rtol=4e-06)}
+                ),
+            ),
+        }
+    )
 
 symbolic_aot_autograd_failures = {
     xfail("combinations", ""),  # aten.masked_select.default


### PR DESCRIPTION
When e.g. OpenBLAS is used instead of MKL the differences get to large:
> Greatest absolute difference: 5.91278076171875e-05 at index (7,) (up to 1e-05 allowed)
> Greatest relative difference: 3.468156592134619e-06 at index (7,) (up to 1.3e-06 allowed)

I traced some of the matmul operations and there are differences of around 8e-6 between MKL and OpenBLAS but I haven't found where exactly the backward pass is calculated which is where the actual differences arise. So I couldn't check if there is some difference in the low-level BLAS function used by the autograd.

However it seems odd that there is a difference at all: For the MKL case it seems to be zero up to the accuracy shown by Python.

So it seems the AOT compilation has some differences when MKL is not available. 

Maybe this is also the reason why it fails for ARM and hence the test is skipped there. Maybe @zou3519 knows more as he introduced those skip markers in https://github.com/pytorch/pytorch/pull/85565

Is there any documentation how and where `matmul_backward(_out)` is generated and how AOT transforms it with and without MKL?