### PR TITLE
[Dynamo] Replace `unimplemented` with `unimplemented_v2` in `torch/_dynamo/variables/misc.py` [1/2]

### DIFF
--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -939,7 +939,8 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
                 "to be initialized on the `autograd.Function` context object.",
                 hints=[
                     "Ensure that the `saved_tensors` attribute is properly "
-                    "initialized before calling `save_for_backward`.",
+                    "initialized before calling `save_for_backward`. "
+                    "`save_for_backward` only supported on a newly constructed `torch.autograd.function.FunctionCtx`.",
                 ],
             )
 

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -455,7 +455,7 @@ class ExceptionVariable(VariableTracker):
                 )
         else:
             unimplemented_v2(
-                gb_type="Unsupported attribute assignment",
+                gb_type="Unsupported attribute assignment on Exception object",
                 context=f"call_setattr {self} {name}",
                 explanation="Dynamo does not support setting the attribute "
                 f"'{name}' on tracked exception objects. Only `__context__`, "

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -78,7 +78,7 @@ class SuperVariable(VariableTracker):
 
     def __init__(self, typevar, objvar=None, **kwargs) -> None:
         super().__init__(**kwargs)
-        # typevar is the fist argument to super(). In the case where no argument
+        # typevar is the first argument to super(). In the case where no argument
         # is provided to super(), it is the __class__ object where
         # the super() function is being called
         self.typevar = typevar
@@ -145,7 +145,9 @@ class SuperVariable(VariableTracker):
         unimplemented_v2(
             gb_type="Unable to resolve super getattr",
             context="",
-            explanation="Dynamo was unable to find the attribute requested via `super()`.",
+            explanation=f"Dynamo failed to trace attribute `{name}` accessed "
+            f"via `super()` (for type `{self.typevar}` and object `{self.objvar}`) "
+            "because the resolved attribute type is not supported.",
             hints=[
                 "Ensure the attribute exists in the parent class.",
                 "Check the arguments passed to `super()`.",

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -927,7 +927,7 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
                 f"`{name}` on `autograd.Function` context objects. Supported "
                 "methods are `__setattr__`, `save_for_backward` and "
                 "`mark_non_differentiable`.",
-                hints=[*graph_break_hints.USER_ERROR],
+                hints=[*graph_break_hints.SUPPORTABLE],
             )
         if self.saved_tensors is None:
             unimplemented_v2(

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -254,7 +254,7 @@ class SuperVariable(VariableTracker):
                 attr = attr.as_python_constant()
             except NotImplementedError as exc:
                 unimplemented_v2(
-                    gb_type="Unsupported non-const delattr attribute",
+                    gb_type="Non-constant attribute given to `super().__delattr__()`",
                     context=f"call_method {self} {name}",
                     explanation="Dynamo requires the attribute name passed to "
                     "`super().__delattr__(...)` to be a constant string.",

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -203,7 +203,7 @@ class SuperVariable(VariableTracker):
                 unimplemented_v2(
                     gb_type="Unsupported super().__init__() call",
                     context=f"call_method {self} {name}",
-                    explanation=f"Dynamo does not know how to trace `super().__init__` for {objvar}.",
+                    explanation=f"Dynamo encountered a super().__init__() call on {objvar} that resolved to a `torch.nn.Module.__init__()` call that we cannot trace.",
                     hints=[
                         "Avoid passing arguments to `super().__init__()` in `nn.Module` if possible.",
                         "Ensure this call happens during the initial `__init__` of the object.",

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -674,6 +674,7 @@ class AutogradFunctionVariable(VariableTracker):
                     hints=[
                         "Remove the custom `vjp` method if possible.",
                         "Use standard `backward` instead if applicable.",
+                        *graph_break_hints.SUPPORTABLE,
                     ],
                 )
 

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -443,7 +443,7 @@ class ExceptionVariable(VariableTracker):
                 self.__traceback__ = val
             else:
                 unimplemented_v2(
-                    gb_type="Unsupported attribute assignment",
+                    gb_type="Set Exception object `__traceback__` attribute to not-`None`",
                     context=f"call_setattr {self} {name}",
                     explanation="Dynamo does not support setting the attribute "
                     "'__traceback__' on tracked exception objects to anything "

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -687,6 +687,7 @@ class AutogradFunctionVariable(VariableTracker):
                     "a custom `jvp` method.",
                     hints=[
                         "Remove the custom `jvp` method if possible.",
+                        *graph_break_hints.SUPPORTABLE,
                     ],
                 )
 

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -930,7 +930,7 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
             )
         if self.saved_tensors is None:
             unimplemented_v2(
-                gb_type="Unsupported autograd.Function context usage",
+                gb_type="Unsupported autograd.Function context `save_for_backward`",
                 context=f"call_method {self} {name}",
                 explanation="Dynamo requires the `saved_tensors` attribute "
                 "to be initialized on the `autograd.Function` context object.",

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1011,7 +1011,7 @@ class AutogradEngineVariable(UserDefinedObjectVariable):
                 )
         else:
             unimplemented_v2(
-                gb_type="Unsupported autograd engine method",
+                gb_type="Unsupported torch._C._ImperativeEngine method",
                 context=f"call_method {self} {name}",
                 explanation="Dynamo only supports the `queue_callback` method "
                 f"on a torch._C._ImperativeEngine instance, but found: `{name}`.",

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -202,12 +202,11 @@ class SuperVariable(VariableTracker):
             else:
                 unimplemented_v2(
                     gb_type="Unsupported super().__init__() call",
-                    context=f"call_method {self} {name}",
-                    explanation=f"Dynamo encountered a super().__init__() call on {objvar} that resolved to a `torch.nn.Module.__init__()` call that we cannot trace.",
-                    hints=[
-                        "Avoid passing arguments to `super().__init__()` in `nn.Module` if possible.",
-                        "Ensure this call happens during the initial `__init__` of the object.",
-                    ],
+                    context=f"call_method {self} {name} {args} {kwargs}",
+                    explanation="Dynamo encountered a super().__init__() call "
+                    f"on {objvar} that resolved to a `torch.nn.Module.__init__()` "
+                    "call that we cannot trace.",
+                    hints=[*graph_break_hints.DIFFICULT],
                 )
         elif (
             self.objvar.source

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -353,7 +353,7 @@ class SuperVariable(VariableTracker):
         unimplemented_v2(
             gb_type="Attempted to call a super() attribute that is not a function or method",
             context=f"call_method {self} {name}",
-            explanation="Dynamo does not know how to trace `super()` for the "
+            explanation=f"Dynamo does not know how to trace the call `super().{name}()` because `super().{name}` is not a function or method".
             f"attribute `{name}`.",
             hints=[
                 "Ensure the attribute accessed via `super()` is a standard method or function.",

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -351,7 +351,7 @@ class SuperVariable(VariableTracker):
             return fn_var.call_function(tx, [self.objvar] + args, kwargs)
 
         unimplemented_v2(
-            gb_type="Unsupported super() attribute type",
+            gb_type="Attempted to call a super() attribute that is not a function or method",
             context=f"call_method {self} {name}",
             explanation="Dynamo does not know how to trace `super()` for the "
             f"attribute `{name}`.",

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -681,7 +681,7 @@ class AutogradFunctionVariable(VariableTracker):
             jvp_fn = self.fn_cls.jvp  # type: ignore[attr-defined]
             if jvp_fn is not torch.autograd.Function.jvp:
                 unimplemented_v2(
-                    gb_type="Unsupported autograd.Function feature",
+                    gb_type="Unsupported custom jvp",
                     context=f"call_apply {self} {args} {kwargs}",
                     explanation="Dynamo does not support tracing "
                     "`torch.autograd.Function` subclasses that define "

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -742,7 +742,7 @@ class AutogradFunctionVariable(VariableTracker):
             ).call_function(tx, args, kwargs)
         else:
             unimplemented_v2(
-                gb_type="Unsupported autograd.Function structure",
+                gb_type="Non-function or method in subclass of torch.autograd.Function",
                 context=f"call_apply {self} {args} {kwargs}",
                 explanation="Dynamo requires the `forward` attribute of a "
                 "`torch.autograd.Function` subclass to be a standard Python "

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -667,7 +667,7 @@ class AutogradFunctionVariable(VariableTracker):
             vjp_fn = self.fn_cls.vjp  # type: ignore[attr-defined]
             if vjp_fn is not torch.autograd.Function.vjp:
                 unimplemented_v2(
-                    gb_type="Unsupported autograd.Function feature",
+                    gb_type="Unsupported custom vjp",
                     context=f"call_apply {self} {args} {kwargs}",
                     explanation="Dynamo does not support tracing "
                     "`torch.autograd.Function` subclasses that define "

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -350,10 +350,12 @@ class SuperVariable(VariableTracker):
             return fn_var.call_function(tx, [self.objvar] + args, kwargs)
 
         unimplemented_v2(
-            gb_type="Attempted to call a super() attribute that is not a function or method",
+            gb_type="Attempted to call a super() attribute that is "
+            "not a function or method",
             context=f"call_method {self} {name}",
-            explanation=f"Dynamo does not know how to trace the call `super().{name}()` because `super().{name}` is not a function or method".
-            f"attribute `{name}`.",
+            explanation="Dynamo does not know how to trace the call "
+            f"`super().{name}()` because `super().{name}` is not a "
+            "function or method attribute.",
             hints=[
                 "Ensure the attribute accessed via `super()` is a standard method or function.",
             ],

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -257,7 +257,7 @@ class SuperVariable(VariableTracker):
                     gb_type="Non-constant attribute given to `super().__delattr__()`",
                     context=f"call_method {self} {name}",
                     explanation="Dynamo requires the attribute name passed to "
-                    "`super().__delattr__(...)` to be a constant string.",
+                    "`super().__delattr__(...)` to be a constant (string).",
                     hints=[
                         "Ensure the attribute name is a string literal or a constant variable."
                     ],

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -265,7 +265,7 @@ class SuperVariable(VariableTracker):
                 )
             if not tx.output.side_effects.is_attribute_mutation(self.objvar):
                 unimplemented_v2(
-                    gb_type="Unsupported super() operation",
+                    gb_type="Attempted super().__delattr__() on an object without mutation tracking",
                     context=f"call_method {self} {name}",
                     explanation="Dynamo needs to track mutations on an object "
                     "before `super().__delattr__` can be used on it. But the "

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -459,7 +459,7 @@ class ExceptionVariable(VariableTracker):
                 explanation="Dynamo does not support setting the attribute "
                 f"'{name}' on tracked exception objects. Only `__context__`, "
                 "`__cause__`, `__suppress_context__`, and `__traceback__` are supported.",
-                hints=[*graph_break_hints.USER_ERROR],
+                hints=[*graph_break_hints.SUPPORTABLE],
             )
         return variables.ConstantVariable(None)
 

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1003,7 +1003,7 @@ class AutogradEngineVariable(UserDefinedObjectVariable):
                 )
             else:
                 unimplemented_v2(
-                    gb_type="Unsupported autograd engine operation",
+                    gb_type="Unsupported torch._C._ImperativeEngine.queue_callback()",
                     context=f"call_method {self} {name}",
                     explanation="queue_callback() is only supported when "
                     "Compiled Autograd is enabled with fullgraph=True.",

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -201,7 +201,7 @@ class SuperVariable(VariableTracker):
                     ).call_function(tx, [self.objvar] + args, kwargs)
             else:
                 unimplemented_v2(
-                    gb_type="Unsupported super() call",
+                    gb_type="Unsupported super().__init__() call",
                     context=f"call_method {self} {name}",
                     explanation=f"Dynamo does not know how to trace `super().__init__` for {objvar}.",
                     hints=[


### PR DESCRIPTION
Part of #147913

Replace `unimplemented` with`unimplemented_v2` in `torch/_dynamo/variables/misc.py`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames