### PR TITLE
Cast to unsigned char to avoid UB

### DIFF
--- a/aten/src/ATen/core/Dimname.cpp
+++ b/aten/src/ATen/core/Dimname.cpp
@@ -25,9 +25,10 @@ bool Dimname::isValidName(const std::string& name) {
   }
   for (auto it = name.begin(); it != name.end(); ++it) {
     // NOLINTNEXTLINE(bugprone-branch-clone)
-    if (std::isalpha(*it) || *it == '_') {
+    const unsigned char ch = static_cast<unsigned char>(*it);
+    if (std::isalpha(ch) || ch == '_') {
       continue;
-    } else if (it != name.begin() && std::isdigit(*it)) {
+    } else if (it != name.begin() && std::isdigit(ch)) {
       continue;
     }
     return false;

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -82,11 +82,12 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
   for (size_t i = 0;
        pstate != DeviceStringParsingState::ERROR && i < device_string.size();
        ++i) {
-    const unsigned char ch = static_cast<unsigned char>(device_string.at(i));
+    const char ch = device_string.at(i);
+    const unsigned char uch = static_cast<unsigned char>(ch);
     switch (pstate) {
       case DeviceStringParsingState::START:
         if (ch != ':') {
-          if (isalpha(ch) || ch == '_') {
+          if (isalpha(uch) || ch == '_') {
             device_name.push_back(ch);
           } else {
             pstate = DeviceStringParsingState::ERROR;
@@ -97,7 +98,7 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
         break;
 
       case DeviceStringParsingState::INDEX_START:
-        if (isdigit(ch)) {
+        if (isdigit(uch)) {
           device_index_str.push_back(ch);
           pstate = DeviceStringParsingState::INDEX_REST;
         } else {
@@ -110,7 +111,7 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
           pstate = DeviceStringParsingState::ERROR;
           break;
         }
-        if (isdigit(ch)) {
+        if (isdigit(uch)) {
           device_index_str.push_back(ch);
         } else {
           pstate = DeviceStringParsingState::ERROR;

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -82,7 +82,7 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
   for (size_t i = 0;
        pstate != DeviceStringParsingState::ERROR && i < device_string.size();
        ++i) {
-    const char ch = device_string.at(i);
+    const unsigned char ch = static_cast<unsigned char>(*it);
     switch (pstate) {
       case DeviceStringParsingState::START:
         if (ch != ':') {

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -82,7 +82,7 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
   for (size_t i = 0;
        pstate != DeviceStringParsingState::ERROR && i < device_string.size();
        ++i) {
-    const unsigned char ch = static_cast<unsigned char>(*it);
+    const unsigned char ch = static_cast<unsigned char>(device_string.at(i));
     switch (pstate) {
       case DeviceStringParsingState::START:
         if (ch != ':') {

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -87,7 +87,7 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
     switch (pstate) {
       case DeviceStringParsingState::START:
         if (ch != ':') {
-          if (isalpha(uch) || ch == '_') {
+          if (std::isalpha(uch) || ch == '_') {
             device_name.push_back(ch);
           } else {
             pstate = DeviceStringParsingState::ERROR;
@@ -98,7 +98,7 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
         break;
 
       case DeviceStringParsingState::INDEX_START:
-        if (isdigit(uch)) {
+        if (std::isdigit(uch)) {
           device_index_str.push_back(ch);
           pstate = DeviceStringParsingState::INDEX_REST;
         } else {
@@ -111,7 +111,7 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
           pstate = DeviceStringParsingState::ERROR;
           break;
         }
-        if (isdigit(uch)) {
+        if (std::isdigit(uch)) {
           device_index_str.push_back(ch);
         } else {
           pstate = DeviceStringParsingState::ERROR;


### PR DESCRIPTION
The standard requires that the argument to functions like `isdigit`, `isalpha`, and similar must be either `EOF` or an `unsigned char`; otherwise, the behavior is undefined (UB).  
To avoid out-of-bounds reads, modern implementations of some libraries (such as glibc) deliberately pad their internal tables to guarantee valid memory access even for negative values. However, this is implementation-specific, and other libraries may not do this.  

Properly casting the argument to `unsigned char` is good practice to avoid potential issues on some platforms.