### PR TITLE
[DTensor] enable SimpleFSDP's composability with Tensor Parallel

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -29,6 +29,7 @@ from torch.distributed.tensor.parallel import (
     PrepareModuleOutput,
     RowwiseParallel,
 )
+from torch.distributed.tensor.placement_types import _StridedShard
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import get_devtype
 from torch.testing._internal.common_utils import (
@@ -196,8 +197,10 @@ def forward(self, b_parametrizations_buffer_original0, x):
             return a
 
         compiled_fn = torch.compile(backend="aot_eager", fullgraph=True)(fn)
-
-        for x in [Shard(0), Replicate(), Partial()]:
+        split_factors = [2, 3, 4]
+        for x in [Shard(0), Replicate(), Partial()] + [
+            _StridedShard(0, split_factor=s) for s in split_factors
+        ]:
             opt_fn = fn(x)
             compiled_out = compiled_fn(x)
             self.assertEqual(opt_fn, compiled_out)

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1675,6 +1675,7 @@ class GuardBuilder(GuardBuilderBase):
         if torch.distributed.is_available():
             from torch.distributed.device_mesh import DeviceMesh
             from torch.distributed.tensor.placement_types import (
+                _StridedShard,
                 Partial,
                 Replicate,
                 Shard,
@@ -1685,6 +1686,7 @@ class GuardBuilder(GuardBuilderBase):
                 Replicate,
                 Partial,
                 DeviceMesh,
+                _StridedShard,
             )
 
         from torch.export.dynamic_shapes import _IntWrapper


### PR DESCRIPTION
This PR adds support for SimpleFSDP's composability with Tensor Parallel + torch.compile. 

`_StridedShard` is used in SimpleFSDP/FSDP2 to support correct distributed checkpointing when FSDP+TP is applied. Previously, `_StridedShard` is not guarded by torch.compile. This PR adds `_StridedShard` as an additional placement type to be guarded by torch.compile.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames