### PR TITLE
Fix clang-tidy suppression in torch/csrc/jit

### DIFF
--- a/torch/csrc/jit/backends/backend.h
+++ b/torch/csrc/jit/backends/backend.h
@@ -7,7 +7,6 @@
 
 namespace torch::jit {
 namespace {
-// NOLINTNEXTLINE(clang-diagnostic-unneeded-internal-declaration)
 inline c10::FunctionSchema getIsAvailableSchema() {
   c10::Argument self("self", c10::AnyType::get());
   c10::Argument available("available", c10::BoolType::get());
@@ -21,7 +20,6 @@ inline c10::FunctionSchema getIsAvailableSchema() {
 
 constexpr static auto kBackendsNamespace = "__backends__";
 
-// NOLINTNEXTLINE(clang-diagnostic-unneeded-internal-declaration)
 inline c10::FunctionSchema getCompileSchema() {
   c10::Argument self("self", c10::AnyType::get());
   c10::Argument mod("processed", c10::AnyType::get());
@@ -38,7 +36,6 @@ inline c10::FunctionSchema getCompileSchema() {
   return compile_schema;
 }
 
-// NOLINTNEXTLINE(clang-diagnostic-unneeded-internal-declaration)
 inline c10::FunctionSchema getExecuteSchema() {
   auto any_list_ty = c10::ListType::create(c10::AnyType::get());
   c10::Argument self("self", c10::AnyType::get());

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
@@ -7,10 +7,7 @@
 #include <caffe2/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.h>
 #include <torch/csrc/jit/backends/xnnpack/serialization/schema_generated.h>
 
-namespace torch {
-namespace jit {
-namespace xnnpack {
-namespace delegate {
+namespace torch::jit::xnnpack::delegate {
 
 class XNNModelWrapper : public CustomClassHolder {
  public:
@@ -80,8 +77,8 @@ class XNNPackBackend : public PyTorchBackendInterface {
     XNNExecutor& executor = model_wrapper->executor_;
 
     std::vector<float*> input_pointers;
-    for (int i = 0; i < inputs.size(); ++i) {
-      const at::IValue& val = inputs.get(i);
+    input_pointers.reserve(inputs.size());
+    for (const at::IValue& val : inputs) {
       TORCH_CHECK(val.isTensor(), "Non-tensor inputs not supported");
       input_pointers.push_back(val.toTensor().data_ptr<float>());
     }
@@ -89,8 +86,8 @@ class XNNPackBackend : public PyTorchBackendInterface {
     std::vector<at::Tensor> output_tensors;
     std::vector<float*> output_pointers;
     output_tensors.reserve(output_shapes.size());
-    for (int i = 0; i < output_shapes.size(); i++) {
-      auto o_shape = output_shapes.get(i).toIntVector();
+    for (const at::IValue& val : output_shapes) {
+      auto o_shape = val.toIntVector();
       auto output = at::empty(o_shape, c10::ScalarType::Float);
       output_tensors.push_back(output);
       output_pointers.push_back(output.data_ptr<float>());
@@ -111,7 +108,4 @@ constexpr auto backend_name = "xnnpack";
 static auto cls = torch::jit::backend<XNNPackBackend>(backend_name);
 } // namespace
 
-} // namespace delegate
-} // namespace xnnpack
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::xnnpack::delegate

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
@@ -86,6 +86,7 @@ class XNNPackBackend : public PyTorchBackendInterface {
     std::vector<at::Tensor> output_tensors;
     std::vector<float*> output_pointers;
     output_tensors.reserve(output_shapes.size());
+    output_pointers.reserve(output_shapes.size());
     for (const at::IValue& val : output_shapes) {
       auto o_shape = val.toIntVector();
       auto output = at::empty(o_shape, c10::ScalarType::Float);

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
@@ -12,7 +12,7 @@ namespace torch::jit::xnnpack::delegate {
 class XNNModelWrapper : public CustomClassHolder {
  public:
   XNNExecutor executor_;
-  XNNModelWrapper(XNNExecutor executor) : executor_(std::move(executor)){};
+  XNNModelWrapper(XNNExecutor executor) : executor_(std::move(executor)) {}
 
   XNNModelWrapper() = delete;
 

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
@@ -25,9 +25,8 @@ class XNNModelWrapper : public CustomClassHolder {
 class XNNPackBackend : public PyTorchBackendInterface {
  public:
   // Constructor.
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  explicit XNNPackBackend() {}
-  virtual ~XNNPackBackend() override = default;
+  explicit XNNPackBackend() = default;
+  ~XNNPackBackend() override = default;
 
   bool is_available() override {
     return xnn_status_success == xnn_initialize(/*allocator=*/nullptr);
@@ -82,7 +81,7 @@ class XNNPackBackend : public PyTorchBackendInterface {
 
     std::vector<float*> input_pointers;
     for (int i = 0; i < inputs.size(); ++i) {
-      at::IValue val = inputs.get(i);
+      const at::IValue& val = inputs.get(i);
       TORCH_CHECK(val.isTensor(), "Non-tensor inputs not supported");
       input_pointers.push_back(val.toTensor().data_ptr<float>());
     }

--- a/torch/csrc/jit/frontend/edit_distance.cpp
+++ b/torch/csrc/jit/frontend/edit_distance.cpp
@@ -15,7 +15,7 @@ size_t ComputeEditDistance(
   size_t m = std::strlen(word1);
   size_t n = std::strlen(word2);
 
-  const unsigned small_buffer_size = 64;
+  constexpr unsigned small_buffer_size = 64;
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   unsigned small_buffer[small_buffer_size];
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)

--- a/torch/csrc/jit/frontend/edit_distance.cpp
+++ b/torch/csrc/jit/frontend/edit_distance.cpp
@@ -12,8 +12,8 @@ size_t ComputeEditDistance(
     const char* word1,
     const char* word2,
     size_t maxEditDistance) {
-  size_t m = strlen(word1);
-  size_t n = strlen(word2);
+  size_t m = std::strlen(word1);
+  size_t n = std::strlen(word2);
 
   const unsigned small_buffer_size = 64;
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)

--- a/torch/csrc/jit/frontend/lexer.cpp
+++ b/torch/csrc/jit/frontend/lexer.cpp
@@ -65,9 +65,9 @@ bool SharedParserData::isBinary(int kind, int* prec) {
 C10_EXPORT int stringToKind(const std::string& str) {
   static std::unordered_map<std::string, int> str_to_kind = []() {
     std::unordered_map<std::string, int> ret_str_to_kind;
-    for (char tok : std::string(valid_single_char_tokens))
-      // NOLINTNEXTLINE(bugprone-signed-char-misuse)
-      ret_str_to_kind[std::string(1, tok)] = tok;
+    for (const char* tok = valid_single_char_tokens; *tok; tok++) {
+      ret_str_to_kind[std::string(1, *tok)] = static_cast<unsigned char>(*tok);
+    }
 #define DEFINE_CASE(tok, _, str) \
   if (std::string(str) != "")    \
     ret_str_to_kind[str] = tok;

--- a/torch/csrc/jit/frontend/lexer.cpp
+++ b/torch/csrc/jit/frontend/lexer.cpp
@@ -2,6 +2,7 @@
 
 #include <c10/util/Exception.h>
 
+#include <cstring>
 #include <string>
 #include <unordered_map>
 
@@ -65,6 +66,7 @@ bool SharedParserData::isBinary(int kind, int* prec) {
 C10_EXPORT int stringToKind(const std::string& str) {
   static std::unordered_map<std::string, int> str_to_kind = []() {
     std::unordered_map<std::string, int> ret_str_to_kind;
+    ret_str_to_kind.reserve(std::strlen(valid_single_char_tokens));
     for (const char* tok = valid_single_char_tokens; *tok; tok++) {
       ret_str_to_kind[std::string(1, *tok)] = static_cast<unsigned char>(*tok);
     }

--- a/torch/csrc/jit/frontend/parser_constants.h
+++ b/torch/csrc/jit/frontend/parser_constants.h
@@ -1,5 +1,6 @@
 #pragma once
 
 namespace torch::jit {
-static const char* valid_single_char_tokens = "+-*/%@()[]:,={}><.?!&^|~";
+static constexpr const char* valid_single_char_tokens =
+    "+-*/%@()[]:,={}><.?!&^|~";
 } // namespace torch::jit

--- a/torch/csrc/jit/ir/scope.cpp
+++ b/torch/csrc/jit/ir/scope.cpp
@@ -89,9 +89,9 @@ std::string Scope::namesFromRoot(const std::string& separator) const {
     return out;
   }
   ScopePtr parent = this->parent_;
+  auto suffix = separator + out;
   while (!parent->isRoot()) {
-    // NOLINTNEXTLINE(performance-inefficient-string-concatenation)
-    out = std::string(parent->name_.toUnqualString()) + separator + out;
+    out = std::string(parent->name_.toUnqualString()) + suffix;
     parent = parent->parent_;
   }
   return out;

--- a/torch/csrc/jit/ir/scope.cpp
+++ b/torch/csrc/jit/ir/scope.cpp
@@ -89,9 +89,9 @@ std::string Scope::namesFromRoot(const std::string& separator) const {
     return out;
   }
   ScopePtr parent = this->parent_;
-  auto suffix = separator + out;
   while (!parent->isRoot()) {
-    out = std::string(parent->name_.toUnqualString()) + suffix;
+    // NOLINTNEXTLINE(performance-inefficient-string-concatenation)
+    out = std::string(parent->name_.toUnqualString()) + separator + out;
     parent = parent->parent_;
   }
   return out;

--- a/torch/csrc/jit/mobile/type_parser.cpp
+++ b/torch/csrc/jit/mobile/type_parser.cpp
@@ -19,7 +19,7 @@ static constexpr const char* kTypeTorchbindCustomClass =
 static constexpr const char* kTypeNamedTuple = "NamedTuple";
 
 bool isSpecialChar(char a) {
-  return strchr(valid_single_char_tokens, a);
+  return std::strchr(valid_single_char_tokens, a);
 }
 } // namespace
 

--- a/torch/csrc/jit/mobile/type_parser.cpp
+++ b/torch/csrc/jit/mobile/type_parser.cpp
@@ -19,11 +19,7 @@ static constexpr const char* kTypeTorchbindCustomClass =
 static constexpr const char* kTypeNamedTuple = "NamedTuple";
 
 bool isSpecialChar(char a) {
-  for (const char* c = valid_single_char_tokens; *c; c++) {
-    if (a == *c)
-      return true;
-  }
-  return false;
+  return strchr(valid_single_char_tokens, a);
 }
 } // namespace
 

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -980,6 +980,7 @@ class AttributePropagator {
   std::unordered_map<ClassTypePtr, IValue::HashAliasedIValues>
       SharedTypeSubModules_;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   Module& module_;
 
   // Allow to freeze modules containing interfaces.

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1638,7 +1638,7 @@ void initJITBindings(PyObject* module) {
           "get_record_offset_no_read",
           [](PyTorchStreamReader& self,
              size_t zipfile_header_offset,
-             const std::string filename,
+             const std::string& filename,
              size_t size,
              uint64_t storage_alignment) {
             return self.getRecordOffsetNoRead(
@@ -1748,7 +1748,7 @@ void initJITBindings(PyObject* module) {
 
   m.def(
       "_jit_resolve_packet",
-      [](const char* op_name, py::args args, const py::kwargs& kwargs) {
+      [](const char* op_name, const py::args& args, const py::kwargs& kwargs) {
         try {
           auto symbol = Symbol::fromQualString(op_name);
           bool allow_numbers_as_tensors = opAllowsNumbersAsTensors(symbol);
@@ -2140,7 +2140,7 @@ void initJITBindings(PyObject* module) {
                 return py::make_tuple();
               },
               /* __setstate__ */
-              [](const py::tuple& /* unused */) { // NOLINT
+              [](const py::tuple& /* unused */) {
                 TORCH_CHECK(false, "Can not unpickle torch.futures.Future");
                 // Note that this return has no meaning since we always
                 // throw, it's only here to satisfy PyBind's API
@@ -2177,7 +2177,7 @@ void initJITBindings(PyObject* module) {
                 return py::make_tuple();
               },
               /* __setstate__ */
-              [](const py::tuple& /* unused */) { // NOLINT
+              [](const py::tuple& /* unused */) {
                 TORCH_CHECK(false, "Can not unpickle torch.jit._Await");
                 // Note that this return has no meaning since we always
                 // throw, it's only here to satisfy PyBind's API

--- a/torch/csrc/jit/runtime/argument_spec.h
+++ b/torch/csrc/jit/runtime/argument_spec.h
@@ -241,7 +241,7 @@ struct CompleteArgumentInfo;
 struct CompleteArgumentSpec {
   CompleteArgumentSpec(bool with_grad, at::ArrayRef<IValue> inputs)
       : ninputs(inputs.size()) {
-    int32_t all_dims = 0;
+    int64_t all_dims = 0;
     const auto num_inputs = inputs.size();
     for (const auto i : c10::irange(num_inputs)) {
       if (!inputs[i].isTensor())

--- a/torch/csrc/jit/runtime/instruction.cpp
+++ b/torch/csrc/jit/runtime/instruction.cpp
@@ -44,7 +44,7 @@ static_assert(
     "Instructions should be 8 bytes");
 std::ostream& operator<<(std::ostream& out, Instruction inst) {
   // TODO: use op info to print out the op in a more user-friendly way
-  int nargs = std::strlen(OpInfo(inst.op));
+  auto nargs = std::strlen(OpInfo(inst.op));
   out << inst.op;
   if (nargs > 0) {
     out << " " << inst.X;

--- a/torch/csrc/jit/runtime/static/ProcessedNodeInputs.h
+++ b/torch/csrc/jit/runtime/static/ProcessedNodeInputs.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 
 #include <memory>
 
@@ -31,6 +32,7 @@ class ProcessedNodeInputs {
   }
 
   uint16_t operator[](uint16_t idx) const {
+    // NOLINTNEXTLINE(*const-cast*)
     return (*const_cast<ProcessedNodeInputs*>(this))[idx];
   }
 

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -12,6 +12,7 @@
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/passes/inliner.h>
 #include <torch/csrc/jit/runtime/instruction.h>
+#include <torch/csrc/jit/serialization/export.h>
 #include <torch/csrc/jit/serialization/import_export_constants.h>
 #include <torch/csrc/jit/serialization/import_export_functions.h>
 #include <torch/csrc/jit/serialization/import_export_helpers.h>

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -547,7 +547,7 @@ void ScriptModuleSerializer::writeArchive(
   TORCH_INTERNAL_ASSERT(tensor_names.size() == data_pickle.tensorData().size());
 
   for (const auto& td : data_pickle.tensorData()) {
-    std::string tensor_name = tensor_names[i++];
+    const std::string& tensor_name = tensor_names[i++];
     if (td.is_meta() || skip_tensor_data) {
       writer_.writeRecord(tensor_dir + tensor_name, nullptr, 0);
       continue;

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -518,6 +518,7 @@ flatbuffers::Offset<mobile::serialization::ObjectType> FlatbufferSerializer::
   } else {
     size_t num_attr = class_ptr->numAttributes();
     std::vector<flatbuffers::Offset<flatbuffers::String>> names;
+    names.reserve(num_attr);
     for (size_t i = 0; i < num_attr; ++i) {
       names.push_back(fbb.CreateSharedString(class_ptr->getAttributeName(i)));
     }
@@ -588,6 +589,7 @@ flatbuffers::Offset<mobile::serialization::Object> FlatbufferSerializer::
   } else {
     size_t num_attr = type->numAttributes();
     std::vector<uint32_t> tuple_index;
+    tuple_index.reserve(num_attr);
     for (size_t i = 0; i < num_attr; ++i) {
       tuple_index.push_back(storeIValueAndGetIndex(fbb, obj->getSlot(i)));
     }

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -130,6 +130,10 @@ struct PythonPrintImpl {
         stack->push_back(n->sourceRange());
       }
     }
+    WithSourceRange(const WithSourceRange&) = delete;
+    WithSourceRange(WithSourceRange&&) = delete;
+    WithSourceRange& operator=(const WithSourceRange&) = delete;
+    WithSourceRange& operator=(WithSourceRange&&) = delete;
 
     ~WithSourceRange() {
       stack->pop_back();
@@ -361,8 +365,9 @@ struct PythonPrintImpl {
       std::unordered_set<std::string>& used) {
     std::string name = candidate;
     while (used.count(name) || reserved_names.count(name)) {
-      // NOLINTNEXTLINE(performance-inefficient-string-concatenation)
-      name = candidate + std::to_string(next_id[name]++);
+      auto suffix = (next_id[name]++);
+      name.resize(candidate.size());
+      name.append(std::to_string(suffix));
     }
     used.insert(name);
     return name;

--- a/torch/csrc/jit/serialization/unpickler.h
+++ b/torch/csrc/jit/serialization/unpickler.h
@@ -73,7 +73,6 @@ class TORCH_API Unpickler {
       TypeParserT type_parser = defaultTypeParser,
       std::shared_ptr<DeserializationStorageContext> storage_context = nullptr)
       : reader_(std::move(reader)),
-
         type_resolver_(std::move(type_resolver)),
         obj_loader_(std::move(obj_loader)),
         read_record_(std::move(read_record)),
@@ -82,6 +81,10 @@ class TORCH_API Unpickler {
         type_parser_(type_parser),
         storage_context_(std::move(storage_context)),
         version_(caffe2::serialize::kProducedFileFormatVersion) {}
+
+  Unpickler(Unpickler&&) = delete;
+  Unpickler& operator=(Unpickler&&) = delete;
+  ~Unpickler() = default;
 
   // consume the pickle stream, producing an IValue from the contents.
   // Type Tags: the pickler will restore the type tags on

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -931,7 +931,7 @@ void nnc_aten_upsample_nearest2d(
   }
   auto tensors = constructTensors(
       bufs_num, buf_data, buf_ranks, buf_dims, buf_strides, buf_dtypes, qdata);
-  auto x = tensors[1];
+  const auto& x = tensors[1];
 
   int64_t output_size_h = extra_args[3];
   int64_t output_size_w = extra_args[4];
@@ -1041,7 +1041,7 @@ void nnc_aten_quantize_per_tensor_out(
       std::nullopt,
       bufs_out_num);
   // NOLINTNEXTLINE(facebook-hte-LocalUncheckedArrayBounds)
-  at::Tensor x = tensors[1];
+  const at::Tensor& x = tensors[1];
   const double qscale = ((double*)extra_args)[0];
   const int64_t qzero = extra_args[1];
   const c10::ScalarType qdtype = static_cast<c10::ScalarType>(extra_args[2]);

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -52,6 +52,9 @@ class StmtNode : public Stmt {
     visitor->visit(static_to<Op>(getptr()));
   }
   StmtPtr accept_mutator(IRMutator* mutator) override;
+  friend Op;
+
+ private:
   StmtNode() = default;
 };
 


### PR DESCRIPTION
Remove some clang-tidy suppression in torch/csrc/jit by applying fixes or refactoring.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel