### PR TITLE
Migrate perf_test/test_[gc]pu_speed_mnist.sh from conda to venv

### DIFF
--- a/.ci/pytorch/perf_test/test_cpu_speed_mnist.sh
+++ b/.ci/pytorch/perf_test/test_cpu_speed_mnist.sh
@@ -13,7 +13,11 @@ test_cpu_speed_mnist () {
 
   cd examples/mnist
 
-  conda install -c pytorch torchvision-cpu
+  python -m venv venv
+  # shellcheck disable=SC1091
+  . venv/bin/activate
+
+  pip install -c pytorch torchvision-cpu
 
   # Download data
   python main.py --epochs 0

--- a/.ci/pytorch/perf_test/test_gpu_speed_mnist.sh
+++ b/.ci/pytorch/perf_test/test_gpu_speed_mnist.sh
@@ -13,7 +13,11 @@ test_gpu_speed_mnist () {
 
   cd examples/mnist
 
-  conda install -c pytorch torchvision
+  python -m venv venv
+  # shellcheck disable=SC1091
+  . venv/bin/activate
+
+  pip install -c pytorch torchvision
 
   # Download data
   python main.py --epochs 0


### PR DESCRIPTION
Replace conda with venv on:
* `.ci/pytorch/perf_test/test_cpu_speed_mnist.sh`
* `.ci/pytorch/perf_test/test_gpu_speed_mnist.sh`

Fixes #148342
