### PR TITLE
Refactor nested benchmark functions in AlgorithmSelectorCache

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -22,7 +22,7 @@ basic_modules_ListOfLinears_eager,compile_time_instruction_count,999400000,0.015
 
 
 
-basic_modules_ListOfLinears_inductor,compile_time_instruction_count,17990000000,0.015
+basic_modules_ListOfLinears_inductor,compile_time_instruction_count,17650000000,0.015
 
 
 
@@ -46,7 +46,7 @@ sum_floordiv_regression,compile_time_instruction_count,985300000,0.015
 
 
 
-symint_sum,compile_time_instruction_count,3189000000,0.015
+symint_sum,compile_time_instruction_count,3111000000,0.015
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152502
* #152147

Summary: The motivation is make AlgorithmSelectorCache.benchmark_in_current_process() a toplevel method so that I can leverage it for remote auto-tune. Currently, it's nested inside make_benchmark_fn(). Just for consistency, I also made AlgorithmSelectorCache.benchmark_in_sub_process a toplevel staticmethod. That method technically didn't need to move, but IMO refactoring makes the code a bit more readable.

Test Plan: existing unit tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov