### PR TITLE
Tighten tolerance of test_vmapvjp_linalg_tensorsolve_cpu_float32

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -1195,6 +1195,8 @@ class TestOperators(TestCase):
                 "linalg.householder_product",
                 {torch.float32: tol(atol=3e-04, rtol=9e-04)},
             ),
+            # Tighten tolerance to check for regressions of issue #114868
+            tol1("linalg.tensorsolve", {torch.float32: tol(atol=1e-4, rtol=1e-5)}),
             tol1(
                 "matrix_exp",
                 {torch.float32: tol(atol=5e-04, rtol=1e-04)},

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -1195,8 +1195,12 @@ class TestOperators(TestCase):
                 "linalg.householder_product",
                 {torch.float32: tol(atol=3e-04, rtol=9e-04)},
             ),
-            # Tighten tolerance to check for regressions of issue #114868
-            tol1("linalg.tensorsolve", {torch.float32: tol(atol=1e-4, rtol=1e-5)}),
+            # The CPU code uses the same algorithm for the batched vs unbatched case, so there should not be any differences.
+            # Use lowest possible tolerance (bounded by the minimum tolerance for float32 later) to check for regressions of issue #114868
+            tol1("linalg.tensorsolve",
+                {torch.float32: tol(atol=0, rtol=0)},
+                device_type='cpu',
+            ),
             tol1(
                 "matrix_exp",
                 {torch.float32: tol(atol=5e-04, rtol=1e-04)},


### PR DESCRIPTION
With the optimzation of `solve` using a transposed input this test fails to meet these tolerances but passes without.

@pytorchbot topic: not user facing