### PR TITLE
[CUDA] Rest peak memory stats before running `test_set_per_process_memory_fraction`

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -447,6 +447,7 @@ class TestCuda(TestCase):
     )
     def test_set_per_process_memory_fraction(self):
         orig = torch.cuda.get_per_process_memory_fraction(0)
+        torch.cuda.reset_peak_memory_stats(0)
         try:
             # test invalid fraction value.
             with self.assertRaisesRegex(TypeError, "Invalid type"):


### PR DESCRIPTION
Otherwise previous tests can cause `application = int(total_memory * 0.499) - torch.cuda.max_memory_reserved()` to go negative

Hopefully abates current flakiness (see also https://github.com/pytorch/pytorch/issues/135115#:~:text=TestCuda.test_set_per_process_memory_fraction)

cc @ptrblck @msaroufim @jerryzh168