### PR TITLE
Remove 3.13 hack when installing TIMM

### DIFF
--- a/.ci/docker/common/install_inductor_benchmark_deps.sh
+++ b/.ci/docker/common/install_inductor_benchmark_deps.sh
@@ -14,13 +14,6 @@ function install_timm() {
   local commit
   commit=$(get_pinned_commit timm)
 
-  # TODO (huydhn): There is no torchvision release on 3.13 when I write this, so
-  # I'm using nightly here instead. We just need to package to be able to install
-  # TIMM. Removing this once vision has a release on 3.13
-  if [[ "${ANACONDA_PYTHON_VERSION}" == "3.13" ]]; then
-    pip_install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu124
-  fi
-
   pip_install "git+https://github.com/huggingface/pytorch-image-models@${commit}"
   # Clean up
   conda_run pip uninstall -y cmake torch torchvision triton


### PR DESCRIPTION
A Docker build failure showing up at this step triggered by the landing of https://github.com/pytorch/pytorch/pull/152362.  Here is the example logs https://github.com/pytorch/pytorch/actions/runs/14718029881/job/41305891896:

```
#37 29.72 + as_jenkins conda run -n py_3.13 pip install --progress-bar off --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu124
#37 29.72 + sudo -E -H -u jenkins env -u SUDO_UID -u SUDO_GID -u SUDO_COMMAND -u SUDO_USER env PATH=/opt/conda/envs/py_3.13/bin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64 conda run -n py_3.13 pip install --progress-bar off --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu124
#37 49.50 ERROR: Cannot install torch and torchvision==0.22.0.dev20250226+cu124 because these package versions have conflicting dependencies.
```

This happens because we have stopped building 12.4 nightly for sometime.  This hack doesn't apply anymore, so let's just remove it.

