### PR TITLE
Remove unnecessary __STDC_FORMAT_MACROS macro

### DIFF
--- a/aten/src/ATen/core/ATen_pch.h
+++ b/aten/src/ATen/core/ATen_pch.h
@@ -3,11 +3,6 @@
 #pragma push_macro("TORCH_ASSERT_NO_OPERATORS")
 #define TORCH_ASSERT_NO_OPERATORS
 
-// This macro doesn't work if defined after the first time inttypes.h
-// is included, so won't work anywhere if not defined here.
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
 #include <cinttypes>
 
 // This list of headers was generated using a script that finds

--- a/aten/src/ATen/templates/RegisterDispatchKey.cpp
+++ b/aten/src/ATen/templates/RegisterDispatchKey.cpp
@@ -1,10 +1,3 @@
-// required for old g++ to compile PRId64 macros, see
-// https://github.com/pytorch/pytorch/issues/3571
-// for context
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 // an external backend might generate file within its code tree
 // and check all the source files within the tree with clang-format.
 // so, disable it since the backend might have a different config.

--- a/torch/csrc/cuda/Tensor.cpp
+++ b/torch/csrc/cuda/Tensor.cpp
@@ -1,7 +1,3 @@
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 // Order of these includes matters, which should be fixed.
 // clang-format off
 #include <torch/csrc/python_headers.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #152522
* #152521
* __->__ #152513
* #152512

As the title stated.