### PR TITLE
[conda] Remove conda from lint-autoformat.yml

### DIFF
--- a/.github/scripts/lintrunner.sh
+++ b/.github/scripts/lintrunner.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # Use uv to speed up lintrunner init
-python3 -m pip install uv==0.1.45 setuptools==80.0.0
+python3 -m pip install uv==0.1.45 setuptools
 
 CACHE_DIRECTORY="/tmp/.lintbin"
 # Try to recover the cached binaries

--- a/.github/scripts/lintrunner.sh
+++ b/.github/scripts/lintrunner.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # Use uv to speed up lintrunner init
-python3 -m pip install uv==0.1.45
+python3 -m pip install uv==0.1.45 setuptools==80.0.0
 
 CACHE_DIRECTORY="/tmp/.lintbin"
 # Try to recover the cached binaries

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -31,6 +31,8 @@ jobs:
         continue-on-error: true
         # we can't run all files here because only changes around where the diff are shown in the PR UI
         run: |
+          python --version
+          python3 --version
           export ADDITIONAL_LINTRUNNER_ARGS="format"
           bash .github/scripts/lintrunner.sh
       - name: Check for changes

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -18,17 +18,6 @@ jobs:
         shell: bash
         run: |
           sudo dnf install -y python3.12
-          python3.12 -m venv /tmp/venv
-          source /tmp/venv/bin/activate
-
-      - name: Stuff
-        run: |
-          set -ex
-          python --version || true
-          python3 --version || true
-          source /tmp/venv/bin/activate
-          python --version || true
-          python3 --version || true
 
       - name: Checkout pytorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
@@ -41,8 +30,8 @@ jobs:
         # we can't run all files here because only changes around where the diff are shown in the PR UI
         run: |
           set -ex
-          python --version || exit 0
-          python3 --version || exit 0
+          python3.12 -m venv /tmp/venv
+          source /tmp/venv/bin/activate
           export ADDITIONAL_LINTRUNNER_ARGS="format"
           bash .github/scripts/lintrunner.sh
       - name: Check for changes

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install python
         shell: bash
         run: |
-          sudo dnf install -y python3.12 python3.12-venv
+          sudo dnf install -y python3.12
           python3.12 -m venv /tmp/venv
           source /tmp/venv/bin/activate
 

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -19,10 +19,14 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - name: Setup miniconda
-        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
-        with:
-          python-version: "3.10"
+
+      - name: Install python
+        shell: bash
+        run: |
+          sudo dnf install -y python3.10 python3.10-venv
+          python3.10 -m venv /tmp/venv
+          source /tmp/venv/bin/activate
+
       - name: Run lintrunner (nonretryable)
         continue-on-error: true
         # we can't run all files here because only changes around where the diff are shown in the PR UI

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -32,6 +32,7 @@ jobs:
           set -ex
           python3.12 -m venv /tmp/venv
           source /tmp/venv/bin/activate
+          pip install setuptools==68.2.2
           export ADDITIONAL_LINTRUNNER_ARGS="format"
           bash .github/scripts/lintrunner.sh
       - name: Check for changes

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Install python
         shell: bash
         run: |
+          dnf list available 'python3*'
           sudo dnf install -y python3.10 python3.10-venv
           python3.10 -m venv /tmp/venv
           source /tmp/venv/bin/activate

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -21,6 +21,15 @@ jobs:
           python3.12 -m venv /tmp/venv
           source /tmp/venv/bin/activate
 
+      - name: Stuff
+        run: |
+          set -ex
+          python --version || exit 0
+          python3 --version || exit 0
+          source /tmp/venv/bin/activate
+          python --version || exit 0
+          python3 --version || exit 0
+
       - name: Checkout pytorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
         with:

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -14,11 +14,6 @@ jobs:
     runs-on: lf.linux.2xlarge
     if: ${{ github.repository_owner == 'pytorch' && github.event.pull_request.user.login != 'ezyang' && github.event.pull_request.user.login != 'malfet' && !startsWith(github.head_ref, 'export-') }}
     steps:
-      - name: Checkout pytorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
-        with:
-          submodules: true
-          fetch-depth: 0
 
       - name: Install python
         shell: bash
@@ -27,6 +22,13 @@ jobs:
           sudo dnf install -y python3.10 python3.10-venv
           python3.10 -m venv /tmp/venv
           source /tmp/venv/bin/activate
+
+      - name: Checkout pytorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+        with:
+          submodules: true
+          fetch-depth: 0
+
 
       - name: Run lintrunner (nonretryable)
         continue-on-error: true

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -14,13 +14,11 @@ jobs:
     runs-on: lf.linux.2xlarge
     if: ${{ github.repository_owner == 'pytorch' && github.event.pull_request.user.login != 'ezyang' && github.event.pull_request.user.login != 'malfet' && !startsWith(github.head_ref, 'export-') }}
     steps:
-
       - name: Install python
         shell: bash
         run: |
-          dnf list available 'python3*'
-          sudo dnf install -y python3.10 python3.10-venv
-          python3.10 -m venv /tmp/venv
+          sudo dnf install -y python3.12 python3.12-venv
+          python3.12 -m venv /tmp/venv
           source /tmp/venv/bin/activate
 
       - name: Checkout pytorch
@@ -28,7 +26,6 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-
 
       - name: Run lintrunner (nonretryable)
         continue-on-error: true

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -19,16 +19,12 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - name: Install python
-        shell: bash
-        run: |
-          sudo dnf install -y python3.12
       - name: Run lintrunner (nonretryable)
         continue-on-error: true
         # we can't run all files here because only changes around where the diff are shown in the PR UI
         run: |
           set -ex
-          python3.12 -m venv /tmp/venv
+          python3 -m venv /tmp/venv
           source /tmp/venv/bin/activate
           export ADDITIONAL_LINTRUNNER_ARGS="format"
           bash .github/scripts/lintrunner.sh

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -14,16 +14,15 @@ jobs:
     runs-on: lf.linux.2xlarge
     if: ${{ github.repository_owner == 'pytorch' && github.event.pull_request.user.login != 'ezyang' && github.event.pull_request.user.login != 'malfet' && !startsWith(github.head_ref, 'export-') }}
     steps:
-      - name: Install python
-        shell: bash
-        run: |
-          sudo dnf install -y python3.12
-
       - name: Checkout pytorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
         with:
           submodules: true
           fetch-depth: 0
+      - name: Install python
+        shell: bash
+        run: |
+          sudo dnf install -y python3.12
       - name: Run lintrunner (nonretryable)
         continue-on-error: true
         # we can't run all files here because only changes around where the diff are shown in the PR UI

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -31,8 +31,9 @@ jobs:
         continue-on-error: true
         # we can't run all files here because only changes around where the diff are shown in the PR UI
         run: |
-          python --version
-          python3 --version
+          set -ex
+          python --version || exit 0
+          python3 --version || exit 0
           export ADDITIONAL_LINTRUNNER_ARGS="format"
           bash .github/scripts/lintrunner.sh
       - name: Check for changes

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Stuff
         run: |
           set -ex
-          python --version || exit 0
-          python3 --version || exit 0
+          python --version || true
+          python3 --version || true
           source /tmp/venv/bin/activate
-          python --version || exit 0
-          python3 --version || exit 0
+          python --version || true
+          python3 --version || true
 
       - name: Checkout pytorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -32,7 +32,6 @@ jobs:
           set -ex
           python3.12 -m venv /tmp/venv
           source /tmp/venv/bin/activate
-          pip install setuptools==68.2.2
           export ADDITIONAL_LINTRUNNER_ARGS="format"
           bash .github/scripts/lintrunner.sh
       - name: Check for changes

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-
       - name: Run lintrunner (nonretryable)
         continue-on-error: true
         # we can't run all files here because only changes around where the diff are shown in the PR UI


### PR DESCRIPTION
Installs setuptools since I get 
https://github.com/pytorch/pytorch/actions/runs/14736804186/job/41364832984#step:5:60
```
+ python3 -m tools.generate_torch_version --is_debug=false
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/ec2-user/actions-runner/_work/pytorch/pytorch/tools/generate_torch_version.py", line 9, in <module>
    from setuptools import distutils  # type: ignore[import]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'setuptools'
```
It should be a no op in the normal lint workflow since setuptools is in the docker image

Switched from using python3.10 to system python, which should be python3.9

Use venv to put deps not in the base?
