### PR TITLE
[ONNX] Add group_norm support from opset 21

### DIFF
--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -542,6 +542,20 @@ class DynamoExporterTest(common_utils.TestCase):
         # make sre the naming is working
         self.assertEqual(onnx_program.model.graph.inputs[0].shape[0], "dx")
 
+    def test_group_norm_opset_21(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return torch.nn.functional.group_norm(x, 4)
+
+        x = torch.randn(1, 4, 4, 4, dtype=torch.float32)
+        onnx_program = self.export(Model(), (x,))
+        # TODO(after ort support): As of ONNX Runtime 1.22, the operator is not implemented yet.
+        # call assert_onnx_program after ort support
+        self.assertIn(
+            "GroupNormalization",
+            [node.op_type for node in onnx_program.model.graph],
+        )
+
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -548,7 +548,7 @@ class DynamoExporterTest(common_utils.TestCase):
                 return torch.nn.functional.group_norm(x, 4)
 
         x = torch.randn(1, 4, 4, 4, dtype=torch.float32)
-        onnx_program = self.export(Model(), (x,))
+        onnx_program = self.export(Model(), (x,), opset_version=21)
         # TODO(after ort support): As of ONNX Runtime 1.22, the operator is not implemented yet.
         # call assert_onnx_program after ort support
         self.assertIn(

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -5,12 +5,12 @@
 
 from __future__ import annotations
 
-import math
+from typing import Optional
 
-from onnxscript.onnx_opset import opset20 as op20
+from onnxscript.onnx_opset import opset20 as op20, opset21 as op21
 
 import torch
-from torch.onnx._internal.exporter._torchlib._tensor_typing import TReal
+from torch.onnx._internal.exporter._torchlib._tensor_typing import TFloat, TReal
 from torch.onnx._internal.exporter._torchlib._torchlib_registry import onnx_impl
 
 
@@ -24,3 +24,19 @@ def aten_gelu_opset20(
 ) -> TReal:
     """gelu(Tensor self, *, bool approximate=False) -> Tensor"""
     return op20.Gelu(self, approximate=approximate)
+
+
+@onnx_impl(aten.group_norm.default, trace_only=True, opset_introduced=21)
+def aten_group_norm(
+    input: TFloat,
+    num_groups: int,
+    weight: Optional[TFloat] = None,
+    bias: Optional[TFloat] = None,
+    eps: float = 1e-05,
+    cudnn_enabled: bool = True,
+) -> TFloat:
+    """group_norm(Tensor input, int num_groups, Tensor? weight=None, Tensor? bias=None, float eps=1e-05, bool cudnn_enabled=True) -> Tensor"""
+
+    return op21.GroupNormalization(
+        input, weight, bias, epsilon=eps, num_groups=num_groups
+    )

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -40,9 +40,9 @@ def aten_group_norm(
 
     c = op21.Shape(input, start=1, end=2)
     if weight is None:
-        weight = op21.ConstantOfShape(c, value=ir.tensor([1.0], dtype=input.dtype))
+        weight = op21.ConstantOfShape(c, value=ir.tensor(1.0, dtype=input.dtype))
     if bias is None:
-        bias = op21.ConstantOfShape(c, value=ir.tensor([0.0], dtype=input.dtype))
+        bias = op21.ConstantOfShape(c, value=ir.tensor(0.0, dtype=input.dtype))
     return op21.GroupNormalization(
         input, weight, bias, epsilon=eps, num_groups=num_groups
     )

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 from typing import Optional
 
 from onnxscript.onnx_opset import opset20 as op20, opset21 as op21
-from torch.onnx._internal._lazy_import import onnxscript_ir as ir
 
 import torch
+from torch.onnx._internal._lazy_import import onnxscript_ir as ir
 from torch.onnx._internal.exporter._torchlib._tensor_typing import TFloat, TReal
 from torch.onnx._internal.exporter._torchlib._torchlib_registry import onnx_impl
 

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Optional
 
 from onnxscript.onnx_opset import opset20 as op20, opset21 as op21
+from torch.onnx._internal._lazy_import import onnxscript_ir as ir
 
 import torch
 from torch.onnx._internal.exporter._torchlib._tensor_typing import TFloat, TReal
@@ -37,6 +38,11 @@ def aten_group_norm(
 ) -> TFloat:
     """group_norm(Tensor input, int num_groups, Tensor? weight=None, Tensor? bias=None, float eps=1e-05, bool cudnn_enabled=True) -> Tensor"""
 
+    c = op21.Shape(input, start=1, end=2)
+    if weight is None:
+        weight = op21.ConstantOfShape(c, value=ir.tensor([1.0], dtype=input.dtype))
+    if bias is None:
+        bias = op21.ConstantOfShape(c, value=ir.tensor([0.0], dtype=input.dtype))
     return op21.GroupNormalization(
         input, weight, bias, epsilon=eps, num_groups=num_groups
     )


### PR DESCRIPTION
I didn't run the model in test because ORT doesn't have the op yet. Nevertheless it should be leveraged for newer opset versions.