### PR TITLE
Accelerate aten::hardtanh_ by 21x | Disable SLEEF implementation of vec::maximum in vec128_float_neon.h 

### DIFF
--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -420,16 +420,9 @@ inline Vectorized<float> Vectorized<float>::frac() const {
   return *this - this->trunc();
 }
 
-//Added sleef Implementation for Maximum
+template <>
 Vectorized<float> inline maximum(const Vectorized<float>& a, const Vectorized<float>& b)  {
-  if(!a.has_inf_nan() && !b.has_inf_nan()){
-    return USE_SLEEF(
-      Vectorized<float>(Sleef_fmaxf4(a, b)),
-      Vectorized<float>(vmaxq_f32(a,b)));
-  }
-  else{
-    return Vectorized<float>(vmaxq_f32(a, b));
-  }
+  return Vectorized<float>(vmaxq_f32(a, b));
 }
 
 // Implements the IEEE 754 201X `minimum` operation, which propagates NaN if


### PR DESCRIPTION
The `has_inf_nan` implementation in `vec::maximum` is scalar, and it slows down certain activations like `tanh` by almost 20 times. Additionally, the `vec::minimum` function simply uses NEON intrinsics and not SLEEF. This PR makes the two fns similar in implementation.

Besides, the SLEEF function `Sleef_fmaxf4` ultimately invokes the `vmaxq_f32` NEON intrinsic through [vmax_vf_vf_vf](https://github.com/shibatch/sleef/blob/d28232a309e06bcb75e9fb0f6262d9251739fd1e/src/arch/helperadvsimd.h#L253).

From a single threaded profile of mobilenet on an Arm Neoverse-V2 machine (code below), the `aten::hardtanh_` takes **5.653ms** per function call while using the current PyTorch 2.7 wheel, whereas it takes **266.096us** per function call while simply using `vmaxq_f32` - a 21x speedup, and overall inference is 1.8x faster.
___

Run the below script: `OMP_NUM_THREADS=1 python profile_mobilenet.py --iterations 10`
<details >
<summary>profile_mobilenet.py</summary>

```
import torch
import torchvision.models as models
from torch.profiler import profile, record_function, ProfilerActivity
import argparse

torch.manual_seed(42)

def load_mobilenet():
    model = models.mobilenet_v2(pretrained=True)
    model.eval()
    return model

def generate_sample_input(batch_size=8):
    return torch.randn(batch_size, 3, 224, 224)

def warmup(model, sample_input, num_warmup=10):
    with torch.inference_mode():
        for _ in range(num_warmup):
            _ = model(sample_input)

def parse_args():
    parser = argparse.ArgumentParser()
    parser.add_argument('--batch_size', type=int, default=8)
    parser.add_argument('--iterations', type=int, default=100)
    return parser.parse_args()


def main():
    args = parse_args()
    model = load_mobilenet()

    sample_input = generate_sample_input(args.batch_size)
    print("Warming up...")
    warmup(model, sample_input)
    print("Warmup complete.")
    with profile(activities=[ProfilerActivity.CPU], record_shapes=True) as prof:
        with torch.inference_mode():
            for i in range(args.iterations):
                with record_function("model_inference"):
                    outputs = model(sample_input)
    
    print(prof.key_averages().table(sort_by="cpu_time_total"))
    print(f"Throughput: {(args.iterations * args.batch_size / (prof.profiler.self_cpu_time_total / 1e6)):.3f} images/s")

if __name__ == "__main__":
    main()
```

</details>

<details>
<summary>Profiler output using the current Pytorch 2.7 wheel </summary>

```
--------------------------------  ------------  ------------  ------------  ------------  ------------  ------------
                            Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
--------------------------------  ------------  ------------  ------------  ------------  ------------  ------------
                 model_inference         2.39%     101.839ms       100.00%        4.254s     425.437ms            10
                 aten::hardtanh_         0.02%     905.454us        46.50%        1.978s       5.653ms           350
                  aten::hardtanh         0.03%       1.239ms        46.48%        1.977s       5.650ms           350
                     aten::clamp        46.45%        1.976s        46.45%        1.976s       5.646ms           350
                    aten::conv2d         0.06%       2.468ms        43.89%        1.867s       3.591ms           520
               aten::convolution         0.06%       2.491ms        43.83%        1.865s       3.586ms           520
              aten::_convolution         0.13%       5.546ms        43.77%        1.862s       3.581ms           520
               aten::thnn_conv2d         0.04%       1.658ms        24.13%        1.027s       3.019ms           340
      aten::_slow_conv2d_forward        23.99%        1.021s        24.09%        1.025s       3.014ms           340
        aten::mkldnn_convolution        14.42%     613.285ms        19.51%     829.885ms       4.610ms           180
                aten::batch_norm         0.06%       2.368ms         6.89%     292.928ms     563.323us           520
    aten::_batch_norm_impl_index         0.11%       4.600ms         6.83%     290.560ms     558.769us           520
         aten::native_batch_norm         6.60%     280.762ms         6.69%     284.567ms     547.244us           520
                aten::contiguous         0.01%     623.099us         5.01%     213.152ms       1.184ms           180
                     aten::clone         0.02%     988.729us         5.00%     212.529ms       1.181ms           180
                     aten::copy_         4.94%     210.315ms         4.94%     210.315ms       1.052ms           200
                    aten::linear         0.00%      58.347us         0.18%       7.659ms     765.905us            10
                     aten::addmm         0.17%       7.373ms         0.18%       7.483ms     748.309us            10
                     aten::empty         0.17%       7.161ms         0.17%       7.161ms       1.790us          4000
                       aten::add         0.11%       4.742ms         0.11%       4.742ms      47.419us           100
                aten::empty_like         0.03%       1.315ms         0.09%       3.890ms       5.557us           700
                      aten::view         0.05%       1.933ms         0.05%       1.933ms       2.801us           690
               aten::as_strided_         0.04%       1.599ms         0.04%       1.599ms       8.885us           180
                   aten::resize_         0.04%       1.493ms         0.04%       1.493ms       2.871us           520
       aten::adaptive_avg_pool2d         0.00%      55.360us         0.04%       1.491ms     149.051us            10
                      aten::mean         0.00%     116.997us         0.03%       1.435ms     143.515us            10
                       aten::sum         0.02%     935.980us         0.02%     992.121us      99.212us            10
                    aten::detach         0.02%     707.217us         0.02%     707.217us       2.080us           340
                      aten::div_         0.00%     161.473us         0.01%     326.035us      32.604us            10
                        aten::to         0.00%     178.193us         0.01%     321.253us       0.892us           360
         aten::_nnpack_available         0.01%     302.835us         0.01%     302.835us       0.891us           340
                  aten::_to_copy         0.00%      63.170us         0.00%     143.060us      14.306us            10
                         aten::t         0.00%      49.759us         0.00%     117.621us      11.762us            10
                 aten::transpose         0.00%      40.637us         0.00%      67.862us       6.786us            10
                   aten::flatten         0.00%      42.634us         0.00%      58.867us       5.887us            10
                     aten::fill_         0.00%      56.141us         0.00%      56.141us       5.614us            10
                    aten::expand         0.00%      42.687us         0.00%      48.930us       4.893us            10
             aten::empty_strided         0.00%      40.589us         0.00%      40.589us       4.059us            10
                aten::as_strided         0.00%      33.468us         0.00%      33.468us       1.673us            20
              aten::resolve_conj         0.00%       9.066us         0.00%       9.066us       0.453us            20
                   aten::dropout         0.00%       5.782us         0.00%       5.782us       0.578us            10
--------------------------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 4.254s

Throughput: 18.804 images/s
```

</details>

<details>
<summary>Profiler output after this PR's changes </summary>

```
--------------------------------  ------------  ------------  ------------  ------------  ------------  ------------
                            Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
--------------------------------  ------------  ------------  ------------  ------------  ------------  ------------
                 model_inference         4.43%     104.484ms       100.00%        2.359s     235.883ms            10
                    aten::conv2d         0.10%       2.313ms        79.19%        1.868s       3.592ms           520
               aten::convolution         0.10%       2.293ms        79.09%        1.866s       3.588ms           520
              aten::_convolution         0.23%       5.436ms        78.99%        1.863s       3.583ms           520
               aten::thnn_conv2d         0.08%       1.799ms        44.29%        1.045s       3.072ms           340
      aten::_slow_conv2d_forward        44.03%        1.039s        44.21%        1.043s       3.067ms           340
        aten::mkldnn_convolution        24.91%     587.584ms        34.47%     812.992ms       4.517ms           180
                aten::batch_norm         0.10%       2.350ms        11.83%     279.113ms     536.757us           520
    aten::_batch_norm_impl_index         0.20%       4.788ms        11.73%     276.764ms     532.238us           520
         aten::native_batch_norm        11.30%     266.660ms        11.46%     270.420ms     520.038us           520
                aten::contiguous         0.02%     575.723us         9.41%     222.080ms       1.234ms           180
                     aten::clone         0.04%       1.061ms         9.39%     221.504ms       1.231ms           180
                     aten::copy_         9.29%     219.131ms         9.29%     219.131ms       1.096ms           200
                 aten::hardtanh_         0.04%     917.669us         3.95%      93.133ms     266.096us           350
                  aten::hardtanh         0.05%       1.130ms         3.91%      92.216ms     263.474us           350
                     aten::clamp         3.85%      90.894ms         3.86%      91.086ms     260.246us           350
                    aten::linear         0.00%      68.681us         0.33%       7.899ms     789.945us            10
                     aten::addmm         0.32%       7.598ms         0.33%       7.707ms     770.673us            10
                     aten::empty         0.30%       7.176ms         0.30%       7.176ms       1.794us          4000
                       aten::add         0.20%       4.627ms         0.20%       4.627ms      46.268us           100
                aten::empty_like         0.06%       1.316ms         0.17%       3.973ms       5.676us           700
                      aten::view         0.08%       2.001ms         0.08%       2.001ms       2.899us           690
       aten::adaptive_avg_pool2d         0.00%      53.745us         0.07%       1.548ms     154.791us            10
                   aten::resize_         0.06%       1.533ms         0.06%       1.533ms       2.948us           520
               aten::as_strided_         0.06%       1.521ms         0.06%       1.521ms       8.450us           180
                      aten::mean         0.00%     117.637us         0.06%       1.494ms     149.417us            10
                       aten::sum         0.04%     973.291us         0.04%       1.013ms     101.342us            10
                    aten::detach         0.03%     652.224us         0.03%     652.224us       1.918us           340
                      aten::div_         0.01%     195.077us         0.02%     363.103us      36.310us            10
                        aten::to         0.01%     212.758us         0.02%     359.655us       0.999us           360
         aten::_nnpack_available         0.01%     295.235us         0.01%     295.235us       0.868us           340
                  aten::_to_copy         0.00%      68.726us         0.01%     146.897us      14.690us            10
                         aten::t         0.00%      53.873us         0.01%     124.033us      12.403us            10
                 aten::transpose         0.00%      42.512us         0.00%      70.160us       7.016us            10
                   aten::flatten         0.00%      44.040us         0.00%      66.631us       6.663us            10
                    aten::expand         0.00%      44.632us         0.00%      51.177us       5.118us            10
                     aten::fill_         0.00%      40.134us         0.00%      40.134us       4.013us            10
             aten::empty_strided         0.00%      35.291us         0.00%      35.291us       3.529us            10
                aten::as_strided         0.00%      34.193us         0.00%      34.193us       1.710us            20
              aten::resolve_conj         0.00%       8.594us         0.00%       8.594us       0.430us            20
                   aten::dropout         0.00%       6.758us         0.00%       6.758us       0.676us            10
--------------------------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 2.359s

Throughput: 33.915 images/s
```

</details>

___

Using torchbench, the models `mobilenet_v2` and `mobilenet_v3_large` showed improvements as expected too.

Before -> After (latency in ms)
```
"mobilenet_v3_large-eval_latency": 1207.212 -> 844.902 
"mobilenet_v2-eval_latency": 1029.834 -> 662.476
```


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168