### PR TITLE
Fix: promote scalar to MPS device in exec_binary_kernel

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1025,11 +1025,12 @@ void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter,
   TORCH_CHECK(iter.common_dtype() != at::kDouble, "float64 is not supported on MPS");
   TORCH_CHECK(iter.can_use_32bit_indexing(), "Can't be indexed using 32-bit iterator");
 
+  iter.cast_inputs_to_common_dtype(true);
+  iter.promote_common_dtype(true);
+
   Tensor input = iter.input(0);
   Tensor other = iter.input(1);
-  if (other.device() != input.device()) {
-     other = other.to(input.device());    //This ensures that in torch.copysign(t_mps, -2.0), the scalar is moved to MPS 
-  }
+
   Tensor out = iter.output();
 
   id<MTLDevice> device = MPSDevice::getInstance()->device();

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1027,6 +1027,9 @@ void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter,
 
   Tensor input = iter.input(0);
   Tensor other = iter.input(1);
+  if (other.device() != input.device()) {
+     other = other.to(input.device());    //This ensures that in torch.copysign(t_mps, -2.0), the scalar is moved to MPS 
+  }
   Tensor out = iter.output();
 
   id<MTLDevice> device = MPSDevice::getInstance()->device();

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2575,6 +2575,16 @@ class TestBinaryUfuncs(TestCase):
             floating_types_and(torch.half, torch.bfloat16),
         )
     )
+
+    @onlyNativeDeviceTypes
+    def test_copysign_scalar_device_mismatch(self, device):
+        if device == "mps":
+            # Ensure scalar on CPU is promoted to match input device (MPS)
+            a = torch.tensor([-1.0, 0.0, 1.0], device="mps")
+            b = torch.copysign(a, -2.0)  # scalar is CPU by default
+            expected = torch.tensor([-1.0, -0.0, -1.0], device="mps")
+            self.assertEqual(b, expected)
+
     def test_copysign_subgradient(self, device, dtypes):
         # Input is 0.0
         x = torch.tensor(


### PR DESCRIPTION
**PR Summary**

This PR fixes an inconsistency in torch.copysign on the MPS backend when used with a scalar as the second operand. Scalars were being promoted to CPU tensors by default, leading to incorrect results due to cross-device operations.

**Repro Before Fix**

import torch
t = torch.tensor([1.0, 2.0, 3.0], device="mps")
torch.copysign(t, -2.0)

Returns: tensor([1., 2., 3.], device='mps:0')
Expected After Fix

Correct output:
tensor([-1., -2., -3.], device='mps:0')

The fix ensures that scalars are promoted to the same device (input.device()) in exec_binary_kernel, aligning behavior across backends and preventing silent failures.

**Related Issue**

This addresses the issue discussed in [https://github.com/pytorch/pytorch/issues/152582] https://github.com/pytorch/pytorch/issues/152582

**CC Maintainers**

@malfet @albanD @kulinseth @DenisVieriu97
Please review: this is a small but important fix to maintain consistency and correctness in binary ops on MPS.