### PR TITLE
[jit] DeadCodeEliminator Mark(block) improvement

### DIFF
--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -3082,6 +3082,25 @@ TEST(TestShapeGraphLinting, Basic) {
   }
 }
 
+TEST(DeadCodeEliminatorTest, TestConstructor) {
+  // Test case 1: markUpdated = true, fullyMarked = true
+  MarkResult result1(true, true);
+  EXPECT_TRUE(result1.markUpdated_);
+  EXPECT_TRUE(result1.fullyMarked_);
+  // Test case 2: markUpdated = true, fullyMarked = false
+  MarkResult result2(true, false);
+  EXPECT_TRUE(result2.markUpdated_);
+  EXPECT_FALSE(result2.fullyMarked_);
+  // Test case 3: markUpdated = false, fullyMarked = true
+  MarkResult result3(false, true);
+  EXPECT_FALSE(result3.markUpdated_);
+  EXPECT_TRUE(result3.fullyMarked_);
+  // Test case 4: markUpdated = false, fullyMarked = false
+  MarkResult result4(false, false);
+  EXPECT_FALSE(result4.markUpdated_);
+  EXPECT_FALSE(result4.fullyMarked_);
+}
+
 // TODO: move to test_kernel when global settings are explicit
 // fusion parameters
 class Composed : public ::testing::Test {

--- a/torch/csrc/jit/passes/dead_code_elimination.cpp
+++ b/torch/csrc/jit/passes/dead_code_elimination.cpp
@@ -30,14 +30,12 @@ class DeadCodeEliminator {
   void run(Block* block, bool recurse) {
     // clean up unused fork inputs before starting the main algorithm
     eliminateDeadForkInputs(block, recurse);
-
     // Initialize by marking the return node and all its consumed values as live
     mark(block->return_node());
 
     mark(block);
 
     deleteCallback_(getLiveValues());
-
     sweep(block, recurse);
   }
 
@@ -95,10 +93,12 @@ class DeadCodeEliminator {
   // returns, we only mark producers for values that "live" (i.e. used outside
   // the block).
   //
-  // Returns true iff this marked something we haven't marked before.
-  bool markReturnNode(Node* node) {
+  // Returned MarkResult is composed by two values.
+  // markUpdated = true iff this marked something we haven't marked before.
+  // fullyMarked = true iff this node is marked.
+  MarkResult markReturnNode(Node* node) {
     if (marked_.count(node)) {
-      return false;
+      return MarkResult(false, true);
     }
 
     AT_ASSERT(node->owningBlock()->return_node() == node);
@@ -146,7 +146,7 @@ class DeadCodeEliminator {
     }
 
     marked_.insert(node);
-    return true;
+    return MarkResult(true, true);
   }
 
   // Loops are special, because we need to run them to convergence.
@@ -165,55 +165,97 @@ class DeadCodeEliminator {
   // We need to mark the loop again with the information that `a` is live, and
   // repeat until we're not marking new stuff anymore.
   //
-  // Returns true iff this marked something we haven't marked before.
-  bool markLoop(Node* node) {
+  // Returned MarkResult is composed by two values.
+  // markUpdated = true iff this marked something we haven't marked before.
+  // fullyMarked = true iff this node is marked.
+  MarkResult markLoop(Node* node) {
     TORCH_INTERNAL_ASSERT(node->kind() == prim::Loop);
     // Did a single iteration over the loop block mark anything new?
     // If this is false, we've converged.
-    bool marked = false;
     // Did we ever mark anything new?
+    bool markUpdated = false;
     bool anyMarked = false;
+    // Did we mark everything already?
+    bool allMarked = false;
     do {
-      marked = mark(node->blocks().at(0));
-      anyMarked |= marked;
-    } while (marked);
-    return anyMarked;
+      auto markedResult = mark(node->blocks().at(0));
+      markUpdated = markedResult.markUpdated_;
+      // Consider every iteration of the loop, as any of them is updated, marked
+      // this flag.
+      anyMarked |= markUpdated;
+      // Consider only the last iteration of the loop, as it has the highest
+      // mark coverage.
+      allMarked = markedResult.fullyMarked_;
+      // this markLoop would iterate until nothing is updated.
+    } while (markUpdated);
+    return MarkResult(anyMarked, allMarked);
   }
 
-  // Returns true iff this marked something we haven't marked before.
-  bool mark(Block* block) {
+  // Returned MarkResult is composed by two values.
+  // markUpdated = true iff this marked something we haven't marked before.
+  // fullyMarked = true iff this block is fully marked.
+  MarkResult mark(Block* block) {
     bool anyMarked = false;
+    bool allMarked = true;
+
+    // If all nodes within this block are already marked, we can safely bypass
+    // revisiting it. This check is the primary driver of our performance
+    // optimization.
+    if (alreadyAllMarked_.count(block)) {
+      return MarkResult(false, true);
+    }
+
     // Mark all nodes with side effects.
     for (auto node : block->nodes()) {
       if (sideEffectPolicy_ ==
               DCESideEffectPolicy::DONT_DELETE_NODES_WITH_SIDE_EFFECTS &&
           hasSideEffects(node)) {
-        anyMarked |= mark(node);
+        auto markNodeResult = mark(node);
+        // if any node is updated/marked, anyMarked becomes True
+        anyMarked |= markNodeResult.markUpdated_;
+        // if any node is not fully marked, allMarked becomes False
+        allMarked &= markNodeResult.fullyMarked_;
       }
     }
 
     // Initialize by marking the return node
-    anyMarked |= markReturnNode(block->return_node());
+    auto markReturnNodeResult = markReturnNode(block->return_node());
+    anyMarked |= markReturnNodeResult.markUpdated_;
+    allMarked &= markReturnNodeResult.fullyMarked_;
 
     for (auto it = block->nodes().rbegin(); it != block->nodes().rend(); ++it) {
       auto node = *it;
       if (node->kind() == prim::Loop) {
         // Special casing for loops, see comment in markLoop.
-        anyMarked |= markLoop(node);
+        auto markLoopResult = markLoop(node);
+        anyMarked |= markLoopResult.markUpdated_;
+        allMarked &= markLoopResult.fullyMarked_;
       } else {
         // Other nodes with sub-blocks get marked normally.
         for (auto subBlock : node->blocks()) {
-          anyMarked |= mark(subBlock);
+          auto markSubBlockResult = mark(subBlock);
+          anyMarked |= markSubBlockResult.markUpdated_;
+          allMarked &= markSubBlockResult.fullyMarked_;
         }
       }
-      anyMarked |= markIfLive(node);
+      auto markIfLiveResult = markIfLive(node);
+      anyMarked |= markIfLiveResult.markUpdated_;
+      allMarked &= markIfLiveResult.fullyMarked_;
     }
-    return anyMarked;
+    // If allMarked is true, it indicates that all nodes within this block have
+    // already been marked. To prevent redundant checks, add this block to the
+    // alreadyAllMarked_ set.
+    if (allMarked) {
+      alreadyAllMarked_.insert(block);
+    }
+    return MarkResult(anyMarked, allMarked);
   }
 
   // If we output or write to a live memory location, mark this node
-  // Returns true iff this marked something we haven't marked before.
-  bool markIfLive(Node* node) {
+  // Returned MarkResult is composed by two values.
+  // markUpdated = true iff this marked something we haven't marked before.
+  // fullyMarked = true iff this node is marked.
+  MarkResult markIfLive(Node* node) {
     for (const auto output : node->outputs()) {
       if (liveValuesContains(output)) {
         return mark(node);
@@ -227,15 +269,17 @@ class DeadCodeEliminator {
       }
     }
 
-    return false;
+    return MarkResult(false, false);
   }
 
   // Mark this node as live and add this node's inputs and aliases to the live
   // value sets.
-  // Returns true iff this marked something we haven't marked before.
-  bool mark(Node* node) {
+  // Returned MarkResult is composed by two values.
+  // markUpdated = true iff this marked something we haven't marked before.
+  // fullyMarked = true iff this node is marked.
+  MarkResult mark(Node* node) {
     if (marked_.count(node)) {
-      return false;
+      return MarkResult(false, true);
     }
 
     marked_.insert(node);
@@ -258,7 +302,7 @@ class DeadCodeEliminator {
       }
       insertLiveValue(input);
     }
-    return true;
+    return MarkResult(true, true);
   }
 
   // Delete all unmarked nodes.
@@ -473,6 +517,7 @@ class DeadCodeEliminator {
   // initialized. liveValuesAndMemoryLocations_ is used if we are using AliasDb
   //   (in order to store aliasing info),
   // otherwise liveValuesSet_ is used.
+  std::unordered_set<Block*> alreadyAllMarked_;
   std::unique_ptr<ValueAndMemoryLocationSet> liveValuesAndMemoryLocations_ =
       nullptr;
   std::unique_ptr<ValueSet> liveValuesSet_ = nullptr;

--- a/torch/csrc/jit/passes/dead_code_elimination.h
+++ b/torch/csrc/jit/passes/dead_code_elimination.h
@@ -4,6 +4,15 @@
 
 namespace torch::jit {
 
+class MarkResult {
+ public:
+  bool markUpdated_; // Returns true iff this marked something we haven't marked
+                     // before.
+  bool fullyMarked_; // Returns true iff all unders are fully marked.
+  MarkResult(bool markUpdated, bool fullyMarked)
+      : markUpdated_(markUpdated), fullyMarked_(fullyMarked) {}
+};
+
 // If given a top-level graph, DCE will construct do alias analysis that allows
 // for "smarter" dead code elimination (we will eliminate mutable ops if we can
 // prove the mutated values are not used). Otherwise, we will not allow DCE to


### PR DESCRIPTION
Summary:
This diff seeks to optimize the DeadCodeEliminator within the mark(block) function.

The primary concept is to prevent redundant traversals of a fully marked block, particularly in the markLoop scenario, if all nodes within a block are marked, we can subsequently mark the block as fully marked.

Test Plan: Existing unittest. Will add new soon

Differential Revision: D73476431




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel