### PR TITLE
add support for 0 size shardedTensor and recalculate metadata from all_gather

### DIFF
--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -2487,6 +2487,130 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
                 shard = remote_shard.to_here()
                 self.assertEqual((5, 5), shard.tensor.size())
 
+    @skipIfRocm
+    @with_comms(init_rpc=False)
+    @skip_if_lt_x_gpu(4)
+    @requires_nccl()
+    def test_recalc_for_metadata(self):
+        shard_sizes = [0, 5]  # test 2 different shard sizes
+        for shard_size in shard_sizes:
+            local_shard_metadata = ShardMetadata(
+                shard_offsets=[0, 0],
+                shard_sizes=[shard_size, shard_size],
+                placement=f"rank:{self.rank}/cuda:{self.rank}",
+            )
+
+            local_shards = [
+                sharded_tensor.Shard(
+                    torch.randn(shard_size, shard_size, device=f"cuda:{self.rank}"),
+                    local_shard_metadata,
+                )
+            ]
+
+            st = sharded_tensor.init_from_local_shards(local_shards, None, None)
+            self.assertEqual((shard_size * 4, shard_size), st.size())
+            self.assertEqual(1, len(st.local_shards()))
+
+            # Verify local shard.
+            local_shard = st.local_shards()[0]
+            self.assertEqual(
+                torch.device(f"cuda:{self.rank}"), local_shard.tensor.device
+            )
+            self.assertEqual((shard_size, shard_size), local_shard.tensor.size())
+
+            # Verify local shard metadata.
+            self.assertEqual(
+                (self.rank * shard_size, 0),
+                local_shard.metadata.shard_offsets,
+            )
+            self.assertEqual((shard_size, shard_size), local_shard.metadata.shard_sizes)
+            self.assertEqual(
+                f"rank:{self.rank}/cuda:{self.rank}",
+                str(local_shard.metadata.placement),
+            )
+
+            # Verify global metadata.
+            shards_metadata = st.metadata().shards_metadata
+            self.assertEqual(4, len(shards_metadata))
+            for rank, shard_metadata in enumerate(shards_metadata):
+                self.assertEqual((rank * shard_size, 0), shard_metadata.shard_offsets)
+                self.assertEqual((shard_size, shard_size), shard_metadata.shard_sizes)
+                self.assertEqual(
+                    f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement)
+                )
+
+            with self.assertRaises(ValueError):
+                st = sharded_tensor.init_from_local_shards(local_shards)
+
+    @skipIfRocm
+    @with_comms(init_rpc=False)
+    @skip_if_lt_x_gpu(4)
+    @requires_nccl()
+    def test_init_from_local_shards_with_different_glb_size(self):
+        wrong_offset_local_shard_metadata = ShardMetadata(
+            shard_offsets=[0, 0],
+            shard_sizes=[5, 5],
+            placement=f"rank:{self.rank}/cuda:{self.rank}",
+        )
+
+        wrong_offset_local_shards = [
+            sharded_tensor.Shard(
+                torch.randn(5, 5, device=f"cuda:{self.rank}"),
+                wrong_offset_local_shard_metadata,
+            )
+        ]
+        with self.assertRaises(ValueError):
+            sharded_tensor.init_from_local_shards(wrong_offset_local_shards, 0, 0)
+
+        local_shard_metadata = ShardMetadata(
+            shard_offsets=[self.rank * 5, 0],
+            shard_sizes=[5, 5],
+            placement=f"rank:{self.rank}/cuda:{self.rank}",
+        )
+
+        local_shards = [
+            sharded_tensor.Shard(
+                torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+            )
+        ]
+        with self.assertRaises(ValueError):
+            sharded_tensor.init_from_local_shards(local_shards, 0, 0)
+
+    @skipIfRocm
+    @with_comms(init_rpc=False)
+    @skip_if_lt_x_gpu(4)
+    @requires_nccl()
+    def test_non_rw_sharded_recalc_for_metadata(self):
+        local_shard_metadata = ShardMetadata(
+            shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
+            shard_sizes=[5, 5],
+            placement=f"rank:{self.rank}/cuda:{self.rank}",
+        )
+
+        local_shards = [
+            sharded_tensor.Shard(
+                torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+            )
+        ]
+
+        st = sharded_tensor.init_from_local_shards(local_shards, None, 5)
+        if self.rank == 0:
+            self.assertEqual(
+                st.local_shards()[0].metadata.shard_offsets,
+                local_shard_metadata.shard_offsets,
+            )
+        else:
+            self.assertNotEqual(
+                st.local_shards()[0].metadata.shard_offsets,
+                local_shard_metadata.shard_offsets,
+            )
+        self.assertEqual(
+            st.local_shards()[0].metadata.shard_sizes, local_shard_metadata.shard_sizes
+        )
+        self.assertEqual(
+            st.local_shards()[0].metadata.placement, local_shard_metadata.placement
+        )
+
     @skip_if_lt_x_gpu(4)
     def test_st_base_init_from_local_shards_and_global_metadata(self):
         world_size = 4
@@ -2546,6 +2670,178 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             )
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
             self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
+
+    @skipIfRocm
+    @with_comms(init_rpc=False)
+    @skip_if_lt_x_gpu(4)
+    @requires_nccl()
+    def test_init_from_local_shards_and_global_metadata_with_all_zeros(self):
+        local_shard_metadata = ShardMetadata(
+            shard_offsets=[0, 0],
+            shard_sizes=[0, 0],
+            placement=f"rank:{self.rank}/cuda:{self.rank}",
+        )
+
+        shards_metadata = []
+        for r in range(self.world_size):
+            if r == self.rank:
+                shards_metadata.append(local_shard_metadata)
+            else:
+                shards_metadata.append(
+                    ShardMetadata(
+                        shard_offsets=[0, 0],
+                        shard_sizes=[0, 0],
+                        placement=f"rank:{r}/cuda:{r}",
+                    )
+                )
+
+        local_shards = [
+            sharded_tensor.Shard(
+                torch.randn(0, 0, device=f"cuda:{self.rank}"), local_shard_metadata
+            )
+        ]
+
+        tensor_properties = TensorProperties(
+            dtype=torch.get_default_dtype(),
+            layout=torch.strided,
+            requires_grad=False,
+            memory_format=torch.contiguous_format,
+            pin_memory=False,
+        )
+
+        sharded_tensor_metadata = sharded_tensor.ShardedTensorMetadata(
+            shards_metadata=shards_metadata,
+            size=torch.Size([0, 0]),
+            tensor_properties=tensor_properties,
+        )
+
+        st = ShardedTensor._init_from_local_shards_and_global_metadata(
+            local_shards,
+            sharded_tensor_metadata,
+        )
+
+        self.assertEqual((0, 0), st.size())
+        self.assertEqual(1, len(st.local_shards()))
+
+        # Verify local shard.
+        local_shard = st.local_shards()[0]
+        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
+        self.assertEqual((0, 0), local_shard.tensor.size())
+
+        # Verify local shard metadata.
+        self.assertEqual(
+            (0, 0),
+            local_shard.metadata.shard_offsets,
+        )
+        self.assertEqual((0, 0), local_shard.metadata.shard_sizes)
+        self.assertEqual(
+            f"rank:{self.rank}/cuda:{self.rank}", str(local_shard.metadata.placement)
+        )
+
+        # Verify global metadata.
+        shards_metadata = st.metadata().shards_metadata
+        self.assertEqual(4, len(shards_metadata))
+        for rank, shard_metadata in enumerate(shards_metadata):
+            self.assertEqual((0, 0), shard_metadata.shard_offsets)
+            self.assertEqual((0, 0), shard_metadata.shard_sizes)
+            self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
+
+    @skipIfRocm
+    @with_comms(init_rpc=False)
+    @skip_if_lt_x_gpu(4)
+    @requires_nccl()
+    def test_init_from_local_shards_and_global_metadata_with_local_view(self):
+        # testing cases where we create ST with local view, meaning we initialize other rank's metadata with 0s
+        shard_offsets = [0, 1]  # valid, invalid
+        for shard_offset in shard_offsets:
+            local_shard_metadata = ShardMetadata(
+                shard_offsets=[shard_offset, 0],
+                shard_sizes=[5, 5],
+                placement=f"rank:{self.rank}/cuda:{self.rank}",
+            )
+
+            shards_metadata = []
+            for r in range(self.world_size):
+                if r == self.rank:
+                    shards_metadata.append(local_shard_metadata)
+                else:
+                    shards_metadata.append(
+                        ShardMetadata(
+                            shard_offsets=[0 if r < self.rank else 5, 0],
+                            shard_sizes=[0, 0],
+                            placement=f"rank:{r}/cuda:{r}",
+                        )
+                    )
+
+            local_shards = [
+                sharded_tensor.Shard(
+                    torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+                )
+            ]
+
+            tensor_properties = TensorProperties(
+                dtype=torch.get_default_dtype(),
+                layout=torch.strided,
+                requires_grad=False,
+                memory_format=torch.contiguous_format,
+                pin_memory=False,
+            )
+
+            sharded_tensor_metadata = sharded_tensor.ShardedTensorMetadata(
+                shards_metadata=shards_metadata,
+                size=torch.Size([5, 5]),
+                tensor_properties=tensor_properties,
+            )
+            if shard_offset == 0:
+                # valid case
+                st = ShardedTensor._init_from_local_shards_and_global_metadata(
+                    local_shards,
+                    sharded_tensor_metadata,
+                )
+            else:
+                # invalid case
+                with self.assertRaises(ValueError):
+                    ShardedTensor._init_from_local_shards_and_global_metadata(
+                        local_shards,
+                        sharded_tensor_metadata,
+                    )
+                return
+
+            self.assertEqual((5, 5), st.size())
+            self.assertEqual(1, len(st.local_shards()))
+
+            # Verify local shard.
+            local_shard = st.local_shards()[0]
+            self.assertEqual(
+                torch.device(f"cuda:{self.rank}"), local_shard.tensor.device
+            )
+            self.assertEqual((5, 5), local_shard.tensor.size())
+
+            # Verify local shard metadata.
+            self.assertEqual(
+                (0, 0),
+                local_shard.metadata.shard_offsets,
+            )
+            self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
+            self.assertEqual(
+                f"rank:{self.rank}/cuda:{self.rank}",
+                str(local_shard.metadata.placement),
+            )
+
+            # Verify global metadata.
+            shards_metadata = st.metadata().shards_metadata
+            self.assertEqual(4, len(shards_metadata))
+            for rank, shard_metadata in enumerate(shards_metadata):
+                self.assertEqual(
+                    (0 if rank <= self.rank else 5, 0), shard_metadata.shard_offsets
+                )
+                if rank == self.rank:
+                    self.assertEqual((5, 5), shard_metadata.shard_sizes)
+                else:
+                    self.assertEqual((0, 0), shard_metadata.shard_sizes)
+                self.assertEqual(
+                    f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement)
+                )
 
     @skipIfRocm
     @with_comms

--- a/torch/distributed/_shard/sharded_tensor/api.py
+++ b/torch/distributed/_shard/sharded_tensor/api.py
@@ -735,6 +735,20 @@ class ShardedTensor(ShardedTensorBase):
         process_group=None,
         init_rrefs=False,
     ):
+        # recalc metadata handles special ST creation cases like each rank only has tensor available
+        # caller need to provide None on the unknown dimension of the global size
+        # We will change None into zeros and go through the same amount of checks as before to create ST
+        # and use all_gather to calculate the offsets and global size for metadata
+        # It is compatible with the current use case since, conventionally we don't pass None as global size
+        # Therefore the old path won't trigger the new feature
+        recalc_metadata = False
+        for dim in global_size:
+            if dim is None:
+                recalc_metadata = True
+        if recalc_metadata:
+            global_size = tuple(
+                0 if dim_size is None else dim_size for dim_size in global_size
+            )
         # STEP 1: Validate the Shardmetadatas locally
         process_group = cls._normalize_pg(process_group)
         current_rank = dist.get_rank()  # intentional to get global rank
@@ -760,7 +774,29 @@ class ShardedTensor(ShardedTensorBase):
         else:
             gathered_metadatas = [local_sharded_tensor_metadata]
 
-        global_sharded_tensor_metadata = build_global_metadata(gathered_metadatas)
+        global_sharded_tensor_metadata = build_global_metadata(
+            gathered_metadatas, recalc_metadata=recalc_metadata
+        )
+        if recalc_metadata:
+            # for recalc use cases, we only support rw for now, limit the blast radius
+            # will modify here once we support more sharding type
+            assert (
+                len(local_shards) > 0
+                and len(global_sharded_tensor_metadata.shards_metadata) > current_rank
+            ), (
+                f"# for metadata recalculation, local_shards must be larger than 0 "
+                f"actual:{len(local_shards)}, # glb metadata must be greater than any rank id, "
+                f"# metadata:{len(global_sharded_tensor_metadata.shards_metadata)}, rank id:{current_rank}"
+            )
+            local_md = [
+                shard_md
+                for shard_md in global_sharded_tensor_metadata.shards_metadata
+                if shard_md.placement.rank() == current_rank
+            ]
+            assert len(local_md) == 1, (
+                f"should has and only has one metadata for local rank, actual:{local_md}"
+            )
+            local_shards[0].metadata = local_md[0]
         tensor_properties = global_sharded_tensor_metadata.tensor_properties
 
         # STEP 3: Validation done, create the actual ShardedTensor and populate fields


### PR DESCRIPTION
Summary:
change set
1. a ShardedTensor could have 0 size initially, the current check won't pass if the size is 0, added here
2. when we call ShardedTensor._init_from_local_shards, it will assume all the metadata is correct, all_gather to double check. In the new case, the metadata could be all 0 size, and the tensor has actual size, we need to provide such capability to recalculate the local/global metadata from the local tensor by all_gathering the information

Test Plan: i don't see a UT is associated, I have tested this with diff stack, D73274786.

Differential Revision: D73903933




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k