### PR TITLE
[MPS] fix memory leak in sdpa float32

### DIFF
--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -99,10 +99,9 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
           auto maskedMM = [mpsGraph matrixMultiplicationWithPrimaryTensor:qTensor secondaryTensor:kT name:nil];
 
           if (macOS15_0_plus && [maskedMM dataType] == MPSDataTypeFloat32) {
-            // TODO: In MacOS15 beta, there is a MPSGraph issue when the SDPA sequence gets remapped to use
-            // an improved kernel for the computation, causing NaNs in the result. This identity prevents the remapping.
-            // Limit the availability check once a fix lands.
-            maskedMM = [mpsGraph identityWithTensor:maskedMM name:nil];
+            // bug in MacOS15, without this trick SDPA leaks memory
+            auto oneTensor = [mpsGraph constantWithScalar:1e-20f shape:getMPSShape({1}) dataType:MPSDataTypeFloat32];
+            maskedMM = [mpsGraph additionWithPrimaryTensor:maskedMM secondaryTensor:oneTensor name:nil];
           }
 
           // upcasting to float32 if needed to improve precision when multiplying by the scale factor

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -99,7 +99,8 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
           auto maskedMM = [mpsGraph matrixMultiplicationWithPrimaryTensor:qTensor secondaryTensor:kT name:nil];
 
           if (macOS15_0_plus && [maskedMM dataType] == MPSDataTypeFloat32) {
-            // bug in MacOS15, without this trick SDPA leaks memory
+            // bug in MacOS15, without this trick SDPA leaks memory, adding 0.0f gets ignored(still takes SDPA sequence
+            // path which leaks)
             auto oneTensor = [mpsGraph constantWithScalar:1e-20f shape:getMPSShape({1}) dataType:MPSDataTypeFloat32];
             maskedMM = [mpsGraph additionWithPrimaryTensor:maskedMM secondaryTensor:oneTensor name:nil];
           }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9239,18 +9239,18 @@ class TestSDPA(TestCaseMPS):
         def get_mps_memory_usage():
             return (torch.mps.current_allocated_memory() / (1024 * 1024),
                     torch.mps.driver_allocated_memory() / (1024 * 1024))
-        if MACOS_VERSION > 15.0:
-            batch_size, seq_len, num_heads, head_dim = 4, 128, 8, 64
-            query = torch.randn(batch_size, num_heads, seq_len, head_dim, device="mps", dtype=torch.float32)
-            key = torch.randn(batch_size, num_heads, seq_len, head_dim, device="mps", dtype=torch.float32)
-            value = torch.randn(batch_size, num_heads, seq_len, head_dim, device="mps", dtype=torch.float32)
-            memory_footprints = []
-            for i in range(100):
-                output = F.scaled_dot_product_attention(query, key, value)
-                current_mem, driver_mem = get_mps_memory_usage()
-                memory_footprints.append((current_mem, driver_mem))
-            # 5 MB different maximum allowed value(could be decreased even more)
-            torch.testing.assert_close(memory_footprints[-1], memory_footprints[0], atol=5, rtol=1)
+
+        batch_size, seq_len, num_heads, head_dim = 4, 128, 8, 64
+        query = torch.randn(batch_size, num_heads, seq_len, head_dim, device="mps", dtype=torch.float32)
+        key = torch.randn(batch_size, num_heads, seq_len, head_dim, device="mps", dtype=torch.float32)
+        value = torch.randn(batch_size, num_heads, seq_len, head_dim, device="mps", dtype=torch.float32)
+        memory_footprints = []
+        for i in range(100):
+            output = F.scaled_dot_product_attention(query, key, value)
+            current_mem, driver_mem = get_mps_memory_usage()
+            memory_footprints.append((current_mem, driver_mem))
+        # 5 MB different maximum allowed value(could be decreased even more)
+        torch.testing.assert_close(memory_footprints[-1], memory_footprints[0], atol=5, rtol=1)
 
 class TestGatherScatter(TestCaseMPS):
     def test_slicing_with_step(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9234,6 +9234,22 @@ class TestSDPA(TestCaseMPS):
             )
         self._compare_tensors(y.cpu(), y_ref)
 
+    def test_sdpa_fp32_no_memory_leak(self):
+        def get_mps_memory_usage():
+            return (torch.mps.current_allocated_memory() / (1024 * 1024),
+                    torch.mps.driver_allocated_memory() / (1024 * 1024))
+        if MACOS_VERSION > 15.0:
+            batch_size, seq_len, num_heads, head_dim = 4, 1024, 8, 512
+            query = torch.randn(batch_size, num_heads, seq_len, head_dim, device="mps", dtype=torch.float32)
+            key = torch.randn(batch_size, num_heads, seq_len, head_dim, device="mps", dtype=torch.float32)
+            value = torch.randn(batch_size, num_heads, seq_len, head_dim, device="mps", dtype=torch.float32)
+            memory_footprints = []
+            for i in range(100):
+                output = F.scaled_dot_product_attention(query, key, value)
+                current_mem, driver_mem = get_mps_memory_usage()
+                memory_footprints.append((current_mem, driver_mem))
+            # 5 MB different maximum allowed value(could be decreased even more)
+            torch.testing.assert_close(memory_footprints[-1], memory_footprints[0], atol=5, rtol=1)
 
 class TestGatherScatter(TestCaseMPS):
     def test_slicing_with_step(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9234,12 +9234,13 @@ class TestSDPA(TestCaseMPS):
             )
         self._compare_tensors(y.cpu(), y_ref)
 
+    @serialTest
     def test_sdpa_fp32_no_memory_leak(self):
         def get_mps_memory_usage():
             return (torch.mps.current_allocated_memory() / (1024 * 1024),
                     torch.mps.driver_allocated_memory() / (1024 * 1024))
         if MACOS_VERSION > 15.0:
-            batch_size, seq_len, num_heads, head_dim = 4, 1024, 8, 512
+            batch_size, seq_len, num_heads, head_dim = 4, 128, 8, 64
             query = torch.randn(batch_size, num_heads, seq_len, head_dim, device="mps", dtype=torch.float32)
             key = torch.randn(batch_size, num_heads, seq_len, head_dim, device="mps", dtype=torch.float32)
             value = torch.randn(batch_size, num_heads, seq_len, head_dim, device="mps", dtype=torch.float32)


### PR DESCRIPTION
Fixes #152344

Leak seems to be on the MPS Graph side, even though there is an identity tensor it seems like it's no longer enough to bypass the SDPA sequence which seems to leak memory.

Even adding 0.0f seems to be optimized to be ignored and still take the sdpa sequence(that's the reason for adding 1e-20)


cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen