### PR TITLE
add device generalisation support for distributed tests

### DIFF
--- a/test/distributed/optim/test_zero_redundancy_optimizer.py
+++ b/test/distributed/optim/test_zero_redundancy_optimizer.py
@@ -6,7 +6,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
-import os
 import sys
 from contextlib import nullcontext
 from typing import Any, cast
@@ -31,11 +30,12 @@ from torch.distributed.optim.zero_redundancy_optimizer import _broadcast_object
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.optim import AdamW, SGD
 from torch.testing._internal import common_distributed
+from torch.testing._internal.common_fsdp import get_devtype
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
-    IS_WINDOWS,
     parametrize,
     run_tests,
+    skipIfHpu,
 )
 
 
@@ -47,63 +47,24 @@ except ImportError:
     HAS_TORCHVISION = False
 
 
-# Use GLOO on GPU when running CUDA + Windows
-def _get_backend_for_tests():
-    return (
-        dist.Backend.NCCL
-        if not IS_WINDOWS and torch.cuda.is_available()
-        # Windows only has GLOO, but GLOO GPU works. And use GLOO CPU when
-        # no GPUs are available.
-        else dist.Backend.GLOO
-    )
+device_type = str(get_devtype())
 
 
-BACKEND = _get_backend_for_tests()
-
-
-class TestZeroRedundancyOptimizer(common_distributed.MultiProcessTestCase):
-    def setUp(self):
-        super().setUp()
-        os.environ["WORLD_SIZE"] = str(self.world_size)
-        self._spawn_processes()
-
+class TestZeroRedundancyOptimizer(common_distributed.DistributedTestBase):
     @property
     def device(self):
-        return (
-            torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
-        )
+        return device_type
 
     @property
     def world_size(self):
         return 1
-
-    def tearDown(self):
-        try:
-            torch.distributed.destroy_process_group()
-        except AssertionError:
-            pass
-        try:
-            os.remove(self.file_name)
-        except OSError:
-            pass
-
-    def dist_init(self, rank, world_size=-1, backend=BACKEND):
-        if world_size < 1:
-            world_size = self.world_size
-        store = dist.FileStore(self.file_name, world_size)
-        return dist.init_process_group(
-            backend=backend,
-            store=store,
-            rank=rank,
-            world_size=world_size,
-        )
 
 
 class TestZeroRedundancyOptimizerSingleRank(TestZeroRedundancyOptimizer):
     def test_state_dict(self):
         """Check that ZeroRedundancyOptimizer exposes the expected state dict
         interface, irrespective of the sharding."""
-        self.dist_init(self.rank)
+        self.create_pg(self.device)
         LR1 = 0.1
         LR2 = 0.01
         MOMENTUM = 0.9
@@ -171,7 +132,7 @@ class TestZeroRedundancyOptimizerSingleRank(TestZeroRedundancyOptimizer):
     def test_lr_scheduler(self):
         """Check that a normal PyTorch ``lr_scheduler`` is usable with
         ZeroRedundancyOptimizer."""
-        self.dist_init(self.rank)
+        self.create_pg(self.device)
         NUM_ITERS = 5
         LR = 0.01
         x = torch.tensor([1.0], device=self.device, requires_grad=True)
@@ -193,7 +154,7 @@ class TestZeroRedundancyOptimizerSingleRank(TestZeroRedundancyOptimizer):
 
     def test_step_with_kwargs(self):
         """Check that the ``step(**kwargs)`` interface is properly exposed."""
-        self.dist_init(self.rank)
+        self.create_pg(self.device)
         LR = 0.1
 
         class SGDWithStepKWArg(torch.optim.SGD):
@@ -217,7 +178,7 @@ class TestZeroRedundancyOptimizerSingleRank(TestZeroRedundancyOptimizer):
         """Check that ZeroRedundancyOptimizer wrapping an optimizer that adds
         extra keys to ``param_groups`` exposes those keys through ZeRO's own
         ``param_groups``."""
-        self.dist_init(self.rank)
+        self.create_pg(self.device)
         LR = 0.1
 
         class SGDWithNewKey(torch.optim.SGD):
@@ -236,7 +197,7 @@ class TestZeroRedundancyOptimizerSingleRank(TestZeroRedundancyOptimizer):
     def test_step_without_closure(self):
         """Check that the ``step()`` method (without closure) is handled as
         expected."""
-        self.dist_init(self.rank)
+        self.create_pg(self.device)
         LR = 0.1
 
         class SGDWithoutClosure(torch.optim.SGD):
@@ -255,7 +216,7 @@ class TestZeroRedundancyOptimizerSingleRank(TestZeroRedundancyOptimizer):
 
     def test_zero_grad(self):
         """Check that the ``zero_grad`` method is properly handled."""
-        self.dist_init(self.rank)
+        self.create_pg(self.device)
         LR = 0.01
         x = torch.rand(1)
         m = torch.nn.Linear(1, 1)
@@ -271,7 +232,7 @@ class TestZeroRedundancyOptimizerSingleRank(TestZeroRedundancyOptimizer):
     def test_constructor(self):
         """Check the robustness of the ZeroRedundancyOptimizer constructor by
         passing different values for the ``params`` argument."""
-        self.dist_init(self.rank)
+        self.create_pg(self.device)
         LR = 0.01
         m = torch.nn.Sequential(
             torch.nn.Linear(5, 10),
@@ -336,7 +297,7 @@ class TestZeroRedundancyOptimizerSingleRank(TestZeroRedundancyOptimizer):
         NOTE: This test should be removed once support for sparse parameters
         and varying parameter types is added.
         """
-        self.dist_init(self.rank)
+        self.create_pg(self.device)
         LR = 0.01
         inputs = [
             [torch.sparse_coo_tensor(size=(2, 3))],
@@ -354,24 +315,15 @@ class TestZeroRedundancyOptimizerSingleRank(TestZeroRedundancyOptimizer):
 
 class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
     @property
-    def device(self):
-        return (
-            torch.device(self.rank)
-            if torch.cuda.is_available()
-            else torch.device("cpu")
-        )
-
-    @property
     def world_size(self):
-        return min(4, max(2, torch.cuda.device_count()))
+        return min(4, max(2, torch.get_device_module(self.device).device_count()))
 
     @property
     def context(self):
-        return (
-            nullcontext()
-            if not torch.cuda.is_available()
-            else torch.cuda.device(self.rank)
-        )
+        if self.device in {"cuda", "xpu"}:
+            return torch.get_device_module(self.device).device(self.rank)
+        else:
+            return nullcontext()
 
     def _check_same_model_params(
         self,
@@ -401,7 +353,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
     def test_step(self):
         """Check that ZeroRedundancyOptimizer properly exposes the ``step()``
         interface."""
-        self.dist_init(self.rank, world_size=self.world_size)
+        self.create_pg(self.device)
         LR = 0.01
 
         with self.context:
@@ -441,8 +393,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
     def test_step_with_closure(self):
         """Check that ZeroRedundancyOptimizer properly exposes the
         ``step(closure)`` interface."""
-        self.dist_init(self.rank, world_size=self.world_size)
-
+        self.create_pg(self.device)
         with self.context:
             for bucket_view in [False, True]:
                 x_val = self.rank + 1
@@ -491,7 +442,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
     def test_lr_scheduler(self):
         """Check that a normal PyTorch ``lr_scheduler`` is usable with
         ZeroRedundancyOptimizer."""
-        self.dist_init(self.rank)
+        self.create_pg(self.device)
         x = torch.tensor([1.0], device=self.device, requires_grad=True)
         x2 = torch.tensor([1.0], device=self.device, requires_grad=True)
         o = ZeroRedundancyOptimizer([x], optimizer_class=SGD, lr=0.01)
@@ -519,7 +470,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
         ``ZeroRedundancyOptimizer._partition_parameters()`` in
         zero_redundancy_optimizer.py.
         """
-        self.dist_init(self.rank)
+        self.create_pg(self.device)
         LR = 0.01
         sizes = [9, 7, 5, 3]
         params = []
@@ -541,7 +492,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
         ``ZeroRedundancyOptimizer._partition_parameters()`` in
         zero_redundancy_optimizer.py.
         """
-        self.dist_init(self.rank)
+        self.create_pg(self.device)
         LR = 0.01
 
         # Test with all parameters trainable to begin with
@@ -596,7 +547,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
         upfront versus adding parameter groups to ZeRO after construction
         versus a non-sharded optimizer.
         """
-        self.dist_init(self.rank)
+        self.create_pg(self.device)
         BATCH_SIZE, NUM_ITERS = 8, 3
         INPUT_DIM, HIDDEN_DIM, OUTPUT_DIM = 5, 10, 5
         WD, LR = 0.01, 0.01
@@ -661,7 +612,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
     def test_collect_shards(self):
         """Check the state consolidation mechanism and the state dict exposed
         by ZeroRedundancyOptimizer."""
-        self.dist_init(self.rank)
+        self.create_pg(self.device)
         LR = 1e-3
         MOMENTUM = 0.99
         BATCH_SIZE, INPUT_DIM, HIDDEN_DIM, OUTPUT_DIM = 3, 20, 10, 5
@@ -726,20 +677,18 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
                 MIN_WORLD_SIZE,
             )
             return
-        BACKEND = dist.Backend.GLOO
-        self.dist_init(self.rank, self.world_size, BACKEND)
-        # Use GPU if enough are available, or fall back to CPU otherwise, which
-        # is fine since Gloo backend supports both
-        if torch.cuda.is_available() and torch.cuda.device_count() >= self.world_size:
-            device = torch.device(self.rank)
-        else:
+        # Use GPU if enough are available, or fall back to CPU otherwise
+        if torch.get_device_module(self.device).device_count() < self.world_size:
             device = torch.device("cpu")
+        else:
+            device = torch.device(self.device)
+        self.create_pg(device.type)
         # Create a new process group consisting of the even ranks to exercise
         # the case where the global and local ranks do not necessarily match
         subgroup_ranks = [r for r in range(self.world_size) if r % 2 == 0]
         process_group = dist.new_group(
             ranks=subgroup_ranks,
-            backend=BACKEND,
+            backend=self.backend(device.type),
         )
         # Ranks not participating in the new process group are no longer needed
         if self.rank not in subgroup_ranks:
@@ -828,7 +777,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
     ):
         """When combined with DDP, check that a local optimizer gives the same
         results as wrapping that optimizer with ZeroRedundancyOptimizer."""
-        self.dist_init(self.rank)
+        self.create_pg(self.device)
         BATCHES = 20
         BATCH_SIZE = 64
         LR = 1e-3
@@ -846,6 +795,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
         else:
             assert 0, f"Unsupported optimizer class: {optimizer_class_str}"
 
+        require_ddp_rank = self.device in {"cuda", "xpu"}
         with self.context:
             # Define a base model with a different buffer for each rank
             model = torch.nn.Sequential(
@@ -867,7 +817,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
             )
             sharded_ddp_model = DDP(
                 module=model,
-                device_ids=[self.rank],
+                device_ids=[self.rank] if require_ddp_rank else None,
                 broadcast_buffers=True,
                 find_unused_parameters=True,
             )
@@ -879,7 +829,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
             )
             ddp_model = DDP(
                 local_model,
-                device_ids=[self.rank],
+                device_ids=[self.rank] if require_ddp_rank else None,
                 broadcast_buffers=True,
                 find_unused_parameters=True,
             )
@@ -892,7 +842,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
             )
 
             def check_step():
-                input_tensor = torch.rand((BATCH_SIZE, INPUT_DIM))
+                input_tensor = torch.rand((BATCH_SIZE, INPUT_DIM)).to(self.device)
 
                 def closure_ddp(input_tensor=input_tensor):
                     ddp_optimizer.zero_grad()
@@ -970,13 +920,13 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
         NUM_EPOCHS = 2
         LR = 0.01
         torch.manual_seed(0)
-        torch.cuda.manual_seed(0)
+        if "cpu" not in device:
+            torch.get_device_module(device).manual_seed(0)
 
         rank = self.rank
         world_size = self.world_size
-        is_gpu = device.type == "cuda"
-        backend = _get_backend_for_tests() if is_gpu else dist.Backend.GLOO
-        self.dist_init(rank, world_size, backend)
+        require_ddp_rank = device in {"cuda", "xpu"}
+        self.create_pg(device)
 
         model = torch.nn.Sequential(
             torch.nn.Linear(2, 3),
@@ -988,7 +938,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
         # DDP ensures correct gradients in data parallel training, so DDP with
         # local optimizers on uneven inputs should be equivalent to ZeRO on
         # uneven inputs with gradients being manually set
-        ddp_model = DDP(model, device_ids=[rank]) if is_gpu else DDP(model)
+        ddp_model = DDP(model, device_ids=[rank]) if require_ddp_rank else DDP(model)
         local_optim = torch.optim.Adam(ddp_model.parameters(), lr=LR)
         zero_model = copy.deepcopy(model)
         zero_model.to(device)
@@ -1111,7 +1061,6 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
                         )
                     iter += 1
 
-    @common_distributed.requires_nccl()
     @common_distributed.skip_if_no_gpu
     def test_zero_join_gpu(self):
         """Check that the ZeRO join hook allows training with uneven inputs
@@ -1122,16 +1071,17 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
     def test_zero_join_cpu(self):
         """Check that the ZeRO join hook allows training with uneven inputs
         on CPU."""
-        self._test_zero_join(torch.device("cpu"))
+        self._test_zero_join("cpu")
 
-    def _test_zero_model_parallel(self, parameters_as_bucket_view: bool):
+    def _test_zero_model_parallel(self, parameters_as_bucket_view: bool, device: str):
         # Use two processes each with two GPUs
         assert self.rank < 2
         NUM_EPOCHS = 2
         NUM_INPUTS = 4
         LR = 0.01
         torch.manual_seed(0)
-        torch.cuda.manual_seed(0)
+        if "cpu" not in device:
+            torch.get_device_module(device).manual_seed(0)
 
         class ModelParallelModel(torch.nn.Module):
             def __init__(self, dev0, dev1):
@@ -1221,6 +1171,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
                         atol=1e-04,
                     ), "Models differ after a step"
 
+    @skipIfHpu
     @common_distributed.skip_if_lt_x_gpu(4)
     @parametrize(
         "parameters_as_bucket_view",
@@ -1234,8 +1185,8 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
         layers are assigned to different devices."""
         if self.rank >= 2:
             return
-        self.dist_init(self.rank, world_size=2)
-        self._test_zero_model_parallel(parameters_as_bucket_view)
+        self.create_pg(self.device, world_size=2)
+        self._test_zero_model_parallel(parameters_as_bucket_view, self.device)
 
     def _test_ddp_zero_overlap(
         self,
@@ -1250,12 +1201,11 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
         SGD_WEIGHT_DECAY = 0.001
         NUM_INPUTS = 5
         torch.manual_seed(0)
-        torch.cuda.manual_seed(0)
+        if "cpu" not in device:
+            torch.get_device_module(device).manual_seed(0)
 
         rank = self.rank
-        is_gpu = device.type == "cuda"
-        if is_gpu:
-            torch.cuda.set_device(device)
+        require_ddp_rank = device in {"cuda", "xpu"}
         models_to_test = [
             (
                 torch.nn.Sequential(
@@ -1277,7 +1227,9 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
             with torch.backends.cudnn.flags(
                 enabled=True, deterministic=True, benchmark=False
             ):
-                device_ids = [rank] if is_gpu else None
+                # Needed for non-cuda devices
+                torch.use_deterministic_algorithms(True)
+                device_ids = [rank] if require_ddp_rank else None
                 # Set up the DDP model overlapping with ZeRO
                 ddp_model_overlap = DDP(
                     copy.deepcopy(model).to(device),
@@ -1375,7 +1327,6 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
     # NOTE: The test is skipped if using Windows since functional optimizers
     # are not currently supported.
     @common_distributed.skip_if_win32()
-    @common_distributed.requires_nccl()
     @common_distributed.skip_if_no_gpu
     @common_distributed.skip_if_rocm_multiprocess
     @parametrize(
@@ -1413,9 +1364,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
         by ``hook_constructor`` and ``shard_buckets`` and using the given ZeRO
         and DDP arguments achieves parity with DDP using a local optimizer.
         """
-        device = torch.device(self.rank) if use_gpu else torch.device("cpu")
-        backend = _get_backend_for_tests()
-        self.dist_init(self.rank, self.world_size, backend)
+        self.create_pg(self.device)
         hook_constructor = (
             hook_with_zero_step
             if not use_interleaved_hook
@@ -1423,7 +1372,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
         )
 
         self._test_ddp_zero_overlap(
-            device,
+            self.device if use_gpu else "cpu",
             hook_constructor,
             gradient_as_bucket_view,
             static_graph,

--- a/test/distributed/test_c10d_logger.py
+++ b/test/distributed/test_c10d_logger.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import os
 import re
 import sys
 from functools import partial, wraps
@@ -16,9 +15,12 @@ if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
-from torch.testing._internal.common_distributed import MultiProcessTestCase, TEST_SKIPS
+from torch.testing._internal.common_distributed import DistributedTestBase, TEST_SKIPS
+from torch.testing._internal.common_fsdp import get_devtype
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
 
+
+device_type = str(get_devtype())
 
 if TEST_WITH_DEV_DBG_ASAN:
     print(
@@ -27,8 +29,7 @@ if TEST_WITH_DEV_DBG_ASAN:
     )
     sys.exit(0)
 
-BACKEND = dist.Backend.NCCL
-WORLD_SIZE = min(4, max(2, torch.cuda.device_count()))
+WORLD_SIZE = min(4, max(2, torch.get_device_module(device_type).device_count()))
 
 
 def with_comms(func=None):
@@ -39,30 +40,16 @@ def with_comms(func=None):
 
     @wraps(func)
     def wrapper(self, *args, **kwargs):
-        if BACKEND == dist.Backend.NCCL and torch.cuda.device_count() < self.world_size:
+        if torch.get_device_module(device_type).device_count() < self.world_size:
             sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
-        self.dist_init()
+        self.create_pg(device_type)
         func(self)
         self.destroy_comms()
 
     return wrapper
 
 
-class C10dErrorLoggerTest(MultiProcessTestCase):
-    def setUp(self):
-        super().setUp()
-        os.environ["WORLD_SIZE"] = str(self.world_size)
-        os.environ["BACKEND"] = BACKEND
-        self._spawn_processes()
-
-    @property
-    def device(self):
-        return (
-            torch.device(self.rank)
-            if BACKEND == dist.Backend.NCCL
-            else torch.device("cpu")
-        )
-
+class C10dErrorLoggerTest(DistributedTestBase):
     @property
     def world_size(self):
         return WORLD_SIZE
@@ -75,18 +62,6 @@ class C10dErrorLoggerTest(MultiProcessTestCase):
         # Wait for all ranks to reach here before starting shutdown.
         dist.barrier()
         dist.destroy_process_group()
-
-    def dist_init(self):
-        dist.init_process_group(
-            backend=BACKEND,
-            world_size=self.world_size,
-            rank=self.rank,
-            init_method=f"file://{self.file_name}",
-        )
-
-        # set device for nccl pg for collectives
-        if BACKEND == "nccl":
-            torch.cuda.set_device(self.rank)
 
     def test_get_or_create_logger(self):
         self.assertIsNotNone(_c10d_logger)
@@ -117,7 +92,11 @@ class C10dErrorLoggerTest(MultiProcessTestCase):
                 re.search("({.+})", captured.output[0]).group(0).replace("'", '"')
             )
 
-            self.assertEqual(len(error_msg_dict), 9)
+            # NCCL adds additional nccl_version data to the error_msg_dict
+            if self.backend(device_type) == dist.Backend.NCCL:
+                self.assertEqual(len(error_msg_dict), 9)
+            else:
+                self.assertEqual(len(error_msg_dict), 8)
 
             self.assertIn("pg_name", error_msg_dict.keys())
             self.assertEqual("None", error_msg_dict["pg_name"])
@@ -126,13 +105,14 @@ class C10dErrorLoggerTest(MultiProcessTestCase):
             self.assertEqual("broadcast", error_msg_dict["func_name"])
 
             self.assertIn("backend", error_msg_dict.keys())
-            self.assertEqual("nccl", error_msg_dict["backend"])
+            self.assertEqual(self.backend(device_type), error_msg_dict["backend"])
 
-            self.assertIn("nccl_version", error_msg_dict.keys())
-            nccl_ver = torch.cuda.nccl.version()
-            self.assertEqual(
-                ".".join(str(v) for v in nccl_ver), error_msg_dict["nccl_version"]
-            )
+            if self.backend(device_type) == dist.Backend.NCCL:
+                self.assertIn("nccl_version", error_msg_dict.keys())
+                nccl_ver = torch.cuda.nccl.version()
+                self.assertEqual(
+                    ".".join(str(v) for v in nccl_ver), error_msg_dict["nccl_version"]
+                )
 
             # In this test case, group_size = world_size, since we don't have multiple processes on one node.
             self.assertIn("group_size", error_msg_dict.keys())

--- a/test/distributed/test_compute_comm_reordering.py
+++ b/test/distributed/test_compute_comm_reordering.py
@@ -26,10 +26,13 @@ from torch.testing._internal.common_distributed import (
     _dynamo_dist_per_rank_init,
     at_least_x_gpu,
     DynamoDistributedMultiProcTestCase,
-    requires_nccl,
 )
+from torch.testing._internal.common_fsdp import get_devtype
 from torch.testing._internal.common_utils import skipIfRocm
 from torch.testing._internal.inductor_utils import HAS_GPU
+
+
+device_type = str(get_devtype())
 
 
 def get_snode_runtime_for_reorder_compute_test(snode):
@@ -74,7 +77,6 @@ def create_grouped_node_for_allreduce_and_its_deps(snodes):
     return new_snode_order
 
 
-@requires_nccl()
 class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
     """
     Run correctness checks in multi-proc runner, mark with minimum # GPUs to run under
@@ -113,9 +115,12 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             return torch.matmul(ar, b)
 
         with _dynamo_dist_per_rank_init(
-            self.rank, self.world_size, fake_pg=not at_least_x_gpu(2)
+            self.rank,
+            self.world_size,
+            self.backend(device_type),
+            fake_pg=not at_least_x_gpu(2),
         ):
-            inputs = torch.ones(4, 4, dtype=torch.float, device="cuda") + self.rank
+            inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
             compiled = torch.compile(func)
             code = run_and_get_triton_code(compiled, inputs)
             # Verify that the wait_tensor is sinked below the 1st matmul but
@@ -154,9 +159,12 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             return torch.matmul(d, e)
 
         with _dynamo_dist_per_rank_init(
-            self.rank, self.world_size, fake_pg=not at_least_x_gpu(2)
+            self.rank,
+            self.world_size,
+            self.backend(device_type),
+            fake_pg=not at_least_x_gpu(2),
         ):
-            inputs = torch.ones(4, 4, dtype=torch.float, device="cuda") + self.rank
+            inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
             compiled = torch.compile(func)
             code = run_and_get_triton_code(compiled, inputs)
             # Verify that the all_reduce_ has been raised above the 2nd matmul
@@ -202,9 +210,12 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             return torch.mm(e, g)
 
         with _dynamo_dist_per_rank_init(
-            self.rank, self.world_size, fake_pg=not at_least_x_gpu(2)
+            self.rank,
+            self.world_size,
+            self.backend(device_type),
+            fake_pg=not at_least_x_gpu(2),
         ):
-            inputs = torch.ones(4, 4, dtype=torch.float, device="cuda") + self.rank
+            inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
             compiled = torch.compile(func)
             code = run_and_get_triton_code(compiled, inputs, **self.get_world_trs())
             # Things to verify:
@@ -255,9 +266,12 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             return (e,)
 
         with _dynamo_dist_per_rank_init(
-            self.rank, self.world_size, fake_pg=not at_least_x_gpu(2)
+            self.rank,
+            self.world_size,
+            self.backend(device_type),
+            fake_pg=not at_least_x_gpu(2),
         ):
-            inputs = torch.ones(4, 4, dtype=torch.float, device="cuda") + self.rank
+            inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
             compiled = torch.compile(func)
             code = run_and_get_triton_code(compiled, inputs, **self.get_world_trs())
             # NOTE: after scheduling the first all_reduce:
@@ -312,9 +326,12 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             return (e,)
 
         with _dynamo_dist_per_rank_init(
-            self.rank, self.world_size, fake_pg=not at_least_x_gpu(2)
+            self.rank,
+            self.world_size,
+            self.backend(device_type),
+            fake_pg=not at_least_x_gpu(2),
         ):
-            inputs = torch.ones(4, 4, dtype=torch.float, device="cuda") + self.rank
+            inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
             compiled = torch.compile(func)
             code = run_and_get_triton_code(compiled, inputs, **self.get_world_trs())
             # NOTE: after scheduling the first all_reduce:
@@ -362,9 +379,12 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             return (mm,)
 
         with _dynamo_dist_per_rank_init(
-            self.rank, self.world_size, fake_pg=not at_least_x_gpu(2)
+            self.rank,
+            self.world_size,
+            self.backend(device_type),
+            fake_pg=not at_least_x_gpu(2),
         ):
-            inputs = torch.ones(4, 4, dtype=torch.float, device="cuda") + self.rank
+            inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
             compiled = torch.compile(func)
             code = run_and_get_triton_code(compiled, inputs, **self.get_world_trs())
             # Expectations:
@@ -387,9 +407,9 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
         ranks = pg_info["ranks"]
         group_size = pg_info["group_size"]
 
-        g1 = torch.ones(10, 10, device="cuda")
-        g2 = torch.ones(11, 11, device="cuda")
-        g3 = torch.ones(12, 12, device="cuda")
+        g1 = torch.ones(10, 10, device=device_type)
+        g2 = torch.ones(11, 11, device=device_type)
+        g3 = torch.ones(12, 12, device=device_type)
 
         def assert_pass(graph):
             # all_reduces need to remain in order!
@@ -429,7 +449,9 @@ graph():
             grad1 = torch.ops._c10d_functional.wait_tensor.default(handle1)
             return grad3, grad2, grad1
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size, fake_pg=True):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, self.backend(device_type), fake_pg=True
+        ):
             fn(g1, g2, g3)
 
     def test_nccl_heuristics(self):


### PR DESCRIPTION
test/distributed/optim/test_zero_redundancy_optimizer.py
test/distributed/test_c10d_logger.py
test/distributed/test_compute_comm_reordering.py
are modified for device generic support

device info is retrieved and used for tests, via get_devtype() from torch.testing._internal.common_fsdp
DistributedTestBase is used instead of MultiProcessTestCase, to make use of helper functions

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k