### PR TITLE
[CUDA] Add new architectures

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -180,7 +180,9 @@ class TestCppExtensionJIT(common.TestCase):
                 )
 
             actual_arches = sorted(re.findall(r"sm_\d+", output))
-            expected_arches = sorted(["sm_" + xx.replace("121", "120") for xx in expected_values])
+            expected_arches = sorted(
+                ["sm_" + xx.replace("121", "120") for xx in expected_values]
+            )
             self.assertEqual(
                 actual_arches,
                 expected_arches,

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -180,7 +180,7 @@ class TestCppExtensionJIT(common.TestCase):
                 )
 
             actual_arches = sorted(re.findall(r"sm_\d+", output))
-            expected_arches = sorted(["sm_" + xx for xx in expected_values])
+            expected_arches = sorted(["sm_" + xx.replace("121", "120") for xx in expected_values])
             self.assertEqual(
                 actual_arches,
                 expected_arches,

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2391,12 +2391,13 @@ def _get_cuda_arch_flags(cflags: Optional[list[str]] = None) -> list[str]:
         ('Ada', '8.9+PTX'),
         ('Hopper', '9.0+PTX'),
         ('Blackwell+Tegra', '10.1'),
-        ('Blackwell', '10.0;12.0+PTX'),
+        ('Blackwell', '10.0;10.3;12.0;12.1+PTX'),
     ])
 
     supported_arches = ['3.5', '3.7', '5.0', '5.2', '5.3', '6.0', '6.1', '6.2',
                         '7.0', '7.2', '7.5', '8.0', '8.6', '8.7', '8.9', '9.0', '9.0a',
-                        '10.0', '10.0a', '10.1', '10.1a', '12.0', '12.0a']
+                        '10.0', '10.0a', '10.1', '10.1a', '10.3', '10.3a', '12.0',
+                        '12.0a', '12.1', '12.1a']
     valid_arch_strings = supported_arches + [s + "+PTX" for s in supported_arches]
 
     # The default is sm_30 for CUDA 9.x and 10.x


### PR DESCRIPTION
CUDA 12.9 will introduce a couple of new architectures `sm_103` and `sm_121`. We do not need to build for them, because they are going to be compatible with`sm_100` and `sm_120` respectively (similar to `sm_86` and `sm_89`), but PyTorch must be "aware" of them.

cc @ptrblck @msaroufim @eqy @jerryzh168