### PR TITLE
[PowerPC] Fix vec256 for complex float and double in Power system

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_qint32_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_qint32_vsx.h
@@ -114,12 +114,14 @@ struct Vectorized<c10::qint32> {
     vfloat32 float_vals1 = vec_float(_vec1);
     vfloat32 scale_vec0 = scale.vec0();
     vfloat32 scale_vec1 = scale.vec1();
-    vfloat32 scale_zp_premul0 = scale_zp_premul.vec0();
-    vfloat32 scale_zp_premul1 = scale_zp_premul.vec1();
-    return {Vectorized<float>{
-        vec_madd(scale_vec0, float_vals0, scale_zp_premul0),
-        vec_madd(scale_vec1, float_vals1, scale_zp_premul1)}};
-  }
+    vfloat32 zero_point_vec0 = zero_point.vec0();
+    vfloat32 zero_point_vec1 = zero_point.vec1();
+
+    vfloat32 vec_sub_zero_point_0 = vec_sub(float_vals0, zero_point_vec0);
+    vfloat32 vec_sub_zero_point_1 = vec_sub(float_vals1, zero_point_vec1);
+    Vectorized<float> vf0 = {vec_mul(scale_vec0, vec_sub_zero_point_0), vec_mul(scale_vec1, vec_sub_zero_point_1)};
+   return {vf0};
+}
 
   float_vec_return_type dequantize(
       Vectorized<float> scale,

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_qint8_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_qint8_vsx.h
@@ -144,22 +144,32 @@ struct Vectorized<c10::qint8> {
     vfloat32 vecf1_3 = vec_float(veci7);
     vfloat32 scale_vec0 = scale.vec0();
     vfloat32 scale_vec1 = scale.vec1();
-    vfloat32 scale_zp_premul0 = scale_zp_premul.vec0();
-    vfloat32 scale_zp_premul1 = scale_zp_premul.vec1();
-    return {
-        Vectorized<float>{
-            vec_madd(scale_vec0, vecf0_0, scale_zp_premul0),
-            vec_madd(scale_vec1, vecf1_0, scale_zp_premul1)},
-        Vectorized<float>{
-            vec_madd(scale_vec0, vecf0_1, scale_zp_premul0),
-            vec_madd(scale_vec1, vecf1_1, scale_zp_premul1)},
-        Vectorized<float>{
-            vec_madd(scale_vec0, vecf0_2, scale_zp_premul0),
-            vec_madd(scale_vec1, vecf1_2, scale_zp_premul1)},
-        Vectorized<float>{
-            vec_madd(scale_vec0, vecf0_3, scale_zp_premul0),
-            vec_madd(scale_vec1, vecf1_3, scale_zp_premul1)}};
-  }
+
+    vfloat32 zero_point_vec0 = zero_point.vec0();
+    vfloat32 zero_point_vec1 = zero_point.vec1();
+
+    vfloat32 vec_substract_src_zp0_0 =  vec_sub(vecf0_0, zero_point_vec0);
+    vfloat32 vec_substract_src_zp1_0 =  vec_sub(vecf1_0, zero_point_vec1);
+    Vectorized<float> vf0_zp = {vec_mul(scale_vec0, vec_substract_src_zp0_0),
+        vec_mul(scale_vec1, vec_substract_src_zp1_0)};
+
+    vfloat32 vec_substract_src_zp0_1 =  vec_sub(vecf0_1, zero_point_vec0);
+    vfloat32 vec_substract_src_zp1_1 =  vec_sub(vecf1_1, zero_point_vec1);
+    Vectorized<float> vf1_zp = {vec_mul(scale_vec0, vec_substract_src_zp0_1),
+        vec_mul(scale_vec1, vec_substract_src_zp1_1)};
+
+    vfloat32 vec_substract_src_zp0_2 = vec_sub(vecf0_2, zero_point_vec0);
+    vfloat32 vec_substract_src_zp1_2 =  vec_sub(vecf1_2, zero_point_vec1);
+    Vectorized<float> vf2_zp = {vec_mul(scale_vec0, vec_substract_src_zp0_2),
+        vec_mul(scale_vec1, vec_substract_src_zp1_2)};
+
+    vfloat32 vec_substract_src_zp0_3 = vec_sub(vecf0_3, zero_point_vec0);
+    vfloat32 vec_substract_src_zp1_3 =  vec_sub(vecf1_3, zero_point_vec1);
+    Vectorized<float> vf3_zp = {vec_mul(scale_vec0, vec_substract_src_zp0_3),
+        vec_mul(scale_vec1, vec_substract_src_zp1_3)};
+
+    return {vf0_zp, vf1_zp, vf2_zp, vf3_zp};
+}
 
   float_vec_return_type C10_ALWAYS_INLINE dequantize(
       Vectorized<float> scale,

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_quint8_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_quint8_vsx.h
@@ -155,21 +155,27 @@ struct Vectorized<c10::quint8> {
     vfloat32 vecf1_3 = vec_float(veci7);
     vfloat32 scale_vec0 = scale.vec0();
     vfloat32 scale_vec1 = scale.vec1();
-    vfloat32 scale_zp_premul0 = scale_zp_premul.vec0();
-    vfloat32 scale_zp_premul1 = scale_zp_premul.vec1();
-    return {
-        Vectorized<float>{
-            vec_madd(scale_vec0, vecf0_0, scale_zp_premul0),
-            vec_madd(scale_vec1, vecf1_0, scale_zp_premul1)},
-        Vectorized<float>{
-            vec_madd(scale_vec0, vecf0_1, scale_zp_premul0),
-            vec_madd(scale_vec1, vecf1_1, scale_zp_premul1)},
-        Vectorized<float>{
-            vec_madd(scale_vec0, vecf0_2, scale_zp_premul0),
-            vec_madd(scale_vec1, vecf1_2, scale_zp_premul1)},
-        Vectorized<float>{
-            vec_madd(scale_vec0, vecf0_3, scale_zp_premul0),
-            vec_madd(scale_vec1, vecf1_3, scale_zp_premul1)}};
+
+    vfloat32 zero_point_vec0 = zero_point.vec0();
+    vfloat32 zero_point_vec1 = zero_point.vec1();
+
+    vfloat32 vec_substract_src_zp0_0 =  vec_sub(vecf0_0, zero_point_vec0);
+    vfloat32 vec_substract_src_zp1_0 =  vec_sub(vecf1_0, zero_point_vec1);
+    Vectorized<float> vf0_zp = {vec_mul(scale_vec0, vec_substract_src_zp0_0), vec_mul(scale_vec1, vec_substract_src_zp1_0)};
+
+    vfloat32 vec_substract_src_zp0_1 =  vec_sub(vecf0_1, zero_point_vec0);
+    vfloat32 vec_substract_src_zp1_1 =  vec_sub(vecf1_1, zero_point_vec1);
+    Vectorized<float> vf1_zp = {vec_mul(scale_vec0, vec_substract_src_zp0_1), vec_mul(scale_vec1, vec_substract_src_zp1_1)};
+
+    vfloat32 vec_substract_src_zp0_2 = vec_sub(vecf0_2, zero_point_vec0);
+    vfloat32 vec_substract_src_zp1_2 =  vec_sub(vecf1_2, zero_point_vec1);
+    Vectorized<float> vf2_zp = {vec_mul(scale_vec0, vec_substract_src_zp0_2), vec_mul(scale_vec1, vec_substract_src_zp1_2)};
+
+    vfloat32 vec_substract_src_zp0_3 = vec_sub(vecf0_3, zero_point_vec0);
+    vfloat32 vec_substract_src_zp1_3 =  vec_sub(vecf1_3, zero_point_vec1);
+    Vectorized<float> vf3_zp = {vec_mul(scale_vec0, vec_substract_src_zp0_3), vec_mul(scale_vec1, vec_substract_src_zp1_3)};
+
+    return {vf0_zp, vf1_zp, vf2_zp, vf3_zp};
   }
 
   float_vec_return_type C10_ALWAYS_INLINE dequantize(
@@ -214,21 +220,22 @@ struct Vectorized<c10::quint8> {
     vfloat32 vecf1_3 = vec_float(veci7);
     vfloat32 scale_vec0 = scale.vec0();
     vfloat32 scale_vec1 = scale.vec1();
+
     vfloat32 zero_point0 = zero_point.vec0();
     vfloat32 zero_point1 = zero_point.vec1();
     return {
-        Vectorized<float>{
-            (vecf0_0 - zero_point0) * scale_vec0,
-            (vecf1_0 - zero_point1) * scale_vec1},
-        Vectorized<float>{
-            (vecf0_1 - zero_point0) * scale_vec0,
-            (vecf1_1 - zero_point1) * scale_vec1},
-        Vectorized<float>{
-            (vecf0_2 - zero_point0) * scale_vec0,
-            (vecf1_2 - zero_point1) * scale_vec1},
-        Vectorized<float>{
-            (vecf0_3 - zero_point0) * scale_vec0,
-            (vecf1_3 - zero_point1) * scale_vec1}};
+    Vectorized<float>{
+        (vecf0_0 - zero_point0) * scale_vec0,
+        (vecf1_0 - zero_point1) * scale_vec1},
+    Vectorized<float>{
+        (vecf0_1 - zero_point0) * scale_vec0,
+        (vecf1_1 - zero_point1) * scale_vec1},
+    Vectorized<float>{
+        (vecf0_2 - zero_point0) * scale_vec0,
+        (vecf1_2 - zero_point1) * scale_vec1},
+    Vectorized<float>{
+        (vecf0_3 - zero_point0) * scale_vec0,
+        (vecf1_3 - zero_point1) * scale_vec1}};
   }
 
   static Vectorized<c10::quint8> quantize(


### PR DESCRIPTION
Power System build is failing with below error.

After this commit it is failing:
https://github.com/pytorch/pytorch/commit/912102b4ecf776711436f95d2fe62d78e39ad880

Fix the build error along with test cases that are failing for complex double and complex float data type.

Build Failure Logs:
```
vec_base.h:790:6: error: use of deleted function ‘at::vec::DEFAULT::ComplexDbl& at::vec::DEFAULT::Vectorized<c10::complex >::operator’
790 | c[i] = a[i] * b[i];
| ~^
error: use of deleted function ‘at::vec::DEFAULT::ComplexDbl& at::vec::DEFAULT::Vectorized<c10::complex >::oper
ator’
802 | c[i] = a[i] / b[i];
| ~^

error: use of deleted function ‘at::vec::DEFAULT::ComplexFlt& at::vec::DEFAULT::Vectorized<c10::complex >::opera
tor’
790 | c[i] = a[i] * b[i];
| ~^

error: use of deleted function ‘at::vec::DEFAULT::ComplexFlt& at::vec::DEFAULT::Vectorized<c10::complex >::opera
tor’
802 | c[i] = a[i] / b[i];
| ~^
```


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168