### PR TITLE
Feature/enable 8 byte vector loading

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1080,7 +1080,6 @@ __global__ void indexFuncLargeIndex(cuda::detail::TensorInfo<T, IndexType> dst,
     op(dst.data, dstOffset, dstNumel, &val);
   }
 }
-
 // Compare the stride between adjacent slices (sliceStride) with strides in the
 // other dimensions (i.e., strides *inside* each slice).
 //
@@ -1539,11 +1538,16 @@ __global__ void indexSelectLargeIndex(cuda::detail::TensorInfo<T, IndexType> dst
                                       int64_t srcSelectDimSize) {
   // We stride over the output including the indexed dimension
   // (totalSize), and calculate the destination index point based on that
-  for (IndexType linearIndex = blockIdx.x * blockDim.x + threadIdx.x;
-       linearIndex < totalSize;
-       linearIndex += gridDim.x * blockDim.x) {
+  constexpr bool kPack4 = (sizeof(T) == 2);
+  constexpr int kElemsPerVec = kPack4 ? 4 : 1;
+
+  for (IndexType vecLinear = (blockIdx.x * blockDim.x + threadIdx.x) * kElemsPerVec;
+       vecLinear < totalSize;
+       vecLinear += gridDim.x * blockDim.x * kElemsPerVec) {
+
+    IndexType linearIndex = vecLinear;
     IndexType dstIndex, elementInSlice;
-    if (IndexIsMajor) {
+    if constexpr (IndexIsMajor) {
       dstIndex = linearIndex / innerSize;
       elementInSlice = linearIndex % innerSize;
     }
@@ -1563,8 +1567,55 @@ __global__ void indexSelectLargeIndex(cuda::detail::TensorInfo<T, IndexType> dst
     IndexType srcOffset =
       cuda::detail::IndexToOffset<const T, IndexType, SrcDim>::get(elementInSlice, src);
     srcOffset += srcIndex * src.strides[srcSelectDim];
+    if constexpr (kPack4) {
+      IndexType srcNextOffset = cuda::detail::IndexToOffset<const T, IndexType, SrcDim>::get(elementInSlice + 1, src) + srcIndex * src.strides[srcSelectDim];
+      IndexType dstNextOffset = cuda::detail::IndexToOffset<T, IndexType, DstDim>::get(elementInSlice + 1, dst) + dstIndex * dst.strides[dstSelectDim];
 
-    dst.data[dstOffset] = src.data[srcOffset];
+      bool inner_contiguous = (srcNextOffset - srcOffset == 1) && (dstNextOffset - dstOffset == 1);
+      bool slic_has_4 = (elementInSlice + 3 < innerSize);
+      bool aligned = (((uintptr_t)(dst.data + dstOffset) & 7)==0) && (((uintptr_t)(src.data + srcOffset) & 7)==0);
+
+      bool can_vectorize = IndexIsMajor && inner_contiguous && slic_has_4 && aligned;
+      #if defined(__CUDA_ARCH__)
+        bool warp_fast = __all_sync(0xffffffffu, can_vectorize);
+      #elif defined(__HIP_DEVICE_COMPILE__)
+        unsigned long long mask = __ballot(can_vectorize);
+        bool warp_fast = (mask == 0xffffffff);
+      #else
+        bool warp_fast = can_vectorize;
+      #endif
+
+      if (warp_fast) {
+        uint64_t tmp;
+        memcpy(&tmp, src.data + srcOffset, 8);
+        memcpy(dst.data + dstOffset, &tmp, 8);
+      } else {
+      #pragma unroll
+      for (int i = 0; i < kElemsPerVec; ++i) {
+        IndexType li = linearIndex + i;
+        if (li >= totalSize) break;
+
+        IndexType dstIndex2, elem2;
+        if constexpr (IndexIsMajor) {
+          dstIndex2 = li / innerSize;
+          elem2 = li % innerSize;
+        } else {
+          elem2 = li / innerSize;
+          dstIndex2 = li % innerSize;
+        }
+
+        IndexType srcIndex2 = indices.data[cuda::detail::IndexToOffset<const IndicesType, IndexType, IdxDim>::get(dstIndex2, indices)];
+        CUDA_KERNEL_ASSERT(srcIndex2 < srcSelectDimSize);
+
+        IndexType dstOffset2 = cuda::detail::IndexToOffset<T, IndexType, DstDim>::get(elem2, dst) + dstIndex2 * dst.strides[dstSelectDim];
+        IndexType srcOffset2 = cuda::detail::IndexToOffset<const T, IndexType, SrcDim>::get(elem2, src) + srcIndex2 * src.strides[srcSelectDim];
+        dst.data[dstOffset2] = src.data[srcOffset2];
+        }
+      }
+    }
+    else {
+      dst.data[dstOffset] = src.data[srcOffset];
+    }
   }
 }
 
@@ -1621,6 +1672,7 @@ void index_select_out_cuda_impl(
   }
 
   bool indContig = index.is_contiguous();
+
 
   // The `self` is partitioned into two parts:
   // -the size of each slice we are indexing, which is the
@@ -1706,7 +1758,13 @@ void index_select_out_cuda_impl(
             LARGE_INDEX(scalar_t, index_t, unsigned int, 3, 3, -2, false);
           }
         } else {
-          LARGE_INDEX(scalar_t, index_t, unsigned int, -1, -1, -1, true);
+
+          if (indexIsMajor) {
+            LARGE_INDEX(scalar_t, index_t, unsigned int, -1, -1, -1, true);
+          } else {
+            LARGE_INDEX(scalar_t, index_t, unsigned int, -1, -1, -1, false);
+          }
+
         }
       }
     });

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -514,11 +514,7 @@ class ReduceAdd {
 public:
   template <typename scalar_t>
   constexpr C10_DEVICE void operator() (scalar_t* self_data_start, int64_t index, int64_t numel, const scalar_t * src_data) const {
-#if (defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || defined(__gfx950__))
-    opportunistic_fastAtomicAdd(self_data_start, index, numel, *src_data);
-#else
     fastAtomicAdd(self_data_start, index, numel, *src_data, true);
-#endif
   }
 };
 static ReduceAdd reduce_add;
@@ -1080,7 +1076,6 @@ __global__ void indexFuncLargeIndex(cuda::detail::TensorInfo<T, IndexType> dst,
     op(dst.data, dstOffset, dstNumel, &val);
   }
 }
-
 // Compare the stride between adjacent slices (sliceStride) with strides in the
 // other dimensions (i.e., strides *inside* each slice).
 //
@@ -1539,11 +1534,16 @@ __global__ void indexSelectLargeIndex(cuda::detail::TensorInfo<T, IndexType> dst
                                       int64_t srcSelectDimSize) {
   // We stride over the output including the indexed dimension
   // (totalSize), and calculate the destination index point based on that
-  for (IndexType linearIndex = blockIdx.x * blockDim.x + threadIdx.x;
-       linearIndex < totalSize;
-       linearIndex += gridDim.x * blockDim.x) {
+  constexpr bool kPack4 = (sizeof(T) == 2);
+  constexpr int kElemsPerVec = kPack4 ? 4 : 1;
+
+  for (IndexType vecLinear = (blockIdx.x * blockDim.x + threadIdx.x) * kElemsPerVec;
+       vecLinear < totalSize;
+       vecLinear += gridDim.x * blockDim.x * kElemsPerVec) {
+
+    IndexType linearIndex = vecLinear;
     IndexType dstIndex, elementInSlice;
-    if (IndexIsMajor) {
+    if constexpr (IndexIsMajor) {
       dstIndex = linearIndex / innerSize;
       elementInSlice = linearIndex % innerSize;
     }
@@ -1563,10 +1563,58 @@ __global__ void indexSelectLargeIndex(cuda::detail::TensorInfo<T, IndexType> dst
     IndexType srcOffset =
       cuda::detail::IndexToOffset<const T, IndexType, SrcDim>::get(elementInSlice, src);
     srcOffset += srcIndex * src.strides[srcSelectDim];
+    if constexpr (kPack4) {
+      IndexType srcNextOffset = cuda::detail::IndexToOffset<const T, IndexType, SrcDim>::get(elementInSlice + 1, src) + srcIndex * src.strides[srcSelectDim];
+      IndexType dstNextOffset = cuda::detail::IndexToOffset<T, IndexType, DstDim>::get(elementInSlice + 1, dst) + dstIndex * dst.strides[dstSelectDim];
 
-    dst.data[dstOffset] = src.data[srcOffset];
+      bool inner_contiguous = (srcNextOffset - srcOffset == 1) && (dstNextOffset - dstOffset == 1);
+      bool slic_has_4 = (elementInSlice + 3 < innerSize);
+      bool aligned = (((uintptr_t)(dst.data + dstOffset) & 7)==0) && (((uintptr_t)(src.data + srcOffset) & 7)==0);
+
+      bool can_vectorize = IndexIsMajor && inner_contiguous && slic_has_4 && aligned;
+      #if defined(__CUDA_ARCH__)
+        bool warp_fast = __all_sync(0xffffffffu, can_vectorize);
+      #elif defined(__HIP_DEVICE_COMPILE__)
+        unsigned long long mask = __ballot(can_vectorize);
+        bool warp_fast = (mask == 0xffffffff);
+      #else
+        bool warp_fast = can_vectorize;
+      #endif
+
+      if (warp_fast) {
+        uint64_t tmp;
+        memcpy(&tmp, src.data + srcOffset, 8);
+        memcpy(dst.data + dstOffset, &tmp, 8);
+      } else {
+      #pragma unroll
+      for (int i = 0; i < kElemsPerVec; ++i) {
+        IndexType li = linearIndex + i;
+        if (li >= totalSize) break;
+
+        IndexType dstIndex2, elem2;
+        if constexpr (IndexIsMajor) {
+          dstIndex2 = li / innerSize;
+          elem2 = li % innerSize;
+        } else {
+          elem2 = li / innerSize;
+          dstIndex2 = li % innerSize;
+        }
+
+        IndexType srcIndex2 = indices.data[cuda::detail::IndexToOffset<const IndicesType, IndexType, IdxDim>::get(dstIndex2, indices)];
+        CUDA_KERNEL_ASSERT(srcIndex2 < srcSelectDimSize);
+
+        IndexType dstOffset2 = cuda::detail::IndexToOffset<T, IndexType, DstDim>::get(elem2, dst) + dstIndex2 * dst.strides[dstSelectDim];
+        IndexType srcOffset2 = cuda::detail::IndexToOffset<const T, IndexType, SrcDim>::get(elem2, src) + srcIndex2 * src.strides[srcSelectDim];
+        dst.data[dstOffset2] = src.data[srcOffset2];
+        }
+      }
+    }
+    else {
+      dst.data[dstOffset] = src.data[srcOffset];
+    }
   }
 }
+
 
 namespace {
 
@@ -1622,6 +1670,7 @@ void index_select_out_cuda_impl(
 
   bool indContig = index.is_contiguous();
 
+
   // The `self` is partitioned into two parts:
   // -the size of each slice we are indexing, which is the
   // total size of the tensor ignoring dimension `dim`;
@@ -1676,6 +1725,7 @@ void index_select_out_cuda_impl(
       auto indicesInfo = tensorInfoLegacyIfScalar(cuda::detail::getTensorInfo<const index_t, unsigned int>(index));
       indicesInfo.collapseDims();
 
+      // bool indexIsMajor = indexShouldBeMajor(outInfo, outSelectDim);
       // A reasonable choice for when to have each thread iterate over
       // indices to choose
       if (numIndices <= 16) {
@@ -1706,7 +1756,13 @@ void index_select_out_cuda_impl(
             LARGE_INDEX(scalar_t, index_t, unsigned int, 3, 3, -2, false);
           }
         } else {
-          LARGE_INDEX(scalar_t, index_t, unsigned int, -1, -1, -1, true);
+
+          if (indexIsMajor) {
+            LARGE_INDEX(scalar_t, index_t, unsigned int, -1, -1, -1, true);
+          } else {
+            LARGE_INDEX(scalar_t, index_t, unsigned int, -1, -1, -1, false);
+          }
+
         }
       }
     });

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -514,7 +514,11 @@ class ReduceAdd {
 public:
   template <typename scalar_t>
   constexpr C10_DEVICE void operator() (scalar_t* self_data_start, int64_t index, int64_t numel, const scalar_t * src_data) const {
+#if (defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || defined(__gfx950__))
+    opportunistic_fastAtomicAdd(self_data_start, index, numel, *src_data);
+#else
     fastAtomicAdd(self_data_start, index, numel, *src_data, true);
+#endif
   }
 };
 static ReduceAdd reduce_add;
@@ -1615,7 +1619,6 @@ __global__ void indexSelectLargeIndex(cuda::detail::TensorInfo<T, IndexType> dst
   }
 }
 
-
 namespace {
 
 // When using a 0-dim scalar tensor, we need the legacy (THC) semantics of
@@ -1725,7 +1728,6 @@ void index_select_out_cuda_impl(
       auto indicesInfo = tensorInfoLegacyIfScalar(cuda::detail::getTensorInfo<const index_t, unsigned int>(index));
       indicesInfo.collapseDims();
 
-      // bool indexIsMajor = indexShouldBeMajor(outInfo, outSelectDim);
       // A reasonable choice for when to have each thread iterate over
       // indices to choose
       if (numIndices <= 16) {


### PR DESCRIPTION
## Summary

Enable aligned vector loading for 2 bytes data types for index select. Specifically:

- **4 element fp16/bf16 packing**: added 8-byte vector load/store to move 4 half values at once.
- **warp-wide predicate (__all_sync)**: decide fast vs fallback path per warp, eliminating lane level divergence
- **alignment guard**: fast or vectorized path only executes when src and dst are 8 byte aligned, preventing mis aligned address faults.
- **Safe for loop fallback**: for misaligned, strid > 1, or tail elements we recompute offsets per element to avoid memory corruption.
- **Bound checks**: fast or vectorized path is skipped when less than 4 elements are remaining, guaranteeing bounded access.
- **Stride remapping**: Redirect calls to inner contiguous dim which has stride = 1 so copies occur along memory coalesced axes.
- **AMD support**: Ensured portability and correctness across CUDA and HIP platforms.

## Perf testing
We note a 2.5x improvement in memory bandwidth after this change when the tensor dim is a multiple of 4 for 2 byte data types (fp16/bf16).

<img width="625" alt="image" src="https://github.com/user-attachments/assets/909b04a3-98f2-4c30-8c29-c36e1beeea0f" />

With input tensor dimension not being a multiple of 4, we see a smaller improvement (~1.2x) due to warp divergence.
<img width="624" alt="image" src="https://github.com/user-attachments/assets/f3ed16f4-b091-48bd-9889-093f6a90688d" />

## Perf testing code
```
# pyre-strict
from typing import List, Optional, Tuple

import click
import pandas as pd

import torch

# @manual=//triton:triton
import triton


@click.command()
@click.option("--data-type", type=str, default="bf16")
@click.option("--return-result", type=bool, default=False)
def main(
    data_type: str,
    return_result: bool,
) -> Optional[Tuple[List[triton.testing.Benchmark], List[pd.DataFrame]]]:
    torch.backends.cudnn.allow_tf32 = True
    torch.backends.cuda.matmul.allow_tf32 = True
    data_types = {"fp32", "fp16", "bf16"}
    if data_type not in data_types:
        raise ValueError(f"Unsupported data type: {data_type}.")

    dtype = {
        "fp32": torch.float32,
        "fp16": torch.float16,
        "bf16": torch.bfloat16
    }[data_type]

    D1 = 192
    D2 = 156
    configs: List[triton.testing.Benchmark] = [
        triton.testing.Benchmark(
            x_names=["B"],
            x_vals=[24],
            line_arg="provider",
            line_vals=[
                "repeat_interleave",
                "repeat_interleave_int32",
            ],
            line_names=["repeat_interleave", "repeat_interleave_int32"],
            styles=[("red", "-"), ("purple", "-")],
            ylabel="ms",
            plot_name=f"torch-repeat_interleave-D1-{D1}-D2-{D2}-dtype-{dtype}",
            args={
                "D1": D1,
                "D2": D2,
                "dtype": dtype,
            },
        )
    ]

    @triton.testing.perf_report(configs)
    def bench_repeat_interleave(
        B: int,
        D1: int,
        D2: int,
        dtype: torch.dtype,
        provider: str,
    ) -> float:
        warmup = 20
        rep = 100
        torch.manual_seed(42)
        torch.cuda.manual_seed(42)

        a = torch.randn(24, D1, D2)
        a = a.to(dtype).to("cuda")

        input_bytes = a.numel() * a.element_size()

        repeats = torch.randint(low=100, high=1600, size=(24,), device="cuda")
        output_bytes = (
            repeats.sum() * a.shape[1] * a.shape[2] * repeats.element_size()
        )
        total_bytes = input_bytes + output_bytes

        def torch_repeat_interleave(
            input_tensor: torch.Tensor, repeats: torch.Tensor
        ) -> torch.Tensor:
            res = input_tensor.repeat_interleave(repeats, dim=0)
            return res

        def torch_repeat_interleave_int32(
            input_tensor: torch.Tensor, repeats: torch.Tensor
        ) -> torch.Tensor:
            dim = 0
            if torch.is_tensor(repeats):
                idx64 = torch.repeat_interleave(
                    torch.arange(
                        0,
                        input_tensor.shape[dim or 0],
                        device=input_tensor.device,
                    ),
                    repeats,
                    dim=0,
                )
            else:
                idx64 = (
                    torch.arange(
                        input_tensor.shape[dim or 0] * repeats,
                        device=input_tensor.device,
                    )
                    .reshape(-1, repeats)
                    .flatten()
                )

            idx32 = idx64.to(torch.int32)
            res = torch.index_select(input_tensor, 0, idx32)
            return res

        def expand_flatten(input_tensor: torch.Tensor) -> torch.Tensor:
            return input_tensor[:, None].expand(-1, 4, -1).flatten(0, 1)

        if provider == "repeat_interleave":
            fn = lambda: torch_repeat_interleave(a, repeats)  # noqa E731
            ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
            bw = total_bytes / (ms * 1e6)
            # print("Bandwidth[GB/s]: ", total_bytes / (ms * 1e6))
            return bw.item()
        if provider == "repeat_interleave_int32":
            fn = lambda: torch_repeat_interleave_int32(a, repeats)
            ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
            bw = total_bytes / (ms * 1e6)
            # print("Bandwidth[GB/s]: ", total_bytes / (ms * 1e6))
            return bw.item()
        elif provider == "expand_flatten":
            fn = lambda: expand_flatten(a)
            ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
            bw = total_bytes / (ms * 1e6)
            # print("Bandwidth[GB/s]: ", total_bytes / (ms * 1e6))
            return bw.item()
        else:
            raise ValueError(f"unsupported provider: {provider}")

    df = bench_repeat_interleave.run(print_data=True, return_df=True)

    if return_result:
        return configs, df


if __name__ == "__main__":
    main()
```
