### PR TITLE
[PT2]: fix add_passes and remove_passes naming issue

### DIFF
--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -161,7 +161,7 @@ def _get_pass_name_func(p):
         pass_name = p.pass_name
         pass_func = p.apply
     elif isinstance(p, types.FunctionType):
-        pass_name = p.__name__
+        pass_name = p.__name__.lstrip("_")
         pass_func = p
     else:
         pass_name = None


### PR DESCRIPTION
Summary:
When defining pre_grad passes, they are initially defined as empty functions, then overriden in [customized_triton_kernel_passes.py](https://www.internalfb.com/code/fbsource/[b4eea3dcd7f22421e68a3c1533fd09a4281bc291]/fbcode/caffe2/torch/_inductor/fx_passes/fb/customized_triton_kernel_passes.py?lines=71-73). This causes issues for add_passes and remove_passes because `p.__name__` now may be prefixed by _.

This diff removes the leading _ to match the pass name.

Test Plan: Tested together with the next diff in the stack.

Reviewed By: oniononion36

Differential Revision: D73809937




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov