### PR TITLE
[TorchDynamo] Fix failure to realize LazyVariableTracker on stack

### DIFF
--- a/test/export/test_export_with_inline_and_install.py
+++ b/test/export/test_export_with_inline_and_install.py
@@ -72,17 +72,6 @@ unittest.expectedFailure(
     InlineAndInstallStrictExportTestExport.test_buffer_util_inline_and_install_strict  # noqa: F821
 )
 
-# NOTE: For this test, when we call `LOAD_ATTR`, we fail to realizing the LazyVariableTracker
-# This is because the variable is popped off stack, pushed into TupleVariable (then ConstDictVariable)
-# So, in the first case (not nested return), the LazyVariable is realized at the RETURN_VALUE call;
-# for the second case (nested return), the LazyVariable is not realized until we begin COMPILING_GRAPH
-# As a result, we don't install the variable, so crash when we expect the variable to be installed later
-# Potential fix: We can force the lazy variable tracker to realize; just need to see how this is done for the non
-# nested case
-unittest.expectedFailure(
-    InlineAndInstallStrictExportTestExport.test_constant_output_inline_and_install_strict  # noqa: F821
-)
-
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -282,6 +282,13 @@ class ConstDictVariable(VariableTracker):
             return id(value.realize()) != id(other.realize())
         return id(value) != id(other)
 
+    def realize(self) -> VariableTracker:
+        # Realize the dictionary by realizing all k/v in the dictionary
+        for k, v in self.items.items():
+            k.vt.realize()
+            v.realize()
+        return self
+
     def reconstruct(self, codegen: "PyCodegen"):
         # instructions to load collections.OrderedDict if necessary
         if self.user_cls is collections.OrderedDict:

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -191,6 +191,12 @@ class BaseListVariable(VariableTracker):
 
         return super().call_method(tx, name, args, kwargs)
 
+    def realize(self) -> VariableTracker:
+        for item in self.items:
+            item.realize()
+
+        return self
+
 
 class RangeVariable(BaseListVariable):
     def __init__(self, items, **kwargs) -> None:


### PR DESCRIPTION
Fixes a bug with install and inline for dynamo where lazy variable tracker was not realized before creating the `FakeRootModule` on [L1129](https://github.com/pytorch/pytorch/blob/a3123dd3ab936a59dc3219dd77785b71c9147019/torch/_dynamo/output_graph.py#L1129) in output_graph.py

As a result, when we try to access the graph attribute `bff`, the attribute was not found and would crash with an error like:
```
  File "/data/users/lucaskabela/pytorch/torch/fx/graph_module.py", line 493, in __init__
    _copy_attr(root, self, node.target)
  File "/data/users/lucaskabela/pytorch/torch/fx/graph_module.py", line 238, in _copy_attr
    orig = getattr(from_module, field)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/lucaskabela/pytorch/torch/nn/modules/module.py", line 1944, in __getattr__
    raise AttributeError(
torch._dynamo.exc.InternalTorchDynamoError: AttributeError: 'FakeRootModule' object has no attribute 'L__self___bff'
```

If we realize the nested structures properly before (since they are on the [stack in L1118](https://github.com/pytorch/pytorch/blob/a3123dd3ab936a59dc3219dd77785b71c9147019/torch/_dynamo/output_graph.py#L1117)), this crash is resolved


### Test:
```
python test/export/test_export_with_inline_and_install.py InlineAndInstallStrictExportTestExport.test_constant_output_inline_and_install_strict
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames