### PR TITLE
ci: Switch benchmark dependency to use pip

### DIFF
--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -178,21 +178,24 @@ torchbench_setup_macos() {
 }
 
 install_benchmark_deps() {
+  # TODO: We should probably update this to use the latest version of numpy
+  #       but it appears as though torchbench itself installs 1.22.3 by default
+  #       and this is causing issues with the build.
   pip_install \
     astunparse==1.6.3 \
-    numpy==2.0.2 \
-    scipy==1.13.1 \
+    numpy==1.22.3 \
+    scipy==1.10.1 \
     ninja==1.11.1.4 \
-    pyyaml==6.0.2 \
-    setuptools==58.0.4 \
-    cmake==4.0.0 \
-    typing-extensions==4.13.2 \
+    pyyaml==6.0 \
+    setuptools==72.1.0 \
+    cmake==3.22.* \
+    typing-extensions==4.11.0 \
     requests==2.32.3 \
-    protobuf==6.30.2 \
-    numba==0.60.0 \
+    protobuf==3.20.2 \
+    numba==0.56.0 \
     cython==3.0.12 \
     scikit-learn==1.6.1 \
-    librosa==0.11.0
+    librosa>=0.6.2
 }
 
 

--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -177,9 +177,22 @@ torchbench_setup_macos() {
   checkout_install_torchbench
 }
 
-conda_benchmark_deps() {
-  conda install -y astunparse numpy scipy ninja pyyaml setuptools cmake typing-extensions requests protobuf numba cython scikit-learn
-  conda install -y -c conda-forge librosa
+install_benchmark_deps() {
+  pip install \
+    astunparse==1.6.3 \
+    numpy==2.2.5 \
+    scipy==1.15.2 \
+    ninja==1.11.1.4 \
+    pyyaml==6.0.2 \
+    setuptools==80.1.0 \
+    cmake==4.0.0 \
+    typing-extensions==4.13.2 \
+    requests==2.32.3 \
+    protobuf==6.30.2 \
+    numba==0.61.2 \
+    cython==3.0.12 \
+    scikit-learn==1.6.1 \
+    librosa==0.11.0
 }
 
 
@@ -187,7 +200,7 @@ test_torchbench_perf() {
   print_cmake_info
 
   echo "Launching torchbench setup"
-  conda_benchmark_deps
+  install_benchmark_deps
   torchbench_setup_macos
 
   TEST_REPORTS_DIR=$(pwd)/test/test-reports
@@ -214,7 +227,7 @@ test_torchbench_smoketest() {
   print_cmake_info
 
   echo "Launching torchbench setup"
-  conda_benchmark_deps
+  install_benchmark_deps
   # shellcheck disable=SC2119,SC2120
   torchbench_setup_macos
 
@@ -263,7 +276,7 @@ test_hf_perf() {
   print_cmake_info
   TEST_REPORTS_DIR=$(pwd)/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
-  conda_benchmark_deps
+  install_benchmark_deps
   torchbench_setup_macos
 
   echo "Launching HuggingFace training perf run"
@@ -279,7 +292,7 @@ test_timm_perf() {
   print_cmake_info
   TEST_REPORTS_DIR=$(pwd)/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
-  conda_benchmark_deps
+  install_benchmark_deps
   torchbench_setup_macos
 
   echo "Launching timm training perf run"

--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -178,18 +178,18 @@ torchbench_setup_macos() {
 }
 
 install_benchmark_deps() {
-  pip install \
+  pip_install \
     astunparse==1.6.3 \
-    numpy==2.2.5 \
-    scipy==1.15.2 \
+    numpy==2.0.2 \
+    scipy==1.13.1 \
     ninja==1.11.1.4 \
     pyyaml==6.0.2 \
-    setuptools==80.1.0 \
+    setuptools==58.0.4 \
     cmake==4.0.0 \
     typing-extensions==4.13.2 \
     requests==2.32.3 \
     protobuf==6.30.2 \
-    numba==0.61.2 \
+    numba==0.60.0 \
     cython==3.0.12 \
     scikit-learn==1.6.1 \
     librosa==0.11.0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #152843
* __->__ #152545

As an effort to reduce our dependency on conda we should use pip here,
also pins all the dependencies based on versions that I took today
(04/30/2024), realistically this should probably be in a
requirements.txt but I'm trying to limit the scope of this PR since I'm
getting it done quickly.

Relates to https://github.com/pytorch/pytorch/issues/148340

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>