### PR TITLE
[Memento] Enable on-demand mode

### DIFF
--- a/docs/source/mtia.memory.rst
+++ b/docs/source/mtia.memory.rst
@@ -11,3 +11,7 @@ The MTIA backend is implemented out of the tree, only interfaces are be defined 
     :nosignatures:
 
     memory_stats
+    record_memory_history
+    snapshot
+    dump_snapshot
+    attach_out_of_memory_observer

--- a/docs/source/mtia.rst
+++ b/docs/source/mtia.rst
@@ -23,6 +23,7 @@ The MTIA backend is implemented out of the tree, only interfaces are be defined 
     empty_cache
     record_memory_history
     snapshot
+    dump_snapshot
     attach_out_of_memory_observer
     set_device
     set_stream

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -1225,6 +1225,75 @@ void PythonMemoryTracer::stop() {
 }
 
 // ============================================================================
+// == Memory Tracer ======================================================
+// ============================================================================
+
+// Assuming python_tracer::PythonMemoryTracerBase is defined elsewhere
+class MTIAPythonMemoryTracer final
+    : public python_tracer::PythonMemoryTracerBase {
+ public:
+  explicit MTIAPythonMemoryTracer() = default;
+  ~MTIAPythonMemoryTracer() override = default;
+  void start() override;
+  void stop() override;
+  void export_memory_history(const std::string path) override;
+};
+
+static void toggle_mtia_memory_tracing(bool enable) {
+  PyGILState_STATE gil_state = PyGILState_Ensure();
+  THPObjectPtr torch_mtia_module(PyImport_ImportModule("torch.mtia"));
+  if (!torch_mtia_module) {
+    return;
+  }
+  THPObjectPtr snapshot_func(
+      PyObject_GetAttrString(torch_mtia_module.get(), "record_memory_history"));
+  if (!snapshot_func) {
+    return;
+  }
+  // Call the function with arguments
+  PyObject* args = PyTuple_New(3);
+  PyTuple_SetItem(args, 0, enable ? PyUnicode_FromString("all") : Py_None);
+  PyTuple_SetItem(args, 1, PyUnicode_FromString("all")); // stacks
+  PyTuple_SetItem(args, 2, THPUtils_packInt64(100000)); // max_entries
+  PyObject* result = PyObject_Call(snapshot_func.get(), args, nullptr);
+  Py_DECREF(args);
+  if (result == nullptr) {
+    return;
+  }
+  PyGILState_Release(gil_state);
+}
+
+void MTIAPythonMemoryTracer::start() {
+  toggle_mtia_memory_tracing(true);
+}
+
+void MTIAPythonMemoryTracer::export_memory_history(const std::string path) {
+  PyGILState_STATE gil_state = PyGILState_Ensure();
+  THPObjectPtr torch_mtia_memory_module(PyImport_ImportModule("torch.mtia"));
+  if (!torch_mtia_memory_module) {
+    return;
+  }
+  THPObjectPtr snapshot_func(
+      PyObject_GetAttrString(torch_mtia_memory_module.get(), "dump_snapshot"));
+  if (!snapshot_func) {
+    return;
+  }
+  PyObject* py_filename = PyUnicode_FromString(path.c_str());
+  // Call the function with arguments (e.g., a file path)
+  PyObject* args = PyTuple_Pack(1, py_filename);
+  PyObject* result = PyObject_Call(snapshot_func.get(), args, nullptr);
+  Py_DECREF(args);
+  if (result == nullptr) {
+    return;
+  }
+  PyGILState_Release(gil_state);
+}
+
+void MTIAPythonMemoryTracer::stop() {
+  toggle_mtia_memory_tracing(false);
+}
+
+// ============================================================================
 // == API =====================================================================
 // ============================================================================
 int PythonTracer::pyProfileFn(
@@ -1262,6 +1331,9 @@ std::unique_ptr<python_tracer::PythonTracerBase> getTracer(
 }
 
 std::unique_ptr<python_tracer::PythonMemoryTracerBase> getMemoryTracer() {
+  if (at::hasMTIA()) {
+    return std::make_unique<MTIAPythonMemoryTracer>();
+  }
   return std::make_unique<PythonMemoryTracer>();
 }
 

--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -172,38 +172,6 @@ def default_stream(device: Optional[_device_t] = None) -> Stream:
     return torch._C._mtia_getDefaultStream(_get_device_index(device, optional=True))
 
 
-def record_memory_history(
-    enabled: Optional[str] = "all", stacks: str = "python", max_entries: int = 0
-) -> None:
-    r"""Enable/Disable the memory profiler on MTIA allocator
-
-    Args:
-        enabled (all or state, optional) selected device. Returns
-            statistics for the current device, given by current_device(),
-            if device is None (default).
-
-        stacks ("python" or "cpp", optional). Select the stack trace to record.
-
-        max_entries (int, optional). Maximum number of entries to record.
-    """
-    if not is_initialized():
-        return
-    torch._C._mtia_recordMemoryHistory(enabled, stacks, max_entries)
-
-
-def snapshot() -> dict[str, Any]:
-    r"""Return a dictionary of MTIA memory allocator history"""
-
-    return torch._C._mtia_memorySnapshot()
-
-
-def attach_out_of_memory_observer(
-    observer: Callable[[int, int, int, int], None]
-) -> None:
-    r"""Attach an out-of-memory observer to MTIA memory allocator"""
-    torch._C._mtia_attachOutOfMemoryObserver(observer)
-
-
 def get_device_capability(device: Optional[_device_t] = None) -> tuple[int, int]:
     r"""Return capability of a given device as a tuple of (major version, minor version).
 
@@ -393,4 +361,5 @@ __all__ = [
     "device",
     "set_rng_state",
     "get_rng_state",
+    "dump_snapshot",
 ]

--- a/torch/mtia/memory.py
+++ b/torch/mtia/memory.py
@@ -2,7 +2,8 @@
 
 r"""This package adds support for device memory management implemented in MTIA."""
 
-from typing import Any, Optional
+import pickle
+from typing import Any, Callable, Optional
 
 import torch
 
@@ -50,8 +51,58 @@ def reset_peak_memory_stats(device: Optional[_device_t] = None) -> None:
     torch._C._mtia_resetPeakMemoryStats(_get_device_index(device, optional=True))
 
 
+def record_memory_history(
+    enabled: Optional[str] = "all", stacks: str = "python", max_entries: int = 0
+) -> None:
+    r"""Enable/Disable the memory profiler on MTIA allocator
+
+    Args:
+        enabled (all or state, optional) selected device. Returns
+            statistics for the current device, given by current_device(),
+            if device is None (default).
+
+        stacks ("python" or "cpp", optional). Select the stack trace to record.
+
+        max_entries (int, optional). Maximum number of entries to record.
+    """
+    if not is_initialized():
+        return
+    torch._C._mtia_recordMemoryHistory(enabled, stacks, max_entries)
+
+
+def snapshot() -> dict[str, Any]:
+    r"""Return a dictionary of MTIA memory allocator history"""
+
+    return torch._C._mtia_memorySnapshot()
+
+
+def dump_snapshot(filename: str = "dump_snapshot.pickle") -> None:
+    """
+    Save a pickled version of the `torch.memory._snapshot()` dictionary to a file.
+
+    This file can be opened by the interactive snapshot viewer at pytorch.org/memory_viz
+
+    Args:
+        filename (str, optional): Name of the file to create. Defaults to "dump_snapshot.pickle".
+    """
+    s = snapshot()
+    with open(filename, "wb") as f:
+        pickle.dump(s, f)
+
+
+def attach_out_of_memory_observer(
+    observer: Callable[[int, int, int, int], None]
+) -> None:
+    r"""Attach an out-of-memory observer to MTIA memory allocator"""
+    torch._C._mtia_attachOutOfMemoryObserver(observer)
+
+
 __all__ = [
     "memory_stats",
     "max_memory_allocated",
     "reset_peak_memory_stats",
+    "dump_snapshot",
+    "record_memory_history",
+    "snapshot",
+    "attach_out_of_memory_observer",
 ]


### PR DESCRIPTION
Summary:
# Context 
Post: https://fb.workplace.com/groups/ai.efficiency.tools.users/permalink/2020094788475989/

On CUDA side, Memento enables the on-demand mode to trace a remote process without requiring code changes. In this diff, we want to enable the same features.

Overall, we follow the same approach to leverage kineto-dyno integration to trigger the process on remote process. We just need to implement our own Python Tracer and register it based on available device

Test Plan:
# Local Test
Check next diff.
P1797938330

```
https://www.internalfb.com/pytorch_memory_visualizer/mtia_traces/tree/gpu_traces/dynocli/0/1745855907/localhost/memory_snapshot_3215421.pickle
``` 
{F1977499533}

# Remote Test

Differential Revision: D73680135


