### PR TITLE
[Inductor] Use `torch._dynamo.utils.same` in block pointer tests, adding atol/rtol kwargs to it.

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -6,7 +6,7 @@ import unittest
 from typing import Any, Callable, Optional, Union
 
 import torch
-import torch.utils._pytree as pytree
+from torch._dynamo.utils import same
 from torch._inductor import config
 from torch._inductor.runtime.hints import TRITON_MAX_BLOCK
 from torch._inductor.runtime.runtime_utils import is_power_of_2
@@ -54,8 +54,8 @@ def run_and_compare(
     expected_num_programs: int = 1,
     expected_num_triton_kernels: int = 1,
     config_patches: Optional[dict] = None,
-    rtol: Optional[float] = None,
     atol: Optional[float] = None,
+    rtol: Optional[float] = None,
 ):
     """
     Runs the module through Inductor, comparing to eager reference.
@@ -65,21 +65,14 @@ def run_and_compare(
     if config_patches is None:
         config_patches = {}
 
-    def flatten_tensors(tensors):
-        flat, spec = pytree.tree_flatten(tensors)
-        return flat
-
     with config.patch(config_patches):
         compiled = torch.compile(func, backend="inductor", **compile_kwargs)
         result, code = run_and_get_code(compiled, *args)
 
     # Check numerical accuracy
-    ref_tensors = flatten_tensors(func(*args))
-    actual_tensors = flatten_tensors(result)
-    for ref, actual in zip(ref_tensors, actual_tensors):
-        # Don't clobber the default tolerance values
-        tol = {t: v for t, v in {"rtol": rtol, "atol": atol}.items() if v is not None}
-        self.assertTrue(torch.allclose(ref, actual, **tol))
+    tol = {t: v for t, v in {"rtol": rtol, "atol": atol}.items() if v is not None}
+    ref = func(*args)
+    self.assertTrue(same(ref, result, **tol))
 
     def count_code(substr: str, expected: Optional[int]):
         count = sum(prog.count(substr) for prog in code)

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -431,7 +431,8 @@ def same_two_models(
         ref,
         res,
         fp64_ref,
-        tol=config.repro_tolerance,
+        atol=config.repro_tolerance,
+        rtol=config.repro_tolerance,
         equal_nan=True,
         ignore_non_fp=ignore_non_fp,
     )

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -782,7 +782,8 @@ def repro_analyze(options, mod, load_args):
                     r,
                     inductor,
                     float64,
-                    tol=torch._dynamo.config.repro_tolerance,
+                    atol=torch._dynamo.config.repro_tolerance,
+                    rtol=torch._dynamo.config.repro_tolerance,
                     equal_nan=True,
                     log_error=log_error,
                 ):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2719,7 +2719,8 @@ def same(
     res,
     fp64_ref=None,
     cos_similarity=False,
-    tol=1e-4,
+    atol=1e-4,
+    rtol=1e-4,
     equal_nan=False,
     exact_dtype=True,
     relax_numpy_equality=False,
@@ -2746,7 +2747,8 @@ def same(
                 bi,
                 fp64_refi,
                 cos_similarity,
-                tol,
+                atol,
+                rtol,
                 equal_nan,
                 exact_dtype,
                 relax_numpy_equality,
@@ -2766,7 +2768,8 @@ def same(
             res.loss,
             fp64_ref.loss,
             cos_similarity,
-            tol,
+            atol,
+            rtol,
             equal_nan,
             exact_dtype,
             relax_numpy_equality,
@@ -2787,7 +2790,8 @@ def same(
                     res[k],
                     fp64_ref[k],
                     cos_similarity=cos_similarity,
-                    tol=tol,
+                    atol=atol,
+                    rtol=rtol,
                     equal_nan=equal_nan,
                     exact_dtype=exact_dtype,
                     relax_numpy_equality=relax_numpy_equality,
@@ -2829,8 +2833,8 @@ def same(
                 r = torch.allclose(
                     ref.to(dtype=torch.uint8),
                     res.to(dtype=torch.uint8),
-                    atol=tol,
-                    rtol=tol,
+                    atol=atol,
+                    rtol=rtol,
                     equal_nan=equal_nan,
                 )
                 if not r:
@@ -2840,7 +2844,7 @@ def same(
         if cos_similarity:
             ref = ref.flatten().to(torch.float32)
             res = res.flatten().to(torch.float32)
-            if torch.allclose(ref, res, atol=tol, rtol=tol, equal_nan=True):
+            if torch.allclose(ref, res, atol=atol, rtol=rtol, equal_nan=True):
                 # early exit that handles zero/nan better
                 # cosine_similarity(zeros(10), zeros(10), dim=0) is 0
                 return True
@@ -2853,7 +2857,7 @@ def same(
                 ref = ref.to(res.dtype)
 
             # First try usual allclose
-            if torch.allclose(ref, res, atol=tol, rtol=tol, equal_nan=equal_nan):
+            if torch.allclose(ref, res, atol=atol, rtol=rtol, equal_nan=equal_nan):
                 return True
 
             # Check error from fp64 version
@@ -2913,8 +2917,8 @@ def same(
                     elif (
                         fp64_ref.numel() < 1000
                         or (ref.ndim == 4 and ref.shape[-1] == ref.shape[-2] == 1)
-                        # large tol means a benchmark has been specified as REQUIRE_HIGHER_TOLERANCE
-                        or tol >= 2 * 1e-2
+                        # large atol means a benchmark has been specified as REQUIRE_HIGHER_TOLERANCE
+                        or atol >= 2 * 1e-2
                     ):
                         # In the presence of noise, noise might dominate our error
                         # metric for smaller tensors.
@@ -2924,7 +2928,7 @@ def same(
 
                 multiplier = get_multiplier()
 
-                passes_test = res_error <= (multiplier * ref_error + tol / 10.0)
+                passes_test = res_error <= (multiplier * ref_error + atol / 10.0)
                 if (
                     not passes_test
                     and equal_nan
@@ -2937,14 +2941,14 @@ def same(
                     passes_test = True
                 if not passes_test:
                     log_error(
-                        "RMSE (res-fp64): %.5f, (ref-fp64): %.5f and shape=%s. res.dtype: %s, multiplier: %f, tol: %f"
+                        "RMSE (res-fp64): %.5f, (ref-fp64): %.5f and shape=%s. res.dtype: %s, multiplier: %f, atol: %f"
                         ", use_larger_multiplier_for_smaller_tensor: %d",
                         res_error,
                         ref_error,
                         res.size(),
                         res.dtype,
                         multiplier,
-                        tol,
+                        atol,
                         use_larger_multiplier_for_smaller_tensor,
                     )
                 return passes_test
@@ -2952,7 +2956,7 @@ def same(
             if ignore_non_fp:
                 return True
 
-            log_error("Accuracy failed: allclose not within tol=%s", tol)
+            log_error("Accuracy failed: allclose not within atol=%s", atol)
             return False
     elif isinstance(ref, (str, int, type(None), bool, torch.device)):
         if ignore_non_fp:
@@ -2976,7 +2980,8 @@ def same(
             torch.as_tensor(res),
             fp64_ref,
             cos_similarity=cos_similarity,
-            tol=tol,
+            atol=atol,
+            rtol=rtol,
             equal_nan=equal_nan,
             exact_dtype=exact_dtype,
             relax_numpy_equality=relax_numpy_equality,
@@ -3004,7 +3009,8 @@ def same(
                 getattr(res, key),
                 getattr(fp64_ref, key),
                 cos_similarity=cos_similarity,
-                tol=tol,
+                atol=atol,
+                rtol=rtol,
                 equal_nan=equal_nan,
                 exact_dtype=exact_dtype,
                 relax_numpy_equality=relax_numpy_equality,


### PR DESCRIPTION
This refactor consolidates test utilities by calling `torch._dynamo.utils.same` in Inductor's block pointer tests. To facilitate this, it also adds `atol` and `rtol` kwargs to the function, which previously supported only the `tol` kwarg assigning the same value to both.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov