### PR TITLE
Fix some inductor periodic benchmarks

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/aot_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_eager_torchbench_training.csv
@@ -114,7 +114,7 @@ hf_Reformer,pass,23
 
 
 
-hf_Roberta_base,fail_accuracy,6
+hf_Roberta_base,pass,6
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_torchbench_inference.csv
@@ -286,7 +286,7 @@ resnext50_32x4d,pass,0
 
 
 
-sam,pass,0
+sam,fail_to_run,0
 
 
 
@@ -342,7 +342,7 @@ torch_multimodal_clip,pass,0
 
 
 
-tts_angular,pass,0
+tts_angular,fail_to_run,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_torchbench_training.csv
@@ -114,7 +114,7 @@ hf_Reformer,fail_to_run,19
 
 
 
-hf_Roberta_base,fail_accuracy,6
+hf_Roberta_base,pass,6
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_training.csv
@@ -114,7 +114,7 @@ hf_Reformer,fail_to_run,19
 
 
 
-hf_Roberta_base,fail_accuracy,6
+hf_Roberta_base,pass,6
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_torchbench_training.csv
@@ -114,7 +114,7 @@ hf_Reformer,pass,23
 
 
 
-hf_Roberta_base,fail_accuracy,6
+hf_Roberta_base,pass,6
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #152621
* __->__ #152605

Some were reporting "pass" consistently on https://hud.pytorch.org/
Those are fine to flip.

I filed a separate issue for the now-regressions for AOTI:
https://github.com/pytorch/pytorch/issues/152606. These should be looked
at.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames