### PR TITLE
Reducer: add check on received data to avoid segfault

### DIFF
--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -1845,6 +1845,11 @@ void Reducer::sync_bucket_indices(
   indices_accessor_Index = 0;
   for (const auto i : c10::irange(num_buckets)) {
     const auto& bucket_size = bucket_sizes_accessor[static_cast<int64_t>(i)];
+    TORCH_CHECK_WITH(
+        IndexError,
+        bucket_size >= 0 && bucket_size <= indices_accessor.size(0),
+        "received invalid bucket_size, was abort called?");
+
     std::vector<size_t> bucket;
     bucket.reserve(bucket_size);
     for (const auto j : c10::irange(bucket_size)) {


### PR DESCRIPTION
When ncclCommAbort is called it may return invalid/corrupted data to the reducer. This adds a check so we don't read past the end of the tensors leading to a segfault.

While this looks like it could be a security issue it actually isn't since we only read past the end of the buffer, not write.

Fixes #149418

Test plan:

https://gist.github.com/d4l3k/b47c2c95cf9c37e78069e19f1b6ed2c6

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab