### PR TITLE
Extend compute_global_tensor_shape to multi dimension sharding

### DIFF
--- a/test/distributed/tensor/test_utils.py
+++ b/test/distributed/tensor/test_utils.py
@@ -193,6 +193,25 @@ class UtilTest(DTensorTestBase):
             self.assertEqual(global_shape, dtensor.full_tensor().shape)
 
     @with_comms
+    def test_compute_global_tensor_shape_uneven(self):
+        device_mesh = init_device_mesh(self.device_type, (2, 2, 2))
+        local_shapes = [
+            (1, 3, 7),
+            (1, 3, 2),
+            (1, 2, 4),
+            (1, 2, 5),
+            (2, 4, 6),
+            (2, 4, 3),
+            (2, 1, 8),
+            (2, 1, 1),
+        ]
+        placement = [Shard(0), Shard(1), Shard(2)]
+        global_shape = compute_global_tensor_shape(
+            torch.Size(local_shapes[device_mesh.get_rank()]), device_mesh, placement
+        )
+        self.assertEqual(global_shape, torch.Size([3, 5, 9]))
+
+    @with_comms
     def test_compute_local_shape_and_global_offset_1D(self):
         one_d_placements = [[Shard(0)], [Replicate()]]
 

--- a/torch/distributed/tensor/_utils.py
+++ b/torch/distributed/tensor/_utils.py
@@ -317,7 +317,7 @@ def _compute_global_tensor_shape(
             sharded_dim_sum += sub_shape[shard_placement.dim]
         global_shape[shard_placement.dim] = sharded_dim_sum
     else:
-        raise RuntimeError(f"placement type {type(placements[0])} not supported!")
+        raise NotImplementedError(f"placement type {type(placements[0])} not supported.")
     return global_shape
 
 

--- a/torch/distributed/tensor/_utils.py
+++ b/torch/distributed/tensor/_utils.py
@@ -317,7 +317,9 @@ def _compute_global_tensor_shape(
             sharded_dim_sum += sub_shape[shard_placement.dim]
         global_shape[shard_placement.dim] = sharded_dim_sum
     else:
-        raise NotImplementedError(f"placement type {type(placements[0])} not supported.")
+        raise NotImplementedError(
+            f"placement type {type(placements[0])} not supported."
+        )
     return global_shape
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152166
* #152751

### Summary

`compute_global_tensor_shape` util all gathers shape of the local
tensors from all the ranks and then computes the shape of the global
DTensor based on the device mesh and the placements. Earlier this util
supported only 1D device mesh, extending the util to now support multi
dimension sharding.

Here we take a recursive approach to calculate the global shape via
a DFS on the device mesh.

### Test

`pytest test/distributed/tensor/test_utils.py`

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k