### PR TITLE
Add a label to skip URL lint if needed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -283,6 +283,7 @@ jobs:
 
   lint-urls:
     name: Lint URLs
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'skip-url-lint')
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     needs: get-label-type
     with:
@@ -293,7 +294,11 @@ jobs:
       submodules: false
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
-        ./scripts/lint_urls.sh
+        if ! ./scripts/lint_urls.sh; then
+          echo
+          echo "URL lint failed. If this is a transient outage, you can bypass it by adding the `skip-url-lint` label to your PR."
+          exit 1
+        fi
 
   lint-xrefs:
     name: Lint Xrefs


### PR DESCRIPTION
Some URLs may be down due to server side issues we can't control