### PR TITLE
[MPSInductor][BE] Make all reductions cacheable

### DIFF
--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -552,14 +552,26 @@ class MetalKernel(SIMDKernel):
         reduction_type: ReductionType,
         value: Union[CSEVariable, tuple[CSEVariable, ...]],
     ) -> Union[CSEVariable, tuple[CSEVariable, ...]]:
-        """Codegen a reduction operation.
-        Only sum and prod operations are somewhat reasonable optimized"""
-        # Return cached reduction
-        assert self.inside_reduction
-        assert not self._load_mask
+        "Caching wrapper around _reduction_nocache"
         cache_key = (src_dtype, reduction_type, value)
+        # Return cached reduction
         if cache_key in self.cse.reduction_cache:
             return self.cse.reduction_cache[cache_key]
+        result = self._reduction_nocache(dtype, src_dtype, reduction_type, value)
+        self.cse.reduction_cache[cache_key] = result
+        return result
+
+    def _reduction_nocache(
+        self,
+        dtype: torch.dtype,
+        src_dtype: torch.dtype,
+        reduction_type: ReductionType,
+        value: Union[CSEVariable, tuple[CSEVariable, ...]],
+    ) -> Union[CSEVariable, tuple[CSEVariable, ...]]:
+        """Codegen a reduction operation.
+        Only sum and prod operations are somewhat reasonable optimized"""
+        assert self.inside_reduction
+        assert not self._load_mask
 
         # Establish reduction buffer size and index expression
         reduction_idx = ""
@@ -665,10 +677,7 @@ class MetalKernel(SIMDKernel):
                     self.compute,
                     f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {acc_buf_size})",
                 )
-                self.cse.reduction_cache[cache_key] = result_tuple = OpsWrapper._unwrap(
-                    (f"{wf_res}.x", f"{wf_res}.y", f"{wf_res}.z")
-                )
-                return result_tuple
+                return OpsWrapper._unwrap((f"{wf_res}.x", f"{wf_res}.y", f"{wf_res}.z"))
             acc_buf = self._new_idxvar("float3", acc_buf_size)
             acc_thread_var = f"{acc_buf}[{reduction_idx}]"
             self.indexing_code.splice(f"{acc_thread_var} = 0.0;")
@@ -679,10 +688,7 @@ class MetalKernel(SIMDKernel):
                 self.stores,
                 f"c10::metal::threadgroup_welford_combine({acc_buf}, {acc_buf_size})",
             )
-            self.cse.reduction_cache[cache_key] = result_tuple = OpsWrapper._unwrap(
-                (f"{wf_res}.x", f"{wf_res}.y", f"{wf_res}.z")
-            )
-            return result_tuple
+            return OpsWrapper._unwrap((f"{wf_res}.x", f"{wf_res}.y", f"{wf_res}.z"))
         if reduction_type == "welford_combine":
             assert isinstance(value, tuple), "Input to welford combine must be tuple"
             acc_buf = self._new_idxvar("float3", acc_buf_size)
@@ -700,10 +706,7 @@ class MetalKernel(SIMDKernel):
                 self.stores if self.multistage_reduction else self.compute,
                 f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {acc_buf_size})",
             )
-            self.cse.reduction_cache[cache_key] = result_tuple = OpsWrapper._unwrap(
-                (f"{wf_res}.x", f"{wf_res}.y", f"{wf_res}.z")
-            )
-            return result_tuple
+            return OpsWrapper._unwrap((f"{wf_res}.x", f"{wf_res}.y", f"{wf_res}.z"))
         raise NotImplementedError(reduction_type)
 
     def codegen_iteration_ranges_entry(self, entry: IterationRangesEntry) -> None:

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -558,7 +558,7 @@ class MetalKernel(SIMDKernel):
         if cache_key in self.cse.reduction_cache:
             return self.cse.reduction_cache[cache_key]
         result = self._reduction_nocache(dtype, src_dtype, reduction_type, value)
-        self.cse.reduction_cache[cache_key] = result
+        self.cse.reduction_cache[cache_key] = result  # type: ignore[assignment]
         return result
 
     def _reduction_nocache(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152363

By moving actual implementaiton to `_reduction_nocache` and make reduction a caching wrapper

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov