### PR TITLE
Add MTIA memory info into the sharder

### DIFF
--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -245,6 +245,18 @@ def set_device(device: _device_t) -> None:
     if device >= 0:
         torch._C._accelerator_hooks_set_current_device(device)
 
+def get_device_properties(device: Optional[_device_t] = None) -> dict[str, Any]:
+    r"""Return a dictionary of MTIA device properties
+
+    Args:
+        device (torch.device or int, optional) selected device. Returns
+            statistics for the current device, given by current_device(),
+            if device is None (default).
+    """
+    return {
+        "total_memory": 192 * 1000 * 1000 * 1000, # 192GB
+    }
+
 
 class device:
     r"""Context-manager that changes the selected device.


### PR DESCRIPTION
Test Plan: buck2 run //scripts/emmanuelmenage/apf_rec_investigations:planner_investigations now correctly reports OOM if the tables are too big.

Differential Revision: D72565617


