### PR TITLE
[CUDA] Fix `test_multi_device_context_manager` on CUDA

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1130,7 +1130,7 @@ class TestCuda(TestCase):
         torch.cuda.set_device(src_device)
         with torch.accelerator.device_index(dst_device):
             self.assertEqual(torch.cuda.current_device(), 1)
-        self.assertEqual(torch.cuda.set_device(), src_device)
+        self.assertEqual(torch.cuda.current_device(), src_device)
 
     def test_stream_context_manager(self):
         prev_stream = torch.cuda.current_stream()


### PR DESCRIPTION
Seems there was a typo where `set_device` was called when the intent was to use `current_device`

As-is the test will fail on multigpu systems with

`TypeError: set_device() missing 1 required positional argument: 'device'`

cc @ptrblck @msaroufim @jerryzh168