### PR TITLE
[c10d] Add support for ReduceOp::AVG in ProcessGroupMPI for FSDP2

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
@@ -1068,7 +1068,7 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::_reduce_scatter_base(
             mpi_op,
             pgComm_));
         if (opts.reduceOp == ReduceOp::AVG) {
-          dstdata.div_(size_); // divide by world size
+          dstdata.div_(size_);
         }
       };
 

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
@@ -422,10 +422,16 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::allreduce(
     std::vector<at::Tensor>& tensors,
     const AllreduceOptions& opts) {
   checkSingleTensor(tensors);
+  TORCH_CHECK(
+      !(opts.reduceOp == ReduceOp::AVG && !tensors[0].is_floating_point()),
+      "Allreduce: input tensor must be floating point for AVG reduce.");
 
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
       [opts, this](std::unique_ptr<WorkEntry>& entry) {
         auto data = (entry->src)[0];
+        MPI_Op mpi_op = (opts.reduceOp == ReduceOp::AVG)
+            ? MPI_SUM
+            : mpiOp.at(opts.reduceOp);
         c10::DeviceGuard guard(data.device());
         std::unique_lock<std::mutex> globalLock(pgGlobalMutex_);
         MPI_CHECK(MPI_Allreduce(
@@ -433,8 +439,11 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::allreduce(
             data.data_ptr(),
             data.numel(),
             mpiDatatype.at(data.scalar_type()),
-            mpiOp.at(opts.reduceOp),
+            mpi_op,
             pgComm_));
+        if (opts.reduceOp == ReduceOp::AVG) {
+          data.div_(size_);
+        }
       };
   auto entry =
       std::make_unique<WorkEntry>(&tensors, &tensors, std::move(runFunc));
@@ -454,6 +463,9 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::reduce(
     std::vector<at::Tensor>& tensors,
     const ReduceOptions& opts) {
   checkSingleTensor(tensors);
+  TORCH_CHECK(
+      !(opts.reduceOp == ReduceOp::AVG && !tensors[0].is_floating_point()),
+      "Reduce: input tensor must be floating point for AVG reduce.");
 
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
       [opts, this](std::unique_ptr<WorkEntry>& entry) {
@@ -461,7 +473,9 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::reduce(
         auto dataPtr = (entry->src)[0].data_ptr();
         void* sendbuf = (rank_ == opts.rootRank) ? MPI_IN_PLACE : dataPtr;
         void* recvbuf = (rank_ == opts.rootRank) ? dataPtr : nullptr;
-
+        MPI_Op mpi_op = (opts.reduceOp == ReduceOp::AVG)
+            ? MPI_SUM
+            : mpiOp.at(opts.reduceOp);
         c10::DeviceGuard guard(data.device());
         std::unique_lock<std::mutex> globalLock(pgGlobalMutex_);
         MPI_CHECK(MPI_Reduce(
@@ -469,9 +483,12 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::reduce(
             recvbuf,
             data.numel(),
             mpiDatatype.at(data.scalar_type()),
-            mpiOp.at(opts.reduceOp),
+            mpi_op,
             opts.rootRank,
             pgComm_));
+        if (opts.reduceOp == ReduceOp::AVG) {
+          data.div_(size_);
+        }
       };
   auto entry =
       std::make_unique<WorkEntry>(&tensors, &tensors, std::move(runFunc));
@@ -708,6 +725,10 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::reduce_scatter(
         "Reduce scatter: number of input tensors should equal "
         "to the world size");
   }
+  TORCH_CHECK(
+      !(opts.reduceOp == ReduceOp::AVG &&
+        !inputTensors[0][0].is_floating_point()),
+      "Reduce scatter: input tensor must be floating point for AVG reduce.");
   checkSameSizeAndType(outputTensors[0], inputTensors[0]);
 
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
@@ -718,7 +739,9 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::reduce_scatter(
           flatInputTensor[static_cast<int64_t>(i)].copy_(entry->src[i]);
         }
         int recvcount = flatInputTensor.numel() / size_;
-
+        MPI_Op mpi_op = (opts.reduceOp == ReduceOp::AVG)
+            ? MPI_SUM
+            : mpiOp.at(opts.reduceOp);
         c10::DeviceGuard guard(data.device());
         std::unique_lock<std::mutex> globalLock(pgGlobalMutex_);
         MPI_CHECK(MPI_Reduce_scatter_block(
@@ -726,8 +749,11 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::reduce_scatter(
             data.data_ptr(),
             recvcount,
             mpiDatatype.at(data.scalar_type()),
-            mpiOp.at(opts.reduceOp),
+            mpi_op,
             pgComm_));
+        if (opts.reduceOp == ReduceOp::AVG) {
+          data.div_(size_);
+        }
       };
 
   auto entry = std::make_unique<WorkEntry>(
@@ -1021,11 +1047,17 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::_reduce_scatter_base(
   TORCH_CHECK(
       outputTensor.numel() * size_ == inputTensor.numel(),
       "Reduce scatter: input tensor size must be equal to output tensor size times the world size");
+  TORCH_CHECK(
+      !(opts.reduceOp == ReduceOp::AVG && !inputTensor.is_floating_point()),
+      "Reduce scatter: input tensor must be floating point for AVG reduce.");
 
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
       [opts, this](std::unique_ptr<WorkEntry>& entry) {
         auto dstdata = (entry->dst)[0];
         auto srcdata = (entry->src)[0];
+        MPI_Op mpi_op = (opts.reduceOp == ReduceOp::AVG)
+            ? MPI_SUM
+            : mpiOp.at(opts.reduceOp);
         c10::DeviceGuard guard(srcdata.device());
         std::unique_lock<std::mutex> globalLock(pgGlobalMutex_);
         MPI_CHECK(MPI_Reduce_scatter_block(
@@ -1033,8 +1065,11 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::_reduce_scatter_base(
             dstdata.data_ptr(),
             dstdata.numel(),
             mpiDatatype.at(srcdata.scalar_type()),
-            mpiOp.at(opts.reduceOp),
+            mpi_op,
             pgComm_));
+        if (opts.reduceOp == ReduceOp::AVG) {
+          dstdata.div_(size_); // divide by world size
+        }
       };
 
   auto inputTensors = std::vector<at::Tensor>({inputTensor});


### PR DESCRIPTION
Hi,

Currently, running FSDP2 with the MPI backend fails. This is because `ProcessGroupMPI` does not support reduce_scatter with `ReduceOp::AVG` used during the backward pass.

However, most MPI implementations (such as OpenMPI) do not natively support an `AVG` reduce operation. To address this, this patch adds support for `ReduceOp::AVG` in `ProcessGroupMPI` as follows:

- The process group performs the collective using `MPI_SUM`, then divides the result by `world_size` to emulate `AVG`.
- A `TORCH_CHECK` is added to ensure the input tensor is of floating-point type. Supporting integer tensors would require additional logic for type conversion, and I believe that there is currently no strong use case for averaging integer data. Therefore, I limited floating-point tensors for AVG op.

This patch enables FSDP2 to train correctly using the MPI backend.

---

### Error Reproduction

Environment: **Ubuntu** 22.04, **Pytorch** v2.8.0a0+gitf84062f, **Open MPI** v5.0.7rc2
<details> <summary>FSDP2 training script</summary>

  ```python
  import os
  import time
  import argparse
  import dataclasses

  import torch
  from torch import nn
  import torch.distributed as dist
  from torch.distributed.fsdp import fully_shard
  import torch.optim as optim

  class SimpleModel(nn.Module):
      def __init__(self):
          super(SimpleModel, self).__init__()
          self.sequential0 = nn.Linear(512, 1024)
          self.sequential1 = nn.Linear(1024, 512)
          self.last = nn.Linear(512, 10)

      def forward(self, x):
          x = torch.relu(self.sequential0(x))
          x = torch.relu(self.sequential1(x))
          return self.last(x)

  def fsdp_training(local_rank: int):
      rank = dist.get_rank()
      world_size = dist.get_world_size()
      device = torch.device('cuda', local_rank)

      model = SimpleModel().to(device)
      fully_shard(model)

      gpu_name = torch.cuda.get_device_name(local_rank)
      print(f"Rank {rank}/{world_size}: FSDP is model created; #params: {sum(p.numel() for p in model.parameters())}; GPU: {gpu_name}")

      if rank == 0:
          print(model)

      optimizer = optim.AdamW(model.parameters(), lr=0.01)
      input_data = torch.randn(2, 512).to(device)
      target = torch.randint(0, 10, (2,)).to(device)

      print(f"Rank {rank}/{world_size}: Start training")
      model.train()
      num_epochs = 100
      for epoch in range(num_epochs):
          optimizer.zero_grad()
          output = model(input_data)
          loss = nn.CrossEntropyLoss()(output, target)
          loss.backward()
          optimizer.step()
          if rank == 0:
              print(f"Epoch {epoch}/{num_epochs}: Loss {loss.item()}")

  if __name__ == '__main__':
      parser = argparse.ArgumentParser(description='FSDP Training')
      args = parser.parse_args()

      local_rank = int(os.getenv("LOCAL_RANK", 0))
      local_rank = int(os.getenv("OMPI_COMM_WORLD_RANK", 0))
      torch.cuda.set_device(local_rank)

      dist.init_process_group(backend="mpi")

      fsdp_training(local_rank)

      dist.destroy_process_group()
  ```
</details>

Command: `mpirun -n 2 -- python3 test_fsdp2.py`
<details> <summary>Error (Traceback)</summary>

```python
[rank0]: Traceback (most recent call last):
[rank0]:   File "/app/pytorch_tests/src/training/test_fsdp2_mpi.py", line 81, in <module>
[rank0]:     fsdp_training(local_rank)
[rank0]:   File "/app/pytorch_tests/src/training/test_fsdp2_mpi.py", line 52, in fsdp_training
[rank0]:     loss.backward()
[rank0]:   File "/app/pytorch/torch/_tensor.py", line 648, in backward
[rank0]:     torch.autograd.backward(
[rank0]:   File "/app/pytorch/torch/autograd/__init__.py", line 354, in backward
[rank0]:     _engine_run_backward(
[rank0]:   File "/app/pytorch/torch/autograd/graph.py", line 824, in _engine_run_backward
[rank0]:     return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
[rank0]:   File "/app/pytorch/torch/distributed/fsdp/_fully_shard/_fsdp_state.py", line 297, in _root_post_backward_final_callback
[rank0]:     fsdp_param_group.post_backward()
[rank0]:   File "/app/pytorch/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py", line 445, in post_backward
[rank0]:     ) = foreach_reduce(
[rank0]:   File "/app/pytorch/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/app/pytorch/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py", line 421, in foreach_reduce
[rank0]:     dist.reduce_scatter_tensor(
[rank0]:   File "/app/pytorch/torch/distributed/c10d_logger.py", line 81, in wrapper
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/app/pytorch/torch/distributed/distributed_c10d.py", line 4416, in reduce_scatter_tensor
[rank0]:     work.wait()
[rank0]: IndexError: map::at
```
  </details>
 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta