### PR TITLE
Fix redistribute new_local_tensor be None case

### DIFF
--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -171,7 +171,7 @@ def redistribute_local_tensor(
         # TODO: alltoall/permute reshuffling to change device_mesh if they are not the same
         raise NotImplementedError("Cross device mesh comm not supported yet!")
 
-    new_local_tensor = None
+    new_local_tensor = local_tensor
     device_mesh = current_spec.mesh
 
     my_coordinate = device_mesh.get_coordinate()
@@ -272,10 +272,7 @@ def redistribute_local_tensor(
                 # partial -> partial no op, should never hit
                 new_local_tensor = local_tensor
 
-        assert new_local_tensor is not None
         local_tensor = new_local_tensor
-
-    assert new_local_tensor is not None, "redistribute failed!"
 
     if not async_op and isinstance(new_local_tensor, funcol.AsyncCollectiveTensor):
         new_local_tensor = new_local_tensor.wait()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152303

as titled, we can just set new_local_tensor to be the local tensor and
remove the None check, as there would be cases where there's no
transformation needed (i.e. src_placements and dst_placements are the same,
and we still want to return the original local_tensor)

cc @H-Huang @awgu @fegin @fduwjj @wz337 @wconstab @d4l3k