### PR TITLE
[inductor] Fix usage of launch_enter_hook/launch_exit_hook

### DIFF
--- a/torch/_inductor/runtime/static_cuda_launcher.py
+++ b/torch/_inductor/runtime/static_cuda_launcher.py
@@ -2,7 +2,7 @@ import functools
 from typing import Any, Optional
 from typing_extensions import Unpack
 
-from .triton_compat import ASTSource, CompiledKernel, config
+from .triton_compat import ASTSource, CompiledKernel, knobs
 
 
 class StaticallyLaunchedCudaKernel:
@@ -45,12 +45,12 @@ class StaticallyLaunchedCudaKernel:
 
         self.hash = kernel.hash
 
-        if config is None:
+        if knobs is None:
             launch_enter = kernel.__class__.launch_enter_hook
             launch_exit = kernel.__class__.launch_exit_hook
         else:
-            launch_enter = config.runtime.launch_enter_hook
-            launch_exit = config.runtime.launch_exit_hook
+            launch_enter = knobs.runtime.launch_enter_hook
+            launch_exit = knobs.runtime.launch_exit_hook
 
         if launch_enter is not None or launch_exit is not None:
             raise NotImplementedError(

--- a/torch/_inductor/runtime/static_cuda_launcher.py
+++ b/torch/_inductor/runtime/static_cuda_launcher.py
@@ -2,7 +2,7 @@ import functools
 from typing import Any, Optional
 from typing_extensions import Unpack
 
-from .triton_compat import ASTSource, CompiledKernel
+from .triton_compat import ASTSource, CompiledKernel, config
 
 
 class StaticallyLaunchedCudaKernel:
@@ -44,10 +44,15 @@ class StaticallyLaunchedCudaKernel:
         self.declared_constexprs = kernel.src.fn.constexprs
 
         self.hash = kernel.hash
-        if (
-            kernel.__class__.launch_enter_hook is not None
-            or kernel.__class__.launch_exit_hook is not None
-        ):
+
+        if config is None:
+            launch_enter = kernel.__class__.launch_enter_hook
+            launch_exit = kernel.__class__.launch_exit_hook
+        else:
+            launch_enter = config.runtime.launch_enter_hook
+            launch_exit = config.runtime.launch_exit_hook
+
+        if launch_enter is not None or launch_exit is not None:
             raise NotImplementedError(
                 "We don't support launch enter or launch exit hooks"
             )

--- a/torch/_inductor/runtime/triton_compat.py
+++ b/torch/_inductor/runtime/triton_compat.py
@@ -71,9 +71,9 @@ if triton is not None:
     HAS_WARP_SPEC = hasattr(tl, "async_task")
 
     try:
-        from triton import config
+        from triton import knobs
     except ImportError:
-        config = None
+        knobs = None
 else:
 
     def _raise_error(*args: Any, **kwargs: Any) -> Any:
@@ -93,7 +93,7 @@ else:
     _log2 = _raise_error
     libdevice = None
     math = None
-    config = None
+    knobs = None
 
     class triton:  # type: ignore[no-redef]
         @staticmethod
@@ -144,5 +144,5 @@ __all__ = [
     "math",
     "triton",
     "cc_warp_size",
-    "config",
+    "knobs",
 ]

--- a/torch/_inductor/runtime/triton_compat.py
+++ b/torch/_inductor/runtime/triton_compat.py
@@ -69,6 +69,11 @@ if triton is not None:
             raise NotImplementedError
 
     HAS_WARP_SPEC = hasattr(tl, "async_task")
+
+    try:
+        from triton import config
+    except ImportError:
+        config = None
 else:
 
     def _raise_error(*args: Any, **kwargs: Any) -> Any:
@@ -88,6 +93,7 @@ else:
     _log2 = _raise_error
     libdevice = None
     math = None
+    config = None
 
     class triton:  # type: ignore[no-redef]
         @staticmethod
@@ -138,4 +144,5 @@ __all__ = [
     "math",
     "triton",
     "cc_warp_size",
+    "config",
 ]

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -70,10 +70,10 @@ from .triton_compat import (
     cc_warp_size,
     CompiledKernel,
     Config,
-    config as tr_config,
     GPUTarget,
     HAS_WARP_SPEC,
     KernelInterface,
+    knobs,
     OutOfResources,
     PTXASError,
     triton,
@@ -1424,12 +1424,12 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
             binary.shared if hasattr(binary, "shared") else binary.metadata.shared
         )
 
-        if tr_config is None:
+        if knobs is None:
             launch_enter = binary.__class__.launch_enter_hook
             launch_exit = binary.__class__.launch_exit_hook
         else:
-            launch_enter = tr_config.runtime.launch_enter_hook
-            launch_exit = tr_config.runtime.launch_exit_hook
+            launch_enter = knobs.runtime.launch_enter_hook
+            launch_exit = knobs.runtime.launch_exit_hook
 
         scope = {
             "grid_meta": cfg.kwargs,

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -70,6 +70,7 @@ from .triton_compat import (
     cc_warp_size,
     CompiledKernel,
     Config,
+    config as tr_config,
     GPUTarget,
     HAS_WARP_SPEC,
     KernelInterface,
@@ -1423,11 +1424,18 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
             binary.shared if hasattr(binary, "shared") else binary.metadata.shared
         )
 
+        if tr_config is None:
+            launch_enter = binary.__class__.launch_enter_hook
+            launch_exit = binary.__class__.launch_exit_hook
+        else:
+            launch_enter = tr_config.runtime.launch_enter_hook
+            launch_exit = tr_config.runtime.launch_exit_hook
+
         scope = {
             "grid_meta": cfg.kwargs,
             "bin": binary,
-            "launch_enter_hook": binary.__class__.launch_enter_hook,
-            "launch_exit_hook": binary.__class__.launch_exit_hook,
+            "launch_enter_hook": launch_enter,
+            "launch_exit_hook": launch_exit,
             "metadata": (
                 binary.packed_metadata
                 if hasattr(binary, "packed_metadata")


### PR DESCRIPTION
In https://github.com/triton-lang/triton/pull/6467 I moved where `launch_enter_hook`/`launch_exit_hook` are specified (from the kernel class to a config). This PR updates the usages to use the config module if it exists to support tip of main triton.

In https://github.com/triton-lang/triton/pull/6641 I renamed `triton.config` to `triton.knobs`, hence the second commit in this PR.

Test Plan: Setup OSS PT with tip of main triton (namely including https://github.com/triton-lang/triton/pull/6641) and run `python test/inductor/test_pad_mm.py`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @oulgen @jamesjwu 