### PR TITLE
Fix common_distributed.py to NOT set root logger

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -53,8 +53,8 @@ from torch.testing._internal.distributed.multi_threaded_pg import (
 )
 import operator
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class TestSkip(NamedTuple):


### PR DESCRIPTION
Using `logging.basicConfig` to set root logger's level is not a good behavior. Fix common_distributed.py to set level for current logger only, because it affects downstream's 3rd-party testing plugins.

cc @ezyang @albanD 
