### PR TITLE
Add private config to broadcast rank0 decision from the partitioner to all ranks

### DIFF
--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -266,6 +266,10 @@ disable_guess_zero_tangent_for_mutated_input_subclass = False
 # TODO(ivankobzarev): Remove this config once extra memory usage is investigated.
 guess_tangent_strides_as_outputs = False
 
+# This is a temporary config to ensure all ranks take the same decision in the partitioner
+# it will untimately be removed once we share size_hints across ranks through compiler collectives
+_broadcast_rank0_decision = False
+
 if TYPE_CHECKING:
     from torch.utils._config_typing import *  # noqa: F401, F403
 


### PR DESCRIPTION
Summary: This PR adds a private configuration to the partitioner that ensures that the decision taken is the same across all ranks. This is a temporary workaround, as when size_hints are also taken into account in compiler collectives this workaround will not be needed anymore.

Test Plan:
This has been tested on some internal models, but I haven't added any tests in PyTorch (yet?)
T

Differential Revision: D73666017


