### PR TITLE
Do not check out nccl when not building it

### DIFF
--- a/tools/build_pytorch_libs.py
+++ b/tools/build_pytorch_libs.py
@@ -6,7 +6,12 @@ import subprocess
 from pathlib import Path
 
 from .setup_helpers.cmake import CMake, USE_NINJA
-from .setup_helpers.env import check_negative_env_flag, IS_64BIT, IS_WINDOWS
+from .setup_helpers.env import (
+    check_env_flag,
+    check_negative_env_flag,
+    IS_64BIT,
+    IS_WINDOWS,
+)
 
 
 repo_root = Path(__file__).absolute().parent.parent
@@ -109,7 +114,11 @@ def build_pytorch(
     cmake: CMake,
 ) -> None:
     my_env = _create_build_env()
-    if os.getenv("USE_SYSTEM_NCCL", "0") == "0":
+    if (
+        not check_negative_env_flag("USE_CUDA")
+        and not check_negative_env_flag("USE_NCCL")
+        and not check_env_flag("USE_SYSTEM_NCCL")
+    ):
         checkout_nccl()
     build_test = not check_negative_env_flag("BUILD_TEST")
     cmake.generate(


### PR DESCRIPTION
Add additional conditions to `build_pytorch_libs.py` to avoid fetching NCCL when `USE_CUDA` or `USE_NCCL` are disabled. While at it, adjust the existing condition for `USE_SYSTEM_NCCL` to use the utility function.
