### PR TITLE
[ROCm] Unskipped test_rnn_dropout_state for ROCm

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4375,8 +4375,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                 outs[0].sum().backward()
 
     @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
-    @skipIfRocm(msg="ROCm doesn't support 'dropout' for RNN "
-                "(WIP to enable dropout https://github.com/pytorch/pytorch/pull/144572)")
     def test_RNN_dropout_state(self):
         for p in (0, 0.1234):
             for train in (True, False):


### PR DESCRIPTION
Unskipping the test, should work fine now.

Related PR: https://github.com/pytorch/pytorch/pull/144572

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd