### PR TITLE
[Accelerator] Fix Python typing in accelerator

### DIFF
--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -34,7 +34,7 @@ def device_count() -> int:
             If there is no available accelerators, return 0.
 
     .. note:: This API delegates to the device-specific version of `device_count`.
-        On CUDA, this API will NOT posion fork if NVML discovery succeeds.
+        On CUDA, this API will NOT poison fork if NVML discovery succeeds.
         Otherwise, it will. For more details, see :ref:`multiprocessing-poison-fork-note`.
     """
     acc = current_accelerator()
@@ -166,7 +166,7 @@ def set_stream(stream: torch.Stream) -> None:
     torch._C._accelerator_setStream(stream)
 
 
-def synchronize(device: _device_t = None) -> None:
+def synchronize(device: _device_t = None, /) -> None:
     r"""Wait for all kernels in all streams on the given device to complete.
 
     Args:
@@ -217,7 +217,7 @@ class device_index:
         ...     pass
     """
 
-    def __init__(self, device: Optional[int]) -> None:
+    def __init__(self, device: Optional[int], /) -> None:
         self.idx = device
         self.prev_idx = -1
 

--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -2,7 +2,7 @@ r"""
 This package introduces support for the current :ref:`accelerator<accelerators>` in python.
 """
 
-from typing import Any, Optional
+from typing import Optional
 from typing_extensions import deprecated
 
 import torch
@@ -121,7 +121,7 @@ current_device_idx = deprecated(
 )(current_device_index)
 
 
-def set_device_index(device: ExplicitDevice) -> None:
+def set_device_index(device: ExplicitDevice, /) -> None:
     r"""Set the current device index to a given device.
 
     Args:

--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -225,6 +225,6 @@ class device_index:
         if self.idx is not None:
             self.prev_idx = torch._C._accelerator_exchangeDevice(self.idx)
 
-    def __exit__(self, *exec_info: Any) -> None:
+    def __exit__(self, *exc_info: object) -> None:
         if self.idx is not None:
             torch._C._accelerator_maybeExchangeDevice(self.prev_idx)

--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -140,7 +140,7 @@ set_device_idx = deprecated(
 )(set_device_index)
 
 
-def current_stream(device: _device_t = None) -> torch.Stream:
+def current_stream(device: _device_t = None, /) -> torch.Stream:
     r"""Return the currently selected stream for a given device.
 
     Args:

--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -6,7 +6,6 @@ from typing import Optional
 from typing_extensions import deprecated
 
 import torch
-from torch.types import ExplicitDevice
 
 from ._utils import _device_t, _get_device_index
 
@@ -121,7 +120,7 @@ current_device_idx = deprecated(
 )(current_device_index)
 
 
-def set_device_index(device: ExplicitDevice, /) -> None:
+def set_device_index(device: _device_t, /) -> None:
     r"""Set the current device index to a given device.
 
     Args:

--- a/torch/types.py
+++ b/torch/types.py
@@ -72,7 +72,8 @@ FileLike: TypeAlias = Union[str, os.PathLike[str], IO[bytes]]
 # literal device object).  This nomenclature is consistent with PythonArgParser.
 ExplicitDevice: TypeAlias = Union[_device, str, int]
 # None means use the default device (typically CPU)
-Device: TypeAlias = Union[ExplicitDevice, None]
+OptionalDevice: TypeAlias = Union[ExplicitDevice, None]
+Device: TypeAlias = OptionalDevice
 
 
 # Storage protocol implemented by ${Type}StorageBase classes

--- a/torch/types.py
+++ b/torch/types.py
@@ -70,8 +70,9 @@ FileLike: TypeAlias = Union[str, os.PathLike[str], IO[bytes]]
 
 # Meta-type for "device-like" things.  Not to be confused with 'device' (a
 # literal device object).  This nomenclature is consistent with PythonArgParser.
+ExplicitDevice: TypeAlias = Union[_device, str, int]
 # None means use the default device (typically CPU)
-Device: TypeAlias = Union[_device, str, int, None]
+Device: TypeAlias = Union[ExplicitDevice, None]
 
 
 # Storage protocol implemented by ${Type}StorageBase classes

--- a/torch/types.py
+++ b/torch/types.py
@@ -72,8 +72,7 @@ FileLike: TypeAlias = Union[str, os.PathLike[str], IO[bytes]]
 # literal device object).  This nomenclature is consistent with PythonArgParser.
 ExplicitDevice: TypeAlias = Union[_device, str, int]
 # None means use the default device (typically CPU)
-OptionalDevice: TypeAlias = Union[ExplicitDevice, None]
-Device: TypeAlias = OptionalDevice
+Device: TypeAlias = Union[ExplicitDevice, None]
 
 
 # Storage protocol implemented by ${Type}StorageBase classes

--- a/torch/types.py
+++ b/torch/types.py
@@ -70,9 +70,8 @@ FileLike: TypeAlias = Union[str, os.PathLike[str], IO[bytes]]
 
 # Meta-type for "device-like" things.  Not to be confused with 'device' (a
 # literal device object).  This nomenclature is consistent with PythonArgParser.
-ExplicitDevice: TypeAlias = Union[_device, str, int]
 # None means use the default device (typically CPU)
-Device: TypeAlias = Union[ExplicitDevice, None]
+Device: TypeAlias = Union[_device, str, int, None]
 
 
 # Storage protocol implemented by ${Type}StorageBase classes


### PR DESCRIPTION
There are some changes:
1. Use keywords for arguments if possible.
2. `__exit__ ` of `device_index` is changed to return None.