### PR TITLE
Add detailed triton kernel logging to tlparse

### DIFF
--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -628,7 +628,6 @@ def _create_aot_dispatcher_function(
 
     # Check flat_args to see if they're already fake.  If so, use that fake
     # mode instead.
-
     python_dispatcher_mode = (
         enable_python_dispatcher() if shape_env is not None else nullcontext()
     )

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -628,6 +628,7 @@ def _create_aot_dispatcher_function(
 
     # Check flat_args to see if they're already fake.  If so, use that fake
     # mode instead.
+
     python_dispatcher_mode = (
         enable_python_dispatcher() if shape_env is not None else nullcontext()
     )

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -477,13 +477,15 @@ class AsyncCompile:
             data = event_data["PyCodeCache.load_by_key_path"]
             if "triton_kernel_info" in data:
                 info = data["triton_kernel_info"]
+                # Sort by kernel name
+                sorted_info = dict(sorted(info.items()))
                 torch._logging.trace_structured(
                     "artifact",
                     metadata_fn=lambda: {
                         "name": f"triton_kernel_info",
                         "encoding": "json",
                     },
-                    payload_fn=lambda: json.dumps(data["triton_kernel_info"]),
+                    payload_fn=lambda: json.dumps(sorted_info),
                 )
         _compile_end()
 

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -353,7 +353,6 @@ class AsyncCompile:
                 chromium_log = get_chromium_event_logger()
                 event_data = chromium_log.get_event_data().get("PyCodeCache.load_by_key_path", {})
                 kernel_info = event_data.get("triton_kernel_info", {})
-                kernel_info["is_backward"] = is_backward
                 kernel_info[kernel_name] = info
                 chromium_log.add_event_data(
                     "PyCodeCache.load_by_key_path",
@@ -391,7 +390,6 @@ class AsyncCompile:
                 chromium_log = get_chromium_event_logger()
                 event_data = chromium_log.get_event_data().get("PyCodeCache.load_by_key_path", {})
                 kernel_info = event_data.get("triton_kernel_info", {})
-                kernel_info["is_backward"] = is_backward
                 kernel_info[kernel_name] = info
                 chromium_log.add_event_data(
                     "PyCodeCache.load_by_key_path",
@@ -479,11 +477,10 @@ class AsyncCompile:
             data = event_data["PyCodeCache.load_by_key_path"]
             if "triton_kernel_info" in data:
                 info = data["triton_kernel_info"]
-                backward_str = "backward" if info["is_backward"] else "forward"
                 torch._logging.trace_structured(
                     "artifact",
                     metadata_fn=lambda: {
-                        "name": f"triton_kernel_info_{backward_str}",
+                        "name": f"triton_kernel_info",
                         "encoding": "json",
                     },
                     payload_fn=lambda: json.dumps(data["triton_kernel_info"]),

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1710,7 +1710,12 @@ def cached_autotune(
                 autotune_cache_info["num_configs"] = len(configs)
                 if inductor_meta.get("coordinate_descent_tuning"):
                     autotune_cache_info["coordesc_tuning"] = True
-
+                    if len(configs) == 1:
+                        # This is the config that coordinate descent tuning started at, which
+                        # is not the same as the final config chosen (i.e. only_config, best_config)
+                        autotune_cache_info["coordesc_tuning_start_config"] = (
+                            triton_config_to_hashable(configs[0])
+                        )
     else:
         if len(configs) == 1:
             autotune_cache_info["autotune_cache_state"] = "only 1 config"

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1701,7 +1701,9 @@ def cached_autotune(
         if autotune_cache:
             if best_config := autotune_cache.read_best(inductor_meta, configs):
                 configs = [best_config]
-                autotune_cache_info["best_config"] = triton_config_to_hashable(best_config)
+                autotune_cache_info["best_config"] = triton_config_to_hashable(
+                    best_config
+                )
                 autotune_cache_info["autotune_cache_state"] = "hit"
             else:
                 autotune_cache_info["autotune_cache_state"] = "miss"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152197

This PR adds detailed logging of each triton kernel we compile, and its autotune result, to every kernel we compile with triton. We add these results to a global variable that we then clear after each triton kernel compile. 

We can't keep these objects around after compile time, so we can't record the autotune cache save or coordinate descent tuning, unfortunately, but we can log at least: 
- The duration of compilation
- Whether or not autotune cache hit
- The best autotuning config, if there's only one. 

Example triton kernel info: https://gist.github.com/jamesjwu/493bdd0f36b0b7e3ca327f87bd6c2c75

See internal diff for an example log for internal model. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov

Differential Revision: [D73674443](https://our.internmc.facebook.com/intern/diff/D73674443)