### PR TITLE
Remove some instances of uninitialized memory use

### DIFF
--- a/test/cpp/lazy/test_ir.cpp
+++ b/test/cpp/lazy/test_ir.cpp
@@ -82,7 +82,7 @@ TEST(IrTest, MetaDataTest) {
   dummySourceLocation.file = "file";
   dummySourceLocation.function = "function";
   dummySourceLocation.line = 10;
-  GetPythonFramesFunction() = [&]() -> std::vector<SourceLocation> {
+  GetPythonFramesFunction() = [=]() -> std::vector<SourceLocation> {
     return {dummySourceLocation};
   };
   node = MakeNode<TestLeafNode>(1);

--- a/torch/csrc/lazy/core/debug_util.cpp
+++ b/torch/csrc/lazy/core/debug_util.cpp
@@ -51,6 +51,8 @@ std::unordered_set<std::string>* LoadExperiments() {
 static std::vector<SourceLocation> NoPythonFrames() {
   SourceLocation dummy_loc;
   dummy_loc.file = "No Python Frames";
+  dummy_loc.function = "";
+  dummy_loc.line = 0;
   return {dummy_loc};
 }
 


### PR DESCRIPTION
Two changes, one caught by MSAN, the other caught because it was blowing up tests.

The change in test_ir fixes a use-after-free by capturing the variable being closed over by value.

The change in debug_util initializes all values for the SourceLocation object.