### PR TITLE
[export] Preserve custom metadata for tensor constants

### DIFF
--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -992,6 +992,12 @@ def placeholder_naming_pass(
             placeholder_prefixes[spec.kind] + base_name,
             is_placeholder=True,
         )
+        if base_name in custom_meta:
+            # the keys in custom_meta are node names from `mod`,
+            # which is the base_name here.
+            # we need the re-mapped name for lookup later
+            custom_meta[name_map[spec.arg.name]] = custom_meta[base_name]
+            del custom_meta[base_name]
 
     # handle naming collisions with call_function/get_attr inputs.
     # here, we want to prioritize user input names over call_function names
@@ -1008,7 +1014,10 @@ def placeholder_naming_pass(
             assert node.name in name_map
             node.name = node.target = name_map[node.name]
             if node.name in custom_meta:
-                node.meta["custom"] = custom_meta[node.name]
+                if node.meta.get("custom") is None:
+                    node.meta["custom"] = custom_meta[node.name]
+                else:
+                    assert node.meta["custom"] == custom_meta[node.name]
             # if the constant obj is an input, we also need to update meta["val"]
             # because this is created before the placeholder naming pass
             if isinstance(node.meta["val"], CustomObjArgument):


### PR DESCRIPTION
Summary:
Fixes https://github.com/pytorch/pytorch/issues/151476
The `custom_meta` collected from `mod` has keys that follow name of nodes in `mod`, which are inconsistent with the node names after the naming pass. For example a constant `b` will become `c_b`.

Test Plan: buck2 run caffe2/test:test_export -- -r test_run_decompositions_keep_tensor_constant_metadata

Differential Revision: D73703068


