### PR TITLE
complex.pow(2) on GPU by replacing with complex * complex to avoid numerical instability

### DIFF
--- a/aten/src/ATen/native/cuda/PowKernel.cu
+++ b/aten/src/ATen/native/cuda/PowKernel.cu
@@ -185,6 +185,12 @@ void pow_tensor_scalar_kernel(TensorIteratorBase& iter, const Scalar& exp_scalar
       return;
     }
     AT_DISPATCH_COMPLEX_TYPES(iter.common_dtype(), "pow_cuda", [&]() {
+      if (exp_scalar.equal(2.0)) {
+        gpu_kernel(iter, [=]GPU_LAMBDA(scalar_t base) -> scalar_t {
+          return base * base;
+        });
+        return;
+      }
       const auto exp = exp_scalar.to<scalar_t>();
       gpu_kernel(iter, [=]GPU_LAMBDA(scalar_t base) -> scalar_t {
         return pow_(base, exp);

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1687,6 +1687,7 @@ class TestBinaryUfuncs(TestCase):
             self._test_pow(base, exp)
 
     @onlyCUDA
+    @dtypes(torch.complex64, torch.complex128)
     def test_pow_cuda_complex_extremal_passing(self, device):
         t = torch.tensor(complex(-1.0, float("inf")), device=device)
         cuda_out = t.pow(2)

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1687,8 +1687,8 @@ class TestBinaryUfuncs(TestCase):
             self._test_pow(base, exp)
 
     @onlyCUDA
-    def test_pow_cuda_complex_extremal_passing(self, device, dtype):
-        t = torch.tensor(complex(-1.0, float("inf")), dtype=dtype, device=device)
+    def test_pow_cuda_complex_extremal_passing(self, device):
+        t = torch.tensor(complex(-1.0, float("inf")), device=device)
         cuda_out = t.pow(2)
         cpu_out = t.cpu().pow(2)
         self.assertEqual(cpu_out, cuda_out)

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1686,23 +1686,12 @@ class TestBinaryUfuncs(TestCase):
             base = torch.tensor(3.0, device="cpu")
             self._test_pow(base, exp)
 
-    # adding special case for power of 2 for complex numbers 
     @onlyCUDA
     def test_pow_cuda_complex_extremal_passing(self, device):
-        t = torch.tensor([-5 + 0.j], device=device)
+        t = torch.tensor([-5 + 0.0j], device=device)
         cuda_out = t.pow(2)
         cpu_out = t.cpu().pow(2)
-        # Ensure exact equality
         self.assertEqual(cpu_out, cuda_out)
-
-    @onlyCUDA
-    @dtypes(torch.complex64, torch.complex128)
-    def test_pow_cuda_complex_extremal_failing(self, device, dtype):
-        t = torch.tensor(complex(-1.0, float("inf")), dtype=dtype, device=device)
-        with self.assertRaises(AssertionError):
-            cuda_out = t.pow(2)
-            cpu_out = t.cpu().pow(2)
-            self.assertEqual(cpu_out, cuda_out)
 
     @skipIfTorchDynamo()
     @onlyNativeDeviceTypes

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1687,8 +1687,8 @@ class TestBinaryUfuncs(TestCase):
             self._test_pow(base, exp)
 
     @onlyCUDA
-    def test_pow_cuda_complex_extremal_passing(self, device):
-        t = torch.tensor([-5 + 0.0j], device=device)
+    def test_pow_cuda_complex_extremal_passing(self, device, dtype):
+        t = torch.tensor(complex(-1.0, float("inf")), dtype=dtype, device=device)
         cuda_out = t.pow(2)
         cpu_out = t.cpu().pow(2)
         self.assertEqual(cpu_out, cuda_out)

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1688,8 +1688,8 @@ class TestBinaryUfuncs(TestCase):
 
     @onlyCUDA
     @dtypes(torch.complex64, torch.complex128)
-    def test_pow_cuda_complex_extremal_passing(self, device):
-        t = torch.tensor(complex(-1.0, float("inf")), device=device)
+    def test_pow_cuda_complex_extremal_passing(self, device, dtype):
+        t = torch.tensor(complex(-1.0, float("inf")), dtype=dtype, device=device)
         cuda_out = t.pow(2)
         cpu_out = t.cpu().pow(2)
         self.assertEqual(cpu_out, cuda_out)

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1686,6 +1686,15 @@ class TestBinaryUfuncs(TestCase):
             base = torch.tensor(3.0, device="cpu")
             self._test_pow(base, exp)
 
+    # adding special case for power of 2 for complex numbers 
+    @onlyCUDA
+    def test_pow_cuda_complex_extremal_passing(self, device):
+        t = torch.tensor([-5 + 0.j], device=device)
+        cuda_out = t.pow(2)
+        cpu_out = t.cpu().pow(2)
+        # Ensure exact equality
+        self.assertEqual(cpu_out, cuda_out)
+
     @onlyCUDA
     @dtypes(torch.complex64, torch.complex128)
     def test_pow_cuda_complex_extremal_failing(self, device, dtype):


### PR DESCRIPTION
Fixes #150951 
Summary:
For complex.pow(2) on GPU:

Uses complex * complex directly.
Produces results consistent with CPU implementation.
Eliminates spurious imaginary components for real inputs.

🧪 Tests
Added unit tests to verify correctness of the new kernel path.
Verified numerical consistency with CPU results.


This change is backward-compatible and only affects the specific case of pow(2) on complex tensors on GPU.