### PR TITLE
 [export] add runtime assert messages to python torch checks (#150719)

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -13482,6 +13482,8 @@ def forward(self, x):
         inps = (torch.randn(1, 224, 768, device="cpu"),)
         export(Foo(), inps)
 
+    @testing.expectedFailureRetraceability
+    @testing.expectedFailureRetraceabilityNonStrict
     @testing.expectedFailureCppSerDes  # TODO(pianpwk): PowByNatural valuerange deserialization
     def test_dim_dynamic(self):
         dynamic = Dim.DYNAMIC
@@ -13557,6 +13559,12 @@ def forward(self, x):
         self.assertEqual(num_asserts, 2)
         with self.assertRaises(RuntimeError):
             ep.module()(torch.randn(4, 2))
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Runtime assertion failed for .* Eq\(Mod\(.*\), 0\) (.*\n)*.*"
+            + r"shape .* is invalid for input of size .*",
+        ):
+            ep.module()(torch.randn(9, 9))
 
     @testing.expectedFailureSerDer  # T195866111
     @testing.expectedFailureSerDerNonStrict

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1629,7 +1629,7 @@ def _check_with(
 
     from torch.fx.experimental.symbolic_shapes import expect_true
 
-    if expect_true(cond):
+    if expect_true(cond, message=message):
         return
 
     # error_type must be a subclass of Exception and not subclass of Warning

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -540,7 +540,7 @@ class SymNode:
             log.warning("Failed to convert to bool: %s", r)
             raise
 
-    def expect_true(self, file, line):
+    def expect_true(self, file, line, message=None):
         from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
 
         if (
@@ -555,7 +555,10 @@ class SymNode:
         # TODO: file/line here is very important, because the assert has been
         # deferred so you can't backtrace easily
         return self.shape_env.defer_runtime_assert(
-            self.expr, f"{file}:{line}", fx_node=self.fx_node
+            self.expr,
+            msg=f"{file}:{line}",
+            info=message,
+            fx_node=self.fx_node,
         )
 
     def expect_size(self, file, line):

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1563,7 +1563,11 @@ def constrain_unify(a: torch.SymInt, b: torch.SymInt) -> None:
 # in the unlikely branch.)  (I think expect is a good name; in recent
 # versions of C++, this is replaced with [[likely]], which is weaker
 # and not accurate for this function!)
-def expect_true(a: Union[SymBool, bool], skip: int = 0) -> bool:
+def expect_true(
+    a: Union[SymBool, bool],
+    skip: int = 0,
+    message: Optional[Union[str, Callable[[], str]]] = None,
+) -> bool:
     if isinstance(a, SymBool):
         # TODO: check perf implications of this
         frame = inspect.currentframe()
@@ -1571,8 +1575,15 @@ def expect_true(a: Union[SymBool, bool], skip: int = 0) -> bool:
             if frame is None:
                 break
             frame = frame.f_back
+        if message is None:  # try to avoid XLA SymNode incompatibility issues
+            return a.node.expect_true(
+                frame.f_code.co_filename if frame else "",
+                frame.f_lineno if frame else 0,
+            )
         return a.node.expect_true(
-            frame.f_code.co_filename if frame else "", frame.f_lineno if frame else 0
+            frame.f_code.co_filename if frame else "",
+            frame.f_lineno if frame else 0,
+            message,
         )
     assert type(a) is bool, a
     return a
@@ -2335,6 +2346,7 @@ def _lru_cache(
 class RuntimeAssert:
     expr: SympyBoolean
     msg: str = field(repr=False)
+    info: Optional[Union[str, Callable[[], str]]] = field(repr=False)
     stack: CapturedTraceback = field(repr=False)
 
 
@@ -7195,7 +7207,11 @@ class ShapeEnv:
     @lru_cache(256)
     @record_shapeenv_event(save_tracked_fakes=True)
     def defer_runtime_assert(
-        self, orig_expr: SympyBoolean, msg: str, fx_node: Optional[torch.fx.Node] = None
+        self,
+        orig_expr: SympyBoolean,
+        msg: str,
+        info: Optional[Union[str, Callable[[], str]]] = None,
+        fx_node: Optional[torch.fx.Node] = None,
     ) -> bool:
         """Create an assert that is checked at runtime
 
@@ -7255,7 +7271,7 @@ class ShapeEnv:
             orig_expr = expr
             expr = canonicalize_bool_expr(expr)
             stack = CapturedTraceback.extract(skip=1)
-            ra = RuntimeAssert(expr, msg, stack)
+            ra = RuntimeAssert(expr, msg, info, stack)
             # TODO: Do this in a way that is less janky than int(s.name[1:])
             cands = sorted(
                 (s for s in expr.free_symbols if symbol_is_type(s, SymT.UNBACKED_INT)),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #152456
* __->__ #152455

Summary:
~fixes https://github.com/pytorch/pytorch/issues/150063 (for python at least)

Before:
```
Runtime assertion failed for expression Eq(Mod(s16*s35, s35 - 1), 0) on node 'eq'
```

Now:
```
RuntimeError: Runtime assertion failed for expression Eq(Mod(s16*s35, s35 - 1), 0) on node 'eq'

The original traceback points to the following location and error message:
/data/users/pianpwk/pytorch/torch/_prims_common/__init__.py:954
shape '[s35 - 1, ((s16*s35)//(s35 - 1))]' is invalid for input of size s16*s35
```


cc ezyang SherlockNoMad EikanWang jgong5 wenzhe-nrv


Reviewed By: laithsakka

Differential Revision: D72483950

Pulled By: pianpwk

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv