### PR TITLE
Make torch/csrc/utils.h to be device-agnostic

### DIFF
--- a/torch/csrc/cuda/THCP.h
+++ b/torch/csrc/cuda/THCP.h
@@ -1,10 +1,8 @@
-#ifndef THCP_H
-#define THCP_H
+#pragma once
 
 #include <torch/csrc/THP.h>
 #include <torch/csrc/cuda/Event.h>
 #include <torch/csrc/cuda/Module.h>
 #include <torch/csrc/cuda/Stream.h>
+#include <torch/csrc/cuda/utils.h>
 #include <torch/csrc/python_headers.h>
-
-#endif

--- a/torch/csrc/cuda/utils.h
+++ b/torch/csrc/cuda/utils.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <c10/cuda/CUDAStream.h>
+#include <torch/csrc/utils/python_numbers.h>
+
+#include <vector>
+
+std::vector<std::optional<at::cuda::CUDAStream>>
+THPUtils_PySequence_to_CUDAStreamList(PyObject* obj);

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -1,5 +1,4 @@
-#ifndef THP_UTILS_H
-#define THP_UTILS_H
+#pragma once
 
 #include <ATen/ATen.h>
 #include <c10/util/Exception.h>
@@ -11,10 +10,6 @@
 #include <string>
 #include <type_traits>
 #include <vector>
-
-#ifdef USE_CUDA
-#include <c10/cuda/CUDAStream.h>
-#endif
 
 #define THPUtils_(NAME) TH_CONCAT_4(THP, Real, Utils_, NAME)
 
@@ -204,14 +199,6 @@ void setBackCompatKeepdimWarn(bool warn);
 bool getBackCompatKeepdimWarn();
 bool maybeThrowBackCompatKeepdimWarn(char* func);
 
-// NB: This is in torch/csrc/cuda/utils.cpp, for whatever reason
-#ifdef USE_CUDA
-std::vector<std::optional<at::cuda::CUDAStream>>
-THPUtils_PySequence_to_CUDAStreamList(PyObject* obj);
-#endif
-
 void storage_fill(const at::Storage& self, uint8_t value);
 void storage_set(const at::Storage& self, ptrdiff_t idx, uint8_t value);
 uint8_t storage_get(const at::Storage& self, ptrdiff_t idx);
-
-#endif


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #152522
* __->__ #152521
* #152513
* #152512

`torch/csrc/utils.h` should be device-independent. Currently, it contains CUDA-related implementations, which indirectly causes the [failure of ROCm testing](https://github.com/pytorch/pytorch/pull/151914#issuecomment-2839691038) (The reason is that the ROCm test environment shouldn`t expose HIP-related header files, which causes the JIT compilation to fail during testing)

Therefore, move CUDA-related implementations to `torch/csrc/cuda/utils.h`.

**Question:**
This change may introduce BC-breack.
I searched for this function globally on github and I think the impact is very small.