### PR TITLE
BE: Swap functorch --> torch._higher_order_ops

### DIFF
--- a/torch/_export/pass_base.py
+++ b/torch/_export/pass_base.py
@@ -6,7 +6,7 @@ from contextlib import nullcontext
 from typing import Any, Callable, Optional, Union
 
 import torch
-from functorch.experimental.control_flow import _unstack_pytree
+from torch._higher_order_ops.map import _unstack_pytree
 from torch import fx
 from torch._dispatch.python import enable_python_dispatcher
 from torch._export.pass_infra.node_metadata import NodeMetadata


### PR DESCRIPTION
Summary: Discovered when attempting to resolve arvr builds, should resolve issues around utilizing functorch through export.

Test Plan:
```
buck2 test arvr/mode/linux/opt //arvr/libraries/xrrp/ml/python/test:convert_to_etvk_test
```

Differential Revision: D74013898


