### PR TITLE
[wip] use base tensor storage offset in gen_alias_from_base

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8155,6 +8155,21 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             self.assertEqual(fn(x[0:]), x[16:][:16])
             self.assertEqual(fn(x[128:]), x[128 + 16 :][:16])
 
+    @requires_cuda
+    def test_alignment_cloned_storage_offset_aliasing(self):
+        def expand(x, n):
+            return x.expand((n,))
+
+        def g(n):
+            numbers = torch.arange(2, device="cuda")
+            result = []
+            for i in range(len(numbers)):
+                result.append(expand(numbers[i], n))
+            return result
+
+        g_opt = torch.compile(g, dynamic=True)
+        self.assertEqual(g(2), g_opt(2))
+
     # from GPT2ForSequenceClassification
     @skip_if_gpu_halide
     def test_index_tensor(self):

--- a/torch/_functorch/_aot_autograd/functional_utils.py
+++ b/torch/_functorch/_aot_autograd/functional_utils.py
@@ -295,7 +295,10 @@ def gen_alias_from_base(
 
     size = target_meta_tensor.size()
     stride = target_meta_tensor.stride()
-    storage_offset = target_meta_tensor.storage_offset()
+    # We use the aliased base tensor's storage offset because the target_meta_tensor's offset
+    # storage can be incorrect since we often times clone_preserve_strides to fix alignment. See
+    # copy_misaligned_inputs in _inductor/utils.py
+    storage_offset = aliased_base_tensor.storage_offset()
     if aliased_base_tensor.is_complex() and not target_meta_tensor.is_complex():
         aliased_out = torch.view_as_real(aliased_base_tensor).as_strided(
             size, stride, storage_offset

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2537,13 +2537,20 @@ def align_inputs_from_check_idxs(
 def clone_preserve_strides(x: torch.Tensor) -> torch.Tensor:
     if 0 in x.size():
         # Short-circuits if the shape has no elements
-        needed_size = 0
+        needed_size: Union[int, torch.SymInt] = 0
     else:
         needed_size = (
-            (sum((shape - 1) * stride for shape, stride in zip(x.size(), x.stride())) + 1) * (x.storage_offset() + 1)
-        )
-    buffer = torch.as_strided(x._base, (needed_size,), (1,)).clone()
-    return torch.as_strided(buffer, x.size(), x.stride(), storage_offset=x.storage_offset())
+            sum((shape - 1) * stride for shape, stride in zip(x.size(), x.stride())) + 1
+        ) * (x.storage_offset() + 1)
+
+    if x._base is not None:
+        buffer = torch.as_strided(x._base, (needed_size,), (1,)).clone()
+    else:
+        buffer = torch.as_strided(x, (needed_size,), (1,)).clone()
+
+    return torch.as_strided(
+        buffer, x.size(), x.stride(), storage_offset=x.storage_offset()
+    )
 
 
 def copy_misaligned_inputs(

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2540,10 +2540,10 @@ def clone_preserve_strides(x: torch.Tensor) -> torch.Tensor:
         needed_size = 0
     else:
         needed_size = (
-            sum((shape - 1) * stride for shape, stride in zip(x.size(), x.stride())) + 1
+            (sum((shape - 1) * stride for shape, stride in zip(x.size(), x.stride())) + 1) * (x.storage_offset() + 1)
         )
-    buffer = torch.as_strided(x, (needed_size,), (1,)).clone()
-    return torch.as_strided(buffer, x.size(), x.stride())
+    buffer = torch.as_strided(x._base, (needed_size,), (1,)).clone()
+    return torch.as_strided(buffer, x.size(), x.stride(), storage_offset=x.storage_offset())
 
 
 def copy_misaligned_inputs(

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2539,8 +2539,8 @@ def clone_preserve_strides(x: torch.Tensor) -> torch.Tensor:
     # proper storage offset.
     if x._base is not None:
         needed_size = (
-            sum((shape - 1) * stride for shape, stride in zip(x.size(), x.stride())) + 1
-        ) * (x.storage_offset() + 1)
+            sum((shape - 1) * stride for shape, stride in zip(x.size(), x.stride())) + x.storage_offset() + 1
+        )
         buffer = torch.as_strided(x._base, (needed_size,), (1,)).clone()
         return torch.as_strided(
             buffer, x.size(), x.stride(), storage_offset=x.storage_offset()

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2535,17 +2535,6 @@ def align_inputs_from_check_idxs(
 
 
 def clone_preserve_strides(x: torch.Tensor) -> torch.Tensor:
-    # If we are dealing with a view, we need to ensure we clone with the
-    # proper storage offset.
-    if x._base is not None:
-        needed_size = (
-            sum((shape - 1) * stride for shape, stride in zip(x.size(), x.stride())) + x.storage_offset() + 1
-        )
-        buffer = torch.as_strided(x._base, (needed_size,), (1,)).clone()
-        return torch.as_strided(
-            buffer, x.size(), x.stride(), storage_offset=x.storage_offset()
-        )
-
     if 0 in x.size():
         # Short-circuits if the shape has no elements
         needed_size = 0
@@ -2553,7 +2542,6 @@ def clone_preserve_strides(x: torch.Tensor) -> torch.Tensor:
         needed_size = (
             sum((shape - 1) * stride for shape, stride in zip(x.size(), x.stride())) + 1
         )
-
     buffer = torch.as_strided(x, (needed_size,), (1,)).clone()
     return torch.as_strided(buffer, x.size(), x.stride())
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152413

Fixes #151799

We use the aliased base tensor's storage offset because the target_meta_tensor's offset
storage can be incorrect since we often times clone_preserve_strides to fix alignment. See
copy_misaligned_inputs in _inductor/utils.py