### PR TITLE
Synchronize mps backend in the timer

### DIFF
--- a/torch/utils/benchmark/utils/timer.py
+++ b/torch/utils/benchmark/utils/timer.py
@@ -21,6 +21,10 @@ elif torch.xpu.is_available():
     def timer() -> float:
         torch.xpu.synchronize()
         return timeit.default_timer()
+elif torch.mps.is_available():
+    def timer() -> float:
+        torch.mps.synchronize()
+        return timeit.default_timer()
 elif torch._C._get_privateuse1_backend_name() != "privateuseone":
     privateuse1_device_handler = getattr(torch, torch._C._get_privateuse1_backend_name(), None) \
         if torch._C._get_privateuse1_backend_name() != "cpu" else None


### PR DESCRIPTION
Add synchronization for the MPS op measurements with the timer class in benchmark utils. This enables measuring the true execution time when we wait for the GPU results.

Test output from calling linear op before the change (which ignores waiting for the GPU result):
```
torch.linear time: <torch.utils.benchmark.utils.common.Measurement object at 0x1108f07d0>
func(*args, **kwargs)
  Median: 22.75 us
  IQR:    0.87 us (22.50 to 23.38)
  8361 measurements, 1 runs per measurement, 1 thread
```
and after the change the measurement accounting for the GPU result turnaround time
```
torch.linear time: <torch.utils.benchmark.utils.common.Measurement object at 0x10a8cd110>
func(*args, **kwargs)
  Median: 245.08 us
  IQR:    22.40 us (235.73 to 258.13)
  815 measurements, 1 runs per measurement, 1 thread
```