### PR TITLE
[ROCm] Update spack includes

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1420,13 +1420,6 @@ if(USE_ROCM)
     set(ROCM_SOURCE_DIR "/opt/rocm")
   endif()
   message(INFO "caffe2 ROCM_SOURCE_DIR = ${ROCM_SOURCE_DIR}")
-  target_include_directories(torch_hip PRIVATE
-    ${ROCM_SOURCE_DIR}/include
-    ${ROCM_SOURCE_DIR}/hcc/include
-    ${ROCM_SOURCE_DIR}/rocblas/include
-    ${ROCM_SOURCE_DIR}/hipsparse/include
-    ${ROCM_SOURCE_DIR}/include/rccl/
-    )
   if(USE_FLASH_ATTENTION)
     target_compile_definitions(torch_hip PRIVATE
         USE_FLASH_ATTENTION
@@ -1760,7 +1753,7 @@ if(USE_ROCM)
   target_link_libraries(torch_hip PRIVATE ${Caffe2_HIP_DEPENDENCY_LIBS})
 
   # Since PyTorch files contain HIP headers, this is also needed to capture the includes.
-  target_include_directories(torch_hip PRIVATE ${Caffe2_HIP_INCLUDE})
+  target_include_directories(torch_hip PRIVATE ${Caffe2_HIP_INCLUDE} ${ROCM_INCLUDE})
   target_include_directories(torch_hip INTERFACE $<INSTALL_INTERFACE:include>)
 endif()
 

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1753,7 +1753,7 @@ if(USE_ROCM)
   target_link_libraries(torch_hip PRIVATE ${Caffe2_HIP_DEPENDENCY_LIBS})
 
   # Since PyTorch files contain HIP headers, this is also needed to capture the includes.
-  target_include_directories(torch_hip PRIVATE ${Caffe2_HIP_INCLUDE} ${ROCM_INCLUDE})
+  target_include_directories(torch_hip PRIVATE ${Caffe2_HIP_INCLUDE} ${ROCM_INCLUDE_DIRS})
   target_include_directories(torch_hip INTERFACE $<INSTALL_INTERFACE:include>)
 endif()
 

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1420,62 +1420,12 @@ if(USE_ROCM)
     set(ROCM_SOURCE_DIR "/opt/rocm")
   endif()
   message(INFO "caffe2 ROCM_SOURCE_DIR = ${ROCM_SOURCE_DIR}")
-  find_package(rocthrust)
-  if(rocthrust_FOUND)
-    message(STATUS "rocthrust found")
- else() #If rocthrust not found
-    message(FATAL_ERROR "rocthrust not found !!! Install rocthrust to proceed ...")
- endif(rocthrust_FOUND)
-
- find_package(aotriton)
-  if(aotriton_FOUND)
-    message(STATUS "aotriton found")
-    set(AOTRITON_INCLUDE_DIR ${INTERFACE_INCLUDE_DIRECTORIES})
- else() #If aotriton not found
-    message(FATAL_ERROR "aotriton not found !!! Install aotriton to proceed ...")
- endif(aotriton_FOUND)
-
- find_package(rocprim)
-  if(rocprim_FOUND)
-    message(STATUS "rocprim found")
- else() #If rocprim not found
-    message(FATAL_ERROR "rocprim not found !!! Install rocprim to proceed ...")
- endif(rocprim_FOUND)
-
- find_package(hipcub)
-  if(hipcub_FOUND)
-    message(STATUS "hipcub found")
- else() #If hipcub not found
-    message(FATAL_ERROR "hipcub not found !!! Install hipcub to proceed ...")
- endif(hipcub_FOUND)
-
- find_package(rocrand)
-  if(rocrand_FOUND)
-    message(STATUS "rocrand found")
- else() #If rocrand not found
-    message(FATAL_ERROR "rocrand not found !!! Install rocrand to proceed ...")
- endif(rocrand_FOUND)
-
- find_package(composable_kernel)
-  if(composable_kernel_FOUND)
-    message(STATUS "composable-kernel found")
-    set(CK_INCLUDE_DIR ${INTERFACE_INCLUDE_DIRECTORIES})
- else() #If composable-kernel not found
-    message(FATAL_ERROR "composable-kernel not found !!! Install composable-kernel to proceed ...")
- endif(composable-kernel_FOUND)
-
   target_include_directories(torch_hip PRIVATE
     ${ROCM_SOURCE_DIR}/include
     ${ROCM_SOURCE_DIR}/hcc/include
     ${ROCM_SOURCE_DIR}/rocblas/include
     ${ROCM_SOURCE_DIR}/hipsparse/include
     ${ROCM_SOURCE_DIR}/include/rccl/
-    ${AOTRITON_INCLUDE_DIR}
-    ${ROCTHRUST_INCLUDE_DIR}
-    ${ROCPRIM_INCLUDE_DIR}
-    ${ROCRAND_INCLUDE_DIR}
-    ${HIPCUB_INCLUDE_DIR}
-    ${CK_INCLUDE_DIR}
     )
   if(USE_FLASH_ATTENTION)
     target_compile_definitions(torch_hip PRIVATE

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1420,12 +1420,62 @@ if(USE_ROCM)
     set(ROCM_SOURCE_DIR "/opt/rocm")
   endif()
   message(INFO "caffe2 ROCM_SOURCE_DIR = ${ROCM_SOURCE_DIR}")
+  find_package(rocthrust)
+  if(rocthrust_FOUND)
+    message(STATUS "rocthrust found")
+ else() #If rocthrust not found
+    message(FATAL_ERROR "rocthrust not found !!! Install rocthrust to proceed ...")
+ endif(rocthrust_FOUND)
+
+ find_package(aotriton)
+  if(aotriton_FOUND)
+    message(STATUS "aotriton found")
+    set(AOTRITON_INCLUDE_DIR ${INTERFACE_INCLUDE_DIRECTORIES})
+ else() #If aotriton not found
+    message(FATAL_ERROR "aotriton not found !!! Install aotriton to proceed ...")
+ endif(aotriton_FOUND)
+
+ find_package(rocprim)
+  if(rocprim_FOUND)
+    message(STATUS "rocprim found")
+ else() #If rocprim not found
+    message(FATAL_ERROR "rocprim not found !!! Install rocprim to proceed ...")
+ endif(rocprim_FOUND)
+
+ find_package(hipcub)
+  if(hipcub_FOUND)
+    message(STATUS "hipcub found")
+ else() #If hipcub not found
+    message(FATAL_ERROR "hipcub not found !!! Install hipcub to proceed ...")
+ endif(hipcub_FOUND)
+
+ find_package(rocrand)
+  if(rocrand_FOUND)
+    message(STATUS "rocrand found")
+ else() #If rocrand not found
+    message(FATAL_ERROR "rocrand not found !!! Install rocrand to proceed ...")
+ endif(rocrand_FOUND)
+
+ find_package(composable_kernel)
+  if(composable_kernel_FOUND)
+    message(STATUS "composable-kernel found")
+    set(CK_INCLUDE_DIR ${INTERFACE_INCLUDE_DIRECTORIES})
+ else() #If composable-kernel not found
+    message(FATAL_ERROR "composable-kernel not found !!! Install composable-kernel to proceed ...")
+ endif(composable-kernel_FOUND)
+
   target_include_directories(torch_hip PRIVATE
     ${ROCM_SOURCE_DIR}/include
     ${ROCM_SOURCE_DIR}/hcc/include
     ${ROCM_SOURCE_DIR}/rocblas/include
     ${ROCM_SOURCE_DIR}/hipsparse/include
     ${ROCM_SOURCE_DIR}/include/rccl/
+    ${AOTRITON_INCLUDE_DIR}
+    ${ROCTHRUST_INCLUDE_DIR}
+    ${ROCPRIM_INCLUDE_DIR}
+    ${ROCRAND_INCLUDE_DIR}
+    ${HIPCUB_INCLUDE_DIR}
+    ${CK_INCLUDE_DIR}
     )
   if(USE_FLASH_ATTENTION)
     target_compile_definitions(torch_hip PRIVATE

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1753,6 +1753,7 @@ if(USE_ROCM)
   target_link_libraries(torch_hip PRIVATE ${Caffe2_HIP_DEPENDENCY_LIBS})
 
   # Since PyTorch files contain HIP headers, this is also needed to capture the includes.
+  # ROCM_INCLUDE_DIRS is defined in LoadHIP.cmake
   target_include_directories(torch_hip PRIVATE ${Caffe2_HIP_INCLUDE} ${ROCM_INCLUDE_DIRS})
   target_include_directories(torch_hip INTERFACE $<INSTALL_INTERFACE:include>)
 endif()

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -26,10 +26,10 @@ else()
   endif()
 endif()
 
-if(NOT DEFINED ENV{ROCM_INCLUDE_DIRS})
-  set(ROCM_INCLUDE_DIRS ${ROCM_PATH}/include)
+if(NOT DEFINED ENV{ROCM_INCLUDE_DIR})
+  set(ROCM_INCLUDE_DIR ${ROCM_PATH}/include)
 else()
-  set(ROCM_INCLUDE_DIRS $ENV{ROCM_INCLUDE_DIRS})
+  set(ROCM_INCLUDE_DIR $ENV{ROCM_INCLUDE_DIR})
 endif()
 
 # MAGMA_HOME
@@ -72,6 +72,7 @@ list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 macro(find_package_and_print_version PACKAGE_NAME)
   find_package("${PACKAGE_NAME}" ${ARGN})
   message("${PACKAGE_NAME} VERSION: ${${PACKAGE_NAME}_VERSION}")
+  list(APPEND ROCM_INCLUDE_DIRS ${${PACKAGE_NAME}_INCLUDE_DIR})
 endmacro()
 
 # Find the HIP Package
@@ -165,16 +166,14 @@ if(HIP_FOUND)
   endif()
   find_package_and_print_version(hipblaslt REQUIRED)
 
-  list(APPEND ROCM_INCLUDE ${rocthrust_INCLUDE_DIR})
-  list(APPEND ROCM_INCLUDE ${rocprim_INCLUDE_DIR})
-  list(APPEND ROCM_INCLUDE ${hipcub_INCLUDE_DIR})
-  list(APPEND ROCM_INCLUDE ${rocRAND_INCLUDE_DIR})
-  list(APPEND ROCM_INCLUDE ${INTERFACE_INCLUDE_DIRECTORIES})
-
   if(UNIX)
     find_package_and_print_version(rccl)
     find_package_and_print_version(hsa-runtime64 REQUIRED)
+  endif()
 
+  list(REMOVE_DUPLICATES ROCM_INCLUDE_DIRS)
+
+  if(UNIX)
     # roctx is part of roctracer
     find_library(ROCM_ROCTX_LIB roctx64 HINTS ${ROCM_PATH}/lib)
 

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -83,9 +83,10 @@ find_package_and_print_version(HIP 1.0 MODULE)
 if(HIP_FOUND)
   set(PYTORCH_FOUND_HIP TRUE)
 
+  find_package_and_print_version(hip REQUIRED CONFIG)
   # Find ROCM version for checks. UNIX filename is rocm_version.h, Windows is hip_version.h
   find_file(ROCM_VERSION_HEADER_PATH NAMES rocm_version.h hip_version.h
-      HINTS ${ROCM_INCLUDE_DIRS}/rocm-core ${ROCM_INCLUDE_DIRS}/hip /usr/include)
+      HINTS ${ROCM_INCLUDE_DIR}/rocm-core ${hip_INCLUDE_DIR}/hip /usr/include)
   get_filename_component(ROCM_HEADER_NAME ${ROCM_VERSION_HEADER_PATH} NAME)
 
   if(EXISTS ${ROCM_VERSION_HEADER_PATH})
@@ -142,7 +143,6 @@ if(HIP_FOUND)
   # Find ROCM components using Config mode
   # These components will be searced for recursively in ${ROCM_PATH}
   message("\n***** Library versions from cmake find_package *****\n")
-  find_package_and_print_version(hip REQUIRED CONFIG)
   find_package_and_print_version(amd_comgr REQUIRED)
   find_package_and_print_version(rocrand REQUIRED)
   find_package_and_print_version(hiprand REQUIRED)

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -165,6 +165,12 @@ if(HIP_FOUND)
   endif()
   find_package_and_print_version(hipblaslt REQUIRED)
 
+  list(APPEND ROCM_INCLUDE ${rocthrust_INCLUDE_DIR})
+  list(APPEND ROCM_INCLUDE ${rocprim_INCLUDE_DIR})
+  list(APPEND ROCM_INCLUDE ${hipcub_INCLUDE_DIR})
+  list(APPEND ROCM_INCLUDE ${rocRAND_INCLUDE_DIR})
+  list(APPEND ROCM_INCLUDE ${INTERFACE_INCLUDE_DIRECTORIES})
+
   if(UNIX)
     find_package_and_print_version(rccl)
     find_package_and_print_version(hsa-runtime64 REQUIRED)

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -85,8 +85,14 @@ if(HIP_FOUND)
 
   find_package_and_print_version(hip REQUIRED CONFIG)
   # Find ROCM version for checks. UNIX filename is rocm_version.h, Windows is hip_version.h
-  find_file(ROCM_VERSION_HEADER_PATH NAMES rocm_version.h hip_version.h
-      HINTS ${ROCM_INCLUDE_DIR}/rocm-core ${hip_INCLUDE_DIR}/hip /usr/include)
+  if(UNIX)
+    find_package_and_print_version(rocm-core REQUIRED CONFIG)
+    find_file(ROCM_VERSION_HEADER_PATH NAMES rocm_version.h
+      HINTS ${rocm_core_INCLUDE_DIR}/rocm-core /usr/include)
+  else() # Win32
+    find_file(ROCM_VERSION_HEADER_PATH NAMES hip_version.h
+      HINTS ${hip_INCLUDE_DIR}/hip /usr/include)
+  endif()
   get_filename_component(ROCM_HEADER_NAME ${ROCM_VERSION_HEADER_PATH} NAME)
 
   if(EXISTS ${ROCM_VERSION_HEADER_PATH})

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -85,7 +85,7 @@ if(HIP_FOUND)
       HINTS ${rocm_core_INCLUDE_DIR}/rocm-core /usr/include)
   else() # Win32
     find_file(ROCM_VERSION_HEADER_PATH NAMES hip_version.h
-      HINTS ${hip_INCLUDE_DIR}/hip /usr/include)
+      HINTS ${hip_INCLUDE_DIR}/hip)
   endif()
   get_filename_component(ROCM_HEADER_NAME ${ROCM_VERSION_HEADER_PATH} NAME)
 

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -26,12 +26,6 @@ else()
   endif()
 endif()
 
-if(NOT DEFINED ENV{ROCM_INCLUDE_DIR})
-  set(ROCM_INCLUDE_DIR ${ROCM_PATH}/include)
-else()
-  set(ROCM_INCLUDE_DIR $ENV{ROCM_INCLUDE_DIR})
-endif()
-
 # MAGMA_HOME
 if(NOT DEFINED ENV{MAGMA_HOME})
   set(MAGMA_HOME ${ROCM_PATH}/magma)


### PR DESCRIPTION
* Cleans up code in `caffe2/CMakeLists.txt` to remove individual ROCm library include paths and use `ROCM_INCLUDE_DIRS` CMake var instead
* `ROCM_INCLUDE_DIRS` CMake var is set in `cmake/public/LoadHIP.cmake` by adding all the ROCm packages that PyTorch depends on
* `rocm_version.h` is provided by the `rocm-core` package, so use the include directory for that component to be compliant with Spack
* Move `find_package_and_print_version(hip REQUIRED CONFIG)` earlier so that `hip_version.h` can be located in the hip package include dir for Spack
* `list(REMOVE_DUPLICATES ROCM_INCLUDE_DIRS)` to remove duplicate `/opt/rocm/include` entries in the non-Spack case
* Remove user-provided env var `ROCM_INCLUDE_DIRS` since `ROCM_PATH` already exists as a user-provided env var, which should be sufficient to locate the include directories for ROCm.

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd