### PR TITLE
Decorate `test_host_memory_stats` with `@serialTest`

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -164,6 +164,7 @@ class TestCuda(TestCase):
         for thread in threads:
             thread.join()
 
+    @serialTest
     def test_host_memory_stats(self):
         # Helper functions
         def empty_stats():


### PR DESCRIPTION
Seems to need it as it is expecting only its allocation behavior to be visible, to address #152422