### PR TITLE
[nativert] port enumerate from folly to c10::utill

### DIFF
--- a/c10/test/util/Enumerate_test.cpp
+++ b/c10/test/util/Enumerate_test.cpp
@@ -1,0 +1,269 @@
+/*
+ * Ported from folly/container/test/EnumerateTest.cpp
+ */
+
+#include <c10/util/Enumerate.h>
+#include <gtest/gtest.h>
+#include <array>
+
+namespace {
+
+template <class T>
+struct IsConstReference {
+  constexpr static bool value = false;
+};
+template <class T>
+struct IsConstReference<const T&> {
+  constexpr static bool value = true;
+};
+
+constexpr int basicSum(const std::array<int, 3>& test) {
+  int sum = 0;
+  for (auto it : c10::enumerate(test)) {
+    sum += *it;
+  }
+  return sum;
+}
+
+constexpr int cpp17StructuredBindingSum(const std::array<int, 3>& test) {
+  int sum = 0;
+  for (auto&& [_, integer] : c10::enumerate(test)) {
+    sum += integer;
+  }
+  return sum;
+}
+
+} // namespace
+
+TEST(Enumerate, Basic) {
+  std::vector<std::string> v = {"abc", "a", "ab"};
+  size_t i = 0;
+  for (auto it : c10::enumerate(v)) {
+    EXPECT_EQ(it.index, i);
+    EXPECT_EQ(*it, v[i]);
+    EXPECT_EQ(it->size(), v[i].size());
+
+    /* Test mutability. */
+    std::string newValue = "x";
+    *it = newValue;
+    EXPECT_EQ(newValue, v[i]);
+
+    ++i;
+  }
+
+  EXPECT_EQ(i, v.size());
+}
+
+TEST(Enumerate, BasicRRef) {
+  std::vector<std::string> v = {"abc", "a", "ab"};
+  size_t i = 0;
+  for (auto&& it : c10::enumerate(v)) {
+    EXPECT_EQ(it.index, i);
+    EXPECT_EQ(*it, v[i]);
+    EXPECT_EQ(it->size(), v[i].size());
+
+    /* Test mutability. */
+    std::string newValue = "x";
+    *it = newValue;
+    EXPECT_EQ(newValue, v[i]);
+
+    ++i;
+  }
+
+  EXPECT_EQ(i, v.size());
+}
+
+TEST(Enumerate, BasicConst) {
+  std::vector<std::string> v = {"abc", "a", "ab"};
+  size_t i = 0;
+  for (const auto it : c10::enumerate(v)) {
+    static_assert(IsConstReference<decltype(*it)>::value, "Const enumeration");
+    EXPECT_EQ(it.index, i);
+    EXPECT_EQ(*it, v[i]);
+    EXPECT_EQ(it->size(), v[i].size());
+    ++i;
+  }
+
+  EXPECT_EQ(i, v.size());
+}
+
+TEST(Enumerate, BasicConstRef) {
+  std::vector<std::string> v = {"abc", "a", "ab"};
+  size_t i = 0;
+  for (const auto& it : c10::enumerate(v)) {
+    static_assert(IsConstReference<decltype(*it)>::value, "Const enumeration");
+    EXPECT_EQ(it.index, i);
+    EXPECT_EQ(*it, v[i]);
+    EXPECT_EQ(it->size(), v[i].size());
+    ++i;
+  }
+
+  EXPECT_EQ(i, v.size());
+}
+
+TEST(Enumerate, BasicConstRRef) {
+  std::vector<std::string> v = {"abc", "a", "ab"};
+  size_t i = 0;
+  for (const auto&& it : c10::enumerate(v)) {
+    static_assert(IsConstReference<decltype(*it)>::value, "Const enumeration");
+    EXPECT_EQ(it.index, i);
+    EXPECT_EQ(*it, v[i]);
+    EXPECT_EQ(it->size(), v[i].size());
+    ++i;
+  }
+
+  EXPECT_EQ(i, v.size());
+}
+
+TEST(Enumerate, BasicVecBool) {
+  std::vector<bool> v = {true, false, false, true};
+  size_t i = 0;
+  for (auto it : c10::enumerate(v)) {
+    EXPECT_EQ(it.index, i);
+    EXPECT_EQ(*it, v[i]);
+    ++i;
+  }
+
+  EXPECT_EQ(i, v.size());
+}
+
+TEST(Enumerate, BasicVecBoolRRef) {
+  std::vector<bool> v = {true, false, false, true};
+  size_t i = 0;
+  for (auto it : c10::enumerate(v)) {
+    EXPECT_EQ(it.index, i);
+    EXPECT_EQ(*it, v[i]);
+    ++i;
+  }
+
+  EXPECT_EQ(i, v.size());
+}
+
+TEST(Enumerate, Temporary) {
+  std::vector<std::string> v = {"abc", "a", "ab"};
+  size_t i = 0;
+  for (auto&& it : c10::enumerate(decltype(v)(v))) { // Copy v.
+    EXPECT_EQ(it.index, i);
+    EXPECT_EQ(*it, v[i]);
+    EXPECT_EQ(it->size(), v[i].size());
+    ++i;
+  }
+
+  EXPECT_EQ(i, v.size());
+}
+
+TEST(Enumerate, BasicConstArg) {
+  const std::vector<std::string> v = {"abc", "a", "ab"};
+  size_t i = 0;
+  for (auto&& it : c10::enumerate(v)) {
+    static_assert(
+        IsConstReference<decltype(*it)>::value, "Enumerating a const vector");
+    EXPECT_EQ(it.index, i);
+    EXPECT_EQ(*it, v[i]);
+    EXPECT_EQ(it->size(), v[i].size());
+    ++i;
+  }
+
+  EXPECT_EQ(i, v.size());
+}
+
+TEST(Enumerate, TemporaryConstEnumerate) {
+  std::vector<std::string> v = {"abc", "a", "ab"};
+  size_t i = 0;
+  for (const auto&& it : c10::enumerate(decltype(v)(v))) { // Copy v.
+    static_assert(IsConstReference<decltype(*it)>::value, "Const enumeration");
+    EXPECT_EQ(it.index, i);
+    EXPECT_EQ(*it, v[i]);
+    EXPECT_EQ(it->size(), v[i].size());
+    ++i;
+  }
+
+  EXPECT_EQ(i, v.size());
+}
+
+TEST(Enumerate, EmptyRange) {
+  std::vector<std::string> v;
+  for (auto&& it : c10::enumerate(v)) {
+    (void)it; // Silence warnings.
+    ADD_FAILURE();
+  }
+}
+
+class CStringRange {
+  const char* cstr;
+
+ public:
+  struct Sentinel {};
+
+  explicit CStringRange(const char* cstr_) : cstr(cstr_) {}
+
+  const char* begin() const {
+    return cstr;
+  }
+  Sentinel end() const {
+    return Sentinel{};
+  }
+};
+
+static bool operator==(const char* c, CStringRange::Sentinel) {
+  return *c == 0;
+}
+
+TEST(Enumerate, Cpp17Support) {
+  std::array<char, 5> test = {"test"};
+  for (const auto&& it : c10::enumerate(CStringRange{test.data()})) {
+    ASSERT_LT(it.index, test.size());
+    EXPECT_EQ(*it, test[it.index]);
+  }
+}
+
+TEST(Enumerate, Cpp17StructuredBindingConstRef) {
+  std::vector<std::string> test = {"abc", "a", "ab"};
+  for (const auto& [index, str] : c10::enumerate(test)) {
+    ASSERT_LT(index, test.size());
+    EXPECT_EQ(str, test[index]);
+  }
+}
+
+TEST(Enumerate, Cpp17StructuredBindingConstRRef) {
+  std::vector<std::string> test = {"abc", "a", "ab"};
+  for (const auto&& [index, str] : c10::enumerate(test)) {
+    ASSERT_LT(index, test.size());
+    EXPECT_EQ(str, test[index]);
+  }
+}
+
+TEST(Enumerate, Cpp17StructuredBindingConstVector) {
+  const std::vector<std::string> test = {"abc", "a", "ab"};
+  for (auto&& [index, str] : c10::enumerate(test)) {
+    static_assert(
+        IsConstReference<decltype(str)>::value, "Enumerating const vector");
+    ASSERT_LT(index, test.size());
+    EXPECT_EQ(str, test[index]);
+  }
+}
+
+TEST(Enumerate, Cpp17StructuredBindingModify) {
+  std::vector<int> test = {1, 2, 3, 4, 5};
+  for (auto&& [index, integer] : c10::enumerate(test)) {
+    integer = 0;
+  }
+
+  for (const auto& integer : test) {
+    EXPECT_EQ(integer, 0);
+  }
+}
+
+TEST(Enumerate, BasicConstexpr) {
+  constexpr std::array<int, 3> test = {1, 2, 3};
+  static_assert(basicSum(test) == 6, "Basic enumerating is not constexpr");
+  EXPECT_EQ(basicSum(test), 6);
+}
+
+TEST(Enumerate, Cpp17StructuredBindingConstexpr) {
+  constexpr std::array<int, 3> test = {1, 2, 3};
+  static_assert(
+      cpp17StructuredBindingSum(test) == 6,
+      "C++17 structured binding enumerating is not constexpr");
+  EXPECT_EQ(cpp17StructuredBindingSum(test), 6);
+}

--- a/c10/util/Enumerate.h
+++ b/c10/util/Enumerate.h
@@ -1,0 +1,159 @@
+/*
+ * Ported from folly/container/Enumerate.h
+ */
+
+#pragma once
+
+#include <iterator>
+#include <memory>
+
+#ifdef _WIN32
+#include <basetsd.h> // @manual
+using ssize_t = SSIZE_T;
+#endif
+
+#include <c10/macros/Macros.h>
+
+/**
+ * Similar to Python's enumerate(), enumerate() can be used to
+ * iterate a range with a for-range loop, and it also allows to
+ * retrieve the count of iterations so far. Can be used in constexpr
+ * context.
+ *
+ * For example:
+ *
+ * for (auto&& [index, element] : enumerate(vec)) {
+ *   // index is a const reference to a size_t containing the iteration count.
+ *   // element is a reference to the type contained within vec, mutable
+ *   // unless vec is const.
+ * }
+ *
+ * If the binding is const, the element reference is too.
+ *
+ * for (const auto&& [index, element] : enumerate(vec)) {
+ *   // element is always a const reference.
+ * }
+ *
+ * It can also be used as follows:
+ *
+ * for (auto&& it : enumerate(vec)) {
+ *   // *it is a reference to the current element. Mutable unless vec is const.
+ *   // it->member can be used as well.
+ *   // it.index contains the iteration count.
+ * }
+ *
+ * As before, const auto&& it can also be used.
+ */
+
+namespace c10 {
+
+namespace detail {
+
+template <class T>
+struct MakeConst {
+  using type = const T;
+};
+template <class T>
+struct MakeConst<T&> {
+  using type = const T&;
+};
+template <class T>
+struct MakeConst<T*> {
+  using type = const T*;
+};
+
+template <class Iterator>
+class Enumerator {
+ public:
+  constexpr explicit Enumerator(Iterator it) : it_(std::move(it)) {}
+
+  class Proxy {
+   public:
+    using difference_type = ssize_t;
+    using value_type = typename std::iterator_traits<Iterator>::value_type;
+    using reference = typename std::iterator_traits<Iterator>::reference;
+    using pointer = typename std::iterator_traits<Iterator>::pointer;
+    using iterator_category = std::input_iterator_tag;
+
+    C10_ALWAYS_INLINE constexpr explicit Proxy(const Enumerator& e)
+        : index(e.idx_), element(*e.it_) {}
+
+    // Non-const Proxy: Forward constness from Iterator.
+    C10_ALWAYS_INLINE constexpr reference operator*() {
+      return element;
+    }
+    C10_ALWAYS_INLINE constexpr pointer operator->() {
+      return std::addressof(element);
+    }
+
+    // Const Proxy: Force const references.
+    C10_ALWAYS_INLINE constexpr typename MakeConst<reference>::type operator*()
+        const {
+      return element;
+    }
+    C10_ALWAYS_INLINE constexpr typename MakeConst<pointer>::type operator->()
+        const {
+      return std::addressof(element);
+    }
+
+   public:
+    size_t index;
+    reference element;
+  };
+
+  C10_ALWAYS_INLINE constexpr Proxy operator*() const {
+    return Proxy(*this);
+  }
+
+  C10_ALWAYS_INLINE constexpr Enumerator& operator++() {
+    ++it_;
+    ++idx_;
+    return *this;
+  }
+
+  template <typename OtherIterator>
+  C10_ALWAYS_INLINE constexpr bool operator==(
+      const Enumerator<OtherIterator>& rhs) const {
+    return it_ == rhs.it_;
+  }
+
+  template <typename OtherIterator>
+  C10_ALWAYS_INLINE constexpr bool operator!=(
+      const Enumerator<OtherIterator>& rhs) const {
+    return !(it_ == rhs.it_);
+  }
+
+ private:
+  template <typename OtherIterator>
+  friend class Enumerator;
+
+  Iterator it_;
+  size_t idx_ = 0;
+};
+
+template <class Range>
+class RangeEnumerator {
+  Range r_;
+  using BeginIteratorType = decltype(std::declval<Range>().begin());
+  using EndIteratorType = decltype(std::declval<Range>().end());
+
+ public:
+  // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+  constexpr explicit RangeEnumerator(Range&& r) : r_(std::forward<Range>(r)) {}
+
+  constexpr Enumerator<BeginIteratorType> begin() {
+    return Enumerator<BeginIteratorType>(r_.begin());
+  }
+  constexpr Enumerator<EndIteratorType> end() {
+    return Enumerator<EndIteratorType>(r_.end());
+  }
+};
+
+} // namespace detail
+
+template <class Range>
+constexpr detail::RangeEnumerator<Range> enumerate(Range&& r) {
+  return detail::RangeEnumerator<Range>(std::forward<Range>(r));
+}
+
+} // namespace c10


### PR DESCRIPTION
Summary:
nativert RFC: https://github.com/zhxchen17/rfcs/blob/master/RFC-0043-torch-native-runtime.md

To land the runtime into PyTorch core, we will gradually land logical parts of the code into the Github issue and get each piece properly reviewed.

This diff ports an enumeration util from folly into c10.

Test Plan: CI

Differential Revision: D73881042
