### PR TITLE
Add epoch to fake tensor cache key

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1477,6 +1477,9 @@ class FakeTensorMode(TorchDispatchMode):
             # Disallowing dynamic shapes can introduce a DynamicOutputShapeException
             # where it wasn't seen on a previous instance of the same op.
             self.shape_env.settings if self.shape_env else None,
+            # During retracing, we increment epoch to regenerate correct unbacked
+            # symbols.
+            self.epoch,
         ]
         # Collect the id_hashed objects to attach a weakref finalize later
         id_hashed_objects: list[object] = []


### PR DESCRIPTION
Summary: This is especially necessary when the output of an op is unbacked symbol. In those cases,we need to regenerate new unbacked val and bind it to the old unbacked symbol via rebind_unbacked_symbol in downstream use.

Test Plan: CI

Differential Revision: D73869239


