### PR TITLE
elastic: do not shutdown rendezvous on leaving workers

### DIFF
--- a/test/distributed/elastic/agent/server/test/api_test.py
+++ b/test/distributed/elastic/agent/server/test/api_test.py
@@ -127,9 +127,7 @@ class TestAgent(SimpleElasticAgent):
         self.stop_workers_call_count = 0
         self.start_workers_call_count = 0
 
-    def _stop_workers(
-        self, worker_group: WorkerGroup
-    ) -> None:
+    def _stop_workers(self, worker_group: WorkerGroup) -> None:
         # workers are fake, nothing to stop; just clear the rdzv info
         worker_group.group_rank = None
         worker_group.group_world_size = None

--- a/test/distributed/elastic/agent/server/test/api_test.py
+++ b/test/distributed/elastic/agent/server/test/api_test.py
@@ -128,7 +128,7 @@ class TestAgent(SimpleElasticAgent):
         self.start_workers_call_count = 0
 
     def _stop_workers(
-        self, worker_group: WorkerGroup, is_restart: bool = False
+        self, worker_group: WorkerGroup
     ) -> None:
         # workers are fake, nothing to stop; just clear the rdzv info
         worker_group.group_rank = None

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -457,9 +457,7 @@ class SimpleElasticAgent(ElasticAgent):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def _stop_workers(
-        self, worker_group: WorkerGroup
-    ) -> None:
+    def _stop_workers(self, worker_group: WorkerGroup) -> None:
         r"""Stop all workers in the given worker group.
 
         Implementors must deal with workers in all states defined by
@@ -477,9 +475,7 @@ class SimpleElasticAgent(ElasticAgent):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def _shutdown(
-        self, death_sig: signal.Signals = signal.SIGTERM
-    ) -> None:
+    def _shutdown(self, death_sig: signal.Signals = signal.SIGTERM) -> None:
         """Clean up any resources that were allocated during the agent's work.
 
         Args:

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -458,7 +458,7 @@ class SimpleElasticAgent(ElasticAgent):
 
     @abc.abstractmethod
     def _stop_workers(
-        self, worker_group: WorkerGroup, is_restart: bool = False
+        self, worker_group: WorkerGroup
     ) -> None:
         r"""Stop all workers in the given worker group.
 
@@ -478,7 +478,7 @@ class SimpleElasticAgent(ElasticAgent):
 
     @abc.abstractmethod
     def _shutdown(
-        self, death_sig: signal.Signals = signal.SIGTERM, is_restart: bool = False
+        self, death_sig: signal.Signals = signal.SIGTERM
     ) -> None:
         """Clean up any resources that were allocated during the agent's work.
 
@@ -698,7 +698,7 @@ class SimpleElasticAgent(ElasticAgent):
         """Restart (stops, rendezvous, starts) all local workers in the group."""
         role = worker_group.spec.role
         logger.info("[%s] Stopping worker group", role)
-        self._stop_workers(worker_group, is_restart=True)
+        self._stop_workers(worker_group)
         worker_group.state = WorkerState.STOPPED
         self._initialize_workers(worker_group)
 

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -280,9 +280,7 @@ class LocalElasticAgent(SimpleElasticAgent):
     # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
     #  `torch.distributed.elastic.metrics.prof`.
     @prof
-    def _stop_workers(
-        self, worker_group: WorkerGroup
-    ) -> None:
+    def _stop_workers(self, worker_group: WorkerGroup) -> None:
         self._shutdown()
 
     # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
@@ -359,9 +357,7 @@ class LocalElasticAgent(SimpleElasticAgent):
 
         return self._pcontext.pids()
 
-    def _shutdown(
-        self, death_sig: signal.Signals = signal.SIGTERM
-    ) -> None:
+    def _shutdown(self, death_sig: signal.Signals = signal.SIGTERM) -> None:
         if self._worker_watchdog is not None:
             self._worker_watchdog.stop()
             self._worker_watchdog = None

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -281,9 +281,9 @@ class LocalElasticAgent(SimpleElasticAgent):
     #  `torch.distributed.elastic.metrics.prof`.
     @prof
     def _stop_workers(
-        self, worker_group: WorkerGroup, is_restart: bool = False
+        self, worker_group: WorkerGroup
     ) -> None:
-        self._shutdown(is_restart=is_restart)
+        self._shutdown()
 
     # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
     #  `torch.distributed.elastic.metrics.prof`.
@@ -360,7 +360,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         return self._pcontext.pids()
 
     def _shutdown(
-        self, death_sig: signal.Signals = signal.SIGTERM, is_restart: bool = False
+        self, death_sig: signal.Signals = signal.SIGTERM
     ) -> None:
         if self._worker_watchdog is not None:
             self._worker_watchdog.stop()
@@ -370,8 +370,6 @@ class LocalElasticAgent(SimpleElasticAgent):
             self._health_check_server = None
         if self._pcontext:
             self._pcontext.close(death_sig)
-        if not is_restart and self._rdzv_handler:
-            self._rdzv_handler.shutdown()
 
     # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
     #  `torch.distributed.elastic.metrics.prof`.


### PR DESCRIPTION
In #117066, shutdown of the rendezvous was added if a worker shuts down. This is incorrect, because the rendezvous is actually shutdown in [this file](https://github.com/pytorch/pytorch/blob/fa6f9eb2be07f6289d2ab4e781077f7fc75dbe55/torch/distributed/launcher/api.py#L290) but should not be shutdown if a signal is received. See also [this pull request](https://github.com/pytorch/pytorch/pull/67749).

#124819 then tried to remediate the situation by fixing the faulty shutdown for the restart case. But this is only triggered if the agent restarts the training, but not if the shutdown of the rendezvous happened before.

Removing both these changes restores the original behavior. The rendezvous should only be shutdown if a run completes or fails, not for a single worker leaving.

Fixes #150916
Fixes #147064


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k