### PR TITLE
[inductor] [compile async] Don't compile in eager

### DIFF
--- a/test/inductor/test_compile_subprocess.py
+++ b/test/inductor/test_compile_subprocess.py
@@ -66,7 +66,7 @@ class TestSubprocess(TestCase):
         # some tests are expected to fail then we should probably add a list of
         # expected failures here.
         self.assertEqual(
-            FxCompile._compile_stats[type(_InProcessFxCompile)].codegen_and_compile, 0
+            FxCompile._compile_stats.codegen_and_compile, 0
         )
         self._stack.close()
         TestCase.tearDown(self)

--- a/torch/_inductor/compile_fx_ext.py
+++ b/torch/_inductor/compile_fx_ext.py
@@ -420,7 +420,7 @@ class _SerializedFxCompile(FxCompile):
         output = self._send_to_child(inputs).deserialize(constants)
 
         self._postprocess(output)
-        self._compile_stats[type(self)].codegen_and_compile += 1
+        _SerializedFxCompile._compile_stats.codegen_and_compile += 1
 
         # TODO: Do we need to figure out what changed in TracingContext in the
         # child and plumb that back up to the parent?


### PR DESCRIPTION
Previously we will compile in eager mode.

This looks not intentional according to the test. There is a check to check the number of compilations (in current process) to be 0. But maybe due to an oversight, the number it checks is always a zero.

In _InProcessFxCompile and _SerializedFxCompile, we increment the number of `codegen_and_compile` by `self`, which is a member variable attached to the instance. But in test, we check the number of `codegen_and_compile`  by the class. I think we should increment the number of `codegen_and_compile` by the class. Then the test will fail now.

See torch/_inductor/compile_fx_async.py for the fix.

CC @aorenste 



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov