### PR TITLE
[inductor] set correct precompile start time

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1848,7 +1848,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 with restore_stdout_stderr():
                     choice.precompile()
                 elapsed_ns = time.time_ns() - start_ns
-                # Return tuple as trition async compile (_worker_compile_triton) 
+                # Return tuple as triton async compile (_worker_compile_triton) 
                 # returns tuple[CachingAutotuner, int]
                 return None, elapsed_ns // 1000
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1842,25 +1842,30 @@ class AlgorithmSelectorCache(PersistentCache):
             # different than the original values. we explicitly restore the state
             # here to avoid this issue.
 
-            def precompile_with_captured_stdout(choice):
+            def precompile_with_captured_stdout(choice) -> tuple[None, int]:
                 log.debug("Precompiling choice with captured stdout: %s", choice)
+                start_ns = time.time_ns()
                 with restore_stdout_stderr():
                     choice.precompile()
+                elapsed_ns = time.time_ns() - start_ns
+                # Return tuple as trition async compile (_worker_compile_triton) 
+                # returns tuple[CachingAutotuner, int]
+                return None, elapsed_ns // 1000
 
             def on_complete(future):
-                assert future in start_times
-                elapsed_times[future] = time.time() - start_times[future]
+                _, precompile_elapsed_us = future.result()
+                elapsed_seconds = precompile_elapsed_us / 1e6
+                elapsed_times[future] = elapsed_seconds 
                 log.debug(
                     "Precompilation complete for future: %s, elapsed time: %.02fs",
                     future,
-                    elapsed_times[future],
+                    elapsed_seconds,
                 )
 
             executor = ThreadPoolExecutor(max_workers=num_workers)
             async_compile = torch._inductor.async_compile.AsyncCompile()
 
             futures: dict[concurrent.futures.Future[Any], ChoiceCaller] = {}
-            start_times: dict[concurrent.futures.Future[Any], float] = {}
             elapsed_times: dict[concurrent.futures.Future[Any], float] = {}
 
             # Some choices only differ in runtime arguments, so we
@@ -1889,7 +1894,6 @@ class AlgorithmSelectorCache(PersistentCache):
                         future = executor.submit(precompile_with_captured_stdout, c)
                         log.debug("Submitted precompile for choice: %s", c)
 
-                    start_times[future] = time.time()
                     future.add_done_callback(on_complete)
                     futures[future] = c
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1848,14 +1848,14 @@ class AlgorithmSelectorCache(PersistentCache):
                 with restore_stdout_stderr():
                     choice.precompile()
                 elapsed_ns = time.time_ns() - start_ns
-                # Return tuple as triton async compile (_worker_compile_triton) 
+                # Return tuple as triton async compile (_worker_compile_triton)
                 # returns tuple[CachingAutotuner, int]
                 return None, elapsed_ns // 1000
 
             def on_complete(future):
                 _, precompile_elapsed_us = future.result()
                 elapsed_seconds = precompile_elapsed_us / 1e6
-                elapsed_times[future] = elapsed_seconds 
+                elapsed_times[future] = elapsed_seconds
                 log.debug(
                     "Precompilation complete for future: %s, elapsed time: %.02fs",
                     future,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152284

Fixes #148777

With num_worker set to 1, ran script in #148777

before:
```
Precompiling benchmark choice TritonTemplateCaller took 0.19s
Precompiling benchmark choice TritonTemplateCaller took 0.38s
Precompiling benchmark choice TritonTemplateCaller took 0.53s
Precompiling benchmark choice TritonTemplateCaller took 0.90s
Precompiling benchmark choice TritonTemplateCaller took 1.29s
Precompiling benchmark choice TritonTemplateCaller took 20.78s
Precompiling benchmark choice TritonTemplateCaller took 25.42s
Precompiling benchmark choice TritonTemplateCaller took 25.92s
Precompiling benchmark choice TritonTemplateCaller took 27.21s
Precompiling benchmark choice TritonTemplateCaller took 48.76s
Precompiling benchmark choice TritonTemplateCaller took 53.66s
Precompiling benchmark choice TritonTemplateCaller took 63.12s
Precompiling benchmark choice TritonTemplateCaller took 69.53s
Precompiling benchmark choice TritonTemplateCaller took 71.24s
Precompiling benchmark choice TritonTemplateCaller took 75.57s
Precompiling benchmark choice TritonTemplateCaller took 97.58s
Precompiling benchmark choice TritonTemplateCaller took 107.71s
Precompiling benchmark choice TritonTemplateCaller took 117.27s
Precompiling benchmark choice TritonTemplateCaller took 126.30s
FX codegen and compilation took 133.733s
```

after:
```
Precompiling benchmark choice TritonTemplateCaller took 0.18s
Precompiling benchmark choice TritonTemplateCaller took 0.18s
Precompiling benchmark choice TritonTemplateCaller took 0.14s
Precompiling benchmark choice TritonTemplateCaller took 0.35s
Precompiling benchmark choice TritonTemplateCaller took 0.39s
Precompiling benchmark choice TritonTemplateCaller took 19.54s
Precompiling benchmark choice TritonTemplateCaller took 4.69s
Precompiling benchmark choice TritonTemplateCaller took 0.52s
Precompiling benchmark choice TritonTemplateCaller took 1.28s
Precompiling benchmark choice TritonTemplateCaller took 20.96s
Precompiling benchmark choice TritonTemplateCaller took 4.81s
Precompiling benchmark choice TritonTemplateCaller took 9.40s
Precompiling benchmark choice TritonTemplateCaller took 6.34s
Precompiling benchmark choice TritonTemplateCaller took 1.93s
Precompiling benchmark choice TritonTemplateCaller took 4.39s
Precompiling benchmark choice TritonTemplateCaller took 21.91s
Precompiling benchmark choice TritonTemplateCaller took 10.10s
Precompiling benchmark choice TritonTemplateCaller took 9.55s
Precompiling benchmark choice TritonTemplateCaller took 9.15s
FX codegen and compilation took 133.246s
```

Also tested async triton compile path by setting num_workers > 1

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov