### PR TITLE
Add new profiling events to `DebugAutotuner`

### DIFF
--- a/test/inductor/test_analysis.py
+++ b/test/inductor/test_analysis.py
@@ -1,0 +1,619 @@
+# Owner(s): ["module: inductor"]
+
+import json
+import re
+import tempfile
+import uuid
+from io import StringIO
+from unittest.mock import patch
+
+import torch
+import torch.nn.functional as F
+from torch._inductor.analysis.profile_analysis import (
+    _augment_trace_helper,
+    _create_extern_mapping,
+    JsonProfile,
+    main,
+)
+from torch._inductor.utils import (
+    fresh_inductor_cache,
+    run_and_get_code,
+    tabulate_2d,
+    zip_dicts,
+)
+from torch.testing._internal.common_cuda import SM70OrLater
+from torch.testing._internal.common_device_type import (
+    dtypes,
+    instantiate_device_type_tests,
+    skipIf,
+)
+from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
+from torch.utils.flop_counter import countable
+
+
+example_profile = """
+{
+  "schemaVersion": 1,
+  "deviceProperties": [
+    {
+      "id": 0, "name": "NVIDIA H100", "totalGlobalMem": 101997215744,
+      "computeMajor": 9, "computeMinor": 0,
+      "maxThreadsPerBlock": 1024, "maxThreadsPerMultiprocessor": 2048,
+      "regsPerBlock": 65536, "warpSize": 32,
+      "sharedMemPerBlock": 49152, "numSms": 132
+    , "regsPerMultiprocessor": 65536, "sharedMemPerBlockOptin": 232448, "sharedMemPerMultiprocessor": 233472
+    }
+  ],
+  "cupti_version": 24,
+  "cuda_runtime_version": 12060,
+  "with_flops": 1,
+  "record_shapes": 1,
+  "cuda_driver_version": 12040,
+  "profile_memory": 1,
+  "trace_id": "301995E163ED42048FBD783860E6E7DC",
+  "displayTimeUnit": "ms",
+  "baseTimeNanoseconds": 1743521598000000000,
+  "traceEvents": [
+  {
+    "ph": "X", "cat": "cpu_op", "name": "aten::convolution", "pid": 1147039, "tid": 1147039,
+    "ts": 198093488368.463, "dur": 425.453,
+    "args": {
+      "External id": 1340,"Sequence number": 0, "Fwd thread id": 0, "Record function id": 0, "Concrete Inputs": \
+["", "", "", "[2, 2]", "[3, 3]", "[1, 1]", "False", "[0, 0]", "1"], "Input type": ["float", "float", "", \
+"ScalarList", "ScalarList", "ScalarList", "Scalar", "ScalarList", "Scalar"], "Input Strides": [[150528, 1, 672, 3],\
+[147, 1, 21, 3], [], [], [], [], [], [], []], "Input Dims": [[1, 3, 224, 224], [64, 3, 7, 7], [], [], [], [], [], \
+[], []], "Ev Idx": 1339
+    }
+  },
+  {
+    "ph": "X", "cat": "cpu_op", "name": "aten::_convolution", "pid": 1147039, "tid": 1147039,
+    "ts": 198093488444.498, "dur": 341.867,
+    "args": {
+      "External id": 1341,"Record function id": 0, "Concrete Inputs": ["", "", "", "[2, 2]", "[3, 3]", "[1, 1]",\
+ "False", "[0, 0]", "1", "False", "False", "True", "True"], "Input type": ["float", "float", "", "ScalarList",\
+ "ScalarList", "ScalarList", "Scalar", "ScalarList", "Scalar", "Scalar", "Scalar", "Scalar", "Scalar"], "Input Strides": \
+[[150528, 1, 672, 3], [147, 1, 21, 3], [], [], [], [], [], [], [], [], [], [], []], "Input Dims": [[1, 3, 224, 224], \
+[64, 3, 7, 7], [], [], [], [], [], [], [], [], [], [], []], "Ev Idx": 1340
+    }
+  },
+  {
+    "ph": "X", "cat": "cpu_op", "name": "aten::addmm", "pid": 1147039, "tid": 1147039,
+    "ts": 198093513655.849, "dur": 251.130,
+    "args": {
+      "External id": 1619,"Sequence number": 0, "Fwd thread id": 0, "Record function id": 0, "Concrete Inputs": \
+["", "", "", "1", "1", ""], "Input type": ["float", "float", "float", "Scalar", "Scalar", "float"], "Input Strides":\
+ [[1], [0, 1], [1, 2048], [], [], [1000, 1]], "Input Dims": [[1000], [1, 2048], [2048, 1000], [], [], [1, 1000]], \
+"Ev Idx": 1618
+    }
+  },
+  {
+    "ph": "X", "cat": "kernel", "name": "void cutlass_addmm", "pid": 1147039, "tid": 1147039,
+    "ts": 198093513655.849, "dur": 251.130,
+    "args": {
+      "External id": 1619,"Sequence number": 0, "Fwd thread id": 0, "Record function id": 0,  "Ev Idx": 1618
+    }
+  },
+  {
+    "ph": "X", "cat": "kernel", "name": "void convolution_kernel", "pid": 1147039, "tid": 1147039,
+    "ts": 198093513655.849, "dur": 200.130,
+    "args": {
+      "External id": 1342, "Sequence number": 0, "Fwd thread id": 0, "Record function id": 0,  "Ev Idx": 1618
+    }
+  },
+  {
+    "ph": "X", "cat": "cpu_op", "name": "aten::convolution", "pid": 1147039, "tid": 1147039,
+    "ts": 198093488444.498, "dur": 341.867,
+    "args": {
+      "External id": 1342,"Record function id": 0, "Concrete Inputs": ["", "", "", "[2, 2]", "[3, 3]", "[1, 1]", \
+"False", "[0, 0]", "1", "False", "False", "True", "True"], "Input type": ["float", "float", "", "ScalarList", \
+"ScalarList", "ScalarList", "Scalar", "ScalarList", "Scalar", "Scalar", "Scalar", "Scalar", "Scalar"], "Input \
+Strides": [[150528, 1, 672, 3], [147, 1, 21, 3], [], [], [], [], [], [], [], [], [], [], []], "Input Dims": \
+[[1, 3, 224, 224], [64, 3, 7, 7], [], [], [], [], [], [], [], [], [], [], []], "Ev Idx": 1340
+    }
+  }
+],
+  "traceName": "/tmp/compiled_module_profile.json"
+}
+"""
+
+
+def verify_flops(self, expected_flops, out_profile):
+    j = 0
+    for i in range(len(out_profile["traceEvents"])):
+        if "kernel_flop" in out_profile["traceEvents"][i]["args"]:
+            self.assertEqual(
+                out_profile["traceEvents"][i]["args"]["kernel_flop"],
+                expected_flops[j],
+            )
+            j += 1
+
+
+def random_tensor(size, dtype, **kwargs):
+    if dtype in [torch.half, torch.bfloat16, torch.float, torch.double]:
+        return torch.randn(size, dtype=dtype, **kwargs)
+    elif dtype in [torch.uint8, torch.int8, torch.short, torch.int, torch.long]:
+        return torch.randint(0, 100, size, dtype=dtype, **kwargs)
+    else:
+        raise ValueError("Unsupported data type")
+
+
+def cT(device, dtype):
+    def T(*shape, requires_grad=False):
+        return random_tensor(
+            shape, requires_grad=requires_grad, device=device, dtype=dtype
+        )
+
+    return T
+
+
+def FlopCounterMode(*args, **kwargs):
+    return torch.utils.flop_counter.FlopCounterMode(*args, **kwargs, display=False)
+
+
+TMP_DIR = tempfile.mkdtemp()
+
+
+def trace_files():
+    TRACE1 = f"{TMP_DIR}/trace1-{uuid.uuid4()}.json"
+    TRACE2 = f"{TMP_DIR}/trace2-{uuid.uuid4()}.json"
+    return TRACE1, TRACE2
+
+
+def omni_model(device, dtype, compile=True):
+    T = cT(device, dtype)
+
+    def model():
+        input_conv = T(1, 3, 56, 56)
+        conv_weight = T(12, 3, 5, 5)
+
+        # Increased matrix sizes
+        mat1 = T(400, 600)
+        mat2 = T(600, 800)
+
+        batch_mat1 = T(1, 600, 800)
+        batch_mat2 = T(1, 800, 20 * 48)
+
+        # Convolution operation
+        conv_output = F.conv2d(input_conv, conv_weight)
+
+        # a pointwise op
+        conv_output = conv_output * 10
+
+        # Matrix multiplication (addmm) operation
+        addmm_output = torch.addmm(
+            torch.zeros(400, 800, device=mat1.device, dtype=mat1.dtype), mat1, mat2
+        )
+
+        # Batch matrix multiplication (bmm) operation
+        bmm_output = torch.bmm(batch_mat1, batch_mat2)
+
+        # Batch addition matrix multiplication (baddbmm) operation
+        baddbmm_output = torch.baddbmm(
+            torch.zeros(
+                1, 600, 20 * 48, device=batch_mat1.device, dtype=batch_mat1.dtype
+            ),
+            batch_mat1,
+            batch_mat2,
+        )
+
+        mm_output = torch.mm(mat1, mat2)
+
+        return torch.cat(
+            [
+                conv_output.flatten(),
+                addmm_output.flatten(),
+                bmm_output.flatten(),
+                baddbmm_output.flatten(),
+                mm_output.flatten(),
+            ]
+        )
+
+    if compile:
+        return torch.compile(
+            model, options={"benchmark_kernel": True, "profile_bandwidth": True}
+        )
+    return model
+
+
+def omni_model_no_bmm(device, dtype, compile=True):
+    T = cT(device, dtype)
+
+    def model():
+        input_conv = T(1, 3, 56, 56)
+        conv_weight = T(12, 3, 5, 5)
+
+        # Increased matrix sizes
+        mat1 = T(400, 600)
+        mat2 = T(600, 800)
+
+        # Convolution operation
+        conv_output = F.conv2d(input_conv, conv_weight)
+
+        # a pointwise op
+        conv_output = conv_output * 10
+
+        # Matrix multiplication (addmm) operation
+        addmm_output = torch.addmm(
+            torch.zeros(400, 800, device=mat1.device, dtype=mat1.dtype), mat1, mat2
+        )
+
+        mm_output = torch.mm(mat1, mat2)
+
+        return torch.cat(
+            [
+                conv_output.flatten(),
+                addmm_output.flatten(),
+                mm_output.flatten(),
+            ]
+        )
+
+    if compile:
+        return torch.compile(
+            model, options={"benchmark_kernel": True, "profile_bandwidth": True}
+        )
+    return model
+
+def omni_model_conv(device, dtype, compile=True):
+
+
+    if compile:
+        return torch.compile(
+            model, options={"benchmark_kernel": True, "profile_bandwidth": True}
+        )
+    return model
+
+
+prefix = ["profile.py"]
+
+
+class TestUtils(TestCase):
+    def test_tabulate2d(self):
+        headers = ["Kernel", "Self H100 TIME (ms)", "Count", "Percent"]
+        rows = [
+            ["aten::mm", 0.500, 7, 0.0],
+            ["aten::bmm", 0.400, 6, 0.0],
+            ["aten::baddbmm", 0.300, 5, 0.0],
+            ["aten::convolution", 0.200, 4, 0.0],
+            ["aten::cudnn_convolution", 0.100, 3, 0.0],
+        ]
+        table = [
+            " Kernel                  | Self H100 TIME (ms) | Count | Percent ",
+            "-----------------------------------------------------------------",
+            " aten::mm                |                 0.5 |     7 |     0.0 ",
+            " aten::bmm               |                 0.4 |     6 |     0.0 ",
+            " aten::baddbmm           |                 0.3 |     5 |     0.0 ",
+            " aten::convolution       |                 0.2 |     4 |     0.0 ",
+            " aten::cudnn_convolution |                 0.1 |     3 |     0.0 ",
+        ]
+        res = tabulate_2d(rows, headers)
+        for r, t in zip(res.split("\n"), table):
+            self.assertEqual(r, t)
+
+    def test_zip_dicts(self):
+        d1 = {"a": 1, "b": 2}
+        d2 = {"a": 3, "c": 4}
+        res = zip_dicts(d1, d2, d1_default="foo", d2_default="bar")
+        self.assertEqual(set(res), {("a", 1, 3), ("b", 2, "bar"), ("c", "foo", 4)})
+        res = zip_dicts(d1, d2)
+        self.assertEqual(set(res), {("a", 1, 3), ("b", 2, None), ("c", None, 4)})
+
+
+
+class TestAnalysis(TestCase):
+    @skipIf(not SM70OrLater, "Requires sm70")
+    def test_noop(self):
+        with (
+            patch("sys.stdout", new_callable=StringIO) as mock_stdout,
+            patch("sys.argv", [*prefix]),
+        ):
+            main()
+            self.assertEqual(mock_stdout.getvalue(), "")
+
+    @skipIf(not SM70OrLater, "Requires sm70")
+    @dtypes(torch.float, torch.double, torch.float16)
+    def test_diff(self, device, dtype):
+        """
+        diff, testing out the nruns feature too.
+        """
+        if device == "cpu":
+            # TODO cpu support
+            return
+        om = omni_model(device, dtype)
+        REPEAT = 5
+        trace1, trace2 = trace_files()
+        print("first trace")
+        with torch.profiler.profile(record_shapes=True) as p:
+            om()
+        p.export_chrome_trace(trace1)
+
+        print("second trace")
+        with torch.profiler.profile(record_shapes=True) as p:
+            for _ in range(REPEAT):
+                om()
+        p.export_chrome_trace(trce2)
+
+        print("diffing...")
+        with patch(
+            "sys.argv",
+            [
+                *prefix,
+                "--diff",
+                trace1,
+                "1",
+                "foo",
+                trace2,
+                str(REPEAT),
+                "bar",
+                "--name_limit",
+                "200",
+            ],
+        ):
+            main()
+
+    @skipIf(not SM70OrLater, "Requires sm70")
+    def test_augment_trace_helper_unit(self):
+        js = json.loads(example_profile)
+        out_profile = _augment_trace_helper(js)
+        expected_flops = [4096000, 4096000, 223552896, 223552896, 0, 0, 0]
+        verify_flops(self, expected_flops, out_profile)
+
+    @skipIf(not SM70OrLater, "Requires sm70")
+    @dtypes(torch.float, torch.double, torch.float16)
+    def test_augment_trace_helper_args(self, device, dtype):
+        if device == "cpu":
+            # cpu doesn't produce traces currently
+            return
+        om = omni_model(device, dtype)
+        with torch.profiler.profile(record_shapes=True) as p:
+            om()
+        trace1, trace2 = trace_files()
+        p.export_chrome_trace(trace1)
+        with patch("sys.argv", [*prefix, "--augment_trace", trace1, trace2]):
+            main()
+        profile = JsonProfile(trace2, 1, "foo")
+        rep = profile.report()
+        self.assertTrue(len(rep.split("\n")) > 3, f"Error, empty table:\n{rep}")
+        # If these fail, just update them. They could change over time
+        self.assertIn("Kernel Name", rep)
+        self.assertIn("Kernel Count", rep)
+        self.assertIn("FLOPS", rep)
+        self.assertIn("bw gbps", rep)
+        self.assertIn("Dur (ms)", rep)
+        self.assertIn("Achieved", rep)
+        self.assertIn("|", rep)
+        self.assertIn("-----", rep)
+
+        tables = profile._create_tables(profile._devices)
+        # check to make sure none of the cols are all zero, no empty columns
+        for tab in tables.values():
+            header, rows = tab
+            ncols = len(header) - 1
+            seen = [False] * ncols
+            for row in rows.values():
+                for i in range(len(row)):
+                    try:
+                        val = float(row[i])
+                    except Exception:
+                        continue
+                    seen[i] = seen[i] or (val != 0.0)
+
+            for i in range(len(seen)):
+                self.assertTrue(
+                    seen[i],
+                    f"column values from column {i + 1} with header '{header[i + 1]}' are all zero",
+                )
+
+        # check to make sure all % values are less than 100%
+        percents = []
+        for tab in tables.values():
+            header, rows = tab
+            for i, h in enumerate(header):
+                if "%" in h:
+                    percents.append(i)
+            self.assertTrue(len(percents) > 0, "There are no headers with % in them")
+            for row in rows.values():
+                for p in percents:
+                    idx = p - 1
+                    self.assertTrue(
+                        float(row[idx]) <= 100.0,
+                        f"column values from column {idx} with header '{header[idx]}' is greater than 100%: {row[idx]}",
+                    )
+                    self.assertTrue(
+                        float(row[idx]) >= 0.0,
+                        f"column values from column {idx} with header '{header[idx]}' is less than 0%: {row[idx]}",
+                    )
+
+    @skipIf(not SM70OrLater, "Requires sm70")
+    @dtypes(torch.float, torch.float16)
+    @parametrize("maxat", [(True, "TRITON")])
+    def test_inductor_meta_flop_gb_annotations(self, device, dtype, maxat):
+        if device == "cpu":
+            return
+        max_autotune, backends = maxat
+        om = omni_model_no_bmm(device, dtype)
+        comp_omni = torch.compile(
+            om,
+            options={
+                "benchmark_kernel": True,
+                "profile_bandwidth": True,
+                "max_autotune_gemm_backends": backends,
+                "force_disable_caches": True,
+                "max_autotune": max_autotune,
+            },
+        )
+        code_string = run_and_get_code(comp_omni)[1][0]
+        triton_mm_string_name = r"triton_.*_fused_mm.* = async_compile\.triton"
+        self.assertRegex(code_string, triton_mm_string_name)
+        lines = code_string.split("\n")
+        lookforward = 50
+        seen = False
+        for line_number, line in enumerate(lines):
+            if re.search(triton_mm_string_name, line):
+                seen = True
+                surrounding_lines = "\n".join(
+                    lines[line_number : min(len(lines), line_number + lookforward)]
+                )
+                if re.search(r"kernel_flop", surrounding_lines):
+                    kernel_flop_number = int(
+                        re.search(r"'kernel_flop': (\d+)", surrounding_lines).group(1)
+                    )
+
+                    self.assertNotEqual(
+                        kernel_flop_number, 0, "kernel_flop should be nonzero"
+                    )
+                else:
+                    self.assertTrue(False, "kernel_flop not found in last 10 lines")
+                break
+        self.assertTrue(seen)
+
+    @skipIf(not SM70OrLater, "Requires sm70")
+    @dtypes(torch.float, torch.double, torch.float16)
+    @parametrize(
+        "maxat",
+        [
+            (True, "TRITON"),
+        ],
+    )
+    def test_triton_has_metadata(self, device, dtype, maxat):
+        """
+        make sure that the chrome trace of triton kernels contains certain values
+        """
+        if device == "cpu":
+            return
+
+        T = cT(device, dtype)
+        input_conv = T(1, 3, 56, 56)
+        conv_weight = T(12, 3, 5, 5)
+        def om(i, w):
+            # Convolution operation
+            conv_output = F.conv2d(i, w)
+            return conv_output
+        max_autotune, backends = maxat
+        comp_omni = torch.compile(
+            om,
+            options={
+                "benchmark_kernel": True,
+                "profile_bandwidth": True,
+                "max_autotune_gemm_backends": backends,
+                "force_disable_caches": True,
+                "max_autotune": max_autotune,
+            },
+        )
+        comp_omni(input_conv, conv_weight)
+        with torch.profiler.profile(record_shapes=True) as profile:
+            comp_omni(input_conv, conv_weight)
+
+        trace1, _ = trace_files()
+        profile.export_chrome_trace(trace1)
+        breakpoint()
+        with open(trace1) as f:
+            out_profile = json.load(f)
+        seen = False
+        for event in out_profile["traceEvents"]:
+            if "triton" in event["name"] and "conv" in event["name"]:
+                seen = True
+                breakpoint()
+        self.assertTrue(seen, "no triton conv found")
+
+    @skipIf(not SM70OrLater, "Requires sm70")
+    @dtypes(torch.float, torch.double, torch.float16)
+    @parametrize(
+        "maxat",
+        [
+            (False, "ATEN,TRITON"),
+            # (True, "ATEN,TRITON"),
+            # (True, "ATEN"),
+            # (True, "TRITON"),
+        ],
+    )
+    def test_augment_trace_against_flop_counter(self, device, dtype, maxat):
+        if device == "cpu":
+            return
+        max_autotune, backends = maxat
+        if dtype == torch.double:
+            om = omni_model_no_addmm(device, dtype, compile=False)
+        else:
+            om = omni_model_no_bmm(device, dtype, compile=False)
+
+        comp_omni = torch.compile(
+            om,
+            options={
+                "benchmark_kernel": True,
+                "profile_bandwidth": True,
+                "max_autotune_gemm_backends": backends,
+                "force_disable_caches": True,
+                "max_autotune": max_autotune,
+            },
+        )
+        comp_omni()
+
+        torch._dynamo.reset()  # reset the cache
+        with fresh_inductor_cache():
+            with torch.profiler.profile(record_shapes=True) as profile:
+                comp_omni()
+
+        torch._dynamo.reset()  # reset the cache
+        with fresh_inductor_cache():
+            with FlopCounterMode() as mode:
+                comp_omni()
+
+        trace1, trace2 = trace_files()
+        profile.export_chrome_trace(trace1)
+        with patch("sys.argv", [*prefix, "--augment_trace", trace1, trace2]):
+            main()
+
+        with open(trace2) as f:
+            out_profile = json.load(f)
+
+        flop_counts = mode.flop_counts
+        extern_mapping = _create_extern_mapping(out_profile)
+
+        seen_mm = False
+        seen_bmm = False
+        seen_baddbmm = False
+        seen_conv = False
+        for event in out_profile["traceEvents"]:
+            if "cat" not in event or event["cat"] != "kernel" or "args" not in event or "External id" not in event["args"]:
+                continue
+
+            print(external_op["name"])
+            external_op = extern_mapping[event["args"]["External id"]][0]
+            if external_op["name"].startswith("aten::mm"):
+                seen_mm = True
+                self.assertEqual(
+                    event["args"]["kernel_flop"],
+                    flop_counts["Global"][torch.ops.aten.mm],
+                )
+            if (
+                external_op["name"].startswith("aten::cudnn_convolution")
+                or external_op["name"].startswith("aten::convolution")
+                or external_op["name"].startswith("aten::_convolution")
+            ):
+                seen_conv = True
+                self.assertEqual(
+                    event["args"]["kernel_flop"],
+                    flop_counts["Global"][torch.ops.aten.convolution],
+                )
+            if external_op["name"].startswith("aten::baddbmm"):
+                seen_baddbmm = True
+                self.assertEqual(
+                    event["args"]["kernel_flop"],
+                    flop_counts["Global"][torch.ops.aten.baddbmm],
+                )
+            if external_op["name"].startswith("aten::bmm"):
+                seen_bmm = True
+                self.assertEqual(
+                    event["args"]["kernel_flop"],
+                    flop_counts["Global"][torch.ops.aten.bmm],
+                )
+        self.assertTrue(seen_mm)
+        if dtype != torch.double:
+            self.assertTrue(seen_bmm)
+            self.assertTrue(seen_baddbmm)
+        self.assertTrue(seen_conv)
+
+
+instantiate_device_type_tests(TestAnalysis, globals())
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -1,0 +1,84 @@
+# Owner(s): ["module: inductor"]
+
+import torch
+import torch.utils.flop_counter
+from torch._inductor.debug import DebugContext
+from torch._inductor.graph import GraphLowering
+from torch._inductor.virtualized import V
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.testing._internal.common_device_type import (
+    dtypes,
+    instantiate_device_type_tests,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+def FlopCounterMode(*args, **kwargs):
+    return torch.utils.flop_counter.FlopCounterMode(*args, **kwargs, display=False)
+
+
+def get_total_flops(mode):
+    return sum(v for _, v in mode.flop_counts["Global"].items())
+
+
+def random_tensor(size, dtype, **kwargs):
+    if dtype in [torch.half, torch.bfloat16, torch.float, torch.double]:
+        return torch.randn(size, dtype=dtype, **kwargs)
+    elif dtype in [torch.uint8, torch.int8, torch.short, torch.int, torch.long]:
+        return torch.randint(0, 100, size, dtype=dtype, **kwargs)
+    else:
+        raise ValueError("Unsupported data type")
+
+
+def cT(device, dtype):
+    def T(*shape, requires_grad=False):
+        return random_tensor(
+            shape, requires_grad=requires_grad, device=device, dtype=dtype
+        )
+
+    return T
+
+
+class TestScheduler(TestCase):
+    @dtypes(torch.float, torch.double)
+    def test_flop_counter_op(self, device, dtype):
+        T = cT(device, dtype)
+
+        def composite(x, y, z):
+            tmp = torch.mm(x + 10, y / 12)
+            return torch.mm(tmp, z)
+
+        def composite_relu(x, y):
+            tmp = torch.mm(x, y)
+            return torch.relu(tmp)
+
+        test_cases = [
+            (torch.mm, [T(4, 5), T(5, 6)], {}),
+            (torch.add, [T(4, 5), T(4, 5)], {}),
+            (composite, [T(5, 4), T(4, 3), T(3, 12)], {}),
+            (composite_relu, [T(5, 4), T(4, 3)], {}),
+        ]
+        for op, example_inputs, kwargs in test_cases:
+            comp = torch.compile(op)
+            with FlopCounterMode() as mode:
+                comp(*example_inputs, **kwargs)
+            gm = make_fx(op)(*example_inputs, **kwargs)
+            reference_flops = get_total_flops(mode)
+
+            graph = GraphLowering(gm)
+
+            with V.set_graph_handler(graph), V.set_debug_handler(DebugContext()):
+                graph.run(*example_inputs, **kwargs)
+                graph.init_wrapper_code()
+                graph._update_scheduler()
+                scheduler_flops = 0
+                for node in graph.scheduler.nodes:
+                    flops = node.estimate_flops()
+                    scheduler_flops += flops if flops is not None else 0
+            self.assertEqual(reference_flops, scheduler_flops, msg=f"op = {op}")
+
+
+instantiate_device_type_tests(TestScheduler, globals())
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -2997,6 +2997,7 @@ aten::mm""",
             assert len(key_averages) == 3
             assert "Overload Name" in key_averages.table()
             validate_json(prof)
+        
     def test_profiler_debug_autotuner(self):
         """
         This test makes sure that profiling events will be present when the kernel is run using the DebugAutotuner.
@@ -3015,13 +3016,24 @@ aten::mm""",
             comp_mm()
         def names(prof):
             return {ev.name for ev in prof.events() if "mm" in ev.name or "triton" in ev.name}
+        # for ev in prof1.events():
+        #     if ev.name == "triton_tem_fused_mm_0":
+        #         breakpoint()
+        # for ev in prof2.events():
+        #     if ev.name == "triton_tem_fused_mm_0":
+        #         breakpoint()
+        
+        trace1 = "/tmp/trace1_pb.json"
+        trace2 = "/tmp/trace2_nopb.json"
+        print(trace1, trace2)
+        prof1.export_chrome_trace(trace1)
+        prof2.export_chrome_trace(trace2)
+        breakpoint()
         
         n1 = names(prof1)
         n2 = names(prof2)
         self.assertEqual(n1, n2)
-
-        
-        
+        breakpoint()        
 
 
 

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -3006,15 +3006,19 @@ aten::mm""",
         def mm():
             return torch.mm(in1, in2)
         
-        pb_mm = torch.compile(mm, options={"benchmark_kernel": True, "max_autotune": True, "max_autotune_gemm_backends": "TRITON,ATEN", "profile_bandwidth": True})
+        pb_mm = torch.compile(mm, options={"benchmark_kernel": True, "max_autotune": True, "max_autotune_gemm_backends": "TRITON", "profile_bandwidth": True})
         comp_mm = torch.compile(mm, options={"benchmark_kernel": True, "max_autotune": True, "max_autotune_gemm_backends": "TRITON"})
 
-        with profile() as prof:
+        with profile() as prof1:
             pb_mm()
-        for ev in prof.events():
-            if "triton" in ev.name:
-                breakpoint()
+        with profile() as prof2:
+            comp_mm()
+        def names(prof):
+            return {ev.name for ev in prof.events() if "mm" in ev.name or "triton" in ev.name}
         
+        n1 = names(prof1)
+        n2 = names(prof2)
+        self.assertEqual(n1, n2)
 
         
         

--- a/torch/_inductor/analysis/README.md
+++ b/torch/_inductor/analysis/README.md
@@ -1,0 +1,2 @@
+# `torch._inductor.analysis`
+Contains scripts for inductor performance analysis.

--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -1,0 +1,148 @@
+from dataclasses import dataclass
+from logging import info
+from typing import Optional
+
+import torch
+
+
+@dataclass(frozen=True)
+class DeviceInfo:
+    """
+    Theoretical Numbers from data sheet. If two numbers are given, Tensor/Matrix Core vs not,
+    then the higher number is reported. Sparsity is not considered.
+
+
+    Bandwidth numbers are tricky, because there are platform differences that may not show up in the profiler trace.
+    For example,
+    """
+
+    tops: dict[torch.dtype, float]
+    dram_bw_gbs: float
+    dram_gb: float
+
+
+# Indexing is based on `torch.cuda.get_device_name()`
+# TODO investigate profiler support for tf32 and allow device to report correct number when it's turned on.
+_device_mapping: dict[str, DeviceInfo] = {
+    # Source: https://resources.nvidia.com/en-us-tensor-core/nvidia-tensor-core-gpu-datasheet
+    "NVIDIA H100": DeviceInfo(
+        tops={
+            torch.float64: 9.7,
+            torch.float32: 19.5,
+            torch.bfloat16: 1979.0,
+            torch.float16: 1979.0,
+            torch.float8_e8m0fnu: 3958.0,
+            torch.float8_e8m0fnu: 3958.0,
+            torch.float8_e4m3fnuz: 3958.0,
+            torch.float8_e5m2: 3958.0,
+            torch.float8_e5m2fnuz: 3958.0,
+            torch.float8_e8m0fnu: 3958.0,
+            torch.int8: 3958.0,
+        },
+        dram_bw_gbs=3350,
+        dram_gb=80,
+    ),
+    # Source: https://resources.nvidia.com/en-us-tensor-core/nvidia-tensor-core-gpu-datasheet
+    "NVIDIA A100": DeviceInfo(
+        tops={
+            torch.float64: 19.5,
+            torch.float32: 19.5,
+            torch.bfloat16: 312.5,
+            torch.float16: 312.5,
+            # Not in datasheet: float8
+            torch.int8: 624.0,
+        },
+        dram_bw_gbs=2039.0,
+        dram_gb=80.0,
+    ),
+    # Source: https://resources.nvidia.com/en-us-gpu-resources/l4-tensor-datasheet
+    "NVIDIA L4": DeviceInfo(
+        tops={
+            # This is a guess, not in datasheet
+            torch.float64: 15.1,
+            torch.float32: 30.3,
+            torch.bfloat16: 242.0,
+            torch.float16: 242.0,
+            torch.float8_e8m0fnu: 485.0,
+            torch.float8_e8m0fnu: 485.0,
+            torch.float8_e4m3fnuz: 485.0,
+            torch.float8_e5m2: 485.0,
+            torch.float8_e5m2fnuz: 485.0,
+            torch.float8_e8m0fnu: 485.0,
+            torch.int8: 485.0,
+        },
+        dram_bw_gbs=3350,
+        dram_gb=24,
+    ),
+    # Source: https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/data-sheets/amd-instinct-mi300a-data-sheet.pdf
+    "AMD MI300A": DeviceInfo(
+        tops={
+            torch.float64: 122.6,
+            torch.float32: 122.6,
+            # torch.tf32: 490.3,
+            torch.bfloat16: 980.6,
+            torch.float16: 980.6,
+            torch.float8_e8m0fnu: 1961.2,
+            torch.float8_e8m0fnu: 1961.2,
+            torch.float8_e4m3fnuz: 1961.2,
+            torch.float8_e5m2: 1961.2,
+            torch.float8_e5m2fnuz: 1961.2,
+            torch.float8_e8m0fnu: 1961.2,
+            torch.int8: 1961.2,
+        },
+        dram_bw_gbs=5300.0,
+        dram_gb=128.0,
+    ),
+    # Source: https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/data-sheets/amd-instinct-mi300x-data-sheet.pdf
+    "AMD MI300X": DeviceInfo(
+        tops={
+            torch.float64: 163.4,
+            torch.float32: 163.4,
+            torch.bfloat16: 1307.4,
+            torch.float16: 1307.4,
+            torch.float8_e8m0fnu: 2614.9,
+            torch.float8_e8m0fnu: 2614.9,
+            torch.float8_e4m3fnuz: 2614.9,
+            torch.float8_e5m2: 2614.9,
+            torch.float8_e5m2fnuz: 2614.9,
+            torch.float8_e8m0fnu: 2614.9,
+            torch.int8: 2614.9,
+        },
+        dram_bw_gbs=5300.0,
+        dram_gb=192.0,
+    ),
+}
+
+
+def lookup_device_info(name: str) -> Optional[DeviceInfo]:
+    """
+    Problem: when diffing profiles between amd and nvidia, we don't have access to the device information
+    of the other one. Also, since the analysis is static, we should be able to do it on another device unrelated
+    to the recorded device. Therefore, _device_mapping statically contains the information for lots of devices.
+    If one is missing, please run DeviceInfo.get_device_info() and add it to _device_mapping.
+      name (str): name of the device to lookup. Should map onto torch.cuda.get_device_name().
+    """
+    if name not in _device_mapping:
+        return None
+    return _device_mapping[name]
+
+
+def datasheet_tops(dtype: torch.dtype) -> Optional[float]:
+    """
+    Get the theoretical TFLOPS of the device for a given dtype. This can throw an exception if the device
+    is not in the datasheet list above.
+    """
+    name: Optional[str] = torch.cuda.get_device_name()
+    if name is None:
+        info("No device found, returning None")
+        return None
+    device_info = lookup_device_info(name)
+    if device_info is None:
+        info(f"Device {name} not in datasheet, returning None")
+        return None
+    if dtype not in device_info.tops:
+        info(
+            f"Device {name} does not have a datasheet entry for {dtype}, returning None"
+        )
+        return None
+    return device_info.tops[dtype]

--- a/torch/_inductor/analysis/profile_analysis.py
+++ b/torch/_inductor/analysis/profile_analysis.py
@@ -1,0 +1,577 @@
+import json
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+from logging import info
+from typing import Any, Optional, Union
+
+import torch
+from torch._inductor.analysis.device_info import DeviceInfo, lookup_device_info
+from torch._inductor.utils import tabulate_2d, zip_dicts
+from torch.utils import _pytree as pytree
+from torch.utils._ordered_set import OrderedSet
+from torch.utils.flop_counter import flop_registry
+
+
+ATEN_PREFIX = "aten::"
+
+
+@dataclass
+class ProfileEvent:
+    category: str
+    key: str
+    self_device_time_ms: float
+    # the benchmark is run multiple times and we average the count across all the
+    # runs. It should be an integer but define a float just in case.
+    count: float
+
+
+# adapters convert the json trace into a format that works with flops_counter
+adapters_map: dict[str, Any] = {}
+
+
+def parse_list(lst: str) -> list[int]:
+    lst = lst.replace("[", "").replace("]", "")
+    substrings = lst.split(",")
+    return [int(substring.strip()) for substring in substrings]
+
+
+def register_adapter(aten: Union[str, list[str]]):  # type: ignore[no-untyped-def]
+    def decorator(func):  # type: ignore[no-untyped-def]
+        global _adapters_map
+
+        def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
+            result = func(*args, **kwargs)
+            return result
+
+        if isinstance(aten, str):
+            adapters_map[aten] = wrapper
+        else:
+            for at in aten:
+                adapters_map[at] = wrapper
+        return wrapper
+
+    return decorator
+
+
+@register_adapter(["convolution", "_convolution", "cudnn_convolution"])
+def conv_adapter(
+    shapes: tuple[Any, ...], concrete: tuple[Any, ...]
+) -> tuple[tuple[Any], dict[Any, Any]]:
+    tmp = list(shapes)
+    if len(tmp) == 4:
+        transposed = False
+
+    transposed = bool(tmp[6])
+    tmp[6] = transposed
+
+    kwargs = {}
+    if not transposed:
+        # calculate output shape if not transposed.
+        def conv_out_dims(x: int, kernel: int, stride: int) -> int:
+            return (x - kernel) // stride + 1
+
+        stride = parse_list(concrete[3])
+        inp = shapes[0]
+        w = shapes[1]
+        out_x_y = [conv_out_dims(*args) for args in zip(inp[2:], w[2:], stride)]
+        out = [inp[0], w[0]] + out_x_y  # we only need the xy values
+        kwargs["out_val"] = out
+
+    return tuple(tmp[:-1]), kwargs
+
+
+def default_adapter(
+    shapes: tuple[Any], concrete: tuple[Any]
+) -> tuple[tuple[Any], dict[Any, Any]]:
+    return shapes, {}
+
+
+@register_adapter("addmm")
+def addmm_adapter(
+    shapes: tuple[Any], concrete: tuple[Any]
+) -> tuple[tuple[Any], dict[Any, Any]]:
+    tmp = list(shapes)[:3]
+    return tuple(tmp), {}
+
+
+@register_adapter("bmm")
+def bmm_adapter(
+    shapes: tuple[Any], concrete: tuple[Any]
+) -> tuple[tuple[Any], dict[Any, Any]]:
+    tmp = list(shapes)
+    return tuple(tmp[:2]), {}
+
+
+@register_adapter("baddbmm")
+def baddbmm_adapter(
+    shapes: tuple[Any], concrete: tuple[Any]
+) -> tuple[tuple[Any], dict[Any, Any]]:
+    tmp = list(shapes)[:3]
+    return tuple(tmp), {}
+
+
+@register_adapter("mm")
+def mm_adapter(
+    shapes: tuple[Any], concrete: tuple[Any]
+) -> tuple[tuple[Any], dict[Any, Any]]:
+    return shapes, {}
+
+
+def _parse_kernel_name(name: str) -> Optional[str]:
+    if name.startswith(ATEN_PREFIX):
+        return name[len(ATEN_PREFIX) :]
+    elif "convolution" in name:
+        return "convolution"
+    elif "addmm" in name:
+        return "addmm"
+    elif "bmm" in name:
+        return "bmm"
+    elif "baddbmm" in name:
+        return "baddbmm"
+    elif "_mm" in name:
+        return "mm"
+    else:
+        return None
+
+
+def _calculate_flops(event: dict[str, Any]) -> int:
+    """
+    This function has to parse the kernel name, which is error prone. There doesn't seem to be another solution that
+    will support all the different backends that can generate kernels, so make sure to update this function when new
+    ops and backends are desired.
+    """
+    name = event["name"]
+    if "kernel_flop" in event["args"] and event["args"]["kernel_flop"] != 0:
+        return event["args"]["kernel_flop"]
+    op_name = _parse_kernel_name(name)
+    if op_name is None:
+        return 0
+
+    op_obj = getattr(torch.ops.aten, op_name, None)
+    if op_obj is None or not op_obj in flop_registry:
+        return 0
+
+    flop_function = flop_registry[op_obj]
+
+    if "Input Dims" not in event["args"] or "Concrete Inputs" not in event["args"]:
+        breakpoint()
+    input_shapes = event["args"]["Input Dims"]
+    concrete = event["args"]["Concrete Inputs"]
+    if op_name in adapters_map:
+        args, kwargs = adapters_map[op_name](input_shapes, concrete)
+    else:
+        args, kwargs = default_adapter(input_shapes, concrete)
+    return flop_function(*args, **kwargs)
+
+
+def _estimate_gb(event: dict[str, Any]) -> float:
+    """
+    This estimate isn't the best because it doesn't know if two input buffers are the same buffer, leading to an
+    overestimate of the real achieved bandwidth.
+    """
+    if "Input type" not in event["args"] or "Input Dims" not in event["args"]:
+        return 0
+    sizes_and_types = zip(event["args"]["Input Dims"], event["args"]["Input type"])
+    bw = 0
+    for size, typ in sizes_and_types:
+        if not hasattr(torch, typ):
+            isize = 0
+        else:
+            isize = getattr(torch, typ).itemsize
+        bw += isize * math.prod(pytree.tree_flatten(size)[0])
+    return bw / 1e9
+
+
+def _create_extern_mapping(
+    data: dict[str, Any],
+) -> defaultdict[int, list[dict[str, Any]]]:
+    """
+    compute a mapping from exteral ids to non kernels, which contain the information we need to estimate flops etc
+    """
+    extern_mapping: defaultdict[int, list[dict[str, Any]]] = defaultdict(list)
+    for event in data["traceEvents"]:
+        if (
+            "args" not in event
+            or "External id" not in event["args"]
+            or event["cat"] != "cpu_op"
+        ):
+            continue
+        if len(extern_mapping[event["args"]["External id"]]) > 0:
+            raise ParseException("duplicate external id in event")
+        extern_mapping[event["args"]["External id"]].append(event)
+    return extern_mapping
+
+
+def _augment_trace_helper(data: dict[str, Any]) -> dict[str, Any]:
+    extern_mapping = _create_extern_mapping(data)
+
+    for event in data["traceEvents"]:
+        if "cat" not in event or event["cat"] != "kernel":
+            continue
+        if "args" not in event:
+            raise ParseException(f"kernel has no args: {event}")
+        if "External id" not in event["args"]:
+            event_str = f"kernel has no External id: {event}"
+            info(event_str)
+            continue
+
+        external_op = extern_mapping[event["args"]["External id"]][0]
+        flops = _calculate_flops(external_op)
+        if flops == 0:
+            flops = _calculate_flops(event)
+        external_op["args"]["kernel_flop"] = flops
+        external_op["args"]["kernel_num_gb"] = _estimate_gb(external_op)
+        event["args"]["kernel_flop"] = external_op["args"]["kernel_flop"]
+        event["args"]["kernel_num_gb"] = external_op["args"]["kernel_num_gb"]
+    return data
+
+
+_dtype_map = {
+    "float": torch.float,
+    "int": torch.int,
+    "long": torch.long,
+    "long int": torch.long,
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+}
+
+
+@dataclass(frozen=True)
+class KernelStats:
+    flops: int
+    bw: float
+    latency: float
+    achieved_flops: float
+    achieved_bandwidth: float
+
+
+KernelNameMap = defaultdict[str, OrderedSet[KernelStats]]
+
+
+@dataclass(frozen=False)
+class Device:
+    name: str
+    index: int
+    info: DeviceInfo
+    stats: KernelNameMap
+
+    def __repr__(self) -> str:
+        return f"Device({self.name}, {self.index})"
+
+
+DeviceMap = dict[int, Device]
+Table = tuple[list[str], dict[str, list[str]]]
+
+
+class JsonProfile:
+    _devices: DeviceMap
+
+    def __init__(
+        self,
+        path: str,
+        nruns: int,
+        benchmark_name: Optional[str] = None,
+    ):
+        """
+        Convienence class for running common operations on chrome/perfetto json traces.
+        """
+        self.path = path
+        with open(path) as f:
+            self.data = json.load(f)
+            self.events = self.data["traceEvents"]
+        self.nruns = nruns
+        self.benchmark_name = benchmark_name
+        self._create_devices()
+
+    def convert_dtype(self, event: dict[str, Any]) -> torch.dtype:
+        """
+        Each op has a list of dtypes for each input arg. We need to convert these into a single dtype for flop estimation.
+        Issues:
+         - converting the strings to concrete torch.dtypes
+         - What if we have float32, float, float16 all in the inputs? Our choice is to use the largest buffer dtype.
+        """
+
+        if (
+            "Input Dims" not in event["args"]
+            or "Input type" not in event["args"]
+            or "Concrete Inputs" not in event["args"]
+        ):
+            if "bfloat16" in event["name"]:
+                return torch.bfloat16
+            elif "float16" in event["name"]:
+                return torch.float16
+            else:
+                return torch.float
+
+        input_sizes = event["args"]["Input Dims"]
+        input_types = event["args"]["Input type"]
+        concrete_inputs = event["args"]["Concrete Inputs"]
+        assert len(input_sizes) == len(input_types)
+        assert len(input_types) == len(concrete_inputs)
+
+        if len(input_sizes) == 0:
+            raise RuntimeError("Empty input_sizes and input_types")
+
+        biggest_size = 0
+        biggest_index = 0
+        for i in range(len(input_sizes)):
+            if concrete_inputs[i] != "":
+                # concrete inputs are usually small tensors, so we can just skip
+                continue
+            my_size = input_sizes[i]
+            total_size = sum(parse_list(my_size))
+            if total_size > biggest_size:
+                biggest_size = total_size
+                biggest_index = i
+        ret_type = input_types[biggest_index]
+        if ret_type in _dtype_map:
+            return _dtype_map[ret_type]
+        raise RuntimeError(f"Unknown type: {ret_type}. Please add to _dtype_map.")
+
+    def _create_devices(self) -> None:
+        self._devices = {}
+        for dev in self.data["deviceProperties"]:
+            name = dev["name"]
+            device_info = lookup_device_info(name)
+            if device_info is None:
+                raise RuntimeError(
+                    f"Unsupported device in profile: {name}, please consider contributing to _device_mapping."
+                )
+            self._devices[dev["id"]] = Device(
+                name, dev["id"], device_info, defaultdict(OrderedSet)
+            )
+
+    def calculate_flops(self, event: dict[str, Any]) -> int:
+        return _calculate_flops(event)
+
+    def estimate_gb(self, event: dict[str, Any]) -> float:
+        """
+        This estimate isn't the best because it doesn't know if two input buffers are the same buffer, leading to an
+        overestimate of the real achieved bandwidth.
+        """
+        return _estimate_gb(event)
+
+    def augment_trace(self) -> None:
+        self.data = _augment_trace_helper(self.data)
+
+    def _compute_stats(self) -> None:
+        """populates the name -> stats map"""
+        for event in self.events:
+            if "cat" not in event or "args" not in event or event["cat"] != "kernel":
+                continue
+            dev = self._devices[event["args"]["device"]]
+            dur = event["dur"]
+            if "kernel_flop" in event["args"]:
+                assert dur != 0
+                # 1000ms/s * flop / ms
+                op_flops = 1e3 * event["args"]["kernel_flop"] / dur
+                if op_flops == 0:
+                    achieved_flops = 0
+                else:
+                    dtype = self.convert_dtype(event)
+                    achieved_flops = 100 * op_flops / (1e12 * dev.info.tops[dtype])
+            else:
+                op_flops = 0
+                achieved_flops = 0
+
+            if "kernel_num_gb" in event["args"]:
+                assert dur != 0
+                # 1000ms/s * gb / ms = gb/s
+                op_gbps = 1e3 * event["args"]["kernel_num_gb"] / dur
+                achieved_bandwidth = 100 * op_gbps / dev.info.dram_bw_gbs
+            else:
+                op_gbps = 0
+                achieved_bandwidth = 0
+
+            dev.stats[event["name"]].add(
+                KernelStats(
+                    flops=op_flops,
+                    bw=op_gbps,
+                    latency=dur,
+                    achieved_bandwidth=achieved_bandwidth,
+                    achieved_flops=achieved_flops,
+                )
+            )
+
+    def _create_single_table(self, dev: Device) -> Table:
+        """Create a table with the devices mapped to indices."""
+        headers = [
+            "Kernel Name",
+            "Kernel Count",
+            "FLOPS",
+            "bw gbps",
+            "Dur (ms)",
+            "Achieved FLOPS %",
+            "Achieved Bandwidth %",
+        ]
+        rows: dict[str, list[str]] = {}
+
+        for kernel_name, stats_set in dev.stats.items():
+            ker_count = 0
+            flops = 0
+            flops_count = 0
+            achieved_flops = 0.0
+            bw = 0.0
+            bw_count = 0
+            achieved_bandwidth = 0.0
+            latency = 0.0
+            for stats in stats_set:
+                if stats.flops != 0:
+                    flops += stats.flops
+                    achieved_flops += stats.achieved_flops
+                    flops_count += 1
+                if stats.bw != 0:
+                    bw += stats.bw
+                    achieved_bandwidth += stats.achieved_bandwidth
+                    bw_count += 1
+                latency += stats.latency
+                ker_count += 1
+            assert ker_count != 0
+            rows[kernel_name] = [
+                str(ker_count),
+                str(flops / flops_count if flops_count != 0 else 0),
+                str(bw / bw_count if bw_count != 0 else 0),
+                str(latency / ker_count if ker_count != 0 else 0),
+                str(achieved_flops / flops_count if flops_count != 0 else 0),
+                str(achieved_bandwidth / bw_count if bw_count != 0 else 0),
+            ]
+
+        return headers, rows
+
+    def _create_tables(self, devs: DeviceMap) -> dict[int, Table]:
+        return {idx: self._create_single_table(dev) for idx, dev in devs.items()}
+
+    def _combine_tables(
+        self, table1: Table, table1_name: str, table2: Table, table2_name: str
+    ) -> Table:
+        new_headers = (
+            ["Kernel Name"]
+            + [f"{table1_name} {head}" for head in table1[0][1:]]
+            + [f"{table2_name} {head}" for head in table2[0][1:]]
+        )
+        t1_length = len(table1[0][1:])
+        t2_length = len(table2[0][1:])
+        new_rows = {}
+
+        for key, row1, row2 in zip_dicts(
+            table1[1],
+            table2[1],
+            d1_default=["Empty"] * t1_length,
+            d2_default=["Empty"] * t2_length,
+        ):
+            new_rows[key] = row1 + row2
+        return new_headers, new_rows
+
+    def report(
+        self, other: Optional["JsonProfile"] = None, name_limit: int = 40
+    ) -> str:
+        def create_ret(
+            table_headers: list[str], table_rows: dict[str, list[str]]
+        ) -> str:
+            table_flattened = [
+                [kernel_name[:name_limit], *kernel_vals]
+                for kernel_name, kernel_vals in table_rows.items()
+            ]
+            return tabulate_2d(table_flattened, headers=table_headers)
+
+        if other is not None:
+            self._compute_stats()
+            other._compute_stats()
+
+            self_tables = self._create_tables(self._devices)
+            other_tables = self._create_tables(other._devices)
+
+            self_name = (
+                self.benchmark_name if self.benchmark_name is not None else "Table 1"
+            )
+            other_name = (
+                other.benchmark_name if other.benchmark_name is not None else "Table 2"
+            )
+
+            ret = []
+            assert self._devices.keys() == other._devices.keys()
+            for device_idx, t1, t2 in zip_dicts(
+                self_tables, other_tables, d1_default=None, d2_default=None
+            ):
+                table_headers, table_rows = self._combine_tables(
+                    t1, self_name, t2, other_name
+                )
+                tab_string = create_ret(table_headers, table_rows)
+                ret.append(f"{self._devices[device_idx]}:\n{tab_string}")
+            return "\n".join(ret)
+        self._compute_stats()
+
+        self_tables = self._create_tables(self._devices)
+
+        ret = []
+        for idx, table in self_tables.items():
+            table_headers, table_rows = table
+            tab_string = create_ret(table_headers, table_rows)
+            ret.append(f"{self._devices[idx]}:\n{tab_string}")
+        return "\n".join(ret)
+
+    def dump(self, out: str) -> None:
+        with open(out, "w") as f:
+            json.dump(self.data, f)
+
+
+class ParseException(RuntimeError):
+    pass
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--diff",
+        nargs=6,
+        metavar=("input_file1", "nruns1", "name1", "input_file2", "nruns2", "name2"),
+        help="Two json traces to compare with, specified as <file1> <nruns1> <name1> <file2> <nruns2> <name2>",
+    )
+    parser.add_argument(
+        "--name_limit",
+        type=int,
+        help="the maximum name size in the final report",
+    )
+    parser.add_argument(
+        "--augment_trace",
+        "-a",
+        type=str,
+        nargs=2,
+        metavar=("input_file", "output_file"),
+        help="Augment a trace with inductor meta information. Provide input and output file paths.",
+    )
+    parser.add_argument(
+        "--analysis",
+        nargs=3,
+        metavar=("input_file", "nruns", "name"),
+        help="Run analysis on a single trace, specified as <file> <nruns> <name>",
+    )
+    args = parser.parse_args()
+
+    if args.diff:
+        p1 = JsonProfile(args.diff[0], int(args.diff[1]), args.diff[2])
+        p1.augment_trace()
+        p2 = JsonProfile(args.diff[3], int(args.diff[4]), args.diff[5])
+        p2.augment_trace()
+        if args.name_limit:
+            print(p1.report(p2, name_limit=args.name_limit))
+        else:
+            print(p1.report(p2))
+    if args.analysis:
+        p1 = JsonProfile(args.analysis[0], args.analysis[1], args.analysis[2])
+        p1.augment_trace()
+        if args.name_limit:
+            print(p1.report(name_limit=args.name_limit))
+        else:
+            print(p1.report())
+    if args.augment_trace:
+        p = JsonProfile(args.augment_trace[0], 1)
+        p.augment_trace()
+        p.dump(args.augment_trace[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -897,6 +897,13 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
             return tuple(map(fn, value))
         return fn(value)
 
+    def estimate_flops(self) -> Optional[int]:
+        flops = [
+            node.estimate_flops()
+            for node in NodeScheduleMarker.only_nodes(self.features.node_schedule)
+        ]
+        return sum(filter(None, flops))
+
     def estimate_kernel_num_bytes(self):
         """
         Try the best to estimate the total size (in bytes) of the
@@ -1533,7 +1540,9 @@ class SIMDScheduling(BaseScheduling):
                             kernel.cse.invalidate(OrderedSet())
 
         if not isinstance(partial_code, str):
-            partial_code.finalize_hook("<DEF_KERNEL>")
+            # This is used to calculate flops in TritonTemplateKernels
+            with ir.IRNode.current_origins(template_node.node.origins):
+                partial_code.finalize_hook("<DEF_KERNEL>")
             partial_code.finalize_hook("<ARGDEFS>", strict=False)
         # finalize must be called after adding epilogue above
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3642,6 +3642,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         if config.benchmark_kernel or config.profile_bandwidth:
             num_gb = self.estimate_kernel_num_bytes() / 1e9
             inductor_meta["kernel_num_gb"] = num_gb
+        if config.benchmark_kernel:
+            inductor_meta["kernel_flop"] = self.estimate_flops()
 
         triton_meta["configs"] = [config_of(signature)]
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -688,16 +688,15 @@ class CachingAutotuner(KernelInterface):
             self.reset_to_zero_args(*args, **kwargs)
             args_with_constexprs = self._get_args_with_constexprs(cloned_args, launcher)
             if autograd_profiler._is_profiler_enabled:
-                breakpoint()
                 profiler_kwargs = self.get_profiler_kwargs(stream, launcher)
                 with torch._C._profiler._RecordFunctionFast(
                     self.inductor_meta.get("kernel_name", "triton kernel"),
-                    args,
+                    args_with_constexprs,
                     profiler_kwargs,
                 ):
                     launcher(
-                        *args,
-                        **kwargs,
+                        *args_with_constexprs,
+                        **cloned_kwargs,
                         stream=stream,
                     )
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1743,7 +1743,7 @@ def cached_autotune(
                 regex_filter=inductor_meta["profile_bandwidth_regex"],
                 with_profiler=inductor_meta[
                     "profile_bandwidth_with_do_bench_using_profiling"
-                ],
+                ] or autograd_profiler._is_profiler_enabled,
                 configs=configs,
                 save_cache_hook=autotune_cache and autotune_cache.save,
                 mutated_arg_names=mutated_arg_names,

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -688,6 +688,7 @@ class CachingAutotuner(KernelInterface):
             self.reset_to_zero_args(*args, **kwargs)
             args_with_constexprs = self._get_args_with_constexprs(cloned_args, launcher)
             if autograd_profiler._is_profiler_enabled:
+                breakpoint()
                 profiler_kwargs = self.get_profiler_kwargs(stream, launcher)
                 with torch._C._profiler._RecordFunctionFast(
                     self.inductor_meta.get("kernel_name", "triton kernel"),
@@ -708,8 +709,7 @@ class CachingAutotuner(KernelInterface):
                 )
             self.restore_args_from_cpu(cpu_copies)
 
-        # NOTE: only use profiler when not already in a profiler instance, because
-        # composing profiler instances isn't supported.
+        # only use profiler when not already in a profiler instance
         if with_profiler and not autograd_profiler._is_profiler_enabled:
             from torch._inductor.utils import do_bench_using_profiling
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -28,10 +28,11 @@ import torch._inductor.async_compile  # noqa: F401 required to warm up AsyncComp
 from torch._dynamo.utils import counters, dynamo_timed
 from torch._inductor.codecache import LambdaFuture, PyCodeCache
 from torch._inductor.metrics import get_metric_table, is_metric_table_enabled
-from torch.fx.experimental.symbolic_shapes import free_symbols, free_unbacked_symbols
+from torch.fx.experimental.symbolic_shapes import free_symbols
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.symbol import free_symbol_is_type, symbol_is_type, SymT
 from torch.utils._triton import has_triton
+from torch.utils.flop_counter import countable
 
 from . import comms, config, dependencies, ir, metrics
 from .analyze_preserves_zero_mask import can_codegen_without_upcasts
@@ -39,13 +40,7 @@ from .codegen.common import BackendFeature, get_scheduling_for_device, Kernel
 from .comm_analysis import estimate_nccl_collective_runtime
 from .dependencies import Dep, MemoryDep, StarDep, WeakDep
 from .exc import GPUTooOldForTriton, TritonMissing
-from .ir import (
-    ComputedBuffer,
-    get_device_type,
-    GraphPartitionSignature,
-    MultiOutput,
-    MultiOutputLayout,
-)
+from .ir import get_device_type, GraphPartitionSignature, MultiOutput, MultiOutputLayout
 from .loop_body import LoopBody
 from .memory import MemoryPlanningInfoForBuffer, MemoryPlanningInfoForNode
 from .runtime.runtime_utils import green_text, red_text
@@ -53,6 +48,7 @@ from .sizevars import SimplifyIndexing
 from .utils import (
     cache_on_self,
     cmp,
+    count_flops_fx,
     device_need_guard,
     get_device_tflops,
     get_dtype_size,
@@ -778,6 +774,20 @@ class BaseSchedulerNode:
         return buf_byte_accesses
 
     @cache_on_self
+    def estimate_flops(self) -> int | None:
+        if self.node is None:
+            return None
+        fx_node = self.node.get_origin_node()
+        if fx_node is None:
+            return None
+        if not countable(fx_node):
+            return None
+        op = fx_node.target._overloadpacket
+
+        flops = count_flops_fx(fx_node)
+        return flops
+
+    @cache_on_self
     def get_estimated_runtime(self) -> float:
         """
         Returns estimated op runtime in nanoseconds (ns)
@@ -817,57 +827,32 @@ class BaseSchedulerNode:
         except Exception:
             return 0
 
-        if isinstance(self, ExternKernelSchedulerNode):
-            assert isinstance(self.node, ir.ExternKernel), f"{type(self.node)=}"
-            op = kernel_name_to_op.get(
-                getattr(self.node, "python_kernel_name", ""), None
+        if isinstance(self, FusedSchedulerNode):
+            flops_est = float(
+                sum(
+                    filter(
+                        lambda x: x is not None,
+                        (node.get_estimated_runtime() for node in self.get_nodes()),
+                    )
+                )
             )
+        else:
+            flops_est = self.estimate_flops()
 
-            # if there is a resolved op, dry-run using fake mode and record flop count
-            if op is not None:
-                from torch._subclasses.fake_tensor import FakeTensorMode
-                from torch.utils.flop_counter import FlopCounterMode
-
-                if any(
-                    len(free_unbacked_symbols(n.get_numel())) > 0
-                    for n in self.node.inputs
-                ):
-                    # Tensor has unbacked symints, we don't know how to estimate
-                    # runtime for that today
-                    return 0
-
-                with (
-                    FakeTensorMode() as fake_mode,
-                    FlopCounterMode(display=False) as flop_counter_mode,
-                    V.set_current_node(self.node.fx_node),
-                    V.set_fake_mode(fake_mode),
-                ):
-                    from .ir import ir_node_to_tensor
-
-                    fake_inputs = [
-                        ir_node_to_tensor(input, guard_shape=False)
-                        for input in self.node.inputs
-                    ]
-                    cls = self.node.__class__
-                    cls.process_kernel(op, *fake_inputs, **self.node.kwargs)
-
-                    # TODO(xmfan): find a better heuristic to model FLOPS/latency relationship
-                    factor = 1.0
-                    counted_flops = flop_counter_mode.get_total_flops()
-                    counted_bytes = self.get_read_write_buffers_sizes()
-                    compute_time = (factor * counted_flops / gpu_flops) * 1e9
-                    transfer_time = counted_bytes / gpu_memory_bandwidth
-
-                    # Return estimated runtime in nanoseconds
-                    return max(compute_time, transfer_time)
-
-        elif isinstance(self, FusedSchedulerNode) or isinstance(
-            self.node, ComputedBuffer
-        ):
-            # Return estimated runtime in nanoseconds (bytes / gbps)
+        if flops_est == 0:
+            # no flops estimate, so fall back to memory estimate
             return self.get_read_write_buffers_sizes() / gpu_memory_bandwidth
 
-        return 0
+        counted_flops: int = 0 if flops_est is None else flops_est
+        # TODO(xmfan): find a better heuristic to model FLOPS/latency relationship
+        factor = 1.0
+        counted_bytes = self.get_read_write_buffers_sizes()
+        counted_bytes = 0 if counted_bytes is None else counted_bytes
+        compute_time = (factor * counted_flops / gpu_flops) * 1e9
+        transfer_time = counted_bytes / gpu_memory_bandwidth
+
+        # Return estimated runtime in nanoseconds
+        return max(compute_time, transfer_time)
 
     def get_template_node(self) -> Optional[ir.TemplateBuffer]:
         return None
@@ -979,17 +964,6 @@ def _prune_redundant_deps(
     if deps_to_prune:
         node.unmet_dependencies = node.unmet_dependencies - deps_to_prune
         node.set_read_writes(node.read_writes.remove_reads(deps_to_prune))
-
-
-# TODO(xmfan): reuse: an existing mapping for this if it exists, or formalize this into ir.py:ExternKernel
-kernel_name_to_op = {
-    "extern_kernels.convolution": torch.ops.aten.convolution,
-    "extern_kernels.mm": torch.ops.aten.mm,
-    "extern_kernels.bmm": torch.ops.aten.bmm,
-    "extern_kernels.addmm": torch.ops.aten.addmm,
-    "extern_kernels._scaled_mm": torch.ops.aten._scaled_mm,
-    "extern_kernels._scaled_grouped_mm": torch.ops.aten._scaled_grouped_mm,
-}
 
 
 class ExternKernelSchedulerNode(BaseSchedulerNode):

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -431,14 +431,13 @@ class TritonTemplateKernel(TritonKernel):
         return sum(num_bytes)
 
     def estimate_flops(self) -> int:
-        flops = 0
         for node in self.input_nodes:
             for fx_node in node._current_origins:
                 if countable(fx_node):
                     f = count_flops_fx(fx_node)
                     if f is not None:
-                        flops += f
-        return flops
+                        return f
+        return 0
 
     def jit_lines(self):
         if self.use_jit:
@@ -476,7 +475,6 @@ class TritonTemplateKernel(TritonKernel):
             num_gb = self.estimate_kernel_num_bytes() / 1e9
             inductor_meta["kernel_num_gb"] = num_gb
         if config.benchmark_kernel:
-            breakpoint()
             flops = self.estimate_flops()
             inductor_meta["kernel_flop"] = flops
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -21,7 +21,14 @@ import tempfile
 import textwrap
 import time
 import unittest
-from collections.abc import Collection, Iterator, Mapping, MutableMapping, MutableSet
+from collections.abc import (
+    Collection,
+    Generator,
+    Iterator,
+    Mapping,
+    MutableMapping,
+    MutableSet,
+)
 from datetime import datetime
 from io import StringIO
 from typing import (
@@ -49,6 +56,7 @@ from unittest import mock
 import sympy
 
 import torch
+from torch._inductor.analysis.device_info import datasheet_tops
 from torch._inductor.runtime.hints import DeviceProperties
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.utils._ordered_set import OrderedSet
@@ -1887,16 +1895,24 @@ def get_backend_num_stages() -> int:
 
 
 @functools.lru_cache(None)
-def get_device_tflops(dtype: torch.dtype) -> int:
+def get_device_tflops(dtype: torch.dtype) -> float:
+    """
+    We don't want to throw errors in this function. First check to see if the device is in device_info.py,
+    then fall back to the inaccurate triton estimation.
+    """
+    ds_tops = datasheet_tops(dtype)
+    if ds_tops is not None:
+        return ds_tops
+
     from triton.testing import get_max_simd_tflops, get_max_tensorcore_tflops
 
     assert dtype in (torch.float16, torch.bfloat16, torch.float32)
 
     if inspect.signature(get_max_simd_tflops).parameters.get("clock_rate"):
         # Triton API change in https://github.com/openai/triton/pull/2293
-        from torch._utils_internal import max_clock_rate
+        from torch._utils_internal import max_clock_rate_mhz
 
-        sm_clock = max_clock_rate()
+        sm_clock = max_clock_rate_mhz()
         if dtype in (torch.float16, torch.bfloat16):
             return get_max_tensorcore_tflops(dtype, sm_clock)
 
@@ -2838,3 +2854,67 @@ def get_ld_library_path() -> str:
             path = os.pathsep.join([lib_path, path]) if path else lib_path
 
     return path
+
+
+def tabulate_2d(elements: Sequence[Sequence[T]], headers: Sequence[T]) -> str:
+    widths = [len(str(e)) for e in headers]
+    for row in elements:
+        assert len(row) == len(headers)
+        for i, e in enumerate(row):
+            widths[i] = max(widths[i], len(str(e)))
+    lines = []
+    lines.append("|".join(f" {h:{w}} " for h, w in zip(headers, widths)))
+    #              widths          whitespace      horizontal separators
+    total_width = sum(widths) + (len(widths) * 2) + (len(widths) - 1)
+    lines.append("-" * total_width)
+    for row in elements:
+        lines.append("|".join(f" {e:{w}} " for e, w in zip(row, widths)))
+    return "\n".join(lines)
+
+
+def zip_dicts(
+    dict1: dict[Any, Any],
+    dict2: dict[Any, Any],
+    d1_default: Any = None,
+    d2_default: Any = None,
+) -> Generator[tuple[Any, Any, Any], None, None]:
+    """
+    Zip two dictionaries together, indicating missing keys.
+
+    Args:
+        dict1 (dict): The first dictionary.
+        dict2 (dict): The second dictionary.
+        d1_default (Any): the default value for the first dictionary
+        d2_default (Any): the default value for the second dictionary
+
+    Yields:
+        tuple: A tuple containing the key, the value from dict1 (or d1_default if missing),
+               and the value from dict2 (or d2_default if missing).
+    """
+    # Find the union of all keys
+    all_keys = OrderedSet(dict1.keys()) | OrderedSet(dict2.keys())
+
+    # Iterate over all keys
+    for key in all_keys:
+        # Get the values from both dictionaries, or default if missing
+        value1 = dict1.get(key, d1_default)
+        value2 = dict2.get(key, d2_default)
+
+        yield key, value1, value2
+
+
+def count_flops_fx(node: torch.fx.Node) -> int | None:
+    from .virtualized import V
+
+    success, args, kwargs = torch._inductor.fx_utils.get_fake_args_kwargs(node)
+
+    if success:
+        with torch.utils.flop_counter.FlopCounterMode(
+            display=False
+        ) as flop_counter_mode:
+            with V.fake_mode:
+                node.target(*args, **kwargs)
+
+        counted_flops = flop_counter_mode.get_total_flops()
+        return counted_flops
+    return None

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -207,7 +207,7 @@ def is_fb_unit_test() -> bool:
 
 
 @functools.lru_cache(None)
-def max_clock_rate():
+def max_clock_rate_mhz():
     if not torch.version.hip:
         from triton.testing import nvsmi
 


### PR DESCRIPTION
This PR adds support for more granular profiling events in DebugAutotuner. These profiling events are already present in CachingAutotuner, and their lack in DebugAutotuner breaks #149697 when `config.profile_bandwidth` is set.

Also fixes an outstanding bug, where attempting to use the profiler to benchmark in DebugAutotuner would fail when the compilation was already in a profiler instance.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov