### PR TITLE
Call torch.distributed.destroy_process_group() at the end of the example

### DIFF
--- a/torch/distributed/tensor/examples/visualize_sharding_example.py
+++ b/torch/distributed/tensor/examples/visualize_sharding_example.py
@@ -79,3 +79,5 @@ visualize_sharding(
     dt.DTensor.from_local(tensor, mesh, [dt.Shard(dim=1), dt.Shard(dim=0)]),
     use_rich=True,
 )
+
+torch.distributed.destroy_process_group()


### PR DESCRIPTION
Address the comment https://github.com/pytorch/pytorch/pull/152027#pullrequestreview-2800075775

## Test Plan

Running the following command

```shell
torchrun --nproc-per-node=4  torch/distributed/tensor/examples/visualize_sharding_example.py
```

should not print the following warning at the end of the execution:

```
Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
```

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k