### PR TITLE
[cutlass backend] add addmm and bmm for cutlass backend benchmark

### DIFF
--- a/benchmarks/inductor_backends/cutlass.py
+++ b/benchmarks/inductor_backends/cutlass.py
@@ -36,13 +36,22 @@ UNITS = {
 }
 PERF_OVER_ATEN_STR: str = "perf_over_aten (%)"
 
-OP_NAMES = ["mm"]
+OP_NAMES = [
+    "mm",
+    "addmm",
+    "bmm",
+]
 
 SHAPES = [
     # M, N, K
     (1024, 1024, 1024),
     (2048, 2048, 2048),
     (8192, 8192, 8192),
+]
+
+BATCH_SIZES = [
+    # For non-bmm testing, still need to specify something
+    8,
 ]
 
 DTYPES = [
@@ -59,10 +68,9 @@ ENABLE_PERSISTENT_TMA_MATMULS = [
 # cutlass knobs
 CUTLASS_INSTANTIATION_LEVELS = [
     "0",
-    "1111",
-    "2222",
-    # not ready yet
-    # "3333",
+    # "1111",
+    # "2222",
+    "3333",
 ]
 
 
@@ -137,12 +145,18 @@ class ExperimentGroupConfig:
     op_name: str
     shape: tuple[int, int, int]
     dtype: torch.dtype
+    batch_size: int
 
     experiments: list[ExperimentConfig] = field(default_factory=list)
 
     def name(self) -> str:
         M, N, K = self.shape
-        sizes = f"({M}x{K}, {K}x{N})"
+        B = self.batch_size
+        sizes = (
+            f"(BS: {B}, {M}x{K}, {K}x{N})"
+            if self.op_name == "bmm"
+            else f"({M}x{K}, {K}x{N})"
+        )
         return f"{self.op_name} {sizes} {self.dtype}"
 
 
@@ -164,17 +178,26 @@ class ExperimentGroup:
 
 def get_inputs(
     config: ExperimentGroupConfig,
-) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+) -> tuple[torch.Tensor, ...]:
     op_name = config.op_name
     M, N, K = config.shape
+    batch_size = config.batch_size
     dtype = config.dtype
     device = torch.device("cuda")
 
     if op_name == "mm":
         A = torch.randn(M, K, dtype=dtype, device=device)
         B = torch.randn(N, K, dtype=dtype, device=device).t()
-        C = None
-        return A, B, C
+        return A, B
+    elif op_name == "addmm":
+        A = torch.randn(M, K, dtype=dtype, device=device)
+        B = torch.randn(N, K, dtype=dtype, device=device).t()
+        C = torch.randn(N, dtype=dtype, device=device)
+        return C, A, B
+    elif op_name == "bmm":
+        A = torch.randn(batch_size, M, K, dtype=dtype, device=device)
+        B = torch.randn(batch_size, K, N, dtype=dtype, device=device).permute(0, 2, 1)
+        return A, B
     else:
         raise ValueError(f"Unknown op {op_name}")
 
@@ -182,7 +205,7 @@ def get_inputs(
 def run_single_experiment_group(
     group_config: ExperimentGroupConfig,
 ) -> list[ExperimentResults]:
-    A, B, C = get_inputs(group_config)
+    inputs = get_inputs(group_config)
     op = getattr(torch, group_config.op_name)
 
     results = []
@@ -194,7 +217,7 @@ def run_single_experiment_group(
 
         start_time = time.perf_counter()
         try:
-            _ = compiled_op(A, B)
+            _ = compiled_op(*inputs)
         except Exception as e:
             log.warning(f"Benchmark config {config.name()} failed: {e}")  # noqa: G004
             results.append(
@@ -209,8 +232,7 @@ def run_single_experiment_group(
 
         forward_time = benchmark_torch_function_in_microseconds(
             compiled_op,
-            A,
-            B,
+            *inputs,
         )
 
         results.append(
@@ -230,13 +252,20 @@ def generate_experiment_groups(
     dtypes: list[torch.dtype],
     enable_persistent_tma_matmuls: list[bool],
     cutlass_instantiation_levels: list[str],
+    batch_sizes: list[int],
 ) -> list[ExperimentGroupConfig]:
     groups = []
-    for op_name, shape, dtype in itertools.product(op_names, shapes, dtypes):
+    for (
+        op_name,
+        shape,
+        dtype,
+        batch_size,
+    ) in itertools.product(op_names, shapes, dtypes, batch_sizes):
         group = ExperimentGroupConfig(
             op_name=op_name,
             shape=shape,
             dtype=dtype,
+            batch_size=batch_size,
         )
         experiments = generate_experiment_configs(
             enable_persistent_tma_matmuls, cutlass_instantiation_levels
@@ -304,22 +333,25 @@ def calculate_table_data(results: list[ExperimentResults]) -> dict:
     return table_data
 
 
-def print_results(experiment_groups: list[ExperimentGroup]):
+def get_printable_results(experiment_groups: list[ExperimentGroup]) -> list[str]:
     edge_over_aten = defaultdict(list)
+    output = []
+
     for experiment_group in experiment_groups:
         group_config_name = experiment_group.config.name()
-        print(f"\nExperiment group: {group_config_name}")
+        output.append(f"\nExperiment group: {group_config_name}")
 
         table_data = calculate_table_data(experiment_group.results)
         for name, edge in zip(table_data["name"], table_data[PERF_OVER_ATEN_STR]):
             edge_over_aten[name].append(edge)
-        print(tabulate(table_data, headers="keys", tablefmt="pretty", floatfmt=".3f"))
+        output.append(
+            tabulate(table_data, headers="keys", tablefmt="pretty", floatfmt=".3f")
+        )
 
     if "aten" in edge_over_aten:
-        print("\nAverage edge over aten (max(-edge, 0), higher is better):")
+        output.append("\nAverage edge over aten (max(-edge, 0), higher is better):")
         for name in edge_over_aten:
             if name != "aten":
-                # calculate average edge over aten, but need to exclude inf
                 values = [
                     max(-v, 0.0)
                     for v in edge_over_aten[name]
@@ -327,28 +359,38 @@ def print_results(experiment_groups: list[ExperimentGroup]):
                 ]
                 valid_count = len(values)
                 average_edge = sum(values) / valid_count if values else "No valid data"
-                print(f"{name}: {average_edge} (from {valid_count} valid values)")
+                output.append(
+                    f"{name}: {average_edge} (from {valid_count} valid values)"
+                )
+        output.append("\n")
+
+    return "\n".join(output)
 
 
 def main():
     seed = 123
     torch.manual_seed(seed)
     results = []
-    for group_config in tqdm(
+    log.info("Starting benchmarking...")
+    configs = list(
         generate_experiment_groups(
             OP_NAMES,
             SHAPES,
             DTYPES,
             ENABLE_PERSISTENT_TMA_MATMULS,
             CUTLASS_INSTANTIATION_LEVELS,
+            BATCH_SIZES,
         )
-    ):
-        group_results = run_single_experiment_group(group_config)
+    )
+    for i, group_config in enumerate(tqdm(configs)):
+        group_results = run_single_experiment_group(group_config)  # noqa: G004
         results.append(
             ExperimentGroup(config=group_config, results=group_results),
         )
-
-    print_results(results)
+        log.info(f"\nINTERMEDIATE results: {i}/{len(configs)}")  # noqa: G004
+        log.info(get_printable_results(results))
+    print("\nFINAL results...")
+    print(get_printable_results(results))
 
 
 if __name__ == "__main__":

--- a/benchmarks/inductor_backends/cutlass.py
+++ b/benchmarks/inductor_backends/cutlass.py
@@ -196,7 +196,7 @@ def get_inputs(
         return C, A, B
     elif op_name == "bmm":
         A = torch.randn(batch_size, M, K, dtype=dtype, device=device)
-        B = torch.randn(batch_size, K, N, dtype=dtype, device=device).permute(0, 2, 1)
+        B = torch.randn(batch_size, N, K, dtype=dtype, device=device).permute(0, 2, 1)
         return A, B
     else:
         raise ValueError(f"Unknown op {op_name}")

--- a/benchmarks/inductor_backends/cutlass.py
+++ b/benchmarks/inductor_backends/cutlass.py
@@ -219,7 +219,12 @@ def run_single_experiment_group(
         try:
             _ = compiled_op(*inputs)
         except Exception as e:
-            log.warning(f"Benchmark config {config.name()} failed: {e}")  # noqa: G004
+            import traceback
+
+            log.warning(
+                f"Benchmark config {config.name()} failed: {e}, "  # noqa: G004
+                f"traceback: {traceback.format_exc()}"
+            )
             results.append(
                 ExperimentResults(
                     name=config.name(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152163

Copying what @kadeng did.

```
FINAL results...

Experiment group: bmm (BS: 8, 1024x1024, 1024x1024) torch.float16
+-----------------------+--------------------+----------------------+---------------------+
|         name          | forward_time (us)  | compilation_time (s) | perf_over_aten (%)  |
+-----------------------+--------------------+----------------------+---------------------+
|         aten          | 44.454172253608704 |  3.0991086587309837  |         NA          |
|        triton         | 44.06978189945221  | 0.07496077567338943  | -0.8646890374284049 |
| triton_persistent_tma | 43.598245829343796 | 0.06154991965740919  | -1.9254130284597197 |
|  cutlass_lvl_default  | 39.91834074258804  | 0.056073310784995556 | -10.20338762612423  |
+-----------------------+--------------------+----------------------+---------------------+

Experiment group: bmm (BS: 8, 1024x1024, 1024x1024) torch.bfloat16
+-----------------------+-------------------+----------------------+---------------------+
|         name          | forward_time (us) | compilation_time (s) | perf_over_aten (%)  |
+-----------------------+-------------------+----------------------+---------------------+
|         aten          | 49.05610531568527 |  0.160279156640172   |         NA          |
|        triton         | 43.97720843553543 |  0.0660805031657219  | -10.353241145961718 |
| triton_persistent_tma | 43.94153505563736 | 0.061738294549286366 | -10.425960697724962 |
|  cutlass_lvl_default  | 40.2066633105278  | 0.034127906896173954 | -18.039430460713596 |
+-----------------------+-------------------+----------------------+---------------------+

Average edge over aten (max(-edge, 0), higher is better):
triton: 5.608965091695062 (from 2 valid values)
triton_persistent_tma: 6.175686863092341 (from 2 valid values)
cutlass_lvl_default: 14.121409043418913 (from 2 valid values)
```

Differential Revision: [D73625766](https://our.internmc.facebook.com/intern/diff/D73625766/)