### PR TITLE
Unify how we create random inputs for auto-tuning

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -348,7 +348,7 @@ class BenchmarkRequest:
         # the kernel name defined in the module
         self.kernel_name = kernel_name
 
-        if not isinstance(input_tensor_meta, list):
+        if not isinstance(input_tensor_meta, (tuple, list)):
             input_tensor_meta = [input_tensor_meta]
         self.input_tensor_meta = input_tensor_meta
 

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -358,7 +358,7 @@ class BenchmarkRequest:
                 assert all(
                     getattr(output_tensor_meta[0], attr) == getattr(x, attr)
                     for x in output_tensor_meta
-                    for attr in ["device", "dtype", "sizes", "strides", "offset"]
+                    for attr in ["device", "dtype", "size", "strides", "offset"]
                 )
             output_tensor_meta = output_tensor_meta[0]
         self.output_tensor_meta = output_tensor_meta

--- a/torch/_inductor/codegen/cpp_template.py
+++ b/torch/_inductor/codegen/cpp_template.py
@@ -11,7 +11,8 @@ from unittest.mock import patch
 import sympy
 
 from .. import codecache, config, ir
-from ..autotune_process import CppBenchmarkRequest, TensorMeta
+from ..autotune_process import CppBenchmarkRequest
+from ..select_algorithm import TensorMeta
 from ..utils import IndentedBuffer, Placeholder, unique
 from ..virtualized import V
 from .common import KernelTemplate

--- a/torch/_inductor/codegen/cuda/cuda_template.py
+++ b/torch/_inductor/codegen/cuda/cuda_template.py
@@ -11,8 +11,9 @@ import sympy
 import torch
 from torch._logging import getArtifactLogger
 
-from ...autotune_process import CUDABenchmarkRequest, TensorMeta
+from ...autotune_process import CUDABenchmarkRequest
 from ...ir import Buffer, CUDATemplateBuffer, IRNode, Layout
+from ...select_algorithm import TensorMeta
 from ...utils import IndentedBuffer, unique
 from ...virtualized import V
 from ..common import KernelTemplate

--- a/torch/_inductor/codegen/rocm/rocm_benchmark_request.py
+++ b/torch/_inductor/codegen/rocm/rocm_benchmark_request.py
@@ -8,16 +8,14 @@ from typing import Any, Callable, Optional, TYPE_CHECKING, Union
 
 import torch
 from torch._inductor import config
-from torch._inductor.autotune_process import (
-    BenchmarkRequest,
-    GPUDeviceBenchmarkMixin,
-    TensorMeta,
-)
+from torch._inductor.autotune_process import BenchmarkRequest, GPUDeviceBenchmarkMixin
 from torch._inductor.codecache import DLLWrapper, ROCmCodeCache
 
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+    from torch._inductor.select_algorithm import TensorMeta
 
 
 log = logging.getLogger(__name__)

--- a/torch/_inductor/codegen/rocm/rocm_template.py
+++ b/torch/_inductor/codegen/rocm/rocm_template.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 from typing import Any, Optional
 from unittest.mock import patch
 
-from ...autotune_process import TensorMeta
 from ...ir import Buffer, IRNode, Layout
+from ...select_algorithm import TensorMeta
 from ...utils import IndentedBuffer, unique
 from ...virtualized import V
 from ..common import KernelTemplate


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152115

Summary: We're creating autotune inputs slightly differently when autotuning in-process vs. in a subprocess: One implementation is in TensorMeta.to_tensor() and another in AlgorithmSelectorCache.benchmark_example_value. Move the TensorMeta definition to select_algorith.py and call that implementation from AlgorithmSelectorCache.benchmark_example_value().

Test Plan: Existing unit tests

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov