### PR TITLE
Add latex settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,9 @@ To create the PDF:
    make LATEXOPTS="-interaction=nonstopmode"
    ```
 
-   This will produce a `pytorch.pdf` with the desired content.
+   This will produce a `pytorch.pdf` with the desired content. Run this
+   command one more time so that it generates the correct table
+   of contents and index.
 
 > [!NOTE]
 > To view the Table of Contents, switch to the **Table of Contents**

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Our trunk health (Continuous Integration signals) can be found at [hud.pytorch.o
     - [Using pre-built images](#using-pre-built-images)
     - [Building the image yourself](#building-the-image-yourself)
   - [Building the Documentation](#building-the-documentation)
+    - [Building a PDF](#building-a-pdf)
   - [Previous Versions](#previous-versions)
 - [Getting Started](#getting-started)
 - [Resources](#resources)
@@ -426,8 +427,6 @@ make -f docker.Makefile
 To build documentation in various formats, you will need [Sphinx](http://www.sphinx-doc.org)
 and the pytorch_sphinx_theme2.
 
-
-
 Before you build the documentation locally, ensure `torch` is
 installed in your environment. For small fixes, you can install the
 nightly version as described in [Getting Started](https://pytorch.org/get-started/locally/).
@@ -465,6 +464,38 @@ If you get a katex error run `npm install katex`.  If it persists, try
 
 When you make changes to the dependencies run by CI, edit the
 `.ci/docker/requirements-docs.txt` file.
+
+#### Building a PDF
+
+To compile a PDF of all PyTorch documentation, ensure you have
+`texlive` and LaTeX installed. On macOS, you can install them using:
+
+```
+brew install --cask mactex
+```
+
+To create the PDF:
+
+1. Run:
+
+   ```
+   make latexpdf
+   ```
+
+   This will generate the necessary files in the `build/latex` directory.
+
+2. Navigate to this directory and execute:
+
+   ```
+   make LATEXOPTS="-interaction=nonstopmode"
+   ```
+
+   This will produce a `pytorch.pdf` with the desired content.
+
+> [!NOTE]
+> To view the Table of Contents, switch to the **Table of Contents**
+> view in your PDF viewer.
+
 
 ### Previous Versions
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3799,7 +3799,7 @@ latex_elements = {
        \setcounter{secnumdepth}{3}
        % Fix table column widths
        \renewenvironment{tabulary}{\begin{longtable}{p{0.3\linewidth}p{0.7\linewidth}}}{\end{longtable}}
-       
+
        % Ensure tables don't overflow
        \AtBeginEnvironment{tabular}{\sloppy}
     """,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,7 @@ import pytorch_sphinx_theme2
 html_theme = "pytorch_sphinx_theme2"
 html_theme_path = [pytorch_sphinx_theme2.get_html_theme_path()]
 
+
 # -- General configuration ------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3786,8 +3786,8 @@ htmlhelp_basename = "PyTorchdoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
-latex_engine = 'xelatex'
-latex_show_urls = 'footnote'
+latex_engine = "lualatex"
+latex_show_urls = "footnote"
 
 latex_elements = {
     "papersize": "letterpaper",
@@ -3797,35 +3797,14 @@ latex_elements = {
        \usepackage{tocloft}
        \setcounter{tocdepth}{3}
        \setcounter{secnumdepth}{3}
-       \usepackage{etoolbox}
-       % Increase LaTeX memory limits
-       \usepackage{etex}
-       \reserveinserts{28}
-       \usepackage{luatex85}
-       % Fix for SVG images
-       \usepackage{graphicx}
-       \usepackage{svg}
-       \usepackage{ifxetex}
-       \ifxetex
-         \usepackage{letltxmacro}
-         \LetLtxMacro\SavedIncludeGraphics\includegraphics
-         \def\includegraphics#1#{% #1 catches optional stuff (star/opt. arg.)
-           \IncludeGraphicsAux{#1}%
-         }%
-         \newcommand*{\IncludeGraphicsAux}[2]{%
-           \ifpdf
-             \SavedIncludeGraphics#1{#2}%
-           \else
-             \SavedIncludeGraphics#1{#2}%
-           \fi
-         }%
-       \fi
+       % Fix table column widths
+       \renewenvironment{tabulary}{\begin{longtable}{p{0.3\linewidth}p{0.7\linewidth}}}{\end{longtable}}
+       
+       % Ensure tables don't overflow
+       \AtBeginEnvironment{tabular}{\sloppy}
     """,
     "fncychap": r"\usepackage[Bjornstrup]{fncychap}",
-    "maxlistdepth": "2",
-    "sphinxsetup": "verbatimwithframe=false",
     "extraclassoptions": "oneside",
-    "babel": "\\usepackage{babel}",
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
@@ -3834,9 +3813,15 @@ latex_elements = {
 
 
 latex_documents = [
-    ('pytorch-api', 'pytorch_api.tex', 'PyTorch API Reference', 'Torch Contributors', 'manual'),
-    ('notes', 'pytorch_notes.tex', 'PyTorch Notes', 'Torch Contributors', 'manual'),
+    (
+        master_doc,
+        "pytorch.tex",
+        "PyTorch Documentation",
+        "Torch Contributors",
+        "manual",
+    ),
 ]
+latex_use_xindy = False
 
 
 # -- Options for manual page output ---------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3795,25 +3795,47 @@ latex_elements = {
     "tableofcontents": r"\pdfbookmark[0]{Contents}{toc}\tableofcontents",
     "preamble": r"""
        \usepackage{tocloft}
-       \setcounter{tocdepth}{4}
-       \setcounter{secnumdepth}{4}
+       \setcounter{tocdepth}{3}
+       \setcounter{secnumdepth}{3}
        \usepackage{etoolbox}
-       \pretocmd{\tableofcontents}{\pdfbookmark[0]{Contents}{toc}}{}{}
+       % Increase LaTeX memory limits
+       \usepackage{etex}
+       \reserveinserts{28}
+       \usepackage{luatex85}
+       % Fix for SVG images
+       \usepackage{graphicx}
+       \usepackage{svg}
+       \usepackage{ifxetex}
+       \ifxetex
+         \usepackage{letltxmacro}
+         \LetLtxMacro\SavedIncludeGraphics\includegraphics
+         \def\includegraphics#1#{% #1 catches optional stuff (star/opt. arg.)
+           \IncludeGraphicsAux{#1}%
+         }%
+         \newcommand*{\IncludeGraphicsAux}[2]{%
+           \ifpdf
+             \SavedIncludeGraphics#1{#2}%
+           \else
+             \SavedIncludeGraphics#1{#2}%
+           \fi
+         }%
+       \fi
     """,
     "fncychap": r"\usepackage[Bjornstrup]{fncychap}",
+    "maxlistdepth": "2",
+    "sphinxsetup": "verbatimwithframe=false",
+    "extraclassoptions": "oneside",
+    "babel": "\\usepackage{babel}",
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
+
+
 latex_documents = [
-    (
-        master_doc,
-        "pytorch.tex",
-        "PyTorch Documentation",
-        "Torch Contributors",
-        "manual",
-    ),
+    ('pytorch-api', 'pytorch_api.tex', 'PyTorch API Reference', 'Torch Contributors', 'manual'),
+    ('notes', 'pytorch_notes.tex', 'PyTorch Notes', 'Torch Contributors', 'manual'),
 ]
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3786,19 +3786,21 @@ htmlhelp_basename = "PyTorchdoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
+latex_engine = 'xelatex'
+latex_show_urls = 'footnote'
+
 latex_elements = {
-    # The paper size ('letterpaper' or 'a4paper').
-    #
-    # 'papersize': 'letterpaper',
-    # The font size ('10pt', '11pt' or '12pt').
-    #
-    # 'pointsize': '10pt',
-    # Additional stuff for the LaTeX preamble.
-    #
-    # 'preamble': '',
-    # Latex figure (float) alignment
-    #
-    # 'figure_align': 'htbp',
+    "papersize": "letterpaper",
+    "pointsize": "10pt",
+    "tableofcontents": r"\pdfbookmark[0]{Contents}{toc}\tableofcontents",
+    "preamble": r"""
+       \usepackage{tocloft}
+       \setcounter{tocdepth}{4}
+       \setcounter{secnumdepth}{4}
+       \usepackage{etoolbox}
+       \pretocmd{\tableofcontents}{\pdfbookmark[0]{Contents}{toc}}{}{}
+    """,
+    "fncychap": r"\usepackage[Bjornstrup]{fncychap}",
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -33,12 +33,6 @@ Features described in this documentation are classified by release status:
 :maxdepth: 2
 
 pytorch-api
-```
-
-```{toctree}
-:glob:
-:maxdepth: 2
-
 notes
 ```
 


### PR DESCRIPTION
- Fixes #147027
- Only lualatex can build our 3K pages PDF with reasonable quality, xelatex runs out of memory and pdflatex just fails.
- Move notes under the same toctree as python-api which is needed for the PDF but doesn't change how the HTML is generated. 

This is the produced PDF:
[pytorch.pdf](https://github.com/user-attachments/files/19945450/pytorch.pdf)




cc @sekyondaMeta @AlannaBurke