### PR TITLE
setuptools.build_meta:__legacy__ backend is deprecated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
     "requests",
 ]
 # Use legacy backend to import local packages in setup.py
-build-backend = "setuptools.build_meta:__legacy__"
+build-backend = "setuptools.build_meta"
 
 
 [tool.black]


### PR DESCRIPTION
setuptools.build_meta:__legacy__ backend is deprecated

see https://projects.gentoo.org/python/guide/qawarn.html#deprecated-pep-517-backends


