### PR TITLE
Unify how we create random inputs for auto-tuning

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -468,7 +468,7 @@ class BenchmarkRequest:
                 assert all(
                     getattr(output_tensor_meta[0], attr) == getattr(x, attr)
                     for x in output_tensor_meta
-                    for attr in ["device", "dtype", "size", "strides", "offset"]
+                    for attr in ["device", "dtype", "size", "stride", "offset"]
                 )
             output_tensor_meta = output_tensor_meta[0]
         self.output_tensor_meta = output_tensor_meta


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #152502
* __->__ #152147

Summary: We're creating autotune inputs slightly differently when autotuning in-process vs. in a subprocess: One implementation is in TensorMeta.to_tensor() and another in AlgorithmSelectorCache.benchmark_example_value. Update the TensorMeta logic to be consistent with AlgorithmSelectorCache.benchmark_example_value() and call it from AlgorithmSelectorCache.benchmark_example_value() instead.

Test Plan: Existing unit tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov