### PR TITLE
Fix assertion in reorder_communication_preserving_peak_memory

### DIFF
--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -165,7 +165,7 @@ class ReorderInfo:
 
     @property
     def improvement(self):
-        assert self.initial_exposed >= self.final_exposed > 0
+        assert self.initial_exposed >= self.final_exposed >= 0
         return self.initial_exposed - self.final_exposed
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152565

>=0 is practically correct becuase we do model the runtime of some ops as 0.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov