### PR TITLE
[compile async] [cache] testing

### DIFF
--- a/torch/_inductor/compile_fx_subproc.py
+++ b/torch/_inductor/compile_fx_subproc.py
@@ -84,7 +84,7 @@ class _SubprocessFxCompile(_OutOfProcessFxCompile):
         # incremented when we clear the cache, send the clock to the worker and
         # only clear caches if the clock changed since last time.
         #
-        clear_inductor_caches()
+        # clear_inductor_caches()
         torch._inductor.metrics.reset()
 
         # TODO: turn off config.fx_graph_async_compile


### PR DESCRIPTION
The comment (https://github.com/pytorch/pytorch/blob/5a52e050248c71dd6e84f51d25cbd17a88555800/torch/_inductor/compile_fx_subproc.py#L70-L87) say it is problematic to not clean the cache for subprocess compile.

But I have some problems to test this locally. I followed the suggestion here https://dev-discuss.pytorch.org/t/how-to-test-properly/2492 to test it.

Would anyone like to approve this to test this? Thanks in ahead.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @aorenste 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov