### PR TITLE
Fix instantiate_device_type_tests() for 3rd-party devices

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -728,15 +728,19 @@ def filter_desired_device_types(device_type_test_bases, except_for=None, only_fo
     # Replace your privateuse1 backend name with 'privateuse1'
     if is_privateuse1_backend_available():
         privateuse1_backend_name = torch._C._get_privateuse1_backend_name()
+
+        def func_replace(x: str):
+            return x.replace(privateuse1_backend_name, "privateuse1")
+
         except_for = (
-            ["privateuse1" if x == privateuse1_backend_name else x for x in except_for]
-            if except_for is not None
-            else None
+            ([func_replace(x) for x in except_for] if except_for is not None else None)
+            if not isinstance(except_for, str)
+            else func_replace(except_for)
         )
         only_for = (
-            ["privateuse1" if x == privateuse1_backend_name else x for x in only_for]
-            if only_for is not None
-            else None
+            ([func_replace(x) for x in only_for] if only_for is not None else None)
+            if not isinstance(only_for, str)
+            else func_replace(only_for)
         )
 
     if except_for:


### PR DESCRIPTION
For 3rd-party devices now, `` instantiate_device_type_tests()`` with explicitly passing ``str`` obj (rather than `List[str]/Tuple[str]`) to argument ``only_for`` or ``except_for`` would causes unexpected results. 

For example, if calling ``instantiate_device_type_tests(TestXXX, globals(), only_for="cpu")``, then it goes into [filter_desired_device_types()](https://github.com/pytorch/pytorch/blob/f38dae76ee8dccd60f99bbddb48f2520f436fa1a/torch/testing/_internal/common_device_type.py#L729) and results in ``only_for=['c', 'p', 'u']`` because ``only_for`` we passed is  a "cpu" string.

This PR fixes the above unexpected behavior for ``str`` case.

cc @albanD 
