### PR TITLE
Improve error handling in CachingAutotuner for argument mismatches

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -685,7 +685,13 @@ class CachingAutotuner(KernelInterface):
             )
             # reset to zero before evaluating any config
             self.reset_to_zero_args(*args, **kwargs)
+            expected_arg_count = launcher.__code__.co_argcount - 1
             args_with_constexprs = self._get_args_with_constexprs(cloned_args, launcher)
+            if len(args_with_constexprs) != expected_arg_count:
+                raise TypeError(
+                    f"CachingAutotuner argument mismatch: expected {expected_arg_count} arguments, "
+                    f"but got {args_with_constexprs}. Please check the kernel definition and launcher invocation."
+                )
             launcher(
                 *args_with_constexprs,
                 **cloned_kwargs,


### PR DESCRIPTION
Fixes #147690

Adds a check in CachingAutotuner.run() to validate that the number of provided arguments matches the expected number of launcher arguments. 
If there is a mismatch, a clear TypeError is raised, specifying the expected and actual argument counts.

This improves the debuggability of kernel launch failures, providing a more informative error message instead of a low-level runtime exception.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos