### PR TITLE
[CUDA][TF32] Account for TF32 in `compile_kernel_advanced`

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -34,6 +34,7 @@ from torch.testing._internal.common_cuda import (
     _create_scaling_case,
     TEST_CUDNN,
     TEST_MULTIGPU,
+    tf32_on_and_off,
 )
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
@@ -6210,7 +6211,7 @@ class TestCompileKernel(TestCase):
 
         # Verify results
         expected_int = a_int + b_int
-        torch.testing.assert_close(c_int, expected_int)
+        self.assertEqual(c_int, expected_int)
 
         # Test with header code
         header_code = """
@@ -6244,7 +6245,7 @@ class TestCompileKernel(TestCase):
 
         # Verify scaling
         expected_scaled = input_tensor * 2.0
-        torch.testing.assert_close(output_tensor, expected_scaled)
+        self.assertEqual(output_tensor, expected_scaled)
 
         # Test error handling with invalid kernel
         invalid_kernel_source = """
@@ -6256,6 +6257,7 @@ class TestCompileKernel(TestCase):
         with self.assertRaises(RuntimeError):
             _compile_kernel(invalid_kernel_source, "invalid_kernel")
 
+    @tf32_on_and_off(0.005)
     @unittest.skipIf(TEST_WITH_ROCM, "ROCM does not support nvrtc")
     @unittest.skipIf(not TEST_CUDA, "No CUDA")
     def test_compile_kernel_advanced(self):
@@ -6303,7 +6305,7 @@ class TestCompileKernel(TestCase):
 
         # Verify results
         expected = torch.matmul(A, B)
-        torch.testing.assert_close(C, expected, rtol=1e-5, atol=1e-5)
+        self.assertEqual(C, expected)
 
         # Test with different compute capability if specified
         device_props = torch.cuda.get_device_properties(torch.cuda.current_device())
@@ -6324,7 +6326,7 @@ class TestCompileKernel(TestCase):
         )
 
         # Verify results
-        torch.testing.assert_close(C_explicit, expected, rtol=1e-5, atol=1e-5)
+        self.assertEqual(C_explicit, expected)
 
 
 instantiate_parametrized_tests(TestCuda)


### PR DESCRIPTION
Also cleanup some uses of `assert_close` in favor of `self.assertEqual`

cc @ptrblck @msaroufim @jerryzh168 @zasdfgbnm